### PR TITLE
test/e2e/ingress: add missing return to fix panics on !GCE

### DIFF
--- a/test/e2e/network/ingress.go
+++ b/test/e2e/network/ingress.go
@@ -622,10 +622,10 @@ var _ = SIGDescribe("Loadbalancing: L7", func() {
 			}
 			if jig.Ingress == nil {
 				ginkgo.By("No ingress created, no cleanup necessary")
-			} else {
-				ginkgo.By("Deleting ingress")
-				jig.TryDeleteIngress()
+				return
 			}
+			ginkgo.By("Deleting ingress")
+			jig.TryDeleteIngress()
 
 			ginkgo.By("Cleaning up cloud resources")
 			err := gceController.CleanupIngressController()


### PR DESCRIPTION
A missing 'return' causes the AfterEach() to try to clean up
GCE ingress objects when they haven't been created, because
the test was skipped in BeforeEach().

```
2020-07-15T17:21:10.3690332Z [BeforeEach] GCE [Slow] [Feature:kubemci]
2020-07-15T17:21:10.3690715Z   /home/runner/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/test/e2e/network/ingress.go:592
2020-07-15T17:21:10.3690970Z Jul 15 17:21:10.368: INFO: Only supported for providers [gce gke] (not )
2020-07-15T17:21:10.3694003Z [AfterEach] GCE [Slow] [Feature:kubemci]
2020-07-15T17:21:10.3696927Z   /home/runner/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/test/e2e/network/ingress.go:614
2020-07-15T17:21:10.3697845Z [1mSTEP[0m: No ingress created, no cleanup necessary
2020-07-15T17:21:10.3698213Z [1mSTEP[0m: Cleaning up cloud resources
2020-07-15T17:21:15.3709789Z E0715 17:21:15.370134   78875 runtime.go:78] Observed a panic: "invalid memory address or nil pointer dereference" (runtime error: invalid memory address or nil pointer dereference)
2020-07-15T17:21:15.3710883Z goroutine 63 [running]:
2020-07-15T17:21:15.3711892Z [AfterEach] [sig-network] Loadbalancing: L7
2020-07-15T17:21:15.3712802Z k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/runtime.logPanic(0x40215e0, 0x7b71700)
2020-07-15T17:21:15.3713654Z   /home/runner/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:179
2020-07-15T17:21:15.3714871Z 	/home/runner/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:74 +0xa3
2020-07-15T17:21:15.3715130Z Jul 15 17:21:15.370: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
2020-07-15T17:21:15.3715703Z k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/runtime.HandleCrash(0x0, 0x0, 0x0)
2020-07-15T17:21:15.3716215Z 	/home/runner/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:48 +0x82
2020-07-15T17:21:15.3716610Z panic(0x40215e0, 0x7b71700)
2020-07-15T17:21:15.3717184Z 	/opt/hostedtoolcache/go/1.13.4/x64/src/runtime/panic.go:679 +0x1b2
2020-07-15T17:21:15.3717803Z k8s.io/kubernetes/test/e2e/framework/providers/gce.(*IngressController).deleteForwardingRule(0x0, 0x0, 0xc0034cce04, 0x2)
2020-07-15T17:21:15.3718372Z 	/home/runner/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/test/e2e/framework/providers/gce/ingress.go:158 +0x20b
2020-07-15T17:21:15.3718859Z k8s.io/kubernetes/test/e2e/framework/providers/gce.(*IngressController).Cleanup(0x0, 0x0, 0x1, 0xc0034ccd68)
2020-07-15T17:21:15.3719369Z 	/home/runner/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/test/e2e/framework/providers/gce/ingress.go:724 +0x38
2020-07-15T17:21:15.3719947Z k8s.io/kubernetes/test/e2e/framework/providers/gce.(*IngressController).CleanupIngressControllerWithTimeout.func1(0xc0034ccd78, 0xc00315e8a0, 0xc0002acf88)
2020-07-15T17:21:15.3720474Z 	/home/runner/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/test/e2e/framework/providers/gce/ingress.go:88 +0x33
2020-07-15T17:21:15.3720968Z k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/wait.runConditionWithCrashProtection(0xc0034ccfa0, 0xc0034cce00, 0x0, 0x0)
2020-07-15T17:21:15.3721508Z 	/home/runner/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:211 +0x6f
2020-07-15T17:21:15.3722020Z k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/wait.WaitFor(0xc003393120, 0xc0034ccfa0, 0xc00341ae40, 0x0, 0x0)
2020-07-15T17:21:15.3722542Z 	/home/runner/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:528 +0x159
2020-07-15T17:21:15.3723233Z k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/wait.pollInternal(0xc003393120, 0xc0034ccfa0, 0x0, 0x0)
2020-07-15T17:21:15.3723771Z 	/home/runner/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:414 +0x9f
2020-07-15T17:21:15.3724305Z k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/wait.Poll(0x12a05f200, 0xd18c2e2800, 0xc0034ccfa0, 0xc0000a4940, 0xc0034ccfb0)
2020-07-15T17:21:15.3724872Z 	/home/runner/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:408 +0x4d
2020-07-15T17:21:15.3725377Z k8s.io/kubernetes/test/e2e/framework/providers/gce.(*IngressController).CleanupIngressControllerWithTimeout(0x0, 0xd18c2e2800, 0x0, 0x0)
2020-07-15T17:21:15.3726709Z 	/home/runner/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/test/e2e/framework/providers/gce/ingress.go:87 +0x69
2020-07-15T17:21:15.3743725Z k8s.io/kubernetes/test/e2e/framework/providers/gce.(*IngressController).CleanupIngressController(...)
2020-07-15T17:21:15.3744385Z 	/home/runner/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/test/e2e/framework/providers/gce/ingress.go:81
2020-07-15T17:21:15.3744822Z k8s.io/kubernetes/test/e2e/network.glob..func10.4.2()
2020-07-15T17:21:15.3745340Z 	/home/runner/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/test/e2e/network/ingress.go:626 +0x12a
2020-07-15T17:21:15.3745868Z k8s.io/kubernetes/vendor/github.com/onsi/ginkgo/internal/leafnodes.(*runner).runSync(0xc000e17740, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
2020-07-15T17:21:15.3746756Z 	/home/runner/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/github.com/onsi/ginkgo/internal/leafnodes/runner.go:113 +0xb8
```

Fixes: 0f81362fa0bdbe1da154405b67430e476d8776a8

@aojea  @danwinship 

/kind flake
/sig network
/priority important-soon
/milestone v1.19

Fixes #62142

```release-note
NONE
```
