### PR TITLE
scheduler: Extend ExtenderFilterResult to include UnschedulableAndUnresolvable nodes 

### DIFF
--- a/pkg/scheduler/core/generic_scheduler_test.go
+++ b/pkg/scheduler/core/generic_scheduler_test.go
@@ -273,6 +273,180 @@ func TestSelectHost(t *testing.T) {
 	}
 }
 
+func TestFindNodesThatPassExtenders(t *testing.T) {
+	tests := []struct {
+		name                  string
+		extenders             []st.FakeExtender
+		nodes                 []*v1.Node
+		filteredNodesStatuses framework.NodeToStatusMap
+		expectsErr            bool
+		expectedNodes         []*v1.Node
+		expectedStatuses      framework.NodeToStatusMap
+	}{
+		{
+			name: "error",
+			extenders: []st.FakeExtender{
+				{
+					Predicates: []st.FitPredicate{st.ErrorPredicateExtender},
+				},
+			},
+			nodes:                 makeNodeList([]string{"a"}),
+			filteredNodesStatuses: make(framework.NodeToStatusMap),
+			expectsErr:            true,
+		},
+		{
+			name: "success",
+			extenders: []st.FakeExtender{
+				{
+					Predicates: []st.FitPredicate{st.TruePredicateExtender},
+				},
+			},
+			nodes:                 makeNodeList([]string{"a"}),
+			filteredNodesStatuses: make(framework.NodeToStatusMap),
+			expectsErr:            false,
+			expectedNodes:         makeNodeList([]string{"a"}),
+			expectedStatuses:      make(framework.NodeToStatusMap),
+		},
+		{
+			name: "unschedulable",
+			extenders: []st.FakeExtender{
+				{
+					Predicates: []st.FitPredicate{func(pod *v1.Pod, node *v1.Node) *framework.Status {
+						if node.Name == "a" {
+							return framework.NewStatus(framework.Success)
+						}
+						return framework.NewStatus(framework.Unschedulable, fmt.Sprintf("node %q is not allowed", node.Name))
+					}},
+				},
+			},
+			nodes:                 makeNodeList([]string{"a", "b"}),
+			filteredNodesStatuses: make(framework.NodeToStatusMap),
+			expectsErr:            false,
+			expectedNodes:         makeNodeList([]string{"a"}),
+			expectedStatuses: framework.NodeToStatusMap{
+				"b": framework.NewStatus(framework.Unschedulable, fmt.Sprintf("FakeExtender: node %q failed", "b")),
+			},
+		},
+		{
+			name: "unschedulable and unresolvable",
+			extenders: []st.FakeExtender{
+				{
+					Predicates: []st.FitPredicate{func(pod *v1.Pod, node *v1.Node) *framework.Status {
+						if node.Name == "a" {
+							return framework.NewStatus(framework.Success)
+						}
+						if node.Name == "b" {
+							return framework.NewStatus(framework.Unschedulable, fmt.Sprintf("node %q is not allowed", node.Name))
+						}
+						return framework.NewStatus(framework.UnschedulableAndUnresolvable, fmt.Sprintf("node %q is not allowed", node.Name))
+					}},
+				},
+			},
+			nodes:                 makeNodeList([]string{"a", "b", "c"}),
+			filteredNodesStatuses: make(framework.NodeToStatusMap),
+			expectsErr:            false,
+			expectedNodes:         makeNodeList([]string{"a"}),
+			expectedStatuses: framework.NodeToStatusMap{
+				"b": framework.NewStatus(framework.Unschedulable, fmt.Sprintf("FakeExtender: node %q failed", "b")),
+				"c": framework.NewStatus(framework.UnschedulableAndUnresolvable, fmt.Sprintf("FakeExtender: node %q failed and unresolvable", "c")),
+			},
+		},
+		{
+			name: "extender may overwrite the statuses",
+			extenders: []st.FakeExtender{
+				{
+					Predicates: []st.FitPredicate{func(pod *v1.Pod, node *v1.Node) *framework.Status {
+						if node.Name == "a" {
+							return framework.NewStatus(framework.Success)
+						}
+						if node.Name == "b" {
+							return framework.NewStatus(framework.Unschedulable, fmt.Sprintf("node %q is not allowed", node.Name))
+						}
+						return framework.NewStatus(framework.UnschedulableAndUnresolvable, fmt.Sprintf("node %q is not allowed", node.Name))
+					}},
+				},
+			},
+			nodes: makeNodeList([]string{"a", "b", "c"}),
+			filteredNodesStatuses: framework.NodeToStatusMap{
+				"c": framework.NewStatus(framework.Unschedulable, fmt.Sprintf("FakeFilterPlugin: node %q failed", "c")),
+			},
+			expectsErr:    false,
+			expectedNodes: makeNodeList([]string{"a"}),
+			expectedStatuses: framework.NodeToStatusMap{
+				"b": framework.NewStatus(framework.Unschedulable, fmt.Sprintf("FakeExtender: node %q failed", "b")),
+				"c": framework.NewStatus(framework.UnschedulableAndUnresolvable, fmt.Sprintf("FakeFilterPlugin: node %q failed", "c"), fmt.Sprintf("FakeExtender: node %q failed and unresolvable", "c")),
+			},
+		},
+		{
+			name: "multiple extenders",
+			extenders: []st.FakeExtender{
+				{
+					Predicates: []st.FitPredicate{func(pod *v1.Pod, node *v1.Node) *framework.Status {
+						if node.Name == "a" {
+							return framework.NewStatus(framework.Success)
+						}
+						if node.Name == "b" {
+							return framework.NewStatus(framework.Unschedulable, fmt.Sprintf("node %q is not allowed", node.Name))
+						}
+						return framework.NewStatus(framework.UnschedulableAndUnresolvable, fmt.Sprintf("node %q is not allowed", node.Name))
+					}},
+				},
+				{
+					Predicates: []st.FitPredicate{func(pod *v1.Pod, node *v1.Node) *framework.Status {
+						if node.Name == "a" {
+							return framework.NewStatus(framework.Success)
+						}
+						return framework.NewStatus(framework.Unschedulable, fmt.Sprintf("node %q is not allowed", node.Name))
+					}},
+				},
+			},
+			nodes:                 makeNodeList([]string{"a", "b", "c"}),
+			filteredNodesStatuses: make(framework.NodeToStatusMap),
+			expectsErr:            false,
+			expectedNodes:         makeNodeList([]string{"a"}),
+			expectedStatuses: framework.NodeToStatusMap{
+				"b": framework.NewStatus(framework.Unschedulable, fmt.Sprintf("FakeExtender: node %q failed", "b")),
+				"c": framework.NewStatus(framework.UnschedulableAndUnresolvable, fmt.Sprintf("FakeExtender: node %q failed and unresolvable", "c")),
+			},
+		},
+	}
+
+	cmpOpts := []cmp.Option{
+		cmp.Comparer(func(s1 framework.Status, s2 framework.Status) bool {
+			return s1.Code() == s2.Code() && reflect.DeepEqual(s1.Reasons(), s2.Reasons())
+		}),
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var extenders []framework.Extender
+			for ii := range tt.extenders {
+				extenders = append(extenders, &tt.extenders[ii])
+			}
+			scheduler := &genericScheduler{
+				extenders: extenders,
+			}
+			pod := &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "1", UID: types.UID("1")}}
+			got, err := scheduler.findNodesThatPassExtenders(pod, tt.nodes, tt.filteredNodesStatuses)
+			if tt.expectsErr {
+				if err == nil {
+					t.Error("Unexpected non-error")
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Unexpected error: %v", err)
+				}
+				if diff := cmp.Diff(tt.expectedNodes, got); diff != "" {
+					t.Errorf("filtered nodes (-want,+got):\n%s", diff)
+				}
+				if diff := cmp.Diff(tt.expectedStatuses, tt.filteredNodesStatuses, cmpOpts...); diff != "" {
+					t.Errorf("filtered statuses (-want,+got):\n%s", diff)
+				}
+			}
+		})
+	}
+}
+
 func TestGenericScheduler(t *testing.T) {
 	tests := []struct {
 		name            string

--- a/pkg/scheduler/factory_test.go
+++ b/pkg/scheduler/factory_test.go
@@ -674,8 +674,8 @@ func (f *fakeExtender) SupportsPreemption() bool {
 	return false
 }
 
-func (f *fakeExtender) Filter(pod *v1.Pod, nodes []*v1.Node) (filteredNodes []*v1.Node, failedNodesMap extenderv1.FailedNodesMap, err error) {
-	return nil, nil, nil
+func (f *fakeExtender) Filter(pod *v1.Pod, nodes []*v1.Node) ([]*v1.Node, extenderv1.FailedNodesMap, extenderv1.FailedNodesMap, error) {
+	return nil, nil, nil, nil
 }
 
 func (f *fakeExtender) Prioritize(

--- a/pkg/scheduler/framework/extender.go
+++ b/pkg/scheduler/framework/extender.go
@@ -29,9 +29,11 @@ type Extender interface {
 	Name() string
 
 	// Filter based on extender-implemented predicate functions. The filtered list is
-	// expected to be a subset of the supplied list. failedNodesMap optionally contains
-	// the list of failed nodes and failure reasons.
-	Filter(pod *v1.Pod, nodes []*v1.Node) (filteredNodes []*v1.Node, failedNodesMap extenderv1.FailedNodesMap, err error)
+	// expected to be a subset of the supplied list.
+	// The failedNodes and failedAndUnresolvableNodes optionally contains the list
+	// of failed nodes and failure reasons, except nodes in the latter are
+	// unresolvable.
+	Filter(pod *v1.Pod, nodes []*v1.Node) (filteredNodes []*v1.Node, failedNodesMap extenderv1.FailedNodesMap, failedAndUnresolvable extenderv1.FailedNodesMap, err error)
 
 	// Prioritize based on extender-implemented priority functions. The returned scores & weight
 	// are used to compute the weighted score for an extender. The weighted scores are added to

--- a/staging/src/k8s.io/kube-scheduler/extender/v1/types.go
+++ b/staging/src/k8s.io/kube-scheduler/extender/v1/types.go
@@ -92,6 +92,10 @@ type ExtenderFilterResult struct {
 	NodeNames *[]string
 	// Filtered out nodes where the pod can't be scheduled and the failure messages
 	FailedNodes FailedNodesMap
+	// Filtered out nodes where the pod can't be scheduled and preemption would
+	// not change anything. The value is the failure message same as FailedNodes.
+	// Nodes specified here takes precedence over FailedNodes.
+	FailedAndUnresolvableNodes FailedNodesMap
 	// Error message indicating failure
 	Error string
 }

--- a/staging/src/k8s.io/kube-scheduler/extender/v1/types_test.go
+++ b/staging/src/k8s.io/kube-scheduler/extender/v1/types_test.go
@@ -67,12 +67,13 @@ func TestCompatibility(t *testing.T) {
 		{
 			emptyObj: &ExtenderFilterResult{},
 			obj: &ExtenderFilterResult{
-				Nodes:       &corev1.NodeList{Items: []corev1.Node{{ObjectMeta: metav1.ObjectMeta{Name: "nodename"}}}},
-				NodeNames:   &[]string{"node1"},
-				FailedNodes: FailedNodesMap{"foo": "bar"},
-				Error:       "myerror",
+				Nodes:                      &corev1.NodeList{Items: []corev1.Node{{ObjectMeta: metav1.ObjectMeta{Name: "nodename"}}}},
+				NodeNames:                  &[]string{"node1"},
+				FailedNodes:                FailedNodesMap{"foo": "bar"},
+				FailedAndUnresolvableNodes: FailedNodesMap{"baz": "qux"},
+				Error:                      "myerror",
 			},
-			expectJSON: `{"Nodes":{"metadata":{},"items":[{"metadata":{"name":"nodename","creationTimestamp":null},"spec":{},"status":{"daemonEndpoints":{"kubeletEndpoint":{"Port":0}},"nodeInfo":{"machineID":"","systemUUID":"","bootID":"","kernelVersion":"","osImage":"","containerRuntimeVersion":"","kubeletVersion":"","kubeProxyVersion":"","operatingSystem":"","architecture":""}}}]},"NodeNames":["node1"],"FailedNodes":{"foo":"bar"},"Error":"myerror"}`,
+			expectJSON: `{"Nodes":{"metadata":{},"items":[{"metadata":{"name":"nodename","creationTimestamp":null},"spec":{},"status":{"daemonEndpoints":{"kubeletEndpoint":{"Port":0}},"nodeInfo":{"machineID":"","systemUUID":"","bootID":"","kernelVersion":"","osImage":"","containerRuntimeVersion":"","kubeletVersion":"","kubeProxyVersion":"","operatingSystem":"","architecture":""}}}]},"NodeNames":["node1"],"FailedNodes":{"foo":"bar"},"FailedAndUnresolvableNodes":{"baz":"qux"},"Error":"myerror"}`,
 		},
 		{
 			emptyObj: &ExtenderBindingArgs{},

--- a/staging/src/k8s.io/kube-scheduler/extender/v1/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/kube-scheduler/extender/v1/zz_generated.deepcopy.go
@@ -115,6 +115,13 @@ func (in *ExtenderFilterResult) DeepCopyInto(out *ExtenderFilterResult) {
 			(*out)[key] = val
 		}
 	}
+	if in.FailedAndUnresolvableNodes != nil {
+		in, out := &in.FailedAndUnresolvableNodes, &out.FailedAndUnresolvableNodes
+		*out = make(FailedNodesMap, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	return
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test
/kind feature
> /kind flake

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #91281

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Scheduler extender filter interface now can report unresolvable failed nodes in the new field `FailedAndUnresolvableNodes` of  `ExtenderFilterResult` struct. Nodes in this map will be skipped in the preemption phase. 
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: https://github.com/kubernetes/enhancements/pull/1850
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/pull/1850
```
