### PR TITLE
fix linter issues for kubelet/cri/remote and ri-api/pkg/apis/testing

### DIFF
--- a/hack/.golint_failures
+++ b/hack/.golint_failures
@@ -99,7 +99,6 @@ pkg/kubelet/apis/config/v1beta1
 pkg/kubelet/cm
 pkg/kubelet/container
 pkg/kubelet/container/testing
-pkg/kubelet/cri/remote
 pkg/kubelet/dockershim/libdocker
 pkg/kubelet/dockershim/network
 pkg/kubelet/dockershim/network/cni/testing
@@ -437,7 +436,6 @@ staging/src/k8s.io/component-base/cli/flag
 staging/src/k8s.io/component-base/config/v1alpha1
 staging/src/k8s.io/component-base/featuregate
 staging/src/k8s.io/component-base/version/verflag
-staging/src/k8s.io/cri-api/pkg/apis/testing
 staging/src/k8s.io/kube-aggregator/pkg/apis/apiregistration/v1
 staging/src/k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1
 staging/src/k8s.io/kube-aggregator/pkg/apiserver

--- a/pkg/kubelet/cri/remote/remote_image.go
+++ b/pkg/kubelet/cri/remote/remote_image.go
@@ -30,8 +30,8 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/cri/remote/util"
 )
 
-// RemoteImageService is a gRPC implementation of internalapi.ImageManagerService.
-type RemoteImageService struct {
+// remoteImageService is a gRPC implementation of internalapi.ImageManagerService.
+type remoteImageService struct {
 	timeout     time.Duration
 	imageClient runtimeapi.ImageServiceClient
 }
@@ -53,14 +53,14 @@ func NewRemoteImageService(endpoint string, connectionTimeout time.Duration) (in
 		return nil, err
 	}
 
-	return &RemoteImageService{
+	return &remoteImageService{
 		timeout:     connectionTimeout,
 		imageClient: runtimeapi.NewImageServiceClient(conn),
 	}, nil
 }
 
 // ListImages lists available images.
-func (r *RemoteImageService) ListImages(filter *runtimeapi.ImageFilter) ([]*runtimeapi.Image, error) {
+func (r *remoteImageService) ListImages(filter *runtimeapi.ImageFilter) ([]*runtimeapi.Image, error) {
 	ctx, cancel := getContextWithTimeout(r.timeout)
 	defer cancel()
 
@@ -76,7 +76,7 @@ func (r *RemoteImageService) ListImages(filter *runtimeapi.ImageFilter) ([]*runt
 }
 
 // ImageStatus returns the status of the image.
-func (r *RemoteImageService) ImageStatus(image *runtimeapi.ImageSpec) (*runtimeapi.Image, error) {
+func (r *remoteImageService) ImageStatus(image *runtimeapi.ImageSpec) (*runtimeapi.Image, error) {
 	ctx, cancel := getContextWithTimeout(r.timeout)
 	defer cancel()
 
@@ -100,7 +100,7 @@ func (r *RemoteImageService) ImageStatus(image *runtimeapi.ImageSpec) (*runtimea
 }
 
 // PullImage pulls an image with authentication config.
-func (r *RemoteImageService) PullImage(image *runtimeapi.ImageSpec, auth *runtimeapi.AuthConfig, podSandboxConfig *runtimeapi.PodSandboxConfig) (string, error) {
+func (r *remoteImageService) PullImage(image *runtimeapi.ImageSpec, auth *runtimeapi.AuthConfig, podSandboxConfig *runtimeapi.PodSandboxConfig) (string, error) {
 	ctx, cancel := getContextWithCancel()
 	defer cancel()
 
@@ -124,7 +124,7 @@ func (r *RemoteImageService) PullImage(image *runtimeapi.ImageSpec, auth *runtim
 }
 
 // RemoveImage removes the image.
-func (r *RemoteImageService) RemoveImage(image *runtimeapi.ImageSpec) error {
+func (r *remoteImageService) RemoveImage(image *runtimeapi.ImageSpec) error {
 	ctx, cancel := getContextWithTimeout(r.timeout)
 	defer cancel()
 
@@ -140,7 +140,7 @@ func (r *RemoteImageService) RemoveImage(image *runtimeapi.ImageSpec) error {
 }
 
 // ImageFsInfo returns information of the filesystem that is used to store images.
-func (r *RemoteImageService) ImageFsInfo() ([]*runtimeapi.FilesystemUsage, error) {
+func (r *remoteImageService) ImageFsInfo() ([]*runtimeapi.FilesystemUsage, error) {
 	// Do not set timeout, because `ImageFsInfo` takes time.
 	// TODO(random-liu): Should we assume runtime should cache the result, and set timeout here?
 	ctx, cancel := getContextWithCancel()

--- a/staging/src/k8s.io/cri-api/pkg/apis/testing/fake_image_service.go
+++ b/staging/src/k8s.io/cri-api/pkg/apis/testing/fake_image_service.go
@@ -25,6 +25,7 @@ import (
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 )
 
+// FakeImageService fakes the image service.
 type FakeImageService struct {
 	sync.Mutex
 
@@ -38,6 +39,7 @@ type FakeImageService struct {
 	FakeFilesystemUsage []*runtimeapi.FilesystemUsage
 }
 
+// SetFakeImages sets the list of fake images for the FakeImageService.
 func (r *FakeImageService) SetFakeImages(images []string) {
 	r.Lock()
 	defer r.Unlock()
@@ -51,6 +53,7 @@ func (r *FakeImageService) SetFakeImages(images []string) {
 	}
 }
 
+// SetFakeImagesWithAnnotations sets the list of fake images for the FakeImageService with annotations.
 func (r *FakeImageService) SetFakeImagesWithAnnotations(imageSpecs []*runtimeapi.ImageSpec) {
 	r.Lock()
 	defer r.Unlock()
@@ -61,6 +64,7 @@ func (r *FakeImageService) SetFakeImagesWithAnnotations(imageSpecs []*runtimeapi
 	}
 }
 
+// SetFakeImageSize sets the image size for the FakeImageService.
 func (r *FakeImageService) SetFakeImageSize(size uint64) {
 	r.Lock()
 	defer r.Unlock()
@@ -68,6 +72,7 @@ func (r *FakeImageService) SetFakeImageSize(size uint64) {
 	r.FakeImageSize = size
 }
 
+// SetFakeFilesystemUsage sets the FilesystemUsage for FakeImageService.
 func (r *FakeImageService) SetFakeFilesystemUsage(usage []*runtimeapi.FilesystemUsage) {
 	r.Lock()
 	defer r.Unlock()
@@ -75,6 +80,7 @@ func (r *FakeImageService) SetFakeFilesystemUsage(usage []*runtimeapi.Filesystem
 	r.FakeFilesystemUsage = usage
 }
 
+// NewFakeImageService creates a new FakeImageService.
 func NewFakeImageService() *FakeImageService {
 	return &FakeImageService{
 		Called: make([]string, 0),
@@ -103,6 +109,7 @@ func stringInSlice(s string, list []string) bool {
 	return false
 }
 
+// InjectError sets the error message for the FakeImageService.
 func (r *FakeImageService) InjectError(f string, err error) {
 	r.Lock()
 	defer r.Unlock()
@@ -123,6 +130,7 @@ func (r *FakeImageService) popError(f string) error {
 	return err
 }
 
+// ListImages returns the list of images from FakeImageService or error if it was previously set.
 func (r *FakeImageService) ListImages(filter *runtimeapi.ImageFilter) ([]*runtimeapi.Image, error) {
 	r.Lock()
 	defer r.Unlock()
@@ -145,6 +153,7 @@ func (r *FakeImageService) ListImages(filter *runtimeapi.ImageFilter) ([]*runtim
 	return images, nil
 }
 
+// ImageStatus returns the status of the image from the FakeImageService.
 func (r *FakeImageService) ImageStatus(image *runtimeapi.ImageSpec) (*runtimeapi.Image, error) {
 	r.Lock()
 	defer r.Unlock()
@@ -157,6 +166,7 @@ func (r *FakeImageService) ImageStatus(image *runtimeapi.ImageSpec) (*runtimeapi
 	return r.Images[image.Image], nil
 }
 
+// PullImage emulate pulling the image from the FakeImageService.
 func (r *FakeImageService) PullImage(image *runtimeapi.ImageSpec, auth *runtimeapi.AuthConfig, podSandboxConfig *runtimeapi.PodSandboxConfig) (string, error) {
 	r.Lock()
 	defer r.Unlock()
@@ -177,6 +187,7 @@ func (r *FakeImageService) PullImage(image *runtimeapi.ImageSpec, auth *runtimea
 	return imageID, nil
 }
 
+// RemoveImage removes image from the FakeImageService.
 func (r *FakeImageService) RemoveImage(image *runtimeapi.ImageSpec) error {
 	r.Lock()
 	defer r.Unlock()
@@ -205,6 +216,7 @@ func (r *FakeImageService) ImageFsInfo() ([]*runtimeapi.FilesystemUsage, error) 
 	return r.FakeFilesystemUsage, nil
 }
 
+// AssertImagePulledWithAuth validates whether the image was pulled with auth and asserts if it wasn't.
 func (r *FakeImageService) AssertImagePulledWithAuth(t *testing.T, image *runtimeapi.ImageSpec, auth *runtimeapi.AuthConfig, failMsg string) {
 	r.Lock()
 	defer r.Unlock()

--- a/staging/src/k8s.io/cri-api/pkg/apis/testing/fake_runtime_service.go
+++ b/staging/src/k8s.io/cri-api/pkg/apis/testing/fake_runtime_service.go
@@ -26,12 +26,17 @@ import (
 )
 
 var (
+	// FakeVersion is a version of a fake runtime.
 	FakeVersion = "0.1.0"
 
-	FakeRuntimeName   = "fakeRuntime"
+	// FakeRuntimeName is the name of the fake runtime.
+	FakeRuntimeName = "fakeRuntime"
+
+	// FakePodSandboxIPs is an IP address of the fake runtime.
 	FakePodSandboxIPs = []string{"192.168.192.168"}
 )
 
+// FakePodSandbox is the fake implementation of runtimeapi.PodSandboxStatus.
 type FakePodSandbox struct {
 	// PodSandboxStatus contains the runtime information for a sandbox.
 	runtimeapi.PodSandboxStatus
@@ -39,6 +44,7 @@ type FakePodSandbox struct {
 	RuntimeHandler string
 }
 
+// FakeContainer is a fake container.
 type FakeContainer struct {
 	// ContainerStatus contains the runtime information for a container.
 	runtimeapi.ContainerStatus
@@ -50,6 +56,7 @@ type FakeContainer struct {
 	SandboxID string
 }
 
+// FakeRuntimeService is a fake runetime service.
 type FakeRuntimeService struct {
 	sync.Mutex
 
@@ -62,6 +69,7 @@ type FakeRuntimeService struct {
 	FakeContainerStats map[string]*runtimeapi.ContainerStats
 }
 
+// GetContainerID returns the unique container ID from the FakeRuntimeService.
 func (r *FakeRuntimeService) GetContainerID(sandboxID, name string, attempt uint32) (string, error) {
 	r.Lock()
 	defer r.Unlock()
@@ -74,6 +82,7 @@ func (r *FakeRuntimeService) GetContainerID(sandboxID, name string, attempt uint
 	return "", fmt.Errorf("container (name, attempt, sandboxID)=(%q, %d, %q) not found", name, attempt, sandboxID)
 }
 
+// SetFakeSandboxes sets the fake sandboxes for the FakeRuntimeService.
 func (r *FakeRuntimeService) SetFakeSandboxes(sandboxes []*FakePodSandbox) {
 	r.Lock()
 	defer r.Unlock()
@@ -85,6 +94,7 @@ func (r *FakeRuntimeService) SetFakeSandboxes(sandboxes []*FakePodSandbox) {
 	}
 }
 
+// SetFakeContainers sets fake containers for the FakeRuntimeService.
 func (r *FakeRuntimeService) SetFakeContainers(containers []*FakeContainer) {
 	r.Lock()
 	defer r.Unlock()
@@ -97,6 +107,7 @@ func (r *FakeRuntimeService) SetFakeContainers(containers []*FakeContainer) {
 
 }
 
+// AssertCalls validates whether specified calls were made to the FakeRuntimeService.
 func (r *FakeRuntimeService) AssertCalls(calls []string) error {
 	r.Lock()
 	defer r.Unlock()
@@ -107,12 +118,14 @@ func (r *FakeRuntimeService) AssertCalls(calls []string) error {
 	return nil
 }
 
+// GetCalls returns the list of calls made to the FakeRuntimeService.
 func (r *FakeRuntimeService) GetCalls() []string {
 	r.Lock()
 	defer r.Unlock()
 	return append([]string{}, r.Called...)
 }
 
+// InjectError inject the error to the next call to the FakeRuntimeService.
 func (r *FakeRuntimeService) InjectError(f string, err error) {
 	r.Lock()
 	defer r.Unlock()
@@ -133,6 +146,7 @@ func (r *FakeRuntimeService) popError(f string) error {
 	return err
 }
 
+// NewFakeRuntimeService creates a new FakeRuntimeService.
 func NewFakeRuntimeService() *FakeRuntimeService {
 	return &FakeRuntimeService{
 		Called:             make([]string, 0),
@@ -143,6 +157,7 @@ func NewFakeRuntimeService() *FakeRuntimeService {
 	}
 }
 
+// Version returns version information from the FakeRuntimeService.
 func (r *FakeRuntimeService) Version(apiVersion string) (*runtimeapi.VersionResponse, error) {
 	r.Lock()
 	defer r.Unlock()
@@ -160,6 +175,7 @@ func (r *FakeRuntimeService) Version(apiVersion string) (*runtimeapi.VersionResp
 	}, nil
 }
 
+// Status returns runtime status of the FakeRuntimeService.
 func (r *FakeRuntimeService) Status() (*runtimeapi.RuntimeStatus, error) {
 	r.Lock()
 	defer r.Unlock()
@@ -172,6 +188,7 @@ func (r *FakeRuntimeService) Status() (*runtimeapi.RuntimeStatus, error) {
 	return r.FakeStatus, nil
 }
 
+// RunPodSandbox emulates the run of the pod sandbox in the FakeRuntimeService.
 func (r *FakeRuntimeService) RunPodSandbox(config *runtimeapi.PodSandboxConfig, runtimeHandler string) (string, error) {
 	r.Lock()
 	defer r.Unlock()
@@ -220,6 +237,7 @@ func (r *FakeRuntimeService) RunPodSandbox(config *runtimeapi.PodSandboxConfig, 
 	return podSandboxID, nil
 }
 
+// StopPodSandbox emulates the stop of pod sandbox in the FakeRuntimeService.
 func (r *FakeRuntimeService) StopPodSandbox(podSandboxID string) error {
 	r.Lock()
 	defer r.Unlock()
@@ -238,6 +256,7 @@ func (r *FakeRuntimeService) StopPodSandbox(podSandboxID string) error {
 	return nil
 }
 
+// RemovePodSandbox emulates removal of the pod sadbox in the FakeRuntimeService.
 func (r *FakeRuntimeService) RemovePodSandbox(podSandboxID string) error {
 	r.Lock()
 	defer r.Unlock()
@@ -253,6 +272,7 @@ func (r *FakeRuntimeService) RemovePodSandbox(podSandboxID string) error {
 	return nil
 }
 
+// PodSandboxStatus returns pod sandbox status from the FakeRuntimeService.
 func (r *FakeRuntimeService) PodSandboxStatus(podSandboxID string) (*runtimeapi.PodSandboxStatus, error) {
 	r.Lock()
 	defer r.Unlock()
@@ -271,6 +291,7 @@ func (r *FakeRuntimeService) PodSandboxStatus(podSandboxID string) (*runtimeapi.
 	return &status, nil
 }
 
+// ListPodSandbox returns the list of pod sandboxes in the FakeRuntimeService.
 func (r *FakeRuntimeService) ListPodSandbox(filter *runtimeapi.PodSandboxFilter) ([]*runtimeapi.PodSandbox, error) {
 	r.Lock()
 	defer r.Unlock()
@@ -308,6 +329,7 @@ func (r *FakeRuntimeService) ListPodSandbox(filter *runtimeapi.PodSandboxFilter)
 	return result, nil
 }
 
+// PortForward emulates the set up of port forward in the FakeRuntimeService.
 func (r *FakeRuntimeService) PortForward(*runtimeapi.PortForwardRequest) (*runtimeapi.PortForwardResponse, error) {
 	r.Lock()
 	defer r.Unlock()
@@ -320,6 +342,7 @@ func (r *FakeRuntimeService) PortForward(*runtimeapi.PortForwardRequest) (*runti
 	return &runtimeapi.PortForwardResponse{}, nil
 }
 
+// CreateContainer emulates container creation in the FakeRuntimeService.
 func (r *FakeRuntimeService) CreateContainer(podSandboxID string, config *runtimeapi.ContainerConfig, sandboxConfig *runtimeapi.PodSandboxConfig) (string, error) {
 	r.Lock()
 	defer r.Unlock()
@@ -353,6 +376,7 @@ func (r *FakeRuntimeService) CreateContainer(podSandboxID string, config *runtim
 	return containerID, nil
 }
 
+// StartContainer emulates start of a container in the FakeRuntimeService.
 func (r *FakeRuntimeService) StartContainer(containerID string) error {
 	r.Lock()
 	defer r.Unlock()
@@ -374,6 +398,7 @@ func (r *FakeRuntimeService) StartContainer(containerID string) error {
 	return nil
 }
 
+// StopContainer emulates stop of a container in the FakeRuntimeService.
 func (r *FakeRuntimeService) StopContainer(containerID string, timeout int64) error {
 	r.Lock()
 	defer r.Unlock()
@@ -397,6 +422,7 @@ func (r *FakeRuntimeService) StopContainer(containerID string, timeout int64) er
 	return nil
 }
 
+// RemoveContainer emulates remove of a container in the FakeRuntimeService.
 func (r *FakeRuntimeService) RemoveContainer(containerID string) error {
 	r.Lock()
 	defer r.Unlock()
@@ -412,6 +438,7 @@ func (r *FakeRuntimeService) RemoveContainer(containerID string) error {
 	return nil
 }
 
+// ListContainers returns the list of containers in the FakeRuntimeService.
 func (r *FakeRuntimeService) ListContainers(filter *runtimeapi.ContainerFilter) ([]*runtimeapi.Container, error) {
 	r.Lock()
 	defer r.Unlock()
@@ -454,6 +481,7 @@ func (r *FakeRuntimeService) ListContainers(filter *runtimeapi.ContainerFilter) 
 	return result, nil
 }
 
+// ContainerStatus returns the container status given the container ID in FakeRuntimeService.
 func (r *FakeRuntimeService) ContainerStatus(containerID string) (*runtimeapi.ContainerStatus, error) {
 	r.Lock()
 	defer r.Unlock()
@@ -472,6 +500,7 @@ func (r *FakeRuntimeService) ContainerStatus(containerID string) (*runtimeapi.Co
 	return &status, nil
 }
 
+// UpdateContainerResources returns the container resource in the FakeRuntimeService.
 func (r *FakeRuntimeService) UpdateContainerResources(string, *runtimeapi.LinuxContainerResources) error {
 	r.Lock()
 	defer r.Unlock()
@@ -480,6 +509,7 @@ func (r *FakeRuntimeService) UpdateContainerResources(string, *runtimeapi.LinuxC
 	return r.popError("UpdateContainerResources")
 }
 
+// ExecSync emulates the sync execution of a command in a container in the FakeRuntimeService.
 func (r *FakeRuntimeService) ExecSync(containerID string, cmd []string, timeout time.Duration) (stdout []byte, stderr []byte, err error) {
 	r.Lock()
 	defer r.Unlock()
@@ -489,6 +519,7 @@ func (r *FakeRuntimeService) ExecSync(containerID string, cmd []string, timeout 
 	return
 }
 
+// Exec emulates the execution of a command in a container in the FakeRuntimeService.
 func (r *FakeRuntimeService) Exec(*runtimeapi.ExecRequest) (*runtimeapi.ExecResponse, error) {
 	r.Lock()
 	defer r.Unlock()
@@ -501,6 +532,7 @@ func (r *FakeRuntimeService) Exec(*runtimeapi.ExecRequest) (*runtimeapi.ExecResp
 	return &runtimeapi.ExecResponse{}, nil
 }
 
+// Attach emulates the attach request in the FakeRuntimeService.
 func (r *FakeRuntimeService) Attach(req *runtimeapi.AttachRequest) (*runtimeapi.AttachResponse, error) {
 	r.Lock()
 	defer r.Unlock()
@@ -513,6 +545,7 @@ func (r *FakeRuntimeService) Attach(req *runtimeapi.AttachRequest) (*runtimeapi.
 	return &runtimeapi.AttachResponse{}, nil
 }
 
+// UpdateRuntimeConfig emulates the update of a runtime config for the FakeRuntimeService.
 func (r *FakeRuntimeService) UpdateRuntimeConfig(runtimeCOnfig *runtimeapi.RuntimeConfig) error {
 	r.Lock()
 	defer r.Unlock()
@@ -521,6 +554,7 @@ func (r *FakeRuntimeService) UpdateRuntimeConfig(runtimeCOnfig *runtimeapi.Runti
 	return r.popError("UpdateRuntimeConfig")
 }
 
+// SetFakeContainerStats sets the fake container stats in the FakeRuntimeService.
 func (r *FakeRuntimeService) SetFakeContainerStats(containerStats []*runtimeapi.ContainerStats) {
 	r.Lock()
 	defer r.Unlock()
@@ -531,6 +565,7 @@ func (r *FakeRuntimeService) SetFakeContainerStats(containerStats []*runtimeapi.
 	}
 }
 
+// ContainerStats returns the container stats in the FakeRuntimeService.
 func (r *FakeRuntimeService) ContainerStats(containerID string) (*runtimeapi.ContainerStats, error) {
 	r.Lock()
 	defer r.Unlock()
@@ -547,6 +582,7 @@ func (r *FakeRuntimeService) ContainerStats(containerID string) (*runtimeapi.Con
 	return s, nil
 }
 
+// ListContainerStats returns the list of all container stats given the filter in the FakeRuntimeService.
 func (r *FakeRuntimeService) ListContainerStats(filter *runtimeapi.ContainerStatsFilter) ([]*runtimeapi.ContainerStats, error) {
 	r.Lock()
 	defer r.Unlock()
@@ -579,6 +615,7 @@ func (r *FakeRuntimeService) ListContainerStats(filter *runtimeapi.ContainerStat
 	return result, nil
 }
 
+// ReopenContainerLog emulates call to the reopen container log in the FakeRuntimeService.
 func (r *FakeRuntimeService) ReopenContainerLog(containerID string) error {
 	r.Lock()
 	defer r.Unlock()

--- a/staging/src/k8s.io/cri-api/pkg/apis/testing/utils.go
+++ b/staging/src/k8s.io/cri-api/pkg/apis/testing/utils.go
@@ -22,11 +22,13 @@ import (
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 )
 
+// BuildContainerName creates a unique container name string.
 func BuildContainerName(metadata *runtimeapi.ContainerMetadata, sandboxID string) string {
 	// include the sandbox ID to make the container ID unique.
 	return fmt.Sprintf("%s_%s_%d", sandboxID, metadata.Name, metadata.Attempt)
 }
 
+// BuildSandboxName creates a unique sandbox name string.
 func BuildSandboxName(metadata *runtimeapi.PodSandboxMetadata) string {
 	return fmt.Sprintf("%s_%s_%s_%d", metadata.Name, metadata.Namespace, metadata.Uid, metadata.Attempt)
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup
/sig node

**What this PR does / why we need it**:

fixes all linter errors in pkg/kubelet/cri/remote and staging/src/k8s.io/cri-api/pkg/apis/testing

**Which issue(s) this PR fixes**:

Related to #68026.

**Special notes for your reviewer**:

List of issues:

```
Errors from golint:
pkg/kubelet/cri/remote/remote_image.go:34:6: type name will be used as remote.RemoteImageService by other packages, and that stutters; consider calling this ImageService
pkg/kubelet/cri/remote/remote_runtime.go:37:6: type name will be used as remote.RemoteRuntimeService by other packages, and that stutters; consider calling this RuntimeService
pkg/kubelet/cri/remote/remote_runtime.go:537:1: exported method RemoteRuntimeService.ListContainerStats should have comment or be unexported
pkg/kubelet/cri/remote/remote_runtime.go:556:1: exported method RemoteRuntimeService.ReopenContainerLog should have comment or be unexported
staging/src/k8s.io/cri-api/pkg/apis/testing/fake_image_service.go:28:6: exported type FakeImageService should have comment or be unexported
staging/src/k8s.io/cri-api/pkg/apis/testing/fake_image_service.go:41:1: exported method FakeImageService.SetFakeImages should have comment or be unexported
staging/src/k8s.io/cri-api/pkg/apis/testing/fake_image_service.go:54:1: exported method FakeImageService.SetFakeImagesWithAnnotations should have comment or be unexported
staging/src/k8s.io/cri-api/pkg/apis/testing/fake_image_service.go:64:1: exported method FakeImageService.SetFakeImageSize should have comment or be unexported
staging/src/k8s.io/cri-api/pkg/apis/testing/fake_image_service.go:71:1: exported method FakeImageService.SetFakeFilesystemUsage should have comment or be unexported
staging/src/k8s.io/cri-api/pkg/apis/testing/fake_image_service.go:78:1: exported function NewFakeImageService should have comment or be unexported
staging/src/k8s.io/cri-api/pkg/apis/testing/fake_image_service.go:106:1: exported method FakeImageService.InjectError should have comment or be unexported
staging/src/k8s.io/cri-api/pkg/apis/testing/fake_image_service.go:126:1: exported method FakeImageService.ListImages should have comment or be unexported
staging/src/k8s.io/cri-api/pkg/apis/testing/fake_image_service.go:148:1: exported method FakeImageService.ImageStatus should have comment or be unexported
staging/src/k8s.io/cri-api/pkg/apis/testing/fake_image_service.go:160:1: exported method FakeImageService.PullImage should have comment or be unexported
staging/src/k8s.io/cri-api/pkg/apis/testing/fake_image_service.go:180:1: exported method FakeImageService.RemoveImage should have comment or be unexported
staging/src/k8s.io/cri-api/pkg/apis/testing/fake_image_service.go:208:1: exported method FakeImageService.AssertImagePulledWithAuth should have comment or be unexported
staging/src/k8s.io/cri-api/pkg/apis/testing/fake_runtime_service.go:29:2: exported var FakeVersion should have comment or be unexported
staging/src/k8s.io/cri-api/pkg/apis/testing/fake_runtime_service.go:35:6: exported type FakePodSandbox should have comment or be unexported
staging/src/k8s.io/cri-api/pkg/apis/testing/fake_runtime_service.go:42:6: exported type FakeContainer should have comment or be unexported
staging/src/k8s.io/cri-api/pkg/apis/testing/fake_runtime_service.go:53:6: exported type FakeRuntimeService should have comment or be unexported
staging/src/k8s.io/cri-api/pkg/apis/testing/fake_runtime_service.go:65:1: exported method FakeRuntimeService.GetContainerID should have comment or be unexported
staging/src/k8s.io/cri-api/pkg/apis/testing/fake_runtime_service.go:77:1: exported method FakeRuntimeService.SetFakeSandboxes should have comment or be unexported
staging/src/k8s.io/cri-api/pkg/apis/testing/fake_runtime_service.go:88:1: exported method FakeRuntimeService.SetFakeContainers should have comment or be unexported
staging/src/k8s.io/cri-api/pkg/apis/testing/fake_runtime_service.go:100:1: exported method FakeRuntimeService.AssertCalls should have comment or be unexported
staging/src/k8s.io/cri-api/pkg/apis/testing/fake_runtime_service.go:110:1: exported method FakeRuntimeService.GetCalls should have comment or be unexported
staging/src/k8s.io/cri-api/pkg/apis/testing/fake_runtime_service.go:116:1: exported method FakeRuntimeService.InjectError should have comment or be unexported
staging/src/k8s.io/cri-api/pkg/apis/testing/fake_runtime_service.go:136:1: exported function NewFakeRuntimeService should have comment or be unexported
staging/src/k8s.io/cri-api/pkg/apis/testing/fake_runtime_service.go:146:1: exported method FakeRuntimeService.Version should have comment or be unexported
staging/src/k8s.io/cri-api/pkg/apis/testing/fake_runtime_service.go:163:1: exported method FakeRuntimeService.Status should have comment or be unexported
staging/src/k8s.io/cri-api/pkg/apis/testing/fake_runtime_service.go:175:1: exported method FakeRuntimeService.RunPodSandbox should have comment or be unexported
staging/src/k8s.io/cri-api/pkg/apis/testing/fake_runtime_service.go:223:1: exported method FakeRuntimeService.StopPodSandbox should have comment or be unexported
staging/src/k8s.io/cri-api/pkg/apis/testing/fake_runtime_service.go:241:1: exported method FakeRuntimeService.RemovePodSandbox should have comment or be unexported
staging/src/k8s.io/cri-api/pkg/apis/testing/fake_runtime_service.go:256:1: exported method FakeRuntimeService.PodSandboxStatus should have comment or be unexported
staging/src/k8s.io/cri-api/pkg/apis/testing/fake_runtime_service.go:274:1: exported method FakeRuntimeService.ListPodSandbox should have comment or be unexported
staging/src/k8s.io/cri-api/pkg/apis/testing/fake_runtime_service.go:311:1: exported method FakeRuntimeService.PortForward should have comment or be unexported
staging/src/k8s.io/cri-api/pkg/apis/testing/fake_runtime_service.go:323:1: exported method FakeRuntimeService.CreateContainer should have comment or be unexported
staging/src/k8s.io/cri-api/pkg/apis/testing/fake_runtime_service.go:356:1: exported method FakeRuntimeService.StartContainer should have comment or be unexported
staging/src/k8s.io/cri-api/pkg/apis/testing/fake_runtime_service.go:377:1: exported method FakeRuntimeService.StopContainer should have comment or be unexported
staging/src/k8s.io/cri-api/pkg/apis/testing/fake_runtime_service.go:400:1: exported method FakeRuntimeService.RemoveContainer should have comment or be unexported
staging/src/k8s.io/cri-api/pkg/apis/testing/fake_runtime_service.go:415:1: exported method FakeRuntimeService.ListContainers should have comment or be unexported
staging/src/k8s.io/cri-api/pkg/apis/testing/fake_runtime_service.go:457:1: exported method FakeRuntimeService.ContainerStatus should have comment or be unexported
staging/src/k8s.io/cri-api/pkg/apis/testing/fake_runtime_service.go:475:1: exported method FakeRuntimeService.UpdateContainerResources should have comment or be unexported
staging/src/k8s.io/cri-api/pkg/apis/testing/fake_runtime_service.go:483:1: exported method FakeRuntimeService.ExecSync should have comment or be unexported
staging/src/k8s.io/cri-api/pkg/apis/testing/fake_runtime_service.go:492:1: exported method FakeRuntimeService.Exec should have comment or be unexported
staging/src/k8s.io/cri-api/pkg/apis/testing/fake_runtime_service.go:504:1: exported method FakeRuntimeService.Attach should have comment or be unexported
staging/src/k8s.io/cri-api/pkg/apis/testing/fake_runtime_service.go:516:1: exported method FakeRuntimeService.UpdateRuntimeConfig should have comment or be unexported
staging/src/k8s.io/cri-api/pkg/apis/testing/fake_runtime_service.go:524:1: exported method FakeRuntimeService.SetFakeContainerStats should have comment or be unexported
staging/src/k8s.io/cri-api/pkg/apis/testing/fake_runtime_service.go:534:1: exported method FakeRuntimeService.ContainerStats should have comment or be unexported
staging/src/k8s.io/cri-api/pkg/apis/testing/fake_runtime_service.go:550:1: exported method FakeRuntimeService.ListContainerStats should have comment or be unexported
staging/src/k8s.io/cri-api/pkg/apis/testing/fake_runtime_service.go:582:1: exported method FakeRuntimeService.ReopenContainerLog should have comment or be unexported
staging/src/k8s.io/cri-api/pkg/apis/testing/utils.go:25:1: exported function BuildContainerName should have comment or be unexported
staging/src/k8s.io/cri-api/pkg/apis/testing/utils.go:30:1: exported function BuildSandboxName should have comment or be unexported

```

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
