### PR TITLE
multiple IPv6/dual-stack endpoint fixes

### DIFF
--- a/pkg/controller/endpoint/BUILD
+++ b/pkg/controller/endpoint/BUILD
@@ -64,6 +64,7 @@ go_test(
         "//staging/src/k8s.io/client-go/tools/cache:go_default_library",
         "//staging/src/k8s.io/client-go/util/testing:go_default_library",
         "//staging/src/k8s.io/component-base/featuregate/testing:go_default_library",
+        "//vendor/k8s.io/utils/net:go_default_library",
         "//vendor/k8s.io/utils/pointer:go_default_library",
     ],
 )

--- a/pkg/controller/endpoint/BUILD
+++ b/pkg/controller/endpoint/BUILD
@@ -48,7 +48,6 @@ go_test(
         "//pkg/api/v1/endpoints:go_default_library",
         "//pkg/apis/core:go_default_library",
         "//pkg/controller:go_default_library",
-        "//pkg/controller/util/endpoint:go_default_library",
         "//pkg/features:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",

--- a/pkg/controller/endpoint/endpoints_controller.go
+++ b/pkg/controller/endpoint/endpoints_controller.go
@@ -19,7 +19,6 @@ package endpoint
 import (
 	"context"
 	"fmt"
-	"reflect"
 	"strconv"
 	"time"
 
@@ -213,39 +212,33 @@ func (e *EndpointController) addPod(obj interface{}) {
 }
 
 func podToEndpointAddressForService(svc *v1.Service, pod *v1.Pod) (*v1.EndpointAddress, error) {
+	var endpointIP string
+
 	if !utilfeature.DefaultFeatureGate.Enabled(features.IPv6DualStack) {
-		return podToEndpointAddress(pod), nil
-	}
+		endpointIP = pod.Status.PodIP
+	} else {
+		// api-server service controller ensured that the service got the correct IP Family
+		// according to user setup, here we only need to match EndPoint IPs' family to service
+		// actual IP family. as in, we don't need to check service.IPFamily
 
-	// api-server service controller ensured that the service got the correct IP Family
-	// according to user setup, here we only need to match EndPoint IPs' family to service
-	// actual IP family. as in, we don't need to check service.IPFamily
-
-	ipv6ClusterIP := utilnet.IsIPv6String(svc.Spec.ClusterIP)
-	for _, podIP := range pod.Status.PodIPs {
-		ipv6PodIP := utilnet.IsIPv6String(podIP.IP)
-		// same family?
-		// TODO (khenidak) when we remove the max of 2 PodIP limit from pods
-		// we will have to return multiple endpoint addresses
-		if ipv6ClusterIP == ipv6PodIP {
-			return &v1.EndpointAddress{
-				IP:       podIP.IP,
-				NodeName: &pod.Spec.NodeName,
-				TargetRef: &v1.ObjectReference{
-					Kind:            "Pod",
-					Namespace:       pod.ObjectMeta.Namespace,
-					Name:            pod.ObjectMeta.Name,
-					UID:             pod.ObjectMeta.UID,
-					ResourceVersion: pod.ObjectMeta.ResourceVersion,
-				}}, nil
+		ipv6ClusterIP := utilnet.IsIPv6String(svc.Spec.ClusterIP)
+		for _, podIP := range pod.Status.PodIPs {
+			ipv6PodIP := utilnet.IsIPv6String(podIP.IP)
+			// same family?
+			// TODO (khenidak) when we remove the max of 2 PodIP limit from pods
+			// we will have to return multiple endpoint addresses
+			if ipv6ClusterIP == ipv6PodIP {
+				endpointIP = podIP.IP
+				break
+			}
+		}
+		if endpointIP == "" {
+			return nil, fmt.Errorf("failed to find a matching endpoint for service %v", svc.Name)
 		}
 	}
-	return nil, fmt.Errorf("failed to find a matching endpoint for service %v", svc.Name)
-}
 
-func podToEndpointAddress(pod *v1.Pod) *v1.EndpointAddress {
 	return &v1.EndpointAddress{
-		IP:       pod.Status.PodIP,
+		IP:       endpointIP,
 		NodeName: &pod.Spec.NodeName,
 		TargetRef: &v1.ObjectReference{
 			Kind:            "Pod",
@@ -253,24 +246,15 @@ func podToEndpointAddress(pod *v1.Pod) *v1.EndpointAddress {
 			Name:            pod.ObjectMeta.Name,
 			UID:             pod.ObjectMeta.UID,
 			ResourceVersion: pod.ObjectMeta.ResourceVersion,
-		}}
-}
-
-func endpointChanged(pod1, pod2 *v1.Pod) bool {
-	endpointAddress1 := podToEndpointAddress(pod1)
-	endpointAddress2 := podToEndpointAddress(pod2)
-
-	endpointAddress1.TargetRef.ResourceVersion = ""
-	endpointAddress2.TargetRef.ResourceVersion = ""
-
-	return !reflect.DeepEqual(endpointAddress1, endpointAddress2)
+		},
+	}, nil
 }
 
 // When a pod is updated, figure out what services it used to be a member of
 // and what services it will be a member of, and enqueue the union of these.
 // old and cur must be *v1.Pod types.
 func (e *EndpointController) updatePod(old, cur interface{}) {
-	services := endpointutil.GetServicesToUpdateOnPodChange(e.serviceLister, e.serviceSelectorCache, old, cur, endpointChanged)
+	services := endpointutil.GetServicesToUpdateOnPodChange(e.serviceLister, e.serviceSelectorCache, old, cur)
 	for key := range services {
 		e.queue.AddAfter(key, e.endpointUpdatesBatchPeriod)
 	}

--- a/pkg/controller/endpoint/endpoints_controller_test.go
+++ b/pkg/controller/endpoint/endpoints_controller_test.go
@@ -1249,21 +1249,21 @@ func TestPodToEndpointAddressForService(t *testing.T) {
 
 			expectedEndpointFamily: ipv6,
 		},
-		// {
-		// 	name: "v6 headless service, in a dual stack cluster",
-		//
-		// 	enableDualStack: true,
-		// 	ipFamilies:      ipv4ipv6,
-		//
-		// 	service: v1.Service{
-		// 		Spec: v1.ServiceSpec{
-		// 			ClusterIP: v1.ClusterIPNone,
-		// 			IPFamily:  &ipv6,
-		// 		},
-		// 	},
-		//
-		// 	expectedEndpointFamily: ipv6,
-		// },
+		{
+			name: "v6 headless service, in a dual stack cluster",
+
+			enableDualStack: true,
+			ipFamilies:      ipv4ipv6,
+
+			service: v1.Service{
+				Spec: v1.ServiceSpec{
+					ClusterIP: v1.ClusterIPNone,
+					IPFamily:  &ipv6,
+				},
+			},
+
+			expectedEndpointFamily: ipv6,
+		},
 		{
 			name: "v6 legacy headless service, in a dual stack cluster",
 

--- a/pkg/controller/endpointslice/endpointslice_controller.go
+++ b/pkg/controller/endpointslice/endpointslice_controller.go
@@ -457,7 +457,7 @@ func (c *Controller) addPod(obj interface{}) {
 }
 
 func (c *Controller) updatePod(old, cur interface{}) {
-	services := endpointutil.GetServicesToUpdateOnPodChange(c.serviceLister, c.serviceSelectorCache, old, cur, podEndpointChanged)
+	services := endpointutil.GetServicesToUpdateOnPodChange(c.serviceLister, c.serviceSelectorCache, old, cur)
 	for key := range services {
 		c.queue.AddAfter(key, c.endpointUpdatesBatchPeriod)
 	}

--- a/pkg/controller/endpointslice/reconciler.go
+++ b/pkg/controller/endpointslice/reconciler.go
@@ -59,7 +59,7 @@ type endpointMeta struct {
 func (r *reconciler) reconcile(service *corev1.Service, pods []*corev1.Pod, existingSlices []*discovery.EndpointSlice, triggerTime time.Time) error {
 	addressType := discovery.AddressTypeIPv4
 
-	if isIPv6Service(service) {
+	if endpointutil.IsIPv6Service(service) {
 		addressType = discovery.AddressTypeIPv6
 	}
 

--- a/pkg/controller/endpointslice/utils.go
+++ b/pkg/controller/endpointslice/utils.go
@@ -18,7 +18,6 @@ package endpointslice
 
 import (
 	"fmt"
-	"reflect"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -36,19 +35,7 @@ import (
 	utilnet "k8s.io/utils/net"
 )
 
-// podEndpointChanged returns true if the results of podToEndpoint are different
-// for the pods passed to this function.
-func podEndpointChanged(pod1, pod2 *corev1.Pod) bool {
-	endpoint1 := podToEndpoint(pod1, &corev1.Node{}, &corev1.Service{Spec: corev1.ServiceSpec{}})
-	endpoint2 := podToEndpoint(pod2, &corev1.Node{}, &corev1.Service{Spec: corev1.ServiceSpec{}})
-
-	endpoint1.TargetRef.ResourceVersion = ""
-	endpoint2.TargetRef.ResourceVersion = ""
-
-	return !reflect.DeepEqual(endpoint1, endpoint2)
-}
-
-// podToEndpoint returns an Endpoint object generated from a Pod and Node.
+// podToEndpoint returns an Endpoint object generated from pod, node, and service.
 func podToEndpoint(pod *corev1.Pod, node *corev1.Node, service *corev1.Service) discovery.Endpoint {
 	// Build out topology information. This is currently limited to hostname,
 	// zone, and region, but this will be expanded in the future.

--- a/pkg/controller/endpointslice/utils.go
+++ b/pkg/controller/endpointslice/utils.go
@@ -120,18 +120,12 @@ func getEndpointAddresses(podStatus corev1.PodStatus, service *corev1.Service) [
 
 	for _, podIP := range podStatus.PodIPs {
 		isIPv6PodIP := utilnet.IsIPv6String(podIP.IP)
-		if isIPv6PodIP == isIPv6Service(service) {
+		if isIPv6PodIP == endpointutil.IsIPv6Service(service) {
 			addresses = append(addresses, podIP.IP)
 		}
 	}
 
 	return addresses
-}
-
-// isIPv6Service returns true if the Service uses IPv6 addresses.
-func isIPv6Service(service *corev1.Service) bool {
-	// IPFamily is not guaranteed to be set, even in an IPv6 only cluster.
-	return (service.Spec.IPFamily != nil && *service.Spec.IPFamily == corev1.IPv6Protocol) || utilnet.IsIPv6String(service.Spec.ClusterIP)
 }
 
 // endpointsEqualBeyondHash returns true if endpoints have equal attributes

--- a/pkg/controller/util/endpoint/BUILD
+++ b/pkg/controller/util/endpoint/BUILD
@@ -10,6 +10,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/api/v1/pod:go_default_library",
+        "//pkg/apis/core/v1/helper:go_default_library",
         "//pkg/controller:go_default_library",
         "//pkg/util/hash:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
@@ -19,6 +20,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//staging/src/k8s.io/client-go/listers/core/v1:go_default_library",
         "//staging/src/k8s.io/client-go/tools/cache:go_default_library",
+        "//vendor/k8s.io/utils/net:go_default_library",
     ],
 )
 

--- a/pkg/controller/util/endpoint/controller_utils.go
+++ b/pkg/controller/util/endpoint/controller_utils.go
@@ -106,9 +106,6 @@ func (sc *ServiceSelectorCache) GetPodServiceMemberships(serviceLister v1listers
 	return set, nil
 }
 
-// EndpointsMatch is a type of function that returns true if pod endpoints match.
-type EndpointsMatch func(*v1.Pod, *v1.Pod) bool
-
 // PortMapKey is used to uniquely identify groups of endpoint ports.
 type PortMapKey string
 
@@ -153,9 +150,10 @@ func ShouldSetHostname(pod *v1.Pod, svc *v1.Service) bool {
 	return len(pod.Spec.Hostname) > 0 && pod.Spec.Subdomain == svc.Name && svc.Namespace == pod.Namespace
 }
 
-// PodChanged returns two boolean values, the first returns true if the pod.
-// has changed, the second value returns true if the pod labels have changed.
-func PodChanged(oldPod, newPod *v1.Pod, endpointChanged EndpointsMatch) (bool, bool) {
+// podEndpointsChanged returns two boolean values. The first is true if the pod has
+// changed in a way that may change existing endpoints. The second value is true if the
+// pod has changed in a way that may affect which Services it matches.
+func podEndpointsChanged(oldPod, newPod *v1.Pod) (bool, bool) {
 	// Check if the pod labels have changed, indicating a possible
 	// change in the service membership
 	labelsChanged := false
@@ -175,16 +173,27 @@ func PodChanged(oldPod, newPod *v1.Pod, endpointChanged EndpointsMatch) (bool, b
 	if podutil.IsPodReady(oldPod) != podutil.IsPodReady(newPod) {
 		return true, labelsChanged
 	}
-	// Convert the pod to an Endpoint, clear inert fields,
-	// and see if they are the same.
-	// TODO: Add a watcher for node changes separate from this
-	// We don't want to trigger multiple syncs at a pod level when a node changes
-	return endpointChanged(newPod, oldPod), labelsChanged
+
+	// Check if the pod IPs have changed
+	if len(oldPod.Status.PodIPs) != len(newPod.Status.PodIPs) {
+		return true, labelsChanged
+	}
+	for i := range oldPod.Status.PodIPs {
+		if oldPod.Status.PodIPs[i].IP != newPod.Status.PodIPs[i].IP {
+			return true, labelsChanged
+		}
+	}
+
+	// Endpoints may also reference a pod's Name, Namespace, UID, and NodeName, but
+	// the first three are immutable, and NodeName is immutable once initially set,
+	// which happens before the pod gets an IP.
+
+	return false, labelsChanged
 }
 
 // GetServicesToUpdateOnPodChange returns a set of Service keys for Services
 // that have potentially been affected by a change to this pod.
-func GetServicesToUpdateOnPodChange(serviceLister v1listers.ServiceLister, selectorCache *ServiceSelectorCache, old, cur interface{}, endpointChanged EndpointsMatch) sets.String {
+func GetServicesToUpdateOnPodChange(serviceLister v1listers.ServiceLister, selectorCache *ServiceSelectorCache, old, cur interface{}) sets.String {
 	newPod := cur.(*v1.Pod)
 	oldPod := old.(*v1.Pod)
 	if newPod.ResourceVersion == oldPod.ResourceVersion {
@@ -193,7 +202,7 @@ func GetServicesToUpdateOnPodChange(serviceLister v1listers.ServiceLister, selec
 		return sets.String{}
 	}
 
-	podChanged, labelsChanged := PodChanged(oldPod, newPod, endpointChanged)
+	podChanged, labelsChanged := podEndpointsChanged(oldPod, newPod)
 
 	// If both the pod and labels are unchanged, no update is needed
 	if !podChanged && !labelsChanged {

--- a/pkg/controller/util/endpoint/controller_utils.go
+++ b/pkg/controller/util/endpoint/controller_utils.go
@@ -32,8 +32,10 @@ import (
 	v1listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
+	"k8s.io/kubernetes/pkg/apis/core/v1/helper"
 	"k8s.io/kubernetes/pkg/controller"
 	"k8s.io/kubernetes/pkg/util/hash"
+	utilnet "k8s.io/utils/net"
 )
 
 // ServiceSelectorCache is a cache of service selectors to avoid high CPU consumption caused by frequent calls to AsSelectorPreValidated (see #73527)
@@ -274,4 +276,19 @@ func (sl portsInOrder) Less(i, j int) bool {
 	h1 := DeepHashObjectToString(sl[i])
 	h2 := DeepHashObjectToString(sl[j])
 	return h1 < h2
+}
+
+// IsIPv6Service checks if svc should have IPv6 endpoints
+func IsIPv6Service(svc *v1.Service) bool {
+	if helper.IsServiceIPSet(svc) {
+		return utilnet.IsIPv6String(svc.Spec.ClusterIP)
+	} else if svc.Spec.IPFamily != nil {
+		return *svc.Spec.IPFamily == v1.IPv6Protocol
+	} else {
+		// FIXME: for legacy headless Services with no IPFamily, the current
+		// thinking is that we should use the cluster default. Unfortunately
+		// the endpoint controller doesn't know the cluster default. For now,
+		// assume it's IPv4.
+		return false
+	}
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Fixes two problems with endpoints in dual-stack and single-stack IPv6 clusters:
1. Fixes #92965; EndpointSliceController was only looking at IPv4 Pod IPs during Pod updates, so it wouldn't notice when a Pod went from having no IPs to having only an IPv6 IP. (May also fix some other problems where certain Pod updates were not noticed in one or both controllers, because of the odd way they were trying to figure out whether a Pod update would result in Endpoint updates. Eg, neither controller would notice if a pod went from single-stack to dual-stack, though it's possible that never happens in practice.)
2. EndpointController now allows headless services to have IPv6 endpoints in single-stack IPv6 and dual stack clusters, as long as they specify `ipFamily: IPv6`. (EndpointSliceController already allowed this.)

However, this preserves the existing behavior (in both controllers) that "legacy" headless services (with no `IPFamily` set) are treated as IPv4-only in all clusters when `IPv6DualStack` is enabled. (Even if the cluster is single-stack IPv6.) ~I had thought we could fix this easily because I thought kube-controller-manager knew the service CIDR(s). But in fact, it usually doesn't; kcm has a `--service-cluster-ip-range` argument, but you only need to specify it if (a) you are using `--allocate-node-cidrs` and (b) your service CIDR is _inside_ the cluster CIDR so you need the Node CIDR allocator to skip over that range. (Srsly???). So anyway, most kcm's are not going to know what the default service CIDR is.~

~There is another approach we could take, which is to take advantage of the fact that the endpoint controller will, shortly after startup, learn whether `kubernetes.default` is IPv4 or IPv6, which is the same as learning whether the default service CIDR is IPv4 or IPv6. But I think we'd need to rearrange the code to ensure that we find that out before queuing any other updates, since if we got an informer notification for a legacy headless service before we got a notification for `kubernetes.default`, we wouldn't be able to process it yet.~

Given that 1.20 will fix the behavior of headless dual-stack services, it's not worth going to any further effort to improve things in 1.19.

Fixes #92965

**Does this PR introduce a user-facing change?**:
```release-note
Fixed the EndpointSliceController to correctly create endpoints for IPv6-only pods.

Fixed the EndpointController to allow IPv6 headless services, if the IPv6DualStack
feature gate is enabled, by specifying `ipFamily: IPv6` on the service. (This already
worked with the EndpointSliceController.)
```

/sig network
/priority important-soon