### PR TITLE
Move ixdy to emeritus

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -21,16 +21,6 @@ filters:
     emeritus_approvers:
       - jbeda
 
-  # Bazel build infrastructure changes often touch files throughout the tree
-  "\\.bzl$":
-    reviewers:
-      - ixdy
-    approvers:
-      - ixdy
-  "BUILD(\\.bazel)?$":
-    approvers:
-      - ixdy
-
   # go.{mod,sum} files relate to go dependencies, and should be reviewed by the
   # dep-approvers
   "go\\.(mod|sum)$":

--- a/build/visible_to/OWNERS
+++ b/build/visible_to/OWNERS
@@ -3,7 +3,6 @@
 reviewers:
   - brendandburns
   - dchen1107
-  - ixdy
   - lavalamp
   - mikedanese
   - monopole
@@ -14,7 +13,6 @@ approvers:
   - bgrant0607
   - brendandburns
   - dchen1107
-  - ixdy
   - lavalamp
   - mikedanese
   - monopole
@@ -23,4 +21,5 @@ approvers:
   - thockin
   - wojtek-t
 emeritus_approvers:
+  - ixdy
   - jbeda

--- a/cluster/images/conformance/OWNERS
+++ b/cluster/images/conformance/OWNERS
@@ -3,7 +3,6 @@
 reviewers:
   - timothysc
   - dims
-  - ixdy
   - spiffxp
   - neolit123
   - bentheelder
@@ -13,10 +12,11 @@ reviewers:
 approvers:
   - timothysc
   - dims
-  - ixdy
   - spiffxp
   - neolit123
   - bentheelder
+emeritus_approvers:
+  - ixdy
 labels:
 - sig/release
 - sig/testing

--- a/hack/OWNERS
+++ b/hack/OWNERS
@@ -4,7 +4,6 @@ reviewers:
   - bentheelder
   - cblecker
   - fejta
-  - ixdy
   - juanvallejo
   - hwdef
   - lavalamp
@@ -20,7 +19,6 @@ approvers:
   - deads2k
   - dims # for local-up-cluster related files
   - fejta
-  - ixdy
   - lavalamp
   - liggitt
   - pwittrock
@@ -32,5 +30,6 @@ approvers:
   - mikedanese
 emeritus_approvers:
   - eparis
+  - ixdy
   - jbeda
   - zmerlynn

--- a/test/images/OWNERS
+++ b/test/images/OWNERS
@@ -7,5 +7,5 @@ approvers:
   - mkumatag
   - listx
 emeritus_approvers:
-  - luxas
   - ixdy
+  - luxas

--- a/test/utils/image/OWNERS
+++ b/test/utils/image/OWNERS
@@ -3,10 +3,10 @@
 reviewers:
   - luxas
   - mkumatag
-  - ixdy
   - listx
 approvers:
   - luxas
   - mkumatag
-  - ixdy
   - listx
+emeritus_approvers:
+  - ixdy

--- a/third_party/forked/shell2junit/OWNERS
+++ b/third_party/forked/shell2junit/OWNERS
@@ -2,11 +2,11 @@
 
 reviewers:
   - cblecker
-  - ixdy
   - mengqiy
   - pwittrock
 approvers:
   - cblecker
-  - ixdy
   - mengqiy
   - pwittrock
+emeritus_approvers:
+  - ixdy


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
I haven't really worked on kubernetes/kubernetes for a while, so I shouldn't be reviewing or approving changes in it. Moving myself to `emeritus_approvers`.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```