### PR TITLE
Fix staticchecks on test/integration/ttlcontroller

### DIFF
--- a/hack/.staticcheck_failures
+++ b/hack/.staticcheck_failures
@@ -12,7 +12,6 @@ test/integration/examples
 test/integration/framework
 test/integration/garbagecollector
 test/integration/scheduler_perf
-test/integration/ttlcontroller
 vendor/k8s.io/apimachinery/pkg/api/apitesting/roundtrip
 vendor/k8s.io/apimachinery/pkg/api/meta
 vendor/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured

--- a/test/integration/ttlcontroller/ttlcontroller_test.go
+++ b/test/integration/ttlcontroller/ttlcontroller_test.go
@@ -25,7 +25,7 @@ import (
 	"testing"
 	"time"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -61,7 +61,7 @@ func createNodes(t *testing.T, client *clientset.Clientset, startIndex, endIndex
 				},
 			}
 			if _, err := client.CoreV1().Nodes().Create(context.TODO(), node, metav1.CreateOptions{}); err != nil {
-				t.Fatalf("Failed to create node: %v", err)
+				t.Errorf("Failed to create node: %v", err)
 			}
 		}(i)
 	}
@@ -76,7 +76,7 @@ func deleteNodes(t *testing.T, client *clientset.Clientset, startIndex, endIndex
 			defer wg.Done()
 			name := fmt.Sprintf("node-%d", idx)
 			if err := client.CoreV1().Nodes().Delete(context.TODO(), name, metav1.DeleteOptions{}); err != nil {
-				t.Fatalf("Failed to delete node: %v", err)
+				t.Errorf("Failed to delete node: %v", err)
 			}
 		}(i)
 	}


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind api-change
> /kind bug

/kind cleanup

> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Addresses staticchecks for the ttlcontroller inside integration tests

**Which issue(s) this PR fixes**:
Part of #92402 

**Special notes for your reviewer**:
This PR is part of a larger cleanup exercise as linked above 
**Does this PR introduce a user-facing change?**:
NONE
```release-note

```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
