### PR TITLE
Resolves staticcheck failures for component-base/metrics

### DIFF
--- a/hack/.staticcheck_failures
+++ b/hack/.staticcheck_failures
@@ -70,7 +70,6 @@ vendor/k8s.io/client-go/rest/watch
 vendor/k8s.io/client-go/restmapper
 vendor/k8s.io/client-go/tools/leaderelection
 vendor/k8s.io/client-go/transport
-vendor/k8s.io/component-base/metrics
 vendor/k8s.io/kubectl/pkg/cmd/get
 vendor/k8s.io/kubectl/pkg/cmd/scale
 vendor/k8s.io/kubectl/pkg/cmd/testing

--- a/staging/src/k8s.io/component-base/metrics/metric.go
+++ b/staging/src/k8s.io/component-base/metrics/metric.go
@@ -188,9 +188,6 @@ func (c *selfCollector) Collect(ch chan<- prometheus.Metric) {
 // no-op vecs for convenience
 var noopCounterVec = &prometheus.CounterVec{}
 var noopHistogramVec = &prometheus.HistogramVec{}
-
-// lint:ignore U1000 Keep it for future use
-var noopSummaryVec = &prometheus.SummaryVec{}
 var noopGaugeVec = &prometheus.GaugeVec{}
 var noopObserverVec = &noopObserverVector{}
 

--- a/staging/src/k8s.io/component-base/metrics/processstarttime.go
+++ b/staging/src/k8s.io/component-base/metrics/processstarttime.go
@@ -54,7 +54,7 @@ func getProcessStart() (float64, error) {
 		return 0, err
 	}
 
-	if stat, err := p.NewStat(); err == nil {
+	if stat, err := p.Stat(); err == nil {
 		return stat.StartTime()
 	}
 	return 0, err


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Resolves staticcheck failures for component-base/metrics:
```
Errors from staticcheck:
vendor/k8s.io/component-base/metrics/metric.go:193:5: var noopSummaryVec is unused (U1000)
vendor/k8s.io/component-base/metrics/processstarttime.go:57:18: p.NewStat is deprecated: use p.Stat() instead  (SA1019)
```
[We have verified that the unused variable is not used in any other components](https://cs.k8s.io/?q=noopSummaryVec&i=nope&files=&repos=).

We replaced the deprecated method with the recommended one.

**Which issue(s) this PR fixes**:
https://github.com/kubernetes/kubernetes/issues/92402

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

cc @nikhita 