### PR TITLE
update help text for test-e2e-node target

### DIFF
--- a/build/root/Makefile
+++ b/build/root/Makefile
@@ -208,18 +208,29 @@ define TEST_E2E_NODE_HELP_INFO
 # Build and run node end-to-end tests.
 #
 # Args:
+#  Test Settings
+#  TEST_ARGS: Used to pass args to the kubelet when running locally.
+#  IMAGE_CONFIG_FILE: path to a file containing image configuration.
+#  SYSTEM_SPEC_NAME: The name of the system spec to be used for validating the
+#    image in the node conformance test. The specs are located at
+#    test/e2e_node/system/specs/. For example, "SYSTEM_SPEC_NAME=gke" will use
+#    the spec at test/e2e_node/system/specs/gke.yaml. If unspecified, the
+#    default built-in spec (system.DefaultSpec) will be used.
+#  Ginkgo settings
 #  FOCUS: Regexp that matches the tests to be run.  Defaults to "".
 #  SKIP: Regexp that matches the tests that needs to be skipped.  Defaults
-#    to "".
+#    to "\[Flaky\]|\[Slow\]|\[Serial\]".
 #  RUN_UNTIL_FAILURE: If true, pass --untilItFails to ginkgo so tests are run
 #    repeatedly until they fail.  Defaults to false.
+#  PARALLELISM: The number of gingko nodes to run.  Defaults to 8.
+#  Remote settings
 #  REMOTE: If true, run the tests on a remote host instance on GCE.  Defaults
 #    to false.
 #  IMAGES: For REMOTE=true only.  Comma delimited list of images for creating
 #    remote hosts to run tests against.  Defaults to a recent image.
-#  LIST_IMAGES: If true, don't run tests.  Just output the list of available
+#  LIST_IMAGES: For REMOTE=true only. If true, don't run tests. Output the list of available
 #    images for testing.  Defaults to false.
-#  HOSTS: For REMOTE=true only.  Comma delimited list of running gce hosts to
+#  HOSTS: For REMOTE=true only. Comma delimited list of running gce hosts to
 #    run tests against.  Defaults to "".
 #  DELETE_INSTANCES: For REMOTE=true only.  Delete any instances created as
 #    part of this test run.  Defaults to false.
@@ -227,30 +238,24 @@ define TEST_E2E_NODE_HELP_INFO
 #    as preemptible.  Defaults to false.
 #  ARTIFACTS: For REMOTE=true only.  Local directory to scp test artifacts into
 #    from the remote hosts.  Defaults to "/tmp/_artifacts".
-#  REPORT: For REMOTE=false only.  Local directory to write juntil xml results
-#    to.  Defaults to "/tmp/".
 #  CLEANUP: For REMOTE=true only.  If false, do not stop processes or delete
 #    test files on remote hosts.  Defaults to true.
 #  IMAGE_PROJECT: For REMOTE=true only.  Project containing images provided to
-#  IMAGES.  Defaults to "kubernetes-node-e2e-images".
+#    IMAGES.  Defaults to "kubernetes-node-e2e-images".
 #  INSTANCE_PREFIX: For REMOTE=true only.  Instances created from images will
 #    have the name "${INSTANCE_PREFIX}-${IMAGE_NAME}".  Defaults to "test".
 #  INSTANCE_METADATA: For REMOTE=true and running on GCE only.
 #  GUBERNATOR: For REMOTE=true only. Produce link to Gubernator to view logs.
 #	 Defaults to false.
-#  PARALLELISM: The number of gingko nodes to run.  Defaults to 8.
+#  REPORT: For REMOTE=false only.  Local directory to write juntil xml results
+#    to.  Defaults to "/tmp/".
+#  Runtime settings
 #  RUNTIME: Container runtime to use (eg. docker, remote).
 #    Defaults to "docker".
 #  CONTAINER_RUNTIME_ENDPOINT: remote container endpoint to connect to.
 #   Used when RUNTIME is set to "remote".
 #  IMAGE_SERVICE_ENDPOINT: remote image endpoint to connect to, to prepull images.
 #   Used when RUNTIME is set to "remote".
-#  IMAGE_CONFIG_FILE: path to a file containing image configuration.
-#  SYSTEM_SPEC_NAME: The name of the system spec to be used for validating the
-#    image in the node conformance test. The specs are located at
-#    test/e2e_node/system/specs/. For example, "SYSTEM_SPEC_NAME=gke" will use
-#    the spec at test/e2e_node/system/specs/gke.yaml. If unspecified, the
-#    default built-in spec (system.DefaultSpec) will be used.
 #
 # Example:
 #   make test-e2e-node FOCUS=Kubelet SKIP=container


### PR DESCRIPTION
 - document TEST_ARGS used in example
 - Break settings into sections, and move args into appropriate section.
 - update SKIP with default as used in the code


**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
add to and update existing developer help text

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**: