### PR TITLE
Revert "fix cross build conformance image error"

### DIFF
--- a/cluster/images/conformance/Makefile
+++ b/cluster/images/conformance/Makefile
@@ -34,9 +34,6 @@ CLUSTER_DIR?=$(shell pwd)/../../../cluster/
 BASEIMAGE=debian:stretch-slim
 TEMP_DIR:=$(shell mktemp -d -t conformanceXXXXXX)
 
-#output format for docker buildx build [push, load]
-OUTPUT=--load
-
 all: build
 
 build:
@@ -59,14 +56,15 @@ endif
 
 	cd ${TEMP_DIR} && sed -i.back "s|BASEIMAGE|${BASEIMAGE}|g" Dockerfile
 
-	DOCKER_CLI_EXPERIMENTAL=enabled docker buildx build --pull --platform linux/$(ARCH) $(OUTPUT) -t ${REGISTRY}/conformance-${ARCH}:${VERSION} ${TEMP_DIR}
-ifeq ($(ARCH),amd64)
-	docker rmi ${REGISTRY}/conformance:${VERSION} 2>/dev/null || true
-	DOCKER_CLI_EXPERIMENTAL=enabled docker buildx build --pull --platform linux/$(ARCH) $(OUTPUT) -t ${REGISTRY}/conformance:${VERSION} ${TEMP_DIR}
-endif
+	docker build --pull -t ${REGISTRY}/conformance-${ARCH}:${VERSION} ${TEMP_DIR}
 	rm -rf "${TEMP_DIR}"
 
-push: OUTPUT=--push
 push: build
+	docker push ${REGISTRY}/conformance-${ARCH}:${VERSION}
+ifeq ($(ARCH),amd64)
+	docker rmi ${REGISTRY}/conformance:${VERSION} 2>/dev/null || true
+	docker tag ${REGISTRY}/conformance-${ARCH}:${VERSION} ${REGISTRY}/conformance:${VERSION}
+	docker push ${REGISTRY}/conformance:${VERSION}
+endif
 
 .PHONY: build push all


### PR DESCRIPTION
Reverts kubernetes/kubernetes#90400

For more context: https://kubernetes.slack.com/archives/CJH2GBF7Y/p1591798874384000?thread_ts=1591794999.379400&cid=CJH2GBF7Y

This change is failing on the release pipeline as we can see some snippet logs
```
+++ [0611 11:26:27] Starting tarball: client linux-s390x
+++ [0611 11:26:27] Starting tarball: client windows-386
+++ [0611 11:26:27] Starting tarball: client windows-amd64
+++ [0611 11:26:27] Waiting on tarballs
tar: Removing leading `/' from member names
tar: Removing leading `/' from member names
tar: Removing leading `/' from member names
tar: Removing leading `/' from member names
+++ [0611 11:26:35] Building tarball: node linux-amd64
+++ [0611 11:26:35] Building images: linux-amd64
+++ [0611 11:26:36] Starting docker build for image: kube-apiserver-amd64
+++ [0611 11:26:36] Starting docker build for image: kube-controller-manager-amd64
+++ [0611 11:26:36] Starting docker build for image: kube-scheduler-amd64
+++ [0611 11:26:36] Starting docker build for image: kube-proxy-amd64
+++ [0611 11:26:36] Building conformance image for arch: amd64
#1 [internal] load .dockerignore
#1 transferring context: 2B done
#1 DONE 1.2s
#2 [internal] load build definition from Dockerfile
#2 transferring dockerfile: 1.06kB done
#2 DONE 1.6s
#3 [internal] load metadata for docker.io/library/debian:stretch-slim
#3 ERROR: docker.io/library/debian:stretch-slim not found
#5 [internal] load build context
#5 DONE 0.0s
#4 [1/8] FROM docker.io/library/debian:stretch-slim
#4 resolve docker.io/library/debian:stretch-slim
#4 resolve docker.io/library/debian:stretch-slim 0.1s done
#4 ERROR: docker.io/library/debian:stretch-slim not found
------
 > [internal] load metadata for docker.io/library/debian:stretch-slim:
------
------
 > [1/8] FROM docker.io/library/debian:stretch-slim:
------
failed to solve: rpc error: code = Unknown desc = failed to solve with frontend dockerfile.v0: failed to build LLB: failed to load cache key: docker.io/library/debian:stretch-slim not found
make[1]: *** [Makefile:58: build] Error 1
!!! [0611 11:26:39] Call tree:
!!! [0611 11:26:39]  1: /workspace/anago-v1.19.0-beta.1.246+a8e43038a430aa/src/k8s.io/kubernetes/build/lib/release.sh:406 kube::release::build_conformance_image(...)
!!! [0611 11:26:39]  2: /workspace/anago-v1.19.0-beta.1.246+a8e43038a430aa/src/k8s.io/kubernetes/build/lib/release.sh:240 kube::release::create_docker_images_for_server(...)
!!! [0611 11:26:39]  3: /workspace/anago-v1.19.0-beta.1.246+a8e43038a430aa/src/k8s.io/kubernetes/build/lib/release.sh:246 kube::release::build_server_images(...)
!!! [0611 11:26:39]  4: /workspace/anago-v1.19.0-beta.1.246+a8e43038a430aa/src/k8s.io/kubernetes/build/lib/release.sh:98 kube::release::package_server_tarballs(...)
!!! [0611 11:26:39]  5: build/package-tarballs.sh:27 kube::release::package_tarballs(...)
+++ [0611 11:26:48] Deleting docker image k8s.gcr.io/kube-scheduler-amd64:v1.19.0-beta.2
+++ [0611 11:26:48] Deleting docker image k8s.gcr.io/kube-controller-manager-amd64:v1.19.0-beta.2
+++ [0611 11:26:48] Deleting docker image k8s.gcr.io/kube-proxy-amd64:v1.19.0-beta.2
+++ [0611 11:26:48] Deleting docker image k8s.gcr.io/kube-apiserver-amd64:v1.19.0-beta.2
!!! [0611 11:26:48] previous Docker build failed
!!! [0611 11:26:48] Call tree:
!!! [0611 11:26:48]  1: /workspace/anago-v1.19.0-beta.1.246+a8e43038a430aa/src/k8s.io/kubernetes/build/lib/release.sh:240 kube::release::create_docker_images_for_server(...)
!!! [0611 11:26:48]  2: /workspace/anago-v1.19.0-beta.1.246+a8e43038a430aa/src/k8s.io/kubernetes/build/lib/release.sh:246 kube::release::build_server_images(...)
!!! [0611 11:26:48]  3: /workspace/anago-v1.19.0-beta.1.246+a8e43038a430aa/src/k8s.io/kubernetes/build/lib/release.sh:98 kube::release::package_server_tarballs(...)
!!! [0611 11:26:48]  4: build/package-tarballs.sh:27 kube::release::package_tarballs(...)
+++ [0611 11:26:51] Building tarball: node linux-arm
+++ [0611 11:27:04] Building tarball: node linux-arm64
+++ [0611 11:27:17] Building tarball: node linux-s390x
+++ [0611 11:27:34] Building tarball: node linux-ppc64le
+++ [0611 11:27:47] Building tarball: node windows-amd64
!!! [0611 11:28:02] previous tarball phase failed
make: *** [Makefile:486: package-tarballs] Error 1
```

the change uses the docker experimental flag + buildx.
tried to set the `HOME=/root` as described here: https://github.com/aramase/test-infra/commit/17d01830332cfbb5d91591a848b742b1ab76dcbc but with no success

all the build failures break in the conformance build. We also build 1.18 release branch where this change does not exist and the build finished successfully.
 

/kind bug
/milestone v1.19
/priority critical-urgent


/cc @justaugustus @dims @kubernetes/release-managers 