### PR TITLE
Set default value for protocol field of container port

### DIFF
--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -1765,6 +1765,7 @@ type ContainerPort struct {
 	// Protocol for port. Must be UDP, TCP, or SCTP.
 	// Defaults to "TCP".
 	// +optional
+	// +kubebuilder:default=TCP
 	Protocol Protocol `json:"protocol,omitempty" protobuf:"bytes,4,opt,name=protocol,casttype=Protocol"`
 	// What host IP to bind the external port to.
 	// +optional


### PR DESCRIPTION
Signed-off-by: Tamal Saha <tamal@appscode.com>

**What type of PR is this?**
/kind api-change

**What this PR does / why we need it**:
Allow generating proper default values when used in a CRD

ref: https://github.com/kubernetes/kubernetes/issues/91395#issuecomment-633261523
ref: https://github.com/kubernetes-sigs/controller-tools/issues/444#issuecomment-633270142

**Which issue(s) this PR fixes**:

Fixes #91395

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
