### PR TITLE
[1.18] hyperkube: Use debian-hyperkube-base@v1.1.0 image

### DIFF
--- a/build/dependencies.yaml
+++ b/build/dependencies.yaml
@@ -106,7 +106,7 @@ dependencies:
       match: TAG\?=
 
   - name: "k8s.gcr.io/debian-hyperkube-base: dependents"
-    version: 1.0.0
+    version: 1.1.0
     refPaths:
     - path: build/workspace.bzl
       match: tag =

--- a/build/workspace.bzl
+++ b/build/workspace.bzl
@@ -102,15 +102,15 @@ _DEBIAN_IPTABLES_DIGEST = {
 # Use skopeo to find these values: https://github.com/containers/skopeo
 #
 # Example
-# Manifest: skopeo inspect docker://gcr.io/k8s-staging-build-image/debian-hyperkube-base:v1.0.0
-# Arches: skopeo inspect --raw docker://gcr.io/k8s-staging-build-image/debian-hyperkube-base:v1.0.0
+# Manifest: skopeo inspect docker://gcr.io/k8s-staging-build-image/debian-hyperkube-base:v1.1.0
+# Arches: skopeo inspect --raw docker://gcr.io/k8s-staging-build-image/debian-hyperkube-base:v1.1.0
 _DEBIAN_HYPERKUBE_BASE_DIGEST = {
-    "manifest": "sha256:8c8d854d868fb08352f73dda94f9e0b998c7318b48ddc587a355d0cbaf687f14",
-    "amd64": "sha256:73a8cb2bfd6707c8ed70c252e97bdccad8bc265a9a585db12b8e3dac50d6cd2a",
-    "arm": "sha256:aee7c2958c6e0de896995e8b04c8173fd0a7bbb16cddb1f4668e3ae010b8c786",
-    "arm64": "sha256:a74fc6d690e5c5e393fd509f50d7203fa5cd19bfbb127d4a3a996fd1ebcf35c4",
-    "ppc64le": "sha256:54afd9a85d6ecbe0792496f36012e7902601fb8084347cdc195c8b0561da39a3",
-    "s390x": "sha256:405a94e6b82f2eb89c773e0e9f6105eb73cde5605d4508ae36a150d922fe1c66",
+    "manifest": "sha256:ce7a6205a175f8eca8edc1bbff4c06516da523db6751085b6c7929d111fecb7f",
+    "amd64": "sha256:5cab0f210e47d4e04fe06fa0a20d8c7fde3bcfe14fe73b3eab3c7070790c4927",
+    "arm": "sha256:7321a64a58e942f0ba0fe5e2979b4ac22df2dcecedf7d118c4e643f5018b305a",
+    "arm64": "sha256:06d0797613073328d86e1721d931b1e0b8026c8e70aeb753eadf5b0856d0aadb",
+    "ppc64le": "sha256:d51068e84f5113af53ca5a1f917f7705b15dd968a42a0dda049c2c7b3ba9ff0e",
+    "s390x": "sha256:9251a1524956d960243ba42ee16274baa93942ee7514b1ef7a1c26f84e959dd8",
 }
 
 def _digest(d, arch):
@@ -148,7 +148,7 @@ def debian_image_dependencies():
             registry = "us.gcr.io/k8s-artifacts-prod/build-image",
             repository = "debian-hyperkube-base",
             # Ensure the digests above are updated to match a new tag
-            tag = "v1.0.0",  # ignored, but kept here for documentation
+            tag = "v1.1.0",  # ignored, but kept here for documentation
         )
 
 def etcd_tarballs():

--- a/cluster/images/hyperkube/Makefile
+++ b/cluster/images/hyperkube/Makefile
@@ -21,7 +21,7 @@ REGISTRY?=staging-k8s.gcr.io
 ARCH?=amd64
 OUT_DIR?=_output
 
-BASEIMAGE?=us.gcr.io/k8s-artifacts-prod/build-image/debian-hyperkube-base-$(ARCH):v1.0.0
+BASEIMAGE?=us.gcr.io/k8s-artifacts-prod/build-image/debian-hyperkube-base-$(ARCH):v1.1.0
 
 LOCAL_OUTPUT_PATH=$(shell pwd)/../../../$(OUT_DIR)/local/bin/linux/$(ARCH)
 DOCKERIZED_OUTPUT_PATH=$(shell pwd)/../../../$(OUT_DIR)/dockerized/bin/linux/$(ARCH)


### PR DESCRIPTION
**What type of PR is this?**

/kind regression
/priority critical-urgent

**What this PR does / why we need it**:

Use debian-hyperkube-base@v1.1.0 image built in https://github.com/kubernetes/kubernetes/pull/92354.

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

cc: @kubernetes/release-engineering

**Which issue(s) this PR fixes**:

Attempt to fix the following issues: https://github.com/kubernetes/kubernetes/issues/92275, https://github.com/kubernetes/kubernetes/issues/92272, https://github.com/kubernetes/kubernetes/issues/92250.

**Special notes for your reviewer**:


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
- hyperkube: Use debian-hyperkube-base@v1.1.0 image

  A previous release built hyperkube using the debian-hyperkube-base@v1.0.0,
  which was updated to address a CVE in the CNI plugins.
  
  A side-effect of using this new image was that the networking packages
  (namely `iptables`) drifted from the versions used in the kube-proxy images.

  The following issues were filed on kube-proxy failures when using hyperkube:
  - https://github.com/kubernetes/kubernetes/issues/92275
  - https://github.com/kubernetes/kubernetes/issues/92272
  - https://github.com/kubernetes/kubernetes/issues/92250

  To address this, the new debian-hyperkube-base image (v1.1.0) uses the
  debian-iptables base image (v12.1.0), which includes iptables-wrapper, a
  script used to determine the correct iptables mode to run in.
```
