### PR TITLE
Fix static check failures for vendor/k8s.io/cli-runtime/pkg/printers.

### DIFF
--- a/hack/.staticcheck_failures
+++ b/hack/.staticcheck_failures
@@ -66,7 +66,6 @@ vendor/k8s.io/apiserver/pkg/util/wsstream
 vendor/k8s.io/apiserver/plugin/pkg/authenticator/token/oidc
 vendor/k8s.io/apiserver/plugin/pkg/authenticator/token/webhook
 vendor/k8s.io/apiserver/plugin/pkg/authorizer/webhook
-vendor/k8s.io/cli-runtime/pkg/printers
 vendor/k8s.io/client-go/discovery
 vendor/k8s.io/client-go/discovery/cached/memory
 vendor/k8s.io/client-go/dynamic/fake

--- a/staging/src/k8s.io/cli-runtime/pkg/printers/tableprinter.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/printers/tableprinter.go
@@ -94,9 +94,8 @@ func printHeader(columnNames []string, w io.Writer) error {
 // PrintObj prints the obj in a human-friendly format according to the type of the obj.
 func (h *HumanReadablePrinter) PrintObj(obj runtime.Object, output io.Writer) error {
 
-	w, found := output.(*tabwriter.Writer)
-	if !found {
-		w = GetNewTabWriter(output)
+	if _, found := output.(*tabwriter.Writer); !found {
+		w := GetNewTabWriter(output)
 		output = w
 		defer w.Flush()
 	}


### PR DESCRIPTION
Signed-off-by: Caesar <longfei.shang@daocloud.io>
*What type of PR is this?**
> /kind cleanup

**What this PR does / why we need it**:
vendor/k8s.io/cli-runtime/pkg/printers/tableprinter.go:96:2: this value of w is never used (SA4006)
**Which issue(s) this PR fixes**:

Ref #81657 
Ref #92402

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:



**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
