### PR TITLE
test/network: don't panic when "GCE [Slow] [Feature:kubemci]" tests are skipped

### DIFF
--- a/test/e2e/network/ingress.go
+++ b/test/e2e/network/ingress.go
@@ -628,8 +628,10 @@ var _ = SIGDescribe("Loadbalancing: L7", func() {
 			}
 
 			ginkgo.By("Cleaning up cloud resources")
-			err := gceController.CleanupIngressController()
-			framework.ExpectNoError(err)
+			if gceController != nil {
+				err := gceController.CleanupIngressController()
+				framework.ExpectNoError(err)
+			}
 		})
 
 		ginkgo.It("should conform to Ingress spec", func() {


### PR DESCRIPTION
If the test is skipped becuase the provider isn't GCE/GKE then
don't try to dereference nil.

```
2020-06-15T05:54:02.3943479Z [1mSTEP[0m: Cleaning up cloud resources
2020-06-15T05:54:06.6970224Z E0615 05:54:06.695713   67720 runtime.go:78] Observed a panic: "invalid memory address or nil pointer dereference" (runtime error: invalid memory address or nil pointer dereference)
2020-06-15T05:54:06.6970491Z goroutine 86 [running]:
2020-06-15T05:54:06.6970767Z k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/runtime.logPanic(0x40215e0, 0x7b71700)
2020-06-15T05:54:06.6971131Z 	/home/runner/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:74 +0xa3
2020-06-15T05:54:06.6971417Z k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/runtime.HandleCrash(0x0, 0x0, 0x0)
2020-06-15T05:54:06.6971761Z 	/home/runner/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:48 +0x82
2020-06-15T05:54:06.6971963Z panic(0x40215e0, 0x7b71700)
2020-06-15T05:54:06.6972190Z 	/opt/hostedtoolcache/go/1.13.4/x64/src/runtime/panic.go:679 +0x1b2
2020-06-15T05:54:06.6972510Z k8s.io/kubernetes/test/e2e/framework/providers/gce.(*IngressController).deleteForwardingRule(0x0, 0x0, 0xc0020a0e04, 0x2)
2020-06-15T05:54:06.6973078Z 	/home/runner/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/test/e2e/framework/providers/gce/ingress.go:158 +0x20b
2020-06-15T05:54:06.6973395Z k8s.io/kubernetes/test/e2e/framework/providers/gce.(*IngressController).Cleanup(0x0, 0x0, 0x1, 0xc0020a0d68)
2020-06-15T05:54:06.6973737Z 	/home/runner/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/test/e2e/framework/providers/gce/ingress.go:724 +0x38
2020-06-15T05:54:06.6974105Z k8s.io/kubernetes/test/e2e/framework/providers/gce.(*IngressController).CleanupIngressControllerWithTimeout.func1(0xc0020a0d78, 0xc00207ea80, 0xc002129e88)
2020-06-15T05:54:06.6974456Z 	/home/runner/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/test/e2e/framework/providers/gce/ingress.go:88 +0x33
2020-06-15T05:54:06.6974791Z k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/wait.runConditionWithCrashProtection(0xc0020a0fa0, 0xc0020a0e00, 0x0, 0x0)
2020-06-15T05:54:06.6975140Z 	/home/runner/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:211 +0x6f
2020-06-15T05:54:06.6975464Z k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/wait.WaitFor(0xc002c35040, 0xc0020a0fa0, 0xc00388a600, 0x0, 0x0)
2020-06-15T05:54:06.6975894Z 	/home/runner/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:528 +0x159
2020-06-15T05:54:06.6976318Z k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/wait.pollInternal(0xc002c35040, 0xc0020a0fa0, 0x0, 0x0)
2020-06-15T05:54:06.6976634Z 	/home/runner/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:414 +0x9f
2020-06-15T05:54:06.6976955Z k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/wait.Poll(0x12a05f200, 0xd18c2e2800, 0xc0020a0fa0, 0xc0000a6900, 0xc0020a0fb0)
2020-06-15T05:54:06.6977275Z 	/home/runner/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:408 +0x4d
2020-06-15T05:54:06.6977595Z k8s.io/kubernetes/test/e2e/framework/providers/gce.(*IngressController).CleanupIngressControllerWithTimeout(0x0, 0xd18c2e2800, 0x0, 0x0)
2020-06-15T05:54:06.6977901Z 	/home/runner/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/test/e2e/framework/providers/gce/ingress.go:87 +0x69
2020-06-15T05:54:06.6978180Z k8s.io/kubernetes/test/e2e/framework/providers/gce.(*IngressController).CleanupIngressController(...)
2020-06-15T05:54:06.6978486Z 	/home/runner/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/test/e2e/framework/providers/gce/ingress.go:81
2020-06-15T05:54:06.6978702Z k8s.io/kubernetes/test/e2e/network.glob..func10.4.2()
2020-06-15T05:54:06.6978981Z 	/home/runner/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/test/e2e/network/ingress.go:626 +0x12a
2020-06-15T05:54:06.6979318Z k8s.io/kubernetes/vendor/github.com/onsi/ginkgo/internal/leafnodes.(*runner).runSync(0xc000999320, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
2020-06-15T05:54:06.6979657Z 	/home/runner/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/github.com/onsi/ginkgo/internal/leafnodes/runner.go:113 +0xb8
2020-06-15T05:54:06.6979991Z k8s.io/kubernetes/vendor/github.com/onsi/ginkgo/internal/leafnodes.(*runner).run(0xc000999320, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
2020-06-15T05:54:06.6980324Z 	/home/runner/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/github.com/onsi/ginkgo/internal/leafnodes/runner.go:64 +0xcf
2020-06-15T05:54:06.6980668Z k8s.io/kubernetes/vendor/github.com/onsi/ginkgo/internal/leafnodes.(*SetupNode).Run(0xc0007e2b28, 0x51bc220, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
2020-06-15T05:54:06.6981002Z 	/home/runner/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/github.com/onsi/ginkgo/internal/leafnodes/setup_nodes.go:15 +0x64
2020-06-15T05:54:06.6981375Z k8s.io/kubernetes/vendor/github.com/onsi/ginkgo/internal/spec.(*Spec).runSample.func1(0xc0020a16c8, 0xc00270b590, 0x51bc220, 0xc0000a6900)
2020-06-15T05:54:06.6981702Z 	/home/runner/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/github.com/onsi/ginkgo/internal/spec/spec.go:180 +0x344
2020-06-15T05:54:06.6982150Z k8s.io/kubernetes/vendor/github.com/onsi/ginkgo/internal/spec.(*Spec).runSample(0xc00270b590, 0x0, 0x51bc220, 0xc0000a6900)
2020-06-15T05:54:06.6982471Z 	/home/runner/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/github.com/onsi/ginkgo/internal/spec/spec.go:197 +0x2e6
2020-06-15T05:54:06.6982767Z k8s.io/kubernetes/vendor/github.com/onsi/ginkgo/internal/spec.(*Spec).Run(0xc00270b590, 0x51bc220, 0xc0000a6900)
2020-06-15T05:54:06.6983083Z 	/home/runner/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/github.com/onsi/ginkgo/internal/spec/spec.go:138 +0x101
2020-06-15T05:54:06.6983387Z k8s.io/kubernetes/vendor/github.com/onsi/ginkgo/internal/specrunner.(*SpecRunner).runSpec(0xc00246cb40, 0xc00270b590, 0x0)
2020-06-15T05:54:06.6983729Z 	/home/runner/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/github.com/onsi/ginkgo/internal/specrunner/spec_runner.go:200 +0x10f
2020-06-15T05:54:06.6984019Z k8s.io/kubernetes/vendor/github.com/onsi/ginkgo/internal/specrunner.(*SpecRunner).runSpecs(0xc00246cb40, 0x1)
2020-06-15T05:54:06.6984407Z 	/home/runner/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/github.com/onsi/ginkgo/internal/specrunner/spec_runner.go:170 +0x120
2020-06-15T05:54:06.6984715Z k8s.io/kubernetes/vendor/github.com/onsi/ginkgo/internal/specrunner.(*SpecRunner).Run(0xc00246cb40, 0xc002a79710)
2020-06-15T05:54:06.6985046Z 	/home/runner/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/github.com/onsi/ginkgo/internal/specrunner/spec_runner.go:66 +0x117
2020-06-15T05:54:06.6985437Z k8s.io/kubernetes/vendor/github.com/onsi/ginkgo/internal/suite.(*Suite).Run(0xc0000d8320, 0x7ff312649690, 0xc002278700, 0x493d69d, 0x14, 0xc0024fefe0, 0x2, 0x2, 0x5285940, 0xc0000a6900, ...)
2020-06-15T05:54:06.6985774Z 	/home/runner/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/github.com/onsi/ginkgo/internal/suite/suite.go:62 +0x42b
2020-06-15T05:54:06.6986108Z k8s.io/kubernetes/vendor/github.com/onsi/ginkgo.RunSpecsWithCustomReporters(0x51c0960, 0xc002278700, 0x493d69d, 0x14, 0xc0024fefc0, 0x2, 0x2, 0x2)
2020-06-15T05:54:06.6986426Z 	/home/runner/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/github.com/onsi/ginkgo/ginkgo_dsl.go:226 +0x217
2020-06-15T05:54:06.6986770Z k8s.io/kubernetes/vendor/github.com/onsi/ginkgo.RunSpecsWithDefaultAndCustomReporters(0x51c0960, 0xc002278700, 0x493d69d, 0x14, 0xc000770070, 0x1, 0x1, 0x1)
2020-06-15T05:54:06.6987085Z 	/home/runner/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/github.com/onsi/ginkgo/ginkgo_dsl.go:214 +0xad
2020-06-15T05:54:06.6987474Z k8s.io/kubernetes/test/e2e.RunE2ETests(0xc002278700)
2020-06-15T05:54:06.6987703Z 	_output/local/go/src/k8s.io/kubernetes/test/e2e/e2e.go:125 +0x324
2020-06-15T05:54:06.6987919Z k8s.io/kubernetes/test/e2e.TestE2E(0xc002278700)
2020-06-15T05:54:06.6988153Z 	_output/local/go/src/k8s.io/kubernetes/test/e2e/e2e_test.go:111 +0x2b
2020-06-15T05:54:06.6988358Z testing.tRunner(0xc002278700, 0x4ae71e8)
2020-06-15T05:54:06.6988590Z 	/opt/hostedtoolcache/go/1.13.4/x64/src/testing/testing.go:909 +0xc9
2020-06-15T05:54:06.6988775Z created by testing.(*T).Run
2020-06-15T05:54:06.6989004Z 	/opt/hostedtoolcache/go/1.13.4/x64/src/testing/testing.go:960 +0x350
2020-06-15T05:54:06.6989808Z [AfterEach] [sig-network] Loadbalancing: L7
2020-06-15T05:54:06.6990116Z   /home/runner/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:179
2020-06-15T05:54:06.6990323Z Jun 15 05:54:06.696: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
2020-06-15T05:54:06.7210486Z [1mSTEP[0m: Destroying namespace "ingress-5383" for this suite.
```

/kind failing-test
```release-note
NONE
```

@danwinship @trozet @girishmg