### PR TITLE
Mention background deletion in kubectl delete cascade help

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/delete/delete_flags.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/delete/delete_flags.go
@@ -119,7 +119,7 @@ func (f *DeleteFlags) AddFlags(cmd *cobra.Command) {
 		cmd.Flags().BoolVar(f.Force, "force", *f.Force, "If true, immediately remove resources from API and bypass graceful deletion. Note that immediate deletion of some resources may result in inconsistency or data loss and requires confirmation.")
 	}
 	if f.Cascade != nil {
-		cmd.Flags().BoolVar(f.Cascade, "cascade", *f.Cascade, "If true, cascade the deletion of the resources managed by this resource (e.g. Pods created by a ReplicationController).  Default true.")
+		cmd.Flags().BoolVar(f.Cascade, "cascade", *f.Cascade, "If true, run background cascade deletion of the resources managed by this resource (e.g. Pods created by a ReplicationController).  Default true.")
 	}
 	if f.Now != nil {
 		cmd.Flags().BoolVar(f.Now, "now", *f.Now, "If true, resources are signaled for immediate shutdown (same as --grace-period=1).")


### PR DESCRIPTION
Adds more information to the help command for kubectl delete where it's not clear that the cascading deletion is background.

**What type of PR is this?**
/kind cleanup
/kind documentation

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```