### PR TITLE
Conformance Behaviors Mapping sig-scheduling

### DIFF
--- a/test/conformance/behaviors/sig-scheduling/limitrange.yaml
+++ b/test/conformance/behaviors/sig-scheduling/limitrange.yaml
@@ -1,0 +1,9 @@
+suite: scheduling/limitrange
+description: Base suite for LimitRange
+behaviors:
+- id: scheduling/limitrange/basic-create
+  description: When a LimitRange is created, pods with no resource requirements must have the default resource requirements applied.
+- id: scheduling/limitrange/basic-update
+  description: When a LimitRange is updated, the new constraints must be enforced.
+- id: scheduling/limitrange/basic-delete
+  description: When a LimitRange is deleted, creating new pods should not enforce any resource limitations.

--- a/test/conformance/behaviors/sig-scheduling/predicates.yaml
+++ b/test/conformance/behaviors/sig-scheduling/predicates.yaml
@@ -1,0 +1,13 @@
+suite: scheduling/predicates
+description: Base suite for Predicates
+behaviors:
+- id: scheduling/predicates/basic
+  description: Scheduling Pods must fail if the resource requests exceed Machine capacity.
+- id: scheduling/predicates/nodeSelector/invalid
+  description: Create a Pod with a NodeSelector set to a value that does not match a node in the cluster. Since there are no nodes matching the criteria the Pod MUST not be scheduled.
+- id: scheduling/predicates/nodeSelector/valid
+  description: Creating a pod with a nodeSelector matching a particular node must result in the Pod scheduled onto that node.
+- id: scheduling/predicates/HostPort/same
+  description: Pods with the same HostPort value MUST be able to be scheduled to the same node if the HostIP or Protocol is different.
+- id: scheduling/predicates/HostPort/allIPs
+  description: If a Pod is scheduled with the default HostIP of 0.0.0.0 (representing all IPs on the host) then no other Pod should be schedulable on any HostIP with the same HostPort and Protocol on the same node.

--- a/test/conformance/behaviors/sig-scheduling/preemption.yaml
+++ b/test/conformance/behaviors/sig-scheduling/preemption.yaml
@@ -1,0 +1,15 @@
+suite: scheduling/framework
+description: Base suite for Scheduling Framework
+behaviors:
+- id: scheduling/framework/predicates/basic
+  description: Scheduling Pods must fail if the resource requests exceed Machine capacity.
+- id: scheduling/framework/predicates/nodeSelector/invalid
+  description: Create a Pod with a NodeSelector set to a value that does not match a node in the cluster. Since there are no nodes matching the criteria the Pod MUST not be scheduled.
+- id: scheduling/framework/predicates/nodeSelector/valid
+  description: Creating a pod with a nodeSelector matching a particular node must result in the Pod scheduled onto that node.
+- id: scheduling/framework/predicates/HostPort/same
+  description: Pods with the same HostPort value MUST be able to be scheduled to the same node if the HostIP or Protocol is different.
+- id: scheduling/framework/predicates/HostPort/allIPs
+  description: If a Pod is scheduled with the default HostIP of 0.0.0.0 (representing all IPs on the host) then no other Pod should be schedulable on any HostIP with the same HostPort and Protocol on the same node.
+- id: scheduling/framework/preemption/priority
+  description: Given a ReplicaSet with different levels of priority, pods must be created in order of priority.

--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -1870,12 +1870,18 @@
     validate the pod resources are applied to the Limitrange
   release: v1.18
   file: test/e2e/scheduling/limit_range.go
+  behaviors:
+  - scheduling/limitrange/basic-create
+  - scheduling/limitrange/basic-update
+  - scheduling/limitrange/basic-delete
 - testname: Scheduler, resource limits
   codename: '[sig-scheduling] SchedulerPredicates [Serial] validates resource limits
     of pods that are allowed to run  [Conformance]'
   description: Scheduling Pods MUST fail if the resource requests exceed Machine capacity.
   release: v1.9
   file: test/e2e/scheduling/predicates.go
+  behaviors:
+  - scheduling/framework/predicates/basic
 - testname: Scheduler, node selector matching
   codename: '[sig-scheduling] SchedulerPredicates [Serial] validates that NodeSelector
     is respected if matching  [Conformance]'
@@ -1884,6 +1890,8 @@
     then Pod MUST be scheduled on that node.'
   release: v1.9
   file: test/e2e/scheduling/predicates.go
+  behaviors:
+  - scheduling/framework/predicates/nodeSelector/invalid
 - testname: Scheduler, node selector not matching
   codename: '[sig-scheduling] SchedulerPredicates [Serial] validates that NodeSelector
     is respected if not matching  [Conformance]'
@@ -1892,6 +1900,8 @@
     MUST not be scheduled.
   release: v1.9
   file: test/e2e/scheduling/predicates.go
+  behaviors:
+  - scheduling/framework/predicates/nodeSelector/invalid
 - testname: Scheduling, HostPort and Protocol match, HostIPs different but one is
     default HostIP (0.0.0.0)
   codename: '[sig-scheduling] SchedulerPredicates [Serial] validates that there exists
@@ -1902,6 +1912,8 @@
     which represents all IPs on the host.
   release: v1.16
   file: test/e2e/scheduling/predicates.go
+  behaviors:
+  - scheduling/framework/predicates/HostPort/allIPs
 - testname: Scheduling, HostPort matching and HostIP and Protocol not-matching
   codename: '[sig-scheduling] SchedulerPredicates [Serial] validates that there is
     no conflict between pods with same hostPort but different hostIP and protocol
@@ -1910,6 +1922,8 @@
     same node if the HostIP or Protocol is different.
   release: v1.16
   file: test/e2e/scheduling/predicates.go
+  behaviors:
+  - scheduling/framework/predicates/HostPort/same
 - testname: Pod preemption verification
   codename: '[sig-scheduling] SchedulerPreemption [Serial] PreemptionExecutionPath
     runs ReplicaSets to verify preemption running path [Conformance]'
@@ -1919,6 +1933,8 @@
     number of Replicas.
   release: v1.19
   file: test/e2e/scheduling/preemption.go
+  behaviors:
+  - scheduling/framework/preemption/priority
 - testname: ConfigMap Volume, text data, binary data
   codename: '[sig-storage] ConfigMap binary data should be reflected in volume [NodeConformance]
     [Conformance]'

--- a/test/e2e/scheduling/limit_range.go
+++ b/test/e2e/scheduling/limit_range.go
@@ -52,6 +52,10 @@ var _ = SIGDescribe("LimitRange", func() {
 		Release : v1.18
 		Testname: LimitRange, resources
 		Description: Creating a Limitrange and verifying the creation of Limitrange, updating the Limitrange and validating the Limitrange. Creating Pods with resources and validate the pod resources are applied to the Limitrange
+		Behaviors:
+		- scheduling/limitrange/basic-create
+		- scheduling/limitrange/basic-update
+		- scheduling/limitrange/basic-delete
 	*/
 	framework.ConformanceIt("should create a LimitRange with defaults and ensure pod has those defaults applied.", func() {
 		ginkgo.By("Creating a LimitRange")

--- a/test/e2e/scheduling/predicates.go
+++ b/test/e2e/scheduling/predicates.go
@@ -321,6 +321,8 @@ var _ = SIGDescribe("SchedulerPredicates [Serial]", func() {
 		Release : v1.9
 		Testname: Scheduler, resource limits
 		Description: Scheduling Pods MUST fail if the resource requests exceed Machine capacity.
+		Behaviors:
+		- scheduling/framework/predicates/basic
 	*/
 	framework.ConformanceIt("validates resource limits of pods that are allowed to run ", func() {
 		WaitForStableCluster(cs, masterNodes)
@@ -431,6 +433,8 @@ var _ = SIGDescribe("SchedulerPredicates [Serial]", func() {
 		Release : v1.9
 		Testname: Scheduler, node selector not matching
 		Description: Create a Pod with a NodeSelector set to a value that does not match a node in the cluster. Since there are no nodes matching the criteria the Pod MUST not be scheduled.
+		Behaviors:
+		- scheduling/framework/predicates/nodeSelector/invalid
 	*/
 	framework.ConformanceIt("validates that NodeSelector is respected if not matching ", func() {
 		ginkgo.By("Trying to schedule Pod with nonempty NodeSelector.")
@@ -454,6 +458,8 @@ var _ = SIGDescribe("SchedulerPredicates [Serial]", func() {
 		Release : v1.9
 		Testname: Scheduler, node selector matching
 		Description: Create a label on the node {k: v}. Then create a Pod with a NodeSelector set to {k: v}. Check to see if the Pod is scheduled. When the NodeSelector matches then Pod MUST be scheduled on that node.
+		Behaviors:
+		- scheduling/framework/predicates/nodeSelector/invalid
 	*/
 	framework.ConformanceIt("validates that NodeSelector is respected if matching ", func() {
 		nodeName := GetNodeThatCanRunPod(f)
@@ -659,6 +665,8 @@ var _ = SIGDescribe("SchedulerPredicates [Serial]", func() {
 		Testname: Scheduling, HostPort matching and HostIP and Protocol not-matching
 		Description: Pods with the same HostPort value MUST be able to be scheduled to the same node
 		if the HostIP or Protocol is different.
+		Behaviors:
+		- scheduling/framework/predicates/HostPort/same
 	*/
 	framework.ConformanceIt("validates that there is no conflict between pods with same hostPort but different hostIP and protocol", func() {
 
@@ -692,6 +700,8 @@ var _ = SIGDescribe("SchedulerPredicates [Serial]", func() {
 		Testname: Scheduling, HostPort and Protocol match, HostIPs different but one is default HostIP (0.0.0.0)
 		Description: Pods with the same HostPort and Protocol, but different HostIPs, MUST NOT schedule to the
 		same node if one of those IPs is the default HostIP of 0.0.0.0, which represents all IPs on the host.
+		Behaviors:
+		- scheduling/framework/predicates/HostPort/allIPs
 	*/
 	framework.ConformanceIt("validates that there exists conflict between pods with same hostPort and protocol but one using 0.0.0.0 hostIP", func() {
 		nodeName := GetNodeThatCanRunPod(f)

--- a/test/e2e/scheduling/preemption.go
+++ b/test/e2e/scheduling/preemption.go
@@ -520,6 +520,8 @@ var _ = SIGDescribe("SchedulerPreemption [Serial]", func() {
 			Release: v1.19
 			Testname: Pod preemption verification
 			Description: Four levels of Pods in ReplicaSets with different levels of Priority, restricted by given CPU limits MUST launch. Priority 1 - 3 Pods MUST spawn first followed by Priority 4 Pod. The ReplicaSets with Replicas MUST contain the expected number of Replicas.
+			Behaviors:
+			- scheduling/framework/preemption/priority
 		*/
 		framework.ConformanceIt("runs ReplicaSets to verify preemption running path", func() {
 			podNamesSeen := []int32{0, 0, 0}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

Since scheduling predicates and preemption mechanisms aren't directly tied to a Kubernetes resource, I put them as part of the `scheduling/framework` group. If you have alternative suggestions, feel free to comment.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/area conformance
/assign @johnbelamaric 
/assign @spiffxp 
