### PR TITLE
Fix naming inconsistency in scheduler plugin interface comments

### DIFF
--- a/pkg/scheduler/framework/v1alpha1/interface.go
+++ b/pkg/scheduler/framework/v1alpha1/interface.go
@@ -63,14 +63,14 @@ const (
 	// scheduler skip preemption.
 	// The accompanying status message should explain why the pod is unschedulable.
 	Unschedulable
-	// UnschedulableAndUnresolvable is used when a (pre-)filter plugin finds a pod unschedulable and
+	// UnschedulableAndUnresolvable is used when a PreFilter plugin finds a pod unschedulable and
 	// preemption would not change anything. Plugins should return Unschedulable if it is possible
 	// that the pod can get scheduled with preemption.
 	// The accompanying status message should explain why the pod is unschedulable.
 	UnschedulableAndUnresolvable
-	// Wait is used when a permit plugin finds a pod scheduling should wait.
+	// Wait is used when a Permit plugin finds a pod scheduling should wait.
 	Wait
-	// Skip is used when a bind plugin chooses to skip binding.
+	// Skip is used when a Bind plugin chooses to skip binding.
 	Skip
 )
 
@@ -195,9 +195,9 @@ func (p PluginToStatus) Merge() *Status {
 type WaitingPod interface {
 	// GetPod returns a reference to the waiting pod.
 	GetPod() *v1.Pod
-	// GetPendingPlugins returns a list of pending permit plugin's name.
+	// GetPendingPlugins returns a list of pending Permit plugin's name.
 	GetPendingPlugins() []string
-	// Allow declares the waiting pod is allowed to be scheduled by plugin pluginName.
+	// Allow declares the waiting pod is allowed to be scheduled by the plugin named as "pluginName".
 	// If this is the last remaining plugin to allow, then a success signal is delivered
 	// to unblock the pod.
 	Allow(pluginName string)
@@ -234,7 +234,7 @@ type PreFilterExtensions interface {
 	RemovePod(ctx context.Context, state *CycleState, podToSchedule *v1.Pod, podToRemove *v1.Pod, nodeInfo *NodeInfo) *Status
 }
 
-// PreFilterPlugin is an interface that must be implemented by "prefilter" plugins.
+// PreFilterPlugin is an interface that must be implemented by "PreFilter" plugins.
 // These plugins are called at the beginning of the scheduling cycle.
 type PreFilterPlugin interface {
 	Plugin
@@ -273,7 +273,7 @@ type FilterPlugin interface {
 	Filter(ctx context.Context, state *CycleState, pod *v1.Pod, nodeInfo *NodeInfo) *Status
 }
 
-// PostFilterPlugin is an interface for PostFilter plugins. These plugins are called
+// PostFilterPlugin is an interface for "PostFilter" plugins. These plugins are called
 // after a pod cannot be scheduled.
 type PostFilterPlugin interface {
 	Plugin
@@ -290,7 +290,7 @@ type PostFilterPlugin interface {
 	PostFilter(ctx context.Context, state *CycleState, pod *v1.Pod, filteredNodeStatusMap NodeToStatusMap) (*PostFilterResult, *Status)
 }
 
-// PreScorePlugin is an interface for Pre-score plugin. Pre-score is an
+// PreScorePlugin is an interface for "PreScore" plugin. PreScore is an
 // informational extension point. Plugins will be called with a list of nodes
 // that passed the filtering phase. A plugin may use this data to update internal
 // state or to generate logs/metrics.
@@ -310,7 +310,7 @@ type ScoreExtensions interface {
 	NormalizeScore(ctx context.Context, state *CycleState, p *v1.Pod, scores NodeScoreList) *Status
 }
 
-// ScorePlugin is an interface that must be implemented by "score" plugins to rank
+// ScorePlugin is an interface that must be implemented by "Score" plugins to rank
 // nodes that passed the filtering phase.
 type ScorePlugin interface {
 	Plugin
@@ -343,8 +343,8 @@ type ReservePlugin interface {
 	Unreserve(ctx context.Context, state *CycleState, p *v1.Pod, nodeName string)
 }
 
-// PreBindPlugin is an interface that must be implemented by "prebind" plugins.
-// These plugins are called before a pod is bound.
+// PreBindPlugin is an interface that must be implemented by "PreBind" plugins.
+// These plugins are called before a pod being scheduled.
 type PreBindPlugin interface {
 	Plugin
 	// PreBind is called before binding a pod. All prebind plugins must return
@@ -352,7 +352,7 @@ type PreBindPlugin interface {
 	PreBind(ctx context.Context, state *CycleState, p *v1.Pod, nodeName string) *Status
 }
 
-// PostBindPlugin is an interface that must be implemented by "postbind" plugins.
+// PostBindPlugin is an interface that must be implemented by "PostBind" plugins.
 // These plugins are called after a pod is successfully bound to a node.
 type PostBindPlugin interface {
 	Plugin
@@ -363,7 +363,7 @@ type PostBindPlugin interface {
 	PostBind(ctx context.Context, state *CycleState, p *v1.Pod, nodeName string)
 }
 
-// PermitPlugin is an interface that must be implemented by "permit" plugins.
+// PermitPlugin is an interface that must be implemented by "Permit" plugins.
 // These plugins are called before a pod is bound to a node.
 type PermitPlugin interface {
 	Plugin
@@ -376,7 +376,7 @@ type PermitPlugin interface {
 	Permit(ctx context.Context, state *CycleState, p *v1.Pod, nodeName string) (*Status, time.Duration)
 }
 
-// BindPlugin is an interface that must be implemented by "bind" plugins. Bind
+// BindPlugin is an interface that must be implemented by "Bind" plugins. Bind
 // plugins are used to bind a pod to a Node.
 type BindPlugin interface {
 	Plugin
@@ -396,13 +396,13 @@ type Framework interface {
 	// QueueSortFunc returns the function to sort pods in scheduling queue
 	QueueSortFunc() LessFunc
 
-	// RunPreFilterPlugins runs the set of configured prefilter plugins. It returns
+	// RunPreFilterPlugins runs the set of configured PreFilter plugins. It returns
 	// *Status and its code is set to non-success if any of the plugins returns
 	// anything but Success. If a non-success status is returned, then the scheduling
 	// cycle is aborted.
 	RunPreFilterPlugins(ctx context.Context, state *CycleState, pod *v1.Pod) *Status
 
-	// RunFilterPlugins runs the set of configured filter plugins for pod on
+	// RunFilterPlugins runs the set of configured Filter plugins for pod on
 	// the given node. Note that for the node being evaluated, the passed nodeInfo
 	// reference could be different from the one in NodeInfoSnapshot map (e.g., pods
 	// considered to be running on the node could be different). For example, during
@@ -427,61 +427,61 @@ type Framework interface {
 	// status other than Success.
 	RunPreFilterExtensionRemovePod(ctx context.Context, state *CycleState, podToSchedule *v1.Pod, podToAdd *v1.Pod, nodeInfo *NodeInfo) *Status
 
-	// RunPreScorePlugins runs the set of configured pre-score plugins. If any
+	// RunPreScorePlugins runs the set of configured PreScore plugins. If any
 	// of these plugins returns any status other than "Success", the given pod is rejected.
 	RunPreScorePlugins(ctx context.Context, state *CycleState, pod *v1.Pod, nodes []*v1.Node) *Status
 
-	// RunScorePlugins runs the set of configured scoring plugins. It returns a map that
-	// stores for each scoring plugin name the corresponding NodeScoreList(s).
+	// RunScorePlugins runs the set of configured Score plugins. It returns a map that
+	// stores for each Score plugin name the corresponding NodeScoreList(s).
 	// It also returns *Status, which is set to non-success if any of the plugins returns
 	// a non-success status.
 	RunScorePlugins(ctx context.Context, state *CycleState, pod *v1.Pod, nodes []*v1.Node) (PluginToNodeScores, *Status)
 
-	// RunPreBindPlugins runs the set of configured prebind plugins. It returns
+	// RunPreBindPlugins runs the set of configured PreBind plugins. It returns
 	// *Status and its code is set to non-success if any of the plugins returns
 	// anything but Success. If the Status code is "Unschedulable", it is
 	// considered as a scheduling check failure, otherwise, it is considered as an
 	// internal error. In either case the pod is not going to be bound.
 	RunPreBindPlugins(ctx context.Context, state *CycleState, pod *v1.Pod, nodeName string) *Status
 
-	// RunPostBindPlugins runs the set of configured postbind plugins.
+	// RunPostBindPlugins runs the set of configured PostBind plugins.
 	RunPostBindPlugins(ctx context.Context, state *CycleState, pod *v1.Pod, nodeName string)
 
 	// RunReservePluginsReserve runs the Reserve method of the set of
-	// configured reserve plugins. If any of these calls returns an error, it
+	// configured Reserve plugins. If any of these calls returns an error, it
 	// does not continue running the remaining ones and returns the error. In
 	// such case, pod will not be scheduled.
 	RunReservePluginsReserve(ctx context.Context, state *CycleState, pod *v1.Pod, nodeName string) *Status
 
 	// RunReservePluginsUnreserve runs the Unreserve method of the set of
-	// configured reserve plugins.
+	// configured Reserve plugins.
 	RunReservePluginsUnreserve(ctx context.Context, state *CycleState, pod *v1.Pod, nodeName string)
 
-	// RunPermitPlugins runs the set of configured permit plugins. If any of these
+	// RunPermitPlugins runs the set of configured Permit plugins. If any of these
 	// plugins returns a status other than "Success" or "Wait", it does not continue
 	// running the remaining plugins and returns an error. Otherwise, if any of the
 	// plugins returns "Wait", then this function will create and add waiting pod
 	// to a map of currently waiting pods and return status with "Wait" code.
-	// Pod will remain waiting pod for the minimum duration returned by the permit plugins.
+	// Pod will remain waiting pod for the minimum duration returned by the Permit plugins.
 	RunPermitPlugins(ctx context.Context, state *CycleState, pod *v1.Pod, nodeName string) *Status
 
 	// WaitOnPermit will block, if the pod is a waiting pod, until the waiting pod is rejected or allowed.
 	WaitOnPermit(ctx context.Context, pod *v1.Pod) *Status
 
-	// RunBindPlugins runs the set of configured bind plugins. A bind plugin may choose
-	// whether or not to handle the given Pod. If a bind plugin chooses to skip the
+	// RunBindPlugins runs the set of configured Bind plugins. A Bind plugin may choose
+	// whether or not to handle the given Pod. If a Bind plugin chooses to skip the
 	// binding, it should return code=5("skip") status. Otherwise, it should return "Error"
 	// or "Success". If none of the plugins handled binding, RunBindPlugins returns
 	// code=5("skip") status.
 	RunBindPlugins(ctx context.Context, state *CycleState, pod *v1.Pod, nodeName string) *Status
 
-	// HasFilterPlugins returns true if at least one filter plugin is defined.
+	// HasFilterPlugins returns true if at least one Filter plugin is defined.
 	HasFilterPlugins() bool
 
-	// HasPostFilterPlugins returns true if at least one postFilter plugin is defined.
+	// HasPostFilterPlugins returns true if at least one PostFilter plugin is defined.
 	HasPostFilterPlugins() bool
 
-	// HasScorePlugins returns true if at least one score plugin is defined.
+	// HasScorePlugins returns true if at least one Score plugin is defined.
 	HasScorePlugins() bool
 
 	// ListPlugins returns a map of extension point name to list of configured Plugins.


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Fixed the inconsistency in plugin naming in the comments of scheduler plugin interfaces. 
Changed all plugin names referred to in the comments to UpperCamelCase. 

**Which issue(s) this PR fixes**:
No

**Special notes for your reviewer**:
None

**Does this PR introduce a user-facing change?**:
No

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```