### PR TITLE
Add CA Cert and CA CRL support to the type=TLS Secrets

### DIFF
--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -5596,6 +5596,13 @@ const (
 	TLSCertKey = "tls.crt"
 	// TLSPrivateKeyKey is the key for the private key field in a TLS secret.
 	TLSPrivateKeyKey = "tls.key"
+	// TLSCACertKey is the intermediate CA Certificate chain for client authentication in a TLS secret
+	TLSCACertKey = "ca.crt"
+	// TLSCACRLKey is the CA Certificate Revocation List in a TLS secret
+	TLSCACRLKey = "ca.crl"
+	// SecretTypeBootstrapToken is used during the automated bootstrap process (first
+	// implemented by kubeadm). It stores tokens that are used to sign well known
+	// ConfigMaps. They are used for authn.
 	// SecretTypeBootstrapToken is used during the automated bootstrap process (first
 	// implemented by kubeadm). It stores tokens that are used to sign well known
 	// ConfigMaps. They are used for authn.


### PR DESCRIPTION
**What type of PR is this?**
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test

/kind feature

> /kind flake

**What this PR does / why we need it**:
This PR adds two optional keys to the TLS Secrets: ca.crt and ca.crl. It makes it possible to include a CA Certificate chain and a CA CRL into the same TLS Secret with the certificate and key. 
The CA Certificate key naming (ca.crt) is compatible with the K8s Ingress and with the Istio expectations.
The CA CRL key naming (ca.crl) is compatible with the K8s Ingress expectations.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
Users can add a CA Certificate chain and a CA CRL to the type=TLS Secrets as optional parameters with kubectl.
Example: 
kubectl create secret tls tls-secret --cert=path/to/tls.cert --key=path/to/tls.key --cacert=/path/to/ca.crt --cacrl=/path/to/ca.crl
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**: