### PR TITLE
Move `RequestedToCapacityRatio` Args defaults to versioned packages

### DIFF
--- a/pkg/scheduler/apis/config/scheme/scheme_test.go
+++ b/pkg/scheduler/apis/config/scheme/scheme_test.go
@@ -98,7 +98,8 @@ profiles:
 						{
 							Name: "RequestedToCapacityRatio",
 							Args: &config.RequestedToCapacityRatioArgs{
-								Shape: []config.UtilizationShapePoint{{Utilization: 1}},
+								Shape:     []config.UtilizationShapePoint{{Utilization: 1}},
+								Resources: []config.ResourceSpec{{Name: "cpu", Weight: 1}, {Name: "memory", Weight: 1}},
 							},
 						},
 						{

--- a/pkg/scheduler/apis/config/v1alpha2/defaults.go
+++ b/pkg/scheduler/apis/config/v1alpha2/defaults.go
@@ -185,3 +185,10 @@ func SetDefaults_NodeResourcesMostAllocatedArgs(obj *v1alpha2.NodeResourcesMostA
 		obj.Resources = append(obj.Resources, defaultResourceSpec...)
 	}
 }
+
+func SetDefaults_RequestedToCapacityRatioArgs(obj *v1alpha2.RequestedToCapacityRatioArgs) {
+	if len(obj.Resources) == 0 {
+		// If no resources specified, used the default set.
+		obj.Resources = append(obj.Resources, defaultResourceSpec...)
+	}
+}

--- a/pkg/scheduler/apis/config/v1alpha2/defaults_test.go
+++ b/pkg/scheduler/apis/config/v1alpha2/defaults_test.go
@@ -345,6 +345,29 @@ func TestPluginArgsDefaults(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "NodeResourcesMostAllocatedArgs resources empty",
+			in:   &v1alpha2.NodeResourcesMostAllocatedArgs{},
+			want: &v1alpha2.NodeResourcesMostAllocatedArgs{
+				Resources: []v1alpha2.ResourceSpec{
+					{Name: "cpu", Weight: 1},
+					{Name: "memory", Weight: 1},
+				},
+			},
+		},
+		{
+			name: "NodeResourcesMostAllocatedArgs resources with value",
+			in: &v1alpha2.NodeResourcesMostAllocatedArgs{
+				Resources: []v1alpha2.ResourceSpec{
+					{Name: "resource", Weight: 2},
+				},
+			},
+			want: &v1alpha2.NodeResourcesMostAllocatedArgs{
+				Resources: []v1alpha2.ResourceSpec{
+					{Name: "resource", Weight: 2},
+				},
+			},
+		},
 	}
 	for _, tc := range tests {
 		scheme := runtime.NewScheme()

--- a/pkg/scheduler/apis/config/v1alpha2/zz_generated.defaults.go
+++ b/pkg/scheduler/apis/config/v1alpha2/zz_generated.defaults.go
@@ -39,6 +39,9 @@ func RegisterDefaults(scheme *runtime.Scheme) error {
 	scheme.AddTypeDefaultingFunc(&v1alpha2.NodeResourcesMostAllocatedArgs{}, func(obj interface{}) {
 		SetObjectDefaults_NodeResourcesMostAllocatedArgs(obj.(*v1alpha2.NodeResourcesMostAllocatedArgs))
 	})
+	scheme.AddTypeDefaultingFunc(&v1alpha2.RequestedToCapacityRatioArgs{}, func(obj interface{}) {
+		SetObjectDefaults_RequestedToCapacityRatioArgs(obj.(*v1alpha2.RequestedToCapacityRatioArgs))
+	})
 	return nil
 }
 
@@ -56,4 +59,8 @@ func SetObjectDefaults_NodeResourcesLeastAllocatedArgs(in *v1alpha2.NodeResource
 
 func SetObjectDefaults_NodeResourcesMostAllocatedArgs(in *v1alpha2.NodeResourcesMostAllocatedArgs) {
 	SetDefaults_NodeResourcesMostAllocatedArgs(in)
+}
+
+func SetObjectDefaults_RequestedToCapacityRatioArgs(in *v1alpha2.RequestedToCapacityRatioArgs) {
+	SetDefaults_RequestedToCapacityRatioArgs(in)
 }

--- a/pkg/scheduler/framework/plugins/noderesources/requested_to_capacity_ratio.go
+++ b/pkg/scheduler/framework/plugins/noderesources/requested_to_capacity_ratio.go
@@ -76,10 +76,6 @@ func NewRequestedToCapacityRatio(plArgs runtime.Object, handle framework.Framewo
 			resourceToWeightMap[v1.ResourceName(resource.Name)] = 1
 		}
 	}
-	if len(args.Resources) == 0 {
-		// If no resources specified, used the default set.
-		resourceToWeightMap = defaultRequestedRatioResources
-	}
 
 	return &RequestedToCapacityRatio{
 		handle: handle,

--- a/pkg/scheduler/framework/v1alpha1/framework_test.go
+++ b/pkg/scheduler/framework/v1alpha1/framework_test.go
@@ -496,10 +496,12 @@ func TestNewFrameworkPluginDefaults(t *testing.T) {
 				"InterPodAffinity": &config.InterPodAffinityArgs{
 					HardPodAffinityWeight: 1,
 				},
-				"NodeLabel":                &config.NodeLabelArgs{},
-				"NodeResourcesFit":         &config.NodeResourcesFitArgs{},
-				"RequestedToCapacityRatio": &config.RequestedToCapacityRatioArgs{},
-				"PodTopologySpread":        &config.PodTopologySpreadArgs{},
+				"NodeLabel":        &config.NodeLabelArgs{},
+				"NodeResourcesFit": &config.NodeResourcesFitArgs{},
+				"RequestedToCapacityRatio": &config.RequestedToCapacityRatioArgs{
+					Resources: []config.ResourceSpec{{Name: "cpu", Weight: 1}, {Name: "memory", Weight: 1}},
+				},
+				"PodTopologySpread": &config.PodTopologySpreadArgs{},
 			},
 		},
 		{
@@ -526,8 +528,10 @@ func TestNewFrameworkPluginDefaults(t *testing.T) {
 				"NodeResourcesFit": &config.NodeResourcesFitArgs{
 					IgnoredResources: []string{"example.com/foo"},
 				},
-				"RequestedToCapacityRatio": &config.RequestedToCapacityRatioArgs{},
-				"PodTopologySpread":        &config.PodTopologySpreadArgs{},
+				"RequestedToCapacityRatio": &config.RequestedToCapacityRatioArgs{
+					Resources: []config.ResourceSpec{{Name: "cpu", Weight: 1}, {Name: "memory", Weight: 1}},
+				},
+				"PodTopologySpread": &config.PodTopologySpreadArgs{},
 			},
 		},
 	}


### PR DESCRIPTION
Following API standards, defaults for Plugin Args should be added per version.

Signed-off-by: Dave Chen <dave.chen@arm.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
/kind cleanup



**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
