### PR TITLE
retry on 'unexpected EOF' error

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/net/http.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/net/http.go
@@ -83,6 +83,8 @@ func IsProbableEOF(err error) bool {
 	switch {
 	case err == io.EOF:
 		return true
+	case err == io.ErrUnexpectedEOF:
+		return true
 	case msg == "http: can't write HTTP request on broken connection":
 		return true
 	case strings.Contains(msg, "http2: server sent GOAWAY and closed the connection"):


### PR DESCRIPTION
**What type of PR is this?**
> /kind api-change

/kind bug

> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
`unexpected EOF` is usually a transient error. client-go request uses `IsProbableEOF` function to determine whether it is going to retry a failed request.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
NONE

```release-note
NONE
```