### PR TITLE
Update seccomp e2e test for GA

### DIFF
--- a/test/e2e/node/security_context.go
+++ b/test/e2e/node/security_context.go
@@ -146,33 +146,29 @@ var _ = SIGDescribe("Security Context", func() {
 		testPodSELinuxLabeling(f, false, true)
 	})
 
-	ginkgo.It("should support seccomp alpha unconfined annotation on the container [Feature:Seccomp] [LinuxOnly]", func() {
-		// TODO: port to SecurityContext as soon as seccomp is out of alpha
+	ginkgo.It("should support seccomp unconfined on the container [LinuxOnly]", func() {
 		pod := scTestPod(false, false)
-		pod.Annotations[v1.SeccompContainerAnnotationKeyPrefix+"test-container"] = "unconfined"
-		pod.Annotations[v1.SeccompPodAnnotationKey] = v1.SeccompProfileRuntimeDefault
+		pod.Spec.Containers[0].SecurityContext = &v1.SecurityContext{SeccompProfile: &v1.SeccompProfile{Type: v1.SeccompProfileTypeUnconfined}}
+		pod.Spec.SecurityContext = &v1.PodSecurityContext{SeccompProfile: &v1.SeccompProfile{Type: v1.SeccompProfileTypeRuntimeDefault}}
 		pod.Spec.Containers[0].Command = []string{"grep", "ecc", "/proc/self/status"}
 		f.TestContainerOutput(v1.SeccompPodAnnotationKey, pod, 0, []string{"0"}) // seccomp disabled
 	})
 
-	ginkgo.It("should support seccomp alpha unconfined annotation on the pod [Feature:Seccomp] [LinuxOnly]", func() {
-		// TODO: port to SecurityContext as soon as seccomp is out of alpha
+	ginkgo.It("should support seccomp unconfined on the pod [LinuxOnly]", func() {
 		pod := scTestPod(false, false)
-		pod.Annotations[v1.SeccompPodAnnotationKey] = "unconfined"
+		pod.Spec.SecurityContext = &v1.PodSecurityContext{SeccompProfile: &v1.SeccompProfile{Type: v1.SeccompProfileTypeUnconfined}}
 		pod.Spec.Containers[0].Command = []string{"grep", "ecc", "/proc/self/status"}
 		f.TestContainerOutput(v1.SeccompPodAnnotationKey, pod, 0, []string{"0"}) // seccomp disabled
 	})
 
-	ginkgo.It("should support seccomp alpha runtime/default annotation [Feature:Seccomp] [LinuxOnly]", func() {
-		// TODO: port to SecurityContext as soon as seccomp is out of alpha
+	ginkgo.It("should support seccomp runtime/default [LinuxOnly]", func() {
 		pod := scTestPod(false, false)
-		pod.Annotations[v1.SeccompContainerAnnotationKeyPrefix+"test-container"] = v1.SeccompProfileRuntimeDefault
+		pod.Spec.Containers[0].SecurityContext = &v1.SecurityContext{SeccompProfile: &v1.SeccompProfile{Type: v1.SeccompProfileTypeRuntimeDefault}}
 		pod.Spec.Containers[0].Command = []string{"grep", "ecc", "/proc/self/status"}
 		f.TestContainerOutput(v1.SeccompPodAnnotationKey, pod, 0, []string{"2"}) // seccomp filtered
 	})
 
-	ginkgo.It("should support seccomp default which is unconfined [Feature:Seccomp] [LinuxOnly]", func() {
-		// TODO: port to SecurityContext as soon as seccomp is out of alpha
+	ginkgo.It("should support seccomp default which is unconfined [LinuxOnly]", func() {
 		pod := scTestPod(false, false)
 		pod.Spec.Containers[0].Command = []string{"grep", "ecc", "/proc/self/status"}
 		f.TestContainerOutput(v1.SeccompPodAnnotationKey, pod, 0, []string{"0"}) // seccomp disabled


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

We now execute the seccomp tests with `[LinuxOnly]` as described in the appropriate KEP test plan:
    
https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/20190717-seccomp-ga.md#test-plan
    
The tests have been changed to used the new seccomp field within the security context in replacement for the annotations.
 
**Which issue(s) this PR fixes**:

Requires #91381 and #91408

/cc @pjbgf @hasheddan @evrardjp
 
**Special notes for your reviewer**:

None

**Does this PR introduce a user-facing change?**:
```release-note
None
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs
None
```
