### PR TITLE
WIP: Update kubectl run help for restart policy

### DIFF
--- a/translations/kubectl/template.pot
+++ b/translations/kubectl/template.pot
@@ -2039,10 +2039,8 @@ msgstr ""
 
 #: pkg/kubectl/cmd/run.go:131
 msgid ""
-"The restart policy for this Pod.  Legal values [Always, OnFailure, Never].  "
-"If set to 'Always' a deployment is created, if set to 'OnFailure' a job is "
-"created, if set to 'Never', a regular pod is created. For the latter two --"
-"replicas must be 1.  Default 'Always', for CronJobs `Never`."
+"The restart policy for this Pod.  Legal values [Always, OnFailure, Never]. "
+"Sets the pod restartPolicy according to the value."
 msgstr ""
 
 #: pkg/kubectl/cmd/create_secret.go:88


### PR DESCRIPTION
Enhancement to the kubectl run help for restart policy.  Existing text refers to k8s <= 1.17.x.  Kubernetes 1.18.x results in Pod creation.  Always/OnFailure/Never change the Pod restartPolicy, rather than creating Jobs/Deployments or Cronjobs as per previous versions, lastly replicas in this command use case are deprecated -

```
"The restart policy for this Pod.  Legal values [Always, OnFailure, Never].  "
"If set to 'Always' a deployment is created, if set to 'OnFailure' a job is "
"created, if set to 'Never', a regular pod is created. For the latter two --"	
"replicas must be 1.  Default 'Always', for CronJobs `Never`."
```

Details as follows -

Always =

```
james@ubuntu-throwaway-1:~$ kubectl run nginx --image=nginx --restart=Always --dry-run=client -o yaml
apiVersion: v1
kind: Pod
metadata:
  creationTimestamp: null
  labels:
    run: nginx
  name: nginx
spec:
  containers:
  - image: nginx
    name: nginx
    resources: {}
  dnsPolicy: ClusterFirst
  restartPolicy: Always
status: {}
```

OnFailure = 

```
james@ubuntu-throwaway-1:~$ kubectl run nginx --image=nginx --restart=OnFailure --dry-run=client -o yaml
apiVersion: v1
kind: Pod
metadata:
  creationTimestamp: null
  labels:
    run: nginx
  name: nginx
spec:
  containers:
  - image: nginx
    name: nginx
    resources: {}
  dnsPolicy: ClusterFirst
  restartPolicy: OnFailure
status: {}
```

Never =

```
james@ubuntu-throwaway-1:~$ kubectl run nginx --image=nginx --restart=Never --dry-run=client -o yaml
apiVersion: v1
kind: Pod
metadata:
  creationTimestamp: null
  labels:
    run: nginx
  name: nginx
spec:
  containers:
  - image: nginx
    name: nginx
    resources: {}
  dnsPolicy: ClusterFirst
  restartPolicy: Never
status: {}
```

Any use of replicas, will also result in a deprecation warning, regardless of 1 or more -

```
james@ubuntu-throwaway-1:~$ kubectl run nginx --image=nginx --restart=Never --dry-run=client --replicas=1 -o yaml
Flag --replicas has been deprecated, has no effect and will be removed in the future.
apiVersion: v1
kind: Pod
metadata:
  creationTimestamp: null
  labels:
    run: nginx
  name: nginx
spec:
  containers:
  - image: nginx
    name: nginx
    resources: {}
  dnsPolicy: ClusterFirst
  restartPolicy: Never
status: {}
```

Simplified the documentation nugget to -

```
"The restart policy for this Pod.  Legal values [Always, OnFailure, Never]. "
"Sets the pod restartPolicy according to the value."
```

/kind documentation