### PR TITLE
Fix golint failures: replicationcontroller and replicationcontroller/storage packages in pkg/registry/core #68026

### DIFF
--- a/hack/.golint_failures
+++ b/hack/.golint_failures
@@ -140,7 +140,6 @@ pkg/registry/core/namespace/storage
 pkg/registry/core/node
 pkg/registry/core/persistentvolume
 pkg/registry/core/persistentvolumeclaim
-pkg/registry/core/replicationcontroller
 pkg/registry/core/replicationcontroller/storage
 pkg/registry/core/rest
 pkg/registry/core/secret

--- a/hack/.golint_failures
+++ b/hack/.golint_failures
@@ -140,7 +140,6 @@ pkg/registry/core/namespace/storage
 pkg/registry/core/node
 pkg/registry/core/persistentvolume
 pkg/registry/core/persistentvolumeclaim
-pkg/registry/core/replicationcontroller/storage
 pkg/registry/core/rest
 pkg/registry/core/secret
 pkg/registry/core/service

--- a/pkg/registry/core/replicationcontroller/doc.go
+++ b/pkg/registry/core/replicationcontroller/doc.go
@@ -14,6 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package controller provides Registry interface and it's RESTStorage
+// Package replicationcontroller provides Registry interface and it's RESTStorage
 // implementation for storing ReplicationController api objects.
 package replicationcontroller // import "k8s.io/kubernetes/pkg/registry/core/replicationcontroller"

--- a/pkg/registry/core/replicationcontroller/storage/storage.go
+++ b/pkg/registry/core/replicationcontroller/storage/storage.go
@@ -48,6 +48,7 @@ type ControllerStorage struct {
 	Scale      *ScaleREST
 }
 
+// NewStorage returns a RESTStorage object that will work against replication controllers.
 func NewStorage(optsGetter generic.RESTOptionsGetter) (ControllerStorage, error) {
 	controllerREST, statusREST, err := NewREST(optsGetter)
 	if err != nil {
@@ -61,6 +62,7 @@ func NewStorage(optsGetter generic.RESTOptionsGetter) (ControllerStorage, error)
 	}, nil
 }
 
+// REST implements a RESTStorage for replication controllers.
 type REST struct {
 	*genericregistry.Store
 }
@@ -111,6 +113,7 @@ type StatusREST struct {
 	store *genericregistry.Store
 }
 
+// New creates a new ReplicationController object.
 func (r *StatusREST) New() runtime.Object {
 	return &api.ReplicationController{}
 }
@@ -127,6 +130,7 @@ func (r *StatusREST) Update(ctx context.Context, name string, objInfo rest.Updat
 	return r.store.Update(ctx, name, objInfo, createValidation, updateValidation, false, options)
 }
 
+// ScaleREST implements a scale for replication controllers.
 type ScaleREST struct {
 	store *genericregistry.Store
 }
@@ -135,6 +139,7 @@ type ScaleREST struct {
 var _ = rest.Patcher(&ScaleREST{})
 var _ = rest.GroupVersionKindProvider(&ScaleREST{})
 
+// GroupVersionKind returns GroupVersionKind for ReplicationController Scale object.
 func (r *ScaleREST) GroupVersionKind(containingGV schema.GroupVersion) schema.GroupVersionKind {
 	switch containingGV {
 	case extensionsv1beta1.SchemeGroupVersion:
@@ -149,6 +154,7 @@ func (r *ScaleREST) New() runtime.Object {
 	return &autoscaling.Scale{}
 }
 
+// Get retrieves object from Scale storage.
 func (r *ScaleREST) Get(ctx context.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {
 	obj, err := r.store.Get(ctx, name, options)
 	if err != nil {
@@ -158,6 +164,7 @@ func (r *ScaleREST) Get(ctx context.Context, name string, options *metav1.GetOpt
 	return scaleFromRC(rc), nil
 }
 
+// Update alters scale subset of ReplicationController object.
 func (r *ScaleREST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, createValidation rest.ValidateObjectFunc, updateValidation rest.ValidateObjectUpdateFunc, forceAllowCreate bool, options *metav1.UpdateOptions) (runtime.Object, bool, error) {
 	obj, _, err := r.store.Update(
 		ctx,

--- a/pkg/registry/core/replicationcontroller/strategy.go
+++ b/pkg/registry/core/replicationcontroller/strategy.go
@@ -170,7 +170,7 @@ func ControllerToSelectableFields(controller *api.ReplicationController) fields.
 func GetAttrs(obj runtime.Object) (labels.Set, fields.Set, error) {
 	rc, ok := obj.(*api.ReplicationController)
 	if !ok {
-		return nil, nil, fmt.Errorf("given object is not a replication controller.")
+		return nil, nil, fmt.Errorf("given object is not a replication controller")
 	}
 	return labels.Set(rc.ObjectMeta.Labels), ControllerToSelectableFields(rc), nil
 }
@@ -190,6 +190,7 @@ type rcStatusStrategy struct {
 	rcStrategy
 }
 
+// StatusStrategy wraps and exports the used rcStrategy and is the default logic that applies when updating Replication Controller object status.
 var StatusStrategy = rcStatusStrategy{Strategy}
 
 func (rcStatusStrategy) PrepareForUpdate(ctx context.Context, obj, old runtime.Object) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
This PR fix golint issues for pkg/registry/core/replicationcontroller and pkg/registry/core/replicationcontroller/storage

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Related to #68026.

**Special notes for your reviewer**:
Errors from golint:
```
pkg/registry/core/replicationcontroller/doc.go:17:1: package comment should be of the form "Package replicationcontroller ..."
pkg/registry/core/replicationcontroller/strategy.go:173:31: error strings should not be capitalized or end with punctuation or a newline
pkg/registry/core/replicationcontroller/strategy.go:193:5: exported var StatusStrategy should have comment or be unexported

pkg/registry/core/replicationcontroller/storage/storage.go:51:1: exported function NewStorage should have comment or be unexported
pkg/registry/core/replicationcontroller/storage/storage.go:64:6: exported type REST should have comment or be unexported
pkg/registry/core/replicationcontroller/storage/storage.go:114:1: exported method StatusREST.New should have comment or be unexported
pkg/registry/core/replicationcontroller/storage/storage.go:130:6: exported type ScaleREST should have comment or be unexported
pkg/registry/core/replicationcontroller/storage/storage.go:138:1: exported method ScaleREST.GroupVersionKind should have comment or be unexported
pkg/registry/core/replicationcontroller/storage/storage.go:152:1: exported method ScaleREST.Get should have comment or be unexported
pkg/registry/core/replicationcontroller/storage/storage.go:161:1: exported method ScaleREST.Update should have comment or be unexported
```

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
