### PR TITLE
update security contacts for apimachinery repos

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/SECURITY_CONTACTS
+++ b/staging/src/k8s.io/apiextensions-apiserver/SECURITY_CONTACTS
@@ -10,9 +10,7 @@
 # DO NOT REPORT SECURITY VULNERABILITIES DIRECTLY TO THESE NAMES, FOLLOW THE
 # INSTRUCTIONS AT https://kubernetes.io/security/
 
-cjcullen
-joelsmith
-liggitt
-philips
+cheftako
+deads2k
+lavalamp
 sttts
-tallclair

--- a/staging/src/k8s.io/apimachinery/SECURITY_CONTACTS
+++ b/staging/src/k8s.io/apimachinery/SECURITY_CONTACTS
@@ -10,9 +10,7 @@
 # DO NOT REPORT SECURITY VULNERABILITIES DIRECTLY TO THESE NAMES, FOLLOW THE
 # INSTRUCTIONS AT https://kubernetes.io/security/
 
-cjcullen
-joelsmith
-liggitt
-philips
+cheftako
+deads2k
+lavalamp
 sttts
-tallclair

--- a/staging/src/k8s.io/apiserver/SECURITY_CONTACTS
+++ b/staging/src/k8s.io/apiserver/SECURITY_CONTACTS
@@ -10,9 +10,7 @@
 # DO NOT REPORT SECURITY VULNERABILITIES DIRECTLY TO THESE NAMES, FOLLOW THE
 # INSTRUCTIONS AT https://kubernetes.io/security/
 
-cjcullen
-joelsmith
-liggitt
-philips
+cheftako
+deads2k
+lavalamp
 sttts
-tallclair

--- a/staging/src/k8s.io/client-go/SECURITY_CONTACTS
+++ b/staging/src/k8s.io/client-go/SECURITY_CONTACTS
@@ -10,9 +10,7 @@
 # DO NOT REPORT SECURITY VULNERABILITIES DIRECTLY TO THESE NAMES, FOLLOW THE
 # INSTRUCTIONS AT https://kubernetes.io/security/
 
-cjcullen
-joelsmith
-liggitt
-philips
+caesarxuchao
+deads2k
+lavalamp
 sttts
-tallclair

--- a/staging/src/k8s.io/code-generator/SECURITY_CONTACTS
+++ b/staging/src/k8s.io/code-generator/SECURITY_CONTACTS
@@ -10,9 +10,7 @@
 # DO NOT REPORT SECURITY VULNERABILITIES DIRECTLY TO THESE NAMES, FOLLOW THE
 # INSTRUCTIONS AT https://kubernetes.io/security/
 
-cjcullen
-joelsmith
-liggitt
-philips
+cheftako
+deads2k
+lavalamp
 sttts
-tallclair

--- a/staging/src/k8s.io/kube-aggregator/SECURITY_CONTACTS
+++ b/staging/src/k8s.io/kube-aggregator/SECURITY_CONTACTS
@@ -10,9 +10,7 @@
 # DO NOT REPORT SECURITY VULNERABILITIES DIRECTLY TO THESE NAMES, FOLLOW THE
 # INSTRUCTIONS AT https://kubernetes.io/security/
 
-cjcullen
-joelsmith
-liggitt
-philips
+cheftako
+deads2k
+lavalamp
 sttts
-tallclair

--- a/staging/src/k8s.io/sample-apiserver/SECURITY_CONTACTS
+++ b/staging/src/k8s.io/sample-apiserver/SECURITY_CONTACTS
@@ -10,9 +10,7 @@
 # DO NOT REPORT SECURITY VULNERABILITIES DIRECTLY TO THESE NAMES, FOLLOW THE
 # INSTRUCTIONS AT https://kubernetes.io/security/
 
-cjcullen
-joelsmith
-liggitt
-philips
+cheftako
+deads2k
+lavalamp
 sttts
-tallclair

--- a/staging/src/k8s.io/sample-controller/SECURITY_CONTACTS
+++ b/staging/src/k8s.io/sample-controller/SECURITY_CONTACTS
@@ -10,9 +10,7 @@
 # DO NOT REPORT SECURITY VULNERABILITIES DIRECTLY TO THESE NAMES, FOLLOW THE
 # INSTRUCTIONS AT https://kubernetes.io/security/
 
-cjcullen
-joelsmith
-liggitt
-philips
+cheftako
+deads2k
+lavalamp
 sttts
-tallclair


### PR DESCRIPTION
fixes https://github.com/kubernetes/kubernetes/issues/92084
fixes https://github.com/kubernetes/kubernetes/issues/92085
fixes https://github.com/kubernetes/kubernetes/issues/92087
fixes https://github.com/kubernetes/kubernetes/issues/92088
fixes https://github.com/kubernetes/kubernetes/issues/92091
fixes https://github.com/kubernetes/kubernetes/issues/92095
fixes https://github.com/kubernetes/kubernetes/issues/92103
fixes https://github.com/kubernetes/kubernetes/issues/92105

@lavalamp let's tweak from here.  I knew Chao for client-go, but I wasn't sure how you wanted to apportion the rest or if these contacts were good enough since we will know the names of individuals we need.

/kind bug
/priority important-soon
@kubernetes/sig-api-machinery-api-reviews 
/assign @lavalamp 

```release-note
NONE
```


