### PR TITLE
Eliminate locking in (anti)affinity calculations

### DIFF
--- a/pkg/scheduler/framework/plugins/interpodaffinity/plugin.go
+++ b/pkg/scheduler/framework/plugins/interpodaffinity/plugin.go
@@ -18,7 +18,6 @@ package interpodaffinity
 
 import (
 	"fmt"
-	"sync"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -45,7 +44,6 @@ var _ framework.ScorePlugin = &InterPodAffinity{}
 type InterPodAffinity struct {
 	args         config.InterPodAffinityArgs
 	sharedLister framework.SharedLister
-	sync.Mutex
 }
 
 // Name returns name of the plugin. It is used in logs, etc.


### PR DESCRIPTION
**What type of PR is this?**

 /kind feature

**What this PR does / why we need it**:
Optimizes (anti)affinity calculations by removing locking overhead, improving performance by additional 30% for preferred and up to 70% for required.

Before:
```
BenchmarkScheduling/5000Nodes/5000Pods-12                          1000  1400054   ns/op
BenchmarkSchedulingPodAntiAffinity/5000Nodes/1000Pods-12           1000  7228791   ns/op
BenchmarkSchedulingPodAffinity/5000Nodes/5000Pods-12               1000  11914596  ns/op
BenchmarkSchedulingPreferredPodAffinity/5000Nodes/5000Pods-12      1000  9423096   ns/op
BenchmarkSchedulingPreferredPodAntiAffinity/5000Nodes/5000Pods-12  1000  10320671  ns/op
BenchmarkSchedulingNodeAffinity/5000Nodes/5000Pods-12              1000  2632871   ns/op
```

After
```
BenchmarkScheduling/5000Nodes/5000Pods-12                   1000           1397570 ns/op
BenchmarkSchedulingPodAntiAffinity/5000Nodes/1000Pods-12                    1000           4789158 ns/op
BenchmarkSchedulingPodAffinity/5000Nodes/5000Pods-12                        1000          10382762 ns/op
BenchmarkSchedulingPreferredPodAffinity/5000Nodes/5000Pods-12               1000           7573003 ns/op
BenchmarkSchedulingPreferredPodAntiAffinity/5000Nodes/5000Pods-12                   1000           7739086 ns/op
BenchmarkSchedulingNodeAffinity/5000Nodes/5000Pods-12                               1000           2737240 ns/op
```

**Special notes for your reviewer**:
Builds over #91084

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

