### PR TITLE
replaces CommonImageWhiteList with CommonImageList

### DIFF
--- a/test/e2e/common/util.go
+++ b/test/e2e/common/util.go
@@ -57,11 +57,11 @@ var (
 // CurrentSuite represents current test suite.
 var CurrentSuite Suite
 
-// CommonImageWhiteList is the list of images used in common test. These images should be prepulled
-// before a tests starts, so that the tests won't fail due image pulling flakes. Currently, this is
+// CommonImageList is the set of images used across tests in e2e/common. These images should be pre-pulled
+// before a test starts so that the test won't fail due image pulling errors. Currently, this is
 // only used by node e2e test.
 // TODO(random-liu): Change the image puller pod to use similar mechanism.
-var CommonImageWhiteList = sets.NewString(
+var CommonImageList = sets.NewString(
 	imageutils.GetE2EImage(imageutils.Agnhost),
 	imageutils.GetE2EImage(imageutils.BusyBox),
 	imageutils.GetE2EImage(imageutils.IpcUtils),

--- a/test/e2e_node/image_list.go
+++ b/test/e2e_node/image_list.go
@@ -66,8 +66,8 @@ var NodePrePullImageList = sets.NewString(
 // 2. the ones passed in from framework.TestContext.ExtraEnvs
 // So this function needs to be called after the extra envs are applied.
 func updateImageWhiteList() {
-	// Union NodePrePullImageList and CommonImageWhiteList into the framework image pre-pull list.
-	framework.ImageWhiteList = NodePrePullImageList.Union(commontest.CommonImageWhiteList)
+	// Union NodeImageWhiteList and CommonImageList into the framework image white list.
+	framework.ImageWhiteList = NodeImageWhiteList.Union(commontest.CommonImageList)
 	// Images from extra envs
 	framework.ImageWhiteList.Insert(getNodeProblemDetectorImage())
 	framework.ImageWhiteList.Insert(getSRIOVDevicePluginImage())


### PR DESCRIPTION
  Part of the work to remove unwanted racist language

  Additionally this was not a correct use of the inappropriate term as the list
  in question is a pre-fetched list of images that are commonly relied upon in
  e2e tests and did not pertain to a list of permitted images over images that
  were not permitted.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #92319

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
