### PR TITLE
Add cri socket path tests

### DIFF
--- a/cmd/kubeadm/app/apis/kubeadm/validation/validation_test.go
+++ b/cmd/kubeadm/app/apis/kubeadm/validation/validation_test.go
@@ -99,22 +99,17 @@ func TestValidateTokenGroups(t *testing.T) {
 func TestValidateNodeRegistrationOptions(t *testing.T) {
 	var tests = []struct {
 		nodeName       string
-		criSocket      string
 		expectedErrors bool
 	}{
-		{"", "/some/path", true},                                                             // node name can't be empty
-		{"INVALID-NODENAME", "/some/path", true},                                             // Upper cases is invalid
-		{"invalid-nodename-", "/some/path", true},                                            // Can't have trailing dashes
-		{"invalid-node?name", "/some/path", true},                                            // Unsupported characters
-		{"valid-nodename", "/some/path", false},                                              // supported
-		{"valid-nodename-with-numbers01234", "/some/path/with/numbers/01234/", false},        // supported, with numbers as well
-		{"valid-nodename", kubeadmapiv1beta2.DefaultUrlScheme + "://" + "/some/path", false}, // supported, with socket url
-		{"valid-nodename", "bla:///some/path", true},                                         // unsupported url scheme
-		{"valid-nodename", ":::", true},                                                      // unparseable url
-		{"valid-nodename", "", true},                                                         // invalid CRISocket (path is not absolute)
+		{"", true},                  // node name can't be empty
+		{"INVALID-NODENAME", true},  // Upper cases is invalid
+		{"invalid-nodename-", true}, // Can't have trailing dashes
+		{"invalid-node?name", true}, // Unsupported characters
+		{"valid-nodename", false},   // supported
+		// test cases for criSocket are covered in TestValidateSocketPath
 	}
 	for _, rt := range tests {
-		nro := kubeadm.NodeRegistrationOptions{Name: rt.nodeName, CRISocket: rt.criSocket}
+		nro := kubeadm.NodeRegistrationOptions{Name: rt.nodeName, CRISocket: "/some/path"}
 		actual := ValidateNodeRegistrationOptions(&nro, field.NewPath("nodeRegistration"))
 		actualErrors := len(actual) > 0
 		if actualErrors != rt.expectedErrors {
@@ -894,6 +889,28 @@ func TestValidateDiscoveryKubeConfigPath(t *testing.T) {
 				rt.expected,
 				(len(actual) == 0),
 			)
+		}
+	}
+}
+
+func TestValidateSocketPath(t *testing.T) {
+	var tests = []struct {
+		name           string
+		criSocket      string
+		expectedErrors bool
+	}{
+		{name: "valid path", criSocket: "/some/path", expectedErrors: false},
+		{name: "valid socket url", criSocket: kubeadmapiv1beta2.DefaultUrlScheme + "://" + "/some/path", expectedErrors: false},
+		{name: "unsupported url scheme", criSocket: "bla:///some/path", expectedErrors: true},
+		{name: "unparseable url", criSocket: ":::", expectedErrors: true},
+		{name: "invalid CRISocket (path is not absolute)", criSocket: "some/path", expectedErrors: true},
+		{name: "empty CRISocket (path is not absolute)", criSocket: "", expectedErrors: true},
+	}
+	for _, tc := range tests {
+		actual := ValidateSocketPath(tc.criSocket, field.NewPath("criSocket"))
+		actualErrors := len(actual) > 0
+		if actualErrors != tc.expectedErrors {
+			t.Errorf("error: socket path: %q\n\texpected: %t\n\t  actual: %t", tc.criSocket, tc.expectedErrors, actualErrors)
 		}
 	}
 }

--- a/cmd/kubeadm/app/apis/kubeadm/validation/validation_test.go
+++ b/cmd/kubeadm/app/apis/kubeadm/validation/validation_test.go
@@ -111,6 +111,7 @@ func TestValidateNodeRegistrationOptions(t *testing.T) {
 		{"valid-nodename", kubeadmapiv1beta2.DefaultUrlScheme + "://" + "/some/path", false}, // supported, with socket url
 		{"valid-nodename", "bla:///some/path", true},                                         // unsupported url scheme
 		{"valid-nodename", ":::", true},                                                      // unparseable url
+		{"valid-nodename", "", true},                                                         // invalid CRISocket (path is not absolute)
 	}
 	for _, rt := range tests {
 		nro := kubeadm.NodeRegistrationOptions{Name: rt.nodeName, CRISocket: rt.criSocket}


### PR DESCRIPTION
Adds tests for `ValidateSocketPath`.

This needs to be merged after #91393 as the patch is built on top of that one.
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
This adds (refactors really) tests for `ValidateSocketPath`

**Special notes for your reviewer**:
`ValidateNodeRegistrationOptions` calls `ValidateSocketPath`. The tests for `ValidateSocketPath` were included in the tests for `ValidateNodeRegistrationOptions`. This refactors that out and adds separate test(suite?) for `ValidateSocketPath`.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

/sig cluster-lifecycle