### PR TITLE
Repair syntax error in Windows-GCE startup script

### DIFF
--- a/cluster/gce/windows/k8s-node-setup.psm1
+++ b/cluster/gce/windows/k8s-node-setup.psm1
@@ -1216,14 +1216,16 @@ function Verify-WorkerServices {
   Log_Todo "run more verification commands."
 }
 
-# Downloads crictl.exe and installs it in $env:NODE_DIR.
+# Downloads the Windows crictl package and installs its contents (e.g.
+# crictl.exe) in $env:NODE_DIR.
 function DownloadAndInstall-Crictl {
   if (-not (ShouldWrite-File ${env:NODE_DIR}\crictl.exe)) {
     return
   }
-  $CRI_TOOLS_GCS_BUCKET = "k8s-artifacts-cri-tools"
-  $url = ('https://storage.googleapis.com/$CRI_TOOLS_GCS_BUCKET/release/' +
-          $CRICTL_VERSION + '/crictl-' + $CRICTL_VERSION + '-windows-amd64.tar.gz')
+  $CRI_TOOLS_GCS_BUCKET = 'k8s-artifacts-cri-tools'
+  $url = ('https://storage.googleapis.com/' + $CRI_TOOLS_GCS_BUCKET +
+          '/release/' + $CRICTL_VERSION + '/crictl-' + $CRICTL_VERSION +
+          '-windows-amd64.tar.gz')
   MustDownload-File `
       -URLs $url `
       -OutFile ${env:NODE_DIR}\crictl.tar.gz `


### PR DESCRIPTION
This fixes a small syntax error introduced in https://github.com/kubernetes/kubernetes/pull/91564. 

Tested: `NUM_NODES=2 NUM_WINDOWS_NODES=2 KUBE_GCE_ENABLE_IP_ALIASES=true KUBERNETES_NODE_PLATFORM=windows LOGGING_STACKDRIVER_RESOURCE_TYPES=new KUBE_UP_AUTOMATIC_CLEANUP=true WINDOWS_NODE_OS_DISTRIBUTION=win2019 ./cluster/kube-up.sh`

With this change the cluster comes up successfully. I did not verify that everything still functions correctly with crictl v1.18; ; I'll check our [containerd Windows testgrid](https://testgrid.k8s.io/google-windows#gce-windows-2019-containerd-master&width=20) after this merges to be sure.

/kind bug

```release-note
NONE
```