### PR TITLE
Adds staging directory for controller-manager code

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -463,6 +463,7 @@ replace (
 	k8s.io/cluster-bootstrap => ./staging/src/k8s.io/cluster-bootstrap
 	k8s.io/code-generator => ./staging/src/k8s.io/code-generator
 	k8s.io/component-base => ./staging/src/k8s.io/component-base
+	k8s.io/controller-manager => ./staging/src/k8s.io/controller-manager
 	k8s.io/cri-api => ./staging/src/k8s.io/cri-api
 	k8s.io/csi-translation-lib => ./staging/src/k8s.io/csi-translation-lib
 	k8s.io/gengo => k8s.io/gengo v0.0.0-20200428234225-8167cfdcfc14

--- a/staging/README.md
+++ b/staging/README.md
@@ -16,6 +16,7 @@ Repositories currently staged here:
 - [`k8s.io/cluster-bootstrap`](https://github.com/kubernetes/cluster-bootstrap)
 - [`k8s.io/code-generator`](https://github.com/kubernetes/code-generator)
 - [`k8s.io/component-base`](https://github.com/kubernetes/component-base)
+- [`k8s.io/controller-manager`](https://github.com/kubernetes/controller-manager)
 - [`k8s.io/cri-api`](https://github.com/kubernetes/cri-api)
 - [`k8s.io/csi-api`](https://github.com/kubernetes/csi-api)
 - [`k8s.io/csi-translation-lib`](https://github.com/kubernetes/csi-translation-lib)

--- a/staging/publishing/rules.yaml
+++ b/staging/publishing/rules.yaml
@@ -1598,3 +1598,13 @@ rules:
       branch: release-1.18
     - repository: metrics
       branch: release-1.18
+
+- destination: controller-manager
+  library: true
+  branches:
+  - source:
+      branch: master
+      dir: staging/src/k8s.io/controller-manager
+    name: master
+    go: 1.13.9
+

--- a/staging/repos_generated.bzl
+++ b/staging/repos_generated.bzl
@@ -26,6 +26,7 @@ staging_repos = [
     "k8s.io/cluster-bootstrap",
     "k8s.io/code-generator",
     "k8s.io/component-base",
+    "k8s.io/controller-manager",
     "k8s.io/cri-api",
     "k8s.io/csi-translation-lib",
     "k8s.io/kube-aggregator",

--- a/staging/src/BUILD
+++ b/staging/src/BUILD
@@ -25,6 +25,7 @@ filegroup(
         "//staging/src/k8s.io/cluster-bootstrap:all-srcs",
         "//staging/src/k8s.io/code-generator:all-srcs",
         "//staging/src/k8s.io/component-base:all-srcs",
+        "//staging/src/k8s.io/controller-manager:all-srcs",
         "//staging/src/k8s.io/cri-api:all-srcs",
         "//staging/src/k8s.io/csi-translation-lib:all-srcs",
         "//staging/src/k8s.io/kube-aggregator:all-srcs",

--- a/staging/src/k8s.io/controller-manager/.github/PULL_REQUEST_TEMPLATE.md
+++ b/staging/src/k8s.io/controller-manager/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,2 @@
+Sorry, we do not accept changes directly against this repository. Please see
+CONTRIBUTING.md for information on where and how to contribute instead.

--- a/staging/src/k8s.io/controller-manager/BUILD
+++ b/staging/src/k8s.io/controller-manager/BUILD
@@ -1,0 +1,27 @@
+package(default_visibility = ["//visibility:public"])
+
+load(
+    "@io_bazel_rules_go//go:def.bzl",
+    "go_library",
+)
+
+go_library(
+    name = "go_default_library",
+    srcs = ["doc.go"],
+    importmap = "k8s.io/kubernetes/vendor/k8s.io/controller-manager",
+    importpath = "k8s.io/controller-manager",
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/staging/src/k8s.io/controller-manager/CONTRIBUTING.md
+++ b/staging/src/k8s.io/controller-manager/CONTRIBUTING.md
@@ -1,0 +1,23 @@
+# Contributing guidelines
+
+Welcome to Kubernetes. We are excited about the prospect of you joining our [community](https://git.k8s.io/community)! The Kubernetes community abides by the CNCF [code of conduct](code-of-conduct.md). Here is an excerpt:
+
+_As contributors and maintainers of this project, and in the interest of fostering an open and welcoming community, we pledge to respect all people who contribute through reporting issues, posting feature requests, updating documentation, submitting pull requests or patches, and other activities._
+
+## How to become a contributor and submit your own code
+
+This repository does not directly accept contributions. Code in this repository is currently being copied from staging within the [Kubernetes repository](https://github.com/kubernetes/kubernetes/tree/master/staging). In order to contribute code to this repository, the coder must modify kubectl code in [staging](https://github.com/kubernetes/kubernetes/tree/master/staging/src/k8s.io/controller-manager).
+
+See [this doc](https://github.com/kubernetes/community/tree/master/sig-api-machinery) and [this doc](https://github.com/kubernetes/community/tree/master/sig-cloud-provider) for information about contributing.
+
+## Getting Started
+
+We have full documentation on how to get started contributing here:
+
+- [Contributor License Agreement](https://git.k8s.io/community/CLA.md) Kubernetes projects require that you sign a Contributor License Agreement (CLA) before we can accept your pull requests
+- [Kubernetes Contributor Guide](https://git.k8s.io/community/contributors/guide) - Main contributor documentation, or you can just jump directly to the [contributing section](https://git.k8s.io/community/contributors/guide#contributing)
+- [Contributor Cheat Sheet](https://git.k8s.io/community/contributors/guide/contributor-cheatsheet) - Common resources for existing developers
+
+## Mentorship
+
+- [Mentoring Initiatives](https://git.k8s.io/community/mentoring) - We have a diverse set of mentorship programs available that are always looking for volunteers!

--- a/staging/src/k8s.io/controller-manager/LICENSE
+++ b/staging/src/k8s.io/controller-manager/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/staging/src/k8s.io/controller-manager/OWNERS
+++ b/staging/src/k8s.io/controller-manager/OWNERS
@@ -1,0 +1,22 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+- andrewsykim
+- cheftako
+- deads2k
+- lavalamp
+- liggitt
+- mtaufen
+- sttts
+reviewers:
+- andrewsykim
+- cheftako
+- deads2k
+- lavalamp
+- liggitt
+- luxas
+- mtaufen
+- sttts
+labels:
+- sig/api-machinery
+- sig/cloud-provider

--- a/staging/src/k8s.io/controller-manager/README.md
+++ b/staging/src/k8s.io/controller-manager/README.md
@@ -1,0 +1,33 @@
+# Controller-manager
+
+## Purpose
+
+This library contains common code for controller managers. Principally its for
+the Kube-Controller-Manager and Cloud-Controller-Manager. However other
+controller managers are welcome to use this code.
+
+
+## Compatibility
+
+There are *NO compatibility guarantees* for this repository, yet.  It is in direct support of Kubernetes, so branches
+will track Kubernetes and be compatible with that repo.  As we more cleanly separate the layers, we will review the
+compatibility guarantee. We have a goal to make this easier to use in the future.
+
+
+## Where does it come from?
+
+This package comes from the common code between kube-controller-manager and
+cloud-controller-manager. The intent is for it to contain our current
+understanding of the right way to build a controller manager. There are legacy
+aspects of these controller managers which should be cleaned before adding them
+here.
+`controller-manager` is synced from https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/controller-manager.
+Code changes are made in that location, merged into `k8s.io/kubernetes` and later synced here.
+
+
+## Things you should *NOT* do
+
+ 1. Directly modify any files under `pkg` in this repo.  Those are driven from `k8s.io/kubernetes/staging/src/k8s.io/controller-manager`.
+ 2. Expect compatibility.  This repo is currently changing rapidly in direct support of
+    Kubernetes and the controller-manager processes and the cloud provider
+    extraction effort.

--- a/staging/src/k8s.io/controller-manager/SECURITY_CONTACTS
+++ b/staging/src/k8s.io/controller-manager/SECURITY_CONTACTS
@@ -1,0 +1,18 @@
+# Defined below are the security contacts for this repo.
+#
+# They are the contact point for the Product Security Committee to reach out
+# to for triaging and handling of incoming issues.
+#
+# The below names agree to abide by the
+# [Embargo Policy](https://git.k8s.io/security/private-distributors-list.md#embargo-policy)
+# and will be removed and replaced if they violate that agreement.
+#
+# DO NOT REPORT SECURITY VULNERABILITIES DIRECTLY TO THESE NAMES, FOLLOW THE
+# INSTRUCTIONS AT https://kubernetes.io/security/
+
+cjcullen
+joelsmith
+liggitt
+luxas
+sttts
+tallclair

--- a/staging/src/k8s.io/controller-manager/code-of-conduct.md
+++ b/staging/src/k8s.io/controller-manager/code-of-conduct.md
@@ -1,0 +1,3 @@
+# Kubernetes Community Code of Conduct
+
+Please refer to our [Kubernetes Community Code of Conduct](https://git.k8s.io/community/code-of-conduct.md)

--- a/staging/src/k8s.io/controller-manager/doc.go
+++ b/staging/src/k8s.io/controller-manager/doc.go
@@ -1,0 +1,20 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package controllermanager contains the common library code for
+// building a controller-manager. It was based on the common code
+// between the kube-controller-manager and the cloud-controller-manager.
+package controllermanager // import "k8s.io/controller-manager"

--- a/staging/src/k8s.io/controller-manager/go.mod
+++ b/staging/src/k8s.io/controller-manager/go.mod
@@ -1,0 +1,7 @@
+// This is a generated file. Do not edit directly.
+
+module k8s.io/controller-manager
+
+go 1.13
+
+replace k8s.io/controller-manager => ../controller-manager

--- a/vendor/k8s.io/controller-manager
+++ b/vendor/k8s.io/controller-manager
@@ -1,0 +1,1 @@
+../../staging/src/k8s.io/controller-manager


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
* Creates staging directory for common controller-manager code
* Adds the following initial files to this directory:

  * .github/PULL_REQUEST_TEMPLATE.md
  * code-of-conduct.md
  * LICENSE
  * OWNERS
  * README.md
  * SECURITY_CONTACTS
* Code committed to the controller-manager staging directory will be published to: https://github.com/kubernetes/controller-manager

**Which issue(s) this PR fixes**:
Fixes # None

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Special notes for your reviewer**:
Initial approval deads2k (sig-api-machinery chair)

The config we would expect any controller manager to need to connect to the API server, set up metrics endpoints, create per-controller-loop API clients, and spin up the individual loops could make sense under a k8s.io/controller-manager package.

Then cmd/kube-controller-manager could continue to contain the weirdnesses specific to kube-controller-manager.

This is similar to the way we split out recommended API server setup into k8s.io/apiserver and tried to limit kube-apiserver oddities to cmd/kube-apiserver and pkg/kubeapiserver

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs
NONE
```

/sig api-machinery
/area kube-controller-manager
/area cloud-controller-manager