### PR TITLE
Update sig-scheduling aliases

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -147,14 +147,14 @@ aliases:
 
   sig-scheduling-maintainers:
     - alculquicondor
-    - bsalamat
     - k82cn
     - wojtek-t
     - ravisantoshgudimetla
     - Huang-Wei
     - ahg-g
+  # emeritus:
+  # - bsalamat
   sig-scheduling:
-    - bsalamat
     - k82cn
     - resouer
     - ravisantoshgudimetla
@@ -451,9 +451,9 @@ aliases:
     - mm4tt
     - wojtek-t
 
-  sig-scheduling-api-reviewers:
-      - bsalamat
-      - k82cn
+  # sig-scheduling-api-reviewers:
+  #   -
+  #   -
 
   sig-storage-api-reviewers:
     - saad-ali


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Updates sig-scheduling aliases moving bsalamat to emeritus (ref: https://github.com/kubernetes/kubernetes/pull/85484), and commenting out the unused `sig-scheduling-api-reviewers` alias group ([search query](https://cs.k8s.io/?q=sig-scheduling-api-reviewers&i=fosho&files=.*(%5E%5B%5Ev%5D.*OWNERS%24)%7C(%5Ev%5B%5Ee%5D.*OWNERS%24)%20%7C(%5Eve%5B%5En%5D.*OWNERS%24)%7C(%5Even%5B%5Ed%5D.*OWNERS%24)%7C(%5Evend%5B%5Eo%5D.*OWNERS%24)%7C(%5Evendo%5B%5Er%5D.*OWNERS%24)%7C(%5E%5B%5Ev%5D%5B%5Ee%5D%5B%5En%5D%5B%5Ed%5D%5B%5Eo%5D%5B%5Er%5D%2F.*OWNERS%24)%7C%5EOWNERS%24%7C%5EOWNERS_ALIASES%24&repos=)).


**Does this PR introduce a user-facing change?**:
No

```release-note
NONE
```

```docs
```

/cc @ahg-g @Huang-Wei 
/priority important-longterm