### PR TITLE
Added `kubectl wait` to wait on jsonpath

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/wait/wait.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/wait/wait.go
@@ -21,6 +21,8 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -60,6 +62,9 @@ var (
 	waitExample = templates.Examples(`
 		# Wait for the pod "busybox1" to contain the status condition of type "Ready".
 		kubectl wait --for=condition=Ready pod/busybox1
+
+		# Wait for the pod "busybox1" to contain the status phase to be "Running".
+		kubectl wait --for='jsonpath={.status.phase=Running}' pod/busybox1
 
 		# Wait for the pod "busybox1" to be deleted, with a timeout of 60s, after having issued the "delete" command.
 		kubectl delete pod/busybox1
@@ -107,7 +112,7 @@ func NewCmdWait(restClientGetter genericclioptions.RESTClientGetter, streams gen
 	flags := NewWaitFlags(restClientGetter, streams)
 
 	cmd := &cobra.Command{
-		Use:     "wait ([-f FILENAME] | resource.group/resource.name | resource.group [(-l label | --all)]) [--for=delete|--for condition=available]",
+		Use:     "wait ([-f FILENAME] | resource.group/resource.name | resource.group [(-l label | --all)]) [--for=delete|--for condition=available|--for=jsonpath=...]",
 		Short:   "Experimental: Wait for a specific condition on one or many resources.",
 		Long:    waitLong,
 		Example: waitExample,
@@ -133,7 +138,7 @@ func (flags *WaitFlags) AddFlags(cmd *cobra.Command) {
 	flags.ResourceBuilderFlags.AddFlags(cmd.Flags())
 
 	cmd.Flags().DurationVar(&flags.Timeout, "timeout", flags.Timeout, "The length of time to wait before giving up.  Zero means check once and don't wait, negative means wait for a week.")
-	cmd.Flags().StringVar(&flags.ForCondition, "for", flags.ForCondition, "The condition to wait on: [delete|condition=condition-name].")
+	cmd.Flags().StringVar(&flags.ForCondition, "for", flags.ForCondition, "The condition to wait on: [delete|condition=condition-name|jsonpath=...].")
 }
 
 // ToOptions converts from CLI inputs to runtime inputs
@@ -177,6 +182,28 @@ func (flags *WaitFlags) ToOptions(args []string) (*WaitOptions, error) {
 func conditionFuncFor(condition string, errOut io.Writer) (ConditionFunc, error) {
 	if strings.ToLower(condition) == "delete" {
 		return IsDeleted, nil
+	}
+	if strings.HasPrefix(condition, "jsonpath=") {
+		conditionName := condition[len("jsonpath="):]
+		conditionValue := "true"
+		conditionName, _ = RelaxedJSONPathExpression(conditionName)
+		if equalsIndex := strings.Index(conditionName, "="); equalsIndex != -1 {
+			conditionValue = conditionName[equalsIndex+1 : len(conditionName)-1]
+			conditionName = conditionName[1:equalsIndex]
+		}
+
+		if strings.HasPrefix(conditionValue, "\"") {
+			quotedVal, err := strconv.Unquote(conditionValue)
+			if err != nil {
+				return nil, fmt.Errorf("unrecognized condition: %q", condition)
+			}
+			conditionValue = quotedVal
+		}
+		return ConditionalWait{
+			conditionName:   conditionName,
+			conditionStatus: conditionValue,
+			errOut:          errOut,
+		}.IsPhaseConditionMet, nil
 	}
 	if strings.HasPrefix(condition, "condition=") {
 		conditionName := condition[len("condition="):]
@@ -275,6 +302,7 @@ func IsDeleted(info *resource.Info, o *WaitOptions) (runtime.Object, bool, error
 			return info.Object, true, nil
 		}
 		gottenObj := &gottenObjList.Items[0]
+
 		resourceLocation := ResourceLocation{
 			GroupResource: info.Mapping.Resource.GroupResource(),
 			Namespace:     gottenObj.GetNamespace(),
@@ -303,6 +331,72 @@ func IsDeleted(info *resource.Info, o *WaitOptions) (runtime.Object, bool, error
 
 		ctx, cancel := watchtools.ContextWithOptionalTimeout(context.Background(), o.Timeout)
 		watchEvent, err := watchtools.UntilWithoutRetry(ctx, objWatch, Wait{errOut: o.ErrOut}.IsDeleted)
+		cancel()
+		switch {
+		case err == nil:
+			return watchEvent.Object, true, nil
+		case err == watchtools.ErrWatchClosed:
+			continue
+		case err == wait.ErrWaitTimeout:
+			if watchEvent != nil {
+				return watchEvent.Object, false, errWaitTimeoutWithName
+			}
+			return gottenObj, false, errWaitTimeoutWithName
+		default:
+			return gottenObj, false, err
+		}
+	}
+}
+
+// IsPhaseConditionMet is a conditionfunc for waiting on an API for phase condition to be met
+func (w ConditionalWait) IsPhaseConditionMet(info *resource.Info, o *WaitOptions) (runtime.Object, bool, error) {
+	endTime := time.Now().Add(o.Timeout)
+	for {
+		if len(info.Name) == 0 {
+			return info.Object, false, fmt.Errorf("resource name must be provided")
+		}
+
+		nameSelector := fields.OneTermEqualSelector("metadata.name", info.Name).String()
+
+		var gottenObj *unstructured.Unstructured
+		// List with a name field selector to get the current resourceVersion to watch from (not the object's resourceVersion)
+		gottenObjList, err := o.DynamicClient.Resource(info.Mapping.Resource).Namespace(info.Namespace).List(context.TODO(), metav1.ListOptions{FieldSelector: nameSelector})
+
+		resourceVersion := ""
+		switch {
+		case err != nil:
+			return info.Object, false, err
+		case len(gottenObjList.Items) != 1:
+			resourceVersion = gottenObjList.GetResourceVersion()
+		default:
+			gottenObj = &gottenObjList.Items[0]
+			conditionMet, err := w.checkPhase(gottenObj)
+			if conditionMet {
+				return gottenObj, true, nil
+			}
+			if err != nil {
+				return gottenObj, false, err
+			}
+			resourceVersion = gottenObjList.GetResourceVersion()
+		}
+
+		watchOptions := metav1.ListOptions{}
+		watchOptions.FieldSelector = nameSelector
+		watchOptions.ResourceVersion = resourceVersion
+		objWatch, err := o.DynamicClient.Resource(info.Mapping.Resource).Namespace(info.Namespace).Watch(context.TODO(), watchOptions)
+		if err != nil {
+			return gottenObj, false, err
+		}
+
+		timeout := endTime.Sub(time.Now())
+		errWaitTimeoutWithName := extendErrWaitTimeout(wait.ErrWaitTimeout, info)
+		if timeout < 0 {
+			// we're out of time
+			return gottenObj, false, errWaitTimeoutWithName
+		}
+
+		ctx, cancel := watchtools.ContextWithOptionalTimeout(context.Background(), o.Timeout)
+		watchEvent, err := watchtools.UntilWithoutRetry(ctx, objWatch, w.isPhaseConditionMet)
 		cancel()
 		switch {
 		case err == nil:
@@ -356,10 +450,10 @@ func (w ConditionalWait) IsConditionMet(info *resource.Info, o *WaitOptions) (ru
 		if len(info.Name) == 0 {
 			return info.Object, false, fmt.Errorf("resource name must be provided")
 		}
-
 		nameSelector := fields.OneTermEqualSelector("metadata.name", info.Name).String()
 
 		var gottenObj *unstructured.Unstructured
+
 		// List with a name field selector to get the current resourceVersion to watch from (not the object's resourceVersion)
 		gottenObjList, err := o.DynamicClient.Resource(info.Mapping.Resource).Namespace(info.Namespace).List(context.TODO(), metav1.ListOptions{FieldSelector: nameSelector})
 
@@ -426,14 +520,14 @@ func (w ConditionalWait) checkCondition(obj *unstructured.Unstructured) (bool, e
 	for _, conditionUncast := range conditions {
 		condition := conditionUncast.(map[string]interface{})
 		name, found, err := unstructured.NestedString(condition, "type")
-		if !found || err != nil || !strings.EqualFold(name, w.conditionName) {
+		if !found || err != nil || strings.ToLower(name) != strings.ToLower(w.conditionName) {
 			continue
 		}
 		status, found, err := unstructured.NestedString(condition, "status")
 		if !found || err != nil {
 			continue
 		}
-		return strings.EqualFold(status, w.conditionStatus), nil
+		return strings.ToLower(status) == strings.ToLower(w.conditionStatus), nil
 	}
 
 	return false, nil
@@ -457,4 +551,81 @@ func (w ConditionalWait) isConditionMet(event watch.Event) (bool, error) {
 
 func extendErrWaitTimeout(err error, info *resource.Info) error {
 	return fmt.Errorf("%s on %s/%s", err.Error(), info.Mapping.Resource.Resource, info.Name)
+}
+
+func (w ConditionalWait) isPhaseConditionMet(event watch.Event) (bool, error) {
+	if event.Type == watch.Error {
+		// keep waiting in the event we see an error - we expect the watch to be closed by
+		// the server
+		err := apierrors.FromObject(event.Object)
+		fmt.Fprintf(w.errOut, "error: An error occurred while waiting for the condition to be satisfied: %v", err)
+		return false, nil
+	}
+	if event.Type == watch.Deleted {
+		// this will chain back out, result in another get and an return false back up the chain
+		return false, nil
+	}
+	obj := event.Object.(*unstructured.Unstructured)
+	return w.checkPhase(obj)
+}
+
+func (w ConditionalWait) checkPhase(obj *unstructured.Unstructured) (bool, error) {
+
+	//phase := strings.Split(w.conditionName, ".")[2]
+	//conditions, found, err := unstructured.NestedMap(obj.Object, "status")
+
+	// If it's a validation with a single node, I guess we can use NestedString
+	condition, found, err := unstructured.NestedString(obj.Object, strings.Split(w.conditionName[0:len(w.conditionName)], ".")...)
+	if err != nil {
+		return false, err
+	}
+	if !found {
+		return false, nil
+	}
+	// var names string
+	// for name, _ := range conditions {
+
+	// 	names += name
+	// 	if strings.ToLower(name) != strings.ToLower(phase) {
+	// 		continue
+	// 	}
+	// 	phaseStatus, found, err := unstructured.NestedString(conditions, phase)
+	// 	if !found || err != nil {
+	// 		continue
+	// 	}
+	// 	return strings.ToLower(phaseStatus) == strings.ToLower(w.conditionStatus), nil
+	// }
+
+	return strings.ToLower(condition) == strings.ToLower(w.conditionStatus), nil
+
+	//return false, nil
+}
+
+var jsonRegexp = regexp.MustCompile(`^\{\.?([^{}]+)\}$|^\.?([^{}]+)$`)
+
+// RelaxedJSONPathExpression attempts to be flexible with JSONPath expressions, it accepts:
+//   * metadata.name (no leading '.' or curly braces '{...}'
+//   * {metadata.name} (no leading '.')
+//   * .metadata.name (no curly braces '{...}')
+//   * {.metadata.name} (complete expression)
+// And transforms them all into a valid jsonpath expression:
+//   {.metadata.name}
+func RelaxedJSONPathExpression(pathExpression string) (string, error) {
+	if len(pathExpression) == 0 {
+		return pathExpression, nil
+	}
+	submatches := jsonRegexp.FindStringSubmatch(pathExpression)
+	if submatches == nil {
+		return "", fmt.Errorf("unexpected path string, expected a 'name1.name2' or '.name1.name2' or '{name1.name2}' or '{.name1.name2}'")
+	}
+	if len(submatches) != 3 {
+		return "", fmt.Errorf("unexpected submatch list: %v", submatches)
+	}
+	var fieldSpec string
+	if len(submatches[1]) != 0 {
+		fieldSpec = submatches[1]
+	} else {
+		fieldSpec = submatches[2]
+	}
+	return fmt.Sprintf("{.%s}", fieldSpec), nil
 }

--- a/staging/src/k8s.io/kubectl/pkg/cmd/wait/wait.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/wait/wait.go
@@ -203,7 +203,7 @@ func conditionFuncFor(condition string, errOut io.Writer) (ConditionFunc, error)
 			conditionName:   conditionName,
 			conditionStatus: conditionValue,
 			errOut:          errOut,
-		}.IsPhaseConditionMet, nil
+		}.IsJSONConditionMet, nil
 	}
 	if strings.HasPrefix(condition, "condition=") {
 		conditionName := condition[len("condition="):]
@@ -349,7 +349,7 @@ func IsDeleted(info *resource.Info, o *WaitOptions) (runtime.Object, bool, error
 }
 
 // IsPhaseConditionMet is a conditionfunc for waiting on an API for phase condition to be met
-func (w ConditionalWait) IsPhaseConditionMet(info *resource.Info, o *WaitOptions) (runtime.Object, bool, error) {
+func (w ConditionalWait) IsJSONConditionMet(info *resource.Info, o *WaitOptions) (runtime.Object, bool, error) {
 	endTime := time.Now().Add(o.Timeout)
 	for {
 		if len(info.Name) == 0 {
@@ -370,7 +370,7 @@ func (w ConditionalWait) IsPhaseConditionMet(info *resource.Info, o *WaitOptions
 			resourceVersion = gottenObjList.GetResourceVersion()
 		default:
 			gottenObj = &gottenObjList.Items[0]
-			conditionMet, err := w.checkPhase(gottenObj)
+			conditionMet, err := w.checkJSON(gottenObj)
 			if conditionMet {
 				return gottenObj, true, nil
 			}
@@ -566,10 +566,10 @@ func (w ConditionalWait) isPhaseConditionMet(event watch.Event) (bool, error) {
 		return false, nil
 	}
 	obj := event.Object.(*unstructured.Unstructured)
-	return w.checkPhase(obj)
+	return w.checkJSON(obj)
 }
 
-func (w ConditionalWait) checkPhase(obj *unstructured.Unstructured) (bool, error) {
+func (w ConditionalWait) checkJSON(obj *unstructured.Unstructured) (bool, error) {
 
 	//phase := strings.Split(w.conditionName, ".")[2]
 	//conditions, found, err := unstructured.NestedMap(obj.Object, "status")


### PR DESCRIPTION
Signed-off-by: Rahul M Chheda <rchheda@infracloud.io>

Added single node JSONPath parser to 
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

> /kind feature

**What this PR does / why we need it**:

- Adds feature to allow validation of JSONPath string for `kubectl wait`

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #https://github.com/kubernetes/kubernetes/issues/83094

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
