### PR TITLE
Fix golint error for pkg/kubelet/types

### DIFF
--- a/hack/.golint_failures
+++ b/hack/.golint_failures
@@ -116,7 +116,6 @@ pkg/kubelet/preemption
 pkg/kubelet/remote
 pkg/kubelet/stats
 pkg/kubelet/sysctl
-pkg/kubelet/types
 pkg/kubemark
 pkg/master/controller/crdregistration
 pkg/master/tunneler

--- a/pkg/kubelet/types/constants.go
+++ b/pkg/kubelet/types/constants.go
@@ -17,14 +17,17 @@ limitations under the License.
 package types
 
 const (
-	// system default DNS resolver configuration
+	// ResolvConfDefault defines a system default DNS resolver configuration
 	ResolvConfDefault = "/etc/resolv.conf"
 
-	// different container runtimes
+	// DockerContainerRuntime defines a docker container runtime
 	DockerContainerRuntime = "docker"
+	// RemoteContainerRuntime defines a remote container runtime
 	RemoteContainerRuntime = "remote"
+)
 
-	// User visible keys for managing node allocatable enforcement on the node.
+// User visible keys for managing node allocatable enforcement on the node.
+const (
 	NodeAllocatableEnforcementKey = "pods"
 	SystemReservedEnforcementKey  = "system-reserved"
 	KubeReservedEnforcementKey    = "kube-reserved"

--- a/pkg/kubelet/types/doc.go
+++ b/pkg/kubelet/types/doc.go
@@ -14,5 +14,5 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Common types in the Kubelet.
+// Package types contains common types of the Kubelet.
 package types // import "k8s.io/kubernetes/pkg/kubelet/types"

--- a/pkg/kubelet/types/labels.go
+++ b/pkg/kubelet/types/labels.go
@@ -17,24 +17,32 @@ limitations under the License.
 package types
 
 const (
-	KubernetesPodNameLabel       = "io.kubernetes.pod.name"
-	KubernetesPodNamespaceLabel  = "io.kubernetes.pod.namespace"
-	KubernetesPodUIDLabel        = "io.kubernetes.pod.uid"
+	// KubernetesPodNameLabel specifies a pod name label
+	KubernetesPodNameLabel = "io.kubernetes.pod.name"
+	// KubernetesPodNamespaceLabel specifies a pod namespace label
+	KubernetesPodNamespaceLabel = "io.kubernetes.pod.namespace"
+	// KubernetesPodUIDLabel specifies a pod UID label
+	KubernetesPodUIDLabel = "io.kubernetes.pod.uid"
+	// KubernetesContainerNameLabel specifies a container name label
 	KubernetesContainerNameLabel = "io.kubernetes.container.name"
 )
 
+// GetContainerName returns container name from labels
 func GetContainerName(labels map[string]string) string {
 	return labels[KubernetesContainerNameLabel]
 }
 
+// GetPodName returns pod name from labels
 func GetPodName(labels map[string]string) string {
 	return labels[KubernetesPodNameLabel]
 }
 
+// GetPodUID returns pod UID from labels
 func GetPodUID(labels map[string]string) string {
 	return labels[KubernetesPodUIDLabel]
 }
 
+// GetPodNamespace returns pod namespace from labels
 func GetPodNamespace(labels map[string]string) string {
 	return labels[KubernetesPodNamespaceLabel]
 }

--- a/pkg/kubelet/types/pod_update.go
+++ b/pkg/kubelet/types/pod_update.go
@@ -25,42 +25,47 @@ import (
 )
 
 const (
-	ConfigSourceAnnotationKey    = "kubernetes.io/config.source"
-	ConfigMirrorAnnotationKey    = v1.MirrorPodAnnotationKey
+	// ConfigSourceAnnotationKey specifies a annotation key for config source
+	ConfigSourceAnnotationKey = "kubernetes.io/config.source"
+	// ConfigMirrorAnnotationKey specifies a annotation key for config mirror
+	ConfigMirrorAnnotationKey = v1.MirrorPodAnnotationKey
+	// ConfigFirstSeenAnnotationKey specifies a annotation key for config first seen
 	ConfigFirstSeenAnnotationKey = "kubernetes.io/config.seen"
-	ConfigHashAnnotationKey      = "kubernetes.io/config.hash"
+	// ConfigHashAnnotationKey specifies a annotation key for config hash
+	ConfigHashAnnotationKey = "kubernetes.io/config.hash"
 )
 
 // PodOperation defines what changes will be made on a pod configuration.
 type PodOperation int
 
 const (
-	// This is the current pod configuration
+	// SET is the current pod configuration
 	SET PodOperation = iota
-	// Pods with the given ids are new to this source
+	// ADD pods with the given ids are new to this source
 	ADD
-	// Pods with the given ids are gracefully deleted from this source
+	// DELETE pods with the given ids are gracefully deleted from this source
 	DELETE
-	// Pods with the given ids have been removed from this source
+	// REMOVE pods with the given ids have been removed from this source
 	REMOVE
-	// Pods with the given ids have been updated in this source
+	// UPDATE pods with the given ids have been updated in this source
 	UPDATE
-	// Pods with the given ids have unexpected status in this source,
+	// RECONCILE pods with the given ids have unexpected status in this source,
 	// kubelet should reconcile status with this source
 	RECONCILE
-	// Pods with the given ids have been restored from a checkpoint.
+	// RESTORE pods with the given ids have been restored from a checkpoint.
 	RESTORE
 
-	// These constants identify the sources of pods
+	// FileSource constants identify the sources of pods
 	// Updates from a file
 	FileSource = "file"
-	// Updates from querying a web page
+	// HTTPSource updates from querying a web page
 	HTTPSource = "http"
-	// Updates from Kubernetes API Server
+	// ApiserverSource updates from Kubernetes API Server
 	ApiserverSource = "api"
-	// Updates from all sources
+	// AllSource updates from all sources
 	AllSource = "*"
 
+	// NamespaceDefault default namespace
 	NamespaceDefault = metav1.NamespaceDefault
 )
 
@@ -79,7 +84,7 @@ type PodUpdate struct {
 	Source string
 }
 
-// Gets all validated sources from the specified sources.
+// GetValidatedSources gets all validated sources from the specified sources.
 func GetValidatedSources(sources []string) ([]string, error) {
 	validated := make([]string, 0, len(sources))
 	for _, source := range sources {

--- a/pkg/kubelet/types/types.go
+++ b/pkg/kubelet/types/types.go
@@ -61,7 +61,7 @@ func (t *Timestamp) GetString() string {
 	return t.time.Format(time.RFC3339Nano)
 }
 
-// A type to help sort container statuses based on container names.
+// SortedContainerStatuses is a type to help sort container statuses based on container names.
 type SortedContainerStatuses []v1.ContainerStatus
 
 func (s SortedContainerStatuses) Len() int      { return len(s) }
@@ -95,8 +95,8 @@ type Reservation struct {
 	Kubernetes v1.ResourceList
 }
 
-// A pod UID which has been translated/resolved to the representation known to kubelets.
+// ResolvedPodUID is a pod UID which has been translated/resolved to the representation known to kubelets.
 type ResolvedPodUID types.UID
 
-// A pod UID for a mirror pod.
+// MirrorPodUID is a pod UID for a mirror pod.
 type MirrorPodUID types.UID


### PR DESCRIPTION
What type of PR is this?
/kind documentation

What this PR does / why we need it:
- Fix lint errors for the whole directory `pkg/kubelet/types`
- Remove `pkg/kubelet/types` from `hack/.golint_failures`;
- Fix some typo from comments.

Which issue(s) this PR fixes: https://github.com/kubernetes/kubernetes/issues/68026

Special notes for your reviewer:

Does this PR introduce a user-facing change?:
```release-note
NONE
```