### PR TITLE
WIP: apiserver: add --termination-goaway flag to drain HTTP/2 early

### DIFF
--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -182,7 +182,7 @@ func CreateServerChain(completedOptions completedServerRunOptions, stopCh <-chan
 		return nil, err
 	}
 
-	kubeAPIServerConfig, insecureServingInfo, serviceResolver, pluginInitializer, err := CreateKubeAPIServerConfig(completedOptions, nodeTunneler, proxyTransport)
+	kubeAPIServerConfig, insecureServingInfo, serviceResolver, pluginInitializer, err := CreateKubeAPIServerConfig(completedOptions, nodeTunneler, proxyTransport, stopCh)
 	if err != nil {
 		return nil, err
 	}
@@ -284,6 +284,7 @@ func CreateKubeAPIServerConfig(
 	s completedServerRunOptions,
 	nodeTunneler tunneler.Tunneler,
 	proxyTransport *http.Transport,
+	stopCh <-chan struct{},
 ) (
 	*master.Config,
 	*genericapiserver.DeprecatedInsecureServingInfo,
@@ -291,7 +292,7 @@ func CreateKubeAPIServerConfig(
 	[]admission.PluginInitializer,
 	error,
 ) {
-	genericConfig, versionedInformers, insecureServingInfo, serviceResolver, pluginInitializers, admissionPostStartHook, storageFactory, err := buildGenericConfig(s.ServerRunOptions, proxyTransport)
+	genericConfig, versionedInformers, insecureServingInfo, serviceResolver, pluginInitializers, admissionPostStartHook, storageFactory, err := buildGenericConfig(s.ServerRunOptions, proxyTransport, stopCh)
 	if err != nil {
 		return nil, nil, nil, nil, err
 	}
@@ -427,6 +428,7 @@ func CreateKubeAPIServerConfig(
 func buildGenericConfig(
 	s *options.ServerRunOptions,
 	proxyTransport *http.Transport,
+	stopCh <-chan struct{},
 ) (
 	genericConfig *genericapiserver.Config,
 	versionedInformers clientgoinformers.SharedInformerFactory,
@@ -438,6 +440,14 @@ func buildGenericConfig(
 	lastErr error,
 ) {
 	genericConfig = genericapiserver.NewConfig(legacyscheme.Codecs)
+	genericConfig.IsTerminating = func() bool {
+		select {
+		case <-stopCh:
+			return true
+		default:
+			return false
+		}
+	}
 	genericConfig.MergedResourceConfig = master.DefaultAPIResourceConfigSource()
 
 	if lastErr = s.GenericServerRunOptions.ApplyTo(genericConfig); lastErr != nil {

--- a/staging/src/k8s.io/apiserver/pkg/server/config.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/config.go
@@ -221,6 +221,9 @@ type Config struct {
 	// EquivalentResourceRegistry provides information about resources equivalent to a given resource,
 	// and the kind associated with a given resource. As resources are installed, they are registered here.
 	EquivalentResourceRegistry runtime.EquivalentResourceRegistry
+
+	// A func that returns whether the server is terminating. This can be nil.
+	IsTerminating func() bool
 }
 
 type RecommendedConfig struct {

--- a/staging/src/k8s.io/apiserver/pkg/server/filters/goaway.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/filters/goaway.go
@@ -56,13 +56,25 @@ func WithProbabilisticGoaway(inner http.Handler, chance float64) http.Handler {
 	}
 }
 
+// WithTerminationGoaway sends a GOAWAY when isTerminating is returning true.
+func WithTerminationGoaway(inner http.Handler, isTerminating func() bool) http.Handler {
+	return &goaway{
+		handler: inner,
+		decider: GoawayDeciderFunc(
+			func(r *http.Request) bool {
+				return isTerminating()
+			},
+		),
+	}
+}
+
 // goaway send a GOAWAY to client according to decider for HTTP2 requests
 type goaway struct {
 	handler http.Handler
 	decider GoawayDecider
 }
 
-// ServeHTTP implement HTTP handler
+// ServeHTTP implements HTTP handler
 func (h *goaway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if r.Proto == "HTTP/2.0" && h.decider.Goaway(r) {
 		// Send a GOAWAY and tear down the TCP connection when idle.
@@ -72,17 +84,21 @@ func (h *goaway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	h.handler.ServeHTTP(w, r)
 }
 
-// probabilisticGoawayDecider send GOAWAY probabilistically according to chance
+// probabilisticGoawayDecider sends GOAWAY probabilistically according to chance
 type probabilisticGoawayDecider struct {
 	chance float64
 	next   func() float64
 }
 
-// Goaway implement GoawayDecider
+// Goaway implements GoawayDecider
 func (p *probabilisticGoawayDecider) Goaway(r *http.Request) bool {
-	if p.next() < p.chance {
-		return true
-	}
+	return p.next() < p.chance
+}
 
-	return false
+// GoawayDeciderFunc wraps a decider func as decider interface.
+type GoawayDeciderFunc func(r *http.Request) bool
+
+// GoawayDeciderFunc implements GoawayDecider
+func (f GoawayDeciderFunc) Goaway(r *http.Request) bool {
+	return f(r)
 }

--- a/staging/src/k8s.io/apiserver/pkg/server/options/server_run_options.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/server_run_options.go
@@ -39,6 +39,7 @@ type ServerRunOptions struct {
 	MaxMutatingRequestsInFlight int
 	RequestTimeout              time.Duration
 	GoawayChance                float64
+	TerminationGoaway           bool
 	LivezGracePeriod            time.Duration
 	MinRequestTimeout           int
 	ShutdownDelayDuration       time.Duration
@@ -77,6 +78,7 @@ func (s *ServerRunOptions) ApplyTo(c *server.Config) error {
 	c.LivezGracePeriod = s.LivezGracePeriod
 	c.RequestTimeout = s.RequestTimeout
 	c.GoawayChance = s.GoawayChance
+	c.TerminationGoaway = s.TerminationGoaway
 	c.MinRequestTimeout = s.MinRequestTimeout
 	c.ShutdownDelayDuration = s.ShutdownDelayDuration
 	c.JSONPatchMaxCopyBytes = s.JSONPatchMaxCopyBytes
@@ -191,6 +193,9 @@ func (s *ServerRunOptions) AddUniversalFlags(fs *pflag.FlagSet) {
 		"The client's other in-flight requests won't be affected, and the client will reconnect, likely landing on a different apiserver after going through the load balancer again. "+
 		"This argument sets the fraction of requests that will be sent a GOAWAY. Clusters with single apiservers, or which don't use a load balancer, should NOT enable this. "+
 		"Min is 0 (off), Max is .02 (1/50 requests); .001 (1/1000) is a recommended starting point.")
+
+	fs.BoolVar(&s.TerminationGoaway, "termination-goaway", s.TerminationGoaway, ""+
+		"This option speeds up draining of a terminating apiserver by sending GOAWAY frames immediately after termination has been initiated (i.e. before shutdown-delay-duration has passed).")
 
 	fs.DurationVar(&s.LivezGracePeriod, "livez-grace-period", s.LivezGracePeriod, ""+
 		"This option represents the maximum amount of time it should take for apiserver to complete its startup sequence "+

--- a/test/integration/framework/test_server.go
+++ b/test/integration/framework/test_server.go
@@ -114,7 +114,7 @@ func StartTestServer(t *testing.T, stopCh <-chan struct{}, setup TestServerSetup
 	if err != nil {
 		t.Fatal(err)
 	}
-	kubeAPIServerConfig, _, _, _, err := app.CreateKubeAPIServerConfig(completedOptions, tunneler, proxyTransport)
+	kubeAPIServerConfig, _, _, _, err := app.CreateKubeAPIServerConfig(completedOptions, tunneler, proxyTransport, nil)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
On termination, the kube-apiserver will keep serving for the time given in `--shutdown-delay-duration`. It might be desirable to start draining connections at this time in order to not wait until the last moment. This option makes this happen, i.e. directly after the SIGTERM signal the apiserver will asks clients to disconnect and restart their connections.

```release-note
Add `--termination-goaway` flag to kube-apiserver to drain http/2 connection early during termination.
```

Disadvantage: it let's clients close connections which might work until the LBs have converged. I.e. the clients might reopen connections to the very same server again leading to extra load due to tls negotiation.