### PR TITLE
Automated cherry pick of #92227: fix aws loadbalancer vpc cidr calculation

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/aws/aws_loadbalancer.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/aws/aws_loadbalancer.go
@@ -719,6 +719,9 @@ func (c *Cloud) getVpcCidrBlocks() ([]string, error) {
 
 	cidrBlocks := make([]string, 0, len(vpcs.Vpcs[0].CidrBlockAssociationSet))
 	for _, cidr := range vpcs.Vpcs[0].CidrBlockAssociationSet {
+		if aws.StringValue(cidr.CidrBlockState.State) != ec2.VpcCidrBlockStateCodeAssociated {
+			continue
+		}
 		cidrBlocks = append(cidrBlocks, aws.StringValue(cidr.CidrBlock))
 	}
 	return cidrBlocks, nil


### PR DESCRIPTION
Cherry pick of #92227 on release-1.18.

#92227: fix aws loadbalancer vpc cidr calculation

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.