### PR TITLE
allow adding annotations to pod when using kubectl run

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/run/run.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/run/run.go
@@ -173,6 +173,7 @@ func NewCmdRun(f cmdutil.Factory, streams genericclioptions.IOStreams) *cobra.Co
 
 func addRunFlags(cmd *cobra.Command, opt *RunOptions) {
 	cmdutil.AddDryRunFlag(cmd)
+	cmd.Flags().StringArray("annotations", []string{}, i18n.T("Annotations to apply to the pod."))
 	cmd.Flags().StringVar(&opt.Generator, "generator", opt.Generator, i18n.T("The name of the API generator to use, see http://kubernetes.io/docs/user-guide/kubectl-conventions/#generators for a list."))
 	cmd.Flags().MarkDeprecated("generator", "has no effect and will be removed in the future.")
 	cmd.Flags().StringVar(&opt.Image, "image", opt.Image, i18n.T("The image for the container to run."))
@@ -319,6 +320,7 @@ func (o *RunOptions) Run(f cmdutil.Factory, cmd *cobra.Command, args []string) e
 		params["args"] = args[1:]
 	}
 
+	params["annotations"] = cmdutil.GetFlagStringArray(cmd, "annotations")
 	params["env"] = cmdutil.GetFlagStringArray(cmd, "env")
 
 	var createdObjects = []*RunObject{}

--- a/staging/src/k8s.io/kubectl/pkg/generate/versioned/BUILD
+++ b/staging/src/k8s.io/kubectl/pkg/generate/versioned/BUILD
@@ -44,6 +44,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/validation:go_default_library",
         "//staging/src/k8s.io/client-go/discovery:go_default_library",
+        "//staging/src/k8s.io/kubectl/pkg/cmd/util:go_default_library",
         "//staging/src/k8s.io/kubectl/pkg/generate:go_default_library",
         "//staging/src/k8s.io/kubectl/pkg/util:go_default_library",
         "//staging/src/k8s.io/kubectl/pkg/util/hash:go_default_library",

--- a/staging/src/k8s.io/kubectl/pkg/generate/versioned/run_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/generate/versioned/run_test.go
@@ -20,7 +20,7 @@ import (
 	"reflect"
 	"testing"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -273,6 +273,33 @@ func TestGeneratePod(t *testing.T) {
 							Name:            "foo",
 							Image:           "someimage",
 							SecurityContext: securityContextWithPrivilege(true),
+						},
+					},
+					DNSPolicy:     v1.DNSClusterFirst,
+					RestartPolicy: v1.RestartPolicyAlways,
+				},
+			},
+		},
+		{
+			name: "test11: check annotations",
+			params: map[string]interface{}{
+				"name":        "foo",
+				"image":       "someimage",
+				"replicas":    "1",
+				"labels":      "foo=bar,baz=blah",
+				"annotations": []string{"foo=bar1", "baz=blah1"},
+			},
+			expected: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "foo",
+					Labels:      map[string]string{"foo": "bar", "baz": "blah"},
+					Annotations: map[string]string{"foo": "bar1", "baz": "blah1"},
+				},
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Name:  "foo",
+							Image: "someimage",
 						},
 					},
 					DNSPolicy:     v1.DNSClusterFirst,


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Allows adding annotations to the created pod from kubectl run through --annotation flag.

**Which issue(s) this PR fixes**:
Fixes [kubernetes/kubectl#826](https://github.com/kubernetes/kubectl/issues/826)

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs

```
