### PR TITLE
kubeconfig: add explicit path, if specified to loading precedence

### DIFF
--- a/staging/src/k8s.io/client-go/tools/clientcmd/client_config_test.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/client_config_test.go
@@ -287,7 +287,7 @@ func TestModifyContext(t *testing.T) {
 
 	// there should now be two contexts
 	if len(startingConfig.Contexts) != len(expectedCtx) {
-		t.Fatalf("unexpected nuber of contexts, expecting %v, but found %v", len(expectedCtx), len(startingConfig.Contexts))
+		t.Fatalf("unexpected number of contexts, expecting %v, but found %v", len(expectedCtx), len(startingConfig.Contexts))
 	}
 
 	for key := range startingConfig.Contexts {

--- a/staging/src/k8s.io/client-go/tools/clientcmd/config.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/config.go
@@ -83,10 +83,13 @@ func (o *PathOptions) GetEnvVarFiles() []string {
 }
 
 func (o *PathOptions) GetLoadingPrecedence() []string {
+	if o.IsExplicitFile() {
+		return []string{o.GetExplicitFile()}
+	}
+
 	if envVarFiles := o.GetEnvVarFiles(); len(envVarFiles) > 0 {
 		return envVarFiles
 	}
-
 	return []string{o.GlobalFile}
 }
 

--- a/staging/src/k8s.io/client-go/tools/clientcmd/loader.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/loader.go
@@ -304,6 +304,10 @@ func (rules *ClientConfigLoadingRules) Migrate() error {
 
 // GetLoadingPrecedence implements ConfigAccess
 func (rules *ClientConfigLoadingRules) GetLoadingPrecedence() []string {
+	if len(rules.ExplicitPath) > 0 {
+		return []string{rules.ExplicitPath}
+	}
+
 	return rules.Precedence
 }
 

--- a/staging/src/k8s.io/client-go/tools/clientcmd/loader_test.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/loader_test.go
@@ -865,3 +865,46 @@ func TestDeduplicate(t *testing.T) {
 		}
 	}
 }
+
+func TestLoadingGetLoadingPrecedence(t *testing.T) {
+	testCases := map[string]struct {
+		rules      *ClientConfigLoadingRules
+		env        string
+		precedence []string
+	}{
+		"default": {
+			precedence: []string{filepath.Join(os.Getenv("HOME"), ".kube/config")},
+		},
+		"explicit": {
+			rules: &ClientConfigLoadingRules{
+				ExplicitPath: "/explicit/kubeconfig",
+			},
+			precedence: []string{"/explicit/kubeconfig"},
+		},
+		"envvar-single": {
+			env:        "/env/kubeconfig",
+			precedence: []string{"/env/kubeconfig"},
+		},
+		"envvar-multiple": {
+			env:        "/env/kubeconfig:/other/kubeconfig",
+			precedence: []string{"/env/kubeconfig", "/other/kubeconfig"},
+		},
+	}
+
+	kubeconfig := os.Getenv("KUBECONFIG")
+	defer os.Setenv("KUBECONFIG", kubeconfig)
+
+	for name, test := range testCases {
+		t.Run(name, func(t *testing.T) {
+			os.Setenv("KUBECONFIG", test.env)
+			rules := test.rules
+			if rules == nil {
+				rules = NewDefaultClientConfigLoadingRules()
+			}
+			actual := rules.GetLoadingPrecedence()
+			if !reflect.DeepEqual(actual, test.precedence) {
+				t.Errorf("expect %v, got %v", test.precedence, actual)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Currently if you invoke:
```
kubectl --kubeconfig=/home/user/kubeconfig config use-context new-context
```
The actual file locked during this process is not the one specified above. This is because the `ModifyConfig` relies on the file precedence from here: https://github.com/kubernetes/kubernetes/blob/b6174e605fd6e23b48131dec9e45043b38372c3c/staging/src/k8s.io/client-go/tools/clientcmd/config.go#L169 which does not include the one specified through `--kubeconfig`. But `writeCurrentContext` is aware of that and checks this accordingly, see https://github.com/kubernetes/kubernetes/blob/b6174e605fd6e23b48131dec9e45043b38372c3c/staging/src/k8s.io/client-go/tools/clientcmd/config.go#L390.
Similarly in [loader.go](https://github.com/kubernetes/kubernetes/blob/b6174e605fd6e23b48131dec9e45043b38372c3c/staging/src/k8s.io/client-go/tools/clientcmd/loader.go#L187) `Load` is aware of explicit path, but `GetLoadingRules` ignores it.

**Special notes for your reviewer**:
/assign @deads2k @liggitt 

/priority critical-urgent 
/sig cli

**Does this PR introduce a user-facing change?**:
<!--
```release-note
NONE
```
