### PR TITLE
Change session affinity e2e tests to use config.MaxTries like other tests

### DIFF
--- a/test/e2e/framework/network/utils.go
+++ b/test/e2e/framework/network/utils.go
@@ -74,8 +74,6 @@ const (
 	testTries = 30
 	// Maximum number of pods in a test, to make test work in large clusters.
 	maxNetProxyPodsCount = 10
-	// SessionAffinityChecks is number of checks to hit a given set of endpoints when enable session affinity.
-	SessionAffinityChecks = 10
 	// RegexIPv4 is a regex to match IPv4 addresses
 	RegexIPv4 = "(?:\\d+)\\.(?:\\d+)\\.(?:\\d+)\\.(?:\\d+)"
 	// RegexIPv6 is a regex to match IPv6 addresses
@@ -255,7 +253,7 @@ func (config *NetworkingTestConfig) DialFromContainer(protocol, dialCommand, con
 			var output map[string][]string
 			if err := json.Unmarshal([]byte(stdout), &output); err != nil {
 				framework.Logf("WARNING: Failed to unmarshal curl response. Cmd %v run in %v, output: %s, err: %v",
-					cmd, config.HostTestContainerPod.Name, stdout, err)
+					cmd, config.TestContainerPod.Name, stdout, err)
 				continue
 			}
 
@@ -272,7 +270,6 @@ func (config *NetworkingTestConfig) DialFromContainer(protocol, dialCommand, con
 		if (responses.Equal(expectedResponses) || responses.Len() == 0 && expectedResponses.Len() == 0) && i+1 >= minTries {
 			return
 		}
-		// TODO: get rid of this delay #36281
 		time.Sleep(hitEndpointRetryDelay)
 	}
 
@@ -313,11 +310,11 @@ func (config *NetworkingTestConfig) GetEndpointsFromContainer(protocol, containe
 			// we confirm unreachability.
 			framework.Logf("Failed to execute %q: %v, stdout: %q, stderr: %q", cmd, err, stdout, stderr)
 		} else {
-			framework.Logf("Tries: %d, in try: %d, stdout: %v, stderr: %v, command run in: %#v", tries, i, stdout, stderr, config.HostTestContainerPod)
+			framework.Logf("Tries: %d, in try: %d, stdout: %v, stderr: %v, command run in: %#v", tries, i, stdout, stderr, config.TestContainerPod)
 			var output map[string][]string
 			if err := json.Unmarshal([]byte(stdout), &output); err != nil {
 				framework.Logf("WARNING: Failed to unmarshal curl response. Cmd %v run in %v, output: %s, err: %v",
-					cmd, config.HostTestContainerPod.Name, stdout, err)
+					cmd, config.TestContainerPod.Name, stdout, err)
 				continue
 			}
 
@@ -327,7 +324,6 @@ func (config *NetworkingTestConfig) GetEndpointsFromContainer(protocol, containe
 					eps.Insert(trimmed)
 				}
 			}
-			// TODO: get rid of this delay #36281
 			time.Sleep(hitEndpointRetryDelay)
 		}
 	}
@@ -384,7 +380,6 @@ func (config *NetworkingTestConfig) DialFromNode(protocol, targetIP string, targ
 
 		framework.Logf("Waiting for %+v endpoints (expected=%+v, actual=%+v)", expectedEps.Difference(eps).List(), expectedEps.List(), eps.List())
 
-		// TODO: get rid of this delay #36281
 		time.Sleep(hitEndpointRetryDelay)
 	}
 

--- a/test/e2e/network/networking.go
+++ b/test/e2e/network/networking.go
@@ -278,7 +278,7 @@ var _ = SIGDescribe("Networking", func() {
 			ginkgo.By(fmt.Sprintf("dialing(http) %v --> %v:%v", config.TestContainerPod.Name, config.SessionAffinityService.Spec.ClusterIP, e2enetwork.ClusterHTTPPort))
 
 			// Check if number of endpoints returned are exactly one.
-			eps, err := config.GetEndpointsFromTestContainer("http", config.SessionAffinityService.Spec.ClusterIP, e2enetwork.ClusterHTTPPort, e2enetwork.SessionAffinityChecks)
+			eps, err := config.GetEndpointsFromTestContainer("http", config.SessionAffinityService.Spec.ClusterIP, e2enetwork.ClusterHTTPPort, config.MaxTries)
 			if err != nil {
 				framework.Failf("ginkgo.Failed to get endpoints from test container, error: %v", err)
 			}
@@ -296,7 +296,7 @@ var _ = SIGDescribe("Networking", func() {
 			ginkgo.By(fmt.Sprintf("dialing(udp) %v --> %v:%v", config.TestContainerPod.Name, config.SessionAffinityService.Spec.ClusterIP, e2enetwork.ClusterUDPPort))
 
 			// Check if number of endpoints returned are exactly one.
-			eps, err := config.GetEndpointsFromTestContainer("udp", config.SessionAffinityService.Spec.ClusterIP, e2enetwork.ClusterUDPPort, e2enetwork.SessionAffinityChecks)
+			eps, err := config.GetEndpointsFromTestContainer("udp", config.SessionAffinityService.Spec.ClusterIP, e2enetwork.ClusterUDPPort, config.MaxTries)
 			if err != nil {
 				framework.Failf("ginkgo.Failed to get endpoints from test container, error: %v", err)
 			}


### PR DESCRIPTION
* Change session affinity tests to use config.MaxTries like other tests 
* Fixed a couple of wrong pod names in log messages

**What type of PR is this?**
/kind flake

**What this PR does / why we need it**:
20 seconds (10 tries * 2s timeout) is not long enough to wait. It looks like kube-proxy could [fail to get iptables lock](https://storage.googleapis.com/kubernetes-jenkins/pr-logs/pull/92152/pull-kubernetes-e2e-kind-ipv6/1272686261995311107/artifacts/logs/kind-worker/containers/kube-proxy-b8ljz_kube-system_kube-proxy-f447ae985d06246fbb92e531f23a25e7f047e64a90799bb6ce426a06c1e630df.log) and will wait 30 seconds to retry if that happens.
> 2020-06-16T01:19:37.353142619Z stderr F E0616 01:19:37.321543       1 proxier.go:858] Failed to ensure that filter chain KUBE-EXTERNAL-SERVICES exists: error creating chain "KUBE-EXTERNAL-SERVICES": exit status 4: Another app is currently holding the xtables lock; still 4s 100000us time ahead to have a chance to grab the lock...
> 2020-06-16T01:19:37.353221178Z stderr F Another app is currently holding the xtables lock; still 3s 100000us time ahead to have a chance to grab the lock...
> 2020-06-16T01:19:37.353232305Z stderr F Another app is currently holding the xtables lock; still 2s 100000us time ahead to have a chance to grab the lock...
> 2020-06-16T01:19:37.353238819Z stderr F Another app is currently holding the xtables lock; still 1s 100000us time ahead to have a chance to grab the lock...
> 2020-06-16T01:19:37.353245281Z stderr F Another app is currently holding the xtables lock; still 0s 100000us time ahead to have a chance to grab the lock...
> 2020-06-16T01:19:37.353252315Z stderr F Another app is currently holding the xtables lock. Stopped waiting after 5s.
> 2020-06-16T01:19:37.353260493Z stderr F I0616 01:19:37.321593       1 proxier.go:850] Sync failed; retrying in 30s

This PR makes the session affinity tests use the same number of tries as other tests.

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs

```
