### PR TITLE
Do not create StatefulSet pods when PVC is being deleted

### DIFF
--- a/pkg/controller/statefulset/stateful_pod_control.go
+++ b/pkg/controller/statefulset/stateful_pod_control.go
@@ -181,7 +181,7 @@ func (spc *realStatefulPodControl) recordClaimEvent(verb string, set *apps.State
 func (spc *realStatefulPodControl) createPersistentVolumeClaims(set *apps.StatefulSet, pod *v1.Pod) error {
 	var errs []error
 	for _, claim := range getPersistentVolumeClaims(set, pod) {
-		_, err := spc.pvcLister.PersistentVolumeClaims(claim.Namespace).Get(claim.Name)
+		pvc, err := spc.pvcLister.PersistentVolumeClaims(claim.Namespace).Get(claim.Name)
 		switch {
 		case apierrors.IsNotFound(err):
 			_, err := spc.client.CoreV1().PersistentVolumeClaims(claim.Namespace).Create(context.TODO(), &claim, metav1.CreateOptions{})
@@ -194,6 +194,10 @@ func (spc *realStatefulPodControl) createPersistentVolumeClaims(set *apps.Statef
 		case err != nil:
 			errs = append(errs, fmt.Errorf("failed to retrieve PVC %s: %s", claim.Name, err))
 			spc.recordClaimEvent("create", set, pod, &claim, err)
+		case err == nil:
+			if pvc.DeletionTimestamp != nil {
+				errs = append(errs, fmt.Errorf("pvc %s is being deleted", claim.Name))
+			}
 		}
 		// TODO: Check resource requirements and accessmodes, update if necessary
 	}


### PR DESCRIPTION
This reopens #79164 and #83273 and similar PRs, as they have been ignored or closed w/o merging.
I have experienced the problem multiple times in our production clusters, and want to fix it.

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Pod with PVC will not be scheduled if the PVC is being deleted.
This can happen when the PVC has finalizers of storage plugins.

Such a pod becomes pending.  Unfortunately, after the finalizer
finishes and PVC is deleted, the pod remains pending forever.
The StatefulSet controller does nothing for this pending pod.

This commit prevents the StatefulSet controller from creating
such pods when PVC is to be deleted.

Reprocedure:

1. Create a single node cluster with [kind](https://github.com/kubernetes-sigs/kind).
2. Create a StatefulSet with the following manifests:

```yaml
apiVersion: v1
kind: Service
metadata:
  name: test
  namespace: default
spec:
  clusterIP: None
  selector:
    app: test
---
apiVersion: apps/v1
kind: StatefulSet
metadata:
  name: test
  namespace: default
spec:
  replicas: 1
  selector:
    matchLabels:
      app: test
  serviceName: test
  template:
    metadata:
      labels:
        app: test
    spec:
      containers:
      - command:
        - pause
        image: quay.io/cybozu/ubuntu:18.04
        name: ubuntu
        volumeMounts:
        - mountPath: /usr/share/nginx/html
          name: www
  volumeClaimTemplates:
  - metadata:
      name: www
    spec:
      accessModes:
      - ReadWriteOnce
      resources:
        requests:
          storage: 1Gi
      volumeMode: Filesystem
```

3. Once the pod gets running, edit PVC to add a finalizer `aaa.bbb/ccc`.
4. Run `kubectl delete --wait=false pvc/www-test-0`.
5. Run `kubectl delete --wait=false pods/test-0`.
6. See a new pod is created and become pending.
7. Edit the PVC to remove the `aaa.bbb/ccc` finalizer.
8. See the PVC is get deleted.
9. See the Pod remains pending forever.

**Does this PR introduce a user-facing change?**:
```release-note
Adding fix to the statefulset controller to wait for pvc deletion before creating pods.
```
