### PR TITLE
fixes 92907 improves test error output

### DIFF
--- a/test/e2e_node/node_problem_detector_linux.go
+++ b/test/e2e_node/node_problem_detector_linux.go
@@ -419,7 +419,7 @@ func verifyEvents(e coreclientset.EventInterface, options metav1.ListOptions, nu
 		count += int(event.Count)
 	}
 	if count != num {
-		return fmt.Errorf("Expected %d events with reason set to %s and message set to %s\nbut %d actual events occured. Events : %v", num, reason, message, count, events.Items)
+		return fmt.Errorf("expected %d events with reason set to %s and message set to %s\nbut %d actual events occurred. Events : %v", num, reason, message, count, events.Items)
 	}
 	return nil
 }

--- a/test/e2e_node/node_problem_detector_linux.go
+++ b/test/e2e_node/node_problem_detector_linux.go
@@ -419,7 +419,7 @@ func verifyEvents(e coreclientset.EventInterface, options metav1.ListOptions, nu
 		count += int(event.Count)
 	}
 	if count != num {
-		return fmt.Errorf("expect event number %d, got %d: %v", num, count, events.Items)
+		return fmt.Errorf("Expected %d events with reason set to %s and message set to %s\nbut %d actual events occured. Events : %v", num, reason, message, count, events.Items)
 	}
 	return nil
 }
@@ -435,7 +435,7 @@ func verifyTotalEvents(e coreclientset.EventInterface, options metav1.ListOption
 		count += int(event.Count)
 	}
 	if count != num {
-		return fmt.Errorf("expect event number %d, got %d: %v", num, count, events.Items)
+		return fmt.Errorf("expected total number of events was %d, actual events counted was %d\nEvents  : %v", num, count, events.Items)
 	}
 	return nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**


/kind cleanup


**What this PR does / why we need it**:
Clarifies a misleading test error message 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #92907

**Special notes for your reviewer**:
Please see linked issue #92907 
 
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```


