### PR TITLE
[client-go] Fix argument ordering for fake scale client update

### DIFF
--- a/staging/src/k8s.io/client-go/scale/fake/client.go
+++ b/staging/src/k8s.io/client-go/scale/fake/client.go
@@ -60,7 +60,7 @@ func (f *fakeNamespacedScaleClient) Get(ctx context.Context, resource schema.Gro
 
 func (f *fakeNamespacedScaleClient) Update(ctx context.Context, resource schema.GroupResource, scale *autoscalingapi.Scale, opts metav1.UpdateOptions) (*autoscalingapi.Scale, error) {
 	obj, err := f.fake.
-		Invokes(testing.NewUpdateSubresourceAction(resource.WithVersion(""), f.namespace, "scale", scale), &autoscalingapi.Scale{})
+		Invokes(testing.NewUpdateSubresourceAction(resource.WithVersion(""), "scale", f.namespace, scale), &autoscalingapi.Scale{})
 
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Fixes the argument order used when calling testing.NewUpdateSubresourceAction
within the fake scale client. This was causing the generated action to swap the values
of the Namespace and Subresource in the Action.

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
