### PR TITLE
tests: Fixes Windows kubelet-stats test

### DIFF
--- a/test/e2e/windows/kubelet_stats.go
+++ b/test/e2e/windows/kubelet_stats.go
@@ -18,6 +18,7 @@ package windows
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
@@ -128,7 +129,7 @@ func newKubeletStatsTestPods(numPods int, image imageutils.Config, nodeName stri
 		podName := "statscollectiontest-" + string(uuid.NewUUID())
 		pod := v1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: podName,
+				Name: fmt.Sprintf("%s-%d", podName, i),
 				Labels: map[string]string{
 					"name":    podName,
 					"testapp": "stats-collection",
@@ -138,7 +139,7 @@ func newKubeletStatsTestPods(numPods int, image imageutils.Config, nodeName stri
 				Containers: []v1.Container{
 					{
 						Image: image.GetE2EImage(),
-						Name:  podName,
+						Name:  "stat-container",
 						Command: []string{
 							"powershell.exe",
 							"-Command",
@@ -149,7 +150,7 @@ func newKubeletStatsTestPods(numPods int, image imageutils.Config, nodeName stri
 				InitContainers: []v1.Container{
 					{
 						Image: image.GetE2EImage(),
-						Name:  podName,
+						Name:  "init-container",
 						Command: []string{
 							"powershell.exe",
 							"-Command",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind failing-test

/sig windows
/sig testing

**What this PR does / why we need it**:

The test spawns 10 pods with the same pod name, which contains multiple containers with the same container name. Because of this, the test fails. This PR addresses this issue.

Logs: https://paste.ubuntu.com/p/sXTHyXdZNp/

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #91677

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
