### PR TITLE
cleanup: Remove_unnecessary_Sprintfs

### DIFF
--- a/test/integration/apiserver/max_request_body_bytes_test.go
+++ b/test/integration/apiserver/max_request_body_bytes_test.go
@@ -18,7 +18,6 @@ package apiserver
 
 import (
 	"context"
-	"fmt"
 	"strings"
 	"testing"
 
@@ -41,7 +40,7 @@ func TestMaxResourceSize(t *testing.T) {
 
 	c := clientSet.CoreV1().RESTClient()
 	t.Run("Create should limit the request body size", func(t *testing.T) {
-		err := c.Post().AbsPath(fmt.Sprintf("/api/v1/namespaces/default/pods")).
+		err := c.Post().AbsPath("/api/v1/namespaces/default/pods").
 			Body(hugeData).Do(context.TODO()).Error()
 		if err == nil {
 			t.Fatalf("unexpected no error")
@@ -64,7 +63,7 @@ func TestMaxResourceSize(t *testing.T) {
 	}
 
 	t.Run("Update should limit the request body size", func(t *testing.T) {
-		err = c.Put().AbsPath(fmt.Sprintf("/api/v1/namespaces/default/secrets/test")).
+		err = c.Put().AbsPath("/api/v1/namespaces/default/secrets/test").
 			Body(hugeData).Do(context.TODO()).Error()
 		if err == nil {
 			t.Fatalf("unexpected no error")
@@ -75,7 +74,7 @@ func TestMaxResourceSize(t *testing.T) {
 		}
 	})
 	t.Run("Patch should limit the request body size", func(t *testing.T) {
-		err = c.Patch(types.JSONPatchType).AbsPath(fmt.Sprintf("/api/v1/namespaces/default/secrets/test")).
+		err = c.Patch(types.JSONPatchType).AbsPath("/api/v1/namespaces/default/secrets/test").
 			Body(hugeData).Do(context.TODO()).Error()
 		if err == nil {
 			t.Fatalf("unexpected no error")
@@ -87,7 +86,7 @@ func TestMaxResourceSize(t *testing.T) {
 	})
 	t.Run("JSONPatchType should handle a patch just under the max limit", func(t *testing.T) {
 		patchBody := []byte(`[{"op":"add","path":"/foo","value":` + strings.Repeat("[", 3*1024*1024/2-100) + strings.Repeat("]", 3*1024*1024/2-100) + `}]`)
-		err = rest.Patch(types.JSONPatchType).AbsPath(fmt.Sprintf("/api/v1/namespaces/default/secrets/test")).
+		err = rest.Patch(types.JSONPatchType).AbsPath("/api/v1/namespaces/default/secrets/test").
 			Body(patchBody).Do(context.TODO()).Error()
 		if err != nil && !apierrors.IsBadRequest(err) {
 			t.Errorf("expected success or bad request err, got %v", err)
@@ -95,7 +94,7 @@ func TestMaxResourceSize(t *testing.T) {
 	})
 	t.Run("JSONPatchType should handle a valid patch just under the max limit", func(t *testing.T) {
 		patchBody := []byte(`[{"op":"add","path":"/foo","value":0` + strings.Repeat(" ", 3*1024*1024-100) + `}]`)
-		err = rest.Patch(types.JSONPatchType).AbsPath(fmt.Sprintf("/api/v1/namespaces/default/secrets/test")).
+		err = rest.Patch(types.JSONPatchType).AbsPath("/api/v1/namespaces/default/secrets/test").
 			Body(patchBody).Do(context.TODO()).Error()
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)
@@ -103,7 +102,7 @@ func TestMaxResourceSize(t *testing.T) {
 	})
 	t.Run("MergePatchType should handle a patch just under the max limit", func(t *testing.T) {
 		patchBody := []byte(`{"value":` + strings.Repeat("[", 3*1024*1024/2-100) + strings.Repeat("]", 3*1024*1024/2-100) + `}`)
-		err = rest.Patch(types.MergePatchType).AbsPath(fmt.Sprintf("/api/v1/namespaces/default/secrets/test")).
+		err = rest.Patch(types.MergePatchType).AbsPath("/api/v1/namespaces/default/secrets/test").
 			Body(patchBody).Do(context.TODO()).Error()
 		if err != nil && !apierrors.IsBadRequest(err) {
 			t.Errorf("expected success or bad request err, got %v", err)
@@ -111,7 +110,7 @@ func TestMaxResourceSize(t *testing.T) {
 	})
 	t.Run("MergePatchType should handle a valid patch just under the max limit", func(t *testing.T) {
 		patchBody := []byte(`{"value":0` + strings.Repeat(" ", 3*1024*1024-100) + `}`)
-		err = rest.Patch(types.MergePatchType).AbsPath(fmt.Sprintf("/api/v1/namespaces/default/secrets/test")).
+		err = rest.Patch(types.MergePatchType).AbsPath("/api/v1/namespaces/default/secrets/test").
 			Body(patchBody).Do(context.TODO()).Error()
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)
@@ -119,7 +118,7 @@ func TestMaxResourceSize(t *testing.T) {
 	})
 	t.Run("StrategicMergePatchType should handle a patch just under the max limit", func(t *testing.T) {
 		patchBody := []byte(`{"value":` + strings.Repeat("[", 3*1024*1024/2-100) + strings.Repeat("]", 3*1024*1024/2-100) + `}`)
-		err = rest.Patch(types.StrategicMergePatchType).AbsPath(fmt.Sprintf("/api/v1/namespaces/default/secrets/test")).
+		err = rest.Patch(types.StrategicMergePatchType).AbsPath("/api/v1/namespaces/default/secrets/test").
 			Body(patchBody).Do(context.TODO()).Error()
 		if err != nil && !apierrors.IsBadRequest(err) {
 			t.Errorf("expected success or bad request err, got %v", err)
@@ -127,7 +126,7 @@ func TestMaxResourceSize(t *testing.T) {
 	})
 	t.Run("StrategicMergePatchType should handle a valid patch just under the max limit", func(t *testing.T) {
 		patchBody := []byte(`{"value":0` + strings.Repeat(" ", 3*1024*1024-100) + `}`)
-		err = rest.Patch(types.StrategicMergePatchType).AbsPath(fmt.Sprintf("/api/v1/namespaces/default/secrets/test")).
+		err = rest.Patch(types.StrategicMergePatchType).AbsPath("/api/v1/namespaces/default/secrets/test").
 			Body(patchBody).Do(context.TODO()).Error()
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)
@@ -135,7 +134,7 @@ func TestMaxResourceSize(t *testing.T) {
 	})
 	t.Run("ApplyPatchType should handle a patch just under the max limit", func(t *testing.T) {
 		patchBody := []byte(`{"value":` + strings.Repeat("[", 3*1024*1024/2-100) + strings.Repeat("]", 3*1024*1024/2-100) + `}`)
-		err = rest.Patch(types.ApplyPatchType).Param("fieldManager", "test").AbsPath(fmt.Sprintf("/api/v1/namespaces/default/secrets/test")).
+		err = rest.Patch(types.ApplyPatchType).Param("fieldManager", "test").AbsPath("/api/v1/namespaces/default/secrets/test").
 			Body(patchBody).Do(context.TODO()).Error()
 		if err != nil && !apierrors.IsBadRequest(err) {
 			t.Errorf("expected success or bad request err, got %#v", err)
@@ -143,14 +142,14 @@ func TestMaxResourceSize(t *testing.T) {
 	})
 	t.Run("ApplyPatchType should handle a valid patch just under the max limit", func(t *testing.T) {
 		patchBody := []byte(`{"apiVersion":"v1","kind":"Secret"` + strings.Repeat(" ", 3*1024*1024-100) + `}`)
-		err = rest.Patch(types.ApplyPatchType).Param("fieldManager", "test").AbsPath(fmt.Sprintf("/api/v1/namespaces/default/secrets/test")).
+		err = rest.Patch(types.ApplyPatchType).Param("fieldManager", "test").AbsPath("/api/v1/namespaces/default/secrets/test").
 			Body(patchBody).Do(context.TODO()).Error()
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}
 	})
 	t.Run("Delete should limit the request body size", func(t *testing.T) {
-		err = c.Delete().AbsPath(fmt.Sprintf("/api/v1/namespaces/default/secrets/test")).
+		err = c.Delete().AbsPath("/api/v1/namespaces/default/secrets/test").
 			Body(hugeData).Do(context.TODO()).Error()
 		if err == nil {
 			t.Fatalf("unexpected no error")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind api-change
> /kind bug
/kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
cleanup unnecessary sprintfs
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
N/A
**Special notes for your reviewer**:
N/A
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
