### PR TITLE
test/images/pets: remove OWNERS to cleanup inactive members

### DIFF
--- a/test/images/pets/OWNERS
+++ b/test/images/pets/OWNERS
@@ -1,3 +1,0 @@
-approvers:
-  - mkumatag
-  - bprashanth


### PR DESCRIPTION
For kubernetes/org#2013

bprashanth hasn't be active since the release of v1.11. Removing them
from test/images/pets/OWNERS would leave mkumatag as the sole approver.

But mkumatag is also an approver for [test/images/OWNERS](https://github.com/kubernetes/kubernetes/blob/master/test/images/OWNERS) so this commit
removes the test/images/pets/OWNERS completely.

Note: we should try to find more OWNERS for test/images/pets instead,
but this cleanup is a short term solution to avoid the bot suggesting
inactive members for reviews and approval.

/sig testing
/kind cleanup
/assign @mkumatag @listx 
cc @mrbobbytables @bprashanth 


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```