### PR TITLE
FairQueuing: Adjust virtual start time synchronization

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/queueset/queueset.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/queueset/queueset.go
@@ -497,8 +497,7 @@ func (qs *queueSet) rejectOrEnqueueLocked(request *request) bool {
 func (qs *queueSet) enqueueLocked(request *request) {
 	queue := request.queue
 	if len(queue.requests) == 0 && queue.requestsExecuting == 0 {
-		// the queue’s virtual start time is set to the virtual time.
-		queue.virtualStart = qs.virtualTime
+		queue.SetVirtualStart(qs.virtualTime, qs.estimatedServiceTime)
 		if klog.V(6).Enabled() {
 			klog.Infof("QS(%s) at r=%s v=%.9fs: initialized queue %d virtual start time due to request %#+v %#+v", qs.qCfg.Name, qs.clock.Now().Format(nsTimeFmt), queue.virtualStart, queue.index, request.descr1, request.descr2)
 		}
@@ -571,8 +570,7 @@ func (qs *queueSet) dispatchLocked() bool {
 	if klog.V(6).Enabled() {
 		klog.Infof("QS(%s) at r=%s v=%.9fs: dispatching request %#+v %#+v from queue %d with virtual start time %.9fs, queue will have %d waiting & %d executing", qs.qCfg.Name, request.startTime.Format(nsTimeFmt), qs.virtualTime, request.descr1, request.descr2, queue.index, queue.virtualStart, len(queue.requests), queue.requestsExecuting)
 	}
-	// When a request is dequeued for service -> qs.virtualStart += G
-	queue.virtualStart += qs.estimatedServiceTime
+	queue.SetVirtualStart(qs.virtualTime, qs.estimatedServiceTime)
 	request.decision.SetLocked(decisionExecute)
 	return ok
 }

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/queueset/types.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/queueset/types.go
@@ -18,6 +18,7 @@ package queueset
 
 import (
 	"context"
+	"math"
 	"time"
 
 	"k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/promise"
@@ -93,4 +94,12 @@ func (q *queue) GetVirtualFinish(J int, G float64) float64 {
 	// counting from J=1 for the head (eg: queue.requests[0] -> J=1) - J+1
 	jg := float64(J+1) * float64(G)
 	return jg + q.virtualStart
+}
+
+// SetVirtualStart syncs virtual start time by:
+// 	Si = MAX(R(t), Fi-1)
+// where "Fi-1"  is estimated by adding estimatedServiceTime to last virtual start
+// time of the queue.
+func (q *queue) SetVirtualStart(currentVirtualTime, estimatedServiceTime float64) {
+	q.virtualStart = math.Max(currentVirtualTime, q.virtualStart+estimatedServiceTime)
 }


### PR DESCRIPTION


```release-note
NONE
```
/sig api-machinery
/kind feature


in the original paper, Si -- the virtual start time for pkt i -- is defined as:

```
Si = MAX(R(t), Fi-1)
```


currently in our implementation, Fi-1 is calculated from the sum of the current virtual start and an initial guess service time. and the virtual start time is set in the following logic:

- sets Si to the R(t) for empty queue
- sets Si to Fi-1 for non-empty queue

mostly, Fi-1 will be greater than R(t) as the guessed service time is the default limit of request time (1 min). however there can be cases when R(t) > Fi-1 which will result in different behaviors than the paper proposed way. for example, a queue keeps serving "mouse" requests but never gets empty. its virtual start time will keep lower and lower than R(t) unboundedly. 

this pull updates the computation of virtual start time to sync up w/ the paper.





