### PR TITLE
Reference listmeta in CR openapi

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/openapi/builder/builder.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/openapi/builder/builder.go
@@ -50,6 +50,7 @@ import (
 const (
 	// Reference and Go types for built-in metadata
 	objectMetaSchemaRef = "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
+	listMetaSchemaRef   = "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
 	listMetaType        = "k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"
 	typeMetaType        = "k8s.io/apimachinery/pkg/apis/meta/v1.TypeMeta"
 
@@ -57,7 +58,8 @@ const (
 )
 
 var (
-	swaggerPartialObjectMetadataDescriptions = metav1beta1.PartialObjectMetadata{}.SwaggerDoc()
+	swaggerPartialObjectMetadataDescriptions     = metav1beta1.PartialObjectMetadata{}.SwaggerDoc()
+	swaggerPartialObjectMetadataListDescriptions = metav1beta1.PartialObjectMetadataList{}.SwaggerDoc()
 
 	nameToken      = "{name}"
 	namespaceToken = "{namespace}"
@@ -457,7 +459,8 @@ func (b *builder) buildListSchema() *spec.Schema {
 	s := new(spec.Schema).WithDescription(fmt.Sprintf("%s is a list of %s", b.listKind, b.kind)).
 		WithRequired("items").
 		SetProperty("items", *spec.ArrayProperty(spec.RefSchema(name)).WithDescription(doc)).
-		SetProperty("metadata", getDefinition(listMetaType))
+		SetProperty("metadata", *spec.RefSchema(listMetaSchemaRef).WithDescription(swaggerPartialObjectMetadataListDescriptions["metadata"]))
+
 	addTypeMetaProperties(s)
 	s.AddExtension(endpoints.ROUTE_META_GVK, []map[string]string{
 		{

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/openapi/builder/builder_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/openapi/builder/builder_test.go
@@ -419,6 +419,17 @@ func TestNewBuilder(t *testing.T) {
 				t.Fatalf("unexpected list properties, got: %s, expected: %s", gotListProperties.List(), want.List())
 			}
 
+			if e, a := (spec.StringOrArray{"string"}), got.listSchema.Properties["apiVersion"].Type; !reflect.DeepEqual(e, a) {
+				t.Errorf("expected %#v, got %#v", e, a)
+			}
+			if e, a := (spec.StringOrArray{"string"}), got.listSchema.Properties["kind"].Type; !reflect.DeepEqual(e, a) {
+				t.Errorf("expected %#v, got %#v", e, a)
+			}
+			listRef := got.listSchema.Properties["metadata"].Ref
+			if e, a := "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta", (&listRef).String(); e != a {
+				t.Errorf("expected %q, got %q", e, a)
+			}
+
 			gotListSchema := got.listSchema.Properties["items"].Items.Schema
 			if !reflect.DeepEqual(&wantedItemsSchema, gotListSchema) {
 				t.Errorf("unexpected list schema: %s (want/got)", schemaDiff(&wantedItemsSchema, gotListSchema))


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Switches rendered custom resource list metadata to reference the standard ListMeta definition.

**Does this PR introduce a user-facing change?**:
```release-note
kube-apiserver: openapi schemas published for custom resources now reference standard ListMeta schema definitions
```

/cc @sttts @roycaihw 
/sig api-machinery
/area custom-resources