### PR TITLE
Define the thresholds per the size of container images

### DIFF
--- a/pkg/scheduler/framework/plugins/imagelocality/image_locality_test.go
+++ b/pkg/scheduler/framework/plugins/imagelocality/image_locality_test.go
@@ -59,7 +59,7 @@ func TestImageLocalityPriority(t *testing.T) {
 				Image: "gcr.io/10",
 			},
 			{
-				Image: "gcr.io/2000",
+				Image: "gcr.io/4000",
 			},
 		},
 	}
@@ -74,6 +74,17 @@ func TestImageLocalityPriority(t *testing.T) {
 			},
 			{
 				Image: "gcr.io/900",
+			},
+		},
+	}
+
+	test3040 := v1.PodSpec{
+		Containers: []v1.Container{
+			{
+				Image: "gcr.io/30",
+			},
+			{
+				Image: "gcr.io/40",
 			},
 		},
 	}
@@ -126,19 +137,19 @@ func TestImageLocalityPriority(t *testing.T) {
 		Images: []v1.ContainerImage{
 			{
 				Names: []string{
-					"gcr.io/600:" + parsers.DefaultImageTag,
+					"gcr.io/600:latest",
 				},
 				SizeBytes: int64(600 * mb),
 			},
 			{
 				Names: []string{
-					"gcr.io/40:" + parsers.DefaultImageTag,
+					"gcr.io/40:latest",
 				},
 				SizeBytes: int64(40 * mb),
 			},
 			{
 				Names: []string{
-					"gcr.io/900:" + parsers.DefaultImageTag,
+					"gcr.io/900:latest",
 				},
 				SizeBytes: int64(900 * mb),
 			},
@@ -149,21 +160,61 @@ func TestImageLocalityPriority(t *testing.T) {
 		Images: []v1.ContainerImage{
 			{
 				Names: []string{
-					"gcr.io/300:" + parsers.DefaultImageTag,
+					"gcr.io/300:latest",
 				},
 				SizeBytes: int64(300 * mb),
 			},
 			{
 				Names: []string{
-					"gcr.io/600:" + parsers.DefaultImageTag,
+					"gcr.io/600:latest",
 				},
 				SizeBytes: int64(600 * mb),
 			},
 			{
 				Names: []string{
-					"gcr.io/900:" + parsers.DefaultImageTag,
+					"gcr.io/900:latest",
 				},
 				SizeBytes: int64(900 * mb),
+			},
+		},
+	}
+
+	node400030 := v1.NodeStatus{
+		Images: []v1.ContainerImage{
+			{
+				Names: []string{
+					"gcr.io/4000:latest",
+				},
+				SizeBytes: int64(4000 * mb),
+			},
+			{
+				Names: []string{
+					"gcr.io/30:latest",
+				},
+				SizeBytes: int64(30 * mb),
+			},
+		},
+	}
+
+	node203040 := v1.NodeStatus{
+		Images: []v1.ContainerImage{
+			{
+				Names: []string{
+					"gcr.io/20:latest",
+				},
+				SizeBytes: int64(20 * mb),
+			},
+			{
+				Names: []string{
+					"gcr.io/30:latest",
+				},
+				SizeBytes: int64(30 * mb),
+			},
+			{
+				Names: []string{
+					"gcr.io/40:latest",
+				},
+				SizeBytes: int64(40 * mb),
 			},
 		},
 	}
@@ -186,10 +237,10 @@ func TestImageLocalityPriority(t *testing.T) {
 
 			// Node2
 			// Image: gcr.io/250:latest 250MB
-			// Score: 100 * (250M/2 - 23M)/(1000M - 23M) = 100
+			// Score: 100 * (250M/2 - 23M)/(1000M * 2 - 23M) = 5
 			pod:          &v1.Pod{Spec: test40250},
 			nodes:        []*v1.Node{makeImageNode("machine1", node403002000), makeImageNode("machine2", node25010)},
-			expectedList: []framework.NodeScore{{Name: "machine1", Score: 0}, {Name: "machine2", Score: 10}},
+			expectedList: []framework.NodeScore{{Name: "machine1", Score: 0}, {Name: "machine2", Score: 5}},
 			name:         "two images spread on two nodes, prefer the larger image one",
 		},
 		{
@@ -197,48 +248,48 @@ func TestImageLocalityPriority(t *testing.T) {
 
 			// Node1
 			// Image: gcr.io/40:latest 40MB, gcr.io/300:latest 300MB
-			// Score: 100 * ((40M + 300M)/2 - 23M)/(1000M - 23M) = 15
+			// Score: 100 * ((40M + 300M)/2 - 23M)/(1000M * 2 - 23M) = 7
 
 			// Node2
 			// Image: not present
 			// Score: 0
 			pod:          &v1.Pod{Spec: test40300},
 			nodes:        []*v1.Node{makeImageNode("machine1", node403002000), makeImageNode("machine2", node25010)},
-			expectedList: []framework.NodeScore{{Name: "machine1", Score: 15}, {Name: "machine2", Score: 0}},
+			expectedList: []framework.NodeScore{{Name: "machine1", Score: 7}, {Name: "machine2", Score: 0}},
 			name:         "two images on one node, prefer this node",
 		},
 		{
-			// Pod: gcr.io/2000 gcr.io/10
+			// Pod: gcr.io/4000 gcr.io/10
 
 			// Node1
-			// Image: gcr.io/2000:latest 2000MB
-			// Score: 100 (2000M/2 >= 1000M, max-threshold)
+			// Image: gcr.io/4000:latest 2000MB
+			// Score: 100 (4000 * 1/2 >= 1000M * 2, max-threshold)
 
 			// Node2
 			// Image: gcr.io/10:latest 10MB
 			// Score: 0 (10M/2 < 23M, min-threshold)
 			pod:          &v1.Pod{Spec: testMinMax},
-			nodes:        []*v1.Node{makeImageNode("machine1", node403002000), makeImageNode("machine2", node25010)},
+			nodes:        []*v1.Node{makeImageNode("machine1", node400030), makeImageNode("machine2", node25010)},
 			expectedList: []framework.NodeScore{{Name: "machine1", Score: framework.MaxNodeScore}, {Name: "machine2", Score: 0}},
 			name:         "if exceed limit, use limit",
 		},
 		{
-			// Pod: gcr.io/2000 gcr.io/10
+			// Pod: gcr.io/4000 gcr.io/10
 
 			// Node1
-			// Image: gcr.io/2000:latest 2000MB
-			// Score: 100 * (2000M/3 - 23M)/(1000M - 23M) = 65
+			// Image: gcr.io/4000:latest 4000MB
+			// Score: 100 * (4000M/3 - 23M)/(1000M * 2 - 23M) = 66
 
 			// Node2
 			// Image: gcr.io/10:latest 10MB
-			// Score: 0 (10M/2 < 23M, min-threshold)
+			// Score: 0 (10M*1/3 < 23M, min-threshold)
 
 			// Node3
 			// Image:
 			// Score: 0
 			pod:          &v1.Pod{Spec: testMinMax},
-			nodes:        []*v1.Node{makeImageNode("machine1", node403002000), makeImageNode("machine2", node25010), makeImageNode("machine3", nodeWithNoImages)},
-			expectedList: []framework.NodeScore{{Name: "machine1", Score: 65}, {Name: "machine2", Score: 0}, {Name: "machine3", Score: 0}},
+			nodes:        []*v1.Node{makeImageNode("machine1", node400030), makeImageNode("machine2", node25010), makeImageNode("machine3", nodeWithNoImages)},
+			expectedList: []framework.NodeScore{{Name: "machine1", Score: 66}, {Name: "machine2", Score: 0}, {Name: "machine3", Score: 0}},
 			name:         "if exceed limit, use limit (with node which has no images present)",
 		},
 		{
@@ -246,19 +297,34 @@ func TestImageLocalityPriority(t *testing.T) {
 
 			// Node1
 			// Image: gcr.io/600:latest 600MB, gcr.io/900:latest 900MB
-			// Score: 100 (600M * 2/3 + 900M * 2/3 = 1000M >= 1000M, max-threshold)
+			// Score: 100 * (600M * 2/3 + 900M * 2/3 - 23M) / (1000M * 3 - 23M) = 32
 
 			// Node2
 			// Image: gcr.io/300:latest 300MB, gcr.io/600:latest 600MB, gcr.io/900:latest 900MB
-			// Score: 100 (300M * 1/3 + 600M * 2/3 + 900M * 2/3) >= 1000M, max-threshold)
+			// Score: 100 * (300M * 1/3 + 600M * 2/3 + 900M * 2/3 - 23M) / (1000M *3 - 23M) = 36
 
 			// Node3
 			// Image:
 			// Score: 0
 			pod:          &v1.Pod{Spec: test300600900},
 			nodes:        []*v1.Node{makeImageNode("machine1", node60040900), makeImageNode("machine2", node300600900), makeImageNode("machine3", nodeWithNoImages)},
-			expectedList: []framework.NodeScore{{Name: "machine1", Score: 100}, {Name: "machine2", Score: 100}, {Name: "machine3", Score: 0}},
-			name:         "max threshold haven't considered the size of containers to be run for the pod",
+			expectedList: []framework.NodeScore{{Name: "machine1", Score: 32}, {Name: "machine2", Score: 36}, {Name: "machine3", Score: 0}},
+			name:         "pod with multiple large images, machine2 is preferred",
+		},
+		{
+			// Pod: gcr.io/30 gcr.io/40
+
+			// Node1
+			// Image: gcr.io/20:latest 20MB, gcr.io/30:latest 30MB gcr.io/40:latest 40MB
+			// Score: 100 * (30M + 40M * 1/2 - 23M) / (1000M * 2 - 23M) = 1
+
+			// Node2
+			// Image: 100 * (30M - 23M) / (1000M * 2 - 23M) = 0
+			// Score: 0
+			pod:          &v1.Pod{Spec: test3040},
+			nodes:        []*v1.Node{makeImageNode("machine1", node203040), makeImageNode("machine2", node400030)},
+			expectedList: []framework.NodeScore{{Name: "machine1", Score: 1}, {Name: "machine2", Score: 0}},
+			name:         "pod with multiple small images",
 		},
 	}
 


### PR DESCRIPTION
Given the assumption that 90%ile of images on dockerhub drops into this range (23~1000)MB,
this assumption is based on the container images instead of the pod.

pod might hold multiple container images, it's better to multiply the assumption by the size
of container images.

Please see the first commit https://github.com/kubernetes/kubernetes/pull/91138/commits/aa363a7562328c42b06a33d9582603b786581445 for how the issue impacts the final score.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
/kind feature


**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubernetes/issues/91204

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
`maxThreshold` of `ImageLocality` plugin is now scaled by the number of images in the pod, which helps to distinguish the node priorities for pod with several images.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
