### PR TITLE
fixed e2e vsphere statefulsets test

### DIFF
--- a/test/e2e/storage/vsphere/vsphere_statefulsets.go
+++ b/test/e2e/storage/vsphere/vsphere_statefulsets.go
@@ -66,10 +66,6 @@ var _ = utils.SIGDescribe("vsphere statefulset [Feature:vsphere]", func() {
 		client = f.ClientSet
 		Bootstrap(f)
 	})
-	ginkgo.AfterEach(func() {
-		framework.Logf("Deleting all statefulset in namespace: %v", namespace)
-		e2estatefulset.DeleteAllStatefulSets(client, namespace)
-	})
 
 	ginkgo.It("vsphere statefulset testing", func() {
 		ginkgo.By("Creating StorageClass for Statefulset")
@@ -83,6 +79,7 @@ var _ = utils.SIGDescribe("vsphere statefulset [Feature:vsphere]", func() {
 		ginkgo.By("Creating statefulset")
 
 		statefulset := e2estatefulset.CreateStatefulSet(client, manifestPath, namespace)
+		defer e2estatefulset.DeleteAllStatefulSets(client, namespace)
 		replicas := *(statefulset.Spec.Replicas)
 		// Waiting for pods status to be Ready
 		e2estatefulset.WaitForStatusReadyReplicas(client, statefulset, replicas)

--- a/test/e2e/testing-manifests/statefulset/nginx/statefulset.yaml
+++ b/test/e2e/testing-manifests/statefulset/nginx/statefulset.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: web


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
 /kind failing-test

**What this PR does / why we need it**:
This PR is required to fix vsphere statefulsets test. See https://github.com/kubernetes/kubernetes/issues/92785 for more detail.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #92785

**Special notes for your reviewer**:

**Test Log**

```
% /Users/divyenp/go/src/github.com/divyenpatel/kubernetes/_output/dockerized/bin/darwin/amd64/e2e.test --provider vsphere -ginkgo.focus 'vsphere\sstatefulset' -kubeconfig /Users/divyenp/.kube/config
I0703 20:49:16.444322   21041 test_context.go:427] Tolerating taints "node-role.kubernetes.io/master" when considering if nodes are ready
I0703 20:49:16.444393   21041 e2e.go:129] Starting e2e run "f40905b3-3566-45b5-99f3-61bcf8dd758d" on Ginkgo node 1
{"msg":"Test Suite starting","total":1,"completed":0,"skipped":0,"failed":0}
Running Suite: Kubernetes e2e suite
===================================
Random Seed: 1593834555 - Will randomize all specs
Will run 1 of 5116 specs

Jul  3 20:49:16.450: INFO: >>> kubeConfig: /Users/divyenp/.kube/config
Jul  3 20:49:16.453: INFO: Waiting up to 30m0s for all (but 0) nodes to be schedulable
Jul  3 20:49:16.539: INFO: Waiting up to 10m0s for all pods (need at least 0) in namespace 'kube-system' to be running and ready
Jul  3 20:49:16.616: INFO: 22 / 22 pods in namespace 'kube-system' are running and ready (0 seconds elapsed)
Jul  3 20:49:16.616: INFO: expected 3 pod replicas in namespace 'kube-system', 3 are Running and Ready.
Jul  3 20:49:16.616: INFO: Waiting up to 5m0s for all daemonsets in namespace 'kube-system' to start
Jul  3 20:49:16.663: INFO: 5 / 5 pods ready in namespace 'kube-system' in daemonset 'kube-flannel-ds-amd64' (0 seconds elapsed)
Jul  3 20:49:16.663: INFO: 0 / 0 pods ready in namespace 'kube-system' in daemonset 'kube-flannel-ds-arm' (0 seconds elapsed)
Jul  3 20:49:16.663: INFO: 0 / 0 pods ready in namespace 'kube-system' in daemonset 'kube-flannel-ds-arm64' (0 seconds elapsed)
Jul  3 20:49:16.663: INFO: 0 / 0 pods ready in namespace 'kube-system' in daemonset 'kube-flannel-ds-ppc64le' (0 seconds elapsed)
Jul  3 20:49:16.663: INFO: 0 / 0 pods ready in namespace 'kube-system' in daemonset 'kube-flannel-ds-s390x' (0 seconds elapsed)
Jul  3 20:49:16.663: INFO: 5 / 5 pods ready in namespace 'kube-system' in daemonset 'kube-proxy' (0 seconds elapsed)
Jul  3 20:49:16.663: INFO: 5 / 5 pods ready in namespace 'kube-system' in daemonset 'vsphere-csi-node' (0 seconds elapsed)
Jul  3 20:49:16.663: INFO: e2e test version: v1.19.0-alpha.3.1808+59b0f9d9a8db40-dirty
Jul  3 20:49:16.684: INFO: kube-apiserver version: v1.19.0-alpha.3.1808+59b0f9d9a8db40
Jul  3 20:49:16.684: INFO: >>> kubeConfig: /Users/divyenp/.kube/config
Jul  3 20:49:16.698: INFO: Cluster IP family: ipv4
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
------------------------------
[sig-storage] vsphere statefulset [Feature:vsphere] 
  vsphere statefulset testing
  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/storage/vsphere/vsphere_statefulsets.go:70
[BeforeEach] [sig-storage] vsphere statefulset [Feature:vsphere]
  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:174
STEP: Creating a kubernetes client
Jul  3 20:49:16.710: INFO: >>> kubeConfig: /Users/divyenp/.kube/config
STEP: Building a namespace api object, basename vsphere-statefulset
Jul  3 20:49:16.825: INFO: Found PodSecurityPolicies; testing pod creation to see if PodSecurityPolicy is enabled
Jul  3 20:49:16.845: INFO: No PSP annotation exists on dry run pod; assuming PodSecurityPolicy is disabled
STEP: Waiting for a default service account to be provisioned in namespace
[BeforeEach] [sig-storage] vsphere statefulset [Feature:vsphere]
  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/storage/vsphere/vsphere_statefulsets.go:63
Jul  3 20:49:16.868: INFO: Initializing vc server 10.160.197.68
Jul  3 20:49:16.868: INFO: ConfigFile &{{administrator@vsphere.local Admin!23 443 true  0} map[10.160.197.68:0xc002e74700] {} {pvscsi} {10.160.197.68 k8s-dc kubernetes vsanDatastore k8s-cluster/Resources}} 
 vSphere instances map[10.160.197.68:0xc0032b8b60]
Jul  3 20:49:17.109: INFO: Search candidates vc=10.160.197.68 and datacenter=k8s-dc
Jul  3 20:49:17.109: INFO: Searching for node with UUID: 422a9520-e2a7-ed33-2fe4-4cf25e41045d
Jul  3 20:49:17.109: INFO: Searching for node with UUID: 422a5ca2-fec1-1574-e6b2-d34bc0502cf7
Jul  3 20:49:17.109: INFO: Searching for node with UUID: 422ae6cd-74cb-2079-ea1a-36c72501209c
Jul  3 20:49:17.109: INFO: Searching for node with UUID: 422aedff-3d10-7e9b-3ebc-6d47b192b725
Jul  3 20:49:17.109: INFO: Searching for node with UUID: 422a0cad-e0c2-f72a-aad0-5c9ff4ca2bb5
Jul  3 20:49:19.942: INFO: Found node k8s-node1 as vm=VirtualMachine:vm-93 placed on host=HostSystem:host-22 under zones [] in vc=10.160.197.68 and datacenter=k8s-dc
Jul  3 20:49:19.957: INFO: Found node k8s-master as vm=VirtualMachine:vm-76 placed on host=HostSystem:host-34 under zones [] in vc=10.160.197.68 and datacenter=k8s-dc
Jul  3 20:49:19.968: INFO: Found node k8s-node3 as vm=VirtualMachine:vm-95 placed on host=HostSystem:host-58 under zones [] in vc=10.160.197.68 and datacenter=k8s-dc
Jul  3 20:49:19.987: INFO: Found node k8s-node4 as vm=VirtualMachine:vm-96 placed on host=HostSystem:host-16 under zones [] in vc=10.160.197.68 and datacenter=k8s-dc
Jul  3 20:49:20.063: INFO: Found node k8s-node2 as vm=VirtualMachine:vm-94 placed on host=HostSystem:host-40 under zones [] in vc=10.160.197.68 and datacenter=k8s-dc
Jul  3 20:49:20.193: INFO: Zone to datastores map : map[]
[It] vsphere statefulset testing
  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/storage/vsphere/vsphere_statefulsets.go:70
STEP: Creating StorageClass for Statefulset
STEP: Creating statefulset
Jul  3 20:49:20.212: INFO: Parsing statefulset from test/e2e/testing-manifests/statefulset/nginx/statefulset.yaml
Jul  3 20:49:20.217: INFO: Parsing service from test/e2e/testing-manifests/statefulset/nginx/service.yaml
Jul  3 20:49:20.217: INFO: creating web service
Jul  3 20:49:20.237: INFO: creating statefulset vsphere-statefulset-2809/web with 3 replicas and selector &LabelSelector{MatchLabels:map[string]string{app: nginx,},MatchExpressions:[]LabelSelectorRequirement{},}
Jul  3 20:49:20.290: INFO: Found 0 stateful pods, waiting for 3
Jul  3 20:49:30.318: INFO: Found 1 stateful pods, waiting for 3
Jul  3 20:49:40.325: INFO: Found 1 stateful pods, waiting for 3
Jul  3 20:49:50.315: INFO: Found 2 stateful pods, waiting for 3
Jul  3 20:50:00.379: INFO: Found 2 stateful pods, waiting for 3
Jul  3 20:50:10.313: INFO: Found 2 stateful pods, waiting for 3
Jul  3 20:50:20.315: INFO: Waiting for pod web-0 to enter Running - Ready=true, currently Running - Ready=true
Jul  3 20:50:20.315: INFO: Waiting for pod web-1 to enter Running - Ready=true, currently Running - Ready=true
Jul  3 20:50:20.315: INFO: Waiting for pod web-2 to enter Running - Ready=true, currently Pending - Ready=false
Jul  3 20:50:30.319: INFO: Waiting for pod web-0 to enter Running - Ready=true, currently Running - Ready=true
Jul  3 20:50:30.319: INFO: Waiting for pod web-1 to enter Running - Ready=true, currently Running - Ready=true
Jul  3 20:50:30.319: INFO: Waiting for pod web-2 to enter Running - Ready=true, currently Pending - Ready=false
Jul  3 20:50:40.318: INFO: Waiting for pod web-0 to enter Running - Ready=true, currently Running - Ready=true
Jul  3 20:50:40.318: INFO: Waiting for pod web-1 to enter Running - Ready=true, currently Running - Ready=true
Jul  3 20:50:40.318: INFO: Waiting for pod web-2 to enter Running - Ready=true, currently Pending - Ready=false
Jul  3 20:50:50.311: INFO: Waiting for pod web-0 to enter Running - Ready=true, currently Running - Ready=true
Jul  3 20:50:50.311: INFO: Waiting for pod web-1 to enter Running - Ready=true, currently Running - Ready=true
Jul  3 20:50:50.311: INFO: Waiting for pod web-2 to enter Running - Ready=true, currently Running - Ready=true
Jul  3 20:50:50.311: INFO: Waiting for statefulset status.replicas updated to 3
Jul  3 20:50:50.342: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/Users/divyenp/.kube/config exec --namespace=vsphere-statefulset-2809 web-0 -- /bin/sh -x -c ls -idlh /usr/share/nginx/html'
Jul  3 20:50:51.883: INFO: stderr: "+ ls -idlh /usr/share/nginx/html\n"
Jul  3 20:50:51.884: INFO: stdout: "      2 drwxr-xr-x    3 root     root        4.0K Jul  4 03:49 /usr/share/nginx/html\n"
Jul  3 20:50:51.884: INFO: stdout of ls -idlh /usr/share/nginx/html on web-0:       2 drwxr-xr-x    3 root     root        4.0K Jul  4 03:49 /usr/share/nginx/html

Jul  3 20:50:51.884: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/Users/divyenp/.kube/config exec --namespace=vsphere-statefulset-2809 web-1 -- /bin/sh -x -c ls -idlh /usr/share/nginx/html'
Jul  3 20:50:52.334: INFO: stderr: "+ ls -idlh /usr/share/nginx/html\n"
Jul  3 20:50:52.334: INFO: stdout: "      2 drwxr-xr-x    3 root     root        4.0K Jul  4 03:50 /usr/share/nginx/html\n"
Jul  3 20:50:52.334: INFO: stdout of ls -idlh /usr/share/nginx/html on web-1:       2 drwxr-xr-x    3 root     root        4.0K Jul  4 03:50 /usr/share/nginx/html

Jul  3 20:50:52.334: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/Users/divyenp/.kube/config exec --namespace=vsphere-statefulset-2809 web-2 -- /bin/sh -x -c ls -idlh /usr/share/nginx/html'
Jul  3 20:50:52.770: INFO: stderr: "+ ls -idlh /usr/share/nginx/html\n"
Jul  3 20:50:52.770: INFO: stdout: "      2 drwxr-xr-x    3 root     root        4.0K Jul  4 03:50 /usr/share/nginx/html\n"
Jul  3 20:50:52.770: INFO: stdout of ls -idlh /usr/share/nginx/html on web-2:       2 drwxr-xr-x    3 root     root        4.0K Jul  4 03:50 /usr/share/nginx/html

Jul  3 20:50:52.790: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/Users/divyenp/.kube/config exec --namespace=vsphere-statefulset-2809 web-0 -- /bin/sh -x -c find /usr/share/nginx/html'
Jul  3 20:50:53.153: INFO: stderr: "+ find /usr/share/nginx/html\n"
Jul  3 20:50:53.153: INFO: stdout: "/usr/share/nginx/html\n/usr/share/nginx/html/lost+found\n"
Jul  3 20:50:53.153: INFO: stdout of find /usr/share/nginx/html on web-0: /usr/share/nginx/html
/usr/share/nginx/html/lost+found

Jul  3 20:50:53.153: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/Users/divyenp/.kube/config exec --namespace=vsphere-statefulset-2809 web-1 -- /bin/sh -x -c find /usr/share/nginx/html'
Jul  3 20:50:53.534: INFO: stderr: "+ find /usr/share/nginx/html\n"
Jul  3 20:50:53.534: INFO: stdout: "/usr/share/nginx/html\n/usr/share/nginx/html/lost+found\n"
Jul  3 20:50:53.534: INFO: stdout of find /usr/share/nginx/html on web-1: /usr/share/nginx/html
/usr/share/nginx/html/lost+found

Jul  3 20:50:53.534: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/Users/divyenp/.kube/config exec --namespace=vsphere-statefulset-2809 web-2 -- /bin/sh -x -c find /usr/share/nginx/html'
Jul  3 20:50:53.898: INFO: stderr: "+ find /usr/share/nginx/html\n"
Jul  3 20:50:53.898: INFO: stdout: "/usr/share/nginx/html\n/usr/share/nginx/html/lost+found\n"
Jul  3 20:50:53.898: INFO: stdout of find /usr/share/nginx/html on web-2: /usr/share/nginx/html
/usr/share/nginx/html/lost+found

Jul  3 20:50:53.917: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/Users/divyenp/.kube/config exec --namespace=vsphere-statefulset-2809 web-0 -- /bin/sh -x -c touch /usr/share/nginx/html/1593834650324740000'
Jul  3 20:50:54.299: INFO: stderr: "+ touch /usr/share/nginx/html/1593834650324740000\n"
Jul  3 20:50:54.299: INFO: stdout: ""
Jul  3 20:50:54.299: INFO: stdout of touch /usr/share/nginx/html/1593834650324740000 on web-0: 
Jul  3 20:50:54.299: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/Users/divyenp/.kube/config exec --namespace=vsphere-statefulset-2809 web-1 -- /bin/sh -x -c touch /usr/share/nginx/html/1593834650324740000'
Jul  3 20:50:54.776: INFO: stderr: "+ touch /usr/share/nginx/html/1593834650324740000\n"
Jul  3 20:50:54.776: INFO: stdout: ""
Jul  3 20:50:54.776: INFO: stdout of touch /usr/share/nginx/html/1593834650324740000 on web-1: 
Jul  3 20:50:54.776: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/Users/divyenp/.kube/config exec --namespace=vsphere-statefulset-2809 web-2 -- /bin/sh -x -c touch /usr/share/nginx/html/1593834650324740000'
Jul  3 20:50:55.169: INFO: stderr: "+ touch /usr/share/nginx/html/1593834650324740000\n"
Jul  3 20:50:55.169: INFO: stdout: ""
Jul  3 20:50:55.169: INFO: stdout of touch /usr/share/nginx/html/1593834650324740000 on web-2: 
STEP: Scaling down statefulsets to number of Replica: 2
Jul  3 20:50:55.327: INFO: Scaling statefulset web to 2
Jul  3 20:51:05.466: INFO: Waiting for statefulset status.replicas updated to 2
STEP: Verify Volumes are detached from Nodes after Statefulsets is scaled down
Jul  3 20:51:05.574: INFO: Waiting for Volume: "[vsanDatastore] 4ccefe5e-9754-6eac-9643-02000e8ca1fb/3efe4e83882f49f6b1a087a06b5e6dc6.vmdk" to detach from Node: "k8s-node3"
Jul  3 20:51:15.650: INFO: VirtualDisk backing filename "[local-ds-8-0] k8s-node3/k8s-node3.vmdk" does not match with diskPath "[vsanDatastore] 4ccefe5e-9754-6eac-9643-02000e8ca1fb/3efe4e83882f49f6b1a087a06b5e6dc6.vmdk"
Jul  3 20:51:15.650: INFO: Volume "[vsanDatastore] 4ccefe5e-9754-6eac-9643-02000e8ca1fb/3efe4e83882f49f6b1a087a06b5e6dc6.vmdk" has successfully detached from "k8s-node3"
STEP: Scaling up statefulsets to number of Replica: 3
Jul  3 20:51:15.650: INFO: Scaling statefulset web to 3
Jul  3 20:51:15.752: INFO: Waiting for statefulset status.replicas updated to 3
Jul  3 20:51:15.767: INFO: Waiting for statefulset status.replicas updated to 3
Jul  3 20:51:15.780: INFO: Waiting for stateful set status.readyReplicas to become 3, currently 2
Jul  3 20:51:25.802: INFO: Waiting for stateful set status.readyReplicas to become 3, currently 2
STEP: Verify all volumes are attached to Nodes after Statefulsets is scaled up
Jul  3 20:51:37.905: INFO: Verify Volume: "[nfs0-1] fcd/5a564f6265d64f7fbe3242f68431a018.vmdk" is attached to the Node: "k8s-node4"
Jul  3 20:51:37.941: INFO: VirtualDisk backing filename "[local-ds-1-0] k8s-node4/k8s-node4.vmdk" does not match with diskPath "[nfs0-1] fcd/5a564f6265d64f7fbe3242f68431a018.vmdk"
Jul  3 20:51:37.941: INFO: Found VirtualDisk backing with filename "[nfs0-1] fcd/5a564f6265d64f7fbe3242f68431a018.vmdk" for diskPath "[nfs0-1] fcd/5a564f6265d64f7fbe3242f68431a018.vmdk"
Jul  3 20:51:37.941: INFO: diskIsAttached found the disk "[nfs0-1] fcd/5a564f6265d64f7fbe3242f68431a018.vmdk" attached on node "k8s-node4"
Jul  3 20:51:40.025: INFO: Verify Volume: "[sharedVmfs-0] fcd/ad04d40bce8b4e1181257b0a47a87bc5.vmdk" is attached to the Node: "k8s-node2"
Jul  3 20:51:40.170: INFO: VirtualDisk backing filename "[local-ds-5-0] k8s-node2/k8s-node2.vmdk" does not match with diskPath "[sharedVmfs-0] fcd/ad04d40bce8b4e1181257b0a47a87bc5.vmdk"
Jul  3 20:51:40.170: INFO: Found VirtualDisk backing with filename "[sharedVmfs-0] fcd/ad04d40bce8b4e1181257b0a47a87bc5.vmdk" for diskPath "[sharedVmfs-0] fcd/ad04d40bce8b4e1181257b0a47a87bc5.vmdk"
Jul  3 20:51:40.170: INFO: diskIsAttached found the disk "[sharedVmfs-0] fcd/ad04d40bce8b4e1181257b0a47a87bc5.vmdk" attached on node "k8s-node2"
Jul  3 20:51:42.255: INFO: Verify Volume: "[vsanDatastore] 4ccefe5e-9754-6eac-9643-02000e8ca1fb/3efe4e83882f49f6b1a087a06b5e6dc6.vmdk" is attached to the Node: "k8s-node1"
Jul  3 20:51:42.316: INFO: VirtualDisk backing filename "[local-ds-2-0] k8s-node1/k8s-node1.vmdk" does not match with diskPath "[vsanDatastore] 4ccefe5e-9754-6eac-9643-02000e8ca1fb/3efe4e83882f49f6b1a087a06b5e6dc6.vmdk"
Jul  3 20:51:42.316: INFO: Found VirtualDisk backing with filename "[vsanDatastore] 4ccefe5e-9754-6eac-9643-02000e8ca1fb/3efe4e83882f49f6b1a087a06b5e6dc6.vmdk" for diskPath "[vsanDatastore] 4ccefe5e-9754-6eac-9643-02000e8ca1fb/3efe4e83882f49f6b1a087a06b5e6dc6.vmdk"
Jul  3 20:51:42.316: INFO: diskIsAttached found the disk "[vsanDatastore] 4ccefe5e-9754-6eac-9643-02000e8ca1fb/3efe4e83882f49f6b1a087a06b5e6dc6.vmdk" attached on node "k8s-node1"
Jul  3 20:51:42.338: INFO: Scaling statefulset web to 0
Jul  3 20:52:02.431: INFO: Waiting for statefulset status.replicas updated to 0
Jul  3 20:52:02.451: INFO: Deleting statefulset web
Jul  3 20:52:02.492: INFO: Deleting pvc: www-web-0 with volume pvc-447c8d9f-248e-45a4-a796-076a2de95d75
Jul  3 20:52:02.508: INFO: Deleting pvc: www-web-1 with volume pvc-594f5dfd-f100-443f-8671-eced8f847ee7
Jul  3 20:52:02.525: INFO: Deleting pvc: www-web-2 with volume pvc-0da23bac-eb34-4bc1-b11b-eec1a8673595
Jul  3 20:52:02.579: INFO: Still waiting for pvs of statefulset to disappear:
pvc-0da23bac-eb34-4bc1-b11b-eec1a8673595: {Phase:Bound Message: Reason:}
pvc-447c8d9f-248e-45a4-a796-076a2de95d75: {Phase:Released Message: Reason:}
pvc-594f5dfd-f100-443f-8671-eced8f847ee7: {Phase:Bound Message: Reason:}
[AfterEach] [sig-storage] vsphere statefulset [Feature:vsphere]
  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:175
Jul  3 20:52:12.620: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
STEP: Destroying namespace "vsphere-statefulset-2809" for this suite.

• [SLOW TEST:175.952 seconds]
[sig-storage] vsphere statefulset [Feature:vsphere]
/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/storage/utils/framework.go:23
  vsphere statefulset testing
  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/storage/vsphere/vsphere_statefulsets.go:70
------------------------------
{"msg":"PASSED [sig-storage] vsphere statefulset [Feature:vsphere] vsphere statefulset testing","total":1,"completed":1,"skipped":2707,"failed":0}
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSJul  3 20:52:12.678: INFO: Running AfterSuite actions on all nodes
Jul  3 20:52:12.678: INFO: Running AfterSuite actions on node 1
{"msg":"Test Suite completed","total":1,"completed":1,"skipped":5115,"failed":0}

Ran 1 of 5116 Specs in 176.224 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 5115 Skipped
PASS

```


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

@chethanv28 @xing-yang @SandeepPissay Can you help review this PR?
