### PR TITLE
Fix static check failures for staging/src/k8s.io/apiserver/pkg/server/healthz

### DIFF
--- a/hack/.staticcheck_failures
+++ b/hack/.staticcheck_failures
@@ -50,7 +50,6 @@ vendor/k8s.io/apiserver/pkg/registry/generic/rest
 vendor/k8s.io/apiserver/pkg/registry/rest/resttest
 vendor/k8s.io/apiserver/pkg/server
 vendor/k8s.io/apiserver/pkg/server/filters
-vendor/k8s.io/apiserver/pkg/server/healthz
 vendor/k8s.io/apiserver/pkg/server/httplog
 vendor/k8s.io/apiserver/pkg/server/options
 vendor/k8s.io/apiserver/pkg/server/options/encryptionconfig

--- a/staging/src/k8s.io/apiserver/pkg/server/healthz/healthz_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/healthz/healthz_test.go
@@ -206,9 +206,6 @@ func TestFormatQuoted(t *testing.T) {
 }
 
 func TestGetExcludedChecks(t *testing.T) {
-	type args struct {
-		r *http.Request
-	}
 	tests := []struct {
 		name string
 		r    *http.Request


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind api-change
> /kind bug

/kind cleanup

> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:fixes `staging/src/k8s.io/apiserver/pkg/server/healthz` package  static check errors.

**Which issue(s) this PR fixes**:
Part of https://github.com/kubernetes/kubernetes/issues/92402

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
