### PR TITLE
basic regression test of runDockershim

### DIFF
--- a/pkg/kubelet/kubelet_dockerless_test.go
+++ b/pkg/kubelet/kubelet_dockerless_test.go
@@ -1,0 +1,33 @@
+// +build dockerless
+
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubelet_test
+
+import (
+	"testing"
+
+	"k8s.io/kubernetes/pkg/kubelet"
+	kubetypes "k8s.io/kubernetes/pkg/kubelet/types"
+)
+
+func TestPreInitRuntimeService(t *testing.T) {
+	err := kubelet.PreInitRuntimeService(nil, nil, nil, kubetypes.DockerContainerRuntime, "", "", "", "")
+	if err == nil {
+		t.Fatal("PreInitRuntimeService should fail when configured to use docker and compiled dockerless")
+	}
+}

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -1953,6 +1953,13 @@ func TestSyncPodKillPod(t *testing.T) {
 	checkPodStatus(t, kl, pod, v1.PodFailed)
 }
 
+func TestPreInitRuntimeService(t *testing.T) {
+	err := PreInitRuntimeService(nil, nil, nil, "", "", "", "", "")
+	if err == nil {
+		t.Fatal("PreInitRuntimeService should fail when not configured with a container runtime")
+	}
+}
+
 func waitForVolumeUnmount(
 	volumeManager kubeletvolume.VolumeManager,
 	pod *v1.Pod) error {


### PR DESCRIPTION
 - added basic regression test to ensure an error is raised in the
   case of an unconfigured runtime, and the case of asking for a docker
   runtime when compiled dockerless

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Regression created during https://github.com/kubernetes/kubernetes/pull/87746

**Which issue(s) this PR fixes**:
Related to #91657

**Special notes for your reviewer**:
Asked to separate in https://github.com/kubernetes/kubernetes/pull/91789#issuecomment-641639770

Willing to add more complicated test cases in the future, but this catches the obvious regression.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/assign @mattjmcnaughton 