### PR TITLE
Automated cherry pick of #90886: Fix public IP not shown issues after assigning public IP to

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_instances.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_instances.go
@@ -73,7 +73,7 @@ func (az *Cloud) NodeAddresses(ctx context.Context, name types.NodeName) ([]v1.N
 	}
 
 	if az.UseInstanceMetadata {
-		metadata, err := az.metadata.GetMetadata(cacheReadTypeUnsafe)
+		metadata, err := az.metadata.GetMetadata(cacheReadTypeDefault)
 		if err != nil {
 			return nil, err
 		}
@@ -259,7 +259,7 @@ func (az *Cloud) InstanceID(ctx context.Context, name types.NodeName) (string, e
 	}
 
 	if az.UseInstanceMetadata {
-		metadata, err := az.metadata.GetMetadata(cacheReadTypeUnsafe)
+		metadata, err := az.metadata.GetMetadata(cacheReadTypeDefault)
 		if err != nil {
 			return "", err
 		}
@@ -346,7 +346,7 @@ func (az *Cloud) InstanceType(ctx context.Context, name types.NodeName) (string,
 	}
 
 	if az.UseInstanceMetadata {
-		metadata, err := az.metadata.GetMetadata(cacheReadTypeUnsafe)
+		metadata, err := az.metadata.GetMetadata(cacheReadTypeDefault)
 		if err != nil {
 			return "", err
 		}

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_instances_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_instances_test.go
@@ -351,5 +351,24 @@ func TestNodeAddresses(t *testing.T) {
 		if !reflect.DeepEqual(ipAddresses, test.expected) {
 			t.Errorf("Test [%s] unexpected ipAddresses: %s, expected %q", test.name, ipAddresses, test.expected)
 		}
+
+		// address should be get again from IMDS if it is not found in cache.
+		err = cloud.metadata.imsCache.Delete(metadataCacheKey)
+		if err != nil {
+			t.Errorf("Test [%s] unexpected error: %v", test.name, err)
+		}
+		ipAddresses, err = cloud.NodeAddresses(context.Background(), types.NodeName(test.nodeName))
+		if test.expectError {
+			if err == nil {
+				t.Errorf("Test [%s] unexpected nil err", test.name)
+			}
+		} else {
+			if err != nil {
+				t.Errorf("Test [%s] unexpected error: %v", test.name, err)
+			}
+		}
+		if !reflect.DeepEqual(ipAddresses, test.expected) {
+			t.Errorf("Test [%s] unexpected ipAddresses: %s, expected %q", test.name, ipAddresses, test.expected)
+		}
 	}
 }


### PR DESCRIPTION
Cherry pick of #90886 on release-1.17.

#90886: Fix public IP not shown issues after assigning public IP to

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.