### PR TITLE
Remove deprecated scheduling metrics in 1.19

### DIFF
--- a/cmd/kube-scheduler/app/BUILD
+++ b/cmd/kube-scheduler/app/BUILD
@@ -17,7 +17,6 @@ go_library(
         "//pkg/scheduler:go_default_library",
         "//pkg/scheduler/apis/config:go_default_library",
         "//pkg/scheduler/framework/v1alpha1:go_default_library",
-        "//pkg/scheduler/metrics:go_default_library",
         "//pkg/scheduler/profile:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/api/events/v1beta1:go_default_library",

--- a/cmd/kube-scheduler/app/server.go
+++ b/cmd/kube-scheduler/app/server.go
@@ -20,7 +20,6 @@ package app
 import (
 	"context"
 	"fmt"
-	"io"
 	"net/http"
 	"os"
 	goruntime "runtime"
@@ -58,7 +57,6 @@ import (
 	"k8s.io/kubernetes/pkg/scheduler"
 	kubeschedulerconfig "k8s.io/kubernetes/pkg/scheduler/apis/config"
 	framework "k8s.io/kubernetes/pkg/scheduler/framework/v1alpha1"
-	"k8s.io/kubernetes/pkg/scheduler/metrics"
 	"k8s.io/kubernetes/pkg/scheduler/profile"
 )
 
@@ -232,17 +230,7 @@ func buildHandlerChain(handler http.Handler, authn authenticator.Request, authz 
 func installMetricHandler(pathRecorderMux *mux.PathRecorderMux) {
 	configz.InstallHandler(pathRecorderMux)
 	//lint:ignore SA1019 See the Metrics Stability Migration KEP
-	defaultMetricsHandler := legacyregistry.Handler().ServeHTTP
-	pathRecorderMux.HandleFunc("/metrics", func(w http.ResponseWriter, req *http.Request) {
-		if req.Method == "DELETE" {
-			metrics.Reset()
-			w.Header().Set("Content-Type", "text/plain; charset=utf-8")
-			w.Header().Set("X-Content-Type-Options", "nosniff")
-			io.WriteString(w, "metrics reset\n")
-			return
-		}
-		defaultMetricsHandler(w, req)
-	})
+	pathRecorderMux.Handle("/metrics", legacyregistry.Handler())
 }
 
 // newMetricsHandler builds a metrics server from the config.

--- a/pkg/scheduler/core/generic_scheduler.go
+++ b/pkg/scheduler/core/generic_scheduler.go
@@ -162,7 +162,6 @@ func (g *genericScheduler) Schedule(ctx context.Context, prof *profile.Profile, 
 	}
 
 	// Run "prefilter" plugins.
-	startPredicateEvalTime := time.Now()
 	filteredNodes, filteredNodesStatuses, err := g.findNodesThatFitPod(ctx, prof, state, pod)
 	if err != nil {
 		return result, err
@@ -177,13 +176,8 @@ func (g *genericScheduler) Schedule(ctx context.Context, prof *profile.Profile, 
 		}
 	}
 
-	metrics.DeprecatedSchedulingAlgorithmPredicateEvaluationSecondsDuration.Observe(metrics.SinceInSeconds(startPredicateEvalTime))
-	metrics.DeprecatedSchedulingDuration.WithLabelValues(metrics.PredicateEvaluation).Observe(metrics.SinceInSeconds(startPredicateEvalTime))
-
-	startPriorityEvalTime := time.Now()
 	// When only one node after predicate, just use it.
 	if len(filteredNodes) == 1 {
-		metrics.DeprecatedSchedulingAlgorithmPriorityEvaluationSecondsDuration.Observe(metrics.SinceInSeconds(startPriorityEvalTime))
 		return ScheduleResult{
 			SuggestedHost:  filteredNodes[0].Name,
 			EvaluatedNodes: 1 + len(filteredNodesStatuses),
@@ -195,9 +189,6 @@ func (g *genericScheduler) Schedule(ctx context.Context, prof *profile.Profile, 
 	if err != nil {
 		return result, err
 	}
-
-	metrics.DeprecatedSchedulingAlgorithmPriorityEvaluationSecondsDuration.Observe(metrics.SinceInSeconds(startPriorityEvalTime))
-	metrics.DeprecatedSchedulingDuration.WithLabelValues(metrics.PriorityEvaluation).Observe(metrics.SinceInSeconds(startPriorityEvalTime))
 
 	host, err := g.selectHost(priorityList)
 	trace.Step("Prioritizing done")

--- a/pkg/scheduler/metrics/metrics.go
+++ b/pkg/scheduler/metrics/metrics.go
@@ -28,22 +28,6 @@ import (
 const (
 	// SchedulerSubsystem - subsystem name used by scheduler
 	SchedulerSubsystem = "scheduler"
-	// DeprecatedSchedulingDurationName - scheduler duration metric name which is deprecated
-	DeprecatedSchedulingDurationName = "scheduling_duration_seconds"
-
-	// OperationLabel - operation label name
-	OperationLabel = "operation"
-	// Below are possible values for the operation label. Each represents a substep of e2e scheduling:
-
-	// PredicateEvaluation - predicate evaluation operation label value
-	PredicateEvaluation = "predicate_evaluation"
-	// PriorityEvaluation - priority evaluation operation label value
-	PriorityEvaluation = "priority_evaluation"
-	// PreemptionEvaluation - preemption evaluation operation label value (occurs in case of scheduling fitError).
-	PreemptionEvaluation = "preemption_evaluation"
-	// Binding - binding operation label value
-	Binding = "binding"
-	// E2eScheduling - e2e scheduling operation label value
 )
 
 // All the histogram based metrics have 1ms as size for the smallest bucket.
@@ -63,20 +47,7 @@ var (
 	PodScheduleFailures = scheduleAttempts.With(metrics.Labels{"result": "unschedulable"})
 	// PodScheduleErrors counts how many pods could not be scheduled due to a scheduler error.
 	// This metric will be initialized again in Register() to assure the metric is not no-op metric.
-	PodScheduleErrors            = scheduleAttempts.With(metrics.Labels{"result": "error"})
-	DeprecatedSchedulingDuration = metrics.NewSummaryVec(
-		&metrics.SummaryOpts{
-			Subsystem: SchedulerSubsystem,
-			Name:      DeprecatedSchedulingDurationName,
-			Help:      "Scheduling latency in seconds split by sub-parts of the scheduling operation",
-			// Make the sliding window of 5h.
-			// TODO: The value for this should be based on some SLI definition (long term).
-			MaxAge:            5 * time.Hour,
-			StabilityLevel:    metrics.ALPHA,
-			DeprecatedVersion: "1.19.0",
-		},
-		[]string{OperationLabel},
-	)
+	PodScheduleErrors    = scheduleAttempts.With(metrics.Labels{"result": "error"})
 	E2eSchedulingLatency = metrics.NewHistogram(
 		&metrics.HistogramOpts{
 			Subsystem:      SchedulerSubsystem,
@@ -93,26 +64,6 @@ var (
 			Help:           "Scheduling algorithm latency in seconds",
 			Buckets:        metrics.ExponentialBuckets(0.001, 2, 15),
 			StabilityLevel: metrics.ALPHA,
-		},
-	)
-	DeprecatedSchedulingAlgorithmPredicateEvaluationSecondsDuration = metrics.NewHistogram(
-		&metrics.HistogramOpts{
-			Subsystem:         SchedulerSubsystem,
-			Name:              "scheduling_algorithm_predicate_evaluation_seconds",
-			Help:              "Scheduling algorithm predicate evaluation duration in seconds",
-			Buckets:           metrics.ExponentialBuckets(0.001, 2, 15),
-			StabilityLevel:    metrics.ALPHA,
-			DeprecatedVersion: "1.19.0",
-		},
-	)
-	DeprecatedSchedulingAlgorithmPriorityEvaluationSecondsDuration = metrics.NewHistogram(
-		&metrics.HistogramOpts{
-			Subsystem:         SchedulerSubsystem,
-			Name:              "scheduling_algorithm_priority_evaluation_seconds",
-			Help:              "Scheduling algorithm priority evaluation duration in seconds",
-			Buckets:           metrics.ExponentialBuckets(0.001, 2, 15),
-			StabilityLevel:    metrics.ALPHA,
-			DeprecatedVersion: "1.19.0",
 		},
 	)
 	SchedulingAlgorithmPreemptionEvaluationDuration = metrics.NewHistogram(
@@ -234,12 +185,9 @@ var (
 
 	metricsList = []metrics.Registerable{
 		scheduleAttempts,
-		DeprecatedSchedulingDuration,
 		E2eSchedulingLatency,
 		SchedulingAlgorithmLatency,
 		BindingLatency,
-		DeprecatedSchedulingAlgorithmPredicateEvaluationSecondsDuration,
-		DeprecatedSchedulingAlgorithmPriorityEvaluationSecondsDuration,
 		SchedulingAlgorithmPreemptionEvaluationDuration,
 		PreemptionVictims,
 		PreemptionAttempts,
@@ -295,11 +243,6 @@ func BackoffPods() metrics.GaugeMetric {
 // UnschedulablePods returns the pending pods metrics with the label unschedulable
 func UnschedulablePods() metrics.GaugeMetric {
 	return pendingPods.With(metrics.Labels{"queue": "unschedulable"})
-}
-
-// Reset resets metrics
-func Reset() {
-	DeprecatedSchedulingDuration.Reset()
 }
 
 // SinceInSeconds gets the time since the specified start in seconds.

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -512,7 +512,6 @@ func (sched *Scheduler) finishBinding(prof *profile.Profile, assumed *v1.Pod, ta
 	}
 
 	metrics.BindingLatency.Observe(metrics.SinceInSeconds(start))
-	metrics.DeprecatedSchedulingDuration.WithLabelValues(metrics.Binding).Observe(metrics.SinceInSeconds(start))
 	prof.Recorder.Eventf(assumed, nil, v1.EventTypeNormal, "Scheduled", "Binding", "Successfully assigned %v/%v to %v", assumed.Namespace, assumed.Name, targetNode)
 }
 
@@ -558,7 +557,6 @@ func (sched *Scheduler) scheduleOne(ctx context.Context) {
 				sched.preempt(schedulingCycleCtx, prof, state, pod, fitError)
 				metrics.PreemptionAttempts.Inc()
 				metrics.SchedulingAlgorithmPreemptionEvaluationDuration.Observe(metrics.SinceInSeconds(preemptionStartTime))
-				metrics.DeprecatedSchedulingDuration.WithLabelValues(metrics.PreemptionEvaluation).Observe(metrics.SinceInSeconds(preemptionStartTime))
 			}
 			// Pod did not fit anywhere, so it is counted as a failure. If preemption
 			// succeeds, the pod should get counted as a success the next time we try to


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup
/kind deprecation
/sig scheduling
/sig instrumentation

**What this PR does / why we need it**:

There are a number of metrics need to be removed in 1.19.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
A number of deprecated scheduling metrics are removed.
- `scheduling_duration_seconds{operation=predicate_evaluation|priority_evaluation}`, `scheduling_algorithm_predicate_evaluation_seconds` and `scheduling_algorithm_priority_evaluation_seconds` are replaced by metric `framework_extension_point_duration_seconds`.
- `scheduling_duration_seconds{operation=preemption_evaluation}` is replaced by metric `scheduling_algorithm_preemption_evaluation_seconds`.
- `scheduling_duration_seconds{operation=binding}` is replaced by metric `binding_duration_seconds`.
```
