### PR TITLE
fix kubectl --local flag bug across all commands

### DIFF
--- a/pkg/kubectl/cmd/convert/convert.go
+++ b/pkg/kubectl/cmd/convert/convert.go
@@ -118,9 +118,11 @@ func (o *ConvertOptions) Complete(f cmdutil.Factory, cmd *cobra.Command) (err er
 	}
 	o.builder = f.NewBuilder
 
-	o.Namespace, _, err = f.ToRawKubeConfigLoader().Namespace()
-	if err != nil {
-		return err
+	if !o.local {
+		o.Namespace, _, err = f.ToRawKubeConfigLoader().Namespace()
+		if err != nil {
+			return err
+		}
 	}
 
 	o.validator = func() (validation.Schema, error) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:


2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Kubectl "local" flag won't ask for kubeconfig after deprecated functionality in [#90243](https://github.com/kubernetes/kubernetes/pull/90243) is removed.

**Which issue(s) this PR fixes**:
Fixes #93188

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
