### PR TITLE
test: prefer NoError/Error over Nil/NotNil

### DIFF
--- a/pkg/controller/endpointslice/endpointslice_controller_test.go
+++ b/pkg/controller/endpointslice/endpointslice_controller_test.go
@@ -98,7 +98,7 @@ func TestSyncServiceNoSelector(t *testing.T) {
 	})
 
 	err := esController.syncService(fmt.Sprintf("%s/%s", ns, serviceName))
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Len(t, client.Actions(), 0)
 }
 
@@ -117,7 +117,7 @@ func TestSyncServicePendingDeletion(t *testing.T) {
 	})
 
 	err := esController.syncService(fmt.Sprintf("%s/%s", ns, serviceName))
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Len(t, client.Actions(), 0)
 }
 
@@ -366,7 +366,7 @@ func TestSyncServiceFull(t *testing.T) {
 
 	// run through full sync service loop
 	err = esController.syncService(fmt.Sprintf("%s/%s", namespace, serviceName))
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	// last action should be to create endpoint slice
 	expectActions(t, client.Actions(), 1, "create", "endpointslices")

--- a/pkg/kubelet/cm/container_manager_linux_test.go
+++ b/pkg/kubelet/cm/container_manager_linux_test.go
@@ -59,7 +59,7 @@ func fakeContainerMgrMountInt() mount.Interface {
 
 func TestCgroupMountValidationSuccess(t *testing.T) {
 	f, err := validateSystemRequirements(fakeContainerMgrMountInt())
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	if cgroups.IsCgroup2UnifiedMode() {
 		assert.True(t, f.cpuHardcapping, "cpu hardcapping is expected to be enabled")
 	} else {
@@ -116,7 +116,7 @@ func TestCgroupMountValidationMultipleSubsystem(t *testing.T) {
 			},
 		})
 	_, err := validateSystemRequirements(mountInt)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestGetCpuWeight(t *testing.T) {

--- a/pkg/kubelet/dockershim/docker_container_windows_test.go
+++ b/pkg/kubelet/dockershim/docker_container_windows_test.go
@@ -91,7 +91,7 @@ func TestApplyGMSAConfig(t *testing.T) {
 		cleanupInfo := &containerCleanupInfo{}
 		err := applyGMSAConfig(containerConfigWithGMSAAnnotation, createConfig, cleanupInfo)
 
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 
 		// the registry key should have been properly created
 		if assert.Equal(t, 1, len(key.setStringValueArgs)) {
@@ -114,7 +114,7 @@ func TestApplyGMSAConfig(t *testing.T) {
 		cleanupInfo := &containerCleanupInfo{}
 		err := applyGMSAConfig(containerConfigWithGMSAAnnotation, createConfig, cleanupInfo)
 
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 
 		if assert.NotNil(t, createConfig.HostConfig) && assert.Equal(t, 1, len(createConfig.HostConfig.SecurityOpt)) {
 			secOpt := createConfig.HostConfig.SecurityOpt[0]
@@ -135,7 +135,7 @@ func TestApplyGMSAConfig(t *testing.T) {
 
 		err := applyGMSAConfig(containerConfigWithGMSAAnnotation, &dockertypes.ContainerCreateConfig{}, &containerCleanupInfo{})
 
-		require.NotNil(t, err)
+		require.Error(t, err)
 		assert.Contains(t, err.Error(), "error when generating gMSA registry value name: unable to generate random string")
 	})
 	t.Run("if there's an error opening the registry key", func(t *testing.T) {
@@ -143,7 +143,7 @@ func TestApplyGMSAConfig(t *testing.T) {
 
 		err := applyGMSAConfig(containerConfigWithGMSAAnnotation, &dockertypes.ContainerCreateConfig{}, &containerCleanupInfo{})
 
-		require.NotNil(t, err)
+		require.Error(t, err)
 		assert.Contains(t, err.Error(), "unable to open registry key")
 	})
 	t.Run("if there's an error writing to the registry key", func(t *testing.T) {
@@ -153,7 +153,7 @@ func TestApplyGMSAConfig(t *testing.T) {
 
 		err := applyGMSAConfig(containerConfigWithGMSAAnnotation, &dockertypes.ContainerCreateConfig{}, &containerCleanupInfo{})
 
-		if assert.NotNil(t, err) {
+		if assert.Error(t, err) {
 			assert.Contains(t, err.Error(), "unable to write into registry value")
 		}
 		assert.True(t, key.closed)
@@ -163,7 +163,7 @@ func TestApplyGMSAConfig(t *testing.T) {
 
 		err := applyGMSAConfig(&runtimeapi.ContainerConfig{}, createConfig, &containerCleanupInfo{})
 
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		assert.Nil(t, createConfig.HostConfig)
 	})
 }
@@ -178,7 +178,7 @@ func TestRemoveGMSARegistryValue(t *testing.T) {
 
 		err := removeGMSARegistryValue(cleanupInfoWithValue)
 
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 
 		// the registry key should have been properly deleted
 		if assert.Equal(t, 1, len(key.deleteValueArgs)) {
@@ -191,7 +191,7 @@ func TestRemoveGMSARegistryValue(t *testing.T) {
 
 		err := removeGMSARegistryValue(cleanupInfoWithValue)
 
-		require.NotNil(t, err)
+		require.Error(t, err)
 		assert.Contains(t, err.Error(), "unable to open registry key")
 	})
 	t.Run("if there's an error deleting from the registry key", func(t *testing.T) {
@@ -201,7 +201,7 @@ func TestRemoveGMSARegistryValue(t *testing.T) {
 
 		err := removeGMSARegistryValue(cleanupInfoWithValue)
 
-		if assert.NotNil(t, err) {
+		if assert.Error(t, err) {
 			assert.Contains(t, err.Error(), "unable to remove registry value")
 		}
 		assert.True(t, key.closed)
@@ -212,7 +212,7 @@ func TestRemoveGMSARegistryValue(t *testing.T) {
 
 		err := removeGMSARegistryValue(&containerCleanupInfo{})
 
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		assert.Equal(t, 0, len(key.deleteValueArgs))
 	})
 }

--- a/pkg/kubelet/dockershim/security_context_test.go
+++ b/pkg/kubelet/dockershim/security_context_test.go
@@ -125,9 +125,9 @@ func TestModifyContainerConfig(t *testing.T) {
 		dockerCfg := &dockercontainer.Config{}
 		err := modifyContainerConfig(tc.sc, dockerCfg)
 		if tc.isErr {
-			assert.NotNil(t, err)
+			assert.Error(t, err)
 		} else {
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 			assert.Equal(t, tc.expected, dockerCfg, "[Test case %q]", tc.name)
 		}
 	}

--- a/pkg/volume/awsebs/aws_ebs_test.go
+++ b/pkg/volume/awsebs/aws_ebs_test.go
@@ -411,7 +411,7 @@ func TestGetCandidateZone(t *testing.T) {
 
 	for _, test := range tests {
 		zones, err := getCandidateZones(test.cloud, test.node)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		assert.Equal(t, test.expectedZones, zones)
 	}
 }
@@ -444,7 +444,7 @@ func TestFormatVolumeID(t *testing.T) {
 	}
 	for _, test := range tests {
 		volumeID, err := formatVolumeID(test.volumeIDFromPath)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		assert.Equal(t, test.expectedVolumeID, volumeID, test.volumeIDFromPath)
 	}
 }

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/versioning_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/versioning_test.go
@@ -112,7 +112,7 @@ func TestInternalVersionIsHandlerVersion(t *testing.T) {
 			i++
 
 			_, err := noxuNamespacedResourceClientV1beta2.Patch(context.TODO(), "foo", types.MergePatchType, patch, metav1.PatchOptions{})
-			assert.NotNil(t, err)
+			assert.Error(t, err)
 
 			// work around "grpc: the client connection is closing" error
 			// TODO: fix the grpc error

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/helpers_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/helpers_test.go
@@ -80,7 +80,7 @@ func TestNestedFieldNoCopy(t *testing.T) {
 	// case 1: field exists and is non-nil
 	res, exists, err := NestedFieldNoCopy(obj, "a", "b")
 	assert.True(t, exists)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, target, res)
 	target["foo"] = "baz"
 	assert.Equal(t, target["foo"], res.(map[string]interface{})["foo"], "result should be a reference to the expected item")
@@ -88,39 +88,39 @@ func TestNestedFieldNoCopy(t *testing.T) {
 	// case 2: field exists and is nil
 	res, exists, err = NestedFieldNoCopy(obj, "a", "c")
 	assert.True(t, exists)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Nil(t, res)
 
 	// case 3: error traversing obj
 	res, exists, err = NestedFieldNoCopy(obj, "a", "d", "foo")
 	assert.False(t, exists)
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 	assert.Nil(t, res)
 
 	// case 4: field does not exist
 	res, exists, err = NestedFieldNoCopy(obj, "a", "g")
 	assert.False(t, exists)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Nil(t, res)
 
 	// case 5: intermediate field does not exist
 	res, exists, err = NestedFieldNoCopy(obj, "a", "g", "f")
 	assert.False(t, exists)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Nil(t, res)
 
 	// case 6: intermediate field is null
 	//         (background: happens easily in YAML)
 	res, exists, err = NestedFieldNoCopy(obj, "a", "c", "f")
 	assert.False(t, exists)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Nil(t, res)
 
 	// case 7: array/slice syntax is not supported
 	//         (background: users may expect this to be supported)
 	res, exists, err = NestedFieldNoCopy(obj, "a", "e[0]")
 	assert.False(t, exists)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Nil(t, res)
 }
 
@@ -138,7 +138,7 @@ func TestNestedFieldCopy(t *testing.T) {
 	// case 1: field exists and is non-nil
 	res, exists, err := NestedFieldCopy(obj, "a", "b")
 	assert.True(t, exists)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, target, res)
 	target["foo"] = "baz"
 	assert.NotEqual(t, target["foo"], res.(map[string]interface{})["foo"], "result should be a copy of the expected item")
@@ -146,19 +146,19 @@ func TestNestedFieldCopy(t *testing.T) {
 	// case 2: field exists and is nil
 	res, exists, err = NestedFieldCopy(obj, "a", "c")
 	assert.True(t, exists)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Nil(t, res)
 
 	// case 3: error traversing obj
 	res, exists, err = NestedFieldCopy(obj, "a", "d", "foo")
 	assert.False(t, exists)
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 	assert.Nil(t, res)
 
 	// case 4: field does not exist
 	res, exists, err = NestedFieldCopy(obj, "a", "e")
 	assert.False(t, exists)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Nil(t, res)
 }
 

--- a/staging/src/k8s.io/apimachinery/pkg/util/net/http_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/net/http_test.go
@@ -428,7 +428,7 @@ func TestConnectWithRedirects(t *testing.T) {
 			require.NoError(t, err, "unexpected request error")
 
 			result, err := ioutil.ReadAll(resp.Body)
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 			require.NoError(t, resp.Body.Close())
 			if test.expectedRedirects < len(test.redirects) {
 				// Expect the last redirect to be returned.

--- a/staging/src/k8s.io/apiserver/pkg/audit/policy/enforce_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/audit/policy/enforce_test.go
@@ -82,7 +82,7 @@ func TestEnforcePolicy(t *testing.T) {
 				objectFuzzer.Fuzz(e)
 				ev, err := EnforcePolicy(e, tc.level, tc.omitStages)
 				if omitSet.Has(string(e.Stage)) {
-					require.Nil(t, err)
+					require.NoError(t, err)
 					require.Nil(t, ev)
 					return
 				}
@@ -136,10 +136,10 @@ func TestEnforcePolicy(t *testing.T) {
 					expected.Level = tc.level
 					require.Equal(t, expected, ev)
 				default:
-					require.NotNil(t, err)
+					require.Error(t, err)
 					return
 				}
-				require.Nil(t, err)
+				require.NoError(t, err)
 			}
 		})
 	}

--- a/staging/src/k8s.io/client-go/testing/fixture_test.go
+++ b/staging/src/k8s.io/client-go/testing/fixture_test.go
@@ -283,7 +283,7 @@ func TestGetWithExactMatch(t *testing.T) {
 	constructObject := func(s schema.GroupVersionResource, name, namespace string) (*unstructured.Unstructured, schema.GroupVersionResource) {
 		obj := getArbitraryResource(s, name, namespace)
 		gvks, _, err := scheme.ObjectKinds(obj)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		gvr, _ := meta.UnsafeGuessKindToResource(gvks[0])
 		return obj, gvr
 	}
@@ -298,11 +298,11 @@ func TestGetWithExactMatch(t *testing.T) {
 
 	// Exact match
 	_, err = o.Get(gvr, "", "node")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	// Unexpected namespace provided
 	_, err = o.Get(gvr, "ns", "node")
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 	errNotFound := errors.NewNotFound(gvr.GroupResource(), "node")
 	assert.EqualError(t, err, errNotFound.Error())
 
@@ -314,11 +314,11 @@ func TestGetWithExactMatch(t *testing.T) {
 
 	// Exact match
 	_, err = o.Get(gvr, "default", "pod")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	// Missing namespace
 	_, err = o.Get(gvr, "", "pod")
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 	errNotFound = errors.NewNotFound(gvr.GroupResource(), "pod")
 	assert.EqualError(t, err, errNotFound.Error())
 }

--- a/staging/src/k8s.io/legacy-cloud-providers/aws/aws_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/aws/aws_test.go
@@ -1764,7 +1764,7 @@ func TestEnsureLoadBalancerHealthCheck(t *testing.T) {
 
 			err = c.ensureLoadBalancerHealthCheck(elbDesc, protocol, port, path, test.annotations)
 
-			require.Nil(t, err)
+			require.NoError(t, err)
 			awsServices.elb.(*MockedFakeELB).AssertExpectations(t)
 		})
 	}
@@ -1784,11 +1784,11 @@ func TestEnsureLoadBalancerHealthCheck(t *testing.T) {
 		// test default HC
 		elbDesc := &elb.LoadBalancerDescription{LoadBalancerName: &lbName, HealthCheck: defaultHC}
 		err = c.ensureLoadBalancerHealthCheck(elbDesc, protocol, port, path, map[string]string{})
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		// test HC with override
 		elbDesc = &elb.LoadBalancerDescription{LoadBalancerName: &lbName, HealthCheck: &currentHC}
 		err = c.ensureLoadBalancerHealthCheck(elbDesc, protocol, port, path, annotations)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 	})
 
 	t.Run("validates resulting expected health check before making an API call", func(t *testing.T) {

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_controller_common_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_controller_common_test.go
@@ -221,7 +221,7 @@ func TestCommonAttachDiskWithVMSS(t *testing.T) {
 				testCloud.DisableAvailabilitySetNodes = true
 			}
 			ss, err := newScaleSet(testCloud)
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 			testCloud.VMSet = ss
 		}
 

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_instances_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_instances_test.go
@@ -729,5 +729,5 @@ func TestCurrentNodeName(t *testing.T) {
 	hostname := "testvm"
 	nodeName, err := cloud.CurrentNodeName(context.Background(), hostname)
 	assert.Equal(t, types.NodeName(hostname), nodeName)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_loadbalancer_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_loadbalancer_test.go
@@ -1194,7 +1194,7 @@ func TestReconcileLoadBalancerRule(t *testing.T) {
 		} else {
 			assert.Equal(t, test.expectedProbes, probe, "TestCase[%d]: %s", i, test.desc)
 			assert.Equal(t, test.expectedRules, lbrule, "TestCase[%d]: %s", i, test.desc)
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 		}
 	}
 }

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_test.go
@@ -1257,7 +1257,7 @@ func TestReconcileSecurityGroupEtagMismatch(t *testing.T) {
 
 	newSG, err := az.reconcileSecurityGroup(testClusterName, &svc1, &lbStatus.Ingress[0].IP, true /* wantLb */)
 	assert.Nil(t, newSG)
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 
 	assert.Equal(t, expectedError.Error(), err)
 }

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_vmss_cache_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_vmss_cache_test.go
@@ -102,7 +102,7 @@ func TestVMSSVMCache(t *testing.T) {
 		vm := expectedVMs[i]
 		vmName := to.String(vm.OsProfile.ComputerName)
 		ssName, instanceID, realVM, err := ss.getVmssVM(vmName, azcache.CacheReadTypeDefault)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		assert.Equal(t, "vmss", ssName)
 		assert.Equal(t, to.String(vm.InstanceID), instanceID)
 		assert.Equal(t, &vm, realVM)

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_vmss_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_vmss_test.go
@@ -1772,7 +1772,7 @@ func TestEnsureHostInPool(t *testing.T) {
 func TestGetVmssAndResourceGroupNameByVMProviderID(t *testing.T) {
 	providerID := "azure:///subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/virtualMachineScaleSets/vmss/virtualMachines/0"
 	rgName, vmssName, err := getVmssAndResourceGroupNameByVMProviderID(providerID)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, "rg", rgName)
 	assert.Equal(t, "vmss", vmssName)
 

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/clients/containerserviceclient/azure_containerserviceclient_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/clients/containerserviceclient/azure_containerserviceclient_test.go
@@ -243,7 +243,7 @@ func TestList(t *testing.T) {
 	armClient := mockarmclient.NewMockInterface(ctrl)
 	mcList := []containerservice.ManagedCluster{getTestManagedCluster("cluster"), getTestManagedCluster("cluster1"), getTestManagedCluster("cluster2")}
 	responseBody, err := json.Marshal(containerservice.ManagedClusterListResult{Value: &mcList})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	armClient.EXPECT().GetResource(gomock.Any(), resourceID, "").Return(
 		&http.Response{
 			StatusCode: http.StatusOK,
@@ -299,7 +299,7 @@ func TestListNextResultsMultiPages(t *testing.T) {
 		mcClient := getTestManagedClusterClient(armClient)
 		result, err := mcClient.listNextResults(context.TODO(), lastResult)
 		if test.prepareErr != nil || test.sendErr != nil {
-			assert.NotNil(t, err)
+			assert.Error(t, err)
 		} else {
 			assert.NoError(t, err)
 		}
@@ -348,7 +348,7 @@ func TestListNextResultsMultiPagesWithListResponderError(t *testing.T) {
 	expected.Response = autorest.Response{Response: response}
 	mcClient := getTestManagedClusterClient(armClient)
 	result, err := mcClient.listNextResults(context.TODO(), lastResult)
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 	assert.Equal(t, expected, result)
 }
 
@@ -360,7 +360,7 @@ func TestListWithListResponderError(t *testing.T) {
 	armClient := mockarmclient.NewMockInterface(ctrl)
 	mcList := []containerservice.ManagedCluster{getTestManagedCluster("cluster"), getTestManagedCluster("cluster1"), getTestManagedCluster("cluster2")}
 	responseBody, err := json.Marshal(containerservice.ManagedClusterListResult{Value: &mcList})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	armClient.EXPECT().GetResource(gomock.Any(), resourceID, "").Return(
 		&http.Response{
 			StatusCode: http.StatusNotFound,

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/clients/deploymentclient/azure_deploymentclient_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/clients/deploymentclient/azure_deploymentclient_test.go
@@ -241,7 +241,7 @@ func TestList(t *testing.T) {
 	armClient := mockarmclient.NewMockInterface(ctrl)
 	dpList := []resources.DeploymentExtended{getTestDeploymentExtended("dep"), getTestDeploymentExtended("dep1"), getTestDeploymentExtended("dep2")}
 	responseBody, err := json.Marshal(resources.DeploymentListResult{Value: &dpList})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	armClient.EXPECT().GetResource(gomock.Any(), resourceID, "").Return(
 		&http.Response{
 			StatusCode: http.StatusOK,
@@ -297,7 +297,7 @@ func TestListNextResultsMultiPages(t *testing.T) {
 		dpClient := getTestDeploymentClient(armClient)
 		result, err := dpClient.listNextResults(context.TODO(), lastResult)
 		if test.prepareErr != nil || test.sendErr != nil {
-			assert.NotNil(t, err)
+			assert.Error(t, err)
 		} else {
 			assert.NoError(t, err)
 		}
@@ -346,7 +346,7 @@ func TestListNextResultsMultiPagesWithListResponderError(t *testing.T) {
 	expected.Response = autorest.Response{Response: response}
 	dpClient := getTestDeploymentClient(armClient)
 	result, err := dpClient.listNextResults(context.TODO(), lastResult)
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 	assert.Equal(t, expected, result)
 }
 
@@ -358,7 +358,7 @@ func TestListWithListResponderError(t *testing.T) {
 	armClient := mockarmclient.NewMockInterface(ctrl)
 	dpList := []resources.DeploymentExtended{getTestDeploymentExtended("dep"), getTestDeploymentExtended("dep1"), getTestDeploymentExtended("dep2")}
 	responseBody, err := json.Marshal(resources.DeploymentListResult{Value: &dpList})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	armClient.EXPECT().GetResource(gomock.Any(), resourceID, "").Return(
 		&http.Response{
 			StatusCode: http.StatusNotFound,

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/clients/interfaceclient/azure_interfaceclient_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/clients/interfaceclient/azure_interfaceclient_test.go
@@ -134,7 +134,7 @@ func TestGetVirtualMachineScaleSetNetworkInterface(t *testing.T) {
 	resourceID := "/subscriptions/subscriptionID/resourceGroups/rg/providers/Microsoft.Compute/virtualMachineScaleSets/vmss/virtualMachines/0/networkInterfaces/nic1"
 	testInterface := getTestVMSSInterface("nic1")
 	networkInterface, err := testInterface.MarshalJSON()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	response := &http.Response{
 		StatusCode: http.StatusOK,
 		Body:       ioutil.NopCloser(bytes.NewReader(networkInterface)),

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/clients/loadbalancerclient/azure_loadbalancerclient_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/clients/loadbalancerclient/azure_loadbalancerclient_test.go
@@ -136,7 +136,7 @@ func TestList(t *testing.T) {
 	armClient := mockarmclient.NewMockInterface(ctrl)
 	lbList := []network.LoadBalancer{getTestLoadBalancer("lb1"), getTestLoadBalancer("lb2"), getTestLoadBalancer("lb3")}
 	responseBody, err := json.Marshal(network.LoadBalancerListResult{Value: &lbList})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	armClient.EXPECT().GetResource(gomock.Any(), resourceID, "").Return(
 		&http.Response{
 			StatusCode: http.StatusOK,
@@ -206,7 +206,7 @@ func TestListNextResultsMultiPages(t *testing.T) {
 		lbClient := getTestLoadBalancerClient(armClient)
 		result, err := lbClient.listNextResults(context.TODO(), lastResult)
 		if test.prepareErr != nil || test.sendErr != nil {
-			assert.NotNil(t, err)
+			assert.Error(t, err)
 		} else {
 			assert.NoError(t, err)
 		}

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/clients/publicipclient/azure_publicipclient_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/clients/publicipclient/azure_publicipclient_test.go
@@ -196,7 +196,7 @@ func TestGetVMSSPublicIPAddress(t *testing.T) {
 		},
 	}
 	pip, err := testPip.MarshalJSON()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	response := &http.Response{
 		StatusCode: http.StatusOK,
 		Body:       ioutil.NopCloser(bytes.NewReader(pip)),
@@ -329,7 +329,7 @@ func TestList(t *testing.T) {
 	armClient := mockarmclient.NewMockInterface(ctrl)
 	pipList := []network.PublicIPAddress{getTestPublicIPAddress("pip1"), getTestPublicIPAddress("pip2"), getTestPublicIPAddress("pip3")}
 	responseBody, err := json.Marshal(network.PublicIPAddressListResult{Value: &pipList})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	armClient.EXPECT().GetResource(gomock.Any(), resourceID, "").Return(
 		&http.Response{
 			StatusCode: http.StatusOK,
@@ -418,7 +418,7 @@ func TestListWithListResponderError(t *testing.T) {
 	armClient := mockarmclient.NewMockInterface(ctrl)
 	pipList := []network.PublicIPAddress{getTestPublicIPAddress("pip1"), getTestPublicIPAddress("pip2"), getTestPublicIPAddress("pip3")}
 	responseBody, err := json.Marshal(network.PublicIPAddressListResult{Value: &pipList})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	armClient.EXPECT().GetResource(gomock.Any(), resourceID, "").Return(
 		&http.Response{
 			StatusCode: http.StatusNotFound,
@@ -507,7 +507,7 @@ func TestListNextResultsMultiPages(t *testing.T) {
 		pipClient := getTestPublicIPAddressClient(armClient)
 		result, err := pipClient.listNextResults(context.TODO(), lastResult)
 		if test.prepareErr != nil || test.sendErr != nil {
-			assert.NotNil(t, err)
+			assert.Error(t, err)
 		} else {
 			assert.NoError(t, err)
 		}
@@ -556,7 +556,7 @@ func TestListNextResultsMultiPagesWithListResponderError(t *testing.T) {
 	expected.Response = autorest.Response{Response: response}
 	pipClient := getTestPublicIPAddressClient(armClient)
 	result, err := pipClient.listNextResults(context.TODO(), lastResult)
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 	assert.Equal(t, expected, result)
 }
 

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/clients/securitygroupclient/azure_securitygroupclient_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/clients/securitygroupclient/azure_securitygroupclient_test.go
@@ -201,7 +201,7 @@ func TestList(t *testing.T) {
 	armClient := mockarmclient.NewMockInterface(ctrl)
 	nsgList := []network.SecurityGroup{getTestSecurityGroup("nsg1"), getTestSecurityGroup("nsg2"), getTestSecurityGroup("nsg3")}
 	responseBody, err := json.Marshal(network.SecurityGroupListResult{Value: &nsgList})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	armClient.EXPECT().GetResource(gomock.Any(), resourceID, "").Return(
 		&http.Response{
 			StatusCode: http.StatusOK,
@@ -257,7 +257,7 @@ func TestListNextResultsMultiPages(t *testing.T) {
 		sgClient := getTestSecurityGroupClient(armClient)
 		result, err := sgClient.listNextResults(context.TODO(), lastResult)
 		if test.prepareErr != nil || test.sendErr != nil {
-			assert.NotNil(t, err)
+			assert.Error(t, err)
 		} else {
 			assert.NoError(t, err)
 		}
@@ -306,7 +306,7 @@ func TestListNextResultsMultiPagesWithListResponderError(t *testing.T) {
 	expected.Response = autorest.Response{Response: response}
 	sgClient := getTestSecurityGroupClient(armClient)
 	result, err := sgClient.listNextResults(context.TODO(), lastResult)
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 	assert.Equal(t, expected, result)
 }
 
@@ -318,7 +318,7 @@ func TestListWithListResponderError(t *testing.T) {
 	armClient := mockarmclient.NewMockInterface(ctrl)
 	nsgList := []network.SecurityGroup{getTestSecurityGroup("nsg1"), getTestSecurityGroup("nsg2"), getTestSecurityGroup("nsg3")}
 	responseBody, err := json.Marshal(network.SecurityGroupListResult{Value: &nsgList})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	armClient.EXPECT().GetResource(gomock.Any(), resourceID, "").Return(
 		&http.Response{
 			StatusCode: http.StatusNotFound,

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/clients/snapshotclient/azure_snapshotclient_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/clients/snapshotclient/azure_snapshotclient_test.go
@@ -193,7 +193,7 @@ func TestListByResourceGroup(t *testing.T) {
 	armClient := mockarmclient.NewMockInterface(ctrl)
 	snList := []compute.Snapshot{getTestSnapshot("sn1"), getTestSnapshot("sn2"), getTestSnapshot("sn3")}
 	responseBody, err := json.Marshal(compute.SnapshotList{Value: &snList})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	armClient.EXPECT().GetResource(gomock.Any(), resourceID, "").Return(
 		&http.Response{
 			StatusCode: http.StatusOK,
@@ -282,7 +282,7 @@ func TestListByResourceGroupWithListResponderError(t *testing.T) {
 	armClient := mockarmclient.NewMockInterface(ctrl)
 	snList := []compute.Snapshot{getTestSnapshot("sn1"), getTestSnapshot("sn2"), getTestSnapshot("sn3")}
 	responseBody, err := json.Marshal(compute.SnapshotList{Value: &snList})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	armClient.EXPECT().GetResource(gomock.Any(), resourceID, "").Return(
 		&http.Response{
 			StatusCode: http.StatusNotFound,
@@ -371,7 +371,7 @@ func TestListNextResultsMultiPages(t *testing.T) {
 		snClient := getTestSnapshotClient(armClient)
 		result, err := snClient.listNextResults(context.TODO(), lastResult)
 		if test.prepareErr != nil || test.sendErr != nil {
-			assert.NotNil(t, err)
+			assert.Error(t, err)
 		} else {
 			assert.NoError(t, err)
 		}
@@ -420,7 +420,7 @@ func TestListNextResultsMultiPagesWithListResponderError(t *testing.T) {
 	expected.Response = autorest.Response{Response: response}
 	snClient := getTestSnapshotClient(armClient)
 	result, err := snClient.listNextResults(context.TODO(), lastResult)
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 	assert.Equal(t, expected, result)
 }
 

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/clients/storageaccountclient/azure_storageaccountclient_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/clients/storageaccountclient/azure_storageaccountclient_test.go
@@ -380,7 +380,7 @@ func TestListNextResultsMultiPages(t *testing.T) {
 		saClient := getTestStorageAccountClient(armClient)
 		result, err := saClient.listNextResults(context.TODO(), lastResult)
 		if test.prepareErr != nil || test.sendErr != nil {
-			assert.NotNil(t, err)
+			assert.Error(t, err)
 		} else {
 			assert.NoError(t, err)
 		}
@@ -428,7 +428,7 @@ func TestListNextResultsMultiPagesWithListResponderError(t *testing.T) {
 	}
 	expected := storage.AccountListResult{Response: autorest.Response{Response: response}}
 	result, err := saClient.listNextResults(context.TODO(), lastResult)
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 	assert.Equal(t, expected, result)
 }
 
@@ -440,7 +440,7 @@ func TestListByResourceGroup(t *testing.T) {
 	armClient := mockarmclient.NewMockInterface(ctrl)
 	snList := []storage.Account{getTestStorageAccount("sn1"), getTestStorageAccount("pip2"), getTestStorageAccount("pip3")}
 	responseBody, err := json.Marshal(storage.AccountListResult{Value: &snList})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	armClient.EXPECT().GetResource(gomock.Any(), resourceID, "").Return(
 		&http.Response{
 			StatusCode: http.StatusOK,
@@ -462,7 +462,7 @@ func TestListByResourceGroupResponderError(t *testing.T) {
 	armClient := mockarmclient.NewMockInterface(ctrl)
 	snList := []storage.Account{getTestStorageAccount("sn1"), getTestStorageAccount("pip2"), getTestStorageAccount("pip3")}
 	responseBody, err := json.Marshal(storage.AccountListResult{Value: &snList})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	armClient.EXPECT().GetResource(gomock.Any(), resourceID, "").Return(
 		&http.Response{
 			StatusCode: http.StatusNotFound,

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/clients/subnetclient/azure_subnetclient_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/clients/subnetclient/azure_subnetclient_test.go
@@ -71,7 +71,7 @@ func TestGet(t *testing.T) {
 		Name: to.StringPtr("subnet1"),
 	}
 	subnet, err := testSubnet.MarshalJSON()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	response := &http.Response{
 		StatusCode: http.StatusOK,
 		Body:       ioutil.NopCloser(bytes.NewReader(subnet)),
@@ -202,7 +202,7 @@ func TestList(t *testing.T) {
 	armClient := mockarmclient.NewMockInterface(ctrl)
 	subnetList := []network.Subnet{getTestSubnet("subnet1"), getTestSubnet("subnet2"), getTestSubnet("subnet3")}
 	responseBody, err := json.Marshal(network.SubnetListResult{Value: &subnetList})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	armClient.EXPECT().GetResource(gomock.Any(), resourceID, "").Return(
 		&http.Response{
 			StatusCode: http.StatusOK,
@@ -292,7 +292,7 @@ func TestListWithListResponderError(t *testing.T) {
 	armClient := mockarmclient.NewMockInterface(ctrl)
 	subnetList := []network.Subnet{getTestSubnet("subnet1"), getTestSubnet("subnet2"), getTestSubnet("subnet3")}
 	responseBody, err := json.Marshal(network.SubnetListResult{Value: &subnetList})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	armClient.EXPECT().GetResource(gomock.Any(), resourceID, "").Return(
 		&http.Response{
 			StatusCode: http.StatusNotFound,
@@ -381,7 +381,7 @@ func TestListNextResultsMultiPages(t *testing.T) {
 		subnetClient := getTestSubnetClient(armClient)
 		result, err := subnetClient.listNextResults(context.TODO(), lastResult)
 		if test.prepareErr != nil || test.sendErr != nil {
-			assert.NotNil(t, err)
+			assert.Error(t, err)
 		} else {
 			assert.NoError(t, err)
 		}
@@ -430,7 +430,7 @@ func TestListNextResultsMultiPagesWithListResponderError(t *testing.T) {
 	expected.Response = autorest.Response{Response: response}
 	subnetClient := getTestSubnetClient(armClient)
 	result, err := subnetClient.listNextResults(context.TODO(), lastResult)
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 	assert.Equal(t, expected, result)
 }
 

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/clients/vmclient/azure_vmclient_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/clients/vmclient/azure_vmclient_test.go
@@ -193,7 +193,7 @@ func TestList(t *testing.T) {
 	armClient := mockarmclient.NewMockInterface(ctrl)
 	vmList := []compute.VirtualMachine{getTestVM("vm1"), getTestVM("vm1"), getTestVM("vm1")}
 	responseBody, err := json.Marshal(compute.VirtualMachineListResult{Value: &vmList})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	armClient.EXPECT().GetResource(gomock.Any(), resourceID, "").Return(
 		&http.Response{
 			StatusCode: http.StatusOK,
@@ -282,7 +282,7 @@ func TestListWithListResponderError(t *testing.T) {
 	armClient := mockarmclient.NewMockInterface(ctrl)
 	vmList := []compute.VirtualMachine{getTestVM("vm1"), getTestVM("vm2"), getTestVM("vm3")}
 	responseBody, err := json.Marshal(compute.VirtualMachineListResult{Value: &vmList})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	armClient.EXPECT().GetResource(gomock.Any(), resourceID, "").Return(
 		&http.Response{
 			StatusCode: http.StatusNotFound,
@@ -380,7 +380,7 @@ func TestListNextResultsMultiPages(t *testing.T) {
 		if err != nil {
 			assert.Equal(t, err.(autorest.DetailedError).Message, test.expectedErrMsg)
 		} else {
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 		}
 
 		if test.prepareErr != nil {
@@ -437,7 +437,7 @@ func TestListNextResultsMultiPagesWithListResponderError(t *testing.T) {
 		expected.Response = autorest.Response{Response: response}
 		vmssClient := getTestVMClient(armClient)
 		result, err := vmssClient.listNextResults(context.TODO(), lastResult)
-		assert.NotNil(t, err)
+		assert.Error(t, err)
 		if test.sendErr != nil {
 			assert.NotEqual(t, expected, result)
 		} else {

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/clients/vmsizeclient/azure_vmsizeclient_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/clients/vmsizeclient/azure_vmsizeclient_test.go
@@ -70,7 +70,7 @@ func TestList(t *testing.T) {
 	armClient := mockarmclient.NewMockInterface(ctrl)
 	vmsizeList := []compute.VirtualMachineSize{getTestVMSize("Standard_D2s_v3"), getTestVMSize("Standard_D4s_v3"), getTestVMSize("Standard_D8s_v3")}
 	responseBody, err := json.Marshal(compute.VirtualMachineSizeListResult{Value: &vmsizeList})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	armClient.EXPECT().GetResource(gomock.Any(), resourceID, "").Return(
 		&http.Response{
 			StatusCode: http.StatusOK,

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/clients/vmssclient/azure_vmssclient_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/clients/vmssclient/azure_vmssclient_test.go
@@ -194,7 +194,7 @@ func TestList(t *testing.T) {
 	armClient := mockarmclient.NewMockInterface(ctrl)
 	vmssList := []compute.VirtualMachineScaleSet{getTestVMSS("vmss1"), getTestVMSS("vmss2"), getTestVMSS("vmss3")}
 	responseBody, err := json.Marshal(compute.VirtualMachineScaleSetListResult{Value: &vmssList})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	armClient.EXPECT().GetResource(gomock.Any(), resourceID, "").Return(
 		&http.Response{
 			StatusCode: http.StatusOK,
@@ -283,7 +283,7 @@ func TestListWithListResponderError(t *testing.T) {
 	armClient := mockarmclient.NewMockInterface(ctrl)
 	vmssList := []compute.VirtualMachineScaleSet{getTestVMSS("vmss1"), getTestVMSS("vmss2"), getTestVMSS("vmss3")}
 	responseBody, err := json.Marshal(compute.VirtualMachineScaleSetListResult{Value: &vmssList})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	armClient.EXPECT().GetResource(gomock.Any(), resourceID, "").Return(
 		&http.Response{
 			StatusCode: http.StatusNotFound,
@@ -381,7 +381,7 @@ func TestListNextResultsMultiPages(t *testing.T) {
 		if err != nil {
 			assert.Equal(t, err.(autorest.DetailedError).Message, test.expectedErrMsg)
 		} else {
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 		}
 
 		if test.prepareErr != nil {
@@ -438,7 +438,7 @@ func TestListNextResultsMultiPagesWithListResponderError(t *testing.T) {
 		expected.Response = autorest.Response{Response: response}
 		vmssClient := getTestVMSSClient(armClient)
 		result, err := vmssClient.listNextResults(context.TODO(), lastResult)
-		assert.NotNil(t, err)
+		assert.Error(t, err)
 		if test.sendErr != nil {
 			assert.NotEqual(t, expected, result)
 		} else {
@@ -632,7 +632,7 @@ func TestWaitForAsyncOperationResult(t *testing.T) {
 	armClient.EXPECT().WaitForAsyncOperationResult(gomock.Any(), &azure.Future{}, "VMSSWaitForAsyncOperationResult").Return(response, nil)
 	vmssClient := getTestVMSSClient(armClient)
 	_, err := vmssClient.WaitForAsyncOperationResult(context.TODO(), &azure.Future{})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestDeleteInstances(t *testing.T) {

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/clients/vmssvmclient/azure_vmssvmclient_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/clients/vmssvmclient/azure_vmssvmclient_test.go
@@ -193,7 +193,7 @@ func TestList(t *testing.T) {
 	armClient := mockarmclient.NewMockInterface(ctrl)
 	vmssList := []compute.VirtualMachineScaleSetVM{getTestVMSSVM("vmss1", "1"), getTestVMSSVM("vmss1", "2"), getTestVMSSVM("vmss1", "3")}
 	responseBody, err := json.Marshal(compute.VirtualMachineScaleSetVMListResult{Value: &vmssList})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	armClient.EXPECT().GetResource(gomock.Any(), resourceID, "InstanceView").Return(
 		&http.Response{
 			StatusCode: http.StatusOK,
@@ -282,7 +282,7 @@ func TestListWithListResponderError(t *testing.T) {
 	armClient := mockarmclient.NewMockInterface(ctrl)
 	vmssvmList := []compute.VirtualMachineScaleSetVM{getTestVMSSVM("vmss1", "1"), getTestVMSSVM("vmss1", "2"), getTestVMSSVM("vmss1", "3")}
 	responseBody, err := json.Marshal(compute.VirtualMachineScaleSetVMListResult{Value: &vmssvmList})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	armClient.EXPECT().GetResource(gomock.Any(), resourceID, "InstanceView").Return(
 		&http.Response{
 			StatusCode: http.StatusNotFound,
@@ -380,7 +380,7 @@ func TestListNextResultsMultiPages(t *testing.T) {
 		if err != nil {
 			assert.Equal(t, err.(autorest.DetailedError).Message, test.expectedErrMsg)
 		} else {
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 		}
 
 		if test.prepareErr != nil {
@@ -437,7 +437,7 @@ func TestListNextResultsMultiPagesWithListResponderError(t *testing.T) {
 		expected.Response = autorest.Response{Response: response}
 		vmssClient := getTestVMSSVMClient(armClient)
 		result, err := vmssClient.listNextResults(context.TODO(), lastResult)
-		assert.NotNil(t, err)
+		assert.Error(t, err)
 		if test.sendErr != nil {
 			assert.NotEqual(t, expected, result)
 		} else {

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/retry/azure_retry_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/retry/azure_retry_test.go
@@ -102,7 +102,7 @@ func TestDoExponentialBackoffRetry(t *testing.T) {
 
 	result, err := sender.Do(req)
 	assert.Nil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestStep(t *testing.T) {
@@ -196,7 +196,7 @@ func TestDoBackoffRetry(t *testing.T) {
 	}
 
 	resp, err = doBackoffRetry(client, fakeRequest, bo)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, 3, client.Attempts())
 	assert.Equal(t, expectedResp, resp)
 
@@ -205,7 +205,7 @@ func TestDoBackoffRetry(t *testing.T) {
 	client = mocks.NewSender()
 	client.AppendAndRepeatResponse(r, 1)
 	resp, err = doBackoffRetry(client, fakeRequest, &Backoff{Factor: 1.0, Steps: 3})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, 1, client.Attempts())
 	assert.NotNil(t, resp)
 	assert.Equal(t, 200, resp.StatusCode)

--- a/staging/src/k8s.io/legacy-cloud-providers/gce/gce_address_manager_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/gce/gce_address_manager_test.go
@@ -124,7 +124,7 @@ func TestAddressManagerBadExternallyOwned(t *testing.T) {
 
 	mgr := newAddressManager(svc, testSvcName, vals.Region, testSubnet, testLBName, targetIP, cloud.SchemeInternal)
 	ad, err := mgr.HoldAddress()
-	assert.NotNil(t, err) // FIXME
+	assert.Error(t, err) // FIXME
 	require.Equal(t, ad, "")
 }
 

--- a/staging/src/k8s.io/legacy-cloud-providers/gce/gce_loadbalancer_external_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/gce/gce_loadbalancer_external_test.go
@@ -641,7 +641,7 @@ func TestTargetPoolNeedsRecreation(t *testing.T) {
 	exists, needsRecreation, err := gce.targetPoolNeedsRecreation(lbName, vals.Region, v1.ServiceAffinityNone)
 	assert.True(t, exists)
 	assert.False(t, needsRecreation)
-	require.NotNil(t, err)
+	require.Error(t, err)
 	assert.True(t, strings.HasPrefix(err.Error(), errPrefixGetTargetPool))
 	c.MockTargetPools.GetHook = nil
 
@@ -934,7 +934,7 @@ func TestCreateAndUpdateFirewallSucceedsOnXPN(t *testing.T) {
 		ipnet,
 		svc.Spec.Ports,
 		hosts)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	msg := fmt.Sprintf("%s %s %s", v1.EventTypeNormal, eventReasonManualChange, eventMsgFirewallChange)
 	checkEvent(t, recorder, msg, true)
@@ -947,7 +947,7 @@ func TestCreateAndUpdateFirewallSucceedsOnXPN(t *testing.T) {
 		ipnet,
 		svc.Spec.Ports,
 		hosts)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	msg = fmt.Sprintf("%s %s %s", v1.EventTypeNormal, eventReasonManualChange, eventMsgFirewallChange)
 	checkEvent(t, recorder, msg, true)

--- a/staging/src/k8s.io/legacy-cloud-providers/gce/gce_loadbalancer_internal_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/gce/gce_loadbalancer_internal_test.go
@@ -682,11 +682,11 @@ func TestEnsureInternalFirewallDeletesLegacyFirewall(t *testing.T) {
 	}
 
 	existingFirewall, err := gce.GetFirewall(fwName)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.NotNil(t, existingFirewall)
 	// Existing firewall will not be deleted yet since this was the first sync with the new rule created.
 	existingLegacyFirewall, err := gce.GetFirewall(lbName)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.NotNil(t, existingLegacyFirewall)
 
 	// Now ensure the firewall again to simulate a second sync where the old rule will be deleted.
@@ -704,10 +704,10 @@ func TestEnsureInternalFirewallDeletesLegacyFirewall(t *testing.T) {
 	}
 
 	existingFirewall, err = gce.GetFirewall(fwName)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.NotNil(t, existingFirewall)
 	existingLegacyFirewall, err = gce.GetFirewall(lbName)
-	require.NotNil(t, err)
+	require.Error(t, err)
 	require.Nil(t, existingLegacyFirewall)
 
 }
@@ -761,9 +761,9 @@ func TestEnsureInternalFirewallSucceedsOnXPN(t *testing.T) {
 		v1.ProtocolTCP,
 		nodes,
 		lbName)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	existingFirewall, err := gce.GetFirewall(fwName)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.NotNil(t, existingFirewall)
 
 	gce.onXPN = true

--- a/staging/src/k8s.io/legacy-cloud-providers/gce/gce_loadbalancer_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/gce/gce_loadbalancer_test.go
@@ -40,7 +40,7 @@ func TestGetLoadBalancer(t *testing.T) {
 	status, found, err := gce.GetLoadBalancer(context.Background(), vals.ClusterName, apiService)
 	assert.Nil(t, status)
 	assert.False(t, found)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	nodeNames := []string{"test-node-1"}
 	nodes, err := createAndInsertNodes(gce, nodeNames, vals.ZoneName)
@@ -51,7 +51,7 @@ func TestGetLoadBalancer(t *testing.T) {
 	status, found, err = gce.GetLoadBalancer(context.Background(), vals.ClusterName, apiService)
 	assert.Equal(t, expectedStatus, status)
 	assert.True(t, found)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestEnsureLoadBalancerCreatesExternalLb(t *testing.T) {

--- a/test/integration/objectmeta/objectmeta_test.go
+++ b/test/integration/objectmeta/objectmeta_test.go
@@ -43,12 +43,12 @@ func TestIgnoreClusterName(t *testing.T) {
 		},
 	}
 	nsNew, err := client.CoreV1().Namespaces().Create(context.TODO(), &ns, metav1.CreateOptions{})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, ns.Name, nsNew.Name)
 	assert.Empty(t, nsNew.ClusterName)
 
 	nsNew, err = client.CoreV1().Namespaces().Update(context.TODO(), &ns, metav1.UpdateOptions{})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, ns.Name, nsNew.Name)
 	assert.Empty(t, nsNew.ClusterName)
 }


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind api-change
> /kind bug

/kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
replaces calls to require/assert Nil/NotNil to NoError/Error

[NoError](https://godoc.org/github.com/stretchr/testify/require#NoError) is for asserting no error was return
[Error](https://godoc.org/github.com/stretchr/testify/require#Error) is for asserting an error was returned

```golang
return Fail(t, fmt.Sprintf("Received unexpected error:\n%+v", err), msgAndArgs...)
```
```golang
return Fail(t, "An error is expected but got nil.", msgAndArgs...)
```
When these fail their message explicitly calls out that we were or were not expecting an error. This communicates the intent of the assertion.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
