### PR TITLE
fix(kubectl-config-unset): set users to `[]` if no users left after `kubectl config unset`

### DIFF
--- a/cmd/kubeadm/app/discovery/token/token_test.go
+++ b/cmd/kubeadm/app/discovery/token/token_test.go
@@ -69,7 +69,7 @@ contexts:
 current-context: token-bootstrap-client@somecluster
 kind: Config
 preferences: {}
-users: null
+users: []
 `
 	)
 

--- a/staging/src/k8s.io/client-go/tools/clientcmd/api/v1/conversion.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/api/v1/conversion.go
@@ -81,6 +81,7 @@ func Convert_Slice_v1_NamedAuthInfo_To_Map_string_To_Pointer_api_AuthInfo(in *[]
 }
 
 func Convert_Map_string_To_Pointer_api_AuthInfo_To_Slice_v1_NamedAuthInfo(in *map[string]*api.AuthInfo, out *[]NamedAuthInfo, s conversion.Scope) error {
+	*out = make([]NamedAuthInfo, 0, len(*in))
 	allKeys := make([]string, 0, len(*in))
 	for key := range *in {
 		allKeys = append(allKeys, key)

--- a/staging/src/k8s.io/client-go/tools/clientcmd/loader_test.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/loader_test.go
@@ -246,7 +246,7 @@ contexts:
 current-context: any-context-value
 kind: Config
 preferences: {}
-users: null
+users: []
 `)
 	if !bytes.Equal(expected, data) {
 		t.Error(diff.ObjectReflectDiff(string(expected), string(data)))


### PR DESCRIPTION
Signed-off-by: knight42 <anonymousknight96@gmail.com>


**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind api-change

/kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

#84503 changed the behaviour of `kubectl config unset` slightly that if no users left in kubeconfig after user run `kubectl config unset users.<user>`, the value of `users` field in kubeconfig would be set to `null` rather than `[]`.


**Which issue(s) this PR fixes**:

Fixes #88524

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
make `kubectl config unset` set `users` field to `[]` if no users left
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
