### PR TITLE
Automated cherry pick of #91690: fieldManager: Ignore and log all errors when updating

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/create.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/create.go
@@ -153,11 +153,7 @@ func createHandler(r rest.NamedCreater, scope *RequestScope, admit admission.Int
 				return
 			}
 
-			obj, err = scope.FieldManager.Update(liveObj, obj, managerOrUserAgent(options.FieldManager, req.UserAgent()))
-			if err != nil {
-				scope.err(fmt.Errorf("failed to update object (Create for %v) managed fields: %v", scope.Kind, err), w, req)
-				return
-			}
+			obj = scope.FieldManager.UpdateNoErrors(liveObj, obj, managerOrUserAgent(options.FieldManager, req.UserAgent()))
 		}
 
 		trace.Step("About to store object in database")

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/internal/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/internal/BUILD
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "go_default_library",
     srcs = [
+        "atmostevery.go",
         "conflict.go",
         "fields.go",
         "gvkparser.go",
@@ -34,6 +35,7 @@ go_library(
 go_test(
     name = "go_default_test",
     srcs = [
+        "atmostevery_test.go",
         "conflict_test.go",
         "fields_test.go",
         "managedfields_test.go",

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/internal/atmostevery.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/internal/atmostevery.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package internal
+
+import (
+	"sync"
+	"time"
+)
+
+// AtMostEvery will never run the method more than once every specified
+// duration.
+type AtMostEvery struct {
+	delay    time.Duration
+	lastCall time.Time
+	mutex    sync.Mutex
+}
+
+// NewAtMostEvery creates a new AtMostEvery, that will run the method at
+// most every given duration.
+func NewAtMostEvery(delay time.Duration) *AtMostEvery {
+	return &AtMostEvery{
+		delay: delay,
+	}
+}
+
+// updateLastCall returns true if the lastCall time has been updated,
+// false if it was too early.
+func (s *AtMostEvery) updateLastCall() bool {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	if time.Since(s.lastCall) < s.delay {
+		return false
+	}
+	s.lastCall = time.Now()
+	return true
+}
+
+// Do will run the method if enough time has passed, and return true.
+// Otherwise, it does nothing and returns false.
+func (s *AtMostEvery) Do(fn func()) bool {
+	if !s.updateLastCall() {
+		return false
+	}
+	fn()
+	return true
+}

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/internal/atmostevery_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/internal/atmostevery_test.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package internal_test
+
+import (
+	"testing"
+	"time"
+
+	"k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/internal"
+)
+
+func TestAtMostEvery(t *testing.T) {
+	duration := time.Second
+	delay := 179 * time.Millisecond
+	atMostEvery := internal.NewAtMostEvery(delay)
+	count := 0
+	exit := time.NewTicker(duration)
+	tick := time.NewTicker(2 * time.Millisecond)
+	defer exit.Stop()
+	defer tick.Stop()
+
+	done := false
+	for !done {
+		select {
+		case <-exit.C:
+			done = true
+		case <-tick.C:
+			atMostEvery.Do(func() {
+				count++
+			})
+		}
+	}
+
+	if expected := int(duration/delay) + 1; count != expected {
+		t.Fatalf("Function called %d times, should have been called exactly %d times", count, expected)
+	}
+}

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/internal/managedfields.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/internal/managedfields.go
@@ -34,6 +34,14 @@ type Managed struct {
 	Times  map[string]*metav1.Time
 }
 
+// NewEmptyManaged creates an empty ManagedInterface.
+func NewEmptyManaged() Managed {
+	return Managed{
+		fieldpath.ManagedFields{},
+		map[string]*metav1.Time{},
+	}
+}
+
 // RemoveObjectManagedFields removes the ManagedFields from the object
 // before we merge so that it doesn't appear in the ManagedFields
 // recursively.

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/patch.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/patch.go
@@ -321,9 +321,7 @@ func (p *jsonPatcher) applyPatchToCurrentObject(currentObject runtime.Object) (r
 	}
 
 	if p.fieldManager != nil {
-		if objToUpdate, err = p.fieldManager.Update(currentObject, objToUpdate, managerOrUserAgent(p.options.FieldManager, p.userAgent)); err != nil {
-			return nil, fmt.Errorf("failed to update object (json PATCH for %v) managed fields: %v", p.kind, err)
-		}
+		objToUpdate = p.fieldManager.UpdateNoErrors(currentObject, objToUpdate, managerOrUserAgent(p.options.FieldManager, p.userAgent))
 	}
 	return objToUpdate, nil
 }
@@ -406,9 +404,7 @@ func (p *smpPatcher) applyPatchToCurrentObject(currentObject runtime.Object) (ru
 	}
 
 	if p.fieldManager != nil {
-		if newObj, err = p.fieldManager.Update(currentObject, newObj, managerOrUserAgent(p.options.FieldManager, p.userAgent)); err != nil {
-			return nil, fmt.Errorf("failed to update object (smp PATCH for %v) managed fields: %v", p.kind, err)
-		}
+		newObj = p.fieldManager.UpdateNoErrors(currentObject, newObj, managerOrUserAgent(p.options.FieldManager, p.userAgent))
 	}
 	return newObj, nil
 }

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/update.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/update.go
@@ -126,11 +126,7 @@ func UpdateResource(r rest.Updater, scope *RequestScope, admit admission.Interfa
 		transformers := []rest.TransformFunc{}
 		if scope.FieldManager != nil {
 			transformers = append(transformers, func(_ context.Context, newObj, liveObj runtime.Object) (runtime.Object, error) {
-				obj, err := scope.FieldManager.Update(liveObj, newObj, managerOrUserAgent(options.FieldManager, req.UserAgent()))
-				if err != nil {
-					return nil, fmt.Errorf("failed to update object (Update for %v) managed fields: %v", scope.Kind, err)
-				}
-				return obj, nil
+				return scope.FieldManager.UpdateNoErrors(liveObj, newObj, managerOrUserAgent(options.FieldManager, req.UserAgent())), nil
 			})
 		}
 		if mutatingAdmission, ok := admit.(admission.MutationInterface); ok {

--- a/test/integration/apiserver/apply/apply_test.go
+++ b/test/integration/apiserver/apply/apply_test.go
@@ -1271,6 +1271,162 @@ func TestClearManagedFieldsWithUpdate(t *testing.T) {
 	}
 }
 
+// TestErrorsDontFail
+func TestErrorsDontFail(t *testing.T) {
+	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, genericfeatures.ServerSideApply, true)()
+
+	_, client, closeFn := setup(t)
+	defer closeFn()
+
+	// Tries to create with a managed fields that has an empty `fieldsType`.
+	_, err := client.CoreV1().RESTClient().Post().
+		Namespace("default").
+		Resource("configmaps").
+		Param("fieldManager", "apply_test").
+		Body([]byte(`{
+			"apiVersion": "v1",
+			"kind": "ConfigMap",
+			"metadata": {
+				"name": "test-cm",
+				"namespace": "default",
+				"managedFields": [{
+					"manager": "apply_test",
+					"operation": "Apply",
+					"apiVersion": "v1",
+					"time": "2019-07-08T09:31:18Z",
+					"fieldsType": "",
+					"fieldsV1": {}
+				}],
+				"labels": {
+					"test-label": "test"
+				}
+			},
+			"data": {
+				"key": "value"
+			}
+		}`)).
+		Do().
+		Get()
+	if err != nil {
+		t.Fatalf("Failed to create object with empty fieldsType: %v", err)
+	}
+}
+
+func TestErrorsDontFailUpdate(t *testing.T) {
+	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, genericfeatures.ServerSideApply, true)()
+
+	_, client, closeFn := setup(t)
+	defer closeFn()
+
+	_, err := client.CoreV1().RESTClient().Post().
+		Namespace("default").
+		Resource("configmaps").
+		Param("fieldManager", "apply_test").
+		Body([]byte(`{
+			"apiVersion": "v1",
+			"kind": "ConfigMap",
+			"metadata": {
+				"name": "test-cm",
+				"namespace": "default",
+				"labels": {
+					"test-label": "test"
+				}
+			},
+			"data": {
+				"key": "value"
+			}
+		}`)).
+		Do().
+		Get()
+	if err != nil {
+		t.Fatalf("Failed to create object: %v", err)
+	}
+
+	_, err = client.CoreV1().RESTClient().Put().
+		Namespace("default").
+		Resource("configmaps").
+		Name("test-cm").
+		Param("fieldManager", "apply_test").
+		Body([]byte(`{
+			"apiVersion": "v1",
+			"kind": "ConfigMap",
+			"metadata": {
+				"name": "test-cm",
+				"namespace": "default",
+				"managedFields": [{
+					"manager": "apply_test",
+					"operation": "Apply",
+					"apiVersion": "v1",
+					"time": "2019-07-08T09:31:18Z",
+					"fieldsType": "",
+					"fieldsV1": {}
+				}],
+				"labels": {
+					"test-label": "test"
+				}
+			},
+			"data": {
+				"key": "value"
+			}
+		}`)).
+		Do().
+		Get()
+	if err != nil {
+		t.Fatalf("Failed to update object with empty fieldsType: %v", err)
+	}
+}
+
+func TestErrorsDontFailPatch(t *testing.T) {
+	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, genericfeatures.ServerSideApply, true)()
+
+	_, client, closeFn := setup(t)
+	defer closeFn()
+
+	_, err := client.CoreV1().RESTClient().Post().
+		Namespace("default").
+		Resource("configmaps").
+		Param("fieldManager", "apply_test").
+		Body([]byte(`{
+			"apiVersion": "v1",
+			"kind": "ConfigMap",
+			"metadata": {
+				"name": "test-cm",
+				"namespace": "default",
+				"labels": {
+					"test-label": "test"
+				}
+			},
+			"data": {
+				"key": "value"
+			}
+		}`)).
+		Do().
+		Get()
+	if err != nil {
+		t.Fatalf("Failed to create object: %v", err)
+	}
+
+	_, err = client.CoreV1().RESTClient().Patch(types.JSONPatchType).
+		Namespace("default").
+		Resource("configmaps").
+		Name("test-cm").
+		Param("fieldManager", "apply_test").
+		Body([]byte(`[{"op": "replace", "path": "/metadata/managedFields", "value": [{
+			"manager": "apply_test",
+			"operation": "Apply",
+			"apiVersion": "v1",
+			"time": "2019-07-08T09:31:18Z",
+			"fieldsType": "",
+			"fieldsV1": {}
+		}]}]`)).
+		Do().
+		Get()
+	if err != nil {
+		t.Fatalf("Failed to patch object with empty FieldsType: %v", err)
+	}
+
+}
+
 var podBytes = []byte(`
 apiVersion: v1
 kind: Pod


### PR DESCRIPTION
Cherry pick of #91690 on release-1.16.

#91690: fieldManager: Ignore and log all errors when updating

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```
Resolve regression in metadata.managedFields handling in create/update/patch requests not using server-side apply
```