### PR TITLE
Add the ability to opt-out from config lock file

### DIFF
--- a/staging/src/k8s.io/client-go/tools/clientcmd/config.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/config.go
@@ -58,6 +58,15 @@ type PathOptions struct {
 	LoadingRules *ClientConfigLoadingRules
 }
 
+var (
+	// UseModifyConfigLock ensures that access to kubeconfig file using ModifyConfig method
+	// is being guarded by a lock file.
+	// This variable is intentionaly made public so other consumers of this library
+	// can modify its default behavior, but be caution when disabling it since
+	// this will make your code not threadsafe.
+	UseModifyConfigLock = true
+)
+
 func (o *PathOptions) GetEnvVarFiles() []string {
 	if len(o.EnvVar) == 0 {
 		return []string{}
@@ -156,15 +165,17 @@ func NewDefaultPathOptions() *PathOptions {
 // that means that this code will only write into a single file.  If you want to relativizePaths, you must provide a fully qualified path in any
 // modified element.
 func ModifyConfig(configAccess ConfigAccess, newConfig clientcmdapi.Config, relativizePaths bool) error {
-	possibleSources := configAccess.GetLoadingPrecedence()
-	// sort the possible kubeconfig files so we always "lock" in the same order
-	// to avoid deadlock (note: this can fail w/ symlinks, but... come on).
-	sort.Strings(possibleSources)
-	for _, filename := range possibleSources {
-		if err := lockFile(filename); err != nil {
-			return err
+	if UseModifyConfigLock {
+		possibleSources := configAccess.GetLoadingPrecedence()
+		// sort the possible kubeconfig files so we always "lock" in the same order
+		// to avoid deadlock (note: this can fail w/ symlinks, but... come on).
+		sort.Strings(possibleSources)
+		for _, filename := range possibleSources {
+			if err := lockFile(filename); err != nil {
+				return err
+			}
+			defer unlockFile(filename)
 		}
-		defer unlockFile(filename)
 	}
 
 	startingConfig, err := configAccess.GetStartingConfig()


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Back in the early days we thought it was smart to have the lock mechanism to prevent concurrent 
modification of the kubeconfig file (see https://github.com/kubernetes/kubernetes/issues/28260 https://github.com/kubernetes/kubernetes/pull/28232) but currently we are advising users to use multiple files when there's a risk of concurrent access from different clusters. I'm pinging the original commenters of the issue back from then.

This PR adds the ability for a user to decide if he cares about locking through `DISABLE_KUBECONFIG_LOCK`.
It's on by default to maintain backwards compatibility but I'm open to making the locking optional
or even remove it, if majority agrees.

/assign @deads2k @smarterclayton @liggitt 


**Does this PR introduce a user-facing change?**:
```release-note
Add the ability to disable kubeconfig file lock through DISABLE_KUBECONFIG_LOCK env var
```
