### PR TITLE
handle empty pod names

### DIFF
--- a/pkg/controller/volume/persistentvolume/pv_controller.go
+++ b/pkg/controller/volume/persistentvolume/pv_controller.go
@@ -303,8 +303,15 @@ func (ctrl *PersistentVolumeController) emitEventForUnboundDelayBindingClaim(cla
 	message := "waiting for first consumer to be created before binding"
 	podNames, err := ctrl.findNonScheduledPodsByPVC(claim)
 	if err != nil {
+		fmt.Errorf("Error finding non scheduled pods by pvc: %v", err)
 		return err
 	}
+
+	if (0 == len(podNames)) {
+		fmt.Errorf("empty pod names finding non scheduled pods by pvc: %v", err)
+		return err
+	}
+
 	if len(podNames) > 0 {
 		reason = events.WaitForPodScheduled
 		if len(podNames) > 1 {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
handle empty pod names.

```release-note
   handle empty pod names.
```
