### PR TITLE
Prevent false error message from resource_aliasing integration test

### DIFF
--- a/test/cmd/discovery.sh
+++ b/test/cmd/discovery.sh
@@ -86,12 +86,9 @@ run_resource_aliasing_tests() {
   request="{{range.items}}{{range .metadata.labels}}{{.}}:{{end}}{{end}}"
 
   # all 4 cassandra's might not be in the request immediately...
-  # first option with :: suffix is for possible service.kubernetes.io/headless
+  # :? suffix is for possible service.kubernetes.io/headless
   # label with "" value
-  kube::test::get_object_assert "$object" "$request" 'cassandra:cassandra:cassandra:cassandra::' || \
-  kube::test::get_object_assert "$object" "$request" 'cassandra:cassandra:cassandra:cassandra:' || \
-  kube::test::get_object_assert "$object" "$request" 'cassandra:cassandra:cassandra:' || \
-  kube::test::get_object_assert "$object" "$request" 'cassandra:cassandra:'
+  kube::test::get_object_assert "$object" "$request" '(cassandra:){2}(cassandra:(cassandra::?)?)?'
 
   kubectl delete all -l app=cassandra "${kube_flags[@]}"
 


### PR DESCRIPTION
**What type of PR is this?**
/kind failing-test

**What this PR does / why we need it**:
The `run_resource_aliasing_tests()` integration test mistakenly reports a failure when the test still passes.

This is confusing because when another integration test fails, Prow makes it look like this was the failure (Even on a successful job, if you view the log, it looks like there was an error when there was not)

See here for an example: https://prow.k8s.io/view/gcs/kubernetes-jenkins/pr-logs/pull/91169/pull-kubernetes-integration/1262791220317392896

The failure was actually in TestPreemptionRaces, and it looks like cassandra was the reason it failed, but it was not and in fact the cassandra test passed.
![cassandra-error](https://user-images.githubusercontent.com/4977542/82365310-80bed180-99de-11ea-8d1f-909ea30d9cd4.png)

This PR fixes that test to only display a failure if all of the `||`ed conditions fail (and therefore the test fails).

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs

```
