### PR TITLE
  ingress: Add v1 describers for Ingress and IngressClass

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/describe/describe_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/describe/describe_test.go
@@ -1677,12 +1677,11 @@ func TestDescribeDeployment(t *testing.T) {
 }
 
 func TestDescribeIngress(t *testing.T) {
-	defaultBackend := networkingv1beta1.IngressBackend{
+	backendV1beta1 := networkingv1beta1.IngressBackend{
 		ServiceName: "default-backend",
 		ServicePort: intstr.FromInt(80),
 	}
-
-	fakeClient := fake.NewSimpleClientset(&networkingv1beta1.Ingress{
+	v1beta1 := fake.NewSimpleClientset(&networkingv1beta1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "bar",
 			Namespace: "foo",
@@ -1694,6 +1693,278 @@ func TestDescribeIngress(t *testing.T) {
 					IngressRuleValue: networkingv1beta1.IngressRuleValue{
 						HTTP: &networkingv1beta1.HTTPIngressRuleValue{
 							Paths: []networkingv1beta1.HTTPIngressPath{
+								{
+									Path:    "/foo",
+									Backend: backendV1beta1,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	})
+	backendV1 := networkingv1.IngressBackend{
+		Service: &networkingv1.IngressServiceBackend{
+			Name: "default-backend",
+			Port: networkingv1.ServiceBackendPort{
+				Number: 80,
+			},
+		},
+	}
+
+	netv1 := fake.NewSimpleClientset(&networkingv1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "bar",
+			Namespace: "foo",
+		},
+		Spec: networkingv1.IngressSpec{
+			Rules: []networkingv1.IngressRule{
+				{
+					Host: "foo.bar.com",
+					IngressRuleValue: networkingv1.IngressRuleValue{
+						HTTP: &networkingv1.HTTPIngressRuleValue{
+							Paths: []networkingv1.HTTPIngressPath{
+								{
+									Path:    "/foo",
+									Backend: backendV1,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	})
+
+	backendResource := networkingv1.IngressBackend{
+		Resource: &corev1.TypedLocalObjectReference{
+			APIGroup: utilpointer.StringPtr("example.com"),
+			Kind:     "foo",
+			Name:     "bar",
+		},
+	}
+
+	tests := map[string]struct {
+		input  *fake.Clientset
+		output string
+	}{
+		"IngressRule.HTTP.Paths.Backend.Service v1beta1": {
+			input: v1beta1,
+			output: `Name:             bar
+Namespace:        foo
+Address:          
+Default backend:  default-http-backend:80 (<error: endpoints "default-http-backend" not found>)
+Rules:
+  Host         Path  Backends
+  ----         ----  --------
+  foo.bar.com  
+               /foo   default-backend:80 (<error: endpoints "default-backend" not found>)
+Annotations:   <none>
+Events:        <none>` + "\n",
+		},
+		"IngressRule.HTTP.Paths.Backend.Service v1": {
+			input: netv1,
+			output: `Name:             bar
+Namespace:        foo
+Address:          
+Default backend:  default-http-backend:80 (<error: endpoints "default-http-backend" not found>)
+Rules:
+  Host         Path  Backends
+  ----         ----  --------
+  foo.bar.com  
+               /foo   default-backend:80 (<error: endpoints "default-backend" not found>)
+Annotations:   <none>
+Events:        <none>` + "\n",
+		},
+		"IngressRule.HTTP.Paths.Backend.Resource v1": {
+			input: fake.NewSimpleClientset(&networkingv1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "bar",
+					Namespace: "foo",
+				},
+				Spec: networkingv1.IngressSpec{
+					Rules: []networkingv1.IngressRule{
+						{
+							Host: "foo.bar.com",
+							IngressRuleValue: networkingv1.IngressRuleValue{
+								HTTP: &networkingv1.HTTPIngressRuleValue{
+									Paths: []networkingv1.HTTPIngressPath{
+										{
+											Path:    "/foo",
+											Backend: backendResource,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}),
+			output: `Name:             bar
+Namespace:        foo
+Address:          
+Default backend:  default-http-backend:80 (<error: endpoints "default-http-backend" not found>)
+Rules:
+  Host         Path  Backends
+  ----         ----  --------
+  foo.bar.com  
+               /foo   APIGroup: example.com, Kind: foo, Name: bar
+Annotations:   <none>
+Events:        <none>` + "\n",
+		},
+		"Spec.DefaultBackend.Service & IngressRule.HTTP.Paths.Backend.Service v1": {
+			input: fake.NewSimpleClientset(&networkingv1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "bar",
+					Namespace: "foo",
+				},
+				Spec: networkingv1.IngressSpec{
+					DefaultBackend: &backendV1,
+					Rules: []networkingv1.IngressRule{
+						{
+							Host: "foo.bar.com",
+							IngressRuleValue: networkingv1.IngressRuleValue{
+								HTTP: &networkingv1.HTTPIngressRuleValue{
+									Paths: []networkingv1.HTTPIngressPath{
+										{
+											Path:    "/foo",
+											Backend: backendV1,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}),
+			output: `Name:             bar
+Namespace:        foo
+Address:          
+Default backend:  default-backend:80 (<error: endpoints "default-backend" not found>)
+Rules:
+  Host         Path  Backends
+  ----         ----  --------
+  foo.bar.com  
+               /foo   default-backend:80 (<error: endpoints "default-backend" not found>)
+Annotations:   <none>
+Events:        <none>` + "\n",
+		},
+		"Spec.DefaultBackend.Resource & IngressRule.HTTP.Paths.Backend.Resource v1": {
+			input: fake.NewSimpleClientset(&networkingv1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "bar",
+					Namespace: "foo",
+				},
+				Spec: networkingv1.IngressSpec{
+					DefaultBackend: &backendResource,
+					Rules: []networkingv1.IngressRule{
+						{
+							Host: "foo.bar.com",
+							IngressRuleValue: networkingv1.IngressRuleValue{
+								HTTP: &networkingv1.HTTPIngressRuleValue{
+									Paths: []networkingv1.HTTPIngressPath{
+										{
+											Path:    "/foo",
+											Backend: backendResource,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}),
+			output: `Name:             bar
+Namespace:        foo
+Address:          
+Default backend:  APIGroup: example.com, Kind: foo, Name: bar
+Rules:
+  Host         Path  Backends
+  ----         ----  --------
+  foo.bar.com  
+               /foo   APIGroup: example.com, Kind: foo, Name: bar
+Annotations:   <none>
+Events:        <none>` + "\n",
+		},
+		"Spec.DefaultBackend.Resource & IngressRule.HTTP.Paths.Backend.Service v1": {
+			input: fake.NewSimpleClientset(&networkingv1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "bar",
+					Namespace: "foo",
+				},
+				Spec: networkingv1.IngressSpec{
+					DefaultBackend: &backendResource,
+					Rules: []networkingv1.IngressRule{
+						{
+							Host: "foo.bar.com",
+							IngressRuleValue: networkingv1.IngressRuleValue{
+								HTTP: &networkingv1.HTTPIngressRuleValue{
+									Paths: []networkingv1.HTTPIngressPath{
+										{
+											Path:    "/foo",
+											Backend: backendV1,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}),
+			output: `Name:             bar
+Namespace:        foo
+Address:          
+Default backend:  APIGroup: example.com, Kind: foo, Name: bar
+Rules:
+  Host         Path  Backends
+  ----         ----  --------
+  foo.bar.com  
+               /foo   default-backend:80 (<error: endpoints "default-backend" not found>)
+Annotations:   <none>
+Events:        <none>` + "\n",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			c := &describeClient{T: t, Namespace: "foo", Interface: test.input}
+			i := IngressDescriber{c}
+			out, err := i.Describe("foo", "bar", DescriberSettings{ShowEvents: true})
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if out != test.output {
+				t.Logf(out)
+				t.Logf(test.output)
+				t.Errorf("expected: \n%q\n but got output: \n%q\n", test.output, out)
+			}
+		})
+	}
+}
+
+func TestDescribeIngressV1(t *testing.T) {
+	defaultBackend := networkingv1.IngressBackend{
+		Service: &networkingv1.IngressServiceBackend{
+			Name: "default-backend",
+			Port: networkingv1.ServiceBackendPort{
+				Number: 80,
+			},
+		},
+	}
+
+	fakeClient := fake.NewSimpleClientset(&networkingv1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "bar",
+			Namespace: "foo",
+		},
+		Spec: networkingv1.IngressSpec{
+			Rules: []networkingv1.IngressRule{
+				{
+					Host: "foo.bar.com",
+					IngressRuleValue: networkingv1.IngressRuleValue{
+						HTTP: &networkingv1.HTTPIngressRuleValue{
+							Paths: []networkingv1.HTTPIngressPath{
 								{
 									Path:    "/foo",
 									Backend: defaultBackend,
@@ -3097,27 +3368,6 @@ func TestDescribeResourceQuota(t *testing.T) {
 }
 
 func TestDescribeIngressClass(t *testing.T) {
-	fake := fake.NewSimpleClientset(&networkingv1beta1.IngressClass{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "example-class",
-		},
-		Spec: networkingv1beta1.IngressClassSpec{
-			Controller: "example.com/controller",
-			Parameters: &corev1.TypedLocalObjectReference{
-				APIGroup: utilpointer.StringPtr("v1"),
-				Kind:     "ConfigMap",
-				Name:     "example-parameters",
-			},
-		},
-	})
-
-	c := &describeClient{T: t, Namespace: "foo", Interface: fake}
-	d := IngressClassDescriber{c}
-	out, err := d.Describe("", "example-class", DescriberSettings{})
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
-
 	expectedOut := `Name:         example-class
 Labels:       <none>
 Annotations:  <none>
@@ -3127,9 +3377,57 @@ Parameters:
   Kind:      ConfigMap
   Name:      example-parameters` + "\n"
 
-	if out != expectedOut {
-		t.Logf(out)
-		t.Errorf("expected : %q\n but got output:\n %q", expectedOut, out)
+	tests := map[string]struct {
+		input  *fake.Clientset
+		output string
+	}{
+		"basic IngressClass (v1beta1)": {
+			input: fake.NewSimpleClientset(&networkingv1beta1.IngressClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "example-class",
+				},
+				Spec: networkingv1beta1.IngressClassSpec{
+					Controller: "example.com/controller",
+					Parameters: &corev1.TypedLocalObjectReference{
+						APIGroup: utilpointer.StringPtr("v1"),
+						Kind:     "ConfigMap",
+						Name:     "example-parameters",
+					},
+				},
+			}),
+			output: expectedOut,
+		},
+		"basic IngressClass (v1)": {
+			input: fake.NewSimpleClientset(&networkingv1.IngressClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "example-class",
+				},
+				Spec: networkingv1.IngressClassSpec{
+					Controller: "example.com/controller",
+					Parameters: &corev1.TypedLocalObjectReference{
+						APIGroup: utilpointer.StringPtr("v1"),
+						Kind:     "ConfigMap",
+						Name:     "example-parameters",
+					},
+				},
+			}),
+			output: expectedOut,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			c := &describeClient{T: t, Namespace: "foo", Interface: test.input}
+			d := IngressClassDescriber{c}
+			out, err := d.Describe("", "example-class", DescriberSettings{})
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if out != expectedOut {
+				t.Logf(out)
+				t.Errorf("expected : %q\n but got output:\n %q", test.output, out)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
**What type of PR is this?**
/kind api-change

**What this PR does / why we need it**:
  Ingressv1 Get is attempted for Ingresses and IngressClasses
  and falls back to Ingressv1beta1 if there is a failure.

**Which issue(s) this PR fixes**:
Based on https://github.com/kubernetes/kubernetes/pull/89778

**Special notes for your reviewer**:
- [x] Handle IngressBackend.Resource types appropriately 
- [x] Change describer tests for series of tests with different input/expected cases

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

[Ingress KEP](https://github.com/kubernetes/enhancements/blob/master/keps/sig-network/20190125-ingress-api-group.md)

https://github.com/kubernetes/enhancements/issues/1453