### PR TITLE
Add comment for Image and imagePullPolicy

### DIFF
--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -2122,6 +2122,7 @@ type Container struct {
 	// More info: https://kubernetes.io/docs/concepts/containers/images
 	// This field is optional to allow higher level config management to default or override
 	// container images in workload controllers like Deployments and StatefulSets.
+	// If no tag and no digest are specified on the image, :latest is used.
 	// +optional
 	Image string `json:"image,omitempty" protobuf:"bytes,2,opt,name=image"`
 	// Entrypoint array. Not executed within a shell.
@@ -2240,7 +2241,7 @@ type Container struct {
 	TerminationMessagePolicy TerminationMessagePolicy `json:"terminationMessagePolicy,omitempty" protobuf:"bytes,20,opt,name=terminationMessagePolicy,casttype=TerminationMessagePolicy"`
 	// Image pull policy.
 	// One of Always, Never, IfNotPresent.
-	// Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+	// Defaults to Always if :latest or no tag is specified, IfNotPresent otherwise.
 	// Cannot be updated.
 	// More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
 	// +optional


### PR DESCRIPTION
imagePullPolicy when defined without a value defaults to Always not to IfNotPresent
Added a comment clarifying that.

<!--  Thanks for sending a pull request!  Here are some tips for you:

/kind documentation

**What this PR does / why we need it**:
Fixes https://github.com/kubernetes/kubernetes/issues/91944#

Also, there is another PR for website.