### PR TITLE
Add metav1.SetMetaDataLabel func

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/helpers.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/helpers.go
@@ -201,6 +201,20 @@ func SetMetaDataAnnotation(obj *ObjectMeta, ann string, value string) {
 	obj.Annotations[ann] = value
 }
 
+// HasLabel returns a bool if passed in label exists
+func HasLabel(obj ObjectMeta, label string) bool {
+	_, found := obj.Labels[label]
+	return found
+}
+
+// SetMetaDataLabel sets the label and value
+func SetMetaDataLabel(obj *ObjectMeta, label string, value string) {
+	if obj.Labels == nil {
+		obj.Labels = make(map[string]string)
+	}
+	obj.Labels[label] = value
+}
+
 // SingleObject returns a ListOptions for watching a single object.
 func SingleObject(meta ObjectMeta) ListOptions {
 	return ListOptions{

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/helpers_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/helpers_test.go
@@ -195,3 +195,38 @@ func TestResetObjectMetaForStatus(t *testing.T) {
 		t.Error(diff.ObjectDiff(meta, existingMeta))
 	}
 }
+
+func TestSetMetaDataLabel(t *testing.T) {
+	tests := []struct {
+		obj   *ObjectMeta
+		label string
+		value string
+		want  map[string]string
+	}{
+		{
+			obj:   &ObjectMeta{},
+			label: "foo",
+			value: "bar",
+			want:  map[string]string{"foo": "bar"},
+		},
+		{
+			obj:   &ObjectMeta{Labels: map[string]string{"foo": "bar"}},
+			label: "foo",
+			value: "baz",
+			want:  map[string]string{"foo": "baz"},
+		},
+		{
+			obj:   &ObjectMeta{Labels: map[string]string{"foo": "bar"}},
+			label: "version",
+			value: "1.0.0",
+			want:  map[string]string{"foo": "bar", "version": "1.0.0"},
+		},
+	}
+
+	for _, tc := range tests {
+		SetMetaDataLabel(tc.obj, tc.label, tc.value)
+		if !reflect.DeepEqual(tc.obj.Labels, tc.want) {
+			t.Errorf("got %v, want %v", tc.obj.Labels, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
`k8s.io/apimachinery/pkg/apis/meta/v1` has already utility funcs such as `HasAnnotation` and `SetMetaDataAnnotation`. This PR also adds to the same package the funcs `HasLabel` and `SetMetaDataLabel`. My idea is to prevent boilerplate code on user side like:

```golang
	if obj.Labels == nil {
		obj.Labels = make(map[string]string)
	}
	obj.Labels[label] = value
```

for setting label on `ObjectMeta`.
I believe that the same boilerplate exist also in the k/k code base and the newly added funcs can be useful also there.


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
