### PR TITLE
Revert "e2epod: use foreground deletion"

### DIFF
--- a/test/e2e/framework/pod/delete.go
+++ b/test/e2e/framework/pod/delete.go
@@ -48,7 +48,7 @@ func DeletePodOrFail(c clientset.Interface, ns, name string) {
 }
 
 // DeletePodWithWait deletes the passed-in pod and waits for the pod to be terminated. Resilient to the pod
-// not existing. Also waits for all owned resources to be deleted.
+// not existing.
 func DeletePodWithWait(c clientset.Interface, pod *v1.Pod) error {
 	if pod == nil {
 		return nil
@@ -57,17 +57,10 @@ func DeletePodWithWait(c clientset.Interface, pod *v1.Pod) error {
 }
 
 // DeletePodWithWaitByName deletes the named and namespaced pod and waits for the pod to be terminated. Resilient to the pod
-// not existing. Also waits for all owned resources to be deleted.
+// not existing.
 func DeletePodWithWaitByName(c clientset.Interface, podName, podNamespace string) error {
 	e2elog.Logf("Deleting pod %q in namespace %q", podName, podNamespace)
-	deletionPolicy := metav1.DeletePropagationForeground
-	err := c.CoreV1().Pods(podNamespace).Delete(context.TODO(), podName,
-		metav1.DeleteOptions{
-			// If the pod is the owner of some resources (like ephemeral inline volumes),
-			// then we want to be sure that those are also gone before we return.
-			// Blocking pod deletion via metav1.DeletePropagationForeground achieves that.
-			PropagationPolicy: &deletionPolicy,
-		})
+	err := c.CoreV1().Pods(podNamespace).Delete(context.TODO(), podName, metav1.DeleteOptions{})
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			return nil // assume pod was already deleted


### PR DESCRIPTION
**What type of PR is this?**

/kind failing-test

**What this PR does / why we need it**:

This reverts commit af91e76d "e2epod: use foreground deletion" and fixes node-kubelet-conformance tests.

**Which issue(s) this PR fixes**:

Fixes #93302


**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
