### PR TITLE
remove unused variable from autoscaling e2e

### DIFF
--- a/test/e2e/autoscaling/cluster_size_autoscaling.go
+++ b/test/e2e/autoscaling/cluster_size_autoscaling.go
@@ -95,7 +95,6 @@ var _ = SIGDescribe("Cluster size autoscaling [Slow]", func() {
 	f := framework.NewDefaultFramework("autoscaling")
 	var c clientset.Interface
 	var nodeCount int
-	var coreCount int64
 	var memAllocatableMb int
 	var originalSizes map[string]int
 
@@ -118,11 +117,6 @@ var _ = SIGDescribe("Cluster size autoscaling [Slow]", func() {
 		nodes, err := e2enode.GetReadySchedulableNodes(f.ClientSet)
 		framework.ExpectNoError(err)
 		nodeCount = len(nodes.Items)
-		coreCount = 0
-		for _, node := range nodes.Items {
-			quantity := node.Status.Allocatable[v1.ResourceCPU]
-			coreCount += quantity.Value()
-		}
 		ginkgo.By(fmt.Sprintf("Initial number of schedulable nodes: %v", nodeCount))
 		framework.ExpectNotEqual(nodeCount, 0)
 		mem := nodes.Items[0].Status.Allocatable[v1.ResourceMemory]


### PR DESCRIPTION
/kind cleanup
/area test

**What this PR does / why we need it**:

This change removes the `coreCount` variable and associated counting
logic from the cluster size autoscaling test. This variable was used
during the 1.9 release era, but the tests that used it were removed
before the 1.10 release. Please see the referenced commits[0][1] for more
information.

[0] https://github.com/kubernetes/kubernetes/commit/c8b807837a381003981f75b9dff5d8cd79e7750d
[1] https://github.com/kubernetes/kubernetes/commit/fd738945b1c4376a9303c2034ddb32988eaeea5c

**Does this PR introduce a user-facing change?**:
```
NONE
```