### PR TITLE
Refactor create deployment and add --port flag 

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_cronjob.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_cronjob.go
@@ -80,14 +80,14 @@ func NewCreateCronJobOptions(ioStreams genericclioptions.IOStreams) *CreateCronJ
 func NewCmdCreateCronJob(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *cobra.Command {
 	o := NewCreateCronJobOptions(ioStreams)
 	cmd := &cobra.Command{
-		Use:     "cronjob NAME --image=image --schedule='0/5 * * * ?' -- [COMMAND] [args...]",
-		Aliases: []string{"cj"},
-		Short:   cronjobLong,
-		Long:    cronjobLong,
-		Example: cronjobExample,
+		Use:                   "cronjob NAME --image=image --schedule='0/5 * * * ?' -- [COMMAND] [args...]",
+		DisableFlagsInUseLine: false,
+		Aliases:               []string{"cj"},
+		Short:                 cronjobLong,
+		Long:                  cronjobLong,
+		Example:               cronjobExample,
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdutil.CheckErr(o.Complete(f, cmd, args))
-			cmdutil.CheckErr(o.Validate())
 			cmdutil.CheckErr(o.Run())
 		},
 	}
@@ -98,7 +98,9 @@ func NewCmdCreateCronJob(f cmdutil.Factory, ioStreams genericclioptions.IOStream
 	cmdutil.AddValidateFlags(cmd)
 	cmdutil.AddDryRunFlag(cmd)
 	cmd.Flags().StringVar(&o.Image, "image", o.Image, "Image name to run.")
+	cmd.MarkFlagRequired("image")
 	cmd.Flags().StringVar(&o.Schedule, "schedule", o.Schedule, "A schedule in the Cron format the job should be run with.")
+	cmd.MarkFlagRequired("schedule")
 	cmd.Flags().StringVar(&o.Restart, "restart", o.Restart, "job's restart policy. supported values: OnFailure, Never")
 	cmdutil.AddFieldManagerFlagVar(cmd, &o.FieldManager, "kubectl-create")
 
@@ -158,20 +160,8 @@ func (o *CreateCronJobOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, a
 	return nil
 }
 
-func (o *CreateCronJobOptions) Validate() error {
-	if len(o.Image) == 0 {
-		return fmt.Errorf("--image must be specified")
-	}
-	if len(o.Schedule) == 0 {
-		return fmt.Errorf("--schedule must be specified")
-	}
-	return nil
-}
-
 func (o *CreateCronJobOptions) Run() error {
-	var cronjob *batchv1beta1.CronJob
-	cronjob = o.createCronJob()
-
+	cronjob := o.createCronJob()
 	if o.DryRunStrategy != cmdutil.DryRunClient {
 		createOptions := metav1.CreateOptions{}
 		if o.FieldManager != "" {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_deployment_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_deployment_test.go
@@ -83,7 +83,7 @@ func TestCreateDeploymentNoImage(t *testing.T) {
 	ioStreams := genericclioptions.NewTestIOStreamsDiscard()
 	cmd := NewCmdCreateDeployment(tf, ioStreams)
 	cmd.Flags().Set("output", "name")
-	options := &DeploymentOpts{
+	options := &CreateDeploymentOptions{
 		PrintFlags:     genericclioptions.NewPrintFlags("created").WithTypeSetter(scheme.Scheme),
 		DryRunStrategy: cmdutil.DryRunClient,
 		IOStreams:      ioStreams,

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_job.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_job.go
@@ -85,10 +85,11 @@ func NewCreateJobOptions(ioStreams genericclioptions.IOStreams) *CreateJobOption
 func NewCmdCreateJob(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *cobra.Command {
 	o := NewCreateJobOptions(ioStreams)
 	cmd := &cobra.Command{
-		Use:     "job NAME --image=image [--from=cronjob/name] -- [COMMAND] [args...]",
-		Short:   jobLong,
-		Long:    jobLong,
-		Example: jobExample,
+		Use:                   "job NAME --image=image [--from=cronjob/name] -- [COMMAND] [args...]",
+		DisableFlagsInUseLine: true,
+		Short:                 jobLong,
+		Long:                  jobLong,
+		Example:               jobExample,
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdutil.CheckErr(o.Complete(f, cmd, args))
 			cmdutil.CheckErr(o.Validate())

--- a/test/cmd/apps.sh
+++ b/test/cmd/apps.sh
@@ -197,7 +197,7 @@ run_deployment_tests() {
   kubectl delete deployment test-nginx-extensions "${kube_flags[@]:?}"
 
   # Test kubectl create deployment
-  kubectl create deployment test-nginx-apps --image=k8s.gcr.io/nginx:test-cmd --generator=deployment-basic/apps.v1
+  kubectl create deployment test-nginx-apps --image=k8s.gcr.io/nginx:test-cmd
   # Post-Condition: Deployment "nginx" is created.
   kube::test::get_object_assert 'deploy test-nginx-apps' "{{${container_name_field:?}}}" 'nginx'
   # and new generator was used, iow. new defaults are applied


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
/kind feature

**What this PR does / why we need it**:
This is coming from discussions from https://github.com/kubernetes/kubernetes/pull/87077 to add `--port` flag support for `kubectl create deployment` command.

**Special notes for your reviewer**:
/assign @sallyom @zhouya0 

**Does this PR introduce a user-facing change?**:
```release-note
Add --port flag to kubectl create deployment
```
