### PR TITLE
Ensure runtimeCache contains all observed started containers on pod delete

### DIFF
--- a/pkg/kubelet/BUILD
+++ b/pkg/kubelet/BUILD
@@ -29,6 +29,7 @@ go_library(
         "reason_cache.go",
         "runonce.go",
         "runtime.go",
+        "time_cache.go",
         "util.go",
         "volume_host.go",
     ],
@@ -179,6 +180,7 @@ go_test(
         "pod_workers_test.go",
         "reason_cache_test.go",
         "runonce_test.go",
+        "time_cache_test.go",
     ],
     embed = [":go_default_library"],
     deps = [
@@ -251,6 +253,7 @@ go_test(
         "//staging/src/k8s.io/client-go/util/testing:go_default_library",
         "//staging/src/k8s.io/component-base/featuregate/testing:go_default_library",
         "//staging/src/k8s.io/component-base/version:go_default_library",
+        "//vendor/github.com/golang/groupcache/lru:go_default_library",
         "//vendor/github.com/google/cadvisor/info/v1:go_default_library",
         "//vendor/github.com/google/cadvisor/info/v2:go_default_library",
         "//vendor/github.com/stretchr/testify/assert:go_default_library",

--- a/pkg/kubelet/time_cache.go
+++ b/pkg/kubelet/time_cache.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubelet
+
+import (
+	"sync"
+	"time"
+
+	"github.com/golang/groupcache/lru"
+
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// timeCache stores a time keyed by uid
+type timeCache struct {
+	lock  sync.RWMutex
+	cache *lru.Cache
+}
+
+// maxTimeCacheEntries is the cache entry number in lru cache. 1000 is a proper number
+// for our 100 pods per node target. If we support more pods per node in the future, we
+// may want to increase the number.
+const maxTimeCacheEntries = 1000
+
+func newTimeCache() *timeCache {
+	return &timeCache{cache: lru.New(maxTimeCacheEntries)}
+}
+
+func (c *timeCache) Add(uid types.UID, t time.Time) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	c.cache.Add(uid, t)
+}
+
+func (c *timeCache) Remove(uid types.UID) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	c.cache.Remove(uid)
+}
+
+func (c *timeCache) Get(uid types.UID) (time.Time, bool) {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	value, ok := c.cache.Get(uid)
+	if !ok {
+		return time.Time{}, false
+	}
+	t, ok := value.(time.Time)
+	if !ok {
+		return time.Time{}, false
+	}
+	return t, true
+}

--- a/pkg/kubelet/time_cache_test.go
+++ b/pkg/kubelet/time_cache_test.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubelet
+
+import (
+	"testing"
+	"time"
+
+	"github.com/golang/groupcache/lru"
+)
+
+func TestTimeCache(t *testing.T) {
+	cache := &timeCache{cache: lru.New(2)}
+	if a, ok := cache.Get("123"); ok {
+		t.Errorf("expected cache miss, got %v, %v", a, ok)
+	}
+
+	now := time.Now()
+	soon := now.Add(time.Minute)
+	cache.Add("now", now)
+	cache.Add("soon", soon)
+
+	if a, ok := cache.Get("now"); !ok || !a.Equal(now) {
+		t.Errorf("expected cache hit matching %v, got %v, %v", now, a, ok)
+	}
+	if a, ok := cache.Get("soon"); !ok || !a.Equal(soon) {
+		t.Errorf("expected cache hit matching %v, got %v, %v", soon, a, ok)
+	}
+
+	then := now.Add(-time.Minute)
+	cache.Add("then", then)
+	if a, ok := cache.Get("now"); ok {
+		t.Errorf("expected cache miss from oldest evicted value, got %v, %v", a, ok)
+	}
+	if a, ok := cache.Get("soon"); !ok || !a.Equal(soon) {
+		t.Errorf("expected cache hit matching %v, got %v, %v", soon, a, ok)
+	}
+	if a, ok := cache.Get("then"); !ok || !a.Equal(then) {
+		t.Errorf("expected cache hit matching %v, got %v, %v", then, a, ok)
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
/kind flake

**What this PR does / why we need it**:
Ensures the runtimeCache used to send graceful deletion signals to running containers is at least as fresh as the most recent container start observed by the kubelet and reported to the API.

See discussion in https://github.com/kubernetes/kubernetes/pull/93261 and on https://github.com/liggitt/kubernetes/commit/da1f636514251fa84d89471d1f66c9fb20909d11#r40791980

**Which issue(s) this PR fixes**:
Fixes #93210 

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/cc @sjenning @dashpole 
/sig node
/milestone v1.19