### PR TITLE
Fix memory leak in endpointSliceTracker

### DIFF
--- a/pkg/controller/endpointslice/BUILD
+++ b/pkg/controller/endpointslice/BUILD
@@ -66,6 +66,7 @@ go_test(
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/intstr:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/rand:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/wait:go_default_library",

--- a/pkg/controller/endpointslice/endpointslice_controller.go
+++ b/pkg/controller/endpointslice/endpointslice_controller.go
@@ -307,6 +307,7 @@ func (c *Controller) syncService(key string) error {
 		if apierrors.IsNotFound(err) {
 			c.triggerTimeTracker.DeleteService(namespace, name)
 			c.reconciler.deleteService(namespace, name)
+			c.endpointSliceTracker.DeleteService(namespace, name)
 			// The service has been deleted, return nil so that it won't be retried.
 			return nil
 		}

--- a/pkg/controller/endpointslice/endpointslice_tracker_test.go
+++ b/pkg/controller/endpointslice/endpointslice_tracker_test.go
@@ -19,8 +19,11 @@ package endpointslice
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	discovery "k8s.io/api/discovery/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 func TestEndpointSliceTrackerUpdate(t *testing.T) {
@@ -43,34 +46,55 @@ func TestEndpointSliceTrackerUpdate(t *testing.T) {
 	epSlice1DifferentRV.ResourceVersion = "rv2"
 
 	testCases := map[string]struct {
-		updateParam *discovery.EndpointSlice
-		checksParam *discovery.EndpointSlice
-		expectHas   bool
-		expectStale bool
+		updateParam                     *discovery.EndpointSlice
+		checksParam                     *discovery.EndpointSlice
+		expectHas                       bool
+		expectStale                     bool
+		expectResourceVersionsByService map[types.NamespacedName]endpointSliceResourceVersions
 	}{
 		"same slice": {
 			updateParam: epSlice1,
 			checksParam: epSlice1,
 			expectHas:   true,
 			expectStale: false,
+			expectResourceVersionsByService: map[types.NamespacedName]endpointSliceResourceVersions{
+				{Namespace: epSlice1.Namespace, Name: "svc1"}: {
+					epSlice1.Name: epSlice1.ResourceVersion,
+				},
+			},
 		},
 		"different namespace": {
 			updateParam: epSlice1,
 			checksParam: epSlice1DifferentNS,
 			expectHas:   false,
 			expectStale: true,
+			expectResourceVersionsByService: map[types.NamespacedName]endpointSliceResourceVersions{
+				{Namespace: epSlice1.Namespace, Name: "svc1"}: {
+					epSlice1.Name: epSlice1.ResourceVersion,
+				},
+			},
 		},
 		"different service": {
 			updateParam: epSlice1,
 			checksParam: epSlice1DifferentService,
 			expectHas:   false,
 			expectStale: true,
+			expectResourceVersionsByService: map[types.NamespacedName]endpointSliceResourceVersions{
+				{Namespace: epSlice1.Namespace, Name: "svc1"}: {
+					epSlice1.Name: epSlice1.ResourceVersion,
+				},
+			},
 		},
 		"different resource version": {
 			updateParam: epSlice1,
 			checksParam: epSlice1DifferentRV,
 			expectHas:   true,
 			expectStale: true,
+			expectResourceVersionsByService: map[types.NamespacedName]endpointSliceResourceVersions{
+				{Namespace: epSlice1.Namespace, Name: "svc1"}: {
+					epSlice1.Name: epSlice1.ResourceVersion,
+				},
+			},
 		},
 	}
 
@@ -84,6 +108,7 @@ func TestEndpointSliceTrackerUpdate(t *testing.T) {
 			if esTracker.Stale(tc.checksParam) != tc.expectStale {
 				t.Errorf("tc.tracker.Stale(%+v) == %t, expected %t", tc.checksParam, esTracker.Stale(tc.checksParam), tc.expectStale)
 			}
+			assert.Equal(t, tc.expectResourceVersionsByService, esTracker.resourceVersionsByService)
 		})
 	}
 }
@@ -169,6 +194,72 @@ func TestEndpointSliceTrackerDelete(t *testing.T) {
 			if esTracker.Stale(tc.checksParam) != tc.expectStale {
 				t.Errorf("esTracker.Stale(%+v) == %t, expected %t", tc.checksParam, esTracker.Stale(tc.checksParam), tc.expectStale)
 			}
+		})
+	}
+}
+
+func TestEndpointSliceTrackerDeleteService(t *testing.T) {
+	svcName1, svcNS1 := "svc1", "ns1"
+	svcName2, svcNS2 := "svc2", "ns2"
+	epSlice1 := &discovery.EndpointSlice{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "example-1",
+			Namespace:       svcNS1,
+			ResourceVersion: "rv1",
+			Labels:          map[string]string{discovery.LabelServiceName: svcName1},
+		},
+	}
+
+	testCases := map[string]struct {
+		updateParam                     *discovery.EndpointSlice
+		deleteServiceParam              *types.NamespacedName
+		expectHas                       bool
+		expectStale                     bool
+		expectResourceVersionsByService map[types.NamespacedName]endpointSliceResourceVersions
+	}{
+		"same service": {
+			updateParam:                     epSlice1,
+			deleteServiceParam:              &types.NamespacedName{Namespace: svcNS1, Name: svcName1},
+			expectHas:                       false,
+			expectStale:                     true,
+			expectResourceVersionsByService: map[types.NamespacedName]endpointSliceResourceVersions{},
+		},
+		"different namespace": {
+			updateParam:        epSlice1,
+			deleteServiceParam: &types.NamespacedName{Namespace: svcNS2, Name: svcName1},
+			expectHas:          true,
+			expectStale:        false,
+			expectResourceVersionsByService: map[types.NamespacedName]endpointSliceResourceVersions{
+				{Namespace: epSlice1.Namespace, Name: "svc1"}: {
+					epSlice1.Name: epSlice1.ResourceVersion,
+				},
+			},
+		},
+		"different service": {
+			updateParam:        epSlice1,
+			deleteServiceParam: &types.NamespacedName{Namespace: svcNS1, Name: svcName2},
+			expectHas:          true,
+			expectStale:        false,
+			expectResourceVersionsByService: map[types.NamespacedName]endpointSliceResourceVersions{
+				{Namespace: epSlice1.Namespace, Name: "svc1"}: {
+					epSlice1.Name: epSlice1.ResourceVersion,
+				},
+			},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			esTracker := newEndpointSliceTracker()
+			esTracker.Update(tc.updateParam)
+			esTracker.DeleteService(tc.deleteServiceParam.Namespace, tc.deleteServiceParam.Name)
+			if esTracker.Has(tc.updateParam) != tc.expectHas {
+				t.Errorf("tc.tracker.Has(%+v) == %t, expected %t", tc.updateParam, esTracker.Has(tc.updateParam), tc.expectHas)
+			}
+			if esTracker.Stale(tc.updateParam) != tc.expectStale {
+				t.Errorf("tc.tracker.Stale(%+v) == %t, expected %t", tc.updateParam, esTracker.Stale(tc.updateParam), tc.expectStale)
+			}
+			assert.Equal(t, tc.expectResourceVersionsByService, esTracker.resourceVersionsByService)
 		})
 	}
 }

--- a/pkg/controller/endpointslice/reconciler_test.go
+++ b/pkg/controller/endpointslice/reconciler_test.go
@@ -983,7 +983,7 @@ func expectActions(t *testing.T, actions []k8stesting.Action, num int, verb, res
 }
 
 func expectTrackedResourceVersion(t *testing.T, tracker *endpointSliceTracker, slice *discovery.EndpointSlice, expectedRV string) {
-	rrv := tracker.relatedResourceVersions(slice)
+	rrv, _ := tracker.relatedResourceVersions(slice)
 	rv, tracked := rrv[slice.Name]
 	if !tracked {
 		t.Fatalf("Expected EndpointSlice %s to be tracked", slice.Name)


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
endpointSliceTracker creates a set of resource versions for each service, the resource versions in the set could be deleted when endpointslices are deleted, but the set and its key in the map is never deleted, leading to memory leak.

This patch deletes the set if the service is deleted, and stops initializing an empty set when "read-only" methods "Has" and "Stale" are called.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #92837

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixed memory leak in endpointSliceTracker
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
