### PR TITLE
Fix throttling issues when Azure VM computer name prefix is different from VMSS name

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_instances.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_instances.go
@@ -21,7 +21,7 @@ package azure
 import (
 	"context"
 	"fmt"
-	"strconv"
+	"os"
 	"strings"
 
 	v1 "k8s.io/api/core/v1"
@@ -36,6 +36,10 @@ const (
 	vmPowerStateStopped      = "stopped"
 	vmPowerStateDeallocated  = "deallocated"
 	vmPowerStateDeallocating = "deallocating"
+
+	// nodeNameEnvironmentName is the environment variable name for getting node name.
+	// It is only used for out-of-tree cloud provider.
+	nodeNameEnvironmentName = "NODE_NAME"
 )
 
 var (
@@ -310,17 +314,20 @@ func (az *Cloud) InstanceMetadataByProviderID(ctx context.Context, providerID st
 }
 
 func (az *Cloud) isCurrentInstance(name types.NodeName, metadataVMName string) (bool, error) {
+	var err error
 	nodeName := mapNodeNameToVMName(name)
 
+	// VMSS vmName is not same with hostname, use hostname instead.
 	if az.VMType == vmTypeVMSS {
-		// VMSS vmName is not same with hostname, construct the node name "{computer-name-prefix}{base-36-instance-id}".
-		// Refer https://docs.microsoft.com/en-us/azure/virtual-machine-scale-sets/virtual-machine-scale-sets-instance-ids#scale-set-vm-computer-name.
-		if ssName, instanceID, err := extractVmssVMName(metadataVMName); err == nil {
-			instance, err := strconv.ParseInt(instanceID, 10, 64)
-			if err != nil {
-				return false, fmt.Errorf("failed to parse VMSS instanceID %q: %v", instanceID, err)
-			}
-			metadataVMName = fmt.Sprintf("%s%06s", ssName, strconv.FormatInt(instance, 36))
+		metadataVMName, err = os.Hostname()
+		if err != nil {
+			return false, err
+		}
+
+		// Use name from env variable "NODE_NAME" if it is set.
+		nodeNameEnv := os.Getenv(nodeNameEnvironmentName)
+		if nodeNameEnv != "" {
+			metadataVMName = nodeNameEnv
 		}
 	}
 

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_instances_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_instances_test.go
@@ -174,14 +174,6 @@ func TestInstanceID(t *testing.T) {
 			expectedErrMsg:      fmt.Errorf("failure of getting instance metadata"),
 		},
 		{
-			name:                "NodeAddresses should report error if VMSS instanceID is invalid",
-			nodeName:            "vm123456",
-			metadataName:        "vmss_$123",
-			vmType:              vmTypeVMSS,
-			useInstanceMetadata: true,
-			expectedErrMsg:      fmt.Errorf("failed to parse VMSS instanceID %q: strconv.ParseInt: parsing %q: invalid syntax", "$123", "$123"),
-		},
-		{
 			name:                "NodeAddresses should report error if cloud.vmSet is nil",
 			nodeName:            "vm1",
 			vmType:              vmTypeStandard,
@@ -451,14 +443,6 @@ func TestNodeAddresses(t *testing.T) {
 			useCustomImsCache:   true,
 			useInstanceMetadata: true,
 			expectedErrMsg:      fmt.Errorf("getError"),
-		},
-		{
-			name:                "NodeAddresses should report error if VMSS instanceID is invalid",
-			nodeName:            "vm123456",
-			metadataName:        "vmss_$123",
-			vmType:              vmTypeVMSS,
-			useInstanceMetadata: true,
-			expectedErrMsg:      fmt.Errorf("failed to parse VMSS instanceID %q: strconv.ParseInt: parsing %q: invalid syntax", "$123", "$123"),
 		},
 		{
 			name:                "NodeAddresses should report error if cloud.vmSet is nil",
@@ -770,14 +754,6 @@ func TestInstanceMetadataByProviderID(t *testing.T) {
 			expectedErrMsg:      fmt.Errorf("getError"),
 		},
 		{
-			name:                "InstanceMetadataByProviderID should report error if VMSS instanceID is invalid",
-			metadataName:        "vmss_$123",
-			providerID:          providerID,
-			vmType:              vmTypeVMSS,
-			useInstanceMetadata: true,
-			expectedErrMsg:      fmt.Errorf("failed to parse VMSS instanceID %q: strconv.ParseInt: parsing %q: invalid syntax", "$123", "$123"),
-		},
-		{
 			name:         "InstanceMetadataByProviderID should get metadata from Azure API if cloud.UseInstanceMetadata is false",
 			metadataName: "vm1",
 			providerID:   providerID,
@@ -920,7 +896,7 @@ func TestInstanceMetadataByProviderID(t *testing.T) {
 func TestIsCurrentInstance(t *testing.T) {
 	cloud := &Cloud{
 		Config: Config{
-			VMType: vmTypeVMSS,
+			VMType: vmTypeStandard,
 		},
 	}
 	testcases := []struct {
@@ -938,22 +914,6 @@ func TestIsCurrentInstance(t *testing.T) {
 			nodeName:       "node1",
 			metadataVMName: "node2",
 			expected:       false,
-		},
-		{
-			nodeName:       "vmss000001",
-			metadataVMName: "vmss_1",
-			expected:       true,
-		},
-		{
-			nodeName:       "vmss_2",
-			metadataVMName: "vmss000000",
-			expected:       false,
-		},
-		{
-			nodeName:       "vmss123456",
-			metadataVMName: "vmss_$123",
-			expected:       false,
-			expectedErrMsg: fmt.Errorf("failed to parse VMSS instanceID %q: strconv.ParseInt: parsing %q: invalid syntax", "$123", "$123"),
 		},
 	}
 
@@ -1047,14 +1007,6 @@ func TestInstanceTypeByProviderID(t *testing.T) {
 			vmType:            vmTypeStandard,
 			useCustomImsCache: true,
 			expectedErrMsg:    fmt.Errorf("getError"),
-		},
-		{
-			name:           "NodeAddresses should report error if VMSS instanceID is invalid",
-			nodeName:       "vm123456",
-			metadataName:   "vmss_$123",
-			providerID:     "azure:///subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/vm1",
-			vmType:         vmTypeVMSS,
-			expectedErrMsg: fmt.Errorf("failed to parse VMSS instanceID %q: strconv.ParseInt: parsing %q: invalid syntax", "$123", "$123"),
 		},
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug
/area provider/azure
/sig cloud-provider

**What this PR does / why we need it**:

If computer name prefix does not match VMSS name, then Azure cloud provider will use VMSS API instead of using metadata service data. This leads to throttling, because every affected kubelet is making API requests. This is because computer name prefix is not included in IMDS, hence NodeName  can't be constructed without VMSS API. 

This PR fixes the issue by getting the NodeName from hostname directly. Because Windows container doesn't support hostNetwork, environment variable "NODE_NAME" would be used as a workaround for Windows containers (e.g. out-of-tree cloud provider).

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #92733

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fix throttling issues when Azure VM computer name prefix is different from VMSS name
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
