### PR TITLE
update metric kubernetes_build_info labels from camelCase to snake_case.

### DIFF
--- a/staging/src/k8s.io/component-base/metrics/prometheus/version/metrics.go
+++ b/staging/src/k8s.io/component-base/metrics/prometheus/version/metrics.go
@@ -29,7 +29,7 @@ var (
 			Help:           "A metric with a constant '1' value labeled by major, minor, git version, git commit, git tree state, build date, Go version, and compiler from which Kubernetes was built, and platform on which it is running.",
 			StabilityLevel: metrics.ALPHA,
 		},
-		[]string{"major", "minor", "gitVersion", "gitCommit", "gitTreeState", "buildDate", "goVersion", "compiler", "platform"},
+		[]string{"major", "minor", "git_version", "git_commit", "git_tree_state", "build_date", "go_version", "compiler", "platform"},
 	)
 )
 

--- a/staging/src/k8s.io/component-base/metrics/testutil/promlint.go
+++ b/staging/src/k8s.io/component-base/metrics/testutil/promlint.go
@@ -47,11 +47,7 @@ var exceptionMetrics = []string{
 	"authentication_attempts",
 	"get_token_count",
 	"get_token_fail_count",
-	"kubernetes_build_info",
 	"node_collector_evictions_number",
-
-	// kube-proxy
-	"kubernetes_build_info",
 
 	// kubelet-resource-v1alpha1
 	"container_cpu_usage_seconds_total",

--- a/staging/src/k8s.io/component-base/metrics/version.go
+++ b/staging/src/k8s.io/component-base/metrics/version.go
@@ -25,7 +25,7 @@ var (
 			Help:           "A metric with a constant '1' value labeled by major, minor, git version, git commit, git tree state, build date, Go version, and compiler from which Kubernetes was built, and platform on which it is running.",
 			StabilityLevel: ALPHA,
 		},
-		[]string{"major", "minor", "gitVersion", "gitCommit", "gitTreeState", "buildDate", "goVersion", "compiler", "platform"},
+		[]string{"major", "minor", "git_version", "git_commit", "git_tree_state", "build_date", "go_version", "compiler", "platform"},
 	)
 )
 


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
As per `promlint` rules, label names should be written in `snake_case` not `camelCase`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
The metric label name of `kubernetes_build_info` has been updated from `camel case` to `snake case`:
- gitVersion --> git_version
- gitCommit --> git_commit
- gitTreeState --> git_tree_state
- buildDate --> build_date
- goVersion --> go_version

This change happens in `kube-apiserver`、`kube-scheduler`、`kube-proxy` and `kube-controller-manager`.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs

```
