### PR TITLE
Update doc for kustomize generators

### DIFF
--- a/staging/src/k8s.io/kubectl/docs/book/pages/reference/kustomize.md
+++ b/staging/src/k8s.io/kubectl/docs/book/pages/reference/kustomize.md
@@ -98,8 +98,8 @@ as well as `namePrefix`'s and `nameSuffix`'s.
 | Name          | Type      | Desc                                |
 | :------------ | :-------- | :---------------------------------- |
 | **behavior**  | string    | Merge behavior when the ConfigMap generator is defined in a base.  May be one of `create`, `replace`, `merge`. |
-| **env**       | string    | Single file to generate ConfigMap data entries from.  Should be a path to a local *env* file, e.g. `path/to/file.env`, where each line of the file is a `key=value` pair.  *Each line* will appear as an entry in the ConfigMap data field. |
-| **files**     | []string  | List of files to generate ConfigMap data entries from. Each item should be a path to a local file, e.g. `path/to/file.config`, and the filename will appear as an entry in the ConfigMap data field with its contents as a value.  |
+| **envs**      | []string  | List of files to generate ConfigMap data entries from. Each item should be a path to a local *env* file, e.g. `path/to/file.env`, where each line of the file is a `key=value` pair.  *Each line* will appear as an entry in the ConfigMap data field. |
+| **files**     | []string  | List of files to generate ConfigMap data entries from. Each item should be a path to a local file or a `name=path` pair, e.g. `path/to/file.config` or `name=path/to/file.config`. If the `name=` is not presented, the filename will appear as an entry in the ConfigMap data field with its contents as a value. Otherwise the `name` specified before `=` will be used as the key in entry. |
 | **literals**  | []string  | List of literal ConfigMap data entries. Each item should be a key and literal value, e.g. `somekey=somevalue`, and the key/value will appear as an entry in the ConfigMap data field.|
 | **name**      | string    | Name for the ConfigMap.  Modified by the `namePrefix` and `nameSuffix` fields. |
 | **namespace** | string    | Namespace for the ConfigMap.  Overridden by kustomize-wide `namespace` field.|
@@ -112,11 +112,11 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 configMapGenerator:
 # generate a ConfigMap named my-java-server-props-<some-hash> where each file
-# in the list appears as a data entry (keyed by base filename).
+# in the list appears as a data entry (keyed by base filename or explicitly specified name).
 - name: my-java-server-props
   files:
   - application.properties
-  - more.properties
+  - extra.properties=more.properties
 # generate a ConfigMap named my-java-server-env-vars-<some-hash> where each literal
 # in the list appears as a data entry (keyed by literal key).
 - name: my-java-server-env-vars
@@ -126,7 +126,8 @@ configMapGenerator:
 # generate a ConfigMap named my-system-env-<some-hash> where each key/value pair in the
 # env.txt appears as a data entry (separated by \n).
 - name: my-system-env
-  env: env.txt
+  envs:
+  - env.txt
 ```
 
 {% endmethod %}
@@ -186,8 +187,8 @@ as well as `namePrefix`'s and `nameSuffix`'s.
 | Name          | Type    | Desc                                |
 | :------------ | :------ | :---------------------------------- |
 | **behavior**  | string  | Merge behavior when the Secret generator is defined in a base.  May be one of `create`, `replace`, `merge`. |
-| **env**       | string  | Single file to generate Secret data entries from.  Should be a path to a local *env* file, e.g. `path/to/file.env`, where each line of the file is a `key=value` pair.  *Each line* will appear as an entry in the Secret data field. |
-| **files**     | []string  | List of files to generate Secret data entries from. Each item should be a path to a local file, e.g. `path/to/file.config`, and the filename will appear as an entry in the ConfigMap data field with its contents as a value.  |
+| **envs**      | []string  | List of files to generate Secret data entries from. Each item should be a path to a local *env* file, e.g. `path/to/file.env`, where each line of the file is a `key=value` pair.  *Each line* will appear as an entry in the Secret data field. |
+| **files**     | []string  | List of files to generate Secret data entries from. Each item should be a path to a local file or a `name=path` pair, e.g. `path/to/file.config` or `name=path/to/file.config`. If the `name=` is not presented, the filename will appear as an entry in the Secret data field with its contents as a value. Otherwise the `name` specified before `=` will be used as the key in entry.  |
 | **literals**  | []string  | List of literal Secret data entries. Each item should be a key and literal value, e.g. `somekey=somevalue`, and the key/value will appear as an entry in the Secret data field.|
 | **name**      | string  | Name for the Secret.  Modified by the `namePrefix` and `nameSuffix` fields. |
 | **namespace** | string  | Namespace for the Secret.  Overridden by kustomize-wide `namespace` field.|
@@ -202,13 +203,13 @@ secretGenerator:
   # generate a tls Secret
 - name: app-tls
   files:
-    - secret/tls.cert
+    - secret/tls.crt=secret/tls.cert
     - secret/tls.key
   type: "kubernetes.io/tls"
 - name: env_file_secret
-  # env is a path to a file to read lines of key=val
-  # you can only specify one env file per secret.
-  env: env.txt
+  # envs is a list of pathes to files to read lines of key=val
+  envs:
+    - env.txt
   type: Opaque
 ```
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:

Currently the doc in kubectl is using `env` in configMapGenerator. But `env` has been deprecated and `envs` should be used.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubectl/issues/877

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
