### PR TITLE
Rename pod_preemption_metrics to preemption_metrics. 

### DIFF
--- a/pkg/scheduler/metrics/metrics.go
+++ b/pkg/scheduler/metrics/metrics.go
@@ -126,7 +126,7 @@ var (
 	PreemptionVictims = metrics.NewHistogram(
 		&metrics.HistogramOpts{
 			Subsystem: SchedulerSubsystem,
-			Name:      "pod_preemption_victims",
+			Name:      "preemption_victims",
 			Help:      "Number of selected preemption victims",
 			// we think #victims>50 is pretty rare, therefore [50, +Inf) is considered a single bucket.
 			Buckets:        metrics.LinearBuckets(5, 5, 10),


### PR DESCRIPTION

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Since this metric's type was changed from Gauge to Histogram, renaming it should make it easier for providers to migrate. Also, the name now matches better with preemption_attempts_total (_total suffix because it is a counter)


**Which issue(s) this PR fixes**:
Part off #83464

**Does this PR introduce a user-facing change?**:
```release-note
Rename pod_preemption_metrics to preemption_metrics. 
```

