### PR TITLE
Remove warning about misuse of %w

### DIFF
--- a/pkg/scheduler/apis/config/scheme/scheme_test.go
+++ b/pkg/scheduler/apis/config/scheme/scheme_test.go
@@ -311,12 +311,12 @@ profiles:
 			obj, gvk, err := decoder.Decode(tt.data, nil, nil)
 			if err != nil {
 				if tt.wantErr != err.Error() {
-					t.Fatalf("got err %w, want %w", err, tt.wantErr)
+					t.Fatalf("got err %v, want %v", err.Error(), tt.wantErr)
 				}
 				return
 			}
 			if len(tt.wantErr) != 0 {
-				t.Fatal("no error produced, wanted %w", tt.wantErr)
+				t.Fatalf("no error produced, wanted %v", tt.wantErr)
 			}
 			got, ok := obj.(*config.KubeSchedulerConfiguration)
 			if !ok {

--- a/pkg/scheduler/framework/plugins/noderesources/least_allocated_test.go
+++ b/pkg/scheduler/framework/plugins/noderesources/least_allocated_test.go
@@ -291,9 +291,9 @@ func TestNodeResourcesLeastAllocated(t *testing.T) {
 
 			if len(test.wantErr) != 0 {
 				if err != nil && test.wantErr != err.Error() {
-					t.Fatalf("got err %w, want %w", err.Error(), test.wantErr)
+					t.Fatalf("got err %v, want %v", err.Error(), test.wantErr)
 				} else if err == nil {
-					t.Fatal("no error produced, wanted %w", test.wantErr)
+					t.Fatalf("no error produced, wanted %v", test.wantErr)
 				}
 				return
 			}

--- a/pkg/scheduler/framework/plugins/noderesources/most_allocated_test.go
+++ b/pkg/scheduler/framework/plugins/noderesources/most_allocated_test.go
@@ -251,9 +251,9 @@ func TestNodeResourcesMostAllocated(t *testing.T) {
 
 			if len(test.wantErr) != 0 {
 				if err != nil && test.wantErr != err.Error() {
-					t.Fatalf("got err %w, want %w", err.Error(), test.wantErr)
+					t.Fatalf("got err %v, want %v", err.Error(), test.wantErr)
 				} else if err == nil {
-					t.Fatal("no error produced, wanted %w", test.wantErr)
+					t.Fatalf("no error produced, wanted %v", test.wantErr)
 				}
 				return
 			}


### PR DESCRIPTION
/kind cleanup

**What this PR does / why we need it**:
When running `make test` I saw the annoying warning:

```
Fatalf format %w has arg err.Error() of wrong type string
```

This PR fixes those warnings. IIUC %w should be used to wrap an error inside another error, but here we are just embedding an error string in another string. %v should be used instead.
