### PR TITLE
Mark --kubelet-https deprecated, unconditionally use https for apiserver->kubelet connections

### DIFF
--- a/cmd/kube-apiserver/app/options/options.go
+++ b/cmd/kube-apiserver/app/options/options.go
@@ -120,7 +120,6 @@ func NewServerRunOptions() *ServerRunOptions {
 				string(api.NodeExternalDNS),
 				string(api.NodeExternalIP),
 			},
-			EnableHTTPS: true,
 			HTTPTimeout: time.Duration(5) * time.Second,
 		},
 		ServiceNodePortRange: kubeoptions.DefaultServiceNodePortRange,
@@ -200,8 +199,9 @@ func (s *ServerRunOptions) Flags() (fss cliflag.NamedFlagSets) {
 		"Example: '30000-32767'. Inclusive at both ends of the range.")
 
 	// Kubelet related flags:
-	fs.BoolVar(&s.KubeletConfig.EnableHTTPS, "kubelet-https", s.KubeletConfig.EnableHTTPS,
-		"Use https for kubelet connections.")
+	kubeletHTTPS := true
+	fs.BoolVar(&kubeletHTTPS, "kubelet-https", kubeletHTTPS, "Use https for kubelet connections.")
+	fs.MarkDeprecated("kubelet-https", "API Server connections to kubelets always use https. This flag will be removed in 1.22.")
 
 	fs.StringSliceVar(&s.KubeletConfig.PreferredAddressTypes, "kubelet-preferred-address-types", s.KubeletConfig.PreferredAddressTypes,
 		"List of the preferred NodeAddressTypes to use for kubelet connections.")

--- a/cmd/kube-apiserver/app/options/options_test.go
+++ b/cmd/kube-apiserver/app/options/options_test.go
@@ -106,7 +106,6 @@ func TestAddFlags(t *testing.T) {
 		"--etcd-certfile=/var/run/kubernetes/etcdce.crt",
 		"--etcd-cafile=/var/run/kubernetes/etcdca.crt",
 		"--http2-max-streams-per-connection=42",
-		"--kubelet-https=true",
 		"--kubelet-read-only-port=10255",
 		"--kubelet-timeout=5s",
 		"--kubelet-client-certificate=/var/run/kubernetes/ceserver.crt",
@@ -193,7 +192,6 @@ func TestAddFlags(t *testing.T) {
 				string(kapi.NodeExternalDNS),
 				string(kapi.NodeExternalIP),
 			},
-			EnableHTTPS: true,
 			HTTPTimeout: time.Duration(5) * time.Second,
 			TLSClientConfig: restclient.TLSClientConfig{
 				CertFile: "/var/run/kubernetes/ceserver.crt",

--- a/pkg/kubelet/client/kubelet_client.go
+++ b/pkg/kubelet/client/kubelet_client.go
@@ -41,9 +41,6 @@ type KubeletClientConfig struct {
 	// ReadOnlyPort specifies the Port for ReadOnly communications.
 	ReadOnlyPort uint
 
-	// EnableHTTPs specifies if traffic should be encrypted.
-	EnableHTTPS bool
-
 	// PreferredAddressTypes - used to select an address from Node.NodeStatus.Addresses
 	PreferredAddressTypes []string
 
@@ -139,7 +136,7 @@ func (c *KubeletClientConfig) transportConfig() *transport.Config {
 		},
 		BearerToken: c.BearerToken,
 	}
-	if c.EnableHTTPS && !cfg.HasCA() {
+	if !cfg.HasCA() {
 		cfg.TLS.Insecure = true
 	}
 	return cfg
@@ -176,11 +173,6 @@ type NodeConnectionInfoGetter struct {
 
 // NewNodeConnectionInfoGetter creates a new NodeConnectionInfoGetter.
 func NewNodeConnectionInfoGetter(nodes NodeGetter, config KubeletClientConfig) (ConnectionInfoGetter, error) {
-	scheme := "http"
-	if config.EnableHTTPS {
-		scheme = "https"
-	}
-
 	transport, err := MakeTransport(&config)
 	if err != nil {
 		return nil, err
@@ -197,7 +189,7 @@ func NewNodeConnectionInfoGetter(nodes NodeGetter, config KubeletClientConfig) (
 
 	return &NodeConnectionInfoGetter{
 		nodes:                          nodes,
-		scheme:                         scheme,
+		scheme:                         "https",
 		defaultPort:                    int(config.Port),
 		transport:                      transport,
 		insecureSkipTLSVerifyTransport: insecureSkipTLSVerifyTransport,

--- a/pkg/kubelet/client/kubelet_client_test.go
+++ b/pkg/kubelet/client/kubelet_client_test.go
@@ -30,7 +30,6 @@ import (
 
 func TestMakeTransportInvalid(t *testing.T) {
 	config := &KubeletClientConfig{
-		EnableHTTPS: true,
 		//Invalid certificate and key path
 		TLSClientConfig: restclient.TLSClientConfig{
 			CertFile: "../../client/testdata/mycertinvalid.cer",
@@ -50,13 +49,12 @@ func TestMakeTransportInvalid(t *testing.T) {
 
 func TestMakeTransportValid(t *testing.T) {
 	config := &KubeletClientConfig{
-		Port:        1234,
-		EnableHTTPS: true,
+		Port: 1234,
 		TLSClientConfig: restclient.TLSClientConfig{
 			CertFile: "../../client/testdata/mycertvalid.cer",
-			// TLS Configuration, only applies if EnableHTTPS is true.
+			// TLS Configuration
 			KeyFile: "../../client/testdata/mycertvalid.key",
-			// TLS Configuration, only applies if EnableHTTPS is true.
+			// TLS Configuration
 			CAFile: "../../client/testdata/myCA.cer",
 		},
 	}
@@ -90,13 +88,12 @@ func TestMakeInsecureTransport(t *testing.T) {
 	}
 
 	config := &KubeletClientConfig{
-		Port:        uint(port),
-		EnableHTTPS: true,
+		Port: uint(port),
 		TLSClientConfig: restclient.TLSClientConfig{
 			CertFile: "../../client/testdata/mycertvalid.cer",
-			// TLS Configuration, only applies if EnableHTTPS is true.
+			// TLS Configuration
 			KeyFile: "../../client/testdata/mycertvalid.key",
-			// TLS Configuration, only applies if EnableHTTPS is true.
+			// TLS Configuration
 			CAFile: "../../client/testdata/myCA.cer",
 		},
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Kubelets have unconditionally used https to serve the endpoints the apiserver communicates with since before v1.0 (in https://github.com/kubernetes/kubernetes/pull/6380), and the apiserver flag to allow switching communication with the kubelet to http has not be usable since then.

This PR marks that flag as deprecated and removes the option for the kube-apiserver -> kubelet connection to switch from https to http.

**Does this PR introduce a user-facing change?**:
```release-note
The kube-apiserver `--kubelet-https` flag is deprecated. kube-apiserver connections to kubelets now unconditionally use `https` (kubelets have unconditionally used `https` to serve the endpoints the apiserver communicates with since before v1.0).
```