### PR TITLE
Expose EventRecorder to scheduler FrameworkHandle

### DIFF
--- a/pkg/scheduler/factory.go
+++ b/pkg/scheduler/factory.go
@@ -38,7 +38,6 @@ import (
 	policylisters "k8s.io/client-go/listers/policy/v1beta1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
-
 	kubefeatures "k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/scheduler/algorithmprovider"
 	schedulerapi "k8s.io/kubernetes/pkg/scheduler/apis/config"

--- a/pkg/scheduler/framework/v1alpha1/BUILD
+++ b/pkg/scheduler/framework/v1alpha1/BUILD
@@ -34,6 +34,7 @@ go_library(
         "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",
         "//staging/src/k8s.io/client-go/informers:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes:go_default_library",
+        "//staging/src/k8s.io/client-go/tools/events:go_default_library",
         "//staging/src/k8s.io/component-base/metrics:go_default_library",
         "//staging/src/k8s.io/kube-scheduler/config/v1beta1:go_default_library",
         "//staging/src/k8s.io/kube-scheduler/extender/v1:go_default_library",

--- a/pkg/scheduler/framework/v1alpha1/interface.go
+++ b/pkg/scheduler/framework/v1alpha1/interface.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/informers"
 	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/events"
 	"k8s.io/kubernetes/pkg/scheduler/apis/config"
 )
 
@@ -511,6 +512,9 @@ type FrameworkHandle interface {
 
 	// ClientSet returns a kubernetes clientSet.
 	ClientSet() clientset.Interface
+
+	// EventRecorder returns an event recorder.
+	EventRecorder() events.EventRecorder
 
 	SharedInformerFactory() informers.SharedInformerFactory
 

--- a/pkg/scheduler/profile/profile.go
+++ b/pkg/scheduler/profile/profile.go
@@ -44,11 +44,11 @@ type Profile struct {
 // NewProfile builds a Profile for the given configuration.
 func NewProfile(cfg config.KubeSchedulerProfile, frameworkFact FrameworkFactory, recorderFact RecorderFactory,
 	opts ...framework.Option) (*Profile, error) {
-	f, err := frameworkFact(cfg, opts...)
+	r := recorderFact(cfg.SchedulerName)
+	f, err := frameworkFact(cfg, append(opts, framework.WithEventRecorder(r))...)
 	if err != nil {
 		return nil, err
 	}
-	r := recorderFact(cfg.SchedulerName)
 	return &Profile{
 		Framework: f,
 		Recorder:  r,


### PR DESCRIPTION
**What type of PR is this?**

/kind feature
/sig scheduling

**What this PR does / why we need it**:

This PR exposes `EventRecorder()` to `FrameworkHandle` interface so that plugin developers can choose to log cluster-level events - which can be observed via `kubectl describe pod`.

This is needed for defaultpreemption plugin as each victim needs to be recorded via `EventRecorder`.

TODO: as a followup, it makes sense to merge Profile and Framework into one data struct.

**Which issue(s) this PR fixes**:

Part of #91038.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
`EventRecorder()` is exposed to `FrameworkHandle` interface so that scheduler plugin developers can choose to log cluster-level events.
```