### PR TITLE
fix stack check pkg/volume/gcepd

### DIFF
--- a/hack/.staticcheck_failures
+++ b/hack/.staticcheck_failures
@@ -4,7 +4,6 @@ pkg/controller/podautoscaler
 pkg/controller/replicaset
 pkg/controller/resourcequota
 pkg/volume/azure_dd
-pkg/volume/gcepd
 pkg/volume/testing
 test/e2e/autoscaling
 test/e2e_node

--- a/pkg/volume/gcepd/attacher.go
+++ b/pkg/volume/gcepd/attacher.go
@@ -220,7 +220,7 @@ func getDiskID(pdName string, exec utilexec.Interface) (string, error) {
 		}
 	}
 
-	return "", fmt.Errorf("Could not found disk number for disk %q", pdName)
+	return "", fmt.Errorf("could not found disk number for disk %q", pdName)
 }
 
 func (attacher *gcePersistentDiskAttacher) WaitForAttach(spec *volume.Spec, devicePath string, _ *v1.Pod, timeout time.Duration) (string, error) {

--- a/pkg/volume/gcepd/gce_pd.go
+++ b/pkg/volume/gcepd/gce_pd.go
@@ -128,11 +128,11 @@ func (plugin *gcePersistentDiskPlugin) GetVolumeLimits() (map[string]int64, erro
 	// default values from here will mean, no one can
 	// override them.
 	if cloud == nil {
-		return nil, fmt.Errorf("No cloudprovider present")
+		return nil, fmt.Errorf("no cloudprovider present")
 	}
 
 	if cloud.ProviderName() != gcecloud.ProviderName {
-		return nil, fmt.Errorf("Expected gce cloud got %s", cloud.ProviderName())
+		return nil, fmt.Errorf("expected gce cloud got %s", cloud.ProviderName())
 	}
 
 	instances, ok := cloud.Instances()
@@ -175,7 +175,7 @@ func getVolumeSource(
 		return spec.PersistentVolume.Spec.GCEPersistentDisk, spec.ReadOnly, nil
 	}
 
-	return nil, false, fmt.Errorf("Spec does not reference a GCE volume type")
+	return nil, false, fmt.Errorf("spec does not reference a GCE volume type")
 }
 
 func (plugin *gcePersistentDiskPlugin) newMounterInternal(spec *volume.Spec, podUID types.UID, manager pdManager, mounter mount.Interface) (volume.Mounter, error) {

--- a/pkg/volume/gcepd/gce_pd_test.go
+++ b/pkg/volume/gcepd/gce_pd_test.go
@@ -220,7 +220,7 @@ func TestPlugin(t *testing.T) {
 	}
 	zones, _ := volumehelpers.ZonesToSet("zone1,zone2")
 	r, _ = getNodeSelectorRequirementWithKey(v1.LabelZoneFailureDomain, term)
-	if r == nil {
+	if r == nil || r.Values == nil {
 		t.Errorf("NodeSelectorRequirement %s-in-%v not found in volume NodeAffinity", v1.LabelZoneFailureDomain, zones)
 	}
 	sort.Strings(r.Values)

--- a/pkg/volume/gcepd/gce_util.go
+++ b/pkg/volume/gcepd/gce_util.go
@@ -211,7 +211,7 @@ func verifyDevicePath(devicePaths []string, sdBeforeSet sets.String, diskName st
 
 	for _, path := range devicePaths {
 		if pathExists, err := mount.PathExists(path); err != nil {
-			return "", fmt.Errorf("Error checking if path exists: %v", err)
+			return "", fmt.Errorf("error checking if path exists: %v", err)
 		} else if pathExists {
 			// validate that the path actually resolves to the correct disk
 			serial, err := getScsiSerial(path, diskName)
@@ -301,7 +301,7 @@ func getCloudProvider(cloudProvider cloudprovider.Interface) (*gcecloud.Cloud, e
 		return gceCloudProvider, nil
 	}
 
-	return nil, fmt.Errorf("Failed to get GCE GCECloudProvider with error %v", err)
+	return nil, fmt.Errorf("failed to get GCE GCECloudProvider with error %v", err)
 }
 
 // Triggers the application of udev rules by calling "udevadm trigger


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind api-change
> /kind bug

/kind cleanup

> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:fixes `pkg/volume/gcepd` package  static check errors.

**Which issue(s) this PR fixes**:
Part of https://github.com/kubernetes/kubernetes/issues/92402

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```