### PR TITLE
kubectl: warn when creating roles with custom verbs

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_clusterrole.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_clusterrole.go
@@ -143,7 +143,7 @@ func (c *CreateClusterRoleOptions) Validate() error {
 	if len(c.Resources) > 0 {
 		for _, v := range c.Verbs {
 			if !arrayContains(validResourceVerbs, v) {
-				return fmt.Errorf("invalid verb: '%s'", v)
+				fmt.Fprintf(c.ErrOut, "Warning: '%s' is not a standard resource verb\n", v)
 			}
 		}
 		if err := c.validateResource(); err != nil {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_clusterrole_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_clusterrole_test.go
@@ -243,7 +243,7 @@ func TestClusterRoleValidate(t *testing.T) {
 					},
 				},
 			},
-			expectErr: true,
+			expectErr: false,
 		},
 		"test-nonresource-verb": {
 			clusterRoleOptions: &CreateClusterRoleOptions{
@@ -257,7 +257,7 @@ func TestClusterRoleValidate(t *testing.T) {
 					},
 				},
 			},
-			expectErr: true,
+			expectErr: false,
 		},
 		"test-special-verb": {
 			clusterRoleOptions: &CreateClusterRoleOptions{
@@ -496,6 +496,7 @@ func TestClusterRoleValidate(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
+			test.clusterRoleOptions.IOStreams = genericclioptions.NewTestIOStreamsDiscard()
 			var err error
 			test.clusterRoleOptions.Mapper, err = tf.ToRESTMapper()
 			if err != nil {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_role.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_role.go
@@ -294,7 +294,7 @@ func (o *CreateRoleOptions) Validate() error {
 
 	for _, v := range o.Verbs {
 		if !arrayContains(validResourceVerbs, v) {
-			return fmt.Errorf("invalid verb: '%s'", v)
+			fmt.Fprintf(o.ErrOut, "Warning: '%s' is not a standard resource verb\n", v)
 		}
 	}
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_role_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_role_test.go
@@ -213,7 +213,7 @@ func TestValidate(t *testing.T) {
 					},
 				},
 			},
-			expectErr: true,
+			expectErr: false,
 		},
 		"test-nonresource-verb": {
 			roleOptions: &CreateRoleOptions{
@@ -225,7 +225,7 @@ func TestValidate(t *testing.T) {
 					},
 				},
 			},
-			expectErr: true,
+			expectErr: false,
 		},
 		"test-special-verb": {
 			roleOptions: &CreateRoleOptions{
@@ -340,6 +340,8 @@ func TestValidate(t *testing.T) {
 	}
 
 	for name, test := range tests {
+		test.roleOptions.IOStreams = genericclioptions.NewTestIOStreamsDiscard()
+
 		var err error
 		test.roleOptions.Mapper, err = tf.ToRESTMapper()
 		if err != nil {


### PR DESCRIPTION

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

This PR replaces errors with warnings when creating Roles and ClusterRoles with custom verbs via `kubectl create`.

**Which issue(s) this PR fixes**:

Fixes https://github.com/kubernetes/kubectl/issues/876

**Special notes for your reviewer**:

This fix came from a [discussion on Slack](https://kubernetes.slack.com/archives/C0EN96KUY/p1593022547361100).

**Does this PR introduce a user-facing change?**:

```release-note
Warn instead of fail when creating Roles and ClusterRoles with custom verbs via kubectl
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
