### PR TITLE
cluster/addons/metadata-proxy: cleanup inactive members from OWNERS

### DIFF
--- a/cluster/addons/metadata-proxy/OWNERS
+++ b/cluster/addons/metadata-proxy/OWNERS
@@ -1,10 +1,10 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-- q-lee
 - cjcullen
 - mikedanese
 reviewers:
-- q-lee
 - cjcullen
 - mikedanese
+emeritus_approvers:
+- q-lee


### PR DESCRIPTION
As a part of kubernetes/org#2013, we are cleaning up inactive members from OWNERS who haven't been active since the release of v1.11. This commit removes q-lee from the cluster/addons/metadata-proxy/OWNERS file.


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

/kind cleanup
/priority backlog
/assign @mikedanese @cjcullen 
cc @Q-Lee @mrbobbytables 
