### PR TITLE
Preferentially pull the the images of critical pod

### DIFF
--- a/pkg/kubelet/images/image_manager.go
+++ b/pkg/kubelet/images/image_manager.go
@@ -141,7 +141,7 @@ func (m *imageManager) EnsureImageExists(pod *v1.Pod, container *v1.Container, p
 	m.logIt(ref, v1.EventTypeNormal, events.PullingImage, logPrefix, fmt.Sprintf("Pulling image %q", container.Image), klog.Info)
 	startTime := time.Now()
 	pullChan := make(chan pullResult)
-	m.puller.pullImage(spec, pullSecrets, pullChan, podSandboxConfig)
+	m.puller.pullImage(spec, pullSecrets, pullChan, podSandboxConfig, pod)
 	imagePullResult := <-pullChan
 	if imagePullResult.err != nil {
 		m.logIt(ref, v1.EventTypeWarning, events.FailedToPullImage, logPrefix, fmt.Sprintf("Failed to pull image %q: %v", container.Image, imagePullResult.err), klog.Warning)

--- a/pkg/kubelet/images/image_manager.go
+++ b/pkg/kubelet/images/image_manager.go
@@ -139,7 +139,7 @@ func (m *imageManager) EnsureImageExists(pod *v1.Pod, container *v1.Container, p
 	}
 	m.logIt(ref, v1.EventTypeNormal, events.PullingImage, logPrefix, fmt.Sprintf("Pulling image %q", container.Image), klog.Info)
 	pullChan := make(chan pullResult)
-	m.puller.pullImage(spec, pullSecrets, pullChan, podSandboxConfig)
+	m.puller.pullImage(spec, pullSecrets, pullChan, podSandboxConfig, pod)
 	imagePullResult := <-pullChan
 	if imagePullResult.err != nil {
 		m.logIt(ref, v1.EventTypeWarning, events.FailedToPullImage, logPrefix, fmt.Sprintf("Failed to pull image %q: %v", container.Image, imagePullResult.err), klog.Warning)

--- a/pkg/kubelet/images/puller.go
+++ b/pkg/kubelet/images/puller.go
@@ -91,18 +91,18 @@ func (sip *serialImagePuller) pullImage(spec kubecontainer.ImageSpec, pullSecret
 }
 
 func (sip *serialImagePuller) processImagePullRequests() {
-	// Set environment variables to identify the namespace that needs to be pulled first
+	// Set environment variables to identify the namespace that needs to be pulled first.
 	priorityNamespace := env.GetEnvAsStringOrFallback("PRIORITY_NAMESPACES", "kube-system")
 	for request := range sip.pullRequests {
 
 		// Wait for a while for as many requests as possible to enter the channel, Avoid first-come request
-		// not being sorted and processed directly
+		// not being sorted and processed directly.
 		time.Sleep(1 * time.Second)
 		pullRequestQ := make([]*imagePullRequest, 0)
 		pullRequestQ = append(pullRequestQ, request)
 
 		// Use a loop to fetch the requests in the channel at the current time and
-		// store them in a slice to wait for sorting
+		// store them in a slice to wait for sorting.
 	Loop:
 		for {
 			select {
@@ -113,7 +113,7 @@ func (sip *serialImagePuller) processImagePullRequests() {
 			}
 		}
 
-		// Prioritize requests in the slice by PriorityClassName and Namespace
+		// Prioritize requests in the slice by PriorityClassName and Namespace.
 		sort.SliceStable(pullRequestQ, func(i, j int) bool {
 			if pullRequestQ[i].pod.Spec.PriorityClassName == scheduling.SystemNodeCritical &&
 				pullRequestQ[j].pod.Spec.PriorityClassName != scheduling.SystemNodeCritical {
@@ -139,7 +139,7 @@ func (sip *serialImagePuller) processImagePullRequests() {
 			return false
 		})
 
-		// Handle the requests one by one
+		// Handle the requests one by one.
 		for _, pr := range pullRequestQ {
 			imageRef, err := sip.imageService.PullImage(pr.spec, pr.pullSecrets, pr.podSandboxConfig)
 			pr.pullChan <- pullResult{

--- a/pkg/kubelet/images/puller.go
+++ b/pkg/kubelet/images/puller.go
@@ -101,7 +101,7 @@ func (sip *serialImagePuller) processImagePullRequests() {
 		pullRequestQ := make([]*imagePullRequest, 0)
 		pullRequestQ = append(pullRequestQ, request)
 
-		// Use a loop to fetch the requests in the channel at the current time and
+		// Use a loop to fetch the requests in the channel at the current time and 
 		// store them in a slice to wait for sorting.
 	Loop:
 		for {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
 
/kind feature

**What this PR does / why we need it**:
This pr implements a method to preferentially pull images of critical pods based on serial pull strategy( --serialize-image-pulls=true ). To mark a Pod as critical, we can set priorityClassName for that Pod to system-cluster-critical or system-node-critical，and we can also prefer to pull the image of the pod in the specified namespaces. 
When a node fails and pods are scheduled to other nodes, we hope that images of critical pods will be pulled first to ensure that important services can started first.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
