### PR TITLE
fix: leaderelection graceful release doesn't work

### DIFF
--- a/staging/src/k8s.io/client-go/tools/leaderelection/leaderelection.go
+++ b/staging/src/k8s.io/client-go/tools/leaderelection/leaderelection.go
@@ -291,7 +291,8 @@ func (le *LeaderElector) release() bool {
 		return true
 	}
 	leaderElectionRecord := rl.LeaderElectionRecord{
-		LeaderTransitions: le.observedRecord.LeaderTransitions,
+		LeaderTransitions:    le.observedRecord.LeaderTransitions,
+		LeaseDurationSeconds: le.observedRecord.LeaseDurationSeconds,
 	}
 	if err := le.config.Lock.Update(context.TODO(), leaderElectionRecord); err != nil {
 		klog.Errorf("Failed to release lock: %v", err)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
 LeaseLocks are not being released properly due to incorrect construction of LeaderElectionRecords.

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes/client-go/issues/762
Fixes https://github.com/kubernetes/kubernetes/issues/88194

**Special notes for your reviewer**:
Previous MR/Discussions:
https://github.com/kubernetes/kubernetes/pull/88925
https://github.com/kubernetes/kubernetes/pull/88192

Both waiting for tests for several months.

One of the issues with writing a test for it was that fake client doesn't execute following validation (https://github.com/kubernetes/kubernetes/blob/4cc44fbef626e87e59f7e9e7bd0bf9ec447a3c39/pkg/apis/coordination/validation/validation.go#L43)
so I had to fake it in reactor. Not ideal but I have no idea how to improve it. 

**Does this PR introduce a user-facing change?**:
No

```release-note
NONE
```
