### PR TITLE
Add OWNERS file to component-base/logs

### DIFF
--- a/staging/src/k8s.io/component-base/logs/OWNERS
+++ b/staging/src/k8s.io/component-base/logs/OWNERS
@@ -1,0 +1,8 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+- sig-instrumentation-approvers
+reviewers:
+- sig-instrumentation-reviewers
+labels:
+- sig/instrumentation


### PR DESCRIPTION
component-base/logs should be owned by sig-instrumentation. Will be useful to speed up review for Structured Logging https://github.com/kubernetes/enhancements/issues/1602

/kind cleanup
```release-note
NONE
```
/assign @mtaufen
