### PR TITLE
Wait for all informers to sync in /readyz

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/config_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/config_test.go
@@ -167,6 +167,7 @@ func TestNewWithDelegate(t *testing.T) {
 		"/metrics",
 		"/readyz",
 		"/readyz/delegate-health",
+		"/readyz/informer-sync",
 		"/readyz/log",
 		"/readyz/ping",
 		"/readyz/poststarthook/delegate-post-start-hook",
@@ -242,10 +243,10 @@ func checkExpectedPathsAtRoot(url string, expectedPaths []string, t *testing.T) 
 			pathset.Insert(p.(string))
 		}
 		expectedset := sets.NewString(expectedPaths...)
-		for _, p := range pathset.Difference(expectedset) {
+		for p := range pathset.Difference(expectedset) {
 			t.Errorf("Got %v path, which we did not expect", p)
 		}
-		for _, p := range expectedset.Difference(pathset) {
+		for p := range expectedset.Difference(pathset) {
 			t.Errorf(" Expected %v path which we did not get", p)
 		}
 	})

--- a/staging/src/k8s.io/apiserver/pkg/server/healthz/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/server/healthz/BUILD
@@ -31,6 +31,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/endpoints/metrics:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/server/httplog:go_default_library",
+        "//staging/src/k8s.io/client-go/informers:go_default_library",
         "//vendor/k8s.io/klog/v2:go_default_library",
     ],
 )

--- a/test/integration/master/kube_apiserver_test.go
+++ b/test/integration/master/kube_apiserver_test.go
@@ -98,10 +98,15 @@ func TestRun(t *testing.T) {
 	}
 }
 
-func endpointReturnsStatusOK(client *kubernetes.Clientset, path string) bool {
-	res := client.CoreV1().RESTClient().Get().AbsPath(path).Do(context.TODO())
+func endpointReturnsStatusOK(t *testing.T, client *kubernetes.Clientset, path string) bool {
+	res := client.CoreV1().RESTClient().Get().RequestURI(path).Do(context.TODO())
 	var status int
 	res.StatusCode(&status)
+	raw, err := res.Raw()
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	t.Logf("Got raw response to %v path: %v", path, string(raw))
 	return status == http.StatusOK
 }
 
@@ -113,10 +118,10 @@ func TestLivezAndReadyz(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if !endpointReturnsStatusOK(client, "/livez") {
+	if !endpointReturnsStatusOK(t, client, "/livez") {
 		t.Fatalf("livez should be healthy")
 	}
-	if !endpointReturnsStatusOK(client, "/readyz") {
+	if !endpointReturnsStatusOK(t, client, "/readyz?verbose=true") {
 		t.Fatalf("readyz should be healthy")
 	}
 }


### PR DESCRIPTION

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Context: https://github.com/kubernetes/kubernetes/issues/92506

In large clusters, informers in kube-apiserver may require significant time (30-50s) to initialize. Before this happens, kube-apiserver is not able to answer some requests (e.g. node authorizer is not able to accept any request).

This PR adds a way to determine if informers in kube-apiserver are already synced. This can be used via /healthz or /readyz to determine if traffic can be sent to that master replica

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
PostStartHook "generic-apiserver-start-informers" waits for all informers to sync
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/assign @lavalamp 