### PR TITLE
Don't use rate limiter when listing resources in multiple chunks

### DIFF
--- a/staging/src/k8s.io/cli-runtime/pkg/resource/helper.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/resource/helper.go
@@ -87,6 +87,12 @@ func (m *Helper) List(namespace, apiVersion string, options *metav1.ListOptions)
 		NamespaceIfScoped(namespace, m.NamespaceScoped).
 		Resource(m.Resource).
 		VersionedParams(options, metav1.ParameterCodec)
+
+	if len(options.Continue) > 0 {
+		// If this is a continuation request, don't throttle it, so that performance is not affected while listing a large number of resources
+		req = req.Throttle(nil)
+	}
+
 	return req.Do(context.TODO()).Get()
 }
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
When you are requesting a large list of resources, chunking can cause a large number of "continue" requests in a short period period of time, which get throttled.

Here is the log showing throttling kicking in after about 12 requests:
```
$ kubectl get cm --namespace mucho --chunk-size 100 -v6
I0624 15:43:47.523276  358450 loader.go:375] Config loaded from file:  /home/bpursley/.kube/config
I0624 15:43:47.592781  358450 round_trippers.go:443] GET https://192.168.200.11:6443/api/v1/namespaces/mucho/configmaps?limit=100 200 OK in 56 milliseconds
I0624 15:43:47.621536  358450 round_trippers.go:443] GET https://192.168.200.11:6443/api/v1/namespaces/mucho/configmaps?continue=eyJ2IjoibWV0YS5rOHMuaW8vdjEiLCJydiI6NDI4NzcwNCwic3RhcnQiOiJjbTEwODdcdTAwMDAifQ&limit=100 200 OK in 15 milliseconds
I0624 15:43:47.687207  358450 round_trippers.go:443] GET https://192.168.200.11:6443/api/v1/namespaces/mucho/configmaps?continue=eyJ2IjoibWV0YS5rOHMuaW8vdjEiLCJydiI6NDI4NzcwNCwic3RhcnQiOiJjbTExNzdcdTAwMDAifQ&limit=100 200 OK in 37 milliseconds
I0624 15:43:47.808130  358450 round_trippers.go:443] GET https://192.168.200.11:6443/api/v1/namespaces/mucho/configmaps?continue=eyJ2IjoibWV0YS5rOHMuaW8vdjEiLCJydiI6NDI4NzcwNCwic3RhcnQiOiJjbTEyNjdcdTAwMDAifQ&limit=100 200 OK in 109 milliseconds
I0624 15:43:47.837942  358450 round_trippers.go:443] GET https://192.168.200.11:6443/api/v1/namespaces/mucho/configmaps?continue=eyJ2IjoibWV0YS5rOHMuaW8vdjEiLCJydiI6NDI4NzcwNCwic3RhcnQiOiJjbTEzNTdcdTAwMDAifQ&limit=100 200 OK in 16 milliseconds
I0624 15:43:47.860396  358450 round_trippers.go:443] GET https://192.168.200.11:6443/api/v1/namespaces/mucho/configmaps?continue=eyJ2IjoibWV0YS5rOHMuaW8vdjEiLCJydiI6NDI4NzcwNCwic3RhcnQiOiJjbTE0NDdcdTAwMDAifQ&limit=100 200 OK in 11 milliseconds
I0624 15:43:47.895909  358450 round_trippers.go:443] GET https://192.168.200.11:6443/api/v1/namespaces/mucho/configmaps?continue=eyJ2IjoibWV0YS5rOHMuaW8vdjEiLCJydiI6NDI4NzcwNCwic3RhcnQiOiJjbTE1MzdcdTAwMDAifQ&limit=100 200 OK in 14 milliseconds
I0624 15:43:47.951812  358450 round_trippers.go:443] GET https://192.168.200.11:6443/api/v1/namespaces/mucho/configmaps?continue=eyJ2IjoibWV0YS5rOHMuaW8vdjEiLCJydiI6NDI4NzcwNCwic3RhcnQiOiJjbTE2MjdcdTAwMDAifQ&limit=100 200 OK in 43 milliseconds
I0624 15:43:47.977016  358450 round_trippers.go:443] GET https://192.168.200.11:6443/api/v1/namespaces/mucho/configmaps?continue=eyJ2IjoibWV0YS5rOHMuaW8vdjEiLCJydiI6NDI4NzcwNCwic3RhcnQiOiJjbTE3MTdcdTAwMDAifQ&limit=100 200 OK in 12 milliseconds
I0624 15:43:48.003067  358450 round_trippers.go:443] GET https://192.168.200.11:6443/api/v1/namespaces/mucho/configmaps?continue=eyJ2IjoibWV0YS5rOHMuaW8vdjEiLCJydiI6NDI4NzcwNCwic3RhcnQiOiJjbTE4MDdcdTAwMDAifQ&limit=100 200 OK in 14 milliseconds
I0624 15:43:48.044446  358450 round_trippers.go:443] GET https://192.168.200.11:6443/api/v1/namespaces/mucho/configmaps?continue=eyJ2IjoibWV0YS5rOHMuaW8vdjEiLCJydiI6NDI4NzcwNCwic3RhcnQiOiJjbTE4OThcdTAwMDAifQ&limit=100 200 OK in 13 milliseconds
I0624 15:43:48.067944  358450 round_trippers.go:443] GET https://192.168.200.11:6443/api/v1/namespaces/mucho/configmaps?continue=eyJ2IjoibWV0YS5rOHMuaW8vdjEiLCJydiI6NDI4NzcwNCwic3RhcnQiOiJjbTE5ODhcdTAwMDAifQ&limit=100 200 OK in 16 milliseconds
I0624 15:43:48.136588  358450 request.go:557] Throttling request took 59.423723ms, request: GET:https://192.168.200.11:6443/api/v1/namespaces/mucho/configmaps?continue=eyJ2IjoibWV0YS5rOHMuaW8vdjEiLCJydiI6NDI4NzcwNCwic3RhcnQiOiJjbTIwNzdcdTAwMDAifQ&limit=100
I0624 15:43:48.153908  358450 round_trippers.go:443] GET https://192.168.200.11:6443/api/v1/namespaces/mucho/configmaps?continue=eyJ2IjoibWV0YS5rOHMuaW8vdjEiLCJydiI6NDI4NzcwNCwic3RhcnQiOiJjbTIwNzdcdTAwMDAifQ&limit=100 200 OK in 17 milliseconds
I0624 15:43:48.336722  358450 request.go:557] Throttling request took 171.541349ms, request: GET:https://192.168.200.11:6443/api/v1/namespaces/mucho/configmaps?continue=eyJ2IjoibWV0YS5rOHMuaW8vdjEiLCJydiI6NDI4NzcwNCwic3RhcnQiOiJjbTIxNjdcdTAwMDAifQ&limit=100
I0624 15:43:48.356059  358450 round_trippers.go:443] GET https://192.168.200.11:6443/api/v1/namespaces/mucho/configmaps?continue=eyJ2IjoibWV0YS5rOHMuaW8vdjEiLCJydiI6NDI4NzcwNCwic3RhcnQiOiJjbTIxNjdcdTAwMDAifQ&limit=100 200 OK in 19 milliseconds
I0624 15:43:48.536699  358450 request.go:557] Throttling request took 173.498823ms, request: GET:https://192.168.200.11:6443/api/v1/namespaces/mucho/configmaps?continue=eyJ2IjoibWV0YS5rOHMuaW8vdjEiLCJydiI6NDI4NzcwNCwic3RhcnQiOiJjbTIyNTdcdTAwMDAifQ&limit=100
I0624 15:43:48.554991  358450 round_trippers.go:443] GET https://192.168.200.11:6443/api/v1/namespaces/mucho/configmaps?continue=eyJ2IjoibWV0YS5rOHMuaW8vdjEiLCJydiI6NDI4NzcwNCwic3RhcnQiOiJjbTIyNTdcdTAwMDAifQ&limit=100 200 OK in 17 milliseconds
I0624 15:43:48.736602  358450 request.go:557] Throttling request took 173.447474ms, request: GET:https://192.168.200.11:6443/api/v1/namespaces/mucho/configmaps?continue=eyJ2IjoibWV0YS5rOHMuaW8vdjEiLCJydiI6NDI4NzcwNCwic3RhcnQiOiJjbTIzNDdcdTAwMDAifQ&limit=100
I0624 15:43:48.757955  358450 round_trippers.go:443] GET https://192.168.200.11:6443/api/v1/namespaces/mucho/configmaps?continue=eyJ2IjoibWV0YS5rOHMuaW8vdjEiLCJydiI6NDI4NzcwNCwic3RhcnQiOiJjbTIzNDdcdTAwMDAifQ&limit=100 200 OK in 21 milliseconds
I0624 15:43:48.936543  358450 request.go:557] Throttling request took 170.02399ms, request: GET:https://192.168.200.11:6443/api/v1/namespaces/mucho/configmaps?continue=eyJ2IjoibWV0YS5rOHMuaW8vdjEiLCJydiI6NDI4NzcwNCwic3RhcnQiOiJjbTI0MzdcdTAwMDAifQ&limit=100
I0624 15:43:48.953616  358450 round_trippers.go:443] GET https://192.168.200.11:6443/api/v1/namespaces/mucho/configmaps?continue=eyJ2IjoibWV0YS5rOHMuaW8vdjEiLCJydiI6NDI4NzcwNCwic3RhcnQiOiJjbTI0MzdcdTAwMDAifQ&limit=100 200 OK in 16 milliseconds
```

This PR changes the client so that it does not use rate limiter when retrieving subsequent chunks.

Before Fix (tested on 10,000 config maps):
```
$ time kubectl get cm --namespace mucho --chunk-size 100 > /dev/null

real	0m18.606s
user	0m1.657s
sys	0m0.210s
```

After Fix (same cluster as above):
```
$ time _output/bin/kubectl get cm --namespace mucho --chunk-size 100 > /dev/null

real	0m2.582s
user	0m1.488s
sys	0m0.151s
```

**Which issue(s) this PR fixes**:
Related to https://github.com/kubernetes/kubectl/issues/866

This PR helps the performance problem experienced with large lists of resources, but does not FIX the issue of not being able to see partial results before the entire set is retrieved.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
Improved kubectl performance when listing a large number of resources
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs

```
