### PR TITLE
Replace framework.Failf with ExpectNoError

### DIFF
--- a/test/e2e/storage/volume_provisioning.go
+++ b/test/e2e/storage/volume_provisioning.go
@@ -673,10 +673,10 @@ var _ = utils.SIGDescribe("Dynamic Provisioning", func() {
 		// Modifying the default storage class can be disruptive to other tests that depend on it
 		ginkgo.It("should be disabled by changing the default annotation [Serial] [Disruptive]", func() {
 			e2eskipper.SkipUnlessProviderIs("openstack", "gce", "aws", "gke", "vsphere", "azure")
+
 			scName, scErr := e2epv.GetDefaultStorageClassName(c)
-			if scErr != nil {
-				framework.Failf(scErr.Error())
-			}
+			framework.ExpectNoError(scErr)
+
 			test := testsuites.StorageClassTest{
 				Name:      "default",
 				ClaimSize: "2Gi",
@@ -710,10 +710,10 @@ var _ = utils.SIGDescribe("Dynamic Provisioning", func() {
 		// Modifying the default storage class can be disruptive to other tests that depend on it
 		ginkgo.It("should be disabled by removing the default annotation [Serial] [Disruptive]", func() {
 			e2eskipper.SkipUnlessProviderIs("openstack", "gce", "aws", "gke", "vsphere", "azure")
+
 			scName, scErr := e2epv.GetDefaultStorageClassName(c)
-			if scErr != nil {
-				framework.Failf(scErr.Error())
-			}
+			framework.ExpectNoError(scErr)
+
 			test := testsuites.StorageClassTest{
 				Name:      "default",
 				ClaimSize: "2Gi",


### PR DESCRIPTION

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

This replaces with conditional framework.Failf with ExpectNoError for cleanup.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
