### PR TITLE
build: Update to repo-infra@v0.0.5 to support go1.14.3 and go1.13.11

### DIFF
--- a/build/dependencies.yaml
+++ b/build/dependencies.yaml
@@ -197,3 +197,11 @@ dependencies:
       match: k8s.gcr.io\/pause:\d+\.\d+
     - path: test/utils/image/manifest.go
       match: configs\[Pause\] = Config{gcRegistry, "pause", "\d+\.\d+"}
+
+  - name: "repo-infra"
+    version: 0.0.5
+    refPaths:
+    - path: build/root/WORKSPACE
+      match: strip_prefix = "repo-infra-\d+.\d+.\d+"
+    - path: build/root/WORKSPACE
+      match: https://github.com/kubernetes/repo-infra/archive/v\d+.\d+.\d+.tar.gz

--- a/build/root/WORKSPACE
+++ b/build/root/WORKSPACE
@@ -5,10 +5,10 @@ load("//build:workspace_mirror.bzl", "mirror")
 
 http_archive(
     name = "io_k8s_repo_infra",
-    sha256 = "7ad484dc5558432ca0666cff68bfc584d52fdb7d3e08905405182a631af56128",
-    strip_prefix = "repo-infra-0.0.4",
+    sha256 = "55e56b332ead9c32e1d53c9834a5c918a4cecd6859b70645eba6cd10372fd68f",
+    strip_prefix = "repo-infra-0.0.5",
     urls = [
-        "https://github.com/kubernetes/repo-infra/archive/0.0.4.tar.gz",
+        "https://github.com/kubernetes/repo-infra/archive/v0.0.5.tar.gz",
     ],
 )
 


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup
/area dependency release-eng
/sig testing release

**What this PR does / why we need it**:

https://github.com/kubernetes/repo-infra/releases/tag/v0.0.5 pulls in bazel toolchain updates to support go1.14.3 and go1.13.11.

Needed for the in-flight Golang updates:
- go1.14.3: https://github.com/kubernetes/release/issues/1216 --> https://github.com/kubernetes/kubernetes/pull/88638
- go1.13.11: https://github.com/kubernetes/release/issues/1257

/assign @fejta @BenTheElder 
cc: @markyjackson-taulia @Verolop @kubernetes/release-engineering 

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
