### PR TITLE
WIP: Remove the extra checks for apiserver.crt and kubelet-client.crt

### DIFF
--- a/cmd/kubeadm/app/phases/certs/certs.go
+++ b/cmd/kubeadm/app/phases/certs/certs.go
@@ -313,7 +313,6 @@ func SharedCertificateExists(cfg *kubeadmapi.ClusterConfiguration) (bool, error)
 // UsingExternalCA determines whether the user is relying on an external CA.  We currently implicitly determine this is the case
 // when the CA Cert is present but the CA Key is not.
 // This allows us to, e.g., skip generating certs or not start the csr signing controller.
-// In case we are using an external front-proxy CA, the function validates the certificates signed by front-proxy CA that should be provided by the user.
 func UsingExternalCA(cfg *kubeadmapi.ClusterConfiguration) (bool, error) {
 
 	if err := validateCACert(certKeyLocation{cfg.CertificatesDir, kubeadmconstants.CACertAndKeyBaseName, "", "CA"}); err != nil {
@@ -323,14 +322,6 @@ func UsingExternalCA(cfg *kubeadmapi.ClusterConfiguration) (bool, error) {
 	caKeyPath := filepath.Join(cfg.CertificatesDir, kubeadmconstants.CAKeyName)
 	if _, err := os.Stat(caKeyPath); !os.IsNotExist(err) {
 		return false, nil
-	}
-
-	if err := validateSignedCert(certKeyLocation{cfg.CertificatesDir, kubeadmconstants.CACertAndKeyBaseName, kubeadmconstants.APIServerCertAndKeyBaseName, "API server"}); err != nil {
-		return true, err
-	}
-
-	if err := validateSignedCert(certKeyLocation{cfg.CertificatesDir, kubeadmconstants.CACertAndKeyBaseName, kubeadmconstants.APIServerKubeletClientCertAndKeyBaseName, "API server kubelet client"}); err != nil {
-		return true, err
 	}
 
 	return true, nil

--- a/cmd/kubeadm/app/phases/certs/certs_test.go
+++ b/cmd/kubeadm/app/phases/certs/certs_test.go
@@ -531,7 +531,7 @@ func TestUsingExternalCA(t *testing.T) {
 			},
 			externalCAFunc: UsingExternalCA,
 			expected:       true,
-			expectedErr:    true,
+			expectedErr:    false,
 		},
 		{
 			name: "Test External CA, when ca.key missing",


### PR DESCRIPTION
I by seeing if I can relax the checks that are performed in ExternalCA mode,
removing the check for apiserver.crt.

But then I run into another check for the admin.conf file, which is also not appropriate when I am pre-populating the pki/ directory using CSRs and an external CA.

But it now dawns on me that these checks are useful sanity checks before performing the full sequence of init phases. So I can't just remove them.

I need to find a way to disable them when performing the individual cert generation phases,
especially when using --csr-only

OR

perhaps these checks should be moved to their own separate init phase, rather than as part of the command initialization.


Fixes: https://github.com/kubernetes/kubeadm/issues/2163
Signed-off-by: Richard Wall <richard.wall@jetstack.io>