### PR TITLE
Promote Event CRUD tests to conformance

### DIFF
--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -1491,6 +1491,21 @@
     the replicaset to 2. Number of running instances of the Pod MUST be 2.
   release: v1.9
   file: test/e2e/kubectl/kubectl.go
+- testname: New Event resource lifecycle, testing a list of events
+  codename: '[sig-instrumentation] Events API should delete a collection of events
+    [Conformance]'
+  description: Create a list of events, the events MUST exist. The events are deleted
+    and MUST NOT show up when listing all events.
+  release: v1.19
+  file: test/e2e/instrumentation/events.go
+- testname: New Event resource lifecycle, testing a single event
+  codename: '[sig-instrumentation] Events API should ensure that an event can be fetched,
+    patched, deleted, and listed [Conformance]'
+  description: Create an event, the event MUST exist. The event is patched with a
+    new note, the check MUST have the update note. The event is deleted and MUST NOT
+    show up when listing all events.
+  release: v1.19
+  file: test/e2e/instrumentation/events.go
 - testname: DNS, cluster
   codename: '[sig-network] DNS should provide /etc/hosts entries for the cluster [LinuxOnly]
     [Conformance]'

--- a/test/e2e/instrumentation/events.go
+++ b/test/e2e/instrumentation/events.go
@@ -86,12 +86,12 @@ var _ = common.SIGDescribe("Events API", func() {
 
 	/*
 		Release : v1.19
-		Testname: Event resource lifecycle
+		Testname: New Event resource lifecycle, testing a single event
 		Description: Create an event, the event MUST exist.
 		The event is patched with a new note, the check MUST have the update note.
 		The event is deleted and MUST NOT show up when listing all events.
 	*/
-	ginkgo.It("should ensure that an event can be fetched, patched, deleted, and listed", func() {
+	framework.ConformanceIt("should ensure that an event can be fetched, patched, deleted, and listed", func() {
 		eventName := "event-test"
 
 		ginkgo.By("creating a test event")
@@ -160,7 +160,13 @@ var _ = common.SIGDescribe("Events API", func() {
 		framework.ExpectEqual(foundCreatedEvent, false, "should not have found test event after deletion")
 	})
 
-	ginkgo.It("should delete a collection of events", func() {
+	/*
+		Release : v1.19
+		Testname: New Event resource lifecycle, testing a list of events
+		Description: Create a list of events, the events MUST exist.
+		The events are deleted and MUST NOT show up when listing all events.
+	*/
+	framework.ConformanceIt("should delete a collection of events", func() {
 		eventNames := []string{"test-event-1", "test-event-2", "test-event-3"}
 
 		ginkgo.By("Create set of events")


### PR DESCRIPTION
**What type of PR is this?**

/kind api-change

**What this PR does / why we need it**:

The new Event API has been graduated to v1, now its CRUD tests should also be promoted to conformance.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs
- [KEP]: <https://github.com/kubernetes/enhancements/tree/master/keps/sig-instrumentation/383-new-event-api-ga-graduation>
```
