### PR TITLE
Add changelogs for 1.16/17 and 18 in the release 1.19 branch

### DIFF
--- a/CHANGELOG/CHANGELOG-1.16.md
+++ b/CHANGELOG/CHANGELOG-1.16.md
@@ -1,0 +1,2838 @@
+<!-- BEGIN MUNGE: GENERATED_TOC -->
+
+- [v1.16.13](#v11613)
+  - [Downloads for v1.16.13](#downloads-for-v11613)
+    - [Source Code](#source-code)
+    - [Client binaries](#client-binaries)
+    - [Server binaries](#server-binaries)
+    - [Node binaries](#node-binaries)
+  - [Changelog since v1.16.12](#changelog-since-v11612)
+  - [Urgent Upgrade Notes](#urgent-upgrade-notes)
+    - [(No, really, you MUST read this before you upgrade)](#no-really-you-must-read-this-before-you-upgrade)
+  - [Changes by Kind](#changes-by-kind)
+    - [Bug or Regression](#bug-or-regression)
+  - [Dependencies](#dependencies)
+    - [Added](#added)
+    - [Changed](#changed)
+    - [Removed](#removed)
+- [v1.16.12](#v11612)
+  - [Downloads for v1.16.12](#downloads-for-v11612)
+    - [Source Code](#source-code-1)
+    - [Client binaries](#client-binaries-1)
+    - [Server binaries](#server-binaries-1)
+    - [Node binaries](#node-binaries-1)
+  - [Changelog since v1.16.11](#changelog-since-v11611)
+  - [Changes by Kind](#changes-by-kind-1)
+    - [API Change](#api-change)
+    - [Bug or Regression](#bug-or-regression-1)
+  - [Dependencies](#dependencies-1)
+    - [Added](#added-1)
+    - [Changed](#changed-1)
+    - [Removed](#removed-1)
+- [v1.16.12-rc.1](#v11612-rc1)
+  - [Downloads for v1.16.12-rc.1](#downloads-for-v11612-rc1)
+    - [Source Code](#source-code-2)
+    - [Client binaries](#client-binaries-2)
+    - [Server binaries](#server-binaries-2)
+    - [Node binaries](#node-binaries-2)
+  - [Changelog since v1.16.11](#changelog-since-v11611-1)
+  - [Changes by Kind](#changes-by-kind-2)
+    - [API Change](#api-change-1)
+    - [Bug or Regression](#bug-or-regression-2)
+  - [Dependencies](#dependencies-2)
+    - [Added](#added-2)
+    - [Changed](#changed-2)
+    - [Removed](#removed-2)
+- [v1.16.11](#v11611)
+  - [Downloads for v1.16.11](#downloads-for-v11611)
+    - [Source Code](#source-code-3)
+    - [Client binaries](#client-binaries-3)
+    - [Server binaries](#server-binaries-3)
+    - [Node binaries](#node-binaries-3)
+  - [Changelog since v1.16.10](#changelog-since-v11610)
+  - [Changes by Kind](#changes-by-kind-3)
+    - [API Change](#api-change-2)
+    - [Feature](#feature)
+    - [Bug or Regression](#bug-or-regression-3)
+    - [Other (Cleanup or Flake)](#other-cleanup-or-flake)
+  - [Dependencies](#dependencies-3)
+    - [Added](#added-3)
+    - [Changed](#changed-3)
+    - [Removed](#removed-3)
+- [v1.16.10](#v11610)
+  - [Downloads for v1.16.10](#downloads-for-v11610)
+    - [Source Code](#source-code-4)
+    - [Client binaries](#client-binaries-4)
+    - [Server binaries](#server-binaries-4)
+    - [Node binaries](#node-binaries-4)
+  - [Changelog since v1.16.9](#changelog-since-v1169)
+  - [Changes by Kind](#changes-by-kind-4)
+    - [API Change](#api-change-3)
+    - [Bug or Regression](#bug-or-regression-4)
+    - [Other (Cleanup or Flake)](#other-cleanup-or-flake-1)
+  - [Dependencies](#dependencies-4)
+    - [Added](#added-4)
+    - [Changed](#changed-4)
+    - [Removed](#removed-4)
+- [v1.16.9](#v1169)
+  - [Downloads for v1.16.9](#downloads-for-v1169)
+    - [Client Binaries](#client-binaries-5)
+    - [Server Binaries](#server-binaries-5)
+    - [Node Binaries](#node-binaries-5)
+  - [Changelog since v1.16.8](#changelog-since-v1168)
+  - [Changes by Kind](#changes-by-kind-5)
+    - [Feature](#feature-1)
+    - [Bug or Regression](#bug-or-regression-5)
+    - [Other (Cleanup or Flake)](#other-cleanup-or-flake-2)
+- [v1.16.8](#v1168)
+  - [Downloads for v1.16.8](#downloads-for-v1168)
+    - [Client Binaries](#client-binaries-6)
+    - [Server Binaries](#server-binaries-6)
+    - [Node Binaries](#node-binaries-6)
+  - [Changelog since v1.16.7](#changelog-since-v1167)
+  - [Changes by Kind](#changes-by-kind-6)
+    - [API Change](#api-change-4)
+    - [Other (Bug, Cleanup or Flake)](#other-bug-cleanup-or-flake)
+- [v1.16.7](#v1167)
+  - [Downloads for v1.16.7](#downloads-for-v1167)
+    - [Client Binaries](#client-binaries-7)
+    - [Server Binaries](#server-binaries-7)
+    - [Node Binaries](#node-binaries-7)
+  - [Changelog since v1.16.6](#changelog-since-v1166)
+  - [Changes by Kind](#changes-by-kind-7)
+    - [Other (Bug, Cleanup or Flake)](#other-bug-cleanup-or-flake-1)
+- [v1.16.6](#v1166)
+  - [Downloads for v1.16.6](#downloads-for-v1166)
+    - [Client Binaries](#client-binaries-8)
+    - [Server Binaries](#server-binaries-8)
+    - [Node Binaries](#node-binaries-8)
+  - [Changelog since v1.16.5](#changelog-since-v1165)
+- [v1.16.5](#v1165)
+  - [Downloads for v1.16.5](#downloads-for-v1165)
+    - [Client Binaries](#client-binaries-9)
+    - [Server Binaries](#server-binaries-9)
+    - [Node Binaries](#node-binaries-9)
+  - [Changelog since v1.16.4](#changelog-since-v1164)
+    - [Other notable changes](#other-notable-changes)
+- [v1.16.4](#v1164)
+  - [Downloads for v1.16.4](#downloads-for-v1164)
+    - [Client Binaries](#client-binaries-10)
+    - [Server Binaries](#server-binaries-10)
+    - [Node Binaries](#node-binaries-10)
+  - [Changelog since v1.16.3](#changelog-since-v1163)
+    - [Other notable changes](#other-notable-changes-1)
+- [v1.16.3](#v1163)
+  - [Downloads for v1.16.3](#downloads-for-v1163)
+    - [Client Binaries](#client-binaries-11)
+    - [Server Binaries](#server-binaries-11)
+    - [Node Binaries](#node-binaries-11)
+  - [Changelog since v1.16.2](#changelog-since-v1162)
+    - [Other notable changes](#other-notable-changes-2)
+- [v1.16.2](#v1162)
+  - [Downloads for v1.16.2](#downloads-for-v1162)
+    - [Client Binaries](#client-binaries-12)
+    - [Server Binaries](#server-binaries-12)
+    - [Node Binaries](#node-binaries-12)
+  - [Changelog since v1.16.1](#changelog-since-v1161)
+    - [Other notable changes](#other-notable-changes-3)
+- [v1.16.1](#v1161)
+  - [Downloads for v1.16.1](#downloads-for-v1161)
+    - [Client Binaries](#client-binaries-13)
+    - [Server Binaries](#server-binaries-13)
+    - [Node Binaries](#node-binaries-13)
+  - [Changelog since v1.16.0](#changelog-since-v1160)
+    - [Other notable changes](#other-notable-changes-4)
+- [v1.16.0](#v1160)
+  - [Downloads for v1.16.0](#downloads-for-v1160)
+    - [Client Binaries](#client-binaries-14)
+    - [Server Binaries](#server-binaries-14)
+    - [Node Binaries](#node-binaries-14)
+- [Kubernetes v1.16.0 Release Notes](#kubernetes-v1160-release-notes)
+  - [What’s New (Major Themes)](#what’s-new-major-themes)
+    - [Additional Notable Feature Updates](#additional-notable-feature-updates)
+  - [Known Issues](#known-issues)
+  - [Urgent Upgrade Notes](#urgent-upgrade-notes-1)
+    - [(No, really, you MUST read this before you upgrade)](#no-really-you-must-read-this-before-you-upgrade-1)
+      - [Cluster Lifecycle](#cluster-lifecycle)
+      - [Storage](#storage)
+    - [Deprecations and Removals](#deprecations-and-removals)
+    - [Metrics Changes](#metrics-changes)
+      - [Added metrics](#added-metrics)
+      - [Removed metrics](#removed-metrics)
+      - [Deprecated/changed metrics](#deprecated/changed-metrics)
+    - [Notable Features](#notable-features)
+      - [Beta](#beta)
+      - [Alpha](#alpha)
+      - [CLI Improvements](#cli-improvements)
+      - [Misc](#misc)
+    - [API Changes](#api-changes)
+    - [Other notable changes](#other-notable-changes-5)
+      - [API Machinery](#api-machinery)
+      - [Apps](#apps)
+      - [Auth](#auth)
+      - [CLI](#cli)
+      - [Cloud Provider](#cloud-provider)
+      - [Cluster Lifecycle](#cluster-lifecycle-1)
+      - [Instrumentation](#instrumentation)
+      - [Network](#network)
+      - [Node](#node)
+      - [Scheduling](#scheduling)
+      - [Storage](#storage-1)
+    - [Testing](#testing)
+      - [Windows](#windows)
+    - [Dependencies](#dependencies-5)
+      - [Changed](#changed-5)
+      - [Unchanged](#unchanged)
+      - [Removed](#removed-5)
+      - [Detailed go Dependency Changes](#detailed-go-dependency-changes)
+        - [Added](#added-5)
+        - [Changed](#changed-6)
+        - [Removed](#removed-6)
+- [v1.16.0-rc.2](#v1160-rc2)
+  - [Downloads for v1.16.0-rc.2](#downloads-for-v1160-rc2)
+    - [Client Binaries](#client-binaries-15)
+    - [Server Binaries](#server-binaries-15)
+    - [Node Binaries](#node-binaries-15)
+  - [Changelog since v1.16.0-rc.1](#changelog-since-v1160-rc1)
+    - [Other notable changes](#other-notable-changes-6)
+- [v1.16.0-rc.1](#v1160-rc1)
+  - [Downloads for v1.16.0-rc.1](#downloads-for-v1160-rc1)
+    - [Client Binaries](#client-binaries-16)
+    - [Server Binaries](#server-binaries-16)
+    - [Node Binaries](#node-binaries-16)
+  - [Changelog since v1.16.0-beta.2](#changelog-since-v1160-beta2)
+    - [Other notable changes](#other-notable-changes-7)
+- [v1.16.0-beta.2](#v1160-beta2)
+  - [Downloads for v1.16.0-beta.2](#downloads-for-v1160-beta2)
+    - [Client Binaries](#client-binaries-17)
+    - [Server Binaries](#server-binaries-17)
+    - [Node Binaries](#node-binaries-17)
+  - [Changelog since v1.16.0-beta.1](#changelog-since-v1160-beta1)
+    - [Other notable changes](#other-notable-changes-8)
+- [v1.16.0-beta.1](#v1160-beta1)
+  - [Downloads for v1.16.0-beta.1](#downloads-for-v1160-beta1)
+    - [Client Binaries](#client-binaries-18)
+    - [Server Binaries](#server-binaries-18)
+    - [Node Binaries](#node-binaries-18)
+  - [Changelog since v1.16.0-alpha.3](#changelog-since-v1160-alpha3)
+    - [Action Required](#action-required)
+    - [Other notable changes](#other-notable-changes-9)
+- [v1.16.0-alpha.3](#v1160-alpha3)
+  - [Downloads for v1.16.0-alpha.3](#downloads-for-v1160-alpha3)
+    - [Client Binaries](#client-binaries-19)
+    - [Server Binaries](#server-binaries-19)
+    - [Node Binaries](#node-binaries-19)
+  - [Changelog since v1.16.0-alpha.2](#changelog-since-v1160-alpha2)
+    - [Action Required](#action-required-1)
+    - [Other notable changes](#other-notable-changes-10)
+- [v1.16.0-alpha.2](#v1160-alpha2)
+  - [Downloads for v1.16.0-alpha.2](#downloads-for-v1160-alpha2)
+    - [Client Binaries](#client-binaries-20)
+    - [Server Binaries](#server-binaries-20)
+    - [Node Binaries](#node-binaries-20)
+  - [Changelog since v1.16.0-alpha.1](#changelog-since-v1160-alpha1)
+    - [Action Required](#action-required-2)
+    - [Other notable changes](#other-notable-changes-11)
+- [v1.16.0-alpha.1](#v1160-alpha1)
+  - [Downloads for v1.16.0-alpha.1](#downloads-for-v1160-alpha1)
+    - [Client Binaries](#client-binaries-21)
+    - [Server Binaries](#server-binaries-21)
+    - [Node Binaries](#node-binaries-21)
+  - [Changelog since v1.15.0](#changelog-since-v1150)
+    - [Action Required](#action-required-3)
+    - [Other notable changes](#other-notable-changes-12)
+
+<!-- END MUNGE: GENERATED_TOC -->
+
+# v1.16.13
+
+
+## Downloads for v1.16.13
+
+### Source Code
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes.tar.gz](https://dl.k8s.io/v1.16.13/kubernetes.tar.gz) | 8491ac95464beb9333e3bc731bfe024af63af568e8fe13ad3ea727338167ec58ee361896e26d4bd0688317f243876b531b07409ef229bbdd659a69093d7c4e7d
+[kubernetes-src.tar.gz](https://dl.k8s.io/v1.16.13/kubernetes-src.tar.gz) | edaca169bcb59b42a165b9343337c0c574fbcfc97291b84a7bd50d38afa468791cde4db983ae9019a6ba0d10e5b0aeba3665690c54139d21a7711e0118d2c517
+
+### Client binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-client-darwin-386.tar.gz](https://dl.k8s.io/v1.16.13/kubernetes-client-darwin-386.tar.gz) | 6e720c2259ec62f0d898804ca55c20ea50034c15a5871b7037edd11c043f95243c792a9fb1890084351ddf3bb7d8ad9e549d80b817f904224033183ddd5ee47b
+[kubernetes-client-darwin-amd64.tar.gz](https://dl.k8s.io/v1.16.13/kubernetes-client-darwin-amd64.tar.gz) | 0fe4ac6853922b7d20b5381991dda48eb9ad11c79b368516e3c1c83227dc617f540f64040550f60bdc2892fc6fda6abc13464a9e51376ccb4ac860fb0154bffb
+[kubernetes-client-linux-386.tar.gz](https://dl.k8s.io/v1.16.13/kubernetes-client-linux-386.tar.gz) | 2d3f59f907311e0ccbc261ac9f0ad24876f6954f2e22d4954456f6c7a1ea99616d97beecf352fc90b225d1ec20df45e599ed0dc9e90f46ac56c843346766fb4f
+[kubernetes-client-linux-amd64.tar.gz](https://dl.k8s.io/v1.16.13/kubernetes-client-linux-amd64.tar.gz) | 587c9f192fbc46e04201906fd8e24c71b18838c13722b743b1d7b60d65cd0c1bd48ffa4bd7e82a9b3f05ff482747f2afde17975e01d2400b14ce3ed864f4308d
+[kubernetes-client-linux-arm.tar.gz](https://dl.k8s.io/v1.16.13/kubernetes-client-linux-arm.tar.gz) | 757f8b512f28d4c62b217dec13963f21bb0dc6ec083deef74974c79f2d989c033a88a8a5d7c206304d2f7499da7343dbc2015f4000e8d38c83fa524283e09721
+[kubernetes-client-linux-arm64.tar.gz](https://dl.k8s.io/v1.16.13/kubernetes-client-linux-arm64.tar.gz) | 6ec7749f380185f8db968964af9822debc509dd4168242a142bbbcd1f2bfb3310534b985c6280f18684e1670d7fbb82806c471a1d87e44c08a13836915f6e9ae
+[kubernetes-client-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.16.13/kubernetes-client-linux-ppc64le.tar.gz) | e34fe6eeb48e40755201e72270077cb7e78e9c9832cae6e6ba59c643f47c2079310577357563908ad79e9d46704eb1abdae93b2671bc7b5afeb0964f4e47f4b5
+[kubernetes-client-linux-s390x.tar.gz](https://dl.k8s.io/v1.16.13/kubernetes-client-linux-s390x.tar.gz) | 1efb4e00b80c6d59472d94e2a016f1e4e48025e7d204a93a89796574c28a6705386fc4eea8a3364083de2b74a0378a61c392b45a975c605f56b1c5192b232a0e
+[kubernetes-client-windows-386.tar.gz](https://dl.k8s.io/v1.16.13/kubernetes-client-windows-386.tar.gz) | ad450577697549e8a492edf4a2cb895c854aa726c3d1025782c1834308619f6123cee1d7072152d7bd5d5e707aa8800e1a88a1a1738813f7aeb9b67d8e12cd1a
+[kubernetes-client-windows-amd64.tar.gz](https://dl.k8s.io/v1.16.13/kubernetes-client-windows-amd64.tar.gz) | 151854b9ad1ddda0f6027248ef369b55f05cc7bb301a2a9def40f4acb62b09612623bf1f862b6ff2f4d51abf12352877c79bbaa6dc37d891ffdab461b70f1441
+
+### Server binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-server-linux-amd64.tar.gz](https://dl.k8s.io/v1.16.13/kubernetes-server-linux-amd64.tar.gz) | 59b9cc215e8cae581c0918fcdfc5bde2dd7ed871e5a71ee9b17fccc2d951e20e74e05abf0091ebd52801b8c998df560860844ab9b1b00d3a76ae3919ca0a338f
+[kubernetes-server-linux-arm.tar.gz](https://dl.k8s.io/v1.16.13/kubernetes-server-linux-arm.tar.gz) | 5d1a9266d1a741933c7e7d5cda3ccefd064d299a35b282df04266aeeab3744ffb160f754c1098413341743ac280405d30e57d2b4a70deb32251a21d79b6f640f
+[kubernetes-server-linux-arm64.tar.gz](https://dl.k8s.io/v1.16.13/kubernetes-server-linux-arm64.tar.gz) | a0bc61b3ae50fd039388caf23d959666169f4f4537db4a835ad6af2035113c36e7249058242b4090ea89f86671d1def8d8a555b2680741a4b741e2b0b2e6a119
+[kubernetes-server-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.16.13/kubernetes-server-linux-ppc64le.tar.gz) | 1636bb2837ec997659648f33505cbaf32e567d6073e6d636180d7a3e603762a8df38d925fe3b7978e218d6e6dc168e884732a4b867dc0b0e60dd3558ab71b5ae
+[kubernetes-server-linux-s390x.tar.gz](https://dl.k8s.io/v1.16.13/kubernetes-server-linux-s390x.tar.gz) | 10db780e2abe2031888ee48c16ea023ffb799937c50c3505357083d7ce2adfc302975d3af1a50312ffd058b3f6902bc0e4c6f47e7be537ccfbbb539f58f36897
+
+### Node binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-node-linux-amd64.tar.gz](https://dl.k8s.io/v1.16.13/kubernetes-node-linux-amd64.tar.gz) | fb2381e684b3260a4d5a3b6410054bc9521f545b3730fd76de8131c6625019290d43fe5d611b774e8f3ff1ed0f2044e6a7104fc2aa30ef9fffa20383d958e415
+[kubernetes-node-linux-arm.tar.gz](https://dl.k8s.io/v1.16.13/kubernetes-node-linux-arm.tar.gz) | 537cd5bcf614cef80409962294b34537e7977224e82aadb66706f3a6c6fcb3de8cc696c7ddea3b04838f006d2a89d289dc38a92e7fd2c7abb8ca77a0b53e4b7f
+[kubernetes-node-linux-arm64.tar.gz](https://dl.k8s.io/v1.16.13/kubernetes-node-linux-arm64.tar.gz) | 07f38550fecc6e9ecbcbbdf74db6ca4ba71b4081d6d7077db9c583da56e6d56ce5bd84211f1f2c3657d8b0dc52c1c533e33e8e174443fd5f170c4168485a0bde
+[kubernetes-node-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.16.13/kubernetes-node-linux-ppc64le.tar.gz) | 34416a3dc2b1e6c38b658c565539246830dec46bb6a0daf093eab0897c82fe0f364102537783dfd802443ddb637df67c13b2fa72035b44a05e2b73b96a3ad594
+[kubernetes-node-linux-s390x.tar.gz](https://dl.k8s.io/v1.16.13/kubernetes-node-linux-s390x.tar.gz) | fdc87ad8aec7cffbf0f95d0bdec18325e0966b3b935ec288d2d14d612d531e12fc8d2085a3afe81a97b81440fd782ccc898d4d05ec531bee9e7159c168d5469c
+[kubernetes-node-windows-amd64.tar.gz](https://dl.k8s.io/v1.16.13/kubernetes-node-windows-amd64.tar.gz) | abfaa76e0c67067668013ebba39c70a76dff291da2da403d1161785979051c09e6f40d59513ae76c5248c3e775c4484219cad72783adf0204731051f09f87daa
+
+## Changelog since v1.16.12
+
+## Urgent Upgrade Notes
+
+### (No, really, you MUST read this before you upgrade)
+
+ - CVE-2020-8559 (Medium): Privilege escalation from compromised node to cluster. See https://github.com/kubernetes/kubernetes/issues/92914 for more details.
+  The API Server will no longer proxy non-101 responses for upgrade requests. This could break proxied backends (such as an extension API server) that respond to upgrade requests with a non-101 response code. ([#92941](https://github.com/kubernetes/kubernetes/pull/92941), [@tallclair](https://github.com/tallclair)) [SIG API Machinery]
+ 
+## Changes by Kind
+
+### Bug or Regression
+
+- CVE-2020-8557 (Medium): Node-local denial of service via container /etc/hosts file. See https://github.com/kubernetes/kubernetes/issues/93032 for more details. ([#92916](https://github.com/kubernetes/kubernetes/pull/92916), [@joelsmith](https://github.com/joelsmith)) [SIG Node]
+- Extend kube-apiserver /readyz with new "informer-sync" check ensuring that internal informers are synced. ([#92644](https://github.com/kubernetes/kubernetes/pull/92644), [@wojtek-t](https://github.com/wojtek-t)) [SIG API Machinery and Testing]
+- Fix: GetLabelsForVolume panic issue for azure disk PV ([#92166](https://github.com/kubernetes/kubernetes/pull/92166), [@andyzhangx](https://github.com/andyzhangx)) [SIG Cloud Provider]
+- Fix: use force detach for azure disk ([#91948](https://github.com/kubernetes/kubernetes/pull/91948), [@andyzhangx](https://github.com/andyzhangx)) [SIG Cloud Provider]
+- Fixes a problem with 63-second or 1-second connection delays with some VXLAN-based
+  network plugins which was first widely noticed in 1.16 (though some users saw it
+  earlier than that, possibly only with specific network plugins). If you were previously
+  using ethtool to disable checksum offload on your primary network interface, you should
+  now be able to stop doing that. ([#92035](https://github.com/kubernetes/kubernetes/pull/92035), [@danwinship](https://github.com/danwinship)) [SIG Network and Node]
+- Kubeadm: add the deprecated flag --port=0 to kube-controller-manager and kube-scheduler manifests to disable insecure serving. Without this flag the components by default serve (e.g. /metrics) insecurely on the default node interface (controlled by --address). Users that wish to override this behavior and enable insecure serving can pass a custom --port=X via kubeadm's "extraArgs" mechanic for these components. ([#92720](https://github.com/kubernetes/kubernetes/pull/92720), [@neolit123](https://github.com/neolit123)) [SIG Cluster Lifecycle]
+- hyperkube: Use debian-hyperkube-base@v1.1.1 image
+  
+    Includes iproute2 to fix a regression in hyperkube images
+    when using hyperkube as a kubelet ([#92626](https://github.com/kubernetes/kubernetes/pull/92626), [@justaugustus](https://github.com/justaugustus)) [SIG Cluster Lifecycle, Network and Release]
+
+## Dependencies
+
+### Added
+_Nothing has changed._
+
+### Changed
+_Nothing has changed._
+
+### Removed
+_Nothing has changed._
+
+
+
+# v1.16.12
+
+
+## Downloads for v1.16.12
+
+### Source Code
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes.tar.gz](https://dl.k8s.io/v1.16.12/kubernetes.tar.gz) | 16aead0c708f1a64ee8b4723551c0e27f3661b06997fe5f32543b9c8f46d89e277d8845248725c64cdfbed9030cdee73e5e6a73acd7775bd5f54f7abab1817a7
+[kubernetes-src.tar.gz](https://dl.k8s.io/v1.16.12/kubernetes-src.tar.gz) | f78c645f6662e0593fa90946df136ad24f76f87ec75ba3131f52eef42c25948b3d49b2139bdb14e73a2bb203489b06e041441c8bf83373bb095bdd6271bcb8e6
+
+### Client binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-client-darwin-386.tar.gz](https://dl.k8s.io/v1.16.12/kubernetes-client-darwin-386.tar.gz) | d0c8b3d3bfd2a74f2c4335aa7d0f1d51bc5b5249431e88c1e3f83842640b30ec8e4185c4c8cc8be6b51d296e5c62a5cd4363b73c99ff665a9bd0ad609e7b5913
+[kubernetes-client-darwin-amd64.tar.gz](https://dl.k8s.io/v1.16.12/kubernetes-client-darwin-amd64.tar.gz) | d4e6b09cc24c04d04bf31510fbbfdc56b63ad2c95a977f22f962f4cd3c1c2ada8e6730ccce1ea3506cd74f9477aa6194221af593c50072b0615ae4c8150a7fa9
+[kubernetes-client-linux-386.tar.gz](https://dl.k8s.io/v1.16.12/kubernetes-client-linux-386.tar.gz) | d801441d1e61cf80adea0f556fdc6b6c6b6d3950ae3f5f349d21b45b2ee87635f31b2eff18f491fb95e8f78aebf504809b7695d1ec7dfa5bfa5b47f4c3a624cf
+[kubernetes-client-linux-amd64.tar.gz](https://dl.k8s.io/v1.16.12/kubernetes-client-linux-amd64.tar.gz) | 5f64aebafd1f5c3d2974a7ecf15defb6f82b4a03f4402555bf973a4fde40de3e81b62a92ef4cafee26a40ff6d4c8fc82580c26855ee587835a5f6740d4c89759
+[kubernetes-client-linux-arm.tar.gz](https://dl.k8s.io/v1.16.12/kubernetes-client-linux-arm.tar.gz) | 49d0c00ac8764c8632d4ffe64b9e0558eb69156bdfbdf56b142082e3ccdc5b4df404600a867de4bd5be40050eefd298fec638b65a7b288d601c0da6c5d97d7b1
+[kubernetes-client-linux-arm64.tar.gz](https://dl.k8s.io/v1.16.12/kubernetes-client-linux-arm64.tar.gz) | 6a8690a22884e9527518e7ba79760b78af426c4b5f6a7b6ceabe7a44658a5459349f6e2342993bcbc82c5b77f3640602a2033ba5390f0c13489bdcbd620834db
+[kubernetes-client-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.16.12/kubernetes-client-linux-ppc64le.tar.gz) | 8325e3ded3ce32d4c6f778f7247a80900c5bdbb6ce965a83b8a267f60f9508031ab9429b1c622b0026e70ffdd0d1b1384ccb1e0d5b79a059e5c4cfbf8274819c
+[kubernetes-client-linux-s390x.tar.gz](https://dl.k8s.io/v1.16.12/kubernetes-client-linux-s390x.tar.gz) | 160fab60b192c13da14cbb7f35d49d084550401758f7622656b278c09f4b1bb0454ff6507c065f0b446ddbbc92f1a1121c4302203cb032029644009c8c904ac9
+[kubernetes-client-windows-386.tar.gz](https://dl.k8s.io/v1.16.12/kubernetes-client-windows-386.tar.gz) | 129d9ec1da5d562693d807f37e73e6a394ebbde9ea421b148eb72ce004e09939530d470d10d118f8894310df4581139a33dd38efcf4c09e7f04f1c58882a08b6
+[kubernetes-client-windows-amd64.tar.gz](https://dl.k8s.io/v1.16.12/kubernetes-client-windows-amd64.tar.gz) | 8b8ec10129bfac6490a73898eee8583959f67f43b729a3ef7f55bad05a3b826dbdc6690bfe207260d0bbc8fcb1cc45d995d0046b78dc70c2fa18be984caa8c21
+
+### Server binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-server-linux-amd64.tar.gz](https://dl.k8s.io/v1.16.12/kubernetes-server-linux-amd64.tar.gz) | 990903598f44df71f9c31c51be50c1f17449443bd2b2be77344fd7c77d8373eefb8763ea1841d4c831310c94eb7e3de0e1229498ebb70d0e11469d1aa8ca65b0
+[kubernetes-server-linux-arm.tar.gz](https://dl.k8s.io/v1.16.12/kubernetes-server-linux-arm.tar.gz) | 9b3f9a8152d52dd35e1b29da2b3ab88afed8ea93be493c464ba4b11bbd81983686604e178b5e779e95982e42a7ca65ace5c382a34c5809a9903d9efd51c67a0c
+[kubernetes-server-linux-arm64.tar.gz](https://dl.k8s.io/v1.16.12/kubernetes-server-linux-arm64.tar.gz) | 9275700fb89441230810d844f63913bb235b4aa4122bb69bf95ba05040175bb176301db2642265caf76dc47ab00919e65020debc973a5e4d339919861d1bc33d
+[kubernetes-server-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.16.12/kubernetes-server-linux-ppc64le.tar.gz) | eb342c35660a3de9991b5e54dbd75c598031a42eb9b0b58f034bbefc401a4c645bc99737025e849acdf34ab06d4b5e16be09141b95d11e3d2cc21c86e27c23dc
+[kubernetes-server-linux-s390x.tar.gz](https://dl.k8s.io/v1.16.12/kubernetes-server-linux-s390x.tar.gz) | d52252d386c5387534a62dc26a59c5a8eb175cdedbd79b2d752d9602bb46426f344aedd0f24dda053561f46e172027b4ad8cd67f8472f3cbea8645a3e4138449
+
+### Node binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-node-linux-amd64.tar.gz](https://dl.k8s.io/v1.16.12/kubernetes-node-linux-amd64.tar.gz) | 54a5ff3b8e33eb0ca299e758170f8aeb0c931bd7700ac80dde56359ca388e6dc4442dd022bbe1b2a1ecbb8ed92f13624aa41859cbd1cd0a1d2f1a7c86f048d0a
+[kubernetes-node-linux-arm.tar.gz](https://dl.k8s.io/v1.16.12/kubernetes-node-linux-arm.tar.gz) | 494f15950d8ba4e33d71a1dd8c500c78c7e07690b94fe9da87242a8bfe78b3258ff1e522a620449998f36029b4ac013386c800662cda55d4a3933a80c7e9742d
+[kubernetes-node-linux-arm64.tar.gz](https://dl.k8s.io/v1.16.12/kubernetes-node-linux-arm64.tar.gz) | 02d87a40a2de13ecb17a30ef80c2b4116cd7690b7aa2e2f685e79d35024f143c131e5943676656f8692a8efb69592f230e4b844690c96e4faff215de4e9d371a
+[kubernetes-node-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.16.12/kubernetes-node-linux-ppc64le.tar.gz) | 1993ad9137602fc706e2d088c17c3c20e80254f450c13f0ccec8c81160da13fbc41c4e7fca22161500494ef62ba3256415fc1f917212c1d5896119a5988ebd67
+[kubernetes-node-linux-s390x.tar.gz](https://dl.k8s.io/v1.16.12/kubernetes-node-linux-s390x.tar.gz) | 1cd922e7d15292e3512d501303a08b98133d046467d117323501f0dc477da404b27297e3615c7db26b7e24df75d42ca54569980169be6cbe6f76d3045f4d53db
+[kubernetes-node-windows-amd64.tar.gz](https://dl.k8s.io/v1.16.12/kubernetes-node-windows-amd64.tar.gz) | 697c10a14cb4f8f021907ec46096c98d3ec69d3d865ad0194a31ae5d3901ba3669f7b82c9b8f08ee7153ba8c730b072ce14dcbe8351db8ca17bbbfd624841a40
+
+## Changelog since v1.16.11
+
+## Changes by Kind
+
+### API Change
+
+- Fixed: log timestamps now include trailing zeros to maintain a fixed width ([#91207](https://github.com/kubernetes/kubernetes/pull/91207), [@iamchuckss](https://github.com/iamchuckss)) [SIG Apps and Node]
+
+### Bug or Regression
+
+- If firstTimestamp is not set use firstTimestamp or eventTime when printing event ([#91056](https://github.com/kubernetes/kubernetes/pull/91056), [@soltysh](https://github.com/soltysh)) [SIG CLI]
+- hyperkube: Use debian-hyperkube-base@v1.1.0 image
+  
+    A previous release built hyperkube using the debian-hyperkube-base@v1.0.0,
+    which was updated to address a CVE in the CNI plugins.
+    
+    A side-effect of using this new image was that the networking packages
+    (namely `iptables`) drifted from the versions used in the kube-proxy images.
+  
+    The following issues were filed on kube-proxy failures when using hyperkube:
+    - https://github.com/kubernetes/kubernetes/issues/92275
+    - https://github.com/kubernetes/kubernetes/issues/92272
+    - https://github.com/kubernetes/kubernetes/issues/92250
+  
+    To address this, the new debian-hyperkube-base image (v1.1.0) uses the
+    debian-iptables base image (v12.1.0), which includes iptables-wrapper, a
+    script used to determine the correct iptables mode to run in. ([#92495](https://github.com/kubernetes/kubernetes/pull/92495), [@justaugustus](https://github.com/justaugustus)) [SIG Cluster Lifecycle and Release]
+
+## Dependencies
+
+### Added
+_Nothing has changed._
+
+### Changed
+_Nothing has changed._
+
+### Removed
+_Nothing has changed._
+
+
+
+# v1.16.12-rc.1
+
+
+## Downloads for v1.16.12-rc.1
+
+### Source Code
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes.tar.gz](https://dl.k8s.io/v1.16.12-rc.1/kubernetes.tar.gz) | 1aea402d8a608320ed420291f560523e2f3cb0c9d748ab9068c65bf41ca7a698bee9d3380951ae60548832196be35150d0de6295ba431d9480cb5b9f431b6916
+[kubernetes-src.tar.gz](https://dl.k8s.io/v1.16.12-rc.1/kubernetes-src.tar.gz) | 887cef5ebf5958b4d1e924499dbd1d89054bd7bd16326c28dfc3912e880172febbd0037121a1d57b6a39b84e9f0c57a3b4a2b553582947442530b8c8d053db0a
+
+### Client binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-client-darwin-386.tar.gz](https://dl.k8s.io/v1.16.12-rc.1/kubernetes-client-darwin-386.tar.gz) | 86323ec3741ac367d937504bafdf14896d5cb086022cad057641d47f39688dc743c3868b4493c976fc3ce0822ce5865889a77234cd2604e65b924c358ac7f89e
+[kubernetes-client-darwin-amd64.tar.gz](https://dl.k8s.io/v1.16.12-rc.1/kubernetes-client-darwin-amd64.tar.gz) | 332c541a3bca1328776a5f27c9f5d6dd162499424bd4fcd1f2ef2f5b68d7ebcecef249cf4f981ecf05d66e3d3c80d85a7e074c5403647428cbca6d3678583db0
+[kubernetes-client-linux-386.tar.gz](https://dl.k8s.io/v1.16.12-rc.1/kubernetes-client-linux-386.tar.gz) | 7a91e23bb34c5ce0c81a625676fa22561cfe09dba292460f28df9f697b0b14d7bbd6688c00aea6c6a213a4dea56b6c7bbf3f136020700e8b01a0449614fada4a
+[kubernetes-client-linux-amd64.tar.gz](https://dl.k8s.io/v1.16.12-rc.1/kubernetes-client-linux-amd64.tar.gz) | 3da004d95a4e94c6f12bf7323340da4ebe6064582b91ae8d081330a1c578f6de59dfb94aff5ce6f4570c060aa43388116b9cb6193783221340d4a3c957a6fc3c
+[kubernetes-client-linux-arm.tar.gz](https://dl.k8s.io/v1.16.12-rc.1/kubernetes-client-linux-arm.tar.gz) | b93385aaf9e9790a6b5277a3f4a2b86f90502ac7309e841d43144df667baa50fc2ebba3de3e261280b807f077905fcaf3b2b7102e12b17d2501e0ad7b639313e
+[kubernetes-client-linux-arm64.tar.gz](https://dl.k8s.io/v1.16.12-rc.1/kubernetes-client-linux-arm64.tar.gz) | ca94841465a723682fae0c91130fed5fa071a8527e4fa9ce9ed250092d1a82d79e5efdc0f648a89d27e4fcc052db5ae47fad7b8d0ff8403da8564021b6b8ab46
+[kubernetes-client-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.16.12-rc.1/kubernetes-client-linux-ppc64le.tar.gz) | b5611661e2bc086ce065067c502ece68004bf95ed4978438b1503caf981698e63a633a03892bf9a4f60fa93b083f5eae5b6798d3b155a8d81f4af556f545fcf6
+[kubernetes-client-linux-s390x.tar.gz](https://dl.k8s.io/v1.16.12-rc.1/kubernetes-client-linux-s390x.tar.gz) | 06ef2e0b53c288e7cd26576681a51fafe3f864cb196da9a12c2f2ee20be2c571b500f0b1abfa2e0d71c9b6c58bb25fd6944190a5410ad73a15b0b9518c854451
+[kubernetes-client-windows-386.tar.gz](https://dl.k8s.io/v1.16.12-rc.1/kubernetes-client-windows-386.tar.gz) | 48a8d5a4967eeed59167e141bddaf6bce4d09dae13db03742f28037e9d5cb50adb1fbdab91225ae4ea6aff17b50b7ed9349dd027ae1eb6d3457ef2bddd3e37c8
+[kubernetes-client-windows-amd64.tar.gz](https://dl.k8s.io/v1.16.12-rc.1/kubernetes-client-windows-amd64.tar.gz) | 720823ec97ecfe588f428f4c876ea6d8597293d14ecc846e766cde3f1a77e8dd47171084066051b328d86629983ceddee02dc30efabe2884bb041985842b819f
+
+### Server binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-server-linux-amd64.tar.gz](https://dl.k8s.io/v1.16.12-rc.1/kubernetes-server-linux-amd64.tar.gz) | 28fd9bbbd831d129e5f7bc495179b0e6b6aaf21f5e2db8c163cd13406a3916c26d4f94dc9cd844ba7274ee2ec519024019ae403cd3a779c3c8654c5de7e2ec9f
+[kubernetes-server-linux-arm.tar.gz](https://dl.k8s.io/v1.16.12-rc.1/kubernetes-server-linux-arm.tar.gz) | ad20d7ba5b7c559206aa4253b9ad79e43bf4f054799cb5e241b9675aed04db5102b519e43c58b0c1e7022c77f016a57ba9f72bdd22cd48d8136b1de8e1e23a1b
+[kubernetes-server-linux-arm64.tar.gz](https://dl.k8s.io/v1.16.12-rc.1/kubernetes-server-linux-arm64.tar.gz) | c4d09fbd0576e1048d6ba404a68abb15f57b1af4daf4321b01a8799d9f3696afe6d01b2a956ba203f99e2c2352fef356f7ec4d38bb5fd51d8ea864776d05e81e
+[kubernetes-server-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.16.12-rc.1/kubernetes-server-linux-ppc64le.tar.gz) | 07085ba7b027be4df44c95b54b8972150bcf9a965fe9a767f8371c71f5746b6214fd8f206a9917e17ac0bf969443f25199eb4a05c8302b43b2fa57b40775b01c
+[kubernetes-server-linux-s390x.tar.gz](https://dl.k8s.io/v1.16.12-rc.1/kubernetes-server-linux-s390x.tar.gz) | b03b616f9e52397bf6c4ea1cfb952b994d3d12c52761d43bd967ebe1857c0d1ce434df69c51ac9695495f1bd074ad5e739407a1c5a1adc4650b019231a344cad
+
+### Node binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-node-linux-amd64.tar.gz](https://dl.k8s.io/v1.16.12-rc.1/kubernetes-node-linux-amd64.tar.gz) | 8b15546050327feed884c2f05b0d2b34d95d475688e2c1a809f964f47b6f16a59e31d0caafc8b09f46301d0a6fd9c411be9469bbbea626d78dbe17f9988e03c8
+[kubernetes-node-linux-arm.tar.gz](https://dl.k8s.io/v1.16.12-rc.1/kubernetes-node-linux-arm.tar.gz) | 38555ae95278a585d1c104c9198d6b9504ceff5c750e1b8fe2d00d3c2846ffb8ff4f3d3cd31ad4dc328c1d026537007de32958c85113a48bede6be727aea047d
+[kubernetes-node-linux-arm64.tar.gz](https://dl.k8s.io/v1.16.12-rc.1/kubernetes-node-linux-arm64.tar.gz) | 047b53bc59737b142cc9a3098ae284ed38c8f80f3d9cd747c25eef3f5871e6cd5d1e5443f521dea4b7ffebd7495110cbe47b293b8394b9636ac7c2d9ec7be1df
+[kubernetes-node-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.16.12-rc.1/kubernetes-node-linux-ppc64le.tar.gz) | 05b138594fcbbb0ffd531b78e0b09fa2300b8fbf013c88f9d0f083b392f7a3642dfb8ebadae79e3a5f0a85ddac35f0e88c11a2e62e2bd335b8ca85a64a7fed96
+[kubernetes-node-linux-s390x.tar.gz](https://dl.k8s.io/v1.16.12-rc.1/kubernetes-node-linux-s390x.tar.gz) | f29940c3063d9e738dbe77b6813940efb34b333197464557664a232ee6e5adc075a9a206cab00ff2f478230da5f20e6055e8802b336b0ecd3764d3641b48d7e3
+[kubernetes-node-windows-amd64.tar.gz](https://dl.k8s.io/v1.16.12-rc.1/kubernetes-node-windows-amd64.tar.gz) | 381a3065d15737b6e1a6fbd59ad66a41cc55d84a550c3037137ad64dc535a371876fb85fddda97742f2402fe9ec6e6ab67013aa49ac7ada224dba3b565b89214
+
+## Changelog since v1.16.11
+
+## Changes by Kind
+
+### API Change
+
+- Fixed: log timestamps now include trailing zeros to maintain a fixed width ([#91207](https://github.com/kubernetes/kubernetes/pull/91207), [@iamchuckss](https://github.com/iamchuckss)) [SIG Apps and Node]
+
+### Bug or Regression
+
+- If firstTimestamp is not set use firstTimestamp or eventTime when printing event ([#91056](https://github.com/kubernetes/kubernetes/pull/91056), [@soltysh](https://github.com/soltysh)) [SIG CLI]
+- hyperkube: Use debian-hyperkube-base@v1.1.0 image
+  
+    A previous release built hyperkube using the debian-hyperkube-base@v1.0.0,
+    which was updated to address a CVE in the CNI plugins.
+    
+    A side-effect of using this new image was that the networking packages
+    (namely `iptables`) drifted from the versions used in the kube-proxy images.
+  
+    The following issues were filed on kube-proxy failures when using hyperkube:
+    - https://github.com/kubernetes/kubernetes/issues/92275
+    - https://github.com/kubernetes/kubernetes/issues/92272
+    - https://github.com/kubernetes/kubernetes/issues/92250
+  
+    To address this, the new debian-hyperkube-base image (v1.1.0) uses the
+    debian-iptables base image (v12.1.0), which includes iptables-wrapper, a
+    script used to determine the correct iptables mode to run in. ([#92495](https://github.com/kubernetes/kubernetes/pull/92495), [@justaugustus](https://github.com/justaugustus)) [SIG Cluster Lifecycle and Release]
+
+## Dependencies
+
+### Added
+_Nothing has changed._
+
+### Changed
+_Nothing has changed._
+
+### Removed
+_Nothing has changed._
+
+
+
+# v1.16.11
+
+
+## Downloads for v1.16.11
+
+### Source Code
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes.tar.gz](https://dl.k8s.io/v1.16.11/kubernetes.tar.gz) | 3830d26b53cc18be80a40249f9db01bde72d3f0f222252cfccd46416ec1725527dcc04aa85f8af4b2847c041807b08b9e4b78a6748b589592399a15160e2467e
+[kubernetes-src.tar.gz](https://dl.k8s.io/v1.16.11/kubernetes-src.tar.gz) | 86c376157342758e346bfd028ff7d8dfd0a40afe96c4d77835c2bd71ef999643c9e1961a9549caf3595bd158dc025e858183544cf4ccac59d5951fa440f93802
+
+### Client binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-client-darwin-386.tar.gz](https://dl.k8s.io/v1.16.11/kubernetes-client-darwin-386.tar.gz) | f8147e6dfc8348c59848fdabbb8ce89e9b7f7c4999de26c82c6caa2cafda24cce8b89dcaa53caf3c39fb319104ec5203482127daec68aa2cd629a6c29a50e747
+[kubernetes-client-darwin-amd64.tar.gz](https://dl.k8s.io/v1.16.11/kubernetes-client-darwin-amd64.tar.gz) | 35c45d7ac5ba281daa4b504f1256b9b67a1cb3476b394ce2b19f5363fb9da4ecac5f923fbe7d7ade3d636bde3646965424408b4a7b6f1ee0a2892383419f8d97
+[kubernetes-client-linux-386.tar.gz](https://dl.k8s.io/v1.16.11/kubernetes-client-linux-386.tar.gz) | 2d185a2f3daf3ea0ff7e0b3eec98c3159d238db5be4dc8423e8ecfbff9d1b6ca17dc7ee3cfff8a52c8cccecc27ae5a2c393fa84c1c2237336ee898c409e0fdd8
+[kubernetes-client-linux-amd64.tar.gz](https://dl.k8s.io/v1.16.11/kubernetes-client-linux-amd64.tar.gz) | 5181f29e832a46bcd454c812cfbabb7a0786434796d893086c29013e59288e56a611892fe4f85d9ba56a70699bf26e50ab61acbe6eb99b06eddd2a6fe4841824
+[kubernetes-client-linux-arm.tar.gz](https://dl.k8s.io/v1.16.11/kubernetes-client-linux-arm.tar.gz) | 7c87111b4bdf94b1305551bbc9e4aab1edf660867a1346f133ef079354c8c7b8af71fd1ebf46eb8544a887cf0e1dba3fdf0dcdb40fbd9fecff58b098c2491b2e
+[kubernetes-client-linux-arm64.tar.gz](https://dl.k8s.io/v1.16.11/kubernetes-client-linux-arm64.tar.gz) | 2241c28ab4d08338cadc43862d0daa235158237cf5e3caa0d7d755ac0cb44039c0200e14abd2e41454d5880b8ff11c811dff0c05e88405b04192f1f342914dad
+[kubernetes-client-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.16.11/kubernetes-client-linux-ppc64le.tar.gz) | a052f627964db4c68268a37afda32af637f74876f254633de16f0e56fe1c3fbba13e67a8a0c4f2a475c5cb69038c6fff545a50e8a9658eb20037020a96cf08b8
+[kubernetes-client-linux-s390x.tar.gz](https://dl.k8s.io/v1.16.11/kubernetes-client-linux-s390x.tar.gz) | cd43ef6f58451e5b4a5c02b27beefd69b6b08bf4846b920c83e9886cb17dce72d358b7d138515454d9c802f327edb3e9b17e8a4319a19b806fdca0f2a857f9b0
+[kubernetes-client-windows-386.tar.gz](https://dl.k8s.io/v1.16.11/kubernetes-client-windows-386.tar.gz) | 94108a54806d28edf6e0f75124bfe192be415e6245e03963c93cc20b9b8eeec48d66e4b7c4e99fca5b6e23628f2925f6c163d910614260c4c1bd32274abb9a3e
+[kubernetes-client-windows-amd64.tar.gz](https://dl.k8s.io/v1.16.11/kubernetes-client-windows-amd64.tar.gz) | f5139a7ceb8f3f9f07bd5ab2f6762b166152e886a78149264789b7f6cad15773e76d4acb42f46c2c6af7c4ec4e8c30f32ce089c92d28cab74e6f6f978f839d4b
+
+### Server binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-server-linux-amd64.tar.gz](https://dl.k8s.io/v1.16.11/kubernetes-server-linux-amd64.tar.gz) | 548e9d9c09458ecd3a5ec83560ecc53fce589edf85b27776d0f501547492a46405be33997e740c1d69dddda3038d8aed7886a26364c9925c50e54aabe4a035fa
+[kubernetes-server-linux-arm.tar.gz](https://dl.k8s.io/v1.16.11/kubernetes-server-linux-arm.tar.gz) | 3858a3a1f5e5edaa48e4ccae37936426222d440802c195923cb29bc02bcf7e2fb18928e6084bb93c20deb59898e7d9ecf43fc8702049caea83233d79bd438456
+[kubernetes-server-linux-arm64.tar.gz](https://dl.k8s.io/v1.16.11/kubernetes-server-linux-arm64.tar.gz) | 7ab1a2018eb190385744799af48362ec9fbde5cff42433b71aa73700033103e3c67a168d981b636da81f712fa01eda73a2010c3de5768e2333b1c0cfce3ccc5f
+[kubernetes-server-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.16.11/kubernetes-server-linux-ppc64le.tar.gz) | e6463da01ac934cc826ae781281737cfe6f42b4355d68e0b90a589af0e14ece1ad59523799b7470ae9d49a735137a6d371933ccc04de6a7c99731ca6822cfb0d
+[kubernetes-server-linux-s390x.tar.gz](https://dl.k8s.io/v1.16.11/kubernetes-server-linux-s390x.tar.gz) | 8be2923df4fa559b647550aba78d3e0a82b1c3d22d7e7043424ce265c9bff593cb7c78d3d3e92d8a973fc4df5a4f118edba3c50ae32ee54fa56e220d1bf9a10b
+
+### Node binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-node-linux-amd64.tar.gz](https://dl.k8s.io/v1.16.11/kubernetes-node-linux-amd64.tar.gz) | ba0f723f05201a0ce7cb8655484f530e22959c21ef7da32eaab95741b97fd9487622bdc229c7b02c14978301dff020939cf88e31f1032110c6722b76c6a7c0a9
+[kubernetes-node-linux-arm.tar.gz](https://dl.k8s.io/v1.16.11/kubernetes-node-linux-arm.tar.gz) | e81998954ca0349169c76385f57dc0bf480f803e191f79c15cbc2eed4ed5f59ca3c991fe0316b590624518b80be2d790c2bb6ba0421854cc84226d74d725a5ed
+[kubernetes-node-linux-arm64.tar.gz](https://dl.k8s.io/v1.16.11/kubernetes-node-linux-arm64.tar.gz) | afbc62f35d7f36a424edbb728b4c1030a594e81666137bff566f7de824b9c4479c8e3a18bf827257d1b14f6aa33efdf27f1259eef014c37742e1a29a84891ee3
+[kubernetes-node-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.16.11/kubernetes-node-linux-ppc64le.tar.gz) | ae544dc78ec673aaabae89e0542579eca19344edac2b830d280cc763c583a84c0978725ac162c875e1d237db1e763d27d2d9ebfa3b272959ccc57676ac28bf49
+[kubernetes-node-linux-s390x.tar.gz](https://dl.k8s.io/v1.16.11/kubernetes-node-linux-s390x.tar.gz) | 727d3aa9fe8a4a3e7cfa2b151afe5e43a94579b55c7c5e603659a686349dc4141a8b8df9d92bb4fe9078f2b9fc877fc02afc6dc30826a5ac0d3d9f4a74e641f6
+[kubernetes-node-windows-amd64.tar.gz](https://dl.k8s.io/v1.16.11/kubernetes-node-windows-amd64.tar.gz) | a7dfa7f10868b061dacde037d1fb8763387724310271cb4cf8d3a5a270a0dc1c52beda81abbdf934217634c8c253d2d48d43ece4538863016a68db6301730bfb
+
+## Changelog since v1.16.10
+
+## Changes by Kind
+
+### API Change
+
+- Resolve regression in metadata.managedFields handling in update/patch requests submitted by older API clients ([#91748](https://github.com/kubernetes/kubernetes/pull/91748), [@apelisse](https://github.com/apelisse)) [SIG API Machinery and Testing]
+
+### Feature
+
+- Extend AWS azToRegion method to support Local Zones ([#90874](https://github.com/kubernetes/kubernetes/pull/90874), [@Jeffwan](https://github.com/Jeffwan)) [SIG Cloud Provider]
+
+### Bug or Regression
+
+- Azure: set dest prefix and port for IPv6 inbound security rule ([#91831](https://github.com/kubernetes/kubernetes/pull/91831), [@aramase](https://github.com/aramase)) [SIG Cloud Provider]
+- Fix internal loadbalancer configuration failure when subnet name too long ([#86276](https://github.com/kubernetes/kubernetes/pull/86276), [@yangl900](https://github.com/yangl900)) [SIG Cloud Provider]
+- Fix public IP not shown issues after assigning public IP to Azure VMs ([#90886](https://github.com/kubernetes/kubernetes/pull/90886), [@feiskyer](https://github.com/feiskyer)) [SIG Cloud Provider]
+- Fixed a regression preventing garbage collection of RBAC role and binding objects ([#90534](https://github.com/kubernetes/kubernetes/pull/90534), [@apelisse](https://github.com/apelisse)) [SIG Auth]
+- Fixed cleanup of raw block devices after kubelet restart. ([#83451](https://github.com/kubernetes/kubernetes/pull/83451), [@jsafrane](https://github.com/jsafrane)) [SIG Node, Storage and Testing]
+- Kubelet podresources API now provides the information about active pods only. ([#79409](https://github.com/kubernetes/kubernetes/pull/79409), [@takmatsu](https://github.com/takmatsu)) [SIG Node]
+- Pod Finalizers and Conditions updates are skipped for re-scheduling attempts ([#91953](https://github.com/kubernetes/kubernetes/pull/91953), [@alculquicondor](https://github.com/alculquicondor)) [SIG Scheduling]
+- Resolve regression in metadata.managedFields handling in create/update/patch requests not using server-side apply ([#91690](https://github.com/kubernetes/kubernetes/pull/91690), [@apelisse](https://github.com/apelisse)) [SIG API Machinery and Testing]
+- Resolves an issue using `kubectl certificate approve/deny` against a server serving the v1 CSR API ([#91691](https://github.com/kubernetes/kubernetes/pull/91691), [@liggitt](https://github.com/liggitt)) [SIG Auth and CLI]
+
+### Other (Cleanup or Flake)
+
+- Update CNI to v0.8.6
+  - build: Use debian-hyperkube-base@v1.0.0 image ([#91388](https://github.com/kubernetes/kubernetes/pull/91388), [@justaugustus](https://github.com/justaugustus)) [SIG Cluster Lifecycle, Network, Release and Testing]
+
+## Dependencies
+
+### Added
+_Nothing has changed._
+
+### Changed
+_Nothing has changed._
+
+### Removed
+_Nothing has changed._
+
+
+
+# v1.16.10
+
+
+## Downloads for v1.16.10
+
+### Source Code
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes.tar.gz](https://dl.k8s.io/v1.16.10/kubernetes.tar.gz) | 5925579630fa2c3f78c1e17b4c2aca3e23cad5db7721b34b9e8d8eb8a443d4ea4cb87369d9d254dfd35603a1f12825a1167ccd2b71e1e1f3eb7676ad4a143276
+[kubernetes-src.tar.gz](https://dl.k8s.io/v1.16.10/kubernetes-src.tar.gz) | 5d265121125e940ea43a54df7ef6ed072598d5d4dcfcbf7173ad252d016869db938c50865aaff31ef7ebd0399fa0de87b4248285b3c7f1abdf813cda0df585b2
+
+### Client binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-client-darwin-386.tar.gz](https://dl.k8s.io/v1.16.10/kubernetes-client-darwin-386.tar.gz) | da77e3fc2bdcc5c6c6dd8c92c2f8fc23ea2974cb36e08316830631132005c03513296179b1ba5e77d9dc3346ce273207f9ae4ae822b13b1a361f6543a4df4bcc
+[kubernetes-client-darwin-amd64.tar.gz](https://dl.k8s.io/v1.16.10/kubernetes-client-darwin-amd64.tar.gz) | f56f42a525e723fdcb203d7671fc8586c45a9987e8f4ffbe9467beefe0af12f8158bba1257392f21cca3cf75c9f8db803d644135da5e2fb2cc74ced858c9f294
+[kubernetes-client-linux-386.tar.gz](https://dl.k8s.io/v1.16.10/kubernetes-client-linux-386.tar.gz) | 10241604f0fec126f696f33963ec607abf378b44524f3dcc3ab26cfcad894d1ab1f3fa06af2ee6619ac3aa43eef6edb46bb7cdb3e5c9e813009a5373b99e1598
+[kubernetes-client-linux-amd64.tar.gz](https://dl.k8s.io/v1.16.10/kubernetes-client-linux-amd64.tar.gz) | 455d8bd8881aa996dd35969b2448fa54ab15650ce2d58c19bf89ff8e11f287beb136ba64ca62d64c958a1227dfee1e94408941258f0b9421ef06bb48a09bbcd2
+[kubernetes-client-linux-arm.tar.gz](https://dl.k8s.io/v1.16.10/kubernetes-client-linux-arm.tar.gz) | a30b1840f7ca2f13468a142f69b1806cf9950d67f5c42cb30972c23704c4c66d47c16245096ddb3245ab9d7a002ae37a944822ef4d8d7d21a253f8cf59d861c8
+[kubernetes-client-linux-arm64.tar.gz](https://dl.k8s.io/v1.16.10/kubernetes-client-linux-arm64.tar.gz) | 1247c48d1abe3d04d8ecc08c34bc627961cc2a830893a039366e36da66ce96431d2d9b8ebb0e4893260195ba702f8a5e9935ac5a043ea0a9b0e34b64682f394b
+[kubernetes-client-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.16.10/kubernetes-client-linux-ppc64le.tar.gz) | c793de5dbe35708ba7992cae395e3c70e48e5ecb57bba73d87496dbccde216b777f60ff41ff10d565e06f48bf18b72f97df12446722860a72a55c46dcdf8bd7e
+[kubernetes-client-linux-s390x.tar.gz](https://dl.k8s.io/v1.16.10/kubernetes-client-linux-s390x.tar.gz) | a71420474b115e5114628b09744a1929163931550d5fbfffbc6c12c7531c6e9769ab5125148a72d151fe6392c8c96d6a4736348a67fa02e66ac8afac6defe13b
+[kubernetes-client-windows-386.tar.gz](https://dl.k8s.io/v1.16.10/kubernetes-client-windows-386.tar.gz) | 42a44700becf4556473498c95561aced6704a49800bf1b96a776607903eca97f77aa208e29d99c963a7e00a8af72540c45572f1fad59d74f3736b180e60f7411
+[kubernetes-client-windows-amd64.tar.gz](https://dl.k8s.io/v1.16.10/kubernetes-client-windows-amd64.tar.gz) | 0fffcf5012ae9495396c64a8b3bea3389456ba5844d44b5b8ae619752011101864eb7ed6ea6fe2fedeb8a07e36a097cd84b79a62b9004e457105f0c0895f7be8
+
+### Server binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-server-linux-amd64.tar.gz](https://dl.k8s.io/v1.16.10/kubernetes-server-linux-amd64.tar.gz) | bb2c68409878c1037f8d2924b010f6e13cb28969046faf75a5e9e16d90e8167223f9ecab0866ba1c3998360d1da87863d3626dada226b153733f39e6d53e710c
+[kubernetes-server-linux-arm.tar.gz](https://dl.k8s.io/v1.16.10/kubernetes-server-linux-arm.tar.gz) | 42dddd7699b77c12690b525dd9c0643e529589a84628c3fa6b7f8ffad064dc1fb93cd3e37aa606d113f4c18833ad6e404af86f0dba5b92238c2410f9bdeb16fa
+[kubernetes-server-linux-arm64.tar.gz](https://dl.k8s.io/v1.16.10/kubernetes-server-linux-arm64.tar.gz) | 0c0e9b484576559eb2d894aef9b705472d31b459123ca4dec61fa0fd9a6d5ddb844003dfbbaa596e3d60fbabfdbd57424053a89c0d9969d181e5e9b820c49d86
+[kubernetes-server-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.16.10/kubernetes-server-linux-ppc64le.tar.gz) | 9a6c12f1c6a442d59f8eb2affa3c980e35c0e85a70ec97d565c660c4bf041257d98f8588280a1e4b28f9a2589c5f8f5ef105030a29271c4bd0faf67b79eb37b6
+[kubernetes-server-linux-s390x.tar.gz](https://dl.k8s.io/v1.16.10/kubernetes-server-linux-s390x.tar.gz) | f4a272179806dc174177c4ae860a8f8dd67743ed1eedab2720761a008e8bf15646c39e0a8a176e980a2e43d2c8068f78f19c35295ceb097e40eea904d5e6c253
+
+### Node binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-node-linux-amd64.tar.gz](https://dl.k8s.io/v1.16.10/kubernetes-node-linux-amd64.tar.gz) | bcd8abebedbb20f93259ccfddefe4f7f5583d2572a8bdb011715b737c88927a89f90923856e43ed6b6b9d6fdd7ce6f348de5e632f63abe16ee66828a33842844
+[kubernetes-node-linux-arm.tar.gz](https://dl.k8s.io/v1.16.10/kubernetes-node-linux-arm.tar.gz) | 9089881d92640de936c07b25ed398e338d95a0b684891377835341e47f868fa0f3337ac8e93307937d2ccdb694da72fc6ca275f1bb2803ae55fe06c7a1d47cd2
+[kubernetes-node-linux-arm64.tar.gz](https://dl.k8s.io/v1.16.10/kubernetes-node-linux-arm64.tar.gz) | b5844cfcbdc13888c3150348252cdf38c39a19fc0e69b1bff42178e10b608e8500e7e527a285c20be0e9ca1ea785c7ff9a198c9e151e7e9ebed694fc7780214c
+[kubernetes-node-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.16.10/kubernetes-node-linux-ppc64le.tar.gz) | bda2e59f704cb314397302a3365f8a2dcbd7663277ede11fe5f69c346ab5ef26103542849751a3c8cd2a72c9819cbc4900b52a0f941d47fb7d774caaa94fda24
+[kubernetes-node-linux-s390x.tar.gz](https://dl.k8s.io/v1.16.10/kubernetes-node-linux-s390x.tar.gz) | 0574ccf4677f8333b6a64c91fcfc4e3d037eec05f3983df647d8d5505ef57a3c6d41e93fbb35ad1f228b3673ee0d6084610054e397714ba0bd86c949455122d9
+[kubernetes-node-windows-amd64.tar.gz](https://dl.k8s.io/v1.16.10/kubernetes-node-windows-amd64.tar.gz) | e5a5bfb79f1e45f13da3dfaa13c44264e099d08c535d6a9c63819685be186f8a84a518468720cd56dc1434aec10d40aa4c929d62fdd7f43b749e05c7572fb2f9
+
+## Changelog since v1.16.9
+
+## Changes by Kind
+
+### API Change
+ - Fix bug where sending a status update completely wipes managedFields for some types. ([#90033](https://github.com/kubernetes/kubernetes/pull/90033), [@apelisse](https://github.com/apelisse)) [SIG API Machinery and Testing]
+
+### Bug or Regression
+ - Base-images: Update to kube-cross:v1.13.9-5 ([#90966](https://github.com/kubernetes/kubernetes/pull/90966), [@justaugustus](https://github.com/justaugustus)) [SIG Release]
+ - Fix HPA when using init containers and CRI-O ([#90900](https://github.com/kubernetes/kubernetes/pull/90900), [@joelsmith](https://github.com/joelsmith)) [SIG Node]
+ - Fix: Init containers are now considered for the calculation of resource requests when scheduling ([#90455](https://github.com/kubernetes/kubernetes/pull/90455), [@alculquicondor](https://github.com/alculquicondor)) [SIG Scheduling]
+ - Fix: azure disk dangling attach issue which would cause API throttling ([#90749](https://github.com/kubernetes/kubernetes/pull/90749), [@andyzhangx](https://github.com/andyzhangx)) [SIG Cloud Provider]
+ - Fix: get attach disk error due to missing item in max count table ([#89768](https://github.com/kubernetes/kubernetes/pull/89768), [@andyzhangx](https://github.com/andyzhangx)) [SIG Cloud Provider and Storage]
+ - Fix: support removal of nodes backed by deleted non VMSS instances on Azure ([#91184](https://github.com/kubernetes/kubernetes/pull/91184), [@bpineau](https://github.com/bpineau)) [SIG Cloud Provider]
+ - Fixes a bug defining a default value for a replicas field in a custom resource definition that has the scale subresource enabled ([#90022](https://github.com/kubernetes/kubernetes/pull/90022), [@liggitt](https://github.com/liggitt)) [SIG API Machinery, CLI, Cloud Provider and Cluster Lifecycle]
+ - Pods that are considered for preemption and haven't started don't produce an error log. ([#90241](https://github.com/kubernetes/kubernetes/pull/90241), [@alculquicondor](https://github.com/alculquicondor)) [SIG Scheduling]
+ - Provides a fix to allow a cluster in a private Azure cloud to authenticate to ACR in the same cloud. ([#90425](https://github.com/kubernetes/kubernetes/pull/90425), [@DavidParks8](https://github.com/DavidParks8)) [SIG Cloud Provider]
+ - Reduced frequency of DescribeVolumes calls of AWS API when attaching/detaching a volume.
+  Fixed "requested device X but found Y" attach error on AWS. ([#89894](https://github.com/kubernetes/kubernetes/pull/89894), [@johanneswuerbach](https://github.com/johanneswuerbach)) [SIG Cloud Provider]
+ - Scheduling failures due to no nodes available are now reported as unschedulable under ```schedule_attempts_total``` metric. ([#90989](https://github.com/kubernetes/kubernetes/pull/90989), [@ahg-g](https://github.com/ahg-g)) [SIG Scheduling]
+
+### Other (Cleanup or Flake)
+ - base-images: Use debian-base:v2.1.0 (update to Debian Buster, includes CVE fixes)
+  - base-images: Use debian-iptables:v12.1.0 (update to Debian Buster, includes CVE fixes and iptables-nft/iptables-legacy wrapper) ([#90940](https://github.com/kubernetes/kubernetes/pull/90940), [@justaugustus](https://github.com/justaugustus)) [SIG API Machinery, Cluster Lifecycle and Release]
+
+## Dependencies
+
+### Added
+_Nothing has changed._
+
+### Changed
+- k8s.io/kube-openapi: 743ec37 → 594e756
+
+### Removed
+_Nothing has changed._
+
+
+
+# v1.16.9
+
+[Documentation](https://docs.k8s.io)
+
+## Downloads for v1.16.9
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes.tar.gz](https://dl.k8s.io/v1.16.9/kubernetes.tar.gz) | `524cb2d5a748e4e0b78aec357b479b8b810fa3bf875b85682d30fe5e4e3d5c6b0a90d0a0ab4dd9866e73a9d78fdbc67de9903bf069e4ee5e303997355e891a54`
+[kubernetes-src.tar.gz](https://dl.k8s.io/v1.16.9/kubernetes-src.tar.gz) | `a5b1d1cbf871d11838ff5be961f22dfaa564f8f3e938571fc0ff87639cfb16193ecdb34ccba922f69f80769fb3f2cd78655fad3a3f4d3f5ebfe9834afbfc5293`
+
+### Client Binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-client-darwin-386.tar.gz](https://dl.k8s.io/v1.16.9/kubernetes-client-darwin-386.tar.gz) | `a876d5eba6955dcf868c6cb105c39a80dea4eea8de88aef464c8619bbd2a002d88598d50697d8a7d1490d21b3184b6107132bcb821d49da1e469a1ad19b549e4`
+[kubernetes-client-darwin-amd64.tar.gz](https://dl.k8s.io/v1.16.9/kubernetes-client-darwin-amd64.tar.gz) | `fad0cc9f88371c909490aa3430d060a8841cceebbb981b404447f933aeb8d4f35107a38f402705bbc7e7741a4a14c34bb6b8078b536865b3708329348e0a79c1`
+[kubernetes-client-linux-386.tar.gz](https://dl.k8s.io/v1.16.9/kubernetes-client-linux-386.tar.gz) | `2dcde1c42b85875bd90b04a9301a73144c0b0f768f585c6bb501f327e0652af62fad8d7a029d6753d6bcb9108b67a34725656906d8c065813fd0d9c9b84d5240`
+[kubernetes-client-linux-amd64.tar.gz](https://dl.k8s.io/v1.16.9/kubernetes-client-linux-amd64.tar.gz) | `c2e69794ad86799cf42aefa26f84d1353984c27eb6a5f360388c6bbfe9389ca5e1cf41a4dabf04a9d2b36557a7054a4623bf2c845508b483a982e77827f06629`
+[kubernetes-client-linux-arm.tar.gz](https://dl.k8s.io/v1.16.9/kubernetes-client-linux-arm.tar.gz) | `876aea3c3ab73765efa6eb657219b36501254a66d36b98274d730035b11cba48aaa9904181afb2df403f176c19d944564455d7af7d918a81dcc83cad07cb70d2`
+[kubernetes-client-linux-arm64.tar.gz](https://dl.k8s.io/v1.16.9/kubernetes-client-linux-arm64.tar.gz) | `d2892e6d81af5ed77186f620a67bf2fc4358d33af8fd818eb6952114df924d834d40efd12ba91e3cce07c664f3f7e902cf0413d86335b6b40c6f53b170ccf66f`
+[kubernetes-client-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.16.9/kubernetes-client-linux-ppc64le.tar.gz) | `dfbf993cad3f8b65c0addaa5f7d5e74490ef4e77abfeafc1111fea5a86a649bb5ad0300871c64270c5d6e6a779b000442fc7b56447565be18266c8088f65e1f4`
+[kubernetes-client-linux-s390x.tar.gz](https://dl.k8s.io/v1.16.9/kubernetes-client-linux-s390x.tar.gz) | `aa5a41350682300f1cb61230dd26f54135aa74eb537754ea8bdf7aff76a3d534c08730170ba80033c0c4d3628d22122bbd9c7b7d6768ac674cfa980cf0c04395`
+[kubernetes-client-windows-386.tar.gz](https://dl.k8s.io/v1.16.9/kubernetes-client-windows-386.tar.gz) | `6e81194ac21e37fd708371ef2df5a5c1276716dd7c9ac71023b7a53e8ba61e7e743fc93eafe0fe4d3be0ec521904dd0db98ea223dbfc3bc89536d9015701eaab`
+[kubernetes-client-windows-amd64.tar.gz](https://dl.k8s.io/v1.16.9/kubernetes-client-windows-amd64.tar.gz) | `79f9cdd12cb97b452fc0c66bb812eb0b78278714432c8b801ff3aef96da877fc5b6ed265bd58ae954a56fea9ec4a664fbaff50dacc76d632daa9671b05f8ea1b`
+
+### Server Binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-server-linux-amd64.tar.gz](https://dl.k8s.io/v1.16.9/kubernetes-server-linux-amd64.tar.gz) | `79d6e3f984134ede83e7ae1f9b072969a4e43d834815f772eba852c77eccc765b24a68f79514c0074cc3240c796d0be9b166957b7bc539394ded5f5c75cc9ea3`
+[kubernetes-server-linux-arm.tar.gz](https://dl.k8s.io/v1.16.9/kubernetes-server-linux-arm.tar.gz) | `7737906093c273324e0598ac60742ad748023d69c1d7bd151d0643d973a99c163fe309210e3f395f600ed77a4e1f39dc6c3db945728df10a0ebce706e8ee902e`
+[kubernetes-server-linux-arm64.tar.gz](https://dl.k8s.io/v1.16.9/kubernetes-server-linux-arm64.tar.gz) | `ff0138d2c91098b380c057db1562d90628806a0508b71ee702bc0608fbd460518cf47064338b569c3c2ff750b69ce6c1c9e6a6649865bed6d834325350e5bc83`
+[kubernetes-server-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.16.9/kubernetes-server-linux-ppc64le.tar.gz) | `b5d8f9271c9ab56a6417a54ff8a51772a465b2ef88713cea5349270c0b56c1e05e09033e69ebb4de3d73975f2ae100d56072e8af7f161f1c7f8e1d7348f25423`
+[kubernetes-server-linux-s390x.tar.gz](https://dl.k8s.io/v1.16.9/kubernetes-server-linux-s390x.tar.gz) | `3183d105eb334a2c82d5344b3b77d504daa5ec3310c0268e297014fe624f655febe7a7b515d28a8ffd19ceb083e5306dd2774e9b1623f2aec75983c11f913e49`
+
+### Node Binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-node-linux-amd64.tar.gz](https://dl.k8s.io/v1.16.9/kubernetes-node-linux-amd64.tar.gz) | `84a3c9e36835f8efa807569556a228c4a99582e1e559733152a6c02dd8a7b1bcdd3d5c722d34dcffbca898813b7d69cb9e1a338cbeb67a8142b91e091ee7b5ef`
+[kubernetes-node-linux-arm.tar.gz](https://dl.k8s.io/v1.16.9/kubernetes-node-linux-arm.tar.gz) | `4b68a56141351dc2bf5f7368b4cc7caa4f6320bfc98d9cf45d246ef7083bec2f90273b2fee700fdcb10e5123463bf2352af515be2a0b28b410a6a4f5358bcaa7`
+[kubernetes-node-linux-arm64.tar.gz](https://dl.k8s.io/v1.16.9/kubernetes-node-linux-arm64.tar.gz) | `798928c0904e1b02c5fb2963e8b9402f0847866a326765d070a27a9ea45c333f004f7b39a31dee8ac7d7bb2b40717419d4b0601346c78ac5ff39905211874c08`
+[kubernetes-node-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.16.9/kubernetes-node-linux-ppc64le.tar.gz) | `b417782b3d18a655ca4c52ce64eb8584e5e71ccefe6989c17d02e553f2f8e0be338ec5a0791e19439e48fe50562fda641828b73deb4e48239ae5a94dfdfb8d56`
+[kubernetes-node-linux-s390x.tar.gz](https://dl.k8s.io/v1.16.9/kubernetes-node-linux-s390x.tar.gz) | `3cff6b2fc22a29204c4d4dffd4e5f54e9f551f3adeaf512463523c1dfd1771316fb5da83b02a0dd1c124f4ef402d674b30bcc1b8c634ce61450f06c4f31f10db`
+[kubernetes-node-windows-amd64.tar.gz](https://dl.k8s.io/v1.16.9/kubernetes-node-windows-amd64.tar.gz) | `0e178894edde44dd43fe9aac94b2ff51c7ba239c0a3827c8dddac4970c361e3d72e44848af731c8b443c25a9ca3ca96b7aa24f42505fe27ccc401fc8e21050ec`
+
+## Changelog since v1.16.8
+
+## Changes by Kind
+
+### Feature
+
+- deps: Update to Golang 1.13.9
+  - build: Remove kube-cross image building ([#89400](https://github.com/kubernetes/kubernetes/pull/89400), [@justaugustus](https://github.com/justaugustus)) [SIG Release and Testing]
+
+### Bug or Regression
+
+- Client-go: resolves an issue with informers falling back to full list requests when timeouts are encountered, rather than re-establishing a watch. ([#89977](https://github.com/kubernetes/kubernetes/pull/89977), [@liggitt](https://github.com/liggitt)) [SIG API Machinery and Testing]
+- Ensure Azure availability zone is always in lower cases. ([#89722](https://github.com/kubernetes/kubernetes/pull/89722), [@feiskyer](https://github.com/feiskyer)) [SIG Cloud Provider]
+- Fix invalid VMSS updates due to incorrect cache ([#89002](https://github.com/kubernetes/kubernetes/pull/89002), [@ArchangelSDY](https://github.com/ArchangelSDY)) [SIG Cloud Provider]
+- Fix panic in kubelet when running IPv4/IPv6 dual-stack mode with a CNI plugin ([#82508](https://github.com/kubernetes/kubernetes/pull/82508), [@aanm](https://github.com/aanm)) [SIG Network and Node]
+- Fix the VMSS name and resource group name when updating Azure VMSS for LoadBalancer backendPools ([#89337](https://github.com/kubernetes/kubernetes/pull/89337), [@feiskyer](https://github.com/feiskyer)) [SIG Cloud Provider]
+- Fix: check disk status before delete azure disk ([#88360](https://github.com/kubernetes/kubernetes/pull/88360), [@andyzhangx](https://github.com/andyzhangx)) [SIG Cloud Provider]
+- Fixed a data race in kubelet image manager that can cause static pod workers to silently stop working. ([#88915](https://github.com/kubernetes/kubernetes/pull/88915), [@roycaihw](https://github.com/roycaihw)) [SIG Node]
+- Fixed an issue that could cause the kubelet to incorrectly run concurrent pod reconciliation loops and crash. ([#89055](https://github.com/kubernetes/kubernetes/pull/89055), [@tedyu](https://github.com/tedyu)) [SIG Node]
+- Fixes conversion error for HorizontalPodAutoscaler objects with invalid annotations ([#89968](https://github.com/kubernetes/kubernetes/pull/89968), [@liggitt](https://github.com/liggitt)) [SIG Autoscaling]
+- Fixes conversion error in multi-version custom resources that could cause metadata.generation to increment on no-op patches or updates of a custom resource. ([#88995](https://github.com/kubernetes/kubernetes/pull/88995), [@liggitt](https://github.com/liggitt)) [SIG API Machinery]
+- For GCE cluster provider, fix bug of not being able to create internal type load balancer for clusters with more than 1000 nodes in a single zone. ([#89902](https://github.com/kubernetes/kubernetes/pull/89902), [@wojtek-t](https://github.com/wojtek-t)) [SIG Cloud Provider, Network and Scalability]
+- For volumes that allow attaches across multiple nodes, attach and detach operations across different nodes are now executed in parallel. ([#89240](https://github.com/kubernetes/kubernetes/pull/89240), [@verult](https://github.com/verult)) [SIG Apps, Node and Storage]
+- Kubelet metrics gathered through metrics-server or prometheus should no longer timeout for Windows nodes running more than 3 pods. ([#87730](https://github.com/kubernetes/kubernetes/pull/87730), [@marosset](https://github.com/marosset)) [SIG Node, Testing and Windows]
+- Restores priority of static control plane pods in the cluster/gce/manifests control-plane manifests ([#89970](https://github.com/kubernetes/kubernetes/pull/89970), [@liggitt](https://github.com/liggitt)) [SIG Cluster Lifecycle and Node]
+
+### Other (Cleanup or Flake)
+
+- Reduce event spam during a volume operation error. ([#89794](https://github.com/kubernetes/kubernetes/pull/89794), [@msau42](https://github.com/msau42)) [SIG Storage]
+
+
+# v1.16.8
+
+[Documentation](https://docs.k8s.io)
+
+## Downloads for v1.16.8
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes.tar.gz](https://dl.k8s.io/v1.16.8/kubernetes.tar.gz) | `405aab246b6b49fa6654f982a11af0118ca86d33e84975f26c26e2f09a0781f7578d4ac90f2c889f12c600a93cdc7c57e91e29df6f67b3822573faba889f8fde`
+[kubernetes-src.tar.gz](https://dl.k8s.io/v1.16.8/kubernetes-src.tar.gz) | `553ad557dec7664ac910a2011c563c2f2960add05d88135a4832a601bea5afdf4145d30c64c27f2d95f3f7b33d9a401f1cd48a5fcba67ed5b45adbb493339f1f`
+
+### Client Binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-client-darwin-386.tar.gz](https://dl.k8s.io/v1.16.8/kubernetes-client-darwin-386.tar.gz) | `b16757163f07c44dc75464b9d08bd175c2e6c2d079455c83ffeefcbb65fe17ea638d6e5ce5106983f747414f63c5c8884db8ee28d284d96a1cfdada664928787`
+[kubernetes-client-darwin-amd64.tar.gz](https://dl.k8s.io/v1.16.8/kubernetes-client-darwin-amd64.tar.gz) | `9c8b1876385bf7c5f4cccf1f463b42ed588831e4168623e6076ae3709195398d53ab5b73c9a123d12caa26275fd889f3517b30f024038a96d98061568ee3484a`
+[kubernetes-client-linux-386.tar.gz](https://dl.k8s.io/v1.16.8/kubernetes-client-linux-386.tar.gz) | `64760d8861d12f79b78b09d8da02bddb6e3f4b069c4ba5e5e99cf057dc94741db06c91bfc5cc90e0194f4adaed52336c1676b5f35fa48e7d98c7553bb3443a29`
+[kubernetes-client-linux-amd64.tar.gz](https://dl.k8s.io/v1.16.8/kubernetes-client-linux-amd64.tar.gz) | `cbe62c70acd576ad3a84c34df50bb8c9f6245662b185f64064f5323da0b9d712c426f255458f6761d39fa004b22b86e773906d54f7e7f0489a02672fc0fab6f6`
+[kubernetes-client-linux-arm.tar.gz](https://dl.k8s.io/v1.16.8/kubernetes-client-linux-arm.tar.gz) | `8d84e5c19299d8d7ed4b064a3cac2f9168b6bd3d867f7a1d18f20ac122a071d3513e150efa1d1763e99b2d2c4d1c27b06e8daf80ad4daa60a98ea99a9f15884f`
+[kubernetes-client-linux-arm64.tar.gz](https://dl.k8s.io/v1.16.8/kubernetes-client-linux-arm64.tar.gz) | `e2d1c29733ee713788e6b863f4cbbb9064db788fa2a96d4307bb59d9d96bd5caf6932a04fc6e291e1031079725452e40774647ed9c23250faa1c6edc151036fe`
+[kubernetes-client-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.16.8/kubernetes-client-linux-ppc64le.tar.gz) | `54d749f7582614bc1b44ae41e001d8ec9073f764f15c4b243cbbb1d384ee4f5dc910ebb1cf4d0e46e6d5491f3834e1a793966a0b53786a76a2477948bd9baac1`
+[kubernetes-client-linux-s390x.tar.gz](https://dl.k8s.io/v1.16.8/kubernetes-client-linux-s390x.tar.gz) | `e3d5036e77f919a1f0270d5c8342e615dd411ed19cc766844a55872cd903892086ae50f247aea469b671cc45ebc78818023e0bb42db4d3e5f2efa9298f2e080b`
+[kubernetes-client-windows-386.tar.gz](https://dl.k8s.io/v1.16.8/kubernetes-client-windows-386.tar.gz) | `f845e73d36e222c60f04b614a800af46d1ed7b6775300cde7bd2188067a8e01896cb452d171b187c399c568cb6a87a36837488b50556fb1f053a81efd4e16a8d`
+[kubernetes-client-windows-amd64.tar.gz](https://dl.k8s.io/v1.16.8/kubernetes-client-windows-amd64.tar.gz) | `66ab87a9156c8ea290ccded3511e81048e1f99a8db713ad2f15c2af68ac55c74ec4aa718e7835cbf12e97be43ca9bf3e770cbae321d5e3270af42b0d778f6f47`
+
+### Server Binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-server-linux-amd64.tar.gz](https://dl.k8s.io/v1.16.8/kubernetes-server-linux-amd64.tar.gz) | `335ade6adf7704b232e0bea7c6556d46d235d0c963a04c0dda8b783c91a06a5b7656226bc977234dfbd596d43ee6183291f969110fb74dc70df1eacd4bb633a7`
+[kubernetes-server-linux-arm.tar.gz](https://dl.k8s.io/v1.16.8/kubernetes-server-linux-arm.tar.gz) | `7902321cad51c10104d9346939df3f0377c71da40fccc9d459b3cdd83ce96fcdcc69dfe4a5cbad05cfc2eaa0655e4fb197fff4a04122808f06f1b62f7f290828`
+[kubernetes-server-linux-arm64.tar.gz](https://dl.k8s.io/v1.16.8/kubernetes-server-linux-arm64.tar.gz) | `82c57aa319237a26c5e97cf3d8394f8f71475f5c307c5cb244cd70aca5e5c87a3a1397b9d1f1ebf864a5f32cd2f0427ce38b2ae41003c08a7a145b29fa470545`
+[kubernetes-server-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.16.8/kubernetes-server-linux-ppc64le.tar.gz) | `971836cda047974048f55db5478e5c250ded6b55077bb73cf05f53e7a9be0fa88ab8003064c6bea1c002818ef18f72fe72cb3e25ae89b3fe062086ee9f8d06ae`
+[kubernetes-server-linux-s390x.tar.gz](https://dl.k8s.io/v1.16.8/kubernetes-server-linux-s390x.tar.gz) | `6595619e59cf26725c4e5570226931e544c895e1e75dc2d9779ae8f222c68dfbaebe080f582634cc3398cd158b4cb489ff45ac412756a20755d57f9471f2dd76`
+
+### Node Binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-node-linux-amd64.tar.gz](https://dl.k8s.io/v1.16.8/kubernetes-node-linux-amd64.tar.gz) | `6b55c0d7375310ea35a12f312ae95d789ce44e590945748c6825bcc8778542865d6d2e09ed1f51af7cd1786a4aa5e47edc86690dae9abd28b11c34d570f963a4`
+[kubernetes-node-linux-arm.tar.gz](https://dl.k8s.io/v1.16.8/kubernetes-node-linux-arm.tar.gz) | `a06012a6c51a66f59fd3bd0675d20c167d8530998bce630fc9390c26c9b45f59acdde01f71269911d5842591a0dab186c550d1e3cb1a0a65f2d7623f6648a1a2`
+[kubernetes-node-linux-arm64.tar.gz](https://dl.k8s.io/v1.16.8/kubernetes-node-linux-arm64.tar.gz) | `81332cdd792efbc9caf2c3ee57567934155c84f813476305da958d5b69e200e42a10f5d2b2e495b4c66fa127709a01e343b7612bcba2c39ecaf5fe03a284a638`
+[kubernetes-node-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.16.8/kubernetes-node-linux-ppc64le.tar.gz) | `fcbf2c8cbc893bed8c949005f2a9ad2ed461d30eb15d066c37ae14f35f745e701b207eaa425a8af76de54762d3046c2d68cffacaf4e9c78e82195db586c8b021`
+[kubernetes-node-linux-s390x.tar.gz](https://dl.k8s.io/v1.16.8/kubernetes-node-linux-s390x.tar.gz) | `8bb5852950167ee3c9402434b661e96764e915da6aa5101b99079ab2a181525ea417b64a4ea4a19313be843fdc68f42d92d4ab577ee9d2126a65c2bd37960146`
+[kubernetes-node-windows-amd64.tar.gz](https://dl.k8s.io/v1.16.8/kubernetes-node-windows-amd64.tar.gz) | `d22d00291b7ae6dcda480f65c1c20cec6bc430cb4bd679bcf5328c8a9d46dd9f23bcc1bbf6bf037ed3488603a050c5346b494cf153053aa2354634c0cf7aae06`
+
+## Changelog since v1.16.7
+
+## Changes by Kind
+
+### API Change
+
+- Fixes a regression with clients prior to 1.15 not being able to update podIP in pod status, or podCIDR in node spec, against >= 1.16 API servers ([#88505](https://github.com/kubernetes/kubernetes/pull/88505), [@liggitt](https://github.com/liggitt)) [SIG Apps and Network]
+
+### Other (Bug, Cleanup or Flake)
+
+- Add delays between goroutines for vm instance update ([#88094](https://github.com/kubernetes/kubernetes/pull/88094), [@aramase](https://github.com/aramase)) [SIG Cloud Provider]
+- Build: Enable kube-cross image-building on K8s Infra ([#88596](https://github.com/kubernetes/kubernetes/pull/88596), [@justaugustus](https://github.com/justaugustus)) [SIG Release and Testing]
+- Fix /readyz to return error immediately after a shutdown is initiated, before the --shutdown-delay-duration has elapsed. ([#88954](https://github.com/kubernetes/kubernetes/pull/88954), [@tkashem](https://github.com/tkashem)) [SIG API Machinery]
+- Fix a bug in kube-proxy that caused it to crash when using load balancers with a different IP family ([#87117](https://github.com/kubernetes/kubernetes/pull/87117), [@aojea](https://github.com/aojea)) [SIG Network]
+- Fix a regression in kubenet  that  prevent pods to obtain ip addresses ([#87287](https://github.com/kubernetes/kubernetes/pull/87287), [@aojea](https://github.com/aojea)) [SIG Network and Node]
+- Fix handling of aws-load-balancer-security-groups annotation. Security-Groups assigned with this annotation are no longer modified by kubernetes which is the expected behaviour of most users. Also no unnecessary Security-Groups are created anymore if this annotation is used. ([#88690](https://github.com/kubernetes/kubernetes/pull/88690), [@Elias481](https://github.com/Elias481)) [SIG Cloud Provider]
+- Fix route conflicted operations when updating multiple routes together ([#88209](https://github.com/kubernetes/kubernetes/pull/88209), [@feiskyer](https://github.com/feiskyer)) [SIG Cloud Provider]
+- Fix the problem where couple nodes becoming NotReady at the same time could cause master instability or even complete outage in large enough clusters. ([#88959](https://github.com/kubernetes/kubernetes/pull/88959), [@mborsz](https://github.com/mborsz)) [SIG Apps]
+- Fix: add remediation in azure disk attach/detach ([#88444](https://github.com/kubernetes/kubernetes/pull/88444), [@andyzhangx](https://github.com/andyzhangx)) [SIG Cloud Provider]
+- Fix: azure file mount timeout issue ([#88610](https://github.com/kubernetes/kubernetes/pull/88610), [@andyzhangx](https://github.com/andyzhangx)) [SIG Cloud Provider and Storage]
+- Fix: corrupted mount point in csi driver ([#88569](https://github.com/kubernetes/kubernetes/pull/88569), [@andyzhangx](https://github.com/andyzhangx)) [SIG Storage]
+- Fix: get azure disk lun timeout issue ([#88158](https://github.com/kubernetes/kubernetes/pull/88158), [@andyzhangx](https://github.com/andyzhangx)) [SIG Cloud Provider and Storage]
+- Fixed `threadSafeMap` high memory usage caused by indices that have churn of high-cardinality keys. E.g. namespaces ([#88007](https://github.com/kubernetes/kubernetes/pull/88007), [@patrickshan](https://github.com/patrickshan)) [SIG API Machinery]
+- Fixes issue where you can't attach more than 15 GCE Persistent Disks to c2, n2, m1, m2 machine types. ([#88602](https://github.com/kubernetes/kubernetes/pull/88602), [@yuga711](https://github.com/yuga711)) [SIG Storage]
+- Fixes kubelet crash in client certificate rotation cases ([#88079](https://github.com/kubernetes/kubernetes/pull/88079), [@liggitt](https://github.com/liggitt)) [SIG API Machinery, Auth and Node]
+- Get-kube.sh uses the gcloud's current local GCP service account for auth when the provider is GCE or GKE instead of the metadata server default ([#88383](https://github.com/kubernetes/kubernetes/pull/88383), [@BenTheElder](https://github.com/BenTheElder)) [SIG Cluster Lifecycle]
+- Golang/x/net has been updated to bring in fixes for CVE-2020-9283 ([#88381](https://github.com/kubernetes/kubernetes/pull/88381), [@BenTheElder](https://github.com/BenTheElder)) [SIG API Machinery, CLI, Cloud Provider, Cluster Lifecycle and Instrumentation]
+- Limit number of instances in a single update to GCE target pool to 1000. ([#87881](https://github.com/kubernetes/kubernetes/pull/87881), [@wojtek-t](https://github.com/wojtek-t)) [SIG Cloud Provider, Network and Scalability]
+- Update to use golang 1.13.8 ([#87648](https://github.com/kubernetes/kubernetes/pull/87648), [@ialidzhikov](https://github.com/ialidzhikov)) [SIG Release and Testing]
+
+
+# v1.16.7
+
+[Documentation](https://docs.k8s.io)
+
+## Downloads for v1.16.7
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes.tar.gz](https://dl.k8s.io/v1.16.7/kubernetes.tar.gz) | `dc95ba079242d2cd0b4b48f960c2b7c097e25228a2e36f08e3a611c91eedeed2d58971bf33604d28e50aae5068f04d669a8889b619d9cee5b1e71f7b5d7f2206`
+[kubernetes-src.tar.gz](https://dl.k8s.io/v1.16.7/kubernetes-src.tar.gz) | `d8f41693601a2876f537239b43ce30cf5162d30152ced81c63d0fc01560a884abfc3c99a632285f73ab5b6292a508c00b8f0b07d6f6a5b52ce34b4b6549a70ee`
+
+### Client Binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-client-darwin-386.tar.gz](https://dl.k8s.io/v1.16.7/kubernetes-client-darwin-386.tar.gz) | `d80cdde0ee493da3e7780a2468031554bea1c6e9f078e2b15c2fc688472d1ba591ded2653b5c011ec6b11e5671194a166f83ae375d192df7b59437e6c3c3a09a`
+[kubernetes-client-darwin-amd64.tar.gz](https://dl.k8s.io/v1.16.7/kubernetes-client-darwin-amd64.tar.gz) | `6379aa1a10dd6922ca4ef4e03d34c0ab02a7c955052f533c2023b34f9b79f27baec0adcee0f0da83e034de019f4c0c66738e4879505016dc47a70a57b44b100e`
+[kubernetes-client-linux-386.tar.gz](https://dl.k8s.io/v1.16.7/kubernetes-client-linux-386.tar.gz) | `07f33999629f88dbad5dad1cf56671795d003506ab2c8295ff77ad1470d887f551927dd201a625dafef3f93fb283f6b7366509c050bdfe16cdd45d779c61f7ac`
+[kubernetes-client-linux-amd64.tar.gz](https://dl.k8s.io/v1.16.7/kubernetes-client-linux-amd64.tar.gz) | `df4b8ef210f5daf5b75000f2ebc54c3e10d0f30da97adcd83eeef7bd3f193df440c47da73bc71e83dae8d52a3ea7251d2b3293c84594da36187d193a5d26576f`
+[kubernetes-client-linux-arm.tar.gz](https://dl.k8s.io/v1.16.7/kubernetes-client-linux-arm.tar.gz) | `d33f094701da1c35c83459648beba90bf525375b82831e34a45da46ac11013b42ba3aa8270a9e3af14f6afae980b298383759e477a492980f868cc18a9510f1b`
+[kubernetes-client-linux-arm64.tar.gz](https://dl.k8s.io/v1.16.7/kubernetes-client-linux-arm64.tar.gz) | `9024da038c0ebfb739787e75ca2a78fff0265d4b0bb241648f76ff18f0bdd731da6617182d0f0d827668d81c27f24e95dd26102f5e297ba46a2fbd3dfb2d05d9`
+[kubernetes-client-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.16.7/kubernetes-client-linux-ppc64le.tar.gz) | `362e67bf6f9d8c8dff2c7e8ef0fab6701992575c9afe640edccbe86426dfe98864be663217b7354e1ae1701c505786256b740a98fed2c08338e0caa132bb1faa`
+[kubernetes-client-linux-s390x.tar.gz](https://dl.k8s.io/v1.16.7/kubernetes-client-linux-s390x.tar.gz) | `958f1d9a98e2b75aebb3a5e33882205a0935f8cf812dbcd152242a295a5534b592c3ffada169f0ed183ab32f87929f5c706aa1db0ab1ec4be2d88a3819480d8e`
+[kubernetes-client-windows-386.tar.gz](https://dl.k8s.io/v1.16.7/kubernetes-client-windows-386.tar.gz) | `87e58926ffabe47b42dedcecf34212a92f67326826b6928cf8143f0baf03cc71cd4b2bcd0f01b9947742bac4ab4cbd24c5c0770aabc4be38e36481d2dd280bb1`
+[kubernetes-client-windows-amd64.tar.gz](https://dl.k8s.io/v1.16.7/kubernetes-client-windows-amd64.tar.gz) | `c7e7892b7845246670bb2d309c55196e4635e10f5c651de281a1f8045f122a70194a397e4ee900e1a0cd65761d6a03b76843ca8c16ddc89420df28a20bc9b999`
+
+### Server Binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-server-linux-amd64.tar.gz](https://dl.k8s.io/v1.16.7/kubernetes-server-linux-amd64.tar.gz) | `e49a47530efc893118e0042e0f0ee3d04f01240bddf7f4e1e440d0da27f822a51e9504c08cfd7b28c0d82dc43252f64ed46c9eb7f31f7c8da88098705174a16e`
+[kubernetes-server-linux-arm.tar.gz](https://dl.k8s.io/v1.16.7/kubernetes-server-linux-arm.tar.gz) | `7b5f3f9a82d2864bd155339ecdc260aaa09bd0d95a594599583f57dade5ad43238b77a8d1c83a46e25a899693ce2dcc07fddbefab4ef6c3ec6266cad126dca41`
+[kubernetes-server-linux-arm64.tar.gz](https://dl.k8s.io/v1.16.7/kubernetes-server-linux-arm64.tar.gz) | `66a2d2b49045a38aa6a1797aba3cae676aee5e21816096f3853efe2ab050575739e01c361bc8377f2af065f6e41e8ecdf99e73fb5cf619263778aef31fd630f6`
+[kubernetes-server-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.16.7/kubernetes-server-linux-ppc64le.tar.gz) | `ff8c651bce2bbd271e90f3964cb5e0674dd20054c451ccb9f542c4f8b7b75ad71f477981c6d59135d424b5ce0f69484fa9376398de9837a7cf34d58fb4a94bf8`
+[kubernetes-server-linux-s390x.tar.gz](https://dl.k8s.io/v1.16.7/kubernetes-server-linux-s390x.tar.gz) | `5836ee2774de947ebaa5ae08a8a86bc0213c7c3518de2461a4b5aa7e4a60d49556c27bacada22b848522a937cb9f6765272dacb2c664d4adf46ea7e8a51fd527`
+
+### Node Binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-node-linux-amd64.tar.gz](https://dl.k8s.io/v1.16.7/kubernetes-node-linux-amd64.tar.gz) | `1bc7b5eac5e36b3215356e8d2447cfd7061571dfc0a8a87d9d021da0b38e904ac2a6a8a9652adea619063aa09e6b74a014cbeb20ec67a62ced81917392dfeac4`
+[kubernetes-node-linux-arm.tar.gz](https://dl.k8s.io/v1.16.7/kubernetes-node-linux-arm.tar.gz) | `4f0950d43478c8f94030fd25a30c21d9d9555465fc7183aa4325564dbd223c21038aaa02becd629ac3990bc5a4d0b7fcdec386b9dc8b60efd7d5041be6c12fa2`
+[kubernetes-node-linux-arm64.tar.gz](https://dl.k8s.io/v1.16.7/kubernetes-node-linux-arm64.tar.gz) | `f272c4ad555ba8d5d4fbb5650edf11c1ee0cd5bdee53df06a494108661be450d101a4c9cd4df16709d88d36287e6bdd8aa4431b7d87c79e3efddd3a8ecb43eb1`
+[kubernetes-node-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.16.7/kubernetes-node-linux-ppc64le.tar.gz) | `2b0c908e2167c919b2e7e85df7160de7815949e95f4fef00b767cb931924ad4119294dc8784aed2531db2dc3ed99942fb1efa03cf4b844ad896111f50a23c06f`
+[kubernetes-node-linux-s390x.tar.gz](https://dl.k8s.io/v1.16.7/kubernetes-node-linux-s390x.tar.gz) | `295e451c9e278ebb8b6fa15f5df43ab127f7acf02fcaba609de2ab4b36f12077fe74716773f4e23f1acbba8a14619ed84a407834b1ee8694f0af95f5b0cf800d`
+[kubernetes-node-windows-amd64.tar.gz](https://dl.k8s.io/v1.16.7/kubernetes-node-windows-amd64.tar.gz) | `53af7e2ffb41a7f87160128326657d8a73549ffb22c7b6d17a4283f8f574bf60fd5c3b2a2d8ca92058b0943be3d1323f668329b3fac3b7a53ab853298c0f17b8`
+
+## Changelog since v1.16.6
+
+## Changes by Kind
+
+### Other (Bug, Cleanup or Flake)
+
+- Bind metrics-server containers to linux nodes to avoid Windows scheduling on kubernetes cluster includes linux nodes and windows nodes ([#87022](https://github.com/kubernetes/kubernetes/pull/87022), [@wawa0210](https://github.com/wawa0210)) [SIG Cluster Lifecycle]
+- Fix the bug PIP's DNS is deleted if no DNS label service annotation isn't set. ([#87311](https://github.com/kubernetes/kubernetes/pull/87311), [@nilo19](https://github.com/nilo19)) [SIG Cloud Provider]
+- Fix: set nil cache entry based on old cache ([#87592](https://github.com/kubernetes/kubernetes/pull/87592), [@aramase](https://github.com/aramase)) [SIG Cloud Provider]
+- Fixed a bug which could prevent a provider ID from ever being set for node if an error occurred determining the provider ID when the node was added. ([#87043](https://github.com/kubernetes/kubernetes/pull/87043), [@zjs](https://github.com/zjs)) [SIG Apps and Cloud Provider]
+- Fixed the following 
+  -  AWS Cloud Provider attempts to delete LoadBalancer security group it didn’t provision
+  -  AWS Cloud Provider creates default LoadBalancer security group even if annotation [service.beta.kubernetes.io/aws-load-balancer-security-groups] is present ([#87207](https://github.com/kubernetes/kubernetes/pull/87207), [@bhagwat070919](https://github.com/bhagwat070919)) [SIG Cloud Provider]
+- Fixed two scheduler metrics (pending_pods and schedule_attempts_total) not being recorded ([#87692](https://github.com/kubernetes/kubernetes/pull/87692), [@everpeace](https://github.com/everpeace)) [SIG Scheduling]
+- Kubelet metrics have been changed to buckets. 
+  For example the exec/{podNamespace}/{podID}/{containerName} is now just exec. ([#87913](https://github.com/kubernetes/kubernetes/pull/87913), [@cheftako](https://github.com/cheftako)) [SIG Node]
+- Openstack: Do not delete managed LB in case of security group reconciliation errors ([#82264](https://github.com/kubernetes/kubernetes/pull/82264), [@multi-io](https://github.com/multi-io)) [SIG Cloud Provider]
+- Reverted a kubectl azure auth module change where oidc claim spn: prefix was omitted resulting a breaking behavior with existing Azure AD OIDC enabled api-server ([#87507](https://github.com/kubernetes/kubernetes/pull/87507), [@weinong](https://github.com/weinong)) [SIG API Machinery, Auth and Cloud Provider]
+- The client label for apiserver_request_count and apiserver_request_total now no-opts and merely records an empty string. ([#87673](https://github.com/kubernetes/kubernetes/pull/87673), [@logicalhan](https://github.com/logicalhan)) [SIG API Machinery, Instrumentation and Scalability]
+- The docker container runtime now enforces a 220 second timeout on container network operations. ([#71653](https://github.com/kubernetes/kubernetes/pull/71653), [@liucimin](https://github.com/liucimin)) [SIG Network and Node]
+
+
+<!-- NEW RELEASE NOTES ENTRY -->
+
+
+# v1.16.6
+
+[Documentation](https://docs.k8s.io)
+
+## Downloads for v1.16.6
+
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes.tar.gz](https://dl.k8s.io/v1.16.6/kubernetes.tar.gz) | `cde4a4285400f92a47ced2c0bced384408b2e38c429726ea8a60ea63bd0bb6efb67282c424409ba92c8e97334708820a21b3b639364c6b2184ae4d5a3a254f82`
+[kubernetes-src.tar.gz](https://dl.k8s.io/v1.16.6/kubernetes-src.tar.gz) | `1d534f5f014e3a0d876932ecf932000622c8d435c056e553630898c017fd19cfd9408ad887a61c252f232bbbd5d7535b2a0f8dccda362ca1468a5ef1a3b40602`
+
+### Client Binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-client-darwin-386.tar.gz](https://dl.k8s.io/v1.16.6/kubernetes-client-darwin-386.tar.gz) | `6f83f4a85110d778120da77c4ae9bbbd2ad3cb39ff2bdeb4966452fdd8e27f73f287a7d2a7aff82dcf45de973d655cc026cb874a3cd63dbbd3a939db12327a74`
+[kubernetes-client-darwin-amd64.tar.gz](https://dl.k8s.io/v1.16.6/kubernetes-client-darwin-amd64.tar.gz) | `7708012605e73ee16edb9124a714571ef943a702eb8e7e20a63932d75a56bfcde46020f0babada681cb2858bb4dfa30749c6b00534a6a70e0d682634507887a4`
+[kubernetes-client-linux-386.tar.gz](https://dl.k8s.io/v1.16.6/kubernetes-client-linux-386.tar.gz) | `9de5684263db702f42a38ff770f35601118320edf8e9d48887b24d55af84571e7e13baf68e2a64ec2a349f740a9d8dedee882b144ed46dd86a8fb33993887c01`
+[kubernetes-client-linux-amd64.tar.gz](https://dl.k8s.io/v1.16.6/kubernetes-client-linux-amd64.tar.gz) | `fa078c6e66c7fc7ec5a7551c714b14b44b68817d87d8a4238a17f1452a382cfc6455a2c3468ce45ba4edf473036af7b92668ce1ba6df05c5dbd902f6f308d5f9`
+[kubernetes-client-linux-arm.tar.gz](https://dl.k8s.io/v1.16.6/kubernetes-client-linux-arm.tar.gz) | `7f0ac2703407e159fee2159056127a45e9c4538763ebb69b5085e3edece22b31d0fdf2b7b1d3febc2d495c7e187033638d8f721e052f510dbd4c1a18435f5764`
+[kubernetes-client-linux-arm64.tar.gz](https://dl.k8s.io/v1.16.6/kubernetes-client-linux-arm64.tar.gz) | `ea83f7c5b6376437d1c5d87dc833e78b4931b4b3b1fc2a4e0a0076483a850c1cb48099ab53f414ab0e38c206ead4cbbfb08c45871b928823b77a6d90fe72867c`
+[kubernetes-client-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.16.6/kubernetes-client-linux-ppc64le.tar.gz) | `29038b137eb9e00767e3faeb2d72f45c3495c273c88541330ad870089ec868c96ab7ce826c059858760500a4bbc0623ffa434b42ff528f1984eafa3223e5bd2d`
+[kubernetes-client-linux-s390x.tar.gz](https://dl.k8s.io/v1.16.6/kubernetes-client-linux-s390x.tar.gz) | `f7a31fccf23c3ba114efb087facf2ef729a3c5288d0e53da550a25c0756554e7740e6ba4d058c7e0098b5cebc42298ad3d8237b94c395f2adb37c8de552c8c07`
+[kubernetes-client-windows-386.tar.gz](https://dl.k8s.io/v1.16.6/kubernetes-client-windows-386.tar.gz) | `de14a4a163bcd6b38edadb22a440d9fcd70d69ac4fa81b11d00c860d8bfda4698be588f3823234dbae7ea6195e7968b510065f2111d70e274fdf667a5aa7a648`
+[kubernetes-client-windows-amd64.tar.gz](https://dl.k8s.io/v1.16.6/kubernetes-client-windows-amd64.tar.gz) | `c209002db706691e3a44bdf65ed99d36878c0fc59df0121c74a4e32f35a701bdd30fe3c5ed3424b1e85c94b7df41ec657e93f60d2c9b5ce9115250e18f172d42`
+
+### Server Binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-server-linux-amd64.tar.gz](https://dl.k8s.io/v1.16.6/kubernetes-server-linux-amd64.tar.gz) | `eb647feb475550c3bb3841a91a1512b0836d0cee9eef0cda3292fe182307caa27be8a589dcfae8ad7cd70d0b028ea3645a36e7d486a03bcb84d351d08c5e79b6`
+[kubernetes-server-linux-arm.tar.gz](https://dl.k8s.io/v1.16.6/kubernetes-server-linux-arm.tar.gz) | `cd1994e92768b5f879ff856ccb6f688646d2f6011c543192b1ece16a25e585b2baece4bd74341d95daa2c78d60fe6c0b0d96e8ea8691bd109529290770438115`
+[kubernetes-server-linux-arm64.tar.gz](https://dl.k8s.io/v1.16.6/kubernetes-server-linux-arm64.tar.gz) | `6119311e77d194b3daa81d71fe3e2bf8762ea9c48417215b9a52d2b351c45751b4d4222afb21ea33f205451c6e183ccb224bf60b939a085f9dcb7c321e855407`
+[kubernetes-server-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.16.6/kubernetes-server-linux-ppc64le.tar.gz) | `5f6ff761146ec59cf118caf36c89545b5ff3c6a3536a5c7a275da365d9dbf420a80af45e809830f4d27e72b2d94b62206c6e3c229152b4dfe80eb205f2278b7f`
+[kubernetes-server-linux-s390x.tar.gz](https://dl.k8s.io/v1.16.6/kubernetes-server-linux-s390x.tar.gz) | `7d35c984bfbd520078785d2164d5a96e27953536adad1f7b0f39f3f6fe82461dcce8f0fec5fc13720446a9a4380288ae7cee523632aa8e2dd2e4a053c8aeb3b2`
+
+### Node Binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-node-linux-amd64.tar.gz](https://dl.k8s.io/v1.16.6/kubernetes-node-linux-amd64.tar.gz) | `a39c7ab21f58f7d47ec17a8ecdb6f08a3f6302ea6dcdd54fee87660df4325cc3557055a60da190f545b1c763140eceaa44bfa5ee86c24a8062a5652bb441e62b`
+[kubernetes-node-linux-arm.tar.gz](https://dl.k8s.io/v1.16.6/kubernetes-node-linux-arm.tar.gz) | `ab7ea3164f83a719a6dabf701e6673b5c082fe9b26a111fb354eb772a355d077c5ff992331683b22b970706d4badc2a35bdd32b4c1a17e9fcb0a40f48925aaab`
+[kubernetes-node-linux-arm64.tar.gz](https://dl.k8s.io/v1.16.6/kubernetes-node-linux-arm64.tar.gz) | `5c4f788f37d48fedf95ea8ed9e5778219c2847e40e63de06b5342aa8564321bdcf3dc224cc9bfe13526a31ee3d1353230abdbe59bc0119e5f231a48e8264df17`
+[kubernetes-node-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.16.6/kubernetes-node-linux-ppc64le.tar.gz) | `2a67a8c2b0455077aa35a8b949854a27a9ce7c36f169a75ecec638fba9115eef4949f6c6be9f0dd3f8dc1485b47dc5ab5938d77391b921edfc224d9e774e770b`
+[kubernetes-node-linux-s390x.tar.gz](https://dl.k8s.io/v1.16.6/kubernetes-node-linux-s390x.tar.gz) | `cced562021cf512967fe2c3ee169d6f20c00df242b47d4a3d7c8dce47da3a622bcb8f50cf10fa92e6b9a1e2f345487d58f1926188cab9df09142fdf26078a88f`
+[kubernetes-node-windows-amd64.tar.gz](https://dl.k8s.io/v1.16.6/kubernetes-node-windows-amd64.tar.gz) | `cb0ca5f0b7e051409d8da99c8d8270d4fb7565e85f963dc55d8874f9d686f9050ffedeb84a0b82a26921ab75ff87d854c7b6849231f34c8cdbae275cfec15189`
+
+## Changelog since v1.16.5
+
+**No notable changes for this release**
+
+
+
+# v1.16.5
+
+[Documentation](https://docs.k8s.io)
+
+## Downloads for v1.16.5
+
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes.tar.gz](https://dl.k8s.io/v1.16.5/kubernetes.tar.gz) | `574c4abd42d3640eb98bf4144afc64bbe25b752235d3398e3717a64fa505b5848e3e0b7a31cbea13d936201844c4f6385006556cf8c191f7bdac638a388345b9`
+[kubernetes-src.tar.gz](https://dl.k8s.io/v1.16.5/kubernetes-src.tar.gz) | `b85014dd97af562f966505cfaf7346aea61ed4a027d58655dc0c6148f2893e8f4309465fc0f66e3abc1e394c34f64754df78229384aacf529e834b026b84f96b`
+
+### Client Binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-client-darwin-386.tar.gz](https://dl.k8s.io/v1.16.5/kubernetes-client-darwin-386.tar.gz) | `becf76f632c6e1cb65074e0a0f9b4d978d9f2c6896faca29a46d4059d4ee5d8663c44dfc868157a1549c333c010015cb91fa1299c224c38af2ee49d84801bfa2`
+[kubernetes-client-darwin-amd64.tar.gz](https://dl.k8s.io/v1.16.5/kubernetes-client-darwin-amd64.tar.gz) | `b073fbe7c435b8498e1a154ba4c50aec7bc75956c3ba3d9679ecb3e172716aabf3e6190309ee508449efe0bf01eeec0bccf4620d0cbd73323e6af9ba09e65cb3`
+[kubernetes-client-linux-386.tar.gz](https://dl.k8s.io/v1.16.5/kubernetes-client-linux-386.tar.gz) | `e6462531b8e2df8e04aae1e75bcf78cdc5879ff90d09438355388d14cbee5b0d1895c1f9cfb8acfe50cb0aa246d8a900050b52b77383e76497417d810f7bf7d4`
+[kubernetes-client-linux-amd64.tar.gz](https://dl.k8s.io/v1.16.5/kubernetes-client-linux-amd64.tar.gz) | `d37424d8d5a275aa949d9b92d448643e4951ae16458135f44f2f4e3c66f379a4fe53e4d46bb0abd07623bf7b8b7bfd7bf9de019a3077dc28e26d13b0533c5559`
+[kubernetes-client-linux-arm.tar.gz](https://dl.k8s.io/v1.16.5/kubernetes-client-linux-arm.tar.gz) | `9b47ed83fcf48355b7ed53619aa6cb32401e367de839f71d316b9ce52000180a358547bf03b58e1cfb763c5bafb6c8841c1b4bfbc6ab8428a51024323549270d`
+[kubernetes-client-linux-arm64.tar.gz](https://dl.k8s.io/v1.16.5/kubernetes-client-linux-arm64.tar.gz) | `762c8a4f65b370c4707770cb211014d4fe2e6f0a19eab883bb06a36a29cd8db3e30a044a11d327d11140b4fb1f555849730c71b08b469f9edc13def79df0cad3`
+[kubernetes-client-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.16.5/kubernetes-client-linux-ppc64le.tar.gz) | `a84010df85b0bb4e8f3e75ad2566fe1e5378dcb812cbd2888c9c5f81640db849b0f82f5ebac3d585e67c37b2c6ec74d425870a66a89e399a64cf59d414afbc6c`
+[kubernetes-client-linux-s390x.tar.gz](https://dl.k8s.io/v1.16.5/kubernetes-client-linux-s390x.tar.gz) | `268dcae0bea43cc91f7eaca7695ffa037875de9f0dfa723667dad24dca569083a609f8873e4c4491ecbdba902b61ec3c39a223ca5e5c4455142109fc5c9c428d`
+[kubernetes-client-windows-386.tar.gz](https://dl.k8s.io/v1.16.5/kubernetes-client-windows-386.tar.gz) | `90895ca4a375fbb4f638d29cd5fb6ea7a49bbb8a6d608fbf4474e99a5b82903a0b7a71fb7234d9abe410100616072ac5560bf5a6698bd41cb23e7c0fa5beec88`
+[kubernetes-client-windows-amd64.tar.gz](https://dl.k8s.io/v1.16.5/kubernetes-client-windows-amd64.tar.gz) | `df6655957b8f8aa0e2baae25b7018753a9f921b4b08a509d9ac22fb299151fe04e5aded9196b7c5b0e5d42a02791d7e973266825fa938479746052f2fa1a7c02`
+
+### Server Binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-server-linux-amd64.tar.gz](https://dl.k8s.io/v1.16.5/kubernetes-server-linux-amd64.tar.gz) | `673308a4a5e4f01aa45d44f7fdbb4c66f7158f47e74cd0f8dd2b0877f18dee71b71973ca94e2a8c075014a14542c680d4b0c43cd9794245965577e929ee0b736`
+[kubernetes-server-linux-arm.tar.gz](https://dl.k8s.io/v1.16.5/kubernetes-server-linux-arm.tar.gz) | `646cf65bae430d78e201c3c4a5c1fbdbc5361cc07e4271b3d04f28d5838060a7f5e47f1bafaeac26862d1a484ec6d2f5c4ae1163609ccf0c4b2a640ebcb7198e`
+[kubernetes-server-linux-arm64.tar.gz](https://dl.k8s.io/v1.16.5/kubernetes-server-linux-arm64.tar.gz) | `c0fd58e4fb4fb923a5d9f421fb3f574940c99e71343bc7bfa06b24be45b4f4053fc6fe1e6ad1bc6585dfd54a4350864edbec75f376dbb5609fb158da122676ad`
+[kubernetes-server-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.16.5/kubernetes-server-linux-ppc64le.tar.gz) | `3ea6a69d4ca2254f0e4df61e57de9cffdd0e5fcd1fbba5b3772e969f54f1399847c3f580a3f7573d7a720d066122c504f8093ca0b8fcb61b2e7040dd7b99d174`
+[kubernetes-server-linux-s390x.tar.gz](https://dl.k8s.io/v1.16.5/kubernetes-server-linux-s390x.tar.gz) | `a00cc44fa9a3ad320573cff4142a9edb80e7c1305827ba81a4c6bbaf92870215d05b63280de721d3d8015bc721d2e5cbef67e23ba949d36c361cb4e519d6829e`
+
+### Node Binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-node-linux-amd64.tar.gz](https://dl.k8s.io/v1.16.5/kubernetes-node-linux-amd64.tar.gz) | `5ea212cb4cb06f099639d5a573e3ac3c4df38d12a76695298abffaedae6a7c0259b974e7b185f67fca39791cedef7e827a908e0c2e0f6ead87010ab8d7bd0fe9`
+[kubernetes-node-linux-arm.tar.gz](https://dl.k8s.io/v1.16.5/kubernetes-node-linux-arm.tar.gz) | `173c7aa6268747f594d8edf355fd392dcc29b8685c002f54e8577fd6797cc8bf8e4599e728eb40b9d41239b420596cb1acc79a4e6430d1d51f62b002753e15b7`
+[kubernetes-node-linux-arm64.tar.gz](https://dl.k8s.io/v1.16.5/kubernetes-node-linux-arm64.tar.gz) | `d302eee8cf5b851db3b3d7ef5ae1e1f2f8b930d44d03df94507d54ba04f0a9f1960a387db17014e815043f77ed66477037b4602896030bbb2b7421be000db981`
+[kubernetes-node-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.16.5/kubernetes-node-linux-ppc64le.tar.gz) | `284afd70e3bd37bf4dc1967ea04f7584e1f9387282416940f5ab720f626e070dc0a5383c90035a1280294dc2e4097650f896f2dc40c47954795348ca9db8d173`
+[kubernetes-node-linux-s390x.tar.gz](https://dl.k8s.io/v1.16.5/kubernetes-node-linux-s390x.tar.gz) | `a600f3872c8a4a8207e384792286da96f3fee58ba488fa3491901d90e3a67abe2d1c2f3642b1551593e0fa7364a01b10aa25b49bddfd97df8ac642583842675f`
+[kubernetes-node-windows-amd64.tar.gz](https://dl.k8s.io/v1.16.5/kubernetes-node-windows-amd64.tar.gz) | `fc8267a1ad5f470b6a630f2b6c1bf812cd41d86e7cc77f938f07d7cb88ec795b24b271f3b49cffe9762fe7a507fdcdd7b59ca36afb40466bbf44d9bda01d1cf0`
+
+## Changelog since v1.16.4
+
+### Other notable changes
+
+* Fixed a regression where the kubelet would fail to update the ready status of pods. ([#86191](https://github.com/kubernetes/kubernetes/pull/86191), [@tedyu](https://github.com/tedyu))
+* Fix nil pointer dereference in azure cloud provider ([#85975](https://github.com/kubernetes/kubernetes/pull/85975), [@ldx](https://github.com/ldx))
+* fix: azure disk could not mounted on Standard_DC4s/DC2s instances ([#86612](https://github.com/kubernetes/kubernetes/pull/86612), [@andyzhangx](https://github.com/andyzhangx))
+* Fixes issue where AAD token obtained by kubectl is incompatible with on-behalf-of flow and oidc. ([#86412](https://github.com/kubernetes/kubernetes/pull/86412), [@weinong](https://github.com/weinong))
+    * The audience claim before this fix has "spn:" prefix. After this fix, "spn:" prefix is omitted.
+* Fixes an issue with kubelet-reported pod status on deleted/recreated pods. ([#86320](https://github.com/kubernetes/kubernetes/pull/86320), [@liggitt](https://github.com/liggitt))
+* Kubernetes 1.16.5+ now requires go1.13.4+ to build  ([#85019](https://github.com/kubernetes/kubernetes/pull/85019), [@liggitt](https://github.com/liggitt))
+* Fix LoadBalancer rule checking so that no unexpected LoadBalancer updates are made ([#85990](https://github.com/kubernetes/kubernetes/pull/85990), [@feiskyer](https://github.com/feiskyer))
+* cherry pick of [#85885](https://github.com/kubernetes/kubernetes/pull/85885): Provider/Azure: Add cache for VMSS. ([#86049](https://github.com/kubernetes/kubernetes/pull/86049), [@nilo19](https://github.com/nilo19))
+* Fixed a bug in the single-numa-policy of the TopologyManager. Previously, best-effort pods would result in a terminated state with a TopologyAffinity error. Now they will run as expected. ([#83777](https://github.com/kubernetes/kubernetes/pull/83777), [@lmdaly](https://github.com/lmdaly))
+
+
+
+# v1.16.4
+
+[Documentation](https://docs.k8s.io)
+
+## Downloads for v1.16.4
+
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes.tar.gz](https://dl.k8s.io/v1.16.4/kubernetes.tar.gz) | `c81e0e69b81b2dcd3d2397bc54756d77a8d41b88adba12eb5a1ffe71672554ecb1ff97c3979d0a81a218477440308860f9076124d6c0a3f0670ea21759a6621b`
+[kubernetes-src.tar.gz](https://dl.k8s.io/v1.16.4/kubernetes-src.tar.gz) | `b27c3946a6b466e5c1c0f1ce25d6af037ee0842d52be424d75ccfc10f9c7b6acc061b03d327ddd1889c0ec11dd46ea0872eed8d428013ae1e69d712b32f78c2e`
+
+### Client Binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-client-darwin-386.tar.gz](https://dl.k8s.io/v1.16.4/kubernetes-client-darwin-386.tar.gz) | `26d6708b788a8524513897133199b7c0737d0578bdf944692c9393f635fe8f0a202a147eabf33748ec7e849045f5a0a19ae0ff1b04b1de7d565dd7fdec797a08`
+[kubernetes-client-darwin-amd64.tar.gz](https://dl.k8s.io/v1.16.4/kubernetes-client-darwin-amd64.tar.gz) | `d4efd604d166f12bd860888dfe379490b64e05ff615855e45314ef405a8d5fa6dc51c1da3abe20b15b155dc7742ac2b929d32c66c3de3e5b497b18685f5fb9e2`
+[kubernetes-client-linux-386.tar.gz](https://dl.k8s.io/v1.16.4/kubernetes-client-linux-386.tar.gz) | `8366ed646ab3a387341455e3059ea02f5238e515303969155d48d735e4af9e8cc47eb9eddca370c854cbe599c4615a77c46dd0be1f893dd252dc1d3246c6304c`
+[kubernetes-client-linux-amd64.tar.gz](https://dl.k8s.io/v1.16.4/kubernetes-client-linux-amd64.tar.gz) | `30aa7aab0f82b1ad20f53ed693666bf39a84c3891549c58988de8e0106f4e5f46725f78de0d149ecdbb6e6f48d8ee7891d2b64c81a9a13cdae41ca6b147500b5`
+[kubernetes-client-linux-arm.tar.gz](https://dl.k8s.io/v1.16.4/kubernetes-client-linux-arm.tar.gz) | `61eb1750800f07b4f8c41da9f87e3fed5c6a42543c46031087ddf334aab3baa413433f66cc3314b62ab23aba594811dc1e363b2b56d9c0c4413135f33b4e1343`
+[kubernetes-client-linux-arm64.tar.gz](https://dl.k8s.io/v1.16.4/kubernetes-client-linux-arm64.tar.gz) | `ffce76381f999ccd51383321824404ee240d69374720077fcd2fa5b0b523584f1d4504538377f3c9a07ee4ad38ad2bdaf5ba1b80c1dbe3998f07a386ea26ca5b`
+[kubernetes-client-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.16.4/kubernetes-client-linux-ppc64le.tar.gz) | `c76d6250028122e2e63ca2ba447b989d4bb476c0eddfb0d0152d33a11e00bf189fd954456fb6d4508505523d8d13f2218878aafba62b114244cd10d328a88a0a`
+[kubernetes-client-linux-s390x.tar.gz](https://dl.k8s.io/v1.16.4/kubernetes-client-linux-s390x.tar.gz) | `cf293f9c8c02201e143aeb3eb6157621156883057b187d0cabc0ec196b7690eeac387dc306053b14c78657cd880a7e775bd966395102bba6cb8580a717b49bb7`
+[kubernetes-client-windows-386.tar.gz](https://dl.k8s.io/v1.16.4/kubernetes-client-windows-386.tar.gz) | `189bd08bb875d5b98bdcdc45b0ae498f52bc438bc59c45080e280349ca92f77a1b05d0677d52421b89f4d1123585f6c9618f97016eaad1d64eb4ede6922facfa`
+[kubernetes-client-windows-amd64.tar.gz](https://dl.k8s.io/v1.16.4/kubernetes-client-windows-amd64.tar.gz) | `ce437278896a75d0f5d13f318b59b6f48f39dd04cf70ca982fe5fe9edf4da23691b3993e5dd8fde1acd7aff8d599ac27d78887fd1253b80a9b65c14f7833eac3`
+
+### Server Binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-server-linux-amd64.tar.gz](https://dl.k8s.io/v1.16.4/kubernetes-server-linux-amd64.tar.gz) | `ed3a3130c34aff712d8591ac2119fe4f6a8ea430afd1d88fb987dbd6f4e61f1a1d734d8491348ee4fd71ca04f2592accbd9d2666d2c816949c8111dcd9e99233`
+[kubernetes-server-linux-arm.tar.gz](https://dl.k8s.io/v1.16.4/kubernetes-server-linux-arm.tar.gz) | `60d537ae2a94f7e3573ee5085eb14ef715a53b4c71516dbbdefc483a809b16fec26d8a112382a35bb4b26ef8c11ed985529d1d7dcc50a4526ec9ffdcd43648b0`
+[kubernetes-server-linux-arm64.tar.gz](https://dl.k8s.io/v1.16.4/kubernetes-server-linux-arm64.tar.gz) | `afb0f2ac7bd92ba107d9cffc9d3723a732d3c51d8b0956af7cc243dc74bee496f7995de75fd9cc758b2b4cd498db8552c3a7ac5c44a6c57fd97a6728a37b4a85`
+[kubernetes-server-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.16.4/kubernetes-server-linux-ppc64le.tar.gz) | `54a9d9c48259718fbe1b49cdd6ea699b8542633bd2ec676ee13e725104064ab7525aefa712b283177dbfc2c71bda2348344fa229c737b1ce35cfdf0aa6c6dcc1`
+[kubernetes-server-linux-s390x.tar.gz](https://dl.k8s.io/v1.16.4/kubernetes-server-linux-s390x.tar.gz) | `15525320b414ab13975c08fefa3272928615f8c3898780103fb33f6ade4342e478a566f31b876b78484fb06e39a2ccfbc9986f781642414b7760fc295f1eb10b`
+
+### Node Binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-node-linux-amd64.tar.gz](https://dl.k8s.io/v1.16.4/kubernetes-node-linux-amd64.tar.gz) | `c25fa6dcd8a62338a4fa748ae6be4c6501733d6012fffd73d61f2d7c9322d6fa8fef18c149f6ea9232bd65cc4d31f8500d25e6c9dc36fd8b0606f934bc5a7d40`
+[kubernetes-node-linux-arm.tar.gz](https://dl.k8s.io/v1.16.4/kubernetes-node-linux-arm.tar.gz) | `3093693fc1af4e319d0fe17700e5ad79a0780db03893e201188e7c5f4ad501761b90ebec251eb63c5a2355ea1d922e04172f86bebd560b07f20d39a72b4fea70`
+[kubernetes-node-linux-arm64.tar.gz](https://dl.k8s.io/v1.16.4/kubernetes-node-linux-arm64.tar.gz) | `93d96b1cd33ada44c8d2f97775edc2782c042d88389b556deec04e8876cc32a726ead5ef4ed3342fa1af2cb23927c3fa43af440d685c340146de6f122c4d5f03`
+[kubernetes-node-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.16.4/kubernetes-node-linux-ppc64le.tar.gz) | `7b607c0afd4cc373d57efdbe88b0e82d087c790d35bd1b98fe12b0b9321dd10d8189cdf9b3c5cf36b674aaeefb2bc6234dde2f83d9adfb8a9c8160fb26335d86`
+[kubernetes-node-linux-s390x.tar.gz](https://dl.k8s.io/v1.16.4/kubernetes-node-linux-s390x.tar.gz) | `43120a2a3b741ad2f40e17156963a5cb0af49190e820ce75808fa1c3969e1dfc96d509a591c328fd6c037e2b4f6380bfd6f0dad5c2675eaa92d635cfe3f74c49`
+[kubernetes-node-windows-amd64.tar.gz](https://dl.k8s.io/v1.16.4/kubernetes-node-windows-amd64.tar.gz) | `fc769cdcbc5eeac8ad6776864a21bc75d2d1cfc682d0c0c51128b3cfcadf8cb14b815c29e545491028c99c35c6ab5a2a4dbfb9e462a92c5d1bc2ab98f8c70a65`
+
+## Changelog since v1.16.3
+
+### Other notable changes
+
+* Fixed issue with addon-resizer using deprecated extensions APIs ([#85793](https://github.com/kubernetes/kubernetes/pull/85793), [@bskiba](https://github.com/bskiba))
+* Fixes a performance issue when using server-side apply with objects with very large atomic maps. ([#85462](https://github.com/kubernetes/kubernetes/pull/85462), [@jennybuckley](https://github.com/jennybuckley))
+* azure: update disk lock logic per vm during attach/detach to allow concurrent updates for different nodes. ([#85115](https://github.com/kubernetes/kubernetes/pull/85115), [@aramase](https://github.com/aramase))
+* Filter published OpenAPI schema by making nullable, required fields non-required in order to avoid kubectl to wrongly reject null values. ([#85733](https://github.com/kubernetes/kubernetes/pull/85733), [@sttts](https://github.com/sttts))
+* For x-kubernetes-list-type=set a scalar or atomic item type is now required, as documented. Persisted, invalid data is tolerated. ([#85385](https://github.com/kubernetes/kubernetes/pull/85385), [@sttts](https://github.com/sttts))
+* Fixes a bug in kubeadm that caused init and join to hang indefinitely in specific conditions. ([#85156](https://github.com/kubernetes/kubernetes/pull/85156), [@chuckha](https://github.com/chuckha))
+* Ensure health probes are created for local traffic policy UDP services on Azure ([#84802](https://github.com/kubernetes/kubernetes/pull/84802), [@feiskyer](https://github.com/feiskyer))
+* fix vmss dirty cache issue in disk attach/detach on vmss node ([#85158](https://github.com/kubernetes/kubernetes/pull/85158), [@andyzhangx](https://github.com/andyzhangx))
+* fix race condition when attach/delete azure disk in same time ([#84917](https://github.com/kubernetes/kubernetes/pull/84917), [@andyzhangx](https://github.com/andyzhangx))
+* set config.BindAddress to IPv4 address "127.0.0.1" if not specified ([#83822](https://github.com/kubernetes/kubernetes/pull/83822), [@zouyee](https://github.com/zouyee))
+* Change GCP ILB firewall names to contain the "k8s-fw-" prefix like the rest of the firewall rules. This is needed for consistency and also for other components to identify the firewall rule as k8s/service-controller managed. ([#84622](https://github.com/kubernetes/kubernetes/pull/84622), [@prameshj](https://github.com/prameshj))
+* kube-controller-manager: Fixes bug setting headless service labels on endpoints ([#85361](https://github.com/kubernetes/kubernetes/pull/85361), [@liggitt](https://github.com/liggitt))
+
+
+
+# v1.16.3
+
+[Documentation](https://docs.k8s.io)
+
+## Downloads for v1.16.3
+
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes.tar.gz](https://dl.k8s.io/v1.16.3/kubernetes.tar.gz) | `17618d2ece64346d03db6a6c31eb3c38bbc3aa206005e99032791bdbe7dad1f401bdb9d707995ff83b658dd1ad59d9b53489e5ee45b9f209edf09b35326aac4a`
+[kubernetes-src.tar.gz](https://dl.k8s.io/v1.16.3/kubernetes-src.tar.gz) | `e51d3418b006fb28039dc30095333f9e362c785eb27778554005a83e70860b33b554f61ddb6dd83e05d1ca0dda4c6f9bf2812347109e83ff72ad4d355bd22546`
+
+### Client Binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-client-darwin-386.tar.gz](https://dl.k8s.io/v1.16.3/kubernetes-client-darwin-386.tar.gz) | `15d3316afc04ae959658cc4489347b1e425df37ce7438e79357bd7fde783766374315c4c6e4ea8a94dab8d113c1871aff70de84e3181d08c37849c4971f6ad7e`
+[kubernetes-client-darwin-amd64.tar.gz](https://dl.k8s.io/v1.16.3/kubernetes-client-darwin-amd64.tar.gz) | `82c2af675d77dea335d99247df9136668bda81d64da82a949543369bb31e0bc2963f9de83cb34174b01a93f6a1acab3459fb64621e771e4f7362c090ac2a256d`
+[kubernetes-client-linux-386.tar.gz](https://dl.k8s.io/v1.16.3/kubernetes-client-linux-386.tar.gz) | `193ae911e58fa61e001730cfa8018cb77b672b77cba6b3916bde53a73add160641085176d8bc60ea25e22f7b9a8d2a9ec17da139ec234771939cc55d5b2c0931`
+[kubernetes-client-linux-amd64.tar.gz](https://dl.k8s.io/v1.16.3/kubernetes-client-linux-amd64.tar.gz) | `904604839bbf46c11c7934f6f906adbc968234044b9f3268b71c175241626f8d4076812aca789dc5aa2f85fd25a384ad779638231d4d94f3f3c6d043b5d9f062`
+[kubernetes-client-linux-arm.tar.gz](https://dl.k8s.io/v1.16.3/kubernetes-client-linux-arm.tar.gz) | `016e9a5662afa27da5ffb055fbf2bf4135b8521deb6bd3dea565f250f611f1690be9d6ea18c3fd1053c71c03213bc53441d88e70633192a443b838d353783278`
+[kubernetes-client-linux-arm64.tar.gz](https://dl.k8s.io/v1.16.3/kubernetes-client-linux-arm64.tar.gz) | `2ee032304114556bf3ab78c000f32ab9605e294030d83edbe013fdeb19eb49283d8b8a9c120e2d076f394f2e0d74015384754e6876e62f68ec515378ddbce77e`
+[kubernetes-client-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.16.3/kubernetes-client-linux-ppc64le.tar.gz) | `07299344bc4c2da573b2bc4b2fa9c7a60358c4a591d711f8a9ce45768543fe678d1f15412db0fa02b777964cebcee2bcf9dea16d94a97754eac163b77cb6ddc8`
+[kubernetes-client-linux-s390x.tar.gz](https://dl.k8s.io/v1.16.3/kubernetes-client-linux-s390x.tar.gz) | `83e6a17b86740199788b48e94534ea6cd08c9325325a7f75a7073771a1de421843c2898ef385a9d8912d7cfd99c09b60a4bb4f3c6220c8f212c08a72a85661b2`
+[kubernetes-client-windows-386.tar.gz](https://dl.k8s.io/v1.16.3/kubernetes-client-windows-386.tar.gz) | `bfc6ff8fcc7e1219074df6db5d42fb38af4b6c10e36fb0fd7c6d8aa72fc01cbca5658d8c6a9882ed234cc20652511f551c5f59d77a0a46fc2b27f96e6f4e385a`
+[kubernetes-client-windows-amd64.tar.gz](https://dl.k8s.io/v1.16.3/kubernetes-client-windows-amd64.tar.gz) | `ccd9d4f53152f1c09cb5c2194892afaf93faf7bfbbf0b8ea0d6c333f121593b7c7d0039246af9234b684ac8501e4f778de8ddf02d4b34ca191621f7c74c811ba`
+
+### Server Binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-server-linux-amd64.tar.gz](https://dl.k8s.io/v1.16.3/kubernetes-server-linux-amd64.tar.gz) | `040f6bfb78cb336d2d23360c0921ef7e008561b2f10bed3261c33811d1d818693cd24dcb5bf52cbf854f4209a8968a5e07ff8356e3e061a4db14623469098e5f`
+[kubernetes-server-linux-arm.tar.gz](https://dl.k8s.io/v1.16.3/kubernetes-server-linux-arm.tar.gz) | `e8d8312f44ecd38d8d88300cda22ef364a637af4a666869e0926bb25008b31eceb5cbdc4ba2fda9358d996c1b9776fe4ae49693b3e95237bd82c2ec7898b4249`
+[kubernetes-server-linux-arm64.tar.gz](https://dl.k8s.io/v1.16.3/kubernetes-server-linux-arm64.tar.gz) | `39e7d76e88da1ac712faf6d61bb980c0a4ac01d4996bb559cc6a9c132105a5b073d7833d431ba44418b4981a190ff613463cbf16f25e4ce38a31f43191842680`
+[kubernetes-server-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.16.3/kubernetes-server-linux-ppc64le.tar.gz) | `72c418ade3291911da4a654ae4c4a88f7d02ad1608d9d9721e9ce7199c4dc07090c9f53b6350911050f25c7e583423ba9e985260e94982e217119b2b0a7be501`
+[kubernetes-server-linux-s390x.tar.gz](https://dl.k8s.io/v1.16.3/kubernetes-server-linux-s390x.tar.gz) | `7405ca92726fb8e4083ee66a996df98e37c1a04b679634fadb0f2e64aa7e264a5e55b1149fede58d7dc693c71551e31abbc1e2bd8b137686debd2091ce9059b4`
+
+### Node Binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-node-linux-amd64.tar.gz](https://dl.k8s.io/v1.16.3/kubernetes-node-linux-amd64.tar.gz) | `6074a03879f385fb3411b024ada7e1d2b8ae89990fe4f5a9c6046424cbb567afaf24264a003157b682c91eedcbd09bca75a51265fbdb3a948930fe7494c997e2`
+[kubernetes-node-linux-arm.tar.gz](https://dl.k8s.io/v1.16.3/kubernetes-node-linux-arm.tar.gz) | `277432b212c98e7eb8020b17745d4c90dbc6c359148efc38e41e0836085eac4655effd9e5a694162d61ee31adc8eb1e9f6196fa9f05d898e2f4d596a1e097055`
+[kubernetes-node-linux-arm64.tar.gz](https://dl.k8s.io/v1.16.3/kubernetes-node-linux-arm64.tar.gz) | `6354e8862e60d6c6d60a115dd6043beed8205991c833716426071dc70d3658da1ddc9b23c4e16cae0410a86ea82eab3240f2a5123e753ff55a151e6f96db436e`
+[kubernetes-node-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.16.3/kubernetes-node-linux-ppc64le.tar.gz) | `2e5bdf3a64b5387fe60aff1b05ccf0f822a3955815576f979e2e8b7673373c49b602ab53fc1a63dd4467787e9b62f3f369f4a656812078709be795e85aaf253b`
+[kubernetes-node-linux-s390x.tar.gz](https://dl.k8s.io/v1.16.3/kubernetes-node-linux-s390x.tar.gz) | `44632772ac2e13b91e9b04c05c42522f8fdcf574daff6e98719724ed0e07c44e1d01c0f047bf462e00f092a21b617822063ee6cc987c531fc7f0980c6b1319ba`
+[kubernetes-node-windows-amd64.tar.gz](https://dl.k8s.io/v1.16.3/kubernetes-node-windows-amd64.tar.gz) | `eb6128b0aa1001b0fea5d458692c96191bfaa51c4a8736a9c370e38fffb9d72a28937581cf79a1ea529058f039a08a3b8a23e7372c7f8a8265a5f9acd252a4c1`
+
+## Changelog since v1.16.2
+
+### Other notable changes
+
+* kubeadm: fix skipped etcd upgrade on secondary control-plane nodes when the command "kubeadm upgrade node" is used. ([#85024](https://github.com/kubernetes/kubernetes/pull/85024), [@neolit123](https://github.com/neolit123))
+* Fix kubelet metrics gathering on non-English Windows hosts ([#84156](https://github.com/kubernetes/kubernetes/pull/84156), [@wawa0210](https://github.com/wawa0210))
+* Bump metrics-server to v0.3.5 ([#83015](https://github.com/kubernetes/kubernetes/pull/83015), [@olagacek](https://github.com/olagacek))
+* Bumps metrics-server version to v0.3.6 with following bugfix: ([#83907](https://github.com/kubernetes/kubernetes/pull/83907), [@olagacek](https://github.com/olagacek))
+        *  Don't break metric storage when duplicate pod metrics encountered causing hpa to fail
+* kube-apiserver: Fixed a regression accepting patch requests > 1MB ([#84963](https://github.com/kubernetes/kubernetes/pull/84963), [@liggitt](https://github.com/liggitt))
+* kube-apiserver: fixed a bug that could cause a goroutine leak if the apiserver encountered an encoding error serving a watch to a websocket watcher ([#84693](https://github.com/kubernetes/kubernetes/pull/84693), [@tedyu](https://github.com/tedyu))
+* azure: Add allow unsafe read from cache ([#83685](https://github.com/kubernetes/kubernetes/pull/83685), [@aramase](https://github.com/aramase))
+* Add data cache flushing during unmount device for GCE-PD driver in Windows Server. ([#83591](https://github.com/kubernetes/kubernetes/pull/83591), [@jingxu97](https://github.com/jingxu97))
+* Fixed binding of block PersistentVolumes / PersistentVolumeClaims when BlockVolume feature is off. ([#84049](https://github.com/kubernetes/kubernetes/pull/84049), [@jsafrane](https://github.com/jsafrane))
+* kube-scheduler now fallbacks to emitting events using core/v1 Events when events.k8s.io/v1beta1 is disabled. ([#83692](https://github.com/kubernetes/kubernetes/pull/83692), [@yastij](https://github.com/yastij))
+* Adds a metric apiserver_request_error_total to kube-apiserver. This metric tallies the number of request_errors encountered by verb, group, version, resource, subresource, scope, component, and code.  ([#83427](https://github.com/kubernetes/kubernetes/pull/83427), [@logicalhan](https://github.com/logicalhan))
+* Update Cluster Autoscaler version to 1.16.2 (CA release docs: https://github.com/kubernetes/autoscaler/releases/tag/cluster-autoscaler-1.16.2) ([#84038](https://github.com/kubernetes/kubernetes/pull/84038), [@losipiuk](https://github.com/losipiuk))
+* Fixed an issue with informers missing an `Added` event if a recently deleted object was immediately recreated at the same time the informer dropped a watch and relisted. ([#83911](https://github.com/kubernetes/kubernetes/pull/83911), [@matte21](https://github.com/matte21))
+* CSI detach timeout increased from 10 seconds to 2 minutes ([#84321](https://github.com/kubernetes/kubernetes/pull/84321), [@cduchesne](https://github.com/cduchesne))
+* Switched intstr.Type to sized integer to follow API guidelines and improve compatibility with proto libraries ([#83956](https://github.com/kubernetes/kubernetes/pull/83956), [@liggitt](https://github.com/liggitt))
+* Upgrade to etcd client 3.3.17 to fix bug where etcd client does not parse IPv6 addresses correctly when members are joining, and to fix bug where failover on multi-member etcd cluster fails certificate check on DNS mismatch ([#83968](https://github.com/kubernetes/kubernetes/pull/83968), [@jpbetz](https://github.com/jpbetz))
+* Update to use go1.12.12 ([#84064](https://github.com/kubernetes/kubernetes/pull/84064), [@cblecker](https://github.com/cblecker))
+* Fix handling tombstones in pod-disruption-budged controller. ([#83951](https://github.com/kubernetes/kubernetes/pull/83951), [@zouyee](https://github.com/zouyee))
+
+
+
+# v1.16.2
+
+[Documentation](https://docs.k8s.io)
+
+## Downloads for v1.16.2
+
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes.tar.gz](https://dl.k8s.io/v1.16.2/kubernetes.tar.gz) | `9e21ab6317fe209dabac72444273b493f5f7639f73c489cc233da3a0205a93f8779964fe2cf2237bb6ca7535560c7c8ac48e25e75a1fbe97dc5b51f248ed7eeb`
+[kubernetes-src.tar.gz](https://dl.k8s.io/v1.16.2/kubernetes-src.tar.gz) | `2e52029a8669f51020f689b0da481f56ab922ecd2c4495e37cb8456e9b10fee50f97bf9faa6a3bc947e4142aa4e5374d7f905a22e5f18830610eacfdf47adbc6`
+
+### Client Binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-client-darwin-386.tar.gz](https://dl.k8s.io/v1.16.2/kubernetes-client-darwin-386.tar.gz) | `6424b3047c5d7557b6c5536f29139bb6f71e4357b5e181d62bfd5fbf7d5575c9d5eeeab531b0afcc72ac17dd6609162bebc1045932ee58cbeb3093a4107cbf3a`
+[kubernetes-client-darwin-amd64.tar.gz](https://dl.k8s.io/v1.16.2/kubernetes-client-darwin-amd64.tar.gz) | `791d2a4f965130ea1d7033f807b29015520afa317f97643f27480a6530213fd3fa06817ba9ce04e81f843b8420f05baa25e597e5880f99cc2ffbfc8b8ebf18cf`
+[kubernetes-client-linux-386.tar.gz](https://dl.k8s.io/v1.16.2/kubernetes-client-linux-386.tar.gz) | `fd727fe3200975f71d1f5b21991e5b8d2471e92dc3185df29b8ef21a9aa87d270baa1bd2f9f2dbe61abe9e9541ee806709d6ed08aa13254a5953ddc1f1ddb5a6`
+[kubernetes-client-linux-amd64.tar.gz](https://dl.k8s.io/v1.16.2/kubernetes-client-linux-amd64.tar.gz) | `69bb92c9b16c0286d7401d87cc73b85c88d6f9a17d2cf1748060e44525194b5be860daf7554c4c6319a546c9ff10f2b4df42a27e32d8f95a4052993b17ef57c0`
+[kubernetes-client-linux-arm.tar.gz](https://dl.k8s.io/v1.16.2/kubernetes-client-linux-arm.tar.gz) | `f846f6018eb3d82741e6d2e8fd2f9f7ca8768ead56c3e2c330ba7e7dbba3209dd66f793b37d330134d3e8f38a03d6492e0054e55fcf32f74743b7b26f3159210`
+[kubernetes-client-linux-arm64.tar.gz](https://dl.k8s.io/v1.16.2/kubernetes-client-linux-arm64.tar.gz) | `49cb3495fa8bbe64cefdb9aab83d4cfbe6a0f3a0e58b1685a49244df02e5ee8bbfaf0be133f5cf5231b1470bb62bd699cd6aba8072cb6ea3542f3ccfd42d3813`
+[kubernetes-client-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.16.2/kubernetes-client-linux-ppc64le.tar.gz) | `35a8b25309150cf5e1dab2af1d5118a24d296e21cdaf4bdec615badbc27a109ffb8b0e1cd93439fb728ec4905178eae2eb9d2ec2760053211b495c103d76fe3b`
+[kubernetes-client-linux-s390x.tar.gz](https://dl.k8s.io/v1.16.2/kubernetes-client-linux-s390x.tar.gz) | `ffd5ab012d38b7a7b9e0acd8339c30545a60bcabba5642f5020464846391ae41930e84c0103231f850f0f0c86e064c18f47bff95ccf11b410c0216a4d887b2fb`
+[kubernetes-client-windows-386.tar.gz](https://dl.k8s.io/v1.16.2/kubernetes-client-windows-386.tar.gz) | `c04d33b31734c7b25c54daa361986fcb745178320daa54d76b7627c475346a87c65443f7b139e1c86436b27eb9d10ed4a61ba5a64e0420bb6ce2f68fbad0a1b0`
+[kubernetes-client-windows-amd64.tar.gz](https://dl.k8s.io/v1.16.2/kubernetes-client-windows-amd64.tar.gz) | `e81fcf83523dd1dc79de7b498df6115465eb83d31a400853cdf143870a281322f24be5609d0c541810f90047a3c4e75530b9a6e872e51ed00d268530f2ed7ca9`
+
+### Server Binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-server-linux-amd64.tar.gz](https://dl.k8s.io/v1.16.2/kubernetes-server-linux-amd64.tar.gz) | `4aa3da6d146db878f4605ea6334925e925268808856f482ea7f9d131dce76ee30d4ba077a6b35de34a68d8d9ca005cccd2e7e4866b775c1f7eaba1320a1b8ec5`
+[kubernetes-server-linux-arm.tar.gz](https://dl.k8s.io/v1.16.2/kubernetes-server-linux-arm.tar.gz) | `0a9cea07a1172038d300277f1d305d99b147ae5949df3dd63856944cc0e4724105a0d79bf9ea39dface923d794b71e9f40d4104218167e56096a9e82a422864a`
+[kubernetes-server-linux-arm64.tar.gz](https://dl.k8s.io/v1.16.2/kubernetes-server-linux-arm64.tar.gz) | `b1aadb87ff310aec7292df5386613c4c0036c0e3c20e0a4ab7bd3d5eea8fff0116c8b8b47289e894950b249be4207daac58449ec9a587353873890b47217ecd8`
+[kubernetes-server-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.16.2/kubernetes-server-linux-ppc64le.tar.gz) | `2aecda7fb53efd23c34cfe90ae37d55efec513996573c9124d9bf94809ea5a86bcd786e84d646039fbaff2e42d7e8f9c5db179beec3fac1f0a420920c93dce35`
+[kubernetes-server-linux-s390x.tar.gz](https://dl.k8s.io/v1.16.2/kubernetes-server-linux-s390x.tar.gz) | `74fd3d5dbedac211570ef011f14e98d37848587b670038c69354c0162668aa2c6789835a5dbfc82f43fb9662444756f974de75917f75f59ab51e6ae9183e5c20`
+
+### Node Binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-node-linux-amd64.tar.gz](https://dl.k8s.io/v1.16.2/kubernetes-node-linux-amd64.tar.gz) | `d1e139006e1ce6b66a1c0b9dd90509db712e5e024e1c5a4c0a1bb185211dd138cbcf201e6a9cdf7df9b78b6817523da23097c8396c0afb98481052447d329cc9`
+[kubernetes-node-linux-arm.tar.gz](https://dl.k8s.io/v1.16.2/kubernetes-node-linux-arm.tar.gz) | `5779c23d4f77edf5d5c3b8bb55fd190bf180f13c782e44a50a96572477af30008685c4e670c07ceb56c8e64390be7e7cbf14a9b25c894c66f90131a993bda4fc`
+[kubernetes-node-linux-arm64.tar.gz](https://dl.k8s.io/v1.16.2/kubernetes-node-linux-arm64.tar.gz) | `f09bc220a05b8f5fca6d4575198ac2b7625fcbceb09ffd6da587c8b13a5b93365b601b94a25fb8cc360c7521ccc30d11d86d88490f5a48369f6078c4395593c2`
+[kubernetes-node-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.16.2/kubernetes-node-linux-ppc64le.tar.gz) | `96b3f8578e4f5e5261489ba392e7167bfdbe5ec6fb60a369455edffbc027b3086bd99055f7e3cabbf56426b7b181764d5cd5979bacd3ad8c26b541cd94ce62d8`
+[kubernetes-node-linux-s390x.tar.gz](https://dl.k8s.io/v1.16.2/kubernetes-node-linux-s390x.tar.gz) | `4c9c7e541164781231378091cae0ab693c29b517b7737be191436c5e85ea4702cdd640890ae7c1295273270cb7944e2a250e2791a9a07bb415dac67d3129d1c1`
+[kubernetes-node-windows-amd64.tar.gz](https://dl.k8s.io/v1.16.2/kubernetes-node-windows-amd64.tar.gz) | `a88e7a1c6f72ea6073dbb4ddfe2e7c8bd37c9a56d94a33823f531e303a9915e7a844ac5880097724e44dfa7f4a9659d14b79cc46e2067f6b13e6df3f3f1b0f64`
+
+## Changelog since v1.16.1
+
+### Other notable changes
+
+* Fixed panic when accessing CustomResources of a CRD with x-kubernetes-int-or-string. ([#83789](https://github.com/kubernetes/kubernetes/pull/83789), [@sttts](https://github.com/sttts))
+* Fixed a bug in the single-numa-node policy of the TopologyManager.  Previously, pods that only requested CPU resources and did not request any third-party devices would fail to launch with a TopologyAffinity error. Now they will launch successfully. ([#83697](https://github.com/kubernetes/kubernetes/pull/83697), [@klueska](https://github.com/klueska))
+* Fixes kube-proxy bug accessing self nodeip:port on windows ([#83027](https://github.com/kubernetes/kubernetes/pull/83027), [@liggitt](https://github.com/liggitt))
+* Fix error where metrics related to dynamic kubelet config isn't registered ([#83184](https://github.com/kubernetes/kubernetes/pull/83184), [@odinuge](https://github.com/odinuge))
+* Use online nodes instead of possible nodes when discovering available NUMA nodes ([#83196](https://github.com/kubernetes/kubernetes/pull/83196), [@zouyee](https://github.com/zouyee))
+* Update Azure load balancer to prevent orphaned public IP addresses ([#82890](https://github.com/kubernetes/kubernetes/pull/82890), [@chewong](https://github.com/chewong))
+* Fixes a goroutine leak in kube-apiserver when a request times out. ([#83333](https://github.com/kubernetes/kubernetes/pull/83333), [@lavalamp](https://github.com/lavalamp))
+* Fix aggressive VM calls for Azure VMSS ([#83102](https://github.com/kubernetes/kubernetes/pull/83102), [@feiskyer](https://github.com/feiskyer))
+* Fixes a flaw (CVE-2019-11253) in json/yaml decoding where large or malformed documents could consume excessive server resources. Request bodies for normal API requests (create/delete/update/patch operations of regular resources) are now limited to 3MB. ([#83261](https://github.com/kubernetes/kubernetes/pull/83261), [@liggitt](https://github.com/liggitt))
+
+
+
+# v1.16.1
+
+[Documentation](https://docs.k8s.io)
+
+## Downloads for v1.16.1
+
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes.tar.gz](https://dl.k8s.io/v1.16.1/kubernetes.tar.gz) | `3dc4f0f2a208d3f235b4dc579418c503ba64fec261294c3683268259117e5c82f56db3f0c4ad63199f0f35f0de21df0b13ca00a74efe7b3142b275f0733e9219`
+[kubernetes-src.tar.gz](https://dl.k8s.io/v1.16.1/kubernetes-src.tar.gz) | `2d79b1e4e43c57c0e24da07f1312d0e49f8c43ebba0231dd5d628a52c25e929fed34c3d34b2ab739c0348c2f42c88feea8f1a4c2d821ace170f451bf74903ae3`
+
+### Client Binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-client-darwin-386.tar.gz](https://dl.k8s.io/v1.16.1/kubernetes-client-darwin-386.tar.gz) | `f7139df5f06f3fc9d1944058e7ba40a482621d6a169bc2f09a50dfa8f903866706051cded14fbd39d8d03c576f9e5219b0887f029ee1cac45919dc5ff232cdcd`
+[kubernetes-client-darwin-amd64.tar.gz](https://dl.k8s.io/v1.16.1/kubernetes-client-darwin-amd64.tar.gz) | `c4d458a0c3ef2dc9e4527daecf6b34da065d1ae7fd245f8b8aceca43467f03073f538e65e504f9800d3db0c64d88fc41f687b493be4d9a8283f39dd001a86a7d`
+[kubernetes-client-linux-386.tar.gz](https://dl.k8s.io/v1.16.1/kubernetes-client-linux-386.tar.gz) | `82d79bc833ae5317c4a1d0d397ccaa9aef616e0c2e5ff2166da8c66a4f55851f4bfa3b57708f75dc12eabefdee35b08d8f7bee74cfaf38a0339ee927f90e1655`
+[kubernetes-client-linux-amd64.tar.gz](https://dl.k8s.io/v1.16.1/kubernetes-client-linux-amd64.tar.gz) | `e355a74a17d96785b0b217673e67fa0f02daa1939f10d410602ac0a0d061a4db71d727b67f75aa886007dab95dd5c7f8cc38253d291dc4d2504ce673df69fb32`
+[kubernetes-client-linux-arm.tar.gz](https://dl.k8s.io/v1.16.1/kubernetes-client-linux-arm.tar.gz) | `b9fba5995a7a02d001bead0305ae2a0c8ee7d2a98069aad6e57612988e298972cb6f69267afb79df292195958871c56a2cc5ec7a8e180a8d56c428f82bbbece8`
+[kubernetes-client-linux-arm64.tar.gz](https://dl.k8s.io/v1.16.1/kubernetes-client-linux-arm64.tar.gz) | `64917bd6c4b277f4cb676b2e3d69cb12148bc90e2b04011d11985e492d525646fd13021b74f93914d37849fba87c07c513fafc1bd07edc7d3e4415fe8bd9ea37`
+[kubernetes-client-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.16.1/kubernetes-client-linux-ppc64le.tar.gz) | `258cc1b13f3ef90c52d401190f4d59c8c0d10367a6d960c6273522a15b879de2df4d141461d80338144e83995422da802a417a55911d7a4d8aeeec5aecd2adec`
+[kubernetes-client-linux-s390x.tar.gz](https://dl.k8s.io/v1.16.1/kubernetes-client-linux-s390x.tar.gz) | `adaa34bde363a030f099a96417e257688e6280d86bdd3e04f7c06b6bccce639f599d494b5181a78e91c7f50207c53fa1a04b3b2fbd65be91512e51441e66a2e8`
+[kubernetes-client-windows-386.tar.gz](https://dl.k8s.io/v1.16.1/kubernetes-client-windows-386.tar.gz) | `3ed99240a99a2d9f4193264f14168896a2418f296e5a2372e4e6aac44b65cd6a531ceec71d24333a7c825ba02acec63fdb51b97aa9fb4665048e929b7e4b774d`
+[kubernetes-client-windows-amd64.tar.gz](https://dl.k8s.io/v1.16.1/kubernetes-client-windows-amd64.tar.gz) | `cbf8363147e44bfadee4da9ced9ab7bfc3c88ba7dcfa3f64803376efa5adc6dbb38519f73253aa9ea8b12bb42a92f5ea78e8b63fb082e4ace04d3ee3e285f549`
+
+### Server Binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-server-linux-amd64.tar.gz](https://dl.k8s.io/v1.16.1/kubernetes-server-linux-amd64.tar.gz) | `c43795fc2bfaee240f1e32e0b523cbbc8a888a40efa85371e682433d6f60dd1f3225ca34484fc9db54e68e250acbb5c2c388071bcd033fed0d8a47d044708b0b`
+[kubernetes-server-linux-arm.tar.gz](https://dl.k8s.io/v1.16.1/kubernetes-server-linux-arm.tar.gz) | `3a6c38db6d6c0950f6d3cd4c158ba9c816dcbf1b1959a74d55ead53b1df2cf9131f56d5b0f5720f9c2000085ada1fd4d48439ea20f4ba35764e1a54f94848697`
+[kubernetes-server-linux-arm64.tar.gz](https://dl.k8s.io/v1.16.1/kubernetes-server-linux-arm64.tar.gz) | `3cbde62bb5ef0af033d643cea800e891c199f9d6e9f0a3e1131bebe6759fd72b2c8d1f86d92ab5d1c352297b57320b47c70a6422768656b2c44c4ef4b7e3c721`
+[kubernetes-server-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.16.1/kubernetes-server-linux-ppc64le.tar.gz) | `a60a25a346de61e705d416b50f8eac582a36faa622c6c45d4e3af92c46f48409b4c2a9bcbfd9297cc77d747cf1a96721146a24a48500a55b806c6fc0d9008e21`
+[kubernetes-server-linux-s390x.tar.gz](https://dl.k8s.io/v1.16.1/kubernetes-server-linux-s390x.tar.gz) | `1ee9bbb36245825604d7cf4c9bdb2e43d0d755958413809ae7d3c9448ada567c0ab510f68318055dd71ec73d2ccce5b8d23faa698fd42772e3bd3c9592006d80`
+
+### Node Binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-node-linux-amd64.tar.gz](https://dl.k8s.io/v1.16.1/kubernetes-node-linux-amd64.tar.gz) | `4ef686de6aa5a2bdcb8034b3def008995fc4474f34f939620c657ae115c61403c8d5698c9af68d3fe7015beaa8d578edc9f1a62b08dea92d99a3c73c9fe9e7a6`
+[kubernetes-node-linux-arm.tar.gz](https://dl.k8s.io/v1.16.1/kubernetes-node-linux-arm.tar.gz) | `58607b1cf68e8420bacc8dc3f95b19b7f90fe4fda1255814c76e66f67638b8db150eb464f85e1b625e13a74b0d86a973e54da87e2fb41985eff14b25a7761b1d`
+[kubernetes-node-linux-arm64.tar.gz](https://dl.k8s.io/v1.16.1/kubernetes-node-linux-arm64.tar.gz) | `f02417299b5b6f3ee4b325d4a23b0ca19ee3c10dbe871a716470e68a3e89f4b84232eac1048dc9dc88a00ed069a8fd3b4f7817664e296e8842322379702e67e4`
+[kubernetes-node-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.16.1/kubernetes-node-linux-ppc64le.tar.gz) | `fa3b44b668d0a341847601a18c463698810457e113459d6f8ddbce6f9305b613c4f61f9831e16d8bab128efdd69524c86981785f9703e248eff11f95e9330e74`
+[kubernetes-node-linux-s390x.tar.gz](https://dl.k8s.io/v1.16.1/kubernetes-node-linux-s390x.tar.gz) | `afe166d9245bd35fbc21763b9ef24bf174396c0611f75ddf93f1e4f3fb3e1cf1d4e7998d963e26fe3761bf4984ea33a5d6656035092c9b0d35e94f97882a5595`
+[kubernetes-node-windows-amd64.tar.gz](https://dl.k8s.io/v1.16.1/kubernetes-node-windows-amd64.tar.gz) | `93ebe21c147dcb38cb1ee222975f35f7c8c8175255cfce09381c8852734d054def58bc630cf868d99baa7f90bd2c201ccaa42dbae3ef360c3135c825ec2c74b1`
+
+## Changelog since v1.16.0
+
+### Other notable changes
+
+* Limit the body length of exec readiness/liveness probes. remote CRIs and Docker shim read a max of 16MB output of which the exec probe itself inspects 10kb. ([#82514](https://github.com/kubernetes/kubernetes/pull/82514), [@dims](https://github.com/dims))
+* Fix possible fd leak and closing of dirs when using openstack ([#82873](https://github.com/kubernetes/kubernetes/pull/82873), [@odinuge](https://github.com/odinuge))
+* Update to go 1.12.10 ([#83139](https://github.com/kubernetes/kubernetes/pull/83139), [@cblecker](https://github.com/cblecker))
+* Use ipv4 in wincat port forward. ([#83036](https://github.com/kubernetes/kubernetes/pull/83036), [@liyanhui1228](https://github.com/liyanhui1228))
+* Fixes a panic in kube-controller-manager cleaning up bootstrap tokens ([#82887](https://github.com/kubernetes/kubernetes/pull/82887), [@tedyu](https://github.com/tedyu))
+* Resolves bottleneck in internal API server communication that can cause increased goroutines and degrade API Server performance ([#80465](https://github.com/kubernetes/kubernetes/pull/80465), [@answer1991](https://github.com/answer1991))
+* Resolves regression generating informers for packages whose names contain `.` characters ([#82410](https://github.com/kubernetes/kubernetes/pull/82410), [@nikhita](https://github.com/nikhita))
+* Fixed a scheduler panic when using PodAffinity. ([#82841](https://github.com/kubernetes/kubernetes/pull/82841), [@Huang-Wei](https://github.com/Huang-Wei))
+* Update Cluster Autoscaler version to 1.16.1 (release notes: https://github.com/kubernetes/autoscaler/releases/tag/cluster-autoscaler-1.16.1) ([#83052](https://github.com/kubernetes/kubernetes/pull/83052), [@losipiuk](https://github.com/losipiuk))
+* Resolves issue with /readyz and /livez not including etcd and kms health checks ([#82713](https://github.com/kubernetes/kubernetes/pull/82713), [@logicalhan](https://github.com/logicalhan))
+* fix: azure disk detach failure if node not exists ([#82640](https://github.com/kubernetes/kubernetes/pull/82640), [@andyzhangx](https://github.com/andyzhangx))
+
+
+
+# v1.16.0
+
+[Documentation](https://docs.k8s.io)
+
+## Downloads for v1.16.0
+
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes.tar.gz](https://dl.k8s.io/v1.16.0/kubernetes.tar.gz) | `99aa74225dd999d112ebc3e7b7d586a2312ec9c99de7a7fef8bbbfb198a5b4cf740baa57ea262995303e2a5060d26397775d928a086acd926042a41ef00f200b`
+[kubernetes-src.tar.gz](https://dl.k8s.io/v1.16.0/kubernetes-src.tar.gz) | `0be7d1d6564385cc20ff4d26bab55b71cc8657cf795429d04caa5db133a6725108d6a116553bf55081ccd854a4078e84d26366022634cdbfffd1a34a10b566cf`
+
+### Client Binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-client-darwin-386.tar.gz](https://dl.k8s.io/v1.16.0/kubernetes-client-darwin-386.tar.gz) | `a5fb80d26c2a75741ad0efccdacd5d5869fbc303ae4bb1920a6883ebd93a6b41969f898d177f2602faf23a7462867e1235edeb0ba0675041d0c8d5ab266ec62d`
+[kubernetes-client-darwin-amd64.tar.gz](https://dl.k8s.io/v1.16.0/kubernetes-client-darwin-amd64.tar.gz) | `47a9a78fada4b840d9ae4dac2b469a36d0812ac83d22fd798c4cb0f1673fb65c6558383c19a7268ed7101ac9fa32d53d79498407bdf94923f4f8f019ea39e912`
+[kubernetes-client-linux-386.tar.gz](https://dl.k8s.io/v1.16.0/kubernetes-client-linux-386.tar.gz) | `916e4dd98f5ed8ee111eeb6c2cf5c5f313e1d98f3531b40a5a777240ddb96b9cc53df101daa077ffff52cf01167fdcc39d38a8655631bac846641308634e127a`
+[kubernetes-client-linux-amd64.tar.gz](https://dl.k8s.io/v1.16.0/kubernetes-client-linux-amd64.tar.gz) | `fccf152588edbaaa21ca94c67408b8754f8bc55e49470380e10cf987be27495a8411d019d807df2b2c1c7620f8535e8f237848c3c1ac3791b91da8df59dea5aa`
+[kubernetes-client-linux-arm.tar.gz](https://dl.k8s.io/v1.16.0/kubernetes-client-linux-arm.tar.gz) | `066c55fabbe3434604c46574c51c324336a02a5bfaed2e4d83b67012d26bf98354928c9c12758b53ece16b8567e2b5ce6cb88d5cf3008c7baf3c5df02611a610`
+[kubernetes-client-linux-arm64.tar.gz](https://dl.k8s.io/v1.16.0/kubernetes-client-linux-arm64.tar.gz) | `e41be74cc36240a64ecc962a066988b5ef7c3f3112977efd4e307b35dd78688f41d6c5b376a6d1152d843182bbbe75d179de75675548bb846f8c1e28827e0e0c`
+[kubernetes-client-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.16.0/kubernetes-client-linux-ppc64le.tar.gz) | `08783eb3bb2e35b48dab3481e17d6e345d43bab8b8dee25bb5ff184ba46cb632750d4c38e9982366050aecce6e121c67bb6812dbfd607216acd3a2d19e05f5a1`
+[kubernetes-client-linux-s390x.tar.gz](https://dl.k8s.io/v1.16.0/kubernetes-client-linux-s390x.tar.gz) | `bcb6eb9cd3d8c92dfaf4f102ff2dc7517f632b1e955be6a02e7f223b15fc09c4ca2d6d9cd5b23871168cf6b455e2368daf17025c9cd61bf43d2ea72676db913a`
+[kubernetes-client-windows-386.tar.gz](https://dl.k8s.io/v1.16.0/kubernetes-client-windows-386.tar.gz) | `efbc764d8e2889ce13c9eaaa61f685a8714563ddc20464523140d6f5bef0dfd51b745c3bd3fe2093258db242bf9b3207f8e9f451b0484de64f18cdb7162ec30e`
+[kubernetes-client-windows-amd64.tar.gz](https://dl.k8s.io/v1.16.0/kubernetes-client-windows-amd64.tar.gz) | `b34bce694c6a0e4c8c5ddabcecb6adcb4d35f8c126b4b5ced7e44ef39cd45982dd9f6483a38e04430846f4da592dc74b475c37da7fe08444ef4eb5efde85e0b2`
+
+### Server Binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-server-linux-amd64.tar.gz](https://dl.k8s.io/v1.16.0/kubernetes-server-linux-amd64.tar.gz) | `a6bdac1eba1b87dc98b2bf5bf3690758960ecb50ed067736459b757fca0c3b01dd01fd215b4c06a653964048c6a81ea80b61ee8c7e4c98241409c091faf0cee1`
+[kubernetes-server-linux-arm.tar.gz](https://dl.k8s.io/v1.16.0/kubernetes-server-linux-arm.tar.gz) | `0560e1e893fe175d74465065d43081ee7f40ba7e7d7cafa53e5d7491f89c61957cf0d3abfa4620cd0f33b6e44911b43184199761005d20b72e3cd2ddc1224f9f`
+[kubernetes-server-linux-arm64.tar.gz](https://dl.k8s.io/v1.16.0/kubernetes-server-linux-arm64.tar.gz) | `4d5dd001fa3ac2b28bfee64e85dbedab0706302ffd634c34330617674e7a90e0108710f4248a2145676bd72f0bbc3598ed61e1e739c64147ea00d3b6a4ba4604`
+[kubernetes-server-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.16.0/kubernetes-server-linux-ppc64le.tar.gz) | `cc642fca57e22bf6edd371e61e254b369b760c67fa00cac50e34464470f7eea624953deff800fa1e4f7791fe06791c48dbba3ed47e789297ead889c2aa7b2bbf`
+[kubernetes-server-linux-s390x.tar.gz](https://dl.k8s.io/v1.16.0/kubernetes-server-linux-s390x.tar.gz) | `1f480ba6f593a3aa20203e82e9e34ac206e35839fd9135f495c5d154480c57d1118673dcb5a6b112c18025fb4a847f65dc7aac470f01d2f06ad3da6aa63d98a3`
+
+### Node Binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-node-linux-amd64.tar.gz](https://dl.k8s.io/v1.16.0/kubernetes-node-linux-amd64.tar.gz) | `e987f141bc0a248e99a371ce220403b78678c739a39dad1c1612e63a0bee4525fbca5ee8c2b5e5332a553cc5f63bce9ec95645589298f41fe83e1fd41faa538e`
+[kubernetes-node-linux-arm.tar.gz](https://dl.k8s.io/v1.16.0/kubernetes-node-linux-arm.tar.gz) | `8b084c1063beda2dd4000e8004634d82e580f05cc300c2ee13ad84bb884987b2c7fd1f033fb2ed46941dfc311249acef06efe5044fb72dc4b6089c66388e1f61`
+[kubernetes-node-linux-arm64.tar.gz](https://dl.k8s.io/v1.16.0/kubernetes-node-linux-arm64.tar.gz) | `365bdf9759e24d22cf507a0a5a507895ed44723496985e6d8f0bd10b03ffe7c78198732ee39873912147f2dd840d2e284118fc6fc1e3876d8f4c2c3a441def0b`
+[kubernetes-node-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.16.0/kubernetes-node-linux-ppc64le.tar.gz) | `ff54d83dd0fd3c447cdd76cdffd253598f6800045d2b6b91b513849d15b0b602590002e7fe2a55dc25ed5a05787f4973c480126491d24be7c5fce6ce98d0b6b6`
+[kubernetes-node-linux-s390x.tar.gz](https://dl.k8s.io/v1.16.0/kubernetes-node-linux-s390x.tar.gz) | `527cd9bf4bf392c3f097f232264c0f0e096ac410b5211b0f308c9d964f86900f5875012353b0b787efc9104f51ad90880f118efb1da54eba5c7675c1840eae5f`
+[kubernetes-node-windows-amd64.tar.gz](https://dl.k8s.io/v1.16.0/kubernetes-node-windows-amd64.tar.gz) | `4f76a94c70481dd1d57941f156f395df008835b5d1cc17708945e8f560234dbd426f3cff7586f10fd4c24e14e3dfdce28e90c8ec213c23d6ed726aec94e9b0ff`
+
+# Kubernetes v1.16.0 Release Notes
+
+A complete changelog for the release notes is now hosted in a customizable format at [relnotes.k8s.io](https://relnotes.k8s.io/?releaseVersions=1.16.0). Check it out and please give us your feedback!
+
+## What’s New (Major Themes)
+
+We’re pleased to announce the delivery of Kubernetes 1.16, our third release of 2019! Kubernetes 1.16 consists of 31 enhancements: 8 enhancements moving to stable, 8 enhancements in beta, and 15 enhancements in alpha.
+
+The main themes of this release are:
+
+- **Custom resources:** CRDs are in widespread use as a way to extend Kubernetes to persist and serve new resource types, and have been available in beta since the 1.7 release. The 1.16 release marks the graduation of CRDs to general availability (GA).
+- **Admission webhooks:** Admission webhooks are in widespread use as a Kubernetes extensibility mechanism and have been available in beta since the 1.9 release. The 1.16 release marks the graduation of admission webhooks to general availability (GA).
+- **Overhauled metrics**: Kubernetes has previously made extensive use of a global metrics registry to register metrics to be exposed. By implementing a metrics registry, metrics are registered in more transparent means. Previously, Kubernetes metrics have been excluded from any kind of stability requirements.
+- **Volume Extension**: There are quite a few enhancements in this release that pertain to volumes and volume modifications. Volume resizing support in CSI specs is moving to beta which allows for any CSI spec volume plugin to be resizable.
+
+### Additional Notable Feature Updates
+
+- [Topology Manager](https://github.com/kubernetes/enhancements/issues/693), a new Kubelet component, aims to co-ordinate resource assignment decisions to provide optimized resource allocations.
+- [IPv4/IPv6 dual-stack](https://kubernetes.io/docs/concepts/services-networking/dual-stack) enables the allocation of both IPv4 and IPv6 addresses to Pods and Services.
+- [API Server Network Proxy](https://github.com/kubernetes/enhancements/blob/master/keps/sig-api-machinery/20190226-network-proxy.md) going alpha in 1.16.
+- [Extensions](https://github.com/kubernetes/enhancements/blob/master/keps/sig-cloud-provider/20190422-cloud-controller-manager-migration.md) for Cloud Controller Manager Migration.
+- Continued deprecation of extensions/v1beta1, apps/v1beta1, and apps/v1beta2 APIs; these extensions will be retired in 1.16!
+
+## Known Issues
+
+- The etcd and KMS plugin health checks are not exposed in the new `livez` and `readyz` endpoints. This will be fixed in 1.16.1.
+- Systems running `iptables` 1.8.0 or newer should start it in legacy mode. Please note that this affects all versions of Kubernetes and not only v1.16.0. For more detailed information about the issue and how to apply a workaround, please refer to the official documentation
+- Generating informers for packages in directories containing dots in their name is broken. This will be fixed in v1.16.1. ([#82860](https://github.com/kubernetes/kubernetes/issues/82860))
+- kube-scheduler won't be able to report scheduling Events if `events.k8s.io/v1beta1` API is disabled. We are targeting the fix for v1.16.2 ([#83203](https://github.com/kubernetes/kubernetes/issues/83203))
+- The etcd client library vendored in v1.16 (github.com/coreos/etcd/clientv3) has a bug where IPv6 IP addresses get incorrectly trimmed to the first occurance of the `:` character. This affects all users of the client library including the kube-apiserver and kubeadm. We are targeting the fix for this bug in v1.16.3. ([#83550](https://github.com/kubernetes/kubernetes/issues/83550))
+
+## Urgent Upgrade Notes
+
+### (No, really, you MUST read this before you upgrade)
+
+#### Cluster Lifecycle
+
+- Container images tar files for `amd64` will now contain the architecture in the RepoTags manifest.json section.
+  If you are using docker manifests there are not visible changes. ([#80266](https://github.com/kubernetes/kubernetes/pull/80266), [@javier-b-perez](https://github.com/javier-b-perez))
+- kubeadm now deletes the bootstrap-kubelet.conf file after TLS bootstrap
+  User relying on bootstrap-kubelet.conf should switch to kubelet.conf that contains node credentials ([#80676](https://github.com/kubernetes/kubernetes/pull/80676), [@fabriziopandini](https://github.com/fabriziopandini))
+- Node labels `beta.kubernetes.io/metadata-proxy-ready`, `beta.kubernetes.io/metadata-proxy-ready` and `beta.kubernetes.io/kube-proxy-ds-ready` are no longer added on new nodes.
+  - ip-mask-agent addon starts to use the label `node.kubernetes.io/masq-agent-ds-ready` instead of `beta.kubernetes.io/masq-agent-ds-ready` as its node selector.
+  - kube-proxy addon starts to use the label `node.kubernetes.io/kube-proxy-ds-ready` instead of `beta.kubernetes.io/kube-proxy-ds-ready` as its node selector.
+  - metadata-proxy addon starts to use the label `cloud.google.com/metadata-proxy-ready` instead of `beta.kubernetes.io/metadata-proxy-ready` as its node selector.
+
+#### Storage
+
+- When PodInfoOnMount is enabled for a CSI driver, the new csi.storage.k8s.io/ephemeral parameter in the volume context allows a driver's NodePublishVolume implementation to determine on a case-by-case basis whether the volume is ephemeral or a normal persistent volume ([#79983](https://github.com/kubernetes/kubernetes/pull/79983), [@pohly](https://github.com/pohly))
+- Add CSI Migration Shim for VerifyVolumesAreAttached and BulkVolumeVerify ([#80443](https://github.com/kubernetes/kubernetes/pull/80443), [@davidz627](https://github.com/davidz627))
+- Promotes VolumePVCDataSource (Cloning) feature to beta for 1.16 release ([#81792](https://github.com/kubernetes/kubernetes/pull/81792), [@j-griffith](https://github.com/j-griffith))
+- Integrated volume limits for in-tree and CSI volumes into one scheduler predicate. ([#77595](https://github.com/kubernetes/kubernetes/pull/77595), [@bertinatto](https://github.com/bertinatto))
+
+## Deprecations and Removals
+
+- API
+
+  - The following APIs are no longer served by default:
+
+    - All resources under `apps/v1beta1` and `apps/v1beta2` - use `apps/v1` instead
+    - `daemonsets`, `deployments`, `replicasets` resources under `extensions/v1beta1` - use `apps/v1` instead
+    - `networkpolicies` resources under `extensions/v1beta1` - use `networking.k8s.io/v1` instead
+    - `podsecuritypolicies` resources under `extensions/v1beta1` - use `policy/v1beta1` instead
+
+    Serving these resources can be temporarily re-enabled using the `--runtime-config` apiserver flag.
+
+    - `apps/v1beta1=true`
+    - `apps/v1beta2=true`
+    - `extensions/v1beta1/daemonsets=true,extensions/v1beta1/deployments=true,extensions/v1beta1/replicasets=true,extensions/v1beta1/networkpolicies=true,extensions/v1beta1/podsecuritypolicies=true`
+
+    The ability to serve these resources will be completely removed in v1.18. ([#70672](https://github.com/kubernetes/kubernetes/pull/70672), [@liggitt](https://github.com/liggitt))
+
+  - Ingress resources will no longer be served from `extensions/v1beta1` in v1.20. Migrate use to the `networking.k8s.io/v1beta1` API, available since v1.14. Existing persisted data can be retrieved via the `networking.k8s.io/v1beta1` API.
+  - PriorityClass resources will no longer be served from `scheduling.k8s.io/v1beta1` and `scheduling.k8s.io/v1alpha1` in v1.17. Migrate to the `scheduling.k8s.io/v1` API, available since v1.14. Existing persisted data can be retrieved via the `scheduling.k8s.io/v1` API.
+  - The `export` query parameter for list API calls, deprecated since v1.14, will be removed in v1.18.
+  - The `series.state` field in the events.k8s.io/v1beta1 Event API is deprecated and will be removed in v1.18 ([#75987](https://github.com/kubernetes/kubernetes/pull/75987), [@yastij](https://github.com/yastij))
+  - The `apiextensions.k8s.io/v1beta1` version of `CustomResourceDefinition` is deprecated and will no longer be served in v1.19. Use `apiextensions.k8s.io/v1` instead. ([#79604](https://github.com/kubernetes/kubernetes/pull/79604), [@liggitt](https://github.com/liggitt))
+  - The `admissionregistration.k8s.io/v1beta1` versions of `MutatingWebhookConfiguration` and `ValidatingWebhookConfiguration` are deprecated and will no longer be served in v1.19. Use `admissionregistration.k8s.io/v1` instead. ([#79549](https://github.com/kubernetes/kubernetes/pull/79549), [@liggitt](https://github.com/liggitt))
+  - The alpha `metadata.initializers` field, deprecated in 1.13, has been removed. ([#79504](https://github.com/kubernetes/kubernetes/pull/79504), [@yue9944882](https://github.com/yue9944882))
+  - The deprecated node condition type `OutOfDisk` has been removed. Use the `DiskPressure` condition instead. ([#72420](https://github.com/kubernetes/kubernetes/pull/72420), [@Pingan2017](https://github.com/Pingan2017))
+  - The `metadata.selfLink` field is deprecated in individual and list objects. It will no longer be returned starting in v1.20, and the field will be removed entirely in v1.21. ([#80978](https://github.com/kubernetes/kubernetes/pull/80978), [@wojtek-t](https://github.com/wojtek-t))
+  - The deprecated cloud providers `ovirt`, `cloudstack` and `photon` have been removed ([#72178](https://github.com/kubernetes/kubernetes/pull/72178), [@dims](https://github.com/dims))
+  - The `Cinder` and `ScaleIO` volume providers have been deprecated and will be removed in a future release. ([#80099](https://github.com/kubernetes/kubernetes/pull/80099), [@dims](https://github.com/dims))
+  - The GA `PodPriority` feature gate is now on by default and cannot be disabled. The feature gate will be removed in v1.18. ([#79262](https://github.com/kubernetes/kubernetes/pull/79262), [@draveness](https://github.com/draveness))
+  - Aggregated discovery requests can now timeout. Aggregated API servers must complete discovery calls within 5 seconds (other requests can take longer). Use the feature gate `EnableAggregatedDiscoveryTimeout=false` to temporarily revert behavior to the previous 30 second timeout if required (the temporary `EnableAggregatedDiscoveryTimeout` feature gate will be removed in v1.17). ([#82146](https://github.com/kubernetes/kubernetes/pull/82146), [@deads2k](https://github.com/deads2k))
+  - the `scheduler.alpha.kubernetes.io/critical-pod` annotation is removed. Pod priority (`spec.priorityClassName`) should be used instead to mark pods as critical. ([#80342](https://github.com/kubernetes/kubernetes/pull/80342), [@draveness](https://github.com/draveness))
+  - the NormalizeScore plugin set is removed from scheduler framework config API. Use ScorePlugin only. ([#80930](https://github.com/kubernetes/kubernetes/pull/80930), [@liu-cong](https://github.com/liu-cong))
+  - the node label `alpha.service-controller.kubernetes.io/exclude-balancer` which excludes a node from cloud load balancers (using Service Type=LoadBalancer) is deprecated in favor of `node.kubernetes.io/exclude-balancer`. Support for `alpha.service-controller.kubernetes.io/exclude-balancer` will be removed in v1.18.
+
+- Features:
+
+  - The following features are now GA, and the associated feature gates are deprecated and will be removed in v1.17:
+    - `GCERegionalPersistentDisk` (since 1.15.0)
+    - `CustomResourcePublishOpenAPI`
+    - `CustomResourceSubresources`
+    - `CustomResourceValidation`
+    - `CustomResourceWebhookConversion`
+  - The feature flags `HugePages`, `VolumeScheduling`, `CustomPodDNS` and `PodReadinessGates` have been removed ([#79307](https://github.com/kubernetes/kubernetes/pull/79307), [@draveness](https://github.com/draveness))
+
+- hyperkube
+
+  - the `--make-symlinks` flag, deprecated in v1.14, has been removed. ([#80017](https://github.com/kubernetes/kubernetes/pull/80017), [@Pothulapati](https://github.com/Pothulapati))
+
+- kube-apiserver
+
+  - the `--basic-auth-file` flag and authentication mode is deprecated and will be removed in a future release. It is not recommended for production environments. ([#81152](https://github.com/kubernetes/kubernetes/pull/81152), [@tedyu](https://github.com/tedyu))
+  - the `--cloud-provider-gce-lb-src-cidrs` flag has been deprecated. This flag will be removed once the GCE Cloud Provider is removed from kube-apiserver. ([#81094](https://github.com/kubernetes/kubernetes/pull/81094), [@andrewsykim](https://github.com/andrewsykim))
+  - the `--enable-logs-handler` flag and log-serving functionality is deprecated since v1.15, and scheduled to be removed in v1.19. ([#77611](https://github.com/kubernetes/kubernetes/pull/77611), [@rohitsardesai83](https://github.com/rohitsardesai83))
+  - Deprecate the default service IP CIDR. The previous default was `10.0.0.0/24` which will be removed in 6 months/2 releases. Cluster admins must specify their own desired value, by using `--service-cluster-ip-range` on kube-apiserver. ([#81668](https://github.com/kubernetes/kubernetes/pull/81668), [@darshanime](https://github.com/darshanime))
+
+- kube-proxy
+
+  - the `--resource-container` flag has been removed from kube-proxy, and specifying it will now cause an error. The behavior is now as if you specified `--resource-container=""`. If you previously specified a non-empty `--resource-container`, you can no longer do so as of kubernetes 1.16. ([#78294](https://github.com/kubernetes/kubernetes/pull/78294), [@vllry](https://github.com/vllry))
+
+- kube-scheduler
+
+  - Migrate scheduler to use v1beta1 Event API. any tool targeting scheduler events needs to use v1beta1 Event API ([#78447](https://github.com/kubernetes/kubernetes/pull/78447), [@yastij](https://github.com/yastij))
+
+- kubeadm
+
+  - The CoreDNS Deployment now checks readiness via the `ready` plugin.
+  - The `proxy` plugin has been deprecated. The `forward` plugin is to be used instead.
+  - `kubernetes` plugin removes the `resyncperiod` option.
+  - The `upstream` option is deprecated and ignored if included.
+    ([#82127](https://github.com/kubernetes/kubernetes/pull/82127), [@rajansandeep](https://github.com/rajansandeep))
+
+- kubectl
+
+  - `kubectl convert`, deprecated since v1.14, will be removed in v1.17.
+  - The `--export` flag for the `kubectl get` command, deprecated since v1.14, will be removed in v1.18.
+  - `kubectl cp` no longer supports copying symbolic links from containers; to support this use case, see `kubectl exec --help` for examples using `tar` directly ([#82143](https://github.com/kubernetes/kubernetes/pull/82143), [@soltysh](https://github.com/soltysh))
+  - Removed deprecated flag `--include-uninitialized`. ([#80337](https://github.com/kubernetes/kubernetes/pull/80337), [@draveness](https://github.com/draveness))
+
+- kubelet
+
+  - the `--containerized` flag was deprecated in 1.14 and has been removed ([#80043](https://github.com/kubernetes/kubernetes/pull/80043), [@dims](https://github.com/dims))
+  - the `beta.kubernetes.io/os` and `beta.kubernetes.io/arch` labels, deprecated since v1.14, are targeted for removal in v1.18.
+  - cAdvisor json endpoints have been deprecated since 1.15. ([#78504](https://github.com/kubernetes/kubernetes/pull/78504), [@dashpole](https://github.com/dashpole))
+  - removed the ability to set `kubernetes.io`- or `k8s.io`-prefixed labels via `--node-labels`, other than the [specifically allowed labels/prefixes](https://github.com/kubernetes/enhancements/blob/master/keps/sig-auth/0000-20170814-bounding-self-labeling-kubelets.md#proposal). ([#79305](https://github.com/kubernetes/kubernetes/pull/79305), [@paivagustavo](https://github.com/paivagustavo))
+
+- client-go
+  - Remove `DirectCodecFactory` (replaced with `serializer.WithoutConversionCodecFactory`), `DirectEncoder` (replaced with `runtime.WithVersionEncoder`) and `DirectDecoder` (replaced with `runtime.WithoutVersionDecoder`). ([#79263](https://github.com/kubernetes/kubernetes/pull/79263), [@draveness](https://github.com/draveness))
+
+## Metrics Changes
+
+### Added metrics
+
+- Added metrics `aggregator_openapi_v2_regeneration_count`, `aggregator_openapi_v2_regeneration_gauge` and `apiextension_openapi_v2_regeneration_count` counting the triggering APIService and CRDs and the reason (add, update, delete) when kube-apiserver regenerates the OpenAPI spec. ([#81786](https://github.com/kubernetes/kubernetes/pull/81786), [@sttts](https://github.com/sttts))
+- Added metrics `authentication_attempts` that can be used to understand the attempts of authentication. ([#81509](https://github.com/kubernetes/kubernetes/pull/81509), [@RainbowMango](https://github.com/RainbowMango))
+- Add a new counter metrics `apiserver_admission_webhook_rejection_count` with details about the causing for a webhook rejection. ([#81399](https://github.com/kubernetes/kubernetes/pull/81399), [@roycaihw](https://github.com/roycaihw))
+- NFS Drivers are now enabled to collect metrics, StatFS metrics provider is used to collect the metrics. (@brahmaroutu) ([#75805](https://github.com/kubernetes/kubernetes/pull/75805), [@brahmaroutu](https://github.com/brahmaroutu))
+- Add `container_sockets`, `container_threads`, and `container_threads_max` metrics ([#81972](https://github.com/kubernetes/kubernetes/pull/81972), [@dashpole](https://github.com/dashpole))
+- Add `container_state` label to `running_container_count` kubelet metrics, to get count of containers based on their state(running/exited/created/unknown) ([#81573](https://github.com/kubernetes/kubernetes/pull/81573), [@irajdeep](https://github.com/irajdeep))
+- Added metric `apiserver_watch_events_total` that can be used to understand the number of watch events in the system. ([#78732](https://github.com/kubernetes/kubernetes/pull/78732), [@mborsz](https://github.com/mborsz))
+- Added metric `apiserver_watch_events_sizes` that can be used to estimate sizes of watch events in the system. ([#80477](https://github.com/kubernetes/kubernetes/pull/80477), [@mborsz](https://github.com/mborsz))
+- Added a new Prometheus counter metric `sync_proxy_rules_iptables_restore_failures_total` for kube-proxy iptables-restore failures (both ipvs and iptables modes)
+  ([#81210](https://github.com/kubernetes/kubernetes/pull/81210), [@figo](https://github.com/figo))
+- kubelet now exports an `kubelet_evictions` metric that counts the number of pod evictions carried out by the kubelet to reclaim resources ([#81377](https://github.com/kubernetes/kubernetes/pull/81377), [@sjenning](https://github.com/sjenning))
+
+### Removed metrics
+
+- Removed cadvisor metric labels `pod_name` and `container_name` to match instrumentation guidelines. Any Prometheus queries that match `pod_name` and `container_name` labels (e.g. cadvisor or kubelet probe metrics) must be updated to use `pod` and `container` instead. ([#80376](https://github.com/kubernetes/kubernetes/pull/80376), [@ehashman](https://github.com/ehashman))
+
+### Deprecated/changed metrics
+
+- kube-controller-manager and cloud-controller-manager metrics are now marked as with the ALPHA stability level. ([#81624](https://github.com/kubernetes/kubernetes/pull/81624), [@logicalhan](https://github.com/logicalhan))
+- kube-proxy metrics are now marked as with the ALPHA stability level. ([#81626](https://github.com/kubernetes/kubernetes/pull/81626), [@logicalhan](https://github.com/logicalhan))
+- kube-apiserver metrics are now marked as with the ALPHA stability level. ([#81531](https://github.com/kubernetes/kubernetes/pull/81531), [@logicalhan](https://github.com/logicalhan))
+- kubelet metrics for /metrics and /metrics/probes are now marked as with the ALPHA stability level. ([#81534](https://github.com/kubernetes/kubernetes/pull/81534), [@logicalhan](https://github.com/logicalhan))
+- Scheduler metrics are now marked as with the ALPHA stability level. ([#81576](https://github.com/kubernetes/kubernetes/pull/81576), [@logicalhan](https://github.com/logicalhan))
+- The `rejected` label in `apiserver_admission_webhook_admission_duration_seconds` metrics now properly indicates if the request was rejected. ([#81399](https://github.com/kubernetes/kubernetes/pull/81399), [@roycaihw](https://github.com/roycaihw))
+- Fixed a bug in the CSI metrics that does not return not supported error when a CSI driver does not support metrics. ([#79851](https://github.com/kubernetes/kubernetes/pull/79851), [@jparklab](https://github.com/jparklab))
+- Fix disk stats in LXD using ZFS storage pool and CRI-O missing network metris bug ([#81972](https://github.com/kubernetes/kubernetes/pull/81972), [@dashpole](https://github.com/dashpole))
+
+## Notable Features
+
+### Beta
+
+- Promote WatchBookmark feature to beta and enable it by default.
+  With WatchBookmark feature, clients are able to request watch events with BOOKMARK type. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. ([#79786](https://github.com/kubernetes/kubernetes/pull/79786), [@wojtek-t](https://github.com/wojtek-t))
+- The server-side apply feature is now beta ([#81956](https://github.com/kubernetes/kubernetes/pull/81956), [@apelisse](https://github.com/apelisse))
+- Server-side apply will now use the openapi provided in the CRD validation field to help figure out how to correctly merge objects and update ownership. ([#77354](https://github.com/kubernetes/kubernetes/pull/77354), [@jennybuckley](https://github.com/jennybuckley))
+- The `CustomResourceDefaulting` feature is promoted to beta and enabled by default. Defaults may be specified in structural schemas via the `apiextensions.k8s.io/v1` API. See https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/#specifying-a-structural-schema for details. ([#81872](https://github.com/kubernetes/kubernetes/pull/81872), [@sttts](https://github.com/sttts))
+- Finalizer Protection for Service LoadBalancers is now in beta (enabled by default). This feature ensures the Service resource is not fully deleted until the correlating load balancer resources are deleted. ([#81691](https://github.com/kubernetes/kubernetes/pull/81691), [@MrHohn](https://github.com/MrHohn))
+- Graduating Windows GMSA support from alpha to beta ([#82110](https://github.com/kubernetes/kubernetes/pull/82110), [@wk8](https://github.com/wk8))
+
+### Alpha
+
+- Introduce a new admission controller for RuntimeClass. Initially, RuntimeClass will be used to apply the pod overhead associated with a given RuntimeClass to the Pod `spec` if a corresponding RuntimeClassName is specified. PodOverhead is an alpha feature as of Kubernetes 1.16. ([#78484](https://github.com/kubernetes/kubernetes/pull/78484), [@egernst](https://github.com/egernst))
+- Introduction of the pod overhead feature to the scheduler. This functionality is alpha-level as of
+  Kubernetes v1.16, and is only honored by servers that enable the PodOverhead feature.gate. ([#78319](https://github.com/kubernetes/kubernetes/pull/78319), [@egernst](https://github.com/egernst))
+- Ephemeral containers have been added in alpha. These temporary containers can be added to running pods for purposes such as debugging, similar to how `kubectl exec` runs a process in an existing container. Also like `kubectl exec`, no resources are reserved for ephemeral containers and they are not restarted when they exit. Note that container namespace targeting is not yet implemented, so [process namespace sharing](https://kubernetes.io/docs/tasks/configure-pod-container/share-process-namespace/) must be enabled to view process from other containers in the pod. ([#59484](https://github.com/kubernetes/kubernetes/pull/59484), [@verb](https://github.com/verb))
+- Pod spread constraints have been added in alpha. You can use these constraints to control how Pods are spread across the cluster among failure-domains. ([#77327](https://github.com/kubernetes/kubernetes/pull/77327), [#77760](https://github.com/kubernetes/kubernetes/pull/77760), [#77828](https://github.com/kubernetes/kubernetes/pull/77828), [#79062](https://github.com/kubernetes/kubernetes/pull/79062), [#80011](https://github.com/kubernetes/kubernetes/pull/80011), [#81068](https://github.com/kubernetes/kubernetes/pull/81068), [@Huang-Wei](https://github.com/Huang-Wei))
+
+### CLI Improvements
+
+- the new flag `--endpoint-updates-batch-period` in kube-controller-manager can be used to reduce the number of endpoints updates generated by pod changes. ([#80509](https://github.com/kubernetes/kubernetes/pull/80509), [@mborsz](https://github.com/mborsz))
+- the kubectl `--all-namespaces` flag is now honored by `kubectl wait` ([#81468](https://github.com/kubernetes/kubernetes/pull/81468), [@ashutoshgngwr](https://github.com/ashutoshgngwr))
+- `kubectl get -w` now takes an `--output-watch-events` flag to indicate the event type (ADDED, MODIFIED, DELETED) ([#72416](https://github.com/kubernetes/kubernetes/pull/72416), [@liggitt](https://github.com/liggitt))
+- Adds Endpoint Slice support for kubectl when discovery API group is enabled. ([#81795](https://github.com/kubernetes/kubernetes/pull/81795), [@robscott](https://github.com/robscott))
+
+### Misc
+
+- Add `--shutdown-delay-duration` to kube-apiserver in order to delay a graceful shutdown. `/healthz` will keep returning success during this time and requests are normally served, but `/readyz` will return failure immediately. This delay can be used to allow the SDN to update iptables on all nodes and stop sending traffic. ([#74416](https://github.com/kubernetes/kubernetes/pull/74416), [@sttts](https://github.com/sttts))
+  Kubeadm now seamlessly migrates the CoreDNS Configuration when upgrading CoreDNS. ([#78033](https://github.com/kubernetes/kubernetes/pull/78033), [@rajansandeep](https://github.com/rajansandeep))
+- Add Endpoint Slice Controller for managing new EndpointSlice resource, disabled by default. ([#81048](https://github.com/kubernetes/kubernetes/pull/81048), [@robscott](https://github.com/robscott))
+- Adds `\livez` for liveness health checking for kube-apiserver. Using the parameter `--maximum-startup-sequence-duration` will allow the liveness endpoint to defer boot-sequence failures for the specified duration period. ([#81969](https://github.com/kubernetes/kubernetes/pull/81969), [@logicalhan](https://github.com/logicalhan))
+- Adds EndpointSlice integration to kube-proxy, can be enabled with EndpointSlice feature gate. ([#81430](https://github.com/kubernetes/kubernetes/pull/81430), [@robscott](https://github.com/robscott))
+- Add status condition to namespace resource ([#73405](https://github.com/kubernetes/kubernetes/pull/73405), [@wozniakjan](https://github.com/wozniakjan))
+- Enhance Azure cloud provider code to support both AAD and ADFS authentication. ([#80841](https://github.com/kubernetes/kubernetes/pull/80841), [@rjaini](https://github.com/rjaini))
+- kubeadm: implement support for concurrent add/remove of stacked etcd members ([#79677](https://github.com/kubernetes/kubernetes/pull/79677), [@neolit123](https://github.com/neolit123))
+- kubeadm: support any Linux kernel version newer than 3.10 ([#81623](https://github.com/kubernetes/kubernetes/pull/81623), [@neolit123](https://github.com/neolit123))
+- Volume expansion is enabled in the default GCE storageclass ([#78672](https://github.com/kubernetes/kubernetes/pull/78672), [@msau42](https://github.com/msau42))
+- kubeadm ClusterConfiguration now supports featureGates: IPv6DualStack: true ([#80145](https://github.com/kubernetes/kubernetes/pull/80145), [@Arvinderpal](https://github.com/Arvinderpal))
+- In order to enable dual-stack support within kubeadm and kubernetes components, as part of the init config file, the user should set feature-gate `IPv6DualStack=true` in the ClusterConfiguration. Additionally, for each worker node, the user should set the feature-gate for kubelet using either `nodeRegistration.kubeletExtraArgs` or `KUBELET_EXTRA_ARGS`. ([#80531](https://github.com/kubernetes/kubernetes/pull/80531), [@Arvinderpal](https://github.com/Arvinderpal))
+- Add possibility to configure controller manager to use IPv6 dual stack:
+  use `--cluster-cidr="<cidr1>,<cidr2>"`.
+  Notes:
+  1. Only the first two CIDRs are used (soft limits for Alpha, might be lifted later on).
+  2. Only the "RangeAllocator" (default) is allowed as a value for `--cidr-allocator-type`. Cloud allocators are not compatible with IPv6 dual stack
+     ([#73977](https://github.com/kubernetes/kubernetes/pull/73977), [@khenidak](https://github.com/khenidak))
+- Add scheduling support for RuntimeClasses. RuntimeClasses can now specify nodeSelector constraints & tolerations, which are merged into the PodSpec for pods using that RuntimeClass. ([#80825](https://github.com/kubernetes/kubernetes/pull/80825), [@tallclair](https://github.com/tallclair))
+- When specifying `--(kube|system)-reserved-cgroup`, with `--cgroup-driver=systemd`, it is now possible to use the fully qualified cgroupfs name (i.e. `/test-cgroup.slice`). ([#78793](https://github.com/kubernetes/kubernetes/pull/78793), [@mattjmcnaughton](https://github.com/mattjmcnaughton))
+- Adds support for vSphere volumes on Windows ([#80911](https://github.com/kubernetes/kubernetes/pull/80911), [@gab-satchi](https://github.com/gab-satchi))
+
+## API Changes
+
+- The `MutatingWebhookConfiguration` and `ValidatingWebhookConfiguration` APIs have been promoted to `admissionregistration.k8s.io/v1`:
+  - `failurePolicy` default changed from `Ignore` to `Fail` for v1
+  - `matchPolicy` default changed from `Exact` to `Equivalent` for v1
+  - `timeout` default changed from `30s` to `10s` for v1
+  - `sideEffects` default value is removed, and the field made required, and only `None` and `NoneOnDryRun` are permitted for v1
+  - `admissionReviewVersions` default value is removed and the field made required for v1 (supported versions for AdmissionReview are `v1` and `v1beta1`)
+  - The `name` field for specified webhooks must be unique for `MutatingWebhookConfiguration` and `ValidatingWebhookConfiguration` objects created via `admissionregistration.k8s.io/v1`
+- The `AdmissionReview` API sent to and received from admission webhooks has been promoted to `admission.k8s.io/v1`. Webhooks can specify a preference for receiving `v1` AdmissionReview objects with `admissionReviewVersions: ["v1","v1beta1"]`, and must respond with an API object in the same `apiVersion` they are sent. When webhooks use `admission.k8s.io/v1`, the following additional validation is performed on their responses:
+  - `response.patch` and `response.patchType` are not permitted from validating admission webhooks
+  - `apiVersion: "admission.k8s.io/v1"` is required
+  - `kind: "AdmissionReview"` is required
+  - `response.uid: "<value of request.uid>"` is required
+  - `response.patchType: "JSONPatch"` is required (if `response.patch` is set) ([#80231](https://github.com/kubernetes/kubernetes/pull/80231), [@liggitt](https://github.com/liggitt))
+- The `CustomResourceDefinition` API type is promoted to `apiextensions.k8s.io/v1` with the following changes:
+  - Use of the new `default` feature in validation schemas is limited to v1
+  - `spec.scope` is no longer defaulted to `Namespaced` and must be explicitly specified
+  - `spec.version` is removed in v1; use `spec.versions` instead
+  - `spec.validation` is removed in v1; use `spec.versions[*].schema` instead
+  - `spec.subresources` is removed in v1; use `spec.versions[*].subresources` instead
+  - `spec.additionalPrinterColumns` is removed in v1; use `spec.versions[*].additionalPrinterColumns` instead
+  - `spec.conversion.webhookClientConfig` is moved to `spec.conversion.webhook.clientConfig` in v1
+  - `spec.conversion.conversionReviewVersions` is moved to `spec.conversion.webhook.conversionReviewVersions` in v1
+  - `spec.versions[*].schema.openAPIV3Schema` is now required when creating v1 CustomResourceDefinitions
+  - `spec.preserveUnknownFields: true` is disallowed when creating v1 CustomResourceDefinitions; it must be specified within schema definitions as `x-kubernetes-preserve-unknown-fields: true`
+  - In `additionalPrinterColumns` items, the `JSONPath` field was renamed to `jsonPath` in v1 (fixes https://github.com/kubernetes/kubernetes/issues/66531)
+    The `apiextensions.k8s.io/v1beta1` version of `CustomResourceDefinition` is deprecated and will no longer be served in v1.19. ([#79604](https://github.com/kubernetes/kubernetes/pull/79604), [@liggitt](https://github.com/liggitt))
+- The `ConversionReview` API sent to and received from custom resource CustomResourceDefinition conversion webhooks has been promoted to `apiextensions.k8s.io/v1`. CustomResourceDefinition conversion webhooks can now indicate they support receiving and responding with `ConversionReview` API objects in the `apiextensions.k8s.io/v1` version by including `v1` in the `conversionReviewVersions` list in their CustomResourceDefinition. Conversion webhooks must respond with a ConversionReview object in the same apiVersion they receive. `apiextensions.k8s.io/v1` `ConversionReview` responses must specify a `response.uid` that matches the `request.uid` of the object they were sent. ([#81476](https://github.com/kubernetes/kubernetes/pull/81476), [@liggitt](https://github.com/liggitt))
+- Add scheduling support for RuntimeClasses. RuntimeClasses can now specify nodeSelector constraints & tolerations, which are merged into the PodSpec for pods using that RuntimeClass. ([#80825](https://github.com/kubernetes/kubernetes/pull/80825), [@tallclair](https://github.com/tallclair))
+- Kubelet should now more reliably report the same primary node IP even if the set of node IPs reported by the CloudProvider changes. ([#79391](https://github.com/kubernetes/kubernetes/pull/79391), [@danwinship](https://github.com/danwinship))
+- Omit nil or empty field when calculating container hash value to avoid hash changed. For a new field with a non-nil default value in the container spec, the hash would still get changed. ([#57741](https://github.com/kubernetes/kubernetes/pull/57741), [@dixudx](https://github.com/dixudx))
+- Property `conditions` in `apiextensions.v1beta1.CustomResourceDefinitionStatus` and `apiextensions.v1.CustomResourceDefinitionStatus` is now optional instead of required. ([#64996](https://github.com/kubernetes/kubernetes/pull/64996), [@roycaihw](https://github.com/roycaihw))
+- When the status of a CustomResourceDefinition condition changes, its corresponding `lastTransitionTime` is now updated. ([#69655](https://github.com/kubernetes/kubernetes/pull/69655), [@CaoShuFeng](https://github.com/CaoShuFeng))
+
+## Other notable changes
+
+### API Machinery
+
+- Remove `GetReference()` and `GetPartialReference()` function from `pkg/api/ref`, as the same function exists also in `staging/src/k8s.io/client-go/tools/ref` ([#80361](https://github.com/kubernetes/kubernetes/pull/80361), [@wojtek-t](https://github.com/wojtek-t))
+- Verify that CRD default values in OpenAPI specs are pruned, with the exceptions of values under `metadata`. ([#78829](https://github.com/kubernetes/kubernetes/pull/78829), [@sttts](https://github.com/sttts))
+- Fixes a bug that when there is a "connection refused" error, the reflector's ListAndWatch func will return directly but what expected is that sleep 1 second and rewatch since the specified resourceVersion.
+  ([#81634](https://github.com/kubernetes/kubernetes/pull/81634), [@likakuli](https://github.com/likakuli))
+- Resolves an issue serving aggregated APIs backed by services that respond to requests to `/` with non-2xx HTTP responses ([#79895](https://github.com/kubernetes/kubernetes/pull/79895), [@deads2k](https://github.com/deads2k))
+- The CRD handler now properly re-creates stale CR storage to reflect CRD update. ([#79114](https://github.com/kubernetes/kubernetes/pull/79114), [@roycaihw](https://github.com/roycaihw))
+- Fix CVE-2019-11247: API server allows access to custom resources via wrong scope ([#80750](https://github.com/kubernetes/kubernetes/pull/80750), [@sttts](https://github.com/sttts))
+- Fixed a bug with the openAPI definition for `io.k8s.apimachinery.pkg.runtime.RawExtension`, which previously required a field `raw` to be specified ([#80773](https://github.com/kubernetes/kubernetes/pull/80773), [@jennybuckley](https://github.com/jennybuckley))
+- Property `conditions` in `apiextensions.v1beta1.CustomResourceDefinitionStatus` and `apiextensions.v1.CustomResourceDefinitionStatus` is now optional instead of required. ([#64996](https://github.com/kubernetes/kubernetes/pull/64996), [@roycaihw](https://github.com/roycaihw))
+- Resolves a transient 404 response to custom resource requests during server startup ([#81244](https://github.com/kubernetes/kubernetes/pull/81244), [@liggitt](https://github.com/liggitt))
+- OpenAPI now advertises correctly supported patch types for custom resources ([#81515](https://github.com/kubernetes/kubernetes/pull/81515), [@liggitt](https://github.com/liggitt))
+- When the status of a CRD Condition changes, it's corresponding `LastTransitionTime` is now updated. ([#69655](https://github.com/kubernetes/kubernetes/pull/69655), [@CaoShuFeng](https://github.com/CaoShuFeng))
+- Add `metadata.generation=1` to old CustomResources. ([#82005](https://github.com/kubernetes/kubernetes/pull/82005), [@sttts](https://github.com/sttts))
+- Fix a bug in the apiserver that could cause a valid update request to be rejected with a precondition check failure. ([#82303](https://github.com/kubernetes/kubernetes/pull/82303), [@roycaihw](https://github.com/roycaihw))
+- Fixes regression in logging spurious stack traces when proxied connections are closed by the backend ([#82588](https://github.com/kubernetes/kubernetes/pull/82588), [@liggitt](https://github.com/liggitt))
+- RateLimiter add a context-aware method, fix client-go request goruntine backlog in async timeout scene. ([#79375](https://github.com/kubernetes/kubernetes/pull/79375), [@answer1991](https://github.com/answer1991))
+- Add a `Patch` method to `ScaleInterface` ([#80699](https://github.com/kubernetes/kubernetes/pull/80699), [@knight42](https://github.com/knight42))
+- CRDs under k8s.io and kubernetes.io must have the `api-approved.kubernetes.io` set to either `unapproved.*` or a link to the pull request approving the schema. See https://github.com/kubernetes/enhancements/pull/1111 for more details. ([#79992](https://github.com/kubernetes/kubernetes/pull/79992), [@deads2k](https://github.com/deads2k))
+- KMS Providers will install a healthz check for the status of kms-plugin in kube-apiservers' encryption config. ([#78540](https://github.com/kubernetes/kubernetes/pull/78540), [@immutableT](https://github.com/immutableT))
+- Improves validation errors for custom resources ([#81212](https://github.com/kubernetes/kubernetes/pull/81212), [@liggitt](https://github.com/liggitt))
+- Populate object name for admission attributes when CREATE ([#53185](https://github.com/kubernetes/kubernetes/pull/53185), [@dixudx](https://github.com/dixudx))
+- Add Overhead field to the PodSpec and RuntimeClass types as part of the Pod Overhead KEP ([#76968](https://github.com/kubernetes/kubernetes/pull/76968), [@egernst](https://github.com/egernst))
+
+### Apps
+
+- Fix a bug that pods not be deleted from unmatched nodes by daemon controller ([#78974](https://github.com/kubernetes/kubernetes/pull/78974), [@DaiHao](https://github.com/DaiHao))
+- Fix a bug that causes DaemonSet rolling update hang when there exist failed pods. ([#78170](https://github.com/kubernetes/kubernetes/pull/78170), [@DaiHao](https://github.com/DaiHao))
+
+### Auth
+
+- Service account tokens now include the JWT Key ID field in their header. ([#78502](https://github.com/kubernetes/kubernetes/pull/78502), [@ahmedtd](https://github.com/ahmedtd))
+- The nbf (not before) claim, if present in ID token, is now enforced. ([#81413](https://github.com/kubernetes/kubernetes/pull/81413), [@anderseknert](https://github.com/anderseknert))
+
+### CLI
+
+- Fix CVE-2019-11249: Incomplete fixes for CVE-2019-1002101 and CVE-2019-11246, kubectl cp potential directory traversal ([#80436](https://github.com/kubernetes/kubernetes/pull/80436), [@M00nF1sh](https://github.com/M00nF1sh))
+- Fix the bash completion error with override flags. ([#80802](https://github.com/kubernetes/kubernetes/pull/80802), [@dtaniwaki](https://github.com/dtaniwaki))
+- Fix a bug in server printer that could cause kube-apiserver to panic. ([#79349](https://github.com/kubernetes/kubernetes/pull/79349), [@roycaihw](https://github.com/roycaihw))
+- Fix invalid "time stamp is the future" error when kubectl cp-ing a file ([#73982](https://github.com/kubernetes/kubernetes/pull/73982), [@tanshanshan](https://github.com/tanshanshan))
+- Fix a bug where `kubectl set config` hangs and uses 100% CPU on some invalid property names ([#79000](https://github.com/kubernetes/kubernetes/pull/79000), [@pswica](https://github.com/pswica))
+- Fix output of `kubectl get --watch-only` when watching a single resource ([#79345](https://github.com/kubernetes/kubernetes/pull/79345), [@liggitt](https://github.com/liggitt))
+- Make kubectl get `--ignore-not-found` continue processing when encountering error. ([#82120](https://github.com/kubernetes/kubernetes/pull/82120), [@soltysh](https://github.com/soltysh))
+- Correct a reference to a not/no longer used kustomize subcommand in the documentation ([#82535](https://github.com/kubernetes/kubernetes/pull/82535), [@demobox](https://github.com/demobox))
+- kubectl could scale custom resource again ([#81342](https://github.com/kubernetes/kubernetes/pull/81342), [@knight42](https://github.com/knight42))
+- Add PodOverhead awareness to kubectl ([#81929](https://github.com/kubernetes/kubernetes/pull/81929), [@egernst](https://github.com/egernst))
+
+### Cloud Provider
+
+- When a load balancer type service is created in a k8s cluster that is backed by Azure Standard Load Balancer, the corresponding load balancer rule added in the Azure Standard Load Balancer would now have the "EnableTcpReset" property set to true. ([#80624](https://github.com/kubernetes/kubernetes/pull/80624), [@xuto2](https://github.com/xuto2))
+- Switch to VM Update call in attach/detach disk operation, original CreateOrUpdate call may lead to orphaned VMs or blocked resources ([#81208](https://github.com/kubernetes/kubernetes/pull/81208), [@andyzhangx](https://github.com/andyzhangx))
+- Fix azure disk naming matching issue due to case sensitive comparison ([#81720](https://github.com/kubernetes/kubernetes/pull/81720), [@andyzhangx](https://github.com/andyzhangx))
+- Fix retry issues when the nodes are under deleting on Azure ([#80419](https://github.com/kubernetes/kubernetes/pull/80419), [@feiskyer](https://github.com/feiskyer))
+- Fix conflicted cache when the requests are canceled by other Azure operations. ([#81282](https://github.com/kubernetes/kubernetes/pull/81282), [@feiskyer](https://github.com/feiskyer))
+- Fix make azure disk URI as case insensitive ([#79020](https://github.com/kubernetes/kubernetes/pull/79020), [@andyzhangx](https://github.com/andyzhangx))
+- Fix VMSS LoadBalancer backend pools so that the network won't be broken when instances are upgraded to latest model ([#81411](https://github.com/kubernetes/kubernetes/pull/81411), [@nilo19](https://github.com/nilo19))
+- Default resourceGroup should be used when the value of annotation azure-load-balancer-resource-group is an empty string. ([#79514](https://github.com/kubernetes/kubernetes/pull/79514), [@feiskyer](https://github.com/feiskyer))
+- Kubelet could be run with no Azure identity without subscriptionId configured now.
+  A sample cloud provider configure is: '{"vmType": "vmss", "useInstanceMetadata": true}'. ([#81500](https://github.com/kubernetes/kubernetes/pull/81500), [@feiskyer](https://github.com/feiskyer))
+- Fix public IP not found issues for VMSS nodes ([#80703](https://github.com/kubernetes/kubernetes/pull/80703), [@feiskyer](https://github.com/feiskyer))
+- Fix Azure client requests stuck issues on http.StatusTooManyRequests (HTTP Code 429). ([#81279](https://github.com/kubernetes/kubernetes/pull/81279), [@feiskyer](https://github.com/feiskyer))
+- Add a service annotation `service.beta.kubernetes.io/azure-pip-name` to specify the public IP name for Azure load balancer. ([#81213](https://github.com/kubernetes/kubernetes/pull/81213), [@nilo19](https://github.com/nilo19))
+- Optimize EC2 DescribeInstances API calls in aws cloud provider library by querying instance ID instead of EC2 filters when possible ([#78140](https://github.com/kubernetes/kubernetes/pull/78140), [@zhan849](https://github.com/zhan849))
+- Creates an annotation `service.beta.kubernetes.io/aws-load-balancer-eip-allocations` to assign AWS EIP to the newly created Network Load Balancer. Number of allocations and subnets must match. ([#69263](https://github.com/kubernetes/kubernetes/pull/69263), [@brooksgarrett](https://github.com/brooksgarrett))
+- Add an azure cloud configuration `LoadBalancerName` and `LoadBalancerResourceGroup` to allow the corresponding customizations of azure load balancer. ([#81054](https://github.com/kubernetes/kubernetes/pull/81054), [@nilo19](https://github.com/nilo19))
+
+### Cluster Lifecycle
+
+- Fix error handling and potential go null pointer exception in kubeadm upgrade diff ([#80648](https://github.com/kubernetes/kubernetes/pull/80648), [@odinuge](https://github.com/odinuge))
+- kubeadm: fall back to client version in case of certain HTTP errors ([#80024](https://github.com/kubernetes/kubernetes/pull/80024), [@RainbowMango](https://github.com/RainbowMango))
+- kubeadm: fix a potential panic if kubeadm discovers an invalid, existing kubeconfig file ([#79165](https://github.com/kubernetes/kubernetes/pull/79165), [@neolit123](https://github.com/neolit123))
+- kubeadm: treat non-fatal errors as warnings when doing reset ([#80862](https://github.com/kubernetes/kubernetes/pull/80862), [@drpaneas](https://github.com/drpaneas))
+- kubeadm: prevent PSP blocking of upgrade image prepull by using a non-root user ([#77792](https://github.com/kubernetes/kubernetes/pull/77792), [@neolit123](https://github.com/neolit123))
+- kubeadm: fix "certificate-authority" files not being pre-loaded when using file discovery ([#80966](https://github.com/kubernetes/kubernetes/pull/80966), [@neolit123](https://github.com/neolit123))
+- Add instruction to setup "Application Default Credentials" to run GCE Windows e2e tests locally. ([#81337](https://github.com/kubernetes/kubernetes/pull/81337), [@YangLu1031](https://github.com/YangLu1031))
+- Fix error in `kubeadm join --discovery-file` when using discovery files with embedded credentials ([#80675](https://github.com/kubernetes/kubernetes/pull/80675), [@fabriziopandini](https://github.com/fabriziopandini))
+- Fix remove the etcd member from the cluster during a kubeadm reset. ([#79326](https://github.com/kubernetes/kubernetes/pull/79326), [@bradbeam](https://github.com/bradbeam))
+- kubeadm: the permissions of generated CSR files are changed from 0644 to 0600 ([#81217](https://github.com/kubernetes/kubernetes/pull/81217), [@SataQiu](https://github.com/SataQiu))
+- kubeadm: avoid double deletion of the upgrade prepull DaemonSet ([#80798](https://github.com/kubernetes/kubernetes/pull/80798), [@xlgao-zju](https://github.com/xlgao-zju))
+- kubeadm: introduce deterministic ordering for the certificates generation in the phase command `kubeadm init phase certs`. ([#78556](https://github.com/kubernetes/kubernetes/pull/78556), [@neolit123](https://github.com/neolit123))
+- kubeadm: implement retry logic for certain ConfigMap failures when joining nodes ([#78915](https://github.com/kubernetes/kubernetes/pull/78915), [@ereslibre](https://github.com/ereslibre))
+- kubeadm: use etcd's /health endpoint for a HTTP liveness probe on localhost instead of having a custom health check using etcdctl ([#81385](https://github.com/kubernetes/kubernetes/pull/81385), [@neolit123](https://github.com/neolit123))
+- kubeadm reset: unmount directories under `/var/lib/kubelet` for Linux only ([#81494](https://github.com/kubernetes/kubernetes/pull/81494), [@Klaven](https://github.com/Klaven))
+- kubeadm: fix the bug that `--cri-socket` flag does not work for `kubeadm reset` ([#79498](https://github.com/kubernetes/kubernetes/pull/79498), [@SataQiu](https://github.com/SataQiu))
+- kubeadm: produce errors if they occur when resetting cluster status for a control-plane node ([#80573](https://github.com/kubernetes/kubernetes/pull/80573), [@bart0sh](https://github.com/bart0sh))
+- Fix an error when using external etcd but storing etcd certificates in the same folder with the same name used by kubeadm for local etcd certificates; for an older version of kubeadm, the workaround is to avoid file name used by kubeadm for local etcd. ([#80867](https://github.com/kubernetes/kubernetes/pull/80867), [@fabriziopandini](https://github.com/fabriziopandini))
+- `kubeadm join` fails if file-based discovery is too long, with a default timeout of 5 minutes. ([#80804](https://github.com/kubernetes/kubernetes/pull/80804), [@olivierlemasle](https://github.com/olivierlemasle))
+- kubeadm: fixed ignoring errors when pulling control plane images ([#80529](https://github.com/kubernetes/kubernetes/pull/80529), [@bart0sh](https://github.com/bart0sh))
+- Fix a bug in kube-addon-manager's leader election logic that made all replicas active. ([#80575](https://github.com/kubernetes/kubernetes/pull/80575), [@mborsz](https://github.com/mborsz))
+- kubeadm: prevent overriding of certain kubelet security configuration parameters if the user wished to modify them ([#81903](https://github.com/kubernetes/kubernetes/pull/81903), [@jfbai](https://github.com/jfbai))
+- kubeadm no longer performs IPVS checks as part of its preflight checks ([#81791](https://github.com/kubernetes/kubernetes/pull/81791), [@yastij](https://github.com/yastij))
+- kubeadm: fix for HTTPProxy check for IPv6 addresses ([#82267](https://github.com/kubernetes/kubernetes/pull/82267), [@kad](https://github.com/kad))
+- kubeadm: Allow users to skip the kube-proxy init addon phase during init and still be able to join a cluster and perform some other minor operations (but not upgrade). ([#82248](https://github.com/kubernetes/kubernetes/pull/82248), [@rosti](https://github.com/rosti))
+- Mounts `/home/kubernetes/bin/nvidia/vulkan/icd.d` on the host to `/etc/vulkan/icd.d` inside containers requesting GPU. ([#78868](https://github.com/kubernetes/kubernetes/pull/78868), [@chardch](https://github.com/chardch))
+- kubeadm: use the `--pod-network-cidr` flag to init or use the podSubnet field in the kubeadm config to pass a comma separated list of pod CIDRs. ([#79033](https://github.com/kubernetes/kubernetes/pull/79033), [@Arvinderpal](https://github.com/Arvinderpal))
+- kubeadm: provide `--control-plane-endpoint` flag for `controlPlaneEndpoint` ([#79270](https://github.com/kubernetes/kubernetes/pull/79270), [@SataQiu](https://github.com/SataQiu))
+- kubeadm: enable secure serving for the kube-scheduler ([#80951](https://github.com/kubernetes/kubernetes/pull/80951), [@neolit123](https://github.com/neolit123))
+- kubeadm: print the stack trace of an error for klog level `--v>=5` ([#80937](https://github.com/kubernetes/kubernetes/pull/80937), [@neolit123](https://github.com/neolit123))
+- Add `--kubernetes-version` to `kubeadm init phase certs ca` and `kubeadm init phase kubeconfig` ([#80115](https://github.com/kubernetes/kubernetes/pull/80115), [@gyuho](https://github.com/gyuho))
+- kubeadm: support fetching configuration from the original cluster for `upgrade diff` ([#80025](https://github.com/kubernetes/kubernetes/pull/80025), [@SataQiu](https://github.com/SataQiu))
+- When using the conformance test image, a new environment variable `E2E_USE_GO_RUNNER` will cause the tests to be run with the new golang-based test runner rather than the current bash wrapper. ([#79284](https://github.com/kubernetes/kubernetes/pull/79284), [@johnSchnake](https://github.com/johnSchnake))
+- Implement a new feature that allows applying kustomize patches to static pod manifests generated by kubeadm. ([#80905](https://github.com/kubernetes/kubernetes/pull/80905), [@fabriziopandini](https://github.com/fabriziopandini))
+- The 404 request handler for the GCE Ingress load balancer now exports prometheus metrics, including:
+
+  - `http_404_request_total` (the number of 404 requests handled)
+  - `http_404_request_duration_ms` (the amount of time the server took to respond in ms)
+
+  Also includes percentile groupings. The directory for the default 404 handler includes instructions on how to enable prometheus for monitoring and setting alerts.
+  ([#79106](https://github.com/kubernetes/kubernetes/pull/79106), [@vbannai](https://github.com/vbannai))
+
+### Instrumentation
+
+- Kibana has been slightly revamped/improved in the latest version ([#80421](https://github.com/kubernetes/kubernetes/pull/80421), [@lostick](https://github.com/lostick))
+
+### Network
+
+- Fix a string comparison bug in IPVS graceful termination where UDP real servers are not deleted. ([#78999](https://github.com/kubernetes/kubernetes/pull/78999), [@andrewsykim](https://github.com/andrewsykim))
+- `kube-proxy --cleanup will` return the correct exit code if the cleanup was successful ([#78775](https://github.com/kubernetes/kubernetes/pull/78775), [@johscheuer](https://github.com/johscheuer))
+- Fix a bug in the IPVS proxier where virtual servers are not cleaned up even though the corresponding Service object was deleted. ([#80942](https://github.com/kubernetes/kubernetes/pull/80942), [@gongguan](https://github.com/gongguan))
+- kube-proxy waits for some duration for the node to be defined. ([#77167](https://github.com/kubernetes/kubernetes/pull/77167), [@paulsubrata55](https://github.com/paulsubrata55))
+- Increase log level for graceful termination to `v=5` ([#80100](https://github.com/kubernetes/kubernetes/pull/80100), [@andrewsykim](https://github.com/andrewsykim))
+- Reduce kube-proxy CPU usage in IPVS mode when a large number of nodePort services exist. ([#79444](https://github.com/kubernetes/kubernetes/pull/79444), [@cezarsa](https://github.com/cezarsa))
+- Fix in kube-proxy for SCTP nodeport service which only works for node's InternalIP, but doesn't work for other IPs present in the node when ipvs is enabled. ([#81477](https://github.com/kubernetes/kubernetes/pull/81477), [@paulsubrata55](https://github.com/paulsubrata55))
+- Ensure the `KUBE-MARK-DROP` chain in kube-proxy IPVS mode. The chain is ensured for both IPv4 and IPv6 in dual-stack operation. ([#82214](https://github.com/kubernetes/kubernetes/pull/82214), [@uablrek](https://github.com/uablrek))
+- Introduce `node.kubernetes.io/exclude-balancer` and `node.kubernetes.io/exclude-disruption` labels in alpha to prevent cluster deployers from being dependent on the optional `node-role` labels which not all clusters may provide. ([#80238](https://github.com/kubernetes/kubernetes/pull/80238), [@smarterclayton](https://github.com/smarterclayton))
+- If targetPort is changed that will process by service controller ([#77712](https://github.com/kubernetes/kubernetes/pull/77712), [@Sn0rt](https://github.com/Sn0rt))
+
+### Node
+
+- Remove PIDs cgroup controller requirement when related feature gates are disabled
+  ([#79073](https://github.com/kubernetes/kubernetes/pull/79073), [@rafatio](https://github.com/rafatio))
+- Fix kubelet NodeLease potential performance issues. Kubelet now will try to update lease using cached one instead of get from API Server every time. ([#81174](https://github.com/kubernetes/kubernetes/pull/81174), [@answer1991](https://github.com/answer1991))
+- Passing an invalid policy name in the `--cpu-manager-policy` flag will now cause the kubelet to fail instead of simply ignoring the flag and running the `cpumanager`’s default policy instead. ([#80294](https://github.com/kubernetes/kubernetes/pull/80294), [@klueska](https://github.com/klueska))
+- Make node lease renew interval more heuristic based on node-status-update-frequency in kubelet ([#80173](https://github.com/kubernetes/kubernetes/pull/80173), [@gaorong](https://github.com/gaorong))
+- Kubelet should now more reliably report the same primary node IP even if the set of node IPs reported by the CloudProvider changes. ([#79391](https://github.com/kubernetes/kubernetes/pull/79391), [@danwinship](https://github.com/danwinship))
+- Omit `nil` or empty field when calculating container hash value to avoid hash changed. For a new field with a non-nil default value in the container spec, the hash would still get changed. ([#57741](https://github.com/kubernetes/kubernetes/pull/57741), [@dixudx](https://github.com/dixudx))
+- Fix a bug where kubelet would not retry pod sandbox creation when the restart policy of the pod is Never ([#79451](https://github.com/kubernetes/kubernetes/pull/79451), [@yujuhong](https://github.com/yujuhong))
+- Limit the body length of exec readiness/liveness probes. remote CRIs and Docker shim read a max of 16MB output of which the exec probe itself inspects 10kb. ([#82514](https://github.com/kubernetes/kubernetes/pull/82514), [@dims](https://github.com/dims))
+- Single static pod files and pod files from http endpoints cannot be larger than 10 MB. HTTP probe payloads are now truncated to 10KB. ([#82669](https://github.com/kubernetes/kubernetes/pull/82669), [@rphillips](https://github.com/rphillips))
+- Introduce support for applying pod overhead to pod cgroups, if the PodOverhead feature is enabled. ([#79247](https://github.com/kubernetes/kubernetes/pull/79247), [@egernst](https://github.com/egernst))
+- Node-Problem-Detector v0.7.1 is used on GCI ([#80726](https://github.com/kubernetes/kubernetes/pull/80726), [@wangzhen127](https://github.com/wangzhen127))
+- Node-Problem-Detector v0.7.1 is used for addon daemonset. ([#82140](https://github.com/kubernetes/kubernetes/pull/82140), [@wangzhen127](https://github.com/wangzhen127))
+- Enable cAdvisor ProcessMetrics collecting. ([#79002](https://github.com/kubernetes/kubernetes/pull/79002), [@jiayingz](https://github.com/jiayingz))
+- kubelet: change `node-lease-renew-interval` to 0.25 of lease-renew-duration ([#80429](https://github.com/kubernetes/kubernetes/pull/80429), [@gaorong](https://github.com/gaorong))
+- Attempt to set the kubelet's hostname & internal IP if `--cloud-provider=external` and no node addresses exists ([#75229](https://github.com/kubernetes/kubernetes/pull/75229), [@andrewsykim](https://github.com/andrewsykim))
+
+### Scheduling
+
+- Scheduler should terminate when it loses leader lock. ([#81306](https://github.com/kubernetes/kubernetes/pull/81306), [@ravisantoshgudimetla](https://github.com/ravisantoshgudimetla))
+- If scheduler extender filtered a not found node, current scheduling round for this pod will just be skipped.
+  ([#79641](https://github.com/kubernetes/kubernetes/pull/79641), [@yqwang-ms](https://github.com/yqwang-ms))
+- Extender bind should respect IsInterested ([#79804](https://github.com/kubernetes/kubernetes/pull/79804), [@yqwang-ms](https://github.com/yqwang-ms))
+- Fix an issue with toleration merging & whitelist checking in the PodTolerationRestriction admission controller. ([#81732](https://github.com/kubernetes/kubernetes/pull/81732), [@tallclair](https://github.com/tallclair))
+- Add a helper function to decode scheduler plugin args. ([#80696](https://github.com/kubernetes/kubernetes/pull/80696), [@hex108](https://github.com/hex108))
+- Fix filter plugins are not been called during preemption ([#81876](https://github.com/kubernetes/kubernetes/pull/81876), [@wgliang](https://github.com/wgliang))
+- Fix an issue that the correct PluginConfig.Args is not passed to the corresponding PluginFactory in kube-scheduler when multiple PluginConfig items are defined. ([#82483](https://github.com/kubernetes/kubernetes/pull/82483), [@everpeace](https://github.com/everpeace))
+- Take the context as the first argument of Schedule. ([#82119](https://github.com/kubernetes/kubernetes/pull/82119), [@wgliang](https://github.com/wgliang))
+- Implement `post-filter` extension point for scheduling framework ([#78097](https://github.com/kubernetes/kubernetes/pull/78097), [@draveness](https://github.com/draveness))
+- Add Bind extension point of the scheduling framework ([#78513](https://github.com/kubernetes/kubernetes/pull/78513), [@chenchun](https://github.com/chenchun))
+- Add Filter extension point to the scheduling framework. ([#78477](https://github.com/kubernetes/kubernetes/pull/78477), [@YoubingLi](https://github.com/YoubingLi))
+- Return error when the scoring plugin returns score out of range `[0, 100]`. ([#81015](https://github.com/kubernetes/kubernetes/pull/81015), [@draveness](https://github.com/draveness))
+- Use a named array instead of a score array in normalizing-score phase. ([#80901](https://github.com/kubernetes/kubernetes/pull/80901), [@draveness](https://github.com/draveness))
+- Updates the `requestedToCapacityRatioArguments` to add resources parameter that allows the users to specify the resource name along with weights for each resource to score nodes based on the request to capacity ratio. ([#77688](https://github.com/kubernetes/kubernetes/pull/77688), [@sudeshsh](https://github.com/sudeshsh))
+- Add `UnschedulableAndUnresolvable` status code for scheduling framework ([#82034](https://github.com/kubernetes/kubernetes/pull/82034), [@alculquicondor](https://github.com/alculquicondor))
+- Add normalize plugin extension point for the scheduling framework.
+  ([#80383](https://github.com/kubernetes/kubernetes/pull/80383), [@liu-cong](https://github.com/liu-cong))
+- Add Bind extension point to the scheduling framework. ([#79313](https://github.com/kubernetes/kubernetes/pull/79313), [@chenchun](https://github.com/chenchun))
+- Add Score extension point to the scheduling framework. ([#79109](https://github.com/kubernetes/kubernetes/pull/79109), [@ahg-g](https://github.com/ahg-g))
+- Add Pre-filter extension point to the scheduling framework. ([#78005](https://github.com/kubernetes/kubernetes/pull/78005), [@ahg-g](https://github.com/ahg-g))
+- Add support for writing out of tree custom scheduler plugins. ([#78162](https://github.com/kubernetes/kubernetes/pull/78162), [@hex108](https://github.com/hex108))
+
+### Storage
+
+- Fix possible file descriptor leak and closing of dirs in `doSafeMakeDir` ([#79534](https://github.com/kubernetes/kubernetes/pull/79534), [@odinuge](https://github.com/odinuge))
+- Azure disks of shared kind will no longer fail if they do not contain `skuname` or `storageaccounttype`. ([#80837](https://github.com/kubernetes/kubernetes/pull/80837), [@rmweir](https://github.com/rmweir))
+- Fix CSI plugin supporting raw block that does not need attach mounted failed ([#79920](https://github.com/kubernetes/kubernetes/pull/79920), [@cwdsuzhou](https://github.com/cwdsuzhou))
+- Reduces GCE PD Node Attach Limits by 1 since the node boot disk is considered an attachable disk ([#80923](https://github.com/kubernetes/kubernetes/pull/80923), [@davidz627](https://github.com/davidz627))
+- Remove iSCSI volume storage cleartext secrets in logs ([#81215](https://github.com/kubernetes/kubernetes/pull/81215), [@zouyee](https://github.com/zouyee))
+- Fixes validation of VolumeAttachment API objects created with inline volume sources. ([#80945](https://github.com/kubernetes/kubernetes/pull/80945), [@tedyu](https://github.com/tedyu))
+- Changes timeout value in csi plugin from 15s to 2min which fixes the timeout issue ([#79529](https://github.com/kubernetes/kubernetes/pull/79529), [@andyzhangx](https://github.com/andyzhangx))
+- Fix kubelet fail to delete orphaned pod directory when the kubelet's pods directory (default is `/var/lib/kubelet/pods`) symbolically links to another disk device's directory ([#79094](https://github.com/kubernetes/kubernetes/pull/79094), [@gaorong](https://github.com/gaorong))
+
+## Testing
+
+- Fix pod list return value of `framework.WaitForPodsWithLabelRunningReady` ([#78687](https://github.com/kubernetes/kubernetes/pull/78687), [@pohly](https://github.com/pohly))
+- Adding `TerminationGracePeriodSeconds` to the test framework API ([#82170](https://github.com/kubernetes/kubernetes/pull/82170), [@vivekbagade](https://github.com/vivekbagade))
+- `/test/e2e/framework`: Adds a flag `non-blocking-taints` which allows tests to run in environments with tainted nodes. String value should be a comma-separated list. ([#81043](https://github.com/kubernetes/kubernetes/pull/81043), [@johnSchnake](https://github.com/johnSchnake))
+- Move CSI volume expansion to beta. ([#81467](https://github.com/kubernetes/kubernetes/pull/81467), [@bertinatto](https://github.com/bertinatto))
+- Added E2E tests validating WindowsOptions.RunAsUserName. ([#79539](https://github.com/kubernetes/kubernetes/pull/79539), [@bclau](https://github.com/bclau))
+- `framework.ExpectNoError` no longer logs the error and instead relies on using the new `log.Fail` as gomega fail handler. ([#80253](https://github.com/kubernetes/kubernetes/pull/80253), [@pohly](https://github.com/pohly))
+
+### Windows
+
+- On Windows systems, `%USERPROFILE%` is now preferred over `%HOMEDRIVE%\%HOMEPATH%` as the home folder if `%HOMEDRIVE%\%HOMEPATH%` does not contain a `.kube\config` file, and `%USERPROFILE%` exists and is writable. ([#73923](https://github.com/kubernetes/kubernetes/pull/73923), [@liggitt](https://github.com/liggitt))
+- Add support for AWS EBS on windows ([#79552](https://github.com/kubernetes/kubernetes/pull/79552), [@wongma7](https://github.com/wongma7))
+- Support Kubelet plugin watcher on Windows nodes. ([#81397](https://github.com/kubernetes/kubernetes/pull/81397), [@ddebroy](https://github.com/ddebroy))
+
+## Dependencies
+
+### Changed
+
+- the default Go version was updated to v1.12.9. ([#78958](https://github.com/kubernetes/kubernetes/pull/78958), [#79966](https://github.com/kubernetes/kubernetes/pull/79966), [#81390](https://github.com/kubernetes/kubernetes/pull/81390), [#81489](https://github.com/kubernetes/kubernetes/pull/81489))
+- etcd has been updated to v3.3.15 ([#82199](https://github.com/kubernetes/kubernetes/pull/82199), [@dims](https://github.com/dims))
+- CoreDNS for kubeadm and kube-up has been updated to v1.6.2 ([#82127](https://github.com/kubernetes/kubernetes/pull/82127))
+- Cluster Autoscaler has been updated to v1.16.0 ([#82501](https://github.com/kubernetes/kubernetes/pull/82501), [@losipiuk](https://github.com/losipiuk))
+- fluentd has been updated to v1.5.1 ([#79014](https://github.com/kubernetes/kubernetes/pull/79014))
+- fluentd-elasticsearch plugin has been updated to v3.5.3 ([#79014](https://github.com/kubernetes/kubernetes/pull/79014))
+- elasticsearch has been updated to v7.1.1 ([#79014](https://github.com/kubernetes/kubernetes/pull/79014))
+- kibana has been updated to v7.1.1 ([#79014](https://github.com/kubernetes/kubernetes/pull/79014))
+- Azure SDK and go-autorest API versions have been updated ([#79574](https://github.com/kubernetes/kubernetes/pull/79574))
+- Azure API versions have been updated (container registry to 2018-09-01, network to 2018-08-01) ([#79583](https://github.com/kubernetes/kubernetes/pull/79583))
+- kube-addon-manager has been updated to v9.0.2 ([#80861](https://github.com/kubernetes/kubernetes/pull/80861))
+- golang/x/net has been updated to bring in fixes for CVE-2019-9512, CVE-2019-9514 ([#81394](https://github.com/kubernetes/kubernetes/pull/81394))
+- GCE windows node image has been updated. ([#81106](https://github.com/kubernetes/kubernetes/pull/81106))
+- portworx plugin has been updated on libopenstorage/openstorage to v1.0.0 ([#80495](https://github.com/kubernetes/kubernetes/pull/80495))
+- metrics-server has been updated to v0.3.4 ([#82322](https://github.com/kubernetes/kubernetes/pull/82322), [@olagacek](https://github.com/olagacek))
+- klog has been updated to v0.4.0 ([#81164](https://github.com/kubernetes/kubernetes/pull/81164))
+
+### Unchanged
+
+- The list of validated docker versions remains unchanged.
+  - The current list is 1.13.1, 17.03, 17.06, 17.09, 18.06, 18.09. ([#72823](https://github.com/kubernetes/kubernetes/pull/72823), [#72831](https://github.com/kubernetes/kubernetes/pull/72831))
+- CNI remains unchanged at v0.7.5. ([#75455](https://github.com/kubernetes/kubernetes/pull/75455))
+- cri-tools remains unchanged at v1.14.0. ([#75658](https://github.com/kubernetes/kubernetes/pull/75658))
+- CAdvisor remains unchanged at v0.33.2. ([#76291](https://github.com/kubernetes/kubernetes/pull/76291))
+- event-exporter remains unchanged at v0.2.5. ([#77815](https://github.com/kubernetes/kubernetes/pull/77815))
+- ip-masq-agent remains unchanged at v2.4.1. ([#77844](https://github.com/kubernetes/kubernetes/pull/77844))
+- k8s-dns-node-cache remains unchanged at v1.15.1 ([#76640](https://github.com/kubernetes/kubernetes/pull/76640), [@george-angel](https://github.com/george-angel))
+- CSI remains unchanged at to v1.1.0. ([#75391](https://github.com/kubernetes/kubernetes/pull/75391))
+- The dashboard add-on remains unchanged at v1.10.1. ([#72495](https://github.com/kubernetes/kubernetes/pull/72495))
+- kube-dns is unchanged at v1.14.13 as of Kubernetes 1.12. ([#68900](https://github.com/kubernetes/kubernetes/pull/68900))
+- Influxdb is unchanged at v1.3.3 as of Kubernetes 1.10. ([#53319](https://github.com/kubernetes/kubernetes/pull/53319))
+- Grafana is unchanged at v4.4.3 as of Kubernetes 1.10. ([#53319](https://github.com/kubernetes/kubernetes/pull/53319))
+- The fluent-plugin-kubernetes_metadata_filter plugin in fluentd-elasticsearch is unchanged at v2.1.6. ([#71180](https://github.com/kubernetes/kubernetes/pull/71180))
+- fluentd-gcp is unchanged at v3.2.0 as of Kubernetes 1.13. ([#70954](https://github.com/kubernetes/kubernetes/pull/70954))
+- OIDC authentication is unchanged at coreos/go-oidc v2 as of Kubernetes 1.10. ([#58544](https://github.com/kubernetes/kubernetes/pull/58544))
+- Calico is unchanged at v3.3.1 as of Kubernetes 1.13. ([#70932](https://github.com/kubernetes/kubernetes/pull/70932))
+- GLBC remains unchanged at v1.2.3 as of Kubernetes 1.12. ([#66793](https://github.com/kubernetes/kubernetes/pull/66793))
+- Ingress-gce remains unchanged at v1.2.3 as of Kubernetes 1.12. ([#66793](https://github.com/kubernetes/kubernetes/pull/66793))
+
+### Removed
+
+- Remove deprecated github.com/kardianos/osext dependency ([#80142](https://github.com/kubernetes/kubernetes/pull/80142))
+
+### Detailed go Dependency Changes
+
+#### Added
+
+- github.com/Azure/go-autorest/autorest/adal: [v0.5.0](https://github.com/Azure/go-autorest/autorest/adal/tree/v0.5.0)
+- github.com/Azure/go-autorest/autorest/date: [v0.1.0](https://github.com/Azure/go-autorest/autorest/date/tree/v0.1.0)
+- github.com/Azure/go-autorest/autorest/mocks: [v0.2.0](https://github.com/Azure/go-autorest/autorest/mocks/tree/v0.2.0)
+- github.com/Azure/go-autorest/autorest/to: [v0.2.0](https://github.com/Azure/go-autorest/autorest/to/tree/v0.2.0)
+- github.com/Azure/go-autorest/autorest/validation: [v0.1.0](https://github.com/Azure/go-autorest/autorest/validation/tree/v0.1.0)
+- github.com/Azure/go-autorest/autorest: [v0.9.0](https://github.com/Azure/go-autorest/autorest/tree/v0.9.0)
+- github.com/Azure/go-autorest/logger: [v0.1.0](https://github.com/Azure/go-autorest/logger/tree/v0.1.0)
+- github.com/Azure/go-autorest/tracing: [v0.5.0](https://github.com/Azure/go-autorest/tracing/tree/v0.5.0)
+- github.com/armon/consul-api: [eb2c6b5](https://github.com/armon/consul-api/tree/eb2c6b5)
+- github.com/bifurcation/mint: [93c51c6](https://github.com/bifurcation/mint/tree/93c51c6)
+- github.com/caddyserver/caddy: [v1.0.3](https://github.com/caddyserver/caddy/tree/v1.0.3)
+- github.com/cenkalti/backoff: [v2.1.1+incompatible](https://github.com/cenkalti/backoff/tree/v2.1.1)
+- github.com/checkpoint-restore/go-criu: [bdb7599](https://github.com/checkpoint-restore/go-criu/tree/bdb7599)
+- github.com/cheekybits/genny: [9127e81](https://github.com/cheekybits/genny/tree/9127e81)
+- github.com/coredns/corefile-migration: [v1.0.2](https://github.com/coredns/corefile-migration/tree/v1.0.2)
+- github.com/coreos/go-etcd: [v2.0.0+incompatible](https://github.com/coreos/go-etcd/tree/v2.0.0)
+- github.com/dustin/go-humanize: [v1.0.0](https://github.com/dustin/go-humanize/tree/v1.0.0)
+- github.com/fatih/color: [v1.6.0](https://github.com/fatih/color/tree/v1.6.0)
+- github.com/flynn/go-shlex: [3f9db97](https://github.com/flynn/go-shlex/tree/3f9db97)
+- github.com/go-acme/lego: [v2.5.0+incompatible](https://github.com/go-acme/lego/tree/v2.5.0)
+- github.com/go-bindata/go-bindata: [v3.1.1+incompatible](https://github.com/go-bindata/go-bindata/tree/v3.1.1)
+- github.com/go-logr/logr: [v0.1.0](https://github.com/go-logr/logr/tree/v0.1.0)
+- github.com/google/martian: [v2.1.0+incompatible](https://github.com/google/martian/tree/v2.1.0)
+- github.com/google/pprof: [3ea8567](https://github.com/google/pprof/tree/3ea8567)
+- github.com/google/renameio: [v0.1.0](https://github.com/google/renameio/tree/v0.1.0)
+- github.com/googleapis/gax-go/v2: [v2.0.4](https://github.com/googleapis/gax-go/v2/tree/v2.0.4)
+- github.com/hashicorp/go-syslog: [v1.0.0](https://github.com/hashicorp/go-syslog/tree/v1.0.0)
+- github.com/jimstudt/http-authentication: [3eca13d](https://github.com/jimstudt/http-authentication/tree/3eca13d)
+- github.com/kisielk/errcheck: [v1.2.0](https://github.com/kisielk/errcheck/tree/v1.2.0)
+- github.com/kisielk/gotool: [v1.0.0](https://github.com/kisielk/gotool/tree/v1.0.0)
+- github.com/klauspost/cpuid: [v1.2.0](https://github.com/klauspost/cpuid/tree/v1.2.0)
+- github.com/kr/pty: [v1.1.5](https://github.com/kr/pty/tree/v1.1.5)
+- github.com/kylelemons/godebug: [d65d576](https://github.com/kylelemons/godebug/tree/d65d576)
+- github.com/lucas-clemente/aes12: [cd47fb3](https://github.com/lucas-clemente/aes12/tree/cd47fb3)
+- github.com/lucas-clemente/quic-clients: [v0.1.0](https://github.com/lucas-clemente/quic-clients/tree/v0.1.0)
+- github.com/lucas-clemente/quic-go-certificates: [d2f8652](https://github.com/lucas-clemente/quic-go-certificates/tree/d2f8652)
+- github.com/lucas-clemente/quic-go: [v0.10.2](https://github.com/lucas-clemente/quic-go/tree/v0.10.2)
+- github.com/marten-seemann/qtls: [v0.2.3](https://github.com/marten-seemann/qtls/tree/v0.2.3)
+- github.com/mattn/go-colorable: [v0.0.9](https://github.com/mattn/go-colorable/tree/v0.0.9)
+- github.com/mattn/go-isatty: [v0.0.3](https://github.com/mattn/go-isatty/tree/v0.0.3)
+- github.com/mholt/certmagic: [6a42ef9](https://github.com/mholt/certmagic/tree/6a42ef9)
+- github.com/mitchellh/go-homedir: [v1.1.0](https://github.com/mitchellh/go-homedir/tree/v1.1.0)
+- github.com/naoina/go-stringutil: [v0.1.0](https://github.com/naoina/go-stringutil/tree/v0.1.0)
+- github.com/naoina/toml: [v0.1.1](https://github.com/naoina/toml/tree/v0.1.1)
+- github.com/rogpeppe/go-internal: [v1.3.0](https://github.com/rogpeppe/go-internal/tree/v1.3.0)
+- github.com/thecodeteam/goscaleio: [v0.1.0](https://github.com/thecodeteam/goscaleio/tree/v0.1.0)
+- github.com/ugorji/go/codec: [d75b2dc](https://github.com/ugorji/go/codec/tree/d75b2dc)
+- github.com/xordataexchange/crypt: [b2862e3](https://github.com/xordataexchange/crypt/tree/b2862e3)
+- go.opencensus.io: v0.21.0
+- golang.org/x/mod: 4bf6d31
+- gopkg.in/airbrake/gobrake.v2: v2.0.9
+- gopkg.in/errgo.v2: v2.1.0
+- gopkg.in/gemnasium/logrus-airbrake-hook.v2: v2.1.2
+- gopkg.in/mcuadros/go-syslog.v2: v2.2.1
+- gotest.tools/gotestsum: v0.3.5
+- honnef.co/go/tools: v0.0.1-2019.2.2
+
+#### Changed
+
+- cloud.google.com/go: v0.34.0 → v0.38.0
+- github.com/Azure/azure-sdk-for-go: [v21.4.0+incompatible → v32.5.0+incompatible](https://github.com/Azure/azure-sdk-for-go/compare/v21.4.0...v32.5.0)
+- github.com/BurntSushi/toml: [v0.3.0 → v0.3.1](https://github.com/BurntSushi/toml/compare/v0.3.0...v0.3.1)
+- github.com/GoogleCloudPlatform/k8s-cloud-provider: [f8e9959 → 27a4ced](https://github.com/GoogleCloudPlatform/k8s-cloud-provider/compare/f8e9959...27a4ced)
+- github.com/PuerkitoBio/purell: [v1.1.0 → v1.1.1](https://github.com/PuerkitoBio/purell/compare/v1.1.0...v1.1.1)
+- github.com/asaskevich/govalidator: [f9ffefc → f61b66f](https://github.com/asaskevich/govalidator/compare/f9ffefc...f61b66f)
+- github.com/client9/misspell: [9ce5d97 → v0.3.4](https://github.com/client9/misspell/compare/9ce5d97...v0.3.4)
+- github.com/containernetworking/cni: [v0.6.0 → v0.7.1](https://github.com/containernetworking/cni/compare/v0.6.0...v0.7.1)
+- github.com/coreos/etcd: [v3.3.13+incompatible → v3.3.15+incompatible](https://github.com/coreos/etcd/compare/v3.3.13...v3.3.15)
+- github.com/coreos/go-oidc: [065b426 → v2.1.0+incompatible](https://github.com/coreos/go-oidc/compare/065b426...v2.1.0)
+- github.com/coreos/go-semver: [e214231 → v0.3.0](https://github.com/coreos/go-semver/compare/e214231...v0.3.0)
+- github.com/cpuguy83/go-md2man: [v1.0.4 → v1.0.10](https://github.com/cpuguy83/go-md2man/compare/v1.0.4...v1.0.10)
+- github.com/cyphar/filepath-securejoin: [ae69057 → v0.2.2](https://github.com/cyphar/filepath-securejoin/compare/ae69057...v0.2.2)
+- github.com/dgrijalva/jwt-go: [01aeca5 → v3.2.0+incompatible](https://github.com/dgrijalva/jwt-go/compare/01aeca5...v3.2.0)
+- github.com/docker/distribution: [edc3ab2 → v2.7.1+incompatible](https://github.com/docker/distribution/compare/edc3ab2...v2.7.1)
+- github.com/emicklei/go-restful: [ff4f55a → v2.9.5+incompatible](https://github.com/emicklei/go-restful/compare/ff4f55a...v2.9.5)
+- github.com/evanphx/json-patch: [5858425 → v4.2.0+incompatible](https://github.com/evanphx/json-patch/compare/5858425...v4.2.0)
+- github.com/fatih/camelcase: [f6a740d → v1.0.0](https://github.com/fatih/camelcase/compare/f6a740d...v1.0.0)
+- github.com/go-openapi/analysis: [v0.17.2 → v0.19.2](https://github.com/go-openapi/analysis/compare/v0.17.2...v0.19.2)
+- github.com/go-openapi/errors: [v0.17.2 → v0.19.2](https://github.com/go-openapi/errors/compare/v0.17.2...v0.19.2)
+- github.com/go-openapi/jsonpointer: [v0.19.0 → v0.19.2](https://github.com/go-openapi/jsonpointer/compare/v0.19.0...v0.19.2)
+- github.com/go-openapi/jsonreference: [v0.19.0 → v0.19.2](https://github.com/go-openapi/jsonreference/compare/v0.19.0...v0.19.2)
+- github.com/go-openapi/loads: [v0.17.2 → v0.19.2](https://github.com/go-openapi/loads/compare/v0.17.2...v0.19.2)
+- github.com/go-openapi/runtime: [v0.17.2 → v0.19.0](https://github.com/go-openapi/runtime/compare/v0.17.2...v0.19.0)
+- github.com/go-openapi/spec: [v0.17.2 → v0.19.2](https://github.com/go-openapi/spec/compare/v0.17.2...v0.19.2)
+- github.com/go-openapi/strfmt: [v0.17.0 → v0.19.0](https://github.com/go-openapi/strfmt/compare/v0.17.0...v0.19.0)
+- github.com/go-openapi/swag: [v0.17.2 → v0.19.2](https://github.com/go-openapi/swag/compare/v0.17.2...v0.19.2)
+- github.com/go-openapi/validate: [v0.18.0 → v0.19.2](https://github.com/go-openapi/validate/compare/v0.18.0...v0.19.2)
+- github.com/godbus/dbus: [c7fdd8b → v4.1.0+incompatible](https://github.com/godbus/dbus/compare/c7fdd8b...v4.1.0)
+- github.com/gogo/protobuf: [342cbe0 → 65acae2](https://github.com/gogo/protobuf/compare/342cbe0...65acae2)
+- github.com/golang/mock: [bd3c8e8 → v1.2.0](https://github.com/golang/mock/compare/bd3c8e8...v1.2.0)
+- github.com/golang/protobuf: [v1.2.0 → v1.3.1](https://github.com/golang/protobuf/compare/v1.2.0...v1.3.1)
+- github.com/google/btree: [7d79101 → 4030bb1](https://github.com/google/btree/compare/7d79101...4030bb1)
+- github.com/google/cadvisor: [9db8c7d → v0.34.0](https://github.com/google/cadvisor/compare/9db8c7d...v0.34.0)
+- github.com/google/gofuzz: [24818f7 → v1.0.0](https://github.com/google/gofuzz/compare/24818f7...v1.0.0)
+- github.com/google/uuid: [v1.0.0 → v1.1.1](https://github.com/google/uuid/compare/v1.0.0...v1.1.1)
+- github.com/gophercloud/gophercloud: [c818fa6 → v0.1.0](https://github.com/gophercloud/gophercloud/compare/c818fa6...v0.1.0)
+- github.com/gorilla/websocket: [4201258 → v1.4.0](https://github.com/gorilla/websocket/compare/4201258...v1.4.0)
+- github.com/grpc-ecosystem/go-grpc-prometheus: [2500245 → v1.2.0](https://github.com/grpc-ecosystem/go-grpc-prometheus/compare/2500245...v1.2.0)
+- github.com/hashicorp/golang-lru: [v0.5.0 → v0.5.1](https://github.com/hashicorp/golang-lru/compare/v0.5.0...v0.5.1)
+- github.com/hashicorp/hcl: [d8c773c → v1.0.0](https://github.com/hashicorp/hcl/compare/d8c773c...v1.0.0)
+- github.com/heketi/heketi: [558b292 → v9.0.0+incompatible](https://github.com/heketi/heketi/compare/558b292...v9.0.0)
+- github.com/jonboulle/clockwork: [72f9bd7 → v0.1.0](https://github.com/jonboulle/clockwork/compare/72f9bd7...v0.1.0)
+- github.com/json-iterator/go: [ab8a2e0 → v1.1.7](https://github.com/json-iterator/go/compare/ab8a2e0...v1.1.7)
+- github.com/kr/pretty: [f31442d → v0.1.0](https://github.com/kr/pretty/compare/f31442d...v0.1.0)
+- github.com/kr/text: [6807e77 → v0.1.0](https://github.com/kr/text/compare/6807e77...v0.1.0)
+- github.com/libopenstorage/openstorage: [093a0c3 → v1.0.0](https://github.com/libopenstorage/openstorage/compare/093a0c3...v1.0.0)
+- github.com/magiconair/properties: [61b492c → v1.8.1](https://github.com/magiconair/properties/compare/61b492c...v1.8.1)
+- github.com/mailru/easyjson: [60711f1 → 94de47d](https://github.com/mailru/easyjson/compare/60711f1...94de47d)
+- github.com/mattn/go-shellwords: [f8471b0 → v1.0.5](https://github.com/mattn/go-shellwords/compare/f8471b0...v1.0.5)
+- github.com/miekg/dns: [5d001d0 → v1.1.4](https://github.com/miekg/dns/compare/5d001d0...v1.1.4)
+- github.com/mistifyio/go-zfs: [1b4ae6f → v2.1.1+incompatible](https://github.com/mistifyio/go-zfs/compare/1b4ae6f...v2.1.1)
+- github.com/mitchellh/go-wordwrap: [ad45545 → v1.0.0](https://github.com/mitchellh/go-wordwrap/compare/ad45545...v1.0.0)
+- github.com/mvdan/xurls: [1b768d7 → v1.1.0](https://github.com/mvdan/xurls/compare/1b768d7...v1.1.0)
+- github.com/onsi/ginkgo: [v1.6.0 → v1.8.0](https://github.com/onsi/ginkgo/compare/v1.6.0...v1.8.0)
+- github.com/onsi/gomega: [5533ce8 → v1.5.0](https://github.com/onsi/gomega/compare/5533ce8...v1.5.0)
+- github.com/opencontainers/go-digest: [a6d0ee4 → v1.0.0-rc1](https://github.com/opencontainers/go-digest/compare/a6d0ee4...v1.0.0-rc1)
+- github.com/opencontainers/image-spec: [372ad78 → v1.0.1](https://github.com/opencontainers/image-spec/compare/372ad78...v1.0.1)
+- github.com/opencontainers/runc: [f000fe1 → 6cc5158](https://github.com/opencontainers/runc/compare/f000fe1...6cc5158)
+- github.com/opencontainers/selinux: [4a2974b → v1.2.2](https://github.com/opencontainers/selinux/compare/4a2974b...v1.2.2)
+- github.com/robfig/cron: [df38d32 → v1.1.0](https://github.com/robfig/cron/compare/df38d32...v1.1.0)
+- github.com/russross/blackfriday: [300106c → v1.5.2](https://github.com/russross/blackfriday/compare/300106c...v1.5.2)
+- github.com/seccomp/libseccomp-golang: [1b506fc → v0.9.1](https://github.com/seccomp/libseccomp-golang/compare/1b506fc...v0.9.1)
+- github.com/sirupsen/logrus: [v1.2.0 → v1.4.2](https://github.com/sirupsen/logrus/compare/v1.2.0...v1.4.2)
+- github.com/spf13/afero: [b28a7ef → v1.2.2](https://github.com/spf13/afero/compare/b28a7ef...v1.2.2)
+- github.com/spf13/cast: [e31f36f → v1.3.0](https://github.com/spf13/cast/compare/e31f36f...v1.3.0)
+- github.com/spf13/cobra: [c439c4f → v0.0.5](https://github.com/spf13/cobra/compare/c439c4f...v0.0.5)
+- github.com/spf13/jwalterweatherman: [33c24e7 → v1.1.0](https://github.com/spf13/jwalterweatherman/compare/33c24e7...v1.1.0)
+- github.com/spf13/pflag: [v1.0.1 → v1.0.3](https://github.com/spf13/pflag/compare/v1.0.1...v1.0.3)
+- github.com/spf13/viper: [7fb2782 → v1.3.2](https://github.com/spf13/viper/compare/7fb2782...v1.3.2)
+- github.com/stretchr/objx: [v0.1.1 → v0.2.0](https://github.com/stretchr/objx/compare/v0.1.1...v0.2.0)
+- github.com/stretchr/testify: [v1.2.2 → v1.3.0](https://github.com/stretchr/testify/compare/v1.2.2...v1.3.0)
+- golang.org/x/net: 65e2d4e → cdfb69a
+- golang.org/x/tools: aa82965 → 6e04913
+- google.golang.org/api: 583d854 → 5213b80
+- google.golang.org/genproto: 09f6ed2 → 54afdca
+- google.golang.org/grpc: v1.13.0 → v1.23.0
+- gopkg.in/check.v1: 20d25e2 → 788fd78
+- gopkg.in/natefinch/lumberjack.v2: 20b71e5 → v2.0.0
+- gopkg.in/square/go-jose.v2: 89060de → v2.2.2
+- gopkg.in/yaml.v2: v2.2.1 → v2.2.2
+- k8s.io/gengo: f8a0810 → 26a6646
+- k8s.io/klog: v0.3.1 → v0.4.0
+- k8s.io/kube-openapi: b3a7cee → 743ec37
+- k8s.io/utils: c2654d5 → 581e001
+- sigs.k8s.io/structured-merge-diff: e85c7b2 → 6149e45
+
+#### Removed
+
+- github.com/Azure/go-autorest: [v11.1.2+incompatible](https://github.com/Azure/go-autorest/tree/v11.1.2)
+- github.com/codedellemc/goscaleio: [20e2ce2](https://github.com/codedellemc/goscaleio/tree/20e2ce2)
+- github.com/d2g/dhcp4: [a1d1b6c](https://github.com/d2g/dhcp4/tree/a1d1b6c)
+- github.com/d2g/dhcp4client: [6e570ed](https://github.com/d2g/dhcp4client/tree/6e570ed)
+- github.com/jteeuwen/go-bindata: [a0ff256](https://github.com/jteeuwen/go-bindata/tree/a0ff256)
+- github.com/kardianos/osext: [8fef92e](https://github.com/kardianos/osext/tree/8fef92e)
+- github.com/kr/fs: [2788f0d](https://github.com/kr/fs/tree/2788f0d)
+- github.com/marstr/guid: [8bdf7d1](https://github.com/marstr/guid/tree/8bdf7d1)
+- github.com/mholt/caddy: [2de4950](https://github.com/mholt/caddy/tree/2de4950)
+- github.com/natefinch/lumberjack: [v2.0.0+incompatible](https://github.com/natefinch/lumberjack/tree/v2.0.0)
+- github.com/pkg/sftp: [4d0e916](https://github.com/pkg/sftp/tree/4d0e916)
+- github.com/shurcooL/sanitized_anchor_name: [10ef21a](https://github.com/shurcooL/sanitized_anchor_name/tree/10ef21a)
+- github.com/sigma/go-inotify: [c87b6cf](https://github.com/sigma/go-inotify/tree/c87b6cf)
+- github.com/vmware/photon-controller-go-sdk: [4a435da](https://github.com/vmware/photon-controller-go-sdk/tree/4a435da)
+- github.com/xanzy/go-cloudstack: [1e2cbf6](https://github.com/xanzy/go-cloudstack/tree/1e2cbf6)
+- gopkg.in/yaml.v1: 9f9df34
+- [v1.16.0-rc.2](#v1160-rc2)
+- [v1.16.0-rc.1](#v1160-rc1)
+- [v1.16.0-beta.2](#v1160-beta2)
+- [v1.16.0-beta.1](#v1160-beta1)
+- [v1.16.0-alpha.3](#v1160-alpha3)
+- [v1.16.0-alpha.2](#v1160-alpha2)
+- [v1.16.0-alpha.1](#v1160-alpha1)
+
+
+
+# v1.16.0-rc.2
+
+[Documentation](https://docs.k8s.io)
+
+## Downloads for v1.16.0-rc.2
+
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes.tar.gz](https://dl.k8s.io/v1.16.0-rc.2/kubernetes.tar.gz) | `68837f83bcf380e22b50f145fb64404584e96e5714a6c0cbc1ba76e290dc267f6b53194e2b51f19c1145ae7c3e5874124d35ff430cda15f67b0f9c954803389c`
+[kubernetes-src.tar.gz](https://dl.k8s.io/v1.16.0-rc.2/kubernetes-src.tar.gz) | `922552ed60d425fa6d126ffb34db6a7f123e1b9104e751edaed57b4992826620383446e6cf4f8a9fd55aac72f95a69b45e53274a41aaa838c2c2ae15ff4ddad2`
+
+### Client Binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-client-darwin-386.tar.gz](https://dl.k8s.io/v1.16.0-rc.2/kubernetes-client-darwin-386.tar.gz) | `d0df8f57f4d9c2822badc507345f82f87d0e8e49c79ca907a0e4e4dd634db964b84572f88b8ae7eaf50a20965378d464e0d1e7f588e84e926edfb741b859e7d2`
+[kubernetes-client-darwin-amd64.tar.gz](https://dl.k8s.io/v1.16.0-rc.2/kubernetes-client-darwin-amd64.tar.gz) | `0bc7daaf1165189b57dcdbe59f402731830b6f4db53b853350056822602579d52fe43ce5ac6b7d4b6d89d81036ae94eab6b7167e78011a96792acfbf6892fa39`
+[kubernetes-client-linux-386.tar.gz](https://dl.k8s.io/v1.16.0-rc.2/kubernetes-client-linux-386.tar.gz) | `7735c607bb99b47924140a6a3e794912b2b97b6b54024af1de5db6765b8cc518cba6b145c25dc67c8d8f827805d9a61f676b4ae67b8ef86cfda2fe76de822c6a`
+[kubernetes-client-linux-amd64.tar.gz](https://dl.k8s.io/v1.16.0-rc.2/kubernetes-client-linux-amd64.tar.gz) | `d35f70cea4780a80c24588bc760c38c138d73e5f80f9fe89d952075c24cbf179dd504c2bd7ddb1756c2632ffbcc69a334684710a2d702443043998f66bec4a25`
+[kubernetes-client-linux-arm.tar.gz](https://dl.k8s.io/v1.16.0-rc.2/kubernetes-client-linux-arm.tar.gz) | `e1fc50b6884c42e92649a231db60e35d4e13e58728e4af7f6eca8b0baa719108cdd960db1f1dbd623085610dbccf7f17df733de1faf10ebf6cd1977ecd7f6213`
+[kubernetes-client-linux-arm64.tar.gz](https://dl.k8s.io/v1.16.0-rc.2/kubernetes-client-linux-arm64.tar.gz) | `defc25fe403c20ef322b2149be28a5b44c28c7284f11bcf193a07d7f45110ce2bd6227d3a4aa48859aaeb67796809962785651ca9f76121fb9534366b40c4b7d`
+[kubernetes-client-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.16.0-rc.2/kubernetes-client-linux-ppc64le.tar.gz) | `e87b16c948d09ddbc5d6e3fab05ad3c5a58aa7836d4f42c59edab640465531869c92ecdfa2845ec3eecd95b8ccba3dafdd9337f4c313763c6e5105b8740f2dca`
+[kubernetes-client-linux-s390x.tar.gz](https://dl.k8s.io/v1.16.0-rc.2/kubernetes-client-linux-s390x.tar.gz) | `2c25a1860fa81cea05a1840d6a200a3a794cc50cfe45a4efec57d7122208b1354e86f698437bbe5c915d6fb70ef9525f844edc0fa63387ab8c1586a6b22008a5`
+[kubernetes-client-windows-386.tar.gz](https://dl.k8s.io/v1.16.0-rc.2/kubernetes-client-windows-386.tar.gz) | `267654a7ecfa37c800c1c94ea78343f5466783881cfac62091cfbd8c62489f04bd74a7a39a08253cb51d7ba52c207f56da371f992f61c1468b595c094f0e080f`
+[kubernetes-client-windows-amd64.tar.gz](https://dl.k8s.io/v1.16.0-rc.2/kubernetes-client-windows-amd64.tar.gz) | `bd4c25b80e54f9fc0c07f64550d020878f899e4e3a28ca57dd532fdbab9ab700d296d2890185591ac27bce6fde336ab90f3102a6797e174d233db76f24f5ac1b`
+
+### Server Binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-server-linux-amd64.tar.gz](https://dl.k8s.io/v1.16.0-rc.2/kubernetes-server-linux-amd64.tar.gz) | `13a93bb9bd5599b669af7bd25537ee81cefd6d8c73bedfbac845703c01950c70b2aa39f94f2346d935bc167bae435dbcd6e1758341b634102265657e1b1c1259`
+[kubernetes-server-linux-arm.tar.gz](https://dl.k8s.io/v1.16.0-rc.2/kubernetes-server-linux-arm.tar.gz) | `781d127f32d8479bc21beed855ec73e383702e6e982854138adce8edb0ee4d1d4b0c6e723532bc761689d17512c18b1945d05b0e4adb3fe4b98428cce40d52c8`
+[kubernetes-server-linux-arm64.tar.gz](https://dl.k8s.io/v1.16.0-rc.2/kubernetes-server-linux-arm64.tar.gz) | `6d6dfa49288e4a4ce77ca4f7e83a51c78a2b1844dd95df10cb12fff5a104e750d8e4e117b631448e066487c4c71648e822c87ed83a213f17f27f8c7ecb328ca4`
+[kubernetes-server-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.16.0-rc.2/kubernetes-server-linux-ppc64le.tar.gz) | `97804d87ea984167fdbdedcfb38380bd98bb2ef150c1a631c6822905ce5270931a907226d5ddefc8d98d5326610daa79a08964fc4d7e8b438832beb966efd214`
+[kubernetes-server-linux-s390x.tar.gz](https://dl.k8s.io/v1.16.0-rc.2/kubernetes-server-linux-s390x.tar.gz) | `d45bd651c7f4b6e62ceb661c2ec70afca06a8d1fde1e50bb7783d05401c37823cf21b9f0d3ac87e6b91eeec9d03fc539c3713fd46beff6207e8ebac1bf9d1dd5`
+
+### Node Binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-node-linux-amd64.tar.gz](https://dl.k8s.io/v1.16.0-rc.2/kubernetes-node-linux-amd64.tar.gz) | `42c57b59ce43f8961e427d622ee9cfa85cc23468779945262d59aa8cd31afd495c7abaaef7263b9db60ec939ba5e9898ebc3281e8ec81298237123ce4739cbff`
+[kubernetes-node-linux-arm.tar.gz](https://dl.k8s.io/v1.16.0-rc.2/kubernetes-node-linux-arm.tar.gz) | `034a5611909df462ef6408f5ba5ff5ebfb4e1178b2ad06a59097560040c4fcdb163faec48ab4297ca6c21282d7b146f9a5eebd3f2573f7d6d7189d6d29f2cf34`
+[kubernetes-node-linux-arm64.tar.gz](https://dl.k8s.io/v1.16.0-rc.2/kubernetes-node-linux-arm64.tar.gz) | `df1493fa2d67b59eaf02096889223bbf0d71797652d3cbd89e8a3106ff6012ea17d25daaa4baf9f26c2e061afb4b69e3e6814ba66e9c4744f04230c922fbc251`
+[kubernetes-node-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.16.0-rc.2/kubernetes-node-linux-ppc64le.tar.gz) | `812a5057bbf832c93f741cc39d04fc0087e36b81b6b123ec5ef02465f7ab145c5152cfc1f7c76032240695c7d7ab71ddb9a2a4f5e1f1a2abb63f32afa3fb6c7c`
+[kubernetes-node-linux-s390x.tar.gz](https://dl.k8s.io/v1.16.0-rc.2/kubernetes-node-linux-s390x.tar.gz) | `2a58a4b201631789d4309ddc665829aedcc05ec4fe6ad6e4d965ef3283a381b8a4980b4b728cfe9a38368dac49921f61ac6938f0208b671afd2327f2013db22a`
+[kubernetes-node-windows-amd64.tar.gz](https://dl.k8s.io/v1.16.0-rc.2/kubernetes-node-windows-amd64.tar.gz) | `7fb09e7667715f539766398fc1bbbc4bf17c64913ca09d4e3535dfc4d1ba2bf6f1a3fcc6d81dbf473ba3f10fd29c537ce5debc17268698048ce7b378802a6c46`
+
+## Changelog since v1.16.0-rc.1
+
+### Other notable changes
+
+* Single static pod files and pod files from http endpoints cannot be larger than 10 MB. HTTP probe payloads are now truncated to 10KB. ([#82669](https://github.com/kubernetes/kubernetes/pull/82669), [@rphillips](https://github.com/rphillips))
+* Restores compatibility with <=1.15.x custom resources by not publishing OpenAPI for non-structural custom resource definitions ([#82653](https://github.com/kubernetes/kubernetes/pull/82653), [@liggitt](https://github.com/liggitt))
+* Fixes regression in logging spurious stack traces when proxied connections are closed by the backend ([#82588](https://github.com/kubernetes/kubernetes/pull/82588), [@liggitt](https://github.com/liggitt))
+
+
+
+# v1.16.0-rc.1
+
+[Documentation](https://docs.k8s.io)
+
+## Downloads for v1.16.0-rc.1
+
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes.tar.gz](https://dl.k8s.io/v1.16.0-rc.1/kubernetes.tar.gz) | `2feadb470a8b0d498dff2c122d792109bc48e24bfc7f49b4b2b40a268061c83d9541cbcf902f2b992d6675e38d69ccdded9435ac488e041ff73d0c2dc518a5a9`
+[kubernetes-src.tar.gz](https://dl.k8s.io/v1.16.0-rc.1/kubernetes-src.tar.gz) | `6d8877e735e041c989c0fca9dd9e57e5960299e74f66f69907b5e1265419c69ed3006c0161e0ced63073e28073355a5627154cf5db53b296b4a209b006b45db0`
+
+### Client Binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-client-darwin-386.tar.gz](https://dl.k8s.io/v1.16.0-rc.1/kubernetes-client-darwin-386.tar.gz) | `27bbfcb709854a9625dbb22c357492c1818bc1986b94e8cf727c046d596c4f1fe385df5b2ce61baaf95b066d584a8c04190215eaf979e12707c6449766e84810`
+[kubernetes-client-darwin-amd64.tar.gz](https://dl.k8s.io/v1.16.0-rc.1/kubernetes-client-darwin-amd64.tar.gz) | `9c2ea22e188282356cd532801cb94d799bde5a5716f037b81e7f83273f699bf80776b253830e3a4e1a72c420f0c0b84e28ae043c9d28a49e9455e6b1449a353c`
+[kubernetes-client-linux-386.tar.gz](https://dl.k8s.io/v1.16.0-rc.1/kubernetes-client-linux-386.tar.gz) | `bbba78b8f972d0c247ed11e88010fc934a694efce8d2605635902b4a22f5ecc7e710f640bcefbba97ef28f6db68b9d8fb9e6a4a099603493c1ddcc5fd50c0d17`
+[kubernetes-client-linux-amd64.tar.gz](https://dl.k8s.io/v1.16.0-rc.1/kubernetes-client-linux-amd64.tar.gz) | `f2f04dc9b93d1c8f5295d3f559a3abdd19ea7011741aa006b2cd96542c06a6892d7ed2bad8479c89e7d6ae0ed0685e68d5096bd5a46431c8cab8a90c04f1f00c`
+[kubernetes-client-linux-arm.tar.gz](https://dl.k8s.io/v1.16.0-rc.1/kubernetes-client-linux-arm.tar.gz) | `77d1f5b4783f7480d879d0b7682b1d46e730e7fb8edbc6eccd96986c31ceecbf123cd9fd11c5a388218a8c693b1b545daed28ca88f36ddaca06adac4422e4be5`
+[kubernetes-client-linux-arm64.tar.gz](https://dl.k8s.io/v1.16.0-rc.1/kubernetes-client-linux-arm64.tar.gz) | `0b57aa1dbbce51136789cb373d93e641d1f095a4bc9695d60917e85c814c8959a4d6e33224dc86295210d01e73e496091a191f303348f3b652a2b6160b1e6059`
+[kubernetes-client-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.16.0-rc.1/kubernetes-client-linux-ppc64le.tar.gz) | `847065d541dece0fc931947146dbc90b181f923137772f26c7c93476e022f4f654e00f9928df7a13a9dec27075dd8134bdb168b5c57d4efa29ed20a6a2112272`
+[kubernetes-client-linux-s390x.tar.gz](https://dl.k8s.io/v1.16.0-rc.1/kubernetes-client-linux-s390x.tar.gz) | `d7e8a808da9e2551ca7d8e7cb25222cb9ac01595f78ebbc86152ae1c21620d4d8478ef3d374d69f47403ca913fc716fbaa81bd3ff082db2fc5814ef8dc66eeec`
+[kubernetes-client-windows-386.tar.gz](https://dl.k8s.io/v1.16.0-rc.1/kubernetes-client-windows-386.tar.gz) | `c9cf6a6b9f2f29152af974d30f3fd97ba33693d5cbbf8fc76bcf6590979e7ac8307e5da4f84a646cec6b68f6fa1a83aa1ce24eb6429baa0a39c92d5901bd80be`
+[kubernetes-client-windows-amd64.tar.gz](https://dl.k8s.io/v1.16.0-rc.1/kubernetes-client-windows-amd64.tar.gz) | `ebea0c0b64d251e6023e8a5a100aa609bc278c797170765da2e35c8997efc233bec9f8d1436aeee1cd6459e30ec78ba64b84de47c26a4e4645e153e5e598202b`
+
+### Server Binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-server-linux-amd64.tar.gz](https://dl.k8s.io/v1.16.0-rc.1/kubernetes-server-linux-amd64.tar.gz) | `2fe7ccce15e705826c4ccfce48df8130ba89a0c930bca4b61f49267e9d490f57cf6220671752e44e55502bee501a9af2f0ac3927378a87b466f2526fa6e45834`
+[kubernetes-server-linux-arm.tar.gz](https://dl.k8s.io/v1.16.0-rc.1/kubernetes-server-linux-arm.tar.gz) | `6eb77e59095a1de9eb21e7065e8d10b7d0baf1888991a42089ede6d4f8a8cac0b17ae793914eef5796d56d8f0b958203d5df1f7ed45856dce7244c9f047f9793`
+[kubernetes-server-linux-arm64.tar.gz](https://dl.k8s.io/v1.16.0-rc.1/kubernetes-server-linux-arm64.tar.gz) | `429ce0d5459384c9d3a2bb103924eebc4c30343c821252dde8f4413fcf29cc73728d378bfd193c443479bde6bfd26e0a13c036d4d4ae22034d66f6cad70f684d`
+[kubernetes-server-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.16.0-rc.1/kubernetes-server-linux-ppc64le.tar.gz) | `18041d9c99efc00c8c9dbb6444974efdbf4969a4f75faea75a3c859b1ee8485d2bf3f01b7942a524dcd6a71c82af7a5937fc9120286e920cf2d501b7c76ab160`
+[kubernetes-server-linux-s390x.tar.gz](https://dl.k8s.io/v1.16.0-rc.1/kubernetes-server-linux-s390x.tar.gz) | `2124c3d8856e50ca6b2b61d83f108ab921a1217fac2a80bf765d51b68f4e67d504471787d375524974173782aa37c57b6bf1fc6c7704ed7e6cabe15ec3c543b1`
+
+### Node Binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-node-linux-amd64.tar.gz](https://dl.k8s.io/v1.16.0-rc.1/kubernetes-node-linux-amd64.tar.gz) | `ea1bcd8cc51fbc95058a8a592eb454c07ab5dadc1c237bbc59f278f8adc46bda1f334e73463e1edbd6da5469c4a527ceb1cb0a96686493d3ff4e8878dd1c9a20`
+[kubernetes-node-linux-arm.tar.gz](https://dl.k8s.io/v1.16.0-rc.1/kubernetes-node-linux-arm.tar.gz) | `e5d62df5fd086ff5712f59f71ade9efcf617a13c567de965ce54c79f3909372bed4edbf6639cf058fe1d5c4042f794e1c6a91e5e20d9dcce597a95dedf2474b2`
+[kubernetes-node-linux-arm64.tar.gz](https://dl.k8s.io/v1.16.0-rc.1/kubernetes-node-linux-arm64.tar.gz) | `5aa0a7a3d02b65253e4e814e51cea6dd895170f2838fea02f94e4efd3f938dbf83bc7f209801856b98420373c04147fab9cb8791d24d51dcedf960068dfe6fda`
+[kubernetes-node-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.16.0-rc.1/kubernetes-node-linux-ppc64le.tar.gz) | `f54bc5ae188f8ecb3ddcae20e06237430dd696f444a5c65b0aa3be79ad85c5b500625fa47ed0e126f6e738eb5d9ee082b52482a6913ec6d22473520fa6582e66`
+[kubernetes-node-linux-s390x.tar.gz](https://dl.k8s.io/v1.16.0-rc.1/kubernetes-node-linux-s390x.tar.gz) | `afa4f9b747fff20ed03d40092a2df60dbd6ced0de7fd0c83c001866c4fe5b7117468e2f8c73cbef26f376b69b4750f188143076953fc200e8a5cc002c8ac705b`
+[kubernetes-node-windows-amd64.tar.gz](https://dl.k8s.io/v1.16.0-rc.1/kubernetes-node-windows-amd64.tar.gz) | `e9b76014a1d4268ad66ade06883dd3344c6312ece14ee988af645bdf9c5e9b62c31a0e339f774c67799b777314db6016d86a3753855c7d2eb461fbbf4e154ae7`
+
+## Changelog since v1.16.0-beta.2
+
+### Other notable changes
+
+* Update Cluster Autoscaler to 1.16.0; changelog: https://github.com/kubernetes/autoscaler/releases/tag/cluster-autoscaler-1.16.0 ([#82501](https://github.com/kubernetes/kubernetes/pull/82501), [@losipiuk](https://github.com/losipiuk))
+* Resolved regression serving custom resources with unhandled validation schemas with the ServerSideApply feature enabled ([#82438](https://github.com/kubernetes/kubernetes/pull/82438), [@liggitt](https://github.com/liggitt))
+* Fix filter plugins are not been called during preemption ([#81876](https://github.com/kubernetes/kubernetes/pull/81876), [@wgliang](https://github.com/wgliang))
+* Fix the dns suffix search list for GCE window clusters. ([#82314](https://github.com/kubernetes/kubernetes/pull/82314), [@lzang](https://github.com/lzang))
+* Install and start logging agent based on kube env ENABLE_NODE_LOGGING. ([#81300](https://github.com/kubernetes/kubernetes/pull/81300), [@liyanhui1228](https://github.com/liyanhui1228))
+* kubeadm: Allow users to skip the kube-proxy init addon phase during init and still be able to join a cluster and perform some other minor operations (but not upgrade). ([#82248](https://github.com/kubernetes/kubernetes/pull/82248), [@rosti](https://github.com/rosti))
+* Bump metrics-server to v0.3.4 ([#82322](https://github.com/kubernetes/kubernetes/pull/82322), [@olagacek](https://github.com/olagacek))
+* Updated default etcd service used by kubernetes to 3.3.15 ([#82199](https://github.com/kubernetes/kubernetes/pull/82199), [@dims](https://github.com/dims))
+
+
+
+# v1.16.0-beta.2
+
+[Documentation](https://docs.k8s.io)
+
+## Downloads for v1.16.0-beta.2
+
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes.tar.gz](https://dl.k8s.io/v1.16.0-beta.2/kubernetes.tar.gz) | `d1f4e9badc6a4422b9a261a5375769d63f0cac7fff2aff4122a325417b77d5e5317ba76a180cda2baa9fb1079c33e396fc16f82b31eeebea61004b0aabdf8c32`
+[kubernetes-src.tar.gz](https://dl.k8s.io/v1.16.0-beta.2/kubernetes-src.tar.gz) | `2ab20b777311746bf9af0947a2bea8ae36e27da7d917149518d7c2d2612f513bbf88d1f2c7efff6dc169aa43c2dd3be73985ef619172d50d99faa56492b35ce4`
+
+### Client Binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-client-darwin-386.tar.gz](https://dl.k8s.io/v1.16.0-beta.2/kubernetes-client-darwin-386.tar.gz) | `55523fd5cfce0c5b79e981c6a4d5572790cfe4488ed23588be45ee13367e374cf703f611769751583986557b2607f271704d9f27e03f558e35e7c75796476b10`
+[kubernetes-client-darwin-amd64.tar.gz](https://dl.k8s.io/v1.16.0-beta.2/kubernetes-client-darwin-amd64.tar.gz) | `13e696782713da96f5fb2c3fa54d99ca40bc71262cb2cbc8e77a6d19ffd33b0767d3f27e693aa84103aca465f9b00ed109996d3579b4bd28566b8998212a0872`
+[kubernetes-client-linux-386.tar.gz](https://dl.k8s.io/v1.16.0-beta.2/kubernetes-client-linux-386.tar.gz) | `7f4818599b84712edd2bf1d94f02f9a53c1f827b428a888356e793ff62e897276afcbc97f03bc0317e7d729740410037c57e6443f65c691eb959b676833511fa`
+[kubernetes-client-linux-amd64.tar.gz](https://dl.k8s.io/v1.16.0-beta.2/kubernetes-client-linux-amd64.tar.gz) | `8a2656289d7d86cbded42831f6bc660b579609622c16428cf6cc782ac8b52df4c8511c5aad65aa520f398a65e35dee6ea5b5ad8e5fd14c5a8690a7248dc4c109`
+[kubernetes-client-linux-arm.tar.gz](https://dl.k8s.io/v1.16.0-beta.2/kubernetes-client-linux-arm.tar.gz) | `418606bc109b9acb2687ed297fa2eec272e8cb4ad3ce1173acd15a4b43cec0ecfd95e944faeecf862b349114081dd99dfac8615dc95cffc1cd4983c5b38e9c4e`
+[kubernetes-client-linux-arm64.tar.gz](https://dl.k8s.io/v1.16.0-beta.2/kubernetes-client-linux-arm64.tar.gz) | `2eb943b745c270cd161e01a12195cfb38565de892a1da89e851495fb6f9d6664055e384e30d3551c25f120964e816e44df5415aff7c12a8639c30a42271abef7`
+[kubernetes-client-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.16.0-beta.2/kubernetes-client-linux-ppc64le.tar.gz) | `262e7d61e167e7accd43c47e9ce28323ae4614939a5af09ecc1023299cd2580220646e7c90d31fee0a17302f5d9df1e7da1e6774cc7e087248666b33399e8821`
+[kubernetes-client-linux-s390x.tar.gz](https://dl.k8s.io/v1.16.0-beta.2/kubernetes-client-linux-s390x.tar.gz) | `8f0cfe669a211423dd697fdab722011ea9641ce3db64debafa539d4a424dd26065c8de5da7502a4d40235ff39158f3935bd337b807a63771391dffb282563ccf`
+[kubernetes-client-windows-386.tar.gz](https://dl.k8s.io/v1.16.0-beta.2/kubernetes-client-windows-386.tar.gz) | `b1deab89653f4cd3ad8ad68b8ec3e1c038d1ef35bd2e4475d71d4781acf0b2002443f9c2b7d2cf06cbb9c568bea3881c06d723b0529cc8210f99450dc2dc5e43`
+[kubernetes-client-windows-amd64.tar.gz](https://dl.k8s.io/v1.16.0-beta.2/kubernetes-client-windows-amd64.tar.gz) | `0e3b5150767efd0ed5d60b2327d2b7f6f2bda1a3532fca8e84a7ca161f6e069fae15af37d3fe8a641d34c9a65fc61f1c44dd3265ef6cacfd2df55c9c004bc6bd`
+
+### Server Binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-server-linux-amd64.tar.gz](https://dl.k8s.io/v1.16.0-beta.2/kubernetes-server-linux-amd64.tar.gz) | `32688295df1fcdb9472ed040dc5e8b19d04d62789d2eca64cfe08080d08ffee1eaa4853ce40bd336aabd2f764dd65b36237d4f9f1c697e2d6572861c0c8eff01`
+[kubernetes-server-linux-arm.tar.gz](https://dl.k8s.io/v1.16.0-beta.2/kubernetes-server-linux-arm.tar.gz) | `c8ea6d66e966889a54194f9dce2021131e9bae34040c56d8839341c47fc4074d6322cc8aadce28e7cdcee88ec79d37a73d52276deb1cc1eee231e4d3083d54e5`
+[kubernetes-server-linux-arm64.tar.gz](https://dl.k8s.io/v1.16.0-beta.2/kubernetes-server-linux-arm64.tar.gz) | `12b42cfa33ff824392b81a604b7edcab95ecc67cddfc24c47ef67adb356a333998bc7b913b00daf7a213692d8d441153904474947b46c7f76ef03d4b2a63eab0`
+[kubernetes-server-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.16.0-beta.2/kubernetes-server-linux-ppc64le.tar.gz) | `e03f0eba181c03ddb7535e56ff330dafebb7dcb40889fd04f5609617ebb717f9f833e89810bff36d5299f72ae75d356fffb80f7b3bab2232c7597abcc003b8ba`
+[kubernetes-server-linux-s390x.tar.gz](https://dl.k8s.io/v1.16.0-beta.2/kubernetes-server-linux-s390x.tar.gz) | `4e7bd061317a3445ad4b6b308f26218777677a1fef5fda181ee1a19e532a758f6bd3746a3fe1917a057ed71c94892aeaf00dd4eb008f61418ec3c80169a1f057`
+
+### Node Binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-node-linux-amd64.tar.gz](https://dl.k8s.io/v1.16.0-beta.2/kubernetes-node-linux-amd64.tar.gz) | `dc5606c17f0191afc6f28dce5ab566fd8f21a69fa3989a1c8f0976d7b8ccd32e26bb21e9fec9f4529c5a6c8301747d278484688a0592da291866f8fa4893dcbb`
+[kubernetes-node-linux-arm.tar.gz](https://dl.k8s.io/v1.16.0-beta.2/kubernetes-node-linux-arm.tar.gz) | `3d5d9893e06fd7be51dca11182ecb9e93108e86af40298fe66bb62e5e86f0bf4713667ba63d00b02cfddaf20878dd78cc738e76bf1ca715bbbe79347ca518ec4`
+[kubernetes-node-linux-arm64.tar.gz](https://dl.k8s.io/v1.16.0-beta.2/kubernetes-node-linux-arm64.tar.gz) | `fd18a02f32aeafc5cce8f3f2eadd0e532857bd5264b7299b4e48f458f77ebaa53be94b1d1fe2062168f9d88c8a97e6c2d904fc3401a2d9e69dd4e8c87d01d915`
+[kubernetes-node-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.16.0-beta.2/kubernetes-node-linux-ppc64le.tar.gz) | `703afd80140db2fae897d83b3d2bc8889ff6c6249bb79be7a1cce6f0c9326148d22585a5249c2e976c69a2518e3f887eef4c9dc4a970ebb854a78e72c1385ccb`
+[kubernetes-node-linux-s390x.tar.gz](https://dl.k8s.io/v1.16.0-beta.2/kubernetes-node-linux-s390x.tar.gz) | `445d4ef4f9d63eabe3b7c16114906bc450cfde3e7bf7c8aedd084c79a5e399bd24a7a9c2283b58d382fb11885bb2b412773a36fffb6fc2fac15d696439a0b800`
+[kubernetes-node-windows-amd64.tar.gz](https://dl.k8s.io/v1.16.0-beta.2/kubernetes-node-windows-amd64.tar.gz) | `88b04171c3c0134044b7555fbc9b88071f5a73dbf2dac21f8a27b394b0870dff349a56b0ee4d8e1d9cfbeb98645e485f40b8d8863f3f3e833cba0ca6b1383ccf`
+
+## Changelog since v1.16.0-beta.1
+
+### Other notable changes
+
+* Fix a bug in apiserver that could cause a valid update request to be rejected with a precondition check failure. ([#82303](https://github.com/kubernetes/kubernetes/pull/82303), [@roycaihw](https://github.com/roycaihw))
+* Webhook client credentials configured with `--admission-control-config-file` must include non-default ports in the configured hostnames. For example, a webhook configured to speak to port 8443 on service `mysvc` in namespace `myns` would specify client credentials in a stanza with `name: mysvc.myns.svc:8443`. See https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#authenticate-apiservers for more details. ([#82252](https://github.com/kubernetes/kubernetes/pull/82252), [@liggitt](https://github.com/liggitt))
+* Ensure the KUBE-MARK-DROP chain in kube-proxy mode=ipvs. The chain is ensured for both ipv4 and ipv6 in dual-stack operation. ([#82214](https://github.com/kubernetes/kubernetes/pull/82214), [@uablrek](https://github.com/uablrek))
+* `kubectl cp` no longer supports copying symbolic links from containers; to support this use case, see `kubectl exec --help` for examples using `tar` directly ([#82143](https://github.com/kubernetes/kubernetes/pull/82143), [@soltysh](https://github.com/soltysh))
+* kubeadm: fix for HTTPProxy check for IPv6 addresses (kubernetes/kubeadm#1769) ([#82267](https://github.com/kubernetes/kubernetes/pull/82267), [@kad](https://github.com/kad))
+* Add PodOverhead awareness to kubectl ([#81929](https://github.com/kubernetes/kubernetes/pull/81929), [@egernst](https://github.com/egernst))
+* The nbf (not before) claim, if present in ID token, is now enforced.   ([#81413](https://github.com/kubernetes/kubernetes/pull/81413), [@anderseknert](https://github.com/anderseknert))
+* Server-side apply will now use the openapi provided in the CRD validation field to help figure out how to correctly merge objects and update ownership. ([#77354](https://github.com/kubernetes/kubernetes/pull/77354), [@jennybuckley](https://github.com/jennybuckley))
+* - Fix disk stats in LXD using ZFS storage pool ([#81972](https://github.com/kubernetes/kubernetes/pull/81972), [@dashpole](https://github.com/dashpole))
+    * - Fix CRI-O missing network metris bug
+    * - Add `container_sockets`, `container_threads`, and `container_threads_max` metrics
+* Adds Endpoint Slice support for kubectl when discovery API group is enabled. ([#81795](https://github.com/kubernetes/kubernetes/pull/81795), [@robscott](https://github.com/robscott))
+* Node-Problem-Detector v0.7.1 is used for addon daemonset. ([#82140](https://github.com/kubernetes/kubernetes/pull/82140), [@wangzhen127](https://github.com/wangzhen127))
+* aggregated discovery requests can now timeout.  Aggregated apiserver *must* complete discovery calls within five seconds.  Other requests can take longer. ([#82146](https://github.com/kubernetes/kubernetes/pull/82146), [@deads2k](https://github.com/deads2k))
+    * Use feature gate `EnableAggregatedDiscoveryTimeout=false` if you *must* remove this check, but that feature gate will be removed next release.
+* Graduating Windows GMSA support from alpha to beta ([#82110](https://github.com/kubernetes/kubernetes/pull/82110), [@wk8](https://github.com/wk8))
+* Add UnschedulableAndUnresolvable status code for Scheduler Framework ([#82034](https://github.com/kubernetes/kubernetes/pull/82034), [@alculquicondor](https://github.com/alculquicondor))
+* Kubeadm now includes CoreDNS version 1.6.2 ([#82127](https://github.com/kubernetes/kubernetes/pull/82127), [@rajansandeep](https://github.com/rajansandeep))
+    *     - The CoreDNS Deployment now checks readiness via the `ready` plugin.
+    *     - The `proxy` plugin has been deprecated. The `forward` plugin is to be used instead.
+    *     - `kubernetes` plugin removes the `resyncperiod` option.
+    *     - The `upstream` option is deprecated and ignored if included.
+* Make kubectl get --ignore-not-found continue processing when encountering error.  ([#82120](https://github.com/kubernetes/kubernetes/pull/82120), [@soltysh](https://github.com/soltysh))
+* Dual stack services (Phase II of IPv6DualStack feature) are enabled via the IPVS proxier. iptables proxier does not support dualstack yet. Dualstack iptables proxier is WIP and should catchup soon. ([#82091](https://github.com/kubernetes/kubernetes/pull/82091), [@khenidak](https://github.com/khenidak))
+    * to enable, kube-proxy must be have the following flags:
+    * --proxy-mode=ipvs
+    * --cluster-cidrs=<cidr>,<cidr>
+* The apiserver now uses http/1.1 to communicate with admission webhooks, opening multiple connections to satisfy concurrent requests, and allowing spreading requests across multiple backing pods. ([#82090](https://github.com/kubernetes/kubernetes/pull/82090), [@liggitt](https://github.com/liggitt))
+* Added support to specify a global-access annotation for gce ILB. ([#81549](https://github.com/kubernetes/kubernetes/pull/81549), [@prameshj](https://github.com/prameshj))
+* Added new startupProbe, related to KEP https://github.com/kubernetes/enhancements/issues/950. ([#77807](https://github.com/kubernetes/kubernetes/pull/77807), [@matthyx](https://github.com/matthyx))
+* Adds \livez for liveness health checking for kube-apiserver. Using the parameter `--maximum-startup-sequence-duration` will allow the liveness endpoint to defer boot-sequence failures for the specified duration period. ([#81969](https://github.com/kubernetes/kubernetes/pull/81969), [@logicalhan](https://github.com/logicalhan))
+* Server-side apply is now Beta. ([#81956](https://github.com/kubernetes/kubernetes/pull/81956), [@apelisse](https://github.com/apelisse))
+* The `rejected` label in `apiserver_admission_webhook_admission_duration_seconds` metrics now properly indicates if a request was rejected. Add a new counter metrics `apiserver_admission_webhook_rejection_count` with details about the causing for a webhook rejection. ([#81399](https://github.com/kubernetes/kubernetes/pull/81399), [@roycaihw](https://github.com/roycaihw))
+* Add `container_state` label to `running_container_count` kubelet metrics, to get count of containers based on their state(running/exited/created/unknown) ([#81573](https://github.com/kubernetes/kubernetes/pull/81573), [@irajdeep](https://github.com/irajdeep))
+* Fix a bug in CRD openapi controller that user-defined CRD can overwrite OpenAPI definition/path for the CRD API. ([#81436](https://github.com/kubernetes/kubernetes/pull/81436), [@roycaihw](https://github.com/roycaihw))
+* Service account tokens now include the JWT Key ID field in their header. ([#78502](https://github.com/kubernetes/kubernetes/pull/78502), [@ahmedtd](https://github.com/ahmedtd))
+* Adds EndpointSlice integration to kube-proxy, can be enabled with EndpointSlice feature gate. ([#81430](https://github.com/kubernetes/kubernetes/pull/81430), [@robscott](https://github.com/robscott))
+* Azure supports IPv6 only on ELB not ILB. The cloud provider will return an error if the service is internal and is IPv6. ([#80485](https://github.com/kubernetes/kubernetes/pull/80485), [@khenidak](https://github.com/khenidak))
+    * Notes on LB name:
+    * to ensure backword and forward compat:
+    * - SingleStack -v4 (pre v1.16) => BackendPool name == clusterName
+    * - SingleStack -v6 => BackendPool name == clusterName (all cluster bootstrap uses this name)
+    * DualStack:
+    * => IPv4 BackendPool name == clusterName
+    * => IPv6 BackendPool name == <clusterName>-IPv6
+    * This result into:
+    * - clusters moving from IPv4 to duakstack will require no changes
+    * - clusters moving from IPv6 (while not seen in the wild, we can not rule out their existence) to dualstack will require deleting backend pools (the reconciler will take care of creating correct backendpools)
+* Promotes VolumePVCDataSource (Cloning) feature to beta for 1.16 release  ([#81792](https://github.com/kubernetes/kubernetes/pull/81792), [@j-griffith](https://github.com/j-griffith))
+* Remove kubectl log, use kubectl logs instead ([#78098](https://github.com/kubernetes/kubernetes/pull/78098), [@soltysh](https://github.com/soltysh))
+* CSI ephemeral inline volume support is beta, i.e. the CSIInlineVolume feature gate is enabled by default ([#82004](https://github.com/kubernetes/kubernetes/pull/82004), [@pohly](https://github.com/pohly))
+* kubectl: the --all-namespaces flag is now honored by `kubectl wait` ([#81468](https://github.com/kubernetes/kubernetes/pull/81468), [@ashutoshgngwr](https://github.com/ashutoshgngwr))
+* Kube-proxy metrics are now marked as with the ALPHA stability level. ([#81626](https://github.com/kubernetes/kubernetes/pull/81626), [@logicalhan](https://github.com/logicalhan))
+* Kube-controller-manager and cloud-controller-manager metrics are now marked as with the ALPHA stability level. ([#81624](https://github.com/kubernetes/kubernetes/pull/81624), [@logicalhan](https://github.com/logicalhan))
+* Adds Endpoint Slice Controller for managing new EndpointSlice resource, disabled by default. ([#81048](https://github.com/kubernetes/kubernetes/pull/81048), [@robscott](https://github.com/robscott))
+* + to run: ([#79386](https://github.com/kubernetes/kubernetes/pull/79386), [@khenidak](https://github.com/khenidak))
+    * Master: convert service CIDR to list  `--service-cluster-ip-range=<CIDR>,<CIDR>` and make sure `IPv6DualStack` feature flag is turned on. The flag is validated and used as the following:
+    * 1. `--service-cluster-ip-range[0]` is consider primary service range, and will be used for any service with `Service.Spec.IPFamily = nil` or any service in the at the time of turning on the feature flag.
+    * 2. A cluster can be dualstack (i.e. Pods and nodes carry dualstack IPs) but does not need to support ingress on dualstack. In this case the cluster can perform egress using `PodIPs` (according to family and binding selection in user code) but will ingress will only be performed against the pod primary IP. This can be configured by supplying single entry to `--service-cluster-ip-range` flag.
+    * 3. Maximum of two entries is allowed in `--service-cluster-ip-range` and they are validated to be dual stacked `i.e. --service-cluster-ip-range=<v4>,<v6> or --service-cluster-ip-range=<v6>,<v4>`
+    * 4. Max 20 bit for range (min network bits `<v6>/108` or <v4>/12)
+    * kube-controller-manager: convert service CIDR to list `--service-cluster-ip-range=<CIDR>,<CIDR>` and make sure `IPv6DualStack` feature flag is turned on. The flag is validated as above.
+    * + to use:
+    * A new service spec field `Service.Spec.IPFamily` has been added. The default of this field is family of (first service cidr in --service-cluster-ip-range flag). The value is defaulted as described above  once the feature gate is turned on. Here are the possible values for this field:
+    * 2. IPv4: api-server will assign an IP from a `service-cluster-ip-range` that is `ipv4` (either the primary or the secondary, according to how they were configured).
+    * 2. IPv6: api-server will assign an IP from a `service-cluster-ip-range` that is `ipv6` (either the primary or the secondary, according to how they were configured).
+    * Notes (v1.16):
+    * 1. IPVS is the only proxy supported (as of v1.16 ) by Dualstack.
+    * 2. Dualstack is mutually exclusive with `EndpointSlice` feature. They can not be turned on together.  `metaproxy` is yet to implement EndpointSlice handling.
+* Kubelet metrics for /metrics and /metrics/probes are now marked as with the ALPHA stability level. ([#81534](https://github.com/kubernetes/kubernetes/pull/81534), [@logicalhan](https://github.com/logicalhan))
+* Added metrics 'authentication_attempts' that can be used to understand the attempts of authentication. ([#81509](https://github.com/kubernetes/kubernetes/pull/81509), [@RainbowMango](https://github.com/RainbowMango))
+* Fix in kube-proxy for SCTP nodeport service which only works for node's InternalIP, but doesn't work for other IPs present in the node when ipvs is enabled. ([#81477](https://github.com/kubernetes/kubernetes/pull/81477), [@paulsubrata55](https://github.com/paulsubrata55))
+* The `CustomResourceValidation`, `CustomResourceSubresources`, `CustomResourceWebhookConversion` and `CustomResourcePublishOpenAPI` features are now GA, and the associated feature gates deprecated and will be removed in v1.18. ([#81965](https://github.com/kubernetes/kubernetes/pull/81965), [@roycaihw](https://github.com/roycaihw))
+* Node-Problem-Detector v0.7.1 is used on GCI. ([#80726](https://github.com/kubernetes/kubernetes/pull/80726), [@wangzhen127](https://github.com/wangzhen127))
+* kubeadm: prevent overriding of certain kubelet security configuration parameters if the user wished to modify them ([#81903](https://github.com/kubernetes/kubernetes/pull/81903), [@jfbai](https://github.com/jfbai))
+* Introduce `node.kubernetes.io/exclude-balancer` and `node.kubernetes.io/exclude-disruption` labels in alpha to prevent cluster deployers from being dependent on the optional `node-role` labels which not all clusters may provide. ([#80238](https://github.com/kubernetes/kubernetes/pull/80238), [@smarterclayton](https://github.com/smarterclayton))
+* Scheduler metrics are now marked as with the ALPHA stability level. ([#81576](https://github.com/kubernetes/kubernetes/pull/81576), [@logicalhan](https://github.com/logicalhan))
+* cache-control headers are now set appropriately.  Only openapi is cacheable if etags match. ([#81946](https://github.com/kubernetes/kubernetes/pull/81946), [@deads2k](https://github.com/deads2k))
+* Added E2E tests validating WindowsOptions.RunAsUserName. ([#79539](https://github.com/kubernetes/kubernetes/pull/79539), [@bclau](https://github.com/bclau))
+* Kube-apiserver metrics are now marked as with the ALPHA stability level. ([#81531](https://github.com/kubernetes/kubernetes/pull/81531), [@logicalhan](https://github.com/logicalhan))
+* Move CSI volume expansion to beta. ([#81467](https://github.com/kubernetes/kubernetes/pull/81467), [@bertinatto](https://github.com/bertinatto))
+* Support Kubelet plugin watcher on Windows nodes. ([#81397](https://github.com/kubernetes/kubernetes/pull/81397), [@ddebroy](https://github.com/ddebroy))
+* Updates the requestedToCapacityRatioArguments to add resources parameter that allows the users to specify the resource name along with weights for each resource to score nodes based on the request to capacity ratio.    ([#77688](https://github.com/kubernetes/kubernetes/pull/77688), [@sudeshsh](https://github.com/sudeshsh))
+* Finalizer Protection for Service LoadBalancers is now in Beta (enabled by default). This feature ensures the Service resource is not fully deleted until the correlating load balancer resources are deleted. ([#81691](https://github.com/kubernetes/kubernetes/pull/81691), [@MrHohn](https://github.com/MrHohn))
+* Adds support for vSphere volumes on Windows ([#80911](https://github.com/kubernetes/kubernetes/pull/80911), [@gab-satchi](https://github.com/gab-satchi))
+* Log when kube-apiserver regenerates the OpenAPI spec and why. OpenAPI spec generation is a very CPU-heavy process that is sensitive to continuous updates of CRDs and APIServices. ([#81786](https://github.com/kubernetes/kubernetes/pull/81786), [@sttts](https://github.com/sttts))
+    * Added metrics aggregator_openapi_v2_regeneration_count, aggregator_openapi_v2_regeneration_gauge and apiextension_openapi_v2_regeneration_count metrics counting the triggering APIService and CRDs and the reason (add, update, delete).
+* Fix an issue with toleration merging & whitelist checking in the PodTolerationRestriction admission controller. ([#81732](https://github.com/kubernetes/kubernetes/pull/81732), [@tallclair](https://github.com/tallclair))
+* Add a helper function to decode scheduler plugin args. ([#80696](https://github.com/kubernetes/kubernetes/pull/80696), [@hex108](https://github.com/hex108))
+* Add metadata.generation=1 to old CustomResources. ([#82005](https://github.com/kubernetes/kubernetes/pull/82005), [@sttts](https://github.com/sttts))
+* kubeadm no longer performs IPVS checks as part of its preflight checks ([#81791](https://github.com/kubernetes/kubernetes/pull/81791), [@yastij](https://github.com/yastij))
+* The RemainingItemCount feature is now beta. ([#81682](https://github.com/kubernetes/kubernetes/pull/81682), [@caesarxuchao](https://github.com/caesarxuchao))
+    * remainingItemCount is the number of subsequent items in the list which are not included in this list response. If the list request contained label or field selectors, then the number of remaining items is unknown and the field will be left unset and omitted during serialization. If the list is complete (either because it is not chunking or because this is the last chunk), then there are no more remaining items and this field will be left unset and omitted during serialization. Servers older than v1.15 do not set this field. The intended use of the remainingItemCount is *estimating* the size of a collection. Clients should not rely on the remainingItemCount to be set or to be exact.
+* The CustomResourceDefaulting feature is promoted to beta and enabled by default. Defaults may be specified in structural schemas via the `apiextensions.k8s.io/v1` API. See https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/#specifying-a-structural-schema for details. ([#81872](https://github.com/kubernetes/kubernetes/pull/81872), [@sttts](https://github.com/sttts))
+* kubectl could scale custom resource again ([#81342](https://github.com/kubernetes/kubernetes/pull/81342), [@knight42](https://github.com/knight42))
+* a CSI driver that supports ephemeral inline volumes must explicitly declare that by providing a CSIDriver object where the new "mode" field is set to "ephemeral" or "persistent+ephemeral" ([#80568](https://github.com/kubernetes/kubernetes/pull/80568), [@pohly](https://github.com/pohly))
+* `framework.ExpectNoError` no longer logs the error and instead relies on using the new `log.Fail` as Gomega fail handler. ([#80253](https://github.com/kubernetes/kubernetes/pull/80253), [@pohly](https://github.com/pohly))
+* Audit events now log the existence and patch of mutating webhooks.  ([#77824](https://github.com/kubernetes/kubernetes/pull/77824), [@roycaihw](https://github.com/roycaihw))
+        * At Metadata audit level or higher, an annotation with key "mutation.webhook.admission.k8s.io/round_{round idx}_index_{order idx}" gets logged with JSON payload indicating a webhook gets invoked for given request and whether it mutated the object or not.
+        * At Request audit level or higher, an annotation with key "patch.webhook.admission.k8s.io/round_{round idx}_index_{order idx}" get logged with the JSON payload logging the patch sent by a webhook for given request.
+* Resolves an issue that prevented block volumes from being resized. ([#81429](https://github.com/kubernetes/kubernetes/pull/81429), [@huffmanca](https://github.com/huffmanca))
+* Verify that CRD default values in OpenAPI specs are pruned, with the exceptions of values under `metadata`. ([#78829](https://github.com/kubernetes/kubernetes/pull/78829), [@sttts](https://github.com/sttts))
+* Use PostFilter instead of Postfilter in the scheduling framework ([#81800](https://github.com/kubernetes/kubernetes/pull/81800), [@draveness](https://github.com/draveness))
+    * Use PreFilter instead of Prefilter in the scheduling framework
+    * Use PreBind instead of Prebind in the scheduling framework
+* Fix `kubectl logs -f` for windows server containers. ([#81747](https://github.com/kubernetes/kubernetes/pull/81747), [@Random-Liu](https://github.com/Random-Liu))
+* fix azure disk naming matching issue due to case sensitive comparison ([#81720](https://github.com/kubernetes/kubernetes/pull/81720), [@andyzhangx](https://github.com/andyzhangx))
+* Fixes a bug that when there is a "connection refused" error, the reflector's ListAndWatch func will return directly but what expected is that sleep 1 second and rewatch since the specified resourceVersion. ([#81634](https://github.com/kubernetes/kubernetes/pull/81634), [@likakuli](https://github.com/likakuli))
+* Fixed a bug with the openAPI definition for io.k8s.apimachinery.pkg.runtime.RawExtension, which previously required a field "raw" to be specified ([#80773](https://github.com/kubernetes/kubernetes/pull/80773), [@jennybuckley](https://github.com/jennybuckley))
+* kubeadm: print the stack trace of an error for klog level --v>=5 ([#80937](https://github.com/kubernetes/kubernetes/pull/80937), [@neolit123](https://github.com/neolit123))
+* Fixes a problem with the iptables proxy mode that could result in long delays ([#80368](https://github.com/kubernetes/kubernetes/pull/80368), [@danwinship](https://github.com/danwinship))
+    * updating Service/Endpoints IPs in very large clusters on RHEL/CentOS 7.
+* kubeadm: support any Linux kernel version newer than 3.10 ([#81623](https://github.com/kubernetes/kubernetes/pull/81623), [@neolit123](https://github.com/neolit123))
+* Added a metric 'apiserver_watch_events_sizes' that can be used to estimate sizes of watch events in the system. ([#80477](https://github.com/kubernetes/kubernetes/pull/80477), [@mborsz](https://github.com/mborsz))
+* NormalizeScore plugin set is removed from scheduler framework config API. Use ScorePlugin only. ([#80930](https://github.com/kubernetes/kubernetes/pull/80930), [@liu-cong](https://github.com/liu-cong))
+* kubeadm reset: unmount directories under "/var/lib/kubelet" for linux only ([#81494](https://github.com/kubernetes/kubernetes/pull/81494), [@Klaven](https://github.com/Klaven))
+* updates fluentd-elasticsearch docker image to fluentd 1.6.3 ([#80912](https://github.com/kubernetes/kubernetes/pull/80912), [@monotek](https://github.com/monotek))
+* Kubeadm now seamlessly migrates the CoreDNS Configuration when upgrading CoreDNS. ([#78033](https://github.com/kubernetes/kubernetes/pull/78033), [@rajansandeep](https://github.com/rajansandeep))
+* Introduce support for applying pod overhead to pod cgroups, if the PodOverhead feature is enabled. ([#79247](https://github.com/kubernetes/kubernetes/pull/79247), [@egernst](https://github.com/egernst))
+* Windows nodes on GCE now run with Windows Defender enabled. ([#81625](https://github.com/kubernetes/kubernetes/pull/81625), [@pjh](https://github.com/pjh))
+
+
+
+# v1.16.0-beta.1
+
+[Documentation](https://docs.k8s.io)
+
+## Downloads for v1.16.0-beta.1
+
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes.tar.gz](https://dl.k8s.io/v1.16.0-beta.1/kubernetes.tar.gz) | `16513ebb52b01afee26156dcd4c449455dc328d7a080ba54b3f3a4584dbd9297025e33a9dafe758b259ae6e33ccb84a18038f6f415e98be298761c4d3dfee94b`
+[kubernetes-src.tar.gz](https://dl.k8s.io/v1.16.0-beta.1/kubernetes-src.tar.gz) | `3933f441ebca812835d6f893ec378896a8adb7ae88ca53247fa402aee1fda00d533301ac806f6bf106badf2f91be8c2524fd98e9757244b4b597c39124c59d01`
+
+### Client Binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-client-darwin-386.tar.gz](https://dl.k8s.io/v1.16.0-beta.1/kubernetes-client-darwin-386.tar.gz) | `28f0a8979f956aa5b3be1c1158a3ade1b242aac332696cb604fbdba44c4279caa1008840af01e50692bf48d0342018f882dd6e30f9fe3279e9784094cfc9ff3c`
+[kubernetes-client-darwin-amd64.tar.gz](https://dl.k8s.io/v1.16.0-beta.1/kubernetes-client-darwin-amd64.tar.gz) | `8804f60b690e5180125cf6ac6d739ad5432b364c5e0d0ee0d2f06220c86ca3a2cffc475e0e3c46c19466e5d1566a5b8bf0a33191cba5bbd3ff27ac64ceee57a0`
+[kubernetes-client-linux-386.tar.gz](https://dl.k8s.io/v1.16.0-beta.1/kubernetes-client-linux-386.tar.gz) | `8f7f86db5a496afd269b926b6baf341bbd4208f49b48fad1a44c5424812667b3bd7912b5b97bd7844dee2a7c6f9441628f7b5db3caa14429020de7788289191c`
+[kubernetes-client-linux-amd64.tar.gz](https://dl.k8s.io/v1.16.0-beta.1/kubernetes-client-linux-amd64.tar.gz) | `7407dc1216cac39f15ca9f75be47c0463a151a3fda7d9843a67c0043c69858fb36eaa6b4194ce5cefd125acd7f521c4b958d446bb0c95ca73a3b3ae47af2c3ee`
+[kubernetes-client-linux-arm.tar.gz](https://dl.k8s.io/v1.16.0-beta.1/kubernetes-client-linux-arm.tar.gz) | `249a82a0af7d8062f49edd9221b3823590b6d166c1bca12c787ae640d6a131bd6a3d7c99136de62074afa6cabe8900dcf4e11037ddbfdf9d5252fc16e256eeb5`
+[kubernetes-client-linux-arm64.tar.gz](https://dl.k8s.io/v1.16.0-beta.1/kubernetes-client-linux-arm64.tar.gz) | `3a8416d99b6ae9bb6d568ff15d1783dc521fe58c60230f38126c64a7739bf03d8490a9a10042d1c4ef07290eaced6cb9d42a9728d4b937305d63f8d3cc7a66f8`
+[kubernetes-client-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.16.0-beta.1/kubernetes-client-linux-ppc64le.tar.gz) | `105bf4afeccf0b314673265b969d1a7f3796ca3098afa788c43cd9ff3e14ee409392caa5766631cca180e790d92731a48f5e7156167637b97abc7c178dd390f3`
+[kubernetes-client-linux-s390x.tar.gz](https://dl.k8s.io/v1.16.0-beta.1/kubernetes-client-linux-s390x.tar.gz) | `98de73accb7deba9896e14a5012a112f6fd00d6e6868e4d21f61b06605efa8868f1965a1c1ba72bb8847416bc789bd7ef5c1a125811b6c6df060217cd84fdb2c`
+[kubernetes-client-windows-386.tar.gz](https://dl.k8s.io/v1.16.0-beta.1/kubernetes-client-windows-386.tar.gz) | `7a43f3285b0ab617990497d41ceadfbd2be2b72d433b02508c198e9d380fb5e0a96863cc14d0e9bf0317df13810af1ab6b7c47cd4fa1d0619a00c9536dc60f0f`
+[kubernetes-client-windows-amd64.tar.gz](https://dl.k8s.io/v1.16.0-beta.1/kubernetes-client-windows-amd64.tar.gz) | `f3fafcffc949bd7f8657dd684c901e199b21c4812009aca1f8cf3c8bf3c3230cab072208d3702d7a248c0b957bc513306dd437fb6a54e1e64b4d7dc8c3c180cd`
+
+### Server Binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-server-linux-amd64.tar.gz](https://dl.k8s.io/v1.16.0-beta.1/kubernetes-server-linux-amd64.tar.gz) | `87b46e73ae2162ee49f510da6549e57503d3ea94b3c4488f39b0b93d45603f540ece30c3784c5e201711a7ddd1260481cd20ac4c618eaf46879e841d054a115a`
+[kubernetes-server-linux-arm.tar.gz](https://dl.k8s.io/v1.16.0-beta.1/kubernetes-server-linux-arm.tar.gz) | `80ba8e615497c0b9c339fbd2d6a4dda54fdbd5659abd7d8e8d448d8d8c24ba7f0ec48693e4bf8ed20513c46432f2a0f1039ab9044f0ed006b935a58772372d95`
+[kubernetes-server-linux-arm64.tar.gz](https://dl.k8s.io/v1.16.0-beta.1/kubernetes-server-linux-arm64.tar.gz) | `b4a76a5fc026b4b3b5f9666df05e46896220591b21c147982ff3d91cec7330ed78cf1fc63f5ab759820aadbcfe400c1ad75d5151d9217d42e3da5873e0ff540d`
+[kubernetes-server-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.16.0-beta.1/kubernetes-server-linux-ppc64le.tar.gz) | `fb435dfd5514e4cd3bc16b9e71865bff3cdd5123fc272c8cbc5956c260449e0dcfd30d2fdb120da73134e62f48507c5a02d4528d7b9d978765ff4ed740b274e8`
+[kubernetes-server-linux-s390x.tar.gz](https://dl.k8s.io/v1.16.0-beta.1/kubernetes-server-linux-s390x.tar.gz) | `65ed3d372a4d03493d0a586c7f67f1236aa99f02552195f1fb58079bc24787200d9a0f34d0c311a846345d0d70d02ad726f74376a91d3ced234bbfdce80c5133`
+
+### Node Binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-node-linux-amd64.tar.gz](https://dl.k8s.io/v1.16.0-beta.1/kubernetes-node-linux-amd64.tar.gz) | `c9161689532a5e995a68bb0985a983dc43d8e747a05f37849cd33062c07e5202417b26bff652b8bc9c0005026618b7ebc56f918c71747a3addb5da044e683b4a`
+[kubernetes-node-linux-arm.tar.gz](https://dl.k8s.io/v1.16.0-beta.1/kubernetes-node-linux-arm.tar.gz) | `7dba9fdb290f33678983c046eb145446edb1b7479c2403f9e8bd835c3d832ab1f2acb28124c53af5b046d47ab433312d6a654f000a22f8e10795b0bc45bfbddb`
+[kubernetes-node-linux-arm64.tar.gz](https://dl.k8s.io/v1.16.0-beta.1/kubernetes-node-linux-arm64.tar.gz) | `8c435824667cd9ec7efdfb72c1d060f62ca61b285cbb9575a6e6013e20ec5b379f77f51d43ae21c1778a3eb3ef69df8895213c54e4b9f39c67c929a276be12de`
+[kubernetes-node-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.16.0-beta.1/kubernetes-node-linux-ppc64le.tar.gz) | `2cfca30dbe49a38cd1f3c78135f60bf7cb3dae0a8ec5d7fa651e1c5949254876fbab8a724ed9a13f733a85b9960edcc4cc971dc3c16297db609209c4270f144f`
+[kubernetes-node-linux-s390x.tar.gz](https://dl.k8s.io/v1.16.0-beta.1/kubernetes-node-linux-s390x.tar.gz) | `63bbe469ddd1be48624ef5627fef1e1557a691819c71a77d419d59d101e8e6ee391eb8545da35b412b94974c06d73329a13660484ab26087a178f34a827a3dcb`
+[kubernetes-node-windows-amd64.tar.gz](https://dl.k8s.io/v1.16.0-beta.1/kubernetes-node-windows-amd64.tar.gz) | `07cb97d5a3b7d0180a9e22696f417422a0c043754c81ae68338aab7b520aa7c119ff53b9ad835f9a0bc9ea8c07483ce506af48d65641dd15d30209a696b064bb`
+
+## Changelog since v1.16.0-alpha.3
+
+### Action Required
+
+* scheduler.alpha.kubernetes.io/critical-pod annotation is removed. Pod priority (spec.priorityClassName) should be used instead to mark pods as critical. Action required! ([#80342](https://github.com/kubernetes/kubernetes/pull/80342), [@draveness](https://github.com/draveness))
+* Removed cadvisor metric labels `pod_name` and `container_name` to match instrumentation guidelines. ([#80376](https://github.com/kubernetes/kubernetes/pull/80376), [@ehashman](https://github.com/ehashman))
+    * Action required: any Prometheus queries that match `pod_name` and `container_name` labels (e.g. cadvisor or kubelet probe metrics) must be updated to use `pod` and `container` instead.
+* Remove DirectCodecFactory(replace with serializer.WithoutConversionCodecFactory), DirectEncoder(replace with runtime.WithVersionEncoder) and DirectDecoder(replace with runtime.WithoutVersionDecoder). action required ([#79263](https://github.com/kubernetes/kubernetes/pull/79263), [@draveness](https://github.com/draveness))
+
+### Other notable changes
+
+* fix: detach azure disk issue using dangling error ([#81266](https://github.com/kubernetes/kubernetes/pull/81266), [@andyzhangx](https://github.com/andyzhangx))
+* Conversion webhooks can now indicate they support receiving and responding with `ConversionReview` API objects in the `apiextensions.k8s.io/v1` version by including `v1` in the `conversionReviewVersions` list in their CustomResourceDefinition. Conversion webhooks must respond with a ConversionReview object in the same apiVersion they receive. `apiextensions.k8s.io/v1` `ConversionReview` responses must specify a `response.uid` that matches the `request.uid` of the object they were sent. ([#81476](https://github.com/kubernetes/kubernetes/pull/81476), [@liggitt](https://github.com/liggitt))
+* The `CustomResourceDefinition` API type is promoted to `apiextensions.k8s.io/v1` with the following changes: ([#79604](https://github.com/kubernetes/kubernetes/pull/79604), [@liggitt](https://github.com/liggitt))
+    * Use of the new `default` feature in validation schemas is limited to v1
+    * `spec.scope` is no longer defaulted to `Namespaced` and must be explicitly specified
+    * `spec.version` is removed; use `spec.versions` instead
+    * `spec.validation` is removed; use `spec.versions[*].schema` instead
+    * `spec.subresources` is removed; use `spec.versions[*].subresources` instead
+    * `spec.additionalPrinterColumns` is removed; use `spec.versions[*].additionalPrinterColumns` instead
+    * `spec.conversion.webhookClientConfig` is moved to `spec.conversion.webhook.clientConfig`
+    * `spec.conversion.conversionReviewVersions` is moved to `spec.conversion.webhook.conversionReviewVersions`
+    * `spec.versions[*].schema.openAPIV3Schema` is now required when creating v1 CustomResourceDefinitions
+    * `spec.preserveUnknownFields: true` is disallowed when creating v1 CustomResourceDefinitions; it must be specified within schema definitions as `x-kubernetes-preserve-unknown-fields: true`
+    * In `additionalPrinterColumns` items, the `JSONPath` field was renamed to `jsonPath` (fixes https://github.com/kubernetes/kubernetes/issues/66531)
+* openapi now advertises correctly supported patch types for custom resources ([#81515](https://github.com/kubernetes/kubernetes/pull/81515), [@liggitt](https://github.com/liggitt))
+* Kubelet could be run with no Azure identity without subscriptionId configured now. ([#81500](https://github.com/kubernetes/kubernetes/pull/81500), [@feiskyer](https://github.com/feiskyer))
+    * A sample cloud provider configure is: '{"vmType": "vmss", "useInstanceMetadata": true}'.
+* Volumes specified in a pod but not used in it are no longer unnecessarily formatted, mounted and reported in `node.status.volumesInUse`. ([#81163](https://github.com/kubernetes/kubernetes/pull/81163), [@jsafrane](https://github.com/jsafrane))
+* kubeadm: use etcd's /health endpoint for a HTTP liveness probe on localhost instead of having a custom health check using etcdctl ([#81385](https://github.com/kubernetes/kubernetes/pull/81385), [@neolit123](https://github.com/neolit123))
+* kubeamd: use the --pod-network-cidr flag to init or use the podSubnet field in the kubeadm config to pass a comma separated list of pod CIDRs.  ([#79033](https://github.com/kubernetes/kubernetes/pull/79033), [@Arvinderpal](https://github.com/Arvinderpal))
+* Update to use go 1.12.9 ([#81489](https://github.com/kubernetes/kubernetes/pull/81489), [@BenTheElder](https://github.com/BenTheElder))
+* Update Azure SDK + go-autorest API versions ([#79574](https://github.com/kubernetes/kubernetes/pull/79574), [@justaugustus](https://github.com/justaugustus))
+* Extender bind should respect IsInterested ([#79804](https://github.com/kubernetes/kubernetes/pull/79804), [@yqwang-ms](https://github.com/yqwang-ms))
+* Add instruction to setup "Application Default Credentials" to run GCE Windows e2e tests locally.  ([#81337](https://github.com/kubernetes/kubernetes/pull/81337), [@YangLu1031](https://github.com/YangLu1031))
+* Scheduler should terminate when it looses leader lock. ([#81306](https://github.com/kubernetes/kubernetes/pull/81306), [@ravisantoshgudimetla](https://github.com/ravisantoshgudimetla))
+* kubelet now exports an "kubelet_evictions" metric that counts the number of pod evictions carried out by the kubelet to reclaim resources ([#81377](https://github.com/kubernetes/kubernetes/pull/81377), [@sjenning](https://github.com/sjenning))
+* Return error when the scoring plugin returns score out of range [0, 100]. ([#81015](https://github.com/kubernetes/kubernetes/pull/81015), [@draveness](https://github.com/draveness))
+* Update to use go 1.12.8 ([#81390](https://github.com/kubernetes/kubernetes/pull/81390), [@cblecker](https://github.com/cblecker))
+* kube-proxy --cleanup will return the correct exit code if the cleanup was successful ([#78775](https://github.com/kubernetes/kubernetes/pull/78775), [@johscheuer](https://github.com/johscheuer))
+* remove iSCSI volume storage cleartext secrets in logs ([#81215](https://github.com/kubernetes/kubernetes/pull/81215), [@zouyee](https://github.com/zouyee))
+* Use a named array instead of a score array in normalizing-score phase. ([#80901](https://github.com/kubernetes/kubernetes/pull/80901), [@draveness](https://github.com/draveness))
+* If scheduler extender filtered a not found node, current scheduling round for this pod will just be skipped. ([#79641](https://github.com/kubernetes/kubernetes/pull/79641), [@yqwang-ms](https://github.com/yqwang-ms))
+* Update golang/x/net dependency to bring in fixes for CVE-2019-9512, CVE-2019-9514 ([#81394](https://github.com/kubernetes/kubernetes/pull/81394), [@cblecker](https://github.com/cblecker))
+* Fixes CVE-2019-11250: client-go header logging (at verbosity levels >= 7) now masks `Authorization` header contents ([#81330](https://github.com/kubernetes/kubernetes/pull/81330), [@tedyu](https://github.com/tedyu))
+* Resolves a transient 404 response to custom resource requests during server startup ([#81244](https://github.com/kubernetes/kubernetes/pull/81244), [@liggitt](https://github.com/liggitt))
+* Non nil DataSource entries on PVC's are now displayed as part of `describe pvc` output. ([#76463](https://github.com/kubernetes/kubernetes/pull/76463), [@j-griffith](https://github.com/j-griffith))
+* Fix Azure client requests stuck issues on http.StatusTooManyRequests (HTTP Code 429). ([#81279](https://github.com/kubernetes/kubernetes/pull/81279), [@feiskyer](https://github.com/feiskyer))
+* Implement a new feature that allows applying kustomize patches to static pod manifests generated by kubeadm.  ([#80905](https://github.com/kubernetes/kubernetes/pull/80905), [@fabriziopandini](https://github.com/fabriziopandini))
+* Add a service annotation `service.beta.kubernetes.io/azure-pip-name` to specify the public IP name for Azure load balancer. ([#81213](https://github.com/kubernetes/kubernetes/pull/81213), [@nilo19](https://github.com/nilo19))
+* Fix a bug in the IPVS proxier where virtual servers are not cleaned up even though the corresponding Service object was deleted. ([#80942](https://github.com/kubernetes/kubernetes/pull/80942), [@gongguan](https://github.com/gongguan))
+* Add scheduling support for RuntimeClasses. RuntimeClasses can now specify nodeSelector constraints & tolerations, which are merged into the PodSpec for pods using that RuntimeClass. ([#80825](https://github.com/kubernetes/kubernetes/pull/80825), [@tallclair](https://github.com/tallclair))
+* etcd Docker image can be run as non-root ([#79722](https://github.com/kubernetes/kubernetes/pull/79722), [@randomvariable](https://github.com/randomvariable))
+* kubeadm: the permissions of generated CSR files are changed from 0644 to 0600 ([#81217](https://github.com/kubernetes/kubernetes/pull/81217), [@SataQiu](https://github.com/SataQiu))
+* Fix conflicted cache when the requests are canceled by other Azure operations. ([#81282](https://github.com/kubernetes/kubernetes/pull/81282), [@feiskyer](https://github.com/feiskyer))
+* Fix kubelet NodeLease potential performance issues. Kubelet now will try to update lease using cached one instead of get from API Server every time. ([#81174](https://github.com/kubernetes/kubernetes/pull/81174), [@answer1991](https://github.com/answer1991))
+* Improves validation errors for custom resources ([#81212](https://github.com/kubernetes/kubernetes/pull/81212), [@liggitt](https://github.com/liggitt))
+* Improvement in Kube-proxy. Kube-proxy waits for some duration for the node to be defined. ([#77167](https://github.com/kubernetes/kubernetes/pull/77167), [@paulsubrata55](https://github.com/paulsubrata55))
+* hyperkube will drop support for cloud-controller-manager in a future release ([#81219](https://github.com/kubernetes/kubernetes/pull/81219), [@dims](https://github.com/dims))
+* added an new Prometheus counter metric "sync_proxy_rules_iptables_restore_failures_total" for kube-proxy iptables-restore failures (both ipvs and iptables modes) ([#81210](https://github.com/kubernetes/kubernetes/pull/81210), [@figo](https://github.com/figo))
+* Add a `Patch` method to `ScaleInterface` ([#80699](https://github.com/kubernetes/kubernetes/pull/80699), [@knight42](https://github.com/knight42))
+* switch to VM Update call in attach/detach disk operation, original CreateOrUpdate call may lead to orphaned VMs or blocked resources ([#81208](https://github.com/kubernetes/kubernetes/pull/81208), [@andyzhangx](https://github.com/andyzhangx))
+* Add a azure cloud configuration `LoadBalancerName` and `LoadBalancerResourceGroup` to allow the corresponding customizations of azure load balancer. ([#81054](https://github.com/kubernetes/kubernetes/pull/81054), [@nilo19](https://github.com/nilo19))
+* Update the GCE windows node image to include hot fixes since July. ([#81106](https://github.com/kubernetes/kubernetes/pull/81106), [@YangLu1031](https://github.com/YangLu1031))
+* Kubelet considers all static pods as critical. Static pods pass kubelet admission even if a node does not have enough resources. Users must ensure that they account for resources when creating static pods. ([#80491](https://github.com/kubernetes/kubernetes/pull/80491), [@hpandeycodeit](https://github.com/hpandeycodeit))
+* kube-apiserver: the `--basic-auth-file` flag and authentication mode is deprecated and will be removed in a future release. It is not recommended for production environments. ([#81152](https://github.com/kubernetes/kubernetes/pull/81152), [@tedyu](https://github.com/tedyu))
+* Fix a bug that pretty printer marshals empty byte or uint8 slice as null ([#81096](https://github.com/kubernetes/kubernetes/pull/81096), [@roycaihw](https://github.com/roycaihw))
+* Deprecate the `--cloud-provider-gce-lb-src-cidrs` flag in the kube-apiserver. This flag will be removed once the GCE Cloud Provider is removed from kube-apiserver.  ([#81094](https://github.com/kubernetes/kubernetes/pull/81094), [@andrewsykim](https://github.com/andrewsykim))
+* cloud-controller-manager binaries and docker images are no longer shipped with kubernetes releases. ([#81029](https://github.com/kubernetes/kubernetes/pull/81029), [@dims](https://github.com/dims))
+* API: the metadata.selfLink field is deprecated in individual and list objects. It will no longer be returned starting in v1.20, and the field will be removed entirely in v1.21. ([#80978](https://github.com/kubernetes/kubernetes/pull/80978), [@wojtek-t](https://github.com/wojtek-t))
+
+
+
+# v1.16.0-alpha.3
+
+[Documentation](https://docs.k8s.io)
+
+## Downloads for v1.16.0-alpha.3
+
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes.tar.gz](https://dl.k8s.io/v1.16.0-alpha.3/kubernetes.tar.gz) | `82bc119f8d1e44518ab4f4bdefb96158b1a3634c003fe1bc8dcd62410189449fbd6736126409d39a6e2d211a036b4aa98baef3b3c6d9f7505e63430847d127c2`
+[kubernetes-src.tar.gz](https://dl.k8s.io/v1.16.0-alpha.3/kubernetes-src.tar.gz) | `bbf330b887a5839e3d3219f5f4aa38f1c70eab64228077f846da80395193b2b402b60030741de14a9dd4de963662cfe694f6ab04035309e54dc48e6dddd5c05d`
+
+### Client Binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-client-darwin-386.tar.gz](https://dl.k8s.io/v1.16.0-alpha.3/kubernetes-client-darwin-386.tar.gz) | `8d509bdc1ca62463cbb25548ec270792630f6a883f3194e5bdbbb3d6f8568b00f695e39950b7b01713f2f05f206c4d1df1959c6ee80f8a3e390eb94759d344b2`
+[kubernetes-client-darwin-amd64.tar.gz](https://dl.k8s.io/v1.16.0-alpha.3/kubernetes-client-darwin-amd64.tar.gz) | `1b00b3a478c210e3c3e6c346f5c4f7f43a00d5ef6acb8d9c1feaf26f913b9d4f97eb6db99bbf67953ef6399abe4fbb79324973c1744a6a8cd76067cb2aeed2ca`
+[kubernetes-client-linux-386.tar.gz](https://dl.k8s.io/v1.16.0-alpha.3/kubernetes-client-linux-386.tar.gz) | `82424207b4ef52c3722436eaaf86dbe5c93c6670fd09c2b04320251028fd1bb75724b4f490b6e8b443bd8e5f892ab64612cd22206119924dafde424bdee9348a`
+[kubernetes-client-linux-amd64.tar.gz](https://dl.k8s.io/v1.16.0-alpha.3/kubernetes-client-linux-amd64.tar.gz) | `57ba937e58755d3b7dfd19626fedb95718f9c1d44ac1c5b4c8c46d11ba0f8783f3611c7b946b563cac9a3cf104c35ba5605e5e76b48ba2a707d787a7f50f7027`
+[kubernetes-client-linux-arm.tar.gz](https://dl.k8s.io/v1.16.0-alpha.3/kubernetes-client-linux-arm.tar.gz) | `3a3601026e019b299a6f662b887ebe749f08782d7ed0d37a807c38a01c6ba19f23e2837c9fb886053ad6e236a329f58a11ee3ec4ba96a8729905ae78a7f6c58c`
+[kubernetes-client-linux-arm64.tar.gz](https://dl.k8s.io/v1.16.0-alpha.3/kubernetes-client-linux-arm64.tar.gz) | `4cdeb2e678c6b817a04f9f5d92c5c6df88e0f954550961813fca63af4501d04c08e3f4353dd8b6dce96e2ee197a4c688245f03c888417a436b3cf70abd4ba53a`
+[kubernetes-client-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.16.0-alpha.3/kubernetes-client-linux-ppc64le.tar.gz) | `0cc7c8f7b48f5affb679352a94e42d8b4003b9ca6f8cbeaf315d2eceddd2e8446a58ba1d4a0df18e8f9c69d0d3b5a46f25b2e6a916e57975381e504d1a4daa1b`
+[kubernetes-client-linux-s390x.tar.gz](https://dl.k8s.io/v1.16.0-alpha.3/kubernetes-client-linux-s390x.tar.gz) | `9d8fa639f543e707dc65f24ce2f8c73a50c606ec7bc27d17840f45ac150d00b3b3f83de5e3b21f72b598acf08273e4b9a889f199f4ce1b1d239b28659e6cd131`
+[kubernetes-client-windows-386.tar.gz](https://dl.k8s.io/v1.16.0-alpha.3/kubernetes-client-windows-386.tar.gz) | `05bf6e696da680bb8feec4f411f342a9661b6165f4f0c72c069871983f199418c4d4fa1e034136bc8be41c5fecc9934a123906f2d5666c09a876db16ae8c11ad`
+[kubernetes-client-windows-amd64.tar.gz](https://dl.k8s.io/v1.16.0-alpha.3/kubernetes-client-windows-amd64.tar.gz) | `b2097bc851f5d3504e562f68161910098b46c66c726b92b092a040acda965fed01f45e7b9e513a4259c7a5ebd65d7aa3e3b711f4179139a935720d91216ef5c2`
+
+### Server Binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-server-linux-amd64.tar.gz](https://dl.k8s.io/v1.16.0-alpha.3/kubernetes-server-linux-amd64.tar.gz) | `721bd09b64e5c8f220332417089a772d9073c0dc5cdfa240984cfeb0d681b4a02620fb3ebf1b9f6a82a4dd3423f5831c259d4bad502dce87f145e0a08cb73ee9`
+[kubernetes-server-linux-arm.tar.gz](https://dl.k8s.io/v1.16.0-alpha.3/kubernetes-server-linux-arm.tar.gz) | `e7638ce4b88b4282f0a157593cfe809fa9cc9139ea7ebae4762ef5ac1dfaa516903a8acb34a45937eb94b2699e5d4c68c639cbe40cbed2a6b97681aeace9948e`
+[kubernetes-server-linux-arm64.tar.gz](https://dl.k8s.io/v1.16.0-alpha.3/kubernetes-server-linux-arm64.tar.gz) | `395566c4be3c2ca5b07e81221b3370bc7ccbef0879f96a9384650fcaf4f699f3b2744ba1d97ae42cc6c5d9e1a65a41a793a8b0c9e01a0a65f57c56b1420f8141`
+[kubernetes-server-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.16.0-alpha.3/kubernetes-server-linux-ppc64le.tar.gz) | `90fcba066efd76d2f271a0eb26ed4d90483674d04f5e8cc39ec1e5b7f343311f2f1c40de386f35d3c69759628a1c7c075559c09b6c4542e42fbbe0daeb61a5fa`
+[kubernetes-server-linux-s390x.tar.gz](https://dl.k8s.io/v1.16.0-alpha.3/kubernetes-server-linux-s390x.tar.gz) | `b25014bcf4138722a710451f6e58ee57588b4d47fcceeda8f6866073c1cc08641082ec56e94b0c6d586c0835ce9b55d205d254436fc22a744b24d8c74e8e5cce`
+
+### Node Binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-node-linux-amd64.tar.gz](https://dl.k8s.io/v1.16.0-alpha.3/kubernetes-node-linux-amd64.tar.gz) | `6925a71096530f7114a68e755d07cb8ba714bc60b477360c85d76d7b71d3a3c0b78a650877d81aae35b308ded27c8207b5fe72d990abc43db3aa8a7d6d7f94f4`
+[kubernetes-node-linux-arm.tar.gz](https://dl.k8s.io/v1.16.0-alpha.3/kubernetes-node-linux-arm.tar.gz) | `073310e1ccf9a8af998d4c0402ae86bee4f253d2af233b0c45cea55902268c2fe7190a41a990b079e24536e9efa27b94249c3a9236531a166ba3ac06c0f26f92`
+[kubernetes-node-linux-arm64.tar.gz](https://dl.k8s.io/v1.16.0-alpha.3/kubernetes-node-linux-arm64.tar.gz) | `c55e9aecef906e56a6003f441a7d336846edb269aed1c7a31cf834b0730508706e73ea0ae135c1604b0697c9e2582480fbfba8ba105152698c240e324da0cbd2`
+[kubernetes-node-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.16.0-alpha.3/kubernetes-node-linux-ppc64le.tar.gz) | `e89d72d27bb0a7f9133ef7310f455ba2b4c46e9852c43e0a981b68a413bcdd18de7168eb16d93cf87a5ada6a4958592d3be80c9be1e6895fa48e2f7fa70f188d`
+[kubernetes-node-linux-s390x.tar.gz](https://dl.k8s.io/v1.16.0-alpha.3/kubernetes-node-linux-s390x.tar.gz) | `6ef8a25f2f80a806672057dc030654345e87d269babe7cf166f7443e04c0b3a9bc1928cbcf5abef1f0f0fcd37f3a727f789887dbbdae62f9d1fd90a71ed26b39`
+[kubernetes-node-windows-amd64.tar.gz](https://dl.k8s.io/v1.16.0-alpha.3/kubernetes-node-windows-amd64.tar.gz) | `22fd1cea6e0150c06dbdc7249635bbf93c4297565d5a9d13e653f9365cd61a0b8306312efc806d267c47be81621016b114510a269c622cccc916ecff4d10f33c`
+
+## Changelog since v1.16.0-alpha.2
+
+### Action Required
+
+* ACTION REQUIRED: ([#80676](https://github.com/kubernetes/kubernetes/pull/80676), [@fabriziopandini](https://github.com/fabriziopandini))
+    * kubeadm now deletes the bootstrap-kubelet.conf file after TLS bootstrap
+    * User relying on bootstrap-kubelet.conf should switch to kubelet.conf that contains node credentials
+
+### Other notable changes
+
+* Fixes validation of VolumeAttachment API objects created with inline volume sources. ([#80945](https://github.com/kubernetes/kubernetes/pull/80945), [@tedyu](https://github.com/tedyu))
+* Azure disks of shared kind will no longer fail if they do not contain skuname or  ([#80837](https://github.com/kubernetes/kubernetes/pull/80837), [@rmweir](https://github.com/rmweir))
+    *     storageaccounttype.
+* kubeadm: fix "certificate-authority" files not being pre-loaded when using file discovery ([#80966](https://github.com/kubernetes/kubernetes/pull/80966), [@neolit123](https://github.com/neolit123))
+* Errors from pod volume set up are now propagated as pod events. ([#80369](https://github.com/kubernetes/kubernetes/pull/80369), [@jsafrane](https://github.com/jsafrane))
+* kubeadm: enable secure serving for the kube-scheduler ([#80951](https://github.com/kubernetes/kubernetes/pull/80951), [@neolit123](https://github.com/neolit123))
+* Kubernetes client users may disable automatic compression when invoking Kubernetes APIs by setting the `DisableCompression` field on their rest.Config.  This is recommended when clients communicate primarily over high bandwidth / low latency networks where response compression does not improve end to end latency. ([#80919](https://github.com/kubernetes/kubernetes/pull/80919), [@smarterclayton](https://github.com/smarterclayton))
+* kubectl get did not correctly count the number of binaryData keys when listing config maps. ([#80827](https://github.com/kubernetes/kubernetes/pull/80827), [@smarterclayton](https://github.com/smarterclayton))
+* Implement "post-filter" extension point for scheduling framework ([#78097](https://github.com/kubernetes/kubernetes/pull/78097), [@draveness](https://github.com/draveness))
+* Reduces GCE PD Node Attach Limits by 1 since the node boot disk is considered an attachable disk ([#80923](https://github.com/kubernetes/kubernetes/pull/80923), [@davidz627](https://github.com/davidz627))
+* This PR fixes an error when using external etcd but storing etcd certificates in the same folder and with the same name used by kubeadm for local etcd certificates; for an older version of kubeadm, the workaround is to avoid file name used by kubeadm for local etcd. ([#80867](https://github.com/kubernetes/kubernetes/pull/80867), [@fabriziopandini](https://github.com/fabriziopandini))
+* When specifying `--(kube|system)-reserved-cgroup`, with `--cgroup-driver=systemd`, it is now possible to use the fully qualified cgroupfs name (i.e. `/test-cgroup.slice`). ([#78793](https://github.com/kubernetes/kubernetes/pull/78793), [@mattjmcnaughton](https://github.com/mattjmcnaughton))
+* kubeadm: treat non-fatal errors as warnings when doing reset ([#80862](https://github.com/kubernetes/kubernetes/pull/80862), [@drpaneas](https://github.com/drpaneas))
+* kube-addon-manager has been updated to v9.0.2 to fix a bug in leader election (https://github.com/kubernetes/kubernetes/pull/80575) ([#80861](https://github.com/kubernetes/kubernetes/pull/80861), [@mborsz](https://github.com/mborsz))
+* Determine system model to get credentials for windows nodes. ([#80764](https://github.com/kubernetes/kubernetes/pull/80764), [@liyanhui1228](https://github.com/liyanhui1228))
+* TBD ([#80730](https://github.com/kubernetes/kubernetes/pull/80730), [@jennybuckley](https://github.com/jennybuckley))
+* The `AdmissionReview` API sent to and received from admission webhooks has been promoted to `admission.k8s.io/v1`. Webhooks can specify a preference for receiving `v1` AdmissionReview objects with `admissionReviewVersions: ["v1","v1beta1"]`, and must respond with an API object in the same `apiVersion` they are sent. When webhooks use `admission.k8s.io/v1`, the following additional validation is performed on their responses: ([#80231](https://github.com/kubernetes/kubernetes/pull/80231), [@liggitt](https://github.com/liggitt))
+        * `response.patch` and `response.patchType` are not permitted from validating admission webhooks
+        * `apiVersion: "admission.k8s.io/v1"` is required
+        * `kind: "AdmissionReview"` is required
+        * `response.uid: "<value of request.uid>"` is required
+        * `response.patchType: "JSONPatch"` is required (if `response.patch` is set)
+* "kubeadm join" fails if file-based discovery is too long, with a default timeout of 5 minutes. ([#80804](https://github.com/kubernetes/kubernetes/pull/80804), [@olivierlemasle](https://github.com/olivierlemasle))
+* enhance Azure cloud provider code to support both AAD and ADFS authentication. ([#80841](https://github.com/kubernetes/kubernetes/pull/80841), [@rjaini](https://github.com/rjaini))
+* Attempt to set the kubelet's hostname & internal IP if `--cloud-provider=external` and no node addresses exists ([#75229](https://github.com/kubernetes/kubernetes/pull/75229), [@andrewsykim](https://github.com/andrewsykim))
+* kubeadm: avoid double deletion of the upgrade prepull DaemonSet ([#80798](https://github.com/kubernetes/kubernetes/pull/80798), [@xlgao-zju](https://github.com/xlgao-zju))
+* Fixes problems with connecting to services on localhost on some systems; in particular, DNS queries to systemd-resolved on Ubuntu. ([#80591](https://github.com/kubernetes/kubernetes/pull/80591), [@danwinship](https://github.com/danwinship))
+* Implement normalize plugin extension point for the scheduler framework. ([#80383](https://github.com/kubernetes/kubernetes/pull/80383), [@liu-cong](https://github.com/liu-cong))
+* Fixed the bash completion error with override flags. ([#80802](https://github.com/kubernetes/kubernetes/pull/80802), [@dtaniwaki](https://github.com/dtaniwaki))
+* Fix CVE-2019-11247: API server allows access to custom resources via wrong scope ([#80750](https://github.com/kubernetes/kubernetes/pull/80750), [@sttts](https://github.com/sttts))
+* Failed iscsi logout is now re-tried periodically. ([#78941](https://github.com/kubernetes/kubernetes/pull/78941), [@jsafrane](https://github.com/jsafrane))
+* Fix public IP not found issues for VMSS nodes ([#80703](https://github.com/kubernetes/kubernetes/pull/80703), [@feiskyer](https://github.com/feiskyer))
+* In order to enable dual-stack support within kubeadm and kubernetes components, as part of the init config file, the user should set feature-gate IPv6DualStack=true in the ClusterConfiguration. Additionally, for each worker node, the user should set the feature-gate for kubelet using either nodeRegistration.kubeletExtraArgs or  KUBELET_EXTRA_ARGS. ([#80531](https://github.com/kubernetes/kubernetes/pull/80531), [@Arvinderpal](https://github.com/Arvinderpal))
+* Fix error in `kubeadm join --discovery-file` when using discovery files with embedded credentials ([#80675](https://github.com/kubernetes/kubernetes/pull/80675), [@fabriziopandini](https://github.com/fabriziopandini))
+
+
+
+# v1.16.0-alpha.2
+
+[Documentation](https://docs.k8s.io)
+
+## Downloads for v1.16.0-alpha.2
+
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes.tar.gz](https://dl.k8s.io/v1.16.0-alpha.2/kubernetes.tar.gz) | `7dfa3f8b9e98e528e2b49ed9cca5e95f265b9e102faac636ff0c29e045689145be236b98406a62eb0385154dc0c1233cac049806c99c9e46590cad5aa729183f`
+[kubernetes-src.tar.gz](https://dl.k8s.io/v1.16.0-alpha.2/kubernetes-src.tar.gz) | `7cf14b92c96cab5fcda3115ec66b44562ca26ea6aa46bc7fa614fa66bda1bdf9ac1f3c94ef0dfa0e37c992c7187ecf4205b253f37f280857e88a318f8479c9a9`
+
+### Client Binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-client-darwin-386.tar.gz](https://dl.k8s.io/v1.16.0-alpha.2/kubernetes-client-darwin-386.tar.gz) | `4871756de2cd1add0b07ec1e577c500d18a59e2f761595b939e1d4e10fbe0a119479ecaaf53d75cb2138363deae23cc88cba24fe3018cec6a27a3182f37cae92`
+[kubernetes-client-darwin-amd64.tar.gz](https://dl.k8s.io/v1.16.0-alpha.2/kubernetes-client-darwin-amd64.tar.gz) | `dbd9ca5fd90652ffc1606f50029d711eb52d34b707b7c04f29201f85aa8a5081923a53585513634f3adb6ace2bc59be9d4ad2abc49fdc3790ef805378c111e68`
+[kubernetes-client-linux-386.tar.gz](https://dl.k8s.io/v1.16.0-alpha.2/kubernetes-client-linux-386.tar.gz) | `6b049098b1dc65416c5dcc30346b82e5cf69a1cdd7e7b065429a76d302ef4b2a1c8e2dc621e9d5c1a6395a1fbd97f196d99404810880d118576e7b94e5621e4c`
+[kubernetes-client-linux-amd64.tar.gz](https://dl.k8s.io/v1.16.0-alpha.2/kubernetes-client-linux-amd64.tar.gz) | `7240a9d49e445e9fb0c9d360a9287933c6c6e7d81d6e11b0d645d3f9b6f3f1372cc343f03d10026518df5d6c95525e84c41b06a034c9ec2c9e306323dbd9325b`
+[kubernetes-client-linux-arm.tar.gz](https://dl.k8s.io/v1.16.0-alpha.2/kubernetes-client-linux-arm.tar.gz) | `947b0d9aeeef08961c0582b4c3c94b7ae1016d20b0c9f50af5fe760b3573f17497059511bcb57ac971a5bdadeb5c77dfd639d5745042ecc67541dd702ee7c657`
+[kubernetes-client-linux-arm64.tar.gz](https://dl.k8s.io/v1.16.0-alpha.2/kubernetes-client-linux-arm64.tar.gz) | `aff0258a223f5061552d340cda36872e3cd7017368117bbb14dc0f8a3a4db8c715c11743bedd72189cd43082aa9ac1ced64a6337c2f174bdcbeef094b47e76b0`
+[kubernetes-client-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.16.0-alpha.2/kubernetes-client-linux-ppc64le.tar.gz) | `3eabecd62290ae8d876ae45333777b2c9959e39461197dbe90e6ba07d0a4c50328cbdf44e77d2bd626e435ffc69593d0e8b807b36601c19dd1a1ef17e6810b4f`
+[kubernetes-client-linux-s390x.tar.gz](https://dl.k8s.io/v1.16.0-alpha.2/kubernetes-client-linux-s390x.tar.gz) | `6651b2d95d0a8dd748c33c9e8018ab606b4061956cc2b6775bd0b008b04ea33df27be819ce6c391ceb2191b53acbbc088d602ed2d86bdd7a3a3fc1c8f876798a`
+[kubernetes-client-windows-386.tar.gz](https://dl.k8s.io/v1.16.0-alpha.2/kubernetes-client-windows-386.tar.gz) | `4b6c11b7a318e5fcac19144f6ab1638126c299e08c7b908495591674abcf4c7dd16f63c74c7d901beff24006150d2a31e0f75e28a9e14d6d0d88a09dafb014f0`
+[kubernetes-client-windows-amd64.tar.gz](https://dl.k8s.io/v1.16.0-alpha.2/kubernetes-client-windows-amd64.tar.gz) | `760ae08da6045ae7089fb27a9324e77bed907662659364857e1a8d103d19ba50e80544d8c21a086738b15baebfd9a5fa78d63638eff7bbe725436c054ba649cc`
+
+### Server Binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-server-linux-amd64.tar.gz](https://dl.k8s.io/v1.16.0-alpha.2/kubernetes-server-linux-amd64.tar.gz) | `69db41f3d79aa0581c36a3736ab8dc96c92127b82d3cf25c5effc675758fe713ca7aa7e5b414914f1bc73187c6cee5f76d76b74a2ee1c0e7fa61557328f1b8ef`
+[kubernetes-server-linux-arm.tar.gz](https://dl.k8s.io/v1.16.0-alpha.2/kubernetes-server-linux-arm.tar.gz) | `ca302f53ee91ab4feb697bb34d360d0872a7abea59c5f28cceefe9237a914c77d68722b85743998ab12bf8e42005e63a1d1a441859c2426c1a8d745dd33f4276`
+[kubernetes-server-linux-arm64.tar.gz](https://dl.k8s.io/v1.16.0-alpha.2/kubernetes-server-linux-arm64.tar.gz) | `79ab1f0a542ce576ea6d81cd2a7c068da6674177b72f1b5f5e3ca47edfdb228f533683a073857b6bc53225a230d15d3ba4b0cb9b6d5d78a309aa6e24c2f6c500`
+[kubernetes-server-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.16.0-alpha.2/kubernetes-server-linux-ppc64le.tar.gz) | `fbe5b45326f1d03bcdd9ffd46ab454917d79f629ba23dae9d667d0c7741bc2f5db2960bf3c989bb75c19c9dc1609dacbb8a6dc9a440e5b192648e70db7f68721`
+[kubernetes-server-linux-s390x.tar.gz](https://dl.k8s.io/v1.16.0-alpha.2/kubernetes-server-linux-s390x.tar.gz) | `eb13ac306793679a3a489136bb7eb6588472688b2bb2aa0e54e61647d8c9da6d3589c19e7ac434c24defa78cb65f7b72593eedec1e7431c7ecae872298efc4de`
+
+### Node Binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-node-linux-amd64.tar.gz](https://dl.k8s.io/v1.16.0-alpha.2/kubernetes-node-linux-amd64.tar.gz) | `a4bde88f3e0f6233d04f04d380d5f612cd3c574bd66b9f3ee531fa76e3e0f1c6597edbc9fa61251a377e8230bce0ce6dc1cf57fd19080bb7d13f14a391b27fe8`
+[kubernetes-node-linux-arm.tar.gz](https://dl.k8s.io/v1.16.0-alpha.2/kubernetes-node-linux-arm.tar.gz) | `7d72aa8c1d883b9f047e5b98dbb662bdfd314f9c06af4213068381ffaac116e68d1aad76327ead7a4fd97976ea72277cebcf765c56b265334cb3a02c83972ec1`
+[kubernetes-node-linux-arm64.tar.gz](https://dl.k8s.io/v1.16.0-alpha.2/kubernetes-node-linux-arm64.tar.gz) | `c9380bb59ba26dcfe1ab52b5cb02e2d920313defda09ec7d19ccbc18f54def4b57cf941ac8a397392beb5836fdc12bc9600d4055f2cfd1319896cfc9631cab10`
+[kubernetes-node-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.16.0-alpha.2/kubernetes-node-linux-ppc64le.tar.gz) | `7bcd79b368a62c24465fce7dcb024bb629eae034e09fb522fb43bb5798478ca2660a3ccc596b424325c6f69e675468900f3b41f3924e7ff453e3db40150b3c16`
+[kubernetes-node-linux-s390x.tar.gz](https://dl.k8s.io/v1.16.0-alpha.2/kubernetes-node-linux-s390x.tar.gz) | `9bda9dd24ee5ca65aaefece4213b46ef57cde4904542d94e6147542e42766f8b80fe24d99a6b8711bd7dbe00c415169a9f258f433c5f5345c2e17c2bb82f2670`
+[kubernetes-node-windows-amd64.tar.gz](https://dl.k8s.io/v1.16.0-alpha.2/kubernetes-node-windows-amd64.tar.gz) | `d5906f229d2d8e99bdb37e7d155d54560b82ea28ce881c5a0cde8f8d20bff8fd2e82ea4b289ae3e58616d3ec8c23ac9b473cb714892a377feb87ecbce156147d`
+
+## Changelog since v1.16.0-alpha.1
+
+### Action Required
+
+* Revert "scheduler.alpha.kubernetes.io/critical-pod annotation is removed. Pod priority (spec.priorityClassName) should be used instead to mark pods as critical. Action required!" ([#80277](https://github.com/kubernetes/kubernetes/pull/80277), [@draveness](https://github.com/draveness))
+* ACTION REQUIRED: container images tar files for 'amd64' will now contain the architecture in the RepoTags manifest.json section. ([#80266](https://github.com/kubernetes/kubernetes/pull/80266), [@javier-b-perez](https://github.com/javier-b-perez))
+    * If you are using docker manifests there are not visible changes.
+
+### Other notable changes
+
+* Use HTTPS as etcd-apiserver protocol when mTLS between etcd and kube-apiserver on master is enabled, change etcd metrics/health port to 2382. ([#77561](https://github.com/kubernetes/kubernetes/pull/77561), [@wenjiaswe](https://github.com/wenjiaswe))
+* kubelet: change node-lease-renew-interval to 0.25 of lease-renew-duration ([#80429](https://github.com/kubernetes/kubernetes/pull/80429), [@gaorong](https://github.com/gaorong))
+* Fix error handling and potential go null pointer exception in kubeadm upgrade diff ([#80648](https://github.com/kubernetes/kubernetes/pull/80648), [@odinuge](https://github.com/odinuge))
+* New flag --endpoint-updates-batch-period in kube-controller-manager can be used to reduce number of endpoints updates generated by pod changes. ([#80509](https://github.com/kubernetes/kubernetes/pull/80509), [@mborsz](https://github.com/mborsz))
+* kubeadm: produce errors if they occur when resetting cluster status for a control-plane node ([#80573](https://github.com/kubernetes/kubernetes/pull/80573), [@bart0sh](https://github.com/bart0sh))
+* When a load balancer type service is created in a k8s cluster that is backed by Azure Standard Load Balancer, the corresponding load balancer rule added in the Azure Standard Load Balancer would now have the "EnableTcpReset" property set to true.  ([#80624](https://github.com/kubernetes/kubernetes/pull/80624), [@xuto2](https://github.com/xuto2))
+* Update portworx plugin dependency on libopenstorage/openstorage to v1.0.0 ([#80495](https://github.com/kubernetes/kubernetes/pull/80495), [@adityadani](https://github.com/adityadani))
+* Fixed detachment of deleted volumes on OpenStack / Cinder. ([#80518](https://github.com/kubernetes/kubernetes/pull/80518), [@jsafrane](https://github.com/jsafrane))
+* when PodInfoOnMount is enabled for a CSI driver, the new csi.storage.k8s.io/ephemeral parameter in the volume context allows a driver's NodePublishVolume implementation to determine on a case-by-case basis whether the volume is ephemeral or a normal persistent volume ([#79983](https://github.com/kubernetes/kubernetes/pull/79983), [@pohly](https://github.com/pohly))
+* Update gogo/protobuf to serialize backward, as to get better performance on deep objects. ([#77355](https://github.com/kubernetes/kubernetes/pull/77355), [@apelisse](https://github.com/apelisse))
+* Remove GetReference() and GetPartialReference() function from pkg/api/ref, as the same function exists also in staging/src/k8s.io/client-go/tools/ref ([#80361](https://github.com/kubernetes/kubernetes/pull/80361), [@wojtek-t](https://github.com/wojtek-t))
+* Fixed a bug in the CSI metrics that does not return not supported error when a CSI driver does not support metrics. ([#79851](https://github.com/kubernetes/kubernetes/pull/79851), [@jparklab](https://github.com/jparklab))
+* Fixed a bug in kube-addon-manager's leader election logic that made all replicas active. ([#80575](https://github.com/kubernetes/kubernetes/pull/80575), [@mborsz](https://github.com/mborsz))
+* Kibana has been slightly revamped/improved in the latest version ([#80421](https://github.com/kubernetes/kubernetes/pull/80421), [@lostick](https://github.com/lostick))
+* kubeadm: fixed ignoring errors when pulling control plane images ([#80529](https://github.com/kubernetes/kubernetes/pull/80529), [@bart0sh](https://github.com/bart0sh))
+* CRDs under k8s.io and kubernetes.io must have the "api-approved.kubernetes.io" set to either `unapproved.*` or a link to the pull request approving the schema.  See https://github.com/kubernetes/enhancements/pull/1111 for more details. ([#79992](https://github.com/kubernetes/kubernetes/pull/79992), [@deads2k](https://github.com/deads2k))
+* Reduce kube-proxy cpu usage in IPVS mode when a large number of nodePort services exist. ([#79444](https://github.com/kubernetes/kubernetes/pull/79444), [@cezarsa](https://github.com/cezarsa))
+* Add CSI Migration Shim for VerifyVolumesAreAttached and BulkVolumeVerify ([#80443](https://github.com/kubernetes/kubernetes/pull/80443), [@davidz627](https://github.com/davidz627))
+* Fix a bug that causes DaemonSet rolling update hang when there exist failed pods.  ([#78170](https://github.com/kubernetes/kubernetes/pull/78170), [@DaiHao](https://github.com/DaiHao))
+* Fix retry issues when the nodes are under deleting on Azure ([#80419](https://github.com/kubernetes/kubernetes/pull/80419), [@feiskyer](https://github.com/feiskyer))
+* Add support for AWS EBS on windows ([#79552](https://github.com/kubernetes/kubernetes/pull/79552), [@wongma7](https://github.com/wongma7))
+* Passing an invalid policy name in the `--cpu-manager-policy` flag will now cause the kubelet to fail instead of simply ignoring the flag and running the `cpumanager`s default policy instead. ([#80294](https://github.com/kubernetes/kubernetes/pull/80294), [@klueska](https://github.com/klueska))
+* Add Filter extension point to the scheduling framework. ([#78477](https://github.com/kubernetes/kubernetes/pull/78477), [@YoubingLi](https://github.com/YoubingLi))
+* cpuUsageNanoCores is now reported in the Kubelet summary API on Windows nodes ([#80176](https://github.com/kubernetes/kubernetes/pull/80176), [@liyanhui1228](https://github.com/liyanhui1228))
+* `[]TopologySpreadConstraint` is introduced into PodSpec to support the "Even Pods Spread" alpha feature. ([#77327](https://github.com/kubernetes/kubernetes/pull/77327), [@Huang-Wei](https://github.com/Huang-Wei))
+* kubeadm: fall back to client version in case of certain HTTP errors ([#80024](https://github.com/kubernetes/kubernetes/pull/80024), [@RainbowMango](https://github.com/RainbowMango))
+* NFS Drivers are now enabled to collect metrics, StatFS metrics provider is used to collect the metrics. ([#75805](https://github.com/kubernetes/kubernetes/pull/75805) , [@brahmaroutu](https://github.com/brahmaroutu)) ([#75805](https://github.com/kubernetes/kubernetes/pull/75805), [@brahmaroutu](https://github.com/brahmaroutu))
+* make node lease renew interval more heuristic based on node-status-update-frequency in kubelet ([#80173](https://github.com/kubernetes/kubernetes/pull/80173), [@gaorong](https://github.com/gaorong))
+* Introduction of the pod overhead feature to the scheduler.  This functionality is alpha-level as of  ([#78319](https://github.com/kubernetes/kubernetes/pull/78319), [@egernst](https://github.com/egernst))
+    * Kubernetes v1.16, and is only honored by servers that enable the PodOverhead feature.gate.
+* N/A ([#80260](https://github.com/kubernetes/kubernetes/pull/80260), [@khenidak](https://github.com/khenidak))
+* Add v1.Container.SecurityContext.WindowsOptions.RunAsUserName to the pod spec  ([#79489](https://github.com/kubernetes/kubernetes/pull/79489), [@bclau](https://github.com/bclau))
+* Pass-through volume MountOptions to global mount (NodeStageVolume) on the node for CSI ([#80191](https://github.com/kubernetes/kubernetes/pull/80191), [@davidz627](https://github.com/davidz627))
+* Add Score extension point to the scheduling framework. ([#79109](https://github.com/kubernetes/kubernetes/pull/79109), [@ahg-g](https://github.com/ahg-g))
+
+
+
+# v1.16.0-alpha.1
+
+[Documentation](https://docs.k8s.io)
+
+## Downloads for v1.16.0-alpha.1
+
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes.tar.gz](https://dl.k8s.io/v1.16.0-alpha.1/kubernetes.tar.gz) | `4834c52267414000fa93c0626bded5a969cf65d3d4681c20e5ae2c5f62002a51dfb8ee869484f141b147990915ba57be96108227f86c4e9f571b4b25e7ed0773`
+[kubernetes-src.tar.gz](https://dl.k8s.io/v1.16.0-alpha.1/kubernetes-src.tar.gz) | `9329d51f5c73f830f3c895c2601bc78e51d2d412b928c9dae902e9ba8d46338f246a79329a27e4248ec81410ff103510ba9b605bb03e08a48414b2935d2c164b`
+
+### Client Binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-client-darwin-386.tar.gz](https://dl.k8s.io/v1.16.0-alpha.1/kubernetes-client-darwin-386.tar.gz) | `3cedffb92a0fca4f0b2d41f8b09baa59dff58df96446e8eece4e1b81022d9fdda8da41b5f73a3468435474721f03cffc6e7beabb25216b089a991b68366c73bc`
+[kubernetes-client-darwin-amd64.tar.gz](https://dl.k8s.io/v1.16.0-alpha.1/kubernetes-client-darwin-amd64.tar.gz) | `14de6bb296b4d022f50778b160c98db3508c9c7230946e2af4eb2a1d662d45b86690e9e04bf3e592ec094e12bed1f2bb74cd59d769a0eaac3c81d9b80e0a79c8`
+[kubernetes-client-linux-386.tar.gz](https://dl.k8s.io/v1.16.0-alpha.1/kubernetes-client-linux-386.tar.gz) | `8b2b9fa55890895239b99fabb866babe50aca599591db1ecf9429e49925ae478b7c813b9d7704a20f41f2d50947c3b3deecb594544f1f3eae6c4e97ae9bb9b70`
+[kubernetes-client-linux-amd64.tar.gz](https://dl.k8s.io/v1.16.0-alpha.1/kubernetes-client-linux-amd64.tar.gz) | `e927ac7b314777267b95e0871dd70c352ec0fc967ba221cb6cba523fa6f18d9d193e4ce92a1f9fa669f9c961de0e34d69e770ef745199ed3693647dd0d692e57`
+[kubernetes-client-linux-arm.tar.gz](https://dl.k8s.io/v1.16.0-alpha.1/kubernetes-client-linux-arm.tar.gz) | `4a230a6d34e2ffd7df40c5b726fbcbb7ef1373d81733bfb75685b2448ed181eb49ef27668fc33700f30de88e5bbdcc1e52649b9d31c7940760f48c6e6eb2f403`
+[kubernetes-client-linux-arm64.tar.gz](https://dl.k8s.io/v1.16.0-alpha.1/kubernetes-client-linux-arm64.tar.gz) | `87c8d7185df23b3496ceb74606558d895a64daf0c41185c833a233e29216131baac6e356a57bb78293ed9d0396966ecc3b00789f2b66af352dc286b101bcc69a`
+[kubernetes-client-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.16.0-alpha.1/kubernetes-client-linux-ppc64le.tar.gz) | `16ea5efa2fc29bc7448a609a7118e7994e901ab26462aac52f03b4851d4c9d103ee12d2335360f8aa503ddbb2a71f3000f0fcb33597dd813df4f5ad5f4819fa9`
+[kubernetes-client-linux-s390x.tar.gz](https://dl.k8s.io/v1.16.0-alpha.1/kubernetes-client-linux-s390x.tar.gz) | `7390ad1682227a70550b20425fa5287fecf6a5d413493b03df3a7795614263e7883f30f3078bbb9fbd389d2a1dab073f8f401be89b82bd5861fa6b0aeda579eb`
+[kubernetes-client-windows-386.tar.gz](https://dl.k8s.io/v1.16.0-alpha.1/kubernetes-client-windows-386.tar.gz) | `88251896dfe38e59699b879f643704c0195e7a5af2cb00078886545f49364a2e3b497590781f135b80d60e256bad3a4ea197211f4f061c98dee096f0845e7a9b`
+[kubernetes-client-windows-amd64.tar.gz](https://dl.k8s.io/v1.16.0-alpha.1/kubernetes-client-windows-amd64.tar.gz) | `766b2a9bf097e45b2549536682cf25129110bd0562ab0df70e841ff8657dd7033119b0929e7a213454f90594b19b90fa57d89918cee33ceadba7d689449fe333`
+
+### Server Binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-server-linux-amd64.tar.gz](https://dl.k8s.io/v1.16.0-alpha.1/kubernetes-server-linux-amd64.tar.gz) | `dfd5c2609990c9b9b94249c654931b240dc072f2cc303e1e1d6dec1fddfb0a9e127e3898421ace00ab1947a3ad2f87cfd1266fd0b6193ef00f942269388ef372`
+[kubernetes-server-linux-arm.tar.gz](https://dl.k8s.io/v1.16.0-alpha.1/kubernetes-server-linux-arm.tar.gz) | `7704c2d3c57950f184322263ac2be1649a0d737d176e7fed1897031d0efb8375805b5f12c7cf9ba87ac06ad8a635d6e399382d99f3cbb418961a4f0901465f50`
+[kubernetes-server-linux-arm64.tar.gz](https://dl.k8s.io/v1.16.0-alpha.1/kubernetes-server-linux-arm64.tar.gz) | `fbbd87cc38cfb6429e3741bfd87ecec4b69b551df6fb7c121900ced4c1cd0bc77a317ca8abd41f71ffd7bc0b1c7144fecb22fa405d0b211b238df24d28599333`
+[kubernetes-server-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.16.0-alpha.1/kubernetes-server-linux-ppc64le.tar.gz) | `cfed5b936eb2fe44df5d0c9c6484bee38ef370fb1258522e8c62fb6a526e9440c1dc768d8bf33403451ae00519cab1450444da854fd6c6a37665ce925c4e7d69`
+[kubernetes-server-linux-s390x.tar.gz](https://dl.k8s.io/v1.16.0-alpha.1/kubernetes-server-linux-s390x.tar.gz) | `317681141734347260ad9f918fa4b67e48751f5a7df64a848d2a83c79a4e9dba269c51804b09444463ba88a2c0efa1c307795cd8f06ed840964eb2c725a4ecc3`
+
+### Node Binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-node-linux-amd64.tar.gz](https://dl.k8s.io/v1.16.0-alpha.1/kubernetes-node-linux-amd64.tar.gz) | `b3b1013453d35251b8fc4759f6ac26bdeb37f14a98697078535f7f902e8ebca581b5629bbb4493188a7e6077eb5afc61cf275f42bf4d9f503b70bfc58b9730b2`
+[kubernetes-node-linux-arm.tar.gz](https://dl.k8s.io/v1.16.0-alpha.1/kubernetes-node-linux-arm.tar.gz) | `0bacc1791d260d2863ab768b48daf66f0f7f89eeee70e68dd515b05fc9d7f14b466382fe16fa84a103e0023324f681767489d9485560baf9eb80fe0e7ffab503`
+[kubernetes-node-linux-arm64.tar.gz](https://dl.k8s.io/v1.16.0-alpha.1/kubernetes-node-linux-arm64.tar.gz) | `73bd70cb9d27ce424828a95d715c16fd9dd22396dbe1dfe721eb0aea9e186ec46e6978956613b0978a8da3c22df39790739b038991c0192281881fce41d7c9f1`
+[kubernetes-node-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.16.0-alpha.1/kubernetes-node-linux-ppc64le.tar.gz) | `a865f98838143dc7e1e12d1e258e5f5f2855fcf6e88488fb164ad62cf886d8e2a47fdf186ad6b55172f73826ae19da9b2642b9a0df0fa08f9351a66aeef3cf17`
+[kubernetes-node-linux-s390x.tar.gz](https://dl.k8s.io/v1.16.0-alpha.1/kubernetes-node-linux-s390x.tar.gz) | `d2f9f746ed0fe00be982a847a3ae1b6a698d5c506be1d3171156902140fec64642ec6d99aa68de08bdc7d65c9a35ac2c36bda53c4db873cb8e7edc419a4ab958`
+[kubernetes-node-windows-amd64.tar.gz](https://dl.k8s.io/v1.16.0-alpha.1/kubernetes-node-windows-amd64.tar.gz) | `37f48a6d8174f38668bc41c81222615942bfe07e01f319bdfed409f83a3de3773dceb09fd86330018bb05f830e165e7bd85b3d23d26a50227895e4ec07f8ab98`
+
+## Changelog since v1.15.0
+
+### Action Required
+
+* Migrate scheduler to use v1beta1 Event API. action required: any tool targeting scheduler events needs to use v1beta1 Event API ([#78447](https://github.com/kubernetes/kubernetes/pull/78447), [@yastij](https://github.com/yastij))
+* scheduler.alpha.kubernetes.io/critical-pod annotation is removed. Pod priority (spec.priorityClassName) should be used instead to mark pods as critical. Action required! ([#79554](https://github.com/kubernetes/kubernetes/pull/79554), [@draveness](https://github.com/draveness))
+* hyperkube: the `--make-symlinks` flag, deprecated in v1.14, has been removed. ([#80017](https://github.com/kubernetes/kubernetes/pull/80017), [@Pothulapati](https://github.com/Pothulapati))
+* Node labels `beta.kubernetes.io/metadata-proxy-ready`, `beta.kubernetes.io/metadata-proxy-ready` and `beta.kubernetes.io/kube-proxy-ds-ready` are no longer added on new nodes. ([#79305](https://github.com/kubernetes/kubernetes/pull/79305), [@paivagustavo](https://github.com/paivagustavo))
+        * ip-mask-agent addon starts to use the label `node.kubernetes.io/masq-agent-ds-ready` instead of `beta.kubernetes.io/masq-agent-ds-ready` as its node selector.
+        * kube-proxy addon starts to use the label `node.kubernetes.io/kube-proxy-ds-ready` instead of `beta.kubernetes.io/kube-proxy-ds-ready` as its node selector.
+        * metadata-proxy addon starts to use the label `cloud.google.com/metadata-proxy-ready` instead of `beta.kubernetes.io/metadata-proxy-ready` as its node selector.
+        * Kubelet removes the ability to set `kubernetes.io` or `k8s.io` labels via --node-labels other than the [specifically allowed labels/prefixes](https://github.com/kubernetes/enhancements/blob/master/keps/sig-auth/0000-20170814-bounding-self-labeling-kubelets.md#proposal).
+* The following APIs are no longer served by default: ([#70672](https://github.com/kubernetes/kubernetes/pull/70672), [@liggitt](https://github.com/liggitt))
+        * All resources under `apps/v1beta1` and `apps/v1beta2` - use `apps/v1` instead
+        * `daemonsets`, `deployments`, `replicasets` resources under `extensions/v1beta1` - use `apps/v1` instead
+        * `networkpolicies` resources under `extensions/v1beta1` - use `networking.k8s.io/v1` instead
+        * `podsecuritypolicies` resources under `extensions/v1beta1` - use `policy/v1beta1` instead
+    * Serving these resources can be temporarily re-enabled using the `--runtime-config` apiserver flag.
+        * `apps/v1beta1=true`
+        * `apps/v1beta2=true`
+        * `extensions/v1beta1/daemonsets=true,extensions/v1beta1/deployments=true,extensions/v1beta1/replicasets=true,extensions/v1beta1/networkpolicies=true,extensions/v1beta1/podsecuritypolicies=true`
+    * The ability to serve these resources will be completely removed in v1.18.
+* ACTION REQUIRED: Removed deprecated flag `--resource-container` from kube-proxy. ([#78294](https://github.com/kubernetes/kubernetes/pull/78294), [@vllry](https://github.com/vllry))
+    * The deprecated `--resource-container` flag has been removed from kube-proxy, and specifying it will now cause an error.  The behavior is now as if you specified `--resource-container=""`.  If you previously specified a non-empty `--resource-container`, you can no longer do so as of kubernetes 1.16.
+
+### Other notable changes
+
+* When HPAScaleToZero feature gate is enabled HPA supports scaling to zero pods based on object or external metrics. HPA remains active as long as at least one metric value available. ([#74526](https://github.com/kubernetes/kubernetes/pull/74526), [@DXist](https://github.com/DXist))
+    * To downgrade the cluster to version that does not support scale-to-zero feature:
+    * 1. make sure there are no hpa objects with minReplicas=0. Here is a oneliner to update it to 1:
+    *     $ kubectl get hpa --all-namespaces  --no-headers=true | awk  '{if($6==0) printf "kubectl patch hpa/%s --namespace=%s -p \"{\\"spec\\":{\\"minReplicas\\":1}}\"
+", $2, $1 }' | sh
+    * 2. disable HPAScaleToZero feature gate
+* Add support for writing out of tree custom scheduler plugins. ([#78162](https://github.com/kubernetes/kubernetes/pull/78162), [@hex108](https://github.com/hex108))
+* Remove deprecated github.com/kardianos/osext dependency ([#80142](https://github.com/kubernetes/kubernetes/pull/80142), [@loqutus](https://github.com/loqutus))
+* Add Bind extension point to the scheduling framework. ([#79313](https://github.com/kubernetes/kubernetes/pull/79313), [@chenchun](https://github.com/chenchun))
+* On Windows systems, %USERPROFILE% is now preferred over %HOMEDRIVE%\%HOMEPATH% as the home folder if %HOMEDRIVE%\%HOMEPATH% does not contain a .kube* Add --kubernetes-version to "kubeadm init phase certs ca" and "kubeadm init phase kubeconfig" ([#80115](https://github.com/kubernetes/kubernetes/pull/80115), [@gyuho](https://github.com/gyuho))
+* kubeadm ClusterConfiguration now supports featureGates: IPv6DualStack: true ([#80145](https://github.com/kubernetes/kubernetes/pull/80145), [@Arvinderpal](https://github.com/Arvinderpal))
+* Fix a bug that ListOptions.AllowWatchBookmarks wasn't propagating correctly in kube-apiserver. ([#80157](https://github.com/kubernetes/kubernetes/pull/80157), [@wojtek-t](https://github.com/wojtek-t))
+* Bugfix: csi plugin supporting raw block that does not need attach mounted failed ([#79920](https://github.com/kubernetes/kubernetes/pull/79920), [@cwdsuzhou](https://github.com/cwdsuzhou))
+* Increase log level for graceful termination to v=5 ([#80100](https://github.com/kubernetes/kubernetes/pull/80100), [@andrewsykim](https://github.com/andrewsykim))
+* kubeadm: support fetching configuration from the original cluster for 'upgrade diff' ([#80025](https://github.com/kubernetes/kubernetes/pull/80025), [@SataQiu](https://github.com/SataQiu))
+* The sample-apiserver gains support for OpenAPI v2 spec serving at `/openapi/v2`. ([#79843](https://github.com/kubernetes/kubernetes/pull/79843), [@sttts](https://github.com/sttts))
+    * The `generate-internal-groups.sh` script in k8s.io/code-generator will generate OpenAPI definitions by default in `pkg/generated/openapi`. Additional API group dependencies can be added via `OPENAPI_EXTRA_PACKAGES=<group>/<version> <group2>/<version2>...`.
+* Cinder and ScaleIO volume providers have been deprecated and will be removed in a future release. ([#80099](https://github.com/kubernetes/kubernetes/pull/80099), [@dims](https://github.com/dims))
+* kubelet's --containerized flag was deprecated in 1.14. This flag is removed in 1.16. ([#80043](https://github.com/kubernetes/kubernetes/pull/80043), [@dims](https://github.com/dims))
+* Optimize EC2 DescribeInstances API calls in aws cloud provider library by querying instance ID instead of EC2 filters when possible ([#78140](https://github.com/kubernetes/kubernetes/pull/78140), [@zhan849](https://github.com/zhan849))
+* etcd migration image no longer supports etcd2 version.  ([#80037](https://github.com/kubernetes/kubernetes/pull/80037), [@dims](https://github.com/dims))
+* Promote WatchBookmark feature to beta and enable it by default. ([#79786](https://github.com/kubernetes/kubernetes/pull/79786), [@wojtek-t](https://github.com/wojtek-t))
+    * With WatchBookmark feature, clients are able to request watch events with BOOKMARK type. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session.
+* update to use go 1.12.7 ([#79966](https://github.com/kubernetes/kubernetes/pull/79966), [@tao12345666333](https://github.com/tao12345666333))
+* Add --shutdown-delay-duration to kube-apiserver in order to delay a graceful shutdown. `/healthz` will keep returning success during this time and requests are normally served, but `/readyz` will return faillure immediately. This delay can be used to allow the SDN to update iptables on all nodes and stop sending traffic. ([#74416](https://github.com/kubernetes/kubernetes/pull/74416), [@sttts](https://github.com/sttts))
+* The `MutatingWebhookConfiguration` and `ValidatingWebhookConfiguration` APIs have been promoted to `admissionregistration.k8s.io/v1`: ([#79549](https://github.com/kubernetes/kubernetes/pull/79549), [@liggitt](https://github.com/liggitt))
+        * `failurePolicy` default changed from `Ignore` to `Fail` for v1
+        * `matchPolicy` default changed from `Exact` to `Equivalent` for v1
+        * `timeout` default changed from `30s` to `10s` for v1
+        * `sideEffects` default value is removed and the field made required for v1
+        * `admissionReviewVersions` default value is removed and the field made required for v1 (supported versions for AdmissionReview are `v1` and `v1beta1`)
+        * The `name` field for specified webhooks must be unique for `MutatingWebhookConfiguration` and `ValidatingWebhookConfiguration` objects created via `admissionregistration.k8s.io/v1`
+    * The `admissionregistration.k8s.io/v1beta1` versions of `MutatingWebhookConfiguration` and `ValidatingWebhookConfiguration` are deprecated and will no longer be served in v1.19.
+* The garbage collector and generic object quota controller have been updated to use the metadata client which improves memory ([#78742](https://github.com/kubernetes/kubernetes/pull/78742), [@smarterclayton](https://github.com/smarterclayton))
+    * and CPU usage of the Kube controller manager.
+* SubjectAccessReview requests sent for RBAC escalation, impersonation, and pod security policy authorization checks now populate the version attribute. ([#80007](https://github.com/kubernetes/kubernetes/pull/80007), [@liggitt](https://github.com/liggitt))
+* na ([#79892](https://github.com/kubernetes/kubernetes/pull/79892), [@mikebrow](https://github.com/mikebrow))
+* Use O_CLOEXEC to ensure file descriptors do not leak to subprocesses. ([#74691](https://github.com/kubernetes/kubernetes/pull/74691), [@cpuguy83](https://github.com/cpuguy83))
+* The namespace controller has been updated to use the metadata client which improves memory ([#78744](https://github.com/kubernetes/kubernetes/pull/78744), [@smarterclayton](https://github.com/smarterclayton))
+    * and CPU usage of the Kube controller manager.
+* NONE ([#79933](https://github.com/kubernetes/kubernetes/pull/79933), [@mm4tt](https://github.com/mm4tt))
+* add  `kubectl replace --raw` and `kubectl delete --raw` to have parity with create and get ([#79724](https://github.com/kubernetes/kubernetes/pull/79724), [@deads2k](https://github.com/deads2k))
+* E2E tests no longer add command line flags directly to the command line, test suites that want that need to be updated if they don't use HandleFlags ([#75593](https://github.com/kubernetes/kubernetes/pull/75593), [@pohly](https://github.com/pohly))
+    * loading a -viper-config=e2e.yaml with suffix (introduced in 1.13) works again and now has a regression test
+* Kubernetes now supports transparent compression of API responses. Clients that send `Accept-Encoding: gzip` will now receive a GZIP compressed response body if the API call was larger than 128KB.  Go clients automatically request gzip-encoding by default and should see reduced transfer times for very large API requests.  Clients in other languages may need to make changes to benefit from compression. ([#77449](https://github.com/kubernetes/kubernetes/pull/77449), [@smarterclayton](https://github.com/smarterclayton))
+* Resolves an issue serving aggregated APIs backed by services that respond to requests to `/` with non-2xx HTTP responses ([#79895](https://github.com/kubernetes/kubernetes/pull/79895), [@deads2k](https://github.com/deads2k))
+* updated fluentd to 1.5.1, elasticsearchs & kibana to 7.1.1 ([#79014](https://github.com/kubernetes/kubernetes/pull/79014), [@monotek](https://github.com/monotek))
+* kubeadm: implement support for concurrent add/remove of stacked etcd members ([#79677](https://github.com/kubernetes/kubernetes/pull/79677), [@neolit123](https://github.com/neolit123))
+* Added a metric 'apiserver_watch_events_total' that can be used to understand the number of watch events in the system. ([#78732](https://github.com/kubernetes/kubernetes/pull/78732), [@mborsz](https://github.com/mborsz))
+* KMS Providers will install a healthz check for the status of kms-pluign in kube-apiservers' encryption config.  ([#78540](https://github.com/kubernetes/kubernetes/pull/78540), [@immutableT](https://github.com/immutableT))
+* Fixes a bug in openapi published for custom resources using x-kubernetes-preserve-unknown-fields extensions, so that kubectl will allow sending unknown fields for that portion of the object. ([#79636](https://github.com/kubernetes/kubernetes/pull/79636), [@liggitt](https://github.com/liggitt))
+* A new client `k8s.io/client-go/metadata.Client` has been added for accessing objects generically. This client makes it easier to retrieve only the metadata (the `metadata` sub-section) from resources on the cluster in an efficient manner for use cases that deal with objects generically, like the garbage collector, quota, or the namespace controller. The client asks the server to return a `meta.k8s.io/v1 PartialObjectMetadata` object for list, get, delete, watch, and patch operations on both normal APIs and custom resources which can be encoded in protobuf for additional work. If the server does not yet support this API the client will gracefully fall back to JSON and transform the response objects into PartialObjectMetadata. ([#77819](https://github.com/kubernetes/kubernetes/pull/77819), [@smarterclayton](https://github.com/smarterclayton))
+* changes timeout value in csi plugin from 15s to 2min which fixes the timeout issue ([#79529](https://github.com/kubernetes/kubernetes/pull/79529), [@andyzhangx](https://github.com/andyzhangx))
+* kubeadm: provide "--control-plane-endpoint" flag for `controlPlaneEndpoint` ([#79270](https://github.com/kubernetes/kubernetes/pull/79270), [@SataQiu](https://github.com/SataQiu))
+* Fixes invalid "time stamp is the future" error when kubectl cp-ing a file ([#73982](https://github.com/kubernetes/kubernetes/pull/73982), [@tanshanshan](https://github.com/tanshanshan))
+* Kubelet should now more reliably report the same primary node IP even if the set of node IPs reported by the CloudProvider changes. ([#79391](https://github.com/kubernetes/kubernetes/pull/79391), [@danwinship](https://github.com/danwinship))
+* To configure controller manager to use ipv6dual stack: ([#73977](https://github.com/kubernetes/kubernetes/pull/73977), [@khenidak](https://github.com/khenidak))
+    * use --cluster-cidr="<cidr1>,<cidr2>".
+    * Notes:
+
+    * 1. Only the first two cidrs are used (soft limits for Alpha, might be lifted later on).
+    * 2. Only the "RangeAllocator" (default) is allowed as a value for --cidr-allocator-type . Cloud allocators are not compatible with ipv6dualstack
+* When using the conformance test image, a new environment variable E2E_USE_GO_RUNNER will cause the tests to be run with the new Golang-based test runner rather than the current bash wrapper. ([#79284](https://github.com/kubernetes/kubernetes/pull/79284), [@johnSchnake](https://github.com/johnSchnake))
+* kubeadm: prevent PSP blocking of upgrade image prepull by using a non-root user ([#77792](https://github.com/kubernetes/kubernetes/pull/77792), [@neolit123](https://github.com/neolit123))
+* kubelet now accepts a --cni-cache-dir option, which defaults to /var/lib/cni/cache, where CNI stores cache files. ([#78908](https://github.com/kubernetes/kubernetes/pull/78908), [@dcbw](https://github.com/dcbw))
+* Update Azure API versions (containerregistry --> 2018-09-01, network --> 2018-08-01) ([#79583](https://github.com/kubernetes/kubernetes/pull/79583), [@justaugustus](https://github.com/justaugustus))
+* Fix possible fd leak and closing of dirs in doSafeMakeDir  ([#79534](https://github.com/kubernetes/kubernetes/pull/79534), [@odinuge](https://github.com/odinuge))
+* kubeadm: fix the bug that "--cri-socket" flag does not work for `kubeadm reset` ([#79498](https://github.com/kubernetes/kubernetes/pull/79498), [@SataQiu](https://github.com/SataQiu))
+* kubectl logs --selector will support --tail=-1. ([#74943](https://github.com/kubernetes/kubernetes/pull/74943), [@JishanXing](https://github.com/JishanXing))
+* Introduce a new admission controller for RuntimeClass. Initially, RuntimeClass will be used to apply the pod overhead associated with a given RuntimeClass to the Pod.Spec if a corresponding RuntimeClassName is specified. ([#78484](https://github.com/kubernetes/kubernetes/pull/78484), [@egernst](https://github.com/egernst))
+    * PodOverhead is an alpha feature as of Kubernetes 1.16.
+* Fix kubelet errors in AArch64 with huge page sizes smaller than 1MiB ([#78495](https://github.com/kubernetes/kubernetes/pull/78495), [@odinuge](https://github.com/odinuge))
+* The alpha `metadata.initializers` field, deprecated in 1.13, has been removed. ([#79504](https://github.com/kubernetes/kubernetes/pull/79504), [@yue9944882](https://github.com/yue9944882))
+* Fix duplicate error messages in cli commands ([#79493](https://github.com/kubernetes/kubernetes/pull/79493), [@odinuge](https://github.com/odinuge))
+* Default resourceGroup should be used when the value of annotation azure-load-balancer-resource-group is an empty string. ([#79514](https://github.com/kubernetes/kubernetes/pull/79514), [@feiskyer](https://github.com/feiskyer))
+* Fixes output of `kubectl get --watch-only` when watching a single resource ([#79345](https://github.com/kubernetes/kubernetes/pull/79345), [@liggitt](https://github.com/liggitt))
+* RateLimiter add a context-aware method, fix client-go request goruntine backlog in async timeout scene. ([#79375](https://github.com/kubernetes/kubernetes/pull/79375), [@answer1991](https://github.com/answer1991))
+* Fix a bug where kubelet would not retry pod sandbox creation when the restart policy of the pod is Never ([#79451](https://github.com/kubernetes/kubernetes/pull/79451), [@yujuhong](https://github.com/yujuhong))
+* Fix CRD validation error on 'items' field. ([#76124](https://github.com/kubernetes/kubernetes/pull/76124), [@tossmilestone](https://github.com/tossmilestone))
+* The CRD handler now properly re-creates stale CR storage to reflect CRD update. ([#79114](https://github.com/kubernetes/kubernetes/pull/79114), [@roycaihw](https://github.com/roycaihw))
+* Integrated volume limits for in-tree and CSI volumes into one scheduler predicate. ([#77595](https://github.com/kubernetes/kubernetes/pull/77595), [@bertinatto](https://github.com/bertinatto))
+* Fix a bug in server printer that could cause kube-apiserver to panic. ([#79349](https://github.com/kubernetes/kubernetes/pull/79349), [@roycaihw](https://github.com/roycaihw))
+* Mounts /home/kubernetes/bin/nvidia/vulkan/icd.d on the host to /etc/vulkan/icd.d inside containers requesting GPU. ([#78868](https://github.com/kubernetes/kubernetes/pull/78868), [@chardch](https://github.com/chardch))
+* Remove CSIPersistentVolume feature gates ([#79309](https://github.com/kubernetes/kubernetes/pull/79309), [@draveness](https://github.com/draveness))
+* Init container resource requests now impact pod QoS class ([#75223](https://github.com/kubernetes/kubernetes/pull/75223), [@sjenning](https://github.com/sjenning))
+* Correct the maximum allowed insecure bind port for the kube-scheduler and kube-apiserver to 65535. ([#79346](https://github.com/kubernetes/kubernetes/pull/79346), [@ncdc](https://github.com/ncdc))
+* Fix remove the etcd member from the cluster during a kubeadm reset. ([#79326](https://github.com/kubernetes/kubernetes/pull/79326), [@bradbeam](https://github.com/bradbeam))
+* Remove KubeletPluginsWatcher feature gates ([#79310](https://github.com/kubernetes/kubernetes/pull/79310), [@draveness](https://github.com/draveness))
+* Remove HugePages, VolumeScheduling, CustomPodDNS and PodReadinessGates feature flags ([#79307](https://github.com/kubernetes/kubernetes/pull/79307), [@draveness](https://github.com/draveness))
+* The GA PodPriority feature gate is now on by default and cannot be disabled. The feature gate will be removed in v1.18. ([#79262](https://github.com/kubernetes/kubernetes/pull/79262), [@draveness](https://github.com/draveness))
+* Remove pids cgroup controller requirement when related feature gates are disabled ([#79073](https://github.com/kubernetes/kubernetes/pull/79073), [@rafatio](https://github.com/rafatio))
+* Add Bind extension point of the scheduling framework ([#78513](https://github.com/kubernetes/kubernetes/pull/78513), [@chenchun](https://github.com/chenchun))
+* if targetPort is changed that will process by service controller  ([#77712](https://github.com/kubernetes/kubernetes/pull/77712), [@Sn0rt](https://github.com/Sn0rt))
+* update to use go 1.12.6 ([#78958](https://github.com/kubernetes/kubernetes/pull/78958), [@tao12345666333](https://github.com/tao12345666333))
+* kubeadm: fix a potential panic if kubeadm discovers an invalid, existing kubeconfig file ([#79165](https://github.com/kubernetes/kubernetes/pull/79165), [@neolit123](https://github.com/neolit123))
+* fix kubelet fail to delete orphaned pod directory when the kubelet's pods directory (default is "/var/lib/kubelet/pods") symbolically links to another disk device's directory ([#79094](https://github.com/kubernetes/kubernetes/pull/79094), [@gaorong](https://github.com/gaorong))
+* Addition of Overhead field to the PodSpec and RuntimeClass types as part of the Pod Overhead KEP ([#76968](https://github.com/kubernetes/kubernetes/pull/76968), [@egernst](https://github.com/egernst))
+* fix pod list return value of framework.WaitForPodsWithLabelRunningReady ([#78687](https://github.com/kubernetes/kubernetes/pull/78687), [@pohly](https://github.com/pohly))
+* The behavior of the default handler for 404 requests fro the GCE Ingress load balancer is slightly modified in the sense that it now exports metrics using prometheus. The metrics exported include:  ([#79106](https://github.com/kubernetes/kubernetes/pull/79106), [@vbannai](https://github.com/vbannai))
+    * - http_404_request_total  (the number of 404 requests handled)
+    * - http_404_request_duration_ms (the amount of time the server took to respond in ms)
+    * Also includes percentile groupings. The directory for the default 404 handler includes instructions on how to enable prometheus for monitoring and setting alerts.
+* The kube-apiserver has improved behavior for both startup and shutdown sequences and also now exposes `/readyz` for readiness checking. Readyz includes all existing healthz checks but also adds a shutdown check. When a cluster admin initiates a shutdown, the kube-apiserver will try to process existing requests (for the duration of request timeout) before killing the apiserver process.   ([#78458](https://github.com/kubernetes/kubernetes/pull/78458), [@logicalhan](https://github.com/logicalhan))
+    * The apiserver also now takes an optional flag "--maximum-startup-sequence-duration". This allows you to explicitly define an upper bound on the apiserver startup sequences before healthz begins to fail. By keeping the kubelet liveness initial delay short, this can enable quick kubelet recovery as soon as we have a boot sequence which has not completed in our expected time frame, despite lack of completion from longer boot sequences (like RBAC). Kube-apiserver behavior when the value of this flag is zero is backwards compatible (this is as the defaulted value of the flag).
+* fix: make azure disk URI as case insensitive ([#79020](https://github.com/kubernetes/kubernetes/pull/79020), [@andyzhangx](https://github.com/andyzhangx))
+* Enable cadvisor ProcessMetrics collecting. ([#79002](https://github.com/kubernetes/kubernetes/pull/79002), [@jiayingz](https://github.com/jiayingz))
+* Fixes a bug where `kubectl set config` hangs and uses 100% CPU on some invalid property names  ([#79000](https://github.com/kubernetes/kubernetes/pull/79000), [@pswica](https://github.com/pswica))
+* Fix a string comparison bug in IPVS graceful termination where UDP real servers are not deleted. ([#78999](https://github.com/kubernetes/kubernetes/pull/78999), [@andrewsykim](https://github.com/andrewsykim))
+* Reflector watchHandler Warning log 'The resourceVersion for the provided watch is too old.' is now logged as Info.  ([#78991](https://github.com/kubernetes/kubernetes/pull/78991), [@sallyom](https://github.com/sallyom))
+* fix a bug that pods not be deleted from unmatched nodes by daemon controller   ([#78974](https://github.com/kubernetes/kubernetes/pull/78974), [@DaiHao](https://github.com/DaiHao))
+* NONE ([#78821](https://github.com/kubernetes/kubernetes/pull/78821), [@jhedev](https://github.com/jhedev))
+* Volume expansion is enabled in the default GCE storageclass ([#78672](https://github.com/kubernetes/kubernetes/pull/78672), [@msau42](https://github.com/msau42))
+* kubeadm: use the service-cidr flag to pass the desired service CIDR to the kube-controller-manager via its service-cluster-ip-range flag. ([#78625](https://github.com/kubernetes/kubernetes/pull/78625), [@Arvinderpal](https://github.com/Arvinderpal))
+* kubeadm: introduce deterministic ordering for the certificates generation in the phase command "kubeadm init phase certs" . ([#78556](https://github.com/kubernetes/kubernetes/pull/78556), [@neolit123](https://github.com/neolit123))
+* Add Pre-filter extension point to the scheduling framework. ([#78005](https://github.com/kubernetes/kubernetes/pull/78005), [@ahg-g](https://github.com/ahg-g))
+* fix pod stuck issue due to corrupt mnt point in flexvol plugin, call Unmount if PathExists returns any error ([#75234](https://github.com/kubernetes/kubernetes/pull/75234), [@andyzhangx](https://github.com/andyzhangx))

--- a/CHANGELOG/CHANGELOG-1.17.md
+++ b/CHANGELOG/CHANGELOG-1.17.md
@@ -1,0 +1,2474 @@
+<!-- BEGIN MUNGE: GENERATED_TOC -->
+
+- [v1.17.9](#v1179)
+  - [Downloads for v1.17.9](#downloads-for-v1179)
+    - [Source Code](#source-code)
+    - [Client binaries](#client-binaries)
+    - [Server binaries](#server-binaries)
+    - [Node binaries](#node-binaries)
+  - [Changelog since v1.17.8](#changelog-since-v1178)
+  - [Urgent Upgrade Notes](#urgent-upgrade-notes)
+    - [(No, really, you MUST read this before you upgrade)](#no-really-you-must-read-this-before-you-upgrade)
+  - [Changes by Kind](#changes-by-kind)
+    - [Bug or Regression](#bug-or-regression)
+  - [Dependencies](#dependencies)
+    - [Added](#added)
+    - [Changed](#changed)
+    - [Removed](#removed)
+- [v1.17.8](#v1178)
+  - [Downloads for v1.17.8](#downloads-for-v1178)
+    - [Source Code](#source-code-1)
+    - [Client binaries](#client-binaries-1)
+    - [Server binaries](#server-binaries-1)
+    - [Node binaries](#node-binaries-1)
+  - [Changelog since v1.17.7](#changelog-since-v1177)
+  - [Changes by Kind](#changes-by-kind-1)
+    - [API Change](#api-change)
+    - [Bug or Regression](#bug-or-regression-1)
+  - [Dependencies](#dependencies-1)
+    - [Added](#added-1)
+    - [Changed](#changed-1)
+    - [Removed](#removed-1)
+- [v1.17.8-rc.1](#v1178-rc1)
+  - [Downloads for v1.17.8-rc.1](#downloads-for-v1178-rc1)
+    - [Source Code](#source-code-2)
+    - [Client binaries](#client-binaries-2)
+    - [Server binaries](#server-binaries-2)
+    - [Node binaries](#node-binaries-2)
+  - [Changelog since v1.17.7](#changelog-since-v1177-1)
+  - [Changes by Kind](#changes-by-kind-2)
+    - [API Change](#api-change-1)
+    - [Bug or Regression](#bug-or-regression-2)
+  - [Dependencies](#dependencies-2)
+    - [Added](#added-2)
+    - [Changed](#changed-2)
+    - [Removed](#removed-2)
+- [v1.17.7](#v1177)
+  - [Downloads for v1.17.7](#downloads-for-v1177)
+    - [Source Code](#source-code-3)
+    - [Client binaries](#client-binaries-3)
+    - [Server binaries](#server-binaries-3)
+    - [Node binaries](#node-binaries-3)
+  - [Changelog since v1.17.6](#changelog-since-v1176)
+  - [Changes by Kind](#changes-by-kind-3)
+    - [API Change](#api-change-2)
+    - [Feature](#feature)
+    - [Bug or Regression](#bug-or-regression-3)
+    - [Other (Cleanup or Flake)](#other-cleanup-or-flake)
+  - [Dependencies](#dependencies-3)
+    - [Added](#added-3)
+    - [Changed](#changed-3)
+    - [Removed](#removed-3)
+- [v1.17.6](#v1176)
+  - [Downloads for v1.17.6](#downloads-for-v1176)
+    - [Source Code](#source-code-4)
+    - [Client binaries](#client-binaries-4)
+    - [Server binaries](#server-binaries-4)
+    - [Node binaries](#node-binaries-4)
+  - [Changelog since v1.17.5](#changelog-since-v1175)
+  - [Changes by Kind](#changes-by-kind-4)
+    - [API Change](#api-change-3)
+    - [Bug or Regression](#bug-or-regression-4)
+    - [Other (Cleanup or Flake)](#other-cleanup-or-flake-1)
+  - [Dependencies](#dependencies-4)
+    - [Added](#added-4)
+    - [Changed](#changed-4)
+    - [Removed](#removed-4)
+- [v1.17.5](#v1175)
+  - [Downloads for v1.17.5](#downloads-for-v1175)
+    - [Client Binaries](#client-binaries-5)
+    - [Server Binaries](#server-binaries-5)
+    - [Node Binaries](#node-binaries-5)
+  - [Changelog since v1.17.4](#changelog-since-v1174)
+  - [Changes by Kind](#changes-by-kind-5)
+    - [Feature](#feature-1)
+    - [Bug or Regression](#bug-or-regression-5)
+    - [Other (Cleanup or Flake)](#other-cleanup-or-flake-2)
+- [v1.17.4](#v1174)
+  - [Downloads for v1.17.4](#downloads-for-v1174)
+    - [Client Binaries](#client-binaries-6)
+    - [Server Binaries](#server-binaries-6)
+    - [Node Binaries](#node-binaries-6)
+  - [Changelog since v1.17.3](#changelog-since-v1173)
+  - [Changes by Kind](#changes-by-kind-6)
+    - [API Change](#api-change-4)
+    - [Other (Bug, Cleanup or Flake)](#other-bug-cleanup-or-flake)
+- [v1.17.3](#v1173)
+  - [Downloads for v1.17.3](#downloads-for-v1173)
+    - [Client Binaries](#client-binaries-7)
+    - [Server Binaries](#server-binaries-7)
+    - [Node Binaries](#node-binaries-7)
+  - [Changelog since v1.17.2](#changelog-since-v1172)
+  - [Changes by Kind](#changes-by-kind-7)
+    - [Other (Bug, Cleanup or Flake)](#other-bug-cleanup-or-flake-1)
+- [v1.17.2](#v1172)
+  - [Downloads for v1.17.2](#downloads-for-v1172)
+    - [Client Binaries](#client-binaries-8)
+    - [Server Binaries](#server-binaries-8)
+    - [Node Binaries](#node-binaries-8)
+  - [Changelog since v1.17.1](#changelog-since-v1171)
+- [v1.17.1](#v1171)
+  - [Downloads for v1.17.1](#downloads-for-v1171)
+    - [Client Binaries](#client-binaries-9)
+    - [Server Binaries](#server-binaries-9)
+    - [Node Binaries](#node-binaries-9)
+  - [Changelog since v1.17.0](#changelog-since-v1170)
+    - [Other notable changes](#other-notable-changes)
+- [v1.17.0](#v1170)
+  - [Downloads for v1.17.0](#downloads-for-v1170)
+    - [Client Binaries](#client-binaries-10)
+    - [Server Binaries](#server-binaries-10)
+    - [Node Binaries](#node-binaries-10)
+- [Changes](#changes)
+  - [What’s New (Major Themes)](#what’s-new-major-themes)
+    - [Cloud Provider Labels reach General Availability](#cloud-provider-labels-reach-general-availability)
+    - [Volume Snapshot Moves to Beta](#volume-snapshot-moves-to-beta)
+    - [CSI Migration Beta](#csi-migration-beta)
+  - [Known Issues](#known-issues)
+  - [Urgent Upgrade Notes](#urgent-upgrade-notes-1)
+    - [(No, really, you MUST read this before you upgrade)](#no-really-you-must-read-this-before-you-upgrade-1)
+      - [Cluster Lifecycle](#cluster-lifecycle)
+      - [Network](#network)
+      - [Scheduling](#scheduling)
+      - [Storage](#storage)
+      - [Windows](#windows)
+    - [Deprecations and Removals](#deprecations-and-removals)
+    - [Metrics Changes](#metrics-changes)
+      - [Added metrics](#added-metrics)
+      - [Deprecated/changed metrics](#deprecated/changed-metrics)
+    - [Notable Features](#notable-features)
+      - [Stable](#stable)
+      - [Beta](#beta)
+      - [CLI Improvements](#cli-improvements)
+    - [API Changes](#api-changes)
+    - [Other notable changes](#other-notable-changes-1)
+      - [API Machinery](#api-machinery)
+      - [Apps](#apps)
+      - [Auth](#auth)
+      - [CLI](#cli)
+      - [Cloud Provider](#cloud-provider)
+      - [Cluster Lifecycle](#cluster-lifecycle-1)
+      - [Instrumentation](#instrumentation)
+      - [Network](#network-1)
+      - [Node](#node)
+      - [Release](#release)
+      - [Scheduling](#scheduling-1)
+      - [Storage](#storage-1)
+      - [Windows](#windows-1)
+      - [Dependencies](#dependencies-5)
+      - [Detailed go Dependency Changes](#detailed-go-dependency-changes)
+        - [Added](#added-5)
+        - [Changed](#changed-5)
+        - [Removed](#removed-5)
+- [v1.17.0-rc.2](#v1170-rc2)
+  - [Downloads for v1.17.0-rc.2](#downloads-for-v1170-rc2)
+    - [Client Binaries](#client-binaries-11)
+    - [Server Binaries](#server-binaries-11)
+    - [Node Binaries](#node-binaries-11)
+  - [Changelog since v1.17.0-rc.1](#changelog-since-v1170-rc1)
+    - [Other notable changes](#other-notable-changes-2)
+- [v1.17.0-rc.1](#v1170-rc1)
+  - [Downloads for v1.17.0-rc.1](#downloads-for-v1170-rc1)
+    - [Client Binaries](#client-binaries-12)
+    - [Server Binaries](#server-binaries-12)
+    - [Node Binaries](#node-binaries-12)
+  - [Changelog since v1.17.0-beta.2](#changelog-since-v1170-beta2)
+    - [Other notable changes](#other-notable-changes-3)
+- [v1.17.0-beta.2](#v1170-beta2)
+  - [Downloads for v1.17.0-beta.2](#downloads-for-v1170-beta2)
+    - [Client Binaries](#client-binaries-13)
+    - [Server Binaries](#server-binaries-13)
+    - [Node Binaries](#node-binaries-13)
+  - [Changelog since v1.17.0-beta.1](#changelog-since-v1170-beta1)
+    - [Action Required](#action-required)
+    - [Other notable changes](#other-notable-changes-4)
+- [v1.17.0-beta.1](#v1170-beta1)
+  - [Downloads for v1.17.0-beta.1](#downloads-for-v1170-beta1)
+    - [Client Binaries](#client-binaries-14)
+    - [Server Binaries](#server-binaries-14)
+    - [Node Binaries](#node-binaries-14)
+  - [Changelog since v1.17.0-alpha.3](#changelog-since-v1170-alpha3)
+    - [Action Required](#action-required-1)
+    - [Other notable changes](#other-notable-changes-5)
+- [v1.17.0-alpha.3](#v1170-alpha3)
+  - [Downloads for v1.17.0-alpha.3](#downloads-for-v1170-alpha3)
+    - [Client Binaries](#client-binaries-15)
+    - [Server Binaries](#server-binaries-15)
+    - [Node Binaries](#node-binaries-15)
+  - [Changelog since v1.17.0-alpha.2](#changelog-since-v1170-alpha2)
+    - [Action Required](#action-required-2)
+    - [Other notable changes](#other-notable-changes-6)
+- [v1.17.0-alpha.2](#v1170-alpha2)
+  - [Downloads for v1.17.0-alpha.2](#downloads-for-v1170-alpha2)
+    - [Client Binaries](#client-binaries-16)
+    - [Server Binaries](#server-binaries-16)
+    - [Node Binaries](#node-binaries-16)
+  - [Changelog since v1.17.0-alpha.1](#changelog-since-v1170-alpha1)
+    - [Action Required](#action-required-3)
+    - [Other notable changes](#other-notable-changes-7)
+- [v1.17.0-alpha.1](#v1170-alpha1)
+  - [Downloads for v1.17.0-alpha.1](#downloads-for-v1170-alpha1)
+    - [Client Binaries](#client-binaries-17)
+    - [Server Binaries](#server-binaries-17)
+    - [Node Binaries](#node-binaries-17)
+  - [Changelog since v1.16.0](#changelog-since-v1160)
+    - [Action Required](#action-required-4)
+    - [Other notable changes](#other-notable-changes-8)
+
+<!-- END MUNGE: GENERATED_TOC -->
+
+# v1.17.9
+
+
+## Downloads for v1.17.9
+
+### Source Code
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes.tar.gz](https://dl.k8s.io/v1.17.9/kubernetes.tar.gz) | c6d71667ec516c150e27f0d81868b90b04f620656c081c85e570f5fa8bb6e1fd70bc305f7e7826a56a7ed4ccbdf061147c69cb39c44e756ca090acc5ee189d67
+[kubernetes-src.tar.gz](https://dl.k8s.io/v1.17.9/kubernetes-src.tar.gz) | 24dc550d00e8ad57b100f19ae33080079c8d274abea1709cf7f45f807e2f9d59bafe1c6ad0fc3aac9992040680b5478c3e8133975ab1b1ef9fb4118033ca7914
+
+### Client binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-client-darwin-386.tar.gz](https://dl.k8s.io/v1.17.9/kubernetes-client-darwin-386.tar.gz) | ba2ac4b1444edb6b40e1537fa77c11796708b2a068791ee39fc54d64d31f9c2503df4316ef00b464988a3f8b5efd17e37fce889d19fb00bc814ca91e215d8b81
+[kubernetes-client-darwin-amd64.tar.gz](https://dl.k8s.io/v1.17.9/kubernetes-client-darwin-amd64.tar.gz) | bb15d61ef2623d007bbda18571a864b13735a20a303a6250a1cd57e25d53cd81179c669440717884d1911aaa04a0bfbb7789330d4cefcd3f32a8233b0d664384
+[kubernetes-client-linux-386.tar.gz](https://dl.k8s.io/v1.17.9/kubernetes-client-linux-386.tar.gz) | 6a121fcacff561b2c3040bd0803d00368743e3c7529597d1b66ea2bcba2f7caeff0ef7fb4bb5f10c83a206c50eece18e227bb2de5175eb3f3cf00b9569b4a762
+[kubernetes-client-linux-amd64.tar.gz](https://dl.k8s.io/v1.17.9/kubernetes-client-linux-amd64.tar.gz) | 57fe9caf9d40e8b3e9e1b58552af1b74bf3cdccb3bd50fb5e51ba95d3e08263dad831724d79f2b99c0d67b03a1e533667422a20ba4159234b3452cdffbb814d4
+[kubernetes-client-linux-arm.tar.gz](https://dl.k8s.io/v1.17.9/kubernetes-client-linux-arm.tar.gz) | 2cbfca1133446dff4d8bbf82976ba14345dfea4c2940d841949bb323c2bd338409280da9789d7f872f41903a5bfb9852547dc548e7aff3d21375f7ff3c4b9d2b
+[kubernetes-client-linux-arm64.tar.gz](https://dl.k8s.io/v1.17.9/kubernetes-client-linux-arm64.tar.gz) | 68ab42f2844ed6f9fb9e71945f0ef30468542997a0c4bb6f39776d266fd18f26e14182c642c4a82c39e36c5deff5e9e056ed0ca4b4505f0faaade19401f5d4df
+[kubernetes-client-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.17.9/kubernetes-client-linux-ppc64le.tar.gz) | baeba57a163248d404f70b83bd2ee2458afec619f5c7ab0da656a96634db4dc841fd86e34a3d849e2847b6f97b15bd3be12f34f03e7296a4b4e9a7c9d4a26049
+[kubernetes-client-linux-s390x.tar.gz](https://dl.k8s.io/v1.17.9/kubernetes-client-linux-s390x.tar.gz) | d4d9c7b152d31b83a49fd4140f88e3014b4571a31b4694fd62ce1e436872cc0227a2192581e7b007f32b0ba397e16611a2dbc29bd2ac7f8da5106b3519ab807d
+[kubernetes-client-windows-386.tar.gz](https://dl.k8s.io/v1.17.9/kubernetes-client-windows-386.tar.gz) | b3ebeaf6b83da17f7facd6029af64f4e98512e49a63188eaa59d2d8dc54ec4eb9c78e48eb9635f73fc13bd899269eeb005264402712b617e9607200aee270367
+[kubernetes-client-windows-amd64.tar.gz](https://dl.k8s.io/v1.17.9/kubernetes-client-windows-amd64.tar.gz) | 1ea45f8d99cf1bb69e330b81f476d6cc6d1ac4ccfe7aa56dc7a02b269e2bbb52351c0ee6e06115d2ba0096ec8e151e09dcdb57351f873fd8ce98a5949178e298
+
+### Server binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-server-linux-amd64.tar.gz](https://dl.k8s.io/v1.17.9/kubernetes-server-linux-amd64.tar.gz) | 5b3123e442e64637d086ff154c1338ad7a63ddfe2e738dce11b590bf50f663de2d067ea902aac81ecf15f72bd0455fa8dc1166132d6335901424e7a385b56e66
+[kubernetes-server-linux-arm.tar.gz](https://dl.k8s.io/v1.17.9/kubernetes-server-linux-arm.tar.gz) | d8b26e70921113fe94da89ab448aea41b8c7e280abf65be569dc198d2904fc07266ee372d4ca5fe9532666846af46161f2c8ea1f7fb99a31ebbbdf93055d786f
+[kubernetes-server-linux-arm64.tar.gz](https://dl.k8s.io/v1.17.9/kubernetes-server-linux-arm64.tar.gz) | 23dab56cdd5eb320bb28d4b1fbdf452cbd9c18c38fad77796f76e0039d3c390024c543e2a3d2da7a843258bc6e6a47e5f546491ffb06b58f0e5196286f640339
+[kubernetes-server-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.17.9/kubernetes-server-linux-ppc64le.tar.gz) | e109727a2bd63edcefa1d25fbe24280db8fd62711edd2ff1d30b748c500d8bb0a7e9f5c10c889a975840b8ee91424c4d3b9ce5d30e8543befdddc368b93f7d20
+[kubernetes-server-linux-s390x.tar.gz](https://dl.k8s.io/v1.17.9/kubernetes-server-linux-s390x.tar.gz) | 7a1757ef6f5f2c5b3c3a3fffea0ee5abc42578331da32decce0581b37cc4a331bdaf15cea4561093a1ddd2a15932edea883cdfa89dff8a82ca93ed0ffbc9bc97
+
+### Node binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-node-linux-amd64.tar.gz](https://dl.k8s.io/v1.17.9/kubernetes-node-linux-amd64.tar.gz) | a8baebd0725d69cde59e5eaad5fbcd9b35911b67539df0d28407f96b8baafc854e7e043af7139c9fc4126bae7bebfe6ca7dfb80180c56399819593d31b96a6d5
+[kubernetes-node-linux-arm.tar.gz](https://dl.k8s.io/v1.17.9/kubernetes-node-linux-arm.tar.gz) | 21c5e452391f39203cab2225204b95a7ffd223da31d95998116ed04bd0b60b9c039ef2db57e747342f5615e1c9858a698a54a1ff0666e79f866ee42fa21c8ecd
+[kubernetes-node-linux-arm64.tar.gz](https://dl.k8s.io/v1.17.9/kubernetes-node-linux-arm64.tar.gz) | 329df0d659ab2b0daecbb5a337ecbca496db5dedb81493850eda3b8abeb24b408ff40e2f1b74d23db2fce568dabacec8f5c069625af39ca8154251a7260d2502
+[kubernetes-node-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.17.9/kubernetes-node-linux-ppc64le.tar.gz) | 913a93cee4b34613ecb0ecc5560e51bef8a8377f7ff6d07561fb2cc37d794c6b80c516bf3961d17aba35c2735314f086939bb21b7cf4559d8547466a60691d76
+[kubernetes-node-linux-s390x.tar.gz](https://dl.k8s.io/v1.17.9/kubernetes-node-linux-s390x.tar.gz) | 0c388b817c9209ff73d13cf50fea545baf0b6bfd4764d045a08451c725671ef27992cac084636da5161df32fb8aa1359306fe96f96c49250ab03eaf70da1b496
+[kubernetes-node-windows-amd64.tar.gz](https://dl.k8s.io/v1.17.9/kubernetes-node-windows-amd64.tar.gz) | 77b6fb8c19c38d5faad7477e4430586fc99e589a668c61043c1e59da551bbe796dc30f2d391dece8fef53516fd2293a634fc96acf82033ce84b9b8c6deb1cf9f
+
+## Changelog since v1.17.8
+
+## Urgent Upgrade Notes
+
+### (No, really, you MUST read this before you upgrade)
+
+ - CVE-2020-8559 (Medium): Privilege escalation from compromised node to cluster. See https://github.com/kubernetes/kubernetes/issues/92914 for more details.
+  The API Server will no longer proxy non-101 responses for upgrade requests. This could break proxied backends (such as an extension API server) that respond to upgrade requests with a non-101 response code. ([#92941](https://github.com/kubernetes/kubernetes/pull/92941), [@tallclair](https://github.com/tallclair)) [SIG API Machinery]
+ 
+## Changes by Kind
+
+### Bug or Regression
+
+- CVE-2020-8557 (Medium): Node-local denial of service via container /etc/hosts file. See https://github.com/kubernetes/kubernetes/issues/93032 for more details. ([#92916](https://github.com/kubernetes/kubernetes/pull/92916), [@joelsmith](https://github.com/joelsmith)) [SIG Node]
+- Extend kube-apiserver /readyz with new "informer-sync" check ensuring that internal informers are synced. ([#92644](https://github.com/kubernetes/kubernetes/pull/92644), [@wojtek-t](https://github.com/wojtek-t)) [SIG API Machinery and Testing]
+- Fix: GetLabelsForVolume panic issue for azure disk PV ([#92166](https://github.com/kubernetes/kubernetes/pull/92166), [@andyzhangx](https://github.com/andyzhangx)) [SIG Cloud Provider]
+- Fix: use force detach for azure disk ([#91948](https://github.com/kubernetes/kubernetes/pull/91948), [@andyzhangx](https://github.com/andyzhangx)) [SIG Cloud Provider]
+- Fixes a problem with 63-second or 1-second connection delays with some VXLAN-based
+  network plugins which was first widely noticed in 1.16 (though some users saw it
+  earlier than that, possibly only with specific network plugins). If you were previously
+  using ethtool to disable checksum offload on your primary network interface, you should
+  now be able to stop doing that. ([#92035](https://github.com/kubernetes/kubernetes/pull/92035), [@danwinship](https://github.com/danwinship)) [SIG Network and Node]
+- Kubeadm: add the deprecated flag --port=0 to kube-controller-manager and kube-scheduler manifests to disable insecure serving. Without this flag the components by default serve (e.g. /metrics) insecurely on the default node interface (controlled by --address). Users that wish to override this behavior and enable insecure serving can pass a custom --port=X via kubeadm's "extraArgs" mechanic for these components. ([#92720](https://github.com/kubernetes/kubernetes/pull/92720), [@neolit123](https://github.com/neolit123)) [SIG Cluster Lifecycle]
+- Kubeadm: during "join", don't re-add an etcd member if it already exists in the cluster. ([#92118](https://github.com/kubernetes/kubernetes/pull/92118), [@neolit123](https://github.com/neolit123)) [SIG Cluster Lifecycle]
+- hyperkube: Use debian-hyperkube-base@v1.1.1 image
+  
+    Includes iproute2 to fix a regression in hyperkube images
+    when using hyperkube as a kubelet ([#92625](https://github.com/kubernetes/kubernetes/pull/92625), [@justaugustus](https://github.com/justaugustus)) [SIG Cluster Lifecycle, Network and Release]
+
+## Dependencies
+
+### Added
+_Nothing has changed._
+
+### Changed
+_Nothing has changed._
+
+### Removed
+_Nothing has changed._
+
+
+
+# v1.17.8
+
+
+## Downloads for v1.17.8
+
+### Source Code
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes.tar.gz](https://dl.k8s.io/v1.17.8/kubernetes.tar.gz) | 8212fb4e823fbae81cd7817a3a7abe5a49503b01163fb6805e40791d0639a1b22ababa14fd1e2c545a1c37f89e1110b58fe2f18e6367ecb17cf84f5657f7e106
+[kubernetes-src.tar.gz](https://dl.k8s.io/v1.17.8/kubernetes-src.tar.gz) | f4838e9950ccc64f9670ce1349f24667825305d7d8d8fc3a9f5f6cc8c51c4edbb00331d528ebcb29489bc0f3df283c6f4c1ea86647ff9ced992adfb0b5269533
+
+### Client binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-client-darwin-386.tar.gz](https://dl.k8s.io/v1.17.8/kubernetes-client-darwin-386.tar.gz) | 6fb3bb627a18d44bf3738d8c9d2ef8a4a624835c345447b92cfb4032f9f475d86c004f2dc61289539cbe132120f8961786829ebd088b3d7a9feee67a3a30f11f
+[kubernetes-client-darwin-amd64.tar.gz](https://dl.k8s.io/v1.17.8/kubernetes-client-darwin-amd64.tar.gz) | 500e9a056a2e9b8a7744e390bedaf233c3809c789d902969e085826a0b38662e08f98df681b87d9b13343bd47bd7a3acafa84cc2c81f3a5a1948c255489e92cd
+[kubernetes-client-linux-386.tar.gz](https://dl.k8s.io/v1.17.8/kubernetes-client-linux-386.tar.gz) | 64515e5358fd8b462ecde19dbeca108843ac164026ed76002032f07366d121eb5489a4608b62eb12b759f47222b4ac92c45c43c9f177693cb601bd673db992bf
+[kubernetes-client-linux-amd64.tar.gz](https://dl.k8s.io/v1.17.8/kubernetes-client-linux-amd64.tar.gz) | 87da207547a5fa06836afa7f8fc15af4b8950e4a263367a8eb59eccb2a13bb7f98db2bb5731444fcc5313d80e28d3992579742d8a7ed26c48ae425f16ced449a
+[kubernetes-client-linux-arm.tar.gz](https://dl.k8s.io/v1.17.8/kubernetes-client-linux-arm.tar.gz) | 7d4151b63589b5271922b1fb350c403c0e4d44465daa6e1931336ce6080f443bc087d4bfaad7f94b5324e9b5d726e22b08734aedad2783bbc50cf01e6ea882a6
+[kubernetes-client-linux-arm64.tar.gz](https://dl.k8s.io/v1.17.8/kubernetes-client-linux-arm64.tar.gz) | 39c1651217f51c168329d490d2c4fa9f1a572bcf016c4c13228f8ae805c63a527e69a09228846a302a1c9aa4bbdd7de05a07f2c3597bdfcb94fd5959f8d19bd0
+[kubernetes-client-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.17.8/kubernetes-client-linux-ppc64le.tar.gz) | c4de90aa7bc7125ad8bad6b940cc8af911cd1e9a7533aec28cf32438c04188da16f6d05673ad5a5a79d2c0bea54fe1d953ee95ff74dddf8b44d4590ba4364f76
+[kubernetes-client-linux-s390x.tar.gz](https://dl.k8s.io/v1.17.8/kubernetes-client-linux-s390x.tar.gz) | 08ec9b6abfb0c0e4874a9ff0d6b43d71ce8bd77f764293c8df755827c811e243d2ba2b589bced1234d1ef1e8da5f74ffa38639246d9b2a0bfb6dc353d5d3421b
+[kubernetes-client-windows-386.tar.gz](https://dl.k8s.io/v1.17.8/kubernetes-client-windows-386.tar.gz) | c2edcce0a450b02432af56775eddbf49e0b031e8a9cb94a0c4320a400d2a1353a4c6d986b57c0115642ac27c8438889a7938987badc03ac42e37e5075f9ec8e4
+[kubernetes-client-windows-amd64.tar.gz](https://dl.k8s.io/v1.17.8/kubernetes-client-windows-amd64.tar.gz) | e3c31ebb172d3077cca2d796af020ba5cb90df552a607ef54e80cdd7aa6f50d2b7cd108d80a6f4fdade90c9340a1c50c13d7b11ab91dfcff9add634272f97bc7
+
+### Server binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-server-linux-amd64.tar.gz](https://dl.k8s.io/v1.17.8/kubernetes-server-linux-amd64.tar.gz) | 8872e69c391e36d8ce2d307858108d69cf5d45202f012f8a1a019d3705c3d91a7dd3c08ee0c8f5f022f69fad0cce945ac92f492043ce113cc5367ddefb1ecb5e
+[kubernetes-server-linux-arm.tar.gz](https://dl.k8s.io/v1.17.8/kubernetes-server-linux-arm.tar.gz) | a0d7086fd78dd5d1e8ad91859b25346b531cde97a9f8916c4dd9ea66aba91d334b1600180795aea8102a76e6e4945dfb3f788e3648db2f98a9f542beb8a2b7f3
+[kubernetes-server-linux-arm64.tar.gz](https://dl.k8s.io/v1.17.8/kubernetes-server-linux-arm64.tar.gz) | 2cd42e859fd6519370b496da7c0b2b0d9ce47f0f8323f3384c7eca5327cd5a0be75978fcced3012ceff52cfc2e8625c0d8f2ad024cf380e7c1e6fb424ac39164
+[kubernetes-server-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.17.8/kubernetes-server-linux-ppc64le.tar.gz) | 97edd2f2e88f77e98bc4e30e8bcd044a16aaa96a486178806e7b9d3fe231310b183c0dc6b9e66ca86f17caede16369f0a1ca91c31755011170f88d5b12b25f9b
+[kubernetes-server-linux-s390x.tar.gz](https://dl.k8s.io/v1.17.8/kubernetes-server-linux-s390x.tar.gz) | a33c746865216dfee05e0718e4b91708c455e18b6b611cfecca1f4efc4f7101cfeeda1e31f84ad116ca3b9392f1c6a8bcae626d69e6726f6427696d6423dcfa1
+
+### Node binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-node-linux-amd64.tar.gz](https://dl.k8s.io/v1.17.8/kubernetes-node-linux-amd64.tar.gz) | 16ae1e32bb0f7b6f8809ab5c20ca7c16cfcc9780476e08f18b4af36f3cb3d6004aecb2833b026cb8b08378b2b499a566d6c72b411df5db9ee6f1cbfd3a750374
+[kubernetes-node-linux-arm.tar.gz](https://dl.k8s.io/v1.17.8/kubernetes-node-linux-arm.tar.gz) | 0e4dbb87bb19422faaefd213baac1e962feeec7a3d22396436709795479bd2bcbef1e7708e561e4421503e81e47c2d24af14a76bb63550db85a37a10980ce790
+[kubernetes-node-linux-arm64.tar.gz](https://dl.k8s.io/v1.17.8/kubernetes-node-linux-arm64.tar.gz) | 4a431e0565c5e2c5029c6f414cb694d6e3e7ee2e056868b6e99542eb163c740d9c73556de3f1e039f081adddcedf52099ff8cd74f7a2618cfa7ab5e3ee63f0a4
+[kubernetes-node-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.17.8/kubernetes-node-linux-ppc64le.tar.gz) | c8868091220993cd4002e125508fc01e327f8025f6012ddc6bba31d785079d7dea20ceb97d70dd1ae452fc4a6bed4a52e8a511122ce4d65af030cb1e7d40fd60
+[kubernetes-node-linux-s390x.tar.gz](https://dl.k8s.io/v1.17.8/kubernetes-node-linux-s390x.tar.gz) | 22463fb6907c28fff6ffe950a03fc9cc9877b3384d3f8a166979fb6334178b1e6d0d86bc5a07b8e04be82afbe2d8085eec565b2614f5112c47fd80af825f9e11
+[kubernetes-node-windows-amd64.tar.gz](https://dl.k8s.io/v1.17.8/kubernetes-node-windows-amd64.tar.gz) | 08b34e5a9a6c529afc23ce57acf62eaf17174812c801f3918599c407832b5b0c7b177f01c5aa66a7d753ec1b9c420cf4d4bda1dab7cf0c8cafb014551306cce7
+
+## Changelog since v1.17.7
+
+## Changes by Kind
+
+### API Change
+
+- Fixed: log timestamps now include trailing zeros to maintain a fixed width ([#91207](https://github.com/kubernetes/kubernetes/pull/91207), [@iamchuckss](https://github.com/iamchuckss)) [SIG Apps and Node]
+
+### Bug or Regression
+
+- Fixes CSI volume attachment scaling issue by using informers. ([#91307](https://github.com/kubernetes/kubernetes/pull/91307), [@yuga711](https://github.com/yuga711)) [SIG API Machinery, Apps, Node, Storage and Testing]
+- If firstTimestamp is not set use firstTimestamp or eventTime when printing event ([#91055](https://github.com/kubernetes/kubernetes/pull/91055), [@soltysh](https://github.com/soltysh)) [SIG CLI]
+- Kubeadm increased to 5 minutes its timeout for the TLS bootstrapping process to complete upon join ([#89735](https://github.com/kubernetes/kubernetes/pull/89735), [@rosti](https://github.com/rosti)) [SIG Cluster Lifecycle]
+- hyperkube: Use debian-hyperkube-base@v1.1.0 image
+  
+    A previous release built hyperkube using the debian-hyperkube-base@v1.0.0,
+    which was updated to address a CVE in the CNI plugins.
+    
+    A side-effect of using this new image was that the networking packages
+    (namely `iptables`) drifted from the versions used in the kube-proxy images.
+  
+    The following issues were filed on kube-proxy failures when using hyperkube:
+    - https://github.com/kubernetes/kubernetes/issues/92275
+    - https://github.com/kubernetes/kubernetes/issues/92272
+    - https://github.com/kubernetes/kubernetes/issues/92250
+  
+    To address this, the new debian-hyperkube-base image (v1.1.0) uses the
+    debian-iptables base image (v12.1.0), which includes iptables-wrapper, a
+    script used to determine the correct iptables mode to run in. ([#92494](https://github.com/kubernetes/kubernetes/pull/92494), [@justaugustus](https://github.com/justaugustus)) [SIG Cluster Lifecycle and Release]
+
+## Dependencies
+
+### Added
+_Nothing has changed._
+
+### Changed
+_Nothing has changed._
+
+### Removed
+_Nothing has changed._
+
+
+
+# v1.17.8-rc.1
+
+
+## Downloads for v1.17.8-rc.1
+
+### Source Code
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes.tar.gz](https://dl.k8s.io/v1.17.8-rc.1/kubernetes.tar.gz) | da3cb0b669e7f3c698911d819a743439e4633da49812d072105acff5122bd308863fd3216c5fced32f0843ad698b0da9344849fdb1b3f414a6839697864ee6ec
+[kubernetes-src.tar.gz](https://dl.k8s.io/v1.17.8-rc.1/kubernetes-src.tar.gz) | 6f429fd968450dc0cc3ed02a81ebf521ed8d87880def7498004eee9b9990effd7e3908a1d8bc8eebf1fea1d932209aee1677b4f4ecbd1dd98a3f97d4cd5f6096
+
+### Client binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-client-darwin-386.tar.gz](https://dl.k8s.io/v1.17.8-rc.1/kubernetes-client-darwin-386.tar.gz) | fa8eda07a4b96e530d8add858ee673df0dbd57d52f642d41d948bd09bdd309b7454af86b11691821c6d89b198c0d8703eb20bbef9e0ef008006f5dc3719386fe
+[kubernetes-client-darwin-amd64.tar.gz](https://dl.k8s.io/v1.17.8-rc.1/kubernetes-client-darwin-amd64.tar.gz) | 635eacbe628705bbd33c31321b069a1853fe2cb2a7fbb44a28e86c62ca2a46d2ebce7d08131594b8b0aa205350de16fc1de41d0ed14c095fbb10929d9c3f5cbd
+[kubernetes-client-linux-386.tar.gz](https://dl.k8s.io/v1.17.8-rc.1/kubernetes-client-linux-386.tar.gz) | b2920840fa9fe79d76a869f4021fdfecbdf8821e94270ca469be6c7ae6025991da1a8dffe4b7c5c828eac64e62473b98a7a30aa6e772257beae08458ff2cf5d3
+[kubernetes-client-linux-amd64.tar.gz](https://dl.k8s.io/v1.17.8-rc.1/kubernetes-client-linux-amd64.tar.gz) | 6beb451d551764eab4e24a463c5c1b2c5430a6a62f5e77153189a5e23268c314f5fd97096d5bd4c9d19906443e3be6f79dfe68fc3080b0cc8cc611e37dcc17ce
+[kubernetes-client-linux-arm.tar.gz](https://dl.k8s.io/v1.17.8-rc.1/kubernetes-client-linux-arm.tar.gz) | 334db1268b23c4d9ff56ccbfd90a5d0cd0ca4bf2874426a45d56e11f501212f2d00e7efdd41ecfdb820bb37cad04776741cfb3f26c9f2d1e9c22e7e82f5a45cc
+[kubernetes-client-linux-arm64.tar.gz](https://dl.k8s.io/v1.17.8-rc.1/kubernetes-client-linux-arm64.tar.gz) | e81fc23422ce62e15e02f4abc1b70dbf1ed566d400df40e5acccbe89d25bfcad466076d48ebd79389acc3759589bb09f9eed319bfd566c207874be571346a37c
+[kubernetes-client-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.17.8-rc.1/kubernetes-client-linux-ppc64le.tar.gz) | df6320c33daae7a86a77904bd194fec51692f6de0778a95f62ad8a7b156043c04cca394159afea06aa219201732f5cc075f4040c4458abbf06793cc1c38a4812
+[kubernetes-client-linux-s390x.tar.gz](https://dl.k8s.io/v1.17.8-rc.1/kubernetes-client-linux-s390x.tar.gz) | d2286ba60a862184694dec22be601bb45abe33ae37936de497bbd290889e4b383e0cea0ba577d52562da5f4b2d36da100e6fd23a704f6b97ed945346ed57a5a7
+[kubernetes-client-windows-386.tar.gz](https://dl.k8s.io/v1.17.8-rc.1/kubernetes-client-windows-386.tar.gz) | 148214721c7165169b382161e093d7828a15ad0149e67624f0c8c16d0e974ad941471fdbacabf0a30eb704eff8a569f11d01930a773334de8617bb60d28cb865
+[kubernetes-client-windows-amd64.tar.gz](https://dl.k8s.io/v1.17.8-rc.1/kubernetes-client-windows-amd64.tar.gz) | 9bd0fb1f2cd30ab2c5f05a294bb4f72a004627a72ed5fe8b66e76b72d97f8378e68f5d84649e4919d9859579712744b16954205ed134c11fdb0b01dd70c41992
+
+### Server binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-server-linux-amd64.tar.gz](https://dl.k8s.io/v1.17.8-rc.1/kubernetes-server-linux-amd64.tar.gz) | 09e4c5eb9eea18702e267a7f3e64e74e16287cb88573940f89010eeed4d6c7a3a35de5fe928ec17361e9738bc8196221e4d37261c1c0032dd4ddaa020b423d67
+[kubernetes-server-linux-arm.tar.gz](https://dl.k8s.io/v1.17.8-rc.1/kubernetes-server-linux-arm.tar.gz) | 8a42e10d04f4093ddfce217081e2020165344e41df8f78ec48938adc40ae6f2c66e832d0f9d1c5f57559550811a53d0d749e7e20fd1fee0f9d03d8aeabaca0f5
+[kubernetes-server-linux-arm64.tar.gz](https://dl.k8s.io/v1.17.8-rc.1/kubernetes-server-linux-arm64.tar.gz) | 61d4ba59824f272530f6ef957a66aad6b7394442062b3b9dfdca7b2f08fe2117f238a6f8465d1648c77f77feadf83e3a9d891606f285ce48886563b1929ccfab
+[kubernetes-server-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.17.8-rc.1/kubernetes-server-linux-ppc64le.tar.gz) | 5693d18a66104fe1d49900297d9bb6c75fe22ee890ae0d40a6e6afb3e63a63cfbf39b4ee697ecd769f7108959f7f0dc62f1237026a59c71a2c883b124e358872
+[kubernetes-server-linux-s390x.tar.gz](https://dl.k8s.io/v1.17.8-rc.1/kubernetes-server-linux-s390x.tar.gz) | 4780f1df8236e0e3fc69c4e1fda45dcc280358215b7f834a63790226e2ae8f28295bc922b257f10bc4aeb2493061caaa5e05cd0e1d113b303375da519de54498
+
+### Node binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-node-linux-amd64.tar.gz](https://dl.k8s.io/v1.17.8-rc.1/kubernetes-node-linux-amd64.tar.gz) | 981058f903a8fc69730d3255778ca0ad095dd8c2cd92cbf2c510ec6921bc753da736ef918d28f7de3a80433b28da77fecdcab10edfa3cbf5f16f5dc2593ff4fd
+[kubernetes-node-linux-arm.tar.gz](https://dl.k8s.io/v1.17.8-rc.1/kubernetes-node-linux-arm.tar.gz) | 50134de1a08dee324ea147e46e5ca805a7cea0846d832c734c6db193c2642311a6c9d8e36c81c2740afb08e62f592486b094360fae28c11fcb3240a74099efbe
+[kubernetes-node-linux-arm64.tar.gz](https://dl.k8s.io/v1.17.8-rc.1/kubernetes-node-linux-arm64.tar.gz) | b570c281cc639a22d63a1caaf8478b80a88d27521a844799cc3153d7cdd9b8a13de14d4a6f986b5530a31f7e367336921547a7e4ab710af938abccbdba16a21a
+[kubernetes-node-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.17.8-rc.1/kubernetes-node-linux-ppc64le.tar.gz) | 357ac7d9f4b26efdd425088eb2fd966af6602c72ffb1f2a661390ec8c930b0f5a6df3879ad74edc115322dad4e2c0e1c0d6db74f07938f39af72d1ee6685c696
+[kubernetes-node-linux-s390x.tar.gz](https://dl.k8s.io/v1.17.8-rc.1/kubernetes-node-linux-s390x.tar.gz) | d6369c4e72cd27c2b2232ca3e5e70dfcdad878122bde90b4f7328a27fafaee47cfdacac51202b3f9e7d984ca050617414fd901aefff7f5add745003952166eb4
+[kubernetes-node-windows-amd64.tar.gz](https://dl.k8s.io/v1.17.8-rc.1/kubernetes-node-windows-amd64.tar.gz) | 8b2f568cfddad0ab47376aaefca8ad4a69b821891e8311c96f014a92f31ac3ae114f38a5e2bcb3a0e625060109cb430f53a447b481e42d59300c53cad71323e5
+
+## Changelog since v1.17.7
+
+## Changes by Kind
+
+### API Change
+
+- Fixed: log timestamps now include trailing zeros to maintain a fixed width ([#91207](https://github.com/kubernetes/kubernetes/pull/91207), [@iamchuckss](https://github.com/iamchuckss)) [SIG Apps and Node]
+
+### Bug or Regression
+
+- Fixes CSI volume attachment scaling issue by using informers. ([#91307](https://github.com/kubernetes/kubernetes/pull/91307), [@yuga711](https://github.com/yuga711)) [SIG API Machinery, Apps, Node, Storage and Testing]
+- If firstTimestamp is not set use firstTimestamp or eventTime when printing event ([#91055](https://github.com/kubernetes/kubernetes/pull/91055), [@soltysh](https://github.com/soltysh)) [SIG CLI]
+- Kubeadm increased to 5 minutes its timeout for the TLS bootstrapping process to complete upon join ([#89735](https://github.com/kubernetes/kubernetes/pull/89735), [@rosti](https://github.com/rosti)) [SIG Cluster Lifecycle]
+- hyperkube: Use debian-hyperkube-base@v1.1.0 image
+  
+    A previous release built hyperkube using the debian-hyperkube-base@v1.0.0,
+    which was updated to address a CVE in the CNI plugins.
+    
+    A side-effect of using this new image was that the networking packages
+    (namely `iptables`) drifted from the versions used in the kube-proxy images.
+  
+    The following issues were filed on kube-proxy failures when using hyperkube:
+    - https://github.com/kubernetes/kubernetes/issues/92275
+    - https://github.com/kubernetes/kubernetes/issues/92272
+    - https://github.com/kubernetes/kubernetes/issues/92250
+  
+    To address this, the new debian-hyperkube-base image (v1.1.0) uses the
+    debian-iptables base image (v12.1.0), which includes iptables-wrapper, a
+    script used to determine the correct iptables mode to run in. ([#92494](https://github.com/kubernetes/kubernetes/pull/92494), [@justaugustus](https://github.com/justaugustus)) [SIG Cluster Lifecycle and Release]
+
+## Dependencies
+
+### Added
+_Nothing has changed._
+
+### Changed
+_Nothing has changed._
+
+### Removed
+_Nothing has changed._
+
+
+
+# v1.17.7
+
+
+## Downloads for v1.17.7
+
+### Source Code
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes.tar.gz](https://dl.k8s.io/v1.17.7/kubernetes.tar.gz) | b98b4e1fae60a50fe23ead412c700f8d0250d9dd327d0012efa3e4b74ff21a33bb6cf3df67f9fd04f92aec4ee369bb7d68ca1380dda32caff9e19b2bdb810abd
+[kubernetes-src.tar.gz](https://dl.k8s.io/v1.17.7/kubernetes-src.tar.gz) | 8be11a7f7696aa19319c0676c1c31db37439e95ac32578d53a21dd1cf7a92ff5f5f795dff6fc7251b47296431dd70a6c4338daf33c342ee6f46387b3a858206a
+
+### Client binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-client-darwin-386.tar.gz](https://dl.k8s.io/v1.17.7/kubernetes-client-darwin-386.tar.gz) | 9c40a33687e212b712e904c8710b3fe4ed4d27542ffde63e40a5e19000cb9b1a3328a292d4e969111ac39cacaf78e210bf44e999ab0c6af118e3c0cd3f311902
+[kubernetes-client-darwin-amd64.tar.gz](https://dl.k8s.io/v1.17.7/kubernetes-client-darwin-amd64.tar.gz) | 8d294e6c28f15ee6518d0a60b809b51bfc3954e139735380305756622debf5a40437b53f57d39afa30b4393ad3c64c65a6eded9faafda8e9a1f9189d89f4ecbc
+[kubernetes-client-linux-386.tar.gz](https://dl.k8s.io/v1.17.7/kubernetes-client-linux-386.tar.gz) | 68e4839c4867172315fd1b163d2df51c588f349dd43f978dcaeb471ea44e06333e54f79f38b6bc8ceb732aaed41a2adf0f517db7a03fe4987b372dab5c72a4d8
+[kubernetes-client-linux-amd64.tar.gz](https://dl.k8s.io/v1.17.7/kubernetes-client-linux-amd64.tar.gz) | a0196a68e70422cc220e5f77d7d0104b4248c0ab03f5d1858655bb522071f22f3e9cb76bced170acaebab8e1f4fc7dbcf879b230c0cfd291afc621bb5debd150
+[kubernetes-client-linux-arm.tar.gz](https://dl.k8s.io/v1.17.7/kubernetes-client-linux-arm.tar.gz) | 2cf7efedbfde502c28b7a0c70d8a29b46a9bd12423d3d4a88429f8b19545eea1fb37e1ebe870a7d6ea11a8388dfe1a25e7b61a559acac80610540d1b49cda27c
+[kubernetes-client-linux-arm64.tar.gz](https://dl.k8s.io/v1.17.7/kubernetes-client-linux-arm64.tar.gz) | 931d5463ec4f93c0522767f8ff35d2e59115191d93f352d68de860d6c59b8238ae6311942b6f7acf69afcbce323268dbd7f541203d162e3398121ca0853fd139
+[kubernetes-client-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.17.7/kubernetes-client-linux-ppc64le.tar.gz) | 0f27cc434068ffd14c5b301f9c9e3f6fcf7e003817b7b831b33fcf38292de51b645be1f30f063b90a64cc4c625ba7c84c96f31f65d6fc7b272ef3ecc2a0f82f8
+[kubernetes-client-linux-s390x.tar.gz](https://dl.k8s.io/v1.17.7/kubernetes-client-linux-s390x.tar.gz) | 5030d86f1516e6d48f3d29ec20f5c9d3a7b578935cef28c1512b2b67548ce8c0a6b128ac8a402fdbb33c04091e3adeecaac405f626b0a34b91dc055a64eded9f
+[kubernetes-client-windows-386.tar.gz](https://dl.k8s.io/v1.17.7/kubernetes-client-windows-386.tar.gz) | 3d5b4689a0ed8bd935cf116cc6c8c43663d0d7a208811075ebe6af26434d4d9280f758df3793d3e676192201dddaa4b2ce8d3ee077df6e1d22c876474bc3936f
+[kubernetes-client-windows-amd64.tar.gz](https://dl.k8s.io/v1.17.7/kubernetes-client-windows-amd64.tar.gz) | e54073dae3b756b899caf4298db20e2da2986fe7539a3b4aaa960bb8341021cb3f3ed4a2a69a62d0804e32b006c9dc1a1ab36cb67f4b6d2a3502668f5c928332
+
+### Server binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-server-linux-amd64.tar.gz](https://dl.k8s.io/v1.17.7/kubernetes-server-linux-amd64.tar.gz) | 2fa986227f26663708dc2062e72160eef46931b561f97e9e81b9156b7cf1338da3d9c0940feae832368142009a9949ca191a76498eb7e354bf2b516f083add54
+[kubernetes-server-linux-arm.tar.gz](https://dl.k8s.io/v1.17.7/kubernetes-server-linux-arm.tar.gz) | 8335b464da28d66c773dd3fb96846b20104fcae656d41edec1bc5212a0a5bf843a02001e13d95640650b1c723adde3606c669ba13e3855ddc77a79bdd8ff1ab9
+[kubernetes-server-linux-arm64.tar.gz](https://dl.k8s.io/v1.17.7/kubernetes-server-linux-arm64.tar.gz) | 7c19c83dda8d501249fdac24d07fe5ab7a99d5c540967107c2c4ec8561b5362d8ae3bddfdbedb75def3bd5c1ce9fd5396410d72698c70b9bf92c85286fc11f22
+[kubernetes-server-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.17.7/kubernetes-server-linux-ppc64le.tar.gz) | ac954e3c467a144b59168b67b7153050260531b3560edf101f4be77cca8bd81b3dd89c4af6ad13d3b65caa6c68eeb595d17ab7f738c8f7fab3b1db430cbf8b74
+[kubernetes-server-linux-s390x.tar.gz](https://dl.k8s.io/v1.17.7/kubernetes-server-linux-s390x.tar.gz) | ca673ec937d28e90eb2c0e8d7ce2b83e823ea4221435b15b244bce30909839f5721e637d28d343e00e9a729542eadf67ce70bc5777d095e8fe5f91a39bd8f798
+
+### Node binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-node-linux-amd64.tar.gz](https://dl.k8s.io/v1.17.7/kubernetes-node-linux-amd64.tar.gz) | 8da87e04eea4fedd7462992042894aab97052e09fd68c4a7e47bf70d6ad411b214ec37ab6dcfb4bec28759a4214e752e805b42adc9563d15cf668cbda25d8a65
+[kubernetes-node-linux-arm.tar.gz](https://dl.k8s.io/v1.17.7/kubernetes-node-linux-arm.tar.gz) | 458d8f4e52995581a163ac51c7f6b6e06a11a900494d92d1a290d78dc03cb2ebe0cb55376c813f600f133f556ca4e4b5859c2e6be1c0c0791550dc5c76884d9b
+[kubernetes-node-linux-arm64.tar.gz](https://dl.k8s.io/v1.17.7/kubernetes-node-linux-arm64.tar.gz) | 7ed90a0028a5205e1b2fd41058260b7497dc9718773f9bef828d3b6e7457a136072c5c583ba61739c0c3ef6b685493e06bb30bc463be00a8a93ca291226913eb
+[kubernetes-node-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.17.7/kubernetes-node-linux-ppc64le.tar.gz) | 59500c1fc178afe92ad8799c2c622586f80209112b966ea20adbcee9a6dc68c3b5c39033d8590a45ddd2f3afe1e9ea19887b29e612cf96a9e77af547c71a937a
+[kubernetes-node-linux-s390x.tar.gz](https://dl.k8s.io/v1.17.7/kubernetes-node-linux-s390x.tar.gz) | e10f2ca363a02ba786d92ae8e2ab502afd434560dc83e2f5b1c9bd8ca9b076b9c53c5a277fe025face69b380d977c1d090817637091ba5a0504be16f73a5a59b
+[kubernetes-node-windows-amd64.tar.gz](https://dl.k8s.io/v1.17.7/kubernetes-node-windows-amd64.tar.gz) | 67a7b24e93597eb5a7de462d379ee7e1a7c878dd04eda4fd5eb01b4ed0ac161cc67d22293265e7227a98fcccaef74f656245dfc4350e985e9ce8b0a0a3dd3484
+
+## Changelog since v1.17.6
+
+## Changes by Kind
+
+### API Change
+
+- Resolve regression in metadata.managedFields handling in update/patch requests submitted by older API clients ([#92008](https://github.com/kubernetes/kubernetes/pull/92008), [@apelisse](https://github.com/apelisse)) [SIG API Machinery and Testing]
+
+### Feature
+
+- Extend AWS azToRegion method to support Local Zones ([#90874](https://github.com/kubernetes/kubernetes/pull/90874), [@Jeffwan](https://github.com/Jeffwan)) [SIG Cloud Provider]
+
+### Bug or Regression
+
+- Azure: set dest prefix and port for IPv6 inbound security rule ([#91831](https://github.com/kubernetes/kubernetes/pull/91831), [@aramase](https://github.com/aramase)) [SIG Cloud Provider]
+- Fix internal loadbalancer configuration failure when subnet name too long ([#86276](https://github.com/kubernetes/kubernetes/pull/86276), [@yangl900](https://github.com/yangl900)) [SIG Cloud Provider]
+- Fix public IP not shown issues after assigning public IP to Azure VMs ([#90886](https://github.com/kubernetes/kubernetes/pull/90886), [@feiskyer](https://github.com/feiskyer)) [SIG Cloud Provider]
+- Fixed a regression preventing garbage collection of RBAC role and binding objects ([#90534](https://github.com/kubernetes/kubernetes/pull/90534), [@apelisse](https://github.com/apelisse)) [SIG Auth]
+- Kubeadm: increase robustness for "kubeadm join" when adding etcd members on slower setups ([#90645](https://github.com/kubernetes/kubernetes/pull/90645), [@neolit123](https://github.com/neolit123)) [SIG Cluster Lifecycle]
+- Kubelet podresources API now provides the information about active pods only. ([#79409](https://github.com/kubernetes/kubernetes/pull/79409), [@takmatsu](https://github.com/takmatsu)) [SIG Node]
+- Pod Finalizers and Conditions updates are skipped for re-scheduling attempts ([#91950](https://github.com/kubernetes/kubernetes/pull/91950), [@alculquicondor](https://github.com/alculquicondor)) [SIG Scheduling]
+- Resolve regression in metadata.managedFields handling in create/update/patch requests not using server-side apply ([#91794](https://github.com/kubernetes/kubernetes/pull/91794), [@apelisse](https://github.com/apelisse)) [SIG API Machinery and Testing]
+- Resolves an issue using `kubectl certificate approve/deny` against a server serving the v1 CSR API ([#91691](https://github.com/kubernetes/kubernetes/pull/91691), [@liggitt](https://github.com/liggitt)) [SIG Auth and CLI]
+
+### Other (Cleanup or Flake)
+
+- Update CNI to v0.8.6
+  - build: Use debian-hyperkube-base@v1.0.0 image ([#91386](https://github.com/kubernetes/kubernetes/pull/91386), [@justaugustus](https://github.com/justaugustus)) [SIG Cluster Lifecycle, Network, Release and Testing]
+
+## Dependencies
+
+### Added
+_Nothing has changed._
+
+### Changed
+_Nothing has changed._
+
+### Removed
+_Nothing has changed._
+
+
+
+# v1.17.6
+
+
+## Downloads for v1.17.6
+
+### Source Code
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes.tar.gz](https://dl.k8s.io/v1.17.6/kubernetes.tar.gz) | 90b10c16aea412c39ea57f6ebb0f5cb74f939089ebad91cdc1a3c2d83890a88305b2e10e9cee4563258c718383be66ee9e90f06c6b07b8d6eb2d11a473ffd670
+[kubernetes-src.tar.gz](https://dl.k8s.io/v1.17.6/kubernetes-src.tar.gz) | ea8bff7a3c607d1d10787d5160527ac26e05c11fd7247e9db2066e55f1514d8d8e0ee034c209e3cb0227a89d8f2a14bf23ea960ed04a7ee4ccf179c0f60ec93b
+
+### Client binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-client-darwin-386.tar.gz](https://dl.k8s.io/v1.17.6/kubernetes-client-darwin-386.tar.gz) | a828219247db473d0e83e72d6b16811da5f6568ed6df9c62b81e42be97e74bebe2006f7890f4b2fb11bace912a60dd389030a82cf177de0720e7baa4e9ca375e
+[kubernetes-client-darwin-amd64.tar.gz](https://dl.k8s.io/v1.17.6/kubernetes-client-darwin-amd64.tar.gz) | 99accc972bd3c3412916867e8fa29ba7895f3f74b1d63999d8a7ba686a34be616962e4320dd078ea74e58242d7a183401c0858e19d2ac25b21e50868cdc24be3
+[kubernetes-client-linux-386.tar.gz](https://dl.k8s.io/v1.17.6/kubernetes-client-linux-386.tar.gz) | 591211c27a91c3890530a90a0afc16a53a965e518b0db0e17024efeb34ee7c2279532357b019743164c7542c3e030d7e822c5fa3a9076291eb202ddb9f90872b
+[kubernetes-client-linux-amd64.tar.gz](https://dl.k8s.io/v1.17.6/kubernetes-client-linux-amd64.tar.gz) | 43ed75d64419d965c5f42dafe06ab8c511001883d91c93ca68d90f36c7f5f2014fd29ecd7bbb2b91e0cf2ebfeffa2223dacb07bf00f9d2c30cc5041849e3438d
+[kubernetes-client-linux-arm.tar.gz](https://dl.k8s.io/v1.17.6/kubernetes-client-linux-arm.tar.gz) | faf2a45cfd178cc1bacaca3d1df6e109ce423214cbc3ef7ea45fae19bc8e4be058ecd0ae04dcc7a4770dee622d37e2a247dc664c17c8fe37c62421e465defc4b
+[kubernetes-client-linux-arm64.tar.gz](https://dl.k8s.io/v1.17.6/kubernetes-client-linux-arm64.tar.gz) | a3d58a6d4accebecb15d7d53f89b1a198db3563f4986a96f38537dec939836f03958e5bfdd0a83afd983f1bbaac3eee72dea99b2b70544c03612416525637a49
+[kubernetes-client-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.17.6/kubernetes-client-linux-ppc64le.tar.gz) | b65305e339f6e4daeaa098baeae16688d99a5e1d869d3f1d875b98ab309f26b7ee352dd0a6c86a67462eb184cff4ff8f650a488ef28a13c9a71b1a89f72a43c8
+[kubernetes-client-linux-s390x.tar.gz](https://dl.k8s.io/v1.17.6/kubernetes-client-linux-s390x.tar.gz) | 31448fc881a4e03cf494615cfc11605c432e8db30eff5355a3e331b65836a23cecfc0a74c0baa30e8a97d0381b37517a87249fd1036b3a165150175bf7c1c201
+[kubernetes-client-windows-386.tar.gz](https://dl.k8s.io/v1.17.6/kubernetes-client-windows-386.tar.gz) | e3943a7030298ffa3ecd49636df99e1786d079db9765ca1b6ac090300224e6fa29e7c2fc5f0928f264db3553019f4c343dfa539cdff1f39a9ab0d50a1506e27b
+[kubernetes-client-windows-amd64.tar.gz](https://dl.k8s.io/v1.17.6/kubernetes-client-windows-amd64.tar.gz) | 4d48a854a66700aa84774219ea647803cbfb93ffd4d392d1b73c85f1aae2457c634bc44ae303ab1fd30aecc1ffe56f8865717c4b68b16dffdeeb60f1ead15294
+
+### Server binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-server-linux-amd64.tar.gz](https://dl.k8s.io/v1.17.6/kubernetes-server-linux-amd64.tar.gz) | aea400c0debb56417d113fa733d6434dff0db8a38f425b307fc204b7035a2b15f4529cb2384a5345fb13947a2fb2120832432371d36bbbdc9de9f7b302a44bd6
+[kubernetes-server-linux-arm.tar.gz](https://dl.k8s.io/v1.17.6/kubernetes-server-linux-arm.tar.gz) | 4d5370b5b4aed73bbda6adf4bfbc2dee2c7dea61af6041c9e7f2713e727d653b218b1080b10b23ba949a7cb5ff9d6a35115d99165a1d2bc394840e2176b8d1c6
+[kubernetes-server-linux-arm64.tar.gz](https://dl.k8s.io/v1.17.6/kubernetes-server-linux-arm64.tar.gz) | 1e6972d013ef6a365175dc621fb72f5b3fad5bb239947bd2ffcc348c0179b565cb4d217ec64717cd5d8651beb004746288264a0aeaf6c337f85d08bdec1d5851
+[kubernetes-server-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.17.6/kubernetes-server-linux-ppc64le.tar.gz) | f3ac669007db1ff156349f80511e8768eef4e0fb6032074549bc779b78f0810abd7592ebf9a9dc7f0015dad9e7f248bd4ea9f2755b38403738781b034de95520
+[kubernetes-server-linux-s390x.tar.gz](https://dl.k8s.io/v1.17.6/kubernetes-server-linux-s390x.tar.gz) | 2cb7e373aeda7e76edaa5576280d8944ae8c9b09905ae82e884f2a769a92ec06c0f5d2cc934d9a5871e2285a91ceb0da2eff1e6daf53d4ab360037254d30edd1
+
+### Node binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-node-linux-amd64.tar.gz](https://dl.k8s.io/v1.17.6/kubernetes-node-linux-amd64.tar.gz) | f6eb62e4939c166f2b0b5ed4b7acf723220f6b30d896b281387af8790a0598fb126221321382d53e82b3dbb0039d8dc25edf00b3b910cc106ebacd0bed8861be
+[kubernetes-node-linux-arm.tar.gz](https://dl.k8s.io/v1.17.6/kubernetes-node-linux-arm.tar.gz) | b945c9c7645b65e7c34bab8f9b3038d4f07b14ccb0cf1ce3bc92bcede90b971a2efe726ae94bb346bfe4d14e9db99c1c4d465c17908805df254fd500bda4c255
+[kubernetes-node-linux-arm64.tar.gz](https://dl.k8s.io/v1.17.6/kubernetes-node-linux-arm64.tar.gz) | b642196aca36c3079b1cf9ff942369976f1291d91393b3c6e8fdcd1df7415636de29bbf03c2af46707af34ed6a535a3be3c396958d464d5dee51518a50f23dbd
+[kubernetes-node-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.17.6/kubernetes-node-linux-ppc64le.tar.gz) | 4fb68986045b2725eeb7a9089fafe99f4faa37e366e494282e07f6c2b957170b0ae962014a36fab1e86ebcd5c7f521e8de2271c4ab7b44aa9d0740a8cebb76d5
+[kubernetes-node-linux-s390x.tar.gz](https://dl.k8s.io/v1.17.6/kubernetes-node-linux-s390x.tar.gz) | f237a2992907c59b71593fedcc3aea993d2c1eca2c8cd0025e9b79d4b193aee4c9aabe8e6b623d2c82f51f97661117c80a5c5052641877497ccfa2d2d8c4b71c
+[kubernetes-node-windows-amd64.tar.gz](https://dl.k8s.io/v1.17.6/kubernetes-node-windows-amd64.tar.gz) | 5c591a1907e01047b8ead6f23a1a0cd08b82b7fd88d93d72ba8d79dfd24ae28550d22d03e131c7e68c305d69786e7123a7b3c60e9172089c4994be3423976e40
+
+## Changelog since v1.17.5
+
+## Changes by Kind
+
+### API Change
+ - Fix bug where sending a status update completely wipes managedFields for some types. ([#90032](https://github.com/kubernetes/kubernetes/pull/90032), [@apelisse](https://github.com/apelisse)) [SIG API Machinery and Testing]
+
+### Bug or Regression
+ - Base-images: Update to kube-cross:v1.13.9-5 ([#90965](https://github.com/kubernetes/kubernetes/pull/90965), [@justaugustus](https://github.com/justaugustus)) [SIG Release]
+ - CSINode initialization does not crash kubelet on startup when APIServer is not reachable or kubelet has not the right credentials yet. ([#89589](https://github.com/kubernetes/kubernetes/pull/89589), [@jsafrane](https://github.com/jsafrane)) [SIG Storage]
+ - Fix HPA when using init containers and CRI-O ([#90901](https://github.com/kubernetes/kubernetes/pull/90901), [@joelsmith](https://github.com/joelsmith)) [SIG Node]
+ - Fix flaws in Azure CSI translation ([#90325](https://github.com/kubernetes/kubernetes/pull/90325), [@andyzhangx](https://github.com/andyzhangx)) [SIG Cloud Provider]
+ - Fix: Init containers are now considered for the calculation of resource requests when scheduling ([#90414](https://github.com/kubernetes/kubernetes/pull/90414), [@alculquicondor](https://github.com/alculquicondor)) [SIG Scheduling]
+ - Fix: azure disk dangling attach issue which would cause API throttling ([#90749](https://github.com/kubernetes/kubernetes/pull/90749), [@andyzhangx](https://github.com/andyzhangx)) [SIG Cloud Provider]
+ - Fix: get attach disk error due to missing item in max count table ([#89768](https://github.com/kubernetes/kubernetes/pull/89768), [@andyzhangx](https://github.com/andyzhangx)) [SIG Cloud Provider and Storage]
+ - Fix: support removal of nodes backed by deleted non VMSS instances on Azure ([#91184](https://github.com/kubernetes/kubernetes/pull/91184), [@bpineau](https://github.com/bpineau)) [SIG Cloud Provider]
+ - Fixed "requested device X but found Y" attach error on AWS. ([#85675](https://github.com/kubernetes/kubernetes/pull/85675), [@jsafrane](https://github.com/jsafrane)) [SIG Cloud Provider and Storage]
+ - Fixes a bug defining a default value for a replicas field in a custom resource definition that has the scale subresource enabled ([#90020](https://github.com/kubernetes/kubernetes/pull/90020), [@liggitt](https://github.com/liggitt)) [SIG API Machinery, CLI, Cloud Provider, Cluster Lifecycle and Instrumentation]
+ - Fixes a regression in 1.17 that dropped cache-control headers on API requests ([#90468](https://github.com/kubernetes/kubernetes/pull/90468), [@liggitt](https://github.com/liggitt)) [SIG API Machinery and Testing]
+ - Provides a fix to allow a cluster in a private Azure cloud to authenticate to ACR in the same cloud. ([#90425](https://github.com/kubernetes/kubernetes/pull/90425), [@DavidParks8](https://github.com/DavidParks8)) [SIG Cloud Provider]
+ - Scheduling failures due to no nodes available are now reported as unschedulable under ```schedule_attempts_total``` metric. ([#90989](https://github.com/kubernetes/kubernetes/pull/90989), [@ahg-g](https://github.com/ahg-g)) [SIG Scheduling]
+
+### Other (Cleanup or Flake)
+ - base-images: Use debian-base:v2.1.0 (includes CVE fixes)
+  - base-images: Use debian-iptables:v12.1.0 (includes CVE fixes) ([#90938](https://github.com/kubernetes/kubernetes/pull/90938), [@justaugustus](https://github.com/justaugustus)) [SIG API Machinery, Cluster Lifecycle and Release]
+
+## Dependencies
+
+### Added
+_Nothing has changed._
+
+### Changed
+- k8s.io/kube-openapi: 82d701f → bcb3869
+
+### Removed
+_Nothing has changed._
+
+
+
+# v1.17.5
+
+[Documentation](https://docs.k8s.io)
+
+## Downloads for v1.17.5
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes.tar.gz](https://dl.k8s.io/v1.17.5/kubernetes.tar.gz) | `d0d1b451d5cafd3e909ba15d09c7277a85eba682696cd60684dca8c5ce8db06c1dbab046ec933931e3122c06f9f5b86eddce40856671d3b8b255b338a1bdcd3e`
+[kubernetes-src.tar.gz](https://dl.k8s.io/v1.17.5/kubernetes-src.tar.gz) | `b7a78f9ea3e8088ac3f7dfd671d011fdb0a6cd28342fc19cf35d183f7cf8ffc9e5d4679af3c42d4e5ae49e388e8b8e37f9d0239c0eb8c2da6c9a6b9677d9cf61`
+
+### Client Binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-client-darwin-386.tar.gz](https://dl.k8s.io/v1.17.5/kubernetes-client-darwin-386.tar.gz) | `8fc24f1f69052372078d76208f9137cf38a3ba689580cf197ab8fff503663e01bce8b0d0c37051b07216be460d6ef492d9319f6206d5a30519ca7e25ab4e742e`
+[kubernetes-client-darwin-amd64.tar.gz](https://dl.k8s.io/v1.17.5/kubernetes-client-darwin-amd64.tar.gz) | `fb7ff087cc82b930399c5512656de68a8b9c61f54e3bd3e627fff097e67a18411e0268b6cec0e40a96d596618002ccc2417deba5c0eba2dcb195813bdd40cc35`
+[kubernetes-client-linux-386.tar.gz](https://dl.k8s.io/v1.17.5/kubernetes-client-linux-386.tar.gz) | `544a71885ac66ba4911db7d086880badbf395518b1e6d7bcc03ffc2139c1dc0adf83c4a3e0b4be069217dec335cf40f0e7a81bc5db187dd8d659e847ac4500f0`
+[kubernetes-client-linux-amd64.tar.gz](https://dl.k8s.io/v1.17.5/kubernetes-client-linux-amd64.tar.gz) | `4cf67f972aad3425bccc48af83f8cb59ddcc96de49d3bb21cdbbcbbeee31718ef681e551d13343538a6e70c2a4ea0435e4540bc1f8cf1a91a2f73265f52b9429`
+[kubernetes-client-linux-arm.tar.gz](https://dl.k8s.io/v1.17.5/kubernetes-client-linux-arm.tar.gz) | `c90a93b3ffc5d2fc41bb913b6b698b5e9a54c737ea13738dc94ef8baed88d0b02ad03b291a54c21c16ecc6c83f300fd4187e7b6112210fcee4d897bd6fa0a3fe`
+[kubernetes-client-linux-arm64.tar.gz](https://dl.k8s.io/v1.17.5/kubernetes-client-linux-arm64.tar.gz) | `c2e2f02a75e92a0505db81941e03cc42effc7f49b89a0c151f5389d57cbc44c8e05d8b7def2d9e17a7928c342e32c0afb0931ea4e22a37ea5dbaaabbfcd89bfa`
+[kubernetes-client-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.17.5/kubernetes-client-linux-ppc64le.tar.gz) | `f1b023d6ae59c5f0f7bbb44f23c7f6185673ff834dd6929e23d14e190a5d0154519a39df072e7801484333eae8e8b53932e918b90e859f2e1317d9e267fac873`
+[kubernetes-client-linux-s390x.tar.gz](https://dl.k8s.io/v1.17.5/kubernetes-client-linux-s390x.tar.gz) | `b7f4e92ee30a57f2f20244e092614ea7dc5bb0791b041b39f9593b35bd10afeeda03892b6da7c89ae791e8c0313eae7351f4d88d9faf689b47df778fa1bd026b`
+[kubernetes-client-windows-386.tar.gz](https://dl.k8s.io/v1.17.5/kubernetes-client-windows-386.tar.gz) | `d21824110b75cfbe3d144eb303560e0a193c9d998be00d4f1f77c672c6fbea487cfda758202487d649c29e52e668ee369a98138a1d32872ef107a74fbbd2f769`
+[kubernetes-client-windows-amd64.tar.gz](https://dl.k8s.io/v1.17.5/kubernetes-client-windows-amd64.tar.gz) | `5dc5d50b85aaa40998b3ade4fd51fffe3c4be4bad4382495cf9f6a3e910de23a35c3747e7f63b79af7989a2943c645724e72da06593329939eaf5b25cd4f96bd`
+
+### Server Binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-server-linux-amd64.tar.gz](https://dl.k8s.io/v1.17.5/kubernetes-server-linux-amd64.tar.gz) | `90f571a24527a119499a1546c44dfdb29df74f302a2907ce14f378d79c5e9fd3db075709ce19f75e853dceb720344fcf46fc24225fadbe7b4f71587e1089f1d6`
+[kubernetes-server-linux-arm.tar.gz](https://dl.k8s.io/v1.17.5/kubernetes-server-linux-arm.tar.gz) | `0555e1969f5fa44ecbe331c4ed75df6d56e929e123d9abe6f4ba75c0ffb1ae1a10cc6c8d0b1336f3915398e9e149ac6d87b95cb671770c96dd5fe159a4a60db1`
+[kubernetes-server-linux-arm64.tar.gz](https://dl.k8s.io/v1.17.5/kubernetes-server-linux-arm64.tar.gz) | `2e8e446d7a132227c0e926504e65bf9ff6180b7171ac16d51dd92c1729161c591c2f2ce828fba0b790147a69e76815da0f720aa7b90f1d343035deaac2ea8721`
+[kubernetes-server-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.17.5/kubernetes-server-linux-ppc64le.tar.gz) | `08733b06f4174cd14d27d33966fe821b20abd67da94f3aa90b146a3d9ce6f28ff25153667d4175cd67af8055c7197f7c6e37d3bfb5f18eb09c75b499759cc7e4`
+[kubernetes-server-linux-s390x.tar.gz](https://dl.k8s.io/v1.17.5/kubernetes-server-linux-s390x.tar.gz) | `a170a62da4e3d5d27c0af7d03aa9db5a947a5d296ccba40fc283fb0da671a395dc5ee1dc7cb7ec662ec562a7bb611eb6cc0f5529f9f58b689cf546542e25d6fa`
+
+### Node Binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-node-linux-amd64.tar.gz](https://dl.k8s.io/v1.17.5/kubernetes-node-linux-amd64.tar.gz) | `99d92cbc9227b49d52fdec303aca4c529bcb45ed66ecbd559803b6d68314b390d7f368c4a803679fe19ed5bba7785948adb1ccc8362334c54067425d4d23775a`
+[kubernetes-node-linux-arm.tar.gz](https://dl.k8s.io/v1.17.5/kubernetes-node-linux-arm.tar.gz) | `931dd0c7b56c7914495cbcba7df998d1db335d635d457c0cf062a3db0c2ec0a1a2a7ae9c51d9711ad744c201c24c2ab7cf8a0718b4cf172a9e3dbffdd910d1dd`
+[kubernetes-node-linux-arm64.tar.gz](https://dl.k8s.io/v1.17.5/kubernetes-node-linux-arm64.tar.gz) | `23bbfe1f60b95705846f214bbe243beaeec6c53de33b15231b99094914584da5589cf55340636f7daf46d3b8b75d2f77a1320093f84288ccba502467568b0a56`
+[kubernetes-node-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.17.5/kubernetes-node-linux-ppc64le.tar.gz) | `808abe9a96f461ac303b020c716e3a7fc94b1901cbd56bba836f2caf8292e7f14a112ae2189916a2a5654fe6a55a25d29b0b1fee31e834416c541ff689214421`
+[kubernetes-node-linux-s390x.tar.gz](https://dl.k8s.io/v1.17.5/kubernetes-node-linux-s390x.tar.gz) | `a645d8e8ade9af849764755165cdf0fc9eb04671afe2610562082f27f2aba7492f4c735e1ad3bff3cf26318674145da18c50df73506276563d3569b3ecea5b1c`
+[kubernetes-node-windows-amd64.tar.gz](https://dl.k8s.io/v1.17.5/kubernetes-node-windows-amd64.tar.gz) | `501a5d52229012e8bfcf1e8f7e4cf72f226d5aac451cc70ca23ead5ed3f9d5fe01952d6ea100330ef9daa56fd3bbd07c1c0ea81a918a432a9d47579a35c8e97d`
+
+## Changelog since v1.17.4
+
+## Changes by Kind
+
+### Feature
+
+- deps: Update to Golang 1.13.9
+  - build: Remove kube-cross image building ([#89399](https://github.com/kubernetes/kubernetes/pull/89399), [@justaugustus](https://github.com/justaugustus)) [SIG Release, Storage and Testing]
+
+### Bug or Regression
+
+- Client-go: resolves an issue with informers falling back to full list requests when timeouts are encountered, rather than re-establishing a watch. ([#89976](https://github.com/kubernetes/kubernetes/pull/89976), [@liggitt](https://github.com/liggitt)) [SIG API Machinery and Testing]
+- EndpointSlice controller now handles terminating pods correctly and is better at preventing race conditions. ([#89118](https://github.com/kubernetes/kubernetes/pull/89118), [@robscott](https://github.com/robscott)) [SIG Apps and Network]
+- Ensure Azure availability zone is always in lower cases. ([#89722](https://github.com/kubernetes/kubernetes/pull/89722), [@feiskyer](https://github.com/feiskyer)) [SIG Cloud Provider]
+- Fix failing conformance when using docker container runtime w/ the docker/journald logging driver. &#35;87933 ([#88586](https://github.com/kubernetes/kubernetes/pull/88586), [@jdef](https://github.com/jdef)) [SIG Node]
+- Fix invalid VMSS updates due to incorrect cache ([#89002](https://github.com/kubernetes/kubernetes/pull/89002), [@ArchangelSDY](https://github.com/ArchangelSDY)) [SIG Cloud Provider]
+- Fix the VMSS name and resource group name when updating Azure VMSS for LoadBalancer backendPools ([#89337](https://github.com/kubernetes/kubernetes/pull/89337), [@feiskyer](https://github.com/feiskyer)) [SIG Cloud Provider]
+- Fix: check disk status before delete azure disk ([#88360](https://github.com/kubernetes/kubernetes/pull/88360), [@andyzhangx](https://github.com/andyzhangx)) [SIG Cloud Provider]
+- Fixed a data race in kubelet image manager that can cause static pod workers to silently stop working. ([#88915](https://github.com/kubernetes/kubernetes/pull/88915), [@roycaihw](https://github.com/roycaihw)) [SIG Node]
+- Fixed an issue that could cause the kubelet to incorrectly run concurrent pod reconciliation loops and crash. ([#89055](https://github.com/kubernetes/kubernetes/pull/89055), [@tedyu](https://github.com/tedyu)) [SIG Node]
+- Fixed the EndpointSlice controller to run without error on a cluster with the OwnerReferencesPermissionEnforcement validating admission plugin enabled. ([#89805](https://github.com/kubernetes/kubernetes/pull/89805), [@marun](https://github.com/marun)) [SIG Auth and Network]
+- Fixes conversion error for HorizontalPodAutoscaler objects with invalid annotations ([#89967](https://github.com/kubernetes/kubernetes/pull/89967), [@liggitt](https://github.com/liggitt)) [SIG Autoscaling]
+- Fixes conversion error in multi-version custom resources that could cause metadata.generation to increment on no-op patches or updates of a custom resource. ([#88995](https://github.com/kubernetes/kubernetes/pull/88995), [@liggitt](https://github.com/liggitt)) [SIG API Machinery]
+- Fixes kubectl apply/prune in namespace other than default. ([#90024](https://github.com/kubernetes/kubernetes/pull/90024), [@seans3](https://github.com/seans3)) [SIG CLI and Testing]
+- For GCE cluster provider, fix bug of not being able to create internal type load balancer for clusters with more than 1000 nodes in a single zone. ([#89902](https://github.com/kubernetes/kubernetes/pull/89902), [@wojtek-t](https://github.com/wojtek-t)) [SIG Cloud Provider, Network and Scalability]
+- For volumes that allow attaches across multiple nodes, attach and detach operations across different nodes are now executed in parallel. ([#89239](https://github.com/kubernetes/kubernetes/pull/89239), [@verult](https://github.com/verult)) [SIG Apps, Node and Storage]
+- Kube-proxy no longer modifies shared EndpointSlices and will not break with EndpointSlice feature gate enabled on Windows. ([#89117](https://github.com/kubernetes/kubernetes/pull/89117), [@robscott](https://github.com/robscott)) [SIG Network]
+- Kubeadm: apply further improvements to the tentative support for concurrent etcd member join. Fixes a bug where multiple members can receive the same hostname. Increase the etcd client dial timeout and retry timeout for add/remove/... operations. ([#87505](https://github.com/kubernetes/kubernetes/pull/87505), [@neolit123](https://github.com/neolit123)) [SIG Cluster Lifecycle]
+- Kubelet metrics gathered through metrics-server or prometheus should no longer timeout for Windows nodes running more than 3 pods. ([#87730](https://github.com/kubernetes/kubernetes/pull/87730), [@marosset](https://github.com/marosset)) [SIG Node, Testing and Windows]
+- Restores priority of static control plane pods in the cluster/gce/manifests control-plane manifests ([#89970](https://github.com/kubernetes/kubernetes/pull/89970), [@liggitt](https://github.com/liggitt)) [SIG Cluster Lifecycle and Node]
+
+### Other (Cleanup or Flake)
+
+- Reduce event spam during a volume operation error. ([#89794](https://github.com/kubernetes/kubernetes/pull/89794), [@msau42](https://github.com/msau42)) [SIG Storage]
+
+
+# v1.17.4
+
+[Documentation](https://docs.k8s.io)
+
+## Downloads for v1.17.4
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes.tar.gz](https://dl.k8s.io/v1.17.4/kubernetes.tar.gz) | `cf69ebcaddc3902008399b96a18548d9a2a551d9fa6a1e34533f0f83ef10ab501030c3310cbaa593d550905d23c23ad7c8901720fe61f89d466f49bdac5554e8`
+[kubernetes-src.tar.gz](https://dl.k8s.io/v1.17.4/kubernetes-src.tar.gz) | `c638e47bc54754842a018e2cd2e724357f5e3906c0971dad76656e8a8e0ced65e5919b9b83a89a251b3458fd17802bfa7f4d37a0ccb9475558b5be5774888497`
+
+### Client Binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-client-darwin-386.tar.gz](https://dl.k8s.io/v1.17.4/kubernetes-client-darwin-386.tar.gz) | `64eee9f00ce02b6a139bd20512130f5d193d3862853460fa94b43c946cbcc90e40254786288263cb589ae730d778766e6204768fbd2292f91ee12ea1ad940a8a`
+[kubernetes-client-darwin-amd64.tar.gz](https://dl.k8s.io/v1.17.4/kubernetes-client-darwin-amd64.tar.gz) | `02646ce4087a59c2b6a3e398554173f969639d47ef6b14f384812f44f5dbbb76d13ec69bc086fb74390eedbbf6d3976c1506b3cec74411a39b19b337a0060dc6`
+[kubernetes-client-linux-386.tar.gz](https://dl.k8s.io/v1.17.4/kubernetes-client-linux-386.tar.gz) | `bef8fe2453666b9e8a4b5f130b95b1dfaf1294d30cbc08eea53caaa715db0ba63bb5f532abe825c55a51d66eef2db47073e0925c10db92ea76e4250b89a5cd70`
+[kubernetes-client-linux-amd64.tar.gz](https://dl.k8s.io/v1.17.4/kubernetes-client-linux-amd64.tar.gz) | `42907ace0672b839f656e3afa09827725cdb94980435b186221c36f7a9e2d6eb39b97ee4ef9848ed817066e6ba7c10d7d29b3e3674c82218c1f5ef1227668ae7`
+[kubernetes-client-linux-arm.tar.gz](https://dl.k8s.io/v1.17.4/kubernetes-client-linux-arm.tar.gz) | `f50785865d8830fa05bc27f7812e213c4ab4b1d020b5eb919bbf20910cfd98c2f55211211b927111a88d054338e965fdaab44128a8317615fa8b785418aa2c0a`
+[kubernetes-client-linux-arm64.tar.gz](https://dl.k8s.io/v1.17.4/kubernetes-client-linux-arm64.tar.gz) | `13b0ec947cb186e17fbb571ad1bceef84cf236a8ab3bf52679006f30bbafa8fa6d40a6926adbabcea8b93e504f25ecbb61ec043e7b4469a9269baded7608cfaa`
+[kubernetes-client-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.17.4/kubernetes-client-linux-ppc64le.tar.gz) | `e4727134da0b01a31977f225794cff9d9860b0f62b670fb525cba1b686d7d733b3ded8150185085b8fb7cd49d7ac05d78b8901e7d33e1c3162f4e115b10c7ec3`
+[kubernetes-client-linux-s390x.tar.gz](https://dl.k8s.io/v1.17.4/kubernetes-client-linux-s390x.tar.gz) | `368b03ac429d2c8368312214be0ce656e7d9ac7ae334a3659b8fbb8c75713d57c09944c72a77bd199f03b2936bdc4751a4fa5e94f471c91ddf9d8b306c273269`
+[kubernetes-client-windows-386.tar.gz](https://dl.k8s.io/v1.17.4/kubernetes-client-windows-386.tar.gz) | `962779586897ec218afad31178b547b2eec1e79c434ead49d51459174cca3578b40ff80b3db2b52d0b0270319a8ff1d3c8d458e72ac30d1e15fc854c9f3308be`
+[kubernetes-client-windows-amd64.tar.gz](https://dl.k8s.io/v1.17.4/kubernetes-client-windows-amd64.tar.gz) | `c905c5ed45bd430aa9c8f2147edb0a0ac7d5bbd934a77ac6b9527dd5f0abc04ee6f9f69de75a26db279e785ca6fa0631b244ea6bdc31866a557b5fbcb50654a0`
+
+### Server Binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-server-linux-amd64.tar.gz](https://dl.k8s.io/v1.17.4/kubernetes-server-linux-amd64.tar.gz) | `a26953a277a383629139651913b85092ef722cf00722193df31ff977cac70a7441bb10d124159527ed8d5eede24208bd95c13a24590ad87c3d831f1a67532940`
+[kubernetes-server-linux-arm.tar.gz](https://dl.k8s.io/v1.17.4/kubernetes-server-linux-arm.tar.gz) | `0c8def28b67d7a8e2644662f8a42aeda5536249d8c7f63e0bbe225e1dab45a1773b5fae49590acb307f9e4f32cfdcad29b1ec5593552d2016d509ff84f0c5be1`
+[kubernetes-server-linux-arm64.tar.gz](https://dl.k8s.io/v1.17.4/kubernetes-server-linux-arm64.tar.gz) | `95285714bf8542bbc482b0544eb6cdfcb0cf217e6863c27810dfe10371674d539cb372ee35a8513fc5710c48cd969ce88c11b020382324650a709b83c39d9466`
+[kubernetes-server-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.17.4/kubernetes-server-linux-ppc64le.tar.gz) | `5cb63c371dc9b2ad7a1d665debd1e9890cc49235b61767aa5244141989e90bf1d0e678c2c89bdcec31b2cb23aa6481deebe7e8291f71ee7c8911ad3b55c8e8e8`
+[kubernetes-server-linux-s390x.tar.gz](https://dl.k8s.io/v1.17.4/kubernetes-server-linux-s390x.tar.gz) | `fd26e9f6d8dc473c75f83ffd5c0fed0e28d307d88915db7c3152804e7728504a9958e6fee0ee21418f146876fcf107ef521eb42d6d2a64d97055db1367e7c0ee`
+
+### Node Binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-node-linux-amd64.tar.gz](https://dl.k8s.io/v1.17.4/kubernetes-node-linux-amd64.tar.gz) | `31cfbc4610504a02c7b3fcd0b97b48b27afdf9232fa0d02527c7873a78bb72f9f3c8fac77a2187695da5cfd40f4d42691d188fa142da3d3b7807e034a279d477`
+[kubernetes-node-linux-arm.tar.gz](https://dl.k8s.io/v1.17.4/kubernetes-node-linux-arm.tar.gz) | `5f458a3b8d91cd9b5fb47a9f6d1091bc960115140d4ed6f6dab7d275599b80f7bc62b3869e1cf7121a3ca34b6a50fb026aed104e9036a4157e6208f404e1f288`
+[kubernetes-node-linux-arm64.tar.gz](https://dl.k8s.io/v1.17.4/kubernetes-node-linux-arm64.tar.gz) | `1d92b3de82c9db491a2281a684d9a2dd86e998b66455ab2b48a4449e50aedd2605a2be04d930696c119b08f3a3eea5ec0afac0ae6735ebbaf968de1e064bbb80`
+[kubernetes-node-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.17.4/kubernetes-node-linux-ppc64le.tar.gz) | `ee17d8964217e6a53b2e9a93edecb882a8e8ad9c6d40c2875bc61f35a5e1dfdd08a9a80f4567578858e3b48b822bb4ce2a52c63258e569b0346c13bfd0fa45bb`
+[kubernetes-node-linux-s390x.tar.gz](https://dl.k8s.io/v1.17.4/kubernetes-node-linux-s390x.tar.gz) | `7e38f136462d6edfe117d8c98da5e5011d4a21bd5e9121649a73ca29d0ed36e877582107a20c52f8d43097d5d9343834f85a309c985e079e5223bfa96af27458`
+[kubernetes-node-windows-amd64.tar.gz](https://dl.k8s.io/v1.17.4/kubernetes-node-windows-amd64.tar.gz) | `1f36238ced406817dd25971616b6bbb3ff595b334442ce614c611e4ef3bde626771390446b90e1f38ebc7c89c236fa44e8c520fbc2a45e22e008cadd41368874`
+
+## Changelog since v1.17.3
+
+## Changes by Kind
+
+### API Change
+
+- Fixes a regression with clients prior to 1.15 not being able to update podIP in pod status, or podCIDR in node spec, against >= 1.16 API servers ([#88505](https://github.com/kubernetes/kubernetes/pull/88505), [@liggitt](https://github.com/liggitt)) [SIG Apps and Network]
+
+### Other (Bug, Cleanup or Flake)
+
+- Add delays between goroutines for vm instance update ([#88094](https://github.com/kubernetes/kubernetes/pull/88094), [@aramase](https://github.com/aramase)) [SIG Cloud Provider]
+- Adds "volume.beta.kubernetes.io/migrated-to" annotation to PV's and PVC's when they are migrated to signal external provisioners to pick up those objects for Provisioning and Deleting. ([#87098](https://github.com/kubernetes/kubernetes/pull/87098), [@davidz627](https://github.com/davidz627)) [SIG Apps and Storage]
+- Build: Enable kube-cross image-building on K8s Infra ([#88595](https://github.com/kubernetes/kubernetes/pull/88595), [@justaugustus](https://github.com/justaugustus)) [SIG Release and Testing]
+- Fix /readyz to return error immediately after a shutdown is initiated, before the --shutdown-delay-duration has elapsed. ([#88953](https://github.com/kubernetes/kubernetes/pull/88953), [@tkashem](https://github.com/tkashem)) [SIG API Machinery]
+- Fix a bug in kube-proxy that caused it to crash when using load balancers with a different IP family ([#87117](https://github.com/kubernetes/kubernetes/pull/87117), [@aojea](https://github.com/aojea)) [SIG Network]
+- Fix handling of aws-load-balancer-security-groups annotation. Security-Groups assigned with this annotation are no longer modified by kubernetes which is the expected behaviour of most users. Also no unnecessary Security-Groups are created anymore if this annotation is used. ([#88689](https://github.com/kubernetes/kubernetes/pull/88689), [@Elias481](https://github.com/Elias481)) [SIG Cloud Provider]
+- Fix route conflicted operations when updating multiple routes together ([#88209](https://github.com/kubernetes/kubernetes/pull/88209), [@feiskyer](https://github.com/feiskyer)) [SIG Cloud Provider]
+- Fix: add azure disk migration support for CSINode ([#88014](https://github.com/kubernetes/kubernetes/pull/88014), [@andyzhangx](https://github.com/andyzhangx)) [SIG Cloud Provider and Storage]
+- Fix: add remediation in azure disk attach/detach ([#88444](https://github.com/kubernetes/kubernetes/pull/88444), [@andyzhangx](https://github.com/andyzhangx)) [SIG Cloud Provider]
+- Fix: azure file mount timeout issue ([#88610](https://github.com/kubernetes/kubernetes/pull/88610), [@andyzhangx](https://github.com/andyzhangx)) [SIG Cloud Provider and Storage]
+- Fix: corrupted mount point in csi driver ([#88569](https://github.com/kubernetes/kubernetes/pull/88569), [@andyzhangx](https://github.com/andyzhangx)) [SIG Storage]
+- Fix: get azure disk lun timeout issue ([#88158](https://github.com/kubernetes/kubernetes/pull/88158), [@andyzhangx](https://github.com/andyzhangx)) [SIG Cloud Provider and Storage]
+- Fixes issue where you can't attach more than 15 GCE Persistent Disks to c2, n2, m1, m2 machine types. ([#88602](https://github.com/kubernetes/kubernetes/pull/88602), [@yuga711](https://github.com/yuga711)) [SIG Storage]
+- Fixes kubelet crash in client certificate rotation cases ([#88079](https://github.com/kubernetes/kubernetes/pull/88079), [@liggitt](https://github.com/liggitt)) [SIG API Machinery, Auth and Node]
+- Get-kube.sh uses the gcloud's current local GCP service account for auth when the provider is GCE or GKE instead of the metadata server default ([#88383](https://github.com/kubernetes/kubernetes/pull/88383), [@BenTheElder](https://github.com/BenTheElder)) [SIG Cluster Lifecycle]
+- Golang/x/net has been updated to bring in fixes for CVE-2020-9283 ([#88381](https://github.com/kubernetes/kubernetes/pull/88381), [@BenTheElder](https://github.com/BenTheElder)) [SIG API Machinery, CLI, Cloud Provider, Cluster Lifecycle and Instrumentation]
+- Limit number of instances in a single update to GCE target pool to 1000. ([#87881](https://github.com/kubernetes/kubernetes/pull/87881), [@wojtek-t](https://github.com/wojtek-t)) [SIG Cloud Provider, Network and Scalability]
+- Update to use golang 1.13.8 ([#87648](https://github.com/kubernetes/kubernetes/pull/87648), [@ialidzhikov](https://github.com/ialidzhikov)) [SIG Release and Testing]
+
+
+# v1.17.3
+
+[Documentation](https://docs.k8s.io)
+
+## Downloads for v1.17.3
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes.tar.gz](https://dl.k8s.io/v1.17.3/kubernetes.tar.gz) | `63e54488630e41488f7153583b3c536df766a623c9eb41634e09a113e2ffdaf973c85ddb5d13adc2727fcf262895ce2552507bdeaf2646c00097f4e24f2b9937`
+[kubernetes-src.tar.gz](https://dl.k8s.io/v1.17.3/kubernetes-src.tar.gz) | `e09b1010d1673faeba6684d28405ee0963c1b42a28da4b00c38169b0422ab86eadf01efdc190066b1556026f5cdc02214cb1237bdfc6e4db332f2c367fa8da8f`
+
+### Client Binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-client-darwin-386.tar.gz](https://dl.k8s.io/v1.17.3/kubernetes-client-darwin-386.tar.gz) | `00233c38903b92cd328b5bf4f48df47df9d858690887e46647e29f2453778ab53b16fe898476451c943e1d6aac4232c6ef2e36309296ea4ca423a7701f9c9feb`
+[kubernetes-client-darwin-amd64.tar.gz](https://dl.k8s.io/v1.17.3/kubernetes-client-darwin-amd64.tar.gz) | `587b2f0e4a8b4e736dfc480a939ad866f5cea8b28fe7cfd34bc383f9150096f6f9cfe43f8d902e06fca7eb51e58fd4a2769b6294e26d92e6f45554b93d92c5f5`
+[kubernetes-client-linux-386.tar.gz](https://dl.k8s.io/v1.17.3/kubernetes-client-linux-386.tar.gz) | `4ab88ef8526ee5a3fdffe3f6fcd85d0314c80cc079cc50945c073849dcc1dc0d0eb1595ce24b1f74494e18a4fa1d0770c15feb41b9b5b183c42a6bae88523968`
+[kubernetes-client-linux-amd64.tar.gz](https://dl.k8s.io/v1.17.3/kubernetes-client-linux-amd64.tar.gz) | `351d6b0d8077cadd8d4b95c145b165be5bc5cd07b59d44b7e81e6dc46f5b85f7419642f8273520ea1b63c9ac6f98c832c9cd46db8a1ca7dd03423f94d782557f`
+[kubernetes-client-linux-arm.tar.gz](https://dl.k8s.io/v1.17.3/kubernetes-client-linux-arm.tar.gz) | `0b2c490398001aa363b4e4dd3ac93abbcb6330e76a54534b6c66dbcd356f5fe7dadc51c8c4eda1ad2e842ff25301b3e54d24ae5b841f4e4c156b6299469ec207`
+[kubernetes-client-linux-arm64.tar.gz](https://dl.k8s.io/v1.17.3/kubernetes-client-linux-arm64.tar.gz) | `be0cab0399bea7aa78f286031328b049177107168a9ed28f0c7f0e38a04813b9a7f0570f3fd4f28080d12e4e4f8fd80c432a44f80fcfc5b872909d486096940f`
+[kubernetes-client-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.17.3/kubernetes-client-linux-ppc64le.tar.gz) | `8ce6ba5ee2f4867786dd279c016f1a2ac3355898cbe647455e108348131cb6df52fdbab3da1f60f0fcdad94da5787c99d5e762e7c7ce6da18526e3df16b64cc4`
+[kubernetes-client-linux-s390x.tar.gz](https://dl.k8s.io/v1.17.3/kubernetes-client-linux-s390x.tar.gz) | `88f20dd15d89b8134240c6c1c036529f1deca1e8f32860c2043147cfd533097d6fe8359f6673f3e2215a910ff4943542b5769a0033e543c26a8658b8277c260a`
+[kubernetes-client-windows-386.tar.gz](https://dl.k8s.io/v1.17.3/kubernetes-client-windows-386.tar.gz) | `71cdda152a25556743f7c83164b45988c9844fe3eae9033d76177a2615f84413f12867b9621762f4c0269caa758508b2eb3c09fb682b06d98f8668934c68ec67`
+[kubernetes-client-windows-amd64.tar.gz](https://dl.k8s.io/v1.17.3/kubernetes-client-windows-amd64.tar.gz) | `19f2a02540c9348b235e43854b3093989c41de0dcfc57df9ad9d63a339d9df13e87649c1675e475f45349fcb89fdea64efa12776f0817e0ae55e09764a95621d`
+
+### Server Binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-server-linux-amd64.tar.gz](https://dl.k8s.io/v1.17.3/kubernetes-server-linux-amd64.tar.gz) | `12f86462f6ab4c1fd1d057d4f8c874bd8782174966ffb3cb2477f0f68c3ede8e8119259f1cad18988ab38879de6e68c7be7ea4d7c6f7565621e82a4e9e949503`
+[kubernetes-server-linux-arm.tar.gz](https://dl.k8s.io/v1.17.3/kubernetes-server-linux-arm.tar.gz) | `ada379873db29c3f6eefcb5efa2b027ae835beb20b39c03fbbbf1c8490f447d888ee56944ca37c9c7054caf728247387509f82fc60d734b0692f9f810cc50b8e`
+[kubernetes-server-linux-arm64.tar.gz](https://dl.k8s.io/v1.17.3/kubernetes-server-linux-arm64.tar.gz) | `e3fc5cf9b111e232d28879116434481a45e2c38ad56a349a7353e020ab88baf492130172cd5a3f99234c5f38eddc63588e6798176191ce993585433aa5fe744a`
+[kubernetes-server-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.17.3/kubernetes-server-linux-ppc64le.tar.gz) | `8b8f8af3864fe71c4fb8f767a42dc47882816216da41c0b5d114a75b37c50c97dda58eb3681e829a5cd6339b4c390d3c7f3e4a157783d6732856bc94e2de6c26`
+[kubernetes-server-linux-s390x.tar.gz](https://dl.k8s.io/v1.17.3/kubernetes-server-linux-s390x.tar.gz) | `5483e4835ea03686b0f79413c3cde16305d752fd15665b3f78848c90f0ee7bcdc41c0869f203ddceb4a31ee43fce9a7e754a42f0b7827608da2e8defc62cf892`
+
+### Node Binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-node-linux-amd64.tar.gz](https://dl.k8s.io/v1.17.3/kubernetes-node-linux-amd64.tar.gz) | `74f34a4c00b6b9350d978bcdd06f6adce55b211876186e98bcef4eef35008ab9d1a39c5fec9f7fb3e6eafa382c2780f665ea52dae36fbbbb5d3bd5eb1f65c7ad`
+[kubernetes-node-linux-arm.tar.gz](https://dl.k8s.io/v1.17.3/kubernetes-node-linux-arm.tar.gz) | `6cd247524ca8373e0f23eba5a2021844a12d068dee64aaf195b8c430c7fc0ac66d3f30abde4cb425de87a0f94e5bd5f17e4e5a6f069b4dd90cdcfb1ec7be9097`
+[kubernetes-node-linux-arm64.tar.gz](https://dl.k8s.io/v1.17.3/kubernetes-node-linux-arm64.tar.gz) | `238e02534c2b905987fe54df477a793561d1e79c40a6c669cabdbec025e17cb186f1f543fb92459e1b1b6211ad670a7a722137800794c2cd4faf3a237910045f`
+[kubernetes-node-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.17.3/kubernetes-node-linux-ppc64le.tar.gz) | `a8d0ff718320cfa2771e4010d970f4e27c80daa2eb7e082be03d4310cf512926e099de9a47abcae5acc3db1ad41c4e9ce843b83ea3930a4fdb97d2d2a8919070`
+[kubernetes-node-linux-s390x.tar.gz](https://dl.k8s.io/v1.17.3/kubernetes-node-linux-s390x.tar.gz) | `c323ad2690a7924a0b264de678a01b4948cdfbac0d0cc357fcdc17c31ebc9debf7c0de5c18da23b533c480c04ffcc8140eb93442d3c5bf641344b0997f542e49`
+[kubernetes-node-windows-amd64.tar.gz](https://dl.k8s.io/v1.17.3/kubernetes-node-windows-amd64.tar.gz) | `7323b7adf83fccc65eea9f23370794aa9901e9a9b3b1ac90403197448408eee5be84f541aa2448ceaa12fe6278814575a26132cf6e0ddd2f8aa5fa47bd127c71`
+
+## Changelog since v1.17.2
+
+## Changes by Kind
+
+### Other (Bug, Cleanup or Flake)
+
+- Bind metrics-server containers to linux nodes to avoid Windows scheduling on kubernetes cluster includes linux nodes and windows nodes ([#87020](https://github.com/kubernetes/kubernetes/pull/87020), [@wawa0210](https://github.com/wawa0210)) [SIG Cluster Lifecycle and Instrumentation]
+- Bug fixes for EndpointSlice controller that prevent race condition and modifying shared objects. ([#87731](https://github.com/kubernetes/kubernetes/pull/87731), [@robscott](https://github.com/robscott)) [SIG Apps and Network]
+- Fix a regression in kubenet  that  prevent pods to obtain ip addresses ([#87286](https://github.com/kubernetes/kubernetes/pull/87286), [@aojea](https://github.com/aojea)) [SIG Network and Node]
+- Fix regression in statefulset conversion which prevented applying a statefulset multiple times. ([#87721](https://github.com/kubernetes/kubernetes/pull/87721), [@liggitt](https://github.com/liggitt)) [SIG Apps and Testing]
+- Fix the bug PIP's DNS is deleted if no DNS label service annotation isn't set. ([#87312](https://github.com/kubernetes/kubernetes/pull/87312), [@nilo19](https://github.com/nilo19)) [SIG Cloud Provider]
+- Fix: set nil cache entry based on old cache ([#87591](https://github.com/kubernetes/kubernetes/pull/87591), [@aramase](https://github.com/aramase)) [SIG Cloud Provider]
+- Fixed a bug which could prevent a provider ID from ever being set for node if an error occurred determining the provider ID when the node was added. ([#87043](https://github.com/kubernetes/kubernetes/pull/87043), [@zjs](https://github.com/zjs)) [SIG Apps and Cloud Provider]
+- Fixed the following 
+  -  AWS Cloud Provider attempts to delete LoadBalancer security group it didn’t provision
+  -  AWS Cloud Provider creates default LoadBalancer security group even if annotation [service.beta.kubernetes.io/aws-load-balancer-security-groups] is present ([#87206](https://github.com/kubernetes/kubernetes/pull/87206), [@bhagwat070919](https://github.com/bhagwat070919)) [SIG Cloud Provider]
+- Fixed two scheduler metrics (pending_pods and schedule_attempts_total) not being recorded ([#87692](https://github.com/kubernetes/kubernetes/pull/87692), [@everpeace](https://github.com/everpeace)) [SIG Scheduling]
+- Kubelet metrics have been changed to buckets. 
+  For example the exec/{podNamespace}/{podID}/{containerName} is now just exec. ([#87913](https://github.com/kubernetes/kubernetes/pull/87913), [@cheftako](https://github.com/cheftako)) [SIG Node]
+- Pods that are considered for preemption and haven't started don't produce an error log. ([#87900](https://github.com/kubernetes/kubernetes/pull/87900), [@alculquicondor](https://github.com/alculquicondor)) [SIG Scheduling]
+- Reverted a kubectl azure auth module change where oidc claim spn: prefix was omitted resulting a breaking behavior with existing Azure AD OIDC enabled api-server ([#87507](https://github.com/kubernetes/kubernetes/pull/87507), [@weinong](https://github.com/weinong)) [SIG API Machinery, Auth and Cloud Provider]
+- The client label for apiserver_request_count and apiserver_request_total now no-opts and merely records an empty string. ([#87673](https://github.com/kubernetes/kubernetes/pull/87673), [@logicalhan](https://github.com/logicalhan)) [SIG API Machinery, Instrumentation and Scalability]
+
+
+<!-- NEW RELEASE NOTES ENTRY -->
+
+
+# v1.17.2
+
+[Documentation](https://docs.k8s.io)
+
+## Downloads for v1.17.2
+
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes.tar.gz](https://dl.k8s.io/v1.17.2/kubernetes.tar.gz) | `82771f9ea6e1da774473500e03bbb8ad8328c27c05ee79514528df5283556f8803763b47a4d815db8f1c0a007d9cdfbb845c985562fb7a5a5386d80b765c4355`
+[kubernetes-src.tar.gz](https://dl.k8s.io/v1.17.2/kubernetes-src.tar.gz) | `117222d9590e17e5f932644e54299cf35c870b7969b12aff51392ba958a298793fee54d7346c64d973a92b1d94a9271fb28ecc68157023fa2424f74a647bacff`
+
+### Client Binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-client-darwin-386.tar.gz](https://dl.k8s.io/v1.17.2/kubernetes-client-darwin-386.tar.gz) | `fb0163fd0f8e8372c6f6424097badf1ee0b9af1aff5aa6331bdfebf529e71c30a3f5eb062e0b9312afb51e7946d35c426631998c7c0e569b888788bee0a851ca`
+[kubernetes-client-darwin-amd64.tar.gz](https://dl.k8s.io/v1.17.2/kubernetes-client-darwin-amd64.tar.gz) | `b8cc6dde28dbf06ecfdad6917e1707c3e776aca05d6d3bf782cc26210d87fd2c6abac4cfa73de8d4df7bbd4a46a637e73e90c02b0ca1aa9d98110153e291398f`
+[kubernetes-client-linux-386.tar.gz](https://dl.k8s.io/v1.17.2/kubernetes-client-linux-386.tar.gz) | `bb2ba270c7953a5ff020cd28116c6067c4299af31c2b2521fd54296b66047c6c4e46731b6293350470ad35a1d4ea90bbd501cbcfa4db8b7aec15f6bcf3e0118f`
+[kubernetes-client-linux-amd64.tar.gz](https://dl.k8s.io/v1.17.2/kubernetes-client-linux-amd64.tar.gz) | `c5cd8954953ea348318f207c99c9dcb679d73dbaf562ac72660f7dab85616fd45b0f349d49eae9ea1f6aac7cae5bba839bf70f40b8be686d35605ae147339399`
+[kubernetes-client-linux-arm.tar.gz](https://dl.k8s.io/v1.17.2/kubernetes-client-linux-arm.tar.gz) | `e53a85f0ff2f522603005fec16a9019794f6c7b2704b66e2a963909193caff92737d48a305a10ce40a829cef916fbfed88b31c7d0cc009816da1c714cf902add`
+[kubernetes-client-linux-arm64.tar.gz](https://dl.k8s.io/v1.17.2/kubernetes-client-linux-arm64.tar.gz) | `9cdd0e75bc67f8197c50d7b07ef3aa5b59882cb50ac06abf56d4897b12dc7579759963eee2cba2ed8d638ff5466879077c69cf555ed2104f37c6880001e93e23`
+[kubernetes-client-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.17.2/kubernetes-client-linux-ppc64le.tar.gz) | `f0ae9f154146047c8153df0de7d085977ff308227503e8cb673d8c97af933a4093ec26f7676acbaf7e44b7a999817dad02696a754298ce949ceb3fd0dbd3dadb`
+[kubernetes-client-linux-s390x.tar.gz](https://dl.k8s.io/v1.17.2/kubernetes-client-linux-s390x.tar.gz) | `203d030803959df4dab13e17e57cfd9ece1e68b09c769172475b73268c3d25bbe7b197c29f7925fe9d79078aa415f91998f319ccfdde9d983218528b85018966`
+[kubernetes-client-windows-386.tar.gz](https://dl.k8s.io/v1.17.2/kubernetes-client-windows-386.tar.gz) | `de36a20e3484c2039344123853cf3b60bd9ce49e248a2d0c821aeb7a9d9051558c3a60b5f8b528dc3173f6ea32c9a57bf9c4f15ea53c2b1c9732b912c5076639`
+[kubernetes-client-windows-amd64.tar.gz](https://dl.k8s.io/v1.17.2/kubernetes-client-windows-amd64.tar.gz) | `e43beb437f077dd995b28bf8a306c413117315612eb5cf2ecbb686b2420d6d2bb4eca387fe9aa5adcc26599a57a7918ff6b558351ca2c6e4bfdf4001806cdb6f`
+
+### Server Binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-server-linux-amd64.tar.gz](https://dl.k8s.io/v1.17.2/kubernetes-server-linux-amd64.tar.gz) | `472e911bf28a6fc583c20cf56eee4a8ec2ede557454b4f5dabc668cd211aeada3cc3486ea104d786105babd9e7de4f817961e6290edfcd073849c6a1de566402`
+[kubernetes-server-linux-arm.tar.gz](https://dl.k8s.io/v1.17.2/kubernetes-server-linux-arm.tar.gz) | `14b95f7e8ecf75026f19e4f28c53ed6d1bc82b5577c045168c787cd95cff9975b610a1f3b9125dc1145eed5313f34d10e8b8884cbeb173db69e6c6a533e4f898`
+[kubernetes-server-linux-arm64.tar.gz](https://dl.k8s.io/v1.17.2/kubernetes-server-linux-arm64.tar.gz) | `cec1cc9a4f99295a9c98467ac76cec50f7da23ed45f21ad9bf860fb950f4ffeb0786ca8929b0d749e7786644d0a5bbe132445d1930d53226ce88551583329f18`
+[kubernetes-server-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.17.2/kubernetes-server-linux-ppc64le.tar.gz) | `4727e58ba35303280a4203b2a09b4344cfed372e943a29176e43b3877c1b854b72519b62dbfdcb536f885068c102fa905f8da20d61fdafa2f6451c79b836f28e`
+[kubernetes-server-linux-s390x.tar.gz](https://dl.k8s.io/v1.17.2/kubernetes-server-linux-s390x.tar.gz) | `e178c46402b9c308ff915a5f7675fead8a43de45fe1c55b0b36b26aa6fe2c97ac853fa937817fb3345df45b93ec19ee11e9e3c64a7ba865d4ddbaba151566e33`
+
+### Node Binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-node-linux-amd64.tar.gz](https://dl.k8s.io/v1.17.2/kubernetes-node-linux-amd64.tar.gz) | `e7546138dd1768716e7bbfe6136625ff2023293ec1f62741b63c167aaebe9b200314f140608445fa5393512aebe7c2eece17d5935c9257fe05d3b9d9ac25c9b3`
+[kubernetes-node-linux-arm.tar.gz](https://dl.k8s.io/v1.17.2/kubernetes-node-linux-arm.tar.gz) | `0360d2676726a6884d6a2a66ecfe77e1b50882ab1301bd9bfb935b958de4da710a9f748a45641c7131863b763df579a1e8f09a940effedee67fe3d903ec9e9c8`
+[kubernetes-node-linux-arm64.tar.gz](https://dl.k8s.io/v1.17.2/kubernetes-node-linux-arm64.tar.gz) | `4ca031a44f2dbbca883406258904e11e11360ab80300f5c422e88103545214a180a6718eb423404f6421f20a2f04863cf6d90c116c95dac962de618f7d2097a8`
+[kubernetes-node-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.17.2/kubernetes-node-linux-ppc64le.tar.gz) | `79a20f5c2acc454e9803bd9ece890ebc0564a45471e4afa03c92b6b489354466081639b779433f6a511a22e3303e7332704f3ba7188b17b4d3861a609c875fc2`
+[kubernetes-node-linux-s390x.tar.gz](https://dl.k8s.io/v1.17.2/kubernetes-node-linux-s390x.tar.gz) | `553b5fccf539da0f149b97ba47d4d1e163c86a6a057132fa308f9eb2e3df728ba692c98000fab977b2900980f20cd58f0482c2cdc0044d5a6d71e4b14e9acf83`
+[kubernetes-node-windows-amd64.tar.gz](https://dl.k8s.io/v1.17.2/kubernetes-node-windows-amd64.tar.gz) | `0d17642c68aeaffa276ee92c87181a3ef6d9e4dd2b41d6b064f7a20bb3ad9cd7d29a8494006c520771e48469049a0d0c146ccd2991199ad5fceda178a03c2ba9`
+
+## Changelog since v1.17.1
+
+**No notable changes for this release**
+
+
+
+# v1.17.1
+
+[Documentation](https://docs.k8s.io)
+
+## Downloads for v1.17.1
+
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes.tar.gz](https://dl.k8s.io/v1.17.1/kubernetes.tar.gz) | `b75a513ac1edc366a0ab829866687c4937485a00a0621a729860ae95fa278ecdadf37d63e608b2259e1c683dd01faf26eb828636710d9864e6f092b1a3cfd1cf`
+[kubernetes-src.tar.gz](https://dl.k8s.io/v1.17.1/kubernetes-src.tar.gz) | `18402d56c7b4b01b59bd8fb6251bf53dcbd1b68b79ca5d7cf0ca6789d8ad9cc5849fe470d018319f1f26a8780d2746be0ead556d00fcc6baf1b675fe8bb7c121`
+
+### Client Binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-client-darwin-386.tar.gz](https://dl.k8s.io/v1.17.1/kubernetes-client-darwin-386.tar.gz) | `160471e49fd1117154bd22b4aabe2c61051db5c0160c4ea32f9341a3f9b2e1a2a04d43588b618a8c3673db8ffcf3df74e523eed614f9f89ff9439a5e8ce83e04`
+[kubernetes-client-darwin-amd64.tar.gz](https://dl.k8s.io/v1.17.1/kubernetes-client-darwin-amd64.tar.gz) | `29291fc2c8b36d13590c7cfdf423ac64d102962c39470398ee7b9e6191c44da29ca2e8c1c82cdae4a97b32f33f781be8b718512033172d03d29ae2e448bb66fe`
+[kubernetes-client-linux-386.tar.gz](https://dl.k8s.io/v1.17.1/kubernetes-client-linux-386.tar.gz) | `41dafee8a1e73a56a25d87b93c2d8287145cfcd3a844a085c34cd6cafdbb229548d11c8e0ddfc776b873d5f2cbfedd8b7f7c607c2a850dc686dccca655807199`
+[kubernetes-client-linux-amd64.tar.gz](https://dl.k8s.io/v1.17.1/kubernetes-client-linux-amd64.tar.gz) | `0f8b21ce610b738d0a993b40134edf4ce5ef3d2b020f2bf2ca5a5f142bbe5d0070004796ae7e617441c524ba27712db1c54c00596b768ec0d592e4bc0cc97d48`
+[kubernetes-client-linux-arm.tar.gz](https://dl.k8s.io/v1.17.1/kubernetes-client-linux-arm.tar.gz) | `c7d4d89c06161ffedec679bc5697b7975bfd4ad40df3d083ef056db0a8c3851f7ffe7d727d360881c7cfb24fea78a49e5396469200078aeab7de19cceeaca272`
+[kubernetes-client-linux-arm64.tar.gz](https://dl.k8s.io/v1.17.1/kubernetes-client-linux-arm64.tar.gz) | `60d5edd8cd48b2facb3e1c5b347ed0f204e7c808933453abd6ed11586cf01272455bf675c77e6bd87aaf8b6acac29d82548be7c4c97c8d475804a7e5290a9da8`
+[kubernetes-client-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.17.1/kubernetes-client-linux-ppc64le.tar.gz) | `0b7c8275bde773fbf5be33522e8f5397646d812b82fd76c94a5267d75695ba1a3f13b2e165c2b5bed9594b719a523fedcb3ef964d7f52293030d4e3ec23b87a8`
+[kubernetes-client-linux-s390x.tar.gz](https://dl.k8s.io/v1.17.1/kubernetes-client-linux-s390x.tar.gz) | `b6e71cb554e521a15c132910c603aee5a6af1e1c5626dbddeb34f1185a6ee77fbf6fa6ede50c7e082abbe425152d25616d31ad67a4e5d02e7f41739575b660bc`
+[kubernetes-client-windows-386.tar.gz](https://dl.k8s.io/v1.17.1/kubernetes-client-windows-386.tar.gz) | `ecb66c26b38e5ef7e4e8a56387abb04c91db4986b3cd7ef885c1f483064f166be0a30267fafd9fe0725313e726af5c19175691085df978d9f9126671fe375a9e`
+[kubernetes-client-windows-amd64.tar.gz](https://dl.k8s.io/v1.17.1/kubernetes-client-windows-amd64.tar.gz) | `84892304a154f52815211c4b34f6d2d733edca81bb7cb9b9f82b57dd80d276b842c81fbaf76becf5a02827b54eb5f02733fccd36da9c9d6a4815d5df14afc49c`
+
+### Server Binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-server-linux-amd64.tar.gz](https://dl.k8s.io/v1.17.1/kubernetes-server-linux-amd64.tar.gz) | `6167314423333f34a4850bd3860617217650f6d2cabf1c287de868040c594601c7d84d2ab17adfa2caf937d74339ae07c71a89af57c2408f5f0e81a347185683`
+[kubernetes-server-linux-arm.tar.gz](https://dl.k8s.io/v1.17.1/kubernetes-server-linux-arm.tar.gz) | `87e04427e7001cb065d1de505f250e054ed3b11d6d3e35b19d830c4040dcf96d3eb3df2247791d5b4e2e593751b1a360a53a7bac54a517248e838b1682f6b768`
+[kubernetes-server-linux-arm64.tar.gz](https://dl.k8s.io/v1.17.1/kubernetes-server-linux-arm64.tar.gz) | `6c6e58a97a6235b37be076439b76f3b102a131b87371793833b420d5b22ae7cfb9b2c201f710a6fd34bef1440a1232d2706019cbd2fa10fe0ec699bd98c34fe0`
+[kubernetes-server-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.17.1/kubernetes-server-linux-ppc64le.tar.gz) | `31aa35a2fff29f54183f1ca82ca7cf3ae1796e1f49592f2f789597edb300364631f46b795f13fbb152ea822a666e3ebcac0837bfa32791bfac3d104556f4baca`
+[kubernetes-server-linux-s390x.tar.gz](https://dl.k8s.io/v1.17.1/kubernetes-server-linux-s390x.tar.gz) | `287eaa186dde6858c84234f7219bb4959476033805294e7d9cddb8b097644b218c5119e2e5c8fffbd1244f948b4e431ea75c7159e4913ae5651abe23aec78f78`
+
+### Node Binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-node-linux-amd64.tar.gz](https://dl.k8s.io/v1.17.1/kubernetes-node-linux-amd64.tar.gz) | `c91c314caa7a5a7ad6d7bf1663b5fd7a7d4a125c250dc1442bae6d742f964e1e5d936740571e89f29b68806f9c220072a2c61ba4ddbed355004d006cee1fd195`
+[kubernetes-node-linux-arm.tar.gz](https://dl.k8s.io/v1.17.1/kubernetes-node-linux-arm.tar.gz) | `c3cefebf12aa0848201cf68d32227386498180c31c78a38e81988953bd0dc387697e164e593482b5c39001cc01b94e274e550091d3312d6c53eb0a4c9f8ac933`
+[kubernetes-node-linux-arm64.tar.gz](https://dl.k8s.io/v1.17.1/kubernetes-node-linux-arm64.tar.gz) | `a278b708b1d68405315128619fca63a7cd35cd980575309a8893c8d128e4cc5c76a0feaac9669ce56524f3c839126eca149e0ea5b20f0da8ca45c954a0c4eda8`
+[kubernetes-node-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.17.1/kubernetes-node-linux-ppc64le.tar.gz) | `8a74e82b6e07203d273c598c6c63af16f278d4d42224157a82b52a490f9549cfe0f3bb72fe05ffc5b1c1fe20e7aacbfcd35b8aadbc77a749a49ef1ddeb911af9`
+[kubernetes-node-linux-s390x.tar.gz](https://dl.k8s.io/v1.17.1/kubernetes-node-linux-s390x.tar.gz) | `fd35476eff035bcf35423a5fec3579861c5b2bd7b970c47075cc3f314be6988323505f526dd4cd46e9a90a4985491a4dca39deb5481c4bcf6a50270beb28bc80`
+[kubernetes-node-windows-amd64.tar.gz](https://dl.k8s.io/v1.17.1/kubernetes-node-windows-amd64.tar.gz) | `feddf53e05819f081d08d8d4086b395848d638c728a8aaa30e7d83cdfdbbbfc2a786a389f9b27c33b00fd42237e5976be1f706734563e1c35cc675bb87a909c2`
+
+## Changelog since v1.17.0
+
+### Other notable changes
+
+* Fixed a regression where the kubelet would fail to update the ready status of pods. ([#84951](https://github.com/kubernetes/kubernetes/pull/84951), [@tedyu](https://github.com/tedyu))
+* Fix nil pointer dereference in azure cloud provider ([#85975](https://github.com/kubernetes/kubernetes/pull/85975), [@ldx](https://github.com/ldx))
+* fix: azure disk could not mounted on Standard_DC4s/DC2s instances ([#86612](https://github.com/kubernetes/kubernetes/pull/86612), [@andyzhangx](https://github.com/andyzhangx))
+* Fix v1.17.0 regression in reflector relist causing master rolling upgrade to fail for large clusters due to excessive list calls to etcd ([#86824](https://github.com/kubernetes/kubernetes/pull/86824), [@jpbetz](https://github.com/jpbetz))
+* Fixes issue where AAD token obtained by kubectl is incompatible with on-behalf-of flow and oidc. ([#86412](https://github.com/kubernetes/kubernetes/pull/86412), [@weinong](https://github.com/weinong))
+    * The audience claim before this fix has "spn:" prefix. After this fix, "spn:" prefix is omitted.
+* fix: azure data disk should use same key as os disk by default ([#86351](https://github.com/kubernetes/kubernetes/pull/86351), [@andyzhangx](https://github.com/andyzhangx))
+* Fixes an issue with kubelet-reported pod status on deleted/recreated pods. ([#86320](https://github.com/kubernetes/kubernetes/pull/86320), [@liggitt](https://github.com/liggitt))
+* Fixes v1.17.0 regression in --service-cluster-ip-range handling with IPv4 ranges larger than 65536 IP addresses ([#86534](https://github.com/kubernetes/kubernetes/pull/86534), [@liggitt](https://github.com/liggitt))
+* Fixed a panic in the kubelet cleaning up pod volumes ([#86277](https://github.com/kubernetes/kubernetes/pull/86277), [@tedyu](https://github.com/tedyu))
+* Resolves performance regression in `kubectl get all` and in client-go discovery clients constructed using `NewDiscoveryClientForConfig` or `NewDiscoveryClientForConfigOrDie`. ([#86168](https://github.com/kubernetes/kubernetes/pull/86168), [@liggitt](https://github.com/liggitt))
+* Fix LoadBalancer rule checking so that no unexpected LoadBalancer updates are made ([#85990](https://github.com/kubernetes/kubernetes/pull/85990), [@feiskyer](https://github.com/feiskyer))
+
+
+
+# v1.17.0
+
+[Documentation](https://docs.k8s.io)
+
+## Downloads for v1.17.0
+
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes.tar.gz](https://dl.k8s.io/v1.17.0/kubernetes.tar.gz) | `68d5af15901281954de01164426cfb5ca31c14341387fad34d0cb9aa5f40c932ad44f0de4f987caf2be6bdcea2051e589d25878cf4f9ac0ee73048029a11825f`
+[kubernetes-src.tar.gz](https://dl.k8s.io/v1.17.0/kubernetes-src.tar.gz) | `5424576d7f7936df15243fee0036e7936d2d6224e98ac805ce96cdf7b83a7c5b66dfffc8823d7bc0c17c700fa3c01841208e8cf89be91d237d12e18f3d2f307c`
+
+### Client Binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-client-darwin-386.tar.gz](https://dl.k8s.io/v1.17.0/kubernetes-client-darwin-386.tar.gz) | `4c9a06409561b8ecc8901d0b88bc955ab8b8c99256b3f6066811539211cff5ba7fb9e3802ac2d8b00a14ce619fa82aeebe83eae9f4b0774bedabd3da0235b78b`
+[kubernetes-client-darwin-amd64.tar.gz](https://dl.k8s.io/v1.17.0/kubernetes-client-darwin-amd64.tar.gz) | `78ce6875c5f5a03bc057e7194fd1966beb621f825ba786d35a9921ab1ae33ed781d0f93a473a6b985da1ba4fbe95c15b23cdca9e439dfd653dbcf5a2b23d1a73`
+[kubernetes-client-linux-386.tar.gz](https://dl.k8s.io/v1.17.0/kubernetes-client-linux-386.tar.gz) | `7a4bcd7d06d0f4ba929451f652c92a3c4d428f9b38ed83093f076bb25699b9c4e82f8f851ab981e68becbf10b148ddab4f7dce3743e84d642baa24c00312a2aa`
+[kubernetes-client-linux-amd64.tar.gz](https://dl.k8s.io/v1.17.0/kubernetes-client-linux-amd64.tar.gz) | `7f9fc9ac07e9acbf12b58ae9077a8ce1f7fb4b5ceccd3856b55d2beb5e435d4fd27884c10ffdf3e2e18cafd4acc001ed5cf2a0a9a5b0545d9be570f63012d9c0`
+[kubernetes-client-linux-arm.tar.gz](https://dl.k8s.io/v1.17.0/kubernetes-client-linux-arm.tar.gz) | `8f74fff80a000cfaefa2409bdce6fd0d546008c7942a7178a4fa88a9b3ca05d10f34352e2ea2aec5297aa5c630c2b9701b507273c0ed0ddc0c297e57b655d62e`
+[kubernetes-client-linux-arm64.tar.gz](https://dl.k8s.io/v1.17.0/kubernetes-client-linux-arm64.tar.gz) | `18d92b320f138f5080f98f1ffee20e405187549ab3aad55b7f60f02e3b7f5a44eb9826098576b42937fd0aac01fe6bcae36b5a8ee52ddde3571a1281b279c114`
+[kubernetes-client-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.17.0/kubernetes-client-linux-ppc64le.tar.gz) | `fd9b15a88b3d5a506a84ebfb56de291b85978b14f61a2c05f4bdb6a7e45a36f92af5a024a6178dbebd82a92574ec6d8cf9d8ac912f868f757649a2a8434011fe`
+[kubernetes-client-linux-s390x.tar.gz](https://dl.k8s.io/v1.17.0/kubernetes-client-linux-s390x.tar.gz) | `ae3b284a78975cbfccaac04ea802085c31fd75cccf4ece3a983f44faf755dd94c43833e60f52c5ea57bc462cb24268ef4b7246876189113f588a012dd58e9630`
+[kubernetes-client-windows-386.tar.gz](https://dl.k8s.io/v1.17.0/kubernetes-client-windows-386.tar.gz) | `4ba83b068e7f4a203bcc5cc8bb2c456a6a9c468e695f86f69d8f2ac81be9a1ce156f9a2f28286cb7eb0480faac397d964821c009473bdb443d84a30b6d020551`
+[kubernetes-client-windows-amd64.tar.gz](https://dl.k8s.io/v1.17.0/kubernetes-client-windows-amd64.tar.gz) | `fc79b0e926a823c7d8b9010dee0c559587b7f97c9290b2126d517c4272891ce36e310a64c85f3861a1c951da8dc21f46244a59ff9d52b7b7a3f84879f533e6aa`
+
+### Server Binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-server-linux-amd64.tar.gz](https://dl.k8s.io/v1.17.0/kubernetes-server-linux-amd64.tar.gz) | `28b2703c95894ab0565e372517c4a4b2c33d1be3d778fae384a6ab52c06cea7dd7ec80060dbdba17c8ab23bbedcde751cccee7657eba254f7d322cf7c4afc701`
+[kubernetes-server-linux-arm.tar.gz](https://dl.k8s.io/v1.17.0/kubernetes-server-linux-arm.tar.gz) | `b36a9f602131dba23f267145399aad0b19e97ab7b5194b2e3c01c57f678d7b0ea30c1ea6b4c15fd87b1fd3bf06abd4ec443bef5a3792c0d813356cdeb3b6a935`
+[kubernetes-server-linux-arm64.tar.gz](https://dl.k8s.io/v1.17.0/kubernetes-server-linux-arm64.tar.gz) | `42adae077603f25b194e893f15e7f415011f25e173507a190bafbee0d0e86cdd6ee8f11f1bcf0a5366e845bd968f92e5bf66785f20c1125c801cf3ec9850d0bd`
+[kubernetes-server-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.17.0/kubernetes-server-linux-ppc64le.tar.gz) | `7e72d4255e661e946203c1c0c684cd0923034eb112c35e3ba08fbf9d1ef5e8bb291840c6ff99aea6180083846f9a9ba88387e176ee7a5def49e1d19366e2789f`
+[kubernetes-server-linux-s390x.tar.gz](https://dl.k8s.io/v1.17.0/kubernetes-server-linux-s390x.tar.gz) | `00bc634654ec7d1ec2eca7a3e943ac287395503a06c8da22b7efb3a35435ceb323618c6d9931d6693bfb19f2b8467ae8f05f98392df8ee4954556c438409c8d4`
+
+### Node Binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-node-linux-amd64.tar.gz](https://dl.k8s.io/v1.17.0/kubernetes-node-linux-amd64.tar.gz) | `49ef6a41c65b3f26a4f3ffe63b92c8096c26aa27a89d227d935bc06a497c97505ad8bc215b4c5d5ad3af6489c1366cd26ecc8e2781a83f46a91503678abba71b`
+[kubernetes-node-linux-arm.tar.gz](https://dl.k8s.io/v1.17.0/kubernetes-node-linux-arm.tar.gz) | `21a213fd572200998bdd71f5ebbb96576fc7a7e7cfb1469f028cc1a310bc2b5c0ce32660629beb166b88f54e6ebecb2022b2ed1fdb902a9b9d5acb193d76fa0f`
+[kubernetes-node-linux-arm64.tar.gz](https://dl.k8s.io/v1.17.0/kubernetes-node-linux-arm64.tar.gz) | `3642ee5e7476080a44005db8e7282fdbe4e4f220622761b95951c2c15b3e10d7b70566bfb7a9a58574f3fc385d5aae80738d88195fa308a07f199cee70f912f4`
+[kubernetes-node-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.17.0/kubernetes-node-linux-ppc64le.tar.gz) | `99687088be50a794894911d43827b7e1125fbc86bfba799f77c096ddaa5b2341b31d009b8063a177e503ce2ce0dafbda1115216f8a5777f34e0e2d81f0114104`
+[kubernetes-node-linux-s390x.tar.gz](https://dl.k8s.io/v1.17.0/kubernetes-node-linux-s390x.tar.gz) | `73b9bc356de43fbed7d3294be747b83e0aac47051d09f1df7be52c33be670b63c2ea35856a483ebc2f57e30a295352b77f1b1a6728afa10ec1f3338cafbdb2bb`
+[kubernetes-node-windows-amd64.tar.gz](https://dl.k8s.io/v1.17.0/kubernetes-node-windows-amd64.tar.gz) | `2fbc80f928231f60a5a7e4f427953ef17244b3a8f6fdeebcbfceb05b0587b84933fa723898c64488d94b9ce180357d6d4ca1505ca3c3c7fb11067b7b3bf6361b`
+
+# Changes
+
+A complete changelog for the release notes is now hosted in a customizable format at [relnotes.k8s.io](https://relnotes.k8s.io). Check it out and please give us your feedback!
+
+## What’s New (Major Themes)
+
+### Cloud Provider Labels reach General Availability
+
+Added as a beta feature way back in v1.2, v1.17 sees the general availability of cloud provider labels.
+
+### Volume Snapshot Moves to Beta
+
+The Kubernetes Volume Snapshot feature is now beta in Kubernetes v1.17. It was introduced as alpha in Kubernetes v1.12, with a second alpha with breaking changes in Kubernetes v1.13.
+
+### CSI Migration Beta
+
+The Kubernetes in-tree storage plugin to Container Storage Interface (CSI) migration infrastructure is now beta in Kubernetes v1.17. CSI migration was introduced as alpha in Kubernetes v1.14.
+
+## Known Issues
+- volumeDevices mapping ignored when container is privileged
+- The `Should recreate evicted statefulset` conformance [test]( https://github.com/kubernetes/kubernetes/blob/master/test/e2e/apps/statefulset.go) fails because `Pod ss-0 expected to be re-created at least once`. This was caused by the `Predicate PodFitsHostPorts failed` scheduling error. The root cause was a host port conflict for port `21017`. This port was in-use as an ephemeral port by another application running on the node. This will be looked at for the 1.18 release.
+- client-go discovery clients constructed using `NewDiscoveryClientForConfig` or `NewDiscoveryClientForConfigOrDie` default to rate limits that cause normal discovery request patterns to take several seconds. This is fixed in https://issue.k8s.io/86168 and will be resolved in v1.17.1. As a workaround, the `Burst` value can be adjusted higher in the rest.Config passed into `NewDiscoveryClientForConfig` or `NewDiscoveryClientForConfigOrDie`.
+- the IP allocator in v1.17.0 can return errors such as `the cluster IP <ip> for service <service-name> is not within the service CIDR <cidr>; please recreate` in the logs of the kube-apiserver. The cause is incorrect CIDR calculations if the service CIDR (`--service-cluster-ip-range`) is set to bits lower than `/16`. This is fixed in http://issue.k8s.io/86534 and will be resolved in v1.17.1.
+
+## Urgent Upgrade Notes
+### (No, really, you MUST read this before you upgrade)
+#### Cluster Lifecycle
+- Kubeadm: add a new `kubelet-finalize` phase as part of the `init` workflow and an experimental sub-phase to enable automatic kubelet client certificate rotation on primary control-plane nodes.
+Prior to 1.17 and for existing nodes created by `kubeadm init` where kubelet client certificate rotation is desired, you must modify `/etc/kubernetes/kubelet.conf` to point to the PEM symlink for rotation:
+`client-certificate: /var/lib/kubelet/pki/kubelet-client-current.pem` and `client-key: /var/lib/kubelet/pki/kubelet-client-current.pem`, replacing the embedded client certificate and key. ([#84118](https://github.com/kubernetes/kubernetes/pull/84118), [@neolit123](https://github.com/neolit123))
+#### Network
+- EndpointSlices: If upgrading a cluster with EndpointSlices already enabled, any EndpointSlices that should be managed by the EndpointSlice controller should have a `endpointslice.kubernetes.io/managed-by` label set to `endpointslice-controller.k8s.io`.
+
+#### Scheduling
+
+- Kubeadm: when adding extra apiserver authorization-modes, the defaults `Node,RBAC` are no longer prepended in the resulting static Pod manifests and a full override is allowed. ([#82616](https://github.com/kubernetes/kubernetes/pull/82616), [@ghouscht](https://github.com/ghouscht))
+
+#### Storage
+- A node that uses a CSI raw block volume needs to be drained before kubelet can be upgraded to 1.17. ([#74026](https://github.com/kubernetes/kubernetes/pull/74026), [@mkimuram](https://github.com/mkimuram))
+
+#### Windows
+- The Windows containers RunAsUsername feature is now beta.
+- Windows worker nodes in a Kubernetes cluster now support Windows Server version 1903 in addition to the existing support for Windows Server 2019
+- The RuntimeClass scheduler can now simplify steering Linux or Windows pods to appropriate nodes
+- All Windows nodes now get the new label `node.kubernetes.io/windows-build` that reflects the Windows major, minor, and build number that are needed to match compatibility between Windows containers and Windows worker nodes.
+
+
+## Deprecations and Removals
+- `kubeadm.k8s.io/v1beta1` has been deprecated, you should update your config to use newer non-deprecated API versions. ([#83276](https://github.com/kubernetes/kubernetes/pull/83276), [@Klaven](https://github.com/Klaven))
+- The deprecated feature gates GCERegionalPersistentDisk, EnableAggregatedDiscoveryTimeout and PersistentLocalVolumes are now unconditionally enabled and can no longer be specified in component invocations. ([#82472](https://github.com/kubernetes/kubernetes/pull/82472), [@draveness](https://github.com/draveness))
+- Deprecate the default service IP CIDR. The previous default was `10.0.0.0/24` which will be removed in 6 months/2 releases. Cluster admins must specify their own desired value, by using `--service-cluster-ip-range` on kube-apiserver. ([#81668](https://github.com/kubernetes/kubernetes/pull/81668), [@darshanime](https://github.com/darshanime))
+- Remove deprecated "include-uninitialized" flag. ([#80337](https://github.com/kubernetes/kubernetes/pull/80337), [@draveness](https://github.com/draveness))
+- All resources within the `rbac.authorization.k8s.io/v1alpha1` and `rbac.authorization.k8s.io/v1beta1` API groups are deprecated in favor of `rbac.authorization.k8s.io/v1`, and will no longer be served in v1.20. ([#84758](https://github.com/kubernetes/kubernetes/pull/84758), [@liggitt](https://github.com/liggitt))
+- The certificate signer no longer accepts ca.key passwords via the `CFSSL_CA_PK_PASSWORD` environment variable. This capability was not prompted by user request, never advertised, and recommended against in the security audit. ([#84677](https://github.com/kubernetes/kubernetes/pull/84677), [@mikedanese](https://github.com/mikedanese))
+- Deprecate the instance type beta label (`beta.kubernetes.io/instance-type`) in favor of its GA equivalent: `node.kubernetes.io/instance-type` ([#82049](https://github.com/kubernetes/kubernetes/pull/82049), [@andrewsykim](https://github.com/andrewsykim))
+- The built-in system:csi-external-provisioner and system:csi-external-attacher cluster roles are removed as of 1.17 release ([#84282](https://github.com/kubernetes/kubernetes/pull/84282), [@tedyu](https://github.com/tedyu))
+- The in-tree GCE PD plugin `kubernetes.io/gce-pd` is now deprecated and will be removed in 1.21. Users that self-deploy Kubernetes on GCP should enable CSIMigration + CSIMigrationGCE features and install the GCE PD CSI Driver (https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver) to avoid disruption to existing Pod and PVC objects at that time. Users should start using the GCE PD CSI CSI Driver directly for any new volumes. ([#85231](https://github.com/kubernetes/kubernetes/pull/85231), [@davidz627](https://github.com/davidz627))
+- The in-tree AWS EBS plugin `kubernetes.io/aws-ebs` is now deprecated and will be removed in 1.21. Users that self-deploy Kubernetes on AWS should enable CSIMigration + CSIMigrationAWS features and install the AWS EBS CSI Driver (https://github.com/kubernetes-sigs/aws-ebs-csi-driver) to avoid disruption to existing Pod and PVC objects at that time. Users should start using the AWS EBS CSI CSI Driver directly for any new volumes. ([#85237](https://github.com/kubernetes/kubernetes/pull/85237), [@leakingtapan](https://github.com/leakingtapan))
+- The CSINodeInfo feature gate is deprecated and will be removed in a future release. The storage.k8s.io/v1beta1 CSINode object is deprecated and will be removed in a future release. ([#83474](https://github.com/kubernetes/kubernetes/pull/83474), [@msau42](https://github.com/msau42))
+- Removed Alpha feature `MountContainers` ([#84365](https://github.com/kubernetes/kubernetes/pull/84365), [@codenrhoden](https://github.com/codenrhoden))
+- Removed plugin watching of the deprecated directory `{kubelet_root_dir}/plugins` and CSI V0 support in accordance with deprecation announcement in https://v1-13.docs.kubernetes.io/docs/setup/release/notes ([#84533](https://github.com/kubernetes/kubernetes/pull/84533), [@davidz627](https://github.com/davidz627))
+- kubeadm deprecates the use of the hyperkube image ([#85094](https://github.com/kubernetes/kubernetes/pull/85094), [@rosti](https://github.com/rosti))
+## Metrics Changes
+### Added metrics
+- Add `scheduler_goroutines` metric to track number of kube-scheduler binding and prioritizing goroutines ([#83535](https://github.com/kubernetes/kubernetes/pull/83535), [@wgliang](https://github.com/wgliang))
+- Adding initial EndpointSlice metrics. ([#83257](https://github.com/kubernetes/kubernetes/pull/83257), [@robscott](https://github.com/robscott))
+- Adds a metric `apiserver_request_error_total` to kube-apiserver. This metric tallies the number of `request_errors` encountered by verb, group, version, resource, subresource, scope, component, and code. ([#83427](https://github.com/kubernetes/kubernetes/pull/83427), [@logicalhan](https://github.com/logicalhan))
+- A new `kubelet_preemptions` metric is reported from Kubelets to track the number of preemptions occuring over time, and which resource is triggering those preemptions. ([#84120](https://github.com/kubernetes/kubernetes/pull/84120), [@smarterclayton](https://github.com/smarterclayton))
+- Kube-apiserver: Added metrics `authentication_latency_seconds` that can be used to understand the latency of authentication. ([#82409](https://github.com/kubernetes/kubernetes/pull/82409), [@RainbowMango](https://github.com/RainbowMango))
+- Add `plugin_execution_duration_seconds` metric for scheduler framework plugins. ([#84522](https://github.com/kubernetes/kubernetes/pull/84522), [@liu-cong](https://github.com/liu-cong))
+- Add `permit_wait_duration_seconds` metric to the scheduler. ([#84011](https://github.com/kubernetes/kubernetes/pull/84011), [@liu-cong](https://github.com/liu-cong))
+
+### Deprecated/changed metrics
+- etcd version monitor metrics are now marked as with the ALPHA stability level. ([#83283](https://github.com/kubernetes/kubernetes/pull/83283), [@RainbowMango](https://github.com/RainbowMango))
+- Change `pod_preemption_victims` metric from Gauge to Histogram. ([#83603](https://github.com/kubernetes/kubernetes/pull/83603), [@Tabrizian](https://github.com/Tabrizian))
+- Following metrics from kubelet are now marked as with the ALPHA stability level:
+  `kubelet_container_log_filesystem_used_bytes`
+  `kubelet_volume_stats_capacity_bytes`
+  `kubelet_volume_stats_available_bytes`
+  `kubelet_volume_stats_used_bytes`
+  `kubelet_volume_stats_inodes`
+  `kubelet_volume_stats_inodes_free`
+  `kubelet_volume_stats_inodes_used`
+  `plugin_manager_total_plugins`
+  `volume_manager_total_volumes`
+  ([#84907](https://github.com/kubernetes/kubernetes/pull/84907), [@RainbowMango](https://github.com/RainbowMango))
+- Deprecated metric `rest_client_request_latency_seconds` has been turned off. ([#83836](https://github.com/kubernetes/kubernetes/pull/83836), [@RainbowMango](https://github.com/RainbowMango))
+- Following metrics from kubelet are now marked as with the ALPHA stability level:
+  `node_cpu_usage_seconds_total`
+  `node_memory_working_set_bytes`
+  `container_cpu_usage_seconds_total`
+  `container_memory_working_set_bytes`
+  `scrape_error`
+  ([#84987](https://github.com/kubernetes/kubernetes/pull/84987), [@RainbowMango](https://github.com/RainbowMango))
+- Deprecated prometheus request meta-metrics have been removed
+ `http_request_duration_microseconds` `http_request_duration_microseconds_sum` `http_request_duration_microseconds_count`
+ `http_request_size_bytes`
+ `http_request_size_bytes_sum`
+ `http_request_size_bytes_count`
+ `http_requests_total, http_response_size_bytes`
+ `http_response_size_bytes_sum`
+ `http_response_size_bytes_count`
+ due to removal from the prometheus client library. Prometheus http request meta-metrics are now generated from [`promhttp.InstrumentMetricHandler`](https://godoc.org/github.com/prometheus/client_golang/prometheus/promhttp&#35;InstrumentMetricHandler) instead.
+- Following metrics from kube-controller-manager are now marked as with the ALPHA stability level:
+  `storage_count_attachable_volumes_in_use`
+  `attachdetach_controller_total_volumes`
+  `pv_collector_bound_pv_count`
+  `pv_collector_unbound_pv_count`
+  `pv_collector_bound_pvc_count`
+  `pv_collector_unbound_pvc_count`
+  ([#84896](https://github.com/kubernetes/kubernetes/pull/84896), [@RainbowMango](https://github.com/RainbowMango))
+- Following metrics have been turned off:
+  `apiserver_request_count`
+  `apiserver_request_latencies`
+  `apiserver_request_latencies_summary`
+  `apiserver_dropped_requests`
+  `etcd_request_latencies_summary`
+  `apiserver_storage_transformation_latencies_microseconds`
+  `apiserver_storage_data_key_generation_latencies_microseconds`
+  `apiserver_storage_transformation_failures_total`
+  ([#83837](https://github.com/kubernetes/kubernetes/pull/83837), [@RainbowMango](https://github.com/RainbowMango))
+- Following metrics have been turned off:
+  `scheduler_scheduling_latency_seconds`
+  `scheduler_e2e_scheduling_latency_microseconds`
+  `scheduler_scheduling_algorithm_latency_microseconds`
+  `scheduler_scheduling_algorithm_predicate_evaluation`
+  `scheduler_scheduling_algorithm_priority_evaluation`
+  `scheduler_scheduling_algorithm_preemption_evaluation`
+  `scheduler_scheduling_binding_latency_microseconds ([#83838](https://github.com/kubernetes/kubernetes/pull/83838`), [@RainbowMango](https://github.com/RainbowMango))
+- Deprecated metric `kubeproxy_sync_proxy_rules_latency_microseconds` has been turned off. ([#83839](https://github.com/kubernetes/kubernetes/pull/83839), [@RainbowMango](https://github.com/RainbowMango))
+
+## Notable Features
+### Stable
+- Graduate ScheduleDaemonSetPods to GA. (feature gate will be removed in 1.18) ([#82795](https://github.com/kubernetes/kubernetes/pull/82795), [@draveness](https://github.com/draveness))
+- Graduate TaintNodesByCondition to GA in 1.17. (feature gate will be removed in 1.18) ([#82703](https://github.com/kubernetes/kubernetes/pull/82703), [@draveness](https://github.com/draveness))
+- The WatchBookmark feature is promoted to GA. With WatchBookmark feature, clients are able to request watch events with BOOKMARK type. See https://kubernetes.io/docs/reference/using-api/api-concepts/#watch-bookmarks for more details. ([#83195](https://github.com/kubernetes/kubernetes/pull/83195), [@wojtek-t](https://github.com/wojtek-t))
+- Promote NodeLease feature to GA.
+The feature make Lease object changes an additional healthiness signal from Node. Together with that, we reduce frequency of NodeStatus updates to 5m by default in case of no changes to status itself ([#84351](https://github.com/kubernetes/kubernetes/pull/84351), [@wojtek-t](https://github.com/wojtek-t))
+- CSI Topology feature is GA. ([#83474](https://github.com/kubernetes/kubernetes/pull/83474), [@msau42](https://github.com/msau42))
+- The VolumeSubpathEnvExpansion feature is graduating to GA. The `VolumeSubpathEnvExpansion` feature gate is unconditionally enabled, and will be removed in v1.19. ([#82578](https://github.com/kubernetes/kubernetes/pull/82578), [@kevtaylor](https://github.com/kevtaylor))
+- Node-specific volume limits has graduated to GA. ([#83568](https://github.com/kubernetes/kubernetes/pull/83568), [@bertinatto](https://github.com/bertinatto))
+- The ResourceQuotaScopeSelectors feature has graduated to GA. The `ResourceQuotaScopeSelectors` feature gate is now unconditionally enabled and will be removed in 1.18. ([#82690](https://github.com/kubernetes/kubernetes/pull/82690), [@draveness](https://github.com/draveness))
+
+### Beta
+- The Kubernetes Volume Snapshot feature has been moved to beta. The VolumeSnapshotDataSource feature gate is on by default in this release. This feature enables you to take a snapshot of a volume (if supported by the CSI driver), and use the snapshot to provision a new volume, pre-populated with data from the snapshot.
+- Feature gates CSIMigration to Beta (on by default) and CSIMigrationGCE to Beta (off by default since it requires installation of the GCE PD CSI Driver) ([#85231](https://github.com/kubernetes/kubernetes/pull/85231), [@davidz627](https://github.com/davidz627))
+- EndpointSlices are now beta but not yet enabled by default. Use the EndpointSlice feature gate to enable this feature. ([#85365](https://github.com/kubernetes/kubernetes/pull/85365), [@robscott](https://github.com/robscott))
+- Promote CSIMigrationAWS to Beta (off by default since it requires installation of the AWS EBS CSI Driver) ([#85237](https://github.com/kubernetes/kubernetes/pull/85237), [@leakingtapan](https://github.com/leakingtapan))
+- Moving Windows RunAsUserName feature to beta ([#84882](https://github.com/kubernetes/kubernetes/pull/84882), [@marosset](https://github.com/marosset))
+
+### CLI Improvements
+- The kubectl's api-resource command now has a `--sort-by` flag to sort resources by name or kind. ([#81971](https://github.com/kubernetes/kubernetes/pull/81971), [@laddng](https://github.com/laddng))
+- A new `--prefix` flag added into kubectl logs which prepends each log line with information about it's source (pod name and container name) ([#76471](https://github.com/kubernetes/kubernetes/pull/76471), [@m1kola](https://github.com/m1kola))
+
+## API Changes
+- CustomResourceDefinitions now validate documented API semantics of `x-kubernetes-list-type` and `x-kubernetes-map-type` atomic to reject non-atomic sub-types. ([#84722](https://github.com/kubernetes/kubernetes/pull/84722), [@sttts](https://github.com/sttts))
+- Kube-apiserver: The `AdmissionConfiguration` type accepted by `--admission-control-config-file` has been promoted to `apiserver.config.k8s.io/v1` with no schema changes. ([#85098](https://github.com/kubernetes/kubernetes/pull/85098), [@liggitt](https://github.com/liggitt))
+- Fixed EndpointSlice port name validation to match Endpoint port name validation (allowing port names longer than 15 characters) ([#84481](https://github.com/kubernetes/kubernetes/pull/84481), [@robscott](https://github.com/robscott))
+- CustomResourceDefinitions introduce `x-kubernetes-map-type` annotation as a CRD API extension. Enables this particular validation for server-side apply. ([#84113](https://github.com/kubernetes/kubernetes/pull/84113), [@enxebre](https://github.com/enxebre))
+
+## Other notable changes
+### API Machinery
+
+- kube-apiserver: the `--runtime-config` flag now supports an `api/beta=false` value which disables all built-in REST API versions matching `v[0-9]+beta[0-9]+`. ([#84304](https://github.com/kubernetes/kubernetes/pull/84304), [@liggitt](https://github.com/liggitt))
+The `--feature-gates` flag now supports an `AllBeta=false` value which disables all beta feature gates. ([#84304](https://github.com/kubernetes/kubernetes/pull/84304), [@liggitt](https://github.com/liggitt))
+- New flag `--show-hidden-metrics-for-version` in kube-apiserver can be used to show all hidden metrics that deprecated in the previous minor release. ([#84292](https://github.com/kubernetes/kubernetes/pull/84292), [@RainbowMango](https://github.com/RainbowMango))
+- kube-apiserver: Authentication configuration for mutating and validating admission webhooks referenced from an `--admission-control-config-file` can now be specified with `apiVersion: apiserver.config.k8s.io/v1, kind: WebhookAdmissionConfiguration`. ([#85138](https://github.com/kubernetes/kubernetes/pull/85138), [@liggitt](https://github.com/liggitt))
+- kube-apiserver: The `ResourceQuota` admission plugin configuration referenced from `--admission-control-config-file` admission config has been promoted to `apiVersion: apiserver.config.k8s.io/v1`, `kind: ResourceQuotaConfiguration` with no schema changes. ([#85099](https://github.com/kubernetes/kubernetes/pull/85099), [@liggitt](https://github.com/liggitt))
+- kube-apiserver: fixed a bug that could cause a goroutine leak if the apiserver encountered an encoding error serving a watch to a websocket watcher ([#84693](https://github.com/kubernetes/kubernetes/pull/84693), [@tedyu](https://github.com/tedyu))
+- Fix the bug that EndpointSlice for masters wasn't created after enabling EndpointSlice feature on a pre-existing cluster. ([#84421](https://github.com/kubernetes/kubernetes/pull/84421), [@tnqn](https://github.com/tnqn))
+- Switched intstr.Type to sized integer to follow API guidelines and improve compatibility with proto libraries ([#83956](https://github.com/kubernetes/kubernetes/pull/83956), [@liggitt](https://github.com/liggitt))
+- Client-go: improved allocation behavior of the delaying workqueue when handling objects with far-future ready times. ([#83945](https://github.com/kubernetes/kubernetes/pull/83945), [@barkbay](https://github.com/barkbay))
+- Fixed an issue with informers missing an `Added` event if a recently deleted object was immediately recreated at the same time the informer dropped a watch and relisted. ([#83911](https://github.com/kubernetes/kubernetes/pull/83911), [@matte21](https://github.com/matte21))
+- Fixed panic when accessing CustomResources of a CRD with `x-kubernetes-int-or-string`. ([#83787](https://github.com/kubernetes/kubernetes/pull/83787), [@sttts](https://github.com/sttts))
+- The resource version option, when passed to a list call, is now consistently interpreted as the minimum allowed resource version.  Previously when listing resources that had the watch cache disabled clients could retrieve a snapshot at that exact resource version.  If the client requests a resource version newer than the current state, a TimeoutError is returned suggesting the client retry in a few seconds.  This behavior is now consistent for both single item retrieval and list calls, and for when the watch cache is enabled or disabled. ([#72170](https://github.com/kubernetes/kubernetes/pull/72170), [@jpbetz](https://github.com/jpbetz))
+- Fixes a goroutine leak in kube-apiserver when a request times out. ([#83333](https://github.com/kubernetes/kubernetes/pull/83333), [@lavalamp](https://github.com/lavalamp))
+- Fixes the bug in informer-gen that it produces incorrect code if a type has nonNamespaced tag set. ([#80458](https://github.com/kubernetes/kubernetes/pull/80458), [@tatsuhiro-t](https://github.com/tatsuhiro-t))
+- Resolves bottleneck in internal API server communication that can cause increased goroutines and degrade API Server performance ([#80465](https://github.com/kubernetes/kubernetes/pull/80465), [@answer1991](https://github.com/answer1991))
+- Resolves regression generating informers for packages whose names contain `.` characters ([#82410](https://github.com/kubernetes/kubernetes/pull/82410), [@nikhita](https://github.com/nikhita))
+- Resolves issue with `/readyz` and `/livez` not including etcd and kms health checks ([#82713](https://github.com/kubernetes/kubernetes/pull/82713), [@logicalhan](https://github.com/logicalhan))
+- Fixes regression in logging spurious stack traces when proxied connections are closed by the backend ([#82588](https://github.com/kubernetes/kubernetes/pull/82588), [@liggitt](https://github.com/liggitt))
+- Kube-apiserver now reloads serving certificates from disk every minute to allow rotation without restarting the server process ([#84200](https://github.com/kubernetes/kubernetes/pull/84200), [@jackkleeman](https://github.com/jackkleeman))
+- Client-ca bundles for the all generic-apiserver based servers will dynamically reload from disk on content changes ([#83579](https://github.com/kubernetes/kubernetes/pull/83579), [@deads2k](https://github.com/deads2k))
+- Client-go: Clients can request protobuf and json and correctly negotiate with the server for JSON for CRD objects, allowing all client libraries to request protobuf if it is available.  If an error occurs negotiating a watch with the server, the error is immediately return by the client `Watch()` method instead of being sent as an `Error` event on the watch stream. ([#84692](https://github.com/kubernetes/kubernetes/pull/84692), [@smarterclayton](https://github.com/smarterclayton))
+Renamed FeatureGate RequestManagement to APIPriorityAndFairness.  This feature gate is an alpha and has not yet been associated with any actual functionality. ([#85260](https://github.com/kubernetes/kubernetes/pull/85260), [@MikeSpreitzer](https://github.com/MikeSpreitzer))
+- Filter published OpenAPI schema by making nullable, required fields non-required in order to avoid kubectl to wrongly reject null values. ([#85722](https://github.com/kubernetes/kubernetes/pull/85722), [@sttts](https://github.com/sttts))
+- kube-apiserver: fixed a conflict error encountered attempting to delete a pod with `gracePeriodSeconds=0` and a resourceVersion precondition ([#85516](https://github.com/kubernetes/kubernetes/pull/85516), [@michaelgugino](https://github.com/michaelgugino))
+- Use context to check client closed instead of http.CloseNotifier in processing watch request which will reduce 1 goroutine for each request if proto is HTTP/2.x . ([#85408](https://github.com/kubernetes/kubernetes/pull/85408), [@answer1991](https://github.com/answer1991))
+- Reload apiserver SNI certificates from disk every minute ([#84303](https://github.com/kubernetes/kubernetes/pull/84303), [@jackkleeman](https://github.com/jackkleeman))
+- The mutating and validating admission webhook plugins now read configuration from the admissionregistration.k8s.io/v1 API. ([#80883](https://github.com/kubernetes/kubernetes/pull/80883), [@liggitt](https://github.com/liggitt))
+- kube-proxy: a configuration file specified via `--config` is now loaded with strict deserialization, which fails if the config file contains duplicate or unknown fields. This protects against accidentally running with config files that are malformed, mis-indented, or have typos in field names, and getting unexpected behavior. ([#82927](https://github.com/kubernetes/kubernetes/pull/82927), [@obitech](https://github.com/obitech))
+- When registering with a 1.17+ API server, MutatingWebhookConfiguration and ValidatingWebhookConfiguration objects can now request that only `v1` AdmissionReview requests be sent to them. Previously, webhooks were required to support receiving `v1beta1` AdmissionReview requests as well for compatibility with API servers <= 1.15.
+  - When registering with a 1.17+ API server, a CustomResourceDefinition conversion webhook can now request that only `v1` ConversionReview requests be sent to them. Previously, conversion webhooks were required to support receiving `v1beta1` ConversionReview requests as well for compatibility with API servers <= 1.15. ([#82707](https://github.com/kubernetes/kubernetes/pull/82707), [@liggitt](https://github.com/liggitt))
+- OpenAPI v3 format in CustomResourceDefinition schemas are now documented. ([#85381](https://github.com/kubernetes/kubernetes/pull/85381), [@sttts](https://github.com/sttts))
+- kube-apiserver: Fixed a regression accepting patch requests > 1MB ([#84963](https://github.com/kubernetes/kubernetes/pull/84963), [@liggitt](https://github.com/liggitt))
+- The example API server has renamed its `wardle.k8s.io` API group to `wardle.example.com` ([#81670](https://github.com/kubernetes/kubernetes/pull/81670), [@liggitt](https://github.com/liggitt))
+- CRDs defaulting is promoted to GA. Note: the feature gate CustomResourceDefaulting will be removed in 1.18. ([#84713](https://github.com/kubernetes/kubernetes/pull/84713), [@sttts](https://github.com/sttts))
+- Restores compatibility with <=1.15.x custom resources by not publishing OpenAPI for non-structural custom resource definitions ([#82653](https://github.com/kubernetes/kubernetes/pull/82653), [@liggitt](https://github.com/liggitt))
+- If given an IPv6 bind-address, kube-apiserver will now advertise an IPv6 endpoint for the kubernetes.default service. ([#84727](https://github.com/kubernetes/kubernetes/pull/84727), [@danwinship](https://github.com/danwinship))
+- Add table convertor to component status. ([#85174](https://github.com/kubernetes/kubernetes/pull/85174), [@zhouya0](https://github.com/zhouya0))
+- Scale custom resource unconditionally if resourceVersion is not provided ([#80572](https://github.com/kubernetes/kubernetes/pull/80572), [@knight42](https://github.com/knight42))
+- When the go-client reflector relists, the ResourceVersion list option is set to the reflector's latest synced resource version to ensure the reflector does not "go back in time" and reprocess events older than it has already processed. If the server responds with an HTTP 410 (Gone) status code response, the relist falls back to using `resourceVersion=""`. ([#83520](https://github.com/kubernetes/kubernetes/pull/83520), [@jpbetz](https://github.com/jpbetz))
+- Fix unsafe JSON construction in a number of locations in the codebase ([#81158](https://github.com/kubernetes/kubernetes/pull/81158), [@zouyee](https://github.com/zouyee))
+- Fixes a flaw (CVE-2019-11253) in json/yaml decoding where large or malformed documents could consume excessive server resources. Request bodies for normal API requests (create/delete/update/patch operations of regular resources) are now limited to 3MB. ([#83261](https://github.com/kubernetes/kubernetes/pull/83261), [@liggitt](https://github.com/liggitt))
+- CRDs can have fields named `type` with value `array` and nested array with `items` fields without validation to fall over this. ([#85223](https://github.com/kubernetes/kubernetes/pull/85223), [@sttts](https://github.com/sttts))
+
+### Apps
+
+- Support Service Topology ([#72046](https://github.com/kubernetes/kubernetes/pull/72046), [@m1093782566](https://github.com/m1093782566))
+- Finalizer Protection for Service LoadBalancers is now in GA (enabled by default). This feature ensures the Service resource is not fully deleted until the correlating load balancer resources are deleted. ([#85023](https://github.com/kubernetes/kubernetes/pull/85023), [@MrHohn](https://github.com/MrHohn))
+- Pod process namespace sharing is now Generally Available. The `PodShareProcessNamespace` feature gate is now deprecated and will be removed in Kubernetes 1.19. ([#84356](https://github.com/kubernetes/kubernetes/pull/84356), [@verb](https://github.com/verb))
+- Fix handling tombstones in pod-disruption-budged controller. ([#83951](https://github.com/kubernetes/kubernetes/pull/83951), [@zouyee](https://github.com/zouyee))
+- Fixed the bug that deleted services were processed by EndpointSliceController repeatedly even their cleanup were successful. ([#82996](https://github.com/kubernetes/kubernetes/pull/82996), [@tnqn](https://github.com/tnqn))
+- Add `RequiresExactMatch` for `label.Selector` ([#85048](https://github.com/kubernetes/kubernetes/pull/85048), [@shaloulcy](https://github.com/shaloulcy))
+- Adds a new label to indicate what is managing an EndpointSlice. ([#83965](https://github.com/kubernetes/kubernetes/pull/83965), [@robscott](https://github.com/robscott))
+- Fix handling tombstones in pod-disruption-budged controller. ([#83951](https://github.com/kubernetes/kubernetes/pull/83951), [@zouyee](https://github.com/zouyee))
+- Fixed the bug that deleted services were processed by EndpointSliceController repeatedly even their cleanup were successful. ([#82996](https://github.com/kubernetes/kubernetes/pull/82996), [@tnqn](https://github.com/tnqn))
+- An end-user may choose to request logs without confirming the identity of the backing kubelet.  This feature can be disabled by setting the `AllowInsecureBackendProxy` feature-gate to false. ([#83419](https://github.com/kubernetes/kubernetes/pull/83419), [@deads2k](https://github.com/deads2k))
+- When scaling down a ReplicaSet, delete doubled up replicas first, where a "doubled up replica" is defined as one that is on the same node as an active replica belonging to a related ReplicaSet.  ReplicaSets are considered "related" if they have a common controller (typically a Deployment). ([#80004](https://github.com/kubernetes/kubernetes/pull/80004), [@Miciah](https://github.com/Miciah))
+- Kube-controller-manager: Fixes bug setting headless service labels on endpoints ([#85361](https://github.com/kubernetes/kubernetes/pull/85361), [@liggitt](https://github.com/liggitt))
+- People can see the right log and note. ([#84637](https://github.com/kubernetes/kubernetes/pull/84637), [@zhipengzuo](https://github.com/zhipengzuo))
+- Clean duplicate GetPodServiceMemberships function ([#83902](https://github.com/kubernetes/kubernetes/pull/83902), [@gongguan](https://github.com/gongguan))
+
+### Auth
+
+- K8s docker config json secrets are now compatible with docker config desktop authentication credentials files ([#82148](https://github.com/kubernetes/kubernetes/pull/82148), [@bbourbie](https://github.com/bbourbie))
+- Kubelet and aggregated API servers now use v1 TokenReview and SubjectAccessReview endpoints to check authentication/authorization. ([#84768](https://github.com/kubernetes/kubernetes/pull/84768), [@liggitt](https://github.com/liggitt))
+- Kube-apiserver can now specify `--authentication-token-webhook-version=v1` or `--authorization-webhook-version=v1` to use `v1` TokenReview and SubjectAccessReview API objects when communicating with authentication and authorization webhooks. ([#84768](https://github.com/kubernetes/kubernetes/pull/84768), [@liggitt](https://github.com/liggitt))
+- Authentication token cache size is increased (from 4k to 32k) to support clusters with many nodes or many namespaces with active service accounts. ([#83643](https://github.com/kubernetes/kubernetes/pull/83643), [@lavalamp](https://github.com/lavalamp))
+- Apiservers based on k8s.io/apiserver with delegated authn based on cluster authentication will automatically update to new authentication information when the authoritative configmap is updated. ([#85004](https://github.com/kubernetes/kubernetes/pull/85004), [@deads2k](https://github.com/deads2k))
+- Configmaps/extension-apiserver-authentication in kube-system is continuously updated by kube-apiservers, instead of just at apiserver start ([#82705](https://github.com/kubernetes/kubernetes/pull/82705), [@deads2k](https://github.com/deads2k))
+
+### CLI
+- Fixed kubectl endpointslice output for get requests ([#82603](https://github.com/kubernetes/kubernetes/pull/82603), [@robscott](https://github.com/robscott))
+- Gives the right error message when using `kubectl delete` a wrong resource. ([#83825](https://github.com/kubernetes/kubernetes/pull/83825), [@zhouya0](https://github.com/zhouya0))
+- If a bad flag is supplied to a kubectl command, only a tip to run `--help` is printed, instead of the usage menu.  Usage menu is printed upon running `kubectl command --help`. ([#82423](https://github.com/kubernetes/kubernetes/pull/82423), [@sallyom](https://github.com/sallyom))
+- Commands like `kubectl apply` now return errors if schema-invalid annotations are specified, rather than silently dropping the entire annotations section. ([#83552](https://github.com/kubernetes/kubernetes/pull/83552), [@liggitt](https://github.com/liggitt))
+- Fixes spurious 0 revisions listed when running `kubectl rollout history` for a StatefulSet ([#82643](https://github.com/kubernetes/kubernetes/pull/82643), [@ZP-AlwaysWin](https://github.com/ZP-AlwaysWin))
+- Correct a reference to a not/no longer used kustomize subcommand in the documentation ([#82535](https://github.com/kubernetes/kubernetes/pull/82535), [@demobox](https://github.com/demobox))
+- Kubectl set resources will no longer return an error if passed an empty change for a resource. kubectl set subject will no longer return an error if passed an empty change for a resource. ([#85490](https://github.com/kubernetes/kubernetes/pull/85490), [@sallyom](https://github.com/sallyom))
+- Kubectl: --resource-version now works properly in label/annotate/set selector commands when racing with other clients to update the target object ([#85285](https://github.com/kubernetes/kubernetes/pull/85285), [@liggitt](https://github.com/liggitt))
+- The `--certificate-authority` flag now correctly overrides existing skip-TLS or CA data settings in the kubeconfig file ([#83547](https://github.com/kubernetes/kubernetes/pull/83547), [@liggitt](https://github.com/liggitt))
+### Cloud Provider
+- Azure: update disk lock logic per vm during attach/detach to allow concurrent updates for different nodes. ([#85115](https://github.com/kubernetes/kubernetes/pull/85115), [@aramase](https://github.com/aramase))
+- Fix vmss dirty cache issue in disk attach/detach on vmss node ([#85158](https://github.com/kubernetes/kubernetes/pull/85158), [@andyzhangx](https://github.com/andyzhangx))
+- Fix race condition when attach/delete azure disk in same time ([#84917](https://github.com/kubernetes/kubernetes/pull/84917), [@andyzhangx](https://github.com/andyzhangx))
+- Change GCP ILB firewall names to contain the `k8s-fw-` prefix like the rest of the firewall rules. This is needed for consistency and also for other components to identify the firewall rule as k8s/service-controller managed. ([#84622](https://github.com/kubernetes/kubernetes/pull/84622), [@prameshj](https://github.com/prameshj))
+- Ensure health probes are created for local traffic policy UDP services on Azure ([#84802](https://github.com/kubernetes/kubernetes/pull/84802), [@feiskyer](https://github.com/feiskyer))
+- Openstack: Do not delete managed LB in case of security group reconciliation errors ([#82264](https://github.com/kubernetes/kubernetes/pull/82264), [@multi-io](https://github.com/multi-io))
+- Fix aggressive VM calls for Azure VMSS ([#83102](https://github.com/kubernetes/kubernetes/pull/83102), [@feiskyer](https://github.com/feiskyer))
+- Fix: azure disk detach failure if node not exists ([#82640](https://github.com/kubernetes/kubernetes/pull/82640), [@andyzhangx](https://github.com/andyzhangx))
+- Add azure disk encryption(SSE+CMK) support ([#84605](https://github.com/kubernetes/kubernetes/pull/84605), [@andyzhangx](https://github.com/andyzhangx))
+- Update Azure SDK versions to v35.0.0 ([#84543](https://github.com/kubernetes/kubernetes/pull/84543), [@andyzhangx](https://github.com/andyzhangx))
+- Azure: Add allow unsafe read from cache ([#83685](https://github.com/kubernetes/kubernetes/pull/83685), [@aramase](https://github.com/aramase))
+- Reduces the number of calls made to the Azure API when requesting the instance view of a virtual machine scale set node. ([#82496](https://github.com/kubernetes/kubernetes/pull/82496), [@hasheddan](https://github.com/hasheddan))
+- Added cloud operation count metrics to azure cloud controller manager. ([#82574](https://github.com/kubernetes/kubernetes/pull/82574), [@kkmsft](https://github.com/kkmsft))
+- On AWS nodes with multiple network interfaces, kubelet should now more reliably report the same primary node IP. ([#80747](https://github.com/kubernetes/kubernetes/pull/80747), [@danwinship](https://github.com/danwinship))
+- Update Azure load balancer to prevent orphaned public IP addresses ([#82890](https://github.com/kubernetes/kubernetes/pull/82890), [@chewong](https://github.com/chewong))
+### Cluster Lifecycle
+- Kubeadm alpha certs command now skip missing files ([#85092](https://github.com/kubernetes/kubernetes/pull/85092), [@fabriziopandini](https://github.com/fabriziopandini))
+- Kubeadm: the command "kubeadm token create" now has a "--certificate-key" flag that can be used for the formation of join commands for control-planes with automatic copy of certificates ([#84591](https://github.com/kubernetes/kubernetes/pull/84591), [@TheLastProject](https://github.com/TheLastProject))
+- Kubeadm: Fix a bug where kubeadm cannot parse kubelet's version if the latter dumps logs on the standard error. ([#85351](https://github.com/kubernetes/kubernetes/pull/85351), [@rosti](https://github.com/rosti))
+- Kubeadm: added retry to all the calls to the etcd API so kubeadm will be more resilient to network glitches ([#85201](https://github.com/kubernetes/kubernetes/pull/85201), [@fabriziopandini](https://github.com/fabriziopandini))
+- Fixes a bug in kubeadm that caused init and join to hang indefinitely in specific conditions. ([#85156](https://github.com/kubernetes/kubernetes/pull/85156), [@chuckha](https://github.com/chuckha))
+- Kubeadm now includes CoreDNS version 1.6.5
+   - `kubernetes` plugin adds metrics to measure kubernetes control plane latency.
+   -  the `health` plugin now includes the `lameduck` option by default, which waits for a duration before shutting down. ([#85109](https://github.com/kubernetes/kubernetes/pull/85109), [@rajansandeep](https://github.com/rajansandeep))
+- Fixed bug when using kubeadm alpha certs commands with clusters using external etcd ([#85091](https://github.com/kubernetes/kubernetes/pull/85091), [@fabriziopandini](https://github.com/fabriziopandini))
+- Kubeadm no longer defaults or validates the component configs of the kubelet or kube-proxy ([#79223](https://github.com/kubernetes/kubernetes/pull/79223), [@rosti](https://github.com/rosti))
+- Kubeadm: remove the deprecated `--cri-socket` flag for `kubeadm upgrade apply`. The flag has been deprecated since v1.14. ([#85044](https://github.com/kubernetes/kubernetes/pull/85044), [@neolit123](https://github.com/neolit123))
+- Kubeadm: prevent potential hanging of commands such as "kubeadm reset" if the apiserver endpoint is not reachable. ([#84648](https://github.com/kubernetes/kubernetes/pull/84648), [@neolit123](https://github.com/neolit123))
+- Kubeadm: fix skipped etcd upgrade on secondary control-plane nodes when the command `kubeadm upgrade node` is used. ([#85024](https://github.com/kubernetes/kubernetes/pull/85024), [@neolit123](https://github.com/neolit123))
+- Kubeadm: fix an issue with the kube-proxy container env. variables ([#84888](https://github.com/kubernetes/kubernetes/pull/84888), [@neolit123](https://github.com/neolit123))
+- Utilize diagnostics tool to dump GKE windows test logs ([#83517](https://github.com/kubernetes/kubernetes/pull/83517), [@YangLu1031](https://github.com/YangLu1031))
+- Kubeadm: always mount the kube-controller-manager hostPath volume that is given by the `--flex-volume-plugin-dir` flag. ([#84468](https://github.com/kubernetes/kubernetes/pull/84468), [@neolit123](https://github.com/neolit123))
+- Update Cluster Autoscaler version to 1.16.2 (CA release docs: https://github.com/kubernetes/autoscaler/releases/tag/cluster-autoscaler-1.16.2) ([#84038](https://github.com/kubernetes/kubernetes/pull/84038), [@losipiuk](https://github.com/losipiuk))
+- Kubeadm no longer removes /etc/cni/net.d as it does not install it. Users should remove files from it manually or rely on the component that created them ([#83950](https://github.com/kubernetes/kubernetes/pull/83950), [@yastij](https://github.com/yastij))
+- Kubeadm: fix wrong default value for the `upgrade node --certificate-renewal` flag. ([#83528](https://github.com/kubernetes/kubernetes/pull/83528), [@neolit123](https://github.com/neolit123))
+- Bump metrics-server to v0.3.5 ([#83015](https://github.com/kubernetes/kubernetes/pull/83015), [@olagacek](https://github.com/olagacek))
+- Dashboard: disable the dashboard Deployment on non-Linux nodes. This step is required to support Windows worker nodes. ([#82975](https://github.com/kubernetes/kubernetes/pull/82975), [@wawa0210](https://github.com/wawa0210))
+- Fixes a panic in kube-controller-manager cleaning up bootstrap tokens ([#82887](https://github.com/kubernetes/kubernetes/pull/82887), [@tedyu](https://github.com/tedyu))
+- Kubeadm: add a new `kubelet-finalize` phase as part of the `init` workflow and an experimental sub-phase to enable automatic kubelet client certificate rotation on primary control-plane nodes.
+
+    Prior to 1.17 and for existing nodes created by `kubeadm init` where kubelet client certificate rotation is desired, you must modify "/etc/kubernetes/kubelet.conf" to point to the PEM symlink for rotation:
+`client-certificate: /var/lib/kubelet/pki/kubelet-client-current.pem` and `client-key: /var/lib/kubelet/pki/kubelet-client-current.pem`, replacing the embedded client certificate and key. ([#84118](https://github.com/kubernetes/kubernetes/pull/84118), [@neolit123](https://github.com/neolit123))
+- Kubeadm: add a upgrade health check that deploys a Job ([#81319](https://github.com/kubernetes/kubernetes/pull/81319), [@neolit123](https://github.com/neolit123))
+- Kubeadm now supports automatic calculations of dual-stack node cidr masks to kube-controller-manager. ([#85609](https://github.com/kubernetes/kubernetes/pull/85609), [@Arvinderpal](https://github.com/Arvinderpal))
+- Kubeadm: reset raises warnings if it cannot delete folders ([#85265](https://github.com/kubernetes/kubernetes/pull/85265), [@SataQiu](https://github.com/SataQiu))
+- Kubeadm: enable the usage of the secure kube-scheduler and kube-controller-manager ports for health checks. For kube-scheduler was 10251, becomes 10259. For kube-controller-manager was 10252, becomes 10257. ([#85043](https://github.com/kubernetes/kubernetes/pull/85043), [@neolit123](https://github.com/neolit123))
+- A new kubelet command line option, `--reserved-cpus`, is introduced to explicitly define the CPU list that will be reserved for system. For example, if `--reserved-cpus=0,1,2,3` is specified, then cpu 0,1,2,3 will be reserved for the system.  On a system with 24 CPUs, the user may specify `isolcpus=4-23` for the kernel option and use CPU 4-23 for the user containers. ([#83592](https://github.com/kubernetes/kubernetes/pull/83592), [@jianzzha](https://github.com/jianzzha))
+- Kubelet: a configuration file specified via `--config` is now loaded with strict deserialization, which fails if the config file contains duplicate or unknown fields. This protects against accidentally running with config files that are malformed, mis-indented, or have typos in field names, and getting unexpected behavior. ([#83204](https://github.com/kubernetes/kubernetes/pull/83204), [@obitech](https://github.com/obitech))
+- Kubeadm now propagates proxy environment variables to kube-proxy ([#84559](https://github.com/kubernetes/kubernetes/pull/84559), [@yastij](https://github.com/yastij))
+- Update the latest validated version of Docker to 19.03 ([#84476](https://github.com/kubernetes/kubernetes/pull/84476), [@neolit123](https://github.com/neolit123))
+- Update to Ingress-GCE v1.6.1 ([#84018](https://github.com/kubernetes/kubernetes/pull/84018), [@rramkumar1](https://github.com/rramkumar1))
+- Kubeadm: enhance certs check-expiration to show the expiration info of related CAs ([#83932](https://github.com/kubernetes/kubernetes/pull/83932), [@SataQiu](https://github.com/SataQiu))
+- Kubeadm: implemented structured output of 'kubeadm token list' in JSON, YAML, Go template and JsonPath formats ([#78764](https://github.com/kubernetes/kubernetes/pull/78764), [@bart0sh](https://github.com/bart0sh))
+- Kubeadm: add support for `127.0.0.1` as advertise address. kubeadm will automatically replace this value with matching global unicast IP address on the loopback interface. ([#83475](https://github.com/kubernetes/kubernetes/pull/83475), [@fabriziopandini](https://github.com/fabriziopandini))
+- Kube-scheduler: a configuration file specified via `--config` is now loaded with strict deserialization, which fails if the config file contains duplicate or unknown fields. This protects against accidentally running with config files that are malformed, mis-indented, or have typos in field names, and getting unexpected behavior. ([#83030](https://github.com/kubernetes/kubernetes/pull/83030), [@obitech](https://github.com/obitech))
+- Kubeadm: use the `--service-cluster-ip-range` flag to init or use the ServiceSubnet field in the kubeadm config to pass a comma separated list of Service CIDRs. ([#82473](https://github.com/kubernetes/kubernetes/pull/82473), [@Arvinderpal](https://github.com/Arvinderpal))
+- Update crictl to v1.16.1. ([#82856](https://github.com/kubernetes/kubernetes/pull/82856), [@Random-Liu](https://github.com/Random-Liu))
+- Bump addon-resizer to 1.8.7 to fix issues with using deprecated extensions APIs ([#85864](https://github.com/kubernetes/kubernetes/pull/85864), [@liggitt](https://github.com/liggitt))
+- Simple script based hyperkube image that bundles all the necessary binaries. This is an equivalent replacement for the image based on the go based hyperkube command + image. ([#84662](https://github.com/kubernetes/kubernetes/pull/84662), [@dims](https://github.com/dims))
+- Hyperkube will now be available in a new Github repository and will not be included in the kubernetes release from 1.17 onwards ([#83454](https://github.com/kubernetes/kubernetes/pull/83454), [@dims](https://github.com/dims))
+- Remove prometheus cluster monitoring addon from kube-up ([#83442](https://github.com/kubernetes/kubernetes/pull/83442), [@serathius](https://github.com/serathius))
+- SourcesReady provides the readiness of kubelet configuration sources such as apiserver update readiness. ([#81344](https://github.com/kubernetes/kubernetes/pull/81344), [@zouyee](https://github.com/zouyee))
+- This PR sets the --cluster-dns flag value to kube-dns service IP whether or not NodeLocal DNSCache is enabled. NodeLocal DNSCache will listen on both the link-local as well as the service IP. ([#84383](https://github.com/kubernetes/kubernetes/pull/84383), [@prameshj](https://github.com/prameshj))
+- kube-dns add-on:
+  - All containers are now being executed under more restrictive privileges.
+  - Most of the containers now run as non-root user and has the root filesystem set as read-only.
+  - The remaining container running as root only has the minimum Linux capabilities it requires to run.
+  - Privilege escalation has been disabled for all containers. ([#82347](https://github.com/kubernetes/kubernetes/pull/82347), [@pjbgf](https://github.com/pjbgf))
+- Kubernetes no longer monitors firewalld. On systems using firewalld for firewall
+  maintenance, kube-proxy will take slightly longer to recover from disruptive
+  firewalld operations that delete kube-proxy's iptables rules.
+
+  As a side effect of these changes, kube-proxy's
+  `sync_proxy_rules_last_timestamp_seconds` metric no longer behaves the
+  way it used to; now it will only change when services or endpoints actually
+  change, rather than reliably updating every 60 seconds (or whatever). If you
+  are trying to monitor for whether iptables updates are failing, the
+  `sync_proxy_rules_iptables_restore_failures_total` metric may be more useful. ([#81517](https://github.com/kubernetes/kubernetes/pull/81517), [@danwinship](https://github.com/danwinship))
+### Instrumentation
+- Bump version of event-exporter to 0.3.1, to switch it to protobuf. ([#83396](https://github.com/kubernetes/kubernetes/pull/83396), [@loburm](https://github.com/loburm))
+- Bumps metrics-server version to v0.3.6 with following bugfix:
+  -  Don't break metric storage when duplicate pod metrics encountered causing hpa to fail ([#83907](https://github.com/kubernetes/kubernetes/pull/83907), [@olagacek](https://github.com/olagacek))
+- addons: elasticsearch discovery supports IPv6 ([#85543](https://github.com/kubernetes/kubernetes/pull/85543), [@SataQiu](https://github.com/SataQiu))
+- Update Cluster Autoscaler to 1.17.0; changelog: https://github.com/kubernetes/autoscaler/releases/tag/cluster-autoscaler-1.17.0 ([#85610](https://github.com/kubernetes/kubernetes/pull/85610), [@losipiuk](https://github.com/losipiuk))
+### Network
+- The official kube-proxy image (used by kubeadm, among other things) is now compatible with systems running iptables 1.8 in "nft" mode, and will autodetect which mode it should use. ([#82966](https://github.com/kubernetes/kubernetes/pull/82966), [@danwinship](https://github.com/danwinship))
+- Kubenet: added HostPort IPv6 support.  HostPortManager: operates only with one IP family, failing if receives port mapping entries with different IP families.  HostPortSyncer: operates only with one IP family, skipping portmap entries with different IP families ([#80854](https://github.com/kubernetes/kubernetes/pull/80854), [@aojea](https://github.com/aojea))
+- Kube-proxy now supports DualStack feature with EndpointSlices and IPVS. ([#85246](https://github.com/kubernetes/kubernetes/pull/85246), [@robscott](https://github.com/robscott))
+- Remove redundant API validation when using Service Topology with externalTrafficPolicy=Local ([#85346](https://github.com/kubernetes/kubernetes/pull/85346), [@andrewsykim](https://github.com/andrewsykim))
+- Update github.com/vishvananda/netlink to v1.0.0 ([#83576](https://github.com/kubernetes/kubernetes/pull/83576), [@andrewsykim](https://github.com/andrewsykim))
+- `-- kube-controller-manager`
+  `--node-cidr-mask-size-ipv4 int32`     Default: 24. Mask size for IPv4 node-cidr in dual-stack cluster.
+`--node-cidr-mask-size-ipv6 int32`     Default: 64. Mask size for IPv6 node-cidr in dual-stack cluster.
+
+    These 2 flags can be used only for dual-stack clusters. For non dual-stack clusters, continue to use  `--node-cidr-mask-size` flag to configure the mask size.
+
+    The default node cidr mask size for IPv6 was 24 which is now changed to 64. ([#79993](https://github.com/kubernetes/kubernetes/pull/79993), [@aramase](https://github.com/aramase))
+- deprecate cleanup-ipvs flag ([#83832](https://github.com/kubernetes/kubernetes/pull/83832), [@gongguan](https://github.com/gongguan))
+- Kube-proxy: emits a warning when a malformed component config file is used with v1alpha1. ([#84143](https://github.com/kubernetes/kubernetes/pull/84143), [@phenixblue](https://github.com/phenixblue))
+- Set config.BindAddress to IPv4 address `127.0.0.1` if not specified ([#83822](https://github.com/kubernetes/kubernetes/pull/83822), [@zouyee](https://github.com/zouyee))
+- Updated kube-proxy ipvs README with correct grep argument to list loaded ipvs modules ([#83677](https://github.com/kubernetes/kubernetes/pull/83677), [@pete911](https://github.com/pete911))
+- The userspace mode of kube-proxy no longer confusingly logs messages about deleting endpoints that it is actually adding. ([#83644](https://github.com/kubernetes/kubernetes/pull/83644), [@danwinship](https://github.com/danwinship))
+- Kube-proxy iptables probabilities are now more granular and will result in better distribution beyond 319 endpoints. ([#83599](https://github.com/kubernetes/kubernetes/pull/83599), [@robscott](https://github.com/robscott))
+- Significant kube-proxy performance improvements for non UDP ports. ([#83208](https://github.com/kubernetes/kubernetes/pull/83208), [@robscott](https://github.com/robscott))
+- Improved performance of kube-proxy with EndpointSlice enabled with more efficient sorting. ([#83035](https://github.com/kubernetes/kubernetes/pull/83035), [@robscott](https://github.com/robscott))
+- EndpointSlices are now beta for better Network Endpoint performance at scale. ([#84390](https://github.com/kubernetes/kubernetes/pull/84390), [@robscott](https://github.com/robscott))
+- Updated EndpointSlices to use PublishNotReadyAddresses from Services. ([#84573](https://github.com/kubernetes/kubernetes/pull/84573), [@robscott](https://github.com/robscott))
+- When upgrading to 1.17 with a cluster with EndpointSlices enabled, the `endpointslice.kubernetes.io/managed-by` label needs to be set on each EndpointSlice. ([#85359](https://github.com/kubernetes/kubernetes/pull/85359), [@robscott](https://github.com/robscott))
+- Adds FQDN addressType support for EndpointSlice. ([#84091](https://github.com/kubernetes/kubernetes/pull/84091), [@robscott](https://github.com/robscott))
+- Fix incorrect network policy description suggesting that pods are isolated when a network policy has no rules of a given type ([#84194](https://github.com/kubernetes/kubernetes/pull/84194), [@jackkleeman](https://github.com/jackkleeman))
+- Fix bug where EndpointSlice controller would attempt to modify shared objects. ([#85368](https://github.com/kubernetes/kubernetes/pull/85368), [@robscott](https://github.com/robscott))
+- Splitting IP address type into IPv4 and IPv6 for EndpointSlices ([#84971](https://github.com/kubernetes/kubernetes/pull/84971), [@robscott](https://github.com/robscott))
+- Added appProtocol field to EndpointSlice Port ([#83815](https://github.com/kubernetes/kubernetes/pull/83815), [@howardjohn](https://github.com/howardjohn))
+- The docker container runtime now enforces a 220 second timeout on container network operations. ([#71653](https://github.com/kubernetes/kubernetes/pull/71653), [@liucimin](https://github.com/liucimin))
+- Fix panic in kubelet when running IPv4/IPv6 dual-stack mode with a CNI plugin ([#82508](https://github.com/kubernetes/kubernetes/pull/82508), [@aanm](https://github.com/aanm))
+- EndpointSlice hostname is now set in the same conditions Endpoints hostname is. ([#84207](https://github.com/kubernetes/kubernetes/pull/84207), [@robscott](https://github.com/robscott))
+- Improving the performance of Endpoint and EndpointSlice controllers by caching Service Selectors ([#84280](https://github.com/kubernetes/kubernetes/pull/84280), [@gongguan](https://github.com/gongguan))
+- Significant kube-proxy performance improvements when using Endpoint Slices at scale. ([#83206](https://github.com/kubernetes/kubernetes/pull/83206), [@robscott](https://github.com/robscott))
+
+### Node
+- Mirror pods now include an ownerReference for the node that created them. ([#84485](https://github.com/kubernetes/kubernetes/pull/84485), [@tallclair](https://github.com/tallclair))
+- Fixed a bug in the single-numa-policy of the TopologyManager. Previously, best-effort pods would result in a terminated state with a TopologyAffinity error. Now they will run as expected. ([#83777](https://github.com/kubernetes/kubernetes/pull/83777), [@lmdaly](https://github.com/lmdaly))
+- Fixed a bug in the single-numa-node policy of the TopologyManager.  Previously, pods that only requested CPU resources and did not request any third-party devices would fail to launch with a TopologyAffinity error. Now they will launch successfully. ([#83697](https://github.com/kubernetes/kubernetes/pull/83697), [@klueska](https://github.com/klueska))
+- Fix error where metrics related to dynamic kubelet config isn't registered ([#83184](https://github.com/kubernetes/kubernetes/pull/83184), [@odinuge](https://github.com/odinuge))
+- If container fails because ContainerCannotRun, do not utilize the FallbackToLogsOnError TerminationMessagePolicy, as it masks more useful logs. ([#81280](https://github.com/kubernetes/kubernetes/pull/81280), [@yqwang-ms](https://github.com/yqwang-ms))
+- Use online nodes instead of possible nodes when discovering available NUMA nodes ([#83196](https://github.com/kubernetes/kubernetes/pull/83196), [@zouyee](https://github.com/zouyee))
+- Use IPv4 in wincat port forward. ([#83036](https://github.com/kubernetes/kubernetes/pull/83036), [@liyanhui1228](https://github.com/liyanhui1228))
+- Single static pod files and pod files from http endpoints cannot be larger than 10 MB. HTTP probe payloads are now truncated to 10KB. ([#82669](https://github.com/kubernetes/kubernetes/pull/82669), [@rphillips](https://github.com/rphillips))
+- Limit the body length of exec readiness/liveness probes. remote CRIs and Docker shim read a max of 16MB output of which the exec probe itself inspects 10kb. ([#82514](https://github.com/kubernetes/kubernetes/pull/82514), [@dims](https://github.com/dims))
+- Kubelet: Added kubelet serving certificate metric `server_rotation_seconds` which is a histogram reporting the age of a just rotated serving certificate in seconds. ([#84534](https://github.com/kubernetes/kubernetes/pull/84534), [@sambdavidson](https://github.com/sambdavidson))
+- Reduce default NodeStatusReportFrequency to 5 minutes. With this change, periodic node status updates will be send every 5m if node status doesn't change (otherwise they are still send with 10s).
+
+  Bump NodeProblemDetector version to v0.8.0 to reduce forced NodeStatus updates frequency to 5 minutes. ([#84007](https://github.com/kubernetes/kubernetes/pull/84007), [@wojtek-t](https://github.com/wojtek-t))
+- The topology manager aligns resources for pods of all QoS classes with respect to NUMA locality, not just Guaranteed QoS pods. ([#83492](https://github.com/kubernetes/kubernetes/pull/83492), [@ConnorDoyle](https://github.com/ConnorDoyle))
+- Fix a bug that a node Lease object may have been created without OwnerReference. ([#84998](https://github.com/kubernetes/kubernetes/pull/84998), [@wojtek-t](https://github.com/wojtek-t))
+- External facing APIs in plugin registration and device plugin packages are now available under k8s.io/kubelet/pkg/apis/ ([#83551](https://github.com/kubernetes/kubernetes/pull/83551), [@dims](https://github.com/dims))
+### Release
+- Added the `crictl` Windows binaries as well as the Linux 32bit binary to the release archives ([#83944](https://github.com/kubernetes/kubernetes/pull/83944), [@saschagrunert](https://github.com/saschagrunert))
+- Bumps the minimum version of Go required for building Kubernetes to 1.12.4. ([#83596](https://github.com/kubernetes/kubernetes/pull/83596), [@jktomer](https://github.com/jktomer))
+- The deprecated mondo `kubernetes-test` tarball is no longer built. Users running Kubernetes e2e tests should use the `kubernetes-test-portable` and `kubernetes-test-{OS}-{ARCH}` tarballs instead. ([#83093](https://github.com/kubernetes/kubernetes/pull/83093), [@ixdy](https://github.com/ixdy))
+
+### Scheduling
+
+- Only validate duplication of the RequestedToCapacityRatio custom priority and allow other custom predicates/priorities ([#84646](https://github.com/kubernetes/kubernetes/pull/84646), [@liu-cong](https://github.com/liu-cong))
+- Scheduler policy configs can no longer be declared multiple times ([#83963](https://github.com/kubernetes/kubernetes/pull/83963), [@damemi](https://github.com/damemi))
+- TaintNodesByCondition was graduated to GA, CheckNodeMemoryPressure, CheckNodePIDPressure, CheckNodeDiskPressure, CheckNodeCondition were accidentally removed since 1.12, the replacement is to use CheckNodeUnschedulablePred ([#84152](https://github.com/kubernetes/kubernetes/pull/84152), [@draveness](https://github.com/draveness))
+- [migration phase 1] PodFitsHostPorts as filter plugin ([#83659](https://github.com/kubernetes/kubernetes/pull/83659), [@wgliang](https://github.com/wgliang))
+- [migration phase 1] PodFitsResources as framework plugin ([#83650](https://github.com/kubernetes/kubernetes/pull/83650), [@wgliang](https://github.com/wgliang))
+- [migration phase 1] PodMatchNodeSelector/NodAffinity as filter plugin ([#83660](https://github.com/kubernetes/kubernetes/pull/83660), [@wgliang](https://github.com/wgliang))
+- Add more tracing steps in generic_scheduler ([#83539](https://github.com/kubernetes/kubernetes/pull/83539), [@wgliang](https://github.com/wgliang))
+- [migration phase 1] PodFitsHost as filter plugin ([#83662](https://github.com/kubernetes/kubernetes/pull/83662), [@wgliang](https://github.com/wgliang))
+- Fixed a scheduler panic when using PodAffinity. ([#82841](https://github.com/kubernetes/kubernetes/pull/82841), [@Huang-Wei](https://github.com/Huang-Wei))
+- Take the context as the first argument of Schedule. ([#82119](https://github.com/kubernetes/kubernetes/pull/82119), [@wgliang](https://github.com/wgliang))
+- Fixed an issue that the correct PluginConfig.Args is not passed to the corresponding PluginFactory in kube-scheduler when multiple PluginConfig items are defined. ([#82483](https://github.com/kubernetes/kubernetes/pull/82483), [@everpeace](https://github.com/everpeace))
+- Profiling is enabled by default in the scheduler ([#84835](https://github.com/kubernetes/kubernetes/pull/84835), [@denkensk](https://github.com/denkensk))
+- Scheduler now reports metrics on cache size including nodes, pods, and assumed pods ([#83508](https://github.com/kubernetes/kubernetes/pull/83508), [@damemi](https://github.com/damemi))
+- User can now use component config to configure NodeLabel plugin for the scheduler framework. ([#84297](https://github.com/kubernetes/kubernetes/pull/84297), [@liu-cong](https://github.com/liu-cong))
+- Optimize inter-pod affinity preferredDuringSchedulingIgnoredDuringExecution type, up to 4x in some cases. ([#84264](https://github.com/kubernetes/kubernetes/pull/84264), [@ahg-g](https://github.com/ahg-g))
+- Filter plugin for cloud provider storage predicate ([#84148](https://github.com/kubernetes/kubernetes/pull/84148), [@gongguan](https://github.com/gongguan))
+- Refactor scheduler's framework permit API. ([#83756](https://github.com/kubernetes/kubernetes/pull/83756), [@hex108](https://github.com/hex108))
+- Add incoming pods metrics to scheduler queue. ([#83577](https://github.com/kubernetes/kubernetes/pull/83577), [@liu-cong](https://github.com/liu-cong))
+- Allow dynamically set glog logging level of kube-scheduler ([#83910](https://github.com/kubernetes/kubernetes/pull/83910), [@mrkm4ntr](https://github.com/mrkm4ntr))
+- Add latency and request count metrics for scheduler framework. ([#83569](https://github.com/kubernetes/kubernetes/pull/83569), [@liu-cong](https://github.com/liu-cong))
+- Expose SharedInformerFactory in the framework handle ([#83663](https://github.com/kubernetes/kubernetes/pull/83663), [@draveness](https://github.com/draveness))
+- Add per-pod scheduling metrics across 1 or more schedule attempts. ([#83674](https://github.com/kubernetes/kubernetes/pull/83674), [@liu-cong](https://github.com/liu-cong))
+- Add `podInitialBackoffDurationSeconds` and `podMaxBackoffDurationSeconds` to the scheduler config API ([#81263](https://github.com/kubernetes/kubernetes/pull/81263), [@draveness](https://github.com/draveness))
+- Expose kubernetes client in the scheduling framework handle. ([#82432](https://github.com/kubernetes/kubernetes/pull/82432), [@draveness](https://github.com/draveness))
+- Remove MaxPriority in the scheduler API, please use MaxNodeScore or MaxExtenderPriority instead. ([#83386](https://github.com/kubernetes/kubernetes/pull/83386), [@draveness](https://github.com/draveness))
+- Consolidate ScoreWithNormalizePlugin into the ScorePlugin interface ([#83042](https://github.com/kubernetes/kubernetes/pull/83042), [@draveness](https://github.com/draveness))
+- New APIs to allow adding/removing pods from pre-calculated prefilter state in the scheduling framework ([#82912](https://github.com/kubernetes/kubernetes/pull/82912), [@ahg-g](https://github.com/ahg-g))
+- Added Clone method to the scheduling framework's PluginContext and ContextData. ([#82951](https://github.com/kubernetes/kubernetes/pull/82951), [@ahg-g](https://github.com/ahg-g))
+- Modified the scheduling framework's Filter API. ([#82842](https://github.com/kubernetes/kubernetes/pull/82842), [@ahg-g](https://github.com/ahg-g))
+- Critical pods can now be created in namespaces other than kube-system. To limit critical pods to the kube-system namespace, cluster admins should create an admission configuration file limiting critical pods by default, and a matching quota object in the `kube-system` namespace permitting critical pods in that namespace. See https://kubernetes.io/docs/concepts/policy/resource-quotas/&#35;limit-priority-class-consumption-by-default for details. ([#76310](https://github.com/kubernetes/kubernetes/pull/76310), [@ravisantoshgudimetla](https://github.com/ravisantoshgudimetla))
+- Scheduler ComponentConfig fields are now pointers ([#83619](https://github.com/kubernetes/kubernetes/pull/83619), [@damemi](https://github.com/damemi))
+- Scheduler Policy API has a new recommended apiVersion `apiVersion: kubescheduler.config.k8s.io/v1` which is consistent with the scheduler API group `kubescheduler.config.k8s.io`. It holds the same API as the old apiVersion `apiVersion: v1`. ([#83578](https://github.com/kubernetes/kubernetes/pull/83578), [@Huang-Wei](https://github.com/Huang-Wei))
+- Rename PluginContext to CycleState in the scheduling framework ([#83430](https://github.com/kubernetes/kubernetes/pull/83430), [@draveness](https://github.com/draveness))
+- Some scheduler extender API fields are moved from `pkg/scheduler/api` to `pkg/scheduler/apis/extender/v1`. ([#83262](https://github.com/kubernetes/kubernetes/pull/83262), [@Huang-Wei](https://github.com/Huang-Wei))
+- Kube-scheduler: emits a warning when a malformed component config file is used with v1alpha1. ([#84129](https://github.com/kubernetes/kubernetes/pull/84129), [@obitech](https://github.com/obitech))
+- Kube-scheduler now falls back to emitting events using core/v1 Events when events.k8s.io/v1beta1 is disabled. ([#83692](https://github.com/kubernetes/kubernetes/pull/83692), [@yastij](https://github.com/yastij))
+- Expand scheduler priority functions and scheduling framework plugins' node score range to [0, 100]. Note: this change is internal and does not affect extender and RequestedToCapacityRatio custom priority, which are still expected to provide a [0, 10] range. ([#83522](https://github.com/kubernetes/kubernetes/pull/83522), [@draveness](https://github.com/draveness))
+
+### Storage
+- Bump CSI version to 1.2.0 ([#84832](https://github.com/kubernetes/kubernetes/pull/84832), [@gnufied](https://github.com/gnufied))
+- CSI Migration: Fixes issue where all volumes with the same inline volume inner spec name were staged in the same path. Migrated inline volumes are now staged at a unique path per unique volume. ([#84754](https://github.com/kubernetes/kubernetes/pull/84754), [@davidz627](https://github.com/davidz627))
+- CSI Migration: GCE PD access mode now reflects read only status of inline volumes - this allows multi-attach for read only many PDs ([#84809](https://github.com/kubernetes/kubernetes/pull/84809), [@davidz627](https://github.com/davidz627))
+- CSI detach timeout increased from 10 seconds to 2 minutes ([#84321](https://github.com/kubernetes/kubernetes/pull/84321), [@cduchesne](https://github.com/cduchesne))
+- Ceph RBD volume plugin now does not use any keyring (`/etc/ceph/ceph.client.lvs01cinder.keyring`, `/etc/ceph/ceph.keyring`, `/etc/ceph/keyring`, `/etc/ceph/keyring.bin`) for authentication. Ceph user credentials must be provided in PersistentVolume objects and referred Secrets. ([#75588](https://github.com/kubernetes/kubernetes/pull/75588), [@smileusd](https://github.com/smileusd))
+- Validate Gluster IP ([#83104](https://github.com/kubernetes/kubernetes/pull/83104), [@zouyee](https://github.com/zouyee))
+- PersistentVolumeLabel admission plugin, responsible for labeling `PersistentVolumes` with topology labels, now does not overwrite existing labels on PVs that were dynamically provisioned. It trusts the  dynamic provisioning that it provided the correct labels to the `PersistentVolume`, saving one potentially expensive cloud API call. `PersistentVolumes` created manually by users are labelled by the admission plugin in the same way as before. ([#82830](https://github.com/kubernetes/kubernetes/pull/82830), [@jsafrane](https://github.com/jsafrane))
+
+- Existing PVs are converted to use volume topology if migration is enabled. ([#83394](https://github.com/kubernetes/kubernetes/pull/83394), [@bertinatto](https://github.com/bertinatto))
+- local: support local filesystem volume with block resource reconstruction ([#84218](https://github.com/kubernetes/kubernetes/pull/84218), [@cofyc](https://github.com/cofyc))
+- Fixed binding of block PersistentVolumes / PersistentVolumeClaims when BlockVolume feature is off. ([#84049](https://github.com/kubernetes/kubernetes/pull/84049), [@jsafrane](https://github.com/jsafrane))
+- Report non-confusing error for negative storage size in PVC spec. ([#82759](https://github.com/kubernetes/kubernetes/pull/82759), [@sttts](https://github.com/sttts))
+- Fixed "requested device X but found Y" attach error on AWS. ([#85675](https://github.com/kubernetes/kubernetes/pull/85675), [@jsafrane](https://github.com/jsafrane))
+- Reduced frequency of DescribeVolumes calls of AWS API when attaching/detaching a volume. ([#84181](https://github.com/kubernetes/kubernetes/pull/84181), [@jsafrane](https://github.com/jsafrane))
+- Fixed attachment of AWS volumes that have just been detached. ([#83567](https://github.com/kubernetes/kubernetes/pull/83567), [@jsafrane](https://github.com/jsafrane))
+- Fix possible fd leak and closing of dirs when using openstack ([#82873](https://github.com/kubernetes/kubernetes/pull/82873), [@odinuge](https://github.com/odinuge))
+- local: support local volume block mode reconstruction ([#84173](https://github.com/kubernetes/kubernetes/pull/84173), [@cofyc](https://github.com/cofyc))
+- Fixed cleanup of raw block devices after kubelet restart. ([#83451](https://github.com/kubernetes/kubernetes/pull/83451), [@jsafrane](https://github.com/jsafrane))
+- Add data cache flushing during unmount device for GCE-PD driver in Windows Server. ([#83591](https://github.com/kubernetes/kubernetes/pull/83591), [@jingxu97](https://github.com/jingxu97))
+### Windows
+- Adds Windows Server build information as a label on the node. ([#84472](https://github.com/kubernetes/kubernetes/pull/84472), [@gab-satchi](https://github.com/gab-satchi))
+- Fixes kube-proxy bug accessing self nodeip:port on windows ([#83027](https://github.com/kubernetes/kubernetes/pull/83027), [@liggitt](https://github.com/liggitt))
+- When using Containerd on Windows, the ``TerminationMessagePath`` file will now be mounted in the Windows Pod. ([#83057](https://github.com/kubernetes/kubernetes/pull/83057), [@bclau](https://github.com/bclau))
+- Fix kubelet metrics gathering on non-English Windows hosts ([#84156](https://github.com/kubernetes/kubernetes/pull/84156), [@wawa0210](https://github.com/wawa0210))
+
+### Dependencies
+
+
+- Update etcd client side to v3.4.3 ([#83987](https://github.com/kubernetes/kubernetes/pull/83987), [@wenjiaswe](https://github.com/wenjiaswe))
+- Kubernetes now requires go1.13.4+ to build ([#82809](https://github.com/kubernetes/kubernetes/pull/82809), [@liggitt](https://github.com/liggitt))
+- Update to use go1.12.12 ([#84064](https://github.com/kubernetes/kubernetes/pull/84064), [@cblecker](https://github.com/cblecker))
+- Update to go 1.12.10 ([#83139](https://github.com/kubernetes/kubernetes/pull/83139), [@cblecker](https://github.com/cblecker))
+- Update default etcd server version to 3.4.3 ([#84329](https://github.com/kubernetes/kubernetes/pull/84329), [@jingyih](https://github.com/jingyih))
+
+### Detailed go Dependency Changes
+
+#### Added
+- github.com/OpenPeeDeeP/depguard: v1.0.1
+- github.com/StackExchange/wmi: 5d04971
+- github.com/agnivade/levenshtein: v1.0.1
+- github.com/alecthomas/template: a0175ee
+- github.com/alecthomas/units: 2efee85
+- github.com/andreyvit/diff: c7f18ee
+- github.com/anmitsu/go-shlex: 648efa6
+- github.com/bazelbuild/rules_go: 6dae44d
+- github.com/bgentry/speakeasy: v0.1.0
+- github.com/bradfitz/go-smtpd: deb6d62
+- github.com/cockroachdb/datadriven: 80d97fb
+- github.com/creack/pty: v1.1.7
+- github.com/gliderlabs/ssh: v0.1.1
+- github.com/go-critic/go-critic: 1df3008
+- github.com/go-kit/kit: v0.8.0
+- github.com/go-lintpack/lintpack: v0.5.2
+- github.com/go-logfmt/logfmt: v0.3.0
+- github.com/go-ole/go-ole: v1.2.1
+- github.com/go-stack/stack: v1.8.0
+- github.com/go-toolsmith/astcast: v1.0.0
+- github.com/go-toolsmith/astcopy: v1.0.0
+- github.com/go-toolsmith/astequal: v1.0.0
+- github.com/go-toolsmith/astfmt: v1.0.0
+- github.com/go-toolsmith/astinfo: 9809ff7
+- github.com/go-toolsmith/astp: v1.0.0
+- github.com/go-toolsmith/pkgload: v1.0.0
+- github.com/go-toolsmith/strparse: v1.0.0
+- github.com/go-toolsmith/typep: v1.0.0
+- github.com/gobwas/glob: v0.2.3
+- github.com/golangci/check: cfe4005
+- github.com/golangci/dupl: 3e9179a
+- github.com/golangci/errcheck: ef45e06
+- github.com/golangci/go-misc: 927a3d8
+- github.com/golangci/go-tools: e32c541
+- github.com/golangci/goconst: 041c5f2
+- github.com/golangci/gocyclo: 2becd97
+- github.com/golangci/gofmt: 0b8337e
+- github.com/golangci/golangci-lint: v1.18.0
+- github.com/golangci/gosec: 66fb7fc
+- github.com/golangci/ineffassign: 42439a7
+- github.com/golangci/lint-1: ee948d0
+- github.com/golangci/maligned: b1d8939
+- github.com/golangci/misspell: 950f5d1
+- github.com/golangci/prealloc: 215b22d
+- github.com/golangci/revgrep: d9c87f5
+- github.com/golangci/unconvert: 28b1c44
+- github.com/google/go-github: v17.0.0+incompatible
+- github.com/google/go-querystring: v1.0.0
+- github.com/gostaticanalysis/analysisutil: v0.0.3
+- github.com/jellevandenhooff/dkim: f50fe3d
+- github.com/julienschmidt/httprouter: v1.2.0
+- github.com/klauspost/compress: v1.4.1
+- github.com/kr/logfmt: b84e30a
+- github.com/logrusorgru/aurora: a7b3b31
+- github.com/mattn/go-runewidth: v0.0.2
+- github.com/mattn/goveralls: v0.0.2
+- github.com/mitchellh/go-ps: 4fdf99a
+- github.com/mozilla/tls-observatory: 8791a20
+- github.com/mwitkow/go-conntrack: cc309e4
+- github.com/nbutton23/zxcvbn-go: eafdab6
+- github.com/olekukonko/tablewriter: a0225b3
+- github.com/quasilyte/go-consistent: c6f3937
+- github.com/rogpeppe/fastuuid: 6724a57
+- github.com/ryanuber/go-glob: 256dc44
+- github.com/sergi/go-diff: v1.0.0
+- github.com/shirou/gopsutil: c95755e
+- github.com/shirou/w32: bb4de01
+- github.com/shurcooL/go-goon: 37c2f52
+- github.com/shurcooL/go: 9e1955d
+- github.com/sourcegraph/go-diff: v0.5.1
+- github.com/tarm/serial: 98f6abe
+- github.com/tidwall/pretty: v1.0.0
+- github.com/timakin/bodyclose: 87058b9
+- github.com/ultraware/funlen: v0.0.2
+- github.com/urfave/cli: v1.20.0
+- github.com/valyala/bytebufferpool: v1.0.0
+- github.com/valyala/fasthttp: v1.2.0
+- github.com/valyala/quicktemplate: v1.1.1
+- github.com/valyala/tcplisten: ceec8f9
+- github.com/vektah/gqlparser: v1.1.2
+- go.etcd.io/etcd: 3cf2f69
+- go.mongodb.org/mongo-driver: v1.1.2
+- go4.org: 417644f
+- golang.org/x/build: 2835ba2
+- golang.org/x/perf: 6e6d33e
+- golang.org/x/xerrors: a985d34
+- gopkg.in/alecthomas/kingpin.v2: v2.2.6
+- gopkg.in/cheggaaa/pb.v1: v1.0.25
+- gopkg.in/resty.v1: v1.12.0
+- grpc.go4.org: 11d0a25
+- k8s.io/system-validators: v1.0.4
+- mvdan.cc/interfacer: c200402
+- mvdan.cc/lint: adc824a
+- mvdan.cc/unparam: fbb5962
+- sourcegraph.com/sqs/pbtypes: d3ebe8f
+
+#### Changed
+- github.com/Azure/azure-sdk-for-go: v32.5.0+incompatible → v35.0.0+incompatible
+- github.com/Microsoft/go-winio: v0.4.11 → v0.4.14
+- github.com/bazelbuild/bazel-gazelle: c728ce9 → 70208cb
+- github.com/bazelbuild/buildtools: 80c7f0d → 69366ca
+- github.com/beorn7/perks: 3a771d9 → v1.0.0
+- github.com/container-storage-interface/spec: v1.1.0 → v1.2.0
+- github.com/coredns/corefile-migration: v1.0.2 → v1.0.4
+- github.com/coreos/etcd: v3.3.17+incompatible → v3.3.10+incompatible
+- github.com/coreos/go-systemd: 39ca1b0 → 95778df
+- github.com/docker/go-units: v0.3.3 → v0.4.0
+- github.com/docker/libnetwork: a9cd636 → f0e46a7
+- github.com/fatih/color: v1.6.0 → v1.7.0
+- github.com/ghodss/yaml: c7ce166 → v1.0.0
+- github.com/go-openapi/analysis: v0.19.2 → v0.19.5
+- github.com/go-openapi/jsonpointer: v0.19.2 → v0.19.3
+- github.com/go-openapi/jsonreference: v0.19.2 → v0.19.3
+- github.com/go-openapi/loads: v0.19.2 → v0.19.4
+- github.com/go-openapi/runtime: v0.19.0 → v0.19.4
+- github.com/go-openapi/spec: v0.19.2 → v0.19.3
+- github.com/go-openapi/strfmt: v0.19.0 → v0.19.3
+- github.com/go-openapi/swag: v0.19.2 → v0.19.5
+- github.com/go-openapi/validate: v0.19.2 → v0.19.5
+- github.com/godbus/dbus: v4.1.0+incompatible → 2ff6f7f
+- github.com/golang/protobuf: v1.3.1 → v1.3.2
+- github.com/google/btree: 4030bb1 → v1.0.0
+- github.com/google/cadvisor: v0.34.0 → v0.35.0
+- github.com/gregjones/httpcache: 787624d → 9cad4c3
+- github.com/grpc-ecosystem/go-grpc-middleware: cfaf568 → f849b54
+- github.com/grpc-ecosystem/grpc-gateway: v1.3.0 → v1.9.5
+- github.com/heketi/heketi: v9.0.0+incompatible → c2e2a4a
+- github.com/json-iterator/go: v1.1.7 → v1.1.8
+- github.com/mailru/easyjson: 94de47d → v0.7.0
+- github.com/mattn/go-isatty: v0.0.3 → v0.0.9
+- github.com/mindprince/gonvml: fee913c → 9ebdce4
+- github.com/mrunalp/fileutils: 4ee1cc9 → 7d4729f
+- github.com/munnerz/goautoneg: a547fc6 → a7dc8b6
+- github.com/onsi/ginkgo: v1.8.0 → v1.10.1
+- github.com/onsi/gomega: v1.5.0 → v1.7.0
+- github.com/opencontainers/runc: 6cc5158 → v1.0.0-rc9
+- github.com/opencontainers/selinux: v1.2.2 → 5215b18
+- github.com/pkg/errors: v0.8.0 → v0.8.1
+- github.com/prometheus/client_golang: v0.9.2 → v1.0.0
+- github.com/prometheus/client_model: 5c3871d → fd36f42
+- github.com/prometheus/common: 4724e92 → v0.4.1
+- github.com/prometheus/procfs: 1dc9a6c → v0.0.2
+- github.com/soheilhy/cmux: v0.1.3 → v0.1.4
+- github.com/spf13/pflag: v1.0.3 → v1.0.5
+- github.com/stretchr/testify: v1.3.0 → v1.4.0
+- github.com/syndtr/gocapability: e7cb7fa → d983527
+- github.com/vishvananda/netlink: b2de5d1 → v1.0.0
+- github.com/vmware/govmomi: v0.20.1 → v0.20.3
+- github.com/xiang90/probing: 07dd2e8 → 43a291a
+- go.uber.org/atomic: 8dc6146 → v1.3.2
+- go.uber.org/multierr: ddea229 → v1.1.0
+- go.uber.org/zap: 67bc79d → v1.10.0
+- golang.org/x/crypto: e84da03 → 60c769a
+- golang.org/x/lint: 8f45f77 → 959b441
+- golang.org/x/net: cdfb69a → 13f9640
+- golang.org/x/oauth2: 9f33145 → 0f29369
+- golang.org/x/sync: 42b3178 → cd5d95a
+- golang.org/x/sys: 3b52091 → fde4db3
+- golang.org/x/text: e6919f6 → v0.3.2
+- golang.org/x/time: f51c127 → 9d24e82
+- golang.org/x/tools: 6e04913 → 65e3620
+- google.golang.org/grpc: v1.23.0 → v1.23.1
+- gopkg.in/inf.v0: v0.9.0 → v0.9.1
+- k8s.io/klog: v0.4.0 → v1.0.0
+- k8s.io/kube-openapi: 743ec37 → 30be4d1
+- k8s.io/repo-infra: 00fe14e → v0.0.1-alpha.1
+- k8s.io/utils: 581e001 → e782cd3
+- sigs.k8s.io/structured-merge-diff: 6149e45 → b1b620d
+
+#### Removed
+- github.com/cloudflare/cfssl: 56268a6
+- github.com/coreos/bbolt: v1.3.3
+- github.com/coreos/rkt: v1.30.0
+- github.com/globalsign/mgo: eeefdec
+- github.com/google/certificate-transparency-go: v1.0.21
+- github.com/heketi/rest: aa6a652
+- github.com/heketi/utils: 435bc5b
+- github.com/pborman/uuid: v1.2.0
+
+# v1.17.0-rc.2
+
+[Documentation](https://docs.k8s.io)
+
+## Downloads for v1.17.0-rc.2
+
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes.tar.gz](https://dl.k8s.io/v1.17.0-rc.2/kubernetes.tar.gz) | `c71521ab0ab1905776b4e05d99672b7ae6555693b95bc4b84c61134197afe4bf9c49297abdfcf87b34d5e8922550d4e45b7e06073881fa5033d39034f3cba402`
+[kubernetes-src.tar.gz](https://dl.k8s.io/v1.17.0-rc.2/kubernetes-src.tar.gz) | `68248a0610e6971db509fa3475032704ed2d37bb5937ee462fff0a7f0b84ee9753ae49fbc66f00eebc6cc5f455b6c41327c50078708c1570c9bf3d1186f5ff6f`
+
+### Client Binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-client-darwin-386.tar.gz](https://dl.k8s.io/v1.17.0-rc.2/kubernetes-client-darwin-386.tar.gz) | `1bd00995cc4a58050d42bd4b430cd353f808eade67556946d70e3e8a365d9e05a49c44d611ff6fe97f89f01a2dfa7f297ea66f0edba39333f9a4bcd06991375b`
+[kubernetes-client-darwin-amd64.tar.gz](https://dl.k8s.io/v1.17.0-rc.2/kubernetes-client-darwin-amd64.tar.gz) | `704727bc0d1ca207ff75f901ffb7b8afd29cdc532455e76bfcf8c0223c605c104f3a588173eef3a3e8b8f976fed34b870d398383454ad201f10ca430d72365ac`
+[kubernetes-client-linux-386.tar.gz](https://dl.k8s.io/v1.17.0-rc.2/kubernetes-client-linux-386.tar.gz) | `706a08ecd314afbc63a7fdedcc47f17d4ab8bc36a2a7239d1f86e4321a6bc274b740893508558e6ca6492dc690b1a6042fc3a6bd3cddeb7bbb84ba851609c974`
+[kubernetes-client-linux-amd64.tar.gz](https://dl.k8s.io/v1.17.0-rc.2/kubernetes-client-linux-amd64.tar.gz) | `36e7041453f735ea19141eebcce48fdc18cd3cae76fa7ac97bc7b46077e9208cad9974479d93450932d338ea162d4153ad0ec6f56f3f2cb8e8d98a132f14f833`
+[kubernetes-client-linux-arm.tar.gz](https://dl.k8s.io/v1.17.0-rc.2/kubernetes-client-linux-arm.tar.gz) | `e6f1bfa5170238fc676e3717ee212e96076e8ec3ceca6b9a4bd4233822185ed8d2aee826d4061bbb1638b0996488e400443d88667948d6b2e5290c3647036dca`
+[kubernetes-client-linux-arm64.tar.gz](https://dl.k8s.io/v1.17.0-rc.2/kubernetes-client-linux-arm64.tar.gz) | `29bf7b4df9786c9be9995b15f05ebb18bd1dfad9cebf61207c1cac050000cabb41b816c4cd6022710c01fc712624359988aac307bcec12a51e2dae3163ac9406`
+[kubernetes-client-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.17.0-rc.2/kubernetes-client-linux-ppc64le.tar.gz) | `d1774fbeafd01447d11e05734055ad133dc90108f5c1bc9adaf84b8334f997e24324f59ee664c7e723b1dfb05e8ec4a59f956148718fdb277be40f9a7886c28e`
+[kubernetes-client-linux-s390x.tar.gz](https://dl.k8s.io/v1.17.0-rc.2/kubernetes-client-linux-s390x.tar.gz) | `ca93b0539bda64f3e168b1ca1178eaf13f81de297475fc750893678a0cc6c626c7dea69253079c16b3875ec68f8162f8c01469f72e5481c1bb21d3f57e5745a1`
+[kubernetes-client-windows-386.tar.gz](https://dl.k8s.io/v1.17.0-rc.2/kubernetes-client-windows-386.tar.gz) | `cda5e2526779991d3169d0089e69a2b9e7aa2a127aeb7eec339f4ed1b2b74afc74ef8154964bffb4219eed4e0956b4eb4356ed8cea6364085a163737010a8286`
+[kubernetes-client-windows-amd64.tar.gz](https://dl.k8s.io/v1.17.0-rc.2/kubernetes-client-windows-amd64.tar.gz) | `c95b17ecd976cf33f182c2d26d49102dad2d7d78fe36d389b18730d59a8866cd28d1b3b28a20126c28b86cdb02ec3e58b8a86397cd778a7642160f11fd789e27`
+
+### Server Binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-server-linux-amd64.tar.gz](https://dl.k8s.io/v1.17.0-rc.2/kubernetes-server-linux-amd64.tar.gz) | `aac109354621dc061e01aa6c72aabe43bb1c784a986be86f2e53c8f8243a2470d31955b06111648ddf0a9be686c7cda97c1106d46772c5db100061a7d3cb2521`
+[kubernetes-server-linux-arm.tar.gz](https://dl.k8s.io/v1.17.0-rc.2/kubernetes-server-linux-arm.tar.gz) | `d9755aa8c2b0c2d2fdd0756422176c7b34a85553edde03f075363f79bada3f349facb19123cab7ac4ed0ff3159d256b1c968037aa25118ab2fb3f67a118fce35`
+[kubernetes-server-linux-arm64.tar.gz](https://dl.k8s.io/v1.17.0-rc.2/kubernetes-server-linux-arm64.tar.gz) | `e0bf1247872b0361237e7c5f0837b496b2c4ed05e38d5878c11a81d86282ac83ba382e3cf606a14a3a6af73085e137a82d193790e2805c88ea35bdf07c163e2a`
+[kubernetes-server-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.17.0-rc.2/kubernetes-server-linux-ppc64le.tar.gz) | `44d54154e37b87841123d9f12bce979e5faec88fa9654c0f46904f1bf477aff28790b59af241706b2f729cf1e0e56b146512c2c66bb28909c898e9df2f6ea920`
+[kubernetes-server-linux-s390x.tar.gz](https://dl.k8s.io/v1.17.0-rc.2/kubernetes-server-linux-s390x.tar.gz) | `9f42dd736b9575eabb4ef37dae8f18e2f433d00d94e7a994734a9b362127de060ee67e02fc6578dd599b0120b58564aa4fdc5bf583e4e7cc825d7875b3ca099a`
+
+### Node Binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-node-linux-amd64.tar.gz](https://dl.k8s.io/v1.17.0-rc.2/kubernetes-node-linux-amd64.tar.gz) | `6f94d2f4a9e2b37797c482a9d42ee9c93d6100fb8b21a983944cb611d57e4e0e6c69a8aa6e8200927f81d68f614913c5453400d298ef884d687f9629d0a213ba`
+[kubernetes-node-linux-arm.tar.gz](https://dl.k8s.io/v1.17.0-rc.2/kubernetes-node-linux-arm.tar.gz) | `7078f7372d733b2933d24ddca38401b6d044f90a9c82e12d61c968f545a24a03d738e7402501771cfbe403a47b96a5f8d2e662823e8fa138b2e30804ceb688bf`
+[kubernetes-node-linux-arm64.tar.gz](https://dl.k8s.io/v1.17.0-rc.2/kubernetes-node-linux-arm64.tar.gz) | `9d9365699ecfecac6e7413bdf6d77b917a0e4ed5747810db8c04a3a6d5d2ae416067ae0164fb909e6849179a5117b9df26f39d2bdeca73e706f17ddb84ac2f78`
+[kubernetes-node-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.17.0-rc.2/kubernetes-node-linux-ppc64le.tar.gz) | `6103b55f433a864360231cc509bd692b3ebdc6be34e3fe43fdc2fbd1a2bff750cc2800a68792fe53b87803197cba95a90317b404c8ef3cd2ac3be3b0c54c0c34`
+[kubernetes-node-linux-s390x.tar.gz](https://dl.k8s.io/v1.17.0-rc.2/kubernetes-node-linux-s390x.tar.gz) | `d83008a4cc86c837afd89b3ef7eece8deac67ba29a9a29076333481e630b59acc044917ad54fd1658932569fc2f11f350267ebe9dd2089a865163dfecea55798`
+[kubernetes-node-windows-amd64.tar.gz](https://dl.k8s.io/v1.17.0-rc.2/kubernetes-node-windows-amd64.tar.gz) | `50b03637ecaacf3e6acd56d1a1eac7a95bb05697a179cd83494726ae05480839161d62be2572040607ad9f1fe21ffb8d0c68a91f3f3aa2d99d6ecc8cde30204f`
+
+## Changelog since v1.17.0-rc.1
+
+### Other notable changes
+
+* Resolved regression in admission, authentication, and authorization webhook performance in v1.17.0-rc.1 ([#85810](https://github.com/kubernetes/kubernetes/pull/85810), [@liggitt](https://github.com/liggitt))
+* Filter published OpenAPI schema by making nullable, required fields non-required in order to avoid kubectl to wrongly reject null values. ([#85732](https://github.com/kubernetes/kubernetes/pull/85732), [@sttts](https://github.com/sttts))
+* Update Cluster Autoscaler to 1.17.0; changelog: https://github.com/kubernetes/autoscaler/releases/tag/cluster-autoscaler-1.17.0 ([#85610](https://github.com/kubernetes/kubernetes/pull/85610), [@losipiuk](https://github.com/losipiuk))
+* kube-apiserver: Fixes a bug that hidden metrics can not be enabled by the command-line option `--show-hidden-metrics-for-version`. ([#85444](https://github.com/kubernetes/kubernetes/pull/85444), [@RainbowMango](https://github.com/RainbowMango))
+* Fix bug where EndpointSlice controller would attempt to modify shared objects. ([#85368](https://github.com/kubernetes/kubernetes/pull/85368), [@robscott](https://github.com/robscott))
+* Revert ensure the KUBE-MARK-DROP chain in kube-proxy mode=iptables. Fix a bug in which kube-proxy deletes the rules associated with the chain in iptables mode. ([#85527](https://github.com/kubernetes/kubernetes/pull/85527), [@aojea](https://github.com/aojea))
+
+
+
+# v1.17.0-rc.1
+
+[Documentation](https://docs.k8s.io)
+
+## Downloads for v1.17.0-rc.1
+
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes.tar.gz](https://dl.k8s.io/v1.17.0-rc.1/kubernetes.tar.gz) | `f349b451362bf489066a5a0ad29e0eeb4c3c9bedd05c46309dbdac85abab6ae0fcf7b21f36cf25094bae76d388ef937beca4bdf1d2aaf4afffd7b620b856ed8d`
+[kubernetes-src.tar.gz](https://dl.k8s.io/v1.17.0-rc.1/kubernetes-src.tar.gz) | `7bda9be86cf317827b66d553eb876ec24a649e60d558f9e6e66db842fdf21eefd8354e7d816d4a08b42d5b8db1172c98efd732a41d601c31cfca83d18e0b7548`
+
+### Client Binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-client-darwin-386.tar.gz](https://dl.k8s.io/v1.17.0-rc.1/kubernetes-client-darwin-386.tar.gz) | `2ada2da6da63ae97dad4a6b5b64326501eed3a19d6f52fdf36b8224a1341142d72b25968cd978414ce5ae432c6cab41372b1b4ef1603b0256055522c580c6a65`
+[kubernetes-client-darwin-amd64.tar.gz](https://dl.k8s.io/v1.17.0-rc.1/kubernetes-client-darwin-amd64.tar.gz) | `ac06923e4c056d5ab97688e1f42ff408eeab0c0e8f3b010630d45f3530696cfcb1352c49b9cc64c723f0e24663b2f5690865e5243158c3eb8887a47872d40082`
+[kubernetes-client-linux-386.tar.gz](https://dl.k8s.io/v1.17.0-rc.1/kubernetes-client-linux-386.tar.gz) | `bb1f4384b6e3aa4cdaf6f629adeb0f81df138f17fc1c5a39c1584c31e228340761d78bf762fa83e69de687c98f2055ecf91a0ac39d82ec2d76ca09111d3bfd56`
+[kubernetes-client-linux-amd64.tar.gz](https://dl.k8s.io/v1.17.0-rc.1/kubernetes-client-linux-amd64.tar.gz) | `f66119eb66f87f19c993e380813c0a8051e562fb62c1e8a2f49237774fe5d9e132cbaaaf265be812d5fd1bbf8ad1ff5a6dc7cb9f8915d241109765cd9b10ef34`
+[kubernetes-client-linux-arm.tar.gz](https://dl.k8s.io/v1.17.0-rc.1/kubernetes-client-linux-arm.tar.gz) | `5a077f979ea775ba45d741b1137ab8a579164601bd8033704e03646ba1c99322c08ced72fdb12f073b6e92df159474f23e3f44be40a17aa45999940062150418`
+[kubernetes-client-linux-arm64.tar.gz](https://dl.k8s.io/v1.17.0-rc.1/kubernetes-client-linux-arm64.tar.gz) | `1b595b0aa568b8de3a4a56d9226e618c3648fb167c5ad62c833578ced95293cf77f1a066012a8f82e38c60cbb38b016665f8a5d151497d9c77a5edaceb541ceb`
+[kubernetes-client-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.17.0-rc.1/kubernetes-client-linux-ppc64le.tar.gz) | `955b1ecf8b04944cc04a06c3023574b7ccfad655df658320402bca15647b8fca65c9c5f4f9482989da4f5740b6f973e312287dda871abf0b17a56fcfbc281b30`
+[kubernetes-client-linux-s390x.tar.gz](https://dl.k8s.io/v1.17.0-rc.1/kubernetes-client-linux-s390x.tar.gz) | `273d5ca8b5fa042b68c7f01f8f6b293c308ee2ce5675419350f01f7763824b61a6ebc7a9470b1196c4c87e1481bbc91931d6d41b3eb50bd99fd0ecc06a65b189`
+[kubernetes-client-windows-386.tar.gz](https://dl.k8s.io/v1.17.0-rc.1/kubernetes-client-windows-386.tar.gz) | `94e20c417c626166cff39a74b05d7eb443a00be9ef7d7f7bb014d170a41ff9b52999bc21bba19b97d27ad5c1a978e761e125a30295338e5db4dbac16d1661b66`
+[kubernetes-client-windows-amd64.tar.gz](https://dl.k8s.io/v1.17.0-rc.1/kubernetes-client-windows-amd64.tar.gz) | `59deabc78139ad4d6dced570f5292eaa67da4d6fca88f90d7e1484b77a71ef64826632613ebedb79215dbaba6dfe4b3eda6cf8bbfa3fd0024b9ab290e3f8cd1f`
+
+### Server Binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-server-linux-amd64.tar.gz](https://dl.k8s.io/v1.17.0-rc.1/kubernetes-server-linux-amd64.tar.gz) | `b73983175bb95accb505ab953635e49d5ce3ef0a58e4de6575e431a6c0c81819bb8fc75949c5e3d35a395a96aaadad2ef6a777cc86bfa1b70afd02269cae58c0`
+[kubernetes-server-linux-arm.tar.gz](https://dl.k8s.io/v1.17.0-rc.1/kubernetes-server-linux-arm.tar.gz) | `7f2b75c7fe9f97dcab6ef00fa72bda3493225c58aa963e6843184f24c32631d33a05288ec525ef378296702d51c715800bc4394b9906285dc105e0dd984cf95b`
+[kubernetes-server-linux-arm64.tar.gz](https://dl.k8s.io/v1.17.0-rc.1/kubernetes-server-linux-arm64.tar.gz) | `113e978c8400acc8048b0a1979cf5cf95cfec76de7a9b2a5e1c204de8969ff7e4662fecf232d03f5889f47e4633197ce5013769b2508350dc0002da9cb004957`
+[kubernetes-server-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.17.0-rc.1/kubernetes-server-linux-ppc64le.tar.gz) | `5dfb184689e9d534788f86dc29bf69e779c5a9927adc50338fee0f7a71603aeccd7822f6ca6ba017e73e595eb4b95c15b26fc2af2783a3b7fe5ac5095555e1be`
+[kubernetes-server-linux-s390x.tar.gz](https://dl.k8s.io/v1.17.0-rc.1/kubernetes-server-linux-s390x.tar.gz) | `ae7a6399672a7333ba85567bf9b6b1f9af7ad9616acbd0bd52237cb5d5c968f3f39617ffad9606c8486cfa253ea2dfc1ff47f55b96f1065998a03fa8a4a4c735`
+
+### Node Binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-node-linux-amd64.tar.gz](https://dl.k8s.io/v1.17.0-rc.1/kubernetes-node-linux-amd64.tar.gz) | `17279e9220a2423aba35056bc631d0b2af1df45297dd40e36949a0ff809d3b7c8cc410808638c266cdd02631b403461a92076ae8e8203398da7cbb1720e0625b`
+[kubernetes-node-linux-arm.tar.gz](https://dl.k8s.io/v1.17.0-rc.1/kubernetes-node-linux-arm.tar.gz) | `4611354f214b2d7d5138adaffd764574dfc6a68d27b7f53563c486a8ba25cefceeb5cf04d75cc1f47f525d450609f90c085ba36d35f166731fc0f51ea350a411`
+[kubernetes-node-linux-arm64.tar.gz](https://dl.k8s.io/v1.17.0-rc.1/kubernetes-node-linux-arm64.tar.gz) | `361e44be2d5a98fb94fd8a39ab9a57198bc7613b2004b239920438853db0a33e360bd76c7e2c19e64e74e900c9cb7e912ab90a3d68ddbc560f0cae75b803818d`
+[kubernetes-node-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.17.0-rc.1/kubernetes-node-linux-ppc64le.tar.gz) | `69f9da64ae19bb4cfc616a2abd587c9711e9667da4743d776510e92aa23da72da85bd9aecd2d334066697d5e241abe4050142b8fb1d56b1db7c2037f944cccb6`
+[kubernetes-node-linux-s390x.tar.gz](https://dl.k8s.io/v1.17.0-rc.1/kubernetes-node-linux-s390x.tar.gz) | `0fb52cfc24b58887be71d98dd1c826be520eef69448f2f207e849b85533c277084fa4b6e04445c0c1cf499e8fcc63f2088696554465caa954b5643aa9f555c40`
+[kubernetes-node-windows-amd64.tar.gz](https://dl.k8s.io/v1.17.0-rc.1/kubernetes-node-windows-amd64.tar.gz) | `7d3ce000317a05737101ff1fd0fd0423be2649e5ae387b9d89e57242a3cf8b202a3152dd6b864601eba07ac319f5787fd9fae86594452a4652e29dd585314c2a`
+
+## Changelog since v1.17.0-beta.2
+
+### Other notable changes
+
+* kubeadm: fix a panic in case the KubeProxyConfiguration feature gates were not initialized. ([#85524](https://github.com/kubernetes/kubernetes/pull/85524), [@Arvinderpal](https://github.com/Arvinderpal))
+* kubeadm: fix stray "node-cidr-mask-size" flag in the kube-controller-manager manifest when IPv6DualStack is enabled ([#85494](https://github.com/kubernetes/kubernetes/pull/85494), [@tedyu](https://github.com/tedyu))
+* CRDs can have fields named `type` with value `array` and nested array with `items` fields without validation to fall over this. ([#85223](https://github.com/kubernetes/kubernetes/pull/85223), [@sttts](https://github.com/sttts))
+* Resolves error from v1.17.0-beta.2 with --authorizer-mode webhook complaining about an invalid version ([#85441](https://github.com/kubernetes/kubernetes/pull/85441), [@liggitt](https://github.com/liggitt))
+* Promote CSIMigrationAWS to Beta (off by default since it requires installation of the AWS EBS CSI Driver) ([#85237](https://github.com/kubernetes/kubernetes/pull/85237), [@leakingtapan](https://github.com/leakingtapan))
+    * The in-tree AWS EBS plugin "kubernetes.io/aws-ebs" is now deprecated and will be removed in 1.21. Users should enable CSIMigration + CSIMigrationAWS features and install the AWS EBS CSI Driver (https://github.com/kubernetes-sigs/aws-ebs-csi-driver) to avoid disruption to existing Pod and PVC objects at that time.
+    * Users should start using the AWS EBS CSI CSI Driver directly for any new volumes.
+
+
+
+# v1.17.0-beta.2
+
+[Documentation](https://docs.k8s.io)
+
+## Downloads for v1.17.0-beta.2
+
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes.tar.gz](https://dl.k8s.io/v1.17.0-beta.2/kubernetes.tar.gz) | `c4e937e784b26b5b18cac0bc8d4c91e1ae576107f14bb475e2d38687fbb5790f2c57898590a2f24d3c4ab4c6060a628e1acb2f15932b70183e5753f751237f60`
+[kubernetes-src.tar.gz](https://dl.k8s.io/v1.17.0-beta.2/kubernetes-src.tar.gz) | `79351b61539c7dc608f4c2a184e788f74503cd801304204de1d52e9ea7b50450503d46d48605b71240395173bcbf1a4727bad3a3dc800766ce4f1f103ca9f2ae`
+
+### Client Binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-client-darwin-386.tar.gz](https://dl.k8s.io/v1.17.0-beta.2/kubernetes-client-darwin-386.tar.gz) | `3940ed06c0848b6ddf9e37e66535085d58a5cf7b66a015eab718eb7b4927e9ebce9e0634040bd7a748610b1d881ad9f6e925650d959eaa37e304baa9bb21b6a9`
+[kubernetes-client-darwin-amd64.tar.gz](https://dl.k8s.io/v1.17.0-beta.2/kubernetes-client-darwin-amd64.tar.gz) | `2d6497ad8f5ca592717fcc704f581020922e317e60c2f7def6b6899398666c6c1c81b0b006ed02c923f54b8f0525dba85aadc5ce62926e9feefe18640c7f2fde`
+[kubernetes-client-linux-386.tar.gz](https://dl.k8s.io/v1.17.0-beta.2/kubernetes-client-linux-386.tar.gz) | `220713aea7709facd2317015467ce1922abf39cdf486d44f4a3fae497aa119f5af00bbfaa46fb022e1b53de285d2366eba1847a98804af4891eec50306be23fb`
+[kubernetes-client-linux-amd64.tar.gz](https://dl.k8s.io/v1.17.0-beta.2/kubernetes-client-linux-amd64.tar.gz) | `afe7fbecb04bba24f6c2d794a7c9b83cdc48032137776e660537541e3b2da6a04a1f0b8dc2ac0826a7d3c3c6fb5f609086d6ffae411f3069737448136d78ea65`
+[kubernetes-client-linux-arm.tar.gz](https://dl.k8s.io/v1.17.0-beta.2/kubernetes-client-linux-arm.tar.gz) | `97addcebe381cfd6ccca94ca4f039ec6e300bda701fc005b1d292a055a2ed8515a80991d0013c3d388e742bb6fcf12f733a100eb1a7cd7e02e122c54bc715f4e`
+[kubernetes-client-linux-arm64.tar.gz](https://dl.k8s.io/v1.17.0-beta.2/kubernetes-client-linux-arm64.tar.gz) | `ca3880ce4c6ca1aa8500d67d0c0eeb85f0323306308d2abe26caa9f97b20432f25e00d25c52b460dbf0f62a65907b3201c51cedca30146dc373ea30331531fc2`
+[kubernetes-client-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.17.0-beta.2/kubernetes-client-linux-ppc64le.tar.gz) | `84c40110c8ae3bfc02edd3f6e937032b41dd67b9c48e738ff8590d9b26d249d4febcb6a5665261a3c835ce0df255fc1aeeeb0df7abd1a158d9cb5eafedbd66f2`
+[kubernetes-client-linux-s390x.tar.gz](https://dl.k8s.io/v1.17.0-beta.2/kubernetes-client-linux-s390x.tar.gz) | `31521ef3a8426676e73011dbe5b00a7cb9479aa9d1147e824c1c4287634f1c0742c7990166e804ed7897c0629fd1eebedc6b8fc41788e1b145e26dd72bd8025d`
+[kubernetes-client-windows-386.tar.gz](https://dl.k8s.io/v1.17.0-beta.2/kubernetes-client-windows-386.tar.gz) | `8601fb516a4557b7579dc3fb3e83e1be2f8e8a6a19aaca5232a5be25d9d23056a37fb5b30742454d8db6598539130c4b9bf6b9eb1b9ec6bdd73ca7c34953c23a`
+[kubernetes-client-windows-amd64.tar.gz](https://dl.k8s.io/v1.17.0-beta.2/kubernetes-client-windows-amd64.tar.gz) | `00b4e163629f415c9c9caca4e5a9b0753ecddc29fde7d63b379d9d13af8992f78c2b1d4810a94264edc766bc41c2334cd81fe9e53d95a7bbfcf3795813e0327d`
+
+### Server Binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-server-linux-amd64.tar.gz](https://dl.k8s.io/v1.17.0-beta.2/kubernetes-server-linux-amd64.tar.gz) | `a5d21dfe1c05ca6fb1357975b75ff9549642f37e8754a884567c0a00048208ba9060d169b378f0be349197b3c55c41179c70a12aa0249fd149271198ebf1c9ba`
+[kubernetes-server-linux-arm.tar.gz](https://dl.k8s.io/v1.17.0-beta.2/kubernetes-server-linux-arm.tar.gz) | `d33a18da3aa4305183f7e3cd3f43f100ed1484c59811c0e8172c5838b94cd0ea11dbc3733d49624e4787e6d12fb5e01b278fc7c328362fadece8cf6b9e91a9bb`
+[kubernetes-server-linux-arm64.tar.gz](https://dl.k8s.io/v1.17.0-beta.2/kubernetes-server-linux-arm64.tar.gz) | `2bba562b5e5f28d1b840490cbcc837f421e30a715daca08234b1302f5b7a528b605594bffac7fa104ca2a023b569a3c38156aa3da3576db28f1bdccd37b274f5`
+[kubernetes-server-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.17.0-beta.2/kubernetes-server-linux-ppc64le.tar.gz) | `a80a80233832aca887b90e688a5ab537468071d8d3237a28cf3e9d7cf4ef1f340ef243f173e67b74fc08f7a723660237dd1721872ca734bb7bcea87d3ecf0a34`
+[kubernetes-server-linux-s390x.tar.gz](https://dl.k8s.io/v1.17.0-beta.2/kubernetes-server-linux-s390x.tar.gz) | `ba23bc2a9c94dd19a8a0a739e15e72dcb30ec103978686e1b4a845175ae8cad66e34b266afcb5ba0adb5969bbc6e71bf4d5ef5664b703ddc2628907e211f3b86`
+
+### Node Binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-node-linux-amd64.tar.gz](https://dl.k8s.io/v1.17.0-beta.2/kubernetes-node-linux-amd64.tar.gz) | `76298a3e8a6184c7ca7026a83c016172e22f5be18e68d3ec01a3d6fc1b3ca2525232ef6f15b423c651c36694a9cad4fd0af08a93a187a7f42443aa0caa82baf7`
+[kubernetes-node-linux-arm.tar.gz](https://dl.k8s.io/v1.17.0-beta.2/kubernetes-node-linux-arm.tar.gz) | `d21b60164cb3ee15a493567e1852fb8844f8a5fa5d6d4e71f8078a039d9fea4af00f992026bbc135fadcf0597da28bd0d8813b231ee05e5c31b17ecd224294b9`
+[kubernetes-node-linux-arm64.tar.gz](https://dl.k8s.io/v1.17.0-beta.2/kubernetes-node-linux-arm64.tar.gz) | `9707c6e9c3835f8a5a80be9600f651c992ae717a8a6efc20cc8e67d562ddc62ec81b70deb74ba75a67eb1741cf2afd57312f1ccf6dc97ead8d7139651b20c09b`
+[kubernetes-node-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.17.0-beta.2/kubernetes-node-linux-ppc64le.tar.gz) | `4c8dea040321fbf8e444ba0252567cb3aed3173db4c82b7572b9f8053b1275b9bc45627510a9abe19c8be3d921a1b018b5b869f415762b2569325425ab9aa819`
+[kubernetes-node-linux-s390x.tar.gz](https://dl.k8s.io/v1.17.0-beta.2/kubernetes-node-linux-s390x.tar.gz) | `7a720070b28ab5b83ec054a3137d434c39f7b8f1a0c751f5d06b1f2bbe00777ff444f2855c135ac113f0c5193680b27d80369761ff79f7ef22a9dc997037efe1`
+[kubernetes-node-windows-amd64.tar.gz](https://dl.k8s.io/v1.17.0-beta.2/kubernetes-node-windows-amd64.tar.gz) | `85b3a0bcb5a319f443cc0f3a9aff0b6fb038d42f515698d51cba27a4a1a6b3d701085c6cfb525cf0f826af3fbdb26abc2ee00fcb8e5022ecd63b8f7697aace88`
+
+## Changelog since v1.17.0-beta.1
+
+### Action Required
+
+* Renamed FeatureGate RequestManagement to APIPriorityAndFairness.  This feature gate is an alpha and has not yet been associated with any actual functionality. ([#85260](https://github.com/kubernetes/kubernetes/pull/85260), [@MikeSpreitzer](https://github.com/MikeSpreitzer))
+    * Action required: change references to feature gate RequestManagement into references to APIPriorityAndFairness
+* ACTION REQUIRED: kubeadm: add a new "kubelet-finalize" phase as part of the "init" workflow and an experimental sub-phase to enable automatic kubelet client certificate rotation on primary control-plane nodes. ([#84118](https://github.com/kubernetes/kubernetes/pull/84118), [@neolit123](https://github.com/neolit123))
+    * Prior to 1.17 and for existing nodes created by "kubeadm init" where kubelet client certificate rotation is desired, you must modify "/etc/kubernetes/kubelet.conf" to point to the PEM symlink for rotation:
+    * "client-certificate: /var/lib/kubelet/pki/kubelet-client-current.pem" and "client-key: /var/lib/kubelet/pki/kubelet-client-current.pem", replacing the embedded client certificate and key.
+* action required: kubeadm deprecates the use of the hyperkube image ([#85094](https://github.com/kubernetes/kubernetes/pull/85094), [@rosti](https://github.com/rosti))
+
+### Other notable changes
+
+* Following metrics have been turned off: ([#83837](https://github.com/kubernetes/kubernetes/pull/83837), [@RainbowMango](https://github.com/RainbowMango))
+    * - apiserver_request_count
+    * - apiserver_request_latencies
+    * - apiserver_request_latencies_summary
+    * - apiserver_dropped_requests
+    * - etcd_request_latencies_summary
+    * - apiserver_storage_transformation_latencies_microseconds
+    * - apiserver_storage_data_key_generation_latencies_microseconds
+    * - apiserver_storage_transformation_failures_total
+* OpenAPI v3 format in CustomResourceDefinition schemas are now documented. ([#85381](https://github.com/kubernetes/kubernetes/pull/85381), [@sttts](https://github.com/sttts))
+* The official kube-proxy image (used by kubeadm, among other things) is now ([#82966](https://github.com/kubernetes/kubernetes/pull/82966), [@danwinship](https://github.com/danwinship))
+    * compatible with systems running iptables 1.8 in "nft" mode, and will autodetect
+    * which mode it should use.
+* Kubenet: added HostPort IPv6 support ([#80854](https://github.com/kubernetes/kubernetes/pull/80854), [@aojea](https://github.com/aojea))
+    * HostPortManager: operates only with one IP family, failing if receives portmapping entries with different IP families
+    * HostPortSyncer: operates only with one IP family, skipping portmap entries with different IP families
+* Implement the documented API semantics of list-type and map-type atomic to reject non-atomic sub-types. ([#84722](https://github.com/kubernetes/kubernetes/pull/84722), [@sttts](https://github.com/sttts))
+* kubeadm: Fix a bug where kubeadm cannot parse kubelet's version if the latter dumps logs on the standard error. ([#85351](https://github.com/kubernetes/kubernetes/pull/85351), [@rosti](https://github.com/rosti))
+* EndpointSlices are not enabled by default. Use the EndpointSlice feature gate to enable this feature. ([#85365](https://github.com/kubernetes/kubernetes/pull/85365), [@robscott](https://github.com/robscott))
+* Feature gates CSIMigration to Beta (on by default) and CSIMigrationGCE to Beta (off by default since it requires installation of the GCE PD CSI Driver) ([#85231](https://github.com/kubernetes/kubernetes/pull/85231), [@davidz627](https://github.com/davidz627))
+    * The in-tree GCE PD plugin "kubernetes.io/gce-pd" is now deprecated and will be removed in 1.21. Users should enable CSIMigration + CSIMigrationGCE features and install the GCE PD CSI Driver (https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver) to avoid disruption to existing Pod and PVC objects at that time.
+    * Users should start using the GCE PD CSI CSI Driver directly for any new volumes.
+* kube-controller-manager: Fixes bug setting headless service labels on endpoints ([#85361](https://github.com/kubernetes/kubernetes/pull/85361), [@liggitt](https://github.com/liggitt))
+* When upgrading to 1.17 with a cluster with EndpointSlices enabled, the `endpointslice.kubernetes.io/managed-by` label needs to be set on each EndpointSlice. ([#85359](https://github.com/kubernetes/kubernetes/pull/85359), [@robscott](https://github.com/robscott))
+* Remove redundant API validation when using Service Topology with externalTrafficPolicy=Local ([#85346](https://github.com/kubernetes/kubernetes/pull/85346), [@andrewsykim](https://github.com/andrewsykim))
+* Following metrics have been turned off: ([#83838](https://github.com/kubernetes/kubernetes/pull/83838), [@RainbowMango](https://github.com/RainbowMango))
+    * - scheduler_scheduling_latency_seconds
+    * - scheduler_e2e_scheduling_latency_microseconds
+    * - scheduler_scheduling_algorithm_latency_microseconds
+    * - scheduler_scheduling_algorithm_predicate_evaluation
+    * - scheduler_scheduling_algorithm_priority_evaluation
+    * - scheduler_scheduling_algorithm_preemption_evaluation
+    * - scheduler_scheduling_binding_latency_microseconds
+* CSI Migration: Fixes issue where all volumes with the same inline volume inner spec name were staged in the same path. Migrated inline volumes are now staged at a unique path per unique volume. ([#84754](https://github.com/kubernetes/kubernetes/pull/84754), [@davidz627](https://github.com/davidz627))
+* kube-controller-manager ([#79993](https://github.com/kubernetes/kubernetes/pull/79993), [@aramase](https://github.com/aramase))
+    * --node-cidr-mask-size-ipv4 int32     Default: 24. Mask size for IPv4 node-cidr in dual-stack cluster.
+    * --node-cidr-mask-size-ipv6 int32     Default: 64. Mask size for IPv6 node-cidr in dual-stack cluster.
+    * These 2 flags can be used only for dual-stack clusters. For non dual-stack clusters, continue to use
+    * --node-cidr-mask-size flag to configure the mask size.
+    * The default node cidr mask size for IPv6 was 24 which is now changed to 64.
+* The following information is available through environment variables: ([#83123](https://github.com/kubernetes/kubernetes/pull/83123), [@aramase](https://github.com/aramase))
+    * status.podIPs - the pod's IP addresses
+* update github.com/vishvananda/netlink to v1.0.0 ([#83576](https://github.com/kubernetes/kubernetes/pull/83576), [@andrewsykim](https://github.com/andrewsykim))
+* kubectl: --resource-version now works properly in label/annotate/set selector commands when racing with other clients to update the target object ([#85285](https://github.com/kubernetes/kubernetes/pull/85285), [@liggitt](https://github.com/liggitt))
+* `--runtime-config` now supports an `api/beta=false` value which disables all built-in REST API versions matching `v[0-9]+beta[0-9]+`. ([#84304](https://github.com/kubernetes/kubernetes/pull/84304), [@liggitt](https://github.com/liggitt))
+    * `--feature-gates` now supports an `AllBeta=false` value which disables all beta feature gates.
+* kube-proxy now supports DualStack feature with EndpointSlices and IPVS. ([#85246](https://github.com/kubernetes/kubernetes/pull/85246), [@robscott](https://github.com/robscott))
+* Add table convertor to componentstatus. ([#85174](https://github.com/kubernetes/kubernetes/pull/85174), [@zhouya0](https://github.com/zhouya0))
+* kubeadm: added retry to all the calls to the etcd API so kubeadm will be more resilient to network glitches ([#85201](https://github.com/kubernetes/kubernetes/pull/85201), [@fabriziopandini](https://github.com/fabriziopandini))
+* azure: update disk lock logic per vm during attach/detach to allow concurrent updates for different nodes. ([#85115](https://github.com/kubernetes/kubernetes/pull/85115), [@aramase](https://github.com/aramase))
+* Scale custom resource unconditionally if resourceVersion is not provided ([#80572](https://github.com/kubernetes/kubernetes/pull/80572), [@knight42](https://github.com/knight42))
+* Bump CSI version to 1.2.0 ([#84832](https://github.com/kubernetes/kubernetes/pull/84832), [@gnufied](https://github.com/gnufied))
+* Adds Windows Server build information as a label on the node. ([#84472](https://github.com/kubernetes/kubernetes/pull/84472), [@gab-satchi](https://github.com/gab-satchi))
+* Deprecated metric `kubeproxy_sync_proxy_rules_latency_microseconds` has been turned off. ([#83839](https://github.com/kubernetes/kubernetes/pull/83839), [@RainbowMango](https://github.com/RainbowMango))
+* Existing PVs are converted to use volume topology if migration is enabled. ([#83394](https://github.com/kubernetes/kubernetes/pull/83394), [@bertinatto](https://github.com/bertinatto))
+* Finalizer Protection for Service LoadBalancers is now in GA (enabled by default). This feature ensures the Service resource is not fully deleted until the correlating load balancer resources are deleted. ([#85023](https://github.com/kubernetes/kubernetes/pull/85023), [@MrHohn](https://github.com/MrHohn))
+* EndpointSlices are now beta and enabled by default for better Network Endpoint performance at scale. ([#84390](https://github.com/kubernetes/kubernetes/pull/84390), [@robscott](https://github.com/robscott))
+* When using Containerd on Windows, the ``TerminationMessagePath`` file will now be mounted in the Windows Pod. ([#83057](https://github.com/kubernetes/kubernetes/pull/83057), [@bclau](https://github.com/bclau))
+* apiservers based on k8s.io/apiserver with delegated authn based on cluster authentication will automatically update to new authentication information when the authoritative configmap is updated. ([#85004](https://github.com/kubernetes/kubernetes/pull/85004), [@deads2k](https://github.com/deads2k))
+* fix vmss dirty cache issue in disk attach/detach on vmss node ([#85158](https://github.com/kubernetes/kubernetes/pull/85158), [@andyzhangx](https://github.com/andyzhangx))
+* Fixes a bug in kubeadm that caused init and join to hang indefinitely in specific conditions. ([#85156](https://github.com/kubernetes/kubernetes/pull/85156), [@chuckha](https://github.com/chuckha))
+* kube-apiserver: Authentication configuration for mutating and validating admission webhooks referenced from an `--admission-control-config-file` can now be specified with `apiVersion: apiserver.config.k8s.io/v1, kind: WebhookAdmissionConfiguration`. ([#85138](https://github.com/kubernetes/kubernetes/pull/85138), [@liggitt](https://github.com/liggitt))
+* Kubeadm now includes CoreDNS version 1.6.5 ([#85109](https://github.com/kubernetes/kubernetes/pull/85109), [@rajansandeep](https://github.com/rajansandeep))
+    *  - `kubernetes` plugin adds metrics to measure kubernetes control plane latency.
+    *  -  the `health` plugin now includes the `lameduck` option by default, which waits for a duration before shutting down.
+* Kubeadm now includes CoreDNS version 1.6.5 ([#85108](https://github.com/kubernetes/kubernetes/pull/85108), [@rajansandeep](https://github.com/rajansandeep))
+    *  - `kubernetes` plugin adds metrics to measure kubernetes control plane latency.
+    *  -  the `health` plugin now includes the `lameduck` option by default, which waits for a duration before shutting down.
+* kube-apiserver: The `ResourceQuota` admission plugin configuration referenced from `--admission-control-config-file` admission config has been promoted to `apiVersion: apiserver.config.k8s.io/v1`, `kind: ResourceQuotaConfiguration` with no schema changes. ([#85099](https://github.com/kubernetes/kubernetes/pull/85099), [@liggitt](https://github.com/liggitt))
+* kube-apiserver: The `AdmissionConfiguration` type accepted by `--admission-control-config-file` has been promoted to `apiserver.config.k8s.io/v1` with no schema changes. ([#85098](https://github.com/kubernetes/kubernetes/pull/85098), [@liggitt](https://github.com/liggitt))
+* New flag `--show-hidden-metrics-for-version` in kube-apiserver can be used to show all hidden metrics that deprecated in the previous minor release. ([#84292](https://github.com/kubernetes/kubernetes/pull/84292), [@RainbowMango](https://github.com/RainbowMango))
+* The ResourceQuotaScopeSelectors feature has graduated to GA. The `ResourceQuotaScopeSelectors` feature gate is now unconditionally enabled and will be removed in 1.18. ([#82690](https://github.com/kubernetes/kubernetes/pull/82690), [@draveness](https://github.com/draveness))
+* Fixed bug when using kubeadm alpha certs commands with clusters using external etcd ([#85091](https://github.com/kubernetes/kubernetes/pull/85091), [@fabriziopandini](https://github.com/fabriziopandini))
+* Fix a bug that a node Lease object may have been created without OwnerReference. ([#84998](https://github.com/kubernetes/kubernetes/pull/84998), [@wojtek-t](https://github.com/wojtek-t))
+* Splitting IP address type into IPv4 and IPv6 for EndpointSlices ([#84971](https://github.com/kubernetes/kubernetes/pull/84971), [@robscott](https://github.com/robscott))
+* Pod process namespace sharing is now Generally Available. The `PodShareProcessNamespace` feature gate is now deprecated and will be removed in Kubernetes 1.19. ([#84356](https://github.com/kubernetes/kubernetes/pull/84356), [@verb](https://github.com/verb))
+* Fix incorrect network policy description suggesting that pods are isolated when a network policy has no rules of a given type ([#84194](https://github.com/kubernetes/kubernetes/pull/84194), [@jackkleeman](https://github.com/jackkleeman))
+* add RequiresExactMatch for label.Selector ([#85048](https://github.com/kubernetes/kubernetes/pull/85048), [@shaloulcy](https://github.com/shaloulcy))
+* Deprecated metric `rest_client_request_latency_seconds` has been turned off. ([#83836](https://github.com/kubernetes/kubernetes/pull/83836), [@RainbowMango](https://github.com/RainbowMango))
+* Removed dependency on kubectl from several storage E2E tests ([#84042](https://github.com/kubernetes/kubernetes/pull/84042), [@okartau](https://github.com/okartau))
+* kubeadm no longer defaults or validates the component configs of the kubelet or kube-proxy ([#79223](https://github.com/kubernetes/kubernetes/pull/79223), [@rosti](https://github.com/rosti))
+* Add plugin_execution_duration_seconds metric for scheduler framework plugins. ([#84522](https://github.com/kubernetes/kubernetes/pull/84522), [@liu-cong](https://github.com/liu-cong))
+* Moving WindowsRunAsUserName feature to beta ([#84882](https://github.com/kubernetes/kubernetes/pull/84882), [@marosset](https://github.com/marosset))
+* Node-specific volume limits has graduated to GA. ([#83568](https://github.com/kubernetes/kubernetes/pull/83568), [@bertinatto](https://github.com/bertinatto))
+* kubelet and aggregated API servers now use v1 TokenReview and SubjectAccessReview endpoints to check authentication/authorization. ([#84768](https://github.com/kubernetes/kubernetes/pull/84768), [@liggitt](https://github.com/liggitt))
+        * kube-apiserver can now specify `--authentication-token-webhook-version=v1` or `--authorization-webhook-version=v1` to use `v1` TokenReview and SubjectAccessReview API objects when communicating with authentication and authorization webhooks.
+* BREAKING CHANGE: Remove plugin watching of deprecated directory {kubelet_root_dir}/plugins and CSI V0 support in accordance with deprecation announcement in https://v1-13.docs.kubernetes.io/docs/setup/release/notes/ ([#84533](https://github.com/kubernetes/kubernetes/pull/84533), [@davidz627](https://github.com/davidz627))
+* Adds a new label to indicate what is managing an EndpointSlice. ([#83965](https://github.com/kubernetes/kubernetes/pull/83965), [@robscott](https://github.com/robscott))
+* Fix a racing issue in client-go UpdateTransportConfig. ([#80284](https://github.com/kubernetes/kubernetes/pull/80284), [@danielqsj](https://github.com/danielqsj))
+* Enables VolumeSnapshotDataSource feature gate and promotes volume snapshot APIs to beta. ([#80058](https://github.com/kubernetes/kubernetes/pull/80058), [@xing-yang](https://github.com/xing-yang))
+* Added appProtocol field to EndpointSlice Port ([#83815](https://github.com/kubernetes/kubernetes/pull/83815), [@howardjohn](https://github.com/howardjohn))
+* kubeadm alpha certs command now skip missing files ([#85092](https://github.com/kubernetes/kubernetes/pull/85092), [@fabriziopandini](https://github.com/fabriziopandini))
+* A new flag "progress-report-url" has been added to the test context which allows progress information about the test run to be sent to a webhook. In addition, this information is printed to stdout to aid in users watching the logs. ([#84524](https://github.com/kubernetes/kubernetes/pull/84524), [@johnSchnake](https://github.com/johnSchnake))
+* kubeadm: remove the deprecated "--cri-socket" flag for "kubeadm upgrade apply". The flag has been deprecated since v1.14. ([#85044](https://github.com/kubernetes/kubernetes/pull/85044), [@neolit123](https://github.com/neolit123))
+* Clients can request protobuf and json and correctly negotiate with the server for JSON for CRD objects, allowing all client libraries to request protobuf if it is available.  If an error occurs negotiating a watch with the server, the error is immediately return by the client `Watch()` method instead of being sent as an `Error` event on the watch stream. ([#84692](https://github.com/kubernetes/kubernetes/pull/84692), [@smarterclayton](https://github.com/smarterclayton))
+* Following metrics from kubelet are now marked as with the ALPHA stability level: ([#84987](https://github.com/kubernetes/kubernetes/pull/84987), [@RainbowMango](https://github.com/RainbowMango))
+    * node_cpu_usage_seconds_total
+    * node_memory_working_set_bytes
+    * container_cpu_usage_seconds_total
+    * container_memory_working_set_bytes
+    * scrape_error
+* Following metrics from kubelet are now marked as with the ALPHA stability level: ([#84907](https://github.com/kubernetes/kubernetes/pull/84907), [@RainbowMango](https://github.com/RainbowMango))
+    * kubelet_container_log_filesystem_used_bytes
+    * kubelet_volume_stats_capacity_bytes
+    * kubelet_volume_stats_available_bytes
+    * kubelet_volume_stats_used_bytes
+    * kubelet_volume_stats_inodes
+    * kubelet_volume_stats_inodes_free
+    * kubelet_volume_stats_inodes_used
+    * plugin_manager_total_plugins
+    * volume_manager_total_volumes
+* kubeadm: enable the usage of the secure kube-scheduler and kube-controller-manager ports for health checks. For kube-scheduler was 10251, becomes 10259. For kube-controller-manager was 10252, becomes 10257. ([#85043](https://github.com/kubernetes/kubernetes/pull/85043), [@neolit123](https://github.com/neolit123))
+* kubeadm: prevent potential hanging of commands such as "kubeadm reset" if the apiserver endpoint is not reachable. ([#84648](https://github.com/kubernetes/kubernetes/pull/84648), [@neolit123](https://github.com/neolit123))
+* Mirror pods now include an ownerReference for the node that created them. ([#84485](https://github.com/kubernetes/kubernetes/pull/84485), [@tallclair](https://github.com/tallclair))
+* kubeadm: fix skipped etcd upgrade on secondary control-plane nodes when the command "kubeadm upgrade node" is used. ([#85024](https://github.com/kubernetes/kubernetes/pull/85024), [@neolit123](https://github.com/neolit123))
+* fix race condition when attach/delete azure disk in same time ([#84917](https://github.com/kubernetes/kubernetes/pull/84917), [@andyzhangx](https://github.com/andyzhangx))
+* If given an IPv6 bind-address, kube-apiserver will now advertise an IPv6 endpoint for the kubernetes.default service. ([#84727](https://github.com/kubernetes/kubernetes/pull/84727), [@danwinship](https://github.com/danwinship))
+* kubeadm: the command "kubeadm token create" now has a "--certificate-key" flag that can be used for the formation of join commands for control-planes with automatic copy of certificates ([#84591](https://github.com/kubernetes/kubernetes/pull/84591), [@TheLastProject](https://github.com/TheLastProject))
+* Deprecate the instance type beta label ("beta.kubernetes.io/instance-type") in favor of it's GA equivalent: "node.kubernetes.io/instance-type" ([#82049](https://github.com/kubernetes/kubernetes/pull/82049), [@andrewsykim](https://github.com/andrewsykim))
+* kube-apiserver: Fixed a regression accepting patch requests > 1MB ([#84963](https://github.com/kubernetes/kubernetes/pull/84963), [@liggitt](https://github.com/liggitt))
+* Promote NodeLease feature to GA. ([#84351](https://github.com/kubernetes/kubernetes/pull/84351), [@wojtek-t](https://github.com/wojtek-t))
+    * The feature make Lease object changes an additional healthiness signal from Node. Together with that, we reduce frequency of NodeStatus updates to 5m by default in case of no changes to status itself
+* Following metrics from kube-controller-manager are now marked as with the ALPHA stability level: ([#84896](https://github.com/kubernetes/kubernetes/pull/84896), [@RainbowMango](https://github.com/RainbowMango))
+    * storage_count_attachable_volumes_in_use
+    * attachdetach_controller_total_volumes
+    * pv_collector_bound_pv_count
+    * pv_collector_unbound_pv_count
+    * pv_collector_bound_pvc_count
+    * pv_collector_unbound_pvc_count
+* Deprecate the beta labels for zones ("failure-domain.beta.kubernetes.io/zone") and  ([#81431](https://github.com/kubernetes/kubernetes/pull/81431), [@andrewsykim](https://github.com/andrewsykim))
+    * regions ("failure-domain.beta.kubernetes.io/region") in favor of their GA equivalents:
+    * "topology.kubernetes.io/zone" and "topology.kubernetes.io/region".
+    * The beta labels "failure-domain.beta.kubernetes.io/zone" and "failure-domain.beta.kubernetes.io/region" will be removed in v1.21
+* kube-apiserver: fixed a bug that could cause a goroutine leak if the apiserver encountered an encoding error serving a watch to a websocket watcher ([#84693](https://github.com/kubernetes/kubernetes/pull/84693), [@tedyu](https://github.com/tedyu))
+* EndpointSlice hostname is now set in the same conditions Endpoints hostname is. ([#84207](https://github.com/kubernetes/kubernetes/pull/84207), [@robscott](https://github.com/robscott))
+* Simple script based hyperkube image that bundles all the necessary binaries. This is a equivalent replacement for the image based on the go based hyperkube command + image. ([#84662](https://github.com/kubernetes/kubernetes/pull/84662), [@dims](https://github.com/dims))
+* configmaps/extension-apiserver-authentication in kube-system is continuously updated by kube-apiservers, instead of just at apiserver start ([#82705](https://github.com/kubernetes/kubernetes/pull/82705), [@deads2k](https://github.com/deads2k))
+* kubeadm: fix an issue with the kube-proxy container env. variables ([#84888](https://github.com/kubernetes/kubernetes/pull/84888), [@neolit123](https://github.com/neolit123))
+* Updated EndpointSlices to use PublishNotReadyAddresses from Services. ([#84573](https://github.com/kubernetes/kubernetes/pull/84573), [@robscott](https://github.com/robscott))
+* The example API server has renamed its `wardle.k8s.io` API group to `wardle.example.com` ([#81670](https://github.com/kubernetes/kubernetes/pull/81670), [@liggitt](https://github.com/liggitt))
+* A new kubelet command line option, --reserved-cpus, is introduced to explicitly define the the CPU list that will be reserved for system. For example, if --reserved-cpus=0,1,2,3 is specified, then cpu 0,1,2,3 will be reserved for the system.  On a system with 24 CPUs, the user may specify isolcpus=4-23 for the kernel option and use CPU 4-23 for the user containers. ([#83592](https://github.com/kubernetes/kubernetes/pull/83592), [@jianzzha](https://github.com/jianzzha))
+* Utilize diagnostics tool to dump GKE windows test logs  ([#83517](https://github.com/kubernetes/kubernetes/pull/83517), [@YangLu1031](https://github.com/YangLu1031))
+* Improving the performance of Endpoint and EndpointSlice controllers by caching Service Selectors ([#84280](https://github.com/kubernetes/kubernetes/pull/84280), [@gongguan](https://github.com/gongguan))
+* When the go-client reflector relists, the ResourceVersion list option is set to the reflector's latest synced resource version to ensure the reflector does not "go back in time" and reprocess events older than it has already processed. If the the server responds with an HTTP 410 (Gone) status code response, the relist falls back to using resourceVersion="". ([#83520](https://github.com/kubernetes/kubernetes/pull/83520), [@jpbetz](https://github.com/jpbetz))
+* Kubernetes now requires go1.13.4+ to build ([#82809](https://github.com/kubernetes/kubernetes/pull/82809), [@liggitt](https://github.com/liggitt))
+* Ensure health probes are created for local traffic policy UDP services on Azure ([#84802](https://github.com/kubernetes/kubernetes/pull/84802), [@feiskyer](https://github.com/feiskyer))
+* CRDs defaulting is promoted to GA. Note: the feature gate CustomResourceDefaulting will be removed in 1.18. ([#84713](https://github.com/kubernetes/kubernetes/pull/84713), [@sttts](https://github.com/sttts))
+* Profiling is enabled by default in the scheduler  ([#84835](https://github.com/kubernetes/kubernetes/pull/84835), [@denkensk](https://github.com/denkensk))
+* CSI Migration: GCE PD access mode now reflects read only status of inline volumes - this allows multi-attach for read only many PDs ([#84809](https://github.com/kubernetes/kubernetes/pull/84809), [@davidz627](https://github.com/davidz627))
+* All resources within the rbac.authorization.k8s.io/v1alpha1 and rbac.authorization.k8s.io/v1beta1 API groups are deprecated in favor of rbac.authorization.k8s.io/v1, and will no longer be served in v1.20. ([#84758](https://github.com/kubernetes/kubernetes/pull/84758), [@liggitt](https://github.com/liggitt))
+* Scheduler ComponentConfig fields are now pointers ([#83619](https://github.com/kubernetes/kubernetes/pull/83619), [@damemi](https://github.com/damemi))
+* Adding initial EndpointSlice metrics. ([#83257](https://github.com/kubernetes/kubernetes/pull/83257), [@robscott](https://github.com/robscott))
+
+
+
+# v1.17.0-beta.1
+
+[Documentation](https://docs.k8s.io)
+
+## Downloads for v1.17.0-beta.1
+
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes.tar.gz](https://dl.k8s.io/v1.17.0-beta.1/kubernetes.tar.gz) | `6d6c61bb4d3372d56b7a429b5b8b5adbfb0aaddd65283d169bb719b8aca7c270db34f4699c4efee364565414770f9870c77a74a958725a8258f4bca271582e4c`
+[kubernetes-src.tar.gz](https://dl.k8s.io/v1.17.0-beta.1/kubernetes-src.tar.gz) | `9878c454c5b482621a7ddeab2ab3290fdafd0cfb3d580b261081ba3943b19b13e54aaa3a80ba68d7cbfa46864e51baedc686ab2a5271da6948493cc7ad730e2c`
+
+### Client Binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-client-darwin-386.tar.gz](https://dl.k8s.io/v1.17.0-beta.1/kubernetes-client-darwin-386.tar.gz) | `67c9d4d97db40ee94a5e021642eeea006dfd66f0c50ccd0d833c52d2bc4156fb044bb481b77e235db330e34ef580d42d8f1b366420abbab0b62c1cfe59f168a3`
+[kubernetes-client-darwin-amd64.tar.gz](https://dl.k8s.io/v1.17.0-beta.1/kubernetes-client-darwin-amd64.tar.gz) | `9a1494c082af52186620d1cd1b02f8a8f4af7e676e2ec217f41cf2915bd6fb1717e2c65e42c84ca842a542526f23edaa5ea378932b37f628611d00b08e9ff102`
+[kubernetes-client-linux-386.tar.gz](https://dl.k8s.io/v1.17.0-beta.1/kubernetes-client-linux-386.tar.gz) | `9de6254a6a267ea283b6118d9da079f072e73ba377e81a361943f6d42baa5dd1b668b20f6909b697cbb5163930e9e497a08b16aa1d3e13feaf5be37047bcf83e`
+[kubernetes-client-linux-amd64.tar.gz](https://dl.k8s.io/v1.17.0-beta.1/kubernetes-client-linux-amd64.tar.gz) | `a93d028c3adda047864b36f314752fbe4745bb6ad8f37574cc124eb1453bad07e3790dac4cc230e3ee2d3f6e9fb8c75d16860454acb3a6049400bb46489f7c51`
+[kubernetes-client-linux-arm.tar.gz](https://dl.k8s.io/v1.17.0-beta.1/kubernetes-client-linux-arm.tar.gz) | `5ca7feea1c4a33cf92f0ee79a92daee4876b43c626346dcc701bb7d6b956c0050f2ed6be1f2ba31756bf3b651da354bbad511cc3ce6c6349c12bcde41c8aec87`
+[kubernetes-client-linux-arm64.tar.gz](https://dl.k8s.io/v1.17.0-beta.1/kubernetes-client-linux-arm64.tar.gz) | `d6a63efa140a1c2cde43252e9f917a02752e90628b51ca28ec7118245cd00da03b83f1bd920d0f1da789b8a0f3c73f41fbc9710c7bddcc24e6ac401966180cc5`
+[kubernetes-client-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.17.0-beta.1/kubernetes-client-linux-ppc64le.tar.gz) | `cdb805bc7bae052a0585b88c5e7980bd8bf9f32a840728455c18f4f01e03cda823bede2145772c4338e95c1a9b258bba7b8154714457fdb72114ac482eca122e`
+[kubernetes-client-linux-s390x.tar.gz](https://dl.k8s.io/v1.17.0-beta.1/kubernetes-client-linux-s390x.tar.gz) | `a9ff545cad6a42dbcdf9f91214c15e2ebee2df20579b7f62ec07397eca792f20ee550841759d9d38c0affdb3071ad4a0a741c8641955eb222a5535dd8fb2d3e4`
+[kubernetes-client-windows-386.tar.gz](https://dl.k8s.io/v1.17.0-beta.1/kubernetes-client-windows-386.tar.gz) | `eb3e4dbbb1dc6829bfa320853b695e61f4daafdff4aaa1f4ffb2e4be4b3f2e0c78f385a8a370811cb379f85d5e48a9b55608747592c771d4cbffd446a586cc6d`
+[kubernetes-client-windows-amd64.tar.gz](https://dl.k8s.io/v1.17.0-beta.1/kubernetes-client-windows-amd64.tar.gz) | `ad0087ef7a0da961d3f22eab2ddab302be2190df5a2150046f7162dfc5072aa1866449a1aafc1c3db65246c392ec47bda20f2b4e7f750e895106fa9cbe1c80f8`
+
+### Server Binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-server-linux-amd64.tar.gz](https://dl.k8s.io/v1.17.0-beta.1/kubernetes-server-linux-amd64.tar.gz) | `8f4878dfbe7e6abc30516bd801bb5c07873b4a80d8bc560e5b5593e0c1d64be2fa662a5f10dd93c947cfb1cfb7336db995a3f2b5c5cc3b259c929f058f27e222`
+[kubernetes-server-linux-arm.tar.gz](https://dl.k8s.io/v1.17.0-beta.1/kubernetes-server-linux-arm.tar.gz) | `3e5745bffbfb3551b4d4962b7ab6524c9b71f55860a91992dd0495266c56b740061f6b0711882e931ead456b14e4bfc9f08c4115a81553c1cfa2aa1cbd769d52`
+[kubernetes-server-linux-arm64.tar.gz](https://dl.k8s.io/v1.17.0-beta.1/kubernetes-server-linux-arm64.tar.gz) | `ed00c196e6e229229b6523e7c3a201e00805304ad72c54bf7d0fc456d1791404bacf5120317f9a833b0bfddf70f4318d8ac274e3d94b80de0567dfea136b0b13`
+[kubernetes-server-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.17.0-beta.1/kubernetes-server-linux-ppc64le.tar.gz) | `57b5cc144fc4f3bfa6217e0d5494e4a4367f0c0d3504721d4343ff009f00fef1212150d0f1925fe0710eb335c526720e8a5c6fd54d27739b75cc91a06f27df94`
+[kubernetes-server-linux-s390x.tar.gz](https://dl.k8s.io/v1.17.0-beta.1/kubernetes-server-linux-s390x.tar.gz) | `6f6d2b61a11e30199997582487f7e4f967771e0367d7f471043e0b9b373d463c5d7370ac3a8e5bbf4761e98e0ab19564f74aa7bf2c8443c9dd53397836d4db9b`
+
+### Node Binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-node-linux-amd64.tar.gz](https://dl.k8s.io/v1.17.0-beta.1/kubernetes-node-linux-amd64.tar.gz) | `0c1b9dbb630a3bc47a835f9bfd9259d464abae8a30b0824a73b20892b013ed60d7e4989f48172b122bcc87e08bdd1af9ca9e790ae768b17e1dff190ae8f11b69`
+[kubernetes-node-linux-arm.tar.gz](https://dl.k8s.io/v1.17.0-beta.1/kubernetes-node-linux-arm.tar.gz) | `191087e26632dcc80991530b79bcda49bd4d0a131689ef48164a0bdb30e0a52ca69aa9a1ad42165707669287b8fd09afd407e556803d15b8c66739359a2b13b5`
+[kubernetes-node-linux-arm64.tar.gz](https://dl.k8s.io/v1.17.0-beta.1/kubernetes-node-linux-arm64.tar.gz) | `f0f58aa8f9ad0ac0a1ee29d318ebb4d14f0bef4cba1fee9081ee2bfb6b41245108bd849470529668a93dcf8b41e53a319bd80ee0bd46ef02b844a995ffcc68e8`
+[kubernetes-node-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.17.0-beta.1/kubernetes-node-linux-ppc64le.tar.gz) | `bf574c4a46731ebc273910176ab67b2455b021972de3aeeb2a2b04af2a1079243728f151b9f06298b84832425ce600e54d8c13eec58598b284b44b21beaf73eb`
+[kubernetes-node-linux-s390x.tar.gz](https://dl.k8s.io/v1.17.0-beta.1/kubernetes-node-linux-s390x.tar.gz) | `5a5d2ece704178a630dc228b51229b8598eb45bf3eaeae75b1475f249922c6a10b93220fd0f3f29d279ee0ceb34e8537a5b197b9454c4171adcc81facc80c3b6`
+[kubernetes-node-windows-amd64.tar.gz](https://dl.k8s.io/v1.17.0-beta.1/kubernetes-node-windows-amd64.tar.gz) | `22fc9a7eb0e8244d51fd11f6d90f44e973983cb21692724c919493a235d2f9b1f22788fbfe8abaec9c52a98385767d2f0dd0bfebbc39c9e23c1047ebdaeb87cb`
+
+## Changelog since v1.17.0-alpha.3
+
+### Action Required
+
+* Graduate ScheduleDaemonSetPods to GA. (feature gate will be removed in 1.18) action required. ([#82795](https://github.com/kubernetes/kubernetes/pull/82795), [@draveness](https://github.com/draveness))
+
+### Other notable changes
+
+* kube-scheduler: emits a warning when a malformed component config file is used with v1alpha1. ([#84129](https://github.com/kubernetes/kubernetes/pull/84129), [@obitech](https://github.com/obitech))
+* add azure disk encryption(SSE+CMK) support ([#84605](https://github.com/kubernetes/kubernetes/pull/84605), [@andyzhangx](https://github.com/andyzhangx))
+* The certificate signer no longer accepts ca.key passwords via the CFSSL_CA_PK_PASSWORD environment variable. This capability was not prompted by user request, never advertised, and recommended against in the security audit. ([#84677](https://github.com/kubernetes/kubernetes/pull/84677), [@mikedanese](https://github.com/mikedanese))
+* Reduce default NodeStatusReportFrequency to 5 minutes. With this change, periodic node status updates will be send every 5m if node status doesn't change (otherwise they are still send with 10s). ([#84007](https://github.com/kubernetes/kubernetes/pull/84007), [@wojtek-t](https://github.com/wojtek-t))
+    * Bump NodeProblemDetector version to v0.8.0 to reduce forced NodeStatus updates frequency to 5 minutes.
+* CSI Topology feature is GA. The CSINodeInfo feature gate is deprecated and will be removed in a future release. The storage.k8s.io/v1beta1 CSINode object is deprecated and will be removed in a future release. ([#83474](https://github.com/kubernetes/kubernetes/pull/83474), [@msau42](https://github.com/msau42))
+* Only validate duplication of the RequestedToCapacityRatio custom priority and allow other custom predicates/priorities ([#84646](https://github.com/kubernetes/kubernetes/pull/84646), [@liu-cong](https://github.com/liu-cong))
+* Added kubelet serving certificate metric `server_rotation_seconds` which is a histogram reporting the age of a just rotated serving certificate in seconds. ([#84534](https://github.com/kubernetes/kubernetes/pull/84534), [@sambdavidson](https://github.com/sambdavidson))
+* During namespace deletion some controllers create event and log spam because they do not recognize namespace deletion as a terminal state. ([#84123](https://github.com/kubernetes/kubernetes/pull/84123), [@smarterclayton](https://github.com/smarterclayton))
+* Removed Alpha feature `MountContainers` ([#84365](https://github.com/kubernetes/kubernetes/pull/84365), [@codenrhoden](https://github.com/codenrhoden))
+* People can see the right log and note. ([#84637](https://github.com/kubernetes/kubernetes/pull/84637), [@zhipengzuo](https://github.com/zhipengzuo))
+* Ensure the KUBE-MARK-DROP chain in kube-proxy mode=iptables. The chain is ensured for both ipv4 and ipv6 in dual-stack operation. ([#84422](https://github.com/kubernetes/kubernetes/pull/84422), [@aojea](https://github.com/aojea))
+* deprecate cleanup-ipvs flag ([#83832](https://github.com/kubernetes/kubernetes/pull/83832), [@gongguan](https://github.com/gongguan))
+* Scheduler Policy API has a new recommended apiVersion "apiVersion: kubescheduler.config.k8s.io/v1" which is consistent with the scheduler API group "kubescheduler.config.k8s.io". It holds the same API as the old apiVersion "apiVersion: v1". ([#83578](https://github.com/kubernetes/kubernetes/pull/83578), [@Huang-Wei](https://github.com/Huang-Wei))
+* Fixed a bug in the single-numa-policy of the TopologyManager. Previously, best-effort pods would result in a terminated state with a TopologyAffinity error. Now they will run as expected. ([#83777](https://github.com/kubernetes/kubernetes/pull/83777), [@lmdaly](https://github.com/lmdaly))
+* local: support local filesystem volume with block resource reconstruction ([#84218](https://github.com/kubernetes/kubernetes/pull/84218), [@cofyc](https://github.com/cofyc))
+* Fix the bug that EndpointSlice for masters wasn't created after enabling EndpointSlice feature on a pre-existing cluster. ([#84421](https://github.com/kubernetes/kubernetes/pull/84421), [@tnqn](https://github.com/tnqn))
+* kubelet: a configuration file specified via `--config` is now loaded with strict deserialization, which fails if the config file contains duplicate or unknown fields. This protects against accidentally running with config files that are malformed, mis-indented, or have typos in field names, and getting unexpected behavior. ([#83204](https://github.com/kubernetes/kubernetes/pull/83204), [@obitech](https://github.com/obitech))
+* kubeadm now propagates proxy environment variables to kube-proxy ([#84559](https://github.com/kubernetes/kubernetes/pull/84559), [@yastij](https://github.com/yastij))
+* Reload apiserver SNI certificates from disk every minute ([#84303](https://github.com/kubernetes/kubernetes/pull/84303), [@jackkleeman](https://github.com/jackkleeman))
+* sourcesReady provides the readiness of kubelet configuration sources such as apiserver update readiness. ([#81344](https://github.com/kubernetes/kubernetes/pull/81344), [@zouyee](https://github.com/zouyee))
+* Update Azure SDK versions to v35.0.0 ([#84543](https://github.com/kubernetes/kubernetes/pull/84543), [@andyzhangx](https://github.com/andyzhangx))
+* Fixed EndpointSlice port name validation to match Endpoint port name validation (allowing port names longer than 15 characters) ([#84481](https://github.com/kubernetes/kubernetes/pull/84481), [@robscott](https://github.com/robscott))
+* Scheduler now reports metrics on cache size including nodes, pods, and assumed pods ([#83508](https://github.com/kubernetes/kubernetes/pull/83508), [@damemi](https://github.com/damemi))
+* kube-proxy: emits a warning when a malformed component config file is used with v1alpha1. ([#84143](https://github.com/kubernetes/kubernetes/pull/84143), [@phenixblue](https://github.com/phenixblue))
+* Update default etcd server version to 3.4.3 ([#84329](https://github.com/kubernetes/kubernetes/pull/84329), [@jingyih](https://github.com/jingyih))
+* Scheduler policy configs can no longer be declared multiple times ([#83963](https://github.com/kubernetes/kubernetes/pull/83963), [@damemi](https://github.com/damemi))
+* This PR sets the --cluster-dns flag value to kube-dns service IP whether or not NodeLocal DNSCache is enabled. NodeLocal DNSCache will listen on both the link-local as well as the service IP. ([#84383](https://github.com/kubernetes/kubernetes/pull/84383), [@prameshj](https://github.com/prameshj))
+* Remove prometheus cluster monitoring addon from kube-up ([#83442](https://github.com/kubernetes/kubernetes/pull/83442), [@serathius](https://github.com/serathius))
+* update the latest validated version of Docker to 19.03 ([#84476](https://github.com/kubernetes/kubernetes/pull/84476), [@neolit123](https://github.com/neolit123))
+* kubeadm: always mount the kube-controller-manager hostPath volume that is given by the --flex-volume-plugin-dir flag. ([#84468](https://github.com/kubernetes/kubernetes/pull/84468), [@neolit123](https://github.com/neolit123))
+* Introduce x-kubernetes-map-type annotation as a CRD API extension. Enables this particular validation for server-side apply. ([#84113](https://github.com/kubernetes/kubernetes/pull/84113), [@enxebre](https://github.com/enxebre))
+* kube-scheduler now fallbacks to emitting events using core/v1 Events when events.k8s.io/v1beta1 is disabled. ([#83692](https://github.com/kubernetes/kubernetes/pull/83692), [@yastij](https://github.com/yastij))
+* Migrate controller-manager and scheduler to EndpointsLeases leader election. ([#84084](https://github.com/kubernetes/kubernetes/pull/84084), [@wojtek-t](https://github.com/wojtek-t))
+* User can now use component config to configure NodeLabel plugin for the scheduler framework. ([#84297](https://github.com/kubernetes/kubernetes/pull/84297), [@liu-cong](https://github.com/liu-cong))
+* local: support local volume block mode reconstruction ([#84173](https://github.com/kubernetes/kubernetes/pull/84173), [@cofyc](https://github.com/cofyc))
+* Fixed kubectl endpointslice output for get requests ([#82603](https://github.com/kubernetes/kubernetes/pull/82603), [@robscott](https://github.com/robscott))
+* set config.BindAddress to IPv4 address "127.0.0.1" if not specified ([#83822](https://github.com/kubernetes/kubernetes/pull/83822), [@zouyee](https://github.com/zouyee))
+* CSI detach timeout increased from 10 seconds to 2 minutes ([#84321](https://github.com/kubernetes/kubernetes/pull/84321), [@cduchesne](https://github.com/cduchesne))
+* Update etcd client side to v3.4.3 ([#83987](https://github.com/kubernetes/kubernetes/pull/83987), [@wenjiaswe](https://github.com/wenjiaswe))
+    * Deprecated prometheus request meta-metrics have been removed (http_request_duration_microseconds, http_request_duration_microseconds_sum, http_request_duration_microseconds_count, http_request_size_bytes, http_request_size_bytes_sum, http_request_size_bytes_count, http_requests_total, http_response_size_bytes, http_response_size_bytes_sum, http_response_size_bytes_count) due to removal from the prometheus client library. Prometheus http request meta-metrics are now generated from [promhttp.InstrumentMetricHandler](https://godoc.org/github.com/prometheus/client_golang/prometheus/promhttp#InstrumentMetricHandler) instead.
+* The built-in system:csi-external-provisioner and system:csi-external-attacher cluster roles are removed as of 1.17 release ([#84282](https://github.com/kubernetes/kubernetes/pull/84282), [@tedyu](https://github.com/tedyu))
+* Pod labels can no longer be updated through the pod/status updates by nodes. ([#84260](https://github.com/kubernetes/kubernetes/pull/84260), [@tallclair](https://github.com/tallclair))
+* Reload apiserver serving certificate from disk every minute ([#84200](https://github.com/kubernetes/kubernetes/pull/84200), [@jackkleeman](https://github.com/jackkleeman))
+* Adds FQDN addressType support for EndpointSlice. ([#84091](https://github.com/kubernetes/kubernetes/pull/84091), [@robscott](https://github.com/robscott))
+* Add permit_wait_duration_seconds metric for scheduler. ([#84011](https://github.com/kubernetes/kubernetes/pull/84011), [@liu-cong](https://github.com/liu-cong))
+* Optimize inter-pod affinity preferredDuringSchedulingIgnoredDuringExecution type, up to 4x in some cases. ([#84264](https://github.com/kubernetes/kubernetes/pull/84264), [@ahg-g](https://github.com/ahg-g))
+* When a namespace is being deleted and spec.finalizers are still being processed, stop returning a 409 conflict error and instead return the object as we would during metadata.finalizer processing. ([#84122](https://github.com/kubernetes/kubernetes/pull/84122), [@smarterclayton](https://github.com/smarterclayton))
+* client-ca bundles for the all generic-apiserver based servers will dynamically reload from disk on content changes ([#83579](https://github.com/kubernetes/kubernetes/pull/83579), [@deads2k](https://github.com/deads2k))
+* Reduced frequency of DescribeVolumes calls of AWS API when attaching/detaching a volume. ([#84181](https://github.com/kubernetes/kubernetes/pull/84181), [@jsafrane](https://github.com/jsafrane))
+* Add a metric to track number of scheduler binding and prioritizing goroutines ([#83535](https://github.com/kubernetes/kubernetes/pull/83535), [@wgliang](https://github.com/wgliang))
+* Fix kubelet metrics gathering on non-English Windows hosts ([#84156](https://github.com/kubernetes/kubernetes/pull/84156), [@wawa0210](https://github.com/wawa0210))
+* A new `kubelet_preemptions` metric is reported from Kubelets to track the number of preemptions occuring over time, and which resource is triggering those preemptions. ([#84120](https://github.com/kubernetes/kubernetes/pull/84120), [@smarterclayton](https://github.com/smarterclayton))
+
+
+
+# v1.17.0-alpha.3
+
+[Documentation](https://docs.k8s.io)
+
+## Downloads for v1.17.0-alpha.3
+
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes.tar.gz](https://dl.k8s.io/v1.17.0-alpha.3/kubernetes.tar.gz) | `dfdb758b21a3dbd820063cb2ba4b4a19e5e1e03fdb95856bf9c99c2c436bbc2c259cd9ac233f0388b5c3690f2c78680362130e045442f4da5b8b94c3013bdc72`
+[kubernetes-src.tar.gz](https://dl.k8s.io/v1.17.0-alpha.3/kubernetes-src.tar.gz) | `1718547ef5baf7ab6514bafff05451fc9d2f0db0b74f094b4d9004e949ef86ed246abf538fabe221e1adbe5aabc39b831c5d332d1aca8d65d58050092b8bcc8c`
+
+### Client Binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-client-darwin-386.tar.gz](https://dl.k8s.io/v1.17.0-alpha.3/kubernetes-client-darwin-386.tar.gz) | `207b281b7da796faa34beaf0c8f7e70f9685b132c2838a12e0c8f2084627e2c98890379cc84eff851349d74ec0a273c1f8967085e1c6471acfa1d5fcf251b1cb`
+[kubernetes-client-darwin-amd64.tar.gz](https://dl.k8s.io/v1.17.0-alpha.3/kubernetes-client-darwin-amd64.tar.gz) | `b0c19de40aa4210c0f06e1864779d60a69b75a443042f448746a0cd8cae680a7f4fab2dc7f3c61a31bde39ef9f490224be9559d6b15225cb7502b281c9968e51`
+[kubernetes-client-linux-386.tar.gz](https://dl.k8s.io/v1.17.0-alpha.3/kubernetes-client-linux-386.tar.gz) | `e8149e6373b48ab97b844b5450be12ec4bb86c869cdf71f98b78b88a9a9ef535df443241bf385fa4588dbe44abd0771b08a2af64dcdd6b891a4d3001cee9ac95`
+[kubernetes-client-linux-amd64.tar.gz](https://dl.k8s.io/v1.17.0-alpha.3/kubernetes-client-linux-amd64.tar.gz) | `d4176dfd049ffa1e59b7c4efd4d4189463153fa6cf53d5fc43c953983b74cbd75af9b8a0f7c13f86c5c3a3bb75ec453a676a931a38acaf32eb3ab98001d8f168`
+[kubernetes-client-linux-arm.tar.gz](https://dl.k8s.io/v1.17.0-alpha.3/kubernetes-client-linux-arm.tar.gz) | `d6de12989c091e78ad95d7e01274936a28ca74219196c27775d00665c9fb98fa1e485652c395114d3ed09534932390035e6d5c7c14d5753614929ecaf90baa2e`
+[kubernetes-client-linux-arm64.tar.gz](https://dl.k8s.io/v1.17.0-alpha.3/kubernetes-client-linux-arm64.tar.gz) | `2f62aeaa39d7b7ab0840bd6c845d73e6135357edbbf93046c1fbd52d02a8c19377787ec016af2db74f236c82b71c1f9f704b650ee689876138f0da828a61951b`
+[kubernetes-client-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.17.0-alpha.3/kubernetes-client-linux-ppc64le.tar.gz) | `895fd028e409cca1667a08ba6d1b32517b23b796530eecef7c1a4783287b45ff826e692d7a4ca103979f5b3a2e8d6550c1df5b3144aa686fe7fed7122b2ef051`
+[kubernetes-client-linux-s390x.tar.gz](https://dl.k8s.io/v1.17.0-alpha.3/kubernetes-client-linux-s390x.tar.gz) | `50fe03594da3c90932e83d0befad9053ef1fb72f4af1a5c139455c8acc6c10adec522efe80195013f88a3b40b0371ff7de85544c3c3d770fea37cff727ff5147`
+[kubernetes-client-windows-386.tar.gz](https://dl.k8s.io/v1.17.0-alpha.3/kubernetes-client-windows-386.tar.gz) | `3e32d47078da5d3d31c4b854c01e081a437fab2c01c7e7be291262b029046acaf96efa6529383b3410b53bc2973ec82c6fe7b4eb4193d15eda4abb73210cecf6`
+[kubernetes-client-windows-amd64.tar.gz](https://dl.k8s.io/v1.17.0-alpha.3/kubernetes-client-windows-amd64.tar.gz) | `42ec1f3273ea070cedcf65bbb76ebf05a24aca5ed55af4b17889fb1be3df99b4e4c023099994cbec572968c297a4671ce4a966c9dacc3c8385a380741d067f2b`
+
+### Server Binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-server-linux-amd64.tar.gz](https://dl.k8s.io/v1.17.0-alpha.3/kubernetes-server-linux-amd64.tar.gz) | `0b1fe1eca603579f70c13509dff32dcb8383ee340b8fc6b8edf23cdaf1f86cf9c8d710380a9350de8b516c5c742eb10e28c97cadf7afa57532bd663c88cad96f`
+[kubernetes-server-linux-arm.tar.gz](https://dl.k8s.io/v1.17.0-alpha.3/kubernetes-server-linux-arm.tar.gz) | `ac1a804dd8980281afe12a116ffaf4ed9fc1066c3a531f3a6ced14f021c69d60ff7120bfbfe159cd93898b937c4c3baddce4429dd7933654f0a6f6bcbeed8fab`
+[kubernetes-server-linux-arm64.tar.gz](https://dl.k8s.io/v1.17.0-alpha.3/kubernetes-server-linux-arm64.tar.gz) | `e34daf4c37ab5c2f52a116ed4ca0f7b52c0d0b5863d027550241b03f9019dcb6dd7d16df7c6ec7a43a86737b16015c19a2a75a19173c2dd9ee574b5f08098881`
+[kubernetes-server-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.17.0-alpha.3/kubernetes-server-linux-ppc64le.tar.gz) | `9c285800beecc53cf5293604270cbcc5ba6245ddf4dfe0c0ec9a1359ed3771d7e1939c2496b2c24bf4cc541e8b29408ec66c24804b321612331c553b55c2c3c8`
+[kubernetes-server-linux-s390x.tar.gz](https://dl.k8s.io/v1.17.0-alpha.3/kubernetes-server-linux-s390x.tar.gz) | `ea883497e80fdb2182342a2bae0382c7d38b0273cae6f8a5ee05d149669134d9b50613184e1fc289d7ce999c172f455f76b08e40cc014a33fc2c9c6491eee9c1`
+
+### Node Binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-node-linux-amd64.tar.gz](https://dl.k8s.io/v1.17.0-alpha.3/kubernetes-node-linux-amd64.tar.gz) | `450197a746a52c3129f97e50b4b69bf2d1e94290be72f1ae143e36bb0fd76b2175cc917ae47389feb0163ae108a752929ac4fa8f90b8dee21f0be5e198c847a5`
+[kubernetes-node-linux-arm.tar.gz](https://dl.k8s.io/v1.17.0-alpha.3/kubernetes-node-linux-arm.tar.gz) | `c10c6ea591a15dc873afb01a7aa1916188e411ba57201f436d6d96cd2bad8cbb4e3bccc743759e3ce6d93e0f13c026ae5d646684611fe11134ba05321522f78c`
+[kubernetes-node-linux-arm64.tar.gz](https://dl.k8s.io/v1.17.0-alpha.3/kubernetes-node-linux-arm64.tar.gz) | `47764435a9367571f7de12d54f0aff7d615fc50383230c6fba08475dc33be60d2912dd2ee5c3f083a450866281c1df90663b1737f2d8293a73b48720aeda6a8b`
+[kubernetes-node-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.17.0-alpha.3/kubernetes-node-linux-ppc64le.tar.gz) | `48d2694450f4b94e8ff76e95ef102670d4a4c933010afadf7a019db73d966462a07ff222f9b48510f5dd3ac8f9076e31646d490ec0c1425d4be7b8475cd11cd6`
+[kubernetes-node-linux-s390x.tar.gz](https://dl.k8s.io/v1.17.0-alpha.3/kubernetes-node-linux-s390x.tar.gz) | `20e712415af7304ecb55e9c2c2f29dda3af4a78f5833499c1f51a492c929a4590717d60fce537fb81c70784a6ca1503f7e731e1779cbc59673f69a03f7533bc0`
+[kubernetes-node-windows-amd64.tar.gz](https://dl.k8s.io/v1.17.0-alpha.3/kubernetes-node-windows-amd64.tar.gz) | `2e88bf26e1293dd733cf1bfe1f0f2dcfb5c482687cf52690488e943a0922a5c9565dd9ce000af76597e0bf1ac8f42ce12044c0ec5e3564db5c2f6a409e9efdb6`
+
+## Changelog since v1.17.0-alpha.2
+
+### Action Required
+
+* Graduate TaintNodesByCondition to GA in 1.17. (feature gate will be removed in 1.18) action required ([#82703](https://github.com/kubernetes/kubernetes/pull/82703), [@draveness](https://github.com/draveness))
+
+### Other notable changes
+
+* TaintNodesByCondition was graduated to GA, CheckNodeMemoryPressure, CheckNodePIDPressure, CheckNodeDiskPressure, CheckNodeCondition were accidentally removed since 1.12, the replacement is to use CheckNodeUnschedulablePred ([#84152](https://github.com/kubernetes/kubernetes/pull/84152), [@draveness](https://github.com/draveness))
+* filter plugin for cloud provider storage predicate ([#84148](https://github.com/kubernetes/kubernetes/pull/84148), [@gongguan](https://github.com/gongguan))
+* Fixed binding of block PersistentVolumes / PersistentVolumeClaims when BlockVolume feature is off. ([#84049](https://github.com/kubernetes/kubernetes/pull/84049), [@jsafrane](https://github.com/jsafrane))
+* Updated kube-proxy ipvs README with correct grep argument to list loaded ipvs modules ([#83677](https://github.com/kubernetes/kubernetes/pull/83677), [@pete911](https://github.com/pete911))
+* Add data cache flushing during unmount device for GCE-PD driver in Windows Server. ([#83591](https://github.com/kubernetes/kubernetes/pull/83591), [@jingxu97](https://github.com/jingxu97))
+* Adds a metric apiserver_request_error_total to kube-apiserver. This metric tallies the number of request_errors encountered by verb, group, version, resource, subresource, scope, component, and code.  ([#83427](https://github.com/kubernetes/kubernetes/pull/83427), [@logicalhan](https://github.com/logicalhan))
+* Refactor scheduler's framework permit API. ([#83756](https://github.com/kubernetes/kubernetes/pull/83756), [@hex108](https://github.com/hex108))
+* The kubectl's api-resource command now has a `--sort-by` flag to sort resources by name or kind. ([#81971](https://github.com/kubernetes/kubernetes/pull/81971), [@laddng](https://github.com/laddng))
+* Update to use go1.12.12 ([#84064](https://github.com/kubernetes/kubernetes/pull/84064), [@cblecker](https://github.com/cblecker))
+* Update to Ingress-GCE v1.6.1 ([#84018](https://github.com/kubernetes/kubernetes/pull/84018), [@rramkumar1](https://github.com/rramkumar1))
+* Update Cluster Autoscaler version to 1.16.2 (CA release docs: https://github.com/kubernetes/autoscaler/releases/tag/cluster-autoscaler-1.16.2) ([#84038](https://github.com/kubernetes/kubernetes/pull/84038), [@losipiuk](https://github.com/losipiuk))
+* When scaling down a ReplicaSet, delete doubled up replicas first, where a "doubled up replica" is defined as one that is on the same node as an active replica belonging to a related ReplicaSet.  ReplicaSets are considered "related" if they have a common controller (typically a Deployment). ([#80004](https://github.com/kubernetes/kubernetes/pull/80004), [@Miciah](https://github.com/Miciah))
+* Promote WatchBookmark feature to GA. ([#83195](https://github.com/kubernetes/kubernetes/pull/83195), [@wojtek-t](https://github.com/wojtek-t))
+    * With WatchBookmark feature, clients are able to request watch events with BOOKMARK type. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session.
+* kubeadm no longer removes /etc/cni/net.d as it does not install it. Users should remove files from it manually or rely on the component that created them ([#83950](https://github.com/kubernetes/kubernetes/pull/83950), [@yastij](https://github.com/yastij))
+* kubeadm: enhance certs check-expiration to show the expiration info of related CAs ([#83932](https://github.com/kubernetes/kubernetes/pull/83932), [@SataQiu](https://github.com/SataQiu))
+* Add incoming pods metrics to scheduler queue. ([#83577](https://github.com/kubernetes/kubernetes/pull/83577), [@liu-cong](https://github.com/liu-cong))
+* An end-user may choose to request logs without confirming the identity of the backing kubelet.  This feature can be disabled by setting the `AllowInsecureBackendProxy` feature-gate to false. ([#83419](https://github.com/kubernetes/kubernetes/pull/83419), [@deads2k](https://github.com/deads2k))
+* Switched intstr.Type to sized integer to follow API guidelines and improve compatibility with proto libraries ([#83956](https://github.com/kubernetes/kubernetes/pull/83956), [@liggitt](https://github.com/liggitt))
+* Fix handling tombstones in pod-disruption-budged controller. ([#83951](https://github.com/kubernetes/kubernetes/pull/83951), [@zouyee](https://github.com/zouyee))
+* client-go: improved allocation behavior of the delaying workqueue when handling objects with far-future ready times. ([#83945](https://github.com/kubernetes/kubernetes/pull/83945), [@barkbay](https://github.com/barkbay))
+* Added the `crictl` Windows binaries as well as the Linux 32bit binary to the release archives ([#83944](https://github.com/kubernetes/kubernetes/pull/83944), [@saschagrunert](https://github.com/saschagrunert))
+* Fixed an issue with informers missing an `Added` event if a recently deleted object was immediately recreated at the same time the informer dropped a watch and relisted. ([#83911](https://github.com/kubernetes/kubernetes/pull/83911), [@matte21](https://github.com/matte21))
+* Allow dynamically set glog logging level of kube-scheduler ([#83910](https://github.com/kubernetes/kubernetes/pull/83910), [@mrkm4ntr](https://github.com/mrkm4ntr))
+* clean duplicate GetPodServiceMemberships function ([#83902](https://github.com/kubernetes/kubernetes/pull/83902), [@gongguan](https://github.com/gongguan))
+* Add information from Lease object corresponding to a given Node to kubectl describe node output ([#83899](https://github.com/kubernetes/kubernetes/pull/83899), [@wojtek-t](https://github.com/wojtek-t))
+* Gives the right error message when using `kubectl delete` a wrong resource. ([#83825](https://github.com/kubernetes/kubernetes/pull/83825), [@zhouya0](https://github.com/zhouya0))
+* The userspace mode of kube-proxy no longer confusingly logs messages about deleting endpoints that it is actually adding. ([#83644](https://github.com/kubernetes/kubernetes/pull/83644), [@danwinship](https://github.com/danwinship))
+* Add latency and request count metrics for scheduler framework. ([#83569](https://github.com/kubernetes/kubernetes/pull/83569), [@liu-cong](https://github.com/liu-cong))
+* ETCD version monitor metrics are now marked as with the ALPHA stability level. ([#83283](https://github.com/kubernetes/kubernetes/pull/83283), [@RainbowMango](https://github.com/RainbowMango))
+* Significant kube-proxy performance improvements when using Endpoint Slices at scale. ([#83206](https://github.com/kubernetes/kubernetes/pull/83206), [@robscott](https://github.com/robscott))
+* Upgrade default etcd server version to 3.3.17 ([#83804](https://github.com/kubernetes/kubernetes/pull/83804), [@jpbetz](https://github.com/jpbetz))
+
+
+
+# v1.17.0-alpha.2
+
+[Documentation](https://docs.k8s.io)
+
+## Downloads for v1.17.0-alpha.2
+
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes.tar.gz](https://dl.k8s.io/v1.17.0-alpha.2/kubernetes.tar.gz) | `37583337b992d9a5ebe5a4677e08c13617b8b9db9ee8f049773b624351c00acacf02daca2f87a357aaa75edcc3a4db2c64e6a7da502a6153d06e228ff6be6006`
+[kubernetes-src.tar.gz](https://dl.k8s.io/v1.17.0-alpha.2/kubernetes-src.tar.gz) | `a44fee5be20c7fb64c58d0a69377074db05ec6889892c93ce970406cb393a1fde60a75612e74802cb2e0085b6357183c1f30e4b322dacf6f30597ab5fd5948f9`
+
+### Client Binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-client-darwin-386.tar.gz](https://dl.k8s.io/v1.17.0-alpha.2/kubernetes-client-darwin-386.tar.gz) | `4aa92894eeaedb022e5409e08784ce1bd34ba268032ef93ad4c438b6ed9f1a210222f5f4a4fc68198d71e167c78bb7695459e4c99059898e1e0cf7c1ae70080c`
+[kubernetes-client-darwin-amd64.tar.gz](https://dl.k8s.io/v1.17.0-alpha.2/kubernetes-client-darwin-amd64.tar.gz) | `1815a3bdd1c13782026fced8720201dea2e518dc56a43e2b53f89341108f03ec0b5ea6efadd8460ab1715b65ae52f9bdd49066f716573e0d76ff3036e193b8d3`
+[kubernetes-client-linux-386.tar.gz](https://dl.k8s.io/v1.17.0-alpha.2/kubernetes-client-linux-386.tar.gz) | `9a470907d6203e69c996f8db3cc257af23f9b35236ee2d5a87d22cd6056eef4f07671cd5711ec4999c1edd93385c4f7e5d6d0b8096404e88414a1ed83b58de4f`
+[kubernetes-client-linux-amd64.tar.gz](https://dl.k8s.io/v1.17.0-alpha.2/kubernetes-client-linux-amd64.tar.gz) | `011d44cf35c841d331a5a0d88b8a5deb7781fa678702ac6402050d096e72396dc76ccaa67a371273bc428612536357c19306d250bd47db4ac5147ff8cc5e1296`
+[kubernetes-client-linux-arm.tar.gz](https://dl.k8s.io/v1.17.0-alpha.2/kubernetes-client-linux-arm.tar.gz) | `1f45d9a9852d2b0a0420b0a26b3add9031d7d691c55660d60580614e6ab6e2d732017832ed3f737f8a43db088e91b64edf12298675be6d128775dce3e4d0ddbe`
+[kubernetes-client-linux-arm64.tar.gz](https://dl.k8s.io/v1.17.0-alpha.2/kubernetes-client-linux-arm64.tar.gz) | `e355f69caed044e5e27efe7ae42027e799a87ec647810fbadf644d147de2f6bd478e338ebb211044a9e6483d32f3534cc40d7b4d735d16d3b6c55e7975515f20`
+[kubernetes-client-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.17.0-alpha.2/kubernetes-client-linux-ppc64le.tar.gz) | `355e0d8c5f241bc2303c38447c241ff8f5151af51aeacf15fa2b96e2721ecc011b5aec84c3f93a26aad86aa29179d16054e34d45bff2824c1abbf1deb571f0f5`
+[kubernetes-client-linux-s390x.tar.gz](https://dl.k8s.io/v1.17.0-alpha.2/kubernetes-client-linux-s390x.tar.gz) | `7cdfc6cde7922290b46f291a168519f4c923fee97968399940164a8a7d8592701b262b30fa299c13f025c70f46f5d32c17a9699f0bf3e5bd55ab4811f01f59ed`
+[kubernetes-client-windows-386.tar.gz](https://dl.k8s.io/v1.17.0-alpha.2/kubernetes-client-windows-386.tar.gz) | `7170da100b2d1d8700990c4175c7d048347b8dcc71e0ceb6c01728f5e6266dd0d5766e5206820d9e54d243ffa73abd5dd72715d6984598655f6160d43cb45a15`
+[kubernetes-client-windows-amd64.tar.gz](https://dl.k8s.io/v1.17.0-alpha.2/kubernetes-client-windows-amd64.tar.gz) | `74484b5c841e1c57c9baf88b84a9cbf3b9865527a8723815cbe8e7384805c80d971126c0b54d52e446d55b04e209984461ec8a8eff4c58aaa50397db0111cca5`
+
+### Server Binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-server-linux-amd64.tar.gz](https://dl.k8s.io/v1.17.0-alpha.2/kubernetes-server-linux-amd64.tar.gz) | `3fb3c5da6e45b32e8d89d4914f0b04cf95242cb0e4ea70b06a665c2975d8b6bbff6206e1f8769f49836b9dc12fb0946cc1986e475945413aff053661941f622b`
+[kubernetes-server-linux-arm.tar.gz](https://dl.k8s.io/v1.17.0-alpha.2/kubernetes-server-linux-arm.tar.gz) | `ff71c9a3f81f2e43d541b9b043e5f43fd30972c2b0ae5d9f3992f76effdcab2d027835844109ee3b501e365994f97aa5b6528a9d23db8ec3f05af6cb6d0e01d0`
+[kubernetes-server-linux-arm64.tar.gz](https://dl.k8s.io/v1.17.0-alpha.2/kubernetes-server-linux-arm64.tar.gz) | `26b9fce5ed930ad3eea5eeab3bec3b009f65837139f7da3644aacdcccda654fe542b03e1c4280950ca561f624ef24da01acff23e3f3b72d1001d794c8d6aa230`
+[kubernetes-server-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.17.0-alpha.2/kubernetes-server-linux-ppc64le.tar.gz) | `ad980f5efe83da1f2a202035eb1cff44ea72692fc3fc5f7d23fd8fc3b80a6797dbb263cc240d8fd2cde80a786b48352127f52c0a1db02e9d09a44440c1704406`
+[kubernetes-server-linux-s390x.tar.gz](https://dl.k8s.io/v1.17.0-alpha.2/kubernetes-server-linux-s390x.tar.gz) | `8e1ab7abd4c13c3d4211e5dd1be63ecd482691fd2cb7b2d3492bb2a02003ec33abe0a7b26e4e93f9586c5fc6fddbfbb559c4c28dcdc65564aeadceb2bc543a7d`
+
+### Node Binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-node-linux-amd64.tar.gz](https://dl.k8s.io/v1.17.0-alpha.2/kubernetes-node-linux-amd64.tar.gz) | `c0928e414e439ba63321ce770a04ea332a4cc93ec87dd9d222fe3f5a593995111a6c0a60a413018d59367df6b4d0ab6f64904551f29f5c94ea406c68cc43b3b3`
+[kubernetes-node-linux-arm.tar.gz](https://dl.k8s.io/v1.17.0-alpha.2/kubernetes-node-linux-arm.tar.gz) | `990a253ba49203348a587ca4d4acf7c25ff47a97b39519dfc7d5bdc2f3ea4713930e17dc6b9ff02a2a6ae2e84011d05d4471dfbfe1ab0627c102f9aa2205114d`
+[kubernetes-node-linux-arm64.tar.gz](https://dl.k8s.io/v1.17.0-alpha.2/kubernetes-node-linux-arm64.tar.gz) | `79381ad17eefc679fb549126eba23ffa65e625d0e1fec459dd54823897947b17a0e7ef6f446dc9e54f16b3e4995e4a084146dcf895e994813233953a3795e3a3`
+[kubernetes-node-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.17.0-alpha.2/kubernetes-node-linux-ppc64le.tar.gz) | `7cfea9b9fa27dcc2024260e19d5e74db2175b491093c8906721d99c94b46af1c2b3ad91fe0fb799de639191fcb0e8ceab1b67bb260d615825002a3239c7b3ed0`
+[kubernetes-node-linux-s390x.tar.gz](https://dl.k8s.io/v1.17.0-alpha.2/kubernetes-node-linux-s390x.tar.gz) | `590bc2afd835a4a236a4a2ab2cde416aae9efdec14c34355a54b671d89308f3729f5af076139cc9c78e323666565ba1fa441149b681fc6addcab133205a3c41f`
+[kubernetes-node-windows-amd64.tar.gz](https://dl.k8s.io/v1.17.0-alpha.2/kubernetes-node-windows-amd64.tar.gz) | `4c15c7c30de0f9d921b534433332b14eb685ad8a3a416315def1cc1064b802227ea4b556bc53a68d75be898b49acadee8317a2355635a69d1c4d305d890e5009`
+
+## Changelog since v1.17.0-alpha.1
+
+### Action Required
+
+* Expand scheduler priority functions and scheduling framework plugins' node score range to [0, 100]. action required. Note: this change is internal and does not affect extender and RequestedToCapacityRatio custom priority, which are still expected to provide a [0, 10] range. ([#83522](https://github.com/kubernetes/kubernetes/pull/83522), [@draveness](https://github.com/draveness))
+* action required: kubeadm: when adding extra apiserver authorization-modes, the defaults "Node,RBAC" are no longer prepended in the resulting static Pod manifests and a full override is allowed. ([#82616](https://github.com/kubernetes/kubernetes/pull/82616), [@ghouscht](https://github.com/ghouscht))
+* ACTION REQUIRED: kubeadm: properly enable kubelet client certificate rotation on primary control-plane nodes, created using "kubeadm init". A side effect of this change is that for external CA users, kubeadm now requires "bootstrap-kubelet.conf" instead of "kubelet.conf" during "kubeadm init" and its phases. ([#83339](https://github.com/kubernetes/kubernetes/pull/83339), [@neolit123](https://github.com/neolit123))
+* Action Required: `kubeadm.k8s.io/v1beta1` has been deprecated, you should update your config to use newer non-deprecated API versions. ([#83276](https://github.com/kubernetes/kubernetes/pull/83276), [@Klaven](https://github.com/Klaven))
+
+### Other notable changes
+
+* [migration phase 1] PodFitsHostPorts as filter plugin ([#83659](https://github.com/kubernetes/kubernetes/pull/83659), [@wgliang](https://github.com/wgliang))
+* [migration phase 1] PodFitsResources as framework plugin ([#83650](https://github.com/kubernetes/kubernetes/pull/83650), [@wgliang](https://github.com/wgliang))
+* Fixed attachment of AWS volumes that have just been detached. ([#83567](https://github.com/kubernetes/kubernetes/pull/83567), [@jsafrane](https://github.com/jsafrane))
+* [migration phase 1] PodMatchNodeSelector/NodAffinity as filter plugin ([#83660](https://github.com/kubernetes/kubernetes/pull/83660), [@wgliang](https://github.com/wgliang))
+* Upgrade to etcd client 3.3.17 to fix bug where etcd client does not parse IPv6 addresses correctly when members are joining, and to fix bug where failover on multi-member etcd cluster fails certificate check on DNS mismatch ([#83801](https://github.com/kubernetes/kubernetes/pull/83801), [@jpbetz](https://github.com/jpbetz))
+* Fixed panic when accessing CustomResources of a CRD with x-kubernetes-int-or-string. ([#83787](https://github.com/kubernetes/kubernetes/pull/83787), [@sttts](https://github.com/sttts))
+* Change `pod_preemption_victims` metric from Gauge to Histogram. ([#83603](https://github.com/kubernetes/kubernetes/pull/83603), [@Tabrizian](https://github.com/Tabrizian))
+* Expose SharedInformerFactory in the framework handle ([#83663](https://github.com/kubernetes/kubernetes/pull/83663), [@draveness](https://github.com/draveness))
+* Add more tracing steps in generic_scheduler ([#83539](https://github.com/kubernetes/kubernetes/pull/83539), [@wgliang](https://github.com/wgliang))
+* [migration phase 1] PodFitsHost as filter plugin ([#83662](https://github.com/kubernetes/kubernetes/pull/83662), [@wgliang](https://github.com/wgliang))
+* The topology manager aligns resources for pods of all QoS classes with respect to NUMA locality, not just Guaranteed QoS pods. ([#83492](https://github.com/kubernetes/kubernetes/pull/83492), [@ConnorDoyle](https://github.com/ConnorDoyle))
+* Fix unsafe JSON construction in a number of locations in the codebase ([#81158](https://github.com/kubernetes/kubernetes/pull/81158), [@zouyee](https://github.com/zouyee))
+* Fixed a bug in the single-numa-node policy of the TopologyManager.  Previously, pods that only requested CPU resources and did not request any third-party devices would fail to launch with a TopologyAffinity error. Now they will launch successfully. ([#83697](https://github.com/kubernetes/kubernetes/pull/83697), [@klueska](https://github.com/klueska))
+* Add per-pod scheduling metrics across 1 or more schedule attempts. ([#83674](https://github.com/kubernetes/kubernetes/pull/83674), [@liu-cong](https://github.com/liu-cong))
+* Fix validation message to mention bytes, not characters. ([#80880](https://github.com/kubernetes/kubernetes/pull/80880), [@DirectXMan12](https://github.com/DirectXMan12))
+* external facing APIs in pluginregistration and deviceplugin packages are now available under k8s.io/kubelet/pkg/apis/ ([#83551](https://github.com/kubernetes/kubernetes/pull/83551), [@dims](https://github.com/dims))
+* Fix error where metrics related to dynamic kubelet config isn't registered ([#83184](https://github.com/kubernetes/kubernetes/pull/83184), [@odinuge](https://github.com/odinuge))
+* The VolumeSubpathEnvExpansion feature is graduating to GA. The `VolumeSubpathEnvExpansion` feature gate is unconditionally enabled, and will be removed in v1.19. ([#82578](https://github.com/kubernetes/kubernetes/pull/82578), [@kevtaylor](https://github.com/kevtaylor))
+* Openstack: Do not delete managed LB in case of security group reconciliation errors ([#82264](https://github.com/kubernetes/kubernetes/pull/82264), [@multi-io](https://github.com/multi-io))
+* The mutating and validating admission webhook plugins now read configuration from the admissionregistration.k8s.io/v1 API. ([#80883](https://github.com/kubernetes/kubernetes/pull/80883), [@liggitt](https://github.com/liggitt))
+* kubeadm: implemented structured output of 'kubeadm token list' in JSON, YAML, Go template and JsonPath formats ([#78764](https://github.com/kubernetes/kubernetes/pull/78764), [@bart0sh](https://github.com/bart0sh))
+* kube-proxy: a configuration file specified via `--config` is now loaded with strict deserialization, which fails if the config file contains duplicate or unknown fields. This protects against accidentally running with config files that are malformed, mis-indented, or have typos in field names, and getting unexpected behavior. ([#82927](https://github.com/kubernetes/kubernetes/pull/82927), [@obitech](https://github.com/obitech))
+* Add "podInitialBackoffDurationSeconds" and "podMaxBackoffDurationSeconds" to the scheduler config API ([#81263](https://github.com/kubernetes/kubernetes/pull/81263), [@draveness](https://github.com/draveness))
+* Authentication token cache size is increased (from 4k to 32k) to support clusters with many nodes or many namespaces with active service accounts. ([#83643](https://github.com/kubernetes/kubernetes/pull/83643), [@lavalamp](https://github.com/lavalamp))
+* Bumps the minimum version of Go required for building Kubernetes to 1.12.4. ([#83596](https://github.com/kubernetes/kubernetes/pull/83596), [@jktomer](https://github.com/jktomer))
+* kube-proxy iptables probabilities are now more granular and will result in better distribution beyond 319 endpoints. ([#83599](https://github.com/kubernetes/kubernetes/pull/83599), [@robscott](https://github.com/robscott))
+* Fixed the bug that deleted services were processed by EndpointSliceController repeatedly even their cleanup were successful. ([#82996](https://github.com/kubernetes/kubernetes/pull/82996), [@tnqn](https://github.com/tnqn))
+* If a bad flag is supplied to a kubectl command, only a tip to run --help is printed, instead of the usage menu.  Usage menu is printed upon running `kubectl command --help`.  ([#82423](https://github.com/kubernetes/kubernetes/pull/82423), [@sallyom](https://github.com/sallyom))
+* If container fails because ContainerCannotRun, do not utilize the FallbackToLogsOnError TerminationMessagePolicy, as it masks more useful logs. ([#81280](https://github.com/kubernetes/kubernetes/pull/81280), [@yqwang-ms](https://github.com/yqwang-ms))
+* Fixed cleanup of raw block devices after kubelet restart. ([#83451](https://github.com/kubernetes/kubernetes/pull/83451), [@jsafrane](https://github.com/jsafrane))
+* Commands like `kubectl apply` now return errors if schema-invalid annotations are specified, rather than silently dropping the entire annotations section. ([#83552](https://github.com/kubernetes/kubernetes/pull/83552), [@liggitt](https://github.com/liggitt))
+* Expose kubernetes client in the scheduling framework handle. ([#82432](https://github.com/kubernetes/kubernetes/pull/82432), [@draveness](https://github.com/draveness))
+* kubeadm: fix wrong default value for the "upgrade node --certificate-renewal" flag. ([#83528](https://github.com/kubernetes/kubernetes/pull/83528), [@neolit123](https://github.com/neolit123))
+* IP validates if a string is a valid IP address ([#83104](https://github.com/kubernetes/kubernetes/pull/83104), [@zouyee](https://github.com/zouyee))
+* The `--certificate-authority` flag now correctly overrides existing skip TLS or CA data settings in the kubeconfig file ([#83547](https://github.com/kubernetes/kubernetes/pull/83547), [@liggitt](https://github.com/liggitt))
+* hyperkube will now be available in a new github repository and will not be included in the kubernetes release from 1.17 onwards ([#83454](https://github.com/kubernetes/kubernetes/pull/83454), [@dims](https://github.com/dims))
+* more complete and accurate logging of stack backtraces in E2E failures ([#82176](https://github.com/kubernetes/kubernetes/pull/82176), [@pohly](https://github.com/pohly))
+* Kubeadm: add support for 127.0.0.1 as advertise address. kubeadm will automatically replace this value with matching global unicast IP address on the loopback interface.  ([#83475](https://github.com/kubernetes/kubernetes/pull/83475), [@fabriziopandini](https://github.com/fabriziopandini))
+* Rename PluginContext to CycleState in the scheduling framework ([#83430](https://github.com/kubernetes/kubernetes/pull/83430), [@draveness](https://github.com/draveness))
+* kube-scheduler: a configuration file specified via `--config` is now loaded with strict deserialization, which fails if the config file contains duplicate or unknown fields. This protects against accidentally running with config files that are malformed, mis-indented, or have typos in field names, and getting unexpected behavior. ([#83030](https://github.com/kubernetes/kubernetes/pull/83030), [@obitech](https://github.com/obitech))
+* Significant kube-proxy performance improvements for non UDP ports. ([#83208](https://github.com/kubernetes/kubernetes/pull/83208), [@robscott](https://github.com/robscott))
+* Fixes a flaw (CVE-2019-11253) in json/yaml decoding where large or malformed documents could consume excessive server resources. Request bodies for normal API requests (create/delete/update/patch operations of regular resources) are now limited to 3MB. ([#83261](https://github.com/kubernetes/kubernetes/pull/83261), [@liggitt](https://github.com/liggitt))
+
+
+
+# v1.17.0-alpha.1
+
+[Documentation](https://docs.k8s.io)
+
+## Downloads for v1.17.0-alpha.1
+
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes.tar.gz](https://dl.k8s.io/v1.17.0-alpha.1/kubernetes.tar.gz) | `40985964b5f4b1e1eb448a8ca61ae5fe05b76cf4e97a4a6b0df0f7933071239ed8c3a6753d8ed8ba0c963694c0f94cce2b5976ddcc0386018cdc66337d80d006`
+[kubernetes-src.tar.gz](https://dl.k8s.io/v1.17.0-alpha.1/kubernetes-src.tar.gz) | `475dfeb8544804dcc206f2284205fb1ee0bcb73169419be5e548ff91ffe6a35cea7e94039af562baee15933bef3afaa7ff10185e40926c7baa60d5936bcc9c1b`
+
+### Client Binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-client-darwin-386.tar.gz](https://dl.k8s.io/v1.17.0-alpha.1/kubernetes-client-darwin-386.tar.gz) | `3f894661ed9b6ed3e75b6882e6c3e4858325f3b7c5c83cb8f7f632a8c8f30dd96a7dd277e4676a8a2ab598fe68da6473f414b494c63bfb4ed386a20dad7ae11a`
+[kubernetes-client-darwin-amd64.tar.gz](https://dl.k8s.io/v1.17.0-alpha.1/kubernetes-client-darwin-amd64.tar.gz) | `f3070d79b0835fdc0791bbc31a334d8b46bf1bbb02f389c871b31063417598d17dd464532df420f2fa0dbbbb9f8cc0730a7ca4e19af09f873e0777d1e296f20c`
+[kubernetes-client-linux-386.tar.gz](https://dl.k8s.io/v1.17.0-alpha.1/kubernetes-client-linux-386.tar.gz) | `64e8961fa32a18a780e40b753772c6794c90a6dd5834388fd67564bb36f5301ea82377893f51e7c7c7247f91ca813e59f5f293522a166341339c2e5d34ac3f28`
+[kubernetes-client-linux-amd64.tar.gz](https://dl.k8s.io/v1.17.0-alpha.1/kubernetes-client-linux-amd64.tar.gz) | `d7ba0f5f4c879d8dcd4404a7c18768190f82985425ab394ddc832ee71c407d0ac517181a24fd5ca2ebfd948c6fa63d095a43c30cf195c9b9637e1a762a2d8d2f`
+[kubernetes-client-linux-arm.tar.gz](https://dl.k8s.io/v1.17.0-alpha.1/kubernetes-client-linux-arm.tar.gz) | `36fc47ee9530ee8a89d64d4be6b78b09831d0838a01b63d2a824a9e7dd0c2127ef1b49f539d16ba1248fbf40a7eb507b968b18c59080e7b80a7a573138218e36`
+[kubernetes-client-linux-arm64.tar.gz](https://dl.k8s.io/v1.17.0-alpha.1/kubernetes-client-linux-arm64.tar.gz) | `a0a8fba0f4424f0a1cb7bad21244f47f98ba717165eaa49558c2612e1949a1b34027e23ccbd44959b391b6d9f82046c5bc07eb7d773603b678bbc0e5bf54502c`
+[kubernetes-client-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.17.0-alpha.1/kubernetes-client-linux-ppc64le.tar.gz) | `eaae9ed0cc8c17f27cff31d92c95c11343b9f383de27e335c83bfdf236e6da6ab55a9d89b3e0b087be159d6b64de21827ca19c861ecfb6471b394ea3720bcb61`
+[kubernetes-client-linux-s390x.tar.gz](https://dl.k8s.io/v1.17.0-alpha.1/kubernetes-client-linux-s390x.tar.gz) | `994cf2dc42d20d36956a51b98dde31a00eae3bd853f7be4fbc32f48fec7b323a47ea5d841f31d2ca41036d27fbfaa3be4f2286654711245accf01c3be81f540c`
+[kubernetes-client-windows-386.tar.gz](https://dl.k8s.io/v1.17.0-alpha.1/kubernetes-client-windows-386.tar.gz) | `68ebe4abea5a174eb189caea567e24e87cca57e7fbc9f8ec344aafbaf48c892d52d179fef67f9825be0eb93f5577f7573873b946e688de78c442c798a5b426bc`
+[kubernetes-client-windows-amd64.tar.gz](https://dl.k8s.io/v1.17.0-alpha.1/kubernetes-client-windows-amd64.tar.gz) | `f29cd3caf5b40622366eae87e8abb47bea507f275257279587b507a00a858de87bcfa56894ae8cd6ba754688fd5cdf093ce6c4e0d0fd1e21ca487a3a8a9fd9f9`
+
+### Server Binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-server-linux-amd64.tar.gz](https://dl.k8s.io/v1.17.0-alpha.1/kubernetes-server-linux-amd64.tar.gz) | `93e560e8572c6a593583d20a35185b93d04c950e6b1980a7b40ca5798958d184724ddebd1fa9377cfe87be4d11169bdba2a9f7fa192690f9edae04779aaf93a4`
+[kubernetes-server-linux-arm.tar.gz](https://dl.k8s.io/v1.17.0-alpha.1/kubernetes-server-linux-arm.tar.gz) | `fe2af93336280e1251f97afecbdfb7416fd9dd7d08b3e5539abeea8ccaf7114cac399e832fa52359d2bc63ec9f8703ae3bca340db85f9b764816f4c36e4eefee`
+[kubernetes-server-linux-arm64.tar.gz](https://dl.k8s.io/v1.17.0-alpha.1/kubernetes-server-linux-arm64.tar.gz) | `efc32c8477efda554d8e82d6e52728f58e706d3d53d1072099b3297c310632e8adece6030427154287d5525e74158c0b44a33421b3dd0ffb57372d63768e82ec`
+[kubernetes-server-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.17.0-alpha.1/kubernetes-server-linux-ppc64le.tar.gz) | `bda4fce6f5be7d0102ff265e0ba10e4dab776caeba1cebdf57db9891a34b4974fa57ac014aa6eca2dcfc1b64e9f67c8168e18026ae30c72ba61205d180f6e8ff`
+[kubernetes-server-linux-s390x.tar.gz](https://dl.k8s.io/v1.17.0-alpha.1/kubernetes-server-linux-s390x.tar.gz) | `655c7157176f4f972c80877d73b0e390aaff455a5dcd046b469eb0f07d18ea1aaef447f90127be699e74518072ea1605652798fa431eb6ac7ee4e4fd85676362`
+
+### Node Binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-node-linux-amd64.tar.gz](https://dl.k8s.io/v1.17.0-alpha.1/kubernetes-node-linux-amd64.tar.gz) | `1ec25c0350973ed06f657f2b613eb07308a9a4f0af7e72ebc5730c3c8d39ce3139a567acc7a224bebbe4e3496633b6053082b7172e2ce76b228c4b697f03f3d1`
+[kubernetes-node-linux-arm.tar.gz](https://dl.k8s.io/v1.17.0-alpha.1/kubernetes-node-linux-arm.tar.gz) | `c65ac3db834596bcb9e81ffa5b94493244385073a232e9f7853759bce2b96a8199f79081d2f00a1b5502d53dc1e82a89afa97ffdb83994f67ebc261de9fb62b9`
+[kubernetes-node-linux-arm64.tar.gz](https://dl.k8s.io/v1.17.0-alpha.1/kubernetes-node-linux-arm64.tar.gz) | `0de8af66269db1ef7513f92811ec52a780abb3c9c49c0a4de9337eb987119bb583d03327c55353b4375d233e1a07a382cc91bdbf9477cf66e3f9e7fb0090499e`
+[kubernetes-node-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.17.0-alpha.1/kubernetes-node-linux-ppc64le.tar.gz) | `adb43c68cd5d1d52f254a14d80bb66667bfc8b367176ff2ed242184cf0b5accd3206bcbd42dec3f132bf1a230193812ae3e7a0c48f68634cb5f67538385e142a`
+[kubernetes-node-linux-s390x.tar.gz](https://dl.k8s.io/v1.17.0-alpha.1/kubernetes-node-linux-s390x.tar.gz) | `1c834cfc06b9ba4a6da3bca2d504b734c935436546bc9304c7933e256dba849d665d34e82f48180f3975a907d37fec5ffb929923352ff63e1d3ff84143eea65b`
+[kubernetes-node-windows-amd64.tar.gz](https://dl.k8s.io/v1.17.0-alpha.1/kubernetes-node-windows-amd64.tar.gz) | `6fc54fd17ebb65a6bd3d4efe93a713cc2aaea54599ddd3d73d01e93d6484087271b3ca65ed7a5861090356224140776a9606c10873b6b106bc9a6634c25b1677`
+
+## Changelog since v1.16.0
+
+### Action Required
+
+* The deprecated feature gates `GCERegionalPersistentDisk`, `EnableAggregatedDiscoveryTimeout` and `PersistentLocalVolumes` are now unconditionally enabled and can no longer be specified in component invocations. ([#82472](https://github.com/kubernetes/kubernetes/pull/82472), [@draveness](https://github.com/draveness))
+* ACTION REQUIRED: ([#81668](https://github.com/kubernetes/kubernetes/pull/81668), [@darshanime](https://github.com/darshanime))
+    * Deprecate the default service IP CIDR. The previous default was `10.0.0.0/24` which will be removed in 6 months/2 releases. Cluster admins must specify their own desired value, by using `--service-cluster-ip-range` on kube-apiserver.
+* Remove deprecated "include-uninitialized" flag. action required ([#80337](https://github.com/kubernetes/kubernetes/pull/80337), [@draveness](https://github.com/draveness))
+
+### Other notable changes
+
+* Bump version of event-exporter to 0.3.1, to switch it to protobuf. ([#83396](https://github.com/kubernetes/kubernetes/pull/83396), [@loburm](https://github.com/loburm))
+* kubeadm: use the --service-cluster-ip-range flag to init or use the ServiceSubnet field in the kubeadm config to pass a comma separated list of Service CIDRs.  ([#82473](https://github.com/kubernetes/kubernetes/pull/82473), [@Arvinderpal](https://github.com/Arvinderpal))
+* Remove MaxPriority in the scheduler API, please use MaxNodeScore or MaxExtenderPriority instead. ([#83386](https://github.com/kubernetes/kubernetes/pull/83386), [@draveness](https://github.com/draveness))
+* Fixes a goroutine leak in kube-apiserver when a request times out. ([#83333](https://github.com/kubernetes/kubernetes/pull/83333), [@lavalamp](https://github.com/lavalamp))
+* Some scheduler extender API fields are moved from `pkg/scheduler/api` to `pkg/scheduler/apis/extender/v1`. ([#83262](https://github.com/kubernetes/kubernetes/pull/83262), [@Huang-Wei](https://github.com/Huang-Wei))
+* Fix aggressive VM calls for Azure VMSS ([#83102](https://github.com/kubernetes/kubernetes/pull/83102), [@feiskyer](https://github.com/feiskyer))
+* Update Azure load balancer to prevent orphaned public IP addresses ([#82890](https://github.com/kubernetes/kubernetes/pull/82890), [@chewong](https://github.com/chewong))
+* Use online nodes instead of possible nodes when discovering available NUMA nodes ([#83196](https://github.com/kubernetes/kubernetes/pull/83196), [@zouyee](https://github.com/zouyee))
+* Fix typos in `certificates.k8s.io/v1beta1` KeyUsage constant names: `UsageContentCommittment` becomes `UsageContentCommitment` and `UsageNetscapSGC` becomes `UsageNetscapeSGC`. ([#82511](https://github.com/kubernetes/kubernetes/pull/82511), [@abursavich](https://github.com/abursavich))
+* Fixes the bug in informer-gen that it produces incorrect code if a type has nonNamespaced tag set. ([#80458](https://github.com/kubernetes/kubernetes/pull/80458), [@tatsuhiro-t](https://github.com/tatsuhiro-t))
+* Update to go 1.12.10 ([#83139](https://github.com/kubernetes/kubernetes/pull/83139), [@cblecker](https://github.com/cblecker))
+* Update crictl to v1.16.1. ([#82856](https://github.com/kubernetes/kubernetes/pull/82856), [@Random-Liu](https://github.com/Random-Liu))
+* Reduces the number of calls made to the Azure API when requesting the instance view of a virtual machine scale set node. ([#82496](https://github.com/kubernetes/kubernetes/pull/82496), [@hasheddan](https://github.com/hasheddan))
+* Consolidate ScoreWithNormalizePlugin into the ScorePlugin interface ([#83042](https://github.com/kubernetes/kubernetes/pull/83042), [@draveness](https://github.com/draveness))
+* On AWS nodes with multiple network interfaces, kubelet should now more reliably report the same primary node IP. ([#80747](https://github.com/kubernetes/kubernetes/pull/80747), [@danwinship](https://github.com/danwinship))
+* Fixes kube-proxy bug accessing self nodeip:port on windows ([#83027](https://github.com/kubernetes/kubernetes/pull/83027), [@liggitt](https://github.com/liggitt))
+* Resolves bottleneck in internal API server communication that can cause increased goroutines and degrade API Server performance ([#80465](https://github.com/kubernetes/kubernetes/pull/80465), [@answer1991](https://github.com/answer1991))
+* The deprecated mondo `kubernetes-test` tarball is no longer built. Users running Kubernetes e2e tests should use the `kubernetes-test-portable` and `kubernetes-test-{OS}-{ARCH}` tarballs instead. ([#83093](https://github.com/kubernetes/kubernetes/pull/83093), [@ixdy](https://github.com/ixdy))
+* Improved performance of kube-proxy with EndpointSlice enabled with more efficient sorting.  ([#83035](https://github.com/kubernetes/kubernetes/pull/83035), [@robscott](https://github.com/robscott))
+* New APIs to allow adding/removing pods from pre-calculated prefilter state in the scheduling framework ([#82912](https://github.com/kubernetes/kubernetes/pull/82912), [@ahg-g](https://github.com/ahg-g))
+* Conformance tests may now include disruptive tests. If you are running tests against a live cluster, consider skipping those tests tagged as `Disruptive` to avoid non-test workloads being impacted. Be aware, skipping any conformance tests (even disruptive ones) will make the results ineligible for consideration for the CNCF Certified Kubernetes program. ([#82664](https://github.com/kubernetes/kubernetes/pull/82664), [@johnSchnake](https://github.com/johnSchnake))
+* Resolves regression generating informers for packages whose names contain `.` characters ([#82410](https://github.com/kubernetes/kubernetes/pull/82410), [@nikhita](https://github.com/nikhita))
+* Added metrics 'authentication_latency_seconds' that can be used to understand the latency of authentication. ([#82409](https://github.com/kubernetes/kubernetes/pull/82409), [@RainbowMango](https://github.com/RainbowMango))
+* kube-dns add-on:  ([#82347](https://github.com/kubernetes/kubernetes/pull/82347), [@pjbgf](https://github.com/pjbgf))
+    * - All containers are now being executed under more restrictive privileges.
+    * - Most of the containers now run as non-root user and has the root filesystem set as read-only.
+    * - The remaining container running as root only has the minimum Linux capabilities it requires to run.
+    * - Privilege escalation has been disabled for all containers.
+* k8s dockerconfigjson secrets are now compatible with docker config desktop authentication credentials files ([#82148](https://github.com/kubernetes/kubernetes/pull/82148), [@bbourbie](https://github.com/bbourbie))
+* Use ipv4 in wincat port forward. ([#83036](https://github.com/kubernetes/kubernetes/pull/83036), [@liyanhui1228](https://github.com/liyanhui1228))
+* Added Clone method to the scheduling framework's PluginContext and ContextData. ([#82951](https://github.com/kubernetes/kubernetes/pull/82951), [@ahg-g](https://github.com/ahg-g))
+* Bump metrics-server to v0.3.5 ([#83015](https://github.com/kubernetes/kubernetes/pull/83015), [@olagacek](https://github.com/olagacek))
+* dashboard: disable the dashboard Deployment on non-Linux nodes. This step is required to support Windows worker nodes. ([#82975](https://github.com/kubernetes/kubernetes/pull/82975), [@wawa0210](https://github.com/wawa0210))
+* Fix possible fd leak and closing of dirs when using openstack ([#82873](https://github.com/kubernetes/kubernetes/pull/82873), [@odinuge](https://github.com/odinuge))
+* PersistentVolumeLabel admission plugin, responsible for labeling `PersistentVolumes` with topology labels, now does not overwrite existing labels on PVs that were dynamically provisioned. It trusts the  dynamic provisioning that it provided the correct labels to the `PersistentVolume`, saving one potentially expensive cloud API call. `PersistentVolumes` created manually by users are labelled by the admission plugin in the same way as before. ([#82830](https://github.com/kubernetes/kubernetes/pull/82830), [@jsafrane](https://github.com/jsafrane))
+* Fixes a panic in kube-controller-manager cleaning up bootstrap tokens ([#82887](https://github.com/kubernetes/kubernetes/pull/82887), [@tedyu](https://github.com/tedyu))
+* Fixed a scheduler panic when using PodAffinity. ([#82841](https://github.com/kubernetes/kubernetes/pull/82841), [@Huang-Wei](https://github.com/Huang-Wei))
+* Modified the scheduling framework's Filter API. ([#82842](https://github.com/kubernetes/kubernetes/pull/82842), [@ahg-g](https://github.com/ahg-g))
+* Fix panic in kubelet when running IPv4/IPv6 dual-stack mode with a CNI plugin ([#82508](https://github.com/kubernetes/kubernetes/pull/82508), [@aanm](https://github.com/aanm))
+* Kubernetes no longer monitors firewalld. On systems using firewalld for firewall ([#81517](https://github.com/kubernetes/kubernetes/pull/81517), [@danwinship](https://github.com/danwinship))
+    * maintenance, kube-proxy will take slightly longer to recover from disruptive
+    * firewalld operations that delete kube-proxy's iptables rules.
+* Added cloud operation count metrics to azure cloud controller manager. ([#82574](https://github.com/kubernetes/kubernetes/pull/82574), [@kkmsft](https://github.com/kkmsft))
+* Report non-confusing error for negative storage size in PVC spec. ([#82759](https://github.com/kubernetes/kubernetes/pull/82759), [@sttts](https://github.com/sttts))
+* When registering with a 1.17+ API server, MutatingWebhookConfiguration and ValidatingWebhookConfiguration objects can now request that only `v1` AdmissionReview requests be sent to them. Previously, webhooks were required to support receiving `v1beta1` AdmissionReview requests as well for compatibility with API servers <= 1.15. ([#82707](https://github.com/kubernetes/kubernetes/pull/82707), [@liggitt](https://github.com/liggitt))
+        * When registering with a 1.17+ API server, a CustomResourceDefinition conversion webhook can now request that only `v1` ConversionReview requests be sent to them. Previously, conversion webhooks were required to support receiving `v1beta1` ConversionReview requests as well for compatibility with API servers <= 1.15.
+* Resolves issue with /readyz and /livez not including etcd and kms health checks ([#82713](https://github.com/kubernetes/kubernetes/pull/82713), [@logicalhan](https://github.com/logicalhan))
+* fix: azure disk detach failure if node not exists ([#82640](https://github.com/kubernetes/kubernetes/pull/82640), [@andyzhangx](https://github.com/andyzhangx))
+* Single static pod files and pod files from http endpoints cannot be larger than 10 MB. HTTP probe payloads are now truncated to 10KB. ([#82669](https://github.com/kubernetes/kubernetes/pull/82669), [@rphillips](https://github.com/rphillips))
+* Restores compatibility with <=1.15.x custom resources by not publishing OpenAPI for non-structural custom resource definitions ([#82653](https://github.com/kubernetes/kubernetes/pull/82653), [@liggitt](https://github.com/liggitt))
+* Take the context as the first argument of Schedule. ([#82119](https://github.com/kubernetes/kubernetes/pull/82119), [@wgliang](https://github.com/wgliang))
+* Fixes regression in logging spurious stack traces when proxied connections are closed by the backend ([#82588](https://github.com/kubernetes/kubernetes/pull/82588), [@liggitt](https://github.com/liggitt))
+* Correct a reference to a not/no longer used kustomize subcommand in the documentation ([#82535](https://github.com/kubernetes/kubernetes/pull/82535), [@demobox](https://github.com/demobox))
+* Limit the body length of exec readiness/liveness probes. remote CRIs and Docker shim read a max of 16MB output of which the exec probe itself inspects 10kb. ([#82514](https://github.com/kubernetes/kubernetes/pull/82514), [@dims](https://github.com/dims))
+* fixed an issue that the correct PluginConfig.Args is not passed to the corresponding PluginFactory in kube-scheduler when multiple PluginConfig items are defined. ([#82483](https://github.com/kubernetes/kubernetes/pull/82483), [@everpeace](https://github.com/everpeace))
+* Adding TerminationGracePeriodSeconds to the test framework API ([#82170](https://github.com/kubernetes/kubernetes/pull/82170), [@vivekbagade](https://github.com/vivekbagade))
+* /test/e2e/framework: Adds a flag "non-blocking-taints" which allows tests to run in environments with tainted nodes. String value should be a comma-separated list. ([#81043](https://github.com/kubernetes/kubernetes/pull/81043), [@johnSchnake](https://github.com/johnSchnake))

--- a/CHANGELOG/CHANGELOG-1.18.md
+++ b/CHANGELOG/CHANGELOG-1.18.md
@@ -1,0 +1,2130 @@
+<!-- BEGIN MUNGE: GENERATED_TOC -->
+
+- [v1.18.6](#v1186)
+  - [Downloads for v1.18.6](#downloads-for-v1186)
+    - [Source Code](#source-code)
+    - [Client binaries](#client-binaries)
+    - [Server binaries](#server-binaries)
+    - [Node binaries](#node-binaries)
+  - [Changelog since v1.18.5](#changelog-since-v1185)
+  - [Urgent Upgrade Notes](#urgent-upgrade-notes)
+    - [(No, really, you MUST read this before you upgrade)](#no-really-you-must-read-this-before-you-upgrade)
+  - [Changes by Kind](#changes-by-kind)
+    - [API Change](#api-change)
+    - [Bug or Regression](#bug-or-regression)
+  - [Dependencies](#dependencies)
+    - [Added](#added)
+    - [Changed](#changed)
+    - [Removed](#removed)
+- [v1.18.5](#v1185)
+  - [Downloads for v1.18.5](#downloads-for-v1185)
+    - [Source Code](#source-code-1)
+    - [Client binaries](#client-binaries-1)
+    - [Server binaries](#server-binaries-1)
+    - [Node binaries](#node-binaries-1)
+  - [Changelog since v1.18.4](#changelog-since-v1184)
+  - [Changes by Kind](#changes-by-kind-1)
+    - [API Change](#api-change-1)
+    - [Bug or Regression](#bug-or-regression-1)
+  - [Dependencies](#dependencies-1)
+    - [Added](#added-1)
+    - [Changed](#changed-1)
+    - [Removed](#removed-1)
+- [v1.18.5-rc.1](#v1185-rc1)
+  - [Downloads for v1.18.5-rc.1](#downloads-for-v1185-rc1)
+    - [Source Code](#source-code-2)
+    - [Client binaries](#client-binaries-2)
+    - [Server binaries](#server-binaries-2)
+    - [Node binaries](#node-binaries-2)
+  - [Changelog since v1.18.4](#changelog-since-v1184-1)
+  - [Changes by Kind](#changes-by-kind-2)
+    - [API Change](#api-change-2)
+    - [Bug or Regression](#bug-or-regression-2)
+  - [Dependencies](#dependencies-2)
+    - [Added](#added-2)
+    - [Changed](#changed-2)
+    - [Removed](#removed-2)
+- [v1.18.4](#v1184)
+  - [Downloads for v1.18.4](#downloads-for-v1184)
+    - [Source Code](#source-code-3)
+    - [Client binaries](#client-binaries-3)
+    - [Server binaries](#server-binaries-3)
+    - [Node binaries](#node-binaries-3)
+  - [Changelog since v1.18.3](#changelog-since-v1183)
+  - [Changes by Kind](#changes-by-kind-3)
+    - [API Change](#api-change-3)
+    - [Feature](#feature)
+    - [Bug or Regression](#bug-or-regression-3)
+    - [Other (Cleanup or Flake)](#other-cleanup-or-flake)
+  - [Dependencies](#dependencies-3)
+    - [Added](#added-3)
+    - [Changed](#changed-3)
+    - [Removed](#removed-3)
+- [v1.18.3](#v1183)
+  - [Downloads for v1.18.3](#downloads-for-v1183)
+    - [Source Code](#source-code-4)
+    - [Client binaries](#client-binaries-4)
+    - [Server binaries](#server-binaries-4)
+    - [Node binaries](#node-binaries-4)
+  - [Changelog since v1.18.2](#changelog-since-v1182)
+  - [Changes by Kind](#changes-by-kind-4)
+    - [Bug or Regression](#bug-or-regression-4)
+    - [Other (Cleanup or Flake)](#other-cleanup-or-flake-1)
+  - [Dependencies](#dependencies-4)
+    - [Added](#added-4)
+    - [Changed](#changed-4)
+    - [Removed](#removed-4)
+- [v1.18.2](#v1182)
+  - [Downloads for v1.18.2](#downloads-for-v1182)
+    - [Client Binaries](#client-binaries-5)
+    - [Server Binaries](#server-binaries-5)
+    - [Node Binaries](#node-binaries-5)
+  - [Changelog since v1.18.1](#changelog-since-v1181)
+  - [Changes by Kind](#changes-by-kind-5)
+    - [Bug or Regression](#bug-or-regression-5)
+- [v1.18.1](#v1181)
+  - [Downloads for v1.18.1](#downloads-for-v1181)
+    - [Client Binaries](#client-binaries-6)
+    - [Server Binaries](#server-binaries-6)
+    - [Node Binaries](#node-binaries-6)
+  - [Changelog since v1.18.0](#changelog-since-v1180)
+  - [Changes by Kind](#changes-by-kind-6)
+    - [Feature](#feature-1)
+    - [Other (Bug, Cleanup or Flake)](#other-bug-cleanup-or-flake)
+- [v1.18.0](#v1180)
+  - [Downloads for v1.18.0](#downloads-for-v1180)
+    - [Client Binaries](#client-binaries-7)
+    - [Server Binaries](#server-binaries-7)
+    - [Node Binaries](#node-binaries-7)
+  - [Changelog since v1.17.0](#changelog-since-v1170)
+  - [What’s New (Major Themes)](#what’s-new-major-themes)
+    - [Kubernetes Topology Manager Moves to Beta - Align Up!](#kubernetes-topology-manager-moves-to-beta---align-up)
+    - [Serverside Apply - Beta 2](#serverside-apply---beta-2)
+    - [Extending Ingress with and replacing a deprecated annotation with IngressClass](#extending-ingress-with-and-replacing-a-deprecated-annotation-with-ingressclass)
+    - [SIG CLI introduces kubectl debug](#sig-cli-introduces-kubectl-debug)
+    - [Introducing Windows CSI support alpha for Kubernetes](#introducing-windows-csi-support-alpha-for-kubernetes)
+    - [Other notable announcements](#other-notable-announcements)
+  - [Known Issues](#known-issues)
+  - [Urgent Upgrade Notes](#urgent-upgrade-notes-1)
+    - [(No, really, you MUST read this before you upgrade)](#no-really-you-must-read-this-before-you-upgrade-1)
+      - [kube-apiserver:](#kube-apiserver:)
+      - [kubelet:](#kubelet:)
+      - [kubectl:](#kubectl:)
+      - [client-go:](#client-go:)
+    - [Changes by Kind](#changes-by-kind-7)
+      - [Deprecation](#deprecation)
+        - [kube-apiserver:](#kube-apiserver:-1)
+        - [kube-controller-manager:](#kube-controller-manager:)
+        - [kubelet:](#kubelet:-1)
+        - [kube-proxy:](#kube-proxy:)
+        - [kubeadm:](#kubeadm:)
+        - [kubectl:](#kubectl:-1)
+        - [add-ons:](#add-ons:)
+        - [kube-scheduler:](#kube-scheduler:)
+        - [Other deprecations:](#other-deprecations:)
+      - [API Change](#api-change-4)
+        - [New API types/versions:](#new-api-types/versions:)
+        - [New API fields:](#new-api-fields:)
+        - [Other API changes:](#other-api-changes:)
+        - [Configuration file changes:](#configuration-file-changes:)
+        - [kube-apiserver:](#kube-apiserver:-2)
+        - [kube-scheduler:](#kube-scheduler:-1)
+        - [kube-proxy:](#kube-proxy:-1)
+        - [Features graduated to beta:](#features-graduated-to-beta:)
+        - [Features graduated to GA:](#features-graduated-to-ga:)
+      - [Feature](#feature-2)
+        - [Metrics:](#metrics:)
+      - [Other (Bug, Cleanup or Flake)](#other-bug-cleanup-or-flake-1)
+    - [Dependencies](#dependencies-5)
+- [v1.18.0-rc.1](#v1180-rc1)
+  - [Downloads for v1.18.0-rc.1](#downloads-for-v1180-rc1)
+    - [Client Binaries](#client-binaries-8)
+    - [Server Binaries](#server-binaries-8)
+    - [Node Binaries](#node-binaries-8)
+  - [Changelog since v1.18.0-beta.2](#changelog-since-v1180-beta2)
+  - [Changes by Kind](#changes-by-kind-8)
+    - [API Change](#api-change-5)
+    - [Other (Bug, Cleanup or Flake)](#other-bug-cleanup-or-flake-2)
+- [v1.18.0-beta.2](#v1180-beta2)
+  - [Downloads for v1.18.0-beta.2](#downloads-for-v1180-beta2)
+    - [Client Binaries](#client-binaries-9)
+    - [Server Binaries](#server-binaries-9)
+    - [Node Binaries](#node-binaries-9)
+  - [Changelog since v1.18.0-beta.1](#changelog-since-v1180-beta1)
+  - [Urgent Upgrade Notes](#urgent-upgrade-notes-2)
+    - [(No, really, you MUST read this before you upgrade)](#no-really-you-must-read-this-before-you-upgrade-2)
+  - [Changes by Kind](#changes-by-kind-9)
+    - [Deprecation](#deprecation-1)
+    - [API Change](#api-change-6)
+    - [Feature](#feature-3)
+    - [Documentation](#documentation)
+    - [Other (Bug, Cleanup or Flake)](#other-bug-cleanup-or-flake-3)
+- [v1.18.0-beta.1](#v1180-beta1)
+  - [Downloads for v1.18.0-beta.1](#downloads-for-v1180-beta1)
+    - [Client Binaries](#client-binaries-10)
+    - [Server Binaries](#server-binaries-10)
+    - [Node Binaries](#node-binaries-10)
+  - [Changelog since v1.18.0-beta.0](#changelog-since-v1180-beta0)
+  - [Urgent Upgrade Notes](#urgent-upgrade-notes-3)
+    - [(No, really, you MUST read this before you upgrade)](#no-really-you-must-read-this-before-you-upgrade-3)
+  - [Changes by Kind](#changes-by-kind-10)
+    - [Deprecation](#deprecation-2)
+    - [API Change](#api-change-7)
+- [v1.18.0-alpha.1](#v1180-alpha1)
+  - [Downloads for v1.18.0-alpha.1](#downloads-for-v1180-alpha1)
+    - [Client Binaries](#client-binaries-11)
+    - [Server Binaries](#server-binaries-11)
+    - [Node Binaries](#node-binaries-11)
+  - [Changelog since v1.17.0](#changelog-since-v1170-1)
+    - [Action Required](#action-required)
+    - [Other notable changes](#other-notable-changes)
+
+<!-- END MUNGE: GENERATED_TOC -->
+
+# v1.18.6
+
+
+## Downloads for v1.18.6
+
+### Source Code
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes.tar.gz](https://dl.k8s.io/v1.18.6/kubernetes.tar.gz) | f036e891ff8dd95df33722b4d13ea2dc36fd8cb0a18fe88654919eb180cadba7724da55b96ea9707a11aaa91021bd6478a0c6eae684034e030717beb4c94f018
+[kubernetes-src.tar.gz](https://dl.k8s.io/v1.18.6/kubernetes-src.tar.gz) | 460551dcde2288a7f3b90ad0720cf479cd38d64e386fedf66d580c4cd547a0e1835437437bdfb8b28c6dd707164abf0ddf4ea761d9f110945b80800f71b953b0
+
+### Client binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-client-darwin-386.tar.gz](https://dl.k8s.io/v1.18.6/kubernetes-client-darwin-386.tar.gz) | 85c4d72f50965a1ecc3e67c02335ec5ae57d8c9617cc79a34a05e1ed3b84e8f80be2901f6f31185a383a85f63ea7fe638b07eb6851a3758b835bf319a5df852d
+[kubernetes-client-darwin-amd64.tar.gz](https://dl.k8s.io/v1.18.6/kubernetes-client-darwin-amd64.tar.gz) | b01c47bd6a16eed131245fb90abfb8b585c14953f9398f11a1ec402b808305ce1fbcabd215b253d805224f2fb41ddeb502239f67dd0634e648279e449fc0ea63
+[kubernetes-client-linux-386.tar.gz](https://dl.k8s.io/v1.18.6/kubernetes-client-linux-386.tar.gz) | 15262c62b8b9bf85c8dd8ead7ed0c384114e09ad3120d7e13956c99d93203b5f9561f923055451e46bcb2a4efa19db43e23ff4d2a9281114bd85a67a6269d841
+[kubernetes-client-linux-amd64.tar.gz](https://dl.k8s.io/v1.18.6/kubernetes-client-linux-amd64.tar.gz) | d061bc34c0df55e766d72c066ef366864c77eff5d0033d29869fc871d2e674d86322a6c5dc3f05ed2d95971ca0e6ea3dd1dc1f57bf1825c9bf834963385a3de6
+[kubernetes-client-linux-arm.tar.gz](https://dl.k8s.io/v1.18.6/kubernetes-client-linux-arm.tar.gz) | 7eb961bff92146952d9cda2b741c8d349838ef66112c6b296f1426eeb79357b95d4e15d5520e8903a881c21bf629b58ce72d986a88620333120b786c415eba35
+[kubernetes-client-linux-arm64.tar.gz](https://dl.k8s.io/v1.18.6/kubernetes-client-linux-arm64.tar.gz) | bb863a4bf6d0fd400274536c6571cd35531d92fa40d38703ef126accc94d08a4e381f6c05840806e81d564161ebe08a99aa73d767ddf1a60b7a7062df704b920
+[kubernetes-client-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.18.6/kubernetes-client-linux-ppc64le.tar.gz) | 71e0ac8298dca06be5aed01c3a2f12389405bfd1e3edff63a849b8663a7b118543e960dca0a920a598f649cce76f58ac2664ea1db9fd69e484e843f27bac4664
+[kubernetes-client-linux-s390x.tar.gz](https://dl.k8s.io/v1.18.6/kubernetes-client-linux-s390x.tar.gz) | 673161c816dfd2369609402461c645a3cc023a09fd9e1418c0fff601c1f5d71f72b43857ef66973af0ee4d8871a52cf914c533fa955f104d327bb28ad6e13ab9
+[kubernetes-client-windows-386.tar.gz](https://dl.k8s.io/v1.18.6/kubernetes-client-windows-386.tar.gz) | 017654b27b06afc219dcf5b590a63a917470f698611bd0348e5a27ea8e30c8178b47786a8491c70e1c3ba7559e7831fc77b636c092fb1946db795e9ec679c140
+[kubernetes-client-windows-amd64.tar.gz](https://dl.k8s.io/v1.18.6/kubernetes-client-windows-amd64.tar.gz) | d2f5bee260a135007185f8b68a11a6ea10f94e548feb4614dca9a428bbb7ad91a6fb4a58efc67b242e6348b5f0eb436f863cadad2e72cdc5fee4c0414ab54db3
+
+### Server binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-server-linux-amd64.tar.gz](https://dl.k8s.io/v1.18.6/kubernetes-server-linux-amd64.tar.gz) | 73cfa5e458205ff81cfa6672c0f6ef10aadbad1244c81b259c3cf9c22c6c9e9272a69778b0417e2353fe9970bfeed23de8ad7dee223de7a487ba4bdf94cd8682
+[kubernetes-server-linux-arm.tar.gz](https://dl.k8s.io/v1.18.6/kubernetes-server-linux-arm.tar.gz) | b8723379e26de43ae0bfe5a64d65beb0f79d4820c02a1b9aae4c80f2b1882b952d587fe1fb87cc202b618ec66f5c1392f6bf94acfad44b84f3b6f33994cd0af9
+[kubernetes-server-linux-arm64.tar.gz](https://dl.k8s.io/v1.18.6/kubernetes-server-linux-arm64.tar.gz) | 47dc425387f98028d32f40610124ecc70162132c339d97f578dbb8a6b7f98f25a20d356d12e6d04b40e62b6f8636bf20617735acddb482f9c4da24c928f31cb4
+[kubernetes-server-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.18.6/kubernetes-server-linux-ppc64le.tar.gz) | b6fbb68288300ef28c710d65a8acd6bceda13ec4c5b156c1395b98310c74babe1dca44ebfccf33eebd8147a7f5f7276930721e1f38854a3b6c2ddbac28c51a83
+[kubernetes-server-linux-s390x.tar.gz](https://dl.k8s.io/v1.18.6/kubernetes-server-linux-s390x.tar.gz) | c77d6661461b230fe934c100a2eedf295e394d0c818bc5c21e0db496b08e10ada8a101bb9b402c5fed566cff39ca6be6766dcda7f536b7e9f671f2703da589c7
+
+### Node binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-node-linux-amd64.tar.gz](https://dl.k8s.io/v1.18.6/kubernetes-node-linux-amd64.tar.gz) | f3d3cc4b38dff84a0c4e1b2364b8f7a000fa86395b7ccab22905f51c7b876c7524a9da61b5447bf761aba0e2015c557715abc573869340e46a616beca33d07c2
+[kubernetes-node-linux-arm.tar.gz](https://dl.k8s.io/v1.18.6/kubernetes-node-linux-arm.tar.gz) | 63d2601741fe159b742141f3ff85293e328808ff056e87f81af502da817e4813e963c61121bce53c4fd19250392808ed36181ccd67c2a18b02317379a0d93c0f
+[kubernetes-node-linux-arm64.tar.gz](https://dl.k8s.io/v1.18.6/kubernetes-node-linux-arm64.tar.gz) | 85d24d99e4408dfa00e306ff90eb4b86260feba40cf8e3770845838f0af319dce674b04b9bf8700d46765e620f84f4bf11463b46cf40ef118c2fd000156c7214
+[kubernetes-node-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.18.6/kubernetes-node-linux-ppc64le.tar.gz) | 1cef745e18704c77f7c31514ca9bf0eb5be676b3fb80affa2cfc482089e7210f14e42c89cd7284f070d6d8a45ba253634294c2db5393d7ac74e8ce28e7395550
+[kubernetes-node-linux-s390x.tar.gz](https://dl.k8s.io/v1.18.6/kubernetes-node-linux-s390x.tar.gz) | 452fc8743c80e05ca0ad6d9267b6a133497bd7779ee74d5a96195d87e68e3e906dcc5a9d6154a9ecf70cc2a05f4e12ffb4a1d7874e979b2ed204facc0c0ff5b9
+[kubernetes-node-windows-amd64.tar.gz](https://dl.k8s.io/v1.18.6/kubernetes-node-windows-amd64.tar.gz) | 09113c05a14c34ac07ba4f635e152d983b6822ef95a7034df56a9fca3634388f90416076c6d8d64a02dd2e6188ed6529582b6093e441cef74dd8716f48fbdb16
+
+## Changelog since v1.18.5
+
+## Urgent Upgrade Notes
+
+### (No, really, you MUST read this before you upgrade)
+
+ - CVE-2020-8559 (Medium): Privilege escalation from compromised node to cluster. See https://github.com/kubernetes/kubernetes/issues/92914 for more details.
+  The API Server will no longer proxy non-101 responses for upgrade requests. This could break proxied backends (such as an extension API server) that respond to upgrade requests with a non-101 response code. ([#92941](https://github.com/kubernetes/kubernetes/pull/92941), [@tallclair](https://github.com/tallclair)) [SIG API Machinery]
+ 
+## Changes by Kind
+
+### API Change
+
+- Fix bug in reflector that couldn't recover from "Too large resource version" errors ([#92537](https://github.com/kubernetes/kubernetes/pull/92537), [@wojtek-t](https://github.com/wojtek-t)) [SIG API Machinery]
+
+### Bug or Regression
+
+- CVE-2020-8557 (Medium): Node-local denial of service via container /etc/hosts file. See https://github.com/kubernetes/kubernetes/issues/93032 for more details. ([#92916](https://github.com/kubernetes/kubernetes/pull/92916), [@joelsmith](https://github.com/joelsmith)) [SIG Node]
+- Containers which specify a `startupProbe` but not a `readinessProbe` were previously considered "ready" before the `startupProbe` completed, but are now considered "not-ready". ([#92196](https://github.com/kubernetes/kubernetes/pull/92196), [@thockin](https://github.com/thockin)) [SIG Node]
+- Extend kube-apiserver /readyz with new "informer-sync" check ensuring that internal informers are synced. ([#92644](https://github.com/kubernetes/kubernetes/pull/92644), [@wojtek-t](https://github.com/wojtek-t)) [SIG API Machinery and Testing]
+- Fix throttling issues when Azure VM computer name prefix is different from VMSS name ([#92793](https://github.com/kubernetes/kubernetes/pull/92793), [@feiskyer](https://github.com/feiskyer)) [SIG Cloud Provider]
+- Fix: GetLabelsForVolume panic issue for azure disk PV ([#92166](https://github.com/kubernetes/kubernetes/pull/92166), [@andyzhangx](https://github.com/andyzhangx)) [SIG Cloud Provider]
+- Fix: don't use docker config cache if it's empty ([#92330](https://github.com/kubernetes/kubernetes/pull/92330), [@andyzhangx](https://github.com/andyzhangx)) [SIG Cloud Provider]
+- Fix: use force detach for azure disk ([#91948](https://github.com/kubernetes/kubernetes/pull/91948), [@andyzhangx](https://github.com/andyzhangx)) [SIG Cloud Provider]
+- Fixes a problem with 63-second or 1-second connection delays with some VXLAN-based
+  network plugins which was first widely noticed in 1.16 (though some users saw it
+  earlier than that, possibly only with specific network plugins). If you were previously
+  using ethtool to disable checksum offload on your primary network interface, you should
+  now be able to stop doing that. ([#92035](https://github.com/kubernetes/kubernetes/pull/92035), [@danwinship](https://github.com/danwinship)) [SIG Network and Node]
+- Kubeadm: add the deprecated flag --port=0 to kube-controller-manager and kube-scheduler manifests to disable insecure serving. Without this flag the components by default serve (e.g. /metrics) insecurely on the default node interface (controlled by --address). Users that wish to override this behavior and enable insecure serving can pass a custom --port=X via kubeadm's "extraArgs" mechanic for these components. ([#92720](https://github.com/kubernetes/kubernetes/pull/92720), [@neolit123](https://github.com/neolit123)) [SIG Cluster Lifecycle]
+- Kubeadm: during "join", don't re-add an etcd member if it already exists in the cluster. ([#92118](https://github.com/kubernetes/kubernetes/pull/92118), [@neolit123](https://github.com/neolit123)) [SIG Cluster Lifecycle]
+- hyperkube: Use debian-hyperkube-base@v1.1.1 image
+  
+    Includes iproute2 to fix a regression in hyperkube images
+    when using hyperkube as a kubelet ([#92624](https://github.com/kubernetes/kubernetes/pull/92624), [@justaugustus](https://github.com/justaugustus)) [SIG Cluster Lifecycle, Network and Release]
+
+## Dependencies
+
+### Added
+_Nothing has changed._
+
+### Changed
+_Nothing has changed._
+
+### Removed
+_Nothing has changed._
+
+
+
+# v1.18.5
+
+
+## Downloads for v1.18.5
+
+### Source Code
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes.tar.gz](https://dl.k8s.io/v1.18.5/kubernetes.tar.gz) | 1e414d955cdde67e1883be27cb47963a905b73e8454bd1b2e665395348c1a88c444136380584bac97b6e50a1f1eafa7d4e3d3a26c9c0bc6aee63fbbdd261489c
+[kubernetes-src.tar.gz](https://dl.k8s.io/v1.18.5/kubernetes-src.tar.gz) | 9ddcd8b517e3cf78113ef977c365d26f0f27fe9b7fd9410f0214fd38cd38c6de6f37d7fbe2bb398587caceb4ae484afc2fe7ae14b80b70fe728405f3d5bd4115
+
+### Client binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-client-darwin-386.tar.gz](https://dl.k8s.io/v1.18.5/kubernetes-client-darwin-386.tar.gz) | 197583cb641dab50d6ad9f1f9929ce45a59f98a3ebe315cf1d7edef8df7aba1e1838cf1fb9414423d81c8575820c27a0c20183bd6ce5fd5df85bd7692a6aff2a
+[kubernetes-client-darwin-amd64.tar.gz](https://dl.k8s.io/v1.18.5/kubernetes-client-darwin-amd64.tar.gz) | d0f54e949850c2321081e722367d7baa5c805e0ba1d8b2f651254e0d7b26bbd9c87c7c7f5ac7b8fd55a2a4c1af08f2f18ccef00d2c1c5c89d51b27903f024155
+[kubernetes-client-linux-386.tar.gz](https://dl.k8s.io/v1.18.5/kubernetes-client-linux-386.tar.gz) | 6d04e1aad657e60d3c2b28f0c9c5b0a63fff8c4a35f24f96feccd19ce1d1e65a942bbb5a5eb291297020e1334d67a4c6bea9b48510fd7f94aed70af61b7543a5
+[kubernetes-client-linux-amd64.tar.gz](https://dl.k8s.io/v1.18.5/kubernetes-client-linux-amd64.tar.gz) | 01e9c71d65c4513c03b22b2b036c3e92875fa4ebdb43b4909a6b21608093d280d9f71953f9656b3728019bdc8cb6bbf864de3c6a3eb94d807ec0330dbccfa005
+[kubernetes-client-linux-arm.tar.gz](https://dl.k8s.io/v1.18.5/kubernetes-client-linux-arm.tar.gz) | b33f901d13bae3824938e0d0c98f50a50ec7335979d6f9e56c06209898619c40f49d0380b7101143484de635bee347cedc5b653a21ae0daab4f7f6a6b11d41c0
+[kubernetes-client-linux-arm64.tar.gz](https://dl.k8s.io/v1.18.5/kubernetes-client-linux-arm64.tar.gz) | ae2f4e5fec58ff47ca2bf91290684c969160ffb89b2574f57f0818fef4d63c4d9b3ea1f8c6a34f4d83acd907b82e3668cdf31dc38042d75ee12afc695a8a2a4a
+[kubernetes-client-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.18.5/kubernetes-client-linux-ppc64le.tar.gz) | 9ebc84fa31184a9d07cbc98abb608c4b48414fb80021b4a4431929baf4c34bcccad9a2f9320cebfc7e662c6ab315bd497a56b5dac7954e0ce1727d493b24cbb8
+[kubernetes-client-linux-s390x.tar.gz](https://dl.k8s.io/v1.18.5/kubernetes-client-linux-s390x.tar.gz) | bbe07152faedb0dc91e6786f4b63eaa79f4bca41b1c9125f70b90e319fda8a7e95033b080f7eb02d55bee39a96192bf3935f935981305340245ab84f3fece4e8
+[kubernetes-client-windows-386.tar.gz](https://dl.k8s.io/v1.18.5/kubernetes-client-windows-386.tar.gz) | 2fdf489d8ce8ee5336f953e268e538bfe6748e7afd805031bc3e525e4b823033e8121c119ef23ef3afc73199ece36fc51cb75871c312bb7ccac1ddaf3c1b245f
+[kubernetes-client-windows-amd64.tar.gz](https://dl.k8s.io/v1.18.5/kubernetes-client-windows-amd64.tar.gz) | 4894700a4406273dff08f36012780216b5c822180944c6e7161c8564c07f4a77f0d798f947b2e6f617ae60073834c9ff546045d98dc51c166fbc4c998ea2a00b
+
+### Server binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-server-linux-amd64.tar.gz](https://dl.k8s.io/v1.18.5/kubernetes-server-linux-amd64.tar.gz) | 40ed152be522f9793d61721f352ab30db072882512fdf7b9c2d42f057cc30b0ae1ca46e52a98da09f4b66b266a04b4bbcf257e3174eba653ca9cef5fbc052ef7
+[kubernetes-server-linux-arm.tar.gz](https://dl.k8s.io/v1.18.5/kubernetes-server-linux-arm.tar.gz) | 8483f12ba4d5263e3029fe658e965da4be62479eb48a6c6d5aa72cf6c344bed3350b3a506a6a23fdf9bf86287930d9329f24b28a3d39628f7224afaf00a2cefa
+[kubernetes-server-linux-arm64.tar.gz](https://dl.k8s.io/v1.18.5/kubernetes-server-linux-arm64.tar.gz) | b7bb94940fcc16f777321289ef865d8689a630311e6fd0ccc945e1195c805e2b32343a7ee11a65a6f49e5c3b3264321cdfbc7c18265e0e39878b660488d6ead2
+[kubernetes-server-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.18.5/kubernetes-server-linux-ppc64le.tar.gz) | 1c82fd55ff1d1496ae2281f9c6df391c3161665e828560efafd3a5269d0745ad14e210b05108e0b32e167a141f58ff08da917ef5eebb47c19d64039a004ed81a
+[kubernetes-server-linux-s390x.tar.gz](https://dl.k8s.io/v1.18.5/kubernetes-server-linux-s390x.tar.gz) | 99f29e8159a79655d8f86b41a89e868127a18086519786a3724fc2bbc83734613716d76fa524f563fd17231496759b224d208dcafdcebf8475b04fb556a5ea8a
+
+### Node binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-node-linux-amd64.tar.gz](https://dl.k8s.io/v1.18.5/kubernetes-node-linux-amd64.tar.gz) | 3bb05fe8e3f3aa52f7290cc33b606125d4ed666583d3265bac019486e8e7e5956e68a8adba849f5bf57e37ae1f784ecae42b53ae8a0e820575f6ac7553044067
+[kubernetes-node-linux-arm.tar.gz](https://dl.k8s.io/v1.18.5/kubernetes-node-linux-arm.tar.gz) | c16db681b24e3094f09b51971c94bf5f8d8347decf0e6e9fab0902b3f17e5d78f9d0908b840fcc5c29bfa38d0ffdb7ca7dbbe7e48fc3b406e748fe6de9f3f092
+[kubernetes-node-linux-arm64.tar.gz](https://dl.k8s.io/v1.18.5/kubernetes-node-linux-arm64.tar.gz) | ddccd9b3844bec9d237373c64f27f4e9c065d70ba0633fafb5ffd9abffd510358d08c7f5d70dd0aa9b1ef7d4e0e20e9c94e8e389b968e5d6c18a9f98723ccb10
+[kubernetes-node-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.18.5/kubernetes-node-linux-ppc64le.tar.gz) | f36dd5017eecc6abfdaabf8ec3e91f050a0e5afb82575dbc8f37aa0fdfcb83dab144e649b5381ac8e8ec7e2fd8b50eec1044d8e342b6cbfd2bebcd92cd962171
+[kubernetes-node-linux-s390x.tar.gz](https://dl.k8s.io/v1.18.5/kubernetes-node-linux-s390x.tar.gz) | 797b1dae35931cc350a500095806980af3ad4381069c80d8a367a62c6e9dda27ffafd7078feafd5f12e1161825cd44fbaa481ef1982a061e25322df6850f5a8d
+[kubernetes-node-windows-amd64.tar.gz](https://dl.k8s.io/v1.18.5/kubernetes-node-windows-amd64.tar.gz) | d784fc4986e03d925a7e855d6f9ce287405133a181a27d12d5495ca6ef3061d106c8eff62a662275d4477a10825fbbf3300c3a77ba8eb499a25a310c12df15c3
+
+## Changelog since v1.18.4
+
+## Changes by Kind
+
+### API Change
+
+- Fixed: log timestamps now include trailing zeros to maintain a fixed width ([#91207](https://github.com/kubernetes/kubernetes/pull/91207), [@iamchuckss](https://github.com/iamchuckss)) [SIG Apps and Node]
+
+### Bug or Regression
+
+- Fixes CSI volume attachment scaling issue by using informers. ([#91307](https://github.com/kubernetes/kubernetes/pull/91307), [@yuga711](https://github.com/yuga711)) [SIG API Machinery, Apps, Node, Storage and Testing]
+- Kubeadm increased to 5 minutes its timeout for the TLS bootstrapping process to complete upon join ([#89735](https://github.com/kubernetes/kubernetes/pull/89735), [@rosti](https://github.com/rosti)) [SIG Cluster Lifecycle]
+- hyperkube: Use debian-hyperkube-base@v1.1.0 image
+  
+    A previous release built hyperkube using the debian-hyperkube-base@v1.0.0,
+    which was updated to address a CVE in the CNI plugins.
+    
+    A side-effect of using this new image was that the networking packages
+    (namely `iptables`) drifted from the versions used in the kube-proxy images.
+  
+    The following issues were filed on kube-proxy failures when using hyperkube:
+    - https://github.com/kubernetes/kubernetes/issues/92275
+    - https://github.com/kubernetes/kubernetes/issues/92272
+    - https://github.com/kubernetes/kubernetes/issues/92250
+  
+    To address this, the new debian-hyperkube-base image (v1.1.0) uses the
+    debian-iptables base image (v12.1.0), which includes iptables-wrapper, a
+    script used to determine the correct iptables mode to run in. ([#92493](https://github.com/kubernetes/kubernetes/pull/92493), [@justaugustus](https://github.com/justaugustus)) [SIG Cluster Lifecycle and Release]
+
+## Dependencies
+
+### Added
+_Nothing has changed._
+
+### Changed
+_Nothing has changed._
+
+### Removed
+_Nothing has changed._
+
+
+
+# v1.18.5-rc.1
+
+
+## Downloads for v1.18.5-rc.1
+
+### Source Code
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes.tar.gz](https://dl.k8s.io/v1.18.5-rc.1/kubernetes.tar.gz) | eab1264657dd76babb4159edb6ff2e85c1e4d2baaea053bd479426c8ee0ad544c4be18e1bbec5948ea4a649adb5f42bc87b15afd5e1818859d4bc61287a7ad08
+[kubernetes-src.tar.gz](https://dl.k8s.io/v1.18.5-rc.1/kubernetes-src.tar.gz) | 48f16d0a9eada28eacbc90da224d64e2d8a1f1b47dd4be8baaca8a386834a7e0413a40f4938c086c1a17c44e6a87fc16cb7dc8e7ebcfbf7e34e1f71c7deb730b
+
+### Client binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-client-darwin-386.tar.gz](https://dl.k8s.io/v1.18.5-rc.1/kubernetes-client-darwin-386.tar.gz) | a079b71c22b6b4893aeb9289354872f07c79e823c26a9a89ea4c72608ff5770356f5c6fb4289a72c2ef0d4bc8d835ba96074f4c188566f5aa51b32ea4a13ee4e
+[kubernetes-client-darwin-amd64.tar.gz](https://dl.k8s.io/v1.18.5-rc.1/kubernetes-client-darwin-amd64.tar.gz) | 4cb738c285226faa885d92495e7b3a2ad2b89fae70dc617bac7e6e2962f0c0c5fcf42c61efcac5a51b0f1c232b015cead2e3ee7f8237e27659ddedf2fe657481
+[kubernetes-client-linux-386.tar.gz](https://dl.k8s.io/v1.18.5-rc.1/kubernetes-client-linux-386.tar.gz) | 1f9c1bfbb68ffb19297990bc8d186761e0f40714862939a9b511de770e9c2227acd24fd584986d1bf4d7e518ef0ded6dc6b8ebe8cb5e32d81484f1274ec3cfc1
+[kubernetes-client-linux-amd64.tar.gz](https://dl.k8s.io/v1.18.5-rc.1/kubernetes-client-linux-amd64.tar.gz) | 70afde567009acc60e2c349096aca1498bbd0b65688ca9cc0e5ef1b847bb297a6c22020a2e7b3ca6832677d1a54be50b5add9b738ba15ef3716a124508517fc8
+[kubernetes-client-linux-arm.tar.gz](https://dl.k8s.io/v1.18.5-rc.1/kubernetes-client-linux-arm.tar.gz) | 9dbabf46ba83b8ac08511b11685f8dd447b7d649db72315674df1ae31c663ed0f36a1cae1895765e396cfb86b1ee5d719976712d6cc4bd57cba1ff35303e3177
+[kubernetes-client-linux-arm64.tar.gz](https://dl.k8s.io/v1.18.5-rc.1/kubernetes-client-linux-arm64.tar.gz) | a8f0ad8429c1e483471e247f79899874f8168ebc316a5b811f9dc74b562c9e227f252177572230a233a852b867f4510d257f61ebc67f0db713aac26c66151715
+[kubernetes-client-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.18.5-rc.1/kubernetes-client-linux-ppc64le.tar.gz) | 2d81d1eecf2cdb14fe44334271cb53466691948268143b6c22e0b852febbee88d1a06ffadd81a4dfc39a27cbec9781d6e861d5d99b99e2895fe358c10c2811e8
+[kubernetes-client-linux-s390x.tar.gz](https://dl.k8s.io/v1.18.5-rc.1/kubernetes-client-linux-s390x.tar.gz) | d8efbc345e7b0833ca010598d915cc3246a01ef940cf5ee7b051929a8e212a530b1a2a27a0bcfa5721cc7823ef286a9ac93c39c005b5d86c4bfd27babc87c4dc
+[kubernetes-client-windows-386.tar.gz](https://dl.k8s.io/v1.18.5-rc.1/kubernetes-client-windows-386.tar.gz) | 71a4756ea4c4ccb19ad9103080d724bebc5993f973e5e33a25d3b020b2c3be0e3d06d9b29befc13397220e5815a42e253be12789d3236e9dceef555c85e95d01
+[kubernetes-client-windows-amd64.tar.gz](https://dl.k8s.io/v1.18.5-rc.1/kubernetes-client-windows-amd64.tar.gz) | 30d0fb3b83222ad90fb78574b63a2de5438f06d918eff13894d34ac70946f9b06618164c7acc1e1380954f8000b9ad3d114be6c39ba19dae40a61ea8d136c9aa
+
+### Server binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-server-linux-amd64.tar.gz](https://dl.k8s.io/v1.18.5-rc.1/kubernetes-server-linux-amd64.tar.gz) | 19c78e05023b9d41acda812f87c2588dc0297583254049324d9cd2c0a2d79997ccfa4e8c54fa19c16bd4f32f943541bedab9d5be974b4078bcf29050d849c2ef
+[kubernetes-server-linux-arm.tar.gz](https://dl.k8s.io/v1.18.5-rc.1/kubernetes-server-linux-arm.tar.gz) | bacec0b0dcbf7d59e78969c22235e0111e95367bd288482110c22a5d41d6a4c31f82ecf81ff09c3746981f9efbaedd3d60fede4d3129a84d9aaedd9e14a63c26
+[kubernetes-server-linux-arm64.tar.gz](https://dl.k8s.io/v1.18.5-rc.1/kubernetes-server-linux-arm64.tar.gz) | 05531280837cbd03dc77d9a726ed1543977d96adcd8e2728e3ef6ee3966e1df7ec2dee1118acb9e449ff6a73ec27b85cb34c6f6c9c65a5c71b814726ebbaf83b
+[kubernetes-server-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.18.5-rc.1/kubernetes-server-linux-ppc64le.tar.gz) | 32762d89c48eb851079c9e6c67dcbb02b04bfb7c63b04a50bfac66ea8ee6b53a41424e8f2ddddd377564e81866d10fc568bc7f2853cfd85a50a828e7206d5254
+[kubernetes-server-linux-s390x.tar.gz](https://dl.k8s.io/v1.18.5-rc.1/kubernetes-server-linux-s390x.tar.gz) | d28ecd106e103273949e09ab1d15027ccebb6d9540c199fdb11f130c84209c6f7116acc24a34c9169c7786f20f2d0101438c3652a23925a4ed857f148c01ff6d
+
+### Node binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-node-linux-amd64.tar.gz](https://dl.k8s.io/v1.18.5-rc.1/kubernetes-node-linux-amd64.tar.gz) | 1b7eeb2374bfdd3e6baff854b834985ea5cb73774322688ccdc1de0e138e64c643e512bf4326f5d772ceb86acbf05f48e06a354a1bbacae945d638aab51bf73e
+[kubernetes-node-linux-arm.tar.gz](https://dl.k8s.io/v1.18.5-rc.1/kubernetes-node-linux-arm.tar.gz) | c5d75e3db341d1a909d6acb14ad7a9c64beaae793d0af80971cd33b1f9b9361f3eceb740f78392cd42d40d7d1989edebab23ec40fb5593ec5300dd2cc72c3d36
+[kubernetes-node-linux-arm64.tar.gz](https://dl.k8s.io/v1.18.5-rc.1/kubernetes-node-linux-arm64.tar.gz) | 98b8a5c6b8fa2958c8a63e2cd0fff3f947545c80474ceaa7d696910ab1cfaacb4fc520dd67db094573eb6f40012a947768e48ce709a51d02a657ae8c26e74b16
+[kubernetes-node-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.18.5-rc.1/kubernetes-node-linux-ppc64le.tar.gz) | ca479f42ae58f614b077f984984de76cfe8105124d7f20f0be9707007a17ba35ea06d92f3de2c4118d94cd7d10e971cd6f1477c164ca0204fcfd527d123be05e
+[kubernetes-node-linux-s390x.tar.gz](https://dl.k8s.io/v1.18.5-rc.1/kubernetes-node-linux-s390x.tar.gz) | e5c85afdb8d2ffcf80c07b8d53ee2bdd5f559d2b0cb18062c9e63dcfc52ce245e91c7e101bbc79e1cce9010ac0d08d38b6eb286f86dd9bbc495197e4e6ca803b
+[kubernetes-node-windows-amd64.tar.gz](https://dl.k8s.io/v1.18.5-rc.1/kubernetes-node-windows-amd64.tar.gz) | 929f3e575dc02fa2b229ecb369a07972536811f55823fc743002f503caee7ad2ec7b39bae08b578eb7cd709910666ba0fd345247d79a36ebb3cb99f17d68772d
+
+## Changelog since v1.18.4
+
+## Changes by Kind
+
+### API Change
+
+- Fixed: log timestamps now include trailing zeros to maintain a fixed width ([#91207](https://github.com/kubernetes/kubernetes/pull/91207), [@iamchuckss](https://github.com/iamchuckss)) [SIG Apps and Node]
+
+### Bug or Regression
+
+- Fixes CSI volume attachment scaling issue by using informers. ([#91307](https://github.com/kubernetes/kubernetes/pull/91307), [@yuga711](https://github.com/yuga711)) [SIG API Machinery, Apps, Node, Storage and Testing]
+- Kubeadm increased to 5 minutes its timeout for the TLS bootstrapping process to complete upon join ([#89735](https://github.com/kubernetes/kubernetes/pull/89735), [@rosti](https://github.com/rosti)) [SIG Cluster Lifecycle]
+- hyperkube: Use debian-hyperkube-base@v1.1.0 image
+  
+    A previous release built hyperkube using the debian-hyperkube-base@v1.0.0,
+    which was updated to address a CVE in the CNI plugins.
+    
+    A side-effect of using this new image was that the networking packages
+    (namely `iptables`) drifted from the versions used in the kube-proxy images.
+  
+    The following issues were filed on kube-proxy failures when using hyperkube:
+    - https://github.com/kubernetes/kubernetes/issues/92275
+    - https://github.com/kubernetes/kubernetes/issues/92272
+    - https://github.com/kubernetes/kubernetes/issues/92250
+  
+    To address this, the new debian-hyperkube-base image (v1.1.0) uses the
+    debian-iptables base image (v12.1.0), which includes iptables-wrapper, a
+    script used to determine the correct iptables mode to run in. ([#92493](https://github.com/kubernetes/kubernetes/pull/92493), [@justaugustus](https://github.com/justaugustus)) [SIG Cluster Lifecycle and Release]
+
+## Dependencies
+
+### Added
+_Nothing has changed._
+
+### Changed
+_Nothing has changed._
+
+### Removed
+_Nothing has changed._
+
+
+
+# v1.18.4
+
+
+## Downloads for v1.18.4
+
+### Source Code
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes.tar.gz](https://dl.k8s.io/v1.18.4/kubernetes.tar.gz) | 8d2cec9d026bbed016f004c23e205e234bcd40072cda81e805ecebe6e8cc8e4b5f1685c9dc57640edc3c5c67e09ac362bfa9bae1b654fcf425d3e4e184b5b46f
+[kubernetes-src.tar.gz](https://dl.k8s.io/v1.18.4/kubernetes-src.tar.gz) | 04a0180addc8c03815652b2cda14608022f0679466028eae475d88661369441f46d6f7be544d88b461508ca8c89410da1f43f51fde246cb8c8470d9c22973f0f
+
+### Client binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-client-darwin-386.tar.gz](https://dl.k8s.io/v1.18.4/kubernetes-client-darwin-386.tar.gz) | 60e5e7b72570c927915a5d9b29bc06c0efbd1f80fbf2e14ccc8811b2962263de4a22b8fc2d3645888bd56b16f21093d6e8dd346bb62ffac50f6a20ed9e1516db
+[kubernetes-client-darwin-amd64.tar.gz](https://dl.k8s.io/v1.18.4/kubernetes-client-darwin-amd64.tar.gz) | 189430f4b19cb7a147e9974268874564584ac0e91aa16864e2fe9c2428e5b08f283c7d48d31bb9f05743db979f7414abace2fc4a9d6b8afc04fba2f7874ebd57
+[kubernetes-client-linux-386.tar.gz](https://dl.k8s.io/v1.18.4/kubernetes-client-linux-386.tar.gz) | 078cff6c8c5b902fc3326026894c68c9e8db49c1e247dafff73ed53c61547179537e60a6839ca34c4ac8632518988834427d336b71f4cbfc2dd878a6cbe48718
+[kubernetes-client-linux-amd64.tar.gz](https://dl.k8s.io/v1.18.4/kubernetes-client-linux-amd64.tar.gz) | 69344ab18d8f9608374cd4994ffbd878a9738b14793a41a25dfbedb0bf9a6174605507f92e7032930700c79ccc12ca899570a099d9db624d4c65580aefedbe0c
+[kubernetes-client-linux-arm.tar.gz](https://dl.k8s.io/v1.18.4/kubernetes-client-linux-arm.tar.gz) | ae202fa504f9f10a9e6e8d6eb2e5407729dbcc3fbde34ecb7814994a45b7e80446cc81845d4cde661d9937fcd1b6914820ce9f1bdf30a27a72f5f96fa3483dbf
+[kubernetes-client-linux-arm64.tar.gz](https://dl.k8s.io/v1.18.4/kubernetes-client-linux-arm64.tar.gz) | 7ee7d1e493b399e3767e526d5a80b94d099c48798f62fa8e9673f974ea87ec5461a793381d6bbfd461a32ac735f6d66faa223659ddcb825ef0a1f405a482e404
+[kubernetes-client-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.18.4/kubernetes-client-linux-ppc64le.tar.gz) | f8f1c44843584aadacd851f3c33cdd3699ff35cff4503da40e4280586b4281af4a24736cdb6b635e486015b3476106065eb61abe06d8d9c51f70e7e6838e0536
+[kubernetes-client-linux-s390x.tar.gz](https://dl.k8s.io/v1.18.4/kubernetes-client-linux-s390x.tar.gz) | ff796f22edff24d84a8f8952490db78ea20570dc7752cabb60035e84368256c900d32c926a501fe70781c2bf682cca2daf920c22034c8b4d3f32679d659ea5d3
+[kubernetes-client-windows-386.tar.gz](https://dl.k8s.io/v1.18.4/kubernetes-client-windows-386.tar.gz) | aebf17c13b081eeeaf7608e89599441cbeed959f3895dc969beec20e2561b4a89a51d40575f01c9d6fb58d1a1057717349ad668d3bed89de77ab78396ffccad9
+[kubernetes-client-windows-amd64.tar.gz](https://dl.k8s.io/v1.18.4/kubernetes-client-windows-amd64.tar.gz) | 7eb3201320139379f095c9d425434edbe7e608499b04033a303e6aa3e205d2b6e7d585d2850d3d2431498f34e48c5ff49561b038f309d02439e9d5eb2e809563
+
+### Server binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-server-linux-amd64.tar.gz](https://dl.k8s.io/v1.18.4/kubernetes-server-linux-amd64.tar.gz) | e85fbe9aa255cabcf58b4c18fa666d6a85effa0fc9c78d0d150abf3f89bfd13fcd55163caf02188b095310e01f49e1f32464c9e87f43cebe1043868436e0e751
+[kubernetes-server-linux-arm.tar.gz](https://dl.k8s.io/v1.18.4/kubernetes-server-linux-arm.tar.gz) | 6d6befa922522b8c6155cdeea7d56e1f21dc175b71ce2285c87a5ef591abc9590a37a56ae21792c0763ccee690110b5b6db5953aef36d607d6b21920f22e9c7f
+[kubernetes-server-linux-arm64.tar.gz](https://dl.k8s.io/v1.18.4/kubernetes-server-linux-arm64.tar.gz) | 8158bc2fdb3577816f709a15633a1740872083032962ae0cb42a0975b614e6307e3a75fe8e58b8753a162702ef789d9c5e51ba22d754198e55339da811b05889
+[kubernetes-server-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.18.4/kubernetes-server-linux-ppc64le.tar.gz) | d1c799ccebdfce580510cd0c5f61b30e47629cc1f837c8c2fed8408b6289fc7ff27f07a006ca04db023bb8924f963b78e10aa8538f02cf0b5a1bdbc3ed7bf1d0
+[kubernetes-server-linux-s390x.tar.gz](https://dl.k8s.io/v1.18.4/kubernetes-server-linux-s390x.tar.gz) | 0b8b357757b3e16ca947ff774b89524a8d2a2be94b422483dbe7148891daabdd6a626ab173084dd09854d83fff6d3c1df853fdeaab89ba289d16b7515746f13b
+
+### Node binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-node-linux-amd64.tar.gz](https://dl.k8s.io/v1.18.4/kubernetes-node-linux-amd64.tar.gz) | b01c34c0303116a2c7a579fec5bcd19d76fa605c6ec9fa7c9885e669437911365cf63c8be381aebab666f833ff9099be024fb139d3ddc50e5f9b6702352b5a3c
+[kubernetes-node-linux-arm.tar.gz](https://dl.k8s.io/v1.18.4/kubernetes-node-linux-arm.tar.gz) | 21384a97bea7d4e97a24d660f7c1ba9b5577314f5c6602c6fa29e1501628a513489a1ce8472f6b5d0b4964625d5e9ff786ea2069a5add112eae3d28069ce3758
+[kubernetes-node-linux-arm64.tar.gz](https://dl.k8s.io/v1.18.4/kubernetes-node-linux-arm64.tar.gz) | 8158b7abd711a42b1ff4eb42ce49d9eeb04d8903f0daa48cd7528516dafaf6693669d8653b1360fe2630c95b78fa3552184423670fd919896411d1d25781d173
+[kubernetes-node-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.18.4/kubernetes-node-linux-ppc64le.tar.gz) | 5fa9d1306790f8cb8b16b7e9521d46f8e56cc619acd90165180c9fb02ac9bf0908130f80a7c0fce046a4f15ab4e366ab0d9f4b18a5da8180607c343e9009433b
+[kubernetes-node-linux-s390x.tar.gz](https://dl.k8s.io/v1.18.4/kubernetes-node-linux-s390x.tar.gz) | ccafa72087fc09e37206e73ff2b2198fd5b2a5d2e56dca31f77c12aabe42d766f877d77c6265ae7a4c180e8926ba53cb4c563bd7a4d3dca85012e7a664fa5762
+[kubernetes-node-windows-amd64.tar.gz](https://dl.k8s.io/v1.18.4/kubernetes-node-windows-amd64.tar.gz) | ee2f631d619ac436232db9eb4ea377526738a15ad3a88752e7a481e02cd09d848fbdf91ac8dba7905272766a3039cb1cd76afce9cf84352020eefaaaad739bf4
+
+## Changelog since v1.18.3
+
+## Changes by Kind
+
+### API Change
+
+- Resolve regression in metadata.managedFields handling in update/patch requests submitted by older API clients ([#92007](https://github.com/kubernetes/kubernetes/pull/92007), [@apelisse](https://github.com/apelisse)) [SIG API Machinery and Testing]
+
+### Feature
+
+- Extend AWS azToRegion method to support Local Zones ([#90874](https://github.com/kubernetes/kubernetes/pull/90874), [@Jeffwan](https://github.com/Jeffwan)) [SIG Cloud Provider]
+
+### Bug or Regression
+
+- Azure: set dest prefix and port for IPv6 inbound security rule ([#91831](https://github.com/kubernetes/kubernetes/pull/91831), [@aramase](https://github.com/aramase)) [SIG Cloud Provider]
+- Fix public IP not shown issues after assigning public IP to Azure VMs ([#90886](https://github.com/kubernetes/kubernetes/pull/90886), [@feiskyer](https://github.com/feiskyer)) [SIG Cloud Provider]
+- Fixed a regression preventing garbage collection of RBAC role and binding objects ([#90534](https://github.com/kubernetes/kubernetes/pull/90534), [@apelisse](https://github.com/apelisse)) [SIG Auth]
+- Fixes regression in CPUManager that caused freeing of exclusive CPUs at incorrect times ([#90377](https://github.com/kubernetes/kubernetes/pull/90377), [@cbf123](https://github.com/cbf123)) [SIG Cloud Provider and Node]
+- Fixes regression in CPUManager that had the (rare) possibility to release exclusive CPUs in app containers inherited from init containers. ([#90419](https://github.com/kubernetes/kubernetes/pull/90419), [@klueska](https://github.com/klueska)) [SIG Node]
+- Pod Finalizers and Conditions updates are skipped for re-scheduling attempts ([#91298](https://github.com/kubernetes/kubernetes/pull/91298), [@alculquicondor](https://github.com/alculquicondor)) [SIG Scheduling]
+- Resolve regression in metadata.managedFields handling in create/update/patch requests not using server-side apply ([#91791](https://github.com/kubernetes/kubernetes/pull/91791), [@apelisse](https://github.com/apelisse)) [SIG API Machinery and Testing]
+- Resolves an issue using `kubectl certificate approve/deny` against a server serving the v1 CSR API ([#91691](https://github.com/kubernetes/kubernetes/pull/91691), [@liggitt](https://github.com/liggitt)) [SIG Auth and CLI]
+
+### Other (Cleanup or Flake)
+
+- Build: Use debian-hyperkube-base@v1.0.0 image ([#91476](https://github.com/kubernetes/kubernetes/pull/91476), [@justaugustus](https://github.com/justaugustus)) [SIG Cluster Lifecycle, Network and Release]
+- Content-type and verb for request metrics are now bounded to a known set. ([#89451](https://github.com/kubernetes/kubernetes/pull/89451), [@logicalhan](https://github.com/logicalhan)) [SIG API Machinery and Instrumentation]
+- Update CNI to v0.8.6 ([#91387](https://github.com/kubernetes/kubernetes/pull/91387), [@justaugustus](https://github.com/justaugustus)) [SIG Cluster Lifecycle, Network, Release and Testing]
+
+## Dependencies
+
+### Added
+_Nothing has changed._
+
+### Changed
+_Nothing has changed._
+
+### Removed
+_Nothing has changed._
+
+
+
+# v1.18.3
+
+
+## Downloads for v1.18.3
+
+### Source Code
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes.tar.gz](https://dl.k8s.io/v1.18.3/kubernetes.tar.gz) | 7d511c960f766f76bc087c00d706dc78ed403f661ea62ea6a2e84b9a0498826c0186f8705d18e1101ce148eecf7046f3e96e0a64aff7698a0976414a56056d4d
+[kubernetes-src.tar.gz](https://dl.k8s.io/v1.18.3/kubernetes-src.tar.gz) | 93b83acf5d15cab94e1d2866b2613d1aeed67c00a9eed064988c3bc4c700e34bd854fffac730c5ed6d8e138f15ce7750c17952f33bd4918771c7da358fbf5b53
+
+### Client binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-client-darwin-386.tar.gz](https://dl.k8s.io/v1.18.3/kubernetes-client-darwin-386.tar.gz) | cf6a22a453b88de6be0e09ad67e8bb3e364b702a86c9ba911540d4f4b2ae0872d3802f814cd471ef4ec0b2822b071489d59e21ece01f38fa567d3afd8718158f
+[kubernetes-client-darwin-amd64.tar.gz](https://dl.k8s.io/v1.18.3/kubernetes-client-darwin-amd64.tar.gz) | bd3c15726d44d083f48dbc1af0f55f2d2d0c82ad020ed583bf05460a4fc9073bdd0395c2e0e4bfc74b705f4427bfe76bee0c77eb4aea83247b6627fc15d8d3f9
+[kubernetes-client-linux-386.tar.gz](https://dl.k8s.io/v1.18.3/kubernetes-client-linux-386.tar.gz) | 6cb3d18086e275b78c3019a51de5795f5d112482ea6dc99a58e3985269e948e054a5e38457f837add606b83d86fb1c5b9044903f9dea964d9ea84c564a8ca6e5
+[kubernetes-client-linux-amd64.tar.gz](https://dl.k8s.io/v1.18.3/kubernetes-client-linux-amd64.tar.gz) | cfcb89a706eb8ddc7aa8225e3f0eb76a0d973faa1c82b1bec0a457cd8b44b7bd5c154b7ed1f7cdabfdee84af8a33fd7fff83970a6ee5a97d661a806b69da968b
+[kubernetes-client-linux-arm.tar.gz](https://dl.k8s.io/v1.18.3/kubernetes-client-linux-arm.tar.gz) | adbb0383ab50358e479438831168b6f3187a7cafcad84e8c22ff2ec52300be643bf535ffbe0c6ffc971120afb56703c206a64459db7b485ee67dd05d84393f5e
+[kubernetes-client-linux-arm64.tar.gz](https://dl.k8s.io/v1.18.3/kubernetes-client-linux-arm64.tar.gz) | 32f5e6cc5a811f941faaa92667d236bb08bc245a103a2ab555569a5bf1bfd1926f30ce08635273fbea414f92c8764f8077b3e3be5ea52e90be4ed3ded9253452
+[kubernetes-client-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.18.3/kubernetes-client-linux-ppc64le.tar.gz) | b0b2ade932e17aa4b88b147fcb6aeace81c65e795202e27c780e270a86f50fd7f863f41558b0fc37ece1196fa39047baf47568416ee6faed7946593ad35fba03
+[kubernetes-client-linux-s390x.tar.gz](https://dl.k8s.io/v1.18.3/kubernetes-client-linux-s390x.tar.gz) | db49113c3e5d727d6c66b17a0a5a3f7d383b7179630fb5680d278f34b35e4f3d5a1086489858a90a5417dafc42222d23ff2aacba7b7d571d3b2d9ced460877de
+[kubernetes-client-windows-386.tar.gz](https://dl.k8s.io/v1.18.3/kubernetes-client-windows-386.tar.gz) | d2a8e6f6e93a3ce6af473372de1c52e039d14a443d93537001e1bc5e7b237768a25a9a1d891a40d50142c23df1e7d94f767d11adf949439e77328c7aafbc7a23
+[kubernetes-client-windows-amd64.tar.gz](https://dl.k8s.io/v1.18.3/kubernetes-client-windows-amd64.tar.gz) | 5f2739b862fbbab9f847b61f9373021b92c4d9188ff7f534125dc48d2d1e6ed51bd7bc5c987f26db3bf1d1f05a4c0f4c0ff7a0836a4ca14e56d2b12f406f1a72
+
+### Server binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-server-linux-amd64.tar.gz](https://dl.k8s.io/v1.18.3/kubernetes-server-linux-amd64.tar.gz) | 5561483d796b124b8fe0e1cf5778ea03fec1e244ebc29f4b1b6c5ac93ab6bd10808d05da81b5f26426d51a3784c93ddf8b375ff971a78aebfd0ec7acac161365
+[kubernetes-server-linux-arm.tar.gz](https://dl.k8s.io/v1.18.3/kubernetes-server-linux-arm.tar.gz) | 5e0e026fb93ac5452d1ddeb5fc016dbd44276d2340088ef59916bdd264b43ab02889beb645b6b8d9e5ee02bf2fe827327478b158f80b152c073b9ecaaba6fd0e
+[kubernetes-server-linux-arm64.tar.gz](https://dl.k8s.io/v1.18.3/kubernetes-server-linux-arm64.tar.gz) | eb0b72f79e9d0c717995f7e52d24646daa8cbaf0e1502c0b27a15acebcfa5d61495bee49cc6ba4eb4ed8d4e1d9aae29170a86c70240da56f8fb9360dabb9ec7b
+[kubernetes-server-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.18.3/kubernetes-server-linux-ppc64le.tar.gz) | 52ef224a68d3ea50f320ca43b2ec98fedc07431b05db6fb00556b870bb8a533aa1ceb5f5ad90ea3d41f611045014a387ae84de5df8c51c6fbf8fa1e0d8c07d31
+[kubernetes-server-linux-s390x.tar.gz](https://dl.k8s.io/v1.18.3/kubernetes-server-linux-s390x.tar.gz) | eb4581d2419734c4835ebd2a91a40fa7e1180c8b8ff4088c9d1995c11787b7d6b7cb26cedfdce8c53affc648b106fe852ed53f165142f1089c27f9368570025d
+
+### Node binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-node-linux-amd64.tar.gz](https://dl.k8s.io/v1.18.3/kubernetes-node-linux-amd64.tar.gz) | 1027a6fccadd320f123894dc624db31539333deef0b3d51b4bd3efc9214f2d74a0a50c53dc28e5801426d3c9556f82f4e06042c824151fea9112df795976d158
+[kubernetes-node-linux-arm.tar.gz](https://dl.k8s.io/v1.18.3/kubernetes-node-linux-arm.tar.gz) | 9dfd609692372660152c6fe6d08be082b0d20d4c70546d722ce5aa5565cc6d810bb0cdac6b98d9a9374382b9dcf8819e4e1d263481791e044cfef5d3980d0b13
+[kubernetes-node-linux-arm64.tar.gz](https://dl.k8s.io/v1.18.3/kubernetes-node-linux-arm64.tar.gz) | d0b0a8ac1f448df7c3bb2254000e0ca8567fafe1fd4e680c75a6c8d40dcc9d4b9ae34648532aef50a953be99d41d62464d704b516c33745fc169337684e7433b
+[kubernetes-node-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.18.3/kubernetes-node-linux-ppc64le.tar.gz) | b5f3a0e3b2b26d3ac5b8be808355233787c1d3663268da88096351b39b6ff6e58befff97dab109b6324ad050fe2a361ac6b35dbdab7f2dd85dc013d881baecf9
+[kubernetes-node-linux-s390x.tar.gz](https://dl.k8s.io/v1.18.3/kubernetes-node-linux-s390x.tar.gz) | 52c9cc8a09c5d5c9150dc023b759ebe77632121a54bf0936b96f4148b7e421964f39bdad4fcd1002f453c012a03d928888cc04520a10a96ea45d798a7cd2ca7b
+[kubernetes-node-windows-amd64.tar.gz](https://dl.k8s.io/v1.18.3/kubernetes-node-windows-amd64.tar.gz) | f83802db06a86edd9ade8e737ed0e8a11ebeeaa69e102f9550b90f0d8a724e7864f6531f7f500ff70d4202168a774c5b328fea1ec0a95b9e275a0233a852f04f
+
+## Changelog since v1.18.2
+
+## Changes by Kind
+
+### Bug or Regression
+ - An issue preventing GCP cloud-controller-manager running out-of-cluster to initialize new Nodes is now fixed. ([#90057](https://github.com/kubernetes/kubernetes/pull/90057), [@ialidzhikov](https://github.com/ialidzhikov)) [SIG Apps and Cloud Provider]
+ - Avoid unnecessary scheduling churn when annotations are updated while Pods are being scheduled. ([#90373](https://github.com/kubernetes/kubernetes/pull/90373), [@fabiokung](https://github.com/fabiokung)) [SIG Scheduling]
+ - Base-images: Update to kube-cross:v1.13.9-5 ([#90964](https://github.com/kubernetes/kubernetes/pull/90964), [@justaugustus](https://github.com/justaugustus)) [SIG Release and Testing]
+ - CSINode initialization does not crash kubelet on startup when APIServer is not reachable or kubelet has not the right credentials yet. ([#89589](https://github.com/kubernetes/kubernetes/pull/89589), [@jsafrane](https://github.com/jsafrane)) [SIG Storage]
+ - Fix IPVS compatiblity issue with older kernels (< 3.18) where the netlink address family attribute is not set ([#90678](https://github.com/kubernetes/kubernetes/pull/90678), [@andrewsykim](https://github.com/andrewsykim)) [SIG Cluster Lifecycle, Network and Testing]
+ - Fix flaws in Azure CSI translation ([#90324](https://github.com/kubernetes/kubernetes/pull/90324), [@andyzhangx](https://github.com/andyzhangx)) [SIG Cloud Provider]
+ - Fix: Init containers are now considered for the calculation of resource requests when scheduling ([#90378](https://github.com/kubernetes/kubernetes/pull/90378), [@alculquicondor](https://github.com/alculquicondor)) [SIG Scheduling]
+ - Fix: azure disk dangling attach issue which would cause API throttling ([#90749](https://github.com/kubernetes/kubernetes/pull/90749), [@andyzhangx](https://github.com/andyzhangx)) [SIG Cloud Provider]
+ - Fix: support removal of nodes backed by deleted non VMSS instances on Azure ([#91184](https://github.com/kubernetes/kubernetes/pull/91184), [@bpineau](https://github.com/bpineau)) [SIG Cloud Provider]
+ - Fixed a 1.18 regression in wait.Forever that skips the backoff period on the first repeat ([#90476](https://github.com/kubernetes/kubernetes/pull/90476), [@zhan849](https://github.com/zhan849)) [SIG API Machinery]
+ - Fixed a regression running kubectl commands with  --local or --dry-run flags when no kubeconfig file is present ([#90243](https://github.com/kubernetes/kubernetes/pull/90243), [@soltysh](https://github.com/soltysh)) [SIG API Machinery, CLI and Testing]
+ - Fixes a bug defining a default value for a replicas field in a custom resource definition that has the scale subresource enabled ([#90019](https://github.com/kubernetes/kubernetes/pull/90019), [@liggitt](https://github.com/liggitt)) [SIG API Machinery, CLI, Cloud Provider, Cluster Lifecycle and Instrumentation]
+ - Fixes a regression in 1.17 that dropped cache-control headers on API requests ([#90468](https://github.com/kubernetes/kubernetes/pull/90468), [@liggitt](https://github.com/liggitt)) [SIG API Machinery and Testing]
+ - Kubeadm: increase robustness for "kubeadm join" when adding etcd members on slower setups ([#90645](https://github.com/kubernetes/kubernetes/pull/90645), [@neolit123](https://github.com/neolit123)) [SIG Cluster Lifecycle]
+ - Provides a fix to allow a cluster in a private Azure cloud to authenticate to ACR in the same cloud. ([#90425](https://github.com/kubernetes/kubernetes/pull/90425), [@DavidParks8](https://github.com/DavidParks8)) [SIG Cloud Provider]
+ - Scheduling failures due to no nodes available are now reported as unschedulable under ```schedule_attempts_total``` metric. ([#90989](https://github.com/kubernetes/kubernetes/pull/90989), [@ahg-g](https://github.com/ahg-g)) [SIG Scheduling]
+
+### Other (Cleanup or Flake)
+ - base-images: Use debian-base:v2.1.0 (includes CVE fixes)
+  - base-images: Use debian-iptables:v12.1.0 (includes CVE fixes) ([#90863](https://github.com/kubernetes/kubernetes/pull/90863), [@justaugustus](https://github.com/justaugustus)) [SIG API Machinery, Cluster Lifecycle and Release]
+
+## Dependencies
+
+### Added
+_Nothing has changed._
+
+### Changed
+- k8s.io/kube-openapi: bf4fb3b → 61e04a5
+
+### Removed
+- github.com/docker/libnetwork: [c8a5fca](https://github.com/docker/libnetwork/tree/c8a5fca)
+
+
+
+# v1.18.2
+
+[Documentation](https://docs.k8s.io)
+
+## Downloads for v1.18.2
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes.tar.gz](https://dl.k8s.io/v1.18.2/kubernetes.tar.gz) | `2f8e853bd59731410259d5357d9969425fbbbea378bbe6cdd0f7a9ddf5c25924838300924b03ec15d6b9030be86bea9d26bb9b63078bf2c150b0bbc0859419d7`
+[kubernetes-src.tar.gz](https://dl.k8s.io/v1.18.2/kubernetes-src.tar.gz) | `0915b658c53b9bad1b3913470cb6728bc51fd49e8ac7778d4653c7271642d56a51ae83e58b9a1829a8df8970e73411f02c5ab277f8a9ba4befc4ba933800a9c5`
+
+### Client Binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-client-darwin-386.tar.gz](https://dl.k8s.io/v1.18.2/kubernetes-client-darwin-386.tar.gz) | `0a0c94fe16819eb16ca7ef0110a2a45ad5368a5cb326ca48e1d72ef56488c5c273fcfa15e9704492dfb3188447800cf109bf434b6d646a2c01c833eccaa7ebbe`
+[kubernetes-client-darwin-amd64.tar.gz](https://dl.k8s.io/v1.18.2/kubernetes-client-darwin-amd64.tar.gz) | `46a056b3bf9936498c1bbb78ca6d882c17271723676ec53409fe6fd67c7f8a9cb0ab00e286f8ab2231216fabbcfec72f943c29827068ab66d6029f585faccfcb`
+[kubernetes-client-linux-386.tar.gz](https://dl.k8s.io/v1.18.2/kubernetes-client-linux-386.tar.gz) | `58f137f3d13b213a153e7589d82040d5f1aee525368de974c134494c14d0f88526e4b1db9022dd728d47fe13ff1c4c97fba94e3b2ebc746ec537bebf41817d53`
+[kubernetes-client-linux-amd64.tar.gz](https://dl.k8s.io/v1.18.2/kubernetes-client-linux-amd64.tar.gz) | `ed36f49e19d8e0a98add7f10f981feda8e59d32a8cb41a3ac6abdfb2491b3b5b3b6e0b00087525aa8473ed07c0e8a171ad43f311ab041dcc40f72b36fa78af95`
+[kubernetes-client-linux-arm.tar.gz](https://dl.k8s.io/v1.18.2/kubernetes-client-linux-arm.tar.gz) | `ae3b7a8f85d2f262b0f24d277602034cd6657aa0a0467768b87c379b821963c10e35cff8131f666038feb2a2e543725c0025ed84a7a254c6e96036b911988530`
+[kubernetes-client-linux-arm64.tar.gz](https://dl.k8s.io/v1.18.2/kubernetes-client-linux-arm64.tar.gz) | `54b10261c354e99d3eeee862461f0c3f99ff0e3b603230da7a48e182fd5890e438ff5bc8daafc74a3be9411a873d9ed611cea99c038fff53aa9e57d8d7140662`
+[kubernetes-client-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.18.2/kubernetes-client-linux-ppc64le.tar.gz) | `b9694a0cf9e42bc9299d923de79e61ec52419a1889605cfd2eb5e6f9277191a0a1c6b7ceaf251735e576ad4aa73465c1c6a48b977243e45b6449fe7017dad18b`
+[kubernetes-client-linux-s390x.tar.gz](https://dl.k8s.io/v1.18.2/kubernetes-client-linux-s390x.tar.gz) | `144861c7cfc28b63da11de4b847d68bb4a984b5eeb54ccbccf998bd87e0e2832d38d3610056cf2e5d3a59535a0f8213bebd9369f0f6c1fd947afad41fdcc8837`
+[kubernetes-client-windows-386.tar.gz](https://dl.k8s.io/v1.18.2/kubernetes-client-windows-386.tar.gz) | `3fa6e6fdf88b7f9ae7dc8f95526977aea6e2fe65fdbb988c2ea40d160ba30342453ee9e0ce022c69d8635405ad92c6672d775e8e477cf3c937c1bbb7217fb279`
+[kubernetes-client-windows-amd64.tar.gz](https://dl.k8s.io/v1.18.2/kubernetes-client-windows-amd64.tar.gz) | `733887310c94e70fb33c6fbea9c5e7d4a74b4c2402735ed7856eb2e009bb0ed2aab3abeb1d13b46681e876df6901bd2be6547a25061a8e8df442301179b82fc9`
+
+### Server Binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-server-linux-amd64.tar.gz](https://dl.k8s.io/v1.18.2/kubernetes-server-linux-amd64.tar.gz) | `f808e85a5e6f8dfed18ee3479691be8283c13c787ad5abb1a06f1c84aa7e7894af9028c6edcc4cdfe2cccf58e9c8394a6958facc92364d388a62ebf6aa9db2e8`
+[kubernetes-server-linux-arm.tar.gz](https://dl.k8s.io/v1.18.2/kubernetes-server-linux-arm.tar.gz) | `7ec6d47cda5f8f2cafaa82ac1179dc181d93562d1a2ad7687dca5dba8737498c0488275eb0ba33018c48e684550fa8612d03726251ed24fdebc893286528a401`
+[kubernetes-server-linux-arm64.tar.gz](https://dl.k8s.io/v1.18.2/kubernetes-server-linux-arm64.tar.gz) | `f5341be0c84cbf383662ed333bb2f9a4b83f80b6ebe77526ed2a407e3cd566f643be030c367606da4eb563523119f7bd8a9a7173b91cc5466602b5f9e1c34921`
+[kubernetes-server-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.18.2/kubernetes-server-linux-ppc64le.tar.gz) | `1c861320ddd63c9731781079fb00d9b0c80befe9b98103056f3abdd214cdd4974b1d79196491fb7c953d0126343fb6d7b9a6a7ca1684b8d8c5db686e1647106b`
+[kubernetes-server-linux-s390x.tar.gz](https://dl.k8s.io/v1.18.2/kubernetes-server-linux-s390x.tar.gz) | `5e57f536844d606873412a5ca46e85c4a6deae5e5dc415b3fbd0b20a58750cd0360265bc237102a8050db795c1293d6d7530cb5183e0ca25bc8e93f3f5fc650c`
+
+### Node Binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-node-linux-amd64.tar.gz](https://dl.k8s.io/v1.18.2/kubernetes-node-linux-amd64.tar.gz) | `b342dbb9fce1c2667ed255e0b7457063e7f4827a74d4c946087bb471144a552e93e17e624075273fd72b1788fc9219ae46a8d8b1c247b2f26320e932143fef1b`
+[kubernetes-node-linux-arm.tar.gz](https://dl.k8s.io/v1.18.2/kubernetes-node-linux-arm.tar.gz) | `d74d6b9a0c05623fb5f3b7423517c3a8c03f6fd18525554cae5704cadc3676d70d42d0537de70f7b7619e31640a8c510b4321e0eeada49300d9c92cac2a9217a`
+[kubernetes-node-linux-arm64.tar.gz](https://dl.k8s.io/v1.18.2/kubernetes-node-linux-arm64.tar.gz) | `d80716155df8ee997b4d81573ab713a04f64e91ec0e7c6c77af2e0031bbbe1f250cc463a7788e548217f6e7071caf458239869f2863737f3007a8cf79abff9cc`
+[kubernetes-node-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.18.2/kubernetes-node-linux-ppc64le.tar.gz) | `89fe1dbbbefe36169232b46b564fc46b96cf6987bca8c1f9c61475d07a771c65f63cdf4c66168e9c515ec862f65b83d5a7668425e956a109e1aa60e0988d4a57`
+[kubernetes-node-linux-s390x.tar.gz](https://dl.k8s.io/v1.18.2/kubernetes-node-linux-s390x.tar.gz) | `734e11c10c4e8dea9931ce0e832dac8495808acb7940ca2be4a13cedbea53b537973320e80b9f021c37c10c9510dcf328b0f975c40afebc301ea3d3937a3c36a`
+[kubernetes-node-windows-amd64.tar.gz](https://dl.k8s.io/v1.18.2/kubernetes-node-windows-amd64.tar.gz) | `f121f7893c102ecd491189077ccbddd7aa0625cf2bfe855a7be00cfe615e6d397928cb5448092993626f33b216e89ac11bd0c09255847e1b6ba9a54a933eee53`
+
+## Changelog since v1.18.1
+
+## Changes by Kind
+
+### Bug or Regression
+
+- Client-go: resolves an issue with informers falling back to full list requests when timeouts are encountered, rather than re-establishing a watch. ([#89975](https://github.com/kubernetes/kubernetes/pull/89975), [@liggitt](https://github.com/liggitt)) [SIG API Machinery and Testing]
+- Fix scheduler crash when removing node before its pods ([#89908](https://github.com/kubernetes/kubernetes/pull/89908), [@alculquicondor](https://github.com/alculquicondor)) [SIG Scheduling]
+- Fixes conversion error for HorizontalPodAutoscaler objects with invalid annotations ([#89965](https://github.com/kubernetes/kubernetes/pull/89965), [@liggitt](https://github.com/liggitt)) [SIG Autoscaling]
+- Fixes kubectl apply/prune in namespace other than default. ([#90016](https://github.com/kubernetes/kubernetes/pull/90016), [@seans3](https://github.com/seans3)) [SIG CLI and Testing]
+- For GCE cluster provider, fix bug of not being able to create internal type load balancer for clusters with more than 1000 nodes in a single zone. ([#89902](https://github.com/kubernetes/kubernetes/pull/89902), [@wojtek-t](https://github.com/wojtek-t)) [SIG Cloud Provider, Network and Scalability]
+- Restores priority of static control plane pods in the cluster/gce/manifests control-plane manifests ([#89970](https://github.com/kubernetes/kubernetes/pull/89970), [@liggitt](https://github.com/liggitt)) [SIG Cluster Lifecycle and Node]
+
+
+# v1.18.1
+
+[Documentation](https://docs.k8s.io)
+
+## Downloads for v1.18.1
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes.tar.gz](https://dl.k8s.io/v1.18.1/kubernetes.tar.gz) | `460dcc0b27fdfd9b4a574287708c0fef22224bd4c1bc777654a69a76c7dafb37e6a37b028aeaa8d79e202c2265fe4b322af6a95515cd438e44de7d55dac176b3`
+[kubernetes-src.tar.gz](https://dl.k8s.io/v1.18.1/kubernetes-src.tar.gz) | `adc6b3ccc9792794b97d2c8c7e5d582ac92aedfa83bb9cdfb782057ce4e80985e940eeb8f3e943b90919927fe8ce65863077e526b56e7675ee1d5d66760d08b6`
+
+### Client Binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-client-darwin-386.tar.gz](https://dl.k8s.io/v1.18.1/kubernetes-client-darwin-386.tar.gz) | `fe7c496778172012504839175c48c69337afc7341c8c71d2858bf9319a2bb4673abeb95b1415ae4abaa2364f24b410edaada963beeb614b361f6d412bf4c9352`
+[kubernetes-client-darwin-amd64.tar.gz](https://dl.k8s.io/v1.18.1/kubernetes-client-darwin-amd64.tar.gz) | `a62a894ae001cb3f245595488a46c8c8c5c52d15eb9eefc7b458df6c93399e58eba52d1ca0dc8df1ee74ea75ecea3ab4853eea4bf830dfb89be3b4d6a5d0d83c`
+[kubernetes-client-linux-386.tar.gz](https://dl.k8s.io/v1.18.1/kubernetes-client-linux-386.tar.gz) | `4cd898e86510f17d0a34c8721f942d81bdaafbf4d6513efde2710aad7dc44e89b6d986491c444f57ad9f183ac376031ecdb8e6dbee7dea76f7e4df116fb3998a`
+[kubernetes-client-linux-amd64.tar.gz](https://dl.k8s.io/v1.18.1/kubernetes-client-linux-amd64.tar.gz) | `37e664e40bb31765572215cf262a5c9bbc7748d158d0db58dbec2d5e593b54d71586af77296eda1cec2a2230b1d27260c51f6410b83afeeafc3c5354c308b4c4`
+[kubernetes-client-linux-arm.tar.gz](https://dl.k8s.io/v1.18.1/kubernetes-client-linux-arm.tar.gz) | `196977d4a09046abb168ea4c6cde261a90226cd391d74877ce1d9907bc8ba670d0365311980422493125a2cde8648ece0035ff1af6d9507975428129de603c83`
+[kubernetes-client-linux-arm64.tar.gz](https://dl.k8s.io/v1.18.1/kubernetes-client-linux-arm64.tar.gz) | `675f27c170eb888f08db834f03b8123d19f0f2dd357c694c6c1cae59067c8d6b0b2db82b9cefc105dd16079ef6f7261e03fe9a73089c03dd3d53b1d68ed1cf68`
+[kubernetes-client-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.18.1/kubernetes-client-linux-ppc64le.tar.gz) | `dd317cf29ed7cfa664a0f88651273565ca831138994cb37d8d53f5ba3993a6da529a377ded98d65c31450b31e1647fb87bc708f2aec6b2ef6a2bea9c73fb73fb`
+[kubernetes-client-linux-s390x.tar.gz](https://dl.k8s.io/v1.18.1/kubernetes-client-linux-s390x.tar.gz) | `57db3fcc952ad57d94f3b92022c1881b3852b321535501af7b2dfca9eb0acde03a34c5863aad6fe304fc4aaa922ff538d5dae7bc8c375a05956f892c265fbaf1`
+[kubernetes-client-windows-386.tar.gz](https://dl.k8s.io/v1.18.1/kubernetes-client-windows-386.tar.gz) | `ad52ae356e9d0156bdaa5ed4c77cd0226610fd715093e2caf7466c1bf87bb9bb2f21a48e9676f265c52de301bc416ce17cda5ac9fd7d379323c977c5f07ee9cd`
+[kubernetes-client-windows-amd64.tar.gz](https://dl.k8s.io/v1.18.1/kubernetes-client-windows-amd64.tar.gz) | `efe66bb5ae58e06c7787b98fc69e191502dadecf719636788f25bff7bd0e50d7d170c5e729611406c304afd159b33b0048c436e823276b0fc9d4c07904ba7974`
+
+### Server Binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-server-linux-amd64.tar.gz](https://dl.k8s.io/v1.18.1/kubernetes-server-linux-amd64.tar.gz) | `2183d1fcfca1370f75146797100801d7fbfec97789d1ca5eef4aff79bf66e01869ddaac51ab76abc073026682fe4d7ee658ffed99b5324ad285019c8dabcfea6`
+[kubernetes-server-linux-arm.tar.gz](https://dl.k8s.io/v1.18.1/kubernetes-server-linux-arm.tar.gz) | `8ca77be8dd999e0a31bb9de597f383628941b7d6537cec19ce3a77c8f4fc537c649e9ce0bd43ec4ecb387d224654804f6f4682c80c26ba7e97cab6aff5b57e21`
+[kubernetes-server-linux-arm64.tar.gz](https://dl.k8s.io/v1.18.1/kubernetes-server-linux-arm64.tar.gz) | `b1eacba21d8740bba785f94b66aea1fb9e4529bea9740d938cd52409acc970f0a93ec5c857059d3d3f555f9eb6cd4f799c42266ad493676b3fed7f1deaf5a878`
+[kubernetes-server-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.18.1/kubernetes-server-linux-ppc64le.tar.gz) | `dc8426bd333aa2fe703003356a6237df760c6753c142e6fea28cbf13656e53eb26d99b862000813ba94fe2041fc073271217879b7036546a7bd4b848aa569f6b`
+[kubernetes-server-linux-s390x.tar.gz](https://dl.k8s.io/v1.18.1/kubernetes-server-linux-s390x.tar.gz) | `2398638d5724627573326b6820cb268d30d47f18afc913d367f518ba8cde8a419b0dc394b925be310c95aa0f3705f625ff0f628a11da38cdf94da4f493e9bb75`
+
+### Node Binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-node-linux-amd64.tar.gz](https://dl.k8s.io/v1.18.1/kubernetes-node-linux-amd64.tar.gz) | `88a9b68c8cba77fe50751d998117ab632d1e8aa12a45f6bef71a24ee5a8fb6f559d00f129b8682f9d5838671edb6649e3c9caebdf9ce2a37f282f21316a522e0`
+[kubernetes-node-linux-arm.tar.gz](https://dl.k8s.io/v1.18.1/kubernetes-node-linux-arm.tar.gz) | `3b558a1743893a994ec061a86aaf343d90e800d7ccd69c771b92d8915fc14217046a2f4817829dbdbe025331fe733ae401dbf671b4345d7a88b0c6470fbd99e8`
+[kubernetes-node-linux-arm64.tar.gz](https://dl.k8s.io/v1.18.1/kubernetes-node-linux-arm64.tar.gz) | `534b3db7e21f247189a484bb57958a3276bf74268d5943d712e68db50806afeeb1253acdc6a4c639c6ac08045e95ac4f9aaf95fa8192c85a19831329068bf5c6`
+[kubernetes-node-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.18.1/kubernetes-node-linux-ppc64le.tar.gz) | `0bb1c7ee23ce7dbee0614e2d8fb8d79e0a36615ea4ea39ef97acf4e907ca5a9b57ee3735afc7b5bce8dd5b15f104cf37e1d92168684bb4e5fd053ed3c35802e6`
+[kubernetes-node-linux-s390x.tar.gz](https://dl.k8s.io/v1.18.1/kubernetes-node-linux-s390x.tar.gz) | `e4529b0804696c8bae9430411d5b51087fa6c204bef37a1c6e30d01490c7e996367f1e9aa1d9c10ca2faf9d90c02459fc36c64b1790fa88b703bb134df54c1c1`
+[kubernetes-node-windows-amd64.tar.gz](https://dl.k8s.io/v1.18.1/kubernetes-node-windows-amd64.tar.gz) | `7d976b1b22766cdd65b2b84602053b765e487d947966b4aaa3b169bb462d095e6a794154cd920b2c5e8a2d59695b75435ddb1237bc07404bba1273a0db01539e`
+
+## Changelog since v1.18.0
+
+## Changes by Kind
+
+### Feature
+
+- deps: Update to Golang 1.13.9
+  - build: Remove kube-cross image building ([#89398](https://github.com/kubernetes/kubernetes/pull/89398), [@justaugustus](https://github.com/justaugustus)) [SIG Release and Testing]
+
+### Other (Bug, Cleanup or Flake)
+
+- Azure: fix concurreny issue in lb creation ([#89604](https://github.com/kubernetes/kubernetes/pull/89604), [@aramase](https://github.com/aramase)) [SIG Cloud Provider]
+- Ensure Azure availability zone is always in lower cases. ([#89722](https://github.com/kubernetes/kubernetes/pull/89722), [@feiskyer](https://github.com/feiskyer)) [SIG Cloud Provider]
+- Fix kubectl diff so it doesn't actually persist patches ([#89795](https://github.com/kubernetes/kubernetes/pull/89795), [@julianvmodesto](https://github.com/julianvmodesto)) [SIG CLI and Testing]
+- Fix: get attach disk error due to missing item in max count table ([#89768](https://github.com/kubernetes/kubernetes/pull/89768), [@andyzhangx](https://github.com/andyzhangx)) [SIG Cloud Provider and Storage]
+- Fixed the EndpointSlice controller to run without error on a cluster with the OwnerReferencesPermissionEnforcement validating admission plugin enabled. ([#89804](https://github.com/kubernetes/kubernetes/pull/89804), [@marun](https://github.com/marun)) [SIG Auth and Network]
+- Fixes kubectl to apply all validly built objects, instead of stopping on error. ([#89864](https://github.com/kubernetes/kubernetes/pull/89864), [@seans3](https://github.com/seans3)) [SIG CLI and Testing]
+- In the kubelet resource metrics endpoint at /metrics/resource, change the names of the following metrics:
+  - node_cpu_usage_seconds --> node_cpu_usage_seconds_total
+  - container_cpu_usage_seconds --> container_cpu_usage_seconds_total
+  This is a partial revert of &#35;86282, which was added in 1.18.0, and initially removed the _total suffix ([#89540](https://github.com/kubernetes/kubernetes/pull/89540), [@dashpole](https://github.com/dashpole)) [SIG Instrumentation and Node]
+- Kubeadm: during join when a check is performed that a Node with the same name already exists in the cluster, make sure the NodeReady condition is properly validated ([#89602](https://github.com/kubernetes/kubernetes/pull/89602), [@kvaps](https://github.com/kvaps)) [SIG Cluster Lifecycle]
+- Kubeadm: fix a bug where post upgrade to 1.18.x, nodes cannot join the cluster due to missing RBAC ([#89537](https://github.com/kubernetes/kubernetes/pull/89537), [@neolit123](https://github.com/neolit123)) [SIG Cluster Lifecycle]
+- Kubectl azure authentication: fixed a regression in 1.18.0 where "spn:" prefix was unexpectedly added to the `apiserver-id` configuration in the kubeconfig file ([#89706](https://github.com/kubernetes/kubernetes/pull/89706), [@weinong](https://github.com/weinong)) [SIG API Machinery and Auth]
+- Kubectl: Fixes bug by aggregating 'apply' errors instead of failing after first error ([#89607](https://github.com/kubernetes/kubernetes/pull/89607), [@seans3](https://github.com/seans3)) [SIG CLI and Testing]
+- Reduce event spam during a volume operation error. ([#89796](https://github.com/kubernetes/kubernetes/pull/89796), [@msau42](https://github.com/msau42)) [SIG Storage]
+
+
+# v1.18.0
+
+[Documentation](https://docs.k8s.io)
+
+## Downloads for v1.18.0
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes.tar.gz](https://dl.k8s.io/v1.18.0/kubernetes.tar.gz) | `cd5b86a3947a4f2cea6d857743ab2009be127d782b6f2eb4d37d88918a5e433ad2c7ba34221c34089ba5ba13701f58b657f0711401e51c86f4007cb78744dee7`
+[kubernetes-src.tar.gz](https://dl.k8s.io/v1.18.0/kubernetes-src.tar.gz) | `fb42cf133355ef18f67c8c4bb555aa1f284906c06e21fa41646e086d34ece774e9d547773f201799c0c703ce48d4d0e62c6ba5b2a4d081e12a339a423e111e52`
+
+### Client Binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-client-darwin-386.tar.gz](https://dl.k8s.io/v1.18.0/kubernetes-client-darwin-386.tar.gz) | `26df342ef65745df12fa52931358e7f744111b6fe1e0bddb8c3c6598faf73af997c00c8f9c509efcd7cd7e82a0341a718c08fbd96044bfb58e80d997a6ebd3c2`
+[kubernetes-client-darwin-amd64.tar.gz](https://dl.k8s.io/v1.18.0/kubernetes-client-darwin-amd64.tar.gz) | `803a0fed122ef6b85f7a120b5485723eaade765b7bc8306d0c0da03bd3df15d800699d15ea2270bb7797fa9ce6a81da90e730dc793ea4ed8c0149b63d26eca30`
+[kubernetes-client-linux-386.tar.gz](https://dl.k8s.io/v1.18.0/kubernetes-client-linux-386.tar.gz) | `110844511b70f9f3ebb92c15105e6680a05a562cd83f79ce2d2e25c2dd70f0dbd91cae34433f61364ae1ce4bd573b635f2f632d52de8f72b54acdbc95a15e3f0`
+[kubernetes-client-linux-amd64.tar.gz](https://dl.k8s.io/v1.18.0/kubernetes-client-linux-amd64.tar.gz) | `594ca3eadc7974ec4d9e4168453e36ca434812167ef8359086cd64d048df525b7bd46424e7cc9c41e65c72bda3117326ba1662d1c9d739567f10f5684fd85bee`
+[kubernetes-client-linux-arm.tar.gz](https://dl.k8s.io/v1.18.0/kubernetes-client-linux-arm.tar.gz) | `d3627b763606557a6c9a5766c34198ec00b3a3cd72a55bc2cb47731060d31c4af93543fb53f53791062bb5ace2f15cbaa8592ac29009641e41bd656b0983a079`
+[kubernetes-client-linux-arm64.tar.gz](https://dl.k8s.io/v1.18.0/kubernetes-client-linux-arm64.tar.gz) | `ba9056eff1452cbdaef699efbf88f74f5309b3f7808d372ebf6918442d0c9fea1653c00b9db3b7626399a460eef9b1fa9e29b827b7784f34561cbc380554e2ea`
+[kubernetes-client-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.18.0/kubernetes-client-linux-ppc64le.tar.gz) | `f80fb3769358cb20820ff1a1ce9994de5ed194aabe6c73fb8b8048bffc394d1b926de82c204f0e565d53ffe7562faa87778e97a3ccaaaf770034a992015e3a86`
+[kubernetes-client-linux-s390x.tar.gz](https://dl.k8s.io/v1.18.0/kubernetes-client-linux-s390x.tar.gz) | `a9b658108b6803d60fa3cd4e76d9e58bf75201017164fe54054b7ccadbb68c4ad7ba7800746940bc518d90475e6c0a96965a26fa50882f4f0e56df404f4ae586`
+[kubernetes-client-windows-386.tar.gz](https://dl.k8s.io/v1.18.0/kubernetes-client-windows-386.tar.gz) | `18adffab5d1be146906fd8531f4eae7153576aac235150ce2da05aee5ae161f6bd527e8dec34ae6131396cd4b3771e0d54ce770c065244ad3175a1afa63c89e1`
+[kubernetes-client-windows-amd64.tar.gz](https://dl.k8s.io/v1.18.0/kubernetes-client-windows-amd64.tar.gz) | `162396256429cef07154f817de2a6b67635c770311f414e38b1e2db25961443f05d7b8eb1f8da46dec8e31c5d1d2cd45f0c95dad1bc0e12a0a7278a62a0b9a6b`
+
+### Server Binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-server-linux-amd64.tar.gz](https://dl.k8s.io/v1.18.0/kubernetes-server-linux-amd64.tar.gz) | `a92f8d201973d5dfa44a398e95fcf6a7b4feeb1ef879ab3fee1c54370e21f59f725f27a9c09ace8c42c96ac202e297fd458e486c489e05f127a5cade53b8d7c4`
+[kubernetes-server-linux-arm.tar.gz](https://dl.k8s.io/v1.18.0/kubernetes-server-linux-arm.tar.gz) | `62fbff3256bc0a83f70244b09149a8d7870d19c2c4b6dee8ca2714fc7388da340876a0f540d2ae9bbd8b81fdedaf4b692c72d2840674db632ba2431d1df1a37d`
+[kubernetes-server-linux-arm64.tar.gz](https://dl.k8s.io/v1.18.0/kubernetes-server-linux-arm64.tar.gz) | `842910a7013f61a60d670079716b207705750d55a9e4f1f93696d19d39e191644488170ac94d8740f8e3aa3f7f28f61a4347f69d7e93d149c69ac0efcf3688fe`
+[kubernetes-server-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.18.0/kubernetes-server-linux-ppc64le.tar.gz) | `95c5b952ac1c4127a5c3b519b664972ee1fb5e8e902551ce71c04e26ad44b39da727909e025614ac1158c258dc60f504b9a354c5ab7583c2ad769717b30b3836`
+[kubernetes-server-linux-s390x.tar.gz](https://dl.k8s.io/v1.18.0/kubernetes-server-linux-s390x.tar.gz) | `a46522d2119a0fd58074564c1fa95dd8a929a79006b82ba3c4245611da8d2db9fd785c482e1b61a9aa361c5c9a6d73387b0e15e6a7a3d84fffb3f65db3b9deeb`
+
+### Node Binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-node-linux-amd64.tar.gz](https://dl.k8s.io/v1.18.0/kubernetes-node-linux-amd64.tar.gz) | `f714f80feecb0756410f27efb4cf4a1b5232be0444fbecec9f25cb85a7ccccdcb5be588cddee935294f460046c0726b90f7acc52b20eeb0c46a7200cf10e351a`
+[kubernetes-node-linux-arm.tar.gz](https://dl.k8s.io/v1.18.0/kubernetes-node-linux-arm.tar.gz) | `806000b5f6d723e24e2f12d19d1b9b3d16c74b855f51c7063284adf1fcc57a96554a3384f8c05a952c6f6b929a05ed12b69151b1e620c958f74c9600f3db0fcb`
+[kubernetes-node-linux-arm64.tar.gz](https://dl.k8s.io/v1.18.0/kubernetes-node-linux-arm64.tar.gz) | `c207e9ab60587d135897b5366af79efe9d2833f33401e469b2a4e0d74ecd2cf6bb7d1e5bc18d80737acbe37555707f63dd581ccc6304091c1d98dafdd30130b7`
+[kubernetes-node-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.18.0/kubernetes-node-linux-ppc64le.tar.gz) | `a542ed5ed02722af44ef12d1602f363fcd4e93cf704da2ea5d99446382485679626835a40ae2ba47a4a26dce87089516faa54479a1cfdee2229e8e35aa1c17d7`
+[kubernetes-node-linux-s390x.tar.gz](https://dl.k8s.io/v1.18.0/kubernetes-node-linux-s390x.tar.gz) | `651e0db73ee67869b2ae93cb0574168e4bd7918290fc5662a6b12b708fa628282e3f64be2b816690f5a2d0f4ff8078570f8187e65dee499a876580a7a63d1d19`
+[kubernetes-node-windows-amd64.tar.gz](https://dl.k8s.io/v1.18.0/kubernetes-node-windows-amd64.tar.gz) | `d726ed904f9f7fe7e8831df621dc9094b87e767410a129aa675ee08417b662ddec314e165f29ecb777110fbfec0dc2893962b6c71950897ba72baaa7eb6371ed`
+
+## Changelog since v1.17.0
+
+A complete changelog for the release notes is now hosted in a customizable
+format at [https://relnotes.k8s.io][1]. Check it out and please give us your
+feedback!
+
+[1]: https://relnotes.k8s.io/?releaseVersions=1.18.0
+
+## What’s New (Major Themes)
+
+### Kubernetes Topology Manager Moves to Beta - Align Up!
+
+A beta feature of Kubernetes in release 1.18, the [Topology Manager feature](https://github.com/nolancon/website/blob/f4200307260ea3234540ef13ed80de325e1a7267/content/en/docs/tasks/administer-cluster/topology-manager.md) enables NUMA alignment of CPU and devices (such as SR-IOV VFs) that will allow your workload to run in an environment optimized for low-latency. Prior to the introduction of the Topology Manager, the CPU and Device Manager would make resource allocation decisions independent of each other. This could result in undesirable allocations on multi-socket systems, causing degraded performance on latency critical applications.
+
+### Serverside Apply - Beta 2
+
+Server-side Apply was promoted to Beta in 1.16, but is now introducing a second Beta in 1.18. This new version will track and manage changes to fields of all new Kubernetes objects, allowing you to know what changed your resources and when.
+
+### Extending Ingress with and replacing a deprecated annotation with IngressClass
+
+In Kubernetes 1.18, there are two significant additions to Ingress: A new `pathType` field and a new `IngressClass` resource. The `pathType` field allows specifying how paths should be matched. In addition to the default `ImplementationSpecific` type, there are new `Exact` and `Prefix` path types. 
+
+The `IngressClass` resource is used to describe a type of Ingress within a Kubernetes cluster. Ingresses can specify the class they are associated with by using a new `ingressClassName` field on Ingresses. This new resource and field replace the deprecated `kubernetes.io/ingress.class` annotation.
+
+### SIG CLI introduces kubectl debug
+
+SIG CLI was debating the need for a debug utility for quite some time already. With the development of [ephemeral containers](https://kubernetes.io/docs/concepts/workloads/pods/ephemeral-containers/), it became more obvious how we can support developers with tooling built on top of `kubectl exec`. The addition of the `kubectl debug` [command](https://github.com/kubernetes/enhancements/blob/master/keps/sig-cli/20190805-kubectl-debug.md) (it is alpha but your feedback is more than welcome), allows developers to easily debug their Pods inside the cluster. We think this addition is invaluable.  This command allows one to create a temporary container which runs next to the Pod one is trying to examine, but also attaches to the console for interactive troubleshooting.
+
+### Introducing Windows CSI support alpha for Kubernetes
+
+With the release of Kubernetes 1.18, an alpha version of CSI Proxy for Windows is getting released. CSI proxy enables non-privileged (pre-approved) containers to perform privileged storage operations on Windows. CSI drivers can now be supported in Windows by leveraging CSI proxy.
+SIG Storage made a lot of progress in the 1.18 release.
+In particular, the following storage features are moving to GA in Kubernetes 1.18:
+- Raw Block Support: Allow volumes to be surfaced as block devices inside containers instead of just mounted filesystems.
+- Volume Cloning: Duplicate a PersistentVolumeClaim and underlying storage volume using the Kubernetes API via CSI.
+- CSIDriver Kubernetes API Object: Simplifies CSI driver discovery and allows CSI Drivers to customize Kubernetes behavior.
+
+SIG Storage is also introducing the following new storage features as alpha in Kubernetes 1.18:
+- Windows CSI Support: Enabling containerized CSI node plugins in Windows via new [CSIProxy](https://github.com/kubernetes-csi/csi-proxy)
+- Recursive Volume Ownership OnRootMismatch Option: Add a new “OnRootMismatch” policy that can help shorten the mount time for volumes that require ownership change and have many directories and files.
+
+### Other notable announcements
+
+SIG Network is moving IPv6 to Beta in Kubernetes 1.18, after incrementing significantly the test coverage with new CI jobs.
+
+NodeLocal DNSCache is an add-on that runs a dnsCache pod as a daemonset to improve clusterDNS performance and reliability. The feature has been in Alpha since 1.13 release. The SIG Network is announcing the GA graduation of Node Local DNSCache [#1351](https://github.com/kubernetes/enhancements/pull/1351)
+
+## Known Issues
+
+No Known Issues Reported
+
+## Urgent Upgrade Notes
+
+### (No, really, you MUST read this before you upgrade)
+
+#### kube-apiserver:
+- in an `--encryption-provider-config` config file, an explicit `cacheSize: 0` parameter previously silently defaulted to caching 1000 keys. In Kubernetes 1.18, this now returns a config validation error. To disable caching, you can specify a negative cacheSize value in Kubernetes 1.18+.
+- consumers of the 'certificatesigningrequests/approval' API must now have permission to 'approve' CSRs for the specific signer requested by the CSR. More information on the new signerName field and the required authorization can be found at https://kubernetes.io/docs/reference/access-authn-authz/certificate-signing-requests#authorization ([#88246](https://github.com/kubernetes/kubernetes/pull/88246), [@munnerz](https://github.com/munnerz)) [SIG API Machinery, Apps, Auth, CLI, Node and Testing]
+- The following features are unconditionally enabled and the corresponding `--feature-gates` flags have been removed: `PodPriority`, `TaintNodesByCondition`, `ResourceQuotaScopeSelectors` and `ScheduleDaemonSetPods` ([#86210](https://github.com/kubernetes/kubernetes/pull/86210), [@draveness](https://github.com/draveness)) [SIG Apps and Scheduling]
+
+#### kubelet:
+- `--enable-cadvisor-endpoints` is now disabled by default. If you need access to the cAdvisor v1 Json API please enable it explicitly in the kubelet command line. Please note that this flag was deprecated in 1.15 and will be removed in 1.19. ([#87440](https://github.com/kubernetes/kubernetes/pull/87440), [@dims](https://github.com/dims)) [SIG Instrumentation, Node and Testing]
+- Promote CSIMigrationOpenStack to Beta (off by default since it requires installation of the OpenStack Cinder CSI Driver. The in-tree AWS OpenStack Cinder driver "kubernetes.io/cinder" was deprecated in 1.16 and will be removed in 1.20. Users should enable CSIMigration + CSIMigrationOpenStack features and install the OpenStack Cinder CSI Driver (https://github.com/kubernetes-sigs/cloud-provider-openstack) to avoid disruption to existing Pod and PVC objects at that time. Users should start using the OpenStack Cinder CSI Driver directly for any new volumes. ([#85637](https://github.com/kubernetes/kubernetes/pull/85637), [@dims](https://github.com/dims)) [SIG Cloud Provider]
+
+#### kubectl:
+- `kubectl` and k8s.io/client-go no longer default to a server address of `http://localhost:8080`. If you own one of these legacy clusters, you are *strongly* encouraged to secure your server. If you cannot secure your server, you can set the `$KUBERNETES_MASTER` environment variable to `http://localhost:8080` to continue defaulting the server address. `kubectl` users can also set the server address using the `--server` flag, or in a kubeconfig file specified via `--kubeconfig` or `$KUBECONFIG`. ([#86173](https://github.com/kubernetes/kubernetes/pull/86173), [@soltysh](https://github.com/soltysh)) [SIG API Machinery, CLI and Testing]
+- `kubectl run` has removed the previously deprecated generators, along with flags unrelated to creating pods. `kubectl run` now only creates pods. See specific `kubectl create` subcommands to create objects other than pods. 
+([#87077](https://github.com/kubernetes/kubernetes/pull/87077), [@soltysh](https://github.com/soltysh)) [SIG Architecture, CLI and Testing]
+- The deprecated command `kubectl rolling-update` has been removed ([#88057](https://github.com/kubernetes/kubernetes/pull/88057), [@julianvmodesto](https://github.com/julianvmodesto)) [SIG Architecture, CLI and Testing]
+
+#### client-go:
+- Signatures on methods in generated clientsets, dynamic, metadata, and scale clients have been modified to accept `context.Context` as a first argument. Signatures of Create, Update, and Patch methods have been updated to accept CreateOptions, UpdateOptions and PatchOptions respectively. Signatures of Delete and DeleteCollection methods now accept DeleteOptions by value instead of by reference. Generated clientsets with the previous interface have been added in new "deprecated" packages to allow incremental migration to the new APIs. The deprecated packages will be removed in the 1.21 release. A tool is available at http://sigs.k8s.io/clientgofix to rewrite method invocations to the new signatures.
+
+- The following deprecated metrics are removed, please convert to the corresponding metrics:
+  - The following replacement metrics are available from v1.14.0:
+      - `rest_client_request_latency_seconds` -> `rest_client_request_duration_seconds`
+      - `scheduler_scheduling_latency_seconds` -> `scheduler_scheduling_duration_seconds `
+      - `docker_operations` -> `docker_operations_total`
+      - `docker_operations_latency_microseconds` -> `docker_operations_duration_seconds`
+      - `docker_operations_errors` -> `docker_operations_errors_total`
+      - `docker_operations_timeout` -> `docker_operations_timeout_total`
+      - `network_plugin_operations_latency_microseconds` -> `network_plugin_operations_duration_seconds`
+      - `kubelet_pod_worker_latency_microseconds` -> `kubelet_pod_worker_duration_seconds`
+      - `kubelet_pod_start_latency_microseconds` -> `kubelet_pod_start_duration_seconds`
+      - `kubelet_cgroup_manager_latency_microseconds` -> `kubelet_cgroup_manager_duration_seconds`
+      - `kubelet_pod_worker_start_latency_microseconds` -> `kubelet_pod_worker_start_duration_seconds`
+      - `kubelet_pleg_relist_latency_microseconds` -> `kubelet_pleg_relist_duration_seconds`
+      - `kubelet_pleg_relist_interval_microseconds` -> `kubelet_pleg_relist_interval_seconds`
+      - `kubelet_eviction_stats_age_microseconds` -> `kubelet_eviction_stats_age_seconds`
+      - `kubelet_runtime_operations` -> `kubelet_runtime_operations_total`
+      - `kubelet_runtime_operations_latency_microseconds` -> `kubelet_runtime_operations_duration_seconds`
+      - `kubelet_runtime_operations_errors` -> `kubelet_runtime_operations_errors_total`
+      - `kubelet_device_plugin_registration_count` -> `kubelet_device_plugin_registration_total`
+      - `kubelet_device_plugin_alloc_latency_microseconds` -> `kubelet_device_plugin_alloc_duration_seconds`
+      - `scheduler_e2e_scheduling_latency_microseconds` -> `scheduler_e2e_scheduling_duration_seconds`
+      - `scheduler_scheduling_algorithm_latency_microseconds` -> `scheduler_scheduling_algorithm_duration_seconds`
+      - `scheduler_scheduling_algorithm_predicate_evaluation` -> `scheduler_scheduling_algorithm_predicate_evaluation_seconds`
+      - `scheduler_scheduling_algorithm_priority_evaluation` -> `scheduler_scheduling_algorithm_priority_evaluation_seconds`
+      - `scheduler_scheduling_algorithm_preemption_evaluation` -> `scheduler_scheduling_algorithm_preemption_evaluation_seconds`
+      - `scheduler_binding_latency_microseconds` -> `scheduler_binding_duration_seconds`
+      - `kubeproxy_sync_proxy_rules_latency_microseconds` -> `kubeproxy_sync_proxy_rules_duration_seconds`
+      - `apiserver_request_latencies` -> `apiserver_request_duration_seconds`
+      - `apiserver_dropped_requests` -> `apiserver_dropped_requests_total`
+      - `etcd_request_latencies_summary` -> `etcd_request_duration_seconds`
+      - `apiserver_storage_transformation_latencies_microseconds ` -> `apiserver_storage_transformation_duration_seconds`
+      - `apiserver_storage_data_key_generation_latencies_microseconds` -> `apiserver_storage_data_key_generation_duration_seconds`
+      - `apiserver_request_count` -> `apiserver_request_total`
+      - `apiserver_request_latencies_summary`
+  - The following replacement metrics are available from v1.15.0:
+      - `apiserver_storage_transformation_failures_total` -> `apiserver_storage_transformation_operations_total` ([#76496](https://github.com/kubernetes/kubernetes/pull/76496), [@danielqsj](https://github.com/danielqsj)) [SIG API Machinery, Cluster Lifecycle, Instrumentation, Network, Node and Scheduling]
+
+## Changes by Kind
+
+### Deprecation
+
+#### kube-apiserver:
+- the following deprecated APIs can no longer be served:
+  - All resources under `apps/v1beta1` and `apps/v1beta2` - use `apps/v1` instead
+  - `daemonsets`, `deployments`, `replicasets` resources under `extensions/v1beta1` - use `apps/v1` instead
+  - `networkpolicies` resources under `extensions/v1beta1` - use `networking.k8s.io/v1` instead
+  - `podsecuritypolicies` resources under `extensions/v1beta1` - use `policy/v1beta1` instead ([#85903](https://github.com/kubernetes/kubernetes/pull/85903), [@liggitt](https://github.com/liggitt)) [SIG API Machinery, Apps, Cluster Lifecycle, Instrumentation and Testing]
+
+#### kube-controller-manager:
+- Azure service annotation service.beta.kubernetes.io/azure-load-balancer-disable-tcp-reset has been deprecated. Its support would be removed in a future release. ([#88462](https://github.com/kubernetes/kubernetes/pull/88462), [@feiskyer](https://github.com/feiskyer)) [SIG Cloud Provider]
+
+#### kubelet:
+- The StreamingProxyRedirects feature and `--redirect-container-streaming` flag are deprecated, and will be removed in a future release. The default behavior (proxy streaming requests through the kubelet) will be the only supported option. If you are setting `--redirect-container-streaming=true`, then you must migrate off this configuration. The flag will no longer be able to be enabled starting in v1.20. If you are not setting the flag, no action is necessary. ([#88290](https://github.com/kubernetes/kubernetes/pull/88290), [@tallclair](https://github.com/tallclair)) [SIG API Machinery and Node]
+- resource metrics endpoint `/metrics/resource/v1alpha1` as well as all metrics under this endpoint have been deprecated. Please convert to the following metrics emitted by endpoint `/metrics/resource`:
+      - scrape_error --> scrape_error
+      - node_cpu_usage_seconds_total --> node_cpu_usage_seconds
+      - node_memory_working_set_bytes --> node_memory_working_set_bytes
+      - container_cpu_usage_seconds_total --> container_cpu_usage_seconds
+      - container_memory_working_set_bytes --> container_memory_working_set_bytes
+      - scrape_error --> scrape_error 
+      ([#86282](https://github.com/kubernetes/kubernetes/pull/86282), [@RainbowMango](https://github.com/RainbowMango)) [SIG Node]
+- In a future release, kubelet will no longer create the CSI NodePublishVolume target directory, in accordance with the CSI specification. CSI drivers may need to be updated accordingly to properly create and process the target path. ([#75535](https://github.com/kubernetes/kubernetes/issues/75535)) [SIG Storage]
+
+#### kube-proxy:
+- `--healthz-port` and `--metrics-port` flags are deprecated, please use `--healthz-bind-address` and `--metrics-bind-address` instead ([#88512](https://github.com/kubernetes/kubernetes/pull/88512), [@SataQiu](https://github.com/SataQiu)) [SIG Network]
+- a new `EndpointSliceProxying` feature gate has been added to control the use of EndpointSlices in kube-proxy. The EndpointSlice feature gate that used to control this behavior no longer affects kube-proxy. This feature has been disabled by default. ([#86137](https://github.com/kubernetes/kubernetes/pull/86137), [@robscott](https://github.com/robscott)) 
+
+#### kubeadm:
+- command line option "kubelet-version" for `kubeadm upgrade node` has been deprecated and will be removed in a future release. ([#87942](https://github.com/kubernetes/kubernetes/pull/87942), [@SataQiu](https://github.com/SataQiu)) [SIG Cluster Lifecycle]
+- deprecate the usage of the experimental flag '--use-api' under the 'kubeadm alpha certs renew' command. ([#88827](https://github.com/kubernetes/kubernetes/pull/88827), [@neolit123](https://github.com/neolit123)) [SIG Cluster Lifecycle]
+- kube-dns is deprecated and will not be supported in a future version ([#86574](https://github.com/kubernetes/kubernetes/pull/86574), [@SataQiu](https://github.com/SataQiu)) [SIG Cluster Lifecycle]
+- the `ClusterStatus` struct present in the kubeadm-config ConfigMap is deprecated and will be removed in a future version. It is going to be maintained by kubeadm until it gets removed. The same information can be found on `etcd` and `kube-apiserver` pod annotations, `kubeadm.kubernetes.io/etcd.advertise-client-urls` and `kubeadm.kubernetes.io/kube-apiserver.advertise-address.endpoint` respectively. ([#87656](https://github.com/kubernetes/kubernetes/pull/87656), [@ereslibre](https://github.com/ereslibre)) [SIG Cluster Lifecycle]
+
+#### kubectl:
+- the boolean and unset values for the --dry-run flag are deprecated and a value --dry-run=server|client|none will be required in a future version. ([#87580](https://github.com/kubernetes/kubernetes/pull/87580), [@julianvmodesto](https://github.com/julianvmodesto)) [SIG CLI]
+- `kubectl apply --server-dry-run` is deprecated and replaced with --dry-run=server ([#87580](https://github.com/kubernetes/kubernetes/pull/87580), [@julianvmodesto](https://github.com/julianvmodesto)) [SIG CLI]
+
+#### add-ons:
+- Remove cluster-monitoring addon ([#85512](https://github.com/kubernetes/kubernetes/pull/85512), [@serathius](https://github.com/serathius)) [SIG Cluster Lifecycle, Instrumentation, Scalability and Testing]
+
+#### kube-scheduler:
+- The `scheduling_duration_seconds` summary metric is deprecated ([#86586](https://github.com/kubernetes/kubernetes/pull/86586), [@xiaoanyunfei](https://github.com/xiaoanyunfei)) [SIG Scheduling]
+- The `scheduling_algorithm_predicate_evaluation_seconds` and
+  `scheduling_algorithm_priority_evaluation_seconds` metrics are deprecated, replaced by `framework_extension_point_duration_seconds[extension_point="Filter"]` and `framework_extension_point_duration_seconds[extension_point="Score"]`. ([#86584](https://github.com/kubernetes/kubernetes/pull/86584), [@xiaoanyunfei](https://github.com/xiaoanyunfei)) [SIG Scheduling]
+- `AlwaysCheckAllPredicates` is deprecated in scheduler Policy API. ([#86369](https://github.com/kubernetes/kubernetes/pull/86369), [@Huang-Wei](https://github.com/Huang-Wei)) [SIG Scheduling]
+
+#### Other deprecations:
+- The k8s.io/node-api component is no longer updated. Instead, use the RuntimeClass types located within k8s.io/api, and the generated clients located within k8s.io/client-go ([#87503](https://github.com/kubernetes/kubernetes/pull/87503), [@liggitt](https://github.com/liggitt)) [SIG Node and Release]
+- Removed the 'client' label from apiserver_request_total. ([#87669](https://github.com/kubernetes/kubernetes/pull/87669), [@logicalhan](https://github.com/logicalhan)) [SIG API Machinery and Instrumentation]
+
+### API Change
+
+#### New API types/versions:
+- A new IngressClass resource has been added to enable better Ingress configuration. ([#88509](https://github.com/kubernetes/kubernetes/pull/88509), [@robscott](https://github.com/robscott)) [SIG API Machinery, Apps, CLI, Network, Node and Testing]
+- The CSIDriver API has graduated to storage.k8s.io/v1, and is now available for use. ([#84814](https://github.com/kubernetes/kubernetes/pull/84814), [@huffmanca](https://github.com/huffmanca)) [SIG Storage]
+
+#### New API fields:
+- autoscaling/v2beta2 HorizontalPodAutoscaler added a `spec.behavior` field that allows scale behavior to be configured. Behaviors are specified separately for scaling up and down. In each direction a stabilization window can be specified as well as a list of policies and how to select amongst them. Policies can limit the absolute number of pods added or removed, or the percentage of pods added or removed. ([#74525](https://github.com/kubernetes/kubernetes/pull/74525), [@gliush](https://github.com/gliush)) [SIG API Machinery, Apps, Autoscaling and CLI]
+- Ingress:
+  - `spec.ingressClassName` replaces the deprecated `kubernetes.io/ingress.class` annotation, and allows associating an Ingress object with a particular controller.
+  - path definitions added a `pathType` field to allow indicating how the specified path should be matched against incoming requests. Valid values are `Exact`, `Prefix`, and `ImplementationSpecific` ([#88587](https://github.com/kubernetes/kubernetes/pull/88587), [@cmluciano](https://github.com/cmluciano)) [SIG Apps, Cluster Lifecycle and Network]
+- The alpha feature `AnyVolumeDataSource` enables PersistentVolumeClaim objects to use the spec.dataSource field to reference a custom type as a data source ([#88636](https://github.com/kubernetes/kubernetes/pull/88636), [@bswartz](https://github.com/bswartz)) [SIG Apps and Storage]
+- The alpha feature `ConfigurableFSGroupPolicy` enables v1 Pods to specify a spec.securityContext.fsGroupChangePolicy policy to control how file permissions are applied to volumes mounted into the pod. ([#88488](https://github.com/kubernetes/kubernetes/pull/88488), [@gnufied](https://github.com/gnufied)) [SIG  Storage]
+- The alpha feature `ServiceAppProtocol` enables setting an `appProtocol` field in ServicePort and EndpointPort definitions. ([#88503](https://github.com/kubernetes/kubernetes/pull/88503), [@robscott](https://github.com/robscott)) [SIG Apps and Network]
+- The alpha feature `ImmutableEphemeralVolumes` enables an `immutable` field in both Secret and ConfigMap objects to mark their contents as immutable. ([#86377](https://github.com/kubernetes/kubernetes/pull/86377), [@wojtek-t](https://github.com/wojtek-t)) [SIG Apps, CLI and Testing]
+
+#### Other API changes:
+- The beta feature `ServerSideApply` enables tracking and managing changed fields for all new objects, which means there will be `managedFields` in `metadata` with the list of managers and their owned fields.
+- The alpha feature `ServiceAccountIssuerDiscovery` enables publishing OIDC discovery information and service account token verification keys at `/.well-known/openid-configuration` and `/openid/v1/jwks` endpoints by API servers configured to issue service account tokens. ([#80724](https://github.com/kubernetes/kubernetes/pull/80724), [@cceckman](https://github.com/cceckman)) [SIG API Machinery, Auth, Cluster Lifecycle and Testing]
+- CustomResourceDefinition schemas that use `x-kubernetes-list-map-keys` to specify properties that uniquely identify list items must make those properties required or have a default value, to ensure those properties are present for all list items. See https://kubernetes.io/docs/reference/using-api/api-concepts/&#35;merge-strategy for details. ([#88076](https://github.com/kubernetes/kubernetes/pull/88076), [@eloyekunle](https://github.com/eloyekunle)) [SIG API Machinery and Testing]
+- CustomResourceDefinition schemas that use `x-kubernetes-list-type: map` or `x-kubernetes-list-type: set` now enable validation that the list items in the corresponding custom resources are unique. ([#84920](https://github.com/kubernetes/kubernetes/pull/84920), [@sttts](https://github.com/sttts)) [SIG API Machinery]
+ 
+#### Configuration file changes:
+
+#### kube-apiserver:
+- The `--egress-selector-config-file` configuration file now accepts an apiserver.k8s.io/v1beta1  EgressSelectorConfiguration configuration object, and has been updated to allow specifying HTTP or GRPC connections to the network proxy ([#87179](https://github.com/kubernetes/kubernetes/pull/87179), [@Jefftree](https://github.com/Jefftree)) [SIG API Machinery, Cloud Provider and Cluster Lifecycle]
+
+#### kube-scheduler:
+- A kubescheduler.config.k8s.io/v1alpha2 configuration file version is now accepted, with support for multiple scheduling profiles ([#87628](https://github.com/kubernetes/kubernetes/pull/87628), [@alculquicondor](https://github.com/alculquicondor)) [SIG Scheduling]
+  - HardPodAffinityWeight moved from a top level ComponentConfig parameter to a PluginConfig parameter of InterPodAffinity Plugin in `kubescheduler.config.k8s.io/v1alpha2` ([#88002](https://github.com/kubernetes/kubernetes/pull/88002), [@alculquicondor](https://github.com/alculquicondor)) [SIG Scheduling and Testing]
+  - Kube-scheduler can run more than one scheduling profile. Given a pod, the profile is selected by using its `.spec.schedulerName`. ([#88285](https://github.com/kubernetes/kubernetes/pull/88285), [@alculquicondor](https://github.com/alculquicondor)) [SIG Apps, Scheduling and Testing]
+  - Scheduler Extenders can now be configured in the v1alpha2 component config ([#88768](https://github.com/kubernetes/kubernetes/pull/88768), [@damemi](https://github.com/damemi)) [SIG Release, Scheduling and Testing]
+  - The PostFilter of scheduler framework is renamed to PreScore in kubescheduler.config.k8s.io/v1alpha2. ([#87751](https://github.com/kubernetes/kubernetes/pull/87751), [@skilxn-go](https://github.com/skilxn-go)) [SIG Scheduling and Testing]
+ 
+#### kube-proxy:
+- Added kube-proxy flags `--ipvs-tcp-timeout`, `--ipvs-tcpfin-timeout`, `--ipvs-udp-timeout` to configure IPVS connection timeouts. ([#85517](https://github.com/kubernetes/kubernetes/pull/85517), [@andrewsykim](https://github.com/andrewsykim)) [SIG Cluster Lifecycle and Network]
+- Added optional `--detect-local-mode` flag to kube-proxy. Valid values are "ClusterCIDR" (default matching previous behavior) and "NodeCIDR" ([#87748](https://github.com/kubernetes/kubernetes/pull/87748), [@satyasm](https://github.com/satyasm)) [SIG Cluster Lifecycle, Network and Scheduling]
+- Kube-controller-manager and kube-scheduler expose profiling by default to match the kube-apiserver.  Use `--enable-profiling=false` to disable. ([#88663](https://github.com/kubernetes/kubernetes/pull/88663), [@deads2k](https://github.com/deads2k)) [SIG API Machinery, Cloud Provider and Scheduling]
+- Kubelet pod resources API now provides the information about active pods only. ([#79409](https://github.com/kubernetes/kubernetes/pull/79409), [@takmatsu](https://github.com/takmatsu)) [SIG Node]
+- New flag `--endpointslice-updates-batch-period` in kube-controller-manager can be used to reduce the number of endpointslice updates generated by pod changes. ([#88745](https://github.com/kubernetes/kubernetes/pull/88745), [@mborsz](https://github.com/mborsz)) [SIG API Machinery, Apps and Network]
+- New flag `--show-hidden-metrics-for-version` in kube-proxy, kubelet, kube-controller-manager, and kube-scheduler can be used to show all hidden metrics that are deprecated in the previous minor release. ([#85279](https://github.com/kubernetes/kubernetes/pull/85279), [@RainbowMango](https://github.com/RainbowMango)) [SIG Cluster Lifecycle and Network]
+
+#### Features graduated to beta:
+  - StartupProbe ([#83437](https://github.com/kubernetes/kubernetes/pull/83437), [@matthyx](https://github.com/matthyx)) [SIG Node, Scalability and Testing]
+
+#### Features graduated to GA:
+  - VolumePVCDataSource ([#88686](https://github.com/kubernetes/kubernetes/pull/88686), [@j-griffith](https://github.com/j-griffith)) [SIG Storage]
+  - TaintBasedEvictions ([#87487](https://github.com/kubernetes/kubernetes/pull/87487), [@skilxn-go](https://github.com/skilxn-go)) [SIG API Machinery, Apps, Node, Scheduling and Testing]
+  - BlockVolume and CSIBlockVolume ([#88673](https://github.com/kubernetes/kubernetes/pull/88673), [@jsafrane](https://github.com/jsafrane)) [SIG Storage]
+  - Windows RunAsUserName ([#87790](https://github.com/kubernetes/kubernetes/pull/87790), [@marosset](https://github.com/marosset)) [SIG Apps and Windows]
+- The following feature gates are removed, because the associated features were unconditionally enabled in previous releases: CustomResourceValidation, CustomResourceSubresources, CustomResourceWebhookConversion, CustomResourcePublishOpenAPI, CustomResourceDefaulting ([#87475](https://github.com/kubernetes/kubernetes/pull/87475), [@liggitt](https://github.com/liggitt)) [SIG API Machinery]
+
+### Feature
+
+- API request throttling (due to a high rate of requests) is now reported in client-go logs at log level 2.  The messages are of the form:`Throttling request took 1.50705208s, request: GET:<URL>` The presence of these messages may indicate to the administrator the need to tune the cluster accordingly. ([#87740](https://github.com/kubernetes/kubernetes/pull/87740), [@jennybuckley](https://github.com/jennybuckley)) [SIG API Machinery]
+- Add support for mount options to the FC volume plugin ([#87499](https://github.com/kubernetes/kubernetes/pull/87499), [@ejweber](https://github.com/ejweber)) [SIG Storage]
+- Added a config-mode flag in azure auth module to enable getting AAD token without spn: prefix in audience claim. When it's not specified, the default behavior doesn't change. ([#87630](https://github.com/kubernetes/kubernetes/pull/87630), [@weinong](https://github.com/weinong)) [SIG API Machinery, Auth, CLI and Cloud Provider]
+- Allow for configuration of CoreDNS replica count ([#85837](https://github.com/kubernetes/kubernetes/pull/85837), [@pickledrick](https://github.com/pickledrick)) [SIG Cluster Lifecycle]
+- Allow user to specify resource using --filename flag when invoking kubectl exec ([#88460](https://github.com/kubernetes/kubernetes/pull/88460), [@soltysh](https://github.com/soltysh)) [SIG CLI and Testing]
+- Apiserver added a new flag --goaway-chance which is the fraction of requests that will be closed gracefully(GOAWAY) to prevent HTTP/2 clients from getting stuck on a single apiserver. ([#88567](https://github.com/kubernetes/kubernetes/pull/88567), [@answer1991](https://github.com/answer1991)) [SIG API Machinery]
+- Azure Cloud Provider now supports using Azure network resources (Virtual Network, Load Balancer, Public IP, Route Table, Network Security Group, etc.) in different AAD Tenant and Subscription than those for the Kubernetes cluster. To use the feature, please reference https://github.com/kubernetes-sigs/cloud-provider-azure/blob/master/docs/cloud-provider-config.md&#35;host-network-resources-in-different-aad-tenant-and-subscription. ([#88384](https://github.com/kubernetes/kubernetes/pull/88384), [@bowen5](https://github.com/bowen5)) [SIG Cloud Provider]
+- Azure VMSS/VMSSVM clients now suppress requests on throttling ([#86740](https://github.com/kubernetes/kubernetes/pull/86740), [@feiskyer](https://github.com/feiskyer)) [SIG Cloud Provider]
+- Azure cloud provider cache TTL is configurable, list of the azure cloud provider is as following:
+  - "availabilitySetNodesCacheTTLInSeconds"
+  - "vmssCacheTTLInSeconds"
+  - "vmssVirtualMachinesCacheTTLInSeconds"
+  - "vmCacheTTLInSeconds"
+  - "loadBalancerCacheTTLInSeconds"
+  - "nsgCacheTTLInSeconds"
+  - "routeTableCacheTTLInSeconds"
+  ([#86266](https://github.com/kubernetes/kubernetes/pull/86266), [@zqingqing1](https://github.com/zqingqing1)) [SIG Cloud Provider]
+- Azure global rate limit is switched to per-client. A set of new rate limit configure options are introduced, including routeRateLimit, SubnetsRateLimit, InterfaceRateLimit, RouteTableRateLimit, LoadBalancerRateLimit, PublicIPAddressRateLimit, SecurityGroupRateLimit, VirtualMachineRateLimit, StorageAccountRateLimit, DiskRateLimit, SnapshotRateLimit, VirtualMachineScaleSetRateLimit and VirtualMachineSizeRateLimit. The original rate limit options would be default values for those new client's rate limiter. ([#86515](https://github.com/kubernetes/kubernetes/pull/86515), [@feiskyer](https://github.com/feiskyer)) [SIG Cloud Provider]
+- Azure network and VM clients now suppress requests on throttling ([#87122](https://github.com/kubernetes/kubernetes/pull/87122), [@feiskyer](https://github.com/feiskyer)) [SIG Cloud Provider]
+- Azure storage clients now suppress requests on throttling ([#87306](https://github.com/kubernetes/kubernetes/pull/87306), [@feiskyer](https://github.com/feiskyer)) [SIG Cloud Provider]
+- Azure: add support for single stack IPv6 ([#88448](https://github.com/kubernetes/kubernetes/pull/88448), [@aramase](https://github.com/aramase)) [SIG Cloud Provider]
+- DefaultConstraints can be specified for PodTopologySpread Plugin in the scheduler’s ComponentConfig ([#88671](https://github.com/kubernetes/kubernetes/pull/88671), [@alculquicondor](https://github.com/alculquicondor)) [SIG Scheduling]
+- DisableAvailabilitySetNodes is added to avoid VM list for VMSS clusters. It should only be used when vmType is "vmss" and all the nodes (including control plane nodes) are VMSS virtual machines. ([#87685](https://github.com/kubernetes/kubernetes/pull/87685), [@feiskyer](https://github.com/feiskyer)) [SIG Cloud Provider]
+- Elasticsearch supports automatically setting the advertise address ([#85944](https://github.com/kubernetes/kubernetes/pull/85944), [@SataQiu](https://github.com/SataQiu)) [SIG Cluster Lifecycle and Instrumentation]
+- EndpointSlices will now be enabled by default. A new `EndpointSliceProxying` feature gate determines if kube-proxy will use EndpointSlices, this is disabled by default. ([#86137](https://github.com/kubernetes/kubernetes/pull/86137), [@robscott](https://github.com/robscott)) [SIG Network]
+- Kube-proxy: Added dual-stack IPv4/IPv6 support to the iptables proxier. ([#82462](https://github.com/kubernetes/kubernetes/pull/82462), [@vllry](https://github.com/vllry)) [SIG Network]
+- Kubeadm now supports automatic calculations of dual-stack node cidr masks to kube-controller-manager. ([#85609](https://github.com/kubernetes/kubernetes/pull/85609), [@Arvinderpal](https://github.com/Arvinderpal)) [SIG Cluster Lifecycle]
+- Kubeadm: add a upgrade health check that deploys a Job ([#81319](https://github.com/kubernetes/kubernetes/pull/81319), [@neolit123](https://github.com/neolit123)) [SIG Cluster Lifecycle]
+- Kubeadm: add the experimental feature gate PublicKeysECDSA that can be used to create a
+  cluster with ECDSA certificates from "kubeadm init". Renewal of existing ECDSA certificates is also supported using "kubeadm alpha certs renew", but not switching between the RSA and ECDSA algorithms on the fly or during upgrades. ([#86953](https://github.com/kubernetes/kubernetes/pull/86953), [@rojkov](https://github.com/rojkov)) [SIG API Machinery, Auth and Cluster Lifecycle]
+- Kubeadm: implemented structured output of 'kubeadm config images list' command in JSON, YAML, Go template and JsonPath formats ([#86810](https://github.com/kubernetes/kubernetes/pull/86810), [@bart0sh](https://github.com/bart0sh)) [SIG Cluster Lifecycle]
+- Kubeadm: on kubeconfig certificate renewal, keep the embedded CA in sync with the one on disk ([#88052](https://github.com/kubernetes/kubernetes/pull/88052), [@neolit123](https://github.com/neolit123)) [SIG Cluster Lifecycle]
+- Kubeadm: reject a node joining the cluster if a node with the same name already exists ([#81056](https://github.com/kubernetes/kubernetes/pull/81056), [@neolit123](https://github.com/neolit123)) [SIG Cluster Lifecycle]
+- Kubeadm: support Windows specific kubelet flags in kubeadm-flags.env ([#88287](https://github.com/kubernetes/kubernetes/pull/88287), [@gab-satchi](https://github.com/gab-satchi)) [SIG Cluster Lifecycle and Windows]
+- Kubeadm: support automatic retry after failing to pull image ([#86899](https://github.com/kubernetes/kubernetes/pull/86899), [@SataQiu](https://github.com/SataQiu)) [SIG Cluster Lifecycle]
+- Kubeadm: upgrade supports fallback to the nearest known etcd version if an unknown k8s version is passed ([#88373](https://github.com/kubernetes/kubernetes/pull/88373), [@SataQiu](https://github.com/SataQiu)) [SIG Cluster Lifecycle]
+- Kubectl/drain: add disable-eviction option.Force drain to use delete, even if eviction is supported. This will bypass checking PodDisruptionBudgets, and should be used with caution. ([#85571](https://github.com/kubernetes/kubernetes/pull/85571), [@michaelgugino](https://github.com/michaelgugino)) [SIG CLI]
+- Kubectl/drain: add skip-wait-for-delete-timeout option. If a pod’s  `DeletionTimestamp` is older than N seconds, skip waiting for the pod.  Seconds must be greater than 0 to skip. ([#85577](https://github.com/kubernetes/kubernetes/pull/85577), [@michaelgugino](https://github.com/michaelgugino)) [SIG CLI]
+- Option `preConfiguredBackendPoolLoadBalancerTypes` is added to azure cloud provider for the pre-configured load balancers, possible values: `""`, `"internal"`, `"external"`,`"all"` ([#86338](https://github.com/kubernetes/kubernetes/pull/86338), [@gossion](https://github.com/gossion)) [SIG Cloud Provider]
+- PodTopologySpread plugin now excludes terminatingPods when making scheduling decisions. ([#87845](https://github.com/kubernetes/kubernetes/pull/87845), [@Huang-Wei](https://github.com/Huang-Wei)) [SIG Scheduling]
+- Provider/azure: Network security groups can now be in a separate resource group. ([#87035](https://github.com/kubernetes/kubernetes/pull/87035), [@CecileRobertMichon](https://github.com/CecileRobertMichon)) [SIG Cloud Provider]
+- SafeSysctlWhitelist: add net.ipv4.ping_group_range ([#85463](https://github.com/kubernetes/kubernetes/pull/85463), [@AkihiroSuda](https://github.com/AkihiroSuda)) [SIG Auth]
+- Scheduler framework permit plugins now run at the end of the scheduling cycle, after reserve plugins. Waiting on permit will remain in the beginning of the binding cycle. ([#88199](https://github.com/kubernetes/kubernetes/pull/88199), [@mateuszlitwin](https://github.com/mateuszlitwin)) [SIG Scheduling]
+- Scheduler: Add DefaultBinder plugin ([#87430](https://github.com/kubernetes/kubernetes/pull/87430), [@alculquicondor](https://github.com/alculquicondor)) [SIG Scheduling and Testing]
+- Skip default spreading scoring plugin for pods that define TopologySpreadConstraints ([#87566](https://github.com/kubernetes/kubernetes/pull/87566), [@skilxn-go](https://github.com/skilxn-go)) [SIG Scheduling]
+- The kubectl --dry-run flag now accepts the values 'client', 'server', and 'none', to support client-side and server-side dry-run strategies. The boolean and unset values for the --dry-run flag are deprecated and a value will be required in a future version. ([#87580](https://github.com/kubernetes/kubernetes/pull/87580), [@julianvmodesto](https://github.com/julianvmodesto)) [SIG CLI]
+- Support server-side dry-run in kubectl with --dry-run=server for commands including apply, patch, create, run, annotate, label, set, autoscale, drain, rollout undo, and expose. ([#87714](https://github.com/kubernetes/kubernetes/pull/87714), [@julianvmodesto](https://github.com/julianvmodesto)) [SIG API Machinery, CLI and Testing]
+- Add --dry-run=server|client to kubectl delete, taint, replace ([#88292](https://github.com/kubernetes/kubernetes/pull/88292), [@julianvmodesto](https://github.com/julianvmodesto)) [SIG CLI and Testing]
+- The feature PodTopologySpread (feature gate `EvenPodsSpread`) has been enabled by default in 1.18. ([#88105](https://github.com/kubernetes/kubernetes/pull/88105), [@Huang-Wei](https://github.com/Huang-Wei)) [SIG Scheduling and Testing]
+- The kubelet and the default docker runtime now support running ephemeral containers in the Linux process namespace of a target container. Other container runtimes must implement support for this feature before it will be available for that runtime. ([#84731](https://github.com/kubernetes/kubernetes/pull/84731), [@verb](https://github.com/verb)) [SIG Node]
+- The underlying format of the `CPUManager` state file has changed. Upgrades should be seamless, but any third-party tools that rely on reading the previous format need to be updated. ([#84462](https://github.com/kubernetes/kubernetes/pull/84462), [@klueska](https://github.com/klueska)) [SIG Node and Testing]
+- Update CNI version to v0.8.5 ([#78819](https://github.com/kubernetes/kubernetes/pull/78819), [@justaugustus](https://github.com/justaugustus)) [SIG API Machinery, Cluster Lifecycle, Network, Release and Testing]
+- Webhooks have alpha support for network proxy ([#85870](https://github.com/kubernetes/kubernetes/pull/85870), [@Jefftree](https://github.com/Jefftree)) [SIG API Machinery, Auth and Testing]
+- When client certificate files are provided, reload files for new connections, and close connections when a certificate changes. ([#79083](https://github.com/kubernetes/kubernetes/pull/79083), [@jackkleeman](https://github.com/jackkleeman)) [SIG API Machinery, Auth, Node and Testing]
+- When deleting objects using kubectl with the --force flag, you are no longer required to also specify --grace-period=0. ([#87776](https://github.com/kubernetes/kubernetes/pull/87776), [@brianpursley](https://github.com/brianpursley)) [SIG CLI]
+- Windows nodes on GCE can use virtual TPM-based authentication to the control plane. ([#85466](https://github.com/kubernetes/kubernetes/pull/85466), [@pjh](https://github.com/pjh)) [SIG Cluster Lifecycle]
+- You can now pass "--node-ip ::" to kubelet to indicate that it should autodetect an IPv6 address to use as the node's primary address. ([#85850](https://github.com/kubernetes/kubernetes/pull/85850), [@danwinship](https://github.com/danwinship)) [SIG Cloud Provider, Network and Node]
+- `kubectl` now contains a `kubectl alpha debug` command. This command allows attaching an ephemeral container to a running pod for the purposes of debugging. ([#88004](https://github.com/kubernetes/kubernetes/pull/88004), [@verb](https://github.com/verb)) [SIG CLI]
+- TLS Server Name overrides can now be specified in a kubeconfig file and via --tls-server-name in kubectl ([#88769](https://github.com/kubernetes/kubernetes/pull/88769), [@deads2k](https://github.com/deads2k)) [SIG API Machinery, Auth and CLI]
+
+#### Metrics:
+- Add `rest_client_rate_limiter_duration_seconds` metric to component-base to track client side rate limiter latency in seconds. Broken down by verb and URL. ([#88134](https://github.com/kubernetes/kubernetes/pull/88134), [@jennybuckley](https://github.com/jennybuckley)) [SIG API Machinery, Cluster Lifecycle and Instrumentation]
+- Added two client certificate metrics for exec auth:
+    - `rest_client_certificate_expiration_seconds` a gauge reporting the lifetime of the current client certificate. Reports the time of expiry in seconds since January 1, 1970 UTC.
+    - `rest_client_certificate_rotation_age` a histogram reporting the age of a just rotated client certificate in seconds. ([#84382](https://github.com/kubernetes/kubernetes/pull/84382), [@sambdavidson](https://github.com/sambdavidson)) [SIG API Machinery, Auth, Cluster Lifecycle and Instrumentation]
+- Controller manager serve workqueue metrics ([#87967](https://github.com/kubernetes/kubernetes/pull/87967), [@zhan849](https://github.com/zhan849)) [SIG API Machinery]
+- Following metrics have been turned off:
+  - kubelet_pod_worker_latency_microseconds
+  - kubelet_pod_start_latency_microseconds
+  - kubelet_cgroup_manager_latency_microseconds
+  - kubelet_pod_worker_start_latency_microseconds
+  - kubelet_pleg_relist_latency_microseconds
+  - kubelet_pleg_relist_interval_microseconds
+  - kubelet_eviction_stats_age_microseconds
+  - kubelet_runtime_operations
+  - kubelet_runtime_operations_latency_microseconds
+  - kubelet_runtime_operations_errors
+  - kubelet_device_plugin_registration_count
+  - kubelet_device_plugin_alloc_latency_microseconds
+  - kubelet_docker_operations
+  - kubelet_docker_operations_latency_microseconds
+  - kubelet_docker_operations_errors
+  - kubelet_docker_operations_timeout
+  - network_plugin_operations_latency_microseconds ([#83841](https://github.com/kubernetes/kubernetes/pull/83841), [@RainbowMango](https://github.com/RainbowMango)) [SIG Network and Node]
+- Kube-apiserver metrics will now include request counts, latencies, and response sizes for /healthz, /livez, and /readyz requests. ([#83598](https://github.com/kubernetes/kubernetes/pull/83598), [@jktomer](https://github.com/jktomer)) [SIG API Machinery]
+- Kubelet now exports a `server_expiration_renew_failure` and `client_expiration_renew_failure` metric counter if the certificate rotations cannot be performed. ([#84614](https://github.com/kubernetes/kubernetes/pull/84614), [@rphillips](https://github.com/rphillips)) [SIG API Machinery, Auth, CLI, Cloud Provider, Cluster Lifecycle, Instrumentation, Node and Release]
+- Kubelet: the metric process_start_time_seconds be marked as with the ALPHA stability level. ([#85446](https://github.com/kubernetes/kubernetes/pull/85446), [@RainbowMango](https://github.com/RainbowMango)) [SIG API Machinery, Cluster Lifecycle, Instrumentation and Node]
+- New metric `kubelet_pleg_last_seen_seconds` to aid diagnosis of PLEG not healthy issues. ([#86251](https://github.com/kubernetes/kubernetes/pull/86251), [@bboreham](https://github.com/bboreham)) [SIG Node]
+
+### Other (Bug, Cleanup or Flake)
+
+- Fixed a regression with clients prior to 1.15 not being able to update podIP in pod status, or podCIDR in node spec, against >= 1.16 API servers ([#88505](https://github.com/kubernetes/kubernetes/pull/88505), [@liggitt](https://github.com/liggitt)) [SIG Apps and Network]
+- Fixed "kubectl describe statefulsets.apps" printing garbage for rolling update partition ([#85846](https://github.com/kubernetes/kubernetes/pull/85846), [@phil9909](https://github.com/phil9909)) [SIG CLI]
+- Add a event to PV when filesystem on PV does not match actual filesystem on disk ([#86982](https://github.com/kubernetes/kubernetes/pull/86982), [@gnufied](https://github.com/gnufied)) [SIG Storage]
+- Add azure disk WriteAccelerator support ([#87945](https://github.com/kubernetes/kubernetes/pull/87945), [@andyzhangx](https://github.com/andyzhangx)) [SIG Cloud Provider and Storage]
+- Add delays between goroutines for vm instance update ([#88094](https://github.com/kubernetes/kubernetes/pull/88094), [@aramase](https://github.com/aramase)) [SIG Cloud Provider]
+- Add init containers log to cluster dump info. ([#88324](https://github.com/kubernetes/kubernetes/pull/88324), [@zhouya0](https://github.com/zhouya0)) [SIG CLI]
+- Addons: elasticsearch discovery supports IPv6 ([#85543](https://github.com/kubernetes/kubernetes/pull/85543), [@SataQiu](https://github.com/SataQiu)) [SIG Cluster Lifecycle and Instrumentation]
+- Adds "volume.beta.kubernetes.io/migrated-to" annotation to PV's and PVC's when they are migrated to signal external provisioners to pick up those objects for Provisioning and Deleting. ([#87098](https://github.com/kubernetes/kubernetes/pull/87098), [@davidz627](https://github.com/davidz627)) [SIG  Storage]
+- All api-server log request lines in a more greppable format. ([#87203](https://github.com/kubernetes/kubernetes/pull/87203), [@lavalamp](https://github.com/lavalamp)) [SIG API Machinery]
+- Azure VMSS LoadBalancerBackendAddressPools updating has been improved with sequential-sync + concurrent-async requests. ([#88699](https://github.com/kubernetes/kubernetes/pull/88699), [@feiskyer](https://github.com/feiskyer)) [SIG Cloud Provider]
+- Azure cloud provider now obtains AAD token who audience claim will not have spn: prefix ([#87590](https://github.com/kubernetes/kubernetes/pull/87590), [@weinong](https://github.com/weinong)) [SIG Cloud Provider]
+- AzureFile and CephFS use the new Mount library that prevents logging of sensitive mount options. ([#88684](https://github.com/kubernetes/kubernetes/pull/88684), [@saad-ali](https://github.com/saad-ali)) [SIG Storage]
+- Bind dns-horizontal containers to linux nodes to avoid Windows scheduling on kubernetes cluster includes linux nodes and windows nodes ([#83364](https://github.com/kubernetes/kubernetes/pull/83364), [@wawa0210](https://github.com/wawa0210)) [SIG Cluster Lifecycle and Windows]
+- Bind kube-dns containers to linux nodes to avoid Windows scheduling ([#83358](https://github.com/kubernetes/kubernetes/pull/83358), [@wawa0210](https://github.com/wawa0210)) [SIG Cluster Lifecycle and Windows]
+- Bind metadata-agent containers to linux nodes to avoid Windows scheduling on kubernetes cluster includes linux nodes and windows nodes ([#83363](https://github.com/kubernetes/kubernetes/pull/83363), [@wawa0210](https://github.com/wawa0210)) [SIG Cluster Lifecycle, Instrumentation and Windows]
+- Bind metrics-server containers to linux nodes to avoid Windows scheduling on kubernetes cluster includes linux nodes and windows nodes ([#83362](https://github.com/kubernetes/kubernetes/pull/83362), [@wawa0210](https://github.com/wawa0210)) [SIG Cluster Lifecycle, Instrumentation and Windows]
+- Bug fixes: Make sure we include latest packages node &#35;351 (@caseydavenport) ([#84163](https://github.com/kubernetes/kubernetes/pull/84163), [@david-tigera](https://github.com/david-tigera)) [SIG Cluster Lifecycle]
+- CPU limits are now respected for Windows containers. If a node is over-provisioned, no weighting is used, only limits are respected. ([#86101](https://github.com/kubernetes/kubernetes/pull/86101), [@PatrickLang](https://github.com/PatrickLang)) [SIG Node, Testing and Windows]
+- Changed core_pattern on COS nodes to be an absolute path. ([#86329](https://github.com/kubernetes/kubernetes/pull/86329), [@mml](https://github.com/mml)) [SIG Cluster Lifecycle and Node]
+- Client-go certificate manager rotation gained the ability to preserve optional intermediate chains accompanying issued certificates ([#88744](https://github.com/kubernetes/kubernetes/pull/88744), [@jackkleeman](https://github.com/jackkleeman)) [SIG API Machinery and Auth]
+- Cloud provider config CloudProviderBackoffMode has been removed since it won't be used anymore. ([#88463](https://github.com/kubernetes/kubernetes/pull/88463), [@feiskyer](https://github.com/feiskyer)) [SIG Cloud Provider]
+- Conformance image now depends on stretch-slim instead of debian-hyperkube-base as that image is being deprecated and removed. ([#88702](https://github.com/kubernetes/kubernetes/pull/88702), [@dims](https://github.com/dims)) [SIG Cluster Lifecycle, Release and Testing]
+- Deprecate --generator flag from kubectl create commands ([#88655](https://github.com/kubernetes/kubernetes/pull/88655), [@soltysh](https://github.com/soltysh)) [SIG CLI]
+- During initialization phase (preflight), kubeadm now verifies the presence of the conntrack executable ([#85857](https://github.com/kubernetes/kubernetes/pull/85857), [@hnanni](https://github.com/hnanni)) [SIG Cluster Lifecycle]
+- EndpointSlice should not contain endpoints for terminating pods ([#89056](https://github.com/kubernetes/kubernetes/pull/89056), [@andrewsykim](https://github.com/andrewsykim)) [SIG Apps and Network]
+- Evictions due to pods breaching their ephemeral storage limits are now recorded by the `kubelet_evictions` metric and can be alerted on. ([#87906](https://github.com/kubernetes/kubernetes/pull/87906), [@smarterclayton](https://github.com/smarterclayton)) [SIG Node]
+- Filter published OpenAPI schema by making nullable, required fields non-required in order to avoid kubectl to wrongly reject null values. ([#85722](https://github.com/kubernetes/kubernetes/pull/85722), [@sttts](https://github.com/sttts)) [SIG API Machinery]
+- Fix /readyz to return error immediately after a shutdown is initiated, before the --shutdown-delay-duration has elapsed. ([#88911](https://github.com/kubernetes/kubernetes/pull/88911), [@tkashem](https://github.com/tkashem)) [SIG API Machinery]
+- Fix API Server potential memory leak issue in processing watch request. ([#85410](https://github.com/kubernetes/kubernetes/pull/85410), [@answer1991](https://github.com/answer1991)) [SIG API Machinery]
+- Fix EndpointSlice controller race condition and ensure that it handles external changes to EndpointSlices. ([#85703](https://github.com/kubernetes/kubernetes/pull/85703), [@robscott](https://github.com/robscott)) [SIG Apps and Network]
+- Fix IPv6 addresses lost issue in pure ipv6 vsphere environment ([#86001](https://github.com/kubernetes/kubernetes/pull/86001), [@hubv](https://github.com/hubv)) [SIG Cloud Provider]
+- Fix LoadBalancer rule checking so that no unexpected LoadBalancer updates are made ([#85990](https://github.com/kubernetes/kubernetes/pull/85990), [@feiskyer](https://github.com/feiskyer)) [SIG Cloud Provider]
+- Fix a bug in kube-proxy that caused it to crash when using load balancers with a different IP family ([#87117](https://github.com/kubernetes/kubernetes/pull/87117), [@aojea](https://github.com/aojea)) [SIG Network]
+- Fix a bug in port-forward: named port not working with service ([#85511](https://github.com/kubernetes/kubernetes/pull/85511), [@oke-py](https://github.com/oke-py)) [SIG CLI]
+- Fix a bug in the dual-stack IPVS proxier where stale IPv6 endpoints were not being cleaned up ([#87695](https://github.com/kubernetes/kubernetes/pull/87695), [@andrewsykim](https://github.com/andrewsykim)) [SIG Network]
+- Fix a bug that orphan revision cannot be adopted and statefulset cannot be synced ([#86801](https://github.com/kubernetes/kubernetes/pull/86801), [@likakuli](https://github.com/likakuli)) [SIG Apps]
+- Fix a bug where ExternalTrafficPolicy is not applied to service ExternalIPs. ([#88786](https://github.com/kubernetes/kubernetes/pull/88786), [@freehan](https://github.com/freehan)) [SIG Network]
+- Fix a bug where kubenet fails to parse the tc output. ([#83572](https://github.com/kubernetes/kubernetes/pull/83572), [@chendotjs](https://github.com/chendotjs)) [SIG Network]
+- Fix a regression in kubenet that prevent pods to obtain ip addresses ([#85993](https://github.com/kubernetes/kubernetes/pull/85993), [@chendotjs](https://github.com/chendotjs)) [SIG Network and Node]
+- Fix azure file AuthorizationFailure ([#85475](https://github.com/kubernetes/kubernetes/pull/85475), [@andyzhangx](https://github.com/andyzhangx)) [SIG Cloud Provider and Storage]
+- Fix bug where EndpointSlice controller would attempt to modify shared objects. ([#85368](https://github.com/kubernetes/kubernetes/pull/85368), [@robscott](https://github.com/robscott)) [SIG API Machinery, Apps and Network]
+- Fix handling of aws-load-balancer-security-groups annotation. Security-Groups assigned with this annotation are no longer modified by kubernetes which is the expected behaviour of most users. Also no unnecessary Security-Groups are created anymore if this annotation is used. ([#83446](https://github.com/kubernetes/kubernetes/pull/83446), [@Elias481](https://github.com/Elias481)) [SIG Cloud Provider]
+- Fix invalid VMSS updates due to incorrect cache ([#89002](https://github.com/kubernetes/kubernetes/pull/89002), [@ArchangelSDY](https://github.com/ArchangelSDY)) [SIG Cloud Provider]
+- Fix isCurrentInstance for Windows by removing the dependency of hostname. ([#89138](https://github.com/kubernetes/kubernetes/pull/89138), [@feiskyer](https://github.com/feiskyer)) [SIG Cloud Provider]
+- Fix issue #85805 about a resource not found in azure cloud provider when LoadBalancer specified in another resource group. ([#86502](https://github.com/kubernetes/kubernetes/pull/86502), [@levimm](https://github.com/levimm)) [SIG Cloud Provider]
+- Fix kubectl annotate error when local=true is set ([#86952](https://github.com/kubernetes/kubernetes/pull/86952), [@zhouya0](https://github.com/zhouya0)) [SIG CLI]
+- Fix kubectl create deployment image name ([#86636](https://github.com/kubernetes/kubernetes/pull/86636), [@zhouya0](https://github.com/zhouya0)) [SIG CLI]
+- Fix `kubectl drain ignore` daemonsets and others. ([#87361](https://github.com/kubernetes/kubernetes/pull/87361), [@zhouya0](https://github.com/zhouya0)) [SIG CLI]
+- Fix missing "apiVersion" for "involvedObject" in Events for Nodes. ([#87537](https://github.com/kubernetes/kubernetes/pull/87537), [@uthark](https://github.com/uthark)) [SIG Apps and Node]
+- Fix nil pointer dereference in azure cloud provider ([#85975](https://github.com/kubernetes/kubernetes/pull/85975), [@ldx](https://github.com/ldx)) [SIG Cloud Provider]
+- Fix regression in statefulset conversion which prevents applying a statefulset multiple times. ([#87706](https://github.com/kubernetes/kubernetes/pull/87706), [@liggitt](https://github.com/liggitt)) [SIG Apps and Testing]
+- Fix route conflicted operations when updating multiple routes together ([#88209](https://github.com/kubernetes/kubernetes/pull/88209), [@feiskyer](https://github.com/feiskyer)) [SIG Cloud Provider]
+- Fix that prevents repeated fetching of PVC/PV objects by kubelet when processing of pod volumes fails. While this prevents hammering API server in these error scenarios, it means that some errors in processing volume(s) for a pod could now take up to 2-3 minutes before retry. ([#88141](https://github.com/kubernetes/kubernetes/pull/88141), [@tedyu](https://github.com/tedyu)) [SIG Node and Storage]
+- Fix the bug PIP's DNS is deleted if no DNS label service annotation isn't set. ([#87246](https://github.com/kubernetes/kubernetes/pull/87246), [@nilo19](https://github.com/nilo19)) [SIG Cloud Provider]
+- Fix control plane hosts rolling upgrade causing thundering herd of LISTs on etcd leading to control plane unavailability. ([#86430](https://github.com/kubernetes/kubernetes/pull/86430), [@wojtek-t](https://github.com/wojtek-t)) [SIG API Machinery, Node and Testing]
+- Fix: add azure disk migration support for CSINode ([#88014](https://github.com/kubernetes/kubernetes/pull/88014), [@andyzhangx](https://github.com/andyzhangx)) [SIG Cloud Provider and Storage]
+- Fix: add non-retriable errors in azure clients ([#87941](https://github.com/kubernetes/kubernetes/pull/87941), [@andyzhangx](https://github.com/andyzhangx)) [SIG Cloud Provider]
+- Fix: add remediation in azure disk attach/detach ([#88444](https://github.com/kubernetes/kubernetes/pull/88444), [@andyzhangx](https://github.com/andyzhangx)) [SIG Cloud Provider]
+- Fix: azure data disk should use same key as os disk by default ([#86351](https://github.com/kubernetes/kubernetes/pull/86351), [@andyzhangx](https://github.com/andyzhangx)) [SIG Cloud Provider]
+- Fix: azure disk could not mounted on Standard_DC4s/DC2s instances ([#86612](https://github.com/kubernetes/kubernetes/pull/86612), [@andyzhangx](https://github.com/andyzhangx)) [SIG Cloud Provider and Storage]
+- Fix: azure file mount timeout issue ([#88610](https://github.com/kubernetes/kubernetes/pull/88610), [@andyzhangx](https://github.com/andyzhangx)) [SIG Cloud Provider and Storage]
+- Fix: check disk status before disk azure disk ([#88360](https://github.com/kubernetes/kubernetes/pull/88360), [@andyzhangx](https://github.com/andyzhangx)) [SIG Cloud Provider]
+- Fix: corrupted mount point in csi driver ([#88569](https://github.com/kubernetes/kubernetes/pull/88569), [@andyzhangx](https://github.com/andyzhangx)) [SIG Storage]
+- Fix: get azure disk lun timeout issue ([#88158](https://github.com/kubernetes/kubernetes/pull/88158), [@andyzhangx](https://github.com/andyzhangx)) [SIG Cloud Provider and Storage]
+- Fix: update azure disk max count ([#88201](https://github.com/kubernetes/kubernetes/pull/88201), [@andyzhangx](https://github.com/andyzhangx)) [SIG Cloud Provider and Storage]
+- Fixed "requested device X but found Y" attach error on AWS. ([#85675](https://github.com/kubernetes/kubernetes/pull/85675), [@jsafrane](https://github.com/jsafrane)) [SIG Cloud Provider and Storage]
+- Fixed NetworkPolicy validation that `Except` values are accepted when they are outside the CIDR range. ([#86578](https://github.com/kubernetes/kubernetes/pull/86578), [@tnqn](https://github.com/tnqn)) [SIG Network]
+- Fixed a bug in the TopologyManager. Previously, the TopologyManager would only guarantee alignment if container creation was serialized in some way. Alignment is now guaranteed under all scenarios of container creation. ([#87759](https://github.com/kubernetes/kubernetes/pull/87759), [@klueska](https://github.com/klueska)) [SIG Node]
+- Fixed a bug which could prevent a provider ID from ever being set for node if an error occurred determining the provider ID when the node was added. ([#87043](https://github.com/kubernetes/kubernetes/pull/87043), [@zjs](https://github.com/zjs)) [SIG Apps and Cloud Provider]
+- Fixed a data race in the kubelet image manager that can cause static pod workers to silently stop working. ([#88915](https://github.com/kubernetes/kubernetes/pull/88915), [@roycaihw](https://github.com/roycaihw)) [SIG Node]
+- Fixed a panic in the kubelet cleaning up pod volumes ([#86277](https://github.com/kubernetes/kubernetes/pull/86277), [@tedyu](https://github.com/tedyu)) [SIG Storage]
+- Fixed a regression where the kubelet would fail to update the ready status of pods. ([#84951](https://github.com/kubernetes/kubernetes/pull/84951), [@tedyu](https://github.com/tedyu)) [SIG Node]
+- Fixed an issue that could cause the kubelet to incorrectly run concurrent pod reconciliation loops and crash. ([#89055](https://github.com/kubernetes/kubernetes/pull/89055), [@tedyu](https://github.com/tedyu)) [SIG Node]
+- Fixed block CSI volume cleanup after timeouts. ([#88660](https://github.com/kubernetes/kubernetes/pull/88660), [@jsafrane](https://github.com/jsafrane)) [SIG Storage]
+- Fixed cleaning of CSI raw block volumes. ([#87978](https://github.com/kubernetes/kubernetes/pull/87978), [@jsafrane](https://github.com/jsafrane)) [SIG Storage]
+- Fixed AWS Cloud Provider attempting to delete LoadBalancer security group it didn’t provision, and fixed AWS Cloud Provider creating a default LoadBalancer security group even if annotation `service.beta.kubernetes.io/aws-load-balancer-security-groups` is present because the intended behavior of aws-load-balancer-security-groups is to replace all security groups assigned to the load balancer. ([#84265](https://github.com/kubernetes/kubernetes/pull/84265), [@bhagwat070919](https://github.com/bhagwat070919)) [SIG Cloud Provider]
+- Fixed two scheduler metrics (pending_pods and schedule_attempts_total) not being recorded ([#87692](https://github.com/kubernetes/kubernetes/pull/87692), [@everpeace](https://github.com/everpeace)) [SIG Scheduling]
+- Fixes an issue with kubelet-reported pod status on deleted/recreated pods. ([#86320](https://github.com/kubernetes/kubernetes/pull/86320), [@liggitt](https://github.com/liggitt)) [SIG Node]
+- Fixes conversion error in multi-version custom resources that could cause metadata.generation to increment on no-op patches or updates of a custom resource. ([#88995](https://github.com/kubernetes/kubernetes/pull/88995), [@liggitt](https://github.com/liggitt)) [SIG API Machinery]
+- Fixes issue where AAD token obtained by kubectl is incompatible with on-behalf-of flow and oidc. The audience claim before this fix has "spn:" prefix. After this fix, "spn:" prefix is omitted. ([#86412](https://github.com/kubernetes/kubernetes/pull/86412), [@weinong](https://github.com/weinong)) [SIG API Machinery, Auth and Cloud Provider]
+- Fixes an issue where you can't attach more than 15 GCE Persistent Disks to c2, n2, m1, m2 machine types. ([#88602](https://github.com/kubernetes/kubernetes/pull/88602), [@yuga711](https://github.com/yuga711)) [SIG Storage]
+- Fixes kube-proxy when EndpointSlice feature gate is enabled on Windows. ([#86016](https://github.com/kubernetes/kubernetes/pull/86016), [@robscott](https://github.com/robscott)) [SIG Auth and Network]
+- Fixes kubelet crash in client certificate rotation cases ([#88079](https://github.com/kubernetes/kubernetes/pull/88079), [@liggitt](https://github.com/liggitt)) [SIG API Machinery, Auth and Node]
+- Fixes service account token admission error in clusters that do not run the service account token controller ([#87029](https://github.com/kubernetes/kubernetes/pull/87029), [@liggitt](https://github.com/liggitt)) [SIG Auth]
+- Fixes v1.17.0 regression in --service-cluster-ip-range handling with IPv4 ranges larger than 65536 IP addresses ([#86534](https://github.com/kubernetes/kubernetes/pull/86534), [@liggitt](https://github.com/liggitt)) [SIG Network]
+- Fixes wrong validation result of NetworkPolicy PolicyTypes ([#85747](https://github.com/kubernetes/kubernetes/pull/85747), [@tnqn](https://github.com/tnqn)) [SIG Network]
+- For subprotocol negotiation, both client and server protocol is required now. ([#86646](https://github.com/kubernetes/kubernetes/pull/86646), [@tedyu](https://github.com/tedyu)) [SIG API Machinery and Node]
+- For volumes that allow attaches across multiple nodes, attach and detach operations across different nodes are now executed in parallel. ([#88678](https://github.com/kubernetes/kubernetes/pull/88678), [@verult](https://github.com/verult)) [SIG Storage]
+- Garbage collector now can correctly orphan ControllerRevisions when StatefulSets are deleted with orphan propagation policy. ([#84984](https://github.com/kubernetes/kubernetes/pull/84984), [@cofyc](https://github.com/cofyc)) [SIG Apps]
+- `Get-kube.sh` uses the gcloud's current local GCP service account for auth when the provider is GCE or GKE instead of the metadata server default ([#88383](https://github.com/kubernetes/kubernetes/pull/88383), [@BenTheElder](https://github.com/BenTheElder)) [SIG Cluster Lifecycle]
+- Golang/x/net has been updated to bring in fixes for CVE-2020-9283 ([#88381](https://github.com/kubernetes/kubernetes/pull/88381), [@BenTheElder](https://github.com/BenTheElder)) [SIG API Machinery, CLI, Cloud Provider, Cluster Lifecycle and Instrumentation]
+- If a serving certificate’s param specifies a name that is an IP for an SNI certificate, it will have priority for replying to server connections. ([#85308](https://github.com/kubernetes/kubernetes/pull/85308), [@deads2k](https://github.com/deads2k)) [SIG API Machinery]
+- Improved yaml parsing performance ([#85458](https://github.com/kubernetes/kubernetes/pull/85458), [@cjcullen](https://github.com/cjcullen)) [SIG API Machinery, CLI, Cloud Provider, Cluster Lifecycle, Instrumentation and Node]
+- Improves performance of the node authorizer ([#87696](https://github.com/kubernetes/kubernetes/pull/87696), [@liggitt](https://github.com/liggitt)) [SIG Auth]
+- In GKE alpha clusters it will be possible to use the service annotation `cloud.google.com/network-tier: Standard` ([#88487](https://github.com/kubernetes/kubernetes/pull/88487), [@zioproto](https://github.com/zioproto)) [SIG Cloud Provider]
+- Includes FSType when describing CSI persistent volumes. ([#85293](https://github.com/kubernetes/kubernetes/pull/85293), [@huffmanca](https://github.com/huffmanca)) [SIG CLI and Storage]
+- Iptables/userspace proxy: improve performance by getting local addresses only once per sync loop, instead of for every external IP ([#85617](https://github.com/kubernetes/kubernetes/pull/85617), [@andrewsykim](https://github.com/andrewsykim)) [SIG API Machinery, CLI, Cloud Provider, Cluster Lifecycle, Instrumentation and Network]
+- Kube-aggregator: always sets unavailableGauge metric to reflect the current state of a service. ([#87778](https://github.com/kubernetes/kubernetes/pull/87778), [@p0lyn0mial](https://github.com/p0lyn0mial)) [SIG API Machinery]
+- Kube-apiserver: fixed a conflict error encountered attempting to delete a pod with gracePeriodSeconds=0 and a resourceVersion precondition ([#85516](https://github.com/kubernetes/kubernetes/pull/85516), [@michaelgugino](https://github.com/michaelgugino)) [SIG API Machinery]
+- Kube-proxy no longer modifies shared EndpointSlices. ([#86092](https://github.com/kubernetes/kubernetes/pull/86092), [@robscott](https://github.com/robscott)) [SIG Network]
+- Kube-proxy: on dual-stack mode, if it is not able to get the IP Family of an endpoint, logs it with level InfoV(4) instead of Warning, avoiding flooding the logs for endpoints without addresses ([#88934](https://github.com/kubernetes/kubernetes/pull/88934), [@aojea](https://github.com/aojea)) [SIG Network]
+- Kubeadm allows to configure single-stack clusters if dual-stack is enabled ([#87453](https://github.com/kubernetes/kubernetes/pull/87453), [@aojea](https://github.com/aojea)) [SIG API Machinery, Cluster Lifecycle and Network]
+- Kubeadm now includes CoreDNS version 1.6.7 ([#86260](https://github.com/kubernetes/kubernetes/pull/86260), [@rajansandeep](https://github.com/rajansandeep)) [SIG Cluster Lifecycle]
+- Kubeadm upgrades always persist the etcd backup for stacked ([#86861](https://github.com/kubernetes/kubernetes/pull/86861), [@SataQiu](https://github.com/SataQiu)) [SIG Cluster Lifecycle]
+- Kubeadm:  'kubeadm alpha kubelet config download' has been removed, please use 'kubeadm upgrade node phase kubelet-config' instead ([#87944](https://github.com/kubernetes/kubernetes/pull/87944), [@SataQiu](https://github.com/SataQiu)) [SIG Cluster Lifecycle]
+- Kubeadm: Forward cluster name to the controller-manager arguments ([#85817](https://github.com/kubernetes/kubernetes/pull/85817), [@ereslibre](https://github.com/ereslibre)) [SIG Cluster Lifecycle]
+- Kubeadm: add support for the "ci/k8s-master" version label as a replacement for "ci-cross/*", which no longer exists. ([#86609](https://github.com/kubernetes/kubernetes/pull/86609), [@Pensu](https://github.com/Pensu)) [SIG Cluster Lifecycle]
+- Kubeadm: apply further improvements to the tentative support for concurrent etcd member join. Fixes a bug where multiple members can receive the same hostname. Increase the etcd client dial timeout and retry timeout for add/remove/... operations. ([#87505](https://github.com/kubernetes/kubernetes/pull/87505), [@neolit123](https://github.com/neolit123)) [SIG Cluster Lifecycle]
+- Kubeadm: don't write the kubelet environment file on "upgrade apply" ([#85412](https://github.com/kubernetes/kubernetes/pull/85412), [@boluisa](https://github.com/boluisa)) [SIG Cluster Lifecycle]
+- Kubeadm: fix potential panic when executing "kubeadm reset" with a corrupted kubelet.conf file ([#86216](https://github.com/kubernetes/kubernetes/pull/86216), [@neolit123](https://github.com/neolit123)) [SIG Cluster Lifecycle]
+- Kubeadm: fix the bug that 'kubeadm upgrade' hangs in single node cluster ([#88434](https://github.com/kubernetes/kubernetes/pull/88434), [@SataQiu](https://github.com/SataQiu)) [SIG Cluster Lifecycle]
+- Kubeadm: make sure images are pre-pulled even if a tag did not change but their contents changed ([#85603](https://github.com/kubernetes/kubernetes/pull/85603), [@bart0sh](https://github.com/bart0sh)) [SIG Cluster Lifecycle]
+- Kubeadm: remove 'kubeadm upgrade node config' command since it was deprecated in v1.15, please use 'kubeadm upgrade node phase kubelet-config' instead ([#87975](https://github.com/kubernetes/kubernetes/pull/87975), [@SataQiu](https://github.com/SataQiu)) [SIG Cluster Lifecycle]
+- Kubeadm: remove the deprecated CoreDNS feature-gate. It was set to "true" since v1.11 when the feature went GA. In v1.13 it was marked as deprecated and hidden from the CLI. ([#87400](https://github.com/kubernetes/kubernetes/pull/87400), [@neolit123](https://github.com/neolit123)) [SIG Cluster Lifecycle]
+- Kubeadm: retry `kubeadm-config` ConfigMap creation or mutation if the apiserver is not responding. This will improve resiliency when joining new control plane nodes. ([#85763](https://github.com/kubernetes/kubernetes/pull/85763), [@ereslibre](https://github.com/ereslibre)) [SIG Cluster Lifecycle]
+- Kubeadm: tolerate whitespace when validating certificate authority PEM data in kubeconfig files ([#86705](https://github.com/kubernetes/kubernetes/pull/86705), [@neolit123](https://github.com/neolit123)) [SIG Cluster Lifecycle]
+- Kubeadm: use bind-address option to configure the kube-controller-manager and kube-scheduler http probes ([#86493](https://github.com/kubernetes/kubernetes/pull/86493), [@aojea](https://github.com/aojea)) [SIG Cluster Lifecycle]
+- Kubeadm: uses the api-server AdvertiseAddress IP family to choose the etcd endpoint IP family for non external etcd clusters ([#85745](https://github.com/kubernetes/kubernetes/pull/85745), [@aojea](https://github.com/aojea)) [SIG Cluster Lifecycle]
+- Kubectl cluster-info dump --output-directory=xxx now generates files with an extension depending on the output format. ([#82070](https://github.com/kubernetes/kubernetes/pull/82070), [@olivierlemasle](https://github.com/olivierlemasle)) [SIG CLI]
+- `Kubectl describe <type>` and `kubectl top pod` will return a message saying `"No resources found"` or `"No resources found in <namespace> namespace"` if there are no results to display. ([#87527](https://github.com/kubernetes/kubernetes/pull/87527), [@brianpursley](https://github.com/brianpursley)) [SIG CLI]
+- `Kubectl drain node --dry-run` will list pods that would be evicted or deleted ([#82660](https://github.com/kubernetes/kubernetes/pull/82660), [@sallyom](https://github.com/sallyom)) [SIG CLI]
+- `Kubectl set resources` will no longer return an error if passed an empty change for a resource. `kubectl set subject` will no longer return an error if passed an empty change for a resource. ([#85490](https://github.com/kubernetes/kubernetes/pull/85490), [@sallyom](https://github.com/sallyom)) [SIG CLI]
+- Kubelet metrics gathered through metrics-server or prometheus should no longer timeout for Windows nodes running more than 3 pods. ([#87730](https://github.com/kubernetes/kubernetes/pull/87730), [@marosset](https://github.com/marosset)) [SIG Node, Testing and Windows]
+- Kubelet metrics have been changed to buckets. For example the `exec/{podNamespace}/{podID}/{containerName}` is now just exec. ([#87913](https://github.com/kubernetes/kubernetes/pull/87913), [@cheftako](https://github.com/cheftako)) [SIG Node]
+- Kubelets perform fewer unnecessary pod status update operations on the API server. ([#88591](https://github.com/kubernetes/kubernetes/pull/88591), [@smarterclayton](https://github.com/smarterclayton)) [SIG Node and Scalability]
+- Kubernetes will try to acquire the iptables lock every 100 msec during 5 seconds instead of every second. This is especially useful for environments using kube-proxy in iptables mode with a high churn rate of services. ([#85771](https://github.com/kubernetes/kubernetes/pull/85771), [@aojea](https://github.com/aojea)) [SIG Network]
+- Limit number of instances in a single update to GCE target pool to 1000. ([#87881](https://github.com/kubernetes/kubernetes/pull/87881), [@wojtek-t](https://github.com/wojtek-t)) [SIG Cloud Provider, Network and Scalability]
+- Make Azure clients only retry on specified HTTP status codes ([#88017](https://github.com/kubernetes/kubernetes/pull/88017), [@feiskyer](https://github.com/feiskyer)) [SIG Cloud Provider]
+- Make error message and service event message more clear ([#86078](https://github.com/kubernetes/kubernetes/pull/86078), [@feiskyer](https://github.com/feiskyer)) [SIG Cloud Provider]
+- Minimize AWS NLB health check timeout when externalTrafficPolicy set to Local ([#73363](https://github.com/kubernetes/kubernetes/pull/73363), [@kellycampbell](https://github.com/kellycampbell)) [SIG Cloud Provider]
+- Pause image contains "Architecture" in non-amd64 images ([#87954](https://github.com/kubernetes/kubernetes/pull/87954), [@BenTheElder](https://github.com/BenTheElder)) [SIG Release]
+- Pause image upgraded to 3.2 in kubelet and kubeadm. ([#88173](https://github.com/kubernetes/kubernetes/pull/88173), [@BenTheElder](https://github.com/BenTheElder)) [SIG CLI, Cluster Lifecycle, Node and Testing]
+- Plugin/PluginConfig and Policy APIs are mutually exclusive when running the scheduler ([#88864](https://github.com/kubernetes/kubernetes/pull/88864), [@alculquicondor](https://github.com/alculquicondor)) [SIG Scheduling]
+- Remove `FilteredNodesStatuses` argument from `PreScore`'s interface. ([#88189](https://github.com/kubernetes/kubernetes/pull/88189), [@skilxn-go](https://github.com/skilxn-go)) [SIG Scheduling and Testing]
+- Resolved a performance issue in the node authorizer index maintenance. ([#87693](https://github.com/kubernetes/kubernetes/pull/87693), [@liggitt](https://github.com/liggitt)) [SIG Auth]
+- Resolved regression in admission, authentication, and authorization webhook performance in v1.17.0-rc.1 ([#85810](https://github.com/kubernetes/kubernetes/pull/85810), [@liggitt](https://github.com/liggitt)) [SIG API Machinery and Testing]
+- Resolves performance regression in `kubectl get all` and in client-go discovery clients constructed using `NewDiscoveryClientForConfig` or `NewDiscoveryClientForConfigOrDie`. ([#86168](https://github.com/kubernetes/kubernetes/pull/86168), [@liggitt](https://github.com/liggitt)) [SIG API Machinery]
+- Reverted a kubectl azure auth module change where oidc claim spn: prefix was omitted resulting a breaking behavior with existing Azure AD OIDC enabled api-server ([#87507](https://github.com/kubernetes/kubernetes/pull/87507), [@weinong](https://github.com/weinong)) [SIG API Machinery, Auth and Cloud Provider]
+- Shared informers are now more reliable in the face of network disruption. ([#86015](https://github.com/kubernetes/kubernetes/pull/86015), [@squeed](https://github.com/squeed)) [SIG API Machinery]
+- Specifying PluginConfig for the same plugin more than once fails scheduler startup.
+  Specifying extenders and configuring .ignoredResources for the NodeResourcesFit plugin fails ([#88870](https://github.com/kubernetes/kubernetes/pull/88870), [@alculquicondor](https://github.com/alculquicondor)) [SIG Scheduling]
+- Terminating a restartPolicy=Never pod no longer has a chance to report the pod succeeded when it actually failed. ([#88440](https://github.com/kubernetes/kubernetes/pull/88440), [@smarterclayton](https://github.com/smarterclayton)) [SIG Node and Testing]
+- The CSR signing cert/key pairs will be reloaded from disk like the kube-apiserver cert/key pairs ([#86816](https://github.com/kubernetes/kubernetes/pull/86816), [@deads2k](https://github.com/deads2k)) [SIG API Machinery, Apps and Auth]
+- The EventRecorder from k8s.io/client-go/tools/events will now create events in the default namespace (instead of kube-system) when the related object does not have it set. ([#88815](https://github.com/kubernetes/kubernetes/pull/88815), [@enj](https://github.com/enj)) [SIG API Machinery]
+- The audit event sourceIPs list will now always end with the IP that sent the request directly to the API server. ([#87167](https://github.com/kubernetes/kubernetes/pull/87167), [@tallclair](https://github.com/tallclair)) [SIG API Machinery and Auth]
+- The sample-apiserver aggregated conformance test has updated to use the Kubernetes v1.17.0 sample apiserver ([#84735](https://github.com/kubernetes/kubernetes/pull/84735), [@liggitt](https://github.com/liggitt)) [SIG API Machinery, Architecture, CLI and Testing]
+- To reduce chances of throttling, VM cache is set to nil when Azure node provisioning state is deleting ([#87635](https://github.com/kubernetes/kubernetes/pull/87635), [@feiskyer](https://github.com/feiskyer)) [SIG Cloud Provider]
+- VMSS cache is added so that less chances of VMSS GET throttling ([#85885](https://github.com/kubernetes/kubernetes/pull/85885), [@nilo19](https://github.com/nilo19)) [SIG Cloud Provider]
+- Wait for kubelet & kube-proxy to be ready on Windows node within 10s ([#85228](https://github.com/kubernetes/kubernetes/pull/85228), [@YangLu1031](https://github.com/YangLu1031)) [SIG Cluster Lifecycle]
+- `kubectl apply  -f <file> --prune -n <namespace>` should prune all resources not defined in the file in the cli specified namespace. ([#85613](https://github.com/kubernetes/kubernetes/pull/85613), [@MartinKaburu](https://github.com/MartinKaburu)) [SIG CLI]
+- `kubectl create clusterrolebinding` creates rbac.authorization.k8s.io/v1 object ([#85889](https://github.com/kubernetes/kubernetes/pull/85889), [@oke-py](https://github.com/oke-py)) [SIG CLI]
+- `kubectl diff` now returns 1 only on diff finding changes, and >1 on kubectl errors. The "exit status code 1" message has also been muted. ([#87437](https://github.com/kubernetes/kubernetes/pull/87437), [@apelisse](https://github.com/apelisse)) [SIG CLI and Testing]
+
+## Dependencies
+
+- Update Calico to v3.8.4 ([#84163](https://github.com/kubernetes/kubernetes/pull/84163), [@david-tigera](https://github.com/david-tigera))[SIG Cluster Lifecycle]
+- Update aws-sdk-go dependency to v1.28.2 ([#87253](https://github.com/kubernetes/kubernetes/pull/87253), [@SaranBalaji90](https://github.com/SaranBalaji90))[SIG API Machinery and Cloud Provider]
+- Update CNI version to v0.8.5 ([#78819](https://github.com/kubernetes/kubernetes/pull/78819), [@justaugustus](https://github.com/justaugustus))[SIG Release, Testing, Network, Cluster Lifecycle and API Machinery]
+- Update cri-tools to v1.17.0 ([#86305](https://github.com/kubernetes/kubernetes/pull/86305), [@saschagrunert](https://github.com/saschagrunert))[SIG Release and Cluster Lifecycle]
+- Pause image upgraded to 3.2 in kubelet and kubeadm ([#88173](https://github.com/kubernetes/kubernetes/pull/88173), [@BenTheElder](https://github.com/BenTheElder))[SIG CLI, Node, Testing and Cluster Lifecycle]
+- Update CoreDNS version to 1.6.7 in kubeadm ([#86260](https://github.com/kubernetes/kubernetes/pull/86260), [@rajansandeep](https://github.com/rajansandeep))[SIG Cluster Lifecycle]
+- Update golang.org/x/crypto to fix CVE-2020-9283 ([#8838](https://github.com/kubernetes/kubernetes/pull/88381), [@BenTheElder](https://github.com/BenTheElder))[SIG CLI, Instrumentation, API Machinery, CLuster Lifecycle and Cloud Provider]
+- Update Go to 1.13.8 ([#87648](https://github.com/kubernetes/kubernetes/pull/87648), [@ialidzhikov](https://github.com/ialidzhikov))[SIG Release and Testing]
+- Update Cluster-Autoscaler to 1.18.0 ([#89095](https://github.com/kubernetes/kubernetes/pull/89095), [@losipiuk](https://github.com/losipiuk))[SIG Autoscaling and Cluster Lifecycle]
+
+
+
+# v1.18.0-rc.1
+
+[Documentation](https://docs.k8s.io)
+
+## Downloads for v1.18.0-rc.1
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes.tar.gz](https://dl.k8s.io/v1.18.0-rc.1/kubernetes.tar.gz) | `c17231d5de2e0677e8af8259baa11a388625821c79b86362049f2edb366404d6f4b4587b8f13ccbceeb2f32c6a9fe98607f779c0f3e1caec438f002e3a2c8c21`
+[kubernetes-src.tar.gz](https://dl.k8s.io/v1.18.0-rc.1/kubernetes-src.tar.gz) | `e84ffad57c301f5d6e90f916b996d5abb0c987928c3ca6b1565f7b042588f839b994ca12c43fc36f0ffb63f9fabc15110eb08be253b8939f49cd951e956da618`
+
+### Client Binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-client-darwin-386.tar.gz](https://dl.k8s.io/v1.18.0-rc.1/kubernetes-client-darwin-386.tar.gz) | `1aea99923d492436b3eb91aaecffac94e5d0aa2b38a0930d266fda85c665bbc4569745c409aa302247df3b578ce60324e7a489eb26240e97d4e65a67428ea3d1`
+[kubernetes-client-darwin-amd64.tar.gz](https://dl.k8s.io/v1.18.0-rc.1/kubernetes-client-darwin-amd64.tar.gz) | `07fa7340a959740bd52b83ff44438bbd988e235277dad1e43f125f08ac85230a24a3b755f4e4c8645743444fa2b66a3602fc445d7da6d2fc3770e8c21ba24b33`
+[kubernetes-client-linux-386.tar.gz](https://dl.k8s.io/v1.18.0-rc.1/kubernetes-client-linux-386.tar.gz) | `48cebd26448fdd47aa36257baa4c716a98fda055bbf6a05230f2a3fe3c1b99b4e483668661415392190f3eebb9cb6e15c784626b48bb2541d93a37902f0e3974`
+[kubernetes-client-linux-amd64.tar.gz](https://dl.k8s.io/v1.18.0-rc.1/kubernetes-client-linux-amd64.tar.gz) | `c3a5fedf263f07a07f59c01fea6c63c1e0b76ee8dc67c45b6c134255c28ed69171ccc2f91b6a45d6a8ec5570a0a7562e24c33b9d7b0d1a864f4dc04b178b3c04`
+[kubernetes-client-linux-arm.tar.gz](https://dl.k8s.io/v1.18.0-rc.1/kubernetes-client-linux-arm.tar.gz) | `a6b11a55bd38583bbaac14931a6862f8ce6493afe30947ba29e5556654a571593358278df59412bbeb6888fa127e9ae4c0047a9d46cb59394995010796df6b14`
+[kubernetes-client-linux-arm64.tar.gz](https://dl.k8s.io/v1.18.0-rc.1/kubernetes-client-linux-arm64.tar.gz) | `9e15331ac8010154a9b64f5488969fc8ee2f21059639896cb84c5cf4f05f4c9d1d8970cb6f9831de6b34013848227c1972c12a698d07aac1ecc056e972fe6f79`
+[kubernetes-client-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.18.0-rc.1/kubernetes-client-linux-ppc64le.tar.gz) | `f828fe6252678de9d4822e482f5873309ae9139b2db87298ab3273ce45d38aa07b6b9b42b76c140705f27ba71e101d58b43e59ac7259d7c08dc647ea809e207c`
+[kubernetes-client-linux-s390x.tar.gz](https://dl.k8s.io/v1.18.0-rc.1/kubernetes-client-linux-s390x.tar.gz) | `19da4b45f0666c063934af616f3e7ed3caa99d4ee1e46d53efadc7a8a4d38e43a36ced7249acd7ad3dcc4b4f60d8451b4f7ec7727e478ee2fadd14d353228bce`
+[kubernetes-client-windows-386.tar.gz](https://dl.k8s.io/v1.18.0-rc.1/kubernetes-client-windows-386.tar.gz) | `775c9afb6cb3e7c4ba53e9f48a5df2cf207234a33059bd74448bc9f177dd120fb3f9c58ab45048a566326acc43bc8a67e886e10ef99f20780c8f63bb17426ebd`
+[kubernetes-client-windows-amd64.tar.gz](https://dl.k8s.io/v1.18.0-rc.1/kubernetes-client-windows-amd64.tar.gz) | `208d2595a5b57ac97aac75b4a2a6130f0c937f781a030bde1a432daf4bc51f2fa523fca2eb84c38798489c4b536ee90aad22f7be8477985d9691d51ad8e1c4dc`
+
+### Server Binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-server-linux-amd64.tar.gz](https://dl.k8s.io/v1.18.0-rc.1/kubernetes-server-linux-amd64.tar.gz) | `dcf832eae04f9f52ff473754ef5cfe697b35f4dc1a282622c94fa10943c8c35f4a8777a0c58c7de871c3c428c8973bf72d6bcd8751416d4c682125268b8fcefe`
+[kubernetes-server-linux-arm.tar.gz](https://dl.k8s.io/v1.18.0-rc.1/kubernetes-server-linux-arm.tar.gz) | `a04e34bea28eb1c8b492e8b1dd3c0dd87ebee71a7dbbef72be10a335e553361af7e48296e504f9844496b04e66350871114d20cfac3f3b49550d8be60f324ba3`
+[kubernetes-server-linux-arm64.tar.gz](https://dl.k8s.io/v1.18.0-rc.1/kubernetes-server-linux-arm64.tar.gz) | `a6af086b07a8c2e498f32b43e6511bf6a5e6baf358c572c6910c8df17cd6cae94f562f459714fcead1595767cb14c7f639c5735f1411173bbd38d5604c082a77`
+[kubernetes-server-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.18.0-rc.1/kubernetes-server-linux-ppc64le.tar.gz) | `5a960ef5ba0c255f587f2ac0b028cd03136dc91e4efc5d1becab46417852e5524d18572b6f66259531ec6fea997da3c4d162ac153a9439672154375053fec6c7`
+[kubernetes-server-linux-s390x.tar.gz](https://dl.k8s.io/v1.18.0-rc.1/kubernetes-server-linux-s390x.tar.gz) | `0f32c7d9b14bc238b9a5764d8f00edc4d3bf36bcf06b340b81061424e6070768962425194a8c2025c3a7ffb97b1de551d3ad23d1591ae34dd4e3ba25ab364c33`
+
+### Node Binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-node-linux-amd64.tar.gz](https://dl.k8s.io/v1.18.0-rc.1/kubernetes-node-linux-amd64.tar.gz) | `27d8955d535d14f3f4dca501fd27e4f06fad84c6da878ea5332a5c83b6955667f6f731bfacaf5a3a23c09f14caa400f9bee927a0f269f5374de7f79cd1919b3b`
+[kubernetes-node-linux-arm.tar.gz](https://dl.k8s.io/v1.18.0-rc.1/kubernetes-node-linux-arm.tar.gz) | `0d56eccad63ba608335988e90b377fe8ae978b177dc836cdb803a5c99d99e8f3399a666d9477ca9cfe5964944993e85c416aec10a99323e3246141efc0b1cc9e`
+[kubernetes-node-linux-arm64.tar.gz](https://dl.k8s.io/v1.18.0-rc.1/kubernetes-node-linux-arm64.tar.gz) | `79bb9be66f9e892d866b28e5cc838245818edb9706981fab6ccbff493181b341c1fcf6fe5d2342120a112eb93af413f5ba191cfba1ab4c4a8b0546a5ad8ec220`
+[kubernetes-node-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.18.0-rc.1/kubernetes-node-linux-ppc64le.tar.gz) | `3e9e2c6f9a2747d828069511dce8b4034c773c2d122f005f4508e22518055c1e055268d9d86773bbd26fbd2d887d783f408142c6c2f56ab2f2365236fd4d2635`
+[kubernetes-node-linux-s390x.tar.gz](https://dl.k8s.io/v1.18.0-rc.1/kubernetes-node-linux-s390x.tar.gz) | `4f96e018c336fa13bb6df6f7217fe46a2b5c47f806f786499c429604ccba2ebe558503ab2c72f63250aa25b61dae2d166e4b80ae10f6ab37d714f87c1dcf6691`
+[kubernetes-node-windows-amd64.tar.gz](https://dl.k8s.io/v1.18.0-rc.1/kubernetes-node-windows-amd64.tar.gz) | `ab110d76d506746af345e5897ef4f6993d5f53ac818ba69a334f3641047351aa63bfb3582841a9afca51dd0baff8b9010077d9c8ec85d2d69e4172b8d4b338b0`
+
+## Changelog since v1.18.0-beta.2
+
+## Changes by Kind
+
+### API Change
+
+- Removes ConfigMap as suggestion for IngressClass parameters ([#89093](https://github.com/kubernetes/kubernetes/pull/89093), [@robscott](https://github.com/robscott)) [SIG Network]
+
+### Other (Bug, Cleanup or Flake)
+
+- EndpointSlice should not contain endpoints for terminating pods ([#89056](https://github.com/kubernetes/kubernetes/pull/89056), [@andrewsykim](https://github.com/andrewsykim)) [SIG Apps and Network]
+- Fix a bug where ExternalTrafficPolicy is not applied to service ExternalIPs. ([#88786](https://github.com/kubernetes/kubernetes/pull/88786), [@freehan](https://github.com/freehan)) [SIG Network]
+- Fix invalid VMSS updates due to incorrect cache ([#89002](https://github.com/kubernetes/kubernetes/pull/89002), [@ArchangelSDY](https://github.com/ArchangelSDY)) [SIG Cloud Provider]
+- Fix isCurrentInstance for Windows by removing the dependency of hostname. ([#89138](https://github.com/kubernetes/kubernetes/pull/89138), [@feiskyer](https://github.com/feiskyer)) [SIG Cloud Provider]
+- Fixed a data race in kubelet image manager that can cause static pod workers to silently stop working. ([#88915](https://github.com/kubernetes/kubernetes/pull/88915), [@roycaihw](https://github.com/roycaihw)) [SIG Node]
+- Fixed an issue that could cause the kubelet to incorrectly run concurrent pod reconciliation loops and crash. ([#89055](https://github.com/kubernetes/kubernetes/pull/89055), [@tedyu](https://github.com/tedyu)) [SIG Node]
+- Kube-proxy: on dual-stack mode, if it is not able to get the IP Family of an endpoint, logs it with level InfoV(4) instead of Warning, avoiding flooding the logs for endpoints without addresses ([#88934](https://github.com/kubernetes/kubernetes/pull/88934), [@aojea](https://github.com/aojea)) [SIG Network]
+- Update Cluster Autoscaler to 1.18.0; changelog: https://github.com/kubernetes/autoscaler/releases/tag/cluster-autoscaler-1.18.0 ([#89095](https://github.com/kubernetes/kubernetes/pull/89095), [@losipiuk](https://github.com/losipiuk)) [SIG Autoscaling and Cluster Lifecycle]
+
+
+# v1.18.0-beta.2
+
+[Documentation](https://docs.k8s.io)
+
+## Downloads for v1.18.0-beta.2
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes.tar.gz](https://dl.k8s.io/v1.18.0-beta.2/kubernetes.tar.gz) | `3017430ca17f8a3523669b4a02c39cedfc6c48b07281bc0a67a9fbe9d76547b76f09529172cc01984765353a6134a43733b7315e0dff370bba2635dd2a6289af`
+[kubernetes-src.tar.gz](https://dl.k8s.io/v1.18.0-beta.2/kubernetes-src.tar.gz) | `c5fd60601380a99efff4458b1c9cf4dc02195f6f756b36e590e54dff68f7064daf32cf63980dddee13ef9dec7a60ad4eeb47a288083fdbbeeef4bc038384e9ea`
+
+### Client Binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-client-darwin-386.tar.gz](https://dl.k8s.io/v1.18.0-beta.2/kubernetes-client-darwin-386.tar.gz) | `7e49ede167b9271d4171e477fa21d267b2fb35f80869337d5b323198dc12f71b61441975bf925ad6e6cd7b61cbf6372d386417dc1e5c9b3c87ae651021c37237`
+[kubernetes-client-darwin-amd64.tar.gz](https://dl.k8s.io/v1.18.0-beta.2/kubernetes-client-darwin-amd64.tar.gz) | `3f5cdf0e85eee7d0773e0ae2df1c61329dea90e0da92b02dae1ffd101008dc4bade1c4951fc09f0cad306f0bcb7d16da8654334ddee43d5015913cc4ac8f3eda`
+[kubernetes-client-linux-386.tar.gz](https://dl.k8s.io/v1.18.0-beta.2/kubernetes-client-linux-386.tar.gz) | `b67b41c11bfecb88017c33feee21735c56f24cf6f7851b63c752495fc0fb563cd417a67a81f46bca091f74dc00fca1f296e483d2e3dfe2004ea4b42e252d30b9`
+[kubernetes-client-linux-amd64.tar.gz](https://dl.k8s.io/v1.18.0-beta.2/kubernetes-client-linux-amd64.tar.gz) | `1fef2197cb80003e3a5c26f05e889af9d85fbbc23e27747944d2997ace4bfa28f3670b13c08f5e26b7e274176b4e2df89c1162aebd8b9506e63b39b311b2d405`
+[kubernetes-client-linux-arm.tar.gz](https://dl.k8s.io/v1.18.0-beta.2/kubernetes-client-linux-arm.tar.gz) | `84e5f4d9776490219ee94a84adccd5dfc7c0362eb330709771afcde95ec83f03d96fe7399eec218e47af0a1e6445e24d95e6f9c66c0882ef8233a09ff2022420`
+[kubernetes-client-linux-arm64.tar.gz](https://dl.k8s.io/v1.18.0-beta.2/kubernetes-client-linux-arm64.tar.gz) | `ba613b114e0cca32fa21a3d10f845aa2f215d3af54e775f917ff93919f7dd7075efe254e4047a85a1f4b817fc2bd78006c2e8873885f1208cbc02db99e2e2e25`
+[kubernetes-client-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.18.0-beta.2/kubernetes-client-linux-ppc64le.tar.gz) | `502a6938d8c4bbe04abbd19b59919d86765058ff72334848be4012cec493e0e7027c6cd950cf501367ac2026eea9f518110cb72d1c792322b396fc2f73d23217`
+[kubernetes-client-linux-s390x.tar.gz](https://dl.k8s.io/v1.18.0-beta.2/kubernetes-client-linux-s390x.tar.gz) | `c24700e0ed2ef5c1d2dd282d638c88d90392ae90ea420837b39fd8e1cfc19525017325ccda71d8472fdaea174762208c09e1bba9bbc77c89deef6fac5e847ba2`
+[kubernetes-client-windows-386.tar.gz](https://dl.k8s.io/v1.18.0-beta.2/kubernetes-client-windows-386.tar.gz) | `0d4c5a741b052f790c8b0923c9586ee9906225e51cf4dc8a56fc303d4d61bb5bf77fba9e65151dec7be854ff31da8fc2dcd3214563e1b4b9951e6af4aa643da4`
+[kubernetes-client-windows-amd64.tar.gz](https://dl.k8s.io/v1.18.0-beta.2/kubernetes-client-windows-amd64.tar.gz) | `841ef2e306c0c9593f04d9528ee019bf3b667761227d9afc1d6ca8bf1aa5631dc25f5fe13ff329c4bf0c816b971fd0dec808f879721e0f3bf51ce49772b38010`
+
+### Server Binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-server-linux-amd64.tar.gz](https://dl.k8s.io/v1.18.0-beta.2/kubernetes-server-linux-amd64.tar.gz) | `b373df2e6ef55215e712315a5508e85a39126bd81b7b93c6b6305238919a88c740077828a6f19bcd97141951048ef7a19806ef6b1c3e1772dbc45715c5fcb3af`
+[kubernetes-server-linux-arm.tar.gz](https://dl.k8s.io/v1.18.0-beta.2/kubernetes-server-linux-arm.tar.gz) | `b8103cb743c23076ce8dd7c2da01c8dd5a542fbac8480e82dc673139c8ee5ec4495ca33695e7a18dd36412cf1e18ed84c8de05042525ddd8e869fbdfa2766569`
+[kubernetes-server-linux-arm64.tar.gz](https://dl.k8s.io/v1.18.0-beta.2/kubernetes-server-linux-arm64.tar.gz) | `8f8f05cf64fb9c8d80cdcb4935b2d3e3edc48bdd303231ae12f93e3f4d979237490744a11e24ba7f52dbb017ca321a8e31624dcffa391b8afda3d02078767fa0`
+[kubernetes-server-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.18.0-beta.2/kubernetes-server-linux-ppc64le.tar.gz) | `b313b911c46f2ec129537407af3f165f238e48caeb4b9e530783ffa3659304a544ed02bef8ece715c279373b9fb2c781bd4475560e02c4b98a6d79837bc81938`
+[kubernetes-server-linux-s390x.tar.gz](https://dl.k8s.io/v1.18.0-beta.2/kubernetes-server-linux-s390x.tar.gz) | `a1b6b06571141f507b12e5ef98efb88f4b6b9aba924722b2a74f11278d29a2972ab8290608360151d124608e6e24da0eb3516d484cb5fa12ff2987562f15964a`
+
+### Node Binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-node-linux-amd64.tar.gz](https://dl.k8s.io/v1.18.0-beta.2/kubernetes-node-linux-amd64.tar.gz) | `20e02ca327543cddb2568ead3d5de164cbfb2914ab6416106d906bf12fcfbc4e55b13bea4d6a515e8feab038e2c929d72c4d6909dfd7881ba69fd1e8c772ab99`
+[kubernetes-node-linux-arm.tar.gz](https://dl.k8s.io/v1.18.0-beta.2/kubernetes-node-linux-arm.tar.gz) | `ecd817ef05d6284f9c6592b84b0a48ea31cf4487030c9fb36518474b2a33dad11b9c852774682e60e4e8b074e6bea7016584ca281dddbe2994da5eaf909025c0`
+[kubernetes-node-linux-arm64.tar.gz](https://dl.k8s.io/v1.18.0-beta.2/kubernetes-node-linux-arm64.tar.gz) | `0020d32b7908ffd5055c8b26a8b3033e4702f89efcfffe3f6fcdb8a9921fa8eaaed4193c85597c24afd8c523662454f233521bb7055841a54c182521217ccc9d`
+[kubernetes-node-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.18.0-beta.2/kubernetes-node-linux-ppc64le.tar.gz) | `e065411d66d486e7793449c1b2f5a412510b913bf7f4e728c0a20e275642b7668957050dc266952cdff09acc391369ae6ac5230184db89af6823ba400745f2fc`
+[kubernetes-node-linux-s390x.tar.gz](https://dl.k8s.io/v1.18.0-beta.2/kubernetes-node-linux-s390x.tar.gz) | `082ee90413beaaea41d6cbe9a18f7d783a95852607f3b94190e0ca12aacdd97d87e233b87117871bfb7d0a4b6302fbc7688549492a9bc50a2f43a5452504d3ce`
+[kubernetes-node-windows-amd64.tar.gz](https://dl.k8s.io/v1.18.0-beta.2/kubernetes-node-windows-amd64.tar.gz) | `fb5aca0cc36be703f9d4033eababd581bac5de8399c50594db087a99ed4cb56e4920e960eb81d0132d696d094729254eeda2a5c0cb6e65e3abca6c8d61da579e`
+
+## Changelog since v1.18.0-beta.1
+
+## Urgent Upgrade Notes
+
+### (No, really, you MUST read this before you upgrade)
+
+- `kubectl` no longer defaults to `http://localhost:8080`.  If you own one of these legacy clusters, you are *strongly- encouraged to secure your server.   If you cannot secure your server, you can set `KUBERNETES_MASTER` if you were relying on that behavior and you're a client-go user. Set `--server`, `--kubeconfig` or `KUBECONFIG` to make it work in `kubectl`. ([#86173](https://github.com/kubernetes/kubernetes/pull/86173), [@soltysh](https://github.com/soltysh)) [SIG API Machinery, CLI and Testing]
+
+## Changes by Kind
+
+### Deprecation
+
+- AlgorithmSource is removed from v1alpha2 Scheduler ComponentConfig ([#87999](https://github.com/kubernetes/kubernetes/pull/87999), [@damemi](https://github.com/damemi)) [SIG Scheduling]
+- Kube-proxy: deprecate `--healthz-port` and `--metrics-port` flag, please use `--healthz-bind-address` and `--metrics-bind-address` instead ([#88512](https://github.com/kubernetes/kubernetes/pull/88512), [@SataQiu](https://github.com/SataQiu)) [SIG Network]
+- Kubeadm: deprecate the usage of the experimental flag '--use-api' under the 'kubeadm alpha certs renew' command. ([#88827](https://github.com/kubernetes/kubernetes/pull/88827), [@neolit123](https://github.com/neolit123)) [SIG Cluster Lifecycle]
+
+### API Change
+
+- A new IngressClass resource has been added to enable better Ingress configuration. ([#88509](https://github.com/kubernetes/kubernetes/pull/88509), [@robscott](https://github.com/robscott)) [SIG API Machinery, Apps, CLI, Network, Node and Testing]
+- Added GenericPVCDataSource feature gate to enable using arbitrary custom resources as the data source for a PVC. ([#88636](https://github.com/kubernetes/kubernetes/pull/88636), [@bswartz](https://github.com/bswartz)) [SIG Apps and Storage]
+- Allow user to specify fsgroup permission change policy for pods ([#88488](https://github.com/kubernetes/kubernetes/pull/88488), [@gnufied](https://github.com/gnufied)) [SIG Apps and Storage]
+- BlockVolume and CSIBlockVolume features are now GA. ([#88673](https://github.com/kubernetes/kubernetes/pull/88673), [@jsafrane](https://github.com/jsafrane)) [SIG Apps, Node and Storage]
+- CustomResourceDefinition schemas that use `x-kubernetes-list-map-keys` to specify properties that uniquely identify list items must make those properties required or have a default value, to ensure those properties are present for all list items. See https://kubernetes.io/docs/reference/using-api/api-concepts/&#35;merge-strategy for details. ([#88076](https://github.com/kubernetes/kubernetes/pull/88076), [@eloyekunle](https://github.com/eloyekunle)) [SIG API Machinery and Testing]
+- Fixes a regression with clients prior to 1.15 not being able to update podIP in pod status, or podCIDR in node spec, against >= 1.16 API servers ([#88505](https://github.com/kubernetes/kubernetes/pull/88505), [@liggitt](https://github.com/liggitt)) [SIG Apps and Network]
+- Ingress: Add Exact and Prefix maching to Ingress PathTypes ([#88587](https://github.com/kubernetes/kubernetes/pull/88587), [@cmluciano](https://github.com/cmluciano)) [SIG Apps, Cluster Lifecycle and Network]
+- Ingress: Add alternate backends via TypedLocalObjectReference ([#88775](https://github.com/kubernetes/kubernetes/pull/88775), [@cmluciano](https://github.com/cmluciano)) [SIG Apps and Network]
+- Ingress: allow wildcard hosts in IngressRule ([#88858](https://github.com/kubernetes/kubernetes/pull/88858), [@cmluciano](https://github.com/cmluciano)) [SIG Network]
+- Kube-controller-manager and kube-scheduler expose profiling by default to match the kube-apiserver.  Use `--enable-profiling=false` to disable. ([#88663](https://github.com/kubernetes/kubernetes/pull/88663), [@deads2k](https://github.com/deads2k)) [SIG API Machinery, Cloud Provider and Scheduling]
+- Move TaintBasedEvictions feature gates to GA ([#87487](https://github.com/kubernetes/kubernetes/pull/87487), [@skilxn-go](https://github.com/skilxn-go)) [SIG API Machinery, Apps, Node, Scheduling and Testing]
+- New flag --endpointslice-updates-batch-period in kube-controller-manager can be used to reduce number of endpointslice updates generated by pod changes. ([#88745](https://github.com/kubernetes/kubernetes/pull/88745), [@mborsz](https://github.com/mborsz)) [SIG API Machinery, Apps and Network]
+- Scheduler Extenders can now be configured in the v1alpha2 component config ([#88768](https://github.com/kubernetes/kubernetes/pull/88768), [@damemi](https://github.com/damemi)) [SIG Release, Scheduling and Testing]
+- The apiserver/v1alph1&#35;EgressSelectorConfiguration API is now beta. ([#88502](https://github.com/kubernetes/kubernetes/pull/88502), [@caesarxuchao](https://github.com/caesarxuchao)) [SIG API Machinery]
+- The storage.k8s.io/CSIDriver has moved to GA, and is now available for use. ([#84814](https://github.com/kubernetes/kubernetes/pull/84814), [@huffmanca](https://github.com/huffmanca)) [SIG API Machinery, Apps, Auth, Node, Scheduling, Storage and Testing]
+- VolumePVCDataSource moves to GA in 1.18 release ([#88686](https://github.com/kubernetes/kubernetes/pull/88686), [@j-griffith](https://github.com/j-griffith)) [SIG Apps, CLI and Cluster Lifecycle]
+
+### Feature
+
+- Add `rest_client_rate_limiter_duration_seconds` metric to component-base to track client side rate limiter latency in seconds. Broken down by verb and URL. ([#88134](https://github.com/kubernetes/kubernetes/pull/88134), [@jennybuckley](https://github.com/jennybuckley)) [SIG API Machinery, Cluster Lifecycle and Instrumentation]
+- Allow user to specify resource using --filename flag when invoking kubectl exec ([#88460](https://github.com/kubernetes/kubernetes/pull/88460), [@soltysh](https://github.com/soltysh)) [SIG CLI and Testing]
+- Apiserver add a new flag --goaway-chance which is the fraction of requests that will be closed gracefully(GOAWAY) to prevent HTTP/2 clients from getting stuck on a single apiserver. 
+  After the connection closed(received GOAWAY), the client's other in-flight requests won't be affected, and the client will reconnect. 
+  The flag min value is 0 (off), max is .02 (1/50 requests); .001 (1/1000) is a recommended starting point.
+  Clusters with single apiservers, or which don't use a load balancer, should NOT enable this. ([#88567](https://github.com/kubernetes/kubernetes/pull/88567), [@answer1991](https://github.com/answer1991)) [SIG API Machinery]
+- Azure: add support for single stack IPv6 ([#88448](https://github.com/kubernetes/kubernetes/pull/88448), [@aramase](https://github.com/aramase)) [SIG Cloud Provider]
+- DefaultConstraints can be specified for the PodTopologySpread plugin in the component config ([#88671](https://github.com/kubernetes/kubernetes/pull/88671), [@alculquicondor](https://github.com/alculquicondor)) [SIG Scheduling]
+- Kubeadm: support Windows specific kubelet flags in kubeadm-flags.env ([#88287](https://github.com/kubernetes/kubernetes/pull/88287), [@gab-satchi](https://github.com/gab-satchi)) [SIG Cluster Lifecycle and Windows]
+- Kubectl cluster-info dump changed to only display a message telling you the location where the output was written when the output is not standard output. ([#88765](https://github.com/kubernetes/kubernetes/pull/88765), [@brianpursley](https://github.com/brianpursley)) [SIG CLI]
+- Print NotReady when pod is not ready based on its conditions. ([#88240](https://github.com/kubernetes/kubernetes/pull/88240), [@soltysh](https://github.com/soltysh)) [SIG CLI]
+- Scheduler Extender API is now located under k8s.io/kube-scheduler/extender ([#88540](https://github.com/kubernetes/kubernetes/pull/88540), [@damemi](https://github.com/damemi)) [SIG Release, Scheduling and Testing]
+- Signatures on scale client methods have been modified to accept `context.Context` as a first argument. Signatures of Get, Update, and Patch methods have been updated to accept GetOptions, UpdateOptions and PatchOptions respectively. ([#88599](https://github.com/kubernetes/kubernetes/pull/88599), [@julianvmodesto](https://github.com/julianvmodesto)) [SIG API Machinery, Apps, Autoscaling and CLI]
+- Signatures on the dynamic client methods have been modified to accept `context.Context` as a first argument. Signatures of Delete and DeleteCollection methods now accept DeleteOptions by value instead of by reference. ([#88906](https://github.com/kubernetes/kubernetes/pull/88906), [@liggitt](https://github.com/liggitt)) [SIG API Machinery, Apps, CLI, Cluster Lifecycle, Storage and Testing]
+- Signatures on the metadata client methods have been modified to accept `context.Context` as a first argument. Signatures of Delete and DeleteCollection methods now accept DeleteOptions by value instead of by reference. ([#88910](https://github.com/kubernetes/kubernetes/pull/88910), [@liggitt](https://github.com/liggitt)) [SIG API Machinery, Apps and Testing]
+- Webhooks will have alpha support for network proxy ([#85870](https://github.com/kubernetes/kubernetes/pull/85870), [@Jefftree](https://github.com/Jefftree)) [SIG API Machinery, Auth and Testing]
+- When client certificate files are provided, reload files for new connections, and close connections when a certificate changes. ([#79083](https://github.com/kubernetes/kubernetes/pull/79083), [@jackkleeman](https://github.com/jackkleeman)) [SIG API Machinery, Auth, Node and Testing]
+- When deleting objects using kubectl with the --force flag, you are no longer required to also specify --grace-period=0. ([#87776](https://github.com/kubernetes/kubernetes/pull/87776), [@brianpursley](https://github.com/brianpursley)) [SIG CLI]
+- `kubectl` now contains a `kubectl alpha debug` command. This command allows attaching an ephemeral container to a running pod for the purposes of debugging. ([#88004](https://github.com/kubernetes/kubernetes/pull/88004), [@verb](https://github.com/verb)) [SIG CLI]
+
+### Documentation
+
+- Update Japanese translation for kubectl help ([#86837](https://github.com/kubernetes/kubernetes/pull/86837), [@inductor](https://github.com/inductor)) [SIG CLI and Docs]
+- `kubectl plugin` now prints a note how to install krew ([#88577](https://github.com/kubernetes/kubernetes/pull/88577), [@corneliusweig](https://github.com/corneliusweig)) [SIG CLI]
+
+### Other (Bug, Cleanup or Flake)
+
+- Azure VMSS LoadBalancerBackendAddressPools updating has been improved with squential-sync + concurrent-async requests. ([#88699](https://github.com/kubernetes/kubernetes/pull/88699), [@feiskyer](https://github.com/feiskyer)) [SIG Cloud Provider]
+- AzureFile and CephFS use new Mount library that prevents logging of sensitive mount options. ([#88684](https://github.com/kubernetes/kubernetes/pull/88684), [@saad-ali](https://github.com/saad-ali)) [SIG API Machinery, CLI, Cloud Provider, Cluster Lifecycle, Instrumentation and Storage]
+- Build: Enable kube-cross image-building on K8s Infra ([#88562](https://github.com/kubernetes/kubernetes/pull/88562), [@justaugustus](https://github.com/justaugustus)) [SIG Release and Testing]
+- Client-go certificate manager rotation gained the ability to preserve optional intermediate chains accompanying issued certificates ([#88744](https://github.com/kubernetes/kubernetes/pull/88744), [@jackkleeman](https://github.com/jackkleeman)) [SIG API Machinery and Auth]
+- Conformance image now depends on stretch-slim instead of debian-hyperkube-base as that image is being deprecated and removed. ([#88702](https://github.com/kubernetes/kubernetes/pull/88702), [@dims](https://github.com/dims)) [SIG Cluster Lifecycle, Release and Testing]
+- Deprecate --generator flag from kubectl create commands ([#88655](https://github.com/kubernetes/kubernetes/pull/88655), [@soltysh](https://github.com/soltysh)) [SIG CLI]
+- FIX: prevent apiserver from panicking when failing to load audit webhook config file ([#88879](https://github.com/kubernetes/kubernetes/pull/88879), [@JoshVanL](https://github.com/JoshVanL)) [SIG API Machinery and Auth]
+- Fix /readyz to return error immediately after a shutdown is initiated, before the --shutdown-delay-duration has elapsed. ([#88911](https://github.com/kubernetes/kubernetes/pull/88911), [@tkashem](https://github.com/tkashem)) [SIG API Machinery]
+- Fix a bug where kubenet fails to parse the tc output. ([#83572](https://github.com/kubernetes/kubernetes/pull/83572), [@chendotjs](https://github.com/chendotjs)) [SIG Network]
+- Fix describe ingress annotations not sorted. ([#88394](https://github.com/kubernetes/kubernetes/pull/88394), [@zhouya0](https://github.com/zhouya0)) [SIG CLI]
+- Fix handling of aws-load-balancer-security-groups annotation. Security-Groups assigned with this annotation are no longer modified by kubernetes which is the expected behaviour of most users. Also no unnecessary Security-Groups are created anymore if this annotation is used. ([#83446](https://github.com/kubernetes/kubernetes/pull/83446), [@Elias481](https://github.com/Elias481)) [SIG Cloud Provider]
+- Fix kubectl create deployment image name ([#86636](https://github.com/kubernetes/kubernetes/pull/86636), [@zhouya0](https://github.com/zhouya0)) [SIG CLI]
+- Fix missing "apiVersion" for "involvedObject" in Events for Nodes. ([#87537](https://github.com/kubernetes/kubernetes/pull/87537), [@uthark](https://github.com/uthark)) [SIG Apps and Node]
+- Fix that prevents repeated fetching of PVC/PV objects by kubelet when processing of pod volumes fails. While this prevents hammering API server in these error scenarios, it means that some errors in processing volume(s) for a pod could now take up to 2-3 minutes before retry. ([#88141](https://github.com/kubernetes/kubernetes/pull/88141), [@tedyu](https://github.com/tedyu)) [SIG Node and Storage]
+- Fix: azure file mount timeout issue ([#88610](https://github.com/kubernetes/kubernetes/pull/88610), [@andyzhangx](https://github.com/andyzhangx)) [SIG Cloud Provider and Storage]
+- Fix: corrupted mount point in csi driver ([#88569](https://github.com/kubernetes/kubernetes/pull/88569), [@andyzhangx](https://github.com/andyzhangx)) [SIG Storage]
+- Fixed a bug in the TopologyManager. Previously, the TopologyManager would only guarantee alignment if container creation was serialized in some way. Alignment is now guaranteed under all scenarios of container creation. ([#87759](https://github.com/kubernetes/kubernetes/pull/87759), [@klueska](https://github.com/klueska)) [SIG Node]
+- Fixed block CSI volume cleanup after timeouts. ([#88660](https://github.com/kubernetes/kubernetes/pull/88660), [@jsafrane](https://github.com/jsafrane)) [SIG Node and Storage]
+- Fixes issue where you can't attach more than 15 GCE Persistent Disks to c2, n2, m1, m2 machine types. ([#88602](https://github.com/kubernetes/kubernetes/pull/88602), [@yuga711](https://github.com/yuga711)) [SIG Storage]
+- For volumes that allow attaches across multiple nodes, attach and detach operations across different nodes are now executed in parallel. ([#88678](https://github.com/kubernetes/kubernetes/pull/88678), [@verult](https://github.com/verult)) [SIG Apps, Node and Storage]
+- Hide kubectl.kubernetes.io/last-applied-configuration in describe command ([#88758](https://github.com/kubernetes/kubernetes/pull/88758), [@soltysh](https://github.com/soltysh)) [SIG Auth and CLI]
+- In GKE alpha clusters it will be possible to use the service annotation `cloud.google.com/network-tier: Standard` ([#88487](https://github.com/kubernetes/kubernetes/pull/88487), [@zioproto](https://github.com/zioproto)) [SIG Cloud Provider]
+- Kubelets perform fewer unnecessary pod status update operations on the API server. ([#88591](https://github.com/kubernetes/kubernetes/pull/88591), [@smarterclayton](https://github.com/smarterclayton)) [SIG Node and Scalability]
+- Plugin/PluginConfig and Policy APIs are mutually exclusive when running the scheduler ([#88864](https://github.com/kubernetes/kubernetes/pull/88864), [@alculquicondor](https://github.com/alculquicondor)) [SIG Scheduling]
+- Specifying PluginConfig for the same plugin more than once fails scheduler startup.
+  
+  Specifying extenders and configuring .ignoredResources for the NodeResourcesFit plugin fails ([#88870](https://github.com/kubernetes/kubernetes/pull/88870), [@alculquicondor](https://github.com/alculquicondor)) [SIG Scheduling]
+- Support TLS Server Name overrides in kubeconfig file and via --tls-server-name in kubectl ([#88769](https://github.com/kubernetes/kubernetes/pull/88769), [@deads2k](https://github.com/deads2k)) [SIG API Machinery, Auth and CLI]
+- Terminating a restartPolicy=Never pod no longer has a chance to report the pod succeeded when it actually failed. ([#88440](https://github.com/kubernetes/kubernetes/pull/88440), [@smarterclayton](https://github.com/smarterclayton)) [SIG Node and Testing]
+- The EventRecorder from k8s.io/client-go/tools/events will now create events in the default namespace (instead of kube-system) when the related object does not have it set. ([#88815](https://github.com/kubernetes/kubernetes/pull/88815), [@enj](https://github.com/enj)) [SIG API Machinery]
+- The audit event sourceIPs list will now always end with the IP that sent the request directly to the API server. ([#87167](https://github.com/kubernetes/kubernetes/pull/87167), [@tallclair](https://github.com/tallclair)) [SIG API Machinery and Auth]
+- Update to use golang 1.13.8 ([#87648](https://github.com/kubernetes/kubernetes/pull/87648), [@ialidzhikov](https://github.com/ialidzhikov)) [SIG Release and Testing]
+- Validate kube-proxy flags --ipvs-tcp-timeout, --ipvs-tcpfin-timeout, --ipvs-udp-timeout ([#88657](https://github.com/kubernetes/kubernetes/pull/88657), [@chendotjs](https://github.com/chendotjs)) [SIG Network]
+
+
+# v1.18.0-beta.1
+
+[Documentation](https://docs.k8s.io)
+
+## Downloads for v1.18.0-beta.1
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes.tar.gz](https://dl.k8s.io/v1.18.0-beta.1/kubernetes.tar.gz) | `7c182ca905b3a31871c01ab5fdaf46f074547536c7975e069ff230af0d402dfc0346958b1d084bd2c108582ffc407484e6a15a1cd93e9affbe34b6e99409ef1f`
+[kubernetes-src.tar.gz](https://dl.k8s.io/v1.18.0-beta.1/kubernetes-src.tar.gz) | `d104b8c792b1517bd730787678c71c8ee3b259de81449192a49a1c6e37a6576d28f69b05c2019cc4a4c40ddeb4d60b80138323df3f85db8682caabf28e67c2de`
+
+### Client Binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-client-darwin-386.tar.gz](https://dl.k8s.io/v1.18.0-beta.1/kubernetes-client-darwin-386.tar.gz) | `bc337bb8f200a789be4b97ce99b9d7be78d35ebd64746307c28339dc4628f56d9903e0818c0888aaa9364357a528d1ac6fd34f74377000f292ec502fbea3837e`
+[kubernetes-client-darwin-amd64.tar.gz](https://dl.k8s.io/v1.18.0-beta.1/kubernetes-client-darwin-amd64.tar.gz) | `38dfa5e0b0cfff39942c913a6bcb2ad8868ec43457d35cffba08217bb6e7531720e0731f8588505f4c81193ce5ec0e5fe6870031cf1403fbbde193acf7e53540`
+[kubernetes-client-linux-386.tar.gz](https://dl.k8s.io/v1.18.0-beta.1/kubernetes-client-linux-386.tar.gz) | `8e63ec7ce29c69241120c037372c6c779e3f16253eabd612c7cbe6aa89326f5160eb5798004d723c5cd72d458811e98dac3574842eb6a57b2798ecd2bbe5bcf9`
+[kubernetes-client-linux-amd64.tar.gz](https://dl.k8s.io/v1.18.0-beta.1/kubernetes-client-linux-amd64.tar.gz) | `c1be9f184a7c3f896a785c41cd6ece9d90d8cb9b1f6088bdfb5557d8856c55e455f6688f5f54c2114396d5ae7adc0361e34ebf8e9c498d0187bd785646ccc1d0`
+[kubernetes-client-linux-arm.tar.gz](https://dl.k8s.io/v1.18.0-beta.1/kubernetes-client-linux-arm.tar.gz) | `8eab02453cfd9e847632a774a0e0cf3a33c7619fb4ced7f1840e1f71444e8719b1c8e8cbfdd1f20bb909f3abe39cdcac74f14cb9c878c656d35871b7c37c7cbe`
+[kubernetes-client-linux-arm64.tar.gz](https://dl.k8s.io/v1.18.0-beta.1/kubernetes-client-linux-arm64.tar.gz) | `f7df0ec02d2e7e63278d5386e8153cfe2b691b864f17b6452cc824a5f328d688976c975b076e60f1c6b3c859e93e477134fbccc53bb49d9e846fb038b34eee48`
+[kubernetes-client-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.18.0-beta.1/kubernetes-client-linux-ppc64le.tar.gz) | `36dd5b10addca678a518e6d052c9d6edf473e3f87388a2f03f714c93c5fbfe99ace16cf3b382a531be20a8fe6f4160f8d891800dd2cff5f23c9ca12c2f4a151b`
+[kubernetes-client-linux-s390x.tar.gz](https://dl.k8s.io/v1.18.0-beta.1/kubernetes-client-linux-s390x.tar.gz) | `5bdbb44b996ab4ccf3a383780270f5cfdbf174982c300723c8bddf0a48ae5e459476031c1d51b9d30ffd621d0a126c18a5de132ef1d92fca2f3e477665ea10cc`
+[kubernetes-client-windows-386.tar.gz](https://dl.k8s.io/v1.18.0-beta.1/kubernetes-client-windows-386.tar.gz) | `5dea3d4c4e91ef889850143b361974250e99a3c526f5efee23ff9ccdcd2ceca4a2247e7c4f236bdfa77d2150157da5d676ac9c3ba26cf3a2f1e06d8827556f77`
+[kubernetes-client-windows-amd64.tar.gz](https://dl.k8s.io/v1.18.0-beta.1/kubernetes-client-windows-amd64.tar.gz) | `db298e698391368703e6aea7f4345aec5a4b8c69f9d8ff6c99fb5804a6cea16d295fb01e70fe943ade3d4ce9200a081ad40da21bd331317ec9213f69b4d6c48f`
+
+### Server Binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-server-linux-amd64.tar.gz](https://dl.k8s.io/v1.18.0-beta.1/kubernetes-server-linux-amd64.tar.gz) | `c6284929dd5940e750b48db72ffbc09f73c5ec31ab3db283babb8e4e07cd8cbb27642f592009caae4717981c0db82c16312849ef4cbafe76acc4264c7d5864ac`
+[kubernetes-server-linux-arm.tar.gz](https://dl.k8s.io/v1.18.0-beta.1/kubernetes-server-linux-arm.tar.gz) | `6fc9552cf082c54cc0833b19876117c87ba7feb5a12c7e57f71b52208daf03eaef3ca56bd22b7bce2d6e81b5a23537cf6f5497a6eaa356c0aab1d3de26c309f9`
+[kubernetes-server-linux-arm64.tar.gz](https://dl.k8s.io/v1.18.0-beta.1/kubernetes-server-linux-arm64.tar.gz) | `b794b9c399e548949b5bfb2fe71123e86c2034847b2c99aca34b6de718a35355bbecdae9dc2a81c49e3c82fb4b5862526a3f63c2862b438895e12c5ea884f22e`
+[kubernetes-server-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.18.0-beta.1/kubernetes-server-linux-ppc64le.tar.gz) | `fddaed7a54f97046a91c29534645811c6346e973e22950b2607b8c119c2377e9ec2d32144f81626078cdaeca673129cc4016c1a3dbd3d43674aa777089fb56ac`
+[kubernetes-server-linux-s390x.tar.gz](https://dl.k8s.io/v1.18.0-beta.1/kubernetes-server-linux-s390x.tar.gz) | `65951a534bb55069c7419f41cbcdfe2fae31541d8a3f9eca11fc2489addf281c5ad2d13719212657da0be5b898f22b57ac39446d99072872fbacb0a7d59a4f74`
+
+### Node Binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-node-linux-amd64.tar.gz](https://dl.k8s.io/v1.18.0-beta.1/kubernetes-node-linux-amd64.tar.gz) | `992059efb5cae7ed0ef55820368d854bad1c6d13a70366162cd3b5111ce24c371c7c87ded2012f055e08b2ff1b4ef506e1f4e065daa3ac474fef50b5efa4fb07`
+[kubernetes-node-linux-arm.tar.gz](https://dl.k8s.io/v1.18.0-beta.1/kubernetes-node-linux-arm.tar.gz) | `c63ae0f8add5821ad267774314b8c8c1ffe3b785872bf278e721fd5dfdad1a5db1d4db3720bea0a36bf10d9c6dd93e247560162c0eac6e1b743246f587d3b27a`
+[kubernetes-node-linux-arm64.tar.gz](https://dl.k8s.io/v1.18.0-beta.1/kubernetes-node-linux-arm64.tar.gz) | `47adb9ddf6eaf8f475b89f59ee16fbd5df183149a11ad1574eaa645b47a6d58aec2ca70ba857ce9f1a5793d44cf7a61ebc6874793bb685edaf19410f4f76fd13`
+[kubernetes-node-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.18.0-beta.1/kubernetes-node-linux-ppc64le.tar.gz) | `a3bc4a165567c7b76a3e45ab7b102d6eb3ecf373eb048173f921a4964cf9be8891d0d5b8dafbd88c3af7b0e21ef3d41c1e540c3347ddd84b929b3a3d02ceb7b2`
+[kubernetes-node-linux-s390x.tar.gz](https://dl.k8s.io/v1.18.0-beta.1/kubernetes-node-linux-s390x.tar.gz) | `109ddf37c748f69584c829db57107c3518defe005c11fcd2a1471845c15aae0a3c89aafdd734229f4069ed18856cc650c80436684e1bdc43cfee3149b0324746`
+[kubernetes-node-windows-amd64.tar.gz](https://dl.k8s.io/v1.18.0-beta.1/kubernetes-node-windows-amd64.tar.gz) | `a3a75d2696ad3136476ad7d811e8eabaff5111b90e592695e651d6111f819ebf0165b8b7f5adc05afb5f7f01d1e5fb64876cb696e492feb20a477a5800382b7a`
+
+## Changelog since v1.18.0-beta.0
+
+## Urgent Upgrade Notes
+
+### (No, really, you MUST read this before you upgrade)
+
+- The StreamingProxyRedirects feature and `--redirect-container-streaming` flag are deprecated, and will be removed in a future release. The default behavior (proxy streaming requests through the kubelet) will be the only supported option.
+  If you are setting `--redirect-container-streaming=true`, then you must migrate off this configuration. The flag will no longer be able to be enabled starting in v1.20. If you are not setting the flag, no action is necessary. ([#88290](https://github.com/kubernetes/kubernetes/pull/88290), [@tallclair](https://github.com/tallclair)) [SIG API Machinery and Node]
+
+- Yes.
+  
+  Feature Name: Support using network resources (VNet, LB, IP, etc.) in different AAD Tenant and Subscription than those for the cluster.
+  
+  Changes in Pull Request:
+  
+    1. Add properties `networkResourceTenantID` and `networkResourceSubscriptionID` in cloud provider auth config section, which indicates the location of network resources.
+    2. Add function `GetMultiTenantServicePrincipalToken` to fetch multi-tenant service principal token, which will be used by Azure VM/VMSS Clients in this feature.
+    3. Add function `GetNetworkResourceServicePrincipalToken` to fetch network resource service principal token, which will be used by Azure Network Resource (Load Balancer, Public IP, Route Table, Network Security Group and their sub level resources) Clients in this feature.
+    4. Related unit tests.
+  
+  None.
+  
+  User Documentation: In PR https://github.com/kubernetes-sigs/cloud-provider-azure/pull/301 ([#88384](https://github.com/kubernetes/kubernetes/pull/88384), [@bowen5](https://github.com/bowen5)) [SIG Cloud Provider]
+
+## Changes by Kind
+
+### Deprecation
+
+- Azure service annotation service.beta.kubernetes.io/azure-load-balancer-disable-tcp-reset has been deprecated. Its support would be removed in a future release. ([#88462](https://github.com/kubernetes/kubernetes/pull/88462), [@feiskyer](https://github.com/feiskyer)) [SIG Cloud Provider]
+
+### API Change
+
+- API additions to apiserver types ([#87179](https://github.com/kubernetes/kubernetes/pull/87179), [@Jefftree](https://github.com/Jefftree)) [SIG API Machinery, Cloud Provider and Cluster Lifecycle]
+- Add Scheduling Profiles to kubescheduler.config.k8s.io/v1alpha2 ([#88087](https://github.com/kubernetes/kubernetes/pull/88087), [@alculquicondor](https://github.com/alculquicondor)) [SIG Scheduling and Testing]
+- Added support for multiple sizes huge pages on a container level ([#84051](https://github.com/kubernetes/kubernetes/pull/84051), [@bart0sh](https://github.com/bart0sh)) [SIG Apps, Node and Storage]
+- AppProtocol is a new field on Service and Endpoints resources, enabled with the ServiceAppProtocol feature gate. ([#88503](https://github.com/kubernetes/kubernetes/pull/88503), [@robscott](https://github.com/robscott)) [SIG Apps and Network]
+- Fixed missing validation of uniqueness of list items in lists with `x-kubernetes-list-type: map` or x-kubernetes-list-type: set` in CustomResources. ([#84920](https://github.com/kubernetes/kubernetes/pull/84920), [@sttts](https://github.com/sttts)) [SIG API Machinery]
+- Introduces optional --detect-local flag to kube-proxy. 
+  Currently the only supported value is "cluster-cidr", 
+  which is the default if not specified. ([#87748](https://github.com/kubernetes/kubernetes/pull/87748), [@satyasm](https://github.com/satyasm)) [SIG Cluster Lifecycle, Network and Scheduling]
+- Kube-scheduler can run more than one scheduling profile. Given a pod, the profile is selected by using its `.spec.SchedulerName`. ([#88285](https://github.com/kubernetes/kubernetes/pull/88285), [@alculquicondor](https://github.com/alculquicondor)) [SIG Apps, Scheduling and Testing]
+- Moving Windows RunAsUserName feature to GA ([#87790](https://github.com/kubernetes/kubernetes/pull/87790), [@marosset](https://github.com/marosset)) [SIG Apps and Windows]
+
+### Feature
+
+- Add --dry-run to kubectl delete, taint, replace ([#88292](https://github.com/kubernetes/kubernetes/pull/88292), [@julianvmodesto](https://github.com/julianvmodesto)) [SIG CLI and Testing]
+- Add huge page stats to Allocated resources in "kubectl describe node" ([#80605](https://github.com/kubernetes/kubernetes/pull/80605), [@odinuge](https://github.com/odinuge)) [SIG CLI]
+- Kubeadm: The ClusterStatus struct present in the kubeadm-config ConfigMap is deprecated and will be removed on a future version. It is going to be maintained by kubeadm until it gets removed. The same information can be found on `etcd` and `kube-apiserver` pod annotations, `kubeadm.kubernetes.io/etcd.advertise-client-urls` and `kubeadm.kubernetes.io/kube-apiserver.advertise-address.endpoint` respectively. ([#87656](https://github.com/kubernetes/kubernetes/pull/87656), [@ereslibre](https://github.com/ereslibre)) [SIG Cluster Lifecycle]
+- Kubeadm: add the experimental feature gate PublicKeysECDSA that can be used to create a
+  cluster with ECDSA certificates from "kubeadm init". Renewal of existing ECDSA certificates is
+  also supported using "kubeadm alpha certs renew", but not switching between the RSA and
+  ECDSA algorithms on the fly or during upgrades. ([#86953](https://github.com/kubernetes/kubernetes/pull/86953), [@rojkov](https://github.com/rojkov)) [SIG API Machinery, Auth and Cluster Lifecycle]
+- Kubeadm: on kubeconfig certificate renewal, keep the embedded CA in sync with the one on disk ([#88052](https://github.com/kubernetes/kubernetes/pull/88052), [@neolit123](https://github.com/neolit123)) [SIG Cluster Lifecycle]
+- Kubeadm: upgrade supports fallback to the nearest known etcd version if an unknown k8s version is passed ([#88373](https://github.com/kubernetes/kubernetes/pull/88373), [@SataQiu](https://github.com/SataQiu)) [SIG Cluster Lifecycle]
+- New flag `--show-hidden-metrics-for-version` in kube-scheduler can be used to show all hidden metrics that deprecated in the previous minor release. ([#84913](https://github.com/kubernetes/kubernetes/pull/84913), [@serathius](https://github.com/serathius)) [SIG Instrumentation and Scheduling]
+- Scheduler framework permit plugins now run at the end of the scheduling cycle, after reserve plugins. Waiting on permit will remain in the beginning of the binding cycle. ([#88199](https://github.com/kubernetes/kubernetes/pull/88199), [@mateuszlitwin](https://github.com/mateuszlitwin)) [SIG Scheduling]
+- The kubelet and the default docker runtime now support running ephemeral containers in the Linux process namespace of a target container. Other container runtimes must implement this feature before it will be available in that runtime. ([#84731](https://github.com/kubernetes/kubernetes/pull/84731), [@verb](https://github.com/verb)) [SIG Node]
+
+### Other (Bug, Cleanup or Flake)
+
+- Add delays between goroutines for vm instance update ([#88094](https://github.com/kubernetes/kubernetes/pull/88094), [@aramase](https://github.com/aramase)) [SIG Cloud Provider]
+- Add init containers log to cluster dump info. ([#88324](https://github.com/kubernetes/kubernetes/pull/88324), [@zhouya0](https://github.com/zhouya0)) [SIG CLI]
+- CPU limits are now respected for Windows containers. If a node is over-provisioned, no weighting is used - only limits are respected. ([#86101](https://github.com/kubernetes/kubernetes/pull/86101), [@PatrickLang](https://github.com/PatrickLang)) [SIG Node, Testing and Windows]
+- Cloud provider config CloudProviderBackoffMode has been removed since it won't be used anymore. ([#88463](https://github.com/kubernetes/kubernetes/pull/88463), [@feiskyer](https://github.com/feiskyer)) [SIG Cloud Provider]
+- Evictions due to pods breaching their ephemeral storage limits are now recorded by the `kubelet_evictions` metric and can be alerted on. ([#87906](https://github.com/kubernetes/kubernetes/pull/87906), [@smarterclayton](https://github.com/smarterclayton)) [SIG Node]
+- Fix: add remediation in azure disk attach/detach ([#88444](https://github.com/kubernetes/kubernetes/pull/88444), [@andyzhangx](https://github.com/andyzhangx)) [SIG Cloud Provider]
+- Fix: check disk status before disk azure disk ([#88360](https://github.com/kubernetes/kubernetes/pull/88360), [@andyzhangx](https://github.com/andyzhangx)) [SIG Cloud Provider]
+- Fixed cleaning of CSI raw block volumes. ([#87978](https://github.com/kubernetes/kubernetes/pull/87978), [@jsafrane](https://github.com/jsafrane)) [SIG Storage]
+- Get-kube.sh uses the gcloud's current local GCP service account for auth when the provider is GCE or GKE instead of the metadata server default ([#88383](https://github.com/kubernetes/kubernetes/pull/88383), [@BenTheElder](https://github.com/BenTheElder)) [SIG Cluster Lifecycle]
+- Golang/x/net has been updated to bring in fixes for CVE-2020-9283 ([#88381](https://github.com/kubernetes/kubernetes/pull/88381), [@BenTheElder](https://github.com/BenTheElder)) [SIG API Machinery, CLI, Cloud Provider, Cluster Lifecycle and Instrumentation]
+- Kubeadm now includes CoreDNS version 1.6.7 ([#86260](https://github.com/kubernetes/kubernetes/pull/86260), [@rajansandeep](https://github.com/rajansandeep)) [SIG Cluster Lifecycle]
+- Kubeadm: fix the bug that 'kubeadm upgrade' hangs in single node cluster ([#88434](https://github.com/kubernetes/kubernetes/pull/88434), [@SataQiu](https://github.com/SataQiu)) [SIG Cluster Lifecycle]
+- Optimize kubectl version help info ([#88313](https://github.com/kubernetes/kubernetes/pull/88313), [@zhouya0](https://github.com/zhouya0)) [SIG CLI]
+- Removes the deprecated command `kubectl rolling-update` ([#88057](https://github.com/kubernetes/kubernetes/pull/88057), [@julianvmodesto](https://github.com/julianvmodesto)) [SIG Architecture, CLI and Testing]
+
+
+# v1.18.0-alpha.5
+
+[Documentation](https://docs.k8s.io)
+
+## Downloads for v1.18.0-alpha.5
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes.tar.gz](https://dl.k8s.io/v1.18.0-alpha.5/kubernetes.tar.gz) | `6452cac2b80721e9f577cb117c29b9ac6858812b4275c2becbf74312566f7d016e8b34019bd1bf7615131b191613bf9b973e40ad9ac8f6de9007d41ef2d7fd70`
+[kubernetes-src.tar.gz](https://dl.k8s.io/v1.18.0-alpha.5/kubernetes-src.tar.gz) | `e41d9d4dd6910a42990051fcdca4bf5d3999df46375abd27ffc56aae9b455ae984872302d590da6aa85bba6079334fb5fe511596b415ee79843dee1c61c137da`
+
+### Client Binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-client-darwin-386.tar.gz](https://dl.k8s.io/v1.18.0-alpha.5/kubernetes-client-darwin-386.tar.gz) | `5c95935863492b31d4aaa6be93260088dafea27663eb91edca980ca3a8485310e60441bc9050d4d577e9c3f7ffd96db516db8d64321124cec1b712e957c9fe1c`
+[kubernetes-client-darwin-amd64.tar.gz](https://dl.k8s.io/v1.18.0-alpha.5/kubernetes-client-darwin-amd64.tar.gz) | `868faa578b3738604d8be62fae599ccc556799f1ce54807f1fe72599f20f8a1f98ad8152fac14a08a463322530b696d375253ba3653325e74b587df6e0510da3`
+[kubernetes-client-linux-386.tar.gz](https://dl.k8s.io/v1.18.0-alpha.5/kubernetes-client-linux-386.tar.gz) | `76a89d1d30b476b47f8fb808e342f89608e5c1c1787c4c06f2d7e763f9482e2ae8b31e6ad26541972e2b9a3a7c28327e3150cdd355e8b8d8b050a801bbf08d49`
+[kubernetes-client-linux-amd64.tar.gz](https://dl.k8s.io/v1.18.0-alpha.5/kubernetes-client-linux-amd64.tar.gz) | `07ad96a09b44d1c707d7c68312c5d69b101a3424bf1e6e9400b2e7a3fba78df04302985d473ddd640d8f3f0257be34110dbe1304b9565dd9d7a4639b7b7b85fd`
+[kubernetes-client-linux-arm.tar.gz](https://dl.k8s.io/v1.18.0-alpha.5/kubernetes-client-linux-arm.tar.gz) | `c04fed9fa370a75c1b8e18b2be0821943bb9befcc784d14762ea3278e73600332a9b324d5eeaa1801d20ad6be07a553c41dcf4fa7ab3eadd0730ab043d687c8c`
+[kubernetes-client-linux-arm64.tar.gz](https://dl.k8s.io/v1.18.0-alpha.5/kubernetes-client-linux-arm64.tar.gz) | `4199147dea9954333df26d34248a1cb7b02ebbd6380ffcd42d9f9ed5fdabae45a59215474dab3c11436c82e60bd27cbd03b3dde288bf611cd3e78b87c783c6a9`
+[kubernetes-client-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.18.0-alpha.5/kubernetes-client-linux-ppc64le.tar.gz) | `4f6d4d61d1c52d3253ca19031ebcd4bad06d19b68bbaaab5c8e8c590774faea4a5ceab1f05f2706b61780927e1467815b3479342c84d45df965aba78414727c4`
+[kubernetes-client-linux-s390x.tar.gz](https://dl.k8s.io/v1.18.0-alpha.5/kubernetes-client-linux-s390x.tar.gz) | `e2a454151ae5dd891230fb516a3f73f73ab97832db66fd3d12e7f1657a569f58a9fe2654d50ddd7d8ec88a5ff5094199323a4c6d7d44dcf7edb06cca11dd4de1`
+[kubernetes-client-windows-386.tar.gz](https://dl.k8s.io/v1.18.0-alpha.5/kubernetes-client-windows-386.tar.gz) | `14b262ba3b71c41f545db2a017cf1746075ada5745a858d2a62bc9df7c5dc10607220375db85e2c4cb85307b09709e58bc66a407488e0961191e3249dc7742b0`
+[kubernetes-client-windows-amd64.tar.gz](https://dl.k8s.io/v1.18.0-alpha.5/kubernetes-client-windows-amd64.tar.gz) | `26353c294755a917216664364b524982b7f5fc6aa832ce90134bb178df8a78604963c68873f121ea5f2626ff615bdbf2ffe54e00578739cde6df42ffae034732`
+
+### Server Binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-server-linux-amd64.tar.gz](https://dl.k8s.io/v1.18.0-alpha.5/kubernetes-server-linux-amd64.tar.gz) | `ba77e0e7c610f59647c1b2601f82752964a0f54b7ad609a89b00fcfd553d0f0249f6662becbabaa755bb769b36a2000779f08022c40fb8cc61440337481317a1`
+[kubernetes-server-linux-arm.tar.gz](https://dl.k8s.io/v1.18.0-alpha.5/kubernetes-server-linux-arm.tar.gz) | `45e87b3e844ea26958b0b489e8c9b90900a3253000850f5ff9e87ffdcafba72ab8fd17b5ba092051a58a4bc277912c047a85940ec7f093dff6f9e8bf6fed3b42`
+[kubernetes-server-linux-arm64.tar.gz](https://dl.k8s.io/v1.18.0-alpha.5/kubernetes-server-linux-arm64.tar.gz) | `155e136e3124ead69c594eead3398d6cfdbb8f823c324880e8a7bbd1b570b05d13a77a69abd0a6758cfcc7923971cc6da4d3e0c1680fd519b632803ece00d5ce`
+[kubernetes-server-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.18.0-alpha.5/kubernetes-server-linux-ppc64le.tar.gz) | `3fa0fb8221da19ad9d03278961172b7fa29a618b30abfa55e7243bb937dede8df56658acf02e6b61e7274fbc9395e237f49c62f2a83017eca2a69f67af31c01c`
+[kubernetes-server-linux-s390x.tar.gz](https://dl.k8s.io/v1.18.0-alpha.5/kubernetes-server-linux-s390x.tar.gz) | `db3199c3d7ba0b326d71dc8b80f50b195e79e662f71386a3b2976d47d13d7b0136887cc21df6f53e70a3d733da6eac7bbbf3bab2df8a1909a3cee4b44c32dd0b`
+
+### Node Binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-node-linux-amd64.tar.gz](https://dl.k8s.io/v1.18.0-alpha.5/kubernetes-node-linux-amd64.tar.gz) | `addcdfbad7f12647e6babb8eadf853a374605c8f18bf63f416fa4d3bf1b903aa206679d840433206423a984bb925e7983366edcdf777cf5daef6ef88e53d6dfa`
+[kubernetes-node-linux-arm.tar.gz](https://dl.k8s.io/v1.18.0-alpha.5/kubernetes-node-linux-arm.tar.gz) | `b2ac54e0396e153523d116a2aaa32c919d6243931e0104cd47a23f546d710e7abdaa9eae92d978ce63c92041e63a9b56f5dd8fd06c812a7018a10ecac440f768`
+[kubernetes-node-linux-arm64.tar.gz](https://dl.k8s.io/v1.18.0-alpha.5/kubernetes-node-linux-arm64.tar.gz) | `7aab36f2735cba805e4fd109831a1af0f586a88db3f07581b6dc2a2aab90076b22c96b490b4f6461a8fb690bf78948b6d514274f0d6fb0664081de2d44dc48e1`
+[kubernetes-node-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.18.0-alpha.5/kubernetes-node-linux-ppc64le.tar.gz) | `a579936f07ebf86f69f297ac50ba4c34caf2c0b903f73190eb581c78382b05ef36d41ade5bfd25d7b1b658cfcbee3d7125702a18e7480f9b09a62733a512a18a`
+[kubernetes-node-linux-s390x.tar.gz](https://dl.k8s.io/v1.18.0-alpha.5/kubernetes-node-linux-s390x.tar.gz) | `58fa0359ddd48835192fab1136a2b9b45d1927b04411502c269cda07cb8a8106536973fb4c7fedf1d41893a524c9fe2e21078fdf27bfbeed778273d024f14449`
+[kubernetes-node-windows-amd64.tar.gz](https://dl.k8s.io/v1.18.0-alpha.5/kubernetes-node-windows-amd64.tar.gz) | `9086c03cd92b440686cea6d8c4e48045cc46a43ab92ae0e70350b3f51804b9e2aaae7178142306768bae00d9ef6dd938167972bfa90b12223540093f735a45db`
+
+## Changelog since v1.18.0-alpha.3
+
+### Deprecation
+
+- Kubeadm: command line option "kubelet-version" for `kubeadm upgrade node` has been deprecated and will be removed in a future release. ([#87942](https://github.com/kubernetes/kubernetes/pull/87942), [@SataQiu](https://github.com/SataQiu)) [SIG Cluster Lifecycle]
+
+### API Change
+
+- Kubelet podresources API now provides the information about active pods only. ([#79409](https://github.com/kubernetes/kubernetes/pull/79409), [@takmatsu](https://github.com/takmatsu)) [SIG Node]
+- Remove deprecated fields from .leaderElection in kubescheduler.config.k8s.io/v1alpha2 ([#87904](https://github.com/kubernetes/kubernetes/pull/87904), [@alculquicondor](https://github.com/alculquicondor)) [SIG Scheduling]
+- Signatures on generated clientset methods have been modified to accept `context.Context` as a first argument. Signatures of generated Create, Update, and Patch methods have been updated to accept CreateOptions, UpdateOptions and PatchOptions respectively. Clientsets that with the previous interface have been added in new "deprecated" packages to allow incremental migration to the new APIs. The deprecated packages will be removed in the 1.21 release. ([#87299](https://github.com/kubernetes/kubernetes/pull/87299), [@mikedanese](https://github.com/mikedanese)) [SIG API Machinery, Apps, Auth, Autoscaling, CLI, Cloud Provider, Cluster Lifecycle, Instrumentation, Network, Node, Scheduling, Storage, Testing and Windows]
+- The k8s.io/node-api component is no longer updated. Instead, use the RuntimeClass types located within k8s.io/api, and the generated clients located within k8s.io/client-go ([#87503](https://github.com/kubernetes/kubernetes/pull/87503), [@liggitt](https://github.com/liggitt)) [SIG Node and Release]
+
+### Feature
+
+- Add indexer for storage cacher ([#85445](https://github.com/kubernetes/kubernetes/pull/85445), [@shaloulcy](https://github.com/shaloulcy)) [SIG API Machinery]
+- Add support for mount options to the FC volume plugin ([#87499](https://github.com/kubernetes/kubernetes/pull/87499), [@ejweber](https://github.com/ejweber)) [SIG Storage]
+- Added a config-mode flag in azure auth module to enable getting AAD token without spn: prefix in audience claim. When it's not specified, the default behavior doesn't change. ([#87630](https://github.com/kubernetes/kubernetes/pull/87630), [@weinong](https://github.com/weinong)) [SIG API Machinery, Auth, CLI and Cloud Provider]
+- Introduced BackoffManager interface for backoff management ([#87829](https://github.com/kubernetes/kubernetes/pull/87829), [@zhan849](https://github.com/zhan849)) [SIG API Machinery]
+- PodTopologySpread plugin now excludes terminatingPods when making scheduling decisions. ([#87845](https://github.com/kubernetes/kubernetes/pull/87845), [@Huang-Wei](https://github.com/Huang-Wei)) [SIG Scheduling]
+- Promote CSIMigrationOpenStack to Beta (off by default since it requires installation of the OpenStack Cinder CSI Driver)
+  The in-tree AWS OpenStack Cinder "kubernetes.io/cinder" was already deprecated a while ago and will be removed in 1.20. Users should enable CSIMigration + CSIMigrationOpenStack features and install the OpenStack Cinder CSI Driver (https://github.com/kubernetes-sigs/cloud-provider-openstack) to avoid disruption to existing Pod and PVC objects at that time.
+  Users should start using the OpenStack Cinder CSI Driver directly for any new volumes. ([#85637](https://github.com/kubernetes/kubernetes/pull/85637), [@dims](https://github.com/dims)) [SIG Cloud Provider]
+
+### Design
+
+- The scheduler Permit extension point doesn't return a boolean value in its Allow() and Reject() functions. ([#87936](https://github.com/kubernetes/kubernetes/pull/87936), [@Huang-Wei](https://github.com/Huang-Wei)) [SIG Scheduling]
+
+### Other (Bug, Cleanup or Flake)
+
+- Adds "volume.beta.kubernetes.io/migrated-to" annotation to PV's and PVC's when they are migrated to signal external provisioners to pick up those objects for Provisioning and Deleting. ([#87098](https://github.com/kubernetes/kubernetes/pull/87098), [@davidz627](https://github.com/davidz627)) [SIG Apps and Storage]
+- Fix a bug in the dual-stack IPVS proxier where stale IPv6 endpoints were not being cleaned up ([#87695](https://github.com/kubernetes/kubernetes/pull/87695), [@andrewsykim](https://github.com/andrewsykim)) [SIG Network]
+- Fix kubectl drain ignore daemonsets and others. ([#87361](https://github.com/kubernetes/kubernetes/pull/87361), [@zhouya0](https://github.com/zhouya0)) [SIG CLI]
+- Fix: add azure disk migration support for CSINode ([#88014](https://github.com/kubernetes/kubernetes/pull/88014), [@andyzhangx](https://github.com/andyzhangx)) [SIG Cloud Provider and Storage]
+- Fix: add non-retriable errors in azure clients ([#87941](https://github.com/kubernetes/kubernetes/pull/87941), [@andyzhangx](https://github.com/andyzhangx)) [SIG Cloud Provider]
+- Fixed NetworkPolicy validation that Except values are accepted when they are outside the CIDR range. ([#86578](https://github.com/kubernetes/kubernetes/pull/86578), [@tnqn](https://github.com/tnqn)) [SIG Network]
+- Improves performance of the node authorizer ([#87696](https://github.com/kubernetes/kubernetes/pull/87696), [@liggitt](https://github.com/liggitt)) [SIG Auth]
+- Iptables/userspace proxy: improve performance by getting local addresses only once per sync loop, instead of for every external IP ([#85617](https://github.com/kubernetes/kubernetes/pull/85617), [@andrewsykim](https://github.com/andrewsykim)) [SIG API Machinery, CLI, Cloud Provider, Cluster Lifecycle, Instrumentation and Network]
+- Kube-aggregator: always sets unavailableGauge metric to reflect the current state of a service. ([#87778](https://github.com/kubernetes/kubernetes/pull/87778), [@p0lyn0mial](https://github.com/p0lyn0mial)) [SIG API Machinery]
+- Kubeadm allows to configure single-stack clusters if dual-stack is enabled ([#87453](https://github.com/kubernetes/kubernetes/pull/87453), [@aojea](https://github.com/aojea)) [SIG API Machinery, Cluster Lifecycle and Network]
+- Kubeadm:  'kubeadm alpha kubelet config download' has been removed, please use 'kubeadm upgrade node phase kubelet-config' instead ([#87944](https://github.com/kubernetes/kubernetes/pull/87944), [@SataQiu](https://github.com/SataQiu)) [SIG Cluster Lifecycle]
+- Kubeadm: remove 'kubeadm upgrade node config' command since it was deprecated in v1.15, please use 'kubeadm upgrade node phase kubelet-config' instead ([#87975](https://github.com/kubernetes/kubernetes/pull/87975), [@SataQiu](https://github.com/SataQiu)) [SIG Cluster Lifecycle]
+- Kubectl describe <type> and kubectl top pod will return a message saying "No resources found" or "No resources found in <namespace> namespace" if there are no results to display. ([#87527](https://github.com/kubernetes/kubernetes/pull/87527), [@brianpursley](https://github.com/brianpursley)) [SIG CLI]
+- Kubelet metrics gathered through metrics-server or prometheus should no longer timeout for Windows nodes running more than 3 pods. ([#87730](https://github.com/kubernetes/kubernetes/pull/87730), [@marosset](https://github.com/marosset)) [SIG Node, Testing and Windows]
+- Kubelet metrics have been changed to buckets.
+  For example the exec/{podNamespace}/{podID}/{containerName} is now just exec. ([#87913](https://github.com/kubernetes/kubernetes/pull/87913), [@cheftako](https://github.com/cheftako)) [SIG Node]
+- Limit number of instances in a single update to GCE target pool to 1000. ([#87881](https://github.com/kubernetes/kubernetes/pull/87881), [@wojtek-t](https://github.com/wojtek-t)) [SIG Cloud Provider, Network and Scalability]
+- Make Azure clients only retry on specified HTTP status codes ([#88017](https://github.com/kubernetes/kubernetes/pull/88017), [@feiskyer](https://github.com/feiskyer)) [SIG Cloud Provider]
+- Pause image contains "Architecture" in non-amd64 images ([#87954](https://github.com/kubernetes/kubernetes/pull/87954), [@BenTheElder](https://github.com/BenTheElder)) [SIG Release]
+- Pods that are considered for preemption and haven't started don't produce an error log. ([#87900](https://github.com/kubernetes/kubernetes/pull/87900), [@alculquicondor](https://github.com/alculquicondor)) [SIG Scheduling]
+- Prevent error message from being displayed when running kubectl plugin list and your path includes an empty string ([#87633](https://github.com/kubernetes/kubernetes/pull/87633), [@brianpursley](https://github.com/brianpursley)) [SIG CLI]
+- `kubectl create clusterrolebinding` creates rbac.authorization.k8s.io/v1 object ([#85889](https://github.com/kubernetes/kubernetes/pull/85889), [@oke-py](https://github.com/oke-py)) [SIG CLI]
+
+# v1.18.0-alpha.4
+
+[Documentation](https://docs.k8s.io)
+
+## Important note about manual tag
+
+Due to a [tagging bug in our Release Engineering tooling](https://github.com/kubernetes/release/issues/1080) during `v1.18.0-alpha.3`, we needed to push a manual tag (`v1.18.0-alpha.4`).
+
+**No binaries have been produced or will be provided for `v1.18.0-alpha.4`.**
+
+The changelog for `v1.18.0-alpha.4` is included as part of the [changelog since v1.18.0-alpha.3][#changelog-since-v1180-alpha3] section.
+
+# v1.18.0-alpha.3
+
+[Documentation](https://docs.k8s.io)
+
+## Downloads for v1.18.0-alpha.3
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes.tar.gz](https://dl.k8s.io/v1.18.0-alpha.3/kubernetes.tar.gz) | `60bf3bfc23b428f53fd853bac18a4a905b980fcc0bacd35ccd6357a89cfc26e47de60975ea6b712e65980e6b9df82a22331152d9f08ed4dba44558ba23a422d4`
+[kubernetes-src.tar.gz](https://dl.k8s.io/v1.18.0-alpha.3/kubernetes-src.tar.gz) | `8adf1016565a7c93713ab6fa4293c2d13b4f6e4e1ec4dcba60bd71e218b4dbe9ef5eb7dbb469006743f498fc7ddeb21865cd12bec041af60b1c0edce8b7aecd5`
+
+### Client Binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-client-darwin-386.tar.gz](https://dl.k8s.io/v1.18.0-alpha.3/kubernetes-client-darwin-386.tar.gz) | `abb32e894e8280c772e96227b574da81cd1eac374b8d29158b7f222ed550087c65482eef4a9817dfb5f2baf0d9b85fcdfa8feced0fbc1aacced7296853b57e1f`
+[kubernetes-client-darwin-amd64.tar.gz](https://dl.k8s.io/v1.18.0-alpha.3/kubernetes-client-darwin-amd64.tar.gz) | `5e4b1a993264e256ec1656305de7c306094cae9781af8f1382df4ce4eed48ce030827fde1a5e757d4ad57233d52075c9e4e93a69efbdc1102e4ba810705ccddc`
+[kubernetes-client-linux-386.tar.gz](https://dl.k8s.io/v1.18.0-alpha.3/kubernetes-client-linux-386.tar.gz) | `68da39c2ae101d2b38f6137ceda07eb0c2124794982a62ef483245dbffb0611c1441ca085fa3127e7a9977f45646788832a783544ff06954114548ea0e526e46`
+[kubernetes-client-linux-amd64.tar.gz](https://dl.k8s.io/v1.18.0-alpha.3/kubernetes-client-linux-amd64.tar.gz) | `dc236ffa8ad426620e50181419e9bebe3c161e953dbfb8a019f61b11286e1eb950b40d7cc03423bdf3e6974973bcded51300f98b55570c29732fa492dcde761d`
+[kubernetes-client-linux-arm.tar.gz](https://dl.k8s.io/v1.18.0-alpha.3/kubernetes-client-linux-arm.tar.gz) | `ab0a8bd6dc31ea160b731593cdc490b3cc03668b1141cf95310bd7060dcaf55c7ee9842e0acae81063fdacb043c3552ccdd12a94afd71d5310b3ce056fdaa06c`
+[kubernetes-client-linux-arm64.tar.gz](https://dl.k8s.io/v1.18.0-alpha.3/kubernetes-client-linux-arm64.tar.gz) | `159ea083c601710d0d6aea423eeb346c99ffaf2abd137d35a53e87a07f5caf12fca8790925f3196f67b768fa92a024f83b50325dbca9ccd4dde6c59acdce3509`
+[kubernetes-client-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.18.0-alpha.3/kubernetes-client-linux-ppc64le.tar.gz) | `16b0459adfa26575d13be49ab53ac7f0ffd05e184e4e13d2dfbfe725d46bb8ac891e1fd8aebe36ecd419781d4cc5cf3bd2aaaf5263cf283724618c4012408f40`
+[kubernetes-client-linux-s390x.tar.gz](https://dl.k8s.io/v1.18.0-alpha.3/kubernetes-client-linux-s390x.tar.gz) | `d5aa1f5d89168995d2797eb839a04ce32560f405b38c1c0baaa0e313e4771ae7bb3b28e22433ad5897d36aadf95f73eb69d8d411d31c4115b6b0adf5fe041f85`
+[kubernetes-client-windows-386.tar.gz](https://dl.k8s.io/v1.18.0-alpha.3/kubernetes-client-windows-386.tar.gz) | `374e16a1e52009be88c94786f80174d82dff66399bf294c9bee18a2159c42251c5debef1109a92570799148b08024960c6c50b8299a93fd66ebef94f198f34e9`
+[kubernetes-client-windows-amd64.tar.gz](https://dl.k8s.io/v1.18.0-alpha.3/kubernetes-client-windows-amd64.tar.gz) | `5a94c1068c19271f810b994adad8e62fae03b3d4473c7c9e6d056995ff7757ea61dd8d140c9267dd41e48808876673ce117826d35a3c1bb5652752f11a044d57`
+
+### Server Binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-server-linux-amd64.tar.gz](https://dl.k8s.io/v1.18.0-alpha.3/kubernetes-server-linux-amd64.tar.gz) | `a677bec81f0eba75114b92ff955bac74512b47e53959d56a685dae5edd527283d91485b1e86ad74ef389c5405863badf7eb22e2f0c9a568a4d0cb495c6a5c32f`
+[kubernetes-server-linux-arm.tar.gz](https://dl.k8s.io/v1.18.0-alpha.3/kubernetes-server-linux-arm.tar.gz) | `2fb696f86ff13ebeb5f3cf2b254bf41303644c5ea84a292782eac6123550702655284d957676d382698c091358e5c7fe73f32803699c19be7138d6530fe413b6`
+[kubernetes-server-linux-arm64.tar.gz](https://dl.k8s.io/v1.18.0-alpha.3/kubernetes-server-linux-arm64.tar.gz) | `738e95da9cfb8f1309479078098de1c38cef5e1dd5ee1129b77651a936a412b7cd0cf15e652afc7421219646a98846ab31694970432e48dea9c9cafa03aa59cf`
+[kubernetes-server-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.18.0-alpha.3/kubernetes-server-linux-ppc64le.tar.gz) | `7a85bfcbb2aa636df60c41879e96e788742ecd72040cb0db2a93418439c125218c58a4cfa96d01b0296c295793e94c544e87c2d98d50b49bc4cb06b41f874376`
+[kubernetes-server-linux-s390x.tar.gz](https://dl.k8s.io/v1.18.0-alpha.3/kubernetes-server-linux-s390x.tar.gz) | `1f1cdb2efa3e7cac857203d8845df2fdaa5cf1f20df764efffff29371945ec58f6deeba06f8fbf70b96faf81b0c955bf4cb84e30f9516cb2cc1ed27c2d2185a6`
+
+### Node Binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-node-linux-amd64.tar.gz](https://dl.k8s.io/v1.18.0-alpha.3/kubernetes-node-linux-amd64.tar.gz) | `4ccfced3f5ba4adfa58f4a9d1b2c5bdb3e89f9203ab0e27d11eb1c325ac323ebe63c015d2c9d070b233f5d1da76cab5349da3528511c1cd243e66edc9af381c4`
+[kubernetes-node-linux-arm.tar.gz](https://dl.k8s.io/v1.18.0-alpha.3/kubernetes-node-linux-arm.tar.gz) | `d695a69d18449062e4c129e54ec8384c573955f8108f4b78adc2ec929719f2196b995469c728dd6656c63c44cda24315543939f85131ebc773cfe0de689df55b`
+[kubernetes-node-linux-arm64.tar.gz](https://dl.k8s.io/v1.18.0-alpha.3/kubernetes-node-linux-arm64.tar.gz) | `21df1da88c89000abc22f97e482c3aaa5ce53ec9628d83dda2e04a1d86c4d53be46c03ed6f1f211df3ee5071bce39d944ff7716b5b6ada3b9c4821d368b0a898`
+[kubernetes-node-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.18.0-alpha.3/kubernetes-node-linux-ppc64le.tar.gz) | `ff77e3aacb6ed9d89baed92ef542c8b5cec83151b6421948583cf608bca3b779dce41fc6852961e00225d5e1502f6a634bfa61a36efa90e1aee90dedb787c2d2`
+[kubernetes-node-linux-s390x.tar.gz](https://dl.k8s.io/v1.18.0-alpha.3/kubernetes-node-linux-s390x.tar.gz) | `57d75b7977ec1a0f6e7ed96a304dbb3b8664910f42ca19aab319a9ec33535ff5901dfca4abcb33bf5741cde6d152acd89a5f8178f0efe1dc24430e0c1af5b98f`
+[kubernetes-node-windows-amd64.tar.gz](https://dl.k8s.io/v1.18.0-alpha.3/kubernetes-node-windows-amd64.tar.gz) | `63fdbb71773cfd73a914c498e69bb9eea3fc314366c99ffb8bd42ec5b4dae807682c83c1eb5cfb1e2feb4d11d9e49cc85ba644e954241320a835798be7653d61`
+
+## Changelog since v1.18.0-alpha.2
+
+### Deprecation
+
+- Remove all the generators from kubectl run. It will now only create pods. Additionally, deprecates all the flags that are not relevant anymore. ([#87077](https://github.com/kubernetes/kubernetes/pull/87077), [@soltysh](https://github.com/soltysh)) [SIG Architecture, SIG CLI, and SIG Testing]
+- kubeadm: kube-dns is deprecated and will not be supported in a future version ([#86574](https://github.com/kubernetes/kubernetes/pull/86574), [@SataQiu](https://github.com/SataQiu)) [SIG Cluster Lifecycle]
+
+### API Change
+
+- Add kubescheduler.config.k8s.io/v1alpha2 ([#87628](https://github.com/kubernetes/kubernetes/pull/87628), [@alculquicondor](https://github.com/alculquicondor)) [SIG Scheduling]
+- --enable-cadvisor-endpoints is now disabled by default. If you need access to the cAdvisor v1 Json API please enable it explicitly in the kubelet command line. Please note that this flag was deprecated in 1.15 and will be removed in 1.19. ([#87440](https://github.com/kubernetes/kubernetes/pull/87440), [@dims](https://github.com/dims)) [SIG Instrumentation, SIG Node, and SIG Testing]
+- The following feature gates are removed, because the associated features were unconditionally enabled in previous releases: CustomResourceValidation, CustomResourceSubresources, CustomResourceWebhookConversion, CustomResourcePublishOpenAPI, CustomResourceDefaulting ([#87475](https://github.com/kubernetes/kubernetes/pull/87475), [@liggitt](https://github.com/liggitt)) [SIG API Machinery]
+
+### Feature
+
+- The aggregation API will have alpha support for network proxy ([#87515](https://github.com/kubernetes/kubernetes/pull/87515), [@Sh4d1](https://github.com/Sh4d1)) [SIG API Machinery]
+- API request throttling (due to a high rate of requests) is now reported in client-go logs at log level 2.  The messages are of the form
+  
+  Throttling request took 1.50705208s, request: GET:<URL>
+  
+  The presence of these messages, may indicate to the administrator the need to tune the cluster accordingly. ([#87740](https://github.com/kubernetes/kubernetes/pull/87740), [@jennybuckley](https://github.com/jennybuckley)) [SIG API Machinery]
+- kubeadm: reject a node joining the cluster if a node with the same name already exists ([#81056](https://github.com/kubernetes/kubernetes/pull/81056), [@neolit123](https://github.com/neolit123)) [SIG Cluster Lifecycle]
+- disableAvailabilitySetNodes is added to avoid VM list for VMSS clusters. It should only be used when vmType is "vmss" and all the nodes (including masters) are VMSS virtual machines. ([#87685](https://github.com/kubernetes/kubernetes/pull/87685), [@feiskyer](https://github.com/feiskyer)) [SIG Cloud Provider]
+- The kubectl --dry-run flag now accepts the values 'client', 'server', and 'none', to support client-side and server-side dry-run strategies. The boolean and unset values for the --dry-run flag are deprecated and a value will be required in a future version. ([#87580](https://github.com/kubernetes/kubernetes/pull/87580), [@julianvmodesto](https://github.com/julianvmodesto)) [SIG CLI]
+- Add support for pre-allocated hugepages for more than one page size ([#82820](https://github.com/kubernetes/kubernetes/pull/82820), [@odinuge](https://github.com/odinuge)) [SIG Apps]
+- Update CNI version to v0.8.5 ([#78819](https://github.com/kubernetes/kubernetes/pull/78819), [@justaugustus](https://github.com/justaugustus)) [SIG API Machinery, SIG Cluster Lifecycle, SIG Network, SIG Release, and SIG Testing]
+- Skip default spreading scoring plugin for pods that define TopologySpreadConstraints ([#87566](https://github.com/kubernetes/kubernetes/pull/87566), [@skilxn-go](https://github.com/skilxn-go)) [SIG Scheduling]
+- Added more details to taint toleration errors ([#87250](https://github.com/kubernetes/kubernetes/pull/87250), [@starizard](https://github.com/starizard)) [SIG Apps, and SIG Scheduling]
+- Scheduler: Add DefaultBinder plugin ([#87430](https://github.com/kubernetes/kubernetes/pull/87430), [@alculquicondor](https://github.com/alculquicondor)) [SIG Scheduling, and SIG Testing]
+- Kube-apiserver metrics will now include request counts, latencies, and response sizes for /healthz, /livez, and /readyz requests. ([#83598](https://github.com/kubernetes/kubernetes/pull/83598), [@jktomer](https://github.com/jktomer)) [SIG API Machinery]
+
+### Other (Bug, Cleanup or Flake)
+
+- Fix the masters rolling upgrade causing thundering herd of LISTs on etcd leading to control plane unavailability. ([#86430](https://github.com/kubernetes/kubernetes/pull/86430), [@wojtek-t](https://github.com/wojtek-t)) [SIG API Machinery, SIG Node, and SIG Testing]
+- `kubectl diff` now returns 1 only on diff finding changes, and >1 on kubectl errors. The "exit status code 1" message as also been muted. ([#87437](https://github.com/kubernetes/kubernetes/pull/87437), [@apelisse](https://github.com/apelisse)) [SIG CLI, and SIG Testing]
+- To reduce chances of throttling, VM cache is set to nil when Azure node provisioning state is deleting ([#87635](https://github.com/kubernetes/kubernetes/pull/87635), [@feiskyer](https://github.com/feiskyer)) [SIG Cloud Provider]
+- Fix regression in statefulset conversion which prevented applying a statefulset multiple times. ([#87706](https://github.com/kubernetes/kubernetes/pull/87706), [@liggitt](https://github.com/liggitt)) [SIG Apps, and SIG Testing]
+- fixed two scheduler metrics (pending_pods and schedule_attempts_total) not being recorded ([#87692](https://github.com/kubernetes/kubernetes/pull/87692), [@everpeace](https://github.com/everpeace)) [SIG Scheduling]
+- Resolved a performance issue in the node authorizer index maintenance. ([#87693](https://github.com/kubernetes/kubernetes/pull/87693), [@liggitt](https://github.com/liggitt)) [SIG Auth]
+- Removed the 'client' label from apiserver_request_total. ([#87669](https://github.com/kubernetes/kubernetes/pull/87669), [@logicalhan](https://github.com/logicalhan)) [SIG API Machinery, and SIG Instrumentation]
+- `(*"k8s.io/client-go/rest".Request).{Do,DoRaw,Stream,Watch}` now require callers to pass a `context.Context` as an argument. The context is used for timeout and cancellation signaling and to pass supplementary information to round trippers in the wrapped transport chain. If you don't need any of this functionality, it is sufficient to pass a context created with `context.Background()` to these functions. The `(*"k8s.io/client-go/rest".Request).Context` method is removed now that all methods that execute a request accept a context directly. ([#87597](https://github.com/kubernetes/kubernetes/pull/87597), [@mikedanese](https://github.com/mikedanese)) [SIG API Machinery, SIG Apps, SIG Auth, SIG Autoscaling, SIG CLI, SIG Cloud Provider, SIG Cluster Lifecycle, SIG Instrumentation, SIG Network, SIG Node, SIG Scheduling, SIG Storage, and SIG Testing]
+- For volumes that allow attaches across multiple nodes, attach and detach operations across different nodes are now executed in parallel. ([#87258](https://github.com/kubernetes/kubernetes/pull/87258), [@verult](https://github.com/verult)) [SIG Apps, SIG Node, and SIG Storage]
+- kubeadm: apply further improvements to the tentative support for concurrent etcd member join. Fixes a bug where multiple members can receive the same hostname. Increase the etcd client dial timeout and retry timeout for add/remove/... operations. ([#87505](https://github.com/kubernetes/kubernetes/pull/87505), [@neolit123](https://github.com/neolit123)) [SIG Cluster Lifecycle]
+- Reverted a kubectl azure auth module change where oidc claim spn: prefix was omitted resulting a breaking behavior with existing Azure AD OIDC enabled api-server ([#87507](https://github.com/kubernetes/kubernetes/pull/87507), [@weinong](https://github.com/weinong)) [SIG API Machinery, SIG Auth, and SIG Cloud Provider]
+- Update cri-tools to v1.17.0 ([#86305](https://github.com/kubernetes/kubernetes/pull/86305), [@saschagrunert](https://github.com/saschagrunert)) [SIG Cluster Lifecycle, and SIG Release]
+- kubeadm: remove the deprecated CoreDNS feature-gate. It was set to "true" since v1.11 when the feature went GA. In v1.13 it was marked as deprecated and hidden from the CLI. ([#87400](https://github.com/kubernetes/kubernetes/pull/87400), [@neolit123](https://github.com/neolit123)) [SIG Cluster Lifecycle]
+- Shared informers are now more reliable in the face of network disruption. ([#86015](https://github.com/kubernetes/kubernetes/pull/86015), [@squeed](https://github.com/squeed)) [SIG API Machinery]
+- the CSR signing cert/key pairs will be reloaded from disk like the kube-apiserver cert/key pairs ([#86816](https://github.com/kubernetes/kubernetes/pull/86816), [@deads2k](https://github.com/deads2k)) [SIG API Machinery, SIG Apps, and SIG Auth]
+- "kubectl describe statefulsets.apps" prints garbage for rolling update partition ([#85846](https://github.com/kubernetes/kubernetes/pull/85846), [@phil9909](https://github.com/phil9909)) [SIG CLI]
+
+
+<!-- NEW RELEASE NOTES ENTRY -->
+
+
+# v1.18.0-alpha.2
+
+[Documentation](https://docs.k8s.io)
+
+## Downloads for v1.18.0-alpha.2
+
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes.tar.gz](https://dl.k8s.io/v1.18.0-alpha.2/kubernetes.tar.gz) | `7af83386b4b35353f0aa1bdaf73599eb08b1d1ca11ecc2c606854aff754db69f3cd3dc761b6d7fc86f01052f615ca53185f33dbf9e53b2f926b0f02fc103fbd3`
+[kubernetes-src.tar.gz](https://dl.k8s.io/v1.18.0-alpha.2/kubernetes-src.tar.gz) | `a14b02a0a0bde97795a836a8f5897b0ee6b43e010e13e43dd4cca80a5b962a1ef3704eedc7916fed1c38ec663a71db48c228c91e5daacba7d9370df98c7ddfb6`
+
+### Client Binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-client-darwin-386.tar.gz](https://dl.k8s.io/v1.18.0-alpha.2/kubernetes-client-darwin-386.tar.gz) | `427f214d47ded44519007de2ae87160c56c2920358130e474b768299751a9affcbc1b1f0f936c39c6138837bca2a97792a6700896976e98c4beee8a1944cfde1`
+[kubernetes-client-darwin-amd64.tar.gz](https://dl.k8s.io/v1.18.0-alpha.2/kubernetes-client-darwin-amd64.tar.gz) | `861fd81ac3bd45765575bedf5e002a2294aba48ef9e15980fc7d6783985f7d7fcde990ea0aef34690977a88df758722ec0a2e170d5dcc3eb01372e64e5439192`
+[kubernetes-client-linux-386.tar.gz](https://dl.k8s.io/v1.18.0-alpha.2/kubernetes-client-linux-386.tar.gz) | `7d59b05d6247e2606a8321c72cd239713373d876dbb43b0fb7f1cb857fa6c998038b41eeed78d9eb67ce77b0b71776ceed428cce0f8d2203c5181b473e0bd86c`
+[kubernetes-client-linux-amd64.tar.gz](https://dl.k8s.io/v1.18.0-alpha.2/kubernetes-client-linux-amd64.tar.gz) | `7cdefb4e32bad9d2df5bb8e7e0a6f4dab2ae6b7afef5d801ac5c342d4effdeacd799081fa2dec699ecf549200786c7623c3176252010f12494a95240dd63311d`
+[kubernetes-client-linux-arm.tar.gz](https://dl.k8s.io/v1.18.0-alpha.2/kubernetes-client-linux-arm.tar.gz) | `6212bbf0fa1d01ced77dcca2c4b76b73956cd3c6b70e0701c1fe0df5ff37160835f6b84fa2481e0e6979516551b14d8232d1c72764a559a3652bfe2a1e7488ff`
+[kubernetes-client-linux-arm64.tar.gz](https://dl.k8s.io/v1.18.0-alpha.2/kubernetes-client-linux-arm64.tar.gz) | `1f0d9990700510165ee471acb2f88222f1b80e8f6deb351ce14cf50a70a9840fb99606781e416a13231c74b2bd7576981b5348171aa33b628d2666e366cd4629`
+[kubernetes-client-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.18.0-alpha.2/kubernetes-client-linux-ppc64le.tar.gz) | `77e00ba12a32db81e96f8de84609de93f32c61bb3f53875a57496d213aa6d1b92c09ad5a6de240a78e1a5bf77fac587ff92874f34a10f8909ae08ca32fda45d2`
+[kubernetes-client-linux-s390x.tar.gz](https://dl.k8s.io/v1.18.0-alpha.2/kubernetes-client-linux-s390x.tar.gz) | `a39ec2044bed5a4570e9c83068e0fc0ce923ccffa44380f8bbc3247426beaff79c8a84613bcb58b05f0eb3afbc34c79fe3309aa2e0b81abcfd0aa04770e62e05`
+[kubernetes-client-windows-386.tar.gz](https://dl.k8s.io/v1.18.0-alpha.2/kubernetes-client-windows-386.tar.gz) | `1a0ab88f9b7e34b60ab31d5538e97202a256ad8b7b7ed5070cae5f2f12d5d4edeae615db7a34ebbe254004b6393c6b2480100b09e30e59c9139492a3019a596a`
+[kubernetes-client-windows-amd64.tar.gz](https://dl.k8s.io/v1.18.0-alpha.2/kubernetes-client-windows-amd64.tar.gz) | `1966eb5dfb78c1bc33aaa6389f32512e3aa92584250a0164182f3566c81d901b59ec78ee4e25df658bc1dd221b5a9527d6ce3b6c487ca3e3c0b319a077caa735`
+
+### Server Binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-server-linux-amd64.tar.gz](https://dl.k8s.io/v1.18.0-alpha.2/kubernetes-server-linux-amd64.tar.gz) | `f814d6a3872e4572aa4da297c29def4c1fad8eba0903946780b6bf9788c72b99d71085c5aef9e12c01133b26fa4563c1766ba724ad2a8af2670a24397951a94d`
+[kubernetes-server-linux-arm.tar.gz](https://dl.k8s.io/v1.18.0-alpha.2/kubernetes-server-linux-arm.tar.gz) | `56aa08225e546c92c2ff88ac57d3db7dd5e63640772ea72a429f080f7069827138cbc206f6f5fe3a0c01bfca043a9eda305ecdc1dcb864649114893e46b6dc84`
+[kubernetes-server-linux-arm64.tar.gz](https://dl.k8s.io/v1.18.0-alpha.2/kubernetes-server-linux-arm64.tar.gz) | `fb87128d905211ba097aa860244a376575ae2edbaca6e51402a24bc2964854b9b273e09df3d31a2bcffc91509f7eecb2118b183fb0e0eb544f33403fa235c274`
+[kubernetes-server-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.18.0-alpha.2/kubernetes-server-linux-ppc64le.tar.gz) | `6d21fbf39b9d3a0df9642407d6f698fabdc809aca83af197bceb58a81b25846072f407f8fb7caae2e02dc90912e3e0f5894f062f91bcb69f8c2329625d3dfeb7`
+[kubernetes-server-linux-s390x.tar.gz](https://dl.k8s.io/v1.18.0-alpha.2/kubernetes-server-linux-s390x.tar.gz) | `ddcda4dc360ca97705f71bf2a18ddacd7b7ddf77535b62e699e97a1b2dd24843751313351d0112e238afe69558e8271eba4d27ab77bb67b4b9e3fbde6eec85c9`
+
+### Node Binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-node-linux-amd64.tar.gz](https://dl.k8s.io/v1.18.0-alpha.2/kubernetes-node-linux-amd64.tar.gz) | `78915a9bde35c70c67014f0cea8754849db4f6a84491a3ad9678fd3bc0203e43af5a63cfafe104ae1d56b05ce74893a87a6dcd008d7859e1af6b3bce65425b5d`
+[kubernetes-node-linux-arm.tar.gz](https://dl.k8s.io/v1.18.0-alpha.2/kubernetes-node-linux-arm.tar.gz) | `3218e811abcb0cb09d80742def339be3916db5e9bbc62c0dc8e6d87085f7e3d9eeed79dea081906f1de78ddd07b7e3acdbd7765fdb838d262bb35602fd1df106`
+[kubernetes-node-linux-arm64.tar.gz](https://dl.k8s.io/v1.18.0-alpha.2/kubernetes-node-linux-arm64.tar.gz) | `fa22de9c4440b8fb27f4e77a5a63c5e1c8aa8aa30bb79eda843b0f40498c21b8c0ad79fff1d841bb9fef53fe20da272506de9a86f81a0b36d028dbeab2e482ce`
+[kubernetes-node-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.18.0-alpha.2/kubernetes-node-linux-ppc64le.tar.gz) | `bbda9b5cc66e8f13d235703b2a85e2c4f02fa16af047be4d27a3e198e11eb11706e4a0fbb6c20978c770b069cd4cd9894b661f09937df9d507411548c36576e0`
+[kubernetes-node-linux-s390x.tar.gz](https://dl.k8s.io/v1.18.0-alpha.2/kubernetes-node-linux-s390x.tar.gz) | `b2ed1eda013069adce2aac00b86d75b84e006cfce9bafac0b5a2bafcb60f8f2cb346b5ea44eafa72d777871abef1ea890eb3a2a05de28968f9316fa88886a8ed`
+[kubernetes-node-windows-amd64.tar.gz](https://dl.k8s.io/v1.18.0-alpha.2/kubernetes-node-windows-amd64.tar.gz) | `bd8eb23dba711f31b5148257076b1bbe9629f2a75de213b2c779bd5b29279e9bf22f8bde32f4bc814f4c0cc49e19671eb8b24f4105f0fe2c1490c4b78ec3c704`
+
+## Changelog since v1.18.0-alpha.1
+
+### Other notable changes
+
+* Bump golang/mock version to v1.3.1 ([#87326](https://github.com/kubernetes/kubernetes/pull/87326), [@wawa0210](https://github.com/wawa0210))
+* fix a bug that orphan revision cannot be adopted and statefulset cannot be synced ([#86801](https://github.com/kubernetes/kubernetes/pull/86801), [@likakuli](https://github.com/likakuli))
+* Azure storage clients now suppress requests on throttling ([#87306](https://github.com/kubernetes/kubernetes/pull/87306), [@feiskyer](https://github.com/feiskyer))
+* Introduce Alpha field `Immutable` in both Secret and ConfigMap objects to mark their contents as immutable. The implementation is hidden behind feature gate `ImmutableEphemeralVolumes` (currently in Alpha stage). ([#86377](https://github.com/kubernetes/kubernetes/pull/86377), [@wojtek-t](https://github.com/wojtek-t))
+* EndpointSlices will now be enabled by default. A new `EndpointSliceProxying` feature gate determines if kube-proxy will use EndpointSlices, this is disabled by default. ([#86137](https://github.com/kubernetes/kubernetes/pull/86137), [@robscott](https://github.com/robscott))
+* kubeadm upgrades always persist the etcd backup for stacked ([#86861](https://github.com/kubernetes/kubernetes/pull/86861), [@SataQiu](https://github.com/SataQiu))
+* Fix the bug PIP's DNS is deleted if no DNS label service annotation isn't set. ([#87246](https://github.com/kubernetes/kubernetes/pull/87246), [@nilo19](https://github.com/nilo19))
+* New flag `--show-hidden-metrics-for-version` in kube-controller-manager can be used to show all hidden metrics that deprecated in the previous minor release. ([#85281](https://github.com/kubernetes/kubernetes/pull/85281), [@RainbowMango](https://github.com/RainbowMango))
+* Azure network and VM clients now suppress requests on throttling ([#87122](https://github.com/kubernetes/kubernetes/pull/87122), [@feiskyer](https://github.com/feiskyer))
+* `kubectl apply  -f <file> --prune -n <namespace>` should prune all resources not defined in the file in the cli specified namespace. ([#85613](https://github.com/kubernetes/kubernetes/pull/85613), [@MartinKaburu](https://github.com/MartinKaburu))
+* Fixes service account token admission error in clusters that do not run the service account token controller ([#87029](https://github.com/kubernetes/kubernetes/pull/87029), [@liggitt](https://github.com/liggitt))
+* CustomResourceDefinition status fields are no longer required for client validation when submitting manifests.  ([#87213](https://github.com/kubernetes/kubernetes/pull/87213), [@hasheddan](https://github.com/hasheddan))
+* All apiservers log request lines in a more greppable format. ([#87203](https://github.com/kubernetes/kubernetes/pull/87203), [@lavalamp](https://github.com/lavalamp))
+* provider/azure: Network security groups can now be in a separate resource group. ([#87035](https://github.com/kubernetes/kubernetes/pull/87035), [@CecileRobertMichon](https://github.com/CecileRobertMichon))
+* Cleaned up the output from `kubectl describe CSINode <name>`. ([#85283](https://github.com/kubernetes/kubernetes/pull/85283), [@huffmanca](https://github.com/huffmanca))
+* Fixed the following  ([#84265](https://github.com/kubernetes/kubernetes/pull/84265), [@bhagwat070919](https://github.com/bhagwat070919))
+    * -  AWS Cloud Provider attempts to delete LoadBalancer security group it didn’t provision
+    * -  AWS Cloud Provider creates default LoadBalancer security group even if annotation [service.beta.kubernetes.io/aws-load-balancer-security-groups] is present
+* kubelet: resource metrics endpoint `/metrics/resource/v1alpha1` as well as all metrics under this endpoint have been deprecated. ([#86282](https://github.com/kubernetes/kubernetes/pull/86282), [@RainbowMango](https://github.com/RainbowMango))
+    * Please convert to the following metrics emitted by endpoint `/metrics/resource`:
+    * - scrape_error --> scrape_error
+    * - node_cpu_usage_seconds_total --> node_cpu_usage_seconds
+    * - node_memory_working_set_bytes --> node_memory_working_set_bytes
+    * - container_cpu_usage_seconds_total --> container_cpu_usage_seconds
+    * - container_memory_working_set_bytes --> container_memory_working_set_bytes
+    * - scrape_error --> scrape_error
+* You can now pass "--node-ip ::" to kubelet to indicate that it should autodetect an IPv6 address to use as the node's primary address. ([#85850](https://github.com/kubernetes/kubernetes/pull/85850), [@danwinship](https://github.com/danwinship))
+* kubeadm: support automatic retry after failing to pull image ([#86899](https://github.com/kubernetes/kubernetes/pull/86899), [@SataQiu](https://github.com/SataQiu))
+* TODO ([#87044](https://github.com/kubernetes/kubernetes/pull/87044), [@jennybuckley](https://github.com/jennybuckley))
+* Improved yaml parsing performance ([#85458](https://github.com/kubernetes/kubernetes/pull/85458), [@cjcullen](https://github.com/cjcullen))
+* Fixed a bug which could prevent a provider ID from ever being set for node if an error occurred determining the provider ID when the node was added. ([#87043](https://github.com/kubernetes/kubernetes/pull/87043), [@zjs](https://github.com/zjs))
+* fix a regression in kubenet that prevent pods to obtain ip addresses ([#85993](https://github.com/kubernetes/kubernetes/pull/85993), [@chendotjs](https://github.com/chendotjs))
+* Bind kube-dns containers to linux nodes to avoid Windows scheduling ([#83358](https://github.com/kubernetes/kubernetes/pull/83358), [@wawa0210](https://github.com/wawa0210))
+* The following features are unconditionally enabled and the corresponding `--feature-gates` flags have been removed: `PodPriority`, `TaintNodesByCondition`, `ResourceQuotaScopeSelectors` and `ScheduleDaemonSetPods` ([#86210](https://github.com/kubernetes/kubernetes/pull/86210), [@draveness](https://github.com/draveness))
+* Bind dns-horizontal containers to linux nodes to avoid Windows scheduling on kubernetes cluster includes linux nodes and windows nodes ([#83364](https://github.com/kubernetes/kubernetes/pull/83364), [@wawa0210](https://github.com/wawa0210))
+* fix kubectl annotate error when local=true is set ([#86952](https://github.com/kubernetes/kubernetes/pull/86952), [@zhouya0](https://github.com/zhouya0))
+* Bug fixes: ([#84163](https://github.com/kubernetes/kubernetes/pull/84163), [@david-tigera](https://github.com/david-tigera))
+    * Make sure we include latest packages node #351 ([@caseydavenport](https://github.com/caseydavenport))
+* fix kuebctl apply set-last-applied namespaces error   ([#86474](https://github.com/kubernetes/kubernetes/pull/86474), [@zhouya0](https://github.com/zhouya0))
+* Add VolumeBinder method to FrameworkHandle interface, which allows user to get the volume binder when implementing scheduler framework plugins. ([#86940](https://github.com/kubernetes/kubernetes/pull/86940), [@skilxn-go](https://github.com/skilxn-go))
+* elasticsearch supports automatically setting the advertise address ([#85944](https://github.com/kubernetes/kubernetes/pull/85944), [@SataQiu](https://github.com/SataQiu))
+* If a serving certificates param specifies a name that is an IP for an SNI certificate, it will have priority for replying to server connections. ([#85308](https://github.com/kubernetes/kubernetes/pull/85308), [@deads2k](https://github.com/deads2k))
+* kube-proxy: Added dual-stack IPv4/IPv6 support to the iptables proxier. ([#82462](https://github.com/kubernetes/kubernetes/pull/82462), [@vllry](https://github.com/vllry))
+* Azure VMSS/VMSSVM clients now suppress requests on throttling ([#86740](https://github.com/kubernetes/kubernetes/pull/86740), [@feiskyer](https://github.com/feiskyer))
+* New metric kubelet_pleg_last_seen_seconds to aid diagnosis of PLEG not healthy issues. ([#86251](https://github.com/kubernetes/kubernetes/pull/86251), [@bboreham](https://github.com/bboreham))
+* For subprotocol negotiation, both client and server protocol is required now. ([#86646](https://github.com/kubernetes/kubernetes/pull/86646), [@tedyu](https://github.com/tedyu))
+* kubeadm: use bind-address option to configure the kube-controller-manager and kube-scheduler http probes ([#86493](https://github.com/kubernetes/kubernetes/pull/86493), [@aojea](https://github.com/aojea))
+* Marked scheduler's metrics scheduling_algorithm_predicate_evaluation_seconds and ([#86584](https://github.com/kubernetes/kubernetes/pull/86584), [@xiaoanyunfei](https://github.com/xiaoanyunfei))
+    * scheduling_algorithm_priority_evaluation_seconds as deprecated. Those are replaced by framework_extension_point_duration_seconds[extenstion_point="Filter"] and framework_extension_point_duration_seconds[extenstion_point="Score"] respectively.
+* Marked scheduler's scheduling_duration_seconds Summary metric as deprecated ([#86586](https://github.com/kubernetes/kubernetes/pull/86586), [@xiaoanyunfei](https://github.com/xiaoanyunfei))
+* Add instructions about how to bring up e2e test cluster ([#85836](https://github.com/kubernetes/kubernetes/pull/85836), [@YangLu1031](https://github.com/YangLu1031))
+* If a required flag is not provided to a command, the user will only see the required flag error message, instead of the entire usage menu. ([#86693](https://github.com/kubernetes/kubernetes/pull/86693), [@sallyom](https://github.com/sallyom))
+* kubeadm: tolerate whitespace when validating certificate authority PEM data in kubeconfig files ([#86705](https://github.com/kubernetes/kubernetes/pull/86705), [@neolit123](https://github.com/neolit123))
+* kubeadm: add support for the "ci/k8s-master" version label as a replacement for "ci-cross/*", which no longer exists. ([#86609](https://github.com/kubernetes/kubernetes/pull/86609), [@Pensu](https://github.com/Pensu))
+* Fix EndpointSlice controller race condition and ensure that it handles external changes to EndpointSlices. ([#85703](https://github.com/kubernetes/kubernetes/pull/85703), [@robscott](https://github.com/robscott))
+* Fix nil pointer dereference in azure cloud provider ([#85975](https://github.com/kubernetes/kubernetes/pull/85975), [@ldx](https://github.com/ldx))
+* fix: azure disk could not mounted on Standard_DC4s/DC2s instances ([#86612](https://github.com/kubernetes/kubernetes/pull/86612), [@andyzhangx](https://github.com/andyzhangx))
+* Fixes v1.17.0 regression in --service-cluster-ip-range handling with IPv4 ranges larger than 65536 IP addresses ([#86534](https://github.com/kubernetes/kubernetes/pull/86534), [@liggitt](https://github.com/liggitt))
+* Adds back support for AlwaysCheckAllPredicates flag. ([#86496](https://github.com/kubernetes/kubernetes/pull/86496), [@ahg-g](https://github.com/ahg-g))
+* Azure global rate limit is switched to per-client. A set of new rate limit configure options are introduced, including routeRateLimit, SubnetsRateLimit, InterfaceRateLimit, RouteTableRateLimit, LoadBalancerRateLimit, PublicIPAddressRateLimit, SecurityGroupRateLimit, VirtualMachineRateLimit, StorageAccountRateLimit, DiskRateLimit, SnapshotRateLimit, VirtualMachineScaleSetRateLimit and VirtualMachineSizeRateLimit. ([#86515](https://github.com/kubernetes/kubernetes/pull/86515), [@feiskyer](https://github.com/feiskyer))
+    * The original rate limit options would be default values for those new client's rate limiter.
+* Fix issue [#85805](https://github.com/kubernetes/kubernetes/pull/85805) about resource not found in azure cloud provider when lb specified in other resource group. ([#86502](https://github.com/kubernetes/kubernetes/pull/86502), [@levimm](https://github.com/levimm))
+* `AlwaysCheckAllPredicates` is deprecated in scheduler Policy API. ([#86369](https://github.com/kubernetes/kubernetes/pull/86369), [@Huang-Wei](https://github.com/Huang-Wei))
+* Kubernetes KMS provider for data encryption now supports disabling the in-memory data encryption key (DEK) cache by setting cachesize to a negative value. ([#86294](https://github.com/kubernetes/kubernetes/pull/86294), [@enj](https://github.com/enj))
+* option `preConfiguredBackendPoolLoadBalancerTypes` is added to azure cloud provider for the pre-configured load balancers, possible values: `""`, `"internal"`, "external"`, `"all"` ([#86338](https://github.com/kubernetes/kubernetes/pull/86338), [@gossion](https://github.com/gossion))
+* Promote StartupProbe to beta for 1.18 release ([#83437](https://github.com/kubernetes/kubernetes/pull/83437), [@matthyx](https://github.com/matthyx))
+* Fixes issue where AAD token obtained by kubectl is incompatible with on-behalf-of flow and oidc. ([#86412](https://github.com/kubernetes/kubernetes/pull/86412), [@weinong](https://github.com/weinong))
+    * The audience claim before this fix has "spn:" prefix. After this fix, "spn:" prefix is omitted.
+* change CounterVec to Counter about  PLEGDiscardEvent ([#86167](https://github.com/kubernetes/kubernetes/pull/86167), [@yiyang5055](https://github.com/yiyang5055))
+* hollow-node do not use remote CRI anymore ([#86425](https://github.com/kubernetes/kubernetes/pull/86425), [@jkaniuk](https://github.com/jkaniuk))
+* hollow-node use fake CRI ([#85879](https://github.com/kubernetes/kubernetes/pull/85879), [@gongguan](https://github.com/gongguan))
+
+
+
+# v1.18.0-alpha.1
+
+[Documentation](https://docs.k8s.io)
+
+## Downloads for v1.18.0-alpha.1
+
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes.tar.gz](https://dl.k8s.io/v1.18.0-alpha.1/kubernetes.tar.gz) | `0c4904efc7f4f1436119c91dc1b6c93b3bd9c7490362a394bff10099c18e1e7600c4f6e2fcbaeb2d342a36c4b20692715cf7aa8ada6dfac369f44cc9292529d7`
+[kubernetes-src.tar.gz](https://dl.k8s.io/v1.18.0-alpha.1/kubernetes-src.tar.gz) | `0a50fc6816c730ca5ae4c4f26d5ad7b049607d29f6a782a4e5b4b05ac50e016486e269dafcc6a163bd15e1a192780a9a987f1bb959696993641c603ed1e841c8`
+
+### Client Binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-client-darwin-386.tar.gz](https://dl.k8s.io/v1.18.0-alpha.1/kubernetes-client-darwin-386.tar.gz) | `c6d75f7f3f20bef17fc7564a619b54e6f4a673d041b7c9ec93663763a1cc8dd16aecd7a2af70e8d54825a0eecb9762cf2edfdade840604c9a32ecd9cc2d5ac3c`
+[kubernetes-client-darwin-amd64.tar.gz](https://dl.k8s.io/v1.18.0-alpha.1/kubernetes-client-darwin-amd64.tar.gz) | `ca1f19db289933beace6daee6fc30af19b0e260634ef6e89f773464a05e24551c791be58b67da7a7e2a863e28b7cbcc7b24b6b9bf467113c26da76ac8f54fdb6`
+[kubernetes-client-linux-386.tar.gz](https://dl.k8s.io/v1.18.0-alpha.1/kubernetes-client-linux-386.tar.gz) | `af2e673653eb39c3f24a54efc68e1055f9258bdf6cf8fea42faf42c05abefc2da853f42faac3b166c37e2a7533020b8993b98c0d6d80a5b66f39e91d8ae0a3fb`
+[kubernetes-client-linux-amd64.tar.gz](https://dl.k8s.io/v1.18.0-alpha.1/kubernetes-client-linux-amd64.tar.gz) | `9009032c3f94ac8a78c1322a28e16644ce3b20989eb762685a1819148aed6e883ca8e1200e5ec37ec0853f115c67e09b5d697d6cf5d4c45f653788a2d3a2f84f`
+[kubernetes-client-linux-arm.tar.gz](https://dl.k8s.io/v1.18.0-alpha.1/kubernetes-client-linux-arm.tar.gz) | `afba9595b37a3f2eead6e3418573f7ce093b55467dce4da0b8de860028576b96b837a2fd942f9c276e965da694e31fbd523eeb39aefb902d7e7a2f169344d271`
+[kubernetes-client-linux-arm64.tar.gz](https://dl.k8s.io/v1.18.0-alpha.1/kubernetes-client-linux-arm64.tar.gz) | `04fc3b2fe3f271807f0bc6c61be52456f26a1af904964400be819b7914519edc72cbab9afab2bb2e2ba1a108963079367cedfb253c9364c0175d1fcc64d52f5c`
+[kubernetes-client-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.18.0-alpha.1/kubernetes-client-linux-ppc64le.tar.gz) | `04c7edab874b33175ff7bebfff5b3a032bc6eb088fcd7387ffcd5b3fa71395ca8c5f9427b7ddb496e92087dfdb09eaf14a46e9513071d3bd73df76c182922d38`
+[kubernetes-client-linux-s390x.tar.gz](https://dl.k8s.io/v1.18.0-alpha.1/kubernetes-client-linux-s390x.tar.gz) | `499287dbbc33399a37b9f3b35e0124ff20b17b6619f25a207ee9c606ef261af61fa0c328dde18c7ce2d3dfb2eea2376623bc3425d16bc8515932a68b44f8bede`
+[kubernetes-client-windows-386.tar.gz](https://dl.k8s.io/v1.18.0-alpha.1/kubernetes-client-windows-386.tar.gz) | `cf84aeddf00f126fb13c0436b116dd0464a625659e44c84bf863517db0406afb4eefd86807e7543c4f96006d275772fbf66214ae7d582db5865c84ac3545b3e6`
+[kubernetes-client-windows-amd64.tar.gz](https://dl.k8s.io/v1.18.0-alpha.1/kubernetes-client-windows-amd64.tar.gz) | `69f20558ccd5cd6dbaccf29307210db4e687af21f6d71f68c69d3a39766862686ac1333ab8a5012010ca5c5e3c11676b45e498e3d4c38773da7d24bcefc46d95`
+
+### Server Binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-server-linux-amd64.tar.gz](https://dl.k8s.io/v1.18.0-alpha.1/kubernetes-server-linux-amd64.tar.gz) | `3f29df2ce904a0f10db4c1d7a425a36f420867b595da3fa158ae430bfead90def2f2139f51425b349faa8a9303dcf20ea01657cb6ea28eb6ad64f5bb32ce2ed1`
+[kubernetes-server-linux-arm.tar.gz](https://dl.k8s.io/v1.18.0-alpha.1/kubernetes-server-linux-arm.tar.gz) | `4a21073b2273d721fbf062c254840be5c8471a010bcc0c731b101729e36e61f637cb7fcb521a22e8d24808510242f4fff8a6ca40f10e9acd849c2a47bf135f27`
+[kubernetes-server-linux-arm64.tar.gz](https://dl.k8s.io/v1.18.0-alpha.1/kubernetes-server-linux-arm64.tar.gz) | `7f1cb6d721bedc90e28b16f99bea7e59f5ad6267c31ef39c14d34db6ad6aad87ee51d2acdd01b6903307c1c00b58ff6b785a03d5a491cc3f8a4df9a1d76d406c`
+[kubernetes-server-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.18.0-alpha.1/kubernetes-server-linux-ppc64le.tar.gz) | `8f2b552030b5274b1c2c7c166eacd5a14b0c6ca0f23042f4c52efe87e22a167ba4460dcd66615a5ecd26d9e88336be1fb555548392e70efe59070dd2c314da98`
+[kubernetes-server-linux-s390x.tar.gz](https://dl.k8s.io/v1.18.0-alpha.1/kubernetes-server-linux-s390x.tar.gz) | `8d9f2c96f66edafb7c8b3aa90960d29b41471743842aede6b47b3b2e61f4306fb6fc60b9ebc18820c547ee200bfedfe254c1cde962d447c791097dd30e79abdb`
+
+### Node Binaries
+
+filename | sha512 hash
+-------- | -----------
+[kubernetes-node-linux-amd64.tar.gz](https://dl.k8s.io/v1.18.0-alpha.1/kubernetes-node-linux-amd64.tar.gz) | `84194cb081d1502f8ca68143569f9707d96f1a28fcf0c574ebd203321463a8b605f67bb2a365eaffb14fbeb8d55c8d3fa17431780b242fb9cba3a14426a0cd4a`
+[kubernetes-node-linux-arm.tar.gz](https://dl.k8s.io/v1.18.0-alpha.1/kubernetes-node-linux-arm.tar.gz) | `0091e108ab94fd8683b89c597c4fdc2fbf4920b007cfcd5297072c44bc3a230dfe5ceed16473e15c3e6cf5edab866d7004b53edab95be0400cc60e009eee0d9d`
+[kubernetes-node-linux-arm64.tar.gz](https://dl.k8s.io/v1.18.0-alpha.1/kubernetes-node-linux-arm64.tar.gz) | `b7e85682cc2848a35d52fd6f01c247f039ee1b5dd03345713821ea10a7fa9939b944f91087baae95eaa0665d11857c1b81c454f720add077287b091f9f19e5d3`
+[kubernetes-node-linux-ppc64le.tar.gz](https://dl.k8s.io/v1.18.0-alpha.1/kubernetes-node-linux-ppc64le.tar.gz) | `cd1f0849e9c62b5d2c93ff0cebf58843e178d8a88317f45f76de0db5ae020b8027e9503a5fccc96445184e0d77ecdf6f57787176ac31dbcbd01323cd0a190cbb`
+[kubernetes-node-linux-s390x.tar.gz](https://dl.k8s.io/v1.18.0-alpha.1/kubernetes-node-linux-s390x.tar.gz) | `e1e697a34424c75d75415b613b81c8af5f64384226c5152d869f12fd7db1a3e25724975b73fa3d89e56e4bf78d5fd07e68a709ba8566f53691ba6a88addc79ea`
+[kubernetes-node-windows-amd64.tar.gz](https://dl.k8s.io/v1.18.0-alpha.1/kubernetes-node-windows-amd64.tar.gz) | `c725a19a4013c74e22383ad3fb4cb799b3e161c4318fdad066daf806730a89bc3be3ff0f75678d02b3cbe52b2ef0c411c0639968e200b9df470be40bb2c015cc`
+
+## Changelog since v1.17.0
+
+### Action Required
+
+* action required ([#85363](https://github.com/kubernetes/kubernetes/pull/85363), [@immutableT](https://github.com/immutableT))
+    * 1. Currently, if users were to explicitly specify CacheSize of 0 for KMS provider, they would end-up with a provider that caches up to 1000 keys. This PR changes this behavior.
+    * Post this PR, when users supply 0 for CacheSize this will result in a validation error.
+    * 2. CacheSize type was changed from int32 to *int32. This allows defaulting logic to differentiate between cases where users explicitly supplied 0 vs. not supplied any value.
+    * 3. KMS Provider's endpoint (path to Unix socket) is now validated when the EncryptionConfiguration files is loaded. This used to be handled by the GRPCService.
+
+### Other notable changes
+
+* fix: azure data disk should use same key as os disk by default ([#86351](https://github.com/kubernetes/kubernetes/pull/86351), [@andyzhangx](https://github.com/andyzhangx))
+* New flag `--show-hidden-metrics-for-version` in kube-proxy can be used to show all hidden metrics that deprecated in the previous minor release. ([#85279](https://github.com/kubernetes/kubernetes/pull/85279), [@RainbowMango](https://github.com/RainbowMango))
+* Remove cluster-monitoring addon ([#85512](https://github.com/kubernetes/kubernetes/pull/85512), [@serathius](https://github.com/serathius))
+* Changed core_pattern on COS nodes to be an absolute path. ([#86329](https://github.com/kubernetes/kubernetes/pull/86329), [@mml](https://github.com/mml))
+* Track mount operations as uncertain if operation fails with non-final error ([#82492](https://github.com/kubernetes/kubernetes/pull/82492), [@gnufied](https://github.com/gnufied))
+* add kube-proxy flags --ipvs-tcp-timeout, --ipvs-tcpfin-timeout, --ipvs-udp-timeout to configure IPVS connection timeouts. ([#85517](https://github.com/kubernetes/kubernetes/pull/85517), [@andrewsykim](https://github.com/andrewsykim))
+* The sample-apiserver aggregated conformance test has updated to use the Kubernetes v1.17.0 sample apiserver ([#84735](https://github.com/kubernetes/kubernetes/pull/84735), [@liggitt](https://github.com/liggitt))
+* The underlying format of the `CPUManager` state file has changed. Upgrades should be seamless, but any third-party tools that rely on reading the previous format need to be updated. ([#84462](https://github.com/kubernetes/kubernetes/pull/84462), [@klueska](https://github.com/klueska))
+* kubernetes will try to acquire the iptables lock every 100 msec during 5 seconds instead of every second. This specially useful for environments using kube-proxy in iptables mode with a high churn rate of services. ([#85771](https://github.com/kubernetes/kubernetes/pull/85771), [@aojea](https://github.com/aojea))
+* Fixed a panic in the kubelet cleaning up pod volumes ([#86277](https://github.com/kubernetes/kubernetes/pull/86277), [@tedyu](https://github.com/tedyu))
+* azure cloud provider cache TTL is configurable, list of the azure cloud provider is as following: ([#86266](https://github.com/kubernetes/kubernetes/pull/86266), [@zqingqing1](https://github.com/zqingqing1))
+    * - "availabilitySetNodesCacheTTLInSeconds"
+    * - "vmssCacheTTLInSeconds"
+    * - "vmssVirtualMachinesCacheTTLInSeconds"
+    * - "vmCacheTTLInSeconds"
+    * - "loadBalancerCacheTTLInSeconds"
+    * - "nsgCacheTTLInSeconds"
+    * - "routeTableCacheTTLInSeconds"
+* Fixes kube-proxy when EndpointSlice feature gate is enabled on Windows. ([#86016](https://github.com/kubernetes/kubernetes/pull/86016), [@robscott](https://github.com/robscott))
+* Fixes wrong validation result of NetworkPolicy PolicyTypes ([#85747](https://github.com/kubernetes/kubernetes/pull/85747), [@tnqn](https://github.com/tnqn))
+* Fixes an issue with kubelet-reported pod status on deleted/recreated pods. ([#86320](https://github.com/kubernetes/kubernetes/pull/86320), [@liggitt](https://github.com/liggitt))
+* kube-apiserver no longer serves the following deprecated APIs: ([#85903](https://github.com/kubernetes/kubernetes/pull/85903), [@liggitt](https://github.com/liggitt))
+        * All resources under `apps/v1beta1` and `apps/v1beta2` - use `apps/v1` instead
+        * `daemonsets`, `deployments`, `replicasets` resources under `extensions/v1beta1` - use `apps/v1` instead
+        * `networkpolicies` resources under `extensions/v1beta1` - use `networking.k8s.io/v1` instead
+        * `podsecuritypolicies` resources under `extensions/v1beta1` - use `policy/v1beta1` instead
+* kubeadm: fix potential panic when executing "kubeadm reset" with a corrupted kubelet.conf file ([#86216](https://github.com/kubernetes/kubernetes/pull/86216), [@neolit123](https://github.com/neolit123))
+* Fix a bug in port-forward: named port not working with service ([#85511](https://github.com/kubernetes/kubernetes/pull/85511), [@oke-py](https://github.com/oke-py))
+* kube-proxy no longer modifies shared EndpointSlices. ([#86092](https://github.com/kubernetes/kubernetes/pull/86092), [@robscott](https://github.com/robscott))
+* allow for configuration of CoreDNS replica count ([#85837](https://github.com/kubernetes/kubernetes/pull/85837), [@pickledrick](https://github.com/pickledrick))
+* Fixed a regression where the kubelet would fail to update the ready status of pods. ([#84951](https://github.com/kubernetes/kubernetes/pull/84951), [@tedyu](https://github.com/tedyu))
+* Resolves performance regression in client-go discovery clients constructed using `NewDiscoveryClientForConfig` or `NewDiscoveryClientForConfigOrDie`. ([#86168](https://github.com/kubernetes/kubernetes/pull/86168), [@liggitt](https://github.com/liggitt))
+* Make error message and service event message more clear ([#86078](https://github.com/kubernetes/kubernetes/pull/86078), [@feiskyer](https://github.com/feiskyer))
+* e2e-test-framework: add e2e test namespace dump if all tests succeed but the cleanup fails. ([#85542](https://github.com/kubernetes/kubernetes/pull/85542), [@schrodit](https://github.com/schrodit))
+* SafeSysctlWhitelist: add net.ipv4.ping_group_range ([#85463](https://github.com/kubernetes/kubernetes/pull/85463), [@AkihiroSuda](https://github.com/AkihiroSuda))
+* kubelet: the metric process_start_time_seconds be marked as with the ALPHA stability level. ([#85446](https://github.com/kubernetes/kubernetes/pull/85446), [@RainbowMango](https://github.com/RainbowMango))
+* API request throttling (due to a high rate of requests) is now reported in the kubelet (and other component) logs by default.  The messages are of the form ([#80649](https://github.com/kubernetes/kubernetes/pull/80649), [@RobertKrawitz](https://github.com/RobertKrawitz))
+    * Throttling request took 1.50705208s, request: GET:<URL>
+    * The presence of large numbers of these messages, particularly with long delay times, may indicate to the administrator the need to tune the cluster accordingly.
+* Fix API Server potential memory leak issue in processing watch request. ([#85410](https://github.com/kubernetes/kubernetes/pull/85410), [@answer1991](https://github.com/answer1991))
+* Verify kubelet & kube-proxy can recover after being killed on Windows nodes ([#84886](https://github.com/kubernetes/kubernetes/pull/84886), [@YangLu1031](https://github.com/YangLu1031))
+* Fixed an issue that the scheduler only returns the first failure reason. ([#86022](https://github.com/kubernetes/kubernetes/pull/86022), [@Huang-Wei](https://github.com/Huang-Wei))
+* kubectl/drain: add skip-wait-for-delete-timeout option. ([#85577](https://github.com/kubernetes/kubernetes/pull/85577), [@michaelgugino](https://github.com/michaelgugino))
+    * If pod DeletionTimestamp older than N seconds, skip waiting for the pod.  Seconds must be greater than 0 to skip.
+* Following metrics have been turned off: ([#83841](https://github.com/kubernetes/kubernetes/pull/83841), [@RainbowMango](https://github.com/RainbowMango))
+    * - kubelet_pod_worker_latency_microseconds
+    * - kubelet_pod_start_latency_microseconds
+    * - kubelet_cgroup_manager_latency_microseconds
+    * - kubelet_pod_worker_start_latency_microseconds
+    * - kubelet_pleg_relist_latency_microseconds
+    * - kubelet_pleg_relist_interval_microseconds
+    * - kubelet_eviction_stats_age_microseconds
+    * - kubelet_runtime_operations
+    * - kubelet_runtime_operations_latency_microseconds
+    * - kubelet_runtime_operations_errors
+    * - kubelet_device_plugin_registration_count
+    * - kubelet_device_plugin_alloc_latency_microseconds
+    * - kubelet_docker_operations
+    * - kubelet_docker_operations_latency_microseconds
+    * - kubelet_docker_operations_errors
+    * - kubelet_docker_operations_timeout
+    * - network_plugin_operations_latency_microseconds
+* - Renamed Kubelet metric certificate_manager_server_expiration_seconds to certificate_manager_server_ttl_seconds and changed to report the second until expiration at read time rather than absolute time of expiry. ([#85874](https://github.com/kubernetes/kubernetes/pull/85874), [@sambdavidson](https://github.com/sambdavidson))
+    * - Improved accuracy of Kubelet metric rest_client_exec_plugin_ttl_seconds.
+* Bind metadata-agent containers to linux nodes to avoid Windows scheduling on kubernetes cluster includes linux nodes and windows nodes ([#83363](https://github.com/kubernetes/kubernetes/pull/83363), [@wawa0210](https://github.com/wawa0210))
+* Bind metrics-server containers to linux nodes to avoid Windows scheduling on kubernetes cluster includes linux nodes and windows nodes ([#83362](https://github.com/kubernetes/kubernetes/pull/83362), [@wawa0210](https://github.com/wawa0210))
+* During initialization phase (preflight), kubeadm now verifies the presence of the conntrack executable ([#85857](https://github.com/kubernetes/kubernetes/pull/85857), [@hnanni](https://github.com/hnanni))
+* VMSS cache is added so that less chances of VMSS GET throttling ([#85885](https://github.com/kubernetes/kubernetes/pull/85885), [@nilo19](https://github.com/nilo19))
+* Update go-winio module version from 0.4.11 to 0.4.14 ([#85739](https://github.com/kubernetes/kubernetes/pull/85739), [@wawa0210](https://github.com/wawa0210))
+* Fix LoadBalancer rule checking so that no unexpected LoadBalancer updates are made ([#85990](https://github.com/kubernetes/kubernetes/pull/85990), [@feiskyer](https://github.com/feiskyer))
+* kubectl drain node --dry-run will list pods that would be evicted or deleted ([#82660](https://github.com/kubernetes/kubernetes/pull/82660), [@sallyom](https://github.com/sallyom))
+* Windows nodes on GCE can use TPM-based authentication to the master. ([#85466](https://github.com/kubernetes/kubernetes/pull/85466), [@pjh](https://github.com/pjh))
+* kubectl/drain: add disable-eviction option. ([#85571](https://github.com/kubernetes/kubernetes/pull/85571), [@michaelgugino](https://github.com/michaelgugino))
+    * Force drain to use delete, even if eviction is supported. This will bypass checking PodDisruptionBudgets, and should be used with caution.
+* kubeadm now errors out whenever a not supported component config version is supplied for the kubelet and kube-proxy ([#85639](https://github.com/kubernetes/kubernetes/pull/85639), [@rosti](https://github.com/rosti))
+* Fixed issue with addon-resizer using deprecated extensions APIs ([#85793](https://github.com/kubernetes/kubernetes/pull/85793), [@bskiba](https://github.com/bskiba))
+* Includes FSType when describing CSI persistent volumes. ([#85293](https://github.com/kubernetes/kubernetes/pull/85293), [@huffmanca](https://github.com/huffmanca))
+* kubelet now exports a "server_expiration_renew_failure" and "client_expiration_renew_failure" metric counter if the certificate rotations cannot be performed. ([#84614](https://github.com/kubernetes/kubernetes/pull/84614), [@rphillips](https://github.com/rphillips))
+* kubeadm: don't write the kubelet environment file on "upgrade apply" ([#85412](https://github.com/kubernetes/kubernetes/pull/85412), [@boluisa](https://github.com/boluisa))
+* fix azure file AuthorizationFailure ([#85475](https://github.com/kubernetes/kubernetes/pull/85475), [@andyzhangx](https://github.com/andyzhangx))
+* Resolved regression in admission, authentication, and authorization webhook performance in v1.17.0-rc.1 ([#85810](https://github.com/kubernetes/kubernetes/pull/85810), [@liggitt](https://github.com/liggitt))
+* kubeadm: uses the apiserver AdvertiseAddress IP family to choose the etcd endpoint IP family for non external etcd clusters ([#85745](https://github.com/kubernetes/kubernetes/pull/85745), [@aojea](https://github.com/aojea))
+* kubeadm: Forward cluster name to the controller-manager arguments ([#85817](https://github.com/kubernetes/kubernetes/pull/85817), [@ereslibre](https://github.com/ereslibre))
+* Fixed "requested device X but found Y" attach error on AWS. ([#85675](https://github.com/kubernetes/kubernetes/pull/85675), [@jsafrane](https://github.com/jsafrane))
+* addons: elasticsearch discovery supports IPv6 ([#85543](https://github.com/kubernetes/kubernetes/pull/85543), [@SataQiu](https://github.com/SataQiu))
+* kubeadm: retry `kubeadm-config` ConfigMap creation or mutation if the apiserver is not responding. This will improve resiliency when joining new control plane nodes. ([#85763](https://github.com/kubernetes/kubernetes/pull/85763), [@ereslibre](https://github.com/ereslibre))
+* Update Cluster Autoscaler to 1.17.0; changelog: https://github.com/kubernetes/autoscaler/releases/tag/cluster-autoscaler-1.17.0 ([#85610](https://github.com/kubernetes/kubernetes/pull/85610), [@losipiuk](https://github.com/losipiuk))
+* Filter published OpenAPI schema by making nullable, required fields non-required in order to avoid kubectl to wrongly reject null values. ([#85722](https://github.com/kubernetes/kubernetes/pull/85722), [@sttts](https://github.com/sttts))
+* kubectl set resources will no longer return an error if passed an empty change for a resource.  ([#85490](https://github.com/kubernetes/kubernetes/pull/85490), [@sallyom](https://github.com/sallyom))
+    * kubectl set subject will no longer return an error if passed an empty change for a resource.  
+* kube-apiserver: fixed a conflict error encountered attempting to delete a pod with gracePeriodSeconds=0 and a resourceVersion precondition ([#85516](https://github.com/kubernetes/kubernetes/pull/85516), [@michaelgugino](https://github.com/michaelgugino))
+* kubeadm: add a upgrade health check that deploys a Job ([#81319](https://github.com/kubernetes/kubernetes/pull/81319), [@neolit123](https://github.com/neolit123))
+* kubeadm: make sure images are pre-pulled even if a tag did not change but their contents changed ([#85603](https://github.com/kubernetes/kubernetes/pull/85603), [@bart0sh](https://github.com/bart0sh))
+* kube-apiserver: Fixes a bug that hidden metrics can not be enabled by the command-line option `--show-hidden-metrics-for-version`. ([#85444](https://github.com/kubernetes/kubernetes/pull/85444), [@RainbowMango](https://github.com/RainbowMango))
+* kubeadm now supports automatic calculations of dual-stack node cidr masks to kube-controller-manager.  ([#85609](https://github.com/kubernetes/kubernetes/pull/85609), [@Arvinderpal](https://github.com/Arvinderpal))
+* Fix bug where EndpointSlice controller would attempt to modify shared objects. ([#85368](https://github.com/kubernetes/kubernetes/pull/85368), [@robscott](https://github.com/robscott))
+* Use context to check client closed instead of http.CloseNotifier in processing watch request which will reduce 1 goroutine for each request if proto is HTTP/2.x . ([#85408](https://github.com/kubernetes/kubernetes/pull/85408), [@answer1991](https://github.com/answer1991))
+* kubeadm: reset raises warnings if it cannot delete folders ([#85265](https://github.com/kubernetes/kubernetes/pull/85265), [@SataQiu](https://github.com/SataQiu))
+* Wait for kubelet & kube-proxy to be ready on Windows node within 10s ([#85228](https://github.com/kubernetes/kubernetes/pull/85228), [@YangLu1031](https://github.com/YangLu1031))


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Add back the changelogs from 1.16/17 and 18 because failed during the branch FF. 
Most likely we need to remove those files in the last RC or after we stop te FF

more context: https://kubernetes.slack.com/archives/CJH2GBF7Y/p1594921378246500

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
/assign @tpepper @saschagrunert 
cc @kubernetes/release-managers 

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
