### PR TITLE
show error when running dockershim

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -316,7 +316,7 @@ func PreInitRuntimeService(kubeCfg *kubeletconfiginternal.KubeletConfiguration,
 
 	switch containerRuntime {
 	case kubetypes.DockerContainerRuntime:
-		runDockershim(
+		if err := runDockershim(
 			kubeCfg,
 			kubeDeps,
 			crOptions,
@@ -324,7 +324,9 @@ func PreInitRuntimeService(kubeCfg *kubeletconfiginternal.KubeletConfiguration,
 			remoteRuntimeEndpoint,
 			remoteImageEndpoint,
 			nonMasqueradeCIDR,
-		)
+		); err != nil {
+			return err
+		}
 	case kubetypes.RemoteContainerRuntime:
 		// No-op.
 		break


### PR DESCRIPTION
The error returned when running the dockershim is not checked.
When running dockerless, we should show the existing error.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
All errors when running dockershim are silently ignored. We should surface errors, especially when they tell you exactly what's wrong.

**Which issue(s) this PR fixes**:
Found while looking at #91657

**Special notes for your reviewer**:
Run `GOFLAGS='-tags=dockerless' make test-e2e-node PARALLELISM=1 TEST_ARGS='--kubelet-flags=--fail-swap-on=false' FOCUS="Legacy:Docker" SKIP="" RUNTIME=docker`

Then check kublet logs for something like:
```
Jun 04 12:39:08 mhb-T470p kubelet[23994]: F0604 12:39:08.482671   23994 server.go:265] failed to run Kubelet: trying to use docker runtime when Kubelet was compiled without docker support
```

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
In theory, related to:
```docs
- [KEP]: https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/20200205-build-kubelet-without-docker.md
```
