### PR TITLE
Update logging format flag help

### DIFF
--- a/staging/src/k8s.io/component-base/logs/options.go
+++ b/staging/src/k8s.io/component-base/logs/options.go
@@ -17,9 +17,13 @@ limitations under the License.
 package logs
 
 import (
+	"flag"
 	"fmt"
+	"strings"
+
 	"github.com/go-logr/logr"
 	"github.com/spf13/pflag"
+
 	"k8s.io/klog/v2"
 )
 
@@ -27,6 +31,12 @@ const (
 	logFormatFlagName = "logging-format"
 	defaultLogFormat  = "text"
 )
+
+// List of logs (k8s.io/klog + k8s.io/component-base/logs) flags supported by all logging formats
+var supportedLogsFlags = map[string]struct{}{
+	"v":       {},
+	"vmodule": {},
+}
 
 // Options has klog format parameters
 type Options struct {
@@ -50,7 +60,9 @@ func (o *Options) Validate() []error {
 
 // AddFlags add logging-format flag
 func (o *Options) AddFlags(fs *pflag.FlagSet) {
-	fs.StringVar(&o.LogFormat, logFormatFlagName, defaultLogFormat, "Set log format")
+	unsupportedFlags := fmt.Sprintf("--%s", strings.Join(unsupportedLoggingFlags(), ", --"))
+	formats := fmt.Sprintf(`"%s"`, strings.Join(logRegistry.List(), `", "`))
+	fs.StringVar(&o.LogFormat, logFormatFlagName, defaultLogFormat, fmt.Sprintf("Set format of logs written by component. Options: %s. Non default formats don't support klog flags like: %s.", formats, unsupportedFlags))
 }
 
 // Apply set klog logger from LogFormat type
@@ -64,4 +76,27 @@ func (o *Options) Apply() {
 // Get logger with LogFormat field
 func (o *Options) Get() (logr.Logger, error) {
 	return logRegistry.Get(o.LogFormat)
+}
+
+func unsupportedLoggingFlags() []string {
+	allFlags := []string{}
+
+	// k8s.io/klog flags
+	fs := &flag.FlagSet{}
+	klog.InitFlags(fs)
+	fs.VisitAll(func(flag *flag.Flag) {
+		if _, found := supportedLogsFlags[flag.Name]; !found {
+			allFlags = append(allFlags, flag.Name)
+		}
+	})
+
+	// k8s.io/component-base/logs flags
+	pfs := &pflag.FlagSet{}
+	AddFlags(pfs)
+	pfs.VisitAll(func(flag *pflag.Flag) {
+		if _, found := supportedLogsFlags[flag.Name]; !found {
+			allFlags = append(allFlags, flag.Name)
+		}
+	})
+	return allFlags
 }

--- a/staging/src/k8s.io/component-base/logs/options.go
+++ b/staging/src/k8s.io/component-base/logs/options.go
@@ -62,7 +62,7 @@ func (o *Options) Validate() []error {
 func (o *Options) AddFlags(fs *pflag.FlagSet) {
 	unsupportedFlags := fmt.Sprintf("--%s", strings.Join(unsupportedLoggingFlags(), ", --"))
 	formats := fmt.Sprintf(`"%s"`, strings.Join(logRegistry.List(), `", "`))
-	fs.StringVar(&o.LogFormat, logFormatFlagName, defaultLogFormat, fmt.Sprintf("Set format of logs written by component. Options: %s. Non default formats don't support klog flags like: %s.", formats, unsupportedFlags))
+	fs.StringVar(&o.LogFormat, logFormatFlagName, defaultLogFormat, fmt.Sprintf("Sets the log format. Permitted formats: %s.\nNon-default formats don't honor these flags: %s.\nNon-default choices are currently alpha and subject to change without warning.", formats, unsupportedFlags))
 }
 
 // Apply set klog logger from LogFormat type

--- a/staging/src/k8s.io/component-base/logs/registry.go
+++ b/staging/src/k8s.io/component-base/logs/registry.go
@@ -80,6 +80,17 @@ func (lfr *LogFormatRegistry) Delete(name string) {
 	delete(lfr.registry, name)
 }
 
+// List names of registered log formats
+func (lfr *LogFormatRegistry) List() []string {
+	lfr.mu.Lock()
+	defer lfr.mu.Unlock()
+	formats := make([]string, 0, len(lfr.registry))
+	for f := range lfr.registry {
+		formats = append(formats, f)
+	}
+	return formats
+}
+
 func init() {
 	// Text format is default klog format
 	logRegistry.Register(defaultLogFormat, nil)


### PR DESCRIPTION
/kind feature
Ref  https://github.com/kubernetes/enhancements/issues/1602

Rendered version:
```
Logs flags:

      --logging-format string                                                                                                                                        
                Sets the log format. Permitted formats: "text", "json".
                Non-default formats don't honor these flags: --add_dir_header, --alsologtostderr, --log_backtrace_at, --log_dir, --log_file, --log_file_max_size,
                --logtostderr, --skip_headers, --skip_log_headers, --stderrthreshold, --log-flush-frequency.
                Non-default choices are currently alpha and subject to change without warning. (default "text")
```

```release-note
Document JSON format in --logging-format command line flag
```

```docs
- [KEP]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-instrumentation/1602-structured-logging
```
/priority important-soon
/sig instrumentation
