### PR TITLE
ingress: promote CRUD API tests for v1 to conformance

### DIFF
--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -1561,6 +1561,27 @@
     DNS configuration MUST be configured in the Pod.
   release: v1.17
   file: test/e2e/network/dns.go
+- testname: Ingress API
+  codename: '[sig-network] Ingress API should support creating Ingress API operations
+    [Conformance]'
+  description: ' The networking.k8s.io API group MUST exist in the /apis discovery
+    document. The networking.k8s.io/v1 API group/version MUST exist in the /apis/networking.k8s.io
+    discovery document. The ingresses resources MUST exist in the /apis/networking.k8s.io/v1
+    discovery document. The ingresses resource must support create, get, list, watch,
+    update, patch, delete, and deletecollection. The ingresses/status resource must
+    support update and patch'
+  release: v1.19
+  file: test/e2e/network/ingress.go
+- testname: IngressClass API
+  codename: '[sig-network] IngressClass API  should support creating IngressClass
+    API operations [Conformance]'
+  description: ' - The networking.k8s.io API group MUST exist in the /apis discovery
+    document. - The networking.k8s.io/v1 API group/version MUST exist in the /apis/networking.k8s.io
+    discovery document. - The ingressclasses resource MUST exist in the /apis/networking.k8s.io/v1
+    discovery document. - The ingressclass resource must support create, get, list,
+    watch, update, patch, delete, and deletecollection.'
+  release: v1.19
+  file: test/e2e/network/ingressclass.go
 - testname: Networking, intra pod http
   codename: '[sig-network] Networking Granular Checks: Pods should function for intra-pod
     communication: http [NodeConformance] [Conformance]'


### PR DESCRIPTION
**What type of PR is this?**
 /kind feature
/kind api-change

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
xref: kubernetes/enhancements#1453

**Special notes for your reviewer**:

Builds on top of https://github.com/kubernetes/kubernetes/pull/89778, only the second commit is new

**DO NOT MERGE UNTIL THE FOLLOWING HAVE MERGED & ARE STABLE**
- [x] IngressClass CRUD API tests #91830
- [x] Ingress CRUD API tests #91593 

Run history:
* [gce-cos-master](https://testgrid.k8s.io/sig-release-master-blocking#gce-cos-master-default&include-filter-by-regex=sig-network.*Ingress.*AP&width=5)
* [kind-master-parallel](https://testgrid.k8s.io/sig-release-master-blocking#kind-master-parallel&include-filter-by-regex=sig-network.*Ingress.*API&width=5)
* current API coverage of those tests against the beta API visible at https://apisnoop.cncf.io/latest/beta/networking


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

- [KEP](https://github.com/kubernetes/enhancements/blob/master/keps/sig-network/1453-ingress-api/README.md)

