### PR TITLE
fix func addAllEventHandlers definition

### DIFF
--- a/pkg/scheduler/eventhandlers.go
+++ b/pkg/scheduler/eventhandlers.go
@@ -362,8 +362,7 @@ func (sched *Scheduler) skipPodUpdate(pod *v1.Pod) bool {
 func addAllEventHandlers(
 	sched *Scheduler,
 	informerFactory informers.SharedInformerFactory,
-	podInformer coreinformers.PodInformer,
-) {
+	podInformer coreinformers.PodInformer) {
 	// scheduled pod cache
 	podInformer.Informer().AddEventHandler(
 		cache.FilteringResourceEventHandler{


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

func addAllEventHandlers defined as follows:

func addAllEventHandlers(
	sched *Scheduler,
	informerFactory informers.SharedInformerFactory,
	podInformer coreinformers.PodInformer,
) {

which only used one place:
	addAllEventHandlers(sched, informerFactory, podInformer)

so better to define addAllEventHandlers as:

 func addAllEventHandlers(
	sched *Scheduler,
	informerFactory informers.SharedInformerFactory,
	podInformer coreinformers.PodInformer) {


```
    fix func addAllEventHandlers definition

```
