### PR TITLE
Automated cherry pick of #89908: Skip updating cache on pod update if…

### DIFF
--- a/pkg/scheduler/internal/cache/cache.go
+++ b/pkg/scheduler/internal/cache/cache.go
@@ -367,6 +367,13 @@ func (cache *schedulerCache) addPod(pod *v1.Pod) {
 
 // Assumes that lock is already acquired.
 func (cache *schedulerCache) updatePod(oldPod, newPod *v1.Pod) error {
+	if _, ok := cache.nodes[newPod.Spec.NodeName]; !ok {
+		// The node might have been deleted already.
+		// This is not a problem in the case where a pod update arrives before the
+		// node creation, because we will always have a create pod event before
+		// that, which will create the placeholder node item.
+		return nil
+	}
 	if err := cache.removePod(oldPod); err != nil {
 		return err
 	}


### PR DESCRIPTION
Cherry pick of #89908 on release-1.17.

#89908: Skip updating cache on pod update if the node was deleted

For details on the cherry pick process, see the cherry pick requests page.