### PR TITLE
Automated cherry pick of #89451: fix a number of unbounded dimensions in request metrics

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/BUILD
@@ -6,12 +6,6 @@ load(
     "go_test",
 )
 
-go_test(
-    name = "go_default_test",
-    srcs = ["metrics_test.go"],
-    embed = [":go_default_library"],
-)
-
 go_library(
     name = "go_default_library",
     srcs = ["metrics.go"],
@@ -42,4 +36,10 @@ filegroup(
     name = "all-srcs",
     srcs = [":package-srcs"],
     tags = ["automanaged"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["metrics_test.go"],
+    embed = [":go_default_library"],
 )

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics_test.go
@@ -16,7 +16,12 @@ limitations under the License.
 
 package metrics
 
-import "testing"
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"testing"
+)
 
 func TestCleanUserAgent(t *testing.T) {
 	panicBuf := []byte{198, 73, 129, 133, 90, 216, 104, 29, 13, 134, 209, 233, 30, 0, 22}
@@ -50,5 +55,133 @@ func TestCleanUserAgent(t *testing.T) {
 		if cleanUserAgent(tc.In) != tc.Out {
 			t.Errorf("Failed to clean User-Agent: %s", tc.In)
 		}
+	}
+}
+func TestCleanVerb(t *testing.T) {
+	testCases := []struct {
+		desc         string
+		initialVerb  string
+		request      *http.Request
+		expectedVerb string
+	}{
+		{
+			desc:         "An empty string should be designated as unknown",
+			initialVerb:  "",
+			request:      nil,
+			expectedVerb: "other",
+		},
+		{
+			desc:         "LIST should normally map to LIST",
+			initialVerb:  "LIST",
+			request:      nil,
+			expectedVerb: "LIST",
+		},
+		{
+			desc:        "LIST should be transformed to WATCH if we have the right query param on the request",
+			initialVerb: "LIST",
+			request: &http.Request{
+				URL: &url.URL{
+					RawQuery: "watch=true",
+				},
+			},
+			expectedVerb: "WATCH",
+		},
+		{
+			desc:        "LIST isn't transformed to WATCH if we have query params that do not include watch",
+			initialVerb: "LIST",
+			request: &http.Request{
+				URL: &url.URL{
+					RawQuery: "blah=asdf&something=else",
+				},
+			},
+			expectedVerb: "LIST",
+		},
+		{
+			desc:         "WATCHLIST should be transformed to WATCH",
+			initialVerb:  "WATCHLIST",
+			request:      nil,
+			expectedVerb: "WATCH",
+		},
+		{
+			desc:        "PATCH should be transformed to APPLY with the right content type",
+			initialVerb: "PATCH",
+			request: &http.Request{
+				Header: http.Header{
+					"Content-Type": []string{"application/apply-patch+yaml"},
+				},
+			},
+			expectedVerb: "APPLY",
+		},
+		{
+			desc:         "PATCH shouldn't be transformed to APPLY without the right content type",
+			initialVerb:  "PATCH",
+			request:      nil,
+			expectedVerb: "PATCH",
+		},
+		{
+			desc:         "WATCHLIST should be transformed to WATCH",
+			initialVerb:  "WATCHLIST",
+			request:      nil,
+			expectedVerb: "WATCH",
+		},
+		{
+			desc:         "unexpected verbs should be designated as unknown",
+			initialVerb:  "notValid",
+			request:      nil,
+			expectedVerb: "other",
+		},
+	}
+	for _, tt := range testCases {
+		t.Run(tt.initialVerb, func(t *testing.T) {
+			req := &http.Request{URL: &url.URL{}}
+			if tt.request != nil {
+				req = tt.request
+			}
+			cleansedVerb := cleanVerb(tt.initialVerb, req)
+			if cleansedVerb != tt.expectedVerb {
+				t.Errorf("Got %s, but expected %s", cleansedVerb, tt.expectedVerb)
+			}
+		})
+	}
+}
+
+func TestContentType(t *testing.T) {
+	testCases := []struct {
+		rawContentType      string
+		expectedContentType string
+	}{
+		{
+			rawContentType:      "application/json",
+			expectedContentType: "application/json",
+		},
+		{
+			rawContentType:      "image/svg+xml",
+			expectedContentType: "other",
+		},
+		{
+			rawContentType:      "text/plain; charset=utf-8",
+			expectedContentType: "text/plain;charset=utf-8",
+		},
+		{
+			rawContentType:      "application/json;foo=bar",
+			expectedContentType: "other",
+		},
+		{
+			rawContentType:      "application/json;charset=hancoding",
+			expectedContentType: "other",
+		},
+		{
+			rawContentType:      "unknownbutvalidtype",
+			expectedContentType: "other",
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(fmt.Sprintf("parse %s", tt.rawContentType), func(t *testing.T) {
+			cleansedContentType := cleanContentType(tt.rawContentType)
+			if cleansedContentType != tt.expectedContentType {
+				t.Errorf("Got %s, but expected %s", cleansedContentType, tt.expectedContentType)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Cherry pick of #89451 on release-1.16.

#89451: fix a number of unbounded dimensions in request metrics

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.