### PR TITLE
Move Node Resources scheduler plugin args validation to apis/config/validation

### DIFF
--- a/pkg/scheduler/framework/plugins/noderesources/BUILD
+++ b/pkg/scheduler/framework/plugins/noderesources/BUILD
@@ -18,6 +18,7 @@ go_library(
         "//pkg/apis/core/v1/helper:go_default_library",
         "//pkg/features:go_default_library",
         "//pkg/scheduler/apis/config:go_default_library",
+        "//pkg/scheduler/apis/config/validation:go_default_library",
         "//pkg/scheduler/framework/v1alpha1:go_default_library",
         "//pkg/scheduler/util:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",

--- a/pkg/scheduler/framework/plugins/noderesources/least_allocated.go
+++ b/pkg/scheduler/framework/plugins/noderesources/least_allocated.go
@@ -23,6 +23,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/kubernetes/pkg/scheduler/apis/config"
+	"k8s.io/kubernetes/pkg/scheduler/apis/config/validation"
 	framework "k8s.io/kubernetes/pkg/scheduler/framework/v1alpha1"
 )
 
@@ -70,14 +71,12 @@ func NewLeastAllocated(laArgs runtime.Object, h framework.FrameworkHandle) (fram
 		return nil, fmt.Errorf("want args to be of type NodeResourcesLeastAllocatedArgs, got %T", laArgs)
 	}
 
+	if err := validation.ValidateNodeResourcesLeastAllocatedArgs(args); err != nil {
+		return nil, err
+	}
+
 	resToWeightMap := make(resourceToWeightMap)
 	for _, resource := range (*args).Resources {
-		if resource.Weight <= 0 {
-			return nil, fmt.Errorf("resource Weight of %v should be a positive value, got %v", resource.Name, resource.Weight)
-		}
-		if resource.Weight > framework.MaxNodeScore {
-			return nil, fmt.Errorf("resource Weight of %v should be less than 100, got %v", resource.Name, resource.Weight)
-		}
 		resToWeightMap[v1.ResourceName(resource.Name)] = resource.Weight
 	}
 

--- a/pkg/scheduler/framework/plugins/noderesources/most_allocated.go
+++ b/pkg/scheduler/framework/plugins/noderesources/most_allocated.go
@@ -23,6 +23,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/kubernetes/pkg/scheduler/apis/config"
+	"k8s.io/kubernetes/pkg/scheduler/apis/config/validation"
 	framework "k8s.io/kubernetes/pkg/scheduler/framework/v1alpha1"
 )
 
@@ -68,15 +69,12 @@ func NewMostAllocated(maArgs runtime.Object, h framework.FrameworkHandle) (frame
 		return nil, fmt.Errorf("want args to be of type NodeResourcesMostAllocatedArgs, got %T", args)
 	}
 
-	resToWeightMap := make(resourceToWeightMap)
+	if err := validation.ValidateNodeResourcesMostAllocatedArgs(args); err != nil {
+		return nil, err
+	}
 
+	resToWeightMap := make(resourceToWeightMap)
 	for _, resource := range (*args).Resources {
-		if resource.Weight <= 0 {
-			return nil, fmt.Errorf("resource Weight of %v should be a positive value, got %v", resource.Name, resource.Weight)
-		}
-		if resource.Weight > framework.MaxNodeScore {
-			return nil, fmt.Errorf("resource Weight of %v should be less than 100, got %v", resource.Name, resource.Weight)
-		}
 		resToWeightMap[v1.ResourceName(resource.Name)] = resource.Weight
 	}
 

--- a/pkg/scheduler/framework/plugins/noderesources/requested_to_capacity_ratio_test.go
+++ b/pkg/scheduler/framework/plugins/noderesources/requested_to_capacity_ratio_test.go
@@ -116,47 +116,6 @@ func makePod(node string, milliCPU, memory int64) *v1.Pod {
 	}
 }
 
-func TestCreatingFunctionShapeErrorsIfEmptyPoints(t *testing.T) {
-	var err error
-	err = validateFunctionShape([]functionShapePoint{})
-	assert.Equal(t, "at least one point must be specified", err.Error())
-}
-
-func TestCreatingResourceNegativeWeight(t *testing.T) {
-	err := validateResourceWeightMap(resourceToWeightMap{v1.ResourceCPU: -1})
-	assert.Equal(t, "resource cpu weight -1 must not be less than 1", err.Error())
-}
-
-func TestCreatingResourceDefaultWeight(t *testing.T) {
-	err := validateResourceWeightMap(resourceToWeightMap{})
-	assert.Equal(t, "resourceToWeightMap cannot be nil", err.Error())
-
-}
-
-func TestCreatingFunctionShapeErrorsIfXIsNotSorted(t *testing.T) {
-	var err error
-	err = validateFunctionShape([]functionShapePoint{{10, 1}, {15, 2}, {20, 3}, {19, 4}, {25, 5}})
-	assert.Equal(t, "utilization values must be sorted. Utilization[2]==20 >= Utilization[3]==19", err.Error())
-
-	err = validateFunctionShape([]functionShapePoint{{10, 1}, {20, 2}, {20, 3}, {22, 4}, {25, 5}})
-	assert.Equal(t, "utilization values must be sorted. Utilization[1]==20 >= Utilization[2]==20", err.Error())
-}
-
-func TestCreatingFunctionPointNotInAllowedRange(t *testing.T) {
-	var err error
-	err = validateFunctionShape([]functionShapePoint{{-1, 0}, {100, 100}})
-	assert.Equal(t, "utilization values must not be less than 0. Utilization[0]==-1", err.Error())
-
-	err = validateFunctionShape([]functionShapePoint{{0, 0}, {101, 100}})
-	assert.Equal(t, "utilization values must not be greater than 100. Utilization[1]==101", err.Error())
-
-	err = validateFunctionShape([]functionShapePoint{{0, -1}, {100, 100}})
-	assert.Equal(t, "score values must not be less than 0. Score[0]==-1", err.Error())
-
-	err = validateFunctionShape([]functionShapePoint{{0, 0}, {100, 101}})
-	assert.Equal(t, "score values not be greater than 100. Score[1]==101", err.Error())
-}
-
 func TestBrokenLinearFunction(t *testing.T) {
 	type Assertion struct {
 		p        int64


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Scheduler plugin args are now API types. This moves their validation code to the API validation package allowing reuse, i.e. when building a scheduler.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of #90859

**Special notes for your reviewer**:
Please note it's another part of #90859 focusing on Node Resources plugin args validation. It moves the code without adding too many improvements. Improvements and use of the functions in `ValidateKubeSchedulerConfiguration` will be added separately.


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
