### PR TITLE
return nil if empty response get in memcached go-client

### DIFF
--- a/staging/src/k8s.io/client-go/discovery/cached/memory/memcache.go
+++ b/staging/src/k8s.io/client-go/discovery/cached/memory/memcache.go
@@ -225,7 +225,7 @@ func (d *memCacheClient) serverResourcesForGroupVersion(groupVersion string) (*m
 		return r, err
 	}
 	if len(r.APIResources) == 0 {
-		return r, fmt.Errorf("Got empty response for: %v", groupVersion)
+		return r, nil
 	}
 	return r, nil
 }

--- a/staging/src/k8s.io/client-go/discovery/cached/memory/memcache_test.go
+++ b/staging/src/k8s.io/client-go/discovery/cached/memory/memcache_test.go
@@ -46,9 +46,6 @@ func (c *fakeDiscovery) ServerResourcesForGroupVersion(groupVersion string) (*me
 	c.lock.Lock()
 	defer c.lock.Unlock()
 	if rl, ok := c.resourceMap[groupVersion]; ok {
-		if len(rl.list.APIResources) == 0 {
-			return nil,nil
-		}
 		return rl.list, rl.err
 	}
 	return nil, errors.New("doesn't exist")
@@ -276,9 +273,6 @@ func TestPartialPermanentFailure(t *testing.T) {
 	r, err = c.ServerResourcesForGroupVersion("astronomy3/v8beta1")
 	if err == nil {
 		t.Errorf("Expected error, got nil")
-	}
-	if r == nil {
-		t.Errorf("Expected list, got nil")
 	}
 
 	fake.lock.Lock()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
In client-go package [Memcached](https://github.com/kubernetes/kubernetes/blob/dc0122ca6a7503de3923d5026073882822d5008e/staging/src/k8s.io/client-go/discovery/cached/memory/memcache.go#L228) return error if we get zero resources of group version but ideally it should return nil.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #92480


**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NO
```
