### PR TITLE
Fixing refcounting of remote endpoints used across services

### DIFF
--- a/pkg/proxy/winkernel/proxier.go
+++ b/pkg/proxy/winkernel/proxier.go
@@ -157,7 +157,7 @@ type endpointsInfo struct {
 	isLocal         bool
 	macAddress      string
 	hnsID           string
-	refCount        uint16
+	refCount        *uint16
 	providerAddress string
 	hns             HostNetworkService
 }
@@ -179,7 +179,7 @@ func newEndpointInfo(ip string, port uint16, isLocal bool, hns HostNetworkServic
 		port:       port,
 		isLocal:    isLocal,
 		macAddress: conjureMac("02-11", net.ParseIP(ip)),
-		refCount:   0,
+		refCount:   new(uint16),
 		hnsID:      "",
 		hns:        hns,
 	}
@@ -200,11 +200,14 @@ func newSourceVIP(hns HostNetworkService, network string, ip string, mac string,
 
 func (ep *endpointsInfo) Cleanup() {
 	Log(ep, "Endpoint Cleanup", 3)
-	ep.refCount--
+	if ep.refCount != nil {
+		*ep.refCount--
+	}
+
 	// Remove the remote hns endpoint, if no service is referring it
 	// Never delete a Local Endpoint. Local Endpoints are already created by other entities.
 	// Remove only remote endpoints created by this service
-	if ep.refCount <= 0 && !ep.isLocal {
+	if (ep.refCount == nil || *ep.refCount <= 0) && !ep.isLocal {
 		klog.V(4).Infof("Removing endpoints for %v, since no one is referencing it", ep)
 		err := ep.hns.deleteEndpoint(ep.hnsID)
 		if err == nil {
@@ -213,6 +216,15 @@ func (ep *endpointsInfo) Cleanup() {
 			klog.Errorf("Endpoint deletion failed for %v: %v", ep.ip, err)
 		}
 	}
+}
+
+func (refCountMap endPointsReferenceCountMap) getRefCount(hnsID string) *uint16 {
+	refCount, exists := refCountMap[hnsID]
+	if !exists {
+		refCountMap[hnsID] = new(uint16)
+		refCount = refCountMap[hnsID]
+	}
+	return refCount
 }
 
 // returns a new serviceInfo struct
@@ -310,6 +322,7 @@ type updateServiceMapResult struct {
 }
 type proxyServiceMap map[proxy.ServicePortName]*serviceInfo
 type proxyEndpointsMap map[proxy.ServicePortName][]*endpointsInfo
+type endPointsReferenceCountMap map[string]*uint16
 
 func newEndpointsChangeMap(hostname string) endpointsChangeMap {
 	return endpointsChangeMap{
@@ -460,10 +473,11 @@ type Proxier struct {
 	endpointsChanges endpointsChangeMap
 	serviceChanges   serviceChangeMap
 
-	mu           sync.Mutex // protects the following fields
-	serviceMap   proxyServiceMap
-	endpointsMap proxyEndpointsMap
-	portsMap     map[localPort]closeable
+	mu                sync.Mutex // protects the following fields
+	serviceMap        proxyServiceMap
+	endpointsMap      proxyEndpointsMap
+	portsMap          map[localPort]closeable
+	endPointsRefCount endPointsReferenceCountMap
 	// endpointsSynced and servicesSynced are set to true when corresponding
 	// objects are synced after startup. This is used to avoid updating hns policies
 	// with some partial data after kube-proxy restart.
@@ -636,6 +650,7 @@ func NewProxier(
 		serviceChanges:      newServiceChangeMap(),
 		endpointsMap:        make(proxyEndpointsMap),
 		endpointsChanges:    newEndpointsChangeMap(hostname),
+		endPointsRefCount:   make(endPointsReferenceCountMap),
 		masqueradeAll:       masqueradeAll,
 		masqueradeMark:      masqueradeMark,
 		clusterCIDR:         clusterCIDR,
@@ -1100,7 +1115,8 @@ func (proxier *Proxier) syncProxyRules() {
 					continue
 				}
 
-				newHnsEndpoint.refCount++
+				newHnsEndpoint.refCount = proxier.endPointsRefCount.getRefCount(newHnsEndpoint.hnsID)
+				*newHnsEndpoint.refCount++
 				svcInfo.remoteEndpoint = newHnsEndpoint
 			}
 		}
@@ -1202,9 +1218,14 @@ func (proxier *Proxier) syncProxyRules() {
 			hnsEndpoints = append(hnsEndpoints, *newHnsEndpoint)
 			if newHnsEndpoint.isLocal {
 				hnsLocalEndpoints = append(hnsLocalEndpoints, *newHnsEndpoint)
+			} else {
+				// We only share the refCounts for remote endpoints
+				ep.refCount = proxier.endPointsRefCount.getRefCount(newHnsEndpoint.hnsID)
 			}
+
 			ep.hnsID = newHnsEndpoint.hnsID
-			ep.refCount++
+			*ep.refCount++
+
 			Log(ep, "Endpoint resource found", 3)
 		}
 
@@ -1337,6 +1358,12 @@ func (proxier *Proxier) syncProxyRules() {
 		klog.V(5).Infof("Pending delete stale service IP %s connections", svcIP)
 	}
 
+	// remove stale endpoint refcount entries
+	for hnsID, referenceCount := range proxier.endPointsRefCount {
+		if *referenceCount <= 0 {
+			delete(proxier.endPointsRefCount, hnsID)
+		}
+	}
 }
 
 type endpointServicePair struct {

--- a/pkg/proxy/winkernel/proxier_test.go
+++ b/pkg/proxy/winkernel/proxier_test.go
@@ -70,7 +70,7 @@ func (hns fakeHNS) getEndpointByIpAddress(ip string, networkName string) (*endpo
 	if ipNet.Contains(net.ParseIP(ip)) {
 		return &endpointsInfo{
 			ip:         ip,
-			isLocal:    true,
+			isLocal:    false,
 			macAddress: macAddress,
 			hnsID:      guid,
 			hns:        hns,
@@ -102,6 +102,7 @@ func (hns fakeHNS) deleteLoadBalancer(hnsID string) error {
 func NewFakeProxier(syncPeriod time.Duration, minSyncPeriod time.Duration, clusterCIDR string, hostname string, nodeIP net.IP, networkType string) *Proxier {
 	sourceVip := "192.168.1.2"
 	hnsNetworkInfo := &hnsNetworkInfo{
+		id:          strings.ToUpper(guid),
 		name:        "TestNetwork",
 		networkType: networkType,
 	}
@@ -120,6 +121,7 @@ func NewFakeProxier(syncPeriod time.Duration, minSyncPeriod time.Duration, clust
 		hostMac:             macAddress,
 		isDSR:               false,
 		hns:                 newFakeHNS(),
+		endPointsRefCount:   make(endPointsReferenceCountMap),
 	}
 	return proxier
 }
@@ -217,6 +219,14 @@ func TestCreateRemoteEndpointOverlay(t *testing.T) {
 	if proxier.endpointsMap[svcPortName][0].hnsID != guid {
 		t.Errorf("%v does not match %v", proxier.endpointsMap[svcPortName][0].hnsID, guid)
 	}
+
+	if *proxier.endPointsRefCount[guid] <= 0 {
+		t.Errorf("RefCount not incremented. Current value: %v", *proxier.endPointsRefCount[guid])
+	}
+
+	if *proxier.endPointsRefCount[guid] != *proxier.endpointsMap[svcPortName][0].refCount {
+		t.Errorf("Global refCount: %v does not match endpoint refCount: %v", *proxier.endPointsRefCount[guid], *proxier.endpointsMap[svcPortName][0].refCount)
+	}
 }
 func TestCreateRemoteEndpointL2Bridge(t *testing.T) {
 	syncPeriod := 30 * time.Second
@@ -264,7 +274,16 @@ func TestCreateRemoteEndpointL2Bridge(t *testing.T) {
 	if proxier.endpointsMap[svcPortName][0].hnsID != guid {
 		t.Errorf("%v does not match %v", proxier.endpointsMap[svcPortName][0].hnsID, guid)
 	}
+
+	if *proxier.endPointsRefCount[guid] <= 0 {
+		t.Errorf("RefCount not incremented. Current value: %v", *proxier.endPointsRefCount[guid])
+	}
+
+	if *proxier.endPointsRefCount[guid] != *proxier.endpointsMap[svcPortName][0].refCount {
+		t.Errorf("Global refCount: %v does not match endpoint refCount: %v", *proxier.endPointsRefCount[guid], *proxier.endpointsMap[svcPortName][0].refCount)
+	}
 }
+
 func TestCreateLoadBalancer(t *testing.T) {
 	syncPeriod := 30 * time.Second
 	proxier := NewFakeProxier(syncPeriod, syncPeriod, clusterCIDR, "testhost", net.ParseIP("10.0.0.1"), "Overlay")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind api-change

/kind bug

> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
In kube-proxy a ref count is maintained on the remote endpoints created for a service. The remote endpoints are deleted from HNS when they are no longer in use by kube-proxy (i.e. refcount is dropped to zero). In the current logic the refcount on the remote endpoints is scoped to a service. So when the service is deleted all the remote endpoints referred by it are no longer in use and they are cleaned up dropping the refcount to 0. This deletes the remote endpoints in HNS. When a remote endpoint is shared across two services this causes a problem since the second service is still referring to it, but the backing HNS remote endpoint is deleted and no longer available.

Fix: A global refcount is maintained for all the remote endpoints created across services. The backing HNS remote endpoint is only deleted when it is no longer in use by any service.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #91703

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
