### PR TITLE
fix(aws): disable source destination check on instance with multiple ENIs

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/aws/aws.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/aws/aws.go
@@ -354,6 +354,8 @@ type EC2 interface {
 
 	ModifyInstanceAttribute(request *ec2.ModifyInstanceAttributeInput) (*ec2.ModifyInstanceAttributeOutput, error)
 
+	ModifyNetworkInterfaceAttribute(request *ec2.ModifyNetworkInterfaceAttributeInput) (*ec2.ModifyNetworkInterfaceAttributeOutput, error)
+
 	DescribeVpcs(input *ec2.DescribeVpcsInput) (*ec2.DescribeVpcsOutput, error)
 }
 
@@ -1142,6 +1144,10 @@ func (s *awsSdkEC2) DeleteRoute(request *ec2.DeleteRouteInput) (*ec2.DeleteRoute
 
 func (s *awsSdkEC2) ModifyInstanceAttribute(request *ec2.ModifyInstanceAttributeInput) (*ec2.ModifyInstanceAttributeOutput, error) {
 	return s.ec2.ModifyInstanceAttribute(request)
+}
+
+func (s *awsSdkEC2) ModifyNetworkInterfaceAttribute(request *ec2.ModifyNetworkInterfaceAttributeInput) (*ec2.ModifyNetworkInterfaceAttributeOutput, error) {
+	return s.ec2.ModifyNetworkInterfaceAttribute(request)
 }
 
 func (s *awsSdkEC2) DescribeVpcs(request *ec2.DescribeVpcsInput) (*ec2.DescribeVpcsOutput, error) {

--- a/staging/src/k8s.io/legacy-cloud-providers/aws/aws_fakes.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/aws/aws_fakes.go
@@ -299,10 +299,34 @@ func (ec2i *FakeEC2Impl) DeleteRoute(request *ec2.DeleteRouteInput) (*ec2.Delete
 	panic("Not implemented")
 }
 
-// ModifyInstanceAttribute is not implemented but is required for interface
-// conformance
+// ModifyInstanceAttribute only modifies SourceDestCheck now.
 func (ec2i *FakeEC2Impl) ModifyInstanceAttribute(request *ec2.ModifyInstanceAttributeInput) (*ec2.ModifyInstanceAttributeOutput, error) {
-	panic("Not implemented")
+	reqInstanceID := aws.StringValue(request.InstanceId)
+	for _, instance := range ec2i.aws.instances {
+		if aws.StringValue(instance.InstanceId) == reqInstanceID {
+			if request.SourceDestCheck != nil {
+				instance.SourceDestCheck = request.SourceDestCheck.Value
+			}
+			return &ec2.ModifyInstanceAttributeOutput{}, nil
+		}
+	}
+	return nil, fmt.Errorf("instance not found: %s", reqInstanceID)
+}
+
+// ModifyNetworkInterfaceAttribute only modifies SourceDestCheck now.
+func (ec2i *FakeEC2Impl) ModifyNetworkInterfaceAttribute(request *ec2.ModifyNetworkInterfaceAttributeInput) (*ec2.ModifyNetworkInterfaceAttributeOutput, error) {
+	interfaceID := aws.StringValue(request.NetworkInterfaceId)
+	for _, instance := range ec2i.aws.instances {
+		for _, device := range instance.NetworkInterfaces {
+			if aws.StringValue(device.NetworkInterfaceId) == interfaceID {
+				if request.SourceDestCheck != nil {
+					device.SourceDestCheck = request.SourceDestCheck.Value
+				}
+				return &ec2.ModifyNetworkInterfaceAttributeOutput{}, nil
+			}
+		}
+	}
+	return nil, fmt.Errorf("interface not found: %s", interfaceID)
 }
 
 // DescribeVpcs returns fake VPC descriptions


### PR DESCRIPTION
Signed-off-by: knight42 <anonymousknight96@gmail.com>

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind api-change

/kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes #92783 
Fixes #70924

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
aws: disable source destination check on instance with multiple ENIs 
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
