### PR TITLE
Ensure that for RWX volumes expansion is called on all nodes

### DIFF
--- a/pkg/controller/volume/attachdetach/cache/BUILD
+++ b/pkg/controller/volume/attachdetach/cache/BUILD
@@ -19,6 +19,7 @@ go_library(
         "//pkg/volume/util/operationexecutor:go_default_library",
         "//pkg/volume/util/types:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/api/resource:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
         "//vendor/k8s.io/klog/v2:go_default_library",
     ],

--- a/pkg/controller/volume/attachdetach/cache/actual_state_of_world.go
+++ b/pkg/controller/volume/attachdetach/cache/actual_state_of_world.go
@@ -28,7 +28,8 @@ import (
 
 	"k8s.io/klog/v2"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/kubernetes/pkg/volume"
 	"k8s.io/kubernetes/pkg/volume/util"
@@ -252,6 +253,14 @@ func (asw *actualStateOfWorld) MarkVolumeAsUncertain(
 
 func (asw *actualStateOfWorld) MarkVolumeAsAttached(
 	uniqueName v1.UniqueVolumeName, volumeSpec *volume.Spec, nodeName types.NodeName, devicePath string) error {
+	_, err := asw.AddVolumeNode(uniqueName, volumeSpec, nodeName, devicePath, true)
+	return err
+}
+
+// MarkAsAttachedWithSize is same as MarkVolumeAsAttached except we also record pvc size in actualStateOfWorld
+// This is not used in A/D controller
+func (asw *actualStateOfWorld) MarkAsAttachedWithSize(
+	uniqueName v1.UniqueVolumeName, volumeSpec *volume.Spec, nodeName types.NodeName, devicePath string, claimSize resource.Quantity) error {
 	_, err := asw.AddVolumeNode(uniqueName, volumeSpec, nodeName, devicePath, true)
 	return err
 }

--- a/pkg/kubelet/volumemanager/cache/actual_state_of_world_test.go
+++ b/pkg/kubelet/volumemanager/cache/actual_state_of_world_test.go
@@ -20,7 +20,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kubernetes/pkg/volume"
 	volumetesting "k8s.io/kubernetes/pkg/volume/testing"
@@ -31,10 +32,10 @@ import (
 
 var emptyVolumeName = v1.UniqueVolumeName("")
 
-// Calls MarkVolumeAsAttached() once to add volume
+// Calls MarkAsAttachedWithSize() once to add volume
 // Verifies newly added volume exists in GetUnmountedVolumes()
 // Verifies newly added volume doesn't exist in GetGloballyMountedVolumes()
-func Test_MarkVolumeAsAttached_Positive_NewVolume(t *testing.T) {
+func Test_MarkAsAttachedWithSize_Positive_NewVolume(t *testing.T) {
 	// Arrange
 	volumePluginMgr, plugin := volumetesting.GetTestVolumePluginMgr(t)
 	asw := NewActualStateOfWorld("mynode" /* nodeName */, volumePluginMgr)
@@ -64,11 +65,11 @@ func Test_MarkVolumeAsAttached_Positive_NewVolume(t *testing.T) {
 	}
 
 	// Act
-	err = asw.MarkVolumeAsAttached(emptyVolumeName, volumeSpec, "" /* nodeName */, devicePath)
+	err = asw.MarkAsAttachedWithSize(emptyVolumeName, volumeSpec, "" /* nodeName */, devicePath, resource.Quantity{Format: resource.BinarySI})
 
 	// Assert
 	if err != nil {
-		t.Fatalf("MarkVolumeAsAttached failed. Expected: <no error> Actual: <%v>", err)
+		t.Fatalf("MarkAsAttachedWithSize failed. Expected: <no error> Actual: <%v>", err)
 	}
 
 	verifyVolumeExistsAsw(t, generatedVolumeName, true /* shouldExist */, asw)
@@ -76,12 +77,12 @@ func Test_MarkVolumeAsAttached_Positive_NewVolume(t *testing.T) {
 	verifyVolumeDoesntExistInGloballyMountedVolumes(t, generatedVolumeName, asw)
 }
 
-// Calls MarkVolumeAsAttached() once to add volume, specifying a name --
+// Calls MarkAsAttachedWithSize() once to add volume, specifying a name --
 // establishes that the supplied volume name is used to register the volume
 // rather than the generated one.
 // Verifies newly added volume exists in GetUnmountedVolumes()
 // Verifies newly added volume doesn't exist in GetGloballyMountedVolumes()
-func Test_MarkVolumeAsAttached_SuppliedVolumeName_Positive_NewVolume(t *testing.T) {
+func Test_MarkAsAttachedWithSize_SuppliedVolumeName_Positive_NewVolume(t *testing.T) {
 	// Arrange
 	volumePluginMgr, _ := volumetesting.GetTestVolumePluginMgr(t)
 	asw := NewActualStateOfWorld("mynode" /* nodeName */, volumePluginMgr)
@@ -108,11 +109,11 @@ func Test_MarkVolumeAsAttached_SuppliedVolumeName_Positive_NewVolume(t *testing.
 	volumeName := v1.UniqueVolumeName("this-would-never-be-a-volume-name")
 
 	// Act
-	err := asw.MarkVolumeAsAttached(volumeName, volumeSpec, "" /* nodeName */, devicePath)
+	err := asw.MarkAsAttachedWithSize(volumeName, volumeSpec, "" /* nodeName */, devicePath, resource.Quantity{Format: resource.BinarySI})
 
 	// Assert
 	if err != nil {
-		t.Fatalf("MarkVolumeAsAttached failed. Expected: <no error> Actual: <%v>", err)
+		t.Fatalf("MarkAsAttachedWithSize failed. Expected: <no error> Actual: <%v>", err)
 	}
 
 	verifyVolumeExistsAsw(t, volumeName, true /* shouldExist */, asw)
@@ -120,11 +121,11 @@ func Test_MarkVolumeAsAttached_SuppliedVolumeName_Positive_NewVolume(t *testing.
 	verifyVolumeDoesntExistInGloballyMountedVolumes(t, volumeName, asw)
 }
 
-// Calls MarkVolumeAsAttached() twice to add the same volume
+// Calls MarkAsAttachedWithSize() twice to add the same volume
 // Verifies second call doesn't fail
 // Verifies newly added volume exists in GetUnmountedVolumes()
 // Verifies newly added volume doesn't exist in GetGloballyMountedVolumes()
-func Test_MarkVolumeAsAttached_Positive_ExistingVolume(t *testing.T) {
+func Test_MarkAsAttachedWithSize_Positive_ExistingVolume(t *testing.T) {
 	// Arrange
 	volumePluginMgr, plugin := volumetesting.GetTestVolumePluginMgr(t)
 	devicePath := "fake/device/path"
@@ -153,17 +154,17 @@ func Test_MarkVolumeAsAttached_Positive_ExistingVolume(t *testing.T) {
 		t.Fatalf("GetUniqueVolumeNameFromSpec failed. Expected: <no error> Actual: <%v>", err)
 	}
 
-	err = asw.MarkVolumeAsAttached(emptyVolumeName, volumeSpec, "" /* nodeName */, devicePath)
+	err = asw.MarkAsAttachedWithSize(emptyVolumeName, volumeSpec, "" /* nodeName */, devicePath, resource.Quantity{Format: resource.BinarySI})
 	if err != nil {
-		t.Fatalf("MarkVolumeAsAttached failed. Expected: <no error> Actual: <%v>", err)
+		t.Fatalf("MarkAsAttachedWithSize failed. Expected: <no error> Actual: <%v>", err)
 	}
 
 	// Act
-	err = asw.MarkVolumeAsAttached(emptyVolumeName, volumeSpec, "" /* nodeName */, devicePath)
+	err = asw.MarkAsAttachedWithSize(emptyVolumeName, volumeSpec, "" /* nodeName */, devicePath, resource.Quantity{Format: resource.BinarySI})
 
 	// Assert
 	if err != nil {
-		t.Fatalf("MarkVolumeAsAttached failed. Expected: <no error> Actual: <%v>", err)
+		t.Fatalf("MarkAsAttachedWithSize failed. Expected: <no error> Actual: <%v>", err)
 	}
 
 	verifyVolumeExistsAsw(t, generatedVolumeName, true /* shouldExist */, asw)
@@ -204,9 +205,9 @@ func Test_AddPodToVolume_Positive_ExistingVolumeNewNode(t *testing.T) {
 		t.Fatalf("GetUniqueVolumeNameFromSpec failed. Expected: <no error> Actual: <%v>", err)
 	}
 
-	err = asw.MarkVolumeAsAttached(emptyVolumeName, volumeSpec, "" /* nodeName */, devicePath)
+	err = asw.MarkAsAttachedWithSize(emptyVolumeName, volumeSpec, "" /* nodeName */, devicePath, resource.Quantity{Format: resource.BinarySI})
 	if err != nil {
-		t.Fatalf("MarkVolumeAsAttached failed. Expected: <no error> Actual: <%v>", err)
+		t.Fatalf("MarkAsAttachedWithSize failed. Expected: <no error> Actual: <%v>", err)
 	}
 	podName := util.GetUniquePodName(pod)
 
@@ -279,9 +280,9 @@ func Test_AddPodToVolume_Positive_ExistingVolumeExistingNode(t *testing.T) {
 		t.Fatalf("GetUniqueVolumeNameFromSpec failed. Expected: <no error> Actual: <%v>", err)
 	}
 
-	err = asw.MarkVolumeAsAttached(emptyVolumeName, volumeSpec, "" /* nodeName */, devicePath)
+	err = asw.MarkAsAttachedWithSize(emptyVolumeName, volumeSpec, "" /* nodeName */, devicePath, resource.Quantity{Format: resource.BinarySI})
 	if err != nil {
-		t.Fatalf("MarkVolumeAsAttached failed. Expected: <no error> Actual: <%v>", err)
+		t.Fatalf("MarkAsAttachedWithSize failed. Expected: <no error> Actual: <%v>", err)
 	}
 	podName := util.GetUniquePodName(pod)
 
@@ -386,9 +387,9 @@ func Test_AddTwoPodsToVolume_Positive(t *testing.T) {
 			generatedVolumeName2, volumeSpec1, volumeSpec2)
 	}
 
-	err = asw.MarkVolumeAsAttached(generatedVolumeName1, volumeSpec1, "" /* nodeName */, devicePath)
+	err = asw.MarkAsAttachedWithSize(generatedVolumeName1, volumeSpec1, "" /* nodeName */, devicePath, resource.Quantity{Format: resource.BinarySI})
 	if err != nil {
-		t.Fatalf("MarkVolumeAsAttached failed. Expected: <no error> Actual: <%v>", err)
+		t.Fatalf("MarkAsAttachedWithSize failed. Expected: <no error> Actual: <%v>", err)
 	}
 	podName1 := util.GetUniquePodName(pod1)
 
@@ -540,7 +541,7 @@ func Test_AddPodToVolume_Negative_VolumeDoesntExist(t *testing.T) {
 	verifyVolumeDoesntExistWithSpecNameInVolumeAsw(t, podName, volumeSpec.Name(), asw)
 }
 
-// Calls MarkVolumeAsAttached() once to add volume
+// Calls MarkAsAttachedWithSize() once to add volume
 // Calls MarkDeviceAsMounted() to mark volume as globally mounted.
 // Verifies newly added volume exists in GetUnmountedVolumes()
 // Verifies newly added volume exists in GetGloballyMountedVolumes()
@@ -574,9 +575,9 @@ func Test_MarkDeviceAsMounted_Positive_NewVolume(t *testing.T) {
 		t.Fatalf("GetUniqueVolumeNameFromSpec failed. Expected: <no error> Actual: <%v>", err)
 	}
 
-	err = asw.MarkVolumeAsAttached(emptyVolumeName, volumeSpec, "" /* nodeName */, devicePath)
+	err = asw.MarkAsAttachedWithSize(emptyVolumeName, volumeSpec, "" /* nodeName */, devicePath, resource.Quantity{Format: resource.BinarySI})
 	if err != nil {
-		t.Fatalf("MarkVolumeAsAttached failed. Expected: <no error> Actual: <%v>", err)
+		t.Fatalf("MarkAsAttachedWithSize failed. Expected: <no error> Actual: <%v>", err)
 	}
 
 	// Act
@@ -621,9 +622,9 @@ func TestUncertainVolumeMounts(t *testing.T) {
 		plugin, volumeSpec1)
 	require.NoError(t, err)
 
-	err = asw.MarkVolumeAsAttached(generatedVolumeName1, volumeSpec1, "" /* nodeName */, devicePath)
+	err = asw.MarkAsAttachedWithSize(generatedVolumeName1, volumeSpec1, "" /* nodeName */, devicePath, resource.Quantity{Format: resource.BinarySI})
 	if err != nil {
-		t.Fatalf("MarkVolumeAsAttached failed. Expected: <no error> Actual: <%v>", err)
+		t.Fatalf("MarkAsAttachedWithSize failed. Expected: <no error> Actual: <%v>", err)
 	}
 	podName1 := util.GetUniquePodName(pod1)
 
@@ -656,7 +657,13 @@ func TestUncertainVolumeMounts(t *testing.T) {
 		t.Fatalf("expected volume %s to be not found in asw", volumeSpec1.Name())
 	}
 
-	volExists, _, _ := asw.PodExistsInVolume(podName1, generatedVolumeName1)
+	vmt := VolumeToMount{
+		VolumeToMount: operationexecutor.VolumeToMount{
+			VolumeName: generatedVolumeName1,
+			PodName:    podName1,
+		},
+	}
+	volExists, _, _ := asw.PodExistsInVolume(vmt)
 	if volExists {
 		t.Fatalf("expected volume %s to not exist in asw", generatedVolumeName1)
 	}
@@ -737,8 +744,13 @@ func verifyPodExistsInVolumeAsw(
 	expectedVolumeName v1.UniqueVolumeName,
 	expectedDevicePath string,
 	asw ActualStateOfWorld) {
-	podExistsInVolume, devicePath, err :=
-		asw.PodExistsInVolume(expectedPodName, expectedVolumeName)
+	vmt := VolumeToMount{
+		VolumeToMount: operationexecutor.VolumeToMount{
+			VolumeName: expectedVolumeName,
+			PodName:    expectedPodName,
+		},
+	}
+	podExistsInVolume, devicePath, err := asw.PodExistsInVolume(vmt)
 	if err != nil {
 		t.Fatalf(
 			"ASW PodExistsInVolume failed. Expected: <no error> Actual: <%v>", err)
@@ -764,8 +776,13 @@ func verifyPodDoesntExistInVolumeAsw(
 	volumeToCheck v1.UniqueVolumeName,
 	expectVolumeToExist bool,
 	asw ActualStateOfWorld) {
-	podExistsInVolume, devicePath, err :=
-		asw.PodExistsInVolume(podToCheck, volumeToCheck)
+	vmt := VolumeToMount{
+		VolumeToMount: operationexecutor.VolumeToMount{
+			VolumeName: volumeToCheck,
+			PodName:    podToCheck,
+		},
+	}
+	podExistsInVolume, devicePath, err := asw.PodExistsInVolume(vmt)
 	if !expectVolumeToExist && err == nil {
 		t.Fatalf(
 			"ASW PodExistsInVolume did not return error. Expected: <error indicating volume does not exist> Actual: <%v>", err)

--- a/pkg/kubelet/volumemanager/metrics/BUILD
+++ b/pkg/kubelet/volumemanager/metrics/BUILD
@@ -39,6 +39,7 @@ go_test(
         "//pkg/volume/util:go_default_library",
         "//pkg/volume/util/operationexecutor:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/api/resource:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
     ],

--- a/pkg/kubelet/volumemanager/metrics/metrics_test.go
+++ b/pkg/kubelet/volumemanager/metrics/metrics_test.go
@@ -19,7 +19,8 @@ package metrics
 import (
 	"testing"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8stypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/kubernetes/pkg/kubelet/volumemanager/cache"
@@ -73,7 +74,7 @@ func TestMetricCollection(t *testing.T) {
 
 	// Add one volume to ActualStateOfWorld
 	devicePath := "fake/device/path"
-	err = asw.MarkVolumeAsAttached("", volumeSpec, "", devicePath)
+	err = asw.MarkAsAttachedWithSize("", volumeSpec, "", devicePath, resource.Quantity{Format: resource.BinarySI})
 	if err != nil {
 		t.Fatalf("MarkVolumeAsAttached failed. Expected: <no error> Actual: <%v>", err)
 	}

--- a/pkg/kubelet/volumemanager/populator/desired_state_of_world_populator_test.go
+++ b/pkg/kubelet/volumemanager/populator/desired_state_of_world_populator_test.go
@@ -894,7 +894,7 @@ func volumeCapacity(size int) v1.ResourceList {
 
 func reconcileASW(asw cache.ActualStateOfWorld, dsw cache.DesiredStateOfWorld, t *testing.T) {
 	for _, volumeToMount := range dsw.GetVolumesToMount() {
-		err := asw.MarkVolumeAsAttached(volumeToMount.VolumeName, volumeToMount.VolumeSpec, "", "")
+		err := asw.MarkAsAttachedWithSize(volumeToMount.VolumeName, volumeToMount.VolumeSpec, "", "", resource.Quantity{Format: resource.BinarySI})
 		if err != nil {
 			t.Fatalf("Unexpected error when MarkVolumeAsAttached: %v", err)
 		}
@@ -936,7 +936,7 @@ func reprocess(dswp *desiredStateOfWorldPopulator, uniquePodName types.UniquePod
 func getResizeRequiredVolumes(dsw cache.DesiredStateOfWorld, asw cache.ActualStateOfWorld) []v1.UniqueVolumeName {
 	resizeRequiredVolumes := []v1.UniqueVolumeName{}
 	for _, volumeToMount := range dsw.GetVolumesToMount() {
-		_, _, err := asw.PodExistsInVolume(volumeToMount.PodName, volumeToMount.VolumeName)
+		_, _, err := asw.PodExistsInVolume(volumeToMount)
 		if cache.IsFSResizeRequiredError(err) {
 			resizeRequiredVolumes = append(resizeRequiredVolumes, volumeToMount.VolumeName)
 		}

--- a/pkg/kubelet/volumemanager/reconciler/BUILD
+++ b/pkg/kubelet/volumemanager/reconciler/BUILD
@@ -22,6 +22,7 @@ go_library(
         "//pkg/volume/util/operationexecutor:go_default_library",
         "//pkg/volume/util/types:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/api/resource:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/wait:go_default_library",

--- a/pkg/volume/csi/expander.go
+++ b/pkg/volume/csi/expander.go
@@ -21,12 +21,15 @@ import (
 	"errors"
 	"fmt"
 
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	api "k8s.io/api/core/v1"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/volume"
 	"k8s.io/kubernetes/pkg/volume/util"
+	volumetypes "k8s.io/kubernetes/pkg/volume/util/types"
 )
 
 var _ volume.NodeExpandableVolumePlugin = &csiPlugin{}
@@ -123,7 +126,25 @@ func (c *csiPlugin) nodeExpandWithClient(
 
 	_, err = csClient.NodeExpandVolume(ctx, opts)
 	if err != nil {
-		return false, fmt.Errorf("Expander.NodeExpand failed to expand the volume : %v", err)
+		if inUseError(err) {
+			return false, volumetypes.NewFailedPreconditionError(err.Error())
+		}
+		return false, err
 	}
 	return true, nil
+}
+
+func inUseError(err error) bool {
+	st, ok := status.FromError(err)
+	if !ok {
+		// not a grpc error
+		return false
+	}
+	// if this is a failed precondition error then that means driver does not support expansion
+	// of in-use volumes
+	// More info - https://github.com/container-storage-interface/spec/blob/master/spec.md#controllerexpandvolume-errors
+	if st.Code() == codes.FailedPrecondition {
+		return true
+	}
+	return false
 }

--- a/pkg/volume/util/operationexecutor/operation_executor.go
+++ b/pkg/volume/util/operationexecutor/operation_executor.go
@@ -195,13 +195,17 @@ type ActualStateOfWorldMounterUpdater interface {
 	MarkDeviceAsUnmounted(volumeName v1.UniqueVolumeName) error
 
 	// Marks the specified volume's file system resize request is finished.
-	MarkVolumeAsResized(podName volumetypes.UniquePodName, volumeName v1.UniqueVolumeName) error
+	MarkVolumeAsResized(volumeName v1.UniqueVolumeName, claimSize resource.Quantity) bool
 
 	// GetDeviceMountState returns mount state of the device in global path
 	GetDeviceMountState(volumeName v1.UniqueVolumeName) DeviceMountState
 
 	// GetVolumeMountState returns mount state of the volume for the Pod
 	GetVolumeMountState(volumName v1.UniqueVolumeName, podName volumetypes.UniquePodName) VolumeMountState
+
+	// MarkForInUseExpansionError marks the volume to have in-use error during expansion.
+	// volume expansion must not be retried for this volume
+	MarkForInUseExpansionError(volumeName v1.UniqueVolumeName)
 }
 
 // ActualStateOfWorldAttacherUpdater defines a set of operations updating the
@@ -215,6 +219,9 @@ type ActualStateOfWorldAttacherUpdater interface {
 	// argument to this method -- since it is used only for attachable
 	// volumes.  See issue 29695.
 	MarkVolumeAsAttached(volumeName v1.UniqueVolumeName, volumeSpec *volume.Spec, nodeName types.NodeName, devicePath string) error
+
+	// MarkAsAttachedWithSize is same as MarkVolumeAsAttached except we also record pvc size in actualStateOfWorld
+	MarkAsAttachedWithSize(volumeName v1.UniqueVolumeName, volumeSpec *volume.Spec, nodeName types.NodeName, devicePath string, claimSize resource.Quantity) error
 
 	// Marks the specified volume as *possibly* attached to the specified node.
 	// If an attach operation fails, the attach/detach controller does not know for certain if the volume is attached or not.

--- a/pkg/volume/util/types/types.go
+++ b/pkg/volume/util/types/types.go
@@ -54,6 +54,30 @@ func (o *GeneratedOperations) Run() (eventErr, detailedErr error) {
 	return o.OperationFunc()
 }
 
+// FailedPrecondition error indicates CSI operation returned failed precondition
+// error
+type FailedPrecondition struct {
+	msg string
+}
+
+func (err *FailedPrecondition) Error() string {
+	return err.msg
+}
+
+// NewFailedPreconditionError returns a new FailedPrecondition error instance
+func NewFailedPreconditionError(msg string) *FailedPrecondition {
+	return &FailedPrecondition{msg: msg}
+}
+
+// IsFailedPreconditionError checks if given error is of type that indicates
+// operation failed with precondition
+func IsFailedPreconditionError(err error) bool {
+	if _, ok := err.(*FailedPrecondition); ok {
+		return true
+	}
+	return false
+}
+
 // TransientOperationFailure indicates operation failed with a transient error
 // and may fix itself when retried.
 type TransientOperationFailure struct {


### PR DESCRIPTION
Also if CSI driver throws volume-in-use error do not retry node expansion.

This PR adds desired size based on PV capacity to desired_state_of_the_world and actual size based on `pvc.Status.Capacity` to actual_state_of_the_world. Actual size is calculated the time when pod enters ASOW. This way if a RWX volume that is node-expanded on one node will not have actual PVC size updated on second node until second node also calls `NodeExpandVolume`. 


Fixes https://github.com/kubernetes/kubernetes/issues/80918 and https://github.com/kubernetes/kubernetes/issues/92931



/kind bug
/sig storage

```release-note
Do not retry NodeExpandVolume if CSI drivers throw volume-in-use error
Call NodeExpandVolume on all RWX nodes
```

