### PR TITLE
Remove a unit test for PDB with multiple controllers

### DIFF
--- a/pkg/controller/disruption/disruption.go
+++ b/pkg/controller/disruption/disruption.go
@@ -636,9 +636,8 @@ func (dc *DisruptionController) getExpectedScale(pdb *policy.PodDisruptionBudget
 	// and each C_pi is the set of controllers controlling the pod pi
 
 	// k8s only defines what will happens when 0 or 1 controllers control a
-	// given pod.  We explicitly exclude the 0 controllers case here, and we
-	// report an error if we find a pod with more than 1 controller.  Thus in
-	// practice each C_pi is a set of exactly 1 controller.
+	// given pod.  We explicitly exclude the 0 controllers case here.
+	// Thus in practice each C_pi is a set of exactly 1 controller.
 
 	// A mapping from controllers to their scale.
 	controllerScale := map[types.UID]int32{}


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
There is TODO comment in pkg/controller/disruption/disruption_test.go.
```
	// 100%>1% healthy BUT two RCs => no disruption allowed	
	// TODO: Find out if this assert is still needed	
	//ps.VerifyDisruptionAllowed(t, pdbName, 0)
```

The TODO was added at #45003.
Before merging #49861, disruption controller returned error and no disruption allowed if a pod has more than 1 controllers.
After the commit, it does not return error.
https://github.com/kubernetes/kubernetes/commit/de3f09780b4abc853b0a114b4e45aa57e52db7a0#diff-af923020fb5800d949a2b1acd9117903L613

Therefore, I think we do not need the unit test for multiple controllers.


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs

```