### PR TITLE
Avoid creating more delete collection workers than items to delete

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store.go
@@ -1006,12 +1006,19 @@ func (e *Store) DeleteCollection(ctx context.Context, deleteValidation rest.Vali
 	if err != nil {
 		return nil, err
 	}
+	if len(items) == 0 {
+		// Nothing to delete, return now
+		return listObj, nil
+	}
 	// Spawn a number of goroutines, so that we can issue requests to storage
 	// in parallel to speed up deletion.
-	// TODO: Make this proportional to the number of items to delete, up to
+	// It is proportional to the number of items to delete, up to
 	// DeleteCollectionWorkers (it doesn't make much sense to spawn 16
 	// workers to delete 10 items).
 	workersNumber := e.DeleteCollectionWorkers
+	if workersNumber > len(items) {
+		workersNumber = len(items)
+	}
 	if workersNumber < 1 {
 		workersNumber = 1
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Was investigating timeout flakes and saw this TODO comment.  I don't think this is the cause of the timeout flakes, but it does seem like a good idea to limit the number of workers to the number of items being deleted.

Practically speaking this will have a limited effect since the default DeleteCollectionWorkers appears to be 1, but if you set it higher, it will avoid creating extra unnecessary workers.

**Which issue(s) this PR fixes**:
I could not find an issue for this, but there was a TODO comment in the code.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs

```
