### PR TITLE
Automated cherry pick of #91045: Deflake port-forward e2e test

### DIFF
--- a/test/e2e/kubectl/portforward.go
+++ b/test/e2e/kubectl/portforward.go
@@ -321,11 +321,6 @@ func doTestMustConnectSendDisconnect(bindAddress string, f *framework.Framework)
 	ginkgo.By("Sending the expected data to the local port")
 	fmt.Fprint(conn, "abc")
 
-	ginkgo.By("Closing the write half of the client's connection")
-	if err = conn.CloseWrite(); err != nil {
-		framework.Failf("Couldn't close the write half of the client's connection: %v", err)
-	}
-
 	ginkgo.By("Reading data from the local port")
 	fromServer, err := ioutil.ReadAll(conn)
 	if err != nil {
@@ -340,6 +335,11 @@ func doTestMustConnectSendDisconnect(bindAddress string, f *framework.Framework)
 			framework.Logf("Logs of portforwardtester pod: %v", podlogs)
 		}
 		framework.Failf("Expected %q from server, got %q", e, a)
+	}
+
+	ginkgo.By("Closing the write half of the client's connection")
+	if err = conn.CloseWrite(); err != nil {
+		framework.Failf("Couldn't close the write half of the client's connection: %v", err)
 	}
 
 	ginkgo.By("Waiting for the target pod to stop running")


### PR DESCRIPTION
Cherry pick of #91045 on release-1.18.

#91045: Deflake port-forward e2e test

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.