### PR TITLE
jsonpath: disallow multiple immediate recursive descent

### DIFF
--- a/staging/src/k8s.io/client-go/util/jsonpath/jsonpath_test.go
+++ b/staging/src/k8s.io/client-go/util/jsonpath/jsonpath_test.go
@@ -263,6 +263,8 @@ func TestStructInput(t *testing.T) {
 		{"allarray", "{.Book[*].Author}", storeData, "Nigel Rees Evelyn Waugh Herman Melville", false},
 		{"allfields", `{range .Bicycle[*]}{ "{" }{ @.* }{ "} " }{end}`, storeData, "{red 19.95 true} {green 20.01 false} ", false},
 		{"recurfields", "{..Price}", storeData, "8.95 12.99 8.99 19.95 20.01", false},
+		{"recurdotfields", "{...Price}", storeData, "8.95 12.99 8.99 19.95 20.01", false},
+		{"superrecurfields", "{............................................................Price}", storeData, "", true},
 		{"allstructsSlice", "{.Bicycle}", storeData,
 			`[{"Color":"red","Price":19.95,"IsNew":true},{"Color":"green","Price":20.01,"IsNew":false}]`, false},
 		{"allstructs", `{range .Bicycle[*]}{ @ }{ " " }{end}`, storeData,

--- a/staging/src/k8s.io/client-go/util/jsonpath/parser.go
+++ b/staging/src/k8s.io/client-go/util/jsonpath/parser.go
@@ -214,8 +214,11 @@ func (p *Parser) parseIdentifier(cur *ListNode) error {
 	return p.parseInsideAction(cur)
 }
 
-// parseRecursive scans the recursive desent operator ..
+// parseRecursive scans the recursive descent operator ..
 func (p *Parser) parseRecursive(cur *ListNode) error {
+	if lastIndex := len(cur.Nodes) - 1; lastIndex >= 0 && cur.Nodes[lastIndex].Type() == NodeRecursive {
+		return fmt.Errorf("invalid multiple recursive descent")
+	}
 	p.pos += len("..")
 	p.consumeText()
 	cur.append(newRecursive())

--- a/staging/src/k8s.io/client-go/util/jsonpath/parser_test.go
+++ b/staging/src/k8s.io/client-go/util/jsonpath/parser_test.go
@@ -141,6 +141,7 @@ func TestFailParser(t *testing.T) {
 		{"invalid number", "{+12.3.0}", "cannot parse number +12.3.0"},
 		{"unterminated array", "{[1}", "unterminated array"},
 		{"unterminated filter", "{[?(.price]}", "unterminated filter"},
+		{"invalid multiple recursive descent", "{........}", "invalid multiple recursive descent"},
 	}
 	for _, test := range failParserTests {
 		_, err := Parse(test.name, test.text)


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Disallows invalid jsonpath expressions such as `.....................................` which currently cause nested recursion and can use large amounts of CPU.

**Which issue(s) this PR fixes**:

Fixes #93400

```release-note
kube-apiserver: jsonpath expressions with consecutive recursive descent operators are no longer evaluated for custom resource printer columns
```