### PR TITLE
serviceaccount: fix log spam when namespace is being terminated

### DIFF
--- a/cmd/kube-controller-manager/app/controllermanager.go
+++ b/cmd/kube-controller-manager/app/controllermanager.go
@@ -573,6 +573,7 @@ func (c serviceAccountTokenControllerStarter) startServiceAccountTokenController
 	controller, err := serviceaccountcontroller.NewTokensController(
 		ctx.InformerFactory.Core().V1().ServiceAccounts(),
 		ctx.InformerFactory.Core().V1().Secrets(),
+		ctx.InformerFactory.Core().V1().Namespaces(),
 		c.rootClientBuilder.ClientOrDie("tokens-controller"),
 		serviceaccountcontroller.TokensControllerOptions{
 			TokenGenerator: tokenGenerator,

--- a/pkg/controller/serviceaccount/tokens_controller_test.go
+++ b/pkg/controller/serviceaccount/tokens_controller_test.go
@@ -26,7 +26,7 @@ import (
 	"gopkg.in/square/go-jose.v2/jwt"
 	"k8s.io/klog/v2"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -583,7 +583,9 @@ func TestTokenCreation(t *testing.T) {
 		secretInformer := informers.Core().V1().Secrets().Informer()
 		secrets := secretInformer.GetStore()
 		serviceAccounts := informers.Core().V1().ServiceAccounts().Informer().GetStore()
-		controller, err := NewTokensController(informers.Core().V1().ServiceAccounts(), informers.Core().V1().Secrets(), client, TokensControllerOptions{TokenGenerator: generator, RootCA: []byte("CA Data"), MaxRetries: tc.MaxRetries})
+		controller, err := NewTokensController(informers.Core().V1().ServiceAccounts(), informers.Core().V1().Secrets(), informers.Core().V1().Namespaces(), client, TokensControllerOptions{TokenGenerator: generator,
+			RootCA:     []byte("CA Data"),
+			MaxRetries: tc.MaxRetries})
 		if err != nil {
 			t.Fatalf("error creating Tokens controller: %v", err)
 		}

--- a/test/integration/serviceaccount/service_account_test.go
+++ b/test/integration/serviceaccount/service_account_test.go
@@ -463,6 +463,7 @@ func startServiceAccountTestServer(t *testing.T) (*clientset.Clientset, restclie
 	tokenController, err := serviceaccountcontroller.NewTokensController(
 		informers.Core().V1().ServiceAccounts(),
 		informers.Core().V1().Secrets(),
+		informers.Core().V1().Namespaces(),
 		rootClientset,
 		serviceaccountcontroller.TokensControllerOptions{TokenGenerator: tokenGenerator},
 	)


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

In case the namespace is terminating, tokens controller will produce a lot of log spam when it tries to recreate the tokens, this will stop it.
It could have been nicer than checking string, but we will have to expose the error type from apiserver package, which will introduce bad import loop.

**Special notes for your reviewer**:

```release-note
NONE
```