### PR TITLE
Adjust VolumeLifecycleModes to use a string set

### DIFF
--- a/pkg/apis/storage/validation/validation.go
+++ b/pkg/apis/storage/validation/validation.go
@@ -442,18 +442,14 @@ func validatePodInfoOnMount(podInfoOnMount *bool, fldPath *field.Path) field.Err
 	return allErrs
 }
 
+var supportedVolumeLifecycleModes = sets.NewString(string(storage.VolumeLifecyclePersistent), string(storage.VolumeLifecycleEphemeral))
+
 // validateVolumeLifecycleModes tests if mode has one of the allowed values.
 func validateVolumeLifecycleModes(modes []storage.VolumeLifecycleMode, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 	for _, mode := range modes {
-		switch mode {
-		case storage.VolumeLifecyclePersistent, storage.VolumeLifecycleEphemeral:
-		default:
-			allErrs = append(allErrs, field.NotSupported(fldPath, mode,
-				[]string{
-					string(storage.VolumeLifecyclePersistent),
-					string(storage.VolumeLifecycleEphemeral),
-				}))
+		if !supportedVolumeLifecycleModes.Has(string(mode)) {
+			allErrs = append(allErrs, field.NotSupported(fldPath, mode, supportedVolumeLifecycleModes.List()))
 		}
 	}
 


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Adjusts the VolumeLifecycleModes to use a string set instead of a switch, keeping it consistent with the other validation checks.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs

```
