### PR TITLE
aws: Fix address sorting of multiple interfaces

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/aws/aws.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/aws/aws.go
@@ -1415,7 +1415,9 @@ func (c *Cloud) NodeAddresses(ctx context.Context, name types.NodeName) ([]v1.No
 		// We want the IPs to end up in order by interface (in particular, we want eth0's
 		// IPs first), but macs isn't necessarily sorted in that order so we have to
 		// explicitly order by device-number (device-number == the "0" in "eth0").
-		macIPs := make(map[int]string)
+
+		var macIDs []string
+		macDevNum := make(map[string]int)
 		for _, macID := range strings.Split(macs, "\n") {
 			if macID == "" {
 				continue
@@ -1430,18 +1432,22 @@ func (c *Cloud) NodeAddresses(ctx context.Context, name types.NodeName) ([]v1.No
 				klog.Warningf("Bad device-number %q for interface %s\n", numStr, macID)
 				continue
 			}
+			macIDs = append(macIDs, macID)
+			macDevNum[macID] = num
+		}
+
+		// Sort macIDs by interface device-number
+		sort.Slice(macIDs, func(i, j int) bool {
+			return macDevNum[macIDs[i]] < macDevNum[macIDs[j]]
+		})
+
+		for _, macID := range macIDs {
 			ipPath := path.Join("network/interfaces/macs/", macID, "local-ipv4s")
-			macIPs[num], err = c.metadata.GetMetadata(ipPath)
+			internalIPs, err := c.metadata.GetMetadata(ipPath)
 			if err != nil {
 				return nil, fmt.Errorf("error querying AWS metadata for %q: %q", ipPath, err)
 			}
-		}
 
-		for i := 0; i < len(macIPs); i++ {
-			internalIPs := macIPs[i]
-			if internalIPs == "" {
-				continue
-			}
 			for _, internalIP := range strings.Split(internalIPs, "\n") {
 				if internalIP == "" {
 					continue

--- a/staging/src/k8s.io/legacy-cloud-providers/aws/aws_fakes.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/aws/aws_fakes.go
@@ -358,7 +358,12 @@ func (m *FakeMetadata) GetMetadata(key string) (string, error) {
 		if len(keySplit) == 5 && keySplit[4] == "device-number" {
 			for i, macElem := range m.aws.networkInterfacesMacs {
 				if macParam == macElem {
-					return fmt.Sprintf("%d\n", i), nil
+					n := i
+					if n > 0 {
+						// Introduce an artificial gap, just to test eg: [eth0, eth2]
+						n++
+					}
+					return fmt.Sprintf("%d\n", n), nil
 				}
 			}
 		}


### PR DESCRIPTION
It is common to have "holes" in the network interfaces, eg after
attaching eth1+eth2, and then removing eth1.

Make the sorting code from #80747 robust to this situation, and add a test that exposes the issue in the original code.

Fixes #91888

/kind bug
/sig aws
/sig cloud-provider

**Special notes for your reviewer**:

Theoretically, this is an important bug and should be backported.  Nobody has noticed however, so I think this reinforces my long-standing suspicion that nothing uses addresses other than the first InternalIP and we should just remove the rest from Kubernetes..  I leave the backport/no-backport decision up to somebody else :stuck_out_tongue: 

```release-note
On AWS nodes with multiple network interfaces, kubelet should now more reliably report addresses from secondary interfaces.
```