### PR TITLE
publishing: use go 1.14.6 for master and release-1.19

### DIFF
--- a/staging/publishing/rules.yaml
+++ b/staging/publishing/rules.yaml
@@ -4,6 +4,7 @@ recursive-delete-patterns:
 - BUILD.bazel
 - "*/BUILD.bazel"
 - Gopkg.toml
+default-go-version: 1.14.6
 rules:
 - destination: code-generator
   branches:
@@ -30,7 +31,7 @@ rules:
       branch: release-1.19
       dir: staging/src/k8s.io/code-generator
     name: release-1.19
-    go: 1.14.4
+    go: 1.14.6
 
 - destination: apimachinery
   library: true
@@ -58,7 +59,7 @@ rules:
       branch: release-1.19
       dir: staging/src/k8s.io/apimachinery
     name: release-1.19
-    go: 1.14.4
+    go: 1.14.6
 
 - destination: api
   library: true
@@ -98,7 +99,7 @@ rules:
       branch: release-1.19
       dir: staging/src/k8s.io/api
     name: release-1.19
-    go: 1.14.4
+    go: 1.14.6
     dependencies:
       - repository: apimachinery
         branch: release-1.19
@@ -149,7 +150,7 @@ rules:
       branch: release-1.19
       dir: staging/src/k8s.io/client-go
     name: release-1.19
-    go: 1.14.4
+    go: 1.14.6
     dependencies:
       - repository: apimachinery
         branch: release-1.19
@@ -214,7 +215,7 @@ rules:
       branch: release-1.19
       dir: staging/src/k8s.io/component-base
     name: release-1.19
-    go: 1.14.4
+    go: 1.14.6
     dependencies:
     - repository: apimachinery
       branch: release-1.19
@@ -285,7 +286,7 @@ rules:
       branch: release-1.19
       dir: staging/src/k8s.io/apiserver
     name: release-1.19
-    go: 1.14.4
+    go: 1.14.6
     dependencies:
     - repository: apimachinery
       branch: release-1.19
@@ -373,7 +374,7 @@ rules:
       branch: release-1.19
       dir: staging/src/k8s.io/kube-aggregator
     name: release-1.19
-    go: 1.14.4
+    go: 1.14.6
     dependencies:
     - repository: apimachinery
       branch: release-1.19
@@ -473,7 +474,7 @@ rules:
       branch: release-1.19
       dir: staging/src/k8s.io/sample-apiserver
     name: release-1.19
-    go: 1.14.4
+    go: 1.14.6
     dependencies:
     - repository: apimachinery
       branch: release-1.19
@@ -562,7 +563,7 @@ rules:
       branch: release-1.19
       dir: staging/src/k8s.io/sample-controller
     name: release-1.19
-    go: 1.14.4
+    go: 1.14.6
     dependencies:
     - repository: apimachinery
       branch: release-1.19
@@ -663,7 +664,7 @@ rules:
       branch: release-1.19
       dir: staging/src/k8s.io/apiextensions-apiserver
     name: release-1.19
-    go: 1.14.4
+    go: 1.14.6
     dependencies:
     - repository: apimachinery
       branch: release-1.19
@@ -742,7 +743,7 @@ rules:
       branch: release-1.19
       dir: staging/src/k8s.io/metrics
     name: release-1.19
-    go: 1.14.4
+    go: 1.14.6
     dependencies:
     - repository: apimachinery
       branch: release-1.19
@@ -807,7 +808,7 @@ rules:
       branch: release-1.19
       dir: staging/src/k8s.io/cli-runtime
     name: release-1.19
-    go: 1.14.4
+    go: 1.14.6
     dependencies:
     - repository: api
       branch: release-1.19
@@ -878,7 +879,7 @@ rules:
       branch: release-1.19
       dir: staging/src/k8s.io/sample-cli-plugin
     name: release-1.19
-    go: 1.14.4
+    go: 1.14.6
     dependencies:
     - repository: api
       branch: release-1.19
@@ -951,7 +952,7 @@ rules:
       branch: release-1.19
       dir: staging/src/k8s.io/kube-proxy
     name: release-1.19
-    go: 1.14.4
+    go: 1.14.6
     dependencies:
     - repository: apimachinery
       branch: release-1.19
@@ -1012,7 +1013,7 @@ rules:
       branch: release-1.19
       dir: staging/src/k8s.io/kubelet
     name: release-1.19
-    go: 1.14.4
+    go: 1.14.6
     dependencies:
     - repository: apimachinery
       branch: release-1.19
@@ -1085,7 +1086,7 @@ rules:
       branch: release-1.19
       dir: staging/src/k8s.io/kube-scheduler
     name: release-1.19
-    go: 1.14.4
+    go: 1.14.6
     dependencies:
     - repository: apimachinery
       branch: release-1.19
@@ -1158,7 +1159,7 @@ rules:
       branch: release-1.19
       dir: staging/src/k8s.io/kube-controller-manager
     name: release-1.19
-    go: 1.14.4
+    go: 1.14.6
     dependencies:
     - repository: apimachinery
       branch: release-1.19
@@ -1215,7 +1216,7 @@ rules:
       branch: release-1.19
       dir: staging/src/k8s.io/cluster-bootstrap
     name: release-1.19
-    go: 1.14.4
+    go: 1.14.6
     dependencies:
     - repository: apimachinery
       branch: release-1.19
@@ -1278,7 +1279,7 @@ rules:
       branch: release-1.19
       dir: staging/src/k8s.io/cloud-provider
     name: release-1.19
-    go: 1.14.4
+    go: 1.14.6
     dependencies:
     - repository: api
       branch: release-1.19
@@ -1353,7 +1354,7 @@ rules:
       branch: release-1.19
       dir: staging/src/k8s.io/csi-translation-lib
     name: release-1.19
-    go: 1.14.4
+    go: 1.14.6
     dependencies:
     - repository: api
       branch: release-1.19
@@ -1452,7 +1453,7 @@ rules:
       branch: release-1.19
       dir: staging/src/k8s.io/legacy-cloud-providers
     name: release-1.19
-    go: 1.14.4
+    go: 1.14.6
     dependencies:
     - repository: api
       branch: release-1.19
@@ -1527,7 +1528,7 @@ rules:
       branch: release-1.19
       dir: staging/src/k8s.io/cri-api
     name: release-1.19
-    go: 1.14.4
+    go: 1.14.6
 
 - destination: kubectl
   library: true
@@ -1615,7 +1616,7 @@ rules:
       branch: release-1.19
       dir: staging/src/k8s.io/kubectl
     name: release-1.19
-    go: 1.14.4
+    go: 1.14.6
     dependencies:
     - repository: api
       branch: release-1.19
@@ -1644,4 +1645,4 @@ rules:
       branch: release-1.19
       dir: staging/src/k8s.io/controller-manager
     name: release-1.19
-    go: 1.14.4
+    go: 1.14.6


### PR DESCRIPTION
The `default-go-version` field specifies the go version used for the
master branch, and the go version used when a version is not 
explicitly specified for a release branch.

This commit also updates to go 1.14.6 for the `release-1.19` branch.

https://github.com/kubernetes/publishing-bot/pull/232 adds the `default-go-version` field to the rules file and https://github.com/kubernetes/kubernetes/pull/93198 updates go version to 1.14.6 in k/k.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

/kind cleanup
/hold
this should not merge until https://github.com/kubernetes/publishing-bot/pull/232 is deployed

/assign @sttts @dims @justaugustus 
