### PR TITLE
Add a well-known Secrets key for CA certificate bundles.

### DIFF
--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -5592,10 +5592,12 @@ const (
 	// TODO: Consider supporting different formats, specifying CA/destinationCA.
 	SecretTypeTLS SecretType = "kubernetes.io/tls"
 
-	// TLSCertKey is the key for tls certificates in a TLS secert.
+	// TLSCertKey is the key for TLS certificates in a TLS secret.
 	TLSCertKey = "tls.crt"
 	// TLSPrivateKeyKey is the key for the private key field in a TLS secret.
 	TLSPrivateKeyKey = "tls.key"
+	// TLSCABundleKey is the certificate bundle from the CA that issued the TLS certificate.
+	TLSCABundleKey = "ca.crt"
 	// SecretTypeBootstrapToken is used during the automated bootstrap process (first
 	// implemented by kubeadm). It stores tokens that are used to sign well known
 	// ConfigMaps. They are used for authn.

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_secret.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_secret.go
@@ -283,6 +283,7 @@ func NewCmdCreateSecretTLS(f cmdutil.Factory, ioStreams genericclioptions.IOStre
 	cmdutil.AddGeneratorFlags(cmd, generateversioned.SecretForTLSV1GeneratorName)
 	cmd.Flags().String("cert", "", i18n.T("Path to PEM encoded public key certificate."))
 	cmd.Flags().String("key", "", i18n.T("Path to private key associated with given certificate."))
+	cmd.Flags().String("ca", "", i18n.T("Path to CA certificate bundle associated with given certificate."))
 	cmd.Flags().Bool("append-hash", false, "Append a hash of the secret to its name.")
 	cmdutil.AddFieldManagerFlagVar(cmd, &options.CreateSubcommandOptions.FieldManager, "kubectl-create")
 	return cmd
@@ -308,6 +309,7 @@ func (o *SecretTLSOpts) Complete(f cmdutil.Factory, cmd *cobra.Command, args []s
 			Name:       name,
 			Key:        cmdutil.GetFlagString(cmd, "key"),
 			Cert:       cmdutil.GetFlagString(cmd, "cert"),
+			CABundle:   cmdutil.GetFlagString(cmd, "ca"),
 			AppendHash: cmdutil.GetFlagBool(cmd, "append-hash"),
 		}
 	default:

--- a/staging/src/k8s.io/kubectl/pkg/generate/versioned/secret_for_tls_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/generate/versioned/secret_for_tls_test.go
@@ -23,7 +23,7 @@ import (
 	"reflect"
 	"testing"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utiltesting "k8s.io/client-go/util/testing"
 )
@@ -148,6 +148,27 @@ func TestSecretForTLSGenerate(t *testing.T) {
 			expectErr: false,
 		},
 		{
+			name: "test-valid-tls-secret-with-ca",
+			params: map[string]interface{}{
+				"name": "foo",
+				"key":  validKeyPath,
+				"cert": validCertPath,
+				"ca":   validCertPath,
+			},
+			expected: &v1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "foo",
+				},
+				Data: map[string][]byte{
+					v1.TLSCertKey:       []byte(rsaCertPEM),
+					v1.TLSPrivateKeyKey: []byte(rsaKeyPEM),
+					v1.TLSCABundleKey:   []byte(rsaCertPEM),
+				},
+				Type: v1.SecretTypeTLS,
+			},
+			expectErr: false,
+		},
+		{
 			name: "test-valid-tls-secret-append-hash",
 			params: map[string]interface{}{
 				"name":        "foo",
@@ -181,6 +202,27 @@ func TestSecretForTLSGenerate(t *testing.T) {
 				Data: map[string][]byte{
 					v1.TLSCertKey:       []byte("test"),
 					v1.TLSPrivateKeyKey: []byte("test"),
+				},
+				Type: v1.SecretTypeTLS,
+			},
+			expectErr: true,
+		},
+		{
+			name: "test-invalid-ca",
+			params: map[string]interface{}{
+				"name": "foo",
+				"key":  validKeyPath,
+				"cert": validCertPath,
+				"ca":   validKeyPath, // No valid certificates in this file.
+			},
+			expected: &v1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "foo",
+				},
+				Data: map[string][]byte{
+					v1.TLSCertKey:       []byte("test"),
+					v1.TLSPrivateKeyKey: []byte("test"),
+					v1.TLSCABundleKey:   []byte("test"),
 				},
 				Type: v1.SecretTypeTLS,
 			},


### PR DESCRIPTION

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Add a well-known key for storing the CA certificate bundle in TLS
secrets. This key is supported by cert-manager and a number of Ingress
controller projects.

Add support for creating secrets with the new key to kubectl.

**Which issue(s) this PR fixes**:

Fixes #91353.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Adds the `--ca` flag to the the `kubectl create secret tls` command.
Adds the `TLSCABundleKey` constant.
```
