### PR TITLE
Move kube-apiserver client cert back to simple e2e

### DIFF
--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -1314,14 +1314,6 @@
     resource must support get, update, patch.'
   release: v1.19
   file: test/e2e/auth/certificates.go
-- testname: CertificateSigningRequest API Client Certificate
-  codename: '[sig-auth] Certificates API [Privileged:ClusterAdmin] should support
-    building a client with a CSR [Conformance]'
-  description: ' The certificatesigningrequests resource must accept a request for
-    a certificate signed by kubernetes.io/kube-apiserver-client. The issued certificate
-    must be valid as a client certificate used to authenticate to the kube-apiserver.'
-  release: v1.19
-  file: test/e2e/auth/certificates.go
 - testname: Service account tokens auto mount optionally
   codename: '[sig-auth] ServiceAccounts should allow opting out of API token automount  [Conformance]'
   description: Ensure that Service Account keys are mounted into the Pod only when

--- a/test/e2e/auth/certificates.go
+++ b/test/e2e/auth/certificates.go
@@ -52,7 +52,7 @@ var _ = SIGDescribe("Certificates API [Privileged:ClusterAdmin]", func() {
 		The certificatesigningrequests resource must accept a request for a certificate signed by kubernetes.io/kube-apiserver-client.
 		The issued certificate must be valid as a client certificate used to authenticate to the kube-apiserver.
 	*/
-	framework.ConformanceIt("should support building a client with a CSR", func() {
+	ginkgo.It("should support building a client with a CSR", func() {
 		const commonName = "tester-csr"
 
 		csrClient := f.ClientSet.CertificatesV1().CertificateSigningRequests()


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Moves the kube-apiserver-client test back to a simple e2e (as it was before https://github.com/kubernetes/kubernetes/pull/91685).

CRUD operations on the CSR API with an example signerName are included in conformance, but request/issuance of apiserver client certs deserves broader discussion.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/cc @smarterclayton 
/sig auth
/area conformance