### PR TITLE
[v1.18]enhancement script: netstat not found in CentOS7/8

### DIFF
--- a/hack/lib/etcd.sh
+++ b/hack/lib/etcd.sh
@@ -41,7 +41,7 @@ kube::etcd::validate() {
   fi
   if ${port_check_command} -nat | grep "LISTEN" | grep "[\.:]${ETCD_PORT:?}" >/dev/null 2>&1; then
     kube::log::usage "unable to start etcd as port ${ETCD_PORT} is in use. please stop the process listening on this port and retry."
-    kube::log::usage "$(netstat -nat | grep "[\.:]${ETCD_PORT:?} .*LISTEN")"
+    kube::log::usage "$(command -v netstat >/dev/null 2>&1 && netstat -nat | grep "[\.:]${ETCD_PORT:?} .*LISTEN" || ss -nplt | grep "[\.:]${ETCD_PORT:?} ")"
     exit 1
   fi
 

--- a/hack/local-up-cluster.sh
+++ b/hack/local-up-cluster.sh
@@ -270,6 +270,7 @@ function test_apiserver_off {
             echo "API SERVER insecure port is free, proceeding..."
         else
             echo "ERROR starting API SERVER, exiting. Some process on ${API_HOST} is serving already on ${API_PORT}"
+	    echo "$(command -v netstat >/dev/null 2>&1 && netstat -nat | grep "[\.:]${API_PORT:?} .*LISTEN" || ss -nplt | grep "[\.:]${API_PORT:?} ")"
             exit 1
         fi
     fi
@@ -278,6 +279,7 @@ function test_apiserver_off {
         echo "API SERVER secure port is free, proceeding..."
     else
         echo "ERROR starting API SERVER, exiting. Some process on ${API_HOST} is serving already on ${API_SECURE_PORT}"
+	echo "$(command -v netstat >/dev/null 2>&1 && netstat -nat | grep "[\.:]${API_SECURE_PORT:?} .*LISTEN" || ss -nplt | grep "[\.:]${API_SECURE_PORT:?} ")"
         exit 1
     fi
 }


### PR DESCRIPTION
What type of PR is this?
/kind feature

What this PR does / why we need it:
netstat command wrapped in  net-tools package, but it is deprecated in CentOS7/8 .etc.
so I add ss command to fix this issue

Which issue(s) this PR fixes:
No issue is opened for that.

Special notes for your reviewer:
/assign @zmerlynn

Does this PR introduce a user-facing change?:
none

I signed it