### PR TITLE
defaultpodtopologyspread: access listers in plugin instantiation

### DIFF
--- a/pkg/scheduler/framework/plugins/defaultpodtopologyspread/BUILD
+++ b/pkg/scheduler/framework/plugins/defaultpodtopologyspread/BUILD
@@ -8,11 +8,14 @@ go_library(
     deps = [
         "//pkg/scheduler/framework/plugins/helper:go_default_library",
         "//pkg/scheduler/framework/v1alpha1:go_default_library",
+        "//pkg/scheduler/listers:go_default_library",
         "//pkg/scheduler/nodeinfo:go_default_library",
         "//pkg/util/node:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
+        "//staging/src/k8s.io/client-go/listers/apps/v1:go_default_library",
+        "//staging/src/k8s.io/client-go/listers/core/v1:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
     ],
 )

--- a/pkg/scheduler/framework/plugins/defaultpodtopologyspread/default_pod_topology_spread.go
+++ b/pkg/scheduler/framework/plugins/defaultpodtopologyspread/default_pod_topology_spread.go
@@ -25,15 +25,22 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
+	appslisters "k8s.io/client-go/listers/apps/v1"
+	corelisters "k8s.io/client-go/listers/core/v1"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/helper"
 	framework "k8s.io/kubernetes/pkg/scheduler/framework/v1alpha1"
+	sharedlisters "k8s.io/kubernetes/pkg/scheduler/listers"
 	schedulernodeinfo "k8s.io/kubernetes/pkg/scheduler/nodeinfo"
 	utilnode "k8s.io/kubernetes/pkg/util/node"
 )
 
 // DefaultPodTopologySpread is a plugin that calculates selector spread priority.
 type DefaultPodTopologySpread struct {
-	handle framework.FrameworkHandle
+	sharedLister           sharedlisters.SharedLister
+	services               corelisters.ServiceLister
+	replicationControllers corelisters.ReplicationControllerLister
+	replicaSets            appslisters.ReplicaSetLister
+	statefulSets           appslisters.StatefulSetLister
 }
 
 var _ framework.ScorePlugin = &DefaultPodTopologySpread{}
@@ -90,7 +97,7 @@ func (pl *DefaultPodTopologySpread) Score(ctx context.Context, state *framework.
 		return 0, framework.NewStatus(framework.Error, fmt.Sprintf("%+v convert to tainttoleration.preScoreState error", c))
 	}
 
-	nodeInfo, err := pl.handle.SnapshotSharedLister().NodeInfos().Get(nodeName)
+	nodeInfo, err := pl.sharedLister.NodeInfos().Get(nodeName)
 	if err != nil {
 		return 0, framework.NewStatus(framework.Error, fmt.Sprintf("getting node %q from Snapshot: %v", nodeName, err))
 	}
@@ -117,7 +124,7 @@ func (pl *DefaultPodTopologySpread) NormalizeScore(ctx context.Context, state *f
 		if scores[i].Score > maxCountByNodeName {
 			maxCountByNodeName = scores[i].Score
 		}
-		nodeInfo, err := pl.handle.SnapshotSharedLister().NodeInfos().Get(scores[i].Name)
+		nodeInfo, err := pl.sharedLister.NodeInfos().Get(scores[i].Name)
 		if err != nil {
 			return framework.NewStatus(framework.Error, err.Error())
 		}
@@ -148,7 +155,7 @@ func (pl *DefaultPodTopologySpread) NormalizeScore(ctx context.Context, state *f
 		}
 		// If there is zone information present, incorporate it
 		if haveZones {
-			nodeInfo, err := pl.handle.SnapshotSharedLister().NodeInfos().Get(scores[i].Name)
+			nodeInfo, err := pl.sharedLister.NodeInfos().Get(scores[i].Name)
 			if err != nil {
 				return framework.NewStatus(framework.Error, err.Error())
 			}
@@ -180,13 +187,12 @@ func (pl *DefaultPodTopologySpread) ScoreExtensions() framework.ScoreExtensions 
 // PreScore builds and writes cycle state used by Score and NormalizeScore.
 func (pl *DefaultPodTopologySpread) PreScore(ctx context.Context, cycleState *framework.CycleState, pod *v1.Pod, nodes []*v1.Node) *framework.Status {
 	var selector labels.Selector
-	informerFactory := pl.handle.SharedInformerFactory()
 	selector = helper.DefaultSelector(
 		pod,
-		informerFactory.Core().V1().Services().Lister(),
-		informerFactory.Core().V1().ReplicationControllers().Lister(),
-		informerFactory.Apps().V1().ReplicaSets().Lister(),
-		informerFactory.Apps().V1().StatefulSets().Lister(),
+		pl.services,
+		pl.replicationControllers,
+		pl.replicaSets,
+		pl.statefulSets,
 	)
 	state := &preScoreState{
 		selector: selector,
@@ -197,8 +203,20 @@ func (pl *DefaultPodTopologySpread) PreScore(ctx context.Context, cycleState *fr
 
 // New initializes a new plugin and returns it.
 func New(_ *runtime.Unknown, handle framework.FrameworkHandle) (framework.Plugin, error) {
+	sharedLister := handle.SnapshotSharedLister()
+	if sharedLister == nil {
+		return nil, fmt.Errorf("SnapshotSharedLister is nil")
+	}
+	sharedInformerFactory := handle.SharedInformerFactory()
+	if sharedInformerFactory == nil {
+		return nil, fmt.Errorf("SharedInformerFactory is nil")
+	}
 	return &DefaultPodTopologySpread{
-		handle: handle,
+		sharedLister:           sharedLister,
+		services:               sharedInformerFactory.Core().V1().Services().Lister(),
+		replicationControllers: sharedInformerFactory.Core().V1().ReplicationControllers().Lister(),
+		replicaSets:            sharedInformerFactory.Apps().V1().ReplicaSets().Lister(),
+		statefulSets:           sharedInformerFactory.Apps().V1().StatefulSets().Lister(),
 	}, nil
 }
 

--- a/pkg/scheduler/framework/plugins/defaultpodtopologyspread/default_pod_topology_spread_perf_test.go
+++ b/pkg/scheduler/framework/plugins/defaultpodtopologyspread/default_pod_topology_spread_perf_test.go
@@ -67,7 +67,11 @@ func BenchmarkTestSelectorSpreadPriority(b *testing.B) {
 				}
 			}
 			fh, _ := framework.NewFramework(nil, nil, nil, framework.WithSnapshotSharedLister(snapshot), framework.WithInformerFactory(informerFactory))
-			plugin := &DefaultPodTopologySpread{handle: fh}
+			pl, err := New(nil, fh)
+			if err != nil {
+				b.Fatal(err)
+			}
+			plugin := pl.(*DefaultPodTopologySpread)
 			b.ResetTimer()
 
 			for i := 0; i < b.N; i++ {

--- a/pkg/scheduler/framework/plugins/defaultpodtopologyspread/default_pod_topology_spread_test.go
+++ b/pkg/scheduler/framework/plugins/defaultpodtopologyspread/default_pod_topology_spread_test.go
@@ -382,9 +382,11 @@ func TestDefaultPodTopologySpreadScore(t *testing.T) {
 
 			state := framework.NewCycleState()
 
-			plugin := &DefaultPodTopologySpread{
-				handle: fh,
+			pl, err := New(nil, fh)
+			if err != nil {
+				t.Fatal(err)
 			}
+			plugin := pl.(*DefaultPodTopologySpread)
 
 			status := plugin.PreScore(ctx, state, test.pod, nodes)
 			if !status.IsSuccess() {
@@ -633,9 +635,11 @@ func TestZoneSelectorSpreadPriority(t *testing.T) {
 				t.Errorf("error creating new framework handle: %+v", err)
 			}
 
-			plugin := &DefaultPodTopologySpread{
-				handle: fh,
+			pl, err := New(nil, fh)
+			if err != nil {
+				t.Fatal(err)
 			}
+			plugin := pl.(*DefaultPodTopologySpread)
 
 			state := framework.NewCycleState()
 			status := plugin.PreScore(ctx, state, test.pod, nodes)


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

This PR is a cherry pick of https://github.com/kubernetes/kubernetes/pull/92840 into the 1.18 release branch. See that PR for more details.

**Which issue(s) this PR fixes**:

Updates https://github.com/kubernetes/kubernetes/issues/92781

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```

/sig scheduling
/cc @alculquicondor @ahg-g 
