### PR TITLE
Add reset handler to the instrumentation metric library and expose Reset on the metric registries

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/routes/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/routes/metrics.go
@@ -17,9 +17,6 @@ limitations under the License.
 package routes
 
 import (
-	"io"
-	"net/http"
-
 	apimetrics "k8s.io/apiserver/pkg/endpoints/metrics"
 	"k8s.io/apiserver/pkg/server/mux"
 	etcd3metrics "k8s.io/apiserver/pkg/storage/etcd3/metrics"
@@ -43,18 +40,7 @@ type MetricsWithReset struct{}
 // Install adds the MetricsWithReset handler
 func (m MetricsWithReset) Install(c *mux.PathRecorderMux) {
 	register()
-	defaultMetricsHandler := legacyregistry.Handler().ServeHTTP
-	c.HandleFunc("/metrics", func(w http.ResponseWriter, req *http.Request) {
-		if req.Method == "DELETE" {
-			apimetrics.Reset()
-			etcd3metrics.Reset()
-			flowcontrolmetrics.Reset()
-
-			io.WriteString(w, "metrics reset\n")
-			return
-		}
-		defaultMetricsHandler(w, req)
-	})
+	c.Handle("/metrics", legacyregistry.HandlerWithReset())
 }
 
 // register apiserver and etcd metrics

--- a/staging/src/k8s.io/component-base/metrics/BUILD
+++ b/staging/src/k8s.io/component-base/metrics/BUILD
@@ -45,6 +45,7 @@ go_test(
         "desc_test.go",
         "gauge_test.go",
         "histogram_test.go",
+        "http_test.go",
         "opts_test.go",
         "registry_test.go",
         "summary_test.go",

--- a/staging/src/k8s.io/component-base/metrics/http_test.go
+++ b/staging/src/k8s.io/component-base/metrics/http_test.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	apimachineryversion "k8s.io/apimachinery/pkg/version"
+)
+
+func TestResetHandler(t *testing.T) {
+	currentVersion := apimachineryversion.Info{
+		Major:      "1",
+		Minor:      "17",
+		GitVersion: "v1.17.1-alpha-1.12345",
+	}
+	registry := newKubeRegistry(currentVersion)
+	resetHandler := HandlerWithReset(registry, HandlerOpts{})
+	testCases := []struct {
+		desc         string
+		method       string
+		expectedBody string
+	}{
+		{
+			desc:         "Should return empty body on a get",
+			method:       http.MethodGet,
+			expectedBody: "",
+		},
+		{
+			desc:         "Should return 'metrics reset' in the body on a delete",
+			method:       http.MethodDelete,
+			expectedBody: "metrics reset\n",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			req, err := http.NewRequest(tc.method, "http://sample.com/metrics", nil)
+			if err != nil {
+				t.Fatalf("Error creating http request")
+			}
+			rec := httptest.NewRecorder()
+			resetHandler.ServeHTTP(rec, req)
+			body, err := ioutil.ReadAll(rec.Result().Body)
+			if err != nil {
+				t.Fatalf("Error reading response body")
+			}
+			if string(body) != tc.expectedBody {
+				t.Errorf("Got '%s' as the response body, but want '%v'", body, tc.expectedBody)
+			}
+		})
+	}
+}

--- a/staging/src/k8s.io/component-base/metrics/legacyregistry/registry.go
+++ b/staging/src/k8s.io/component-base/metrics/legacyregistry/registry.go
@@ -29,6 +29,18 @@ var (
 	defaultRegistry = metrics.NewKubeRegistry()
 	// DefaultGatherer exposes the global registry gatherer
 	DefaultGatherer metrics.Gatherer = defaultRegistry
+	// Reset calls reset on the global registry
+	Reset = defaultRegistry.Reset
+	// MustRegister registers registerable metrics but uses the global registry.
+	MustRegister = defaultRegistry.MustRegister
+	// RawMustRegister registers prometheus collectors but uses the global registry, this
+	// bypasses the metric stability framework
+	//
+	// Deprecated
+	RawMustRegister = defaultRegistry.RawMustRegister
+
+	// Register registers a collectable metric but uses the global registry
+	Register = defaultRegistry.Register
 )
 
 func init() {
@@ -54,25 +66,6 @@ func HandlerWithReset() http.Handler {
 		metrics.HandlerWithReset(defaultRegistry, metrics.HandlerOpts{}))
 }
 
-// Register registers a collectable metric but uses the global registry
-func Register(c metrics.Registerable) error {
-	err := defaultRegistry.Register(c)
-	return err
-}
-
-// MustRegister registers registerable metrics but uses the global registry.
-func MustRegister(cs ...metrics.Registerable) {
-	defaultRegistry.MustRegister(cs...)
-}
-
-// RawMustRegister registers prometheus collectors but uses the global registry, this
-// bypasses the metric stability framework
-//
-// Deprecated
-func RawMustRegister(cs ...prometheus.Collector) {
-	defaultRegistry.RawMustRegister(cs...)
-}
-
 // CustomRegister registers a custom collector but uses the global registry.
 func CustomRegister(c metrics.StableCollector) error {
 	err := defaultRegistry.CustomRegister(c)
@@ -90,9 +83,4 @@ func CustomMustRegister(cs ...metrics.StableCollector) {
 	for _, c := range cs {
 		prometheus.MustRegister(c)
 	}
-}
-
-// Reset calls reset on the global registry
-func Reset() {
-	defaultRegistry.Reset()
 }

--- a/staging/src/k8s.io/component-base/metrics/legacyregistry/registry.go
+++ b/staging/src/k8s.io/component-base/metrics/legacyregistry/registry.go
@@ -46,6 +46,14 @@ func Handler() http.Handler {
 	return promhttp.InstrumentMetricHandler(prometheus.DefaultRegisterer, promhttp.HandlerFor(defaultRegistry, promhttp.HandlerOpts{}))
 }
 
+// HandlerWithReset returns an HTTP handler for the DefaultGatherer but invokes
+// registry reset if the http method is DELETE.
+func HandlerWithReset() http.Handler {
+	return promhttp.InstrumentMetricHandler(
+		prometheus.DefaultRegisterer,
+		metrics.HandlerWithReset(defaultRegistry, metrics.HandlerOpts{}))
+}
+
 // Register registers a collectable metric but uses the global registry
 func Register(c metrics.Registerable) error {
 	err := defaultRegistry.Register(c)
@@ -82,4 +90,9 @@ func CustomMustRegister(cs ...metrics.StableCollector) {
 	for _, c := range cs {
 		prometheus.MustRegister(c)
 	}
+}
+
+// Reset calls reset on the global registry
+func Reset() {
+	defaultRegistry.Reset()
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup


**What this PR does / why we need it**:

We've had a few issues involving metric registry reset recently (https://github.com/kubernetes/kubernetes/pull/91310 & https://github.com/kubernetes/kubernetes/issues/92671). This PR will fix re-occurrances of the former but not the latter. 


**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/sig instrumentation
/assign @brancz @RainbowMango 
