### PR TITLE
Promote Delete Collection Pods e2e test to conformance +1 endpoint coverage

### DIFF
--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -259,6 +259,13 @@
     and FOOSERVICE_PORT_8765_TCP_ADDR that are populated with proper values.
   release: v1.9
   file: test/e2e/common/pods.go
+- testname: Pods, delete a collection
+  codename: '[k8s.io] Pods should delete a collection of pods [Conformance]'
+  description: A set of pods is created with a label selector which MUST be found
+    when listed. The set of pods is deleted and MUST NOT show up when listed by its
+    label selector.
+  release: v1.19
+  file: test/e2e/common/pods.go
 - testname: Pods, assigned hostip
   codename: '[k8s.io] Pods should get a host IP [NodeConformance] [Conformance]'
   description: Create a Pod. Pod status MUST return successfully and contains a valid

--- a/test/e2e/common/pods.go
+++ b/test/e2e/common/pods.go
@@ -832,7 +832,13 @@ var _ = framework.KubeDescribe("Pods", func() {
 
 	})
 
-	ginkgo.It("should delete a collection of pods", func() {
+	/*
+		Release : v1.19
+		Testname: Pods, delete a collection
+		Description: A set of pods is created with a label selector which MUST be found when listed.
+		The set of pods is deleted and MUST NOT show up when listed by its label selector.
+	*/
+	framework.ConformanceIt("should delete a collection of pods", func() {
 		podTestNames := []string{"test-pod-1", "test-pod-2", "test-pod-3"}
 
 		ginkgo.By("Create set of pods")


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it:**
This PR adds a test to test the following untested endpoints:
deleteCoreV1CollectionNamespacedPod

**Testgrid Link**
[Testgrid](https://testgrid.k8s.io/sig-release-master-blocking#gce-cos-master-default&width=5&include-filter-by-regex=should%20delete%20a%20collection%20of%20pods)

**Which issue(s) this PR fixes:**
Fixes #90913 

**Special notes for your reviewer:**
Adds +1 endpoint test coverage (good for conformance)

**Does this PR introduce a user-facing change?:**
```
NONE
```
**Release note:**
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:**
```
NONE
```

/sig testing
/sig architecture
/area conformance