### PR TITLE
[Kubeadm]:Bump CoreDNS to v1.7.0

### DIFF
--- a/build/dependencies.yaml
+++ b/build/dependencies.yaml
@@ -22,7 +22,7 @@ dependencies:
       match: k8s.gcr.io/coredns
 
   - name: "coredns-kubeadm"
-    version: 1.6.7
+    version: 1.7.0
     refPaths:
     - path: cmd/kubeadm/app/constants/constants.go
       match: CoreDNSVersion =

--- a/cmd/kubeadm/app/constants/constants.go
+++ b/cmd/kubeadm/app/constants/constants.go
@@ -329,7 +329,7 @@ const (
 	KubeDNSVersion = "1.14.13"
 
 	// CoreDNSVersion is the version of CoreDNS to be deployed if it is used
-	CoreDNSVersion = "1.6.7"
+	CoreDNSVersion = "1.7.0"
 
 	// ClusterConfigurationKind is the string kind value for the ClusterConfiguration struct
 	ClusterConfigurationKind = "ClusterConfiguration"

--- a/cmd/kubeadm/app/phases/addons/dns/dns_test.go
+++ b/cmd/kubeadm/app/phases/addons/dns/dns_test.go
@@ -585,7 +585,9 @@ func TestCreateCoreDNSConfigMap(t *testing.T) {
         ttl 30
     }
     prometheus :9153
-    forward . /etc/resolv.conf
+    forward . /etc/resolv.conf {
+        max_concurrent 1000
+    }
     cache 30
     loop
     reload
@@ -623,7 +625,9 @@ func TestCreateCoreDNSConfigMap(t *testing.T) {
         fallthrough in-addr.arpa ip6.arpa
     }
     prometheus :9153
-    forward . /etc/resolv.conf
+    forward . /etc/resolv.conf {
+        max_concurrent 1000
+    }
     k8s_external example.com
     cache 30
     loop

--- a/cmd/kubeadm/app/phases/addons/dns/manifests.go
+++ b/cmd/kubeadm/app/phases/addons/dns/manifests.go
@@ -320,7 +320,9 @@ data:
            ttl 30
         }
         prometheus :9153
-        forward . {{ .UpstreamNameserver }}
+        forward . {{ .UpstreamNameserver }} {
+           max_concurrent 1000
+        }
         cache 30
         loop
         reload

--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/codegangsta/negroni v1.0.0 // indirect
 	github.com/container-storage-interface/spec v1.2.0
 	github.com/containernetworking/cni v0.8.0
-	github.com/coredns/corefile-migration v1.0.8
+	github.com/coredns/corefile-migration v1.0.10
 	github.com/coreos/go-oidc v2.1.0+incompatible
 	github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e
 	github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f
@@ -209,7 +209,7 @@ replace (
 	github.com/containerd/ttrpc => github.com/containerd/ttrpc v1.0.0
 	github.com/containerd/typeurl => github.com/containerd/typeurl v1.0.0
 	github.com/containernetworking/cni => github.com/containernetworking/cni v0.8.0
-	github.com/coredns/corefile-migration => github.com/coredns/corefile-migration v1.0.8
+	github.com/coredns/corefile-migration => github.com/coredns/corefile-migration v1.0.10
 	github.com/coreos/bbolt => github.com/coreos/bbolt v1.3.2
 	github.com/coreos/etcd => github.com/coreos/etcd v3.3.10+incompatible
 	github.com/coreos/go-oidc => github.com/coreos/go-oidc v2.1.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -108,8 +108,8 @@ github.com/containerd/typeurl v1.0.0 h1:7LMH7LfEmpWeCkGcIputvd4P0Rnd0LrIv1Jk2s5o
 github.com/containerd/typeurl v1.0.0/go.mod h1:Cm3kwCdlkCfMSHURc+r6fwoGH6/F1hH3S4sg0rLFWPc=
 github.com/containernetworking/cni v0.8.0 h1:BT9lpgGoH4jw3lFC7Odz2prU5ruiYKcgAjMCbgybcKI=
 github.com/containernetworking/cni v0.8.0/go.mod h1:LGwApLUm2FpoOfxTDEeq8T9ipbpZ61X79hmU3w8FmsY=
-github.com/coredns/corefile-migration v1.0.8 h1:y/DSRGlmrLPTMUGWR81MgFC2ITLiaTGkbth0BqW3wvc=
-github.com/coredns/corefile-migration v1.0.8/go.mod h1:OFwBp/Wc9dJt5cAZzHWMNhK1r5L0p0jDwIBc6j8NC8E=
+github.com/coredns/corefile-migration v1.0.10 h1:7HI4r5S5Fne749a+JDxUZppqBpYoZK8Q53ZVK9cn3aM=
+github.com/coredns/corefile-migration v1.0.10/go.mod h1:RMy/mXdeDlYwzt0vdMEJvT2hGJ2I86/eO0UdXmH9XNI=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/go-oidc v2.1.0+incompatible h1:sdJrfw8akMnCuUlaZU3tE/uYXFgfqom8DBE9so9EBsM=

--- a/vendor/github.com/coredns/corefile-migration/migration/plugins.go
+++ b/vendor/github.com/coredns/corefile-migration/migration/plugins.go
@@ -146,8 +146,8 @@ var plugins = map[string]map[string]plugin{
 		},
 		"v6": plugin{
 			namedOptions: map[string]option{
-				"resyncperiod": { // new removal
-					status: removed,
+				"resyncperiod": { // now ignored
+					status: ignored,
 					action: removeOption,
 				},
 				"endpoint": {
@@ -173,7 +173,10 @@ var plugins = map[string]map[string]plugin{
 		},
 		"v7": plugin{
 			namedOptions: map[string]option{
-				// resyncperiod removed
+				"resyncperiod": { // new removal
+					status: removed,
+					action: removeOption,
+				},
 				"endpoint": {
 					status: ignored,
 					action: useFirstArgumentOnly,
@@ -184,8 +187,8 @@ var plugins = map[string]map[string]plugin{
 				"labels":             {},
 				"pods":               {},
 				"endpoint_pod_names": {},
-				"upstream": {
-					status: ignored,
+				"upstream": { // new removal
+					status: removed,
 					action: removeOption,
 				},
 				"ttl":         {},
@@ -312,6 +315,26 @@ var plugins = map[string]map[string]plugin{
 				"tls_servername": {},
 				"policy":         {},
 				"health_check":   {},
+			},
+		},
+		"v3": plugin{
+			namedOptions: map[string]option{
+				"except":         {},
+				"force_tcp":      {},
+				"prefer_udp":     {},
+				"expire":         {},
+				"max_fails":      {},
+				"tls":            {},
+				"tls_servername": {},
+				"policy":         {},
+				"health_check":   {},
+				"max_concurrent": { // new option
+					status: newdefault,
+					add: func(c *corefile.Plugin) (*corefile.Plugin, error) {
+						return addOptionToPlugin(c, &corefile.Option{Name: "max_concurrent 1000"})
+					},
+					downAction: removeOption,
+				},
 			},
 		},
 	},

--- a/vendor/github.com/coredns/corefile-migration/migration/versions.go
+++ b/vendor/github.com/coredns/corefile-migration/migration/versions.go
@@ -29,7 +29,72 @@ type release struct {
 
 // Versions holds a map of plugin/option migrations per CoreDNS release (since 1.1.4)
 var Versions = map[string]release{
+	"1.7.0": {
+		priorVersion:   "1.6.9",
+		k8sReleases:    []string{"1.19"},
+		dockerImageSHA: "73ca82b4ce829766d4f1f10947c3a338888f876fbed0540dc849c89ff256e90c",
+		defaultConf: `.:53 {
+    errors
+    health {
+        lameduck 5s
+    }
+    ready
+    kubernetes * *** {
+        pods insecure
+        fallthrough in-addr.arpa ip6.arpa
+        ttl 30
+    }
+    prometheus :9153
+    forward . * {
+        max_concurrent 1000
+    }
+    cache 30
+    loop
+    reload
+    loadbalance
+}`,
+		plugins: map[string]plugin{
+			"errors":       plugins["errors"]["v2"],
+			"log":          plugins["log"]["v1"],
+			"health":       plugins["health"]["v1"],
+			"ready":        {},
+			"autopath":     {},
+			"kubernetes":   plugins["kubernetes"]["v7"],
+			"k8s_external": plugins["k8s_external"]["v1"],
+			"prometheus":   {},
+			"forward":      plugins["forward"]["v3"],
+			"cache":        plugins["cache"]["v1"],
+			"loop":         {},
+			"reload":       {},
+			"loadbalance":  {},
+			"hosts":        plugins["hosts"]["v1"],
+			"rewrite":      plugins["rewrite"]["v2"],
+		},
+	},
+	"1.6.9": {
+		nextVersion:    "1.7.0",
+		priorVersion:   "1.6.7",
+		dockerImageSHA: "40ee1b708e20e3a6b8e04ccd8b6b3dd8fd25343eab27c37154946f232649ae21",
+		plugins: map[string]plugin{
+			"errors":       plugins["errors"]["v2"],
+			"log":          plugins["log"]["v1"],
+			"health":       plugins["health"]["v1"],
+			"ready":        {},
+			"autopath":     {},
+			"kubernetes":   plugins["kubernetes"]["v6"],
+			"k8s_external": plugins["k8s_external"]["v1"],
+			"prometheus":   {},
+			"forward":      plugins["forward"]["v2"],
+			"cache":        plugins["cache"]["v2"],
+			"loop":         {},
+			"reload":       {},
+			"loadbalance":  {},
+			"hosts":        plugins["hosts"]["v1"],
+			"rewrite":      plugins["rewrite"]["v2"],
+		},
+	},
 	"1.6.7": {
+		nextVersion:    "1.6.9",
 		priorVersion:   "1.6.6",
 		k8sReleases:    []string{"1.18"},
 		dockerImageSHA: "2c8d61c46f484d881db43b34d13ca47a269336e576c81cf007ca740fa9ec0800",
@@ -57,7 +122,7 @@ var Versions = map[string]release{
 			"health":       plugins["health"]["v1"],
 			"ready":        {},
 			"autopath":     {},
-			"kubernetes":   plugins["kubernetes"]["v7"],
+			"kubernetes":   plugins["kubernetes"]["v6"],
 			"k8s_external": plugins["k8s_external"]["v1"],
 			"prometheus":   {},
 			"forward":      plugins["forward"]["v2"],
@@ -79,7 +144,7 @@ var Versions = map[string]release{
 			"health":       plugins["health"]["v1"],
 			"ready":        {},
 			"autopath":     {},
-			"kubernetes":   plugins["kubernetes"]["v7"],
+			"kubernetes":   plugins["kubernetes"]["v6"],
 			"k8s_external": plugins["k8s_external"]["v1"],
 			"prometheus":   {},
 			"forward":      plugins["forward"]["v2"],
@@ -120,7 +185,7 @@ var Versions = map[string]release{
 			"health":       plugins["health"]["v1 add lameduck"],
 			"ready":        {},
 			"autopath":     {},
-			"kubernetes":   plugins["kubernetes"]["v7"],
+			"kubernetes":   plugins["kubernetes"]["v6"],
 			"k8s_external": plugins["k8s_external"]["v1"],
 			"prometheus":   {},
 			"forward":      plugins["forward"]["v2"],
@@ -142,7 +207,7 @@ var Versions = map[string]release{
 			"health":       plugins["health"]["v1"],
 			"ready":        {},
 			"autopath":     {},
-			"kubernetes":   plugins["kubernetes"]["v7"],
+			"kubernetes":   plugins["kubernetes"]["v6"],
 			"k8s_external": plugins["k8s_external"]["v1"],
 			"prometheus":   {},
 			"forward":      plugins["forward"]["v2"],
@@ -164,7 +229,7 @@ var Versions = map[string]release{
 			"health":       plugins["health"]["v1"],
 			"ready":        {},
 			"autopath":     {},
-			"kubernetes":   plugins["kubernetes"]["v7"],
+			"kubernetes":   plugins["kubernetes"]["v6"],
 			"k8s_external": plugins["k8s_external"]["v1"],
 			"prometheus":   {},
 			"forward":      plugins["forward"]["v2"],
@@ -203,7 +268,7 @@ var Versions = map[string]release{
 			"health":       plugins["health"]["v1"],
 			"ready":        {},
 			"autopath":     {},
-			"kubernetes":   plugins["kubernetes"]["v7"],
+			"kubernetes":   plugins["kubernetes"]["v6"],
 			"k8s_external": plugins["k8s_external"]["v1"],
 			"prometheus":   {},
 			"forward":      plugins["forward"]["v2"],
@@ -225,7 +290,7 @@ var Versions = map[string]release{
 			"health":       plugins["health"]["v1"],
 			"ready":        {},
 			"autopath":     {},
-			"kubernetes":   plugins["kubernetes"]["v7"],
+			"kubernetes":   plugins["kubernetes"]["v6"],
 			"k8s_external": plugins["k8s_external"]["v1"],
 			"prometheus":   {},
 			"forward":      plugins["forward"]["v2"],

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -169,7 +169,7 @@ github.com/containernetworking/cni/pkg/types/020
 github.com/containernetworking/cni/pkg/types/current
 github.com/containernetworking/cni/pkg/utils
 github.com/containernetworking/cni/pkg/version
-# github.com/coredns/corefile-migration v1.0.8 => github.com/coredns/corefile-migration v1.0.8
+# github.com/coredns/corefile-migration v1.0.10 => github.com/coredns/corefile-migration v1.0.10
 github.com/coredns/corefile-migration/migration
 github.com/coredns/corefile-migration/migration/corefile
 # github.com/coreos/go-oidc v2.1.0+incompatible => github.com/coreos/go-oidc v2.1.0+incompatible


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Updates CoreDNS to v1.7.0. The default Corefile now includes the `max_concurrent` option, which sets the maximum number of concurrent upstream queries allowed by the `forward` plugin.

Also updates the migration library to 1.0.10 which supports coredns v1.7.0

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
ACTION REQUIRED : In CoreDNS v1.7.0, [metrics names have been changed](https://github.com/coredns/coredns/blob/master/notes/coredns-1.7.0.md#metric-changes) which will be backward incompatible with existing reporting formulas that use the old metrics' names. Adjust your formulas to the new names before upgrading. 

Kubeadm now includes CoreDNS version v1.7.0. Some of the major changes include:
-  Fixed a bug that could cause CoreDNS to stop updating service records.
-  Fixed a bug in the forward plugin where only the first upstream server is always selected no matter which policy is set.
-  Remove already deprecated options `resyncperiod` and `upstream` in the Kubernetes plugin.
-  Includes Prometheus metrics name changes (to bring them in line with standard Prometheus metrics naming convention). They will be backward incompatible with existing reporting formulas that use the old metrics' names.
-  The federation plugin (allows for v1 Kubernetes federation) has been removed.
More details are available in https://coredns.io/2020/06/15/coredns-1.7.0-release/
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
