### PR TITLE
Fix v1beta1.Event printing in kubectl

### DIFF
--- a/pkg/printers/internalversion/printers.go
+++ b/pkg/printers/internalversion/printers.go
@@ -1673,9 +1673,23 @@ func printEvent(obj *api.Event, options printers.GenerateOptions) ([]metav1.Tabl
 	if obj.FirstTimestamp.IsZero() {
 		firstTimestamp = translateMicroTimestampSince(obj.EventTime)
 	}
+
 	lastTimestamp := translateTimestampSince(obj.LastTimestamp)
 	if obj.LastTimestamp.IsZero() {
 		lastTimestamp = firstTimestamp
+	}
+
+	count := obj.Count
+	if obj.Series != nil {
+		lastTimestamp = translateMicroTimestampSince(obj.Series.LastObservedTime)
+		// When a series is created for the first time, its count is set to 1.
+		// However, for a series to be created, there needs to be an isomorphic
+		// singleton event created beforehand. This singleton event is not
+		// counted in the series count which is why one is added here.
+		count = obj.Series.Count + 1
+	} else if count == 0 {
+		// Singleton events don't have a count set in the new API.
+		count = 1
 	}
 
 	var target string
@@ -1694,7 +1708,7 @@ func printEvent(obj *api.Event, options printers.GenerateOptions) ([]metav1.Tabl
 			formatEventSource(obj.Source),
 			strings.TrimSpace(obj.Message),
 			firstTimestamp,
-			int64(obj.Count),
+			int64(count),
 			obj.Name,
 		)
 	} else {

--- a/pkg/printers/internalversion/printers_test.go
+++ b/pkg/printers/internalversion/printers_test.go
@@ -178,11 +178,11 @@ func TestPrintEvent(t *testing.T) {
 				FirstTimestamp: metav1.Time{Time: time.Now().UTC().AddDate(0, 0, -3)},
 				Count:          1,
 				Type:           api.EventTypeWarning,
-				ObjectMeta:     metav1.ObjectMeta{Name: "event3"},
+				ObjectMeta:     metav1.ObjectMeta{Name: "event4"},
 			},
 			options: printers.GenerateOptions{Wide: true},
 			// Columns: Last Seen, Type, Reason, Object, Subobject, Message, First Seen, Count, Name
-			expected: []metav1.TableRow{{Cells: []interface{}{"3d", "Warning", "Event Reason", "deployment/Deployment Name", "spec.containers{foo}", "kubelet, Node1", "Message Data", "3d", int64(1), "event3"}}},
+			expected: []metav1.TableRow{{Cells: []interface{}{"3d", "Warning", "Event Reason", "deployment/Deployment Name", "spec.containers{foo}", "kubelet, Node1", "Message Data", "3d", int64(1), "event4"}}},
 		},
 		// Basic event, w/o FirstTimestamp and LastTimestamp set
 		{
@@ -201,11 +201,59 @@ func TestPrintEvent(t *testing.T) {
 				EventTime:  metav1.MicroTime{Time: time.Now().UTC().AddDate(0, 0, -3)},
 				Count:      1,
 				Type:       api.EventTypeWarning,
-				ObjectMeta: metav1.ObjectMeta{Name: "event3"},
+				ObjectMeta: metav1.ObjectMeta{Name: "event5"},
 			},
 			options: printers.GenerateOptions{Wide: true},
 			// Columns: Last Seen, Type, Reason, Object, Subobject, Message, First Seen, Count, Name
-			expected: []metav1.TableRow{{Cells: []interface{}{"3d", "Warning", "Event Reason", "deployment/Deployment Name", "spec.containers{foo}", "kubelet, Node1", "Message Data", "3d", int64(1), "event3"}}},
+			expected: []metav1.TableRow{{Cells: []interface{}{"3d", "Warning", "Event Reason", "deployment/Deployment Name", "spec.containers{foo}", "kubelet, Node1", "Message Data", "3d", int64(1), "event5"}}},
+		},
+		// Basic event serie, w/o FirstTimestamp, LastTimestamp and Count set
+		{
+			event: api.Event{
+				Source: api.EventSource{
+					Component: "kubelet",
+					Host:      "Node1",
+				},
+				InvolvedObject: api.ObjectReference{
+					Kind:      "Deployment",
+					Name:      "Deployment Name",
+					FieldPath: "spec.containers{foo}",
+				},
+				Series: &api.EventSeries{
+					Count:            1,
+					LastObservedTime: metav1.MicroTime{Time: time.Now().UTC().AddDate(0, 0, -2)},
+				},
+				Reason:     "Event Reason",
+				Message:    "Message Data",
+				EventTime:  metav1.MicroTime{Time: time.Now().UTC().AddDate(0, 0, -3)},
+				Type:       api.EventTypeWarning,
+				ObjectMeta: metav1.ObjectMeta{Name: "event6"},
+			},
+			options: printers.GenerateOptions{Wide: true},
+			// Columns: Last Seen, Type, Reason, Object, Subobject, Message, First Seen, Count, Name
+			expected: []metav1.TableRow{{Cells: []interface{}{"2d", "Warning", "Event Reason", "deployment/Deployment Name", "spec.containers{foo}", "kubelet, Node1", "Message Data", "3d", int64(2), "event6"}}},
+		},
+		// Singleton event, w/o FirstTimestamp, LastTimestamp and Count set
+		{
+			event: api.Event{
+				Source: api.EventSource{
+					Component: "kubelet",
+					Host:      "Node1",
+				},
+				InvolvedObject: api.ObjectReference{
+					Kind:      "Deployment",
+					Name:      "Deployment Name",
+					FieldPath: "spec.containers{foo}",
+				},
+				Reason:     "Event Reason",
+				Message:    "Message Data",
+				EventTime:  metav1.MicroTime{Time: time.Now().UTC().AddDate(0, 0, -3)},
+				Type:       api.EventTypeWarning,
+				ObjectMeta: metav1.ObjectMeta{Name: "event7"},
+			},
+			options: printers.GenerateOptions{Wide: true},
+			// Columns: Last Seen, Type, Reason, Object, Subobject, Message, First Seen, Count, Name
+			expected: []metav1.TableRow{{Cells: []interface{}{"3d", "Warning", "Event Reason", "deployment/Deployment Name", "spec.containers{foo}", "kubelet, Node1", "Message Data", "3d", int64(1), "event7"}}},
 		},
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

This PR intends to fix incorrect data displayed by kubectl v1beta1.Event printing.
The new Events API [deprecates](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/instrumentation/events-redesign.md#backward-compatibility) a few fields that are used by kubectl to print Events:
- FirstTimestamp => DeprecatedFirstTimestamp
- LastTimestamp => DeprecatedLastTimestamp
- Count => DeprecatedCount

For the timestamps, the new API is replacing them with already existing more precise timestamps ([details](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/instrumentation/events-redesign.md#api-changes-goals)):
- FirstTimestamp => EventTime
- LastTimestamp => Series.LastObservedTime

As for the count, it is replaced by the already existing Series.Count.

That being said, there was already an effort to support the new FirstTimestamp alternative in #89999.
However, the LastTimestamp and Count deprecations have not been handled yet. This PR is an attempt to handle these cases.

The first condition added in this PR is handling the new notion of Series brought by the new Event API. Thus, it is making use of the Series.LastObservedTime and Series.Count.

To quote the new [Event API KEP](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/instrumentation/events-redesign.md#changes-in-eventrecorder) on the notion of series:
> - When event is emitted for the first time it's written to the API server without series field set.
> - When isomorphic event is emitted within the threshold from the original one EventRecorder detects the start of the series, updates the Event object, with the Series field set carrying count and sets State to EventSeriesStateOngoing. In the EventRecorder it also creates an entry in activeSeries map with the timestamp of last observed Event in the series.

Programmatically, this translates into this [piece of code](https://github.com/kubernetes/client-go/blob/v0.19.0-beta.2/tools/events/event_broadcaster.go#L162-L173) where we can see that the latest timestamp is now being recorded in Series.LastObservedTime and the count in Series.Count.

As for the second, it is handling the following edge cases from the new notion of Event singleton:
> The biggest change is the semantics of the Event object in case of loops. If Series is nil it means that Event is a singleton, i.e. it happened only once and the semantics is exactly the same as currently in Events with count = 1. If Series is not nil it means that the Event is either beginning or the end of an Event series - equivalence of current Events with count > 1. Events for ongoing series have Series.State set to EventSeriesStateOngoing, while endings have Series.State set to EventSeriesStateFinished. [link](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/instrumentation/events-redesign.md#comparison-between-old-and-new-api)

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
/sig cli
/area kubectl