### PR TITLE
Use canonical import path in client-gen input-base

### DIFF
--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -59,7 +59,7 @@ GV_DIRS_CSV=$(IFS=',';echo "${GV_DIRS[*]// /,}";IFS=$)
 
 # This can be called with one flag, --verify-only, so it works for both the
 # update- and verify- scripts.
-${clientgen} --output-base "${KUBE_ROOT}/vendor" --output-package="k8s.io/client-go" --clientset-name="kubernetes" --input-base="k8s.io/kubernetes/vendor/k8s.io/api" --input="${GV_DIRS_CSV}" --go-header-file "${KUBE_ROOT}/hack/boilerplate/boilerplate.generatego.txt" "$@"
+${clientgen} --output-base "${KUBE_ROOT}/vendor" --output-package="k8s.io/client-go" --clientset-name="kubernetes" --input-base="k8s.io/api" --input="${GV_DIRS_CSV}" --go-header-file "${KUBE_ROOT}/hack/boilerplate/boilerplate.generatego.txt" "$@"
 
 listergen_external_apis=()
 kube::util::read-array listergen_external_apis < <(

--- a/staging/src/k8s.io/code-generator/cmd/client-gen/generators/BUILD
+++ b/staging/src/k8s.io/code-generator/cmd/client-gen/generators/BUILD
@@ -24,6 +24,7 @@ go_library(
         "//staging/src/k8s.io/code-generator/cmd/client-gen/path:go_default_library",
         "//staging/src/k8s.io/code-generator/cmd/client-gen/types:go_default_library",
         "//staging/src/k8s.io/code-generator/pkg/namer:go_default_library",
+        "//staging/src/k8s.io/code-generator/pkg/util:go_default_library",
         "//vendor/k8s.io/gengo/args:go_default_library",
         "//vendor/k8s.io/gengo/generator:go_default_library",
         "//vendor/k8s.io/gengo/namer:go_default_library",

--- a/staging/src/k8s.io/code-generator/cmd/client-gen/generators/client_generator.go
+++ b/staging/src/k8s.io/code-generator/cmd/client-gen/generators/client_generator.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/code-generator/cmd/client-gen/path"
 	clientgentypes "k8s.io/code-generator/cmd/client-gen/types"
 	codegennamer "k8s.io/code-generator/pkg/namer"
+	genutil "k8s.io/code-generator/pkg/util"
 	"k8s.io/gengo/args"
 	"k8s.io/gengo/generator"
 	"k8s.io/gengo/namer"
@@ -279,7 +280,7 @@ func applyGroupOverrides(universe types.Universe, customArgs *clientgenargs.Cust
 	// Create a map from "old GV" to "new GV" so we know what changes we need to make.
 	changes := make(map[clientgentypes.GroupVersion]clientgentypes.GroupVersion)
 	for gv, inputDir := range customArgs.GroupVersionPackages() {
-		p := universe.Package(inputDir)
+		p := universe.Package(genutil.Vendorless(inputDir))
 		if override := types.ExtractCommentTags("+", p.Comments)["groupName"]; override != nil {
 			newGV := clientgentypes.GroupVersion{
 				Group:   clientgentypes.Group(override[0]),

--- a/staging/src/k8s.io/code-generator/cmd/conversion-gen/generators/BUILD
+++ b/staging/src/k8s.io/code-generator/cmd/conversion-gen/generators/BUILD
@@ -12,6 +12,7 @@ go_library(
     importpath = "k8s.io/code-generator/cmd/conversion-gen/generators",
     deps = [
         "//staging/src/k8s.io/code-generator/cmd/conversion-gen/args:go_default_library",
+        "//staging/src/k8s.io/code-generator/pkg/util:go_default_library",
         "//vendor/k8s.io/gengo/args:go_default_library",
         "//vendor/k8s.io/gengo/generator:go_default_library",
         "//vendor/k8s.io/gengo/namer:go_default_library",

--- a/staging/src/k8s.io/code-generator/cmd/conversion-gen/generators/conversion.go
+++ b/staging/src/k8s.io/code-generator/cmd/conversion-gen/generators/conversion.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/klog/v2"
 
 	conversionargs "k8s.io/code-generator/cmd/conversion-gen/args"
+	genutil "k8s.io/code-generator/pkg/util"
 )
 
 // These are the comment tags that carry parameters for conversion generation.
@@ -292,14 +293,8 @@ func Packages(context *generator.Context, arguments *args.GeneratorArgs) generat
 		// in the output directory.
 		// TODO: build a more fundamental concept in gengo for dealing with modifications
 		// to vendored packages.
-		vendorless := func(pkg string) string {
-			if pos := strings.LastIndex(pkg, "/vendor/"); pos != -1 {
-				return pkg[pos+len("/vendor/"):]
-			}
-			return pkg
-		}
 		for i := range peerPkgs {
-			peerPkgs[i] = vendorless(peerPkgs[i])
+			peerPkgs[i] = genutil.Vendorless(peerPkgs[i])
 		}
 
 		// Make sure our peer-packages are added and fully parsed.

--- a/staging/src/k8s.io/code-generator/cmd/informer-gen/generators/packages.go
+++ b/staging/src/k8s.io/code-generator/cmd/informer-gen/generators/packages.go
@@ -89,13 +89,6 @@ func packageForInternalInterfaces(base string) string {
 	return filepath.Join(base, "internalinterfaces")
 }
 
-func vendorless(p string) string {
-	if pos := strings.LastIndex(p, "/vendor/"); pos != -1 {
-		return p[pos+len("/vendor/"):]
-	}
-	return p
-}
-
 // Packages makes the client package definition.
 func Packages(context *generator.Context, arguments *args.GeneratorArgs) generator.Packages {
 	boilerplate, err := arguments.LoadGoBoilerplate()
@@ -122,7 +115,7 @@ func Packages(context *generator.Context, arguments *args.GeneratorArgs) generat
 	internalGroupVersions := make(map[string]clientgentypes.GroupVersions)
 	groupGoNames := make(map[string]string)
 	for _, inputDir := range arguments.InputDirs {
-		p := context.Universe.Package(vendorless(inputDir))
+		p := context.Universe.Package(genutil.Vendorless(inputDir))
 
 		objectMeta, internal, err := objectMetaForPackage(p)
 		if err != nil {

--- a/staging/src/k8s.io/code-generator/pkg/util/build.go
+++ b/staging/src/k8s.io/code-generator/pkg/util/build.go
@@ -59,3 +59,11 @@ func hasSubdir(root, dir string) (rel string, ok bool) {
 func BoilerplatePath() string {
 	return path.Join(reflect.TypeOf(empty{}).PkgPath(), "/../../hack/boilerplate.go.txt")
 }
+
+// Vendorless trims vendor prefix from a package path to make it canonical
+func Vendorless(p string) string {
+	if pos := strings.LastIndex(p, "/vendor/"); pos != -1 {
+		return p[pos+len("/vendor/"):]
+	}
+	return p
+}


### PR DESCRIPTION
/kind bug

The [parameter](https://github.com/kubernetes/kubernetes/blob/fbbc3ed3595287cc8daf684a39ad9c26a90ca7eb/staging/src/k8s.io/code-generator/cmd/client-gen/args/args.go#L80) `--input-base` in client-gen is used to [compose](https://github.com/kubernetes/kubernetes/blob/fbbc3ed3595287cc8daf684a39ad9c26a90ca7eb/staging/src/k8s.io/code-generator/cmd/client-gen/args/gvpackages.go#L129) the [full qualified package path](https://github.com/kubernetes/kubernetes/blob/fbbc3ed3595287cc8daf684a39ad9c26a90ca7eb/staging/src/k8s.io/code-generator/cmd/client-gen/types/types.go#L47-L48), which is later used with `gengo` to [locate the package source and extract package comments](https://github.com/kubernetes/kubernetes/blob/fbbc3ed3595287cc8daf684a39ad9c26a90ca7eb/staging/src/k8s.io/code-generator/cmd/client-gen/generators/client_generator.go#L282-L283). 

Because `gengo` always [canonicalizes](https://github.com/kubernetes/gengo/blob/c0d492a0f3cab707b841450d5b5919720682da31/parser/parse.go#L854-L862) a package path before [adding it to the universe](https://github.com/kubernetes/gengo/blob/c0d492a0f3cab707b841450d5b5919720682da31/parser/parse.go#L259-L290), the universe doesn't understand non-canonical paths and will [return a empty package](https://github.com/kubernetes/gengo/blob/c0d492a0f3cab707b841450d5b5919720682da31/types/types.go#L267-L285). As a result the package comments were lost and group overrides didn't happen for APIs under `k8s.io/kubernetes/vendor/k8s.io/api`.

It was okay for most APIs because the [old group name](https://github.com/kubernetes/kubernetes/blob/fbbc3ed3595287cc8daf684a39ad9c26a90ca7eb/hack/update-codegen.sh#L47) (e.g. "**flowcontrol**/v1alpha1") is the same as the [override group name](https://github.com/kubernetes/kubernetes/blob/fbbc3ed3595287cc8daf684a39ad9c26a90ca7eb/staging/src/k8s.io/code-generator/cmd/client-gen/generators/client_generator.go#L285) ("**flowcontrol**.apiserver.k8s.io/v1alpha1"). However, for the StorageVersion API the old group name (**apiserverinternal**/v1alpha1) and the override group name (**internal**.apiserver.k8s.io/v1alpha1) are different (ref https://github.com/kubernetes/kubernetes/pull/93087). This caused error  because other generators like [informer-gen](https://github.com/kubernetes/kubernetes/blob/fbbc3ed3595287cc8daf684a39ad9c26a90ca7eb/staging/src/k8s.io/code-generator/cmd/informer-gen/generators/packages.go#L125) honored the package comments. 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

/sig api-machinery
/cc @caesarxuchao 
/priority important-soon