### PR TITLE
Added +inf bucket for quantile computations

### DIFF
--- a/staging/src/k8s.io/component-base/metrics/testutil/metrics.go
+++ b/staging/src/k8s.io/component-base/metrics/testutil/metrics.go
@@ -286,8 +286,14 @@ func (hist *Histogram) Quantile(q float64) float64 {
 		})
 	}
 
-	// bucketQuantile expects the upper bound of the last bucket to be +inf
-	// buckets[len(buckets)-1].upperBound = math.Inf(+1)
+	if len(buckets) == 0 || buckets[len(buckets)-1].upperBound != math.Inf(+1) {
+		// The list of buckets in dto.Histogram doesn't include the final +Inf bucket, so we
+		// add it here for the reset of the samples.
+		buckets = append(buckets, bucket{
+			count:      float64(hist.GetSampleCount()),
+			upperBound: math.Inf(+1),
+		})
+	}
 
 	return bucketQuantile(q, buckets)
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:
Fixes quantile computations for histograms used in integration tests. 

The buckets included in dto.Histogram doesn't include [the last +inf bucket](https://sourcegraph.com/github.com/kubernetes/kubernetes@master/-/blob/vendor/github.com/prometheus/client_golang/prometheus/histogram.go#L87), which means samples outside the range of the last bucket will not be accounted for in quantile computation unless we add them manually, which this PR does.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/cc @ingvagabund 