### PR TITLE
Preserves leaseDuration in leaderelection

### DIFF
--- a/staging/src/k8s.io/client-go/tools/leaderelection/leaderelection.go
+++ b/staging/src/k8s.io/client-go/tools/leaderelection/leaderelection.go
@@ -291,7 +291,8 @@ func (le *LeaderElector) release() bool {
 		return true
 	}
 	leaderElectionRecord := rl.LeaderElectionRecord{
-		LeaderTransitions: le.observedRecord.LeaderTransitions,
+		LeaderTransitions:    le.observedRecord.LeaderTransitions,
+		LeaseDurationSeconds: int(le.config.LeaseDuration.Seconds()),
 	}
 	if err := le.config.Lock.Update(context.TODO(), leaderElectionRecord); err != nil {
 		klog.Errorf("Failed to release lock: %v", err)

--- a/staging/src/k8s.io/client-go/tools/leaderelection/leaderelection.go
+++ b/staging/src/k8s.io/client-go/tools/leaderelection/leaderelection.go
@@ -292,7 +292,7 @@ func (le *LeaderElector) release() bool {
 	}
 	leaderElectionRecord := rl.LeaderElectionRecord{
 		LeaderTransitions:    le.observedRecord.LeaderTransitions,
-		LeaseDurationSeconds: int(le.config.LeaseDuration.Seconds()),
+		LeaseDurationSeconds: int(le.config.LeaseDuration / time.Second),
 	}
 	if err := le.config.Lock.Update(context.TODO(), leaderElectionRecord); err != nil {
 		klog.Errorf("Failed to release lock: %v", err)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug


**What this PR does / why we need it**:

This PR targets client-go's leaderelection package. It allows a lease to be successfully released when ctx is cancelled by preserving the leaseDuration config value in `func (le *LeaderElector) release()`.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

No issue submitted yet. But I started one below

**What happened:**

Currently in client-go’s tools/leaderelection/leaderelection.go (http://k8s.io/client-go@v0.18.3/tools/leaderelection/leaderelection.go), the release() function does not preserve the leaseDurationSeconds when creating a new LeaderElectionRecord
```
func (le *LeaderElector) release() bool {
    if !le.IsLeader() {
        return true
    }
    leaderElectionRecord := rl.LeaderElectionRecord{
        LeaderTransitions: le.observedRecord.LeaderTransitions,
    }
    
    if err := le.config.Lock.Update(context.TODO(), leaderElectionRecord); err != nil {
        klog.Errorf("Failed to release lock: %v", err)
        return false
    }
```
This results in the following error when Lock.Update() is called

```
Failed to release lock: Lease.coordination.k8s.io "example" is invalid: spec.leaseDurationSeconds: Invalid value: 0: must be greater than 0
```
**What you expected to happen:**

Error should not occur and release() should release the lease successfully.

**How to reproduce it (as minimally and precisely as possible):**

* Ran leader election example found at https://github.com/kubernetes/client-go/tree/master/examples/leader-election

* Issued a SIGTERM (by ctrl-c) to id=1 process. Observed the following error `Failed to release lock: Lease.coordination.k8s.io "example" is invalid: spec.leaseDurationSeconds: Invalid value: 0: must be greater than 0`

![image](https://user-images.githubusercontent.com/11370398/84204825-c3fde480-aa60-11ea-89a9-64dda3435c60.png)


Observed that lease was acquired by id=2 process but only after the leaseDuration expired (i.e. 60s)
![image](https://user-images.githubusercontent.com/11370398/84204848-ca8c5c00-aa60-11ea-8774-aa19a7c7d815.png)


**Anything else we need to know?**:

**Environment**:

minkube v1.9.2
macOS Mojave 10.14.6
go 1.14.3

- Kubernetes version (use `kubectl version`): v1.18.0
- Cloud provider or hardware configuration:
- OS (e.g: `cat /etc/os-release`):
- Kernel (e.g. `uname -a`): Darwin Kernel Version 18.7.0
- Install tools:
- Network plugin and version (if this is a network-related bug):
- Others:


**Special notes for your reviewer**:
* I feel like it might be useful to have an explicit test on the lock release behavior and would welcome feedback on how to best implement if that's needed.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
