### PR TITLE
Bump addon-resizer for metrics-server to 1.8.11

### DIFF
--- a/cluster/addons/metrics-server/metrics-server-deployment.yaml
+++ b/cluster/addons/metrics-server/metrics-server-deployment.yaml
@@ -64,7 +64,7 @@ spec:
           name: https
           protocol: TCP
       - name: metrics-server-nanny
-        image: k8s.gcr.io/addon-resizer:1.8.10
+        image: k8s.gcr.io/addon-resizer:1.8.11
         resources:
           limits:
             cpu: 100m


### PR DESCRIPTION
The current version, 1.8.10, is vulnerable to https://github.com/kubernetes/autoscaler/issues/3294


/kind bug



**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
