### PR TITLE
Add warning if client/server version difference exceeds the supported skew

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/util/BUILD
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/util/BUILD
@@ -22,6 +22,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/util/errors:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/yaml:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/version:go_default_library",
         "//staging/src/k8s.io/cli-runtime/pkg/genericclioptions:go_default_library",
         "//staging/src/k8s.io/cli-runtime/pkg/resource:go_default_library",
         "//staging/src/k8s.io/client-go/discovery:go_default_library",
@@ -46,7 +47,10 @@ go_library(
 
 go_test(
     name = "go_default_test",
-    srcs = ["helpers_test.go"],
+    srcs = [
+        "helpers_test.go",
+        "kubectl_match_version_test.go",
+    ],
     embed = [":go_default_library"],
     deps = [
         "//staging/src/k8s.io/api/core/v1:go_default_library",
@@ -58,6 +62,10 @@ go_test(
         "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/diff:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/validation/field:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/version:go_default_library",
+        "//staging/src/k8s.io/cli-runtime/pkg/genericclioptions:go_default_library",
+        "//staging/src/k8s.io/client-go/discovery/fake:go_default_library",
+        "//staging/src/k8s.io/client-go/testing:go_default_library",
         "//staging/src/k8s.io/kubectl/pkg/scheme:go_default_library",
         "//vendor/k8s.io/utils/exec:go_default_library",
     ],

--- a/staging/src/k8s.io/kubectl/pkg/cmd/util/kubectl_match_version_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/util/kubectl_match_version_test.go
@@ -1,0 +1,153 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"bytes"
+	apimachineryversion "k8s.io/apimachinery/pkg/version"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	fakediscovery "k8s.io/client-go/discovery/fake"
+	coretesting "k8s.io/client-go/testing"
+	"os"
+	"testing"
+)
+
+type fakeCachedDiscoveryClient struct {
+	fakediscovery.FakeDiscovery
+}
+
+func (svp *fakeCachedDiscoveryClient) Fresh() bool {
+	return true
+}
+
+func (svp *fakeCachedDiscoveryClient) Invalidate() {
+}
+
+func TestVersionSkewWarning(t *testing.T) {
+	discoveryClient := &fakeCachedDiscoveryClient{}
+	discoveryClient.Fake = &coretesting.Fake{}
+	output := &bytes.Buffer{}
+	mvf := &MatchVersionFlags{
+		Delegate:                 genericclioptions.NewTestConfigFlags().WithDiscoveryClient(discoveryClient),
+		versionSkewWarningWriter: output,
+	}
+
+	testCases := []struct {
+		name               string
+		clientMajorVersion string
+		clientMinorVersion string
+		serverMajorVersion string
+		serverMinorVersion string
+		isWarningExpected  bool
+	}{
+		{
+			name:               "Should not warn if server and client versions are same",
+			clientMajorVersion: "1",
+			clientMinorVersion: "19",
+			serverMajorVersion: "1",
+			serverMinorVersion: "19",
+			isWarningExpected:  false,
+		},
+		{
+			name:               "Should not warn if server and client versions are same except server minor has a plus sign",
+			clientMajorVersion: "1",
+			clientMinorVersion: "19",
+			serverMajorVersion: "1",
+			serverMinorVersion: "19+",
+			isWarningExpected:  false,
+		},
+		{
+			name:               "Should not warn if server is 1 minor version ahead of client",
+			clientMajorVersion: "1",
+			clientMinorVersion: "18",
+			serverMajorVersion: "1",
+			serverMinorVersion: "19",
+			isWarningExpected:  false,
+		},
+		{
+			name:               "Should not warn if server is 1 minor version behind client",
+			clientMajorVersion: "1",
+			clientMinorVersion: "19",
+			serverMajorVersion: "1",
+			serverMinorVersion: "18",
+			isWarningExpected:  false,
+		},
+		{
+			name:               "Should warn if server is 2 minor versions ahead of client",
+			clientMajorVersion: "1",
+			clientMinorVersion: "17",
+			serverMajorVersion: "1",
+			serverMinorVersion: "19",
+			isWarningExpected:  true,
+		},
+		{
+			name:               "Should warn if server is 2 minor versions behind client",
+			clientMajorVersion: "1",
+			clientMinorVersion: "19",
+			serverMajorVersion: "1",
+			serverMinorVersion: "17",
+			isWarningExpected:  true,
+		},
+		{
+			name:               "Should warn if major versions are not equal",
+			clientMajorVersion: "1",
+			clientMinorVersion: "0",
+			serverMajorVersion: "2",
+			serverMinorVersion: "0",
+			isWarningExpected:  true,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			output.Reset()
+
+			mvf.clientVersion = apimachineryversion.Info{Major: tc.clientMajorVersion, Minor: tc.clientMinorVersion}
+			discoveryClient.FakedServerVersion = &apimachineryversion.Info{Major: tc.serverMajorVersion, Minor: tc.serverMinorVersion}
+
+			mvf.warnIfUnsupportedVersionSkew()
+
+			if tc.isWarningExpected && output.Len() == 0 {
+				t.Error("warning was expected, but not written to the output")
+			} else if !tc.isWarningExpected && output.Len() > 0 {
+				t.Errorf("warning was not expected, but was written to the output: %s", output.String())
+			}
+		})
+	}
+}
+
+func TestVersionSkewWarningSuppression(t *testing.T) {
+	discoveryClient := &fakeCachedDiscoveryClient{}
+	discoveryClient.Fake = &coretesting.Fake{}
+	output := &bytes.Buffer{}
+	mvf := &MatchVersionFlags{
+		Delegate:                 genericclioptions.NewTestConfigFlags().WithDiscoveryClient(discoveryClient),
+		versionSkewWarningWriter: output,
+	}
+
+	if err := os.Setenv(suppressVersionSkewWarningEnvironmentVariable, "true"); err != nil {
+		t.Fatalf(err.Error())
+	}
+	defer os.Unsetenv(suppressVersionSkewWarningEnvironmentVariable)
+
+	mvf.clientVersion = apimachineryversion.Info{Major: "1", Minor: "19"}
+	discoveryClient.FakedServerVersion = &apimachineryversion.Info{Major: "1", Minor: "17"}
+
+	mvf.warnIfUnsupportedVersionSkew()
+	if output.Len() > 0 {
+		t.Errorf("warning was expected to be suppressed, but was written to the output: %s", output.String())
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
When version difference between client and server is more than 1 minor version, display a warning message to the user. 

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes/kubectl/issues/685

**Special notes for your reviewer**:
* I'm not certain that this is the best place for this code, but I thought I would go ahead and add it here at least as a starting point. Let me know if you think it belongs someplace else.

* I found some mixed information on whether the supported skew was +/-1 or +/-2 minor versions. I went with +/-1 because that is [what I found in the official documentation](https://kubernetes.io/docs/setup/release/version-skew-policy/#kubectl). Let me know if that is incorrect.

* The warning looks like this and is written to stderr. Let me know any changes needed: 
```
WARNING: version difference between client (1.19) and server (1.17) exceeds the supported minor version skew of +/-1
```

* I included an environment variable you can set to suppress the warning, if you are sure you don't want to see it. If you set `KUBECTL_SUPPRESS_VERSION_SKEW_WARNING=true` then the version skew check won't be performed. Good idea? Bad idea? let me know. I was thinking it might be nice to at least have some way to suppress the warning, but it should be a conscious thing.

**Does this PR introduce a user-facing change?**:
```release-note
Added warning message to kubectl when the difference between the client and server versions exceeds the sported version skew
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

/cc @seans3 
/cc @soltysh 