### PR TITLE
Pass event recorder and health server to IPVS IPv6

### DIFF
--- a/pkg/proxy/ipvs/proxier.go
+++ b/pkg/proxy/ipvs/proxier.go
@@ -523,7 +523,7 @@ func NewDualStackProxier(
 		exec, syncPeriod, minSyncPeriod, filterCIDRs(true, excludeCIDRs), strictARP,
 		tcpTimeout, tcpFinTimeout, udpTimeout, masqueradeAll, masqueradeBit,
 		localDetectors[1], hostname, nodeIP[1],
-		nil, nil, scheduler, nodePortAddresses, kernelHandler)
+		recorder, healthzServer, scheduler, nodePortAddresses, kernelHandler)
 	if err != nil {
 		return nil, fmt.Errorf("unable to create ipv6 proxier: %v", err)
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
If an error occurs within the IPVS IPv6 proxier, when it attempts to send it to the reporter, kube-proxy panics with a nil pointer dereference error. This PR passes the reporter and health servers down the IPVS IPv6.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```