### PR TITLE
Delete pod collection immediately

### DIFF
--- a/test/e2e/common/pods.go
+++ b/test/e2e/common/pods.go
@@ -835,6 +835,8 @@ var _ = framework.KubeDescribe("Pods", func() {
 	ginkgo.It("should delete a collection of pods", func() {
 		podTestNames := []string{"test-pod-1", "test-pod-2", "test-pod-3"}
 
+		zero := int64(0)
+
 		ginkgo.By("Create set of pods")
 		// create a set of pods in test namespace
 		for _, podTestName := range podTestNames {
@@ -845,6 +847,7 @@ var _ = framework.KubeDescribe("Pods", func() {
 						"type": "Testing"},
 				},
 				Spec: v1.PodSpec{
+					TerminationGracePeriodSeconds: &zero,
 					Containers: []v1.Container{{
 						Image: imageutils.GetE2EImage(imageutils.Agnhost),
 						Name:  "token-test",
@@ -861,7 +864,7 @@ var _ = framework.KubeDescribe("Pods", func() {
 		framework.ExpectNoError(err, "3 pods not found")
 
 		// delete Collection of pods with a label in the current namespace
-		err = f.ClientSet.CoreV1().Pods(f.Namespace.Name).DeleteCollection(context.TODO(), metav1.DeleteOptions{}, metav1.ListOptions{
+		err = f.ClientSet.CoreV1().Pods(f.Namespace.Name).DeleteCollection(context.TODO(), metav1.DeleteOptions{GracePeriodSeconds: &zero}, metav1.ListOptions{
 			LabelSelector: "type=Testing"})
 		framework.ExpectNoError(err, "failed to delete collection of pods")
 


### PR DESCRIPTION
**What type of PR is this?**
/kind flake

**What this PR does / why we need it**:
Delete pods with no grace period to deflake the e2e test

The test set up three pods with a default grace period of 30 seconds, then only waited a minute for the kubelet to complete deleting them. If the kubelet was busy processing other pods, this can delay removal of the objects and fail the test.

Fixes https://github.com/kubernetes/kubernetes/issues/93372

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/assign @Riaankl 