### PR TITLE
Sets desiredcapacity instead of minsize and maxsize on ResizeInstanceGroup

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/aws/aws_instancegroups.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/aws/aws_instancegroups.go
@@ -35,8 +35,7 @@ var _ InstanceGroups = &Cloud{}
 func ResizeInstanceGroup(asg ASG, instanceGroupName string, size int) error {
 	request := &autoscaling.UpdateAutoScalingGroupInput{
 		AutoScalingGroupName: aws.String(instanceGroupName),
-		MinSize:              aws.Int64(int64(size)),
-		MaxSize:              aws.Int64(int64(size)),
+		DesiredCapacity:      aws.Int64(int64(size)),
 	}
 	if _, err := asg.UpdateAutoScalingGroup(request); err != nil {
 		return fmt.Errorf("error resizing AWS autoscaling group: %q", err)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Currently, after the autoscaling_timer.go test (the only callsite of this function), the ASG is reset with min and max nodes. If the test is ever run again, it fails due to the ASG being unable to scale up or down. This simply resets the Desired count leaving the original min/max intact.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #92548
