### PR TITLE
Add error if using kubectl run with generator other than run-pod/v1

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/run/run.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/run/run.go
@@ -306,6 +306,10 @@ func (o *RunOptions) Run(f cmdutil.Factory, cmd *cobra.Command, args []string) e
 		return err
 	}
 
+	if len(o.Generator) > 0 && o.Generator != generateversioned.RunPodV1GeneratorName {
+		return cmdutil.UsageErrorf(cmd, "generator %q is not supported by run", o.Generator)
+	}
+
 	generators := generateversioned.GeneratorFn("run")
 	generator, found := generators[generateversioned.RunPodV1GeneratorName]
 	if !found {


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

If I try to create a deployment with run, like this:
```
kubectl run foo --image=nginx --generator=deployment/apps.v1
```

With kubectl 1.17, I get a warning and it successfully creates the deployment:
```
kubectl run --generator=deployment/apps.v1 is DEPRECATED and will be removed in a future version. Use kubectl run --generator=run-pod/v1 or kubectl create instead.
deployment.apps/foo created
```

But with kubectl 1.18, I get a warning and at first glance, it *appears* to succeed, but upon closer look, it shows that a pod was created instead of a deployment:
```
Flag --generator has been deprecated, has no effect and will be removed in the future.
pod/foo created
```

This PR puts a check in place to fail if you are attempting to set the generator to something other than `run-pod/v1`.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
Add validation check to prevent calling kubectl run with unsupported generator
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs

```

/cc @soltysh 