### PR TITLE
Seccomp GA - Deprecate SeccompProfileRuntimeDefault

### DIFF
--- a/pkg/apis/core/annotation_key_constants.go
+++ b/pkg/apis/core/annotation_key_constants.go
@@ -45,11 +45,14 @@ const (
 	// to one container of a pod.
 	SeccompContainerAnnotationKeyPrefix string = "container.seccomp.security.alpha.kubernetes.io/"
 
-	// SeccompProfileRuntimeDefault represents the default seccomp profile used by container runtime.
-	SeccompProfileRuntimeDefault string = "runtime/default"
+	// DeprecatedSeccompProfileRuntimeDefault represents the default seccomp profile used by container runtime.
+	// Seccomp annotations are now deprecated.
+	// This should be replaced by setting SeccompProfileRuntimeDefault on SeccompProfile.SeccompProfileType.
+	DeprecatedSeccompProfileRuntimeDefault string = "runtime/default"
 
 	// DeprecatedSeccompProfileDockerDefault represents the default seccomp profile used by docker.
-	// This is now deprecated and should be replaced by SeccompProfileRuntimeDefault.
+	// Seccomp annotations are now deprecated.
+	// This should be replaced by setting SeccompProfileRuntimeDefault on SeccompProfile.SeccompProfileType.
 	DeprecatedSeccompProfileDockerDefault string = "docker/default"
 
 	// PreferAvoidPodsAnnotationKey represents the key of preferAvoidPods data (json serialized)

--- a/pkg/apis/core/validation/validation.go
+++ b/pkg/apis/core/validation/validation.go
@@ -3551,7 +3551,7 @@ func validatePodAffinity(podAffinity *core.PodAffinity, fldPath *field.Path) fie
 }
 
 func ValidateSeccompProfile(p string, fldPath *field.Path) field.ErrorList {
-	if p == core.SeccompProfileRuntimeDefault || p == core.DeprecatedSeccompProfileDockerDefault {
+	if p == core.DeprecatedSeccompProfileRuntimeDefault || p == core.DeprecatedSeccompProfileDockerDefault {
 		return nil
 	}
 	if p == "unconfined" {

--- a/pkg/apis/core/validation/validation_test.go
+++ b/pkg/apis/core/validation/validation_test.go
@@ -7242,7 +7242,7 @@ func TestValidatePod(t *testing.T) {
 				Name:      "123",
 				Namespace: "ns",
 				Annotations: map[string]string{
-					core.SeccompPodAnnotationKey: core.SeccompProfileRuntimeDefault,
+					core.SeccompPodAnnotationKey: core.DeprecatedSeccompProfileRuntimeDefault,
 				},
 			},
 			Spec: validPodSpec(nil),

--- a/pkg/apis/policy/validation/validation_test.go
+++ b/pkg/apis/policy/validation/validation_test.go
@@ -254,7 +254,7 @@ func TestValidatePodSecurityPolicy(t *testing.T) {
 	}
 	invalidSeccompAllowed := validPSP()
 	invalidSeccompAllowed.Annotations = map[string]string{
-		seccomp.AllowedProfilesAnnotationKey: api.SeccompProfileRuntimeDefault + ",not-good",
+		seccomp.AllowedProfilesAnnotationKey: api.DeprecatedSeccompProfileRuntimeDefault + ",not-good",
 	}
 
 	invalidAllowedHostPathMissingPath := validPSP()
@@ -533,8 +533,8 @@ func TestValidatePodSecurityPolicy(t *testing.T) {
 
 	validSeccomp := validPSP()
 	validSeccomp.Annotations = map[string]string{
-		seccomp.DefaultProfileAnnotationKey:  api.SeccompProfileRuntimeDefault,
-		seccomp.AllowedProfilesAnnotationKey: api.SeccompProfileRuntimeDefault + ",unconfined,localhost/foo,*",
+		seccomp.DefaultProfileAnnotationKey:  api.DeprecatedSeccompProfileRuntimeDefault,
+		seccomp.AllowedProfilesAnnotationKey: api.DeprecatedSeccompProfileRuntimeDefault + ",unconfined,localhost/foo,*",
 	}
 
 	validDefaultAllowPrivilegeEscalation := validPSP()

--- a/pkg/kubelet/dockershim/helpers_linux.go
+++ b/pkg/kubelet/dockershim/helpers_linux.go
@@ -54,7 +54,7 @@ func getSeccompDockerOpts(seccompProfile string) ([]dockerOpt, error) {
 		return defaultSeccompOpt, nil
 	}
 
-	if seccompProfile == v1.SeccompProfileRuntimeDefault || seccompProfile == v1.DeprecatedSeccompProfileDockerDefault {
+	if seccompProfile == v1.DeprecatedSeccompProfileRuntimeDefault || seccompProfile == v1.DeprecatedSeccompProfileDockerDefault {
 		// return nil so docker will load the default seccomp profile
 		return nil, nil
 	}

--- a/pkg/kubelet/dockershim/helpers_linux_test.go
+++ b/pkg/kubelet/dockershim/helpers_linux_test.go
@@ -45,7 +45,7 @@ func TestGetSeccompSecurityOpts(t *testing.T) {
 		expectedOpts:   []string{"seccomp=unconfined"},
 	}, {
 		msg:            "Seccomp default",
-		seccompProfile: v1.SeccompProfileRuntimeDefault,
+		seccompProfile: v1.DeprecatedSeccompProfileRuntimeDefault,
 		expectedOpts:   nil,
 	}, {
 		msg:            "Seccomp deprecated default",

--- a/pkg/kubelet/kuberuntime/helpers_test.go
+++ b/pkg/kubelet/kuberuntime/helpers_test.go
@@ -191,9 +191,9 @@ func TestGetSeccompProfileFromAnnotations(t *testing.T) {
 		{
 			description: "pod runtime/default seccomp profile should return runtime/default",
 			annotation: map[string]string{
-				v1.SeccompPodAnnotationKey: v1.SeccompProfileRuntimeDefault,
+				v1.SeccompPodAnnotationKey: v1.DeprecatedSeccompProfileRuntimeDefault,
 			},
-			expectedProfile: v1.SeccompProfileRuntimeDefault,
+			expectedProfile: v1.DeprecatedSeccompProfileRuntimeDefault,
 		},
 		{
 			description: "pod docker/default seccomp profile should return docker/default",
@@ -205,10 +205,10 @@ func TestGetSeccompProfileFromAnnotations(t *testing.T) {
 		{
 			description: "pod runtime/default seccomp profile with containerName should return runtime/default",
 			annotation: map[string]string{
-				v1.SeccompPodAnnotationKey: v1.SeccompProfileRuntimeDefault,
+				v1.SeccompPodAnnotationKey: v1.DeprecatedSeccompProfileRuntimeDefault,
 			},
 			containerName:   "container1",
-			expectedProfile: v1.SeccompProfileRuntimeDefault,
+			expectedProfile: v1.DeprecatedSeccompProfileRuntimeDefault,
 		},
 		{
 			description: "pod docker/default seccomp profile with containerName should return docker/default",

--- a/staging/src/k8s.io/api/core/v1/annotation_key_constants.go
+++ b/staging/src/k8s.io/api/core/v1/annotation_key_constants.go
@@ -45,8 +45,10 @@ const (
 	// to one container of a pod.
 	SeccompContainerAnnotationKeyPrefix string = "container.seccomp.security.alpha.kubernetes.io/"
 
-	// SeccompProfileRuntimeDefault represents the default seccomp profile used by container runtime.
-	SeccompProfileRuntimeDefault string = "runtime/default"
+	// DeprecatedSeccompProfileRuntimeDefault represents the default seccomp profile used by container runtime.
+	// Seccomp annotations are now deprecated.
+	// This should be replaced by setting SeccompProfileRuntimeDefault on SeccompProfile.SeccompProfileType.
+	DeprecatedSeccompProfileRuntimeDefault string = "runtime/default"
 
 	// AppArmorBetaContainerAnnotationKeyPrefix is the prefix to an annotation key specifying a container's apparmor profile.
 	AppArmorBetaContainerAnnotationKeyPrefix = "container.apparmor.security.beta.kubernetes.io/"
@@ -65,7 +67,8 @@ const (
 	AppArmorBetaProfileNameUnconfined = "unconfined"
 
 	// DeprecatedSeccompProfileDockerDefault represents the default seccomp profile used by docker.
-	// This is now deprecated and should be replaced by SeccompProfileRuntimeDefault.
+	// Seccomp annotations are now deprecated.
+	// This should be replaced by setting SeccompProfileRuntimeDefault on SeccompProfile.SeccompProfileType.
 	DeprecatedSeccompProfileDockerDefault string = "docker/default"
 
 	// PreferAvoidPodsAnnotationKey represents the key of preferAvoidPods data (json serialized)

--- a/test/e2e/auth/pod_security_policy.go
+++ b/test/e2e/auth/pod_security_policy.go
@@ -255,7 +255,7 @@ func restrictedPod(name string) *v1.Pod {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
 			Annotations: map[string]string{
-				v1.SeccompPodAnnotationKey:                            v1.SeccompProfileRuntimeDefault,
+				v1.SeccompPodAnnotationKey:                            v1.DeprecatedSeccompProfileRuntimeDefault,
 				v1.AppArmorBetaContainerAnnotationKeyPrefix + "pause": v1.AppArmorBetaProfileRuntimeDefault,
 			},
 		},
@@ -315,8 +315,8 @@ func restrictedPSP(name string) *policyv1beta1.PodSecurityPolicy {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
 			Annotations: map[string]string{
-				seccomp.AllowedProfilesAnnotationKey:        v1.SeccompProfileRuntimeDefault,
-				seccomp.DefaultProfileAnnotationKey:         v1.SeccompProfileRuntimeDefault,
+				seccomp.AllowedProfilesAnnotationKey:        v1.DeprecatedSeccompProfileRuntimeDefault,
+				seccomp.DefaultProfileAnnotationKey:         v1.DeprecatedSeccompProfileRuntimeDefault,
 				v1.AppArmorBetaAllowedProfilesAnnotationKey: v1.AppArmorBetaProfileRuntimeDefault,
 				v1.AppArmorBetaDefaultProfileAnnotationKey:  v1.AppArmorBetaProfileRuntimeDefault,
 			},

--- a/test/e2e/node/security_context.go
+++ b/test/e2e/node/security_context.go
@@ -150,7 +150,7 @@ var _ = SIGDescribe("Security Context", func() {
 		// TODO: port to SecurityContext as soon as seccomp is out of alpha
 		pod := scTestPod(false, false)
 		pod.Annotations[v1.SeccompContainerAnnotationKeyPrefix+"test-container"] = "unconfined"
-		pod.Annotations[v1.SeccompPodAnnotationKey] = v1.SeccompProfileRuntimeDefault
+		pod.Annotations[v1.SeccompPodAnnotationKey] = v1.DeprecatedSeccompProfileRuntimeDefault
 		pod.Spec.Containers[0].Command = []string{"grep", "ecc", "/proc/self/status"}
 		f.TestContainerOutput(v1.SeccompPodAnnotationKey, pod, 0, []string{"0"}) // seccomp disabled
 	})
@@ -166,7 +166,7 @@ var _ = SIGDescribe("Security Context", func() {
 	ginkgo.It("should support seccomp alpha runtime/default annotation [Feature:Seccomp] [LinuxOnly]", func() {
 		// TODO: port to SecurityContext as soon as seccomp is out of alpha
 		pod := scTestPod(false, false)
-		pod.Annotations[v1.SeccompContainerAnnotationKeyPrefix+"test-container"] = v1.SeccompProfileRuntimeDefault
+		pod.Annotations[v1.SeccompContainerAnnotationKeyPrefix+"test-container"] = v1.DeprecatedSeccompProfileDockerDefault
 		pod.Spec.Containers[0].Command = []string{"grep", "ecc", "/proc/self/status"}
 		f.TestContainerOutput(v1.SeccompPodAnnotationKey, pod, 0, []string{"2"}) // seccomp filtered
 	})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind deprecation


**What this PR does / why we need it**:
Seccomp GA will introduce new fields whilst deprecating the existing annotations. This PR deprecates `SeccompProfileRuntimeDefault`.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of #91286

**Special notes for your reviewer**:
Separate PRs will be created to cover the entirety of the seccomp GA graduation.

This PR resolves the name collision between the `SeccompProfileRuntimeDefault` (the annotation to be deprecated), and the new `SeccompProfileRuntimeDefault` (the new `SeccompProfileType`), which will be created on a follow-up PR.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
SeccompProfileRuntimeDefault (a.k.a. "runtime/default") for seccomp annotations is deprecated.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

References:
- [Seccomp GA - KEP](https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/20190717-seccomp-ga.md)

/sig node
/area security
/cc @tallclair @hasheddan @saschagrunert @evrardjp