### PR TITLE
disruption uses apps/v1 instead of apps/v1beta1 and extensions/v1beta1

### DIFF
--- a/pkg/controller/disruption/BUILD
+++ b/pkg/controller/disruption/BUILD
@@ -13,9 +13,8 @@ go_library(
     deps = [
         "//pkg/api/v1/pod:go_default_library",
         "//pkg/controller:go_default_library",
-        "//staging/src/k8s.io/api/apps/v1beta1:go_default_library",
+        "//staging/src/k8s.io/api/apps/v1:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
-        "//staging/src/k8s.io/api/extensions/v1beta1:go_default_library",
         "//staging/src/k8s.io/api/policy/v1beta1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/equality:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/errors:go_default_library",

--- a/pkg/controller/disruption/disruption.go
+++ b/pkg/controller/disruption/disruption.go
@@ -21,9 +21,8 @@ import (
 	"fmt"
 	"time"
 
-	apps "k8s.io/api/apps/v1beta1"
-	v1 "k8s.io/api/core/v1"
-	"k8s.io/api/extensions/v1beta1"
+	apps "k8s.io/api/apps/v1"
+	"k8s.io/api/core/v1"
 	policy "k8s.io/api/policy/v1beta1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -179,15 +178,15 @@ func (dc *DisruptionController) finders() []podControllerFinder {
 }
 
 var (
-	controllerKindRS  = v1beta1.SchemeGroupVersion.WithKind("ReplicaSet")
+	controllerKindRS  = apps.SchemeGroupVersion.WithKind("ReplicaSet")
 	controllerKindSS  = apps.SchemeGroupVersion.WithKind("StatefulSet")
 	controllerKindRC  = v1.SchemeGroupVersion.WithKind("ReplicationController")
-	controllerKindDep = v1beta1.SchemeGroupVersion.WithKind("Deployment")
+	controllerKindDep = apps.SchemeGroupVersion.WithKind("Deployment")
 )
 
 // getPodReplicaSet finds a replicaset which has no matching deployments.
 func (dc *DisruptionController) getPodReplicaSet(controllerRef *metav1.OwnerReference, namespace string) (*controllerAndScale, error) {
-	ok, err := verifyGroupKind(controllerRef, controllerKindRS.Kind, []string{"apps", "extensions"})
+	ok, err := verifyGroupKind(controllerRef, controllerKindRS.Kind, []string{"apps"})
 	if !ok || err != nil {
 		return nil, err
 	}
@@ -227,7 +226,7 @@ func (dc *DisruptionController) getPodStatefulSet(controllerRef *metav1.OwnerRef
 
 // getPodDeployments finds deployments for any replicasets which are being managed by deployments.
 func (dc *DisruptionController) getPodDeployment(controllerRef *metav1.OwnerReference, namespace string) (*controllerAndScale, error) {
-	ok, err := verifyGroupKind(controllerRef, controllerKindRS.Kind, []string{"apps", "extensions"})
+	ok, err := verifyGroupKind(controllerRef, controllerKindRS.Kind, []string{"apps"})
 	if !ok || err != nil {
 		return nil, err
 	}
@@ -244,7 +243,7 @@ func (dc *DisruptionController) getPodDeployment(controllerRef *metav1.OwnerRefe
 		return nil, nil
 	}
 
-	ok, err = verifyGroupKind(controllerRef, controllerKindDep.Kind, []string{"apps", "extensions"})
+	ok, err = verifyGroupKind(controllerRef, controllerKindDep.Kind, []string{"apps"})
 	if !ok || err != nil {
 		return nil, err
 	}

--- a/pkg/controller/disruption/disruption_test.go
+++ b/pkg/controller/disruption/disruption_test.go
@@ -952,7 +952,7 @@ func TestDeploymentFinderFunction(t *testing.T) {
 		"happy path": {
 			rsApiVersion:  "apps/v1",
 			rsKind:        controllerKindRS.Kind,
-			depApiVersion: "extensions/v1",
+			depApiVersion: "apps/v1",
 			depKind:       controllerKindDep.Kind,
 			findsScale:    true,
 			expectedScale: 10,
@@ -972,7 +972,7 @@ func TestDeploymentFinderFunction(t *testing.T) {
 			findsScale:    false,
 		},
 		"invalid deployment apiVersion": {
-			rsApiVersion:  "extensions/v1",
+			rsApiVersion:  "apps/v1",
 			rsKind:        controllerKindRS.Kind,
 			depApiVersion: "deployment/v1",
 			depKind:       controllerKindDep.Kind,
@@ -981,7 +981,7 @@ func TestDeploymentFinderFunction(t *testing.T) {
 		"invalid deployment kind": {
 			rsApiVersion:  "apps/v1",
 			rsKind:        controllerKindRS.Kind,
-			depApiVersion: "extensions/v1",
+			depApiVersion: "apps/v1",
 			depKind:       "InvalidKind",
 			findsScale:    false,
 		},


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
/kind deprecation

**What this PR does / why we need it**:
[v1.18 release note](https://kubernetes.io/docs/setup/release/notes/#deprecation) mentions the following.
```
the following deprecated APIs can no longer be served:

    All resources under apps/v1beta1 and apps/v1beta2 - use apps/v1 instead
    daemonsets, deployments, replicasets resources under extensions/v1beta1 - use apps/v1 instead
    networkpolicies resources under extensions/v1beta1 - use networking.k8s.io/v1 instead
    podsecuritypolicies resources under extensions/v1beta1 - use policy/v1beta1 instead
```
From this, I think we should use apps/v1 as much as possible.
pkg/controller/disruption contains apps/v1beta1 and extensions/v1beta1 in order to use replicaset and deployment, so this PR modifies this.

**Which issue(s) this PR fixes**:
Refs #85903

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs

```
