### PR TITLE
Reset flowcontrol metrics on a DELETE /metrics

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/routes/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/routes/metrics.go
@@ -48,6 +48,8 @@ func (m MetricsWithReset) Install(c *mux.PathRecorderMux) {
 		if req.Method == "DELETE" {
 			apimetrics.Reset()
 			etcd3metrics.Reset()
+			flowcontrolmetrics.Reset()
+
 			io.WriteString(w, "metrics reset\n")
 			return
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
>
> /kind api-change

/kind bug

> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Priority and Fairness metrics should reset when a a reset request is received (DELETE on /metrics endpoint)

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
None

```release-note
```
