### PR TITLE
Remove excess logs for inactive containers

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -694,6 +694,7 @@ func NewMainKubelet(kubeCfg *kubeletconfiginternal.KubeletConfiguration,
 			klet.runtimeService,
 			kubeCfg.ContainerLogMaxSize,
 			int(kubeCfg.ContainerLogMaxFiles),
+			containerGCPolicy.MaxPerPodContainer,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("failed to initialize container log manager: %v", err)

--- a/pkg/kubelet/kuberuntime/kuberuntime_container.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container.go
@@ -861,10 +861,6 @@ func (m *kubeGenericRuntimeManager) removeContainerLog(containerID string) error
 		return fmt.Errorf("failed to get container status %q: %v", containerID, err)
 	}
 	labeledInfo := getContainerInfoFromLabels(status.Labels)
-	path := status.GetLogPath()
-	if err := m.osInterface.Remove(path); err != nil && !os.IsNotExist(err) {
-		return fmt.Errorf("failed to remove container %q log %q: %v", containerID, path, err)
-	}
 
 	// Remove the legacy container log symlink.
 	// TODO(random-liu): Remove this after cluster logging supports CRI container log path.

--- a/pkg/kubelet/kuberuntime/kuberuntime_container_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container_test.go
@@ -18,7 +18,6 @@ package kuberuntime
 
 import (
 	"fmt"
-	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -68,9 +67,8 @@ func TestRemoveContainer(t *testing.T) {
 	err = m.removeContainer(containerID)
 	assert.NoError(t, err)
 	// Verify container log is removed
-	expectedContainerLogPath := filepath.Join(podLogsRootDirectory, "new_bar_12345678", "foo", "0.log")
 	expectedContainerLogSymlink := legacyLogSymlink(containerID, "foo", "bar", "new")
-	assert.Equal(t, fakeOS.Removes, []string{expectedContainerLogPath, expectedContainerLogSymlink})
+	assert.Equal(t, fakeOS.Removes, []string{expectedContainerLogSymlink})
 	// Verify container is removed
 	assert.Contains(t, fakeRuntime.Called, "RemoveContainer")
 	containers, err := fakeRuntime.ListContainers(&runtimeapi.ContainerFilter{Id: containerID})


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Currently containerGC#evictPodLogsDirectories() operates on logs directories if there are no corresponding pods. This poses issue for log cleaning of long running pod where some containers keep restarting and generating considerable log files.

Current log rotation / pruning is based on container Id.

The requirement for #90334 is different: we want to keep cap on the containers (of the same pod) whose log files are to be kept so that the logs of dead containers don't consume disk space for extended period of time.

This PR introduces handling of excess logs for inactive containers.
Containers with same name and same sandbox Id are grouped. The logs for containerGCPolicy.MaxPerPodContainer containers (e.g. the live container and one dead container) are kept. Logs for other containers of the same name are cleaned.

Without the fix, a misbehaving Pod may potentially consume large amount of disk space.

Tested on patched 1.18 kubelet for the Pod given in this comment:
https://github.com/kubernetes/kubernetes/issues/90334#issuecomment-619217547
```
apiVersion: v1
kind: Pod
metadata:
  name: log-test
  namespace: default
spec:
  terminationGracePeriodSeconds: 5
  containers:
  - name: log-test
    image: busybox:1.31.1
    command: ["/bin/sh"]
    args:
      - -c
      - |
        /bin/timeout 300 /bin/sh -c "while true; do date;done"
```
The additional state maintained for log manager allows the log pruning to be independent of containers' log directory.

**Which issue(s) this PR fixes**:
Fixes #90334

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
