### PR TITLE
Fix annotation sorting in kuberuntime convert test

### DIFF
--- a/pkg/kubelet/kuberuntime/convert_test.go
+++ b/pkg/kubelet/kuberuntime/convert_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package kuberuntime
 
 import (
+	"sort"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -92,6 +93,12 @@ func TestConvertToKubeContainerImageSpec(t *testing.T) {
 
 	for _, test := range testCases {
 		actual := toKubeContainerImageSpec(test.input)
+		sort.Slice(test.expected.Annotations, func(i, j int) bool {
+			return test.expected.Annotations[i].Name < test.expected.Annotations[j].Name
+		})
+		sort.Slice(actual.Annotations, func(i, j int) bool {
+			return actual.Annotations[i].Name < actual.Annotations[j].Name
+		})
 		assert.Equal(t, test.expected, actual)
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind flake

**What this PR does / why we need it**:

The source image annotation is based on map[string]string which is not sorted in Go. The resulting slice of annotations can be different between test runs and produce flakes, see: https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_kubernetes/166/pull-ci-openshift-kubernetes-master-unit/1286171049615953920

```
=== RUN   TestConvertToKubeContainerImageSpec
--- FAIL: TestConvertToKubeContainerImageSpec (0.00s)
    convert_test.go:95: 
        	Error Trace:	convert_test.go:95
        	Error:      	Not equal: 
        	            	expected: container.ImageSpec{Image:"test", Annotations:[]container.Annotation{container.Annotation{Name:"kubernetes.io/os", Value:"linux"}, container.Annotation{Name:"kubernetes.io/runtimehandler", Value:"handler"}}}
        	            	actual  : container.ImageSpec{Image:"test", Annotations:[]container.Annotation{container.Annotation{Name:"kubernetes.io/runtimehandler", Value:"handler"}, container.Annotation{Name:"kubernetes.io/os", Value:"linux"}}}
```
```release-note
NONE
```


