### PR TITLE
Deflake port-forward e2e test

### DIFF
--- a/test/e2e/kubectl/portforward.go
+++ b/test/e2e/kubectl/portforward.go
@@ -322,11 +322,6 @@ func doTestMustConnectSendDisconnect(bindAddress string, f *framework.Framework)
 	ginkgo.By("Sending the expected data to the local port")
 	fmt.Fprint(conn, "abc")
 
-	ginkgo.By("Closing the write half of the client's connection")
-	if err = conn.CloseWrite(); err != nil {
-		framework.Failf("Couldn't close the write half of the client's connection: %v", err)
-	}
-
 	ginkgo.By("Reading data from the local port")
 	fromServer, err := ioutil.ReadAll(conn)
 	if err != nil {
@@ -341,6 +336,11 @@ func doTestMustConnectSendDisconnect(bindAddress string, f *framework.Framework)
 			framework.Logf("Logs of portforwardtester pod: %v", podlogs)
 		}
 		framework.Failf("Expected %q from server, got %q", e, a)
+	}
+
+	ginkgo.By("Closing the write half of the client's connection")
+	if err = conn.CloseWrite(); err != nil {
+		framework.Failf("Couldn't close the write half of the client's connection: %v", err)
 	}
 
 	ginkgo.By("Waiting for the target pod to stop running")


### PR DESCRIPTION
**What type of PR is this?**

/kind flake

**What this PR does / why we need it**:

We should read and verify the data before actually closing the
connection to avoid connection based-races within the test.

**Which issue(s) this PR fixes**:

Fixes #86355
Refers to https://github.com/containerd/cri/pull/1477, https://github.com/cri-o/cri-o/pull/3749

**Special notes for your reviewer**:

cc @aojea 

- Flakyness report: https://storage.googleapis.com/k8s-gubernator/triage/index.html?test=sends%20DATA

**Does this PR introduce a user-facing change?**:

```release-note
None
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs
None
```
