### PR TITLE
Fix kubectl config set in struct pointer failure

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/navigation_step_parser.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/navigation_step_parser.go
@@ -61,7 +61,7 @@ func newNavigationSteps(path string) (*navigationSteps, error) {
 			currPartIndex += len(strings.Split(nextPart, "."))
 			currType = mapValueType
 
-		case reflect.Struct:
+		case reflect.Struct, reflect.Ptr:
 			nextPart := individualParts[currPartIndex]
 
 			options, err := getPotentialTypeValues(currType)

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/set.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/set.go
@@ -147,6 +147,9 @@ func modifyConfig(curr reflect.Value, steps *navigationSteps, propertyValue stri
 	actualCurrValue := curr
 	if curr.Kind() == reflect.Ptr {
 		actualCurrValue = curr.Elem()
+		if actualCurrValue.Kind() == reflect.Ptr {
+			actualCurrValue = actualCurrValue.Elem()
+		}
 	}
 
 	switch actualCurrValue.Kind() {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/set_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/set_test.go
@@ -54,6 +54,26 @@ func TestSetConfigCurrentContext(t *testing.T) {
 	test.run(t)
 }
 
+func TestSetConfigUserExecCommand(t *testing.T) {
+	execConfig := clientcmdapi.ExecConfig{Command: "bar"}
+	conf := clientcmdapi.Config{
+		Kind:       "Config",
+		APIVersion: "v1",
+		AuthInfos:  map[string]*clientcmdapi.AuthInfo{"foo": &clientcmdapi.AuthInfo{Exec: &execConfig}},
+	}
+	expectedConfig := *clientcmdapi.NewConfig()
+	expectedExecConfig := clientcmdapi.ExecConfig{Command: "baz"}
+	expectedConfig.AuthInfos = map[string]*clientcmdapi.AuthInfo{"foo": &clientcmdapi.AuthInfo{Exec: &expectedExecConfig}}
+	test := setConfigTest{
+		description:    "Testing for kubectl config set user exec command",
+		config:         conf,
+		args:           []string{"users.foo.exec.command", "baz"},
+		expected:       `Property "users.foo.exec.command" set.` + "\n",
+		expectedConfig: expectedConfig,
+	}
+	test.run(t)
+}
+
 func (test setConfigTest) run(t *testing.T) {
 	fakeKubeFile, err := ioutil.TempFile("", "")
 	if err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
When having a ptr type in config, like in`AuthInfo` we have `AuthProvider` and `Exec`:
```
AuthProvider *AuthProviderConfig `json:"auth-provider,omitempty"`

Exec *ExecConfig `json:"exec,omitempty"`
```
It's impossible to set values in these fields by using `kubectl config set`.

Before this PR:
```
[root@master ~]# kubectl config set users.test3.exec.command testcommand
error: unable to parse one or more field values of users.test3.exec.command
```

After this PR:
```
[root@master ~]# ./kubectl-config config set users.test3.exec.command testcommand
Property "users.test3.exec.command" set.
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubernetes/issues/92629

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fix kubectl config set in struct pointer failure.
```

