### PR TITLE
Add the pod with the specified nodename to the schedule life cycle.

### DIFF
--- a/pkg/scheduler/core/generic_scheduler.go
+++ b/pkg/scheduler/core/generic_scheduler.go
@@ -280,7 +280,7 @@ func (g *genericScheduler) findNodesThatFitPod(ctx context.Context, prof *profil
 
 	if len(pod.Spec.NodeName) > 0 {
 		nodeInfo, err := g.nodeInfoSnapshot.NodeInfos().Get(pod.Spec.NodeName)
-		if err != nil {
+		if err != nil || nodeInfo == nil {
 			return nil, filteredNodesStatuses, err
 		}
 		return []*v1.Node{nodeInfo.Node()}, filteredNodesStatuses, nil

--- a/pkg/scheduler/core/generic_scheduler.go
+++ b/pkg/scheduler/core/generic_scheduler.go
@@ -278,6 +278,14 @@ func (g *genericScheduler) findNodesThatFitPod(ctx context.Context, prof *profil
 
 	}
 
+	if len(pod.Spec.NodeName) > 0 {
+		nodeInfo, err := g.nodeInfoSnapshot.NodeInfos().Get(pod.Spec.NodeName)
+		if err != nil {
+			return nil, filteredNodesStatuses, err
+		}
+		return []*v1.Node{nodeInfo.Node()}, filteredNodesStatuses, nil
+	}
+
 	feasibleNodes, err := g.findNodesThatPassFilters(ctx, prof, state, pod, filteredNodesStatuses)
 	if err != nil {
 		return nil, nil, err

--- a/pkg/scheduler/eventhandlers.go
+++ b/pkg/scheduler/eventhandlers.go
@@ -333,10 +333,6 @@ func (sched *Scheduler) skipPodUpdate(pod *v1.Pod) bool {
 		// ResourceVersion must be excluded because each object update will
 		// have a new resource version.
 		p.ResourceVersion = ""
-		// Spec.NodeName must be excluded because the pod assumed in the cache
-		// is expected to have a node assigned while the pod update may nor may
-		// not have this field set.
-		p.Spec.NodeName = ""
 		// Annotations must be excluded for the reasons described in
 		// https://github.com/kubernetes/kubernetes/issues/52914.
 		p.Annotations = nil


### PR DESCRIPTION
**What type of PR is this?**
/kind feature


**What this PR does / why we need it**:
Now pod specify `nodename` field will skip schedule phase , it will cause the volume binding to not be executed and the pod failed to start. 
I think we shouldn't skip plugins running phase, we can give the feasibleNodes directly at `findNodesThatFitPod` method by `nodename` field:

https://github.com/kubernetes/kubernetes/blob/363c3b89f570142da5c43b1ccbd99629f03e0ee0/pkg/scheduler/core/generic_scheduler.go#L259

I think this is a friendly method to incorporate the specified nodename schedule into the current schedule life cycle.

**Which issue(s) this PR fixes**:
#93145 

#89953

**Special notes for your reviewer**:
My design is giving the feasibleNodes directly  in findNodesThatFitPod method  when we specify `nodename` field.

I think although we specified `nodename`, we can't skip the predicate stage, checking node info by `nodename` field   is also required. 

Therefore, the pod started by the specified node name can also be added to the schedule life cycle.

**Does this PR introduce a user-facing change?**:
None

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
None