### PR TITLE
Automated cherry pick of #91678: tests: Fixes Windows kubelet-stats test

### DIFF
--- a/test/e2e/windows/kubelet_stats.go
+++ b/test/e2e/windows/kubelet_stats.go
@@ -17,6 +17,7 @@ limitations under the License.
 package windows
 
 import (
+	"fmt"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
@@ -126,7 +127,7 @@ func newKubeletStatsTestPods(numPods int, image imageutils.Config, nodeName stri
 		podName := "statscollectiontest-" + string(uuid.NewUUID())
 		pod := v1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: podName,
+				Name: fmt.Sprintf("%s-%d", podName, i),
 				Labels: map[string]string{
 					"name":    podName,
 					"testapp": "stats-collection",
@@ -136,7 +137,7 @@ func newKubeletStatsTestPods(numPods int, image imageutils.Config, nodeName stri
 				Containers: []v1.Container{
 					{
 						Image: image.GetE2EImage(),
-						Name:  podName,
+						Name:  "stat-container",
 						Command: []string{
 							"powershell.exe",
 							"-Command",
@@ -147,7 +148,7 @@ func newKubeletStatsTestPods(numPods int, image imageutils.Config, nodeName stri
 				InitContainers: []v1.Container{
 					{
 						Image: image.GetE2EImage(),
-						Name:  podName,
+						Name:  "init-container",
 						Command: []string{
 							"powershell.exe",
 							"-Command",


### PR DESCRIPTION
Cherry pick of #91678 on release-1.17.

#91678: tests: Fixes Windows kubelet-stats test


Meant to fix the test ``[sig-windows] [Feature:Windows] Kubelet-Stats [Serial] Kubelet stats collection for Windows nodes when running 10 pods should return within 10 seconds`` in https://testgrid.k8s.io/sig-windows-azure#aks-engine-azure-1-17-windows-serial-slow


/kind bug

/sig windows
/sig testing

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.