### PR TITLE
[WIP] Investigate failing DisruptionController test

### DIFF
--- a/pkg/registry/core/pod/storage/eviction.go
+++ b/pkg/registry/core/pod/storage/eviction.go
@@ -247,8 +247,7 @@ func (r *EvictionREST) Create(ctx context.Context, name string, obj runtime.Obje
 // canIgnorePDB returns true for pod conditions that allow the pod to be deleted
 // without checking PDBs.
 func canIgnorePDB(pod *api.Pod) bool {
-	if pod.Status.Phase == api.PodSucceeded || pod.Status.Phase == api.PodFailed ||
-		pod.Status.Phase == api.PodPending || !pod.ObjectMeta.DeletionTimestamp.IsZero() {
+	if pod.Status.Phase == api.PodSucceeded || pod.Status.Phase == api.PodFailed || pod.Status.Phase == api.PodPending {
 		return true
 	}
 	return false
@@ -256,7 +255,7 @@ func canIgnorePDB(pod *api.Pod) bool {
 
 func shouldEnforceResourceVersion(pod *api.Pod) bool {
 	// We don't need to enforce ResourceVersion for terminal pods
-	if pod.Status.Phase == api.PodSucceeded || pod.Status.Phase == api.PodFailed || !pod.ObjectMeta.DeletionTimestamp.IsZero() {
+	if pod.Status.Phase == api.PodSucceeded || pod.Status.Phase == api.PodFailed {
 		return false
 	}
 	// Return true for all other pods to ensure we don't race against a pod becoming

--- a/pkg/registry/core/pod/storage/eviction_test.go
+++ b/pkg/registry/core/pod/storage/eviction_test.go
@@ -218,7 +218,6 @@ func TestEvictionIngorePDB(t *testing.T) {
 		podPhase            api.PodPhase
 		podName             string
 		expectedDeleteCount int
-		podTerminating      bool
 	}{
 		{
 			name: "pdbs No disruptions allowed, pod pending, first delete conflict, pod still pending, pod deleted successfully",
@@ -288,19 +287,6 @@ func TestEvictionIngorePDB(t *testing.T) {
 			podName:             "t5",
 			expectedDeleteCount: 1,
 		},
-		{
-			name: "matching pdbs with no disruptions allowed, pod terminating",
-			pdbs: []runtime.Object{&policyv1beta1.PodDisruptionBudget{
-				ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "default"},
-				Spec:       policyv1beta1.PodDisruptionBudgetSpec{Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"a": "true"}}},
-				Status:     policyv1beta1.PodDisruptionBudgetStatus{DisruptionsAllowed: 0},
-			}},
-			eviction:            &policy.Eviction{ObjectMeta: metav1.ObjectMeta{Name: "t6", Namespace: "default"}, DeleteOptions: metav1.NewDeleteOptions(300)},
-			expectError:         false,
-			podName:             "t6",
-			expectedDeleteCount: 1,
-			podTerminating:      true,
-		},
 	}
 
 	for _, tc := range testcases {
@@ -316,11 +302,6 @@ func TestEvictionIngorePDB(t *testing.T) {
 			pod.Spec.NodeName = "foo"
 			if tc.podPhase != "" {
 				pod.Status.Phase = tc.podPhase
-			}
-
-			if tc.podTerminating {
-				currentTime := metav1.Now()
-				pod.ObjectMeta.DeletionTimestamp = &currentTime
 			}
 
 			client := fake.NewSimpleClientset(tc.pdbs...)
@@ -415,10 +396,6 @@ func (ms *mockStore) mutatorDeleteFunc(count int, options *metav1.DeleteOptions)
 	if ms.pod.Name == "t4" {
 		// Always return error for this pod
 		return nil, false, apierrors.NewConflict(resource("tests"), "2", errors.New("message"))
-	}
-	if ms.pod.Name == "t6" {
-		// This pod has a deletionTimestamp and should not raise conflict on delete
-		return nil, true, nil
 	}
 	if count == 1 {
 		// This is a hack to ensure that some test pods don't change phase


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind api-change

/kind bug

> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
