### PR TITLE
fix pull image error from multiple ACRs using azure managed identity

### DIFF
--- a/pkg/credentialprovider/aws/aws_credentials.go
+++ b/pkg/credentialprovider/aws/aws_credentials.go
@@ -104,6 +104,11 @@ func (p *ecrProvider) Provide(image string) credentialprovider.DockerConfig {
 	return cfg
 }
 
+// UseCache decide whether to use cache according to image and cache content
+func (p *ecrProvider) UseCache(image string, config credentialprovider.DockerConfig) bool {
+	return true
+}
+
 // getFromCache attempts to get credentials from the cache
 func (p *ecrProvider) getFromCache(parsed *parsedURL) (credentialprovider.DockerConfig, bool) {
 	cfg := credentialprovider.DockerConfig{}

--- a/pkg/credentialprovider/azure/BUILD
+++ b/pkg/credentialprovider/azure/BUILD
@@ -32,6 +32,7 @@ go_test(
     srcs = ["azure_credentials_test.go"],
     embed = [":go_default_library"],
     deps = [
+        "//pkg/credentialprovider:go_default_library",
         "//vendor/github.com/Azure/azure-sdk-for-go/services/containerregistry/mgmt/2019-05-01/containerregistry:go_default_library",
         "//vendor/github.com/Azure/go-autorest/autorest/azure:go_default_library",
         "//vendor/github.com/Azure/go-autorest/autorest/to:go_default_library",

--- a/pkg/credentialprovider/gcp/metadata.go
+++ b/pkg/credentialprovider/gcp/metadata.go
@@ -159,6 +159,11 @@ func (g *dockerConfigKeyProvider) Provide(image string) credentialprovider.Docke
 	return credentialprovider.DockerConfig{}
 }
 
+// UseCache decide whether to use cache according to image and cache content
+func (g *dockerConfigKeyProvider) UseCache(image string, config credentialprovider.DockerConfig) bool {
+	return true
+}
+
 // Provide implements DockerConfigProvider
 func (g *dockerConfigURLKeyProvider) Provide(image string) credentialprovider.DockerConfig {
 	// Read the contents of the google-dockercfg-url key and load a .dockercfg from there
@@ -178,6 +183,11 @@ func (g *dockerConfigURLKeyProvider) Provide(image string) credentialprovider.Do
 	}
 
 	return credentialprovider.DockerConfig{}
+}
+
+// UseCache decide whether to use cache according to image and cache content
+func (g *dockerConfigURLKeyProvider) UseCache(image string, config credentialprovider.DockerConfig) bool {
+	return true
 }
 
 // runWithBackoff runs input function `f` with an exponential backoff.
@@ -297,4 +307,9 @@ func (g *containerRegistryProvider) Provide(image string) credentialprovider.Doc
 		cfg[k] = entry
 	}
 	return cfg
+}
+
+// UseCache decide whether to use cache according to image and cache content
+func (g *containerRegistryProvider) UseCache(image string, config credentialprovider.DockerConfig) bool {
+	return true
 }

--- a/pkg/credentialprovider/keyring_test.go
+++ b/pkg/credentialprovider/keyring_test.go
@@ -469,6 +469,11 @@ func (d *testProvider) Provide(image string) DockerConfig {
 	return DockerConfig{}
 }
 
+// UseCache implements dockerConfigProvider
+func (d *testProvider) UseCache(image string, config DockerConfig) bool {
+	return true
+}
+
 func TestProvidersDockerKeyring(t *testing.T) {
 	provider := &testProvider{
 		Count: 0,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This PR continues with PR(https://github.com/kubernetes/kubernetes/pull/92330), fixed the pull image error with azure managed identity, does not change the behavior of service principal.

This PR would check credential cache first when pull image with azure managed identity
 - if login server(e.g. `foo.azurecr.io`) is already in the `d.cacheDockerConfig` cache, then it would continue with cache if not expired, 
 - if login server is not in the cache and it's an `*.azurecr.*` registry, then it would not use cache and invoke `Provide` directly.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #92326

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
fix: pull image error from multiple ACRs using azure managed identity
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
fix: pull image error from multiple ACRs using azure managed identity
```

/kind bug
/assign @feiskyer
/priority important-soon
/sig cloud-provider
/area provider/azure
