### PR TITLE
Skip Pod Conditions from scheduling queue updates

### DIFF
--- a/pkg/scheduler/eventhandlers_test.go
+++ b/pkg/scheduler/eventhandlers_test.go
@@ -204,6 +204,30 @@ func TestSkipPodUpdate(t *testing.T) {
 			},
 			expected: true,
 		},
+		{
+			name: "with changes on Conditions",
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "pod-0",
+				},
+				Status: v1.PodStatus{
+					Conditions: []v1.PodCondition{
+						{Type: "foo"},
+					},
+				},
+			},
+			isAssumedPodFunc: func(*v1.Pod) bool {
+				return true
+			},
+			getPodFunc: func(*v1.Pod) *v1.Pod {
+				return &v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pod-0",
+					},
+				}
+			},
+			expected: true,
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			c := &Scheduler{


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Skips updates in Pod Conditions so that there is no extra scheduling attempt when other controllers update Conditions while pod is binding.

**Which issue(s) this PR fixes**:

Fixes #91249

**Does this PR introduce a user-facing change?**:

```release-note
Pod Conditions updates are skipped for re-scheduling attempts
```
