### PR TITLE
Skip arch dependent kubectl test for non AMD64 nodes

### DIFF
--- a/test/e2e/framework/skipper/skipper.go
+++ b/test/e2e/framework/skipper/skipper.go
@@ -213,6 +213,13 @@ func SkipUnlessNodeOSDistroIs(supportedNodeOsDistros ...string) {
 	}
 }
 
+// SkipUnlessNodeOSArchIs skips if the node OS distro is not included in the supportedNodeOsArchs.
+func SkipUnlessNodeOSArchIs(supportedNodeOsArchs ...string) {
+	if !framework.NodeOSArchIs(supportedNodeOsArchs...) {
+		skipInternalf(1, "Only supported for node OS arch %v (not %s)", supportedNodeOsArchs, framework.TestContext.NodeOSArch)
+	}
+}
+
 // SkipIfNodeOSDistroIs skips if the node OS distro is included in the unsupportedNodeOsDistros.
 func SkipIfNodeOSDistroIs(unsupportedNodeOsDistros ...string) {
 	if framework.NodeOSDistroIs(unsupportedNodeOsDistros...) {

--- a/test/e2e/framework/test_context.go
+++ b/test/e2e/framework/test_context.go
@@ -116,6 +116,7 @@ type TestContextType struct {
 	ImageServiceEndpoint     string
 	MasterOSDistro           string
 	NodeOSDistro             string
+	NodeOSArch               string
 	VerifyServiceAccount     bool
 	DeleteNamespace          bool
 	DeleteNamespaceOnFailure bool
@@ -324,6 +325,7 @@ func RegisterClusterFlags(flags *flag.FlagSet) {
 	flags.StringVar(&TestContext.Prefix, "prefix", "e2e", "A prefix to be added to cloud resources created during testing.")
 	flags.StringVar(&TestContext.MasterOSDistro, "master-os-distro", "debian", "The OS distribution of cluster master (debian, ubuntu, gci, coreos, or custom).")
 	flags.StringVar(&TestContext.NodeOSDistro, "node-os-distro", "debian", "The OS distribution of cluster VM instances (debian, ubuntu, gci, coreos, or custom).")
+	flags.StringVar(&TestContext.NodeOSArch, "node-os-arch", "amd64", "The OS architecture of cluster VM instances (amd64, arm64, or custom).")
 	flags.StringVar(&TestContext.ClusterDNSDomain, "dns-domain", "cluster.local", "The DNS Domain of the cluster.")
 
 	// TODO: Flags per provider?  Rename gce-project/gce-zone?

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -203,6 +203,16 @@ func NodeOSDistroIs(supportedNodeOsDistros ...string) bool {
 	return false
 }
 
+// NodeOSArchIs returns true if the node OS arch is included in the supportedNodeOsArchs. Otherwise false.
+func NodeOSArchIs(supportedNodeOsArchs ...string) bool {
+	for _, arch := range supportedNodeOsArchs {
+		if strings.EqualFold(arch, TestContext.NodeOSArch) {
+			return true
+		}
+	}
+	return false
+}
+
 // DeleteNamespaces deletes all namespaces that match the given delete and skip filters.
 // Filter is by simple strings.Contains; first skip filter, then delete filter.
 // Returns the list of deleted namespaces or an error.

--- a/test/e2e/kubectl/BUILD
+++ b/test/e2e/kubectl/BUILD
@@ -39,6 +39,7 @@ go_library(
         "//test/e2e/framework/node:go_default_library",
         "//test/e2e/framework/pod:go_default_library",
         "//test/e2e/framework/service:go_default_library",
+        "//test/e2e/framework/skipper:go_default_library",
         "//test/e2e/framework/testfiles:go_default_library",
         "//test/e2e/framework/websocket:go_default_library",
         "//test/e2e/scheduling:go_default_library",

--- a/test/e2e/kubectl/kubectl.go
+++ b/test/e2e/kubectl/kubectl.go
@@ -69,6 +69,7 @@ import (
 	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 	e2eservice "k8s.io/kubernetes/test/e2e/framework/service"
+	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
 	e2etestfiles "k8s.io/kubernetes/test/e2e/framework/testfiles"
 	"k8s.io/kubernetes/test/e2e/scheduling"
 	testutils "k8s.io/kubernetes/test/utils"
@@ -646,6 +647,10 @@ var _ = SIGDescribe("Kubectl client", func() {
 		})
 
 		ginkgo.It("should handle in-cluster config", func() {
+			// TODO: Find a way to download and copy the appropriate kubectl binary, or maybe a multi-arch kubectl image
+			// for now this only works on amd64
+			e2eskipper.SkipUnlessNodeOSArchIs("amd64")
+
 			ginkgo.By("adding rbac permissions")
 			// grant the view permission widely to allow inspection of the `invalid` namespace and the default namespace
 			err := e2eauth.BindClusterRole(f.ClientSet.RbacV1(), "view", f.Namespace.Name,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation

/kind failing-test

> /kind feature
> /kind flake

**What this PR does / why we need it**:
The `[sig-cli] Kubectl client Simple pod [It] should handle in-cluster config` test fails on ARM64 setups because it assumes it copies and uses the `kubectl` binary from the host from which tests are run.
https://testgrid.k8s.io/kops-misc#kops-aws-arm64-latest

In most situations the host running the tests is AMD64 based, so it will fail with something like this:
```
<exec.CodeExitError>: {
        Err: {
            s: "error running /workspace/kubernetes/platforms/linux/amd64/kubectl --server=https://api.e2e-kops-aws-arm64-latest.test-cncf-aws.k8s.io --kubeconfig=/tmp/kops584361883/kubeconfig exec --namespace=kubectl-6690 httpd -- /bin/sh -x -c /tmp/kubectl get pods --v=6 2>&1:\nCommand stdout:\n/tmp/kubectl: line 1: syntax error: unterminated quoted string\n\nstderr:\n+ /tmp/kubectl get pods '--v=6'\ncommand terminated with exit code 2\n\nerror:\nexit status 2",
        },
        Code: 2,
    }
```

**Which issue(s) this PR fixes**:
n/a

**Special notes for your reviewer**:
n/a

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
