### PR TITLE
fixing static checks for volume/testing

### DIFF
--- a/hack/.staticcheck_failures
+++ b/hack/.staticcheck_failures
@@ -9,7 +9,6 @@ pkg/controller/statefulset
 pkg/volume/azure_dd
 pkg/volume/gcepd
 pkg/volume/rbd
-pkg/volume/testing
 pkg/volume/vsphere_volume
 test/e2e/apps
 test/e2e/autoscaling

--- a/pkg/volume/testing/testing.go
+++ b/pkg/volume/testing/testing.go
@@ -401,8 +401,11 @@ var _ DeviceMountableVolumePlugin = &FakeVolumePlugin{}
 var _ NodeExpandableVolumePlugin = &FakeVolumePlugin{}
 
 func (plugin *FakeVolumePlugin) getFakeVolume(list *[]*FakeVolume) *FakeVolume {
+	if list == nil {
+		panic("list param cannot be nil")
+	}
 	volumeList := *list
-	if list != nil && len(volumeList) > 0 {
+	if len(volumeList) > 0 {
 		volume := volumeList[0]
 		volume.Lock()
 		defer volume.Unlock()


### PR DESCRIPTION
Apologies for the small PR, but it appears the only unaddressed part of #92402. 

I've added the explicit panic() to make sure failures remain noisy, since this is a test utility.

**What type of PR is this?**
> /kind cleanup

**Which issue(s) this PR fixes**:
Part of #92402

**Does this PR introduce a user-facing change?**:
no
