### PR TITLE
Handle clean up of read only files.

### DIFF
--- a/hack/verify-bazel.sh
+++ b/hack/verify-bazel.sh
@@ -37,7 +37,7 @@ fi
 rm -f "${KUBE_ROOT}/{pkg/generated,staging/src/k8s.io/apiextensions-apiserver/pkg/client,staging/src/k8s.io/kube-aggregator/pkg/client}/openapi/zz_generated.openapi.go"
 
 _tmpdir="$(kube::realpath "$(mktemp -d -t verify-bazel.XXXXXX)")"
-kube::util::trap_add "rm -rf ${_tmpdir}" EXIT
+kube::util::trap_add "chmod -R u+rw ${_tmpdir} && rm -rf ${_tmpdir}" EXIT
 
 _tmp_gopath="${_tmpdir}/go"
 _tmp_kuberoot="${_tmp_gopath}/src/k8s.io/kubernetes"


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
verify-bazel seems to create read only files under its tmp dir.
When it then goes to clean up the tmp dir it fails.
Adding a command prior to delete to make sure we have perms.


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs
NONE
```
