### PR TITLE
Add sig-apps-approvers and reviewers

### DIFF
--- a/pkg/controller/OWNERS
+++ b/pkg/controller/OWNERS
@@ -5,8 +5,10 @@ approvers:
 - derekwaynecarr
 - mikedanese
 - janetkuo
+- sig-apps-approvers
 reviewers:
 - deads2k
 - cheftako
+- sig-apps-reviewers
 labels:
 - sig/apps


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Most of the tools in `pkg/controller` are used by sig-apps owned controller and the OWNERS file is already marked only with sig-apps label - that suggest sig-apps should be maintaining it but our aliases are not in place. It's likely that this was forgotten when we migrated to using aliases to keep approvers up to date.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/cc @janetkuo @kow3ns @mattfarina @soltysh 

