### PR TITLE
Automated cherry pick of #91298: skip unnecessary scheduling attempt when pod's finalizers

### DIFF
--- a/pkg/scheduler/eventhandlers.go
+++ b/pkg/scheduler/eventhandlers.go
@@ -286,8 +286,8 @@ func responsibleForPod(pod *v1.Pod, schedulerName string) bool {
 // skipPodUpdate checks whether the specified pod update should be ignored.
 // This function will return true if
 //   - The pod has already been assumed, AND
-//   - The pod has only its ResourceVersion, Spec.NodeName, Annotations, ManagedFields and/or Finalizers
-//     updated.
+//   - The pod has only its ResourceVersion, Spec.NodeName, Annotations,
+//     ManagedFields, Finalizers and/or Conditions updated.
 func (sched *Scheduler) skipPodUpdate(pod *v1.Pod) bool {
 	// Non-assumed pods should never be skipped.
 	isAssumed, err := sched.SchedulerCache.IsAssumedPod(pod)
@@ -320,8 +320,10 @@ func (sched *Scheduler) skipPodUpdate(pod *v1.Pod) bool {
 		// Annotations must be excluded for the reasons described in
 		// https://github.com/kubernetes/kubernetes/issues/52914.
 		p.Annotations = nil
-		// Finalizers must be excluded because scheduled result can not be affected
+		// The following might be changed by external controllers, but they don't
+		// affect scheduling decisions.
 		p.Finalizers = nil
+		p.Status.Conditions = nil
 		return p
 	}
 	assumedPodCopy, podCopy := f(assumedPod), f(pod)

--- a/pkg/scheduler/eventhandlers.go
+++ b/pkg/scheduler/eventhandlers.go
@@ -286,7 +286,7 @@ func responsibleForPod(pod *v1.Pod, schedulerName string) bool {
 // skipPodUpdate checks whether the specified pod update should be ignored.
 // This function will return true if
 //   - The pod has already been assumed, AND
-//   - The pod has only its ResourceVersion, Spec.NodeName and/or Annotations
+//   - The pod has only its ResourceVersion, Spec.NodeName, Annotations, ManagedFields and/or Finalizers
 //     updated.
 func (sched *Scheduler) skipPodUpdate(pod *v1.Pod) bool {
 	// Non-assumed pods should never be skipped.
@@ -320,6 +320,8 @@ func (sched *Scheduler) skipPodUpdate(pod *v1.Pod) bool {
 		// Annotations must be excluded for the reasons described in
 		// https://github.com/kubernetes/kubernetes/issues/52914.
 		p.Annotations = nil
+		// Finalizers must be excluded because scheduled result can not be affected
+		p.Finalizers = nil
 		return p
 	}
 	assumedPodCopy, podCopy := f(assumedPod), f(pod)

--- a/pkg/scheduler/eventhandlers_test.go
+++ b/pkg/scheduler/eventhandlers_test.go
@@ -102,6 +102,27 @@ func TestSkipPodUpdate(t *testing.T) {
 			},
 			expected: false,
 		},
+		{
+			name: "with changes on Finalizers",
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "pod-0",
+					Finalizers: []string{"a", "b"},
+				},
+			},
+			isAssumedPodFunc: func(*v1.Pod) bool {
+				return true
+			},
+			getPodFunc: func(*v1.Pod) *v1.Pod {
+				return &v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       "pod-0",
+						Finalizers: []string{"c", "d"},
+					},
+				}
+			},
+			expected: true,
+		},
 	}
 	for _, test := range table {
 		t.Run(test.name, func(t *testing.T) {

--- a/pkg/scheduler/eventhandlers_test.go
+++ b/pkg/scheduler/eventhandlers_test.go
@@ -123,6 +123,30 @@ func TestSkipPodUpdate(t *testing.T) {
 			},
 			expected: true,
 		},
+		{
+			name: "with changes on Conditions",
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "pod-0",
+				},
+				Status: v1.PodStatus{
+					Conditions: []v1.PodCondition{
+						{Type: "foo"},
+					},
+				},
+			},
+			isAssumedPodFunc: func(*v1.Pod) bool {
+				return true
+			},
+			getPodFunc: func(*v1.Pod) *v1.Pod {
+				return &v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pod-0",
+					},
+				}
+			},
+			expected: true,
+		},
 	}
 	for _, test := range table {
 		t.Run(test.name, func(t *testing.T) {


### PR DESCRIPTION
Cherry pick of #91298 on release-1.17.

#91298: skip unnecessary scheduling attempt when pod's finalizers

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

/priority important-soon
/kind bug
/sig scheduling

**Release note**

```release-note
Pod Finalizers and Conditions updates are skipped for re-scheduling attempts
```