### PR TITLE
Handle int -> float conversion in FromUnstructured

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/runtime/converter.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/converter.go
@@ -186,6 +186,9 @@ func fromUnstructured(sv, dv reflect.Value) error {
 					reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
 					dv.Set(sv.Convert(dt))
 					return nil
+				case reflect.Float32, reflect.Float64:
+					dv.Set(sv.Convert(dt))
+					return nil
 				}
 			case reflect.Float32, reflect.Float64:
 				switch dt.Kind() {

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/converter_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/converter_test.go
@@ -544,6 +544,28 @@ func TestFloatIntConversion(t *testing.T) {
 	}
 }
 
+func TestIntFloatConversion(t *testing.T) {
+	unstr := map[string]interface{}{"ch": int64(3)}
+
+	var obj C
+	if err := runtime.NewTestUnstructuredConverter(simpleEquality).FromUnstructured(unstr, &obj); err != nil {
+		t.Errorf("Unexpected error in FromUnstructured: %v", err)
+	}
+
+	data, err := json.Marshal(unstr)
+	if err != nil {
+		t.Fatalf("Error when marshaling unstructured: %v", err)
+	}
+	var unmarshalled C
+	if err := json.Unmarshal(data, &unmarshalled); err != nil {
+		t.Fatalf("Error when unmarshaling to object: %v", err)
+	}
+
+	if !reflect.DeepEqual(obj, unmarshalled) {
+		t.Errorf("Incorrect conversion, diff: %v", diff.ObjectReflectDiff(obj, unmarshalled))
+	}
+}
+
 func TestCustomToUnstructured(t *testing.T) {
 	testcases := []struct {
 		Data     string


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Handles int -> float conversions in FromUnstructured

**Which issue(s) this PR fixes**:
Fixes #87675

**Does this PR introduce a user-facing change?**:
```release-note
k8s.io/apimachinery: runtime.DefaultUnstructuredConverter.FromUnstructured now handles converting integer fields to typed float values
```

/cc @sttts
/sig api-machinery