### PR TITLE
Flush cache to disk to persist configuration status

### DIFF
--- a/cluster/gce/windows/configure.ps1
+++ b/cluster/gce/windows/configure.ps1
@@ -152,6 +152,9 @@ try {
     Configure-LoggingAgent
     Restart-LoggingAgent
   }
+  # Flush cache to disk before starting kubelet & kube-proxy services
+  # to make metadata server route and stackdriver service more persistent.
+  Write-Volumecache C -PassThru
   Start-WorkerServices
   Log-Output 'Waiting 15 seconds for node to join cluster.'
   Start-Sleep 15
@@ -162,6 +165,8 @@ try {
   Schedule-LogRotation -Pattern '.*\.log$' -Path ${env:LOGS_DIR} -RepetitionInterval $(New-Timespan -Hour 1) -Config $config
 
   Pull-InfraContainer
+  # Flush cache to disk to persist the setup status
+  Write-Volumecache C -PassThru
 }
 catch {
   Write-Host 'Exception caught in script:'


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Found the metadata connection or stackdriver service was lost when hard reset right after kubelet was setup.  Flush the cache to disk to make configurations more persistent.

**Special notes for your reviewer**:
[Serial logs](https://gist.github.com/YangLu1031/142146997a2c14a5d2b205ca40638d3f) for failed case

**Does this PR introduce a user-facing change?**:
```release-note
None
```
