### PR TITLE
Document the sources for the sourceIPs audit log field

### DIFF
--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -46051,7 +46051,7 @@ func schema_pkg_apis_audit_v1_Event(ref common.ReferenceCallback) common.OpenAPI
 					},
 					"sourceIPs": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Source IPs, from where the request originated and intermediate proxies.",
+							Description: "Source IPs, from where the request originated and intermediate proxies. The source IPs are listed from (in order): 1. X-Forwarded-For request header IPs 2. X-Real-Ip header, if not present in the X-Forwarded-For list 3. The remote address for the connection, if it doesn't match the last\n   IP in the list up to here (X-Forwarded-For or X-Real-Ip).\nNote: All but the last IP can be arbitrarily set by the client.",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{

--- a/staging/src/k8s.io/apiserver/pkg/apis/audit/types.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/audit/types.go
@@ -98,6 +98,12 @@ type Event struct {
 	// +optional
 	ImpersonatedUser *authnv1.UserInfo
 	// Source IPs, from where the request originated and intermediate proxies.
+	// The source IPs are listed from (in order):
+	// 1. X-Forwarded-For request header IPs
+	// 2. X-Real-Ip header, if not present in the X-Forwarded-For list
+	// 3. The remote address for the connection, if it doesn't match the last
+	//    IP in the list up to here (X-Forwarded-For or X-Real-Ip).
+	// Note: All but the last IP can be arbitrarily set by the client.
 	// +optional
 	SourceIPs []string
 	// UserAgent records the user agent string reported by the client.

--- a/staging/src/k8s.io/apiserver/pkg/apis/audit/v1/generated.proto
+++ b/staging/src/k8s.io/apiserver/pkg/apis/audit/v1/generated.proto
@@ -55,6 +55,12 @@ message Event {
   optional k8s.io.api.authentication.v1.UserInfo impersonatedUser = 7;
 
   // Source IPs, from where the request originated and intermediate proxies.
+  // The source IPs are listed from (in order):
+  // 1. X-Forwarded-For request header IPs
+  // 2. X-Real-Ip header, if not present in the X-Forwarded-For list
+  // 3. The remote address for the connection, if it doesn't match the last
+  //    IP in the list up to here (X-Forwarded-For or X-Real-Ip).
+  // Note: All but the last IP can be arbitrarily set by the client.
   // +optional
   repeated string sourceIPs = 8;
 

--- a/staging/src/k8s.io/apiserver/pkg/apis/audit/v1/types.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/audit/v1/types.go
@@ -91,6 +91,12 @@ type Event struct {
 	// +optional
 	ImpersonatedUser *authnv1.UserInfo `json:"impersonatedUser,omitempty" protobuf:"bytes,7,opt,name=impersonatedUser"`
 	// Source IPs, from where the request originated and intermediate proxies.
+	// The source IPs are listed from (in order):
+	// 1. X-Forwarded-For request header IPs
+	// 2. X-Real-Ip header, if not present in the X-Forwarded-For list
+	// 3. The remote address for the connection, if it doesn't match the last
+	//    IP in the list up to here (X-Forwarded-For or X-Real-Ip).
+	// Note: All but the last IP can be arbitrarily set by the client.
 	// +optional
 	SourceIPs []string `json:"sourceIPs,omitempty" protobuf:"bytes,8,rep,name=sourceIPs"`
 	// UserAgent records the user agent string reported by the client.


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
Update the doc comment on the `sourceIPs` audit log field to indicate the sources included in the list. See https://github.com/kubernetes/kubernetes/pull/87167.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/assign @mikedanese @deads2k 
/sig auth api-machinery
/priority important-longterm