### PR TITLE
Set appropriate owner references when creating a job from cronjob

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_job.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_job.go
@@ -256,7 +256,12 @@ func (o *CreateJobOptions) createJobFromCronJob(cronJob *batchv1beta1.CronJob) *
 			Annotations: annotations,
 			Labels:      cronJob.Spec.JobTemplate.Labels,
 			OwnerReferences: []metav1.OwnerReference{
-				*metav1.NewControllerRef(cronJob, cronJob.GroupVersionKind()),
+				{
+					APIVersion: batchv1beta1.SchemeGroupVersion.String(),
+					Kind:       cronJob.Kind,
+					Name:       cronJob.GetName(),
+					UID:        cronJob.GetUID(),
+				},
 			},
 		},
 		Spec: cronJob.Spec.JobTemplate.Spec,

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_job_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_job_test.go
@@ -162,9 +162,16 @@ func TestCreateJobFromCronJob(t *testing.T) {
 			expected: &batchv1.Job{
 				TypeMeta: metav1.TypeMeta{APIVersion: batchv1.SchemeGroupVersion.String(), Kind: "Job"},
 				ObjectMeta: metav1.ObjectMeta{
-					Name:            jobName,
-					Annotations:     map[string]string{"cronjob.kubernetes.io/instantiate": "manual"},
-					OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(cronJob, cronJob.GroupVersionKind())},
+					Name:        jobName,
+					Annotations: map[string]string{"cronjob.kubernetes.io/instantiate": "manual"},
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion: batchv1beta1.SchemeGroupVersion.String(),
+							Kind:       cronJob.Kind,
+							Name:       cronJob.GetName(),
+							UID:        cronJob.GetUID(),
+						},
+					},
 				},
 				Spec: batchv1.JobSpec{
 					Template: corev1.PodTemplateSpec{


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
We are wrongly setting owner references for a job setting `BlockOwnerDeletion` and `Controller` fields to `true`, but they should only be ever set by an actual controller, not a user. With these attributes set a regular user cannot create a job from an existing cronjob. `kubectl create job` should never use `metav1.NewControllerRef` method which is explicitly reserved for controllers. 

**Special notes for your reviewer**:
/assign @sallyom @zhouya0 
/sig cli
/priority backlog

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
