### PR TITLE
[1.18] Fix ListZonesInRegion() after client BasePath change

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/gce/gce_zones.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/gce/gce_zones.go
@@ -20,6 +20,7 @@ package gce
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	compute "google.golang.org/api/compute/v1"
@@ -79,7 +80,9 @@ func (g *Cloud) ListZonesInRegion(region string) ([]*compute.Zone, error) {
 	defer cancel()
 
 	mc := newZonesMetricContext("list", region)
-	list, err := g.c.Zones().List(ctx, filter.Regexp("region", g.getRegionLink(region)))
+	// Use regex match instead of an exact regional link constructed from getRegionalLink below.
+	// See comments in issue kubernetes/kubernetes#87905
+	list, err := g.c.Zones().List(ctx, filter.Regexp("region", fmt.Sprintf(".*/regions/%s", region)))
 	if err != nil {
 		return nil, mc.Observe(err)
 	}


### PR DESCRIPTION
Backport #92883

This path fixes region Regex for listing zones.
Compute client BasePath changed to compute.googleapis.com, but resource URI were left as www.googleapis.com

**What type of PR is this?**

/kind failing-test

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

This PR can help some tests mentioned in #87905

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```

```

/cc @alculquicondor 
/cc @jingxu97 