### PR TITLE
Windows: Fixes subpath volume persistance on container restart 

### DIFF
--- a/pkg/volume/util/subpath/BUILD
+++ b/pkg/volume/util/subpath/BUILD
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "go_default_library",
     srcs = [
+        "common.go",
         "subpath.go",
         "subpath_linux.go",
         "subpath_unsupported.go",
@@ -10,56 +11,44 @@ go_library(
     ],
     importpath = "k8s.io/kubernetes/pkg/volume/util/subpath",
     visibility = ["//visibility:public"],
-    deps = select({
+    deps = [
+        "//vendor/k8s.io/klog/v2:go_default_library",
+        "//vendor/k8s.io/utils/mount:go_default_library",
+    ] + select({
         "@io_bazel_rules_go//go/platform:android": [
             "//vendor/golang.org/x/sys/unix:go_default_library",
-            "//vendor/k8s.io/klog/v2:go_default_library",
-            "//vendor/k8s.io/utils/mount:go_default_library",
         ],
         "@io_bazel_rules_go//go/platform:darwin": [
-            "//vendor/k8s.io/utils/mount:go_default_library",
             "//vendor/k8s.io/utils/nsenter:go_default_library",
         ],
         "@io_bazel_rules_go//go/platform:dragonfly": [
-            "//vendor/k8s.io/utils/mount:go_default_library",
             "//vendor/k8s.io/utils/nsenter:go_default_library",
         ],
         "@io_bazel_rules_go//go/platform:freebsd": [
-            "//vendor/k8s.io/utils/mount:go_default_library",
             "//vendor/k8s.io/utils/nsenter:go_default_library",
         ],
         "@io_bazel_rules_go//go/platform:ios": [
-            "//vendor/k8s.io/utils/mount:go_default_library",
             "//vendor/k8s.io/utils/nsenter:go_default_library",
         ],
         "@io_bazel_rules_go//go/platform:linux": [
             "//vendor/golang.org/x/sys/unix:go_default_library",
-            "//vendor/k8s.io/klog/v2:go_default_library",
-            "//vendor/k8s.io/utils/mount:go_default_library",
         ],
         "@io_bazel_rules_go//go/platform:nacl": [
-            "//vendor/k8s.io/utils/mount:go_default_library",
             "//vendor/k8s.io/utils/nsenter:go_default_library",
         ],
         "@io_bazel_rules_go//go/platform:netbsd": [
-            "//vendor/k8s.io/utils/mount:go_default_library",
             "//vendor/k8s.io/utils/nsenter:go_default_library",
         ],
         "@io_bazel_rules_go//go/platform:openbsd": [
-            "//vendor/k8s.io/utils/mount:go_default_library",
             "//vendor/k8s.io/utils/nsenter:go_default_library",
         ],
         "@io_bazel_rules_go//go/platform:plan9": [
-            "//vendor/k8s.io/utils/mount:go_default_library",
             "//vendor/k8s.io/utils/nsenter:go_default_library",
         ],
         "@io_bazel_rules_go//go/platform:solaris": [
-            "//vendor/k8s.io/utils/mount:go_default_library",
             "//vendor/k8s.io/utils/nsenter:go_default_library",
         ],
         "@io_bazel_rules_go//go/platform:windows": [
-            "//vendor/k8s.io/klog/v2:go_default_library",
-            "//vendor/k8s.io/utils/mount:go_default_library",
             "//vendor/k8s.io/utils/nsenter:go_default_library",
         ],
         "//conditions:default": [],

--- a/pkg/volume/util/subpath/common.go
+++ b/pkg/volume/util/subpath/common.go
@@ -1,0 +1,303 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package subpath
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
+
+	"k8s.io/klog/v2"
+	"k8s.io/utils/mount"
+)
+
+const (
+	// place for subpath mounts
+	// TODO: pass in directory using kubelet_getters instead
+	containerSubPathDirectoryName = "volume-subpaths"
+)
+
+type subpath struct {
+	mounter mount.Interface
+}
+
+// New returns a subpath.Interface for the current system
+func New(mounter mount.Interface) Interface {
+	return &subpath{
+		mounter: mounter,
+	}
+}
+
+func (sp *subpath) CleanSubPaths(podDir string, volumeName string) error {
+	return doCleanSubPaths(sp.mounter, podDir, volumeName)
+}
+
+// SafeMakeDir makes sure that the created directory does not escape given base directory mis-using symlinks.
+func (sp *subpath) SafeMakeDir(subdir string, base string, perm os.FileMode) error {
+	realBase, err := filepath.EvalSymlinks(base)
+	if err != nil {
+		return fmt.Errorf("error resolving symlinks in %s: %s", base, err)
+	}
+
+	realFullPath := filepath.Join(realBase, subdir)
+	return doSafeMakeDir(realFullPath, realBase, perm)
+}
+
+// prepareSubpathTarget creates target for bind-mount of subpath. It returns
+// "true" when the target already exists and something is mounted there.
+// Given Subpath must have all paths with already resolved symlinks and with
+// paths relevant to kubelet (when it runs in a container).
+// This function is called also by NsEnterMounter. It works because
+// /var/lib/kubelet is mounted from the host into the container with Kubelet as
+// /var/lib/kubelet too.
+func prepareSubpathTarget(mounter mount.Interface, subpath Subpath) (bool, string, error) {
+	// Early check for already bind-mounted subpath.
+	bindPathTarget := getSubpathBindTarget(subpath)
+	notMount, err := mount.IsNotMountPoint(mounter, bindPathTarget)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return false, "", fmt.Errorf("error checking path %s for mount: %s", bindPathTarget, err)
+		}
+		// Ignore ErrorNotExist: the file/directory will be created below if it does not exist yet.
+		notMount = true
+	}
+	if !notMount {
+		// It's already mounted
+		klog.V(5).Infof("Skipping bind-mounting subpath %s: already mounted", bindPathTarget)
+		return true, bindPathTarget, nil
+	}
+
+	// bindPathTarget is in /var/lib/kubelet and thus reachable without any
+	// translation even to containerized kubelet.
+	bindParent := filepath.Dir(bindPathTarget)
+	err = os.MkdirAll(bindParent, 0750)
+	if err != nil && !os.IsExist(err) {
+		return false, "", fmt.Errorf("error creating directory %s: %s", bindParent, err)
+	}
+
+	// On Windows, a symlink cannot be created if the target already exists.
+	// We've already created the parent folder, nothing else to do.
+	if runtime.GOOS == "windows" {
+		return false, bindPathTarget, nil
+	}
+
+	t, err := os.Lstat(subpath.Path)
+	if err != nil {
+		return false, "", fmt.Errorf("lstat %s failed: %s", subpath.Path, err)
+	}
+
+	if t.Mode()&os.ModeDir > 0 {
+		if err = os.Mkdir(bindPathTarget, 0750); err != nil && !os.IsExist(err) {
+			return false, "", fmt.Errorf("error creating directory %s: %s", bindPathTarget, err)
+		}
+	} else {
+		// "/bin/touch <bindPathTarget>".
+		// A file is enough for all possible targets (symlink, device, pipe,
+		// socket, ...), bind-mounting them into a file correctly changes type
+		// of the target file.
+		if err = ioutil.WriteFile(bindPathTarget, []byte{}, 0640); err != nil {
+			return false, "", fmt.Errorf("error creating file %s: %s", bindPathTarget, err)
+		}
+	}
+	return false, bindPathTarget, nil
+}
+
+func getSubpathBindTarget(subpath Subpath) string {
+	// containerName is DNS label, i.e. safe as a directory name.
+	return filepath.Join(subpath.PodDir, containerSubPathDirectoryName, subpath.VolumeName, subpath.ContainerName, strconv.Itoa(subpath.VolumeMountIndex))
+}
+
+func doBindSubPath(mounter mount.Interface, subpath Subpath) (hostPath string, err error) {
+	// Linux, kubelet runs on the host:
+	// - safely open the subpath
+	// - bind-mount /proc/<pid of kubelet>/fd/<fd> to subpath target
+	// User can't change /proc/<pid of kubelet>/fd/<fd> to point to a bad place.
+
+	// Evaluate all symlinks here once for all subsequent functions.
+	newVolumePath, err := filepath.EvalSymlinks(subpath.VolumePath)
+	if err != nil {
+		return "", fmt.Errorf("error resolving symlinks in %q: %v", subpath.VolumePath, err)
+	}
+	newPath, err := filepath.EvalSymlinks(subpath.Path)
+	if err != nil {
+		return "", fmt.Errorf("error resolving symlinks in %q: %v", subpath.Path, err)
+	}
+	klog.V(5).Infof("doBindSubPath %q (%q) for volumepath %q", subpath.Path, newPath, subpath.VolumePath)
+	subpath.VolumePath = newVolumePath
+	subpath.Path = newPath
+
+	alreadyMounted, bindPathTarget, err := prepareSubpathTarget(mounter, subpath)
+	if err != nil {
+		return "", err
+	}
+	if alreadyMounted {
+		return bindPathTarget, nil
+	}
+
+	success := false
+	defer func() {
+		// Cleanup subpath on error
+		if !success {
+			klog.V(4).Infof("doBindSubPath() failed for %q, cleaning up subpath", bindPathTarget)
+			if cleanErr := cleanSubPath(mounter, subpath); cleanErr != nil {
+				klog.Errorf("Failed to clean subpath %q: %v", bindPathTarget, cleanErr)
+			}
+		}
+	}()
+
+	// Do the bind mount
+	if err = bindMount(mounter, subpath, bindPathTarget); err != nil {
+		return "", err
+	}
+	success = true
+
+	klog.V(3).Infof("Bound SubPath %s into %s", subpath.Path, bindPathTarget)
+	return bindPathTarget, nil
+}
+
+// This implementation is shared between Linux and NsEnter
+func doCleanSubPaths(mounter mount.Interface, podDir string, volumeName string) error {
+	// scan /var/lib/kubelet/pods/<uid>/volume-subpaths/<volume>/*
+	subPathDir := filepath.Join(podDir, containerSubPathDirectoryName, volumeName)
+	klog.V(4).Infof("Cleaning up subpath mounts for %s", subPathDir)
+
+	containerDirs, err := ioutil.ReadDir(subPathDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("error reading %s: %s", subPathDir, err)
+	}
+
+	for _, containerDir := range containerDirs {
+		if !containerDir.IsDir() {
+			klog.V(4).Infof("Container file is not a directory: %s", containerDir.Name())
+			continue
+		}
+		klog.V(4).Infof("Cleaning up subpath mounts for container %s", containerDir.Name())
+
+		// scan /var/lib/kubelet/pods/<uid>/volume-subpaths/<volume>/<container name>/*
+		fullContainerDirPath := filepath.Join(subPathDir, containerDir.Name())
+		err = filepath.Walk(fullContainerDirPath, func(path string, info os.FileInfo, _ error) error {
+			if path == fullContainerDirPath {
+				// Skip top level directory
+				return nil
+			}
+
+			// pass through errors and let doCleanSubPath handle them
+			if err = doCleanSubPath(mounter, fullContainerDirPath, filepath.Base(path)); err != nil {
+				return err
+			}
+
+			// We need to check that info is not nil. This may happen when the incoming err is not nil due to stale mounts or permission errors.
+			if info != nil && info.IsDir() {
+				// skip subdirs of the volume: it only matters the first level to unmount, otherwise it would try to unmount subdir of the volume
+				return filepath.SkipDir
+			}
+
+			return nil
+		})
+		if err != nil {
+			return fmt.Errorf("error processing %s: %s", fullContainerDirPath, err)
+		}
+
+		// Whole container has been processed, remove its directory.
+		if err := os.Remove(fullContainerDirPath); err != nil {
+			return fmt.Errorf("error deleting %s: %s", fullContainerDirPath, err)
+		}
+		klog.V(5).Infof("Removed %s", fullContainerDirPath)
+	}
+	// Whole pod volume subpaths have been cleaned up, remove its subpath directory.
+	if err := os.Remove(subPathDir); err != nil {
+		return fmt.Errorf("error deleting %s: %s", subPathDir, err)
+	}
+	klog.V(5).Infof("Removed %s", subPathDir)
+
+	// Remove entire subpath directory if it's the last one
+	podSubPathDir := filepath.Join(podDir, containerSubPathDirectoryName)
+	if err := os.Remove(podSubPathDir); err != nil && !os.IsExist(err) {
+		return fmt.Errorf("error deleting %s: %s", podSubPathDir, err)
+	}
+	klog.V(5).Infof("Removed %s", podSubPathDir)
+	return nil
+}
+
+// doCleanSubPath tears down the single subpath bind mount
+func doCleanSubPath(mounter mount.Interface, fullContainerDirPath, subPathIndex string) error {
+	// process /var/lib/kubelet/pods/<uid>/volume-subpaths/<volume>/<container name>/<subPathName>
+	klog.V(4).Infof("Cleaning up subpath mounts for subpath %v", subPathIndex)
+	fullSubPath := filepath.Join(fullContainerDirPath, subPathIndex)
+
+	if err := mount.CleanupMountPoint(fullSubPath, mounter, true); err != nil {
+		return fmt.Errorf("error cleaning subpath mount %s: %s", fullSubPath, err)
+	}
+
+	klog.V(4).Infof("Successfully cleaned subpath directory %s", fullSubPath)
+	return nil
+}
+
+// cleanSubPath will teardown the subpath bind mount and any remove any directories if empty
+func cleanSubPath(mounter mount.Interface, subpath Subpath) error {
+	containerDir := filepath.Join(subpath.PodDir, containerSubPathDirectoryName, subpath.VolumeName, subpath.ContainerName)
+
+	// Clean subdir bindmount
+	if err := doCleanSubPath(mounter, containerDir, strconv.Itoa(subpath.VolumeMountIndex)); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+
+	// Recusively remove directories if empty
+	if err := removeEmptyDirs(subpath.PodDir, containerDir); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// removeEmptyDirs works backwards from endDir to baseDir and removes each directory
+// if it is empty.  It stops once it encounters a directory that has content
+func removeEmptyDirs(baseDir, endDir string) error {
+	if !mount.PathWithinBase(endDir, baseDir) {
+		return fmt.Errorf("endDir %q is not within baseDir %q", endDir, baseDir)
+	}
+
+	for curDir := endDir; curDir != baseDir; curDir = filepath.Dir(curDir) {
+		s, err := os.Stat(curDir)
+		if err != nil {
+			if os.IsNotExist(err) {
+				klog.V(5).Infof("curDir %q doesn't exist, skipping", curDir)
+				continue
+			}
+			return fmt.Errorf("error stat %q: %v", curDir, err)
+		}
+		if !s.IsDir() {
+			return fmt.Errorf("path %q not a directory", curDir)
+		}
+
+		err = os.Remove(curDir)
+		if os.IsExist(err) {
+			klog.V(5).Infof("Directory %q not empty, not removing", curDir)
+			break
+		} else if err != nil {
+			return fmt.Errorf("error removing directory %q: %v", curDir, err)
+		}
+		klog.V(5).Infof("Removed directory %q", curDir)
+	}
+	return nil
+}

--- a/pkg/volume/util/subpath/subpath_linux.go
+++ b/pkg/volume/util/subpath/subpath_linux.go
@@ -20,10 +20,8 @@ package subpath
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"syscall"
 
@@ -33,40 +31,11 @@ import (
 )
 
 const (
-	// place for subpath mounts
-	// TODO: pass in directory using kubelet_getters instead
-	containerSubPathDirectoryName = "volume-subpaths"
 	// syscall.Openat flags used to traverse directories not following symlinks
 	nofollowFlags = unix.O_RDONLY | unix.O_NOFOLLOW
 	// flags for getting file descriptor without following the symlink
 	openFDFlags = unix.O_NOFOLLOW | unix.O_PATH
 )
-
-type subpath struct {
-	mounter mount.Interface
-}
-
-// New returns a subpath.Interface for the current system
-func New(mounter mount.Interface) Interface {
-	return &subpath{
-		mounter: mounter,
-	}
-}
-
-func (sp *subpath) CleanSubPaths(podDir string, volumeName string) error {
-	return doCleanSubPaths(sp.mounter, podDir, volumeName)
-}
-
-func (sp *subpath) SafeMakeDir(subdir string, base string, perm os.FileMode) error {
-	realBase, err := filepath.EvalSymlinks(base)
-	if err != nil {
-		return fmt.Errorf("error resolving symlinks in %s: %s", base, err)
-	}
-
-	realFullPath := filepath.Join(realBase, subdir)
-
-	return doSafeMakeDir(realFullPath, realBase, perm)
-}
 
 func (sp *subpath) PrepareSafeSubpath(subPath Subpath) (newHostPath string, cleanupAction func(), err error) {
 	newHostPath, err = doBindSubPath(sp.mounter, subPath)
@@ -89,250 +58,22 @@ func safeOpenSubPath(mounter mount.Interface, subpath Subpath) (int, error) {
 	return fd, nil
 }
 
-// prepareSubpathTarget creates target for bind-mount of subpath. It returns
-// "true" when the target already exists and something is mounted there.
-// Given Subpath must have all paths with already resolved symlinks and with
-// paths relevant to kubelet (when it runs in a container).
-// This function is called also by NsEnterMounter. It works because
-// /var/lib/kubelet is mounted from the host into the container with Kubelet as
-// /var/lib/kubelet too.
-func prepareSubpathTarget(mounter mount.Interface, subpath Subpath) (bool, string, error) {
-	// Early check for already bind-mounted subpath.
-	bindPathTarget := getSubpathBindTarget(subpath)
-	notMount, err := mount.IsNotMountPoint(mounter, bindPathTarget)
-	if err != nil {
-		if !os.IsNotExist(err) {
-			return false, "", fmt.Errorf("error checking path %s for mount: %s", bindPathTarget, err)
-		}
-		// Ignore ErrorNotExist: the file/directory will be created below if it does not exist yet.
-		notMount = true
-	}
-	if !notMount {
-		// It's already mounted
-		klog.V(5).Infof("Skipping bind-mounting subpath %s: already mounted", bindPathTarget)
-		return true, bindPathTarget, nil
-	}
-
-	// bindPathTarget is in /var/lib/kubelet and thus reachable without any
-	// translation even to containerized kubelet.
-	bindParent := filepath.Dir(bindPathTarget)
-	err = os.MkdirAll(bindParent, 0750)
-	if err != nil && !os.IsExist(err) {
-		return false, "", fmt.Errorf("error creating directory %s: %s", bindParent, err)
-	}
-
-	t, err := os.Lstat(subpath.Path)
-	if err != nil {
-		return false, "", fmt.Errorf("lstat %s failed: %s", subpath.Path, err)
-	}
-
-	if t.Mode()&os.ModeDir > 0 {
-		if err = os.Mkdir(bindPathTarget, 0750); err != nil && !os.IsExist(err) {
-			return false, "", fmt.Errorf("error creating directory %s: %s", bindPathTarget, err)
-		}
-	} else {
-		// "/bin/touch <bindPathTarget>".
-		// A file is enough for all possible targets (symlink, device, pipe,
-		// socket, ...), bind-mounting them into a file correctly changes type
-		// of the target file.
-		if err = ioutil.WriteFile(bindPathTarget, []byte{}, 0640); err != nil {
-			return false, "", fmt.Errorf("error creating file %s: %s", bindPathTarget, err)
-		}
-	}
-	return false, bindPathTarget, nil
-}
-
-func getSubpathBindTarget(subpath Subpath) string {
-	// containerName is DNS label, i.e. safe as a directory name.
-	return filepath.Join(subpath.PodDir, containerSubPathDirectoryName, subpath.VolumeName, subpath.ContainerName, strconv.Itoa(subpath.VolumeMountIndex))
-}
-
-func doBindSubPath(mounter mount.Interface, subpath Subpath) (hostPath string, err error) {
-	// Linux, kubelet runs on the host:
-	// - safely open the subpath
-	// - bind-mount /proc/<pid of kubelet>/fd/<fd> to subpath target
-	// User can't change /proc/<pid of kubelet>/fd/<fd> to point to a bad place.
-
-	// Evaluate all symlinks here once for all subsequent functions.
-	newVolumePath, err := filepath.EvalSymlinks(subpath.VolumePath)
-	if err != nil {
-		return "", fmt.Errorf("error resolving symlinks in %q: %v", subpath.VolumePath, err)
-	}
-	newPath, err := filepath.EvalSymlinks(subpath.Path)
-	if err != nil {
-		return "", fmt.Errorf("error resolving symlinks in %q: %v", subpath.Path, err)
-	}
-	klog.V(5).Infof("doBindSubPath %q (%q) for volumepath %q", subpath.Path, newPath, subpath.VolumePath)
-	subpath.VolumePath = newVolumePath
-	subpath.Path = newPath
-
+func bindMount(mounter mount.Interface, subpath Subpath, bindPathTarget string) error {
 	fd, err := safeOpenSubPath(mounter, subpath)
 	if err != nil {
-		return "", err
+		return err
 	}
 	defer syscall.Close(fd)
-
-	alreadyMounted, bindPathTarget, err := prepareSubpathTarget(mounter, subpath)
-	if err != nil {
-		return "", err
-	}
-	if alreadyMounted {
-		return bindPathTarget, nil
-	}
-
-	success := false
-	defer func() {
-		// Cleanup subpath on error
-		if !success {
-			klog.V(4).Infof("doBindSubPath() failed for %q, cleaning up subpath", bindPathTarget)
-			if cleanErr := cleanSubPath(mounter, subpath); cleanErr != nil {
-				klog.Errorf("Failed to clean subpath %q: %v", bindPathTarget, cleanErr)
-			}
-		}
-	}()
 
 	kubeletPid := os.Getpid()
 	mountSource := fmt.Sprintf("/proc/%d/fd/%v", kubeletPid, fd)
 
-	// Do the bind mount
 	options := []string{"bind"}
 	klog.V(5).Infof("bind mounting %q at %q", mountSource, bindPathTarget)
 	if err = mounter.Mount(mountSource, bindPathTarget, "" /*fstype*/, options); err != nil {
-		return "", fmt.Errorf("error mounting %s: %s", subpath.Path, err)
-	}
-	success = true
-
-	klog.V(3).Infof("Bound SubPath %s into %s", subpath.Path, bindPathTarget)
-	return bindPathTarget, nil
-}
-
-// This implementation is shared between Linux and NsEnter
-func doCleanSubPaths(mounter mount.Interface, podDir string, volumeName string) error {
-	// scan /var/lib/kubelet/pods/<uid>/volume-subpaths/<volume>/*
-	subPathDir := filepath.Join(podDir, containerSubPathDirectoryName, volumeName)
-	klog.V(4).Infof("Cleaning up subpath mounts for %s", subPathDir)
-
-	containerDirs, err := ioutil.ReadDir(subPathDir)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil
-		}
-		return fmt.Errorf("error reading %s: %s", subPathDir, err)
+		return fmt.Errorf("error mounting %s: %s", subpath.Path, err)
 	}
 
-	for _, containerDir := range containerDirs {
-		if !containerDir.IsDir() {
-			klog.V(4).Infof("Container file is not a directory: %s", containerDir.Name())
-			continue
-		}
-		klog.V(4).Infof("Cleaning up subpath mounts for container %s", containerDir.Name())
-
-		// scan /var/lib/kubelet/pods/<uid>/volume-subpaths/<volume>/<container name>/*
-		fullContainerDirPath := filepath.Join(subPathDir, containerDir.Name())
-		err = filepath.Walk(fullContainerDirPath, func(path string, info os.FileInfo, _ error) error {
-			if path == fullContainerDirPath {
-				// Skip top level directory
-				return nil
-			}
-
-			// pass through errors and let doCleanSubPath handle them
-			if err = doCleanSubPath(mounter, fullContainerDirPath, filepath.Base(path)); err != nil {
-				return err
-			}
-
-			// We need to check that info is not nil. This may happen when the incoming err is not nil due to stale mounts or permission errors.
-			if info != nil && info.IsDir() {
-				// skip subdirs of the volume: it only matters the first level to unmount, otherwise it would try to unmount subdir of the volume
-				return filepath.SkipDir
-			}
-
-			return nil
-		})
-		if err != nil {
-			return fmt.Errorf("error processing %s: %s", fullContainerDirPath, err)
-		}
-
-		// Whole container has been processed, remove its directory.
-		if err := os.Remove(fullContainerDirPath); err != nil {
-			return fmt.Errorf("error deleting %s: %s", fullContainerDirPath, err)
-		}
-		klog.V(5).Infof("Removed %s", fullContainerDirPath)
-	}
-	// Whole pod volume subpaths have been cleaned up, remove its subpath directory.
-	if err := os.Remove(subPathDir); err != nil {
-		return fmt.Errorf("error deleting %s: %s", subPathDir, err)
-	}
-	klog.V(5).Infof("Removed %s", subPathDir)
-
-	// Remove entire subpath directory if it's the last one
-	podSubPathDir := filepath.Join(podDir, containerSubPathDirectoryName)
-	if err := os.Remove(podSubPathDir); err != nil && !os.IsExist(err) {
-		return fmt.Errorf("error deleting %s: %s", podSubPathDir, err)
-	}
-	klog.V(5).Infof("Removed %s", podSubPathDir)
-	return nil
-}
-
-// doCleanSubPath tears down the single subpath bind mount
-func doCleanSubPath(mounter mount.Interface, fullContainerDirPath, subPathIndex string) error {
-	// process /var/lib/kubelet/pods/<uid>/volume-subpaths/<volume>/<container name>/<subPathName>
-	klog.V(4).Infof("Cleaning up subpath mounts for subpath %v", subPathIndex)
-	fullSubPath := filepath.Join(fullContainerDirPath, subPathIndex)
-
-	if err := mount.CleanupMountPoint(fullSubPath, mounter, true); err != nil {
-		return fmt.Errorf("error cleaning subpath mount %s: %s", fullSubPath, err)
-	}
-
-	klog.V(4).Infof("Successfully cleaned subpath directory %s", fullSubPath)
-	return nil
-}
-
-// cleanSubPath will teardown the subpath bind mount and any remove any directories if empty
-func cleanSubPath(mounter mount.Interface, subpath Subpath) error {
-	containerDir := filepath.Join(subpath.PodDir, containerSubPathDirectoryName, subpath.VolumeName, subpath.ContainerName)
-
-	// Clean subdir bindmount
-	if err := doCleanSubPath(mounter, containerDir, strconv.Itoa(subpath.VolumeMountIndex)); err != nil && !os.IsNotExist(err) {
-		return err
-	}
-
-	// Recusively remove directories if empty
-	if err := removeEmptyDirs(subpath.PodDir, containerDir); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-// removeEmptyDirs works backwards from endDir to baseDir and removes each directory
-// if it is empty.  It stops once it encounters a directory that has content
-func removeEmptyDirs(baseDir, endDir string) error {
-	if !mount.PathWithinBase(endDir, baseDir) {
-		return fmt.Errorf("endDir %q is not within baseDir %q", endDir, baseDir)
-	}
-
-	for curDir := endDir; curDir != baseDir; curDir = filepath.Dir(curDir) {
-		s, err := os.Stat(curDir)
-		if err != nil {
-			if os.IsNotExist(err) {
-				klog.V(5).Infof("curDir %q doesn't exist, skipping", curDir)
-				continue
-			}
-			return fmt.Errorf("error stat %q: %v", curDir, err)
-		}
-		if !s.IsDir() {
-			return fmt.Errorf("path %q not a directory", curDir)
-		}
-
-		err = os.Remove(curDir)
-		if os.IsExist(err) {
-			klog.V(5).Infof("Directory %q not empty, not removing", curDir)
-			break
-		} else if err != nil {
-			return fmt.Errorf("error removing directory %q: %v", curDir, err)
-		}
-		klog.V(5).Infof("Removed directory %q", curDir)
-	}
 	return nil
 }
 

--- a/pkg/volume/util/subpath/subpath_unsupported.go
+++ b/pkg/volume/util/subpath/subpath_unsupported.go
@@ -26,14 +26,7 @@ import (
 	"k8s.io/utils/nsenter"
 )
 
-type subpath struct{}
-
 var errUnsupported = errors.New("util/subpath on this platform is not supported")
-
-// New returns a subpath.Interface for the current system.
-func New(mount.Interface) Interface {
-	return &subpath{}
-}
 
 // NewNSEnter is to satisfy the compiler for having NewSubpathNSEnter exist for all
 // OS choices. however, NSEnter is only valid on Linux
@@ -45,10 +38,10 @@ func (sp *subpath) PrepareSafeSubpath(subPath Subpath) (newHostPath string, clea
 	return subPath.Path, nil, errUnsupported
 }
 
-func (sp *subpath) CleanSubPaths(podDir string, volumeName string) error {
-	return errUnsupported
+func bindMount(mounter mount.Interface, subpath Subpath, bindPathTarget string) error {
+	return nil
 }
 
-func (sp *subpath) SafeMakeDir(pathname string, base string, perm os.FileMode) error {
-	return errUnsupported
+func doSafeMakeDir(pathname string, base string, perm os.FileMode) error {
+	return nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug

/sig windows
/sig storage

/priority important-soon

**What this PR does / why we need it**:

Pods can have volume subpaths mounted inside the containers. Those subpaths can be based on expressions based on expanded environment variables, which can also be based on Pod annotations.

Kubernetes expects that the mounted volume subpaths to remain consistent across container restarts even if the Pod annotation it was based on changed. This behaviour is checked by the E2E test ``should not change the subpath mount on a container restart if the environment variable change``.

This test fails on Windows because the subpath itself is always mounted (which is based on the Pod Annotation), while on Linux, on the first first, the volume subpath is created and mounted under ``kubelet/pods/<uid>/volume-subpaths/<volume>/<container-name>`` and cached, then on restart, it is going to use the same mount path that already exists, keeping the same subpath mounted in the container.

This commit addresses the issue on Windows, following a similar approach to the Linux implementation.

Refactors some of the code, which can be used on both Linux and Windows.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #90336

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixed issue on changing volume subpaths based on expanded environment variables on Windows hosts.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
