### PR TITLE
Revert assumed PVs and PVCs in unreserve extension point

### DIFF
--- a/pkg/controller/volume/scheduling/scheduler_binder.go
+++ b/pkg/controller/volume/scheduling/scheduler_binder.go
@@ -118,6 +118,9 @@ type SchedulerVolumeBinder interface {
 	// This function is called serially.
 	AssumePodVolumes(assumedPod *v1.Pod, nodeName string) (allFullyBound bool, err error)
 
+	// RevertAssumedPodVolumes will revert assumed PV and PVC cache.
+	RevertAssumedPodVolumes(assumedPod *v1.Pod, nodeName string)
+
 	// BindPodVolumes will:
 	// 1. Initiate the volume binding by making the API call to prebind the PV
 	// to its matching PVC.
@@ -385,6 +388,12 @@ func (b *volumeBinder) AssumePodVolumes(assumedPod *v1.Pod, nodeName string) (al
 	b.podBindingCache.UpdateBindings(assumedPod, nodeName, newBindings, newProvisionedPVCs)
 
 	return
+}
+
+// RevertAssumedPodVolumes will revert assumed PV and PVC cache.
+func (b *volumeBinder) RevertAssumedPodVolumes(assumedPod *v1.Pod, nodeName string) {
+	b.revertAssumedPVs(b.podBindingCache.GetBindings(assumedPod, nodeName))
+	b.revertAssumedPVCs(b.podBindingCache.GetProvisionedPVCs(assumedPod, nodeName))
 }
 
 // BindPodVolumes gets the cached bindings and PVCs to provision in podBindingCache,

--- a/pkg/controller/volume/scheduling/scheduler_binder_fake.go
+++ b/pkg/controller/volume/scheduling/scheduler_binder_fake.go
@@ -53,6 +53,9 @@ func (b *FakeVolumeBinder) AssumePodVolumes(assumedPod *v1.Pod, nodeName string)
 	return b.config.AllBound, b.config.AssumeErr
 }
 
+// RevertAssumedPodVolumes implements SchedulerVolumeBinder.RevertAssumedPodVolumes
+func (b *FakeVolumeBinder) RevertAssumedPodVolumes(assumedPod *v1.Pod, nodeName string) {}
+
 // BindPodVolumes implements SchedulerVolumeBinder.BindPodVolumes.
 func (b *FakeVolumeBinder) BindPodVolumes(assumedPod *v1.Pod) error {
 	b.BindCalled = true

--- a/pkg/controller/volume/scheduling/scheduler_binder_test.go
+++ b/pkg/controller/volume/scheduling/scheduler_binder_test.go
@@ -465,13 +465,14 @@ func (env *testEnv) validateAssume(t *testing.T, pod *v1.Pod, bindings []*bindin
 	}
 }
 
-func (env *testEnv) validateFailedAssume(t *testing.T, pod *v1.Pod, bindings []*bindingInfo, provisionings []*v1.PersistentVolumeClaim) {
+func (env *testEnv) validateCacheRestored(t *testing.T, pod *v1.Pod, bindings []*bindingInfo, provisionings []*v1.PersistentVolumeClaim) {
 	// All PVs have been unmodified in cache
 	pvCache := env.internalBinder.pvCache
 	for _, b := range bindings {
 		pv, _ := pvCache.GetPV(b.pv.Name)
+		apiPV, _ := pvCache.GetAPIPV(b.pv.Name)
 		// PV could be nil if it's missing from cache
-		if pv != nil && pv != b.pv {
+		if pv != nil && pv != apiPV {
 			t.Errorf("PV %q was modified in cache", b.pv.Name)
 		}
 	}
@@ -1225,7 +1226,7 @@ func TestAssumePodVolumes(t *testing.T) {
 			scenario.expectedProvisionings = scenario.provisionedPVCs
 		}
 		if scenario.shouldFail {
-			testEnv.validateFailedAssume(t, pod, scenario.expectedBindings, scenario.expectedProvisionings)
+			testEnv.validateCacheRestored(t, pod, scenario.bindings, scenario.provisionedPVCs)
 		} else {
 			testEnv.validateAssume(t, pod, scenario.expectedBindings, scenario.expectedProvisionings)
 		}
@@ -1235,6 +1236,34 @@ func TestAssumePodVolumes(t *testing.T) {
 	for name, scenario := range scenarios {
 		t.Run(name, func(t *testing.T) { run(t, scenario) })
 	}
+}
+
+func TestRevertAssumedPodVolumes(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	podPVCs := []*v1.PersistentVolumeClaim{unboundPVC, provisionedPVC}
+	bindings := []*bindingInfo{makeBinding(unboundPVC, pvNode1a)}
+	pvs := []*v1.PersistentVolume{pvNode1a}
+	provisionedPVCs := []*v1.PersistentVolumeClaim{provisionedPVC}
+	expectedBindings := []*bindingInfo{makeBinding(unboundPVC, pvNode1aBound)}
+	expectedProvisionings := []*v1.PersistentVolumeClaim{selectedNodePVC}
+
+	// Setup
+	testEnv := newTestBinder(t, ctx.Done())
+	testEnv.initClaims(podPVCs, podPVCs)
+	pod := makePod(podPVCs)
+	testEnv.initPodCache(pod, "node1", bindings, provisionedPVCs)
+	testEnv.initVolumes(pvs, pvs)
+
+	allbound, err := testEnv.binder.AssumePodVolumes(pod, "node1")
+	if allbound || err != nil {
+		t.Errorf("No volumes are assumed")
+	}
+	testEnv.validateAssume(t, pod, expectedBindings, expectedProvisionings)
+
+	testEnv.binder.RevertAssumedPodVolumes(pod, "node1")
+	testEnv.validateCacheRestored(t, pod, bindings, provisionedPVCs)
 }
 
 func TestBindAPIUpdate(t *testing.T) {

--- a/pkg/scheduler/framework/plugins/volumebinding/volume_binding.go
+++ b/pkg/scheduler/framework/plugins/volumebinding/volume_binding.go
@@ -157,9 +157,10 @@ func (pl *VolumeBinding) PreBind(ctx context.Context, cs *framework.CycleState, 
 	return nil
 }
 
-// Unreserve clears pod binding state.
-// TODO(#90962) Revert assumed PV/PVC cache
+// Unreserve clears assumed PV and PVC cache and pod binding state.
+// It's idempotent, and does nothing if no cache or binding state found for the given pod.
 func (pl *VolumeBinding) Unreserve(ctx context.Context, cs *framework.CycleState, pod *v1.Pod, nodeName string) {
+	pl.Binder.RevertAssumedPodVolumes(pod, nodeName)
 	pl.Binder.DeletePodBindings(pod)
 	return
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind api-change
> /kind bug

/kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Revert assumed PVs and PVCs in unreserve extension point of volume binding scheduler plugin.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #91654

**Special notes for your reviewer**:
Ignoring problems about another scheduling cycle.
https://github.com/kubernetes/kubernetes/issues/56180#issuecomment-457046118

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
