### PR TITLE
Minor Fix: Restrict service account token metrics to kube-apiserver only.

### DIFF
--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -300,6 +300,7 @@ func CreateKubeAPIServerConfig(
 	})
 
 	s.Metrics.Apply()
+	serviceaccount.RegisterMetrics()
 
 	serviceIPRange, apiServerServiceIP, err := master.ServiceIPRange(s.PrimaryServiceClusterIPRange)
 	if err != nil {

--- a/pkg/serviceaccount/metrics.go
+++ b/pkg/serviceaccount/metrics.go
@@ -17,6 +17,8 @@ limitations under the License.
 package serviceaccount
 
 import (
+	"sync"
+
 	"k8s.io/component-base/metrics"
 	"k8s.io/component-base/metrics/legacyregistry"
 )
@@ -56,8 +58,12 @@ var (
 	)
 )
 
-func init() {
-	legacyregistry.MustRegister(legacyTokensTotal)
-	legacyregistry.MustRegister(staleTokensTotal)
-	legacyregistry.MustRegister(validTokensTotal)
+var registerMetricsOnce sync.Once
+
+func RegisterMetrics() {
+	registerMetricsOnce.Do(func() {
+		legacyregistry.MustRegister(legacyTokensTotal)
+		legacyregistry.MustRegister(staleTokensTotal)
+		legacyregistry.MustRegister(validTokensTotal)
+	})
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
We install the metrics to monitor bound service account token in init() method, which means all services importing serviceaccount package would automatically install the metric.
kube-controller-manager also import this package and installed the metric, which is not desired.

Modify the metric installation to be explicit in kube-apiserver init process.

```release-note
NONE
```