### PR TITLE
[WIP] Move klog flags to k8s.io/component-base/logs

### DIFF
--- a/cmd/kubelet/app/options/BUILD
+++ b/cmd/kubelet/app/options/BUILD
@@ -36,11 +36,9 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",
         "//staging/src/k8s.io/component-base/cli/flag:go_default_library",
-        "//staging/src/k8s.io/component-base/logs:go_default_library",
         "//staging/src/k8s.io/component-base/version/verflag:go_default_library",
         "//staging/src/k8s.io/kubelet/config/v1beta1:go_default_library",
         "//vendor/github.com/spf13/pflag:go_default_library",
-        "//vendor/k8s.io/klog/v2:go_default_library",
     ] + select({
         "@io_bazel_rules_go//go/platform:android": [
             "//vendor/github.com/google/cadvisor/container/common:go_default_library",

--- a/cmd/kubelet/app/options/globalflags.go
+++ b/cmd/kubelet/app/options/globalflags.go
@@ -25,9 +25,7 @@ import (
 	"github.com/spf13/pflag"
 
 	// libs that provide registration functions
-	"k8s.io/component-base/logs"
 	"k8s.io/component-base/version/verflag"
-	"k8s.io/klog/v2"
 
 	// ensure libs have a chance to globally register their flags
 	_ "k8s.io/kubernetes/pkg/credentialprovider/azure"
@@ -38,11 +36,9 @@ import (
 // against the global flagsets from "flag" and "github.com/spf13/pflag".
 // We do this in order to prevent unwanted flags from leaking into the Kubelet's flagset.
 func AddGlobalFlags(fs *pflag.FlagSet) {
-	addKlogFlags(fs)
 	addCadvisorFlags(fs)
 	addCredentialProviderFlags(fs)
 	verflag.AddFlags(fs)
-	logs.AddFlags(fs)
 }
 
 // normalize replaces underscores with hyphens
@@ -89,11 +85,4 @@ func addCredentialProviderFlags(fs *pflag.FlagSet) {
 	pflagRegister(global, local, "azure-container-registry-config")
 
 	fs.AddFlagSet(local)
-}
-
-// addKlogFlags adds flags from k8s.io/klog
-func addKlogFlags(fs *pflag.FlagSet) {
-	local := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
-	klog.InitFlags(local)
-	fs.AddGoFlagSet(local)
 }

--- a/staging/src/k8s.io/component-base/cli/globalflag/BUILD
+++ b/staging/src/k8s.io/component-base/cli/globalflag/BUILD
@@ -6,11 +6,7 @@ go_library(
     importmap = "k8s.io/kubernetes/vendor/k8s.io/component-base/cli/globalflag",
     importpath = "k8s.io/component-base/cli/globalflag",
     visibility = ["//visibility:public"],
-    deps = [
-        "//staging/src/k8s.io/component-base/logs:go_default_library",
-        "//vendor/github.com/spf13/pflag:go_default_library",
-        "//vendor/k8s.io/klog/v2:go_default_library",
-    ],
+    deps = ["//vendor/github.com/spf13/pflag:go_default_library"],
 )
 
 go_test(

--- a/staging/src/k8s.io/component-base/cli/globalflag/globalflags.go
+++ b/staging/src/k8s.io/component-base/cli/globalflag/globalflags.go
@@ -19,32 +19,16 @@ package globalflag
 import (
 	"flag"
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/spf13/pflag"
-	"k8s.io/component-base/logs"
-	"k8s.io/klog/v2"
 )
 
-// AddGlobalFlags explicitly registers flags that libraries (klog, verflag, etc.) register
-// against the global flagsets from "flag" and "k8s.io/klog/v2".
+// AddGlobalFlags explicitly registers flags that libraries (verflag, etc.) register
+// against the global flagsets from "flag".
 // We do this in order to prevent unwanted flags from leaking into the component's flagset.
 func AddGlobalFlags(fs *pflag.FlagSet, name string) {
-	addKlogFlags(fs)
-	logs.AddFlags(fs)
-
 	fs.BoolP("help", "h", false, fmt.Sprintf("help for %s", name))
-}
-
-// addKlogFlags adds flags from k8s.io/klog
-func addKlogFlags(fs *pflag.FlagSet) {
-	local := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
-	klog.InitFlags(local)
-	local.VisitAll(func(fl *flag.Flag) {
-		fl.Name = normalize(fl.Name)
-		fs.AddGoFlag(fl)
-	})
 }
 
 // normalize replaces underscores with hyphens

--- a/staging/src/k8s.io/component-base/cli/globalflag/globalflags_test.go
+++ b/staging/src/k8s.io/component-base/cli/globalflag/globalflags_test.go
@@ -57,7 +57,7 @@ func TestAddGlobalFlags(t *testing.T) {
 	}{
 		{
 			// Happy case
-			expectedFlag:  []string{"add-dir-header", "alsologtostderr", "help", "log-backtrace-at", "log-dir", "log-file", "log-file-max-size", "log-flush-frequency", "logtostderr", "skip-headers", "skip-log-headers", "stderrthreshold", "v", "vmodule"},
+			expectedFlag:  []string{"help"},
 			matchExpected: false,
 		},
 		{

--- a/staging/src/k8s.io/component-base/logs/logs.go
+++ b/staging/src/k8s.io/component-base/logs/logs.go
@@ -17,29 +17,11 @@ limitations under the License.
 package logs
 
 import (
-	"flag"
 	"fmt"
 	"log"
-	"time"
 
-	"github.com/spf13/pflag"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
 )
-
-const logFlushFreqFlagName = "log-flush-frequency"
-
-var logFlushFreq = pflag.Duration(logFlushFreqFlagName, 5*time.Second, "Maximum number of seconds between log flushes")
-
-func init() {
-	klog.InitFlags(flag.CommandLine)
-}
-
-// AddFlags registers this package's flags on arbitrary FlagSets, such that they point to the
-// same value as the global flags.
-func AddFlags(fs *pflag.FlagSet) {
-	fs.AddFlag(pflag.Lookup(logFlushFreqFlagName))
-}
 
 // KlogWriter serves as a bridge between the standard log package and the glog package.
 type KlogWriter struct{}
@@ -55,7 +37,6 @@ func InitLogs() {
 	log.SetOutput(KlogWriter{})
 	log.SetFlags(0)
 	// The default glog flush interval is 5 seconds.
-	go wait.Forever(klog.Flush, *logFlushFreq)
 }
 
 // FlushLogs flushes logs immediately.

--- a/staging/src/k8s.io/component-base/logs/options.go
+++ b/staging/src/k8s.io/component-base/logs/options.go
@@ -19,17 +19,22 @@ package logs
 import (
 	"flag"
 	"fmt"
+	"os"
 	"strings"
+	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/spf13/pflag"
 
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
 )
 
 const (
-	logFormatFlagName = "logging-format"
-	defaultLogFormat  = "text"
+	logFormatFlagName    = "logging-format"
+	defaultLogFormat     = "text"
+	logFlushFreqFlagName = "log-flush-frequency"
+	defaultLogFlushFreq  = 5 * time.Second
 )
 
 // List of logs (k8s.io/klog + k8s.io/component-base/logs) flags supported by all logging formats
@@ -40,13 +45,15 @@ var supportedLogsFlags = map[string]struct{}{
 
 // Options has klog format parameters
 type Options struct {
-	LogFormat string
+	LogFormat         string
+	LogFlushFrequency time.Duration
 }
 
 // NewOptions return new klog options
 func NewOptions() *Options {
 	return &Options{
-		LogFormat: defaultLogFormat,
+		LogFormat:         defaultLogFormat,
+		LogFlushFrequency: defaultLogFlushFreq,
 	}
 }
 
@@ -82,6 +89,7 @@ func flagIsSet(name string) bool {
 
 // AddFlags add logging-format flag
 func (o *Options) AddFlags(fs *pflag.FlagSet) {
+	o.addKlogFlags(fs)
 	unsupportedFlags := fmt.Sprintf("--%s", strings.Join(unsupportedLoggingFlags(), ", --"))
 	formats := fmt.Sprintf(`"%s"`, strings.Join(logRegistry.List(), `", "`))
 	fs.StringVar(&o.LogFormat, logFormatFlagName, defaultLogFormat, fmt.Sprintf("Sets the log format. Permitted formats: %s.\nNon-default formats don't honor these flags: %s.\nNon-default choices are currently alpha and subject to change without warning.", formats, unsupportedFlags))
@@ -90,11 +98,22 @@ func (o *Options) AddFlags(fs *pflag.FlagSet) {
 	logRegistry.Freeze()
 }
 
+func (o *Options) addKlogFlags(fs *pflag.FlagSet) {
+	local := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+	klog.InitFlags(local)
+	local.VisitAll(func(fl *flag.Flag) {
+		fl.Name = strings.Replace(fl.Name, "_", "-", -1)
+		fs.AddGoFlag(fl)
+	})
+	fs.DurationVar(&o.LogFlushFrequency, logFlushFreqFlagName, defaultLogFlushFreq, "Maximum number of seconds between log flushes")
+}
+
 // Apply set klog logger from LogFormat type
 func (o *Options) Apply() {
 	// if log format not exists, use nil loggr
 	loggr, _ := o.Get()
 	klog.SetLogger(loggr)
+	go wait.Forever(klog.Flush, o.LogFlushFrequency)
 }
 
 // Get logger with LogFormat field
@@ -104,19 +123,8 @@ func (o *Options) Get() (logr.Logger, error) {
 
 func unsupportedLoggingFlags() []string {
 	allFlags := []string{}
-
-	// k8s.io/klog flags
-	fs := &flag.FlagSet{}
-	klog.InitFlags(fs)
-	fs.VisitAll(func(flag *flag.Flag) {
-		if _, found := supportedLogsFlags[flag.Name]; !found {
-			allFlags = append(allFlags, flag.Name)
-		}
-	})
-
-	// k8s.io/component-base/logs flags
 	pfs := &pflag.FlagSet{}
-	AddFlags(pfs)
+	NewOptions().addKlogFlags(pfs)
 	pfs.VisitAll(func(flag *pflag.Flag) {
 		if _, found := supportedLogsFlags[flag.Name]; !found {
 			allFlags = append(allFlags, flag.Name)


### PR DESCRIPTION
This idea was proposed by @sttts to unify all logging flags under same flagSet
/kind cleanup
This PR proposes implementation where we would remove klog flags from Global Flags and add them to k8s.io/component-base/logs

This PR is rebased on commit adding `--logging-format` flag. Result from calling `kube-controller-manager --help`
```
Logs flags:

      --add-dir-header                                                                                                                                                                                                                                                                                                                                      
                If true, adds the file directory to the header of the log messages
      --alsologtostderr                                                                                                                                                                                                                                                                                                                                     
                log to standard error as well as files
      --log-backtrace-at traceLocation                                                                                                                                                                                                                                                                                                                      
                when logging hits line file:N, emit a stack trace (default :0)
      --log-dir string                                                                                                                                                                                                                                                                                                                                      
                If non-empty, write log files in this directory
      --log-file string                                                                                                                                                                                                                                                                                                                                     
                If non-empty, use this log file
      --log-file-max-size uint                                                                                                                                                                                                                                                                                                                              
                Defines the maximum size a log file can grow to. Unit is megabytes. If the value is 0, the maximum file size is unlimited. (default 1800)
      --log-flush-frequency duration                                                                                                                                                                                                                                                                                                                        
                Maximum number of seconds between log flushes (default 5s)
      --logging-format string                                                                                                                                                                                                                                                                                                                               
                Sets the log format. Permitted formats: "text", "json".
                Non-default formats don't honor these flags: --add-dir-header, --alsologtostderr, --log-backtrace-at, --log-dir, --log-file, --log-file-max-size, --logtostderr, --skip-headers, --skip-log-headers, --stderrthreshold, --log-flush-frequency.
                Non-default choices are currently alpha and subject to change without warning. (default "text")
      --logtostderr                                                                                                                                                                                                                                                                                                                                         
                log to standard error instead of files (default true)
      --skip-headers                                                                                                                                                                                                                                                                                                                                        
                If true, avoid header prefixes in the log messages
      --skip-log-headers                                                                                                                                                                                                                                                                                                                                    
                If true, avoid headers when opening log files
      --stderrthreshold severity                                                                                                                                                                                                                                                                                                                            
                logs at or above this threshold go to stderr (default 2)
  -v, --v Level                                                                                                                                                                                                                                                                                                                                             
                number for the log level verbosity
      --vmodule moduleSpec                                                                                                                                                                                                                                                                                                                                  
                comma-separated list of pattern=N settings for file-filtered logging

Misc flags:

      --kubeconfig string                                                                                                                                                                                                                                                                                                                                   
                Path to kubeconfig file with authorization and master location information.
      --master string                                                                                                                                                                                                                                                                                                                                       
                The address of the Kubernetes API server (overrides any value in kubeconfig).

Global flags:

  -h, --help                                                                                                                                                                                                                                                                                                                                                
                help for kube-controller-manager
      --version version[=true]                                                                                                                                                                                                                                                                                                                              
                Print version information and quit
```


```release-note
Move klog flags from Global flags group to Logs flags
```