### PR TITLE
another:Replace framework.Failf with ExpectNoError

### DIFF
--- a/test/e2e/storage/volume_metrics.go
+++ b/test/e2e/storage/volume_metrics.go
@@ -59,9 +59,8 @@ var _ = utils.SIGDescribe("[Serial] Volume metrics", func() {
 		var err error
 		e2eskipper.SkipUnlessProviderIs("gce", "gke", "aws")
 		defaultScName, err = e2epv.GetDefaultStorageClassName(c)
-		if err != nil {
-			framework.Failf(err.Error())
-		}
+		framework.ExpectNoError(err)
+
 		test := testsuites.StorageClassTest{
 			Name:      "default",
 			ClaimSize: "2Gi",


### PR DESCRIPTION
What type of PR is this?

/kind cleanup

What this PR does / why we need it:

This replaces with conditional framework.Failf with ExpectNoError for cleanup.


```release-note
   Replace framework.Failf with ExpectNoError
```
