### PR TITLE
Remove warning about misuse of %w

### DIFF
--- a/pkg/scheduler/apis/config/scheme/scheme_test.go
+++ b/pkg/scheduler/apis/config/scheme/scheme_test.go
@@ -311,12 +311,12 @@ profiles:
 			obj, gvk, err := decoder.Decode(tt.data, nil, nil)
 			if err != nil {
 				if tt.wantErr != err.Error() {
-					t.Fatalf("got err %w, want %w", err, tt.wantErr)
+					t.Fatalf("got err %v, want %v", err.Error(), tt.wantErr)
 				}
 				return
 			}
 			if len(tt.wantErr) != 0 {
-				t.Fatal("no error produced, wanted %w", tt.wantErr)
+				t.Fatalf("no error produced, wanted %v", tt.wantErr)
 			}
 			got, ok := obj.(*config.KubeSchedulerConfiguration)
 			if !ok {


### PR DESCRIPTION
/kind cleanup

What this PR does / why we need it:
When running make test I saw the annoying warning:

Fatalf format %w has arg err.Error() of wrong type string
This PR fixes those warnings. IIUC %w should be used to wrap an error inside another error, but here we are just embedding an error string in another string. %v should be used instead.

```release-note
NONE
```
