### PR TITLE
Suppress expected error messages in verify-generated-files-remake.sh which cause confusion 

### DIFF
--- a/hack/verify-generated-files-remake.sh
+++ b/hack/verify-generated-files-remake.sh
@@ -338,7 +338,7 @@ assert_clean
 touch "staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/types.go"
 echo > api/api-rules/violation_exceptions.list
 echo > api/api-rules/codegen_violation_exceptions.list
-if make generated_files >/dev/null; then
+if make generated_files >/dev/null 2>&1; then
     echo "Expected make generated_files to fail with API violations."
     echo ""
     exit 1


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
In verify-generated-files-remake.sh, when testing a make command that expects errors, suppress error messages which cause confusion.

**Which issue(s) this PR fixes**:
Fixes #92488

**Special notes for your reviewer**:
verify-generated-files-remake.sh script tests a make failure, so an error in make is expected.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
