### PR TITLE
Automated cherry pick of #93189: Fix a bug whereby reusable CPUs and devices were not being

### DIFF
--- a/pkg/kubelet/cm/cpumanager/policy_static.go
+++ b/pkg/kubelet/cm/cpumanager/policy_static.go
@@ -343,7 +343,7 @@ func (p *staticPolicy) GetTopologyHints(s state.State, pod *v1.Pod, container *v
 	}
 
 	// Get a list of available CPUs.
-	available := p.assignableCPUs(s)
+	available := p.assignableCPUs(s).Union(p.cpusToReuse[string(pod.UID)])
 
 	// Generate hints.
 	cpuHints := p.generateCPUTopologyHints(available, requested)

--- a/pkg/kubelet/cm/devicemanager/topology_hints.go
+++ b/pkg/kubelet/cm/devicemanager/topology_hints.go
@@ -62,7 +62,7 @@ func (m *ManagerImpl) GetTopologyHints(pod *v1.Pod, container *v1.Container) map
 			}
 
 			// Get the list of available devices, for which TopologyHints should be generated.
-			available := m.getAvailableDevices(resource)
+			available := m.getAvailableDevices(resource).Union(m.devicesToReuse[string(pod.UID)][resource])
 			if available.Len() < requested {
 				klog.Errorf("[devicemanager] Unable to generate topology hints: requested number of devices unavailable for '%s': requested: %d, available: %d", resource, requested, available.Len())
 				deviceHints[resource] = []topologymanager.TopologyHint{}


### PR DESCRIPTION
Cherry pick of #93189 on release-1.19.

#93189: Fix a bug whereby reusable CPUs and devices were not being

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Fixed a bug whereby the allocation of reusable CPUs and devices was not being honored when the TopologyManager was enabled
```