### PR TITLE
Automated cherry pick of #91257: Use staging-csi to work around quay.io availability

### DIFF
--- a/cluster/addons/volumesnapshots/volume-snapshot-controller/volume-snapshot-controller-deployment.yaml
+++ b/cluster/addons/volumesnapshots/volume-snapshot-controller/volume-snapshot-controller-deployment.yaml
@@ -23,7 +23,7 @@ spec:
       containers:
         - name: volume-snapshot-controller
           # TODO(xyang): Replace with an official image when it is released
-          image: quay.io/k8scsi/snapshot-controller:v2.0.0-rc2
+          image: gcr.io/k8s-staging-csi/snapshot-controller:v2.0.0-rc2
           args:
             - "--v=5"
           imagePullPolicy: Always

--- a/test/e2e/testing-manifests/storage-csi/gce-pd/controller_ss.yaml
+++ b/test/e2e/testing-manifests/storage-csi/gce-pd/controller_ss.yaml
@@ -21,7 +21,7 @@ spec:
       serviceAccountName: csi-gce-pd-controller-sa
       containers:
         - name: csi-snapshotter
-          image: quay.io/k8scsi/csi-snapshotter:v2.0.1
+          image: gcr.io/k8s-staging-csi/csi-snapshotter:v2.0.1
           args:
             - "--v=5"
             - "--csi-address=/csi/csi.sock"

--- a/test/e2e/testing-manifests/storage-csi/hostpath/hostpath/csi-hostpath-attacher.yaml
+++ b/test/e2e/testing-manifests/storage-csi/hostpath/hostpath/csi-hostpath-attacher.yaml
@@ -40,7 +40,7 @@ spec:
       serviceAccountName: csi-attacher
       containers:
         - name: csi-attacher
-          image: quay.io/k8scsi/csi-attacher:v2.1.0
+          image: gcr.io/k8s-staging-csi/csi-attacher:v2.2.0
           args:
             - --v=5
             - --csi-address=/csi/csi.sock

--- a/test/e2e/testing-manifests/storage-csi/hostpath/hostpath/csi-hostpath-plugin.yaml
+++ b/test/e2e/testing-manifests/storage-csi/hostpath/hostpath/csi-hostpath-plugin.yaml
@@ -36,7 +36,7 @@ spec:
     spec:
       containers:
         - name: node-driver-registrar
-          image: quay.io/k8scsi/csi-node-driver-registrar:v1.2.0
+          image: gcr.io/k8s-staging-csi/csi-node-driver-registrar:v1.3.0
           lifecycle:
             preStop:
               exec:
@@ -65,7 +65,7 @@ spec:
             name: csi-data-dir
 
         - name: hostpath
-          image: quay.io/k8scsi/hostpathplugin:v1.4.0-rc2
+          image: gcr.io/k8s-staging-csi/hostpathplugin:v1.4.0-rc2
           args:
             - "--drivername=hostpath.csi.k8s.io"
             - "--v=5"
@@ -112,7 +112,7 @@ spec:
           volumeMounts:
           - mountPath: /csi
             name: socket-dir
-          image: quay.io/k8scsi/livenessprobe:v1.1.0
+          image: gcr.io/k8s-staging-csi/livenessprobe:v1.1.0
           args:
           - --csi-address=/csi/csi.sock
           - --connection-timeout=3s

--- a/test/e2e/testing-manifests/storage-csi/hostpath/hostpath/csi-hostpath-provisioner.yaml
+++ b/test/e2e/testing-manifests/storage-csi/hostpath/hostpath/csi-hostpath-provisioner.yaml
@@ -40,7 +40,7 @@ spec:
       serviceAccountName: csi-provisioner
       containers:
         - name: csi-provisioner
-          image: quay.io/k8scsi/csi-provisioner:v1.5.0
+          image: gcr.io/k8s-staging-csi/csi-provisioner:v1.6.0
           args:
             - -v=5
             - --csi-address=/csi/csi.sock

--- a/test/e2e/testing-manifests/storage-csi/hostpath/hostpath/csi-hostpath-resizer.yaml
+++ b/test/e2e/testing-manifests/storage-csi/hostpath/hostpath/csi-hostpath-resizer.yaml
@@ -30,7 +30,7 @@ spec:
       serviceAccountName: csi-resizer
       containers:
         - name: csi-resizer
-          image: quay.io/k8scsi/csi-resizer:v0.4.0
+          image: gcr.io/k8s-staging-csi/csi-resizer:v0.5.0
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"

--- a/test/e2e/testing-manifests/storage-csi/hostpath/hostpath/csi-hostpath-snapshotter.yaml
+++ b/test/e2e/testing-manifests/storage-csi/hostpath/hostpath/csi-hostpath-snapshotter.yaml
@@ -30,7 +30,7 @@ spec:
       serviceAccount: csi-snapshotter
       containers:
       - name: csi-snapshotter
-        image: quay.io/k8scsi/csi-snapshotter:v2.0.0
+        image: gcr.io/k8s-staging-csi/csi-snapshotter:v2.1.0
         args:
         - "--v=5"
         - "--csi-address=$(ADDRESS)"

--- a/test/e2e/testing-manifests/storage-csi/mock/csi-mock-driver-attacher.yaml
+++ b/test/e2e/testing-manifests/storage-csi/mock/csi-mock-driver-attacher.yaml
@@ -15,7 +15,7 @@ spec:
       serviceAccountName: csi-mock
       containers:
         - name: csi-attacher
-          image: quay.io/k8scsi/csi-attacher:v2.1.0
+          image: gcr.io/k8s-staging-csi/csi-attacher:v2.2.0
           args:
             - --v=5
             - --csi-address=$(ADDRESS)

--- a/test/e2e/testing-manifests/storage-csi/mock/csi-mock-driver-resizer.yaml
+++ b/test/e2e/testing-manifests/storage-csi/mock/csi-mock-driver-resizer.yaml
@@ -15,7 +15,7 @@ spec:
       serviceAccountName: csi-mock
       containers:
         - name: csi-resizer
-          image: quay.io/k8scsi/csi-resizer:v0.4.0
+          image: gcr.io/k8s-staging-csi/csi-resizer:v0.4.0
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"

--- a/test/e2e/testing-manifests/storage-csi/mock/csi-mock-driver.yaml
+++ b/test/e2e/testing-manifests/storage-csi/mock/csi-mock-driver.yaml
@@ -15,7 +15,7 @@ spec:
       serviceAccountName: csi-mock
       containers:
         - name: csi-provisioner
-          image: quay.io/k8scsi/csi-provisioner:v1.5.0
+          image: gcr.io/k8s-staging-csi/csi-provisioner:v1.6.0
           args:
             - "--csi-address=$(ADDRESS)"
             - "--connection-timeout=15s"
@@ -26,7 +26,7 @@ spec:
             - mountPath: /csi
               name: socket-dir
         - name: driver-registrar
-          image: quay.io/k8scsi/csi-node-driver-registrar:v1.2.0
+          image: gcr.io/k8s-staging-csi/csi-node-driver-registrar:v1.2.0
           args:
             - --v=5
             - --csi-address=/csi/csi.sock
@@ -45,7 +45,7 @@ spec:
           - mountPath: /registration
             name: registration-dir
         - name: mock
-          image: quay.io/k8scsi/mock-driver:v2.1.0
+          image: gcr.io/k8s-staging-csi/mock-driver:v3.1.0
           args:
             - "--name=mock.storage.k8s.io"
             - "--permissive-target-path" # because of https://github.com/kubernetes/kubernetes/issues/75535

--- a/test/utils/image/manifest.go
+++ b/test/utils/image/manifest.go
@@ -39,7 +39,6 @@ type RegistryList struct {
 	PrivateRegistry         string `yaml:"privateRegistry"`
 	SampleRegistry          string `yaml:"sampleRegistry"`
 	K8sCSI                  string `yaml:"k8sCSI"`
-	QuayIncubator           string `yaml:"quayIncubator"`
 }
 
 // Config holds an images registry, name, and version
@@ -79,7 +78,6 @@ func initReg() RegistryList {
 		PrivateRegistry:         "gcr.io/k8s-authenticated-test",
 		SampleRegistry:          "gcr.io/google-samples",
 		K8sCSI:                  "gcr.io/k8s-staging-csi",
-		QuayIncubator:           "quay.io/kubernetes_incubator",
 	}
 	repoList := os.Getenv("KUBE_TEST_REPO_LIST")
 	if repoList == "" {
@@ -110,7 +108,6 @@ var (
 	googleContainerRegistry = registry.GoogleContainerRegistry
 	invalidRegistry         = registry.InvalidRegistry
 	k8sCSI                  = registry.K8sCSI
-	quayIncubator           = registry.QuayIncubator
 	// PrivateRegistry is an image repository that requires authentication
 	PrivateRegistry = registry.PrivateRegistry
 	sampleRegistry  = registry.SampleRegistry
@@ -227,7 +224,7 @@ func initImageConfigs() map[int]Config {
 	configs[Mounttest] = Config{e2eRegistry, "mounttest", "1.0"}
 	configs[MounttestUser] = Config{e2eRegistry, "mounttest-user", "1.0"}
 	configs[Nautilus] = Config{e2eRegistry, "nautilus", "1.0"}
-	configs[NFSProvisioner] = Config{quayIncubator, "nfs-provisioner", "v2.2.2"}
+	configs[NFSProvisioner] = Config{k8sCSI, "nfs-provisioner", "v2.2.2"}
 	configs[Nginx] = Config{dockerLibraryRegistry, "nginx", "1.14-alpine"}
 	configs[NginxNew] = Config{dockerLibraryRegistry, "nginx", "1.15-alpine"}
 	configs[Nonewprivs] = Config{e2eRegistry, "nonewprivs", "1.0"}

--- a/test/utils/image/manifest.go
+++ b/test/utils/image/manifest.go
@@ -38,7 +38,7 @@ type RegistryList struct {
 	GoogleContainerRegistry string `yaml:"googleContainerRegistry"`
 	PrivateRegistry         string `yaml:"privateRegistry"`
 	SampleRegistry          string `yaml:"sampleRegistry"`
-	QuayK8sCSI              string `yaml:"quayK8sCSI"`
+	K8sCSI                  string `yaml:"k8sCSI"`
 	QuayIncubator           string `yaml:"quayIncubator"`
 }
 
@@ -78,7 +78,7 @@ func initReg() RegistryList {
 		GoogleContainerRegistry: "gcr.io/google-containers",
 		PrivateRegistry:         "gcr.io/k8s-authenticated-test",
 		SampleRegistry:          "gcr.io/google-samples",
-		QuayK8sCSI:              "quay.io/k8scsi",
+		K8sCSI:                  "gcr.io/k8s-staging-csi",
 		QuayIncubator:           "quay.io/kubernetes_incubator",
 	}
 	repoList := os.Getenv("KUBE_TEST_REPO_LIST")
@@ -109,7 +109,7 @@ var (
 	gcrReleaseRegistry      = registry.GcrReleaseRegistry
 	googleContainerRegistry = registry.GoogleContainerRegistry
 	invalidRegistry         = registry.InvalidRegistry
-	quayK8sCSI              = registry.QuayK8sCSI
+	k8sCSI                  = registry.K8sCSI
 	quayIncubator           = registry.QuayIncubator
 	// PrivateRegistry is an image repository that requires authentication
 	PrivateRegistry = registry.PrivateRegistry
@@ -293,8 +293,8 @@ func ReplaceRegistryInImageURL(imageURL string) (string, error) {
 		registryAndUser = gcrReleaseRegistry
 	case "docker.io/library":
 		registryAndUser = dockerLibraryRegistry
-	case "quay.io/k8scsi":
-		registryAndUser = quayK8sCSI
+	case "gcr.io/k8s-staging-csi":
+		registryAndUser = k8sCSI
 	default:
 		if countParts == 1 {
 			// We assume we found an image from docker hub library

--- a/test/utils/image/manifest_test.go
+++ b/test/utils/image/manifest_test.go
@@ -87,9 +87,9 @@ var registryTests = []struct {
 		},
 	},
 	{
-		"quay.io/k8scsi/test:latest",
+		"gcr.io/k8s-staging-csi/test:latest",
 		result{
-			result: "test.io/k8scsi/test:latest",
+			result: "test.io/k8s-staging-csi/test:latest",
 			err:    nil,
 		},
 	},
@@ -111,7 +111,7 @@ func TestReplaceRegistryInImageURL(t *testing.T) {
 	gcrReleaseRegistry = "test.io/gke-release"
 	PrivateRegistry = "test.io/k8s-authenticated-test"
 	sampleRegistry = "test.io/google-samples"
-	quayK8sCSI = "test.io/k8scsi"
+	k8sCSI = "test.io/k8s-staging-csi"
 
 	for _, tt := range registryTests {
 		t.Run(tt.in, func(t *testing.T) {


### PR DESCRIPTION
Cherry pick of #91257 on release-1.18.

#91257: Use staging-csi to work around quay.io availability

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.