### PR TITLE
Adjust admission webhook auth config for default-enabled admission plugins

### DIFF
--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -965,7 +965,7 @@ EOF
     # If GKE exec auth for webhooks has been requested, then
     # ValidatingAdmissionWebhook should use it.  Otherwise, run with the default
     # config.
-    if [[ "${ADMISSION_CONTROL:-}" == *"ValidatingAdmissionWebhook"* && -n "${WEBHOOK_GKE_EXEC_AUTH:-}" ]]; then
+    if [[ -n "${WEBHOOK_GKE_EXEC_AUTH:-}" ]]; then
       1>&2 echo "ValidatingAdmissionWebhook requested, and WEBHOOK_GKE_EXEC_AUTH specified.  Configuring ValidatingAdmissionWebhook to use gke-exec-auth-plugin."
 
       # Append config for ValidatingAdmissionWebhook to the shared admission


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
validating webhook admission plugins are implicitly enabled as of f7bf17bc2f62bd147350c9b32152886fb6f1ea3b, we don't need to check for an explicit value in the admission control configuration

**Does this PR introduce a user-facing change?**:
```release-note
kube-up: fixes setup of validating admission webhook credential configuration
```