### PR TITLE
Teach kubectl drain to evict on nodes in parallel

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/drain/drain.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/drain/drain.go
@@ -292,7 +292,7 @@ func (o *DrainCmdOptions) drainNode(
 	drainResultMutex *sync.Mutex,
 	drainWG *sync.WaitGroup,
 	drainedNodes *sets.String,
-	drainErrors []error,
+	drainErrors *[]error,
 	printObj printers.ResourcePrinterFunc,
 ) {
 	err := o.deleteOrEvictPodsSimple(nodeInfo)
@@ -305,7 +305,7 @@ func (o *DrainCmdOptions) drainNode(
 		printObj(nodeInfo.Object, o.Out)
 	} else {
 		fmt.Fprintf(o.ErrOut, "error: unable to drain node %q\n\n", nodeInfo.Name)
-		drainErrors = append(drainErrors, err)
+		*drainErrors = append(*drainErrors, err)
 	}
 }
 
@@ -328,9 +328,9 @@ func (o *DrainCmdOptions) RunDrain() error {
 
 	for _, info := range o.nodeInfos {
 		if o.drainer.ParallelizeNodes {
-			go o.drainNode(info, &drainResultMutex, &drainWG, &drainedNodes, drainErrors, printObj)
+			go o.drainNode(info, &drainResultMutex, &drainWG, &drainedNodes, &drainErrors, printObj)
 		} else {
-			o.drainNode(info, &drainResultMutex, &drainWG, &drainedNodes, drainErrors, printObj)
+			o.drainNode(info, &drainResultMutex, &drainWG, &drainedNodes, &drainErrors, printObj)
 		}
 	}
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/drain/drain.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/drain/drain.go
@@ -195,7 +195,7 @@ func NewCmdDrain(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *cobr
 	cmd.Flags().StringVarP(&o.drainer.PodSelector, "pod-selector", "", o.drainer.PodSelector, "Label selector to filter pods on the node")
 	cmd.Flags().BoolVar(&o.drainer.DisableEviction, "disable-eviction", o.drainer.DisableEviction, "Force drain to use delete, even if eviction is supported. This will bypass checking PodDisruptionBudgets, use with caution.")
 	cmd.Flags().IntVar(&o.drainer.SkipWaitForDeleteTimeoutSeconds, "skip-wait-for-delete-timeout", o.drainer.SkipWaitForDeleteTimeoutSeconds, "If pod DeletionTimestamp older than N seconds, skip waiting for the pod.  Seconds must be greater than 0 to skip.")
-	cmd.Flags().BoolVar(&o.drainer.ParallelizeNodes, "parallelize-nodes", o.drainer.ParallelizeNodes, "Execute drains on multiple nodes in parallel")
+	cmd.Flags().BoolVar(&o.drainer.Parallel, "parallel", o.drainer.Parallel, "Execute drains on multiple nodes in parallel")
 
 	cmdutil.AddDryRunFlag(cmd)
 	return cmd
@@ -327,7 +327,7 @@ func (o *DrainCmdOptions) RunDrain() error {
 	drainWG.Add(len(o.nodeInfos))
 
 	for _, info := range o.nodeInfos {
-		if o.drainer.ParallelizeNodes {
+		if o.drainer.Parallel {
 			go o.drainNode(info, &drainResultMutex, &drainWG, &drainedNodes, &drainErrors, printObj)
 		} else {
 			o.drainNode(info, &drainResultMutex, &drainWG, &drainedNodes, &drainErrors, printObj)

--- a/staging/src/k8s.io/kubectl/pkg/cmd/drain/drain.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/drain/drain.go
@@ -287,7 +287,6 @@ func (o *DrainCmdOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args [
 	})
 }
 
-// drainNode is expected to be thread-safe to support parallel node drain
 func (o *DrainCmdOptions) drainNode(
 	nodeInfo *resource.Info,
 	drainResultMutex *sync.Mutex,
@@ -354,7 +353,6 @@ func (o *DrainCmdOptions) RunDrain() error {
 	return utilerrors.NewAggregate(drainErrors)
 }
 
-// deleteOrEvictPodsSimple is expected to be thread-safe to support parallel node drain
 func (o *DrainCmdOptions) deleteOrEvictPodsSimple(nodeInfo *resource.Info) error {
 	list, errs := o.drainer.GetPodsForDeletion(nodeInfo.Name)
 	if errs != nil {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/drain/drain.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/drain/drain.go
@@ -287,6 +287,7 @@ func (o *DrainCmdOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args [
 	})
 }
 
+// drainNode is expected to be thread-safe to support parallel node drain
 func (o *DrainCmdOptions) drainNode(
 	nodeInfo *resource.Info,
 	drainResultMutex *sync.Mutex,
@@ -353,6 +354,7 @@ func (o *DrainCmdOptions) RunDrain() error {
 	return utilerrors.NewAggregate(drainErrors)
 }
 
+// deleteOrEvictPodsSimple is expected to be thread-safe to support parallel node drain
 func (o *DrainCmdOptions) deleteOrEvictPodsSimple(nodeInfo *resource.Info) error {
 	list, errs := o.drainer.GetPodsForDeletion(nodeInfo.Name)
 	if errs != nil {

--- a/staging/src/k8s.io/kubectl/pkg/drain/drain.go
+++ b/staging/src/k8s.io/kubectl/pkg/drain/drain.go
@@ -61,7 +61,7 @@ type Helper struct {
 	DisableEviction bool
 
 	// Drain pods from multiple nodes in parallel
-	ParallelizeNodes bool
+	Parallel bool
 
 	// SkipWaitForDeleteTimeoutSeconds ignores pods that have a
 	// DeletionTimeStamp > N seconds. It's up to the user to decide when this

--- a/staging/src/k8s.io/kubectl/pkg/drain/drain.go
+++ b/staging/src/k8s.io/kubectl/pkg/drain/drain.go
@@ -59,6 +59,9 @@ type Helper struct {
 	// DisableEviction forces drain to use delete rather than evict
 	DisableEviction bool
 
+	// Drain pods from multiple nodes in parallel
+	ParallelizeNodes bool
+
 	// SkipWaitForDeleteTimeoutSeconds ignores pods that have a
 	// DeletionTimeStamp > N seconds. It's up to the user to decide when this
 	// option is appropriate; examples include the Node is unready and the pods

--- a/staging/src/k8s.io/kubectl/pkg/drain/drain.go
+++ b/staging/src/k8s.io/kubectl/pkg/drain/drain.go
@@ -44,7 +44,8 @@ const (
 	podSkipMsgTemplate  = "pod %q has DeletionTimestamp older than %v seconds, skipping\n"
 )
 
-// Helper contains the parameters to control the behaviour of drainer
+// Helper contains the parameters to control the behaviour of drainer. Methods on
+// Helper are expected to be thread-safe to support parallel node drain
 type Helper struct {
 	Ctx                 context.Context
 	Client              kubernetes.Interface


### PR DESCRIPTION
/kind feature

**What this PR does / why we need it**:

Pod eviction can be a very slow operation. Currently `kubectl drain` takes multiple node arguments and then evicts pods on each given node in serial. This change makes `kubectl drain` time roughly constant instead of linear with the number of nodes given.

**Does this PR introduce a user-facing change?**:

Yes

```release-note
"kubectl drain" with multiple node arguments now drains all nodes in parallel rather then in sequence
```