### PR TITLE
Instrument the arrival time of the last request for KMS Service.

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/value/encrypt/envelope/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/value/encrypt/envelope/metrics.go
@@ -56,6 +56,17 @@ var (
 		},
 	)
 
+	lastRequestArrivalTime = metrics.NewGaugeVec(
+		&metrics.GaugeOpts{
+			Namespace:      namespace,
+			Subsystem:      subsystem,
+			Name:           "last_request_arrival_time_seconds",
+			Help:           "Last time a request arrived.",
+			StabilityLevel: metrics.ALPHA,
+		},
+		[]string{"transformation_type"},
+	)
+
 	dekCacheInterArrivals = metrics.NewHistogramVec(
 		&metrics.HistogramOpts{
 			Namespace:      namespace,
@@ -75,10 +86,12 @@ func registerMetrics() {
 	registerMetricsFunc.Do(func() {
 		legacyregistry.MustRegister(dekCacheFillPercent)
 		legacyregistry.MustRegister(dekCacheInterArrivals)
+		legacyregistry.MustRegister(lastRequestArrivalTime)
 	})
 }
 
 func recordArrival(transformationType string, start time.Time) {
+	lastRequestArrivalTime.WithLabelValues(transformationType).SetToCurrentTime()
 	switch transformationType {
 	case fromStorageLabel:
 		lockLastFromStorage.Lock()


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Instrument the last arrival time of a request for KMS Service.
This metric will allow to measure the latency between kube-apiserver and kms-plugin (assuming that kms-plugin developers implement a similar metric).
Such a metric would be useful to determine the overhead of over the Unix Domain Socket communications.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

