### PR TITLE
api: add port protocol default to allow use in CRDs

### DIFF
--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -1764,6 +1764,7 @@ type ContainerPort struct {
 	ContainerPort int32 `json:"containerPort" protobuf:"varint,3,opt,name=containerPort"`
 	// Protocol for port. Must be UDP, TCP, or SCTP.
 	// Defaults to "TCP".
+	// +kubebuilder:default="TCP"
 	// +optional
 	Protocol Protocol `json:"protocol,omitempty" protobuf:"bytes,4,opt,name=protocol,casttype=Protocol"`
 	// What host IP to bind the external port to.
@@ -4031,6 +4032,7 @@ type ServicePort struct {
 
 	// The IP protocol for this port. Supports "TCP", "UDP", and "SCTP".
 	// Default is TCP.
+	// +kubebuilder:default="TCP"
 	// +optional
 	Protocol Protocol `json:"protocol,omitempty" protobuf:"bytes,2,opt,name=protocol,casttype=Protocol"`
 


### PR DESCRIPTION
PodSpecs are not embeddable into CRDs today because there are optional map keys, e.g. in ports. This adds the annotation to be interpreted by controller-gen.

> /kind bug

```release-note
NONE
```