### PR TITLE
Fix description of conversion generator

### DIFF
--- a/staging/src/k8s.io/code-generator/cmd/conversion-gen/main.go
+++ b/staging/src/k8s.io/code-generator/cmd/conversion-gen/main.go
@@ -30,21 +30,33 @@ limitations under the License.
 // ones named
 //     autoConvert_<pkg1>_<type>_To_<pkg2>_<type>
 // for each such pair of types --- both with (pkg1,pkg2) =
-// (internal,external) and (pkg1,pkg2) = (external,internal).
-// Additionally: if the destination package does not contain one in a
-// non-generated file then a function named
+// (internal,external) and (pkg1,pkg2) = (external,internal).  The
+// generated conversion functions recurse on the structure of the data
+// types.  For structs, source and destination fields are matched up
+// according to name; if a source field has no corresponding
+// destination or there is a fundamental mismatch in the type of the
+// field then the generated autoConvert_... function has just a
+// warning comment about that field.  The generated conversion
+// functions use standard value assignment wherever possible.  For
+// compound types, the generated conversion functions call the
+// `Convert...` functions for the subsidiary types.
+//
+// For each pair of types `conversion-gen` will also generate a
+// function named
 //     Convert_<pkg1>_<type>_To_<pkg2>_<type>
-// is also generated and it simply calls the `autoConvert...`
-// function.  The generated conversion functions use standard value
-// assignment wherever possible.  For compound types, the generated
-// conversion functions call the `Convert...` functions for the
-// subsidiary types.  Thus developers can override the behavior for
-// selected types.  For a top-level object type (i.e., the type of an
-// object that will be input to an apiserver), for such an override to
-// be used by the apiserver the developer-maintained conversion
-// functions must also be registered by invoking the
-// `AddConversionFunc`/`AddGeneratedConversionFunc` method of the
-// relevant `Scheme` object from k8s.io/apimachinery/pkg/runtime.
+// if both of two conditions are met: (1) the destination package does
+// not contain a function of that name in a non-generated file and (2)
+// the generation of the corresponding autoConvert_...  function did
+// not run into trouble with a missing or fundamentally differently
+// typed field.  A generated Convert_... function simply calls the
+// corresponding `autoConvert...` function.  `conversion_gen` also
+// generates a function that updates a given `runtime.Scheme` by
+// registering all the Convert_... functions found and generated.
+// Thus developers can override the generated behavior for selected
+// type pairs by putting the desired Convert_... functions in
+// non-generated files.  Further, developers are practically required
+// to override the generated behavior when there are missing or
+// fundamentally differently typed fields.
 //
 // `conversion-gen` will scan its `--input-dirs`, looking at the
 // package defined in each of those directories for comment tags that


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind api-change

/kind bug

> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
The old description failed to note that the `Convert_<pkg1>_<type>_To_<pkg2>_<type>` function is NOT generated if generation of the corresponding `autoConvert_...` function ran into
trouble with a missing or mis-typed field.  This PR revises the description of the conversion
generator to note this exception and also explain the generated registration of conversion functions.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #92895 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
