### PR TITLE
ignore "vmdk not found" vsphere errors during unmount (assume success)

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/vsphere/vclib/diskmanagers/vdm.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/vsphere/vclib/diskmanagers/vdm.go
@@ -97,7 +97,7 @@ func (diskManager virtualDiskManager) Delete(ctx context.Context, datacenter *vc
 	}
 	err = task.Wait(ctx)
 	vclib.RecordvSphereMetric(vclib.APIDeleteVolume, requestTime, err)
-	if err != nil {
+	if err != nil && !types.IsFileNotFound(err) {
 		klog.Errorf("Failed to delete virtual disk. err: %v", err)
 		return err
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
/sig storage

**What this PR does / why we need it**:

A vsphere deletion call may succeed before Kubernetes learns about its result. This can happen when the kube-controller-manager loses a leader election or crashes. When the deletion is retried, a "file not found" error is returned. Future retries will get the same error and manual clean up is required. This PR checks for the not found error and treats it as success so that the volume can be cleaned up from Kubernetes side as well. Once applied, this also automatically cleans up volumes that are in "State: Failed" due to this.

**Does this PR introduce a user-facing change?**:
```release-note
Treat VSphere "File (vmdk path here) was not found" errors as success during volume deletion
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs
Error classes returned by the API call to delete virtual disks are detailed here:
https://code.vmware.com/apis/196/vsphere/doc/vim.VirtualDiskManager.html#deleteVirtualDisk
`FileNotFound` is a subclass of `FileFault`, which are used for issues specific
to this file or disk. General datastore issues return `InvalidDatastore` errors.
```