### PR TITLE
 [WIP] Server-Side Apply: Status Wiping/Reset Fields implementation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -140,7 +140,7 @@ require (
 	k8s.io/system-validators v1.2.0
 	k8s.io/utils v0.0.0-20200729134348-d5654de09c73
 	sigs.k8s.io/kustomize v2.0.3+incompatible
-	sigs.k8s.io/structured-merge-diff/v3 v3.0.1-0.20200706213357-43c19bbb7fba
+	sigs.k8s.io/structured-merge-diff/v4 v4.0.1
 	sigs.k8s.io/yaml v1.2.0
 )
 
@@ -501,6 +501,7 @@ replace (
 	rsc.io/pdf => rsc.io/pdf v0.1.1
 	sigs.k8s.io/apiserver-network-proxy/konnectivity-client => sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.12
 	sigs.k8s.io/kustomize => sigs.k8s.io/kustomize v2.0.3+incompatible
+	sigs.k8s.io/structured-merge-diff/v3 => sigs.k8s.io/structured-merge-diff/v3 v3.0.1-0.20200706213357-43c19bbb7fba
 	sigs.k8s.io/structured-merge-diff/v4 => sigs.k8s.io/structured-merge-diff/v4 v4.0.1
 	sigs.k8s.io/yaml => sigs.k8s.io/yaml v1.2.0
 )

--- a/go.mod
+++ b/go.mod
@@ -139,6 +139,8 @@ require (
 	k8s.io/sample-apiserver v0.0.0
 	k8s.io/system-validators v1.2.0
 	k8s.io/utils v0.0.0-20200729134348-d5654de09c73
+	sigs.k8s.io/kustomize v2.0.3+incompatible
+	sigs.k8s.io/structured-merge-diff/v3 v3.0.1-0.20200706213357-43c19bbb7fba
 	sigs.k8s.io/yaml v1.2.0
 )
 

--- a/go.mod
+++ b/go.mod
@@ -501,7 +501,6 @@ replace (
 	rsc.io/pdf => rsc.io/pdf v0.1.1
 	sigs.k8s.io/apiserver-network-proxy/konnectivity-client => sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.12
 	sigs.k8s.io/kustomize => sigs.k8s.io/kustomize v2.0.3+incompatible
-	sigs.k8s.io/structured-merge-diff/v3 => sigs.k8s.io/structured-merge-diff/v3 v3.0.1-0.20200706213357-43c19bbb7fba
 	sigs.k8s.io/structured-merge-diff/v4 => sigs.k8s.io/structured-merge-diff/v4 v4.0.1
 	sigs.k8s.io/yaml => sigs.k8s.io/yaml v1.2.0
 )

--- a/go.mod
+++ b/go.mod
@@ -139,7 +139,6 @@ require (
 	k8s.io/sample-apiserver v0.0.0
 	k8s.io/system-validators v1.2.0
 	k8s.io/utils v0.0.0-20200729134348-d5654de09c73
-	sigs.k8s.io/kustomize v2.0.3+incompatible
 	sigs.k8s.io/structured-merge-diff/v4 v4.0.1
 	sigs.k8s.io/yaml v1.2.0
 )

--- a/pkg/api/persistentvolume/BUILD
+++ b/pkg/api/persistentvolume/BUILD
@@ -10,6 +10,7 @@ go_library(
         "//pkg/apis/core:go_default_library",
         "//pkg/features:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",
+        "//vendor/sigs.k8s.io/structured-merge-diff/v4/fieldpath:go_default_library",
     ],
 )
 

--- a/pkg/api/persistentvolume/util.go
+++ b/pkg/api/persistentvolume/util.go
@@ -20,6 +20,7 @@ import (
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	api "k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/features"
+	"sigs.k8s.io/structured-merge-diff/v3/fieldpath"
 )
 
 // DropDisabledFields removes disabled fields from the pv spec.
@@ -29,6 +30,15 @@ func DropDisabledFields(pvSpec *api.PersistentVolumeSpec, oldPVSpec *api.Persist
 		if pvSpec.CSI != nil {
 			pvSpec.CSI.ControllerExpandSecretRef = nil
 		}
+	}
+}
+
+// AddDisabledFieldsTo to the provided set of resetFields
+// This should be called with the resetFields for all resources containing a Pod
+func AddDisabledFieldsTo(resetFields *fieldpath.Set) {
+	if !utilfeature.DefaultFeatureGate.Enabled(features.ExpandCSIVolumes) {
+		// TODO: make sure this path is correct, the api type has some inlines
+		resetFields.Insert(fieldpath.MakePathOrDie("spec", "csi", "controllerExpandSecretRef"))
 	}
 }
 

--- a/pkg/api/persistentvolume/util.go
+++ b/pkg/api/persistentvolume/util.go
@@ -20,7 +20,7 @@ import (
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	api "k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/features"
-	"sigs.k8s.io/structured-merge-diff/v3/fieldpath"
+	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
 )
 
 // DropDisabledFields removes disabled fields from the pv spec.

--- a/pkg/api/pod/BUILD
+++ b/pkg/api/pod/BUILD
@@ -16,6 +16,7 @@ go_library(
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",
+        "//vendor/sigs.k8s.io/structured-merge-diff/v3/fieldpath:go_default_library",
     ],
 )
 

--- a/pkg/api/pod/BUILD
+++ b/pkg/api/pod/BUILD
@@ -16,7 +16,7 @@ go_library(
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",
-        "//vendor/sigs.k8s.io/structured-merge-diff/v3/fieldpath:go_default_library",
+        "//vendor/sigs.k8s.io/structured-merge-diff/v4/fieldpath:go_default_library",
     ],
 )
 

--- a/pkg/api/pod/util.go
+++ b/pkg/api/pod/util.go
@@ -24,7 +24,7 @@ import (
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	api "k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/features"
-	"sigs.k8s.io/structured-merge-diff/v3/fieldpath"
+	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
 )
 
 // ContainerType signifies container type

--- a/pkg/api/pod/util.go
+++ b/pkg/api/pod/util.go
@@ -304,6 +304,13 @@ func DropDisabledTemplateFields(podTemplate, oldPodTemplate *api.PodTemplateSpec
 	dropDisabledFields(podSpec, podAnnotations, oldPodSpec, oldPodAnnotations)
 }
 
+// AddDisabledTemplateFieldsTo the provided set of resetFields
+// This should be called with the resetFields for all resources containing a PodTemplate
+// To add the fields at the right location, pass a prefixed fieldset
+func AddDisabledTemplateFieldsTo(resetFields *fieldpath.Set) {
+	addDisabledFieldsTo(resetFields)
+}
+
 // DropDisabledPodFields removes disabled fields from the pod metadata and spec.
 // This should be called from PrepareForCreate/PrepareForUpdate for all resources containing a Pod
 func DropDisabledPodFields(pod, oldPod *api.Pod) {

--- a/pkg/api/pod/util.go
+++ b/pkg/api/pod/util.go
@@ -19,7 +19,7 @@ package pod
 import (
 	"strings"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	api "k8s.io/kubernetes/pkg/apis/core"
@@ -329,11 +329,11 @@ func DropDisabledPodFields(pod, oldPod *api.Pod) {
 	dropPodStatusDisabledFields(podStatus, oldPodStatus)
 }
 
-// AddDisabledFields to the provided set of resetFields
+// AddDisabledFieldsTo the provided set of resetFields
 // This should be called with the resetFields for all resources containing a Pod
-func AddDisabledFields(to *fieldpath.Set) {
-	addDisabledStatusFields(to)
-	addDisabledFields(to)
+func AddDisabledFieldsTo(resetFields *fieldpath.Set) {
+	addDisabledStatusFieldsTo(resetFields)
+	addDisabledFieldsTo(resetFields)
 }
 
 // dropPodStatusDisabledFields removes disabled fields from the pod status
@@ -347,9 +347,9 @@ func dropPodStatusDisabledFields(podStatus *api.PodStatus, oldPodStatus *api.Pod
 	}
 }
 
-func addDisabledStatusFields(to *fieldpath.Set) {
+func addDisabledStatusFieldsTo(resetFields *fieldpath.Set) {
 	if !utilfeature.DefaultFeatureGate.Enabled(features.IPv6DualStack) {
-		to.Insert(fieldpath.MakePathOrDie("status", "podIPs"))
+		resetFields.Insert(fieldpath.MakePathOrDie("status", "podIPs"))
 	}
 }
 
@@ -453,12 +453,12 @@ func dropDisabledFields(
 
 }
 
-// dropDisabledFields removes disabled fields from the pod metadata and spec.
-func addDisabledFields(to *fieldpath.Set) {
+// addDisabledFields removes disabled fields from the pod metadata and spec.
+func addDisabledFieldsTo(resetFields *fieldpath.Set) {
 	if !utilfeature.DefaultFeatureGate.Enabled(features.TokenRequestProjection) {
 		// TODO: add the actual fieldpath here, this is just a probably wrong dummy based on
 		// podSpec.Volumes[i].Projected.Sources[j].ServiceAccountToken
-		to.Insert(fieldpath.MakePathOrDie("spec", "volumes", "projected", "sources", "serviceAccountToken"))
+		resetFields.Insert(fieldpath.MakePathOrDie("spec", "volumes", "projected", "sources", "serviceAccountToken"))
 	}
 	// TODO: add all the fields from podutil.DropDisabledPodFields (a lot)
 
@@ -475,7 +475,7 @@ func addDisabledFields(to *fieldpath.Set) {
 		// if podSpec.SecurityContext != nil {
 		// 	podSpec.SecurityContext.Sysctls = nil
 		// }
-		to.Insert(fieldpath.MakePathOrDie("spec", "securityContext", "sysctls"))
+		resetFields.Insert(fieldpath.MakePathOrDie("spec", "securityContext", "sysctls"))
 	}
 }
 

--- a/pkg/registry/apiserverinternal/storageversion/storage/storage.go
+++ b/pkg/registry/apiserverinternal/storageversion/storage/storage.go
@@ -29,6 +29,7 @@ import (
 	printersinternal "k8s.io/kubernetes/pkg/printers/internalversion"
 	printerstorage "k8s.io/kubernetes/pkg/printers/storage"
 	strategy "k8s.io/kubernetes/pkg/registry/apiserverinternal/storageversion"
+	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
 )
 
 // REST implements a RESTStorage for storage version against etcd
@@ -46,10 +47,11 @@ func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, *StatusREST, error) {
 		},
 		DefaultQualifiedResource: apiserverinternal.Resource("storageversions"),
 
-		CreateStrategy: strategy.Strategy,
-		UpdateStrategy: strategy.Strategy,
-		DeleteStrategy: strategy.Strategy,
-		TableConvertor: printerstorage.TableConvertor{TableGenerator: printers.NewTableGenerator().With(printersinternal.AddHandlers)},
+		CreateStrategy:      strategy.Strategy,
+		UpdateStrategy:      strategy.Strategy,
+		DeleteStrategy:      strategy.Strategy,
+		ResetFieldsStrategy: strategy.Strategy,
+		TableConvertor:      printerstorage.TableConvertor{TableGenerator: printers.NewTableGenerator().With(printersinternal.AddHandlers)},
 	}
 	options := &generic.StoreOptions{RESTOptions: optsGetter}
 	if err := store.CompleteWithOptions(options); err != nil {
@@ -57,6 +59,7 @@ func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, *StatusREST, error) {
 	}
 	statusStore := *store
 	statusStore.UpdateStrategy = strategy.StatusStrategy
+	statusStore.ResetFieldsStrategy = strategy.StatusStrategy
 	return &REST{store}, &StatusREST{store: &statusStore}, nil
 }
 
@@ -80,4 +83,9 @@ func (r *StatusREST) Update(ctx context.Context, name string, objInfo rest.Updat
 	// We are explicitly setting forceAllowCreate to false in the call to the underlying storage because
 	// subresources should never allow create on update.
 	return r.store.Update(ctx, name, objInfo, createValidation, updateValidation, false, options)
+}
+
+// GetResetFields implements rest.ResetFieldsStrategy
+func (r *StatusREST) GetResetFields() map[fieldpath.APIVersion]*fieldpath.Set {
+	return r.store.GetResetFields()
 }

--- a/pkg/registry/apps/daemonset/BUILD
+++ b/pkg/registry/apps/daemonset/BUILD
@@ -29,6 +29,7 @@ go_library(
         "//staging/src/k8s.io/apiserver/pkg/endpoints/request:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/registry/rest:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/storage/names:go_default_library",
+        "//vendor/sigs.k8s.io/structured-merge-diff/v4/fieldpath:go_default_library",
     ],
 )
 

--- a/pkg/registry/apps/daemonset/storage/BUILD
+++ b/pkg/registry/apps/daemonset/storage/BUILD
@@ -39,6 +39,7 @@ go_library(
         "//staging/src/k8s.io/apiserver/pkg/registry/generic:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/registry/generic/registry:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/registry/rest:go_default_library",
+        "//vendor/sigs.k8s.io/structured-merge-diff/v4/fieldpath:go_default_library",
     ],
 )
 

--- a/pkg/registry/apps/daemonset/storage/storage.go
+++ b/pkg/registry/apps/daemonset/storage/storage.go
@@ -29,7 +29,7 @@ import (
 	printersinternal "k8s.io/kubernetes/pkg/printers/internalversion"
 	printerstorage "k8s.io/kubernetes/pkg/printers/storage"
 	"k8s.io/kubernetes/pkg/registry/apps/daemonset"
-	"sigs.k8s.io/structured-merge-diff/v3/fieldpath"
+	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
 )
 
 // REST implements a RESTStorage for DaemonSets

--- a/pkg/registry/apps/daemonset/storage/storage.go
+++ b/pkg/registry/apps/daemonset/storage/storage.go
@@ -29,6 +29,7 @@ import (
 	printersinternal "k8s.io/kubernetes/pkg/printers/internalversion"
 	printerstorage "k8s.io/kubernetes/pkg/printers/storage"
 	"k8s.io/kubernetes/pkg/registry/apps/daemonset"
+	"sigs.k8s.io/structured-merge-diff/v3/fieldpath"
 )
 
 // REST implements a RESTStorage for DaemonSets
@@ -44,9 +45,10 @@ func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, *StatusREST, error) {
 		NewListFunc:              func() runtime.Object { return &apps.DaemonSetList{} },
 		DefaultQualifiedResource: apps.Resource("daemonsets"),
 
-		CreateStrategy: daemonset.Strategy,
-		UpdateStrategy: daemonset.Strategy,
-		DeleteStrategy: daemonset.Strategy,
+		CreateStrategy:      daemonset.Strategy,
+		UpdateStrategy:      daemonset.Strategy,
+		DeleteStrategy:      daemonset.Strategy,
+		ResetFieldsStrategy: daemonset.Strategy,
 
 		TableConvertor: printerstorage.TableConvertor{TableGenerator: printers.NewTableGenerator().With(printersinternal.AddHandlers)},
 	}
@@ -57,6 +59,7 @@ func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, *StatusREST, error) {
 
 	statusStore := *store
 	statusStore.UpdateStrategy = daemonset.StatusStrategy
+	statusStore.ResetFieldsStrategy = daemonset.StatusStrategy
 
 	return &REST{store, []string{"all"}}, &StatusREST{store: &statusStore}, nil
 }
@@ -102,4 +105,9 @@ func (r *StatusREST) Update(ctx context.Context, name string, objInfo rest.Updat
 	// We are explicitly setting forceAllowCreate to false in the call to the underlying storage because
 	// subresources should never allow create on update.
 	return r.store.Update(ctx, name, objInfo, createValidation, updateValidation, false, options)
+}
+
+// GetResetFields implements rest.ResetFieldsStrategy
+func (r *StatusREST) GetResetFields() map[fieldpath.APIVersion]*fieldpath.Set {
+	return r.store.GetResetFields()
 }

--- a/pkg/registry/apps/daemonset/strategy.go
+++ b/pkg/registry/apps/daemonset/strategy.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/kubernetes/pkg/apis/apps"
 	"k8s.io/kubernetes/pkg/apis/apps/validation"
 	corevalidation "k8s.io/kubernetes/pkg/apis/core/validation"
+	"sigs.k8s.io/structured-merge-diff/v3/fieldpath"
 )
 
 // daemonSetStrategy implements verification logic for daemon sets.
@@ -64,6 +65,25 @@ func (daemonSetStrategy) DefaultGarbageCollectionPolicy(ctx context.Context) res
 // NamespaceScoped returns true because all DaemonSets need to be within a namespace.
 func (daemonSetStrategy) NamespaceScoped() bool {
 	return true
+}
+
+// GetResetFields returns the set of fields that get reset by the strategy
+// and should not be modified by the user.
+func (daemonSetStrategy) GetResetFields() map[fieldpath.APIVersion]*fieldpath.Set {
+	fields := map[fieldpath.APIVersion]*fieldpath.Set{
+		"apps/v1": fieldpath.NewSet(
+			fieldpath.MakePathOrDie("status"),
+			fieldpath.MakePathOrDie("spec", "templateGeneration"),
+		),
+	}
+
+	// TODO: make sure this works and is the best way to do this
+	specStr, templateStr := "spec", "template"
+	pod.AddDisabledTemplateFieldsTo(fields["apps/v1"].
+		WithPrefix(fieldpath.PathElement{FieldName: &specStr}).
+		WithPrefix(fieldpath.PathElement{FieldName: &templateStr}))
+
+	return fields
 }
 
 // PrepareForCreate clears the status of a daemon set before creation.
@@ -168,6 +188,16 @@ type daemonSetStatusStrategy struct {
 
 // StatusStrategy is the default logic invoked when updating object status.
 var StatusStrategy = daemonSetStatusStrategy{Strategy}
+
+// GetResetFields returns the set of fields that get reset by the strategy
+// and should not be modified by the user.
+func (daemonSetStatusStrategy) GetResetFields() map[fieldpath.APIVersion]*fieldpath.Set {
+	return map[fieldpath.APIVersion]*fieldpath.Set{
+		"apps/v1": fieldpath.NewSet(
+			fieldpath.MakePathOrDie("spec"),
+		),
+	}
+}
 
 func (daemonSetStatusStrategy) PrepareForUpdate(ctx context.Context, obj, old runtime.Object) {
 	newDaemonSet := obj.(*apps.DaemonSet)

--- a/pkg/registry/apps/daemonset/strategy.go
+++ b/pkg/registry/apps/daemonset/strategy.go
@@ -34,7 +34,7 @@ import (
 	"k8s.io/kubernetes/pkg/apis/apps"
 	"k8s.io/kubernetes/pkg/apis/apps/validation"
 	corevalidation "k8s.io/kubernetes/pkg/apis/core/validation"
-	"sigs.k8s.io/structured-merge-diff/v3/fieldpath"
+	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
 )
 
 // daemonSetStrategy implements verification logic for daemon sets.

--- a/pkg/registry/apps/deployment/BUILD
+++ b/pkg/registry/apps/deployment/BUILD
@@ -30,6 +30,7 @@ go_library(
         "//staging/src/k8s.io/apiserver/pkg/endpoints/request:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/registry/rest:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/storage/names:go_default_library",
+        "//vendor/sigs.k8s.io/structured-merge-diff/v4/fieldpath:go_default_library",
     ],
 )
 

--- a/pkg/registry/apps/deployment/storage/BUILD
+++ b/pkg/registry/apps/deployment/storage/BUILD
@@ -59,6 +59,7 @@ go_library(
         "//staging/src/k8s.io/apiserver/pkg/storage:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/storage/errors:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/util/dryrun:go_default_library",
+        "//vendor/sigs.k8s.io/structured-merge-diff/v4/fieldpath:go_default_library",
     ],
 )
 

--- a/pkg/registry/apps/deployment/storage/storage.go
+++ b/pkg/registry/apps/deployment/storage/storage.go
@@ -43,7 +43,7 @@ import (
 	printersinternal "k8s.io/kubernetes/pkg/printers/internalversion"
 	printerstorage "k8s.io/kubernetes/pkg/printers/storage"
 	"k8s.io/kubernetes/pkg/registry/apps/deployment"
-	"sigs.k8s.io/structured-merge-diff/v3/fieldpath"
+	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
 )
 
 // DeploymentStorage includes dummy storage for Deployments and for Scale subresource.

--- a/pkg/registry/apps/deployment/storage/storage.go
+++ b/pkg/registry/apps/deployment/storage/storage.go
@@ -43,6 +43,7 @@ import (
 	printersinternal "k8s.io/kubernetes/pkg/printers/internalversion"
 	printerstorage "k8s.io/kubernetes/pkg/printers/storage"
 	"k8s.io/kubernetes/pkg/registry/apps/deployment"
+	"sigs.k8s.io/structured-merge-diff/v3/fieldpath"
 )
 
 // DeploymentStorage includes dummy storage for Deployments and for Scale subresource.
@@ -81,9 +82,10 @@ func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, *StatusREST, *Rollbac
 		NewListFunc:              func() runtime.Object { return &apps.DeploymentList{} },
 		DefaultQualifiedResource: apps.Resource("deployments"),
 
-		CreateStrategy: deployment.Strategy,
-		UpdateStrategy: deployment.Strategy,
-		DeleteStrategy: deployment.Strategy,
+		CreateStrategy:      deployment.Strategy,
+		UpdateStrategy:      deployment.Strategy,
+		DeleteStrategy:      deployment.Strategy,
+		ResetFieldsStrategy: deployment.Strategy,
 
 		TableConvertor: printerstorage.TableConvertor{TableGenerator: printers.NewTableGenerator().With(printersinternal.AddHandlers)},
 	}
@@ -94,6 +96,7 @@ func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, *StatusREST, *Rollbac
 
 	statusStore := *store
 	statusStore.UpdateStrategy = deployment.StatusStrategy
+	statusStore.ResetFieldsStrategy = deployment.StatusStrategy
 	return &REST{store, []string{"all"}}, &StatusREST{store: &statusStore}, &RollbackREST{store: store}, nil
 }
 
@@ -139,6 +142,11 @@ func (r *StatusREST) Update(ctx context.Context, name string, objInfo rest.Updat
 	// We are explicitly setting forceAllowCreate to false in the call to the underlying storage because
 	// subresources should never allow create on update.
 	return r.store.Update(ctx, name, objInfo, createValidation, updateValidation, false, options)
+}
+
+// GetResetFields implements rest.ResetFieldsStrategy
+func (r *StatusREST) GetResetFields() map[fieldpath.APIVersion]*fieldpath.Set {
+	return r.store.GetResetFields()
 }
 
 // RollbackREST implements the REST endpoint for initiating the rollback of a deployment

--- a/pkg/registry/apps/deployment/strategy.go
+++ b/pkg/registry/apps/deployment/strategy.go
@@ -35,6 +35,7 @@ import (
 	"k8s.io/kubernetes/pkg/apis/apps"
 	"k8s.io/kubernetes/pkg/apis/apps/validation"
 	corevalidation "k8s.io/kubernetes/pkg/apis/core/validation"
+	"sigs.k8s.io/structured-merge-diff/v3/fieldpath"
 )
 
 // deploymentStrategy implements behavior for Deployments.
@@ -66,6 +67,24 @@ func (deploymentStrategy) DefaultGarbageCollectionPolicy(ctx context.Context) re
 // NamespaceScoped is true for deployment.
 func (deploymentStrategy) NamespaceScoped() bool {
 	return true
+}
+
+// GetResetFields returns the set of fields that get reset by the strategy
+// and should not be modified by the user.
+func (deploymentStrategy) GetResetFields() map[fieldpath.APIVersion]*fieldpath.Set {
+	fields := map[fieldpath.APIVersion]*fieldpath.Set{
+		"apps/v1": fieldpath.NewSet(
+			fieldpath.MakePathOrDie("status"),
+		),
+	}
+
+	// TODO: make sure this works and is the best way to do this
+	specStr, templateStr := "spec", "template"
+	pod.AddDisabledTemplateFieldsTo(fields["apps/v1"].
+		WithPrefix(fieldpath.PathElement{FieldName: &specStr}).
+		WithPrefix(fieldpath.PathElement{FieldName: &templateStr}))
+
+	return fields
 }
 
 // PrepareForCreate clears fields that are not allowed to be set by end users on creation.
@@ -147,6 +166,17 @@ type deploymentStatusStrategy struct {
 
 // StatusStrategy is the default logic invoked when updating object status.
 var StatusStrategy = deploymentStatusStrategy{Strategy}
+
+// GetResetFields returns the set of fields that get reset by the strategy
+// and should not be modified by the user.
+func (deploymentStatusStrategy) GetResetFields() map[fieldpath.APIVersion]*fieldpath.Set {
+	return map[fieldpath.APIVersion]*fieldpath.Set{
+		"apps/v1": fieldpath.NewSet(
+			fieldpath.MakePathOrDie("spec"),
+			fieldpath.MakePathOrDie("metadata", "labels"),
+		),
+	}
+}
 
 // PrepareForUpdate clears fields that are not allowed to be set by end users on update of status
 func (deploymentStatusStrategy) PrepareForUpdate(ctx context.Context, obj, old runtime.Object) {

--- a/pkg/registry/apps/deployment/strategy.go
+++ b/pkg/registry/apps/deployment/strategy.go
@@ -35,7 +35,7 @@ import (
 	"k8s.io/kubernetes/pkg/apis/apps"
 	"k8s.io/kubernetes/pkg/apis/apps/validation"
 	corevalidation "k8s.io/kubernetes/pkg/apis/core/validation"
-	"sigs.k8s.io/structured-merge-diff/v3/fieldpath"
+	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
 )
 
 // deploymentStrategy implements behavior for Deployments.

--- a/pkg/registry/apps/replicaset/BUILD
+++ b/pkg/registry/apps/replicaset/BUILD
@@ -33,6 +33,7 @@ go_library(
         "//staging/src/k8s.io/apiserver/pkg/registry/rest:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/storage:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/storage/names:go_default_library",
+        "//vendor/sigs.k8s.io/structured-merge-diff/v4/fieldpath:go_default_library",
     ],
 )
 

--- a/pkg/registry/apps/replicaset/storage/BUILD
+++ b/pkg/registry/apps/replicaset/storage/BUILD
@@ -53,6 +53,7 @@ go_library(
         "//staging/src/k8s.io/apiserver/pkg/registry/generic:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/registry/generic/registry:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/registry/rest:go_default_library",
+        "//vendor/sigs.k8s.io/structured-merge-diff/v4/fieldpath:go_default_library",
     ],
 )
 

--- a/pkg/registry/apps/replicaset/storage/storage.go
+++ b/pkg/registry/apps/replicaset/storage/storage.go
@@ -40,6 +40,7 @@ import (
 	printersinternal "k8s.io/kubernetes/pkg/printers/internalversion"
 	printerstorage "k8s.io/kubernetes/pkg/printers/storage"
 	"k8s.io/kubernetes/pkg/registry/apps/replicaset"
+	"sigs.k8s.io/structured-merge-diff/v3/fieldpath"
 )
 
 // ReplicaSetStorage includes dummy storage for ReplicaSets and for Scale subresource.
@@ -77,9 +78,10 @@ func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, *StatusREST, error) {
 		PredicateFunc:            replicaset.MatchReplicaSet,
 		DefaultQualifiedResource: apps.Resource("replicasets"),
 
-		CreateStrategy: replicaset.Strategy,
-		UpdateStrategy: replicaset.Strategy,
-		DeleteStrategy: replicaset.Strategy,
+		CreateStrategy:      replicaset.Strategy,
+		UpdateStrategy:      replicaset.Strategy,
+		DeleteStrategy:      replicaset.Strategy,
+		ResetFieldsStrategy: replicaset.Strategy,
 
 		TableConvertor: printerstorage.TableConvertor{TableGenerator: printers.NewTableGenerator().With(printersinternal.AddHandlers)},
 	}
@@ -90,6 +92,7 @@ func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, *StatusREST, error) {
 
 	statusStore := *store
 	statusStore.UpdateStrategy = replicaset.StatusStrategy
+	statusStore.ResetFieldsStrategy = replicaset.StatusStrategy
 
 	return &REST{store, []string{"all"}}, &StatusREST{store: &statusStore}, nil
 }
@@ -136,6 +139,11 @@ func (r *StatusREST) Update(ctx context.Context, name string, objInfo rest.Updat
 	// We are explicitly setting forceAllowCreate to false in the call to the underlying storage because
 	// subresources should never allow create on update.
 	return r.store.Update(ctx, name, objInfo, createValidation, updateValidation, false, options)
+}
+
+// GetResetFields implements rest.ResetFieldsStrategy
+func (r *StatusREST) GetResetFields() map[fieldpath.APIVersion]*fieldpath.Set {
+	return r.store.GetResetFields()
 }
 
 // ScaleREST implements a Scale for ReplicaSet.

--- a/pkg/registry/apps/replicaset/storage/storage.go
+++ b/pkg/registry/apps/replicaset/storage/storage.go
@@ -40,7 +40,7 @@ import (
 	printersinternal "k8s.io/kubernetes/pkg/printers/internalversion"
 	printerstorage "k8s.io/kubernetes/pkg/printers/storage"
 	"k8s.io/kubernetes/pkg/registry/apps/replicaset"
-	"sigs.k8s.io/structured-merge-diff/v3/fieldpath"
+	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
 )
 
 // ReplicaSetStorage includes dummy storage for ReplicaSets and for Scale subresource.

--- a/pkg/registry/apps/replicaset/strategy.go
+++ b/pkg/registry/apps/replicaset/strategy.go
@@ -42,7 +42,7 @@ import (
 	"k8s.io/kubernetes/pkg/apis/apps"
 	"k8s.io/kubernetes/pkg/apis/apps/validation"
 	corevalidation "k8s.io/kubernetes/pkg/apis/core/validation"
-	"sigs.k8s.io/structured-merge-diff/v3/fieldpath"
+	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
 )
 
 // rsStrategy implements verification logic for ReplicaSets.

--- a/pkg/registry/apps/statefulset/BUILD
+++ b/pkg/registry/apps/statefulset/BUILD
@@ -28,6 +28,7 @@ go_library(
         "//staging/src/k8s.io/apiserver/pkg/endpoints/request:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/registry/rest:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/storage/names:go_default_library",
+        "//vendor/sigs.k8s.io/structured-merge-diff/v4/fieldpath:go_default_library",
     ],
 )
 

--- a/pkg/registry/apps/statefulset/storage/BUILD
+++ b/pkg/registry/apps/statefulset/storage/BUILD
@@ -52,6 +52,7 @@ go_library(
         "//staging/src/k8s.io/apiserver/pkg/registry/generic:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/registry/generic/registry:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/registry/rest:go_default_library",
+        "//vendor/sigs.k8s.io/structured-merge-diff/v4/fieldpath:go_default_library",
     ],
 )
 

--- a/pkg/registry/apps/statefulset/storage/storage.go
+++ b/pkg/registry/apps/statefulset/storage/storage.go
@@ -37,6 +37,7 @@ import (
 	printersinternal "k8s.io/kubernetes/pkg/printers/internalversion"
 	printerstorage "k8s.io/kubernetes/pkg/printers/storage"
 	"k8s.io/kubernetes/pkg/registry/apps/statefulset"
+	"sigs.k8s.io/structured-merge-diff/v3/fieldpath"
 )
 
 // StatefulSetStorage includes dummy storage for StatefulSets, and their Status and Scale subresource.
@@ -72,9 +73,10 @@ func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, *StatusREST, error) {
 		NewListFunc:              func() runtime.Object { return &apps.StatefulSetList{} },
 		DefaultQualifiedResource: apps.Resource("statefulsets"),
 
-		CreateStrategy: statefulset.Strategy,
-		UpdateStrategy: statefulset.Strategy,
-		DeleteStrategy: statefulset.Strategy,
+		CreateStrategy:      statefulset.Strategy,
+		UpdateStrategy:      statefulset.Strategy,
+		DeleteStrategy:      statefulset.Strategy,
+		ResetFieldsStrategy: statefulset.Strategy,
 
 		TableConvertor: printerstorage.TableConvertor{TableGenerator: printers.NewTableGenerator().With(printersinternal.AddHandlers)},
 	}
@@ -85,6 +87,7 @@ func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, *StatusREST, error) {
 
 	statusStore := *store
 	statusStore.UpdateStrategy = statefulset.StatusStrategy
+	statusStore.ResetFieldsStrategy = statefulset.StatusStrategy
 	return &REST{store}, &StatusREST{store: &statusStore}, nil
 }
 
@@ -116,6 +119,11 @@ func (r *StatusREST) Update(ctx context.Context, name string, objInfo rest.Updat
 	// We are explicitly setting forceAllowCreate to false in the call to the underlying storage because
 	// subresources should never allow create on update.
 	return r.store.Update(ctx, name, objInfo, createValidation, updateValidation, false, options)
+}
+
+// GetResetFields implements rest.ResetFieldsStrategy
+func (r *StatusREST) GetResetFields() map[fieldpath.APIVersion]*fieldpath.Set {
+	return r.store.GetResetFields()
 }
 
 // Implement ShortNamesProvider

--- a/pkg/registry/apps/statefulset/storage/storage.go
+++ b/pkg/registry/apps/statefulset/storage/storage.go
@@ -37,7 +37,7 @@ import (
 	printersinternal "k8s.io/kubernetes/pkg/printers/internalversion"
 	printerstorage "k8s.io/kubernetes/pkg/printers/storage"
 	"k8s.io/kubernetes/pkg/registry/apps/statefulset"
-	"sigs.k8s.io/structured-merge-diff/v3/fieldpath"
+	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
 )
 
 // StatefulSetStorage includes dummy storage for StatefulSets, and their Status and Scale subresource.

--- a/pkg/registry/apps/statefulset/strategy.go
+++ b/pkg/registry/apps/statefulset/strategy.go
@@ -33,7 +33,7 @@ import (
 	"k8s.io/kubernetes/pkg/apis/apps"
 	"k8s.io/kubernetes/pkg/apis/apps/validation"
 	corevalidation "k8s.io/kubernetes/pkg/apis/core/validation"
-	"sigs.k8s.io/structured-merge-diff/v3/fieldpath"
+	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
 )
 
 // statefulSetStrategy implements verification logic for Replication StatefulSets.

--- a/pkg/registry/autoscaling/horizontalpodautoscaler/BUILD
+++ b/pkg/registry/autoscaling/horizontalpodautoscaler/BUILD
@@ -19,6 +19,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/validation/field:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/storage/names:go_default_library",
+        "//vendor/sigs.k8s.io/structured-merge-diff/v4/fieldpath:go_default_library",
     ],
 )
 

--- a/pkg/registry/autoscaling/horizontalpodautoscaler/storage/BUILD
+++ b/pkg/registry/autoscaling/horizontalpodautoscaler/storage/BUILD
@@ -44,6 +44,7 @@ go_library(
         "//staging/src/k8s.io/apiserver/pkg/registry/generic:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/registry/generic/registry:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/registry/rest:go_default_library",
+        "//vendor/sigs.k8s.io/structured-merge-diff/v4/fieldpath:go_default_library",
     ],
 )
 

--- a/pkg/registry/autoscaling/horizontalpodautoscaler/storage/storage.go
+++ b/pkg/registry/autoscaling/horizontalpodautoscaler/storage/storage.go
@@ -29,6 +29,7 @@ import (
 	printersinternal "k8s.io/kubernetes/pkg/printers/internalversion"
 	printerstorage "k8s.io/kubernetes/pkg/printers/storage"
 	"k8s.io/kubernetes/pkg/registry/autoscaling/horizontalpodautoscaler"
+	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
 )
 
 // REST implements a RESTStorage for pod disruption budgets against etcd
@@ -43,9 +44,10 @@ func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, *StatusREST, error) {
 		NewListFunc:              func() runtime.Object { return &autoscaling.HorizontalPodAutoscalerList{} },
 		DefaultQualifiedResource: autoscaling.Resource("horizontalpodautoscalers"),
 
-		CreateStrategy: horizontalpodautoscaler.Strategy,
-		UpdateStrategy: horizontalpodautoscaler.Strategy,
-		DeleteStrategy: horizontalpodautoscaler.Strategy,
+		CreateStrategy:      horizontalpodautoscaler.Strategy,
+		UpdateStrategy:      horizontalpodautoscaler.Strategy,
+		DeleteStrategy:      horizontalpodautoscaler.Strategy,
+		ResetFieldsStrategy: horizontalpodautoscaler.Strategy,
 
 		TableConvertor: printerstorage.TableConvertor{TableGenerator: printers.NewTableGenerator().With(printersinternal.AddHandlers)},
 	}
@@ -56,6 +58,7 @@ func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, *StatusREST, error) {
 
 	statusStore := *store
 	statusStore.UpdateStrategy = horizontalpodautoscaler.StatusStrategy
+	statusStore.ResetFieldsStrategy = horizontalpodautoscaler.StatusStrategy
 	return &REST{store}, &StatusREST{store: &statusStore}, nil
 }
 
@@ -95,4 +98,9 @@ func (r *StatusREST) Update(ctx context.Context, name string, objInfo rest.Updat
 	// We are explicitly setting forceAllowCreate to false in the call to the underlying storage because
 	// subresources should never allow create on update.
 	return r.store.Update(ctx, name, objInfo, createValidation, updateValidation, false, options)
+}
+
+// GetResetFields implements rest.ResetFieldsStrategy
+func (r *StatusREST) GetResetFields() map[fieldpath.APIVersion]*fieldpath.Set {
+	return r.store.GetResetFields()
 }

--- a/pkg/registry/autoscaling/horizontalpodautoscaler/strategy.go
+++ b/pkg/registry/autoscaling/horizontalpodautoscaler/strategy.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	"k8s.io/kubernetes/pkg/apis/autoscaling"
 	"k8s.io/kubernetes/pkg/apis/autoscaling/validation"
+	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
 )
 
 // autoscalerStrategy implements behavior for HorizontalPodAutoscalers
@@ -40,6 +41,24 @@ var Strategy = autoscalerStrategy{legacyscheme.Scheme, names.SimpleNameGenerator
 // NamespaceScoped is true for autoscaler.
 func (autoscalerStrategy) NamespaceScoped() bool {
 	return true
+}
+
+// GetResetFields returns the set of fields that get reset by the strategy
+// and should not be modified by the user.
+func (autoscalerStrategy) GetResetFields() map[fieldpath.APIVersion]*fieldpath.Set {
+	fields := map[fieldpath.APIVersion]*fieldpath.Set{
+		"autoscaling/v1": fieldpath.NewSet(
+			fieldpath.MakePathOrDie("status"),
+		),
+		"autoscaling/v2beta1": fieldpath.NewSet(
+			fieldpath.MakePathOrDie("status"),
+		),
+		"autoscaling/v2beta2": fieldpath.NewSet(
+			fieldpath.MakePathOrDie("status"),
+		),
+	}
+
+	return fields
 }
 
 // PrepareForCreate clears fields that are not allowed to be set by end users on creation.
@@ -88,6 +107,24 @@ type autoscalerStatusStrategy struct {
 
 // StatusStrategy is the default logic invoked when updating object status.
 var StatusStrategy = autoscalerStatusStrategy{Strategy}
+
+// GetResetFields returns the set of fields that get reset by the strategy
+// and should not be modified by the user.
+func (autoscalerStatusStrategy) GetResetFields() map[fieldpath.APIVersion]*fieldpath.Set {
+	fields := map[fieldpath.APIVersion]*fieldpath.Set{
+		"autoscaling/v1": fieldpath.NewSet(
+			fieldpath.MakePathOrDie("spec"),
+		),
+		"autoscaling/v2beta1": fieldpath.NewSet(
+			fieldpath.MakePathOrDie("spec"),
+		),
+		"autoscaling/v2beta2": fieldpath.NewSet(
+			fieldpath.MakePathOrDie("spec"),
+		),
+	}
+
+	return fields
+}
 
 func (autoscalerStatusStrategy) PrepareForUpdate(ctx context.Context, obj, old runtime.Object) {
 	newAutoscaler := obj.(*autoscaling.HorizontalPodAutoscaler)

--- a/pkg/registry/batch/job/BUILD
+++ b/pkg/registry/batch/job/BUILD
@@ -33,6 +33,7 @@ go_library(
         "//staging/src/k8s.io/apiserver/pkg/storage:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/storage/names:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",
+        "//vendor/sigs.k8s.io/structured-merge-diff/v4/fieldpath:go_default_library",
     ],
 )
 

--- a/pkg/registry/batch/job/storage/BUILD
+++ b/pkg/registry/batch/job/storage/BUILD
@@ -39,6 +39,7 @@ go_library(
         "//staging/src/k8s.io/apiserver/pkg/registry/generic:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/registry/generic/registry:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/registry/rest:go_default_library",
+        "//vendor/sigs.k8s.io/structured-merge-diff/v4/fieldpath:go_default_library",
     ],
 )
 

--- a/pkg/registry/batch/job/storage/storage.go
+++ b/pkg/registry/batch/job/storage/storage.go
@@ -29,6 +29,7 @@ import (
 	printersinternal "k8s.io/kubernetes/pkg/printers/internalversion"
 	printerstorage "k8s.io/kubernetes/pkg/printers/storage"
 	"k8s.io/kubernetes/pkg/registry/batch/job"
+	"sigs.k8s.io/structured-merge-diff/v3/fieldpath"
 )
 
 // JobStorage includes dummy storage for Job.
@@ -63,9 +64,10 @@ func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, *StatusREST, error) {
 		PredicateFunc:            job.MatchJob,
 		DefaultQualifiedResource: batch.Resource("jobs"),
 
-		CreateStrategy: job.Strategy,
-		UpdateStrategy: job.Strategy,
-		DeleteStrategy: job.Strategy,
+		CreateStrategy:      job.Strategy,
+		UpdateStrategy:      job.Strategy,
+		DeleteStrategy:      job.Strategy,
+		ResetFieldsStrategy: job.Strategy,
 
 		TableConvertor: printerstorage.TableConvertor{TableGenerator: printers.NewTableGenerator().With(printersinternal.AddHandlers)},
 	}
@@ -76,6 +78,7 @@ func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, *StatusREST, error) {
 
 	statusStore := *store
 	statusStore.UpdateStrategy = job.StatusStrategy
+	statusStore.ResetFieldsStrategy = job.StatusStrategy
 
 	return &REST{store}, &StatusREST{store: &statusStore}, nil
 }
@@ -108,4 +111,9 @@ func (r *StatusREST) Update(ctx context.Context, name string, objInfo rest.Updat
 	// We are explicitly setting forceAllowCreate to false in the call to the underlying storage because
 	// subresources should never allow create on update.
 	return r.store.Update(ctx, name, objInfo, createValidation, updateValidation, false, options)
+}
+
+// GetResetFields implements rest.ResetFieldsStrategy
+func (r *StatusREST) GetResetFields() map[fieldpath.APIVersion]*fieldpath.Set {
+	return r.store.GetResetFields()
 }

--- a/pkg/registry/batch/job/storage/storage.go
+++ b/pkg/registry/batch/job/storage/storage.go
@@ -29,7 +29,7 @@ import (
 	printersinternal "k8s.io/kubernetes/pkg/printers/internalversion"
 	printerstorage "k8s.io/kubernetes/pkg/printers/storage"
 	"k8s.io/kubernetes/pkg/registry/batch/job"
-	"sigs.k8s.io/structured-merge-diff/v3/fieldpath"
+	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
 )
 
 // JobStorage includes dummy storage for Job.

--- a/pkg/registry/batch/job/strategy.go
+++ b/pkg/registry/batch/job/strategy.go
@@ -40,7 +40,7 @@ import (
 	"k8s.io/kubernetes/pkg/apis/batch/validation"
 	corevalidation "k8s.io/kubernetes/pkg/apis/core/validation"
 	"k8s.io/kubernetes/pkg/features"
-	"sigs.k8s.io/structured-merge-diff/v3/fieldpath"
+	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
 )
 
 // jobStrategy implements verification logic for Replication Controllers.

--- a/pkg/registry/certificates/certificates/BUILD
+++ b/pkg/registry/certificates/certificates/BUILD
@@ -27,6 +27,7 @@ go_library(
         "//staging/src/k8s.io/apiserver/pkg/endpoints/request:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/registry/generic:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/storage/names:go_default_library",
+        "//vendor/sigs.k8s.io/structured-merge-diff/v4/fieldpath:go_default_library",
     ],
 )
 

--- a/pkg/registry/certificates/certificates/storage/BUILD
+++ b/pkg/registry/certificates/certificates/storage/BUILD
@@ -20,6 +20,7 @@ go_library(
         "//staging/src/k8s.io/apiserver/pkg/registry/generic:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/registry/generic/registry:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/registry/rest:go_default_library",
+        "//vendor/sigs.k8s.io/structured-merge-diff/v4/fieldpath:go_default_library",
     ],
 )
 

--- a/pkg/registry/certificates/certificates/storage/storage.go
+++ b/pkg/registry/certificates/certificates/storage/storage.go
@@ -29,6 +29,7 @@ import (
 	printersinternal "k8s.io/kubernetes/pkg/printers/internalversion"
 	printerstorage "k8s.io/kubernetes/pkg/printers/storage"
 	csrregistry "k8s.io/kubernetes/pkg/registry/certificates/certificates"
+	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
 )
 
 // REST implements a RESTStorage for CertificateSigningRequest.
@@ -43,10 +44,11 @@ func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, *StatusREST, *Approva
 		NewListFunc:              func() runtime.Object { return &certificates.CertificateSigningRequestList{} },
 		DefaultQualifiedResource: certificates.Resource("certificatesigningrequests"),
 
-		CreateStrategy: csrregistry.Strategy,
-		UpdateStrategy: csrregistry.Strategy,
-		DeleteStrategy: csrregistry.Strategy,
-		ExportStrategy: csrregistry.Strategy,
+		CreateStrategy:      csrregistry.Strategy,
+		UpdateStrategy:      csrregistry.Strategy,
+		DeleteStrategy:      csrregistry.Strategy,
+		ExportStrategy:      csrregistry.Strategy,
+		ResetFieldsStrategy: csrregistry.Strategy,
 
 		TableConvertor: printerstorage.TableConvertor{TableGenerator: printers.NewTableGenerator().With(printersinternal.AddHandlers)},
 	}
@@ -60,9 +62,11 @@ func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, *StatusREST, *Approva
 	// dedicated strategies.
 	statusStore := *store
 	statusStore.UpdateStrategy = csrregistry.StatusStrategy
+	statusStore.ResetFieldsStrategy = csrregistry.StatusStrategy
 
 	approvalStore := *store
 	approvalStore.UpdateStrategy = csrregistry.ApprovalStrategy
+	approvalStore.ResetFieldsStrategy = csrregistry.ApprovalStrategy
 
 	return &REST{store}, &StatusREST{store: &statusStore}, &ApprovalREST{store: &approvalStore}, nil
 }
@@ -97,6 +101,11 @@ func (r *StatusREST) Update(ctx context.Context, name string, objInfo rest.Updat
 	return r.store.Update(ctx, name, objInfo, createValidation, updateValidation, false, options)
 }
 
+// GetResetFields implements rest.ResetFieldsStrategy
+func (r *StatusREST) GetResetFields() map[fieldpath.APIVersion]*fieldpath.Set {
+	return r.store.GetResetFields()
+}
+
 var _ = rest.Patcher(&StatusREST{})
 
 // ApprovalREST implements the REST endpoint for changing the approval state of a CSR.
@@ -119,6 +128,11 @@ func (r *ApprovalREST) Update(ctx context.Context, name string, objInfo rest.Upd
 	// We are explicitly setting forceAllowCreate to false in the call to the underlying storage because
 	// subresources should never allow create on update.
 	return r.store.Update(ctx, name, objInfo, createValidation, updateValidation, false, options)
+}
+
+// GetResetFields implements rest.ResetFieldsStrategy
+func (r *ApprovalREST) GetResetFields() map[fieldpath.APIVersion]*fieldpath.Set {
+	return r.store.GetResetFields()
 }
 
 var _ = rest.Patcher(&ApprovalREST{})

--- a/pkg/registry/certificates/certificates/strategy.go
+++ b/pkg/registry/certificates/certificates/strategy.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	"k8s.io/kubernetes/pkg/apis/certificates"
 	"k8s.io/kubernetes/pkg/apis/certificates/validation"
+	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
 )
 
 // csrStrategy implements behavior for CSRs
@@ -48,6 +49,23 @@ var Strategy = csrStrategy{legacyscheme.Scheme, names.SimpleNameGenerator}
 // NamespaceScoped is false for CSRs.
 func (csrStrategy) NamespaceScoped() bool {
 	return false
+}
+
+// GetResetFields returns the set of fields that get reset by the strategy
+// and should not be modified by the user.
+func (csrStrategy) GetResetFields() map[fieldpath.APIVersion]*fieldpath.Set {
+	fields := map[fieldpath.APIVersion]*fieldpath.Set{
+		"certificates.k8s.io/v1": fieldpath.NewSet(
+			fieldpath.MakePathOrDie("spec"),
+			fieldpath.MakePathOrDie("status"),
+		),
+		"certificates.k8s.io/v1beta1": fieldpath.NewSet(
+			fieldpath.MakePathOrDie("spec"),
+			fieldpath.MakePathOrDie("status"),
+		),
+	}
+
+	return fields
 }
 
 // AllowCreateOnUpdate is false for CSRs.
@@ -139,6 +157,23 @@ type csrStatusStrategy struct {
 }
 
 var StatusStrategy = csrStatusStrategy{Strategy}
+
+// GetResetFields returns the set of fields that get reset by the strategy
+// and should not be modified by the user.
+func (csrStatusStrategy) GetResetFields() map[fieldpath.APIVersion]*fieldpath.Set {
+	fields := map[fieldpath.APIVersion]*fieldpath.Set{
+		"certificates.k8s.io/v1": fieldpath.NewSet(
+			fieldpath.MakePathOrDie("spec"),
+			fieldpath.MakePathOrDie("status", "conditions"),
+		),
+		"certificates.k8s.io/v1beta1": fieldpath.NewSet(
+			fieldpath.MakePathOrDie("spec"),
+			fieldpath.MakePathOrDie("status", "conditions"),
+		),
+	}
+
+	return fields
+}
 
 func (csrStatusStrategy) PrepareForUpdate(ctx context.Context, obj, old runtime.Object) {
 	newCSR := obj.(*certificates.CertificateSigningRequest)
@@ -234,6 +269,23 @@ type csrApprovalStrategy struct {
 }
 
 var ApprovalStrategy = csrApprovalStrategy{Strategy}
+
+// GetResetFields returns the set of fields that get reset by the strategy
+// and should not be modified by the user.
+func (csrApprovalStrategy) GetResetFields() map[fieldpath.APIVersion]*fieldpath.Set {
+	fields := map[fieldpath.APIVersion]*fieldpath.Set{
+		"certificates.k8s.io/v1": fieldpath.NewSet(
+			fieldpath.MakePathOrDie("spec"),
+			fieldpath.MakePathOrDie("status", "certificate"),
+		),
+		"certificates.k8s.io/v1beta1": fieldpath.NewSet(
+			fieldpath.MakePathOrDie("spec"),
+			fieldpath.MakePathOrDie("status", "certificate"),
+		),
+	}
+
+	return fields
+}
 
 // PrepareForUpdate prepares the new certificate signing request by limiting
 // the data that is updated to only the conditions and populating condition timestamps

--- a/pkg/registry/core/namespace/BUILD
+++ b/pkg/registry/core/namespace/BUILD
@@ -22,7 +22,6 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/validation/field:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/registry/generic:go_default_library",
-        "//staging/src/k8s.io/apiserver/pkg/registry/rest:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/storage:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/storage/names:go_default_library",
         "//vendor/sigs.k8s.io/structured-merge-diff/v3/fieldpath:go_default_library",

--- a/pkg/registry/core/namespace/BUILD
+++ b/pkg/registry/core/namespace/BUILD
@@ -22,8 +22,10 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/validation/field:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/registry/generic:go_default_library",
+        "//staging/src/k8s.io/apiserver/pkg/registry/rest:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/storage:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/storage/names:go_default_library",
+        "//vendor/sigs.k8s.io/structured-merge-diff/v3/fieldpath:go_default_library",
     ],
 )
 

--- a/pkg/registry/core/namespace/BUILD
+++ b/pkg/registry/core/namespace/BUILD
@@ -24,7 +24,7 @@ go_library(
         "//staging/src/k8s.io/apiserver/pkg/registry/generic:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/storage:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/storage/names:go_default_library",
-        "//vendor/sigs.k8s.io/structured-merge-diff/v3/fieldpath:go_default_library",
+        "//vendor/sigs.k8s.io/structured-merge-diff/v4/fieldpath:go_default_library",
     ],
 )
 

--- a/pkg/registry/core/namespace/storage/BUILD
+++ b/pkg/registry/core/namespace/storage/BUILD
@@ -48,7 +48,7 @@ go_library(
         "//staging/src/k8s.io/apiserver/pkg/storage:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/storage/errors:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/util/dryrun:go_default_library",
-        "//vendor/sigs.k8s.io/structured-merge-diff/v3/fieldpath:go_default_library",
+        "//vendor/sigs.k8s.io/structured-merge-diff/v4/fieldpath:go_default_library",
     ],
 )
 

--- a/pkg/registry/core/namespace/storage/BUILD
+++ b/pkg/registry/core/namespace/storage/BUILD
@@ -48,6 +48,7 @@ go_library(
         "//staging/src/k8s.io/apiserver/pkg/storage:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/storage/errors:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/util/dryrun:go_default_library",
+        "//vendor/sigs.k8s.io/structured-merge-diff/v3/fieldpath:go_default_library",
     ],
 )
 

--- a/pkg/registry/core/namespace/storage/storage.go
+++ b/pkg/registry/core/namespace/storage/storage.go
@@ -24,6 +24,7 @@ import (
 	metainternalversion "k8s.io/apimachinery/pkg/apis/meta/internalversion"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/apiserver/pkg/registry/generic"
 	genericregistry "k8s.io/apiserver/pkg/registry/generic/registry"
@@ -31,13 +32,12 @@ import (
 	"k8s.io/apiserver/pkg/storage"
 	storageerr "k8s.io/apiserver/pkg/storage/errors"
 	"k8s.io/apiserver/pkg/util/dryrun"
-
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	api "k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/printers"
 	printersinternal "k8s.io/kubernetes/pkg/printers/internalversion"
 	printerstorage "k8s.io/kubernetes/pkg/printers/storage"
 	"k8s.io/kubernetes/pkg/registry/core/namespace"
+	"sigs.k8s.io/structured-merge-diff/v3/fieldpath"
 )
 
 // rest implements a RESTStorage for namespaces
@@ -297,9 +297,9 @@ func (r *REST) StorageVersion() runtime.GroupVersioner {
 	return r.store.StorageVersion()
 }
 
-// ResetFields implements rest.ResetFieldsProvider
-func (r *REST) ResetFields() rest.ResetFields {
-	return r.store.ResetFields()
+// GetResetFields implements rest.ResetFieldsStrategy
+func (r *REST) GetResetFields() map[fieldpath.APIVersion]*fieldpath.Set {
+	return r.store.GetResetFields()
 }
 func (r *StatusREST) New() runtime.Object {
 	return r.store.New()
@@ -317,9 +317,9 @@ func (r *StatusREST) Update(ctx context.Context, name string, objInfo rest.Updat
 	return r.store.Update(ctx, name, objInfo, createValidation, updateValidation, false, options)
 }
 
-// ResetFields implements rest.ResetFieldsProvider
-func (r *StatusREST) ResetFields() rest.ResetFields {
-	return r.store.ResetFields()
+// GetResetFields implements rest.ResetFieldsStrategy
+func (r *StatusREST) GetResetFields() map[fieldpath.APIVersion]*fieldpath.Set {
+	return r.store.GetResetFields()
 }
 func (r *FinalizeREST) New() runtime.Object {
 	return r.store.New()
@@ -332,7 +332,7 @@ func (r *FinalizeREST) Update(ctx context.Context, name string, objInfo rest.Upd
 	return r.store.Update(ctx, name, objInfo, createValidation, updateValidation, false, options)
 }
 
-// ResetFields implements rest.ResetFieldsProvider
-func (r *FinalizeREST) ResetFields() rest.ResetFields {
-	return r.store.ResetFields()
+// GetResetFields implements rest.ResetFieldsStrategy
+func (r *FinalizeREST) GetResetFields() map[fieldpath.APIVersion]*fieldpath.Set {
+	return r.store.GetResetFields()
 }

--- a/pkg/registry/core/namespace/storage/storage.go
+++ b/pkg/registry/core/namespace/storage/storage.go
@@ -37,7 +37,7 @@ import (
 	printersinternal "k8s.io/kubernetes/pkg/printers/internalversion"
 	printerstorage "k8s.io/kubernetes/pkg/printers/storage"
 	"k8s.io/kubernetes/pkg/registry/core/namespace"
-	"sigs.k8s.io/structured-merge-diff/v3/fieldpath"
+	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
 )
 
 // rest implements a RESTStorage for namespaces

--- a/pkg/registry/core/namespace/storage/storage.go
+++ b/pkg/registry/core/namespace/storage/storage.go
@@ -67,6 +67,7 @@ func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, *StatusREST, *Finaliz
 		CreateStrategy:      namespace.Strategy,
 		UpdateStrategy:      namespace.Strategy,
 		DeleteStrategy:      namespace.Strategy,
+		ResetFieldsStrategy: namespace.Strategy,
 		ReturnDeletedObject: true,
 
 		ShouldDeleteDuringUpdate: ShouldDeleteNamespaceDuringUpdate,
@@ -80,9 +81,11 @@ func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, *StatusREST, *Finaliz
 
 	statusStore := *store
 	statusStore.UpdateStrategy = namespace.StatusStrategy
+	statusStore.ResetFieldsStrategy = namespace.StatusStrategy
 
 	finalizeStore := *store
 	finalizeStore.UpdateStrategy = namespace.FinalizeStrategy
+	finalizeStore.ResetFieldsStrategy = namespace.FinalizeStrategy
 
 	return &REST{store: store, status: &statusStore}, &StatusREST{store: &statusStore}, &FinalizeREST{store: &finalizeStore}, nil
 }
@@ -294,6 +297,10 @@ func (r *REST) StorageVersion() runtime.GroupVersioner {
 	return r.store.StorageVersion()
 }
 
+// ResetFields implements rest.ResetFieldsProvider
+func (r *REST) ResetFields() rest.ResetFields {
+	return r.store.ResetFields()
+}
 func (r *StatusREST) New() runtime.Object {
 	return r.store.New()
 }
@@ -310,6 +317,10 @@ func (r *StatusREST) Update(ctx context.Context, name string, objInfo rest.Updat
 	return r.store.Update(ctx, name, objInfo, createValidation, updateValidation, false, options)
 }
 
+// ResetFields implements rest.ResetFieldsProvider
+func (r *StatusREST) ResetFields() rest.ResetFields {
+	return r.store.ResetFields()
+}
 func (r *FinalizeREST) New() runtime.Object {
 	return r.store.New()
 }
@@ -319,4 +330,9 @@ func (r *FinalizeREST) Update(ctx context.Context, name string, objInfo rest.Upd
 	// We are explicitly setting forceAllowCreate to false in the call to the underlying storage because
 	// subresources should never allow create on update.
 	return r.store.Update(ctx, name, objInfo, createValidation, updateValidation, false, options)
+}
+
+// ResetFields implements rest.ResetFieldsProvider
+func (r *FinalizeREST) ResetFields() rest.ResetFields {
+	return r.store.ResetFields()
 }

--- a/pkg/registry/core/namespace/strategy.go
+++ b/pkg/registry/core/namespace/strategy.go
@@ -30,7 +30,7 @@ import (
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	api "k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/apis/core/validation"
-	"sigs.k8s.io/structured-merge-diff/v3/fieldpath"
+	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
 )
 
 // namespaceStrategy implements behavior for Namespaces

--- a/pkg/registry/core/namespace/strategy.go
+++ b/pkg/registry/core/namespace/strategy.go
@@ -25,7 +25,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/apiserver/pkg/registry/generic"
-	"k8s.io/apiserver/pkg/registry/rest"
 	apistorage "k8s.io/apiserver/pkg/storage"
 	"k8s.io/apiserver/pkg/storage/names"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
@@ -49,10 +48,10 @@ func (namespaceStrategy) NamespaceScoped() bool {
 	return false
 }
 
-// ResetFields returns the set of fields that get reset by the strategy
+// GetResetFields returns the set of fields that get reset by the strategy
 // and should not be modified by the user.
-func (namespaceStrategy) ResetFields() rest.ResetFields {
-	return rest.ResetFields{
+func (namespaceStrategy) GetResetFields() map[fieldpath.APIVersion]*fieldpath.Set {
+	return map[fieldpath.APIVersion]*fieldpath.Set{
 		"v1": fieldpath.NewSet(
 			fieldpath.MakePathOrDie("status"),
 			fieldpath.MakePathOrDie("spec.finalizers"),
@@ -124,10 +123,10 @@ type namespaceStatusStrategy struct {
 
 var StatusStrategy = namespaceStatusStrategy{Strategy}
 
-// ResetFields returns the set of fields that get reset by the strategy
+// GetResetFields returns the set of fields that get reset by the strategy
 // and should not be modified by the user.
-func (namespaceStatusStrategy) ResetFields() rest.ResetFields {
-	return rest.ResetFields{
+func (namespaceStatusStrategy) GetResetFields() map[fieldpath.APIVersion]*fieldpath.Set {
+	return map[fieldpath.APIVersion]*fieldpath.Set{
 		"v1": fieldpath.NewSet(
 			fieldpath.MakePathOrDie("spec"),
 		),
@@ -154,10 +153,10 @@ func (namespaceFinalizeStrategy) ValidateUpdate(ctx context.Context, obj, old ru
 	return validation.ValidateNamespaceFinalizeUpdate(obj.(*api.Namespace), old.(*api.Namespace))
 }
 
-// ResetFields returns the set of fields that get reset by the strategy
+// GetResetFields returns the set of fields that get reset by the strategy
 // and should not be modified by the user.
-func (namespaceFinalizeStrategy) ResetFields() rest.ResetFields {
-	return rest.ResetFields{
+func (namespaceFinalizeStrategy) GetResetFields() map[fieldpath.APIVersion]*fieldpath.Set {
+	return map[fieldpath.APIVersion]*fieldpath.Set{
 		"v1": fieldpath.NewSet(
 			fieldpath.MakePathOrDie("status"),
 			fieldpath.MakePathOrDie("spec.finalizers"),

--- a/pkg/registry/core/node/BUILD
+++ b/pkg/registry/core/node/BUILD
@@ -32,6 +32,7 @@ go_library(
         "//staging/src/k8s.io/apiserver/pkg/storage:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/storage/names:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",
+        "//vendor/sigs.k8s.io/structured-merge-diff/v4/fieldpath:go_default_library",
     ],
 )
 

--- a/pkg/registry/core/node/storage/BUILD
+++ b/pkg/registry/core/node/storage/BUILD
@@ -45,6 +45,7 @@ go_library(
         "//staging/src/k8s.io/apiserver/pkg/registry/generic/registry:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/registry/rest:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/storage:go_default_library",
+        "//vendor/sigs.k8s.io/structured-merge-diff/v4/fieldpath:go_default_library",
     ],
 )
 

--- a/pkg/registry/core/node/storage/storage.go
+++ b/pkg/registry/core/node/storage/storage.go
@@ -37,6 +37,7 @@ import (
 	printerstorage "k8s.io/kubernetes/pkg/printers/storage"
 	"k8s.io/kubernetes/pkg/registry/core/node"
 	noderest "k8s.io/kubernetes/pkg/registry/core/node/rest"
+	"sigs.k8s.io/structured-merge-diff/v3/fieldpath"
 )
 
 // NodeStorage includes storage for nodes and all sub resources.
@@ -77,6 +78,11 @@ func (r *StatusREST) Update(ctx context.Context, name string, objInfo rest.Updat
 	return r.store.Update(ctx, name, objInfo, createValidation, updateValidation, false, options)
 }
 
+// GetResetFields implements rest.ResetFieldsStrategy
+func (r *StatusREST) GetResetFields() map[fieldpath.APIVersion]*fieldpath.Set {
+	return r.store.GetResetFields()
+}
+
 // NewStorage returns a NodeStorage object that will work against nodes.
 func NewStorage(optsGetter generic.RESTOptionsGetter, kubeletClientConfig client.KubeletClientConfig, proxyTransport http.RoundTripper) (*NodeStorage, error) {
 	store := &genericregistry.Store{
@@ -85,10 +91,11 @@ func NewStorage(optsGetter generic.RESTOptionsGetter, kubeletClientConfig client
 		PredicateFunc:            node.MatchNode,
 		DefaultQualifiedResource: api.Resource("nodes"),
 
-		CreateStrategy: node.Strategy,
-		UpdateStrategy: node.Strategy,
-		DeleteStrategy: node.Strategy,
-		ExportStrategy: node.Strategy,
+		CreateStrategy:      node.Strategy,
+		UpdateStrategy:      node.Strategy,
+		DeleteStrategy:      node.Strategy,
+		ExportStrategy:      node.Strategy,
+		ResetFieldsStrategy: node.Strategy,
 
 		TableConvertor: printerstorage.TableConvertor{TableGenerator: printers.NewTableGenerator().With(printersinternal.AddHandlers)},
 	}
@@ -103,6 +110,7 @@ func NewStorage(optsGetter generic.RESTOptionsGetter, kubeletClientConfig client
 
 	statusStore := *store
 	statusStore.UpdateStrategy = node.StatusStrategy
+	statusStore.ResetFieldsStrategy = node.StatusStrategy
 
 	// Set up REST handlers
 	nodeREST := &REST{Store: store, proxyTransport: proxyTransport}

--- a/pkg/registry/core/node/storage/storage.go
+++ b/pkg/registry/core/node/storage/storage.go
@@ -37,7 +37,7 @@ import (
 	printerstorage "k8s.io/kubernetes/pkg/printers/storage"
 	"k8s.io/kubernetes/pkg/registry/core/node"
 	noderest "k8s.io/kubernetes/pkg/registry/core/node/rest"
-	"sigs.k8s.io/structured-merge-diff/v3/fieldpath"
+	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
 )
 
 // NodeStorage includes storage for nodes and all sub resources.

--- a/pkg/registry/core/node/strategy.go
+++ b/pkg/registry/core/node/strategy.go
@@ -41,7 +41,7 @@ import (
 	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/kubelet/client"
 	proxyutil "k8s.io/kubernetes/pkg/proxy/util"
-	"sigs.k8s.io/structured-merge-diff/v3/fieldpath"
+	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
 )
 
 // nodeStrategy implements behavior for nodes

--- a/pkg/registry/core/persistentvolume/BUILD
+++ b/pkg/registry/core/persistentvolume/BUILD
@@ -26,6 +26,7 @@ go_library(
         "//staging/src/k8s.io/apiserver/pkg/registry/generic:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/storage:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/storage/names:go_default_library",
+        "//vendor/sigs.k8s.io/structured-merge-diff/v4/fieldpath:go_default_library",
     ],
 )
 

--- a/pkg/registry/core/persistentvolume/storage/BUILD
+++ b/pkg/registry/core/persistentvolume/storage/BUILD
@@ -43,6 +43,7 @@ go_library(
         "//staging/src/k8s.io/apiserver/pkg/registry/generic:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/registry/generic/registry:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/registry/rest:go_default_library",
+        "//vendor/sigs.k8s.io/structured-merge-diff/v4/fieldpath:go_default_library",
     ],
 )
 

--- a/pkg/registry/core/persistentvolume/storage/storage.go
+++ b/pkg/registry/core/persistentvolume/storage/storage.go
@@ -29,7 +29,7 @@ import (
 	printersinternal "k8s.io/kubernetes/pkg/printers/internalversion"
 	printerstorage "k8s.io/kubernetes/pkg/printers/storage"
 	"k8s.io/kubernetes/pkg/registry/core/persistentvolume"
-	"sigs.k8s.io/structured-merge-diff/v3/fieldpath"
+	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
 )
 
 // REST implements a RESTStorage for persistent volumes.

--- a/pkg/registry/core/persistentvolume/storage/storage.go
+++ b/pkg/registry/core/persistentvolume/storage/storage.go
@@ -29,6 +29,7 @@ import (
 	printersinternal "k8s.io/kubernetes/pkg/printers/internalversion"
 	printerstorage "k8s.io/kubernetes/pkg/printers/storage"
 	"k8s.io/kubernetes/pkg/registry/core/persistentvolume"
+	"sigs.k8s.io/structured-merge-diff/v3/fieldpath"
 )
 
 // REST implements a RESTStorage for persistent volumes.
@@ -48,6 +49,7 @@ func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, *StatusREST, error) {
 		UpdateStrategy:      persistentvolume.Strategy,
 		DeleteStrategy:      persistentvolume.Strategy,
 		ReturnDeletedObject: true,
+		ResetFieldsStrategy: persistentvolume.Strategy,
 
 		TableConvertor: printerstorage.TableConvertor{TableGenerator: printers.NewTableGenerator().With(printersinternal.AddHandlers)},
 	}
@@ -58,6 +60,7 @@ func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, *StatusREST, error) {
 
 	statusStore := *store
 	statusStore.UpdateStrategy = persistentvolume.StatusStrategy
+	statusStore.ResetFieldsStrategy = persistentvolume.StatusStrategy
 
 	return &REST{store}, &StatusREST{store: &statusStore}, nil
 }
@@ -90,4 +93,9 @@ func (r *StatusREST) Update(ctx context.Context, name string, objInfo rest.Updat
 	// We are explicitly setting forceAllowCreate to false in the call to the underlying storage because
 	// subresources should never allow create on update.
 	return r.store.Update(ctx, name, objInfo, createValidation, updateValidation, false, options)
+}
+
+// GetResetFields implements rest.ResetFieldsStrategy
+func (r *StatusREST) GetResetFields() map[fieldpath.APIVersion]*fieldpath.Set {
+	return r.store.GetResetFields()
 }

--- a/pkg/registry/core/persistentvolume/strategy.go
+++ b/pkg/registry/core/persistentvolume/strategy.go
@@ -32,6 +32,7 @@ import (
 	api "k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/apis/core/validation"
 	volumevalidation "k8s.io/kubernetes/pkg/volume/validation"
+	"sigs.k8s.io/structured-merge-diff/v3/fieldpath"
 )
 
 // persistentvolumeStrategy implements behavior for PersistentVolume objects
@@ -46,6 +47,20 @@ var Strategy = persistentvolumeStrategy{legacyscheme.Scheme, names.SimpleNameGen
 
 func (persistentvolumeStrategy) NamespaceScoped() bool {
 	return false
+}
+
+// GetResetFields returns the set of fields that get reset by the strategy
+// and should not be modified by the user.
+func (persistentvolumeStrategy) GetResetFields() map[fieldpath.APIVersion]*fieldpath.Set {
+	fields := map[fieldpath.APIVersion]*fieldpath.Set{
+		"v1": fieldpath.NewSet(
+			fieldpath.MakePathOrDie("status"),
+		),
+	}
+
+	pvutil.AddDisabledFieldsTo(fields["v1"])
+
+	return fields
 }
 
 // ResetBeforeCreate clears the Status field which is not allowed to be set by end users on creation.
@@ -95,6 +110,18 @@ type persistentvolumeStatusStrategy struct {
 }
 
 var StatusStrategy = persistentvolumeStatusStrategy{Strategy}
+
+// GetResetFields returns the set of fields that get reset by the strategy
+// and should not be modified by the user.
+func (persistentvolumeStatusStrategy) GetResetFields() map[fieldpath.APIVersion]*fieldpath.Set {
+	fields := map[fieldpath.APIVersion]*fieldpath.Set{
+		"v1": fieldpath.NewSet(
+			fieldpath.MakePathOrDie("spec"),
+		),
+	}
+
+	return fields
+}
 
 // PrepareForUpdate sets the Spec field which is not allowed to be changed when updating a PV's Status
 func (persistentvolumeStatusStrategy) PrepareForUpdate(ctx context.Context, obj, old runtime.Object) {

--- a/pkg/registry/core/persistentvolume/strategy.go
+++ b/pkg/registry/core/persistentvolume/strategy.go
@@ -32,7 +32,7 @@ import (
 	api "k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/apis/core/validation"
 	volumevalidation "k8s.io/kubernetes/pkg/volume/validation"
-	"sigs.k8s.io/structured-merge-diff/v3/fieldpath"
+	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
 )
 
 // persistentvolumeStrategy implements behavior for PersistentVolume objects

--- a/pkg/registry/core/persistentvolumeclaim/BUILD
+++ b/pkg/registry/core/persistentvolumeclaim/BUILD
@@ -27,6 +27,7 @@ go_library(
         "//staging/src/k8s.io/apiserver/pkg/storage:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/storage/names:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",
+        "//vendor/sigs.k8s.io/structured-merge-diff/v4/fieldpath:go_default_library",
     ],
 )
 

--- a/pkg/registry/core/persistentvolumeclaim/storage/BUILD
+++ b/pkg/registry/core/persistentvolumeclaim/storage/BUILD
@@ -43,6 +43,7 @@ go_library(
         "//staging/src/k8s.io/apiserver/pkg/registry/generic:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/registry/generic/registry:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/registry/rest:go_default_library",
+        "//vendor/sigs.k8s.io/structured-merge-diff/v4/fieldpath:go_default_library",
     ],
 )
 

--- a/pkg/registry/core/persistentvolumeclaim/storage/storage.go
+++ b/pkg/registry/core/persistentvolumeclaim/storage/storage.go
@@ -29,6 +29,7 @@ import (
 	printersinternal "k8s.io/kubernetes/pkg/printers/internalversion"
 	printerstorage "k8s.io/kubernetes/pkg/printers/storage"
 	"k8s.io/kubernetes/pkg/registry/core/persistentvolumeclaim"
+	"sigs.k8s.io/structured-merge-diff/v3/fieldpath"
 )
 
 // REST implements a RESTStorage for persistent volume claims.
@@ -48,6 +49,7 @@ func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, *StatusREST, error) {
 		UpdateStrategy:      persistentvolumeclaim.Strategy,
 		DeleteStrategy:      persistentvolumeclaim.Strategy,
 		ReturnDeletedObject: true,
+		ResetFieldsStrategy: persistentvolumeclaim.Strategy,
 
 		TableConvertor: printerstorage.TableConvertor{TableGenerator: printers.NewTableGenerator().With(printersinternal.AddHandlers)},
 	}
@@ -58,6 +60,7 @@ func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, *StatusREST, error) {
 
 	statusStore := *store
 	statusStore.UpdateStrategy = persistentvolumeclaim.StatusStrategy
+	statusStore.ResetFieldsStrategy = persistentvolumeclaim.StatusStrategy
 
 	return &REST{store}, &StatusREST{store: &statusStore}, nil
 }
@@ -90,4 +93,9 @@ func (r *StatusREST) Update(ctx context.Context, name string, objInfo rest.Updat
 	// We are explicitly setting forceAllowCreate to false in the call to the underlying storage because
 	// subresources should never allow create on update.
 	return r.store.Update(ctx, name, objInfo, createValidation, updateValidation, false, options)
+}
+
+// GetResetFields implements rest.ResetFieldsStrategy
+func (r *StatusREST) GetResetFields() map[fieldpath.APIVersion]*fieldpath.Set {
+	return r.store.GetResetFields()
 }

--- a/pkg/registry/core/persistentvolumeclaim/storage/storage.go
+++ b/pkg/registry/core/persistentvolumeclaim/storage/storage.go
@@ -29,7 +29,7 @@ import (
 	printersinternal "k8s.io/kubernetes/pkg/printers/internalversion"
 	printerstorage "k8s.io/kubernetes/pkg/printers/storage"
 	"k8s.io/kubernetes/pkg/registry/core/persistentvolumeclaim"
-	"sigs.k8s.io/structured-merge-diff/v3/fieldpath"
+	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
 )
 
 // REST implements a RESTStorage for persistent volume claims.

--- a/pkg/registry/core/persistentvolumeclaim/strategy.go
+++ b/pkg/registry/core/persistentvolumeclaim/strategy.go
@@ -33,6 +33,7 @@ import (
 	api "k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/apis/core/validation"
 	"k8s.io/kubernetes/pkg/features"
+	"sigs.k8s.io/structured-merge-diff/v3/fieldpath"
 )
 
 // persistentvolumeclaimStrategy implements behavior for PersistentVolumeClaim objects
@@ -47,6 +48,19 @@ var Strategy = persistentvolumeclaimStrategy{legacyscheme.Scheme, names.SimpleNa
 
 func (persistentvolumeclaimStrategy) NamespaceScoped() bool {
 	return true
+}
+
+// GetResetFields returns the set of fields that get reset by the strategy
+// and should not be modified by the user.
+func (persistentvolumeclaimStrategy) GetResetFields() map[fieldpath.APIVersion]*fieldpath.Set {
+	fields := map[fieldpath.APIVersion]*fieldpath.Set{
+		"v1": fieldpath.NewSet(
+			fieldpath.MakePathOrDie("status"),
+			// TODO: add fields reset by pvcutil.DropDisabledFields
+		),
+	}
+
+	return fields
 }
 
 // PrepareForCreate clears the Status field which is not allowed to be set by end users on creation.
@@ -93,6 +107,22 @@ type persistentvolumeclaimStatusStrategy struct {
 }
 
 var StatusStrategy = persistentvolumeclaimStatusStrategy{Strategy}
+
+// GetResetFields returns the set of fields that get reset by the strategy
+// and should not be modified by the user.
+func (persistentvolumeclaimStatusStrategy) GetResetFields() map[fieldpath.APIVersion]*fieldpath.Set {
+	fields := map[fieldpath.APIVersion]*fieldpath.Set{
+		"v1": fieldpath.NewSet(
+			fieldpath.MakePathOrDie("spec"),
+		),
+	}
+
+	if !utilfeature.DefaultFeatureGate.Enabled(features.ExpandPersistentVolumes) {
+		fields["v1"].Insert(fieldpath.MakePathOrDie("status", "conditions"))
+	}
+
+	return fields
+}
 
 // PrepareForUpdate sets the Spec field which is not allowed to be changed when updating a PV's Status
 func (persistentvolumeclaimStatusStrategy) PrepareForUpdate(ctx context.Context, obj, old runtime.Object) {

--- a/pkg/registry/core/persistentvolumeclaim/strategy.go
+++ b/pkg/registry/core/persistentvolumeclaim/strategy.go
@@ -33,7 +33,7 @@ import (
 	api "k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/apis/core/validation"
 	"k8s.io/kubernetes/pkg/features"
-	"sigs.k8s.io/structured-merge-diff/v3/fieldpath"
+	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
 )
 
 // persistentvolumeclaimStrategy implements behavior for PersistentVolumeClaim objects

--- a/pkg/registry/core/pod/BUILD
+++ b/pkg/registry/core/pod/BUILD
@@ -33,7 +33,6 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/util/validation/field:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/features:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/registry/generic:go_default_library",
-        "//staging/src/k8s.io/apiserver/pkg/registry/rest:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/storage:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/storage/names:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",

--- a/pkg/registry/core/pod/BUILD
+++ b/pkg/registry/core/pod/BUILD
@@ -37,7 +37,7 @@ go_library(
         "//staging/src/k8s.io/apiserver/pkg/storage/names:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",
         "//staging/src/k8s.io/client-go/tools/cache:go_default_library",
-        "//vendor/sigs.k8s.io/structured-merge-diff/v3/fieldpath:go_default_library",
+        "//vendor/sigs.k8s.io/structured-merge-diff/v4/fieldpath:go_default_library",
     ],
 )
 

--- a/pkg/registry/core/pod/BUILD
+++ b/pkg/registry/core/pod/BUILD
@@ -33,10 +33,12 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/util/validation/field:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/features:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/registry/generic:go_default_library",
+        "//staging/src/k8s.io/apiserver/pkg/registry/rest:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/storage:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/storage/names:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",
         "//staging/src/k8s.io/client-go/tools/cache:go_default_library",
+        "//vendor/sigs.k8s.io/structured-merge-diff/v3/fieldpath:go_default_library",
     ],
 )
 

--- a/pkg/registry/core/pod/storage/BUILD
+++ b/pkg/registry/core/pod/storage/BUILD
@@ -78,7 +78,7 @@ go_library(
         "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/typed/policy/v1beta1:go_default_library",
         "//staging/src/k8s.io/client-go/util/retry:go_default_library",
-        "//vendor/sigs.k8s.io/structured-merge-diff/v3/fieldpath:go_default_library",
+        "//vendor/sigs.k8s.io/structured-merge-diff/v4/fieldpath:go_default_library",
     ],
 )
 

--- a/pkg/registry/core/pod/storage/BUILD
+++ b/pkg/registry/core/pod/storage/BUILD
@@ -78,6 +78,7 @@ go_library(
         "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/typed/policy/v1beta1:go_default_library",
         "//staging/src/k8s.io/client-go/util/retry:go_default_library",
+        "//vendor/sigs.k8s.io/structured-merge-diff/v3/fieldpath:go_default_library",
     ],
 )
 

--- a/pkg/registry/core/pod/storage/storage.go
+++ b/pkg/registry/core/pod/storage/storage.go
@@ -44,6 +44,7 @@ import (
 	printerstorage "k8s.io/kubernetes/pkg/printers/storage"
 	registrypod "k8s.io/kubernetes/pkg/registry/core/pod"
 	podrest "k8s.io/kubernetes/pkg/registry/core/pod/rest"
+	"sigs.k8s.io/structured-merge-diff/v3/fieldpath"
 )
 
 // PodStorage includes storage for pods and all sub resources
@@ -280,9 +281,9 @@ func (r *StatusREST) Update(ctx context.Context, name string, objInfo rest.Updat
 	return r.store.Update(ctx, name, objInfo, createValidation, updateValidation, false, options)
 }
 
-// ResetFields implements rest.ResetFieldsProvider
-func (r *StatusREST) ResetFields() rest.ResetFields {
-	return r.store.ResetFields()
+// GetResetFields implements rest.ResetFieldsStrategy
+func (r *StatusREST) GetResetFields() map[fieldpath.APIVersion]*fieldpath.Set {
+	return r.store.GetResetFields()
 }
 
 // EphemeralContainersREST implements the REST endpoint for adding EphemeralContainers

--- a/pkg/registry/core/pod/storage/storage.go
+++ b/pkg/registry/core/pod/storage/storage.go
@@ -44,7 +44,7 @@ import (
 	printerstorage "k8s.io/kubernetes/pkg/printers/storage"
 	registrypod "k8s.io/kubernetes/pkg/registry/core/pod"
 	podrest "k8s.io/kubernetes/pkg/registry/core/pod/rest"
-	"sigs.k8s.io/structured-merge-diff/v3/fieldpath"
+	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
 )
 
 // PodStorage includes storage for pods and all sub resources

--- a/pkg/registry/core/pod/storage/storage.go
+++ b/pkg/registry/core/pod/storage/storage.go
@@ -79,6 +79,7 @@ func NewStorage(optsGetter generic.RESTOptionsGetter, k client.ConnectionInfoGet
 		CreateStrategy:      registrypod.Strategy,
 		UpdateStrategy:      registrypod.Strategy,
 		DeleteStrategy:      registrypod.Strategy,
+		ResetFieldsStrategy: registrypod.Strategy,
 		ReturnDeletedObject: true,
 
 		TableConvertor: printerstorage.TableConvertor{TableGenerator: printers.NewTableGenerator().With(printersinternal.AddHandlers)},
@@ -95,6 +96,7 @@ func NewStorage(optsGetter generic.RESTOptionsGetter, k client.ConnectionInfoGet
 
 	statusStore := *store
 	statusStore.UpdateStrategy = registrypod.StatusStrategy
+	statusStore.ResetFieldsStrategy = registrypod.StatusStrategy
 	ephemeralContainersStore := *store
 	ephemeralContainersStore.UpdateStrategy = registrypod.EphemeralContainersStrategy
 
@@ -276,6 +278,11 @@ func (r *StatusREST) Update(ctx context.Context, name string, objInfo rest.Updat
 	// We are explicitly setting forceAllowCreate to false in the call to the underlying storage because
 	// subresources should never allow create on update.
 	return r.store.Update(ctx, name, objInfo, createValidation, updateValidation, false, options)
+}
+
+// ResetFields implements rest.ResetFieldsProvider
+func (r *StatusREST) ResetFields() rest.ResetFields {
+	return r.store.ResetFields()
 }
 
 // EphemeralContainersREST implements the REST endpoint for adding EphemeralContainers

--- a/pkg/registry/core/pod/strategy.go
+++ b/pkg/registry/core/pod/strategy.go
@@ -37,7 +37,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	genericfeatures "k8s.io/apiserver/pkg/features"
 	"k8s.io/apiserver/pkg/registry/generic"
-	"k8s.io/apiserver/pkg/registry/rest"
 	"k8s.io/apiserver/pkg/storage"
 	"k8s.io/apiserver/pkg/storage/names"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
@@ -68,10 +67,10 @@ func (podStrategy) NamespaceScoped() bool {
 	return true
 }
 
-// ResetFields returns the set of fields that get reset by the strategy
+// GetResetFields returns the set of fields that get reset by the strategy
 // and should not be modified by the user.
-func (podStrategy) ResetFields() rest.ResetFields {
-	fields := rest.ResetFields{
+func (podStrategy) GetResetFields() map[fieldpath.APIVersion]*fieldpath.Set {
+	fields := map[fieldpath.APIVersion]*fieldpath.Set{
 		"v1": fieldpath.NewSet(
 			fieldpath.MakePathOrDie("status"),
 			// TODO: add fields reset by podutil.DropDisabledPodFields
@@ -183,10 +182,10 @@ type podStatusStrategy struct {
 // StatusStrategy wraps and exports the used podStrategy for the storage package.
 var StatusStrategy = podStatusStrategy{Strategy}
 
-// ResetFields returns the set of fields that get reset by the strategy
+// GetResetFields returns the set of fields that get reset by the strategy
 // and should not be modified by the user.
-func (podStatusStrategy) ResetFields() rest.ResetFields {
-	return rest.ResetFields{
+func (podStatusStrategy) GetResetFields() map[fieldpath.APIVersion]*fieldpath.Set {
+	return map[fieldpath.APIVersion]*fieldpath.Set{
 		"v1": fieldpath.NewSet(
 			fieldpath.MakePathOrDie("spec"),
 			fieldpath.MakePathOrDie("metadata", "deletionTimestamp"),

--- a/pkg/registry/core/pod/strategy.go
+++ b/pkg/registry/core/pod/strategy.go
@@ -49,7 +49,7 @@ import (
 	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/kubelet/client"
 	proxyutil "k8s.io/kubernetes/pkg/proxy/util"
-	"sigs.k8s.io/structured-merge-diff/v3/fieldpath"
+	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
 )
 
 // podStrategy implements behavior for Pods

--- a/pkg/registry/core/pod/strategy.go
+++ b/pkg/registry/core/pod/strategy.go
@@ -79,7 +79,7 @@ func (podStrategy) GetResetFields() map[fieldpath.APIVersion]*fieldpath.Set {
 
 	// For more versions, loop here
 	// This should not be done at every call as currently the result can not change at runtime
-	podutil.AddDisabledFields(fields["v1"])
+	podutil.AddDisabledFieldsTo(fields["v1"])
 
 	return fields
 }

--- a/pkg/registry/core/replicationcontroller/BUILD
+++ b/pkg/registry/core/replicationcontroller/BUILD
@@ -31,6 +31,7 @@ go_library(
         "//staging/src/k8s.io/apiserver/pkg/registry/rest:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/storage:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/storage/names:go_default_library",
+        "//vendor/sigs.k8s.io/structured-merge-diff/v4/fieldpath:go_default_library",
     ],
 )
 

--- a/pkg/registry/core/replicationcontroller/storage/BUILD
+++ b/pkg/registry/core/replicationcontroller/storage/BUILD
@@ -51,6 +51,7 @@ go_library(
         "//staging/src/k8s.io/apiserver/pkg/registry/generic:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/registry/generic/registry:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/registry/rest:go_default_library",
+        "//vendor/sigs.k8s.io/structured-merge-diff/v4/fieldpath:go_default_library",
     ],
 )
 

--- a/pkg/registry/core/replicationcontroller/storage/storage.go
+++ b/pkg/registry/core/replicationcontroller/storage/storage.go
@@ -39,6 +39,7 @@ import (
 	printersinternal "k8s.io/kubernetes/pkg/printers/internalversion"
 	printerstorage "k8s.io/kubernetes/pkg/printers/storage"
 	"k8s.io/kubernetes/pkg/registry/core/replicationcontroller"
+	"sigs.k8s.io/structured-merge-diff/v3/fieldpath"
 )
 
 // ControllerStorage includes dummy storage for Replication Controllers and for Scale subresource.
@@ -73,9 +74,10 @@ func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, *StatusREST, error) {
 		PredicateFunc:            replicationcontroller.MatchController,
 		DefaultQualifiedResource: api.Resource("replicationcontrollers"),
 
-		CreateStrategy: replicationcontroller.Strategy,
-		UpdateStrategy: replicationcontroller.Strategy,
-		DeleteStrategy: replicationcontroller.Strategy,
+		CreateStrategy:      replicationcontroller.Strategy,
+		UpdateStrategy:      replicationcontroller.Strategy,
+		DeleteStrategy:      replicationcontroller.Strategy,
+		ResetFieldsStrategy: replicationcontroller.Strategy,
 
 		TableConvertor: printerstorage.TableConvertor{TableGenerator: printers.NewTableGenerator().With(printersinternal.AddHandlers)},
 	}
@@ -86,6 +88,7 @@ func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, *StatusREST, error) {
 
 	statusStore := *store
 	statusStore.UpdateStrategy = replicationcontroller.StatusStrategy
+	statusStore.ResetFieldsStrategy = replicationcontroller.StatusStrategy
 
 	return &REST{store}, &StatusREST{store: &statusStore}, nil
 }
@@ -125,6 +128,11 @@ func (r *StatusREST) Update(ctx context.Context, name string, objInfo rest.Updat
 	// We are explicitly setting forceAllowCreate to false in the call to the underlying storage because
 	// subresources should never allow create on update.
 	return r.store.Update(ctx, name, objInfo, createValidation, updateValidation, false, options)
+}
+
+// GetResetFields implements rest.ResetFieldsStrategy
+func (r *StatusREST) GetResetFields() map[fieldpath.APIVersion]*fieldpath.Set {
+	return r.store.GetResetFields()
 }
 
 type ScaleREST struct {

--- a/pkg/registry/core/replicationcontroller/storage/storage.go
+++ b/pkg/registry/core/replicationcontroller/storage/storage.go
@@ -39,7 +39,7 @@ import (
 	printersinternal "k8s.io/kubernetes/pkg/printers/internalversion"
 	printerstorage "k8s.io/kubernetes/pkg/printers/storage"
 	"k8s.io/kubernetes/pkg/registry/core/replicationcontroller"
-	"sigs.k8s.io/structured-merge-diff/v3/fieldpath"
+	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
 )
 
 // ControllerStorage includes dummy storage for Replication Controllers and for Scale subresource.

--- a/pkg/registry/core/replicationcontroller/strategy.go
+++ b/pkg/registry/core/replicationcontroller/strategy.go
@@ -41,7 +41,7 @@ import (
 	api "k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/apis/core/helper"
 	"k8s.io/kubernetes/pkg/apis/core/validation"
-	"sigs.k8s.io/structured-merge-diff/v3/fieldpath"
+	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
 )
 
 // rcStrategy implements verification logic for Replication Controllers.

--- a/pkg/registry/core/resourcequota/BUILD
+++ b/pkg/registry/core/resourcequota/BUILD
@@ -20,6 +20,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/validation/field:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/storage/names:go_default_library",
+        "//vendor/sigs.k8s.io/structured-merge-diff/v4/fieldpath:go_default_library",
     ],
 )
 

--- a/pkg/registry/core/resourcequota/storage/BUILD
+++ b/pkg/registry/core/resourcequota/storage/BUILD
@@ -42,6 +42,7 @@ go_library(
         "//staging/src/k8s.io/apiserver/pkg/registry/generic:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/registry/generic/registry:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/registry/rest:go_default_library",
+        "//vendor/sigs.k8s.io/structured-merge-diff/v4/fieldpath:go_default_library",
     ],
 )
 

--- a/pkg/registry/core/resourcequota/storage/storage.go
+++ b/pkg/registry/core/resourcequota/storage/storage.go
@@ -29,6 +29,7 @@ import (
 	printersinternal "k8s.io/kubernetes/pkg/printers/internalversion"
 	printerstorage "k8s.io/kubernetes/pkg/printers/storage"
 	"k8s.io/kubernetes/pkg/registry/core/resourcequota"
+	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
 )
 
 // REST implements a RESTStorage for resource quotas.
@@ -46,6 +47,7 @@ func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, *StatusREST, error) {
 		CreateStrategy:      resourcequota.Strategy,
 		UpdateStrategy:      resourcequota.Strategy,
 		DeleteStrategy:      resourcequota.Strategy,
+		ResetFieldsStrategy: resourcequota.Strategy,
 		ReturnDeletedObject: true,
 
 		TableConvertor: printerstorage.TableConvertor{TableGenerator: printers.NewTableGenerator().With(printersinternal.AddHandlers)},
@@ -57,6 +59,7 @@ func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, *StatusREST, error) {
 
 	statusStore := *store
 	statusStore.UpdateStrategy = resourcequota.StatusStrategy
+	statusStore.ResetFieldsStrategy = resourcequota.StatusStrategy
 
 	return &REST{store}, &StatusREST{store: &statusStore}, nil
 }
@@ -89,4 +92,9 @@ func (r *StatusREST) Update(ctx context.Context, name string, objInfo rest.Updat
 	// We are explicitly setting forceAllowCreate to false in the call to the underlying storage because
 	// subresources should never allow create on update.
 	return r.store.Update(ctx, name, objInfo, createValidation, updateValidation, false, options)
+}
+
+// GetResetFields implements rest.ResetFieldsStrategy
+func (r *StatusREST) GetResetFields() map[fieldpath.APIVersion]*fieldpath.Set {
+	return r.store.GetResetFields()
 }

--- a/pkg/registry/core/resourcequota/strategy.go
+++ b/pkg/registry/core/resourcequota/strategy.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	api "k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/apis/core/validation"
+	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
 )
 
 // resourcequotaStrategy implements behavior for ResourceQuota objects
@@ -40,6 +41,18 @@ var Strategy = resourcequotaStrategy{legacyscheme.Scheme, names.SimpleNameGenera
 // NamespaceScoped is true for resourcequotas.
 func (resourcequotaStrategy) NamespaceScoped() bool {
 	return true
+}
+
+// GetResetFields returns the set of fields that get reset by the strategy
+// and should not be modified by the user.
+func (resourcequotaStrategy) GetResetFields() map[fieldpath.APIVersion]*fieldpath.Set {
+	fields := map[fieldpath.APIVersion]*fieldpath.Set{
+		"v1": fieldpath.NewSet(
+			fieldpath.MakePathOrDie("status"),
+		),
+	}
+
+	return fields
 }
 
 // PrepareForCreate clears fields that are not allowed to be set by end users on creation.
@@ -86,6 +99,18 @@ type resourcequotaStatusStrategy struct {
 
 // StatusStrategy is the default logic invoked when updating object status.
 var StatusStrategy = resourcequotaStatusStrategy{Strategy}
+
+// GetResetFields returns the set of fields that get reset by the strategy
+// and should not be modified by the user.
+func (resourcequotaStatusStrategy) GetResetFields() map[fieldpath.APIVersion]*fieldpath.Set {
+	fields := map[fieldpath.APIVersion]*fieldpath.Set{
+		"v1": fieldpath.NewSet(
+			fieldpath.MakePathOrDie("spec"),
+		),
+	}
+
+	return fields
+}
 
 func (resourcequotaStatusStrategy) PrepareForUpdate(ctx context.Context, obj, old runtime.Object) {
 	newResourcequota := obj.(*api.ResourceQuota)

--- a/pkg/registry/core/service/BUILD
+++ b/pkg/registry/core/service/BUILD
@@ -28,6 +28,7 @@ go_library(
         "//staging/src/k8s.io/apiserver/pkg/storage/names:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",
         "//vendor/k8s.io/utils/net:go_default_library",
+        "//vendor/sigs.k8s.io/structured-merge-diff/v4/fieldpath:go_default_library",
     ],
 )
 

--- a/pkg/registry/core/service/storage/BUILD
+++ b/pkg/registry/core/service/storage/BUILD
@@ -79,6 +79,7 @@ go_library(
         "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",
         "//vendor/k8s.io/klog/v2:go_default_library",
         "//vendor/k8s.io/utils/net:go_default_library",
+        "//vendor/sigs.k8s.io/structured-merge-diff/v4/fieldpath:go_default_library",
     ],
 )
 

--- a/pkg/registry/core/service/storage/BUILD
+++ b/pkg/registry/core/service/storage/BUILD
@@ -41,6 +41,7 @@ go_test(
         "//staging/src/k8s.io/apiserver/pkg/util/dryrun:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",
         "//staging/src/k8s.io/component-base/featuregate/testing:go_default_library",
+        "//vendor/sigs.k8s.io/structured-merge-diff/v4/fieldpath:go_default_library",
     ],
 )
 

--- a/pkg/registry/core/service/storage/rest.go
+++ b/pkg/registry/core/service/storage/rest.go
@@ -36,19 +36,18 @@ import (
 	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/registry/rest"
 	"k8s.io/apiserver/pkg/util/dryrun"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/klog/v2"
-
 	apiservice "k8s.io/kubernetes/pkg/api/service"
 	api "k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/apis/core/helper"
 	"k8s.io/kubernetes/pkg/apis/core/validation"
+	"k8s.io/kubernetes/pkg/features"
 	registry "k8s.io/kubernetes/pkg/registry/core/service"
 	"k8s.io/kubernetes/pkg/registry/core/service/ipallocator"
 	"k8s.io/kubernetes/pkg/registry/core/service/portallocator"
 	netutil "k8s.io/utils/net"
-
-	utilfeature "k8s.io/apiserver/pkg/util/feature"
-	"k8s.io/kubernetes/pkg/features"
+	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
 )
 
 // REST adapts a service registry into apiserver's RESTStorage model.
@@ -82,6 +81,7 @@ type ServiceStorage interface {
 	rest.Watcher
 	rest.Exporter
 	rest.StorageVersionProvider
+	rest.ResetFieldsStrategy
 }
 
 type EndpointsStorage interface {
@@ -460,6 +460,11 @@ func (rs *REST) Update(ctx context.Context, name string, objInfo rest.UpdatedObj
 	}
 
 	return out, created, err
+}
+
+// GetResetFields implements rest.ResetFieldsStrategy
+func (rs *REST) GetResetFields() map[fieldpath.APIVersion]*fieldpath.Set {
+	return rs.services.GetResetFields()
 }
 
 // Implement Redirector.

--- a/pkg/registry/core/service/storage/rest_test.go
+++ b/pkg/registry/core/service/storage/rest_test.go
@@ -45,6 +45,7 @@ import (
 	"k8s.io/kubernetes/pkg/registry/core/service/ipallocator"
 	"k8s.io/kubernetes/pkg/registry/core/service/portallocator"
 	"k8s.io/kubernetes/pkg/registry/registrytest"
+	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
 
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
@@ -170,6 +171,15 @@ func (s *serviceStorage) Export(ctx context.Context, name string, opts metav1.Ex
 
 func (s *serviceStorage) StorageVersion() runtime.GroupVersioner {
 	panic("not implemented")
+}
+
+// GetResetFields implements rest.ResetFieldsStrategy
+func (s *serviceStorage) GetResetFields() map[fieldpath.APIVersion]*fieldpath.Set {
+	return nil
+}
+
+func generateRandomNodePort() int32 {
+	return int32(rand.IntnRange(30001, 30999))
 }
 
 func NewTestREST(t *testing.T, endpoints *api.EndpointsList, ipFamilies []api.IPFamily) (*REST, *serviceStorage, *etcd3testing.EtcdTestServer) {

--- a/pkg/registry/flowcontrol/flowschema/BUILD
+++ b/pkg/registry/flowcontrol/flowschema/BUILD
@@ -16,6 +16,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/validation/field:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/storage/names:go_default_library",
+        "//vendor/sigs.k8s.io/structured-merge-diff/v4/fieldpath:go_default_library",
     ],
 )
 

--- a/pkg/registry/flowcontrol/flowschema/storage/BUILD
+++ b/pkg/registry/flowcontrol/flowschema/storage/BUILD
@@ -16,6 +16,7 @@ go_library(
         "//staging/src/k8s.io/apiserver/pkg/registry/generic:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/registry/generic/registry:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/registry/rest:go_default_library",
+        "//vendor/sigs.k8s.io/structured-merge-diff/v4/fieldpath:go_default_library",
     ],
 )
 

--- a/pkg/registry/flowcontrol/flowschema/storage/storage.go
+++ b/pkg/registry/flowcontrol/flowschema/storage/storage.go
@@ -29,6 +29,7 @@ import (
 	printersinternal "k8s.io/kubernetes/pkg/printers/internalversion"
 	printerstorage "k8s.io/kubernetes/pkg/printers/storage"
 	"k8s.io/kubernetes/pkg/registry/flowcontrol/flowschema"
+	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
 )
 
 // FlowSchemaStorage implements storage for flow schema.
@@ -49,9 +50,10 @@ func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, *StatusREST, error) {
 		NewListFunc:              func() runtime.Object { return &flowcontrol.FlowSchemaList{} },
 		DefaultQualifiedResource: flowcontrol.Resource("flowschemas"),
 
-		CreateStrategy: flowschema.Strategy,
-		UpdateStrategy: flowschema.Strategy,
-		DeleteStrategy: flowschema.Strategy,
+		CreateStrategy:      flowschema.Strategy,
+		UpdateStrategy:      flowschema.Strategy,
+		DeleteStrategy:      flowschema.Strategy,
+		ResetFieldsStrategy: flowschema.Strategy,
 
 		TableConvertor: printerstorage.TableConvertor{TableGenerator: printers.NewTableGenerator().With(printersinternal.AddHandlers)},
 	}
@@ -64,6 +66,7 @@ func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, *StatusREST, error) {
 	statusStore.CreateStrategy = nil
 	statusStore.UpdateStrategy = flowschema.StatusStrategy
 	statusStore.DeleteStrategy = nil
+	statusStore.ResetFieldsStrategy = flowschema.StatusStrategy
 
 	return &REST{store}, &StatusREST{store: &statusStore}, nil
 }
@@ -88,4 +91,9 @@ func (r *StatusREST) Update(ctx context.Context, name string, objInfo rest.Updat
 	// We are explicitly setting forceAllowCreate to false in the call to the underlying storage because
 	// subresources should never allow create on update.
 	return r.store.Update(ctx, name, objInfo, createValidation, updateValidation, false, options)
+}
+
+// GetResetFields implements rest.ResetFieldsStrategy
+func (r *StatusREST) GetResetFields() map[fieldpath.APIVersion]*fieldpath.Set {
+	return r.store.GetResetFields()
 }

--- a/pkg/registry/flowcontrol/flowschema/strategy.go
+++ b/pkg/registry/flowcontrol/flowschema/strategy.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	"k8s.io/kubernetes/pkg/apis/flowcontrol"
 	"k8s.io/kubernetes/pkg/apis/flowcontrol/validation"
+	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
 )
 
 // flowSchemaStrategy implements verification logic for FlowSchema.
@@ -40,6 +41,18 @@ var Strategy = flowSchemaStrategy{legacyscheme.Scheme, names.SimpleNameGenerator
 // NamespaceScoped returns false because all PriorityClasses are global.
 func (flowSchemaStrategy) NamespaceScoped() bool {
 	return false
+}
+
+// GetResetFields returns the set of fields that get reset by the strategy
+// and should not be modified by the user.
+func (flowSchemaStrategy) GetResetFields() map[fieldpath.APIVersion]*fieldpath.Set {
+	fields := map[fieldpath.APIVersion]*fieldpath.Set{
+		"flowcontrol.apiserver.k8s.io/v1alpha1": fieldpath.NewSet(
+			fieldpath.MakePathOrDie("status"),
+		),
+	}
+
+	return fields
 }
 
 // PrepareForCreate clears the status of a flow-schema before creation.
@@ -90,6 +103,19 @@ type flowSchemaStatusStrategy struct {
 
 // StatusStrategy is the default logic that applies when updating flow-schema objects' status.
 var StatusStrategy = flowSchemaStatusStrategy{Strategy}
+
+// GetResetFields returns the set of fields that get reset by the strategy
+// and should not be modified by the user.
+func (flowSchemaStatusStrategy) GetResetFields() map[fieldpath.APIVersion]*fieldpath.Set {
+	fields := map[fieldpath.APIVersion]*fieldpath.Set{
+		"flowcontrol.apiserver.k8s.io/v1alpha1": fieldpath.NewSet(
+			fieldpath.MakePathOrDie("spec"),
+			fieldpath.MakePathOrDie("metadata"),
+		),
+	}
+
+	return fields
+}
 
 func (flowSchemaStatusStrategy) PrepareForUpdate(ctx context.Context, obj, old runtime.Object) {
 	newFlowSchema := obj.(*flowcontrol.FlowSchema)

--- a/pkg/registry/flowcontrol/prioritylevelconfiguration/BUILD
+++ b/pkg/registry/flowcontrol/prioritylevelconfiguration/BUILD
@@ -16,6 +16,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/validation/field:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/storage/names:go_default_library",
+        "//vendor/sigs.k8s.io/structured-merge-diff/v4/fieldpath:go_default_library",
     ],
 )
 

--- a/pkg/registry/flowcontrol/prioritylevelconfiguration/storage/BUILD
+++ b/pkg/registry/flowcontrol/prioritylevelconfiguration/storage/BUILD
@@ -16,6 +16,7 @@ go_library(
         "//staging/src/k8s.io/apiserver/pkg/registry/generic:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/registry/generic/registry:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/registry/rest:go_default_library",
+        "//vendor/sigs.k8s.io/structured-merge-diff/v4/fieldpath:go_default_library",
     ],
 )
 

--- a/pkg/registry/flowcontrol/prioritylevelconfiguration/strategy.go
+++ b/pkg/registry/flowcontrol/prioritylevelconfiguration/strategy.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	"k8s.io/kubernetes/pkg/apis/flowcontrol"
 	"k8s.io/kubernetes/pkg/apis/flowcontrol/validation"
+	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
 )
 
 // priorityLevelConfigurationStrategy implements verification logic for priority level configurations.
@@ -40,6 +41,18 @@ var Strategy = priorityLevelConfigurationStrategy{legacyscheme.Scheme, names.Sim
 // NamespaceScoped returns false because all PriorityClasses are global.
 func (priorityLevelConfigurationStrategy) NamespaceScoped() bool {
 	return false
+}
+
+// GetResetFields returns the set of fields that get reset by the strategy
+// and should not be modified by the user.
+func (priorityLevelConfigurationStrategy) GetResetFields() map[fieldpath.APIVersion]*fieldpath.Set {
+	fields := map[fieldpath.APIVersion]*fieldpath.Set{
+		"flowcontrol.apiserver.k8s.io/v1alpha1": fieldpath.NewSet(
+			fieldpath.MakePathOrDie("status"),
+		),
+	}
+
+	return fields
 }
 
 // PrepareForCreate clears the status of a priority-level-configuration before creation.
@@ -90,6 +103,19 @@ type priorityLevelConfigurationStatusStrategy struct {
 
 // StatusStrategy is the default logic that applies when updating priority level configuration objects' status.
 var StatusStrategy = priorityLevelConfigurationStatusStrategy{Strategy}
+
+// GetResetFields returns the set of fields that get reset by the strategy
+// and should not be modified by the user.
+func (priorityLevelConfigurationStatusStrategy) GetResetFields() map[fieldpath.APIVersion]*fieldpath.Set {
+	fields := map[fieldpath.APIVersion]*fieldpath.Set{
+		"flowcontrol.apiserver.k8s.io/v1alpha1": fieldpath.NewSet(
+			fieldpath.MakePathOrDie("spec"),
+			fieldpath.MakePathOrDie("metadata"),
+		),
+	}
+
+	return fields
+}
 
 func (priorityLevelConfigurationStatusStrategy) PrepareForUpdate(ctx context.Context, obj, old runtime.Object) {
 	newPriorityLevelConfiguration := obj.(*flowcontrol.PriorityLevelConfiguration)

--- a/pkg/registry/networking/ingress/BUILD
+++ b/pkg/registry/networking/ingress/BUILD
@@ -23,6 +23,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/util/validation/field:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/endpoints/request:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/storage/names:go_default_library",
+        "//vendor/sigs.k8s.io/structured-merge-diff/v4/fieldpath:go_default_library",
     ],
 )
 

--- a/pkg/registry/networking/ingress/storage/BUILD
+++ b/pkg/registry/networking/ingress/storage/BUILD
@@ -42,6 +42,7 @@ go_library(
         "//staging/src/k8s.io/apiserver/pkg/registry/generic:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/registry/generic/registry:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/registry/rest:go_default_library",
+        "//vendor/sigs.k8s.io/structured-merge-diff/v4/fieldpath:go_default_library",
     ],
 )
 

--- a/pkg/registry/policy/poddisruptionbudget/BUILD
+++ b/pkg/registry/policy/poddisruptionbudget/BUILD
@@ -21,6 +21,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/validation/field:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/storage/names:go_default_library",
+        "//vendor/sigs.k8s.io/structured-merge-diff/v4/fieldpath:go_default_library",
     ],
 )
 

--- a/pkg/registry/policy/poddisruptionbudget/storage/BUILD
+++ b/pkg/registry/policy/poddisruptionbudget/storage/BUILD
@@ -40,6 +40,7 @@ go_library(
         "//staging/src/k8s.io/apiserver/pkg/registry/generic:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/registry/generic/registry:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/registry/rest:go_default_library",
+        "//vendor/sigs.k8s.io/structured-merge-diff/v4/fieldpath:go_default_library",
     ],
 )
 

--- a/pkg/registry/storage/volumeattachment/BUILD
+++ b/pkg/registry/storage/volumeattachment/BUILD
@@ -21,6 +21,7 @@ go_library(
         "//staging/src/k8s.io/apiserver/pkg/endpoints/request:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/storage/names:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",
+        "//vendor/sigs.k8s.io/structured-merge-diff/v4/fieldpath:go_default_library",
     ],
 )
 

--- a/pkg/registry/storage/volumeattachment/storage/BUILD
+++ b/pkg/registry/storage/volumeattachment/storage/BUILD
@@ -16,6 +16,7 @@ go_library(
         "//staging/src/k8s.io/apiserver/pkg/registry/generic:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/registry/generic/registry:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/registry/rest:go_default_library",
+        "//vendor/sigs.k8s.io/structured-merge-diff/v4/fieldpath:go_default_library",
     ],
 )
 

--- a/pkg/registry/storage/volumeattachment/storage/storage.go
+++ b/pkg/registry/storage/volumeattachment/storage/storage.go
@@ -29,6 +29,7 @@ import (
 	printersinternal "k8s.io/kubernetes/pkg/printers/internalversion"
 	printerstorage "k8s.io/kubernetes/pkg/printers/storage"
 	"k8s.io/kubernetes/pkg/registry/storage/volumeattachment"
+	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
 )
 
 // VolumeAttachmentStorage includes storage for VolumeAttachments and all subresources
@@ -52,6 +53,7 @@ func NewStorage(optsGetter generic.RESTOptionsGetter) (*VolumeAttachmentStorage,
 		CreateStrategy:      volumeattachment.Strategy,
 		UpdateStrategy:      volumeattachment.Strategy,
 		DeleteStrategy:      volumeattachment.Strategy,
+		ResetFieldsStrategy: volumeattachment.Strategy,
 		ReturnDeletedObject: true,
 
 		TableConvertor: printerstorage.TableConvertor{TableGenerator: printers.NewTableGenerator().With(printersinternal.AddHandlers)},
@@ -63,6 +65,7 @@ func NewStorage(optsGetter generic.RESTOptionsGetter) (*VolumeAttachmentStorage,
 
 	statusStore := *store
 	statusStore.UpdateStrategy = volumeattachment.StatusStrategy
+	statusStore.ResetFieldsStrategy = volumeattachment.StatusStrategy
 
 	return &VolumeAttachmentStorage{
 		VolumeAttachment: &REST{store},
@@ -92,4 +95,9 @@ func (r *StatusREST) Update(ctx context.Context, name string, objInfo rest.Updat
 	// We are explicitly setting forceAllowCreate to false in the call to the underlying storage because
 	// subresources should never allow create on update.
 	return r.store.Update(ctx, name, objInfo, createValidation, updateValidation, false, options)
+}
+
+// GetResetFields implements rest.ResetFieldsStrategy
+func (r *StatusREST) GetResetFields() map[fieldpath.APIVersion]*fieldpath.Set {
+	return r.store.GetResetFields()
 }

--- a/pkg/registry/storage/volumeattachment/strategy.go
+++ b/pkg/registry/storage/volumeattachment/strategy.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/kubernetes/pkg/apis/storage"
 	"k8s.io/kubernetes/pkg/apis/storage/validation"
 	"k8s.io/kubernetes/pkg/features"
+	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
 )
 
 // volumeAttachmentStrategy implements behavior for VolumeAttachment objects
@@ -45,6 +46,22 @@ var Strategy = volumeAttachmentStrategy{legacyscheme.Scheme, names.SimpleNameGen
 
 func (volumeAttachmentStrategy) NamespaceScoped() bool {
 	return false
+}
+
+// GetResetFields returns the set of fields that get reset by the strategy
+// and should not be modified by the user.
+func (volumeAttachmentStrategy) GetResetFields() map[fieldpath.APIVersion]*fieldpath.Set {
+	fields := map[fieldpath.APIVersion]*fieldpath.Set{
+		"storage.k8s.io/v1": fieldpath.NewSet(
+			fieldpath.MakePathOrDie("status"),
+		),
+	}
+
+	if !utilfeature.DefaultFeatureGate.Enabled(features.CSIMigration) {
+		fields["storage.k8s.io/v1"].Insert(fieldpath.MakePathOrDie("spec", "source", "inlineVolumeSpec"))
+	}
+
+	return fields
 }
 
 // ResetBeforeCreate clears the Status field which is not allowed to be set by end users on creation.
@@ -142,6 +159,23 @@ type volumeAttachmentStatusStrategy struct {
 // StatusStrategy is the default logic that applies when creating and updating
 // VolumeAttachmentStatus subresource via the REST API.
 var StatusStrategy = volumeAttachmentStatusStrategy{Strategy}
+
+// GetResetFields returns the set of fields that get reset by the strategy
+// and should not be modified by the user.
+func (volumeAttachmentStatusStrategy) GetResetFields() map[fieldpath.APIVersion]*fieldpath.Set {
+	fields := map[fieldpath.APIVersion]*fieldpath.Set{
+		"storage.k8s.io/v1": fieldpath.NewSet(
+			fieldpath.MakePathOrDie("metadata"),
+			fieldpath.MakePathOrDie("spec"),
+		),
+	}
+
+	if !utilfeature.DefaultFeatureGate.Enabled(features.CSIMigration) {
+		fields["storage.k8s.io/v1"].Insert(fieldpath.MakePathOrDie("spec", "source", "inlineVolumeSpec"))
+	}
+
+	return fields
+}
 
 // PrepareForUpdate sets the Status fields which is not allowed to be set by an end user updating a VolumeAttachment
 func (volumeAttachmentStatusStrategy) PrepareForUpdate(ctx context.Context, obj, old runtime.Object) {

--- a/staging/src/k8s.io/apiextensions-apiserver/go.mod
+++ b/staging/src/k8s.io/apiextensions-apiserver/go.mod
@@ -30,6 +30,7 @@ require (
 	k8s.io/klog/v2 v2.2.0
 	k8s.io/kube-openapi v0.0.0-20200805222855-6aeccd4b50c6
 	k8s.io/utils v0.0.0-20200729134348-d5654de09c73
+	sigs.k8s.io/structured-merge-diff/v4 v4.0.1
 	sigs.k8s.io/yaml v1.2.0
 )
 

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_handler.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_handler.go
@@ -875,21 +875,6 @@ func (r *crdHandler) getOrCreateServingInfoFor(uid types.UID, name string) (*crd
 		// override status subresource values
 		// shallow copy
 		statusScope := *requestScopes[v.Name]
-		if utilfeature.DefaultFeatureGate.Enabled(features.ServerSideApply) {
-			statusScope.FieldManager, err = fieldmanager.NewDefaultCRDFieldManager(
-				openAPIModels,
-				statusScope.Convertor,
-				statusScope.Defaulter,
-				statusScope.Creater,
-				statusScope.Kind,
-				statusScope.HubGroupVersion,
-				crd.Spec.PreserveUnknownFields,
-				true,
-			)
-			if err != nil {
-				return nil, err
-			}
-		}
 		statusScope.Subresource = "status"
 		statusScope.Namer = handlers.ContextBasedNaming{
 			SelfLinker:         meta.NewAccessor(),
@@ -904,6 +889,7 @@ func (r *crdHandler) getOrCreateServingInfoFor(uid types.UID, name string) (*crd
 				statusScope,
 				storages[v.Name].Status,
 				crd.Spec.PreserveUnknownFields,
+				true,
 			)
 			if err != nil {
 				return nil, err
@@ -947,7 +933,7 @@ func (r *crdHandler) getOrCreateServingInfoFor(uid types.UID, name string) (*crd
 	return ret, nil
 }
 
-func scopeWithFieldManager(openAPIModels proto.Models, reqScope handlers.RequestScope, storage rest.ResetFieldsStrategy, preserveUnknownFields bool) (handlers.RequestScope, error) {
+func scopeWithFieldManager(openAPIModels proto.Models, reqScope handlers.RequestScope, storage rest.ResetFieldsStrategy, preserveUnknownFields, ignoreManagedFieldsFromRequestObject bool) (handlers.RequestScope, error) {
 	resetFields := storage.GetResetFields()
 
 	fieldManager, err := fieldmanager.NewDefaultCRDFieldManager(
@@ -959,6 +945,7 @@ func scopeWithFieldManager(openAPIModels proto.Models, reqScope handlers.Request
 		reqScope.HubGroupVersion,
 		resetFields,
 		preserveUnknownFields,
+		ignoreManagedFieldsFromRequestObject,
 	)
 	if err != nil {
 		return handlers.RequestScope{}, err

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_handler.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_handler.go
@@ -848,6 +848,7 @@ func (r *crdHandler) getOrCreateServingInfoFor(uid types.UID, name string) (*crd
 				reqScope.Creater,
 				reqScope.Kind,
 				reqScope.HubGroupVersion,
+				nil,
 				crd.Spec.PreserveUnknownFields,
 				false,
 			)

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresource/BUILD
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresource/BUILD
@@ -41,6 +41,7 @@ go_library(
         "//staging/src/k8s.io/apiserver/pkg/storage:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/storage/names:go_default_library",
         "//vendor/github.com/go-openapi/validate:go_default_library",
+        "//vendor/sigs.k8s.io/structured-merge-diff/v4/fieldpath:go_default_library",
     ],
 )
 

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresource/status_strategy.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresource/status_strategy.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
 )
 
 type statusStrategy struct {
@@ -30,6 +31,25 @@ type statusStrategy struct {
 
 func NewStatusStrategy(strategy customResourceStrategy) statusStrategy {
 	return statusStrategy{strategy}
+}
+
+// GetResetFields returns the set of fields that get reset by the strategy
+// and should not be modified by the user.
+func (a statusStrategy) GetResetFields() map[fieldpath.APIVersion]*fieldpath.Set {
+	fields := map[fieldpath.APIVersion]*fieldpath.Set{
+		"apiextensions.k8s.io/v1": fieldpath.NewSet(
+			// TODO: this is not correct, we might need a way to specify an inverse,
+			// like ignore everything but status.
+			fieldpath.MakePathOrDie("spec"),
+		),
+		"apiextensions.k8s.io/v1beta1": fieldpath.NewSet(
+			// TODO: this is not correct, we might need a way to specify an inverse,
+			// like ignore everything but status.
+			fieldpath.MakePathOrDie("spec"),
+		),
+	}
+
+	return fields
 }
 
 func (a statusStrategy) PrepareForUpdate(ctx context.Context, obj, old runtime.Object) {

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresource/status_strategy.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresource/status_strategy.go
@@ -37,12 +37,7 @@ func NewStatusStrategy(strategy customResourceStrategy) statusStrategy {
 // and should not be modified by the user.
 func (a statusStrategy) GetResetFields() map[fieldpath.APIVersion]*fieldpath.Set {
 	fields := map[fieldpath.APIVersion]*fieldpath.Set{
-		"apiextensions.k8s.io/v1": fieldpath.NewSet(
-			// TODO: this is not correct, we might need a way to specify an inverse,
-			// like ignore everything but status.
-			fieldpath.MakePathOrDie("spec"),
-		),
-		"apiextensions.k8s.io/v1beta1": fieldpath.NewSet(
+		fieldpath.APIVersion(a.customResourceStrategy.kind.GroupVersion().String()): fieldpath.NewSet(
 			// TODO: this is not correct, we might need a way to specify an inverse,
 			// like ignore everything but status.
 			fieldpath.MakePathOrDie("spec"),

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresource/strategy.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresource/strategy.go
@@ -37,6 +37,7 @@ import (
 	structuralschema "k8s.io/apiextensions-apiserver/pkg/apiserver/schema"
 	structurallisttype "k8s.io/apiextensions-apiserver/pkg/apiserver/schema/listtype"
 	schemaobjectmeta "k8s.io/apiextensions-apiserver/pkg/apiserver/schema/objectmeta"
+	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
 )
 
 // customResourceStrategy implements behavior for CustomResources.
@@ -70,6 +71,23 @@ func NewStrategy(typer runtime.ObjectTyper, namespaceScoped bool, kind schema.Gr
 
 func (a customResourceStrategy) NamespaceScoped() bool {
 	return a.namespaceScoped
+}
+
+// GetResetFields returns the set of fields that get reset by the strategy
+// and should not be modified by the user.
+func (a customResourceStrategy) GetResetFields() map[fieldpath.APIVersion]*fieldpath.Set {
+	fields := map[fieldpath.APIVersion]*fieldpath.Set{}
+
+	if a.status != nil {
+		fields["apiextensions.k8s.io/v1"] = fieldpath.NewSet(
+			fieldpath.MakePathOrDie("status"),
+		)
+		fields["apiextensions.k8s.io/v1beta1"] = fieldpath.NewSet(
+			fieldpath.MakePathOrDie("status"),
+		)
+	}
+
+	return fields
 }
 
 // PrepareForCreate clears the status of a CustomResource before creation.

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresource/strategy.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresource/strategy.go
@@ -50,6 +50,7 @@ type customResourceStrategy struct {
 	structuralSchemas map[string]*structuralschema.Structural
 	status            *apiextensions.CustomResourceSubresourceStatus
 	scale             *apiextensions.CustomResourceSubresourceScale
+	kind              schema.GroupVersionKind
 }
 
 func NewStrategy(typer runtime.ObjectTyper, namespaceScoped bool, kind schema.GroupVersionKind, schemaValidator, statusSchemaValidator *validate.SchemaValidator, structuralSchemas map[string]*structuralschema.Structural, status *apiextensions.CustomResourceSubresourceStatus, scale *apiextensions.CustomResourceSubresourceScale) customResourceStrategy {
@@ -66,6 +67,7 @@ func NewStrategy(typer runtime.ObjectTyper, namespaceScoped bool, kind schema.Gr
 			statusSchemaValidator: statusSchemaValidator,
 		},
 		structuralSchemas: structuralSchemas,
+		kind:              kind,
 	}
 }
 
@@ -79,10 +81,7 @@ func (a customResourceStrategy) GetResetFields() map[fieldpath.APIVersion]*field
 	fields := map[fieldpath.APIVersion]*fieldpath.Set{}
 
 	if a.status != nil {
-		fields["apiextensions.k8s.io/v1"] = fieldpath.NewSet(
-			fieldpath.MakePathOrDie("status"),
-		)
-		fields["apiextensions.k8s.io/v1beta1"] = fieldpath.NewSet(
+		fields[fieldpath.APIVersion(a.kind.GroupVersion().String())] = fieldpath.NewSet(
 			fieldpath.MakePathOrDie("status"),
 		)
 	}

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresourcedefinition/BUILD
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresourcedefinition/BUILD
@@ -29,6 +29,7 @@ go_library(
         "//staging/src/k8s.io/apiserver/pkg/storage/errors:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/storage/names:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/util/dryrun:go_default_library",
+        "//vendor/sigs.k8s.io/structured-merge-diff/v4/fieldpath:go_default_library",
     ],
 )
 

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresourcedefinition/etcd.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresourcedefinition/etcd.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/apiserver/pkg/storage"
 	storageerr "k8s.io/apiserver/pkg/storage/errors"
 	"k8s.io/apiserver/pkg/util/dryrun"
+	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
 )
 
 // rest implements a RESTStorage for API services against etcd
@@ -47,9 +48,10 @@ func NewREST(scheme *runtime.Scheme, optsGetter generic.RESTOptionsGetter) (*RES
 		PredicateFunc:            MatchCustomResourceDefinition,
 		DefaultQualifiedResource: apiextensions.Resource("customresourcedefinitions"),
 
-		CreateStrategy: strategy,
-		UpdateStrategy: strategy,
-		DeleteStrategy: strategy,
+		CreateStrategy:      strategy,
+		UpdateStrategy:      strategy,
+		DeleteStrategy:      strategy,
+		ResetFieldsStrategy: strategy,
 
 		// TODO: define table converter that exposes more than name/creation timestamp
 		TableConvertor: rest.NewDefaultTableConvertor(apiextensions.Resource("customresourcedefinitions")),
@@ -168,7 +170,9 @@ func NewStatusREST(scheme *runtime.Scheme, rest *REST) *StatusREST {
 	statusStore := *rest.Store
 	statusStore.CreateStrategy = nil
 	statusStore.DeleteStrategy = nil
-	statusStore.UpdateStrategy = NewStatusStrategy(scheme)
+	statusStrategy := NewStatusStrategy(scheme)
+	statusStore.UpdateStrategy = statusStrategy
+	statusStore.ResetFieldsStrategy = statusStrategy
 	return &StatusREST{store: &statusStore}
 }
 
@@ -192,4 +196,9 @@ func (r *StatusREST) Update(ctx context.Context, name string, objInfo rest.Updat
 	// We are explicitly setting forceAllowCreate to false in the call to the underlying storage because
 	// subresources should never allow create on update.
 	return r.store.Update(ctx, name, objInfo, createValidation, updateValidation, false, options)
+}
+
+// GetResetFields implements rest.ResetFieldsStrategy
+func (r *StatusREST) GetResetFields() map[fieldpath.APIVersion]*fieldpath.Set {
+	return r.store.GetResetFields()
 }

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/BUILD
@@ -95,6 +95,7 @@ go_library(
         "//vendor/github.com/emicklei/go-restful:go_default_library",
         "//vendor/k8s.io/klog/v2:go_default_library",
         "//vendor/k8s.io/kube-openapi/pkg/util/proto:go_default_library",
+        "//vendor/sigs.k8s.io/structured-merge-diff/v3/fieldpath:go_default_library",
     ],
 )
 

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/BUILD
@@ -95,7 +95,7 @@ go_library(
         "//vendor/github.com/emicklei/go-restful:go_default_library",
         "//vendor/k8s.io/klog/v2:go_default_library",
         "//vendor/k8s.io/kube-openapi/pkg/util/proto:go_default_library",
-        "//vendor/sigs.k8s.io/structured-merge-diff/v3/fieldpath:go_default_library",
+        "//vendor/sigs.k8s.io/structured-merge-diff/v4/fieldpath:go_default_library",
     ],
 )
 

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/BUILD
@@ -93,6 +93,7 @@ go_library(
         "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",
         "//staging/src/k8s.io/component-base/version:go_default_library",
         "//vendor/github.com/emicklei/go-restful:go_default_library",
+        "//vendor/k8s.io/klog/v2:go_default_library",
         "//vendor/k8s.io/kube-openapi/pkg/util/proto:go_default_library",
     ],
 )

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/BUILD
@@ -25,6 +25,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/internal:go_default_library",
+        "//staging/src/k8s.io/apiserver/pkg/registry/rest:go_default_library",
         "//vendor/k8s.io/klog/v2:go_default_library",
         "//vendor/k8s.io/kube-openapi/pkg/util/proto:go_default_library",
         "//vendor/sigs.k8s.io/structured-merge-diff/v4/fieldpath:go_default_library",

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/BUILD
@@ -25,7 +25,6 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/internal:go_default_library",
-        "//staging/src/k8s.io/apiserver/pkg/registry/rest:go_default_library",
         "//vendor/k8s.io/klog/v2:go_default_library",
         "//vendor/k8s.io/kube-openapi/pkg/util/proto:go_default_library",
         "//vendor/sigs.k8s.io/structured-merge-diff/v4/fieldpath:go_default_library",

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/fieldmanager.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/fieldmanager.go
@@ -26,7 +26,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/internal"
-	"k8s.io/apiserver/pkg/registry/rest"
 	"k8s.io/klog/v2"
 	openapiproto "k8s.io/kube-openapi/pkg/util/proto"
 	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
@@ -80,7 +79,7 @@ func NewFieldManager(f Manager, ignoreManagedFieldsFromRequestObject bool) *Fiel
 
 // NewDefaultFieldManager creates a new FieldManager that merges apply requests
 // and update managed fields for other types of requests.
-func NewDefaultFieldManager(models openapiproto.Models, objectConverter runtime.ObjectConvertor, objectDefaulter runtime.ObjectDefaulter, objectCreater runtime.ObjectCreater, kind schema.GroupVersionKind, hub schema.GroupVersion, resetFields rest.ResetFields, ignoreManagedFieldsFromRequestObject bool) (*FieldManager, error) {
+func NewDefaultFieldManager(models openapiproto.Models, objectConverter runtime.ObjectConvertor, objectDefaulter runtime.ObjectDefaulter, objectCreater runtime.ObjectCreater, kind schema.GroupVersionKind, hub schema.GroupVersion, resetFields map[fieldpath.APIVersion]*fieldpath.Set, ignoreManagedFieldsFromRequestObject bool) (*FieldManager, error) {
 	typeConverter, err := internal.NewTypeConverter(models, false)
 	if err != nil {
 		return nil, err
@@ -96,7 +95,7 @@ func NewDefaultFieldManager(models openapiproto.Models, objectConverter runtime.
 // NewDefaultCRDFieldManager creates a new FieldManager specifically for
 // CRDs. This allows for the possibility of fields which are not defined
 // in models, as well as having no models defined at all.
-func NewDefaultCRDFieldManager(models openapiproto.Models, objectConverter runtime.ObjectConvertor, objectDefaulter runtime.ObjectDefaulter, objectCreater runtime.ObjectCreater, kind schema.GroupVersionKind, hub schema.GroupVersion, resetFields rest.ResetFields, preserveUnknownFields, ignoreManagedFieldsFromRequestObject bool) (_ *FieldManager, err error) {
+func NewDefaultCRDFieldManager(models openapiproto.Models, objectConverter runtime.ObjectConvertor, objectDefaulter runtime.ObjectDefaulter, objectCreater runtime.ObjectCreater, kind schema.GroupVersionKind, hub schema.GroupVersion, resetFields map[fieldpath.APIVersion]*fieldpath.Set, preserveUnknownFields, ignoreManagedFieldsFromRequestObject bool) (_ *FieldManager, err error) {
 	var typeConverter internal.TypeConverter = internal.DeducedTypeConverter{}
 	if models != nil {
 		typeConverter, err = internal.NewTypeConverter(models, preserveUnknownFields)

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/fieldmanager_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/fieldmanager_test.go
@@ -105,6 +105,7 @@ func NewTestFieldManager(gvk schema.GroupVersionKind, ignoreManagedFieldsFromReq
 		&fakeObjectDefaulter{},
 		gvk.GroupVersion(),
 		gvk.GroupVersion(),
+		nil,
 	)
 	if err != nil {
 		panic(err)

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/structuredmerge.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/structuredmerge.go
@@ -24,7 +24,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/internal"
-	"k8s.io/apiserver/pkg/registry/rest"
 	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
 	"sigs.k8s.io/structured-merge-diff/v4/merge"
 )
@@ -36,14 +35,14 @@ type structuredMergeManager struct {
 	groupVersion    schema.GroupVersion
 	hubVersion      schema.GroupVersion
 	updater         merge.Updater
-	resetFields     rest.ResetFields
+	resetFields     map[fieldpath.APIVersion]*fieldpath.Set
 }
 
 var _ Manager = &structuredMergeManager{}
 
 // NewStructuredMergeManager creates a new Manager that merges apply requests
 // and update managed fields for other types of requests.
-func NewStructuredMergeManager(typeConverter internal.TypeConverter, objectConverter runtime.ObjectConvertor, objectDefaulter runtime.ObjectDefaulter, gv schema.GroupVersion, hub schema.GroupVersion, resetFields rest.ResetFields) (Manager, error) {
+func NewStructuredMergeManager(typeConverter internal.TypeConverter, objectConverter runtime.ObjectConvertor, objectDefaulter runtime.ObjectDefaulter, gv schema.GroupVersion, hub schema.GroupVersion, resetFields map[fieldpath.APIVersion]*fieldpath.Set) (Manager, error) {
 	return &structuredMergeManager{
 		typeConverter:   typeConverter,
 		objectConverter: objectConverter,
@@ -60,7 +59,7 @@ func NewStructuredMergeManager(typeConverter internal.TypeConverter, objectConve
 // NewCRDStructuredMergeManager creates a new Manager specifically for
 // CRDs. This allows for the possibility of fields which are not defined
 // in models, as well as having no models defined at all.
-func NewCRDStructuredMergeManager(typeConverter internal.TypeConverter, objectConverter runtime.ObjectConvertor, objectDefaulter runtime.ObjectDefaulter, gv schema.GroupVersion, hub schema.GroupVersion, resetFields rest.ResetFields, preserveUnknownFields bool) (_ Manager, err error) {
+func NewCRDStructuredMergeManager(typeConverter internal.TypeConverter, objectConverter runtime.ObjectConvertor, objectDefaulter runtime.ObjectDefaulter, gv schema.GroupVersion, hub schema.GroupVersion, resetFields map[fieldpath.APIVersion]*fieldpath.Set, preserveUnknownFields bool) (_ Manager, err error) {
 	return &structuredMergeManager{
 		typeConverter:   typeConverter,
 		objectConverter: objectConverter,

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/installer.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/installer.go
@@ -46,7 +46,7 @@ import (
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	versioninfo "k8s.io/component-base/version"
 	"k8s.io/klog/v2"
-	"sigs.k8s.io/structured-merge-diff/v3/fieldpath"
+	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
 )
 
 const (

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/installer.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/installer.go
@@ -46,6 +46,7 @@ import (
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	versioninfo "k8s.io/component-base/version"
 	"k8s.io/klog/v2"
+	"sigs.k8s.io/structured-merge-diff/v3/fieldpath"
 )
 
 const (
@@ -263,10 +264,10 @@ func (a *APIInstaller) registerResourceHandlers(path string, storage rest.Storag
 		isCreater = true
 	}
 
-	var resetFields rest.ResetFields
+	var resetFields map[fieldpath.APIVersion]*fieldpath.Set
 	if a.group.OpenAPIModels != nil && utilfeature.DefaultFeatureGate.Enabled(features.ServerSideApply) {
-		if resetFieldsProvider, isResetFieldsProvider := storage.(rest.ResetFieldsProvider); isResetFieldsProvider {
-			resetFields = resetFieldsProvider.ResetFields()
+		if resetFieldsStrategy, isResetFieldsStrategy := storage.(rest.ResetFieldsStrategy); isResetFieldsStrategy {
+			resetFields = resetFieldsStrategy.GetResetFields()
 			// TODO(kwiesmueller): remove debug logging
 			klog.Infof("---- +ResetFields: %v %v %v", a.group.GroupVersion.Group, a.group.GroupVersion.Version, path)
 		} else {

--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/BUILD
@@ -89,7 +89,7 @@ go_library(
         "//staging/src/k8s.io/apiserver/pkg/util/dryrun:go_default_library",
         "//staging/src/k8s.io/client-go/tools/cache:go_default_library",
         "//vendor/k8s.io/klog/v2:go_default_library",
-        "//vendor/sigs.k8s.io/structured-merge-diff/v3/fieldpath:go_default_library",
+        "//vendor/sigs.k8s.io/structured-merge-diff/v4/fieldpath:go_default_library",
     ],
 )
 

--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/BUILD
@@ -89,6 +89,7 @@ go_library(
         "//staging/src/k8s.io/apiserver/pkg/util/dryrun:go_default_library",
         "//staging/src/k8s.io/client-go/tools/cache:go_default_library",
         "//vendor/k8s.io/klog/v2:go_default_library",
+        "//vendor/sigs.k8s.io/structured-merge-diff/v3/fieldpath:go_default_library",
     ],
 )
 

--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store.go
@@ -178,6 +178,10 @@ type Store struct {
 	// of items into tabular output. If unset, the default will be used.
 	TableConvertor rest.TableConvertor
 
+	// ResetFieldsStrategy provides the fields reset by the strategy that
+	// should not be modified by the user.
+	ResetFieldsStrategy rest.ResetFieldsProvider
+
 	// Storage is the interface for the underlying storage for the
 	// resource. It is wrapped into a "DryRunnableStorage" that will
 	// either pass-through or simply dry-run.
@@ -1395,6 +1399,14 @@ func (e *Store) ConvertToTable(ctx context.Context, object runtime.Object, table
 
 func (e *Store) StorageVersion() runtime.GroupVersioner {
 	return e.StorageVersioner
+}
+
+// ResetFields implements rest.ResetFieldsProvider
+func (e *Store) ResetFields() rest.ResetFields {
+	if e.ResetFieldsStrategy == nil {
+		return nil
+	}
+	return e.ResetFieldsStrategy.ResetFields()
 }
 
 // validateIndexers will check the prefix of indexers.

--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store.go
@@ -46,7 +46,7 @@ import (
 	"k8s.io/apiserver/pkg/storage/etcd3/metrics"
 	"k8s.io/apiserver/pkg/util/dryrun"
 	"k8s.io/client-go/tools/cache"
-	"sigs.k8s.io/structured-merge-diff/v3/fieldpath"
+	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
 
 	"k8s.io/klog/v2"
 )

--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store.go
@@ -46,6 +46,7 @@ import (
 	"k8s.io/apiserver/pkg/storage/etcd3/metrics"
 	"k8s.io/apiserver/pkg/util/dryrun"
 	"k8s.io/client-go/tools/cache"
+	"sigs.k8s.io/structured-merge-diff/v3/fieldpath"
 
 	"k8s.io/klog/v2"
 )
@@ -180,7 +181,7 @@ type Store struct {
 
 	// ResetFieldsStrategy provides the fields reset by the strategy that
 	// should not be modified by the user.
-	ResetFieldsStrategy rest.ResetFieldsProvider
+	ResetFieldsStrategy rest.ResetFieldsStrategy
 
 	// Storage is the interface for the underlying storage for the
 	// resource. It is wrapped into a "DryRunnableStorage" that will
@@ -1401,12 +1402,12 @@ func (e *Store) StorageVersion() runtime.GroupVersioner {
 	return e.StorageVersioner
 }
 
-// ResetFields implements rest.ResetFieldsProvider
-func (e *Store) ResetFields() rest.ResetFields {
+// GetResetFields implements rest.ResetFieldsStrategy
+func (e *Store) GetResetFields() map[fieldpath.APIVersion]*fieldpath.Set {
 	if e.ResetFieldsStrategy == nil {
 		return nil
 	}
-	return e.ResetFieldsStrategy.ResetFields()
+	return e.ResetFieldsStrategy.GetResetFields()
 }
 
 // validateIndexers will check the prefix of indexers.

--- a/staging/src/k8s.io/apiserver/pkg/registry/rest/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/registry/rest/BUILD
@@ -51,7 +51,7 @@ go_library(
         "//staging/src/k8s.io/apiserver/pkg/features:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/storage/names:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",
-        "//vendor/sigs.k8s.io/structured-merge-diff/v3/fieldpath:go_default_library",
+        "//vendor/sigs.k8s.io/structured-merge-diff/v4/fieldpath:go_default_library",
     ],
 )
 

--- a/staging/src/k8s.io/apiserver/pkg/registry/rest/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/registry/rest/BUILD
@@ -51,6 +51,7 @@ go_library(
         "//staging/src/k8s.io/apiserver/pkg/features:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/storage/names:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",
+        "//vendor/sigs.k8s.io/structured-merge-diff/v3/fieldpath:go_default_library",
     ],
 )
 

--- a/staging/src/k8s.io/apiserver/pkg/registry/rest/rest.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/rest/rest.go
@@ -351,11 +351,8 @@ type StorageVersionProvider interface {
 	StorageVersion() runtime.GroupVersioner
 }
 
-// ResetFields maps versions to the sets of fields that will be reset by the storage strategy.
-type ResetFields map[fieldpath.APIVersion]*fieldpath.Set
-
-// ResetFieldsProvider is an optional interface that a storage object can
+// ResetFieldsStrategy is an optional interface that a storage object can
 // implement if it wishes to provide the fields reset by its strategies.
-type ResetFieldsProvider interface {
-	ResetFields() ResetFields
+type ResetFieldsStrategy interface {
+	GetResetFields() map[fieldpath.APIVersion]*fieldpath.Set
 }

--- a/staging/src/k8s.io/apiserver/pkg/registry/rest/rest.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/rest/rest.go
@@ -27,7 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/watch"
-	"sigs.k8s.io/structured-merge-diff/v3/fieldpath"
+	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
 )
 
 //TODO:

--- a/staging/src/k8s.io/apiserver/pkg/registry/rest/rest.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/rest/rest.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/watch"
+	"sigs.k8s.io/structured-merge-diff/v3/fieldpath"
 )
 
 //TODO:
@@ -348,4 +349,13 @@ type StorageVersionProvider interface {
 	// an object will be converted to before persisted in etcd, given a
 	// list of kinds the object might belong to.
 	StorageVersion() runtime.GroupVersioner
+}
+
+// ResetFields maps versions to the sets of fields that will be reset by the storage strategy.
+type ResetFields map[fieldpath.APIVersion]*fieldpath.Set
+
+// ResetFieldsProvider is an optional interface that a storage object can
+// implement if it wishes to provide the fields reset by its strategies.
+type ResetFieldsProvider interface {
+	ResetFields() ResetFields
 }

--- a/test/integration/apiserver/apply/BUILD
+++ b/test/integration/apiserver/apply/BUILD
@@ -7,6 +7,7 @@ go_test(
         "apply_crd_test.go",
         "apply_test.go",
         "main_test.go",
+        "resetFields_test.go",
         "status_test.go",
     ],
     tags = [

--- a/test/integration/apiserver/apply/resetFields_test.go
+++ b/test/integration/apiserver/apply/resetFields_test.go
@@ -1,0 +1,188 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apiserver
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	apiextensionsclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+	genericfeatures "k8s.io/apiserver/pkg/features"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
+	apiservertesting "k8s.io/kubernetes/cmd/kube-apiserver/app/testing"
+	"k8s.io/kubernetes/test/integration/etcd"
+	"k8s.io/kubernetes/test/integration/framework"
+	"sigs.k8s.io/yaml"
+)
+
+// namespace used for all tests, do not change this
+const resetFieldsNamespace = "reset-fields-namespace"
+
+// TestResetFields makes sure that fieldManager does not own fields reset by the storage strategy.
+func TestApplyResetFields(t *testing.T) {
+	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, genericfeatures.ServerSideApply, true)()
+	server, err := apiservertesting.StartTestServer(t, apiservertesting.NewDefaultTestServerOptions(), []string{"--disable-admission-plugins", "ServiceAccount,TaintNodesByCondition"}, framework.SharedEtcd())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer server.TearDownFn()
+
+	client, err := kubernetes.NewForConfig(server.ClientConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dynamicClient, err := dynamic.NewForConfig(server.ClientConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// create CRDs so we can make sure that custom resources do not get lost
+	etcd.CreateTestCRDs(t, apiextensionsclientset.NewForConfigOrDie(server.ClientConfig), false, etcd.GetCustomResourceDefinitionData()...)
+
+	if _, err := client.CoreV1().Namespaces().Create(context.TODO(), &v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: resetFieldsNamespace}}, metav1.CreateOptions{}); err != nil {
+		t.Fatal(err)
+	}
+
+	createData := etcd.GetEtcdStorageDataForNamespace(resetFieldsNamespace)
+
+	// gather resources to test
+	_, resourceLists, err := client.Discovery().ServerGroupsAndResources()
+	if err != nil {
+		t.Fatalf("Failed to get ServerGroupsAndResources with error: %+v", err)
+	}
+
+	for _, resourceList := range resourceLists {
+		for _, resource := range resourceList.APIResources {
+			if !strings.HasSuffix(resource.Name, "/status") {
+				continue
+			}
+			mapping, err := createMapping(resourceList.GroupVersion, resource)
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Run(mapping.Resource.String(), func(t *testing.T) {
+				if _, ok := ignoreList[mapping.Resource]; ok {
+					t.Skip()
+				}
+
+				status, ok := statusData[mapping.Resource]
+				if !ok {
+					status = statusDefault
+				}
+				newResource, ok := createData[mapping.Resource]
+				if !ok {
+					t.Fatalf("no test data for %s.  Please add a test for your new type to etcd.GetEtcdStorageData().", mapping.Resource)
+				}
+
+				newObj := unstructured.Unstructured{}
+				if err := json.Unmarshal([]byte(newResource.Stub), &newObj.Object); err != nil {
+					t.Fatal(err)
+				}
+				if err := json.Unmarshal([]byte(status), &newObj.Object); err != nil {
+					t.Fatal(err)
+				}
+
+				namespace := resetFieldsNamespace
+				if mapping.Scope == meta.RESTScopeRoot {
+					namespace = ""
+				}
+				name := newObj.GetName()
+				rsc := dynamicClient.Resource(mapping.Resource).Namespace(namespace)
+				_, err := rsc.Create(context.TODO(), &newObj, metav1.CreateOptions{FieldManager: "create_test"})
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				statusObj := unstructured.Unstructured{}
+				if err := json.Unmarshal([]byte(status), &statusObj.Object); err != nil {
+					t.Fatal(err)
+				}
+				statusObj.SetAPIVersion(mapping.GroupVersionKind.GroupVersion().String())
+				statusObj.SetKind(mapping.GroupVersionKind.Kind)
+				statusObj.SetName(name)
+				statusYAML, err := yaml.Marshal(statusObj.Object)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				True := true
+				obj, err := dynamicClient.
+					Resource(mapping.Resource).
+					Namespace(namespace).
+					Patch(context.TODO(), name, types.ApplyPatchType, statusYAML, metav1.PatchOptions{FieldManager: "apply_status_test", Force: &True}, "status")
+				if err != nil {
+					t.Fatalf("Failed to apply: %v", err)
+				}
+
+				accessor, err := meta.Accessor(obj)
+				if err != nil {
+					t.Fatalf("Failed to get meta accessor: %v:\n%v", err, obj)
+				}
+
+				managedFields := accessor.GetManagedFields()
+				if managedFields == nil {
+					t.Fatal("Empty managed fields")
+				}
+
+				createFields, err := getManagedFieldsFor(managedFields, "create_test")
+				if err != nil {
+					t.Fatal(err)
+				}
+				statusFields, err := getManagedFieldsFor(managedFields, "apply_status_test")
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				// TODO: test for full object applies to status (~~status~~/spec wiping on status strategies)
+				for field := range createFields {
+					if _, exists := statusFields[field]; exists {
+						t.Errorf("found overlapping field ownership: %v", field)
+					}
+				}
+
+				if err := rsc.Delete(context.TODO(), name, *metav1.NewDeleteOptions(0)); err != nil {
+					t.Fatalf("deleting final object failed: %v", err)
+				}
+			})
+		}
+	}
+}
+
+func getManagedFieldsFor(managedFields []metav1.ManagedFieldsEntry, manager string) (map[string]interface{}, error) {
+	for _, entry := range managedFields {
+		if entry.Manager == manager {
+
+			fields := make(map[string]interface{})
+			if err := json.Unmarshal(entry.FieldsV1.Raw, &fields); err != nil {
+				return nil, err
+			}
+			return fields, nil
+		}
+	}
+	return nil, fmt.Errorf("manager not found: %s", manager)
+}

--- a/test/integration/apiserver/apply/resetFields_test.go
+++ b/test/integration/apiserver/apply/resetFields_test.go
@@ -89,6 +89,13 @@ func TestApplyResetFields(t *testing.T) {
 					t.Skip()
 				}
 
+				// TODO: fix this test for customresourcedefinitions
+				// CRD status gets updated by other actors which makes those own the conditions field,
+				// which causes this test to get a conflict.
+				if mapping.Resource.Resource == "customresourcedefinitions" {
+					t.Skip()
+				}
+
 				status, ok := statusData[mapping.Resource]
 				if !ok {
 					status = statusDefault

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -2520,7 +2520,9 @@ sigs.k8s.io/kustomize/pkg/transformers
 sigs.k8s.io/kustomize/pkg/transformers/config
 sigs.k8s.io/kustomize/pkg/transformers/config/defaultconfig
 sigs.k8s.io/kustomize/pkg/types
+# sigs.k8s.io/structured-merge-diff/v3 => sigs.k8s.io/structured-merge-diff/v3 v3.0.1-0.20200706213357-43c19bbb7fba
 # sigs.k8s.io/structured-merge-diff/v4 v4.0.1 => sigs.k8s.io/structured-merge-diff/v4 v4.0.1
+## explicit
 # sigs.k8s.io/structured-merge-diff/v4 => sigs.k8s.io/structured-merge-diff/v4 v4.0.1
 sigs.k8s.io/structured-merge-diff/v4/fieldpath
 sigs.k8s.io/structured-merge-diff/v4/merge

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -2520,7 +2520,6 @@ sigs.k8s.io/kustomize/pkg/transformers
 sigs.k8s.io/kustomize/pkg/transformers/config
 sigs.k8s.io/kustomize/pkg/transformers/config/defaultconfig
 sigs.k8s.io/kustomize/pkg/types
-# sigs.k8s.io/structured-merge-diff/v3 => sigs.k8s.io/structured-merge-diff/v3 v3.0.1-0.20200706213357-43c19bbb7fba
 # sigs.k8s.io/structured-merge-diff/v4 v4.0.1 => sigs.k8s.io/structured-merge-diff/v4 v4.0.1
 ## explicit
 # sigs.k8s.io/structured-merge-diff/v4 => sigs.k8s.io/structured-merge-diff/v4 v4.0.1


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

This is a simpler take on https://github.com/kubernetes/kubernetes/pull/89486

Implements https://github.com/kubernetes/enhancements/pull/1123
Adds the ResetFieldsProvider interface and implements it for all strategies.

**Which issue(s) this PR fixes**:

Fixes #75564

**Does this PR introduce a user-facing change?**:

```release-note
FieldManager no longer owns fields that get reset before the object is persisted (e.g. "status wiping").
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs
- [KEP]: https://github.com/kubernetes/enhancements/pull/1123
```

/sig api-machinery
/wg api-expression
/assign @apelisse 
