### PR TITLE
Add label selector value validation

### DIFF
--- a/pkg/apis/apps/validation/validation_test.go
+++ b/pkg/apis/apps/validation/validation_test.go
@@ -2141,6 +2141,26 @@ func TestValidateDeployment(t *testing.T) {
 	}}
 	errorCases["ephemeral containers not allowed"] = invalidEphemeralContainersDeployment
 
+	invalidAntiAffinity := validDeployment()
+	invalidAntiAffinity.Spec.Template.Spec.Affinity = &api.Affinity{
+		PodAntiAffinity: &api.PodAntiAffinity{
+			PreferredDuringSchedulingIgnoredDuringExecution: []api.WeightedPodAffinityTerm{
+				{
+					Weight: 100,
+					PodAffinityTerm: api.PodAffinityTerm{
+						TopologyKey: "kubernetes.io/hostname",
+						LabelSelector: &metav1.LabelSelector{
+							MatchExpressions: []metav1.LabelSelectorRequirement{
+								{Key: "app.kubernetes.io/instance", Operator: metav1.LabelSelectorOpIn, Values: []string{"{{ .Release.Name }}"}},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	errorCases["a valid label must be an empty string or consist of alphanumeric characters"] = invalidAntiAffinity
+
 	for k, v := range errorCases {
 		errs := ValidateDeployment(v)
 		if len(errs) == 0 {

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/validation/validation.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/validation/validation.go
@@ -45,6 +45,12 @@ func ValidateLabelSelectorRequirement(sr metav1.LabelSelectorRequirement, fldPat
 	case metav1.LabelSelectorOpIn, metav1.LabelSelectorOpNotIn:
 		if len(sr.Values) == 0 {
 			allErrs = append(allErrs, field.Required(fldPath.Child("values"), "must be specified when `operator` is 'In' or 'NotIn'"))
+		} else {
+			for _, v := range sr.Values {
+				for _, msg := range validation.IsValidLabelValue(v) {
+					allErrs = append(allErrs, field.Invalid(fldPath, v, msg))
+				}
+			}
 		}
 	case metav1.LabelSelectorOpExists, metav1.LabelSelectorOpDoesNotExist:
 		if len(sr.Values) > 0 {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Deployments (and pods) are currently able to be created even if they set labelselectors with invalid values. This causes undefined behavior that is inconsistent across versions and usually presents as a "scheduler" bug (when the scheduler affinity plugins fail to parse the invalid selector and return an error)

For example, currently if you try to create a pod with a preferred antiaffinity and an invalid selector, the scheduler assumes an invalid selector will never be created and [throws away the error](https://github.com/kubernetes/kubernetes/blob/ff1d6b3746d8586090d6909079005aecb3019f03/pkg/scheduler/framework/v1alpha1/types.go#L129-L132), essentially scheduling the pod without any affinity.

In 1.18, the scheduler fails to schedule the invalid pod (but really, this is only by chance). During `PreScore` affinity calculations for the pod it calls `LabelSelectorAsSelector` and throws out the error, failing to store a PreScore cycle state. The scheduling cycle then actually continues, and only fails because the `Score` plugin does not find the PreScore state.

From what I can tell, this issue goes back at least as far as 1.11, which has the weirdest behavior. In that version, the scheduler successfully schedules the pods and then every *new* pod after that fails with the error that it has an invalid label selector (even if the new pods have no selector). This is because the scheduler used to parse existing pod's affinity labels, but not incoming pod's labels.

Of course we probably don't need to backport this fix all the way to 1.11, but it shows that this has been a longstanding issue. Ultimately there is a standard regex for label values and pods should not be created if they violate this. It is only by luck that the errors are currently "caught" by the scheduler, and as seen here refactors of the scheduling plugins may eliminate any handling of these errors (this is currently the case).

This is the output of this change:
```
$ cat ~/hello-pod.yaml 
apiVersion: apps/v1
kind: Deployment
metadata:
  name: hello-pod
  labels:
    app: hello-pod
spec:
  replicas: 2
  selector:
    matchLabels:
      app: hello-pod
  template:
    metadata:
      labels:
        app: hello-pod
      name: hello-pod
    spec:
      affinity:
        podAntiAffinity:
          preferredDuringSchedulingIgnoredDuringExecution:
            - podAffinityTerm:
                labelSelector:
                  matchExpressions:
                    - key: app.kubernetes.io/instance
                      operator: In
                      values:
                        - '{{ .Release.Name }}'
                topologyKey: kubernetes.io/hostname
              weight: 100
      containers:
        - image: "docker.io/ocpqe/hello-pod"
          name: hello-pod
$ kubectl create -f ~/hello-pod.yaml 
The Deployment "hello-pod" is invalid: spec.template.spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].podAffinityTerm.matchExpressions.matchExpressions[0]: Invalid value: "{{ .Release.Name }}": a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyValue',  or 'my_value',  or '12345', regex used for validation is '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?')
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Label selector values are now validated at creation time
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/sig scheduling
