### PR TITLE
skip unnecessary scheduling attempt when pod has its Finalizers updated

### DIFF
--- a/pkg/scheduler/eventhandlers.go
+++ b/pkg/scheduler/eventhandlers.go
@@ -301,7 +301,7 @@ func responsibleForPod(pod *v1.Pod, profiles profile.Map) bool {
 // skipPodUpdate checks whether the specified pod update should be ignored.
 // This function will return true if
 //   - The pod has already been assumed, AND
-//   - The pod has only its ResourceVersion, Spec.NodeName and/or Annotations
+//   - The pod has only its ResourceVersion, Spec.NodeName, Annotations, ManagedFields and/or Finalizers
 //     updated.
 func (sched *Scheduler) skipPodUpdate(pod *v1.Pod) bool {
 	// Non-assumed pods should never be skipped.
@@ -338,6 +338,8 @@ func (sched *Scheduler) skipPodUpdate(pod *v1.Pod) bool {
 		// Same as above, when annotations are modified with ServerSideApply,
 		// ManagedFields may also change and must be excluded
 		p.ManagedFields = nil
+		// Finalizers must be excluded because scheduled result can not be affected
+		p.Finalizers = nil
 		return p
 	}
 	assumedPodCopy, podCopy := f(assumedPod), f(pod)

--- a/pkg/scheduler/eventhandlers_test.go
+++ b/pkg/scheduler/eventhandlers_test.go
@@ -180,6 +180,27 @@ func TestSkipPodUpdate(t *testing.T) {
 			},
 			expected: false,
 		},
+		{
+			name: "with changes on Finalizers",
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "pod-0",
+					Finalizers: []string{"a", "b"},
+				},
+			},
+			isAssumedPodFunc: func(*v1.Pod) bool {
+				return true
+			},
+			getPodFunc: func(*v1.Pod) *v1.Pod {
+				return &v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       "pod-0",
+						Finalizers: []string{"c", "d"},
+					},
+				}
+			},
+			expected: true,
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			c := &Scheduler{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> /kind cleanup
   /kind bug

**What this PR does / why we need it**:
We use pod.Finalizers to do some cleanup before pod is deleted. Our operator watch the create and delete event of pod, add entry in the pod.Finalizers list for create event and remove entry for delete event. Both add entry and remove entry would use client to update pod which generates a PodUpdate event.

Scheduler also watch the create event of pod, select a host and bind it.

But unfortunately, the binding step is running as a goroutine, which in practice can happen after the PodUpdate event step. 

```
podInformer.Informer().AddEventHandler(
		cache.FilteringResourceEventHandler{
			FilterFunc: func(obj interface{}) bool {
				switch t := obj.(type) {
				case *v1.Pod:
					return !assignedPod(t) && responsibleForPod(t, sched.Profiles)
				case cache.DeletedFinalStateUnknown:
					if pod, ok := t.Obj.(*v1.Pod); ok {
						return !assignedPod(pod) && responsibleForPod(pod, sched.Profiles)
					}
					utilruntime.HandleError(fmt.Errorf("unable to convert object %T to *v1.Pod in %T", obj, sched))
					return false
				default:
					utilruntime.HandleError(fmt.Errorf("unable to handle object in %T: %T", sched, obj))
					return false
				}
			},
			Handler: cache.ResourceEventHandlerFuncs{
				AddFunc:    sched.addPodToSchedulingQueue,
				UpdateFunc: sched.updatePodInSchedulingQueue,
				DeleteFunc: sched.deletePodFromSchedulingQueue,
			},
		},
	)
```
When PodUpdate event happens, the binding has not be completed, so `FilterFunc` pass through the pod.


```
func (sched *Scheduler) updatePodInSchedulingQueue(oldObj, newObj interface{}) {
	pod := newObj.(*v1.Pod)
	if sched.skipPodUpdate(pod) {
		return
	}
	if err := sched.SchedulingQueue.Update(oldObj.(*v1.Pod), pod); err != nil {
		utilruntime.HandleError(fmt.Errorf("unable to update %T: %v", newObj, err))
	}
}
```
`skipPodUpdate` would not skip the podUpdate because changes are Finalizers.
```
func (sched *Scheduler) skipPodUpdate(pod *v1.Pod) bool {
	......

	// Compares the assumed pod in the cache with the pod update. If they are
	// equal (with certain fields excluded), this pod update will be skipped.
	f := func(pod *v1.Pod) *v1.Pod {
		p := pod.DeepCopy()
		// ResourceVersion must be excluded because each object update will
		// have a new resource version.
		p.ResourceVersion = ""
		// Spec.NodeName must be excluded because the pod assumed in the cache
		// is expected to have a node assigned while the pod update may nor may
		// not have this field set.
		p.Spec.NodeName = ""
		// Annotations must be excluded for the reasons described in
		// https://github.com/kubernetes/kubernetes/issues/52914.
		p.Annotations = nil
		// Same as above, when annotations are modified with ServerSideApply,
		// ManagedFields may also change and must be excluded
		p.ManagedFields = nil
		return p
	}
	assumedPodCopy, podCopy := f(assumedPod), f(pod)
	if !reflect.DeepEqual(assumedPodCopy, podCopy) {
		return false
	}
	klog.V(3).Infof("Skipping pod %s/%s update", pod.Namespace, pod.Name)
	return true
}
```
As results, the same pod is put into scheduler active queue again which is unnecessary.


Solutions:
1. Skip podUpdate when pod has its Finalizers updated like this PR.

~~2. The skipPodUpdate method is blacklist now, we write these fields in the blacklist which should be ignored. Maybe we can use whitelist, write the fields in the whitelist which would affect scheduling.~~

Similar issues: 

https://github.com/kubernetes/kubernetes/pull/86230

https://github.com/kubernetes/kubernetes/issues/90616