### PR TITLE
Fix to configure-kubeapiserver.sh error.

### DIFF
--- a/cluster/gce/gci/configure-kubeapiserver.sh
+++ b/cluster/gce/gci/configure-kubeapiserver.sh
@@ -84,7 +84,7 @@ function start-kube-apiserver {
   params+=" --tls-private-key-file=${APISERVER_SERVER_KEY_PATH}"
   if [[ -n "${OLD_MASTER_IP:-}" ]]; then
     local old_ips="${OLD_MASTER_IP}"
-    if [[ -n "${OLD_LOAD_BALANCER_IP}" ]]; then
+    if [[ -n "${OLD_LOAD_BALANCER_IP:-}" ]]; then
       old_ips+=",${OLD_LOAD_BALANCER_IP}"
     fi
     params+=" --tls-sni-cert-key=${OLD_MASTER_CERT_PATH},${OLD_MASTER_KEY_PATH}:${old_ips}"


### PR DESCRIPTION
It no longer errors and exits if
env-var OLD_LOAD_BALANCER_IP is undefined.

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Fixes fatal error when running the script when env-var is undefined. 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes GCE bug. FIxup of #91228

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

/assign @mikedanese @liggitt 
