### PR TITLE
Avoid executing preemption for pods with 0 priority

### DIFF
--- a/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption.go
+++ b/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption.go
@@ -194,6 +194,13 @@ func podEligibleToPreemptOthers(pod *v1.Pod, nodeInfos framework.NodeInfoLister,
 		klog.V(5).Infof("Pod %v/%v is not eligible for preemption because it has a preemptionPolicy of %v", pod.Namespace, pod.Name, v1.PreemptNever)
 		return false
 	}
+
+	podPriority := podutil.GetPodPriority(pod)
+	if podPriority == 0 {
+		// Lowest possible priority.
+		return false
+	}
+
 	nomNodeName := pod.Status.NominatedNodeName
 	if len(nomNodeName) > 0 {
 		// If the pod's nominated node is considered as UnschedulableAndUnresolvable by the filters,
@@ -203,7 +210,6 @@ func podEligibleToPreemptOthers(pod *v1.Pod, nodeInfos framework.NodeInfoLister,
 		}
 
 		if nodeInfo, _ := nodeInfos.Get(nomNodeName); nodeInfo != nil {
-			podPriority := podutil.GetPodPriority(pod)
 			for _, p := range nodeInfo.Pods {
 				if p.Pod.DeletionTimestamp != nil && podutil.GetPodPriority(p.Pod) < podPriority {
 					// There is a terminating pod on the nominated node.

--- a/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption_test.go
+++ b/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption_test.go
@@ -915,6 +915,20 @@ func TestPodEligibleToPreemptOthers(t *testing.T) {
 			expected:            false,
 		},
 		{
+			name:                "Pod with priority zero",
+			pod:                 st.MakePod().Name("p_priority_zero").UID("p").Priority(0).Obj(),
+			nodes:               []string{"node1"},
+			nominatedNodeStatus: nil,
+			expected:            false,
+		},
+		{
+			name:                "Pod with no priority",
+			pod:                 st.MakePod().Name("p_no_priority").UID("p").Obj(),
+			nodes:               []string{"node1"},
+			nominatedNodeStatus: nil,
+			expected:            false,
+		},
+		{
 			name:                "Pod without nominated node",
 			pod:                 st.MakePod().Name("p_without_nominated_node").UID("p").Priority(highPriority).Obj(),
 			pods:                []*v1.Pod{},


### PR DESCRIPTION
**What type of PR is this?**

 /kind feature

**What this PR does / why we need it**:

0 is the lowest priority, pods with such priority can't preempt any other pods. This PR avoids executing the preemption logic for such pods. This should have a non-negligible positive impact on scheduling latency since 0 is the default pod priority and we expect that most workloads just use that.

**Which issue(s) this PR fixes**:
Part of #89036

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

