### PR TITLE
Revert "Revert "Rely on default watch cache capacity and ignore its requested size""

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher.go
@@ -61,6 +61,8 @@ const (
 // Config contains the configuration for a given Cache.
 type Config struct {
 	// Maximum size of the history cached in memory.
+	//
+	// DEPRECATED: Cache capacity is dynamic and this field is no longer used.
 	CacheCapacity int
 
 	// An underlying storage.Interface.
@@ -357,7 +359,7 @@ func NewCacherFromConfig(config Config) (*Cacher, error) {
 	}
 
 	watchCache := newWatchCache(
-		config.CacheCapacity, config.KeyFunc, cacher.processEvent, config.GetAttrsFunc, config.Versioner, config.Indexers, objType)
+		config.KeyFunc, cacher.processEvent, config.GetAttrsFunc, config.Versioner, config.Indexers, objType)
 	listerWatcher := NewCacherListerWatcher(config.Storage, config.ResourcePrefix, config.NewListFunc)
 	reflectorName := "storage/cacher.go:" + config.ResourcePrefix
 

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache.go
@@ -193,7 +193,6 @@ type watchCache struct {
 }
 
 func newWatchCache(
-	capacity int,
 	keyFunc func(runtime.Object) (string, error),
 	eventHandler func(*watchCacheEvent),
 	getAttrsFunc func(runtime.Object) (labels.Set, fields.Set, error),
@@ -201,13 +200,12 @@ func newWatchCache(
 	indexers *cache.Indexers,
 	objectType reflect.Type) *watchCache {
 	wc := &watchCache{
-		capacity:     capacity,
-		keyFunc:      keyFunc,
-		getAttrsFunc: getAttrsFunc,
-		cache:        make([]*watchCacheEvent, capacity),
-		// TODO get rid of them once we stop passing capacity as a parameter to watch cache.
-		lowerBoundCapacity:  min(capacity, defaultLowerBoundCapacity),
-		upperBoundCapacity:  max(capacity, defaultUpperBoundCapacity),
+		capacity:            defaultLowerBoundCapacity,
+		keyFunc:             keyFunc,
+		getAttrsFunc:        getAttrsFunc,
+		cache:               make([]*watchCacheEvent, defaultLowerBoundCapacity),
+		lowerBoundCapacity:  defaultLowerBoundCapacity,
+		upperBoundCapacity:  defaultUpperBoundCapacity,
 		startIndex:          0,
 		endIndex:            0,
 		store:               cache.NewIndexer(storeElementKey, storeElementIndexers(indexers)),

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache_test.go
@@ -81,7 +81,14 @@ func newTestWatchCache(capacity int, indexers *cache.Indexers) *watchCache {
 	}
 	versioner := etcd3.APIObjectVersioner{}
 	mockHandler := func(*watchCacheEvent) {}
-	wc := newWatchCache(capacity, keyFunc, mockHandler, getAttrsFunc, versioner, indexers, reflect.TypeOf(&example.Pod{}))
+	wc := newWatchCache(keyFunc, mockHandler, getAttrsFunc, versioner, indexers, reflect.TypeOf(&example.Pod{}))
+	// To preserve behavior of tests that assume a given capacity,
+	// resize it to th expected size.
+	wc.capacity = capacity
+	wc.cache = make([]*watchCacheEvent, capacity)
+	wc.lowerBoundCapacity = min(capacity, defaultLowerBoundCapacity)
+	wc.upperBoundCapacity = max(capacity, defaultUpperBoundCapacity)
+
 	wc.clock = clock.NewFakeClock(time.Now())
 	return wc
 }


### PR DESCRIPTION
Reverts kubernetes/kubernetes#91380

The problem that caused revert was debugged and fixed in https://github.com/kubernetes/kubernetes/issues/91415 (and it was a different PR that was faulty, this one was only increasing probability.
Re-reverting now.

```release-note
NONE
```

@liggitt - FYI