### PR TITLE
cleanup kubelet node status functions 

### DIFF
--- a/pkg/kubelet/kubelet_network.go
+++ b/pkg/kubelet/kubelet_network.go
@@ -40,20 +40,6 @@ const (
 	KubeFirewallChain utiliptables.Chain = "KUBE-FIREWALL"
 )
 
-// providerRequiresNetworkingConfiguration returns whether the cloud provider
-// requires special networking configuration.
-func (kl *Kubelet) providerRequiresNetworkingConfiguration() bool {
-	// TODO: We should have a mechanism to say whether native cloud provider
-	// is used or whether we are using overlay networking. We should return
-	// true for cloud providers if they implement Routes() interface and
-	// we are not using overlay networking.
-	if kl.cloud == nil || kl.cloud.ProviderName() != "gce" {
-		return false
-	}
-	_, supported := kl.cloud.Routes()
-	return supported
-}
-
 // updatePodCIDR updates the pod CIDR in the runtime state if it is different
 // from the current CIDR. Return true if pod CIDR is actually changed.
 func (kl *Kubelet) updatePodCIDR(cidr string) (bool, error) {

--- a/pkg/kubelet/kubelet_node_status_test.go
+++ b/pkg/kubelet/kubelet_node_status_test.go
@@ -60,6 +60,9 @@ import (
 )
 
 const (
+	minImgSize int64 = 23 * 1024 * 1024
+	maxImgSize int64 = 1000 * 1024 * 1024
+
 	maxImageTagsForTest = 20
 )
 

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -86,11 +86,6 @@ func init() {
 const (
 	testKubeletHostname = "127.0.0.1"
 	testKubeletHostIP   = "127.0.0.1"
-
-	// TODO(harry) any global place for these two?
-	// Reasonable size range of all container images. 90%ile of images on dockerhub drops into this range.
-	minImgSize int64 = 23 * 1024 * 1024
-	maxImgSize int64 = 1000 * 1024 * 1024
 )
 
 // fakeImageGCManager is a fake image gc manager for testing. It will return image


### PR DESCRIPTION
Part of [#90643](https://github.com/kubernetes/kubernetes/pull/90643)

/kind cleanup

**Special notes for your reviewer**:
This pr contains:
Migrate fastStatusUpdateOnce, providerRequiresNetworkingConfiguration to kubelet_node_status.go because they are related to node status or a helper of node status.
Make reconcileHugePageResource, updateDefaultLabels, reconcileCMADAnnotationWithExistingNode and providerRequiresNetworkingConfiguration no longer kubelet functions because most of them don't rely on kubelet struct.

```release-note
None
```