### PR TITLE
Add conformance test for events Update operation

### DIFF
--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -1515,7 +1515,8 @@
   codename: '[sig-instrumentation] Events API should ensure that an event can be fetched,
     patched, deleted, and listed [Conformance]'
   description: Create an event, the event MUST exist. The event is patched with a
-    new note, the check MUST have the update note. The event is deleted and MUST NOT
+    new note, the check MUST have the update note. The event is updated with a new
+    series, the check MUST have the update series. The event is deleted and MUST NOT
     show up when listing all events.
   release: v1.19
   file: test/e2e/instrumentation/events.go


### PR DESCRIPTION
**What type of PR is this?**

/kind api-change

**What this PR does / why we need it**:

replaceEventsV1NamespacedEvent endpoint is missing a conformance test: https://apisnoop.cncf.io/1.19.0/stable/events/replaceEventsV1NamespacedEvent. We should add a test for events Update operation.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs
- [KEP]: <https://github.com/kubernetes/enhancements/tree/master/keps/sig-instrumentation/383-new-event-api-ga-graduation>
```
