### PR TITLE
Categorize existing conformance tests as Base or Privileged

### DIFF
--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -1,6 +1,6 @@
 - testname: Pod Lifecycle, post start exec hook
   codename: '[k8s.io] Container Lifecycle Hook when create a pod with lifecycle hook
-    should execute poststart exec hook properly [NodeConformance] [Conformance]'
+    should execute poststart exec hook properly [NodeConformance] [Conformance] [Profile:Base]'
   description: When a post start handler is specified in the container lifecycle using
     a 'Exec' action, then the handler MUST be invoked after the start of the container.
     A server pod is created that will serve http requests, create a second pod with
@@ -10,7 +10,7 @@
   file: test/e2e/common/lifecycle_hook.go
 - testname: Pod Lifecycle, post start http hook
   codename: '[k8s.io] Container Lifecycle Hook when create a pod with lifecycle hook
-    should execute poststart http hook properly [NodeConformance] [Conformance]'
+    should execute poststart http hook properly [NodeConformance] [Conformance] [Profile:Base]'
   description: When a post start handler is specified in the container lifecycle using
     a HttpGet action, then the handler MUST be invoked after the start of the container.
     A server pod is created that will serve http requests, create a second pod with
@@ -20,7 +20,7 @@
   file: test/e2e/common/lifecycle_hook.go
 - testname: Pod Lifecycle, prestop exec hook
   codename: '[k8s.io] Container Lifecycle Hook when create a pod with lifecycle hook
-    should execute prestop exec hook properly [NodeConformance] [Conformance]'
+    should execute prestop exec hook properly [NodeConformance] [Conformance] [Profile:Base]'
   description: When a pre-stop handler is specified in the container lifecycle using
     a 'Exec' action, then the handler MUST be invoked before the container is terminated.
     A server pod is created that will serve http requests, create a second pod with
@@ -30,7 +30,7 @@
   file: test/e2e/common/lifecycle_hook.go
 - testname: Pod Lifecycle, prestop http hook
   codename: '[k8s.io] Container Lifecycle Hook when create a pod with lifecycle hook
-    should execute prestop http hook properly [NodeConformance] [Conformance]'
+    should execute prestop http hook properly [NodeConformance] [Conformance] [Profile:Base]'
   description: When a pre-stop handler is specified in the container lifecycle using
     a 'HttpGet' action, then the handler MUST be invoked before the container is terminated.
     A server pod is created that will serve http requests, create a second pod with
@@ -41,7 +41,7 @@
 - testname: Container Runtime, TerminationMessage, from log output of succeeding container
   codename: '[k8s.io] Container Runtime blackbox test on terminated container should
     report termination message [LinuxOnly] as empty when pod succeeds and TerminationMessagePolicy
-    FallbackToLogsOnError is set [NodeConformance] [Conformance]'
+    FallbackToLogsOnError is set [NodeConformance] [Conformance] [Profile:Base]'
   description: 'Create a pod with an container. Container''s output is recorded in
     log and container exits successfully without an error. When container is terminated,
     terminationMessage MUST have no content as container succeed. [LinuxOnly]: Cannot
@@ -51,7 +51,7 @@
 - testname: Container Runtime, TerminationMessage, from file of succeeding container
   codename: '[k8s.io] Container Runtime blackbox test on terminated container should
     report termination message [LinuxOnly] from file when pod succeeds and TerminationMessagePolicy
-    FallbackToLogsOnError is set [NodeConformance] [Conformance]'
+    FallbackToLogsOnError is set [NodeConformance] [Conformance] [Profile:Base]'
   description: 'Create a pod with an container. Container''s output is recorded in
     a file and the container exits successfully without an error. When container is
     terminated, terminationMessage MUST match with the content from file. [LinuxOnly]:
@@ -62,7 +62,7 @@
     failing container
   codename: '[k8s.io] Container Runtime blackbox test on terminated container should
     report termination message [LinuxOnly] from log output if TerminationMessagePolicy
-    FallbackToLogsOnError is set [NodeConformance] [Conformance]'
+    FallbackToLogsOnError is set [NodeConformance] [Conformance] [Profile:Base]'
   description: 'Create a pod with an container. Container''s output is recorded in
     log and container exits with an error. When container is terminated, termination
     message MUST match the expected output recorded from container''s log. [LinuxOnly]:
@@ -73,7 +73,7 @@
     path
   codename: '[k8s.io] Container Runtime blackbox test on terminated container should
     report termination message [LinuxOnly] if TerminationMessagePath is set as non-root
-    user and at a non-default path [NodeConformance] [Conformance]'
+    user and at a non-default path [NodeConformance] [Conformance] [Profile:Base]'
   description: 'Create a pod with a container to run it as a non-root user with a
     custom TerminationMessagePath set. Pod redirects the output to the provided path
     successfully. When the container is terminated, the termination message MUST match
@@ -83,7 +83,7 @@
   file: test/e2e/common/runtime.go
 - testname: Container Runtime, Restart Policy, Pod Phases
   codename: '[k8s.io] Container Runtime blackbox test when starting a container that
-    exits should run with the expected status [NodeConformance] [Conformance]'
+    exits should run with the expected status [NodeConformance] [Conformance] [Profile:Base]'
   description: If the restart policy is set to 'Always', Pod MUST be restarted when
     terminated, If restart policy is 'OnFailure', Pod MUST be started only if it is
     terminated with non-zero exit code. If the restart policy is 'Never', Pod MUST
@@ -93,7 +93,7 @@
   file: test/e2e/common/runtime.go
 - testname: Docker containers, with arguments
   codename: '[k8s.io] Docker Containers should be able to override the image''s default
-    arguments (docker cmd) [NodeConformance] [Conformance]'
+    arguments (docker cmd) [NodeConformance] [Conformance] [Profile:Base]'
   description: Default command and  from the docker image entrypoint MUST be used
     when Pod does not specify the container command but the arguments from Pod spec
     MUST override when specified.
@@ -101,7 +101,7 @@
   file: test/e2e/common/docker_containers.go
 - testname: Docker containers, with command
   codename: '[k8s.io] Docker Containers should be able to override the image''s default
-    command (docker entrypoint) [NodeConformance] [Conformance]'
+    command (docker entrypoint) [NodeConformance] [Conformance] [Profile:Base]'
   description: Default command from the docker image entrypoint MUST NOT be used when
     Pod specifies the container command.  Command from Pod spec MUST override the
     command in the image.
@@ -109,7 +109,7 @@
   file: test/e2e/common/docker_containers.go
 - testname: Docker containers, with command and arguments
   codename: '[k8s.io] Docker Containers should be able to override the image''s default
-    command and arguments [NodeConformance] [Conformance]'
+    command and arguments [NodeConformance] [Conformance] [Profile:Base]'
   description: Default command and arguments from the docker image entrypoint MUST
     NOT be used when Pod specifies the container command and arguments.  Command and
     arguments from Pod spec MUST override the command and arguments in the image.
@@ -117,14 +117,14 @@
   file: test/e2e/common/docker_containers.go
 - testname: Docker containers, without command and arguments
   codename: '[k8s.io] Docker Containers should use the image defaults if command and
-    args are blank [NodeConformance] [Conformance]'
+    args are blank [NodeConformance] [Conformance] [Profile:Base]'
   description: Default command and arguments from the docker image entrypoint MUST
     be used when Pod does not specify the container command
   release: v1.9
   file: test/e2e/common/docker_containers.go
 - testname: init-container-starts-app-restartalways-pod
   codename: '[k8s.io] InitContainer [NodeConformance] should invoke init containers
-    on a RestartAlways pod [Conformance]'
+    on a RestartAlways pod [Conformance] [Profile:Base]'
   description: Ensure that all InitContainers are started and all containers in pod
     started and at least one container is still running or is in the process of being
     restarted when Pod has restart policy as RestartAlways.
@@ -132,7 +132,7 @@
   file: test/e2e/common/init_container.go
 - testname: init-container-starts-app-restartnever-pod
   codename: '[k8s.io] InitContainer [NodeConformance] should invoke init containers
-    on a RestartNever pod [Conformance]'
+    on a RestartNever pod [Conformance] [Profile:Base]'
   description: Ensure that all InitContainers are started and all containers in pod
     are voluntarily terminated with exit status 0, and the system is not going to
     restart any of these containers when Pod has restart policy as RestartNever.
@@ -140,14 +140,14 @@
   file: test/e2e/common/init_container.go
 - testname: init-container-fails-stops-app-restartnever-pod
   codename: '[k8s.io] InitContainer [NodeConformance] should not start app containers
-    and fail the pod if init containers fail on a RestartNever pod [Conformance]'
+    and fail the pod if init containers fail on a RestartNever pod [Conformance] [Profile:Base]'
   description: Ensure that app container is not started when at least one InitContainer
     fails to start and Pod has restart policy as RestartNever.
   release: v1.12
   file: test/e2e/common/init_container.go
 - testname: init-container-fails-stops-app-restartalways-pod
   codename: '[k8s.io] InitContainer [NodeConformance] should not start app containers
-    if init containers fail on a RestartAlways pod [Conformance]'
+    if init containers fail on a RestartAlways pod [Conformance] [Profile:Base]'
   description: Ensure that app container is not started when all InitContainers failed
     to start and Pod has restarted for few occurrences and pod has restart policy
     as RestartAlways.
@@ -155,7 +155,7 @@
   file: test/e2e/common/init_container.go
 - testname: Kubelet, hostAliases
   codename: '[k8s.io] Kubelet when scheduling a busybox Pod with hostAliases should
-    write entries to /etc/hosts [LinuxOnly] [NodeConformance] [Conformance]'
+    write entries to /etc/hosts [LinuxOnly] [NodeConformance] [Conformance] [Profile:Base]'
   description: Create a Pod with hostAliases and a container with command to output
     /etc/hosts entries. Pod's logs MUST have matching entries of specified hostAliases
     to the output of /etc/hosts entries. Kubernetes mounts the /etc/hosts file into
@@ -165,28 +165,28 @@
   file: test/e2e/common/kubelet.go
 - testname: Kubelet, log output, default
   codename: '[k8s.io] Kubelet when scheduling a busybox command in a pod should print
-    the output to logs [NodeConformance] [Conformance]'
+    the output to logs [NodeConformance] [Conformance] [Profile:Base]'
   description: By default the stdout and stderr from the process being executed in
     a pod MUST be sent to the pod's logs.
   release: v1.13
   file: test/e2e/common/kubelet.go
 - testname: Kubelet, failed pod, delete
   codename: '[k8s.io] Kubelet when scheduling a busybox command that always fails
-    in a pod should be possible to delete [NodeConformance] [Conformance]'
+    in a pod should be possible to delete [NodeConformance] [Conformance] [Profile:Base]'
   description: Create a Pod with terminated state. This terminated pod MUST be able
     to be deleted.
   release: v1.13
   file: test/e2e/common/kubelet.go
 - testname: Kubelet, failed pod, terminated reason
   codename: '[k8s.io] Kubelet when scheduling a busybox command that always fails
-    in a pod should have an terminated reason [NodeConformance] [Conformance]'
+    in a pod should have an terminated reason [NodeConformance] [Conformance] [Profile:Base]'
   description: Create a Pod with terminated state. Pod MUST have only one container.
     Container MUST be in terminated state and MUST have an terminated reason.
   release: v1.13
   file: test/e2e/common/kubelet.go
 - testname: Kubelet, pod with read only root file system
   codename: '[k8s.io] Kubelet when scheduling a read only busybox container should
-    not write to root filesystem [LinuxOnly] [NodeConformance] [Conformance]'
+    not write to root filesystem [LinuxOnly] [NodeConformance] [Conformance] [Profile:Base]'
   description: Create a Pod with security context set with ReadOnlyRootFileSystem
     set to true. The Pod then tries to write to the /file on the root, write operation
     to the root filesystem MUST fail as expected. This test is marked LinuxOnly since
@@ -195,7 +195,7 @@
   file: test/e2e/common/kubelet.go
 - testname: Kubelet, managed etc hosts
   codename: '[k8s.io] KubeletManagedEtcHosts should test kubelet managed /etc/hosts
-    file [LinuxOnly] [NodeConformance] [Conformance]'
+    file [LinuxOnly] [NodeConformance] [Conformance] [Profile:Privileged]'
   description: Create a Pod with containers with hostNetwork set to false, one of
     the containers mounts the /etc/hosts file form the host. Create a second Pod with
     hostNetwork set to true. 1. The Pod with hostNetwork=false MUST have /etc/hosts
@@ -207,7 +207,7 @@
   release: v1.9
   file: test/e2e/common/kubelet_etc_hosts.go
 - testname: lease API should be available
-  codename: '[k8s.io] Lease lease API should be available [Conformance]'
+  codename: '[k8s.io] Lease lease API should be available [Conformance] [Profile:Base]'
   description: "Create Lease object, and get it; create and get MUST be successful
     and Spec of the read Lease MUST match Spec of original Lease. Update the Lease
     and get it; update and get MUST be successful\tand Spec of the read Lease MUST
@@ -222,14 +222,15 @@
   file: test/e2e/common/lease.go
 - testname: Pods, ActiveDeadlineSeconds
   codename: '[k8s.io] Pods should allow activeDeadlineSeconds to be updated [NodeConformance]
-    [Conformance]'
+    [Conformance] [Profile:Base]'
   description: Create a Pod with a unique label. Query for the Pod with the label
     as selector MUST be successful. The Pod is updated with ActiveDeadlineSeconds
     set on the Pod spec. Pod MUST terminate of the specified time elapses.
   release: v1.9
   file: test/e2e/common/pods.go
 - testname: Pods, lifecycle
-  codename: '[k8s.io] Pods should be submitted and removed [NodeConformance] [Conformance]'
+  codename: '[k8s.io] Pods should be submitted and removed [NodeConformance] [Conformance]
+    [Profile:Base]'
   description: A Pod is created with a unique label. Pod MUST be accessible when queried
     using the label selector upon creation. Add a watch, check if the Pod is running.
     Pod then deleted, The pod deletion timestamp is observed. The watch MUST return
@@ -238,7 +239,7 @@
   release: v1.9
   file: test/e2e/common/pods.go
 - testname: Pods, update
-  codename: '[k8s.io] Pods should be updated [NodeConformance] [Conformance]'
+  codename: '[k8s.io] Pods should be updated [NodeConformance] [Conformance] [Profile:Base]'
   description: Create a Pod with a unique label. Query for the Pod with the label
     as selector MUST be successful. Update the pod to change the value of the Label.
     Query for the Pod with the new value for the label MUST be successful.
@@ -249,7 +250,7 @@
   - pod/spec/label/patch
 - testname: Pods, service environment variables
   codename: '[k8s.io] Pods should contain environment variables for services [NodeConformance]
-    [Conformance]'
+    [Conformance] [Profile:Base]'
   description: Create a server Pod listening on port 9376. A Service called fooservice
     is created for the server Pod listening on port 8765 targeting port 8080. If a
     new Pod is created in the cluster then the Pod MUST have the fooservice environment
@@ -260,14 +261,14 @@
   release: v1.9
   file: test/e2e/common/pods.go
 - testname: Pods, assigned hostip
-  codename: '[k8s.io] Pods should get a host IP [NodeConformance] [Conformance]'
+  codename: '[k8s.io] Pods should get a host IP [NodeConformance] [Conformance] [Profile:Base]'
   description: Create a Pod. Pod status MUST return successfully and contains a valid
     IP address.
   release: v1.9
   file: test/e2e/common/pods.go
 - testname: Pods, remote command execution over websocket
   codename: '[k8s.io] Pods should support remote command execution over websockets
-    [NodeConformance] [Conformance]'
+    [NodeConformance] [Conformance] [Profile:Base]'
   description: A Pod is created. Websocket is created to retrieve exec command output
     from this pod. Message retrieved form Websocket MUST match with expected exec
     command output.
@@ -275,14 +276,14 @@
   file: test/e2e/common/pods.go
 - testname: Pods, logs from websockets
   codename: '[k8s.io] Pods should support retrieving logs from the container over
-    websockets [NodeConformance] [Conformance]'
+    websockets [NodeConformance] [Conformance] [Profile:Base]'
   description: A Pod is created. Websocket is created to retrieve log of a container
     from this pod. Message retrieved form Websocket MUST match with container's output.
   release: v1.13
   file: test/e2e/common/pods.go
 - testname: Pod liveness probe, using http endpoint, failure
   codename: '[k8s.io] Probing container should *not* be restarted with a /healthz
-    http liveness probe [NodeConformance] [Conformance]'
+    http liveness probe [NodeConformance] [Conformance] [Profile:Base]'
   description: A Pod is created with liveness probe on http endpoint '/'. Liveness
     probe on this endpoint will not fail. When liveness probe does not fail then the
     restart count MUST remain zero.
@@ -290,7 +291,7 @@
   file: test/e2e/common/container_probe.go
 - testname: Pod liveness probe, using local file, no restart
   codename: '[k8s.io] Probing container should *not* be restarted with a exec "cat
-    /tmp/health" liveness probe [NodeConformance] [Conformance]'
+    /tmp/health" liveness probe [NodeConformance] [Conformance] [Profile:Base]'
   description: Pod is created with liveness probe that uses 'exec' command to cat
     /temp/health file. Liveness probe MUST not fail to check health and the restart
     count should remain 0.
@@ -298,7 +299,7 @@
   file: test/e2e/common/container_probe.go
 - testname: Pod liveness probe, using tcp socket, no restart
   codename: '[k8s.io] Probing container should *not* be restarted with a tcp:8080
-    liveness probe [NodeConformance] [Conformance]'
+    liveness probe [NodeConformance] [Conformance] [Profile:Base]'
   description: A Pod is created with liveness probe on tcp socket 8080. The http handler
     on port 8080 will return http errors after 10 seconds, but the socket will remain
     open. Liveness probe MUST not fail to check health and the restart count should
@@ -307,7 +308,7 @@
   file: test/e2e/common/container_probe.go
 - testname: Pod liveness probe, using http endpoint, restart
   codename: '[k8s.io] Probing container should be restarted with a /healthz http liveness
-    probe [NodeConformance] [Conformance]'
+    probe [NodeConformance] [Conformance] [Profile:Base]'
   description: A Pod is created with liveness probe on http endpoint /healthz. The
     http handler on the /healthz will return a http error after 10 seconds since the
     Pod is started. This MUST result in liveness check failure. The Pod MUST now be
@@ -316,7 +317,7 @@
   file: test/e2e/common/container_probe.go
 - testname: Pod liveness probe, using local file, restart
   codename: '[k8s.io] Probing container should be restarted with a exec "cat /tmp/health"
-    liveness probe [NodeConformance] [Conformance]'
+    liveness probe [NodeConformance] [Conformance] [Profile:Base]'
   description: Create a Pod with liveness probe that uses ExecAction handler to cat
     /temp/health file. The Container deletes the file /temp/health after 10 second,
     triggering liveness probe to fail. The Pod MUST now be killed and restarted incrementing
@@ -325,7 +326,7 @@
   file: test/e2e/common/container_probe.go
 - testname: Pod liveness probe, using http endpoint, multiple restarts (slow)
   codename: '[k8s.io] Probing container should have monotonically increasing restart
-    count [NodeConformance] [Conformance]'
+    count [NodeConformance] [Conformance] [Profile:Base]'
   description: A Pod is created with liveness probe on http endpoint /healthz. The
     http handler on the /healthz will return a http error after 10 seconds since the
     Pod is started. This MUST result in liveness check failure. The Pod MUST now be
@@ -337,7 +338,7 @@
   file: test/e2e/common/container_probe.go
 - testname: Pod readiness probe, with initial delay
   codename: '[k8s.io] Probing container with readiness probe should not be ready before
-    initial delay and never restart [NodeConformance] [Conformance]'
+    initial delay and never restart [NodeConformance] [Conformance] [Profile:Base]'
   description: Create a Pod that is configured with a initial delay set on the readiness
     probe. Check the Pod Start time to compare to the initial delay. The Pod MUST
     be ready only after the specified initial delay.
@@ -345,7 +346,7 @@
   file: test/e2e/common/container_probe.go
 - testname: Pod readiness probe, failure
   codename: '[k8s.io] Probing container with readiness probe that fails should never
-    be ready and never restart [NodeConformance] [Conformance]'
+    be ready and never restart [NodeConformance] [Conformance] [Profile:Base]'
   description: Create a Pod with a readiness probe that fails consistently. When this
     Pod is created, then the Pod MUST never be ready, never be running and restart
     count MUST be zero.
@@ -353,7 +354,7 @@
   file: test/e2e/common/container_probe.go
 - testname: Security Context, runAsUser=65534
   codename: '[k8s.io] Security Context When creating a container with runAsUser should
-    run the container with uid 65534 [LinuxOnly] [NodeConformance] [Conformance]'
+    run the container with uid 65534 [LinuxOnly] [NodeConformance] [Conformance] [Profile:Base]'
   description: 'Container is created with runAsUser option by passing uid 65534 to
     run as unpriviledged user. Pod MUST be in Succeeded phase. [LinuxOnly]: This test
     is marked as LinuxOnly since Windows does not support running as UID / GID.'
@@ -361,7 +362,8 @@
   file: test/e2e/common/security_context.go
 - testname: Security Context, privileged=false.
   codename: '[k8s.io] Security Context When creating a pod with privileged should
-    run the container as unprivileged when false [LinuxOnly] [NodeConformance] [Conformance]'
+    run the container as unprivileged when false [LinuxOnly] [NodeConformance] [Conformance]
+    [Profile:Base]'
   description: 'Create a container to run in unprivileged mode by setting pod''s SecurityContext
     Privileged option as false. Pod MUST be in Succeeded phase. [LinuxOnly]: This
     test is marked as LinuxOnly since it runs a Linux-specific command.'
@@ -370,7 +372,7 @@
 - testname: Security Context, readOnlyRootFilesystem=false.
   codename: '[k8s.io] Security Context When creating a pod with readOnlyRootFilesystem
     should run the container with writable rootfs when readOnlyRootFilesystem=false
-    [NodeConformance] [Conformance]'
+    [NodeConformance] [Conformance] [Profile:Base]'
   description: Container is configured to run with readOnlyRootFilesystem to false.
     Write operation MUST be allowed and Pod MUST be in Succeeded state.
   release: v1.15
@@ -378,7 +380,7 @@
 - testname: Security Context, allowPrivilegeEscalation=false.
   codename: '[k8s.io] Security Context when creating containers with AllowPrivilegeEscalation
     should not allow privilege escalation when false [LinuxOnly] [NodeConformance]
-    [Conformance]'
+    [Conformance] [Profile:Base]'
   description: 'Configuring the allowPrivilegeEscalation to false, does not allow
     the privilege escalation operation. A container is configured with allowPrivilegeEscalation=false
     and a given uid (1000) which is not 0. When the container is run, container''s
@@ -389,14 +391,14 @@
   file: test/e2e/common/security_context.go
 - testname: Environment variables, expansion
   codename: '[k8s.io] Variable Expansion should allow composing env vars into new
-    env vars [NodeConformance] [Conformance]'
+    env vars [NodeConformance] [Conformance] [Profile:Base]'
   description: Create a Pod with environment variables. Environment variables defined
     using previously defined environment variables MUST expand to proper values.
   release: v1.9
   file: test/e2e/common/expansion.go
 - testname: Environment variables, command argument expansion
   codename: '[k8s.io] Variable Expansion should allow substituting values in a container''s
-    args [NodeConformance] [Conformance]'
+    args [NodeConformance] [Conformance] [Profile:Base]'
   description: Create a Pod with environment variables and container command arguments
     using them. Container command arguments using the  defined environment variables
     MUST expand to proper values.
@@ -404,7 +406,7 @@
   file: test/e2e/common/expansion.go
 - testname: Environment variables, command expansion
   codename: '[k8s.io] Variable Expansion should allow substituting values in a container''s
-    command [NodeConformance] [Conformance]'
+    command [NodeConformance] [Conformance] [Profile:Base]'
   description: Create a Pod with environment variables and container command using
     them. Container command using the  defined environment variables MUST expand to
     proper values.
@@ -412,28 +414,28 @@
   file: test/e2e/common/expansion.go
 - testname: VolumeSubpathEnvExpansion, subpath expansion
   codename: '[k8s.io] Variable Expansion should allow substituting values in a volume
-    subpath [sig-storage] [Conformance]'
+    subpath [sig-storage] [Conformance] [Profile:Base]'
   description: Make sure a container's subpath can be set using an expansion of environment
     variables.
   release: v1.19
   file: test/e2e/common/expansion.go
 - testname: VolumeSubpathEnvExpansion, subpath with absolute path
   codename: '[k8s.io] Variable Expansion should fail substituting values in a volume
-    subpath with absolute path [sig-storage][Slow] [Conformance]'
+    subpath with absolute path [sig-storage][Slow] [Conformance] [Profile:Base]'
   description: Make sure a container's subpath can not be set using an expansion of
     environment variables when absolute path is supplied.
   release: v1.19
   file: test/e2e/common/expansion.go
 - testname: VolumeSubpathEnvExpansion, subpath with backticks
   codename: '[k8s.io] Variable Expansion should fail substituting values in a volume
-    subpath with backticks [sig-storage][Slow] [Conformance]'
+    subpath with backticks [sig-storage][Slow] [Conformance] [Profile:Base]'
   description: Make sure a container's subpath can not be set using an expansion of
     environment variables when backticks are supplied.
   release: v1.19
   file: test/e2e/common/expansion.go
 - testname: VolumeSubpathEnvExpansion, subpath test writes
   codename: '[k8s.io] Variable Expansion should succeed in writing subpaths in container
-    [sig-storage][Slow] [Conformance]'
+    [sig-storage][Slow] [Conformance] [Profile:Base]'
   description: "Verify that a subpath expansion can be used to write files into subpaths.
     1.\tvalid subpathexpr starts a container running 2.\ttest for valid subpath writes
     3.\tsuccessful expansion of the subpathexpr isn't required for volume cleanup"
@@ -441,14 +443,15 @@
   file: test/e2e/common/expansion.go
 - testname: VolumeSubpathEnvExpansion, subpath ready from failed state
   codename: '[k8s.io] Variable Expansion should verify that a failing subpath expansion
-    can be modified during the lifecycle of a container [sig-storage][Slow] [Conformance]'
+    can be modified during the lifecycle of a container [sig-storage][Slow] [Conformance]
+    [Profile:Base]'
   description: Verify that a failing subpath expansion can be modified during the
     lifecycle of a container.
   release: v1.19
   file: test/e2e/common/expansion.go
 - testname: Pod events, verify event from Scheduler and Kubelet
   codename: '[k8s.io] [sig-node] Events should be sent by kubelets and the scheduler
-    about pods scheduling and running  [Conformance]'
+    about pods scheduling and running  [Conformance] [Profile:Base]'
   description: Create a Pod, make sure that the Pod can be queried. Create a event
     selector for the kind=Pod and the source is the Scheduler. List of the events
     MUST be at least one. Create a event selector for kind=Pod and the source is the
@@ -458,21 +461,22 @@
   file: test/e2e/node/events.go
 - testname: Pod Eviction, Toleration limits
   codename: '[k8s.io] [sig-node] NoExecuteTaintManager Multiple Pods [Serial] evicts
-    pods with minTolerationSeconds [Disruptive] [Conformance]'
+    pods with minTolerationSeconds [Disruptive] [Conformance] [Profile:Privileged]'
   description: In a multi-pods scenario with tolerationSeconds, the pods MUST be evicted
     as per the toleration time limit.
   release: v1.16
   file: test/e2e/node/taints.go
 - testname: Taint, Pod Eviction on taint removal
   codename: '[k8s.io] [sig-node] NoExecuteTaintManager Single Pod [Serial] removing
-    taint cancels eviction [Disruptive] [Conformance]'
+    taint cancels eviction [Disruptive] [Conformance] [Profile:Privileged]'
   description: The Pod with toleration timeout scheduled on a tainted Node MUST not
     be evicted if the taint is removed before toleration time ends.
   release: v1.16
   file: test/e2e/node/taints.go
 - testname: Pods, QOS
   codename: '[k8s.io] [sig-node] Pods Extended [k8s.io] Pods Set QOS Class should
-    be set on Pods with matching resource requests and limits for memory and cpu [Conformance]'
+    be set on Pods with matching resource requests and limits for memory and cpu [Conformance]
+    [Profile:Base]'
   description: Create a Pod with CPU and Memory request and limits. Pod status MUST
     have QOSClass set to PodQOSGuaranteed.
   release: v1.9
@@ -480,7 +484,8 @@
   behaviors:
   - pod/spec/container/resources
 - testname: Pods, prestop hook
-  codename: '[k8s.io] [sig-node] PreStop should call prestop when killing a pod  [Conformance]'
+  codename: '[k8s.io] [sig-node] PreStop should call prestop when killing a pod  [Conformance]
+    [Profile:Base]'
   description: Create a server pod with a rest endpoint '/write' that changes state.Received
     field. Create a Pod with a pre-stop handle that posts to the /write endpoint on
     the server Pod. Verify that the Pod with pre-stop hook is running. Delete the
@@ -491,7 +496,7 @@
   file: test/e2e/node/pre_stop.go
 - testname: Admission webhook, list mutating webhooks
   codename: '[sig-api-machinery] AdmissionWebhook [Privileged:ClusterAdmin] listing
-    mutating webhooks should work [Conformance]'
+    mutating webhooks should work [Conformance] [Profile:Privileged]'
   description: Create 10 mutating webhook configurations, all with a label. Attempt
     to list the webhook configurations matching the label; all the created webhook
     configurations MUST be present. Attempt to create an object; the object MUST be
@@ -502,7 +507,7 @@
   file: test/e2e/apimachinery/webhook.go
 - testname: Admission webhook, list validating webhooks
   codename: '[sig-api-machinery] AdmissionWebhook [Privileged:ClusterAdmin] listing
-    validating webhooks should work [Conformance]'
+    validating webhooks should work [Conformance] [Profile:Privileged]'
   description: Create 10 validating webhook configurations, all with a label. Attempt
     to list the webhook configurations matching the label; all the created webhook
     configurations MUST be present. Attempt to create an object; the create MUST be
@@ -513,7 +518,7 @@
   file: test/e2e/apimachinery/webhook.go
 - testname: Admission webhook, update mutating webhook
   codename: '[sig-api-machinery] AdmissionWebhook [Privileged:ClusterAdmin] patching/updating
-    a mutating webhook should work [Conformance]'
+    a mutating webhook should work [Conformance] [Profile:Privileged]'
   description: Register a mutating admission webhook configuration. Update the webhook
     to not apply to the create operation and attempt to create an object; the webhook
     MUST NOT mutate the object. Patch the webhook to apply to the create operation
@@ -522,7 +527,7 @@
   file: test/e2e/apimachinery/webhook.go
 - testname: Admission webhook, update validating webhook
   codename: '[sig-api-machinery] AdmissionWebhook [Privileged:ClusterAdmin] patching/updating
-    a validating webhook should work [Conformance]'
+    a validating webhook should work [Conformance] [Profile:Privileged]'
   description: Register a validating admission webhook configuration. Update the webhook
     to not apply to the create operation and attempt to create an object; the webhook
     MUST NOT deny the create. Patch the webhook to apply to the create operation again
@@ -531,14 +536,14 @@
   file: test/e2e/apimachinery/webhook.go
 - testname: Admission webhook, deny attach
   codename: '[sig-api-machinery] AdmissionWebhook [Privileged:ClusterAdmin] should
-    be able to deny attaching pod [Conformance]'
+    be able to deny attaching pod [Conformance] [Profile:Privileged]'
   description: Register an admission webhook configuration that denies connecting
     to a pod's attach sub-resource. Attempts to attach MUST be denied.
   release: v1.16
   file: test/e2e/apimachinery/webhook.go
 - testname: Admission webhook, deny custom resource create and delete
   codename: '[sig-api-machinery] AdmissionWebhook [Privileged:ClusterAdmin] should
-    be able to deny custom resource creation, update and deletion [Conformance]'
+    be able to deny custom resource creation, update and deletion [Conformance] [Profile:Privileged]'
   description: Register an admission webhook configuration that denies creation, update
     and deletion of custom resources. Attempts to create, update and delete custom
     resources MUST be denied.
@@ -546,7 +551,7 @@
   file: test/e2e/apimachinery/webhook.go
 - testname: Admission webhook, deny create
   codename: '[sig-api-machinery] AdmissionWebhook [Privileged:ClusterAdmin] should
-    be able to deny pod and configmap creation [Conformance]'
+    be able to deny pod and configmap creation [Conformance] [Profile:Privileged]'
   description: Register an admission webhook configuration that admits pod and configmap.
     Attempts to create non-compliant pods and configmaps, or update/patch compliant
     pods and configmaps to be non-compliant MUST be denied. An attempt to create a
@@ -557,14 +562,14 @@
   file: test/e2e/apimachinery/webhook.go
 - testname: Admission webhook, deny custom resource definition
   codename: '[sig-api-machinery] AdmissionWebhook [Privileged:ClusterAdmin] should
-    deny crd creation [Conformance]'
+    deny crd creation [Conformance] [Profile:Privileged]'
   description: Register a webhook that denies custom resource definition create. Attempt
     to create a custom resource definition; the create request MUST be denied.
   release: v1.16
   file: test/e2e/apimachinery/webhook.go
 - testname: Admission webhook, honor timeout
   codename: '[sig-api-machinery] AdmissionWebhook [Privileged:ClusterAdmin] should
-    honor timeout [Conformance]'
+    honor timeout [Conformance] [Profile:Privileged]'
   description: Using a webhook that waits 5 seconds before admitting objects, configure
     the webhook with combinations of timeouts and failure policy values. Attempt to
     create a config map with each combination. Requests MUST timeout if the configured
@@ -575,7 +580,7 @@
   file: test/e2e/apimachinery/webhook.go
 - testname: Admission webhook, discovery document
   codename: '[sig-api-machinery] AdmissionWebhook [Privileged:ClusterAdmin] should
-    include webhook resources in discovery documents [Conformance]'
+    include webhook resources in discovery documents [Conformance] [Profile:Privileged]'
   description: The admissionregistration.k8s.io API group MUST exists in the /apis
     discovery document. The admissionregistration.k8s.io/v1 API group/version MUST
     exists in the /apis discovery document. The mutatingwebhookconfigurations and
@@ -585,7 +590,7 @@
   file: test/e2e/apimachinery/webhook.go
 - testname: Admission webhook, ordered mutation
   codename: '[sig-api-machinery] AdmissionWebhook [Privileged:ClusterAdmin] should
-    mutate configmap [Conformance]'
+    mutate configmap [Conformance] [Profile:Privileged]'
   description: Register a mutating webhook configuration with two webhooks that admit
     configmaps, one that adds a data key if the configmap already has a specific key,
     and another that adds a key if the key added by the first webhook is present.
@@ -594,14 +599,14 @@
   file: test/e2e/apimachinery/webhook.go
 - testname: Admission webhook, mutate custom resource
   codename: '[sig-api-machinery] AdmissionWebhook [Privileged:ClusterAdmin] should
-    mutate custom resource [Conformance]'
+    mutate custom resource [Conformance] [Profile:Privileged]'
   description: Register a webhook that mutates a custom resource. Attempt to create
     custom resource object; the custom resource MUST be mutated.
   release: v1.16
   file: test/e2e/apimachinery/webhook.go
 - testname: Admission webhook, mutate custom resource with different stored version
   codename: '[sig-api-machinery] AdmissionWebhook [Privileged:ClusterAdmin] should
-    mutate custom resource with different stored version [Conformance]'
+    mutate custom resource with different stored version [Conformance] [Profile:Privileged]'
   description: Register a webhook that mutates custom resources on create and update.
     Register a custom resource definition using v1 as stored version. Create a custom
     resource. Patch the custom resource definition to use v2 as the stored version.
@@ -611,7 +616,7 @@
   file: test/e2e/apimachinery/webhook.go
 - testname: Admission webhook, mutate custom resource with pruning
   codename: '[sig-api-machinery] AdmissionWebhook [Privileged:ClusterAdmin] should
-    mutate custom resource with pruning [Conformance]'
+    mutate custom resource with pruning [Conformance] [Profile:Privileged]'
   description: Register mutating webhooks that adds fields to custom objects. Register
     a custom resource definition with a schema that includes only one of the data
     keys added by the webhooks. Attempt to a custom resource; the fields included
@@ -621,7 +626,7 @@
   file: test/e2e/apimachinery/webhook.go
 - testname: Admission webhook, mutation with defaulting
   codename: '[sig-api-machinery] AdmissionWebhook [Privileged:ClusterAdmin] should
-    mutate pod and apply defaults after mutation [Conformance]'
+    mutate pod and apply defaults after mutation [Conformance] [Profile:Privileged]'
   description: Register a mutating webhook that adds an InitContainer to pods. Attempt
     to create a pod; the InitContainer MUST be added the TerminationMessagePolicy
     MUST be defaulted.
@@ -630,7 +635,8 @@
 - testname: Admission webhook, admission control not allowed on webhook configuration
     objects
   codename: '[sig-api-machinery] AdmissionWebhook [Privileged:ClusterAdmin] should
-    not be able to mutate or prevent deletion of webhook configuration objects [Conformance]'
+    not be able to mutate or prevent deletion of webhook configuration objects [Conformance]
+    [Profile:Privileged]'
   description: Register webhooks that mutate and deny deletion of webhook configuration
     objects. Attempt to create and delete a webhook configuration object; both operations
     MUST be allowed and the webhook configuration object MUST NOT be mutated the webhooks.
@@ -638,7 +644,7 @@
   file: test/e2e/apimachinery/webhook.go
 - testname: Admission webhook, fail closed
   codename: '[sig-api-machinery] AdmissionWebhook [Privileged:ClusterAdmin] should
-    unconditionally reject operations on fail closed webhook [Conformance]'
+    unconditionally reject operations on fail closed webhook [Conformance] [Profile:Privileged]'
   description: Register a webhook with a fail closed policy and without CA bundle
     so that it cannot be called. Attempt operations that require the admission webhook;
     all MUST be denied.
@@ -646,14 +652,14 @@
   file: test/e2e/apimachinery/webhook.go
 - testname: aggregator-supports-the-sample-apiserver
   codename: '[sig-api-machinery] Aggregator Should be able to support the 1.17 Sample
-    API Server using the current Aggregator [Conformance]'
+    API Server using the current Aggregator [Conformance] [Profile:Privileged]'
   description: Ensure that the sample-apiserver code from 1.17 and compiled against
     1.17 will work on the current Aggregator/API-Server.
   release: ""
   file: test/e2e/apimachinery/aggregator.go
 - testname: Custom Resource Definition Conversion Webhook, convert mixed version list
   codename: '[sig-api-machinery] CustomResourceConversionWebhook [Privileged:ClusterAdmin]
-    should be able to convert a non homogeneous list of CRs [Conformance]'
+    should be able to convert a non homogeneous list of CRs [Conformance] [Profile:Privileged]'
   description: Register a conversion webhook and a custom resource definition. Create
     a custom resource stored at v1. Change the custom resource definition storage
     to v2. Create a custom resource stored at v2. Attempt to list the custom resources
@@ -662,14 +668,15 @@
   file: test/e2e/apimachinery/crd_conversion_webhook.go
 - testname: Custom Resource Definition Conversion Webhook, conversion custom resource
   codename: '[sig-api-machinery] CustomResourceConversionWebhook [Privileged:ClusterAdmin]
-    should be able to convert from CR v1 to CR v2 [Conformance]'
+    should be able to convert from CR v1 to CR v2 [Conformance] [Profile:Privileged]'
   description: Register a conversion webhook and a custom resource definition. Create
     a v1 custom resource. Attempts to read it at v2 MUST succeed.
   release: v1.16
   file: test/e2e/apimachinery/crd_conversion_webhook.go
 - testname: Custom Resource Definition, watch
   codename: '[sig-api-machinery] CustomResourceDefinition Watch [Privileged:ClusterAdmin]
-    CustomResourceDefinition Watch watch on custom resource definition objects [Conformance]'
+    CustomResourceDefinition Watch watch on custom resource definition objects [Conformance]
+    [Profile:Privileged]'
   description: Create a Custom Resource Definition. Attempt to watch it; the watch
     MUST observe create, modify and delete events.
   release: v1.16
@@ -677,7 +684,7 @@
 - testname: Custom Resource Definition, create
   codename: '[sig-api-machinery] CustomResourceDefinition resources [Privileged:ClusterAdmin]
     Simple CustomResourceDefinition creating/deleting custom resource definition objects
-    works  [Conformance]'
+    works  [Conformance] [Profile:Privileged]'
   description: Create a API extension client and define a random custom resource definition.
     Create the custom resource definition and then delete it. The creation and deletion
     MUST be successful.
@@ -686,7 +693,7 @@
 - testname: Custom Resource Definition, status sub-resource
   codename: '[sig-api-machinery] CustomResourceDefinition resources [Privileged:ClusterAdmin]
     Simple CustomResourceDefinition getting/updating/patching custom resource definition
-    status sub-resource works  [Conformance]'
+    status sub-resource works  [Conformance] [Profile:Privileged]'
   description: Create a custom resource definition. Attempt to read, update and patch
     its status sub-resource; all mutating sub-resource operations MUST be visible
     to subsequent reads.
@@ -694,7 +701,8 @@
   file: test/e2e/apimachinery/custom_resource_definition.go
 - testname: Custom Resource Definition, list
   codename: '[sig-api-machinery] CustomResourceDefinition resources [Privileged:ClusterAdmin]
-    Simple CustomResourceDefinition listing custom resource definition objects works  [Conformance]'
+    Simple CustomResourceDefinition listing custom resource definition objects works  [Conformance]
+    [Profile:Privileged]'
   description: Create a API extension client, define 10 labeled custom resource definitions
     and list them using a label selector; the list result MUST contain only the labeled
     custom resource definitions. Delete the labeled custom resource definitions via
@@ -704,7 +712,8 @@
   file: test/e2e/apimachinery/custom_resource_definition.go
 - testname: Custom Resource Definition, defaulting
   codename: '[sig-api-machinery] CustomResourceDefinition resources [Privileged:ClusterAdmin]
-    custom resource defaulting for requests and from storage works  [Conformance]'
+    custom resource defaulting for requests and from storage works  [Conformance]
+    [Profile:Privileged]'
   description: Create a custom resource definition without default. Create CR. Add
     default and read CR until the default is applied. Create another CR. Remove default,
     add default for another field and read CR until new field is defaulted, but old
@@ -713,7 +722,8 @@
   file: test/e2e/apimachinery/custom_resource_definition.go
 - testname: Custom Resource Definition, discovery
   codename: '[sig-api-machinery] CustomResourceDefinition resources [Privileged:ClusterAdmin]
-    should include custom resource definition resources in discovery documents [Conformance]'
+    should include custom resource definition resources in discovery documents [Conformance]
+    [Profile:Privileged]'
   description: Fetch /apis, /apis/apiextensions.k8s.io, and /apis/apiextensions.k8s.io/v1
     discovery documents, and ensure they indicate CustomResourceDefinition apiextensions.k8s.io/v1
     resources are available.
@@ -721,7 +731,8 @@
   file: test/e2e/apimachinery/custom_resource_definition.go
 - testname: Custom Resource OpenAPI Publish, stop serving version
   codename: '[sig-api-machinery] CustomResourcePublishOpenAPI [Privileged:ClusterAdmin]
-    removes definition from spec when one version gets changed to not be served [Conformance]'
+    removes definition from spec when one version gets changed to not be served [Conformance]
+    [Profile:Privileged]'
   description: Register a custom resource definition with multiple versions. OpenAPI
     definitions MUST be published for custom resource definitions. Update the custom
     resource definition to not serve one of the versions. OpenAPI definitions MUST
@@ -730,7 +741,7 @@
   file: test/e2e/apimachinery/crd_publish_openapi.go
 - testname: Custom Resource OpenAPI Publish, version rename
   codename: '[sig-api-machinery] CustomResourcePublishOpenAPI [Privileged:ClusterAdmin]
-    updates the published spec when one version gets renamed [Conformance]'
+    updates the published spec when one version gets renamed [Conformance] [Profile:Privileged]'
   description: Register a custom resource definition with multiple versions; OpenAPI
     definitions MUST be published for custom resource definitions. Rename one of the
     versions of the custom resource definition via a patch; OpenAPI definitions MUST
@@ -739,7 +750,7 @@
   file: test/e2e/apimachinery/crd_publish_openapi.go
 - testname: Custom Resource OpenAPI Publish, with x-preserve-unknown-fields at root
   codename: '[sig-api-machinery] CustomResourcePublishOpenAPI [Privileged:ClusterAdmin]
-    works for CRD preserving unknown fields at the schema root [Conformance]'
+    works for CRD preserving unknown fields at the schema root [Conformance] [Profile:Privileged]'
   description: Register a custom resource definition with x-preserve-unknown-fields
     in the schema root. Attempt to create and apply a change a custom resource, via
     kubectl; client-side validation MUST accept unknown properties. Attempt kubectl
@@ -749,7 +760,7 @@
 - testname: Custom Resource OpenAPI Publish, with x-preserve-unknown-fields in embedded
     object
   codename: '[sig-api-machinery] CustomResourcePublishOpenAPI [Privileged:ClusterAdmin]
-    works for CRD preserving unknown fields in an embedded object [Conformance]'
+    works for CRD preserving unknown fields in an embedded object [Conformance] [Profile:Privileged]'
   description: Register a custom resource definition with x-preserve-unknown-fields
     in an embedded object. Attempt to create and apply a change a custom resource,
     via kubectl; client-side validation MUST accept unknown properties. Attempt kubectl
@@ -759,7 +770,7 @@
   file: test/e2e/apimachinery/crd_publish_openapi.go
 - testname: Custom Resource OpenAPI Publish, with validation schema
   codename: '[sig-api-machinery] CustomResourcePublishOpenAPI [Privileged:ClusterAdmin]
-    works for CRD with validation schema [Conformance]'
+    works for CRD with validation schema [Conformance] [Profile:Privileged]'
   description: Register a custom resource definition with a validating schema consisting
     of objects, arrays and primitives. Attempt to create and apply a change a custom
     resource using valid properties, via kubectl; client-side validation MUST pass.
@@ -772,7 +783,7 @@
   file: test/e2e/apimachinery/crd_publish_openapi.go
 - testname: Custom Resource OpenAPI Publish, with x-preserve-unknown-fields in object
   codename: '[sig-api-machinery] CustomResourcePublishOpenAPI [Privileged:ClusterAdmin]
-    works for CRD without validation schema [Conformance]'
+    works for CRD without validation schema [Conformance] [Profile:Privileged]'
   description: Register a custom resource definition with x-preserve-unknown-fields
     in the top level object. Attempt to create and apply a change a custom resource,
     via kubectl; client-side validation MUST accept unknown properties. Attempt kubectl
@@ -781,14 +792,15 @@
   file: test/e2e/apimachinery/crd_publish_openapi.go
 - testname: Custom Resource OpenAPI Publish, varying groups
   codename: '[sig-api-machinery] CustomResourcePublishOpenAPI [Privileged:ClusterAdmin]
-    works for multiple CRDs of different groups [Conformance]'
+    works for multiple CRDs of different groups [Conformance] [Profile:Privileged]'
   description: Register multiple custom resource definitions spanning different groups
     and versions; OpenAPI definitions MUST be published for custom resource definitions.
   release: v1.16
   file: test/e2e/apimachinery/crd_publish_openapi.go
 - testname: Custom Resource OpenAPI Publish, varying kinds
   codename: '[sig-api-machinery] CustomResourcePublishOpenAPI [Privileged:ClusterAdmin]
-    works for multiple CRDs of same group and version but different kinds [Conformance]'
+    works for multiple CRDs of same group and version but different kinds [Conformance]
+    [Profile:Privileged]'
   description: Register multiple custom resource definitions in the same group and
     version but spanning different kinds; OpenAPI definitions MUST be published for
     custom resource definitions.
@@ -796,13 +808,14 @@
   file: test/e2e/apimachinery/crd_publish_openapi.go
 - testname: Custom Resource OpenAPI Publish, varying versions
   codename: '[sig-api-machinery] CustomResourcePublishOpenAPI [Privileged:ClusterAdmin]
-    works for multiple CRDs of same group but different versions [Conformance]'
+    works for multiple CRDs of same group but different versions [Conformance] [Profile:Privileged]'
   description: Register a custom resource definition with multiple versions; OpenAPI
     definitions MUST be published for custom resource definitions.
   release: v1.16
   file: test/e2e/apimachinery/crd_publish_openapi.go
 - testname: Event, delete a collection
-  codename: '[sig-api-machinery] Events should delete a collection of events [Conformance]'
+  codename: '[sig-api-machinery] Events should delete a collection of events [Conformance]
+    [Profile:Base]'
   description: A set of events is created with a label selector which MUST be found
     when listed. The set of events is deleted and MUST NOT show up when listed by
     its label selector.
@@ -810,7 +823,7 @@
   file: test/e2e/apimachinery/events.go
 - testname: Event resource lifecycle
   codename: '[sig-api-machinery] Events should ensure that an event can be fetched,
-    patched, deleted, and listed [Conformance]'
+    patched, deleted, and listed [Conformance] [Profile:Base]'
   description: Create an event, the event MUST exist. The event is patched with a
     new message, the check MUST have the update message. The event is deleted and
     MUST NOT show up when listing all events.
@@ -818,7 +831,7 @@
   file: test/e2e/apimachinery/events.go
 - testname: Garbage Collector, delete deployment,  propagation policy background
   codename: '[sig-api-machinery] Garbage collector should delete RS created by deployment
-    when not orphaning [Conformance]'
+    when not orphaning [Conformance] [Profile:Base]'
   description: Create a deployment with a replicaset. Once replicaset is created ,
     delete the deployment  with deleteOptions.PropagationPolicy set to Background.
     Deleting the deployment MUST delete the replicaset created by the deployment and
@@ -827,7 +840,7 @@
   file: test/e2e/apimachinery/garbage_collector.go
 - testname: Garbage Collector, delete replication controller, propagation policy background
   codename: '[sig-api-machinery] Garbage collector should delete pods created by rc
-    when not orphaning [Conformance]'
+    when not orphaning [Conformance] [Profile:Base]'
   description: Create a replication controller with 2 Pods. Once RC is created and
     the first Pod is created, delete RC with deleteOptions.PropagationPolicy set to
     Background. Deleting the Replication Controller MUST cause pods created by that
@@ -836,7 +849,7 @@
   file: test/e2e/apimachinery/garbage_collector.go
 - testname: Garbage Collector, delete replication controller, after owned pods
   codename: '[sig-api-machinery] Garbage collector should keep the rc around until
-    all its pods are deleted if the deleteOptions says so [Conformance]'
+    all its pods are deleted if the deleteOptions says so [Conformance] [Profile:Base]'
   description: Create a replication controller with maximum allocatable Pods between
     10 and 100 replicas. Once RC is created and the all Pods are created, delete RC
     with deleteOptions.PropagationPolicy set to Foreground. Deleting the Replication
@@ -845,7 +858,7 @@
   file: test/e2e/apimachinery/garbage_collector.go
 - testname: Garbage Collector, dependency cycle
   codename: '[sig-api-machinery] Garbage collector should not be blocked by dependency
-    circle [Conformance]'
+    circle [Conformance] [Profile:Base]'
   description: Create three pods, patch them with Owner references such that pod1
     has pod3, pod2 has pod1 and pod3 has pod2 as owner references respectively. Delete
     pod1 MUST delete all pods. The dependency cycle MUST not block the garbage collection.
@@ -853,7 +866,8 @@
   file: test/e2e/apimachinery/garbage_collector.go
 - testname: Garbage Collector, multiple owners
   codename: '[sig-api-machinery] Garbage collector should not delete dependents that
-    have both valid owner and owner that''s waiting for dependents to be deleted [Conformance]'
+    have both valid owner and owner that''s waiting for dependents to be deleted [Conformance]
+    [Profile:Base]'
   description: Create a replication controller RC1, with maximum allocatable Pods
     between 10 and 100 replicas. Create second replication controller RC2 and set
     RC2 as owner for half of those replicas. Once RC1 is created and the all Pods
@@ -865,7 +879,7 @@
   file: test/e2e/apimachinery/garbage_collector.go
 - testname: Garbage Collector, delete deployment, propagation policy orphan
   codename: '[sig-api-machinery] Garbage collector should orphan RS created by deployment
-    when deleteOptions.PropagationPolicy is Orphan [Conformance]'
+    when deleteOptions.PropagationPolicy is Orphan [Conformance] [Profile:Base]'
   description: Create a deployment with a replicaset. Once replicaset is created ,
     delete the deployment  with deleteOptions.PropagationPolicy set to Orphan. Deleting
     the deployment MUST cause the replicaset created by the deployment to be orphaned,
@@ -874,7 +888,7 @@
   file: test/e2e/apimachinery/garbage_collector.go
 - testname: Garbage Collector, delete replication controller, propagation policy orphan
   codename: '[sig-api-machinery] Garbage collector should orphan pods created by rc
-    if delete options say so [Conformance]'
+    if delete options say so [Conformance] [Profile:Base]'
   description: Create a replication controller with maximum allocatable Pods between
     10 and 100 replicas. Once RC is created and the all Pods are created, delete RC
     with deleteOptions.PropagationPolicy set to Orphan. Deleting the Replication Controller
@@ -883,27 +897,28 @@
   file: test/e2e/apimachinery/garbage_collector.go
 - testname: namespace-deletion-removes-pods
   codename: '[sig-api-machinery] Namespaces [Serial] should ensure that all pods are
-    removed when a namespace is deleted [Conformance]'
+    removed when a namespace is deleted [Conformance] [Profile:Base]'
   description: Ensure that if a namespace is deleted then all pods are removed from
     that namespace.
   release: ""
   file: test/e2e/apimachinery/namespace.go
 - testname: namespace-deletion-removes-services
   codename: '[sig-api-machinery] Namespaces [Serial] should ensure that all services
-    are removed when a namespace is deleted [Conformance]'
+    are removed when a namespace is deleted [Conformance] [Profile:Base]'
   description: Ensure that if a namespace is deleted then all services are removed
     from that namespace.
   release: ""
   file: test/e2e/apimachinery/namespace.go
 - testname: Namespace patching
-  codename: '[sig-api-machinery] Namespaces [Serial] should patch a Namespace [Conformance]'
+  codename: '[sig-api-machinery] Namespaces [Serial] should patch a Namespace [Conformance]
+    [Profile:Base]'
   description: A Namespace is created. The Namespace is patched. The Namespace and
     MUST now include the new Label.
   release: v1.18
   file: test/e2e/apimachinery/namespace.go
 - testname: ResourceQuota, update and delete
   codename: '[sig-api-machinery] ResourceQuota should be able to update and delete
-    ResourceQuota. [Conformance]'
+    ResourceQuota. [Conformance] [Profile:Privileged]'
   description: Create a ResourceQuota for CPU and Memory quota limits. Creation MUST
     be successful. When ResourceQuota is updated to modify CPU and Memory quota limits,
     update MUST succeed with updated values for CPU and Memory limits. When ResourceQuota
@@ -912,7 +927,7 @@
   file: test/e2e/apimachinery/resource_quota.go
 - testname: ResourceQuota, object count quota, configmap
   codename: '[sig-api-machinery] ResourceQuota should create a ResourceQuota and capture
-    the life of a configMap. [Conformance]'
+    the life of a configMap. [Conformance] [Profile:Privileged]'
   description: Create a ResourceQuota. Creation MUST be successful and its ResourceQuotaStatus
     MUST match to expected used and total allowed resource quota count within namespace.
     Create a ConfigMap. Its creation MUST be successful and resource usage count against
@@ -923,7 +938,7 @@
   file: test/e2e/apimachinery/resource_quota.go
 - testname: ResourceQuota, object count quota, pod
   codename: '[sig-api-machinery] ResourceQuota should create a ResourceQuota and capture
-    the life of a pod. [Conformance]'
+    the life of a pod. [Conformance] [Profile:Privileged]'
   description: Create a ResourceQuota. Creation MUST be successful and its ResourceQuotaStatus
     MUST match to expected used and total allowed resource quota count within namespace.
     Create a Pod with resource request count for CPU, Memory, EphemeralStorage and
@@ -939,7 +954,7 @@
   file: test/e2e/apimachinery/resource_quota.go
 - testname: ResourceQuota, object count quota, replicaSet
   codename: '[sig-api-machinery] ResourceQuota should create a ResourceQuota and capture
-    the life of a replica set. [Conformance]'
+    the life of a replica set. [Conformance] [Profile:Privileged]'
   description: Create a ResourceQuota. Creation MUST be successful and its ResourceQuotaStatus
     MUST match to expected used and total allowed resource quota count within namespace.
     Create a ReplicaSet. Its creation MUST be successful and resource usage count
@@ -950,7 +965,7 @@
   file: test/e2e/apimachinery/resource_quota.go
 - testname: ResourceQuota, object count quota, replicationController
   codename: '[sig-api-machinery] ResourceQuota should create a ResourceQuota and capture
-    the life of a replication controller. [Conformance]'
+    the life of a replication controller. [Conformance] [Profile:Privileged]'
   description: Create a ResourceQuota. Creation MUST be successful and its ResourceQuotaStatus
     MUST match to expected used and total allowed resource quota count within namespace.
     Create a ReplicationController. Its creation MUST be successful and resource usage
@@ -962,7 +977,7 @@
   file: test/e2e/apimachinery/resource_quota.go
 - testname: ResourceQuota, object count quota, secret
   codename: '[sig-api-machinery] ResourceQuota should create a ResourceQuota and capture
-    the life of a secret. [Conformance]'
+    the life of a secret. [Conformance] [Profile:Privileged]'
   description: Create a ResourceQuota. Creation MUST be successful and its ResourceQuotaStatus
     MUST match to expected used and total allowed resource quota count within namespace.
     Create a Secret. Its creation MUST be successful and resource usage count against
@@ -974,7 +989,7 @@
   file: test/e2e/apimachinery/resource_quota.go
 - testname: ResourceQuota, object count quota, service
   codename: '[sig-api-machinery] ResourceQuota should create a ResourceQuota and capture
-    the life of a service. [Conformance]'
+    the life of a service. [Conformance] [Profile:Privileged]'
   description: Create a ResourceQuota. Creation MUST be successful and its ResourceQuotaStatus
     MUST match to expected used and total allowed resource quota count within namespace.
     Create a Service. Its creation MUST be successful and resource usage count against
@@ -986,14 +1001,14 @@
   file: test/e2e/apimachinery/resource_quota.go
 - testname: ResourceQuota, object count quota, resourcequotas
   codename: '[sig-api-machinery] ResourceQuota should create a ResourceQuota and ensure
-    its status is promptly calculated. [Conformance]'
+    its status is promptly calculated. [Conformance] [Profile:Privileged]'
   description: Create a ResourceQuota. Creation MUST be successful and its ResourceQuotaStatus
     MUST match to expected used and total allowed resource quota count within namespace.
   release: v1.16
   file: test/e2e/apimachinery/resource_quota.go
 - testname: ResourceQuota, quota scope, BestEffort and NotBestEffort scope
   codename: '[sig-api-machinery] ResourceQuota should verify ResourceQuota with best
-    effort scope. [Conformance]'
+    effort scope. [Conformance] [Profile:Privileged]'
   description: Create two ResourceQuotas, one with 'BestEffort' scope and another
     with 'NotBestEffort' scope. Creation MUST be successful and their ResourceQuotaStatus
     MUST match to expected used and total allowed resource quota count within namespace.
@@ -1011,7 +1026,7 @@
   file: test/e2e/apimachinery/resource_quota.go
 - testname: ResourceQuota, quota scope, Terminating and NotTerminating scope
   codename: '[sig-api-machinery] ResourceQuota should verify ResourceQuota with terminating
-    scopes. [Conformance]'
+    scopes. [Conformance] [Profile:Privileged]'
   description: Create two ResourceQuotas, one with 'Terminating' scope and another
     'NotTerminating' scope. Request and the limit counts for CPU and Memory resources
     are set for the ResourceQuota. Creation MUST be successful and their ResourceQuotaStatus
@@ -1031,7 +1046,7 @@
   file: test/e2e/apimachinery/resource_quota.go
 - testname: Secrets, pod environment field
   codename: '[sig-api-machinery] Secrets should be consumable from pods in env vars
-    [NodeConformance] [Conformance]'
+    [NodeConformance] [Conformance] [Profile:Base]'
   description: Create a secret. Create a Pod with Container that declares a environment
     variable which references the secret created to extract a key value from the secret.
     Pod MUST have the environment variable that contains proper value for the key
@@ -1040,7 +1055,7 @@
   file: test/e2e/common/secrets.go
 - testname: Secrets, pod environment from source
   codename: '[sig-api-machinery] Secrets should be consumable via the environment
-    [NodeConformance] [Conformance]'
+    [NodeConformance] [Conformance] [Profile:Base]'
   description: Create a secret. Create a Pod with Container that declares a environment
     variable using 'EnvFrom' which references the secret created to extract a key
     value from the secret. Pod MUST have the environment variable that contains proper
@@ -1049,12 +1064,12 @@
   file: test/e2e/common/secrets.go
 - testname: Secrets, with empty-key
   codename: '[sig-api-machinery] Secrets should fail to create secret due to empty
-    secret key [Conformance]'
+    secret key [Conformance] [Profile:Base]'
   description: Attempt to create a Secret with an empty key. The creation MUST fail.
   release: v1.15
   file: test/e2e/common/secrets.go
 - testname: Secret patching
-  codename: '[sig-api-machinery] Secrets should patch a secret [Conformance]'
+  codename: '[sig-api-machinery] Secrets should patch a secret [Conformance] [Profile:Base]'
   description: A Secret is created. Listing all Secrets MUST return an empty list.
     Given the patching and fetching of the Secret, the fields MUST equal the new values.
     The Secret is deleted by it's static Label. Secrets are listed finally, the list
@@ -1063,14 +1078,14 @@
   file: test/e2e/common/secrets.go
 - testname: API metadata HTTP return
   codename: '[sig-api-machinery] Servers with support for Table transformation should
-    return a 406 for a backend which does not implement metadata [Conformance]'
+    return a 406 for a backend which does not implement metadata [Conformance] [Profile:Base]'
   description: Issue a HTTP request to the API. HTTP request MUST return a HTTP status
     code of 406.
   release: v1.16
   file: test/e2e/apimachinery/table_conversion.go
 - testname: watch-configmaps-closed-and-restarted
   codename: '[sig-api-machinery] Watchers should be able to restart watching from
-    the last resource version observed by the previous watch [Conformance]'
+    the last resource version observed by the previous watch [Conformance] [Profile:Base]'
   description: Ensure that a watch can be reopened from the last resource version
     observed by the previous watch, and it will continue delivering notifications
     from that point in time.
@@ -1078,14 +1093,14 @@
   file: test/e2e/apimachinery/watch.go
 - testname: watch-configmaps-from-resource-version
   codename: '[sig-api-machinery] Watchers should be able to start watching from a
-    specific resource version [Conformance]'
+    specific resource version [Conformance] [Profile:Base]'
   description: Ensure that a watch can be opened from a particular resource version
     in the past and only notifications happening after that resource version are observed.
   release: ""
   file: test/e2e/apimachinery/watch.go
 - testname: watch-configmaps-with-multiple-watchers
   codename: '[sig-api-machinery] Watchers should observe add, update, and delete watch
-    notifications on configmaps [Conformance]'
+    notifications on configmaps [Conformance] [Profile:Base]'
   description: Ensure that multiple watchers are able to receive all add, update,
     and delete notifications on configmaps that match a label selector and do not
     receive notifications for configmaps which do not match that label selector.
@@ -1093,7 +1108,7 @@
   file: test/e2e/apimachinery/watch.go
 - testname: watch-configmaps-label-changed
   codename: '[sig-api-machinery] Watchers should observe an object deletion if it
-    stops meeting the requirements of the selector [Conformance]'
+    stops meeting the requirements of the selector [Conformance] [Profile:Base]'
   description: Ensure that a watched object stops meeting the requirements of a watch's
     selector, the watch will observe a delete, and will not observe notifications
     for that object until it meets the selector's requirements again.
@@ -1101,7 +1116,7 @@
   file: test/e2e/apimachinery/watch.go
 - testname: watch-consistency
   codename: '[sig-api-machinery] Watchers should receive events on concurrent watches
-    in same order [Conformance]'
+    in same order [Conformance] [Profile:Base]'
   description: Ensure that concurrent watches are consistent with each other by initiating
     an additional watch for events received from the first watch, initiated at the
     resource version of the event, and checking that all resource versions of all
@@ -1109,33 +1124,36 @@
   release: v1.15
   file: test/e2e/apimachinery/watch.go
 - testname: Confirm a server version
-  codename: '[sig-api-machinery] server version should find the server version [Conformance]'
+  codename: '[sig-api-machinery] server version should find the server version [Conformance]
+    [Profile:Base]'
   description: Ensure that an API server version can be retrieved. Both the major
     and minor versions MUST only be an integer.
   release: v1.19
   file: test/e2e/apimachinery/server_version.go
 - testname: DaemonSet-FailedPodCreation
   codename: '[sig-apps] Daemon set [Serial] should retry creating failed daemon pods
-    [Conformance]'
+    [Conformance] [Profile:Base]'
   description: A conformant Kubernetes distribution MUST create new DaemonSet Pods
     when they fail.
   release: ""
   file: test/e2e/apps/daemon_set.go
 - testname: DaemonSet-Rollback
   codename: '[sig-apps] Daemon set [Serial] should rollback without unnecessary restarts
-    [Conformance]'
+    [Conformance] [Profile:Base]'
   description: A conformant Kubernetes distribution MUST support automated, minimally
     disruptive rollback of updates to a DaemonSet.
   release: ""
   file: test/e2e/apps/daemon_set.go
 - testname: DaemonSet-NodeSelection
-  codename: '[sig-apps] Daemon set [Serial] should run and stop complex daemon [Conformance]'
+  codename: '[sig-apps] Daemon set [Serial] should run and stop complex daemon [Conformance]
+    [Profile:Privileged]'
   description: A conformant Kubernetes distribution MUST support DaemonSet Pod node
     selection via label selectors.
   release: ""
   file: test/e2e/apps/daemon_set.go
 - testname: DaemonSet-Creation
-  codename: '[sig-apps] Daemon set [Serial] should run and stop simple daemon [Conformance]'
+  codename: '[sig-apps] Daemon set [Serial] should run and stop simple daemon [Conformance]
+    [Profile:Base]'
   description: A conformant Kubernetes distribution MUST support the creation of DaemonSets.
     When a DaemonSet Pod is deleted, the DaemonSet controller MUST create a replacement
     Pod.
@@ -1143,40 +1161,42 @@
   file: test/e2e/apps/daemon_set.go
 - testname: DaemonSet-RollingUpdate
   codename: '[sig-apps] Daemon set [Serial] should update pod when spec was updated
-    and update strategy is RollingUpdate [Conformance]'
+    and update strategy is RollingUpdate [Conformance] [Profile:Base]'
   description: A conformant Kubernetes distribution MUST support DaemonSet RollingUpdates.
   release: ""
   file: test/e2e/apps/daemon_set.go
 - testname: Deployment Recreate
   codename: '[sig-apps] Deployment RecreateDeployment should delete old pods and create
-    new ones [Conformance]'
+    new ones [Conformance] [Profile:Base]'
   description: A conformant Kubernetes distribution MUST support the Deployment with
     Recreate strategy.
   release: ""
   file: test/e2e/apps/deployment.go
 - testname: Deployment RollingUpdate
   codename: '[sig-apps] Deployment RollingUpdateDeployment should delete old pods
-    and create new ones [Conformance]'
+    and create new ones [Conformance] [Profile:Base]'
   description: A conformant Kubernetes distribution MUST support the Deployment with
     RollingUpdate strategy.
   release: ""
   file: test/e2e/apps/deployment.go
 - testname: Deployment RevisionHistoryLimit
-  codename: '[sig-apps] Deployment deployment should delete old replica sets [Conformance]'
+  codename: '[sig-apps] Deployment deployment should delete old replica sets [Conformance]
+    [Profile:Base]'
   description: A conformant Kubernetes distribution MUST clean up Deployment's ReplicaSets
     based on the Deployment's `.spec.revisionHistoryLimit`.
   release: ""
   file: test/e2e/apps/deployment.go
 - testname: Deployment Proportional Scaling
   codename: '[sig-apps] Deployment deployment should support proportional scaling
-    [Conformance]'
+    [Conformance] [Profile:Base]'
   description: A conformant Kubernetes distribution MUST support Deployment proportional
     scaling, i.e. proportionally scale a Deployment's ReplicaSets when a Deployment
     is scaled.
   release: ""
   file: test/e2e/apps/deployment.go
 - testname: Deployment Rollover
-  codename: '[sig-apps] Deployment deployment should support rollover [Conformance]'
+  codename: '[sig-apps] Deployment deployment should support rollover [Conformance]
+    [Profile:Base]'
   description: A conformant Kubernetes distribution MUST support Deployment rollover,
     i.e. allow arbitrary number of changes to desired state during rolling update
     before the rollout finishes.
@@ -1184,28 +1204,28 @@
   file: test/e2e/apps/deployment.go
 - testname: Jobs, orphan pods, re-adoption
   codename: '[sig-apps] Job should adopt matching orphans and release non-matching
-    pods [Conformance]'
+    pods [Conformance] [Profile:Base]'
   description: Create a parallel job. The number of Pods MUST equal the level of parallelism.
     Orphan a Pod by modifying its owner reference. The Job MUST re-adopt the orphan
     pod. Modify the labels of one of the Job's Pods. The Job MUST release the Pod.
   release: v1.16
   file: test/e2e/apps/job.go
 - testname: Jobs, active pods, graceful termination
-  codename: '[sig-apps] Job should delete a job [Conformance]'
+  codename: '[sig-apps] Job should delete a job [Conformance] [Profile:Base]'
   description: Create a job. Ensure the active pods reflect paralellism in the namespace
     and delete the job. Job MUST be deleted successfully.
   release: v1.15
   file: test/e2e/apps/job.go
 - testname: Jobs, completion after task failure
   codename: '[sig-apps] Job should run a job to completion when tasks sometimes fail
-    and are locally restarted [Conformance]'
+    and are locally restarted [Conformance] [Profile:Base]'
   description: Explicitly cause the tasks to fail once initially. After restarting,
     the Job MUST execute to completion.
   release: v1.16
   file: test/e2e/apps/job.go
 - testname: Replica Set, adopt matching pods and release non matching pods
   codename: '[sig-apps] ReplicaSet should adopt matching pods on creation and release
-    no longer matching pods [Conformance]'
+    no longer matching pods [Conformance] [Profile:Base]'
   description: A Pod is created, then a Replica Set (RS) whose label selector will
     match the Pod. The RS MUST either adopt the Pod or delete and replace it with
     a new Pod. When the labels on one of the Pods owned by the RS change to no longer
@@ -1215,14 +1235,14 @@
   file: test/e2e/apps/replica_set.go
 - testname: Replica Set, run basic image
   codename: '[sig-apps] ReplicaSet should serve a basic image on each replica with
-    a public image  [Conformance]'
+    a public image  [Conformance] [Profile:Base]'
   description: Create a ReplicaSet with a Pod and a single Container. Make sure that
     the Pod is running. Pod SHOULD send a valid response when queried.
   release: v1.9
   file: test/e2e/apps/replica_set.go
 - testname: Replication Controller, adopt matching pods
   codename: '[sig-apps] ReplicationController should adopt matching pods on creation
-    [Conformance]'
+    [Conformance] [Profile:Base]'
   description: An ownerless Pod is created, then a Replication Controller (RC) is
     created whose label selector will match the Pod. The RC MUST either adopt the
     Pod or delete and replace it with a new Pod
@@ -1230,7 +1250,7 @@
   file: test/e2e/apps/rc.go
 - testname: Replication Controller, release pods
   codename: '[sig-apps] ReplicationController should release no longer matching pods
-    [Conformance]'
+    [Conformance] [Profile:Base]'
   description: A Replication Controller (RC) is created, and its Pods are created.
     When the labels on one of the Pods change to no longer match the RC's label selector,
     the RC MUST release the Pod and update the Pod's owner references.
@@ -1238,7 +1258,7 @@
   file: test/e2e/apps/rc.go
 - testname: Replication Controller, run basic image
   codename: '[sig-apps] ReplicationController should serve a basic image on each replica
-    with a public image  [Conformance]'
+    with a public image  [Conformance] [Profile:Base]'
   description: Replication Controller MUST create a Pod with Basic Image and MUST
     run the service with the provided image. Image MUST be tested by dialing into
     the service listening through TCP, UDP and HTTP.
@@ -1246,14 +1266,15 @@
   file: test/e2e/apps/rc.go
 - testname: Replication Controller, check for issues like exceeding allocated quota
   codename: '[sig-apps] ReplicationController should surface a failure condition on
-    a common issue like exceeded quota [Conformance]'
+    a common issue like exceeded quota [Conformance] [Profile:Base]'
   description: Attempt to create a Replication Controller with pods exceeding the
     namespace quota. The creation MUST fail
   release: v1.15
   file: test/e2e/apps/rc.go
 - testname: StatefulSet, Burst Scaling
   codename: '[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
-    Burst scaling should run to completion even with unhealthy pods [Slow] [Conformance]'
+    Burst scaling should run to completion even with unhealthy pods [Slow] [Conformance]
+    [Profile:Base]'
   description: StatefulSet MUST support the Parallel PodManagementPolicy for burst
     scaling. This test does not depend on a preexisting default StorageClass or a
     dynamic provisioner.
@@ -1262,7 +1283,7 @@
 - testname: StatefulSet, Scaling
   codename: '[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
     Scaling should happen in predictable order and halt if any stateful pod is unhealthy
-    [Slow] [Conformance]'
+    [Slow] [Conformance] [Profile:Base]'
   description: StatefulSet MUST create Pods in ascending order by ordinal index when
     scaling up, and delete Pods in descending order when scaling down. Scaling up
     or down MUST pause if any Pods belonging to the StatefulSet are unhealthy. This
@@ -1271,7 +1292,7 @@
   file: test/e2e/apps/statefulset.go
 - testname: StatefulSet, Recreate Failed Pod
   codename: '[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
-    Should recreate evicted statefulset [Conformance]'
+    Should recreate evicted statefulset [Conformance] [Profile:Privileged]'
   description: StatefulSet MUST delete and recreate Pods it owns that go into a Failed
     state, such as when they are rejected or evicted by a Node. This test does not
     depend on a preexisting default StorageClass or a dynamic provisioner.
@@ -1279,7 +1300,7 @@
   file: test/e2e/apps/statefulset.go
 - testname: StatefulSet resource Replica scaling
   codename: '[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
-    should have a working scale subresource [Conformance]'
+    should have a working scale subresource [Conformance] [Profile:Base]'
   description: Create a StatefulSet resource. Newly created StatefulSet resource MUST
     have a scale of one. Bring the scale of the StatefulSet resource up to two. StatefulSet
     scale MUST be at two replicas.
@@ -1288,7 +1309,7 @@
 - testname: StatefulSet, Rolling Update with Partition
   codename: '[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
     should perform canary updates and phased rolling updates of template modifications
-    [Conformance]'
+    [Conformance] [Profile:Base]'
   description: StatefulSet's RollingUpdate strategy MUST support the Partition parameter
     for canaries and phased rollouts. If a Pod is deleted while a rolling update is
     in progress, StatefulSet MUST restore the Pod without violating the Partition.
@@ -1297,7 +1318,8 @@
   file: test/e2e/apps/statefulset.go
 - testname: StatefulSet, Rolling Update
   codename: '[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
-    should perform rolling updates and roll backs of template modifications [Conformance]'
+    should perform rolling updates and roll backs of template modifications [Conformance]
+    [Profile:Base]'
   description: StatefulSet MUST support the RollingUpdate strategy to automatically
     replace Pods one at a time when the Pod template changes. The StatefulSet's status
     MUST indicate the CurrentRevision and UpdateRevision. If the template is changed
@@ -1308,7 +1330,7 @@
   file: test/e2e/apps/statefulset.go
 - testname: CertificateSigningRequest API
   codename: '[sig-auth] Certificates API [Privileged:ClusterAdmin] should support
-    CSR API operations [Conformance]'
+    CSR API operations [Conformance] [Profile:Privileged]'
   description: ' The certificates.k8s.io API group MUST exists in the /apis discovery
     document. The certificates.k8s.io/v1 API group/version MUST exist in the /apis/certificates.k8s.io
     discovery document. The certificatesigningrequests, certificatesigningrequests/approval,
@@ -1320,7 +1342,8 @@
   release: v1.19
   file: test/e2e/auth/certificates.go
 - testname: Service account tokens auto mount optionally
-  codename: '[sig-auth] ServiceAccounts should allow opting out of API token automount  [Conformance]'
+  codename: '[sig-auth] ServiceAccounts should allow opting out of API token automount  [Conformance]
+    [Profile:Base]'
   description: Ensure that Service Account keys are mounted into the Pod only when
     AutoMountServiceToken is not set to false. We test the following scenarios here.
     1. Create Pod, Pod Spec has AutomountServiceAccountToken set to nil a) Service
@@ -1340,7 +1363,8 @@
   release: v1.9
   file: test/e2e/auth/service_accounts.go
 - testname: Service Account Tokens Must AutoMount
-  codename: '[sig-auth] ServiceAccounts should mount an API token into pods  [Conformance]'
+  codename: '[sig-auth] ServiceAccounts should mount an API token into pods  [Conformance]
+    [Profile:Base]'
   description: Ensure that Service Account keys are mounted into the Container. Pod
     contains three containers each will read Service Account token, root CA and default
     namespace respectively from the default API Token Mount path. All these three
@@ -1350,7 +1374,7 @@
   file: test/e2e/auth/service_accounts.go
 - testname: ServiceAccount lifecycle test
   codename: '[sig-auth] ServiceAccounts should run through the lifecycle of a ServiceAccount
-    [Conformance]'
+    [Conformance] [Profile:Base]'
   description: Creates a ServiceAccount with a static Label MUST be added as shown
     in watch event. Patching the ServiceAccount MUST return it's new property. Listing
     the ServiceAccounts MUST return the test ServiceAccount with it's patched values.
@@ -1359,7 +1383,7 @@
   file: test/e2e/auth/service_accounts.go
 - testname: Kubectl, guestbook application
   codename: '[sig-cli] Kubectl client Guestbook application should create and stop
-    a working application  [Conformance]'
+    a working application  [Conformance] [Profile:Base]'
   description: Create Guestbook application that contains an agnhost primary server,
     2 agnhost replicas, frontend application, frontend service and agnhost primary
     service and agnhost replica service. Using frontend service, the test will write
@@ -1370,21 +1394,21 @@
   file: test/e2e/kubectl/kubectl.go
 - testname: Kubectl, check version v1
   codename: '[sig-cli] Kubectl client Kubectl api-versions should check if v1 is in
-    available api versions  [Conformance]'
+    available api versions  [Conformance] [Profile:Base]'
   description: Run kubectl to get api versions, output MUST contain returned versions
     with 'v1' listed.
   release: v1.9
   file: test/e2e/kubectl/kubectl.go
 - testname: Kubectl, cluster info
   codename: '[sig-cli] Kubectl client Kubectl cluster-info should check if Kubernetes
-    master services is included in cluster-info  [Conformance]'
+    master services is included in cluster-info  [Conformance] [Profile:Base]'
   description: Call kubectl to get cluster-info, output MUST contain cluster-info
     returned and Kubernetes Master SHOULD be running.
   release: v1.9
   file: test/e2e/kubectl/kubectl.go
 - testname: Kubectl, describe pod or rc
   codename: '[sig-cli] Kubectl client Kubectl describe should check if kubectl describe
-    prints relevant information for rc and pods  [Conformance]'
+    prints relevant information for rc and pods  [Conformance] [Profile:Base]'
   description: Deploy an agnhost controller and an agnhost service. Kubectl describe
     pods SHOULD return the name, namespace, labels, state and other information as
     expected. Kubectl describe on rc, service, node and namespace SHOULD also return
@@ -1393,14 +1417,15 @@
   file: test/e2e/kubectl/kubectl.go
 - testname: Kubectl, diff Deployment
   codename: '[sig-cli] Kubectl client Kubectl diff should check if kubectl diff finds
-    a difference for Deployments [Conformance]'
+    a difference for Deployments [Conformance] [Profile:Base]'
   description: Create a Deployment with httpd image. Declare the same Deployment with
     a different image, busybox. Diff of live Deployment with declared Deployment MUST
     include the difference between live and declared image.
   release: v1.19
   file: test/e2e/kubectl/kubectl.go
 - testname: Kubectl, create service, replication controller
-  codename: '[sig-cli] Kubectl client Kubectl expose should create services for rc  [Conformance]'
+  codename: '[sig-cli] Kubectl client Kubectl expose should create services for rc  [Conformance]
+    [Profile:Base]'
   description: Create a Pod running agnhost listening to port 6379. Using kubectl
     expose the agnhost primary replication controllers at port 1234. Validate that
     the replication controller is listening on port 1234 and the target port is set
@@ -1410,7 +1435,8 @@
   release: v1.9
   file: test/e2e/kubectl/kubectl.go
 - testname: Kubectl, label update
-  codename: '[sig-cli] Kubectl client Kubectl label should update the label on a resource  [Conformance]'
+  codename: '[sig-cli] Kubectl client Kubectl label should update the label on a resource  [Conformance]
+    [Profile:Base]'
   description: When a Pod is running, update a Label using 'kubectl label' command.
     The label MUST be created in the Pod. A 'kubectl get pod' with -l option on the
     container MUST verify that the label can be read back. Use 'kubectl label label-'
@@ -1420,7 +1446,7 @@
   file: test/e2e/kubectl/kubectl.go
 - testname: Kubectl, logs
   codename: '[sig-cli] Kubectl client Kubectl logs should be able to retrieve and
-    filter logs  [Conformance]'
+    filter logs  [Conformance] [Profile:Base]'
   description: When a Pod is running then it MUST generate logs. Starting a Pod should
     have a expected log line. Also log command options MUST work as expected and described
     below. 'kubectl logs -tail=1' should generate a output of one line, the last line
@@ -1432,7 +1458,7 @@
   file: test/e2e/kubectl/kubectl.go
 - testname: Kubectl, patch to annotate
   codename: '[sig-cli] Kubectl client Kubectl patch should add annotations for pods
-    in rc  [Conformance]'
+    in rc  [Conformance] [Profile:Base]'
   description: Start running agnhost and a replication controller. When the pod is
     running, using 'kubectl patch' command add annotations. The annotation MUST be
     added to running pods and SHOULD be able to read added annotations from each of
@@ -1441,7 +1467,7 @@
   file: test/e2e/kubectl/kubectl.go
 - testname: Kubectl, replace
   codename: '[sig-cli] Kubectl client Kubectl replace should update a single-container
-    pod''s image  [Conformance]'
+    pod''s image  [Conformance] [Profile:Base]'
   description: Command 'kubectl replace' on a existing Pod with a new spec MUST update
     the image of the container running in the Pod. A -f option to 'kubectl replace'
     SHOULD force to re-create the resource. The new Pod SHOULD have the container
@@ -1450,7 +1476,7 @@
   file: test/e2e/kubectl/kubectl.go
 - testname: Kubectl, run pod
   codename: '[sig-cli] Kubectl client Kubectl run pod should create a pod from an
-    image when restart is Never  [Conformance]'
+    image when restart is Never  [Conformance] [Profile:Base]'
   description: Command 'kubectl run' MUST create a pod, when a image name is specified
     in the run command. After the run command there SHOULD be a pod that should exist
     with one container running the specified image.
@@ -1458,7 +1484,7 @@
   file: test/e2e/kubectl/kubectl.go
 - testname: Kubectl, server-side dry-run Pod
   codename: '[sig-cli] Kubectl client Kubectl server-side dry-run should check if
-    kubectl can dry-run update Pods [Conformance]'
+    kubectl can dry-run update Pods [Conformance] [Profile:Base]'
   description: The command 'kubectl run' must create a pod with the specified image
     name. After, the command 'kubectl replace --dry-run=server' should update the
     Pod with the new image name and server-side dry-run enabled. The image name must
@@ -1467,13 +1493,14 @@
   file: test/e2e/kubectl/kubectl.go
 - testname: Kubectl, version
   codename: '[sig-cli] Kubectl client Kubectl version should check is all data is
-    printed  [Conformance]'
+    printed  [Conformance] [Profile:Base]'
   description: The command 'kubectl version' MUST return the major, minor versions,  GitCommit,
     etc of the Client and the Server that the kubectl is configured to connect to.
   release: v1.9
   file: test/e2e/kubectl/kubectl.go
 - testname: Kubectl, proxy socket
-  codename: '[sig-cli] Kubectl client Proxy server should support --unix-socket=/path  [Conformance]'
+  codename: '[sig-cli] Kubectl client Proxy server should support --unix-socket=/path  [Conformance]
+    [Profile:Base]'
   description: Start a proxy server on by running 'kubectl proxy' with --unix-socket=<some
     path>. Call the proxy server by requesting api versions from  http://locahost:0/api.
     The proxy server MUST provide at least one version string
@@ -1481,7 +1508,7 @@
   file: test/e2e/kubectl/kubectl.go
 - testname: Kubectl, proxy port zero
   codename: '[sig-cli] Kubectl client Proxy server should support proxy with --port
-    0  [Conformance]'
+    0  [Conformance] [Profile:Base]'
   description: Start a proxy server on port zero by running 'kubectl proxy' with --port=0.
     Call the proxy server by requesting api versions from unix socket. The proxy server
     MUST provide at least one version string.
@@ -1489,14 +1516,15 @@
   file: test/e2e/kubectl/kubectl.go
 - testname: Kubectl, replication controller
   codename: '[sig-cli] Kubectl client Update Demo should create and stop a replication
-    controller  [Conformance]'
+    controller  [Conformance] [Profile:Base]'
   description: Create a Pod and a container with a given image. Configure replication
     controller to run 2 replicas. The number of running instances of the Pod MUST
     equal the number of replicas set on the replication controller which is 2.
   release: v1.9
   file: test/e2e/kubectl/kubectl.go
 - testname: Kubectl, scale replication controller
-  codename: '[sig-cli] Kubectl client Update Demo should scale a replication controller  [Conformance]'
+  codename: '[sig-cli] Kubectl client Update Demo should scale a replication controller  [Conformance]
+    [Profile:Base]'
   description: Create a Pod and a container with a given image. Configure replication
     controller to run 2 replicas. The number of running instances of the Pod MUST
     equal the number of replicas set on the replication controller which is 2. Update
@@ -1506,14 +1534,14 @@
   file: test/e2e/kubectl/kubectl.go
 - testname: New Event resource lifecycle, testing a list of events
   codename: '[sig-instrumentation] Events API should delete a collection of events
-    [Conformance]'
+    [Conformance] [Profile:Base]'
   description: Create a list of events, the events MUST exist. The events are deleted
     and MUST NOT show up when listing all events.
   release: v1.19
   file: test/e2e/instrumentation/events.go
 - testname: New Event resource lifecycle, testing a single event
   codename: '[sig-instrumentation] Events API should ensure that an event can be fetched,
-    patched, deleted, and listed [Conformance]'
+    patched, deleted, and listed [Conformance] [Profile:Base]'
   description: Create an event, the event MUST exist. The event is patched with a
     new note, the check MUST have the update note. The event is updated with a new
     series, the check MUST have the update series. The event is deleted and MUST NOT
@@ -1522,13 +1550,14 @@
   file: test/e2e/instrumentation/events.go
 - testname: DNS, cluster
   codename: '[sig-network] DNS should provide /etc/hosts entries for the cluster [LinuxOnly]
-    [Conformance]'
+    [Conformance] [Profile:Base]'
   description: When a Pod is created, the pod MUST be able to resolve cluster dns
     entries such as kubernetes.default via /etc/hosts.
   release: v1.14
   file: test/e2e/network/dns.go
 - testname: DNS, for ExternalName Services
-  codename: '[sig-network] DNS should provide DNS for ExternalName services [Conformance]'
+  codename: '[sig-network] DNS should provide DNS for ExternalName services [Conformance]
+    [Profile:Base]'
   description: Create a service with externalName. Pod MUST be able to resolve the
     address for this service via CNAME. When externalName of this service is changed,
     Pod MUST resolve to new DNS entry for the service. Change the service type from
@@ -1537,7 +1566,7 @@
   file: test/e2e/network/dns.go
 - testname: DNS, resolve the hostname
   codename: '[sig-network] DNS should provide DNS for pods for Hostname [LinuxOnly]
-    [Conformance]'
+    [Conformance] [Profile:Base]'
   description: Create a headless service with label. Create a Pod with label to match
     service's label, with hostname and a subdomain same as service name. Pod MUST
     be able to resolve its fully qualified domain name as well as hostname by serving
@@ -1545,7 +1574,8 @@
   release: v1.15
   file: test/e2e/network/dns.go
 - testname: DNS, resolve the subdomain
-  codename: '[sig-network] DNS should provide DNS for pods for Subdomain [Conformance]'
+  codename: '[sig-network] DNS should provide DNS for pods for Subdomain [Conformance]
+    [Profile:Base]'
   description: Create a headless service with label. Create a Pod with label to match
     service's label, with hostname and a subdomain same as service name. Pod MUST
     be able to resolve its fully qualified domain name as well as subdomain by serving
@@ -1553,7 +1583,7 @@
   release: v1.15
   file: test/e2e/network/dns.go
 - testname: DNS, services
-  codename: '[sig-network] DNS should provide DNS for services  [Conformance]'
+  codename: '[sig-network] DNS should provide DNS for services  [Conformance] [Profile:Base]'
   description: When a headless service is created, the service MUST be able to resolve
     all the required service endpoints. When the service is created, any pod in the
     same namespace must be able to resolve the service by all of the expected DNS
@@ -1561,14 +1591,14 @@
   release: v1.9
   file: test/e2e/network/dns.go
 - testname: DNS, cluster
-  codename: '[sig-network] DNS should provide DNS for the cluster  [Conformance]'
+  codename: '[sig-network] DNS should provide DNS for the cluster  [Conformance] [Profile:Base]'
   description: When a Pod is created, the pod MUST be able to resolve cluster dns
     entries such as kubernetes.default via DNS.
   release: v1.9
   file: test/e2e/network/dns.go
 - testname: DNS, PQDN for services
   codename: '[sig-network] DNS should resolve DNS of partial qualified names for services
-    [LinuxOnly] [Conformance]'
+    [LinuxOnly] [Conformance] [Profile:Base]'
   description: 'Create a headless service and normal service. Both the services MUST
     be able to resolve partial qualified DNS entries of their service endpoints by
     serving A records and SRV records. [LinuxOnly]: As Windows currently does not
@@ -1576,7 +1606,8 @@
   release: v1.17
   file: test/e2e/network/dns.go
 - testname: DNS, custom dnsConfig
-  codename: '[sig-network] DNS should support configurable pod DNS nameservers [Conformance]'
+  codename: '[sig-network] DNS should support configurable pod DNS nameservers [Conformance]
+    [Profile:Base]'
   description: Create a Pod with DNSPolicy as None and custom DNS configuration, specifying
     nameservers and search path entries. Pod creation MUST be successful and provided
     DNS configuration MUST be configured in the Pod.
@@ -1584,7 +1615,7 @@
   file: test/e2e/network/dns.go
 - testname: Ingress API
   codename: '[sig-network] Ingress API should support creating Ingress API operations
-    [Conformance]'
+    [Conformance] [Profile:Base]'
   description: ' The networking.k8s.io API group MUST exist in the /apis discovery
     document. The networking.k8s.io/v1 API group/version MUST exist in the /apis/networking.k8s.io
     discovery document. The ingresses resources MUST exist in the /apis/networking.k8s.io/v1
@@ -1595,7 +1626,7 @@
   file: test/e2e/network/ingress.go
 - testname: IngressClass API
   codename: '[sig-network] IngressClass API  should support creating IngressClass
-    API operations [Conformance]'
+    API operations [Conformance] [Profile:Base]'
   description: ' - The networking.k8s.io API group MUST exist in the /apis discovery
     document. - The networking.k8s.io/v1 API group/version MUST exist in the /apis/networking.k8s.io
     discovery document. - The ingressclasses resource MUST exist in the /apis/networking.k8s.io/v1
@@ -1605,7 +1636,7 @@
   file: test/e2e/network/ingressclass.go
 - testname: Networking, intra pod http
   codename: '[sig-network] Networking Granular Checks: Pods should function for intra-pod
-    communication: http [NodeConformance] [Conformance]'
+    communication: http [NodeConformance] [Conformance] [Profile:Base]'
   description: Create a hostexec pod that is capable of curl to netcat commands. Create
     a test Pod that will act as a webserver front end exposing ports 8080 for tcp
     and 8081 for udp. The netserver service proxies are created on specified number
@@ -1617,7 +1648,7 @@
   file: test/e2e/common/networking.go
 - testname: Networking, intra pod udp
   codename: '[sig-network] Networking Granular Checks: Pods should function for intra-pod
-    communication: udp [NodeConformance] [Conformance]'
+    communication: udp [NodeConformance] [Conformance] [Profile:Base]'
   description: Create a hostexec pod that is capable of curl to netcat commands. Create
     a test Pod that will act as a webserver front end exposing ports 8080 for tcp
     and 8081 for udp. The netserver service proxies are created on specified number
@@ -1629,7 +1660,7 @@
   file: test/e2e/common/networking.go
 - testname: Networking, intra pod http, from node
   codename: '[sig-network] Networking Granular Checks: Pods should function for node-pod
-    communication: http [LinuxOnly] [NodeConformance] [Conformance]'
+    communication: http [LinuxOnly] [NodeConformance] [Conformance] [Profile:Privileged]'
   description: Create a hostexec pod that is capable of curl to netcat commands. Create
     a test Pod that will act as a webserver front end exposing ports 8080 for tcp
     and 8081 for udp. The netserver service proxies are created on specified number
@@ -1643,7 +1674,7 @@
   file: test/e2e/common/networking.go
 - testname: Networking, intra pod http, from node
   codename: '[sig-network] Networking Granular Checks: Pods should function for node-pod
-    communication: udp [LinuxOnly] [NodeConformance] [Conformance]'
+    communication: udp [LinuxOnly] [NodeConformance] [Conformance] [Profile:Privileged]'
   description: Create a hostexec pod that is capable of curl to netcat commands. Create
     a test Pod that will act as a webserver front end exposing ports 8080 for tcp
     and 8081 for udp. The netserver service proxies are created on specified number
@@ -1656,13 +1687,15 @@
   release: v1.9
   file: test/e2e/common/networking.go
 - testname: Proxy, logs service endpoint
-  codename: '[sig-network] Proxy version v1 should proxy through a service and a pod  [Conformance]'
+  codename: '[sig-network] Proxy version v1 should proxy through a service and a pod  [Conformance]
+    [Profile:Base]'
   description: Select any node in the cluster to invoke  /logs endpoint  using the
     /nodes/proxy subresource from the kubelet port. This endpoint MUST be reachable.
   release: v1.9
   file: test/e2e/network/proxy.go
 - testname: Service endpoint latency, thresholds
-  codename: '[sig-network] Service endpoints latency should not be very high  [Conformance]'
+  codename: '[sig-network] Service endpoints latency should not be very high  [Conformance]
+    [Profile:Base]'
   description: Run 100 iterations of create service with the Pod running the pause
     image, measure the time it takes for creating the service and the endpoint with
     the service name is available. These durations are captured for 100 iterations,
@@ -1673,7 +1706,7 @@
   file: test/e2e/network/service_latency.go
 - testname: Service, change type, ClusterIP to ExternalName
   codename: '[sig-network] Services should be able to change the type from ClusterIP
-    to ExternalName [Conformance]'
+    to ExternalName [Conformance] [Profile:Base]'
   description: Create a service of type ClusterIP. Service creation MUST be successful
     by assigning ClusterIP to the service. Update service type from ClusterIP to ExternalName
     by setting CNAME entry as externalName. Service update MUST be successful and
@@ -1683,7 +1716,7 @@
   file: test/e2e/network/service.go
 - testname: Service, change type, ExternalName to ClusterIP
   codename: '[sig-network] Services should be able to change the type from ExternalName
-    to ClusterIP [Conformance]'
+    to ClusterIP [Conformance] [Profile:Base]'
   description: Create a service of type ExternalName, pointing to external DNS. ClusterIP
     MUST not be assigned to the service. Update the service from ExternalName to ClusterIP
     by removing ExternalName entry, assigning port 80 as service port and TCP as protocol.
@@ -1693,7 +1726,7 @@
   file: test/e2e/network/service.go
 - testname: Service, change type, ExternalName to NodePort
   codename: '[sig-network] Services should be able to change the type from ExternalName
-    to NodePort [Conformance]'
+    to NodePort [Conformance] [Profile:Base]'
   description: Create a service of type ExternalName, pointing to external DNS. ClusterIP
     MUST not be assigned to the service. Update the service from ExternalName to NodePort,
     assigning port 80 as service port and, TCP as protocol. service update MUST be
@@ -1705,7 +1738,7 @@
   file: test/e2e/network/service.go
 - testname: Service, change type, NodePort to ExternalName
   codename: '[sig-network] Services should be able to change the type from NodePort
-    to ExternalName [Conformance]'
+    to ExternalName [Conformance] [Profile:Base]'
   description: Create a service of type NodePort. Service creation MUST be successful
     by exposing service on every node's IP on dynamically assigned NodePort and, ClusterIP
     MUST be assigned to route service requests. Update the service type from NodePort
@@ -1717,7 +1750,7 @@
   file: test/e2e/network/service.go
 - testname: Service, NodePort Service
   codename: '[sig-network] Services should be able to create a functioning NodePort
-    service [Conformance]'
+    service [Conformance] [Profile:Base]'
   description: Create a TCP NodePort service, and test reachability from a client
     Pod. The client Pod MUST be able to access the NodePort service by service name
     and cluster IP on the service port, and on nodes' internal and external IPs on
@@ -1726,7 +1759,7 @@
   file: test/e2e/network/service.go
 - testname: Service, NodePort type, session affinity to None
   codename: '[sig-network] Services should be able to switch session affinity for
-    NodePort service [LinuxOnly] [Conformance]'
+    NodePort service [LinuxOnly] [Conformance] [Profile:Base]'
   description: 'Create a service of type "NodePort" and provide service port and protocol.
     Service''s sessionAffinity is set to "ClientIP". Service creation MUST be successful
     by assigning a "ClusterIP" to the service and allocating NodePort on all the nodes.
@@ -1744,7 +1777,7 @@
   file: test/e2e/network/service.go
 - testname: Service, ClusterIP type, session affinity to None
   codename: '[sig-network] Services should be able to switch session affinity for
-    service with type clusterIP [LinuxOnly] [Conformance]'
+    service with type clusterIP [LinuxOnly] [Conformance] [Profile:Base]'
   description: 'Create a service of type "ClusterIP". Service''s sessionAffinity is
     set to "ClientIP". Service creation MUST be successful by assigning "ClusterIP"
     to the service. Create a Replication Controller to ensure that 3 pods are running
@@ -1760,14 +1793,14 @@
   file: test/e2e/network/service.go
 - testname: Find Kubernetes Service in default Namespace
   codename: '[sig-network] Services should find a service from listing all namespaces
-    [Conformance]'
+    [Conformance] [Profile:Base]'
   description: List all Services in all Namespaces, response MUST include a Service
     named Kubernetes with the Namespace of default.
   release: v1.18
   file: test/e2e/network/service.go
 - testname: Service, NodePort type, session affinity to ClientIP with timeout
   codename: '[sig-network] Services should have session affinity timeout work for
-    NodePort service [LinuxOnly] [Conformance]'
+    NodePort service [LinuxOnly] [Conformance] [Profile:Base]'
   description: 'Create a service of type "NodePort" and provide service port and protocol.
     Service''s sessionAffinity is set to "ClientIP" and session affinity timeout is
     set. Service creation MUST be successful by assigning a "ClusterIP" to service
@@ -1784,7 +1817,7 @@
   file: test/e2e/network/service.go
 - testname: Service, ClusterIP type, session affinity to ClientIP with timeout
   codename: '[sig-network] Services should have session affinity timeout work for
-    service with type clusterIP [LinuxOnly] [Conformance]'
+    service with type clusterIP [LinuxOnly] [Conformance] [Profile:Base]'
   description: 'Create a service of type "ClusterIP". Service''s sessionAffinity is
     set to "ClientIP" and session affinity timeout is set. Service creation MUST be
     successful by assigning "ClusterIP" to the service. Create a Replication Controller
@@ -1799,7 +1832,7 @@
   file: test/e2e/network/service.go
 - testname: Service, NodePort type, session affinity to ClientIP
   codename: '[sig-network] Services should have session affinity work for NodePort
-    service [LinuxOnly] [Conformance]'
+    service [LinuxOnly] [Conformance] [Profile:Base]'
   description: 'Create a service of type "NodePort" and provide service port and protocol.
     Service''s sessionAffinity is set to "ClientIP". Service creation MUST be successful
     by assigning a "ClusterIP" to service and allocating NodePort on all nodes. Create
@@ -1814,7 +1847,7 @@
   file: test/e2e/network/service.go
 - testname: Service, ClusterIP type, session affinity to ClientIP
   codename: '[sig-network] Services should have session affinity work for service
-    with type clusterIP [LinuxOnly] [Conformance]'
+    with type clusterIP [LinuxOnly] [Conformance] [Profile:Base]'
   description: 'Create a service of type "ClusterIP". Service''s sessionAffinity is
     set to "ClientIP". Service creation MUST be successful by assigning "ClusterIP"
     to the service. Create a Replication Controller to ensure that 3 pods are running
@@ -1826,13 +1859,15 @@
   release: v1.19
   file: test/e2e/network/service.go
 - testname: Kubernetes Service
-  codename: '[sig-network] Services should provide secure master service  [Conformance]'
+  codename: '[sig-network] Services should provide secure master service  [Conformance]
+    [Profile:Base]'
   description: By default when a kubernetes cluster is running there MUST be a 'kubernetes'
     service running in the cluster.
   release: v1.9
   file: test/e2e/network/service.go
 - testname: Service, endpoints
-  codename: '[sig-network] Services should serve a basic endpoint from pods  [Conformance]'
+  codename: '[sig-network] Services should serve a basic endpoint from pods  [Conformance]
+    [Profile:Base]'
   description: Create a service with a endpoint without any Pods, the service MUST
     run and show empty endpoints. Add a pod to the service and the service MUST validate
     to show all the endpoints for the ports exposed by the Pod. Add another Pod then
@@ -1843,7 +1878,8 @@
   release: v1.9
   file: test/e2e/network/service.go
 - testname: Service, endpoints with multiple ports
-  codename: '[sig-network] Services should serve multiport endpoints from pods  [Conformance]'
+  codename: '[sig-network] Services should serve multiport endpoints from pods  [Conformance]
+    [Profile:Base]'
   description: Create a service with two ports but no Pods are added to the service
     yet.  The service MUST run and show empty set of endpoints. Add a Pod to the first
     port, service MUST list one endpoint for the Pod on that port. Add another Pod
@@ -1854,26 +1890,28 @@
   file: test/e2e/network/service.go
 - testname: ConfigMap, from environment field
   codename: '[sig-node] ConfigMap should be consumable via environment variable [NodeConformance]
-    [Conformance]'
+    [Conformance] [Profile:Base]'
   description: Create a Pod with an environment variable value set using a value from
     ConfigMap. A ConfigMap value MUST be accessible in the container environment.
   release: v1.9
   file: test/e2e/common/configmap.go
 - testname: ConfigMap, from environment variables
   codename: '[sig-node] ConfigMap should be consumable via the environment [NodeConformance]
-    [Conformance]'
+    [Conformance] [Profile:Base]'
   description: Create a Pod with a environment source from ConfigMap. All ConfigMap
     values MUST be available as environment variables in the container.
   release: v1.9
   file: test/e2e/common/configmap.go
 - testname: ConfigMap, with empty-key
-  codename: '[sig-node] ConfigMap should fail to create ConfigMap with empty key [Conformance]'
+  codename: '[sig-node] ConfigMap should fail to create ConfigMap with empty key [Conformance]
+    [Profile:Base]'
   description: Attempt to create a ConfigMap with an empty key. The creation MUST
     fail.
   release: v1.14
   file: test/e2e/common/configmap.go
 - testname: ConfigMap lifecycle
-  codename: '[sig-node] ConfigMap should run through a ConfigMap lifecycle [Conformance]'
+  codename: '[sig-node] ConfigMap should run through a ConfigMap lifecycle [Conformance]
+    [Profile:Base]'
   description: Attempt to create a ConfigMap. Patch the created ConfigMap. Fetching
     the ConfigMap MUST reflect changes. By fetching all the ConfigMaps via a Label
     selector it MUST find the ConfigMap by it's static label and updated value. The
@@ -1882,21 +1920,21 @@
   file: test/e2e/common/configmap.go
 - testname: DownwardAPI, environment for CPU and memory limits and requests
   codename: '[sig-node] Downward API should provide container''s limits.cpu/memory
-    and requests.cpu/memory as env vars [NodeConformance] [Conformance]'
+    and requests.cpu/memory as env vars [NodeConformance] [Conformance] [Profile:Base]'
   description: Downward API MUST expose CPU request and Memory request set through
     environment variables at runtime in the container.
   release: v1.9
   file: test/e2e/common/downward_api.go
 - testname: DownwardAPI, environment for default CPU and memory limits and requests
   codename: '[sig-node] Downward API should provide default limits.cpu/memory from
-    node allocatable [NodeConformance] [Conformance]'
+    node allocatable [NodeConformance] [Conformance] [Profile:Base]'
   description: Downward API MUST expose CPU request and Memory limits set through
     environment variables at runtime in the container.
   release: v1.9
   file: test/e2e/common/downward_api.go
 - testname: DownwardAPI, environment for host ip
   codename: '[sig-node] Downward API should provide host IP as an env var [NodeConformance]
-    [Conformance]'
+    [Conformance] [Profile:Base]'
   description: Downward API MUST expose Pod and Container fields as environment variables.
     Specify host IP as environment variable in the Pod Spec are visible at runtime
     in the container.
@@ -1904,28 +1942,30 @@
   file: test/e2e/common/downward_api.go
 - testname: DownwardAPI, environment for Pod UID
   codename: '[sig-node] Downward API should provide pod UID as env vars [NodeConformance]
-    [Conformance]'
+    [Conformance] [Profile:Base]'
   description: Downward API MUST expose Pod UID set through environment variables
     at runtime in the container.
   release: v1.9
   file: test/e2e/common/downward_api.go
 - testname: DownwardAPI, environment for name, namespace and ip
   codename: '[sig-node] Downward API should provide pod name, namespace and IP address
-    as env vars [NodeConformance] [Conformance]'
+    as env vars [NodeConformance] [Conformance] [Profile:Base]'
   description: Downward API MUST expose Pod and Container fields as environment variables.
     Specify Pod Name, namespace and IP as environment variable in the Pod Spec are
     visible at runtime in the container.
   release: v1.9
   file: test/e2e/common/downward_api.go
 - testname: PodTemplate, delete a collection
-  codename: '[sig-node] PodTemplates should delete a collection of pod templates [Conformance]'
+  codename: '[sig-node] PodTemplates should delete a collection of pod templates [Conformance]
+    [Profile:Base]'
   description: A set of Pod Templates is created with a label selector which MUST
     be found when listed. The set of Pod Templates is deleted and MUST NOT show up
     when listed by its label selector.
   release: v1.19
   file: test/e2e/common/podtemplates.go
 - testname: PodTemplate lifecycle
-  codename: '[sig-node] PodTemplates should run the lifecycle of PodTemplates [Conformance]'
+  codename: '[sig-node] PodTemplates should run the lifecycle of PodTemplates [Conformance]
+    [Profile:Base]'
   description: Attempt to create a PodTemplate. Patch the created PodTemplate. Fetching
     the PodTemplate MUST reflect changes. By fetching all the PodTemplates via a Label
     selector it MUST find the PodTemplate by it's static label and updated value.
@@ -1934,7 +1974,7 @@
   file: test/e2e/common/podtemplates.go
 - testname: LimitRange, resources
   codename: '[sig-scheduling] LimitRange should create a LimitRange with defaults
-    and ensure pod has those defaults applied. [Conformance]'
+    and ensure pod has those defaults applied. [Conformance] [Profile:Base]'
   description: Creating a Limitrange and verifying the creation of Limitrange, updating
     the Limitrange and validating the Limitrange. Creating Pods with resources and
     validate the pod resources are applied to the Limitrange
@@ -1942,13 +1982,13 @@
   file: test/e2e/scheduling/limit_range.go
 - testname: Scheduler, resource limits
   codename: '[sig-scheduling] SchedulerPredicates [Serial] validates resource limits
-    of pods that are allowed to run  [Conformance]'
+    of pods that are allowed to run  [Conformance] [Profile:Privileged]'
   description: Scheduling Pods MUST fail if the resource requests exceed Machine capacity.
   release: v1.9
   file: test/e2e/scheduling/predicates.go
 - testname: Scheduler, node selector matching
   codename: '[sig-scheduling] SchedulerPredicates [Serial] validates that NodeSelector
-    is respected if matching  [Conformance]'
+    is respected if matching  [Conformance] [Profile:Privileged]'
   description: 'Create a label on the node {k: v}. Then create a Pod with a NodeSelector
     set to {k: v}. Check to see if the Pod is scheduled. When the NodeSelector matches
     then Pod MUST be scheduled on that node.'
@@ -1956,7 +1996,7 @@
   file: test/e2e/scheduling/predicates.go
 - testname: Scheduler, node selector not matching
   codename: '[sig-scheduling] SchedulerPredicates [Serial] validates that NodeSelector
-    is respected if not matching  [Conformance]'
+    is respected if not matching  [Conformance] [Profile:Privileged]'
   description: Create a Pod with a NodeSelector set to a value that does not match
     a node in the cluster. Since there are no nodes matching the criteria the Pod
     MUST not be scheduled.
@@ -1966,7 +2006,7 @@
     default HostIP (0.0.0.0)
   codename: '[sig-scheduling] SchedulerPredicates [Serial] validates that there exists
     conflict between pods with same hostPort and protocol but one using 0.0.0.0 hostIP
-    [Conformance]'
+    [Conformance] [Profile:Privileged]'
   description: Pods with the same HostPort and Protocol, but different HostIPs, MUST
     NOT schedule to the same node if one of those IPs is the default HostIP of 0.0.0.0,
     which represents all IPs on the host.
@@ -1975,14 +2015,14 @@
 - testname: Scheduling, HostPort matching and HostIP and Protocol not-matching
   codename: '[sig-scheduling] SchedulerPredicates [Serial] validates that there is
     no conflict between pods with same hostPort but different hostIP and protocol
-    [Conformance]'
+    [Conformance] [Profile:Privileged]'
   description: Pods with the same HostPort value MUST be able to be scheduled to the
     same node if the HostIP or Protocol is different.
   release: v1.16
   file: test/e2e/scheduling/predicates.go
 - testname: Pod preemption verification
   codename: '[sig-scheduling] SchedulerPreemption [Serial] PreemptionExecutionPath
-    runs ReplicaSets to verify preemption running path [Conformance]'
+    runs ReplicaSets to verify preemption running path [Conformance] [Profile:Privileged]'
   description: Four levels of Pods in ReplicaSets with different levels of Priority,
     restricted by given CPU limits MUST launch. Priority 1 - 3 Pods MUST spawn first
     followed by Priority 4 Pod. The ReplicaSets with Replicas MUST contain the expected
@@ -1991,7 +2031,7 @@
   file: test/e2e/scheduling/preemption.go
 - testname: Scheduler, Basic Preemption
   codename: '[sig-scheduling] SchedulerPreemption [Serial] validates basic preemption
-    works [Conformance]'
+    works [Conformance] [Profile:Privileged]'
   description: When a higher priority pod is created and no node with enough resources
     is found, the scheduler MUST preempt a lower priority pod and schedule the high
     priority pod.
@@ -1999,7 +2039,7 @@
   file: test/e2e/scheduling/preemption.go
 - testname: Scheduler, Preemption for critical pod
   codename: '[sig-scheduling] SchedulerPreemption [Serial] validates lower priority
-    pod preemption by critical pod [Conformance]'
+    pod preemption by critical pod [Conformance] [Profile:Privileged]'
   description: When a critical pod is created and no node with enough resources is
     found, the scheduler MUST preempt a lower priority pod to schedule the critical
     pod.
@@ -2007,7 +2047,7 @@
   file: test/e2e/scheduling/preemption.go
 - testname: ConfigMap Volume, text data, binary data
   codename: '[sig-storage] ConfigMap binary data should be reflected in volume [NodeConformance]
-    [Conformance]'
+    [Conformance] [Profile:Base]'
   description: The ConfigMap that is created with text data and binary data MUST be
     accessible to read from the newly created Pod using the volume mount that is mapped
     to custom path in the Pod. ConfigMap's text data and binary data MUST be verified
@@ -2016,7 +2056,7 @@
   file: test/e2e/common/configmap_volume.go
 - testname: ConfigMap Volume, create, update and delete
   codename: '[sig-storage] ConfigMap optional updates should be reflected in volume
-    [NodeConformance] [Conformance]'
+    [NodeConformance] [Conformance] [Profile:Base]'
   description: The ConfigMap that is created MUST be accessible to read from the newly
     created Pod using the volume mount that is mapped to custom path in the Pod. When
     the config map is updated the change to the config map MUST be verified by reading
@@ -2026,7 +2066,7 @@
   file: test/e2e/common/configmap_volume.go
 - testname: ConfigMap Volume, without mapping
   codename: '[sig-storage] ConfigMap should be consumable from pods in volume [NodeConformance]
-    [Conformance]'
+    [Conformance] [Profile:Base]'
   description: Create a ConfigMap, create a Pod that mounts a volume and populates
     the volume with data stored in the ConfigMap. The ConfigMap that is created MUST
     be accessible to read from the newly created Pod using the volume mount. The data
@@ -2036,7 +2076,7 @@
   file: test/e2e/common/configmap_volume.go
 - testname: ConfigMap Volume, without mapping, non-root user
   codename: '[sig-storage] ConfigMap should be consumable from pods in volume as non-root
-    [NodeConformance] [Conformance]'
+    [NodeConformance] [Conformance] [Profile:Base]'
   description: Create a ConfigMap, create a Pod that mounts a volume and populates
     the volume with data stored in the ConfigMap. Pod is run as a non-root user with
     uid=1000. The ConfigMap that is created MUST be accessible to read from the newly
@@ -2046,7 +2086,7 @@
   file: test/e2e/common/configmap_volume.go
 - testname: ConfigMap Volume, without mapping, volume mode set
   codename: '[sig-storage] ConfigMap should be consumable from pods in volume with
-    defaultMode set [LinuxOnly] [NodeConformance] [Conformance]'
+    defaultMode set [LinuxOnly] [NodeConformance] [Conformance] [Profile:Base]'
   description: Create a ConfigMap, create a Pod that mounts a volume and populates
     the volume with data stored in the ConfigMap. File mode is changed to a custom
     value of '0x400'. The ConfigMap that is created MUST be accessible to read from
@@ -2058,7 +2098,7 @@
   file: test/e2e/common/configmap_volume.go
 - testname: ConfigMap Volume, with mapping
   codename: '[sig-storage] ConfigMap should be consumable from pods in volume with
-    mappings [NodeConformance] [Conformance]'
+    mappings [NodeConformance] [Conformance] [Profile:Base]'
   description: Create a ConfigMap, create a Pod that mounts a volume and populates
     the volume with data stored in the ConfigMap. Files are mapped to a path in the
     volume. The ConfigMap that is created MUST be accessible to read from the newly
@@ -2068,7 +2108,7 @@
   file: test/e2e/common/configmap_volume.go
 - testname: ConfigMap Volume, with mapping, volume mode set
   codename: '[sig-storage] ConfigMap should be consumable from pods in volume with
-    mappings and Item mode set [LinuxOnly] [NodeConformance] [Conformance]'
+    mappings and Item mode set [LinuxOnly] [NodeConformance] [Conformance] [Profile:Base]'
   description: Create a ConfigMap, create a Pod that mounts a volume and populates
     the volume with data stored in the ConfigMap. Files are mapped to a path in the
     volume. File mode is changed to a custom value of '0x400'. The ConfigMap that
@@ -2080,7 +2120,7 @@
   file: test/e2e/common/configmap_volume.go
 - testname: ConfigMap Volume, with mapping, non-root user
   codename: '[sig-storage] ConfigMap should be consumable from pods in volume with
-    mappings as non-root [NodeConformance] [Conformance]'
+    mappings as non-root [NodeConformance] [Conformance] [Profile:Base]'
   description: Create a ConfigMap, create a Pod that mounts a volume and populates
     the volume with data stored in the ConfigMap. Files are mapped to a path in the
     volume. Pod is run as a non-root user with uid=1000. The ConfigMap that is created
@@ -2090,7 +2130,7 @@
   file: test/e2e/common/configmap_volume.go
 - testname: ConfigMap Volume, multiple volume maps
   codename: '[sig-storage] ConfigMap should be consumable in multiple volumes in the
-    same pod [NodeConformance] [Conformance]'
+    same pod [NodeConformance] [Conformance] [Profile:Base]'
   description: The ConfigMap that is created MUST be accessible to read from the newly
     created Pod using the volume mount that is mapped to multiple paths in the Pod.
     The content MUST be accessible from all the mapped volume mounts.
@@ -2098,7 +2138,7 @@
   file: test/e2e/common/configmap_volume.go
 - testname: ConfigMap Volume, update
   codename: '[sig-storage] ConfigMap updates should be reflected in volume [NodeConformance]
-    [Conformance]'
+    [Conformance] [Profile:Base]'
   description: The ConfigMap that is created MUST be accessible to read from the newly
     created Pod using the volume mount that is mapped to custom path in the Pod. When
     the ConfigMap is updated the change to the config map MUST be verified by reading
@@ -2107,7 +2147,7 @@
   file: test/e2e/common/configmap_volume.go
 - testname: DownwardAPI volume, CPU limits
   codename: '[sig-storage] Downward API volume should provide container''s cpu limit
-    [NodeConformance] [Conformance]'
+    [NodeConformance] [Conformance] [Profile:Base]'
   description: A Pod is configured with DownwardAPIVolumeSource and DownwardAPIVolumeFiles
     contains a item for the CPU limits. The container runtime MUST be able to access
     CPU limits from the specified path on the mounted volume.
@@ -2115,7 +2155,7 @@
   file: test/e2e/common/downwardapi_volume.go
 - testname: DownwardAPI volume, CPU request
   codename: '[sig-storage] Downward API volume should provide container''s cpu request
-    [NodeConformance] [Conformance]'
+    [NodeConformance] [Conformance] [Profile:Base]'
   description: A Pod is configured with DownwardAPIVolumeSource and DownwardAPIVolumeFiles
     contains a item for the CPU request. The container runtime MUST be able to access
     CPU request from the specified path on the mounted volume.
@@ -2123,7 +2163,7 @@
   file: test/e2e/common/downwardapi_volume.go
 - testname: DownwardAPI volume, memory limits
   codename: '[sig-storage] Downward API volume should provide container''s memory
-    limit [NodeConformance] [Conformance]'
+    limit [NodeConformance] [Conformance] [Profile:Base]'
   description: A Pod is configured with DownwardAPIVolumeSource and DownwardAPIVolumeFiles
     contains a item for the memory limits. The container runtime MUST be able to access
     memory limits from the specified path on the mounted volume.
@@ -2131,7 +2171,7 @@
   file: test/e2e/common/downwardapi_volume.go
 - testname: DownwardAPI volume, memory request
   codename: '[sig-storage] Downward API volume should provide container''s memory
-    request [NodeConformance] [Conformance]'
+    request [NodeConformance] [Conformance] [Profile:Base]'
   description: A Pod is configured with DownwardAPIVolumeSource and DownwardAPIVolumeFiles
     contains a item for the memory request. The container runtime MUST be able to
     access memory request from the specified path on the mounted volume.
@@ -2139,7 +2179,7 @@
   file: test/e2e/common/downwardapi_volume.go
 - testname: DownwardAPI volume, CPU limit, default node allocatable
   codename: '[sig-storage] Downward API volume should provide node allocatable (cpu)
-    as default cpu limit if the limit is not set [NodeConformance] [Conformance]'
+    as default cpu limit if the limit is not set [NodeConformance] [Conformance] [Profile:Base]'
   description: A Pod is configured with DownwardAPIVolumeSource and DownwardAPIVolumeFiles
     contains a item for the CPU limits. CPU limits is not specified for the container.
     The container runtime MUST be able to access CPU limits from the specified path
@@ -2148,7 +2188,8 @@
   file: test/e2e/common/downwardapi_volume.go
 - testname: DownwardAPI volume, memory limit, default node allocatable
   codename: '[sig-storage] Downward API volume should provide node allocatable (memory)
-    as default memory limit if the limit is not set [NodeConformance] [Conformance]'
+    as default memory limit if the limit is not set [NodeConformance] [Conformance]
+    [Profile:Base]'
   description: A Pod is configured with DownwardAPIVolumeSource and DownwardAPIVolumeFiles
     contains a item for the memory limits. memory limits is not specified for the
     container. The container runtime MUST be able to access memory limits from the
@@ -2157,7 +2198,7 @@
   file: test/e2e/common/downwardapi_volume.go
 - testname: DownwardAPI volume, pod name
   codename: '[sig-storage] Downward API volume should provide podname only [NodeConformance]
-    [Conformance]'
+    [Conformance] [Profile:Base]'
   description: A Pod is configured with DownwardAPIVolumeSource and DownwardAPIVolumeFiles
     contains a item for the Pod name. The container runtime MUST be able to access
     Pod name from the specified path on the mounted volume.
@@ -2165,7 +2206,7 @@
   file: test/e2e/common/downwardapi_volume.go
 - testname: DownwardAPI volume, volume mode 0400
   codename: '[sig-storage] Downward API volume should set DefaultMode on files [LinuxOnly]
-    [NodeConformance] [Conformance]'
+    [NodeConformance] [Conformance] [Profile:Base]'
   description: A Pod is configured with DownwardAPIVolumeSource with the volumesource
     mode set to -r-------- and DownwardAPIVolumeFiles contains a item for the Pod
     name. The container runtime MUST be able to access Pod name from the specified
@@ -2175,7 +2216,7 @@
   file: test/e2e/common/downwardapi_volume.go
 - testname: DownwardAPI volume, file mode 0400
   codename: '[sig-storage] Downward API volume should set mode on item file [LinuxOnly]
-    [NodeConformance] [Conformance]'
+    [NodeConformance] [Conformance] [Profile:Base]'
   description: A Pod is configured with DownwardAPIVolumeSource and DownwardAPIVolumeFiles
     contains a item for the Pod name with the file mode set to -r--------. The container
     runtime MUST be able to access Pod name from the specified path on the mounted
@@ -2185,7 +2226,7 @@
   file: test/e2e/common/downwardapi_volume.go
 - testname: DownwardAPI volume, update annotations
   codename: '[sig-storage] Downward API volume should update annotations on modification
-    [NodeConformance] [Conformance]'
+    [NodeConformance] [Conformance] [Profile:Base]'
   description: A Pod is configured with DownwardAPIVolumeSource and DownwardAPIVolumeFiles
     contains list of items for each of the Pod annotations. The container runtime
     MUST be able to access Pod annotations from the specified path on the mounted
@@ -2195,7 +2236,7 @@
   file: test/e2e/common/downwardapi_volume.go
 - testname: DownwardAPI volume, update label
   codename: '[sig-storage] Downward API volume should update labels on modification
-    [NodeConformance] [Conformance]'
+    [NodeConformance] [Conformance] [Profile:Base]'
   description: A Pod is configured with DownwardAPIVolumeSource and DownwardAPIVolumeFiles
     contains list of items for each of the Pod labels. The container runtime MUST
     be able to access Pod labels from the specified path on the mounted volume. Update
@@ -2205,7 +2246,7 @@
   file: test/e2e/common/downwardapi_volume.go
 - testname: EmptyDir, Shared volumes between containers
   codename: '[sig-storage] EmptyDir volumes pod should support shared volumes between
-    containers [Conformance]'
+    containers [Conformance] [Profile:Base]'
   description: A Pod created with an 'emptyDir' Volume, should share volumes between
     the containeres in the pod. The two busybox image containers shoud share the volumes
     mounted to the pod. The main container shoud wait until the sub container drops
@@ -2214,7 +2255,7 @@
   file: test/e2e/common/empty_dir.go
 - testname: EmptyDir, medium default, volume mode 0644
   codename: '[sig-storage] EmptyDir volumes should support (non-root,0644,default)
-    [LinuxOnly] [NodeConformance] [Conformance]'
+    [LinuxOnly] [NodeConformance] [Conformance] [Profile:Base]'
   description: A Pod created with an 'emptyDir' Volume, the volume mode set to 0644.
     Volume is mounted into the container where container is run as a non-root user.
     The volume MUST have mode -rw-r--r-- and mount type set to tmpfs and the contents
@@ -2224,7 +2265,7 @@
   file: test/e2e/common/empty_dir.go
 - testname: EmptyDir, medium memory, volume mode 0644, non-root user
   codename: '[sig-storage] EmptyDir volumes should support (non-root,0644,tmpfs) [LinuxOnly]
-    [NodeConformance] [Conformance]'
+    [NodeConformance] [Conformance] [Profile:Base]'
   description: A Pod created with an 'emptyDir' Volume and 'medium' as 'Memory', the
     volume mode set to 0644. Volume is mounted into the container where container
     is run as a non-root user. The volume MUST have mode -rw-r--r-- and mount type
@@ -2235,7 +2276,7 @@
   file: test/e2e/common/empty_dir.go
 - testname: EmptyDir, medium default, volume mode 0666
   codename: '[sig-storage] EmptyDir volumes should support (non-root,0666,default)
-    [LinuxOnly] [NodeConformance] [Conformance]'
+    [LinuxOnly] [NodeConformance] [Conformance] [Profile:Base]'
   description: A Pod created with an 'emptyDir' Volume, the volume mode set to 0666.
     Volume is mounted into the container where container is run as a non-root user.
     The volume MUST have mode -rw-rw-rw- and mount type set to tmpfs and the contents
@@ -2245,7 +2286,7 @@
   file: test/e2e/common/empty_dir.go
 - testname: EmptyDir, medium memory, volume mode 0666,, non-root user
   codename: '[sig-storage] EmptyDir volumes should support (non-root,0666,tmpfs) [LinuxOnly]
-    [NodeConformance] [Conformance]'
+    [NodeConformance] [Conformance] [Profile:Base]'
   description: A Pod created with an 'emptyDir' Volume and 'medium' as 'Memory', the
     volume mode set to 0666. Volume is mounted into the container where container
     is run as a non-root user. The volume MUST have mode -rw-rw-rw- and mount type
@@ -2256,7 +2297,7 @@
   file: test/e2e/common/empty_dir.go
 - testname: EmptyDir, medium default, volume mode 0777
   codename: '[sig-storage] EmptyDir volumes should support (non-root,0777,default)
-    [LinuxOnly] [NodeConformance] [Conformance]'
+    [LinuxOnly] [NodeConformance] [Conformance] [Profile:Base]'
   description: A Pod created with an 'emptyDir' Volume, the volume mode set to 0777.
     Volume is mounted into the container where container is run as a non-root user.
     The volume MUST have mode -rwxrwxrwx and mount type set to tmpfs and the contents
@@ -2266,7 +2307,7 @@
   file: test/e2e/common/empty_dir.go
 - testname: EmptyDir, medium memory, volume mode 0777, non-root user
   codename: '[sig-storage] EmptyDir volumes should support (non-root,0777,tmpfs) [LinuxOnly]
-    [NodeConformance] [Conformance]'
+    [NodeConformance] [Conformance] [Profile:Base]'
   description: A Pod created with an 'emptyDir' Volume and 'medium' as 'Memory', the
     volume mode set to 0777. Volume is mounted into the container where container
     is run as a non-root user. The volume MUST have mode -rwxrwxrwx and mount type
@@ -2277,7 +2318,7 @@
   file: test/e2e/common/empty_dir.go
 - testname: EmptyDir, medium default, volume mode 0644
   codename: '[sig-storage] EmptyDir volumes should support (root,0644,default) [LinuxOnly]
-    [NodeConformance] [Conformance]'
+    [NodeConformance] [Conformance] [Profile:Base]'
   description: A Pod created with an 'emptyDir' Volume, the volume mode set to 0644.
     The volume MUST have mode -rw-r--r-- and mount type set to tmpfs and the contents
     MUST be readable. This test is marked LinuxOnly since Windows does not support
@@ -2286,7 +2327,7 @@
   file: test/e2e/common/empty_dir.go
 - testname: EmptyDir, medium memory, volume mode 0644
   codename: '[sig-storage] EmptyDir volumes should support (root,0644,tmpfs) [LinuxOnly]
-    [NodeConformance] [Conformance]'
+    [NodeConformance] [Conformance] [Profile:Base]'
   description: A Pod created with an 'emptyDir' Volume and 'medium' as 'Memory', the
     volume mode set to 0644. The volume MUST have mode -rw-r--r-- and mount type set
     to tmpfs and the contents MUST be readable. This test is marked LinuxOnly since
@@ -2296,7 +2337,7 @@
   file: test/e2e/common/empty_dir.go
 - testname: EmptyDir, medium default, volume mode 0666
   codename: '[sig-storage] EmptyDir volumes should support (root,0666,default) [LinuxOnly]
-    [NodeConformance] [Conformance]'
+    [NodeConformance] [Conformance] [Profile:Base]'
   description: A Pod created with an 'emptyDir' Volume, the volume mode set to 0666.
     The volume MUST have mode -rw-rw-rw- and mount type set to tmpfs and the contents
     MUST be readable. This test is marked LinuxOnly since Windows does not support
@@ -2305,7 +2346,7 @@
   file: test/e2e/common/empty_dir.go
 - testname: EmptyDir, medium memory, volume mode 0666
   codename: '[sig-storage] EmptyDir volumes should support (root,0666,tmpfs) [LinuxOnly]
-    [NodeConformance] [Conformance]'
+    [NodeConformance] [Conformance] [Profile:Base]'
   description: A Pod created with an 'emptyDir' Volume and 'medium' as 'Memory', the
     volume mode set to 0666. The volume MUST have mode -rw-rw-rw- and mount type set
     to tmpfs and the contents MUST be readable. This test is marked LinuxOnly since
@@ -2315,7 +2356,7 @@
   file: test/e2e/common/empty_dir.go
 - testname: EmptyDir, medium default, volume mode 0777
   codename: '[sig-storage] EmptyDir volumes should support (root,0777,default) [LinuxOnly]
-    [NodeConformance] [Conformance]'
+    [NodeConformance] [Conformance] [Profile:Base]'
   description: A Pod created with an 'emptyDir' Volume, the volume mode set to 0777.  The
     volume MUST have mode set as -rwxrwxrwx and mount type set to tmpfs and the contents
     MUST be readable. This test is marked LinuxOnly since Windows does not support
@@ -2324,7 +2365,7 @@
   file: test/e2e/common/empty_dir.go
 - testname: EmptyDir, medium memory, volume mode 0777
   codename: '[sig-storage] EmptyDir volumes should support (root,0777,tmpfs) [LinuxOnly]
-    [NodeConformance] [Conformance]'
+    [NodeConformance] [Conformance] [Profile:Base]'
   description: A Pod created with an 'emptyDir' Volume and 'medium' as 'Memory', the
     volume mode set to 0777.  The volume MUST have mode set as -rwxrwxrwx and mount
     type set to tmpfs and the contents MUST be readable. This test is marked LinuxOnly
@@ -2334,7 +2375,7 @@
   file: test/e2e/common/empty_dir.go
 - testname: EmptyDir, medium default, volume mode default
   codename: '[sig-storage] EmptyDir volumes volume on default medium should have the
-    correct mode [LinuxOnly] [NodeConformance] [Conformance]'
+    correct mode [LinuxOnly] [NodeConformance] [Conformance] [Profile:Base]'
   description: A Pod created with an 'emptyDir' Volume, the volume MUST have mode
     set as -rwxrwxrwx and mount type set to tmpfs. This test is marked LinuxOnly since
     Windows does not support setting specific file permissions.
@@ -2342,7 +2383,7 @@
   file: test/e2e/common/empty_dir.go
 - testname: EmptyDir, medium memory, volume mode default
   codename: '[sig-storage] EmptyDir volumes volume on tmpfs should have the correct
-    mode [LinuxOnly] [NodeConformance] [Conformance]'
+    mode [LinuxOnly] [NodeConformance] [Conformance] [Profile:Base]'
   description: A Pod created with an 'emptyDir' Volume and 'medium' as 'Memory', the
     volume MUST have mode set as -rwxrwxrwx and mount type set to tmpfs. This test
     is marked LinuxOnly since Windows does not support setting specific file permissions,
@@ -2351,20 +2392,21 @@
   file: test/e2e/common/empty_dir.go
 - testname: EmptyDir Wrapper Volume, ConfigMap volumes, no race
   codename: '[sig-storage] EmptyDir wrapper volumes should not cause race condition
-    when used for configmaps [Serial] [Conformance]'
+    when used for configmaps [Serial] [Conformance] [Profile:Privileged]'
   description: Create 50 ConfigMaps Volumes and 5 replicas of pod with these ConfigMapvolumes
     mounted. Pod MUST NOT fail waiting for Volumes.
   release: v1.13
   file: test/e2e/storage/empty_dir_wrapper.go
 - testname: EmptyDir Wrapper Volume, Secret and ConfigMap volumes, no conflict
-  codename: '[sig-storage] EmptyDir wrapper volumes should not conflict [Conformance]'
+  codename: '[sig-storage] EmptyDir wrapper volumes should not conflict [Conformance]
+    [Profile:Base]'
   description: Secret volume and ConfigMap volume is created with data. Pod MUST be
     able to start with Secret and ConfigMap volumes mounted into the container.
   release: v1.13
   file: test/e2e/storage/empty_dir_wrapper.go
 - testname: Projected Volume, multiple projections
   codename: '[sig-storage] Projected combined should project all components that make
-    up the projection API [Projection][NodeConformance] [Conformance]'
+    up the projection API [Projection][NodeConformance] [Conformance] [Profile:Base]'
   description: A Pod is created with a projected volume source for secrets, configMap
     and downwardAPI with pod name, cpu and memory limits and cpu and memory requests.
     Pod MUST be able to read the secrets, configMap values and the cpu and memory
@@ -2373,7 +2415,7 @@
   file: test/e2e/common/projected_combined.go
 - testname: Projected Volume, ConfigMap, create, update and delete
   codename: '[sig-storage] Projected configMap optional updates should be reflected
-    in volume [NodeConformance] [Conformance]'
+    in volume [NodeConformance] [Conformance] [Profile:Base]'
   description: Create a Pod with three containers with ConfigMaps namely a create,
     update and delete container. Create Container when started MUST not have configMap,
     update and delete containers MUST be created with a ConfigMap value as 'value-1'.
@@ -2385,7 +2427,7 @@
   file: test/e2e/common/projected_configmap.go
 - testname: Projected Volume, ConfigMap, volume mode default
   codename: '[sig-storage] Projected configMap should be consumable from pods in volume
-    [NodeConformance] [Conformance]'
+    [NodeConformance] [Conformance] [Profile:Base]'
   description: A Pod is created with projected volume source 'ConfigMap' to store
     a configMap with default permission mode. Pod MUST be able to read the content
     of the ConfigMap successfully and the mode on the volume MUST be -rw-r--r--.
@@ -2393,7 +2435,7 @@
   file: test/e2e/common/projected_configmap.go
 - testname: Projected Volume, ConfigMap, non-root user
   codename: '[sig-storage] Projected configMap should be consumable from pods in volume
-    as non-root [NodeConformance] [Conformance]'
+    as non-root [NodeConformance] [Conformance] [Profile:Base]'
   description: A Pod is created with projected volume source 'ConfigMap' to store
     a configMap as non-root user with uid 1000. Pod MUST be able to read the content
     of the ConfigMap successfully and the mode on the volume MUST be -rw-r--r--.
@@ -2401,7 +2443,7 @@
   file: test/e2e/common/projected_configmap.go
 - testname: Projected Volume, ConfigMap, volume mode 0400
   codename: '[sig-storage] Projected configMap should be consumable from pods in volume
-    with defaultMode set [LinuxOnly] [NodeConformance] [Conformance]'
+    with defaultMode set [LinuxOnly] [NodeConformance] [Conformance] [Profile:Base]'
   description: A Pod is created with projected volume source 'ConfigMap' to store
     a configMap with permission mode set to 0400. Pod MUST be able to read the content
     of the ConfigMap successfully and the mode on the volume MUST be -r--------. This
@@ -2411,7 +2453,7 @@
   file: test/e2e/common/projected_configmap.go
 - testname: Projected Volume, ConfigMap, mapped
   codename: '[sig-storage] Projected configMap should be consumable from pods in volume
-    with mappings [NodeConformance] [Conformance]'
+    with mappings [NodeConformance] [Conformance] [Profile:Base]'
   description: A Pod is created with projected volume source 'ConfigMap' to store
     a configMap with default permission mode. The ConfigMap is also mapped to a custom
     path. Pod MUST be able to read the content of the ConfigMap from the custom location
@@ -2420,7 +2462,7 @@
   file: test/e2e/common/projected_configmap.go
 - testname: Projected Volume, ConfigMap, mapped, volume mode 0400
   codename: '[sig-storage] Projected configMap should be consumable from pods in volume
-    with mappings and Item mode set [LinuxOnly] [NodeConformance] [Conformance]'
+    with mappings and Item mode set [LinuxOnly] [NodeConformance] [Conformance] [Profile:Base]'
   description: A Pod is created with projected volume source 'ConfigMap' to store
     a configMap with permission mode set to 0400. The ConfigMap is also mapped to
     a custom path. Pod MUST be able to read the content of the ConfigMap from the
@@ -2431,7 +2473,7 @@
   file: test/e2e/common/projected_configmap.go
 - testname: Projected Volume, ConfigMap, mapped, non-root user
   codename: '[sig-storage] Projected configMap should be consumable from pods in volume
-    with mappings as non-root [NodeConformance] [Conformance]'
+    with mappings as non-root [NodeConformance] [Conformance] [Profile:Base]'
   description: A Pod is created with projected volume source 'ConfigMap' to store
     a configMap as non-root user with uid 1000. The ConfigMap is also mapped to a
     custom path. Pod MUST be able to read the content of the ConfigMap from the custom
@@ -2440,7 +2482,7 @@
   file: test/e2e/common/projected_configmap.go
 - testname: Projected Volume, ConfigMap, multiple volume paths
   codename: '[sig-storage] Projected configMap should be consumable in multiple volumes
-    in the same pod [NodeConformance] [Conformance]'
+    in the same pod [NodeConformance] [Conformance] [Profile:Base]'
   description: A Pod is created with a projected volume source 'ConfigMap' to store
     a configMap. The configMap is mapped to two different volume mounts. Pod MUST
     be able to read the content of the configMap successfully from the two volume
@@ -2449,7 +2491,7 @@
   file: test/e2e/common/projected_configmap.go
 - testname: Projected Volume, ConfigMap, update
   codename: '[sig-storage] Projected configMap updates should be reflected in volume
-    [NodeConformance] [Conformance]'
+    [NodeConformance] [Conformance] [Profile:Base]'
   description: A Pod is created with projected volume source 'ConfigMap' to store
     a configMap and performs a create and update to new value. Pod MUST be able to
     create the configMap with value-1. Pod MUST be able to update the value in the
@@ -2458,7 +2500,7 @@
   file: test/e2e/common/projected_configmap.go
 - testname: Projected Volume, DownwardAPI, CPU limits
   codename: '[sig-storage] Projected downwardAPI should provide container''s cpu limit
-    [NodeConformance] [Conformance]'
+    [NodeConformance] [Conformance] [Profile:Base]'
   description: A Pod is created with a projected volume source for downwardAPI with
     pod name, cpu and memory limits and cpu and memory requests. Pod MUST be able
     to read the cpu limits from the mounted DownwardAPIVolumeFiles.
@@ -2466,7 +2508,7 @@
   file: test/e2e/common/projected_downwardapi.go
 - testname: Projected Volume, DownwardAPI, CPU request
   codename: '[sig-storage] Projected downwardAPI should provide container''s cpu request
-    [NodeConformance] [Conformance]'
+    [NodeConformance] [Conformance] [Profile:Base]'
   description: A Pod is created with a projected volume source for downwardAPI with
     pod name, cpu and memory limits and cpu and memory requests. Pod MUST be able
     to read the cpu request from the mounted DownwardAPIVolumeFiles.
@@ -2474,7 +2516,7 @@
   file: test/e2e/common/projected_downwardapi.go
 - testname: Projected Volume, DownwardAPI, memory limits
   codename: '[sig-storage] Projected downwardAPI should provide container''s memory
-    limit [NodeConformance] [Conformance]'
+    limit [NodeConformance] [Conformance] [Profile:Base]'
   description: A Pod is created with a projected volume source for downwardAPI with
     pod name, cpu and memory limits and cpu and memory requests. Pod MUST be able
     to read the memory limits from the mounted DownwardAPIVolumeFiles.
@@ -2482,7 +2524,7 @@
   file: test/e2e/common/projected_downwardapi.go
 - testname: Projected Volume, DownwardAPI, memory request
   codename: '[sig-storage] Projected downwardAPI should provide container''s memory
-    request [NodeConformance] [Conformance]'
+    request [NodeConformance] [Conformance] [Profile:Base]'
   description: A Pod is created with a projected volume source for downwardAPI with
     pod name, cpu and memory limits and cpu and memory requests. Pod MUST be able
     to read the memory request from the mounted DownwardAPIVolumeFiles.
@@ -2490,7 +2532,7 @@
   file: test/e2e/common/projected_downwardapi.go
 - testname: Projected Volume, DownwardAPI, CPU limit, node allocatable
   codename: '[sig-storage] Projected downwardAPI should provide node allocatable (cpu)
-    as default cpu limit if the limit is not set [NodeConformance] [Conformance]'
+    as default cpu limit if the limit is not set [NodeConformance] [Conformance] [Profile:Base]'
   description: A Pod is created with a projected volume source for downwardAPI with
     pod name, cpu and memory limits and cpu and memory requests.  The CPU and memory
     resources for requests and limits are NOT specified for the container. Pod MUST
@@ -2499,7 +2541,8 @@
   file: test/e2e/common/projected_downwardapi.go
 - testname: Projected Volume, DownwardAPI, memory limit, node allocatable
   codename: '[sig-storage] Projected downwardAPI should provide node allocatable (memory)
-    as default memory limit if the limit is not set [NodeConformance] [Conformance]'
+    as default memory limit if the limit is not set [NodeConformance] [Conformance]
+    [Profile:Base]'
   description: A Pod is created with a projected volume source for downwardAPI with
     pod name, cpu and memory limits and cpu and memory requests.  The CPU and memory
     resources for requests and limits are NOT specified for the container. Pod MUST
@@ -2508,7 +2551,7 @@
   file: test/e2e/common/projected_downwardapi.go
 - testname: Projected Volume, DownwardAPI, pod name
   codename: '[sig-storage] Projected downwardAPI should provide podname only [NodeConformance]
-    [Conformance]'
+    [Conformance] [Profile:Base]'
   description: A Pod is created with a projected volume source for downwardAPI with
     pod name, cpu and memory limits and cpu and memory requests. Pod MUST be able
     to read the pod name from the mounted DownwardAPIVolumeFiles.
@@ -2516,7 +2559,7 @@
   file: test/e2e/common/projected_downwardapi.go
 - testname: Projected Volume, DownwardAPI, volume mode 0400
   codename: '[sig-storage] Projected downwardAPI should set DefaultMode on files [LinuxOnly]
-    [NodeConformance] [Conformance]'
+    [NodeConformance] [Conformance] [Profile:Base]'
   description: A Pod is created with a projected volume source for downwardAPI with
     pod name, cpu and memory limits and cpu and memory requests. The default mode
     for the volume mount is set to 0400. Pod MUST be able to read the pod name from
@@ -2527,7 +2570,7 @@
   file: test/e2e/common/projected_downwardapi.go
 - testname: Projected Volume, DownwardAPI, volume mode 0400
   codename: '[sig-storage] Projected downwardAPI should set mode on item file [LinuxOnly]
-    [NodeConformance] [Conformance]'
+    [NodeConformance] [Conformance] [Profile:Base]'
   description: A Pod is created with a projected volume source for downwardAPI with
     pod name, cpu and memory limits and cpu and memory requests. The default mode
     for the volume mount is set to 0400. Pod MUST be able to read the pod name from
@@ -2538,7 +2581,7 @@
   file: test/e2e/common/projected_downwardapi.go
 - testname: Projected Volume, DownwardAPI, update annotation
   codename: '[sig-storage] Projected downwardAPI should update annotations on modification
-    [NodeConformance] [Conformance]'
+    [NodeConformance] [Conformance] [Profile:Base]'
   description: A Pod is created with a projected volume source for downwardAPI with
     pod name, cpu and memory limits and cpu and memory requests and annotation items.
     Pod MUST be able to read the annotations from the mounted DownwardAPIVolumeFiles.
@@ -2548,7 +2591,7 @@
   file: test/e2e/common/projected_downwardapi.go
 - testname: Projected Volume, DownwardAPI, update labels
   codename: '[sig-storage] Projected downwardAPI should update labels on modification
-    [NodeConformance] [Conformance]'
+    [NodeConformance] [Conformance] [Profile:Base]'
   description: A Pod is created with a projected volume source for downwardAPI with
     pod name, cpu and memory limits and cpu and memory requests and label items. Pod
     MUST be able to read the labels from the mounted DownwardAPIVolumeFiles. Labels
@@ -2557,7 +2600,7 @@
   file: test/e2e/common/projected_downwardapi.go
 - testname: Projected Volume, Secrets, create, update delete
   codename: '[sig-storage] Projected secret optional updates should be reflected in
-    volume [NodeConformance] [Conformance]'
+    volume [NodeConformance] [Conformance] [Profile:Base]'
   description: Create a Pod with three containers with secrets namely a create, update
     and delete container. Create Container when started MUST no have a secret, update
     and delete containers MUST be created with a secret value. Create a secret in
@@ -2569,7 +2612,7 @@
   file: test/e2e/common/projected_secret.go
 - testname: Projected Volume, Secrets, volume mode default
   codename: '[sig-storage] Projected secret should be consumable from pods in volume
-    [NodeConformance] [Conformance]'
+    [NodeConformance] [Conformance] [Profile:Base]'
   description: A Pod is created with a projected volume source 'secret' to store a
     secret with a specified key with default permission mode. Pod MUST be able to
     read the content of the key successfully and the mode MUST be -rw-r--r-- by default.
@@ -2577,7 +2620,8 @@
   file: test/e2e/common/projected_secret.go
 - testname: Project Volume, Secrets, non-root, custom fsGroup
   codename: '[sig-storage] Projected secret should be consumable from pods in volume
-    as non-root with defaultMode and fsGroup set [LinuxOnly] [NodeConformance] [Conformance]'
+    as non-root with defaultMode and fsGroup set [LinuxOnly] [NodeConformance] [Conformance]
+    [Profile:Base]'
   description: A Pod is created with a projected volume source 'secret' to store a
     secret with a specified key. The volume has permission mode set to 0440, fsgroup
     set to 1001 and user set to non-root uid of 1000. Pod MUST be able to read the
@@ -2588,7 +2632,7 @@
   file: test/e2e/common/projected_secret.go
 - testname: Projected Volume, Secrets, volume mode 0400
   codename: '[sig-storage] Projected secret should be consumable from pods in volume
-    with defaultMode set [LinuxOnly] [NodeConformance] [Conformance]'
+    with defaultMode set [LinuxOnly] [NodeConformance] [Conformance] [Profile:Base]'
   description: A Pod is created with a projected volume source 'secret' to store a
     secret with a specified key with permission mode set to 0x400 on the Pod. Pod
     MUST be able to read the content of the key successfully and the mode MUST be
@@ -2598,7 +2642,7 @@
   file: test/e2e/common/projected_secret.go
 - testname: Projected Volume, Secrets, mapped
   codename: '[sig-storage] Projected secret should be consumable from pods in volume
-    with mappings [NodeConformance] [Conformance]'
+    with mappings [NodeConformance] [Conformance] [Profile:Base]'
   description: A Pod is created with a projected volume source 'secret' to store a
     secret with a specified key with default permission mode. The secret is also mapped
     to a custom path. Pod MUST be able to read the content of the key successfully
@@ -2607,7 +2651,7 @@
   file: test/e2e/common/projected_secret.go
 - testname: Projected Volume, Secrets, mapped, volume mode 0400
   codename: '[sig-storage] Projected secret should be consumable from pods in volume
-    with mappings and Item Mode set [LinuxOnly] [NodeConformance] [Conformance]'
+    with mappings and Item Mode set [LinuxOnly] [NodeConformance] [Conformance] [Profile:Base]'
   description: A Pod is created with a projected volume source 'secret' to store a
     secret with a specified key with permission mode set to 0400. The secret is also
     mapped to a specific name. Pod MUST be able to read the content of the key successfully
@@ -2617,7 +2661,7 @@
   file: test/e2e/common/projected_secret.go
 - testname: Projected Volume, Secrets, mapped, multiple paths
   codename: '[sig-storage] Projected secret should be consumable in multiple volumes
-    in a pod [NodeConformance] [Conformance]'
+    in a pod [NodeConformance] [Conformance] [Profile:Base]'
   description: A Pod is created with a projected volume source 'secret' to store a
     secret with a specified key. The secret is mapped to two different volume mounts.
     Pod MUST be able to read the content of the key successfully from the two volume
@@ -2626,7 +2670,7 @@
   file: test/e2e/common/projected_secret.go
 - testname: Secrets Volume, create, update and delete
   codename: '[sig-storage] Secrets optional updates should be reflected in volume
-    [NodeConformance] [Conformance]'
+    [NodeConformance] [Conformance] [Profile:Base]'
   description: Create a Pod with three containers with secrets volume sources namely
     a create, update and delete container. Create Container when started MUST not
     have secret, update and delete containers MUST be created with a secret value.
@@ -2640,7 +2684,7 @@
     namespace
   codename: '[sig-storage] Secrets should be able to mount in a volume regardless
     of a different secret existing with same name in different namespace [NodeConformance]
-    [Conformance]'
+    [Conformance] [Profile:Base]'
   description: Create a secret with same name in two namespaces. Create a Pod with
     secret volume source configured into the container. Pod MUST be able to read the
     secrets from the mounted volume from the container runtime and only secrets which
@@ -2650,7 +2694,7 @@
   file: test/e2e/common/secrets_volume.go
 - testname: Secrets Volume, default
   codename: '[sig-storage] Secrets should be consumable from pods in volume [NodeConformance]
-    [Conformance]'
+    [Conformance] [Profile:Base]'
   description: Create a secret. Create a Pod with secret volume source configured
     into the container. Pod MUST be able to read the secret from the mounted volume
     from the container runtime and the file mode of the secret MUST be -rw-r--r--
@@ -2659,7 +2703,7 @@
   file: test/e2e/common/secrets_volume.go
 - testname: Secrets Volume, volume mode 0440, fsGroup 1001 and uid 1000
   codename: '[sig-storage] Secrets should be consumable from pods in volume as non-root
-    with defaultMode and fsGroup set [LinuxOnly] [NodeConformance] [Conformance]'
+    with defaultMode and fsGroup set [LinuxOnly] [NodeConformance] [Conformance] [Profile:Base]'
   description: Create a secret. Create a Pod with secret volume source configured
     into the container with file mode set to 0x440 as a non-root user with uid 1000
     and fsGroup id 1001. Pod MUST be able to read the secret from the mounted volume
@@ -2670,7 +2714,7 @@
   file: test/e2e/common/secrets_volume.go
 - testname: Secrets Volume, volume mode 0400
   codename: '[sig-storage] Secrets should be consumable from pods in volume with defaultMode
-    set [LinuxOnly] [NodeConformance] [Conformance]'
+    set [LinuxOnly] [NodeConformance] [Conformance] [Profile:Base]'
   description: Create a secret. Create a Pod with secret volume source configured
     into the container with file mode set to 0x400. Pod MUST be able to read the secret
     from the mounted volume from the container runtime and the file mode of the secret
@@ -2680,7 +2724,7 @@
   file: test/e2e/common/secrets_volume.go
 - testname: Secrets Volume, mapping
   codename: '[sig-storage] Secrets should be consumable from pods in volume with mappings
-    [NodeConformance] [Conformance]'
+    [NodeConformance] [Conformance] [Profile:Base]'
   description: Create a secret. Create a Pod with secret volume source configured
     into the container with a custom path. Pod MUST be able to read the secret from
     the mounted volume from the specified custom path. The file mode of the secret
@@ -2689,7 +2733,7 @@
   file: test/e2e/common/secrets_volume.go
 - testname: Secrets Volume, mapping, volume mode 0400
   codename: '[sig-storage] Secrets should be consumable from pods in volume with mappings
-    and Item Mode set [LinuxOnly] [NodeConformance] [Conformance]'
+    and Item Mode set [LinuxOnly] [NodeConformance] [Conformance] [Profile:Base]'
   description: Create a secret. Create a Pod with secret volume source configured
     into the container with a custom path and file mode set to 0x400. Pod MUST be
     able to read the secret from the mounted volume from the specified custom path.
@@ -2699,7 +2743,7 @@
   file: test/e2e/common/secrets_volume.go
 - testname: Secrets Volume, mapping multiple volume paths
   codename: '[sig-storage] Secrets should be consumable in multiple volumes in a pod
-    [NodeConformance] [Conformance]'
+    [NodeConformance] [Conformance] [Profile:Base]'
   description: Create a secret. Create a Pod with two secret volume sources configured
     into the container in to two different custom paths. Pod MUST be able to read
     the secret from the both the mounted volumes from the two specified custom paths.
@@ -2707,7 +2751,7 @@
   file: test/e2e/common/secrets_volume.go
 - testname: 'SubPath: Reading content from a configmap volume.'
   codename: '[sig-storage] Subpath Atomic writer volumes should support subpaths with
-    configmap pod [LinuxOnly] [Conformance]'
+    configmap pod [LinuxOnly] [Conformance] [Profile:Base]'
   description: Containers in a pod can read content from a configmap mounted volume
     which was configured with a subpath. This test is marked LinuxOnly since Windows
     cannot mount individual files in Containers.
@@ -2715,7 +2759,7 @@
   file: test/e2e/storage/subpath.go
 - testname: 'SubPath: Reading content from a configmap volume.'
   codename: '[sig-storage] Subpath Atomic writer volumes should support subpaths with
-    configmap pod with mountPath of existing file [LinuxOnly] [Conformance]'
+    configmap pod with mountPath of existing file [LinuxOnly] [Conformance] [Profile:Base]'
   description: Containers in a pod can read content from a configmap mounted volume
     which was configured with a subpath and also using a mountpath that is a specific
     file. This test is marked LinuxOnly since Windows cannot mount individual files
@@ -2724,7 +2768,7 @@
   file: test/e2e/storage/subpath.go
 - testname: 'SubPath: Reading content from a downwardAPI volume.'
   codename: '[sig-storage] Subpath Atomic writer volumes should support subpaths with
-    downward pod [LinuxOnly] [Conformance]'
+    downward pod [LinuxOnly] [Conformance] [Profile:Base]'
   description: Containers in a pod can read content from a downwardAPI mounted volume
     which was configured with a subpath. This test is marked LinuxOnly since Windows
     cannot mount individual files in Containers.
@@ -2732,7 +2776,7 @@
   file: test/e2e/storage/subpath.go
 - testname: 'SubPath: Reading content from a projected volume.'
   codename: '[sig-storage] Subpath Atomic writer volumes should support subpaths with
-    projected pod [LinuxOnly] [Conformance]'
+    projected pod [LinuxOnly] [Conformance] [Profile:Base]'
   description: Containers in a pod can read content from a projected mounted volume
     which was configured with a subpath. This test is marked LinuxOnly since Windows
     cannot mount individual files in Containers.
@@ -2740,7 +2784,7 @@
   file: test/e2e/storage/subpath.go
 - testname: 'SubPath: Reading content from a secret volume.'
   codename: '[sig-storage] Subpath Atomic writer volumes should support subpaths with
-    secret pod [LinuxOnly] [Conformance]'
+    secret pod [LinuxOnly] [Conformance] [Profile:Base]'
   description: Containers in a pod can read content from a secret mounted volume which
     was configured with a subpath. This test is marked LinuxOnly since Windows cannot
     mount individual files in Containers.

--- a/test/e2e/apimachinery/aggregator.go
+++ b/test/e2e/apimachinery/aggregator.go
@@ -94,7 +94,7 @@ var _ = SIGDescribe("Aggregator", func() {
 		    Description: Ensure that the sample-apiserver code from 1.17 and compiled against 1.17
 			will work on the current Aggregator/API-Server.
 	*/
-	framework.ConformanceIt("Should be able to support the 1.17 Sample API Server using the current Aggregator", func() {
+	framework.ConformanceIt("Privileged", "Should be able to support the 1.17 Sample API Server using the current Aggregator", func() {
 		// Testing a 1.17 version of the sample-apiserver
 		TestSampleAPIServer(f, aggrclient, imageutils.GetE2EImage(imageutils.APIServer))
 	})

--- a/test/e2e/apimachinery/crd_conversion_webhook.go
+++ b/test/e2e/apimachinery/crd_conversion_webhook.go
@@ -144,7 +144,7 @@ var _ = SIGDescribe("CustomResourceConversionWebhook [Privileged:ClusterAdmin]",
 		Description: Register a conversion webhook and a custom resource definition. Create a v1 custom
 		resource. Attempts to read it at v2 MUST succeed.
 	*/
-	framework.ConformanceIt("should be able to convert from CR v1 to CR v2", func() {
+	framework.ConformanceIt("Privileged", "should be able to convert from CR v1 to CR v2", func() {
 		testcrd, err := crd.CreateMultiVersionTestCRD(f, "stable.example.com", func(crd *apiextensionsv1.CustomResourceDefinition) {
 			crd.Spec.Versions = apiVersions
 			crd.Spec.Conversion = &apiextensionsv1.CustomResourceConversion{
@@ -179,7 +179,7 @@ var _ = SIGDescribe("CustomResourceConversionWebhook [Privileged:ClusterAdmin]",
 		v1. Change the custom resource definition storage to v2. Create a custom resource stored at v2. Attempt to list
 		the custom resources at v2; the list result MUST contain both custom resources at v2.
 	*/
-	framework.ConformanceIt("should be able to convert a non homogeneous list of CRs", func() {
+	framework.ConformanceIt("Privileged", "should be able to convert a non homogeneous list of CRs", func() {
 		testcrd, err := crd.CreateMultiVersionTestCRD(f, "stable.example.com", func(crd *apiextensionsv1.CustomResourceDefinition) {
 			crd.Spec.Versions = apiVersions
 			crd.Spec.Conversion = &apiextensionsv1.CustomResourceConversion{

--- a/test/e2e/apimachinery/crd_publish_openapi.go
+++ b/test/e2e/apimachinery/crd_publish_openapi.go
@@ -62,7 +62,7 @@ var _ = SIGDescribe("CustomResourcePublishOpenAPI [Privileged:ClusterAdmin]", fu
 		explain the custom resource properties. Attempt kubectl explain on custom resource properties; the output MUST
 		explain the nested custom resource properties.
 	*/
-	framework.ConformanceIt("works for CRD with validation schema", func() {
+	framework.ConformanceIt("Privileged", "works for CRD with validation schema", func() {
 		crd, err := setupCRD(f, schemaFoo, "foo", "v1")
 		if err != nil {
 			framework.Failf("%v", err)
@@ -137,7 +137,7 @@ var _ = SIGDescribe("CustomResourcePublishOpenAPI [Privileged:ClusterAdmin]", fu
 		Attempt to create and apply a change a custom resource, via kubectl; client-side validation MUST accept unknown
 		properties. Attempt kubectl explain; the output MUST contain a valid DESCRIPTION stanza.
 	*/
-	framework.ConformanceIt("works for CRD without validation schema", func() {
+	framework.ConformanceIt("Privileged", "works for CRD without validation schema", func() {
 		crd, err := setupCRD(f, nil, "empty", "v1")
 		if err != nil {
 			framework.Failf("%v", err)
@@ -178,7 +178,7 @@ var _ = SIGDescribe("CustomResourcePublishOpenAPI [Privileged:ClusterAdmin]", fu
 		Attempt to create and apply a change a custom resource, via kubectl; client-side validation MUST accept unknown
 		properties. Attempt kubectl explain; the output MUST show the custom resource KIND.
 	*/
-	framework.ConformanceIt("works for CRD preserving unknown fields at the schema root", func() {
+	framework.ConformanceIt("Privileged", "works for CRD preserving unknown fields at the schema root", func() {
 		crd, err := setupCRDAndVerifySchema(f, schemaPreserveRoot, nil, "unknown-at-root", "v1")
 		if err != nil {
 			framework.Failf("%v", err)
@@ -220,7 +220,7 @@ var _ = SIGDescribe("CustomResourcePublishOpenAPI [Privileged:ClusterAdmin]", fu
 		properties. Attempt kubectl explain; the output MUST show that x-preserve-unknown-properties is used on the
 		nested field.
 	*/
-	framework.ConformanceIt("works for CRD preserving unknown fields in an embedded object", func() {
+	framework.ConformanceIt("Privileged", "works for CRD preserving unknown fields in an embedded object", func() {
 		crd, err := setupCRDAndVerifySchema(f, schemaPreserveNested, nil, "unknown-in-nested", "v1")
 		if err != nil {
 			framework.Failf("%v", err)
@@ -260,7 +260,7 @@ var _ = SIGDescribe("CustomResourcePublishOpenAPI [Privileged:ClusterAdmin]", fu
 		Description: Register multiple custom resource definitions spanning different groups and versions;
 		OpenAPI definitions MUST be published for custom resource definitions.
 	*/
-	framework.ConformanceIt("works for multiple CRDs of different groups", func() {
+	framework.ConformanceIt("Privileged", "works for multiple CRDs of different groups", func() {
 		ginkgo.By("CRs in different groups (two CRDs) show up in OpenAPI documentation")
 		crdFoo, err := setupCRD(f, schemaFoo, "foo", "v1")
 		if err != nil {
@@ -293,7 +293,7 @@ var _ = SIGDescribe("CustomResourcePublishOpenAPI [Privileged:ClusterAdmin]", fu
 		Description: Register a custom resource definition with multiple versions; OpenAPI definitions MUST be published
 		for custom resource definitions.
 	*/
-	framework.ConformanceIt("works for multiple CRDs of same group but different versions", func() {
+	framework.ConformanceIt("Privileged", "works for multiple CRDs of same group but different versions", func() {
 		ginkgo.By("CRs in the same group but different versions (one multiversion CRD) show up in OpenAPI documentation")
 		crdMultiVer, err := setupCRD(f, schemaFoo, "multi-ver", "v2", "v3")
 		if err != nil {
@@ -341,7 +341,7 @@ var _ = SIGDescribe("CustomResourcePublishOpenAPI [Privileged:ClusterAdmin]", fu
 		Description: Register multiple custom resource definitions in the same group and version but spanning different kinds;
 		OpenAPI definitions MUST be published for custom resource definitions.
 	*/
-	framework.ConformanceIt("works for multiple CRDs of same group and version but different kinds", func() {
+	framework.ConformanceIt("Privileged", "works for multiple CRDs of same group and version but different kinds", func() {
 		ginkgo.By("CRs in the same group and version but different kinds (two CRDs) show up in OpenAPI documentation")
 		crdFoo, err := setupCRD(f, schemaFoo, "common-group", "v6")
 		if err != nil {
@@ -375,7 +375,7 @@ var _ = SIGDescribe("CustomResourcePublishOpenAPI [Privileged:ClusterAdmin]", fu
 		for custom resource definitions. Rename one of the versions of the custom resource definition via a patch;
 		OpenAPI definitions MUST update to reflect the rename.
 	*/
-	framework.ConformanceIt("updates the published spec when one version gets renamed", func() {
+	framework.ConformanceIt("Privileged", "updates the published spec when one version gets renamed", func() {
 		ginkgo.By("set up a multi version CRD")
 		crdMultiVer, err := setupCRD(f, schemaFoo, "multi-ver", "v2", "v3")
 		if err != nil {
@@ -426,7 +426,7 @@ var _ = SIGDescribe("CustomResourcePublishOpenAPI [Privileged:ClusterAdmin]", fu
 		for custom resource definitions. Update the custom resource definition to not serve one of the versions. OpenAPI
 		definitions MUST be updated to not contain the version that is no longer served.
 	*/
-	framework.ConformanceIt("removes definition from spec when one version gets changed to not be served", func() {
+	framework.ConformanceIt("Privileged", "removes definition from spec when one version gets changed to not be served", func() {
 		ginkgo.By("set up a multi version CRD")
 		crd, err := setupCRD(f, schemaFoo, "multi-to-single-ver", "v5", "v6alpha1")
 		if err != nil {

--- a/test/e2e/apimachinery/crd_watch.go
+++ b/test/e2e/apimachinery/crd_watch.go
@@ -46,7 +46,7 @@ var _ = SIGDescribe("CustomResourceDefinition Watch [Privileged:ClusterAdmin]", 
 			Description: Create a Custom Resource Definition. Attempt to watch it; the watch MUST observe create,
 			modify and delete events.
 		*/
-		framework.ConformanceIt("watch on custom resource definition objects", func() {
+		framework.ConformanceIt("Privileged", "watch on custom resource definition objects", func() {
 
 			const (
 				watchCRNameA = "name1"

--- a/test/e2e/apimachinery/custom_resource_definition.go
+++ b/test/e2e/apimachinery/custom_resource_definition.go
@@ -53,7 +53,7 @@ var _ = SIGDescribe("CustomResourceDefinition resources [Privileged:ClusterAdmin
 			Create the custom resource definition and then delete it. The creation and deletion MUST
 			be successful.
 		*/
-		framework.ConformanceIt("creating/deleting custom resource definition objects works ", func() {
+		framework.ConformanceIt("Privileged", "creating/deleting custom resource definition objects works ", func() {
 
 			config, err := framework.LoadConfig()
 			framework.ExpectNoError(err, "loading config")
@@ -80,7 +80,7 @@ var _ = SIGDescribe("CustomResourceDefinition resources [Privileged:ClusterAdmin
 			custom resource definitions via delete collection; the delete MUST be successful and MUST delete only the
 			labeled custom resource definitions.
 		*/
-		framework.ConformanceIt("listing custom resource definition objects works ", func() {
+		framework.ConformanceIt("Privileged", "listing custom resource definition objects works ", func() {
 			testListSize := 10
 			config, err := framework.LoadConfig()
 			framework.ExpectNoError(err, "loading config")
@@ -140,7 +140,7 @@ var _ = SIGDescribe("CustomResourceDefinition resources [Privileged:ClusterAdmin
 			Description: Create a custom resource definition. Attempt to read, update and patch its status sub-resource;
 			all mutating sub-resource operations MUST be visible to subsequent reads.
 		*/
-		framework.ConformanceIt("getting/updating/patching custom resource definition status sub-resource works ", func() {
+		framework.ConformanceIt("Privileged", "getting/updating/patching custom resource definition status sub-resource works ", func() {
 			config, err := framework.LoadConfig()
 			framework.ExpectNoError(err, "loading config")
 			apiExtensionClient, err := clientset.NewForConfig(config)
@@ -193,7 +193,7 @@ var _ = SIGDescribe("CustomResourceDefinition resources [Privileged:ClusterAdmin
 		Description: Fetch /apis, /apis/apiextensions.k8s.io, and /apis/apiextensions.k8s.io/v1 discovery documents,
 		and ensure they indicate CustomResourceDefinition apiextensions.k8s.io/v1 resources are available.
 	*/
-	framework.ConformanceIt("should include custom resource definition resources in discovery documents", func() {
+	framework.ConformanceIt("Privileged", "should include custom resource definition resources in discovery documents", func() {
 		{
 			ginkgo.By("fetching the /apis discovery document")
 			apiGroupList := &metav1.APIGroupList{}
@@ -264,7 +264,7 @@ var _ = SIGDescribe("CustomResourceDefinition resources [Privileged:ClusterAdmin
 		the default is applied. Create another CR. Remove default, add default for another field and read CR until
 		new field is defaulted, but old default stays.
 	*/
-	framework.ConformanceIt("custom resource defaulting for requests and from storage works ", func() {
+	framework.ConformanceIt("Privileged", "custom resource defaulting for requests and from storage works ", func() {
 		config, err := framework.LoadConfig()
 		framework.ExpectNoError(err, "loading config")
 		apiExtensionClient, err := clientset.NewForConfig(config)

--- a/test/e2e/apimachinery/events.go
+++ b/test/e2e/apimachinery/events.go
@@ -45,7 +45,7 @@ var _ = ginkgo.Describe("[sig-api-machinery] Events", func() {
 		           The event is patched with a new message, the check MUST have the update message.
 		           The event is deleted and MUST NOT show up when listing all events.
 	*/
-	framework.ConformanceIt("should ensure that an event can be fetched, patched, deleted, and listed", func() {
+	framework.ConformanceIt("Base", "should ensure that an event can be fetched, patched, deleted, and listed", func() {
 		eventTestName := "event-test"
 
 		ginkgo.By("creating a test event")
@@ -129,7 +129,7 @@ var _ = ginkgo.Describe("[sig-api-machinery] Events", func() {
 	   Description: A set of events is created with a label selector which MUST be found when listed.
 	   The set of events is deleted and MUST NOT show up when listed by its label selector.
 	*/
-	framework.ConformanceIt("should delete a collection of events", func() {
+	framework.ConformanceIt("Base", "should delete a collection of events", func() {
 		eventTestNames := []string{"test-event-1", "test-event-2", "test-event-3"}
 
 		ginkgo.By("Create set of events")

--- a/test/e2e/apimachinery/garbage_collector.go
+++ b/test/e2e/apimachinery/garbage_collector.go
@@ -324,7 +324,7 @@ var _ = SIGDescribe("Garbage collector", func() {
 		Testname: Garbage Collector, delete replication controller, propagation policy background
 		Description: Create a replication controller with 2 Pods. Once RC is created and the first Pod is created, delete RC with deleteOptions.PropagationPolicy set to Background. Deleting the Replication Controller MUST cause pods created by that RC to be deleted.
 	*/
-	framework.ConformanceIt("should delete pods created by rc when not orphaning", func() {
+	framework.ConformanceIt("Base", "should delete pods created by rc when not orphaning", func() {
 		clientSet := f.ClientSet
 		rcClient := clientSet.CoreV1().ReplicationControllers(f.Namespace.Name)
 		podClient := clientSet.CoreV1().Pods(f.Namespace.Name)
@@ -382,7 +382,7 @@ var _ = SIGDescribe("Garbage collector", func() {
 		Testname: Garbage Collector, delete replication controller, propagation policy orphan
 		Description: Create a replication controller with maximum allocatable Pods between 10 and 100 replicas. Once RC is created and the all Pods are created, delete RC with deleteOptions.PropagationPolicy set to Orphan. Deleting the Replication Controller MUST cause pods created by that RC to be orphaned.
 	*/
-	framework.ConformanceIt("should orphan pods created by rc if delete options say so", func() {
+	framework.ConformanceIt("Base", "should orphan pods created by rc if delete options say so", func() {
 		clientSet := f.ClientSet
 		rcClient := clientSet.CoreV1().ReplicationControllers(f.Namespace.Name)
 		podClient := clientSet.CoreV1().Pods(f.Namespace.Name)
@@ -503,7 +503,7 @@ var _ = SIGDescribe("Garbage collector", func() {
 		Testname: Garbage Collector, delete deployment,  propagation policy background
 		Description: Create a deployment with a replicaset. Once replicaset is created , delete the deployment  with deleteOptions.PropagationPolicy set to Background. Deleting the deployment MUST delete the replicaset created by the deployment and also the Pods that belong to the deployments MUST be deleted.
 	*/
-	framework.ConformanceIt("should delete RS created by deployment when not orphaning", func() {
+	framework.ConformanceIt("Base", "should delete RS created by deployment when not orphaning", func() {
 		clientSet := f.ClientSet
 		deployClient := clientSet.AppsV1().Deployments(f.Namespace.Name)
 		rsClient := clientSet.AppsV1().ReplicaSets(f.Namespace.Name)
@@ -562,7 +562,7 @@ var _ = SIGDescribe("Garbage collector", func() {
 		Testname: Garbage Collector, delete deployment, propagation policy orphan
 		Description: Create a deployment with a replicaset. Once replicaset is created , delete the deployment  with deleteOptions.PropagationPolicy set to Orphan. Deleting the deployment MUST cause the replicaset created by the deployment to be orphaned, also the Pods created by the deployments MUST be orphaned.
 	*/
-	framework.ConformanceIt("should orphan RS created by deployment when deleteOptions.PropagationPolicy is Orphan", func() {
+	framework.ConformanceIt("Base", "should orphan RS created by deployment when deleteOptions.PropagationPolicy is Orphan", func() {
 		clientSet := f.ClientSet
 		deployClient := clientSet.AppsV1().Deployments(f.Namespace.Name)
 		rsClient := clientSet.AppsV1().ReplicaSets(f.Namespace.Name)
@@ -646,7 +646,7 @@ var _ = SIGDescribe("Garbage collector", func() {
 		Testname: Garbage Collector, delete replication controller, after owned pods
 		Description: Create a replication controller with maximum allocatable Pods between 10 and 100 replicas. Once RC is created and the all Pods are created, delete RC with deleteOptions.PropagationPolicy set to Foreground. Deleting the Replication Controller MUST cause pods created by that RC to be deleted before the RC is deleted.
 	*/
-	framework.ConformanceIt("should keep the rc around until all its pods are deleted if the deleteOptions says so", func() {
+	framework.ConformanceIt("Base", "should keep the rc around until all its pods are deleted if the deleteOptions says so", func() {
 		clientSet := f.ClientSet
 		rcClient := clientSet.CoreV1().ReplicationControllers(f.Namespace.Name)
 		podClient := clientSet.CoreV1().Pods(f.Namespace.Name)
@@ -731,7 +731,7 @@ var _ = SIGDescribe("Garbage collector", func() {
 		Testname: Garbage Collector, multiple owners
 		Description: Create a replication controller RC1, with maximum allocatable Pods between 10 and 100 replicas. Create second replication controller RC2 and set RC2 as owner for half of those replicas. Once RC1 is created and the all Pods are created, delete RC1 with deleteOptions.PropagationPolicy set to Foreground. Half of the Pods that has RC2 as owner MUST not be deleted but have a deletion timestamp. Deleting the Replication Controller MUST not delete Pods that are owned by multiple replication controllers.
 	*/
-	framework.ConformanceIt("should not delete dependents that have both valid owner and owner that's waiting for dependents to be deleted", func() {
+	framework.ConformanceIt("Base", "should not delete dependents that have both valid owner and owner that's waiting for dependents to be deleted", func() {
 		clientSet := f.ClientSet
 		rcClient := clientSet.CoreV1().ReplicationControllers(f.Namespace.Name)
 		podClient := clientSet.CoreV1().Pods(f.Namespace.Name)
@@ -845,7 +845,7 @@ var _ = SIGDescribe("Garbage collector", func() {
 		Testname: Garbage Collector, dependency cycle
 		Description: Create three pods, patch them with Owner references such that pod1 has pod3, pod2 has pod1 and pod3 has pod2 as owner references respectively. Delete pod1 MUST delete all pods. The dependency cycle MUST not block the garbage collection.
 	*/
-	framework.ConformanceIt("should not be blocked by dependency circle", func() {
+	framework.ConformanceIt("Base", "should not be blocked by dependency circle", func() {
 		clientSet := f.ClientSet
 		podClient := clientSet.CoreV1().Pods(f.Namespace.Name)
 		pod1Name := "pod1"

--- a/test/e2e/apimachinery/namespace.go
+++ b/test/e2e/apimachinery/namespace.go
@@ -231,14 +231,14 @@ var _ = SIGDescribe("Namespaces [Serial]", func() {
 		Testname: namespace-deletion-removes-pods
 		Description: Ensure that if a namespace is deleted then all pods are removed from that namespace.
 	*/
-	framework.ConformanceIt("should ensure that all pods are removed when a namespace is deleted",
+	framework.ConformanceIt("Base", "should ensure that all pods are removed when a namespace is deleted",
 		func() { ensurePodsAreRemovedWhenNamespaceIsDeleted(f) })
 
 	/*
 		Testname: namespace-deletion-removes-services
 		Description: Ensure that if a namespace is deleted then all services are removed from that namespace.
 	*/
-	framework.ConformanceIt("should ensure that all services are removed when a namespace is deleted",
+	framework.ConformanceIt("Base", "should ensure that all services are removed when a namespace is deleted",
 		func() { ensureServicesAreRemovedWhenNamespaceIsDeleted(f) })
 
 	ginkgo.It("should delete fast enough (90 percent of 100 namespaces in 150 seconds)",
@@ -255,7 +255,7 @@ var _ = SIGDescribe("Namespaces [Serial]", func() {
 	   The Namespace is patched.
 	   The Namespace and MUST now include the new Label.
 	*/
-	framework.ConformanceIt("should patch a Namespace", func() {
+	framework.ConformanceIt("Base", "should patch a Namespace", func() {
 		ginkgo.By("creating a Namespace")
 		namespaceName := "nspatchtest-" + string(uuid.NewUUID())
 		ns, err := f.CreateNamespace(namespaceName, nil)

--- a/test/e2e/apimachinery/resource_quota.go
+++ b/test/e2e/apimachinery/resource_quota.go
@@ -57,7 +57,7 @@ var _ = SIGDescribe("ResourceQuota", func() {
 		Testname: ResourceQuota, object count quota, resourcequotas
 		Description: Create a ResourceQuota. Creation MUST be successful and its ResourceQuotaStatus MUST match to expected used and total allowed resource quota count within namespace.
 	*/
-	framework.ConformanceIt("should create a ResourceQuota and ensure its status is promptly calculated.", func() {
+	framework.ConformanceIt("Privileged", "should create a ResourceQuota and ensure its status is promptly calculated.", func() {
 		ginkgo.By("Counting existing ResourceQuota")
 		c, err := countResourceQuota(f.ClientSet, f.Namespace.Name)
 		framework.ExpectNoError(err)
@@ -82,7 +82,7 @@ var _ = SIGDescribe("ResourceQuota", func() {
 		Create a Service. Its creation MUST be successful and resource usage count against the Service object and resourceQuota object MUST be captured in ResourceQuotaStatus of the ResourceQuota.
 		Delete the Service. Deletion MUST succeed and resource usage count against the Service object MUST be released from ResourceQuotaStatus of the ResourceQuota.
 	*/
-	framework.ConformanceIt("should create a ResourceQuota and capture the life of a service.", func() {
+	framework.ConformanceIt("Privileged", "should create a ResourceQuota and capture the life of a service.", func() {
 		ginkgo.By("Counting existing ResourceQuota")
 		c, err := countResourceQuota(f.ClientSet, f.Namespace.Name)
 		framework.ExpectNoError(err)
@@ -128,7 +128,7 @@ var _ = SIGDescribe("ResourceQuota", func() {
 		Create a Secret. Its creation MUST be successful and resource usage count against the Secret object and resourceQuota object MUST be captured in ResourceQuotaStatus of the ResourceQuota.
 		Delete the Secret. Deletion MUST succeed and resource usage count against the Secret object MUST be released from ResourceQuotaStatus of the ResourceQuota.
 	*/
-	framework.ConformanceIt("should create a ResourceQuota and capture the life of a secret.", func() {
+	framework.ConformanceIt("Privileged", "should create a ResourceQuota and capture the life of a secret.", func() {
 		ginkgo.By("Discovering how many secrets are in namespace by default")
 		found, unchanged := 0, 0
 		// On contended servers the service account controller can slow down, leading to the count changing during a run.
@@ -198,7 +198,7 @@ var _ = SIGDescribe("ResourceQuota", func() {
 		Update the successfully created pod's resource requests. Updation MUST fail as a Pod can not dynamically update its resource requirements.
 		Delete the successfully created Pod. Pod Deletion MUST be scuccessful and it MUST release the allocated resource counts from ResourceQuotaStatus of the ResourceQuota.
 	*/
-	framework.ConformanceIt("should create a ResourceQuota and capture the life of a pod.", func() {
+	framework.ConformanceIt("Privileged", "should create a ResourceQuota and capture the life of a pod.", func() {
 		ginkgo.By("Counting existing ResourceQuota")
 		c, err := countResourceQuota(f.ClientSet, f.Namespace.Name)
 		framework.ExpectNoError(err)
@@ -294,7 +294,7 @@ var _ = SIGDescribe("ResourceQuota", func() {
 		Create a ConfigMap. Its creation MUST be successful and resource usage count against the ConfigMap object MUST be captured in ResourceQuotaStatus of the ResourceQuota.
 		Delete the ConfigMap. Deletion MUST succeed and resource usage count against the ConfigMap object MUST be released from ResourceQuotaStatus of the ResourceQuota.
 	*/
-	framework.ConformanceIt("should create a ResourceQuota and capture the life of a configMap.", func() {
+	framework.ConformanceIt("Privileged", "should create a ResourceQuota and capture the life of a configMap.", func() {
 		found, unchanged := 0, 0
 		// On contended servers the service account controller can slow down, leading to the count changing during a run.
 		// Wait up to 5s for the count to stabilize, assuming that updates come at a consistent rate, and are not held indefinitely.
@@ -362,7 +362,7 @@ var _ = SIGDescribe("ResourceQuota", func() {
 		Create a ReplicationController. Its creation MUST be successful and resource usage count against the ReplicationController object MUST be captured in ResourceQuotaStatus of the ResourceQuota.
 		Delete the ReplicationController. Deletion MUST succeed and resource usage count against the ReplicationController object MUST be released from ResourceQuotaStatus of the ResourceQuota.
 	*/
-	framework.ConformanceIt("should create a ResourceQuota and capture the life of a replication controller.", func() {
+	framework.ConformanceIt("Privileged", "should create a ResourceQuota and capture the life of a replication controller.", func() {
 		ginkgo.By("Counting existing ResourceQuota")
 		c, err := countResourceQuota(f.ClientSet, f.Namespace.Name)
 		framework.ExpectNoError(err)
@@ -418,7 +418,7 @@ var _ = SIGDescribe("ResourceQuota", func() {
 		Create a ReplicaSet. Its creation MUST be successful and resource usage count against the ReplicaSet object MUST be captured in ResourceQuotaStatus of the ResourceQuota.
 		Delete the ReplicaSet. Deletion MUST succeed and resource usage count against the ReplicaSet object MUST be released from ResourceQuotaStatus of the ResourceQuota.
 	*/
-	framework.ConformanceIt("should create a ResourceQuota and capture the life of a replica set.", func() {
+	framework.ConformanceIt("Privileged", "should create a ResourceQuota and capture the life of a replica set.", func() {
 		ginkgo.By("Counting existing ResourceQuota")
 		c, err := countResourceQuota(f.ClientSet, f.Namespace.Name)
 		framework.ExpectNoError(err)
@@ -660,7 +660,7 @@ var _ = SIGDescribe("ResourceQuota", func() {
 		Create a pod with specified activeDeadlineSeconds and resourceRequirements for CPU and Memory fall within quota limits. Pod creation MUST be successful and usage count MUST be captured in ResourceQuotaStatus of 'Terminating' scoped ResourceQuota but MUST NOT in 'NotTerminating' scoped ResourceQuota.
 		Delete the Pod. Pod deletion MUST succeed and Pod resource usage count MUST be released from ResourceQuotaStatus of 'Terminating' scoped ResourceQuota.
 	*/
-	framework.ConformanceIt("should verify ResourceQuota with terminating scopes.", func() {
+	framework.ConformanceIt("Privileged", "should verify ResourceQuota with terminating scopes.", func() {
 		ginkgo.By("Creating a ResourceQuota with terminating scope")
 		quotaTerminatingName := "quota-terminating"
 		resourceQuotaTerminating, err := createResourceQuota(f.ClientSet, f.Namespace.Name, newTestResourceQuotaWithScope(quotaTerminatingName, v1.ResourceQuotaScopeTerminating))
@@ -773,7 +773,7 @@ var _ = SIGDescribe("ResourceQuota", func() {
 		Create a 'NotBestEffort' Pod by explicitly specifying resource limits and requests. Pod creation MUST be successful and usage count MUST be captured in ResourceQuotaStatus of 'NotBestEffort' scoped ResourceQuota but MUST NOT in 'BestEffort' scoped ResourceQuota.
 		Delete the Pod. Pod deletion MUST succeed and Pod resource usage count MUST be released from ResourceQuotaStatus of 'NotBestEffort' scoped ResourceQuota.
 	*/
-	framework.ConformanceIt("should verify ResourceQuota with best effort scope.", func() {
+	framework.ConformanceIt("Privileged", "should verify ResourceQuota with best effort scope.", func() {
 		ginkgo.By("Creating a ResourceQuota with best effort scope")
 		resourceQuotaBestEffort, err := createResourceQuota(f.ClientSet, f.Namespace.Name, newTestResourceQuotaWithScope("quota-besteffort", v1.ResourceQuotaScopeBestEffort))
 		framework.ExpectNoError(err)
@@ -854,7 +854,7 @@ var _ = SIGDescribe("ResourceQuota", func() {
 		When ResourceQuota is updated to modify CPU and Memory quota limits, update MUST succeed with updated values for CPU and Memory limits.
 		When ResourceQuota is deleted, it MUST not be available in the namespace.
 	*/
-	framework.ConformanceIt("should be able to update and delete ResourceQuota.", func() {
+	framework.ConformanceIt("Privileged", "should be able to update and delete ResourceQuota.", func() {
 		client := f.ClientSet
 		ns := f.Namespace.Name
 

--- a/test/e2e/apimachinery/server_version.go
+++ b/test/e2e/apimachinery/server_version.go
@@ -33,7 +33,7 @@ var _ = SIGDescribe("server version", func() {
 	   Description: Ensure that an API server version can be retrieved.
 	   Both the major and minor versions MUST only be an integer.
 	*/
-	framework.ConformanceIt("should find the server version", func() {
+	framework.ConformanceIt("Base", "should find the server version", func() {
 
 		ginkgo.By("Request ServerVersion")
 

--- a/test/e2e/apimachinery/table_conversion.go
+++ b/test/e2e/apimachinery/table_conversion.go
@@ -151,7 +151,7 @@ var _ = SIGDescribe("Servers with support for Table transformation", func() {
 				Description: Issue a HTTP request to the API.
 		        HTTP request MUST return a HTTP status code of 406.
 	*/
-	framework.ConformanceIt("should return a 406 for a backend which does not implement metadata", func() {
+	framework.ConformanceIt("Base", "should return a 406 for a backend which does not implement metadata", func() {
 		c := f.ClientSet
 
 		table := &metav1beta1.Table{}

--- a/test/e2e/apimachinery/watch.go
+++ b/test/e2e/apimachinery/watch.go
@@ -51,7 +51,7 @@ var _ = SIGDescribe("Watchers", func() {
 			update, and delete notifications on configmaps that match a label selector and do
 			not receive notifications for configmaps which do not match that label selector.
 	*/
-	framework.ConformanceIt("should observe add, update, and delete watch notifications on configmaps", func() {
+	framework.ConformanceIt("Base", "should observe add, update, and delete watch notifications on configmaps", func() {
 		c := f.ClientSet
 		ns := f.Namespace.Name
 
@@ -136,7 +136,7 @@ var _ = SIGDescribe("Watchers", func() {
 		    Description: Ensure that a watch can be opened from a particular resource version
 			in the past and only notifications happening after that resource version are observed.
 	*/
-	framework.ConformanceIt("should be able to start watching from a specific resource version", func() {
+	framework.ConformanceIt("Base", "should be able to start watching from a specific resource version", func() {
 		c := f.ClientSet
 		ns := f.Namespace.Name
 
@@ -184,7 +184,7 @@ var _ = SIGDescribe("Watchers", func() {
 			observed by the previous watch, and it will continue delivering notifications from
 			that point in time.
 	*/
-	framework.ConformanceIt("should be able to restart watching from the last resource version observed by the previous watch", func() {
+	framework.ConformanceIt("Base", "should be able to restart watching from the last resource version observed by the previous watch", func() {
 		c := f.ClientSet
 		ns := f.Namespace.Name
 
@@ -249,7 +249,7 @@ var _ = SIGDescribe("Watchers", func() {
 			a watch's selector, the watch will observe a delete, and will not observe
 			notifications for that object until it meets the selector's requirements again.
 	*/
-	framework.ConformanceIt("should observe an object deletion if it stops meeting the requirements of the selector", func() {
+	framework.ConformanceIt("Base", "should observe an object deletion if it stops meeting the requirements of the selector", func() {
 		c := f.ClientSet
 		ns := f.Namespace.Name
 
@@ -326,7 +326,7 @@ var _ = SIGDescribe("Watchers", func() {
 	   for events received from the first watch, initiated at the resource version of the event, and checking that all
 	   resource versions of all events match. Events are produced from writes on a background goroutine.
 	*/
-	framework.ConformanceIt("should receive events on concurrent watches in same order", func() {
+	framework.ConformanceIt("Base", "should receive events on concurrent watches in same order", func() {
 		c := f.ClientSet
 		ns := f.Namespace.Name
 

--- a/test/e2e/apimachinery/webhook.go
+++ b/test/e2e/apimachinery/webhook.go
@@ -111,7 +111,7 @@ var _ = SIGDescribe("AdmissionWebhook [Privileged:ClusterAdmin]", func() {
 		The mutatingwebhookconfigurations and validatingwebhookconfigurations resources MUST exist in the
 		/apis/admissionregistration.k8s.io/v1 discovery document.
 	*/
-	framework.ConformanceIt("should include webhook resources in discovery documents", func() {
+	framework.ConformanceIt("Privileged", "should include webhook resources in discovery documents", func() {
 		{
 			ginkgo.By("fetching the /apis discovery document")
 			apiGroupList := &metav1.APIGroupList{}
@@ -191,7 +191,7 @@ var _ = SIGDescribe("AdmissionWebhook [Privileged:ClusterAdmin]", func() {
 		and the pod creation MUST be denied. An attempt to create a non-compliant configmap in a whitelisted
 		namespace based on the webhook namespace selector MUST be allowed.
 	*/
-	framework.ConformanceIt("should be able to deny pod and configmap creation", func() {
+	framework.ConformanceIt("Privileged", "should be able to deny pod and configmap creation", func() {
 		webhookCleanup := registerWebhook(f, f.UniqueName, certCtx, servicePort)
 		defer webhookCleanup()
 		testWebhook(f)
@@ -203,7 +203,7 @@ var _ = SIGDescribe("AdmissionWebhook [Privileged:ClusterAdmin]", func() {
 		Description: Register an admission webhook configuration that denies connecting to a pod's attach sub-resource.
 		Attempts to attach MUST be denied.
 	*/
-	framework.ConformanceIt("should be able to deny attaching pod", func() {
+	framework.ConformanceIt("Privileged", "should be able to deny attaching pod", func() {
 		webhookCleanup := registerWebhookForAttachingPod(f, f.UniqueName, certCtx, servicePort)
 		defer webhookCleanup()
 		testAttachingPodWebhook(f)
@@ -215,7 +215,7 @@ var _ = SIGDescribe("AdmissionWebhook [Privileged:ClusterAdmin]", func() {
 		Description: Register an admission webhook configuration that denies creation, update and deletion of
 		custom resources. Attempts to create, update and delete custom resources MUST be denied.
 	*/
-	framework.ConformanceIt("should be able to deny custom resource creation, update and deletion", func() {
+	framework.ConformanceIt("Privileged", "should be able to deny custom resource creation, update and deletion", func() {
 		testcrd, err := crd.CreateTestCRD(f)
 		if err != nil {
 			return
@@ -233,7 +233,7 @@ var _ = SIGDescribe("AdmissionWebhook [Privileged:ClusterAdmin]", func() {
 		Description: Register a webhook with a fail closed policy and without CA bundle so that it cannot be called.
 		Attempt operations that require the admission webhook; all MUST be denied.
 	*/
-	framework.ConformanceIt("should unconditionally reject operations on fail closed webhook", func() {
+	framework.ConformanceIt("Privileged", "should unconditionally reject operations on fail closed webhook", func() {
 		webhookCleanup := registerFailClosedWebhook(f, f.UniqueName, certCtx, servicePort)
 		defer webhookCleanup()
 		testFailClosedWebhook(f)
@@ -246,7 +246,7 @@ var _ = SIGDescribe("AdmissionWebhook [Privileged:ClusterAdmin]", func() {
 		adds a data key if the configmap already has a specific key, and another that adds a key if the key added by
 		the first webhook is present. Attempt to create a config map; both keys MUST be added to the config map.
 	*/
-	framework.ConformanceIt("should mutate configmap", func() {
+	framework.ConformanceIt("Privileged", "should mutate configmap", func() {
 		webhookCleanup := registerMutatingWebhookForConfigMap(f, f.UniqueName, certCtx, servicePort)
 		defer webhookCleanup()
 		testMutatingConfigMapWebhook(f)
@@ -258,7 +258,7 @@ var _ = SIGDescribe("AdmissionWebhook [Privileged:ClusterAdmin]", func() {
 		Description: Register a mutating webhook that adds an InitContainer to pods. Attempt to create a pod;
 		the InitContainer MUST be added the TerminationMessagePolicy MUST be defaulted.
 	*/
-	framework.ConformanceIt("should mutate pod and apply defaults after mutation", func() {
+	framework.ConformanceIt("Privileged", "should mutate pod and apply defaults after mutation", func() {
 		webhookCleanup := registerMutatingWebhookForPod(f, f.UniqueName, certCtx, servicePort)
 		defer webhookCleanup()
 		testMutatingPodWebhook(f)
@@ -271,7 +271,7 @@ var _ = SIGDescribe("AdmissionWebhook [Privileged:ClusterAdmin]", func() {
 		and delete a webhook configuration object; both operations MUST be allowed and the webhook configuration object
 		MUST NOT be mutated the webhooks.
 	*/
-	framework.ConformanceIt("should not be able to mutate or prevent deletion of webhook configuration objects", func() {
+	framework.ConformanceIt("Privileged", "should not be able to mutate or prevent deletion of webhook configuration objects", func() {
 		validatingWebhookCleanup := registerValidatingWebhookForWebhookConfigurations(f, f.UniqueName+"blocking", certCtx, servicePort)
 		defer validatingWebhookCleanup()
 		mutatingWebhookCleanup := registerMutatingWebhookForWebhookConfigurations(f, f.UniqueName+"blocking", certCtx, servicePort)
@@ -285,7 +285,7 @@ var _ = SIGDescribe("AdmissionWebhook [Privileged:ClusterAdmin]", func() {
 		Description: Register a webhook that mutates a custom resource. Attempt to create custom resource object;
 		the custom resource MUST be mutated.
 	*/
-	framework.ConformanceIt("should mutate custom resource", func() {
+	framework.ConformanceIt("Privileged", "should mutate custom resource", func() {
 		testcrd, err := crd.CreateTestCRD(f)
 		if err != nil {
 			return
@@ -302,7 +302,7 @@ var _ = SIGDescribe("AdmissionWebhook [Privileged:ClusterAdmin]", func() {
 		Description: Register a webhook that denies custom resource definition create. Attempt to create a
 		custom resource definition; the create request MUST be denied.
 	*/
-	framework.ConformanceIt("should deny crd creation", func() {
+	framework.ConformanceIt("Privileged", "should deny crd creation", func() {
 		crdWebhookCleanup := registerValidatingWebhookForCRD(f, f.UniqueName, certCtx, servicePort)
 		defer crdWebhookCleanup()
 
@@ -317,7 +317,7 @@ var _ = SIGDescribe("AdmissionWebhook [Privileged:ClusterAdmin]", func() {
 		the stored version. Attempt to patch the custom resource with a new field and value; the patch MUST be applied
 		successfully.
 	*/
-	framework.ConformanceIt("should mutate custom resource with different stored version", func() {
+	framework.ConformanceIt("Privileged", "should mutate custom resource with different stored version", func() {
 		testcrd, err := createAdmissionWebhookMultiVersionTestCRDWithV1Storage(f)
 		if err != nil {
 			return
@@ -335,7 +335,7 @@ var _ = SIGDescribe("AdmissionWebhook [Privileged:ClusterAdmin]", func() {
 		with a schema that includes only one of the data keys added by the webhooks. Attempt to a custom resource;
 		the fields included in the schema MUST be present and field not included in the schema MUST NOT be present.
 	*/
-	framework.ConformanceIt("should mutate custom resource with pruning", func() {
+	framework.ConformanceIt("Privileged", "should mutate custom resource with pruning", func() {
 		const prune = true
 		testcrd, err := createAdmissionWebhookMultiVersionTestCRDWithV1Storage(f, func(crd *apiextensionsv1.CustomResourceDefinition) {
 			crd.Spec.PreserveUnknownFields = false
@@ -375,7 +375,7 @@ var _ = SIGDescribe("AdmissionWebhook [Privileged:ClusterAdmin]", func() {
 		the failure policy is ignore. Requests MUST NOT timeout if configured webhook timeout is 10 seconds (much longer
 		than the webhook wait duration).
 	*/
-	framework.ConformanceIt("should honor timeout", func() {
+	framework.ConformanceIt("Privileged", "should honor timeout", func() {
 		policyFail := admissionregistrationv1.Fail
 		policyIgnore := admissionregistrationv1.Ignore
 
@@ -407,7 +407,7 @@ var _ = SIGDescribe("AdmissionWebhook [Privileged:ClusterAdmin]", func() {
 		operation and attempt to create an object; the webhook MUST NOT deny the create. Patch the webhook to apply to the
 		create operation again and attempt to create an object; the webhook MUST deny the create.
 	*/
-	framework.ConformanceIt("patching/updating a validating webhook should work", func() {
+	framework.ConformanceIt("Privileged", "patching/updating a validating webhook should work", func() {
 		client := f.ClientSet
 		admissionClient := client.AdmissionregistrationV1()
 
@@ -502,7 +502,7 @@ var _ = SIGDescribe("AdmissionWebhook [Privileged:ClusterAdmin]", func() {
 		operation and attempt to create an object; the webhook MUST NOT mutate the object. Patch the webhook to apply to the
 		create operation again and attempt to create an object; the webhook MUST mutate the object.
 	*/
-	framework.ConformanceIt("patching/updating a mutating webhook should work", func() {
+	framework.ConformanceIt("Privileged", "patching/updating a mutating webhook should work", func() {
 		client := f.ClientSet
 		admissionClient := client.AdmissionregistrationV1()
 
@@ -576,7 +576,7 @@ var _ = SIGDescribe("AdmissionWebhook [Privileged:ClusterAdmin]", func() {
 		object; the create MUST be denied. Attempt to remove the webhook configurations matching the label with deletecollection;
 		all webhook configurations MUST be deleted. Attempt to create an object; the create MUST NOT be denied.
 	*/
-	framework.ConformanceIt("listing validating webhooks should work", func() {
+	framework.ConformanceIt("Privileged", "listing validating webhooks should work", func() {
 		testListSize := 10
 		testUUID := string(uuid.NewUUID())
 
@@ -650,7 +650,7 @@ var _ = SIGDescribe("AdmissionWebhook [Privileged:ClusterAdmin]", func() {
 		object; the object MUST be mutated. Attempt to remove the webhook configurations matching the label with deletecollection;
 		all webhook configurations MUST be deleted. Attempt to create an object; the object MUST NOT be mutated.
 	*/
-	framework.ConformanceIt("listing mutating webhooks should work", func() {
+	framework.ConformanceIt("Privileged", "listing mutating webhooks should work", func() {
 		testListSize := 10
 		testUUID := string(uuid.NewUUID())
 

--- a/test/e2e/apps/daemon_set.go
+++ b/test/e2e/apps/daemon_set.go
@@ -150,7 +150,7 @@ var _ = SIGDescribe("Daemon set [Serial]", func() {
 	  Description: A conformant Kubernetes distribution MUST support the creation of DaemonSets. When a DaemonSet
 	  Pod is deleted, the DaemonSet controller MUST create a replacement Pod.
 	*/
-	framework.ConformanceIt("should run and stop simple daemon", func() {
+	framework.ConformanceIt("Base", "should run and stop simple daemon", func() {
 		label := map[string]string{daemonsetNameLabel: dsName}
 
 		ginkgo.By(fmt.Sprintf("Creating simple DaemonSet %q", dsName))
@@ -177,7 +177,7 @@ var _ = SIGDescribe("Daemon set [Serial]", func() {
 	  Description: A conformant Kubernetes distribution MUST support DaemonSet Pod node selection via label
 	  selectors.
 	*/
-	framework.ConformanceIt("should run and stop complex daemon", func() {
+	framework.ConformanceIt("Privileged", "should run and stop complex daemon", func() {
 		complexLabel := map[string]string{daemonsetNameLabel: dsName}
 		nodeSelector := map[string]string{daemonsetColorLabel: "blue"}
 		framework.Logf("Creating daemon %q with a node selector", dsName)
@@ -276,7 +276,7 @@ var _ = SIGDescribe("Daemon set [Serial]", func() {
 	  Testname: DaemonSet-FailedPodCreation
 	  Description: A conformant Kubernetes distribution MUST create new DaemonSet Pods when they fail.
 	*/
-	framework.ConformanceIt("should retry creating failed daemon pods", func() {
+	framework.ConformanceIt("Base", "should retry creating failed daemon pods", func() {
 		label := map[string]string{daemonsetNameLabel: dsName}
 
 		ginkgo.By(fmt.Sprintf("Creating a simple DaemonSet %q", dsName))
@@ -355,7 +355,7 @@ var _ = SIGDescribe("Daemon set [Serial]", func() {
 	  Testname: DaemonSet-RollingUpdate
 	  Description: A conformant Kubernetes distribution MUST support DaemonSet RollingUpdates.
 	*/
-	framework.ConformanceIt("should update pod when spec was updated and update strategy is RollingUpdate", func() {
+	framework.ConformanceIt("Base", "should update pod when spec was updated and update strategy is RollingUpdate", func() {
 		label := map[string]string{daemonsetNameLabel: dsName}
 
 		framework.Logf("Creating simple daemon set %s", dsName)
@@ -412,7 +412,7 @@ var _ = SIGDescribe("Daemon set [Serial]", func() {
 	  Description: A conformant Kubernetes distribution MUST support automated, minimally disruptive
 	  rollback of updates to a DaemonSet.
 	*/
-	framework.ConformanceIt("should rollback without unnecessary restarts", func() {
+	framework.ConformanceIt("Base", "should rollback without unnecessary restarts", func() {
 		schedulableNodes, err := e2enode.GetReadySchedulableNodes(c)
 		framework.ExpectNoError(err)
 		gomega.Expect(len(schedulableNodes.Items)).To(gomega.BeNumerically(">", 1), "Conformance test suite needs a cluster with at least 2 nodes.")

--- a/test/e2e/apps/deployment.go
+++ b/test/e2e/apps/deployment.go
@@ -86,14 +86,14 @@ var _ = SIGDescribe("Deployment", func() {
 	  Testname: Deployment RollingUpdate
 	  Description: A conformant Kubernetes distribution MUST support the Deployment with RollingUpdate strategy.
 	*/
-	framework.ConformanceIt("RollingUpdateDeployment should delete old pods and create new ones", func() {
+	framework.ConformanceIt("Base", "RollingUpdateDeployment should delete old pods and create new ones", func() {
 		testRollingUpdateDeployment(f)
 	})
 	/*
 	  Testname: Deployment Recreate
 	  Description: A conformant Kubernetes distribution MUST support the Deployment with Recreate strategy.
 	*/
-	framework.ConformanceIt("RecreateDeployment should delete old pods and create new ones", func() {
+	framework.ConformanceIt("Base", "RecreateDeployment should delete old pods and create new ones", func() {
 		testRecreateDeployment(f)
 	})
 	/*
@@ -101,7 +101,7 @@ var _ = SIGDescribe("Deployment", func() {
 	  Description: A conformant Kubernetes distribution MUST clean up Deployment's ReplicaSets based on
 	  the Deployment's `.spec.revisionHistoryLimit`.
 	*/
-	framework.ConformanceIt("deployment should delete old replica sets", func() {
+	framework.ConformanceIt("Base", "deployment should delete old replica sets", func() {
 		testDeploymentCleanUpPolicy(f)
 	})
 	/*
@@ -110,7 +110,7 @@ var _ = SIGDescribe("Deployment", func() {
 	    i.e. allow arbitrary number of changes to desired state during rolling update
 	    before the rollout finishes.
 	*/
-	framework.ConformanceIt("deployment should support rollover", func() {
+	framework.ConformanceIt("Base", "deployment should support rollover", func() {
 		testRolloverDeployment(f)
 	})
 	ginkgo.It("iterative rollouts should eventually progress", func() {
@@ -125,7 +125,7 @@ var _ = SIGDescribe("Deployment", func() {
 	    proportional scaling, i.e. proportionally scale a Deployment's ReplicaSets
 	    when a Deployment is scaled.
 	*/
-	framework.ConformanceIt("deployment should support proportional scaling", func() {
+	framework.ConformanceIt("Base", "deployment should support proportional scaling", func() {
 		testProportionalScalingDeployment(f)
 	})
 	ginkgo.It("should not disrupt a cloud load-balancer's connectivity during rollout", func() {

--- a/test/e2e/apps/job.go
+++ b/test/e2e/apps/job.go
@@ -97,7 +97,7 @@ var _ = SIGDescribe("Job", func() {
 		Description: Explicitly cause the tasks to fail once initially. After restarting, the Job MUST
 		execute to completion.
 	*/
-	framework.ConformanceIt("should run a job to completion when tasks sometimes fail and are locally restarted", func() {
+	framework.ConformanceIt("Base", "should run a job to completion when tasks sometimes fail and are locally restarted", func() {
 		ginkgo.By("Creating a job")
 		// One failure, then a success, local restarts.
 		// We can't use the random failure approach, because kubelet will
@@ -152,7 +152,7 @@ var _ = SIGDescribe("Job", func() {
 		Testname: Jobs, active pods, graceful termination
 		Description: Create a job. Ensure the active pods reflect paralellism in the namespace and delete the job. Job MUST be deleted successfully.
 	*/
-	framework.ConformanceIt("should delete a job", func() {
+	framework.ConformanceIt("Base", "should delete a job", func() {
 		ginkgo.By("Creating a job")
 		job := e2ejob.NewTestJob("notTerminate", "foo", v1.RestartPolicyNever, parallelism, completions, nil, backoffLimit)
 		job, err := e2ejob.CreateJob(f.ClientSet, f.Namespace.Name, job)
@@ -178,7 +178,7 @@ var _ = SIGDescribe("Job", func() {
 		Orphan a Pod by modifying its owner reference. The Job MUST re-adopt the orphan pod.
 		Modify the labels of one of the Job's Pods. The Job MUST release the Pod.
 	*/
-	framework.ConformanceIt("should adopt matching orphans and release non-matching pods", func() {
+	framework.ConformanceIt("Base", "should adopt matching orphans and release non-matching pods", func() {
 		ginkgo.By("Creating a job")
 		job := e2ejob.NewTestJob("notTerminate", "adopt-release", v1.RestartPolicyNever, parallelism, completions, nil, backoffLimit)
 		// Replace job with the one returned from Create() so it has the UID.

--- a/test/e2e/apps/rc.go
+++ b/test/e2e/apps/rc.go
@@ -61,7 +61,7 @@ var _ = SIGDescribe("ReplicationController", func() {
 		Testname: Replication Controller, run basic image
 		Description: Replication Controller MUST create a Pod with Basic Image and MUST run the service with the provided image. Image MUST be tested by dialing into the service listening through TCP, UDP and HTTP.
 	*/
-	framework.ConformanceIt("should serve a basic image on each replica with a public image ", func() {
+	framework.ConformanceIt("Base", "should serve a basic image on each replica with a public image ", func() {
 		TestReplicationControllerServeImageOrFail(f, "basic", framework.ServeHostnameImage)
 	})
 
@@ -77,7 +77,7 @@ var _ = SIGDescribe("ReplicationController", func() {
 		Testname: Replication Controller, check for issues like exceeding allocated quota
 		Description: Attempt to create a Replication Controller with pods exceeding the namespace quota. The creation MUST fail
 	*/
-	framework.ConformanceIt("should surface a failure condition on a common issue like exceeded quota", func() {
+	framework.ConformanceIt("Base", "should surface a failure condition on a common issue like exceeded quota", func() {
 		testReplicationControllerConditionCheck(f)
 	})
 
@@ -86,7 +86,7 @@ var _ = SIGDescribe("ReplicationController", func() {
 		Testname: Replication Controller, adopt matching pods
 		Description: An ownerless Pod is created, then a Replication Controller (RC) is created whose label selector will match the Pod. The RC MUST either adopt the Pod or delete and replace it with a new Pod
 	*/
-	framework.ConformanceIt("should adopt matching pods on creation", func() {
+	framework.ConformanceIt("Base", "should adopt matching pods on creation", func() {
 		testRCAdoptMatchingOrphans(f)
 	})
 
@@ -95,7 +95,7 @@ var _ = SIGDescribe("ReplicationController", func() {
 		Testname: Replication Controller, release pods
 		Description: A Replication Controller (RC) is created, and its Pods are created. When the labels on one of the Pods change to no longer match the RC's label selector, the RC MUST release the Pod and update the Pod's owner references.
 	*/
-	framework.ConformanceIt("should release no longer matching pods", func() {
+	framework.ConformanceIt("Base", "should release no longer matching pods", func() {
 		testRCReleaseControlledNotMatching(f)
 	})
 

--- a/test/e2e/apps/replica_set.go
+++ b/test/e2e/apps/replica_set.go
@@ -91,7 +91,7 @@ var _ = SIGDescribe("ReplicaSet", func() {
 		Testname: Replica Set, run basic image
 		Description: Create a ReplicaSet with a Pod and a single Container. Make sure that the Pod is running. Pod SHOULD send a valid response when queried.
 	*/
-	framework.ConformanceIt("should serve a basic image on each replica with a public image ", func() {
+	framework.ConformanceIt("Base", "should serve a basic image on each replica with a public image ", func() {
 		testReplicaSetServeImageOrFail(f, "basic", framework.ServeHostnameImage)
 	})
 
@@ -111,7 +111,7 @@ var _ = SIGDescribe("ReplicaSet", func() {
 		Testname: Replica Set, adopt matching pods and release non matching pods
 		Description: A Pod is created, then a Replica Set (RS) whose label selector will match the Pod. The RS MUST either adopt the Pod or delete and replace it with a new Pod. When the labels on one of the Pods owned by the RS change to no longer match the RS's label selector, the RS MUST release the Pod and update the Pod's owner references
 	*/
-	framework.ConformanceIt("should adopt matching pods on creation and release no longer matching pods", func() {
+	framework.ConformanceIt("Base", "should adopt matching pods on creation and release no longer matching pods", func() {
 		testRSAdoptMatchingAndReleaseNotMatching(f)
 	})
 })

--- a/test/e2e/apps/statefulset.go
+++ b/test/e2e/apps/statefulset.go
@@ -293,7 +293,7 @@ var _ = SIGDescribe("StatefulSet", func() {
 		   Testname: StatefulSet, Rolling Update
 		   Description: StatefulSet MUST support the RollingUpdate strategy to automatically replace Pods one at a time when the Pod template changes. The StatefulSet's status MUST indicate the CurrentRevision and UpdateRevision. If the template is changed to match a prior revision, StatefulSet MUST detect this as a rollback instead of creating a new revision. This test does not depend on a preexisting default StorageClass or a dynamic provisioner.
 		*/
-		framework.ConformanceIt("should perform rolling updates and roll backs of template modifications", func() {
+		framework.ConformanceIt("Base", "should perform rolling updates and roll backs of template modifications", func() {
 			ginkgo.By("Creating a new StatefulSet")
 			ss := e2estatefulset.NewStatefulSet("ss2", ns, headlessSvcName, 3, nil, nil, labels)
 			rollbackTest(c, ns, ss)
@@ -304,7 +304,7 @@ var _ = SIGDescribe("StatefulSet", func() {
 		   Testname: StatefulSet, Rolling Update with Partition
 		   Description: StatefulSet's RollingUpdate strategy MUST support the Partition parameter for canaries and phased rollouts. If a Pod is deleted while a rolling update is in progress, StatefulSet MUST restore the Pod without violating the Partition. This test does not depend on a preexisting default StorageClass or a dynamic provisioner.
 		*/
-		framework.ConformanceIt("should perform canary updates and phased rolling updates of template modifications", func() {
+		framework.ConformanceIt("Base", "should perform canary updates and phased rolling updates of template modifications", func() {
 			ginkgo.By("Creating a new StatefulSet")
 			ss := e2estatefulset.NewStatefulSet("ss2", ns, headlessSvcName, 3, nil, nil, labels)
 			setHTTPProbe(ss)
@@ -574,7 +574,7 @@ var _ = SIGDescribe("StatefulSet", func() {
 		   Testname: StatefulSet, Scaling
 		   Description: StatefulSet MUST create Pods in ascending order by ordinal index when scaling up, and delete Pods in descending order when scaling down. Scaling up or down MUST pause if any Pods belonging to the StatefulSet are unhealthy. This test does not depend on a preexisting default StorageClass or a dynamic provisioner.
 		*/
-		framework.ConformanceIt("Scaling should happen in predictable order and halt if any stateful pod is unhealthy [Slow]", func() {
+		framework.ConformanceIt("Base", "Scaling should happen in predictable order and halt if any stateful pod is unhealthy [Slow]", func() {
 			psLabels := klabels.Set(labels)
 			w := &cache.ListWatch{
 				WatchFunc: func(options metav1.ListOptions) (i watch.Interface, e error) {
@@ -684,7 +684,7 @@ var _ = SIGDescribe("StatefulSet", func() {
 		   Testname: StatefulSet, Burst Scaling
 		   Description: StatefulSet MUST support the Parallel PodManagementPolicy for burst scaling. This test does not depend on a preexisting default StorageClass or a dynamic provisioner.
 		*/
-		framework.ConformanceIt("Burst scaling should run to completion even with unhealthy pods [Slow]", func() {
+		framework.ConformanceIt("Base", "Burst scaling should run to completion even with unhealthy pods [Slow]", func() {
 			psLabels := klabels.Set(labels)
 
 			ginkgo.By("Creating stateful set " + ssName + " in namespace " + ns)
@@ -726,7 +726,7 @@ var _ = SIGDescribe("StatefulSet", func() {
 		   Testname: StatefulSet, Recreate Failed Pod
 		   Description: StatefulSet MUST delete and recreate Pods it owns that go into a Failed state, such as when they are rejected or evicted by a Node. This test does not depend on a preexisting default StorageClass or a dynamic provisioner.
 		*/
-		framework.ConformanceIt("Should recreate evicted statefulset", func() {
+		framework.ConformanceIt("Privileged", "Should recreate evicted statefulset", func() {
 			podName := "test-pod"
 			statefulPodName := ssName + "-0"
 			ginkgo.By("Looking for a node to schedule stateful set and pod")
@@ -836,7 +836,7 @@ var _ = SIGDescribe("StatefulSet", func() {
 			Newly created StatefulSet resource MUST have a scale of one.
 			Bring the scale of the StatefulSet resource up to two. StatefulSet scale MUST be at two replicas.
 		*/
-		framework.ConformanceIt("should have a working scale subresource", func() {
+		framework.ConformanceIt("Base", "should have a working scale subresource", func() {
 			ginkgo.By("Creating statefulset " + ssName + " in namespace " + ns)
 			ss := e2estatefulset.NewStatefulSet(ssName, ns, headlessSvcName, 1, nil, nil, labels)
 			setHTTPProbe(ss)

--- a/test/e2e/auth/certificates.go
+++ b/test/e2e/auth/certificates.go
@@ -183,7 +183,7 @@ var _ = SIGDescribe("Certificates API [Privileged:ClusterAdmin]", func() {
 		The certificatesigningrequests/approval resource must support get, update, patch.
 		The certificatesigningrequests/status resource must support get, update, patch.
 	*/
-	framework.ConformanceIt("should support CSR API operations", func() {
+	framework.ConformanceIt("Privileged", "should support CSR API operations", func() {
 
 		// Setup
 		csrVersion := "v1"

--- a/test/e2e/auth/service_accounts.go
+++ b/test/e2e/auth/service_accounts.go
@@ -172,7 +172,7 @@ var _ = SIGDescribe("ServiceAccounts", func() {
 	                Token Mount path. All these three files MUST exist and the Service
 	                Account mount path MUST be auto mounted to the Container.
 	*/
-	framework.ConformanceIt("should mount an API token into pods ", func() {
+	framework.ConformanceIt("Base", "should mount an API token into pods ", func() {
 		var rootCAContent string
 
 		sa, err := f.ClientSet.CoreV1().ServiceAccounts(f.Namespace.Name).Create(context.TODO(), &v1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "mount-test"}}, metav1.CreateOptions{})
@@ -278,7 +278,7 @@ var _ = SIGDescribe("ServiceAccounts", func() {
 	   include test cases 1a,1b,2a,2b and 2c.
 	   In the test cases 1c,3a,3b and 3c the ServiceTokenVolume MUST not be auto mounted.
 	*/
-	framework.ConformanceIt("should allow opting out of API token automount ", func() {
+	framework.ConformanceIt("Base", "should allow opting out of API token automount ", func() {
 
 		var err error
 		trueValue := true
@@ -753,7 +753,7 @@ var _ = SIGDescribe("ServiceAccounts", func() {
 		                        Listing the ServiceAccounts MUST return the test ServiceAccount with it's patched values.
 		                        ServiceAccount will be deleted and MUST find a deleted watch event.
 	*/
-	framework.ConformanceIt("should run through the lifecycle of a ServiceAccount", func() {
+	framework.ConformanceIt("Base", "should run through the lifecycle of a ServiceAccount", func() {
 		testNamespaceName := f.Namespace.Name
 		testServiceAccountName := "testserviceaccount"
 		testServiceAccountStaticLabels := map[string]string{"test-serviceaccount-static": "true"}

--- a/test/e2e/common/configmap.go
+++ b/test/e2e/common/configmap.go
@@ -39,7 +39,7 @@ var _ = ginkgo.Describe("[sig-node] ConfigMap", func() {
 		Testname: ConfigMap, from environment field
 		Description: Create a Pod with an environment variable value set using a value from ConfigMap. A ConfigMap value MUST be accessible in the container environment.
 	*/
-	framework.ConformanceIt("should be consumable via environment variable [NodeConformance]", func() {
+	framework.ConformanceIt("Base", "should be consumable via environment variable [NodeConformance]", func() {
 		name := "configmap-test-" + string(uuid.NewUUID())
 		configMap := newConfigMap(f, name)
 		ginkgo.By(fmt.Sprintf("Creating configMap %v/%v", f.Namespace.Name, configMap.Name))
@@ -87,7 +87,7 @@ var _ = ginkgo.Describe("[sig-node] ConfigMap", func() {
 		Testname: ConfigMap, from environment variables
 		Description: Create a Pod with a environment source from ConfigMap. All ConfigMap values MUST be available as environment variables in the container.
 	*/
-	framework.ConformanceIt("should be consumable via the environment [NodeConformance]", func() {
+	framework.ConformanceIt("Base", "should be consumable via the environment [NodeConformance]", func() {
 		name := "configmap-test-" + string(uuid.NewUUID())
 		configMap := newEnvFromConfigMap(f, name)
 		ginkgo.By(fmt.Sprintf("Creating configMap %v/%v", f.Namespace.Name, configMap.Name))
@@ -132,7 +132,7 @@ var _ = ginkgo.Describe("[sig-node] ConfigMap", func() {
 	   Testname: ConfigMap, with empty-key
 	   Description: Attempt to create a ConfigMap with an empty key. The creation MUST fail.
 	*/
-	framework.ConformanceIt("should fail to create ConfigMap with empty key", func() {
+	framework.ConformanceIt("Base", "should fail to create ConfigMap with empty key", func() {
 		configMap, err := newConfigMapWithEmptyKey(f)
 		framework.ExpectError(err, "created configMap %q with empty key in namespace %q", configMap.Name, f.Namespace.Name)
 	})
@@ -163,7 +163,7 @@ var _ = ginkgo.Describe("[sig-node] ConfigMap", func() {
 	   Description: Attempt to create a ConfigMap. Patch the created ConfigMap. Fetching the ConfigMap MUST reflect changes.
 	   By fetching all the ConfigMaps via a Label selector it MUST find the ConfigMap by it's static label and updated value. The ConfigMap must be deleted by Collection.
 	*/
-	framework.ConformanceIt("should run through a ConfigMap lifecycle", func() {
+	framework.ConformanceIt("Base", "should run through a ConfigMap lifecycle", func() {
 		testNamespaceName := f.Namespace.Name
 		testConfigMapName := "test-configmap" + string(uuid.NewUUID())
 

--- a/test/e2e/common/configmap_volume.go
+++ b/test/e2e/common/configmap_volume.go
@@ -41,7 +41,7 @@ var _ = ginkgo.Describe("[sig-storage] ConfigMap", func() {
 		Testname: ConfigMap Volume, without mapping
 		Description: Create a ConfigMap, create a Pod that mounts a volume and populates the volume with data stored in the ConfigMap. The ConfigMap that is created MUST be accessible to read from the newly created Pod using the volume mount. The data content of the file MUST be readable and verified and file modes MUST default to 0x644.
 	*/
-	framework.ConformanceIt("should be consumable from pods in volume [NodeConformance]", func() {
+	framework.ConformanceIt("Base", "should be consumable from pods in volume [NodeConformance]", func() {
 		doConfigMapE2EWithoutMappings(f, false, 0, nil)
 	})
 
@@ -51,7 +51,7 @@ var _ = ginkgo.Describe("[sig-storage] ConfigMap", func() {
 		Description: Create a ConfigMap, create a Pod that mounts a volume and populates the volume with data stored in the ConfigMap. File mode is changed to a custom value of '0x400'. The ConfigMap that is created MUST be accessible to read from the newly created Pod using the volume mount. The data content of the file MUST be readable and verified and file modes MUST be set to the custom value of '0x400'
 		This test is marked LinuxOnly since Windows does not support setting specific file permissions.
 	*/
-	framework.ConformanceIt("should be consumable from pods in volume with defaultMode set [LinuxOnly] [NodeConformance]", func() {
+	framework.ConformanceIt("Base", "should be consumable from pods in volume with defaultMode set [LinuxOnly] [NodeConformance]", func() {
 		defaultMode := int32(0400)
 		doConfigMapE2EWithoutMappings(f, false, 0, &defaultMode)
 	})
@@ -68,7 +68,7 @@ var _ = ginkgo.Describe("[sig-storage] ConfigMap", func() {
 		Testname: ConfigMap Volume, without mapping, non-root user
 		Description: Create a ConfigMap, create a Pod that mounts a volume and populates the volume with data stored in the ConfigMap. Pod is run as a non-root user with uid=1000. The ConfigMap that is created MUST be accessible to read from the newly created Pod using the volume mount. The file on the volume MUST have file mode set to default value of 0x644.
 	*/
-	framework.ConformanceIt("should be consumable from pods in volume as non-root [NodeConformance]", func() {
+	framework.ConformanceIt("Base", "should be consumable from pods in volume as non-root [NodeConformance]", func() {
 		doConfigMapE2EWithoutMappings(f, true, 0, nil)
 	})
 
@@ -83,7 +83,7 @@ var _ = ginkgo.Describe("[sig-storage] ConfigMap", func() {
 		Testname: ConfigMap Volume, with mapping
 		Description: Create a ConfigMap, create a Pod that mounts a volume and populates the volume with data stored in the ConfigMap. Files are mapped to a path in the volume. The ConfigMap that is created MUST be accessible to read from the newly created Pod using the volume mount. The data content of the file MUST be readable and verified and file modes MUST default to 0x644.
 	*/
-	framework.ConformanceIt("should be consumable from pods in volume with mappings [NodeConformance]", func() {
+	framework.ConformanceIt("Base", "should be consumable from pods in volume with mappings [NodeConformance]", func() {
 		doConfigMapE2EWithMappings(f, false, 0, nil)
 	})
 
@@ -93,7 +93,7 @@ var _ = ginkgo.Describe("[sig-storage] ConfigMap", func() {
 		Description: Create a ConfigMap, create a Pod that mounts a volume and populates the volume with data stored in the ConfigMap. Files are mapped to a path in the volume. File mode is changed to a custom value of '0x400'. The ConfigMap that is created MUST be accessible to read from the newly created Pod using the volume mount. The data content of the file MUST be readable and verified and file modes MUST be set to the custom value of '0x400'
 		This test is marked LinuxOnly since Windows does not support setting specific file permissions.
 	*/
-	framework.ConformanceIt("should be consumable from pods in volume with mappings and Item mode set [LinuxOnly] [NodeConformance]", func() {
+	framework.ConformanceIt("Base", "should be consumable from pods in volume with mappings and Item mode set [LinuxOnly] [NodeConformance]", func() {
 		mode := int32(0400)
 		doConfigMapE2EWithMappings(f, false, 0, &mode)
 	})
@@ -103,7 +103,7 @@ var _ = ginkgo.Describe("[sig-storage] ConfigMap", func() {
 		Testname: ConfigMap Volume, with mapping, non-root user
 		Description: Create a ConfigMap, create a Pod that mounts a volume and populates the volume with data stored in the ConfigMap. Files are mapped to a path in the volume. Pod is run as a non-root user with uid=1000. The ConfigMap that is created MUST be accessible to read from the newly created Pod using the volume mount. The file on the volume MUST have file mode set to default value of 0x644.
 	*/
-	framework.ConformanceIt("should be consumable from pods in volume with mappings as non-root [NodeConformance]", func() {
+	framework.ConformanceIt("Base", "should be consumable from pods in volume with mappings as non-root [NodeConformance]", func() {
 		doConfigMapE2EWithMappings(f, true, 0, nil)
 	})
 
@@ -118,7 +118,7 @@ var _ = ginkgo.Describe("[sig-storage] ConfigMap", func() {
 		Testname: ConfigMap Volume, update
 		Description: The ConfigMap that is created MUST be accessible to read from the newly created Pod using the volume mount that is mapped to custom path in the Pod. When the ConfigMap is updated the change to the config map MUST be verified by reading the content from the mounted file in the Pod.
 	*/
-	framework.ConformanceIt("updates should be reflected in volume [NodeConformance]", func() {
+	framework.ConformanceIt("Base", "updates should be reflected in volume [NodeConformance]", func() {
 		podLogTimeout := e2epod.GetPodSecretUpdateTimeout(f.ClientSet)
 		containerTimeoutArg := fmt.Sprintf("--retry_time=%v", int(podLogTimeout.Seconds()))
 
@@ -201,7 +201,7 @@ var _ = ginkgo.Describe("[sig-storage] ConfigMap", func() {
 		Testname: ConfigMap Volume, text data, binary data
 		Description: The ConfigMap that is created with text data and binary data MUST be accessible to read from the newly created Pod using the volume mount that is mapped to custom path in the Pod. ConfigMap's text data and binary data MUST be verified by reading the content from the mounted files in the Pod.
 	*/
-	framework.ConformanceIt("binary data should be reflected in volume [NodeConformance]", func() {
+	framework.ConformanceIt("Base", "binary data should be reflected in volume [NodeConformance]", func() {
 		podLogTimeout := e2epod.GetPodSecretUpdateTimeout(f.ClientSet)
 		containerTimeoutArg := fmt.Sprintf("--retry_time=%v", int(podLogTimeout.Seconds()))
 
@@ -297,7 +297,7 @@ var _ = ginkgo.Describe("[sig-storage] ConfigMap", func() {
 		Testname: ConfigMap Volume, create, update and delete
 		Description: The ConfigMap that is created MUST be accessible to read from the newly created Pod using the volume mount that is mapped to custom path in the Pod. When the config map is updated the change to the config map MUST be verified by reading the content from the mounted file in the Pod. Also when the item(file) is deleted from the map that MUST result in a error reading that item(file).
 	*/
-	framework.ConformanceIt("optional updates should be reflected in volume [NodeConformance]", func() {
+	framework.ConformanceIt("Base", "optional updates should be reflected in volume [NodeConformance]", func() {
 		podLogTimeout := e2epod.GetPodSecretUpdateTimeout(f.ClientSet)
 		containerTimeoutArg := fmt.Sprintf("--retry_time=%v", int(podLogTimeout.Seconds()))
 		trueVal := true
@@ -480,7 +480,7 @@ var _ = ginkgo.Describe("[sig-storage] ConfigMap", func() {
 		Testname: ConfigMap Volume, multiple volume maps
 		Description: The ConfigMap that is created MUST be accessible to read from the newly created Pod using the volume mount that is mapped to multiple paths in the Pod. The content MUST be accessible from all the mapped volume mounts.
 	*/
-	framework.ConformanceIt("should be consumable in multiple volumes in the same pod [NodeConformance]", func() {
+	framework.ConformanceIt("Base", "should be consumable in multiple volumes in the same pod [NodeConformance]", func() {
 		var (
 			name             = "configmap-test-volume-" + string(uuid.NewUUID())
 			volumeName       = "configmap-volume"

--- a/test/e2e/common/container_probe.go
+++ b/test/e2e/common/container_probe.go
@@ -60,7 +60,7 @@ var _ = framework.KubeDescribe("Probing container", func() {
 		Testname: Pod readiness probe, with initial delay
 		Description: Create a Pod that is configured with a initial delay set on the readiness probe. Check the Pod Start time to compare to the initial delay. The Pod MUST be ready only after the specified initial delay.
 	*/
-	framework.ConformanceIt("with readiness probe should not be ready before initial delay and never restart [NodeConformance]", func() {
+	framework.ConformanceIt("Base", "with readiness probe should not be ready before initial delay and never restart [NodeConformance]", func() {
 		containerName := "test-webserver"
 		p := podClient.Create(testWebServerPodSpec(probe.withInitialDelay().build(), nil, containerName, 80))
 		e2epod.WaitTimeoutForPodReadyInNamespace(f.ClientSet, p.Name, f.Namespace.Name, framework.PodStartTimeout)
@@ -94,7 +94,7 @@ var _ = framework.KubeDescribe("Probing container", func() {
 		Description: Create a Pod with a readiness probe that fails consistently. When this Pod is created,
 			then the Pod MUST never be ready, never be running and restart count MUST be zero.
 	*/
-	framework.ConformanceIt("with readiness probe that fails should never be ready and never restart [NodeConformance]", func() {
+	framework.ConformanceIt("Base", "with readiness probe that fails should never be ready and never restart [NodeConformance]", func() {
 		p := podClient.Create(testWebServerPodSpec(probe.withFailing().build(), nil, "test-webserver", 80))
 		gomega.Consistently(func() (bool, error) {
 			p, err := podClient.Get(context.TODO(), p.Name, metav1.GetOptions{})
@@ -119,7 +119,7 @@ var _ = framework.KubeDescribe("Probing container", func() {
 		Testname: Pod liveness probe, using local file, restart
 		Description: Create a Pod with liveness probe that uses ExecAction handler to cat /temp/health file. The Container deletes the file /temp/health after 10 second, triggering liveness probe to fail. The Pod MUST now be killed and restarted incrementing restart count to 1.
 	*/
-	framework.ConformanceIt("should be restarted with a exec \"cat /tmp/health\" liveness probe [NodeConformance]", func() {
+	framework.ConformanceIt("Base", "should be restarted with a exec \"cat /tmp/health\" liveness probe [NodeConformance]", func() {
 		cmd := []string{"/bin/sh", "-c", "echo ok >/tmp/health; sleep 10; rm -rf /tmp/health; sleep 600"}
 		livenessProbe := &v1.Probe{
 			Handler:             execHandler([]string{"cat", "/tmp/health"}),
@@ -135,7 +135,7 @@ var _ = framework.KubeDescribe("Probing container", func() {
 		Testname: Pod liveness probe, using local file, no restart
 		Description:  Pod is created with liveness probe that uses 'exec' command to cat /temp/health file. Liveness probe MUST not fail to check health and the restart count should remain 0.
 	*/
-	framework.ConformanceIt("should *not* be restarted with a exec \"cat /tmp/health\" liveness probe [NodeConformance]", func() {
+	framework.ConformanceIt("Base", "should *not* be restarted with a exec \"cat /tmp/health\" liveness probe [NodeConformance]", func() {
 		cmd := []string{"/bin/sh", "-c", "echo ok >/tmp/health; sleep 600"}
 		livenessProbe := &v1.Probe{
 			Handler:             execHandler([]string{"cat", "/tmp/health"}),
@@ -151,7 +151,7 @@ var _ = framework.KubeDescribe("Probing container", func() {
 		Testname: Pod liveness probe, using http endpoint, restart
 		Description: A Pod is created with liveness probe on http endpoint /healthz. The http handler on the /healthz will return a http error after 10 seconds since the Pod is started. This MUST result in liveness check failure. The Pod MUST now be killed and restarted incrementing restart count to 1.
 	*/
-	framework.ConformanceIt("should be restarted with a /healthz http liveness probe [NodeConformance]", func() {
+	framework.ConformanceIt("Base", "should be restarted with a /healthz http liveness probe [NodeConformance]", func() {
 		livenessProbe := &v1.Probe{
 			Handler:             httpGetHandler("/healthz", 8080),
 			InitialDelaySeconds: 15,
@@ -166,7 +166,7 @@ var _ = framework.KubeDescribe("Probing container", func() {
 		Testname: Pod liveness probe, using tcp socket, no restart
 		Description: A Pod is created with liveness probe on tcp socket 8080. The http handler on port 8080 will return http errors after 10 seconds, but the socket will remain open. Liveness probe MUST not fail to check health and the restart count should remain 0.
 	*/
-	framework.ConformanceIt("should *not* be restarted with a tcp:8080 liveness probe [NodeConformance]", func() {
+	framework.ConformanceIt("Base", "should *not* be restarted with a tcp:8080 liveness probe [NodeConformance]", func() {
 		livenessProbe := &v1.Probe{
 			Handler:             tcpSocketHandler(8080),
 			InitialDelaySeconds: 15,
@@ -181,7 +181,7 @@ var _ = framework.KubeDescribe("Probing container", func() {
 		Testname: Pod liveness probe, using http endpoint, multiple restarts (slow)
 		Description: A Pod is created with liveness probe on http endpoint /healthz. The http handler on the /healthz will return a http error after 10 seconds since the Pod is started. This MUST result in liveness check failure. The Pod MUST now be killed and restarted incrementing restart count to 1. The liveness probe must fail again after restart once the http handler for /healthz enpoind on the Pod returns an http error after 10 seconds from the start. Restart counts MUST increment everytime health check fails, measure upto 5 restart.
 	*/
-	framework.ConformanceIt("should have monotonically increasing restart count [NodeConformance]", func() {
+	framework.ConformanceIt("Base", "should have monotonically increasing restart count [NodeConformance]", func() {
 		livenessProbe := &v1.Probe{
 			Handler:             httpGetHandler("/healthz", 8080),
 			InitialDelaySeconds: 5,
@@ -196,7 +196,7 @@ var _ = framework.KubeDescribe("Probing container", func() {
 		Testname: Pod liveness probe, using http endpoint, failure
 		Description: A Pod is created with liveness probe on http endpoint '/'. Liveness probe on this endpoint will not fail. When liveness probe does not fail then the restart count MUST remain zero.
 	*/
-	framework.ConformanceIt("should *not* be restarted with a /healthz http liveness probe [NodeConformance]", func() {
+	framework.ConformanceIt("Base", "should *not* be restarted with a /healthz http liveness probe [NodeConformance]", func() {
 		livenessProbe := &v1.Probe{
 			Handler:             httpGetHandler("/", 80),
 			InitialDelaySeconds: 15,

--- a/test/e2e/common/docker_containers.go
+++ b/test/e2e/common/docker_containers.go
@@ -35,7 +35,7 @@ var _ = framework.KubeDescribe("Docker Containers", func() {
 		Testname: Docker containers, without command and arguments
 		Description: Default command and arguments from the docker image entrypoint MUST be used when Pod does not specify the container command
 	*/
-	framework.ConformanceIt("should use the image defaults if command and args are blank [NodeConformance]", func() {
+	framework.ConformanceIt("Base", "should use the image defaults if command and args are blank [NodeConformance]", func() {
 		pod := f.PodClient().Create(entrypointTestPod())
 		err := e2epod.WaitForPodNameRunningInNamespace(f.ClientSet, pod.Name, f.Namespace.Name)
 		framework.ExpectNoError(err, "Expected pod %q to be running, got error: %v", pod.Name, err)
@@ -54,7 +54,7 @@ var _ = framework.KubeDescribe("Docker Containers", func() {
 		Testname: Docker containers, with arguments
 		Description: Default command and  from the docker image entrypoint MUST be used when Pod does not specify the container command but the arguments from Pod spec MUST override when specified.
 	*/
-	framework.ConformanceIt("should be able to override the image's default arguments (docker cmd) [NodeConformance]", func() {
+	framework.ConformanceIt("Base", "should be able to override the image's default arguments (docker cmd) [NodeConformance]", func() {
 		pod := entrypointTestPod()
 		pod.Spec.Containers[0].Args = []string{"entrypoint-tester", "override", "arguments"}
 
@@ -70,7 +70,7 @@ var _ = framework.KubeDescribe("Docker Containers", func() {
 		Testname: Docker containers, with command
 		Description: Default command from the docker image entrypoint MUST NOT be used when Pod specifies the container command.  Command from Pod spec MUST override the command in the image.
 	*/
-	framework.ConformanceIt("should be able to override the image's default command (docker entrypoint) [NodeConformance]", func() {
+	framework.ConformanceIt("Base", "should be able to override the image's default command (docker entrypoint) [NodeConformance]", func() {
 		pod := entrypointTestPod()
 		pod.Spec.Containers[0].Command = []string{"/agnhost-2", "entrypoint-tester"}
 
@@ -84,7 +84,7 @@ var _ = framework.KubeDescribe("Docker Containers", func() {
 		Testname: Docker containers, with command and arguments
 		Description: Default command and arguments from the docker image entrypoint MUST NOT be used when Pod specifies the container command and arguments.  Command and arguments from Pod spec MUST override the command and arguments in the image.
 	*/
-	framework.ConformanceIt("should be able to override the image's default command and arguments [NodeConformance]", func() {
+	framework.ConformanceIt("Base", "should be able to override the image's default command and arguments [NodeConformance]", func() {
 		pod := entrypointTestPod()
 		pod.Spec.Containers[0].Command = []string{"/agnhost-2"}
 		pod.Spec.Containers[0].Args = []string{"entrypoint-tester", "override", "arguments"}

--- a/test/e2e/common/downward_api.go
+++ b/test/e2e/common/downward_api.go
@@ -39,7 +39,7 @@ var _ = ginkgo.Describe("[sig-node] Downward API", func() {
 	   Testname: DownwardAPI, environment for name, namespace and ip
 	   Description: Downward API MUST expose Pod and Container fields as environment variables. Specify Pod Name, namespace and IP as environment variable in the Pod Spec are visible at runtime in the container.
 	*/
-	framework.ConformanceIt("should provide pod name, namespace and IP address as env vars [NodeConformance]", func() {
+	framework.ConformanceIt("Base", "should provide pod name, namespace and IP address as env vars [NodeConformance]", func() {
 		podName := "downward-api-" + string(uuid.NewUUID())
 		env := []v1.EnvVar{
 			{
@@ -85,7 +85,7 @@ var _ = ginkgo.Describe("[sig-node] Downward API", func() {
 	   Testname: DownwardAPI, environment for host ip
 	   Description: Downward API MUST expose Pod and Container fields as environment variables. Specify host IP as environment variable in the Pod Spec are visible at runtime in the container.
 	*/
-	framework.ConformanceIt("should provide host IP as an env var [NodeConformance]", func() {
+	framework.ConformanceIt("Base", "should provide host IP as an env var [NodeConformance]", func() {
 		podName := "downward-api-" + string(uuid.NewUUID())
 		env := []v1.EnvVar{
 			{
@@ -161,7 +161,7 @@ var _ = ginkgo.Describe("[sig-node] Downward API", func() {
 	   Testname: DownwardAPI, environment for CPU and memory limits and requests
 	   Description: Downward API MUST expose CPU request and Memory request set through environment variables at runtime in the container.
 	*/
-	framework.ConformanceIt("should provide container's limits.cpu/memory and requests.cpu/memory as env vars [NodeConformance]", func() {
+	framework.ConformanceIt("Base", "should provide container's limits.cpu/memory and requests.cpu/memory as env vars [NodeConformance]", func() {
 		podName := "downward-api-" + string(uuid.NewUUID())
 		env := []v1.EnvVar{
 			{
@@ -212,7 +212,7 @@ var _ = ginkgo.Describe("[sig-node] Downward API", func() {
 	   Testname: DownwardAPI, environment for default CPU and memory limits and requests
 	   Description: Downward API MUST expose CPU request and Memory limits set through environment variables at runtime in the container.
 	*/
-	framework.ConformanceIt("should provide default limits.cpu/memory from node allocatable [NodeConformance]", func() {
+	framework.ConformanceIt("Base", "should provide default limits.cpu/memory from node allocatable [NodeConformance]", func() {
 		podName := "downward-api-" + string(uuid.NewUUID())
 		env := []v1.EnvVar{
 			{
@@ -262,7 +262,7 @@ var _ = ginkgo.Describe("[sig-node] Downward API", func() {
 	   Testname: DownwardAPI, environment for Pod UID
 	   Description: Downward API MUST expose Pod UID set through environment variables at runtime in the container.
 	*/
-	framework.ConformanceIt("should provide pod UID as env vars [NodeConformance]", func() {
+	framework.ConformanceIt("Base", "should provide pod UID as env vars [NodeConformance]", func() {
 		podName := "downward-api-" + string(uuid.NewUUID())
 		env := []v1.EnvVar{
 			{

--- a/test/e2e/common/downwardapi_volume.go
+++ b/test/e2e/common/downwardapi_volume.go
@@ -48,7 +48,7 @@ var _ = ginkgo.Describe("[sig-storage] Downward API volume", func() {
 		Testname: DownwardAPI volume, pod name
 		Description: A Pod is configured with DownwardAPIVolumeSource and DownwardAPIVolumeFiles contains a item for the Pod name. The container runtime MUST be able to access Pod name from the specified path on the mounted volume.
 	*/
-	framework.ConformanceIt("should provide podname only [NodeConformance]", func() {
+	framework.ConformanceIt("Base", "should provide podname only [NodeConformance]", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
 		pod := downwardAPIVolumePodForSimpleTest(podName, "/etc/podinfo/podname")
 
@@ -63,7 +63,7 @@ var _ = ginkgo.Describe("[sig-storage] Downward API volume", func() {
 		Description: A Pod is configured with DownwardAPIVolumeSource with the volumesource mode set to -r-------- and DownwardAPIVolumeFiles contains a item for the Pod name. The container runtime MUST be able to access Pod name from the specified path on the mounted volume.
 		This test is marked LinuxOnly since Windows does not support setting specific file permissions.
 	*/
-	framework.ConformanceIt("should set DefaultMode on files [LinuxOnly] [NodeConformance]", func() {
+	framework.ConformanceIt("Base", "should set DefaultMode on files [LinuxOnly] [NodeConformance]", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
 		defaultMode := int32(0400)
 		pod := downwardAPIVolumePodForModeTest(podName, "/etc/podinfo/podname", nil, &defaultMode)
@@ -79,7 +79,7 @@ var _ = ginkgo.Describe("[sig-storage] Downward API volume", func() {
 		Description: A Pod is configured with DownwardAPIVolumeSource and DownwardAPIVolumeFiles contains a item for the Pod name with the file mode set to -r--------. The container runtime MUST be able to access Pod name from the specified path on the mounted volume.
 		This test is marked LinuxOnly since Windows does not support setting specific file permissions.
 	*/
-	framework.ConformanceIt("should set mode on item file [LinuxOnly] [NodeConformance]", func() {
+	framework.ConformanceIt("Base", "should set mode on item file [LinuxOnly] [NodeConformance]", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
 		mode := int32(0400)
 		pod := downwardAPIVolumePodForModeTest(podName, "/etc/podinfo/podname", &mode, nil)
@@ -125,7 +125,7 @@ var _ = ginkgo.Describe("[sig-storage] Downward API volume", func() {
 		Testname: DownwardAPI volume, update label
 		Description: A Pod is configured with DownwardAPIVolumeSource and DownwardAPIVolumeFiles contains list of items for each of the Pod labels. The container runtime MUST be able to access Pod labels from the specified path on the mounted volume. Update the labels by adding a new label to the running Pod. The new label MUST be available from the mounted volume.
 	*/
-	framework.ConformanceIt("should update labels on modification [NodeConformance]", func() {
+	framework.ConformanceIt("Base", "should update labels on modification [NodeConformance]", func() {
 		labels := map[string]string{}
 		labels["key1"] = "value1"
 		labels["key2"] = "value2"
@@ -157,7 +157,7 @@ var _ = ginkgo.Describe("[sig-storage] Downward API volume", func() {
 		Testname: DownwardAPI volume, update annotations
 		Description: A Pod is configured with DownwardAPIVolumeSource and DownwardAPIVolumeFiles contains list of items for each of the Pod annotations. The container runtime MUST be able to access Pod annotations from the specified path on the mounted volume. Update the annotations by adding a new annotation to the running Pod. The new annotation MUST be available from the mounted volume.
 	*/
-	framework.ConformanceIt("should update annotations on modification [NodeConformance]", func() {
+	framework.ConformanceIt("Base", "should update annotations on modification [NodeConformance]", func() {
 		annotations := map[string]string{}
 		annotations["builder"] = "bar"
 		podName := "annotationupdate" + string(uuid.NewUUID())
@@ -191,7 +191,7 @@ var _ = ginkgo.Describe("[sig-storage] Downward API volume", func() {
 		Testname: DownwardAPI volume, CPU limits
 		Description: A Pod is configured with DownwardAPIVolumeSource and DownwardAPIVolumeFiles contains a item for the CPU limits. The container runtime MUST be able to access CPU limits from the specified path on the mounted volume.
 	*/
-	framework.ConformanceIt("should provide container's cpu limit [NodeConformance]", func() {
+	framework.ConformanceIt("Base", "should provide container's cpu limit [NodeConformance]", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
 		pod := downwardAPIVolumeForContainerResources(podName, "/etc/podinfo/cpu_limit")
 
@@ -205,7 +205,7 @@ var _ = ginkgo.Describe("[sig-storage] Downward API volume", func() {
 		Testname: DownwardAPI volume, memory limits
 		Description: A Pod is configured with DownwardAPIVolumeSource and DownwardAPIVolumeFiles contains a item for the memory limits. The container runtime MUST be able to access memory limits from the specified path on the mounted volume.
 	*/
-	framework.ConformanceIt("should provide container's memory limit [NodeConformance]", func() {
+	framework.ConformanceIt("Base", "should provide container's memory limit [NodeConformance]", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
 		pod := downwardAPIVolumeForContainerResources(podName, "/etc/podinfo/memory_limit")
 
@@ -219,7 +219,7 @@ var _ = ginkgo.Describe("[sig-storage] Downward API volume", func() {
 		Testname: DownwardAPI volume, CPU request
 		Description: A Pod is configured with DownwardAPIVolumeSource and DownwardAPIVolumeFiles contains a item for the CPU request. The container runtime MUST be able to access CPU request from the specified path on the mounted volume.
 	*/
-	framework.ConformanceIt("should provide container's cpu request [NodeConformance]", func() {
+	framework.ConformanceIt("Base", "should provide container's cpu request [NodeConformance]", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
 		pod := downwardAPIVolumeForContainerResources(podName, "/etc/podinfo/cpu_request")
 
@@ -233,7 +233,7 @@ var _ = ginkgo.Describe("[sig-storage] Downward API volume", func() {
 		Testname: DownwardAPI volume, memory request
 		Description: A Pod is configured with DownwardAPIVolumeSource and DownwardAPIVolumeFiles contains a item for the memory request. The container runtime MUST be able to access memory request from the specified path on the mounted volume.
 	*/
-	framework.ConformanceIt("should provide container's memory request [NodeConformance]", func() {
+	framework.ConformanceIt("Base", "should provide container's memory request [NodeConformance]", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
 		pod := downwardAPIVolumeForContainerResources(podName, "/etc/podinfo/memory_request")
 
@@ -247,7 +247,7 @@ var _ = ginkgo.Describe("[sig-storage] Downward API volume", func() {
 		Testname: DownwardAPI volume, CPU limit, default node allocatable
 		Description: A Pod is configured with DownwardAPIVolumeSource and DownwardAPIVolumeFiles contains a item for the CPU limits. CPU limits is not specified for the container. The container runtime MUST be able to access CPU limits from the specified path on the mounted volume and the value MUST be default node allocatable.
 	*/
-	framework.ConformanceIt("should provide node allocatable (cpu) as default cpu limit if the limit is not set [NodeConformance]", func() {
+	framework.ConformanceIt("Base", "should provide node allocatable (cpu) as default cpu limit if the limit is not set [NodeConformance]", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
 		pod := downwardAPIVolumeForDefaultContainerResources(podName, "/etc/podinfo/cpu_limit")
 
@@ -259,7 +259,7 @@ var _ = ginkgo.Describe("[sig-storage] Downward API volume", func() {
 		Testname: DownwardAPI volume, memory limit, default node allocatable
 		Description: A Pod is configured with DownwardAPIVolumeSource and DownwardAPIVolumeFiles contains a item for the memory limits. memory limits is not specified for the container. The container runtime MUST be able to access memory limits from the specified path on the mounted volume and the value MUST be default node allocatable.
 	*/
-	framework.ConformanceIt("should provide node allocatable (memory) as default memory limit if the limit is not set [NodeConformance]", func() {
+	framework.ConformanceIt("Base", "should provide node allocatable (memory) as default memory limit if the limit is not set [NodeConformance]", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
 		pod := downwardAPIVolumeForDefaultContainerResources(podName, "/etc/podinfo/memory_limit")
 

--- a/test/e2e/common/empty_dir.go
+++ b/test/e2e/common/empty_dir.go
@@ -80,7 +80,7 @@ var _ = ginkgo.Describe("[sig-storage] EmptyDir volumes", func() {
 		Description: A Pod created with an 'emptyDir' Volume and 'medium' as 'Memory', the volume MUST have mode set as -rwxrwxrwx and mount type set to tmpfs.
 		This test is marked LinuxOnly since Windows does not support setting specific file permissions, or the medium = 'Memory'.
 	*/
-	framework.ConformanceIt("volume on tmpfs should have the correct mode [LinuxOnly] [NodeConformance]", func() {
+	framework.ConformanceIt("Base", "volume on tmpfs should have the correct mode [LinuxOnly] [NodeConformance]", func() {
 		doTestVolumeMode(f, 0, v1.StorageMediumMemory)
 	})
 
@@ -90,7 +90,7 @@ var _ = ginkgo.Describe("[sig-storage] EmptyDir volumes", func() {
 		Description: A Pod created with an 'emptyDir' Volume and 'medium' as 'Memory', the volume mode set to 0644. The volume MUST have mode -rw-r--r-- and mount type set to tmpfs and the contents MUST be readable.
 		This test is marked LinuxOnly since Windows does not support setting specific file permissions, or running as UID / GID, or the medium = 'Memory'.
 	*/
-	framework.ConformanceIt("should support (root,0644,tmpfs) [LinuxOnly] [NodeConformance]", func() {
+	framework.ConformanceIt("Base", "should support (root,0644,tmpfs) [LinuxOnly] [NodeConformance]", func() {
 		doTest0644(f, 0, v1.StorageMediumMemory)
 	})
 
@@ -100,7 +100,7 @@ var _ = ginkgo.Describe("[sig-storage] EmptyDir volumes", func() {
 		Description: A Pod created with an 'emptyDir' Volume and 'medium' as 'Memory', the volume mode set to 0666. The volume MUST have mode -rw-rw-rw- and mount type set to tmpfs and the contents MUST be readable.
 		This test is marked LinuxOnly since Windows does not support setting specific file permissions, or running as UID / GID, or the medium = 'Memory'.
 	*/
-	framework.ConformanceIt("should support (root,0666,tmpfs) [LinuxOnly] [NodeConformance]", func() {
+	framework.ConformanceIt("Base", "should support (root,0666,tmpfs) [LinuxOnly] [NodeConformance]", func() {
 		doTest0666(f, 0, v1.StorageMediumMemory)
 	})
 
@@ -110,7 +110,7 @@ var _ = ginkgo.Describe("[sig-storage] EmptyDir volumes", func() {
 		Description: A Pod created with an 'emptyDir' Volume and 'medium' as 'Memory', the volume mode set to 0777.  The volume MUST have mode set as -rwxrwxrwx and mount type set to tmpfs and the contents MUST be readable.
 		This test is marked LinuxOnly since Windows does not support setting specific file permissions, or running as UID / GID, or the medium = 'Memory'.
 	*/
-	framework.ConformanceIt("should support (root,0777,tmpfs) [LinuxOnly] [NodeConformance]", func() {
+	framework.ConformanceIt("Base", "should support (root,0777,tmpfs) [LinuxOnly] [NodeConformance]", func() {
 		doTest0777(f, 0, v1.StorageMediumMemory)
 	})
 
@@ -120,7 +120,7 @@ var _ = ginkgo.Describe("[sig-storage] EmptyDir volumes", func() {
 		Description: A Pod created with an 'emptyDir' Volume and 'medium' as 'Memory', the volume mode set to 0644. Volume is mounted into the container where container is run as a non-root user. The volume MUST have mode -rw-r--r-- and mount type set to tmpfs and the contents MUST be readable.
 		This test is marked LinuxOnly since Windows does not support setting specific file permissions, or running as UID / GID, or the medium = 'Memory'.
 	*/
-	framework.ConformanceIt("should support (non-root,0644,tmpfs) [LinuxOnly] [NodeConformance]", func() {
+	framework.ConformanceIt("Base", "should support (non-root,0644,tmpfs) [LinuxOnly] [NodeConformance]", func() {
 		doTest0644(f, nonRootUid, v1.StorageMediumMemory)
 	})
 
@@ -130,7 +130,7 @@ var _ = ginkgo.Describe("[sig-storage] EmptyDir volumes", func() {
 		Description: A Pod created with an 'emptyDir' Volume and 'medium' as 'Memory', the volume mode set to 0666. Volume is mounted into the container where container is run as a non-root user. The volume MUST have mode -rw-rw-rw- and mount type set to tmpfs and the contents MUST be readable.
 		This test is marked LinuxOnly since Windows does not support setting specific file permissions, or running as UID / GID, or the medium = 'Memory'.
 	*/
-	framework.ConformanceIt("should support (non-root,0666,tmpfs) [LinuxOnly] [NodeConformance]", func() {
+	framework.ConformanceIt("Base", "should support (non-root,0666,tmpfs) [LinuxOnly] [NodeConformance]", func() {
 		doTest0666(f, nonRootUid, v1.StorageMediumMemory)
 	})
 
@@ -140,7 +140,7 @@ var _ = ginkgo.Describe("[sig-storage] EmptyDir volumes", func() {
 		Description: A Pod created with an 'emptyDir' Volume and 'medium' as 'Memory', the volume mode set to 0777. Volume is mounted into the container where container is run as a non-root user. The volume MUST have mode -rwxrwxrwx and mount type set to tmpfs and the contents MUST be readable.
 		This test is marked LinuxOnly since Windows does not support setting specific file permissions, or running as UID / GID, or the medium = 'Memory'.
 	*/
-	framework.ConformanceIt("should support (non-root,0777,tmpfs) [LinuxOnly] [NodeConformance]", func() {
+	framework.ConformanceIt("Base", "should support (non-root,0777,tmpfs) [LinuxOnly] [NodeConformance]", func() {
 		doTest0777(f, nonRootUid, v1.StorageMediumMemory)
 	})
 
@@ -150,7 +150,7 @@ var _ = ginkgo.Describe("[sig-storage] EmptyDir volumes", func() {
 		Description: A Pod created with an 'emptyDir' Volume, the volume MUST have mode set as -rwxrwxrwx and mount type set to tmpfs.
 		This test is marked LinuxOnly since Windows does not support setting specific file permissions.
 	*/
-	framework.ConformanceIt("volume on default medium should have the correct mode [LinuxOnly] [NodeConformance]", func() {
+	framework.ConformanceIt("Base", "volume on default medium should have the correct mode [LinuxOnly] [NodeConformance]", func() {
 		doTestVolumeMode(f, 0, v1.StorageMediumDefault)
 	})
 
@@ -160,7 +160,7 @@ var _ = ginkgo.Describe("[sig-storage] EmptyDir volumes", func() {
 		Description: A Pod created with an 'emptyDir' Volume, the volume mode set to 0644. The volume MUST have mode -rw-r--r-- and mount type set to tmpfs and the contents MUST be readable.
 		This test is marked LinuxOnly since Windows does not support setting specific file permissions, or running as UID / GID.
 	*/
-	framework.ConformanceIt("should support (root,0644,default) [LinuxOnly] [NodeConformance]", func() {
+	framework.ConformanceIt("Base", "should support (root,0644,default) [LinuxOnly] [NodeConformance]", func() {
 		doTest0644(f, 0, v1.StorageMediumDefault)
 	})
 
@@ -170,7 +170,7 @@ var _ = ginkgo.Describe("[sig-storage] EmptyDir volumes", func() {
 		Description: A Pod created with an 'emptyDir' Volume, the volume mode set to 0666. The volume MUST have mode -rw-rw-rw- and mount type set to tmpfs and the contents MUST be readable.
 		This test is marked LinuxOnly since Windows does not support setting specific file permissions, or running as UID / GID.
 	*/
-	framework.ConformanceIt("should support (root,0666,default) [LinuxOnly] [NodeConformance]", func() {
+	framework.ConformanceIt("Base", "should support (root,0666,default) [LinuxOnly] [NodeConformance]", func() {
 		doTest0666(f, 0, v1.StorageMediumDefault)
 	})
 
@@ -180,7 +180,7 @@ var _ = ginkgo.Describe("[sig-storage] EmptyDir volumes", func() {
 		Description: A Pod created with an 'emptyDir' Volume, the volume mode set to 0777.  The volume MUST have mode set as -rwxrwxrwx and mount type set to tmpfs and the contents MUST be readable.
 		This test is marked LinuxOnly since Windows does not support setting specific file permissions, or running as UID / GID.
 	*/
-	framework.ConformanceIt("should support (root,0777,default) [LinuxOnly] [NodeConformance]", func() {
+	framework.ConformanceIt("Base", "should support (root,0777,default) [LinuxOnly] [NodeConformance]", func() {
 		doTest0777(f, 0, v1.StorageMediumDefault)
 	})
 
@@ -190,7 +190,7 @@ var _ = ginkgo.Describe("[sig-storage] EmptyDir volumes", func() {
 		Description: A Pod created with an 'emptyDir' Volume, the volume mode set to 0644. Volume is mounted into the container where container is run as a non-root user. The volume MUST have mode -rw-r--r-- and mount type set to tmpfs and the contents MUST be readable.
 		This test is marked LinuxOnly since Windows does not support setting specific file permissions, or running as UID / GID.
 	*/
-	framework.ConformanceIt("should support (non-root,0644,default) [LinuxOnly] [NodeConformance]", func() {
+	framework.ConformanceIt("Base", "should support (non-root,0644,default) [LinuxOnly] [NodeConformance]", func() {
 		doTest0644(f, nonRootUid, v1.StorageMediumDefault)
 	})
 
@@ -200,7 +200,7 @@ var _ = ginkgo.Describe("[sig-storage] EmptyDir volumes", func() {
 		Description: A Pod created with an 'emptyDir' Volume, the volume mode set to 0666. Volume is mounted into the container where container is run as a non-root user. The volume MUST have mode -rw-rw-rw- and mount type set to tmpfs and the contents MUST be readable.
 		This test is marked LinuxOnly since Windows does not support setting specific file permissions, or running as UID / GID.
 	*/
-	framework.ConformanceIt("should support (non-root,0666,default) [LinuxOnly] [NodeConformance]", func() {
+	framework.ConformanceIt("Base", "should support (non-root,0666,default) [LinuxOnly] [NodeConformance]", func() {
 		doTest0666(f, nonRootUid, v1.StorageMediumDefault)
 	})
 
@@ -210,7 +210,7 @@ var _ = ginkgo.Describe("[sig-storage] EmptyDir volumes", func() {
 		Description: A Pod created with an 'emptyDir' Volume, the volume mode set to 0777. Volume is mounted into the container where container is run as a non-root user. The volume MUST have mode -rwxrwxrwx and mount type set to tmpfs and the contents MUST be readable.
 		This test is marked LinuxOnly since Windows does not support setting specific file permissions, or running as UID / GID.
 	*/
-	framework.ConformanceIt("should support (non-root,0777,default) [LinuxOnly] [NodeConformance]", func() {
+	framework.ConformanceIt("Base", "should support (non-root,0777,default) [LinuxOnly] [NodeConformance]", func() {
 		doTest0777(f, nonRootUid, v1.StorageMediumDefault)
 	})
 
@@ -220,7 +220,7 @@ var _ = ginkgo.Describe("[sig-storage] EmptyDir volumes", func() {
 		Description: A Pod created with an 'emptyDir' Volume, should share volumes between the containeres in the pod. The two busybox image containers shoud share the volumes mounted to the pod.
 		The main container shoud wait until the sub container drops a file, and main container acess the shared data.
 	*/
-	framework.ConformanceIt("pod should support shared volumes between containers", func() {
+	framework.ConformanceIt("Base", "pod should support shared volumes between containers", func() {
 		var (
 			volumeName                 = "shared-data"
 			busyBoxMainVolumeMountPath = "/usr/share/volumeshare"

--- a/test/e2e/common/expansion.go
+++ b/test/e2e/common/expansion.go
@@ -38,7 +38,7 @@ var _ = framework.KubeDescribe("Variable Expansion", func() {
 		Testname: Environment variables, expansion
 		Description: Create a Pod with environment variables. Environment variables defined using previously defined environment variables MUST expand to proper values.
 	*/
-	framework.ConformanceIt("should allow composing env vars into new env vars [NodeConformance]", func() {
+	framework.ConformanceIt("Base", "should allow composing env vars into new env vars [NodeConformance]", func() {
 		envVars := []v1.EnvVar{
 			{
 				Name:  "FOO",
@@ -67,7 +67,7 @@ var _ = framework.KubeDescribe("Variable Expansion", func() {
 		Testname: Environment variables, command expansion
 		Description: Create a Pod with environment variables and container command using them. Container command using the  defined environment variables MUST expand to proper values.
 	*/
-	framework.ConformanceIt("should allow substituting values in a container's command [NodeConformance]", func() {
+	framework.ConformanceIt("Base", "should allow substituting values in a container's command [NodeConformance]", func() {
 		envVars := []v1.EnvVar{
 			{
 				Name:  "TEST_VAR",
@@ -86,7 +86,7 @@ var _ = framework.KubeDescribe("Variable Expansion", func() {
 		Testname: Environment variables, command argument expansion
 		Description: Create a Pod with environment variables and container command arguments using them. Container command arguments using the  defined environment variables MUST expand to proper values.
 	*/
-	framework.ConformanceIt("should allow substituting values in a container's args [NodeConformance]", func() {
+	framework.ConformanceIt("Base", "should allow substituting values in a container's args [NodeConformance]", func() {
 		envVars := []v1.EnvVar{
 			{
 				Name:  "TEST_VAR",
@@ -106,7 +106,7 @@ var _ = framework.KubeDescribe("Variable Expansion", func() {
 		Testname: VolumeSubpathEnvExpansion, subpath expansion
 		Description: Make sure a container's subpath can be set using an expansion of environment variables.
 	*/
-	framework.ConformanceIt("should allow substituting values in a volume subpath [sig-storage]", func() {
+	framework.ConformanceIt("Base", "should allow substituting values in a volume subpath [sig-storage]", func() {
 		envVars := []v1.EnvVar{
 			{
 				Name:  "POD_NAME",
@@ -146,7 +146,7 @@ var _ = framework.KubeDescribe("Variable Expansion", func() {
 		Testname: VolumeSubpathEnvExpansion, subpath with backticks
 		Description: Make sure a container's subpath can not be set using an expansion of environment variables when backticks are supplied.
 	*/
-	framework.ConformanceIt("should fail substituting values in a volume subpath with backticks [sig-storage][Slow]", func() {
+	framework.ConformanceIt("Base", "should fail substituting values in a volume subpath with backticks [sig-storage][Slow]", func() {
 
 		envVars := []v1.EnvVar{
 			{
@@ -180,7 +180,7 @@ var _ = framework.KubeDescribe("Variable Expansion", func() {
 		Testname: VolumeSubpathEnvExpansion, subpath with absolute path
 		Description: Make sure a container's subpath can not be set using an expansion of environment variables when absolute path is supplied.
 	*/
-	framework.ConformanceIt("should fail substituting values in a volume subpath with absolute path [sig-storage][Slow]", func() {
+	framework.ConformanceIt("Base", "should fail substituting values in a volume subpath with absolute path [sig-storage][Slow]", func() {
 
 		envVars := []v1.EnvVar{
 			{
@@ -214,7 +214,7 @@ var _ = framework.KubeDescribe("Variable Expansion", func() {
 		Testname: VolumeSubpathEnvExpansion, subpath ready from failed state
 		Description: Verify that a failing subpath expansion can be modified during the lifecycle of a container.
 	*/
-	framework.ConformanceIt("should verify that a failing subpath expansion can be modified during the lifecycle of a container [sig-storage][Slow]", func() {
+	framework.ConformanceIt("Base", "should verify that a failing subpath expansion can be modified during the lifecycle of a container [sig-storage][Slow]", func() {
 
 		envVars := []v1.EnvVar{
 			{
@@ -283,7 +283,7 @@ var _ = framework.KubeDescribe("Variable Expansion", func() {
 		3.	successful expansion of the subpathexpr isn't required for volume cleanup
 
 	*/
-	framework.ConformanceIt("should succeed in writing subpaths in container [sig-storage][Slow]", func() {
+	framework.ConformanceIt("Base", "should succeed in writing subpaths in container [sig-storage][Slow]", func() {
 
 		envVars := []v1.EnvVar{
 			{

--- a/test/e2e/common/init_container.go
+++ b/test/e2e/common/init_container.go
@@ -171,7 +171,7 @@ var _ = framework.KubeDescribe("InitContainer [NodeConformance]", func() {
 		and the system is not going to restart any of these containers
 		when Pod has restart policy as RestartNever.
 	*/
-	framework.ConformanceIt("should invoke init containers on a RestartNever pod", func() {
+	framework.ConformanceIt("Base", "should invoke init containers on a RestartNever pod", func() {
 		ginkgo.By("creating the pod")
 		name := "pod-init-" + string(uuid.NewUUID())
 		value := strconv.Itoa(time.Now().Nanosecond())
@@ -247,7 +247,7 @@ var _ = framework.KubeDescribe("InitContainer [NodeConformance]", func() {
 		and at least one container is still running or is in the process of being restarted
 		when Pod has restart policy as RestartAlways.
 	*/
-	framework.ConformanceIt("should invoke init containers on a RestartAlways pod", func() {
+	framework.ConformanceIt("Base", "should invoke init containers on a RestartAlways pod", func() {
 		ginkgo.By("creating the pod")
 		name := "pod-init-" + string(uuid.NewUUID())
 		value := strconv.Itoa(time.Now().Nanosecond())
@@ -324,7 +324,7 @@ var _ = framework.KubeDescribe("InitContainer [NodeConformance]", func() {
 		and Pod has restarted for few occurrences
 		and pod has restart policy as RestartAlways.
 	*/
-	framework.ConformanceIt("should not start app containers if init containers fail on a RestartAlways pod", func() {
+	framework.ConformanceIt("Base", "should not start app containers if init containers fail on a RestartAlways pod", func() {
 		ginkgo.By("creating the pod")
 		name := "pod-init-" + string(uuid.NewUUID())
 		value := strconv.Itoa(time.Now().Nanosecond())
@@ -448,7 +448,7 @@ var _ = framework.KubeDescribe("InitContainer [NodeConformance]", func() {
 		Description: Ensure that app container is not started
 		when at least one InitContainer fails to start and Pod has restart policy as RestartNever.
 	*/
-	framework.ConformanceIt("should not start app containers and fail the pod if init containers fail on a RestartNever pod", func() {
+	framework.ConformanceIt("Base", "should not start app containers and fail the pod if init containers fail on a RestartNever pod", func() {
 		ginkgo.By("creating the pod")
 		name := "pod-init-" + string(uuid.NewUUID())
 		value := strconv.Itoa(time.Now().Nanosecond())

--- a/test/e2e/common/kubelet.go
+++ b/test/e2e/common/kubelet.go
@@ -46,7 +46,7 @@ var _ = framework.KubeDescribe("Kubelet", func() {
 			Testname: Kubelet, log output, default
 			Description: By default the stdout and stderr from the process being executed in a pod MUST be sent to the pod's logs.
 		*/
-		framework.ConformanceIt("should print the output to logs [NodeConformance]", func() {
+		framework.ConformanceIt("Base", "should print the output to logs [NodeConformance]", func() {
 			podClient.CreateSync(&v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: podName,
@@ -104,7 +104,7 @@ var _ = framework.KubeDescribe("Kubelet", func() {
 			Testname: Kubelet, failed pod, terminated reason
 			Description: Create a Pod with terminated state. Pod MUST have only one container. Container MUST be in terminated state and MUST have an terminated reason.
 		*/
-		framework.ConformanceIt("should have an terminated reason [NodeConformance]", func() {
+		framework.ConformanceIt("Base", "should have an terminated reason [NodeConformance]", func() {
 			gomega.Eventually(func() error {
 				podData, err := podClient.Get(context.TODO(), podName, metav1.GetOptions{})
 				if err != nil {
@@ -129,7 +129,7 @@ var _ = framework.KubeDescribe("Kubelet", func() {
 			Testname: Kubelet, failed pod, delete
 			Description: Create a Pod with terminated state. This terminated pod MUST be able to be deleted.
 		*/
-		framework.ConformanceIt("should be possible to delete [NodeConformance]", func() {
+		framework.ConformanceIt("Base", "should be possible to delete [NodeConformance]", func() {
 			err := podClient.Delete(context.TODO(), podName, metav1.DeleteOptions{})
 			gomega.Expect(err).To(gomega.BeNil(), fmt.Sprintf("Error deleting Pod %v", err))
 		})
@@ -143,7 +143,7 @@ var _ = framework.KubeDescribe("Kubelet", func() {
 			Description: Create a Pod with hostAliases and a container with command to output /etc/hosts entries. Pod's logs MUST have matching entries of specified hostAliases to the output of /etc/hosts entries.
 			Kubernetes mounts the /etc/hosts file into its containers, however, mounting individual files is not supported on Windows Containers. For this reason, this test is marked LinuxOnly.
 		*/
-		framework.ConformanceIt("should write entries to /etc/hosts [LinuxOnly] [NodeConformance]", func() {
+		framework.ConformanceIt("Base", "should write entries to /etc/hosts [LinuxOnly] [NodeConformance]", func() {
 			podClient.CreateSync(&v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: podName,
@@ -194,7 +194,7 @@ var _ = framework.KubeDescribe("Kubelet", func() {
 			Description: Create a Pod with security context set with ReadOnlyRootFileSystem set to true. The Pod then tries to write to the /file on the root, write operation to the root filesystem MUST fail as expected.
 			This test is marked LinuxOnly since Windows does not support creating containers with read-only access.
 		*/
-		framework.ConformanceIt("should not write to root filesystem [LinuxOnly] [NodeConformance]", func() {
+		framework.ConformanceIt("Base", "should not write to root filesystem [LinuxOnly] [NodeConformance]", func() {
 			isReadOnly := true
 			podClient.CreateSync(&v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{

--- a/test/e2e/common/kubelet_etc_hosts.go
+++ b/test/e2e/common/kubelet_etc_hosts.go
@@ -59,7 +59,7 @@ var _ = framework.KubeDescribe("KubeletManagedEtcHosts", func() {
 			3. The Pod with hostNetwork=true , /etc/hosts file MUST not be managed by the Kubelet.
 		This test is marked LinuxOnly since Windows cannot mount individual files in Containers.
 	*/
-	framework.ConformanceIt("should test kubelet managed /etc/hosts file [LinuxOnly] [NodeConformance]", func() {
+	framework.ConformanceIt("Privileged", "should test kubelet managed /etc/hosts file [LinuxOnly] [NodeConformance]", func() {
 		ginkgo.By("Setting up the test")
 		config.setup()
 

--- a/test/e2e/common/lease.go
+++ b/test/e2e/common/lease.go
@@ -65,7 +65,7 @@ var _ = framework.KubeDescribe("Lease", func() {
 		return just the remaining lease. Delete the lease; delete MUST be successful. Get the lease; get
 		MUST return not found error.
 	*/
-	framework.ConformanceIt("lease API should be available", func() {
+	framework.ConformanceIt("Base", "lease API should be available", func() {
 		leaseClient := f.ClientSet.CoordinationV1().Leases(f.Namespace.Name)
 
 		name := "lease"

--- a/test/e2e/common/lifecycle_hook.go
+++ b/test/e2e/common/lifecycle_hook.go
@@ -96,7 +96,7 @@ var _ = framework.KubeDescribe("Container Lifecycle Hook", func() {
 			Testname: Pod Lifecycle, post start exec hook
 			Description: When a post start handler is specified in the container lifecycle using a 'Exec' action, then the handler MUST be invoked after the start of the container. A server pod is created that will serve http requests, create a second pod with a container lifecycle specifying a post start that invokes the server pod using ExecAction to validate that the post start is executed.
 		*/
-		framework.ConformanceIt("should execute poststart exec hook properly [NodeConformance]", func() {
+		framework.ConformanceIt("Base", "should execute poststart exec hook properly [NodeConformance]", func() {
 			lifecycle := &v1.Lifecycle{
 				PostStart: &v1.Handler{
 					Exec: &v1.ExecAction{
@@ -112,7 +112,7 @@ var _ = framework.KubeDescribe("Container Lifecycle Hook", func() {
 			Testname: Pod Lifecycle, prestop exec hook
 			Description: When a pre-stop handler is specified in the container lifecycle using a 'Exec' action, then the handler MUST be invoked before the container is terminated. A server pod is created that will serve http requests, create a second pod with a container lifecycle specifying a pre-stop that invokes the server pod using ExecAction to validate that the pre-stop is executed.
 		*/
-		framework.ConformanceIt("should execute prestop exec hook properly [NodeConformance]", func() {
+		framework.ConformanceIt("Base", "should execute prestop exec hook properly [NodeConformance]", func() {
 			lifecycle := &v1.Lifecycle{
 				PreStop: &v1.Handler{
 					Exec: &v1.ExecAction{
@@ -128,7 +128,7 @@ var _ = framework.KubeDescribe("Container Lifecycle Hook", func() {
 			Testname: Pod Lifecycle, post start http hook
 			Description: When a post start handler is specified in the container lifecycle using a HttpGet action, then the handler MUST be invoked after the start of the container. A server pod is created that will serve http requests, create a second pod with a container lifecycle specifying a post start that invokes the server pod to validate that the post start is executed.
 		*/
-		framework.ConformanceIt("should execute poststart http hook properly [NodeConformance]", func() {
+		framework.ConformanceIt("Base", "should execute poststart http hook properly [NodeConformance]", func() {
 			lifecycle := &v1.Lifecycle{
 				PostStart: &v1.Handler{
 					HTTPGet: &v1.HTTPGetAction{
@@ -146,7 +146,7 @@ var _ = framework.KubeDescribe("Container Lifecycle Hook", func() {
 			Testname: Pod Lifecycle, prestop http hook
 			Description: When a pre-stop handler is specified in the container lifecycle using a 'HttpGet' action, then the handler MUST be invoked before the container is terminated. A server pod is created that will serve http requests, create a second pod with a container lifecycle specifying a pre-stop that invokes the server pod to validate that the pre-stop is executed.
 		*/
-		framework.ConformanceIt("should execute prestop http hook properly [NodeConformance]", func() {
+		framework.ConformanceIt("Base", "should execute prestop http hook properly [NodeConformance]", func() {
 			lifecycle := &v1.Lifecycle{
 				PreStop: &v1.Handler{
 					HTTPGet: &v1.HTTPGetAction{

--- a/test/e2e/common/networking.go
+++ b/test/e2e/common/networking.go
@@ -37,7 +37,7 @@ var _ = ginkgo.Describe("[sig-network] Networking", func() {
 			Description: Create a hostexec pod that is capable of curl to netcat commands. Create a test Pod that will act as a webserver front end exposing ports 8080 for tcp and 8081 for udp. The netserver service proxies are created on specified number of nodes.
 			The kubectl exec on the webserver container MUST reach a http port on the each of service proxy endpoints in the cluster and the request MUST be successful. Container will execute curl command to reach the service port within specified max retry limit and MUST result in reporting unique hostnames.
 		*/
-		framework.ConformanceIt("should function for intra-pod communication: http [NodeConformance]", func() {
+		framework.ConformanceIt("Base", "should function for intra-pod communication: http [NodeConformance]", func() {
 			config := e2enetwork.NewCoreNetworkingTestConfig(f, false)
 			for _, endpointPod := range config.EndpointPods {
 				config.DialFromTestContainer("http", endpointPod.Status.PodIP, e2enetwork.EndpointHTTPPort, config.MaxTries, 0, sets.NewString(endpointPod.Name))
@@ -50,7 +50,7 @@ var _ = ginkgo.Describe("[sig-network] Networking", func() {
 			Description: Create a hostexec pod that is capable of curl to netcat commands. Create a test Pod that will act as a webserver front end exposing ports 8080 for tcp and 8081 for udp. The netserver service proxies are created on specified number of nodes.
 			The kubectl exec on the webserver container MUST reach a udp port on the each of service proxy endpoints in the cluster and the request MUST be successful. Container will execute curl command to reach the service port within specified max retry limit and MUST result in reporting unique hostnames.
 		*/
-		framework.ConformanceIt("should function for intra-pod communication: udp [NodeConformance]", func() {
+		framework.ConformanceIt("Base", "should function for intra-pod communication: udp [NodeConformance]", func() {
 			config := e2enetwork.NewCoreNetworkingTestConfig(f, false)
 			for _, endpointPod := range config.EndpointPods {
 				config.DialFromTestContainer("udp", endpointPod.Status.PodIP, e2enetwork.EndpointUDPPort, config.MaxTries, 0, sets.NewString(endpointPod.Name))
@@ -64,7 +64,7 @@ var _ = ginkgo.Describe("[sig-network] Networking", func() {
 			The kubectl exec on the webserver container MUST reach a http port on the each of service proxy endpoints in the cluster using a http post(protocol=tcp)  and the request MUST be successful. Container will execute curl command to reach the service port within specified max retry limit and MUST result in reporting unique hostnames.
 			This test is marked LinuxOnly since HostNetwork is not supported on other platforms like Windows.
 		*/
-		framework.ConformanceIt("should function for node-pod communication: http [LinuxOnly] [NodeConformance]", func() {
+		framework.ConformanceIt("Privileged", "should function for node-pod communication: http [LinuxOnly] [NodeConformance]", func() {
 			config := e2enetwork.NewCoreNetworkingTestConfig(f, true)
 			for _, endpointPod := range config.EndpointPods {
 				config.DialFromNode("http", endpointPod.Status.PodIP, e2enetwork.EndpointHTTPPort, config.MaxTries, 0, sets.NewString(endpointPod.Name))
@@ -78,7 +78,7 @@ var _ = ginkgo.Describe("[sig-network] Networking", func() {
 			The kubectl exec on the webserver container MUST reach a http port on the each of service proxy endpoints in the cluster using a http post(protocol=udp)  and the request MUST be successful. Container will execute curl command to reach the service port within specified max retry limit and MUST result in reporting unique hostnames.
 			This test is marked LinuxOnly since HostNetwork is not supported on other platforms like Windows.
 		*/
-		framework.ConformanceIt("should function for node-pod communication: udp [LinuxOnly] [NodeConformance]", func() {
+		framework.ConformanceIt("Privileged", "should function for node-pod communication: udp [LinuxOnly] [NodeConformance]", func() {
 			config := e2enetwork.NewCoreNetworkingTestConfig(f, true)
 			for _, endpointPod := range config.EndpointPods {
 				config.DialFromNode("udp", endpointPod.Status.PodIP, e2enetwork.EndpointUDPPort, config.MaxTries, 0, sets.NewString(endpointPod.Name))

--- a/test/e2e/common/pods.go
+++ b/test/e2e/common/pods.go
@@ -187,7 +187,7 @@ var _ = framework.KubeDescribe("Pods", func() {
 		Testname: Pods, assigned hostip
 		Description: Create a Pod. Pod status MUST return successfully and contains a valid IP address.
 	*/
-	framework.ConformanceIt("should get a host IP [NodeConformance]", func() {
+	framework.ConformanceIt("Base", "should get a host IP [NodeConformance]", func() {
 		name := "pod-hostip-" + string(uuid.NewUUID())
 		testHostIP(podClient, &v1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
@@ -209,7 +209,7 @@ var _ = framework.KubeDescribe("Pods", func() {
 		Testname: Pods, lifecycle
 		Description: A Pod is created with a unique label. Pod MUST be accessible when queried using the label selector upon creation. Add a watch, check if the Pod is running. Pod then deleted, The pod deletion timestamp is observed. The watch MUST return the pod deleted event. Query with the original selector for the Pod MUST return empty list.
 	*/
-	framework.ConformanceIt("should be submitted and removed [NodeConformance]", func() {
+	framework.ConformanceIt("Base", "should be submitted and removed [NodeConformance]", func() {
 		ginkgo.By("creating the pod")
 		name := "pod-submit-remove-" + string(uuid.NewUUID())
 		value := strconv.Itoa(time.Now().Nanosecond())
@@ -343,7 +343,7 @@ var _ = framework.KubeDescribe("Pods", func() {
 		- pod/spec/label/create
 		- pod/spec/label/patch
 	*/
-	framework.ConformanceIt("should be updated [NodeConformance]", func() {
+	framework.ConformanceIt("Base", "should be updated [NodeConformance]", func() {
 		ginkgo.By("creating the pod")
 		name := "pod-update-" + string(uuid.NewUUID())
 		value := strconv.Itoa(time.Now().Nanosecond())
@@ -397,7 +397,7 @@ var _ = framework.KubeDescribe("Pods", func() {
 		Testname: Pods, ActiveDeadlineSeconds
 		Description: Create a Pod with a unique label. Query for the Pod with the label as selector MUST be successful. The Pod is updated with ActiveDeadlineSeconds set on the Pod spec. Pod MUST terminate of the specified time elapses.
 	*/
-	framework.ConformanceIt("should allow activeDeadlineSeconds to be updated [NodeConformance]", func() {
+	framework.ConformanceIt("Base", "should allow activeDeadlineSeconds to be updated [NodeConformance]", func() {
 		ginkgo.By("creating the pod")
 		name := "pod-update-activedeadlineseconds-" + string(uuid.NewUUID())
 		value := strconv.Itoa(time.Now().Nanosecond())
@@ -443,7 +443,7 @@ var _ = framework.KubeDescribe("Pods", func() {
 		Testname: Pods, service environment variables
 		Description: Create a server Pod listening on port 9376. A Service called fooservice is created for the server Pod listening on port 8765 targeting port 8080. If a new Pod is created in the cluster then the Pod MUST have the fooservice environment variables available from this new Pod. The new create Pod MUST have environment variables such as FOOSERVICE_SERVICE_HOST, FOOSERVICE_SERVICE_PORT, FOOSERVICE_PORT, FOOSERVICE_PORT_8765_TCP_PORT, FOOSERVICE_PORT_8765_TCP_PROTO, FOOSERVICE_PORT_8765_TCP and FOOSERVICE_PORT_8765_TCP_ADDR that are populated with proper values.
 	*/
-	framework.ConformanceIt("should contain environment variables for services [NodeConformance]", func() {
+	framework.ConformanceIt("Base", "should contain environment variables for services [NodeConformance]", func() {
 		// Make a pod that will be a service.
 		// This pod serves its hostname via HTTP.
 		serverName := "server-envvars-" + string(uuid.NewUUID())
@@ -535,7 +535,7 @@ var _ = framework.KubeDescribe("Pods", func() {
 		Description: A Pod is created. Websocket is created to retrieve exec command output from this pod.
 		Message retrieved form Websocket MUST match with expected exec command output.
 	*/
-	framework.ConformanceIt("should support remote command execution over websockets [NodeConformance]", func() {
+	framework.ConformanceIt("Base", "should support remote command execution over websockets [NodeConformance]", func() {
 		config, err := framework.LoadConfig()
 		framework.ExpectNoError(err, "unable to get base config")
 
@@ -617,7 +617,7 @@ var _ = framework.KubeDescribe("Pods", func() {
 		Description: A Pod is created. Websocket is created to retrieve log of a container from this pod.
 		Message retrieved form Websocket MUST match with container's output.
 	*/
-	framework.ConformanceIt("should support retrieving logs from the container over websockets [NodeConformance]", func() {
+	framework.ConformanceIt("Base", "should support retrieving logs from the container over websockets [NodeConformance]", func() {
 		config, err := framework.LoadConfig()
 		framework.ExpectNoError(err, "unable to get base config")
 

--- a/test/e2e/common/podtemplates.go
+++ b/test/e2e/common/podtemplates.go
@@ -45,7 +45,7 @@ var _ = ginkgo.Describe("[sig-node] PodTemplates", func() {
 	   Description: Attempt to create a PodTemplate. Patch the created PodTemplate. Fetching the PodTemplate MUST reflect changes.
 	          By fetching all the PodTemplates via a Label selector it MUST find the PodTemplate by it's static label and updated value. The PodTemplate must be deleted.
 	*/
-	framework.ConformanceIt("should run the lifecycle of PodTemplates", func() {
+	framework.ConformanceIt("Base", "should run the lifecycle of PodTemplates", func() {
 		testNamespaceName := f.Namespace.Name
 		podTemplateName := "nginx-pod-template-" + string(uuid.NewUUID())
 
@@ -114,7 +114,7 @@ var _ = ginkgo.Describe("[sig-node] PodTemplates", func() {
 		Description: A set of Pod Templates is created with a label selector which MUST be found when listed.
 		The set of Pod Templates is deleted and MUST NOT show up when listed by its label selector.
 	*/
-	framework.ConformanceIt("should delete a collection of pod templates", func() {
+	framework.ConformanceIt("Base", "should delete a collection of pod templates", func() {
 		podTemplateNames := []string{"test-podtemplate-1", "test-podtemplate-2", "test-podtemplate-3"}
 
 		ginkgo.By("Create set of pod templates")

--- a/test/e2e/common/projected_combined.go
+++ b/test/e2e/common/projected_combined.go
@@ -38,7 +38,7 @@ var _ = ginkgo.Describe("[sig-storage] Projected combined", func() {
 	   Testname: Projected Volume, multiple projections
 	   Description: A Pod is created with a projected volume source for secrets, configMap and downwardAPI with pod name, cpu and memory limits and cpu and memory requests. Pod MUST be able to read the secrets, configMap values and the cpu and memory limits as well as cpu and memory requests from the mounted DownwardAPIVolumeFiles.
 	*/
-	framework.ConformanceIt("should project all components that make up the projection API [Projection][NodeConformance]", func() {
+	framework.ConformanceIt("Base", "should project all components that make up the projection API [Projection][NodeConformance]", func() {
 		var err error
 		podName := "projected-volume-" + string(uuid.NewUUID())
 		secretName := "secret-projected-all-test-volume-" + string(uuid.NewUUID())

--- a/test/e2e/common/projected_configmap.go
+++ b/test/e2e/common/projected_configmap.go
@@ -41,7 +41,7 @@ var _ = ginkgo.Describe("[sig-storage] Projected configMap", func() {
 	   Testname: Projected Volume, ConfigMap, volume mode default
 	   Description: A Pod is created with projected volume source 'ConfigMap' to store a configMap with default permission mode. Pod MUST be able to read the content of the ConfigMap successfully and the mode on the volume MUST be -rw-r--r--.
 	*/
-	framework.ConformanceIt("should be consumable from pods in volume [NodeConformance]", func() {
+	framework.ConformanceIt("Base", "should be consumable from pods in volume [NodeConformance]", func() {
 		doProjectedConfigMapE2EWithoutMappings(f, false, 0, nil)
 	})
 
@@ -51,7 +51,7 @@ var _ = ginkgo.Describe("[sig-storage] Projected configMap", func() {
 	   Description: A Pod is created with projected volume source 'ConfigMap' to store a configMap with permission mode set to 0400. Pod MUST be able to read the content of the ConfigMap successfully and the mode on the volume MUST be -r--------.
 	   This test is marked LinuxOnly since Windows does not support setting specific file permissions.
 	*/
-	framework.ConformanceIt("should be consumable from pods in volume with defaultMode set [LinuxOnly] [NodeConformance]", func() {
+	framework.ConformanceIt("Base", "should be consumable from pods in volume with defaultMode set [LinuxOnly] [NodeConformance]", func() {
 		defaultMode := int32(0400)
 		doProjectedConfigMapE2EWithoutMappings(f, false, 0, &defaultMode)
 	})
@@ -68,7 +68,7 @@ var _ = ginkgo.Describe("[sig-storage] Projected configMap", func() {
 	   Testname: Projected Volume, ConfigMap, non-root user
 	   Description: A Pod is created with projected volume source 'ConfigMap' to store a configMap as non-root user with uid 1000. Pod MUST be able to read the content of the ConfigMap successfully and the mode on the volume MUST be -rw-r--r--.
 	*/
-	framework.ConformanceIt("should be consumable from pods in volume as non-root [NodeConformance]", func() {
+	framework.ConformanceIt("Base", "should be consumable from pods in volume as non-root [NodeConformance]", func() {
 		doProjectedConfigMapE2EWithoutMappings(f, true, 0, nil)
 	})
 
@@ -83,7 +83,7 @@ var _ = ginkgo.Describe("[sig-storage] Projected configMap", func() {
 	   Testname: Projected Volume, ConfigMap, mapped
 	   Description: A Pod is created with projected volume source 'ConfigMap' to store a configMap with default permission mode. The ConfigMap is also mapped to a custom path. Pod MUST be able to read the content of the ConfigMap from the custom location successfully and the mode on the volume MUST be -rw-r--r--.
 	*/
-	framework.ConformanceIt("should be consumable from pods in volume with mappings [NodeConformance]", func() {
+	framework.ConformanceIt("Base", "should be consumable from pods in volume with mappings [NodeConformance]", func() {
 		doProjectedConfigMapE2EWithMappings(f, false, 0, nil)
 	})
 
@@ -93,7 +93,7 @@ var _ = ginkgo.Describe("[sig-storage] Projected configMap", func() {
 	   Description: A Pod is created with projected volume source 'ConfigMap' to store a configMap with permission mode set to 0400. The ConfigMap is also mapped to a custom path. Pod MUST be able to read the content of the ConfigMap from the custom location successfully and the mode on the volume MUST be -r--r--r--.
 	   This test is marked LinuxOnly since Windows does not support setting specific file permissions.
 	*/
-	framework.ConformanceIt("should be consumable from pods in volume with mappings and Item mode set [LinuxOnly] [NodeConformance]", func() {
+	framework.ConformanceIt("Base", "should be consumable from pods in volume with mappings and Item mode set [LinuxOnly] [NodeConformance]", func() {
 		mode := int32(0400)
 		doProjectedConfigMapE2EWithMappings(f, false, 0, &mode)
 	})
@@ -103,7 +103,7 @@ var _ = ginkgo.Describe("[sig-storage] Projected configMap", func() {
 	   Testname: Projected Volume, ConfigMap, mapped, non-root user
 	   Description: A Pod is created with projected volume source 'ConfigMap' to store a configMap as non-root user with uid 1000. The ConfigMap is also mapped to a custom path. Pod MUST be able to read the content of the ConfigMap from the custom location successfully and the mode on the volume MUST be -r--r--r--.
 	*/
-	framework.ConformanceIt("should be consumable from pods in volume with mappings as non-root [NodeConformance]", func() {
+	framework.ConformanceIt("Base", "should be consumable from pods in volume with mappings as non-root [NodeConformance]", func() {
 		doProjectedConfigMapE2EWithMappings(f, true, 0, nil)
 	})
 
@@ -118,7 +118,7 @@ var _ = ginkgo.Describe("[sig-storage] Projected configMap", func() {
 	   Testname: Projected Volume, ConfigMap, update
 	   Description: A Pod is created with projected volume source 'ConfigMap' to store a configMap and performs a create and update to new value. Pod MUST be able to create the configMap with value-1. Pod MUST be able to update the value in the confgiMap to value-2.
 	*/
-	framework.ConformanceIt("updates should be reflected in volume [NodeConformance]", func() {
+	framework.ConformanceIt("Base", "updates should be reflected in volume [NodeConformance]", func() {
 		podLogTimeout := e2epod.GetPodSecretUpdateTimeout(f.ClientSet)
 		containerTimeoutArg := fmt.Sprintf("--retry_time=%v", int(podLogTimeout.Seconds()))
 
@@ -206,7 +206,7 @@ var _ = ginkgo.Describe("[sig-storage] Projected configMap", func() {
 	   Testname: Projected Volume, ConfigMap, create, update and delete
 	   Description: Create a Pod with three containers with ConfigMaps namely a create, update and delete container. Create Container when started MUST not have configMap, update and delete containers MUST be created with a ConfigMap value as 'value-1'. Create a configMap in the create container, the Pod MUST be able to read the configMap from the create container. Update the configMap in the update container, Pod MUST be able to read the updated configMap value. Delete the configMap in the delete container. Pod MUST fail to read the configMap from the delete container.
 	*/
-	framework.ConformanceIt("optional updates should be reflected in volume [NodeConformance]", func() {
+	framework.ConformanceIt("Base", "optional updates should be reflected in volume [NodeConformance]", func() {
 		podLogTimeout := e2epod.GetPodSecretUpdateTimeout(f.ClientSet)
 		containerTimeoutArg := fmt.Sprintf("--retry_time=%v", int(podLogTimeout.Seconds()))
 		trueVal := true
@@ -407,7 +407,7 @@ var _ = ginkgo.Describe("[sig-storage] Projected configMap", func() {
 	   Testname: Projected Volume, ConfigMap, multiple volume paths
 	   Description: A Pod is created with a projected volume source 'ConfigMap' to store a configMap. The configMap is mapped to two different volume mounts. Pod MUST be able to read the content of the configMap successfully from the two volume mounts.
 	*/
-	framework.ConformanceIt("should be consumable in multiple volumes in the same pod [NodeConformance]", func() {
+	framework.ConformanceIt("Base", "should be consumable in multiple volumes in the same pod [NodeConformance]", func() {
 		var (
 			name             = "projected-configmap-test-volume-" + string(uuid.NewUUID())
 			volumeName       = "projected-configmap-volume"

--- a/test/e2e/common/projected_downwardapi.go
+++ b/test/e2e/common/projected_downwardapi.go
@@ -48,7 +48,7 @@ var _ = ginkgo.Describe("[sig-storage] Projected downwardAPI", func() {
 	   Testname: Projected Volume, DownwardAPI, pod name
 	   Description: A Pod is created with a projected volume source for downwardAPI with pod name, cpu and memory limits and cpu and memory requests. Pod MUST be able to read the pod name from the mounted DownwardAPIVolumeFiles.
 	*/
-	framework.ConformanceIt("should provide podname only [NodeConformance]", func() {
+	framework.ConformanceIt("Base", "should provide podname only [NodeConformance]", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
 		pod := downwardAPIVolumePodForSimpleTest(podName, "/etc/podinfo/podname")
 
@@ -63,7 +63,7 @@ var _ = ginkgo.Describe("[sig-storage] Projected downwardAPI", func() {
 	   Description: A Pod is created with a projected volume source for downwardAPI with pod name, cpu and memory limits and cpu and memory requests. The default mode for the volume mount is set to 0400. Pod MUST be able to read the pod name from the mounted DownwardAPIVolumeFiles and the volume mode must be -r--------.
 	   This test is marked LinuxOnly since Windows does not support setting specific file permissions.
 	*/
-	framework.ConformanceIt("should set DefaultMode on files [LinuxOnly] [NodeConformance]", func() {
+	framework.ConformanceIt("Base", "should set DefaultMode on files [LinuxOnly] [NodeConformance]", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
 		defaultMode := int32(0400)
 		pod := projectedDownwardAPIVolumePodForModeTest(podName, "/etc/podinfo/podname", nil, &defaultMode)
@@ -79,7 +79,7 @@ var _ = ginkgo.Describe("[sig-storage] Projected downwardAPI", func() {
 	   Description: A Pod is created with a projected volume source for downwardAPI with pod name, cpu and memory limits and cpu and memory requests. The default mode for the volume mount is set to 0400. Pod MUST be able to read the pod name from the mounted DownwardAPIVolumeFiles and the volume mode must be -r--------.
 	   This test is marked LinuxOnly since Windows does not support setting specific file permissions.
 	*/
-	framework.ConformanceIt("should set mode on item file [LinuxOnly] [NodeConformance]", func() {
+	framework.ConformanceIt("Base", "should set mode on item file [LinuxOnly] [NodeConformance]", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
 		mode := int32(0400)
 		pod := projectedDownwardAPIVolumePodForModeTest(podName, "/etc/podinfo/podname", &mode, nil)
@@ -125,7 +125,7 @@ var _ = ginkgo.Describe("[sig-storage] Projected downwardAPI", func() {
 	   Testname: Projected Volume, DownwardAPI, update labels
 	   Description: A Pod is created with a projected volume source for downwardAPI with pod name, cpu and memory limits and cpu and memory requests and label items. Pod MUST be able to read the labels from the mounted DownwardAPIVolumeFiles. Labels are then updated. Pod MUST be able to read the updated values for the Labels.
 	*/
-	framework.ConformanceIt("should update labels on modification [NodeConformance]", func() {
+	framework.ConformanceIt("Base", "should update labels on modification [NodeConformance]", func() {
 		labels := map[string]string{}
 		labels["key1"] = "value1"
 		labels["key2"] = "value2"
@@ -157,7 +157,7 @@ var _ = ginkgo.Describe("[sig-storage] Projected downwardAPI", func() {
 	   Testname: Projected Volume, DownwardAPI, update annotation
 	   Description: A Pod is created with a projected volume source for downwardAPI with pod name, cpu and memory limits and cpu and memory requests and annotation items. Pod MUST be able to read the annotations from the mounted DownwardAPIVolumeFiles. Annotations are then updated. Pod MUST be able to read the updated values for the Annotations.
 	*/
-	framework.ConformanceIt("should update annotations on modification [NodeConformance]", func() {
+	framework.ConformanceIt("Base", "should update annotations on modification [NodeConformance]", func() {
 		annotations := map[string]string{}
 		annotations["builder"] = "bar"
 		podName := "annotationupdate" + string(uuid.NewUUID())
@@ -191,7 +191,7 @@ var _ = ginkgo.Describe("[sig-storage] Projected downwardAPI", func() {
 	   Testname: Projected Volume, DownwardAPI, CPU limits
 	   Description: A Pod is created with a projected volume source for downwardAPI with pod name, cpu and memory limits and cpu and memory requests. Pod MUST be able to read the cpu limits from the mounted DownwardAPIVolumeFiles.
 	*/
-	framework.ConformanceIt("should provide container's cpu limit [NodeConformance]", func() {
+	framework.ConformanceIt("Base", "should provide container's cpu limit [NodeConformance]", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
 		pod := downwardAPIVolumeForContainerResources(podName, "/etc/podinfo/cpu_limit")
 
@@ -205,7 +205,7 @@ var _ = ginkgo.Describe("[sig-storage] Projected downwardAPI", func() {
 	   Testname: Projected Volume, DownwardAPI, memory limits
 	   Description: A Pod is created with a projected volume source for downwardAPI with pod name, cpu and memory limits and cpu and memory requests. Pod MUST be able to read the memory limits from the mounted DownwardAPIVolumeFiles.
 	*/
-	framework.ConformanceIt("should provide container's memory limit [NodeConformance]", func() {
+	framework.ConformanceIt("Base", "should provide container's memory limit [NodeConformance]", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
 		pod := downwardAPIVolumeForContainerResources(podName, "/etc/podinfo/memory_limit")
 
@@ -219,7 +219,7 @@ var _ = ginkgo.Describe("[sig-storage] Projected downwardAPI", func() {
 	   Testname: Projected Volume, DownwardAPI, CPU request
 	   Description: A Pod is created with a projected volume source for downwardAPI with pod name, cpu and memory limits and cpu and memory requests. Pod MUST be able to read the cpu request from the mounted DownwardAPIVolumeFiles.
 	*/
-	framework.ConformanceIt("should provide container's cpu request [NodeConformance]", func() {
+	framework.ConformanceIt("Base", "should provide container's cpu request [NodeConformance]", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
 		pod := downwardAPIVolumeForContainerResources(podName, "/etc/podinfo/cpu_request")
 
@@ -233,7 +233,7 @@ var _ = ginkgo.Describe("[sig-storage] Projected downwardAPI", func() {
 	   Testname: Projected Volume, DownwardAPI, memory request
 	   Description: A Pod is created with a projected volume source for downwardAPI with pod name, cpu and memory limits and cpu and memory requests. Pod MUST be able to read the memory request from the mounted DownwardAPIVolumeFiles.
 	*/
-	framework.ConformanceIt("should provide container's memory request [NodeConformance]", func() {
+	framework.ConformanceIt("Base", "should provide container's memory request [NodeConformance]", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
 		pod := downwardAPIVolumeForContainerResources(podName, "/etc/podinfo/memory_request")
 
@@ -247,7 +247,7 @@ var _ = ginkgo.Describe("[sig-storage] Projected downwardAPI", func() {
 	   Testname: Projected Volume, DownwardAPI, CPU limit, node allocatable
 	   Description: A Pod is created with a projected volume source for downwardAPI with pod name, cpu and memory limits and cpu and memory requests.  The CPU and memory resources for requests and limits are NOT specified for the container. Pod MUST be able to read the default cpu limits from the mounted DownwardAPIVolumeFiles.
 	*/
-	framework.ConformanceIt("should provide node allocatable (cpu) as default cpu limit if the limit is not set [NodeConformance]", func() {
+	framework.ConformanceIt("Base", "should provide node allocatable (cpu) as default cpu limit if the limit is not set [NodeConformance]", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
 		pod := downwardAPIVolumeForDefaultContainerResources(podName, "/etc/podinfo/cpu_limit")
 
@@ -259,7 +259,7 @@ var _ = ginkgo.Describe("[sig-storage] Projected downwardAPI", func() {
 	   Testname: Projected Volume, DownwardAPI, memory limit, node allocatable
 	   Description: A Pod is created with a projected volume source for downwardAPI with pod name, cpu and memory limits and cpu and memory requests.  The CPU and memory resources for requests and limits are NOT specified for the container. Pod MUST be able to read the default memory limits from the mounted DownwardAPIVolumeFiles.
 	*/
-	framework.ConformanceIt("should provide node allocatable (memory) as default memory limit if the limit is not set [NodeConformance]", func() {
+	framework.ConformanceIt("Base", "should provide node allocatable (memory) as default memory limit if the limit is not set [NodeConformance]", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
 		pod := downwardAPIVolumeForDefaultContainerResources(podName, "/etc/podinfo/memory_limit")
 

--- a/test/e2e/common/projected_secret.go
+++ b/test/e2e/common/projected_secret.go
@@ -40,7 +40,7 @@ var _ = ginkgo.Describe("[sig-storage] Projected secret", func() {
 	   Testname: Projected Volume, Secrets, volume mode default
 	   Description: A Pod is created with a projected volume source 'secret' to store a secret with a specified key with default permission mode. Pod MUST be able to read the content of the key successfully and the mode MUST be -rw-r--r-- by default.
 	*/
-	framework.ConformanceIt("should be consumable from pods in volume [NodeConformance]", func() {
+	framework.ConformanceIt("Base", "should be consumable from pods in volume [NodeConformance]", func() {
 		doProjectedSecretE2EWithoutMapping(f, nil /* default mode */, "projected-secret-test-"+string(uuid.NewUUID()), nil, nil)
 	})
 
@@ -50,7 +50,7 @@ var _ = ginkgo.Describe("[sig-storage] Projected secret", func() {
 	   Description: A Pod is created with a projected volume source 'secret' to store a secret with a specified key with permission mode set to 0x400 on the Pod. Pod MUST be able to read the content of the key successfully and the mode MUST be -r--------.
 	   This test is marked LinuxOnly since Windows does not support setting specific file permissions.
 	*/
-	framework.ConformanceIt("should be consumable from pods in volume with defaultMode set [LinuxOnly] [NodeConformance]", func() {
+	framework.ConformanceIt("Base", "should be consumable from pods in volume with defaultMode set [LinuxOnly] [NodeConformance]", func() {
 		defaultMode := int32(0400)
 		doProjectedSecretE2EWithoutMapping(f, &defaultMode, "projected-secret-test-"+string(uuid.NewUUID()), nil, nil)
 	})
@@ -61,7 +61,7 @@ var _ = ginkgo.Describe("[sig-storage] Projected secret", func() {
 	   Description: A Pod is created with a projected volume source 'secret' to store a secret with a specified key. The volume has permission mode set to 0440, fsgroup set to 1001 and user set to non-root uid of 1000. Pod MUST be able to read the content of the key successfully and the mode MUST be -r--r-----.
 	   This test is marked LinuxOnly since Windows does not support setting specific file permissions, or running as UID / GID.
 	*/
-	framework.ConformanceIt("should be consumable from pods in volume as non-root with defaultMode and fsGroup set [LinuxOnly] [NodeConformance]", func() {
+	framework.ConformanceIt("Base", "should be consumable from pods in volume as non-root with defaultMode and fsGroup set [LinuxOnly] [NodeConformance]", func() {
 		defaultMode := int32(0440) /* setting fsGroup sets mode to at least 440 */
 		fsGroup := int64(1001)
 		doProjectedSecretE2EWithoutMapping(f, &defaultMode, "projected-secret-test-"+string(uuid.NewUUID()), &fsGroup, &nonRootTestUserID)
@@ -72,7 +72,7 @@ var _ = ginkgo.Describe("[sig-storage] Projected secret", func() {
 	   Testname: Projected Volume, Secrets, mapped
 	   Description: A Pod is created with a projected volume source 'secret' to store a secret with a specified key with default permission mode. The secret is also mapped to a custom path. Pod MUST be able to read the content of the key successfully and the mode MUST be -r--------on the mapped volume.
 	*/
-	framework.ConformanceIt("should be consumable from pods in volume with mappings [NodeConformance]", func() {
+	framework.ConformanceIt("Base", "should be consumable from pods in volume with mappings [NodeConformance]", func() {
 		doProjectedSecretE2EWithMapping(f, nil)
 	})
 
@@ -82,7 +82,7 @@ var _ = ginkgo.Describe("[sig-storage] Projected secret", func() {
 	   Description: A Pod is created with a projected volume source 'secret' to store a secret with a specified key with permission mode set to 0400. The secret is also mapped to a specific name. Pod MUST be able to read the content of the key successfully and the mode MUST be -r-------- on the mapped volume.
 	   This test is marked LinuxOnly since Windows does not support setting specific file permissions.
 	*/
-	framework.ConformanceIt("should be consumable from pods in volume with mappings and Item Mode set [LinuxOnly] [NodeConformance]", func() {
+	framework.ConformanceIt("Base", "should be consumable from pods in volume with mappings and Item Mode set [LinuxOnly] [NodeConformance]", func() {
 		mode := int32(0400)
 		doProjectedSecretE2EWithMapping(f, &mode)
 	})
@@ -113,7 +113,7 @@ var _ = ginkgo.Describe("[sig-storage] Projected secret", func() {
 	   Testname: Projected Volume, Secrets, mapped, multiple paths
 	   Description: A Pod is created with a projected volume source 'secret' to store a secret with a specified key. The secret is mapped to two different volume mounts. Pod MUST be able to read the content of the key successfully from the two volume mounts and the mode MUST be -r-------- on the mapped volumes.
 	*/
-	framework.ConformanceIt("should be consumable in multiple volumes in a pod [NodeConformance]", func() {
+	framework.ConformanceIt("Base", "should be consumable in multiple volumes in a pod [NodeConformance]", func() {
 		// This test ensures that the same secret can be mounted in multiple
 		// volumes in the same pod.  This test case exists to prevent
 		// regressions that break this use-case.
@@ -209,7 +209,7 @@ var _ = ginkgo.Describe("[sig-storage] Projected secret", func() {
 	   Testname: Projected Volume, Secrets, create, update delete
 	   Description: Create a Pod with three containers with secrets namely a create, update and delete container. Create Container when started MUST no have a secret, update and delete containers MUST be created with a secret value. Create a secret in the create container, the Pod MUST be able to read the secret from the create container. Update the secret in the update container, Pod MUST be able to read the updated secret value. Delete the secret in the delete container. Pod MUST fail to read the secret from the delete container.
 	*/
-	framework.ConformanceIt("optional updates should be reflected in volume [NodeConformance]", func() {
+	framework.ConformanceIt("Base", "optional updates should be reflected in volume [NodeConformance]", func() {
 		podLogTimeout := e2epod.GetPodSecretUpdateTimeout(f.ClientSet)
 		containerTimeoutArg := fmt.Sprintf("--retry_time=%v", int(podLogTimeout.Seconds()))
 		trueVal := true

--- a/test/e2e/common/runtime.go
+++ b/test/e2e/common/runtime.go
@@ -46,7 +46,7 @@ var _ = framework.KubeDescribe("Container Runtime", func() {
 				Testname: Container Runtime, Restart Policy, Pod Phases
 				Description: If the restart policy is set to 'Always', Pod MUST be restarted when terminated, If restart policy is 'OnFailure', Pod MUST be started only if it is terminated with non-zero exit code. If the restart policy is 'Never', Pod MUST never be restarted. All these three test cases MUST verify the restart counts accordingly.
 			*/
-			framework.ConformanceIt("should run with the expected status [NodeConformance]", func() {
+			framework.ConformanceIt("Base", "should run with the expected status [NodeConformance]", func() {
 				restartCountVolumeName := "restart-count"
 				restartCountVolumePath := "/restart-count"
 				testContainer := v1.Container{
@@ -193,7 +193,7 @@ while true; do sleep 1; done
 				Description: Create a pod with a container to run it as a non-root user with a custom TerminationMessagePath set. Pod redirects the output to the provided path successfully. When the container is terminated, the termination message MUST match the expected output logged in the provided custom path.
 				[LinuxOnly]: Tagged LinuxOnly due to use of 'uid' and unable to mount files in Windows Containers.
 			*/
-			framework.ConformanceIt("should report termination message [LinuxOnly] if TerminationMessagePath is set as non-root user and at a non-default path [NodeConformance]", func() {
+			framework.ConformanceIt("Base", "should report termination message [LinuxOnly] if TerminationMessagePath is set as non-root user and at a non-default path [NodeConformance]", func() {
 				// TODO(claudiub): Remove [LinuxOnly] tag once Containerd becomes the default
 				// container runtime on Windows
 				container := v1.Container{
@@ -217,7 +217,7 @@ while true; do sleep 1; done
 				Description: Create a pod with an container. Container's output is recorded in log and container exits with an error. When container is terminated, termination message MUST match the expected output recorded from container's log.
 				[LinuxOnly]: Cannot mount files in Windows Containers.
 			*/
-			framework.ConformanceIt("should report termination message [LinuxOnly] from log output if TerminationMessagePolicy FallbackToLogsOnError is set [NodeConformance]", func() {
+			framework.ConformanceIt("Base", "should report termination message [LinuxOnly] from log output if TerminationMessagePolicy FallbackToLogsOnError is set [NodeConformance]", func() {
 				container := v1.Container{
 					Image:                    framework.BusyBoxImage,
 					Command:                  []string{"/bin/sh", "-c"},
@@ -234,7 +234,7 @@ while true; do sleep 1; done
 				Description: Create a pod with an container. Container's output is recorded in log and container exits successfully without an error. When container is terminated, terminationMessage MUST have no content as container succeed.
 				[LinuxOnly]: Cannot mount files in Windows Containers.
 			*/
-			framework.ConformanceIt("should report termination message [LinuxOnly] as empty when pod succeeds and TerminationMessagePolicy FallbackToLogsOnError is set [NodeConformance]", func() {
+			framework.ConformanceIt("Base", "should report termination message [LinuxOnly] as empty when pod succeeds and TerminationMessagePolicy FallbackToLogsOnError is set [NodeConformance]", func() {
 				container := v1.Container{
 					Image:                    framework.BusyBoxImage,
 					Command:                  []string{"/bin/sh", "-c"},
@@ -251,7 +251,7 @@ while true; do sleep 1; done
 				Description: Create a pod with an container. Container's output is recorded in a file and the container exits successfully without an error. When container is terminated, terminationMessage MUST match with the content from file.
 				[LinuxOnly]: Cannot mount files in Windows Containers.
 			*/
-			framework.ConformanceIt("should report termination message [LinuxOnly] from file when pod succeeds and TerminationMessagePolicy FallbackToLogsOnError is set [NodeConformance]", func() {
+			framework.ConformanceIt("Base", "should report termination message [LinuxOnly] from file when pod succeeds and TerminationMessagePolicy FallbackToLogsOnError is set [NodeConformance]", func() {
 				container := v1.Container{
 					Image:                    framework.BusyBoxImage,
 					Command:                  []string{"/bin/sh", "-c"},

--- a/test/e2e/common/secrets.go
+++ b/test/e2e/common/secrets.go
@@ -40,7 +40,7 @@ var _ = ginkgo.Describe("[sig-api-machinery] Secrets", func() {
 		Testname: Secrets, pod environment field
 		Description: Create a secret. Create a Pod with Container that declares a environment variable which references the secret created to extract a key value from the secret. Pod MUST have the environment variable that contains proper value for the key to the secret.
 	*/
-	framework.ConformanceIt("should be consumable from pods in env vars [NodeConformance]", func() {
+	framework.ConformanceIt("Base", "should be consumable from pods in env vars [NodeConformance]", func() {
 		name := "secret-test-" + string(uuid.NewUUID())
 		secret := secretForTest(f.Namespace.Name, name)
 
@@ -89,7 +89,7 @@ var _ = ginkgo.Describe("[sig-api-machinery] Secrets", func() {
 		Testname: Secrets, pod environment from source
 		Description: Create a secret. Create a Pod with Container that declares a environment variable using 'EnvFrom' which references the secret created to extract a key value from the secret. Pod MUST have the environment variable that contains proper value for the key to the secret.
 	*/
-	framework.ConformanceIt("should be consumable via the environment [NodeConformance]", func() {
+	framework.ConformanceIt("Base", "should be consumable via the environment [NodeConformance]", func() {
 		name := "secret-test-" + string(uuid.NewUUID())
 		secret := newEnvFromSecret(f.Namespace.Name, name)
 		ginkgo.By(fmt.Sprintf("creating secret %v/%v", f.Namespace.Name, secret.Name))
@@ -134,7 +134,7 @@ var _ = ginkgo.Describe("[sig-api-machinery] Secrets", func() {
 	   Testname: Secrets, with empty-key
 	   Description: Attempt to create a Secret with an empty key. The creation MUST fail.
 	*/
-	framework.ConformanceIt("should fail to create secret due to empty secret key", func() {
+	framework.ConformanceIt("Base", "should fail to create secret due to empty secret key", func() {
 		secret, err := createEmptyKeySecretForTest(f)
 		framework.ExpectError(err, "created secret %q with empty key in namespace %q", secret.Name, f.Namespace.Name)
 	})
@@ -148,7 +148,7 @@ var _ = ginkgo.Describe("[sig-api-machinery] Secrets", func() {
 		           The Secret is deleted by it's static Label.
 		           Secrets are listed finally, the list MUST NOT include the originally created Secret.
 	*/
-	framework.ConformanceIt("should patch a secret", func() {
+	framework.ConformanceIt("Base", "should patch a secret", func() {
 		ginkgo.By("creating a secret")
 
 		secretTestName := "test-secret-" + string(uuid.NewUUID())

--- a/test/e2e/common/secrets_volume.go
+++ b/test/e2e/common/secrets_volume.go
@@ -41,7 +41,7 @@ var _ = ginkgo.Describe("[sig-storage] Secrets", func() {
 		Testname: Secrets Volume, default
 		Description: Create a secret. Create a Pod with secret volume source configured into the container. Pod MUST be able to read the secret from the mounted volume from the container runtime and the file mode of the secret MUST be -rw-r--r-- by default.
 	*/
-	framework.ConformanceIt("should be consumable from pods in volume [NodeConformance]", func() {
+	framework.ConformanceIt("Base", "should be consumable from pods in volume [NodeConformance]", func() {
 		doSecretE2EWithoutMapping(f, nil /* default mode */, "secret-test-"+string(uuid.NewUUID()), nil, nil)
 	})
 
@@ -51,7 +51,7 @@ var _ = ginkgo.Describe("[sig-storage] Secrets", func() {
 		Description: Create a secret. Create a Pod with secret volume source configured into the container with file mode set to 0x400. Pod MUST be able to read the secret from the mounted volume from the container runtime and the file mode of the secret MUST be -r-------- by default.
 		This test is marked LinuxOnly since Windows does not support setting specific file permissions.
 	*/
-	framework.ConformanceIt("should be consumable from pods in volume with defaultMode set [LinuxOnly] [NodeConformance]", func() {
+	framework.ConformanceIt("Base", "should be consumable from pods in volume with defaultMode set [LinuxOnly] [NodeConformance]", func() {
 		defaultMode := int32(0400)
 		doSecretE2EWithoutMapping(f, &defaultMode, "secret-test-"+string(uuid.NewUUID()), nil, nil)
 	})
@@ -62,7 +62,7 @@ var _ = ginkgo.Describe("[sig-storage] Secrets", func() {
 		Description: Create a secret. Create a Pod with secret volume source configured into the container with file mode set to 0x440 as a non-root user with uid 1000 and fsGroup id 1001. Pod MUST be able to read the secret from the mounted volume from the container runtime and the file mode of the secret MUST be -r--r-----by default.
 		This test is marked LinuxOnly since Windows does not support setting specific file permissions, or running as UID / GID.
 	*/
-	framework.ConformanceIt("should be consumable from pods in volume as non-root with defaultMode and fsGroup set [LinuxOnly] [NodeConformance]", func() {
+	framework.ConformanceIt("Base", "should be consumable from pods in volume as non-root with defaultMode and fsGroup set [LinuxOnly] [NodeConformance]", func() {
 		defaultMode := int32(0440) /* setting fsGroup sets mode to at least 440 */
 		fsGroup := int64(1001)
 		doSecretE2EWithoutMapping(f, &defaultMode, "secret-test-"+string(uuid.NewUUID()), &fsGroup, &nonRootTestUserID)
@@ -73,7 +73,7 @@ var _ = ginkgo.Describe("[sig-storage] Secrets", func() {
 		Testname: Secrets Volume, mapping
 		Description: Create a secret. Create a Pod with secret volume source configured into the container with a custom path. Pod MUST be able to read the secret from the mounted volume from the specified custom path. The file mode of the secret MUST be -rw-r--r-- by default.
 	*/
-	framework.ConformanceIt("should be consumable from pods in volume with mappings [NodeConformance]", func() {
+	framework.ConformanceIt("Base", "should be consumable from pods in volume with mappings [NodeConformance]", func() {
 		doSecretE2EWithMapping(f, nil)
 	})
 
@@ -83,7 +83,7 @@ var _ = ginkgo.Describe("[sig-storage] Secrets", func() {
 		Description: Create a secret. Create a Pod with secret volume source configured into the container with a custom path and file mode set to 0x400. Pod MUST be able to read the secret from the mounted volume from the specified custom path. The file mode of the secret MUST be -r--r--r--.
 		This test is marked LinuxOnly since Windows does not support setting specific file permissions.
 	*/
-	framework.ConformanceIt("should be consumable from pods in volume with mappings and Item Mode set [LinuxOnly] [NodeConformance]", func() {
+	framework.ConformanceIt("Base", "should be consumable from pods in volume with mappings and Item Mode set [LinuxOnly] [NodeConformance]", func() {
 		mode := int32(0400)
 		doSecretE2EWithMapping(f, &mode)
 	})
@@ -93,7 +93,7 @@ var _ = ginkgo.Describe("[sig-storage] Secrets", func() {
 		Testname: Secrets Volume, volume mode default, secret with same name in different namespace
 		Description: Create a secret with same name in two namespaces. Create a Pod with secret volume source configured into the container. Pod MUST be able to read the secrets from the mounted volume from the container runtime and only secrets which are associated with namespace where pod is created. The file mode of the secret MUST be -rw-r--r-- by default.
 	*/
-	framework.ConformanceIt("should be able to mount in a volume regardless of a different secret existing with same name in different namespace [NodeConformance]", func() {
+	framework.ConformanceIt("Base", "should be able to mount in a volume regardless of a different secret existing with same name in different namespace [NodeConformance]", func() {
 		var (
 			namespace2  *v1.Namespace
 			err         error
@@ -119,7 +119,7 @@ var _ = ginkgo.Describe("[sig-storage] Secrets", func() {
 		Testname: Secrets Volume, mapping multiple volume paths
 		Description: Create a secret. Create a Pod with two secret volume sources configured into the container in to two different custom paths. Pod MUST be able to read the secret from the both the mounted volumes from the two specified custom paths.
 	*/
-	framework.ConformanceIt("should be consumable in multiple volumes in a pod [NodeConformance]", func() {
+	framework.ConformanceIt("Base", "should be consumable in multiple volumes in a pod [NodeConformance]", func() {
 		// This test ensures that the same secret can be mounted in multiple
 		// volumes in the same pod.  This test case exists to prevent
 		// regressions that break this use-case.
@@ -199,7 +199,7 @@ var _ = ginkgo.Describe("[sig-storage] Secrets", func() {
 		Testname: Secrets Volume, create, update and delete
 		Description: Create a Pod with three containers with secrets volume sources namely a create, update and delete container. Create Container when started MUST not have secret, update and delete containers MUST be created with a secret value. Create a secret in the create container, the Pod MUST be able to read the secret from the create container. Update the secret in the update container, Pod MUST be able to read the updated secret value. Delete the secret in the delete container. Pod MUST fail to read the secret from the delete container.
 	*/
-	framework.ConformanceIt("optional updates should be reflected in volume [NodeConformance]", func() {
+	framework.ConformanceIt("Base", "optional updates should be reflected in volume [NodeConformance]", func() {
 		podLogTimeout := e2epod.GetPodSecretUpdateTimeout(f.ClientSet)
 		containerTimeoutArg := fmt.Sprintf("--retry_time=%v", int(podLogTimeout.Seconds()))
 		trueVal := true

--- a/test/e2e/common/security_context.go
+++ b/test/e2e/common/security_context.go
@@ -80,7 +80,7 @@ var _ = framework.KubeDescribe("Security Context", func() {
 			Description: Container is created with runAsUser option by passing uid 65534 to run as unpriviledged user. Pod MUST be in Succeeded phase.
 			[LinuxOnly]: This test is marked as LinuxOnly since Windows does not support running as UID / GID.
 		*/
-		framework.ConformanceIt("should run the container with uid 65534 [LinuxOnly] [NodeConformance]", func() {
+		framework.ConformanceIt("Base", "should run the container with uid 65534 [LinuxOnly] [NodeConformance]", func() {
 			createAndWaitUserPod(65534)
 		})
 
@@ -219,7 +219,7 @@ var _ = framework.KubeDescribe("Security Context", func() {
 			Description: Container is configured to run with readOnlyRootFilesystem to false.
 			Write operation MUST be allowed and Pod MUST be in Succeeded state.
 		*/
-		framework.ConformanceIt("should run the container with writable rootfs when readOnlyRootFilesystem=false [NodeConformance]", func() {
+		framework.ConformanceIt("Base", "should run the container with writable rootfs when readOnlyRootFilesystem=false [NodeConformance]", func() {
 			createAndWaitUserPod(false)
 		})
 	})
@@ -261,7 +261,7 @@ var _ = framework.KubeDescribe("Security Context", func() {
 			Description: Create a container to run in unprivileged mode by setting pod's SecurityContext Privileged option as false. Pod MUST be in Succeeded phase.
 			[LinuxOnly]: This test is marked as LinuxOnly since it runs a Linux-specific command.
 		*/
-		framework.ConformanceIt("should run the container as unprivileged when false [LinuxOnly] [NodeConformance]", func() {
+		framework.ConformanceIt("Base", "should run the container as unprivileged when false [LinuxOnly] [NodeConformance]", func() {
 			podName := createAndWaitUserPod(false)
 			logs, err := e2epod.GetPodLogs(f.ClientSet, f.Namespace.Name, podName, podName)
 			if err != nil {
@@ -342,7 +342,7 @@ var _ = framework.KubeDescribe("Security Context", func() {
 			When the container is run, container's output MUST match with expected output verifying container ran with given uid i.e. uid=1000.
 			[LinuxOnly]: This test is marked LinuxOnly since Windows does not support running as UID / GID, or privilege escalation.
 		*/
-		framework.ConformanceIt("should not allow privilege escalation when false [LinuxOnly] [NodeConformance]", func() {
+		framework.ConformanceIt("Base", "should not allow privilege escalation when false [LinuxOnly] [NodeConformance]", func() {
 			podName := "alpine-nnp-false-" + string(uuid.NewUUID())
 			apeFalse := false
 			if err := createAndMatchOutput(podName, fmt.Sprintf("Effective uid: %d", nonRootTestUserID), &apeFalse, nonRootTestUserID); err != nil {

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -593,8 +593,8 @@ func KubeDescribe(text string, body func()) bool {
 }
 
 // ConformanceIt is wrapper function for ginkgo It.  Adds "[Conformance]" tag and makes static analysis easier.
-func ConformanceIt(text string, body interface{}, timeout ...float64) bool {
-	return ginkgo.It(text+" [Conformance]", body, timeout...)
+func ConformanceIt(profile, text string, body interface{}, timeout ...float64) bool {
+	return ginkgo.It(text+" [Conformance] [Profile:" + profile +"]", body, timeout...)
 }
 
 // PodStateVerification represents a verification of pod state.

--- a/test/e2e/instrumentation/events.go
+++ b/test/e2e/instrumentation/events.go
@@ -92,7 +92,7 @@ var _ = common.SIGDescribe("Events API", func() {
 		The event is updated with a new series, the check MUST have the update series.
 		The event is deleted and MUST NOT show up when listing all events.
 	*/
-	framework.ConformanceIt("should ensure that an event can be fetched, patched, deleted, and listed", func() {
+	framework.ConformanceIt("Base", "should ensure that an event can be fetched, patched, deleted, and listed", func() {
 		eventName := "event-test"
 
 		ginkgo.By("creating a test event")
@@ -185,7 +185,7 @@ var _ = common.SIGDescribe("Events API", func() {
 		Description: Create a list of events, the events MUST exist.
 		The events are deleted and MUST NOT show up when listing all events.
 	*/
-	framework.ConformanceIt("should delete a collection of events", func() {
+	framework.ConformanceIt("Base", "should delete a collection of events", func() {
 		eventNames := []string{"test-event-1", "test-event-2", "test-event-3"}
 
 		ginkgo.By("Create set of events")

--- a/test/e2e/kubectl/kubectl.go
+++ b/test/e2e/kubectl/kubectl.go
@@ -318,7 +318,7 @@ var _ = SIGDescribe("Kubectl client", func() {
 			Testname: Kubectl, replication controller
 			Description: Create a Pod and a container with a given image. Configure replication controller to run 2 replicas. The number of running instances of the Pod MUST equal the number of replicas set on the replication controller which is 2.
 		*/
-		framework.ConformanceIt("should create and stop a replication controller ", func() {
+		framework.ConformanceIt("Base", "should create and stop a replication controller ", func() {
 			defer cleanupKubectlInputs(nautilus, ns, updateDemoSelector)
 
 			ginkgo.By("creating a replication controller")
@@ -331,7 +331,7 @@ var _ = SIGDescribe("Kubectl client", func() {
 			Testname: Kubectl, scale replication controller
 			Description: Create a Pod and a container with a given image. Configure replication controller to run 2 replicas. The number of running instances of the Pod MUST equal the number of replicas set on the replication controller which is 2. Update the replicaset to 1. Number of running instances of the Pod MUST be 1. Update the replicaset to 2. Number of running instances of the Pod MUST be 2.
 		*/
-		framework.ConformanceIt("should scale a replication controller ", func() {
+		framework.ConformanceIt("Base", "should scale a replication controller ", func() {
 			defer cleanupKubectlInputs(nautilus, ns, updateDemoSelector)
 
 			ginkgo.By("creating a replication controller")
@@ -373,7 +373,7 @@ var _ = SIGDescribe("Kubectl client", func() {
 			Testname: Kubectl, guestbook application
 			Description: Create Guestbook application that contains an agnhost primary server, 2 agnhost replicas, frontend application, frontend service and agnhost primary service and agnhost replica service. Using frontend service, the test will write an entry into the guestbook application which will store the entry into the backend agnhost store. Application flow MUST work as expected and the data written MUST be available to read.
 		*/
-		framework.ConformanceIt("should create and stop a working application ", func() {
+		framework.ConformanceIt("Base", "should create and stop a working application ", func() {
 			defer forEachGBFile(func(contents string) {
 				cleanupKubectlInputs(contents, ns)
 			})
@@ -781,7 +781,7 @@ metadata:
 			Testname: Kubectl, check version v1
 			Description: Run kubectl to get api versions, output MUST contain returned versions with 'v1' listed.
 		*/
-		framework.ConformanceIt("should check if v1 is in available api versions ", func() {
+		framework.ConformanceIt("Base", "should check if v1 is in available api versions ", func() {
 			ginkgo.By("validating api versions")
 			output := framework.RunKubectlOrDie(ns, "api-versions")
 			if !strings.Contains(output, "v1") {
@@ -891,7 +891,7 @@ metadata:
 			Testname: Kubectl, diff Deployment
 			Description: Create a Deployment with httpd image. Declare the same Deployment with a different image, busybox. Diff of live Deployment with declared Deployment MUST include the difference between live and declared image.
 		*/
-		framework.ConformanceIt("should check if kubectl diff finds a difference for Deployments", func() {
+		framework.ConformanceIt("Base", "should check if kubectl diff finds a difference for Deployments", func() {
 			ginkgo.By("create deployment with httpd image")
 			deployment := commonutils.SubstituteImageName(string(readTestFileOrDie(httpdDeployment3Filename)))
 			framework.RunKubectlOrDieInput(ns, deployment, "create", "-f", "-")
@@ -922,7 +922,7 @@ metadata:
 			Testname: Kubectl, server-side dry-run Pod
 			Description: The command 'kubectl run' must create a pod with the specified image name. After, the command 'kubectl replace --dry-run=server' should update the Pod with the new image name and server-side dry-run enabled. The image name must not change.
 		*/
-		framework.ConformanceIt("should check if kubectl can dry-run update Pods", func() {
+		framework.ConformanceIt("Base", "should check if kubectl can dry-run update Pods", func() {
 			ginkgo.By("running the image " + httpdImage)
 			podName := "e2e-test-httpd-pod"
 			nsFlag := fmt.Sprintf("--namespace=%v", ns)
@@ -1082,7 +1082,7 @@ metadata:
 			Testname: Kubectl, cluster info
 			Description: Call kubectl to get cluster-info, output MUST contain cluster-info returned and Kubernetes Master SHOULD be running.
 		*/
-		framework.ConformanceIt("should check if Kubernetes master services is included in cluster-info ", func() {
+		framework.ConformanceIt("Base", "should check if Kubernetes master services is included in cluster-info ", func() {
 			ginkgo.By("validating cluster-info")
 			output := framework.RunKubectlOrDie(ns, "cluster-info")
 			// Can't check exact strings due to terminal control commands (colors)
@@ -1108,7 +1108,7 @@ metadata:
 			Testname: Kubectl, describe pod or rc
 			Description: Deploy an agnhost controller and an agnhost service. Kubectl describe pods SHOULD return the name, namespace, labels, state and other information as expected. Kubectl describe on rc, service, node and namespace SHOULD also return proper information.
 		*/
-		framework.ConformanceIt("should check if kubectl describe prints relevant information for rc and pods ", func() {
+		framework.ConformanceIt("Base", "should check if kubectl describe prints relevant information for rc and pods ", func() {
 			controllerJSON := commonutils.SubstituteImageName(string(readTestFileOrDie(agnhostControllerFilename)))
 			serviceJSON := readTestFileOrDie(agnhostServiceFilename)
 
@@ -1249,7 +1249,7 @@ metadata:
 			Testname: Kubectl, create service, replication controller
 			Description: Create a Pod running agnhost listening to port 6379. Using kubectl expose the agnhost primary replication controllers at port 1234. Validate that the replication controller is listening on port 1234 and the target port is set to 6379, port that agnhost primary is listening. Using kubectl expose the agnhost primary as a service at port 2345. The service MUST be listening on port 2345 and the target port is set to 6379, port that agnhost primary is listening.
 		*/
-		framework.ConformanceIt("should create services for rc ", func() {
+		framework.ConformanceIt("Base", "should create services for rc ", func() {
 			controllerJSON := commonutils.SubstituteImageName(string(readTestFileOrDie(agnhostControllerFilename)))
 			nsFlag := fmt.Sprintf("--namespace=%v", ns)
 
@@ -1346,7 +1346,7 @@ metadata:
 			Testname: Kubectl, label update
 			Description: When a Pod is running, update a Label using 'kubectl label' command. The label MUST be created in the Pod. A 'kubectl get pod' with -l option on the container MUST verify that the label can be read back. Use 'kubectl label label-' to remove the label. 'kubectl get pod' with -l option SHOULD not list the deleted label as the label is removed.
 		*/
-		framework.ConformanceIt("should update the label on a resource ", func() {
+		framework.ConformanceIt("Base", "should update the label on a resource ", func() {
 			labelName := "testing-label"
 			labelValue := "testing-label-value"
 
@@ -1433,7 +1433,7 @@ metadata:
 				'kubectl --since=1s' should output logs that are only 1 second older from now
 				'kubectl --since=24h' should output logs that are only 1 day older from now
 		*/
-		framework.ConformanceIt("should be able to retrieve and filter logs ", func() {
+		framework.ConformanceIt("Base", "should be able to retrieve and filter logs ", func() {
 			// Split("something\n", "\n") returns ["something", ""], so
 			// strip trailing newline first
 			lines := func(out string) []string {
@@ -1493,7 +1493,7 @@ metadata:
 			Testname: Kubectl, patch to annotate
 			Description: Start running agnhost and a replication controller. When the pod is running, using 'kubectl patch' command add annotations. The annotation MUST be added to running pods and SHOULD be able to read added annotations from each of the Pods running under the replication controller.
 		*/
-		framework.ConformanceIt("should add annotations for pods in rc ", func() {
+		framework.ConformanceIt("Base", "should add annotations for pods in rc ", func() {
 			controllerJSON := commonutils.SubstituteImageName(string(readTestFileOrDie(agnhostControllerFilename)))
 			nsFlag := fmt.Sprintf("--namespace=%v", ns)
 			ginkgo.By("creating Agnhost RC")
@@ -1527,7 +1527,7 @@ metadata:
 			Testname: Kubectl, version
 			Description: The command 'kubectl version' MUST return the major, minor versions,  GitCommit, etc of the Client and the Server that the kubectl is configured to connect to.
 		*/
-		framework.ConformanceIt("should check is all data is printed ", func() {
+		framework.ConformanceIt("Base", "should check is all data is printed ", func() {
 			version := framework.RunKubectlOrDie(ns, "version")
 			requiredItems := []string{"Client Version:", "Server Version:", "Major:", "Minor:", "GitCommit:"}
 			for _, item := range requiredItems {
@@ -1556,7 +1556,7 @@ metadata:
 			Testname: Kubectl, run pod
 			Description: Command 'kubectl run' MUST create a pod, when a image name is specified in the run command. After the run command there SHOULD be a pod that should exist with one container running the specified image.
 		*/
-		framework.ConformanceIt("should create a pod from an image when restart is Never ", func() {
+		framework.ConformanceIt("Base", "should create a pod from an image when restart is Never ", func() {
 			ginkgo.By("running the image " + httpdImage)
 			framework.RunKubectlOrDie(ns, "run", podName, "--restart=Never", "--image="+httpdImage, nsFlag)
 			ginkgo.By("verifying the pod " + podName + " was created")
@@ -1592,7 +1592,7 @@ metadata:
 			Testname: Kubectl, replace
 			Description: Command 'kubectl replace' on a existing Pod with a new spec MUST update the image of the container running in the Pod. A -f option to 'kubectl replace' SHOULD force to re-create the resource. The new Pod SHOULD have the container with new change to the image.
 		*/
-		framework.ConformanceIt("should update a single-container pod's image ", func() {
+		framework.ConformanceIt("Base", "should update a single-container pod's image ", func() {
 			ginkgo.By("running the image " + httpdImage)
 			framework.RunKubectlOrDie(ns, "run", podName, "--image="+httpdImage, "--labels=run="+podName, nsFlag)
 
@@ -1632,7 +1632,7 @@ metadata:
 			Testname: Kubectl, proxy port zero
 			Description: Start a proxy server on port zero by running 'kubectl proxy' with --port=0. Call the proxy server by requesting api versions from unix socket. The proxy server MUST provide at least one version string.
 		*/
-		framework.ConformanceIt("should support proxy with --port 0 ", func() {
+		framework.ConformanceIt("Base", "should support proxy with --port 0 ", func() {
 			ginkgo.By("starting the proxy server")
 			port, cmd, err := startProxyServer(ns)
 			if cmd != nil {
@@ -1657,7 +1657,7 @@ metadata:
 			Testname: Kubectl, proxy socket
 			Description: Start a proxy server on by running 'kubectl proxy' with --unix-socket=<some path>. Call the proxy server by requesting api versions from  http://locahost:0/api. The proxy server MUST provide at least one version string
 		*/
-		framework.ConformanceIt("should support --unix-socket=/path ", func() {
+		framework.ConformanceIt("Base", "should support --unix-socket=/path ", func() {
 			ginkgo.By("Starting the proxy")
 			tmpdir, err := ioutil.TempDir("", "kubectl-proxy-unix")
 			if err != nil {

--- a/test/e2e/network/dns.go
+++ b/test/e2e/network/dns.go
@@ -44,7 +44,7 @@ var _ = SIGDescribe("DNS", func() {
 		Testname: DNS, cluster
 		Description: When a Pod is created, the pod MUST be able to resolve cluster dns entries such as kubernetes.default via DNS.
 	*/
-	framework.ConformanceIt("should provide DNS for the cluster ", func() {
+	framework.ConformanceIt("Base", "should provide DNS for the cluster ", func() {
 		// All the names we need to be able to resolve.
 		// TODO: Spin up a separate test service and test that dns works for that service.
 		// NOTE: This only contains the FQDN and the Host name, for testing partial name, see the test below
@@ -111,7 +111,7 @@ var _ = SIGDescribe("DNS", func() {
 		Testname: DNS, cluster
 		Description: When a Pod is created, the pod MUST be able to resolve cluster dns entries such as kubernetes.default via /etc/hosts.
 	*/
-	framework.ConformanceIt("should provide /etc/hosts entries for the cluster [LinuxOnly]", func() {
+	framework.ConformanceIt("Base", "should provide /etc/hosts entries for the cluster [LinuxOnly]", func() {
 		hostFQDN := fmt.Sprintf("%s.%s.%s.svc.%s", dnsTestPodHostName, dnsTestServiceName, f.Namespace.Name, framework.TestContext.ClusterDNSDomain)
 		hostEntries := []string{hostFQDN, dnsTestPodHostName}
 		// TODO: Validate both IPv4 and IPv6 families for dual-stack
@@ -131,7 +131,7 @@ var _ = SIGDescribe("DNS", func() {
 		Testname: DNS, services
 		Description: When a headless service is created, the service MUST be able to resolve all the required service endpoints. When the service is created, any pod in the same namespace must be able to resolve the service by all of the expected DNS names.
 	*/
-	framework.ConformanceIt("should provide DNS for services ", func() {
+	framework.ConformanceIt("Base", "should provide DNS for services ", func() {
 		// NOTE: This only contains the FQDN and the Host name, for testing partial name, see the test below
 		// Create a test headless service.
 		ginkgo.By("Creating a test headless service")
@@ -187,7 +187,7 @@ var _ = SIGDescribe("DNS", func() {
 		Description: Create a headless service and normal service. Both the services MUST be able to resolve partial qualified DNS entries of their service endpoints by serving A records and SRV records.
 		[LinuxOnly]: As Windows currently does not support resolving PQDNs.
 	*/
-	framework.ConformanceIt("should resolve DNS of partial qualified names for services [LinuxOnly]", func() {
+	framework.ConformanceIt("Base", "should resolve DNS of partial qualified names for services [LinuxOnly]", func() {
 		// Create a test headless service.
 		ginkgo.By("Creating a test headless service")
 		testServiceSelector := map[string]string{
@@ -242,7 +242,7 @@ var _ = SIGDescribe("DNS", func() {
 		Description: Create a headless service with label. Create a Pod with label to match service's label, with hostname and a subdomain same as service name.
 		Pod MUST be able to resolve its fully qualified domain name as well as hostname by serving an A record at that name.
 	*/
-	framework.ConformanceIt("should provide DNS for pods for Hostname [LinuxOnly]", func() {
+	framework.ConformanceIt("Base", "should provide DNS for pods for Hostname [LinuxOnly]", func() {
 		// Create a test headless service.
 		ginkgo.By("Creating a test headless service")
 		testServiceSelector := map[string]string{
@@ -284,7 +284,7 @@ var _ = SIGDescribe("DNS", func() {
 		Description: Create a headless service with label. Create a Pod with label to match service's label, with hostname and a subdomain same as service name.
 		Pod MUST be able to resolve its fully qualified domain name as well as subdomain by serving an A record at that name.
 	*/
-	framework.ConformanceIt("should provide DNS for pods for Subdomain", func() {
+	framework.ConformanceIt("Base", "should provide DNS for pods for Subdomain", func() {
 		// Create a test headless service.
 		ginkgo.By("Creating a test headless service")
 		testServiceSelector := map[string]string{
@@ -327,7 +327,7 @@ var _ = SIGDescribe("DNS", func() {
 		Description: Create a service with externalName. Pod MUST be able to resolve the address for this service via CNAME. When externalName of this service is changed, Pod MUST resolve to new DNS entry for the service.
 		Change the service type from externalName to ClusterIP, Pod MUST resolve DNS to the service by serving A records.
 	*/
-	framework.ConformanceIt("should provide DNS for ExternalName services", func() {
+	framework.ConformanceIt("Base", "should provide DNS for ExternalName services", func() {
 		// Create a test ExternalName service.
 		ginkgo.By("Creating a test externalName service")
 		serviceName := "dns-test-service-3"
@@ -405,7 +405,7 @@ var _ = SIGDescribe("DNS", func() {
 		Description: Create a Pod with DNSPolicy as None and custom DNS configuration, specifying nameservers and search path entries.
 		Pod creation MUST be successful and provided DNS configuration MUST be configured in the Pod.
 	*/
-	framework.ConformanceIt("should support configurable pod DNS nameservers", func() {
+	framework.ConformanceIt("Base", "should support configurable pod DNS nameservers", func() {
 		ginkgo.By("Creating a pod with dnsPolicy=None and customized dnsConfig...")
 		testServerIP := "1.1.1.1"
 		testSearchPath := "resolv.conf.local"

--- a/test/e2e/network/ingress.go
+++ b/test/e2e/network/ingress.go
@@ -954,7 +954,7 @@ var _ = SIGDescribe("Ingress API", func() {
 		The ingresses/status resource must support update and patch
 	*/
 
-	framework.ConformanceIt("should support creating Ingress API operations", func() {
+	framework.ConformanceIt("Base", "should support creating Ingress API operations", func() {
 		// Setup
 		ns := f.Namespace.Name
 		ingVersion := "v1"

--- a/test/e2e/network/ingressclass.go
+++ b/test/e2e/network/ingressclass.go
@@ -157,7 +157,7 @@ var _ = SIGDescribe("IngressClass API", func() {
 		- The ingressclasses resource MUST exist in the /apis/networking.k8s.io/v1 discovery document.
 		- The ingressclass resource must support create, get, list, watch, update, patch, delete, and deletecollection.
 	*/
-	framework.ConformanceIt(" should support creating IngressClass API operations", func() {
+	framework.ConformanceIt("Base", " should support creating IngressClass API operations", func() {
 
 		// Setup
 		icClient := f.ClientSet.NetworkingV1().IngressClasses()

--- a/test/e2e/network/proxy.go
+++ b/test/e2e/network/proxy.go
@@ -82,7 +82,7 @@ var _ = SIGDescribe("Proxy", func() {
 			Testname: Proxy, logs service endpoint
 			Description: Select any node in the cluster to invoke  /logs endpoint  using the /nodes/proxy subresource from the kubelet port. This endpoint MUST be reachable.
 		*/
-		framework.ConformanceIt("should proxy through a service and a pod ", func() {
+		framework.ConformanceIt("Base", "should proxy through a service and a pod ", func() {
 			start := time.Now()
 			labels := map[string]string{"proxy-service-target": "true"}
 			service, err := f.ClientSet.CoreV1().Services(f.Namespace.Name).Create(context.TODO(), &v1.Service{

--- a/test/e2e/network/service.go
+++ b/test/e2e/network/service.go
@@ -797,7 +797,7 @@ var _ = SIGDescribe("Services", func() {
 		Testname: Kubernetes Service
 		Description: By default when a kubernetes cluster is running there MUST be a 'kubernetes' service running in the cluster.
 	*/
-	framework.ConformanceIt("should provide secure master service ", func() {
+	framework.ConformanceIt("Base", "should provide secure master service ", func() {
 		_, err := cs.CoreV1().Services(metav1.NamespaceDefault).Get(context.TODO(), "kubernetes", metav1.GetOptions{})
 		framework.ExpectNoError(err, "failed to fetch the service object for the service named kubernetes")
 	})
@@ -807,7 +807,7 @@ var _ = SIGDescribe("Services", func() {
 		Testname: Service, endpoints
 		Description: Create a service with a endpoint without any Pods, the service MUST run and show empty endpoints. Add a pod to the service and the service MUST validate to show all the endpoints for the ports exposed by the Pod. Add another Pod then the list of all Ports exposed by both the Pods MUST be valid and have corresponding service endpoint. Once the second Pod is deleted then set of endpoint MUST be validated to show only ports from the first container that are exposed. Once both pods are deleted the endpoints from the service MUST be empty.
 	*/
-	framework.ConformanceIt("should serve a basic endpoint from pods ", func() {
+	framework.ConformanceIt("Base", "should serve a basic endpoint from pods ", func() {
 		serviceName := "endpoint-test2"
 		ns := f.Namespace.Name
 		jig := e2eservice.NewTestJig(cs, ns, serviceName)
@@ -860,7 +860,7 @@ var _ = SIGDescribe("Services", func() {
 		Testname: Service, endpoints with multiple ports
 		Description: Create a service with two ports but no Pods are added to the service yet.  The service MUST run and show empty set of endpoints. Add a Pod to the first port, service MUST list one endpoint for the Pod on that port. Add another Pod to the second port, service MUST list both the endpoints. Delete the first Pod and the service MUST list only the endpoint to the second Pod. Delete the second Pod and the service must now have empty set of endpoints.
 	*/
-	framework.ConformanceIt("should serve multiport endpoints from pods ", func() {
+	framework.ConformanceIt("Base", "should serve multiport endpoints from pods ", func() {
 		// repacking functionality is intentionally not tested here - it's better to test it in an integration test.
 		serviceName := "multi-endpoint-test"
 		ns := f.Namespace.Name
@@ -1216,7 +1216,7 @@ var _ = SIGDescribe("Services", func() {
 		The client Pod MUST be able to access the NodePort service by service name and cluster
 		IP on the service port, and on nodes' internal and external IPs on the NodePort.
 	*/
-	framework.ConformanceIt("should be able to create a functioning NodePort service", func() {
+	framework.ConformanceIt("Base", "should be able to create a functioning NodePort service", func() {
 		serviceName := "nodeport-test"
 		ns := f.Namespace.Name
 
@@ -1685,7 +1685,7 @@ var _ = SIGDescribe("Services", func() {
 		Update the service from ExternalName to ClusterIP by removing ExternalName entry, assigning port 80 as service port and TCP as protocol.
 		Service update MUST be successful by assigning ClusterIP to the service and it MUST be reachable over serviceName and ClusterIP on provided service port.
 	*/
-	framework.ConformanceIt("should be able to change the type from ExternalName to ClusterIP", func() {
+	framework.ConformanceIt("Base", "should be able to change the type from ExternalName to ClusterIP", func() {
 		serviceName := "externalname-service"
 		ns := f.Namespace.Name
 		jig := e2eservice.NewTestJig(cs, ns, serviceName)
@@ -1724,7 +1724,7 @@ var _ = SIGDescribe("Services", func() {
 		service update MUST be successful by exposing service on every node's IP on dynamically assigned NodePort and, ClusterIP MUST be assigned to route service requests.
 		Service MUST be reachable over serviceName and the ClusterIP on servicePort. Service MUST also be reachable over node's IP on NodePort.
 	*/
-	framework.ConformanceIt("should be able to change the type from ExternalName to NodePort", func() {
+	framework.ConformanceIt("Base", "should be able to change the type from ExternalName to NodePort", func() {
 		serviceName := "externalname-service"
 		ns := f.Namespace.Name
 		jig := e2eservice.NewTestJig(cs, ns, serviceName)
@@ -1762,7 +1762,7 @@ var _ = SIGDescribe("Services", func() {
 		Update service type from ClusterIP to ExternalName by setting CNAME entry as externalName. Service update MUST be successful and service MUST not has associated ClusterIP.
 		Service MUST be able to resolve to IP address by returning A records ensuring service is pointing to provided externalName.
 	*/
-	framework.ConformanceIt("should be able to change the type from ClusterIP to ExternalName", func() {
+	framework.ConformanceIt("Base", "should be able to change the type from ClusterIP to ExternalName", func() {
 		serviceName := "clusterip-service"
 		ns := f.Namespace.Name
 		jig := e2eservice.NewTestJig(cs, ns, serviceName)
@@ -1802,7 +1802,7 @@ var _ = SIGDescribe("Services", func() {
 		Update the service type from NodePort to ExternalName by setting CNAME entry as externalName. Service update MUST be successful and, MUST not has ClusterIP associated with the service and, allocated NodePort MUST be released.
 		Service MUST be able to resolve to IP address by returning A records ensuring service is pointing to provided externalName.
 	*/
-	framework.ConformanceIt("should be able to change the type from NodePort to ExternalName", func() {
+	framework.ConformanceIt("Base", "should be able to change the type from NodePort to ExternalName", func() {
 		serviceName := "nodeport-service"
 		ns := f.Namespace.Name
 		jig := e2eservice.NewTestJig(cs, ns, serviceName)
@@ -2450,7 +2450,7 @@ var _ = SIGDescribe("Services", func() {
 		Service MUST be reachable over serviceName and the ClusterIP on servicePort.
 		[LinuxOnly]: Windows does not support session affinity.
 	*/
-	framework.ConformanceIt("should have session affinity work for service with type clusterIP [LinuxOnly]", func() {
+	framework.ConformanceIt("Base", "should have session affinity work for service with type clusterIP [LinuxOnly]", func() {
 		svc := getServeHostnameService("affinity-clusterip")
 		svc.Spec.Type = v1.ServiceTypeClusterIP
 		execAffinityTestForNonLBService(f, cs, svc)
@@ -2466,7 +2466,7 @@ var _ = SIGDescribe("Services", func() {
 		Service MUST be reachable over serviceName and the ClusterIP on servicePort.
 		[LinuxOnly]: Windows does not support session affinity.
 	*/
-	framework.ConformanceIt("should have session affinity timeout work for service with type clusterIP [LinuxOnly]", func() {
+	framework.ConformanceIt("Base", "should have session affinity timeout work for service with type clusterIP [LinuxOnly]", func() {
 		svc := getServeHostnameService("affinity-clusterip-timeout")
 		svc.Spec.Type = v1.ServiceTypeClusterIP
 		execAffinityTestForSessionAffinityTimeout(f, cs, svc)
@@ -2482,7 +2482,7 @@ var _ = SIGDescribe("Services", func() {
 		Service MUST be reachable over serviceName and the ClusterIP on servicePort.
 		[LinuxOnly]: Windows does not support session affinity.
 	*/
-	framework.ConformanceIt("should be able to switch session affinity for service with type clusterIP [LinuxOnly]", func() {
+	framework.ConformanceIt("Base", "should be able to switch session affinity for service with type clusterIP [LinuxOnly]", func() {
 		svc := getServeHostnameService("affinity-clusterip-transition")
 		svc.Spec.Type = v1.ServiceTypeClusterIP
 		execAffinityTestForNonLBServiceWithTransition(f, cs, svc)
@@ -2497,7 +2497,7 @@ var _ = SIGDescribe("Services", func() {
 		Service MUST be reachable over serviceName and the ClusterIP on servicePort. Service MUST also be reachable over node's IP on NodePort.
 		[LinuxOnly]: Windows does not support session affinity.
 	*/
-	framework.ConformanceIt("should have session affinity work for NodePort service [LinuxOnly]", func() {
+	framework.ConformanceIt("Base", "should have session affinity work for NodePort service [LinuxOnly]", func() {
 		svc := getServeHostnameService("affinity-nodeport")
 		svc.Spec.Type = v1.ServiceTypeNodePort
 		execAffinityTestForNonLBService(f, cs, svc)
@@ -2514,7 +2514,7 @@ var _ = SIGDescribe("Services", func() {
 		Service MUST be reachable over serviceName and the ClusterIP on servicePort. Service MUST also be reachable over node's IP on NodePort.
 		[LinuxOnly]: Windows does not support session affinity.
 	*/
-	framework.ConformanceIt("should have session affinity timeout work for NodePort service [LinuxOnly]", func() {
+	framework.ConformanceIt("Base", "should have session affinity timeout work for NodePort service [LinuxOnly]", func() {
 		svc := getServeHostnameService("affinity-nodeport-timeout")
 		svc.Spec.Type = v1.ServiceTypeNodePort
 		execAffinityTestForSessionAffinityTimeout(f, cs, svc)
@@ -2530,7 +2530,7 @@ var _ = SIGDescribe("Services", func() {
 		Service MUST be reachable over serviceName and the ClusterIP on servicePort. Service MUST also be reachable over node's IP on NodePort.
 		[LinuxOnly]: Windows does not support session affinity.
 	*/
-	framework.ConformanceIt("should be able to switch session affinity for NodePort service [LinuxOnly]", func() {
+	framework.ConformanceIt("Base", "should be able to switch session affinity for NodePort service [LinuxOnly]", func() {
 		svc := getServeHostnameService("affinity-nodeport-transition")
 		svc.Spec.Type = v1.ServiceTypeNodePort
 		execAffinityTestForNonLBServiceWithTransition(f, cs, svc)
@@ -2797,7 +2797,7 @@ var _ = SIGDescribe("Services", func() {
 	   Testname: Find Kubernetes Service in default Namespace
 	   Description: List all Services in all Namespaces, response MUST include a Service named Kubernetes with the Namespace of default.
 	*/
-	framework.ConformanceIt("should find a service from listing all namespaces", func() {
+	framework.ConformanceIt("Base", "should find a service from listing all namespaces", func() {
 		ginkgo.By("fetching services")
 		svcs, _ := f.ClientSet.CoreV1().Services("").List(context.TODO(), metav1.ListOptions{})
 

--- a/test/e2e/network/service_latency.go
+++ b/test/e2e/network/service_latency.go
@@ -53,7 +53,7 @@ var _ = SIGDescribe("Service endpoints latency", func() {
 		Testname: Service endpoint latency, thresholds
 		Description: Run 100 iterations of create service with the Pod running the pause image, measure the time it takes for creating the service and the endpoint with the service name is available. These durations are captured for 100 iterations, then the durations are sorted to compute 50th, 90th and 99th percentile. The single server latency MUST not exceed liberally set thresholds of 20s for 50th percentile and 50s for the 90th percentile.
 	*/
-	framework.ConformanceIt("should not be very high ", func() {
+	framework.ConformanceIt("Base", "should not be very high ", func() {
 		const (
 			// These are very generous criteria. Ideally we will
 			// get this much lower in the future. See issue

--- a/test/e2e/node/events.go
+++ b/test/e2e/node/events.go
@@ -41,7 +41,7 @@ var _ = SIGDescribe("Events", func() {
 		Testname: Pod events, verify event from Scheduler and Kubelet
 		Description: Create a Pod, make sure that the Pod can be queried. Create a event selector for the kind=Pod and the source is the Scheduler. List of the events MUST be at least one. Create a event selector for kind=Pod and the source is the Kubelet. List of the events MUST be at least one. Both Scheduler and Kubelet MUST send events when scheduling and running a Pod.
 	*/
-	framework.ConformanceIt("should be sent by kubelets and the scheduler about pods scheduling and running ", func() {
+	framework.ConformanceIt("Base", "should be sent by kubelets and the scheduler about pods scheduling and running ", func() {
 
 		podClient := f.ClientSet.CoreV1().Pods(f.Namespace.Name)
 

--- a/test/e2e/node/pods.go
+++ b/test/e2e/node/pods.go
@@ -169,7 +169,7 @@ var _ = SIGDescribe("Pods Extended", func() {
 			Behaviors:
 			- pod/spec/container/resources
 		*/
-		framework.ConformanceIt("should be set on Pods with matching resource requests and limits for memory and cpu", func() {
+		framework.ConformanceIt("Base", "should be set on Pods with matching resource requests and limits for memory and cpu", func() {
 			ginkgo.By("creating the pod")
 			name := "pod-qos-class-" + string(uuid.NewUUID())
 			pod := &v1.Pod{

--- a/test/e2e/node/pre_stop.go
+++ b/test/e2e/node/pre_stop.go
@@ -177,7 +177,7 @@ var _ = SIGDescribe("PreStop", func() {
 		Testname: Pods, prestop hook
 		Description: Create a server pod with a rest endpoint '/write' that changes state.Received field. Create a Pod with a pre-stop handle that posts to the /write endpoint on the server Pod. Verify that the Pod with pre-stop hook is running. Delete the Pod with the pre-stop hook. Before the Pod is deleted, pre-stop handler MUST be called when configured. Verify that the Pod is deleted and a call to prestop hook is verified by checking the status received on the server Pod.
 	*/
-	framework.ConformanceIt("should call prestop when killing a pod ", func() {
+	framework.ConformanceIt("Base", "should call prestop when killing a pod ", func() {
 		testPreStop(f.ClientSet, f.Namespace.Name)
 	})
 

--- a/test/e2e/node/taints.go
+++ b/test/e2e/node/taints.go
@@ -284,7 +284,7 @@ var _ = SIGDescribe("NoExecuteTaintManager Single Pod [Serial]", func() {
 		Description: The Pod with toleration timeout scheduled on a tainted Node MUST not be
 		evicted if the taint is removed before toleration time ends.
 	*/
-	framework.ConformanceIt("removing taint cancels eviction [Disruptive]", func() {
+	framework.ConformanceIt("Privileged", "removing taint cancels eviction [Disruptive]", func() {
 		podName := "taint-eviction-4"
 		pod := createPodForTaintsTest(true, 2*additionalWaitPerDeleteSeconds, podName, podName, ns)
 		observedDeletions := make(chan string, 100)
@@ -414,7 +414,7 @@ var _ = SIGDescribe("NoExecuteTaintManager Multiple Pods [Serial]", func() {
 		Description: In a multi-pods scenario with tolerationSeconds, the pods MUST be evicted as per
 		the toleration time limit.
 	*/
-	framework.ConformanceIt("evicts pods with minTolerationSeconds [Disruptive]", func() {
+	framework.ConformanceIt("Privileged", "evicts pods with minTolerationSeconds [Disruptive]", func() {
 		podGroup := "taint-eviction-b"
 		observedDeletions := make(chan string, 100)
 		stopCh := make(chan struct{})

--- a/test/e2e/scheduling/limit_range.go
+++ b/test/e2e/scheduling/limit_range.go
@@ -53,7 +53,7 @@ var _ = SIGDescribe("LimitRange", func() {
 		Testname: LimitRange, resources
 		Description: Creating a Limitrange and verifying the creation of Limitrange, updating the Limitrange and validating the Limitrange. Creating Pods with resources and validate the pod resources are applied to the Limitrange
 	*/
-	framework.ConformanceIt("should create a LimitRange with defaults and ensure pod has those defaults applied.", func() {
+	framework.ConformanceIt("Base", "should create a LimitRange with defaults and ensure pod has those defaults applied.", func() {
 		ginkgo.By("Creating a LimitRange")
 		min := getResourceList("50m", "100Mi", "100Gi")
 		max := getResourceList("500m", "500Mi", "500Gi")

--- a/test/e2e/scheduling/predicates.go
+++ b/test/e2e/scheduling/predicates.go
@@ -319,7 +319,7 @@ var _ = SIGDescribe("SchedulerPredicates [Serial]", func() {
 		Testname: Scheduler, resource limits
 		Description: Scheduling Pods MUST fail if the resource requests exceed Machine capacity.
 	*/
-	framework.ConformanceIt("validates resource limits of pods that are allowed to run ", func() {
+	framework.ConformanceIt("Privileged", "validates resource limits of pods that are allowed to run ", func() {
 		WaitForStableCluster(cs, workerNodes)
 		nodeMaxAllocatable := int64(0)
 		nodeToAllocatableMap := make(map[string]int64)
@@ -429,7 +429,7 @@ var _ = SIGDescribe("SchedulerPredicates [Serial]", func() {
 		Testname: Scheduler, node selector not matching
 		Description: Create a Pod with a NodeSelector set to a value that does not match a node in the cluster. Since there are no nodes matching the criteria the Pod MUST not be scheduled.
 	*/
-	framework.ConformanceIt("validates that NodeSelector is respected if not matching ", func() {
+	framework.ConformanceIt("Privileged", "validates that NodeSelector is respected if not matching ", func() {
 		ginkgo.By("Trying to schedule Pod with nonempty NodeSelector.")
 		podName := "restricted-pod"
 
@@ -452,7 +452,7 @@ var _ = SIGDescribe("SchedulerPredicates [Serial]", func() {
 		Testname: Scheduler, node selector matching
 		Description: Create a label on the node {k: v}. Then create a Pod with a NodeSelector set to {k: v}. Check to see if the Pod is scheduled. When the NodeSelector matches then Pod MUST be scheduled on that node.
 	*/
-	framework.ConformanceIt("validates that NodeSelector is respected if matching ", func() {
+	framework.ConformanceIt("Privileged", "validates that NodeSelector is respected if matching ", func() {
 		nodeName := GetNodeThatCanRunPod(f)
 
 		ginkgo.By("Trying to apply a random label on the found node.")
@@ -657,7 +657,7 @@ var _ = SIGDescribe("SchedulerPredicates [Serial]", func() {
 		Description: Pods with the same HostPort value MUST be able to be scheduled to the same node
 		if the HostIP or Protocol is different.
 	*/
-	framework.ConformanceIt("validates that there is no conflict between pods with same hostPort but different hostIP and protocol", func() {
+	framework.ConformanceIt("Privileged", "validates that there is no conflict between pods with same hostPort but different hostIP and protocol", func() {
 
 		nodeName := GetNodeThatCanRunPod(f)
 
@@ -690,7 +690,7 @@ var _ = SIGDescribe("SchedulerPredicates [Serial]", func() {
 		Description: Pods with the same HostPort and Protocol, but different HostIPs, MUST NOT schedule to the
 		same node if one of those IPs is the default HostIP of 0.0.0.0, which represents all IPs on the host.
 	*/
-	framework.ConformanceIt("validates that there exists conflict between pods with same hostPort and protocol but one using 0.0.0.0 hostIP", func() {
+	framework.ConformanceIt("Privileged", "validates that there exists conflict between pods with same hostPort and protocol but one using 0.0.0.0 hostIP", func() {
 		nodeName := GetNodeThatCanRunPod(f)
 
 		// use nodeSelector to make sure the testing pods get assigned on the same node to explicitly verify there exists conflict or not

--- a/test/e2e/scheduling/preemption.go
+++ b/test/e2e/scheduling/preemption.go
@@ -117,7 +117,7 @@ var _ = SIGDescribe("SchedulerPreemption [Serial]", func() {
 		resources is found, the scheduler MUST preempt a lower priority pod and
 		schedule the high priority pod.
 	*/
-	framework.ConformanceIt("validates basic preemption works", func() {
+	framework.ConformanceIt("Privileged", "validates basic preemption works", func() {
 		var podRes v1.ResourceList
 
 		// Create one pod per node that uses a lot of the node's resources.
@@ -205,7 +205,7 @@ var _ = SIGDescribe("SchedulerPreemption [Serial]", func() {
 		resources is found, the scheduler MUST preempt a lower priority pod to
 		schedule the critical pod.
 	*/
-	framework.ConformanceIt("validates lower priority pod preemption by critical pod", func() {
+	framework.ConformanceIt("Privileged", "validates lower priority pod preemption by critical pod", func() {
 		var podRes v1.ResourceList
 
 		ginkgo.By("Create pods that use 2/3 of node resources.")
@@ -530,7 +530,7 @@ var _ = SIGDescribe("SchedulerPreemption [Serial]", func() {
 			Testname: Pod preemption verification
 			Description: Four levels of Pods in ReplicaSets with different levels of Priority, restricted by given CPU limits MUST launch. Priority 1 - 3 Pods MUST spawn first followed by Priority 4 Pod. The ReplicaSets with Replicas MUST contain the expected number of Replicas.
 		*/
-		framework.ConformanceIt("runs ReplicaSets to verify preemption running path", func() {
+		framework.ConformanceIt("Privileged", "runs ReplicaSets to verify preemption running path", func() {
 			podNamesSeen := []int32{0, 0, 0}
 			stopCh := make(chan struct{})
 

--- a/test/e2e/storage/empty_dir_wrapper.go
+++ b/test/e2e/storage/empty_dir_wrapper.go
@@ -62,7 +62,7 @@ var _ = utils.SIGDescribe("EmptyDir wrapper volumes", func() {
 		Testname: EmptyDir Wrapper Volume, Secret and ConfigMap volumes, no conflict
 		Description: Secret volume and ConfigMap volume is created with data. Pod MUST be able to start with Secret and ConfigMap volumes mounted into the container.
 	*/
-	framework.ConformanceIt("should not conflict", func() {
+	framework.ConformanceIt("Base", "should not conflict", func() {
 		name := "emptydir-wrapper-test-" + string(uuid.NewUUID())
 		volumeName := "secret-volume"
 		volumeMountPath := "/etc/secret-volume"
@@ -184,7 +184,7 @@ var _ = utils.SIGDescribe("EmptyDir wrapper volumes", func() {
 		Testname: EmptyDir Wrapper Volume, ConfigMap volumes, no race
 		Description: Create 50 ConfigMaps Volumes and 5 replicas of pod with these ConfigMapvolumes mounted. Pod MUST NOT fail waiting for Volumes.
 	*/
-	framework.ConformanceIt("should not cause race condition when used for configmaps [Serial]", func() {
+	framework.ConformanceIt("Privileged", "should not cause race condition when used for configmaps [Serial]", func() {
 		configMapNames := createConfigmapsForRace(f)
 		defer deleteConfigMaps(f, configMapNames)
 		volumes, volumeMounts := makeConfigMapVolumes(configMapNames)

--- a/test/e2e/storage/subpath.go
+++ b/test/e2e/storage/subpath.go
@@ -56,7 +56,7 @@ var _ = utils.SIGDescribe("Subpath", func() {
 		  Description: Containers in a pod can read content from a secret mounted volume which was configured with a subpath.
 		  This test is marked LinuxOnly since Windows cannot mount individual files in Containers.
 		*/
-		framework.ConformanceIt("should support subpaths with secret pod [LinuxOnly]", func() {
+		framework.ConformanceIt("Base", "should support subpaths with secret pod [LinuxOnly]", func() {
 			// TODO(claudiub): Remove [LinuxOnly] tag once Containerd becomes the default container runtime on Windows.
 			pod := testsuites.SubpathTestPod(f, "secret-key", "secret", &v1.VolumeSource{Secret: &v1.SecretVolumeSource{SecretName: "my-secret"}}, privilegedSecurityContext)
 			testsuites.TestBasicSubpath(f, "secret-value", pod)
@@ -68,7 +68,7 @@ var _ = utils.SIGDescribe("Subpath", func() {
 		  Description: Containers in a pod can read content from a configmap mounted volume which was configured with a subpath.
 		  This test is marked LinuxOnly since Windows cannot mount individual files in Containers.
 		*/
-		framework.ConformanceIt("should support subpaths with configmap pod [LinuxOnly]", func() {
+		framework.ConformanceIt("Base", "should support subpaths with configmap pod [LinuxOnly]", func() {
 			// TODO(claudiub): Remove [LinuxOnly] tag once Containerd becomes the default container runtime on Windows.
 			pod := testsuites.SubpathTestPod(f, "configmap-key", "configmap", &v1.VolumeSource{ConfigMap: &v1.ConfigMapVolumeSource{LocalObjectReference: v1.LocalObjectReference{Name: "my-configmap"}}}, privilegedSecurityContext)
 			testsuites.TestBasicSubpath(f, "configmap-value", pod)
@@ -80,7 +80,7 @@ var _ = utils.SIGDescribe("Subpath", func() {
 		  Description: Containers in a pod can read content from a configmap mounted volume which was configured with a subpath and also using a mountpath that is a specific file.
 		  This test is marked LinuxOnly since Windows cannot mount individual files in Containers.
 		*/
-		framework.ConformanceIt("should support subpaths with configmap pod with mountPath of existing file [LinuxOnly]", func() {
+		framework.ConformanceIt("Base", "should support subpaths with configmap pod with mountPath of existing file [LinuxOnly]", func() {
 			// TODO(claudiub): Remove [LinuxOnly] tag once Containerd becomes the default container runtime on Windows.
 			pod := testsuites.SubpathTestPod(f, "configmap-key", "configmap", &v1.VolumeSource{ConfigMap: &v1.ConfigMapVolumeSource{LocalObjectReference: v1.LocalObjectReference{Name: "my-configmap"}}}, privilegedSecurityContext)
 			file := "/etc/resolv.conf"
@@ -94,7 +94,7 @@ var _ = utils.SIGDescribe("Subpath", func() {
 		  Description: Containers in a pod can read content from a downwardAPI mounted volume which was configured with a subpath.
 		  This test is marked LinuxOnly since Windows cannot mount individual files in Containers.
 		*/
-		framework.ConformanceIt("should support subpaths with downward pod [LinuxOnly]", func() {
+		framework.ConformanceIt("Base", "should support subpaths with downward pod [LinuxOnly]", func() {
 			// TODO(claudiub): Remove [LinuxOnly] tag once Containerd becomes the default container runtime on Windows.
 			pod := testsuites.SubpathTestPod(f, "downward/podname", "downwardAPI", &v1.VolumeSource{
 				DownwardAPI: &v1.DownwardAPIVolumeSource{
@@ -110,7 +110,7 @@ var _ = utils.SIGDescribe("Subpath", func() {
 		  Description: Containers in a pod can read content from a projected mounted volume which was configured with a subpath.
 		  This test is marked LinuxOnly since Windows cannot mount individual files in Containers.
 		*/
-		framework.ConformanceIt("should support subpaths with projected pod [LinuxOnly]", func() {
+		framework.ConformanceIt("Base", "should support subpaths with projected pod [LinuxOnly]", func() {
 			// TODO(claudiub): Remove [LinuxOnly] tag once Containerd becomes the default container runtime on Windows.
 			pod := testsuites.SubpathTestPod(f, "projected/configmap-key", "projected", &v1.VolumeSource{
 				Projected: &v1.ProjectedVolumeSource{


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Implements the first two conformance profiles by labeling existing tests as described in the [Profiles KEP](https://github.com/kubernetes/enhancements/tree/master/keps/sig-architecture/1618-conformance-profiles).

This categorizes the tests based upon https://github.com/kubernetes/community/pull/4994 and there is a worksheet (open to k-dev) describing the specific reason for each test put into "Privileged":

https://docs.google.com/spreadsheets/d/1pUiZj_ZJ013wx9ZHvBw18oy7mpV7Xaq2d7Wv75Xk7iI/edit#gid=758339929

Note that this implementation is the simplest possible; it just adds a single string parameter to `ConformanceIt` that defines the profile. This is sufficient for now; if we want overlapping profiles in the future it would need to change.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs

```