### PR TITLE
 Move kubectl get-context validate logic to Validate function

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/get_contexts.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/get_contexts.go
@@ -73,16 +73,7 @@ func NewCmdConfigGetContexts(streams genericclioptions.IOStreams, configAccess c
 		Long:                  getContextsLong,
 		Example:               getContextsExample,
 		Run: func(cmd *cobra.Command, args []string) {
-			validOutputTypes := sets.NewString("", "json", "yaml", "wide", "name", "custom-columns", "custom-columns-file", "go-template", "go-template-file", "jsonpath", "jsonpath-file")
-			supportedOutputTypes := sets.NewString("", "name")
-			outputFormat := cmdutil.GetFlagString(cmd, "output")
-			if !validOutputTypes.Has(outputFormat) {
-				cmdutil.CheckErr(fmt.Errorf("output must be one of '' or 'name': %v", outputFormat))
-			}
-			if !supportedOutputTypes.Has(outputFormat) {
-				fmt.Fprintf(options.Out, "--output %v is not available in kubectl config get-contexts; resetting to default output format\n", outputFormat)
-				cmd.Flags().Set("output", "")
-			}
+			cmdutil.CheckErr(options.Validate(cmd))
 			cmdutil.CheckErr(options.Complete(cmd, args))
 			cmdutil.CheckErr(options.RunGetContexts())
 		},
@@ -105,6 +96,21 @@ func (o *GetContextsOptions) Complete(cmd *cobra.Command, args []string) error {
 		o.showHeaders = false
 	}
 
+	return nil
+}
+
+// Validate ensures the of output format
+func (o *GetContextsOptions) Validate(cmd *cobra.Command) error {
+	validOutputTypes := sets.NewString("", "json", "yaml", "wide", "name", "custom-columns", "custom-columns-file", "go-template", "go-template-file", "jsonpath", "jsonpath-file")
+	supportedOutputTypes := sets.NewString("", "name")
+	outputFormat := cmdutil.GetFlagString(cmd, "output")
+	if !validOutputTypes.Has(outputFormat) {
+		return fmt.Errorf("output must be one of '' or 'name': %v", outputFormat)
+	}
+	if !supportedOutputTypes.Has(outputFormat) {
+		cmd.Flags().Set("output", "")
+		return fmt.Errorf("--output %v is not available in kubectl config get-contexts; resetting to default output format", outputFormat)
+	}
 	return nil
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup


**What this PR does / why we need it**:
This PR moves validation logic to `Validate` to make the code sync with other commands.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
/assign @soltysh

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

