### PR TITLE
A benchmark to evaluate overhead of unschedulable pods

### DIFF
--- a/test/integration/scheduler_perf/config/performance-config.yaml
+++ b/test/integration/scheduler_perf/config/performance-config.yaml
@@ -240,3 +240,20 @@
   - numNodes: 5000
     numInitPods: [20000]
     numPodsToSchedule: 5000
+- template:
+    desc: Unschedulable
+    skipWaitUntilInitPodsScheduled: true
+    initPods:
+    - podTemplatePath: config/pod-large-cpu.yaml
+    podsToSchedule:
+      podTemplatePath: config/pod-default.yaml
+  params:
+  - numNodes: 500
+    numInitPods: [200]
+    numPodsToSchedule: 1000
+  - numNodes: 5000
+    numInitPods: [200]
+    numPodsToSchedule: 5000
+  - numNodes: 5000
+    numInitPods: [2000]
+    numPodsToSchedule: 5000

--- a/test/integration/scheduler_perf/config/pod-large-cpu.yaml
+++ b/test/integration/scheduler_perf/config/pod-large-cpu.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  generateName: pod-
+spec:
+  containers:
+  - image: k8s.gcr.io/pause:3.2
+    name: pause
+    ports:
+    - containerPort: 80
+    resources:
+      requests:
+        cpu: 9
+        memory: 500Mi

--- a/test/integration/scheduler_perf/scheduler_perf_test.go
+++ b/test/integration/scheduler_perf/scheduler_perf_test.go
@@ -68,6 +68,9 @@ type testCase struct {
 	Nodes nodeCase
 	// configures pods in the cluster before running the tests
 	InitPods []podCase
+	// configures the test to now wait for init pods to schedule before creating
+	// test pods.
+	SkipWaitUntilInitPodsScheduled bool
 	// pods to be scheduled during the test.
 	PodsToSchedule podCase
 	// optional, feature gates to set before running the test
@@ -156,8 +159,10 @@ func perfScheduling(test testCase, b *testing.B) []DataItem {
 		}
 		total += p.Num
 	}
-	if err := waitNumPodsScheduled(b, total, podInformer, setupNamespace); err != nil {
-		b.Fatal(err)
+	if !test.SkipWaitUntilInitPodsScheduled {
+		if err := waitNumPodsScheduled(b, total, podInformer, setupNamespace); err != nil {
+			b.Fatal(err)
+		}
 	}
 
 	// start benchmark


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:
Adds a scheduler benchmark that evaluates the overhead of unschedulable pods.


**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/cc @Huang-Wei @alculquicondor 