### PR TITLE
delete one key per delete directive in strategicPatch

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/strategicpatch/patch.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/strategicpatch/patch.go
@@ -1478,7 +1478,7 @@ func mergeSliceWithSpecialElements(original, patch []interface{}, mergeKey strin
 				mergeValue, ok := typedV[mergeKey]
 				if ok {
 					var err error
-					original, err = deleteMatchingEntries(original, mergeKey, mergeValue)
+					original, err = deleteMatchingEntry(original, mergeKey, mergeValue)
 					if err != nil {
 						return nil, nil, err
 					}
@@ -1501,17 +1501,14 @@ func mergeSliceWithSpecialElements(original, patch []interface{}, mergeKey strin
 	return original, patchWithoutSpecialElements, nil
 }
 
-// delete all matching entries (based on merge key) from a merging list
-func deleteMatchingEntries(original []interface{}, mergeKey string, mergeValue interface{}) ([]interface{}, error) {
-	for {
-		_, originalKey, found, err := findMapInSliceBasedOnKeyValue(original, mergeKey, mergeValue)
-		if err != nil {
-			return nil, err
-		}
+// delete matching entry (based on merge key) from a merging list
+func deleteMatchingEntry(original []interface{}, mergeKey string, mergeValue interface{}) ([]interface{}, error) {
+	_, originalKey, found, err := findMapInSliceBasedOnKeyValue(original, mergeKey, mergeValue)
+	if err != nil {
+		return nil, err
+	}
 
-		if !found {
-			break
-		}
+	if found {
 		// Delete the element at originalKey.
 		original = append(original[:originalKey], original[originalKey+1:]...)
 	}

--- a/staging/src/k8s.io/apimachinery/pkg/util/strategicpatch/patch_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/strategicpatch/patch_test.go
@@ -375,6 +375,27 @@ testCases:
       $patch: replace
     modified:
       other: a
+  - description: de-duplicate entries in a merging list
+    original:
+      mergingList:
+        - name: 1
+        - name: 1
+        - name: 2
+          value: a
+        - name: 3
+        - name: 3
+    twoWay:
+      mergingList:
+        - name: 1
+          $patch: delete
+        - name: 3
+          $patch: delete
+    modified:
+      mergingList:
+        - name: 1
+        - name: 2
+          value: a
+        - name: 3
   - description: delete all duplicate entries in a merging list
     original:
       mergingList:
@@ -387,6 +408,10 @@ testCases:
     twoWay:
       mergingList:
         - name: 1
+          $patch: delete
+        - name: 1
+          $patch: delete
+        - name: 3
           $patch: delete
         - name: 3
           $patch: delete
@@ -1617,8 +1642,72 @@ mergingList:
     other: b
 `),
 		},
+  },
+{
+		Description: "de-duplicate field in merging list",
+		StrategicMergePatchRawTestCaseData: StrategicMergePatchRawTestCaseData{
+			Original: []byte(`
+mergingList:
+  - name: 1
+  - name: 1
+`),
+			TwoWay: []byte(`
+$setElementOrder/mergingList:
+  - name: 1
+mergingList:
+  - $patch: delete
+    name: 1
+`),
+			Modified: []byte(`
+mergingList:
+  - name: 1
+`),
+			Current: []byte(`
+mergingList:
+  - name: 1
+  - name: 1
+`),
+			ThreeWay: []byte(`
+$setElementOrder/mergingList:
+  - name: 1
+mergingList:
+  - $patch: delete
+    name: 1
+`),
+			Result: []byte(`
+mergingList:
+  - name: 1
+`),
+		},
 	},
-	{
+{
+  Description: "delete duplicate field in merging list",
+  StrategicMergePatchRawTestCaseData: StrategicMergePatchRawTestCaseData{
+    Original: []byte(`
+mergingList:
+- name: 1
+- name: 1
+`),
+    TwoWay: []byte(`
+mergingList: {}
+`),
+    Modified: []byte(`
+mergingList: {}
+`),
+    Current: []byte(`
+mergingList:
+- name: 1
+- name: 1
+`),
+    ThreeWay: []byte(`
+mergingList: {}
+`),
+    Result: []byte(`
+mergingList: {}
+`),
+  },
+},
+{
 		Description: "add an item that already exists in current object in merging list",
 		StrategicMergePatchRawTestCaseData: StrategicMergePatchRawTestCaseData{
 			Original: []byte(`

--- a/staging/src/k8s.io/apimachinery/pkg/util/strategicpatch/patch_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/strategicpatch/patch_test.go
@@ -1642,8 +1642,8 @@ mergingList:
     other: b
 `),
 		},
-  },
-{
+	},
+	{
 		Description: "de-duplicate field in merging list",
 		StrategicMergePatchRawTestCaseData: StrategicMergePatchRawTestCaseData{
 			Original: []byte(`
@@ -1680,34 +1680,34 @@ mergingList:
 `),
 		},
 	},
-{
-  Description: "delete duplicate field in merging list",
-  StrategicMergePatchRawTestCaseData: StrategicMergePatchRawTestCaseData{
-    Original: []byte(`
+	{
+		Description: "delete duplicate field in merging list",
+		StrategicMergePatchRawTestCaseData: StrategicMergePatchRawTestCaseData{
+			Original: []byte(`
 mergingList:
 - name: 1
 - name: 1
 `),
-    TwoWay: []byte(`
+			TwoWay: []byte(`
 mergingList: {}
 `),
-    Modified: []byte(`
+			Modified: []byte(`
 mergingList: {}
 `),
-    Current: []byte(`
+			Current: []byte(`
 mergingList:
 - name: 1
 - name: 1
 `),
-    ThreeWay: []byte(`
+			ThreeWay: []byte(`
 mergingList: {}
 `),
-    Result: []byte(`
+			Result: []byte(`
 mergingList: {}
 `),
-  },
-},
-{
+		},
+	},
+	{
 		Description: "add an item that already exists in current object in merging list",
 		StrategicMergePatchRawTestCaseData: StrategicMergePatchRawTestCaseData{
 			Original: []byte(`


### PR DESCRIPTION
attempts to address https://github.com/kubernetes/kubernetes/issues/58477 by only deleting one element per directive

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
A patch to delete an accidental duplicate key in a resource definition ends up deleting all of the keys.  This requires a workaround where a person removes all of the keys, then adds one of them back.  Instead, the merged resource definition should reflect what was submitted into the system.

**Which issue(s) this PR fixes**:
Fixes #58477

**Special notes for your reviewer**:


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixed a bug where `kubectl apply` removes all entries when attempting to remove a single duplicated entry in a persisted object
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
