### PR TITLE
test/e2e/framework/pods: Fix "to success" -> "to succeed"

### DIFF
--- a/test/e2e/framework/pods.go
+++ b/test/e2e/framework/pods.go
@@ -209,7 +209,7 @@ func (c *PodClient) WaitForSuccess(name string, timeout time.Duration) {
 				return false, nil
 			}
 		},
-	)).To(gomega.Succeed(), "wait for pod %q to success", name)
+	)).To(gomega.Succeed(), "wait for pod %q to succeed", name)
 }
 
 // WaitForFinish waits for pod to finish running, regardless of success or failure.


### PR DESCRIPTION
Typo is from 5eb41e9acb (#33389).

```release-note
NONE
```