### PR TITLE
Make kubectl tolerate other versions of the CSR API

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/certificates/certificates.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/certificates/certificates.go
@@ -222,7 +222,7 @@ func (o *CertificateOptions) modifyCertificateCondition(builder *resource.Builde
 		WithScheme(scheme.Scheme, scheme.Scheme.PrioritizedVersionsAllGroups()...).
 		ContinueOnError().
 		FilenameParam(false, &o.FilenameOptions).
-		ResourceNames("certificatesigningrequest", o.csrNames...).
+		ResourceNames("certificatesigningrequests.v1beta1.certificates.k8s.io", o.csrNames...).
 		RequireObject(true).
 		Flatten().
 		Latest().
@@ -232,7 +232,10 @@ func (o *CertificateOptions) modifyCertificateCondition(builder *resource.Builde
 			return err
 		}
 		for i := 0; ; i++ {
-			csr := info.Object.(*certificatesv1beta1.CertificateSigningRequest)
+			csr, ok := info.Object.(*certificatesv1beta1.CertificateSigningRequest)
+			if !ok {
+				return fmt.Errorf("can only handle certificates.k8s.io/v1beta1 certificate signing requests")
+			}
 			csr, hasCondition := modify(csr)
 			if !hasCondition || force {
 				_, err = clientSet.CertificateSigningRequests().UpdateApproval(context.TODO(), csr, metav1.UpdateOptions{})


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
As prep work for CSR v1 API promotion, this will be backported to ensure older versions of kubectl use a specific version of the CSR API.

xref https://github.com/kubernetes/enhancements/issues/1513

**Special notes for your reviewer**:
Will be backported to 1.16-1.18

**Does this PR introduce a user-facing change?**:
```release-note
Resolves an issue using `kubectl certificate approve/deny` against a server serving the v1 CSR API
```

/cc @munnerz 
/sig auth cli