### PR TITLE
Automated cherry pick of #92941: Don't return proxied redirects to the client

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/net/http.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/net/http.go
@@ -431,7 +431,7 @@ redirectLoop:
 
 		// Only follow redirects to the same host. Otherwise, propagate the redirect response back.
 		if requireSameHostRedirects && location.Hostname() != originalLocation.Hostname() {
-			break redirectLoop
+			return nil, nil, fmt.Errorf("hostname mismatch: expected %s, found %s", originalLocation.Hostname(), location.Hostname())
 		}
 
 		// Reset the connection.

--- a/staging/src/k8s.io/apimachinery/pkg/util/net/http_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/net/http_test.go
@@ -330,13 +330,13 @@ func TestConnectWithRedirects(t *testing.T) {
 		redirects:   []string{"/1", "/2", "/3", "/4", "/5", "/6", "/7", "/8", "/9", "/10"},
 		expectError: true,
 	}, {
-		desc:              "redirect to different host are prevented",
-		redirects:         []string{"http://example.com/foo"},
-		expectedRedirects: 0,
+		desc:        "redirect to different host are prevented",
+		redirects:   []string{"http://example.com/foo"},
+		expectError: true,
 	}, {
-		desc:              "multiple redirect to different host forbidden",
-		redirects:         []string{"/1", "/2", "/3", "http://example.com/foo"},
-		expectedRedirects: 3,
+		desc:        "multiple redirect to different host forbidden",
+		redirects:   []string{"/1", "/2", "/3", "http://example.com/foo"},
+		expectError: true,
 	}, {
 		desc:              "redirect to different port is allowed",
 		redirects:         []string{"http://HOST/foo"},

--- a/staging/src/k8s.io/apimachinery/pkg/util/proxy/upgradeaware_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/proxy/upgradeaware_test.go
@@ -493,7 +493,7 @@ func (r *noErrorsAllowed) Error(w http.ResponseWriter, req *http.Request, err er
 	r.t.Error(err)
 }
 
-func TestProxyUpgradeErrorResponse(t *testing.T) {
+func TestProxyUpgradeConnectionErrorResponse(t *testing.T) {
 	var (
 		responder   *fakeResponder
 		expectedErr = errors.New("EXPECTED")
@@ -541,7 +541,7 @@ func TestProxyUpgradeErrorResponse(t *testing.T) {
 
 func TestProxyUpgradeErrorResponseTerminates(t *testing.T) {
 	for _, intercept := range []bool{true, false} {
-		for _, code := range []int{200, 400, 500} {
+		for _, code := range []int{400, 500} {
 			t.Run(fmt.Sprintf("intercept=%v,code=%v", intercept, code), func(t *testing.T) {
 				// Set up a backend server
 				backend := http.NewServeMux()
@@ -593,6 +593,49 @@ func TestProxyUpgradeErrorResponseTerminates(t *testing.T) {
 				req.Write(conn)
 				// wait to ensure the handler does not receive the request
 				time.Sleep(time.Second)
+
+				// clean up
+				conn.Close()
+			})
+		}
+	}
+}
+
+func TestProxyUpgradeErrorResponse(t *testing.T) {
+	for _, intercept := range []bool{true, false} {
+		for _, code := range []int{200, 300, 302, 307} {
+			t.Run(fmt.Sprintf("intercept=%v,code=%v", intercept, code), func(t *testing.T) {
+				// Set up a backend server
+				backend := http.NewServeMux()
+				backend.Handle("/hello", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					http.Redirect(w, r, "https://example.com/there", code)
+				}))
+				backendServer := httptest.NewServer(backend)
+				defer backendServer.Close()
+				backendServerURL, _ := url.Parse(backendServer.URL)
+				backendServerURL.Path = "/hello"
+
+				// Set up a proxy pointing to a specific path on the backend
+				proxyHandler := NewUpgradeAwareHandler(backendServerURL, nil, false, false, &fakeResponder{t: t})
+				proxyHandler.InterceptRedirects = intercept
+				proxyHandler.RequireSameHostRedirects = true
+				proxy := httptest.NewServer(proxyHandler)
+				defer proxy.Close()
+				proxyURL, _ := url.Parse(proxy.URL)
+
+				conn, err := net.Dial("tcp", proxyURL.Host)
+				require.NoError(t, err)
+				bufferedReader := bufio.NewReader(conn)
+
+				// Send upgrade request resulting in a non-101 response from the backend
+				req, _ := http.NewRequest("GET", "/", nil)
+				req.Header.Set(httpstream.HeaderConnection, httpstream.HeaderUpgrade)
+				require.NoError(t, req.Write(conn))
+				// Verify we get the correct response and full message body content
+				resp, err := http.ReadResponse(bufferedReader, nil)
+				require.NoError(t, err)
+				assert.Equal(t, fakeStatusCode, resp.StatusCode)
+				resp.Body.Close()
 
 				// clean up
 				conn.Close()


### PR DESCRIPTION
Cherry pick of #92941 on release-1.16.

#92941: Don't return proxied redirects to the client

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.