### PR TITLE
Automated cherry pick of #91485: fix: make fake.Clientset support streaming logs

### DIFF
--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/BUILD
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/BUILD
@@ -3,6 +3,7 @@ package(default_visibility = ["//visibility:public"])
 load(
     "@io_bazel_rules_go//go:def.bzl",
     "go_library",
+    "go_test",
 )
 
 go_library(
@@ -46,8 +47,10 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/watch:go_default_library",
+        "//staging/src/k8s.io/client-go/kubernetes/scheme:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/typed/core/v1:go_default_library",
         "//staging/src/k8s.io/client-go/rest:go_default_library",
+        "//staging/src/k8s.io/client-go/rest/fake:go_default_library",
         "//staging/src/k8s.io/client-go/testing:go_default_library",
     ],
 )
@@ -63,4 +66,14 @@ filegroup(
     name = "all-srcs",
     srcs = [":package-srcs"],
     tags = ["automanaged"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["fake_pod_expansion_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//staging/src/k8s.io/api/core/v1:go_default_library",
+        "//staging/src/k8s.io/client-go/testing:go_default_library",
+    ],
 )

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_pod_expansion.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_pod_expansion.go
@@ -18,11 +18,17 @@ package fake
 
 import (
 	"context"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	policy "k8s.io/api/policy/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
 	restclient "k8s.io/client-go/rest"
+	fakerest "k8s.io/client-go/rest/fake"
 	core "k8s.io/client-go/testing"
 )
 
@@ -57,7 +63,19 @@ func (c *FakePods) GetLogs(name string, opts *v1.PodLogOptions) *restclient.Requ
 	action.Value = opts
 
 	_, _ = c.Fake.Invokes(action, &v1.Pod{})
-	return &restclient.Request{}
+	fakeClient := &fakerest.RESTClient{
+		Client: fakerest.CreateHTTPClient(func(request *http.Request) (*http.Response, error) {
+			resp := &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       ioutil.NopCloser(strings.NewReader("fake logs")),
+			}
+			return resp, nil
+		}),
+		NegotiatedSerializer: scheme.Codecs.WithoutConversion(),
+		GroupVersion:         podsKind.GroupVersion(),
+		VersionedAPIPath:     fmt.Sprintf("/api/v1/namespaces/%s/pods/%s/log", c.ns, name),
+	}
+	return fakeClient.Request()
 }
 
 func (c *FakePods) Evict(ctx context.Context, eviction *policy.Eviction) error {

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_pod_expansion_test.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_pod_expansion_test.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	cgtesting "k8s.io/client-go/testing"
+)
+
+func TestFakePodsGetLogs(t *testing.T) {
+	fp := FakePods{
+		Fake: &FakeCoreV1{Fake: &cgtesting.Fake{}},
+		ns:   "default",
+	}
+	req := fp.GetLogs("foo", &corev1.PodLogOptions{})
+	body, err := req.Stream(context.Background())
+	if err != nil {
+		t.Fatal("Stream pod logs:", err)
+	}
+	var buf bytes.Buffer
+	n, err := io.Copy(&buf, body)
+	if err != nil {
+		t.Fatal("Read pod logs:", err)
+	}
+	if n == 0 {
+		t.Fatal("Empty log")
+	}
+	err = body.Close()
+	if err != nil {
+		t.Fatal("Close response body:", err)
+	}
+}


### PR DESCRIPTION
Cherry pick of #91485 on release-1.18.

also includes a commit updating copyright date in generated files

#84203: client-go: fake.Clientset doesn't support streaming logs 