### PR TITLE
[WIP] Backport #82416 to 1.15: Create LoadBalancer in nginx ingress tests

### DIFF
--- a/test/e2e/framework/ingress/BUILD
+++ b/test/e2e/framework/ingress/BUILD
@@ -21,6 +21,7 @@ go_library(
         "//test/e2e/framework/log:go_default_library",
         "//test/e2e/framework/testfiles:go_default_library",
         "//test/e2e/manifest:go_default_library",
+        "//test/e2e/network:go_default_library",
         "//test/utils:go_default_library",
         "//vendor/github.com/onsi/ginkgo:go_default_library",
         "//vendor/google.golang.org/api/compute/v1:go_default_library",

--- a/test/e2e/framework/ingress/ingress_utils.go
+++ b/test/e2e/framework/ingress/ingress_utils.go
@@ -832,15 +832,30 @@ func (j *TestJig) GetDistinctResponseFromIngress() (sets.String, error) {
 
 // NginxIngressController manages implementation details of Ingress on Nginx.
 type NginxIngressController struct {
-	Ns         string
-	rc         *v1.ReplicationController
-	pod        *v1.Pod
-	Client     clientset.Interface
-	externalIP string
+	Ns     string
+	rc     *v1.ReplicationController
+	pod    *v1.Pod
+	Client clientset.Interface
 }
 
 // Init initializes the NginxIngressController
 func (cont *NginxIngressController) Init() {
+	// Set up a LoadBalancer service in front of nginx ingress controller and pass it via
+	// --publish-service flag (see <IngressManifestPath>/nginx/rc.yaml) to make it work in private
+	// clusters, i.e. clusters where nodes don't have public IPs.
+	e2elog.Logf("Creating load balancer service for nginx ingress controller")
+	serviceJig := framework.NewServiceTestJig(cont.Client, "nginx-ingress-lb")
+	serviceJig.CreateTCPServiceOrFail(cont.Ns, func(svc *v1.Service) {
+		svc.Spec.Type = v1.ServiceTypeLoadBalancer
+		svc.Spec.Selector = map[string]string{"k8s-app": "nginx-ingress-lb"}
+		svc.Spec.Ports = []v1.ServicePort{
+			{Name: "http", Port: 80},
+			{Name: "https", Port: 443},
+			{Name: "stats", Port: 18080}}
+	})
+	svc := serviceJig.WaitForLoadBalancerOrFail(cont.Ns, "nginx-ingress-lb", framework.LoadBalancerCreateTimeoutDefault)
+	serviceJig.SanityCheckService(svc, v1.ServiceTypeLoadBalancer)
+
 	read := func(file string) string {
 		return string(testfiles.ReadOrDie(filepath.Join(IngressManifestPath, "nginx", file), ginkgo.Fail))
 	}
@@ -860,9 +875,7 @@ func (cont *NginxIngressController) Init() {
 		framework.Failf("Failed to find nginx ingress controller pods with selector %v", sel)
 	}
 	cont.pod = &pods.Items[0]
-	cont.externalIP, err = framework.GetHostExternalAddress(cont.Client, cont.pod)
-	framework.ExpectNoError(err)
-	e2elog.Logf("ingress controller running in pod %v on ip %v", cont.pod.Name, cont.externalIP)
+	e2elog.Logf("ingress controller running in pod %v", cont.pod.Name)
 }
 
 func generateBacksideHTTPSIngressSpec(ns string) *networkingv1beta1.Ingress {

--- a/test/e2e/network/ingress.go
+++ b/test/e2e/network/ingress.go
@@ -738,6 +738,7 @@ var _ = SIGDescribe("Loadbalancing: L7", func() {
 			if ginkgo.CurrentGinkgoTestDescription().Failed {
 				framework.DescribeIng(ns)
 			}
+			defer nginxController.TearDown()
 			if jig.Ingress == nil {
 				ginkgo.By("No ingress created, no cleanup necessary")
 				return

--- a/test/e2e/network/service.go
+++ b/test/e2e/network/service.go
@@ -1866,7 +1866,7 @@ var _ = SIGDescribe("Services", func() {
 		})
 
 		defer func() {
-			waitForServiceDeletedWithFinalizer(cs, svc.Namespace, svc.Name)
+			WaitForServiceDeletedWithFinalizer(cs, svc.Namespace, svc.Name)
 		}()
 
 		ginkgo.By("Wait for load balancer to serve traffic")
@@ -1894,7 +1894,7 @@ var _ = SIGDescribe("Services", func() {
 		})
 
 		defer func() {
-			waitForServiceDeletedWithFinalizer(cs, svc.Namespace, svc.Name)
+			WaitForServiceDeletedWithFinalizer(cs, svc.Namespace, svc.Name)
 		}()
 
 		ginkgo.By("Wait for load balancer to serve traffic")
@@ -1913,7 +1913,7 @@ var _ = SIGDescribe("Services", func() {
 	})
 })
 
-func waitForServiceDeletedWithFinalizer(cs clientset.Interface, namespace, name string) {
+func WaitForServiceDeletedWithFinalizer(cs clientset.Interface, namespace, name string) {
 	ginkgo.By("Delete service with finalizer")
 	if err := cs.CoreV1().Services(namespace).Delete(name, nil); err != nil {
 		framework.Failf("Failed to delete service %s/%s", namespace, name)

--- a/test/e2e/testing-manifests/ingress/nginx/rc.yaml
+++ b/test/e2e/testing-manifests/ingress/nginx/rc.yaml
@@ -48,3 +48,4 @@ spec:
         args:
         - /nginx-ingress-controller
         - --default-backend-service=kube-system/default-http-backend
+        - --publish-service=$(POD_NAMESPACE)/nginx-ingress-lb


### PR DESCRIPTION
Backport #82416

**What type of PR is this?**
/kind failing-test

**What this PR does / why we need it**:
It fixes the nginx ingress tests that is currently failing in the private clusters where nodes don't have public ips, see https://k8s-testgrid.appspot.com/sig-scalability-experiments#gce-private-cluster-correctness.
It achieves that by creating a load balancer in front of the nginx controller and using the [`--publish-service` nginx ingress feature](https://github.com/kubernetes/ingress-nginx/tree/master/docs/examples/static-ip)

**Which issue(s) this PR fixes**:
Fixes #77538 for 1.15

**Does this PR introduce a user-facing change?**:
```
NONE
```

/cc mm4tt
/cc wojtek-t
