### PR TITLE
Refactor and expose common preemption functions

### DIFF
--- a/pkg/scheduler/framework/plugins/defaultpreemption/BUILD
+++ b/pkg/scheduler/framework/plugins/defaultpreemption/BUILD
@@ -2,7 +2,10 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
-    srcs = ["default_preemption.go"],
+    srcs = [
+        "candidate.go",
+        "default_preemption.go",
+    ],
     importpath = "k8s.io/kubernetes/pkg/scheduler/framework/plugins/defaultpreemption",
     visibility = ["//visibility:public"],
     deps = [
@@ -20,6 +23,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",
         "//staging/src/k8s.io/client-go/informers:go_default_library",
+        "//staging/src/k8s.io/client-go/kubernetes:go_default_library",
         "//staging/src/k8s.io/client-go/listers/policy/v1beta1:go_default_library",
         "//staging/src/k8s.io/kube-scheduler/extender/v1:go_default_library",
         "//vendor/k8s.io/klog/v2:go_default_library",

--- a/pkg/scheduler/framework/plugins/defaultpreemption/candidate.go
+++ b/pkg/scheduler/framework/plugins/defaultpreemption/candidate.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package defaultpreemption
+
+import (
+	extenderv1 "k8s.io/kube-scheduler/extender/v1"
+)
+
+// Candidate represents a nominated node on which the preemptor can be scheduled,
+// along with the list of victims that should be evicted for the preemptor to fit the node.
+type Candidate interface {
+	// Victims wraps a list of to-be-preempted Pods and the number of PDB violation.
+	Victims() *extenderv1.Victims
+	// Name returns the target node name where the preemptor gets nominated to run.
+	Name() string
+}
+
+type candidate struct {
+	victims *extenderv1.Victims
+	name    string
+}
+
+// Victims returns s.victims.
+func (s *candidate) Victims() *extenderv1.Victims {
+	return s.victims
+}
+
+// Name returns s.name.
+func (s *candidate) Name() string {
+	return s.name
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup
/sig scheduling

**What this PR does / why we need it**:

This PR divides the whole preemption flow into 5 public functions:

- **PodEligibleToPreemptOthers**: Ensure the preemptor is eligible to preempt other pods. Out-of-tree plugins can either customize or reuse it.
- **FindCandidates:** Calculate the preemption candidates. Out-of-tree plugins may rewrite this in their implementation.
- **CallExtenders:** Interact with extenders. Usually, out-of-tree plugins just call it as-is.
- **SelectBestCandidate:** Pick the best-fit candidate from preemption candidates. Out-of-tree plugins may rewrite this in their implementation.
- **PreNominateCandidate:** Perform preparation work before nominating the candidate winner. Usually, out-of-tree plugins just call it as-is.

Other notable changes:

- `selectNodesForPreemption` is renamed to `dryRunPreemption`
- a `Candidate` interface is introduced. Out-of-tree plugins can have their own implementation.
- map `nodeNameToVictims` is refactored to `[]Candidate` as we used to assume the nominated node name is unique, but with the same nominated node, there could be more than one candidate, so using a slice instead of map to represent all candidates would make more sense.

**Which issue(s) this PR fixes**:

Part of #91038.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```