### PR TITLE
scheduler.go: convert int to string properly

### DIFF
--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -22,6 +22,7 @@ import (
 	"io/ioutil"
 	"math/rand"
 	"os"
+	"strconv"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
@@ -613,7 +614,7 @@ func getAttemptsLabel(p *framework.QueuedPodInfo) string {
 	if p.Attempts >= 15 {
 		return "15+"
 	}
-	return string(p.Attempts)
+	return strconv.Itoa(p.Attempts)
 }
 
 func (sched *Scheduler) profileForPod(pod *v1.Pod) (*profile.Profile, error) {


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**: A `string` cannot be cast into an `int` just like that. This PR adds a `strconv.Itoa` to do this correctly.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/sig scheduling
/cc @ahg-g @alculquicondor 