### PR TITLE
kubeadm: introduce --experimental-patches and deprecate --experimental-kustomize

### DIFF
--- a/cmd/kubeadm/app/apis/kubeadm/validation/validation.go
+++ b/cmd/kubeadm/app/apis/kubeadm/validation/validation.go
@@ -463,6 +463,7 @@ func isAllowedFlag(flagName string) bool {
 		kubeadmcmdoptions.KubeconfigDir,
 		kubeadmcmdoptions.UploadCerts,
 		kubeadmcmdoptions.Kustomize,
+		kubeadmcmdoptions.Patches,
 		"print-join-command", "rootfs", "v")
 	if knownFlags.Has(flagName) {
 		return true

--- a/cmd/kubeadm/app/cmd/init.go
+++ b/cmd/kubeadm/app/cmd/init.go
@@ -99,6 +99,7 @@ type initOptions struct {
 	uploadCerts             bool
 	skipCertificateKeyPrint bool
 	kustomizeDir            string
+	patchesDir              string
 }
 
 // compile-time assert that the local data object satisfies the phases data interface.
@@ -121,6 +122,7 @@ type initData struct {
 	uploadCerts             bool
 	skipCertificateKeyPrint bool
 	kustomizeDir            string
+	patchesDir              string
 }
 
 // NewCmdInit returns "kubeadm init" command.
@@ -277,6 +279,7 @@ func AddInitOtherFlags(flagSet *flag.FlagSet, initOptions *initOptions) {
 		"Don't print the key used to encrypt the control-plane certificates.",
 	)
 	options.AddKustomizePodsFlag(flagSet, &initOptions.kustomizeDir)
+	options.AddPatchesFlag(flagSet, &initOptions.patchesDir)
 }
 
 // newInitOptions returns a struct ready for being used for creating cmd init flags.
@@ -413,6 +416,7 @@ func newInitData(cmd *cobra.Command, args []string, options *initOptions, out io
 		uploadCerts:             options.uploadCerts,
 		skipCertificateKeyPrint: options.skipCertificateKeyPrint,
 		kustomizeDir:            options.kustomizeDir,
+		patchesDir:              options.patchesDir,
 	}, nil
 }
 
@@ -548,6 +552,11 @@ func (d *initData) Tokens() []string {
 // KustomizeDir returns the folder where kustomize patches for static pod manifest are stored
 func (d *initData) KustomizeDir() string {
 	return d.kustomizeDir
+}
+
+// PatchesDir returns the folder where patches for components are stored
+func (d *initData) PatchesDir() string {
+	return d.patchesDir
 }
 
 func printJoinCommand(out io.Writer, adminKubeConfigPath, token string, i *initData) error {

--- a/cmd/kubeadm/app/cmd/join.go
+++ b/cmd/kubeadm/app/cmd/join.go
@@ -130,6 +130,7 @@ type joinOptions struct {
 	externalcfg           *kubeadmapiv1beta2.JoinConfiguration
 	joinControlPlane      *kubeadmapiv1beta2.JoinControlPlane
 	kustomizeDir          string
+	patchesDir            string
 }
 
 // compile-time assert that the local data object satisfies the phases data interface.
@@ -145,6 +146,7 @@ type joinData struct {
 	ignorePreflightErrors sets.String
 	outputWriter          io.Writer
 	kustomizeDir          string
+	patchesDir            string
 }
 
 // NewCmdJoin returns "kubeadm join" command.
@@ -286,6 +288,7 @@ func addJoinOtherFlags(flagSet *flag.FlagSet, joinOptions *joinOptions) {
 		"Create a new control plane instance on this node",
 	)
 	options.AddKustomizePodsFlag(flagSet, &joinOptions.kustomizeDir)
+	options.AddPatchesFlag(flagSet, &joinOptions.patchesDir)
 }
 
 // newJoinOptions returns a struct ready for being used for creating cmd join flags.
@@ -441,6 +444,7 @@ func newJoinData(cmd *cobra.Command, args []string, opt *joinOptions, out io.Wri
 		ignorePreflightErrors: ignorePreflightErrorsSet,
 		outputWriter:          out,
 		kustomizeDir:          opt.kustomizeDir,
+		patchesDir:            opt.patchesDir,
 	}, nil
 }
 
@@ -509,6 +513,11 @@ func (j *joinData) OutputWriter() io.Writer {
 // KustomizeDir returns the folder where kustomize patches for static pod manifest are stored
 func (j *joinData) KustomizeDir() string {
 	return j.kustomizeDir
+}
+
+// PatchesDir returns the folder where patches for components are stored
+func (j *joinData) PatchesDir() string {
+	return j.patchesDir
 }
 
 // fetchInitConfigurationFromJoinConfiguration retrieves the init configuration from a join configuration, performing the discovery

--- a/cmd/kubeadm/app/cmd/options/constant.go
+++ b/cmd/kubeadm/app/cmd/options/constant.go
@@ -145,4 +145,7 @@ const (
 
 	// Kustomize flag sets the folder where kustomize patches for static pod manifest are stored
 	Kustomize = "experimental-kustomize"
+
+	// Patches flag sets the folder where kubeadm component patches are stored
+	Patches = "experimental-patches"
 )

--- a/cmd/kubeadm/app/cmd/options/generic.go
+++ b/cmd/kubeadm/app/cmd/options/generic.go
@@ -17,6 +17,7 @@ limitations under the License.
 package options
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/spf13/pflag"
@@ -92,4 +93,5 @@ func AddKubeadmOtherFlags(flagSet *pflag.FlagSet, rootfsPath *string) {
 // AddKustomizePodsFlag adds the --kustomize flag to the given flagset
 func AddKustomizePodsFlag(fs *pflag.FlagSet, kustomizeDir *string) {
 	fs.StringVarP(kustomizeDir, Kustomize, "k", *kustomizeDir, "The path where kustomize patches for static pod manifests are stored.")
+	fs.MarkDeprecated(Kustomize, fmt.Sprintf("This flag is deprecated and will be removed in a future version. Please use %s instead.", Patches))
 }

--- a/cmd/kubeadm/app/cmd/options/generic.go
+++ b/cmd/kubeadm/app/cmd/options/generic.go
@@ -95,3 +95,15 @@ func AddKustomizePodsFlag(fs *pflag.FlagSet, kustomizeDir *string) {
 	fs.StringVarP(kustomizeDir, Kustomize, "k", *kustomizeDir, "The path where kustomize patches for static pod manifests are stored.")
 	fs.MarkDeprecated(Kustomize, fmt.Sprintf("This flag is deprecated and will be removed in a future version. Please use %s instead.", Patches))
 }
+
+// AddPatchesFlag adds the --patches flag to the given flagset
+func AddPatchesFlag(fs *pflag.FlagSet, patchesDir *string) {
+	fs.StringVar(patchesDir, Patches, *patchesDir, `Path to a directory that contains files named `+
+		`"target[suffix][+patchtype].extension". For example, `+
+		`"kube-apiserver0+merge.yaml" or just "etcd.json". `+
+		`"patchtype" can be one of "strategic", "merge" or "json" and they match the patch formats `+
+		`supported by kubectl. The default "patchtype" is "strategic". "extension" must be either `+
+		`"json" or "yaml". "suffix" is an optional string that can be used to determine `+
+		`which patches are applied first alpha-numerically.`,
+	)
+}

--- a/cmd/kubeadm/app/cmd/phases/init/controlplane.go
+++ b/cmd/kubeadm/app/cmd/phases/init/controlplane.go
@@ -145,6 +145,6 @@ func runControlPlaneSubphase(component string) func(c workflow.RunData) error {
 		cfg := data.Cfg()
 
 		fmt.Printf("[control-plane] Creating static Pod manifest for %q\n", component)
-		return controlplane.CreateStaticPodFiles(data.ManifestDir(), data.KustomizeDir(), &cfg.ClusterConfiguration, &cfg.LocalAPIEndpoint, component)
+		return controlplane.CreateStaticPodFiles(data.ManifestDir(), data.KustomizeDir(), data.PatchesDir(), &cfg.ClusterConfiguration, &cfg.LocalAPIEndpoint, component)
 	}
 }

--- a/cmd/kubeadm/app/cmd/phases/init/data.go
+++ b/cmd/kubeadm/app/cmd/phases/init/data.go
@@ -46,4 +46,5 @@ type InitData interface {
 	Client() (clientset.Interface, error)
 	Tokens() []string
 	KustomizeDir() string
+	PatchesDir() string
 }

--- a/cmd/kubeadm/app/cmd/phases/init/data_test.go
+++ b/cmd/kubeadm/app/cmd/phases/init/data_test.go
@@ -49,3 +49,4 @@ func (t *testInitData) OutputWriter() io.Writer              { return nil }
 func (t *testInitData) Client() (clientset.Interface, error) { return nil, nil }
 func (t *testInitData) Tokens() []string                     { return nil }
 func (t *testInitData) KustomizeDir() string                 { return "" }
+func (t *testInitData) PatchesDir() string                   { return "" }

--- a/cmd/kubeadm/app/cmd/phases/init/etcd.go
+++ b/cmd/kubeadm/app/cmd/phases/init/etcd.go
@@ -70,6 +70,7 @@ func getEtcdPhaseFlags() []string {
 		options.CfgPath,
 		options.ImageRepository,
 		options.Kustomize,
+		options.Patches,
 	}
 	return flags
 }
@@ -93,7 +94,7 @@ func runEtcdPhaseLocal() func(c workflow.RunData) error {
 				fmt.Printf("[dryrun] Would ensure that %q directory is present\n", cfg.Etcd.Local.DataDir)
 			}
 			fmt.Printf("[etcd] Creating static Pod manifest for local etcd in %q\n", data.ManifestDir())
-			if err := etcdphase.CreateLocalEtcdStaticPodManifestFile(data.ManifestDir(), data.KustomizeDir(), cfg.NodeRegistration.Name, &cfg.ClusterConfiguration, &cfg.LocalAPIEndpoint); err != nil {
+			if err := etcdphase.CreateLocalEtcdStaticPodManifestFile(data.ManifestDir(), data.KustomizeDir(), data.PatchesDir(), cfg.NodeRegistration.Name, &cfg.ClusterConfiguration, &cfg.LocalAPIEndpoint); err != nil {
 				return errors.Wrap(err, "error creating local etcd static pod manifest file")
 			}
 		} else {

--- a/cmd/kubeadm/app/cmd/phases/join/controlplanejoin.go
+++ b/cmd/kubeadm/app/cmd/phases/join/controlplanejoin.go
@@ -43,7 +43,7 @@ func getControlPlaneJoinPhaseFlags(name string) []string {
 		options.NodeName,
 	}
 	if name == "etcd" {
-		flags = append(flags, options.Kustomize)
+		flags = append(flags, options.Kustomize, options.Patches)
 	}
 	if name != "mark-control-plane" {
 		flags = append(flags, options.APIServerAdvertiseAddress)
@@ -139,8 +139,9 @@ func runEtcdPhase(c workflow.RunData) error {
 	// From https://coreos.com/etcd/docs/latest/v2/runtime-configuration.html
 	// "If you add a new member to a 1-node cluster, the cluster cannot make progress before the new member starts
 	// because it needs two members as majority to agree on the consensus. You will only see this behavior between the time
-	// etcdctl member add informs the cluster about the new member and the new member successfully establishing a connection to the 	// existing one."
-	if err := etcdphase.CreateStackedEtcdStaticPodManifestFile(client, kubeadmconstants.GetStaticPodDirectory(), data.KustomizeDir(), cfg.NodeRegistration.Name, &cfg.ClusterConfiguration, &cfg.LocalAPIEndpoint); err != nil {
+	// etcdctl member add informs the cluster about the new member and the new member successfully establishing a connection to the
+	// existing one."
+	if err := etcdphase.CreateStackedEtcdStaticPodManifestFile(client, kubeadmconstants.GetStaticPodDirectory(), data.KustomizeDir(), data.PatchesDir(), cfg.NodeRegistration.Name, &cfg.ClusterConfiguration, &cfg.LocalAPIEndpoint); err != nil {
 		return errors.Wrap(err, "error creating local etcd static pod manifest file")
 	}
 

--- a/cmd/kubeadm/app/cmd/phases/join/controlplaneprepare.go
+++ b/cmd/kubeadm/app/cmd/phases/join/controlplaneprepare.go
@@ -79,6 +79,7 @@ func getControlPlanePreparePhaseFlags(name string) []string {
 			options.TokenStr,
 			options.CertificateKey,
 			options.Kustomize,
+			options.Patches,
 		}
 	case "download-certs":
 		flags = []string{
@@ -124,6 +125,7 @@ func getControlPlanePreparePhaseFlags(name string) []string {
 			options.CfgPath,
 			options.ControlPlane,
 			options.Kustomize,
+			options.Patches,
 		}
 	default:
 		flags = []string{}
@@ -190,6 +192,7 @@ func runControlPlanePrepareControlPlaneSubphase(c workflow.RunData) error {
 		err := controlplane.CreateStaticPodFiles(
 			kubeadmconstants.GetStaticPodDirectory(),
 			data.KustomizeDir(),
+			data.PatchesDir(),
 			&cfg.ClusterConfiguration,
 			&cfg.LocalAPIEndpoint,
 			component,

--- a/cmd/kubeadm/app/cmd/phases/join/data.go
+++ b/cmd/kubeadm/app/cmd/phases/join/data.go
@@ -36,4 +36,5 @@ type JoinData interface {
 	IgnorePreflightErrors() sets.String
 	OutputWriter() io.Writer
 	KustomizeDir() string
+	PatchesDir() string
 }

--- a/cmd/kubeadm/app/cmd/phases/join/data_test.go
+++ b/cmd/kubeadm/app/cmd/phases/join/data_test.go
@@ -39,3 +39,4 @@ func (j *testJoinData) ClientSet() (*clientset.Clientset, error)        { return
 func (j *testJoinData) IgnorePreflightErrors() sets.String              { return nil }
 func (j *testJoinData) OutputWriter() io.Writer                         { return nil }
 func (j *testJoinData) KustomizeDir() string                            { return "" }
+func (j *testJoinData) PatchesDir() string                              { return "" }

--- a/cmd/kubeadm/app/cmd/phases/upgrade/node/data.go
+++ b/cmd/kubeadm/app/cmd/phases/upgrade/node/data.go
@@ -34,4 +34,5 @@ type Data interface {
 	Client() clientset.Interface
 	IgnorePreflightErrors() sets.String
 	KustomizeDir() string
+	PatchesDir() string
 }

--- a/cmd/kubeadm/app/cmd/upgrade/apply.go
+++ b/cmd/kubeadm/app/cmd/upgrade/apply.go
@@ -52,6 +52,7 @@ type applyFlags struct {
 	renewCerts         bool
 	imagePullTimeout   time.Duration
 	kustomizeDir       string
+	patchesDir         string
 }
 
 // sessionIsInteractive returns true if the session is of an interactive type (the default, can be opted out of with -y, -f or --dry-run)
@@ -94,6 +95,7 @@ func NewCmdApply(apf *applyPlanFlags) *cobra.Command {
 	// TODO: The flag was deprecated in 1.19; remove the flag following a GA deprecation policy of 12 months or 2 releases (whichever is longer)
 	cmd.Flags().MarkDeprecated("image-pull-timeout", "This flag is deprecated and will be removed in a future version.")
 	options.AddKustomizePodsFlag(cmd.Flags(), &flags.kustomizeDir)
+	options.AddPatchesFlag(cmd.Flags(), &flags.patchesDir)
 
 	return cmd
 }
@@ -220,8 +222,8 @@ func PerformControlPlaneUpgrade(flags *applyFlags, client clientset.Interface, w
 	fmt.Printf("[upgrade/apply] Upgrading your Static Pod-hosted control plane to version %q...\n", internalcfg.KubernetesVersion)
 
 	if flags.dryRun {
-		return upgrade.DryRunStaticPodUpgrade(flags.kustomizeDir, internalcfg)
+		return upgrade.DryRunStaticPodUpgrade(flags.kustomizeDir, flags.patchesDir, internalcfg)
 	}
 
-	return upgrade.PerformStaticPodUpgrade(client, waiter, internalcfg, flags.etcdUpgrade, flags.renewCerts, flags.kustomizeDir)
+	return upgrade.PerformStaticPodUpgrade(client, waiter, internalcfg, flags.etcdUpgrade, flags.renewCerts, flags.kustomizeDir, flags.patchesDir)
 }

--- a/cmd/kubeadm/app/cmd/upgrade/node.go
+++ b/cmd/kubeadm/app/cmd/upgrade/node.go
@@ -44,6 +44,7 @@ type nodeOptions struct {
 	renewCerts            bool
 	dryRun                bool
 	kustomizeDir          string
+	patchesDir            string
 	ignorePreflightErrors []string
 }
 
@@ -61,6 +62,7 @@ type nodeData struct {
 	isControlPlaneNode    bool
 	client                clientset.Interface
 	kustomizeDir          string
+	patchesDir            string
 	ignorePreflightErrors sets.String
 }
 
@@ -82,6 +84,7 @@ func NewCmdNode() *cobra.Command {
 	// flags could be eventually inherited by the sub-commands automatically generated for phases
 	addUpgradeNodeFlags(cmd.Flags(), nodeOptions)
 	options.AddKustomizePodsFlag(cmd.Flags(), &nodeOptions.kustomizeDir)
+	options.AddPatchesFlag(cmd.Flags(), &nodeOptions.patchesDir)
 
 	// initialize the workflow runner with the list of phases
 	nodeRunner.AppendPhase(phases.NewPreflightPhase())
@@ -162,6 +165,7 @@ func newNodeData(cmd *cobra.Command, args []string, options *nodeOptions) (*node
 		client:                client,
 		isControlPlaneNode:    isControlPlaneNode,
 		kustomizeDir:          options.kustomizeDir,
+		patchesDir:            options.patchesDir,
 		ignorePreflightErrors: ignorePreflightErrorsSet,
 	}, nil
 }
@@ -204,6 +208,11 @@ func (d *nodeData) Client() clientset.Interface {
 // KustomizeDir returns the folder where kustomize patches for static pod manifest are stored
 func (d *nodeData) KustomizeDir() string {
 	return d.kustomizeDir
+}
+
+// PatchesDir returns the folder where patches for components are stored
+func (d *nodeData) PatchesDir() string {
+	return d.patchesDir
 }
 
 // IgnorePreflightErrors returns the list of preflight errors to ignore.

--- a/cmd/kubeadm/app/phases/controlplane/manifests.go
+++ b/cmd/kubeadm/app/phases/controlplane/manifests.go
@@ -37,9 +37,9 @@ import (
 )
 
 // CreateInitStaticPodManifestFiles will write all static pod manifest files needed to bring up the control plane.
-func CreateInitStaticPodManifestFiles(manifestDir, kustomizeDir string, cfg *kubeadmapi.InitConfiguration) error {
+func CreateInitStaticPodManifestFiles(manifestDir, kustomizeDir, patchesDir string, cfg *kubeadmapi.InitConfiguration) error {
 	klog.V(1).Infoln("[control-plane] creating static Pod files")
-	return CreateStaticPodFiles(manifestDir, kustomizeDir, &cfg.ClusterConfiguration, &cfg.LocalAPIEndpoint, kubeadmconstants.KubeAPIServer, kubeadmconstants.KubeControllerManager, kubeadmconstants.KubeScheduler)
+	return CreateStaticPodFiles(manifestDir, kustomizeDir, patchesDir, &cfg.ClusterConfiguration, &cfg.LocalAPIEndpoint, kubeadmconstants.KubeAPIServer, kubeadmconstants.KubeControllerManager, kubeadmconstants.KubeScheduler)
 }
 
 // GetStaticPodSpecs returns all staticPodSpecs actualized to the context of the current configuration
@@ -90,7 +90,7 @@ func GetStaticPodSpecs(cfg *kubeadmapi.ClusterConfiguration, endpoint *kubeadmap
 }
 
 // CreateStaticPodFiles creates all the requested static pod files.
-func CreateStaticPodFiles(manifestDir, kustomizeDir string, cfg *kubeadmapi.ClusterConfiguration, endpoint *kubeadmapi.APIEndpoint, componentNames ...string) error {
+func CreateStaticPodFiles(manifestDir, kustomizeDir, patchesDir string, cfg *kubeadmapi.ClusterConfiguration, endpoint *kubeadmapi.APIEndpoint, componentNames ...string) error {
 	// gets the StaticPodSpecs, actualized for the current ClusterConfiguration
 	klog.V(1).Infoln("[control-plane] getting StaticPodSpecs")
 	specs := GetStaticPodSpecs(cfg, endpoint)

--- a/cmd/kubeadm/app/phases/controlplane/manifests.go
+++ b/cmd/kubeadm/app/phases/controlplane/manifests.go
@@ -19,6 +19,7 @@ package controlplane
 import (
 	"fmt"
 	"net"
+	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -115,6 +116,15 @@ func CreateStaticPodFiles(manifestDir, kustomizeDir, patchesDir string, cfg *kub
 				return errors.Wrapf(err, "failed to kustomize static pod manifest file for %q", componentName)
 			}
 			spec = *kustomizedSpec
+		}
+
+		// if patchesDir is defined, patch the static Pod manifest
+		if patchesDir != "" {
+			patchedSpec, err := staticpodutil.PatchStaticPod(&spec, patchesDir, os.Stdout)
+			if err != nil {
+				return errors.Wrapf(err, "failed to patch static Pod manifest file for %q", componentName)
+			}
+			spec = *patchedSpec
 		}
 
 		// writes the StaticPodSpec to disk

--- a/cmd/kubeadm/app/phases/controlplane/manifests_test.go
+++ b/cmd/kubeadm/app/phases/controlplane/manifests_test.go
@@ -125,7 +125,7 @@ func TestCreateStaticPodFilesAndWrappers(t *testing.T) {
 
 			// Execute createStaticPodFunction
 			manifestPath := filepath.Join(tmpdir, kubeadmconstants.ManifestsSubDirName)
-			err := CreateStaticPodFiles(manifestPath, "", cfg, &kubeadmapi.APIEndpoint{}, test.components...)
+			err := CreateStaticPodFiles(manifestPath, "", "", cfg, &kubeadmapi.APIEndpoint{}, test.components...)
 			if err != nil {
 				t.Errorf("Error executing createStaticPodFunction: %v", err)
 				return
@@ -174,7 +174,7 @@ func TestCreateStaticPodFilesKustomize(t *testing.T) {
 
 	// Execute createStaticPodFunction with kustomizations
 	manifestPath := filepath.Join(tmpdir, kubeadmconstants.ManifestsSubDirName)
-	err = CreateStaticPodFiles(manifestPath, kustomizePath, cfg, &kubeadmapi.APIEndpoint{}, kubeadmconstants.KubeAPIServer)
+	err = CreateStaticPodFiles(manifestPath, kustomizePath, "", cfg, &kubeadmapi.APIEndpoint{}, kubeadmconstants.KubeAPIServer)
 	if err != nil {
 		t.Errorf("Error executing createStaticPodFunction: %v", err)
 		return

--- a/cmd/kubeadm/app/phases/etcd/local.go
+++ b/cmd/kubeadm/app/phases/etcd/local.go
@@ -19,6 +19,7 @@ package etcd
 import (
 	"fmt"
 	"net"
+	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -62,6 +63,15 @@ func CreateLocalEtcdStaticPodManifestFile(manifestDir, kustomizeDir, patchesDir 
 			return errors.Wrapf(err, "failed to kustomize static pod manifest file for %q", kubeadmconstants.Etcd)
 		}
 		spec = *kustomizedSpec
+	}
+
+	// if patchesDir is defined, patch the static Pod manifest
+	if patchesDir != "" {
+		patchedSpec, err := staticpodutil.PatchStaticPod(&spec, patchesDir, os.Stdout)
+		if err != nil {
+			return errors.Wrapf(err, "failed to patch static Pod manifest file for %q", kubeadmconstants.Etcd)
+		}
+		spec = *patchedSpec
 	}
 
 	// writes etcd StaticPod to disk
@@ -172,6 +182,15 @@ func CreateStackedEtcdStaticPodManifestFile(client clientset.Interface, manifest
 			return errors.Wrapf(err, "failed to kustomize static pod manifest file for %q", kubeadmconstants.Etcd)
 		}
 		spec = *kustomizedSpec
+	}
+
+	// if patchesDir is defined, patch the static Pod manifest
+	if patchesDir != "" {
+		patchedSpec, err := staticpodutil.PatchStaticPod(&spec, patchesDir, os.Stdout)
+		if err != nil {
+			return errors.Wrapf(err, "failed to patch static Pod manifest file for %q", kubeadmconstants.Etcd)
+		}
+		spec = *patchedSpec
 	}
 
 	// writes etcd StaticPod to disk

--- a/cmd/kubeadm/app/phases/etcd/local.go
+++ b/cmd/kubeadm/app/phases/etcd/local.go
@@ -48,7 +48,7 @@ const (
 // CreateLocalEtcdStaticPodManifestFile will write local etcd static pod manifest file.
 // This function is used by init - when the etcd cluster is empty - or by kubeadm
 // upgrade - when the etcd cluster is already up and running (and the --initial-cluster flag have no impact)
-func CreateLocalEtcdStaticPodManifestFile(manifestDir, kustomizeDir string, nodeName string, cfg *kubeadmapi.ClusterConfiguration, endpoint *kubeadmapi.APIEndpoint) error {
+func CreateLocalEtcdStaticPodManifestFile(manifestDir, kustomizeDir, patchesDir string, nodeName string, cfg *kubeadmapi.ClusterConfiguration, endpoint *kubeadmapi.APIEndpoint) error {
 	if cfg.Etcd.External != nil {
 		return errors.New("etcd static pod manifest cannot be generated for cluster using external etcd")
 	}
@@ -141,7 +141,7 @@ func RemoveStackedEtcdMemberFromCluster(client clientset.Interface, cfg *kubeadm
 // CreateStackedEtcdStaticPodManifestFile will write local etcd static pod manifest file
 // for an additional etcd member that is joining an existing local/stacked etcd cluster.
 // Other members of the etcd cluster will be notified of the joining node in beforehand as well.
-func CreateStackedEtcdStaticPodManifestFile(client clientset.Interface, manifestDir, kustomizeDir string, nodeName string, cfg *kubeadmapi.ClusterConfiguration, endpoint *kubeadmapi.APIEndpoint) error {
+func CreateStackedEtcdStaticPodManifestFile(client clientset.Interface, manifestDir, kustomizeDir, patchesDir string, nodeName string, cfg *kubeadmapi.ClusterConfiguration, endpoint *kubeadmapi.APIEndpoint) error {
 	// creates an etcd client that connects to all the local/stacked etcd members
 	klog.V(1).Info("creating etcd client that connects to etcd pods")
 	etcdClient, err := etcdutil.NewFromCluster(client, cfg.CertificatesDir)

--- a/cmd/kubeadm/app/phases/etcd/local_test.go
+++ b/cmd/kubeadm/app/phases/etcd/local_test.go
@@ -166,6 +166,56 @@ func TestCreateLocalEtcdStaticPodManifestFileKustomize(t *testing.T) {
 	}
 }
 
+func TestCreateLocalEtcdStaticPodManifestFileWithPatches(t *testing.T) {
+	// Create temp folder for the test case
+	tmpdir := testutil.SetupTempDir(t)
+	defer os.RemoveAll(tmpdir)
+
+	// Creates a Cluster Configuration
+	cfg := &kubeadmapi.ClusterConfiguration{
+		KubernetesVersion: "v1.7.0",
+		Etcd: kubeadmapi.Etcd{
+			Local: &kubeadmapi.LocalEtcd{
+				DataDir: tmpdir + "/etcd",
+			},
+		},
+	}
+
+	patchesPath := filepath.Join(tmpdir, "patch-files")
+	err := os.MkdirAll(patchesPath, 0777)
+	if err != nil {
+		t.Fatalf("Couldn't create %s", patchesPath)
+	}
+
+	patchString := dedent.Dedent(`
+	metadata:
+	  annotations:
+	    patched: "true"
+	`)
+
+	err = ioutil.WriteFile(filepath.Join(patchesPath, kubeadmconstants.Etcd+".yaml"), []byte(patchString), 0644)
+	if err != nil {
+		t.Fatalf("WriteFile returned unexpected error: %v", err)
+	}
+
+	manifestPath := filepath.Join(tmpdir, kubeadmconstants.ManifestsSubDirName)
+	err = CreateLocalEtcdStaticPodManifestFile(manifestPath, "", patchesPath, "", cfg, &kubeadmapi.APIEndpoint{})
+	if err != nil {
+		t.Errorf("Error executing createStaticPodFunction: %v", err)
+		return
+	}
+
+	pod, err := staticpodutil.ReadStaticPodFromDisk(filepath.Join(manifestPath, kubeadmconstants.Etcd+".yaml"))
+	if err != nil {
+		t.Errorf("Error executing ReadStaticPodFromDisk: %v", err)
+		return
+	}
+
+	if _, ok := pod.ObjectMeta.Annotations["patched"]; !ok {
+		t.Errorf("Patches were not applied to %s", kubeadmconstants.Etcd)
+	}
+}
+
 func TestGetEtcdCommand(t *testing.T) {
 	var tests = []struct {
 		name             string

--- a/cmd/kubeadm/app/phases/etcd/local_test.go
+++ b/cmd/kubeadm/app/phases/etcd/local_test.go
@@ -96,7 +96,7 @@ func TestCreateLocalEtcdStaticPodManifestFile(t *testing.T) {
 	for _, test := range tests {
 		// Execute createStaticPodFunction
 		manifestPath := filepath.Join(tmpdir, kubeadmconstants.ManifestsSubDirName)
-		err := CreateLocalEtcdStaticPodManifestFile(manifestPath, "", "", test.cfg, &kubeadmapi.APIEndpoint{})
+		err := CreateLocalEtcdStaticPodManifestFile(manifestPath, "", "", "", test.cfg, &kubeadmapi.APIEndpoint{})
 
 		if !test.expectedError {
 			if err != nil {
@@ -149,7 +149,7 @@ func TestCreateLocalEtcdStaticPodManifestFileKustomize(t *testing.T) {
 
 	// Execute createStaticPodFunction with kustomizations
 	manifestPath := filepath.Join(tmpdir, kubeadmconstants.ManifestsSubDirName)
-	err = CreateLocalEtcdStaticPodManifestFile(manifestPath, kustomizePath, "", cfg, &kubeadmapi.APIEndpoint{})
+	err = CreateLocalEtcdStaticPodManifestFile(manifestPath, kustomizePath, "", "", cfg, &kubeadmapi.APIEndpoint{})
 	if err != nil {
 		t.Errorf("Error executing createStaticPodFunction: %v", err)
 		return

--- a/cmd/kubeadm/app/util/BUILD
+++ b/cmd/kubeadm/app/util/BUILD
@@ -89,6 +89,7 @@ filegroup(
         "//cmd/kubeadm/app/util/kubeconfig:all-srcs",
         "//cmd/kubeadm/app/util/kustomize:all-srcs",
         "//cmd/kubeadm/app/util/output:all-srcs",
+        "//cmd/kubeadm/app/util/patches:all-srcs",
         "//cmd/kubeadm/app/util/pkiutil:all-srcs",
         "//cmd/kubeadm/app/util/pubkeypin:all-srcs",
         "//cmd/kubeadm/app/util/runtime:all-srcs",

--- a/cmd/kubeadm/app/util/patches/BUILD
+++ b/cmd/kubeadm/app/util/patches/BUILD
@@ -1,0 +1,40 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["patches.go"],
+    importpath = "k8s.io/kubernetes/cmd/kubeadm/app/util/patches",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/strategicpatch:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/yaml:go_default_library",
+        "//vendor/github.com/evanphx/json-patch:go_default_library",
+        "//vendor/github.com/pkg/errors:go_default_library",
+        "//vendor/sigs.k8s.io/yaml:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["patches_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//staging/src/k8s.io/api/core/v1:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/cmd/kubeadm/app/util/patches/patches.go
+++ b/cmd/kubeadm/app/util/patches/patches.go
@@ -1,0 +1,342 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package patches
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"sync"
+
+	jsonpatch "github.com/evanphx/json-patch"
+	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/strategicpatch"
+	utilyaml "k8s.io/apimachinery/pkg/util/yaml"
+	"sigs.k8s.io/yaml"
+)
+
+// PatchTarget defines a target to be patched, such as a control-plane static Pod.
+type PatchTarget struct {
+	// Name must be the name of a known target. In the case of Kubernetes objects
+	// this is likely to match the ObjectMeta.Name of a target.
+	Name string
+
+	// StrategicMergePatchObject is only used for strategic merge patches.
+	// It represents the underlying object type that is patched - e.g. "v1.Pod"
+	StrategicMergePatchObject interface{}
+
+	// Data must contain the bytes that will be patched.
+	Data []byte
+}
+
+// PatchManager defines an object that can apply patches.
+type PatchManager struct {
+	patchSets    []*patchSet
+	knownTargets []string
+	output       io.Writer
+}
+
+// patchSet defines a set of patches of a certain type that can patch a PatchTarget.
+type patchSet struct {
+	targetName string
+	patchType  types.PatchType
+	patches    []string
+}
+
+// String() is used for unit-testing.
+func (ps *patchSet) String() string {
+	return fmt.Sprintf(
+		"{%q, %q, %#v}",
+		ps.targetName,
+		ps.patchType,
+		ps.patches,
+	)
+}
+
+var (
+	pathLock  = &sync.RWMutex{}
+	pathCache = map[string]*PatchManager{}
+
+	patchTypes = map[string]types.PatchType{
+		"json":      types.JSONPatchType,
+		"merge":     types.MergePatchType,
+		"strategic": types.StrategicMergePatchType,
+		"":          types.StrategicMergePatchType, // Default
+	}
+	patchTypeList    = []string{"json", "merge", "strategic"}
+	patchTypesJoined = strings.Join(patchTypeList, "|")
+	knownExtensions  = []string{"json", "yaml"}
+
+	regExtension = regexp.MustCompile(`.+\.(` + strings.Join(knownExtensions, "|") + `)$`)
+)
+
+// GetPatchManagerForPath creates a patch manager that can be used to apply patches to "knownTargets".
+// "path" should contain patches that can be used to patch the "knownTargets".
+// If "output" is non-nil, messages about actions performed by the manager would go on this io.Writer.
+func GetPatchManagerForPath(path string, knownTargets []string, output io.Writer) (*PatchManager, error) {
+	pathLock.RLock()
+	if pm, known := pathCache[path]; known {
+		pathLock.RUnlock()
+		return pm, nil
+	}
+	pathLock.RUnlock()
+
+	if output == nil {
+		output = ioutil.Discard
+	}
+
+	fmt.Fprintf(output, "[patches] Reading patches from path %q\n", path)
+
+	// Get the files in the path.
+	patchSets, patchFiles, ignoredFiles, err := getPatchSetsFromPath(path, knownTargets, output)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(patchFiles) > 0 {
+		fmt.Fprintf(output, "[patches] Found the following patch files: %v\n", patchFiles)
+	}
+	if len(ignoredFiles) > 0 {
+		fmt.Fprintf(output, "[patches] Ignored the following files: %v\n", ignoredFiles)
+	}
+
+	pm := &PatchManager{
+		patchSets:    patchSets,
+		knownTargets: knownTargets,
+		output:       output,
+	}
+	pathLock.Lock()
+	pathCache[path] = pm
+	pathLock.Unlock()
+
+	return pm, nil
+}
+
+// ApplyPatchesToTarget takes a patch target and patches its "Data" using the patches
+// stored in the patch manager. The resulted "Data" is always converted to JSON.
+func (pm *PatchManager) ApplyPatchesToTarget(patchTarget *PatchTarget) error {
+	var err error
+	var patchedData []byte
+
+	var found bool
+	for _, pt := range pm.knownTargets {
+		if pt == patchTarget.Name {
+			found = true
+			break
+		}
+	}
+	if !found {
+		return errors.Errorf("unknown patch target name %q, must be one of %v", patchTarget.Name, pm.knownTargets)
+	}
+
+	// Always convert the target data to JSON.
+	patchedData, err = yaml.YAMLToJSON(patchTarget.Data)
+	if err != nil {
+		return err
+	}
+
+	// Iterate over the patchSets.
+	for _, patchSet := range pm.patchSets {
+		if patchSet.targetName != patchTarget.Name {
+			continue
+		}
+
+		// Iterate over the patches in the patchSets.
+		for _, patch := range patchSet.patches {
+			patchBytes := []byte(patch)
+
+			// Patch based on the patch type.
+			switch patchSet.patchType {
+
+			// JSON patch.
+			case types.JSONPatchType:
+				var patchObj jsonpatch.Patch
+				patchObj, err = jsonpatch.DecodePatch(patchBytes)
+				if err == nil {
+					patchedData, err = patchObj.Apply(patchedData)
+				}
+
+			// Merge patch.
+			case types.MergePatchType:
+				patchedData, err = jsonpatch.MergePatch(patchedData, patchBytes)
+
+			// Strategic merge patch.
+			case types.StrategicMergePatchType:
+				patchedData, err = strategicpatch.StrategicMergePatch(
+					patchedData,
+					patchBytes,
+					patchTarget.StrategicMergePatchObject,
+				)
+			}
+
+			if err != nil {
+				return errors.Wrapf(err, "could not apply the following patch of type %q to target %q:\n%s\n",
+					patchSet.patchType,
+					patchTarget.Name,
+					patch)
+			}
+			fmt.Fprintf(pm.output, "[patches] Applied patch of type %q to target %q\n", patchSet.patchType, patchTarget.Name)
+		}
+
+		// Update the data for this patch target.
+		patchTarget.Data = patchedData
+	}
+
+	return nil
+}
+
+// parseFilename validates a file name and retrieves the encoded target name and patch type.
+// - On unknown extension or target name it returns a warning
+// - On unknown patch type it returns an error
+// - On success it returns a target name and patch type
+func parseFilename(fileName string, knownTargets []string) (string, types.PatchType, error, error) {
+	// Return a warning if the extension cannot be matched.
+	if !regExtension.MatchString(fileName) {
+		return "", "", errors.Errorf("the file extension must be one of %v", knownExtensions), nil
+	}
+
+	regFileNameSplit := regexp.MustCompile(
+		fmt.Sprintf(`^(%s)([^.+\n]*)?(\+)?(%s)?`, strings.Join(knownTargets, "|"), patchTypesJoined),
+	)
+	// Extract the target name and patch type. The resulting sub-string slice would look like this:
+	//   [full-match, targetName, suffix, +, patchType]
+	sub := regFileNameSplit.FindStringSubmatch(fileName)
+	if sub == nil {
+		return "", "", errors.Errorf("unknown target, must be one of %v", knownTargets), nil
+	}
+	targetName := sub[1]
+
+	if len(sub[3]) > 0 && len(sub[4]) == 0 {
+		return "", "", nil, errors.Errorf("unknown or missing patch type after '+', must be one of %v", patchTypeList)
+	}
+	patchType := patchTypes[sub[4]]
+
+	return targetName, patchType, nil, nil
+}
+
+// createPatchSet creates a patchSet object, by splitting the given "data" by "\n---".
+func createPatchSet(targetName string, patchType types.PatchType, data string) (*patchSet, error) {
+	var patches []string
+
+	// Split the patches and convert them to JSON.
+	// Data that is already JSON will not cause an error.
+	buf := bytes.NewBuffer([]byte(data))
+	reader := utilyaml.NewYAMLReader(bufio.NewReader(buf))
+	for {
+		patch, err := reader.Read()
+		if err == io.EOF {
+			break
+		} else if err != nil {
+			return nil, errors.Wrapf(err, "could not split patches for data:\n%s\n", data)
+		}
+
+		patch = bytes.TrimSpace(patch)
+		if len(patch) == 0 {
+			continue
+		}
+
+		patchJSON, err := yaml.YAMLToJSON(patch)
+		if err != nil {
+			return nil, errors.Wrapf(err, "could not convert patch to JSON:\n%s\n", patch)
+		}
+		patches = append(patches, string(patchJSON))
+	}
+
+	return &patchSet{
+		targetName: targetName,
+		patchType:  patchType,
+		patches:    patches,
+	}, nil
+}
+
+// getPatchSetsFromPath walks a path, ignores sub-directories and non-patch files, and
+// returns a list of patchFile objects.
+func getPatchSetsFromPath(targetPath string, knownTargets []string, output io.Writer) ([]*patchSet, []string, []string, error) {
+	patchFiles := []string{}
+	ignoredFiles := []string{}
+	patchSets := []*patchSet{}
+
+	// Check if targetPath is a directory.
+	info, err := os.Lstat(targetPath)
+	if err != nil {
+		goto return_path_error
+	}
+	if !info.IsDir() {
+		err = errors.New("not a directory")
+		goto return_path_error
+	}
+
+	err = filepath.Walk(targetPath, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		// Sub-directories and "." are ignored.
+		if info.IsDir() {
+			return nil
+		}
+
+		baseName := info.Name()
+
+		// Parse the filename and retrieve the target and patch type
+		targetName, patchType, warn, err := parseFilename(baseName, knownTargets)
+		if err != nil {
+			return err
+		}
+		if warn != nil {
+			fmt.Fprintf(output, "[patches] Ignoring file %q: %v\n", baseName, warn)
+			ignoredFiles = append(ignoredFiles, baseName)
+			return nil
+		}
+
+		// Read the patch file.
+		data, err := ioutil.ReadFile(path)
+		if err != nil {
+			return errors.Wrapf(err, "could not read the file %q", path)
+		}
+
+		if len(data) == 0 {
+			fmt.Fprintf(output, "[patches] Ignoring empty file: %q\n", baseName)
+			ignoredFiles = append(ignoredFiles, baseName)
+			return nil
+		}
+
+		// Create a patchSet object.
+		patchSet, err := createPatchSet(targetName, patchType, string(data))
+		if err != nil {
+			return err
+		}
+
+		patchFiles = append(patchFiles, baseName)
+		patchSets = append(patchSets, patchSet)
+		return nil
+	})
+
+return_path_error:
+	if err != nil {
+		return nil, nil, nil, errors.Wrapf(err, "could not list patch files for path %q", targetPath)
+	}
+
+	return patchSets, patchFiles, ignoredFiles, nil
+}

--- a/cmd/kubeadm/app/util/patches/patches_test.go
+++ b/cmd/kubeadm/app/util/patches/patches_test.go
@@ -1,0 +1,413 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package patches
+
+import (
+	"bytes"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+var testKnownTargets = []string{
+	"etcd",
+	"kube-apiserver",
+	"kube-controller-manager",
+	"kube-scheduler",
+}
+
+const testDirPattern = "patch-files"
+
+func TestParseFilename(t *testing.T) {
+	tests := []struct {
+		name               string
+		fileName           string
+		expectedTargetName string
+		expectedPatchType  types.PatchType
+		expectedWarning    bool
+		expectedError      bool
+	}{
+		{
+			name:               "valid: known target and patch type",
+			fileName:           "etcd+merge.json",
+			expectedTargetName: "etcd",
+			expectedPatchType:  types.MergePatchType,
+		},
+		{
+			name:               "valid: known target and default patch type",
+			fileName:           "etcd0.yaml",
+			expectedTargetName: "etcd",
+			expectedPatchType:  types.StrategicMergePatchType,
+		},
+		{
+			name:               "valid: known target and custom patch type",
+			fileName:           "etcd0+merge.yaml",
+			expectedTargetName: "etcd",
+			expectedPatchType:  types.MergePatchType,
+		},
+		{
+			name:            "invalid: unknown target",
+			fileName:        "foo.yaml",
+			expectedWarning: true,
+		},
+		{
+			name:            "invalid: unknown extension",
+			fileName:        "etcd.foo",
+			expectedWarning: true,
+		},
+		{
+			name:            "invalid: missing extension",
+			fileName:        "etcd",
+			expectedWarning: true,
+		},
+		{
+			name:          "invalid: unknown patch type",
+			fileName:      "etcd+foo.json",
+			expectedError: true,
+		},
+		{
+			name:          "invalid: missing patch type",
+			fileName:      "etcd+.json",
+			expectedError: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			targetName, patchType, warn, err := parseFilename(tc.fileName, testKnownTargets)
+			if (err != nil) != tc.expectedError {
+				t.Errorf("expected error: %v, got: %v, error: %v", tc.expectedError, err != nil, err)
+			}
+			if (warn != nil) != tc.expectedWarning {
+				t.Errorf("expected warning: %v, got: %v, warning: %v", tc.expectedWarning, warn != nil, warn)
+			}
+			if targetName != tc.expectedTargetName {
+				t.Errorf("expected target name: %v, got: %v", tc.expectedTargetName, targetName)
+			}
+			if patchType != tc.expectedPatchType {
+				t.Errorf("expected patch type: %v, got: %v", tc.expectedPatchType, patchType)
+			}
+		})
+	}
+}
+
+func TestCreatePatchSet(t *testing.T) {
+	tests := []struct {
+		name             string
+		targetName       string
+		patchType        types.PatchType
+		expectedPatchSet *patchSet
+		data             string
+	}{
+		{
+
+			name:       "valid: YAML patches are separated and converted to JSON",
+			targetName: "etcd",
+			patchType:  types.StrategicMergePatchType,
+			data:       "foo: bar\n---\nfoo: baz\n",
+			expectedPatchSet: &patchSet{
+				targetName: "etcd",
+				patchType:  types.StrategicMergePatchType,
+				patches:    []string{`{"foo":"bar"}`, `{"foo":"baz"}`},
+			},
+		},
+		{
+			name:       "valid: JSON patches are separated",
+			targetName: "etcd",
+			patchType:  types.StrategicMergePatchType,
+			data:       `{"foo":"bar"}` + "\n---\n" + `{"foo":"baz"}`,
+			expectedPatchSet: &patchSet{
+				targetName: "etcd",
+				patchType:  types.StrategicMergePatchType,
+				patches:    []string{`{"foo":"bar"}`, `{"foo":"baz"}`},
+			},
+		},
+		{
+			name:       "valid: empty patches are ignored",
+			targetName: "etcd",
+			patchType:  types.StrategicMergePatchType,
+			data:       `{"foo":"bar"}` + "\n---\n     ---\n" + `{"foo":"baz"}`,
+			expectedPatchSet: &patchSet{
+				targetName: "etcd",
+				patchType:  types.StrategicMergePatchType,
+				patches:    []string{`{"foo":"bar"}`, `{"foo":"baz"}`},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ps, _ := createPatchSet(tc.targetName, tc.patchType, tc.data)
+			if !reflect.DeepEqual(ps, tc.expectedPatchSet) {
+				t.Fatalf("expected patch set:\n%+v\ngot:\n%+v\n", tc.expectedPatchSet, ps)
+			}
+		})
+	}
+}
+
+func TestGetPatchSetsForPathMustBeDirectory(t *testing.T) {
+	tempFile, err := ioutil.TempFile("", "test-file")
+	if err != nil {
+		t.Errorf("error creating temporary file: %v", err)
+	}
+	defer os.Remove(tempFile.Name())
+
+	_, _, _, err = getPatchSetsFromPath(tempFile.Name(), testKnownTargets, ioutil.Discard)
+	if err == nil {
+		t.Fatalf("expected error for non-directory path %q", tempFile.Name())
+	}
+}
+
+func TestGetPatchSetsForPath(t *testing.T) {
+	const patchData = `{"foo":"bar"}`
+
+	tests := []struct {
+		name                 string
+		filesToWrite         []string
+		expectedPatchSets    []*patchSet
+		expectedPatchFiles   []string
+		expectedIgnoredFiles []string
+		expectedError        bool
+		patchData            string
+	}{
+		{
+			name:         "valid: patch files are sorted and non-patch files are ignored",
+			filesToWrite: []string{"kube-scheduler+merge.json", "kube-apiserver+json.yaml", "etcd.yaml", "foo", "bar.json"},
+			patchData:    patchData,
+			expectedPatchSets: []*patchSet{
+				{
+					targetName: "etcd",
+					patchType:  types.StrategicMergePatchType,
+					patches:    []string{patchData},
+				},
+				{
+					targetName: "kube-apiserver",
+					patchType:  types.JSONPatchType,
+					patches:    []string{patchData},
+				},
+				{
+					targetName: "kube-scheduler",
+					patchType:  types.MergePatchType,
+					patches:    []string{patchData},
+				},
+			},
+			expectedPatchFiles:   []string{"etcd.yaml", "kube-apiserver+json.yaml", "kube-scheduler+merge.json"},
+			expectedIgnoredFiles: []string{"bar.json", "foo"},
+		},
+		{
+			name:                 "valid: empty files are ignored",
+			patchData:            "",
+			filesToWrite:         []string{"kube-scheduler.json"},
+			expectedPatchFiles:   []string{},
+			expectedIgnoredFiles: []string{"kube-scheduler.json"},
+			expectedPatchSets:    []*patchSet{},
+		},
+		{
+			name:          "invalid: bad patch type in filename returns and error",
+			filesToWrite:  []string{"kube-scheduler+foo.json"},
+			expectedError: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tempDir, err := ioutil.TempDir("", testDirPattern)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer os.RemoveAll(tempDir)
+
+			for _, file := range tc.filesToWrite {
+				filePath := filepath.Join(tempDir, file)
+				err := ioutil.WriteFile(filePath, []byte(tc.patchData), 0644)
+				if err != nil {
+					t.Fatalf("could not write temporary file %q", filePath)
+				}
+			}
+
+			patchSets, patchFiles, ignoredFiles, err := getPatchSetsFromPath(tempDir, testKnownTargets, ioutil.Discard)
+			if (err != nil) != tc.expectedError {
+				t.Fatalf("expected error: %v, got: %v, error: %v", tc.expectedError, err != nil, err)
+			}
+
+			if !reflect.DeepEqual(tc.expectedPatchFiles, patchFiles) {
+				t.Fatalf("expected patch files:\n%+v\ngot:\n%+v", tc.expectedPatchFiles, patchFiles)
+			}
+			if !reflect.DeepEqual(tc.expectedIgnoredFiles, ignoredFiles) {
+				t.Fatalf("expected ignored files:\n%+v\ngot:\n%+v", tc.expectedIgnoredFiles, ignoredFiles)
+			}
+			if !reflect.DeepEqual(tc.expectedPatchSets, patchSets) {
+				t.Fatalf("expected patch sets:\n%+v\ngot:\n%+v", tc.expectedPatchSets, patchSets)
+			}
+		})
+	}
+}
+
+func TestGetPatchManagerForPath(t *testing.T) {
+	type file struct {
+		name string
+		data string
+	}
+
+	tests := []struct {
+		name          string
+		files         []*file
+		patchTarget   *PatchTarget
+		expectedData  []byte
+		expectedError bool
+	}{
+		{
+			name: "valid: patch a kube-apiserver target using merge patch; json patch is applied first",
+			patchTarget: &PatchTarget{
+				Name:                      "kube-apiserver",
+				StrategicMergePatchObject: v1.Pod{},
+				Data:                      []byte("foo: bar\nbaz: qux\n"),
+			},
+			expectedData: []byte(`{"baz":"qux","foo":"patched"}`),
+			files: []*file{
+				{
+					name: "kube-apiserver+merge.yaml",
+					data: "foo: patched",
+				},
+				{
+					name: "kube-apiserver+json.json",
+					data: `[{"op": "replace", "path": "/foo", "value": "zzz"}]`,
+				},
+			},
+		},
+		{
+			name: "valid: kube-apiserver target is patched with json patch",
+			patchTarget: &PatchTarget{
+				Name:                      "kube-apiserver",
+				StrategicMergePatchObject: v1.Pod{},
+				Data:                      []byte("foo: bar\n"),
+			},
+			expectedData: []byte(`{"foo":"zzz"}`),
+			files: []*file{
+				{
+					name: "kube-apiserver+json.json",
+					data: `[{"op": "replace", "path": "/foo", "value": "zzz"}]`,
+				},
+			},
+		},
+		{
+			name: "valid: kube-apiserver target is patched with strategic merge patch",
+			patchTarget: &PatchTarget{
+				Name:                      "kube-apiserver",
+				StrategicMergePatchObject: v1.Pod{},
+				Data:                      []byte("foo: bar\n"),
+			},
+			expectedData: []byte(`{"foo":"zzz"}`),
+			files: []*file{
+				{
+					name: "kube-apiserver+strategic.json",
+					data: `{"foo":"zzz"}`,
+				},
+			},
+		},
+		{
+			name: "valid: etcd target is not changed because there are no patches for it",
+			patchTarget: &PatchTarget{
+				Name:                      "etcd",
+				StrategicMergePatchObject: v1.Pod{},
+				Data:                      []byte("foo: bar\n"),
+			},
+			expectedData: []byte("foo: bar\n"),
+			files: []*file{
+				{
+					name: "kube-apiserver+merge.yaml",
+					data: "foo: patched",
+				},
+			},
+		},
+		{
+			name: "invalid: cannot patch etcd target due to malformed json patch",
+			patchTarget: &PatchTarget{
+				Name:                      "etcd",
+				StrategicMergePatchObject: v1.Pod{},
+				Data:                      []byte("foo: bar\n"),
+			},
+			files: []*file{
+				{
+					name: "etcd+json.json",
+					data: `{"foo":"zzz"}`,
+				},
+			},
+			expectedError: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tempDir, err := ioutil.TempDir("", testDirPattern)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer os.RemoveAll(tempDir)
+
+			for _, file := range tc.files {
+				filePath := filepath.Join(tempDir, file.name)
+				err := ioutil.WriteFile(filePath, []byte(file.data), 0644)
+				if err != nil {
+					t.Fatalf("could not write temporary file %q", filePath)
+				}
+			}
+
+			pm, err := GetPatchManagerForPath(tempDir, testKnownTargets, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			err = pm.ApplyPatchesToTarget(tc.patchTarget)
+			if (err != nil) != tc.expectedError {
+				t.Fatalf("expected error: %v, got: %v, error: %v", tc.expectedError, err != nil, err)
+			}
+			if err != nil {
+				return
+			}
+
+			if !bytes.Equal(tc.patchTarget.Data, tc.expectedData) {
+				t.Fatalf("expected result:\n%s\ngot:\n%s", tc.expectedData, tc.patchTarget.Data)
+			}
+		})
+	}
+}
+
+func TestGetPatchManagerForPathCache(t *testing.T) {
+	tempDir, err := ioutil.TempDir("", testDirPattern)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	pmOld, err := GetPatchManagerForPath(tempDir, testKnownTargets, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pmNew, err := GetPatchManagerForPath(tempDir, testKnownTargets, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pmOld != pmNew {
+		t.Logf("path %q was not cached, expected pointer: %p, got: %p", tempDir, pmOld, pmNew)
+	}
+}

--- a/cmd/kubeadm/app/util/staticpod/BUILD
+++ b/cmd/kubeadm/app/util/staticpod/BUILD
@@ -29,6 +29,7 @@ go_library(
         "//cmd/kubeadm/app/constants:go_default_library",
         "//cmd/kubeadm/app/util:go_default_library",
         "//cmd/kubeadm/app/util/kustomize:go_default_library",
+        "//cmd/kubeadm/app/util/patches:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/resource:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",

--- a/cmd/kubeadm/app/util/staticpod/utils_test.go
+++ b/cmd/kubeadm/app/util/staticpod/utils_test.go
@@ -796,3 +796,84 @@ func TestKustomizeStaticPod(t *testing.T) {
 		t.Error("Kustomize did not apply patches corresponding to the resource")
 	}
 }
+
+func TestPatchStaticPod(t *testing.T) {
+	type file struct {
+		name string
+		data string
+	}
+
+	tests := []struct {
+		name          string
+		files         []*file
+		pod           *v1.Pod
+		expectedPod   *v1.Pod
+		expectedError bool
+	}{
+		{
+			name: "valid: patch a kube-apiserver target using a couple of ordered patches",
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kube-apiserver",
+					Namespace: "foo",
+				},
+			},
+			expectedPod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kube-apiserver",
+					Namespace: "bar2",
+				},
+			},
+			files: []*file{
+				{
+					name: "kube-apiserver1+merge.json",
+					data: `{"metadata":{"namespace":"bar2"}}`,
+				},
+				{
+					name: "kube-apiserver0+json.json",
+					data: `[{"op": "replace", "path": "/metadata/namespace", "value": "bar1"}]`,
+				},
+			},
+		},
+		{
+			name: "invalid: unknown patch target name",
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "bar",
+				},
+			},
+			expectedError: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tempDir, err := ioutil.TempDir("", "patch-files")
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer os.RemoveAll(tempDir)
+
+			for _, file := range tc.files {
+				filePath := filepath.Join(tempDir, file.name)
+				err := ioutil.WriteFile(filePath, []byte(file.data), 0644)
+				if err != nil {
+					t.Fatalf("could not write temporary file %q", filePath)
+				}
+			}
+
+			pod, err := PatchStaticPod(tc.pod, tempDir, ioutil.Discard)
+			if (err != nil) != tc.expectedError {
+				t.Fatalf("expected error: %v, got: %v, error: %v", tc.expectedError, (err != nil), err)
+			}
+			if err != nil {
+				return
+			}
+
+			if tc.expectedPod.String() != pod.String() {
+				t.Fatalf("expected object:\n%s\ngot:\n%s", tc.expectedPod.String(), pod.String())
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Introduce the flag --experimental-patches and deprecate --experimental-kustomize.
Add a new backend for using raw patches for patching kubeadm managed components.
Only patching of static Pod manifests is enabled for the time being but technically
the backend supports patching any component or target.

The existing Kustomize support is left untouched for the time being and kustomize
patches apply before the new patching functionality.

Targets and patch types are determined using the file naming pattern, as agreed on the [KEP](https://github.com/kubernetes/enhancements/tree/master/keps/sig-cluster-lifecycle/kubeadm/1739-customization-with-patches):
`target[suffix][+patchtype].extension`
and the usage is briefly documented in the new flag description.

The new backend is planned to long term support the kubeadm API, which will be
reflected in the [KEP](https://github.com/kubernetes/enhancements/tree/master/keps/sig-cluster-lifecycle/kubeadm/1739-customization-with-patches) eventually.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Refs: https://github.com/kubernetes/kubeadm/issues/2046

**Special notes for your reviewer**:
please review one commit at a time.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kubeadm: deprecate the feature --experimental-kustomize in favor of --experimental-patches. The supported patch formats are the same as "kubectl patch". They are read as files from a directory and can be applied to kubeadm components during init/join/upgrade. Only patching of static Pods is supported for the time being.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-cluster-lifecycle/kubeadm/1739-customization-with-patches
```
