### PR TITLE
cluster/README.md: update notes about content

### DIFF
--- a/cluster/README.md
+++ b/cluster/README.md
@@ -2,11 +2,6 @@
 
 ##### Deprecation Notice: This directory has entered maintenance mode and will not be accepting new providers. Deployments in this directory will continue to be maintained and supported at their current level of support.
 
-The scripts and data in this directory automate creation and configuration of a Kubernetes cluster, including networking, DNS, nodes, and control plane components.
-
-See the [getting-started guides](https://kubernetes.io/docs/getting-started-guides) for examples of how to use the scripts.
-
-*cloudprovider*/`config-default.sh` contains a set of tweakable definitions/parameters for the cluster.
-
+See the [Getting started](https://kubernetes.io/docs/setup/) guide for alternatives.
 
 [![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/cluster/README.md?pixel)]()


### PR DESCRIPTION
**What this PR does / why we need it**:

- Adjust the link to point at https://kubernetes.io/docs/setup/
for alternative solutions.
https://kubernetes.io/docs/getting-started-guides already redirects to
https://kubernetes.io/docs/setup/ and it does not contain details on
/cluster usage.
- Remove notes about the contents of the folder, leaving only the
deprecation notice and link to alternatives.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
NONE

**Special notes for your reviewer**:
NONE

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
