### PR TITLE
exec credential provider: add install hint

### DIFF
--- a/staging/src/k8s.io/client-go/plugin/pkg/client/auth/exec/BUILD
+++ b/staging/src/k8s.io/client-go/plugin/pkg/client/auth/exec/BUILD
@@ -14,6 +14,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/clock:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/runtime:go_default_library",
         "//staging/src/k8s.io/client-go/pkg/apis/clientauthentication:go_default_library",
         "//staging/src/k8s.io/client-go/pkg/apis/clientauthentication/v1alpha1:go_default_library",
@@ -39,6 +40,7 @@ go_test(
     deps = [
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/clock:go_default_library",
         "//staging/src/k8s.io/client-go/pkg/apis/clientauthentication:go_default_library",
         "//staging/src/k8s.io/client-go/tools/clientcmd/api:go_default_library",
         "//staging/src/k8s.io/client-go/transport:go_default_library",

--- a/staging/src/k8s.io/client-go/plugin/pkg/client/auth/exec/exec.go
+++ b/staging/src/k8s.io/client-go/plugin/pkg/client/auth/exec/exec.go
@@ -29,6 +29,7 @@ import (
 	"os"
 	"os/exec"
 	"reflect"
+	"strings"
 	"sync"
 	"time"
 
@@ -38,6 +39,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/apimachinery/pkg/util/clock"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/pkg/apis/clientauthentication"
 	"k8s.io/client-go/pkg/apis/clientauthentication/v1alpha1"
@@ -51,6 +53,12 @@ import (
 
 const execInfoEnv = "KUBERNETES_EXEC_INFO"
 const onRotateListWarningLength = 1000
+const installHintVerboseHelp = `
+
+It looks like you are trying to use a client-go credential plugin that is not installed.
+
+To learn more about this feature, consult the documentation available at:
+      https://kubernetes.io/docs/reference/access-authn-authz/authentication/#client-go-credential-plugins`
 
 var scheme = runtime.NewScheme()
 var codecs = serializer.NewCodecFactory(scheme)
@@ -108,6 +116,44 @@ func (c *cache) put(s string, a *Authenticator) *Authenticator {
 	return a
 }
 
+// sometimes rate limits how often a function f() is called. Specifically, Do()
+// will run the provided function f() up to threshold times every interval
+// duration.
+type sometimes struct {
+	threshold int
+	interval  time.Duration
+
+	clock clock.Clock
+	mu    sync.Mutex
+
+	count  int       // times we have called f() in this window
+	window time.Time // beginning of current window of length interval
+}
+
+func (s *sometimes) Do(f func()) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	now := s.clock.Now()
+	if s.window.IsZero() {
+		s.window = now
+	}
+
+	// If we are no longer in our saved time window, then we get to reset our run
+	// count back to 0 and start increasing towards the threshold again.
+	if inWindow := now.Sub(s.window) < s.interval; !inWindow {
+		s.window = now
+		s.count = 0
+	}
+
+	// If we have not run the function more than threshold times in this current
+	// time window, we get to run it now!
+	if underThreshold := s.count < s.threshold; underThreshold {
+		s.count++
+		f()
+	}
+}
+
 // GetAuthenticator returns an exec-based plugin for providing client credentials.
 func GetAuthenticator(config *api.ExecConfig) (*Authenticator, error) {
 	return newAuthenticator(globalCache, config)
@@ -128,6 +174,13 @@ func newAuthenticator(c *cache, config *api.ExecConfig) (*Authenticator, error) 
 		cmd:   config.Command,
 		args:  config.Args,
 		group: gv,
+
+		installHint: config.InstallHint,
+		sometimes: &sometimes{
+			threshold: 10,
+			interval:  time.Hour,
+			clock:     clock.RealClock{},
+		},
 
 		stdin:       os.Stdin,
 		stderr:      os.Stderr,
@@ -151,6 +204,12 @@ type Authenticator struct {
 	args  []string
 	group schema.GroupVersion
 	env   []string
+
+	// Used to avoid log spew by rate limiting install hint printing. We didn't do
+	// this by interval based rate limiting alone since that way may have prevented
+	// the install hint from showing up for kubectl users.
+	sometimes   *sometimes
+	installHint string
 
 	// Stubbable for testing
 	stdin       io.Reader
@@ -323,7 +382,7 @@ func (a *Authenticator) refreshCredsLocked(r *clientauthentication.Response) err
 	}
 
 	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("exec: %v", err)
+		return a.wrapCmdRunErrorLocked(err)
 	}
 
 	_, gvk, err := codecs.UniversalDecoder(a.group).Decode(stdout.Bytes(), nil, cred)
@@ -393,4 +452,36 @@ func (a *Authenticator) refreshCredsLocked(r *clientauthentication.Response) err
 	}
 	expirationMetrics.set(a, expiry)
 	return nil
+}
+
+// wrapCmdRunErrorLocked pulls out the code to construct a helpful error message
+// for when the exec plugin's binary fails to Run().
+//
+// It must be called while holding the Authenticator's mutex.
+func (a *Authenticator) wrapCmdRunErrorLocked(err error) error {
+	switch err.(type) {
+	case *exec.Error: // Binary does not exist (see exec.Error).
+		builder := strings.Builder{}
+		fmt.Fprintf(&builder, "exec: executable %s not found", a.cmd)
+
+		a.sometimes.Do(func() {
+			fmt.Fprint(&builder, installHintVerboseHelp)
+			if a.installHint != "" {
+				fmt.Fprintf(&builder, "\n\n%s", a.installHint)
+			}
+		})
+
+		return errors.New(builder.String())
+
+	case *exec.ExitError: // Binary execution failed (see exec.Cmd.Run()).
+		e := err.(*exec.ExitError)
+		return fmt.Errorf(
+			"exec: executable %s failed with exit code %d",
+			a.cmd,
+			e.ProcessState.ExitCode(),
+		)
+
+	default:
+		return fmt.Errorf("exec: %v", err)
+	}
 }

--- a/staging/src/k8s.io/client-go/plugin/pkg/client/auth/exec/exec_test.go
+++ b/staging/src/k8s.io/client-go/plugin/pkg/client/auth/exec/exec_test.go
@@ -32,12 +32,14 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"reflect"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
 
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/clock"
 	"k8s.io/client-go/pkg/apis/clientauthentication"
 	"k8s.io/client-go/tools/clientcmd/api"
 	"k8s.io/client-go/transport"
@@ -168,15 +170,17 @@ func compJSON(t *testing.T, got, want []byte) {
 
 func TestRefreshCreds(t *testing.T) {
 	tests := []struct {
-		name        string
-		config      api.ExecConfig
-		output      string
-		interactive bool
-		response    *clientauthentication.Response
-		wantInput   string
-		wantCreds   credentials
-		wantExpiry  time.Time
-		wantErr     bool
+		name          string
+		config        api.ExecConfig
+		exitCode      int
+		output        string
+		interactive   bool
+		response      *clientauthentication.Response
+		wantInput     string
+		wantCreds     credentials
+		wantExpiry    time.Time
+		wantErr       bool
+		wantErrSubstr string
 	}{
 		{
 			name: "basic-request",
@@ -450,17 +454,42 @@ func TestRefreshCreds(t *testing.T) {
 			}`,
 			wantErr: true,
 		},
+		{
+			name: "unknown-binary",
+			config: api.ExecConfig{
+				APIVersion:  "client.authentication.k8s.io/v1beta1",
+				Command:     "does not exist",
+				InstallHint: "some install hint",
+			},
+			wantErr:       true,
+			wantErrSubstr: "some install hint",
+		},
+		{
+			name: "binary-fails",
+			config: api.ExecConfig{
+				APIVersion: "client.authentication.k8s.io/v1beta1",
+			},
+			exitCode:      73,
+			wantErr:       true,
+			wantErrSubstr: "73",
+		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			c := test.config
 
-			c.Command = "./testdata/test-plugin.sh"
-			c.Env = append(c.Env, api.ExecEnvVar{
-				Name:  "TEST_OUTPUT",
-				Value: test.output,
-			})
+			if c.Command == "" {
+				c.Command = "./testdata/test-plugin.sh"
+				c.Env = append(c.Env, api.ExecEnvVar{
+					Name:  "TEST_OUTPUT",
+					Value: test.output,
+				})
+				c.Env = append(c.Env, api.ExecEnvVar{
+					Name:  "TEST_EXIT_CODE",
+					Value: strconv.Itoa(test.exitCode),
+				})
+			}
 
 			a, err := newAuthenticator(newCache(), &c)
 			if err != nil {
@@ -475,6 +504,8 @@ func TestRefreshCreds(t *testing.T) {
 			if err := a.refreshCredsLocked(test.response); err != nil {
 				if !test.wantErr {
 					t.Errorf("get token %v", err)
+				} else if !strings.Contains(err.Error(), test.wantErrSubstr) {
+					t.Errorf("expected error with substring '%v' got '%v'", test.wantErrSubstr, err.Error())
 				}
 				return
 			}
@@ -761,6 +792,75 @@ func TestConcurrentUpdateTransportConfig(t *testing.T) {
 		}()
 	}
 	time.Sleep(2 * time.Second)
+}
+
+func TestInstallHintRateLimit(t *testing.T) {
+	tests := []struct {
+		name string
+
+		threshold int
+		interval  time.Duration
+
+		calls          int
+		perCallAdvance time.Duration
+
+		wantInstallHint int
+	}{
+		{
+			name:            "print-up-to-threshold",
+			threshold:       2,
+			interval:        time.Second,
+			calls:           10,
+			wantInstallHint: 2,
+		},
+		{
+			name:            "after-interval-threshold-resets",
+			threshold:       2,
+			interval:        time.Second * 5,
+			calls:           10,
+			perCallAdvance:  time.Second,
+			wantInstallHint: 4,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := api.ExecConfig{
+				Command:     "does not exist",
+				APIVersion:  "client.authentication.k8s.io/v1alpha1",
+				InstallHint: "some install hint",
+			}
+			a, err := newAuthenticator(newCache(), &c)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			a.sometimes.threshold = test.threshold
+			a.sometimes.interval = test.interval
+
+			clock := clock.NewFakeClock(time.Now())
+			a.sometimes.clock = clock
+
+			count := 0
+			for i := 0; i < test.calls; i++ {
+				err := a.refreshCredsLocked(&clientauthentication.Response{})
+				if strings.Contains(err.Error(), c.InstallHint) {
+					count++
+				}
+
+				clock.SetTime(clock.Now().Add(test.perCallAdvance))
+			}
+
+			if test.wantInstallHint != count {
+				t.Errorf(
+					"%s: expected install hint %d times got %d",
+					test.name,
+					test.wantInstallHint,
+					count,
+				)
+			}
+		})
+	}
 }
 
 // genClientCert generates an x509 certificate for testing. Certificate and key

--- a/staging/src/k8s.io/client-go/plugin/pkg/client/auth/exec/testdata/test-plugin.sh
+++ b/staging/src/k8s.io/client-go/plugin/pkg/client/auth/exec/testdata/test-plugin.sh
@@ -16,3 +16,4 @@
 
 >&2 echo "$KUBERNETES_EXEC_INFO"
 echo "$TEST_OUTPUT"
+exit "${TEST_EXIT_CODE:-0}"

--- a/staging/src/k8s.io/client-go/tools/clientcmd/api/types.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/api/types.go
@@ -210,6 +210,11 @@ type ExecConfig struct {
 	// Preferred input version of the ExecInfo. The returned ExecCredentials MUST use
 	// the same encoding version as the input.
 	APIVersion string `json:"apiVersion,omitempty"`
+
+	// This text is shown to the user when the executable doesn't seem to be
+	// present. For example, `brew install foo-cli` might be a good InstallHint for
+	// foo-cli on Mac OS systems.
+	InstallHint string `json:"installHint,omitempty"`
 }
 
 var _ fmt.Stringer = new(ExecConfig)

--- a/staging/src/k8s.io/client-go/tools/clientcmd/api/types.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/api/types.go
@@ -193,7 +193,7 @@ func (c AuthProviderConfig) String() string {
 // ExecConfig specifies a command to provide client credentials. The command is exec'd
 // and outputs structured stdout holding credentials.
 //
-// See the client.authentiction.k8s.io API group for specifications of the exact input
+// See the client.authentication.k8s.io API group for specifications of the exact input
 // and output format
 type ExecConfig struct {
 	// Command to execute.

--- a/staging/src/k8s.io/client-go/tools/clientcmd/api/v1/types.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/api/v1/types.go
@@ -209,6 +209,11 @@ type ExecConfig struct {
 	// Preferred input version of the ExecInfo. The returned ExecCredentials MUST use
 	// the same encoding version as the input.
 	APIVersion string `json:"apiVersion,omitempty"`
+
+	// This text is shown to the user when the executable doesn't seem to be
+	// present. For example, `brew install foo-cli` might be a good InstallHint for
+	// foo-cli on Mac OS systems.
+	InstallHint string `json:"installHint,omitempty"`
 }
 
 // ExecEnvVar is used for setting environment variables when executing an exec-based

--- a/staging/src/k8s.io/client-go/tools/clientcmd/api/v1/types.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/api/v1/types.go
@@ -192,7 +192,7 @@ type AuthProviderConfig struct {
 // ExecConfig specifies a command to provide client credentials. The command is exec'd
 // and outputs structured stdout holding credentials.
 //
-// See the client.authentiction.k8s.io API group for specifications of the exact input
+// See the client.authentication.k8s.io API group for specifications of the exact input
 // and output format
 type ExecConfig struct {
 	// Command to execute.

--- a/staging/src/k8s.io/client-go/tools/clientcmd/api/v1/zz_generated.conversion.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/api/v1/zz_generated.conversion.go
@@ -358,6 +358,7 @@ func autoConvert_v1_ExecConfig_To_api_ExecConfig(in *ExecConfig, out *api.ExecCo
 	out.Args = *(*[]string)(unsafe.Pointer(&in.Args))
 	out.Env = *(*[]api.ExecEnvVar)(unsafe.Pointer(&in.Env))
 	out.APIVersion = in.APIVersion
+	out.InstallHint = in.InstallHint
 	return nil
 }
 
@@ -371,6 +372,7 @@ func autoConvert_api_ExecConfig_To_v1_ExecConfig(in *api.ExecConfig, out *ExecCo
 	out.Args = *(*[]string)(unsafe.Pointer(&in.Args))
 	out.Env = *(*[]ExecEnvVar)(unsafe.Pointer(&in.Env))
 	out.APIVersion = in.APIVersion
+	out.InstallHint = in.InstallHint
 	return nil
 }
 


### PR DESCRIPTION
Signed-off-by: Andrew Keesler akeesler@vmware.com

/kind feature
/sig auth
/milestone v1.19
/assign @enj 
/priority important-soon
@kubernetes/sig-auth-pr-reviews

Fixes https://github.com/kubernetes/kubernetes/issues/91217

```release-note
client-go credential plugins can be given an install hint to tell users how to acquire the plugin executable.
```

```docs
- [KEP]: https://github.com/kubernetes/enhancements/blob/be64460ffc93037602bc5497782c0be898a85361/keps/sig-auth/541-external-credential-providers/README.md
```
