### PR TITLE
Remove false positive warning in kubeadm cmd

### DIFF
--- a/cmd/kubeadm/app/componentconfigs/configset.go
+++ b/cmd/kubeadm/app/componentconfigs/configset.go
@@ -17,8 +17,6 @@ limitations under the License.
 package componentconfigs
 
 import (
-	"sort"
-
 	"github.com/pkg/errors"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -338,13 +336,7 @@ func GetVersionStates(clusterCfg *kubeadmapi.ClusterConfiguration, client client
 }
 
 // Validate is a placeholder for performing a validation on an already loaded component configs in a ClusterConfiguration
-// Currently it prints a warning that no validation was performed
+// TODO: investigate if the function can be repurposed for validating component config via CLI
 func Validate(clusterCfg *kubeadmapi.ClusterConfiguration) field.ErrorList {
-	groups := []string{}
-	for group := range clusterCfg.ComponentConfigs {
-		groups = append(groups, group)
-	}
-	sort.Strings(groups) // The sort is needed to make the output predictable
-	klog.Warningf("WARNING: kubeadm cannot validate component configs for API groups %v", groups)
 	return field.ErrorList{}
 }


### PR DESCRIPTION


**What type of PR is this?**
> /kind cleanup

**What this PR does / why we need it**:
This PR is to remove false positive warning message when using several kubeadm commands. 
 
**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes/kubeadm/issues/2230

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```
