### PR TITLE
util.sh: Replace wait-until-stable with wait-until --stable

### DIFF
--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -3033,7 +3033,7 @@ function create-linux-nodes() {
           --base-instance-name "${extra_group_name}" \
           --size "${num_additional}" \
           --template "${extra_template_name}" || true;
-      gcloud compute instance-groups managed wait-until-stable \
+      gcloud compute instance-groups managed wait-until --stable \
           "${extra_group_name}" \
           --zone "${ZONE}" \
           --project "${PROJECT}" \
@@ -3064,7 +3064,7 @@ function create-linux-nodes() {
           --base-instance-name "${group_name}" \
           --size "${this_mig_size}" \
           --template "${template_name}" || true;
-      gcloud compute instance-groups managed wait-until-stable \
+      gcloud compute instance-groups managed wait-until --stable \
           "${group_name}" \
           --zone "${ZONE}" \
           --project "${PROJECT}" \
@@ -3104,7 +3104,7 @@ function create-windows-nodes() {
         --base-instance-name "${group_name}" \
         --size "${this_mig_size}" \
         --template "${template_name}" || true;
-    gcloud compute instance-groups managed wait-until-stable \
+    gcloud compute instance-groups managed wait-until --stable \
         "${group_name}" \
         --zone "${ZONE}" \
         --project "${PROJECT}" \


### PR DESCRIPTION
**What type of PR is this?**
/kind deprecation

**What this PR does / why we need it**:
This change follows the recommendation from the CI logs:

WARNING: `gcloud compute instance-groups managed wait-until-stable` is
deprecated. Please use `gcloud compute instance-groups managed
wait-until --stable` instead.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
