### PR TITLE
Revert "Update cri-tools to v1.18.0"

### DIFF
--- a/build/dependencies.yaml
+++ b/build/dependencies.yaml
@@ -28,7 +28,7 @@ dependencies:
       match: CoreDNSVersion =
 
   - name: "crictl"
-    version: 1.18.0
+    version: 1.17.0
     refPaths:
     - path: build/workspace.bzl
       match: CRI_TOOLS_VERSION =

--- a/build/workspace.bzl
+++ b/build/workspace.bzl
@@ -26,16 +26,16 @@ _CNI_TARBALL_ARCH_SHA256 = {
     "s390x": "033ea910a83144609083d5c3fb62bf4a379b0b17729a1a9e829feed9fa7a9d97",
 }
 
-CRI_TOOLS_VERSION = "1.18.0"
+CRI_TOOLS_VERSION = "1.17.0"
 _CRI_TARBALL_ARCH_SHA256 = {
-    "linux-386": "a1aaf482928d0a19aabeb321e406333c5ddecf77a532f7ec8c0bd6ca7014101e",
-    "linux-amd64": "876dd2b3d0d1c2590371f940fb1bf1fbd5f15aebfbe456703ee465d959700f4a",
-    "linux-arm": "d420925d10b47a234b7e51e9cf1039c3c09f2703945a99435549fcdd7487ae3a",
-    "linux-arm64": "95ba32c47ad690b1e3e24f60255273dd7d176e62b1a0b482e5b44a7c31639979",
-    "linux-ppc64le": "53a1fedbcee37f5d6c9480d21a9bb17f1c0214ffe7b640e39231a59927a665ef",
-    "linux-s390x": "114c8885a7eeb43bbe19baaf23c04a5761d06330ba8e7aa39a3a15c2051221f1",
-    "windows-386": "f37e8b5c499fb5a2bd06668782a7dc34e5acf2fda6d1bfe8f0ea9c773359a378",
-    "windows-amd64": "5045bcc6d8b0e6004be123ab99ea06e5b1b2ae1e586c968fcdf85fccd4d67ae1",
+    "linux-386": "cffa443cf76ab4b760a68d4db555d1854cb692e8b20b3360cf23221815ca151e",
+    "linux-amd64": "7b72073797f638f099ed19550d52e9b9067672523fc51b746e65d7aa0bafa414",
+    "linux-arm": "9700957218e8e7bdc02cbc8fda4c189f5b6223a93ba89d876bdfd77b6117e9b7",
+    "linux-arm64": "d89afd89c2852509fafeaff6534d456272360fcee732a8d0cb89476377387e12",
+    "linux-ppc64le": "a61c52b9ac5bffe94ae4c09763083c60f3eccd30eb351017b310f32d1cafb855",
+    "linux-s390x": "0db445f0b74ecb51708b710480a462b728174155c5f2709a39d1cc2dc975e350",
+    "windows-386": "2e285250d36b5cb3e8c047b191c0c0af606fed7c0034bb140ba95cc1498f4996",
+    "windows-amd64": "e18150d5546d3ddf6b165bd9aec0f65c18aacf75b94fb28bb26bfc0238f07b28",
 }
 
 ETCD_VERSION = "3.4.7"

--- a/cluster/gce/gci/configure.sh
+++ b/cluster/gce/gci/configure.sh
@@ -28,8 +28,8 @@ DEFAULT_CNI_VERSION="v0.8.5"
 DEFAULT_CNI_SHA1="677d218b62c0ef941c1d0b606d6570faa5277ffd"
 DEFAULT_NPD_VERSION="v0.8.0"
 DEFAULT_NPD_SHA1="9406c975b1b035995a137029a004622b905b4e7f"
-DEFAULT_CRICTL_VERSION="v1.18.0"
-DEFAULT_CRICTL_SHA1="f384f594bd0a7e558a827363f54f58b45e670075"
+DEFAULT_CRICTL_VERSION="v1.17.0"
+DEFAULT_CRICTL_SHA1="5c18f4e52ab524d429063b78d086dd18b894aae7"
 DEFAULT_MOUNTER_TAR_SHA="8003b798cf33c7f91320cd6ee5cec4fa22244571"
 ###
 
@@ -280,7 +280,7 @@ function install-crictl {
     local -r crictl_version="${DEFAULT_CRICTL_VERSION}"
     local -r crictl_sha1="${DEFAULT_CRICTL_SHA1}"
   fi
-  local -r crictl="crictl-${crictl_version}-linux-amd64.tar.gz"
+  local -r crictl="crictl-${crictl_version}-linux-amd64"
 
   # Create crictl config file.
   cat > /etc/crictl.yaml <<EOF
@@ -293,10 +293,10 @@ EOF
   fi
 
   echo "Downloading crictl"
-  local -r crictl_path="https://github.com/kubernetes-sigs/cri-tools/releases/download/${crictl_version}"
+  local -r crictl_path="https://storage.googleapis.com/kubernetes-release/crictl"
   download-or-bust "${crictl_sha1}" "${crictl_path}/${crictl}"
-  tar xf "${crictl}"
-  mv crictl "${KUBE_BIN}/crictl"
+  mv "${KUBE_HOME}/${crictl}" "${KUBE_BIN}/crictl"
+  chmod a+x "${KUBE_BIN}/crictl"
 }
 
 function install-exec-auth-plugin {

--- a/cluster/gce/windows/k8s-node-setup.psm1
+++ b/cluster/gce/windows/k8s-node-setup.psm1
@@ -57,8 +57,8 @@ $GCE_METADATA_SERVER = "169.254.169.254"
 # exist until an initial HNS network has been created on the Windows node - see
 # Add_InitialHnsNetwork().
 $MGMT_ADAPTER_NAME = "vEthernet (Ethernet*"
-$CRICTL_VERSION = 'v1.18.0'
-$CRICTL_SHA256 = '5045bcc6d8b0e6004be123ab99ea06e5b1b2ae1e586c968fcdf85fccd4d67ae1'
+$CRICTL_VERSION = 'v1.17.0'
+$CRICTL_SHA256 = '781fd3bd15146a924c6fc2428b11d8a0f20fa04a0c8e00a9a5808f2cc37e0569'
 
 Import-Module -Force C:\common.psm1
 
@@ -1211,14 +1211,13 @@ function DownloadAndInstall-Crictl {
   if (-not (ShouldWrite-File ${env:NODE_DIR}\crictl.exe)) {
     return
   }
-  $url = ('https://github.com/kubernetes-sigs/cri-tools/releases/download/' +
-          $CRICTL_VERSION + '/crictl-' + $CRICTL_VERSION + '-windows-amd64.tar.gz')
+  $url = ('https://storage.googleapis.com/kubernetes-release/crictl/' +
+      'crictl-' + $CRICTL_VERSION + '-windows-amd64.exe')
   MustDownload-File `
       -URLs $url `
-      -OutFile ${env:NODE_DIR}\crictl.tar.gz `
+      -OutFile ${env:NODE_DIR}\crictl.exe `
       -Hash $CRICTL_SHA256 `
       -Algorithm SHA256
-  tar xzvf ${env:NODE_DIR}\crictl.tar.gz -C ${env:NODE_DIR}
 }
 
 # Sets crictl configuration values.


### PR DESCRIPTION
This reverts commit 4b3e023659d5437d5ea611e9e14295d1143385d8.

**What type of PR is this?**
/kind failing-test

**What this PR does / why we need it**:
Cluster for 5k nodes performance test did not setup. All nodes were created in MIGs, however they were not registered.

Checking logs from kubelets it seems that there was slow setup, because of recurring 429 error while downloading `crictl`. For this node it took over 30 minutes, some nodes were not registered.

Extract from [1262428312236462085/artifacts/gce-scale-cluster-minion-group-zf2x/systemd.log](https://storage.googleapis.com/kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-scale-performance/1262428312236462085/artifacts/gce-scale-cluster-minion-group-zf2x/systemd.log).
```
May 18 17:19:43.170157 gce-scale-cluster-minion-group-zf2x configure.sh[1205]: curl: (22) The requested URL returned error: 429 Too Many Requests
May 18 17:19:43.171132 gce-scale-cluster-minion-group-zf2x configure.sh[1205]: == Failed to download https://github.com/kubernetes-sigs/cri-tools/releases/download/v1.18.0/crictl-v1.18.0-linux-amd64.tar.gz. Retrying. ==
May 18 17:19:43.177474 gce-scale-cluster-minion-group-zf2x configure.sh[1205]:   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
May 18 17:19:43.178334 gce-scale-cluster-minion-group-zf2x configure.sh[1205]:                                  Dload  Upload   Total   Spent    Left  Speed
May 18 17:19:43.237433 gce-scale-cluster-minion-group-zf2x configure.sh[1205]: [158B blob data]
```

**Which issue(s) this PR fixes**:
None, it reverts #89720 

**Special notes for your reviewer**:
Revert because of a broken sig-scalability test

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

**FYI**:
@saschagrunert 
@justaugustus 
@fejta 
@feiskyer 
@cpanato 
@pjh 
@BenTheElder 
@mm4tt 

/assign @wojtek-t 
/sig scalability
/sig release
@cc @kubernetes/release-engineering 
