### PR TITLE
pkg/kubelet: add KUBE-FIREWALL-IN chain, move localnet rule to it

### DIFF
--- a/pkg/kubelet/kubelet_network.go
+++ b/pkg/kubelet/kubelet_network.go
@@ -19,7 +19,7 @@ package kubelet
 import (
 	"fmt"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 	"k8s.io/klog/v2"
 	utiliptables "k8s.io/kubernetes/pkg/util/iptables"
@@ -38,6 +38,9 @@ const (
 
 	// KubeFirewallChain is kubernetes firewall rules
 	KubeFirewallChain utiliptables.Chain = "KUBE-FIREWALL"
+
+	// KubeFirewallInChain is firewall rules only for incoming packets
+	KubeFirewallInChain utiliptables.Chain = "KUBE-FIREWALL-IN"
 )
 
 // providerRequiresNetworkingConfiguration returns whether the cloud provider


### PR DESCRIPTION
@champtar observed that the rule added in #91569 still allowed packets through unidirectionally, meaning UDP with a spoofed source wouldn't be caught. So we need to filter on source interface.

However, KUBE-FIREWALL is run on both OUTPUT and INPUT, so it can't reference interfaces. This PR, thus,
- creates a chain KUBE-FIREWALL-IN
- Add it to INPUT, pass through to KUBE-FIREWALL
- Move the localnet protection rule to KUBE-FIREWALL-IN, and adjust it
  to reference source if, not source address.

Signed-off-by: Casey Callendrello <cdc@redhat.com>


**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #90259

**Special notes for your reviewer**:
You can test this pretty simply using `cnitool` if you don't want to spin up a whole kind cluster.


**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/sig network