### PR TITLE
Automated cherry pick of #92537 upstream release 1.18 

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/types.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/types.go
@@ -873,6 +873,9 @@ const (
 	// FieldManagerConflict is used to report when another client claims to manage this field,
 	// It should only be returned for a request using server-side apply.
 	CauseTypeFieldManagerConflict CauseType = "FieldManagerConflict"
+	// CauseTypeResourceVersionTooLarge is used to report that the requested resource version
+	// is newer than the data observed by the API server, so the request cannot be served.
+	CauseTypeResourceVersionTooLarge CauseType = "ResourceVersionTooLarge"
 )
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/staging/src/k8s.io/apiserver/pkg/storage/errors.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/errors.go
@@ -177,7 +177,12 @@ var tooLargeResourceVersionCauseMsg = "Too large resource version"
 // a minimum resource version that is larger than the largest currently available resource version for a requested resource.
 func NewTooLargeResourceVersionError(minimumResourceVersion, currentRevision uint64, retrySeconds int) error {
 	err := errors.NewTimeoutError(fmt.Sprintf("Too large resource version: %d, current: %d", minimumResourceVersion, currentRevision), retrySeconds)
-	err.ErrStatus.Details.Causes = []metav1.StatusCause{{Message: tooLargeResourceVersionCauseMsg}}
+	err.ErrStatus.Details.Causes = []metav1.StatusCause{
+		{
+			Type:    metav1.CauseTypeResourceVersionTooLarge,
+			Message: tooLargeResourceVersionCauseMsg,
+		},
+	}
 	return err
 }
 
@@ -186,15 +191,5 @@ func IsTooLargeResourceVersion(err error) bool {
 	if !errors.IsTimeout(err) {
 		return false
 	}
-	switch t := err.(type) {
-	case errors.APIStatus:
-		if d := t.Status().Details; d != nil {
-			for _, cause := range d.Causes {
-				if cause.Message == tooLargeResourceVersionCauseMsg {
-					return true
-				}
-			}
-		}
-	}
-	return false
+	return errors.HasStatusCause(err, metav1.CauseTypeResourceVersionTooLarge)
 }


### PR DESCRIPTION
Cherry pick of #92537 on release-1.18
#92537 : Fix bug in reflector not recovering from "Too large resource version"

Fix https://github.com/kubernetes/kubernetes/issues/91073

/kind bug