### PR TITLE
breakdown PodSchedulingDuration by number of attempts

### DIFF
--- a/pkg/scheduler/metrics/metrics.go
+++ b/pkg/scheduler/metrics/metrics.go
@@ -154,7 +154,7 @@ var (
 			StabilityLevel: metrics.ALPHA,
 		}, []string{"work"})
 
-	PodSchedulingDuration = metrics.NewHistogram(
+	PodSchedulingDuration = metrics.NewHistogramVec(
 		&metrics.HistogramOpts{
 			Subsystem: SchedulerSubsystem,
 			Name:      "pod_scheduling_duration_seconds",
@@ -162,7 +162,8 @@ var (
 			// Start with 1ms with the last bucket being [~16s, Inf)
 			Buckets:        metrics.ExponentialBuckets(0.001, 2, 15),
 			StabilityLevel: metrics.ALPHA,
-		})
+		},
+		[]string{"attempts"})
 
 	PodSchedulingAttempts = metrics.NewHistogram(
 		&metrics.HistogramOpts{


### PR DESCRIPTION

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Breakdown PodSchedulingDuration by number of attempts, this is useful when monitoring the scheduler to understand how scheduling attempts impact latency.


**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
Add attempts label to scheduler's PodSchedulingDuration metric.
```

