### PR TITLE
e2e: examples: fix test image reference

### DIFF
--- a/test/fixtures/doc-yaml/user-guide/secrets/secret-pod.yaml.in
+++ b/test/fixtures/doc-yaml/user-guide/secrets/secret-pod.yaml.in
@@ -5,8 +5,8 @@ metadata:
 spec:
   containers:
     - name: test-container
-      image: {{.MounttestImage}}
-      command: [ "/mounttest", "--file_content=/etc/secret-volume/data-1" ]
+      image: {{.AgnhostImage}}
+      args: [ "mounttest", "--file_content=/etc/secret-volume/data-1" ]
       volumeMounts:
           # name must match the volume name below
           - name: secret-volume


### PR DESCRIPTION
**What type of PR is this?**
/kind failing-test

**What this PR does / why we need it**:
https://github.com/kubernetes/kubernetes/pull/88248 switched to using agnhost image for all tests that use `mounttest`.  But one got left out leading to the following error:

```
[It] should create a pod that reads a secret [sig-node] [Suite:openshift/conformance/parallel] [Suite:k8s]
  @/k8s.io/kubernetes/test/e2e/examples.go:115
Jul 24 09:55:11.646: FAIL: Failed executing template: template: imagemanifest:8:15: executing "imagemanifest" at <.MounttestImage>: can't evaluate field MounttestImage in type common.testImagesStruct
```



**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
No

```release-note
None
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

/cc @sttts 
