### PR TITLE
only log cloud provider deprecation warning for in-tree components

### DIFF
--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -228,6 +228,8 @@ func CreateNodeDialer(s completedServerRunOptions) (tunneler.Tunneler, *http.Tra
 	if len(s.SSHUser) > 0 {
 		// Get ssh key distribution func, if supported
 		var installSSHKey tunneler.InstallSSHKey
+
+		cloudprovider.DeprecationWarningForProvider(s.CloudProvider.CloudProvider)
 		cloud, err := cloudprovider.InitCloudProvider(s.CloudProvider.CloudProvider, s.CloudProvider.CloudConfigFile)
 		if err != nil {
 			return nil, nil, fmt.Errorf("cloud provider could not be initialized: %v", err)

--- a/cmd/kube-controller-manager/app/cloudproviders.go
+++ b/cmd/kube-controller-manager/app/cloudproviders.go
@@ -41,6 +41,8 @@ func createCloudProvider(cloudProvider string, externalCloudVolumePlugin string,
 		}
 		cloud, err = cloudprovider.InitCloudProvider(externalCloudVolumePlugin, cloudConfigFile)
 	} else {
+		cloudprovider.DeprecationWarningForProvider(cloudProvider)
+
 		loopMode = IncludeCloudLoops
 		cloud, err = cloudprovider.InitCloudProvider(cloudProvider, cloudConfigFile)
 	}

--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -520,6 +520,7 @@ func run(s *options.KubeletServer, kubeDeps *kubelet.Dependencies, featureGate f
 
 	if kubeDeps.Cloud == nil {
 		if !cloudprovider.IsExternal(s.CloudProvider) {
+			cloudprovider.DeprecationWarningForProvider(s.CloudProvider)
 			cloud, err := cloudprovider.InitCloudProvider(s.CloudProvider, s.CloudConfigFile)
 			if err != nil {
 				return err

--- a/staging/src/k8s.io/cloud-provider/plugins.go
+++ b/staging/src/k8s.io/cloud-provider/plugins.go
@@ -91,6 +91,22 @@ func IsExternal(name string) bool {
 	return name == externalCloudProvider
 }
 
+func DeprecationWarningForProvider(providerName string) {
+	for _, provider := range deprecatedCloudProviders {
+		if provider.name != providerName {
+			continue
+		}
+
+		detail := provider.detail
+		if provider.external {
+			detail = fmt.Sprintf("Please use 'external' cloud provider for %s: %s", providerName, provider.detail)
+		}
+
+		klog.Warningf("WARNING: %s built-in cloud provider is now deprecated. %s", providerName, detail)
+		break
+	}
+}
+
 // InitCloudProvider creates an instance of the named cloud provider.
 func InitCloudProvider(name string, configFilePath string) (Interface, error) {
 	var cloud Interface
@@ -104,18 +120,6 @@ func InitCloudProvider(name string, configFilePath string) (Interface, error) {
 	if IsExternal(name) {
 		klog.Info("External cloud provider specified")
 		return nil, nil
-	}
-
-	for _, provider := range deprecatedCloudProviders {
-		if provider.name == name {
-			detail := provider.detail
-			if provider.external {
-				detail = fmt.Sprintf("Please use 'external' cloud provider for %s: %s", name, provider.detail)
-			}
-			klog.Warningf("WARNING: %s built-in cloud provider is now deprecated. %s", name, detail)
-
-			break
-		}
 	}
 
 	if configFilePath != "" {


### PR DESCRIPTION
Signed-off-by: Andrew Sy Kim <kim.andrewsy@gmail.com>

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
`InitCloudProvider` is used by both in-tree and out-of-tree components but it logs a deprecation based on a provider name. If an out-of-tree component shares the same provider name it will log a deprecation warning incorrectly. This PR separates the deprecation warning log into a separate method and only calls it from the in-tree components.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
