### PR TITLE
Automated cherry pick of #90554: kubelet: fix `/stats/summary` endpoint on Windows when

### DIFF
--- a/pkg/kubelet/dockershim/docker_stats.go
+++ b/pkg/kubelet/dockershim/docker_stats.go
@@ -53,8 +53,9 @@ func (ds *dockerService) ListContainerStats(ctx context.Context, r *runtimeapi.L
 		if err != nil {
 			return nil, err
 		}
-
-		stats = append(stats, containerStats)
+		if containerStats != nil {
+			stats = append(stats, containerStats)
+		}
 	}
 
 	return &runtimeapi.ListContainerStatsResponse{Stats: stats}, nil

--- a/pkg/kubelet/dockershim/docker_stats_windows.go
+++ b/pkg/kubelet/dockershim/docker_stats_windows.go
@@ -35,7 +35,13 @@ func (ds *dockerService) getContainerStats(containerID string) (*runtimeapi.Cont
 
 	hcsshim_container, err := hcsshim.OpenContainer(containerID)
 	if err != nil {
-		return nil, err
+		// As we moved from using Docker stats to hcsshim directly, we may query HCS with already exited container IDs.
+		// That will typically happen with init-containers in Exited state. Docker still knows about them but the HCS does not.
+		// As we don't want to block stats retrieval for other containers, we only log errors.
+		if !hcsshim.IsNotExist(err) && !hcsshim.IsAlreadyStopped(err) {
+			klog.Errorf("Error opening container (stats will be missing) '%s': %v", containerID, err)
+		}
+		return nil, nil
 	}
 	defer func() {
 		closeErr := hcsshim_container.Close()

--- a/test/e2e/windows/kubelet_stats.go
+++ b/test/e2e/windows/kubelet_stats.go
@@ -144,7 +144,17 @@ func newKubeletStatsTestPods(numPods int, image imageutils.Config, nodeName stri
 						},
 					},
 				},
-
+				InitContainers: []v1.Container{
+					{
+						Image: image.GetE2EImage(),
+						Name:  podName,
+						Command: []string{
+							"powershell.exe",
+							"-Command",
+							"sleep -Seconds 1",
+						},
+					},
+				},
 				NodeName: nodeName,
 			},
 		}


### PR DESCRIPTION
Cherry pick of #90554 on release-1.16.

#90554: kubelet: fix `/stats/summary` endpoint on Windows when

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.