### PR TITLE
Migrate a single node_authorizer.go klog.Infof call to klog.InfoS

### DIFF
--- a/plugin/pkg/auth/authorizer/node/node_authorizer.go
+++ b/plugin/pkg/auth/authorizer/node/node_authorizer.go
@@ -206,7 +206,7 @@ func (r *NodeAuthorizer) authorize(nodeName string, startingType vertexType, att
 
 	ok, err := r.hasPathFrom(nodeName, startingType, attrs.GetNamespace(), attrs.GetName())
 	if err != nil {
-		klog.V(2).Infof("NODE DENY: %v", err)
+		klog.V(2).InfoS("NODE DENY", "err", err)
 		return authorizer.DecisionNoOpinion, fmt.Sprintf("no relationship found between node %q and this object", nodeName), nil
 	}
 	if !ok {

--- a/plugin/pkg/auth/authorizer/node/node_authorizer.go
+++ b/plugin/pkg/auth/authorizer/node/node_authorizer.go
@@ -151,12 +151,12 @@ func (r *NodeAuthorizer) authorizeStatusUpdate(nodeName string, startingType ver
 	case "update", "patch":
 		// ok
 	default:
-		klog.V(2).Infof("NODE DENY: %s %#v", nodeName, attrs)
+		klog.V(2).Infof("NODE DENY: '%s' %#v", nodeName, attrs)
 		return authorizer.DecisionNoOpinion, "can only get/update/patch this type", nil
 	}
 
 	if attrs.GetSubresource() != "status" {
-		klog.V(2).Infof("NODE DENY: %s %#v", nodeName, attrs)
+		klog.V(2).Infof("NODE DENY: '%s' %#v", nodeName, attrs)
 		return authorizer.DecisionNoOpinion, "can only update status subresource", nil
 	}
 
@@ -166,11 +166,11 @@ func (r *NodeAuthorizer) authorizeStatusUpdate(nodeName string, startingType ver
 // authorizeGet authorizes "get" requests to objects of the specified type if they are related to the specified node
 func (r *NodeAuthorizer) authorizeGet(nodeName string, startingType vertexType, attrs authorizer.Attributes) (authorizer.Decision, string, error) {
 	if attrs.GetVerb() != "get" {
-		klog.V(2).Infof("NODE DENY: %s %#v", nodeName, attrs)
+		klog.V(2).Infof("NODE DENY: '%s' %#v", nodeName, attrs)
 		return authorizer.DecisionNoOpinion, "can only get individual resources of this type", nil
 	}
 	if len(attrs.GetSubresource()) > 0 {
-		klog.V(2).Infof("NODE DENY: %s %#v", nodeName, attrs)
+		klog.V(2).Infof("NODE DENY: '%s' %#v", nodeName, attrs)
 		return authorizer.DecisionNoOpinion, "cannot get subresource", nil
 	}
 	return r.authorize(nodeName, startingType, attrs)
@@ -183,16 +183,16 @@ func (r *NodeAuthorizer) authorizeReadNamespacedObject(nodeName string, starting
 	case "get", "list", "watch":
 		//ok
 	default:
-		klog.V(2).Infof("NODE DENY: %s %#v", nodeName, attrs)
+		klog.V(2).Infof("NODE DENY: '%s' %#v", nodeName, attrs)
 		return authorizer.DecisionNoOpinion, "can only read resources of this type", nil
 	}
 
 	if len(attrs.GetSubresource()) > 0 {
-		klog.V(2).Infof("NODE DENY: %s %#v", nodeName, attrs)
+		klog.V(2).Infof("NODE DENY: '%s' %#v", nodeName, attrs)
 		return authorizer.DecisionNoOpinion, "cannot read subresource", nil
 	}
 	if len(attrs.GetNamespace()) == 0 {
-		klog.V(2).Infof("NODE DENY: %s %#v", nodeName, attrs)
+		klog.V(2).Infof("NODE DENY: '%s' %#v", nodeName, attrs)
 		return authorizer.DecisionNoOpinion, "can only read namespaced object of this type", nil
 	}
 	return r.authorize(nodeName, startingType, attrs)
@@ -200,18 +200,18 @@ func (r *NodeAuthorizer) authorizeReadNamespacedObject(nodeName string, starting
 
 func (r *NodeAuthorizer) authorize(nodeName string, startingType vertexType, attrs authorizer.Attributes) (authorizer.Decision, string, error) {
 	if len(attrs.GetName()) == 0 {
-		klog.V(2).Infof("NODE DENY: %s %#v", nodeName, attrs)
+		klog.V(2).Infof("NODE DENY: '%s' %#v", nodeName, attrs)
 		return authorizer.DecisionNoOpinion, "No Object name found", nil
 	}
 
 	ok, err := r.hasPathFrom(nodeName, startingType, attrs.GetNamespace(), attrs.GetName())
 	if err != nil {
 		klog.V(2).InfoS("NODE DENY", "err", err)
-		return authorizer.DecisionNoOpinion, fmt.Sprintf("no relationship found between node %s and this object", nodeName), nil
+		return authorizer.DecisionNoOpinion, fmt.Sprintf("no relationship found between node '%s' and this object", nodeName), nil
 	}
 	if !ok {
-		klog.V(2).Infof("NODE DENY: %s %#v", nodeName, attrs)
-		return authorizer.DecisionNoOpinion, fmt.Sprintf("no relationship found between node %s and this object", nodeName), nil
+		klog.V(2).Infof("NODE DENY: '%s' %#v", nodeName, attrs)
+		return authorizer.DecisionNoOpinion, fmt.Sprintf("no relationship found between node '%s' and this object", nodeName), nil
 	}
 	return authorizer.DecisionAllow, "", nil
 }
@@ -220,23 +220,23 @@ func (r *NodeAuthorizer) authorize(nodeName string, startingType vertexType, att
 // subresource of pods running on a node
 func (r *NodeAuthorizer) authorizeCreateToken(nodeName string, startingType vertexType, attrs authorizer.Attributes) (authorizer.Decision, string, error) {
 	if attrs.GetVerb() != "create" || len(attrs.GetName()) == 0 {
-		klog.V(2).Infof("NODE DENY: %s %#v", nodeName, attrs)
+		klog.V(2).Infof("NODE DENY: '%s' %#v", nodeName, attrs)
 		return authorizer.DecisionNoOpinion, "can only create tokens for individual service accounts", nil
 	}
 
 	if attrs.GetSubresource() != "token" {
-		klog.V(2).Infof("NODE DENY: %s %#v", nodeName, attrs)
+		klog.V(2).Infof("NODE DENY: '%s' %#v", nodeName, attrs)
 		return authorizer.DecisionNoOpinion, "can only create token subresource of serviceaccount", nil
 	}
 
 	ok, err := r.hasPathFrom(nodeName, startingType, attrs.GetNamespace(), attrs.GetName())
 	if err != nil {
 		klog.V(2).Infof("NODE DENY: %v", err)
-		return authorizer.DecisionNoOpinion, fmt.Sprintf("no relationship found between node %s and this object", nodeName), nil
+		return authorizer.DecisionNoOpinion, fmt.Sprintf("no relationship found between node '%s' and this object", nodeName), nil
 	}
 	if !ok {
-		klog.V(2).Infof("NODE DENY: %s %#v", nodeName, attrs)
-		return authorizer.DecisionNoOpinion, fmt.Sprintf("no relationship found between node %s and this object", nodeName), nil
+		klog.V(2).Infof("NODE DENY: '%s' %#v", nodeName, attrs)
+		return authorizer.DecisionNoOpinion, fmt.Sprintf("no relationship found between node '%s' and this object", nodeName), nil
 	}
 	return authorizer.DecisionAllow, "", nil
 }
@@ -249,13 +249,13 @@ func (r *NodeAuthorizer) authorizeLease(nodeName string, attrs authorizer.Attrib
 	case "get", "create", "update", "patch", "delete":
 		//ok
 	default:
-		klog.V(2).Infof("NODE DENY: %s %#v", nodeName, attrs)
+		klog.V(2).Infof("NODE DENY: '%s' %#v", nodeName, attrs)
 		return authorizer.DecisionNoOpinion, "can only get, create, update, patch, or delete a node lease", nil
 	}
 
 	// the request must be against the system namespace reserved for node leases
 	if attrs.GetNamespace() != api.NamespaceNodeLease {
-		klog.V(2).Infof("NODE DENY: %s %#v", nodeName, attrs)
+		klog.V(2).Infof("NODE DENY: '%s' %#v", nodeName, attrs)
 		return authorizer.DecisionNoOpinion, fmt.Sprintf("can only access leases in the %q system namespace", api.NamespaceNodeLease), nil
 	}
 
@@ -263,7 +263,7 @@ func (r *NodeAuthorizer) authorizeLease(nodeName string, attrs authorizer.Attrib
 	// note we skip this check for create, since the authorizer doesn't know the name on create
 	// the noderestriction admission plugin is capable of performing this check at create time
 	if verb != "create" && attrs.GetName() != nodeName {
-		klog.V(2).Infof("NODE DENY: %s %#v", nodeName, attrs)
+		klog.V(2).Infof("NODE DENY: '%s' %#v", nodeName, attrs)
 		return authorizer.DecisionNoOpinion, "can only access node lease with the same name as the requesting node", nil
 	}
 
@@ -278,12 +278,12 @@ func (r *NodeAuthorizer) authorizeCSINode(nodeName string, attrs authorizer.Attr
 	case "get", "create", "update", "patch", "delete":
 		//ok
 	default:
-		klog.V(2).Infof("NODE DENY: %s %#v", nodeName, attrs)
+		klog.V(2).Infof("NODE DENY: '%s' %#v", nodeName, attrs)
 		return authorizer.DecisionNoOpinion, "can only get, create, update, patch, or delete a CSINode", nil
 	}
 
 	if len(attrs.GetSubresource()) > 0 {
-		klog.V(2).Infof("NODE DENY: %s %#v", nodeName, attrs)
+		klog.V(2).Infof("NODE DENY: '%s' %#v", nodeName, attrs)
 		return authorizer.DecisionNoOpinion, "cannot authorize CSINode subresources", nil
 	}
 
@@ -291,7 +291,7 @@ func (r *NodeAuthorizer) authorizeCSINode(nodeName string, attrs authorizer.Attr
 	// note we skip this check for create, since the authorizer doesn't know the name on create
 	// the noderestriction admission plugin is capable of performing this check at create time
 	if verb != "create" && attrs.GetName() != nodeName {
-		klog.V(2).Infof("NODE DENY: %s %#v", nodeName, attrs)
+		klog.V(2).Infof("NODE DENY: '%s' %#v", nodeName, attrs)
 		return authorizer.DecisionNoOpinion, "can only access CSINode with the same name as the requesting node", nil
 	}
 
@@ -305,12 +305,12 @@ func (r *NodeAuthorizer) hasPathFrom(nodeName string, startingType vertexType, s
 
 	nodeVertex, exists := r.graph.getVertex_rlocked(nodeVertexType, "", nodeName)
 	if !exists {
-		return false, fmt.Errorf("unknown node %s cannot get %s %s/%s", nodeName, vertexTypes[startingType], startingNamespace, startingName)
+		return false, fmt.Errorf("unknown node '%s' cannot get %s %s/%s", nodeName, vertexTypes[startingType], startingNamespace, startingName)
 	}
 
 	startingVertex, exists := r.graph.getVertex_rlocked(startingType, startingNamespace, startingName)
 	if !exists {
-		return false, fmt.Errorf("node %s cannot get unknown %s %s/%s", nodeName, vertexTypes[startingType], startingNamespace, startingName)
+		return false, fmt.Errorf("node '%s' cannot get unknown %s %s/%s", nodeName, vertexTypes[startingType], startingNamespace, startingName)
 	}
 
 	// Fast check to see if we know of a destination edge
@@ -342,7 +342,7 @@ func (r *NodeAuthorizer) hasPathFrom(nodeName string, startingType vertexType, s
 		return found
 	})
 	if !found {
-		return false, fmt.Errorf("node %s cannot get %s %s/%s, no relationship to this object was found in the node authorizer graph", nodeName, vertexTypes[startingType], startingNamespace, startingName)
+		return false, fmt.Errorf("node '%s' cannot get %s %s/%s, no relationship to this object was found in the node authorizer graph", nodeName, vertexTypes[startingType], startingNamespace, startingName)
 	}
 	return true, nil
 }

--- a/plugin/pkg/auth/authorizer/node/node_authorizer.go
+++ b/plugin/pkg/auth/authorizer/node/node_authorizer.go
@@ -207,11 +207,11 @@ func (r *NodeAuthorizer) authorize(nodeName string, startingType vertexType, att
 	ok, err := r.hasPathFrom(nodeName, startingType, attrs.GetNamespace(), attrs.GetName())
 	if err != nil {
 		klog.V(2).InfoS("NODE DENY", "err", err)
-		return authorizer.DecisionNoOpinion, fmt.Sprintf("no relationship found between node %q and this object", nodeName), nil
+		return authorizer.DecisionNoOpinion, fmt.Sprintf("no relationship found between node %s and this object", nodeName), nil
 	}
 	if !ok {
-		klog.V(2).Infof("NODE DENY: %q %#v", nodeName, attrs)
-		return authorizer.DecisionNoOpinion, fmt.Sprintf("no relationship found between node %q and this object", nodeName), nil
+		klog.V(2).Infof("NODE DENY: %s %#v", nodeName, attrs)
+		return authorizer.DecisionNoOpinion, fmt.Sprintf("no relationship found between node %s and this object", nodeName), nil
 	}
 	return authorizer.DecisionAllow, "", nil
 }
@@ -232,11 +232,11 @@ func (r *NodeAuthorizer) authorizeCreateToken(nodeName string, startingType vert
 	ok, err := r.hasPathFrom(nodeName, startingType, attrs.GetNamespace(), attrs.GetName())
 	if err != nil {
 		klog.V(2).Infof("NODE DENY: %v", err)
-		return authorizer.DecisionNoOpinion, fmt.Sprintf("no relationship found between node %q and this object", nodeName), nil
+		return authorizer.DecisionNoOpinion, fmt.Sprintf("no relationship found between node %s and this object", nodeName), nil
 	}
 	if !ok {
-		klog.V(2).Infof("NODE DENY: %q %#v", nodeName, attrs)
-		return authorizer.DecisionNoOpinion, fmt.Sprintf("no relationship found between node %q and this object", nodeName), nil
+		klog.V(2).Infof("NODE DENY: %s %#v", nodeName, attrs)
+		return authorizer.DecisionNoOpinion, fmt.Sprintf("no relationship found between node %s and this object", nodeName), nil
 	}
 	return authorizer.DecisionAllow, "", nil
 }
@@ -305,12 +305,12 @@ func (r *NodeAuthorizer) hasPathFrom(nodeName string, startingType vertexType, s
 
 	nodeVertex, exists := r.graph.getVertex_rlocked(nodeVertexType, "", nodeName)
 	if !exists {
-		return false, fmt.Errorf("unknown node %q cannot get %s %s/%s", nodeName, vertexTypes[startingType], startingNamespace, startingName)
+		return false, fmt.Errorf("unknown node %s cannot get %s %s/%s", nodeName, vertexTypes[startingType], startingNamespace, startingName)
 	}
 
 	startingVertex, exists := r.graph.getVertex_rlocked(startingType, startingNamespace, startingName)
 	if !exists {
-		return false, fmt.Errorf("node %q cannot get unknown %s %s/%s", nodeName, vertexTypes[startingType], startingNamespace, startingName)
+		return false, fmt.Errorf("node %s cannot get unknown %s %s/%s", nodeName, vertexTypes[startingType], startingNamespace, startingName)
 	}
 
 	// Fast check to see if we know of a destination edge

--- a/plugin/pkg/auth/authorizer/node/node_authorizer.go
+++ b/plugin/pkg/auth/authorizer/node/node_authorizer.go
@@ -342,7 +342,7 @@ func (r *NodeAuthorizer) hasPathFrom(nodeName string, startingType vertexType, s
 		return found
 	})
 	if !found {
-		return false, fmt.Errorf("node %q cannot get %s %s/%s, no relationship to this object was found in the node authorizer graph", nodeName, vertexTypes[startingType], startingNamespace, startingName)
+		return false, fmt.Errorf("node %s cannot get %s %s/%s, no relationship to this object was found in the node authorizer graph", nodeName, vertexTypes[startingType], startingNamespace, startingName)
 	}
 	return true, nil
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

We are starting to migrate the most popular log lines to use structured logging.

Ref:
* Structured logging KEP: https://github.com/kubernetes/enhancements/tree/master/keps/sig-instrumentation/1602-structured-logging
* Structured logging work tracking: https://github.com/kubernetes/enhancements/issues/1602

**Special notes for your reviewer**:

I assumed that I should only move over the single `NODE DENY` log line as referenced in https://github.com/kubernetes/enhancements/issues/1602#issue-577135877; I figured if I was wrong about that assumption, I could hear about it after I opened a PR.

```release-note
NONE
```