### PR TITLE
apimachinery: remove inactive members from OWNERS

### DIFF
--- a/cmd/kube-controller-manager/OWNERS
+++ b/cmd/kube-controller-manager/OWNERS
@@ -32,7 +32,6 @@ reviewers:
 - madhusudancs
 - mikedanese
 - mml
-- mqliang
 - mwielgus
 - nikhiljindal
 - ping035627
@@ -41,7 +40,6 @@ reviewers:
 - quinton-hoole
 - resouer
 - rootfs
-- rrati
 - saad-ali
 - screeley44
 - sjenning

--- a/pkg/apis/extensions/OWNERS
+++ b/pkg/apis/extensions/OWNERS
@@ -32,7 +32,6 @@ reviewers:
 - mbohlool
 - therc
 - pweil-
-- mqliang
 - lukaszo
 - jianhuiz
 labels:

--- a/pkg/registry/registrytest/OWNERS
+++ b/pkg/registry/registrytest/OWNERS
@@ -19,6 +19,5 @@ reviewers:
 - dims
 - hongchaodeng
 - a-robinson
-- mqliang
 - sdminonne
 - enj

--- a/staging/src/k8s.io/api/extensions/OWNERS
+++ b/staging/src/k8s.io/api/extensions/OWNERS
@@ -32,6 +32,5 @@ reviewers:
 - mbohlool
 - therc
 - pweil-
-- mqliang
 - lukaszo
 - jianhuiz

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/OWNERS
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/OWNERS
@@ -26,6 +26,5 @@ reviewers:
 - mml
 - mbohlool
 - therc
-- mqliang
 - kevin-wangzefeng
 - jianhuiz

--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/OWNERS
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/OWNERS
@@ -24,6 +24,5 @@ reviewers:
 - krousey
 - xiang90
 - resouer
-- mqliang
 - sdminonne
 - enj

--- a/staging/src/k8s.io/apiserver/pkg/storage/OWNERS
+++ b/staging/src/k8s.io/apiserver/pkg/storage/OWNERS
@@ -23,6 +23,4 @@ reviewers:
 - ingvagabund
 - resouer
 - mbohlool
-- mqliang
-- rrati
 - enj

--- a/staging/src/k8s.io/client-go/tools/cache/OWNERS
+++ b/staging/src/k8s.io/client-go/tools/cache/OWNERS
@@ -38,6 +38,5 @@ reviewers:
 - resouer
 - jessfraz
 - mfojtik
-- mqliang
 - sdminonne
 - ncdc


### PR DESCRIPTION
For https://github.com/kubernetes/org/issues/2013

This PR removes inactive members (members who haven't had any contributions since release of v1.11) from apimachinery-related OWNERS files.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

/assign @liggitt 
cc @mrbobbytables @mqliang @rrati 
