### PR TITLE
Fix a wrong usage of recover in apiserver

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/util/wsstream/stream.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/wsstream/stream.go
@@ -63,7 +63,7 @@ type Reader struct {
 	protocols        map[string]ReaderProtocolConfig
 	selectedProtocol string
 
-	handleCrash func() // overridable for testing
+	handleCrash func(additionalHandlers ...func(interface{})) // overridable for testing
 }
 
 // NewReader creates a WebSocket pipe that will copy the contents of r to a provided
@@ -78,7 +78,7 @@ func NewReader(r io.Reader, ping bool, protocols map[string]ReaderProtocolConfig
 		err:         make(chan error),
 		ping:        ping,
 		protocols:   protocols,
-		handleCrash: func() { runtime.HandleCrash() },
+		handleCrash: runtime.HandleCrash,
 	}
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/util/wsstream/stream_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/wsstream/stream_test.go
@@ -169,7 +169,7 @@ func TestStreamSurvivesPanic(t *testing.T) {
 	r := NewReader(errs, false, NewDefaultReaderProtocols())
 
 	// do not call runtime.HandleCrash() in handler. Otherwise, the tests are interrupted.
-	r.handleCrash = func() { recover() }
+	r.handleCrash = func(additionalHandlers ...func(interface{})) { recover() }
 
 	data, err := readWebSocket(r, t, nil)
 	if !reflect.DeepEqual(data, []byte(input)) {


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Fixed a wrong usage of `recover`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
based on the discussion on slack https://kubernetes.slack.com/archives/C0EG7JC6T/p1590739564011400.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

/assign @sttts 
/priority backlog