### PR TITLE
Conformance Behaviors Mapping sig-apimachinery

### DIFF
--- a/test/conformance/behaviors/sig-apimachinery/aggregator.yaml
+++ b/test/conformance/behaviors/sig-apimachinery/aggregator.yaml
@@ -1,0 +1,5 @@
+suite: apimachinery/aggregator
+description: Base suite for aggregator
+behaviors:
+- id: apimachinery/aggregator/sample-apiserver
+  description: The sample-apiserver code from 1.17 and compiled against 1.17 must work on the current Aggregator/API-Server.

--- a/test/conformance/behaviors/sig-apimachinery/crd.yaml
+++ b/test/conformance/behaviors/sig-apimachinery/crd.yaml
@@ -1,0 +1,27 @@
+suite: apimachinery/crd
+description: Base suite for CRDs
+behaviors:
+- id: apimachinery/crd/conversionwebhook/v2list
+  description: A v1 CRD must be readable as v2.
+- id: apimachinery/crd/conversionwebhook/homogeneous-v1v2
+  description: A CRD created at v1 with its storage type changed to v2 and a CRD created at v2 must both be able to be listed at v2.
+- id: apimachinery/crd/watch
+  description: Watch must be able to observe create, modify, and delete events on CRDs.
+- id: apimachinery/crd/create
+  description: Calling create on a CRD must create the CRD object.
+- id: apimachinery/crd/delete
+  description: Calling delete on a CRD must delete the CRD object.
+- id: apimachinery/crd/label/list
+  description: CRDs created with labels must be listed when the corresponding label selector is applied to a query.
+- id: apimachinery/crd/label/deletecollection
+  description: Delete Collection applied on CRDs with a labelSelector must delete all CRDs with the corresponding label.
+- id: apimachinery/crd/status/update
+  description: Updating a CRD's status sub-resource should be visible on subsequent reads.
+- id: apimachinery/crd/discovery
+  description: Fetch /apis, /apis/apiextensions.k8s.io, and /apis/apiextensions.k8s.io/v1 discovery documents, and ensure they indicate CustomResourceDefinition apiextensions.k8s.io/v1 resources are available.
+- id: apimachinery/crd/default/create
+  description: Creating a CRD with the schema defaulting a field to a value should have the value set.
+- id: apimachinery/crd/default/update
+  description: Changing the default for a field in the CRD schema should not change already created CRDs
+- id: apimachinery/crd/default/add
+  description: Adding a default for a field in the CRD schema should update existing CRD objects to use the new default for the particular field.

--- a/test/conformance/behaviors/sig-apimachinery/garbagecollector.yaml
+++ b/test/conformance/behaviors/sig-apimachinery/garbagecollector.yaml
@@ -1,0 +1,19 @@
+suite: apimachinery/gc
+description: Base suite for GarbageCollector
+behaviors:
+- id: apimachinery/gc/rc/delete/propagationPolicy/Background
+  description: When deleting a replication controller with propagationPolicy set to Background, all pods created by the RC must be deleted as well. The RC must be deleted before the pods are deleted.
+- id: apimachinery/gc/rc/delete/propagationPolicy/Foreground
+  description: When deleting a replication controller with propagationPolicy set to Foreground, all pods created by the RC must be deleted as well. The RC must be deleted after the pods are deleted.
+- id: apimachinery/gc/rc/delete/propagationPolicy/Orphan
+  description: When deleting a replication controller with propagationPolicy set to Orphan, all pods created by the RC must be be orphaned.
+- id: apimachinery/gc/rc/delete/pod-multiple-owner
+  description: When deleting a replication controller, pods created by the RC must not be deleted if they have multiple owners.
+- id: apimachinery/gc/delete/dependency
+  description: Deleting a resource should delete all other resources it owns.
+- id: apimachinery/gc/delete/dependency-cycle
+  description: Deleting a resource with a cyclical dependency for owner references should not block the garbage collection.
+- id: apimachinery/gc/deployment/delete/propagationPolicy/Background
+  description: When deleting a deployment with propagationPolicy set to Background, all replicasets created by the deployment and all pods created by the replicasets must be deleted.
+- id: apimachinery/gc/deployment/delete/propagationPolicy/Orphan
+  description: When deleting a deployment with propagationPolicy set to Background, all replicasets created by the deployment and all pods created by the replicasets must orphaned.

--- a/test/conformance/behaviors/sig-apimachinery/webhook.yaml
+++ b/test/conformance/behaviors/sig-apimachinery/webhook.yaml
@@ -1,0 +1,53 @@
+suite: apimachinery/webhook
+description: Base suite for webhooks
+behaviors:
+- id: apimachinery/webhook/discovery
+  description: The admissionregistration.k8s.io API group MUST exists in the /apis discovery document. The admissionregistration.k8s.io/v1 API group/version MUST exists in the /apis discovery document. The mutatingwebhookconfigurations and validatingwebhookconfigurations resources MUST exist in the /apis/admissionregistration.k8s.io/v1 discovery document.
+- id: apimachinery/webhook/admission/denycreatenoncompliant
+  description: Admissions webhook should deny the creation of non-compliant resources.
+- id: apimachinery/webhook/admission/denycreatehang
+  description: Admissions webhook should deny the creation of compliant resources that cause the webhook to hang.
+- id: apimachinery/webhook/admission/admitcreate
+  description: Admissions webhook should accept the creation of a a resource compliant with its admissions.
+- id: apimachinery/webhook/admission/denypatchnoncompliant
+  description: Admissions webhook should deny the PATCH operation on changing a compliant resource to a non-compliant one
+- id: apimachinery/webhook/admission/denyputnoncompliant
+  description: Admissions webhook should deny the PUT operation on changing a compliant resource to a non-compliant one
+- id: apimachinery/webhook/admission/admitcreatewhitelisted
+  description: Admissions webhook should accept the creation of a non-compliant resource within a whitelisted namespace
+- id: apimachinery/webhook/admission/denypodattach
+  description: Admissions webhook configured to deny connecting to a pod's attach subresource should deny pod attach attempts.
+- id: apimachinery/webhook/admission/deny-crd-operation
+  description: Admissions webhook configured to deny creation, update, and/or deletion of CRDs should deny those operations on CRDs.
+- id: apimachinery/webhook/admission/failclosed/deny
+  description: Misconfigured admission webhook with a failed closed policy and without CA bundle should deny all operations that require the admission webhook.
+- id: apimachinery/webhook/admission/mutation/basic
+  description: Mutating webhook configured to mutate a resource on operation should mutate the corresponding resource when the operation is applied.
+- id: apimachinery/webhook/admission/mutation/ordered
+  description: Webhooks may be reordered. If a webhook depends on the execution of another webhook, they must both execute.
+- id: apimachinery/webhook/admission/mutation/InitContainer
+  description: A mutating webhook that adds an InitContainer to pods must add the container when invoked and must initialize the InitContainer's terminationMessagePolicy to be the default.
+- id: apimachinery/webhook/admission/mutation/self
+  description: A mutating webhook must not be allowed to act on webhook configuration objects.
+- id: apimachinery/webhook/admission/mutation/basic-crd
+  description: A mutating webhook configured to mutate a custom resource must mutate it when invoked.
+- id: apimachinery/webhook/admission/mutation/pruning-crd
+  description: A mutating webhook configured to add fields to custom objects must have the fields pruned if they are not part of the CRD schema
+- id: apimachinery/webhook/admission/timeout/FailurePolicy/Ignore
+  description: A admission webhook that hits the timeout with FailurePolicy set to Ignore should not result in a failure
+- id: apimachinery/webhook/admission/timeout/FailurePolicy/Fail
+  description: A admission webhook that hits the timeout with FailurePolicy set to Fail should timeout
+- id: apimachinery/webhook/admission/timeout/pass
+  description: A admission webhook that succeeds before hitting the timeout should not cause any error
+- id: apimachinery/webhook/admission/timeout/empty
+  description: A admission webhook without the timeout parameter should use the default timeout value
+- id: apimachinery/webhook/admission/update/denyaccept
+  description: A admission webhook set to deny an operation and later patched to accept that operation should not deny the corresponding operation
+- id: apimachinery/webhook/admission/update/acceptdeny
+  description: A admission webhook set to accept an operation and later patched to deny that operation should deny the corresponding operation
+- id: apimachinery/webhook/admission/mutating/update/denyaccept
+  description: A mutating webhook set to deny an operation and later patched to accept that operation should not deny the corresponding operation
+- id: apimachinery/webhook/admission/mutating/update/acceptdeny
+  description: A mutating webhook set to accept an operation and later patched to deny that operation should deny the corresponding operation
+- id: apimachinery/webhook/admission/validating/label
+  description: Admission webhooks created with a label should be present when querying by the corresponding label selector.

--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -508,6 +508,10 @@
     an object; the object MUST NOT be mutated.
   release: v1.16
   file: test/e2e/apimachinery/webhook.go
+  behaviors:
+  - apimachinery/webhook/admission/mutating/basic
+  - apimachinery/webhook/admission/mutating/label
+  - apimachinery/webhook/admission/mutating/delete
 - testname: Admission webhook, list validating webhooks
   codename: '[sig-api-machinery] AdmissionWebhook [Privileged:ClusterAdmin] listing
     validating webhooks should work [Conformance]'
@@ -519,6 +523,10 @@
     MUST NOT be denied.
   release: v1.16
   file: test/e2e/apimachinery/webhook.go
+  behaviors:
+  - apimachinery/webhook/admission/denycreatenoncompliant
+  - apimachinery/webhook/admission/validating/label
+  - apimachinery/webhook/admission/validating/delete
 - testname: Admission webhook, update mutating webhook
   codename: '[sig-api-machinery] AdmissionWebhook [Privileged:ClusterAdmin] patching/updating
     a mutating webhook should work [Conformance]'
@@ -528,6 +536,9 @@
     again and attempt to create an object; the webhook MUST mutate the object.
   release: v1.16
   file: test/e2e/apimachinery/webhook.go
+  behaviors:
+  - apimachinery/webhook/admission/mutating/update/denyaccept
+  - apimachinery/webhook/admission/mutating/update/acceptdeny
 - testname: Admission webhook, update validating webhook
   codename: '[sig-api-machinery] AdmissionWebhook [Privileged:ClusterAdmin] patching/updating
     a validating webhook should work [Conformance]'
@@ -537,6 +548,9 @@
     and attempt to create an object; the webhook MUST deny the create.
   release: v1.16
   file: test/e2e/apimachinery/webhook.go
+  behaviors:
+  - apimachinery/webhook/admission/update/denyaccept
+  - apimachinery/webhook/admission/update/acceptdeny
 - testname: Admission webhook, deny attach
   codename: '[sig-api-machinery] AdmissionWebhook [Privileged:ClusterAdmin] should
     be able to deny attaching pod [Conformance]'
@@ -544,6 +558,8 @@
     to a pod's attach sub-resource. Attempts to attach MUST be denied.
   release: v1.16
   file: test/e2e/apimachinery/webhook.go
+  behaviors:
+  - apimachinery/webhook/admission/denypodattach
 - testname: Admission webhook, deny custom resource create and delete
   codename: '[sig-api-machinery] AdmissionWebhook [Privileged:ClusterAdmin] should
     be able to deny custom resource creation, update and deletion [Conformance]'
@@ -552,6 +568,8 @@
     resources MUST be denied.
   release: v1.16
   file: test/e2e/apimachinery/webhook.go
+  behaviors:
+  - apimachinery/webhook/admission/deny-crd-operation
 - testname: Admission webhook, deny create
   codename: '[sig-api-machinery] AdmissionWebhook [Privileged:ClusterAdmin] should
     be able to deny pod and configmap creation [Conformance]'
@@ -563,6 +581,13 @@
     in a whitelisted namespace based on the webhook namespace selector MUST be allowed.
   release: v1.16
   file: test/e2e/apimachinery/webhook.go
+  behaviors:
+  - apimachinery/webhook/admission/denycreatenoncompliant
+  - apimachinery/webhook/admission/denycreatehang
+  - apimachinery/webhook/admission/admitcreate
+  - apimachinery/webhook/admission/denypatchnoncompliant
+  - apimachinery/webhook/admission/denyputnoncompliant
+  - apimachinery/webhook/admission/admitcreatewhitelisted
 - testname: Admission webhook, deny custom resource definition
   codename: '[sig-api-machinery] AdmissionWebhook [Privileged:ClusterAdmin] should
     deny crd creation [Conformance]'
@@ -570,6 +595,8 @@
     to create a custom resource definition; the create request MUST be denied.
   release: v1.16
   file: test/e2e/apimachinery/webhook.go
+  behaviors:
+  - apimachinery/webhook/admission/deny-crd-operation
 - testname: Admission webhook, honor timeout
   codename: '[sig-api-machinery] AdmissionWebhook [Privileged:ClusterAdmin] should
     honor timeout [Conformance]'
@@ -581,6 +608,11 @@
     webhook timeout is 10 seconds (much longer than the webhook wait duration).
   release: v1.16
   file: test/e2e/apimachinery/webhook.go
+  behaviors:
+  - apimachinery/webhook/admission/timeout/FailurePolicy/Ignore
+  - apimachinery/webhook/admission/timeout/FailurePolicy/Fail
+  - apimachinery/webhook/admission/timeout/pass
+  - apimachinery/webhook/admission/timeout/empty
 - testname: Admission webhook, discovery document
   codename: '[sig-api-machinery] AdmissionWebhook [Privileged:ClusterAdmin] should
     include webhook resources in discovery documents [Conformance]'
@@ -591,6 +623,8 @@
     discovery document.
   release: v1.16
   file: test/e2e/apimachinery/webhook.go
+  behaviors:
+  - apimachinery/webhook/discovery
 - testname: Admission webhook, ordered mutation
   codename: '[sig-api-machinery] AdmissionWebhook [Privileged:ClusterAdmin] should
     mutate configmap [Conformance]'
@@ -600,6 +634,8 @@
     Attempt to create a config map; both keys MUST be added to the config map.
   release: v1.16
   file: test/e2e/apimachinery/webhook.go
+  behaviors:
+  - apimachinery/webhook/admission/mutation/ordered
 - testname: Admission webhook, mutate custom resource
   codename: '[sig-api-machinery] AdmissionWebhook [Privileged:ClusterAdmin] should
     mutate custom resource [Conformance]'
@@ -607,6 +643,8 @@
     custom resource object; the custom resource MUST be mutated.
   release: v1.16
   file: test/e2e/apimachinery/webhook.go
+  behaviors:
+  - apimachinery/webhook/admission/mutation/basic-crd
 - testname: Admission webhook, mutate custom resource with different stored version
   codename: '[sig-api-machinery] AdmissionWebhook [Privileged:ClusterAdmin] should
     mutate custom resource with different stored version [Conformance]'
@@ -622,11 +660,13 @@
     mutate custom resource with pruning [Conformance]'
   description: Register mutating webhooks that adds fields to custom objects. Register
     a custom resource definition with a schema that includes only one of the data
-    keys added by the webhooks. Attempt to a custom resource; the fields included
+    keys added by the webhooks. Attempt to create a custom resource; the fields included
     in the schema MUST be present and field not included in the schema MUST NOT be
     present.
   release: v1.16
   file: test/e2e/apimachinery/webhook.go
+  behaviors:
+  - apimachinery/webhook/admission/mutation/pruning-crd
 - testname: Admission webhook, mutation with defaulting
   codename: '[sig-api-machinery] AdmissionWebhook [Privileged:ClusterAdmin] should
     mutate pod and apply defaults after mutation [Conformance]'
@@ -635,6 +675,8 @@
     MUST be defaulted.
   release: v1.16
   file: test/e2e/apimachinery/webhook.go
+  behaviors:
+  - apimachinery/webhook/admission/mutation/InitContainer
 - testname: Admission webhook, admission control not allowed on webhook configuration
     objects
   codename: '[sig-api-machinery] AdmissionWebhook [Privileged:ClusterAdmin] should
@@ -644,6 +686,8 @@
     MUST be allowed and the webhook configuration object MUST NOT be mutated the webhooks.
   release: v1.16
   file: test/e2e/apimachinery/webhook.go
+  behaviors:
+  - apimachinery/webhook/admission/mutation/self
 - testname: Admission webhook, fail closed
   codename: '[sig-api-machinery] AdmissionWebhook [Privileged:ClusterAdmin] should
     unconditionally reject operations on fail closed webhook [Conformance]'
@@ -652,6 +696,8 @@
     all MUST be denied.
   release: v1.16
   file: test/e2e/apimachinery/webhook.go
+  behaviors:
+  - apimachinery/webhook/admission/failclosed/deny
 - testname: aggregator-supports-the-sample-apiserver
   codename: '[sig-api-machinery] Aggregator Should be able to support the 1.17 Sample
     API Server using the current Aggregator [Conformance]'
@@ -659,6 +705,8 @@
     1.17 will work on the current Aggregator/API-Server.
   release: ""
   file: test/e2e/apimachinery/aggregator.go
+  behaviors:
+  - apimachinery/aggregator/sample-apiserver
 - testname: Custom Resource Definition Conversion Webhook, convert mixed version list
   codename: '[sig-api-machinery] CustomResourceConversionWebhook [Privileged:ClusterAdmin]
     should be able to convert a non homogeneous list of CRs [Conformance]'
@@ -668,6 +716,8 @@
     at v2; the list result MUST contain both custom resources at v2.
   release: v1.16
   file: test/e2e/apimachinery/crd_conversion_webhook.go
+  behaviors:
+  - apimachinery/crd/conversionwebhook/homogeneous-v1v2
 - testname: Custom Resource Definition Conversion Webhook, conversion custom resource
   codename: '[sig-api-machinery] CustomResourceConversionWebhook [Privileged:ClusterAdmin]
     should be able to convert from CR v1 to CR v2 [Conformance]'
@@ -675,6 +725,8 @@
     a v1 custom resource. Attempts to read it at v2 MUST succeed.
   release: v1.16
   file: test/e2e/apimachinery/crd_conversion_webhook.go
+  behaviors:
+  - apimachinery/crd/conversionwebhook/v2list
 - testname: Custom Resource Definition, watch
   codename: '[sig-api-machinery] CustomResourceDefinition Watch [Privileged:ClusterAdmin]
     CustomResourceDefinition Watch watch on custom resource definition objects [Conformance]'
@@ -682,6 +734,8 @@
     MUST observe create, modify and delete events.
   release: v1.16
   file: test/e2e/apimachinery/crd_watch.go
+  behaviors:
+  - apimachinery/crd/watch
 - testname: Custom Resource Definition, create
   codename: '[sig-api-machinery] CustomResourceDefinition resources [Privileged:ClusterAdmin]
     Simple CustomResourceDefinition creating/deleting custom resource definition objects
@@ -691,6 +745,9 @@
     MUST be successful.
   release: v1.9
   file: test/e2e/apimachinery/custom_resource_definition.go
+  behaviors:
+  - apimachinery/crd/create
+  - apimachinery/crd/delete
 - testname: Custom Resource Definition, status sub-resource
   codename: '[sig-api-machinery] CustomResourceDefinition resources [Privileged:ClusterAdmin]
     Simple CustomResourceDefinition getting/updating/patching custom resource definition
@@ -700,6 +757,8 @@
     to subsequent reads.
   release: v1.16
   file: test/e2e/apimachinery/custom_resource_definition.go
+  behaviors:
+  - apimachinery/crd/status/update
 - testname: Custom Resource Definition, list
   codename: '[sig-api-machinery] CustomResourceDefinition resources [Privileged:ClusterAdmin]
     Simple CustomResourceDefinition listing custom resource definition objects works  [Conformance]'
@@ -710,6 +769,9 @@
     custom resource definitions.
   release: v1.16
   file: test/e2e/apimachinery/custom_resource_definition.go
+  behaviors:
+  - apimachinery/crd/label/list
+  - apimachinery/crd/label/deletecollection
 - testname: Custom Resource Definition, defaulting
   codename: '[sig-api-machinery] CustomResourceDefinition resources [Privileged:ClusterAdmin]
     custom resource defaulting for requests and from storage works  [Conformance]'
@@ -719,6 +781,10 @@
     default stays.
   release: v1.17
   file: test/e2e/apimachinery/custom_resource_definition.go
+  behaviors:
+  - apimachinery/crd/default/create
+  - apimachinery/crd/default/update
+  - apimachinery/crd/default/add
 - testname: Custom Resource Definition, discovery
   codename: '[sig-api-machinery] CustomResourceDefinition resources [Privileged:ClusterAdmin]
     should include custom resource definition resources in discovery documents [Conformance]'
@@ -727,6 +793,8 @@
     resources are available.
   release: v1.16
   file: test/e2e/apimachinery/custom_resource_definition.go
+  behaviors:
+  - apimachinery/crd/discovery
 - testname: Custom Resource OpenAPI Publish, stop serving version
   codename: '[sig-api-machinery] CustomResourcePublishOpenAPI [Privileged:ClusterAdmin]
     removes definition from spec when one version gets changed to not be served [Conformance]'
@@ -826,6 +894,8 @@
     also the Pods that belong to the deployments MUST be deleted.
   release: v1.9
   file: test/e2e/apimachinery/garbage_collector.go
+  behaviors:
+  - apimachinery/gc/deployment/delete/propagationPolicy/Background
 - testname: Garbage Collector, delete replication controller, propagation policy background
   codename: '[sig-api-machinery] Garbage collector should delete pods created by rc
     when not orphaning [Conformance]'
@@ -835,6 +905,8 @@
     RC to be deleted.
   release: v1.9
   file: test/e2e/apimachinery/garbage_collector.go
+  behaviors:
+  - apimachinery/gc/rc/delete/propagationPolicy/Background
 - testname: Garbage Collector, delete replication controller, after owned pods
   codename: '[sig-api-machinery] Garbage collector should keep the rc around until
     all its pods are deleted if the deleteOptions says so [Conformance]'
@@ -844,6 +916,8 @@
     Controller MUST cause pods created by that RC to be deleted before the RC is deleted.
   release: v1.9
   file: test/e2e/apimachinery/garbage_collector.go
+  behaviors:
+  - apimachinery/gc/rc/delete/propagationPolicy/Foreground
 - testname: Garbage Collector, dependency cycle
   codename: '[sig-api-machinery] Garbage collector should not be blocked by dependency
     circle [Conformance]'
@@ -852,6 +926,9 @@
     pod1 MUST delete all pods. The dependency cycle MUST not block the garbage collection.
   release: v1.9
   file: test/e2e/apimachinery/garbage_collector.go
+  behaviors:
+  - apimachinery/gc/delete/dependency
+  - apimachinery/gc/delete/dependency-cycle
 - testname: Garbage Collector, multiple owners
   codename: '[sig-api-machinery] Garbage collector should not delete dependents that
     have both valid owner and owner that''s waiting for dependents to be deleted [Conformance]'
@@ -864,6 +941,8 @@
     by multiple replication controllers.
   release: v1.9
   file: test/e2e/apimachinery/garbage_collector.go
+  behaviors:
+  - apimachinery/gc/rc/delete/pod-multiple-owner
 - testname: Garbage Collector, delete deployment, propagation policy orphan
   codename: '[sig-api-machinery] Garbage collector should orphan RS created by deployment
     when deleteOptions.PropagationPolicy is Orphan [Conformance]'
@@ -873,6 +952,8 @@
     also the Pods created by the deployments MUST be orphaned.
   release: v1.9
   file: test/e2e/apimachinery/garbage_collector.go
+  behaviors:
+  - apimachinery/gc/deployment/delete/propagationPolicy/Orphan
 - testname: Garbage Collector, delete replication controller, propagation policy orphan
   codename: '[sig-api-machinery] Garbage collector should orphan pods created by rc
     if delete options say so [Conformance]'
@@ -882,6 +963,8 @@
     MUST cause pods created by that RC to be orphaned.
   release: v1.9
   file: test/e2e/apimachinery/garbage_collector.go
+  behaviors:
+  - apimachinery/gc/rc/delete/propagationPolicy/Orphan
 - testname: namespace-deletion-removes-pods
   codename: '[sig-api-machinery] Namespaces [Serial] should ensure that all pods are
     removed when a namespace is deleted [Conformance]'

--- a/test/e2e/apimachinery/aggregator.go
+++ b/test/e2e/apimachinery/aggregator.go
@@ -93,6 +93,8 @@ var _ = SIGDescribe("Aggregator", func() {
 		    Testname: aggregator-supports-the-sample-apiserver
 		    Description: Ensure that the sample-apiserver code from 1.17 and compiled against 1.17
 			will work on the current Aggregator/API-Server.
+		    Behaviors:
+		    - apimachinery/aggregator/sample-apiserver
 	*/
 	framework.ConformanceIt("Should be able to support the 1.17 Sample API Server using the current Aggregator", func() {
 		// Testing a 1.17 version of the sample-apiserver

--- a/test/e2e/apimachinery/crd_conversion_webhook.go
+++ b/test/e2e/apimachinery/crd_conversion_webhook.go
@@ -143,6 +143,8 @@ var _ = SIGDescribe("CustomResourceConversionWebhook [Privileged:ClusterAdmin]",
 		Testname: Custom Resource Definition Conversion Webhook, conversion custom resource
 		Description: Register a conversion webhook and a custom resource definition. Create a v1 custom
 		resource. Attempts to read it at v2 MUST succeed.
+		Behaviors:
+		- apimachinery/crd/conversionwebhook/v2list
 	*/
 	framework.ConformanceIt("should be able to convert from CR v1 to CR v2", func() {
 		testcrd, err := crd.CreateMultiVersionTestCRD(f, "stable.example.com", func(crd *apiextensionsv1.CustomResourceDefinition) {
@@ -178,6 +180,9 @@ var _ = SIGDescribe("CustomResourceConversionWebhook [Privileged:ClusterAdmin]",
 		Description: Register a conversion webhook and a custom resource definition. Create a custom resource stored at
 		v1. Change the custom resource definition storage to v2. Create a custom resource stored at v2. Attempt to list
 		the custom resources at v2; the list result MUST contain both custom resources at v2.
+		Behaviors:
+		- apimachinery/crd/conversionwebhook/homogeneous-v1v2
+
 	*/
 	framework.ConformanceIt("should be able to convert a non homogeneous list of CRs", func() {
 		testcrd, err := crd.CreateMultiVersionTestCRD(f, "stable.example.com", func(crd *apiextensionsv1.CustomResourceDefinition) {

--- a/test/e2e/apimachinery/crd_conversion_webhook.go
+++ b/test/e2e/apimachinery/crd_conversion_webhook.go
@@ -182,7 +182,6 @@ var _ = SIGDescribe("CustomResourceConversionWebhook [Privileged:ClusterAdmin]",
 		the custom resources at v2; the list result MUST contain both custom resources at v2.
 		Behaviors:
 		- apimachinery/crd/conversionwebhook/homogeneous-v1v2
-
 	*/
 	framework.ConformanceIt("should be able to convert a non homogeneous list of CRs", func() {
 		testcrd, err := crd.CreateMultiVersionTestCRD(f, "stable.example.com", func(crd *apiextensionsv1.CustomResourceDefinition) {

--- a/test/e2e/apimachinery/crd_watch.go
+++ b/test/e2e/apimachinery/crd_watch.go
@@ -45,6 +45,8 @@ var _ = SIGDescribe("CustomResourceDefinition Watch [Privileged:ClusterAdmin]", 
 			Testname: Custom Resource Definition, watch
 			Description: Create a Custom Resource Definition. Attempt to watch it; the watch MUST observe create,
 			modify and delete events.
+			Behaviors:
+			- apimachinery/crd/watch
 		*/
 		framework.ConformanceIt("watch on custom resource definition objects", func() {
 

--- a/test/e2e/apimachinery/custom_resource_definition.go
+++ b/test/e2e/apimachinery/custom_resource_definition.go
@@ -52,6 +52,9 @@ var _ = SIGDescribe("CustomResourceDefinition resources [Privileged:ClusterAdmin
 			Description: Create a API extension client and define a random custom resource definition.
 			Create the custom resource definition and then delete it. The creation and deletion MUST
 			be successful.
+			Behaviors:
+			- apimachinery/crd/create
+			- apimachinery/crd/delete
 		*/
 		framework.ConformanceIt("creating/deleting custom resource definition objects works ", func() {
 
@@ -79,6 +82,9 @@ var _ = SIGDescribe("CustomResourceDefinition resources [Privileged:ClusterAdmin
 			a label selector; the list result MUST contain only the labeled custom resource definitions. Delete the labeled
 			custom resource definitions via delete collection; the delete MUST be successful and MUST delete only the
 			labeled custom resource definitions.
+			Behaviors:
+			- apimachinery/crd/label/list
+			- apimachinery/crd/label/deletecollection
 		*/
 		framework.ConformanceIt("listing custom resource definition objects works ", func() {
 			testListSize := 10
@@ -139,6 +145,8 @@ var _ = SIGDescribe("CustomResourceDefinition resources [Privileged:ClusterAdmin
 			Testname: Custom Resource Definition, status sub-resource
 			Description: Create a custom resource definition. Attempt to read, update and patch its status sub-resource;
 			all mutating sub-resource operations MUST be visible to subsequent reads.
+			Behaviors:
+			- apimachinery/crd/status/update
 		*/
 		framework.ConformanceIt("getting/updating/patching custom resource definition status sub-resource works ", func() {
 			config, err := framework.LoadConfig()
@@ -192,6 +200,8 @@ var _ = SIGDescribe("CustomResourceDefinition resources [Privileged:ClusterAdmin
 		Testname: Custom Resource Definition, discovery
 		Description: Fetch /apis, /apis/apiextensions.k8s.io, and /apis/apiextensions.k8s.io/v1 discovery documents,
 		and ensure they indicate CustomResourceDefinition apiextensions.k8s.io/v1 resources are available.
+		Behaviors:
+		- apimachinery/crd/discovery
 	*/
 	framework.ConformanceIt("should include custom resource definition resources in discovery documents", func() {
 		{
@@ -263,6 +273,10 @@ var _ = SIGDescribe("CustomResourceDefinition resources [Privileged:ClusterAdmin
 		Description: Create a custom resource definition without default. Create CR. Add default and read CR until
 		the default is applied. Create another CR. Remove default, add default for another field and read CR until
 		new field is defaulted, but old default stays.
+		Behaviors:
+		- apimachinery/crd/default/create
+		- apimachinery/crd/default/update
+		- apimachinery/crd/default/add
 	*/
 	framework.ConformanceIt("custom resource defaulting for requests and from storage works ", func() {
 		config, err := framework.LoadConfig()

--- a/test/e2e/apimachinery/garbage_collector.go
+++ b/test/e2e/apimachinery/garbage_collector.go
@@ -323,6 +323,8 @@ var _ = SIGDescribe("Garbage collector", func() {
 		Release : v1.9
 		Testname: Garbage Collector, delete replication controller, propagation policy background
 		Description: Create a replication controller with 2 Pods. Once RC is created and the first Pod is created, delete RC with deleteOptions.PropagationPolicy set to Background. Deleting the Replication Controller MUST cause pods created by that RC to be deleted.
+		Behaviors:
+		- apimachinery/gc/rc/delete/propagationPolicy/Background
 	*/
 	framework.ConformanceIt("should delete pods created by rc when not orphaning", func() {
 		clientSet := f.ClientSet
@@ -381,6 +383,8 @@ var _ = SIGDescribe("Garbage collector", func() {
 		Release : v1.9
 		Testname: Garbage Collector, delete replication controller, propagation policy orphan
 		Description: Create a replication controller with maximum allocatable Pods between 10 and 100 replicas. Once RC is created and the all Pods are created, delete RC with deleteOptions.PropagationPolicy set to Orphan. Deleting the Replication Controller MUST cause pods created by that RC to be orphaned.
+		Behaviors:
+		- apimachinery/gc/rc/delete/propagationPolicy/Orphan
 	*/
 	framework.ConformanceIt("should orphan pods created by rc if delete options say so", func() {
 		clientSet := f.ClientSet
@@ -502,6 +506,8 @@ var _ = SIGDescribe("Garbage collector", func() {
 		Release : v1.9
 		Testname: Garbage Collector, delete deployment,  propagation policy background
 		Description: Create a deployment with a replicaset. Once replicaset is created , delete the deployment  with deleteOptions.PropagationPolicy set to Background. Deleting the deployment MUST delete the replicaset created by the deployment and also the Pods that belong to the deployments MUST be deleted.
+		Behaviors:
+		- apimachinery/gc/deployment/delete/propagationPolicy/Background
 	*/
 	framework.ConformanceIt("should delete RS created by deployment when not orphaning", func() {
 		clientSet := f.ClientSet
@@ -561,6 +567,8 @@ var _ = SIGDescribe("Garbage collector", func() {
 		Release : v1.9
 		Testname: Garbage Collector, delete deployment, propagation policy orphan
 		Description: Create a deployment with a replicaset. Once replicaset is created , delete the deployment  with deleteOptions.PropagationPolicy set to Orphan. Deleting the deployment MUST cause the replicaset created by the deployment to be orphaned, also the Pods created by the deployments MUST be orphaned.
+		Behaviors:
+		- apimachinery/gc/deployment/delete/propagationPolicy/Orphan
 	*/
 	framework.ConformanceIt("should orphan RS created by deployment when deleteOptions.PropagationPolicy is Orphan", func() {
 		clientSet := f.ClientSet
@@ -645,6 +653,8 @@ var _ = SIGDescribe("Garbage collector", func() {
 		Release : v1.9
 		Testname: Garbage Collector, delete replication controller, after owned pods
 		Description: Create a replication controller with maximum allocatable Pods between 10 and 100 replicas. Once RC is created and the all Pods are created, delete RC with deleteOptions.PropagationPolicy set to Foreground. Deleting the Replication Controller MUST cause pods created by that RC to be deleted before the RC is deleted.
+		Behaviors:
+		- apimachinery/gc/rc/delete/propagationPolicy/Foreground
 	*/
 	framework.ConformanceIt("should keep the rc around until all its pods are deleted if the deleteOptions says so", func() {
 		clientSet := f.ClientSet
@@ -730,6 +740,8 @@ var _ = SIGDescribe("Garbage collector", func() {
 		Release : v1.9
 		Testname: Garbage Collector, multiple owners
 		Description: Create a replication controller RC1, with maximum allocatable Pods between 10 and 100 replicas. Create second replication controller RC2 and set RC2 as owner for half of those replicas. Once RC1 is created and the all Pods are created, delete RC1 with deleteOptions.PropagationPolicy set to Foreground. Half of the Pods that has RC2 as owner MUST not be deleted but have a deletion timestamp. Deleting the Replication Controller MUST not delete Pods that are owned by multiple replication controllers.
+		Behaviors:
+		- apimachinery/gc/rc/delete/pod-multiple-owner
 	*/
 	framework.ConformanceIt("should not delete dependents that have both valid owner and owner that's waiting for dependents to be deleted", func() {
 		clientSet := f.ClientSet
@@ -844,6 +856,9 @@ var _ = SIGDescribe("Garbage collector", func() {
 		Release : v1.9
 		Testname: Garbage Collector, dependency cycle
 		Description: Create three pods, patch them with Owner references such that pod1 has pod3, pod2 has pod1 and pod3 has pod2 as owner references respectively. Delete pod1 MUST delete all pods. The dependency cycle MUST not block the garbage collection.
+		Behaviors:
+		- apimachinery/gc/delete/dependency
+		- apimachinery/gc/delete/dependency-cycle
 	*/
 	framework.ConformanceIt("should not be blocked by dependency circle", func() {
 		clientSet := f.ClientSet

--- a/test/e2e/apimachinery/webhook.go
+++ b/test/e2e/apimachinery/webhook.go
@@ -695,7 +695,6 @@ var _ = SIGDescribe("AdmissionWebhook [Privileged:ClusterAdmin]", func() {
 		- apimachinery/webhook/admission/mutating/basic
 		- apimachinery/webhook/admission/mutating/label
 		- apimachinery/webhook/admission/mutating/delete
-
 	*/
 	framework.ConformanceIt("listing mutating webhooks should work", func() {
 		testListSize := 10


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

New Conformance Behaviors format per [KEP](https://github.com/kubernetes/enhancements/tree/master/keps/sig-architecture/960-conformance-behaviors)

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/area conformance
/assign @johnbelamaric 
/assign @spiffxp 