### PR TITLE
Fix FieldManager Conversion Error for CRD Updates

### DIFF
--- a/test/integration/auth/node_test.go
+++ b/test/integration/auth/node_test.go
@@ -480,7 +480,7 @@ func TestNodeAuthorizer(t *testing.T) {
 	expectNotFound(t, deleteNode2MirrorPod(node1Client))
 	expectNotFound(t, createNode2MirrorPodEviction(node1Client))
 	expectForbidden(t, createNode2(node1Client))
-	expectForbidden(t, updateNode2Status(node1Client))
+	expectNotFound(t, updateNode2Status(node1Client))
 	expectForbidden(t, deleteNode2(node1Client))
 
 	// related object requests from node2 fail
@@ -500,6 +500,8 @@ func TestNodeAuthorizer(t *testing.T) {
 	expectAllowed(t, updateNode2Status(node2Client))
 	// self deletion is not allowed
 	expectForbidden(t, deleteNode2(node2Client))
+	// modification of another node's status is not allowed
+	expectForbidden(t, updateNode2Status(node1Client))
 	// clean up node2
 	expectAllowed(t, deleteNode2(superuserClient))
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

When handling a crd update, the fieldManager sometimes fails conversion of the live object an error like:
`failed to update object (Update for openfaas.com/v1, Kind=Function) managed fields: failed to convert live object to proper version: /, Kind= is unstructured and is not suitable for converting to "openfaas.com/v1"`

This seems to be caused by the fieldManager receiving a liveObject that is empty.

The current approach changes the Update call to not call the UpdateHandler if there is no existing object and createOnUpdate is not allowed.
This way the fieldManager never gets called.

**Which issue(s) this PR fixes**:

Partial fix for https://github.com/kubernetes/kubernetes/issues/90904

```release-note
NONE
```

/sig api-machinery
/wg api-expression
/cc @apelisse @liggitt 