### PR TITLE
fix: Azure deallocating node should be regarded as shut down

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_instances.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_instances.go
@@ -32,9 +32,10 @@ import (
 )
 
 const (
-	vmPowerStatePrefix      = "PowerState/"
-	vmPowerStateStopped     = "stopped"
-	vmPowerStateDeallocated = "deallocated"
+	vmPowerStatePrefix       = "PowerState/"
+	vmPowerStateStopped      = "stopped"
+	vmPowerStateDeallocated  = "deallocated"
+	vmPowerStateDeallocating = "deallocating"
 )
 
 var (
@@ -230,7 +231,8 @@ func (az *Cloud) InstanceShutdownByProviderID(ctx context.Context, providerID st
 	}
 	klog.V(5).Infof("InstanceShutdownByProviderID gets power status %q for node %q", powerStatus, nodeName)
 
-	return strings.ToLower(powerStatus) == vmPowerStateStopped || strings.ToLower(powerStatus) == vmPowerStateDeallocated, nil
+	status := strings.ToLower(powerStatus)
+	return status == vmPowerStateStopped || status == vmPowerStateDeallocated || status == vmPowerStateDeallocating, nil
 }
 
 // InstanceMetadataByProviderID returns metadata of the specified instance.

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_instances_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_instances_test.go
@@ -284,7 +284,7 @@ func TestInstanceShutdownByProviderID(t *testing.T) {
 			vmList:     map[string]string{"vm3": "PowerState/Deallocating"},
 			nodeName:   "vm3",
 			providerID: "azure:///subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/vm3",
-			expected:   false,
+			expected:   true,
 		},
 		{
 			name:       "InstanceShutdownByProviderID should return false if the vm is in PowerState/Starting status",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
fix: Azure deallocating node should be regarded as shut down

From what I observed, when deallocate a node, sometimes it makes the node in `PowerState/deallocating` for a few minutes, actually at that time, the node is in NotReady already. This PR tries to taint the node as `NotReady` as soon as possible.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
```console
# az vmss get-instance-view -g MC_andy-aks1169_andy-aks1169_eastus2 -n aks-agentpool-31701716-vmss --instance-id 0
  "statuses": [
    {
      "code": "ProvisioningState/succeeded",
      "displayStatus": "Provisioning succeeded",
      "level": "Info",
      "message": null,
      "time": "2020-06-18T08:36:27.990319+00:00"
    },
    {
      "code": "PowerState/deallocated",
      "displayStatus": "VM deallocated",
      "level": "Info",
      "message": null,
      "time": null
    }
  ],
```

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
fix: Azure deallocating node should be regarded as shut down
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/kind bug
/assign @feiskyer 
/priority important-soon
/sig cloud-provider
/area provider/azure

