### PR TITLE
make Kubelet bootstrap certificate signal aware

### DIFF
--- a/pkg/kubelet/certificate/bootstrap/bootstrap_test.go
+++ b/pkg/kubelet/certificate/bootstrap/bootstrap_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package bootstrap
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -95,7 +96,7 @@ users:
 }
 
 func TestRequestNodeCertificateNoKeyData(t *testing.T) {
-	certData, err := requestNodeCertificate(newClientset(fakeClient{}), []byte{}, "fake-node-name")
+	certData, err := requestNodeCertificate(context.TODO(), newClientset(fakeClient{}), []byte{}, "fake-node-name")
 	if err == nil {
 		t.Errorf("Got no error, wanted error an error because there was an empty private key passed in.")
 	}
@@ -113,7 +114,7 @@ func TestRequestNodeCertificateErrorCreatingCSR(t *testing.T) {
 		t.Fatalf("Unable to generate a new private key: %v", err)
 	}
 
-	certData, err := requestNodeCertificate(client, privateKeyData, "fake-node-name")
+	certData, err := requestNodeCertificate(context.TODO(), client, privateKeyData, "fake-node-name")
 	if err == nil {
 		t.Errorf("Got no error, wanted error an error because client.Create failed.")
 	}
@@ -128,7 +129,7 @@ func TestRequestNodeCertificate(t *testing.T) {
 		t.Fatalf("Unable to generate a new private key: %v", err)
 	}
 
-	certData, err := requestNodeCertificate(newClientset(fakeClient{}), privateKeyData, "fake-node-name")
+	certData, err := requestNodeCertificate(context.TODO(), newClientset(fakeClient{}), privateKeyData, "fake-node-name")
 	if err != nil {
 		t.Errorf("Got %v, wanted no error.", err)
 	}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

When I work on #92727, I found Kubelet is not signal aware when bootstrapping certificate. Which means we can only use twice signal to kill Kubelet(through os.Exit(1)) when the certificate bootstrap is in progress. However, when kube-controller-manager or connection to kube-apiserver has some problem, the progress of certificate bootstrap may take a little long time.

**Which issue(s) this PR fixes**:

None

**Special notes for your reviewer**:

Add a new function `SetupSignalContext` which is similar to `SetupSignalHandler`, but returned is `context.Context`. `context.Context` is more standard than stop chan(`<-chan struct{}`) as a parameter to call an async or long-term function, and I found same new function receive `context.Context` rather than `<-chan struct{}`. It's easy to get `<-chan struct{}` from `context.Context`(use `Context.Done()`), but it's not easy to build `context.Context` from `<-chan struct{}`(may cost an new goroutine).

**Does this PR introduce a user-facing change?**:

```release-note
make Kubelet bootstrap certificate signal aware
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
