### PR TITLE
Add apimachinery package for parsing manifests

### DIFF
--- a/staging/src/k8s.io/apimachinery/BUILD
+++ b/staging/src/k8s.io/apimachinery/BUILD
@@ -37,6 +37,7 @@ filegroup(
         "//staging/src/k8s.io/apimachinery/pkg/util/intstr:all-srcs",
         "//staging/src/k8s.io/apimachinery/pkg/util/json:all-srcs",
         "//staging/src/k8s.io/apimachinery/pkg/util/jsonmergepatch:all-srcs",
+        "//staging/src/k8s.io/apimachinery/pkg/util/manifest:all-srcs",
         "//staging/src/k8s.io/apimachinery/pkg/util/mergepatch:all-srcs",
         "//staging/src/k8s.io/apimachinery/pkg/util/naming:all-srcs",
         "//staging/src/k8s.io/apimachinery/pkg/util/net:all-srcs",

--- a/staging/src/k8s.io/apimachinery/pkg/util/manifest/BUILD
+++ b/staging/src/k8s.io/apimachinery/pkg/util/manifest/BUILD
@@ -1,0 +1,34 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["manifest.go"],
+    importmap = "k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/manifest",
+    importpath = "k8s.io/apimachinery/pkg/util/manifest",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/yaml:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["manifest_test.go"],
+    data = glob(["testdata/**"]),
+    embed = [":go_default_library"],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/staging/src/k8s.io/apimachinery/pkg/util/manifest/manifest.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/manifest/manifest.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubernetes
+
+import (
+	"bytes"
+	"io"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/util/yaml"
+)
+
+// NewUnstructuredList decodes YAML or JSON data into a flattened list of Kubernetes resources,
+// it will attempt parsing all manner of manifests, such as YAML multi docs and any list types
+func NewUnstructuredList(data []byte) (*unstructured.UnstructuredList, error) {
+	list := new(unstructured.UnstructuredList)
+	decoder := yaml.NewYAMLOrJSONDecoder(bytes.NewBuffer(data), 4096)
+
+	for {
+		obj := new(unstructured.Unstructured)
+		if err := decoder.Decode(obj); err != nil {
+			if err == io.EOF {
+				return list, nil
+			}
+			return nil, err
+		}
+		list.Items = append(list.Items, *obj)
+	}
+}
+
+// AppendFlattened will append newItem to list; making sure that raw newItem is decoded
+// and flattened with another list; it drops empty lists
+func AppendFlattened(list *unstructured.UnstructuredList, newItem *unstructured.Unstructured) error {
+	if newItem.Object == nil {
+		return nil
+	}
+	gvk := newItem.GetObjectKind().GroupVersionKind()
+	// IsList() checks if object has 'items', but it will ignore
+	// something like `{"apiVersion": "v1", "kind": "List"}`, which
+	// is still a list and should be treated as such
+	if newItem.IsList() || strings.HasSuffix(gvk.Kind, "List") {
+		innerList, err := newItem.ToList()
+		if err != nil {
+			return err
+		}
+		for _, item := range innerList.Items {
+			if err := AppendFlattened(list, &item); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	list.Items = append(list.Items, *newItem)
+	return nil
+}
+
+// Flatten will ensure given list is fully flattened
+func Flatten(list *unstructured.UnstructuredList) (*unstructured.UnstructuredList, error) {
+	newList := new(unstructured.UnstructuredList)
+	for _, item := range list.Items {
+		if err := AppendFlattened(newList, &item); err != nil {
+			return nil, err
+		}
+	}
+	return newList, nil
+}

--- a/staging/src/k8s.io/apimachinery/pkg/util/manifest/manifest_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/manifest/manifest_test.go
@@ -1,0 +1,71 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubernetes_test
+
+import (
+	"io/ioutil"
+	"testing"
+
+	. "k8s.io/apimachinery/pkg/util/manifest"
+)
+
+func TestLoadAllItemsIntoFlattendList(t *testing.T) {
+	for _, sample := range []struct {
+		path        string
+		expectedLen int
+	}{
+		{
+			path:        "testdata/misc-sample-nested-list-1.json",
+			expectedLen: 6,
+		},
+		{
+			path:        "testdata/misc-sample-multidoc-nested-lists-1.yaml",
+			expectedLen: 4,
+		},
+		{
+			path:        "testdata/misc-sample-empty-list-1.json",
+			expectedLen: 0,
+		},
+		{
+			path:        "testdata/misc-sample-multidoc-empty-lists-1.yaml",
+			expectedLen: 0,
+		},
+		{
+			path:        "testdata/misc-sample-multidoc-empty-lists-2.yaml",
+			expectedLen: 0,
+		},
+	} {
+		data, err := ioutil.ReadFile(sample.path)
+		if err != nil {
+			t.Fatalf("unexpected error reading sample %q: %v", sample.path, err)
+		}
+		list, err := NewUnstructuredList(data)
+		if err != nil {
+			t.Fatalf("unexpected error converting data from %q into a list: %v", sample.path, err)
+		}
+		if list == nil {
+			t.Fatalf("unexpected empty list from %q", sample.path)
+		}
+		list, err = Flatten(list)
+		if err != nil {
+			t.Fatalf("unexpected error flattening list parsed from %q: %v", sample.path, err)
+		}
+		if l := len(list.Items); l != sample.expectedLen {
+			t.Fatalf("unexpected length of flattened list from %q: expected %d, got %d", sample.path, sample.expectedLen, l)
+		}
+	}
+}

--- a/staging/src/k8s.io/apimachinery/pkg/util/manifest/testdata/misc-sample-empty-list-1.json
+++ b/staging/src/k8s.io/apimachinery/pkg/util/manifest/testdata/misc-sample-empty-list-1.json
@@ -1,0 +1,24 @@
+{
+    "kind": "List",
+    "apiVersion": "v1",
+    "items": [
+        {
+            "kind": "List",
+            "apiVersion": "v1",
+            "items": [
+
+            ]
+        },
+        {
+            "kind": "List",
+            "apiVersion": "v1",
+            "items": [
+                {
+                    "kind": "List",
+                    "apiVersion": "v1",
+                    "items": [ ]
+                }
+            ]
+        }
+    ]
+}

--- a/staging/src/k8s.io/apimachinery/pkg/util/manifest/testdata/misc-sample-multidoc-empty-lists-1.yaml
+++ b/staging/src/k8s.io/apimachinery/pkg/util/manifest/testdata/misc-sample-multidoc-empty-lists-1.yaml
@@ -1,0 +1,22 @@
+---
+kind: List
+apiVersion: v1
+---
+kind: List
+apiVersion: v1
+items: []
+---
+kind: List
+apiVersion: v1
+items:
+- kind: List
+  apiVersion: v1
+  items:
+  - kind: List
+    apiVersion: v1
+    items: []
+  - kind: List
+    apiVersion: v1
+- kind: List
+  apiVersion: v1
+  items: []

--- a/staging/src/k8s.io/apimachinery/pkg/util/manifest/testdata/misc-sample-multidoc-empty-lists-2.yaml
+++ b/staging/src/k8s.io/apimachinery/pkg/util/manifest/testdata/misc-sample-multidoc-empty-lists-2.yaml
@@ -1,0 +1,8 @@
+---
+kind: List
+apiVersion: v1
+items: []
+---
+kind: List
+apiVersion: v1
+items: []

--- a/staging/src/k8s.io/apimachinery/pkg/util/manifest/testdata/misc-sample-multidoc-nested-lists-1.yaml
+++ b/staging/src/k8s.io/apimachinery/pkg/util/manifest/testdata/misc-sample-multidoc-nested-lists-1.yaml
@@ -1,0 +1,44 @@
+---
+kind: List
+apiVersion: v1
+---
+kind: List
+apiVersion: v1
+items: []
+---
+kind: List
+apiVersion: v1
+items:
+- apiVersion: "v1"
+  kind: "Service"
+  metadata:
+    name: "test"
+    namespace: "test1"
+- apiVersion: "v1"
+  kind: "Service"
+  metadata:
+    name: "test"
+    namespace: "test2"
+---
+kind: List
+apiVersion: v1
+items:
+- kind: List
+  apiVersion: v1
+  items:
+  - kind: List
+    apiVersion: v1
+    items: []
+  - kind: List
+    apiVersion: v1
+- kind: List
+  apiVersion: v1
+  items: []
+---
+apiVersion: v1
+kind: Namespace
+metadata: {name: "test1"}
+---
+apiVersion: v1
+kind: Namespace
+metadata: {name: "test2"}

--- a/staging/src/k8s.io/apimachinery/pkg/util/manifest/testdata/misc-sample-nested-list-1.json
+++ b/staging/src/k8s.io/apimachinery/pkg/util/manifest/testdata/misc-sample-nested-list-1.json
@@ -1,0 +1,72 @@
+{
+    "kind": "List",
+    "apiVersion": "v1",
+    "items": [
+        {
+            "kind": "List",
+            "apiVersion": "v1",
+            "items": [
+                {
+                    "apiVersion": "v1",
+                    "kind": "Service",
+                    "metadata": {
+                          "name": "test",
+                          "namespace": "test1"
+                    }
+                },
+                {
+                    "apiVersion": "v1",
+                    "kind": "Service",
+                    "metadata": {
+                          "name": "test",
+                          "namespace": "test2"
+                    }
+                }
+            ]
+        },
+        {
+            "apiVersion": "v1",
+            "kind": "Service",
+            "metadata": {
+                  "name": "test",
+                  "namespace": "test3"
+            }
+        },
+        {
+            "apiVersion": "v1",
+            "kind": "Service",
+            "metadata": {
+                  "name": "test",
+                  "namespace": "test4"
+            }
+        },
+        {
+            "kind": "List",
+            "apiVersion": "v1",
+            "items": [
+                {
+                    "kind": "List",
+                    "apiVersion": "v1",
+                    "items": [
+                        {
+                            "apiVersion": "v1",
+                            "kind": "ServiceAccount",
+                            "metadata": {
+                                  "name": "test",
+                                  "namespace": "test5"
+                            }
+                        },
+                        {
+                            "apiVersion": "v1",
+                            "kind": "ServiceAccount",
+                            "metadata": {
+                                  "name": "test",
+                                  "namespace": "test6"
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

    
When using Kubernetes client it's not very easy
to read a manifest with just any set of resource
from file and parse it in the same way kubectl
would do. This code was previously used by eksctl
project and could be useful more widely.
    
This commit imports code from [eksctl repository][1].
    
The author of this commit is also the original author
of the given code. It was originally under APL2, hence
there should be no licensing issues either.
    
[1]: https://github.com/weaveworks/eksctl/blob/91b4eddc988276c8a3c857321e1347bd7405d954/pkg/kubernetes/manifests.go

**Special notes for your reviewer**:

The author of this commit is also the original author
of the given code. It was originally under APL2, hence
there should be no licensing issues either.

**Does this PR introduce a user-facing change?**:

```release-note
Add apimachinery package for parsing manifests
```