### PR TITLE
nit: Fix invokeStaleDummyVMTestWithStoragePolicy()

### DIFF
--- a/test/e2e/storage/vsphere/vsphere_volume_vsan_policy.go
+++ b/test/e2e/storage/vsphere/vsphere_volume_vsan_policy.go
@@ -335,8 +335,9 @@ func invokeStaleDummyVMTestWithStoragePolicy(client clientset.Interface, masterN
 	fnvHash := fnv.New32a()
 	fnvHash.Write([]byte(vmName))
 	dummyVMFullName := dummyVMPrefixName + "-" + fmt.Sprint(fnvHash.Sum32())
-	errorMsg := "Dummy VM - " + vmName + "is still present. Failing the test.."
+	errorMsg := "Dummy VM - " + vmName + " is still present. Failing the test.."
 	nodeInfo := TestContext.NodeMapper.GetNodeInfo(masterNode)
-	isVMPresentFlag, _ := nodeInfo.VSphere.IsVMPresent(dummyVMFullName, nodeInfo.DataCenterRef)
-	framework.ExpectNotEqual(isVMPresentFlag, true, errorMsg)
+	isVMPresentFlag, err := nodeInfo.VSphere.IsVMPresent(dummyVMFullName, nodeInfo.DataCenterRef)
+	framework.ExpectNoError(err)
+	framework.ExpectEqual(isVMPresentFlag, false, errorMsg)
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

There were nits in invokeStaleDummyVMTestWithStoragePolicy() like
- The error message didn't contain necessary space
- IsVMPresent() can return an error, but lack of the error handling
- IsVMPresent() returns true/false, but didn't use ExpectEqual() and
  less code readability

This fixes those things.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
