### PR TITLE
Setup cache dirs properly based on --cache-dir value 

### DIFF
--- a/staging/src/k8s.io/client-go/discovery/cached/disk/cached_discovery.go
+++ b/staging/src/k8s.io/client-go/discovery/cached/disk/cached_discovery.go
@@ -268,8 +268,6 @@ func (d *CachedDiscoveryClient) Invalidate() {
 // CachedDiscoveryClient cache data. If httpCacheDir is empty, the restconfig's transport will not
 // be updated with a roundtripper that understands cache responses.
 // If discoveryCacheDir is empty, cached server resource data will be looked up in the current directory.
-// TODO(juanvallejo): the value of "--cache-dir" should be honored. Consolidate discoveryCacheDir with httpCacheDir
-// so that server resources and http-cache data are stored in the same location, provided via config flags.
 func NewCachedDiscoveryClientForConfig(config *restclient.Config, discoveryCacheDir, httpCacheDir string, ttl time.Duration) (*CachedDiscoveryClient, error) {
 	if len(httpCacheDir) > 0 {
 		// update the given restconfig with a custom roundtripper that


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
This is a followup that builds on top of https://github.com/kubernetes/kubernetes/pull/91851 cleaning the remaining bits and setting a single parent cache dir for both http and discovery.

**Special notes for your reviewer**:
/assign @sallyom @SataQiu 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
--cache-dir sets cache directory for both http and discovery, defaults to $HOME/.kube/cache
```
