### PR TITLE
kubectl: add env option to deployment creation

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/BUILD
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/BUILD
@@ -98,6 +98,7 @@ go_test(
         "//staging/src/k8s.io/kubectl/pkg/cmd/testing:go_default_library",
         "//staging/src/k8s.io/kubectl/pkg/cmd/util:go_default_library",
         "//staging/src/k8s.io/kubectl/pkg/scheme:go_default_library",
+        "//staging/src/k8s.io/kubectl/pkg/util:go_default_library",
         "//vendor/github.com/stretchr/testify/assert:go_default_library",
     ],
 )

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_deployment_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_deployment_test.go
@@ -138,7 +138,6 @@ func TestCreateDeploymentWithEnvironmentVariables(t *testing.T) {
 			"SingleEnvVar",
 			[]string{
 				"FOO=bar",
-				"FIZZ=buzz",
 			},
 		},
 		{

--- a/test/cmd/apps.sh
+++ b/test/cmd/apps.sh
@@ -242,7 +242,7 @@ run_deployment_tests() {
   kube::test::get_object_assert 'deploy nginx-with-env-vars' "{{${container_env_var_name:?}}}" 'FOO'
   kube::test::get_object_assert 'deploy nginx-with-env-vars' "{{${container_env_var_value:?}}}" 'bar'
   # Clean up
-  kubectl delete deployment nginx-with-command "${kube_flags[@]:?}"
+  kubectl delete deployment nginx-with-env-vars "${kube_flags[@]:?}"
 
   ### Test kubectl create deployment should not fail validation
   # Pre-Condition: No deployment exists.

--- a/test/cmd/legacy-script.sh
+++ b/test/cmd/legacy-script.sh
@@ -375,6 +375,9 @@ runTests() {
   export image_field="(index .spec.containers 0).image"
   export pod_container_name_field="(index .spec.containers 0).name"
   export container_name_field="(index .spec.template.spec.containers 0).name"
+  export container_env_var_name="(index (index .spec.template.spec.containers 0).env 0).name"
+  export container_env_var_value="(index (index .spec.template.spec.containers 0).env 0).value"
+  export container_len="(len .spec.template.spec.containers)"
   export hpa_min_field=".spec.minReplicas"
   export hpa_max_field=".spec.maxReplicas"
   export hpa_cpu_field=".spec.targetCPUUtilizationPercentage"
@@ -389,7 +392,6 @@ runTests() {
   export pdb_min_available=".spec.minAvailable"
   export pdb_max_unavailable=".spec.maxUnavailable"
   export generation_field=".metadata.generation"
-  export container_len="(len .spec.template.spec.containers)"
   export image_field0="(index .spec.template.spec.containers 0).image"
   export image_field1="(index .spec.template.spec.containers 1).image"
 


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Creating a deployment using kubectl with environment variables was done with `kubectl run`. Since most of the generators have been deprecated, including the one for deployments (#87077), this PR adds functionality to the preferred method of deployment creation, `kubectl create deployment`.

I think this feature would be useful in providing more flexibility for deployments with `kubectl create`. Additionally, resources related to deployment creation with environment variables via `kubectl run` can be updated and remain useful rather than eventually being deprecated.

I did not create an issue/enhancement beforehand but I would be more than happy to do so. Apologies especially in case I had missed any content which deemed that this feature shouldn't be implemented. 

Supporting documentation/PRs:
- [#91113](https://github.com/kubernetes/kubernetes/pull/91113)
- [#87077](https://github.com/kubernetes/kubernetes/pull/87077)
- [#68132](https://github.com/kubernetes/kubernetes/pull/68132)

and also attached in the docs section.

**Special notes for your reviewer**:
In addition to running and providing tests, I built the kubectl binary and tested that the new flag/feature works as expected; the intent is for its behavior to be similar to how the flag was in `kubectl run`.

Please let me know if any changes or amendments should be made, or if I'm not adhering to any guidelines or processes. Would also be more than happy to refactor any recommendations for changes.

Thank you very much to all reviewers, maintainers, and contributors for the time and effort!

**Does this PR introduce a user-facing change?**:
Yes, this will add an optional flag `--env` which expects a key value pair of an environment name and value. This flag can be repeated to provide multiple environment variables. 

```release-note
Added the --env flag to allow environment variables to be provided to deployments made with kubectl create. 
```

```docs
- [#91113](https://github.com/kubernetes/kubernetes/pull/91113)
- [#87077](https://github.com/kubernetes/kubernetes/pull/87077)
- [#68132](https://github.com/kubernetes/kubernetes/pull/68132)
```