### PR TITLE
change kubelet metrics name

### DIFF
--- a/pkg/kubelet/metrics/metrics.go
+++ b/pkg/kubelet/metrics/metrics.go
@@ -349,7 +349,7 @@ var (
 	RunningPodCount = metrics.NewGauge(
 		&metrics.GaugeOpts{
 			Subsystem:      KubeletSubsystem,
-			Name:           "running_pod_count",
+			Name:           "running_pods",
 			Help:           "Number of pods currently running",
 			StabilityLevel: metrics.ALPHA,
 		},
@@ -358,7 +358,7 @@ var (
 	RunningContainerCount = metrics.NewGaugeVec(
 		&metrics.GaugeOpts{
 			Subsystem:      KubeletSubsystem,
-			Name:           "running_container_count",
+			Name:           "running_containers",
 			Help:           "Number of containers currently running",
 			StabilityLevel: metrics.ALPHA,
 		},

--- a/pkg/kubelet/pleg/generic_test.go
+++ b/pkg/kubelet/pleg/generic_test.go
@@ -682,22 +682,22 @@ func TestRunningPodAndContainerCount(t *testing.T) {
 	}{
 		{
 			name:        "test container count",
-			metricsName: "kubelet_running_container_count",
+			metricsName: "kubelet_running_containers",
 			wants: `
-# HELP kubelet_running_container_count [ALPHA] Number of containers currently running
-# TYPE kubelet_running_container_count gauge
-kubelet_running_container_count{container_state="exited"} 1
-kubelet_running_container_count{container_state="running"} 1
-kubelet_running_container_count{container_state="unknown"} 2
+# HELP kubelet_running_containers [ALPHA] Number of containers currently running
+# TYPE kubelet_running_containers gauge
+kubelet_running_containers{container_state="exited"} 1
+kubelet_running_containers{container_state="running"} 1
+kubelet_running_containers{container_state="unknown"} 2
 `,
 		},
 		{
 			name:        "test pod count",
-			metricsName: "kubelet_running_pod_count",
+			metricsName: "kubelet_running_pods",
 			wants: `
-# HELP kubelet_running_pod_count [ALPHA] Number of pods currently running
-# TYPE kubelet_running_pod_count gauge
-kubelet_running_pod_count 2
+# HELP kubelet_running_pods [ALPHA] Number of pods currently running
+# TYPE kubelet_running_pods gauge
+kubelet_running_pods 2
 `,
 		},
 	}

--- a/staging/src/k8s.io/component-base/metrics/testutil/promlint.go
+++ b/staging/src/k8s.io/component-base/metrics/testutil/promlint.go
@@ -64,12 +64,9 @@ var exceptionMetrics = []string{
 	"node_collector_evictions_number",
 
 	// k8s.io/kubernetes/pkg/kubelet/server/stats
+	// The two metrics have been deprecated and will be removed in release v1.20+.
 	"container_cpu_usage_seconds_total", // non-counter metrics should not have "_total" suffix
 	"node_cpu_usage_seconds_total",      // non-counter metrics should not have "_total" suffix
-
-	// k8s.io/kubernetes/pkg/kubelet/pleg
-	"kubelet_running_container_count", // non-histogram and non-summary metrics should not have "_count" suffix
-	"kubelet_running_pod_count",       // non-histogram and non-summary metrics should not have "_count" suffix
 }
 
 // A Problem is an issue detected by a Linter.


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
https://github.com/kubernetes/kubernetes/blob/3a51aaf8b4baff1242ea30b08d599d913fe7a127/staging/src/k8s.io/component-base/metrics/testutil/promlint.go#L70-L72

**Which issue(s) this PR fixes**:
Refer [discussion here](https://kubernetes.slack.com/archives/C20HH14P7/p1592661271239300).

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kubelet: following metrics have been renamed:
kubelet_running_container_count --> kubelet_running_containers
kubelet_running_pod_count --> kubelet_running_pods
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

/priority important-soon