### PR TITLE
Update docs to reflect that the largest supported service subnet

### DIFF
--- a/cmd/kube-apiserver/app/options/options.go
+++ b/cmd/kube-apiserver/app/options/options.go
@@ -192,7 +192,7 @@ func (s *ServerRunOptions) Flags() (fss cliflag.NamedFlagSets) {
 	// TODO (khenidak) change documentation as we move IPv6DualStack feature from ALPHA to BETA
 	fs.StringVar(&s.ServiceClusterIPRanges, "service-cluster-ip-range", s.ServiceClusterIPRanges, ""+
 		"A CIDR notation IP range from which to assign service cluster IPs. This must not "+
-		"overlap with any IP ranges assigned to nodes or pods.")
+		"overlap with any IP ranges assigned to nodes or pods. The largest supported service subnet is /12 for IPv4 and /112 for IPv6.")
 
 	fs.Var(&s.ServiceNodePortRange, "service-node-port-range", ""+
 		"A port range to reserve for services with NodePort visibility. "+

--- a/cmd/kube-controller-manager/app/options/nodeipamcontroller.go
+++ b/cmd/kube-controller-manager/app/options/nodeipamcontroller.go
@@ -35,7 +35,7 @@ func (o *NodeIPAMControllerOptions) AddFlags(fs *pflag.FlagSet) {
 	if o == nil {
 		return
 	}
-	fs.StringVar(&o.ServiceCIDR, "service-cluster-ip-range", o.ServiceCIDR, "CIDR Range for Services in cluster. Requires --allocate-node-cidrs to be true")
+	fs.StringVar(&o.ServiceCIDR, "service-cluster-ip-range", o.ServiceCIDR, "CIDR Range for Services in cluster. Requires --allocate-node-cidrs to be true. The largest supported service subnet is /12 for IPv4 and /112 for IPv6.")
 	fs.Int32Var(&o.NodeCIDRMaskSize, "node-cidr-mask-size", o.NodeCIDRMaskSize, "Mask size for node cidr in cluster. Default is 24 for IPv4 and 64 for IPv6.")
 	fs.Int32Var(&o.NodeCIDRMaskSizeIPv4, "node-cidr-mask-size-ipv4", o.NodeCIDRMaskSizeIPv4, "Mask size for IPv4 node cidr in dual-stack cluster. Default is 24.")
 	fs.Int32Var(&o.NodeCIDRMaskSizeIPv6, "node-cidr-mask-size-ipv6", o.NodeCIDRMaskSizeIPv6, "Mask size for IPv6 node cidr in dual-stack cluster. Default is 64.")

--- a/cmd/kubeadm/app/apis/kubeadm/validation/validation_test.go
+++ b/cmd/kubeadm/app/apis/kubeadm/validation/validation_test.go
@@ -184,41 +184,48 @@ func TestValidateIPFromString(t *testing.T) {
 
 func TestValidateIPNetFromString(t *testing.T) {
 	var tests = []struct {
-		name           string
-		subnet         string
-		minaddrs       int64
-		checkDualStack bool
-		expected       bool
+		name               string
+		subnet             string
+		minaddrs           int64
+		checkDualStack     bool
+		checkServiceSubnet bool
+		expected           bool
 	}{
-		{"invalid missing CIDR", "", 0, false, false},
-		{"invalid  CIDR", "a", 0, false, false},
-		{"invalid CIDR missing decimal points in IPv4 address and / mask", "1234", 0, false, false},
-		{"invalid CIDR use of letters instead of numbers and / mask", "abc", 0, false, false},
-		{"invalid IPv4 address provided instead of CIDR representation", "1.2.3.4", 0, false, false},
-		{"invalid IPv6 address provided instead of CIDR representation", "2001:db8::1", 0, false, false},
-		{"invalid multiple CIDR provided in a single stack cluster", "2001:db8::1/64,1.2.3.4/24", 0, false, false},
-		{"invalid multiple CIDR provided in a single stack cluster and one invalid subnet", "2001:db8::1/64,a", 0, false, false},
-		{"valid, but IPv4 CIDR too small. At least 10 addresses needed", "10.0.0.16/29", 10, false, false},
-		{"valid, but IPv6 CIDR too small. At least 10 addresses needed", "2001:db8::/125", 10, false, false},
-		{"valid IPv4 CIDR", "10.0.0.16/12", 10, false, true},
-		{"valid IPv6 CIDR", "2001:db8::/98", 10, false, true},
+		{"invalid missing CIDR", "", 0, false, false, false},
+		{"invalid  CIDR", "a", 0, false, false, false},
+		{"invalid CIDR missing decimal points in IPv4 address and / mask", "1234", 0, false, false, false},
+		{"invalid CIDR use of letters instead of numbers and / mask", "abc", 0, false, false, false},
+		{"invalid IPv4 address provided instead of CIDR representation", "1.2.3.4", 0, false, false, false},
+		{"invalid IPv6 address provided instead of CIDR representation", "2001:db8::1", 0, false, false, false},
+		{"invalid multiple CIDR provided in a single stack cluster", "2001:db8::1/64,1.2.3.4/24", 0, false, false, false},
+		{"invalid multiple CIDR provided in a single stack cluster and one invalid subnet", "2001:db8::1/64,a", 0, false, false, false},
+		{"valid, but IPv4 CIDR too small. At least 10 addresses needed", "10.0.0.16/29", 10, false, false, false},
+		{"valid, but IPv6 CIDR too small. At least 10 addresses needed", "2001:db8::/125", 10, false, false, false},
+		{"valid IPv4 CIDR", "10.0.0.16/12", 10, false, false, true},
+		{"valid IPv6 CIDR", "2001:db8::/98", 10, false, false, true},
 		// dual-stack:
-		{"invalid missing CIDR", "", 0, true, false},
-		{"valid dual-stack enabled but only an IPv4 CIDR specified", "10.0.0.16/12", 10, true, true},
-		{"valid dual-stack enabled but only an IPv6 CIDR specified", "2001:db8::/98", 10, true, true},
-		{"invalid IPv4 address provided instead of CIDR representation", "1.2.3.4,2001:db8::/98", 0, true, false},
-		{"invalid IPv6 address provided instead of CIDR representation", "2001:db8::1,10.0.0.16/12", 0, true, false},
-		{"valid, but IPv4 CIDR too small. At least 10 addresses needed", "10.0.0.16/29,2001:db8::/98", 10, true, false},
-		{"valid, but IPv6 CIDR too small. At least 10 addresses needed", "10.0.0.16/12,2001:db8::/125", 10, true, false},
-		{"valid, but only IPv4 family addresses specified. IPv6 CIDR is necessary.", "10.0.0.16/12,192.168.0.0/16", 10, true, false},
-		{"valid, but only IPv6 family addresses specified. IPv4 CIDR is necessary.", "2001:db8::/98,2005:db8::/98", 10, true, false},
-		{"valid IPv4 and IPv6 CIDR", "10.0.0.16/12,2001:db8::/98", 10, true, true},
-		{"valid IPv6 and IPv4 CIDR", "10.0.0.16/12,2001:db8::/98", 10, true, true},
-		{"invalid IPv6 and IPv4 CIDR with more than 2 subnets", "10.0.0.16/12,2001:db8::/98,192.168.0.0/16", 10, true, false},
-		{"invalid IPv6 and IPv4 CIDR with more than 2 subnets", "10.0.0.16/12,2001:db8::/98,192.168.0.0/16,a.b.c.d/24", 10, true, false},
+		{"invalid missing CIDR", "", 0, true, false, false},
+		{"valid dual-stack enabled but only an IPv4 CIDR specified", "10.0.0.16/12", 10, true, false, true},
+		{"valid dual-stack enabled but only an IPv6 CIDR specified", "2001:db8::/98", 10, true, false, true},
+		{"invalid IPv4 address provided instead of CIDR representation", "1.2.3.4,2001:db8::/98", 0, true, false, false},
+		{"invalid IPv6 address provided instead of CIDR representation", "2001:db8::1,10.0.0.16/12", 0, true, false, false},
+		{"valid, but IPv4 CIDR too small. At least 10 addresses needed", "10.0.0.16/29,2001:db8::/98", 10, true, false, false},
+		{"valid, but IPv6 CIDR too small. At least 10 addresses needed", "10.0.0.16/12,2001:db8::/125", 10, true, false, false},
+		{"valid, but only IPv4 family addresses specified. IPv6 CIDR is necessary.", "10.0.0.16/12,192.168.0.0/16", 10, true, false, false},
+		{"valid, but only IPv6 family addresses specified. IPv4 CIDR is necessary.", "2001:db8::/98,2005:db8::/98", 10, true, false, false},
+		{"valid IPv4 and IPv6 CIDR", "10.0.0.16/12,2001:db8::/98", 10, true, false, true},
+		{"valid IPv6 and IPv4 CIDR", "10.0.0.16/12,2001:db8::/98", 10, true, false, true},
+		{"invalid IPv6 and IPv4 CIDR with more than 2 subnets", "10.0.0.16/12,2001:db8::/98,192.168.0.0/16", 10, true, false, false},
+		{"invalid IPv6 and IPv4 CIDR with more than 2 subnets", "10.0.0.16/12,2001:db8::/98,192.168.0.0/16,a.b.c.d/24", 10, true, false, false},
+		{"valid IPv4 service subnet", "10.0.0.0/12", 10, false, true, true},
+		{"valid IPv6 service subnet", "2001:db8::/112", 10, false, true, true},
+		{"valid, but IPv4 service subnet is too large. Max bits used for service subnet must not exceed 20 bits", "10.0.0.0/11", 10, false, true, false},
+		{"valid, but IPv6 service subnet is is too large. Max bits used for service subnet must not exceed 20 bits", "2001:db8::/107", 10, false, true, false},
+		{"valid, but IPv4 service subnet is is too large. Max bits used for service subnet must not exceed 20 bits", "10.0.0.16/10,2001:db8::/118", 10, true, true, false},
+		{"valid, but IPv6 service subnet is is too large. Max bits used for service subnet must not exceed 20 bits", "10.0.0.16/12,2001:db8::/106", 10, true, true, false},
 	}
 	for _, rt := range tests {
-		actual := ValidateIPNetFromString(rt.subnet, rt.minaddrs, rt.checkDualStack, nil)
+		actual := ValidateIPNetFromString(rt.subnet, rt.minaddrs, rt.checkDualStack, rt.checkServiceSubnet, nil)
 		if (len(actual) == 0) != rt.expected {
 			t.Errorf(
 				"%s test case failed :\n\texpected: %t\n\t  actual: %t\n\t  err(s): %v\n\t",
@@ -465,7 +472,7 @@ func TestValidateInitConfiguration(t *testing.T) {
 						},
 					},
 					Networking: kubeadm.Networking{
-						ServiceSubnet: "2001:db8::1/98",
+						ServiceSubnet: "2001:db8::1/112",
 						DNSDomain:     "cluster.local",
 					},
 					CertificatesDir: "/some/other/cert/dir",

--- a/cmd/kubeadm/app/cmd/init.go
+++ b/cmd/kubeadm/app/cmd/init.go
@@ -223,7 +223,7 @@ func AddInitConfigFlags(flagSet *flag.FlagSet, cfg *kubeadmapiv1beta2.InitConfig
 func AddClusterConfigFlags(flagSet *flag.FlagSet, cfg *kubeadmapiv1beta2.ClusterConfiguration, featureGatesString *string) {
 	flagSet.StringVar(
 		&cfg.Networking.ServiceSubnet, options.NetworkingServiceSubnet, cfg.Networking.ServiceSubnet,
-		"Use alternative range of IP address for service VIPs.",
+		"Use alternative range of IP address for service VIPs. The largest supported service subnet is /12 for IPv4 and /112 for IPv6.",
 	)
 	flagSet.StringVar(
 		&cfg.Networking.PodSubnet, options.NetworkingPodSubnet, cfg.Networking.PodSubnet,

--- a/cmd/kubeadm/app/constants/constants.go
+++ b/cmd/kubeadm/app/constants/constants.go
@@ -195,6 +195,10 @@ const (
 	// We need at least ten, because the DNS service is always at the tenth cluster clusterIP
 	MinimumAddressesInServiceSubnet = 10
 
+	// MaximumBitsForServiceSubnet defines maximum possible size of the service subnet in terms of bits. For example, if value is 20, then the largest supported service subnet is /12 for IPv4 and /108 for IPv6.
+	// Note however that anything in between /108 and /112 will be clamped to /112 due to the limitations of the underlying allocation logic.
+	MaximumBitsForServiceSubnet = 20
+
 	// DefaultTokenDuration specifies the default amount of time that a bootstrap token will be valid
 	// Default behaviour is 24 hours
 	DefaultTokenDuration = 24 * time.Hour


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
Update docs to reflect that the largest supported service subnet is /12 for IPv4 and /108 for IPv6. Also add validation of max allowable subnet size to kubeadm which identical to what the apiserver does. 

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes/kubeadm/issues/2132

**Does this PR introduce a user-facing change?**:
```release-note
kube-controller-manager, kube-apiserver and kubeadm now include a more descriptive message on what IPv4 and IPv6 ranges are supported for service subnet. Add related validation in kubeadm and exit on errors early.
```
