### PR TITLE
Clean unsed code in Merge status

### DIFF
--- a/pkg/scheduler/framework/v1alpha1/interface.go
+++ b/pkg/scheduler/framework/v1alpha1/interface.go
@@ -174,7 +174,6 @@ func (p PluginToStatus) Merge() *Status {
 		} else if s.Code() == Unschedulable {
 			hasUnschedulable = true
 		}
-		finalStatus.code = s.Code()
 		for _, r := range s.reasons {
 			finalStatus.AppendReason(r)
 		}


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
No need to set `finalStatus.code` in the for loop, it'll be set to the correct value before return or just use the init value `Success`
