### PR TITLE
auto triage sig-instrumentation tagged PRs

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -33,3 +33,4 @@ filters:
   "metrics\\.go$":
     labels:
       - sig/instrumentation
+      - triage/needs-information

--- a/cluster/addons/fluentd-elasticsearch/OWNERS
+++ b/cluster/addons/fluentd-elasticsearch/OWNERS
@@ -8,3 +8,4 @@ reviewers:
 - sig-instrumentation-reviewers
 labels:
 - sig/instrumentation
+- triage/needs-information

--- a/cluster/addons/fluentd-gcp/OWNERS
+++ b/cluster/addons/fluentd-gcp/OWNERS
@@ -8,3 +8,4 @@ reviewers:
 labels:
 - area/provider/gcp
 - sig/instrumentation
+- triage/needs-information

--- a/cluster/addons/metadata-agent/OWNERS
+++ b/cluster/addons/metadata-agent/OWNERS
@@ -8,3 +8,4 @@ reviewers:
 - sig-instrumentation-reviewers
 labels:
 - sig/instrumentation
+- triage/needs-information

--- a/cluster/addons/metrics-server/OWNERS
+++ b/cluster/addons/metrics-server/OWNERS
@@ -8,3 +8,4 @@ reviewers:
 - sig-instrumentation-reviewers
 labels:
 - sig/instrumentation
+- triage/needs-information

--- a/staging/src/k8s.io/component-base/logs/OWNERS
+++ b/staging/src/k8s.io/component-base/logs/OWNERS
@@ -6,3 +6,4 @@ reviewers:
 - sig-instrumentation-reviewers
 labels:
 - sig/instrumentation
+- triage/needs-information

--- a/staging/src/k8s.io/component-base/metrics/OWNERS
+++ b/staging/src/k8s.io/component-base/metrics/OWNERS
@@ -8,3 +8,4 @@ reviewers:
 - sig-instrumentation-reviewers
 labels:
 - sig/instrumentation
+- triage/needs-information

--- a/staging/src/k8s.io/metrics/OWNERS
+++ b/staging/src/k8s.io/metrics/OWNERS
@@ -4,3 +4,4 @@ approvers:
 - sig-instrumentation-approvers
 labels:
 - sig/instrumentation
+- triage/needs-information

--- a/test/e2e/instrumentation/OWNERS
+++ b/test/e2e/instrumentation/OWNERS
@@ -12,3 +12,4 @@ reviewers:
 - sig-instrumentation-reviewers
 labels:
 - sig/instrumentation
+- triage/needs-information

--- a/test/e2e/instrumentation/logging/OWNERS
+++ b/test/e2e/instrumentation/logging/OWNERS
@@ -8,3 +8,4 @@ reviewers:
 - sig-instrumentation-reviewers
 labels:
 - sig/instrumentation
+- triage/needs-information

--- a/test/instrumentation/OWNERS
+++ b/test/instrumentation/OWNERS
@@ -9,3 +9,4 @@ emeritus_approvers:
 - piosz
 labels:
 - sig/instrumentation
+- triage/needs-information

--- a/test/instrumentation/testdata/OWNERS
+++ b/test/instrumentation/testdata/OWNERS
@@ -6,3 +6,4 @@ reviewers:
 - sig-instrumentation-reviewers
 labels:
 - sig/instrumentation
+- triage/needs-information


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

This PR leverages our automated labeling mechanism to tag sig-instrumentation PRs with triage labels. This builds off of https://github.com/kubernetes/kubernetes/pull/90220 and extends it in a similar way to https://github.com/kubernetes/kubernetes/pull/93156


**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
/sig instrumentation 