### PR TITLE
Check for v1 CSR API in kube-controller-manager

### DIFF
--- a/cmd/kube-controller-manager/app/certificates.go
+++ b/cmd/kube-controller-manager/app/certificates.go
@@ -39,7 +39,7 @@ import (
 )
 
 func startCSRSigningController(ctx ControllerContext) (http.Handler, bool, error) {
-	gvr := schema.GroupVersionResource{Group: "certificates.k8s.io", Version: "v1beta1", Resource: "certificatesigningrequests"}
+	gvr := schema.GroupVersionResource{Group: "certificates.k8s.io", Version: "v1", Resource: "certificatesigningrequests"}
 	if !ctx.AvailableResources[gvr] {
 		klog.Warningf("Resource %s is not available now", gvr.String())
 		return nil, false, nil
@@ -129,7 +129,7 @@ func getKubeletServingSignerFiles(config csrsigningconfig.CSRSigningControllerCo
 }
 
 func startCSRApprovingController(ctx ControllerContext) (http.Handler, bool, error) {
-	gvr := schema.GroupVersionResource{Group: "certificates.k8s.io", Version: "v1beta1", Resource: "certificatesigningrequests"}
+	gvr := schema.GroupVersionResource{Group: "certificates.k8s.io", Version: "v1", Resource: "certificatesigningrequests"}
 	if !ctx.AvailableResources[gvr] {
 		klog.Warningf("Resource %s is not available now", gvr.String())
 		return nil, false, nil


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
The CSR controllers switched to the v1 API in https://github.com/kubernetes/kubernetes/pull/91713 but the API availability check was still looking for the v1beta1 API.

This updates the controllers to check for the API they actually use.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

Part of https://github.com/kubernetes/enhancements/issues/1513