### PR TITLE
test: deflake TestRecycleSlices test

### DIFF
--- a/pkg/controller/endpointslicemirroring/reconciler_helpers_test.go
+++ b/pkg/controller/endpointslicemirroring/reconciler_helpers_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package endpointslicemirroring
 
 import (
+	"sort"
 	"testing"
 
 	discovery "k8s.io/api/discovery/v1beta1"
@@ -50,8 +51,8 @@ func TestRecycleSlices(t *testing.T) {
 		},
 		expectedSlices: &slicesByAction{
 			toUpdate: []*discovery.EndpointSlice{
-				simpleEndpointSlice("baz", "10.2.3.4", discovery.AddressTypeIPv4),
 				simpleEndpointSlice("bar", "10.1.2.3", discovery.AddressTypeIPv4),
+				simpleEndpointSlice("baz", "10.2.3.4", discovery.AddressTypeIPv4),
 			},
 		},
 	}, {
@@ -122,11 +123,19 @@ func TestRecycleSlices(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.testName, func(t *testing.T) {
-			recycleSlices(tc.startingSlices)
+			startingSlices := tc.startingSlices
+			recycleSlices(startingSlices)
 
-			expectEqualSlices(t, tc.startingSlices.toCreate, tc.expectedSlices.toCreate)
-			expectEqualSlices(t, tc.startingSlices.toUpdate, tc.expectedSlices.toUpdate)
-			expectEqualSlices(t, tc.startingSlices.toDelete, tc.expectedSlices.toDelete)
+			unorderedSlices := [][]*discovery.EndpointSlice{startingSlices.toCreate, startingSlices.toUpdate, startingSlices.toDelete}
+			for _, actual := range unorderedSlices {
+				sort.Slice(actual, func(i, j int) bool {
+					return actual[i].Name < actual[j].Name
+				})
+			}
+
+			expectEqualSlices(t, startingSlices.toCreate, tc.expectedSlices.toCreate)
+			expectEqualSlices(t, startingSlices.toUpdate, tc.expectedSlices.toUpdate)
+			expectEqualSlices(t, startingSlices.toDelete, tc.expectedSlices.toDelete)
 		})
 	}
 }


### PR DESCRIPTION
Signed-off-by: knight42 <anonymousknight96@gmail.com>

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature

/kind flake

**What this PR does / why we need it**:

sorts the endpoint slices by name in test `TestRecycleSlices`

**Which issue(s) this PR fixes**:

Fixes #93449 

**Special notes for your reviewer**:

ref: https://github.com/kubernetes/kubernetes/issues/93449#issuecomment-663940310

> @liggitt: looks like toCreateByAddrType is a map which doesn't have a defined iteration order, so the address family order of toUpdate is not well-defined
> https://github.com/kubernetes/kubernetes/blob/master/pkg/controller/endpointslicemirroring/reconciler_helpers.go#L108

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
