### PR TITLE
Automated cherry pick of #92166: fix#92167: GetLabelsForVolume panic issue for azure disk PV

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_managedDiskController.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_managedDiskController.go
@@ -336,6 +336,13 @@ func (c *Cloud) GetAzureDiskLabels(diskURI string) (map[string]string, error) {
 		return nil, err
 	}
 
+	labels := map[string]string{
+		v1.LabelZoneRegion: c.Location,
+	}
+	// no azure credential is set, return nil
+	if c.DisksClient == nil {
+		return labels, nil
+	}
 	// Get information of the disk.
 	ctx, cancel := getContextWithCancel()
 	defer cancel()
@@ -348,7 +355,7 @@ func (c *Cloud) GetAzureDiskLabels(diskURI string) (map[string]string, error) {
 	// Check whether availability zone is specified.
 	if disk.Zones == nil || len(*disk.Zones) == 0 {
 		klog.V(4).Infof("Azure disk %q is not zoned", diskName)
-		return nil, nil
+		return labels, nil
 	}
 
 	zones := *disk.Zones
@@ -359,9 +366,6 @@ func (c *Cloud) GetAzureDiskLabels(diskURI string) (map[string]string, error) {
 
 	zone := c.makeZone(c.Location, zoneID)
 	klog.V(4).Infof("Got zone %q for Azure disk %q", zone, diskName)
-	labels := map[string]string{
-		v1.LabelZoneRegion:        c.Location,
-		v1.LabelZoneFailureDomain: zone,
-	}
+	labels[v1.LabelZoneFailureDomain] = zone
 	return labels, nil
 }


### PR DESCRIPTION
Cherry pick of #92166 on release-1.18.

#92166: fix#92167: GetLabelsForVolume panic issue for azure disk PV

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.