### PR TITLE
fix a client-go crash handler not working issue.

### DIFF
--- a/staging/src/k8s.io/client-go/tools/leaderelection/leaderelection.go
+++ b/staging/src/k8s.io/client-go/tools/leaderelection/leaderelection.go
@@ -195,10 +195,11 @@ type LeaderElector struct {
 
 // Run starts the leader election loop
 func (le *LeaderElector) Run(ctx context.Context) {
+	defer runtime.HandleCrash()
 	defer func() {
-		runtime.HandleCrash()
 		le.config.Callbacks.OnStoppedLeading()
 	}()
+
 	if !le.acquire(ctx) {
 		return // ctx signalled done
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
As per [Golang specification of handling panics](https://golang.org/ref/spec#Handling_panics), if `recover was not called directly by a deferred function`, the return value of `recover()` always be nil.

Here is the case that `runtime.HandleCrash()` can not recover a panic:
https://github.com/kubernetes/kubernetes/blob/c8ceeed6982752db80def3a16266e72a6046db0e/staging/src/k8s.io/client-go/tools/leaderelection/leaderelection.go#L197-L201



**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
/priority backlog