### PR TITLE
update metrics to conform promlint

### DIFF
--- a/pkg/scheduler/metrics/metrics.go
+++ b/pkg/scheduler/metrics/metrics.go
@@ -145,7 +145,7 @@ var (
 	PreemptionAttempts = metrics.NewCounter(
 		&metrics.CounterOpts{
 			Subsystem:      SchedulerSubsystem,
-			Name:           "total_preemption_attempts",
+			Name:           "preemption_attempts_total",
 			Help:           "Total preemption attempts in the cluster till now",
 			StabilityLevel: metrics.ALPHA,
 		})

--- a/staging/src/k8s.io/component-base/metrics/testutil/promlint.go
+++ b/staging/src/k8s.io/component-base/metrics/testutil/promlint.go
@@ -53,9 +53,6 @@ var exceptionMetrics = []string{
 	// kube-proxy
 	"kubernetes_build_info",
 
-	// kube-scheduler
-	"scheduler_total_preemption_attempts",
-
 	// kubelet-resource-v1alpha1
 	"container_cpu_usage_seconds_total",
 	"node_cpu_usage_seconds_total",


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Update metrics name from `scheduler_total_preemption_attempts` to `scheduler_preemption_attempts_total` as per `promlint` rules: `counter metrics should have "_total" suffix`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
kube-scheduler: The metric name `scheduler_total_preemption_attempts` has been renamed to `scheduler_preemption_attempts_total`.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

/priority important-soon