### PR TITLE
Update to set pod lastTransitionTime when condition transitioned from…

### DIFF
--- a/pkg/kubelet/status/status_manager.go
+++ b/pkg/kubelet/status/status_manager.go
@@ -725,9 +725,16 @@ func mergePodStatus(oldPodStatus, newPodStatus v1.PodStatus) v1.PodStatus {
 		}
 	}
 
-	for _, c := range newPodStatus.Conditions {
-		if kubetypes.PodConditionByKubelet(c.Type) {
-			podConditions = append(podConditions, c)
+	for _, newConditions := range newPodStatus.Conditions {
+		if kubetypes.PodConditionByKubelet(newConditions.Type) {
+			for _, oldConditions := range oldPodStatus.Conditions {
+				// // Need to update LastTransitionTime.
+				if oldConditions.Type == newConditions.Type && oldConditions.Status != newConditions.Status {
+					newConditions.LastTransitionTime = metav1.Now()
+					continue
+				}
+			}
+			podConditions = append(podConditions, newConditions)
 		}
 	}
 	newPodStatus.Conditions = podConditions


### PR DESCRIPTION
**What type of PR is this?**

> /kind cleanup
> /kind bug

**What this PR does / why we need it**:
Update to set pod lastTransitionTime when condition transitioned from one status to another.

**Which issue(s) this PR fixes**:
Update to set pod lastTransitionTime when condition transitioned from one status to another.
Now even though the status changes, the time of the lastTransitionTime field does not change
![image](https://user-images.githubusercontent.com/23489782/82427677-fe0c4400-9abb-11ea-872d-d693553b8d7c.png)


**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
