### PR TITLE
Automated cherry pick of #91997: enable floating IP for IPv6

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_loadbalancer.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_loadbalancer.go
@@ -1082,14 +1082,8 @@ func (az *Cloud) reconcileLoadBalancerRule(
 					BackendPort:         to.Int32Ptr(port.Port),
 					DisableOutboundSnat: to.BoolPtr(az.disableLoadBalancerOutboundSNAT()),
 					EnableTCPReset:      enableTCPReset,
+					EnableFloatingIP:    to.BoolPtr(true),
 				},
-			}
-			// LB does not support floating IPs for IPV6 rules
-			if utilnet.IsIPv6String(service.Spec.ClusterIP) {
-				expectedRule.BackendPort = to.Int32Ptr(port.NodePort)
-				expectedRule.EnableFloatingIP = to.BoolPtr(false)
-			} else {
-				expectedRule.EnableFloatingIP = to.BoolPtr(true)
 			}
 
 			if protocol == v1.ProtocolTCP {
@@ -1160,8 +1154,6 @@ func (az *Cloud) reconcileSecurityGroup(clusterName string, service *v1.Service,
 	}
 	expectedSecurityRules := []network.SecurityRule{}
 
-	ipv6 := utilnet.IsIPv6String(service.Spec.ClusterIP)
-
 	if wantLb {
 		expectedSecurityRules = make([]network.SecurityRule, len(ports)*len(sourceAddressPrefixes))
 
@@ -1173,7 +1165,7 @@ func (az *Cloud) reconcileSecurityGroup(clusterName string, service *v1.Service,
 			for j := range sourceAddressPrefixes {
 				ix := i*len(sourceAddressPrefixes) + j
 				securityRuleName := az.getSecurityRuleName(service, port, sourceAddressPrefixes[j])
-				securityRule := network.SecurityRule{
+				expectedSecurityRules[ix] = network.SecurityRule{
 					Name: to.StringPtr(securityRuleName),
 					SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
 						Protocol:                 *securityProto,
@@ -1185,13 +1177,6 @@ func (az *Cloud) reconcileSecurityGroup(clusterName string, service *v1.Service,
 						Direction:                network.SecurityRuleDirectionInbound,
 					},
 				}
-				// For IPv6, the destination port needs to be node port and Destination Any as floating IPs
-				// not supported for IPv6
-				if ipv6 {
-					securityRule.SecurityRulePropertiesFormat.DestinationPortRange = to.StringPtr(strconv.Itoa(int(port.NodePort)))
-					securityRule.SecurityRulePropertiesFormat.DestinationAddressPrefix = to.StringPtr("*")
-				}
-				expectedSecurityRules[ix] = securityRule
 			}
 		}
 	}

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_loadbalancer_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_loadbalancer_test.go
@@ -1766,9 +1766,9 @@ func TestReconcileSecurityGroup(t *testing.T) {
 							SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
 								Protocol:                 network.SecurityRuleProtocol("Tcp"),
 								SourcePortRange:          to.StringPtr("*"),
-								DestinationPortRange:     to.StringPtr("10080"),
+								DestinationPortRange:     to.StringPtr("80"),
 								SourceAddressPrefix:      to.StringPtr("Internet"),
-								DestinationAddressPrefix: to.StringPtr("*"),
+								DestinationAddressPrefix: to.StringPtr("fd00::eef0"),
 								Access:                   network.SecurityRuleAccess("Allow"),
 								Priority:                 to.Int32Ptr(500),
 								Direction:                network.SecurityRuleDirection("Inbound"),


### PR DESCRIPTION
Cherry pick of #91997 on release-1.17.

#91997: enable floating IP for IPv6

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.