### PR TITLE
set pod ready ConditionFalse reason when node not ready

### DIFF
--- a/pkg/controller/util/node/controller_utils.go
+++ b/pkg/controller/util/node/controller_utils.go
@@ -29,7 +29,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	clientset "k8s.io/client-go/kubernetes"
 	appsv1listers "k8s.io/client-go/listers/apps/v1"
 	utilpod "k8s.io/kubernetes/pkg/api/v1/pod"
@@ -132,7 +132,12 @@ func MarkPodsNotReady(kubeClient clientset.Interface, recorder record.EventRecor
 		pod := pods[i].DeepCopy()
 		for _, cond := range pod.Status.Conditions {
 			if cond.Type == v1.PodReady {
+				if cond.Status == v1.ConditionFalse {
+					continue
+				}
 				cond.Status = v1.ConditionFalse
+				cond.Reason = "NodeNotReady"
+				cond.Message = "Node is not ready"
 				if !utilpod.UpdatePodCondition(&pod.Status, &cond) {
 					break
 				}


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:

/kind feature

**What this PR does / why we need it**:
We only set pod ready ConditionFalse when node is not ready now. We'd better set this reason why is not ready since It's calculation logic is different with kubelet.

**Which issue(s) this PR fixes**:
Fixes #92223

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
