### PR TITLE
optimize insecure tls cipher checks within one loop

### DIFF
--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -60,7 +60,6 @@ import (
 	"k8s.io/client-go/util/connrotation"
 	"k8s.io/client-go/util/keyutil"
 	cloudprovider "k8s.io/cloud-provider"
-	"k8s.io/component-base/cli/flag"
 	cliflag "k8s.io/component-base/cli/flag"
 	"k8s.io/component-base/configz"
 	"k8s.io/component-base/featuregate"
@@ -1006,19 +1005,14 @@ func InitializeTLS(kf *options.KubeletFlags, kc *kubeletconfiginternal.KubeletCo
 		}
 	}
 
-	tlsCipherSuites, err := cliflag.TLSCipherSuites(kc.TLSCipherSuites)
+	tlsCipherSuites, insecureCipherNames, err := cliflag.TLSCipherSuites(kc.TLSCipherSuites)
 	if err != nil {
 		return nil, err
 	}
 
-	if len(tlsCipherSuites) > 0 {
-		insecureCiphers := flag.InsecureTLSCiphers()
-		for i := 0; i < len(tlsCipherSuites); i++ {
-			for cipherName, cipherID := range insecureCiphers {
-				if tlsCipherSuites[i] == cipherID {
-					klog.Warningf("Use of insecure cipher '%s' detected.", cipherName)
-				}
-			}
+	if len(insecureCipherNames) > 0 {
+		for _, cipherName := range insecureCipherNames {
+			klog.Warningf("Use of insecure cipher '%s' detected.", cipherName)
 		}
 	}
 

--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -1010,10 +1010,8 @@ func InitializeTLS(kf *options.KubeletFlags, kc *kubeletconfiginternal.KubeletCo
 		return nil, err
 	}
 
-	if len(insecureCipherNames) > 0 {
-		for _, cipherName := range insecureCipherNames {
-			klog.Warningf("Use of insecure cipher '%s' detected.", cipherName)
-		}
+	for _, cipherName := range insecureCipherNames {
+		klog.Warningf("Use of insecure cipher '%s' detected.", cipherName)
 	}
 
 	minTLSVersion, err := cliflag.TLSVersion(kc.TLSMinVersion)

--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -1005,12 +1005,12 @@ func InitializeTLS(kf *options.KubeletFlags, kc *kubeletconfiginternal.KubeletCo
 		}
 	}
 
-	tlsCipherSuites, insecureCipherNames, err := cliflag.TLSCipherSuites(kc.TLSCipherSuites)
+	tlsCipherSuites, err := cliflag.TLSCipherSuites(kc.TLSCipherSuites)
 	if err != nil {
 		return nil, err
 	}
 
-	for _, cipherName := range insecureCipherNames {
+	for _, cipherName := range cliflag.InsecureTLSCipherNamesUsed(kc.TLSCipherSuites) {
 		klog.Warningf("Use of insecure cipher '%s' detected.", cipherName)
 	}
 

--- a/staging/src/k8s.io/apiserver/pkg/server/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/server/BUILD
@@ -117,7 +117,6 @@ go_library(
         "//staging/src/k8s.io/apiserver/pkg/util/openapi:go_default_library",
         "//staging/src/k8s.io/client-go/informers:go_default_library",
         "//staging/src/k8s.io/client-go/rest:go_default_library",
-        "//staging/src/k8s.io/component-base/cli/flag:go_default_library",
         "//staging/src/k8s.io/component-base/logs:go_default_library",
         "//vendor/github.com/coreos/go-systemd/daemon:go_default_library",
         "//vendor/github.com/emicklei/go-restful:go_default_library",

--- a/staging/src/k8s.io/apiserver/pkg/server/options/serving.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/serving.go
@@ -255,11 +255,17 @@ func (s *SecureServingOptions) ApplyTo(config **server.SecureServingInfo) error 
 	}
 
 	if len(s.CipherSuites) != 0 {
-		cipherSuites, err := cliflag.TLSCipherSuites(s.CipherSuites)
+		cipherSuites, insecureCipherNames, err := cliflag.TLSCipherSuites(s.CipherSuites)
 		if err != nil {
 			return err
 		}
 		c.CipherSuites = cipherSuites
+
+		if len(insecureCipherNames) > 0 {
+			for _, cipherName := range insecureCipherNames {
+				klog.Warningf("Use of insecure cipher '%s' detected.", cipherName)
+			}
+		}
 	}
 
 	var err error

--- a/staging/src/k8s.io/apiserver/pkg/server/options/serving.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/serving.go
@@ -255,13 +255,13 @@ func (s *SecureServingOptions) ApplyTo(config **server.SecureServingInfo) error 
 	}
 
 	if len(s.CipherSuites) != 0 {
-		cipherSuites, insecureCipherNames, err := cliflag.TLSCipherSuites(s.CipherSuites)
+		cipherSuites, err := cliflag.TLSCipherSuites(s.CipherSuites)
 		if err != nil {
 			return err
 		}
 		c.CipherSuites = cipherSuites
 
-		for _, cipherName := range insecureCipherNames {
+		for _, cipherName := range cliflag.InsecureTLSCipherNamesUsed(s.CipherSuites) {
 			klog.Warningf("Use of insecure cipher '%s' detected.", cipherName)
 		}
 	}

--- a/staging/src/k8s.io/apiserver/pkg/server/options/serving.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/serving.go
@@ -261,10 +261,8 @@ func (s *SecureServingOptions) ApplyTo(config **server.SecureServingInfo) error 
 		}
 		c.CipherSuites = cipherSuites
 
-		if len(insecureCipherNames) > 0 {
-			for _, cipherName := range insecureCipherNames {
-				klog.Warningf("Use of insecure cipher '%s' detected.", cipherName)
-			}
+		for _, cipherName := range insecureCipherNames {
+			klog.Warningf("Use of insecure cipher '%s' detected.", cipherName)
 		}
 	}
 

--- a/staging/src/k8s.io/apiserver/pkg/server/secure_serving.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/secure_serving.go
@@ -25,7 +25,6 @@ import (
 	"time"
 
 	"golang.org/x/net/http2"
-	"k8s.io/component-base/cli/flag"
 	"k8s.io/klog/v2"
 
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -57,14 +56,6 @@ func (s *SecureServingInfo) tlsConfig(stopCh <-chan struct{}) (*tls.Config, erro
 	}
 	if len(s.CipherSuites) > 0 {
 		tlsConfig.CipherSuites = s.CipherSuites
-		insecureCiphers := flag.InsecureTLSCiphers()
-		for i := 0; i < len(s.CipherSuites); i++ {
-			for cipherName, cipherID := range insecureCiphers {
-				if s.CipherSuites[i] == cipherID {
-					klog.Warningf("Use of insecure cipher '%s' detected.", cipherName)
-				}
-			}
-		}
 	}
 
 	if s.ClientCA != nil {

--- a/staging/src/k8s.io/component-base/cli/flag/ciphersuites_flag.go
+++ b/staging/src/k8s.io/component-base/cli/flag/ciphersuites_flag.go
@@ -99,22 +99,19 @@ func TLSCipherPossibleValues() []string {
 	return cipherKeys.List()
 }
 
-// TLSCipherSuites returns a list of cipher suite IDs from the cipher suite names passed
-// and returns insecure cipher names matched.
+// TLSCipherSuites returns a list of cipher suite IDs from the cipher suite names passed.
 func TLSCipherSuites(cipherNames []string) ([]uint16, error) {
 	if len(cipherNames) == 0 {
 		return nil, nil
 	}
 	ciphersIntSlice := make([]uint16, 0)
-
 	possibleCiphers := allCiphers()
 	for _, cipher := range cipherNames {
 		intValue, ok := possibleCiphers[cipher]
 		if !ok {
-			return nil, fmt.Errorf("cipher suite %s not supported or doesn't exist", cipher)
+			return nil, fmt.Errorf("Cipher suite %s not supported or doesn't exist", cipher)
 		}
 		ciphersIntSlice = append(ciphersIntSlice, intValue)
-
 	}
 	return ciphersIntSlice, nil
 }

--- a/staging/src/k8s.io/component-base/cli/flag/ciphersuites_flag.go
+++ b/staging/src/k8s.io/component-base/cli/flag/ciphersuites_flag.go
@@ -58,16 +58,6 @@ var insecureCiphers = map[string]uint16{
 	"TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256":   tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,
 }
 
-// InsecureTLSCiphers returns the cipher suites implemented by crypto/tls which have
-// security issues.
-func InsecureTLSCiphers() map[string]uint16 {
-	cipherKeys := make(map[string]uint16, len(insecureCiphers))
-	for k, v := range insecureCiphers {
-		cipherKeys[k] = v
-	}
-	return cipherKeys
-}
-
 // InsecureTLSCipherNames returns a list of cipher suite names implemented by crypto/tls
 // which have security issues.
 func InsecureTLSCipherNames() []string {
@@ -111,25 +101,36 @@ func TLSCipherPossibleValues() []string {
 
 // TLSCipherSuites returns a list of cipher suite IDs from the cipher suite names passed
 // and returns insecure cipher names matched.
-func TLSCipherSuites(cipherNames []string) ([]uint16, []string, error) {
+func TLSCipherSuites(cipherNames []string) ([]uint16, error) {
 	if len(cipherNames) == 0 {
-		return nil, nil, nil
+		return nil, nil
 	}
 	ciphersIntSlice := make([]uint16, 0)
-	insecureCipherNamesMatched := make([]string, 0)
+
 	possibleCiphers := allCiphers()
 	for _, cipher := range cipherNames {
 		intValue, ok := possibleCiphers[cipher]
 		if !ok {
-			return nil, nil, fmt.Errorf("Cipher suite %s not supported or doesn't exist", cipher)
+			return nil, fmt.Errorf("cipher suite %s not supported or doesn't exist", cipher)
 		}
 		ciphersIntSlice = append(ciphersIntSlice, intValue)
 
-		if _, ok := insecureCiphers[cipher]; ok {
-			insecureCipherNamesMatched = append(insecureCipherNamesMatched, cipher)
+	}
+	return ciphersIntSlice, nil
+}
+
+// InsecureTLSCipherNamesUsed returns the cipher suites names implemented by crypto/tls which have
+// security issues.
+func InsecureTLSCipherNamesUsed(cipherNames []string) []string {
+	insecureCipherNamesMatched := make([]string, 0)
+
+	for _, cipherName := range cipherNames {
+		if _, ok := insecureCiphers[cipherName]; ok {
+			insecureCipherNamesMatched = append(insecureCipherNamesMatched, cipherName)
 		}
 	}
-	return ciphersIntSlice, insecureCipherNamesMatched, nil
+
+	return insecureCipherNamesMatched
 }
 
 var versions = map[string]uint16{

--- a/staging/src/k8s.io/component-base/cli/flag/ciphersuites_flag.go
+++ b/staging/src/k8s.io/component-base/cli/flag/ciphersuites_flag.go
@@ -109,21 +109,27 @@ func TLSCipherPossibleValues() []string {
 	return cipherKeys.List()
 }
 
-// TLSCipherSuites returns a list of cipher suite IDs from the cipher suite names passed.
-func TLSCipherSuites(cipherNames []string) ([]uint16, error) {
+// TLSCipherSuites returns a list of cipher suite IDs from the cipher suite names passed
+// and returns insecure cipher names matched.
+func TLSCipherSuites(cipherNames []string) ([]uint16, []string, error) {
 	if len(cipherNames) == 0 {
-		return nil, nil
+		return nil, nil, nil
 	}
 	ciphersIntSlice := make([]uint16, 0)
+	insecureCipherNamesMatched := make([]string, 0)
 	possibleCiphers := allCiphers()
 	for _, cipher := range cipherNames {
 		intValue, ok := possibleCiphers[cipher]
 		if !ok {
-			return nil, fmt.Errorf("Cipher suite %s not supported or doesn't exist", cipher)
+			return nil, nil, fmt.Errorf("Cipher suite %s not supported or doesn't exist", cipher)
 		}
 		ciphersIntSlice = append(ciphersIntSlice, intValue)
+
+		if _, ok := insecureCiphers[cipher]; ok {
+			insecureCipherNamesMatched = append(insecureCipherNamesMatched, cipher)
+		}
 	}
-	return ciphersIntSlice, nil
+	return ciphersIntSlice, insecureCipherNamesMatched, nil
 }
 
 var versions = map[string]uint16{

--- a/staging/src/k8s.io/component-base/cli/flag/ciphersuites_flag_test.go
+++ b/staging/src/k8s.io/component-base/cli/flag/ciphersuites_flag_test.go
@@ -64,13 +64,32 @@ func TestStrToUInt16(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		uIntFlags, err := TLSCipherSuites(test.flag)
+		uIntFlags, _, err := TLSCipherSuites(test.flag)
 		if reflect.DeepEqual(uIntFlags, test.expected) == false {
 			t.Errorf("%d: expected %+v, got %+v", i, test.expected, uIntFlags)
 		}
 		if test.expected_error && err == nil {
 			t.Errorf("%d: expecting error, got %+v", i, err)
 		}
+	}
+}
+
+func TestInsecureCiphersMatched(t *testing.T) {
+	testFlag := []string{"TLS_RSA_WITH_RC4_128_SHA", "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305"}
+	expectAll := []uint16{tls.TLS_RSA_WITH_RC4_128_SHA, tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305}
+	expectInsecure := []string{"TLS_RSA_WITH_RC4_128_SHA"}
+
+	actualAll, actualInsecure, err := TLSCipherSuites(testFlag)
+	if err != nil {
+		t.Errorf("expect no error, actual: %s", err)
+	}
+
+	if !reflect.DeepEqual(expectAll, actualAll) {
+		t.Errorf("expect all tls ciphers ids: %+v, actual: %+v", expectAll, actualAll)
+	}
+
+	if !reflect.DeepEqual(expectInsecure, actualInsecure) {
+		t.Errorf("expect insecure tls ciphers names: %+v, actual: %+v", expectInsecure, actualInsecure)
 	}
 }
 

--- a/staging/src/k8s.io/component-base/cli/flag/ciphersuites_flag_test.go
+++ b/staging/src/k8s.io/component-base/cli/flag/ciphersuites_flag_test.go
@@ -64,7 +64,7 @@ func TestStrToUInt16(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		uIntFlags, _, err := TLSCipherSuites(test.flag)
+		uIntFlags, err := TLSCipherSuites(test.flag)
 		if reflect.DeepEqual(uIntFlags, test.expected) == false {
 			t.Errorf("%d: expected %+v, got %+v", i, test.expected, uIntFlags)
 		}
@@ -74,22 +74,14 @@ func TestStrToUInt16(t *testing.T) {
 	}
 }
 
-func TestInsecureCiphersMatched(t *testing.T) {
-	testFlag := []string{"TLS_RSA_WITH_RC4_128_SHA", "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305"}
-	expectAll := []uint16{tls.TLS_RSA_WITH_RC4_128_SHA, tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305}
-	expectInsecure := []string{"TLS_RSA_WITH_RC4_128_SHA"}
+func TestInsecureTLSCipherNamesUsed(t *testing.T) {
+	cipherNames := []string{"TLS_RSA_WITH_RC4_128_SHA", "TLS_RSA_WITH_AES_256_CBC_SHA"}
 
-	actualAll, actualInsecure, err := TLSCipherSuites(testFlag)
-	if err != nil {
-		t.Errorf("expect no error, actual: %s", err)
-	}
+	expect := []string{"TLS_RSA_WITH_RC4_128_SHA"}
+	actual := InsecureTLSCipherNamesUsed(cipherNames)
 
-	if !reflect.DeepEqual(expectAll, actualAll) {
-		t.Errorf("expect all tls ciphers ids: %+v, actual: %+v", expectAll, actualAll)
-	}
-
-	if !reflect.DeepEqual(expectInsecure, actualInsecure) {
-		t.Errorf("expect insecure tls ciphers names: %+v, actual: %+v", expectInsecure, actualInsecure)
+	if reflect.DeepEqual(actual, expect) == false {
+		t.Errorf("expected %+v, got %+v", expect, actual)
 	}
 }
 


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**


> /kind cleanup

**What this PR does / why we need it**:

Old insecure cipher are checked by two for loops nested and one extra loop to fetch all insecure cipher Info, [here](https://github.com/kubernetes/kubernetes/blob/master/cmd/kubelet/app/server.go#L1014)
The new one will collect insecure ciphers within one loop to check all ciphers in flag valid or not.
```golang
func TLSCipherSuites(cipherNames []string) ([]uint16, []string, error) {
	if len(cipherNames) == 0 {
		return nil, nil, nil
	}
	ciphersIntSlice := make([]uint16, 0)
	insecureCipherNamesMatched := make([]string, 0)
	possibleCiphers := allCiphers()
	for _, cipher := range cipherNames {
		intValue, ok := possibleCiphers[cipher]
		if !ok {
			return nil, nil, fmt.Errorf("Cipher suite %s not supported or doesn't exist", cipher)
		}
		ciphersIntSlice = append(ciphersIntSlice, intValue)

		if _, ok := insecureCiphers[cipher]; ok {
			insecureCipherNamesMatched = append(insecureCipherNamesMatched, cipher)
		}
	}
	return ciphersIntSlice, insecureCipherNamesMatched, nil
}
```

Then:
```golang
//...
	tlsCipherSuites, insecureCipherNames, err := cliflag.TLSCipherSuites(kc.TLSCipherSuites)
	if err != nil {
		return nil, err
	}

	for _, cipherName := range insecureCipherNames {
		klog.Warningf("Use of insecure cipher '%s' detected.", cipherName)
	}

//...
```

Maybe that is cool than before.

**Which issue(s) this PR fixes**: 
none

Fixes # 
**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
