### PR TITLE
feat(informer-gen): add option WithCustomInformer 

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/informers/externalversions/factory.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/informers/externalversions/factory.go
@@ -75,6 +75,14 @@ func WithNamespace(namespace string) SharedInformerOption {
 	}
 }
 
+// WithCustomInformer sets a custom informer for the given informer type.
+func WithCustomInformer(obj v1.Object, informer cache.SharedIndexInformer) SharedInformerOption {
+	return func(factory *sharedInformerFactory) *sharedInformerFactory {
+		factory.informers[reflect.TypeOf(obj)] = informer
+		return factory
+	}
+}
+
 // NewSharedInformerFactory constructs a new instance of sharedInformerFactory for all namespaces.
 func NewSharedInformerFactory(client versioned.Interface, defaultResync time.Duration) SharedInformerFactory {
 	return NewSharedInformerFactoryWithOptions(client, defaultResync)

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions/factory.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions/factory.go
@@ -75,6 +75,14 @@ func WithNamespace(namespace string) SharedInformerOption {
 	}
 }
 
+// WithCustomInformer sets a custom informer for the given informer type.
+func WithCustomInformer(obj v1.Object, informer cache.SharedIndexInformer) SharedInformerOption {
+	return func(factory *sharedInformerFactory) *sharedInformerFactory {
+		factory.informers[reflect.TypeOf(obj)] = informer
+		return factory
+	}
+}
+
 // NewSharedInformerFactory constructs a new instance of sharedInformerFactory for all namespaces.
 func NewSharedInformerFactory(client clientset.Interface, defaultResync time.Duration) SharedInformerFactory {
 	return NewSharedInformerFactoryWithOptions(client, defaultResync)

--- a/staging/src/k8s.io/client-go/informers/factory.go
+++ b/staging/src/k8s.io/client-go/informers/factory.go
@@ -92,6 +92,14 @@ func WithNamespace(namespace string) SharedInformerOption {
 	}
 }
 
+// WithCustomInformer sets a custom informer for the given informer type.
+func WithCustomInformer(obj v1.Object, informer cache.SharedIndexInformer) SharedInformerOption {
+	return func(factory *sharedInformerFactory) *sharedInformerFactory {
+		factory.informers[reflect.TypeOf(obj)] = informer
+		return factory
+	}
+}
+
 // NewSharedInformerFactory constructs a new instance of sharedInformerFactory for all namespaces.
 func NewSharedInformerFactory(client kubernetes.Interface, defaultResync time.Duration) SharedInformerFactory {
 	return NewSharedInformerFactoryWithOptions(client, defaultResync)

--- a/staging/src/k8s.io/code-generator/_examples/HyphenGroup/informers/externalversions/factory.go
+++ b/staging/src/k8s.io/code-generator/_examples/HyphenGroup/informers/externalversions/factory.go
@@ -75,6 +75,14 @@ func WithNamespace(namespace string) SharedInformerOption {
 	}
 }
 
+// WithCustomInformer sets a custom informer for the given informer type.
+func WithCustomInformer(obj v1.Object, informer cache.SharedIndexInformer) SharedInformerOption {
+	return func(factory *sharedInformerFactory) *sharedInformerFactory {
+		factory.informers[reflect.TypeOf(obj)] = informer
+		return factory
+	}
+}
+
 // NewSharedInformerFactory constructs a new instance of sharedInformerFactory for all namespaces.
 func NewSharedInformerFactory(client versioned.Interface, defaultResync time.Duration) SharedInformerFactory {
 	return NewSharedInformerFactoryWithOptions(client, defaultResync)

--- a/staging/src/k8s.io/code-generator/_examples/MixedCase/informers/externalversions/factory.go
+++ b/staging/src/k8s.io/code-generator/_examples/MixedCase/informers/externalversions/factory.go
@@ -75,6 +75,14 @@ func WithNamespace(namespace string) SharedInformerOption {
 	}
 }
 
+// WithCustomInformer sets a custom informer for the given informer type.
+func WithCustomInformer(obj v1.Object, informer cache.SharedIndexInformer) SharedInformerOption {
+	return func(factory *sharedInformerFactory) *sharedInformerFactory {
+		factory.informers[reflect.TypeOf(obj)] = informer
+		return factory
+	}
+}
+
 // NewSharedInformerFactory constructs a new instance of sharedInformerFactory for all namespaces.
 func NewSharedInformerFactory(client versioned.Interface, defaultResync time.Duration) SharedInformerFactory {
 	return NewSharedInformerFactoryWithOptions(client, defaultResync)

--- a/staging/src/k8s.io/code-generator/_examples/apiserver/informers/externalversions/factory.go
+++ b/staging/src/k8s.io/code-generator/_examples/apiserver/informers/externalversions/factory.go
@@ -77,6 +77,14 @@ func WithNamespace(namespace string) SharedInformerOption {
 	}
 }
 
+// WithCustomInformer sets a custom informer for the given informer type.
+func WithCustomInformer(obj v1.Object, informer cache.SharedIndexInformer) SharedInformerOption {
+	return func(factory *sharedInformerFactory) *sharedInformerFactory {
+		factory.informers[reflect.TypeOf(obj)] = informer
+		return factory
+	}
+}
+
 // NewSharedInformerFactory constructs a new instance of sharedInformerFactory for all namespaces.
 func NewSharedInformerFactory(client versioned.Interface, defaultResync time.Duration) SharedInformerFactory {
 	return NewSharedInformerFactoryWithOptions(client, defaultResync)

--- a/staging/src/k8s.io/code-generator/_examples/apiserver/informers/internalversion/factory.go
+++ b/staging/src/k8s.io/code-generator/_examples/apiserver/informers/internalversion/factory.go
@@ -77,6 +77,14 @@ func WithNamespace(namespace string) SharedInformerOption {
 	}
 }
 
+// WithCustomInformer sets a custom informer for the given informer type.
+func WithCustomInformer(obj v1.Object, informer cache.SharedIndexInformer) SharedInformerOption {
+	return func(factory *sharedInformerFactory) *sharedInformerFactory {
+		factory.informers[reflect.TypeOf(obj)] = informer
+		return factory
+	}
+}
+
 // NewSharedInformerFactory constructs a new instance of sharedInformerFactory for all namespaces.
 func NewSharedInformerFactory(client internalversion.Interface, defaultResync time.Duration) SharedInformerFactory {
 	return NewSharedInformerFactoryWithOptions(client, defaultResync)

--- a/staging/src/k8s.io/code-generator/_examples/crd/informers/externalversions/factory.go
+++ b/staging/src/k8s.io/code-generator/_examples/crd/informers/externalversions/factory.go
@@ -76,6 +76,14 @@ func WithNamespace(namespace string) SharedInformerOption {
 	}
 }
 
+// WithCustomInformer sets a custom informer for the given informer type.
+func WithCustomInformer(obj v1.Object, informer cache.SharedIndexInformer) SharedInformerOption {
+	return func(factory *sharedInformerFactory) *sharedInformerFactory {
+		factory.informers[reflect.TypeOf(obj)] = informer
+		return factory
+	}
+}
+
 // NewSharedInformerFactory constructs a new instance of sharedInformerFactory for all namespaces.
 func NewSharedInformerFactory(client versioned.Interface, defaultResync time.Duration) SharedInformerFactory {
 	return NewSharedInformerFactoryWithOptions(client, defaultResync)

--- a/staging/src/k8s.io/code-generator/cmd/informer-gen/generators/factory.go
+++ b/staging/src/k8s.io/code-generator/cmd/informer-gen/generators/factory.go
@@ -142,6 +142,14 @@ func WithNamespace(namespace string) SharedInformerOption {
 	}
 }
 
+// WithCustomInformer sets a custom informer for the given informer type.
+func WithCustomInformer(obj {{.object|raw}}, informer {{.cacheSharedIndexInformer|raw}}) SharedInformerOption {
+	return func(factory *sharedInformerFactory) *sharedInformerFactory {
+		factory.informers[reflect.TypeOf(obj)] = informer
+		return factory
+	}
+}
+
 // NewSharedInformerFactory constructs a new instance of sharedInformerFactory for all namespaces.
 func NewSharedInformerFactory(client {{.clientSetInterface|raw}}, defaultResync {{.timeDuration|raw}}) SharedInformerFactory {
 	return NewSharedInformerFactoryWithOptions(client, defaultResync)

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/informers/externalversions/factory.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/informers/externalversions/factory.go
@@ -75,6 +75,14 @@ func WithNamespace(namespace string) SharedInformerOption {
 	}
 }
 
+// WithCustomInformer sets a custom informer for the given informer type.
+func WithCustomInformer(obj v1.Object, informer cache.SharedIndexInformer) SharedInformerOption {
+	return func(factory *sharedInformerFactory) *sharedInformerFactory {
+		factory.informers[reflect.TypeOf(obj)] = informer
+		return factory
+	}
+}
+
 // NewSharedInformerFactory constructs a new instance of sharedInformerFactory for all namespaces.
 func NewSharedInformerFactory(client clientset.Interface, defaultResync time.Duration) SharedInformerFactory {
 	return NewSharedInformerFactoryWithOptions(client, defaultResync)

--- a/staging/src/k8s.io/sample-apiserver/pkg/generated/informers/externalversions/factory.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/generated/informers/externalversions/factory.go
@@ -75,6 +75,14 @@ func WithNamespace(namespace string) SharedInformerOption {
 	}
 }
 
+// WithCustomInformer sets a custom informer for the given informer type.
+func WithCustomInformer(obj v1.Object, informer cache.SharedIndexInformer) SharedInformerOption {
+	return func(factory *sharedInformerFactory) *sharedInformerFactory {
+		factory.informers[reflect.TypeOf(obj)] = informer
+		return factory
+	}
+}
+
 // NewSharedInformerFactory constructs a new instance of sharedInformerFactory for all namespaces.
 func NewSharedInformerFactory(client versioned.Interface, defaultResync time.Duration) SharedInformerFactory {
 	return NewSharedInformerFactoryWithOptions(client, defaultResync)

--- a/staging/src/k8s.io/sample-controller/pkg/generated/informers/externalversions/factory.go
+++ b/staging/src/k8s.io/sample-controller/pkg/generated/informers/externalversions/factory.go
@@ -75,6 +75,14 @@ func WithNamespace(namespace string) SharedInformerOption {
 	}
 }
 
+// WithCustomInformer sets a custom informer for the given informer type.
+func WithCustomInformer(obj v1.Object, informer cache.SharedIndexInformer) SharedInformerOption {
+	return func(factory *sharedInformerFactory) *sharedInformerFactory {
+		factory.informers[reflect.TypeOf(obj)] = informer
+		return factory
+	}
+}
+
 // NewSharedInformerFactory constructs a new instance of sharedInformerFactory for all namespaces.
 func NewSharedInformerFactory(client versioned.Interface, defaultResync time.Duration) SharedInformerFactory {
 	return NewSharedInformerFactoryWithOptions(client, defaultResync)


### PR DESCRIPTION
Signed-off-by: knight42 <anonymousknight96@gmail.com>

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test

/kind feature
> /kind flake

**What this PR does / why we need it**:

The k8s scheduler needs to watch running pods and now there are two PodInformers, a cutomized one in scheduler and the default one in `sharedInformerFactory`. The k8s scheduler hope to use only one PodInformer to eliminate unexpected bugs.

Ref: https://github.com/kubernetes/kubernetes/pull/92682#issuecomment-653734850

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #92792

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
