### PR TITLE
Save container image when creating container, keep images in spec and…

### DIFF
--- a/pkg/kubelet/kuberuntime/labels.go
+++ b/pkg/kubelet/kuberuntime/labels.go
@@ -117,6 +117,7 @@ func newContainerAnnotations(container *v1.Container, pod *v1.Pod, restartCount 
 	annotations[containerRestartCountLabel] = strconv.Itoa(restartCount)
 	annotations[containerTerminationMessagePathLabel] = container.TerminationMessagePath
 	annotations[containerTerminationMessagePolicyLabel] = string(container.TerminationMessagePolicy)
+	annotations[types.KubernetesContainerImageLabel] = container.Image
 
 	if pod.DeletionGracePeriodSeconds != nil {
 		annotations[podDeletionGracePeriodLabel] = strconv.FormatInt(*pod.DeletionGracePeriodSeconds, 10)

--- a/pkg/kubelet/types/labels.go
+++ b/pkg/kubelet/types/labels.go
@@ -17,10 +17,11 @@ limitations under the License.
 package types
 
 const (
-	KubernetesPodNameLabel       = "io.kubernetes.pod.name"
-	KubernetesPodNamespaceLabel  = "io.kubernetes.pod.namespace"
-	KubernetesPodUIDLabel        = "io.kubernetes.pod.uid"
-	KubernetesContainerNameLabel = "io.kubernetes.container.name"
+	KubernetesPodNameLabel        = "io.kubernetes.pod.name"
+	KubernetesPodNamespaceLabel   = "io.kubernetes.pod.namespace"
+	KubernetesPodUIDLabel         = "io.kubernetes.pod.uid"
+	KubernetesContainerNameLabel  = "io.kubernetes.container.name"
+	KubernetesContainerImageLabel = "io.kubernetes.container.image"
 )
 
 func GetContainerName(labels map[string]string) string {


### PR DESCRIPTION
… status consistent

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug


**What this PR does / why we need it**:
Store image tag in container annotation and fetch it when call CRI interface ContainerStatus, to keep image in ContainerStatus and image in pod spec consistent when a image has multiple tags on a node.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #51017

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
None
```
