### PR TITLE
Add profile label to schedule_attempts_total metric and e2e_scheduling_duration_seconds

### DIFF
--- a/pkg/scheduler/metrics/BUILD
+++ b/pkg/scheduler/metrics/BUILD
@@ -7,6 +7,7 @@ go_library(
     srcs = [
         "metric_recorder.go",
         "metrics.go",
+        "profile_metrics.go",
     ],
     importpath = "k8s.io/kubernetes/pkg/scheduler/metrics",
     deps = [

--- a/pkg/scheduler/metrics/metrics.go
+++ b/pkg/scheduler/metrics/metrics.go
@@ -54,16 +54,7 @@ var (
 			Name:           "schedule_attempts_total",
 			Help:           "Number of attempts to schedule pods, by the result. 'unschedulable' means a pod could not be scheduled, while 'error' means an internal scheduler problem.",
 			StabilityLevel: metrics.ALPHA,
-		}, []string{"result"})
-	// PodScheduleSuccesses counts how many pods were scheduled.
-	// This metric will be initialized again in Register() to assure the metric is not no-op metric.
-	PodScheduleSuccesses = scheduleAttempts.With(metrics.Labels{"result": "scheduled"})
-	// PodScheduleFailures counts how many pods could not be scheduled.
-	// This metric will be initialized again in Register() to assure the metric is not no-op metric.
-	PodScheduleFailures = scheduleAttempts.With(metrics.Labels{"result": "unschedulable"})
-	// PodScheduleErrors counts how many pods could not be scheduled due to a scheduler error.
-	// This metric will be initialized again in Register() to assure the metric is not no-op metric.
-	PodScheduleErrors            = scheduleAttempts.With(metrics.Labels{"result": "error"})
+		}, []string{"result", "profile"})
 	DeprecatedSchedulingDuration = metrics.NewSummaryVec(
 		&metrics.SummaryOpts{
 			Subsystem: SchedulerSubsystem,
@@ -77,15 +68,14 @@ var (
 		},
 		[]string{OperationLabel},
 	)
-	E2eSchedulingLatency = metrics.NewHistogram(
+	e2eSchedulingLatency = metrics.NewHistogramVec(
 		&metrics.HistogramOpts{
 			Subsystem:      SchedulerSubsystem,
 			Name:           "e2e_scheduling_duration_seconds",
 			Help:           "E2e scheduling latency in seconds (scheduling algorithm + binding)",
 			Buckets:        metrics.ExponentialBuckets(0.001, 2, 15),
 			StabilityLevel: metrics.ALPHA,
-		},
-	)
+		}, []string{"result", "profile"})
 	SchedulingAlgorithmLatency = metrics.NewHistogram(
 		&metrics.HistogramOpts{
 			Subsystem:      SchedulerSubsystem,
@@ -235,7 +225,7 @@ var (
 	metricsList = []metrics.Registerable{
 		scheduleAttempts,
 		DeprecatedSchedulingDuration,
-		E2eSchedulingLatency,
+		e2eSchedulingLatency,
 		SchedulingAlgorithmLatency,
 		BindingLatency,
 		DeprecatedSchedulingAlgorithmPredicateEvaluationSecondsDuration,
@@ -263,9 +253,6 @@ func Register() {
 	registerMetrics.Do(func() {
 		RegisterMetrics(metricsList...)
 		volumeschedulingmetrics.RegisterVolumeSchedulingMetrics()
-		PodScheduleSuccesses = scheduleAttempts.With(metrics.Labels{"result": "scheduled"})
-		PodScheduleFailures = scheduleAttempts.With(metrics.Labels{"result": "unschedulable"})
-		PodScheduleErrors = scheduleAttempts.With(metrics.Labels{"result": "error"})
 	})
 }
 

--- a/pkg/scheduler/metrics/profile_metrics.go
+++ b/pkg/scheduler/metrics/profile_metrics.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+// This file contains helpers for metrics that are associated to a profile.
+
+var (
+	scheduledResult     = "scheduled"
+	unschedulableResult = "unschedulable"
+	errorResult         = "error"
+)
+
+// PodScheduled can records a successful scheduling attempt and the duration
+// since `start`.
+func PodScheduled(profile string, duration float64) {
+	observeScheduleAttemptAndLatency(scheduledResult, profile, duration)
+}
+
+// PodUnschedulable can records a scheduling attempt for an unschedulable pod
+// and the duration since `start`.
+func PodUnschedulable(profile string, duration float64) {
+	observeScheduleAttemptAndLatency(unschedulableResult, profile, duration)
+}
+
+// PodScheduleError can records a scheduling attempt that had an error and the
+// duration since `start`.
+func PodScheduleError(profile string, duration float64) {
+	observeScheduleAttemptAndLatency(errorResult, profile, duration)
+}
+
+func observeScheduleAttemptAndLatency(result, profile string, duration float64) {
+	e2eSchedulingLatency.WithLabelValues(result, profile).Observe(duration)
+	scheduleAttempts.WithLabelValues(result, profile).Inc()
+}

--- a/pkg/scheduler/profile/profile.go
+++ b/pkg/scheduler/profile/profile.go
@@ -40,19 +40,22 @@ type FrameworkFactory func(config.KubeSchedulerProfile, ...frameworkruntime.Opti
 type Profile struct {
 	framework.Framework
 	Recorder events.EventRecorder
+	Name     string
 }
 
 // NewProfile builds a Profile for the given configuration.
 func NewProfile(cfg config.KubeSchedulerProfile, frameworkFact FrameworkFactory, recorderFact RecorderFactory,
 	opts ...frameworkruntime.Option) (*Profile, error) {
-	r := recorderFact(cfg.SchedulerName)
-	f, err := frameworkFact(cfg, append(opts, frameworkruntime.WithEventRecorder(r))...)
+	recorder := recorderFact(cfg.SchedulerName)
+	opts = append(opts, frameworkruntime.WithEventRecorder(recorder))
+	fwk, err := frameworkFact(cfg, opts...)
 	if err != nil {
 		return nil, err
 	}
 	return &Profile{
-		Framework: f,
-		Recorder:  r,
+		Name:      cfg.SchedulerName,
+		Framework: fwk,
+		Recorder:  recorder,
 	}, nil
 }
 

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -319,6 +319,7 @@ func TestSchedulerScheduleOne(t *testing.T) {
 					testSchedulerName: &profile.Profile{
 						Framework: fwk,
 						Recorder:  eventBroadcaster.NewRecorder(scheme.Scheme, testSchedulerName),
+						Name:      testSchedulerName,
 					},
 				},
 			}
@@ -770,6 +771,7 @@ func setupTestScheduler(queuedPodStore *clientcache.FIFO, scache internalcache.C
 	prof := &profile.Profile{
 		Framework: fwk,
 		Recorder:  &events.FakeRecorder{},
+		Name:      testSchedulerName,
 	}
 	if broadcaster != nil {
 		prof.Recorder = broadcaster.NewRecorder(scheme.Scheme, testSchedulerName)


### PR DESCRIPTION
Also adding `result` label to e2e_scheduling_duration_seconds. Previously, the metric was only updated for successful attempts

/sig scheduling

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

A `profile` label allows cluster operators to distinguish different behavior from different scheduling profiles.

The metric e2e_scheduling_duration_seconds was only tracking successful scheduling attempts. This doesn't reflect the true latency of the scheduler. The `result` label can be used to filter out the latencies for specific results.

**Which issue(s) this PR fixes**:

Refs #92189 kubernetes/enhancements#1451

**Special notes for your reviewer**:

In a follow up PR, more metrics will get the same label.

**Does this PR introduce a user-facing change?**:

```release-note
- Adds profile label to kube-scheduler metric schedule_attempts_total
- Adds result and profile label to e2e_scheduling_duration_seconds. Times for unschedulable and error attempts are now recorded.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs
[KEP]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-scheduling/1451-multi-scheduling-profiles
```
