### PR TITLE
Skip repairing clusterIP and nodeport if a service is being deleted

### DIFF
--- a/pkg/registry/core/service/ipallocator/controller/repair.go
+++ b/pkg/registry/core/service/ipallocator/controller/repair.go
@@ -22,7 +22,7 @@ import (
 	"net"
 	"time"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/runtime"
@@ -212,8 +212,10 @@ func (c *Repair) runOnce() error {
 
 	// Check every Service's ClusterIP, and rebuild the state as we think it should be.
 	for _, svc := range list.Items {
-		if !helper.IsServiceIPSet(&svc) {
-			// didn't need a cluster IP
+		if svc.ObjectMeta.DeletionTimestamp != nil ||
+			!helper.IsServiceIPSet(&svc) {
+			// Skip repairing if service is being deleted
+			// or didn't need a cluster IP.
 			continue
 		}
 		ip := net.ParseIP(svc.Spec.ClusterIP)

--- a/pkg/registry/core/service/portallocator/controller/repair.go
+++ b/pkg/registry/core/service/portallocator/controller/repair.go
@@ -130,6 +130,10 @@ func (c *Repair) runOnce() error {
 	// Check every Service's ports, and rebuild the state as we think it should be.
 	for i := range list.Items {
 		svc := &list.Items[i]
+		if svc.ObjectMeta.DeletionTimestamp != nil {
+			// Skip repairing if service is being deleted.
+			continue
+		}
 		ports := collectServiceNodePorts(svc)
 		if len(ports) == 0 {
 			continue


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Ref https://github.com/kubernetes/kubernetes/pull/90753#issuecomment-660268232, we are leaking clusterIP and nodeport because the repair controller mistakenly repairs them even if a service is being deleted with finalizer.

This PR fixes the repair controller to also check for deletionTimestamp before repairing.

I will work on the E2E test (as requested on https://github.com/kubernetes/kubernetes/pull/90753#issuecomment-626873028, probably adapting #91285) when I get a chance :)

**Which issue(s) this PR fixes**:

Fixes #87603

**Special notes for your reviewer**:
/assign @liggitt @bowei 
cc @aojea @thockin 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fix a bug that service's clusterIP and nodeport is not released promptly after deletion with finalizers.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
