### PR TITLE
kube-proxy detect IP family based on nodeIP

### DIFF
--- a/cmd/kube-proxy/app/BUILD
+++ b/cmd/kube-proxy/app/BUILD
@@ -234,7 +234,6 @@ go_test(
         "//pkg/proxy/apis/config:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/component-base/config:go_default_library",
-        "//staging/src/k8s.io/component-base/configz:go_default_library",
         "//vendor/github.com/google/go-cmp/cmp:go_default_library",
         "//vendor/github.com/stretchr/testify/assert:go_default_library",
         "//vendor/k8s.io/utils/pointer:go_default_library",
@@ -245,6 +244,7 @@ go_test(
             "//pkg/util/iptables:go_default_library",
             "//pkg/util/iptables/testing:go_default_library",
             "//staging/src/k8s.io/api/core/v1:go_default_library",
+            "//staging/src/k8s.io/client-go/kubernetes/fake:go_default_library",
         ],
         "@io_bazel_rules_go//go/platform:darwin": [
             "//pkg/proxy/ipvs:go_default_library",
@@ -252,6 +252,7 @@ go_test(
             "//pkg/util/iptables:go_default_library",
             "//pkg/util/iptables/testing:go_default_library",
             "//staging/src/k8s.io/api/core/v1:go_default_library",
+            "//staging/src/k8s.io/client-go/kubernetes/fake:go_default_library",
         ],
         "@io_bazel_rules_go//go/platform:dragonfly": [
             "//pkg/proxy/ipvs:go_default_library",
@@ -259,6 +260,7 @@ go_test(
             "//pkg/util/iptables:go_default_library",
             "//pkg/util/iptables/testing:go_default_library",
             "//staging/src/k8s.io/api/core/v1:go_default_library",
+            "//staging/src/k8s.io/client-go/kubernetes/fake:go_default_library",
         ],
         "@io_bazel_rules_go//go/platform:freebsd": [
             "//pkg/proxy/ipvs:go_default_library",
@@ -266,6 +268,7 @@ go_test(
             "//pkg/util/iptables:go_default_library",
             "//pkg/util/iptables/testing:go_default_library",
             "//staging/src/k8s.io/api/core/v1:go_default_library",
+            "//staging/src/k8s.io/client-go/kubernetes/fake:go_default_library",
         ],
         "@io_bazel_rules_go//go/platform:ios": [
             "//pkg/proxy/ipvs:go_default_library",
@@ -273,6 +276,7 @@ go_test(
             "//pkg/util/iptables:go_default_library",
             "//pkg/util/iptables/testing:go_default_library",
             "//staging/src/k8s.io/api/core/v1:go_default_library",
+            "//staging/src/k8s.io/client-go/kubernetes/fake:go_default_library",
         ],
         "@io_bazel_rules_go//go/platform:linux": [
             "//pkg/proxy/ipvs:go_default_library",
@@ -280,6 +284,7 @@ go_test(
             "//pkg/util/iptables:go_default_library",
             "//pkg/util/iptables/testing:go_default_library",
             "//staging/src/k8s.io/api/core/v1:go_default_library",
+            "//staging/src/k8s.io/client-go/kubernetes/fake:go_default_library",
         ],
         "@io_bazel_rules_go//go/platform:nacl": [
             "//pkg/proxy/ipvs:go_default_library",
@@ -287,6 +292,7 @@ go_test(
             "//pkg/util/iptables:go_default_library",
             "//pkg/util/iptables/testing:go_default_library",
             "//staging/src/k8s.io/api/core/v1:go_default_library",
+            "//staging/src/k8s.io/client-go/kubernetes/fake:go_default_library",
         ],
         "@io_bazel_rules_go//go/platform:netbsd": [
             "//pkg/proxy/ipvs:go_default_library",
@@ -294,6 +300,7 @@ go_test(
             "//pkg/util/iptables:go_default_library",
             "//pkg/util/iptables/testing:go_default_library",
             "//staging/src/k8s.io/api/core/v1:go_default_library",
+            "//staging/src/k8s.io/client-go/kubernetes/fake:go_default_library",
         ],
         "@io_bazel_rules_go//go/platform:openbsd": [
             "//pkg/proxy/ipvs:go_default_library",
@@ -301,6 +308,7 @@ go_test(
             "//pkg/util/iptables:go_default_library",
             "//pkg/util/iptables/testing:go_default_library",
             "//staging/src/k8s.io/api/core/v1:go_default_library",
+            "//staging/src/k8s.io/client-go/kubernetes/fake:go_default_library",
         ],
         "@io_bazel_rules_go//go/platform:plan9": [
             "//pkg/proxy/ipvs:go_default_library",
@@ -308,6 +316,7 @@ go_test(
             "//pkg/util/iptables:go_default_library",
             "//pkg/util/iptables/testing:go_default_library",
             "//staging/src/k8s.io/api/core/v1:go_default_library",
+            "//staging/src/k8s.io/client-go/kubernetes/fake:go_default_library",
         ],
         "@io_bazel_rules_go//go/platform:solaris": [
             "//pkg/proxy/ipvs:go_default_library",
@@ -315,6 +324,7 @@ go_test(
             "//pkg/util/iptables:go_default_library",
             "//pkg/util/iptables/testing:go_default_library",
             "//staging/src/k8s.io/api/core/v1:go_default_library",
+            "//staging/src/k8s.io/client-go/kubernetes/fake:go_default_library",
         ],
         "//conditions:default": [],
     }),

--- a/cmd/kube-proxy/app/server_others.go
+++ b/cmd/kube-proxy/app/server_others.go
@@ -91,10 +91,24 @@ func newProxyServer(
 		return nil, fmt.Errorf("unable to register configz: %s", err)
 	}
 
+	hostname, err := utilnode.GetHostname(config.HostnameOverride)
+	if err != nil {
+		return nil, err
+	}
+
+	client, eventClient, err := createClients(config.ClientConnection, master)
+	if err != nil {
+		return nil, err
+	}
+
+	nodeIP := detectNodeIP(client, hostname, config.BindAddress)
+
 	protocol := utiliptables.ProtocolIPv4
-	if net.ParseIP(config.BindAddress).To4() == nil {
-		klog.V(0).Infof("IPv6 bind address (%s), assume IPv6 operation", config.BindAddress)
+	if utilsnet.IsIPv6(nodeIP) {
+		klog.V(0).Infof("kube-proxy node IP is an IPv6 address (%s), assume IPv6 operation", nodeIP.String())
 		protocol = utiliptables.ProtocolIPv6
+	} else {
+		klog.V(0).Infof("kube-proxy node IP is an IPv4 address (%s), assume IPv4 operation", nodeIP.String())
 	}
 
 	var iptInterface utiliptables.Interface
@@ -131,16 +145,7 @@ func newProxyServer(
 		metrics.SetShowHidden()
 	}
 
-	client, eventClient, err := createClients(config.ClientConnection, master)
-	if err != nil {
-		return nil, err
-	}
-
 	// Create event recorder
-	hostname, err := utilnode.GetHostname(config.HostnameOverride)
-	if err != nil {
-		return nil, err
-	}
 	eventBroadcaster := record.NewBroadcaster()
 	recorder := eventBroadcaster.NewRecorder(proxyconfigscheme.Scheme, v1.EventSource{Component: "kube-proxy", Host: hostname})
 
@@ -173,15 +178,6 @@ func newProxyServer(
 			return nil, err
 		}
 		klog.Infof("NodeInfo PodCIDR: %v, PodCIDRs: %v", nodeInfo.Spec.PodCIDR, nodeInfo.Spec.PodCIDRs)
-	}
-
-	nodeIP := net.ParseIP(config.BindAddress)
-	if nodeIP.IsUnspecified() {
-		nodeIP = utilnode.GetNodeIP(client, hostname)
-		if nodeIP == nil {
-			klog.V(0).Infof("can't determine this node's IP, assuming 127.0.0.1; if this is incorrect, please set the --bind-address flag")
-			nodeIP = net.ParseIP("127.0.0.1")
-		}
 	}
 
 	klog.V(2).Info("DetectLocalMode: '", string(detectLocalMode), "'")
@@ -420,6 +416,23 @@ func waitForPodCIDR(client clientset.Interface, nodeName string) (*v1.Node, erro
 		return n, nil
 	}
 	return nil, fmt.Errorf("event object not of type node")
+}
+
+// detectNodeIP returns the nodeIP used by the proxier
+// The order of precedence is:
+// 1. config.bindAddress if bindAddress is not 0.0.0.0 or ::
+// 2. the primary IP from the Node object, if set
+// 3. if no IP is found it defaults to 127.0.0.1 and IPv4
+func detectNodeIP(client clientset.Interface, hostname, bindAddress string) net.IP {
+	nodeIP := net.ParseIP(bindAddress)
+	if nodeIP.IsUnspecified() {
+		nodeIP = utilnode.GetNodeIP(client, hostname)
+	}
+	if nodeIP == nil {
+		klog.V(0).Infof("can't determine this node's IP, assuming 127.0.0.1; if this is incorrect, please set the --bind-address flag")
+		nodeIP = net.ParseIP("127.0.0.1")
+	}
+	return nodeIP
 }
 
 func getDetectLocalMode(config *proxyconfigapi.KubeProxyConfiguration) (proxyconfigapi.LocalMode, error) {

--- a/cmd/kube-proxy/app/server_others_test.go
+++ b/cmd/kube-proxy/app/server_others_test.go
@@ -20,10 +20,15 @@ package app
 
 import (
 	"fmt"
+	"net"
 	"reflect"
 	"testing"
 
 	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	clientsetfake "k8s.io/client-go/kubernetes/fake"
+
 	proxyconfigapi "k8s.io/kubernetes/pkg/proxy/apis/config"
 	"k8s.io/kubernetes/pkg/proxy/ipvs"
 	proxyutiliptables "k8s.io/kubernetes/pkg/proxy/util/iptables"
@@ -190,6 +195,111 @@ func Test_getDetectLocalMode(t *testing.T) {
 		}
 		if r != c.expected {
 			t.Errorf("Case[%d] Expected %q got %q", i, c.expected, r)
+		}
+	}
+}
+
+func Test_detectNodeIP(t *testing.T) {
+	cases := []struct {
+		name        string
+		nodeInfo    *v1.Node
+		hostname    string
+		bindAddress string
+		expectedIP  net.IP
+	}{
+		{
+			name:        "Bind address IPv4 unicast address and no Node object",
+			nodeInfo:    makeNodeWithAddresses("", "", ""),
+			hostname:    "fakeHost",
+			bindAddress: "10.0.0.1",
+			expectedIP:  net.ParseIP("10.0.0.1"),
+		},
+		{
+			name:        "Bind address IPv6 unicast address and no Node object",
+			nodeInfo:    makeNodeWithAddresses("", "", ""),
+			hostname:    "fakeHost",
+			bindAddress: "fd00:4321::2",
+			expectedIP:  net.ParseIP("fd00:4321::2"),
+		},
+		{
+			name:        "No Valid IP found",
+			nodeInfo:    makeNodeWithAddresses("", "", ""),
+			hostname:    "fakeHost",
+			bindAddress: "",
+			expectedIP:  net.ParseIP("127.0.0.1"),
+		},
+		// Disabled because the GetNodeIP method has a backoff retry mechanism
+		// and the test takes more than 30 seconds
+		// ok  	k8s.io/kubernetes/cmd/kube-proxy/app	34.136s
+		// {
+		//	name:        "No Valid IP found and unspecified bind address",
+		//	nodeInfo:    makeNodeWithAddresses("", "", ""),
+		//	hostname:    "fakeHost",
+		//	bindAddress: "0.0.0.0",
+		//	expectedIP:  net.ParseIP("127.0.0.1"),
+		// },
+		{
+			name:        "Bind address 0.0.0.0 and node with IPv4 InternalIP set",
+			nodeInfo:    makeNodeWithAddresses("fakeHost", "192.168.1.1", "90.90.90.90"),
+			hostname:    "fakeHost",
+			bindAddress: "0.0.0.0",
+			expectedIP:  net.ParseIP("192.168.1.1"),
+		},
+		{
+			name:        "Bind address :: and node with IPv4 InternalIP set",
+			nodeInfo:    makeNodeWithAddresses("fakeHost", "192.168.1.1", "90.90.90.90"),
+			hostname:    "fakeHost",
+			bindAddress: "::",
+			expectedIP:  net.ParseIP("192.168.1.1"),
+		},
+		{
+			name:        "Bind address 0.0.0.0 and node with IPv6 InternalIP set",
+			nodeInfo:    makeNodeWithAddresses("fakeHost", "fd00:1234::1", "2001:db8::2"),
+			hostname:    "fakeHost",
+			bindAddress: "0.0.0.0",
+			expectedIP:  net.ParseIP("fd00:1234::1"),
+		},
+		{
+			name:        "Bind address :: and node with IPv6 InternalIP set",
+			nodeInfo:    makeNodeWithAddresses("fakeHost", "fd00:1234::1", "2001:db8::2"),
+			hostname:    "fakeHost",
+			bindAddress: "::",
+			expectedIP:  net.ParseIP("fd00:1234::1"),
+		},
+		{
+			name:        "Bind address 0.0.0.0 and node with only IPv4 ExternalIP set",
+			nodeInfo:    makeNodeWithAddresses("fakeHost", "", "90.90.90.90"),
+			hostname:    "fakeHost",
+			bindAddress: "0.0.0.0",
+			expectedIP:  net.ParseIP("90.90.90.90"),
+		},
+		{
+			name:        "Bind address :: and node with only IPv4 ExternalIP set",
+			nodeInfo:    makeNodeWithAddresses("fakeHost", "", "90.90.90.90"),
+			hostname:    "fakeHost",
+			bindAddress: "::",
+			expectedIP:  net.ParseIP("90.90.90.90"),
+		},
+		{
+			name:        "Bind address 0.0.0.0 and node with only IPv6 ExternalIP set",
+			nodeInfo:    makeNodeWithAddresses("fakeHost", "", "2001:db8::2"),
+			hostname:    "fakeHost",
+			bindAddress: "0.0.0.0",
+			expectedIP:  net.ParseIP("2001:db8::2"),
+		},
+		{
+			name:        "Bind address :: and node with only IPv6 ExternalIP set",
+			nodeInfo:    makeNodeWithAddresses("fakeHost", "", "2001:db8::2"),
+			hostname:    "fakeHost",
+			bindAddress: "::",
+			expectedIP:  net.ParseIP("2001:db8::2"),
+		},
+	}
+	for _, c := range cases {
+		client := clientsetfake.NewSimpleClientset(c.nodeInfo)
+		ip := detectNodeIP(client, c.hostname, c.bindAddress)
+		if !ip.Equal(c.expectedIP) {
+			t.Errorf("Case[%s] Expected IP %q got %q", c.name, c.expectedIP, ip)
 		}
 	}
 }
@@ -472,6 +582,35 @@ func Test_getDualStackLocalDetectorTuple(t *testing.T) {
 			t.Errorf("Case[%d] Unexpected detect-local implementation, expected: %q, got: %q", i, c.expected, r)
 		}
 	}
+}
+
+func makeNodeWithAddresses(name, internal, external string) *v1.Node {
+	if name == "" {
+		return &v1.Node{}
+	}
+
+	node := &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Status: v1.NodeStatus{
+			Addresses: []v1.NodeAddress{},
+		},
+	}
+
+	if internal != "" {
+		node.Status.Addresses = append(node.Status.Addresses,
+			v1.NodeAddress{Type: v1.NodeInternalIP, Address: internal},
+		)
+	}
+
+	if external != "" {
+		node.Status.Addresses = append(node.Status.Addresses,
+			v1.NodeAddress{Type: v1.NodeExternalIP, Address: external},
+		)
+	}
+
+	return node
 }
 
 func makeNodeWithPodCIDRs(cidrs ...string) *v1.Node {

--- a/cmd/kube-proxy/app/server_test.go
+++ b/cmd/kube-proxy/app/server_test.go
@@ -36,35 +36,8 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	componentbaseconfig "k8s.io/component-base/config"
-	"k8s.io/component-base/configz"
 	kubeproxyconfig "k8s.io/kubernetes/pkg/proxy/apis/config"
 )
-
-// This test verifies that NewProxyServer does not crash when CleanupAndExit is true.
-func TestProxyServerWithCleanupAndExit(t *testing.T) {
-	// Each bind address below is a separate test case
-	bindAddresses := []string{
-		"0.0.0.0",
-		"::",
-	}
-	for _, addr := range bindAddresses {
-		options := NewOptions()
-
-		options.config = &kubeproxyconfig.KubeProxyConfiguration{
-			BindAddress: addr,
-		}
-		options.CleanupAndExit = true
-
-		proxyserver, err := NewProxyServer(options)
-
-		assert.Nil(t, err, "unexpected error in NewProxyServer, addr: %s", addr)
-		assert.NotNil(t, proxyserver, "nil proxy server obj, addr: %s", addr)
-		assert.NotNil(t, proxyserver.IptInterface, "nil iptables intf, addr: %s", addr)
-
-		// Clean up config for next test case
-		configz.Delete(kubeproxyconfig.GroupName)
-	}
-}
 
 func TestGetConntrackMax(t *testing.T) {
 	ncores := runtime.NumCPU()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind api-change

/kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
We were detecting the IP family that kube-proxy should use
based on the bind address, however, this is not valid when
using an unspecified address, because on those cases
kube-proxy adopts the IP family of the address reported
in the Node API object.



**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

This fails if bind-address= 0.0.0.0 but the nodeIP is an IPv6 address
```
2020-05-04T13:43:49.547255619+00:00 stderr F I0504 13:43:49.547248       1 server.go:536] Neither kubeconfig file nor master URL was specified. Falling back to in-cluster config.
2020-05-04T13:43:49.555761603+00:00 stderr F I0504 13:43:49.555662       1 node.go:135] Successfully retrieved node IP: 2001:db8::10
2020-05-04T13:43:49.555761603+00:00 stderr F I0504 13:43:49.555679       1 server_others.go:145] Using iptables Proxier.
2020-05-04T13:43:49.555761603+00:00 stderr F F0504 13:43:49.555715       1 server.go:485] unable to create proxier: clusterCIDR 2001:db8::0/64 has incorrect IP version: expect isIPv6=false
```

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kube-proxy IP family will be determined by the nodeIP used by the proxier. The order of precedence is:
1. the configured --bind-address if the bind address is not 0.0.0.0 or ::
2. the primary IP from the Node object, if set.
3. if no IP is found, NodeIP defaults to 127.0.0.1 and the IP family to IPv4
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
