### PR TITLE
fix cluster/images/etcd/migrate staticcheck

### DIFF
--- a/cluster/images/etcd/migrate/versions.go
+++ b/cluster/images/etcd/migrate/versions.go
@@ -124,16 +124,6 @@ func ParseEtcdVersionPair(s string) (*EtcdVersionPair, error) {
 	return &EtcdVersionPair{version, storageVersion}, nil
 }
 
-// MustParseEtcdVersionPair parses a "<version>/<storage-version>" string to an EtcdVersionPair
-// or panics if the parse fails.
-func MustParseEtcdVersionPair(s string) *EtcdVersionPair {
-	pair, err := ParseEtcdVersionPair(s)
-	if err != nil {
-		panic(err)
-	}
-	return pair
-}
-
 // String returns "<version>/<storage-version>" string of the EtcdVersionPair.
 func (vp *EtcdVersionPair) String() string {
 	return fmt.Sprintf("%s/%s", vp.version, vp.storageVersion)
@@ -185,13 +175,4 @@ func ParseSupportedVersions(list []string) (SupportedVersions, error) {
 		}
 	}
 	return versions, nil
-}
-
-// MustParseSupportedVersions parses a comma separated list of etcd versions or panics if the parse fails.
-func MustParseSupportedVersions(list []string) SupportedVersions {
-	versions, err := ParseSupportedVersions(list)
-	if err != nil {
-		panic(err)
-	}
-	return versions
 }

--- a/hack/.staticcheck_failures
+++ b/hack/.staticcheck_failures
@@ -1,4 +1,3 @@
-cluster/images/etcd/migrate
 pkg/controller/garbagecollector
 pkg/controller/nodeipam
 pkg/controller/podautoscaler


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

fix staticcheck 

```shell
# edward @ edward-pc in ~/code/go/kubernetes/cluster on git:master o [10:27:43] 
$ staticcheck ./...
images/etcd/migrate/versions.go:129:6: func MustParseEtcdVersionPair is unused (U1000)
images/etcd/migrate/versions.go:191:6: func MustParseSupportedVersions is unused (U1000)
```


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

Part of #92402

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
