### PR TITLE
kubelet, kube-proxy: unmark packets before masquerading them

### DIFF
--- a/pkg/kubelet/kubelet_network_linux.go
+++ b/pkg/kubelet/kubelet_network_linux.go
@@ -62,7 +62,7 @@ func (kl *Kubelet) syncNetworkUtil() {
 		klog.Errorf("Failed to ensure that %s chain %s exists: %v", utiliptables.TableNAT, KubeMarkDropChain, err)
 		return
 	}
-	if _, err := kl.iptClient.EnsureRule(utiliptables.Append, utiliptables.TableNAT, KubeMarkDropChain, "-j", "MARK", "--set-xmark", dropMark); err != nil {
+	if _, err := kl.iptClient.EnsureRule(utiliptables.Append, utiliptables.TableNAT, KubeMarkDropChain, "-j", "MARK", "--or-mark", dropMark); err != nil {
 		klog.Errorf("Failed to ensure marking rule for %v: %v", KubeMarkDropChain, err)
 		return
 	}
@@ -72,7 +72,7 @@ func (kl *Kubelet) syncNetworkUtil() {
 	}
 	if _, err := kl.iptClient.EnsureRule(utiliptables.Append, utiliptables.TableFilter, KubeFirewallChain,
 		"-m", "comment", "--comment", "kubernetes firewall for dropping marked packets",
-		"-m", "mark", "--mark", dropMark,
+		"-m", "mark", "--mark", fmt.Sprintf("%s/%s", dropMark, dropMark),
 		"-j", "DROP"); err != nil {
 		klog.Errorf("Failed to ensure rule to drop packet marked by %v in %v chain %v: %v", KubeMarkDropChain, utiliptables.TableFilter, KubeFirewallChain, err)
 		return
@@ -112,7 +112,7 @@ func (kl *Kubelet) syncNetworkUtil() {
 		klog.Errorf("Failed to ensure that %s chain %s exists: %v", utiliptables.TableNAT, KubePostroutingChain, err)
 		return
 	}
-	if _, err := kl.iptClient.EnsureRule(utiliptables.Append, utiliptables.TableNAT, KubeMarkMasqChain, "-j", "MARK", "--set-xmark", masqueradeMark); err != nil {
+	if _, err := kl.iptClient.EnsureRule(utiliptables.Append, utiliptables.TableNAT, KubeMarkMasqChain, "-j", "MARK", "--or-mark", masqueradeMark); err != nil {
 		klog.Errorf("Failed to ensure marking rule for %v: %v", KubeMarkMasqChain, err)
 		return
 	}
@@ -121,12 +121,26 @@ func (kl *Kubelet) syncNetworkUtil() {
 		klog.Errorf("Failed to ensure that %s chain %s jumps to %s: %v", utiliptables.TableNAT, utiliptables.ChainPostrouting, KubePostroutingChain, err)
 		return
 	}
-	// Establish the masquerading rule.
+
+	// Set up KUBE-POSTROUTING to unmark and masquerade marked packets
 	// NB: THIS MUST MATCH the corresponding code in the iptables and ipvs
 	// modes of kube-proxy
+	if _, err := kl.iptClient.EnsureRule(utiliptables.Append, utiliptables.TableNAT, KubePostroutingChain,
+		"-m", "mark", "!", "--mark", fmt.Sprintf("%s/%s", masqueradeMark, masqueradeMark),
+		"-j", "RETURN"); err != nil {
+		klog.Errorf("Failed to ensure filtering rule for %v: %v", KubePostroutingChain, err)
+		return
+	}
+	// Clear the mark to avoid re-masquerading if the packet re-traverses the network stack.
+	// We know the mark bit is currently set so we can use --xor-mark to clear it (without needing
+	// to Sprintf another bitmask).
+	if _, err := kl.iptClient.EnsureRule(utiliptables.Append, utiliptables.TableNAT, KubePostroutingChain,
+		"-j", "MARK", "--xor-mark", masqueradeMark); err != nil {
+		klog.Errorf("Failed to ensure unmarking rule for %v: %v", KubePostroutingChain, err)
+		return
+	}
 	masqRule := []string{
 		"-m", "comment", "--comment", "kubernetes service traffic requiring SNAT",
-		"-m", "mark", "--mark", masqueradeMark,
 		"-j", "MASQUERADE",
 	}
 	if kl.iptClient.HasRandomFully() {
@@ -141,5 +155,5 @@ func (kl *Kubelet) syncNetworkUtil() {
 // getIPTablesMark returns the fwmark given the bit
 func getIPTablesMark(bit int) string {
 	value := 1 << uint(bit)
-	return fmt.Sprintf("%#08x/%#08x", value, value)
+	return fmt.Sprintf("%#08x", value)
 }

--- a/pkg/kubelet/kubelet_network_test.go
+++ b/pkg/kubelet/kubelet_network_test.go
@@ -31,11 +31,11 @@ func TestGetIPTablesMark(t *testing.T) {
 	}{
 		{
 			14,
-			"0x00004000/0x00004000",
+			"0x00004000",
 		},
 		{
 			15,
-			"0x00008000/0x00008000",
+			"0x00008000",
 		},
 	}
 	for _, tc := range tests {

--- a/pkg/proxy/iptables/proxier.go
+++ b/pkg/proxy/iptables/proxier.go
@@ -282,7 +282,7 @@ func NewProxier(ipt utiliptables.Interface,
 
 	// Generate the masquerade mark to use for SNAT rules.
 	masqueradeValue := 1 << uint(masqueradeBit)
-	masqueradeMark := fmt.Sprintf("%#08x/%#08x", masqueradeValue, masqueradeValue)
+	masqueradeMark := fmt.Sprintf("%#08x", masqueradeValue)
 	klog.V(2).Infof("iptables(%s) masquerade mark: %s", ipt.Protocol(), masqueradeMark)
 
 	endpointSlicesEnabled := utilfeature.DefaultFeatureGate.Enabled(features.EndpointSliceProxying)
@@ -919,10 +919,20 @@ func (proxier *Proxier) syncProxyRules() {
 	// this so that it is easier to flush and change, for example if the mark
 	// value should ever change.
 	// NB: THIS MUST MATCH the corresponding code in the kubelet
+	writeLine(proxier.natRules, []string{
+		"-A", string(kubePostroutingChain),
+		"-m", "mark", "!", "--mark", fmt.Sprintf("%s/%s", proxier.masqueradeMark, proxier.masqueradeMark),
+		"-j", "RETURN",
+	}...)
+	// Clear the mark to avoid re-masquerading if the packet re-traverses the network stack.
+	writeLine(proxier.natRules, []string{
+		"-A", string(kubePostroutingChain),
+		// XOR proxier.masqueradeMark to unset it
+		"-j", "MARK", "--xor-mark", proxier.masqueradeMark,
+	}...)
 	masqRule := []string{
 		"-A", string(kubePostroutingChain),
 		"-m", "comment", "--comment", `"kubernetes service traffic requiring SNAT"`,
-		"-m", "mark", "--mark", proxier.masqueradeMark,
 		"-j", "MASQUERADE",
 	}
 	if proxier.iptables.HasRandomFully() {
@@ -935,7 +945,7 @@ func (proxier *Proxier) syncProxyRules() {
 	// value should ever change.
 	writeLine(proxier.natRules, []string{
 		"-A", string(KubeMarkMasqChain),
-		"-j", "MARK", "--set-xmark", proxier.masqueradeMark,
+		"-j", "MARK", "--or-mark", proxier.masqueradeMark,
 	}...)
 
 	// Accumulate NAT chains to keep.
@@ -1514,7 +1524,7 @@ func (proxier *Proxier) syncProxyRules() {
 	writeLine(proxier.filterRules,
 		"-A", string(kubeForwardChain),
 		"-m", "comment", "--comment", `"kubernetes forwarding rules"`,
-		"-m", "mark", "--mark", proxier.masqueradeMark,
+		"-m", "mark", "--mark", fmt.Sprintf("%s/%s", proxier.masqueradeMark, proxier.masqueradeMark),
 		"-j", "ACCEPT",
 	)
 

--- a/pkg/proxy/iptables/proxier_test.go
+++ b/pkg/proxy/iptables/proxier_test.go
@@ -357,6 +357,7 @@ func NewFakeProxier(ipt utiliptables.Interface, endpointSlicesEnabled bool) *Pro
 		endpointsMap:             make(proxy.EndpointsMap),
 		endpointsChanges:         proxy.NewEndpointChangeTracker(testHostname, newEndpointInfo, nil, nil, endpointSlicesEnabled),
 		iptables:                 ipt,
+		masqueradeMark:           "0x4000",
 		localDetector:            detectLocal,
 		hostname:                 testHostname,
 		portsMap:                 make(map[utilproxy.LocalPort]utilproxy.Closeable),
@@ -2418,7 +2419,7 @@ func TestEndpointSliceE2E(t *testing.T) {
 :KUBE-EXTERNAL-SERVICES - [0:0]
 :KUBE-FORWARD - [0:0]
 -A KUBE-FORWARD -m conntrack --ctstate INVALID -j DROP
--A KUBE-FORWARD -m comment --comment "kubernetes forwarding rules" -m mark --mark  -j ACCEPT
+-A KUBE-FORWARD -m comment --comment "kubernetes forwarding rules" -m mark --mark 0x4000/0x4000 -j ACCEPT
 -A KUBE-FORWARD -m comment --comment "kubernetes forwarding conntrack pod source rule" -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
 -A KUBE-FORWARD -m comment --comment "kubernetes forwarding conntrack pod destination rule" -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
 COMMIT
@@ -2431,8 +2432,10 @@ COMMIT
 :KUBE-SEP-3JOIVZTXZZRGORX4 - [0:0]
 :KUBE-SEP-IO5XOSKPAXIFQXAJ - [0:0]
 :KUBE-SEP-XGJFVO3L2O5SRFNT - [0:0]
--A KUBE-POSTROUTING -m comment --comment "kubernetes service traffic requiring SNAT" -m mark --mark  -j MASQUERADE
--A KUBE-MARK-MASQ -j MARK --set-xmark 
+-A KUBE-POSTROUTING -m mark ! --mark 0x4000/0x4000 -j RETURN
+-A KUBE-POSTROUTING -j MARK --xor-mark 0x4000
+-A KUBE-POSTROUTING -m comment --comment "kubernetes service traffic requiring SNAT" -j MASQUERADE
+-A KUBE-MARK-MASQ -j MARK --or-mark 0x4000
 -A KUBE-SERVICES -m comment --comment "ns1/svc1 cluster IP" -m tcp -p tcp -d 172.20.1.1/32 --dport 0 ! -s 10.0.0.0/24 -j KUBE-MARK-MASQ
 -A KUBE-SERVICES -m comment --comment "ns1/svc1 cluster IP" -m tcp -p tcp -d 172.20.1.1/32 --dport 0 -j KUBE-SVC-AQI2S6QIMU7PVVRP
 -A KUBE-SVC-AQI2S6QIMU7PVVRP -m comment --comment ns1/svc1 -m statistic --mode random --probability 0.3333333333 -j KUBE-SEP-3JOIVZTXZZRGORX4

--- a/pkg/proxy/ipvs/proxier.go
+++ b/pkg/proxy/ipvs/proxier.go
@@ -418,7 +418,7 @@ func NewProxier(ipt utiliptables.Interface,
 
 	// Generate the masquerade mark to use for SNAT rules.
 	masqueradeValue := 1 << uint(masqueradeBit)
-	masqueradeMark := fmt.Sprintf("%#08x/%#08x", masqueradeValue, masqueradeValue)
+	masqueradeMark := fmt.Sprintf("%#08x", masqueradeValue)
 
 	isIPv6 := utilnet.IsIPv6(nodeIP)
 
@@ -1758,7 +1758,7 @@ func (proxier *Proxier) writeIptablesRules() {
 	writeLine(proxier.filterRules,
 		"-A", string(KubeForwardChain),
 		"-m", "comment", "--comment", `"kubernetes forwarding rules"`,
-		"-m", "mark", "--mark", proxier.masqueradeMark,
+		"-m", "mark", "--mark", fmt.Sprintf("%s/%s", proxier.masqueradeMark, proxier.masqueradeMark),
 		"-j", "ACCEPT",
 	)
 
@@ -1842,10 +1842,20 @@ func (proxier *Proxier) createAndLinkeKubeChain() {
 	// this so that it is easier to flush and change, for example if the mark
 	// value should ever change.
 	// NB: THIS MUST MATCH the corresponding code in the kubelet
+	writeLine(proxier.natRules, []string{
+		"-A", string(kubePostroutingChain),
+		"-m", "mark", "!", "--mark", fmt.Sprintf("%s/%s", proxier.masqueradeMark, proxier.masqueradeMark),
+		"-j", "RETURN",
+	}...)
+	// Clear the mark to avoid re-masquerading if the packet re-traverses the network stack.
+	writeLine(proxier.natRules, []string{
+		"-A", string(kubePostroutingChain),
+		// XOR proxier.masqueradeMark to unset it
+		"-j", "MARK", "--xor-mark", proxier.masqueradeMark,
+	}...)
 	masqRule := []string{
 		"-A", string(kubePostroutingChain),
 		"-m", "comment", "--comment", `"kubernetes service traffic requiring SNAT"`,
-		"-m", "mark", "--mark", proxier.masqueradeMark,
 		"-j", "MASQUERADE",
 	}
 	if proxier.iptables.HasRandomFully() {
@@ -1858,7 +1868,7 @@ func (proxier *Proxier) createAndLinkeKubeChain() {
 	// value should ever change.
 	writeLine(proxier.natRules, []string{
 		"-A", string(KubeMarkMasqChain),
-		"-j", "MARK", "--set-xmark", proxier.masqueradeMark,
+		"-j", "MARK", "--or-mark", proxier.masqueradeMark,
 	}...)
 }
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
As noted by @tommasopozzetti in #88986, we appear to be double-NAT-ing some packets due to oddness about how the packet mark works in the kernel. (Routing a packet through a VXLAN tunnel reuses the same kernel packet object and sends it through the network stack a second time. In particular, it does not reset the packet mark when this happens, so as a result if we call `KUBE-MARK-MASQ` on a packet and then later route that packet through a VXLAN tunnel, then `KUBE-POSTROUTING` will end up NAT-ing first the original packet, and then later the outer VXLAN-encapsulating packet.) The superfluous NAT-ing of the outer packet, combined with our use of `iptables -j MASQUERADE --random-fully`, results in us hitting a kernel packet checksum bug which then causes dropped packets and severe performance problems.

Although the kernel bug has been fixed, the fact that we are double-NAT-ing is still not great. #78948 mentions a few smaller issues, and apparently it might also cause performance problems by making the VXLAN packets look unrelated to each either due to their differing source ports, causing them to end up in different rx queues on the destination side (which I guess means successive packets might not all be processed by the same CPU or something?)

Additionally, fixing it here means it will be fixed even for people who can't easily upgrade to a fixed kernel.

**Which issue(s) this PR fixes**:
Fixes #88986
Fixes #90854
(and various flannel/weave/calico/etc issues)

**Special notes for your reviewer**:
This changes `KUBE-POSTROUTING` from "if marked for masquerade then masquerade" to "if _not_ marked for masquerade then return to `POSTROUTING`, else unmark and then masquerade". This required some extra rewriting of the code though because it was previously doing `-set-xmark 0x4000/0x4000` to set the bit and `--mark 0x4000/0x4000` to match it, but there's no way to _clear_ the mark using the string `0x4000/0x4000` so I had to rewrite it in terms of `0x4000` instead.

**Does this PR introduce a user-facing change?**:

```release-note
Fixes a problem with 63-second or 1-second connection delays with some VXLAN-based
network plugins which was first widely noticed in 1.16 (though some users saw it
earlier than that, possibly only with specific network plugins). If you were previously
using ethtool to disable checksum offload on your primary network interface, you should
now be able to stop doing that.
```

(EDIT: Further explanation of both the kube bug and the kernel bug and how they interact [in this comment](https://github.com/kubernetes/kubernetes/pull/92035#issuecomment-652395132))

/sig network
/priority important-soon
