### PR TITLE
Add check for blocking tests in e2e framework

### DIFF
--- a/hack/verify-test-code.sh
+++ b/hack/verify-test-code.sh
@@ -64,6 +64,17 @@ do
     fi
 done
 
+all_e2e_framework_files=()
+kube::util::read-array all_e2e_framework_files < <(find test/e2e/framework/ -name '*.go' | grep -v "_test.go")
+errors_framework_contains_tests=()
+for file in "${all_e2e_framework_files[@]}"
+do
+    if grep -E "(ConformanceIt\(.*, func\(\) {|ginkgo.It\(.*, func\(\) {)" "${file}" > /dev/null
+    then
+        errors_framework_contains_tests+=( "${file}" )
+    fi
+done
+
 if [ ${#errors_expect_no_error[@]} -ne 0 ]; then
   {
     echo "Errors:"
@@ -115,6 +126,20 @@ if [ ${#errors_expect_equal[@]} -ne 0 ]; then
     echo
     echo 'The above files need to use framework.ExpectEqual(foo, bar) instead of '
     echo 'Expect(foo).To(Equal(bar)) or gomega.Expect(foo).To(gomega.Equal(bar))'
+    echo
+  } >&2
+  exit 1
+fi
+
+if [ ${#errors_framework_contains_tests[@]} -ne 0 ]; then
+  {
+    echo "Errors:"
+    for err in "${errors_framework_contains_tests[@]}"; do
+      echo "$err"
+    done
+    echo
+    echo 'The above e2e framework files should not contain any e2e tests which are implemented '
+    echo 'with framework.ConformanceIt() or ginkgo.It()'
     echo
   } >&2
   exit 1


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
/kind cleanup

**What this PR does / why we need it**:

e2e test framework provides useful functions for implementing e2e tests, but the framework itself should not contain e2e tests themself.
This adds hacking check for blocking implementing e2e tests in the framework.

**Special notes for your reviewer**:

This comes from https://github.com/kubernetes/kubernetes/pull/91230
https://github.com/kubernetes/kubernetes/pull/92271 should be merged before this.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
