### PR TITLE
fix json customNumberExtension decode

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/json/json.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/json/json.go
@@ -19,6 +19,7 @@ package json
 import (
 	"encoding/json"
 	"io"
+	"math"
 	"strconv"
 	"unsafe"
 
@@ -128,14 +129,13 @@ func (customNumberDecoder) Decode(ptr unsafe.Pointer, iter *jsoniter.Iterator) {
 	case jsoniter.NumberValue:
 		var number jsoniter.Number
 		iter.ReadVal(&number)
-		i64, err := strconv.ParseInt(string(number), 10, 64)
-		if err == nil {
-			*(*interface{})(ptr) = i64
-			return
-		}
 		f64, err := strconv.ParseFloat(string(number), 64)
 		if err == nil {
-			*(*interface{})(ptr) = f64
+			if math.Floor(f64) == f64 {
+				*(*interface{})(ptr) = int64(f64)
+			} else {
+				*(*interface{})(ptr) = f64
+			}
 			return
 		}
 		iter.ReportError("DecodeNumber", err.Error())

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/json/json_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/json/json_test.go
@@ -424,6 +424,34 @@ func TestDecode(t *testing.T) {
 	}
 }
 
+func TestCustomNumberExtension(t *testing.T) {
+	api := json.CaseSensitiveJsonIterator()
+
+	testCases := []struct {
+		data           string
+		expectedObject map[string]interface{}
+	}{{
+		data: `{"i641": 11, "i642": 12.0, "f64": 13.1}`,
+		expectedObject: map[string]interface{}{
+			"i641": int64(11),
+			"i642": int64(12),
+			"f64":  float64(13.1),
+		},
+	}}
+
+	for i, test := range testCases {
+		actualObject := map[string]interface{}{}
+		err := api.Unmarshal([]byte(test.data), &actualObject)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if !reflect.DeepEqual(test.expectedObject, actualObject) {
+			t.Errorf("%d: unexpected object:\n%s", i, diff.ObjectGoPrintSideBySide(test.expectedObject, actualObject))
+		}
+	}
+}
+
 func TestCacheableObject(t *testing.T) {
 	gvk := schema.GroupVersionKind{Group: "group", Version: "version", Kind: "MockCacheableObject"}
 	creater := &mockCreater{obj: &runtimetesting.MockCacheableObject{}}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Two reasons:
1. try to convert a float64 with no decimal type like 12.0 to an int64
2. reduce the overhead of strconv.ParseInt, which should be faster

**Which issue(s) this PR fixes**:
NONE

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
NONE
