### PR TITLE
Fix sig-node-containerd/containerd-e2e-gci

### DIFF
--- a/cluster/gce/config-default.sh
+++ b/cluster/gce/config-default.sh
@@ -103,7 +103,7 @@ if [[ "${CONTAINER_RUNTIME}" == "docker" ]]; then
   export CONTAINER_RUNTIME_ENDPOINT=${KUBE_CONTAINER_RUNTIME_ENDPOINT:-unix:///var/run/dockershim.sock}
   export CONTAINER_RUNTIME_NAME=${KUBE_CONTAINER_RUNTIME_NAME:-docker}
   export LOAD_IMAGE_COMMAND=${KUBE_LOAD_IMAGE_COMMAND:-}
-elif [[ "${CONTAINER_RUNTIME}" == "containerd" ]]; then
+elif [[ "${CONTAINER_RUNTIME}" == "containerd" ||  "${CONTAINER_RUNTIME}" == "remote" ]]; then
   export CONTAINER_RUNTIME_ENDPOINT=${KUBE_CONTAINER_RUNTIME_ENDPOINT:-unix:///run/containerd/containerd.sock}
   export CONTAINER_RUNTIME_NAME=${KUBE_CONTAINER_RUNTIME_NAME:-containerd}
   export LOG_DUMP_SYSTEMD_SERVICES=${LOG_DUMP_SYSTEMD_SERVICES:-containerd}

--- a/cluster/gce/config-test.sh
+++ b/cluster/gce/config-test.sh
@@ -106,7 +106,7 @@ if [[ "${CONTAINER_RUNTIME}" == "docker" ]]; then
   export CONTAINER_RUNTIME_ENDPOINT=${KUBE_CONTAINER_RUNTIME_ENDPOINT:-unix:///var/run/dockershim.sock}
   export CONTAINER_RUNTIME_NAME=${KUBE_CONTAINER_RUNTIME_NAME:-docker}
   export LOAD_IMAGE_COMMAND=${KUBE_LOAD_IMAGE_COMMAND:-}
-elif [[ "${CONTAINER_RUNTIME}" == "containerd" ]]; then
+elif [[ "${CONTAINER_RUNTIME}" == "containerd" || "${CONTAINER_RUNTIME}" == "remote" ]]; then
   export CONTAINER_RUNTIME_ENDPOINT=${KUBE_CONTAINER_RUNTIME_ENDPOINT:-unix:///run/containerd/containerd.sock}
   export CONTAINER_RUNTIME_NAME=${KUBE_CONTAINER_RUNTIME_NAME:-containerd}
   export LOAD_IMAGE_COMMAND=${KUBE_LOAD_IMAGE_COMMAND:-ctr -n=k8s.io images import}


### PR DESCRIPTION
Signed-off-by: Roy Yang <royyang@google.com>

**What type of PR is this?**


 /kind failing-test


**What this PR does / why we need it**:
Looks after #91684, https://testgrid.k8s.io/sig-node-containerd#containerd-e2e-gci starts fail.

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:
I do not understand why there is a 'remote' value for container-runtime. But from my grep, looks this is the
3rd options other than 'docker' and 'containerd'. I would like to understand this but for now, gave it a try
first.

**Does this PR introduce a user-facing change?**:
N/A 
**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
N/A
