### PR TITLE
Bypass PreFilter in ServiceAfffinity if AffinityLabels arg is not present

### DIFF
--- a/pkg/scheduler/framework/plugins/serviceaffinity/service_affinity.go
+++ b/pkg/scheduler/framework/plugins/serviceaffinity/service_affinity.go
@@ -127,10 +127,13 @@ func (pl *ServiceAffinity) createPreFilterState(pod *v1.Pod) (*preFilterState, e
 
 // PreFilter invoked at the prefilter extension point.
 func (pl *ServiceAffinity) PreFilter(ctx context.Context, cycleState *framework.CycleState, pod *v1.Pod) *framework.Status {
+	if len(pl.args.AffinityLabels) == 0 {
+		return nil
+	}
+
 	s, err := pl.createPreFilterState(pod)
 	if err != nil {
 		return framework.NewStatus(framework.Error, fmt.Sprintf("could not create preFilterState: %v", err))
-
 	}
 	cycleState.Write(preFilterStateKey, s)
 	return nil
@@ -138,6 +141,9 @@ func (pl *ServiceAffinity) PreFilter(ctx context.Context, cycleState *framework.
 
 // PreFilterExtensions returns prefilter extensions, pod add and remove.
 func (pl *ServiceAffinity) PreFilterExtensions() framework.PreFilterExtensions {
+	if len(pl.args.AffinityLabels) == 0 {
+		return nil
+	}
 	return pl
 }
 

--- a/pkg/scheduler/framework/plugins/serviceaffinity/service_affinity_test.go
+++ b/pkg/scheduler/framework/plugins/serviceaffinity/service_affinity_test.go
@@ -500,6 +500,9 @@ func TestPreFilterStateAddRemovePod(t *testing.T) {
 				p := &ServiceAffinity{
 					sharedLister:  snapshot,
 					serviceLister: fakeframework.ServiceLister(test.services),
+					args: config.ServiceAffinityArgs{
+						AffinityLabels: []string{"region", "zone"},
+					},
 				}
 				cycleState := framework.NewCycleState()
 				preFilterStatus := p.PreFilter(context.Background(), cycleState, test.pendingPod)


### PR DESCRIPTION
**What type of PR is this?**

/kind feature
/sig scheduling

**What this PR does / why we need it**:

The arg `AffinityLabels` in ServiceAfffinity plugin controls the Filtering logic:

https://github.com/kubernetes/kubernetes/blob/865cbf0bdfb4ae0d6cb5029ffacea127cd42e89c/pkg/scheduler/framework/plugins/serviceaffinity/service_affinity.go#L229-L232

So apparently, we should run PreFilter only when that arg is present (not a default configuration); otherwise, every scheduling cycle would waste time on ServiceAfffinity's PreFitler function.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```