### PR TITLE
kubelet force node-ip family autodetection

### DIFF
--- a/pkg/kubelet/nodestatus/setters.go
+++ b/pkg/kubelet/nodestatus/setters.go
@@ -194,8 +194,8 @@ func NodeAddress(nodeIP net.IP, // typically Kubelet.nodeIP
 			// 3) Lookup the IP from node name by DNS
 			// 4) Try to get the IP from the network interface used as default gateway
 			//
-			// For steps 3 and 4, IPv4 addresses are preferred to IPv6 addresses
-			// unless nodeIP is "::", in which case it is reversed.
+			// For steps 3 and 4, IPv4 addresses are used unless
+			// nodeIP is "::", in which case IPv6 addresses are used.
 			if nodeIPSpecified {
 				ipAddr = nodeIP
 			} else if addr := net.ParseIP(hostname); addr != nil {
@@ -208,8 +208,6 @@ func NodeAddress(nodeIP net.IP, // typically Kubelet.nodeIP
 						if isPreferredIPFamily(addr) {
 							ipAddr = addr
 							break
-						} else if ipAddr == nil {
-							ipAddr = addr
 						}
 					}
 				}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind api-change

/kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature

/kind flake

**What this PR does / why we need it**:

kubelet uses the unspecified addresses in the node-ip flag
to auto-discover the node address, it tries to resolve first
the hostname DNS address, or obtain the one used in the interface
with the default route.

The unspecified address IP family is being used to discriminate over
one or other IP family, however, if no IP was found in the
preferred IP family, we fall back to the other one.

It may happen in noise environments, that some of the DNS requests
are dropped, if this is the case for the nodeIP hostname, it may
cause that the nodeIP reported changes temporary and uses the wrong
IP family.

Since we added the semantic to the unspecified address to choose one
or other IP family, it makes sense to enforce that choice instead of
falling back the other IP family, avoiding  possible conflicts or
incongruences between the cluster IP family and the nodeIP reported.


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kubelet: the InternalIP reported will match the IP family of the unspecified address used in --node-ip, IPv4 if empty or 0.0.0.0 or IPv6 if ::
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
