### PR TITLE
Add minimum supported cipher suite.

### DIFF
--- a/cmd/kubelet/app/options/options.go
+++ b/cmd/kubelet/app/options/options.go
@@ -466,11 +466,15 @@ func AddKubeletConfigFlags(mainfs *pflag.FlagSet, c *kubeletconfig.KubeletConfig
 
 	tlsCipherPreferredValues := cliflag.PreferredTLSCipherNames()
 	tlsCipherInsecureValues := cliflag.InsecureTLSCipherNames()
-	fs.StringSliceVar(&c.TLSCipherSuites, "tls-cipher-suites", c.TLSCipherSuites,
-		"Comma-separated list of cipher suites for the server. "+
-			"If omitted, the default Go cipher suites will be used. \n"+
-			"Preferred values: "+strings.Join(tlsCipherPreferredValues, ", ")+". \n"+
-			"Insecure values: "+strings.Join(tlsCipherInsecureValues, ", ")+".")
+	tlsMsg := "Comma-separated list of cipher suites for the server. " +
+		"If omitted, the default Go cipher suites will be used. \n" +
+		"Preferred values: " + strings.Join(tlsCipherPreferredValues, ", ") + "."
+
+	if len(tlsCipherInsecureValues) > 0 {
+		tlsMsg += " \nInsecure values: " + strings.Join(tlsCipherInsecureValues, ", ") + "."
+	}
+	fs.StringSliceVar(&c.TLSCipherSuites, "tls-cipher-suites", c.TLSCipherSuites, tlsMsg)
+
 	tlsPossibleVersions := cliflag.TLSPossibleVersions()
 	fs.StringVar(&c.TLSMinVersion, "tls-min-version", c.TLSMinVersion,
 		"Minimum TLS version supported. "+

--- a/staging/src/k8s.io/apiserver/pkg/server/options/serving.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/serving.go
@@ -172,12 +172,15 @@ func (s *SecureServingOptions) AddFlags(fs *pflag.FlagSet) {
 		"File containing the default x509 private key matching --tls-cert-file.")
 
 	tlsCipherPreferredValues := cliflag.PreferredTLSCipherNames()
+	tlsMsg := "Comma-separated list of cipher suites for the server. " +
+		"If omitted, the default Go cipher suites will be used. \n" +
+		"Preferred values: " + strings.Join(tlsCipherPreferredValues, ", ") + "."
 	tlsCipherInsecureValues := cliflag.InsecureTLSCipherNames()
-	fs.StringSliceVar(&s.CipherSuites, "tls-cipher-suites", s.CipherSuites,
-		"Comma-separated list of cipher suites for the server. "+
-			"If omitted, the default Go cipher suites will be used. \n"+
-			"Preferred values: "+strings.Join(tlsCipherPreferredValues, ", ")+". \n"+
-			"Insecure values: "+strings.Join(tlsCipherInsecureValues, ", ")+".")
+
+	if len(tlsCipherInsecureValues) > 0 {
+		tlsMsg += " \nInsecure values: " + strings.Join(tlsCipherInsecureValues, ", ") + "."
+	}
+	fs.StringSliceVar(&s.CipherSuites, "tls-cipher-suites", s.CipherSuites, tlsMsg)
 
 	tlsPossibleVersions := cliflag.TLSPossibleVersions()
 	fs.StringVar(&s.MinTLSVersion, "tls-min-version", s.MinTLSVersion,

--- a/staging/src/k8s.io/component-base/cli/flag/ciphersuites_flag_test.go
+++ b/staging/src/k8s.io/component-base/cli/flag/ciphersuites_flag_test.go
@@ -33,14 +33,14 @@ func TestStrToUInt16(t *testing.T) {
 	}{
 		{
 			// Happy case
-			flag:           []string{"TLS_RSA_WITH_RC4_128_SHA", "TLS_RSA_WITH_AES_128_CBC_SHA", "TLS_ECDHE_RSA_WITH_RC4_128_SHA", "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA"},
-			expected:       []uint16{tls.TLS_RSA_WITH_RC4_128_SHA, tls.TLS_RSA_WITH_AES_128_CBC_SHA, tls.TLS_ECDHE_RSA_WITH_RC4_128_SHA, tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA},
+			flag:           []string{"TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384", "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305", "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305"},
+			expected:       []uint16{tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384, tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305, tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305},
 			expected_error: false,
 		},
 		{
 			// One flag only
-			flag:           []string{"TLS_RSA_WITH_RC4_128_SHA"},
-			expected:       []uint16{tls.TLS_RSA_WITH_RC4_128_SHA},
+			flag:           []string{"TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305"},
+			expected:       []uint16{tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305},
 			expected_error: false,
 		},
 		{
@@ -51,9 +51,21 @@ func TestStrToUInt16(t *testing.T) {
 		},
 		{
 			// Duplicated flag
-			flag:           []string{"TLS_RSA_WITH_RC4_128_SHA", "TLS_RSA_WITH_AES_128_CBC_SHA", "TLS_ECDHE_RSA_WITH_RC4_128_SHA", "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA", "TLS_RSA_WITH_RC4_128_SHA"},
-			expected:       []uint16{tls.TLS_RSA_WITH_RC4_128_SHA, tls.TLS_RSA_WITH_AES_128_CBC_SHA, tls.TLS_ECDHE_RSA_WITH_RC4_128_SHA, tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA, tls.TLS_RSA_WITH_RC4_128_SHA},
+			flag:           []string{"TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384", "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305", "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305", "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305"},
+			expected:       []uint16{tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384, tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305, tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305, tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305},
 			expected_error: false,
+		},
+		{
+			// Ignore ciphers below minimum
+			flag:           []string{"TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384", "TLS_RSA_WITH_RC4_128_SHA", "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA"},
+			expected:       []uint16{tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384},
+			expected_error: false,
+		},
+		{
+			// Error if all ciphers below provided are below minimum tls cipher
+			flag:           []string{"TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA", "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA", "TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA", "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA", "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA", "TLS_RSA_WITH_RC4_128_SHA", "TLS_RSA_WITH_AES_128_CBC_SHA256", "TLS_ECDHE_ECDSA_WITH_RC4_128_SHA", "TLS_ECDHE_RSA_WITH_RC4_128_SHA"},
+			expected:       nil,
+			expected_error: true,
 		},
 		{
 			// Invalid flag
@@ -82,16 +94,19 @@ func TestConstantMaps(t *testing.T) {
 	}
 	discoveredVersions := map[string]bool{}
 	discoveredCiphers := map[string]bool{}
+	acceptedCiphers := allCiphers()
 	for _, declName := range pkg.Scope().Names() {
 		if strings.HasPrefix(declName, "VersionTLS") {
 			discoveredVersions[declName] = true
 		}
 		if strings.HasPrefix(declName, "TLS_") && !strings.HasPrefix(declName, "TLS_FALLBACK_") {
-			discoveredCiphers[declName] = true
+			v, ok := acceptedCiphers[declName]
+			if ok && v >= minTLS12CipherSupported {
+				discoveredCiphers[declName] = true
+			}
 		}
 	}
 
-	acceptedCiphers := allCiphers()
 	for k := range discoveredCiphers {
 		if _, ok := acceptedCiphers[k]; !ok {
 			t.Errorf("discovered cipher tls.%s not in ciphers map", k)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
This PR sets the minimum supported TLS cipher suite to `TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256`, as recommended by the [security audit](https://github.com/kubernetes/community/blob/master/wg-security-audit/findings/Kubernetes%20Final%20Report.pdf).
This also removes cipher options which the api-server does not support by themselves.

With this changes, the help usage for this flag becomes:
```
--tls-cipher-suites strings                                                                                                                                                                               
       Comma-separated list of cipher suites for the server. If omitted, the default Go cipher suites will be used. 
       Preferred values: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256, TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384, TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305, TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
       TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384, TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305.
```

The reason we need this PR is to remove old and weak TLS options which the use is no longer recommended. 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #91444

**Special notes for your reviewer**:
We could set the minimum to `TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256`. This would add two extra (insecure) ciphers which api-server support on its default configuration. Anything below that, would cause the api-server to not start, unless `HTTP/2` is disabled.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
The flag --tls-cipher-suites for the kubelet and api-server supports only the TLS Cipher suites TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256 or above.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```

/area security
/sig auth
/sig api-machinery
/wg security-audit
/cc @liggitt 