### PR TITLE
Add bootstrap policy for monitoring endpoints

### DIFF
--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -687,6 +687,9 @@ function create-master-auth {
     append_or_replace_prefixed_line "${known_tokens_csv}" "${KONNECTIVITY_SERVER_TOKEN},"     "system:konnectivity-server,uid:system:konnectivity-server"
     create-kubeconfig "konnectivity-server" ${KONNECTIVITY_SERVER_TOKEN}
   fi
+  if [[ -n "${MONITORING_TOKEN:-}" ]]; then
+    append_or_replace_prefixed_line "${known_tokens_csv}" "${MONITORING_TOKEN},"     "system:monitoring,uid:system:monitoring,system:monitoring"
+  fi
 
   if [[ -n "${EXTRA_STATIC_AUTH_COMPONENTS:-}" ]]; then
     # Create a static Bearer token and kubeconfig for extra, comma-separated components.
@@ -2899,7 +2902,9 @@ function main() {
   if [[ "${ENABLE_EGRESS_VIA_KONNECTIVITY_SERVICE:-false}" == "true" ]]; then
     KONNECTIVITY_SERVER_TOKEN="$(secure_random 32)"
   fi
-
+  if [[ "${ENABLE_MONITORING_TOKEN:-false}" == "true" ]]; then
+    MONITORING_TOKEN="$(secure_random 32)"
+  fi
 
   setup-os-params
   config-ip-firewall

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
@@ -196,7 +196,8 @@ func ClusterRoles() []rbacv1.ClusterRole {
 			},
 		},
 		{
-			// a role which provides just enough power to determine if the server is ready and discover API versions for negotiation
+			// a role which provides just enough power to determine if the server is
+			// ready and discover API versions for negotiation
 			ObjectMeta: metav1.ObjectMeta{Name: "system:discovery"},
 			Rules: []rbacv1.PolicyRule{
 				rbacv1helpers.NewRule("get").URLs(
@@ -205,6 +206,20 @@ func ClusterRoles() []rbacv1.ClusterRole {
 					"/openapi", "/openapi/*",
 					"/api", "/api/*",
 					"/apis", "/apis/*",
+				).RuleOrDie(),
+			},
+		},
+		{
+			// a role which provides minimal read access to the monitoring endpoints
+			// (i.e. /metrics, /livez/*, /readyz/*, /healthz/*, /livez, /readyz, /healthz)
+			// The splatted health check endpoints allow read access to individual health check
+			// endpoints which may contain more sensitive cluster information information
+			ObjectMeta: metav1.ObjectMeta{Name: "system:monitoring"},
+			Rules: []rbacv1.PolicyRule{
+				rbacv1helpers.NewRule("get").URLs(
+					"/metrics",
+					"/livez", "/readyz", "/healthz",
+					"/livez/*", "/readyz/*", "/healthz/*",
 				).RuleOrDie(),
 			},
 		},
@@ -563,6 +578,7 @@ const systemNodeRoleName = "system:node"
 func ClusterRoleBindings() []rbacv1.ClusterRoleBinding {
 	rolebindings := []rbacv1.ClusterRoleBinding{
 		rbacv1helpers.NewClusterBinding("cluster-admin").Groups(user.SystemPrivilegedGroup).BindingOrDie(),
+		rbacv1helpers.NewClusterBinding("system:monitoring").Groups(user.MonitoringGroup).BindingOrDie(),
 		rbacv1helpers.NewClusterBinding("system:discovery").Groups(user.AllAuthenticated).BindingOrDie(),
 		rbacv1helpers.NewClusterBinding("system:basic-user").Groups(user.AllAuthenticated).BindingOrDie(),
 		rbacv1helpers.NewClusterBinding("system:public-info-viewer").Groups(user.AllAuthenticated, user.AllUnauthenticated).BindingOrDie(),

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-role-bindings.yaml
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-role-bindings.yaml
@@ -110,6 +110,23 @@ items:
     creationTimestamp: null
     labels:
       kubernetes.io/bootstrapping: rbac-defaults
+    name: system:monitoring
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: ClusterRole
+    name: system:monitoring
+  subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: system:monitoring
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRoleBinding
+  metadata:
+    annotations:
+      rbac.authorization.kubernetes.io/autoupdate: "true"
+    creationTimestamp: null
+    labels:
+      kubernetes.io/bootstrapping: rbac-defaults
     name: system:node
   roleRef:
     apiGroup: rbac.authorization.k8s.io

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-roles.yaml
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-roles.yaml
@@ -869,6 +869,26 @@ items:
     creationTimestamp: null
     labels:
       kubernetes.io/bootstrapping: rbac-defaults
+    name: system:monitoring
+  rules:
+  - nonResourceURLs:
+    - /healthz
+    - /healthz/*
+    - /livez
+    - /livez/*
+    - /metrics
+    - /readyz
+    - /readyz/*
+    verbs:
+    - get
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRole
+  metadata:
+    annotations:
+      rbac.authorization.kubernetes.io/autoupdate: "true"
+    creationTimestamp: null
+    labels:
+      kubernetes.io/bootstrapping: rbac-defaults
     name: system:node
   rules:
   - apiGroups:

--- a/staging/src/k8s.io/apiserver/pkg/authentication/user/user.go
+++ b/staging/src/k8s.io/apiserver/pkg/authentication/user/user.go
@@ -70,6 +70,7 @@ func (i *DefaultInfo) GetExtra() map[string][]string {
 const (
 	SystemPrivilegedGroup = "system:masters"
 	NodesGroup            = "system:nodes"
+	MonitoringGroup       = "system:monitoring"
 	AllUnauthenticated    = "system:unauthenticated"
 	AllAuthenticated      = "system:authenticated"
 


### PR DESCRIPTION
We enable metrics by default, but that doesn't mean we should have (nor encourage) full cluster-admin access to use those endpoints. 

Also, having a bootstrapping role defined for /metrics and health check endpoints means that we have access to instrumentation earlier in the apiserver startup lifecycle, which is desirable when you have larger clusters (which have correspondingly longer startups) or in the case that you have failures in the startup sequence before (and possibly preventing) new policies from being applied. 

**What type of PR is this?**

/kind cleanup

**Does this PR introduce a user-facing change?**:

```release-note
Adds a bootstrapping ClusterRole, ClusterRoleBinding and group for /metrics, /livez/*, /readyz/*, & /healthz/* endpoints. 
```

/sig instrumentation api-machinery auth
