### PR TITLE
publishing: disallow specifying go version for master branch in rules

### DIFF
--- a/hack/verify-publishing-bot.py
+++ b/hack/verify-publishing-bot.py
@@ -86,6 +86,11 @@ def main():
         if branch["source"]["branch"] != "master":
             raise Exception("cannot find master source branch for destination %s" % rule["destination"])
 
+        # we specify the go version for all master branches through `default-go-version`
+        # so ensure we don't specify explicit go version for master branch in rules
+        if "go" in branch:
+            raise Exception("go version must not be specified for master branch for destination %s" % rule["destination"])
+
         print("processing : %s" % rule["destination"])
         if rule["destination"] not in gomod_dependencies:
             raise Exception("missing go.mod for %s" % rule["destination"])

--- a/staging/publishing/rules.yaml
+++ b/staging/publishing/rules.yaml
@@ -1640,7 +1640,6 @@ rules:
       branch: master
       dir: staging/src/k8s.io/controller-manager
     name: master
-    go: 1.13.9
   - source:
       branch: release-1.19
       dir: staging/src/k8s.io/controller-manager


### PR DESCRIPTION
The rules now use `default-go-version` at the top of the rules file
to define the go version used globally for all master branches.

https://github.com/kubernetes/kubernetes/blob/8a3fc2d7e2043bc980bb5301d2f4292020f1a2dd/staging/publishing/rules.yaml#L7

This PR adds a test to ensure that we don't specify a specific go
version for master branch in rules.yaml.

Note that this validation isn't added to publishing-bot directly because
we still want to give users of the publishing-bot the ability to specify
specific go versions for the master branch if they need, but we want to
explicitly disallow this for kubernetes repos.

Came across this at https://github.com/kubernetes/kubernetes/pull/91596#discussion_r459515581

/assign @dims 
/kind cleanup

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
