### PR TITLE
Backport #82416 to 1.16: Create LoadBalancer in nginx ingress tests

### DIFF
--- a/test/e2e/framework/ingress/ingress_utils.go
+++ b/test/e2e/framework/ingress/ingress_utils.go
@@ -827,15 +827,30 @@ func (j *TestJig) GetDistinctResponseFromIngress() (sets.String, error) {
 
 // NginxIngressController manages implementation details of Ingress on Nginx.
 type NginxIngressController struct {
-	Ns         string
-	rc         *v1.ReplicationController
-	pod        *v1.Pod
-	Client     clientset.Interface
-	externalIP string
+	Ns     string
+	rc     *v1.ReplicationController
+	pod    *v1.Pod
+	Client clientset.Interface
 }
 
 // Init initializes the NginxIngressController
 func (cont *NginxIngressController) Init() {
+	// Set up a LoadBalancer service in front of nginx ingress controller and pass it via
+	// --publish-service flag (see <IngressManifestPath>/nginx/rc.yaml) to make it work in private
+	// clusters, i.e. clusters where nodes don't have public IPs.
+	framework.Logf("Creating load balancer service for nginx ingress controller")
+	serviceJig := e2eservice.NewTestJig(cont.Client, "nginx-ingress-lb")
+	serviceJig.CreateTCPServiceOrFail(cont.Ns, func(svc *v1.Service) {
+		svc.Spec.Type = v1.ServiceTypeLoadBalancer
+		svc.Spec.Selector = map[string]string{"k8s-app": "nginx-ingress-lb"}
+		svc.Spec.Ports = []v1.ServicePort{
+			{Name: "http", Port: 80},
+			{Name: "https", Port: 443},
+			{Name: "stats", Port: 18080}}
+	})
+	svc := serviceJig.WaitForLoadBalancerOrFail(cont.Ns, "nginx-ingress-lb", e2eservice.LoadBalancerCreateTimeoutDefault)
+	serviceJig.SanityCheckService(svc, v1.ServiceTypeLoadBalancer)
+
 	read := func(file string) string {
 		return string(testfiles.ReadOrDie(filepath.Join(IngressManifestPath, "nginx", file)))
 	}
@@ -855,9 +870,7 @@ func (cont *NginxIngressController) Init() {
 		framework.Failf("Failed to find nginx ingress controller pods with selector %v", sel)
 	}
 	cont.pod = &pods.Items[0]
-	cont.externalIP, err = framework.GetHostExternalAddress(cont.Client, cont.pod)
-	framework.ExpectNoError(err)
-	framework.Logf("ingress controller running in pod %v on ip %v", cont.pod.Name, cont.externalIP)
+	framework.Logf("ingress controller running in pod %v", cont.pod.Name)
 }
 
 func generateBacksideHTTPSIngressSpec(ns string) *networkingv1beta1.Ingress {

--- a/test/e2e/network/ingress.go
+++ b/test/e2e/network/ingress.go
@@ -738,6 +738,7 @@ var _ = SIGDescribe("Loadbalancing: L7", func() {
 			if ginkgo.CurrentGinkgoTestDescription().Failed {
 				framework.DescribeIng(ns)
 			}
+			defer nginxController.TearDown()
 			if jig.Ingress == nil {
 				ginkgo.By("No ingress created, no cleanup necessary")
 				return

--- a/test/e2e/testing-manifests/ingress/nginx/rc.yaml
+++ b/test/e2e/testing-manifests/ingress/nginx/rc.yaml
@@ -48,3 +48,4 @@ spec:
         args:
         - /nginx-ingress-controller
         - --default-backend-service=kube-system/default-http-backend
+        - --publish-service=$(POD_NAMESPACE)/nginx-ingress-lb


### PR DESCRIPTION
Backport #82416

**What type of PR is this?**
/kind failing-test

**What this PR does / why we need it**:
It fixes the nginx ingress tests that is currently failing in the private clusters where nodes don't have public ips, see https://k8s-testgrid.appspot.com/sig-scalability-experiments#gce-private-cluster-correctness.
It achieves that by creating a load balancer in front of the nginx controller and using the [`--publish-service` nginx ingress feature](https://github.com/kubernetes/ingress-nginx/tree/master/docs/examples/static-ip)

**Which issue(s) this PR fixes**:
Fixes #77538 for 1.16

**Does this PR introduce a user-facing change?**:
```
NONE
```

/cc mm4tt
/cc wojtek-t
