### PR TITLE
[kubeadm]: Remove kube-dns translation for federation

### DIFF
--- a/cmd/kubeadm/app/phases/addons/dns/dns_test.go
+++ b/cmd/kubeadm/app/phases/addons/dns/dns_test.go
@@ -139,9 +139,8 @@ func TestCompileManifests(t *testing.T) {
 		{
 			name:     "CoreDNSConfigMap manifest",
 			manifest: CoreDNSConfigMap,
-			data: struct{ DNSDomain, Federation, UpstreamNameserver, StubDomain string }{
+			data: struct{ DNSDomain, UpstreamNameserver, StubDomain string }{
 				DNSDomain:          "foo",
-				Federation:         "foo",
 				UpstreamNameserver: "foo",
 				StubDomain:         "foo",
 			},
@@ -491,80 +490,6 @@ func TestTranslateUpstreamKubeDNSToCoreDNS(t *testing.T) {
 			}
 			if !strings.EqualFold(out, testCase.expect) {
 				t.Errorf("expected to find %q in output: %q", testCase.expect, out)
-			}
-		})
-	}
-}
-
-func TestTranslateFederationKubeDNSToCoreDNS(t *testing.T) {
-	testCases := []struct {
-		name      string
-		configMap *v1.ConfigMap
-		expectOne string
-		expectTwo string
-	}{
-		{
-			name: "valid call",
-			configMap: &v1.ConfigMap{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "kube-dns",
-					Namespace: "kube-system",
-				},
-				Data: map[string]string{
-					"federations":         `{"foo" : "foo.feddomain.com", "bar" : "bar.feddomain.com"}`,
-					"stubDomains":         `{"foo.com" : ["1.2.3.4:5300","3.3.3.3"], "my.cluster.local" : ["2.3.4.5"]}`,
-					"upstreamNameservers": `["8.8.8.8", "8.8.4.4"]`,
-				},
-			},
-
-			expectOne: `
-        federation cluster.local {
-           foo foo.feddomain.com
-           bar bar.feddomain.com
-        }`,
-			expectTwo: `
-        federation cluster.local {
-           bar bar.feddomain.com
-           foo foo.feddomain.com
-        }`,
-		},
-		{
-			name: "empty data",
-			configMap: &v1.ConfigMap{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "kubedns",
-					Namespace: "kube-system",
-				},
-			},
-
-			expectOne: "",
-			expectTwo: "",
-		},
-		{
-			name: "missing federations data",
-			configMap: &v1.ConfigMap{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "kube-dns",
-					Namespace: "kube-system",
-				},
-				Data: map[string]string{
-					"stubDomains":         `{"foo.com" : ["1.2.3.4:5300"], "my.cluster.local" : ["2.3.4.5"]}`,
-					"upstreamNameservers": `["8.8.8.8", "8.8.4.4"]`,
-				},
-			},
-
-			expectOne: "",
-			expectTwo: "",
-		},
-	}
-	for _, testCase := range testCases {
-		t.Run(testCase.name, func(t *testing.T) {
-			out, err := translateFederationsofKubeDNSToCoreDNS(kubeDNSFederation, "cluster.local", testCase.configMap)
-			if err != nil {
-				t.Errorf("unexpected error: %v", err)
-			}
-			if !strings.EqualFold(out, testCase.expectOne) && !strings.EqualFold(out, testCase.expectTwo) {
-				t.Errorf("expected to find %q or %q in output: %q", testCase.expectOne, testCase.expectTwo, out)
 			}
 		})
 	}

--- a/cmd/kubeadm/app/phases/addons/dns/manifests.go
+++ b/cmd/kubeadm/app/phases/addons/dns/manifests.go
@@ -318,7 +318,7 @@ data:
            pods insecure
            fallthrough in-addr.arpa ip6.arpa
            ttl 30
-        }{{ .Federation }}
+        }
         prometheus :9153
         forward . {{ .UpstreamNameserver }}
         cache 30

--- a/cmd/kubeadm/app/phases/upgrade/preflight.go
+++ b/cmd/kubeadm/app/phases/upgrade/preflight.go
@@ -17,12 +17,15 @@ limitations under the License.
 package upgrade
 
 import (
+	"context"
 	"fmt"
 	"os"
 
 	"github.com/coredns/corefile-migration/migration"
 	"github.com/pkg/errors"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
@@ -68,6 +71,11 @@ func RunCoreDNSMigrationCheck(client clientset.Interface, ignorePreflightErrors 
 			client: client,
 			f:      checkMigration,
 		},
+		&CoreDNSCheck{
+			name:   "kubeDNSTranslation",
+			client: client,
+			f:      checkKubeDNSConfigMap,
+		},
 	}
 
 	return preflight.RunChecks(migrationChecks, os.Stderr, ignorePreflightErrors)
@@ -111,6 +119,24 @@ func checkMigration(client clientset.Interface) error {
 	_, err = migration.Migrate(currentInstalledCoreDNSversion, kubeadmconstants.CoreDNSVersion, corefile, false)
 	if err != nil {
 		return errors.Wrap(err, "CoreDNS will not be upgraded")
+	}
+	return nil
+}
+
+// checkKubeDNSConfigMap checks if the translation of kube-dns to CoreDNS ConfigMap is supported
+func checkKubeDNSConfigMap(client clientset.Interface) error {
+	kubeDNSConfigMap, err := client.CoreV1().ConfigMaps(metav1.NamespaceSystem).Get(context.TODO(), kubeadmconstants.KubeDNSConfigMap, metav1.GetOptions{})
+	if err != nil && !apierrors.IsNotFound(err) {
+		return err
+	}
+	if kubeDNSConfigMap == nil {
+		return nil
+	}
+
+	if _, ok := kubeDNSConfigMap.Data["federations"]; ok {
+		klog.V(1).Infoln("CoreDNS no longer supports Federation and " +
+			"hence will not translate the federation data from kube-dns to CoreDNS ConfigMap")
+		return errors.Wrap(err, "kube-dns Federation data will not be translated")
 	}
 	return nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Following https://github.com/kubernetes/kubernetes/pull/92651 which upgrades CoreDNS to v1.7.0, CoreDNS no longer supports Federation. 
This PR removes the translation logic from kube-dns to CoreDNS ConfigMap for Federation data.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
Since kube-dns has been deprecated in kubeadm, this should not affect users (or kubeadm), but for safety I have included a preflight check to just warn any users who might be depending on this.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
CoreDNS will no longer be supporting Federation data translation for kube-dns ConfigMap
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
