### PR TITLE
Fix buildtags so that kubelet can build on illumos

### DIFF
--- a/pkg/kubelet/util/boottime_util_illumos.go
+++ b/pkg/kubelet/util/boottime_util_illumos.go
@@ -1,0 +1,36 @@
+// +build illumos
+
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"fmt"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+// GetBootTime returns the time at which the machine was started, truncated to the nearest second
+func GetBootTime() (time.Time, error) {
+	currentTime := time.Now()
+	var info unix.Sysinfo_t
+	if err := unix.Sysinfo(&info); err != nil {
+		return time.Time{}, fmt.Errorf("error getting system uptime: %s", err)
+	}
+	return currentTime.Add(-time.Duration(info.Uptime) * time.Second).Truncate(time.Second), nil
+}

--- a/pkg/kubelet/util/boottime_util_illumos_test.go
+++ b/pkg/kubelet/util/boottime_util_illumos_test.go
@@ -1,0 +1,36 @@
+// +build illumos
+
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"testing"
+	"time"
+)
+
+func TestGetBootTime(t *testing.T) {
+	boottime, err := GetBootTime()
+
+	if err != nil {
+		t.Errorf("Unable to get system uptime")
+	}
+
+	if !boottime.After(time.Time{}) {
+		t.Errorf("Invalid system uptime")
+	}
+}

--- a/pkg/kubelet/util/util_unix.go
+++ b/pkg/kubelet/util/util_unix.go
@@ -1,4 +1,4 @@
-// +build freebsd linux darwin
+// +build freebsd linux darwin solaris illumos
 
 /*
 Copyright 2017 The Kubernetes Authors.

--- a/pkg/kubelet/util/util_unix_test.go
+++ b/pkg/kubelet/util/util_unix_test.go
@@ -1,4 +1,4 @@
-// +build freebsd linux darwin
+// +build freebsd linux darwin solaris illumos
 
 /*
 Copyright 2018 The Kubernetes Authors.

--- a/pkg/kubelet/util/util_unsupported.go
+++ b/pkg/kubelet/util/util_unsupported.go
@@ -1,4 +1,4 @@
-// +build !freebsd,!linux,!windows,!darwin
+// +build !freebsd,!linux,!windows,!darwin,!illumos,!solaris
 
 /*
 Copyright 2017 The Kubernetes Authors.


### PR DESCRIPTION
**What type of PR is this?**
Unfortunately there is no kind porting, so I assume based on what is written that everything not explicitly broken is a feature? Please let me know if that is not the case.
/kind feature

**What this PR does / why we need it**:
This enables all illumos parts to build on illumos.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
- Master Issue: #91570

