### PR TITLE
Migrate klog to klog.InfoS in vendor/k8s.io/utils

### DIFF
--- a/vendor/k8s.io/utils/trace/trace.go
+++ b/vendor/k8s.io/utils/trace/trace.go
@@ -88,32 +88,27 @@ func (t *Trace) logWithStepThreshold(stepThreshold time.Duration) {
 	endTime := time.Now()
 
 	totalTime := endTime.Sub(t.startTime)
-	buffer.WriteString(fmt.Sprintf("Trace[%d]: %q ", tracenum, t.name))
 	if len(t.fields) > 0 {
 		writeFields(&buffer, t.fields)
-		buffer.WriteString(" ")
 	}
-	buffer.WriteString(fmt.Sprintf("(started: %v) (total time: %v):\n", t.startTime, totalTime))
+	klog.InfoS("Trace", "tracenum", tracenum, "name", t.name, "keyvalues", buffer.String(), "starttime", t.startTime, "totaltime", totalTime)
 	lastStepTime := t.startTime
 	for _, step := range t.steps {
 		stepDuration := step.stepTime.Sub(lastStepTime)
 		if stepThreshold == 0 || stepDuration > stepThreshold || klog.V(4).Enabled() {
-			buffer.WriteString(fmt.Sprintf("Trace[%d]: [%v] [%v] ", tracenum, step.stepTime.Sub(t.startTime), stepDuration))
-			buffer.WriteString(step.msg)
+			buffer.Reset()
 			if len(step.fields) > 0 {
-				buffer.WriteString(" ")
 				writeFields(&buffer, step.fields)
 			}
-			buffer.WriteString("\n")
+			klog.InfoS("Trace", "tracenum", tracenum, "steptime", step.stepTime.Sub(t.startTime), "stepduration", stepDuration, "stepmsg", step.msg, "keyvalues", buffer.String())
 		}
 		lastStepTime = step.stepTime
 	}
 	stepDuration := endTime.Sub(lastStepTime)
 	if stepThreshold == 0 || stepDuration > stepThreshold || klog.V(4).Enabled() {
-		buffer.WriteString(fmt.Sprintf("Trace[%d]: [%v] [%v] END\n", tracenum, endTime.Sub(t.startTime), stepDuration))
+		klog.InfoS("Trace end", "tracenum", tracenum, "endtime", endTime.Sub(t.startTime), "stepduration", stepDuration)
 	}
 
-	klog.Info(buffer.String())
 }
 
 // LogIfLong is used to dump steps that took longer than its share

--- a/vendor/k8s.io/utils/trace/trace.go
+++ b/vendor/k8s.io/utils/trace/trace.go
@@ -106,18 +106,18 @@ func (t *Trace) logWithStepThreshold(stepThreshold time.Duration) {
 	endTime := time.Now()
 
 	totalTime := endTime.Sub(t.startTime)
-	klog.InfoS("Trace start", logTraceArgs(tracenum, t, totalTime)...)
+	klog.InfoS("Trace", logTraceArgs(tracenum, t, totalTime)...)
 	lastStepTime := t.startTime
 	for _, step := range t.steps {
 		stepDuration := step.stepTime.Sub(lastStepTime)
 		if stepThreshold == 0 || stepDuration > stepThreshold || klog.V(4).Enabled() {
-			klog.InfoS("Trace step", logStepArgs(tracenum, step, step.stepTime.Sub(t.startTime), stepDuration)...)
+			klog.InfoS("Trace", logStepArgs(tracenum, step, step.stepTime.Sub(t.startTime), stepDuration)...)
 		}
 		lastStepTime = step.stepTime
 	}
 	stepDuration := endTime.Sub(lastStepTime)
 	if stepThreshold == 0 || stepDuration > stepThreshold || klog.V(4).Enabled() {
-		klog.InfoS("Trace end", "traceNum", tracenum, "endTime", endTime.Sub(t.startTime), "stepDuration", stepDuration)
+		klog.InfoS("Trace", "traceNum", tracenum, "endTime", endTime.Sub(t.startTime), "stepDuration", stepDuration)
 	}
 
 }


### PR DESCRIPTION
**What type of PR is this?**
 /kind cleanup

**What this PR does / why we need it**:

Ref:

kubernetes/enhancements#1602
https://github.com/kubernetes/enhancements/tree/master/keps/sig-instrumentation/1602-structured-logging


**Explain about this PR**
Original klog call is `klog.Info(buffer.String())`

buffer.String() contains all trace information(trace name, start time, end time, etc) and single string message, so it needs to be decomposed into key and value.
However, there were the following problems.
A trace can contain multiple [steps](https://github.com/kubernetes/utils/tree/master/trace), 0 or more(the number of steps is not fixed.)
Each step contains trace information such as duration time.
I think that it is difficult to move this to InfoS with a fixed number of keys and values.

So, in this PR, we split one klog into three klog.InfoS
1. InfoS is called when trace starts
2. InfoS is called for each step (if there are multiple steps, InfoS is called same number of times.)
3. InfoS is called when the trace ends

The following is an example of log when the number of steps is 2.

Log output before migration
```
I0604 20:36:01.292061   32667 trace.go:116] Trace[2122920980]: "test-trace" test-key:100 (started: 2020-06-04 20:36:01.291233486 +0900 JST m=+67.466231521) (total time: 557.294μs):
Trace[2122920980]: [441.259μs] [441.259μs] step1-trace
Trace[2122920980]: [443.542μs] [2.283μs] step2-trace key-B:200,test-key:100,key-A:testtest
Trace[2122920980]: [557.294μs] [113.752μs] END
```

After migration
```
I0604 20:57:25.449051   16582 trace.go:94] "Trace" tracenum=1438512885 name="test-trace" keyvalues="test-key:100" starttime="2020-06-04 20:57:25.448668419 +0900 JST m=+67.710287384" totaltime="307.95μs"
I0604 20:57:25.449107   16582 trace.go:103] "Trace" tracenum=1438512885 steptime="245.901μs" stepduration="245.901μs" stepmsg="step1-trace" keyvalues=""
I0604 20:57:25.449198   16582 trace.go:103] "Trace" tracenum=1438512885 steptime="248.113μs" stepduration="2.212μs" stepmsg="step2-trace" keyvalues="key-B:200,test-key:100,key-A:testtest"
I0604 20:57:25.449268   16582 trace.go:109] "Trace end" tracenum=1438512885 endtime="307.95μs" stepduration="59.837μs"
```

In the log before migration, new line is inserted in each above 1 to 3 (Trace start/each step/Trace end), so the format is similar to after migration( eventhough there is multipule InfoS).

Is this idea(multiple InfoS) accepted?
Please let me know if we need to change it.