### PR TITLE
Automated cherry pick of #92258: Add logic to check if local NVMe SSDs in node boot-up script

### DIFF
--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -334,6 +334,13 @@ function ensure-local-ssds() {
   # The following mounts or symlinks NVMe devices
   get-local-disk-num "nvme" "block"
   local nvmeblocknum="${localdisknum}"
+  get-local-disk-num "nvme" "fs"
+  local nvmefsnum="${localdisknum}"
+  # Check if NVMe SSD specified.
+  if [ "${nvmeblocknum}" -eq "0" ] && [ "${nvmefsnum}" -eq "0" ]; then
+    echo "No local NVMe SSD specified."
+    return
+  fi
   local i=0
   for ssd in /dev/nvme*; do
     if [ -e "${ssd}" ]; then


### PR DESCRIPTION
Cherry pick of #92258 on release-1.18.

#92258: Add logic to check if local NVMe SSDs in node boot-up script

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.