### PR TITLE
client-go: add ProxyGet expansion method for pods

### DIFF
--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_pod_expansion.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_pod_expansion.go
@@ -89,3 +89,7 @@ func (c *FakePods) Evict(ctx context.Context, eviction *policy.Eviction) error {
 	_, err := c.Fake.Invokes(action, eviction)
 	return err
 }
+
+func (c *FakePods) ProxyGet(scheme, name, port, path string, params map[string]string) restclient.ResponseWrapper {
+	return c.Fake.InvokesProxy(core.NewProxyGetAction(podsResource, c.ns, scheme, name, port, path, params))
+}


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes/issues/90768

Currently, the proxy subresource is not supported for pods in client-go.
Today, invoking this requires using the REST client directly.

To make using the proxy subresource easier, this commit adds a ProxyGet
method for pods in pod_expansion.go similar to the ProxyGet method
for services in service_expansion.go.

Ref: https://github.com/kubernetes/kubernetes/blob/d8febccacfc9d51a017be9531247689e0e36df04/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/service_expansion.go#L26

Note: context is not plumbed here since the underlying client event API calls already provide context-enabled API access. See https://github.com/kubernetes/kubernetes/pull/88929#issuecomment-595984894 and https://github.com/kubernetes/kubernetes/pull/88929#issuecomment-596004585 for more details.

/kind feature
/sig api-machinery

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
