### PR TITLE
explicitly fail if no images are found when running remote tests

### DIFF
--- a/test/e2e_node/runner/remote/run_remote.go
+++ b/test/e2e_node/runner/remote/run_remote.go
@@ -244,6 +244,10 @@ func main() {
 					klog.Fatalf("Could not retrieve list of images based on image prefix %q and family %q: %v",
 						imageConfig.ImageRegex, imageConfig.ImageFamily, err)
 				}
+				if len(images) == 0 { // if we have no images we can't run anything
+					klog.Fatalf("No matching images retrieved on image prefix %q and family %q: %v",
+						imageConfig.ImageRegex, imageConfig.ImageFamily, err)
+				}
 			} else {
 				images = []string{imageConfig.Image}
 			}


### PR DESCRIPTION
The previous implementation succeeds if no images are run. This causes
silent failures when image matchers are provided that do not match any image.

<!--  Thanks for sending a pull request!  Here are some tips for you:
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Some of the root cause of this existing in the first place.
https://github.com/kubernetes/kubernetes/issues/91292
In this issue we can see that in april some images were updated, and tests stopped running at all for 2 of 3 images.

**Special notes for your reviewer**:
With a list of no images, it turns a bunch of the later for loops into nops, because we `for _,_ := range ` over an empty container.

Ya'll looked at the issue:
/cc @spiffxp @vpickard @bart0sh @dims 

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
I think tests should fail if they don't run.

I'm not sure how to test this.

This has potential to cause anything using image-regex, image_regex, image-family, image_family matchers to fail loudly.
/hold


```
$ rg 'image_regex|image-regex|image-family|image_family' ./

./community/contributors/devel/sig-node/e2e-node-tests.md
163:     image_regex: cos-stable-60-9592-84-0

# I don't think this runs anymore?
./kubernetes/test/e2e_node/jenkins/image-config.yaml
16:    image_regex: cos-stable-59-9460-64-0 # docker 1.11.2
20:    image_regex: cos-stable-60-9592-84-0 # docker 1.13.1

# I don't think this runs anymore?
./kubernetes/test/e2e_node/jenkins/image-config-serial.yaml
16:    image_regex: cos-stable-59-9460-64-0 # docker 1.11.2
24:    image_regex: cos-stable-60-9592-84-0 # docker 1.13.1

./test-infra/jobs/e2e_node/image-config.yaml
9:    image_regex: cos-stable-81-12871-103-0 # docker v19.03.6
13:    image_regex: cos-stable-77-12371-227-0 # docker v19.03.1, deprecated after 2020-12-17

./test-infra/jobs/e2e_node/image-config-serial-cpu-manager.yaml
11:    image_regex: cos-stable-73-11647-510-0 # docker v18.09.7, deprecated after 2020-06-19

./test-infra/jobs/e2e_node/image-config-serial.yaml
9:    image_regex: cos-stable-73-11647-510-0 # docker v18.09.7, deprecated after 2020-06-19
17:    image_regex: cos-stable-77-12371-227-0 # docker v19.03.1, deprecated after 2020-12-17

./test-infra/jobs/e2e_node/containerd/image-config.yaml
3:    image_family: pipeline-2
7:    image_family: cos-77-lts

./test-infra/jobs/e2e_node/containerd/containerd-master/image-config.yaml
7:    image_regex: cos-stable-73-11647-510-0

./test-infra/jobs/e2e_node/containerd/containerd-release-1.3/image-config.yaml
7:    image_regex: cos-stable-73-11647-510-0

./test-infra/jobs/e2e_node/containerd/cri-master/image-config-pr.yaml
7:    image_regex: cos-stable-73-11647-510-0

./test-infra/experiment/bump_e2e_image.sh
24:bazel run //experiment/image-bumper -- --image-regex gcr.io/k8s-testimages/kubekins-e2e "${TREE}/experiment/generate_tests.py" "${TREE}/experiment/test_config.yaml" "${TREE}/config/prow/config.yaml"
25:find "${TREE}/config/jobs/" . -name "*.yaml" | xargs bazel run //experiment/image-bumper -- --image-regex gcr.io/k8s-testimages/kubekins-e2e

./test-infra/jobs/e2e_node/containerd/containerd-release-1.3/#image-config.yaml#
7:    image_family: cos-stable-73-11647-510-0

./test-infra/jobs/e2e_node/containerd/containerd-release-1.2/image-config.yaml
7:    image_regex: cos-stable-73-11647-510-0

./test-infra/jobs/e2e_node/containerd/cri-master/image-config.yaml
7:    image_regex: cos-stable-73-11647-510-0

./test-infra/releng/test_config.yaml
493:    - --image-family=cos-shielded-lts-1
499:    - --image-family=cos-lts-2
505:    - --image-family=pipeline-1
511:    - --image-family=pipeline-2
635:    - --image-family=cos-shielded-lts-1
641:    - --image-family=cos-lts-2
647:    - --image-family=pipeline-1
652:    - --image-family=pipeline-2

./test-infra/config/jobs/kubernetes/sig-node/containerd.yaml
210:      - --image-family=ubuntu-gke-1604-lts
923:      - --image-family=ubuntu-gke-1604-lts
1102:      - --image-family=cos-73-lts
1129:      - --image-family=pipeline-2

./test-infra/config/jobs/kubernetes/generated/generated.yaml
21:      - --image-family=pipeline-1
53:      - --image-family=pipeline-1
85:      - --image-family=pipeline-1
117:      - --image-family=pipeline-1
149:      - --image-family=pipeline-1
181:      - --image-family=pipeline-1
213:      - --image-family=pipeline-1
245:      - --image-family=pipeline-1
277:      - --image-family=pipeline-2
309:      - --image-family=pipeline-2
341:      - --image-family=pipeline-2
373:      - --image-family=pipeline-2
405:      - --image-family=pipeline-2
437:      - --image-family=pipeline-2
469:      - --image-family=pipeline-2
501:      - --image-family=pipeline-2
531:      - --image-family=pipeline-1
564:      - --image-family=pipeline-1
597:      - --image-family=pipeline-1
630:      - --image-family=pipeline-1
663:      - --image-family=pipeline-1
696:      - --image-family=pipeline-1
729:      - --image-family=pipeline-1
762:      - --image-family=pipeline-1
795:      - --image-family=pipeline-1
828:      - --image-family=pipeline-1
861:      - --image-family=pipeline-1
894:      - --image-family=pipeline-1
927:      - --image-family=pipeline-2
960:      - --image-family=pipeline-2
993:      - --image-family=pipeline-2
1026:      - --image-family=pipeline-2
1059:      - --image-family=pipeline-2
1092:      - --image-family=pipeline-2
1125:      - --image-family=pipeline-2
1158:      - --image-family=pipeline-2
1191:      - --image-family=pipeline-2
1224:      - --image-family=pipeline-2
1257:      - --image-family=pipeline-2
1290:      - --image-family=pipeline-2

./test-infra/config/jobs/kubernetes/node-problem-detector/node-problem-detector-ci.yaml
268:      - name: IMAGE_FAMILY

./test-infra/config/jobs/kubernetes/sig-network/ci-e2e-gce-netd.yaml
994:      - --image-family=ubuntu-gke-1604-lts
1022:      - --image-family=ubuntu-gke-1604-lts

./test-infra/config/jobs/kubernetes/sig-storage/sig-storage-gce-config.yaml
230:        - --image-family=ubuntu-gke-1804-lts-1
271:        - --image-family=ubuntu-gke-1804-lts-1
338:      - --image-family=ubuntu-gke-1804-lts-1
363:      - --image-family=ubuntu-gke-1804-lts-1
```