### PR TITLE
Promote deleteCoreV1CollectionNamespacedEvent test - +1 endpoint coverage

### DIFF
--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -809,6 +809,13 @@
     definitions MUST be published for custom resource definitions.
   release: v1.16
   file: test/e2e/apimachinery/crd_publish_openapi.go
+- testname: Event, delete a collection
+  codename: '[sig-api-machinery] Events should delete a collection of events [Conformance]'
+  description: A set of events is created with a label selector which MUST be found
+    when listed. The set of events is deleted and MUST NOT show up when listed by
+    its label selector.
+  release: v1.19
+  file: test/e2e/apimachinery/events.go
 - testname: Event resource lifecycle
   codename: '[sig-api-machinery] Events should ensure that an event can be fetched,
     patched, deleted, and listed [Conformance]'

--- a/test/e2e/apimachinery/events.go
+++ b/test/e2e/apimachinery/events.go
@@ -123,7 +123,13 @@ var _ = ginkgo.Describe("[sig-api-machinery] Events", func() {
 		framework.ExpectEqual(foundCreatedEvent, false, "should not have found test event after deletion")
 	})
 
-	ginkgo.It("should delete a collection of events", func() {
+	/*
+	   Release : v1.19
+	   Testname: Event, delete a collection
+	   Description: A set of events is created with a label selector which MUST be found when listed.
+	   The set of events is deleted and MUST NOT show up when listed by its label selector.
+	*/
+	framework.ConformanceIt("should delete a collection of events", func() {
 		eventTestNames := []string{"test-event-1", "test-event-2", "test-event-3"}
 
 		ginkgo.By("Create set of events")


### PR DESCRIPTION
**What** type of PR is this?
/kind cleanup

**What** this PR does / why we need it:
This PR adds a test to test the following untested endpoints:
deleteCoreV1CollectionNamespacedEvent

**Which** issue(s) this PR fixes:
Fixes #90914

**Special** notes for your reviewer:
Adds +1 endpoint test coverage (good for conformance)

**Does** this PR introduce a user-facing change?:
```
NONE

```

**Release note:**
```release-note
NONE
```

**Additional** documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```
NONE

```

/sig testing
/sig architecture
/area conformance