### PR TITLE
Fix client config data race

### DIFF
--- a/staging/src/k8s.io/client-go/tools/clientcmd/merged_client_builder.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/merged_client_builder.go
@@ -60,27 +60,22 @@ func NewInteractiveDeferredLoadingClientConfig(loader ClientConfigLoader, overri
 }
 
 func (config *DeferredLoadingClientConfig) createClientConfig() (ClientConfig, error) {
-	if config.clientConfig == nil {
-		config.loadingLock.Lock()
-		defer config.loadingLock.Unlock()
+	config.loadingLock.Lock()
+	defer config.loadingLock.Unlock()
 
-		if config.clientConfig == nil {
-			mergedConfig, err := config.loader.Load()
-			if err != nil {
-				return nil, err
-			}
-
-			var mergedClientConfig ClientConfig
-			if config.fallbackReader != nil {
-				mergedClientConfig = NewInteractiveClientConfig(*mergedConfig, config.overrides.CurrentContext, config.overrides, config.fallbackReader, config.loader)
-			} else {
-				mergedClientConfig = NewNonInteractiveClientConfig(*mergedConfig, config.overrides.CurrentContext, config.overrides, config.loader)
-			}
-
-			config.clientConfig = mergedClientConfig
-		}
+	if config.clientConfig != nil {
+		return config.clientConfig, nil
+	}
+	mergedConfig, err := config.loader.Load()
+	if err != nil {
+		return nil, err
 	}
 
+	if config.fallbackReader != nil {
+		config.clientConfig = NewInteractiveClientConfig(*mergedConfig, config.overrides.CurrentContext, config.overrides, config.fallbackReader, config.loader)
+	} else {
+		config.clientConfig = NewNonInteractiveClientConfig(*mergedConfig, config.overrides.CurrentContext, config.overrides, config.loader)
+	}
 	return config.clientConfig, nil
 }
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This PR fixes a data race on config.clientConfig field. It can have an unlocked read and a locked write, which is a data race by definition.

/sig api-machinery