### PR TITLE
Pods which have not "started" can not be "ready"

### DIFF
--- a/pkg/kubelet/prober/prober_manager.go
+++ b/pkg/kubelet/prober/prober_manager.go
@@ -235,18 +235,6 @@ func (m *manager) CleanupPods(desiredPods map[types.UID]sets.Empty) {
 
 func (m *manager) UpdatePodStatus(podUID types.UID, podStatus *v1.PodStatus) {
 	for i, c := range podStatus.ContainerStatuses {
-		var ready bool
-		if c.State.Running == nil {
-			ready = false
-		} else if result, ok := m.readinessManager.Get(kubecontainer.ParseContainerID(c.ContainerID)); ok {
-			ready = result == results.Success
-		} else {
-			// The check whether there is a probe which hasn't run yet.
-			_, exists := m.getWorker(podUID, c.Name, readiness)
-			ready = !exists
-		}
-		podStatus.ContainerStatuses[i].Ready = ready
-
 		var started bool
 		if c.State.Running == nil {
 			started = false
@@ -261,6 +249,20 @@ func (m *manager) UpdatePodStatus(podUID types.UID, podStatus *v1.PodStatus) {
 			started = !exists
 		}
 		podStatus.ContainerStatuses[i].Started = &started
+
+		if started {
+			var ready bool
+			if c.State.Running == nil {
+				ready = false
+			} else if result, ok := m.readinessManager.Get(kubecontainer.ParseContainerID(c.ContainerID)); ok {
+				ready = result == results.Success
+			} else {
+				// The check whether there is a probe which hasn't run yet.
+				_, exists := m.getWorker(podUID, c.Name, readiness)
+				ready = !exists
+			}
+			podStatus.ContainerStatuses[i].Ready = ready
+		}
 	}
 	// init containers are ready if they have exited with success or if a readiness probe has
 	// succeeded.


### PR DESCRIPTION
Before this commit, containers which have both a `startupProbe` and a
`readinessProbe` are marked as `ready=false` during stratup, but
containers which have only a `startupProbe` are marked `ready=true`.
This doesn't make sense.

This commit only considers readiness if the container is considered to
have "started", which leaves `ready=false` while starting up.

/kind bug

Fixes #89995

**Special notes for your reviewer**:

I am NOT super familiar with this code area.  I dug around to find this and empirically it seems to work. 

**Does this PR introduce a user-facing change?**:

```release-note
Containers which specify a `startupProbe` but not a `readinessProbe` were previously considered "ready" before the `startupProbe` completed, but are now considered "not-ready".
```