### PR TITLE
Disable deprecated insecure port by default

### DIFF
--- a/cluster/gce/gci/configure-kubeapiserver.sh
+++ b/cluster/gce/gci/configure-kubeapiserver.sh
@@ -76,9 +76,8 @@ function start-kube-apiserver {
   configure-etcd-params params
 
   params+=" --secure-port=443"
-  if [[ "${ENABLE_APISERVER_INSECURE_PORT:-false}" != "true" ]]; then
-    # Default is :8080
-    params+=" --insecure-port=0"
+  if [[ "${ENABLE_APISERVER_INSECURE_PORT:-false}" == "true" ]]; then
+    params+=" --insecure-port=8080"
   fi
   params+=" --tls-cert-file=${APISERVER_SERVER_CERT_PATH}"
   params+=" --tls-private-key-file=${APISERVER_SERVER_KEY_PATH}"

--- a/cmd/kube-apiserver/app/options/options_test.go
+++ b/cmd/kube-apiserver/app/options/options_test.go
@@ -179,7 +179,7 @@ func TestAddFlags(t *testing.T) {
 		}).WithLoopback(),
 		InsecureServing: (&apiserveroptions.DeprecatedInsecureServingOptions{
 			BindAddress: net.ParseIP("127.0.0.1"),
-			BindPort:    8080,
+			BindPort:    0,
 		}).WithLoopback(),
 		EventTTL: 1 * time.Hour,
 		KubeletConfig: kubeletclient.KubeletClientConfig{

--- a/pkg/kubeapiserver/options/serving.go
+++ b/pkg/kubeapiserver/options/serving.go
@@ -41,11 +41,10 @@ func NewSecureServingOptions() *genericoptions.SecureServingOptionsWithLoopback 
 }
 
 // NewInsecureServingOptions gives default values for the kube-apiserver.
-// TODO: switch insecure serving off by default
 func NewInsecureServingOptions() *genericoptions.DeprecatedInsecureServingOptionsWithLoopback {
 	o := genericoptions.DeprecatedInsecureServingOptions{
 		BindAddress: net.ParseIP("127.0.0.1"),
-		BindPort:    8080,
+		BindPort:    0, // Disabled.
 	}
 	return o.WithLoopback()
 }

--- a/staging/src/k8s.io/apiserver/pkg/server/options/deprecated_insecure_serving.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/deprecated_insecure_serving.go
@@ -28,7 +28,7 @@ import (
 
 // DeprecatedInsecureServingOptions are for creating an unauthenticated, unauthorized, insecure port.
 // No one should be using these anymore.
-// DEPRECATED: all insecure serving options are removed in a future version
+// DEPRECATED: all insecure serving options will be removed in v1.20
 type DeprecatedInsecureServingOptions struct {
 	BindAddress net.IP
 	BindPort    int
@@ -69,14 +69,12 @@ func (s *DeprecatedInsecureServingOptions) AddFlags(fs *pflag.FlagSet) {
 
 	fs.IPVar(&s.BindAddress, "insecure-bind-address", s.BindAddress, ""+
 		"The IP address on which to serve the --insecure-port (set to 0.0.0.0 for all IPv4 interfaces and :: for all IPv6 interfaces).")
-	// Though this flag is deprecated, we discovered security concerns over how to do health checks without it e.g. #43784
-	fs.MarkDeprecated("insecure-bind-address", "This flag will be removed in a future version.")
+	fs.MarkDeprecated("insecure-bind-address", "This flag will be removed in v1.20.")
 	fs.Lookup("insecure-bind-address").Hidden = false
 
 	fs.IntVar(&s.BindPort, "insecure-port", s.BindPort, ""+
 		"The port on which to serve unsecured, unauthenticated access.")
-	// Though this flag is deprecated, we discovered security concerns over how to do health checks without it e.g. #43784
-	fs.MarkDeprecated("insecure-port", "This flag will be removed in a future version.")
+	fs.MarkDeprecated("insecure-port", "This flag will be removed in v1.20.")
 	fs.Lookup("insecure-port").Hidden = false
 }
 

--- a/test/e2e/framework/test_context.go
+++ b/test/e2e/framework/test_context.go
@@ -36,7 +36,7 @@ import (
 )
 
 const (
-	defaultHost = "http://127.0.0.1:8080"
+	defaultHost = "https://127.0.0.1:6443"
 
 	// DefaultNumNodes is the number of nodes. If not specified, then number of nodes is auto-detected
 	DefaultNumNodes = -1

--- a/test/e2e_node/services/apiserver.go
+++ b/test/e2e_node/services/apiserver.go
@@ -27,7 +27,7 @@ import (
 
 const (
 	clusterIPRange          = "10.0.0.1/24"
-	apiserverClientURL      = "http://localhost:8080"
+	apiserverClientURL      = "https://localhost:6443"
 	apiserverHealthCheckURL = apiserverClientURL + "/healthz"
 )
 
@@ -53,6 +53,7 @@ func (a *APIServer) Start() error {
 	if err != nil {
 		return err
 	}
+	o.SecureServing.BindAddress = net.ParseIP("127.0.0.1")
 	o.ServiceClusterIPRanges = ipnet.String()
 	o.AllowPrivileged = true
 	o.Admission.GenericAdmission.DisablePlugins = []string{"ServiceAccount", "TaintNodesByCondition"}

--- a/test/e2e_node/services/server.go
+++ b/test/e2e_node/services/server.go
@@ -19,7 +19,6 @@ package services
 import (
 	"flag"
 	"fmt"
-	"net/http"
 	"os"
 	"os/exec"
 	"path"
@@ -191,8 +190,7 @@ func (s *server) start() error {
 						return
 					case <-time.After(time.Second):
 						for _, url := range s.healthCheckUrls {
-							resp, err := http.Head(url)
-							if err != nil || resp.StatusCode != http.StatusOK {
+							if !healthCheck(url) {
 								break stillAlive
 							}
 						}

--- a/test/e2e_node/services/util.go
+++ b/test/e2e_node/services/util.go
@@ -94,5 +94,14 @@ func readinessCheck(name string, urls []string, errCh <-chan error) error {
 // Skip verification of server certs.
 func healthCheck(url string) bool {
 	resp, err := insecureHTTPClient.Head(url)
-	return err == nil && resp.StatusCode == http.StatusOK
+	// return err == nil && resp.StatusCode == http.StatusOK
+	if err == nil && resp.StatusCode == http.StatusOK { // FIXME
+		return true
+	}
+	if err != nil {
+		klog.Warningf("Health check on '%s' failed. Error: %v", url, err)
+	} else {
+		klog.Warningf("Health check on '%s' failed. Status: %d", url, resp.StatusCode)
+	}
+	return false
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind deprecation

**What this PR does / why we need it**:

Disable the deprecated `--insecure-port` by default. The port will be permanently disabled starting in v1.20, and the flag removed in a later release.

**Which issue(s) this PR fixes**:
For https://github.com/kubernetes/kubernetes/issues/91506

**Does this PR introduce a user-facing change?**:
```release-note
kube-apiserver: The `--insecure-port` now defaults to disabled. Set `--insecure-port=8080` to temporarily keep the previous behavior. The flag will be permanently disabled starting in v1.20.
```

/assign @liggitt 
/area security
/milestone v1.19
/sig api-machinery
/sig auth