### PR TITLE
e2e: access nodes via a test container

### DIFF
--- a/test/e2e/framework/network/utils.go
+++ b/test/e2e/framework/network/utils.go
@@ -160,6 +160,12 @@ type NetworkingTestConfig struct {
 	Namespace string
 }
 
+// NetexecDialResponse represents the response returned by the `netexec` subcommand of `agnhost`
+type NetexecDialResponse struct {
+	Responses []string `json:"responses"`
+	Errors    []string `json:"errors"`
+}
+
 // DialFromEndpointContainer executes a curl via kubectl exec in an endpoint container.
 func (config *NetworkingTestConfig) DialFromEndpointContainer(protocol, targetIP string, targetPort, maxTries, minTries int, expectedEps sets.String) {
 	config.DialFromContainer(protocol, echoHostname, config.EndpointPods[0].Status.PodIP, targetIP, EndpointHTTPPort, targetPort, maxTries, minTries, expectedEps)
@@ -212,6 +218,18 @@ func (config *NetworkingTestConfig) EndpointHostnames() sets.String {
 	return expectedEps
 }
 
+func makeCURLDialCommand(ipPort, dialCmd, protocol, targetIP string, targetPort int) string {
+	// The current versions of curl included in CentOS and RHEL distros
+	// misinterpret square brackets around IPv6 as globbing, so use the -g
+	// argument to disable globbing to handle the IPv6 case.
+	return fmt.Sprintf("curl -g -q -s 'http://%s/dial?request=%s&protocol=%s&host=%s&port=%d&tries=1'",
+		ipPort,
+		dialCmd,
+		protocol,
+		targetIP,
+		targetPort)
+}
+
 // DialFromContainer executes a curl via kubectl exec in a test container,
 // which might then translate to a tcp or udp request based on the protocol
 // argument in the url.
@@ -232,38 +250,19 @@ func (config *NetworkingTestConfig) EndpointHostnames() sets.String {
 // pod and confirm it doesn't show up as an endpoint.
 func (config *NetworkingTestConfig) DialFromContainer(protocol, dialCommand, containerIP, targetIP string, containerHTTPPort, targetPort, maxTries, minTries int, expectedResponses sets.String) {
 	ipPort := net.JoinHostPort(containerIP, strconv.Itoa(containerHTTPPort))
-	// The current versions of curl included in CentOS and RHEL distros
-	// misinterpret square brackets around IPv6 as globbing, so use the -g
-	// argument to disable globbing to handle the IPv6 case.
-	cmd := fmt.Sprintf("curl -g -q -s 'http://%s/dial?request=%s&protocol=%s&host=%s&port=%d&tries=1'",
-		ipPort,
-		dialCommand,
-		protocol,
-		targetIP,
-		targetPort)
+	cmd := makeCURLDialCommand(ipPort, dialCommand, protocol, targetIP, targetPort)
 
 	responses := sets.NewString()
 
 	for i := 0; i < maxTries; i++ {
-		stdout, stderr, err := config.f.ExecShellInPodWithFullOutput(config.TestContainerPod.Name, cmd)
+		resp, err := config.GetResponseFromContainer(protocol, dialCommand, containerIP, targetIP, containerHTTPPort, targetPort)
 		if err != nil {
-			// A failure to kubectl exec counts as a try, not a hard fail.
-			// Also note that we will keep failing for maxTries in tests where
-			// we confirm unreachability.
-			framework.Logf("Failed to execute %q: %v, stdout: %q, stderr %q", cmd, err, stdout, stderr)
-		} else {
-			var output map[string][]string
-			if err := json.Unmarshal([]byte(stdout), &output); err != nil {
-				framework.Logf("WARNING: Failed to unmarshal curl response. Cmd %v run in %v, output: %s, err: %v",
-					cmd, config.HostTestContainerPod.Name, stdout, err)
-				continue
-			}
-
-			for _, response := range output["responses"] {
-				trimmed := strings.TrimSpace(response)
-				if trimmed != "" {
-					responses.Insert(trimmed)
-				}
+			continue
+		}
+		for _, response := range resp.Responses {
+			trimmed := strings.TrimSpace(response)
+			if trimmed != "" {
+				responses.Insert(trimmed)
 			}
 		}
 		framework.Logf("Waiting for responses: %v", expectedResponses.Difference(responses))
@@ -314,14 +313,14 @@ func (config *NetworkingTestConfig) GetEndpointsFromContainer(protocol, containe
 			framework.Logf("Failed to execute %q: %v, stdout: %q, stderr: %q", cmd, err, stdout, stderr)
 		} else {
 			framework.Logf("Tries: %d, in try: %d, stdout: %v, stderr: %v, command run in: %#v", tries, i, stdout, stderr, config.HostTestContainerPod)
-			var output map[string][]string
+			var output NetexecDialResponse
 			if err := json.Unmarshal([]byte(stdout), &output); err != nil {
 				framework.Logf("WARNING: Failed to unmarshal curl response. Cmd %v run in %v, output: %s, err: %v",
 					cmd, config.HostTestContainerPod.Name, stdout, err)
 				continue
 			}
 
-			for _, hostName := range output["responses"] {
+			for _, hostName := range output.Responses {
 				trimmed := strings.TrimSpace(hostName)
 				if trimmed != "" {
 					eps.Insert(trimmed)
@@ -332,6 +331,34 @@ func (config *NetworkingTestConfig) GetEndpointsFromContainer(protocol, containe
 		}
 	}
 	return eps, nil
+}
+
+// GetResponseFromContainer executes a curl via kubectl exec in a container.
+func (config *NetworkingTestConfig) GetResponseFromContainer(protocol, dialCommand, containerIP, targetIP string, containerHTTPPort, targetPort int) (NetexecDialResponse, error) {
+	ipPort := net.JoinHostPort(containerIP, strconv.Itoa(containerHTTPPort))
+	cmd := makeCURLDialCommand(ipPort, dialCommand, protocol, targetIP, targetPort)
+
+	stdout, stderr, err := config.f.ExecShellInPodWithFullOutput(config.TestContainerPod.Name, cmd)
+	if err != nil {
+		// A failure to kubectl exec counts as a try, not a hard fail.
+		// Also note that we will keep failing for maxTries in tests where
+		// we confirm unreachability.
+		framework.Logf("Failed to execute %q: %v, stdout: %q, stderr: %q", cmd, err, stdout, stderr)
+		return NetexecDialResponse{}, err
+	}
+
+	var output NetexecDialResponse
+	if err := json.Unmarshal([]byte(stdout), &output); err != nil {
+		framework.Logf("WARNING: Failed to unmarshal curl response. Cmd %v run in %v, output: %s, err: %v",
+			cmd, config.HostTestContainerPod.Name, stdout, err)
+		return NetexecDialResponse{}, err
+	}
+	return output, nil
+}
+
+// GetResponseFromTestContainer executes a curl via kubectl exec in a test container.
+func (config *NetworkingTestConfig) GetResponseFromTestContainer(protocol, dialCommand, targetIP string, targetPort int) (NetexecDialResponse, error) {
+	return config.GetResponseFromContainer(protocol, dialCommand, config.TestContainerPod.Status.PodIP, targetIP, testContainerHTTPPort, targetPort)
 }
 
 // DialFromNode executes a tcp or udp request based on protocol via kubectl exec

--- a/test/e2e/framework/service/jig.go
+++ b/test/e2e/framework/service/jig.go
@@ -260,21 +260,36 @@ func (j *TestJig) CreateLoadBalancerService(timeout time.Duration, tweak func(sv
 // GetEndpointNodes returns a map of nodenames:external-ip on which the
 // endpoints of the Service are running.
 func (j *TestJig) GetEndpointNodes() (map[string][]string, error) {
-	nodes, err := e2enode.GetBoundedReadySchedulableNodes(j.Client, MaxNodesForEndpointsTests)
-	if err != nil {
-		return nil, err
-	}
-	epNodes, err := j.GetEndpointNodeNames()
+	nodes, err := j.ListNodesWithEndpoint()
 	if err != nil {
 		return nil, err
 	}
 	nodeMap := map[string][]string{}
-	for _, n := range nodes.Items {
-		if epNodes.Has(n.Name) {
-			nodeMap[n.Name] = e2enode.GetAddresses(&n, v1.NodeExternalIP)
-		}
+	for _, node := range nodes {
+		nodeMap[node.Name] = e2enode.GetAddresses(&node, v1.NodeExternalIP)
 	}
 	return nodeMap, nil
+}
+
+// ListNodesWithEndpoint returns a list of nodes on which the
+// endpoints of the given Service are running.
+func (j *TestJig) ListNodesWithEndpoint() ([]v1.Node, error) {
+	nodeNames, err := j.GetEndpointNodeNames()
+	if err != nil {
+		return nil, err
+	}
+	ctx := context.TODO()
+	allNodes, err := j.Client.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+	epNodes := make([]v1.Node, 0, nodeNames.Len())
+	for _, node := range allNodes.Items {
+		if nodeNames.Has(node.Name) {
+			epNodes = append(epNodes, node)
+		}
+	}
+	return epNodes, nil
 }
 
 // GetEndpointNodeNames returns a string set of node names on which the


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation

/kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

currently we expect public IPs on the nodes in NetLB tests, but this requirement is not always met. As a result, we decide to access nodes via a test container.

**Which issue(s) this PR fixes**:

Fixes #90047 

**Special notes for your reviewer**:

@wojtek-t I am not sure if the updated test is equivalent to the previous one and I think I need a thorough review since I might not have a complete picture of the tests, any advices are welcome.

In addition, I only migrate one test this time for debugging. If it works, I will continue to migrate the remain tests involved in #90171.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
