### PR TITLE
Set CSIMigrationvSphere feature gates to beta

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -411,13 +411,13 @@ const (
 	CSIMigrationAzureFileComplete featuregate.Feature = "CSIMigrationAzureFileComplete"
 
 	// owner: @divyenpatel
-	// alpha: v1.19
+	// beta: v1.19 (requires: vSphere vCenter/ESXi Version: 7.0u1, HW Version: VM version 15)
 	//
 	// Enables the vSphere in-tree driver to vSphere CSI Driver migration feature.
 	CSIMigrationvSphere featuregate.Feature = "CSIMigrationvSphere"
 
 	// owner: @divyenpatel
-	// alpha: v1.19
+	// beta: v1.19 (requires: vSphere vCenter/ESXi Version: 7.0u1, HW Version: VM version 15)
 	//
 	// Disables the vSphere in-tree driver.
 	// Expects vSphere CSI Driver to be installed and configured on all nodes.
@@ -654,8 +654,8 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 	CSIMigrationAzureDiskComplete:  {Default: false, PreRelease: featuregate.Alpha},
 	CSIMigrationAzureFile:          {Default: false, PreRelease: featuregate.Alpha},
 	CSIMigrationAzureFileComplete:  {Default: false, PreRelease: featuregate.Alpha},
-	CSIMigrationvSphere:            {Default: false, PreRelease: featuregate.Alpha},
-	CSIMigrationvSphereComplete:    {Default: false, PreRelease: featuregate.Alpha},
+	CSIMigrationvSphere:            {Default: false, PreRelease: featuregate.Beta},
+	CSIMigrationvSphereComplete:    {Default: false, PreRelease: featuregate.Beta},
 	RunAsGroup:                     {Default: true, PreRelease: featuregate.Beta},
 	CSIMigrationOpenStack:          {Default: false, PreRelease: featuregate.Beta}, // Off by default (requires OpenStack Cinder CSI driver)
 	CSIMigrationOpenStackComplete:  {Default: false, PreRelease: featuregate.Alpha},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature


**What this PR does / why we need it**:
This PR is setting `CSIMigrationvSphere` and `CSIMigrationvSphereComplete` feature gates to beta.

**Special notes for your reviewer**:
Executed in-tree E2E test case on the Kubernetes Cluster with these migration flags enabled and CSI Driver installed.

Here is the result

| Test File | https://github.com/kubernetes/kubernetes/blob/master/test/e2e/storage/vsphere/persistent_volumes-vsphere.go |
|-|-|
| Number of Tests | 5 |
| Result | Pass |
| Logs | https://gist.github.com/chethanv28/f57c66b02c85805b2ca50518fb68a987#file-persistentvolumes-vsphere-test-case-1-log<br>https://gist.github.com/chethanv28/30255b0534a54c9bfc2e54d6a3c11e7c#file-persistentvolumes-vsphere-test-case-2-log<br>https://gist.github.com/chethanv28/57709861ebba1c89dca42164f6fb0b13#file-persistentvolumes-vsphere-test-case-3-log<br>https://gist.github.com/chethanv28/7ffc48ae7bc81094779b347359d72900#file-persistentvolumes-vsphere-test-case-4-disruptive-1-log<br>https://gist.github.com/chethanv28/f31915ecba2459fb8dbc7c3904d7b4b3#file-persistentvolumes-vsphere-test-case-4-disruptive-2-log |


| Test File | https://github.com/kubernetes/kubernetes/blob/master/test/e2e/storage/vsphere/pvc_label_selector.go |
|-|-|
| Number of Tests | 1 |
| Result | Pass |
| Logs | https://gist.github.com/divyenpatel/d9fd40b75a7db2fa416f3d62c31ee2ae#file-pvc_label_selector-go-log |


| Test File | https://github.com/kubernetes/kubernetes/blob/master/test/e2e/storage/vsphere/vsphere_statefulsets.go |
|-|-|
| Number of Tests | 1 |
| Result | Pass |
| Logs | https://gist.github.com/divyenpatel/d9fd40b75a7db2fa416f3d62c31ee2ae#file-vsphere_statefulsets-go-log |



| Test File | https://github.com/kubernetes/kubernetes/blob/master/test/e2e/storage/vsphere/vsphere_volume_datastore.go |
|-|-|
| Number of Tests | 1 |
| Result | Pass |
| Logs | PASS<br><br>https://gist.github.com/divyenpatel/d9fd40b75a7db2fa416f3d62c31ee2ae#file-vsphere_volume_datastore-go-log |

| Test File | https://github.com/kubernetes/kubernetes/blob/master/test/e2e/storage/vsphere/vsphere_volume_diskformat.go |
|-|-|
| Number of Tests | 3 |
| Result | 1 Pass, 2 Fail (Failures are expected, as vSphere CSI Driver does not support Provisioning eagerzeroedthick<br>and zeroedthick volume). |
| Logs | https://gist.github.com/divyenpatel/d9fd40b75a7db2fa416f3d62c31ee2ae#file-vsphere_volume_disksize-go-log |



| Test File | https://github.com/kubernetes/kubernetes/blob/master/test/e2e/storage/vsphere/vsphere_volume_disksize.go |
|-|-|
| Number of Tests | 1 |
| Result | Pass |
| Logs | https://gist.github.com/divyenpatel/d9fd40b75a7db2fa416f3d62c31ee2ae#file-vsphere_volume_disksize-go-test-log |


| Test File | https://github.com/kubernetes/kubernetes/blob/master/test/e2e/storage/vsphere/vsphere_volume_ops_storm.go |
|-|-|
| Number of Tests | 1 |
| Result | Pass |
| Logs | https://gist.github.com/marunachalam/1613133fc241f5a3468239fc8e19393a#file-volume-ops-storm-log |


| Test File | https://github.com/kubernetes/kubernetes/blob/master/test/e2e/storage/vsphere/vsphere_scale.go |
|-|-|
| Number of Tests | 1 |
| Result | Pass |
| Logs | https://gist.github.com/chethanv28/952160981eab7cf68db54760b54ae798#file-vsphere_scale-go-log |


| Test File | https://github.com/kubernetes/kubernetes/blob/master/test/e2e/storage/vsphere/vsphere_stress.go |
|-|-|
| Number of Tests | 1 |
| Result | Pass |
| Logs | https://gist.github.com/chethanv28/35d04c7aa0dc9f81c85eb973a6ade9b0#file-vsphere-cloud-provider-stress-log |

| Test File | https://github.com/kubernetes/kubernetes/blob/master/test/e2e/storage/vsphere/vsphere_volume_perf.go |
|-|-|
| Number of Tests | 1 |
| Result | Pass |
| Logs | https://gist.github.com/chethanv28/144ccce41bb567f37986dc27ff4d95d4#file-vcp-performance-test-log |


| Test File | https://github.com/kubernetes/kubernetes/blob/master/test/e2e/storage/vsphere/vsphere_volume_vsan_policy.go |
|-|-|
| Number of Tests | 13 |
| Result | Pass 7, Fail 6 (Failes tests are negative tests related raw vsan policy and its validation, vSphere CSI Driver does not support raw vsan policy parameters) |
| Logs | https://gist.github.com/chethanv28/efd06c2623589d1628827616f9bc2731#file-storage-policy-based-volume-provisioning-1-log - PASS<br>https://gist.github.com/chethanv28/8c1ada0fcc5f204e3463179b53a08765#file-storage-policy-based-volume-provisioning-2-log - PASS<br>https://gist.github.com/chethanv28/37e45797f885fd5f8da95349a3c200ae#file-storage-policy-based-volume-provisioning-3-log - PASS<br>https://gist.github.com/chethanv28/f35d92155e96812e5a82c49a914a8952#file-storage-policy-based-volume-provisioning-4-log - PASS<br>https://gist.github.com/chethanv28/abd150bf8c01753adee3cb487fb71db0#file-storage-policy-based-volume-provisioning-5-log - PASS<br>https://gist.github.com/chethanv28/4dd0afd4c0cb7809345750d81e40d1c2#file-non-compatible-datastore-for-dynamically-provisioned-pvc-log -PASS<br>https://gist.github.com/chethanv28/a22c268e980b4c0c3485f7dcc2304155#file-non-existing-spbm-policy-is-not-honored-for-dynamically-provisioned-pvc-log - PASS<br><br><br>https://gist.github.com/chethanv28/60cc110240e04d8bbec96b535a3f5f32#file-verify-an-if-a-spbm-policy-and-vsan-capabilities-cannot-be-honored-for-dynamically-provisioned-pvc-using-storageclass-log - FAILED<br>https://gist.github.com/chethanv28/80890375965b2a543b7f2700fc75ecfb#file-verify-vsan-storage-capability-with-invalid-hostfailurestotolerate-value-is-not-honored-for-dynamically-provisioned-pvc-using-storageclass-log - FAILED<br>https://gist.github.com/chethanv28/114cbe3783c84915aee916b582c083b5#file-verify-vsan-storage-capability-with-invalid-diskstripes-value-is-not-honored-for-dynamically-provisioned-pvc-using-storageclass-log- FAILED<br>https://gist.github.com/chethanv28/6edc8dada2d405b1ab5fc4594e654fe3#file-verify-vsan-storage-capability-with-non-vsan-datastore-is-not-honored-for-dynamically-provisioned-pvc-using-storageclass-log - FAILED<br>https://gist.github.com/chethanv28/7b570cc5a27c57d84e474bbf5bda9c51#file-verify-clean-up-of-stale-dummy-vm-for-dynamically-provisioned-pvc-using-spbm-policy-log- FAILED<br>https://gist.github.com/chethanv28/8b10805152f9469334e540a711ebc559#file-verify-vsan-storage-capability-with-invalid-capability-name-objectspacereserve-is-not-honored-for-dynamically-provisioned-pvc-using-storageclass-log - FAILED |

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".




For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Set CSIMigrationvSphere feature gates to beta.
Users should enable CSIMigration + CSIMigrationvSphere features and install the vSphere CSI Driver (https://github.com/kubernetes-sigs/vsphere-csi-driver) to move workload from the in-tree vSphere plugin "kubernetes.io/vsphere-volume" to vSphere CSI Driver.

Requires: vSphere vCenter/ESXi Version: 7.0u1, HW Version: VM version 15
```


@msau42  @xing-yang @chethanv28  @SandeepPissay Can you help review this PR?
