### PR TITLE
feat: make kubectl honor `$XDG_CACHE_HOME`

### DIFF
--- a/staging/src/k8s.io/client-go/tools/clientcmd/BUILD
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/BUILD
@@ -55,6 +55,7 @@ go_library(
         "//staging/src/k8s.io/client-go/tools/clientcmd/api:go_default_library",
         "//staging/src/k8s.io/client-go/tools/clientcmd/api/latest:go_default_library",
         "//staging/src/k8s.io/client-go/util/homedir:go_default_library",
+        "//staging/src/k8s.io/client-go/util/userdir:go_default_library",
         "//vendor/github.com/imdario/mergo:go_default_library",
         "//vendor/github.com/spf13/pflag:go_default_library",
         "//vendor/golang.org/x/crypto/ssh/terminal:go_default_library",

--- a/staging/src/k8s.io/client-go/util/userdir/BUILD
+++ b/staging/src/k8s.io/client-go/util/userdir/BUILD
@@ -1,0 +1,26 @@
+package(default_visibility = ["//visibility:public"])
+
+load(
+    "@io_bazel_rules_go//go:def.bzl",
+    "go_library",
+)
+
+go_library(
+    name = "go_default_library",
+    srcs = ["homedir.go"],
+    importmap = "k8s.io/kubernetes/vendor/k8s.io/client-go/util/userdir",
+    importpath = "k8s.io/client-go/util/userdir",
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+)

--- a/staging/src/k8s.io/client-go/util/userdir/userdir.go
+++ b/staging/src/k8s.io/client-go/util/userdir/userdir.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package userdir
+
+import (
+	"os"
+	"runtime"
+)
+
+// UserCacheDir returns the default root directory to use for user-specific
+// cached data. Users should create their own application-specific subdirectory
+// within this one and use that.
+//
+// It returns $XDG_CACHE_HOME if not empty, otherwise:
+// On Unix systems, it returns $HOME/.cache.
+// On Darwin, it returns $HOME/Library/Caches.
+// On Windows, it returns %LocalAppData%.
+// On Plan 9, it returns $home/lib/cache.
+//
+// If the location cannot be determined (for example, $HOME is not defined),
+// then it will return an empty string.
+func UserCacheDir() string {
+	cacheHome := os.Getenv("XDG_CACHE_HOME")
+	if len(cacheHome) != 0 {
+		return cacheHome
+	}
+
+	// The below code is mainly copied from `os.UserCacheDir`.
+
+	// The reason why not to use `os.UserCacheDir` here is that user may want to override the cache dir by setting the
+	// `XDG_CACHE_HOME` environment variable.
+
+	switch runtime.GOOS {
+	case "windows":
+		return os.Getenv("LocalAppData")
+
+	case "darwin":
+		dir := os.Getenv("HOME")
+		if len(dir) == 0 {
+			return ""
+		}
+		return dir + "/Library/Caches"
+
+	case "plan9":
+		dir := os.Getenv("home")
+		if len(dir) == 0 {
+			return ""
+		}
+		return dir + "/lib/cache"
+
+	default: // Unix
+		dir := os.Getenv("HOME")
+		if len(dir) == 0 {
+			return ""
+		}
+		return dir + "/.cache"
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test
> 
/kind feature
> /kind flake

**What this PR does / why we need it**:

make kubectl honor `XDG_CACHE_HOME` and allow users to speicify the location of local cache dir by setting `XDG_CACHE_HOME`.

**Which issue(s) this PR fixes**:

Fixes #80399 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kubectl uses $XDG_CACHE_HOME/kubernetes-cli as local cache dir by default
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
