### PR TITLE
Add watch event tooling

### DIFF
--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -1296,7 +1296,7 @@ func taintExists(taints []v1.Taint, taintToFind *v1.Taint) bool {
 //   listOptions         options used to find the resource, recommended to use listOptions.labelSelector
 //   expectedWatchEvents array of events which are expected to occur
 //   scenario            the test itself
-//   retryCleanup             a function to run which ensures that there are no dangling resources upon test failure
+//   retryCleanup        a function to run which ensures that there are no dangling resources upon test failure
 func WatchEventSequenceVerifier(ctx context.Context, dc dynamic.Interface, resourceType schema.GroupVersionResource, namespace string, resourceName string, listOptions metav1.ListOptions, expectedWatchEvents []watch.Event, scenario func(*watchtools.RetryWatcher) []watch.Event, retryCleanup func() error) {
 	initResource, err := dc.Resource(resourceType).Namespace(namespace).List(ctx, listOptions)
 	ExpectNoError(err, "Failed to fetch initial resource")
@@ -1335,7 +1335,7 @@ retriesLoop:
 			totalValidWatchEvents++
 		}
 		err := retryCleanup()
-		ExpectNoError(err, "Error occured when cleaning up resources")
+		ExpectNoError(err, "Error occurred when cleaning up resources")
 		if errs.Len() > 0 && try < retries {
 			fmt.Println("invariants violated:\n", strings.Join(errs.List(), "\n - "))
 			continue retriesLoop

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -1312,22 +1312,22 @@ retriesLoop:
 		// NOTE the test may need access to the events to see what's going on, such as a change in status
 		actualWatchEvents := scenario(resourceWatch)
 		errs := sets.NewString()
-	watchEventsLoop:
+		// watchEventsLoop:
+		totalValidWatchEvents := 0
 		for watchEventIndex, _ := range expectedWatchEvents {
 			foundExpectedWatchEvent := false
-			watchEventNextIndex := watchEventIndex + 1
-			if watchEventNextIndex >= len(expectedWatchEvents) {
-				continue watchEventsLoop
-			}
+			ExpectEqual(len(expectedWatchEvents) <= len(actualWatchEvents), true, "Error: actual watch events amount must be greater than or equal to expected watch events amount")
 			for actualWatchEventIndex, _ := range actualWatchEvents {
-				if actualWatchEvents[watchEventIndex] == expectedWatchEvents[actualWatchEventIndex] {
+				if actualWatchEvents[watchEventIndex].Type == expectedWatchEvents[actualWatchEventIndex].Type {
 					foundExpectedWatchEvent = true
 				}
 			}
 			if foundExpectedWatchEvent == false {
-				errs.Insert(fmt.Sprintf("Watch event %v not found", expectedWatchEvents[watchEventIndex]))
+				errs.Insert(fmt.Sprintf("Watch event %v not found", expectedWatchEvents[watchEventIndex].Type))
 			}
+			totalValidWatchEvents ++
 		}
+		ExpectEqual(totalValidWatchEvents, len(expectedWatchEvents), "Error: there must be an equal amount of total valid watch events (%v) and expected watch events (%v)", totalValidWatchEvents, len(expectedWatchEvents))
 		// TODO restructure failures handling
 		if errs.Len() > 0 && try < retries {
 			fmt.Errorf("invariants violated:\n* %s", strings.Join(errs.List(), "\n* "))

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -1317,22 +1317,26 @@ retriesLoop:
 		// NOTE the test may need access to the events to see what's going on, such as a change in status
 		actualWatchEvents := scenario(resourceWatch)
 		errs := sets.NewString()
-		// watchEventsLoop:
+		ExpectEqual(len(expectedWatchEvents) <= len(actualWatchEvents), true, "Error: actual watch events amount (%d) must be greater than or equal to expected watch events amount (%d)", len(actualWatchEvents), len(expectedWatchEvents))
+
 		totalValidWatchEvents := 0
-		actualWatchEventsHasDelete := false
-		for watchEventIndex := range expectedWatchEvents {
+		foundEventIndexes := map[int]*int{}
+
+		for watchEventIndex, expectedWatchEvent := range expectedWatchEvents {
 			foundExpectedWatchEvent := false
-			ExpectEqual(len(expectedWatchEvents) <= len(actualWatchEvents), true, "Error: actual watch events amount (%d) must be greater than or equal to expected watch events amount (%d)", len(actualWatchEvents), len(expectedWatchEvents))
-			for actualWatchEventIndex := range actualWatchEvents {
-				if actualWatchEvents[watchEventIndex].Type == expectedWatchEvents[actualWatchEventIndex].Type {
-					foundExpectedWatchEvent = true
+		actualWatchEventsLoop:
+			for actualWatchEventIndex, actualWatchEvent := range actualWatchEvents {
+				if foundEventIndexes[actualWatchEventIndex] != nil {
+					continue actualWatchEventsLoop
 				}
-				if actualWatchEvents[actualWatchEventIndex].Type == watch.Deleted && actualWatchEventsHasDelete != true {
-					actualWatchEventsHasDelete = true
+				if actualWatchEvent.Type == expectedWatchEvent.Type {
+					foundExpectedWatchEvent = true
+					foundEventIndexes[actualWatchEventIndex] = &watchEventIndex
+					break actualWatchEventsLoop
 				}
 			}
 			if foundExpectedWatchEvent == false {
-				errs.Insert(fmt.Sprintf("Watch event %v not found", expectedWatchEvents[watchEventIndex].Type))
+				errs.Insert(fmt.Sprintf("Watch event %v not found", expectedWatchEvent.Type))
 			}
 			totalValidWatchEvents++
 		}

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -1298,7 +1298,7 @@ func taintExists(taints []v1.Taint, taintToFind *v1.Taint) bool {
 //   scenario            the function to run
 func WatchEventSequenceVerifier(testContext context.Context, dc dynamic.Interface, resourceType schema.GroupVersionResource, namespace string, resourceName string, listOptions metav1.ListOptions, expectedWatchEvents []watch.Event, scenario func(*watchtools.RetryWatcher) []watch.Event) {
 	initResource, err := dc.Resource(resourceType).Namespace(namespace).List(testContext, listOptions)
-	ExpectNoError(err, "Failed to fetch inital resource")
+	ExpectNoError(err, "Failed to fetch initial resource")
 	listWatcher := &cache.ListWatch{
 		WatchFunc: func(listOptions metav1.ListOptions) (watch.Interface, error) {
 			return dc.Resource(resourceType).Namespace(namespace).Watch(testContext, listOptions)
@@ -1346,6 +1346,14 @@ retriesLoop:
 	}
 }
 
+// WatchUntilWithoutRetry ...
+// reads items from the watch until each provided condition succeeds, and then returns the last watch
+// encountered. The first condition that returns an error terminates the watch (and the event is also returned).
+// If no event has been received, the returned event will be nil.
+// Conditions are satisfied sequentially so as to provide a useful primitive for higher level composition.
+// Waits until context deadline or until context is canceled.
+//
+// the same as watchtools.UntilWithoutRetry, just without the closing of the watch
 func WatchUntilWithoutRetry(ctx context.Context, watcher watch.Interface, conditions ...watchtools.ConditionFunc) (*watch.Event, error) {
 	ch := watcher.ResultChan()
 	var lastEvent *watch.Event

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -1297,12 +1297,14 @@ func taintExists(taints []v1.Taint, taintToFind *v1.Taint) bool {
 //   expectedWatchEvents array of events which are expected to occur
 //   scenario            the function to run
 func WatchEventSequenceVerifier(testContext context.Context, dc dynamic.Interface, resourceType schema.GroupVersionResource, namespace string, resourceName string, listOptions metav1.ListOptions, expectedWatchEvents []watch.Event, scenario func(*watchtools.RetryWatcher) []watch.Event) {
+	initResource, err := dc.Resource(resourceType).Namespace(namespace).List(testContext, listOptions)
+	ExpectNoError(err, "Failed to fetch inital resource")
 	listWatcher := &cache.ListWatch{
 		WatchFunc: func(listOptions metav1.ListOptions) (watch.Interface, error) {
 			return dc.Resource(resourceType).Namespace(namespace).Watch(testContext, listOptions)
 		},
 	}
-	resourceWatch, err := watchtools.NewRetryWatcher("1", listWatcher)
+	resourceWatch, err := watchtools.NewRetryWatcher(initResource.GetResourceVersion(), listWatcher)
 	ExpectNoError(err, "Failed to create a resource watch of %v in namespace %v", resourceType.Resource, namespace)
 
 	// NOTE value of 3 retries seems to make sense
@@ -1334,12 +1336,51 @@ retriesLoop:
 		if actualWatchEventsHasDelete == false {
 			_ = dc.Resource(resourceType).Namespace(namespace).DeleteCollection(testContext, metav1.DeleteOptions{}, listOptions)
 		}
-		// TODO restructure failures handling
 		if errs.Len() > 0 && try < retries {
-			fmt.Println(fmt.Errorf("invariants violated:\n* %s", strings.Join(errs.List(), "\n* ")))
+			fmt.Println("invariants violated:\n", strings.Join(errs.List(), "\n - "))
 			continue retriesLoop
 		}
-		ExpectEqual(errs.Len() > 0, false, fmt.Errorf("invariants violated:\n* %s", strings.Join(errs.List(), "\n* ")))
+		ExpectEqual(errs.Len() > 0, false, strings.Join(errs.List(), "\n - "))
 		ExpectEqual(totalValidWatchEvents, len(expectedWatchEvents), "Error: there must be an equal amount of total valid watch events (%v) and expected watch events (%v)", totalValidWatchEvents, len(expectedWatchEvents))
+		break retriesLoop
 	}
+}
+
+func WatchUntilWithoutRetry(ctx context.Context, watcher watch.Interface, conditions ...watchtools.ConditionFunc) (*watch.Event, error) {
+	ch := watcher.ResultChan()
+	var lastEvent *watch.Event
+	for _, condition := range conditions {
+		// check the next condition against the previous event and short circuit waiting for the next watch
+		if lastEvent != nil {
+			done, err := condition(*lastEvent)
+			if err != nil {
+				return lastEvent, err
+			}
+			if done {
+				continue
+			}
+		}
+	ConditionSucceeded:
+		for {
+			select {
+			case event, ok := <-ch:
+				if !ok {
+					return lastEvent, watchtools.ErrWatchClosed
+				}
+				lastEvent = &event
+
+				done, err := condition(event)
+				if err != nil {
+					return lastEvent, err
+				}
+				if done {
+					break ConditionSucceeded
+				}
+
+			case <-ctx.Done():
+				return lastEvent, wait.ErrWaitTimeout
+			}
+		}
+	}
+	return lastEvent, nil
 }

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -1286,12 +1286,9 @@ func taintExists(taints []v1.Taint, taintToFind *v1.Taint) bool {
 	return false
 }
 
-func getDynamicResourceWatch(testContext context.Context, dc dynamic.Interface, resourceType schema.GroupVersionResource, namespace string, resourceName string, listOptions metav1.ListOptions) func() (watch.Interface, error) {
-	return func() (watch.Interface, error) {
-		res, err := dc.Resource(resourceType).Namespace(namespace).Watch(context.TODO(), listOptions)
-		ExpectNoError(err, "Failed to create a watch for %v", resourceType.Resource)
-		return res, err
-	}
+func getDynamicResourceWatch(testContext context.Context, dc dynamic.Interface, resourceType schema.GroupVersionResource, namespace string, listOptions metav1.ListOptions) (watch.Interface, error) {
+	res, err := dc.Resource(resourceType).Namespace(namespace).Watch(context.TODO(), listOptions)
+	return res, err
 }
 
 // WatchEventEnsurerAndManager
@@ -1305,10 +1302,20 @@ func getDynamicResourceWatch(testContext context.Context, dc dynamic.Interface, 
 //   expectedWatchEvents array of events which are expected to occur
 //   scenario            the function to run
 func WatchEventEnsurerAndManager(testContext context.Context, dc dynamic.Interface, resourceType schema.GroupVersionResource, namespace string, resourceName string, listOptions metav1.ListOptions, expectedWatchEvents []watch.Event, scenario func(*watch.Interface) []watch.Event) {
-	// TODO add client-go/tools/watch/retrywatcher to manage watch restarts
+	listWatcher := &cache.ListWatch{
+		WatchFunc: func(listOptions metav1.ListOptions) (watch.Interface, error) {
+			return getDynamicResourceWatch(testContext, dc, resourceType, namespace, listOptions)
+		},
+	}
+	resourceWatch, err := watchtools.NewRetryWatcher("", listWatcher)
+	ExpectNoError(err, "Failed to create a resource watch of %v in namespace %v", resourceType.Resource, namespace)
+
+	ExpectNoError(err, "Failed to create a watch for %v", resourceType.Resource)
 	retries := 3
 retriesLoop:
 	for try := 1; try <= retries; try++ {
+		// TODO pass resourceWatch to the test function, or just collect events separately and parse them after
+		scenario()
 		errs := sets.NewString()
 	watchEventsLoop:
 		for watchEventIndex, _ := range expectedWatchEvents {

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -1286,6 +1286,14 @@ func taintExists(taints []v1.Taint, taintToFind *v1.Taint) bool {
 	return false
 }
 
+func getDynamicResourceWatch(testContext context.Context, dc dynamic.Interface, resourceType schema.GroupVersionResource, namespace string, resourceName string, listOptions metav1.ListOptions) func() (watch.Interface, error) {
+	return func() (watch.Interface, error) {
+		res, err := dc.Resource(resourceType).Namespace(namespace).Watch(context.TODO(), listOptions)
+		ExpectNoError(err, "Failed to create a watch for %v", resourceType.Resource)
+		return res, err
+	}
+}
+
 // WatchEventEnsurerAndManager
 // manages a watch for a given resource, ensures that events take place in a given order, retries the test on failure
 //   testContext         cancelation signal across API boundries, e.g: context.TODO()

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -1295,13 +1295,14 @@ func taintExists(taints []v1.Taint, taintToFind *v1.Taint) bool {
 //   resourceName        the name of the given resource
 //   listOptions         options used to find the resource, recommended to use listOptions.labelSelector
 //   expectedWatchEvents array of events which are expected to occur
-//   scenario            the function to run
-func WatchEventSequenceVerifier(testContext context.Context, dc dynamic.Interface, resourceType schema.GroupVersionResource, namespace string, resourceName string, listOptions metav1.ListOptions, expectedWatchEvents []watch.Event, scenario func(*watchtools.RetryWatcher) []watch.Event) {
-	initResource, err := dc.Resource(resourceType).Namespace(namespace).List(testContext, listOptions)
+//   scenario            the test itself
+//   retryCleanup             a function to run which ensures that there are no dangling resources upon test failure
+func WatchEventSequenceVerifier(ctx context.Context, dc dynamic.Interface, resourceType schema.GroupVersionResource, namespace string, resourceName string, listOptions metav1.ListOptions, expectedWatchEvents []watch.Event, scenario func(*watchtools.RetryWatcher) []watch.Event, retryCleanup func() error) {
+	initResource, err := dc.Resource(resourceType).Namespace(namespace).List(ctx, listOptions)
 	ExpectNoError(err, "Failed to fetch initial resource")
 	listWatcher := &cache.ListWatch{
 		WatchFunc: func(listOptions metav1.ListOptions) (watch.Interface, error) {
-			return dc.Resource(resourceType).Namespace(namespace).Watch(testContext, listOptions)
+			return dc.Resource(resourceType).Namespace(namespace).Watch(ctx, listOptions)
 		},
 	}
 	resourceWatch, err := watchtools.NewRetryWatcher(initResource.GetResourceVersion(), listWatcher)
@@ -1319,7 +1320,7 @@ retriesLoop:
 		actualWatchEventsHasDelete := false
 		for watchEventIndex := range expectedWatchEvents {
 			foundExpectedWatchEvent := false
-			ExpectEqual(len(expectedWatchEvents) <= len(actualWatchEvents), true, "Error: actual watch events amount must be greater than or equal to expected watch events amount")
+			ExpectEqual(len(expectedWatchEvents) <= len(actualWatchEvents), true, "Error: actual watch events amount (%d) must be greater than or equal to expected watch events amount (%d)", len(actualWatchEvents), len(expectedWatchEvents))
 			for actualWatchEventIndex := range actualWatchEvents {
 				if actualWatchEvents[watchEventIndex].Type == expectedWatchEvents[actualWatchEventIndex].Type {
 					foundExpectedWatchEvent = true
@@ -1333,15 +1334,14 @@ retriesLoop:
 			}
 			totalValidWatchEvents++
 		}
-		if actualWatchEventsHasDelete == false {
-			_ = dc.Resource(resourceType).Namespace(namespace).DeleteCollection(testContext, metav1.DeleteOptions{}, listOptions)
-		}
+		err := retryCleanup()
+		ExpectNoError(err, "Error occured when cleaning up resources")
 		if errs.Len() > 0 && try < retries {
 			fmt.Println("invariants violated:\n", strings.Join(errs.List(), "\n - "))
 			continue retriesLoop
 		}
 		ExpectEqual(errs.Len() > 0, false, strings.Join(errs.List(), "\n - "))
-		ExpectEqual(totalValidWatchEvents, len(expectedWatchEvents), "Error: there must be an equal amount of total valid watch events (%v) and expected watch events (%v)", totalValidWatchEvents, len(expectedWatchEvents))
+		ExpectEqual(totalValidWatchEvents, len(expectedWatchEvents), "Error: there must be an equal amount of total valid watch events (%d) and expected watch events (%d)", totalValidWatchEvents, len(expectedWatchEvents))
 		break retriesLoop
 	}
 }
@@ -1353,7 +1353,7 @@ retriesLoop:
 // Conditions are satisfied sequentially so as to provide a useful primitive for higher level composition.
 // Waits until context deadline or until context is canceled.
 //
-// the same as watchtools.UntilWithoutRetry, just without the closing of the watch
+// the same as watchtools.UntilWithoutRetry, just without the closing of the watch - as for the purpose of being paired with WatchEventSequenceVerifier, the watch is needed for continual watch event collection
 func WatchUntilWithoutRetry(ctx context.Context, watcher watch.Interface, conditions ...watchtools.ConditionFunc) (*watch.Event, error) {
 	ch := watcher.ResultChan()
 	var lastEvent *watch.Event

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -1297,6 +1297,10 @@ func taintExists(taints []v1.Taint, taintToFind *v1.Taint) bool {
 //   expectedWatchEvents array of events which are expected to occur
 //   scenario            the test itself
 //   retryCleanup        a function to run which ensures that there are no dangling resources upon test failure
+// this tooling relies on the test to return the events as they occur
+// the entire scenario must be run to ensure that the desired watch events arrive in order (allowing for interweaving of watch events)
+//   if an expected watch event is missing we elect to clean up and run the entire scenario again
+// we try the scenario three times to allow the sequencing to fail a couple of times
 func WatchEventSequenceVerifier(ctx context.Context, dc dynamic.Interface, resourceType schema.GroupVersionResource, namespace string, resourceName string, listOptions metav1.ListOptions, expectedWatchEvents []watch.Event, scenario func(*watchtools.RetryWatcher) []watch.Event, retryCleanup func() error) {
 	listWatcher := &cache.ListWatch{
 		WatchFunc: func(listOptions metav1.ListOptions) (watch.Interface, error) {
@@ -1304,7 +1308,6 @@ func WatchEventSequenceVerifier(ctx context.Context, dc dynamic.Interface, resou
 		},
 	}
 
-	// NOTE value of 3 retries seems to make sense
 	retries := 3
 retriesLoop:
 	for try := 1; try <= retries; try++ {

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -1315,10 +1315,10 @@ retriesLoop:
 		// watchEventsLoop:
 		totalValidWatchEvents := 0
 		actualWatchEventsHasDelete := false
-		for watchEventIndex, _ := range expectedWatchEvents {
+		for watchEventIndex := range expectedWatchEvents {
 			foundExpectedWatchEvent := false
 			ExpectEqual(len(expectedWatchEvents) <= len(actualWatchEvents), true, "Error: actual watch events amount must be greater than or equal to expected watch events amount")
-			for actualWatchEventIndex, _ := range actualWatchEvents {
+			for actualWatchEventIndex := range actualWatchEvents {
 				if actualWatchEvents[watchEventIndex].Type == expectedWatchEvents[actualWatchEventIndex].Type {
 					foundExpectedWatchEvent = true
 				}
@@ -1329,7 +1329,7 @@ retriesLoop:
 			if foundExpectedWatchEvent == false {
 				errs.Insert(fmt.Sprintf("Watch event %v not found", expectedWatchEvents[watchEventIndex].Type))
 			}
-			totalValidWatchEvents ++
+			totalValidWatchEvents++
 		}
 		if actualWatchEventsHasDelete == false {
 			_ = dc.Resource(resourceType).Namespace(namespace).DeleteCollection(testContext, metav1.DeleteOptions{}, listOptions)

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -1302,7 +1302,7 @@ func WatchEventSequenceVerifier(testContext context.Context, dc dynamic.Interfac
 			return dc.Resource(resourceType).Namespace(namespace).Watch(testContext, listOptions)
 		},
 	}
-	resourceWatch, err := watchtools.NewRetryWatcher("", listWatcher)
+	resourceWatch, err := watchtools.NewRetryWatcher("1", listWatcher)
 	ExpectNoError(err, "Failed to create a resource watch of %v in namespace %v", resourceType.Resource, namespace)
 
 	// NOTE value of 3 retries seems to make sense

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -1286,7 +1286,7 @@ func taintExists(taints []v1.Taint, taintToFind *v1.Taint) bool {
 	return false
 }
 
-// WatchEventSequenceVerifier
+// WatchEventSequenceVerifier ...
 // manages a watch for a given resource, ensures that events take place in a given order, retries the test on failure
 //   testContext         cancelation signal across API boundries, e.g: context.TODO()
 //   dc                  sets up a client to the API

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -51,6 +51,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	"k8s.io/client-go/dynamic"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	restclient "k8s.io/client-go/rest"
@@ -1283,4 +1284,37 @@ func taintExists(taints []v1.Taint, taintToFind *v1.Taint) bool {
 		}
 	}
 	return false
+}
+
+// WatchEventEnsurerAndManager
+// manages a watch for a given resource, ensures that events take place in a given order, retries the test on failure
+func WatchEventEnsurerAndManager(testContext context.Context, dc dynamic.Interface, resourceType schema.GroupVersionResource, namespace string, resourceName string, listOptions metav1.ListOptions, expectedWatchEvents []watch.Event, scenario func(*watch.Interface) []watch.Event) {
+	retries := 3
+retriesLoop:
+	for try := 1; try <= retries; try++ {
+		var watchEvents []watch.Event
+		resourceWatch := &watch.Interface{}
+		// TODO consider watch deaths
+		&resourceWatch, err = dc.Resource(resourceType).Namespace(namespace).Watch(testContext, listOptions)
+		framework.ExpectNoError(err, "Failed to set a resource watch up for resourceType %v in namespace %s", resourceType, namespace)
+
+		actualWatchEvents := scenario(resourceWatch)
+		framework.ExpectEqual(len(expectedWatchEvents) <= len(actualWatchEvents), true, "Amount of actual watch events to be equal to or greater than the amount of expected watch events")
+
+	expectedWatchEventsLoop:
+		for expectedWatchEventIndex, expectedWatchEvent := range expectedWatchEvents {
+			for actualWatchEventIndex, _ := range actualWatchEvents {
+				if actualWatchEvents[expectedWatchEventIndex].Type == expectedWatchEvents[actualWatchEventIndex].Type {
+					watchEvents = append(watchEvents, expectedWatchEvent)
+					continue expectedWatchEventsLoop
+				}
+			}
+		}
+
+		// TODO clean up resources, based on watchEvent.Object, using DynamicClient
+
+		if len(watchEvents) != len(actualWatchEvents) {
+			continue retriesLoop
+		}
+	}
 }

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -1298,20 +1298,22 @@ func taintExists(taints []v1.Taint, taintToFind *v1.Taint) bool {
 //   scenario            the test itself
 //   retryCleanup        a function to run which ensures that there are no dangling resources upon test failure
 func WatchEventSequenceVerifier(ctx context.Context, dc dynamic.Interface, resourceType schema.GroupVersionResource, namespace string, resourceName string, listOptions metav1.ListOptions, expectedWatchEvents []watch.Event, scenario func(*watchtools.RetryWatcher) []watch.Event, retryCleanup func() error) {
-	initResource, err := dc.Resource(resourceType).Namespace(namespace).List(ctx, listOptions)
-	ExpectNoError(err, "Failed to fetch initial resource")
 	listWatcher := &cache.ListWatch{
 		WatchFunc: func(listOptions metav1.ListOptions) (watch.Interface, error) {
 			return dc.Resource(resourceType).Namespace(namespace).Watch(ctx, listOptions)
 		},
 	}
-	resourceWatch, err := watchtools.NewRetryWatcher(initResource.GetResourceVersion(), listWatcher)
-	ExpectNoError(err, "Failed to create a resource watch of %v in namespace %v", resourceType.Resource, namespace)
 
 	// NOTE value of 3 retries seems to make sense
 	retries := 3
 retriesLoop:
 	for try := 1; try <= retries; try++ {
+		initResource, err := dc.Resource(resourceType).Namespace(namespace).List(ctx, listOptions)
+		ExpectNoError(err, "Failed to fetch initial resource")
+
+		resourceWatch, err := watchtools.NewRetryWatcher(initResource.GetResourceVersion(), listWatcher)
+		ExpectNoError(err, "Failed to create a resource watch of %v in namespace %v", resourceType.Resource, namespace)
+
 		// NOTE the test may need access to the events to see what's going on, such as a change in status
 		actualWatchEvents := scenario(resourceWatch)
 		errs := sets.NewString()
@@ -1334,7 +1336,7 @@ retriesLoop:
 			}
 			totalValidWatchEvents++
 		}
-		err := retryCleanup()
+		err = retryCleanup()
 		ExpectNoError(err, "Error occurred when cleaning up resources")
 		if errs.Len() > 0 && try < retries {
 			fmt.Println("invariants violated:\n", strings.Join(errs.List(), "\n - "))


### PR DESCRIPTION
What type of PR is this?
/kind cleanup

What this PR does / why we need it:
Adds a function to verify the sequence of watch events as they come through - via the creation and management of a watch and a scenario.
This PR will enable the progress of several Issues and PR's

Which issue(s) this PR fixes:
Fixes: #90957


Special notes for your reviewer:
PR's waiting for the watch tooling: #90944, #90880, #90942, 
Issues waiting for the watch tooling: #90877, #90916

Does this PR introduce a user-facing change?:
NONE

Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
NONE

/sig testing
/sig architecture
/area conformance