### PR TITLE
dump conntrack table on e2e conntrack failures

### DIFF
--- a/test/e2e/network/conntrack.go
+++ b/test/e2e/network/conntrack.go
@@ -17,6 +17,7 @@ limitations under the License.
 package network
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"time"
@@ -116,6 +117,9 @@ var _ = SIGDescribe("Conntrack", func() {
 	})
 
 	ginkgo.It("should be able to preserve UDP traffic when server pod cycles for a NodePort service", func() {
+		// TODO(#91236): Remove once the test is debugged and fixed.
+		// dump conntrack table for debugging
+		defer dumpConntrack(cs)
 
 		// Create a NodePort service
 		udpJig := e2eservice.NewTestJig(cs, ns, serviceName)
@@ -193,6 +197,9 @@ var _ = SIGDescribe("Conntrack", func() {
 	})
 
 	ginkgo.It("should be able to preserve UDP traffic when server pod cycles for a ClusterIP service", func() {
+		// TODO(#91236): Remove once the test is debugged and fixed.
+		// dump conntrack table for debugging
+		defer dumpConntrack(cs)
 
 		// Create a ClusterIP service
 		udpJig := e2eservice.NewTestJig(cs, ns, serviceName)
@@ -269,3 +276,24 @@ var _ = SIGDescribe("Conntrack", func() {
 		}
 	})
 })
+
+func dumpConntrack(cs clientset.Interface) {
+	// Dump conntrack table of each node for troubleshooting using the kube-proxy pods
+	namespace := "kube-system"
+	pods, err := cs.CoreV1().Pods(namespace).List(context.TODO(), metav1.ListOptions{})
+	if err != nil || len(pods.Items) == 0 {
+		framework.Logf("failed to list kube-proxy pods in namespace: %s", namespace)
+		return
+	}
+	cmd := "conntrack -L"
+	for _, pod := range pods.Items {
+		if strings.Contains(pod.Name, "kube-proxy") {
+			stdout, err := framework.RunHostCmd(namespace, pod.Name, cmd)
+			if err != nil {
+				framework.Logf("Failed to dump conntrack table of node %s: %v", pod.Spec.NodeName, err)
+				continue
+			}
+			framework.Logf("conntrack table of node %s: %s", pod.Spec.NodeName, stdout)
+		}
+	}
+}


### PR DESCRIPTION
> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature

/kind flake

**What this PR does / why we need it**:


```release-note
NONE
```
