### PR TITLE
Add IPv6 family compatibility for the e2e tests

### DIFF
--- a/test/e2e/network/no_snat.go
+++ b/test/e2e/network/no_snat.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
+	"net"
 	"net/http"
 	"strconv"
 	"strings"
@@ -217,7 +218,7 @@ var _ = SIGDescribe("NoSNAT [Feature:NoSNAT] [Slow]", func() {
 		// collect pod IPs
 		podIPs := []string{}
 		for _, pod := range pods.Items {
-			podIPs = append(podIPs, pod.Status.PodIP+":"+strconv.Itoa(testPodPort))
+			podIPs = append(podIPs, net.JoinHostPort(pod.Status.PodIP, strconv.Itoa(testPodPort)))
 		}
 
 		// hit the /checknosnat endpoint on each Pod, tell each Pod to check all the other Pods

--- a/test/e2e/storage/empty_dir_wrapper.go
+++ b/test/e2e/storage/empty_dir_wrapper.go
@@ -19,6 +19,7 @@ package storage
 import (
 	"context"
 	"fmt"
+	"net"
 	"strconv"
 
 	v1 "k8s.io/api/core/v1"
@@ -258,7 +259,7 @@ func createGitServer(f *framework.Framework) (gitURL string, gitRepo string, cle
 		framework.Failf("unable to create test git server service %s: %v", gitServerSvc.Name, err)
 	}
 
-	return "http://" + gitServerSvc.Spec.ClusterIP + ":" + strconv.Itoa(httpPort), "test", func() {
+	return "http://" + net.JoinHostPort(gitServerSvc.Spec.ClusterIP, strconv.Itoa(httpPort)), "test", func() {
 		ginkgo.By("Cleaning up the git server pod")
 		if err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Delete(context.TODO(), gitServerPod.Name, *metav1.NewDeleteOptions(0)); err != nil {
 			framework.Failf("unable to delete git server pod %v: %v", gitServerPod.Name, err)

--- a/test/e2e/upgrades/cassandra.go
+++ b/test/e2e/upgrades/cassandra.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"net"
 	"net/http"
 	"path/filepath"
 	"sync"
@@ -112,7 +113,7 @@ func (t *CassandraUpgradeTest) Setup(f *framework.Framework) {
 
 // listUsers gets a list of users from the db via the tester service.
 func (t *CassandraUpgradeTest) listUsers() ([]string, error) {
-	r, err := http.Get(fmt.Sprintf("http://%s:8080/list", t.ip))
+	r, err := http.Get(fmt.Sprintf("http://%s/list", net.JoinHostPort(t.ip, "8080")))
 	if err != nil {
 		return nil, err
 	}
@@ -134,7 +135,7 @@ func (t *CassandraUpgradeTest) listUsers() ([]string, error) {
 // addUser adds a user to the db via the tester services.
 func (t *CassandraUpgradeTest) addUser(name string) error {
 	val := map[string][]string{"name": {name}}
-	r, err := http.PostForm(fmt.Sprintf("http://%s:8080/add", t.ip), val)
+	r, err := http.PostForm(fmt.Sprintf("http://%s/add", net.JoinHostPort(t.ip, "8080")), val)
 	if err != nil {
 		return err
 	}

--- a/test/e2e/upgrades/etcd.go
+++ b/test/e2e/upgrades/etcd.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"net"
 	"net/http"
 	"path/filepath"
 	"sync"
@@ -106,7 +107,7 @@ func (t *EtcdUpgradeTest) Setup(f *framework.Framework) {
 }
 
 func (t *EtcdUpgradeTest) listUsers() ([]string, error) {
-	r, err := http.Get(fmt.Sprintf("http://%s:8080/list", t.ip))
+	r, err := http.Get(fmt.Sprintf("http://%s/list", net.JoinHostPort(t.ip, "8080")))
 	if err != nil {
 		return nil, err
 	}
@@ -127,7 +128,7 @@ func (t *EtcdUpgradeTest) listUsers() ([]string, error) {
 
 func (t *EtcdUpgradeTest) addUser(name string) error {
 	val := map[string][]string{"name": {name}}
-	r, err := http.PostForm(fmt.Sprintf("http://%s:8080/add", t.ip), val)
+	r, err := http.PostForm(fmt.Sprintf("http://%s/add", net.JoinHostPort(t.ip, "8080")), val)
 	if err != nil {
 		return err
 	}

--- a/test/e2e/upgrades/mysql.go
+++ b/test/e2e/upgrades/mysql.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"net"
 	"net/http"
 	"path/filepath"
 	"strconv"
@@ -175,7 +176,7 @@ func (t *MySQLUpgradeTest) Teardown(f *framework.Framework) {
 func (t *MySQLUpgradeTest) addName(name string) error {
 	val := map[string][]string{"name": {name}}
 	t.nextWrite++
-	r, err := http.PostForm(fmt.Sprintf("http://%s:8080/addName", t.ip), val)
+	r, err := http.PostForm(fmt.Sprintf("http://%s/addName", net.JoinHostPort(t.ip, "8080")), val)
 	if err != nil {
 		return err
 	}
@@ -193,7 +194,7 @@ func (t *MySQLUpgradeTest) addName(name string) error {
 // countNames checks to make sure the values in testing.users are available, and returns
 // the count of them.
 func (t *MySQLUpgradeTest) countNames() (int, error) {
-	r, err := http.Get(fmt.Sprintf("http://%s:8080/countNames", t.ip))
+	r, err := http.Get(fmt.Sprintf("http://%s/countNames", net.JoinHostPort(t.ip, "8080")))
 	if err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

> /kind failing-test


**What this PR does / why we need it**:

IPv6 family should be supported when we are combining Host and Port.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
