### PR TITLE
Remove KubeSchedulerConfiguration.BindTimeoutSeconds

### DIFF
--- a/cmd/kube-scheduler/app/options/options_test.go
+++ b/cmd/kube-scheduler/app/options/options_test.go
@@ -247,7 +247,6 @@ profiles:
 	}
 
 	defaultSource := "DefaultProvider"
-	defaultBindTimeoutSeconds := int64(600)
 	defaultPodInitialBackoffSeconds := int64(1)
 	defaultPodMaxBackoffSeconds := int64(10)
 	defaultPercentageOfNodesToScore := int32(0)
@@ -320,7 +319,6 @@ profiles:
 					ContentType: "application/vnd.kubernetes.protobuf",
 				},
 				PercentageOfNodesToScore: defaultPercentageOfNodesToScore,
-				BindTimeoutSeconds:       defaultBindTimeoutSeconds,
 				PodInitialBackoffSeconds: defaultPodInitialBackoffSeconds,
 				PodMaxBackoffSeconds:     defaultPodMaxBackoffSeconds,
 				Profiles: []kubeschedulerconfig.KubeSchedulerProfile{
@@ -410,7 +408,6 @@ profiles:
 					ContentType: "application/vnd.kubernetes.protobuf",
 				},
 				PercentageOfNodesToScore: defaultPercentageOfNodesToScore,
-				BindTimeoutSeconds:       defaultBindTimeoutSeconds,
 				PodInitialBackoffSeconds: defaultPodInitialBackoffSeconds,
 				PodMaxBackoffSeconds:     defaultPodMaxBackoffSeconds,
 				Profiles: []kubeschedulerconfig.KubeSchedulerProfile{
@@ -474,7 +471,6 @@ profiles:
 					ContentType: "application/vnd.kubernetes.protobuf",
 				},
 				PercentageOfNodesToScore: defaultPercentageOfNodesToScore,
-				BindTimeoutSeconds:       defaultBindTimeoutSeconds,
 				PodInitialBackoffSeconds: defaultPodInitialBackoffSeconds,
 				PodMaxBackoffSeconds:     defaultPodMaxBackoffSeconds,
 				Profiles: []kubeschedulerconfig.KubeSchedulerProfile{
@@ -513,7 +509,6 @@ profiles:
 					ContentType: "application/vnd.kubernetes.protobuf",
 				},
 				PercentageOfNodesToScore: defaultPercentageOfNodesToScore,
-				BindTimeoutSeconds:       defaultBindTimeoutSeconds,
 				PodInitialBackoffSeconds: defaultPodInitialBackoffSeconds,
 				PodMaxBackoffSeconds:     defaultPodMaxBackoffSeconds,
 				Profiles: []kubeschedulerconfig.KubeSchedulerProfile{
@@ -587,7 +582,6 @@ profiles:
 					ContentType: "application/vnd.kubernetes.protobuf",
 				},
 				PercentageOfNodesToScore: defaultPercentageOfNodesToScore,
-				BindTimeoutSeconds:       defaultBindTimeoutSeconds,
 				PodInitialBackoffSeconds: defaultPodInitialBackoffSeconds,
 				PodMaxBackoffSeconds:     defaultPodMaxBackoffSeconds,
 				Profiles: []kubeschedulerconfig.KubeSchedulerProfile{
@@ -659,7 +653,6 @@ profiles:
 					ContentType: "application/vnd.kubernetes.protobuf",
 				},
 				PercentageOfNodesToScore: defaultPercentageOfNodesToScore,
-				BindTimeoutSeconds:       defaultBindTimeoutSeconds,
 				PodInitialBackoffSeconds: defaultPodInitialBackoffSeconds,
 				PodMaxBackoffSeconds:     defaultPodMaxBackoffSeconds,
 				Profiles: []kubeschedulerconfig.KubeSchedulerProfile{
@@ -711,7 +704,6 @@ profiles:
 					ContentType: "application/vnd.kubernetes.protobuf",
 				},
 				PercentageOfNodesToScore: defaultPercentageOfNodesToScore,
-				BindTimeoutSeconds:       defaultBindTimeoutSeconds,
 				PodInitialBackoffSeconds: defaultPodInitialBackoffSeconds,
 				PodMaxBackoffSeconds:     defaultPodMaxBackoffSeconds,
 				Profiles: []kubeschedulerconfig.KubeSchedulerProfile{

--- a/cmd/kube-scheduler/app/server.go
+++ b/cmd/kube-scheduler/app/server.go
@@ -337,7 +337,6 @@ func Setup(ctx context.Context, opts *options.Options, outOfTreeRegistryOptions 
 		scheduler.WithAlgorithmSource(cc.ComponentConfig.AlgorithmSource),
 		scheduler.WithPreemptionDisabled(cc.ComponentConfig.DisablePreemption),
 		scheduler.WithPercentageOfNodesToScore(cc.ComponentConfig.PercentageOfNodesToScore),
-		scheduler.WithBindTimeoutSeconds(cc.ComponentConfig.BindTimeoutSeconds),
 		scheduler.WithFrameworkOutOfTreeRegistry(outOfTreeRegistry),
 		scheduler.WithPodMaxBackoffSeconds(cc.ComponentConfig.PodMaxBackoffSeconds),
 		scheduler.WithPodInitialBackoffSeconds(cc.ComponentConfig.PodInitialBackoffSeconds),

--- a/pkg/scheduler/BUILD
+++ b/pkg/scheduler/BUILD
@@ -21,7 +21,6 @@ go_library(
         "//pkg/scheduler/framework/plugins/defaultbinder:go_default_library",
         "//pkg/scheduler/framework/plugins/noderesources:go_default_library",
         "//pkg/scheduler/framework/plugins/queuesort:go_default_library",
-        "//pkg/scheduler/framework/plugins/volumebinding:go_default_library",
         "//pkg/scheduler/framework/v1alpha1:go_default_library",
         "//pkg/scheduler/internal/cache:go_default_library",
         "//pkg/scheduler/internal/cache/debugger:go_default_library",

--- a/pkg/scheduler/apis/config/scheme/scheme_test.go
+++ b/pkg/scheduler/apis/config/scheme/scheme_test.go
@@ -478,7 +478,6 @@ profiles:
 				},
 			},
 			want: `apiVersion: kubescheduler.config.k8s.io/v1beta1
-bindTimeoutSeconds: 0
 clientConnection:
   acceptContentTypes: ""
   burst: 0

--- a/pkg/scheduler/apis/config/testing/compatibility_test.go
+++ b/pkg/scheduler/apis/config/testing/compatibility_test.go
@@ -1617,15 +1617,6 @@ func TestPluginsConfigurationCompatibility(t *testing.T) {
 		"PostBindPlugin":  {{Name: "VolumeBinding"}},
 	}
 
-	defaultPluginConfigs := []config.PluginConfig{
-		{
-			Name: "VolumeBinding",
-			Args: &config.VolumeBindingArgs{
-				BindTimeoutSeconds: 600,
-			},
-		},
-	}
-
 	testcases := []struct {
 		name             string
 		plugins          config.Plugins
@@ -1636,7 +1627,7 @@ func TestPluginsConfigurationCompatibility(t *testing.T) {
 		{
 			name:             "default plugins",
 			wantPlugins:      defaultPlugins,
-			wantPluginConfig: defaultPluginConfigs,
+			wantPluginConfig: nil,
 		},
 		{
 			name:        "default plugins with customized plugin config",
@@ -1967,7 +1958,7 @@ func TestPluginsConfigurationCompatibility(t *testing.T) {
 				"BindPlugin":      {{Name: "DefaultBinder"}},
 				"PostBindPlugin":  {{Name: "VolumeBinding"}},
 			},
-			wantPluginConfig: defaultPluginConfigs,
+			wantPluginConfig: nil,
 		},
 	}
 	for _, tc := range testcases {

--- a/pkg/scheduler/apis/config/types.go
+++ b/pkg/scheduler/apis/config/types.go
@@ -90,13 +90,6 @@ type KubeSchedulerConfiguration struct {
 	// nodes will be scored.
 	PercentageOfNodesToScore int32
 
-	// BindTimeoutSeconds is the timeout in seconds in volume binding operation.
-	// Value must be non-negative integer. The value zero indicates no waiting.
-	// If this value is nil, the default value will be used.
-	// DEPRECATED: BindTimeoutSeconds in deprecated.
-	// TODO(#90958) Remove this and the versioned counterparts in future API versions.
-	BindTimeoutSeconds int64
-
 	// PodInitialBackoffSeconds is the initial backoff for unschedulable pods.
 	// If specified, it must be greater than 0. If this value is null, the default value (1s)
 	// will be used.

--- a/pkg/scheduler/apis/config/v1beta1/defaults.go
+++ b/pkg/scheduler/apis/config/v1beta1/defaults.go
@@ -135,11 +135,6 @@ func SetDefaults_KubeSchedulerConfiguration(obj *v1beta1.KubeSchedulerConfigurat
 	// Use the default LeaderElectionConfiguration options
 	componentbaseconfigv1alpha1.RecommendedDefaultLeaderElectionConfiguration(&obj.LeaderElection)
 
-	if obj.BindTimeoutSeconds == nil {
-		val := int64(600)
-		obj.BindTimeoutSeconds = &val
-	}
-
 	if obj.PodInitialBackoffSeconds == nil {
 		val := int64(1)
 		obj.PodInitialBackoffSeconds = &val

--- a/pkg/scheduler/apis/config/v1beta1/defaults_test.go
+++ b/pkg/scheduler/apis/config/v1beta1/defaults_test.go
@@ -62,7 +62,6 @@ func TestSchedulerDefaults(t *testing.T) {
 				},
 				DisablePreemption:        pointer.BoolPtr(false),
 				PercentageOfNodesToScore: pointer.Int32Ptr(0),
-				BindTimeoutSeconds:       pointer.Int64Ptr(600),
 				PodInitialBackoffSeconds: pointer.Int64Ptr(1),
 				PodMaxBackoffSeconds:     pointer.Int64Ptr(10),
 				Profiles: []v1beta1.KubeSchedulerProfile{
@@ -104,7 +103,6 @@ func TestSchedulerDefaults(t *testing.T) {
 				},
 				DisablePreemption:        pointer.BoolPtr(false),
 				PercentageOfNodesToScore: pointer.Int32Ptr(0),
-				BindTimeoutSeconds:       pointer.Int64Ptr(600),
 				PodInitialBackoffSeconds: pointer.Int64Ptr(1),
 				PodMaxBackoffSeconds:     pointer.Int64Ptr(10),
 				Profiles: []v1beta1.KubeSchedulerProfile{
@@ -161,7 +159,6 @@ func TestSchedulerDefaults(t *testing.T) {
 				},
 				DisablePreemption:        pointer.BoolPtr(false),
 				PercentageOfNodesToScore: pointer.Int32Ptr(0),
-				BindTimeoutSeconds:       pointer.Int64Ptr(600),
 				PodInitialBackoffSeconds: pointer.Int64Ptr(1),
 				PodMaxBackoffSeconds:     pointer.Int64Ptr(10),
 				Profiles: []v1beta1.KubeSchedulerProfile{
@@ -212,7 +209,6 @@ func TestSchedulerDefaults(t *testing.T) {
 				},
 				DisablePreemption:        pointer.BoolPtr(false),
 				PercentageOfNodesToScore: pointer.Int32Ptr(0),
-				BindTimeoutSeconds:       pointer.Int64Ptr(600),
 				PodInitialBackoffSeconds: pointer.Int64Ptr(1),
 				PodMaxBackoffSeconds:     pointer.Int64Ptr(10),
 				Profiles: []v1beta1.KubeSchedulerProfile{
@@ -249,7 +245,6 @@ func TestSchedulerDefaults(t *testing.T) {
 				},
 				DisablePreemption:        pointer.BoolPtr(false),
 				PercentageOfNodesToScore: pointer.Int32Ptr(0),
-				BindTimeoutSeconds:       pointer.Int64Ptr(600),
 				PodInitialBackoffSeconds: pointer.Int64Ptr(1),
 				PodMaxBackoffSeconds:     pointer.Int64Ptr(10),
 				Profiles: []v1beta1.KubeSchedulerProfile{

--- a/pkg/scheduler/apis/config/v1beta1/zz_generated.conversion.go
+++ b/pkg/scheduler/apis/config/v1beta1/zz_generated.conversion.go
@@ -259,9 +259,6 @@ func autoConvert_v1beta1_KubeSchedulerConfiguration_To_config_KubeSchedulerConfi
 	if err := v1.Convert_Pointer_int32_To_int32(&in.PercentageOfNodesToScore, &out.PercentageOfNodesToScore, s); err != nil {
 		return err
 	}
-	if err := v1.Convert_Pointer_int64_To_int64(&in.BindTimeoutSeconds, &out.BindTimeoutSeconds, s); err != nil {
-		return err
-	}
 	if err := v1.Convert_Pointer_int64_To_int64(&in.PodInitialBackoffSeconds, &out.PodInitialBackoffSeconds, s); err != nil {
 		return err
 	}
@@ -304,9 +301,6 @@ func autoConvert_config_KubeSchedulerConfiguration_To_v1beta1_KubeSchedulerConfi
 		return err
 	}
 	if err := v1.Convert_int32_To_Pointer_int32(&in.PercentageOfNodesToScore, &out.PercentageOfNodesToScore, s); err != nil {
-		return err
-	}
-	if err := v1.Convert_int64_To_Pointer_int64(&in.BindTimeoutSeconds, &out.BindTimeoutSeconds, s); err != nil {
 		return err
 	}
 	if err := v1.Convert_int64_To_Pointer_int64(&in.PodInitialBackoffSeconds, &out.PodInitialBackoffSeconds, s); err != nil {

--- a/pkg/scheduler/apis/config/validation/validation_test.go
+++ b/pkg/scheduler/apis/config/validation/validation_test.go
@@ -28,7 +28,6 @@ import (
 )
 
 func TestValidateKubeSchedulerConfiguration(t *testing.T) {
-	testTimeout := int64(0)
 	podInitialBackoffSeconds := int64(1)
 	podMaxBackoffSeconds := int64(1)
 	validConfig := &config.KubeSchedulerConfiguration{
@@ -59,7 +58,6 @@ func TestValidateKubeSchedulerConfiguration(t *testing.T) {
 		},
 		PodInitialBackoffSeconds: podInitialBackoffSeconds,
 		PodMaxBackoffSeconds:     podMaxBackoffSeconds,
-		BindTimeoutSeconds:       testTimeout,
 		PercentageOfNodesToScore: 35,
 		Profiles: []config.KubeSchedulerProfile{
 			{

--- a/pkg/scheduler/factory_test.go
+++ b/pkg/scheduler/factory_test.go
@@ -36,7 +36,6 @@ import (
 	"k8s.io/client-go/tools/events"
 	extenderv1 "k8s.io/kube-scheduler/extender/v1"
 	apicore "k8s.io/kubernetes/pkg/apis/core"
-	"k8s.io/kubernetes/pkg/scheduler/apis/config"
 	schedulerapi "k8s.io/kubernetes/pkg/scheduler/apis/config"
 	"k8s.io/kubernetes/pkg/scheduler/apis/config/scheme"
 	frameworkplugins "k8s.io/kubernetes/pkg/scheduler/framework/plugins"
@@ -45,7 +44,6 @@ import (
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/nodelabel"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/queuesort"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/serviceaffinity"
-	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/volumebinding"
 	framework "k8s.io/kubernetes/pkg/scheduler/framework/v1alpha1"
 	internalcache "k8s.io/kubernetes/pkg/scheduler/internal/cache"
 	internalqueue "k8s.io/kubernetes/pkg/scheduler/internal/queue"
@@ -54,7 +52,6 @@ import (
 
 const (
 	disablePodPreemption             = false
-	bindTimeoutSeconds               = 600
 	podInitialBackoffDurationSeconds = 1
 	podMaxBackoffDurationSeconds     = 10
 	testSchedulerName                = "test-scheduler"
@@ -242,14 +239,7 @@ func TestCreateFromEmptyConfig(t *testing.T) {
 		t.Fatal(err)
 	}
 	prof := factory.profiles[0]
-	wantConfig := []schedulerapi.PluginConfig{
-		{
-			Name: volumebinding.Name,
-			Args: &config.VolumeBindingArgs{
-				BindTimeoutSeconds: bindTimeoutSeconds,
-			},
-		},
-	}
+	wantConfig := []schedulerapi.PluginConfig{}
 	if diff := cmp.Diff(wantConfig, prof.PluginConfig); diff != "" {
 		t.Errorf("wrong plugin config (-want, +got): %s", diff)
 	}
@@ -465,7 +455,6 @@ func newConfigFactoryWithFrameworkRegistry(
 		podInformer:              informerFactory.Core().V1().Pods(),
 		disablePreemption:        disablePodPreemption,
 		percentageOfNodesToScore: schedulerapi.DefaultPercentageOfNodesToScore,
-		bindTimeoutSeconds:       bindTimeoutSeconds,
 		podInitialBackoffSeconds: podInitialBackoffDurationSeconds,
 		podMaxBackoffSeconds:     podMaxBackoffDurationSeconds,
 		StopEverything:           stopCh,

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -41,7 +41,6 @@ import (
 	"k8s.io/kubernetes/pkg/scheduler/apis/config/scheme"
 	"k8s.io/kubernetes/pkg/scheduler/core"
 	frameworkplugins "k8s.io/kubernetes/pkg/scheduler/framework/plugins"
-	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/volumebinding"
 	framework "k8s.io/kubernetes/pkg/scheduler/framework/v1alpha1"
 	internalcache "k8s.io/kubernetes/pkg/scheduler/internal/cache"
 	internalqueue "k8s.io/kubernetes/pkg/scheduler/internal/queue"
@@ -113,7 +112,6 @@ type schedulerOptions struct {
 	schedulerAlgorithmSource schedulerapi.SchedulerAlgorithmSource
 	disablePreemption        bool
 	percentageOfNodesToScore int32
-	bindTimeoutSeconds       int64
 	podInitialBackoffSeconds int64
 	podMaxBackoffSeconds     int64
 	// Contains out-of-tree plugins to be merged with the in-tree registry.
@@ -152,13 +150,6 @@ func WithPreemptionDisabled(disablePreemption bool) Option {
 func WithPercentageOfNodesToScore(percentageOfNodesToScore int32) Option {
 	return func(o *schedulerOptions) {
 		o.percentageOfNodesToScore = percentageOfNodesToScore
-	}
-}
-
-// WithBindTimeoutSeconds sets bindTimeoutSeconds for Scheduler, the default value is 100
-func WithBindTimeoutSeconds(bindTimeoutSeconds int64) Option {
-	return func(o *schedulerOptions) {
-		o.bindTimeoutSeconds = bindTimeoutSeconds
 	}
 }
 
@@ -211,7 +202,6 @@ var defaultSchedulerOptions = schedulerOptions{
 	},
 	disablePreemption:        false,
 	percentageOfNodesToScore: schedulerapi.DefaultPercentageOfNodesToScore,
-	bindTimeoutSeconds:       volumebinding.DefaultBindTimeoutSeconds,
 	podInitialBackoffSeconds: int64(internalqueue.DefaultPodInitialBackoffDuration.Seconds()),
 	podMaxBackoffSeconds:     int64(internalqueue.DefaultPodMaxBackoffDuration.Seconds()),
 }
@@ -252,7 +242,6 @@ func New(client clientset.Interface,
 		StopEverything:           stopEverything,
 		disablePreemption:        options.disablePreemption,
 		percentageOfNodesToScore: options.percentageOfNodesToScore,
-		bindTimeoutSeconds:       options.bindTimeoutSeconds,
 		podInitialBackoffSeconds: options.podInitialBackoffSeconds,
 		podMaxBackoffSeconds:     options.podMaxBackoffSeconds,
 		profiles:                 append([]schedulerapi.KubeSchedulerProfile(nil), options.profiles...),

--- a/staging/src/k8s.io/kube-scheduler/config/v1beta1/types.go
+++ b/staging/src/k8s.io/kube-scheduler/config/v1beta1/types.go
@@ -74,13 +74,6 @@ type KubeSchedulerConfiguration struct {
 	// nodes will be scored.
 	PercentageOfNodesToScore *int32 `json:"percentageOfNodesToScore,omitempty"`
 
-	// Duration to wait for a binding operation to complete before timing out
-	// Value must be non-negative integer. The value zero indicates no waiting.
-	// If this value is nil, the default value will be used.
-	// DEPRECATED: BindTimeoutSeconds is deprecated. To change volume bind
-	// timeout, configure via plugin args for VolumeBinding.
-	BindTimeoutSeconds *int64 `json:"bindTimeoutSeconds,omitempty"`
-
 	// PodInitialBackoffSeconds is the initial backoff for unschedulable pods.
 	// If specified, it must be greater than 0. If this value is null, the default value (1s)
 	// will be used.

--- a/staging/src/k8s.io/kube-scheduler/config/v1beta1/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/kube-scheduler/config/v1beta1/zz_generated.deepcopy.go
@@ -83,11 +83,6 @@ func (in *KubeSchedulerConfiguration) DeepCopyInto(out *KubeSchedulerConfigurati
 		*out = new(int32)
 		**out = **in
 	}
-	if in.BindTimeoutSeconds != nil {
-		in, out := &in.BindTimeoutSeconds, &out.BindTimeoutSeconds
-		*out = new(int64)
-		**out = **in
-	}
 	if in.PodInitialBackoffSeconds != nil {
 		in, out := &in.PodInitialBackoffSeconds, &out.PodInitialBackoffSeconds
 		*out = new(int64)

--- a/test/integration/scheduler/scheduler_test.go
+++ b/test/integration/scheduler/scheduler_test.go
@@ -274,8 +274,6 @@ priorities: []
 		stopCh := make(chan struct{})
 		eventBroadcaster.StartRecordingToSink(stopCh)
 
-		defaultBindTimeout := int64(30)
-
 		sched, err := scheduler.New(clientSet,
 			informerFactory,
 			scheduler.NewPodInformer(clientSet, 0),
@@ -289,7 +287,17 @@ priorities: []
 					},
 				},
 			}),
-			scheduler.WithBindTimeoutSeconds(defaultBindTimeout),
+			scheduler.WithProfiles(kubeschedulerconfig.KubeSchedulerProfile{
+				SchedulerName: v1.DefaultSchedulerName,
+				PluginConfig: []kubeschedulerconfig.PluginConfig{
+					{
+						Name: "VolumeBinding",
+						Args: &kubeschedulerconfig.VolumeBindingArgs{
+							BindTimeoutSeconds: 30,
+						},
+					},
+				},
+			}),
 		)
 		if err != nil {
 			t.Fatalf("couldn't make scheduler config for test %d: %v", i, err)
@@ -320,8 +328,6 @@ func TestSchedulerCreationFromNonExistentConfigMap(t *testing.T) {
 	stopCh := make(chan struct{})
 	eventBroadcaster.StartRecordingToSink(stopCh)
 
-	defaultBindTimeout := int64(30)
-
 	_, err := scheduler.New(clientSet,
 		informerFactory,
 		scheduler.NewPodInformer(clientSet, 0),
@@ -335,7 +341,18 @@ func TestSchedulerCreationFromNonExistentConfigMap(t *testing.T) {
 				},
 			},
 		}),
-		scheduler.WithBindTimeoutSeconds(defaultBindTimeout))
+		scheduler.WithProfiles(kubeschedulerconfig.KubeSchedulerProfile{
+			SchedulerName: v1.DefaultSchedulerName,
+			PluginConfig: []kubeschedulerconfig.PluginConfig{
+				{
+					Name: "VolumeBinding",
+					Args: &kubeschedulerconfig.VolumeBindingArgs{
+						BindTimeoutSeconds: 30,
+					},
+				},
+			},
+		}),
+	)
 
 	if err == nil {
 		t.Fatalf("Creation of scheduler didn't fail while the policy ConfigMap didn't exist.")

--- a/test/integration/util/util.go
+++ b/test/integration/util/util.go
@@ -391,7 +391,6 @@ func InitTestSchedulerWithOptions(
 	if policy != nil {
 		opts = append(opts, scheduler.WithAlgorithmSource(CreateAlgorithmSourceFromPolicy(policy, testCtx.ClientSet)))
 	}
-	opts = append([]scheduler.Option{scheduler.WithBindTimeoutSeconds(600)}, opts...)
 	testCtx.Scheduler, err = scheduler.New(
 		testCtx.ClientSet,
 		testCtx.InformerFactory,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
/kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
This PR removes `KubeSchedulerConfiguration.BindTimeoutSeconds` from v1beta1 (as for k8s 1.19 release, it's gone with v1alpha2 version). Starting from v1beta1, users can configure it via VolumeBinding plugin args.
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #90958 

**Special notes for your reviewer**:
the first commit contains auto-generated files only 
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md

removed release note: ACTION REQUIRED: `BindTimeoutSeconds` field in scheduler `KubeSchedulerConfiguration` is removed in v1beta1 version, please configure it via plugin args for `VolumeBinding`.
-->
```release-note
Remove `BindTimeoutSeconds` from schedule configuration `KubeSchedulerConfiguration`
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-scheduling/785-scheduler-component-config-api
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
[KEP]: https://github.com/kubernetes/enhancements/tree/1a55e249afccbfad7d87673073efd19dc6089ce2/keps/sig-scheduling/785-scheduler-component-config-api
```
