### PR TITLE
[wip]  Standard API qps and burst in kubeconfig file

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/util/webhook/authentication.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/webhook/authentication.go
@@ -235,6 +235,12 @@ func restConfigFromKubeconfig(configAuthInfo *clientcmdapi.AuthInfo) (*rest.Conf
 			Extra:    configAuthInfo.ImpersonateUserExtra,
 		}
 	}
+	if configAuthInfo.QPS != 0 {
+		config.QPS = configAuthInfo.QPS
+	}
+	if configAuthInfo.Burst != 0 {
+		config.Burst = int(configAuthInfo.Burst)
+	}
 	if len(configAuthInfo.ClientCertificate) > 0 || len(configAuthInfo.ClientCertificateData) > 0 {
 		config.CertFile = configAuthInfo.ClientCertificate
 		config.CertData = configAuthInfo.ClientCertificateData

--- a/staging/src/k8s.io/client-go/tools/clientcmd/api/types.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/api/types.go
@@ -142,6 +142,15 @@ type AuthInfo struct {
 	// Exec specifies a custom exec-based authentication plugin for the kubernetes cluster.
 	// +optional
 	Exec *ExecConfig `json:"exec,omitempty"`
+
+	// qps indicates the maximum rate tokens will be added to the token bucket for use by a client.
+	// If it's zero, the created RESTClient will use DefaultQPS: 5
+	// Set to -1 to turn off rate limiting.
+	QPS float32 `json:"qps,omitempty"`
+	// burst is the maximum number of tokens to "save up" for immediate use.
+	// If it's zero, the created RESTClient will use DefaultBurst: 10.
+	Burst int32 `json:"burst,omitempty"`
+
 	// Extensions holds additional information. This is useful for extenders so that reads and writes don't clobber unknown fields
 	// +optional
 	Extensions map[string]runtime.Object `json:"extensions,omitempty"`

--- a/staging/src/k8s.io/client-go/tools/clientcmd/api/v1/types.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/api/v1/types.go
@@ -132,6 +132,15 @@ type AuthInfo struct {
 	// Exec specifies a custom exec-based authentication plugin for the kubernetes cluster.
 	// +optional
 	Exec *ExecConfig `json:"exec,omitempty"`
+
+	// qps indicates the maximum rate tokens will be added to the token bucket for use by a client.
+	// If it's zero, the created RESTClient will use DefaultQPS: 5
+	// Set to -1 to turn off rate limiting.
+	QPS float32 `json:"qps,omitempty"`
+	// burst is the maximum number of tokens to "save up" for immediate use.
+	// If it's zero, the created RESTClient will use DefaultBurst: 10.
+	Burst int32 `json:"burst,omitempty"`
+
 	// Extensions holds additional information. This is useful for extenders so that reads and writes don't clobber unknown fields
 	// +optional
 	Extensions []NamedExtension `json:"extensions,omitempty"`

--- a/staging/src/k8s.io/client-go/tools/clientcmd/api/v1/zz_generated.conversion.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/api/v1/zz_generated.conversion.go
@@ -172,6 +172,8 @@ func autoConvert_v1_AuthInfo_To_api_AuthInfo(in *AuthInfo, out *api.AuthInfo, s 
 	out.Password = in.Password
 	out.AuthProvider = (*api.AuthProviderConfig)(unsafe.Pointer(in.AuthProvider))
 	out.Exec = (*api.ExecConfig)(unsafe.Pointer(in.Exec))
+	out.QPS = in.QPS
+	out.Burst = in.Burst
 	if err := Convert_Slice_v1_NamedExtension_To_Map_string_To_runtime_Object(&in.Extensions, &out.Extensions, s); err != nil {
 		return err
 	}
@@ -198,6 +200,8 @@ func autoConvert_api_AuthInfo_To_v1_AuthInfo(in *api.AuthInfo, out *AuthInfo, s 
 	out.Password = in.Password
 	out.AuthProvider = (*AuthProviderConfig)(unsafe.Pointer(in.AuthProvider))
 	out.Exec = (*ExecConfig)(unsafe.Pointer(in.Exec))
+	out.QPS = in.QPS
+	out.Burst = in.Burst
 	if err := Convert_Map_string_To_runtime_Object_To_Slice_v1_NamedExtension(&in.Extensions, &out.Extensions, s); err != nil {
 		return err
 	}

--- a/staging/src/k8s.io/client-go/tools/clientcmd/client_config.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/client_config.go
@@ -179,6 +179,12 @@ func (config *DirectClientConfig) ClientConfig() (*restclient.Config, error) {
 			Extra:    configAuthInfo.ImpersonateUserExtra,
 		}
 	}
+	if configAuthInfo.QPS != 0 {
+		clientConfig.QPS = configAuthInfo.QPS
+	}
+	if configAuthInfo.Burst != 0 {
+		clientConfig.Burst = int(configAuthInfo.Burst)
+	}
 
 	// only try to read the auth information if we are secure
 	if restclient.IsConfigTransportTLS(*clientConfig) {
@@ -252,6 +258,12 @@ func (config *DirectClientConfig) getUserIdentificationPartialConfig(configAuthI
 			Groups:   configAuthInfo.ImpersonateGroups,
 			Extra:    configAuthInfo.ImpersonateUserExtra,
 		}
+	}
+	if configAuthInfo.QPS != 0 {
+		mergedConfig.QPS = configAuthInfo.QPS
+	}
+	if configAuthInfo.Burst != 0 {
+		mergedConfig.Burst = int(configAuthInfo.Burst)
 	}
 	if len(configAuthInfo.ClientCertificate) > 0 || len(configAuthInfo.ClientCertificateData) > 0 {
 		mergedConfig.CertFile = configAuthInfo.ClientCertificate


### PR DESCRIPTION
proof that https://github.com/kubernetes/enhancements/pull/1629 is practical

needs KEP merge and tests

/hold

/kind feature
/priority important-soon
@kubernetes/sig-api-machinery-api-reviews 

```release-note
TODO fill this in
```