### PR TITLE
Add dependencycheck tool to address long running no-vendor-cycles test

### DIFF
--- a/cmd/BUILD
+++ b/cmd/BUILD
@@ -14,6 +14,7 @@ filegroup(
         "//cmd/clicheck:all-srcs",
         "//cmd/cloud-controller-manager:all-srcs",
         "//cmd/controller-manager/app:all-srcs",
+        "//cmd/dependencycheck:all-srcs",
         "//cmd/gendocs:all-srcs",
         "//cmd/genkubedocs:all-srcs",
         "//cmd/genman:all-srcs",

--- a/cmd/dependencycheck/BUILD
+++ b/cmd/dependencycheck/BUILD
@@ -1,0 +1,28 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["dependencycheck.go"],
+    importpath = "k8s.io/kubernetes/cmd/dependencycheck",
+    visibility = ["//visibility:private"],
+)
+
+go_binary(
+    name = "vendorcycle",
+    embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/cmd/dependencycheck/OWNERS
+++ b/cmd/dependencycheck/OWNERS
@@ -1,0 +1,8 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+reviewers:
+  - hasheddan
+approvers:
+  - bentheelder
+  - hasheddan
+  - liggitt

--- a/cmd/dependencycheck/dependencycheck.go
+++ b/cmd/dependencycheck/dependencycheck.go
@@ -1,0 +1,115 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Checks for restricted dependencies in go packages. Does not check transitive
+// dependencies implicitly, so they must be supplied in dependencies file if
+// they are to be evaluated.
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"log"
+	"regexp"
+)
+
+var (
+	exclude  = flag.String("exclude", "", "skip packages regex pattern (e.g. '^k8s.io/kubernetes/')")
+	restrict = flag.String("restrict", "", "restricted dependencies regex pattern (e.g. '^k8s.io/(apimachinery|client-go)/')")
+)
+
+type goPackage struct {
+	Name         string
+	ImportPath   string
+	Imports      []string
+	TestImports  []string
+	XTestImports []string
+}
+
+func main() {
+	flag.Parse()
+
+	args := flag.Args()
+
+	if len(args) != 1 {
+		log.Fatalf("usage: dependencycheck <json-dep-file> (e.g. 'go list -mod=vendor -test -deps -json ./vendor/...')")
+	}
+	if *restrict == "" {
+		log.Fatalf("Must specify restricted regex pattern")
+	}
+	depsPattern, err := regexp.Compile(*restrict)
+	if err != nil {
+		log.Fatalf("Error compiling restricted dependencies regex: %v", err)
+	}
+	var excludePattern *regexp.Regexp
+	if *exclude != "" {
+		excludePattern, err = regexp.Compile(*exclude)
+		if err != nil {
+			log.Fatalf("Error compiling excluded package regex: %v", err)
+		}
+	}
+	b, err := ioutil.ReadFile(args[0])
+	if err != nil {
+		log.Fatalf("Error reading dependencies file: %v", err)
+	}
+
+	packages := []goPackage{}
+	decoder := json.NewDecoder(bytes.NewBuffer(b))
+	for {
+		pkg := goPackage{}
+		if err := decoder.Decode(&pkg); err != nil {
+			if err == io.EOF {
+				break
+			}
+			log.Fatalf("Error unmarshaling dependencies file: %v", err)
+		}
+		packages = append(packages, pkg)
+	}
+
+	violations := map[string][]string{}
+	for _, p := range packages {
+		if excludePattern != nil && excludePattern.MatchString(p.ImportPath) {
+			continue
+		}
+		importViolations := []string{}
+		allImports := []string{}
+		allImports = append(allImports, p.Imports...)
+		allImports = append(allImports, p.TestImports...)
+		allImports = append(allImports, p.XTestImports...)
+		for _, i := range allImports {
+			if depsPattern.MatchString(i) {
+				importViolations = append(importViolations, i)
+			}
+		}
+		if len(importViolations) > 0 {
+			violations[p.ImportPath] = importViolations
+		}
+	}
+
+	if len(violations) > 0 {
+		for k, v := range violations {
+			fmt.Printf("Found dependency violations in package %s:\n", k)
+			for _, a := range v {
+				fmt.Println("--> " + a)
+			}
+		}
+		log.Fatal("Found restricted dependency violations in packages")
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind cleanup
> /kind flake

**What this PR does / why we need it**:

Adds a new tool, `dependencycheck`, to detect cyclical dependencies on main and staging repos in vendored packages. This is currently being handled by `hack/verify-no-vendor-cycles.sh`, which takes exceedingly long to run (3-4 minutes) for the task it is accomplishing. `dependencycheck` typically runs in a few seconds. In addition, when taking a look at the logs for `verify-master` and trying it out locally, I am not certain that this script is actually accomplishing its goal. For instance, if a package depended on `k8s.io/apimachinery/pkg/runtime`, it appears it is being printed as such, yet the script is checking for a match of `k8s.io/kubernetes/vendor/k8s.io` then `k8s.io/apimachinery`. I am guessing this may have to do with dependencies formerly being printed by their full path, but I am not sure. See more here: https://storage.googleapis.com/kubernetes-jenkins/logs/ci-kubernetes-verify-master/1287005337945116672/build-log.txt

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Ref: https://github.com/kubernetes/kubernetes/issues/87807 https://github.com/kubernetes/kubernetes/issues/92937

**Special notes for your reviewer**:

I wasn't sure who to add to the `OWNERS` file here so I just picked some of the usual suspects.

/cc @BenTheElder @dims @liggitt 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
