### PR TITLE
Fix an error in PreBindPlugin comment

### DIFF
--- a/pkg/scheduler/framework/v1alpha1/interface.go
+++ b/pkg/scheduler/framework/v1alpha1/interface.go
@@ -345,7 +345,7 @@ type ReservePlugin interface {
 }
 
 // PreBindPlugin is an interface that must be implemented by "prebind" plugins.
-// These plugins are called before a pod being scheduled.
+// These plugins are called before a pod is bound.
 type PreBindPlugin interface {
 	Plugin
 	// PreBind is called before binding a pod. All prebind plugins must return


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
It corrected an error in the comment of PreBindPlugin interface.
"_before a pod is being scheduled_"  ->" _before a pod is bound"_

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
None

**Does this PR introduce a user-facing change?**:
No

-->
```release-note
NONE
```
