### PR TITLE
remove '-f' to compatible with low version xfs_quota

### DIFF
--- a/pkg/volume/util/fsquota/BUILD
+++ b/pkg/volume/util/fsquota/BUILD
@@ -45,6 +45,7 @@ go_test(
             "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
             "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",
             "//staging/src/k8s.io/component-base/featuregate/testing:go_default_library",
+            "//vendor/golang.org/x/sys/unix:go_default_library",
             "//vendor/k8s.io/utils/mount:go_default_library",
         ],
         "@io_bazel_rules_go//go/platform:linux": [
@@ -54,6 +55,7 @@ go_test(
             "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
             "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",
             "//staging/src/k8s.io/component-base/featuregate/testing:go_default_library",
+            "//vendor/golang.org/x/sys/unix:go_default_library",
             "//vendor/k8s.io/utils/mount:go_default_library",
         ],
         "//conditions:default": [],

--- a/pkg/volume/util/fsquota/common/BUILD
+++ b/pkg/volume/util/fsquota/common/BUILD
@@ -10,9 +10,11 @@ go_library(
     visibility = ["//visibility:public"],
     deps = select({
         "@io_bazel_rules_go//go/platform:android": [
+            "//vendor/golang.org/x/sys/unix:go_default_library",
             "//vendor/k8s.io/klog/v2:go_default_library",
         ],
         "@io_bazel_rules_go//go/platform:linux": [
+            "//vendor/golang.org/x/sys/unix:go_default_library",
             "//vendor/k8s.io/klog/v2:go_default_library",
         ],
         "//conditions:default": [],

--- a/pkg/volume/util/fsquota/common/quota_linux_common.go
+++ b/pkg/volume/util/fsquota/common/quota_linux_common.go
@@ -59,7 +59,7 @@ type LinuxVolumeQuotaProvider interface {
 	// GetQuotaApplier retrieves an object that can apply
 	// quotas (or nil if this provider cannot support quotas
 	// on the device)
-	GetQuotaApplier(mountpoint string, backingDev string) LinuxVolumeQuotaApplier
+	GetQuotaApplier(mountpoint string, fsTypeMagic int64) LinuxVolumeQuotaApplier
 }
 
 // LinuxVolumeQuotaApplier is a generic interface to any quota


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
```
May 20 17:34:51 kubelet[53872]: I0520 17:34:51.578395   53872 quota_linux_common_impl.go:129] runXFSQuotaCommand /usr/sbin/xfs_quota -t /tmp/mounts384265801 -P/dev/null -D/dev/null -x -f /var/lib/kubelet -c state -p
```
## CentOS Linux release 7.6.1810
```
xfs_quota -V
xfs_quota version 4.5.0
```
```
xfs_quota -x -f /var/lib/kubelet -c 'state -p'
xfs_quota: invalid option -- 'f'
Usage: xfs_quota [-V] [-x] [-p prog] [-c cmd]... [-d project]... [path]
```
```
xfs_quota -x /var/lib/kubelet -c 'state -p'
Project quota state on /var/lib/kubelet (/dev/vdb)
  Accounting: ON
  Enforcement: ON
  Inode: #170 (1 blocks, 1 extents)
Blocks grace time: [7 days 00:00:30]
Inodes grace time: [7 days 00:00:30]
Realtime Blocks grace time: [7 days 00:00:30]
```
## Ubuntu 18.04
```
xfs_quota -V
xfs_quota version 4.9.0
```
```
xfs_quota -x -f /var/lib/kubelet -c 'state -p'
Project quota state on /var/lib/kubelet (/dev/vdb)
  Accounting: ON
  Enforcement: ON
  Inode: #141 (2 blocks, 2 extents)
Blocks grace time: [7 days]
Inodes grace time: [7 days]
Realtime Blocks grace time: [7 days]
```
```
xfs_quota -x /var/lib/kubelet -c 'state -p'
Project quota state on /var/lib/kubelet (/dev/vdb)
  Accounting: ON
  Enforcement: ON
  Inode: #141 (2 blocks, 2 extents)
Blocks grace time: [7 days]
Inodes grace time: [7 days]
Realtime Blocks grace time: [7 days]
```
so we should remove '-f' to compatible with low version xfs_quota.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #91288 

**Special notes for your reviewer**:
@RobertKrawitz 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
