### PR TITLE
Update: Extend podRetryTimeout to deal with slow pod deletions

### DIFF
--- a/test/e2e/common/pods.go
+++ b/test/e2e/common/pods.go
@@ -55,7 +55,7 @@ const (
 	syncLoopFrequency    = 10 * time.Second
 	maxBackOffTolerance  = time.Duration(1.3 * float64(kubelet.MaxContainerBackOff))
 	podRetryPeriod       = 1 * time.Second
-	podRetryTimeout      = 1 * time.Minute
+	podRetryTimeout      = 2 * time.Minute
 )
 
 // testHostIP tests that a pod gets a host IP


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it:**
This PR help support timeout issue in [#93086](https://github.com/kubernetes/kubernetes/pull/93086)
[Feedback](https://github.com/kubernetes/kubernetes/pull/93086#issuecomment-662440462) form SIG Noted advised to increase the timeout and it is wide supported as there is no other technical reason for the test to fail.

**Testgrid Link**
[Testgrid](https://testgrid.k8s.io/sig-release-master-blocking#gce-cos-master-default&width=5&include-filter-by-regex=should%20delete%20a%20collection%20of%20pods)

**Which issue(s) this PR fixes:**
Fixes #90913 

**Special notes for your reviewer:**
This PR help support timeout issue in [#93086](https://github.com/kubernetes/kubernetes/pull/93086)

**Does this PR introduce a user-facing change?:**
```
NONE
```
**Release note:**
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:**
```
NONE
```
/sig testing
/sig architecture
/area conformance