### PR TITLE
Bump addon-resizer image to 1.8.10

### DIFF
--- a/cluster/addons/metrics-server/metrics-server-deployment.yaml
+++ b/cluster/addons/metrics-server/metrics-server-deployment.yaml
@@ -64,7 +64,7 @@ spec:
           name: https
           protocol: TCP
       - name: metrics-server-nanny
-        image: k8s.gcr.io/addon-resizer:1.8.9
+        image: k8s.gcr.io/addon-resizer:1.8.10
         resources:
           limits:
             cpu: 100m


### PR DESCRIPTION
This is reducing addon-resizer memory usage by ~2.5x.

```release-note
NONE
```