### PR TITLE
Configure strict encoding for RequestedToCapacityRatioArgs

### DIFF
--- a/api/api-rules/violation_exceptions.list
+++ b/api/api-rules/violation_exceptions.list
@@ -586,10 +586,6 @@ API rule violation: names_match,k8s.io/kube-controller-manager/config/v1alpha1,V
 API rule violation: names_match,k8s.io/kube-controller-manager/config/v1alpha1,VolumeConfiguration,PersistentVolumeRecyclerConfiguration
 API rule violation: names_match,k8s.io/kube-proxy/config/v1alpha1,KubeProxyConfiguration,IPTables
 API rule violation: names_match,k8s.io/kube-scheduler/config/v1,Extender,EnableHTTPS
-API rule violation: names_match,k8s.io/kube-scheduler/config/v1beta1,ResourceSpec,Name
-API rule violation: names_match,k8s.io/kube-scheduler/config/v1beta1,ResourceSpec,Weight
-API rule violation: names_match,k8s.io/kube-scheduler/config/v1beta1,UtilizationShapePoint,Score
-API rule violation: names_match,k8s.io/kube-scheduler/config/v1beta1,UtilizationShapePoint,Utilization
 API rule violation: names_match,k8s.io/kubelet/config/v1beta1,KubeletConfiguration,IPTablesDropBit
 API rule violation: names_match,k8s.io/kubelet/config/v1beta1,KubeletConfiguration,IPTablesMasqueradeBit
 API rule violation: names_match,k8s.io/kubelet/config/v1beta1,KubeletConfiguration,ResolverConfig

--- a/pkg/scheduler/apis/config/scheme/scheme_test.go
+++ b/pkg/scheduler/apis/config/scheme/scheme_test.go
@@ -21,7 +21,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/kube-scheduler/config/v1beta1"
@@ -108,8 +108,8 @@ profiles:
 						{
 							Name: "PodTopologySpread",
 							Args: &config.PodTopologySpreadArgs{
-								DefaultConstraints: []v1.TopologySpreadConstraint{
-									{MaxSkew: 1, TopologyKey: "zone", WhenUnsatisfiable: v1.ScheduleAnyway},
+								DefaultConstraints: []corev1.TopologySpreadConstraint{
+									{MaxSkew: 1, TopologyKey: "zone", WhenUnsatisfiable: corev1.ScheduleAnyway},
 								},
 							},
 						},
@@ -178,11 +178,25 @@ profiles:
       apiVersion: kubescheduler.config.k8s.io/v1beta1
       kind: InterPodAffinityArgs
 `),
-			wantErr: "decoding .profiles[0].pluginConfig[0]: args for plugin NodeLabel were not of type NodeLabelArgs.kubescheduler.config.k8s.io, got InterPodAffinityArgs.kubescheduler.config.k8s.io",
+			wantErr: `decoding .profiles[0].pluginConfig[0]: args for plugin NodeLabel were not of type NodeLabelArgs.kubescheduler.config.k8s.io, got InterPodAffinityArgs.kubescheduler.config.k8s.io`,
 		},
 		{
-			// TODO: do not replicate this case for v1beta1.
-			name: "v1beta1 case insensitive RequestedToCapacityRatioArgs",
+			name: "v1beta1 RequestedToCapacityRatioArgs shape encoding is strict",
+			data: []byte(`
+apiVersion: kubescheduler.config.k8s.io/v1beta1
+kind: KubeSchedulerConfiguration
+profiles:
+- pluginConfig:
+  - name: RequestedToCapacityRatio
+    args:
+      shape:
+      - Utilization: 1
+        Score: 2
+`),
+			wantErr: `decoding .profiles[0].pluginConfig[0]: decoding args for plugin RequestedToCapacityRatio: strict decoder error for {"shape":[{"Score":2,"Utilization":1}]}: v1beta1.RequestedToCapacityRatioArgs.Shape: []v1beta1.UtilizationShapePoint: v1beta1.UtilizationShapePoint.ReadObject: found unknown field: Score, error found in #10 byte of ...|:[{"Score":2,"Utiliz|..., bigger context ...|{"shape":[{"Score":2,"Utilization":1}]}|...`,
+		},
+		{
+			name: "v1beta1 RequestedToCapacityRatioArgs resources encoding is strict",
 			data: []byte(`
 apiVersion: kubescheduler.config.k8s.io/v1beta1
 kind: KubeSchedulerConfiguration
@@ -193,34 +207,11 @@ profiles:
       shape:
       - utilization: 1
         score: 2
-      - Utilization: 3
-        Score: 4
       resources:
-      - name: Upper
-        weight: 1
-      - Name: lower
-        weight: 2
+      - Name: 1
+        Weight: 2
 `),
-			wantProfiles: []config.KubeSchedulerProfile{
-				{
-					SchedulerName: "default-scheduler",
-					PluginConfig: []config.PluginConfig{
-						{
-							Name: "RequestedToCapacityRatio",
-							Args: &config.RequestedToCapacityRatioArgs{
-								Shape: []config.UtilizationShapePoint{
-									{Utilization: 1, Score: 2},
-									{Utilization: 3, Score: 4},
-								},
-								Resources: []config.ResourceSpec{
-									{Name: "Upper", Weight: 1},
-									{Name: "lower", Weight: 2},
-								},
-							},
-						},
-					},
-				},
-			},
+			wantErr: `decoding .profiles[0].pluginConfig[0]: decoding args for plugin RequestedToCapacityRatio: strict decoder error for {"resources":[{"Name":1,"Weight":2}],"shape":[{"score":2,"utilization":1}]}: v1beta1.RequestedToCapacityRatioArgs.Shape: []v1beta1.UtilizationShapePoint: Resources: []v1beta1.ResourceSpec: v1beta1.ResourceSpec.ReadObject: found unknown field: Name, error found in #10 byte of ...|":[{"Name":1,"Weight|..., bigger context ...|{"resources":[{"Name":1,"Weight":2}],"shape":[{"score":2,"utilization":|...`,
 		},
 		{
 			name: "out-of-tree plugin args",
@@ -311,7 +302,7 @@ profiles:
 			obj, gvk, err := decoder.Decode(tt.data, nil, nil)
 			if err != nil {
 				if tt.wantErr != err.Error() {
-					t.Fatalf("got err %v, want %v", err.Error(), tt.wantErr)
+					t.Fatalf("\ngot err:\n\t%v\nwant:\n\t%s", err, tt.wantErr)
 				}
 				return
 			}
@@ -367,7 +358,7 @@ func TestCodecsEncodePluginConfig(t *testing.T) {
 											{Utilization: 1, Score: 2},
 										},
 										Resources: []v1beta1.ResourceSpec{
-											{Name: "lower", Weight: 2},
+											{Name: "cpu", Weight: 2},
 										},
 									},
 								},
@@ -424,18 +415,18 @@ profiles:
       apiVersion: kubescheduler.config.k8s.io/v1beta1
       kind: RequestedToCapacityRatioArgs
       resources:
-      - Name: lower
-        Weight: 2
+      - name: cpu
+        weight: 2
       shape:
-      - Score: 2
-        Utilization: 1
+      - score: 2
+        utilization: 1
     name: RequestedToCapacityRatio
   - args:
       apiVersion: kubescheduler.config.k8s.io/v1beta1
       kind: NodeResourcesLeastAllocatedArgs
       resources:
-      - Name: mem
-        Weight: 2
+      - name: mem
+        weight: 2
     name: NodeResourcesLeastAllocated
   - args:
       foo: bar
@@ -512,8 +503,8 @@ profiles:
       apiVersion: kubescheduler.config.k8s.io/v1beta1
       kind: NodeResourcesMostAllocatedArgs
       resources:
-      - Name: cpu
-        Weight: 1
+      - name: cpu
+        weight: 1
     name: NodeResourcesMostAllocated
   - args:
       apiVersion: kubescheduler.config.k8s.io/v1beta1

--- a/pkg/scheduler/apis/config/v1beta1/defaults.go
+++ b/pkg/scheduler/apis/config/v1beta1/defaults.go
@@ -20,7 +20,7 @@ import (
 	"net"
 	"strconv"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/util/feature"
 	componentbaseconfigv1alpha1 "k8s.io/component-base/config/v1alpha1"
@@ -34,8 +34,8 @@ import (
 )
 
 var defaultResourceSpec = []v1beta1.ResourceSpec{
-	{Name: string(v1.ResourceCPU), Weight: 1},
-	{Name: string(v1.ResourceMemory), Weight: 1},
+	{Name: string(corev1.ResourceCPU), Weight: 1},
+	{Name: string(corev1.ResourceMemory), Weight: 1},
 }
 
 func addDefaultingFuncs(scheme *runtime.Scheme) error {
@@ -203,15 +203,15 @@ func SetDefaults_PodTopologySpreadArgs(obj *v1beta1.PodTopologySpreadArgs) {
 		return
 	}
 	if obj.DefaultConstraints == nil {
-		obj.DefaultConstraints = []v1.TopologySpreadConstraint{
+		obj.DefaultConstraints = []corev1.TopologySpreadConstraint{
 			{
-				TopologyKey:       v1.LabelHostname,
-				WhenUnsatisfiable: v1.ScheduleAnyway,
+				TopologyKey:       corev1.LabelHostname,
+				WhenUnsatisfiable: corev1.ScheduleAnyway,
 				MaxSkew:           3,
 			},
 			{
-				TopologyKey:       v1.LabelZoneFailureDomainStable,
-				WhenUnsatisfiable: v1.ScheduleAnyway,
+				TopologyKey:       corev1.LabelZoneFailureDomainStable,
+				WhenUnsatisfiable: corev1.ScheduleAnyway,
 				MaxSkew:           5,
 			},
 		}

--- a/staging/src/k8s.io/kube-scheduler/config/v1beta1/types_pluginargs.go
+++ b/staging/src/k8s.io/kube-scheduler/config/v1beta1/types_pluginargs.go
@@ -17,9 +17,7 @@ limitations under the License.
 package v1beta1
 
 import (
-	gojson "encoding/json"
-
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -80,7 +78,7 @@ type PodTopologySpreadArgs struct {
 	// Empty by default.
 	// +optional
 	// +listType=atomic
-	DefaultConstraints []v1.TopologySpreadConstraint `json:"defaultConstraints"`
+	DefaultConstraints []corev1.TopologySpreadConstraint `json:"defaultConstraints"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
@@ -123,39 +121,20 @@ type NodeResourcesMostAllocatedArgs struct {
 	Resources []ResourceSpec `json:"resources,omitempty"`
 }
 
-// TODO add JSON tags and remove custom unmarshalling in v1beta1.
-// UtilizationShapePoint and ResourceSpec fields are not annotated with JSON tags in v1alpha2
-// to maintain backward compatibility with the args shipped with v1.18.
-// See https://github.com/kubernetes/kubernetes/pull/88585#discussion_r405021905
-
 // UtilizationShapePoint represents single point of priority function shape.
 type UtilizationShapePoint struct {
 	// Utilization (x axis). Valid values are 0 to 100. Fully utilized node maps to 100.
-	Utilization int32
+	Utilization int32 `json:"utilization"`
 	// Score assigned to given utilization (y axis). Valid values are 0 to 10.
-	Score int32
-}
-
-// UnmarshalJSON provides case insensitive unmarshalling for the type.
-// TODO remove when copying to v1beta1.
-func (t *UtilizationShapePoint) UnmarshalJSON(data []byte) error {
-	type internal *UtilizationShapePoint
-	return gojson.Unmarshal(data, internal(t))
+	Score int32 `json:"score"`
 }
 
 // ResourceSpec represents single resource and weight for bin packing of priority RequestedToCapacityRatioArguments.
 type ResourceSpec struct {
 	// Name of the resource to be managed by RequestedToCapacityRatio function.
-	Name string
+	Name string `json:"name"`
 	// Weight of the resource.
-	Weight int64
-}
-
-// UnmarshalJSON provides case insensitive unmarshalling for the type.
-// TODO remove when copying to v1beta1.
-func (t *ResourceSpec) UnmarshalJSON(data []byte) error {
-	type internal *ResourceSpec
-	return gojson.Unmarshal(data, internal(t))
+	Weight int64 `json:"weight,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object


### PR DESCRIPTION
**What type of PR is this?**
/kind api-change

**What this PR does / why we need it**:
1.18 shipped `v1alpha2`  Kube Scheduler Plugin Args. `RequestedToCapacityRatioArgs` allowed case-insenstive encoding of `Shape` and `Resources` fields. `v1beta1` disallows this enabling strict encoding for these plugin args.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of #89701

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
`RequestedToCapacityRatioArgs` encoding is now strict
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/tree/30bc12a2e26a06a1995c379df125fc6f6ae58e77/keps/sig-scheduling/785-scheduler-component-config-api
```
