### PR TITLE
WIP: Event: Document TTL and best-effort-ness

### DIFF
--- a/pkg/apis/core/types.go
+++ b/pkg/apis/core/types.go
@@ -4564,7 +4564,12 @@ const (
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
-// Event is a report of an event somewhere in the cluster.
+// Event is a report of an event somewhere in the cluster.  Events
+// have a limited retention time and triggers and messages may evolve
+// with time.  Event consumers should not rely on the timing of an event
+// with a given Reason reflecting a consistent underlying trigger, or the
+// continued existence of events with that Reason.  Events should be
+// treated as informative, best-effort, supplemental data.
 // TODO: Decide whether to store these separately or with the object they apply to.
 type Event struct {
 	metav1.TypeMeta

--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -5275,7 +5275,12 @@ const (
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
-// Event is a report of an event somewhere in the cluster.
+// Event is a report of an event somewhere in the cluster.  Events
+// have a limited retention time and triggers and messages may evolve
+// with time.  Event consumers should not rely on the timing of an event
+// with a given Reason reflecting a consistent underlying trigger, or the
+// continued existence of events with that Reason.  Events should be
+// treated as informative, best-effort, supplemental data.
 type Event struct {
 	metav1.TypeMeta `json:",inline"`
 	// Standard object's metadata.


### PR DESCRIPTION
Generally try to waive away folks who see a particular event stream and feel tempted to extrapolate and build tooling that expects the same underlying resource transition chain to continue to produce a similar event stream as the underlying components evolve and are updated.  New controllers should not be constrained to be backwards-compatible with previous versions with regard to Event emission.  This is distinct from the Event type itself, which has the usual Kubernetes-API compatibility commitments for versioned types.

The `EventTTL` default has been 1h since 7e258b85bd (#5315), and remains so today:

```console
$ git --no-pager log -1 --format='%h %s' origin/master
8e5c02255cc Merge pull request #90942 from ii/ii-create-pod%2Bpodstatus-resource-lifecycle-test
$ git --no-pager grep EventTTL: 8e5c02255cc cmd/kube-apiserver/app/options/options.go
8e5c02255cc:cmd/kube-apiserver/app/options/options.go:		EventTTL:               1 * time.Hour,
```

[In][1] [this][2] space:

> To avoid filling up master's disk, a retention policy is enforced: events are removed one hour after the last occurrence.  To provide longer history and aggregation capabilities, a third party solution should be installed to capture events.
> ...
> Note: It is not guaranteed that all events happening in a cluster will be exported to Stackdriver.  One possible scenario when events will not be exported is when event exporter is not running (e.g. during restart or upgrade).  In most cases it's fine to use events for purposes like setting up metrics and alerts, but you should be aware of the potential inaccuracy.
> ...
> To prevent disturbing your workloads, event exporter does not have resources set and is in the best effort QOS class, which means that it will be the first to be killed in the case of resource starvation.

Although that's talking more about export from etcd -> external storage, and not about cluster components submitting events to etcd.

```release-note
NONE
```

CC @deads2k

[1]: https://kubernetes.io/docs/tasks/debug-application-cluster/events-stackdriver/
[2]: https://github.com/kubernetes/website/pull/4155/files#diff-d8eb69c5436aa38b396d4f3ed75e4792R10