### PR TITLE
Increase the size of the buckets for PodSchedulingDuration scheduler metric.

### DIFF
--- a/pkg/scheduler/metrics/metrics.go
+++ b/pkg/scheduler/metrics/metrics.go
@@ -159,8 +159,8 @@ var (
 			Subsystem: SchedulerSubsystem,
 			Name:      "pod_scheduling_duration_seconds",
 			Help:      "E2e latency for a pod being scheduled which may include multiple scheduling attempts.",
-			// Start with 1ms with the last bucket being [~16s, Inf)
-			Buckets:        metrics.ExponentialBuckets(0.001, 2, 15),
+			// Start with 10ms with the last bucket being [~88m, Inf).
+			Buckets:        metrics.ExponentialBuckets(0.01, 2, 20),
 			StabilityLevel: metrics.ALPHA,
 		},
 		[]string{"attempts"})


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:
PodSchedulingDuration includes the time the pod is sitting in the queue and all scheduling attempts, this duration is expected to
be from seconds to minutes rather than milliseconds to seconds.

-->
```release-note
NONE
```

/priority important-soon
/milestone v1.19