### PR TITLE
Log user provided NODE_IP_RANGE to stdout instead of stderr

### DIFF
--- a/cluster/gce/config-common.sh
+++ b/cluster/gce/config-common.sh
@@ -79,7 +79,6 @@ function get-master-disk-size() {
 
 function get-node-ip-range {
   if [[ -n "${NODE_IP_RANGE:-}" ]]; then
-    >&2 echo "Using user provided NODE_IP_RANGE: ${NODE_IP_RANGE}"
     echo "${NODE_IP_RANGE}"
     return
   fi


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
In PR #91205 we noticed that each call to k/k/cluster/kubectl.sh results in a `get-node-ip-range` function call. When `NODE_IP_RANGE` env var is provided, the function logs a message to `stderr`. In the aforementioned PR we call `kubectl.sh` multiple times and suppress only `stdout` and because of that the build log grows with redundant information. In addition, the information logged inside `get-node-ip-range` to `stderr` fits more to `stdout`.

**Which issue(s) this PR fixes**:
No issue is opened for that.

**Special notes for your reviewer**:
/sig scalability
/cc mm4tt

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
