### PR TITLE
Tuned npb is workload resources

### DIFF
--- a/test/e2e_node/perf/workloads/npb_is.go
+++ b/test/e2e_node/perf/workloads/npb_is.go
@@ -44,11 +44,11 @@ func (w npbISWorkload) PodSpec() v1.PodSpec {
 		Image: "gcr.io/kubernetes-e2e-test-images/node-perf/npb-is:1.0",
 		Resources: v1.ResourceRequirements{
 			Requests: v1.ResourceList{
-				v1.ResourceName(v1.ResourceCPU):    resource.MustParse("16000m"),
+				v1.ResourceName(v1.ResourceCPU):    resource.MustParse("15000m"),
 				v1.ResourceName(v1.ResourceMemory): resource.MustParse("48Gi"),
 			},
 			Limits: v1.ResourceList{
-				v1.ResourceName(v1.ResourceCPU):    resource.MustParse("16000m"),
+				v1.ResourceName(v1.ResourceCPU):    resource.MustParse("15000m"),
 				v1.ResourceName(v1.ResourceMemory): resource.MustParse("48Gi"),
 			},
 		},


### PR DESCRIPTION
Lowering the amount of cpu allocated to this workload will set the
resources allocated to be similar to the other npb and tf workload in
this tests.
This will also allow to run all three workloads in a n1-standard-12 gcp
instance - which has 16 cpus and 60 GB.

Signed-off-by: alejandrox1 <alarcj137@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind failing-test


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Related to https://github.com/kubernetes/test-infra/pull/17687
Aiming to fix the test failure in https://github.com/kubernetes/kubernetes/issues/91263



**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```

/sig node
/priority important-longterm
/kind failing-test