### PR TITLE
Add isNodeSchedulableWithoutTaints()

### DIFF
--- a/test/e2e/framework/node/resource.go
+++ b/test/e2e/framework/node/resource.go
@@ -374,7 +374,7 @@ func GetMasterAndWorkerNodes(c clientset.Interface) (sets.String, *v1.NodeList, 
 	for _, n := range all.Items {
 		if system.DeprecatedMightBeMasterNode(n.Name) {
 			masters.Insert(n.Name)
-		} else if IsNodeSchedulable(&n) && isNodeUntainted(&n) {
+		} else if isNodeSchedulableWithoutTaints(&n) {
 			nodes.Items = append(nodes.Items, n)
 		}
 	}
@@ -476,6 +476,14 @@ func IsNodeReady(node *v1.Node) bool {
 	networkReady := isConditionUnset(node, v1.NodeNetworkUnavailable) ||
 		IsConditionSetAsExpectedSilent(node, v1.NodeNetworkUnavailable, false)
 	return nodeReady && networkReady
+}
+
+// isNodeSchedulableWithoutTaints returns true if:
+// 1) doesn't have "unschedulable" field set
+// 2) it also returns true from IsNodeReady
+// 3) it also returns true from isNodeUntainted
+func isNodeSchedulableWithoutTaints(node *v1.Node) bool {
+	return IsNodeSchedulable(node) && isNodeUntainted(node)
 }
 
 // hasNonblockingTaint returns true if the node contains at least

--- a/test/e2e/framework/node/wait.go
+++ b/test/e2e/framework/node/wait.go
@@ -28,7 +28,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	clientset "k8s.io/client-go/kubernetes"
 	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
-	"k8s.io/kubernetes/test/e2e/system"
 	testutils "k8s.io/kubernetes/test/utils"
 )
 
@@ -84,7 +83,7 @@ func WaitForTotalHealthy(c clientset.Interface, timeout time.Duration) error {
 		}
 		missingPodsPerNode = make(map[string][]string)
 		for _, node := range nodes.Items {
-			if !system.DeprecatedMightBeMasterNode(node.Name) {
+			if isNodeSchedulableWithoutTaints(&node) {
 				for _, requiredPod := range requiredPerNodePods {
 					foundRequired := false
 					for _, presentPod := range systemPodsPerNode[node.Name] {


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

For reducing usage of system.DeprecatedMightBeMasterNode(), this adds isNodeSchedulableWithoutTaints().

Ref: https://github.com/kubernetes/kubernetes/issues/80177

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
