### PR TITLE
Automated cherry pick of #93316: Fix instance not found issues when an Azure Node is recreated

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_vmss.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_vmss.go
@@ -259,6 +259,13 @@ func (ss *scaleSet) getVmssVMByInstanceID(resourceGroup, scaleSetName, instanceI
 	if found && vm != nil {
 		return vm, nil
 	}
+	if found && vm == nil {
+		klog.V(2).Infof("Couldn't find VMSS VM with scaleSetName %q and instanceID %q, refreshing the cache if it is expired", scaleSetName, instanceID)
+		vm, found, err = getter(azcache.CacheReadTypeDefault)
+		if err != nil {
+			return nil, err
+		}
+	}
 	if !found || vm == nil {
 		return nil, cloudprovider.InstanceNotFound
 	}


### PR DESCRIPTION
Cherry pick of #93316 on release-1.18.

#93316: Fix instance not found issues when an Azure Node is recreated

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.