### PR TITLE
kube-aggregator: Fix goroutine leak

### DIFF
--- a/staging/src/k8s.io/kube-aggregator/pkg/controllers/status/available_controller.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/controllers/status/available_controller.go
@@ -287,7 +287,7 @@ func (c *AvailableConditionController) sync(key string) error {
 				}
 				discoveryURL.Path = "/apis/" + apiService.Spec.Group + "/" + apiService.Spec.Version
 
-				errCh := make(chan error)
+				errCh := make(chan error, 1)
 				go func() {
 					// be sure to check a URL that the aggregated API server is required to serve
 					newReq, err := http.NewRequest("GET", discoveryURL.String(), nil)
@@ -321,13 +321,6 @@ func (c *AvailableConditionController) sync(key string) error {
 					// we had trouble with slow dial and DNS responses causing us to wait too long.
 					// we added this as insurance
 				case <-time.After(6 * time.Second):
-					// errCh needs to have a reader since the above goroutine doing the work 
-					// needs to send to it. 
-					go func() {
-						if res := <-errch; res != nil {
-							fmt.Errorf("timed out response from %v: %v", discoveryURL, res)
-						}
-					}()
 					results <- fmt.Errorf("timed out waiting for %v", discoveryURL)
 					return
 				}

--- a/staging/src/k8s.io/kube-aggregator/pkg/controllers/status/available_controller.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/controllers/status/available_controller.go
@@ -321,6 +321,17 @@ func (c *AvailableConditionController) sync(key string) error {
 					// we had trouble with slow dial and DNS responses causing us to wait too long.
 					// we added this as insurance
 				case <-time.After(6 * time.Second):
+        			defer func() {
+            			// errCh needs to have a reader since the above goroutine doing the work 
+            			// needs to send to it. This is defered to ensure it runs
+            			// even if the post timeout work itself panics.
+            			go func() {
+                			res := <-errch
+                			if res != nil {
+                    			fmt.Error("%v", res)
+                			}	   
+            			}() 
+        			}() 
 					results <- fmt.Errorf("timed out waiting for %v", discoveryURL)
 					return
 				}

--- a/staging/src/k8s.io/kube-aggregator/pkg/controllers/status/available_controller.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/controllers/status/available_controller.go
@@ -321,17 +321,13 @@ func (c *AvailableConditionController) sync(key string) error {
 					// we had trouble with slow dial and DNS responses causing us to wait too long.
 					// we added this as insurance
 				case <-time.After(6 * time.Second):
-        			defer func() {
-            			// errCh needs to have a reader since the above goroutine doing the work 
-            			// needs to send to it. This is defered to ensure it runs
-            			// even if the post timeout work itself panics.
-            			go func() {
-                			res := <-errch
-                			if res != nil {
-                    			fmt.Error("%v", res)
-                			}	   
-            			}() 
-        			}() 
+					// errCh needs to have a reader since the above goroutine doing the work 
+					// needs to send to it. 
+					go func() {
+						if res := <-errch; res != nil {
+							fmt.Errorf("timed out response from %v: %v", discoveryURL, res)
+						}
+					}()
 					results <- fmt.Errorf("timed out waiting for %v", discoveryURL)
 					return
 				}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind api-change
/kind bug
/kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Fixes a goroutine leak. Explanation: errCh needs to have a reader since the goroutine doing the work needs to send to it. A simple fix is to add buffer to the errCh.
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
N/A
**Special notes for your reviewer**:
Tested using a demo program: https://play.golang.com/p/4CzvVdwPMUn
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
