### PR TITLE
Automated cherry pick of #86276: fix: should truncate long subnet name on lb rules

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_loadbalancer.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_loadbalancer.go
@@ -405,7 +405,7 @@ func (az *Cloud) getServiceLoadBalancerStatus(service *v1.Service, lb *network.L
 		return nil, nil
 	}
 	isInternal := requiresInternalLoadBalancer(service)
-	lbFrontendIPConfigName := az.getFrontendIPConfigName(service, subnet(service))
+	lbFrontendIPConfigName := az.getFrontendIPConfigName(service)
 	serviceName := getServiceName(service)
 	for _, ipConfiguration := range *lb.FrontendIPConfigurations {
 		if lbFrontendIPConfigName == *ipConfiguration.Name {
@@ -695,7 +695,7 @@ func (az *Cloud) reconcileLoadBalancer(clusterName string, service *v1.Service, 
 	}
 	lbName := *lb.Name
 	klog.V(2).Infof("reconcileLoadBalancer for service(%s): lb(%s) wantLb(%t) resolved load balancer name", serviceName, lbName, wantLb)
-	lbFrontendIPConfigName := az.getFrontendIPConfigName(service, subnet(service))
+	lbFrontendIPConfigName := az.getFrontendIPConfigName(service)
 	lbFrontendIPConfigID := az.getFrontendIPConfigID(lbName, lbFrontendIPConfigName)
 	lbBackendPoolName := getBackendPoolName(az.ipv6DualStackEnabled, clusterName, service)
 	lbBackendPoolID := az.getBackendPoolID(lbName, lbBackendPoolName)
@@ -1028,7 +1028,7 @@ func (az *Cloud) reconcileLoadBalancerRule(
 		}
 
 		for _, protocol := range protocols {
-			lbRuleName := az.getLoadBalancerRuleName(service, protocol, port.Port, subnet(service))
+			lbRuleName := az.getLoadBalancerRuleName(service, protocol, port.Port)
 			klog.V(2).Infof("reconcileLoadBalancerRule lb name (%s) rule name (%s)", lbName, lbRuleName)
 
 			transportProto, _, probeProto, err := getProtocolsFromKubernetesProtocol(protocol)

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_loadbalancer_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_loadbalancer_test.go
@@ -1628,7 +1628,7 @@ func TestGetServiceLoadBalancerStatus(t *testing.T) {
 		},
 		{
 			desc: "getServiceLoadBalancerStatus shall return nil if lb.FrontendIPConfigurations.name != " +
-				"az.getFrontendIPConfigName(service, subnet(service))",
+				"az.getFrontendIPConfigName(service)",
 			service: &internalService,
 			lb:      &lb3,
 		},

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_standard.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_standard.go
@@ -65,7 +65,7 @@ const (
 	nodeLabelRole  = "kubernetes.io/role"
 	nicFailedState = "Failed"
 
-	storageAccountNameMaxLength = 24
+	storageAccountNameMaxLength   = 24
 	frontendIPConfigNameMaxLength = 80
 	loadBalancerRuleNameMaxLength = 80
 )
@@ -284,10 +284,10 @@ func (az *Cloud) getLoadBalancerRuleName(service *v1.Service, protocol v1.Protoc
 		return ruleName
 	}
 
-	// Load balancer rule name must be less or equal to 80 charactors, so excluding the hyphen two segments cannot exceed 79
+	// Load balancer rule name must be less or equal to 80 characters, so excluding the hyphen two segments cannot exceed 79
 	subnetSegment := *subnet
-	if len(ruleName) + len(subnetSegment) + 1 > loadBalancerRuleNameMaxLength {
-		subnetSegment = subnetSegment[:loadBalancerRuleNameMaxLength - len(ruleName) - 1]
+	if len(ruleName)+len(subnetSegment)+1 > loadBalancerRuleNameMaxLength {
+		subnetSegment = subnetSegment[:loadBalancerRuleNameMaxLength-len(ruleName)-1]
 	}
 
 	return fmt.Sprintf("%s-%s-%s-%d", prefix, subnetSegment, protocol, port)
@@ -333,8 +333,8 @@ func (az *Cloud) getFrontendIPConfigName(service *v1.Service) string {
 	subnetName := subnet(service)
 	if subnetName != nil {
 		ipcName := fmt.Sprintf("%s-%s", baseName, *subnetName)
-		
-		// Azure lb front end configuration name must not exceed 80 charactors
+
+		// Azure lb front end configuration name must not exceed 80 characters
 		if len(ipcName) > frontendIPConfigNameMaxLength {
 			ipcName = ipcName[:frontendIPConfigNameMaxLength]
 		}

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_standard.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_standard.go
@@ -66,6 +66,8 @@ const (
 	nicFailedState = "Failed"
 
 	storageAccountNameMaxLength = 24
+	frontendIPConfigNameMaxLength = 80
+	loadBalancerRuleNameMaxLength = 80
 )
 
 var errNotInVMSet = errors.New("vm is not in the vmset")
@@ -284,8 +286,8 @@ func (az *Cloud) getLoadBalancerRuleName(service *v1.Service, protocol v1.Protoc
 
 	// Load balancer rule name must be less or equal to 80 charactors, so excluding the hyphen two segments cannot exceed 79
 	subnetSegment := *subnet
-	if len(ruleName) + len(subnetSegment) > 79 {
-		subnetSegment = subnetSegment[:79 - len(ruleName)]
+	if len(ruleName) + len(subnetSegment) + 1 > loadBalancerRuleNameMaxLength {
+		subnetSegment = subnetSegment[:loadBalancerRuleNameMaxLength - len(ruleName) - 1]
 	}
 
 	return fmt.Sprintf("%s-%s-%s-%d", prefix, subnetSegment, protocol, port)
@@ -333,8 +335,8 @@ func (az *Cloud) getFrontendIPConfigName(service *v1.Service) string {
 		ipcName := fmt.Sprintf("%s-%s", baseName, *subnetName)
 		
 		// Azure lb front end configuration name must not exceed 80 charactors
-		if len(ipcName) > 80 {
-			ipcName = ipcName[:80]
+		if len(ipcName) > frontendIPConfigNameMaxLength {
+			ipcName = ipcName[:frontendIPConfigNameMaxLength]
 		}
 		return ipcName
 	}

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_standard_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_standard_test.go
@@ -347,7 +347,7 @@ func TestGetLoadBalancingRuleName(t *testing.T) {
 	}
 }
 
-func TestgetFrontendIPConfigName(t *testing.T) {
+func TestGetFrontendIPConfigName(t *testing.T) {
 	az := getTestCloud()
 	az.PrimaryAvailabilitySetName = "primary"
 
@@ -380,14 +380,14 @@ func TestgetFrontendIPConfigName(t *testing.T) {
 			subnetName:       "averylonnnngggnnnnnnnnnnnnnnnnnnnnnngggggggggggggggggggggggggggggggggggggsubet",
 			isInternal: true,
 			useStandardLB:    true,
-			expected: "a257b965551374ad2b091ef3f07043ad-averylonnnngggnnnnnnnnnnnnnnnnnnnnnngg",
+			expected: "a257b965551374ad2b091ef3f07043ad-averylonnnngggnnnnnnnnnnnnnnnnnnnnnnggggggggggg",
 		},
 		{
 			description: "internal basic lb should have subnet name on the frontend ip configuration name but truncated to 80 charactors",
 			subnetName:       "averylonnnngggnnnnnnnnnnnnnnnnnnnnnngggggggggggggggggggggggggggggggggggggsubet",
 			isInternal: true,
 			useStandardLB:    false,
-			expected: "a257b965551374ad2b091ef3f07043ad-averylonnnngggnnnnnnnnnnnnnnnnnnnnnngg",
+			expected: "a257b965551374ad2b091ef3f07043ad-averylonnnngggnnnnnnnnnnnnnnnnnnnnnnggggggggggg",
 		},
 		{
 			description: "external standard lb should not have subnet name on the frontend ip configuration name",
@@ -414,7 +414,7 @@ func TestgetFrontendIPConfigName(t *testing.T) {
 		svc.Annotations[ServiceAnnotationLoadBalancerInternalSubnet] = c.subnetName
 		svc.Annotations[ServiceAnnotationLoadBalancerInternal] = strconv.FormatBool(c.isInternal)
 
-		loadbalancerName := az.getFrontendIPConfigName(svc)
-		assert.Equal(t, c.expected, loadbalancerName, c.description)
+		ipconfigName := az.getFrontendIPConfigName(svc)
+		assert.Equal(t, c.expected, ipconfigName, c.description)
 	}
 }

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_standard_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_standard_test.go
@@ -272,10 +272,7 @@ func TestGetLoadBalancingRuleName(t *testing.T) {
 
 	svc := &v1.Service{
 		ObjectMeta: meta.ObjectMeta{
-			Annotations: map[string]string{
-				ServiceAnnotationLoadBalancerInternalSubnet: "subnet",
-				ServiceAnnotationLoadBalancerInternal:       "true",
-			},
+			Annotations: map[string]string{ 	},
 			UID: "257b9655-5137-4ad2-b091-ef3f07043ad3",
 		},
 	}
@@ -345,7 +342,79 @@ func TestGetLoadBalancingRuleName(t *testing.T) {
 		svc.Annotations[ServiceAnnotationLoadBalancerInternalSubnet] = c.subnetName
 		svc.Annotations[ServiceAnnotationLoadBalancerInternal] = strconv.FormatBool(c.isInternal)
 
-		loadbalancerName := az.getLoadBalancerRuleName(svc, c.protocol, c.port)
+		loadbalancerRuleName := az.getLoadBalancerRuleName(svc, c.protocol, c.port)
+		assert.Equal(t, c.expected, loadbalancerRuleName, c.description)
+	}
+}
+
+func TestgetFrontendIPConfigName(t *testing.T) {
+	az := getTestCloud()
+	az.PrimaryAvailabilitySetName = "primary"
+
+	svc := &v1.Service{
+		ObjectMeta: meta.ObjectMeta{
+			Annotations: map[string]string{
+				ServiceAnnotationLoadBalancerInternalSubnet: "subnet",
+				ServiceAnnotationLoadBalancerInternal:       "true",
+			},
+			UID: "257b9655-5137-4ad2-b091-ef3f07043ad3",
+		},
+	}
+
+	cases := []struct {
+		description string
+		subnetName    string
+		isInternal    bool
+		useStandardLB bool
+		expected      string
+	}{
+		{
+			description: "internal lb should have subnet name on the frontend ip configuration name",
+			subnetName:       "shortsubnet",
+			isInternal: true,
+			useStandardLB:    true,
+			expected: "a257b965551374ad2b091ef3f07043ad-shortsubnet",
+		},
+		{
+			description: "internal standard lb should have subnet name on the frontend ip configuration name but truncated to 80 charactors",
+			subnetName:       "averylonnnngggnnnnnnnnnnnnnnnnnnnnnngggggggggggggggggggggggggggggggggggggsubet",
+			isInternal: true,
+			useStandardLB:    true,
+			expected: "a257b965551374ad2b091ef3f07043ad-averylonnnngggnnnnnnnnnnnnnnnnnnnnnngg",
+		},
+		{
+			description: "internal basic lb should have subnet name on the frontend ip configuration name but truncated to 80 charactors",
+			subnetName:       "averylonnnngggnnnnnnnnnnnnnnnnnnnnnngggggggggggggggggggggggggggggggggggggsubet",
+			isInternal: true,
+			useStandardLB:    false,
+			expected: "a257b965551374ad2b091ef3f07043ad-averylonnnngggnnnnnnnnnnnnnnnnnnnnnngg",
+		},
+		{
+			description: "external standard lb should not have subnet name on the frontend ip configuration name",
+			subnetName:       "shortsubnet",
+			isInternal: false,
+			useStandardLB:    true,
+			expected: "a257b965551374ad2b091ef3f07043ad",
+		},
+		{
+			description: "external basic lb should not have subnet name on the frontend ip configuration name",
+			subnetName:       "shortsubnet",
+			isInternal: false,
+			useStandardLB:    false,
+			expected: "a257b965551374ad2b091ef3f07043ad",
+		},
+	}
+
+	for _, c := range cases {
+		if c.useStandardLB {
+			az.Config.LoadBalancerSku = loadBalancerSkuStandard
+		} else {
+			az.Config.LoadBalancerSku = loadBalancerSkuBasic
+		}
+		svc.Annotations[ServiceAnnotationLoadBalancerInternalSubnet] = c.subnetName
+		svc.Annotations[ServiceAnnotationLoadBalancerInternal] = strconv.FormatBool(c.isInternal)
+
+		loadbalancerName := az.getFrontendIPConfigName(svc)
 		assert.Equal(t, c.expected, loadbalancerName, c.description)
 	}
 }

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_standard_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_standard_test.go
@@ -19,8 +19,8 @@ limitations under the License.
 package azure
 
 import (
-	"testing"
 	"strconv"
+	"testing"
 
 	"github.com/stretchr/testify/assert"
 
@@ -272,13 +272,13 @@ func TestGetLoadBalancingRuleName(t *testing.T) {
 
 	svc := &v1.Service{
 		ObjectMeta: meta.ObjectMeta{
-			Annotations: map[string]string{ 	},
-			UID: "257b9655-5137-4ad2-b091-ef3f07043ad3",
+			Annotations: map[string]string{},
+			UID:         "257b9655-5137-4ad2-b091-ef3f07043ad3",
 		},
 	}
 
 	cases := []struct {
-		description string
+		description   string
 		subnetName    string
 		isInternal    bool
 		useStandardLB bool
@@ -287,49 +287,49 @@ func TestGetLoadBalancingRuleName(t *testing.T) {
 		expected      string
 	}{
 		{
-			description: "internal lb should have subnet name on the rule name",
-			subnetName:       "shortsubnet",
-			isInternal: true,
-			useStandardLB:    true,
-			protocol: v1.ProtocolTCP,
-			port: 9000,
-			expected: "a257b965551374ad2b091ef3f07043ad-shortsubnet-TCP-9000",
+			description:   "internal lb should have subnet name on the rule name",
+			subnetName:    "shortsubnet",
+			isInternal:    true,
+			useStandardLB: true,
+			protocol:      v1.ProtocolTCP,
+			port:          9000,
+			expected:      "a257b965551374ad2b091ef3f07043ad-shortsubnet-TCP-9000",
 		},
 		{
-			description: "internal standard lb should have subnet name on the rule name but truncated to 80 charactors",
-			subnetName:       "averylonnnngggnnnnnnnnnnnnnnnnnnnnnngggggggggggggggggggggggggggggggggggggsubet",
-			isInternal: true,
-			useStandardLB:    true,
-			protocol: v1.ProtocolTCP,
-			port: 9000,
-			expected: "a257b965551374ad2b091ef3f07043ad-averylonnnngggnnnnnnnnnnnnnnnnnnnnnngg-TCP-9000",
+			description:   "internal standard lb should have subnet name on the rule name but truncated to 80 characters",
+			subnetName:    "averylonnnngggnnnnnnnnnnnnnnnnnnnnnngggggggggggggggggggggggggggggggggggggsubet",
+			isInternal:    true,
+			useStandardLB: true,
+			protocol:      v1.ProtocolTCP,
+			port:          9000,
+			expected:      "a257b965551374ad2b091ef3f07043ad-averylonnnngggnnnnnnnnnnnnnnnnnnnnnngg-TCP-9000",
 		},
 		{
-			description: "internal basic lb should have subnet name on the rule name but truncated to 80 charactors",
-			subnetName:       "averylonnnngggnnnnnnnnnnnnnnnnnnnnnngggggggggggggggggggggggggggggggggggggsubet",
-			isInternal: true,
-			useStandardLB:    false,
-			protocol: v1.ProtocolTCP,
-			port: 9000,
-			expected: "a257b965551374ad2b091ef3f07043ad-averylonnnngggnnnnnnnnnnnnnnnnnnnnnngg-TCP-9000",
+			description:   "internal basic lb should have subnet name on the rule name but truncated to 80 characters",
+			subnetName:    "averylonnnngggnnnnnnnnnnnnnnnnnnnnnngggggggggggggggggggggggggggggggggggggsubet",
+			isInternal:    true,
+			useStandardLB: false,
+			protocol:      v1.ProtocolTCP,
+			port:          9000,
+			expected:      "a257b965551374ad2b091ef3f07043ad-averylonnnngggnnnnnnnnnnnnnnnnnnnnnngg-TCP-9000",
 		},
 		{
-			description: "external standard lb should not have subnet name on the rule name",
-			subnetName:       "shortsubnet",
-			isInternal: false,
-			useStandardLB:    true,
-			protocol: v1.ProtocolTCP,
-			port: 9000,
-			expected: "a257b965551374ad2b091ef3f07043ad-TCP-9000",
+			description:   "external standard lb should not have subnet name on the rule name",
+			subnetName:    "shortsubnet",
+			isInternal:    false,
+			useStandardLB: true,
+			protocol:      v1.ProtocolTCP,
+			port:          9000,
+			expected:      "a257b965551374ad2b091ef3f07043ad-TCP-9000",
 		},
 		{
-			description: "external basic lb should not have subnet name on the rule name",
-			subnetName:       "shortsubnet",
-			isInternal: false,
-			useStandardLB:    false,
-			protocol: v1.ProtocolTCP,
-			port: 9000,
-			expected: "a257b965551374ad2b091ef3f07043ad-TCP-9000",
+			description:   "external basic lb should not have subnet name on the rule name",
+			subnetName:    "shortsubnet",
+			isInternal:    false,
+			useStandardLB: false,
+			protocol:      v1.ProtocolTCP,
+			port:          9000,
+			expected:      "a257b965551374ad2b091ef3f07043ad-TCP-9000",
 		},
 	}
 
@@ -362,46 +362,46 @@ func TestGetFrontendIPConfigName(t *testing.T) {
 	}
 
 	cases := []struct {
-		description string
+		description   string
 		subnetName    string
 		isInternal    bool
 		useStandardLB bool
 		expected      string
 	}{
 		{
-			description: "internal lb should have subnet name on the frontend ip configuration name",
-			subnetName:       "shortsubnet",
-			isInternal: true,
-			useStandardLB:    true,
-			expected: "a257b965551374ad2b091ef3f07043ad-shortsubnet",
+			description:   "internal lb should have subnet name on the frontend ip configuration name",
+			subnetName:    "shortsubnet",
+			isInternal:    true,
+			useStandardLB: true,
+			expected:      "a257b965551374ad2b091ef3f07043ad-shortsubnet",
 		},
 		{
-			description: "internal standard lb should have subnet name on the frontend ip configuration name but truncated to 80 charactors",
-			subnetName:       "averylonnnngggnnnnnnnnnnnnnnnnnnnnnngggggggggggggggggggggggggggggggggggggsubet",
-			isInternal: true,
-			useStandardLB:    true,
-			expected: "a257b965551374ad2b091ef3f07043ad-averylonnnngggnnnnnnnnnnnnnnnnnnnnnnggggggggggg",
+			description:   "internal standard lb should have subnet name on the frontend ip configuration name but truncated to 80 characters",
+			subnetName:    "averylonnnngggnnnnnnnnnnnnnnnnnnnnnngggggggggggggggggggggggggggggggggggggsubet",
+			isInternal:    true,
+			useStandardLB: true,
+			expected:      "a257b965551374ad2b091ef3f07043ad-averylonnnngggnnnnnnnnnnnnnnnnnnnnnnggggggggggg",
 		},
 		{
-			description: "internal basic lb should have subnet name on the frontend ip configuration name but truncated to 80 charactors",
-			subnetName:       "averylonnnngggnnnnnnnnnnnnnnnnnnnnnngggggggggggggggggggggggggggggggggggggsubet",
-			isInternal: true,
-			useStandardLB:    false,
-			expected: "a257b965551374ad2b091ef3f07043ad-averylonnnngggnnnnnnnnnnnnnnnnnnnnnnggggggggggg",
+			description:   "internal basic lb should have subnet name on the frontend ip configuration name but truncated to 80 characters",
+			subnetName:    "averylonnnngggnnnnnnnnnnnnnnnnnnnnnngggggggggggggggggggggggggggggggggggggsubet",
+			isInternal:    true,
+			useStandardLB: false,
+			expected:      "a257b965551374ad2b091ef3f07043ad-averylonnnngggnnnnnnnnnnnnnnnnnnnnnnggggggggggg",
 		},
 		{
-			description: "external standard lb should not have subnet name on the frontend ip configuration name",
-			subnetName:       "shortsubnet",
-			isInternal: false,
-			useStandardLB:    true,
-			expected: "a257b965551374ad2b091ef3f07043ad",
+			description:   "external standard lb should not have subnet name on the frontend ip configuration name",
+			subnetName:    "shortsubnet",
+			isInternal:    false,
+			useStandardLB: true,
+			expected:      "a257b965551374ad2b091ef3f07043ad",
 		},
 		{
-			description: "external basic lb should not have subnet name on the frontend ip configuration name",
-			subnetName:       "shortsubnet",
-			isInternal: false,
-			useStandardLB:    false,
-			expected: "a257b965551374ad2b091ef3f07043ad",
+			description:   "external basic lb should not have subnet name on the frontend ip configuration name",
+			subnetName:    "shortsubnet",
+			isInternal:    false,
+			useStandardLB: false,
+			expected:      "a257b965551374ad2b091ef3f07043ad",
 		},
 	}
 

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_test.go
@@ -1240,14 +1240,14 @@ func validateLoadBalancer(t *testing.T, loadBalancer *network.LoadBalancer, serv
 		if len(svc.Spec.Ports) > 0 {
 			expectedFrontendIPCount++
 			expectedFrontendIP := ExpectedFrontendIPInfo{
-				Name:   az.getFrontendIPConfigName(&svc, subnet(&svc)),
+				Name:   az.getFrontendIPConfigName(&svc),
 				Subnet: subnet(&svc),
 			}
 			expectedFrontendIPs = append(expectedFrontendIPs, expectedFrontendIP)
 		}
 		for _, wantedRule := range svc.Spec.Ports {
 			expectedRuleCount++
-			wantedRuleName := az.getLoadBalancerRuleName(&svc, wantedRule.Protocol, wantedRule.Port, subnet(&svc))
+			wantedRuleName := az.getLoadBalancerRuleName(&svc, wantedRule.Protocol, wantedRule.Port)
 			foundRule := false
 			for _, actualRule := range *loadBalancer.LoadBalancingRules {
 				if strings.EqualFold(*actualRule.Name, wantedRuleName) &&


### PR DESCRIPTION
Cherry pick of #86276 on release-1.17.

#86276: fix: should truncate long subnet name on lb rules

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.