### PR TITLE
test(e2e): ensure agnhost-replica is not on the same node with primary

### DIFF
--- a/test/e2e/testing-manifests/guestbook/agnhost-primary-deployment.yaml.in
+++ b/test/e2e/testing-manifests/guestbook/agnhost-primary-deployment.yaml.in
@@ -16,6 +16,15 @@ spec:
         role: primary
         tier: backend
     spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                app: agnhost
+                role: replica
+                tier: backend
+            topologyKey: kubernetes.io/hostname
       containers:
       - name: primary
         image: {{.AgnhostImage}}

--- a/test/e2e/testing-manifests/guestbook/agnhost-replica-deployment.yaml.in
+++ b/test/e2e/testing-manifests/guestbook/agnhost-replica-deployment.yaml.in
@@ -16,6 +16,15 @@ spec:
         role: replica
         tier: backend
     spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                app: agnhost
+                role: primary
+                tier: backend
+            topologyKey: kubernetes.io/hostname
       containers:
       - name: replica
         image: {{.AgnhostImage}}


### PR DESCRIPTION
Signed-off-by: knight42 <anonymousknight96@gmail.com>

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature

/kind flake

**What this PR does / why we need it**:

Speicify pod anti-affinity to ensure agnhost-replica pods are not on the same node with agnhost-primary pods.

**Which issue(s) this PR fixes**:

Fixes #92973 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
