### PR TITLE
Fix if don't set ephemeral-storage limit emptyDir's sizeLimit doesn't work

### DIFF
--- a/pkg/kubelet/volumemanager/cache/BUILD
+++ b/pkg/kubelet/volumemanager/cache/BUILD
@@ -43,6 +43,7 @@ go_test(
         "//pkg/volume/util/operationexecutor:go_default_library",
         "//pkg/volume/util/types:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/api/resource:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/github.com/stretchr/testify/require:go_default_library",
     ],

--- a/pkg/kubelet/volumemanager/cache/desired_state_of_world.go
+++ b/pkg/kubelet/volumemanager/cache/desired_state_of_world.go
@@ -263,7 +263,7 @@ func (dsw *desiredStateOfWorld) AddPodToVolume(
 				if volumeSpec.Volume.EmptyDir != nil &&
 					volumeSpec.Volume.EmptyDir.SizeLimit != nil &&
 					volumeSpec.Volume.EmptyDir.SizeLimit.Value() > 0 &&
-					volumeSpec.Volume.EmptyDir.SizeLimit.Value() < sizeLimit.Value() {
+					(sizeLimit.Value() == 0 || volumeSpec.Volume.EmptyDir.SizeLimit.Value() < sizeLimit.Value()) {
 					sizeLimit = resource.NewQuantity(volumeSpec.Volume.EmptyDir.SizeLimit.Value(), resource.BinarySI)
 				}
 			}

--- a/pkg/kubelet/volumemanager/cache/desired_state_of_world_test.go
+++ b/pkg/kubelet/volumemanager/cache/desired_state_of_world_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cache
 
 import (
+	"k8s.io/apimachinery/pkg/api/resource"
 	"testing"
 
 	"k8s.io/api/core/v1"
@@ -460,6 +461,141 @@ func Test_MarkVolumesReportedInUse_Positive_NewPodNewVolume(t *testing.T) {
 	verifyPodExistsInVolumeDsw(t, pod3Name, generatedVolume3Name, dsw)
 }
 
+func Test_AddPodToVolume_WithEmptyDirSizeLimit(t *testing.T) {
+	volumePluginMgr, _ := volumetesting.GetTestVolumePluginMgr(t)
+	dsw := NewDesiredStateOfWorld(volumePluginMgr)
+	quantity1Gi := resource.MustParse("1Gi")
+	quantity2Gi := resource.MustParse("2Gi")
+	quantity3Gi := resource.MustParse("3Gi")
+
+	pod1 := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "pod1",
+			UID:  "pod1uid",
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{
+					Resources: v1.ResourceRequirements{
+						Limits: v1.ResourceList{
+							v1.ResourceEphemeralStorage: quantity1Gi,
+						},
+					},
+				},
+				{
+					Resources: v1.ResourceRequirements{
+						Limits: v1.ResourceList{
+							v1.ResourceEphemeralStorage: quantity1Gi,
+						},
+					},
+				},
+			},
+			Volumes: []v1.Volume{
+				{
+					Name: "emptyDir1",
+					VolumeSource: v1.VolumeSource{
+						EmptyDir: &v1.EmptyDirVolumeSource{
+							SizeLimit: &quantity1Gi,
+						},
+					},
+				},
+				{
+					Name: "emptyDir2",
+					VolumeSource: v1.VolumeSource{
+						EmptyDir: &v1.EmptyDirVolumeSource{
+							SizeLimit: &quantity2Gi,
+						},
+					},
+				},
+				{
+					Name: "emptyDir3",
+					VolumeSource: v1.VolumeSource{
+						EmptyDir: &v1.EmptyDirVolumeSource{
+							SizeLimit: &quantity3Gi,
+						},
+					},
+				},
+				{
+					Name: "emptyDir4",
+					VolumeSource: v1.VolumeSource{
+						EmptyDir: &v1.EmptyDirVolumeSource{},
+					},
+				},
+			},
+		},
+	}
+	pod1Name := util.GetUniquePodName(pod1)
+	pod1DesiredSizeLimitMap := map[string]*resource.Quantity{
+		"emptyDir1": &quantity1Gi,
+		"emptyDir2": &quantity2Gi,
+		"emptyDir3": &quantity2Gi,
+		"emptyDir4": &quantity2Gi,
+	}
+	pod2 := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "pod2",
+			UID:  "pod2uid",
+		},
+		Spec: v1.PodSpec{
+			Volumes: []v1.Volume{
+				{
+					Name: "emptyDir5",
+					VolumeSource: v1.VolumeSource{
+						EmptyDir: &v1.EmptyDirVolumeSource{
+							SizeLimit: &quantity1Gi,
+						},
+					},
+				},
+				{
+					Name: "emptyDir6",
+					VolumeSource: v1.VolumeSource{
+						EmptyDir: &v1.EmptyDirVolumeSource{
+							SizeLimit: &quantity2Gi,
+						},
+					},
+				},
+				{
+					Name: "emptyDir7",
+					VolumeSource: v1.VolumeSource{
+						EmptyDir: &v1.EmptyDirVolumeSource{
+							SizeLimit: &quantity3Gi,
+						},
+					},
+				},
+				{
+					Name: "emptyDir8",
+					VolumeSource: v1.VolumeSource{
+						EmptyDir: &v1.EmptyDirVolumeSource{},
+					},
+				},
+			},
+		},
+	}
+	pod2Name := util.GetUniquePodName(pod2)
+	pod2DesiredSizeLimitMap := map[string]*resource.Quantity{
+		"emptyDir5": &quantity1Gi,
+		"emptyDir6": &quantity2Gi,
+		"emptyDir7": &quantity3Gi,
+		"emptyDir8": resource.NewQuantity(0, resource.BinarySI),
+	}
+	for i := range pod1.Spec.Volumes {
+		volumeSpec := &volume.Spec{Volume: &pod1.Spec.Volumes[i]}
+		_, err := dsw.AddPodToVolume(pod1Name, pod1, volumeSpec, volumeSpec.Name(), "")
+		if err != nil {
+			t.Fatalf("AddPodToVolume failed. Expected: <no error> Actual: <%v>", err)
+		}
+	}
+	for i := range pod2.Spec.Volumes {
+		volumeSpec := &volume.Spec{Volume: &pod2.Spec.Volumes[i]}
+		_, err := dsw.AddPodToVolume(pod2Name, pod2, volumeSpec, volumeSpec.Name(), "")
+		if err != nil {
+			t.Fatalf("AddPodToVolume failed. Expected: <no error> Actual: <%v>", err)
+		}
+	}
+	verifyDesiredSizeLimitInVolumeDsw(t, pod1Name, pod1DesiredSizeLimitMap, dsw)
+	verifyDesiredSizeLimitInVolumeDsw(t, pod2Name, pod2DesiredSizeLimitMap, dsw)
+}
+
 func verifyVolumeExistsDsw(
 	t *testing.T, expectedVolumeName v1.UniqueVolumeName, dsw DesiredStateOfWorld) {
 	volumeExists := dsw.VolumeExists(expectedVolumeName)
@@ -569,5 +705,33 @@ func verifyVolumeDoesntExistWithSpecNameInVolumeDsw(
 		t.Fatalf(
 			"DSW VolumeExistsWithSpecNam returned incorrect value. Expected: <true> Actual: <%v>",
 			podExistsInVolume)
+	}
+}
+
+func verifyDesiredSizeLimitInVolumeDsw(
+	t *testing.T,
+	expectedPodName volumetypes.UniquePodName,
+	expectedDesiredSizeMap map[string]*resource.Quantity,
+	dsw DesiredStateOfWorld) {
+	volumesToMount := dsw.GetVolumesToMount()
+	for volumeName, expectedDesiredSize := range expectedDesiredSizeMap {
+		if podExistsInVolume := dsw.VolumeExistsWithSpecName(
+			expectedPodName, volumeName); !podExistsInVolume {
+			t.Fatalf(
+				"DSW VolumeExistsWithSpecName returned incorrect value. Expected: <true> Actual: <%v>",
+				podExistsInVolume)
+		}
+		for _, v := range volumesToMount {
+			if v.VolumeSpec.Name() == volumeName && v.PodName == expectedPodName {
+				if v.DesiredSizeLimit == nil || v.DesiredSizeLimit.Value() != expectedDesiredSize.Value() {
+					t.Fatalf(
+						"Found volume %v in the list of VolumesToMount, but DesiredSizeLimit incorrect. Expected: <%v> Actual: <%v>",
+						volumeName,
+						expectedDesiredSize,
+						v.DesiredSizeLimit)
+
+				}
+			}
+		}
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**
 /kind bug

**What this PR does / why we need it**:

If we don't set ephemeral-storage limit and only set emptyDir's sizeLimit like
```yaml
apiVersion: v1
kind: Pod
metadata:
  name: myapp-pod
  labels:
    app: myapp
spec:
  containers:
  - name: myapp-container
    image: busybox
    command: ['sh', '-c', 'echo Hello Kubernetes! && sleep 3600']
    volumeMounts:
    - mountPath: /cache
       name: cache-volume
  volumes:
  - name: cache-volume
    emptyDir:
      sizeLimit: "1Gi"
```
`LocalStorageCapacityIsolationFSQuotaMonitoring` feature doesn't work, because `volumeToMount.desiredSizeLimit` is zero, we should make `volumeToMount.desiredSizeLimit` equal `emptyDir.sizeLimit`.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
@RobertKrawitz 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
