### PR TITLE
Filters on kubemark nodegroups when selecting node template to enable hollow node clusters that contain real nodes.

### DIFF
--- a/pkg/kubemark/controller.go
+++ b/pkg/kubemark/controller.go
@@ -351,7 +351,8 @@ func (kubemarkController *KubemarkController) runNodeCreation(stop <-chan struct
 }
 
 func (kubemarkCluster *kubemarkCluster) getHollowNodeName() (string, error) {
-	nodes, err := kubemarkCluster.nodeLister.List(labels.Everything())
+	selector, _ := labels.Parse(nodeGroupLabel)
+	nodes, err := kubemarkCluster.nodeLister.List(selector)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test
> /kind flake


/kind feature

**What this PR does / why we need it**:
Kubemark controller detects existing kubemark nodes to determine the node template they use. One consumer is the cluster autoscaler, which uses this node template to create more kubemark nodes. This works well for kubemark setups which only have hollow nodes in a cluster, but for clusters that have both real and hollow nodes, this code can accidentally select real nodes, which causes breaking behavior. 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #93200

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
NONE
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Kubemark now supports both real and hollow nodes in a single cluster.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
