### PR TITLE
lack a newline character when describe hpa

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/describe/describe.go
+++ b/staging/src/k8s.io/kubectl/pkg/describe/describe.go
@@ -3461,7 +3461,7 @@ func describeHorizontalPodAutoscalerV2beta2(hpa *autoscalingv2beta2.HorizontalPo
 					w.Write(LEVEL_1, "(as a percentage of request):\t%s / %s\n", current, target)
 				}
 			default:
-				w.Write(LEVEL_1, "<unknown metric type %q>", string(metric.Type))
+				w.Write(LEVEL_1, "<unknown metric type %q>\n", string(metric.Type))
 			}
 		}
 		minReplicas := "<unset>"


### PR DESCRIPTION
**What type of PR is this?**
> /kind bug

Something wrong shows when describe hpa:
```
Metrics:                                   ( current / target )
  <unknown metric type "xxx">Min replicas:                              1
Max replicas:                              5
```
The reason is lack of a newline character.

```release-note
NONE
```