### PR TITLE
Skip expensive integration tests in short run mode

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/limit_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/limit_test.go
@@ -80,6 +80,9 @@ values: `+strings.Repeat("[", 3*1024*1024), apiVersion, kind))
 
 	// Create YAML just under 3MB limit, nested
 	t.Run("create YAML doc under limit, nested", func(t *testing.T) {
+		if testing.Short() {
+			t.Skip("skipping expensive test")
+		}
 		yamlBody := []byte(fmt.Sprintf(`
 	apiVersion: %s
 	kind: %s
@@ -100,6 +103,9 @@ values: `+strings.Repeat("[", 3*1024*1024), apiVersion, kind))
 
 	// Create YAML just under 3MB limit, not nested
 	t.Run("create YAML doc under limit, not nested", func(t *testing.T) {
+		if testing.Short() {
+			t.Skip("skipping expensive test")
+		}
 		yamlBody := []byte(fmt.Sprintf(`
 		apiVersion: %s
 		kind: %s
@@ -141,6 +147,9 @@ values: `+strings.Repeat("[", 3*1024*1024), apiVersion, kind))
 
 	// Create JSON just under 3MB limit, nested
 	t.Run("create JSON doc under limit, nested", func(t *testing.T) {
+		if testing.Short() {
+			t.Skip("skipping expensive test")
+		}
 		jsonBody := []byte(fmt.Sprintf(`{
 		"apiVersion": %q,
 		"kind": %q,
@@ -162,6 +171,9 @@ values: `+strings.Repeat("[", 3*1024*1024), apiVersion, kind))
 
 	// Create JSON just under 3MB limit, not nested
 	t.Run("create JSON doc under limit, not nested", func(t *testing.T) {
+		if testing.Short() {
+			t.Skip("skipping expensive test")
+		}
 		jsonBody := []byte(fmt.Sprintf(`{
 			"apiVersion": %q,
 			"kind": %q,
@@ -191,6 +203,9 @@ values: `+strings.Repeat("[", 3*1024*1024), apiVersion, kind))
 	}
 
 	t.Run("JSONPatchType nested patch under limit", func(t *testing.T) {
+		if testing.Short() {
+			t.Skip("skipping expensive test")
+		}
 		patchBody := []byte(`[{"op":"add","path":"/foo","value":` + strings.Repeat("[", 3*1024*1024/2-100) + strings.Repeat("]", 3*1024*1024/2-100) + `}]`)
 		err = rest.Patch(types.JSONPatchType).AbsPath("/apis", noxuDefinition.Spec.Group, noxuDefinition.Spec.Version, noxuDefinition.Spec.Names.Plural, "test").
 			Body(patchBody).Do(context.TODO()).Error()
@@ -199,6 +214,9 @@ values: `+strings.Repeat("[", 3*1024*1024), apiVersion, kind))
 		}
 	})
 	t.Run("MergePatchType nested patch under limit", func(t *testing.T) {
+		if testing.Short() {
+			t.Skip("skipping expensive test")
+		}
 		patchBody := []byte(`{"value":` + strings.Repeat("[", 3*1024*1024/2-100) + strings.Repeat("]", 3*1024*1024/2-100) + `}`)
 		err = rest.Patch(types.MergePatchType).AbsPath("/apis", noxuDefinition.Spec.Group, noxuDefinition.Spec.Version, noxuDefinition.Spec.Names.Plural, "test").
 			Body(patchBody).Do(context.TODO()).Error()
@@ -207,6 +225,9 @@ values: `+strings.Repeat("[", 3*1024*1024), apiVersion, kind))
 		}
 	})
 	t.Run("ApplyPatchType nested patch under limit", func(t *testing.T) {
+		if testing.Short() {
+			t.Skip("skipping expensive test")
+		}
 		patchBody := []byte(`{"value":` + strings.Repeat("[", 3*1024*1024/2-100) + strings.Repeat("]", 3*1024*1024/2-100) + `}`)
 		err = rest.Patch(types.ApplyPatchType).Param("fieldManager", "test").AbsPath("/apis", noxuDefinition.Spec.Group, noxuDefinition.Spec.Version, noxuDefinition.Spec.Names.Plural, "test").
 			Body(patchBody).Do(context.TODO()).Error()

--- a/test/integration/apiserver/max_request_body_bytes_test.go
+++ b/test/integration/apiserver/max_request_body_bytes_test.go
@@ -85,6 +85,9 @@ func TestMaxResourceSize(t *testing.T) {
 		}
 	})
 	t.Run("JSONPatchType should handle a patch just under the max limit", func(t *testing.T) {
+		if testing.Short() {
+			t.Skip("skipping expensive test")
+		}
 		patchBody := []byte(`[{"op":"add","path":"/foo","value":` + strings.Repeat("[", 3*1024*1024/2-100) + strings.Repeat("]", 3*1024*1024/2-100) + `}]`)
 		err = rest.Patch(types.JSONPatchType).AbsPath("/api/v1/namespaces/default/secrets/test").
 			Body(patchBody).Do(context.TODO()).Error()
@@ -93,6 +96,9 @@ func TestMaxResourceSize(t *testing.T) {
 		}
 	})
 	t.Run("JSONPatchType should handle a valid patch just under the max limit", func(t *testing.T) {
+		if testing.Short() {
+			t.Skip("skipping expensive test")
+		}
 		patchBody := []byte(`[{"op":"add","path":"/foo","value":0` + strings.Repeat(" ", 3*1024*1024-100) + `}]`)
 		err = rest.Patch(types.JSONPatchType).AbsPath("/api/v1/namespaces/default/secrets/test").
 			Body(patchBody).Do(context.TODO()).Error()
@@ -101,6 +107,9 @@ func TestMaxResourceSize(t *testing.T) {
 		}
 	})
 	t.Run("MergePatchType should handle a patch just under the max limit", func(t *testing.T) {
+		if testing.Short() {
+			t.Skip("skipping expensive test")
+		}
 		patchBody := []byte(`{"value":` + strings.Repeat("[", 3*1024*1024/2-100) + strings.Repeat("]", 3*1024*1024/2-100) + `}`)
 		err = rest.Patch(types.MergePatchType).AbsPath("/api/v1/namespaces/default/secrets/test").
 			Body(patchBody).Do(context.TODO()).Error()
@@ -109,6 +118,9 @@ func TestMaxResourceSize(t *testing.T) {
 		}
 	})
 	t.Run("MergePatchType should handle a valid patch just under the max limit", func(t *testing.T) {
+		if testing.Short() {
+			t.Skip("skipping expensive test")
+		}
 		patchBody := []byte(`{"value":0` + strings.Repeat(" ", 3*1024*1024-100) + `}`)
 		err = rest.Patch(types.MergePatchType).AbsPath("/api/v1/namespaces/default/secrets/test").
 			Body(patchBody).Do(context.TODO()).Error()
@@ -117,6 +129,9 @@ func TestMaxResourceSize(t *testing.T) {
 		}
 	})
 	t.Run("StrategicMergePatchType should handle a patch just under the max limit", func(t *testing.T) {
+		if testing.Short() {
+			t.Skip("skipping expensive test")
+		}
 		patchBody := []byte(`{"value":` + strings.Repeat("[", 3*1024*1024/2-100) + strings.Repeat("]", 3*1024*1024/2-100) + `}`)
 		err = rest.Patch(types.StrategicMergePatchType).AbsPath("/api/v1/namespaces/default/secrets/test").
 			Body(patchBody).Do(context.TODO()).Error()
@@ -125,6 +140,9 @@ func TestMaxResourceSize(t *testing.T) {
 		}
 	})
 	t.Run("StrategicMergePatchType should handle a valid patch just under the max limit", func(t *testing.T) {
+		if testing.Short() {
+			t.Skip("skipping expensive test")
+		}
 		patchBody := []byte(`{"value":0` + strings.Repeat(" ", 3*1024*1024-100) + `}`)
 		err = rest.Patch(types.StrategicMergePatchType).AbsPath("/api/v1/namespaces/default/secrets/test").
 			Body(patchBody).Do(context.TODO()).Error()
@@ -133,6 +151,9 @@ func TestMaxResourceSize(t *testing.T) {
 		}
 	})
 	t.Run("ApplyPatchType should handle a patch just under the max limit", func(t *testing.T) {
+		if testing.Short() {
+			t.Skip("skipping expensive test")
+		}
 		patchBody := []byte(`{"value":` + strings.Repeat("[", 3*1024*1024/2-100) + strings.Repeat("]", 3*1024*1024/2-100) + `}`)
 		err = rest.Patch(types.ApplyPatchType).Param("fieldManager", "test").AbsPath("/api/v1/namespaces/default/secrets/test").
 			Body(patchBody).Do(context.TODO()).Error()
@@ -141,6 +162,9 @@ func TestMaxResourceSize(t *testing.T) {
 		}
 	})
 	t.Run("ApplyPatchType should handle a valid patch just under the max limit", func(t *testing.T) {
+		if testing.Short() {
+			t.Skip("skipping expensive test")
+		}
 		patchBody := []byte(`{"apiVersion":"v1","kind":"Secret"` + strings.Repeat(" ", 3*1024*1024-100) + `}`)
 		err = rest.Patch(types.ApplyPatchType).Param("fieldManager", "test").AbsPath("/api/v1/namespaces/default/secrets/test").
 			Body(patchBody).Do(context.TODO()).Error()
@@ -182,6 +206,9 @@ values: ` + strings.Repeat("[", 3*1024*1024))
 
 	// Create YAML just under 3MB limit, nested
 	t.Run("create should handle a yaml document just under the maximum size with correct nesting", func(t *testing.T) {
+		if testing.Short() {
+			t.Skip("skipping expensive test")
+		}
 		yamlBody := []byte(`
 apiVersion: v1
 kind: ConfigMap
@@ -202,6 +229,9 @@ values: ` + strings.Repeat("[", 3*1024*1024/2-500) + strings.Repeat("]", 3*1024*
 
 	// Create YAML just under 3MB limit, not nested
 	t.Run("create should handle a yaml document just under the maximum size with unbalanced nesting", func(t *testing.T) {
+		if testing.Short() {
+			t.Skip("skipping expensive test")
+		}
 		yamlBody := []byte(`
 apiVersion: v1
 kind: ConfigMap
@@ -243,6 +273,9 @@ values: ` + strings.Repeat("[", 3*1024*1024-1000))
 
 	// Create JSON just under 3MB limit, nested
 	t.Run("create should handle a json document just under the maximum size with correct nesting", func(t *testing.T) {
+		if testing.Short() {
+			t.Skip("skipping expensive test")
+		}
 		jsonBody := []byte(`{
 	"apiVersion": "v1",
 	"kind": "ConfigMap",
@@ -265,6 +298,9 @@ values: ` + strings.Repeat("[", 3*1024*1024-1000))
 
 	// Create JSON just under 3MB limit, not nested
 	t.Run("create should handle a json document just under the maximum size with unbalanced nesting", func(t *testing.T) {
+		if testing.Short() {
+			t.Skip("skipping expensive test")
+		}
 		jsonBody := []byte(`{
 	"apiVersion": "v1",
 	"kind": "ConfigMap",


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
/kind flake

**What this PR does / why we need it**:
Several of the integration tests exercise the API server at the limit of the request body size it can parse.

Skip these tests when short test runs are requested. Opt into longer runs in post-merge CI runs in https://github.com/kubernetes/test-infra/pull/18196

```release-note
NONE
```

/sig api-machinery
/cc @lavalamp @BenTheElder 