### PR TITLE
kubelet, cgroupv2: make hugetlb optional

### DIFF
--- a/pkg/kubelet/cm/cgroup_manager_linux.go
+++ b/pkg/kubelet/cm/cgroup_manager_linux.go
@@ -497,6 +497,14 @@ func setResourcesV2(cgroupConfig *libcontainerconfigs.Cgroup) error {
 	}
 	cgroupConfig.Resources.SkipDevices = true
 
+	// if the hugetlb controller is missing
+	supportedControllers := getSupportedUnifiedControllers()
+	if !supportedControllers.Has("hugetlb") {
+		cgroupConfig.Resources.HugetlbLimit = nil
+		// the cgroup is not present, but its not required so skip it
+		klog.V(6).Infof("Optional subsystem not supported: hugetlb")
+	}
+
 	manager, err := cgroupfs2.NewManager(cgroupConfig, cgroupConfig.Path, false)
 	if err != nil {
 		return fmt.Errorf("failed to create cgroup v2 manager: %v", err)


### PR DESCRIPTION
make the hugetlb controller optional when cgroup v2 is used.

Closes: https://github.com/kubernetes/kubernetes/issues/92933

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
/kind bug

**What this PR does / why we need it**:
we can use cgroup v2 with kernel not supporting hugetlb


**Which issue(s) this PR fixes**:
Fixes #92933

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
