### PR TITLE
Fix --save-config for kubectl create commands, where it was missing

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create.go
@@ -427,6 +427,9 @@ func (o *CreateSubcommandOptions) Run() error {
 	if err != nil {
 		return err
 	}
+	if err := util.CreateOrUpdateAnnotation(o.CreateAnnotation, obj, scheme.DefaultJSONEncoder()); err != nil {
+		return err
+	}
 	if o.DryRunStrategy != cmdutil.DryRunClient {
 		// create subcommands have compiled knowledge of things they create, so type them directly
 		gvks, _, err := scheme.Scheme.ObjectKinds(obj)
@@ -439,12 +442,7 @@ func (o *CreateSubcommandOptions) Run() error {
 			return err
 		}
 
-		if err := util.CreateOrUpdateAnnotation(o.CreateAnnotation, obj, scheme.DefaultJSONEncoder()); err != nil {
-			return err
-		}
-
 		asUnstructured := &unstructured.Unstructured{}
-
 		if err := scheme.Scheme.Convert(obj, asUnstructured, nil); err != nil {
 			return err
 		}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_clusterrole.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_clusterrole.go
@@ -28,6 +28,8 @@ import (
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	cliflag "k8s.io/component-base/cli/flag"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+	"k8s.io/kubectl/pkg/scheme"
+	"k8s.io/kubectl/pkg/util"
 	"k8s.io/kubectl/pkg/util/i18n"
 	"k8s.io/kubectl/pkg/util/templates"
 )
@@ -199,6 +201,10 @@ func (c *CreateClusterRoleOptions) RunCreateRole() error {
 				},
 			},
 		}
+	}
+
+	if err := util.CreateOrUpdateAnnotation(c.CreateAnnotation, clusterRole, scheme.DefaultJSONEncoder()); err != nil {
+		return err
 	}
 
 	// Create ClusterRole.

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_deployment.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_deployment.go
@@ -33,6 +33,7 @@ import (
 	appsv1client "k8s.io/client-go/kubernetes/typed/apps/v1"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/scheme"
+	"k8s.io/kubectl/pkg/util"
 	"k8s.io/kubectl/pkg/util/i18n"
 	"k8s.io/kubectl/pkg/util/templates"
 )
@@ -69,6 +70,7 @@ type CreateDeploymentOptions struct {
 	Namespace        string
 	EnforceNamespace bool
 	FieldManager     string
+	CreateAnnotation bool
 
 	Client         appsv1client.AppsV1Interface
 	DryRunStrategy cmdutil.DryRunStrategy
@@ -143,6 +145,8 @@ func (o *CreateDeploymentOptions) Complete(f cmdutil.Factory, cmd *cobra.Command
 		return err
 	}
 
+	o.CreateAnnotation = cmdutil.GetFlagBool(cmd, cmdutil.ApplyAnnotationsFlag)
+
 	o.DryRunStrategy, err = cmdutil.GetDryRunStrategy(cmd)
 	if err != nil {
 		return err
@@ -179,6 +183,10 @@ func (o *CreateDeploymentOptions) Validate() error {
 // Run performs the execution of 'create deployment' sub command
 func (o *CreateDeploymentOptions) Run() error {
 	deploy := o.createDeployment()
+
+	if err := util.CreateOrUpdateAnnotation(o.CreateAnnotation, deploy, scheme.DefaultJSONEncoder()); err != nil {
+		return err
+	}
 
 	if o.DryRunStrategy != cmdutil.DryRunClient {
 		createOptions := metav1.CreateOptions{}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
/sig cli
/priority backlog 

**What this PR does / why we need it**:
This fixes `--save-config` flag for the `kubectl create` commands which were missing it.

**Special notes for your reviewer**:
/assign @zhouya0 

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
