### PR TITLE
Renamed image "white lists" to pre-pull image lists in test

### DIFF
--- a/test/e2e/common/util.go
+++ b/test/e2e/common/util.go
@@ -60,7 +60,7 @@ var CurrentSuite Suite
 // PrePulledImages are a list of images used in e2e/common tests. These images should be prepulled
 // before tests starts, so that the tests won't fail due image pulling flakes.
 // Currently, this is only used by node e2e test.
-// See also updateImageWhiteList() in ../../e2e_node/image_list.go
+// See also updateImageAllowList() in ../../e2e_node/image_list.go
 // TODO(random-liu): Change the image puller pod to use similar mechanism.
 var PrePulledImages = sets.NewString(
 	imageutils.GetE2EImage(imageutils.Agnhost),

--- a/test/e2e/framework/pods.go
+++ b/test/e2e/framework/pods.go
@@ -57,10 +57,10 @@ const (
 	forbiddenReason = "SysctlForbidden"
 )
 
-// ImageWhiteList is the images used in the current test suite. It should be initialized in test suite and
-// the images in the white list should be pre-pulled in the test suite.  Currently, this is only used by
+// ImagePrePullList is the images used in the current test suite. It should be initialized in test suite and
+// the images in the list should be pre-pulled in the test suite.  Currently, this is only used by
 // node e2e test.
-var ImageWhiteList sets.String
+var ImagePrePullList sets.String
 
 // PodClient is a convenience method for getting a pod client interface in the framework's namespace,
 // possibly applying test-suite specific transformations to the pod spec, e.g. for
@@ -187,7 +187,7 @@ func (c *PodClient) mungeSpec(pod *v1.Pod) {
 		}
 		// If the image policy is not PullAlways, the image must be in the pre-pull list and
 		// pre-pulled.
-		gomega.Expect(ImageWhiteList.Has(c.Image)).To(gomega.BeTrue(), "Image %q is not in the white list, consider adding it to CommonImageWhiteList in test/e2e/common/util.go or NodePrePullImageList in test/e2e_node/image_list.go", c.Image)
+		gomega.Expect(ImagePrePullList.Has(c.Image)).To(gomega.BeTrue(), "Image %q is not in the pre-pull list, consider adding it to PrePulledImages in test/e2e/common/util.go or NodePrePullImageList in test/e2e_node/image_list.go", c.Image)
 		// Do not pull images during the tests because the images in pre-pull list should have
 		// been prepulled.
 		c.ImagePullPolicy = v1.PullNever

--- a/test/e2e_node/e2e_node_suite_test.go
+++ b/test/e2e_node/e2e_node_suite_test.go
@@ -179,7 +179,7 @@ var _ = ginkgo.SynchronizedBeforeSuite(func() []byte {
 	// This helps with debugging test flakes since it is hard to tell when a test failure is due to image pulling.
 	if framework.TestContext.PrepullImages {
 		klog.Infof("Pre-pulling images so that they are cached for the tests.")
-		updateImageWhiteList()
+		updateImageAllowList()
 		err := PrePullAllImages()
 		gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 	}
@@ -279,7 +279,7 @@ func waitForNodeReady() {
 // update test context with node configuration.
 func updateTestContext() error {
 	setExtraEnvs()
-	updateImageWhiteList()
+	updateImageAllowList()
 
 	client, err := getAPIServerClient()
 	if err != nil {

--- a/test/e2e_node/image_list.go
+++ b/test/e2e_node/image_list.go
@@ -61,16 +61,16 @@ var NodePrePullImageList = sets.NewString(
 	"gcr.io/kubernetes-e2e-test-images/node-perf/tf-wide-deep-amd64:1.0",
 )
 
-// updateImageWhiteList updates the framework.ImageWhiteList with
+// updateImageAllowList updates the framework.ImagePrePullList with
 // 1. the hard coded lists
 // 2. the ones passed in from framework.TestContext.ExtraEnvs
 // So this function needs to be called after the extra envs are applied.
-func updateImageWhiteList() {
-	// Union NodePrePullImageList and CommonImageWhiteList into the framework image pre-pull list.
-	framework.ImageWhiteList = NodePrePullImageList.Union(commontest.PrePulledImages)
+func updateImageAllowList() {
+	// Union NodePrePullImageList and PrePulledImages into the framework image pre-pull list.
+	framework.ImagePrePullList = NodePrePullImageList.Union(commontest.PrePulledImages)
 	// Images from extra envs
-	framework.ImageWhiteList.Insert(getNodeProblemDetectorImage())
-	framework.ImageWhiteList.Insert(getSRIOVDevicePluginImage())
+	framework.ImagePrePullList.Insert(getNodeProblemDetectorImage())
+	framework.ImagePrePullList.Insert(getSRIOVDevicePluginImage())
 }
 
 func getNodeProblemDetectorImage() string {
@@ -149,7 +149,7 @@ func PrePullAllImages() error {
 	if err != nil {
 		return err
 	}
-	images := framework.ImageWhiteList.List()
+	images := framework.ImagePrePullList.List()
 	klog.V(4).Infof("Pre-pulling images with %s %+v", puller.Name(), images)
 	for _, image := range images {
 		var (


### PR DESCRIPTION
Signed-off-by: alejandrox1 <alarcj137@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind cleanup


**What this PR does / why we need it**:
In the spirit of #90277
xref #92317

> Associating "white" with good/allowed and "black" with bad/disallowed cannot be disentangled from systemic racism. In contrast, allowlist and denylist exactly and merely describe the functions of these fields and variables.

I wanted to propose this change to the e2e node code to get the conversation started and try to improve the naming conventions we use throughout the codebase.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
