### PR TITLE
Promote: Discovery PreferredVersion test+16 Endpoints

### DIFF
--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -801,6 +801,13 @@
     definitions MUST be published for custom resource definitions.
   release: v1.16
   file: test/e2e/apimachinery/crd_publish_openapi.go
+- testname: Discovery, confirm the PreferredVersion for each api group
+  codename: '[sig-api-machinery] Discovery should validate PreferredVersion for each
+    APIGroup [Conformance]'
+  description: Ensure that a list of apis is retrieved. Each api group found MUST
+    return a valid PreferredVersion unless the group suffix is example.com.
+  release: v1.19
+  file: test/e2e/apimachinery/discovery.go
 - testname: Event, delete a collection
   codename: '[sig-api-machinery] Events should delete a collection of events [Conformance]'
   description: A set of events is created with a label selector which MUST be found

--- a/test/e2e/apimachinery/discovery.go
+++ b/test/e2e/apimachinery/discovery.go
@@ -82,7 +82,13 @@ var _ = SIGDescribe("Discovery", func() {
 		}
 	})
 
-	ginkgo.It("should validate PreferredVersion for each APIGroup", func() {
+	/*
+	   Release : v1.19
+	   Testname: Discovery, confirm the PreferredVersion for each api group
+	   Description: Ensure that a list of apis is retrieved.
+	   Each api group found MUST return a valid PreferredVersion unless the group suffix is example.com.
+	*/
+	framework.ConformanceIt("should validate PreferredVersion for each APIGroup", func() {
 
 		// get list of APIGroup endpoints
 		list := &metav1.APIGroupList{}


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it:**
This PR adds a test to test the following untested endpoints:
getApiregistrationAPIGroup
getAppsAPIGroup
getAuthenticationAPIGroup
getAuthorizationAPIGroup
getAutoscalingAPIGroup
getBatchAPIGroup
getCoordinationAPIGroup
getDiscoveryAPIGroup
getEventsAPIGroup
getExtensionsAPIGroup
getNodeAPIGroup
getPolicyAPIGroup
getRbacAuthorizationAPIGroup
getSchedulingAPIGroup
getStorageAPIGroup

**Which issue(s) this PR fixes:**
Fixes #92158

**Testgrid Link:**
[Testgrid](https://testgrid.k8s.io/sig-release-master-blocking#gce-cos-master-default&width=5&include-filter-by-regex=should%20validate%20PreferredVersion%20for%20each%20APIGroup)

**Special notes for your reviewer:**
Adds +16 endpoint test coverage (good for conformance)

**Does this PR introduce a user-facing change?:**
```
NONE

```

**Release note:**
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:**
```
NONE

```

/sig testing
/sig architecture
/area conformance