### PR TITLE
[kube-up]: Bump CoreDNS to v1.7.0

### DIFF
--- a/build/dependencies.yaml
+++ b/build/dependencies.yaml
@@ -12,7 +12,7 @@ dependencies:
       match: cniVersion[\t\n\f\r ]*=
 
   - name: "coredns-kube-up"
-    version: 1.6.7
+    version: 1.7.0
     refPaths:
     - path: cluster/addons/dns/coredns/coredns.yaml.base
       match: k8s.gcr.io/coredns

--- a/cluster/addons/dns/coredns/coredns.yaml.base
+++ b/cluster/addons/dns/coredns/coredns.yaml.base
@@ -73,7 +73,9 @@ data:
             ttl 30
         }
         prometheus :9153
-        forward . /etc/resolv.conf
+        forward . /etc/resolv.conf {
+            max_concurrent 1000
+        }
         cache 30
         loop
         reload
@@ -118,7 +120,7 @@ spec:
         kubernetes.io/os: linux
       containers:
       - name: coredns
-        image: k8s.gcr.io/coredns:1.6.7
+        image: k8s.gcr.io/coredns:1.7.0
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/cluster/addons/dns/coredns/coredns.yaml.in
+++ b/cluster/addons/dns/coredns/coredns.yaml.in
@@ -73,7 +73,9 @@ data:
             ttl 30
         }
         prometheus :9153
-        forward . /etc/resolv.conf
+        forward . /etc/resolv.conf {
+            max_concurrent 1000
+        }
         cache 30
         loop
         reload
@@ -118,7 +120,7 @@ spec:
         kubernetes.io/os: linux
       containers:
       - name: coredns
-        image: k8s.gcr.io/coredns:1.6.7
+        image: k8s.gcr.io/coredns:1.7.0
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/cluster/addons/dns/coredns/coredns.yaml.sed
+++ b/cluster/addons/dns/coredns/coredns.yaml.sed
@@ -73,7 +73,9 @@ data:
             ttl 30
         }
         prometheus :9153
-        forward . /etc/resolv.conf
+        forward . /etc/resolv.conf {
+            max_concurrent 1000
+        }
         cache 30
         loop
         reload
@@ -118,7 +120,7 @@ spec:
         kubernetes.io/os: linux
       containers:
       - name: coredns
-        image: k8s.gcr.io/coredns:1.6.7
+        image: k8s.gcr.io/coredns:1.7.0
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/cluster/gce/upgrade.sh
+++ b/cluster/gce/upgrade.sh
@@ -477,35 +477,35 @@ function update-coredns-config() {
   case "$(uname -m)" in
       x86_64*)
         host_arch=amd64
-        corefile_tool_SHA="b902651aa26434f9aa087cadb634a1c26e9808571d48241e4d3c4ecf21a773ff"
+        corefile_tool_SHA="2e1da3d2a27e103597438ccc99be5cf909fd1be038c4770ddac3985e7df18fa2"
         ;;
       i?86_64*)
         host_arch=amd64
-        corefile_tool_SHA="b902651aa26434f9aa087cadb634a1c26e9808571d48241e4d3c4ecf21a773ff"
+        corefile_tool_SHA="2e1da3d2a27e103597438ccc99be5cf909fd1be038c4770ddac3985e7df18fa2"
         ;;
       amd64*)
         host_arch=amd64
-        corefile_tool_SHA="b902651aa26434f9aa087cadb634a1c26e9808571d48241e4d3c4ecf21a773ff"
+        corefile_tool_SHA="2e1da3d2a27e103597438ccc99be5cf909fd1be038c4770ddac3985e7df18fa2"
         ;;
       aarch64*)
         host_arch=arm64
-        corefile_tool_SHA="d8be194de0f430e364da9de148693b11bcbaf31751f6aa77ea2c8a4e2418503a"
+        corefile_tool_SHA="12a08dfa9f01b806ab46902c1e6c909fdf93264f8c6aac3d951e7ac30d9c7f9b"
         ;;
       arm64*)
         host_arch=arm64
-        corefile_tool_SHA="d8be194de0f430e364da9de148693b11bcbaf31751f6aa77ea2c8a4e2418503a"
+        corefile_tool_SHA="12a08dfa9f01b806ab46902c1e6c909fdf93264f8c6aac3d951e7ac30d9c7f9b"
         ;;
       arm*)
         host_arch=arm
-        corefile_tool_SHA="d7ba2ebe740382ed7c5f00bc00eda3d383b2bbbe3554ffb12b912946d28ceb59"
+        corefile_tool_SHA="b5d83f5e29a2900cc345de8e7b5b25c4e5534e57d61bf52395343d76e64026e3"
         ;;
       s390x*)
         host_arch=s390x
-        corefile_tool_SHA="77eac119aef08fcf1541f3594138838fbfe4669e309b20d530247dff408a67c0"
+        corefile_tool_SHA="29754c9966f5215260562eed1db1017e86462dbaba1c0ee9801f0f9cdae3bd2f"
         ;;
       ppc64le*)
         host_arch=ppc64le
-         corefile_tool_SHA="f1bd00d9f3846c3fbedb4dd53fd61c5daf6d09a75c0d24fe8744f4f7b7252acb"
+        corefile_tool_SHA="c4271ddc80345ed7b3a3d41b706c5c7abb4ad6a3e3e9f20fe8849699e399adc8"
         ;;
       *)
         echo "Unsupported host arch. Must be x86_64, 386, arm, arm64, s390x or ppc64le." >&2
@@ -515,7 +515,7 @@ function update-coredns-config() {
 
   # Download the CoreDNS migration tool
   echo "== Downloading the CoreDNS migration tool =="
-  wget -P "${download_dir}" "https://github.com/coredns/corefile-migration/releases/download/v1.0.6/corefile-tool-${host_arch}" >/dev/null 2>&1
+  wget -P "${download_dir}" "https://github.com/coredns/corefile-migration/releases/download/v1.0.10/corefile-tool-${host_arch}" >/dev/null 2>&1
 
   local -r checkSHA=$(sha256sum "${download_dir}/corefile-tool-${host_arch}" | cut -d " " -f 1)
   if [[ "${checkSHA}" != "${corefile_tool_SHA}" ]]; then


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Updates CoreDNS to v1.7.0. The default Corefile now includes the max_concurrent option, which sets the maximum number of concurrent upstream queries allowed by the forward plugin.

Also updates the migration library to 1.0.10 which supports coredns v1.7.0
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Kube-up now includes CoreDNS version v1.7.0. Some of the major changes include:
-  Fixed a bug that could cause CoreDNS to stop updating service records.
-  Fixed a bug in the forward plugin where only the first upstream server is always selected no matter which policy is set.
-  Remove already deprecated options `resyncperiod` and `upstream` in the Kubernetes plugin.
-  Includes Prometheus metrics name changes (to bring them in line with standard Prometheus metrics naming convention). They will be backward incompatible with existing reporting formulas that use the old metrics' names.
-  The federation plugin (allows for v1 Kubernetes federation) has been removed.
More details are available in https://coredns.io/2020/06/15/coredns-1.7.0-release/
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
