### PR TITLE
Enable build on illumos.

### DIFF
--- a/hack/lib/golang.sh
+++ b/hack/lib/golang.sh
@@ -27,6 +27,7 @@ readonly KUBE_SUPPORTED_SERVER_PLATFORMS=(
   linux/arm64
   linux/s390x
   linux/ppc64le
+  illumos/amd64
 )
 
 # The node platforms we build for
@@ -37,6 +38,7 @@ readonly KUBE_SUPPORTED_NODE_PLATFORMS=(
   linux/s390x
   linux/ppc64le
   windows/amd64
+  illumos/amd64
 )
 
 # If we update this we should also update the set of platforms whose standard
@@ -51,6 +53,7 @@ readonly KUBE_SUPPORTED_CLIENT_PLATFORMS=(
   darwin/amd64
   windows/amd64
   windows/386
+  illumos/amd64
 )
 
 # Which platforms we should compile test targets for.
@@ -63,6 +66,7 @@ readonly KUBE_SUPPORTED_TEST_PLATFORMS=(
   linux/ppc64le
   darwin/amd64
   windows/amd64
+  illumos/amd64
 )
 
 # The set of server targets that we are only building for Linux

--- a/hack/lib/util.sh
+++ b/hack/lib/util.sh
@@ -147,6 +147,9 @@ kube::util::host_os() {
     Linux)
       host_os=linux
       ;;
+    SunOS)
+      host_os=illumos
+      ;;
     *)
       kube::log::error "Unsupported host OS.  Must be Linux or Mac OS X."
       exit 1
@@ -165,6 +168,9 @@ kube::util::host_arch() {
       host_arch=amd64
       ;;
     amd64*)
+      host_arch=amd64
+      ;;
+    i86pc)
       host_arch=amd64
       ;;
     aarch64*)

--- a/hack/local-up-cluster.sh
+++ b/hack/local-up-cluster.sh
@@ -295,6 +295,9 @@ function detect_binary {
       Linux)
         host_os=linux
         ;;
+      SunOS)
+        host_os=illumos
+        ;;
       *)
         echo "Unsupported host OS.  Must be Linux or Mac OS X." >&2
         exit 1
@@ -309,6 +312,9 @@ function detect_binary {
         host_arch=amd64
         ;;
       amd64*)
+        host_arch=amd64
+        ;;
+      i86pc)
         host_arch=amd64
         ;;
       aarch64*)


### PR DESCRIPTION
**What type of PR is this?**
This is part of the porting effort in #91570 it allows the build to work on illumos as buildhost
/kind feature

**What this PR does / why we need it**:
Enable illumos based builds
**Special notes for your reviewer**:
The OUT_DIR might be something, that breaks builds on linux, but I was not able to make it work otherwise. Somebody with more knowledge to input on that part would be very appreciated. My makefile-fu is not that great.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
- Master Issue: #91570
