### PR TITLE
Automated cherry pick of #91691: Make kubectl tolerate other versions of the CSR API

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/certificates/certificates.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/certificates/certificates.go
@@ -221,7 +221,7 @@ func (o *CertificateOptions) modifyCertificateCondition(builder *resource.Builde
 		WithScheme(scheme.Scheme, scheme.Scheme.PrioritizedVersionsAllGroups()...).
 		ContinueOnError().
 		FilenameParam(false, &o.FilenameOptions).
-		ResourceNames("certificatesigningrequest", o.csrNames...).
+		ResourceNames("certificatesigningrequests.v1beta1.certificates.k8s.io", o.csrNames...).
 		RequireObject(true).
 		Flatten().
 		Latest().
@@ -231,7 +231,10 @@ func (o *CertificateOptions) modifyCertificateCondition(builder *resource.Builde
 			return err
 		}
 		for i := 0; ; i++ {
-			csr := info.Object.(*certificatesv1beta1.CertificateSigningRequest)
+			csr, ok := info.Object.(*certificatesv1beta1.CertificateSigningRequest)
+			if !ok {
+				return fmt.Errorf("can only handle certificates.k8s.io/v1beta1 certificate signing requests")
+			}
 			csr, hasCondition := modify(csr)
 			if !hasCondition || force {
 				csr, err = clientSet.CertificateSigningRequests().UpdateApproval(csr)


### PR DESCRIPTION
Cherry pick of #91691 on release-1.17.

#91691: Make kubectl tolerate other versions of the CSR API

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.