### PR TITLE
Restore docker focal version in gci nodes

### DIFF
--- a/cluster/gce/gci/configure.sh
+++ b/cluster/gce/gci/configure.sh
@@ -423,12 +423,7 @@ function install-docker {
     software-properties-common \
     lsb-release
 
-  # focal repo for docker is not yet available, so we use bonic for now
-  # https://github.com/kubernetes/kubernetes/issues/90709
   release=$(lsb_release -cs)
-  if [ "$release" == "focal" ]; then
-    release="bionic";
-  fi
 
   # Add the Docker apt-repository
   curl -fsSL https://download.docker.com/linux/$(. /etc/os-release; echo "$ID")/gpg \
@@ -469,12 +464,7 @@ function install-containerd-ubuntu {
     software-properties-common \
     lsb-release
 
-  # focal repo for docker is not yet available, so we use bonic for now
-  # https://github.com/kubernetes/kubernetes/issues/90709
   release=$(lsb_release -cs)
-  if [ "$release" == "focal" ]; then
-    release="bionic";
-  fi
 
   # Add the Docker apt-repository (as we install containerd from there)
   curl -fsSL https://download.docker.com/linux/$(. /etc/os-release; echo "$ID")/gpg \


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This change reverts a workaround needed to install docker in ubuntu focal fossa gci nodes.

**Which issue(s) this PR fixes**:
Fixes #90709

**Special notes for your reviewer**:
The workaround was installing docker on focal fossa nodes from the bionic repo instead of the focal fossa repo because the focal fossa repo did not exist. Docker team has now created the focal fossa repo, so we no longer need the workaround.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

