### PR TITLE
When combining PolicyRules, don't duplicate verbs

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/util/rbac/BUILD
+++ b/staging/src/k8s.io/kubectl/pkg/util/rbac/BUILD
@@ -6,7 +6,10 @@ go_library(
     importmap = "k8s.io/kubernetes/vendor/k8s.io/kubectl/pkg/util/rbac",
     importpath = "k8s.io/kubectl/pkg/util/rbac",
     visibility = ["//visibility:public"],
-    deps = ["//staging/src/k8s.io/api/rbac/v1:go_default_library"],
+    deps = [
+        "//staging/src/k8s.io/api/rbac/v1:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
+    ],
 )
 
 filegroup(

--- a/staging/src/k8s.io/kubectl/pkg/util/rbac/rbac.go
+++ b/staging/src/k8s.io/kubectl/pkg/util/rbac/rbac.go
@@ -18,6 +18,7 @@ package rbac
 
 import (
 	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"reflect"
 	"strings"
 )
@@ -42,7 +43,13 @@ func CompactRules(rules []rbacv1.PolicyRule) ([]rbacv1.PolicyRule, error) {
 				if existingRule.Verbs == nil {
 					existingRule.Verbs = []string{}
 				}
-				existingRule.Verbs = append(existingRule.Verbs, rule.Verbs...)
+				existingVerbs := sets.NewString(existingRule.Verbs...)
+				for _, verb := range rule.Verbs {
+					if !existingVerbs.Has(verb) {
+						existingRule.Verbs = append(existingRule.Verbs, verb)
+					}
+				}
+
 			} else {
 				// Copy the rule to accumulate matching simple resource rules into
 				simpleRules[resource] = rule.DeepCopy()


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:
With this cmd: `kubectl describe clusterroles.rbac view` there are duplicate verbs listed like so:
```
PolicyRule:
  Resources            Non-Resource URLs  Resource Names  Verbs
  ---------            -----------------  --------------  -----
  namespaces           []                 []              [get get list watch]
```
**Which issue(s) this PR fixes**:
This PR only adds unique verbs to list of PolicyRule Resource Verbs

```release-note
NONE
```

/assign @soltysh 