### PR TITLE
[WIP]fix: azure CSI driver migration issue in `TranslateInTreePVToCSI` scenario

### DIFF
--- a/staging/src/k8s.io/csi-translation-lib/plugins/azure_disk.go
+++ b/staging/src/k8s.io/csi-translation-lib/plugins/azure_disk.go
@@ -169,8 +169,8 @@ func (t *azureDiskCSITranslator) TranslateInTreePVToCSI(pv *v1.PersistentVolume)
 		csiSource.ReadOnly = *azureSource.ReadOnly
 	}
 
-	pv.Spec.PersistentVolumeSource.AzureDisk = nil
-	pv.Spec.PersistentVolumeSource.CSI = csiSource
+	pv.Spec.AzureDisk = nil
+	pv.Spec.CSI = csiSource
 
 	return pv, nil
 }

--- a/staging/src/k8s.io/csi-translation-lib/plugins/azure_file.go
+++ b/staging/src/k8s.io/csi-translation-lib/plugins/azure_file.go
@@ -142,8 +142,8 @@ func (t *azureFileCSITranslator) TranslateInTreePVToCSI(pv *v1.PersistentVolume)
 		csiSource.NodeStageSecretRef.Namespace = *azureSource.SecretNamespace
 	}
 
-	pv.Spec.PersistentVolumeSource.AzureFile = nil
-	pv.Spec.PersistentVolumeSource.CSI = csiSource
+	pv.Spec.AzureFile = nil
+	pv.Spec.CSI = csiSource
 
 	return pv, nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
fix: azure CSI driver migration issue in `TranslateInTreePVToCSI` scenario

It looks like `pv.Spec.PersistentVolumeSource` is only for in-tree inline volume, is that correct? @davidz627 

I found same issue for GCE driver:
https://github.com/kubernetes/csi-translation-lib/blob/08bf6a63b59d3404fcdcc3733113a4feadc28938/plugins/gce_pd.go#L257-L258

I would say original migration code works, while it does not work in snapshot scenario:
 - user create PV with in-tree driver
 - turn on migration(`CSIMigration=true,CSIMigrationAzureDisk=true`) switch
 - Use CSI snapshot on in-tree PV

Do we support such scenario? @davidz627 
I got following error message when take CSI snapshot on in-tree PV:
```
Events:
  Type     Reason                         Age   From                 Message
  ----     ------                         ----  ----                 -------
  Warning  SnapshotContentCreationFailed  42s   snapshot-controller  Failed to create snapshot content with error cannot find CSI PersistentVolumeSource for volume pvc-33ea6bed-1a15-459d-bf5f-890c3e30f578
```

From this code, we should use this PR fix:
https://github.com/kubernetes-csi/external-snapshotter/blob/034c54581c37049e318fd982db2d3b6c8ea508a1/pkg/common-controller/snapshot_controller.go#L624-L627

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
fix: azure CSI driver migration issue in `TranslateInTreePVToCSI` scenario
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
fix: azure CSI driver migration issue in `TranslateInTreePVToCSI` scenario
```
