### PR TITLE
Automated cherry pick of #90989: count no nodes scheduling failure as unschedulable instead of

### DIFF
--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -592,6 +592,9 @@ func (sched *Scheduler) scheduleOne(ctx context.Context) {
 			// succeeds, the pod should get counted as a success the next time we try to
 			// schedule it. (hopefully)
 			metrics.PodScheduleFailures.Inc()
+		} else if err == core.ErrNoNodesAvailable {
+			// No nodes available is counted as unschedulable rather than an error.
+			metrics.PodScheduleFailures.Inc()
 		} else {
 			klog.Errorf("error selecting node for pod: %v", err)
 			metrics.PodScheduleErrors.Inc()


### PR DESCRIPTION
Cherry pick of #90989 on release-1.18.

#90989: count no nodes scheduling failure as unschedulable instead of

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.