### PR TITLE
publishing: add rules for 1.19 and remove for 1.15

### DIFF
--- a/staging/publishing/rules.yaml
+++ b/staging/publishing/rules.yaml
@@ -31,6 +31,11 @@ rules:
       dir: staging/src/k8s.io/code-generator
     name: release-1.18
     go: 1.13.9
+  - source:
+      branch: release-1.19
+      dir: staging/src/k8s.io/code-generator
+    name: release-1.19
+    go: 1.14.4
 
 - destination: apimachinery
   library: true
@@ -59,6 +64,11 @@ rules:
       dir: staging/src/k8s.io/apimachinery
     name: release-1.18
     go: 1.13.9
+  - source:
+      branch: release-1.19
+      dir: staging/src/k8s.io/apimachinery
+    name: release-1.19
+    go: 1.14.4
 
 - destination: api
   library: true
@@ -102,6 +112,14 @@ rules:
     dependencies:
       - repository: apimachinery
         branch: release-1.18
+  - source:
+      branch: release-1.19
+      dir: staging/src/k8s.io/api
+    name: release-1.19
+    go: 1.14.4
+    dependencies:
+      - repository: apimachinery
+        branch: release-1.19
 
 - destination: client-go
   library: true
@@ -155,6 +173,16 @@ rules:
         branch: release-1.18
       - repository: api
         branch: release-1.18
+  - source:
+      branch: release-1.19
+      dir: staging/src/k8s.io/client-go
+    name: release-1.19
+    go: 1.14.4
+    dependencies:
+      - repository: apimachinery
+        branch: release-1.19
+      - repository: api
+        branch: release-1.19
   smoke-test: |
     # assumes GO111MODULE=on
     go build ./...
@@ -218,6 +246,18 @@ rules:
       branch: release-1.18
     - repository: client-go
       branch: release-1.18
+  - source:
+      branch: release-1.19
+      dir: staging/src/k8s.io/component-base
+    name: release-1.19
+    go: 1.14.4
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.19
+    - repository: api
+      branch: release-1.19
+    - repository: client-go
+      branch: release-1.19
 
 - destination: apiserver
   library: true
@@ -291,6 +331,20 @@ rules:
       branch: release-1.18
     - repository: component-base
       branch: release-1.18
+  - source:
+      branch: release-1.19
+      dir: staging/src/k8s.io/apiserver
+    name: release-1.19
+    go: 1.14.4
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.19
+    - repository: api
+      branch: release-1.19
+    - repository: client-go
+      branch: release-1.19
+    - repository: component-base
+      branch: release-1.19
 
 - destination: kube-aggregator
   branches:
@@ -383,6 +437,24 @@ rules:
       branch: release-1.18
     - repository: code-generator
       branch: release-1.18
+  - source:
+      branch: release-1.19
+      dir: staging/src/k8s.io/kube-aggregator
+    name: release-1.19
+    go: 1.14.4
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.19
+    - repository: api
+      branch: release-1.19
+    - repository: client-go
+      branch: release-1.19
+    - repository: apiserver
+      branch: release-1.19
+    - repository: component-base
+      branch: release-1.19
+    - repository: code-generator
+      branch: release-1.19
 
 - destination: sample-apiserver
   branches:
@@ -485,6 +557,26 @@ rules:
       branch: release-1.18
     required-packages:
     - k8s.io/code-generator
+  - source:
+      branch: release-1.19
+      dir: staging/src/k8s.io/sample-apiserver
+    name: release-1.19
+    go: 1.14.4
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.19
+    - repository: api
+      branch: release-1.19
+    - repository: client-go
+      branch: release-1.19
+    - repository: apiserver
+      branch: release-1.19
+    - repository: code-generator
+      branch: release-1.19
+    - repository: component-base
+      branch: release-1.19
+    required-packages:
+    - k8s.io/code-generator
   smoke-test: |
     # assumes GO111MODULE=on
     go build .
@@ -568,6 +660,22 @@ rules:
       branch: release-1.18
     - repository: code-generator
       branch: release-1.18
+    required-packages:
+    - k8s.io/code-generator
+  - source:
+      branch: release-1.19
+      dir: staging/src/k8s.io/sample-controller
+    name: release-1.19
+    go: 1.14.4
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.19
+    - repository: api
+      branch: release-1.19
+    - repository: client-go
+      branch: release-1.19
+    - repository: code-generator
+      branch: release-1.19
     required-packages:
     - k8s.io/code-generator
   smoke-test: |
@@ -675,6 +783,26 @@ rules:
       branch: release-1.18
     required-packages:
     - k8s.io/code-generator
+  - source:
+      branch: release-1.19
+      dir: staging/src/k8s.io/apiextensions-apiserver
+    name: release-1.19
+    go: 1.14.4
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.19
+    - repository: api
+      branch: release-1.19
+    - repository: client-go
+      branch: release-1.19
+    - repository: apiserver
+      branch: release-1.19
+    - repository: code-generator
+      branch: release-1.19
+    - repository: component-base
+      branch: release-1.19
+    required-packages:
+    - k8s.io/code-generator
 
 - destination: metrics
   library: true
@@ -748,6 +876,20 @@ rules:
       branch: release-1.18
     - repository: code-generator
       branch: release-1.18
+  - source:
+      branch: release-1.19
+      dir: staging/src/k8s.io/metrics
+    name: release-1.19
+    go: 1.14.4
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.19
+    - repository: api
+      branch: release-1.19
+    - repository: client-go
+      branch: release-1.19
+    - repository: code-generator
+      branch: release-1.19
 
 - destination: cli-runtime
   library: true
@@ -811,6 +953,18 @@ rules:
       branch: release-1.18
     - repository: client-go
       branch: release-1.18
+  - source:
+      branch: release-1.19
+      dir: staging/src/k8s.io/cli-runtime
+    name: release-1.19
+    go: 1.14.4
+    dependencies:
+    - repository: api
+      branch: release-1.19
+    - repository: apimachinery
+      branch: release-1.19
+    - repository: client-go
+      branch: release-1.19
 
 - destination: sample-cli-plugin
   library: false
@@ -884,6 +1038,20 @@ rules:
       branch: release-1.18
     - repository: client-go
       branch: release-1.18
+  - source:
+      branch: release-1.19
+      dir: staging/src/k8s.io/sample-cli-plugin
+    name: release-1.19
+    go: 1.14.4
+    dependencies:
+    - repository: api
+      branch: release-1.19
+    - repository: apimachinery
+      branch: release-1.19
+    - repository: cli-runtime
+      branch: release-1.19
+    - repository: client-go
+      branch: release-1.19
 
 - destination: kube-proxy
   library: true
@@ -953,6 +1121,20 @@ rules:
       branch: release-1.18
     - repository: client-go
       branch: release-1.18
+  - source:
+      branch: release-1.19
+      dir: staging/src/k8s.io/kube-proxy
+    name: release-1.19
+    go: 1.14.4
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.19
+    - repository: component-base
+      branch: release-1.19
+    - repository: api
+      branch: release-1.19
+    - repository: client-go
+      branch: release-1.19
 
 - destination: kubelet
   library: true
@@ -1010,6 +1192,20 @@ rules:
       branch: release-1.18
     - repository: api
       branch: release-1.18
+  - source:
+      branch: release-1.19
+      dir: staging/src/k8s.io/kubelet
+    name: release-1.19
+    go: 1.14.4
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.19
+    - repository: api
+      branch: release-1.19
+    - repository: client-go
+      branch: release-1.19
+    - repository: component-base
+      branch: release-1.19
 
 - destination: kube-scheduler
   library: true
@@ -1079,6 +1275,20 @@ rules:
       branch: release-1.18
     - repository: client-go
       branch: release-1.18
+  - source:
+      branch: release-1.19
+      dir: staging/src/k8s.io/kube-scheduler
+    name: release-1.19
+    go: 1.14.4
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.19
+    - repository: component-base
+      branch: release-1.19
+    - repository: api
+      branch: release-1.19
+    - repository: client-go
+      branch: release-1.19
 
 - destination: kube-controller-manager
   library: true
@@ -1148,6 +1358,20 @@ rules:
       branch: release-1.18
     - repository: client-go
       branch: release-1.18
+  - source:
+      branch: release-1.19
+      dir: staging/src/k8s.io/kube-controller-manager
+    name: release-1.19
+    go: 1.14.4
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.19
+    - repository: component-base
+      branch: release-1.19
+    - repository: api
+      branch: release-1.19
+    - repository: client-go
+      branch: release-1.19
 
 - destination: cluster-bootstrap
   library: true
@@ -1201,6 +1425,16 @@ rules:
       branch: release-1.18
     - repository: api
       branch: release-1.18
+  - source:
+      branch: release-1.19
+      dir: staging/src/k8s.io/cluster-bootstrap
+    name: release-1.19
+    go: 1.14.4
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.19
+    - repository: api
+      branch: release-1.19
 
 - destination: cloud-provider
   library: true
@@ -1266,6 +1500,20 @@ rules:
       branch: release-1.18
     - repository: client-go
       branch: release-1.18
+  - source:
+      branch: release-1.19
+      dir: staging/src/k8s.io/cloud-provider
+    name: release-1.19
+    go: 1.14.4
+    dependencies:
+    - repository: api
+      branch: release-1.19
+    - repository: apimachinery
+      branch: release-1.19
+    - repository: client-go
+      branch: release-1.19
+    - repository: component-base
+      branch: release-1.19
 
 - destination: csi-translation-lib
   library: true
@@ -1341,6 +1589,22 @@ rules:
       branch: release-1.18
     - repository: cloud-provider
       branch: release-1.18
+  - source:
+      branch: release-1.19
+      dir: staging/src/k8s.io/csi-translation-lib
+    name: release-1.19
+    go: 1.14.4
+    dependencies:
+    - repository: api
+      branch: release-1.19
+    - repository: apimachinery
+      branch: release-1.19
+    - repository: client-go
+      branch: release-1.19
+    - repository: cloud-provider
+      branch: release-1.19
+    - repository: component-base
+      branch: release-1.19
 
 - destination: legacy-cloud-providers
   library: true
@@ -1440,6 +1704,26 @@ rules:
       branch: release-1.18
     - repository: component-base
       branch: release-1.18
+  - source:
+      branch: release-1.19
+      dir: staging/src/k8s.io/legacy-cloud-providers
+    name: release-1.19
+    go: 1.14.4
+    dependencies:
+    - repository: api
+      branch: release-1.19
+    - repository: apimachinery
+      branch: release-1.19
+    - repository: client-go
+      branch: release-1.19
+    - repository: cloud-provider
+      branch: release-1.19
+    - repository: csi-translation-lib
+      branch: release-1.19
+    - repository: apiserver
+      branch: release-1.19
+    - repository: component-base
+      branch: release-1.19
 
 - destination: node-api
   library: true
@@ -1514,6 +1798,11 @@ rules:
       dir: staging/src/k8s.io/cri-api
     name: release-1.18
     go: 1.13.9
+  - source:
+      branch: release-1.19
+      dir: staging/src/k8s.io/cri-api
+    name: release-1.19
+    go: 1.14.4
 
 - destination: kubectl
   library: true
@@ -1602,6 +1891,26 @@ rules:
       branch: release-1.18
     - repository: metrics
       branch: release-1.18
+  - source:
+      branch: release-1.19
+      dir: staging/src/k8s.io/kubectl
+    name: release-1.19
+    go: 1.14.4
+    dependencies:
+    - repository: api
+      branch: release-1.19
+    - repository: apimachinery
+      branch: release-1.19
+    - repository: cli-runtime
+      branch: release-1.19
+    - repository: client-go
+      branch: release-1.19
+    - repository: code-generator
+      branch: release-1.19
+    - repository: component-base
+      branch: release-1.19
+    - repository: metrics
+      branch: release-1.19
 
 - destination: controller-manager
   library: true
@@ -1611,4 +1920,8 @@ rules:
       dir: staging/src/k8s.io/controller-manager
     name: master
     go: 1.13.9
-
+  - source:
+      branch: release-1.19
+      dir: staging/src/k8s.io/controller-manager
+    name: release-1.19
+    go: 1.14.4

--- a/staging/publishing/rules.yaml
+++ b/staging/publishing/rules.yaml
@@ -12,11 +12,6 @@ rules:
       dir: staging/src/k8s.io/code-generator
     name: master
   - source:
-      branch: release-1.15
-      dir: staging/src/k8s.io/code-generator
-    name: release-1.15
-    go: 1.12.17
-  - source:
       branch: release-1.16
       dir: staging/src/k8s.io/code-generator
     name: release-1.16
@@ -44,11 +39,6 @@ rules:
       branch: master
       dir: staging/src/k8s.io/apimachinery
     name: master
-  - source:
-      branch: release-1.15
-      dir: staging/src/k8s.io/apimachinery
-    name: release-1.15
-    go: 1.12.17
   - source:
       branch: release-1.16
       dir: staging/src/k8s.io/apimachinery
@@ -80,14 +70,6 @@ rules:
     dependencies:
     - repository: apimachinery
       branch: master
-  - source:
-      branch: release-1.15
-      dir: staging/src/k8s.io/api
-    name: release-1.15
-    go: 1.12.17
-    dependencies:
-      - repository: apimachinery
-        branch: release-1.15
   - source:
       branch: release-1.16
       dir: staging/src/k8s.io/api
@@ -133,16 +115,6 @@ rules:
       branch: master
     - repository: api
       branch: master
-  - source:
-      branch: release-1.15
-      dir: staging/src/k8s.io/client-go
-    name: release-12.0
-    go: 1.12.17
-    dependencies:
-      - repository: apimachinery
-        branch: release-1.15
-      - repository: api
-        branch: release-1.15
   - source:
       branch: release-1.16
       dir: staging/src/k8s.io/client-go
@@ -202,14 +174,6 @@ rules:
       branch: master
     - repository: client-go
       branch: master
-  - source:
-      branch: release-1.15
-      dir: staging/src/k8s.io/component-base
-    name: release-1.15
-    go: 1.12.17
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.15
   - source:
       branch: release-1.16
       dir: staging/src/k8s.io/component-base
@@ -275,20 +239,6 @@ rules:
       branch: master
     - repository: component-base
       branch: master
-  - source:
-      branch: release-1.15
-      dir: staging/src/k8s.io/apiserver
-    name: release-1.15
-    go: 1.12.17
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.15
-    - repository: api
-      branch: release-1.15
-    - repository: client-go
-      branch: release-12.0
-    - repository: component-base
-      branch: release-1.15
   - source:
       branch: release-1.16
       dir: staging/src/k8s.io/apiserver
@@ -365,24 +315,6 @@ rules:
       branch: master
     - repository: code-generator
       branch: master
-  - source:
-      branch: release-1.15
-      dir: staging/src/k8s.io/kube-aggregator
-    name: release-1.15
-    go: 1.12.17
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.15
-    - repository: api
-      branch: release-1.15
-    - repository: client-go
-      branch: release-12.0
-    - repository: apiserver
-      branch: release-1.15
-    - repository: component-base
-      branch: release-1.15
-    - repository: code-generator
-      branch: release-1.15
   - source:
       branch: release-1.16
       dir: staging/src/k8s.io/kube-aggregator
@@ -475,26 +407,6 @@ rules:
       branch: master
     - repository: component-base
       branch: master
-    required-packages:
-    - k8s.io/code-generator
-  - source:
-      branch: release-1.15
-      dir: staging/src/k8s.io/sample-apiserver
-    name: release-1.15
-    go: 1.12.17
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.15
-    - repository: api
-      branch: release-1.15
-    - repository: client-go
-      branch: release-12.0
-    - repository: apiserver
-      branch: release-1.15
-    - repository: code-generator
-      branch: release-1.15
-    - repository: component-base
-      branch: release-1.15
     required-packages:
     - k8s.io/code-generator
   - source:
@@ -599,22 +511,6 @@ rules:
     required-packages:
     - k8s.io/code-generator
   - source:
-      branch: release-1.15
-      dir: staging/src/k8s.io/sample-controller
-    name: release-1.15
-    go: 1.12.17
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.15
-    - repository: api
-      branch: release-1.15
-    - repository: client-go
-      branch: release-12.0
-    - repository: code-generator
-      branch: release-1.15
-    required-packages:
-    - k8s.io/code-generator
-  - source:
       branch: release-1.16
       dir: staging/src/k8s.io/sample-controller
     name: release-1.16
@@ -701,26 +597,6 @@ rules:
       branch: master
     - repository: component-base
       branch: master
-    required-packages:
-    - k8s.io/code-generator
-  - source:
-      branch: release-1.15
-      dir: staging/src/k8s.io/apiextensions-apiserver
-    name: release-1.15
-    go: 1.12.17
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.15
-    - repository: api
-      branch: release-1.15
-    - repository: client-go
-      branch: release-12.0
-    - repository: apiserver
-      branch: release-1.15
-    - repository: code-generator
-      branch: release-1.15
-    - repository: component-base
-      branch: release-1.15
     required-packages:
     - k8s.io/code-generator
   - source:
@@ -821,20 +697,6 @@ rules:
     - repository: code-generator
       branch: master
   - source:
-      branch: release-1.15
-      dir: staging/src/k8s.io/metrics
-    name: release-1.15
-    go: 1.12.17
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.15
-    - repository: api
-      branch: release-1.15
-    - repository: client-go
-      branch: release-12.0
-    - repository: code-generator
-      branch: release-1.15
-  - source:
       branch: release-1.16
       dir: staging/src/k8s.io/metrics
     name: release-1.16
@@ -906,18 +768,6 @@ rules:
     - repository: client-go
       branch: master
   - source:
-      branch: release-1.15
-      dir: staging/src/k8s.io/cli-runtime
-    name: release-1.15
-    go: 1.12.17
-    dependencies:
-    - repository: api
-      branch: release-1.15
-    - repository: apimachinery
-      branch: release-1.15
-    - repository: client-go
-      branch: release-12.0
-  - source:
       branch: release-1.16
       dir: staging/src/k8s.io/cli-runtime
     name: release-1.16
@@ -982,20 +832,6 @@ rules:
       branch: master
     - repository: client-go
       branch: master
-  - source:
-      branch: release-1.15
-      dir: staging/src/k8s.io/sample-cli-plugin
-    name: release-1.15
-    go: 1.12.17
-    dependencies:
-    - repository: api
-      branch: release-1.15
-    - repository: apimachinery
-      branch: release-1.15
-    - repository: cli-runtime
-      branch: release-1.15
-    - repository: client-go
-      branch: release-12.0
   - source:
       branch: release-1.16
       dir: staging/src/k8s.io/sample-cli-plugin
@@ -1070,16 +906,6 @@ rules:
     - repository: client-go
       branch: master
   - source:
-      branch: release-1.15
-      dir: staging/src/k8s.io/kube-proxy
-    name: release-1.15
-    go: 1.12.17
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.15
-    - repository: component-base
-      branch: release-1.15
-  - source:
       branch: release-1.16
       dir: staging/src/k8s.io/kube-proxy
     name: release-1.16
@@ -1153,16 +979,6 @@ rules:
     - repository: component-base
       branch: master
   - source:
-      branch: release-1.15
-      dir: staging/src/k8s.io/kubelet
-    name: release-1.15
-    go: 1.12.17
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.15
-    - repository: api
-      branch: release-1.15
-  - source:
       branch: release-1.16
       dir: staging/src/k8s.io/kubelet
     name: release-1.16
@@ -1223,16 +1039,6 @@ rules:
       branch: master
     - repository: client-go
       branch: master
-  - source:
-      branch: release-1.15
-      dir: staging/src/k8s.io/kube-scheduler
-    name: release-1.15
-    go: 1.12.17
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.15
-    - repository: component-base
-      branch: release-1.15
   - source:
       branch: release-1.16
       dir: staging/src/k8s.io/kube-scheduler
@@ -1307,16 +1113,6 @@ rules:
     - repository: client-go
       branch: master
   - source:
-      branch: release-1.15
-      dir: staging/src/k8s.io/kube-controller-manager
-    name: release-1.15
-    go: 1.12.17
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.15
-    - repository: component-base
-      branch: release-1.15
-  - source:
       branch: release-1.16
       dir: staging/src/k8s.io/kube-controller-manager
     name: release-1.16
@@ -1386,16 +1182,6 @@ rules:
     - repository: api
       branch: master
   - source:
-      branch: release-1.15
-      dir: staging/src/k8s.io/cluster-bootstrap
-    name: release-1.15
-    go: 1.12.17
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.15
-    - repository: api
-      branch: release-1.15
-  - source:
       branch: release-1.16
       dir: staging/src/k8s.io/cluster-bootstrap
     name: release-1.16
@@ -1452,18 +1238,6 @@ rules:
       branch: master
     - repository: component-base
       branch: master
-  - source:
-      branch: release-1.15
-      dir: staging/src/k8s.io/cloud-provider
-    name: release-1.15
-    go: 1.12.17
-    dependencies:
-    - repository: api
-      branch: release-1.15
-    - repository: apimachinery
-      branch: release-1.15
-    - repository: client-go
-      branch: release-12.0
   - source:
       branch: release-1.16
       dir: staging/src/k8s.io/cloud-provider
@@ -1533,20 +1307,6 @@ rules:
       branch: master
     - repository: component-base
       branch: master
-  - source:
-      branch: release-1.15
-      dir: staging/src/k8s.io/csi-translation-lib
-    name: release-1.15
-    go: 1.12.17
-    dependencies:
-    - repository: api
-      branch: release-1.15
-    - repository: apimachinery
-      branch: release-1.15
-    - repository: client-go
-      branch: release-12.0
-    - repository: cloud-provider
-      branch: release-1.15
   - source:
       branch: release-1.16
       dir: staging/src/k8s.io/csi-translation-lib
@@ -1628,22 +1388,6 @@ rules:
       branch: master
     - repository: component-base
       branch: master
-  - source:
-      branch: release-1.15
-      dir: staging/src/k8s.io/legacy-cloud-providers
-    name: release-1.15
-    go: 1.12.17
-    dependencies:
-    - repository: api
-      branch: release-1.15
-    - repository: apimachinery
-      branch: release-1.15
-    - repository: client-go
-      branch: release-12.0
-    - repository: cloud-provider
-      branch: release-1.15
-    - repository: csi-translation-lib
-      branch: release-1.15
   - source:
       branch: release-1.16
       dir: staging/src/k8s.io/legacy-cloud-providers
@@ -1729,20 +1473,6 @@ rules:
   library: true
   branches:
   - source:
-      branch: release-1.15
-      dir: staging/src/k8s.io/node-api
-    name: release-1.15
-    go: 1.12.17
-    dependencies:
-    - repository: api
-      branch: release-1.15
-    - repository: apimachinery
-      branch: release-1.15
-    - repository: client-go
-      branch: release-12.0
-    - repository: code-generator
-      branch: release-1.15
-  - source:
       branch: release-1.16
       dir: staging/src/k8s.io/node-api
     name: release-1.16
@@ -1778,11 +1508,6 @@ rules:
       branch: master
       dir: staging/src/k8s.io/cri-api
     name: master
-  - source:
-      branch: release-1.15
-      dir: staging/src/k8s.io/cri-api
-    name: release-1.15
-    go: 1.12.17
   - source:
       branch: release-1.16
       dir: staging/src/k8s.io/cri-api
@@ -1826,11 +1551,6 @@ rules:
       branch: master
     - repository: metrics
       branch: master
-  - source:
-      branch: release-1.15
-      dir: staging/src/k8s.io/kubectl
-    name: release-1.15
-    go: 1.12.17
   - source:
       branch: release-1.16
       dir: staging/src/k8s.io/kubectl


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes/issues/92944

As per the release timeline (https://github.com/kubernetes/sig-release/tree/master/releases/release-1.19#timeline), the `release-1.19` branches would be created tomorrow. This PR gets the publishing-bot ready for _after_ the branch is cut.

/hold
until `release-1.19` is cut

/assign @dims
for lgtm

/assign @onlydole 
release team lead


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```