### PR TITLE
Remove unnecessary logging info from kubemark nodes annotation

### DIFF
--- a/test/kubemark/start-kubemark.sh
+++ b/test/kubemark/start-kubemark.sh
@@ -238,7 +238,7 @@ function resize-node-objects {
   echo "Annotating node objects with ${annotation_size_bytes} byte label"
   label=$( (< /dev/urandom tr -dc 'a-zA-Z0-9' | fold -w "$annotation_size_bytes"; true) | head -n 1)
   "${KUBECTL}" --kubeconfig="${LOCAL_KUBECONFIG}" get nodes -o name \
-    | xargs -n10 -P100 -r -I% "${KUBECTL}" --kubeconfig="${LOCAL_KUBECONFIG}" annotate --overwrite % label="$label"
+    | xargs -n10 -P100 -r -I% "${KUBECTL}" --kubeconfig="${LOCAL_KUBECONFIG}" annotate --overwrite % label="$label" > /dev/null
   echo "Annotating node objects completed"
 }
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
SIG Scalability kubemark test jobs build logs have swelled after merging #90806 where kubemark nodes are annotated. The PR's change simply redirects the unnecessary logging info about annotating to `/dev/null`.

**Which issue(s) this PR fixes**:
Fixes #91201.

**Special notes for your reviewer**:
/sig scalability
/cc mm4tt

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```