### PR TITLE
fix(kubectl): print error if users place flags before plugin name

### DIFF
--- a/pkg/kubectl/cmd/cmd.go
+++ b/pkg/kubectl/cmd/cmd.go
@@ -318,7 +318,7 @@ func NewDefaultKubectlCommandWithArgs(pluginHandler PluginHandler, args []string
 		// the specified command does not already exist
 		if _, _, err := cmd.Find(cmdPathPieces); err != nil {
 			if err := HandlePluginCommand(pluginHandler, cmdPathPieces); err != nil {
-				fmt.Fprintf(errout, "%v\n", err)
+				fmt.Fprintf(errout, "Error: %v\n", err)
 				os.Exit(1)
 			}
 		}
@@ -393,13 +393,17 @@ func (h *DefaultPluginHandler) Execute(executablePath string, cmdArgs, environme
 // HandlePluginCommand receives a pluginHandler and command-line arguments and attempts to find
 // a plugin executable on the PATH that satisfies the given arguments.
 func HandlePluginCommand(pluginHandler PluginHandler, cmdArgs []string) error {
-	remainingArgs := []string{} // all "non-flag" arguments
-
-	for idx := range cmdArgs {
-		if strings.HasPrefix(cmdArgs[idx], "-") {
+	var remainingArgs []string // all "non-flag" arguments
+	for _, arg := range cmdArgs {
+		if strings.HasPrefix(arg, "-") {
 			break
 		}
-		remainingArgs = append(remainingArgs, strings.Replace(cmdArgs[idx], "-", "_", -1))
+		remainingArgs = append(remainingArgs, strings.Replace(arg, "-", "_", -1))
+	}
+
+	if len(remainingArgs) == 0 {
+		// the length of cmdArgs is at least 1
+		return fmt.Errorf("flags cannot be placed before plugin name: %s", cmdArgs[0])
 	}
 
 	foundBinaryPath := ""


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind api-change

/kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

At present if we call kubectl plugins while putting the flags before its name, like `kubectl -n foo bar`, kubectl would print a confusing error since it consider `bar` as its subcommand:
```
Error: unknown command "bar" for "kubectl"
Run 'kubectl --help' for usage.
```

This patch makes kubectl warn users that they cannot place flags before plugin name.

Before:
```
$ kubectl -n foo echo
Error: unknown command "echo" for "kubectl"
Run 'kubectl --help' for usage.
```

After:
```
$ ./_output/bin/kubectl -n foo echo
Error: flags cannot be placed before plugin name: -n
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubectl/issues/884

**Special notes for your reviewer**:
https://docs.google.com/document/d/1r0YElcXt6G5mOWxwZiXgGu_X6he3F--wKwg-9UBc29I/edit#heading=h.ji0nwpg7dyuz 
sig-cli has discussed this issue a bit on the sig meeting held on July 15th 2020 and decided not to change the current behavior. After discussion with @soltysh on Slack, we both agree that we could improve the error message so that users are not confused.

**Does this PR introduce a user-facing change?**:

```release-note
kubectl: print error if users place flags before plugin name
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
