### PR TITLE
Revert "Rely on default watch cache capacity and ignore its requested size"

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher.go
@@ -61,8 +61,6 @@ const (
 // Config contains the configuration for a given Cache.
 type Config struct {
 	// Maximum size of the history cached in memory.
-	//
-	// DEPRECATED: Cache capacity is dynamic and this field is no longer used.
 	CacheCapacity int
 
 	// An underlying storage.Interface.
@@ -359,7 +357,7 @@ func NewCacherFromConfig(config Config) (*Cacher, error) {
 	}
 
 	watchCache := newWatchCache(
-		config.KeyFunc, cacher.processEvent, config.GetAttrsFunc, config.Versioner, config.Indexers, objType)
+		config.CacheCapacity, config.KeyFunc, cacher.processEvent, config.GetAttrsFunc, config.Versioner, config.Indexers, objType)
 	listerWatcher := NewCacherListerWatcher(config.Storage, config.ResourcePrefix, config.NewListFunc)
 	reflectorName := "storage/cacher.go:" + config.ResourcePrefix
 

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache.go
@@ -193,6 +193,7 @@ type watchCache struct {
 }
 
 func newWatchCache(
+	capacity int,
 	keyFunc func(runtime.Object) (string, error),
 	eventHandler func(*watchCacheEvent),
 	getAttrsFunc func(runtime.Object) (labels.Set, fields.Set, error),
@@ -200,12 +201,13 @@ func newWatchCache(
 	indexers *cache.Indexers,
 	objectType reflect.Type) *watchCache {
 	wc := &watchCache{
-		capacity:            defaultLowerBoundCapacity,
-		keyFunc:             keyFunc,
-		getAttrsFunc:        getAttrsFunc,
-		cache:               make([]*watchCacheEvent, defaultLowerBoundCapacity),
-		lowerBoundCapacity:  defaultLowerBoundCapacity,
-		upperBoundCapacity:  defaultUpperBoundCapacity,
+		capacity:     capacity,
+		keyFunc:      keyFunc,
+		getAttrsFunc: getAttrsFunc,
+		cache:        make([]*watchCacheEvent, capacity),
+		// TODO get rid of them once we stop passing capacity as a parameter to watch cache.
+		lowerBoundCapacity:  min(capacity, defaultLowerBoundCapacity),
+		upperBoundCapacity:  max(capacity, defaultUpperBoundCapacity),
 		startIndex:          0,
 		endIndex:            0,
 		store:               cache.NewIndexer(storeElementKey, storeElementIndexers(indexers)),

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache_test.go
@@ -81,14 +81,7 @@ func newTestWatchCache(capacity int, indexers *cache.Indexers) *watchCache {
 	}
 	versioner := etcd3.APIObjectVersioner{}
 	mockHandler := func(*watchCacheEvent) {}
-	wc := newWatchCache(keyFunc, mockHandler, getAttrsFunc, versioner, indexers, reflect.TypeOf(&example.Pod{}))
-	// To preserve behavior of tests that assume a given capacity,
-	// resize it to th expected size.
-	wc.capacity = capacity
-	wc.cache = make([]*watchCacheEvent, capacity)
-	wc.lowerBoundCapacity = min(capacity, defaultLowerBoundCapacity)
-	wc.upperBoundCapacity = max(capacity, defaultUpperBoundCapacity)
-
+	wc := newWatchCache(capacity, keyFunc, mockHandler, getAttrsFunc, versioner, indexers, reflect.TypeOf(&example.Pod{}))
 	wc.clock = clock.NewFakeClock(time.Now())
 	return wc
 }


### PR DESCRIPTION
This reverts PR 91260 to fix #91367

```release-note
NONE
```

/kind bug failing-test
/sig api-machinery
/cc @wojtek-t 