### PR TITLE
Use maxSkew in PodTopologySpread scoring as tolerance to skew

### DIFF
--- a/pkg/scheduler/framework/plugins/podtopologyspread/scoring_test.go
+++ b/pkg/scheduler/framework/plugins/podtopologyspread/scoring_test.go
@@ -315,12 +315,11 @@ func TestPodTopologySpreadScore(t *testing.T) {
 			},
 		},
 		{
-			// matching pods spread as 2/1/0/3.
-			// With maxSkew=2, counts change internally to 2/1/1/3.
 			name: "one constraint on node, all 4 nodes are candidates, maxSkew=2",
 			pod: st.MakePod().Name("p").Label("foo", "").
 				SpreadConstraint(2, v1.LabelHostname, v1.ScheduleAnyway, st.MakeLabelSelector().Exists("foo").Obj()).
 				Obj(),
+			// matching pods spread as 2/1/0/3.
 			existingPods: []*v1.Pod{
 				st.MakePod().Name("p-a1").Node("node-a").Label("foo", "").Obj(),
 				st.MakePod().Name("p-a2").Node("node-a").Label("foo", "").Obj(),
@@ -337,20 +336,19 @@ func TestPodTopologySpreadScore(t *testing.T) {
 			},
 			failedNodes: []*v1.Node{},
 			want: []framework.NodeScore{
-				{Name: "node-a", Score: 60},  // +20, compared to maxSkew=1
-				{Name: "node-b", Score: 100}, // +20, compared to maxSkew=1
+				{Name: "node-a", Score: 50}, // +10, compared to maxSkew=1
+				{Name: "node-b", Score: 83}, // +3, compared to maxSkew=1
 				{Name: "node-c", Score: 100},
-				{Name: "node-d", Score: 20}, // +20, compared to maxSkew=1
+				{Name: "node-d", Score: 16}, // +16, compared to maxSkew=1
 			},
 		},
 		{
-			// matching pods spread as 4/3/2/1.
-			// With maxSkew=3, counts change internally to 4/3/2/2.
 			name: "one constraint on node, all 4 nodes are candidates, maxSkew=3",
 			pod: st.MakePod().Name("p").Label("foo", "").
 				SpreadConstraint(3, v1.LabelHostname, v1.ScheduleAnyway, st.MakeLabelSelector().Exists("foo").Obj()).
 				Obj(),
 			existingPods: []*v1.Pod{
+				// matching pods spread as 4/3/2/1.
 				st.MakePod().Name("p-a1").Node("node-a").Label("foo", "").Obj(),
 				st.MakePod().Name("p-a2").Node("node-a").Label("foo", "").Obj(),
 				st.MakePod().Name("p-a3").Node("node-a").Label("foo", "").Obj(),
@@ -370,9 +368,9 @@ func TestPodTopologySpreadScore(t *testing.T) {
 			},
 			failedNodes: []*v1.Node{},
 			want: []framework.NodeScore{
-				{Name: "node-a", Score: 42},  // +28 compared to maxSkew=1
-				{Name: "node-b", Score: 71},  // +29 compared to maxSkew=1
-				{Name: "node-c", Score: 100}, // +29 compared to maxSkew=1
+				{Name: "node-a", Score: 33}, // +19 compared to maxSkew=1
+				{Name: "node-b", Score: 55}, // +13 compared to maxSkew=1
+				{Name: "node-c", Score: 77}, // +6 compared to maxSkew=1
 				{Name: "node-d", Score: 100},
 			},
 		},


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

The approach in #90820 had the downside of giving zero spreading with low number of pods.
In this new approach, maxSkew is interpreted as tolerance for skews. As maxSkew increases, the differentiating between topology domains reduces.

maxSkew=1 preserves its behavior.

**Which issue(s) this PR fixes**:

Ref #91793. This will enable the use of a default for PodTopologySpreading to replace the legacy DefaultPodTopologySpreading plugin.

**Special notes for your reviewer**:

Simulation for deploying 10 pods under different skews and different initial node utilization.

### Scenarios

Numbers are node usage in percentage

```
[[10, 10, 0], [5, 10, 0], [5, 5, 5]]
[[20, 20, 0], [10, 20, 0], [10, 10, 10]]
[[40, 40, 0], [20, 40, 0], [20, 20, 20]]
[[80, 80, 0], [40, 80, 0], [40, 40, 40]]
```

### Results

**node maxSkew=1, zone maxSkew=1**

```
[[1, 1, 2], [1, 1, 1], [1, 1, 1]]
[[1, 1, 2], [1, 1, 1], [1, 1, 1]]
[[1, 1, 2], [1, 1, 1], [1, 1, 1]]
[[1, 1, 2], [1, 0, 2], [1, 1, 1]]
```

**node maxSkew=2, zone maxSkew=4**

```
[[1, 1, 2], [1, 1, 1], [1, 1, 1]]
[[1, 1, 2], [1, 1, 1], [1, 1, 1]]
[[1, 1, 2], [1, 0, 2], [1, 1, 1]]
[[1, 1, 2], [1, 0, 2], [1, 1, 1]]
```

**node maxSkew=3, zone maxSkew=5**

```
[[1, 1, 2], [1, 1, 1], [1, 1, 1]]
[[1, 1, 2], [1, 1, 1], [1, 1, 1]]
[[1, 1, 2], [1, 0, 2], [1, 1, 1]]
[[0, 0, 3], [1, 0, 3], [1, 1, 1]]
```

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```