### PR TITLE
fix: reduce azure credential caching to fix pull image issue using managed identity

### DIFF
--- a/pkg/credentialprovider/azure/azure_credentials.go
+++ b/pkg/credentialprovider/azure/azure_credentials.go
@@ -57,7 +57,7 @@ func init() {
 	credentialprovider.RegisterCredentialProvider("azure",
 		&credentialprovider.CachingDockerConfigProvider{
 			Provider:    NewACRProvider(flagConfigFile),
-			Lifetime:    1 * time.Minute,
+			Lifetime:    5 * time.Second,
 			ShouldCache: func(d credentialprovider.DockerConfig) bool { return len(d) > 0 },
 		})
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
fix: reduce azure credential caching
PR(https://github.com/kubernetes/kubernetes/pull/92330) did not fix the pull image issue using Managed Identity completely, e.g. when there are two images from two different ACR repos, image pull will still fail randomly.
This PR reduces azure credential caching from 1min to 5s to make azure credential caching as short as possible, that would mitigate this issue a lot. 
 - about the impact of this change:
   - The `Provide` func with SP only prepares an array, it should cost < 0.01s every time, no impact for SP
   - The `Provide` func with Manaaged Identity costs 0.3s to get token, after 5s, it would get token again if there is ACR image pull again, that would only have little impact.

/assign @weinong 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #92326

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
fix: reduce azure credential caching to fix docker pull issue using MSI
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
none
```

/kind bug
/priority important-soon
/sig cloud-provider
/area provider/azure