### PR TITLE
fix HandleCrash() order

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/watch/streamwatcher.go
+++ b/staging/src/k8s.io/apimachinery/pkg/watch/streamwatcher.go
@@ -97,9 +97,9 @@ func (sw *StreamWatcher) stopping() bool {
 
 // receive reads result from the decoder in a loop and sends down the result channel.
 func (sw *StreamWatcher) receive() {
+	defer utilruntime.HandleCrash()
 	defer close(sw.result)
 	defer sw.Stop()
-	defer utilruntime.HandleCrash()
 	for {
 		action, obj, err := sw.source.Decode()
 		if err != nil {


### PR DESCRIPTION
What type of PR is this?
/kind bug

What this PR does / why we need it:
HandleCrash() is a final handling func, after HandleCrash(), the process will terminate, and the funcs before it will not be handled, thus should put HandleCrash() to the first line:

func (sw *StreamWatcher) receive() {
	defer close(sw.result)
	defer sw.Stop()
	defer utilruntime.HandleCrash()

```release-note
   fix HandleCrash order
```
