### PR TITLE
fix: improved the way CSR object fields(CN & O) displayed

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/describe/BUILD
+++ b/staging/src/k8s.io/kubectl/pkg/describe/BUILD
@@ -81,6 +81,8 @@ go_test(
         "//staging/src/k8s.io/api/autoscaling/v1:go_default_library",
         "//staging/src/k8s.io/api/autoscaling/v2beta2:go_default_library",
         "//staging/src/k8s.io/api/batch/v1:go_default_library",
+        "//staging/src/k8s.io/api/certificates/v1:go_default_library",
+        "//staging/src/k8s.io/api/certificates/v1beta1:go_default_library",
         "//staging/src/k8s.io/api/coordination/v1:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/api/discovery/v1beta1:go_default_library",

--- a/staging/src/k8s.io/kubectl/pkg/describe/describe.go
+++ b/staging/src/k8s.io/kubectl/pkg/describe/describe.go
@@ -25,6 +25,7 @@ import (
 	"net"
 	"net/url"
 	"reflect"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -3505,6 +3506,12 @@ func describeCertificateSigningRequest(csr metav1.ObjectMeta, signerName string,
 		w.Write(LEVEL_0, "\n")
 	}
 
+	CommonName := cr.Subject.CommonName
+	reg, err := regexp.Compile("[^a-zA-Z0-9: ]")
+	if err == nil {
+		CommonName = reg.ReplaceAllString(cr.Subject.CommonName, "")
+	}
+
 	return tabbedString(func(out io.Writer) error {
 		w := NewPrefixWriter(out)
 		w.Write(LEVEL_0, "Name:\t%s\n", csr.Name)
@@ -3518,7 +3525,7 @@ func describeCertificateSigningRequest(csr metav1.ObjectMeta, signerName string,
 		w.Write(LEVEL_0, "Status:\t%s\n", status)
 
 		w.Write(LEVEL_0, "Subject:\n")
-		w.Write(LEVEL_0, "\tCommon Name:\t%q\n", cr.Subject.CommonName)
+		w.Write(LEVEL_0, "\tCommon Name:\t%q\n", CommonName)
 		w.Write(LEVEL_0, "\tSerial Number:\t%q\n", cr.Subject.SerialNumber)
 		printListHelper(w, "\t", "Organization", cr.Subject.Organization)
 		printListHelper(w, "\t", "Organizational Unit", cr.Subject.OrganizationalUnit)

--- a/staging/src/k8s.io/kubectl/pkg/describe/describe.go
+++ b/staging/src/k8s.io/kubectl/pkg/describe/describe.go
@@ -3501,7 +3501,7 @@ func describeCertificateSigningRequest(csr metav1.ObjectMeta, signerName string,
 			return
 		}
 		w.Write(LEVEL_0, prefix+name+":\t")
-		w.Write(LEVEL_0, strings.Join(values, "\n"+prefix+"\t"))
+		w.Write(LEVEL_0, "%q", strings.Join(values, "\n"+prefix+"\t"))
 		w.Write(LEVEL_0, "\n")
 	}
 
@@ -3518,8 +3518,8 @@ func describeCertificateSigningRequest(csr metav1.ObjectMeta, signerName string,
 		w.Write(LEVEL_0, "Status:\t%s\n", status)
 
 		w.Write(LEVEL_0, "Subject:\n")
-		w.Write(LEVEL_0, "\tCommon Name:\t%s\n", cr.Subject.CommonName)
-		w.Write(LEVEL_0, "\tSerial Number:\t%s\n", cr.Subject.SerialNumber)
+		w.Write(LEVEL_0, "\tCommon Name:\t%q\n", cr.Subject.CommonName)
+		w.Write(LEVEL_0, "\tSerial Number:\t%q\n", cr.Subject.SerialNumber)
 		printListHelper(w, "\t", "Organization", cr.Subject.Organization)
 		printListHelper(w, "\t", "Organizational Unit", cr.Subject.OrganizationalUnit)
 		printListHelper(w, "\t", "Country", cr.Subject.Country)

--- a/staging/src/k8s.io/kubectl/pkg/describe/describe.go
+++ b/staging/src/k8s.io/kubectl/pkg/describe/describe.go
@@ -3506,10 +3506,10 @@ func describeCertificateSigningRequest(csr metav1.ObjectMeta, signerName string,
 		w.Write(LEVEL_0, "\n")
 	}
 
-	CommonName := cr.Subject.CommonName
+	commonName := cr.Subject.CommonName
 	reg, err := regexp.Compile("[^a-zA-Z0-9: ]")
 	if err == nil {
-		CommonName = reg.ReplaceAllString(cr.Subject.CommonName, "")
+		commonName = reg.ReplaceAllString(cr.Subject.CommonName, "")
 	}
 
 	return tabbedString(func(out io.Writer) error {
@@ -3525,7 +3525,7 @@ func describeCertificateSigningRequest(csr metav1.ObjectMeta, signerName string,
 		w.Write(LEVEL_0, "Status:\t%s\n", status)
 
 		w.Write(LEVEL_0, "Subject:\n")
-		w.Write(LEVEL_0, "\tCommon Name:\t%q\n", CommonName)
+		w.Write(LEVEL_0, "\tCommon Name:\t%q\n", commonName)
 		w.Write(LEVEL_0, "\tSerial Number:\t%q\n", cr.Subject.SerialNumber)
 		printListHelper(w, "\t", "Organization", cr.Subject.Organization)
 		printListHelper(w, "\t", "Organizational Unit", cr.Subject.OrganizationalUnit)

--- a/staging/src/k8s.io/kubectl/pkg/describe/describe_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/describe/describe_test.go
@@ -4310,7 +4310,7 @@ Subject:
          Common Name:    "system:master:user1"
          Serial Number:  ""
          Organization:   "system:master"
-Events:  <none>`+"\n",
+Events:  <none>` + "\n",
 			csr: fake.NewSimpleClientset(&certificatesv1beta1.CertificateSigningRequest{
 				TypeMeta: metav1.TypeMeta{
 					APIVersion: "certificates.k8s.io/v1beta1",
@@ -4338,7 +4338,7 @@ Subject:
          Common Name:    "system:master:user1"
          Serial Number:  ""
          Organization:   "system:master"
-Events:  <none>`+"\n",
+Events:  <none>` + "\n",
 			csr: fake.NewSimpleClientset(&certificatesv1.CertificateSigningRequest{
 				TypeMeta: metav1.TypeMeta{
 					APIVersion: "certificates.k8s.io/v1",

--- a/staging/src/k8s.io/kubectl/pkg/describe/describe_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/describe/describe_test.go
@@ -4259,7 +4259,7 @@ func generatePemWithCNAndGroupTemplate(commonName string, group string) []byte {
 	// form the the certificate request template using the CN and org/group name
 	template := &x509.CertificateRequest{
 		Subject: pkix.Name{
-			CommonName: commonName,
+			CommonName:   commonName,
 			Organization: []string{group},
 		},
 	}
@@ -4275,7 +4275,7 @@ func generatePemWithCNAndGroupTemplate(commonName string, group string) []byte {
 	}
 
 	csrPemBlk := &pem.Block{
-		Type: "CERTIFICATE REQUEST",
+		Type:  "CERTIFICATE REQUEST",
 		Bytes: csr,
 	}
 
@@ -4287,30 +4287,31 @@ func generatePemWithCNAndGroupTemplate(commonName string, group string) []byte {
 	return pemKey
 }
 
-func TestV1beta1DescribeCertificateSigningRequest(t *testing.T) {
+func TestDescribeCertificateSigningRequest(t *testing.T) {
 	commonName := "system:master:user1"
 	groupName := "system:master"
 	csrRequest := generatePemWithCNAndGroupTemplate(commonName, groupName)
 	signerv1beta1 := certificatesv1beta1.KubeAPIServerClientSignerName
 	signerv1 := certificatesv1.KubeAPIServerClientSignerName
 
-	tests := [] struct {
-		expectedOutput		string
-		csr					*fake.Clientset
+	tests := []struct {
+		expectedOutput string
+		csr            *fake.Clientset
 	}{
 		{
-			expectedOutput: `Name:               user1
-Labels:             <none>
-Annotations:        <none>
-CreationTimestamp:  Mon, 01 Jan 0001 00:00:00 +0000
-Requesting User:    sample-userv1beta1
-Signer:             kubernetes.io/kube-apiserver-client
-Status:             Pending
-Subject:
-         Common Name:    "system:master:user1"
-         Serial Number:  ""
-         Organization:   "system:master"
-Events:  <none>` + "\n",
+			expectedOutput: `
+				Name:               user1
+				Labels:             <none>
+				Annotations:        <none>
+				CreationTimestamp:  Mon, 01 Jan 0001 00:00:00 +0000
+				Requesting User:    sample-userv1beta1
+				Signer:             kubernetes.io/kube-apiserver-client
+				Status:             Pending
+				Subject:
+						Common Name:    "system:master:user1"
+						Serial Number:  ""
+						Organization:   "system:master"
+				Events:  <none>` + "\n",
 			csr: fake.NewSimpleClientset(&certificatesv1beta1.CertificateSigningRequest{
 				TypeMeta: metav1.TypeMeta{
 					APIVersion: "certificates.k8s.io/v1beta1",
@@ -4327,19 +4328,20 @@ Events:  <none>` + "\n",
 			}),
 		},
 		{
-			expectedOutput: `Name:               user1
-Labels:             <none>
-Annotations:        <none>
-CreationTimestamp:  Mon, 01 Jan 0001 00:00:00 +0000
-Requesting User:    sample-userv1
-Signer:             kubernetes.io/kube-apiserver-client
-Status:             Pending
-Subject:
-         Common Name:    "system:master:user1"
-         Serial Number:  ""
-         Organization:   "system:master"
-Events:  <none>` + "\n",
-			csr : fake.NewSimpleClientset(&certificatesv1.CertificateSigningRequest{
+			expectedOutput: `
+				Name:               user1
+				Labels:             <none>
+				Annotations:        <none>
+				CreationTimestamp:  Mon, 01 Jan 0001 00:00:00 +0000
+				Requesting User:    sample-userv1
+				Signer:             kubernetes.io/kube-apiserver-client
+				Status:             Pending
+				Subject:
+						Common Name:    "system:master:user1"
+						Serial Number:  ""
+						Organization:   "system:master"
+				Events:  <none>` + "\n",
+			csr: fake.NewSimpleClientset(&certificatesv1.CertificateSigningRequest{
 				TypeMeta: metav1.TypeMeta{
 					APIVersion: "certificates.k8s.io/v1",
 					Kind:       "CertificateSigningRequest",

--- a/staging/src/k8s.io/kubectl/pkg/describe/describe_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/describe/describe_test.go
@@ -4299,19 +4299,18 @@ func TestDescribeCertificateSigningRequest(t *testing.T) {
 		csr            *fake.Clientset
 	}{
 		{
-			expectedOutput: `
-				Name:               user1
-				Labels:             <none>
-				Annotations:        <none>
-				CreationTimestamp:  Mon, 01 Jan 0001 00:00:00 +0000
-				Requesting User:    sample-userv1beta1
-				Signer:             kubernetes.io/kube-apiserver-client
-				Status:             Pending
-				Subject:
-						Common Name:    "system:master:user1"
-						Serial Number:  ""
-						Organization:   "system:master"
-				Events:  <none>` + "\n",
+			expectedOutput: `Name:               user1
+Labels:             <none>
+Annotations:        <none>
+CreationTimestamp:  Mon, 01 Jan 0001 00:00:00 +0000
+Requesting User:    sample-userv1beta1
+Signer:             kubernetes.io/kube-apiserver-client
+Status:             Pending
+Subject:
+         Common Name:    "system:master:user1"
+         Serial Number:  ""
+         Organization:   "system:master"
+Events:  <none>`+"\n",
 			csr: fake.NewSimpleClientset(&certificatesv1beta1.CertificateSigningRequest{
 				TypeMeta: metav1.TypeMeta{
 					APIVersion: "certificates.k8s.io/v1beta1",
@@ -4328,19 +4327,18 @@ func TestDescribeCertificateSigningRequest(t *testing.T) {
 			}),
 		},
 		{
-			expectedOutput: `
-				Name:               user1
-				Labels:             <none>
-				Annotations:        <none>
-				CreationTimestamp:  Mon, 01 Jan 0001 00:00:00 +0000
-				Requesting User:    sample-userv1
-				Signer:             kubernetes.io/kube-apiserver-client
-				Status:             Pending
-				Subject:
-						Common Name:    "system:master:user1"
-						Serial Number:  ""
-						Organization:   "system:master"
-				Events:  <none>` + "\n",
+			expectedOutput: `Name:               user1
+Labels:             <none>
+Annotations:        <none>
+CreationTimestamp:  Mon, 01 Jan 0001 00:00:00 +0000
+Requesting User:    sample-userv1
+Signer:             kubernetes.io/kube-apiserver-client
+Status:             Pending
+Subject:
+         Common Name:    "system:master:user1"
+         Serial Number:  ""
+         Organization:   "system:master"
+Events:  <none>`+"\n",
 			csr: fake.NewSimpleClientset(&certificatesv1.CertificateSigningRequest{
 				TypeMeta: metav1.TypeMeta{
 					APIVersion: "certificates.k8s.io/v1",
@@ -4368,8 +4366,8 @@ func TestDescribeCertificateSigningRequest(t *testing.T) {
 		}
 
 		if !reflect.DeepEqual(out, test.expectedOutput) {
-			t.Errorf("actual out:%s", out)
-			t.Errorf("Expected is : %s", test.expectedOutput)
+			t.Errorf("actual out:%#v", out)
+			t.Errorf("Expected is : %#v", test.expectedOutput)
 		}
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This PR address code changes that improves/fixes the output of `kubectl describe csr <name>` by improving/fixing the CommonName(CN) and Organization(O) fields.

**Which issue(s) this PR fixes**:
Fixes kubernetes/kubectl#888

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```


**Note to the reviewer**:
`kubectl describe csr user2`

**Output before fix:**
```
Name:         user2
Labels:       <none>
Annotations:  <none>

CreationTimestamp:  Tue, 30 Jun 2020 20:58:14 +1000
Requesting User:    minikube-user
Signer:             kubernetes.io/legacy-unknown
Status:             Pending
Subject:
  Common Name:  fool
  Organization: usergroup

  Requestor Information:
         Serial Number:  
         Organization:   system:masters
Events:  <none>
```

**Output after fix:**
```
Name:         user2
Labels:       <none>
Annotations:  <none>

CreationTimestamp:  Tue, 30 Jun 2020 20:58:14 +1000
Requesting User:    minikube-user
Signer:             kubernetes.io/legacy-unknown
Status:             Pending
Subject:
         Common Name:    "fool  Organization: usergroup  Requestor Information:"
         Serial Number:  ""
         Organization:   "system:masters"
Events:  <none>
```
