### PR TITLE
get-kube.sh: fix order to get the binaries from the right bucket

### DIFF
--- a/cluster/get-kube.sh
+++ b/cluster/get-kube.sh
@@ -183,11 +183,16 @@ release=${KUBERNETES_RELEASE:-"release/stable"}
 # Translate a published version <bucket>/<version> (e.g. "release/stable") to version number.
 set_binary_version "${release}"
 if [[ -z "${KUBERNETES_SKIP_RELEASE_VALIDATION-}" ]]; then
-  if [[ ${KUBE_VERSION} =~ ${KUBE_CI_VERSION_REGEX} ]]; then
+  if [[ ${KUBE_VERSION} =~ ${KUBE_RELEASE_VERSION_REGEX} ]]; then
+    # Use KUBERNETES_RELEASE_URL for Releases and Pre-Releases
+    # ie. 1.18.0 or 1.19.0-beta.0
+    KUBERNETES_RELEASE_URL="${KUBERNETES_RELEASE_URL}"
+  elif [[ ${KUBE_VERSION} =~ ${KUBE_CI_VERSION_REGEX} ]]; then
     # Override KUBERNETES_RELEASE_URL to point to the CI bucket;
     # this will be used by get-kube-binaries.sh.
+    # ie. v1.19.0-beta.0.318+b618411f1edb98
     KUBERNETES_RELEASE_URL="${KUBERNETES_CI_RELEASE_URL}"
-  elif ! [[ ${KUBE_VERSION} =~ ${KUBE_RELEASE_VERSION_REGEX} ]]; then
+  else
     echo "Version doesn't match regexp" >&2
     exit 1
   fi


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Change the order where it sets from which bucket will download the K8s binaries.

If it is a Release or Pre-release (ie. `1.18.2` or `1.19.0-alpha.1`) uses the `https://dl.k8s.io` bucket if it is a CI release (ie. `v1.19.0-beta.0.318+b618411f1edb98`) uses the `https://dl.k8s.io/ci`
If the input release does not match fail the script.

examples:
1. running for `v1.18.0`: 
```bash
$ KUBERNETES_SKIP_CREATE_CLUSTER=true  KUBERNETES_RELEASE=v1.18.0 ./cluster/get-kube.sh
TEST- https://dl.k8s.io/ci
Downloading kubernetes release v1.18.0
  from https://dl.k8s.io/v1.18.0/kubernetes.tar.gz
  to /Users/cpanato/go/src/github.com/kubernetes/kubernetes/kubernetes.tar.gz
Is this ok? [Y]/n
```

2. running for `v1.19.0-alpha.1`: 
```bash
$ KUBERNETES_SKIP_CREATE_CLUSTER=true  KUBERNETES_RELEASE=v1.19.0-alpha.1 ./cluster/get-kube.sh
TEST- https://dl.k8s.io/ci
Downloading kubernetes release v1.19.0-alpha.1
  from https://dl.k8s.io/v1.19.0-alpha.1/kubernetes.tar.gz
  to /Users/cpanato/go/src/github.com/kubernetes/kubernetes/kubernetes.tar.gz
Is this ok? [Y]/n
```

3. running for `ci/latest`: 
```bash
$ KUBERNETES_SKIP_CREATE_CLUSTER=true  KUBERNETES_RELEASE=ci/latest ./cluster/get-kube.sh
Downloading kubernetes release v1.19.0-beta.0.318+b618411f1edb98
  from https://dl.k8s.io/ci/v1.19.0-beta.0.318+b618411f1edb98/kubernetes.tar.gz
  to /Users/cpanato/go/src/github.com/kubernetes/kubernetes/kubernetes.tar.gz
Is this ok? [Y]/n
```

4. running for `1.17.3`: 
```bash
$ KUBERNETES_SKIP_CREATE_CLUSTER=true  KUBERNETES_RELEASE=1.18.0 ./cluster/get-kube.sh
Version doesn't match regexp
```

**Which issue(s) this PR fixes**:
 - Fixes https://github.com/kubernetes/kubernetes/issues/86267

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
get-kube.sh: fix order to get the binaries from the right bucket
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/cc @justaugustus @liggitt  
