### PR TITLE
Possibility to disable "short routing path" for LoadBalancer

### DIFF
--- a/pkg/proxy/util/utils.go
+++ b/pkg/proxy/util/utils.go
@@ -41,6 +41,9 @@ const (
 
 	// IPv6ZeroCIDR is the CIDR block for the whole IPv6 address space
 	IPv6ZeroCIDR = "::/0"
+
+	// DisableExternalShortRouting annotation value to disable external LB "short" routing
+	DisableExternalShortRouting = "loadbalancer.kubernetes.io/disable-lb-short-routing"
 )
 
 var (
@@ -299,4 +302,25 @@ func EnsureSysctl(sysctl utilsysctl.Interface, name string, newVal int) error {
 		klog.V(1).Infof("Changed sysctl %q: %d -> %d", name, oldVal, newVal)
 	}
 	return nil
+}
+
+func GetBoolFromServiceAnnotation(service *v1.Service, annotationKey string, defaultSetting bool) bool {
+	klog.V(4).Infof("GetBoolFromServiceAnnotation(%v, %v, %v)", service.Annotations, annotationKey, defaultSetting)
+	if annotationValue, ok := service.Annotations[annotationKey]; ok {
+		returnValue := false
+		switch annotationValue {
+		case "true":
+			returnValue = true
+		case "false":
+			returnValue = false
+		default:
+			klog.V(4).Infof("Invalid value falling back to defaultSetting")
+			return defaultSetting
+		}
+
+		klog.V(4).Infof("Found a Service Annotation: %v = %v", annotationKey, returnValue)
+		return returnValue
+	}
+	klog.V(4).Infof("Could not find a Service Annotation; falling back to default setting: %v = %v", annotationKey, defaultSetting)
+	return defaultSetting
 }

--- a/pkg/proxy/util/utils.go
+++ b/pkg/proxy/util/utils.go
@@ -304,6 +304,7 @@ func EnsureSysctl(sysctl utilsysctl.Interface, name string, newVal int) error {
 	return nil
 }
 
+// GetBoolFromServiceAnnotation returns boolean value from service annotation
 func GetBoolFromServiceAnnotation(service *v1.Service, annotationKey string, defaultSetting bool) bool {
 	klog.V(4).Infof("GetBoolFromServiceAnnotation(%v, %v, %v)", service.Annotations, annotationKey, defaultSetting)
 	if annotationValue, ok := service.Annotations[annotationKey]; ok {

--- a/pkg/proxy/util/utils_test.go
+++ b/pkg/proxy/util/utils_test.go
@@ -630,3 +630,77 @@ func TestFilterIncorrectIPVersion(t *testing.T) {
 		})
 	}
 }
+
+func TestServiceAnnotation(t *testing.T) {
+	testCases := []struct {
+		desc           string
+		defaultSetting bool
+		expect         bool
+		svc            *v1.Service
+	}{
+		{
+			desc:   "service without annotation",
+			svc:    &v1.Service{},
+			expect: false,
+		},
+		{
+			desc:           "service without annotation using defaultsetting true",
+			svc:            &v1.Service{},
+			defaultSetting: true,
+			expect:         true,
+		},
+		{
+			desc: "service with correct annotation value false",
+			svc: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{DisableExternalShortRouting: "false"},
+				},
+			},
+			expect: false,
+		},
+		{
+			desc: "service with correct annotation value true",
+			svc: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{DisableExternalShortRouting: "true"},
+				},
+			},
+			expect: true,
+		},
+		{
+			desc: "service with correct annotation invalid value",
+			svc: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{DisableExternalShortRouting: "invalidvalue"},
+				},
+			},
+			defaultSetting: false,
+			expect:         false,
+		},
+		{
+			desc: "service with incorrect annotation value true",
+			svc: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{"foobar": "true"},
+				},
+			},
+			expect: false,
+		},
+		{
+			desc: "service with incorrect annotation value false",
+			svc: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{"foobar": "false"},
+				},
+			},
+			expect: false,
+		},
+	}
+
+	for _, testcase := range testCases {
+		got := GetBoolFromServiceAnnotation(testcase.svc, DisableExternalShortRouting, testcase.defaultSetting)
+		if testcase.expect != got {
+			t.Errorf("case %s: expected %v, got %v", testcase.desc, testcase.expect, got)
+		}
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

Like mentioned in https://github.com/kubernetes/kubernetes/issues/66607#issuecomment-474513060 currently it is impossible to call external loadbalancers from inside same kubernetes cluster when running for instance proxy protocol. Shorter path does not work in that case. This PR does not change default behaviour, but it makes it possible to enable new feature by using annotation.

I think people who did kube-proxy were thinking that "shorting the path" works always (tcp and udp). However, now we have use-case where our service is listening for proxy protocol and external loadbalancer is listening tcp, but will forward proxy protocol package forward to kubernetes cluster service. Now when we call that external loadbalancer ip from inside the kubernetes cluster it will forward all traffic internally kubernetes clusterIP service (instead external lb), which listens for proxy protocol - but it will receive normal tcp request. The external loadbalancer will modify tcp request to proxy protocol, that is why longer path is needed.

![Screenshot 2020-05-25 at 13 32 24](https://user-images.githubusercontent.com/22482503/82805161-38932980-9e8c-11ea-986a-e43162ee6617.png)

So it is something like this:

1) blue lines are normal TCP connections
2) red lines are TCP connections (proxy protocol)
3) dashed blue line is current behaviour (do not work because nginx assumes that the traffic coming is using proxy protocol instead of normal TCP)
4) from blue line `pod1` to `ext lb` is the new way that I am introducing in this PR. 

#66607 has been open for over two years. I am now trying to fix it, so please give feedback is this possible solution. At least for me this solves problems in OpenStack k8s when running kube-proxy in iptables mode.

**Which issue(s) this PR fixes**:
Fixes #66607

**Special notes for your reviewer**:

This is my first PR under kube-proxy, so not sure does this break some other behaviour. This is critical part of kubernetes business logic.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
