### PR TITLE
azure: use the parsed value from the configuration

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure.go
@@ -391,7 +391,7 @@ func (az *Cloud) InitializeCloudFromConfig(config *Config, fromSecret bool) erro
 		// No credentials provided, useInstanceMetadata should be enabled for Kubelet.
 		// TODO(feiskyer): print different error message for Kubelet and controller-manager, as they're
 		// requiring different credential settings.
-		if !config.UseInstanceMetadata && az.Config.CloudConfigType == cloudConfigTypeFile {
+		if !config.UseInstanceMetadata && config.CloudConfigType == cloudConfigTypeFile {
 			return fmt.Errorf("useInstanceMetadata must be enabled without Azure credentials")
 		}
 

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_test.go
@@ -3324,8 +3324,8 @@ func TestInitializeCloudFromConfig(t *testing.T) {
 		AzureAuthConfig: auth.AzureAuthConfig{
 			Cloud: "AZUREPUBLICCLOUD",
 		},
+		CloudConfigType: cloudConfigTypeFile,
 	}
-	az.Config.CloudConfigType = cloudConfigTypeFile
 	err = az.InitializeCloudFromConfig(&config, false)
 	expectedErr = fmt.Errorf("useInstanceMetadata must be enabled without Azure credentials")
 	assert.Equal(t, expectedErr, err)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

This PR helps any administrator to configure a `kube-controller-manager` in Azure as it raises the expected error intead of a panic:

```text
F0625 12:07:55.399082   20282 controllermanager.go:244] error building controller context: cloud provider could not be initialized: could not init cloud provider "azure": useInstanceMetadata must be enabled without Azure credentials
```

**Which issue(s) this PR fixes**:

Fixes #92504

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```


