### PR TITLE
Automated cherry pick of #90113: Windows tests: Makes gMSA test more nanoserver friendly

### DIFF
--- a/test/e2e/windows/gmsa_full.go
+++ b/test/e2e/windows/gmsa_full.go
@@ -208,9 +208,7 @@ func retrieveCRDManifestFileContents(f *framework.Framework, node v1.Node) strin
 	}
 	f.PodClient().CreateSync(pod)
 
-	// using powershell and using forward slashes avoids the nightmare of having to properly
-	// escape quotes and backward slashes
-	output, err := runKubectlExecInNamespace(f.Namespace.Name, podName, "powershell", "Get-Content", strings.ReplaceAll(gmsaCrdManifestPath, `\`, "/"))
+	output, err := runKubectlExecInNamespace(f.Namespace.Name, podName, "cmd", "/S", "/C", fmt.Sprintf("type %s", gmsaCrdManifestPath))
 	if err != nil {
 		framework.Failf("failed to retrieve the contents of %q on node %q: %v", gmsaCrdManifestPath, node.Name, err)
 	}


### PR DESCRIPTION
Cherry pick of #90113 on release-1.18.

#90113: Windows tests: Makes gMSA test more nanoserver friendly

This change is required to fix the the test ``[sig-windows] [Feature:Windows] GMSA Full [Slow] GMSA support works end to end`` on the ``aks-engine-azure-1-18-windows-serial-slow`` job: https://testgrid.k8s.io/sig-windows#aks-engine-azure-1-18-windows-serial-slow

/kind bug

/sig windows
/sig testing

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.