### PR TITLE
Mirror pod without OwnerReference should not be created

### DIFF
--- a/plugin/pkg/admission/noderestriction/admission.go
+++ b/plugin/pkg/admission/noderestriction/admission.go
@@ -224,6 +224,9 @@ func (p *Plugin) admitPodCreate(nodeName string, a admission.Attributes) error {
 	if len(pod.OwnerReferences) > 1 {
 		return admission.NewForbidden(a, fmt.Errorf("node %q can only create pods with a single owner reference set to itself", nodeName))
 	}
+	if len(pod.OwnerReferences) == 0 {
+		return admission.NewForbidden(a, fmt.Errorf("node %q can only create pods with an owner reference set to itself", nodeName))
+	}
 	if len(pod.OwnerReferences) == 1 {
 		owner := pod.OwnerReferences[0]
 		if owner.APIVersion != v1.SchemeGroupVersion.String() ||

--- a/plugin/pkg/admission/noderestriction/admission_test.go
+++ b/plugin/pkg/admission/noderestriction/admission_test.go
@@ -1314,8 +1314,9 @@ func Test_nodePlugin_Admit_OwnerReference(t *testing.T) {
 		expectErr   string
 	}{
 		{
-			name:   "no owner",
-			owners: nil,
+			name:      "no owner",
+			owners:    nil,
+			expectErr: "pods \"test\" is forbidden: node \"mynode\" can only create pods with an owner reference set to itself",
 		},
 		{
 			name:   "valid owner",


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This PR updates the NodeRestriction admission controller to reject mirror pods missing owner reference.

Ref: https://github.com/kubernetes/enhancements/issues/1314

**Which issue(s) this PR fixes**:
Fixes #

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
