### PR TITLE
Add Deallocate and PostStopContainer to device plugin API

### DIFF
--- a/pkg/kubelet/cm/container_manager.go
+++ b/pkg/kubelet/cm/container_manager.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/lifecycle"
 	"k8s.io/kubernetes/pkg/kubelet/pluginmanager/cache"
 	"k8s.io/kubernetes/pkg/kubelet/status"
+	"k8s.io/kubernetes/pkg/kubelet/cm/devicemanager"
 	schedulerframework "k8s.io/kubernetes/pkg/scheduler/framework/v1alpha1"
 
 	"fmt"
@@ -73,6 +74,9 @@ type ContainerManager interface {
 	// GetCapacity returns the amount of compute resources tracked by container manager available on the node.
 	GetCapacity() v1.ResourceList
 
+    // GetDevicePlugin returns the device plugin assoctiated with this container manager
+    GetDevicePluginManager() devicemanager.Manager
+
 	// GetDevicePluginResourceCapacity returns the node capacity (amount of total device plugin resources),
 	// node allocatable (amount of total healthy resources reported by device plugin),
 	// and inactive device plugin resources previously registered on the node.
@@ -92,6 +96,9 @@ type ContainerManager interface {
 	// to make sure it is at least equal to the pod's requested capacity for
 	// any registered device plugin resource
 	UpdatePluginResources(*schedulerframework.NodeInfo, *lifecycle.PodAdmitAttributes) error
+
+	// DeletePluginResources release devices that device plugin allcated.
+	DeletePluginResources(podUID string, containerName string)
 
 	InternalContainerLifecycle() InternalContainerLifecycle
 

--- a/pkg/kubelet/cm/container_manager_linux.go
+++ b/pkg/kubelet/cm/container_manager_linux.go
@@ -680,6 +680,10 @@ func (cm *containerManagerImpl) UpdatePluginResources(node *schedulerframework.N
 	return cm.deviceManager.UpdatePluginResources(node, attrs)
 }
 
+func (cm *containerManagerImpl) DeletePluginResources(podUID string, containerName string) {
+	cm.deviceManager.Deallocate(podUID, containerName)
+}
+
 func (cm *containerManagerImpl) GetAllocateResourcesPodAdmitHandler() lifecycle.PodAdmitHandler {
 	if utilfeature.DefaultFeatureGate.Enabled(kubefeatures.TopologyManager) {
 		return cm.topologyManager
@@ -985,6 +989,10 @@ func isKernelPid(pid int) bool {
 
 func (cm *containerManagerImpl) GetCapacity() v1.ResourceList {
 	return cm.capacity
+}
+
+func (cm *containerManagerImpl) GetDevicePluginManager() devicemanager.Manager {
+    return cm.deviceManager
 }
 
 func (cm *containerManagerImpl) GetDevicePluginResourceCapacity() (v1.ResourceList, v1.ResourceList, []string) {

--- a/pkg/kubelet/cm/container_manager_linux.go
+++ b/pkg/kubelet/cm/container_manager_linux.go
@@ -361,7 +361,7 @@ func (cm *containerManagerImpl) NewPodContainerManager() PodContainerManager {
 }
 
 func (cm *containerManagerImpl) InternalContainerLifecycle() InternalContainerLifecycle {
-	return &internalContainerLifecycleImpl{cm.cpuManager, cm.topologyManager}
+	return &internalContainerLifecycleImpl{cm.cpuManager, cm.deviceManager, cm.topologyManager}
 }
 
 // Create a cgroup container manager.

--- a/pkg/kubelet/cm/container_manager_stub.go
+++ b/pkg/kubelet/cm/container_manager_stub.go
@@ -24,6 +24,7 @@ import (
 	internalapi "k8s.io/cri-api/pkg/apis"
 	podresourcesapi "k8s.io/kubernetes/pkg/kubelet/apis/podresources/v1alpha1"
 	"k8s.io/kubernetes/pkg/kubelet/cm/cpumanager"
+	"k8s.io/kubernetes/pkg/kubelet/cm/devicemanager"
 	"k8s.io/kubernetes/pkg/kubelet/cm/topologymanager"
 	"k8s.io/kubernetes/pkg/kubelet/config"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
@@ -102,7 +103,8 @@ func (cm *containerManagerStub) UpdatePluginResources(*schedulerframework.NodeIn
 }
 
 func (cm *containerManagerStub) InternalContainerLifecycle() InternalContainerLifecycle {
-	return &internalContainerLifecycleImpl{cpumanager.NewFakeManager(), topologymanager.NewFakeManager()}
+    dm, _ := devicemanager.NewManagerStub()
+	return &internalContainerLifecycleImpl{cpumanager.NewFakeManager(), dm, topologymanager.NewFakeManager()}
 }
 
 func (cm *containerManagerStub) GetPodCgroupRoot() string {

--- a/pkg/kubelet/cm/container_manager_stub.go
+++ b/pkg/kubelet/cm/container_manager_stub.go
@@ -86,6 +86,10 @@ func (cm *containerManagerStub) GetPluginRegistrationHandler() cache.PluginHandl
 	return nil
 }
 
+func (cm *containerManagerStub) GetDevicePluginManager() devicemanager.Manager {
+    return nil
+}
+
 func (cm *containerManagerStub) GetDevicePluginResourceCapacity() (v1.ResourceList, v1.ResourceList, []string) {
 	return nil, nil, []string{}
 }
@@ -102,8 +106,10 @@ func (cm *containerManagerStub) UpdatePluginResources(*schedulerframework.NodeIn
 	return nil
 }
 
+func (cm *containerManagerStub) DeletePluginResources(podUID string, containerName string) {}
+
 func (cm *containerManagerStub) InternalContainerLifecycle() InternalContainerLifecycle {
-    dm, _ := devicemanager.NewManagerStub()
+	dm, _ := devicemanager.NewManagerStub()
 	return &internalContainerLifecycleImpl{cpumanager.NewFakeManager(), dm, topologymanager.NewFakeManager()}
 }
 

--- a/pkg/kubelet/cm/container_manager_windows.go
+++ b/pkg/kubelet/cm/container_manager_windows.go
@@ -36,6 +36,7 @@ import (
 	podresourcesapi "k8s.io/kubernetes/pkg/kubelet/apis/podresources/v1alpha1"
 	"k8s.io/kubernetes/pkg/kubelet/cadvisor"
 	"k8s.io/kubernetes/pkg/kubelet/cm/cpumanager"
+	"k8s.io/kubernetes/pkg/kubelet/cm/devicemanager"
 	"k8s.io/kubernetes/pkg/kubelet/cm/topologymanager"
 	"k8s.io/kubernetes/pkg/kubelet/config"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
@@ -170,7 +171,8 @@ func (cm *containerManagerImpl) UpdatePluginResources(*schedulerframework.NodeIn
 }
 
 func (cm *containerManagerImpl) InternalContainerLifecycle() InternalContainerLifecycle {
-	return &internalContainerLifecycleImpl{cpumanager.NewFakeManager(), topologymanager.NewFakeManager()}
+    dm, _ := devicemanager.NewManagerStub()
+	return &internalContainerLifecycleImpl{cpumanager.NewFakeManager(), dm, topologymanager.NewFakeManager()}
 }
 
 func (cm *containerManagerImpl) GetPodCgroupRoot() string {

--- a/pkg/kubelet/cm/container_manager_windows.go
+++ b/pkg/kubelet/cm/container_manager_windows.go
@@ -154,6 +154,10 @@ func (cm *containerManagerImpl) GetPluginRegistrationHandler() cache.PluginHandl
 	return nil
 }
 
+func (cm *containerManagerImpl) GetDevicePluginManager() devicemanager.Manager {
+    return nil
+}
+
 func (cm *containerManagerImpl) GetDevicePluginResourceCapacity() (v1.ResourceList, v1.ResourceList, []string) {
 	return nil, nil, []string{}
 }
@@ -170,8 +174,10 @@ func (cm *containerManagerImpl) UpdatePluginResources(*schedulerframework.NodeIn
 	return nil
 }
 
+func (cm *containerManagerImpl) DeletePluginResources(podUID string, containerName string) {}
+
 func (cm *containerManagerImpl) InternalContainerLifecycle() InternalContainerLifecycle {
-    dm, _ := devicemanager.NewManagerStub()
+	dm, _ := devicemanager.NewManagerStub()
 	return &internalContainerLifecycleImpl{cpumanager.NewFakeManager(), dm, topologymanager.NewFakeManager()}
 }
 

--- a/pkg/kubelet/cm/devicemanager/device_plugin_stub.go
+++ b/pkg/kubelet/cm/devicemanager/device_plugin_stub.go
@@ -195,6 +195,12 @@ func (m *Stub) PreStartContainer(ctx context.Context, r *pluginapi.PreStartConta
 	return &pluginapi.PreStartContainerResponse{}, nil
 }
 
+// PostStopContainer resets the devices received
+func (m *Stub) PostStopContainer(ctx context.Context, r *pluginapi.PostStopContainerRequest) (*pluginapi.Empty, error) {
+	klog.Infof("PostStopContainer, %+v", r)
+	return nil, nil
+}
+
 // ListAndWatch lists devices and update that list according to the Update call
 func (m *Stub) ListAndWatch(e *pluginapi.Empty, s pluginapi.DevicePlugin_ListAndWatchServer) error {
 	klog.Info("ListAndWatch")
@@ -227,6 +233,12 @@ func (m *Stub) Allocate(ctx context.Context, r *pluginapi.AllocateRequest) (*plu
 	}
 
 	return m.allocFunc(r, devs)
+}
+
+// Deallocate does a mock allocation
+func (m *Stub) Deallocate(ctx context.Context, r *pluginapi.DeallocateRequest) (*pluginapi.Empty, error) {
+	klog.Infof("Deallocate, %+v", r)
+	return nil, nil
 }
 
 func (m *Stub) cleanup() error {

--- a/pkg/kubelet/cm/devicemanager/manager_stub.go
+++ b/pkg/kubelet/cm/devicemanager/manager_stub.go
@@ -59,6 +59,10 @@ func (h *ManagerStub) GetDeviceRunContainerOptions(pod *v1.Pod, container *v1.Co
 	return nil, nil
 }
 
+func (m *ManagerStub) PreStartContainer(pod *v1.Pod, container *v1.Container) error {
+    return nil
+}
+
 // GetCapacity simply returns nil capacity and empty removed resource list.
 func (h *ManagerStub) GetCapacity() (v1.ResourceList, v1.ResourceList, []string) {
 	return nil, nil, []string{}

--- a/pkg/kubelet/cm/devicemanager/manager_stub.go
+++ b/pkg/kubelet/cm/devicemanager/manager_stub.go
@@ -49,6 +49,9 @@ func (h *ManagerStub) Allocate(pod *v1.Pod, container *v1.Container) error {
 	return nil
 }
 
+// Deallocate does not do anything
+func (h *ManagerStub) Deallocate(podUID string, containerName string) {}
+
 // UpdatePluginResources simply returns nil.
 func (h *ManagerStub) UpdatePluginResources(node *schedulerframework.NodeInfo, attrs *lifecycle.PodAdmitAttributes) error {
 	return nil
@@ -59,9 +62,13 @@ func (h *ManagerStub) GetDeviceRunContainerOptions(pod *v1.Pod, container *v1.Co
 	return nil, nil
 }
 
-func (m *ManagerStub) PreStartContainer(pod *v1.Pod, container *v1.Container) error {
-    return nil
+// PreStartContainer simply returns nil.
+func (h *ManagerStub) PreStartContainer(pod *v1.Pod, container *v1.Container) error {
+	return nil
 }
+
+// PostStopContainer does nothing
+func (h *ManagerStub) PostStopContainer(podUID string, containerName string) {}
 
 // GetCapacity simply returns nil capacity and empty removed resource list.
 func (h *ManagerStub) GetCapacity() (v1.ResourceList, v1.ResourceList, []string) {

--- a/pkg/kubelet/cm/devicemanager/manager_test.go
+++ b/pkg/kubelet/cm/devicemanager/manager_test.go
@@ -733,6 +733,8 @@ func TestPodContainerDeviceAllocation(t *testing.T) {
 				testCase.description, testCase.expErr, err)
 		}
 		runContainerOpts, err := testManager.GetDeviceRunContainerOptions(pod, &pod.Spec.Containers[0])
+        as.Nil(err)
+        err = testManager.PreStartContainer(pod, &pod.Spec.Containers[0])
 		if testCase.expErr == nil {
 			as.Nil(err)
 		}
@@ -836,6 +838,8 @@ func TestDevicePreStartContainer(t *testing.T) {
 	podsStub.updateActivePods(activePods)
 	err = testManager.Allocate(pod, &pod.Spec.Containers[0])
 	as.Nil(err)
+    err = testManager.PreStartContainer(pod, &pod.Spec.Containers[0])
+    as.Nil(err)
 	runContainerOpts, err := testManager.GetDeviceRunContainerOptions(pod, &pod.Spec.Containers[0])
 	as.Nil(err)
 	var initializedDevs []string

--- a/pkg/kubelet/cm/devicemanager/manager_test.go
+++ b/pkg/kubelet/cm/devicemanager/manager_test.go
@@ -605,7 +605,6 @@ func getTestManager(tmpDir string, activePods ActivePodsFunc, testRes []TestReso
 		allocatedDevices:      make(map[string]sets.String),
 		endpoints:             make(map[string]endpointInfo),
 		podDevices:            make(podDevices),
-		devicesToReuse:        make(PodReusableDevices),
 		topologyAffinityStore: topologymanager.NewFakeManager(),
 		activePods:            activePods,
 		sourcesReady:          &sourcesReadyStub{},
@@ -748,105 +747,6 @@ func TestPodContainerDeviceAllocation(t *testing.T) {
 		as.Equal(testCase.expectedAllocatedResName2, testManager.allocatedDevices[res2.resourceName].Len())
 	}
 
-}
-
-func TestInitContainerDeviceAllocation(t *testing.T) {
-	// Requesting to create a pod that requests resourceName1 in init containers and normal containers
-	// should succeed with devices allocated to init containers reallocated to normal containers.
-	res1 := TestResource{
-		resourceName:     "domain1.com/resource1",
-		resourceQuantity: *resource.NewQuantity(int64(2), resource.DecimalSI),
-		devs:             []string{"dev1", "dev2"},
-	}
-	res2 := TestResource{
-		resourceName:     "domain2.com/resource2",
-		resourceQuantity: *resource.NewQuantity(int64(1), resource.DecimalSI),
-		devs:             []string{"dev3", "dev4"},
-	}
-	testResources := make([]TestResource, 2)
-	testResources = append(testResources, res1)
-	testResources = append(testResources, res2)
-	as := require.New(t)
-	podsStub := activePodsStub{
-		activePods: []*v1.Pod{},
-	}
-	tmpDir, err := ioutil.TempDir("", "checkpoint")
-	as.Nil(err)
-	defer os.RemoveAll(tmpDir)
-
-	testManager, err := getTestManager(tmpDir, podsStub.getActivePods, testResources)
-	as.Nil(err)
-
-	podWithPluginResourcesInInitContainers := &v1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			UID: uuid.NewUUID(),
-		},
-		Spec: v1.PodSpec{
-			InitContainers: []v1.Container{
-				{
-					Name: string(uuid.NewUUID()),
-					Resources: v1.ResourceRequirements{
-						Limits: v1.ResourceList{
-							v1.ResourceName(res1.resourceName): res2.resourceQuantity,
-						},
-					},
-				},
-				{
-					Name: string(uuid.NewUUID()),
-					Resources: v1.ResourceRequirements{
-						Limits: v1.ResourceList{
-							v1.ResourceName(res1.resourceName): res1.resourceQuantity,
-						},
-					},
-				},
-			},
-			Containers: []v1.Container{
-				{
-					Name: string(uuid.NewUUID()),
-					Resources: v1.ResourceRequirements{
-						Limits: v1.ResourceList{
-							v1.ResourceName(res1.resourceName): res2.resourceQuantity,
-							v1.ResourceName(res2.resourceName): res2.resourceQuantity,
-						},
-					},
-				},
-				{
-					Name: string(uuid.NewUUID()),
-					Resources: v1.ResourceRequirements{
-						Limits: v1.ResourceList{
-							v1.ResourceName(res1.resourceName): res2.resourceQuantity,
-							v1.ResourceName(res2.resourceName): res2.resourceQuantity,
-						},
-					},
-				},
-			},
-		},
-	}
-	podsStub.updateActivePods([]*v1.Pod{podWithPluginResourcesInInitContainers})
-	for _, container := range podWithPluginResourcesInInitContainers.Spec.InitContainers {
-		err = testManager.Allocate(podWithPluginResourcesInInitContainers, &container)
-	}
-	for _, container := range podWithPluginResourcesInInitContainers.Spec.Containers {
-		err = testManager.Allocate(podWithPluginResourcesInInitContainers, &container)
-	}
-	as.Nil(err)
-	podUID := string(podWithPluginResourcesInInitContainers.UID)
-	initCont1 := podWithPluginResourcesInInitContainers.Spec.InitContainers[0].Name
-	initCont2 := podWithPluginResourcesInInitContainers.Spec.InitContainers[1].Name
-	normalCont1 := podWithPluginResourcesInInitContainers.Spec.Containers[0].Name
-	normalCont2 := podWithPluginResourcesInInitContainers.Spec.Containers[1].Name
-	initCont1Devices := testManager.podDevices.containerDevices(podUID, initCont1, res1.resourceName)
-	initCont2Devices := testManager.podDevices.containerDevices(podUID, initCont2, res1.resourceName)
-	normalCont1Devices := testManager.podDevices.containerDevices(podUID, normalCont1, res1.resourceName)
-	normalCont2Devices := testManager.podDevices.containerDevices(podUID, normalCont2, res1.resourceName)
-	as.Equal(1, initCont1Devices.Len())
-	as.Equal(2, initCont2Devices.Len())
-	as.Equal(1, normalCont1Devices.Len())
-	as.Equal(1, normalCont2Devices.Len())
-	as.True(initCont2Devices.IsSuperset(initCont1Devices))
-	as.True(initCont2Devices.IsSuperset(normalCont1Devices))
-	as.True(initCont2Devices.IsSuperset(normalCont2Devices))
-	as.Equal(0, normalCont1Devices.Intersection(normalCont2Devices).Len())
 }
 
 func TestUpdatePluginResources(t *testing.T) {

--- a/pkg/kubelet/cm/devicemanager/manager_test.go
+++ b/pkg/kubelet/cm/devicemanager/manager_test.go
@@ -563,12 +563,18 @@ func (m *MockEndpoint) preStartContainer(devs []string) (*pluginapi.PreStartCont
 	return &pluginapi.PreStartContainerResponse{}, nil
 }
 
+func (m *MockEndpoint) postStopContainer(devs []string) {
+	m.initChan <- devs
+}
+
 func (m *MockEndpoint) allocate(devs []string) (*pluginapi.AllocateResponse, error) {
 	if m.allocateFunc != nil {
 		return m.allocateFunc(devs)
 	}
 	return nil, nil
 }
+
+func (m *MockEndpoint) deallocate(devs []string) {}
 
 func (m *MockEndpoint) isStopped() bool { return false }
 
@@ -733,8 +739,8 @@ func TestPodContainerDeviceAllocation(t *testing.T) {
 				testCase.description, testCase.expErr, err)
 		}
 		runContainerOpts, err := testManager.GetDeviceRunContainerOptions(pod, &pod.Spec.Containers[0])
-        as.Nil(err)
-        err = testManager.PreStartContainer(pod, &pod.Spec.Containers[0])
+		as.Nil(err)
+		err = testManager.PreStartContainer(pod, &pod.Spec.Containers[0])
 		if testCase.expErr == nil {
 			as.Nil(err)
 		}
@@ -838,8 +844,8 @@ func TestDevicePreStartContainer(t *testing.T) {
 	podsStub.updateActivePods(activePods)
 	err = testManager.Allocate(pod, &pod.Spec.Containers[0])
 	as.Nil(err)
-    err = testManager.PreStartContainer(pod, &pod.Spec.Containers[0])
-    as.Nil(err)
+	err = testManager.PreStartContainer(pod, &pod.Spec.Containers[0])
+	as.Nil(err)
 	runContainerOpts, err := testManager.GetDeviceRunContainerOptions(pod, &pod.Spec.Containers[0])
 	as.Nil(err)
 	var initializedDevs []string

--- a/pkg/kubelet/cm/devicemanager/pod_devices.go
+++ b/pkg/kubelet/cm/devicemanager/pod_devices.go
@@ -80,36 +80,6 @@ func (pdev podDevices) containerDevices(podUID, contName, resource string) sets.
 	return devs.deviceIds
 }
 
-// Populates allocatedResources with the device resources allocated to the specified <podUID, contName>.
-func (pdev podDevices) addContainerAllocatedResources(podUID, contName string, allocatedResources map[string]sets.String) {
-	containers, exists := pdev[podUID]
-	if !exists {
-		return
-	}
-	resources, exists := containers[contName]
-	if !exists {
-		return
-	}
-	for resource, devices := range resources {
-		allocatedResources[resource] = allocatedResources[resource].Union(devices.deviceIds)
-	}
-}
-
-// Removes the device resources allocated to the specified <podUID, contName> from allocatedResources.
-func (pdev podDevices) removeContainerAllocatedResources(podUID, contName string, allocatedResources map[string]sets.String) {
-	containers, exists := pdev[podUID]
-	if !exists {
-		return
-	}
-	resources, exists := containers[contName]
-	if !exists {
-		return
-	}
-	for resource, devices := range resources {
-		allocatedResources[resource] = allocatedResources[resource].Difference(devices.deviceIds)
-	}
-}
-
 // Returns all of devices allocated to the pods being tracked, keyed by resourceName.
 func (pdev podDevices) devices() map[string]sets.String {
 	ret := make(map[string]sets.String)

--- a/pkg/kubelet/cm/devicemanager/topology_hints_test.go
+++ b/pkg/kubelet/cm/devicemanager/topology_hints_test.go
@@ -613,7 +613,7 @@ func TestTopologyAlignedAllocation(t *testing.T) {
 			m.healthyDevices[tc.resource].Insert(d.ID)
 		}
 
-		allocated, err := m.devicesToAllocate("podUID", "containerName", tc.resource, tc.request, sets.NewString())
+		allocated, err := m.devicesToAllocate("podUID", "containerName", tc.resource, tc.request)
 		if err != nil {
 			t.Errorf("Unexpected error: %v", err)
 			continue

--- a/pkg/kubelet/cm/devicemanager/types.go
+++ b/pkg/kubelet/cm/devicemanager/types.go
@@ -46,6 +46,9 @@ type Manager interface {
 	// update the node capacity to reflect the currently available devices.
 	UpdatePluginResources(node *schedulerframework.NodeInfo, attrs *lifecycle.PodAdmitAttributes) error
 
+	// Deallocate devices allocated to containers.
+	Deallocate(podUID string, containerName string)
+
 	// Stop stops the manager.
 	Stop() error
 
@@ -54,8 +57,11 @@ type Manager interface {
 	// for the found one. An empty struct is returned in case no cached state is found.
 	GetDeviceRunContainerOptions(pod *v1.Pod, container *v1.Container) (*DeviceRunContainerOptions, error)
 
-    // PreStartContainer calls the preStartContainer gRPC call if necessary for all devices
-    PreStartContainer(pod *v1.Pod, container *v1.Container) error
+	// PreStartContainer calls the preStartContainer gRPC call if necessary for all devices
+	PreStartContainer(pod *v1.Pod, container *v1.Container) error
+
+	// PostStopContainer calls the postStopContainer gRPC call if necessary for all devices
+	PostStopContainer(podUID string, containerName string)
 
 	// GetCapacity returns the amount of available device plugin resource capacity, resource allocatable
 	// and inactive device plugin resources previously registered on the node.

--- a/pkg/kubelet/cm/devicemanager/types.go
+++ b/pkg/kubelet/cm/devicemanager/types.go
@@ -54,6 +54,9 @@ type Manager interface {
 	// for the found one. An empty struct is returned in case no cached state is found.
 	GetDeviceRunContainerOptions(pod *v1.Pod, container *v1.Container) (*DeviceRunContainerOptions, error)
 
+    // PreStartContainer calls the preStartContainer gRPC call if necessary for all devices
+    PreStartContainer(pod *v1.Pod, container *v1.Container) error
+
 	// GetCapacity returns the amount of available device plugin resource capacity, resource allocatable
 	// and inactive device plugin resources previously registered on the node.
 	GetCapacity() (v1.ResourceList, v1.ResourceList, []string)

--- a/pkg/kubelet/cm/fake_internal_container_lifecycle.go
+++ b/pkg/kubelet/cm/fake_internal_container_lifecycle.go
@@ -34,6 +34,6 @@ func (f *fakeInternalContainerLifecycle) PreStopContainer(containerID string) er
 	return nil
 }
 
-func (f *fakeInternalContainerLifecycle) PostStopContainer(containerID string) error {
+func (f *fakeInternalContainerLifecycle) PostStopContainer(podUID string, containerName string, containerID string) error {
 	return nil
 }

--- a/pkg/kubelet/cm/internal_container_lifecycle.go
+++ b/pkg/kubelet/cm/internal_container_lifecycle.go
@@ -22,6 +22,7 @@ import (
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	kubefeatures "k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/kubelet/cm/cpumanager"
+	"k8s.io/kubernetes/pkg/kubelet/cm/devicemanager"
 	"k8s.io/kubernetes/pkg/kubelet/cm/topologymanager"
 )
 
@@ -34,6 +35,7 @@ type InternalContainerLifecycle interface {
 // Implements InternalContainerLifecycle interface.
 type internalContainerLifecycleImpl struct {
 	cpuManager      cpumanager.Manager
+    deviceManager   devicemanager.Manager
 	topologyManager topologymanager.Manager
 }
 
@@ -44,6 +46,12 @@ func (i *internalContainerLifecycleImpl) PreStartContainer(pod *v1.Pod, containe
 			return err
 		}
 	}
+    if i.deviceManager != nil {
+        err := i.deviceManager.PreStartContainer(pod, container)
+        if err != nil {
+			return err
+		}
+    }
 	if utilfeature.DefaultFeatureGate.Enabled(kubefeatures.TopologyManager) {
 		err := i.topologyManager.AddContainer(pod, containerID)
 		if err != nil {

--- a/pkg/kubelet/container/runtime.go
+++ b/pkg/kubelet/container/runtime.go
@@ -113,7 +113,7 @@ type Runtime interface {
 	// "100" or "all") to tail the log.
 	GetContainerLogs(ctx context.Context, pod *v1.Pod, containerID ContainerID, logOptions *v1.PodLogOptions, stdout, stderr io.Writer) (err error)
 	// Delete a container. If the container is still running, an error is returned.
-	DeleteContainer(containerID ContainerID) error
+	DeleteContainer(podUID string, containerName string, containerID ContainerID) error
 	// ImageService provides methods to image-related methods.
 	ImageService
 	// UpdatePodCIDR sends a new podCIDR to the runtime.

--- a/pkg/kubelet/container/testing/fake_runtime.go
+++ b/pkg/kubelet/container/testing/fake_runtime.go
@@ -356,7 +356,7 @@ func (f *FakeRuntime) GarbageCollect(gcPolicy kubecontainer.GCPolicy, ready bool
 	return f.Err
 }
 
-func (f *FakeRuntime) DeleteContainer(containerID kubecontainer.ContainerID) error {
+func (f *FakeRuntime) DeleteContainer(podUID string, containerName string, containerID kubecontainer.ContainerID) error {
 	f.Lock()
 	defer f.Unlock()
 

--- a/pkg/kubelet/container/testing/runtime_mock.go
+++ b/pkg/kubelet/container/testing/runtime_mock.go
@@ -142,8 +142,8 @@ func (r *Mock) GarbageCollect(gcPolicy kubecontainer.GCPolicy, ready bool, evict
 	return args.Error(0)
 }
 
-func (r *Mock) DeleteContainer(containerID kubecontainer.ContainerID) error {
-	args := r.Called(containerID)
+func (r *Mock) DeleteContainer(podUID string, containerName string, containerID kubecontainer.ContainerID) error {
+	args := r.Called(podUID, containerName, containerID)
 	return args.Error(0)
 }
 

--- a/pkg/kubelet/kuberuntime/kuberuntime_container_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container_test.go
@@ -65,7 +65,7 @@ func TestRemoveContainer(t *testing.T) {
 
 	containerID := fakeContainers[0].Id
 	fakeOS := m.osInterface.(*containertest.FakeOS)
-	err = m.removeContainer(containerID)
+	err = m.removeContainer(string(pod.UID), pod.Spec.Containers[0].Name, containerID)
 	assert.NoError(t, err)
 	// Verify container log is removed
 	expectedContainerLogPath := filepath.Join(podLogsRootDirectory, "new_bar_12345678", "foo", "0.log")

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager.go
@@ -562,7 +562,7 @@ func (m *kubeGenericRuntimeManager) computePodActions(pod *v1.Pod, podStatus *ku
 		// allocated cpus are released immediately. If the container is restarted, cpus will be re-allocated
 		// to it.
 		if containerStatus != nil && containerStatus.State != kubecontainer.ContainerStateRunning {
-			if err := m.internalLifecycle.PostStopContainer(containerStatus.ID.ID); err != nil {
+			if err := m.internalLifecycle.PostStopContainer(string(pod.UID), container.Name, containerStatus.ID.ID); err != nil {
 				klog.Errorf("internal container post-stop lifecycle hook failed for container %v in pod %v with error %v",
 					container.Name, pod.Name, err)
 			}

--- a/pkg/kubelet/pod_container_deletor.go
+++ b/pkg/kubelet/pod_container_deletor.go
@@ -32,8 +32,14 @@ const (
 
 type containerStatusbyCreatedList []*kubecontainer.Status
 
+type deletorCandidate struct {
+	podUID        string
+	containerName string
+	container     kubecontainer.ContainerID
+}
+
 type podContainerDeletor struct {
-	worker           chan<- kubecontainer.ContainerID
+	worker           chan<- deletorCandidate
 	containersToKeep int
 }
 
@@ -44,11 +50,14 @@ func (a containerStatusbyCreatedList) Less(i, j int) bool {
 }
 
 func newPodContainerDeletor(runtime kubecontainer.Runtime, containersToKeep int) *podContainerDeletor {
-	buffer := make(chan kubecontainer.ContainerID, containerDeletorBufferLimit)
+	buffer := make(chan deletorCandidate, containerDeletorBufferLimit)
 	go wait.Until(func() {
 		for {
-			id := <-buffer
-			if err := runtime.DeleteContainer(id); err != nil {
+			candidate := <-buffer
+			podUID := candidate.podUID
+			containerName := candidate.containerName
+			id := candidate.container
+			if err := runtime.DeleteContainer(podUID, containerName, id); err != nil {
 				klog.Warningf("[pod_container_deletor] DeleteContainer returned error for (id=%v): %v", id, err)
 			}
 		}
@@ -99,7 +108,7 @@ func getContainersToDeleteInPod(filterContainerID string, podStatus *kubecontain
 }
 
 // deleteContainersInPod issues container deletion requests for containers selected by getContainersToDeleteInPod.
-func (p *podContainerDeletor) deleteContainersInPod(filterContainerID string, podStatus *kubecontainer.PodStatus, removeAll bool) {
+func (p *podContainerDeletor) deleteContainersInPod(podUID string, filterContainerID string, podStatus *kubecontainer.PodStatus, removeAll bool) {
 	containersToKeep := p.containersToKeep
 	if removeAll {
 		containersToKeep = 0
@@ -107,8 +116,9 @@ func (p *podContainerDeletor) deleteContainersInPod(filterContainerID string, po
 	}
 
 	for _, candidate := range getContainersToDeleteInPod(filterContainerID, podStatus, containersToKeep) {
+		deleteInfo := deletorCandidate{podUID: podUID, containerName: candidate.Name}
 		select {
-		case p.worker <- candidate.ID:
+		case p.worker <- deleteInfo:
 		default:
 			klog.Warningf("Failed to issue the request to remove container %v", candidate.ID)
 		}

--- a/staging/src/k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1/api.proto
+++ b/staging/src/k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1/api.proto
@@ -25,8 +25,12 @@ service Registration {
 }
 
 message DevicePluginOptions {
-        // Indicates if PreStartContainer call is required before each container start
+    // Indicates if PreStartContainer call is required before each container start
 	bool pre_start_required = 1;
+    // Indicates if PostStopContainer call is required before each container start
+	bool post_stop_required = 2;
+    // Indicates if the Deallocate call is required before after each container death
+    bool deallocate_required = 3;
 }
 
 message RegisterRequest {
@@ -37,8 +41,8 @@ message RegisterRequest {
 	string endpoint = 2;
 	// Schedulable resource name. As of now it's expected to be a DNS Label
 	string resource_name = 3;
-        // Options to be communicated with Device Manager
-        DevicePluginOptions options = 4;
+    // Options to be communicated with Device Manager
+    DevicePluginOptions options = 4;
 }
 
 message Empty {
@@ -60,10 +64,20 @@ service DevicePlugin {
 	// of the steps to make the Device available in the container
 	rpc Allocate(AllocateRequest) returns (AllocateResponse) {}
 
-        // PreStartContainer is called, if indicated by Device Plugin during registeration phase,
-        // before each container start. Device plugin can run device specific operations
-        // such as resetting the device before making devices available to the container
+    // PreStartContainer is called, if indicated by Device Plugin during registeration phase,
+    // before each container start. Device plugin can run device specific operations
+    // such as resetting the device before making devices available to the container
 	rpc PreStartContainer(PreStartContainerRequest) returns (PreStartContainerResponse) {}
+
+    // PostStopContainer is called, if indicated by Device Plugin during registeration phase,
+    // before each container start. Device plugin can run device specific operations
+    // such as resetting/clearing up the device after its use by the container
+	rpc PostStopContainer(PostStopContainerRequest) returns (Empty) {}
+    
+    // Deallocate is called during container deletion so that the Device
+	// Plugin can run device specific operations or keep track of the 
+    // released devices
+	rpc Deallocate(DeallocateRequest) returns (Empty) {}
 }
 
 // ListAndWatch returns a stream of List of Devices
@@ -112,6 +126,13 @@ message PreStartContainerRequest {
 message PreStartContainerResponse {
 }
 
+// - PostStopContainer is expected to be called after each container death if indicated by plugin during registration phase.
+// - PostStopContainer allows Device Plugin to run device specific operations on
+//   the Devices requested to clear/reset them
+message PostStopContainerRequest {
+        repeated string devicesIDs = 1;
+}
+
 // - Allocate is expected to be called during pod creation since allocation
 //   failures for any container would result in pod startup failure.
 // - Allocate allows kubelet to exposes additional artifacts in a pod's
@@ -147,6 +168,19 @@ message ContainerAllocateResponse {
 	repeated DeviceSpec devices = 3;
 	// Container annotations to pass to the container runtime
 	map<string, string> annotations = 4;
+}
+
+// - Deallocate allows Device Plugin to run device specific operations on
+//   the Devices requested
+// - Deallocate is useful for complex device plugins that need to track
+//   the allocation of their devices
+// - Deallocated 
+message DeallocateRequest {
+	repeated ContainerDeallocateRequest container_requests = 1;
+}
+
+message ContainerDeallocateRequest {
+	repeated string devicesIDs = 1;
 }
 
 // Mount specifies a host volume to mount into a container.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
The PR adds DevicePlugin calls for `PostStopContainer` and `Deallocate`. Both calls are optional, same way `PreStartContainer` is. They maintain the same hierarchy of having both `Allocate` and `PreStartContainer`.
- `PostStopContainer` is useful for device plugins that need to clean up their devices post use. For example, FPGAs. This is necessary because otherwise those device can keep working, wasting power, and potentially polluting networks or host interfaces.
- `Deallocate` may sound redundant after having `PostStopContainer`. But it is useful for two reasons, the first is to maintain the same reasoning of having both `Allocate` and `PreStartContainer`, and the second is to help complex device plugins that need to keep track of which devices are being used and which are not, which is a different use case from the `PostStopContainer` callback. An example of such usage is device plugins that can serve "partitions" of FPGAs using something called DPR (Dynamic Partial Reconfiguration).

**Which issue(s) this PR fixes**:
Fixes #86539
Cancels https://github.com/kubernetes/kubernetes/pull/87223

**Special notes for your reviewer**:
Given the long discussions in #59110, I tried to follow most requirements as much as possible. Both calls are optional, so not breaking to existing device plugins. They do not return errors, making it the responsibility of the device plugin to mark devices `unhealthy` if any of the two calls fails.

**Does this PR introduce a user-facing change?**:
```release-note
The user will optionally add `Deallocate` and/or `PostStopContainer` to their device plugins, if needed.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
Please use the following format for linking documentation:
```docs
- [Usage]: https://github.com/kubernetes/community/blob/master/contributors/design-proposals/resource-management/device-plugin.md
```
