### PR TITLE
fix typo release to update

### DIFF
--- a/staging/src/k8s.io/client-go/tools/leaderelection/leaderelection.go
+++ b/staging/src/k8s.io/client-go/tools/leaderelection/leaderelection.go
@@ -294,7 +294,7 @@ func (le *LeaderElector) release() bool {
 		LeaderTransitions: le.observedRecord.LeaderTransitions,
 	}
 	if err := le.config.Lock.Update(context.TODO(), leaderElectionRecord); err != nil {
-		klog.Errorf("Failed to release lock: %v", err)
+		klog.Errorf("Failed to update lock: %v", err)
 		return false
 	}
 	le.observedRecord = leaderElectionRecord


### PR DESCRIPTION
What type of PR is this?
/kind cleanup

What this PR does / why we need it:
following error info release should be update:
func (le *LeaderElector) release() bool {
	if err := le.config.Lock.Update(context.TODO(), leaderElectionRecord); err != nil {
		klog.Errorf("Failed to release lock: %v", err)
		return false
	}

```release-note
   fix typo release to update
```
