### PR TITLE
Remove unused port flag for create service

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_service.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_service.go
@@ -310,7 +310,6 @@ func NewCmdCreateServiceExternalName(f cmdutil.Factory, ioStreams genericcliopti
 	cmdutil.AddApplyAnnotationFlags(cmd)
 	cmdutil.AddValidateFlags(cmd)
 	cmdutil.AddGeneratorFlags(cmd, generateversioned.ServiceExternalNameGeneratorV1Name)
-	addPortFlags(cmd)
 	cmd.Flags().String("external-name", "", i18n.T("External name of service"))
 	cmd.MarkFlagRequired("external-name")
 	cmdutil.AddFieldManagerFlagVar(cmd, &options.CreateSubcommandOptions.FieldManager, "kubectl-create")

--- a/staging/src/k8s.io/kubectl/pkg/generate/versioned/service_basic.go
+++ b/staging/src/k8s.io/kubectl/pkg/generate/versioned/service_basic.go
@@ -236,7 +236,11 @@ func (s ServiceCommonGeneratorV1) StructuredGenerate() (runtime.Object, error) {
 	labels := map[string]string{}
 	labels["app"] = s.Name
 	selector := map[string]string{}
-	selector["app"] = s.Name
+	// The selector will be ignored if the type is ExternalName
+	// So we only add the selector to services with a type != ExternalName
+	if s.Type != v1.ServiceTypeExternalName {
+		selector["app"] = s.Name
+	}
 
 	service := v1.Service{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind api-change
> /kind bug

/kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
During inspecting this issue: https://github.com/kubernetes/kubernetes/issues/91043 I saw that the `--tcp` flag is provided but never used (which makes sense since we create an CNAME). In order to prevent confusion we should remove this flag from the subcommand. I also removed the unused selector from the service of type `externalName`: from the docs ` Ignored if type is ExternalName. More info`

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
kubectl create service externalname has the unused "--tcp" flag removed and won't create a selector anymore
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
