### PR TITLE
e2e pods: add missing pod and node name in the formatted log line

### DIFF
--- a/test/e2e/node/pods.go
+++ b/test/e2e/node/pods.go
@@ -372,7 +372,7 @@ var _ = SIGDescribe("Pods Extended", func() {
 									// expected
 								case t.ExitCode == 128 && (t.Reason == "StartError" || t.Reason == "ContainerCannotRun") && reBug88766.MatchString(t.Message):
 									// pod volume teardown races with container start in CRI, which reports a failure
-									framework.Logf("pod %s on node %s failed with the symptoms of https://github.com/kubernetes/kubernetes/issues/88766")
+									framework.Logf("pod %s on node %s failed with the symptoms of https://github.com/kubernetes/kubernetes/issues/88766", pod.Name, pod.Spec.NodeName)
 								default:
 									return fmt.Errorf("pod %s on node %s container unexpected exit code %d: start=%s end=%s reason=%s message=%s", pod.Name, pod.Spec.NodeName, t.ExitCode, t.StartedAt, t.FinishedAt, t.Reason, t.Message)
 								}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
https://github.com/kubernetes/kubernetes/pull/88440/ introduced a new e2e test: `should never report success for a pending container`. This test has a formatted log line with `%s` symbols but does not include the parameters.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs
NONE
```

/cc @smarterclayton @sjenning 