### PR TITLE
 Changed kubectl config set-cluster and set-credentials to support process substitution for filenames

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/create_authinfo.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/create_authinfo.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -421,13 +422,13 @@ func (o createAuthInfoOptions) validate() error {
 			return fmt.Errorf("you must specify a --%s or --%s to embed", clientcmd.FlagCertFile, clientcmd.FlagKeyFile)
 		}
 		if certPath != "" {
-			if _, err := ioutil.ReadFile(certPath); err != nil {
-				return fmt.Errorf("error reading %s data from %s: %v", clientcmd.FlagCertFile, certPath, err)
+			if _, err := os.Stat(certPath); err != nil {
+				return fmt.Errorf("could not stat %s file %s: %v", clientcmd.FlagCertFile, certPath, err)
 			}
 		}
 		if keyPath != "" {
-			if _, err := ioutil.ReadFile(keyPath); err != nil {
-				return fmt.Errorf("error reading %s data from %s: %v", clientcmd.FlagKeyFile, keyPath, err)
+			if _, err := os.Stat(keyPath); err != nil {
+				return fmt.Errorf("could not stat %s file %s: %v", clientcmd.FlagKeyFile, keyPath, err)
 			}
 		}
 	}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/create_cluster.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/create_cluster.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	"github.com/spf13/cobra"
@@ -53,7 +54,7 @@ var (
 		kubectl config set-cluster e2e --server=https://1.2.3.4
 
 		# Embed certificate authority data for the e2e cluster entry
-		kubectl config set-cluster e2e --certificate-authority=~/.kube/e2e/kubernetes.ca.crt
+		kubectl config set-cluster e2e --embed-certs --certificate-authority=~/.kube/e2e/kubernetes.ca.crt
 
 		# Disable cert checking for the dev cluster entry
 		kubectl config set-cluster e2e --insecure-skip-tls-verify=true
@@ -181,8 +182,8 @@ func (o createClusterOptions) validate() error {
 		if caPath == "" {
 			return fmt.Errorf("you must specify a --%s to embed", clientcmd.FlagCAFile)
 		}
-		if _, err := ioutil.ReadFile(caPath); err != nil {
-			return fmt.Errorf("could not read %s data from %s: %v", clientcmd.FlagCAFile, caPath, err)
+		if _, err := os.Stat(caPath); err != nil {
+			return fmt.Errorf("could not stat %s file %s: %v", clientcmd.FlagCAFile, caPath, err)
 		}
 	}
 

--- a/test/cmd/kubeconfig.sh
+++ b/test/cmd/kubeconfig.sh
@@ -43,6 +43,164 @@ run_kubectl_config_set_tests() {
   set +o errexit
 }
 
+run_kubectl_config_set_cluster_tests() {
+  set -o nounset
+  set -o errexit
+
+  create_and_use_new_namespace
+  kube::log::status "Testing kubectl config set-cluster"
+
+  ca_file="${TMPDIR:-/tmp}/apiserver.crt"
+  ca_data=$(base64 -w0 "$ca_file")
+
+  # Set cert file
+  kubectl config set-cluster test-cluster-1 --certificate-authority "$ca_file"
+  expected="$ca_file"
+  actual=$(kubectl config view --raw -o jsonpath='{.clusters[?(@.name == "test-cluster-1")].cluster.certificate-authority}')
+  if [ "$expected" != "$actual" ]; then
+    kube::log::error "Certificate authority did not match the expected value (expected=$expected, actual=$actual)"
+    exit 1
+  fi
+
+  # Embed cert from file
+  kubectl config set-cluster test-cluster-2 --embed-certs --certificate-authority "$ca_file"
+  expected="$ca_data"
+  actual=$(kubectl config view --raw -o jsonpath='{.clusters[?(@.name == "test-cluster-2")].cluster.certificate-authority-data}')
+  if [ "$expected" != "$actual" ]; then
+    kube::log::error "Certificate authority embedded from file did not match the expected value (expected=$expected, actual=$actual)"
+    exit 1
+  fi
+
+  # Embed cert using process substitution
+  kubectl config set-cluster test-cluster-3 --embed-certs --certificate-authority <(cat "$ca_file")
+  expected="$ca_data"
+  actual=$(kubectl config view --raw -o jsonpath='{.clusters[?(@.name == "test-cluster-3")].cluster.certificate-authority-data}')
+  if [ "$expected" != "$actual" ]; then
+    kube::log::error "Certificate authority embedded using process substitution did not match the expected value (expected=$expected, actual=$actual)"
+    exit 1
+  fi
+
+  set +o nounset
+  set +o errexit
+}
+
+run_kubectl_config_set_credentials_tests() {
+  set -o nounset
+  set -o errexit
+
+  create_and_use_new_namespace
+  kube::log::status "Testing kubectl config set-credentials"
+
+  cert_file="${TMPDIR:-/tmp}/test-client-certificate.crt"
+  key_file="${TMPDIR:-/tmp}/test-client-key.crt"
+
+  cat << EOF > "$cert_file"
+-----BEGIN CERTIFICATE-----
+MIIDazCCAlOgAwIBAgIUdSrvuXs0Bft9Ao/AFnC7fNBqD+owDQYJKoZIhvcNAQEL
+BQAwRTELMAkGA1UEBhMCQVUxEzARBgNVBAgMClNvbWUtU3RhdGUxITAfBgNVBAoM
+GEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZDAeFw0yMDA1MTExODMyNDJaFw0yMTA1
+MTExODMyNDJaMEUxCzAJBgNVBAYTAkFVMRMwEQYDVQQIDApTb21lLVN0YXRlMSEw
+HwYDVQQKDBhJbnRlcm5ldCBXaWRnaXRzIFB0eSBMdGQwggEiMA0GCSqGSIb3DQEB
+AQUAA4IBDwAwggEKAoIBAQCrS5/kYM3TjdFw4OYMdSOys0+4aHPgtXqePWrn1pBP
+W9D1yhjI/JS1/uPAWLi+1nnn0PBMCbqo+ZEsRIlSAABJE4fVbRPg+AuBPDdlCex5
+QfKNi3vwp0Gy756SKTNZmIx42I9in0WeocCDliTEM2KsawCrVzuE3gwcHHkOnmLX
+DEc4bajkQxcaJITG3hsJ2Cm5OBMLPwrsq/77VzOdC12r9j8+w0f7lCJfOm2ui7rm
+Vl76V2Nits6U0ZrF1yzYtVQ1iWqCnOudPPf3jyc7KcSetGwozgoydkcqfUS9iMs9
+2OV3v17GX6+sd8zY8tA95d/Vj6yU/l03GI9V6X9LXHSTAgMBAAGjUzBRMB0GA1Ud
+DgQWBBQo2BKDxo4XI5FJDj9ZUuDst9ck7DAfBgNVHSMEGDAWgBQo2BKDxo4XI5FJ
+Dj9ZUuDst9ck7DAPBgNVHRMBAf8EBTADAQH/MA0GCSqGSIb3DQEBCwUAA4IBAQAL
+LjJ5k5kNdOUXFL2XhKO8w25tpkjd71vD3vKvPIN0Q5BgVmu5Bg476/WPBnSMvTVU
+QYLQR5aGMLPdWuiSJnwO0BChKjOHaoCnP6D3cs2xP9hLBGoENaXMJRM4ZvFBRbES
+Q6iTfq4OBPh5yCDDrjlppjhSnqaZuksmFnPFHLB/km003w8fgCD3VhmC2UFscl2K
+nHaxK6uzIxisyE84ZDZYhjnPPib1wXGL8yu1dq0cbktE5+xJ2FHQkBJ6qaujkgV0
+jpuWE9zk3CImFRkzPEwTF+3s5eP2XTIyWbtJGvJMmO0kHFx2PqCiAkdFldPKfrRh
+M007Wf15dtkqyLNkzOxv
+-----END CERTIFICATE-----
+EOF
+
+  cat << EOF > "$key_file"
+-----BEGIN PRIVATE KEY-----
+MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQCrS5/kYM3TjdFw
+4OYMdSOys0+4aHPgtXqePWrn1pBPW9D1yhjI/JS1/uPAWLi+1nnn0PBMCbqo+ZEs
+RIlSAABJE4fVbRPg+AuBPDdlCex5QfKNi3vwp0Gy756SKTNZmIx42I9in0WeocCD
+liTEM2KsawCrVzuE3gwcHHkOnmLXDEc4bajkQxcaJITG3hsJ2Cm5OBMLPwrsq/77
+VzOdC12r9j8+w0f7lCJfOm2ui7rmVl76V2Nits6U0ZrF1yzYtVQ1iWqCnOudPPf3
+jyc7KcSetGwozgoydkcqfUS9iMs92OV3v17GX6+sd8zY8tA95d/Vj6yU/l03GI9V
+6X9LXHSTAgMBAAECggEASKlTsfS+WrcV2OQNscse0XbuojLstK1GzkkPSDjkDkXM
+ZfbMfLVn/6uXwMfh1lH0dDlVNWwLGhKDWlvYREhr1pPKUuZqQEv31WJNvTZwcR9g
+XFqGwJayb8zlXurLNX5YWArFB/i394p1t1vBTNjfSnQ5XHUscjgeuu35DBJzqvSA
+mh1nDUBFIMC4ruPzD7OMI7rXBN02PbfTBpoL8MGoesW0S/BFQciMS07rELL2hFih
+zZPJE+E6h3GMoSPAzqx+ubSkhMbxb/xQQSw4gfp8zii2SMuq8Ith9xaGhdj1TuaX
+NqZahgSRe7bbgYyHWHXYbd7gQa4fxxoT7Qyh0cSKwQKBgQDZP0yYcFfNADFfnw62
+eWgNHnfPsOTYa/gAXdKgueUekT+linGvAUQtdXxnLoVMiLXSVxaJbW1rAP0avJt8
+EJiTdtTXkKqTqwtfbUP/bmxjYNExvGfIOpJbDsCX+kwpCoWzHupXeQlZn7UDEmKR
+l0DWUVzqNnhO0WWaM9J4MD4BjwKBgQDJ2elu8h7V/U/0dr2e4GG1/Xoa1nIcct8C
+rn0cG2GJ6UxN9Rr/brrLZuBewlhul9VjGtcmD7ZvEEsR4EUHUguvheAg90rpAqSE
+c6LOYdGAsUa21iuVLPKPMFwd4MhtrP2JcwHO+oqlUK4939TlZEtyiMWsMJGuugh1
+nrudZ9LSvQKBgBFG83R8Gr928HZGVAk3BotkjOq7irebfpGo5INbxVj0/DbSF9Bv
+LVjgKxCZpog7pxofSu+LAFSuM3LY5RSszTWNEchC/Q3ZYIIqUmoSAhS1Mm3eKfLG
+lbUgKzjq8vuglpl0L/bc7V1vUhn4cFZbzRA+UEFgK5k5Ffd5f5eHXqcJAoGBAJmA
+hVwg9sBHfnlrn3JmMwiCdkxYjrkBxoS0i2JHlFqbt7KFVn2wCI/McY6+fx/Dibxv
+WfSQ+Gzn2B8FDZmulEJsLfED/szKfLBZfBM1Imya5CsBHm24m9G2tibmnaWCa+EO
+O+7aa3uiqo9VXAMCzbmRN7plyTQ2N16zUvw2S4aFAoGARoPL2cJ+7HHcnc4SzKm4
+Su5nLwVPj+IJUwI5SRsRdnUKqo4gaX54p/u/TlA6fm7esRqPu5LK0oIyItVP7wmT
+nUCUFtnE53Rm2QT+BlYg7CewkaRiUHgQR31RDsQP8XtQouy0Si2jG53QLtBm+b7D
+zpqQAUELuiSK67vTd+D96ss=
+-----END PRIVATE KEY-----
+EOF
+
+  cert_data=$(base64 -w0 "$cert_file")
+  key_data=$(base64 -w0 "$key_file")
+
+  # Set client certificate and client key files
+  kubectl config set-credentials user1 --client-certificate="$cert_file" --client-key="$key_file"
+  expected="$cert_file"
+  actual=$(kubectl config view --raw -o jsonpath='{.users[?(@.name == "user1")].user.client-certificate}')
+  if [ "$expected" != "$actual" ]; then
+    kube::log::error "Client certificate did not match the expected value (expected=$expected, actual=$actual)"
+    exit 1
+  fi
+  expected="$key_file"
+  actual=$(kubectl config view --raw -o jsonpath='{.users[?(@.name == "user1")].user.client-key}')
+  if [ "$expected" != "$actual" ]; then
+    kube::log::error "Client key did not match the expected value (expected=$expected, actual=$actual)"
+    exit 1
+  fi
+
+  # Embed client certificate and client key from files
+  kubectl config set-credentials user2 --client-certificate="$cert_file" --client-key="$key_file" --embed-certs=true
+  expected="$cert_data"
+  actual=$(kubectl config view --raw -o jsonpath='{.users[?(@.name == "user2")].user.client-certificate-data}')
+  if [ "$expected" != "$actual" ]; then
+    kube::log::error "Client certificate data embedded from file did not match the expected value (expected=$expected, actual=$actual)"
+    exit 1
+  fi
+  expected="$key_data"
+  actual=$(kubectl config view --raw -o jsonpath='{.users[?(@.name == "user2")].user.client-key-data}')
+  if [ "$expected" != "$actual" ]; then
+    kube::log::error "Client key data embedded from file did not match the expected value (expected=$expected, actual=$actual)"
+    exit 1
+  fi
+
+  # Embed client certificate and client key using process substitution
+  kubectl config set-credentials user3 --client-certificate=<(cat "$cert_file") --client-key=<(cat "$key_file") --embed-certs=true
+  expected="$cert_data"
+  actual=$(kubectl config view --raw -o jsonpath='{.users[?(@.name == "user3")].user.client-certificate-data}')
+  if [ "$expected" != "$actual" ]; then
+    kube::log::error "Client certificate data embedded using process substitution did not match the expected value (expected=$expected, actual=$actual)"
+    exit 1
+  fi
+  expected="$key_data"
+  actual=$(kubectl config view --raw -o jsonpath='{.users[?(@.name == "user3")].user.client-key-data}')
+  if [ "$expected" != "$actual" ]; then
+    kube::log::error "Client key data embedded using process substitution did not match the expected value (expected=$expected, actual=$actual)"
+    exit 1
+  fi
+
+  set +o nounset
+  set +o errexit
+}
+
 run_client_config_tests() {
   set -o nounset
   set -o errexit

--- a/test/cmd/legacy-script.sh
+++ b/test/cmd/legacy-script.sh
@@ -439,6 +439,18 @@ runTests() {
 
   record_command run_kubectl_config_set_tests
 
+  ##############################
+  # kubectl config set-cluster #
+  ##############################
+
+  record_command run_kubectl_config_set_cluster_tests
+
+  ##################################
+  # kubectl config set-credentials #
+  ##################################
+
+  record_command run_kubectl_config_set_credentials_tests
+
   #######################
   # kubectl local proxy #
   #######################


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
`kubectl config set-cluster` doesn't work with process substitution, so you can't set the certificate authority from an environment variable like this:
```
kubectl config set-cluster xyz --embed-certs --certificate-authority <(echo $CACERT)
```

This doesn't result in an error, but fails to set the certificate authority.

This PR changes `kubectl config set-cluster` so that it only reads the ca file once, thereby allowing process substitution to work properly.

This PR also makes the same change to `kubectl config set-credentials`.

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes/kubectl/issues/501

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs

```
