### PR TITLE
Detect PSP enablement more accurately

### DIFF
--- a/plugin/pkg/admission/security/podsecuritypolicy/admission.go
+++ b/plugin/pkg/admission/security/podsecuritypolicy/admission.go
@@ -127,7 +127,7 @@ func (p *Plugin) Admit(ctx context.Context, a admission.Attributes, o admission.
 	// compute the context. Mutation is allowed. ValidatedPSPAnnotation is not taken into account.
 	allowedPod, pspName, validationErrs, err := p.computeSecurityContext(ctx, a, pod, true, "")
 	if err != nil {
-		return admission.NewForbidden(a, err)
+		return admission.NewForbidden(a, fmt.Errorf("PodSecurityPolicy: %w", err))
 	}
 	if allowedPod != nil {
 		*pod = *allowedPod
@@ -145,8 +145,8 @@ func (p *Plugin) Admit(ctx context.Context, a admission.Attributes, o admission.
 	}
 
 	// we didn't validate against any provider, reject the pod and give the errors for each attempt
-	klog.V(4).Infof("unable to validate pod %s (generate: %s) in namespace %s against any pod security policy: %v", pod.Name, pod.GenerateName, a.GetNamespace(), validationErrs)
-	return admission.NewForbidden(a, fmt.Errorf("unable to validate against any pod security policy: %v", validationErrs))
+	klog.V(4).Infof("unable to admit pod %s (generate: %s) in namespace %s against any pod security policy: %v", pod.Name, pod.GenerateName, a.GetNamespace(), validationErrs)
+	return admission.NewForbidden(a, fmt.Errorf("PodSecurityPolicy: unable to admit pod: %v", validationErrs))
 }
 
 // Validate verifies attributes against the PodSecurityPolicy
@@ -162,7 +162,7 @@ func (p *Plugin) Validate(ctx context.Context, a admission.Attributes, o admissi
 	// compute the context. Mutation is not allowed. ValidatedPSPAnnotation is used as a hint to gain same speed-up.
 	allowedPod, pspName, validationErrs, err := p.computeSecurityContext(ctx, a, pod, false, pod.ObjectMeta.Annotations[psputil.ValidatedPSPAnnotation])
 	if err != nil {
-		return admission.NewForbidden(a, err)
+		return admission.NewForbidden(a, fmt.Errorf("PodSecurityPolicy: %w", err))
 	}
 	if apiequality.Semantic.DeepEqual(pod, allowedPod) {
 		key := auditKeyPrefix + "/" + "validate-policy"
@@ -174,7 +174,7 @@ func (p *Plugin) Validate(ctx context.Context, a admission.Attributes, o admissi
 
 	// we didn't validate against any provider, reject the pod and give the errors for each attempt
 	klog.V(4).Infof("unable to validate pod %s (generate: %s) in namespace %s against any pod security policy: %v", pod.Name, pod.GenerateName, a.GetNamespace(), validationErrs)
-	return admission.NewForbidden(a, fmt.Errorf("unable to validate against any pod security policy: %v", validationErrs))
+	return admission.NewForbidden(a, fmt.Errorf("PodSecurityPolicy: unable to validate pod: %v", validationErrs))
 }
 
 func shouldIgnore(a admission.Attributes) (bool, error) {


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Rather than just look for the presence of PSP API objects, also attempt to submit a dry run pod and see if it gets decorated with a PSP annotation or rejected with a PSP error.

**Which issue(s) this PR fixes**:
Fixes #91463

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/sig auth
/cc @tallclair 