### PR TITLE
remove some notes about scheduler/algorithm

### DIFF
--- a/pkg/scheduler/framework/v1alpha1/interface.go
+++ b/pkg/scheduler/framework/v1alpha1/interface.go
@@ -262,8 +262,7 @@ type FilterPlugin interface {
 	// Filter is called by the scheduling framework.
 	// All FilterPlugins should return "Success" to declare that
 	// the given node fits the pod. If Filter doesn't return "Success",
-	// please refer scheduler/algorithm/predicates/error.go
-	// to set error message.
+	// it will return "Unschedulable", "UnschedulableAndUnresolvable" or "Error".
 	// For the node being evaluated, Filter plugins should look at the passed
 	// nodeInfo reference for this particular node's information (e.g., pods
 	// considered to be running on the node) instead of looking it up in the


### PR DESCRIPTION
What type of PR is this?
/kind cleanup

What this PR does / why we need it:
Path pkg/scheduler/algorithm has been removed, so following notes better to remove:

	// the given node fits the pod. If Filter doesn't return "Success",
	// please refer scheduler/algorithm/predicates/error.go
	// to set error message.

