### PR TITLE
Remove resync period for disruption controller

### DIFF
--- a/pkg/controller/disruption/disruption.go
+++ b/pkg/controller/disruption/disruption.go
@@ -140,13 +140,12 @@ func NewDisruptionController(
 	dc.podLister = podInformer.Lister()
 	dc.podListerSynced = podInformer.Informer().HasSynced
 
-	pdbInformer.Informer().AddEventHandlerWithResyncPeriod(
+	pdbInformer.Informer().AddEventHandler(
 		cache.ResourceEventHandlerFuncs{
 			AddFunc:    dc.addDb,
 			UpdateFunc: dc.updateDb,
 			DeleteFunc: dc.removeDb,
 		},
-		30*time.Second,
 	)
 	dc.pdbLister = pdbInformer.Lister()
 	dc.pdbListerSynced = pdbInformer.Informer().HasSynced


### PR DESCRIPTION
What type of PR is this?
/kind cleanup

What this PR does / why we need it:
The disruption controller is resyncing all ssets every 30 seconds, this is not necessary, and make the depth of disruption workqueue longer and can cause delays processing actual updates when large amounts of disruptions exist.

Special notes for your reviewer:

Does this PR introduce a user-facing change?
Disruption controllers no longer force a resync every 30 seconds when nothing has changed.