### PR TITLE
Add test case for a pod becoming schedulable when a node is added

### DIFF
--- a/test/integration/scheduler/framework_test.go
+++ b/test/integration/scheduler/framework_test.go
@@ -507,7 +507,7 @@ func TestPreFilterPlugin(t *testing.T) {
 		preFilterPlugin.rejectPreFilter = test.reject
 		// Create a best effort pod.
 		pod, err := createPausePod(testCtx.ClientSet,
-			initPausePod(testCtx.ClientSet, &pausePodConfig{Name: "test-pod", Namespace: testCtx.NS.Name}))
+			initPausePod(&pausePodConfig{Name: "test-pod", Namespace: testCtx.NS.Name}))
 		if err != nil {
 			t.Errorf("Error while creating a test pod: %v", err)
 		}
@@ -559,7 +559,7 @@ func TestScorePlugin(t *testing.T) {
 		scorePlugin.failScore = fail
 		// Create a best effort pod.
 		pod, err := createPausePod(testCtx.ClientSet,
-			initPausePod(testCtx.ClientSet, &pausePodConfig{Name: "test-pod", Namespace: testCtx.NS.Name}))
+			initPausePod(&pausePodConfig{Name: "test-pod", Namespace: testCtx.NS.Name}))
 		if err != nil {
 			t.Fatalf("Error while creating a test pod: %v", err)
 		}
@@ -617,7 +617,7 @@ func TestNormalizeScorePlugin(t *testing.T) {
 
 	// Create a best effort pod.
 	pod, err := createPausePod(testCtx.ClientSet,
-		initPausePod(testCtx.ClientSet, &pausePodConfig{Name: "test-pod", Namespace: testCtx.NS.Name}))
+		initPausePod(&pausePodConfig{Name: "test-pod", Namespace: testCtx.NS.Name}))
 	if err != nil {
 		t.Fatalf("Error while creating a test pod: %v", err)
 	}
@@ -666,7 +666,7 @@ func TestReservePlugin(t *testing.T) {
 		reservePlugin.failReserve = fail
 		// Create a best effort pod.
 		pod, err := createPausePod(testCtx.ClientSet,
-			initPausePod(testCtx.ClientSet, &pausePodConfig{Name: "test-pod", Namespace: testCtx.NS.Name}))
+			initPausePod(&pausePodConfig{Name: "test-pod", Namespace: testCtx.NS.Name}))
 		if err != nil {
 			t.Errorf("Error while creating a test pod: %v", err)
 		}
@@ -744,7 +744,7 @@ func TestPrebindPlugin(t *testing.T) {
 		preBindPlugin.rejectPreBind = test.reject
 		// Create a best effort pod.
 		pod, err := createPausePod(testCtx.ClientSet,
-			initPausePod(testCtx.ClientSet, &pausePodConfig{Name: "test-pod", Namespace: testCtx.NS.Name}))
+			initPausePod(&pausePodConfig{Name: "test-pod", Namespace: testCtx.NS.Name}))
 		if err != nil {
 			t.Errorf("Error while creating a test pod: %v", err)
 		}
@@ -819,7 +819,7 @@ func TestUnreservePlugin(t *testing.T) {
 
 		// Create a best effort pod.
 		pod, err := createPausePod(testCtx.ClientSet,
-			initPausePod(testCtx.ClientSet, &pausePodConfig{Name: "test-pod", Namespace: testCtx.NS.Name}))
+			initPausePod(&pausePodConfig{Name: "test-pod", Namespace: testCtx.NS.Name}))
 		if err != nil {
 			t.Errorf("Error while creating a test pod: %v", err)
 		}
@@ -953,7 +953,7 @@ func TestBindPlugin(t *testing.T) {
 
 		// Create a best effort pod.
 		pod, err := createPausePod(testCtx.ClientSet,
-			initPausePod(testCtx.ClientSet, &pausePodConfig{Name: "test-pod", Namespace: testCtx.NS.Name}))
+			initPausePod(&pausePodConfig{Name: "test-pod", Namespace: testCtx.NS.Name}))
 		if err != nil {
 			t.Errorf("Error while creating a test pod: %v", err)
 		}
@@ -1080,7 +1080,7 @@ func TestPostBindPlugin(t *testing.T) {
 
 		// Create a best effort pod.
 		pod, err := createPausePod(testCtx.ClientSet,
-			initPausePod(testCtx.ClientSet, &pausePodConfig{Name: "test-pod", Namespace: testCtx.NS.Name}))
+			initPausePod(&pausePodConfig{Name: "test-pod", Namespace: testCtx.NS.Name}))
 		if err != nil {
 			t.Errorf("Error while creating a test pod: %v", err)
 		}
@@ -1165,7 +1165,7 @@ func TestPermitPlugin(t *testing.T) {
 
 		// Create a best effort pod.
 		pod, err := createPausePod(testCtx.ClientSet,
-			initPausePod(testCtx.ClientSet, &pausePodConfig{Name: "test-pod", Namespace: testCtx.NS.Name}))
+			initPausePod(&pausePodConfig{Name: "test-pod", Namespace: testCtx.NS.Name}))
 		if err != nil {
 			t.Errorf("Error while creating a test pod: %v", err)
 		}
@@ -1214,7 +1214,7 @@ func TestMultiplePermitPlugins(t *testing.T) {
 	// Create a test pod.
 	podName := "test-pod"
 	pod, err := createPausePod(testCtx.ClientSet,
-		initPausePod(testCtx.ClientSet, &pausePodConfig{Name: podName, Namespace: testCtx.NS.Name}))
+		initPausePod(&pausePodConfig{Name: podName, Namespace: testCtx.NS.Name}))
 	if err != nil {
 		t.Errorf("Error while creating a test pod: %v", err)
 	}
@@ -1269,7 +1269,7 @@ func TestPermitPluginsCancelled(t *testing.T) {
 	// Create a test pod.
 	podName := "test-pod"
 	pod, err := createPausePod(testCtx.ClientSet,
-		initPausePod(testCtx.ClientSet, &pausePodConfig{Name: podName, Namespace: testCtx.NS.Name}))
+		initPausePod(&pausePodConfig{Name: podName, Namespace: testCtx.NS.Name}))
 	if err != nil {
 		t.Errorf("Error while creating a test pod: %v", err)
 	}
@@ -1328,12 +1328,12 @@ func TestCoSchedulingWithPermitPlugin(t *testing.T) {
 		// Create two pods. First pod to enter Permit() will wait and a second one will either
 		// reject or allow first one.
 		podA, err := createPausePod(testCtx.ClientSet,
-			initPausePod(testCtx.ClientSet, &pausePodConfig{Name: "pod-a", Namespace: testCtx.NS.Name}))
+			initPausePod(&pausePodConfig{Name: "pod-a", Namespace: testCtx.NS.Name}))
 		if err != nil {
 			t.Errorf("Error while creating the first pod: %v", err)
 		}
 		podB, err := createPausePod(testCtx.ClientSet,
-			initPausePod(testCtx.ClientSet, &pausePodConfig{Name: "pod-b", Namespace: testCtx.NS.Name}))
+			initPausePod(&pausePodConfig{Name: "pod-b", Namespace: testCtx.NS.Name}))
 		if err != nil {
 			t.Errorf("Error while creating the second pod: %v", err)
 		}
@@ -1403,7 +1403,7 @@ func TestFilterPlugin(t *testing.T) {
 		filterPlugin.failFilter = fail
 		// Create a best effort pod.
 		pod, err := createPausePod(testCtx.ClientSet,
-			initPausePod(testCtx.ClientSet, &pausePodConfig{Name: "test-pod", Namespace: testCtx.NS.Name}))
+			initPausePod(&pausePodConfig{Name: "test-pod", Namespace: testCtx.NS.Name}))
 		if err != nil {
 			t.Errorf("Error while creating a test pod: %v", err)
 		}
@@ -1457,7 +1457,7 @@ func TestPreScorePlugin(t *testing.T) {
 		preScorePlugin.failPreScore = fail
 		// Create a best effort pod.
 		pod, err := createPausePod(testCtx.ClientSet,
-			initPausePod(testCtx.ClientSet, &pausePodConfig{Name: "test-pod", Namespace: testCtx.NS.Name}))
+			initPausePod(&pausePodConfig{Name: "test-pod", Namespace: testCtx.NS.Name}))
 		if err != nil {
 			t.Errorf("Error while creating a test pod: %v", err)
 		}
@@ -1517,7 +1517,7 @@ func TestPreemptWithPermitPlugin(t *testing.T) {
 	}
 
 	// First pod will go waiting.
-	waitingPod := initPausePod(testCtx.ClientSet, &pausePodConfig{Name: "waiting-pod", Namespace: testCtx.NS.Name, Priority: &lowPriority, Resources: &resourceRequest})
+	waitingPod := initPausePod(&pausePodConfig{Name: "waiting-pod", Namespace: testCtx.NS.Name, Priority: &lowPriority, Resources: &resourceRequest})
 	waitingPod.Spec.TerminationGracePeriodSeconds = new(int64)
 	waitingPod, err = createPausePod(testCtx.ClientSet, waitingPod)
 	if err != nil {
@@ -1532,7 +1532,7 @@ func TestPreemptWithPermitPlugin(t *testing.T) {
 
 	// Create second pod which should preempt first pod.
 	preemptorPod, err := createPausePod(testCtx.ClientSet,
-		initPausePod(testCtx.ClientSet, &pausePodConfig{Name: "preemptor-pod", Namespace: testCtx.NS.Name, Priority: &highPriority, Resources: &resourceRequest}))
+		initPausePod(&pausePodConfig{Name: "preemptor-pod", Namespace: testCtx.NS.Name, Priority: &highPriority, Resources: &resourceRequest}))
 	if err != nil {
 		t.Errorf("Error while creating the preemptor pod: %v", err)
 	}

--- a/test/integration/scheduler/plugins_test.go
+++ b/test/integration/scheduler/plugins_test.go
@@ -54,7 +54,7 @@ func TestNodeResourceLimits(t *testing.T) {
 	}
 
 	podName := "pod-with-resource-limits"
-	pod, err := runPausePod(testCtx.ClientSet, initPausePod(testCtx.ClientSet, &pausePodConfig{
+	pod, err := runPausePod(testCtx.ClientSet, initPausePod(&pausePodConfig{
 		Name:      podName,
 		Namespace: testCtx.NS.Name,
 		Resources: &v1.ResourceRequirements{Requests: v1.ResourceList{

--- a/test/integration/scheduler/preemption_test.go
+++ b/test/integration/scheduler/preemption_test.go
@@ -172,7 +172,7 @@ func TestPreemption(t *testing.T) {
 			description: "basic pod preemption",
 			initTokens:  maxTokens,
 			existingPods: []*v1.Pod{
-				initPausePod(testCtx.ClientSet, &pausePodConfig{
+				initPausePod(&pausePodConfig{
 					Name:      "victim-pod",
 					Namespace: testCtx.NS.Name,
 					Priority:  &lowPriority,
@@ -182,7 +182,7 @@ func TestPreemption(t *testing.T) {
 					},
 				}),
 			},
-			pod: initPausePod(cs, &pausePodConfig{
+			pod: initPausePod(&pausePodConfig{
 				Name:      "preemptor-pod",
 				Namespace: testCtx.NS.Name,
 				Priority:  &highPriority,
@@ -197,7 +197,7 @@ func TestPreemption(t *testing.T) {
 			description: "basic pod preemption with filter",
 			initTokens:  1,
 			existingPods: []*v1.Pod{
-				initPausePod(testCtx.ClientSet, &pausePodConfig{
+				initPausePod(&pausePodConfig{
 					Name:      "victim-pod",
 					Namespace: testCtx.NS.Name,
 					Priority:  &lowPriority,
@@ -207,7 +207,7 @@ func TestPreemption(t *testing.T) {
 					},
 				}),
 			},
-			pod: initPausePod(cs, &pausePodConfig{
+			pod: initPausePod(&pausePodConfig{
 				Name:      "preemptor-pod",
 				Namespace: testCtx.NS.Name,
 				Priority:  &highPriority,
@@ -224,7 +224,7 @@ func TestPreemption(t *testing.T) {
 			initTokens:   1,
 			unresolvable: true,
 			existingPods: []*v1.Pod{
-				initPausePod(testCtx.ClientSet, &pausePodConfig{
+				initPausePod(&pausePodConfig{
 					Name:      "victim-pod",
 					Namespace: testCtx.NS.Name,
 					Priority:  &lowPriority,
@@ -234,7 +234,7 @@ func TestPreemption(t *testing.T) {
 					},
 				}),
 			},
-			pod: initPausePod(cs, &pausePodConfig{
+			pod: initPausePod(&pausePodConfig{
 				Name:      "preemptor-pod",
 				Namespace: testCtx.NS.Name,
 				Priority:  &highPriority,
@@ -249,13 +249,13 @@ func TestPreemption(t *testing.T) {
 			description: "preemption is performed to satisfy anti-affinity",
 			initTokens:  maxTokens,
 			existingPods: []*v1.Pod{
-				initPausePod(cs, &pausePodConfig{
+				initPausePod(&pausePodConfig{
 					Name: "pod-0", Namespace: testCtx.NS.Name,
 					Priority:  &mediumPriority,
 					Labels:    map[string]string{"pod": "p0"},
 					Resources: defaultPodRes,
 				}),
-				initPausePod(cs, &pausePodConfig{
+				initPausePod(&pausePodConfig{
 					Name: "pod-1", Namespace: testCtx.NS.Name,
 					Priority:  &lowPriority,
 					Labels:    map[string]string{"pod": "p1"},
@@ -281,7 +281,7 @@ func TestPreemption(t *testing.T) {
 				}),
 			},
 			// A higher priority pod with anti-affinity.
-			pod: initPausePod(cs, &pausePodConfig{
+			pod: initPausePod(&pausePodConfig{
 				Name:      "preemptor-pod",
 				Namespace: testCtx.NS.Name,
 				Priority:  &highPriority,
@@ -313,13 +313,13 @@ func TestPreemption(t *testing.T) {
 			description: "preemption is not performed when anti-affinity is not satisfied",
 			initTokens:  maxTokens,
 			existingPods: []*v1.Pod{
-				initPausePod(cs, &pausePodConfig{
+				initPausePod(&pausePodConfig{
 					Name: "pod-0", Namespace: testCtx.NS.Name,
 					Priority:  &mediumPriority,
 					Labels:    map[string]string{"pod": "p0"},
 					Resources: defaultPodRes,
 				}),
-				initPausePod(cs, &pausePodConfig{
+				initPausePod(&pausePodConfig{
 					Name: "pod-1", Namespace: testCtx.NS.Name,
 					Priority:  &highPriority,
 					Labels:    map[string]string{"pod": "p1"},
@@ -345,7 +345,7 @@ func TestPreemption(t *testing.T) {
 				}),
 			},
 			// A higher priority pod with anti-affinity.
-			pod: initPausePod(cs, &pausePodConfig{
+			pod: initPausePod(&pausePodConfig{
 				Name:      "preemptor-pod",
 				Namespace: testCtx.NS.Name,
 				Priority:  &highPriority,
@@ -449,7 +449,7 @@ func TestDisablePreemption(t *testing.T) {
 		{
 			description: "pod preemption will not happen",
 			existingPods: []*v1.Pod{
-				initPausePod(testCtx.ClientSet, &pausePodConfig{
+				initPausePod(&pausePodConfig{
 					Name:      "victim-pod",
 					Namespace: testCtx.NS.Name,
 					Priority:  &lowPriority,
@@ -459,7 +459,7 @@ func TestDisablePreemption(t *testing.T) {
 					},
 				}),
 			},
-			pod: initPausePod(cs, &pausePodConfig{
+			pod: initPausePod(&pausePodConfig{
 				Name:      "preemptor-pod",
 				Namespace: testCtx.NS.Name,
 				Priority:  &highPriority,
@@ -549,7 +549,7 @@ func TestPodPriorityResolution(t *testing.T) {
 			Name:             "SystemNodeCritical priority class",
 			PriorityClass:    scheduling.SystemNodeCritical,
 			ExpectedPriority: scheduling.SystemCriticalPriority + 1000,
-			Pod: initPausePod(cs, &pausePodConfig{
+			Pod: initPausePod(&pausePodConfig{
 				Name:              fmt.Sprintf("pod1-%v", scheduling.SystemNodeCritical),
 				Namespace:         metav1.NamespaceSystem,
 				PriorityClassName: scheduling.SystemNodeCritical,
@@ -559,7 +559,7 @@ func TestPodPriorityResolution(t *testing.T) {
 			Name:             "SystemClusterCritical priority class",
 			PriorityClass:    scheduling.SystemClusterCritical,
 			ExpectedPriority: scheduling.SystemCriticalPriority,
-			Pod: initPausePod(cs, &pausePodConfig{
+			Pod: initPausePod(&pausePodConfig{
 				Name:              fmt.Sprintf("pod2-%v", scheduling.SystemClusterCritical),
 				Namespace:         metav1.NamespaceSystem,
 				PriorityClassName: scheduling.SystemClusterCritical,
@@ -569,7 +569,7 @@ func TestPodPriorityResolution(t *testing.T) {
 			Name:             "Invalid priority class should result in error",
 			PriorityClass:    "foo",
 			ExpectedPriority: scheduling.SystemCriticalPriority,
-			Pod: initPausePod(cs, &pausePodConfig{
+			Pod: initPausePod(&pausePodConfig{
 				Name:              fmt.Sprintf("pod3-%v", scheduling.SystemClusterCritical),
 				Namespace:         metav1.NamespaceSystem,
 				PriorityClassName: "foo",
@@ -622,7 +622,7 @@ func mkPriorityPodWithGrace(tc *testutils.TestContext, name string, priority int
 		v1.ResourceCPU:    *resource.NewMilliQuantity(100, resource.DecimalSI),
 		v1.ResourceMemory: *resource.NewQuantity(100, resource.DecimalSI)},
 	}
-	pod := initPausePod(tc.ClientSet, &pausePodConfig{
+	pod := initPausePod(&pausePodConfig{
 		Name:      name,
 		Namespace: tc.NS.Name,
 		Priority:  &priority,
@@ -657,7 +657,7 @@ func TestPreemptionStarvation(t *testing.T) {
 			description:        "starvation test: higher priority pod is scheduled before the lower priority ones",
 			numExistingPod:     10,
 			numExpectedPending: 5,
-			preemptor: initPausePod(cs, &pausePodConfig{
+			preemptor: initPausePod(&pausePodConfig{
 				Name:      "preemptor-pod",
 				Namespace: testCtx.NS.Name,
 				Priority:  &highPriority,
@@ -756,7 +756,7 @@ func TestPreemptionRaces(t *testing.T) {
 			numInitialPods:    2,
 			numAdditionalPods: 50,
 			numRepetitions:    10,
-			preemptor: initPausePod(cs, &pausePodConfig{
+			preemptor: initPausePod(&pausePodConfig{
 				Name:      "preemptor-pod",
 				Namespace: testCtx.NS.Name,
 				Priority:  &highPriority,
@@ -891,7 +891,7 @@ func TestNominatedNodeCleanUp(t *testing.T) {
 		}
 	}
 	// Step 2. Create a medium priority pod.
-	podConf := initPausePod(cs, &pausePodConfig{
+	podConf := initPausePod(&pausePodConfig{
 		Name:      "medium-priority",
 		Namespace: testCtx.NS.Name,
 		Priority:  &mediumPriority,
@@ -909,7 +909,7 @@ func TestNominatedNodeCleanUp(t *testing.T) {
 		t.Errorf("NominatedNodeName annotation was not set for pod %v/%v: %v", medPriPod.Namespace, medPriPod.Name, err)
 	}
 	// Step 4. Create a high priority pod.
-	podConf = initPausePod(cs, &pausePodConfig{
+	podConf = initPausePod(&pausePodConfig{
 		Name:      "high-priority",
 		Namespace: testCtx.NS.Name,
 		Priority:  &highPriority,
@@ -1008,28 +1008,28 @@ func TestPDBInPreemption(t *testing.T) {
 			},
 			pdbPodNum: []int32{2},
 			existingPods: []*v1.Pod{
-				initPausePod(testCtx.ClientSet, &pausePodConfig{
+				initPausePod(&pausePodConfig{
 					Name:      "low-pod1",
 					Namespace: testCtx.NS.Name,
 					Priority:  &lowPriority,
 					Resources: defaultPodRes,
 					Labels:    map[string]string{"foo": "bar"},
 				}),
-				initPausePod(testCtx.ClientSet, &pausePodConfig{
+				initPausePod(&pausePodConfig{
 					Name:      "low-pod2",
 					Namespace: testCtx.NS.Name,
 					Priority:  &lowPriority,
 					Resources: defaultPodRes,
 					Labels:    map[string]string{"foo": "bar"},
 				}),
-				initPausePod(testCtx.ClientSet, &pausePodConfig{
+				initPausePod(&pausePodConfig{
 					Name:      "mid-pod3",
 					Namespace: testCtx.NS.Name,
 					Priority:  &mediumPriority,
 					Resources: defaultPodRes,
 				}),
 			},
-			pod: initPausePod(cs, &pausePodConfig{
+			pod: initPausePod(&pausePodConfig{
 				Name:      "preemptor-pod",
 				Namespace: testCtx.NS.Name,
 				Priority:  &highPriority,
@@ -1051,7 +1051,7 @@ func TestPDBInPreemption(t *testing.T) {
 			},
 			pdbPodNum: []int32{1},
 			existingPods: []*v1.Pod{
-				initPausePod(testCtx.ClientSet, &pausePodConfig{
+				initPausePod(&pausePodConfig{
 					Name:      "low-pod1",
 					Namespace: testCtx.NS.Name,
 					Priority:  &lowPriority,
@@ -1059,7 +1059,7 @@ func TestPDBInPreemption(t *testing.T) {
 					NodeName:  "node-1",
 					Labels:    map[string]string{"foo": "bar"},
 				}),
-				initPausePod(testCtx.ClientSet, &pausePodConfig{
+				initPausePod(&pausePodConfig{
 					Name:      "mid-pod2",
 					Namespace: testCtx.NS.Name,
 					Priority:  &mediumPriority,
@@ -1067,7 +1067,7 @@ func TestPDBInPreemption(t *testing.T) {
 					Resources: defaultPodRes,
 				}),
 			},
-			pod: initPausePod(cs, &pausePodConfig{
+			pod: initPausePod(&pausePodConfig{
 				Name:      "preemptor-pod",
 				Namespace: testCtx.NS.Name,
 				Priority:  &highPriority,
@@ -1091,7 +1091,7 @@ func TestPDBInPreemption(t *testing.T) {
 			},
 			pdbPodNum: []int32{1, 5},
 			existingPods: []*v1.Pod{
-				initPausePod(testCtx.ClientSet, &pausePodConfig{
+				initPausePod(&pausePodConfig{
 					Name:      "low-pod1",
 					Namespace: testCtx.NS.Name,
 					Priority:  &lowPriority,
@@ -1099,14 +1099,14 @@ func TestPDBInPreemption(t *testing.T) {
 					NodeName:  "node-1",
 					Labels:    map[string]string{"foo1": "bar"},
 				}),
-				initPausePod(testCtx.ClientSet, &pausePodConfig{
+				initPausePod(&pausePodConfig{
 					Name:      "mid-pod1",
 					Namespace: testCtx.NS.Name,
 					Priority:  &mediumPriority,
 					Resources: defaultPodRes,
 					NodeName:  "node-1",
 				}),
-				initPausePod(testCtx.ClientSet, &pausePodConfig{
+				initPausePod(&pausePodConfig{
 					Name:      "low-pod2",
 					Namespace: testCtx.NS.Name,
 					Priority:  &lowPriority,
@@ -1114,7 +1114,7 @@ func TestPDBInPreemption(t *testing.T) {
 					NodeName:  "node-2",
 					Labels:    map[string]string{"foo2": "bar"},
 				}),
-				initPausePod(testCtx.ClientSet, &pausePodConfig{
+				initPausePod(&pausePodConfig{
 					Name:      "mid-pod2",
 					Namespace: testCtx.NS.Name,
 					Priority:  &mediumPriority,
@@ -1122,7 +1122,7 @@ func TestPDBInPreemption(t *testing.T) {
 					NodeName:  "node-2",
 					Labels:    map[string]string{"foo2": "bar"},
 				}),
-				initPausePod(testCtx.ClientSet, &pausePodConfig{
+				initPausePod(&pausePodConfig{
 					Name:      "low-pod4",
 					Namespace: testCtx.NS.Name,
 					Priority:  &lowPriority,
@@ -1130,7 +1130,7 @@ func TestPDBInPreemption(t *testing.T) {
 					NodeName:  "node-3",
 					Labels:    map[string]string{"foo2": "bar"},
 				}),
-				initPausePod(testCtx.ClientSet, &pausePodConfig{
+				initPausePod(&pausePodConfig{
 					Name:      "low-pod5",
 					Namespace: testCtx.NS.Name,
 					Priority:  &lowPriority,
@@ -1138,7 +1138,7 @@ func TestPDBInPreemption(t *testing.T) {
 					NodeName:  "node-3",
 					Labels:    map[string]string{"foo2": "bar"},
 				}),
-				initPausePod(testCtx.ClientSet, &pausePodConfig{
+				initPausePod(&pausePodConfig{
 					Name:      "low-pod6",
 					Namespace: testCtx.NS.Name,
 					Priority:  &lowPriority,
@@ -1147,7 +1147,7 @@ func TestPDBInPreemption(t *testing.T) {
 					Labels:    map[string]string{"foo2": "bar"},
 				}),
 			},
-			pod: initPausePod(cs, &pausePodConfig{
+			pod: initPausePod(&pausePodConfig{
 				Name:      "preemptor-pod",
 				Namespace: testCtx.NS.Name,
 				Priority:  &highPriority,

--- a/test/integration/scheduler/priorities_test.go
+++ b/test/integration/scheduler/priorities_test.go
@@ -62,7 +62,7 @@ func TestNodeAffinity(t *testing.T) {
 	}
 	// Create a pod with node affinity.
 	podName := "pod-with-node-affinity"
-	pod, err := runPausePod(testCtx.ClientSet, initPausePod(testCtx.ClientSet, &pausePodConfig{
+	pod, err := runPausePod(testCtx.ClientSet, initPausePod(&pausePodConfig{
 		Name:      podName,
 		Namespace: testCtx.NS.Name,
 		Affinity: &v1.Affinity{
@@ -121,7 +121,7 @@ func TestPodAffinity(t *testing.T) {
 	// Add a pod with a label and wait for it to schedule.
 	labelKey := "service"
 	labelValue := "S1"
-	_, err = runPausePod(testCtx.ClientSet, initPausePod(testCtx.ClientSet, &pausePodConfig{
+	_, err = runPausePod(testCtx.ClientSet, initPausePod(&pausePodConfig{
 		Name:      "attractor-pod",
 		Namespace: testCtx.NS.Name,
 		Labels:    map[string]string{labelKey: labelValue},
@@ -136,7 +136,7 @@ func TestPodAffinity(t *testing.T) {
 	}
 	// Add a new pod with affinity to the attractor pod.
 	podName := "pod-with-podaffinity"
-	pod, err := runPausePod(testCtx.ClientSet, initPausePod(testCtx.ClientSet, &pausePodConfig{
+	pod, err := runPausePod(testCtx.ClientSet, initPausePod(&pausePodConfig{
 		Name:      podName,
 		Namespace: testCtx.NS.Name,
 		Affinity: &v1.Affinity{

--- a/test/integration/scheduler/scheduler_test.go
+++ b/test/integration/scheduler/scheduler_test.go
@@ -503,13 +503,13 @@ func TestMultipleSchedulers(t *testing.T) {
 	}
 
 	defaultScheduler := "default-scheduler"
-	testPodFitsDefault, err := createPausePod(testCtx.ClientSet, initPausePod(testCtx.ClientSet, &pausePodConfig{Name: "pod-fits-default", Namespace: testCtx.NS.Name, SchedulerName: defaultScheduler}))
+	testPodFitsDefault, err := createPausePod(testCtx.ClientSet, initPausePod(&pausePodConfig{Name: "pod-fits-default", Namespace: testCtx.NS.Name, SchedulerName: defaultScheduler}))
 	if err != nil {
 		t.Fatalf("Failed to create pod: %v", err)
 	}
 
 	fooScheduler := "foo-scheduler"
-	testPodFitsFoo, err := createPausePod(testCtx.ClientSet, initPausePod(testCtx.ClientSet, &pausePodConfig{Name: "pod-fits-foo", Namespace: testCtx.NS.Name, SchedulerName: fooScheduler}))
+	testPodFitsFoo, err := createPausePod(testCtx.ClientSet, initPausePod(&pausePodConfig{Name: "pod-fits-foo", Namespace: testCtx.NS.Name, SchedulerName: fooScheduler}))
 	if err != nil {
 		t.Fatalf("Failed to create pod: %v", err)
 	}
@@ -634,7 +634,7 @@ func TestMultipleSchedulingProfiles(t *testing.T) {
 		{Name: "baz", Namespace: testCtx.NS.Name, SchedulerName: "default-scheduler"},
 		{Name: "zet", Namespace: testCtx.NS.Name, SchedulerName: "custom-scheduler"},
 	} {
-		if _, err := createPausePod(testCtx.ClientSet, initPausePod(testCtx.ClientSet, pc)); err != nil {
+		if _, err := createPausePod(testCtx.ClientSet, initPausePod(pc)); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -774,7 +774,7 @@ func TestSchedulerInformers(t *testing.T) {
 			description: "Pod cannot be scheduled when node is occupied by pods scheduled by other schedulers",
 			nodes:       []*nodeConfig{{name: "node-1", res: defaultNodeRes}},
 			existingPods: []*v1.Pod{
-				initPausePod(testCtx.ClientSet, &pausePodConfig{
+				initPausePod(&pausePodConfig{
 					Name:          "pod1",
 					Namespace:     testCtx.NS.Name,
 					Resources:     defaultPodRes,
@@ -782,7 +782,7 @@ func TestSchedulerInformers(t *testing.T) {
 					NodeName:      "node-1",
 					SchedulerName: "foo-scheduler",
 				}),
-				initPausePod(testCtx.ClientSet, &pausePodConfig{
+				initPausePod(&pausePodConfig{
 					Name:          "pod2",
 					Namespace:     testCtx.NS.Name,
 					Resources:     defaultPodRes,
@@ -791,7 +791,7 @@ func TestSchedulerInformers(t *testing.T) {
 					SchedulerName: "bar-scheduler",
 				}),
 			},
-			pod: initPausePod(cs, &pausePodConfig{
+			pod: initPausePod(&pausePodConfig{
 				Name:      "unschedulable-pod",
 				Namespace: testCtx.NS.Name,
 				Resources: defaultPodRes,

--- a/test/integration/scheduler/util.go
+++ b/test/integration/scheduler/util.go
@@ -209,7 +209,7 @@ type pausePodConfig struct {
 
 // initPausePod initializes a pod API object from the given config. It is used
 // mainly in pod creation process.
-func initPausePod(cs clientset.Interface, conf *pausePodConfig) *v1.Pod {
+func initPausePod(conf *pausePodConfig) *v1.Pod {
 	pod := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        conf.Name,
@@ -265,7 +265,7 @@ func createPausePodWithResource(cs clientset.Interface, podName string,
 			},
 		}
 	}
-	return createPausePod(cs, initPausePod(cs, &conf))
+	return createPausePod(cs, initPausePod(&conf))
 }
 
 // runPausePod creates a pod with "Pause" image and the given config and waits


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

We have little coverage around node addition and removal. Since distinct event handlers interact, it is important to cover this in integration tests. More cases can be added to exercise other events.

Part of #91111

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```