### PR TITLE
Update kubeadm test TestMarkControlPlane

### DIFF
--- a/cmd/kubeadm/app/phases/markcontrolplane/BUILD
+++ b/cmd/kubeadm/app/phases/markcontrolplane/BUILD
@@ -12,7 +12,6 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//cmd/kubeadm/app/constants:go_default_library",
-        "//cmd/kubeadm/app/util:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes:go_default_library",

--- a/cmd/kubeadm/app/phases/markcontrolplane/markcontrolplane_test.go
+++ b/cmd/kubeadm/app/phases/markcontrolplane/markcontrolplane_test.go
@@ -19,17 +19,15 @@ package markcontrolplane
 import (
 	"bytes"
 	"encoding/json"
-	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"
 	restclient "k8s.io/client-go/rest"
 	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
-	kubeadmutil "k8s.io/kubernetes/cmd/kubeadm/app/util"
 )
 
 func TestMarkControlPlane(t *testing.T) {
@@ -46,77 +44,74 @@ func TestMarkControlPlane(t *testing.T) {
 		expectedPatch  string
 	}{
 		{
-			"control-plane label and taint missing",
-			"",
-			nil,
-			[]v1.Taint{kubeadmconstants.ControlPlaneTaint},
-			"{\"metadata\":{\"labels\":{\"node-role.kubernetes.io/master\":\"\"}},\"spec\":{\"taints\":[{\"effect\":\"NoSchedule\",\"key\":\"node-role.kubernetes.io/master\"}]}}",
+			name:           "control-plane label and taint missing",
+			existingLabel:  "",
+			existingTaints: nil,
+			newTaints:      []v1.Taint{kubeadmconstants.ControlPlaneTaint},
+			expectedPatch:  `{"metadata":{"labels":{"node-role.kubernetes.io/master":""}},"spec":{"taints":[{"effect":"NoSchedule","key":"node-role.kubernetes.io/master"}]}}`,
 		},
 		{
-			"control-plane label and taint missing but taint not wanted",
-			"",
-			nil,
-			nil,
-			"{\"metadata\":{\"labels\":{\"node-role.kubernetes.io/master\":\"\"}}}",
+			name:           "control-plane label and taint missing but taint not wanted",
+			existingLabel:  "",
+			existingTaints: nil,
+			newTaints:      nil,
+			expectedPatch:  `{"metadata":{"labels":{"node-role.kubernetes.io/master":""}}}`,
 		},
 		{
-			"control-plane label missing",
-			"",
-			[]v1.Taint{kubeadmconstants.ControlPlaneTaint},
-			[]v1.Taint{kubeadmconstants.ControlPlaneTaint},
-			"{\"metadata\":{\"labels\":{\"node-role.kubernetes.io/master\":\"\"}}}",
+			name:           "control-plane label missing",
+			existingLabel:  "",
+			existingTaints: []v1.Taint{kubeadmconstants.ControlPlaneTaint},
+			newTaints:      []v1.Taint{kubeadmconstants.ControlPlaneTaint},
+			expectedPatch:  `{"metadata":{"labels":{"node-role.kubernetes.io/master":""}}}`,
 		},
 		{
-			"control-plane taint missing",
-			kubeadmconstants.LabelNodeRoleMaster,
-			nil,
-			[]v1.Taint{kubeadmconstants.ControlPlaneTaint},
-			"{\"spec\":{\"taints\":[{\"effect\":\"NoSchedule\",\"key\":\"node-role.kubernetes.io/master\"}]}}",
+			name:           "control-plane taint missing",
+			existingLabel:  kubeadmconstants.LabelNodeRoleMaster,
+			existingTaints: nil,
+			newTaints:      []v1.Taint{kubeadmconstants.ControlPlaneTaint},
+			expectedPatch:  `{"spec":{"taints":[{"effect":"NoSchedule","key":"node-role.kubernetes.io/master"}]}}`,
 		},
 		{
-			"nothing missing",
-			kubeadmconstants.LabelNodeRoleMaster,
-			[]v1.Taint{kubeadmconstants.ControlPlaneTaint},
-			[]v1.Taint{kubeadmconstants.ControlPlaneTaint},
-			"{}",
+			name:           "nothing missing",
+			existingLabel:  kubeadmconstants.LabelNodeRoleMaster,
+			existingTaints: []v1.Taint{kubeadmconstants.ControlPlaneTaint},
+			newTaints:      []v1.Taint{kubeadmconstants.ControlPlaneTaint},
+			expectedPatch:  `{}`,
 		},
 		{
-			"has taint and no new taints wanted",
-			kubeadmconstants.LabelNodeRoleMaster,
-			[]v1.Taint{
+			name:          "has taint and no new taints wanted",
+			existingLabel: kubeadmconstants.LabelNodeRoleMaster,
+			existingTaints: []v1.Taint{
 				{
 					Key:    "node.cloudprovider.kubernetes.io/uninitialized",
 					Effect: v1.TaintEffectNoSchedule,
 				},
 			},
-			nil,
-			"{}",
+			newTaints:     nil,
+			expectedPatch: `{}`,
 		},
 		{
-			"has taint and should merge with wanted taint",
-			kubeadmconstants.LabelNodeRoleMaster,
-			[]v1.Taint{
+			name:          "has taint and should merge with wanted taint",
+			existingLabel: kubeadmconstants.LabelNodeRoleMaster,
+			existingTaints: []v1.Taint{
 				{
 					Key:    "node.cloudprovider.kubernetes.io/uninitialized",
 					Effect: v1.TaintEffectNoSchedule,
 				},
 			},
-			[]v1.Taint{kubeadmconstants.ControlPlaneTaint},
-			"{\"spec\":{\"taints\":[{\"effect\":\"NoSchedule\",\"key\":\"node-role.kubernetes.io/master\"},{\"effect\":\"NoSchedule\",\"key\":\"node.cloudprovider.kubernetes.io/uninitialized\"}]}}",
+			newTaints:     []v1.Taint{kubeadmconstants.ControlPlaneTaint},
+			expectedPatch: `{"spec":{"taints":[{"effect":"NoSchedule","key":"node-role.kubernetes.io/master"},{"effect":"NoSchedule","key":"node.cloudprovider.kubernetes.io/uninitialized"}]}}`,
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			hostname, err := kubeadmutil.GetHostname("")
-			if err != nil {
-				t.Fatalf("MarkControlPlane(%s): unexpected error: %v", tc.name, err)
-			}
+			nodename := "node01"
 			controlPlaneNode := &v1.Node{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: hostname,
+					Name: nodename,
 					Labels: map[string]string{
-						v1.LabelHostname: hostname,
+						v1.LabelHostname: nodename,
 					},
 				},
 			}
@@ -131,15 +126,15 @@ func TestMarkControlPlane(t *testing.T) {
 
 			jsonNode, err := json.Marshal(controlPlaneNode)
 			if err != nil {
-				t.Fatalf("MarkControlPlane(%s): unexpected encoding error: %v", tc.name, err)
+				t.Fatalf("unexpected encoding error: %v", err)
 			}
 
 			var patchRequest string
 			s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
 
-				if req.URL.Path != "/api/v1/nodes/"+hostname {
-					t.Errorf("MarkControlPlane(%s): request for unexpected HTTP resource: %v", tc.name, req.URL.Path)
+				if req.URL.Path != "/api/v1/nodes/"+nodename {
+					t.Errorf("request for unexpected HTTP resource: %v", req.URL.Path)
 					http.Error(w, "", http.StatusNotFound)
 					return
 				}
@@ -147,9 +142,11 @@ func TestMarkControlPlane(t *testing.T) {
 				switch req.Method {
 				case "GET":
 				case "PATCH":
-					patchRequest = toString(req.Body)
+					buf := new(bytes.Buffer)
+					buf.ReadFrom(req.Body)
+					patchRequest = buf.String()
 				default:
-					t.Errorf("MarkControlPlane(%s): request for unexpected HTTP verb: %v", tc.name, req.Method)
+					t.Errorf("request for unexpected HTTP verb: %v", req.Method)
 					http.Error(w, "", http.StatusNotFound)
 					return
 				}
@@ -161,22 +158,16 @@ func TestMarkControlPlane(t *testing.T) {
 
 			cs, err := clientset.NewForConfig(&restclient.Config{Host: s.URL})
 			if err != nil {
-				t.Fatalf("MarkControlPlane(%s): unexpected error building clientset: %v", tc.name, err)
+				t.Fatalf("unexpected error building clientset: %v", err)
 			}
 
-			if err := MarkControlPlane(cs, hostname, tc.newTaints); err != nil {
-				t.Errorf("MarkControlPlane(%s) returned unexpected error: %v", tc.name, err)
+			if err := MarkControlPlane(cs, nodename, tc.newTaints); err != nil {
+				t.Errorf("unexpected error: %v", err)
 			}
 
 			if tc.expectedPatch != patchRequest {
-				t.Errorf("MarkControlPlane(%s) wanted patch %v, got %v", tc.name, tc.expectedPatch, patchRequest)
+				t.Errorf("unexpected error: wanted patch %v, got %v", tc.expectedPatch, patchRequest)
 			}
 		})
 	}
-}
-
-func toString(r io.Reader) string {
-	buf := new(bytes.Buffer)
-	buf.ReadFrom(r)
-	return buf.String()
 }


### PR DESCRIPTION
- Use a dummy nodename instead of OS hostname
- Inline toString() function
- Use backticks to wrap expected patch
- Remove redundant test name from error logs

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Improves the kubeadm test TestMarkControlPlane by applying the feedback received on another similar test

**Special notes for your reviewer**:
Most of these changes are based on the feedback from https://github.com/kubernetes/kubernetes/pull/91158

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

/sig cluster-lifecycle
/priority backlog