### PR TITLE
update corefile-migration library to 1.0.8

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/codegangsta/negroni v1.0.0 // indirect
 	github.com/container-storage-interface/spec v1.2.0
 	github.com/containernetworking/cni v0.7.1
-	github.com/coredns/corefile-migration v1.0.6
+	github.com/coredns/corefile-migration v1.0.8
 	github.com/coreos/go-oidc v2.1.0+incompatible
 	github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e
 	github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f
@@ -211,7 +211,7 @@ replace (
 	github.com/containerd/ttrpc => github.com/containerd/ttrpc v1.0.0
 	github.com/containerd/typeurl => github.com/containerd/typeurl v1.0.0
 	github.com/containernetworking/cni => github.com/containernetworking/cni v0.7.1
-	github.com/coredns/corefile-migration => github.com/coredns/corefile-migration v1.0.6
+	github.com/coredns/corefile-migration => github.com/coredns/corefile-migration v1.0.8
 	github.com/coreos/bbolt => github.com/coreos/bbolt v1.3.2
 	github.com/coreos/etcd => github.com/coreos/etcd v3.3.10+incompatible
 	github.com/coreos/go-oidc => github.com/coreos/go-oidc v2.1.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -108,8 +108,8 @@ github.com/containerd/typeurl v1.0.0 h1:7LMH7LfEmpWeCkGcIputvd4P0Rnd0LrIv1Jk2s5o
 github.com/containerd/typeurl v1.0.0/go.mod h1:Cm3kwCdlkCfMSHURc+r6fwoGH6/F1hH3S4sg0rLFWPc=
 github.com/containernetworking/cni v0.7.1 h1:fE3r16wpSEyaqY4Z4oFrLMmIGfBYIKpPrHK31EJ9FzE=
 github.com/containernetworking/cni v0.7.1/go.mod h1:LGwApLUm2FpoOfxTDEeq8T9ipbpZ61X79hmU3w8FmsY=
-github.com/coredns/corefile-migration v1.0.6 h1:hB6vclp2g/KeXe9n1oz/PafgieUahsOYeHMQA+RJ4Hg=
-github.com/coredns/corefile-migration v1.0.6/go.mod h1:OFwBp/Wc9dJt5cAZzHWMNhK1r5L0p0jDwIBc6j8NC8E=
+github.com/coredns/corefile-migration v1.0.8 h1:y/DSRGlmrLPTMUGWR81MgFC2ITLiaTGkbth0BqW3wvc=
+github.com/coredns/corefile-migration v1.0.8/go.mod h1:OFwBp/Wc9dJt5cAZzHWMNhK1r5L0p0jDwIBc6j8NC8E=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible h1:jFneRYjIvLMLhDLCzuTuU4rSJUjRplcJQ7pD7MnhC04=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=

--- a/vendor/github.com/coredns/corefile-migration/migration/corefile/corefile.go
+++ b/vendor/github.com/coredns/corefile-migration/migration/corefile/corefile.go
@@ -76,7 +76,7 @@ func (c *Corefile) ToString() (out string) {
 }
 
 func (s *Server) ToString() (out string) {
-	str := strings.Join(s.DomPorts, " ")
+	str := strings.Join(escapeArgs(s.DomPorts), " ")
 	strs := []string{}
 	for _, p := range s.Plugins {
 		strs = append(strs, strings.Repeat(" ", indent)+p.ToString())
@@ -88,7 +88,7 @@ func (s *Server) ToString() (out string) {
 }
 
 func (p *Plugin) ToString() (out string) {
-	str := strings.Join(append([]string{p.Name}, p.Args...), " ")
+	str := strings.Join(append([]string{p.Name}, escapeArgs(p.Args)...), " ")
 	strs := []string{}
 	for _, o := range p.Options {
 		strs = append(strs, strings.Repeat(" ", indent*2)+o.ToString())
@@ -100,8 +100,24 @@ func (p *Plugin) ToString() (out string) {
 }
 
 func (o *Option) ToString() (out string) {
-	str := strings.Join(append([]string{o.Name}, o.Args...), " ")
+	str := strings.Join(append([]string{o.Name}, escapeArgs(o.Args)...), " ")
 	return str
+}
+
+// escapeArgs returns the arguments list escaping and wrapping any argument containing whitespace in quotes
+func escapeArgs(args []string) []string {
+	var escapedArgs []string
+	for _, a := range args {
+		// if there is white space, wrap argument with quotes
+		if len(strings.Fields(a)) > 1 {
+			// escape quotes
+			a = strings.Replace(a, "\"", "\\\"", -1)
+			// wrap with quotes
+			a = "\"" + a + "\""
+		}
+		escapedArgs = append(escapedArgs, a)
+	}
+	return escapedArgs
 }
 
 func (s *Server) FindMatch(def []*Server) (*Server, bool) {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -164,7 +164,7 @@ github.com/containernetworking/cni/pkg/types
 github.com/containernetworking/cni/pkg/types/020
 github.com/containernetworking/cni/pkg/types/current
 github.com/containernetworking/cni/pkg/version
-# github.com/coredns/corefile-migration v1.0.6 => github.com/coredns/corefile-migration v1.0.6
+# github.com/coredns/corefile-migration v1.0.8 => github.com/coredns/corefile-migration v1.0.8
 github.com/coredns/corefile-migration/migration
 github.com/coredns/corefile-migration/migration/corefile
 # github.com/coreos/go-oidc v2.1.0+incompatible => github.com/coreos/go-oidc v2.1.0+incompatible


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:
From  https://github.com/coredns/corefile-migration/releases/tag/v1.0.8

The latest version fixes a critical bug.

This problem will occur when upgrading kubernetes via kubeadm. If coredns has an upgrade scenario, kubeadm will try to migrate the coredns corefile to the latest. For example, if there is a whitespace in the plugin parameter in the previous corefile, it will be migrated to the wrong parameter during the migration

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
https://github.com/coredns/corefile-migration/issues/42

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
update corefile-migration library to 1.0.8
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
update corefile-migration library to 1.0.8
```

/assign @bgrant0607
