### PR TITLE
selectorspread: access listers in plugin instantiation

### DIFF
--- a/pkg/scheduler/framework/plugins/selectorspread/BUILD
+++ b/pkg/scheduler/framework/plugins/selectorspread/BUILD
@@ -12,6 +12,8 @@ go_library(
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
+        "//staging/src/k8s.io/client-go/listers/apps/v1:go_default_library",
+        "//staging/src/k8s.io/client-go/listers/core/v1:go_default_library",
     ],
 )
 

--- a/pkg/scheduler/framework/plugins/selectorspread/selector_spread_perf_test.go
+++ b/pkg/scheduler/framework/plugins/selectorspread/selector_spread_perf_test.go
@@ -69,7 +69,11 @@ func BenchmarkTestSelectorSpreadPriority(b *testing.B) {
 				}
 			}
 			fh, _ := runtime.NewFramework(nil, nil, nil, runtime.WithSnapshotSharedLister(snapshot), runtime.WithInformerFactory(informerFactory))
-			plugin := &SelectorSpread{handle: fh}
+			pl, err := New(nil, fh)
+			if err != nil {
+				b.Fatal(err)
+			}
+			plugin := pl.(*SelectorSpread)
 			b.ResetTimer()
 
 			for i := 0; i < b.N; i++ {

--- a/pkg/scheduler/framework/plugins/selectorspread/selector_spread_test.go
+++ b/pkg/scheduler/framework/plugins/selectorspread/selector_spread_test.go
@@ -383,9 +383,11 @@ func TestSelectorSpreadScore(t *testing.T) {
 
 			state := framework.NewCycleState()
 
-			plugin := &SelectorSpread{
-				handle: fh,
+			pl, err := New(nil, fh)
+			if err != nil {
+				t.Fatal(err)
 			}
+			plugin := pl.(*SelectorSpread)
 
 			status := plugin.PreScore(ctx, state, test.pod, nodes)
 			if !status.IsSuccess() {
@@ -635,9 +637,11 @@ func TestZoneSelectorSpreadPriority(t *testing.T) {
 				t.Errorf("error creating new framework handle: %+v", err)
 			}
 
-			plugin := &SelectorSpread{
-				handle: fh,
+			pl, err := New(nil, fh)
+			if err != nil {
+				t.Fatal(err)
 			}
+			plugin := pl.(*SelectorSpread)
 
 			state := framework.NewCycleState()
 			status := plugin.PreScore(ctx, state, test.pod, nodes)


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Plugins must access listers at instantiation time in order to have them populated. Two plugins (selectorspread and defaultpreemption) access one or all listers outside of instantiation. This PR makes fixes the bug in selectorspread (~~a separate PR for defaultpreemption in the works~~).

**Which issue(s) this PR fixes**:

Updates https://github.com/kubernetes/kubernetes/issues/92781

**Special notes for your reviewer**:

~~I'll be submitting a separate PR for defaultpreemption in a bit (wanted to keep this PR small).~~

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs
```

/sig scheduling
/cc @ahg-g @alculquicondor @Huang-Wei @liggitt 