### PR TITLE
kubectl describe: print toleration tolerating everything

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/describe/describe.go
+++ b/staging/src/k8s.io/kubectl/pkg/describe/describe.go
@@ -4606,6 +4606,17 @@ func printTolerationsMultilineWithIndent(w PrefixWriter, initialIndent, title, i
 		if len(toleration.Effect) != 0 {
 			w.Write(LEVEL_0, ":%s", toleration.Effect)
 		}
+		// tolerations:
+		// - operator: "Exists"
+		// is a special case which tolerates everything
+		if toleration.Operator == corev1.TolerationOpExists && len(toleration.Value) == 0 {
+			if len(toleration.Key) != 0 {
+				w.Write(LEVEL_0, " op=Exists")
+			} else {
+				w.Write(LEVEL_0, "op=Exists")
+			}
+		}
+
 		if toleration.TolerationSeconds != nil {
 			w.Write(LEVEL_0, " for %ds", *toleration.TolerationSeconds)
 		}

--- a/staging/src/k8s.io/kubectl/pkg/describe/describe_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/describe/describe_test.go
@@ -179,6 +179,7 @@ func TestDescribePodTolerations(t *testing.T) {
 		},
 		Spec: corev1.PodSpec{
 			Tolerations: []corev1.Toleration{
+				{Operator: corev1.TolerationOpExists},
 				{Key: "key0", Operator: corev1.TolerationOpExists},
 				{Key: "key1", Value: "value1"},
 				{Key: "key2", Operator: corev1.TolerationOpEqual, Value: "value2", Effect: corev1.TaintEffectNoSchedule},
@@ -193,7 +194,8 @@ func TestDescribePodTolerations(t *testing.T) {
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
-	if !strings.Contains(out, "key0\n") ||
+	if !strings.Contains(out, "  op=Exists\n") ||
+		!strings.Contains(out, "key0 op=Exists\n") ||
 		!strings.Contains(out, "key1=value1\n") ||
 		!strings.Contains(out, "key2=value2:NoSchedule\n") ||
 		!strings.Contains(out, "key3=value3:NoExecute for 300s\n") ||


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
An empty key with operator Exists matches all keys, values
and effects which means this will tolerate everything:
tolerations:
- operator: "Exists"

as stated in https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/.

However, the current printTolerationsMultilineWithIndent implementation ignores
this case. As the toleration is valid, there's no reason
to skip it when writing the list of all pod's tolerations.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
Snippet of the kubectl describe output after applying the PR:

```
QoS Class:       Burstable
Node-Selectors:  kubernetes.io/os=linux
Tolerations:     op=Exists
Events:          <none>
```

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
