### PR TITLE
iptables: don't do reverse DNS lookups

### DIFF
--- a/pkg/util/iptables/iptables.go
+++ b/pkg/util/iptables/iptables.go
@@ -607,6 +607,9 @@ func (runner *runner) chainExists(table Table, chain Chain) (bool, error) {
 	runner.mu.Lock()
 	defer runner.mu.Unlock()
 
+	trace := utiltrace.New("iptables Monitor CANARY check")
+	defer trace.LogIfLong(2 * time.Second)
+
 	_, err := runner.run(opListChain, fullArgs)
 	return err == nil, err
 }
@@ -617,7 +620,7 @@ const (
 	opCreateChain operation = "-N"
 	opFlushChain  operation = "-F"
 	opDeleteChain operation = "-X"
-	opListChain   operation = "-L"
+	opListChain   operation = "-S"
 	opAppendRule  operation = "-A"
 	opCheckRule   operation = "-C"
 	opDeleteRule  operation = "-D"


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

the iptables monitor was using iptables -L to list the chains,
without the -n option, so it was trying to do reverse DNS lookups.

However, this is not a big impact in Kubernetes because it's only being used
for checking the CANARY chains that are always empty.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

This caused multiple issues on KIND jobs, don't know exactly what it was more evident there, maybe because of the DNS
resolution is slower :shrug: 

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
