### PR TITLE
Add usage in some hack/update scripts

### DIFF
--- a/hack/update-generated-pod-resources.sh
+++ b/hack/update-generated-pod-resources.sh
@@ -14,6 +14,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# This script generates `/pkg/kubelet/apis/podresources/v1alpha1/api.pb.go`
+# from the protobuf file `/pkg/kubelet/apis/podresources/v1alpha1/api.proto`
+# for pods.
+# Usage: `hack/update-generated-pod-resources.sh`.
+
 set -o errexit
 set -o nounset
 set -o pipefail

--- a/hack/update-generated-protobuf-dockerized.sh
+++ b/hack/update-generated-protobuf-dockerized.sh
@@ -14,6 +14,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# This script genertates `*/api.pb.go` from the protobuf file `*/api.proto`.
+# Usage: 
+#     hack/update-generated-protobuf-dockerized.sh "${APIROOTS}"
+#     An example APIROOT is: "k8s.io/api/admissionregistration/v1"
+
 set -o errexit
 set -o nounset
 set -o pipefail

--- a/hack/update-generated-protobuf.sh
+++ b/hack/update-generated-protobuf.sh
@@ -14,6 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# This script generates all go files from the corresponding protobuf files.
+# Usage: `hack/update-generated-protobuf.sh`.
+
 set -o errexit
 set -o nounset
 set -o pipefail

--- a/hack/update-generated-runtime-dockerized.sh
+++ b/hack/update-generated-runtime-dockerized.sh
@@ -14,6 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# This script builds protoc-gen-gogo binary in runtime and genertates 
+# `*/api.pb.go` from the protobuf file `*/api.proto`.
+
 set -o errexit
 set -o nounset
 set -o pipefail

--- a/hack/update-generated-runtime.sh
+++ b/hack/update-generated-runtime.sh
@@ -14,6 +14,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# This script builds protoc-gen-gogo binary in runtime and genertates 
+# `*/api.pb.go` from the protobuf file `*/api.proto`.
+# Usage: 
+#     hack/update-generated-runtime.sh
+
 set -o errexit
 set -o nounset
 set -o pipefail

--- a/hack/update-generated-swagger-docs.sh
+++ b/hack/update-generated-swagger-docs.sh
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Generates `types_swagger_doc_generated.go` files for API group
+# This script generates `types_swagger_doc_generated.go` files for API group
 # versions. That file contains functions on API structs that return
 # the comments that should be surfaced for the corresponding API type
 # in our API docs.


### PR DESCRIPTION

**What type of PR is this?**

> /kind cleanup

**What this PR does / why we need it**:
Update usage of them:
```
 kubernetes/hack/update-generated-pod-resources.sh
 kubernetes/hack/update-generated-protobuf-dockerized.sh
 kubernetes/hack/update-generated-protobuf.sh
 kubernetes/hack/update-generated-runtime-dockerized.sh
 kubernetes/hack/update-generated-runtime.sh
 kubernetes/hack/update-generated-swagger-docs.sh
```


**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes/kubernetes/issues/86597
