### PR TITLE
Remove log message causing significant overhead on Preemption evaluation

### DIFF
--- a/pkg/scheduler/core/generic_scheduler.go
+++ b/pkg/scheduler/core/generic_scheduler.go
@@ -273,6 +273,13 @@ func (g *genericScheduler) Preempt(ctx context.Context, prof *profile.Profile, s
 		// In this case, we should clean-up any existing nominated node name of the pod.
 		return "", nil, []*v1.Pod{pod}, nil
 	}
+	if klog.V(5).Enabled() {
+		var sample []string
+		for i := 0; i < 10 && i < len(potentialNodes); i++ {
+			sample = append(sample, potentialNodes[i].Node().Name)
+		}
+		klog.Infof("%v potential nodes for preemption, first %v are: %v", len(potentialNodes), len(sample), sample)
+	}
 	var pdbs []*policy.PodDisruptionBudget
 	if g.pdbLister != nil {
 		pdbs, err = g.pdbLister.List(labels.Everything())
@@ -1042,7 +1049,6 @@ func nodesWherePreemptionMightHelp(nodes []*framework.NodeInfo, fitErr *FitError
 		if fitErr.FilteredNodesStatuses[name].Code() == framework.UnschedulableAndUnresolvable {
 			continue
 		}
-		klog.V(3).Infof("Node %v is a potential node for preemption.", name)
 		potentialNodes = append(potentialNodes, node)
 	}
 	return potentialNodes


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Preemption evaluation on large scale clusters is expensive. When the cluster has many unschedulable pods, this overhead impacts the scheduler's performance for other schedulable pods.

Based on profiling, the formatting of the log message removed in this PR causes significant performance overhead on 5k clusters since it is evaluated inside a tight loop.

Before:

```
   {
      "data": {
        "Average": 78.125,
        "Perc50": 0,
        "Perc90": 459,
        "Perc99": 814
      },
      "unit": "pods/s",
      "labels": {
        "Metric": "SchedulingThroughput",
        "Name": "BenchmarkPerfScheduling/Unschedulable/5000Nodes/2000InitPods/5000PodsToSchedule"
      }
    },
    {
      "data": {
        "Average": 15.996093224812654,
        "Perc50": 14.4688995215311,
        "Perc90": 28.900223713646536,
        "Perc99": 31.049664429530203
      },
      "unit": "ms",
      "labels": {
        "Metric": "scheduler_scheduling_algorithm_preemption_evaluation_seconds",
        "Name": "BenchmarkPerfScheduling/Unschedulable/5000Nodes/2000InitPods/5000PodsToSchedule"
      }
    },
```

After
```
   {
      "data": {
        "Average": 122.75675675675676,
        "Perc50": 0,
        "Perc90": 799,
        "Perc99": 817
      },
      "unit": "pods/s",
      "labels": {
        "Metric": "SchedulingThroughput",
        "Name": "BenchmarkPerfScheduling/Unschedulable/5000Nodes/2000InitPods/5000PodsToSchedule"
      }
    },
    {
      "data": {
        "Average": 5.290055630570604,
        "Perc50": 5.075514874141876,
        "Perc90": 8.097435897435902,
        "Perc99": 14.253846153846144
      },
      "unit": "ms",
      "labels": {
        "Metric": "scheduler_scheduling_algorithm_preemption_evaluation_seconds",
        "Name": "BenchmarkPerfScheduling/Unschedulable/5000Nodes/2000InitPods/5000PodsToSchedule"
      }
    },
```

**Special notes for your reviewer**:
Builds on the benchmark PR #91787

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

