### PR TITLE
automatically assign triage labels to api-machinery tagged PRs

### DIFF
--- a/cluster/images/etcd-version-monitor/OWNERS
+++ b/cluster/images/etcd-version-monitor/OWNERS
@@ -2,3 +2,4 @@
 
 labels:
 - sig/api-machinery
+- triage/needs-information

--- a/cluster/images/etcd/OWNERS
+++ b/cluster/images/etcd/OWNERS
@@ -7,3 +7,4 @@ approvers:
   - jpbetz
 labels:
 - sig/api-machinery
+- triage/needs-information

--- a/cmd/cloud-controller-manager/OWNERS
+++ b/cmd/cloud-controller-manager/OWNERS
@@ -16,4 +16,5 @@ emeritus_approvers:
 - wlan0
 labels:
 - sig/api-machinery
+- triage/needs-information
 - sig/cloud-provider

--- a/cmd/controller-manager/OWNERS
+++ b/cmd/controller-manager/OWNERS
@@ -15,3 +15,4 @@ reviewers:
 - stewart-yu
 labels:
 - sig/api-machinery
+- triage/needs-information

--- a/cmd/kube-apiserver/OWNERS
+++ b/cmd/kube-apiserver/OWNERS
@@ -28,4 +28,5 @@ reviewers:
 - yue9944882
 labels:
 - sig/api-machinery
+- triage/needs-information
 - area/apiserver

--- a/cmd/kube-controller-manager/OWNERS
+++ b/cmd/kube-controller-manager/OWNERS
@@ -55,3 +55,4 @@ reviewers:
 - wojtek-t
 labels:
 - sig/api-machinery
+- triage/needs-information

--- a/pkg/controller/garbagecollector/OWNERS
+++ b/pkg/controller/garbagecollector/OWNERS
@@ -10,3 +10,4 @@ reviewers:
 - deads2k
 labels:
 - sig/api-machinery
+- triage/needs-information

--- a/pkg/controller/namespace/OWNERS
+++ b/pkg/controller/namespace/OWNERS
@@ -5,3 +5,4 @@ reviewers:
 - smarterclayton
 labels:
 - sig/api-machinery
+- triage/needs-information

--- a/pkg/generated/openapi/OWNERS
+++ b/pkg/generated/openapi/OWNERS
@@ -8,4 +8,5 @@ reviewers:
 - liggitt
 labels:
 - sig/api-machinery
+- triage/needs-information
 - area/code-generation

--- a/pkg/kubeapiserver/OWNERS
+++ b/pkg/kubeapiserver/OWNERS
@@ -14,4 +14,5 @@ reviewers:
 - logicalhan
 labels:
 - sig/api-machinery
+- triage/needs-information
 - area/apiserver

--- a/pkg/master/OWNERS
+++ b/pkg/master/OWNERS
@@ -40,3 +40,4 @@ reviewers:
 - enj
 labels:
 - sig/api-machinery
+- triage/needs-information

--- a/pkg/quota/v1/OWNERS
+++ b/pkg/quota/v1/OWNERS
@@ -11,3 +11,4 @@ reviewers:
 - vishh
 labels:
 - sig/api-machinery
+- triage/needs-information

--- a/staging/src/k8s.io/apiextensions-apiserver/OWNERS
+++ b/staging/src/k8s.io/apiextensions-apiserver/OWNERS
@@ -15,3 +15,4 @@ reviewers:
 - roycaihw
 labels:
 - sig/api-machinery
+- triage/needs-information

--- a/staging/src/k8s.io/apimachinery/OWNERS
+++ b/staging/src/k8s.io/apimachinery/OWNERS
@@ -24,3 +24,4 @@ reviewers:
 - logicalhan
 labels:
 - sig/api-machinery
+- triage/needs-information

--- a/staging/src/k8s.io/apiserver/OWNERS
+++ b/staging/src/k8s.io/apiserver/OWNERS
@@ -23,4 +23,5 @@ reviewers:
 - jpbetz
 labels:
 - sig/api-machinery
+- triage/needs-information
 - area/apiserver

--- a/staging/src/k8s.io/client-go/OWNERS
+++ b/staging/src/k8s.io/client-go/OWNERS
@@ -17,3 +17,4 @@ reviewers:
 - yliaog
 labels:
 - sig/api-machinery
+- triage/needs-information

--- a/staging/src/k8s.io/code-generator/OWNERS
+++ b/staging/src/k8s.io/code-generator/OWNERS
@@ -10,4 +10,5 @@ reviewers:
 - sttts
 labels:
 - sig/api-machinery
+- triage/needs-information
 - area/code-generation

--- a/staging/src/k8s.io/component-base/OWNERS
+++ b/staging/src/k8s.io/component-base/OWNERS
@@ -18,3 +18,4 @@ emeritus_approvers:
 labels:
 - sig/cluster-lifecycle
 - sig/api-machinery
+- triage/needs-information

--- a/staging/src/k8s.io/controller-manager/OWNERS
+++ b/staging/src/k8s.io/controller-manager/OWNERS
@@ -19,4 +19,5 @@ reviewers:
 - sttts
 labels:
 - sig/api-machinery
+- triage/needs-information
 - sig/cloud-provider

--- a/staging/src/k8s.io/kube-aggregator/OWNERS
+++ b/staging/src/k8s.io/kube-aggregator/OWNERS
@@ -16,3 +16,4 @@ reviewers:
 - logicalhan
 labels:
 - sig/api-machinery
+- triage/needs-information

--- a/staging/src/k8s.io/sample-apiserver/OWNERS
+++ b/staging/src/k8s.io/sample-apiserver/OWNERS
@@ -15,3 +15,4 @@ reviewers:
 - cheftako
 labels:
 - sig/api-machinery
+- triage/needs-information

--- a/staging/src/k8s.io/sample-controller/OWNERS
+++ b/staging/src/k8s.io/sample-controller/OWNERS
@@ -9,3 +9,4 @@ reviewers:
 - nikhita
 labels:
 - sig/api-machinery
+- triage/needs-information

--- a/test/e2e/apimachinery/OWNERS
+++ b/test/e2e/apimachinery/OWNERS
@@ -24,3 +24,4 @@ reviewers:
 - logicalhan
 labels:
 - sig/api-machinery
+- triage/needs-information


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

This adds auto-triage labeling to sig api-machinery related code changes.


**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

/sig api-machinery
/assign @fedebongio 