### PR TITLE
Apiservier staticchecks tests

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/generic/conversion_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/generic/conversion_test.go
@@ -104,7 +104,7 @@ func TestConvertToGVK(t *testing.T) {
 					},
 				},
 				Spec: example2v1.ReplicaSetSpec{
-					Replicas: func() *int32 { var i int32; i = 1; return &i }(),
+					Replicas: func() *int32 { var i int32 = 1; return &i }(),
 				},
 			},
 		},

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/fieldmanager_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/fieldmanager_test.go
@@ -63,7 +63,6 @@ func (c *fakeObjectConvertor) Convert(in, out, context interface{}) error {
 		out, err = c.converter.Convert(typedValue, c.apiVersion)
 		return err
 	}
-	out = in
 	return nil
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/structuredmerge.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/structuredmerge.go
@@ -129,7 +129,7 @@ func (f *structuredMergeManager) Apply(liveObj, patchObj runtime.Object, managed
 		return nil, nil, fmt.Errorf("couldn't get accessor: %v", err)
 	}
 	if patchObjMeta.GetManagedFields() != nil {
-		return nil, nil, errors.NewBadRequest(fmt.Sprintf("metadata.managedFields must be nil"))
+		return nil, nil, errors.NewBadRequest("metadata.managedFields must be nil")
 	}
 
 	liveObjVersioned, err := f.toVersioned(liveObj)

--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/dryrun_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/dryrun_test.go
@@ -186,6 +186,9 @@ func TestDryRunUpdateDoesntUpdate(t *testing.T) {
 	}
 	out := UnstructuredOrDie(`{}`)
 	err = s.Get(context.Background(), "key", storage.GetOptions{}, out)
+	if err != nil {
+		t.Fatalf("Failed to get storage: %v", err)
+	}
 	if !reflect.DeepEqual(created, out) {
 		t.Fatalf("Returned object %q different from expected %q", created, out)
 	}

--- a/staging/src/k8s.io/apiserver/pkg/registry/rest/resttest/resttest.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/rest/resttest/resttest.go
@@ -886,7 +886,7 @@ func (t *Tester) testDeleteWithUID(obj runtime.Object, createFn CreateFunc, getF
 		t.Errorf("unexpected error: %v", err)
 	}
 	opts.Preconditions = metav1.NewPreconditionDeleteOptions("UID1111").Preconditions
-	obj, _, err := t.storage.(rest.GracefulDeleter).Delete(ctx, objectMeta.GetName(), rest.ValidateAllObjectFunc, &opts)
+	_, _, err := t.storage.(rest.GracefulDeleter).Delete(ctx, objectMeta.GetName(), rest.ValidateAllObjectFunc, &opts)
 	if err == nil || !errors.IsConflict(err) {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -923,7 +923,7 @@ func (t *Tester) testDeleteWithResourceVersion(obj runtime.Object, createFn Crea
 		t.Errorf("unexpected error: %v", err)
 	}
 	opts.Preconditions = metav1.NewRVDeletionPrecondition("RV1111").Preconditions
-	obj, wasDeleted, err := t.storage.(rest.GracefulDeleter).Delete(ctx, objectMeta.GetName(), rest.ValidateAllObjectFunc, &opts)
+	_, wasDeleted, err := t.storage.(rest.GracefulDeleter).Delete(ctx, objectMeta.GetName(), rest.ValidateAllObjectFunc, &opts)
 	if err == nil || !errors.IsConflict(err) {
 		t.Errorf("unexpected error: %v", err)
 	}

--- a/staging/src/k8s.io/apiserver/pkg/server/filters/goaway_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/filters/goaway_test.go
@@ -132,13 +132,11 @@ func TestClientReceivedGOAWAY(t *testing.T) {
 	mux.Handle(urlNormal, WithProbabilisticGoaway(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte("hello"))
-		return
 	}), 0))
 	mux.Handle(urlWatch, WithProbabilisticGoaway(watchHandler, 0))
 	mux.Handle(urlGoaway, WithProbabilisticGoaway(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte("hello"))
-		return
 	}), 1))
 	mux.Handle(urlWatchWithGoaway, WithProbabilisticGoaway(watchHandler, 1))
 
@@ -274,7 +272,6 @@ func TestHTTP1Requests(t *testing.T) {
 	s := httptest.NewUnstartedServer(WithProbabilisticGoaway(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte("hello"))
-		return
 	}), 1))
 
 	http2Options := &http2.Server{}

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_whitebox_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_whitebox_test.go
@@ -882,7 +882,7 @@ func TestDispatchingBookmarkEventsWithConcurrentStop(t *testing.T) {
 	resourceVersion := uint64(1000)
 	err = cacher.watchCache.Add(&examplev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:            fmt.Sprintf("pod-0"),
+			Name:            "pod-0",
 			Namespace:       "ns",
 			ResourceVersion: fmt.Sprintf("%v", resourceVersion),
 		}})

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache_test.go
@@ -34,10 +34,11 @@ import (
 	"k8s.io/apimachinery/pkg/util/clock"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/tools/cache"
+
 	"k8s.io/apiserver/pkg/apis/example"
 	"k8s.io/apiserver/pkg/storage"
 	"k8s.io/apiserver/pkg/storage/etcd3"
-	"k8s.io/client-go/tools/cache"
 )
 
 func makeTestPod(name string, resourceVersion uint64) *v1.Pod {
@@ -405,6 +406,9 @@ func TestWaitUntilFreshAndList(t *testing.T) {
 		{IndexName: "l:not-exist-label", Value: "whatever"},
 	}
 	list, resourceVersion, err = store.WaitUntilFreshAndList(5, matchValues, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	if resourceVersion != 5 {
 		t.Errorf("unexpected resourceVersion: %v, expected: 5", resourceVersion)
 	}

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache_test.go
@@ -34,11 +34,10 @@ import (
 	"k8s.io/apimachinery/pkg/util/clock"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
-	"k8s.io/client-go/tools/cache"
-
 	"k8s.io/apiserver/pkg/apis/example"
 	"k8s.io/apiserver/pkg/storage"
 	"k8s.io/apiserver/pkg/storage/etcd3"
+	"k8s.io/client-go/tools/cache"
 )
 
 func makeTestPod(name string, resourceVersion uint64) *v1.Pod {

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache_test.go
@@ -139,7 +139,7 @@ func TestWatchCacheBasic(t *testing.T) {
 			"prefix/ns/pod2": *makeTestStoreElement(makeTestPod("pod2", 5)),
 			"prefix/ns/pod3": *makeTestStoreElement(makeTestPod("pod3", 6)),
 		}
-		items := make(map[string]storeElement, 0)
+		items := make(map[string]storeElement)
 		for _, item := range store.List() {
 			elem := item.(*storeElement)
 			items[elem.Key] = *elem

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/watcher_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/watcher_test.go
@@ -301,8 +301,7 @@ func TestWatchDeleteEventObjectHaveLatestRV(t *testing.T) {
 
 	e := <-w.ResultChan()
 	watchedDeleteObj := e.Object.(*example.Pod)
-	var wres clientv3.WatchResponse
-	wres = <-etcdW
+	wres := <-etcdW
 
 	watchedDeleteRev, err := store.versioner.ParseResourceVersion(watchedDeleteObj.ResourceVersion)
 	if err != nil {

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/apf_controller.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/apf_controller.go
@@ -609,7 +609,6 @@ func (meal *cfgMeal) imaginePL(proto *fctypesv1a1.PriorityLevelConfiguration, re
 	if proto.Spec.Limited != nil {
 		meal.shareSum += float64(proto.Spec.Limited.AssuredConcurrencyShares)
 	}
-	return
 }
 
 type immediateRequest struct{}

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/queueset/queueset.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/queueset/queueset.go
@@ -602,7 +602,6 @@ func (qs *queueSet) cancelWait(req *request) {
 			break
 		}
 	}
-	return
 }
 
 // selectQueueLocked examines the queues in round robin order and

--- a/staging/src/k8s.io/apiserver/pkg/util/shufflesharding/shufflesharding_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/shufflesharding/shufflesharding_test.go
@@ -277,7 +277,7 @@ func TestDealer_DealIntoHand(t *testing.T) {
 		},
 		{
 			"size: 6 cap: 6 slice",
-			make([]int, 6, 6),
+			make([]int, 6),
 			6,
 		},
 		{
@@ -287,7 +287,7 @@ func TestDealer_DealIntoHand(t *testing.T) {
 		},
 		{
 			"size: 4 cap: 4 slice",
-			make([]int, 4, 4),
+			make([]int, 4),
 			6,
 		},
 		{
@@ -297,7 +297,7 @@ func TestDealer_DealIntoHand(t *testing.T) {
 		},
 		{
 			"size: 10 cap: 10 slice",
-			make([]int, 10, 10),
+			make([]int, 10),
 			6,
 		},
 		{

--- a/staging/src/k8s.io/apiserver/pkg/util/shufflesharding/shufflesharding_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/shufflesharding/shufflesharding_test.go
@@ -254,7 +254,6 @@ func TestUniformDistribution(t *testing.T) {
 			t.Errorf("Only %v percent of the hands got a central count", goodPct)
 		}
 	}
-	return
 }
 
 func TestDealer_DealIntoHand(t *testing.T) {

--- a/staging/src/k8s.io/apiserver/pkg/util/webhook/webhook_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/webhook/webhook_test.go
@@ -420,7 +420,6 @@ func TestRequestTimeout(t *testing.T) {
 
 	handler := func(w http.ResponseWriter, r *http.Request) {
 		<-done
-		return
 	}
 
 	// Create and start a simple HTTPS server

--- a/staging/src/k8s.io/apiserver/pkg/util/wsstream/conn_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/wsstream/conn_test.go
@@ -238,7 +238,7 @@ func TestVersionedConn(t *testing.T) {
 			conn := NewConn(supportedProtocols)
 			// note that it's not enough to wait for conn.ready to avoid a race here. Hence,
 			// we use a channel.
-			selectedProtocol := make(chan string, 0)
+			selectedProtocol := make(chan string)
 			s, addr := newServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 				p, _, _ := conn.Open(w, req)
 				selectedProtocol <- p


### PR DESCRIPTION
Signed-off-by: Ken Sipe <kensipe@gmail.com>


**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
fixes `apiserver` static checks for 
* S1039 unnecessary use of fmt.Sprintf
* S1021 var declaration
* SA2006 value of error not used
* S1019 use of make
* S1023 redundant returns


**Which issue(s) this PR fixes**:
Part of #92402

**Special notes for your reviewer**:
the PR would be too large to cover all issues found by static check

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
