### PR TITLE
GCE: Bump addon resizer to 1.8.9 version and use metrics to get cluster size there

### DIFF
--- a/cluster/addons/metrics-server/metrics-server-deployment.yaml
+++ b/cluster/addons/metrics-server/metrics-server-deployment.yaml
@@ -64,7 +64,7 @@ spec:
           name: https
           protocol: TCP
       - name: metrics-server-nanny
-        image: k8s.gcr.io/addon-resizer:1.8.7
+        image: k8s.gcr.io/addon-resizer:1.8.9
         resources:
           limits:
             cpu: 100m
@@ -99,6 +99,8 @@ spec:
           # Specifies the smallest cluster (defined in number of nodes)
           # resources will be scaled to.
           - --minClusterSize={{ metrics_server_min_cluster_size }}
+          # Use kube-apiserver metrics to avoid periodically listing nodes.
+          - --use-metrics=true
       volumes:
         - name: metrics-server-config-volume
           configMap:

--- a/cluster/addons/metrics-server/resource-reader.yaml
+++ b/cluster/addons/metrics-server/resource-reader.yaml
@@ -25,6 +25,10 @@ rules:
   - list
   - update
   - watch
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
```release-note
NONE
```