### PR TITLE
Fixes missing port in network policy test

### DIFF
--- a/test/e2e/network/network_policy.go
+++ b/test/e2e/network/network_policy.go
@@ -1069,6 +1069,7 @@ var _ = SIGDescribe("NetworkPolicy [LinuxOnly]", func() {
 			framework.ExpectNoError(err, "Error occurred while waiting for pod status in namespace: Ready.")
 
 			ginkgo.By("Creating a network policy for the server which allows traffic only to a server in different namespace.")
+			protocolTCP := v1.ProtocolTCP
 			protocolUDP := v1.ProtocolUDP
 			policyAllowToServerInNSB := &networkingv1.NetworkPolicy{
 				ObjectMeta: metav1.ObjectMeta{
@@ -1087,6 +1088,10 @@ var _ = SIGDescribe("NetworkPolicy [LinuxOnly]", func() {
 					Egress: []networkingv1.NetworkPolicyEgressRule{
 						{
 							Ports: []networkingv1.NetworkPolicyPort{
+								{
+									Protocol: &protocolTCP,
+									Port:     &intstr.IntOrString{Type: intstr.Int, IntVal: 80},
+								},
 								// Allow DNS look-ups
 								{
 									Protocol: &protocolUDP,


### PR DESCRIPTION
Test is creating an egress policy and allowing DNS, but is missing an
allow for the target TCP port 80 which is being used to test
connectivity.

Signed-off-by: Tim Rozet <trozet@redhat.com>

**What type of PR is this?**
/kind failing-test

```release-note
NONE
```
