### PR TITLE
Add Deprecated description to metrics scheduling_duration_seconds

### DIFF
--- a/pkg/controller/volume/scheduling/metrics/metrics.go
+++ b/pkg/controller/volume/scheduling/metrics/metrics.go
@@ -38,11 +38,12 @@ var (
 	// VolumeSchedulingStageLatency tracks the latency of volume scheduling operations.
 	VolumeSchedulingStageLatency = metrics.NewHistogramVec(
 		&metrics.HistogramOpts{
-			Subsystem:      VolumeSchedulerSubsystem,
-			Name:           "scheduling_duration_seconds",
-			Help:           "Volume scheduling stage latency",
-			Buckets:        metrics.ExponentialBuckets(1000, 2, 15),
-			StabilityLevel: metrics.ALPHA,
+			Subsystem:         VolumeSchedulerSubsystem,
+			Name:              "scheduling_duration_seconds",
+			Help:              "Volume scheduling stage latency (Deprecated since 1.19.0)",
+			Buckets:           metrics.ExponentialBuckets(1000, 2, 15),
+			StabilityLevel:    metrics.ALPHA,
+			DeprecatedVersion: "1.19.0",
 		},
 		[]string{"operation"},
 	)

--- a/pkg/scheduler/metrics/metrics.go
+++ b/pkg/scheduler/metrics/metrics.go
@@ -68,7 +68,7 @@ var (
 		&metrics.SummaryOpts{
 			Subsystem: SchedulerSubsystem,
 			Name:      DeprecatedSchedulingDurationName,
-			Help:      "Scheduling latency in seconds split by sub-parts of the scheduling operation",
+			Help:      "Scheduling latency in seconds split by sub-parts of the scheduling operation (Deprecated since 1.19.0)",
 			// Make the sliding window of 5h.
 			// TODO: The value for this should be based on some SLI definition (long term).
 			MaxAge:            5 * time.Hour,
@@ -99,7 +99,7 @@ var (
 		&metrics.HistogramOpts{
 			Subsystem:         SchedulerSubsystem,
 			Name:              "scheduling_algorithm_predicate_evaluation_seconds",
-			Help:              "Scheduling algorithm predicate evaluation duration in seconds",
+			Help:              "Scheduling algorithm predicate evaluation duration in seconds (Deprecated since 1.19.0)",
 			Buckets:           metrics.ExponentialBuckets(0.001, 2, 15),
 			StabilityLevel:    metrics.ALPHA,
 			DeprecatedVersion: "1.19.0",
@@ -109,7 +109,7 @@ var (
 		&metrics.HistogramOpts{
 			Subsystem:         SchedulerSubsystem,
 			Name:              "scheduling_algorithm_priority_evaluation_seconds",
-			Help:              "Scheduling algorithm priority evaluation duration in seconds",
+			Help:              "Scheduling algorithm priority evaluation duration in seconds (Deprecated since 1.19.0)",
 			Buckets:           metrics.ExponentialBuckets(0.001, 2, 15),
 			StabilityLevel:    metrics.ALPHA,
 			DeprecatedVersion: "1.19.0",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:

/kind documentation

**What this PR does / why we need it**:

This PR adds Deprecated description to metrics scheduling_duration_seconds.
scheduling_duration_seconds is deprecated since v1.18.
See: https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.18.md#kube-scheduler


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #



**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
