### PR TITLE
Cherry pick of #91099 #91252: Skip pod updates from scheduling queue updates

### DIFF
--- a/pkg/scheduler/eventhandlers.go
+++ b/pkg/scheduler/eventhandlers.go
@@ -21,7 +21,6 @@ import (
 	"reflect"
 
 	"k8s.io/klog"
-	"k8s.io/kubernetes/pkg/scheduler/profile"
 
 	v1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
@@ -32,6 +31,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/scheduler/internal/queue"
+	"k8s.io/kubernetes/pkg/scheduler/profile"
 )
 
 func (sched *Scheduler) onPvAdd(obj interface{}) {
@@ -301,8 +301,8 @@ func responsibleForPod(pod *v1.Pod, profiles profile.Map) bool {
 // skipPodUpdate checks whether the specified pod update should be ignored.
 // This function will return true if
 //   - The pod has already been assumed, AND
-//   - The pod has only its ResourceVersion, Spec.NodeName, Annotations, ManagedFields and/or Finalizers
-//     updated.
+//   - The pod has only its ResourceVersion, Spec.NodeName, Annotations,
+//     ManagedFields, Finalizers and/or Conditions updated.
 func (sched *Scheduler) skipPodUpdate(pod *v1.Pod) bool {
 	// Non-assumed pods should never be skipped.
 	isAssumed, err := sched.SchedulerCache.IsAssumedPod(pod)
@@ -338,8 +338,10 @@ func (sched *Scheduler) skipPodUpdate(pod *v1.Pod) bool {
 		// Same as above, when annotations are modified with ServerSideApply,
 		// ManagedFields may also change and must be excluded
 		p.ManagedFields = nil
-		// Finalizers must be excluded because scheduled result can not be affected
+		// The following might be changed by external controllers, but they don't
+		// affect scheduling decisions.
 		p.Finalizers = nil
+		p.Status.Conditions = nil
 		return p
 	}
 	assumedPodCopy, podCopy := f(assumedPod), f(pod)

--- a/pkg/scheduler/eventhandlers.go
+++ b/pkg/scheduler/eventhandlers.go
@@ -301,7 +301,7 @@ func responsibleForPod(pod *v1.Pod, profiles profile.Map) bool {
 // skipPodUpdate checks whether the specified pod update should be ignored.
 // This function will return true if
 //   - The pod has already been assumed, AND
-//   - The pod has only its ResourceVersion, Spec.NodeName and/or Annotations
+//   - The pod has only its ResourceVersion, Spec.NodeName, Annotations, ManagedFields and/or Finalizers
 //     updated.
 func (sched *Scheduler) skipPodUpdate(pod *v1.Pod) bool {
 	// Non-assumed pods should never be skipped.
@@ -338,6 +338,8 @@ func (sched *Scheduler) skipPodUpdate(pod *v1.Pod) bool {
 		// Same as above, when annotations are modified with ServerSideApply,
 		// ManagedFields may also change and must be excluded
 		p.ManagedFields = nil
+		// Finalizers must be excluded because scheduled result can not be affected
+		p.Finalizers = nil
 		return p
 	}
 	assumedPodCopy, podCopy := f(assumedPod), f(pod)

--- a/pkg/scheduler/eventhandlers_test.go
+++ b/pkg/scheduler/eventhandlers_test.go
@@ -180,6 +180,27 @@ func TestSkipPodUpdate(t *testing.T) {
 			},
 			expected: false,
 		},
+		{
+			name: "with changes on Finalizers",
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "pod-0",
+					Finalizers: []string{"a", "b"},
+				},
+			},
+			isAssumedPodFunc: func(*v1.Pod) bool {
+				return true
+			},
+			getPodFunc: func(*v1.Pod) *v1.Pod {
+				return &v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       "pod-0",
+						Finalizers: []string{"c", "d"},
+					},
+				}
+			},
+			expected: true,
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			c := &Scheduler{

--- a/pkg/scheduler/eventhandlers_test.go
+++ b/pkg/scheduler/eventhandlers_test.go
@@ -201,6 +201,30 @@ func TestSkipPodUpdate(t *testing.T) {
 			},
 			expected: true,
 		},
+		{
+			name: "with changes on Conditions",
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "pod-0",
+				},
+				Status: v1.PodStatus{
+					Conditions: []v1.PodCondition{
+						{Type: "foo"},
+					},
+				},
+			},
+			isAssumedPodFunc: func(*v1.Pod) bool {
+				return true
+			},
+			getPodFunc: func(*v1.Pod) *v1.Pod {
+				return &v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pod-0",
+					},
+				}
+			},
+			expected: true,
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			c := &Scheduler{


### PR DESCRIPTION
/kind bug
/sig scheduling
/priority important-soon

Cherry pick of #91099 and #91252 on release-1.18.

**Release Note**:

```release-note
Pod Finalizers and Conditions updates are skipped for re-scheduling attempts
```