### PR TITLE
Use temporary directory when creating temporary file in tests

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/config_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/config_test.go
@@ -261,7 +261,7 @@ func TestAdditionalAuth(t *testing.T) {
 }
 
 func TestEmbedClientCert(t *testing.T) {
-	fakeCertFile, _ := ioutil.TempFile("", "")
+	fakeCertFile, _ := ioutil.TempFile(os.TempDir(), "")
 	defer os.Remove(fakeCertFile.Name())
 	fakeData := []byte("fake-data")
 	ioutil.WriteFile(fakeCertFile.Name(), fakeData, 0600)
@@ -280,7 +280,7 @@ func TestEmbedClientCert(t *testing.T) {
 }
 
 func TestEmbedClientKey(t *testing.T) {
-	fakeKeyFile, _ := ioutil.TempFile("", "")
+	fakeKeyFile, _ := ioutil.TempFile(os.TempDir(), "")
 	defer os.Remove(fakeKeyFile.Name())
 	fakeData := []byte("fake-data")
 	ioutil.WriteFile(fakeKeyFile.Name(), fakeData, 0600)
@@ -326,7 +326,7 @@ func TestEmbedNoKeyOrCertDisallowed(t *testing.T) {
 }
 
 func TestEmptyTokenAndCertAllowed(t *testing.T) {
-	fakeCertFile, _ := ioutil.TempFile("", "cert-file")
+	fakeCertFile, _ := ioutil.TempFile(os.TempDir(), "cert-file")
 	defer os.Remove(fakeCertFile.Name())
 	expectedConfig := newRedFederalCowHammerConfig()
 	authInfo := clientcmdapi.NewAuthInfo()
@@ -569,7 +569,7 @@ func TestUnsetBytes(t *testing.T) {
 }
 
 func TestCAClearsInsecure(t *testing.T) {
-	fakeCAFile, _ := ioutil.TempFile("", "ca-file")
+	fakeCAFile, _ := ioutil.TempFile(os.TempDir(), "ca-file")
 	defer os.Remove(fakeCAFile.Name())
 	clusterInfoWithInsecure := clientcmdapi.NewCluster()
 	clusterInfoWithInsecure.InsecureSkipTLSVerify = true
@@ -638,7 +638,7 @@ func TestInsecureClearsCA(t *testing.T) {
 }
 
 func TestCADataClearsCA(t *testing.T) {
-	fakeCAFile, _ := ioutil.TempFile("", "")
+	fakeCAFile, _ := ioutil.TempFile(os.TempDir(), "")
 	defer os.Remove(fakeCAFile.Name())
 	fakeData := []byte("cadata")
 	ioutil.WriteFile(fakeCAFile.Name(), fakeData, 0600)
@@ -852,7 +852,7 @@ func TestToBool(t *testing.T) {
 }
 
 func testConfigCommand(args []string, startingConfig clientcmdapi.Config, t *testing.T) (string, clientcmdapi.Config) {
-	fakeKubeFile, _ := ioutil.TempFile("", "")
+	fakeKubeFile, _ := ioutil.TempFile(os.TempDir(), "")
 	defer os.Remove(fakeKubeFile.Name())
 	err := clientcmd.WriteToFile(startingConfig, fakeKubeFile.Name())
 	if err != nil {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/current_context_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/current_context_test.go
@@ -57,7 +57,7 @@ func TestCurrentContextWithUnsetContext(t *testing.T) {
 }
 
 func (test currentContextTest) run(t *testing.T) {
-	fakeKubeFile, err := ioutil.TempFile("", "")
+	fakeKubeFile, err := ioutil.TempFile(os.TempDir(), "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/delete_cluster_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/delete_cluster_test.go
@@ -53,7 +53,7 @@ func TestDeleteCluster(t *testing.T) {
 }
 
 func (test deleteClusterTest) run(t *testing.T) {
-	fakeKubeFile, err := ioutil.TempFile("", "")
+	fakeKubeFile, err := ioutil.TempFile(os.TempDir(), "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/delete_context_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/delete_context_test.go
@@ -53,7 +53,7 @@ func TestDeleteContext(t *testing.T) {
 }
 
 func (test deleteContextTest) run(t *testing.T) {
-	fakeKubeFile, err := ioutil.TempFile("", "")
+	fakeKubeFile, err := ioutil.TempFile(os.TempDir(), "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/get_clusters_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/get_clusters_test.go
@@ -57,7 +57,7 @@ func TestGetClustersEmpty(t *testing.T) {
 }
 
 func (test getClustersTest) run(t *testing.T) {
-	fakeKubeFile, err := ioutil.TempFile("", "")
+	fakeKubeFile, err := ioutil.TempFile(os.TempDir(), "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/get_contexts_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/get_contexts_test.go
@@ -144,7 +144,7 @@ func TestGetContextsSelectOneOfTwo(t *testing.T) {
 }
 
 func (test getContextsTest) run(t *testing.T) {
-	fakeKubeFile, err := ioutil.TempFile("", "")
+	fakeKubeFile, err := ioutil.TempFile(os.TempDir(), "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/rename_context_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/rename_context_test.go
@@ -103,7 +103,7 @@ func TestRenameToAlreadyExistingContext(t *testing.T) {
 }
 
 func (test renameContextTest) run(t *testing.T) {
-	fakeKubeFile, _ := ioutil.TempFile("", "")
+	fakeKubeFile, _ := ioutil.TempFile(os.TempDir(), "")
 	defer os.Remove(fakeKubeFile.Name())
 	err := clientcmd.WriteToFile(test.initialConfig, fakeKubeFile.Name())
 	if err != nil {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/set_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/set_test.go
@@ -55,7 +55,7 @@ func TestSetConfigCurrentContext(t *testing.T) {
 }
 
 func (test setConfigTest) run(t *testing.T) {
-	fakeKubeFile, err := ioutil.TempFile("", "")
+	fakeKubeFile, err := ioutil.TempFile(os.TempDir(), "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/get/customcolumn_flags_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/get/customcolumn_flags_test.go
@@ -32,7 +32,7 @@ import (
 func TestPrinterSupportsExpectedCustomColumnFormats(t *testing.T) {
 	testObject := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "foo"}}
 
-	customColumnsFile, err := ioutil.TempFile("", "printers_jsonpath_flags")
+	customColumnsFile, err := ioutil.TempFile(os.TempDir(), "printers_jsonpath_flags")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/testing/fake.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/testing/fake.go
@@ -407,7 +407,7 @@ type TestFactory struct {
 func NewTestFactory() *TestFactory {
 	// specify an optionalClientConfig to explicitly use in testing
 	// to avoid polluting an existing user config.
-	tmpFile, err := ioutil.TempFile("", "cmdtests_temp")
+	tmpFile, err := ioutil.TempFile(os.TempDir(), "cmdtests_temp")
 	if err != nil {
 		panic(fmt.Sprintf("unable to create a fake client config: %v", err))
 	}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/util/helpers_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/util/helpers_test.go
@@ -297,7 +297,7 @@ func testCheckError(t *testing.T, tests []checkErrTestCase) {
 
 func TestDumpReaderToFile(t *testing.T) {
 	testString := "TEST STRING"
-	tempFile, err := ioutil.TempFile("", "hlpers_test_dump_")
+	tempFile, err := ioutil.TempFile(os.TempDir(), "hlpers_test_dump_")
 	if err != nil {
 		t.Errorf("unexpected error setting up a temporary file %v", err)
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

/sig cli
/priority backlog

**What this PR does / why we need it**:
[ioutil.TempFile](https://golang.org/pkg/io/ioutil/#TempFile) creates a temporary file in the directory specified as the first argument. It sometimes is `/tmp` but sometimes not. It's better to be explicit about this being `/tmp`. 

**Special notes for your reviewer**:
/assign @damemi 

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
