### PR TITLE
add azurefile protocol  parameter in azure cloud provider lib

### DIFF
--- a/pkg/volume/azure_file/azure_provision.go
+++ b/pkg/volume/azure_file/azure_provision.go
@@ -47,7 +47,7 @@ var (
 // azure cloud provider should implement it
 type azureCloudProvider interface {
 	// create a file share
-	CreateFileShare(shareName, accountName, accountType, accountKind, resourceGroup, location string, requestGiB int) (string, string, error)
+	CreateFileShare(shareName, accountName, accountType, accountKind, resourceGroup, location string, protocol storage.EnabledProtocols, requestGiB int) (string, string, error)
 	// delete a file share
 	DeleteFileShare(resourceGroup, accountName, shareName string) error
 	// resize a file share
@@ -204,7 +204,7 @@ func (a *azureFileProvisioner) Provision(selectedNode *v1.Node, allowedTopologie
 	if strings.HasPrefix(strings.ToLower(sku), "premium") {
 		accountKind = string(storage.FileStorage)
 	}
-	account, key, err := a.azureProvider.CreateFileShare(shareName, account, sku, accountKind, resourceGroup, location, requestGiB)
+	account, key, err := a.azureProvider.CreateFileShare(shareName, account, sku, accountKind, resourceGroup, location, storage.SMB, requestGiB)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_blobDiskController.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_blobDiskController.go
@@ -84,7 +84,7 @@ func (c *BlobDiskController) initStorageAccounts() {
 // If no storage account is given, search all the storage accounts associated with the resource group and pick one that
 // fits storage type and location.
 func (c *BlobDiskController) CreateVolume(blobName, accountName, accountType, location string, requestGB int) (string, string, int, error) {
-	account, key, err := c.common.cloud.EnsureStorageAccount(accountName, accountType, string(defaultStorageAccountKind), c.common.resourceGroup, location, dedicatedDiskAccountNamePrefix)
+	account, key, err := c.common.cloud.EnsureStorageAccount(accountName, accountType, string(defaultStorageAccountKind), c.common.resourceGroup, location, dedicatedDiskAccountNamePrefix, true)
 	if err != nil {
 		return "", "", 0, fmt.Errorf("could not get storage key for storage account %s: %v", accountName, err)
 	}

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_file.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_file.go
@@ -23,8 +23,8 @@ import (
 )
 
 // create file share
-func (az *Cloud) createFileShare(resourceGroupName, accountName, name string, sizeGiB int) error {
-	return az.FileClient.CreateFileShare(resourceGroupName, accountName, name, sizeGiB)
+func (az *Cloud) createFileShare(resourceGroupName, accountName, name string, protocol storage.EnabledProtocols, sizeGiB int) error {
+	return az.FileClient.CreateFileShare(resourceGroupName, accountName, name, protocol, sizeGiB)
 }
 
 func (az *Cloud) deleteFileShare(resourceGroupName, accountName, name string) error {

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_storage_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_storage_test.go
@@ -141,7 +141,7 @@ func TestCreateFileShare(t *testing.T) {
 	for _, test := range tests {
 		mockFileClient := mockfileclient.NewMockInterface(ctrl)
 		cloud.FileClient = mockFileClient
-		mockFileClient.EXPECT().CreateFileShare(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(test.err).AnyTimes()
+		mockFileClient.EXPECT().CreateFileShare(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(test.err).AnyTimes()
 
 		mockStorageAccountsClient := mockstorageaccountclient.NewMockInterface(ctrl)
 		cloud.StorageAccountClient = mockStorageAccountsClient
@@ -149,7 +149,7 @@ func TestCreateFileShare(t *testing.T) {
 		mockStorageAccountsClient.EXPECT().ListByResourceGroup(gomock.Any(), "rg").Return(test.accounts, nil).AnyTimes()
 		mockStorageAccountsClient.EXPECT().Create(gomock.Any(), "rg", gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 
-		account, key, err := cloud.CreateFileShare(test.name, test.acct, test.acctType, test.acctKind, test.rg, test.loc, test.gb)
+		account, key, err := cloud.CreateFileShare(test.name, test.acct, test.acctType, test.acctKind, test.rg, test.loc, storage.SMB, test.gb)
 		if test.expectErr && err == nil {
 			t.Errorf("unexpected non-error")
 			continue

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_storageaccount.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_storageaccount.go
@@ -90,7 +90,7 @@ func (az *Cloud) GetStorageAccesskey(account, resourceGroup string) (string, err
 }
 
 // EnsureStorageAccount search storage account, create one storage account(with genAccountNamePrefix) if not found, return accountName, accountKey
-func (az *Cloud) EnsureStorageAccount(accountName, accountType, accountKind, resourceGroup, location, genAccountNamePrefix string) (string, string, error) {
+func (az *Cloud) EnsureStorageAccount(accountName, accountType, accountKind, resourceGroup, location, genAccountNamePrefix string, enableHTTPSTrafficOnly bool) (string, string, error) {
 	if len(accountName) == 0 {
 		// find a storage account that matches accountType
 		accounts, err := az.getStorageAccounts(accountType, accountKind, resourceGroup, location)
@@ -123,7 +123,7 @@ func (az *Cloud) EnsureStorageAccount(accountName, accountType, accountKind, res
 			cp := storage.AccountCreateParameters{
 				Sku:                               &storage.Sku{Name: storage.SkuName(accountType)},
 				Kind:                              kind,
-				AccountPropertiesCreateParameters: &storage.AccountPropertiesCreateParameters{EnableHTTPSTrafficOnly: to.BoolPtr(true)},
+				AccountPropertiesCreateParameters: &storage.AccountPropertiesCreateParameters{EnableHTTPSTrafficOnly: &enableHTTPSTrafficOnly},
 				Tags:                              map[string]*string{"created-by": to.StringPtr("azure")},
 				Location:                          &location}
 

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/clients/fileclient/azure_fileclient.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/clients/fileclient/azure_fileclient.go
@@ -46,7 +46,7 @@ func New(config *azclients.ClientConfig) *Client {
 }
 
 // CreateFileShare creates a file share
-func (c *Client) CreateFileShare(resourceGroupName, accountName, name string, sizeGiB int) error {
+func (c *Client) CreateFileShare(resourceGroupName, accountName, name string, protocol storage.EnabledProtocols, sizeGiB int) error {
 	result, err := c.GetFileShare(resourceGroupName, accountName, name)
 	if err == nil {
 		klog.V(2).Infof("file share(%s) under account(%s) rg(%s) already exists", name, accountName, resourceGroupName)
@@ -56,11 +56,15 @@ func (c *Client) CreateFileShare(resourceGroupName, accountName, name string, si
 	}
 
 	quota := int32(sizeGiB)
+	fileShareProperties := &storage.FileShareProperties{
+		ShareQuota: &quota,
+	}
+	if protocol == storage.NFS {
+		fileShareProperties.EnabledProtocols = protocol
+	}
 	fileShare := storage.FileShare{
-		Name: &name,
-		FileShareProperties: &storage.FileShareProperties{
-			ShareQuota: &quota,
-		},
+		Name:                &name,
+		FileShareProperties: fileShareProperties,
 	}
 	_, err = c.fileSharesClient.Create(context.Background(), resourceGroupName, accountName, name, fileShare)
 

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/clients/fileclient/interface.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/clients/fileclient/interface.go
@@ -25,7 +25,7 @@ import (
 // Interface is the client interface for creating file shares, interface for test injection.
 // mockgen -source=$GOPATH/src/k8s.io/kubernetes/staging/src/k8s.io/legacy-cloud-providers/azure/clients/fileclient/interface.go -package=mockfileclient Interface > $GOPATH/src/k8s.io/kubernetes/staging/src/k8s.io/legacy-cloud-providers/azure/clients/fileclient/mockfileclient/interface.go
 type Interface interface {
-	CreateFileShare(resourceGroupName, accountName, name string, sizeGiB int) error
+	CreateFileShare(resourceGroupName, accountName, name string, protocol storage.EnabledProtocols, sizeGiB int) error
 	DeleteFileShare(resourceGroupName, accountName, name string) error
 	ResizeFileShare(resourceGroupName, accountName, name string, sizeGiB int) error
 	GetFileShare(resourceGroupName, accountName, name string) (storage.FileShare, error)

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/clients/fileclient/mockfileclient/interface.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/clients/fileclient/mockfileclient/interface.go
@@ -19,9 +19,10 @@ limitations under the License.
 package mockfileclient
 
 import (
+	reflect "reflect"
+
 	storage "github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2019-06-01/storage"
 	gomock "github.com/golang/mock/gomock"
-	reflect "reflect"
 )
 
 // MockInterface is a mock of Interface interface
@@ -48,17 +49,17 @@ func (m *MockInterface) EXPECT() *MockInterfaceMockRecorder {
 }
 
 // CreateFileShare mocks base method
-func (m *MockInterface) CreateFileShare(resourceGroupName, accountName, name string, sizeGiB int) error {
+func (m *MockInterface) CreateFileShare(resourceGroupName, accountName, name string, protocol storage.EnabledProtocols, sizeGiB int) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateFileShare", resourceGroupName, accountName, name, sizeGiB)
+	ret := m.ctrl.Call(m, "CreateFileShare", resourceGroupName, accountName, name, protocol, sizeGiB)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // CreateFileShare indicates an expected call of CreateFileShare
-func (mr *MockInterfaceMockRecorder) CreateFileShare(resourceGroupName, accountName, name, sizeGiB interface{}) *gomock.Call {
+func (mr *MockInterfaceMockRecorder) CreateFileShare(resourceGroupName, accountName, name, protocol, sizeGiB interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateFileShare", reflect.TypeOf((*MockInterface)(nil).CreateFileShare), resourceGroupName, accountName, name, sizeGiB)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateFileShare", reflect.TypeOf((*MockInterface)(nil).CreateFileShare), resourceGroupName, accountName, name, protocol, sizeGiB)
 }
 
 // DeleteFileShare mocks base method


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
This PR add azurefile protocol  field protocal field in azure cloud provider lib, would support NFS in Azure File CSI driver.
Note: there is no plan to support NFS in in-tree driver, this PR just updates the lib used by CSI driver.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
none
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
none
```

/assign @feiskyer 
/priority important-soon
/sig cloud-provider
/area provider/azure