### PR TITLE
[fluentd/elasticsearch] Add mechanism to load simple sniffer class

### DIFF
--- a/cluster/addons/fluentd-elasticsearch/fluentd-es-image/entrypoint.sh
+++ b/cluster/addons/fluentd-elasticsearch/fluentd-es-image/entrypoint.sh
@@ -27,6 +27,16 @@ else
     export LD_PRELOAD=/usr/lib/aarch64-linux-gnu/libjemalloc.so.2
 fi
 
+# For disabling elasticsearch ruby client sniffering feature.
+# Because, on k8s, sniffering feature sometimes causes failed to flush buffers error
+# due to between service name and ip address glitch.
+# And this should be needed for downstream helm chart configurations
+# for sniffer_class_name parameter.
+SIMPLE_SNIFFER=$( gem contents fluent-plugin-elasticsearch | grep elasticsearch_simple_sniffer.rb )
+if [ -n "$SIMPLE_SNIFFER" ] && [ -f "$SIMPLE_SNIFFER" ] ; then
+    FLUENTD_ARGS="$FLUENTD_ARGS -r $SIMPLE_SNIFFER"
+fi
+
 # Use exec to get the signal
 # A non-quoted string and add the comment to prevent shellcheck failures on this line.
 # See https://github.com/koalaman/shellcheck/wiki/SC2086


### PR DESCRIPTION
Signed-off-by: Hiroshi Hatake <cosmo0920.oucc@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

We'd received that fluentd which is deployed with fluentd-elasticsearch stable chart sometimes exhausted due to elasticsearch ruby client sniffering issue.
This issue should be fixed in fluent-plugin-elasticsearch repository: https://github.com/uken/fluent-plugin-elasticsearch/pull/459
But this feature requests to add additional load command for simple sniffer class which is bundled in fluent-plugin-elasticsearch.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #92852

**Special notes for your reviewer**:



**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Add mechanism to load simple sniffer class into fluentd-elasticsearch image
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
