### PR TITLE
feat: more accurate description in multiple containers

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/polymorphichelpers/helpers.go
+++ b/staging/src/k8s.io/kubectl/pkg/polymorphichelpers/helpers.go
@@ -189,3 +189,16 @@ func SelectorsForObject(object runtime.Object) (namespace string, selector label
 
 	return namespace, selector, nil
 }
+
+func CheckAllContainersIfMoreThanOne(pod *corev1.Pod) string {
+	containerNames := getContainerNames(pod.Spec.Containers)
+	otherContainersDesc := ""
+	if len(pod.Spec.InitContainers) > 0 {
+		otherContainersDesc += fmt.Sprintf(" or one of the init containers: [%s]", getContainerNames(pod.Spec.InitContainers))
+	}
+	if len(pod.Spec.EphemeralContainers) > 0 {
+		otherContainersDesc += fmt.Sprintf(" or one of the ephemeral containers: [%s]", getContainerNames(ephemeralContainersToContainers(pod.Spec.EphemeralContainers)))
+	}
+
+	return fmt.Sprintf("A container name must be specified for pod %s, choose one of: [%s]%s\n", pod.Name, containerNames, otherContainersDesc)
+}


### PR DESCRIPTION
**What type of PR is this?**

> /kind feature

**What this PR does / why we need it**:

Before this pull request. When execute kubectl attach and kuberctl exec commods in multiple containers, it will show to execute kubectl describe commod to see all of the containers in this pod.
 
After this pull request,  it will show containers list directly in terminal.

