### PR TITLE
Refetch base image for building conformance images

### DIFF
--- a/cluster/images/conformance/Dockerfile
+++ b/cluster/images/conformance/Dockerfile
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM BASEIMAGE
+ARG BASEIMAGE
+FROM $BASEIMAGE
 
 COPY ginkgo /usr/local/bin/
 COPY e2e.test /usr/local/bin/

--- a/cluster/images/conformance/Makefile
+++ b/cluster/images/conformance/Makefile
@@ -31,7 +31,7 @@ E2E_GO_RUNNER_BIN?=$(shell test -f $(LOCAL_OUTPUT_PATH)/go-runner && echo $(LOCA
 
 CLUSTER_DIR?=$(shell pwd)/../../../cluster/
 
-BASEIMAGE=debian:stretch-slim
+BASEIMAGE?=debian:stretch-slim
 TEMP_DIR:=$(shell mktemp -d -t conformanceXXXXXX)
 
 all: build
@@ -54,9 +54,10 @@ endif
 	chmod a+rx ${TEMP_DIR}/e2e.test
 	chmod a+rx ${TEMP_DIR}/gorunner
 
-	cd ${TEMP_DIR} && sed -i.back "s|BASEIMAGE|${BASEIMAGE}|g" Dockerfile
-
-	docker build --pull -t ${REGISTRY}/conformance-${ARCH}:${VERSION} ${TEMP_DIR}
+	docker rmi ${BASEIMAGE} 2>/dev/null || :
+	DOCKER_CLI_EXPERIMENTAL=enabled docker buildx build \
+                --load --platform linux/$(ARCH) \
+		-t ${REGISTRY}/conformance-${ARCH}:${VERSION} --build-arg BASEIMAGE="${BASEIMAGE}" ${TEMP_DIR}
 	rm -rf "${TEMP_DIR}"
 
 push: build


### PR DESCRIPTION
The debian base image is actually multi-arch, but docker might not actually pull it if it has a similar one in the registry and that one was for a different architecture.
    
So remove the image that is there to ensure that we're actually refetching.

Also, explicitly specify the platform and platform architecture to be explicit rather than implicit.
    
Convert the Dockerfile to use an ARG for BASEIMAGE instead of in-place sed as an additional small cleanup


Fix for issue #89554.


**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes #89554 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
* conformance e2e images for arm64 have been fixed to be based on an arm64 base image.
```