### PR TITLE
Revert #92745: Use Pause image for DisruptionController tests

### DIFF
--- a/test/e2e/apps/disruption.go
+++ b/test/e2e/apps/disruption.go
@@ -461,8 +461,8 @@ func createPodsOrDie(cs kubernetes.Interface, ns string, n int) {
 			Spec: v1.PodSpec{
 				Containers: []v1.Container{
 					{
-						Name:  "donothing",
-						Image: imageutils.GetPauseImageName(),
+						Name:  "busybox",
+						Image: imageutils.GetE2EImage(imageutils.EchoServer),
 					},
 				},
 				RestartPolicy: v1.RestartPolicyAlways,
@@ -506,8 +506,8 @@ func waitForPodsOrDie(cs kubernetes.Interface, ns string, n int) {
 
 func createReplicaSetOrDie(cs kubernetes.Interface, ns string, size int32, exclusive bool) {
 	container := v1.Container{
-		Name:  "donothing",
-		Image: imageutils.GetPauseImageName(),
+		Name:  "busybox",
+		Image: imageutils.GetE2EImage(imageutils.EchoServer),
 	}
 	if exclusive {
 		container.Ports = []v1.ContainerPort{


### PR DESCRIPTION
**What type of PR is this?**

/kind failing-test

**What this PR does / why we need it**:

This reverts commit 9a23ee02

**Which issue(s) this PR fixes**:
#92977

**Special notes for your reviewer**:
n/a

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs

```
