### PR TITLE
prevent panic in azure cloud provider from killing the process

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_routes.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_routes.go
@@ -29,6 +29,7 @@ import (
 	"github.com/Azure/go-autorest/autorest/to"
 
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
 	cloudprovider "k8s.io/cloud-provider"
 	"k8s.io/klog/v2"
 	azcache "k8s.io/legacy-cloud-providers/azure/cache"
@@ -90,9 +91,12 @@ func newDelayedRouteUpdater(az *Cloud, interval time.Duration) *delayedRouteUpda
 
 // run starts the updater reconciling loop.
 func (d *delayedRouteUpdater) run() {
-	for {
+	err := wait.PollImmediateInfinite(d.interval, func() (bool, error) {
 		d.updateRoutes()
-		time.Sleep(d.interval)
+		return false, nil
+	})
+	if err != nil { // this should never happen, if it does, panic
+		panic(err)
 	}
 }
 


### PR DESCRIPTION
without panic protection on the launched go func, any panic will kill the process

/kind bug
/priority important-soon

```release-note
NONE
```