### PR TITLE
replace InsecureTLSCiphers function with InsecureTLSCipherNamesUsed

### DIFF
--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -59,7 +59,6 @@ import (
 	"k8s.io/client-go/util/connrotation"
 	"k8s.io/client-go/util/keyutil"
 	cloudprovider "k8s.io/cloud-provider"
-	"k8s.io/component-base/cli/flag"
 	cliflag "k8s.io/component-base/cli/flag"
 	"k8s.io/component-base/configz"
 	"k8s.io/component-base/featuregate"
@@ -1009,15 +1008,8 @@ func InitializeTLS(kf *options.KubeletFlags, kc *kubeletconfiginternal.KubeletCo
 		return nil, err
 	}
 
-	if len(tlsCipherSuites) > 0 {
-		insecureCiphers := flag.InsecureTLSCiphers()
-		for i := 0; i < len(tlsCipherSuites); i++ {
-			for cipherName, cipherID := range insecureCiphers {
-				if tlsCipherSuites[i] == cipherID {
-					klog.Warningf("Use of insecure cipher '%s' detected.", cipherName)
-				}
-			}
-		}
+	for _, cipherName := range cliflag.InsecureTLSCipherNamesUsed(kc.TLSCipherSuites) {
+		klog.Warningf("Use of insecure cipher '%s' detected.", cipherName)
 	}
 
 	minTLSVersion, err := cliflag.TLSVersion(kc.TLSMinVersion)

--- a/staging/src/k8s.io/apiserver/pkg/server/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/server/BUILD
@@ -120,7 +120,6 @@ go_library(
         "//staging/src/k8s.io/apiserver/pkg/util/openapi:go_default_library",
         "//staging/src/k8s.io/client-go/informers:go_default_library",
         "//staging/src/k8s.io/client-go/rest:go_default_library",
-        "//staging/src/k8s.io/component-base/cli/flag:go_default_library",
         "//staging/src/k8s.io/component-base/logs:go_default_library",
         "//vendor/github.com/coreos/go-systemd/daemon:go_default_library",
         "//vendor/github.com/emicklei/go-restful:go_default_library",

--- a/staging/src/k8s.io/apiserver/pkg/server/options/serving.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/serving.go
@@ -260,6 +260,10 @@ func (s *SecureServingOptions) ApplyTo(config **server.SecureServingInfo) error 
 			return err
 		}
 		c.CipherSuites = cipherSuites
+
+		for _, cipherName := range cliflag.InsecureTLSCipherNamesUsed(s.CipherSuites) {
+			klog.Warningf("Use of insecure cipher '%s' detected.", cipherName)
+		}
 	}
 
 	var err error

--- a/staging/src/k8s.io/apiserver/pkg/server/secure_serving.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/secure_serving.go
@@ -29,7 +29,6 @@ import (
 	"time"
 
 	"golang.org/x/net/http2"
-	"k8s.io/component-base/cli/flag"
 	"k8s.io/klog/v2"
 
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -62,14 +61,6 @@ func (s *SecureServingInfo) tlsConfig(stopCh <-chan struct{}) (*tls.Config, erro
 	}
 	if len(s.CipherSuites) > 0 {
 		tlsConfig.CipherSuites = s.CipherSuites
-		insecureCiphers := flag.InsecureTLSCiphers()
-		for i := 0; i < len(s.CipherSuites); i++ {
-			for cipherName, cipherID := range insecureCiphers {
-				if s.CipherSuites[i] == cipherID {
-					klog.Warningf("Use of insecure cipher '%s' detected.", cipherName)
-				}
-			}
-		}
 	}
 
 	if s.ClientCA != nil {

--- a/staging/src/k8s.io/component-base/cli/flag/ciphersuites_flag.go
+++ b/staging/src/k8s.io/component-base/cli/flag/ciphersuites_flag.go
@@ -58,16 +58,6 @@ var insecureCiphers = map[string]uint16{
 	"TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256":   tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,
 }
 
-// InsecureTLSCiphers returns the cipher suites implemented by crypto/tls which have
-// security issues.
-func InsecureTLSCiphers() map[string]uint16 {
-	cipherKeys := make(map[string]uint16, len(insecureCiphers))
-	for k, v := range insecureCiphers {
-		cipherKeys[k] = v
-	}
-	return cipherKeys
-}
-
 // InsecureTLSCipherNames returns a list of cipher suite names implemented by crypto/tls
 // which have security issues.
 func InsecureTLSCipherNames() []string {
@@ -96,6 +86,20 @@ func allCiphers() map[string]uint16 {
 		acceptedCiphers[k] = v
 	}
 	return acceptedCiphers
+}
+
+// InsecureTLSCipherNamesUsed returns the cipher suites names implemented by crypto/tls which have
+// security issues.
+func InsecureTLSCipherNamesUsed(cipherNames []string) []string {
+	insecureCipherNamesMatched := make([]string, 0)
+
+	for _, cipherName := range cipherNames {
+		if _, ok := insecureCiphers[cipherName]; ok {
+			insecureCipherNamesMatched = append(insecureCipherNamesMatched, cipherName)
+		}
+	}
+
+	return insecureCipherNamesMatched
 }
 
 // TLSCipherPossibleValues returns all acceptable cipher suite names.

--- a/staging/src/k8s.io/component-base/cli/flag/ciphersuites_flag_test.go
+++ b/staging/src/k8s.io/component-base/cli/flag/ciphersuites_flag_test.go
@@ -113,3 +113,14 @@ func TestConstantMaps(t *testing.T) {
 		}
 	}
 }
+
+func TestInsecureTLSCipherNamesUsed(t *testing.T) {
+	cipherNames := []string{"TLS_RSA_WITH_RC4_128_SHA", "TLS_RSA_WITH_AES_256_CBC_SHA"}
+
+	expect := []string{"TLS_RSA_WITH_RC4_128_SHA"}
+	actual := InsecureTLSCipherNamesUsed(cipherNames)
+
+	if reflect.DeepEqual(actual, expect) == false {
+		t.Errorf("expected %+v, got %+v", expect, actual)
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**


> /kind cleanup

**What this PR does / why we need it**:

Old insecure cipher are checked by two `for` loops nested and one extra loop to fetch all insecure cipher Info.
The new one will collect insecure ciphers within one loop to check all ciphers in flag valid or not, and remove fussy codes by comparing cipher ids in two place: [here](https://github.com/kubernetes/kubernetes/blob/master/cmd/kubelet/app/server.go#L1012-L1021) and [here](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/apiserver/pkg/server/secure_serving.go#L66-L72).

It is a duplicate PR like https://github.com/kubernetes/kubernetes/pull/91587. For some reason(CI test or milestone), the former one was closed. 


**Which issue(s) this PR fixes**: 
none

Fixes # 
**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
