### PR TITLE
Fix access to Kubernetes Service from inside Windows Pod when two ser…

### DIFF
--- a/pkg/proxy/winkernel/proxier.go
+++ b/pkg/proxy/winkernel/proxier.go
@@ -278,6 +278,24 @@ func newServiceInfo(svcPortName proxy.ServicePortName, port *v1.ServicePort, ser
 	return info
 }
 
+func (network hnsNetworkInfo) findRemoteSubnetProviderAddress(ip string) string {
+	var providerAddress string
+	for _, rs := range network.remoteSubnets {
+		_, ipNet, err := net.ParseCIDR(rs.destinationPrefix)
+		if err != nil {
+			klog.Fatalf("%v", err)
+		}
+		if ipNet.Contains(net.ParseIP(ip)) {
+			providerAddress = rs.providerAddress
+		}
+		if ip == rs.providerAddress {
+			providerAddress = rs.providerAddress
+		}
+	}
+
+	return providerAddress
+}
+
 type endpointsChange struct {
 	previous proxyEndpointsMap
 	current  proxyEndpointsMap
@@ -1153,24 +1171,12 @@ func (proxier *Proxier) syncProxyRules() {
 						return
 					}
 					proxier.network = *updatedNetwork
-					var providerAddress string
-					for _, rs := range proxier.network.remoteSubnets {
-						_, ipNet, err := net.ParseCIDR(rs.destinationPrefix)
-						if err != nil {
-							klog.Fatalf("%v", err)
-						}
-						if ipNet.Contains(net.ParseIP(ep.ip)) {
-							providerAddress = rs.providerAddress
-						}
-						if ep.ip == rs.providerAddress {
-							providerAddress = rs.providerAddress
-							containsNodeIP = true
-						}
-					}
+
+					providerAddress := proxier.network.findRemoteSubnetProviderAddress(ep.ip)
+
 					if len(providerAddress) == 0 {
 						klog.Infof("Could not find provider address for %s. Assuming it is a public IP", ep.ip)
 						providerAddress = proxier.nodeIP.String()
-						containsPublicIP = true
 					}
 
 					hnsEndpoint := &endpointsInfo{
@@ -1198,6 +1204,17 @@ func (proxier *Proxier) syncProxyRules() {
 						continue
 					}
 				}
+			}
+
+			if proxier.network.networkType == "Overlay" {
+				providerAddress := proxier.network.findRemoteSubnetProviderAddress(ep.ip)
+
+				isNodeIP := (ep.ip == providerAddress)
+				isPublicIP := (len(providerAddress) == 0)
+				klog.Infof("Endpoint %s on overlay network %s is classified as NodeIp: %v, Public Ip: %v", ep.ip, hnsNetworkName, isNodeIP, isPublicIP)
+
+				containsNodeIP = containsNodeIP || isNodeIP
+				containsPublicIP = containsPublicIP || isPublicIP
 			}
 
 			// Save the hnsId for reference

--- a/pkg/proxy/winkernel/proxier_test.go
+++ b/pkg/proxy/winkernel/proxier_test.go
@@ -321,6 +321,27 @@ func TestNoopEndpointSlice(t *testing.T) {
 	p.OnEndpointSlicesSynced()
 }
 
+func TestFindRemoteSubnetProviderAddress(t *testing.T) {
+	networkInfo, _ := newFakeHNS().getNetworkByName("TestNetwork")
+	pa := networkInfo.findRemoteSubnetProviderAddress(providerAddress)
+
+	if pa != providerAddress {
+		t.Errorf("%v does not match %v", pa, providerAddress)
+	}
+
+	pa = networkInfo.findRemoteSubnetProviderAddress(epIpAddressRemote)
+
+	if pa != providerAddress {
+		t.Errorf("%v does not match %v", pa, providerAddress)
+	}
+
+	pa = networkInfo.findRemoteSubnetProviderAddress(serviceVip)
+
+	if len(pa) != 0 {
+		t.Errorf("Provider address is not empty as expected")
+	}
+}
+
 func makeNSN(namespace, name string) types.NamespacedName {
 	return types.NamespacedName{Namespace: namespace, Name: name}
 }


### PR DESCRIPTION
…vices have same NodeIp as backend (Overlay)

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind api-change

/kind bug

> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
In Overlay mode, when 2 services have the same Node IP as backend , the load balancer is programmed incorrectly in HNS with a wrong Source VIP. 

For a case when a remote endpoint (for Node IP) is already created in HNS, we are missing the logic to classify the remote endpoint as NodeIP/PublicIP.  We need to use the current windows worker node's IP as source VIP in the LB policy when remote endpoints are classified as NodeIP/PublicIP.

Fix: Classify the remote endpoint as NodeIP/PublicIP before plumbing the LB policy for cases where remote endpoint was previously created in HNS.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #91912 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
