### PR TITLE
kubernetes modify statefulset controller, make code clear

### DIFF
--- a/pkg/controller/statefulset/stateful_set_control.go
+++ b/pkg/controller/statefulset/stateful_set_control.go
@@ -224,17 +224,19 @@ func (ssc *defaultStatefulSetControl) getStatefulSetRevisions(
 	equalRevisions := history.FindEqualRevisions(revisions, updateRevision)
 	equalCount := len(equalRevisions)
 
-	if equalCount > 0 && history.EqualRevision(revisions[revisionCount-1], equalRevisions[equalCount-1]) {
+	if equalCount > 0 {
 		// if the equivalent revision is immediately prior the update revision has not changed
-		updateRevision = revisions[revisionCount-1]
-	} else if equalCount > 0 {
-		// if the equivalent revision is not immediately prior we will roll back by incrementing the
-		// Revision of the equivalent revision
-		updateRevision, err = ssc.controllerHistory.UpdateControllerRevision(
-			equalRevisions[equalCount-1],
-			updateRevision.Revision)
-		if err != nil {
-			return nil, nil, collisionCount, err
+		if history.EqualRevision(revisions[revisionCount-1], equalRevisions[equalCount-1]) {
+			updateRevision = revisions[revisionCount-1]
+		} else {
+			// if the equivalent revision is not immediately prior we will roll back by incrementing the
+			// Revision of the equivalent revision
+			updateRevision, err = ssc.controllerHistory.UpdateControllerRevision(
+				equalRevisions[equalCount-1],
+				updateRevision.Revision)
+			if err != nil {
+				return nil, nil, collisionCount, err
+			}
 		}
 	} else {
 		//if there is no equivalent revision we create a new one


### PR DESCRIPTION

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
> /kind cleanup


**What this PR does / why we need it**:
kubernetes modify statefulset controller, make code clear, kubernetes modify statefulset controller, make code clear.

