### PR TITLE
Automated cherry pick of #92793: Fix throttling issues when Azure VM computer name prefix is

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_instances_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_instances_test.go
@@ -384,7 +384,7 @@ func TestNodeAddresses(t *testing.T) {
 func TestIsCurrentInstance(t *testing.T) {
 	cloud := &Cloud{
 		Config: Config{
-			VMType: vmTypeVMSS,
+			VMType: vmTypeStandard,
 		},
 	}
 	testcases := []struct {
@@ -404,11 +404,6 @@ func TestIsCurrentInstance(t *testing.T) {
 			expected:       false,
 		},
 		{
-			nodeName:       "vmss000001",
-			metadataVMName: "vmss_1",
-			expected:       true,
-		},
-		{
 			nodeName:       "vmss_2",
 			metadataVMName: "vmss000000",
 			expected:       false,
@@ -417,7 +412,6 @@ func TestIsCurrentInstance(t *testing.T) {
 			nodeName:       "vmss123456",
 			metadataVMName: "vmss_$123",
 			expected:       false,
-			expectError:    true,
 		},
 	}
 


### PR DESCRIPTION
Cherry pick of #92793 on release-1.18.

#92793: Fix throttling issues when Azure VM computer name prefix is

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.