### PR TITLE
cri-api: Introduce errors package for the CRI

### DIFF
--- a/staging/src/k8s.io/cri-api/BUILD
+++ b/staging/src/k8s.io/cri-api/BUILD
@@ -10,6 +10,7 @@ filegroup(
     srcs = [
         ":package-srcs",
         "//staging/src/k8s.io/cri-api/pkg/apis:all-srcs",
+        "//staging/src/k8s.io/cri-api/pkg/errors:all-srcs",
     ],
     tags = ["automanaged"],
     visibility = ["//visibility:public"],

--- a/staging/src/k8s.io/cri-api/pkg/errors/BUILD
+++ b/staging/src/k8s.io/cri-api/pkg/errors/BUILD
@@ -1,0 +1,40 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "doc.go",
+        "errors.go",
+    ],
+    importmap = "k8s.io/kubernetes/vendor/k8s.io/cri-api/pkg/errors",
+    importpath = "k8s.io/cri-api/pkg/errors",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//vendor/google.golang.org/grpc/codes:go_default_library",
+        "//vendor/google.golang.org/grpc/status:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["errors_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//vendor/google.golang.org/grpc/codes:go_default_library",
+        "//vendor/google.golang.org/grpc/status:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/staging/src/k8s.io/cri-api/pkg/errors/doc.go
+++ b/staging/src/k8s.io/cri-api/pkg/errors/doc.go
@@ -1,0 +1,19 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package errors provides helper functions for use by the kubelet
+// to deal with CRI errors.
+package errors // import "k8s.io/cri-api/pkg/errors"

--- a/staging/src/k8s.io/cri-api/pkg/errors/errors.go
+++ b/staging/src/k8s.io/cri-api/pkg/errors/errors.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package errors
+
+import (
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// IsNotFound returns a boolean indicating whether the error
+// is grpc not found error.
+// See https://github.com/grpc/grpc/blob/master/doc/statuscodes.md
+// for a list of grpc status codes.
+func IsNotFound(err error) bool {
+	s, ok := status.FromError(err)
+	if !ok {
+		return ok
+	}
+	if s.Code() == codes.NotFound {
+		return true
+	}
+
+	return false
+}

--- a/staging/src/k8s.io/cri-api/pkg/errors/errors_test.go
+++ b/staging/src/k8s.io/cri-api/pkg/errors/errors_test.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package errors
+
+import (
+	"fmt"
+	"testing"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestErrorIsNotFound(t *testing.T) {
+	enf := status.Errorf(codes.NotFound, "container not found")
+	if !IsNotFound(enf) {
+		t.Errorf("%v expected to pass not found check", enf)
+	}
+}
+
+func TestSimpleErrorDoesNotTriggerNotFound(t *testing.T) {
+	err := fmt.Errorf("Some random error")
+	if IsNotFound(err) {
+		t.Errorf("%v unexpectedly passed not found check", err)
+	}
+}
+
+func TestOtherGrpcErrorDoesNotTriggerNotFound(t *testing.T) {
+	gerr := status.Errorf(codes.DeadlineExceeded, "timed out")
+	if IsNotFound(gerr) {
+		t.Errorf("%v unexpectedly passed not found check", gerr)
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:
We start by adding a helper function for IsNotFound errors.
The expectation is that CRI implementations return
the grcp not found status code for situations where
they can't find a container or a pod. This is the lowest
hanging fruit to start improving the kubelet to detect
such conditions and react better.

**Which issue(s) this PR fixes**:
None

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs
[KEP]: https://github.com/kubernetes/enhancements/pull/1654 
```
cc: @derekwaynecarr @dchen1107 
