### PR TITLE
Fix golint failures for kubelet/container

### DIFF
--- a/pkg/kubelet/container/container_gc.go
+++ b/pkg/kubelet/container/container_gc.go
@@ -23,7 +23,7 @@ import (
 	"k8s.io/klog/v2"
 )
 
-// Specified a policy for garbage collecting containers.
+// ContainerGCPolicy specifies a policy for garbage collecting containers.
 type ContainerGCPolicy struct {
 	// Minimum age at which a container can be garbage collected, zero for no limit.
 	MinAge time.Duration
@@ -36,7 +36,7 @@ type ContainerGCPolicy struct {
 	MaxContainers int
 }
 
-// Manages garbage collection of dead containers.
+// ContainerGC manages garbage collection of dead containers.
 //
 // Implementation is thread-compatible.
 type ContainerGC interface {
@@ -64,7 +64,7 @@ type realContainerGC struct {
 	sourcesReadyProvider SourcesReadyProvider
 }
 
-// New ContainerGC instance with the specified policy.
+// NewContainerGC creates a new instance of ContainerGC with the specified policy.
 func NewContainerGC(runtime Runtime, policy ContainerGCPolicy, sourcesReadyProvider SourcesReadyProvider) (ContainerGC, error) {
 	if policy.MinAge < 0 {
 		return nil, fmt.Errorf("invalid minimum garbage collection age: %v", policy.MinAge)

--- a/pkg/kubelet/container/helpers.go
+++ b/pkg/kubelet/container/helpers.go
@@ -141,7 +141,7 @@ func ExpandContainerCommandOnlyStatic(containerCommand []string, envs []v1.EnvVa
 	return command
 }
 
-// ExpandContainerVolumeMounts expands the subpath of the given VolumeMount by replacing variable references `with the values of given EnvVar.
+// ExpandContainerVolumeMounts expands the subpath of the given VolumeMount by replacing variable references with the values of given EnvVar.
 func ExpandContainerVolumeMounts(mount v1.VolumeMount, envs []EnvVar) (string, error) {
 
 	envmap := EnvVarsToMap(envs)

--- a/pkg/kubelet/container/helpers.go
+++ b/pkg/kubelet/container/helpers.go
@@ -102,8 +102,8 @@ func HashContainer(container *v1.Container) uint64 {
 	hash := fnv.New32a()
 	// Omit nil or empty field when calculating hash value
 	// Please see https://github.com/kubernetes/kubernetes/issues/53644
-	containerJson, _ := json.Marshal(container)
-	hashutil.DeepHashObject(hash, containerJson)
+	containerJSON, _ := json.Marshal(container)
+	hashutil.DeepHashObject(hash, containerJSON)
 	return uint64(hash.Sum32())
 }
 
@@ -141,6 +141,7 @@ func ExpandContainerCommandOnlyStatic(containerCommand []string, envs []v1.EnvVa
 	return command
 }
 
+// ExpandContainerVolumeMounts expands the subpath of the given VolumeMount by replacing variable references `with the values of given EnvVar.
 func ExpandContainerVolumeMounts(mount v1.VolumeMount, envs []EnvVar) (string, error) {
 
 	envmap := EnvVarsToMap(envs)
@@ -159,6 +160,7 @@ func ExpandContainerVolumeMounts(mount v1.VolumeMount, envs []EnvVar) (string, e
 	return expanded, nil
 }
 
+// ExpandContainerCommandAndArgs expands the given Container's command by replacing variable references `with the values of given EnvVar.
 func ExpandContainerCommandAndArgs(container *v1.Container, envs []EnvVar) (command []string, args []string) {
 	mapping := expansion.MappingFuncFor(EnvVarsToMap(envs))
 
@@ -177,7 +179,7 @@ func ExpandContainerCommandAndArgs(container *v1.Container, envs []EnvVar) (comm
 	return command, args
 }
 
-// Create an event recorder to record object's event except implicitly required container's, like infra container.
+// FilterEventRecorder creates an event recorder to record object's event except implicitly required container's, like infra container.
 func FilterEventRecorder(recorder record.EventRecorder) record.EventRecorder {
 	return &innerEventRecorder{
 		recorder: recorder,
@@ -220,11 +222,13 @@ func (irecorder *innerEventRecorder) AnnotatedEventf(object runtime.Object, anno
 
 }
 
+// IsHostNetworkPod returns whether the host networking requested for the given Pod.
 // Pod must not be nil.
 func IsHostNetworkPod(pod *v1.Pod) bool {
 	return pod.Spec.HostNetwork
 }
 
+// ConvertPodStatusToRunningPod returns Pod given PodStatus and container runtime string.
 // TODO(random-liu): Convert PodStatus to running Pod, should be deprecated soon
 func ConvertPodStatusToRunningPod(runtimeName string, podStatus *PodStatus) Pod {
 	runningPod := Pod{

--- a/pkg/kubelet/container/ref.go
+++ b/pkg/kubelet/container/ref.go
@@ -19,14 +19,15 @@ package container
 import (
 	"fmt"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	ref "k8s.io/client-go/tools/reference"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	"k8s.io/kubernetes/pkg/features"
 )
 
-var ImplicitContainerPrefix string = "implicitly required container "
+// ImplicitContainerPrefix is a container name prefix that will indicate that container was started implicitly (like the pod infra container).
+var ImplicitContainerPrefix = "implicitly required container "
 
 // GenerateContainerRef returns an *v1.ObjectReference which references the given container
 // within the given pod. Returns an error if the reference can't be constructed or the

--- a/pkg/kubelet/container/resize.go
+++ b/pkg/kubelet/container/resize.go
@@ -21,7 +21,7 @@ import (
 	"k8s.io/client-go/tools/remotecommand"
 )
 
-// handleResizing spawns a goroutine that processes the resize channel, calling resizeFunc for each
+// HandleResizing spawns a goroutine that processes the resize channel, calling resizeFunc for each
 // remotecommand.TerminalSize received from the channel. The resize channel must be closed elsewhere to stop the
 // goroutine.
 func HandleResizing(resize <-chan remotecommand.TerminalSize, resizeFunc func(size remotecommand.TerminalSize)) {

--- a/pkg/kubelet/container/runtime.go
+++ b/pkg/kubelet/container/runtime.go
@@ -260,7 +260,7 @@ const (
 	ContainerStateRunning ContainerState = "running"
 	// ContainerStateExited indicates a container that ran and completed ("stopped" in other contexts, although a created container is technically also "stopped").
 	ContainerStateExited ContainerState = "exited"
-	// ContainerStateUnknown encompasses all the states that we currently don't care (like restarting, paused, dead).
+	// ContainerStateUnknown encompasses all the states that we currently don't care about (like restarting, paused, dead).
 	ContainerStateUnknown ContainerState = "unknown"
 )
 

--- a/pkg/kubelet/container/runtime.go
+++ b/pkg/kubelet/container/runtime.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/kubernetes/pkg/volume"
 )
 
+// Version interface allow to consume the runtime versions - compare and format to string.
 type Version interface {
 	// Compare compares two versions of the runtime. On success it returns -1
 	// if the version is less than the other, 1 if it is greater than the other,
@@ -87,7 +88,7 @@ type Runtime interface {
 	GetPods(all bool) ([]*Pod, error)
 	// GarbageCollect removes dead containers using the specified container gc policy
 	// If allSourcesReady is not true, it means that kubelet doesn't have the
-	// complete list of pods from all avialble sources (e.g., apiserver, http,
+	// complete list of pods from all available sources (e.g., apiserver, http,
 	// file). In this case, garbage collector should refrain itself from aggressive
 	// behavior such as removing all containers of unrecognized pods (yet).
 	// If evictNonDeletedPods is set to true, containers and sandboxes belonging to pods
@@ -130,6 +131,7 @@ type StreamingRuntime interface {
 	GetPortForward(podName, podNamespace string, podUID types.UID, ports []int32) (*url.URL, error)
 }
 
+// ImageService interfaces allows to work with image service.
 type ImageService interface {
 	// PullImage pulls an image from the network to local storage using the supplied
 	// secrets if necessary. It returns a reference (digest or ID) to the pulled image.
@@ -145,10 +147,12 @@ type ImageService interface {
 	ImageStats() (*ImageStats, error)
 }
 
+// ContainerAttacher interface allows to attach a container.
 type ContainerAttacher interface {
 	AttachContainer(id ContainerID, stdin io.Reader, stdout, stderr io.WriteCloser, tty bool, resize <-chan remotecommand.TerminalSize) (err error)
 }
 
+// ContainerCommandRunner interface allows to run command in a container.
 type ContainerCommandRunner interface {
 	// RunInContainer synchronously executes the command in the container, and returns the output.
 	// If the command completes with a non-0 exit code, a k8s.io/utils/exec.ExitError will be returned.
@@ -167,7 +171,7 @@ type Pod struct {
 	// running containers, or mixed with dead ones (when GetPods(true)).
 	Containers []*Container
 	// List of sandboxes associated with this pod. The sandboxes are converted
-	// to Container temporariliy to avoid substantial changes to other
+	// to Container temporarily to avoid substantial changes to other
 	// components. This is only populated by kuberuntime.
 	// TODO: use the runtimeApi.PodSandbox type directly.
 	Sandboxes []*Container
@@ -191,11 +195,12 @@ type ContainerID struct {
 	ID string
 }
 
+// BuildContainerID returns the ContainerID given type and id.
 func BuildContainerID(typ, ID string) ContainerID {
 	return ContainerID{Type: typ, ID: ID}
 }
 
-// Convenience method for creating a ContainerID from an ID string.
+// ParseContainerID is a convenience method for creating a ContainerID from an ID string.
 func ParseContainerID(containerID string) ContainerID {
 	var id ContainerID
 	if err := id.ParseString(containerID); err != nil {
@@ -204,6 +209,7 @@ func ParseContainerID(containerID string) ContainerID {
 	return id
 }
 
+// ParseString converts given string into ContainerID
 func (c *ContainerID) ParseString(data string) error {
 	// Trim the quotes and split the type and ID.
 	parts := strings.Split(strings.Trim(data, "\""), "://")
@@ -218,14 +224,17 @@ func (c *ContainerID) String() string {
 	return fmt.Sprintf("%s://%s", c.Type, c.ID)
 }
 
+// IsEmpty returns whether given ContainerID is empty.
 func (c *ContainerID) IsEmpty() bool {
 	return *c == ContainerID{}
 }
 
+// MarshalJSON formats a given ContainerID into a byte array.
 func (c *ContainerID) MarshalJSON() ([]byte, error) {
 	return []byte(fmt.Sprintf("%q", c.String())), nil
 }
 
+// UnmarshalJSON parses ContainerID from a given array of bytes.
 func (c *ContainerID) UnmarshalJSON(data []byte) error {
 	return c.ParseString(string(data))
 }
@@ -233,6 +242,7 @@ func (c *ContainerID) UnmarshalJSON(data []byte) error {
 // DockerID is an ID of docker container. It is a type to make it clear when we're working with docker container Ids
 type DockerID string
 
+// ContainerID converts DockerID into a ContainerID.
 func (id DockerID) ContainerID() ContainerID {
 	return ContainerID{
 		Type: "docker",
@@ -240,13 +250,17 @@ func (id DockerID) ContainerID() ContainerID {
 	}
 }
 
+// ContainerState represents the state of a container
 type ContainerState string
 
 const (
+	// ContainerStateCreated indicates a container that has been created (e.g. with docker create) but not started.
 	ContainerStateCreated ContainerState = "created"
+	// ContainerStateRunning indicates a currently running container.
 	ContainerStateRunning ContainerState = "running"
-	ContainerStateExited  ContainerState = "exited"
-	// This unknown encompasses all the states that we currently don't care.
+	// ContainerStateExited indicates a container that ran and completed ("stopped" in other contexts, although a created container is technically also "stopped").
+	ContainerStateExited ContainerState = "exited"
+	// ContainerStateUnknown encompasses all the states that we currently don't care (like restarting, paused, dead).
 	ContainerStateUnknown ContainerState = "unknown"
 )
 
@@ -331,7 +345,7 @@ func (podStatus *PodStatus) FindContainerStatusByName(containerName string) *Con
 	return nil
 }
 
-// Get container status of all the running containers in a pod
+// GetRunningContainerStatuses returns container status of all the running containers in a pod
 func (podStatus *PodStatus) GetRunningContainerStatuses() []*ContainerStatus {
 	runningContainerStatuses := []*ContainerStatus{}
 	for _, containerStatus := range podStatus.ContainerStatuses {
@@ -342,7 +356,7 @@ func (podStatus *PodStatus) GetRunningContainerStatuses() []*ContainerStatus {
 	return runningContainerStatuses
 }
 
-// Basic information about a container image.
+// Image contains basic information about a container image.
 type Image struct {
 	// ID of the image.
 	ID string
@@ -356,16 +370,19 @@ type Image struct {
 	Spec ImageSpec
 }
 
+// EnvVar represents the environment variable.
 type EnvVar struct {
 	Name  string
 	Value string
 }
 
+// Annotation represents an annotation.
 type Annotation struct {
 	Name  string
 	Value string
 }
 
+// Mount represents a volume mount.
 type Mount struct {
 	// Name of the volume mount.
 	// TODO(yifan): Remove this field, as this is not representing the unique name of the mount,
@@ -383,6 +400,7 @@ type Mount struct {
 	Propagation runtimeapi.MountPropagation
 }
 
+// PortMapping contains information about the port mapping.
 type PortMapping struct {
 	// Name of the port mapping
 	Name string
@@ -396,6 +414,7 @@ type PortMapping struct {
 	HostIP string
 }
 
+// DeviceInfo contains information about the device.
 type DeviceInfo struct {
 	// Path on host for mapping
 	PathOnHost string
@@ -452,6 +471,7 @@ type VolumeInfo struct {
 	InnerVolumeSpecName string
 }
 
+// VolumeMap represents the map of volumes.
 type VolumeMap map[string]VolumeInfo
 
 // RuntimeConditionType is the types of required runtime conditions.
@@ -482,9 +502,9 @@ func (r *RuntimeStatus) GetRuntimeCondition(t RuntimeConditionType) *RuntimeCond
 }
 
 // String formats the runtime status into human readable string.
-func (s *RuntimeStatus) String() string {
+func (r *RuntimeStatus) String() string {
 	var ss []string
-	for _, c := range s.Conditions {
+	for _, c := range r.Conditions {
 		ss = append(ss, c.String())
 	}
 	return fmt.Sprintf("Runtime Conditions: %s", strings.Join(ss, ", "))
@@ -507,6 +527,7 @@ func (c *RuntimeCondition) String() string {
 	return fmt.Sprintf("%s=%t reason:%s message:%s", c.Type, c.Status, c.Reason, c.Message)
 }
 
+// Pods represents the list of pods
 type Pods []*Pod
 
 // FindPodByID finds and returns a pod in the pod list by UID. It will return an empty pod
@@ -553,6 +574,7 @@ func (p *Pod) FindContainerByName(containerName string) *Container {
 	return nil
 }
 
+// FindContainerByID returns a container in the pod with the given ContainerID.
 func (p *Pod) FindContainerByID(id ContainerID) *Container {
 	for _, c := range p.Containers {
 		if c.ID == id {
@@ -562,6 +584,7 @@ func (p *Pod) FindContainerByID(id ContainerID) *Container {
 	return nil
 }
 
+// FindSandboxByID returns a sandbox in the pod with the given ContainerID.
 func (p *Pod) FindSandboxByID(id ContainerID) *Container {
 	for _, c := range p.Sandboxes {
 		if c.ID == id {
@@ -600,12 +623,12 @@ func GetPodFullName(pod *v1.Pod) string {
 	return pod.Name + "_" + pod.Namespace
 }
 
-// Build the pod full name from pod name and namespace.
+// BuildPodFullName builds the pod full name from pod name and namespace.
 func BuildPodFullName(name, namespace string) string {
 	return name + "_" + namespace
 }
 
-// Parse the pod full name.
+// ParsePodFullName parsed the pod full name.
 func ParsePodFullName(podFullName string) (string, string, error) {
 	parts := strings.Split(podFullName, "_")
 	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
@@ -618,7 +641,7 @@ func ParsePodFullName(podFullName string) (string, string, error) {
 // completely optional settings.
 type Option func(Runtime)
 
-// Sort the container statuses by creation time.
+// SortContainerStatusesByCreationTime sorts the container statuses by creation time.
 type SortContainerStatusesByCreationTime []*ContainerStatus
 
 func (s SortContainerStatusesByCreationTime) Len() int      { return len(s) }

--- a/pkg/kubelet/container/runtime_cache.go
+++ b/pkg/kubelet/container/runtime_cache.go
@@ -26,6 +26,7 @@ var (
 	defaultCachePeriod = time.Second * 2
 )
 
+// RuntimeCache is in interface for obtaining cached Pods.
 type RuntimeCache interface {
 	GetPods() ([]*Pod, error)
 	ForceUpdateIfOlder(time.Time) error

--- a/pkg/kubelet/container/runtime_cache_fake.go
+++ b/pkg/kubelet/container/runtime_cache_fake.go
@@ -16,7 +16,7 @@ limitations under the License.
 
 package container
 
-// TestRunTimeCache embeds runtimeCache with some additional methods for testing.
+// TestRuntimeCache embeds runtimeCache with some additional methods for testing.
 // It must be declared in the container package to have visibility to runtimeCache.
 // It cannot be in a "..._test.go" file in order for runtime_cache_test.go to have cross-package visibility to it.
 // (cross-package declarations in test files cannot be used from dot imports if this package is vendored)
@@ -24,18 +24,21 @@ type TestRuntimeCache struct {
 	runtimeCache
 }
 
+// UpdateCacheWithLock updates the cache with the lock.
 func (r *TestRuntimeCache) UpdateCacheWithLock() error {
 	r.Lock()
 	defer r.Unlock()
 	return r.updateCache()
 }
 
+// GetCachedPods returns the cached pods.
 func (r *TestRuntimeCache) GetCachedPods() []*Pod {
 	r.Lock()
 	defer r.Unlock()
 	return r.pods
 }
 
+// NewTestRuntimeCache creates a new instance of TestRuntimeCache.
 func NewTestRuntimeCache(getter podsGetter) *TestRuntimeCache {
 	return &TestRuntimeCache{
 		runtimeCache: runtimeCache{

--- a/pkg/kubelet/container/sync_result.go
+++ b/pkg/kubelet/container/sync_result.go
@@ -25,7 +25,7 @@ import (
 
 // TODO(random-liu): We need to better organize runtime errors for introspection.
 
-// Container Terminated and Kubelet is backing off the restart
+// ErrCrashLoopBackOff returned when a container Terminated and Kubelet is backing off the restart.
 var ErrCrashLoopBackOff = errors.New("CrashLoopBackOff")
 
 var (
@@ -35,17 +35,26 @@ var (
 )
 
 var (
-	ErrRunContainer     = errors.New("RunContainerError")
-	ErrKillContainer    = errors.New("KillContainerError")
-	ErrVerifyNonRoot    = errors.New("VerifyNonRootError")
+	// ErrRunContainer returned when runtime failed to start any of pod's container.
+	ErrRunContainer = errors.New("RunContainerError")
+	// ErrKillContainer returned when runtime failed to kill any of pod's containers.
+	ErrKillContainer = errors.New("KillContainerError")
+	// ErrVerifyNonRoot returned if the container or image will run as the root user.
+	ErrVerifyNonRoot = errors.New("VerifyNonRootError")
+	// ErrRunInitContainer returned when container init failed.
 	ErrRunInitContainer = errors.New("RunInitContainerError")
+	// ErrCreatePodSandbox returned when runtime failed to create a sandbox for pod.
 	ErrCreatePodSandbox = errors.New("CreatePodSandboxError")
+	// ErrConfigPodSandbox returned when runetime failed to get pod sandbox config from pod.
 	ErrConfigPodSandbox = errors.New("ConfigPodSandboxError")
-	ErrKillPodSandbox   = errors.New("KillPodSandboxError")
+	// ErrKillPodSandbox returned when runtime failed to stop pod's sandbox.
+	ErrKillPodSandbox = errors.New("KillPodSandboxError")
 )
 
 var (
-	ErrSetupNetwork    = errors.New("SetupNetworkError")
+	// ErrSetupNetwork returned when network setup failed.
+	ErrSetupNetwork = errors.New("SetupNetworkError")
+	// ErrTeardownNetwork returned when network tear down failed.
 	ErrTeardownNetwork = errors.New("TeardownNetworkError")
 )
 
@@ -54,14 +63,22 @@ var (
 type SyncAction string
 
 const (
-	StartContainer   SyncAction = "StartContainer"
-	KillContainer    SyncAction = "KillContainer"
-	SetupNetwork     SyncAction = "SetupNetwork"
-	TeardownNetwork  SyncAction = "TeardownNetwork"
-	InitContainer    SyncAction = "InitContainer"
+	// StartContainer action
+	StartContainer SyncAction = "StartContainer"
+	// KillContainer action
+	KillContainer SyncAction = "KillContainer"
+	// SetupNetwork action
+	SetupNetwork SyncAction = "SetupNetwork"
+	// TeardownNetwork action
+	TeardownNetwork SyncAction = "TeardownNetwork"
+	// InitContainer action
+	InitContainer SyncAction = "InitContainer"
+	// CreatePodSandbox action
 	CreatePodSandbox SyncAction = "CreatePodSandbox"
+	// ConfigPodSandbox action
 	ConfigPodSandbox SyncAction = "ConfigPodSandbox"
-	KillPodSandbox   SyncAction = "KillPodSandbox"
+	// KillPodSandbox action
+	KillPodSandbox SyncAction = "KillPodSandbox"
 )
 
 // SyncResult is the result of sync action.


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup
/sig node

**What this PR does / why we need it**:

Fix linter issues in kubelet/container component. 

**Which issue(s) this PR fixes**:

Related to #68026.

List of issues:

```
pkg/kubelet/container/container_gc.go:26:1: comment on exported type ContainerGCPolicy should be of the form "ContainerGCPolicy ..." (with optional leading article)
pkg/kubelet/container/container_gc.go:27:6: type name will be used as container.ContainerGCPolicy by other packages, and that stutters; consider calling this GCPolicy
pkg/kubelet/container/container_gc.go:39:1: comment on exported type ContainerGC should be of the form "ContainerGC ..." (with optional leading article)
pkg/kubelet/container/container_gc.go:42:6: type name will be used as container.ContainerGC by other packages, and that stutters; consider calling this GC
pkg/kubelet/container/container_gc.go:67:1: comment on exported function NewContainerGC should be of the form "NewContainerGC ..."
pkg/kubelet/container/helpers.go:105:2: var containerJson should be containerJSON
pkg/kubelet/container/helpers.go:144:1: exported function ExpandContainerVolumeMounts should have comment or be unexported
pkg/kubelet/container/helpers.go:162:1: exported function ExpandContainerCommandAndArgs should have comment or be unexported
pkg/kubelet/container/helpers.go:180:1: comment on exported function FilterEventRecorder should be of the form "FilterEventRecorder ..."
pkg/kubelet/container/helpers.go:223:1: comment on exported function IsHostNetworkPod should be of the form "IsHostNetworkPod ..."
pkg/kubelet/container/helpers.go:228:1: comment on exported function ConvertPodStatusToRunningPod should be of the form "ConvertPodStatusToRunningPod ..."
pkg/kubelet/container/ref.go:29:5: exported var ImplicitContainerPrefix should have comment or be unexported
pkg/kubelet/container/ref.go:29:29: should omit type string from declaration of var ImplicitContainerPrefix; it will be inferred from the right-hand side
pkg/kubelet/container/resize.go:24:1: comment on exported function HandleResizing should be of the form "HandleResizing ..."
pkg/kubelet/container/runtime_cache_fake.go:19:1: comment on exported type TestRuntimeCache should be of the form "TestRuntimeCache ..." (with optional leading article)
pkg/kubelet/container/runtime_cache_fake.go:27:1: exported method TestRuntimeCache.UpdateCacheWithLock should have comment or be unexported
pkg/kubelet/container/runtime_cache_fake.go:33:1: exported method TestRuntimeCache.GetCachedPods should have comment or be unexported
pkg/kubelet/container/runtime_cache_fake.go:39:1: exported function NewTestRuntimeCache should have comment or be unexported
pkg/kubelet/container/runtime_cache.go:29:6: exported type RuntimeCache should have comment or be unexported
pkg/kubelet/container/runtime.go:37:6: exported type Version should have comment or be unexported
pkg/kubelet/container/runtime.go:133:6: exported type ImageService should have comment or be unexported
pkg/kubelet/container/runtime.go:148:6: exported type ContainerAttacher should have comment or be unexported
pkg/kubelet/container/runtime.go:148:6: type name will be used as container.ContainerAttacher by other packages, and that stutters; consider calling this Attacher
pkg/kubelet/container/runtime.go:152:6: exported type ContainerCommandRunner should have comment or be unexported
pkg/kubelet/container/runtime.go:152:6: type name will be used as container.ContainerCommandRunner by other packages, and that stutters; consider calling this CommandRunner
pkg/kubelet/container/runtime.go:185:6: type name will be used as container.ContainerID by other packages, and that stutters; consider calling this ID
pkg/kubelet/container/runtime.go:194:1: exported function BuildContainerID should have comment or be unexported
pkg/kubelet/container/runtime.go:198:1: comment on exported function ParseContainerID should be of the form "ParseContainerID ..."
pkg/kubelet/container/runtime.go:207:1: exported method ContainerID.ParseString should have comment or be unexported
pkg/kubelet/container/runtime.go:221:1: exported method ContainerID.IsEmpty should have comment or be unexported
pkg/kubelet/container/runtime.go:225:1: exported method ContainerID.MarshalJSON should have comment or be unexported
pkg/kubelet/container/runtime.go:229:1: exported method ContainerID.UnmarshalJSON should have comment or be unexported
pkg/kubelet/container/runtime.go:236:1: exported method DockerID.ContainerID should have comment or be unexported
pkg/kubelet/container/runtime.go:243:6: exported type ContainerState should have comment or be unexported
pkg/kubelet/container/runtime.go:243:6: type name will be used as container.ContainerState by other packages, and that stutters; consider calling this State
pkg/kubelet/container/runtime.go:246:2: exported const ContainerStateCreated should have comment (or a comment on this block) or be unexported
pkg/kubelet/container/runtime.go:249:2: comment on exported const ContainerStateUnknown should be of the form "ContainerStateUnknown ..."
pkg/kubelet/container/runtime.go:293:6: type name will be used as container.ContainerStatus by other packages, and that stutters; consider calling this Status
pkg/kubelet/container/runtime.go:335:1: comment on exported method PodStatus.GetRunningContainerStatuses should be of the form "GetRunningContainerStatuses ..."
pkg/kubelet/container/runtime.go:346:1: comment on exported type Image should be of the form "Image ..." (with optional leading article)
pkg/kubelet/container/runtime.go:360:6: exported type EnvVar should have comment or be unexported
pkg/kubelet/container/runtime.go:365:6: exported type Annotation should have comment or be unexported
pkg/kubelet/container/runtime.go:370:6: exported type Mount should have comment or be unexported
pkg/kubelet/container/runtime.go:387:6: exported type PortMapping should have comment or be unexported
pkg/kubelet/container/runtime.go:400:6: exported type DeviceInfo should have comment or be unexported
pkg/kubelet/container/runtime.go:456:6: exported type VolumeMap should have comment or be unexported
pkg/kubelet/container/runtime.go:486:1: receiver name s should be consistent with previous receiver name r for RuntimeStatus
pkg/kubelet/container/runtime.go:511:6: exported type Pods should have comment or be unexported
pkg/kubelet/container/runtime.go:557:1: exported method Pod.FindContainerByID should have comment or be unexported
pkg/kubelet/container/runtime.go:566:1: exported method Pod.FindSandboxByID should have comment or be unexported
pkg/kubelet/container/runtime.go:604:1: comment on exported function BuildPodFullName should be of the form "BuildPodFullName ..."
pkg/kubelet/container/runtime.go:609:1: comment on exported function ParsePodFullName should be of the form "ParsePodFullName ..."
pkg/kubelet/container/runtime.go:622:1: comment on exported type SortContainerStatusesByCreationTime should be of the form "SortContainerStatusesByCreationTime ..." (with optional leading article)
pkg/kubelet/container/sync_result.go:28:1: comment on exported var ErrCrashLoopBackOff should be of the form "ErrCrashLoopBackOff ..."
pkg/kubelet/container/sync_result.go:38:2: exported var ErrRunContainer should have comment or be unexported
pkg/kubelet/container/sync_result.go:48:2: exported var ErrSetupNetwork should have comment or be unexported
pkg/kubelet/container/sync_result.go:57:2: exported const StartContainer should have comment (or a comment on this block) or be unexported
```

**Special notes for your reviewer**:

Issues with "stutters" are left out for a separate PR as they might be more controversial. This is why the component is not removed from the `.golint_failures`.

```
pkg/kubelet/container/container_gc.go:27:6: type name will be used as container.ContainerGCPolicy by other packages, and that stutters; consider calling this GCPolicy
pkg/kubelet/container/container_gc.go:42:6: type name will be used as container.ContainerGC by other packages, and that stutters; consider calling this GC
pkg/kubelet/container/runtime.go:151:6: type name will be used as container.ContainerAttacher by other packages, and that stutters; consider calling this Attacher
pkg/kubelet/container/runtime.go:156:6: type name will be used as container.ContainerCommandRunner by other packages, and that stutters; consider calling this CommandRunner
pkg/kubelet/container/runtime.go:189:6: type name will be used as container.ContainerID by other packages, and that stutters; consider calling this ID
pkg/kubelet/container/runtime.go:254:6: type name will be used as container.ContainerState by other packages, and that stutters; consider calling this State
pkg/kubelet/container/runtime.go:307:6: type name will be used as container.ContainerStatus by other packages, and that stutters; consider calling this Status
```


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
