### PR TITLE
Add ebtables rule delete function + broute table + brouting chain

### DIFF
--- a/pkg/util/ebtables/ebtables.go
+++ b/pkg/util/ebtables/ebtables.go
@@ -43,6 +43,7 @@ type Table string
 const (
 	TableNAT    Table = "nat"
 	TableFilter Table = "filter"
+	TableBroute Table = "broute"
 )
 
 type Chain string
@@ -52,6 +53,7 @@ const (
 	ChainPrerouting  Chain = "PREROUTING"
 	ChainOutput      Chain = "OUTPUT"
 	ChainInput       Chain = "INPUT"
+	ChainBrouting    Chain = "BROUTING"
 )
 
 type operation string
@@ -75,6 +77,8 @@ type Interface interface {
 	// Input args must follow the format and sequence of ebtables list output. Otherwise, EnsureRule will always create
 	// new rules and causing duplicates.
 	EnsureRule(position RulePosition, table Table, chain Chain, args ...string) (bool, error)
+	// DeleteRule checks if the specified rule is present and, if so, deletes it.
+	DeleteRule(table Table, chain Chain, args ...string) error
 	// EnsureChain checks if the specified chain is present and, if not, creates it.  If the rule existed, return true.
 	EnsureChain(table Table, chain Chain) (bool, error)
 	// DeleteChain deletes the specified chain.  If the chain did not exist, return error.
@@ -137,6 +141,27 @@ func (runner *runner) EnsureRule(position RulePosition, table Table, chain Chain
 		}
 	}
 	return exist, nil
+}
+
+func (runner *runner) DeleteRule(table Table, chain Chain, args ...string) error {
+	exist := true
+	fullArgs := makeFullArgs(table, opListChain, chain, fullMac)
+	out, err := runner.exec.Command(cmdebtables, fullArgs...).CombinedOutput()
+	if err != nil {
+		exist = false
+	} else {
+		exist = checkIfRuleExists(string(out), args...)
+	}
+
+	if !exist {
+		return nil
+	}
+	fullArgs = makeFullArgs(table, opDeleteRule, chain, args...)
+	out, err = runner.exec.Command(cmdebtables, fullArgs...).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("Failed to delete rule: %v, output: %s", err, out)
+	}
+	return nil
 }
 
 func (runner *runner) EnsureChain(table Table, chain Chain) (bool, error) {


### PR DESCRIPTION
Implementation of the enhancement documented in:

https://github.com/kubernetes/kubernetes/issues/92439

/kind feature

**What this PR does / why we need it**:

Enhance  ebtables utility adding the following 3 features:

- DeleteRule method
- broute table
- brouting chain


**Which issue(s) this PR fixes**:
Fixes #92439 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
NONE

```release-note
No actions required. This is a small enhancement to a utility library.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

Implementing the missing features allows to:

- delete rules as there is currently a way to add (ensure) a rule but not removing it.
- manipulate the broute table and brouting chain.

The first feature would also align ebtables with iptables, as a DeleteRule method is available there.
