### PR TITLE
decouple testfiles from framework

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -110,7 +110,11 @@ func TestMain(m *testing.M) {
 			File        string `yaml:"file"`
 		}
 
-		data := testfiles.ReadOrDie("test/conformance/testdata/conformance.yaml")
+		data, err := testfiles.Read("test/conformance/testdata/conformance.yaml")
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
 		if err := yaml.Unmarshal(data, &tests); err != nil {
 			fmt.Fprintln(os.Stderr, err)
 			os.Exit(1)

--- a/test/e2e/examples.go
+++ b/test/e2e/examples.go
@@ -155,5 +155,9 @@ var _ = framework.KubeDescribe("[Feature:Example]", func() {
 
 func readFile(test, file string) string {
 	from := filepath.Join(test, file)
-	return commonutils.SubstituteImageName(string(testfiles.ReadOrDie(from)))
+	data, err := testfiles.Read(from)
+	if err != nil {
+		framework.Fail(err.Error())
+	}
+	return commonutils.SubstituteImageName(string(data))
 }

--- a/test/e2e/framework/testfiles/BUILD
+++ b/test/e2e/framework/testfiles/BUILD
@@ -5,7 +5,6 @@ go_library(
     srcs = ["testfiles.go"],
     importpath = "k8s.io/kubernetes/test/e2e/framework/testfiles",
     visibility = ["//visibility:public"],
-    deps = ["//test/e2e/framework:go_default_library"],
 )
 
 filegroup(

--- a/test/e2e/framework/testfiles/testfiles.go
+++ b/test/e2e/framework/testfiles/testfiles.go
@@ -33,8 +33,6 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
-
-	"k8s.io/kubernetes/test/e2e/framework"
 )
 
 var filesources []FileSource
@@ -66,18 +64,6 @@ type FileSource interface {
 	DescribeFiles() string
 }
 
-// ReadOrDie tries to retrieve the desired file content from
-// one of the registered file sources. In contrast to FileSource, it
-// will either return a valid slice or abort the test by calling the fatal function,
-// i.e. the caller doesn't have to implement error checking.
-func ReadOrDie(filePath string) []byte {
-	data, err := Read(filePath)
-	if err != nil {
-		framework.Fail(err.Error(), 1)
-	}
-	return data
-}
-
 // Read tries to retrieve the desired file content from
 // one of the registered file sources.
 func Read(filePath string) ([]byte, error) {
@@ -106,17 +92,17 @@ func Read(filePath string) ([]byte, error) {
 // Exists checks whether a file could be read. Unexpected errors
 // are handled by calling the fail function, which then should
 // abort the current test.
-func Exists(filePath string) bool {
+func Exists(filePath string) (bool, error) {
 	for _, filesource := range filesources {
 		data, err := filesource.ReadTestFile(filePath)
 		if err != nil {
-			framework.Fail(fmt.Sprintf("fatal error looking for test file %s: %s", filePath, err), 1)
+			return false, err
 		}
 		if data != nil {
-			return true
+			return true, nil
 		}
 	}
-	return false
+	return false, nil
 }
 
 // RootFileSource looks for files relative to a root directory.

--- a/test/e2e/kubectl/kubectl.go
+++ b/test/e2e/kubectl/kubectl.go
@@ -210,7 +210,11 @@ func assertCleanup(ns string, selectors ...string) {
 }
 
 func readTestFileOrDie(file string) []byte {
-	return e2etestfiles.ReadOrDie(path.Join(kubeCtlManifestPath, file))
+	data, err := e2etestfiles.Read(path.Join(kubeCtlManifestPath, file))
+	if err != nil {
+		framework.Fail(err.Error(), 1)
+	}
+	return data
 }
 
 func runKubectlRetryOrDie(ns string, args ...string) string {
@@ -302,7 +306,11 @@ var _ = SIGDescribe("Kubectl client", func() {
 		var nautilus string
 		ginkgo.BeforeEach(func() {
 			updateDemoRoot := "test/fixtures/doc-yaml/user-guide/update-demo"
-			nautilus = commonutils.SubstituteImageName(string(e2etestfiles.ReadOrDie(filepath.Join(updateDemoRoot, "nautilus-rc.yaml.in"))))
+			data, err := e2etestfiles.Read(filepath.Join(updateDemoRoot, "nautilus-rc.yaml.in"))
+			if err != nil {
+				framework.Fail(err.Error())
+			}
+			nautilus = commonutils.SubstituteImageName(string(data))
 		})
 		/*
 			Release : v1.9
@@ -350,7 +358,11 @@ var _ = SIGDescribe("Kubectl client", func() {
 				"agnhost-primary-deployment.yaml.in",
 				"agnhost-replica-deployment.yaml.in",
 			} {
-				contents := commonutils.SubstituteImageName(string(e2etestfiles.ReadOrDie(filepath.Join(guestbookRoot, gbAppFile))))
+				data, err := e2etestfiles.Read(filepath.Join(guestbookRoot, gbAppFile))
+				if err != nil {
+					framework.Fail(err.Error())
+				}
+				contents := commonutils.SubstituteImageName(string(data))
 				run(contents)
 			}
 		}

--- a/test/e2e/storage/flexvolume.go
+++ b/test/e2e/storage/flexvolume.go
@@ -91,7 +91,10 @@ func installFlex(c clientset.Interface, node *v1.Node, vendor, driver, filePath 
 	cmd := fmt.Sprintf("sudo mkdir -p %s", flexDir)
 	sshAndLog(cmd, host, true /*failOnError*/)
 
-	data := e2etestfiles.ReadOrDie(filePath)
+	data, err := e2etestfiles.Read(filePath)
+	if err != nil {
+		framework.Fail(err.Error())
+	}
 	cmd = fmt.Sprintf("sudo tee <<'EOF' %s\n%s\nEOF", flexFile, string(data))
 	sshAndLog(cmd, host, true /*failOnError*/)
 

--- a/test/e2e/upgrades/cassandra.go
+++ b/test/e2e/upgrades/cassandra.go
@@ -60,7 +60,11 @@ func (CassandraUpgradeTest) Skip(upgCtx UpgradeContext) bool {
 }
 
 func cassandraKubectlCreate(ns, file string) {
-	input := string(e2etestfiles.ReadOrDie(filepath.Join(cassandraManifestPath, file)))
+	data, err := e2etestfiles.Read(filepath.Join(cassandraManifestPath, file))
+	if err != nil {
+		framework.Fail(err.Error())
+	}
+	input := string(data)
 	framework.RunKubectlOrDieInput(ns, input, "create", "-f", "-", fmt.Sprintf("--namespace=%s", ns))
 }
 

--- a/test/e2e/upgrades/etcd.go
+++ b/test/e2e/upgrades/etcd.go
@@ -59,7 +59,11 @@ func (EtcdUpgradeTest) Skip(upgCtx UpgradeContext) bool {
 }
 
 func kubectlCreate(ns, file string) {
-	input := string(e2etestfiles.ReadOrDie(filepath.Join(manifestPath, file)))
+	data, err := e2etestfiles.Read(filepath.Join(manifestPath, file))
+	if err != nil {
+		framework.Fail(err.Error())
+	}
+	input := string(data)
 	framework.RunKubectlOrDieInput(ns, input, "create", "-f", "-", fmt.Sprintf("--namespace=%s", ns))
 }
 

--- a/test/e2e/upgrades/mysql.go
+++ b/test/e2e/upgrades/mysql.go
@@ -61,7 +61,11 @@ func (MySQLUpgradeTest) Skip(upgCtx UpgradeContext) bool {
 }
 
 func mysqlKubectlCreate(ns, file string) {
-	input := string(e2etestfiles.ReadOrDie(filepath.Join(mysqlManifestPath, file)))
+	data, err := e2etestfiles.Read(filepath.Join(mysqlManifestPath, file))
+	if err != nil {
+		framework.Fail(err.Error())
+	}
+	input := string(data)
 	framework.RunKubectlOrDieInput(ns, input, "create", "-f", "-", fmt.Sprintf("--namespace=%s", ns))
 }
 

--- a/test/e2e_node/device_plugin_test.go
+++ b/test/e2e_node/device_plugin_test.go
@@ -80,7 +80,12 @@ func numberOfSampleResources(node *v1.Node) int64 {
 
 // getSampleDevicePluginPod returns the Device Plugin pod for sample resources in e2e tests.
 func getSampleDevicePluginPod() *v1.Pod {
-	ds := readDaemonSetV1OrDie(e2etestfiles.ReadOrDie(sampleDevicePluginDSYAML))
+	data, err := e2etestfiles.Read(sampleDevicePluginDSYAML)
+	if err != nil {
+		framework.Fail(err.Error())
+	}
+
+	ds := readDaemonSetV1OrDie(data)
 	p := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      sampleDevicePluginName,

--- a/test/e2e_node/topology_manager_test.go
+++ b/test/e2e_node/topology_manager_test.go
@@ -246,7 +246,12 @@ func configureTopologyManagerInKubelet(f *framework.Framework, oldCfg *kubeletco
 
 // getSRIOVDevicePluginPod returns the Device Plugin pod for sriov resources in e2e tests.
 func getSRIOVDevicePluginPod() *v1.Pod {
-	ds := readDaemonSetV1OrDie(e2etestfiles.ReadOrDie(SRIOVDevicePluginDSYAML))
+	data, err := e2etestfiles.Read(SRIOVDevicePluginDSYAML)
+	if err != nil {
+		framework.Fail(err.Error())
+	}
+
+	ds := readDaemonSetV1OrDie(data)
 	p := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      SRIOVDevicePluginName,
@@ -415,13 +420,15 @@ func isTopologyAffinityError(pod *v1.Pod) bool {
 }
 
 func getSRIOVDevicePluginConfigMap(cmFile string) *v1.ConfigMap {
-	cmData := e2etestfiles.ReadOrDie(SRIOVDevicePluginCMYAML)
-	var err error
+	data, err := e2etestfiles.Read(SRIOVDevicePluginCMYAML)
+	if err != nil {
+		framework.Fail(err.Error())
+	}
 
 	// the SRIOVDP configuration is hw-dependent, so we allow per-test-host customization.
 	framework.Logf("host-local SRIOV Device Plugin Config Map %q", cmFile)
 	if cmFile != "" {
-		cmData, err = ioutil.ReadFile(cmFile)
+		data, err = ioutil.ReadFile(cmFile)
 		if err != nil {
 			framework.Failf("unable to load the SRIOV Device Plugin ConfigMap: %v", err)
 		}
@@ -429,7 +436,7 @@ func getSRIOVDevicePluginConfigMap(cmFile string) *v1.ConfigMap {
 		framework.Logf("Using built-in SRIOV Device Plugin Config Map")
 	}
 
-	return readConfigMapV1OrDie(cmData)
+	return readConfigMapV1OrDie(data)
 }
 
 type sriovData struct {
@@ -449,7 +456,11 @@ func setupSRIOVConfigOrFail(f *framework.Framework, configMap *v1.ConfigMap) *sr
 		framework.Failf("unable to create test configMap %s: %v", configMap.Name, err)
 	}
 
-	serviceAccount := readServiceAccountV1OrDie(e2etestfiles.ReadOrDie(SRIOVDevicePluginSAYAML))
+	data, err := e2etestfiles.Read(SRIOVDevicePluginSAYAML)
+	if err != nil {
+		framework.Fail(err.Error())
+	}
+	serviceAccount := readServiceAccountV1OrDie(data)
 	ginkgo.By(fmt.Sprintf("Creating serviceAccount %v/%v", metav1.NamespaceSystem, serviceAccount.Name))
 	if _, err = f.ClientSet.CoreV1().ServiceAccounts(metav1.NamespaceSystem).Create(context.TODO(), serviceAccount, metav1.CreateOptions{}); err != nil {
 		framework.Failf("unable to create test serviceAccount %s: %v", serviceAccount.Name, err)


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

This drops testfiles.ReadOrDie and updated testfiles.Exists to return an
error, forcing the caller to decide whether to call framework.Fail or do
something else. It's slightly less friendly / more verbose to use now.
But test/e2e/framework/testfiles is back to being a self-contained
package as described in its comments.

**Special notes for your reviewer**:

```release-note
NONE
```