### PR TITLE
kubeadm: deprecate "kubeadm alpha kubelet config enable-dynamic"

### DIFF
--- a/cmd/kubeadm/app/cmd/alpha/kubelet.go
+++ b/cmd/kubeadm/app/cmd/alpha/kubelet.go
@@ -34,7 +34,7 @@ var (
 		Enable or update dynamic kubelet configuration for a Node, against the kubelet-config-1.X ConfigMap in the cluster,
 		where X is the minor version of the desired kubelet version.
 
-		WARNING: This feature is still experimental, and disabled by default. Enable only if you know what you are doing, as it
+		WARNING: This kubeadm feature is deprecated. Enable only if you know what you are doing, as it
 		may have surprising side-effects at this stage.
 
 		` + cmdutil.AlphaDisclaimer)
@@ -43,7 +43,7 @@ var (
 		# Enable dynamic kubelet configuration for a Node.
 		kubeadm alpha phase kubelet enable-dynamic-config --node-name node-1 --kubelet-version %s
 
-		WARNING: This feature is still experimental, and disabled by default. Enable only if you know what you are doing, as it
+		WARNING: This kubeadm feature is deprecated. Enable only if you know what you are doing, as it
 		may have surprising side-effects at this stage.
 		`, constants.CurrentKubernetesVersion))
 )
@@ -80,9 +80,11 @@ func newCmdKubeletConfigEnableDynamic() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:     "enable-dynamic",
-		Short:   "EXPERIMENTAL: Enable or update dynamic kubelet configuration for a Node",
+		Short:   "DEPRECATED: Enable or update dynamic kubelet configuration for a Node",
 		Long:    kubeletConfigEnableDynamicLongDesc,
 		Example: kubeletConfigEnableDynamicExample,
+		Deprecated: "This command is deprecated and will be removed in a future release. Please defer to the official \"Dynamic Kubelet Configuration\" " +
+			"guide at k8s.io if you wish to use this feature",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(nodeName) == 0 {
 				return errors.New("the --node-name argument is required")


### PR DESCRIPTION
**What this PR does / why we need it**:

Deprecate the command and recommend users to follow the
official guide at the k8s.io website instead.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
xref https://github.com/kubernetes/kubeadm/issues/2216

**Special notes for your reviewer**:
NONE

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kubeadm: deprecate the "kubeadm alpha kubelet config enable-dynamic" command. To continue using the feature please defer to the guide for "Dynamic Kubelet Configuration" at k8s.io.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
