### PR TITLE
Fix the bug that kubectl logs does not filter correctly with --since-time at fractions of a second

### DIFF
--- a/pkg/registry/core/pod/strategy.go
+++ b/pkg/registry/core/pod/strategy.go
@@ -367,7 +367,7 @@ func LogLocation(
 		params.Add("sinceSeconds", strconv.FormatInt(*opts.SinceSeconds, 10))
 	}
 	if opts.SinceTime != nil {
-		params.Add("sinceTime", opts.SinceTime.Format(time.RFC3339))
+		params.Add("sinceTime", opts.SinceTime.Format(time.RFC3339Nano))
 	}
 	if opts.TailLines != nil {
 		params.Add("tailLines", strconv.FormatInt(*opts.TailLines, 10))

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/time.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/time.go
@@ -130,7 +130,7 @@ func (t *Time) UnmarshalQueryParameter(str string) error {
 		return nil
 	}
 
-	pt, err := time.Parse(time.RFC3339, str)
+	pt, err := time.Parse(time.RFC3339Nano, str)
 	if err != nil {
 		return err
 	}
@@ -180,7 +180,7 @@ func (t Time) MarshalQueryParameter() (string, error) {
 		return "", nil
 	}
 
-	return t.UTC().Format(time.RFC3339), nil
+	return t.UTC().Format(time.RFC3339Nano), nil
 }
 
 // Fuzz satisfies fuzz.Interface.


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Fix the bug that `kubectl logs` does not filter correctly with `--since-time` at fractions of a second.
After some investigation, I found that the reasons of the issue were: 
1. `kubectl` lost accuracy when it made a request to `kube-apiserver`
2. `kube-apiserver` also lost accuracy when it made a request to `kubelet`

To solve this problem, we need to fix `kubectl` as well `kube-apiserver`.

Before this patch:
```
[root@centos-01 ~]# ./kubectl logs -f etcd-centos-01 -n kube-system --timestamps=true --since-time=2020-06-29T04:49:18.759915138Z
2020-06-29T04:49:18.013711163Z 2020-06-29 04:49:18.013576 I | mvcc: store.index: compact 3883339
2020-06-29T04:49:18.759915138Z 2020-06-29 04:49:18.759815 I | mvcc: finished scheduled compaction at 3883339 (took 706.127822ms)
2020-06-29T04:52:41.583440288Z 2020-06-29 04:52:41.582861 W | etcdserver: read-only range request "key:\"/registry/namespaces/kube-system\" " with result "range_response_count:1 size:265" took too long (115.855114ms) to execute
...
```

After 
```
[root@centos-01 ~]# ./kubectl logs -f etcd-centos-01 -n kube-system --timestamps=true --since-time=2020-06-29T04:49:18.759915138Z
2020-06-29T04:49:18.759915138Z 2020-06-29 04:49:18.759815 I | mvcc: finished scheduled compaction at 3883339 (took 706.127822ms)
2020-06-29T04:52:41.583440288Z 2020-06-29 04:52:41.582861 W | etcdserver: read-only range request "key:\"/registry/namespaces/kube-system\" " with result "range_response_count:1 size:265" took too long (115.855114ms) to execute
```


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #92389

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
fix the bug that 'kubectl logs' does not filter correctly with '--since-time' at fractions of a second
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
