### PR TITLE
Add sjenning as kubelet approver

### DIFF
--- a/pkg/kubelet/OWNERS
+++ b/pkg/kubelet/OWNERS
@@ -7,6 +7,7 @@ approvers:
 - vishh
 - yujuhong
 - dashpole
+- sjenning
 reviewers:
 - sig-node-reviewers
 - tallclair

--- a/pkg/kubelet/cadvisor/OWNERS
+++ b/pkg/kubelet/cadvisor/OWNERS
@@ -1,4 +1,0 @@
-# See the OWNERS docs at https://go.k8s.io/owners
-
-approvers:
-- sjenning

--- a/pkg/kubelet/cm/OWNERS
+++ b/pkg/kubelet/cm/OWNERS
@@ -7,7 +7,6 @@ approvers:
 - vishh
 - yujuhong
 - ConnorDoyle
-- sjenning
 - klueska
 reviewers:
 - sig-node-reviewers

--- a/pkg/kubelet/cm/cpumanager/OWNERS
+++ b/pkg/kubelet/cm/cpumanager/OWNERS
@@ -4,7 +4,6 @@ approvers:
 - derekwaynecarr
 - vishh
 - ConnorDoyle
-- sjenning
 - balajismaniam
 reviewers:
 - klueska

--- a/pkg/kubelet/cm/cpuset/OWNERS
+++ b/pkg/kubelet/cm/cpuset/OWNERS
@@ -4,4 +4,3 @@ approvers:
 - derekwaynecarr
 - vishh
 - ConnorDoyle
-- sjenning

--- a/pkg/kubelet/eviction/OWNERS
+++ b/pkg/kubelet/eviction/OWNERS
@@ -1,4 +1,0 @@
-# See the OWNERS docs at https://go.k8s.io/owners
-
-approvers:
-- sjenning

--- a/pkg/kubelet/images/OWNERS
+++ b/pkg/kubelet/images/OWNERS
@@ -1,4 +1,0 @@
-# See the OWNERS docs at https://go.k8s.io/owners
-
-approvers:
-- sjenning

--- a/pkg/kubelet/metrics/OWNERS
+++ b/pkg/kubelet/metrics/OWNERS
@@ -1,4 +1,0 @@
-# See the OWNERS docs at https://go.k8s.io/owners
-
-approvers:
-- sjenning

--- a/pkg/kubelet/preemption/OWNERS
+++ b/pkg/kubelet/preemption/OWNERS
@@ -1,4 +1,0 @@
-# See the OWNERS docs at https://go.k8s.io/owners
-
-approvers:
-- sjenning


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
/priority backlog
/sig node
/assign @derekwaynecarr @dchen1107

_NOTE: this is stacked on top of https://github.com/kubernetes/kubernetes/pull/86223 and it should merge first_

**What this PR does / why we need it:**
As proposed in sig-node on 12/10/2019 by @RainbowMango and approved by @dchen1107 and @derekwaynecarr during the meeting, I am adding myself as a kubelet approver. There was agreement at sig-node that we should use this to establish a bar for use in future decisions to grant approver status.

The community membership docs say that approver requirements are "highly experienced and active reviewer + contributor to a subproject".

My experience:
Kubernetes member working on the kubelet since 2/2016
I have [93 commits](https://github.com/kubernetes/kubernetes/pulls?q=is%3Apr+author%3Asjenning) in kubernetes/kubernetes with 53 commits in {pkg,cmd}/kubelet
I am an active member of SIG-Node, regularly attending and participating in the sig weekly meeting 
[PRs](https://github.com/kubernetes/kubernetes/issues?q=is%3Aissue+commenter%3Asjenning) [Issues](https://github.com/kubernetes/kubernetes/pulls?q=is%3Apr+commenter%3Asjenning)
I am already a `sig-node-reviewer` and an approver on the following kubelet subcomponents:
* pkg/kubelet/preemption
* pkg/kubelet/cm
* pkg/kubelet/images
* pkg/kubelet/eviction
* pkg/kubelet/metrics
* pkg/kubelet/cadvisor

see https://github.com/kubernetes/kubernetes/pull/86223#issue-352586160

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```