### PR TITLE
Fix typo in metrics.go

### DIFF
--- a/staging/src/k8s.io/component-base/metrics/testutil/metrics.go
+++ b/staging/src/k8s.io/component-base/metrics/testutil/metrics.go
@@ -123,7 +123,7 @@ func ExtractMetricSamples(metricsBlob string) ([]*model.Sample, error) {
 	}
 }
 
-// PrintSample returns formated representation of metric Sample
+// PrintSample returns formatted representation of metric Sample
 func PrintSample(sample *model.Sample) string {
 	buf := make([]string, 0)
 	// Id is a VERY special label. For 'normal' container it's useless, but it's necessary


### PR DESCRIPTION
**What type of PR is this?**
 /kind cleanup

**What this PR does / why we need it**:
Fixes a typo.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```