### PR TITLE
Introduce feature gates to Scheduler component config

### DIFF
--- a/cmd/kube-scheduler/app/options/BUILD
+++ b/cmd/kube-scheduler/app/options/BUILD
@@ -76,8 +76,11 @@ go_test(
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/rand:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/server/options:go_default_library",
+        "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",
         "//staging/src/k8s.io/component-base/config:go_default_library",
+        "//staging/src/k8s.io/component-base/featuregate:go_default_library",
         "//vendor/github.com/google/go-cmp/cmp:go_default_library",
+        "//vendor/github.com/spf13/pflag:go_default_library",
         "//vendor/github.com/stretchr/testify/assert:go_default_library",
     ],
 )

--- a/cmd/kube-scheduler/app/options/options.go
+++ b/cmd/kube-scheduler/app/options/options.go
@@ -188,10 +188,7 @@ func (o *Options) ApplyTo(c *schedulerappconfig.Config) error {
 			return err
 		}
 
-		// flag feature gates take precedence over feature gates in config file
-		for name, value := range o.ComponentConfig.FeatureGates {
-			cfg.FeatureGates[name] = value
-		}
+		flagFeatureGates := o.ComponentConfig.FeatureGates
 
 		// use the loaded config file only, with the exception of --address, --port and --feature-gates. This means that
 		// none of the deprecated flags in o.Deprecated are taken into consideration. This is the old
@@ -200,6 +197,10 @@ func (o *Options) ApplyTo(c *schedulerappconfig.Config) error {
 
 		if err := o.CombinedInsecureServing.ApplyToFromLoadedConfig(c, &c.ComponentConfig); err != nil {
 			return err
+		}
+
+		for name, value := range flagFeatureGates {
+			c.ComponentConfig.FeatureGates[name] = value
 		}
 	}
 

--- a/cmd/kube-scheduler/app/options/options.go
+++ b/cmd/kube-scheduler/app/options/options.go
@@ -193,7 +193,7 @@ func (o *Options) ApplyTo(c *schedulerappconfig.Config) error {
 			cfg.FeatureGates[name] = value
 		}
 
-		// use the loaded config file only, with the exception of --address and --port. This means that
+		// use the loaded config file only, with the exception of --address, --port and --feature-gates. This means that
 		// none of the deprecated flags in o.Deprecated are taken into consideration. This is the old
 		// behaviour of the flags we have to keep.
 		c.ComponentConfig = *cfg
@@ -201,6 +201,10 @@ func (o *Options) ApplyTo(c *schedulerappconfig.Config) error {
 		if err := o.CombinedInsecureServing.ApplyToFromLoadedConfig(c, &c.ComponentConfig); err != nil {
 			return err
 		}
+	}
+
+	if err := utilfeature.DefaultMutableFeatureGate.SetFromMap(c.ComponentConfig.FeatureGates); err != nil {
+		return err
 	}
 
 	if err := o.SecureServing.ApplyTo(&c.SecureServing, &c.LoopbackClientConfig); err != nil {
@@ -215,10 +219,6 @@ func (o *Options) ApplyTo(c *schedulerappconfig.Config) error {
 		}
 	}
 	o.Metrics.Apply()
-
-	if err := utilfeature.DefaultMutableFeatureGate.SetFromMap(c.ComponentConfig.FeatureGates); err != nil {
-		return err
-	}
 
 	return nil
 }

--- a/pkg/scheduler/apis/config/types.go
+++ b/pkg/scheduler/apis/config/types.go
@@ -109,6 +109,9 @@ type KubeSchedulerConfiguration struct {
 	// Extenders are the list of scheduler extenders, each holding the values of how to communicate
 	// with the extender. These extenders are shared by all scheduler profiles.
 	Extenders []Extender
+
+	// FeatureGates is a map of feature names to bools that enable or disable alpha/experimental features.
+	FeatureGates map[string]bool
 }
 
 // KubeSchedulerProfile is a scheduling profile.

--- a/pkg/scheduler/apis/config/v1beta1/zz_generated.conversion.go
+++ b/pkg/scheduler/apis/config/v1beta1/zz_generated.conversion.go
@@ -277,6 +277,7 @@ func autoConvert_v1beta1_KubeSchedulerConfiguration_To_config_KubeSchedulerConfi
 		out.Profiles = nil
 	}
 	out.Extenders = *(*[]config.Extender)(unsafe.Pointer(&in.Extenders))
+	out.FeatureGates = *(*map[string]bool)(unsafe.Pointer(&in.FeatureGates))
 	return nil
 }
 
@@ -321,6 +322,7 @@ func autoConvert_config_KubeSchedulerConfiguration_To_v1beta1_KubeSchedulerConfi
 		out.Profiles = nil
 	}
 	out.Extenders = *(*[]configv1.Extender)(unsafe.Pointer(&in.Extenders))
+	out.FeatureGates = *(*map[string]bool)(unsafe.Pointer(&in.FeatureGates))
 	return nil
 }
 

--- a/pkg/scheduler/apis/config/zz_generated.deepcopy.go
+++ b/pkg/scheduler/apis/config/zz_generated.deepcopy.go
@@ -145,6 +145,13 @@ func (in *KubeSchedulerConfiguration) DeepCopyInto(out *KubeSchedulerConfigurati
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.FeatureGates != nil {
+		in, out := &in.FeatureGates, &out.FeatureGates
+		*out = make(map[string]bool, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	return
 }
 

--- a/staging/src/k8s.io/kube-scheduler/config/v1beta1/types.go
+++ b/staging/src/k8s.io/kube-scheduler/config/v1beta1/types.go
@@ -96,6 +96,9 @@ type KubeSchedulerConfiguration struct {
 	// with the extender. These extenders are shared by all scheduler profiles.
 	// +listType=set
 	Extenders []v1.Extender `json:"extenders,omitempty"`
+
+	// FeatureGates is a map of feature names to bools that enable or disable alpha/experimental features.
+	FeatureGates map[string]bool `json:"featureGates,omitempty"`
 }
 
 // DecodeNestedObjects decodes plugin args for known types.

--- a/staging/src/k8s.io/kube-scheduler/config/v1beta1/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/kube-scheduler/config/v1beta1/zz_generated.deepcopy.go
@@ -107,6 +107,13 @@ func (in *KubeSchedulerConfiguration) DeepCopyInto(out *KubeSchedulerConfigurati
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.FeatureGates != nil {
+		in, out := &in.FeatureGates, &out.FeatureGates
+		*out = make(map[string]bool, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	return
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind api-change

**What this PR does / why we need it**:
Introduce feature gates to Scheduler CLI flags and component config

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #84922

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kube-scheduler: a `featureGates` field (mapping from string feature name to boolean enabled state) is added to the v1beta1 config file to allow enabling/disabling feature gates.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
