### PR TITLE
check the azurefile if exists before creating

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/azure/clients/fileclient/azure_fileclient.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/clients/fileclient/azure_fileclient.go
@@ -21,6 +21,8 @@ package fileclient
 import (
 	"context"
 	"fmt"
+	"net/http"
+	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2019-06-01/storage"
 
@@ -45,6 +47,14 @@ func New(config *azclients.ClientConfig) *Client {
 
 // CreateFileShare creates a file share
 func (c *Client) CreateFileShare(resourceGroupName, accountName, name string, sizeGiB int) error {
+	result, err := c.GetFileShare(resourceGroupName, accountName, name)
+	if err == nil {
+		klog.V(2).Infof("file share(%s) under account(%s) rg(%s) already exists", name, accountName, resourceGroupName)
+		return nil
+	} else if err != nil && result.Response.StatusCode != http.StatusNotFound && !strings.Contains(err.Error(), "ShareNotFound") {
+		return fmt.Errorf("failed to get file share(%s), err: %v", name, err)
+	}
+
 	quota := int32(sizeGiB)
 	fileShare := storage.FileShare{
 		Name: &name,
@@ -52,7 +62,7 @@ func (c *Client) CreateFileShare(resourceGroupName, accountName, name string, si
 			ShareQuota: &quota,
 		},
 	}
-	_, err := c.fileSharesClient.Create(context.Background(), resourceGroupName, accountName, name, fileShare)
+	_, err = c.fileSharesClient.Create(context.Background(), resourceGroupName, accountName, name, fileShare)
 
 	return err
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind flake

**What this PR does / why we need it**:
With management plane SDK, if the name is same with the existed azure file share, but the size is different, CreateFileShare() will update the size.
With data plane SDK, if the name is same with the existed azure file share, CreateFileShare() won't update the size.

In the past, we used data plane SDK. Users always followed the logic of data plane SDK. Now we switch to use management plane SDK.  We should minimize the facing change for user. So here we should make the logic consistent with the original.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #85354

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```

/priority important-soon
/sig cloud-provider
/area provider/azure
/assign @andyzhangx 
