### PR TITLE
Add test case for a pod becoming schedulable when a node is updated

### DIFF
--- a/test/integration/scheduler/predicates_test.go
+++ b/test/integration/scheduler/predicates_test.go
@@ -1051,8 +1051,35 @@ func TestUnschedulablePodBecomesSchedulable(t *testing.T) {
 				Name: "pod-1",
 			},
 			update: func(cs kubernetes.Interface) error {
-				_, err := createNode(cs, "node-1", nil)
-				return err
+				_, err := createNode(cs, "node-added", nil)
+				if err != nil {
+					return fmt.Errorf("cannot create node: %v", err)
+				}
+				return nil
+			},
+		},
+		{
+			name: "node gets taint removed",
+			init: func(cs kubernetes.Interface) error {
+				node, err := createNode(cs, "node-tainted", nil)
+				if err != nil {
+					return fmt.Errorf("cannot create node: %v", err)
+				}
+				taint := v1.Taint{Key: "test", Value: "test", Effect: v1.TaintEffectNoSchedule}
+				if err := testutils.AddTaintToNode(cs, node.Name, taint); err != nil {
+					return fmt.Errorf("cannot add taint to node: %v", err)
+				}
+				return nil
+			},
+			pod: &pausePodConfig{
+				Name: "pod-1",
+			},
+			update: func(cs kubernetes.Interface) error {
+				taint := v1.Taint{Key: "test", Value: "test", Effect: v1.TaintEffectNoSchedule}
+				if err := testutils.RemoveTaintOffNode(cs, "node-tainted", taint); err != nil {
+					return fmt.Errorf("cannot remove taint off node: %v", err)
+				}
+				return nil
 			},
 		},
 		// TODO(#91111): Add more test cases.
@@ -1061,6 +1088,7 @@ func TestUnschedulablePodBecomesSchedulable(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			testCtx := initTest(t, "scheduler-informer")
 			defer testutils.CleanupTest(t, testCtx)
+
 			if tt.init != nil {
 				if err := tt.init(testCtx.ClientSet); err != nil {
 					t.Fatal(err)

--- a/test/integration/util/util.go
+++ b/test/integration/util/util.go
@@ -219,9 +219,25 @@ func AddTaintToNode(cs clientset.Interface, nodeName string, taint v1.Taint) err
 	if err != nil {
 		return err
 	}
-	copy := node.DeepCopy()
-	copy.Spec.Taints = append(copy.Spec.Taints, taint)
-	_, err = cs.CoreV1().Nodes().Update(context.TODO(), copy, metav1.UpdateOptions{})
+	node.Spec.Taints = append(node.Spec.Taints, taint)
+	_, err = cs.CoreV1().Nodes().Update(context.TODO(), node, metav1.UpdateOptions{})
+	return err
+}
+
+// RemoveTaintOffNode removes a specific taint from a node
+func RemoveTaintOffNode(cs clientset.Interface, nodeName string, taint v1.Taint) error {
+	node, err := cs.CoreV1().Nodes().Get(context.TODO(), nodeName, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+	var taints []v1.Taint
+	for _, t := range node.Spec.Taints {
+		if !t.MatchTaint(&taint) {
+			taints = append(taints, t)
+		}
+	}
+	node.Spec.Taints = taints
+	_, err = cs.CoreV1().Nodes().Update(context.TODO(), node, metav1.UpdateOptions{})
 	return err
 }
 


### PR DESCRIPTION
What type of PR is this?

/kind cleanup

What this PR does / why we need it:

It adds integration test coverage around node changed. This is part of #91111, an effort to add more coverage to event handlers.

Does this PR introduce a user-facing change?:

NONE
