### PR TITLE
The Pod is eligible to preempt when previous nominanted node is UnschedulableAndUnresolvable 

### DIFF
--- a/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption_test.go
+++ b/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption_test.go
@@ -889,6 +889,61 @@ func TestPickOneNodeForPreemption(t *testing.T) {
 	}
 }
 
+func TestPodEligibleToPreemptOthers(t *testing.T) {
+	tests := []struct {
+		name                string
+		pod                 *v1.Pod
+		pods                []*v1.Pod
+		nodes               []string
+		nominatedNodeStatus *framework.Status
+		expected            bool
+	}{
+		{
+			name:                "Pod with nominated node",
+			pod:                 st.MakePod().Name("p_with_nominated_node").UID("p").Priority(highPriority).NominatedNodeName("node1").Obj(),
+			pods:                []*v1.Pod{st.MakePod().Name("p1").UID("p1").Priority(lowPriority).Node("node1").Terminating().Obj()},
+			nodes:               []string{"node1"},
+			nominatedNodeStatus: framework.NewStatus(framework.UnschedulableAndUnresolvable, tainttoleration.ErrReasonNotMatch),
+			expected:            true,
+		},
+		{
+			name:                "Pod with nominated node, but without nominated node status",
+			pod:                 st.MakePod().Name("p_without_status").UID("p").Priority(highPriority).NominatedNodeName("node1").Obj(),
+			pods:                []*v1.Pod{st.MakePod().Name("p1").UID("p1").Priority(lowPriority).Node("node1").Terminating().Obj()},
+			nodes:               []string{"node1"},
+			nominatedNodeStatus: nil,
+			expected:            false,
+		},
+		{
+			name:                "Pod without nominated node",
+			pod:                 st.MakePod().Name("p_without_nominated_node").UID("p").Priority(highPriority).Obj(),
+			pods:                []*v1.Pod{},
+			nodes:               []string{},
+			nominatedNodeStatus: nil,
+			expected:            true,
+		},
+		{
+			name:                "Pod with 'PreemptNever' preemption policy",
+			pod:                 st.MakePod().Name("p_with_preempt_never_policy").UID("p").Priority(highPriority).PreemptionPolicy(v1.PreemptNever).Obj(),
+			pods:                []*v1.Pod{},
+			nodes:               []string{},
+			nominatedNodeStatus: nil,
+			expected:            false,
+		},
+	}
+
+	for _, test := range tests {
+		var nodes []*v1.Node
+		for _, n := range test.nodes {
+			nodes = append(nodes, st.MakeNode().Name(n).Obj())
+		}
+		snapshot := internalcache.NewSnapshot(test.pods, nodes)
+		if got := podEligibleToPreemptOthers(test.pod, snapshot.NodeInfos(), test.nominatedNodeStatus); got != test.expected {
+			t.Errorf("expected %t, got %t for pod: %s", test.expected, got, test.pod.Name)
+		}
+	}
+}
+
 func TestNodesWherePreemptionMightHelp(t *testing.T) {
 	// Prepare 4 nodes names.
 	nodeNames := []string{"node1", "node2", "node3", "node4"}

--- a/pkg/scheduler/testing/wrappers.go
+++ b/pkg/scheduler/testing/wrappers.go
@@ -244,6 +244,12 @@ func (p *PodWrapper) StartTime(t metav1.Time) *PodWrapper {
 	return p
 }
 
+// NominatedNodeName sets `n` as the .Status.NominatedNodeName of the inner pod.
+func (p *PodWrapper) NominatedNodeName(n string) *PodWrapper {
+	p.Status.NominatedNodeName = n
+	return p
+}
+
 // PodAffinityKind represents different kinds of PodAffinity.
 type PodAffinityKind int
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
/sig scheduling

**What this PR does / why we need it**:
This PR is trying to fix the Pod won't be considered for preemption even its nominated node is considered as UnschedulableAndUnresolvable by the filters

**Which issue(s) this PR fixes**:

Fixes #92600

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
Fixes the pod can be considered for preemption after its previous nominated node become unschedulable and unresolvable.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

