### PR TITLE
[1.18] Update bucket location for cri-tools

### DIFF
--- a/cluster/gce/gci/configure.sh
+++ b/cluster/gce/gci/configure.sh
@@ -29,7 +29,7 @@ DEFAULT_CNI_SHA1="a31251105250279fe57b4474d91d2db1d4d48b5a"
 DEFAULT_NPD_VERSION="v0.8.0"
 DEFAULT_NPD_SHA1="9406c975b1b035995a137029a004622b905b4e7f"
 DEFAULT_CRICTL_VERSION="v1.17.0"
-DEFAULT_CRICTL_SHA1="5c18f4e52ab524d429063b78d086dd18b894aae7"
+DEFAULT_CRICTL_SHA1="41116457c34da51e5df8de6ae8404889c4c7080a"
 DEFAULT_MOUNTER_TAR_SHA="8003b798cf33c7f91320cd6ee5cec4fa22244571"
 ###
 
@@ -280,7 +280,7 @@ function install-crictl {
     local -r crictl_version="${DEFAULT_CRICTL_VERSION}"
     local -r crictl_sha1="${DEFAULT_CRICTL_SHA1}"
   fi
-  local -r crictl="crictl-${crictl_version}-linux-amd64"
+  local -r crictl="crictl-${crictl_version}-linux-amd64.tar.gz"
 
   # Create crictl config file.
   cat > /etc/crictl.yaml <<EOF
@@ -293,10 +293,10 @@ EOF
   fi
 
   echo "Downloading crictl"
-  local -r crictl_path="https://storage.googleapis.com/kubernetes-release/crictl"
+  local -r crictl_path="https://storage.googleapis.com/k8s-artifacts-cri-tools/release/${crictl_version}"
   download-or-bust "${crictl_sha1}" "${crictl_path}/${crictl}"
-  mv "${KUBE_HOME}/${crictl}" "${KUBE_BIN}/crictl"
-  chmod a+x "${KUBE_BIN}/crictl"
+  tar xf "${crictl}"
+  mv crictl "${KUBE_BIN}/crictl"
 }
 
 function install-exec-auth-plugin {

--- a/cluster/gce/windows/k8s-node-setup.psm1
+++ b/cluster/gce/windows/k8s-node-setup.psm1
@@ -1224,18 +1224,22 @@ function Verify-WorkerServices {
   Log_Todo "run more verification commands."
 }
 
-# Downloads crictl.exe and installs it in $env:NODE_DIR.
+# Downloads the Windows crictl package and installs its contents (e.g.
+# crictl.exe) in $env:NODE_DIR.
 function DownloadAndInstall-Crictl {
   if (-not (ShouldWrite-File ${env:NODE_DIR}\crictl.exe)) {
     return
   }
-  $url = ('https://storage.googleapis.com/kubernetes-release/crictl/' +
-      'crictl-' + $CRICTL_VERSION + '-windows-amd64.exe')
+  $CRI_TOOLS_GCS_BUCKET = 'k8s-artifacts-cri-tools'
+  $url = ('https://storage.googleapis.com/' + $CRI_TOOLS_GCS_BUCKET +
+          '/release/' + $CRICTL_VERSION + '/crictl-' + $CRICTL_VERSION +
+          '-windows-amd64.tar.gz')
   MustDownload-File `
       -URLs $url `
-      -OutFile ${env:NODE_DIR}\crictl.exe `
+      -OutFile ${env:NODE_DIR}\crictl.tar.gz `
       -Hash $CRICTL_SHA256 `
       -Algorithm SHA256
+  tar xzvf ${env:NODE_DIR}\crictl.tar.gz -C ${env:NODE_DIR}
 }
 
 # Sets crictl configuration values.


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

We now use the k8s-artifacts-cri-tools bucket for downloading the
binaries in GCE to synchronize with the latest changes from the master
branch.

**Which issue(s) this PR fixes**:

Incorporates with https://github.com/kubernetes/kubernetes/pull/91564 (partly cherry-picket)
Refers to https://github.com/kubernetes-sigs/cri-tools/issues/616
X-Ref is https://github.com/kubernetes/kubernetes/pull/91662, https://github.com/kubernetes/kubernetes/pull/91663

**Special notes for your reviewer**:

cc @kubernetes/release-managers 

**Does this PR introduce a user-facing change?**:

```release-note
None
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs
None
```
