### PR TITLE
ensure requests equals to limits in static policy

### DIFF
--- a/pkg/kubelet/cm/cpumanager/policy_static.go
+++ b/pkg/kubelet/cm/cpumanager/policy_static.go
@@ -299,6 +299,10 @@ func (p *staticPolicy) guaranteedCPUs(pod *v1.Pod, container *v1.Container) int 
 		return 0
 	}
 	cpuQuantity := container.Resources.Requests[v1.ResourceCPU]
+	cpuLimitsQuantity := container.Resources.Limits[v1.ResourceCPU]
+	if cpuQuantity.Value() != cpuLimitsQuantity.Value() {
+		return 0
+	}
 	if cpuQuantity.Value()*1000 != cpuQuantity.MilliValue() {
 		return 0
 	}


### PR DESCRIPTION
**What type of PR is this?**

> /kind api-change
/kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

Static policy allocates CPUs (aligned to `requests`) to init container when requests and limits are not equal.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

No

**Does this PR introduce a user-facing change?**:

```release-note
No
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs
No
```
/sig node
/assign @klueska 