### PR TITLE
Merge patches to ImagePullSecrets for Service Accounts

### DIFF
--- a/api/api-rules/violation_exceptions.list
+++ b/api/api-rules/violation_exceptions.list
@@ -136,7 +136,6 @@ API rule violation: list_type_missing,k8s.io/api/core/v1,PodSecurityContext,Sysc
 API rule violation: list_type_missing,k8s.io/api/core/v1,PodSpec,Containers
 API rule violation: list_type_missing,k8s.io/api/core/v1,PodSpec,EphemeralContainers
 API rule violation: list_type_missing,k8s.io/api/core/v1,PodSpec,HostAliases
-API rule violation: list_type_missing,k8s.io/api/core/v1,PodSpec,ImagePullSecrets
 API rule violation: list_type_missing,k8s.io/api/core/v1,PodSpec,InitContainers
 API rule violation: list_type_missing,k8s.io/api/core/v1,PodSpec,ReadinessGates
 API rule violation: list_type_missing,k8s.io/api/core/v1,PodSpec,Tolerations
@@ -156,7 +155,6 @@ API rule violation: list_type_missing,k8s.io/api/core/v1,ScopeSelector,MatchExpr
 API rule violation: list_type_missing,k8s.io/api/core/v1,ScopedResourceSelectorRequirement,Values
 API rule violation: list_type_missing,k8s.io/api/core/v1,SecretProjection,Items
 API rule violation: list_type_missing,k8s.io/api/core/v1,SecretVolumeSource,Items
-API rule violation: list_type_missing,k8s.io/api/core/v1,ServiceAccount,ImagePullSecrets
 API rule violation: list_type_missing,k8s.io/api/core/v1,ServiceAccount,Secrets
 API rule violation: list_type_missing,k8s.io/api/core/v1,ServiceSpec,ExternalIPs
 API rule violation: list_type_missing,k8s.io/api/core/v1,ServiceSpec,LoadBalancerSourceRanges

--- a/staging/src/k8s.io/api/core/v1/generated.proto
+++ b/staging/src/k8s.io/api/core/v1/generated.proto
@@ -3508,6 +3508,8 @@ message PodSpec {
   // +optional
   // +patchMergeKey=name
   // +patchStrategy=merge
+  // +listType=map
+  // +listMapKey=name
   repeated LocalObjectReference imagePullSecrets = 15;
 
   // Specifies the hostname of the Pod
@@ -4701,6 +4703,10 @@ message ServiceAccount {
   // can be mounted in the pod, but ImagePullSecrets are only accessed by the kubelet.
   // More info: https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
   // +optional
+  // +patchMergeKey=name
+  // +patchStrategy=merge
+  // +listType=map
+  // +listMapKey=name
   repeated LocalObjectReference imagePullSecrets = 3;
 
   // AutomountServiceAccountToken indicates whether pods running as this service account should have an API token automatically mounted.

--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -3071,6 +3071,8 @@ type PodSpec struct {
 	// +optional
 	// +patchMergeKey=name
 	// +patchStrategy=merge
+	// +listType=map
+	// +listMapKey=name
 	ImagePullSecrets []LocalObjectReference `json:"imagePullSecrets,omitempty" patchStrategy:"merge" patchMergeKey:"name" protobuf:"bytes,15,rep,name=imagePullSecrets"`
 	// Specifies the hostname of the Pod
 	// If not specified, the pod's hostname will be set to a system-defined value.
@@ -4453,7 +4455,11 @@ type ServiceAccount struct {
 	// can be mounted in the pod, but ImagePullSecrets are only accessed by the kubelet.
 	// More info: https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
 	// +optional
-	ImagePullSecrets []LocalObjectReference `json:"imagePullSecrets,omitempty" protobuf:"bytes,3,rep,name=imagePullSecrets"`
+	// +patchMergeKey=name
+	// +patchStrategy=merge
+	// +listType=map
+	// +listMapKey=name
+	ImagePullSecrets []LocalObjectReference `json:"imagePullSecrets,omitempty" patchStrategy:"merge" patchMergeKey:"name" protobuf:"bytes,3,rep,name=imagePullSecrets"`
 
 	// AutomountServiceAccountToken indicates whether pods running as this service account should have an API token automatically mounted.
 	// Can be overridden at the pod level.

--- a/staging/src/k8s.io/client-go/applyconfigurations/internal/internal.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/internal/internal.go
@@ -6086,7 +6086,9 @@ var schemaYAML = typed.YAMLObject(`types:
         list:
           elementType:
             namedType: io.k8s.api.core.v1.LocalObjectReference
-          elementRelationship: atomic
+          elementRelationship: associative
+          keys:
+          - name
     - name: kind
       type:
         scalar: string


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Adds the merge strategy to imagePullSecrets in the ServiceAccount API

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #91250

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
When using `kubectl patch` to update `ServiceAccount` image pull secrets, new pull secrets will be added without replacing the whole array.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
