### PR TITLE
Mark kubectl e2e tests that use deprecated features with [Deprecated]…

### DIFF
--- a/test/e2e/kubectl/kubectl.go
+++ b/test/e2e/kubectl/kubectl.go
@@ -232,7 +232,8 @@ var _ = SIGDescribe("Kubectl alpha client", func() {
 			framework.RunKubectlOrDie("delete", "cronjobs", cjName, nsFlag)
 		})
 
-		ginkgo.It("should create a CronJob", func() {
+		// [Deprecated] because kubectl run --generator=cronjob/v2alpha1 and --schedule are deprecated
+		ginkgo.It("should create a CronJob [Deprecated]", func() {
 			framework.SkipIfMissingResource(f.DynamicClient, cronJobGroupVersionResourceAlpha, f.Namespace.Name)
 
 			schedule := "*/5 * * * ?"
@@ -1643,7 +1644,8 @@ metadata:
 			Testname: Kubectl, run rc
 			Description: Command ‘kubectl run’ MUST create a running rc with default one replicas given a image using the option --image=’httpd’. The running replication controller SHOULD have one container and the container SHOULD be running the image specified in the ‘run’ command. Also there MUST be 1 pod controlled by this replica set running 1 container with the image specified. A ‘kubetctl logs’ command MUST return the logs from the container in the replication controller.
 		*/
-		framework.ConformanceIt("should create an rc from an image ", func() {
+		// [Deprecated] because kubectl run --generator=run/v1 is deprecated
+		framework.ConformanceIt("should create an rc from an image [Deprecated]", func() {
 			ginkgo.By("running the image " + httpdImage)
 			framework.RunKubectlOrDie("run", rcName, "--image="+httpdImage, "--generator=run/v1", nsFlag)
 			ginkgo.By("verifying the rc " + rcName + " was created")
@@ -1704,7 +1706,8 @@ metadata:
 			Testname: Kubectl, rolling update
 			Description: Command ‘kubectl rolling-update’ MUST replace the specified replication controller with a new replication controller by updating one pod at a time to use the new Pod spec.
 		*/
-		framework.ConformanceIt("should support rolling-update to same image ", func() {
+		// [Deprecated] because kubectl run --generator=run/v1 is deprecated
+		framework.ConformanceIt("should support rolling-update to same image [Deprecated]", func() {
 			ginkgo.By("running the image " + httpdImage)
 			framework.RunKubectlOrDie("run", rcName, "--image="+httpdImage, "--generator=run/v1", nsFlag)
 			ginkgo.By("verifying the rc " + rcName + " was created")
@@ -1754,7 +1757,8 @@ metadata:
 			Testname: Kubectl, run deployment
 			Description: Command ‘kubectl run’ MUST create a deployment, with --generator=deployment, when a image name is specified in the run command. After the run command there SHOULD be a deployment that should exist with one container running the specified image. Also there SHOULD be a Pod that is controlled by this deployment, with a container running the specified image.
 		*/
-		framework.ConformanceIt("should create a deployment from an image ", func() {
+		// [Deprecated] because --generator=deployment/apps.v1 is deprecated
+		framework.ConformanceIt("should create a deployment from an image [Deprecated]", func() {
 			ginkgo.By("running the image " + httpdImage)
 			framework.RunKubectlOrDie("run", dName, "--image="+httpdImage, "--generator=deployment/apps.v1", nsFlag)
 			ginkgo.By("verifying the deployment " + dName + " was created")
@@ -1799,7 +1803,8 @@ metadata:
 			Testname: Kubectl, run job
 			Description: Command ‘kubectl run’ MUST create a job, with --generator=job, when a image name is specified in the run command. After the run command there SHOULD be a job that should exist with one container running the specified image. Also there SHOULD be a restart policy on the job spec that SHOULD match the command line.
 		*/
-		framework.ConformanceIt("should create a job from an image when restart is OnFailure ", func() {
+		// [Deprecated] because kubectl run --generator=job/v1 is deprecated
+		framework.ConformanceIt("should create a job from an image when restart is OnFailure [Deprecated]", func() {
 			ginkgo.By("running the image " + httpdImage)
 			framework.RunKubectlOrDie("run", jobName, "--restart=OnFailure", "--generator=job/v1", "--image="+httpdImage, nsFlag)
 			ginkgo.By("verifying the job " + jobName + " was created")
@@ -1830,7 +1835,8 @@ metadata:
 			framework.RunKubectlOrDie("delete", "cronjobs", cjName, nsFlag)
 		})
 
-		ginkgo.It("should create a CronJob", func() {
+		// [Deprecated] because kubectl run --generator=cronjob/v1beta1 and --schedule are deprecated
+		ginkgo.It("should create a CronJob [Deprecated]", func() {
 			framework.SkipIfMissingResource(f.DynamicClient, cronJobGroupVersionResourceBeta, f.Namespace.Name)
 
 			schedule := "*/5 * * * ?"
@@ -1949,7 +1955,8 @@ metadata:
 			Testname: Kubectl, run job with --rm
 			Description: Start a job with a Pod using ‘kubectl run’ but specify --rm=true. Wait for the Pod to start running by verifying that there is output as expected. Now verify that the job has exited and cannot be found. With --rm=true option the job MUST start by running the image specified and then get deleted itself.
 		*/
-		framework.ConformanceIt("should create a job from an image, then delete the job ", func() {
+		// [Deprecated] because kubectl run --generator=job/v1 is deprecated
+		framework.ConformanceIt("should create a job from an image, then delete the job [Deprecated]", func() {
 			nsFlag := fmt.Sprintf("--namespace=%v", ns)
 
 			ginkgo.By("executing a command with run --rm and attach with stdin")


### PR DESCRIPTION
… so they can be filtered out when skew tests are performed

**What type of PR is this?**
/kind failing-test

**What this PR does / why we need it**:
When periodic e2e skew tests are run, [if they are testing deprecated features that were removed one of the skews, the tests fail](https://prow.k8s.io/job-history/gs/kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-new-master-gci-kubectl-skew). This PR changes the name of some of the tests in the 1.17 release branch to include `[Deprecated]` if they use deprecated flags so that the skew tests will skip them.

For each deprecated case, I added a comment explaining the reason [Deprectaed] was added.

**Which issue(s) this PR fixes**:
Fixes #92734

**Special notes for your reviewer**:

**!!! IMPORTANT !!!** 
**This PR is to merge into the 1.17 branch**

I have never submitted a PR to merge into a past branch before, so I'm not 100% sure I'm doing this correctly. Please educate me on the best way, if this is not it. Thanks!

This change should not be needed in the 1.18 and master branches since the e2e tests in those branches do not use deprecated flags.

Related recently-merged PR that allows skew tests to skip deprecated... https://github.com/kubernetes/test-infra/pull/18213

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs

```
