### PR TITLE
tests: Fixes agnhost-primary renaming issue

### DIFF
--- a/test/e2e/kubectl/kubectl.go
+++ b/test/e2e/kubectl/kubectl.go
@@ -344,10 +344,10 @@ var _ = SIGDescribe("Kubectl client", func() {
 			guestbookRoot := "test/e2e/testing-manifests/guestbook"
 			for _, gbAppFile := range []string{
 				"agnhost-replica-service.yaml",
-				"agnhost-master-service.yaml",
+				"agnhost-primary-service.yaml",
 				"frontend-service.yaml",
 				"frontend-deployment.yaml.in",
-				"agnhost-master-deployment.yaml.in",
+				"agnhost-primary-deployment.yaml.in",
 				"agnhost-replica-deployment.yaml.in",
 			} {
 				contents := commonutils.SubstituteImageName(string(e2etestfiles.ReadOrDie(filepath.Join(guestbookRoot, gbAppFile))))

--- a/test/e2e/testing-manifests/guestbook/agnhost-primary-deployment.yaml.in
+++ b/test/e2e/testing-manifests/guestbook/agnhost-primary-deployment.yaml.in
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: agnhost-master
+  name: agnhost-primary
 spec:
   replicas: 1
   selector:

--- a/test/e2e/testing-manifests/guestbook/agnhost-primary-service.yaml
+++ b/test/e2e/testing-manifests/guestbook/agnhost-primary-service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: agnhost-master
+  name: agnhost-primary
   labels:
     app: agnhost
     role: master

--- a/test/e2e/testing-manifests/guestbook/agnhost-replica-deployment.yaml.in
+++ b/test/e2e/testing-manifests/guestbook/agnhost-replica-deployment.yaml.in
@@ -19,7 +19,7 @@ spec:
       containers:
       - name: replica
         image: {{.AgnhostImage}}
-        args: [ "guestbook", "--replicaof", "agnhost-master", "--http-port", "6379" ]
+        args: [ "guestbook", "--replicaof", "agnhost-primary", "--http-port", "6379" ]
         resources:
           requests:
             cpu: 100m


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind failing-test

/sig testing
/sig windows

/area conformance
/priority important-soon

**What this PR does / why we need it**:

A previous commit updated the agnhost guestbook app to use the ``agnhost-primary``, ``agnhost-replica`` services names, instead of ``agnhost-master``, ``agnhost-slave`` services names, but those changes were not reflected in the test.

Because of this, the guestbook test fails, as it cannot connect to the ``agnhost-primary`` service name, which does not exist.

This updates the test and its files to fully use the ``agnhost-primary`` service name.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

Test run logs with these changes: https://paste.ubuntu.com/p/5hX6BSKrM3/
Cause: https://github.com/kubernetes/kubernetes/pull/92119

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
