### PR TITLE
Update kube-addon-manager to v9.1.1

### DIFF
--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -2525,6 +2525,7 @@ EOF
 
   # Place addon manager pod manifest.
   src_file="${src_dir}/kube-addon-manager.yaml"
+  sed -i -e "s@{{kubectl_prune_whitelist_override}}@${KUBECTL_PRUNE_WHITELIST_OVERRIDE:-}@g" "${src_file}"
   sed -i -e "s@{{kubectl_extra_prune_whitelist}}@${ADDON_MANAGER_PRUNE_WHITELIST:-}@g" "${src_file}"
   sed -i -e "s@{{runAsUser}}@${KUBE_ADDON_MANAGER_RUNASUSER:-2002}@g" "${src_file}"
   sed -i -e "s@{{runAsGroup}}@${KUBE_ADDON_MANAGER_RUNASGROUP:-2002}@g" "${src_file}"

--- a/cluster/gce/manifests/kube-addon-manager.yaml
+++ b/cluster/gce/manifests/kube-addon-manager.yaml
@@ -23,7 +23,7 @@ spec:
         - all
     # When updating version also bump it in:
     # - test/kubemark/resources/manifests/kube-addon-manager.yaml
-    image: k8s.gcr.io/kube-addon-manager:v9.0.2
+    image: k8s.gcr.io/kube-addon-manager:v9.1.1
     command:
     - /bin/bash
     - -c
@@ -43,6 +43,8 @@ spec:
       name: srvkube
       readOnly: true
     env:
+    - name: KUBECTL_PRUNE_WHITELIST_OVERRIDE
+      value: {{kubectl_prune_whitelist_override}}
     - name: KUBECTL_EXTRA_PRUNE_WHITELIST
       value: {{kubectl_extra_prune_whitelist}}
     - name: KUBECTL_OPTS

--- a/test/kubemark/resources/manifests/kube-addon-manager.yaml
+++ b/test/kubemark/resources/manifests/kube-addon-manager.yaml
@@ -9,7 +9,7 @@ spec:
   hostNetwork: true
   containers:
   - name: kube-addon-manager
-    image: {{kube_docker_registry}}/kube-addon-manager:v9.0.2
+    image: {{kube_docker_registry}}/kube-addon-manager:v9.1.1
     command:
     - /bin/bash
     - -c


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Update manifests to use new kube-addon-manager image (v9.1.1) from #91261 which is a fixed version of v9.1.0 that was introduced in #91136.

**Which issue(s) this PR fixes**:
No issue is opened for that.

**Special notes for your reviewer**:
/sig scalability
/cc mm4tt

**Does this PR introduce a user-facing change?**:
```release-note
kube-addon-manager has been updated to v9.1.1 to allow overriding the default list of whitelisted resources (https://github.com/kubernetes/kubernetes/pull/91018)
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
