### PR TITLE
add common methods for handling finalizers

### DIFF
--- a/pkg/controller/garbagecollector/graph_builder.go
+++ b/pkg/controller/garbagecollector/graph_builder.go
@@ -423,7 +423,7 @@ func referencesDiffs(old []metav1.OwnerReference, new []metav1.OwnerReference) (
 
 func deletionStartsWithFinalizer(oldObj interface{}, newAccessor metav1.Object, matchingFinalizer string) bool {
 	// if the new object isn't being deleted, or doesn't have the finalizer we're interested in, return false
-	if !beingDeleted(newAccessor) || !hasFinalizer(newAccessor, matchingFinalizer) {
+	if !beingDeleted(newAccessor) || !meta.HasFinalizer(newAccessor, matchingFinalizer) {
 		return false
 	}
 
@@ -436,7 +436,7 @@ func deletionStartsWithFinalizer(oldObj interface{}, newAccessor metav1.Object, 
 		utilruntime.HandleError(fmt.Errorf("cannot access oldObj: %v", err))
 		return false
 	}
-	return !beingDeleted(oldAccessor) || !hasFinalizer(oldAccessor, matchingFinalizer)
+	return !beingDeleted(oldAccessor) || !meta.HasFinalizer(oldAccessor, matchingFinalizer)
 }
 
 func beingDeleted(accessor metav1.Object) bool {
@@ -444,21 +444,11 @@ func beingDeleted(accessor metav1.Object) bool {
 }
 
 func hasDeleteDependentsFinalizer(accessor metav1.Object) bool {
-	return hasFinalizer(accessor, metav1.FinalizerDeleteDependents)
+	return meta.HasFinalizer(accessor, metav1.FinalizerDeleteDependents)
 }
 
 func hasOrphanFinalizer(accessor metav1.Object) bool {
-	return hasFinalizer(accessor, metav1.FinalizerOrphanDependents)
-}
-
-func hasFinalizer(accessor metav1.Object, matchingFinalizer string) bool {
-	finalizers := accessor.GetFinalizers()
-	for _, finalizer := range finalizers {
-		if finalizer == matchingFinalizer {
-			return true
-		}
-	}
-	return false
+	return meta.HasFinalizer(accessor, metav1.FinalizerOrphanDependents)
 }
 
 // this function takes newAccessor directly because the caller already

--- a/pkg/controller/service/BUILD
+++ b/pkg/controller/service/BUILD
@@ -11,6 +11,7 @@ go_library(
     deps = [
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/errors:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/api/meta:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",

--- a/pkg/controller/volume/pvcprotection/BUILD
+++ b/pkg/controller/volume/pvcprotection/BUILD
@@ -7,10 +7,10 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/controller/volume/protectionutil:go_default_library",
-        "//pkg/util/slice:go_default_library",
         "//pkg/volume/util:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/errors:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/api/meta:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/runtime:go_default_library",

--- a/pkg/controller/volume/pvprotection/BUILD
+++ b/pkg/controller/volume/pvprotection/BUILD
@@ -7,10 +7,10 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/controller/volume/protectionutil:go_default_library",
-        "//pkg/util/slice:go_default_library",
         "//pkg/volume/util:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/errors:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/api/meta:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/wait:go_default_library",

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apihelpers/helpers.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apihelpers/helpers.go
@@ -145,28 +145,6 @@ func IsCRDConditionEquivalent(lhs, rhs *apiextensionsv1.CustomResourceDefinition
 	return lhs.Message == rhs.Message && lhs.Reason == rhs.Reason && lhs.Status == rhs.Status && lhs.Type == rhs.Type
 }
 
-// CRDHasFinalizer returns true if the finalizer is in the list.
-func CRDHasFinalizer(crd *apiextensionsv1.CustomResourceDefinition, needle string) bool {
-	for _, finalizer := range crd.Finalizers {
-		if finalizer == needle {
-			return true
-		}
-	}
-
-	return false
-}
-
-// CRDRemoveFinalizer removes the finalizer if present.
-func CRDRemoveFinalizer(crd *apiextensionsv1.CustomResourceDefinition, needle string) {
-	newFinalizers := []string{}
-	for _, finalizer := range crd.Finalizers {
-		if finalizer != needle {
-			newFinalizers = append(newFinalizers, finalizer)
-		}
-	}
-	crd.Finalizers = newFinalizers
-}
-
 // HasServedCRDVersion returns true if the given version is in the list of CRD's versions and the Served flag is set.
 func HasServedCRDVersion(crd *apiextensionsv1.CustomResourceDefinition, version string) bool {
 	for _, v := range crd.Spec.Versions {

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apihelpers/helpers_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apihelpers/helpers_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package apihelpers
 
 import (
-	"reflect"
 	"testing"
 	"time"
 
@@ -137,72 +136,6 @@ func TestGetAPIApprovalState(t *testing.T) {
 				t.Fatalf("expected %v, got %v", test.expected, actual)
 			}
 		})
-	}
-}
-
-func TestCRDHasFinalizer(t *testing.T) {
-	tests := []struct {
-		name             string
-		crd              *apiextensionsv1.CustomResourceDefinition
-		finalizerToCheck string
-
-		expected bool
-	}{
-		{
-			name: "missing",
-			crd: &apiextensionsv1.CustomResourceDefinition{
-				ObjectMeta: metav1.ObjectMeta{Finalizers: []string{"not-it"}},
-			},
-			finalizerToCheck: "it",
-			expected:         false,
-		},
-		{
-			name: "present",
-			crd: &apiextensionsv1.CustomResourceDefinition{
-				ObjectMeta: metav1.ObjectMeta{Finalizers: []string{"not-it", "it"}},
-			},
-			finalizerToCheck: "it",
-			expected:         true,
-		},
-	}
-	for _, tc := range tests {
-		actual := CRDHasFinalizer(tc.crd, tc.finalizerToCheck)
-		if tc.expected != actual {
-			t.Errorf("%v expected %v, got %v", tc.name, tc.expected, actual)
-		}
-	}
-}
-
-func TestCRDRemoveFinalizer(t *testing.T) {
-	tests := []struct {
-		name             string
-		crd              *apiextensionsv1.CustomResourceDefinition
-		finalizerToCheck string
-
-		expected []string
-	}{
-		{
-			name: "missing",
-			crd: &apiextensionsv1.CustomResourceDefinition{
-				ObjectMeta: metav1.ObjectMeta{Finalizers: []string{"not-it"}},
-			},
-			finalizerToCheck: "it",
-			expected:         []string{"not-it"},
-		},
-		{
-			name: "present",
-			crd: &apiextensionsv1.CustomResourceDefinition{
-				ObjectMeta: metav1.ObjectMeta{Finalizers: []string{"not-it", "it"}},
-			},
-			finalizerToCheck: "it",
-			expected:         []string{"not-it"},
-		},
-	}
-	for _, tc := range tests {
-		CRDRemoveFinalizer(tc.crd, tc.finalizerToCheck)
-		if !reflect.DeepEqual(tc.expected, tc.crd.Finalizers) {
-			t.Errorf("%v expected %v, got %v", tc.name, tc.expected, tc.crd.Finalizers)
-		}
 	}
 }
 

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/helpers.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/helpers.go
@@ -17,7 +17,6 @@ limitations under the License.
 package apiextensions
 
 import (
-	"fmt"
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -29,7 +28,7 @@ var swaggerMetadataDescriptions = metav1.ObjectMeta{}.SwaggerDoc()
 func SetCRDCondition(crd *CustomResourceDefinition, newCondition CustomResourceDefinitionCondition) {
 	newCondition.LastTransitionTime = metav1.NewTime(time.Now())
 
-	existingCondition := FindCRDCondition(crd, newCondition.Type)
+	existingCondition := findCRDCondition(crd, newCondition.Type)
 	if existingCondition == nil {
 		crd.Status.Conditions = append(crd.Status.Conditions, newCondition)
 		return
@@ -44,19 +43,8 @@ func SetCRDCondition(crd *CustomResourceDefinition, newCondition CustomResourceD
 	existingCondition.Message = newCondition.Message
 }
 
-// RemoveCRDCondition removes the status condition.
-func RemoveCRDCondition(crd *CustomResourceDefinition, conditionType CustomResourceDefinitionConditionType) {
-	newConditions := []CustomResourceDefinitionCondition{}
-	for _, condition := range crd.Status.Conditions {
-		if condition.Type != conditionType {
-			newConditions = append(newConditions, condition)
-		}
-	}
-	crd.Status.Conditions = newConditions
-}
-
-// FindCRDCondition returns the condition you're looking for or nil.
-func FindCRDCondition(crd *CustomResourceDefinition, conditionType CustomResourceDefinitionConditionType) *CustomResourceDefinitionCondition {
+// findCRDCondition returns the condition you're looking for or nil.
+func findCRDCondition(crd *CustomResourceDefinition, conditionType CustomResourceDefinitionConditionType) *CustomResourceDefinitionCondition {
 	for i := range crd.Status.Conditions {
 		if crd.Status.Conditions[i].Type == conditionType {
 			return &crd.Status.Conditions[i]
@@ -71,11 +59,6 @@ func IsCRDConditionTrue(crd *CustomResourceDefinition, conditionType CustomResou
 	return IsCRDConditionPresentAndEqual(crd, conditionType, ConditionTrue)
 }
 
-// IsCRDConditionFalse indicates if the condition is present and false.
-func IsCRDConditionFalse(crd *CustomResourceDefinition, conditionType CustomResourceDefinitionConditionType) bool {
-	return IsCRDConditionPresentAndEqual(crd, conditionType, ConditionFalse)
-}
-
 // IsCRDConditionPresentAndEqual indicates if the condition is present and equal to the given status.
 func IsCRDConditionPresentAndEqual(crd *CustomResourceDefinition, conditionType CustomResourceDefinitionConditionType, status ConditionStatus) bool {
 	for _, condition := range crd.Status.Conditions {
@@ -86,172 +69,12 @@ func IsCRDConditionPresentAndEqual(crd *CustomResourceDefinition, conditionType 
 	return false
 }
 
-// IsCRDConditionEquivalent returns true if the lhs and rhs are equivalent except for times.
-func IsCRDConditionEquivalent(lhs, rhs *CustomResourceDefinitionCondition) bool {
-	if lhs == nil && rhs == nil {
-		return true
-	}
-	if lhs == nil || rhs == nil {
-		return false
-	}
-
-	return lhs.Message == rhs.Message && lhs.Reason == rhs.Reason && lhs.Status == rhs.Status && lhs.Type == rhs.Type
-}
-
-// CRDHasFinalizer returns true if the finalizer is in the list.
-func CRDHasFinalizer(crd *CustomResourceDefinition, needle string) bool {
-	for _, finalizer := range crd.Finalizers {
-		if finalizer == needle {
-			return true
-		}
-	}
-
-	return false
-}
-
-// CRDRemoveFinalizer removes the finalizer if present.
-func CRDRemoveFinalizer(crd *CustomResourceDefinition, needle string) {
-	newFinalizers := []string{}
-	for _, finalizer := range crd.Finalizers {
-		if finalizer != needle {
-			newFinalizers = append(newFinalizers, finalizer)
-		}
-	}
-	crd.Finalizers = newFinalizers
-}
-
-// HasServedCRDVersion returns true if the given version is in the list of CRD's versions and the Served flag is set.
-func HasServedCRDVersion(crd *CustomResourceDefinition, version string) bool {
-	for _, v := range crd.Spec.Versions {
-		if v.Name == version {
-			return v.Served
-		}
-	}
-	return false
-}
-
-// GetCRDStorageVersion returns the storage version for given CRD.
-func GetCRDStorageVersion(crd *CustomResourceDefinition) (string, error) {
-	for _, v := range crd.Spec.Versions {
-		if v.Storage {
-			return v.Name, nil
-		}
-	}
-	// This should not happened if crd is valid
-	return "", fmt.Errorf("invalid CustomResourceDefinition, no storage version")
-}
-
 // IsStoredVersion returns whether the given version is the storage version of the CRD.
 func IsStoredVersion(crd *CustomResourceDefinition, version string) bool {
 	for _, v := range crd.Status.StoredVersions {
 		if version == v {
 			return true
 		}
-	}
-	return false
-}
-
-// GetSchemaForVersion returns the validation schema for the given version or nil.
-func GetSchemaForVersion(crd *CustomResourceDefinition, version string) (*CustomResourceValidation, error) {
-	if !HasPerVersionSchema(crd.Spec.Versions) {
-		return crd.Spec.Validation, nil
-	}
-	if crd.Spec.Validation != nil {
-		return nil, fmt.Errorf("malformed CustomResourceDefinition %s version %s: top-level and per-version schemas must be mutual exclusive", crd.Name, version)
-	}
-	for _, v := range crd.Spec.Versions {
-		if version == v.Name {
-			return v.Schema, nil
-		}
-	}
-	return nil, fmt.Errorf("version %s not found in CustomResourceDefinition: %v", version, crd.Name)
-}
-
-// GetSubresourcesForVersion returns the subresources for given version or nil.
-func GetSubresourcesForVersion(crd *CustomResourceDefinition, version string) (*CustomResourceSubresources, error) {
-	if !HasPerVersionSubresources(crd.Spec.Versions) {
-		return crd.Spec.Subresources, nil
-	}
-	if crd.Spec.Subresources != nil {
-		return nil, fmt.Errorf("malformed CustomResourceDefinition %s version %s: top-level and per-version subresources must be mutual exclusive", crd.Name, version)
-	}
-	for _, v := range crd.Spec.Versions {
-		if version == v.Name {
-			return v.Subresources, nil
-		}
-	}
-	return nil, fmt.Errorf("version %s not found in CustomResourceDefinition: %v", version, crd.Name)
-}
-
-// GetColumnsForVersion returns the columns for given version or nil.
-// NOTE: the newly logically-defaulted columns is not pointing to the original CRD object.
-// One cannot mutate the original CRD columns using the logically-defaulted columns. Please iterate through
-// the original CRD object instead.
-func GetColumnsForVersion(crd *CustomResourceDefinition, version string) ([]CustomResourceColumnDefinition, error) {
-	if !HasPerVersionColumns(crd.Spec.Versions) {
-		return serveDefaultColumnsIfEmpty(crd.Spec.AdditionalPrinterColumns), nil
-	}
-	if len(crd.Spec.AdditionalPrinterColumns) > 0 {
-		return nil, fmt.Errorf("malformed CustomResourceDefinition %s version %s: top-level and per-version additionalPrinterColumns must be mutual exclusive", crd.Name, version)
-	}
-	for _, v := range crd.Spec.Versions {
-		if version == v.Name {
-			return serveDefaultColumnsIfEmpty(v.AdditionalPrinterColumns), nil
-		}
-	}
-	return nil, fmt.Errorf("version %s not found in CustomResourceDefinition: %v", version, crd.Name)
-}
-
-// HasPerVersionSchema returns true if a CRD uses per-version schema.
-func HasPerVersionSchema(versions []CustomResourceDefinitionVersion) bool {
-	for _, v := range versions {
-		if v.Schema != nil {
-			return true
-		}
-	}
-	return false
-}
-
-// HasPerVersionSubresources returns true if a CRD uses per-version subresources.
-func HasPerVersionSubresources(versions []CustomResourceDefinitionVersion) bool {
-	for _, v := range versions {
-		if v.Subresources != nil {
-			return true
-		}
-	}
-	return false
-}
-
-// HasPerVersionColumns returns true if a CRD uses per-version columns.
-func HasPerVersionColumns(versions []CustomResourceDefinitionVersion) bool {
-	for _, v := range versions {
-		if len(v.AdditionalPrinterColumns) > 0 {
-			return true
-		}
-	}
-	return false
-}
-
-// serveDefaultColumnsIfEmpty applies logically defaulting to columns, if the input columns is empty.
-// NOTE: in this way, the newly logically-defaulted columns is not pointing to the original CRD object.
-// One cannot mutate the original CRD columns using the logically-defaulted columns. Please iterate through
-// the original CRD object instead.
-func serveDefaultColumnsIfEmpty(columns []CustomResourceColumnDefinition) []CustomResourceColumnDefinition {
-	if len(columns) > 0 {
-		return columns
-	}
-	return []CustomResourceColumnDefinition{
-		{Name: "Age", Type: "date", Description: swaggerMetadataDescriptions["creationTimestamp"], JSONPath: ".metadata.creationTimestamp"},
-	}
-}
-
-// HasVersionServed returns true if given CRD has given version served.
-func HasVersionServed(crd *CustomResourceDefinition, version string) bool {
-	for _, v := range crd.Spec.Versions {
-		if !v.Served || v.Name != version {
-			continue
-		}
-		return true
 	}
 	return false
 }

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresourcedefinition/BUILD
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresourcedefinition/BUILD
@@ -15,6 +15,7 @@ go_library(
         "//staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/validation:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/equality:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/errors:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/api/meta:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/fields:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/labels:go_default_library",

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresourcedefinition/etcd.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresourcedefinition/etcd.go
@@ -22,6 +22,7 @@ import (
 
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/registry/generic"
@@ -132,7 +133,7 @@ func (r *REST) Delete(ctx context.Context, name string, deleteValidation rest.Va
 					existingCRD.DeletionTimestamp = &now
 				}
 
-				if !apiextensions.CRDHasFinalizer(existingCRD, apiextensions.CustomResourceCleanupFinalizer) {
+				if !meta.HasFinalizer(existingCRD, apiextensions.CustomResourceCleanupFinalizer) {
 					existingCRD.Finalizers = append(existingCRD.Finalizers, apiextensions.CustomResourceCleanupFinalizer)
 				}
 				// update the status condition too

--- a/staging/src/k8s.io/apimachinery/pkg/api/meta/BUILD
+++ b/staging/src/k8s.io/apimachinery/pkg/api/meta/BUILD
@@ -9,6 +9,7 @@ load(
 go_test(
     name = "go_default_test",
     srcs = [
+        "finalizer_test.go",
         "meta_test.go",
         "multirestmapper_test.go",
         "priority_test.go",
@@ -18,6 +19,7 @@ go_test(
     deps = [
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1beta1:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/diff:go_default_library",
         "//vendor/github.com/google/gofuzz:go_default_library",
@@ -29,6 +31,7 @@ go_library(
     srcs = [
         "doc.go",
         "errors.go",
+        "finalizer.go",
         "firsthit_restmapper.go",
         "help.go",
         "interfaces.go",

--- a/staging/src/k8s.io/apimachinery/pkg/api/meta/finalizer.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/meta/finalizer.go
@@ -1,0 +1,92 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package meta
+
+import (
+	"reflect"
+
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// DeepCopiableObject is a runtime.Object with get/set finalizer functions
+type FinalizeableObject interface {
+	runtime.Object
+	Finalizeable
+}
+
+// Finalizeable has get/set finalizer functions
+type Finalizeable interface {
+	GetFinalizers() []string
+	SetFinalizers(finalizers []string)
+}
+
+// AddFinalizer adds the finalizer to the metadata if it isn't already present.  If it is present, no action is taken.
+// If no action is taken, the return value is the passed object.  If the finalizer is added, the object is deep copied
+// to avoid mutating input.
+func AddFinalizer(object FinalizeableObject, finalizerName string) runtime.Object {
+	if HasFinalizer(object, finalizerName) {
+		return object
+	}
+
+	ret := object.DeepCopyObject().(FinalizeableObject)
+	ret.SetFinalizers(append(ret.GetFinalizers(), finalizerName))
+	return ret
+}
+
+// RemoveFinalizer removes the finalizer to the metadata if it is present.  If it is not present, no action is taken.
+// If no action is taken, the return value is the passed object.  If the finalizer is added, the object is deep copied
+// to avoid mutating input.
+func RemoveFinalizer(object FinalizeableObject, finalizerName string) runtime.Object {
+	if !HasFinalizer(object, finalizerName) {
+		return object
+	}
+
+	ret := object.DeepCopyObject().(FinalizeableObject)
+	ret.SetFinalizers(removeString(ret.GetFinalizers(), finalizerName))
+	return ret
+}
+
+// HasFinalizer returns true if the specified finalizer is in the list of finalizers.
+func HasFinalizer(object Finalizeable, finalizerName string) bool {
+	for _, finalizer := range object.GetFinalizers() {
+		if finalizer == finalizerName {
+			return true
+		}
+	}
+	return false
+}
+
+// FinalizersEqual is syntactic sugar for determining if finalizers were mutated while allowing type preservation.
+// eg.
+//   updated := meta.AddFinalizer(service, key).(*v1.Service)
+//   if meta.FinalizersEqual(updated, service) {
+//       return nil
+//   }
+func FinalizersEqual(newObj, oldObj FinalizeableObject) bool {
+	return reflect.DeepEqual(newObj, oldObj)
+}
+
+// removeString returns a newly created []string that contains all items from slice that are not equal to s.
+func removeString(slice []string, s string) []string {
+	var newSlice []string
+	for _, item := range slice {
+		if item != s {
+			newSlice = append(newSlice, item)
+		}
+	}
+	return newSlice
+}

--- a/staging/src/k8s.io/apimachinery/pkg/api/meta/finalizer_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/meta/finalizer_test.go
@@ -1,0 +1,92 @@
+package meta
+
+import (
+	"reflect"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+type fakeResource struct {
+	metav1.TypeMeta
+	metav1.ObjectMeta
+}
+
+func (o *fakeResource) GetObjectKind() schema.ObjectKind {
+	return schema.EmptyObjectKind
+}
+func (o *fakeResource) DeepCopyObject() runtime.Object {
+	t := *o
+	return &t
+}
+
+// TestAddRemoveFinalizer tests the add/remove and hasFinalizer methods.
+func TestAddRemoveFinalizer(t *testing.T) {
+	resource := &fakeResource{}
+
+	// add one works
+	prev := resource.DeepCopyObject().(*fakeResource)
+	curr := AddFinalizer(resource, "the-finalizer").(*fakeResource)
+	if FinalizersEqual(curr, prev) {
+		t.Fatalf("unexpected result")
+	}
+	if !HasFinalizer(curr, "the-finalizer") {
+		t.Fatalf("unexpected result")
+	}
+	if HasFinalizer(curr, "the-other-finalizer") {
+		t.Fatalf("unexpected result")
+	}
+	// confirm we didn't mutate input
+	if !reflect.DeepEqual(prev, resource) {
+		t.Fatalf("unexpected result")
+	}
+
+	// re-add doesn't mutate
+	prev = curr.DeepCopyObject().(*fakeResource)
+	curr = AddFinalizer(curr, "the-finalizer").(*fakeResource)
+	if !FinalizersEqual(curr, prev) {
+		t.Fatalf("unexpected result")
+	}
+
+	// add second still works
+	prev = curr.DeepCopyObject().(*fakeResource)
+	curr = AddFinalizer(curr, "the-other-finalizer").(*fakeResource)
+	if FinalizersEqual(curr, prev) {
+		t.Fatalf("unexpected result")
+	}
+	if !HasFinalizer(curr, "the-finalizer") {
+		t.Fatalf("unexpected result")
+	}
+	if !HasFinalizer(curr, "the-other-finalizer") {
+		t.Fatalf("unexpected result")
+	}
+
+	// remove one works
+	prev = curr.DeepCopyObject().(*fakeResource)
+	curr = RemoveFinalizer(curr, "the-other-finalizer").(*fakeResource)
+	if FinalizersEqual(curr, prev) {
+		t.Fatalf("unexpected result")
+	}
+	if !HasFinalizer(curr, "the-finalizer") {
+		t.Fatalf("unexpected result")
+	}
+	if HasFinalizer(curr, "the-other-finalizer") {
+		t.Fatalf("unexpected result")
+	}
+	// confirm we didn't mutate input
+	if reflect.DeepEqual(prev, curr) { // if we mutated input, these would be the same
+		t.Fatalf("unexpected result")
+	}
+
+	// re-remove doesn't mutate
+	prev = curr.DeepCopyObject().(*fakeResource)
+	curr = RemoveFinalizer(curr, "the-other-finalizer").(*fakeResource)
+	if !FinalizersEqual(curr, prev) {
+		t.Fatalf("unexpected result")
+	}
+	if !HasFinalizer(curr, "the-finalizer") {
+		t.Fatalf("unexpected result")
+	}
+}

--- a/staging/src/k8s.io/cloud-provider/service/helpers/BUILD
+++ b/staging/src/k8s.io/cloud-provider/service/helpers/BUILD
@@ -8,6 +8,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//staging/src/k8s.io/api/core/v1:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/api/meta:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/strategicpatch:go_default_library",

--- a/staging/src/k8s.io/cloud-provider/service/helpers/helper.go
+++ b/staging/src/k8s.io/cloud-provider/service/helpers/helper.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
@@ -114,12 +115,7 @@ func NeedsHealthCheck(service *v1.Service) bool {
 
 // HasLBFinalizer checks if service contains LoadBalancerCleanupFinalizer.
 func HasLBFinalizer(service *v1.Service) bool {
-	for _, finalizer := range service.ObjectMeta.Finalizers {
-		if finalizer == LoadBalancerCleanupFinalizer {
-			return true
-		}
-	}
-	return false
+	return meta.HasFinalizer(service, LoadBalancerCleanupFinalizer)
 }
 
 // LoadBalancerStatusEqual checks if load balancer status are equal

--- a/staging/src/k8s.io/legacy-cloud-providers/gce/BUILD
+++ b/staging/src/k8s.io/legacy-cloud-providers/gce/BUILD
@@ -43,6 +43,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//staging/src/k8s.io/api/core/v1:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/api/meta:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/resource:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/fields:go_default_library",
@@ -107,6 +108,7 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//staging/src/k8s.io/api/core/v1:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/api/meta:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",

--- a/staging/src/k8s.io/legacy-cloud-providers/gce/gce_loadbalancer_internal.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/gce/gce_loadbalancer_internal.go
@@ -29,7 +29,8 @@ import (
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud"
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
 	compute "google.golang.org/api/compute/v1"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
+	kmeta "k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	cloudprovider "k8s.io/cloud-provider"
@@ -56,7 +57,7 @@ func (g *Cloud) ensureInternalLoadBalancer(clusterName, clusterID string, svc *v
 			"Skipped ensureInternalLoadBalancer since %s feature is enabled.", AlphaFeatureILBSubsets)
 		return nil, cloudprovider.ImplementedElsewhere
 	}
-	if hasFinalizer(svc, ILBFinalizerV2) {
+	if kmeta.HasFinalizer(svc, ILBFinalizerV2) {
 		// Another controller is handling the resources for this service.
 		g.eventRecorder.Eventf(svc, v1.EventTypeNormal, "SkippingEnsureInternalLoadBalancer",
 			"Skipped ensureInternalLoadBalancer as service contains '%s' finalizer.", ILBFinalizerV2)

--- a/staging/src/k8s.io/legacy-cloud-providers/gce/gce_loadbalancer_internal_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/gce/gce_loadbalancer_internal_test.go
@@ -32,11 +32,12 @@ import (
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/mock"
 	"google.golang.org/api/compute/v1"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
+	kmeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
-	"k8s.io/cloud-provider"
+	cloudprovider "k8s.io/cloud-provider"
 	servicehelper "k8s.io/cloud-provider/service/helpers"
 )
 
@@ -1549,7 +1550,7 @@ func TestEnsureInternalLoadBalancerFinalizer(t *testing.T) {
 	assertInternalLbResources(t, gce, svc, vals, nodeNames)
 	svc, err = gce.client.CoreV1().Services(svc.Namespace).Get(context.TODO(), svc.Name, metav1.GetOptions{})
 	require.NoError(t, err)
-	if !hasFinalizer(svc, ILBFinalizerV1) {
+	if !kmeta.HasFinalizer(svc, ILBFinalizerV1) {
 		t.Errorf("Expected finalizer '%s' not found in Finalizer list - %v", ILBFinalizerV1, svc.Finalizers)
 	}
 
@@ -1559,7 +1560,7 @@ func TestEnsureInternalLoadBalancerFinalizer(t *testing.T) {
 	assertInternalLbResourcesDeleted(t, gce, svc, vals, true)
 	svc, err = gce.client.CoreV1().Services(svc.Namespace).Get(context.TODO(), svc.Name, metav1.GetOptions{})
 	require.NoError(t, err)
-	if hasFinalizer(svc, ILBFinalizerV1) {
+	if kmeta.HasFinalizer(svc, ILBFinalizerV1) {
 		t.Errorf("Finalizer '%s' not deleted as part of ILB delete", ILBFinalizerV1)
 	}
 }

--- a/staging/src/k8s.io/legacy-cloud-providers/gce/gce_util_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/gce/gce_util_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 
 	compute "google.golang.org/api/compute/v1"
+	kmeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -141,7 +142,7 @@ func TestAddRemoveFinalizer(t *testing.T) {
 	if err != nil {
 		t.Errorf("Failed to get service, err %v", err)
 	}
-	if !hasFinalizer(svc, ILBFinalizerV1) {
+	if !kmeta.HasFinalizer(svc, ILBFinalizerV1) {
 		t.Errorf("Unable to find finalizer '%s' in service %s", ILBFinalizerV1, svc.Name)
 	}
 	err = removeFinalizer(svc, gce.client.CoreV1(), ILBFinalizerV1)
@@ -152,7 +153,7 @@ func TestAddRemoveFinalizer(t *testing.T) {
 	if err != nil {
 		t.Errorf("Failed to get service, err %v", err)
 	}
-	if hasFinalizer(svc, ILBFinalizerV1) {
+	if kmeta.HasFinalizer(svc, ILBFinalizerV1) {
 		t.Errorf("Failed to remove finalizer '%s' in service %s", ILBFinalizerV1, svc.Name)
 	}
 }


### PR DESCRIPTION
I got tired of seeing versions of `{Add,Remove,Has}Finalizers` all with slightly different problems.  I've created the sixth version, but removed several others in k/k, so I'm going to claim net positive.

@liggitt you're likely to care about GC.  It's the one that stands out as changing perf characteristics slightly by doing a larger copy.

/kind cleanup
/priority important-soon
@kubernetes/sig-api-machinery-pr-reviews 


```release-note
NONE
```