### PR TITLE
Do not set sysctlRouteLocalnet (CVE-2020-8558)

### DIFF
--- a/pkg/proxy/ipvs/proxier.go
+++ b/pkg/proxy/ipvs/proxier.go
@@ -190,7 +190,6 @@ var ipsetWithIptablesChain = []struct {
 }
 
 // In IPVS proxy mode, the following flags need to be set
-const sysctlRouteLocalnet = "net/ipv4/conf/all/route_localnet"
 const sysctlBridgeCallIPTables = "net/bridge/bridge-nf-call-iptables"
 const sysctlVSConnTrack = "net/ipv4/vs/conntrack"
 const sysctlConnReuse = "net/ipv4/vs/conn_reuse_mode"
@@ -361,11 +360,6 @@ func NewProxier(ipt utiliptables.Interface,
 	nodePortAddresses []string,
 	kernelHandler KernelHandler,
 ) (*Proxier, error) {
-	// Set the route_localnet sysctl we need for
-	if err := utilproxy.EnsureSysctl(sysctl, sysctlRouteLocalnet, 1); err != nil {
-		return nil, err
-	}
-
 	// Proxy needs br_netfilter and bridge-nf-call-iptables=1 when containers
 	// are connected to a Linux bridge (but not SDN bridges).  Until most
 	// plugins handle this, log when config is missing


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
/sig network
/area ipvs

**What this PR does / why we need it**:
Don't set sysctlRouteLocalnet when running in IPVS mode to avoid CVE-2020-8558
Accessing a Nodeport from the host network using localhost:Nodeport never worked in IPVS (see #67730)

**Which issue(s) this PR fixes**:
Fixes #92315 (for IPVS mode)

**Does this PR introduce a user-facing change?**:
```release-note
[ACTION REQUIRED] kube-proxy's IPVS proxy mode no longer sets the net.ipv4.conf.all.route_localnet sysctl parameter. Nodes upgrading will have net.ipv4.conf.all.route_localnet set to 1 but new nodes will inherit the system default (usually 0). If you relied on any behavior requiring net.ipv4.conf.all.route_localnet, you must set ensure it is enabled as kube-proxy will no longer set it automatically. This change helps to further mitigate CVE-2020-8558.
```
