### PR TITLE
default-binder: ignore pod not found error when bind

### DIFF
--- a/pkg/scheduler/framework/plugins/defaultbinder/BUILD
+++ b/pkg/scheduler/framework/plugins/defaultbinder/BUILD
@@ -8,6 +8,7 @@ go_library(
     deps = [
         "//pkg/scheduler/framework/v1alpha1:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/klog/v2:go_default_library",

--- a/pkg/scheduler/framework/plugins/defaultbinder/default_binder.go
+++ b/pkg/scheduler/framework/plugins/defaultbinder/default_binder.go
@@ -20,6 +20,7 @@ import (
 	"context"
 
 	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/klog/v2"
@@ -54,7 +55,7 @@ func (b DefaultBinder) Bind(ctx context.Context, state *framework.CycleState, p 
 		Target:     v1.ObjectReference{Kind: "Node", Name: nodeName},
 	}
 	err := b.handle.ClientSet().CoreV1().Pods(binding.Namespace).Bind(ctx, binding, metav1.CreateOptions{})
-	if err != nil {
+	if err != nil && !apierrors.IsNotFound(err) {
 		return framework.NewStatus(framework.Error, err.Error())
 	}
 	return nil

--- a/pkg/scheduler/framework/plugins/defaultbinder/default_binder_test.go
+++ b/pkg/scheduler/framework/plugins/defaultbinder/default_binder_test.go
@@ -71,7 +71,7 @@ func TestDefaultBinder(t *testing.T) {
 				t.Fatal(err)
 			}
 			binder := &DefaultBinder{handle: fh}
-			status := binder.Bind(context.Background(), nil, testPod, "foohost.kubernetes.mydomain.com")
+			status := binder.Bind(context.Background(), nil, testPod, testNode)
 			if got := status.AsError(); (tt.injectErr != nil) != (got != nil) {
 				t.Errorf("got error %q, want %q", got, tt.injectErr)
 			}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind cleanup


**What this PR does / why we need it**:

When api-server runs with high workloads, it is possible that a pod is already deleted when kube-scheduler finally gets to schedule it.  

This PR avoids retrying and updating pod condition (PodScheduled==False, Reason=SchedulerError) on this occasion thus reduce some pressure for api-server. 

An example log from kube-scheduler may be:
```
I0525 07:59:42.263307       1 default_binder.go:52] Attempting to bind default/simple-http-5dbc6cdb48-dkqcz to kind-worker2
I0525 07:59:42.349878       1 round_trippers.go:443] GET https://kind-control-plane:6443/api/v1/namespaces/kube-system/endpoints/kube-scheduler?timeout=10s 200 OK in 23 milliseconds
I0525 07:59:42.357876       1 round_trippers.go:443] GET https://kind-control-plane:6443/apis/coordination.k8s.io/v1/namespaces/kube-system/leases/kube-scheduler?timeout=10s 200 OK in 4 milliseconds
I0525 07:59:42.375518       1 round_trippers.go:443] PUT https://kind-control-plane:6443/api/v1/namespaces/kube-system/endpoints/kube-scheduler?timeout=10s 200 OK in 11 milliseconds
I0525 07:59:42.381965       1 round_trippers.go:443] GET https://kind-control-plane:6443/apis/coordination.k8s.io/v1/namespaces/kube-system/leases/kube-scheduler?timeout=10s 200 OK in 3 milliseconds
I0525 07:59:42.399327       1 round_trippers.go:443] PUT https://kind-control-plane:6443/apis/coordination.k8s.io/v1/namespaces/kube-system/leases/kube-scheduler?timeout=10s 200 OK in 12 milliseconds
I0525 07:59:42.399478       1 leaderelection.go:272] successfully renewed lease kube-system/kube-scheduler
I0525 07:59:42.442460       1 cache.go:722] Couldn't expire cache for pod default/simple-http-5dbc6cdb48-dkqcz. Binding is still in progress.
I0525 07:59:43.443556       1 cache.go:722] Couldn't expire cache for pod default/simple-http-5dbc6cdb48-dkqcz. Binding is still in progress.
I0525 07:59:44.407459       1 round_trippers.go:443] GET https://kind-control-plane:6443/api/v1/namespaces/kube-system/endpoints/kube-scheduler?timeout=10s 200 OK in 6 milliseconds
I0525 07:59:44.438851       1 round_trippers.go:443] GET https://kind-control-plane:6443/apis/coordination.k8s.io/v1/namespaces/kube-system/leases/kube-scheduler?timeout=10s 200 OK in 25 milliseconds
I0525 07:59:44.444556       1 cache.go:722] Couldn't expire cache for pod default/simple-http-5dbc6cdb48-dkqcz. Binding is still in progress.
I0525 07:59:44.473521       1 round_trippers.go:443] PUT https://kind-control-plane:6443/api/v1/namespaces/kube-system/endpoints/kube-scheduler?timeout=10s 200 OK in 31 milliseconds
I0525 07:59:44.480529       1 round_trippers.go:443] GET https://kind-control-plane:6443/apis/coordination.k8s.io/v1/namespaces/kube-system/leases/kube-scheduler?timeout=10s 200 OK in 4 milliseconds
I0525 07:59:44.494991       1 round_trippers.go:443] PUT https://kind-control-plane:6443/apis/coordination.k8s.io/v1/namespaces/kube-system/leases/kube-scheduler?timeout=10s 200 OK in 12 milliseconds
I0525 07:59:44.497358       1 leaderelection.go:272] successfully renewed lease kube-system/kube-scheduler
I0525 07:59:45.166710       1 scheduling_queue.go:810] About to try and schedule pod default/simple-http-5dbc6cdb48-dkqcz
I0525 07:59:45.172380       1 scheduler.go:754] Skip schedule deleting pod: default/simple-http-5dbc6cdb48-dkqcz
I0525 07:59:45.181618       1 eventhandlers.go:205] delete event for unscheduled pod default/simple-http-5dbc6cdb48-dkqcz
I0525 07:59:45.253450       1 round_trippers.go:443] POST https://kind-control-plane:6443/apis/events.k8s.io/v1beta1/namespaces/default/events 201 Created in 76 milliseconds
I0525 07:59:45.369119       1 reflector.go:495] k8s.io/client-go/informers/factory.go:135: Watch close - *v1.CSINode total 0 items received
I0525 07:59:45.375543       1 round_trippers.go:443] GET https://kind-control-plane:6443/apis/storage.k8s.io/v1/csinodes?allowWatchBookmarks=true&resourceVersion=535&timeout=9m9s&timeoutSeconds=549&watch=true 200 OK in 5 milliseconds
E0525 07:59:47.288991       1 framework.go:650] plugin "DefaultBinder" failed to bind pod "default/simple-http-5dbc6cdb48-dkqcz": pods "simple-http-5dbc6cdb48-dkqcz" not found
I0525 07:59:47.289219       1 cache.go:379] Finished binding for pod 26c13ca4-43f0-48e2-9f26-3952b607806d. Can be expired.
I0525 07:59:47.289355       1 scheduler.go:535] Failed to bind pod: default/simple-http-5dbc6cdb48-dkqcz
E0525 07:59:47.289629       1 factory.go:479] Error scheduling default/simple-http-5dbc6cdb48-dkqcz: plugin "DefaultBinder" failed to bind pod "default/simple-http-5dbc6cdb48-dkqcz": pods "simple-http-5dbc6cdb48-dkqcz" not found; retrying
I0525 07:59:47.290904       1 scheduler.go:773] Updating pod condition for default/simple-http-5dbc6cdb48-dkqcz to (PodScheduled==False, Reason=SchedulerError)
I0525 07:59:47.309869       1 round_trippers.go:443] POST https://kind-control-plane:6443/apis/events.k8s.io/v1beta1/namespaces/default/events 201 Created in 17 milliseconds
I0525 07:59:47.315973       1 round_trippers.go:443] PUT https://kind-control-plane:6443/api/v1/namespaces/default/pods/simple-http-5dbc6cdb48-dkqcz/status 409 Conflict in 18 milliseconds
E0525 07:59:47.316246       1 scheduler.go:385] Error updating the condition of the pod default/simple-http-5dbc6cdb48-dkqcz: Operation cannot be fulfilled on pods "simple-http-5dbc6cdb48-dkqcz": StorageError: invalid object, Code: 4, Key: /registry/pods/default/simple-http-5dbc6cdb48-dkqcz, ResourceVersion: 0, AdditionalErrorMsg: Precondition failed: UID in precondition: 26c13ca4-43f0-48e2-9f26-3952b607806d, UID in object meta:
I0525 07:59:47.319634       1 round_trippers.go:443] GET https://kind-control-plane:6443/api/v1/namespaces/default/pods/simple-http-5dbc6cdb48-dkqcz 404 Not Found in 28 milliseconds
W0525 07:59:47.319887       1 factory.go:510] A pod default/simple-http-5dbc6cdb48-dkqcz no longer exists
```  

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
