### PR TITLE
Don't apply triage/needs-information on apimachinery and instrumentation PRs

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -33,4 +33,3 @@ filters:
   "metrics\\.go$":
     labels:
       - sig/instrumentation
-      - triage/needs-information

--- a/cluster/addons/fluentd-elasticsearch/OWNERS
+++ b/cluster/addons/fluentd-elasticsearch/OWNERS
@@ -8,4 +8,3 @@ reviewers:
 - sig-instrumentation-reviewers
 labels:
 - sig/instrumentation
-- triage/needs-information

--- a/cluster/addons/fluentd-gcp/OWNERS
+++ b/cluster/addons/fluentd-gcp/OWNERS
@@ -8,4 +8,3 @@ reviewers:
 labels:
 - area/provider/gcp
 - sig/instrumentation
-- triage/needs-information

--- a/cluster/addons/metadata-agent/OWNERS
+++ b/cluster/addons/metadata-agent/OWNERS
@@ -8,4 +8,3 @@ reviewers:
 - sig-instrumentation-reviewers
 labels:
 - sig/instrumentation
-- triage/needs-information

--- a/cluster/addons/metrics-server/OWNERS
+++ b/cluster/addons/metrics-server/OWNERS
@@ -8,4 +8,3 @@ reviewers:
 - sig-instrumentation-reviewers
 labels:
 - sig/instrumentation
-- triage/needs-information

--- a/cluster/images/etcd-version-monitor/OWNERS
+++ b/cluster/images/etcd-version-monitor/OWNERS
@@ -2,4 +2,3 @@
 
 labels:
 - sig/api-machinery
-- triage/needs-information

--- a/cluster/images/etcd/OWNERS
+++ b/cluster/images/etcd/OWNERS
@@ -7,4 +7,3 @@ approvers:
   - jpbetz
 labels:
 - sig/api-machinery
-- triage/needs-information

--- a/cmd/cloud-controller-manager/OWNERS
+++ b/cmd/cloud-controller-manager/OWNERS
@@ -16,5 +16,4 @@ emeritus_approvers:
 - wlan0
 labels:
 - sig/api-machinery
-- triage/needs-information
 - sig/cloud-provider

--- a/cmd/controller-manager/OWNERS
+++ b/cmd/controller-manager/OWNERS
@@ -15,4 +15,3 @@ reviewers:
 - stewart-yu
 labels:
 - sig/api-machinery
-- triage/needs-information

--- a/cmd/kube-apiserver/OWNERS
+++ b/cmd/kube-apiserver/OWNERS
@@ -28,5 +28,4 @@ reviewers:
 - yue9944882
 labels:
 - sig/api-machinery
-- triage/needs-information
 - area/apiserver

--- a/cmd/kube-controller-manager/OWNERS
+++ b/cmd/kube-controller-manager/OWNERS
@@ -55,4 +55,3 @@ reviewers:
 - wojtek-t
 labels:
 - sig/api-machinery
-- triage/needs-information

--- a/pkg/controller/garbagecollector/OWNERS
+++ b/pkg/controller/garbagecollector/OWNERS
@@ -10,4 +10,3 @@ reviewers:
 - deads2k
 labels:
 - sig/api-machinery
-- triage/needs-information

--- a/pkg/controller/namespace/OWNERS
+++ b/pkg/controller/namespace/OWNERS
@@ -5,4 +5,3 @@ reviewers:
 - smarterclayton
 labels:
 - sig/api-machinery
-- triage/needs-information

--- a/pkg/generated/openapi/OWNERS
+++ b/pkg/generated/openapi/OWNERS
@@ -8,5 +8,4 @@ reviewers:
 - liggitt
 labels:
 - sig/api-machinery
-- triage/needs-information
 - area/code-generation

--- a/pkg/kubeapiserver/OWNERS
+++ b/pkg/kubeapiserver/OWNERS
@@ -14,5 +14,4 @@ reviewers:
 - logicalhan
 labels:
 - sig/api-machinery
-- triage/needs-information
 - area/apiserver

--- a/pkg/master/OWNERS
+++ b/pkg/master/OWNERS
@@ -40,4 +40,3 @@ reviewers:
 - enj
 labels:
 - sig/api-machinery
-- triage/needs-information

--- a/pkg/quota/v1/OWNERS
+++ b/pkg/quota/v1/OWNERS
@@ -11,4 +11,3 @@ reviewers:
 - vishh
 labels:
 - sig/api-machinery
-- triage/needs-information

--- a/staging/src/k8s.io/apiextensions-apiserver/OWNERS
+++ b/staging/src/k8s.io/apiextensions-apiserver/OWNERS
@@ -15,4 +15,3 @@ reviewers:
 - roycaihw
 labels:
 - sig/api-machinery
-- triage/needs-information

--- a/staging/src/k8s.io/apimachinery/OWNERS
+++ b/staging/src/k8s.io/apimachinery/OWNERS
@@ -24,4 +24,3 @@ reviewers:
 - logicalhan
 labels:
 - sig/api-machinery
-- triage/needs-information

--- a/staging/src/k8s.io/apiserver/OWNERS
+++ b/staging/src/k8s.io/apiserver/OWNERS
@@ -23,5 +23,4 @@ reviewers:
 - jpbetz
 labels:
 - sig/api-machinery
-- triage/needs-information
 - area/apiserver

--- a/staging/src/k8s.io/client-go/OWNERS
+++ b/staging/src/k8s.io/client-go/OWNERS
@@ -17,4 +17,3 @@ reviewers:
 - yliaog
 labels:
 - sig/api-machinery
-- triage/needs-information

--- a/staging/src/k8s.io/code-generator/OWNERS
+++ b/staging/src/k8s.io/code-generator/OWNERS
@@ -10,5 +10,4 @@ reviewers:
 - sttts
 labels:
 - sig/api-machinery
-- triage/needs-information
 - area/code-generation

--- a/staging/src/k8s.io/component-base/OWNERS
+++ b/staging/src/k8s.io/component-base/OWNERS
@@ -18,4 +18,3 @@ emeritus_approvers:
 labels:
 - sig/cluster-lifecycle
 - sig/api-machinery
-- triage/needs-information

--- a/staging/src/k8s.io/component-base/logs/OWNERS
+++ b/staging/src/k8s.io/component-base/logs/OWNERS
@@ -6,4 +6,3 @@ reviewers:
 - sig-instrumentation-reviewers
 labels:
 - sig/instrumentation
-- triage/needs-information

--- a/staging/src/k8s.io/component-base/metrics/OWNERS
+++ b/staging/src/k8s.io/component-base/metrics/OWNERS
@@ -8,4 +8,3 @@ reviewers:
 - sig-instrumentation-reviewers
 labels:
 - sig/instrumentation
-- triage/needs-information

--- a/staging/src/k8s.io/controller-manager/OWNERS
+++ b/staging/src/k8s.io/controller-manager/OWNERS
@@ -19,5 +19,4 @@ reviewers:
 - sttts
 labels:
 - sig/api-machinery
-- triage/needs-information
 - sig/cloud-provider

--- a/staging/src/k8s.io/kube-aggregator/OWNERS
+++ b/staging/src/k8s.io/kube-aggregator/OWNERS
@@ -16,4 +16,3 @@ reviewers:
 - logicalhan
 labels:
 - sig/api-machinery
-- triage/needs-information

--- a/staging/src/k8s.io/metrics/OWNERS
+++ b/staging/src/k8s.io/metrics/OWNERS
@@ -4,4 +4,3 @@ approvers:
 - sig-instrumentation-approvers
 labels:
 - sig/instrumentation
-- triage/needs-information

--- a/staging/src/k8s.io/sample-apiserver/OWNERS
+++ b/staging/src/k8s.io/sample-apiserver/OWNERS
@@ -15,4 +15,3 @@ reviewers:
 - cheftako
 labels:
 - sig/api-machinery
-- triage/needs-information

--- a/staging/src/k8s.io/sample-controller/OWNERS
+++ b/staging/src/k8s.io/sample-controller/OWNERS
@@ -9,4 +9,3 @@ reviewers:
 - nikhita
 labels:
 - sig/api-machinery
-- triage/needs-information

--- a/test/e2e/apimachinery/OWNERS
+++ b/test/e2e/apimachinery/OWNERS
@@ -24,4 +24,3 @@ reviewers:
 - logicalhan
 labels:
 - sig/api-machinery
-- triage/needs-information

--- a/test/e2e/instrumentation/OWNERS
+++ b/test/e2e/instrumentation/OWNERS
@@ -12,4 +12,3 @@ reviewers:
 - sig-instrumentation-reviewers
 labels:
 - sig/instrumentation
-- triage/needs-information

--- a/test/e2e/instrumentation/logging/OWNERS
+++ b/test/e2e/instrumentation/logging/OWNERS
@@ -8,4 +8,3 @@ reviewers:
 - sig-instrumentation-reviewers
 labels:
 - sig/instrumentation
-- triage/needs-information

--- a/test/instrumentation/OWNERS
+++ b/test/instrumentation/OWNERS
@@ -9,4 +9,3 @@ emeritus_approvers:
 - piosz
 labels:
 - sig/instrumentation
-- triage/needs-information

--- a/test/instrumentation/testdata/OWNERS
+++ b/test/instrumentation/testdata/OWNERS
@@ -6,4 +6,3 @@ reviewers:
 - sig-instrumentation-reviewers
 labels:
 - sig/instrumentation
-- triage/needs-information


### PR DESCRIPTION
Reverts https://github.com/kubernetes/kubernetes/pull/93156 and https://github.com/kubernetes/kubernetes/pull/93160

/kind cleanup

`triage/needs-information` can confuse contributors making them wonder if there is any additional thing needed from them on the PR (see [slack thread](https://kubernetes.slack.com/archives/C09R23FHP/p1595569101347900)). If a workaround is needed, let's discuss it with contribex first :) 

/assign @cblecker @mrbobbytables 
/sig contributor-experience

/assign @logicalhan @lavalamp 
/sig api-machinery

cc @MikeSpreitzer 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

