### PR TITLE
Remove the dependency between create clusterrolebinding command and generators

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/BUILD
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/BUILD
@@ -86,7 +86,6 @@ go_test(
         "//staging/src/k8s.io/api/batch/v1beta1:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/api/rbac/v1:go_default_library",
-        "//staging/src/k8s.io/api/rbac/v1beta1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/equality:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_clusterrolebinding.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_clusterrolebinding.go
@@ -17,12 +17,21 @@ limitations under the License.
 package create
 
 import (
+	"context"
+	"fmt"
+	"strings"
+
 	"github.com/spf13/cobra"
 
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/resource"
+	rbacclientv1 "k8s.io/client-go/kubernetes/typed/rbac/v1"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
-	"k8s.io/kubectl/pkg/generate"
-	generateversioned "k8s.io/kubectl/pkg/generate/versioned"
+	"k8s.io/kubectl/pkg/scheme"
+	"k8s.io/kubectl/pkg/util"
 	"k8s.io/kubectl/pkg/util/i18n"
 	"k8s.io/kubectl/pkg/util/templates"
 )
@@ -36,16 +45,40 @@ var (
 		  kubectl create clusterrolebinding cluster-admin --clusterrole=cluster-admin --user=user1 --user=user2 --group=group1`))
 )
 
-// ClusterRoleBindingOpts is returned by NewCmdCreateClusterRoleBinding
-type ClusterRoleBindingOpts struct {
-	CreateSubcommandOptions *CreateSubcommandOptions
+// ClusterRoleBindingOptions is returned by NewCmdCreateClusterRoleBinding
+type ClusterRoleBindingOptions struct {
+	PrintFlags *genericclioptions.PrintFlags
+	PrintObj   func(obj runtime.Object) error
+
+	Name             string
+	ClusterRole      string
+	Users            []string
+	Groups           []string
+	ServiceAccounts  []string
+	FieldManager     string
+	CreateAnnotation bool
+
+	Client         rbacclientv1.RbacV1Interface
+	DryRunStrategy cmdutil.DryRunStrategy
+	DryRunVerifier *resource.DryRunVerifier
+
+	genericclioptions.IOStreams
+}
+
+// NewClusterRoleBindingOptions creates a new *ClusterRoleBindingOptions with sane defaults
+func NewClusterRoleBindingOptions(ioStreams genericclioptions.IOStreams) *ClusterRoleBindingOptions {
+	return &ClusterRoleBindingOptions{
+		Users:           []string{},
+		Groups:          []string{},
+		ServiceAccounts: []string{},
+		PrintFlags:      genericclioptions.NewPrintFlags("created").WithTypeSetter(scheme.Scheme),
+		IOStreams:       ioStreams,
+	}
 }
 
 // NewCmdCreateClusterRoleBinding returns an initialized command instance of ClusterRoleBinding
 func NewCmdCreateClusterRoleBinding(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *cobra.Command {
-	o := &ClusterRoleBindingOpts{
-		CreateSubcommandOptions: NewCreateSubcommandOptions(ioStreams),
-	}
+	o := NewClusterRoleBindingOptions(ioStreams)
 
 	cmd := &cobra.Command{
 		Use:                   "clusterrolebinding NAME --clusterrole=NAME [--user=username] [--group=groupname] [--serviceaccount=namespace:serviceaccountname] [--dry-run=server|client|none]",
@@ -59,45 +92,136 @@ func NewCmdCreateClusterRoleBinding(f cmdutil.Factory, ioStreams genericclioptio
 		},
 	}
 
-	o.CreateSubcommandOptions.PrintFlags.AddFlags(cmd)
+	o.PrintFlags.AddFlags(cmd)
 
 	cmdutil.AddApplyAnnotationFlags(cmd)
 	cmdutil.AddValidateFlags(cmd)
-	cmdutil.AddGeneratorFlags(cmd, generateversioned.ClusterRoleBindingV1GeneratorName)
-	cmd.Flags().String("clusterrole", "", i18n.T("ClusterRole this ClusterRoleBinding should reference"))
+	cmdutil.AddDryRunFlag(cmd)
+	cmd.Flags().StringVar(&o.ClusterRole, "clusterrole", "", i18n.T("ClusterRole this ClusterRoleBinding should reference"))
+	cmd.MarkFlagRequired("clusterrole")
 	cmd.MarkFlagCustom("clusterrole", "__kubectl_get_resource_clusterrole")
-	cmd.Flags().StringArray("user", []string{}, "Usernames to bind to the clusterrole")
-	cmd.Flags().StringArray("group", []string{}, "Groups to bind to the clusterrole")
-	cmd.Flags().StringArray("serviceaccount", []string{}, "Service accounts to bind to the clusterrole, in the format <namespace>:<name>")
-	cmdutil.AddFieldManagerFlagVar(cmd, &o.CreateSubcommandOptions.FieldManager, "kubectl-create")
+	cmd.Flags().StringArrayVar(&o.Users, "user", o.Users, "Usernames to bind to the clusterrole")
+	cmd.Flags().StringArrayVar(&o.Groups, "group", o.Groups, "Groups to bind to the clusterrole")
+	cmd.Flags().StringArrayVar(&o.ServiceAccounts, "serviceaccount", o.ServiceAccounts, "Service accounts to bind to the clusterrole, in the format <namespace>:<name>")
+	cmdutil.AddFieldManagerFlagVar(cmd, &o.FieldManager, "kubectl-create")
 	return cmd
 }
 
 // Complete completes all the required options
-func (o *ClusterRoleBindingOpts) Complete(f cmdutil.Factory, cmd *cobra.Command, args []string) error {
-	name, err := NameFromCommandArgs(cmd, args)
+func (o *ClusterRoleBindingOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []string) error {
+	var err error
+	o.Name, err = NameFromCommandArgs(cmd, args)
 	if err != nil {
 		return err
 	}
 
-	var generator generate.StructuredGenerator
-	switch generatorName := cmdutil.GetFlagString(cmd, "generator"); generatorName {
-	case generateversioned.ClusterRoleBindingV1GeneratorName:
-		generator = &generateversioned.ClusterRoleBindingGeneratorV1{
-			Name:            name,
-			ClusterRole:     cmdutil.GetFlagString(cmd, "clusterrole"),
-			Users:           cmdutil.GetFlagStringArray(cmd, "user"),
-			Groups:          cmdutil.GetFlagStringArray(cmd, "group"),
-			ServiceAccounts: cmdutil.GetFlagStringArray(cmd, "serviceaccount"),
-		}
-	default:
-		return errUnsupportedGenerator(cmd, generatorName)
+	cs, err := f.KubernetesClientSet()
+	if err != nil {
+		return err
+	}
+	o.Client = cs.RbacV1()
+
+	o.CreateAnnotation = cmdutil.GetFlagBool(cmd, cmdutil.ApplyAnnotationsFlag)
+
+	o.DryRunStrategy, err = cmdutil.GetDryRunStrategy(cmd)
+	if err != nil {
+		return err
+	}
+	dynamicClient, err := f.DynamicClient()
+	if err != nil {
+		return err
+	}
+	discoveryClient, err := f.ToDiscoveryClient()
+	if err != nil {
+		return err
+	}
+	o.DryRunVerifier = resource.NewDryRunVerifier(dynamicClient, discoveryClient)
+	cmdutil.PrintFlagsWithDryRunStrategy(o.PrintFlags, o.DryRunStrategy)
+
+	printer, err := o.PrintFlags.ToPrinter()
+	if err != nil {
+		return err
+	}
+	o.PrintObj = func(obj runtime.Object) error {
+		return printer.PrintObj(obj, o.Out)
 	}
 
-	return o.CreateSubcommandOptions.Complete(f, cmd, args, generator)
+	return nil
 }
 
-// Run calls the CreateSubcommandOptions.Run in ClusterRoleBindingOpts instance
-func (o *ClusterRoleBindingOpts) Run() error {
-	return o.CreateSubcommandOptions.Run()
+// Run calls the CreateSubcommandOptions.Run in ClusterRoleBindingOptions instance
+func (o *ClusterRoleBindingOptions) Run() error {
+	clusterRoleBinding, err := o.createClusterRoleBinding()
+	if err != nil {
+		return err
+	}
+
+	if err := util.CreateOrUpdateAnnotation(o.CreateAnnotation, clusterRoleBinding, scheme.DefaultJSONEncoder()); err != nil {
+		return err
+	}
+
+	if o.DryRunStrategy != cmdutil.DryRunClient {
+		createOptions := metav1.CreateOptions{}
+		if o.FieldManager != "" {
+			createOptions.FieldManager = o.FieldManager
+		}
+		if o.DryRunStrategy == cmdutil.DryRunServer {
+			if err := o.DryRunVerifier.HasSupport(clusterRoleBinding.GroupVersionKind()); err != nil {
+				return err
+			}
+			createOptions.DryRun = []string{metav1.DryRunAll}
+		}
+		var err error
+		clusterRoleBinding, err = o.Client.ClusterRoleBindings().Create(context.TODO(), clusterRoleBinding, createOptions)
+		if err != nil {
+			return fmt.Errorf("failed to create clusterrolebinding: %v", err)
+		}
+	}
+
+	return o.PrintObj(clusterRoleBinding)
+}
+
+func (o *ClusterRoleBindingOptions) createClusterRoleBinding() (*rbacv1.ClusterRoleBinding, error) {
+	clusterRoleBinding := &rbacv1.ClusterRoleBinding{
+		TypeMeta: metav1.TypeMeta{APIVersion: rbacv1.SchemeGroupVersion.String(), Kind: "ClusterRoleBinding"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: o.Name,
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: rbacv1.GroupName,
+			Kind:     "ClusterRole",
+			Name:     o.ClusterRole,
+		},
+	}
+
+	for _, user := range o.Users {
+		clusterRoleBinding.Subjects = append(clusterRoleBinding.Subjects, rbacv1.Subject{
+			Kind:     rbacv1.UserKind,
+			APIGroup: rbacv1.GroupName,
+			Name:     user,
+		})
+	}
+
+	for _, group := range o.Groups {
+		clusterRoleBinding.Subjects = append(clusterRoleBinding.Subjects, rbacv1.Subject{
+			Kind:     rbacv1.GroupKind,
+			APIGroup: rbacv1.GroupName,
+			Name:     group,
+		})
+	}
+
+	for _, sa := range o.ServiceAccounts {
+		tokens := strings.Split(sa, ":")
+		if len(tokens) != 2 || tokens[0] == "" || tokens[1] == "" {
+			return nil, fmt.Errorf("serviceaccount must be <namespace>:<name>")
+		}
+		clusterRoleBinding.Subjects = append(clusterRoleBinding.Subjects, rbacv1.Subject{
+			Kind:      rbacv1.ServiceAccountKind,
+			APIGroup:  "",
+			Namespace: tokens[0],
+			Name:      tokens[1],
+		})
+	}
+
+	return clusterRoleBinding, nil
 }

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_clusterrolebinding_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_clusterrolebinding_test.go
@@ -17,117 +17,71 @@ limitations under the License.
 package create
 
 import (
-	"bytes"
-	"io/ioutil"
-	"net/http"
-	"reflect"
 	"testing"
 
-	rbac "k8s.io/api/rbac/v1beta1"
+	rbac "k8s.io/api/rbac/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/cli-runtime/pkg/genericclioptions"
-	restclient "k8s.io/client-go/rest"
-	"k8s.io/client-go/rest/fake"
-	cmdtesting "k8s.io/kubectl/pkg/cmd/testing"
-	"k8s.io/kubectl/pkg/scheme"
 )
 
 func TestCreateClusterRoleBinding(t *testing.T) {
-	expectBinding := &rbac.ClusterRoleBinding{
-		ObjectMeta: v1.ObjectMeta{
-			Name: "fake-binding",
-		},
-		TypeMeta: v1.TypeMeta{
-			Kind:       "ClusterRoleBinding",
-			APIVersion: "rbac.authorization.k8s.io/v1beta1",
-		},
-		RoleRef: rbac.RoleRef{
-			APIGroup: rbac.GroupName,
-			Kind:     "ClusterRole",
-			Name:     "fake-clusterrole",
-		},
-		Subjects: []rbac.Subject{
-			{
-				Kind:     rbac.UserKind,
-				APIGroup: "rbac.authorization.k8s.io",
-				Name:     "fake-user",
+	tests := []struct {
+		options  *ClusterRoleBindingOptions
+		expected *rbac.ClusterRoleBinding
+	}{
+		{
+			options: &ClusterRoleBindingOptions{
+				ClusterRole:     "fake-clusterrole",
+				Users:           []string{"fake-user"},
+				Groups:          []string{"fake-group"},
+				ServiceAccounts: []string{"fake-namespace:fake-account"},
+				Name:            "fake-binding",
 			},
-			{
-				Kind:     rbac.GroupKind,
-				APIGroup: "rbac.authorization.k8s.io",
-				Name:     "fake-group",
-			},
-			{
-				Kind:      rbac.ServiceAccountKind,
-				Namespace: "fake-namespace",
-				Name:      "fake-account",
+			expected: &rbac.ClusterRoleBinding{
+				TypeMeta: v1.TypeMeta{
+					Kind:       "ClusterRoleBinding",
+					APIVersion: "rbac.authorization.k8s.io/v1",
+				},
+				ObjectMeta: v1.ObjectMeta{
+					Name: "fake-binding",
+				},
+				RoleRef: rbac.RoleRef{
+					APIGroup: rbac.GroupName,
+					Kind:     "ClusterRole",
+					Name:     "fake-clusterrole",
+				},
+				Subjects: []rbac.Subject{
+					{
+						Kind:     rbac.UserKind,
+						APIGroup: "rbac.authorization.k8s.io",
+						Name:     "fake-user",
+					},
+					{
+						Kind:     rbac.GroupKind,
+						APIGroup: "rbac.authorization.k8s.io",
+						Name:     "fake-group",
+					},
+					{
+						Kind:      rbac.ServiceAccountKind,
+						Namespace: "fake-namespace",
+						Name:      "fake-account",
+					},
+				},
 			},
 		},
 	}
 
-	tf := cmdtesting.NewTestFactory().WithNamespace("test")
-	defer tf.Cleanup()
-
-	ns := scheme.Codecs.WithoutConversion()
-
-	info, _ := runtime.SerializerInfoForMediaType(ns.SupportedMediaTypes(), runtime.ContentTypeJSON)
-	encoder := ns.EncoderForVersion(info.Serializer, groupVersion)
-	decoder := ns.DecoderToVersion(info.Serializer, groupVersion)
-
-	tf.Client = &ClusterRoleBindingRESTClient{
-		RESTClient: &fake.RESTClient{
-			GroupVersion:         schema.GroupVersion{Group: "rbac.authorization.k8s.io", Version: "v1beta1"},
-			NegotiatedSerializer: ns,
-			Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
-				switch p, m := req.URL.Path, req.Method; {
-				case p == "/clusterrolebindings" && m == "POST":
-					bodyBits, err := ioutil.ReadAll(req.Body)
-					if err != nil {
-						t.Fatalf("TestCreateClusterRoleBinding error: %v", err)
-						return nil, nil
-					}
-
-					if obj, _, err := decoder.Decode(bodyBits, nil, &rbac.ClusterRoleBinding{}); err == nil {
-						if !reflect.DeepEqual(obj.(*rbac.ClusterRoleBinding), expectBinding) {
-							t.Fatalf("TestCreateClusterRoleBinding: expected:\n%#v\nsaw:\n%#v", expectBinding, obj.(*rbac.ClusterRoleBinding))
-							return nil, nil
-						}
-					} else {
-						t.Fatalf("TestCreateClusterRoleBinding error, could not decode the request body into rbac.ClusterRoleBinding object: %v", err)
-						return nil, nil
-					}
-
-					responseBinding := &rbac.ClusterRoleBinding{}
-					responseBinding.Name = "fake-binding"
-					return &http.Response{StatusCode: http.StatusCreated, Header: cmdtesting.DefaultHeader(), Body: ioutil.NopCloser(bytes.NewReader([]byte(runtime.EncodeOrDie(encoder, responseBinding))))}, nil
-				default:
-					t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
-					return nil, nil
-				}
-			}),
-		},
+	for i, tc := range tests {
+		t.Run(string(i), func(t *testing.T) {
+			clusterRoleBinding, err := tc.options.createClusterRoleBinding()
+			if err != nil {
+				t.Errorf("unexpected error:\n%#v\n", err)
+				return
+			}
+			if !apiequality.Semantic.DeepEqual(clusterRoleBinding, tc.expected) {
+				t.Errorf("expected:\n%#v\ngot:\n%#v", tc.expected, clusterRoleBinding)
+			}
+		})
 	}
 
-	expectedOutput := "clusterrolebinding.rbac.authorization.k8s.io/" + expectBinding.Name + "\n"
-	ioStreams, _, buf, _ := genericclioptions.NewTestIOStreams()
-	cmd := NewCmdCreateClusterRoleBinding(tf, ioStreams)
-	cmd.Flags().Set("clusterrole", "fake-clusterrole")
-	cmd.Flags().Set("user", "fake-user")
-	cmd.Flags().Set("group", "fake-group")
-	cmd.Flags().Set("output", "name")
-	cmd.Flags().Set("serviceaccount", "fake-namespace:fake-account")
-	cmd.Run(cmd, []string{"fake-binding"})
-	if buf.String() != expectedOutput {
-		t.Errorf("TestCreateClusterRoleBinding: expected %v\n but got %v\n", expectedOutput, buf.String())
-	}
-}
-
-type ClusterRoleBindingRESTClient struct {
-	*fake.RESTClient
-}
-
-func (c *ClusterRoleBindingRESTClient) Post() *restclient.Request {
-	return c.RESTClient.Verb("POST")
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Pursuing the work started in https://github.com/kubernetes/kubernetes/pull/90676, by removing the generators dependency from the `kubectl create clusterrolebinding` command.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

1) I had to use `dynamic.Interface` instead of `rbacv1client.RbacV1Interface` in order to not break the unit tests. The result is a bit more verbose, let me know what you think.

2) I switched from `cmd.Flags().StringArray()` to `cmd.Flags().StringSlice()` for the `user`, `serviceaccount` and `group` flags. As a result, providing a value with commas will produce multiple subjects instead of a single one with commas in the name. I figured this was a bug, but let me know if you want me to rollback that change.
