### PR TITLE
azure: enable floating IP for IPv6 LB

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_loadbalancer.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_loadbalancer.go
@@ -1080,14 +1080,8 @@ func (az *Cloud) reconcileLoadBalancerRule(
 					BackendPort:         to.Int32Ptr(port.Port),
 					DisableOutboundSnat: to.BoolPtr(az.disableLoadBalancerOutboundSNAT()),
 					EnableTCPReset:      enableTCPReset,
+					EnableFloatingIP:    to.BoolPtr(true),
 				},
-			}
-			// LB does not support floating IPs for IPV6 rules
-			if utilnet.IsIPv6String(service.Spec.ClusterIP) {
-				expectedRule.BackendPort = to.Int32Ptr(port.NodePort)
-				expectedRule.EnableFloatingIP = to.BoolPtr(false)
-			} else {
-				expectedRule.EnableFloatingIP = to.BoolPtr(true)
 			}
 
 			if protocol == v1.ProtocolTCP {
@@ -1158,8 +1152,6 @@ func (az *Cloud) reconcileSecurityGroup(clusterName string, service *v1.Service,
 	}
 	expectedSecurityRules := []network.SecurityRule{}
 
-	ipv6 := utilnet.IsIPv6String(service.Spec.ClusterIP)
-
 	if wantLb {
 		expectedSecurityRules = make([]network.SecurityRule, len(ports)*len(sourceAddressPrefixes))
 
@@ -1171,7 +1163,7 @@ func (az *Cloud) reconcileSecurityGroup(clusterName string, service *v1.Service,
 			for j := range sourceAddressPrefixes {
 				ix := i*len(sourceAddressPrefixes) + j
 				securityRuleName := az.getSecurityRuleName(service, port, sourceAddressPrefixes[j])
-				securityRule := network.SecurityRule{
+				expectedSecurityRules[ix] = network.SecurityRule{
 					Name: to.StringPtr(securityRuleName),
 					SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
 						Protocol:                 *securityProto,
@@ -1183,13 +1175,6 @@ func (az *Cloud) reconcileSecurityGroup(clusterName string, service *v1.Service,
 						Direction:                network.SecurityRuleDirectionInbound,
 					},
 				}
-				// For IPv6, the destination port needs to be node port and Destination Any as floating IPs
-				// not supported for IPv6
-				if ipv6 {
-					securityRule.SecurityRulePropertiesFormat.DestinationPortRange = to.StringPtr(strconv.Itoa(int(port.NodePort)))
-					securityRule.SecurityRulePropertiesFormat.DestinationAddressPrefix = to.StringPtr("*")
-				}
-				expectedSecurityRules[ix] = securityRule
 			}
 		}
 	}

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_loadbalancer_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_loadbalancer_test.go
@@ -1879,9 +1879,9 @@ func TestReconcileSecurityGroup(t *testing.T) {
 							SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
 								Protocol:                 network.SecurityRuleProtocol("Tcp"),
 								SourcePortRange:          to.StringPtr("*"),
-								DestinationPortRange:     to.StringPtr("10080"),
+								DestinationPortRange:     to.StringPtr("80"),
 								SourceAddressPrefix:      to.StringPtr("Internet"),
-								DestinationAddressPrefix: to.StringPtr("*"),
+								DestinationAddressPrefix: to.StringPtr("fd00::eef0"),
 								Access:                   network.SecurityRuleAccess("Allow"),
 								Priority:                 to.Int32Ptr(500),
 								Direction:                network.SecurityRuleDirection("Inbound"),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
/kind bug

**What this PR does / why we need it**:
Enables Floating IP for IPv6 as its now supported - https://docs.microsoft.com/en-us/azure/virtual-network/ipv6-overview#capabilities
```
Standard IPv6 public Load Balancer support to create resilient, scalable applications, which include:
- Optional IPv6 ports can be reused on backend instances using the Floating IP feature of load-balancing rules
```
```json
➜ az network lb rule show -g ds0610 --lb-name ds0610 -n aae4b8e7f0e5948539ed386c050007b4-TCP-80
{
  "backendAddressPool": {
    "id": "/subscriptions/xxxx/resourceGroups/ds0610/providers/Microsoft.Network/loadBalancers/ds0610/backendAddressPools/ds0610-IPv6",
    "resourceGroup": "ds0610"
  },
  "backendPort": 80,
  "disableOutboundSnat": false,
  "enableFloatingIp": true,
  "enableTcpReset": true,
  "etag": "W/\"41240de2-0bc7-4cbd-b49d-e94024e33911\"",
  "frontendIpConfiguration": {
    "id": "/subscriptions/xxxx/resourceGroups/ds0610/providers/Microsoft.Network/loadBalancers/ds0610/frontendIPConfigurations/aae4b8e7f0e5948539ed386c050007b4",
    "resourceGroup": "ds0610"
  },
  "frontendPort": 80,
  "id": "/subscriptions/xxxx/resourceGroups/ds0610/providers/Microsoft.Network/loadBalancers/ds0610/loadBalancingRules/aae4b8e7f0e5948539ed386c050007b4-TCP-80",
  "idleTimeoutInMinutes": 4,
  "loadDistribution": "Default",
  "name": "aae4b8e7f0e5948539ed386c050007b4-TCP-80",
  "probe": {
    "id": "/subscriptions/xxxx/resourceGroups/ds0610/providers/Microsoft.Network/loadBalancers/ds0610/probes/aae4b8e7f0e5948539ed386c050007b4-TCP-80",
    "resourceGroup": "ds0610"
  },
  "protocol": "Tcp",
  "provisioningState": "Succeeded",
  "resourceGroup": "ds0610",
  "type": "Microsoft.Network/loadBalancers/loadBalancingRules"
}
```


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
azure: enable floating IP for IPv6 LB
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```

/area provider/azure
/priority important-soon

/assign @feiskyer @khenidak 