### PR TITLE
Add function GetFileShare in Azure Cloud Provider

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_file.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_file.go
@@ -18,6 +18,10 @@ limitations under the License.
 
 package azure
 
+import (
+	"github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2019-06-01/storage"
+)
+
 // create file share
 func (az *Cloud) createFileShare(resourceGroupName, accountName, name string, sizeGiB int) error {
 	return az.FileClient.CreateFileShare(resourceGroupName, accountName, name, sizeGiB)
@@ -29,4 +33,8 @@ func (az *Cloud) deleteFileShare(resourceGroupName, accountName, name string) er
 
 func (az *Cloud) resizeFileShare(resourceGroupName, accountName, name string, sizeGiB int) error {
 	return az.FileClient.ResizeFileShare(resourceGroupName, accountName, name, sizeGiB)
+}
+
+func (az *Cloud) getFileShare(resourceGroupName, accountName, name string) (storage.FileShare, error) {
+	return az.FileClient.GetFileShare(resourceGroupName, accountName, name)
 }

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_storage.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_storage.go
@@ -66,3 +66,8 @@ func (az *Cloud) DeleteFileShare(resourceGroup, accountName, shareName string) e
 func (az *Cloud) ResizeFileShare(resourceGroup, accountName, name string, sizeGiB int) error {
 	return az.resizeFileShare(resourceGroup, accountName, name, sizeGiB)
 }
+
+// GetFileShare gets a file share
+func (az *Cloud) GetFileShare(resourceGroupName, accountName, name string) (storage.FileShare, error) {
+	return az.getFileShare(resourceGroupName, accountName, name)
+}

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/clients/fileclient/azure_fileclient.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/clients/fileclient/azure_fileclient.go
@@ -89,3 +89,8 @@ func (c *Client) ResizeFileShare(resourceGroupName, accountName, name string, si
 
 	return nil
 }
+
+// GetFileShare gets a file share
+func (c *Client) GetFileShare(resourceGroupName, accountName, name string) (storage.FileShare, error) {
+	return c.fileSharesClient.Get(context.Background(), resourceGroupName, accountName, name)
+}

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/clients/fileclient/interface.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/clients/fileclient/interface.go
@@ -18,10 +18,15 @@ limitations under the License.
 
 package fileclient
 
+import (
+	"github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2019-06-01/storage"
+)
+
 // Interface is the client interface for creating file shares, interface for test injection.
 // mockgen -source=$GOPATH/src/k8s.io/kubernetes/staging/src/k8s.io/legacy-cloud-providers/azure/clients/fileclient/interface.go -package=mockfileclient Interface > $GOPATH/src/k8s.io/kubernetes/staging/src/k8s.io/legacy-cloud-providers/azure/clients/fileclient/mockfileclient/interface.go
 type Interface interface {
 	CreateFileShare(resourceGroupName, accountName, name string, sizeGiB int) error
 	DeleteFileShare(resourceGroupName, accountName, name string) error
 	ResizeFileShare(resourceGroupName, accountName, name string, sizeGiB int) error
+	GetFileShare(resourceGroupName, accountName, name string) (storage.FileShare, error)
 }

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/clients/fileclient/mockfileclient/BUILD
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/clients/fileclient/mockfileclient/BUILD
@@ -9,7 +9,10 @@ go_library(
     importmap = "k8s.io/kubernetes/vendor/k8s.io/legacy-cloud-providers/azure/clients/fileclient/mockfileclient",
     importpath = "k8s.io/legacy-cloud-providers/azure/clients/fileclient/mockfileclient",
     visibility = ["//visibility:public"],
-    deps = ["//vendor/github.com/golang/mock/gomock:go_default_library"],
+    deps = [
+        "//vendor/github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2019-06-01/storage:go_default_library",
+        "//vendor/github.com/golang/mock/gomock:go_default_library",
+    ],
 )
 
 filegroup(

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/clients/fileclient/mockfileclient/interface.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/clients/fileclient/mockfileclient/interface.go
@@ -19,9 +19,9 @@ limitations under the License.
 package mockfileclient
 
 import (
-	reflect "reflect"
-
+	storage "github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2019-06-01/storage"
 	gomock "github.com/golang/mock/gomock"
+	reflect "reflect"
 )
 
 // MockInterface is a mock of Interface interface
@@ -87,4 +87,19 @@ func (m *MockInterface) ResizeFileShare(resourceGroupName, accountName, name str
 func (mr *MockInterfaceMockRecorder) ResizeFileShare(resourceGroupName, accountName, name, sizeGiB interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResizeFileShare", reflect.TypeOf((*MockInterface)(nil).ResizeFileShare), resourceGroupName, accountName, name, sizeGiB)
+}
+
+// GetFileShare mocks base method
+func (m *MockInterface) GetFileShare(resourceGroupName, accountName, name string) (storage.FileShare, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetFileShare", resourceGroupName, accountName, name)
+	ret0, _ := ret[0].(storage.FileShare)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetFileShare indicates an expected call of GetFileShare
+func (mr *MockInterfaceMockRecorder) GetFileShare(resourceGroupName, accountName, name interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFileShare", reflect.TypeOf((*MockInterface)(nil).GetFileShare), resourceGroupName, accountName, name)
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind flake

**What this PR does / why we need it**:
Add function GetFileShare in Azure Cloud Provider. Then we can use management SDK to get file share instead of data plane SDK.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
