### PR TITLE
Adjust weight of PodTopologySpread to 2 in legacy Policy API

### DIFF
--- a/pkg/scheduler/framework/plugins/legacy_registry.go
+++ b/pkg/scheduler/framework/plugins/legacy_registry.go
@@ -213,7 +213,7 @@ func NewLegacyRegistry() *LegacyRegistry {
 			NodeAffinityPriority:        1,
 			TaintTolerationPriority:     1,
 			ImageLocalityPriority:       1,
-			EvenPodsSpreadPriority:      1,
+			EvenPodsSpreadPriority:      2,
 		},
 
 		PredicateToConfigProducer: make(map[string]ConfigProducer),

--- a/test/integration/scheduler/scheduler_test.go
+++ b/test/integration/scheduler/scheduler_test.go
@@ -134,7 +134,7 @@ func TestSchedulerCreationFromConfigMap(t *testing.T) {
 				},
 				"ScorePlugin": {
 					{Name: "NodeResourcesBalancedAllocation", Weight: 1},
-					{Name: "PodTopologySpread", Weight: 1},
+					{Name: "PodTopologySpread", Weight: 2},
 					{Name: "ImageLocality", Weight: 1},
 					{Name: "InterPodAffinity", Weight: 1},
 					{Name: "NodeResourcesLeastAllocated", Weight: 1},
@@ -228,7 +228,7 @@ kind: Policy
 				},
 				"ScorePlugin": {
 					{Name: "NodeResourcesBalancedAllocation", Weight: 1},
-					{Name: "PodTopologySpread", Weight: 1},
+					{Name: "PodTopologySpread", Weight: 2},
 					{Name: "ImageLocality", Weight: 1},
 					{Name: "InterPodAffinity", Weight: 1},
 					{Name: "NodeResourcesLeastAllocated", Weight: 1},


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup
/sig scheduling

**What this PR does / why we need it**:

A leftover of #91258 to ensure the adjusted weight(2) of PodTopologySpread is honored in legacy Policy API as well.

**Which issue(s) this PR fixes**:

/ref  #91258

**Special notes for your reviewer**:

Wait for #91598 to be merged.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```