### PR TITLE
Fix pick-node strategy when there is no filter plugin

### DIFF
--- a/pkg/scheduler/core/generic_scheduler.go
+++ b/pkg/scheduler/core/generic_scheduler.go
@@ -427,10 +427,11 @@ func (g *genericScheduler) findNodesThatPassFilters(ctx context.Context, prof *p
 	filtered := make([]*v1.Node, numNodesToFind)
 
 	if !prof.HasFilterPlugins() {
+		length := len(allNodes)
 		for i := range filtered {
-			filtered[i] = allNodes[i].Node()
+			filtered[i] = allNodes[(g.nextStartNodeIndex+i)%length].Node()
 		}
-		g.nextStartNodeIndex = (g.nextStartNodeIndex + len(filtered)) % len(allNodes)
+		g.nextStartNodeIndex = (g.nextStartNodeIndex + len(filtered)) % length
 		return filtered, nil
 	}
 


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:
Fix the bug of picking node strategy when there is no filter plugin.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
