### PR TITLE
Updating EndpointSliceMirroring controller to copy labels from Endpoints

### DIFF
--- a/pkg/controller/endpointslicemirroring/utils.go
+++ b/pkg/controller/endpointslicemirroring/utils.go
@@ -88,10 +88,7 @@ func newEndpointSlice(endpoints *corev1.Endpoints, ports []discovery.EndpointPor
 	ownerRef := metav1.NewControllerRef(endpoints, gvk)
 	epSlice := &discovery.EndpointSlice{
 		ObjectMeta: metav1.ObjectMeta{
-			Labels: map[string]string{
-				discovery.LabelServiceName: endpoints.Name,
-				discovery.LabelManagedBy:   controllerName,
-			},
+			Labels:          map[string]string{},
 			OwnerReferences: []metav1.OwnerReference{*ownerRef},
 			Namespace:       endpoints.Namespace,
 		},
@@ -99,6 +96,13 @@ func newEndpointSlice(endpoints *corev1.Endpoints, ports []discovery.EndpointPor
 		AddressType: addrType,
 		Endpoints:   []discovery.Endpoint{},
 	}
+
+	for label, val := range endpoints.Labels {
+		epSlice.Labels[label] = val
+	}
+
+	epSlice.Labels[discovery.LabelServiceName] = endpoints.Name
+	epSlice.Labels[discovery.LabelManagedBy] = controllerName
 
 	if sliceName == "" {
 		epSlice.GenerateName = getEndpointSlicePrefix(endpoints.Name)

--- a/pkg/controller/endpointslicemirroring/utils_test.go
+++ b/pkg/controller/endpointslicemirroring/utils_test.go
@@ -39,7 +39,11 @@ func TestNewEndpointSlice(t *testing.T) {
 	addrType := discovery.AddressTypeIPv4
 
 	endpoints := v1.Endpoints{
-		ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "test"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "foo",
+			Namespace: "test",
+			Labels:    map[string]string{"foo": "bar"},
+		},
 		Subsets: []v1.EndpointSubset{{
 			Ports: []v1.EndpointPort{{Port: 80}},
 		}},
@@ -51,6 +55,7 @@ func TestNewEndpointSlice(t *testing.T) {
 	expectedSlice := discovery.EndpointSlice{
 		ObjectMeta: metav1.ObjectMeta{
 			Labels: map[string]string{
+				"foo":                      "bar",
 				discovery.LabelServiceName: endpoints.Name,
 				discovery.LabelManagedBy:   controllerName,
 			},
@@ -65,6 +70,10 @@ func TestNewEndpointSlice(t *testing.T) {
 	generatedSlice := newEndpointSlice(&endpoints, ports, addrType, "")
 
 	assert.EqualValues(t, expectedSlice, *generatedSlice)
+
+	if len(endpoints.Labels) > 1 {
+		t.Errorf("Expected Endpoints labels to not be modified, got %+v", endpoints.Labels)
+	}
 }
 
 // Test helpers


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
The [KEP specifies](https://github.com/kubernetes/enhancements/blob/master/keps/sig-network/20190603-endpointslices/README.md#mirroring-details) that the controller will "mirror all labels from the Endpoints resource and all endpoints and ports from the corresponding subset". I'd missed that in my initial implementation, this should fix that.

**Special notes for your reviewer**:
I'm not a milestone maintainer, but it would be great to get this into 1.19 if anyone can add that to this PR.

**Does this PR introduce a user-facing change?**:
```release-note
EndpointSliceMirroring controller now copies labels from Endpoints to EndpointSlices.
```

/sig network
/priority important-soon
/assign @freehan