### PR TITLE
Adds Windows support for etcd image

### DIFF
--- a/cluster/images/etcd/Dockerfile.windows
+++ b/cluster/images/etcd/Dockerfile.windows
@@ -1,0 +1,28 @@
+# Copyright 2021 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG RUNNERIMAGE
+FROM ${RUNNERIMAGE}
+
+EXPOSE 2379 2380 4001 7001
+
+COPY etcd* etcdctl* /usr/local/bin/
+COPY cp* /usr/local/bin/
+COPY migrate-if-needed.bat /usr/local/bin/
+COPY migrate /usr/local/bin/migrate.exe
+
+# NOTE(claudiub): docker buildx sets the PATH env variable to a Linux-like PATH,
+# # which is not desirable. See: https://github.com/moby/buildkit/issues/1560
+# # TODO(claudiub): remove this once the issue has been resolved.
+ENV PATH="C:\usr\local\bin;C:\Windows\system32;C:\Windows;"

--- a/cluster/images/etcd/README.md
+++ b/cluster/images/etcd/README.md
@@ -22,7 +22,8 @@ but can also be used as the etcd target version.
 
 Always run `/usr/local/bin/migrate` (or the
 `/usr/local/bin/migrate-if-needed.sh` wrapper script) before starting the etcd
-server.
+server. On Windows, run `C:\bin\migrate.exe` (or the `C:\bin\migrate-if-needed.bat
+wrapper script`).
 
 `migrate` writes a `version.txt` file to track the "current" version
 of etcd that was used to persist data to disk. A "target" version may also be provided
@@ -48,6 +49,9 @@ directory permissions and 0644 file permissions.
 For `amd64`, official `etcd` and `etcdctl` binaries are downloaded from Github
 to maintain official support.  For other architectures, `etcd` is cross-compiled
 from source. Arch-specific `busybox` images serve as base images.
+
+Windows images can be built on Linux nodes due to `docker buildx`, but they will
+only be created and pushed when using the `all-push` make target.
 
 #### How to release
 

--- a/cluster/images/etcd/cloudbuild.yaml
+++ b/cluster/images/etcd/cloudbuild.yaml
@@ -18,5 +18,7 @@ steps:
       - '-c'
       - |
         gcloud auth configure-docker \
+        && docker buildx create --name img-builder --use \
+        && docker buildx inspect --bootstrap \
         && docker run --rm --privileged linuxkit/binfmt:4ea3b9b0938cbd19834c096aa31ff475cc75d281 \
         && make all-push

--- a/cluster/images/etcd/migrate-if-needed.bat
+++ b/cluster/images/etcd/migrate-if-needed.bat
@@ -1,0 +1,21 @@
+@echo off
+REM Copyright 2021 The Kubernetes Authors.
+REM
+REM Licensed under the Apache License, Version 2.0 (the "License");
+REM you may not use this file except in compliance with the License.
+REM You may obtain a copy of the License at
+REM
+REM     http://www.apache.org/licenses/LICENSE-2.0
+REM
+REM Unless required by applicable law or agreed to in writing, software
+REM distributed under the License is distributed on an "AS IS" BASIS,
+REM WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+REM See the License for the specific language governing permissions and
+REM limitations under the License.
+
+REM DEPRECATED:
+REM The functionality has been moved to migrate binary and this script
+REM if left for backward compatibility with previous manifests. It will be
+REM removed in the future.
+
+C:\bin\migrate.exe


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind feature

/sig windows

**What this PR does / why we need it**:

We can use `docker buildx` in order to build and push Windows images from the same Linux node, as long as the Dockerfile does not have any `RUN` commands in the Windows step.

We also need to create a non-default builder instance in order to be able to build and push Windows images.

The Windows images have to be built and pushed directly to the registry.

For Windows containers without Hyper-V isolation, the host OS Version and the Container OS Version need to match, which is why we added multiple Windows OS Versions to the building process.

Adds support for Windows OS Versions: 1809, 2004, 20H2, 2022.

Bumped etcd image revision to 2.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
The etcd container image now supports Windows.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
