### PR TITLE
Fix scheduler issue with nodetree additions

### DIFF
--- a/pkg/scheduler/internal/cache/cache.go
+++ b/pkg/scheduler/internal/cache/cache.go
@@ -281,6 +281,7 @@ func (cache *schedulerCache) updateNodeInfoSnapshotList(snapshot *Snapshot, upda
 	if updateAll {
 		// Take a snapshot of the nodes order in the tree
 		snapshot.nodeInfoList = make([]*schedulernodeinfo.NodeInfo, 0, cache.nodeTree.numNodes)
+		cache.nodeTree.resetExhausted()
 		for i := 0; i < cache.nodeTree.numNodes; i++ {
 			nodeName := cache.nodeTree.next()
 			if n := snapshot.nodeInfoMap[nodeName]; n != nil {


### PR DESCRIPTION
**What type of PR is this?**
 /kind bug

**What this PR does / why we need it**:

When adding multiple nodes to the scheduler nodetree, the function getting the next node does not return all the nodes one after an other, but skips some and duplicate others. This commit works around the problem by always starting with reset counters.

**Which issue(s) this PR fixes**:

Fixes #91601 

**Does this PR introduce a user-facing change?**:
NONE

/sig scheduling
