### PR TITLE
Add kubebuilder tags to Condition type

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/generated.proto
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/generated.proto
@@ -153,22 +153,32 @@ message Condition {
   // ---
   // Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
   // useful (see .node.status.conditions), the ability to deconflict is important.
+  // The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
   // +required
+  // +kubebuilder:validation:Required
+  // +kubebuilder:validation:Pattern=`^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$`
+  // +kubebuilder:validation:MaxLength=316
   optional string type = 1;
 
   // status of the condition, one of True, False, Unknown.
   // +required
+  // +kubebuilder:validation:Required
+  // +kubebuilder:validation:Enum=True;False;Unknown
   optional string status = 2;
 
   // observedGeneration represents the .metadata.generation that the condition was set based upon.
   // For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
   // with respect to the current state of the instance.
   // +optional
+  // +kubebuilder:validation:Minimum=0
   optional int64 observedGeneration = 3;
 
   // lastTransitionTime is the last time the condition transitioned from one status to another.
   // This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
   // +required
+  // +kubebuilder:validation:Required
+  // +kubebuilder:validation:Type=string
+  // +kubebuilder:validation:Format=date-time
   optional Time lastTransitionTime = 4;
 
   // reason contains a programmatic identifier indicating the reason for the condition's last transition.
@@ -177,11 +187,17 @@ message Condition {
   // The value should be a CamelCase string.
   // This field may not be empty.
   // +required
+  // +kubebuilder:validation:Required
+  // +kubebuilder:validation:MaxLength=1024
+  // +kubebuilder:validation:MinLength=1
+  // +kubebuilder:validation:Pattern=`^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$`
   optional string reason = 5;
 
   // message is a human readable message indicating details about the transition.
   // This may be an empty string.
   // +required
+  // +kubebuilder:validation:Required
+  // +kubebuilder:validation:MaxLength=32768
   optional string message = 6;
 }
 

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/types.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/types.go
@@ -1369,19 +1369,29 @@ type Condition struct {
 	// ---
 	// Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
 	// useful (see .node.status.conditions), the ability to deconflict is important.
+	// The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
 	// +required
+	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:Pattern=`^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$`
+	// +kubebuilder:validation:MaxLength=316
 	Type string `json:"type" protobuf:"bytes,1,opt,name=type"`
 	// status of the condition, one of True, False, Unknown.
 	// +required
+	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:Enum=True;False;Unknown
 	Status ConditionStatus `json:"status" protobuf:"bytes,2,opt,name=status"`
 	// observedGeneration represents the .metadata.generation that the condition was set based upon.
 	// For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
 	// with respect to the current state of the instance.
 	// +optional
+	// +kubebuilder:validation:Minimum=0
 	ObservedGeneration int64 `json:"observedGeneration,omitempty" protobuf:"varint,3,opt,name=observedGeneration"`
 	// lastTransitionTime is the last time the condition transitioned from one status to another.
 	// This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
 	// +required
+	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:Type=string
+	// +kubebuilder:validation:Format=date-time
 	LastTransitionTime Time `json:"lastTransitionTime" protobuf:"bytes,4,opt,name=lastTransitionTime"`
 	// reason contains a programmatic identifier indicating the reason for the condition's last transition.
 	// Producers of specific condition types may define expected values and meanings for this field,
@@ -1389,9 +1399,15 @@ type Condition struct {
 	// The value should be a CamelCase string.
 	// This field may not be empty.
 	// +required
+	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:MaxLength=1024
+	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:Pattern=`^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$`
 	Reason string `json:"reason" protobuf:"bytes,5,opt,name=reason"`
 	// message is a human readable message indicating details about the transition.
 	// This may be an empty string.
 	// +required
+	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:MaxLength=32768
 	Message string `json:"message" protobuf:"bytes,6,opt,name=message"`
 }

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/validation/validation.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/validation/validation.go
@@ -18,6 +18,7 @@ package validation
 
 import (
 	"fmt"
+	"regexp"
 	"unicode"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -183,4 +184,79 @@ func ValidateManagedFields(fieldsList []metav1.ManagedFieldsEntry, fldPath *fiel
 		}
 	}
 	return allErrs
+}
+
+func ValidateConditions(conditions []metav1.Condition, fldPath *field.Path) field.ErrorList {
+	var allErrs field.ErrorList
+
+	conditionTypeToFirstIndex := map[string]int{}
+	for i, condition := range conditions {
+		if _, ok := conditionTypeToFirstIndex[condition.Type]; ok {
+			allErrs = append(allErrs, field.Duplicate(fldPath.Index(i).Child("type"), condition.Type))
+		} else {
+			conditionTypeToFirstIndex[condition.Type] = i
+		}
+
+		allErrs = append(allErrs, ValidateCondition(condition, fldPath.Index(i))...)
+	}
+
+	return allErrs
+}
+
+// validConditionStatuses is used internally to check validity and provide a good message
+var validConditionStatuses = sets.NewString(string(metav1.ConditionTrue), string(metav1.ConditionFalse), string(metav1.ConditionUnknown))
+
+const (
+	maxReasonLen  = 1 * 1024
+	maxMessageLen = 32 * 1024
+)
+
+func ValidateCondition(condition metav1.Condition, fldPath *field.Path) field.ErrorList {
+	var allErrs field.ErrorList
+
+	// type is set and is a valid format
+	allErrs = append(allErrs, ValidateLabelName(condition.Type, fldPath.Child("type"))...)
+
+	// status is set and is an accepted value
+	if !validConditionStatuses.Has(string(condition.Status)) {
+		allErrs = append(allErrs, field.NotSupported(fldPath.Child("status"), condition.Status, validConditionStatuses.List()))
+	}
+
+	if condition.ObservedGeneration < 0 {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("observedGeneration"), condition.ObservedGeneration, "must be greater than or equal to zero"))
+	}
+
+	if condition.LastTransitionTime.IsZero() {
+		allErrs = append(allErrs, field.Required(fldPath.Child("lastTransitionTime"), "must be set"))
+	}
+
+	if len(condition.Reason) == 0 {
+		allErrs = append(allErrs, field.Required(fldPath.Child("reason"), "must be set"))
+	} else {
+		for _, currErr := range isValidConditionReason(condition.Reason) {
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("reason"), condition.Reason, currErr))
+		}
+		if len(condition.Reason) > maxReasonLen {
+			allErrs = append(allErrs, field.TooLong(fldPath.Child("reason"), condition.Reason, maxReasonLen))
+		}
+	}
+
+	if len(condition.Message) > maxMessageLen {
+		allErrs = append(allErrs, field.TooLong(fldPath.Child("message"), condition.Message, maxMessageLen))
+	}
+
+	return allErrs
+}
+
+const conditionReasonFmt string = "[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?"
+const conditionReasonErrMsg string = "a condition reason must start with alphabetic character, optionally followed by a string of alphanumeric characters or '_,:', and must end with an alphanumeric character or '_'"
+
+var conditionReasonRegexp = regexp.MustCompile("^" + conditionReasonFmt + "$")
+
+// isValidConditionReason tests for a string that conforms to rules for condition reasons. This checks the format, but not the length.
+func isValidConditionReason(value string) []string {
+	if !conditionReasonRegexp.MatchString(value) {
+		return []string{validation.RegexError(conditionReasonErrMsg, conditionReasonFmt, "my_name", "MY_NAME", "MyName", "ReasonA,ReasonB", "ReasonA:ReasonB")}
+	}
+	return nil
 }

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/validation/validation_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/validation/validation_test.go
@@ -293,3 +293,136 @@ func TestValidateMangedFieldsValid(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateConditions(t *testing.T) {
+	tests := []struct {
+		name         string
+		conditions   []metav1.Condition
+		validateErrs func(t *testing.T, errs field.ErrorList)
+	}{
+		{
+			name: "bunch-of-invalid-fields",
+			conditions: []metav1.Condition{{
+				Type:               ":invalid",
+				Status:             "unknown",
+				ObservedGeneration: -1,
+				LastTransitionTime: metav1.Time{},
+				Reason:             "invalid;val",
+				Message:            "",
+			}},
+			validateErrs: func(t *testing.T, errs field.ErrorList) {
+				needle := `status.conditions[0].type: Invalid value: ":invalid": name part must consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or '123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]')`
+				if !hasError(errs, needle) {
+					t.Errorf("missing %q in\n%v", needle, errorsAsString(errs))
+				}
+				needle = `status.conditions[0].status: Unsupported value: "unknown": supported values: "False", "True", "Unknown"`
+				if !hasError(errs, needle) {
+					t.Errorf("missing %q in\n%v", needle, errorsAsString(errs))
+				}
+				needle = `status.conditions[0].observedGeneration: Invalid value: -1: must be greater than or equal to zero`
+				if !hasError(errs, needle) {
+					t.Errorf("missing %q in\n%v", needle, errorsAsString(errs))
+				}
+				needle = `status.conditions[0].lastTransitionTime: Required value: must be set`
+				if !hasError(errs, needle) {
+					t.Errorf("missing %q in\n%v", needle, errorsAsString(errs))
+				}
+				needle = `status.conditions[0].reason: Invalid value: "invalid;val": a condition reason must start with alphabetic character, optionally followed by a string of alphanumeric characters or '_,:', and must end with an alphanumeric character or '_' (e.g. 'my_name',  or 'MY_NAME',  or 'MyName',  or 'ReasonA,ReasonB',  or 'ReasonA:ReasonB', regex used for validation is '[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?')`
+				if !hasError(errs, needle) {
+					t.Errorf("missing %q in\n%v", needle, errorsAsString(errs))
+				}
+			},
+		},
+		{
+			name: "duplicates",
+			conditions: []metav1.Condition{{
+				Type: "First",
+			},
+				{
+					Type: "Second",
+				},
+				{
+					Type: "First",
+				},
+			},
+			validateErrs: func(t *testing.T, errs field.ErrorList) {
+				needle := `status.conditions[2].type: Duplicate value: "First"`
+				if !hasError(errs, needle) {
+					t.Errorf("missing %q in\n%v", needle, errorsAsString(errs))
+				}
+			},
+		},
+		{
+			name: "colon-allowed-in-reason",
+			conditions: []metav1.Condition{{
+				Type:   "First",
+				Reason: "valid:val",
+			}},
+			validateErrs: func(t *testing.T, errs field.ErrorList) {
+				needle := `status.conditions[0].reason`
+				if hasPrefixError(errs, needle) {
+					t.Errorf("has %q in\n%v", needle, errorsAsString(errs))
+				}
+			},
+		},
+		{
+			name: "comma-allowed-in-reason",
+			conditions: []metav1.Condition{{
+				Type:   "First",
+				Reason: "valid,val",
+			}},
+			validateErrs: func(t *testing.T, errs field.ErrorList) {
+				needle := `status.conditions[0].reason`
+				if hasPrefixError(errs, needle) {
+					t.Errorf("has %q in\n%v", needle, errorsAsString(errs))
+				}
+			},
+		},
+		{
+			name: "reason-does-not-end-in-delimiter",
+			conditions: []metav1.Condition{{
+				Type:   "First",
+				Reason: "valid,val:",
+			}},
+			validateErrs: func(t *testing.T, errs field.ErrorList) {
+				needle := `status.conditions[0].reason: Invalid value: "valid,val:": a condition reason must start with alphabetic character, optionally followed by a string of alphanumeric characters or '_,:', and must end with an alphanumeric character or '_' (e.g. 'my_name',  or 'MY_NAME',  or 'MyName',  or 'ReasonA,ReasonB',  or 'ReasonA:ReasonB', regex used for validation is '[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?')`
+				if !hasError(errs, needle) {
+					t.Errorf("missing %q in\n%v", needle, errorsAsString(errs))
+				}
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			errs := ValidateConditions(test.conditions, field.NewPath("status").Child("conditions"))
+			test.validateErrs(t, errs)
+		})
+	}
+}
+
+func hasError(errs field.ErrorList, needle string) bool {
+	for _, curr := range errs {
+		if curr.Error() == needle {
+			return true
+		}
+	}
+	return false
+}
+
+func hasPrefixError(errs field.ErrorList, prefix string) bool {
+	for _, curr := range errs {
+		if strings.HasPrefix(curr.Error(), prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+func errorsAsString(errs field.ErrorList) string {
+	messages := []string{}
+	for _, curr := range errs {
+		messages = append(messages, curr.Error())
+	}
+	return strings.Join(messages, "\n")
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind api-change


**What this PR does / why we need it**:
This picks the changes from https://github.com/kubernetes/kubernetes/pull/92519 and adds kubebuilder validation tags for CRD generation

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Kubebuilder validation tags are set on metav1.Condition for CRD generation
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```


related to https://github.com/kubernetes/enhancements/issues/1623