### PR TITLE
Write readNetworkingV1NamespacedIngressStatus test - +1 endpoint coverage

### DIFF
--- a/test/e2e/network/BUILD
+++ b/test/e2e/network/BUILD
@@ -49,6 +49,7 @@ go_library(
         "//staging/src/k8s.io/api/rbac/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/fields:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",


### PR DESCRIPTION
**What** type of PR is this?
/kind cleanup

**What** this PR does / why we need it:
This PR adds a test to test the following untested endpoints:
**readNetworkingV1NamespacedIngressStatus**

**Which** issue(s) this PR fixes:
Fixes #93035 

**Special** notes for your reviewer:
Adds +1 endpoint test coverage (good for conformance)

**Does** this PR introduce a user-facing change?:
```
NONE

```

**Release note:**
```release-note
NONE
```

**Additional** documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```
NONE
```

/sig testing
/sig architecture
/area conformance
/area testing
/sig network
/sig api-machinery
/sig apps