### PR TITLE
kubelet: tweak exec-probe log statement to be more concise

### DIFF
--- a/pkg/kubelet/prober/prober.go
+++ b/pkg/kubelet/prober/prober.go
@@ -163,7 +163,7 @@ func buildHeader(headerList []v1.HTTPHeader) http.Header {
 func (pb *prober) runProbe(probeType probeType, p *v1.Probe, pod *v1.Pod, status v1.PodStatus, container v1.Container, containerID kubecontainer.ContainerID) (probe.Result, string, error) {
 	timeout := time.Duration(p.TimeoutSeconds) * time.Second
 	if p.Exec != nil {
-		klog.V(4).Infof("Exec-Probe Pod: %v, Container: %v, Command: %v", pod, container, p.Exec.Command)
+		klog.V(4).Infof("Exec-Probe Pod: %v, Container: %v, Command: %v", pod.Name, container.Name, p.Exec.Command)
 		command := kubecontainer.ExpandContainerCommandOnlyStatic(p.Exec.Command, container.Env)
 		return pb.exec.Probe(pb.newExecInContainer(container, containerID, command, timeout))
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
When the kubelet is set to log level 4 the kubelet will display for exec probes the entire pod information including raw fields:

```
May 12 20:57:47.234719 ci-op-rgllt-w-b-jtvvw.c.openshift-gce-devel-ci.internal hyperkube[1515]: I0512 20:57:47.231903    1515 prober.go:166] Exec-Probe Pod: &Pod{ObjectMeta:{sdn-lqbn6 sdn- openshift-sdn /api/v1/namespaces/openshift-sdn/pods/sdn-lqbn6 859876a9-2869-4ea5-8864-7602c9c4b9df 15324 0 2020-05-12 20:56:49 +0000 UTC <nil> <nil> map[app:sdn component:network controller-revision-hash:86c6fc4dcc openshift.io/component:network pod-template-generation:1 type:infra] map[kubernetes.io/config.seen:2020-05-12T20:57:09.763828727Z kubernetes.io/config.source:api] [{apps/v1 DaemonSet sdn cfeaea62-6be7-4b45-b4e5-90993c292f76 0xc0008cbc6d 0xc0008cbc6e}] []  [{kube-controller-manager Update v1 2020-05-12 20:56:49 +0000 UTC FieldsV1 FieldsV1{Raw:*[123 34 102 58 109 101 116 97 100 97 116 97 34 58 123 34 102 58 103 101 110 101 114 97 116 101 78 97 109 101 34 58 123 125 44 34 102 58 108 97 98 101 108 115 34 58 123 34 46 34 58 123 125 44 34 102 58 97 112 112 34 58 123 125 44 34 102 58 99 111 109 112 111 110 101 110 116 34 58 123 125 44 34 102 58 99 111 110 116 114 111 108 108 101 114 45 114 101 118 105 115 105 111 110 45 104 97 115 104 34 58 123 125 44 34 102 58 111 112 101 110 115 104 105 102 116 46 105 111 47 99 111 109 112 111 110 101 110 116 34 58 123 125 44 34 102 58 112 111 100 45 116 101 109 112 108 97 116 101 45 103 101 110 101 114 97 116 105 111 110 34 58 123 125 44 34 102 58 116 121 112 101 34 58 123 125 125 44 34 102 58 111 119 110 101 114 82 101 102 101 114 101 110 99 101 115 34 58 123 34 4
```

This PR changes the log statement to be the pod and container name.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs
NONE
```
