### PR TITLE
kube-up: limit critical pods to kube-system by default

### DIFF
--- a/cluster/gce/addons/admission-resource-quota-critical-pods/resource-quota.yaml
+++ b/cluster/gce/addons/admission-resource-quota-critical-pods/resource-quota.yaml
@@ -1,0 +1,18 @@
+# critical pods are configured as a limited resource by admission_controller_config.yaml,
+# which means they are disallowed unless explicitly allowed by a namespaced quota object.
+# This quota effectively removes the restriction on the number of critical pods allowed in the kube-system namespace.
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: gcp-critical-pods
+  namespace: kube-system
+  labels:
+    addonmanager.kubernetes.io/mode: Reconcile
+spec:
+  hard:
+    pods: "1000000000"
+  scopeSelector:
+    matchExpressions:
+    - operator : In
+      scopeName: PriorityClass
+      values: ["system-node-critical", "system-cluster-critical"]


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

Implements the approach described in https://github.com/kubernetes/kubernetes/pull/76310#discussion_r344902842 for kube-up (xref https://kubernetes.io/docs/concepts/policy/resource-quotas/#limit-priority-class-consumption-by-default)

**Does this PR introduce a user-facing change?**:
```release-note
kube-up: defaults to limiting critical pods to the kube-system namespace to match behavior prior to 1.17
```

/sig scheduling
/cc @ahg-g 