### PR TITLE
Introduces EKS auth plugin

### DIFF
--- a/staging/src/k8s.io/client-go/go.mod
+++ b/staging/src/k8s.io/client-go/go.mod
@@ -8,6 +8,7 @@ require (
 	cloud.google.com/go v0.51.0 // indirect
 	github.com/Azure/go-autorest/autorest v0.9.6
 	github.com/Azure/go-autorest/autorest/adal v0.8.2
+	github.com/aws/aws-sdk-go v1.31.0
 	github.com/davecgh/go-spew v1.1.1
 	github.com/evanphx/json-patch v4.2.0+incompatible
 	github.com/gogo/protobuf v1.3.1

--- a/staging/src/k8s.io/client-go/go.sum
+++ b/staging/src/k8s.io/client-go/go.sum
@@ -38,6 +38,8 @@ github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
 github.com/PuerkitoBio/purell v1.0.0/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/urlesc v0.0.0-20160726150825-5bd2802263f2/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
+github.com/aws/aws-sdk-go v1.31.0 h1:ITLZ0oy7IOB1NGt2Ee75bLevBaH1jaAXE2eyGbPRbCg=
+github.com/aws/aws-sdk-go v1.31.0/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=

--- a/staging/src/k8s.io/client-go/plugin/pkg/client/auth/eks/BUILD
+++ b/staging/src/k8s.io/client-go/plugin/pkg/client/auth/eks/BUILD
@@ -1,0 +1,49 @@
+package(default_visibility = ["//visibility:public"])
+
+load(
+    "@io_bazel_rules_go//go:def.bzl",
+    "go_library",
+    "go_test",
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["eks_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//vendor/github.com/aws/aws-sdk-go/aws:go_default_library"
+        "//vendor/github.com/aws/aws-sdk-go/aws/credentials:go_default_library"
+        "//vendor/github.com/aws/aws-sdk-go/aws/credentials/stscreds:go_default_library"
+        "//vendor/github.com/aws/aws-sdk-go/aws/session:go_default_library"
+        "//vendor/github.com/aws/aws-sdk-go/aws/signer/v4:go_default_library"
+    ],
+)
+
+go_library(
+    name = "go_default_library",
+    srcs = ["eks.go"],
+    importmap = "k8s.io/kubernetes/vendor/k8s.io/client-go/plugin/pkg/client/auth/eks",
+    importpath = "k8s.io/client-go/plugin/pkg/client/auth/eks",
+    deps = [
+        "//staging/src/k8s.io/client-go/rest:go_default_library",
+        "//vendor/github.com/aws/aws-sdk-go/aws:go_default_library"
+        "//vendor/github.com/aws/aws-sdk-go/aws/credentials:go_default_library"
+        "//vendor/github.com/aws/aws-sdk-go/aws/credentials/stscreds:go_default_library"
+        "//vendor/github.com/aws/aws-sdk-go/aws/session:go_default_library"
+        "//vendor/github.com/aws/aws-sdk-go/aws/signer/v4:go_default_library"
+        "//vendor/k8s.io/klog/v2:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+)

--- a/staging/src/k8s.io/client-go/plugin/pkg/client/auth/eks/eks.go
+++ b/staging/src/k8s.io/client-go/plugin/pkg/client/auth/eks/eks.go
@@ -1,0 +1,215 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package eks
+
+import (
+	"encoding/base64"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
+	"github.com/aws/aws-sdk-go/aws/session"
+	v4 "github.com/aws/aws-sdk-go/aws/signer/v4"
+	"k8s.io/klog/v2"
+
+	"k8s.io/client-go/rest"
+)
+
+func init() {
+	if err := rest.RegisterAuthProviderPlugin("eks", newEKSAuthProvider); err != nil {
+		klog.Fatalf("Failed to register eks auth plugin: %v", err)
+	}
+}
+
+// eksAuthProvider is an auth provider plugin that uses AWS credentials to provide
+// tokens for kubectl to authenticate itself to an EKS apiserver. A sample json config
+// is provided below with all recognized options described.
+//
+// {
+//   'auth-provider': {
+//     # Required
+//     "name": "eks",
+//
+//     "config": {
+//			# Required - The EKS cluster name, as configured in AWS
+//			"clusterName": "",
+//			# Required - AWS access key id that is used to authenticate to the cluster
+//			"accessKeyId": "",
+//			# Required - AWS secret access key that is used to authenticate to the cluster
+//			"secretAccessKey": "",
+//			# Optional - If set, this auth plugin assumes this role and authenticates with it
+//			"roleARN": "",
+//     }
+//   }
+// }
+//
+type eksAuthProvider struct {
+	tokenSource *eksTokenSource
+}
+
+const (
+	accessKeyIdField     = "accessKeyId"
+	secretAccessKeyField = "secretAccessKey"
+	clusterNameField     = "clusterName"
+	roleARNField         = "roleARN"
+)
+
+// Authenticating to an EKS cluster requires to send a presigned STS url as the token.
+// The signed URL is very short lived, and so is not persisted.
+func newEKSAuthProvider(_ string, config map[string]string, _ rest.AuthProviderConfigPersister) (rest.AuthProvider, error) {
+	var accessKeyId, secretAccessKey, clusterName, roleARN string
+
+	requiredFields := map[string]*string{
+		clusterNameField:     &clusterName,
+		accessKeyIdField:     &accessKeyId,
+		secretAccessKeyField: &secretAccessKey,
+	}
+
+	for key, strPtr := range requiredFields {
+		val, ok := config[key]
+		if !ok {
+			klog.Errorf("Failed to find required: '%s' key in auth provider config", key)
+			return nil, fmt.Errorf("failed to find required: '%s' key in auth provider config", key)
+		}
+
+		*strPtr = val
+	}
+
+	roleARN, _ = config[roleARNField]
+	creds, err := getAWSCreds(accessKeyId, secretAccessKey, roleARN)
+	if creds == nil || err != nil {
+		klog.Errorf("Failed getting AWS creds: %v", err)
+		return nil, fmt.Errorf("failed getting AWS creds: %w", err)
+	}
+
+	tokenSource := eksTokenSource{
+		creds:       creds,
+		clusterName: clusterName,
+	}
+
+	return &eksAuthProvider{tokenSource: &tokenSource}, nil
+}
+
+func getAWSCreds(accessKeyId, secretAccessKey, roleARN string) (*credentials.Credentials, error) {
+	sessionToken := ""
+	creds := credentials.NewStaticCredentials(accessKeyId, secretAccessKey, sessionToken)
+
+	if roleARN != "" {
+		awsSession, err := session.NewSession(&aws.Config{Credentials: creds})
+		if awsSession == nil || err != nil {
+			return nil, fmt.Errorf("failed creating session: %v", err)
+		}
+
+		creds = stscreds.NewCredentials(awsSession, roleARN)
+	}
+
+	return creds, nil
+}
+
+var _ rest.AuthProvider = (*eksAuthProvider)(nil)
+
+// WrapTransport will add an authorization middleware to a given round-tripper
+func (a *eksAuthProvider) WrapTransport(roundTripper http.RoundTripper) http.RoundTripper {
+	return &eksRoundTripper{roundTripper: roundTripper, tokenSource: a.tokenSource}
+}
+
+// Login - not implemented in this context
+func (a *eksAuthProvider) Login() error {
+	// Irrelevant
+	return nil
+}
+
+type eksTokenSource struct {
+	creds       *credentials.Credentials
+	clusterName string
+}
+
+const (
+	stsUrlToSign = "https://sts.amazonaws.com/?Action=GetCallerIdentity&Version=2011-06-15"
+	headerToSign = "x-k8s-aws-id"
+
+	// STS presigned urls must be scoped to us-east-1
+	stsRegion                 = "us-east-1"
+	stsServiceName            = "sts"
+	authorizationHeaderPrefix = "k8s-aws-v1."
+)
+
+// Token will retrieve the bearer token that should be passed to an EKS cluster
+// Specifically, this is a presigned URL to STS/GetCallerIdentity, which the in-cluster authorization layer
+// later executes, in order to map the current identity to k8s RBAC policies, defined in the aws-auth config-map.
+// This will be invoked every time - there's no need to cache this, as the presigned URL is very short-lived,
+// and there's no I/O made in calculating the token.
+func (t *eksTokenSource) Token() (string, error) {
+	signer := v4.NewSigner(t.creds)
+
+	req, err := http.NewRequest(http.MethodGet, stsUrlToSign, nil)
+
+	if req == nil || err != nil {
+		klog.Errorf("Failed creating presign url request: %v", err)
+		return "", fmt.Errorf("failed creating presign url request: %w", err)
+	}
+
+	req.Header.Add(headerToSign, t.clusterName)
+
+	_, err = signer.Presign(req, nil, stsServiceName, stsRegion, time.Minute, time.Now())
+	if err != nil {
+		klog.Errorf("Failed presigning url: %v", err)
+		return "", fmt.Errorf("failed presigning url: %v", err)
+	}
+
+	encodedUrl := base64.RawURLEncoding.EncodeToString([]byte(req.URL.String()))
+	return authorizationHeaderPrefix + encodedUrl, nil
+}
+
+type eksRoundTripper struct {
+	roundTripper http.RoundTripper
+	tokenSource  *eksTokenSource
+}
+
+var _ http.RoundTripper = (*eksRoundTripper)(nil)
+
+const (
+	authorizationHeader = "Authorization"
+	tokenType           = "Bearer"
+)
+
+// RoundTrip will set the Authorization header with an STS presigned URL
+func (r *eksRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	if len(req.Header.Get(authorizationHeader)) != 0 {
+		return r.roundTripper.RoundTrip(req)
+	}
+
+	token, err := r.tokenSource.Token()
+	if err != nil {
+		klog.Errorf("Failed acquiring token for authorization header: %v", err)
+		return nil, fmt.Errorf("acquiring a token for authorization header: %w", err)
+	}
+
+	// clone the request in order to avoid modifying the headers of the original request
+	req2 := new(http.Request)
+	*req2 = *req
+	req2.Header = make(http.Header, len(req.Header))
+	for k, s := range req.Header {
+		req2.Header[k] = append([]string(nil), s...)
+	}
+
+	req2.Header.Set(authorizationHeader, tokenType+" "+token)
+	return r.roundTripper.RoundTrip(req2)
+}

--- a/staging/src/k8s.io/client-go/plugin/pkg/client/auth/eks/eks_test.go
+++ b/staging/src/k8s.io/client-go/plugin/pkg/client/auth/eks/eks_test.go
@@ -1,0 +1,173 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package eks
+
+import (
+	"encoding/base64"
+	"fmt"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+func TestEKSAuthProvider(t *testing.T) {
+	t.Run("validate against invalid configurations", func(t *testing.T) {
+		vectors := []struct {
+			cfg           map[string]string
+			expectedError string
+		}{
+			{
+				cfg: map[string]string{
+					// Missing clusterName
+					accessKeyIdField:     "Access Key",
+					secretAccessKeyField: "Secret Access Key",
+				},
+				expectedError: fmt.Sprintf("failed to find required: '%s' key in auth provider config", clusterNameField),
+			},
+			{
+				cfg: map[string]string{
+					clusterNameField: "Cluster Name",
+					// Missing accessKeyId
+					secretAccessKeyField: "Secret Access Key",
+				},
+				expectedError: fmt.Sprintf("failed to find required: '%s' key in auth provider config", accessKeyIdField),
+			},
+			{
+				cfg: map[string]string{
+					clusterNameField: "Cluster Name",
+					accessKeyIdField: "Access Key ID",
+					// Missing secretAccessKey
+				},
+				expectedError: fmt.Sprintf("failed to find required: '%s' key in auth provider config", secretAccessKeyField),
+			},
+		}
+
+		for _, v := range vectors {
+			_, err := newEKSAuthProvider("", v.cfg, nil)
+			if err == nil {
+				t.Errorf("cfg %v should fail but succeeded", v.cfg)
+			}
+
+			if err != nil && !strings.Contains(err.Error(), v.expectedError) {
+				t.Errorf("cfg %v should fail with message containing '%s'. actual: '%s'", v.cfg, v.expectedError, err)
+			}
+		}
+	})
+
+	t.Run("it should return non-nil provider in happy cases", func(t *testing.T) {
+		accessKey := "AAAAAAAAAAAAAAAAAAAA"
+
+		vectors := []struct {
+			cfg map[string]string
+		}{
+			{
+				cfg: map[string]string{
+					clusterNameField:     "Cluster Name",
+					accessKeyIdField:     accessKey,
+					secretAccessKeyField: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+				},
+			},
+		}
+
+		expectedQueryParams := map[string]string{
+			"X-Amz-Algorithm":     "AWS4-HMAC-SHA256",
+			"X-Amz-Credential":    fmt.Sprintf("%s/20200519/us-east-1/sts/aws4_request", accessKey),
+			"X-Amz-Expires":       "60",
+			"X-Amz-SignedHeaders": "host;x-k8s-aws-id",
+		}
+
+		for _, v := range vectors {
+			provider, err := newEKSAuthProvider("", v.cfg, nil)
+			if err != nil {
+				t.Errorf("newEKSAuthProvider should not fail with '%s'", err)
+			}
+
+			if provider == nil {
+				t.Fatalf("newEKSAuthProvider should return non-nil provider")
+			}
+
+			eksProvider := provider.(*eksAuthProvider)
+			if eksProvider == nil {
+				t.Fatalf("newEKSAuthProvider should return an instance of type eksAuthProvider, actual: %T", provider)
+			}
+
+			ts := eksProvider.tokenSource
+			if ts == nil {
+				t.Fatalf("eks token source should be non-nil")
+			}
+
+			expectedClusterName := v.cfg[clusterNameField]
+			if ts.clusterName != expectedClusterName {
+				t.Fatalf("unexpected cluster name, expected: %s, actual: %s", expectedClusterName, ts.clusterName)
+			}
+
+			token, err := ts.Token()
+			if err != nil {
+				t.Fatalf("unexpected failure for Token()")
+			}
+
+			if token == "" {
+				t.Fatal("unexpected blank token from EKS auth provider")
+			}
+
+			if !strings.HasPrefix(token, authorizationHeaderPrefix) {
+				t.Fatalf("unexpected token: %s, expected the prefix: %s", token, authorizationHeaderPrefix)
+			}
+
+			token = strings.TrimPrefix(token, authorizationHeaderPrefix)
+			if token == "" {
+				t.Fatalf("unexpected token: %s, expected a continuation post prefix", token)
+			}
+
+			decoded, err := base64.RawURLEncoding.DecodeString(token)
+			if err != nil {
+				t.Fatalf("error %v: failed decoding token: %s", err, decoded)
+			}
+
+			if len(decoded) == 0 {
+				t.Fatalf("failed decoding token: %s, expected non blank decoded", decoded)
+			}
+
+			decodedUrl := string(decoded)
+			if !strings.HasPrefix(decodedUrl, stsUrlToSign) {
+				t.Fatalf("unexpected token: %s, expected sts URL as a prefix: %s", decodedUrl, stsUrlToSign)
+			}
+
+			parsedUrl, err := url.Parse(decodedUrl)
+			if parsedUrl == nil || err != nil {
+				t.Fatalf("unexpected token: %s, expected it to be a valid STS URL", decodedUrl)
+			}
+
+			queryParams := parsedUrl.Query()
+
+			for key, val := range expectedQueryParams {
+				fromUrl, ok := queryParams[key]
+				if !ok {
+					t.Fatalf("token does not contain required query param: %s", key)
+				}
+
+				if len(fromUrl) == 0 {
+					t.Fatalf("expected query param: %s to contain at least one value, but got none", key)
+				}
+
+				if fromUrl[0] != val {
+					t.Fatalf("expected query param: %s to be equal to: %s. actual value: %s", key, val, fromUrl[0])
+				}
+			}
+		}
+	})
+}


### PR DESCRIPTION
This commit introduces an EKS (Amazon Elastic Kubernetes Service)
authentication plugin for the kubernetes go client.

Fixes issue: https://github.com/kubernetes/kubernetes/issues/91251.

EKS takes a unique approach for authenticating a client - instead of
passing a token directly, one passes a short lived STS pre-signed URL.

The cluster then accesses STS using that URL, retrieves the identity
which presigned it, and maps the identity to the aws-creds config map;
the resulted k8s RBAC value is then used to authorize the request.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
This PR adds an EKS auth plugin for the kubernetes go client.
Users may use this plugin in order to authenticate to their existing EKS clusters.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #91251

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
