### PR TITLE
e2e_node: fix node-kubelet-benchmark test

### DIFF
--- a/test/e2e_node/density_test.go
+++ b/test/e2e_node/density_test.go
@@ -126,7 +126,7 @@ var _ = framework.KubeDescribe("Density [Serial] [Slow]", func() {
 				interval: 0 * time.Millisecond,
 			},
 			{
-				podsNr:   105,
+				podsNr:   90,
 				interval: 0 * time.Millisecond,
 			},
 			{
@@ -138,7 +138,7 @@ var _ = framework.KubeDescribe("Density [Serial] [Slow]", func() {
 				interval: 100 * time.Millisecond,
 			},
 			{
-				podsNr:   105,
+				podsNr:   90,
 				interval: 100 * time.Millisecond,
 			},
 			{
@@ -150,7 +150,7 @@ var _ = framework.KubeDescribe("Density [Serial] [Slow]", func() {
 				interval: 300 * time.Millisecond,
 			},
 			{
-				podsNr:   105,
+				podsNr:   90,
 				interval: 300 * time.Millisecond,
 			},
 		}
@@ -176,17 +176,17 @@ var _ = framework.KubeDescribe("Density [Serial] [Slow]", func() {
 	ginkgo.Context("create a batch of pods with higher API QPS", func() {
 		dTests := []densityTest{
 			{
-				podsNr:      105,
+				podsNr:      90,
 				interval:    0 * time.Millisecond,
 				APIQPSLimit: 60,
 			},
 			{
-				podsNr:      105,
+				podsNr:      90,
 				interval:    100 * time.Millisecond,
 				APIQPSLimit: 60,
 			},
 			{
-				podsNr:      105,
+				podsNr:      90,
 				interval:    300 * time.Millisecond,
 				APIQPSLimit: 60,
 			},


### PR DESCRIPTION
**What type of PR is this?**

/kind failing-test

**What this PR does / why we need it**:

e2e_node tests trigger OOM events on COS versions > 73-11636-0-0
possibly because of this change in the COS v.73-11636-0-0:
```
    Made containerd run as a standalone systemd service
```
OOM killer usually kills cadvisor and e2e_node.test processes
causing node-kubelet-benchmark failures.

Decreasing amount of pods from 105 to 90 frees enough memory for
the test to succeed.

See more details in [this PR](https://github.com/kubernetes/test-infra/pull/17743)

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
