### PR TITLE
Add missing release metadata for e2e tests

### DIFF
--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -649,7 +649,7 @@
     API Server using the current Aggregator [Conformance]'
   description: Ensure that the sample-apiserver code from 1.17 and compiled against
     1.17 will work on the current Aggregator/API-Server.
-  release: ""
+  release: v1.17
   file: test/e2e/apimachinery/aggregator.go
 - testname: Custom Resource Definition Conversion Webhook, convert mixed version list
   codename: '[sig-api-machinery] CustomResourceConversionWebhook [Privileged:ClusterAdmin]
@@ -886,14 +886,14 @@
     removed when a namespace is deleted [Conformance]'
   description: Ensure that if a namespace is deleted then all pods are removed from
     that namespace.
-  release: ""
+  release: v1.11
   file: test/e2e/apimachinery/namespace.go
 - testname: namespace-deletion-removes-services
   codename: '[sig-api-machinery] Namespaces [Serial] should ensure that all services
     are removed when a namespace is deleted [Conformance]'
   description: Ensure that if a namespace is deleted then all services are removed
     from that namespace.
-  release: ""
+  release: v1.11
   file: test/e2e/apimachinery/namespace.go
 - testname: Namespace patching
   codename: '[sig-api-machinery] Namespaces [Serial] should patch a Namespace [Conformance]'
@@ -1074,14 +1074,14 @@
   description: Ensure that a watch can be reopened from the last resource version
     observed by the previous watch, and it will continue delivering notifications
     from that point in time.
-  release: ""
+  release: v1.11
   file: test/e2e/apimachinery/watch.go
 - testname: watch-configmaps-from-resource-version
   codename: '[sig-api-machinery] Watchers should be able to start watching from a
     specific resource version [Conformance]'
   description: Ensure that a watch can be opened from a particular resource version
     in the past and only notifications happening after that resource version are observed.
-  release: ""
+  release: v1.11
   file: test/e2e/apimachinery/watch.go
 - testname: watch-configmaps-with-multiple-watchers
   codename: '[sig-api-machinery] Watchers should observe add, update, and delete watch
@@ -1089,7 +1089,7 @@
   description: Ensure that multiple watchers are able to receive all add, update,
     and delete notifications on configmaps that match a label selector and do not
     receive notifications for configmaps which do not match that label selector.
-  release: ""
+  release: v1.11
   file: test/e2e/apimachinery/watch.go
 - testname: watch-configmaps-label-changed
   codename: '[sig-api-machinery] Watchers should observe an object deletion if it
@@ -1097,7 +1097,7 @@
   description: Ensure that a watched object stops meeting the requirements of a watch's
     selector, the watch will observe a delete, and will not observe notifications
     for that object until it meets the selector's requirements again.
-  release: ""
+  release: v1.11
   file: test/e2e/apimachinery/watch.go
 - testname: watch-consistency
   codename: '[sig-api-machinery] Watchers should receive events on concurrent watches
@@ -1119,53 +1119,53 @@
     [Conformance]'
   description: A conformant Kubernetes distribution MUST create new DaemonSet Pods
     when they fail.
-  release: ""
+  release: v1.10
   file: test/e2e/apps/daemon_set.go
 - testname: DaemonSet-Rollback
   codename: '[sig-apps] Daemon set [Serial] should rollback without unnecessary restarts
     [Conformance]'
   description: A conformant Kubernetes distribution MUST support automated, minimally
     disruptive rollback of updates to a DaemonSet.
-  release: ""
+  release: v1.10
   file: test/e2e/apps/daemon_set.go
 - testname: DaemonSet-NodeSelection
   codename: '[sig-apps] Daemon set [Serial] should run and stop complex daemon [Conformance]'
   description: A conformant Kubernetes distribution MUST support DaemonSet Pod node
     selection via label selectors.
-  release: ""
+  release: v1.10
   file: test/e2e/apps/daemon_set.go
 - testname: DaemonSet-Creation
   codename: '[sig-apps] Daemon set [Serial] should run and stop simple daemon [Conformance]'
   description: A conformant Kubernetes distribution MUST support the creation of DaemonSets.
     When a DaemonSet Pod is deleted, the DaemonSet controller MUST create a replacement
     Pod.
-  release: ""
+  release: v1.10
   file: test/e2e/apps/daemon_set.go
 - testname: DaemonSet-RollingUpdate
   codename: '[sig-apps] Daemon set [Serial] should update pod when spec was updated
     and update strategy is RollingUpdate [Conformance]'
   description: A conformant Kubernetes distribution MUST support DaemonSet RollingUpdates.
-  release: ""
+  release: v1.10
   file: test/e2e/apps/daemon_set.go
 - testname: Deployment Recreate
   codename: '[sig-apps] Deployment RecreateDeployment should delete old pods and create
     new ones [Conformance]'
   description: A conformant Kubernetes distribution MUST support the Deployment with
     Recreate strategy.
-  release: ""
+  release: v1.12
   file: test/e2e/apps/deployment.go
 - testname: Deployment RollingUpdate
   codename: '[sig-apps] Deployment RollingUpdateDeployment should delete old pods
     and create new ones [Conformance]'
   description: A conformant Kubernetes distribution MUST support the Deployment with
     RollingUpdate strategy.
-  release: ""
+  release: v1.12
   file: test/e2e/apps/deployment.go
 - testname: Deployment RevisionHistoryLimit
   codename: '[sig-apps] Deployment deployment should delete old replica sets [Conformance]'
   description: A conformant Kubernetes distribution MUST clean up Deployment's ReplicaSets
     based on the Deployment's `.spec.revisionHistoryLimit`.
-  release: ""
+  release: v1.12
   file: test/e2e/apps/deployment.go
 - testname: Deployment Proportional Scaling
   codename: '[sig-apps] Deployment deployment should support proportional scaling
@@ -1173,14 +1173,14 @@
   description: A conformant Kubernetes distribution MUST support Deployment proportional
     scaling, i.e. proportionally scale a Deployment's ReplicaSets when a Deployment
     is scaled.
-  release: ""
+  release: v1.12
   file: test/e2e/apps/deployment.go
 - testname: Deployment Rollover
   codename: '[sig-apps] Deployment deployment should support rollover [Conformance]'
   description: A conformant Kubernetes distribution MUST support Deployment rollover,
     i.e. allow arbitrary number of changes to desired state during rolling update
     before the rollout finishes.
-  release: ""
+  release: v1.12
   file: test/e2e/apps/deployment.go
 - testname: Jobs, orphan pods, re-adoption
   codename: '[sig-apps] Job should adopt matching orphans and release non-matching

--- a/test/e2e/apimachinery/aggregator.go
+++ b/test/e2e/apimachinery/aggregator.go
@@ -90,6 +90,7 @@ var _ = SIGDescribe("Aggregator", func() {
 	})
 
 	/*
+		    Release : v1.17
 		    Testname: aggregator-supports-the-sample-apiserver
 		    Description: Ensure that the sample-apiserver code from 1.17 and compiled against 1.17
 			will work on the current Aggregator/API-Server.

--- a/test/e2e/apimachinery/namespace.go
+++ b/test/e2e/apimachinery/namespace.go
@@ -228,6 +228,7 @@ var _ = SIGDescribe("Namespaces [Serial]", func() {
 	f := framework.NewDefaultFramework("namespaces")
 
 	/*
+		Release : v1.11
 		Testname: namespace-deletion-removes-pods
 		Description: Ensure that if a namespace is deleted then all pods are removed from that namespace.
 	*/
@@ -235,6 +236,7 @@ var _ = SIGDescribe("Namespaces [Serial]", func() {
 		func() { ensurePodsAreRemovedWhenNamespaceIsDeleted(f) })
 
 	/*
+		Release : v1.11
 		Testname: namespace-deletion-removes-services
 		Description: Ensure that if a namespace is deleted then all services are removed from that namespace.
 	*/

--- a/test/e2e/apimachinery/watch.go
+++ b/test/e2e/apimachinery/watch.go
@@ -46,6 +46,7 @@ var _ = SIGDescribe("Watchers", func() {
 	f := framework.NewDefaultFramework("watch")
 
 	/*
+		    Release : v1.11
 		    Testname: watch-configmaps-with-multiple-watchers
 		    Description: Ensure that multiple watchers are able to receive all add,
 			update, and delete notifications on configmaps that match a label selector and do
@@ -132,6 +133,7 @@ var _ = SIGDescribe("Watchers", func() {
 	})
 
 	/*
+		    Release : v1.11
 		    Testname: watch-configmaps-from-resource-version
 		    Description: Ensure that a watch can be opened from a particular resource version
 			in the past and only notifications happening after that resource version are observed.
@@ -179,6 +181,7 @@ var _ = SIGDescribe("Watchers", func() {
 	})
 
 	/*
+		    Release : v1.11
 		    Testname: watch-configmaps-closed-and-restarted
 		    Description: Ensure that a watch can be reopened from the last resource version
 			observed by the previous watch, and it will continue delivering notifications from
@@ -244,6 +247,7 @@ var _ = SIGDescribe("Watchers", func() {
 	})
 
 	/*
+		    Release : v1.11
 		    Testname: watch-configmaps-label-changed
 		    Description: Ensure that a watched object stops meeting the requirements of
 			a watch's selector, the watch will observe a delete, and will not observe

--- a/test/e2e/apps/daemon_set.go
+++ b/test/e2e/apps/daemon_set.go
@@ -146,6 +146,7 @@ var _ = SIGDescribe("Daemon set [Serial]", func() {
 	})
 
 	/*
+	  Release : v1.10
 	  Testname: DaemonSet-Creation
 	  Description: A conformant Kubernetes distribution MUST support the creation of DaemonSets. When a DaemonSet
 	  Pod is deleted, the DaemonSet controller MUST create a replacement Pod.
@@ -173,6 +174,7 @@ var _ = SIGDescribe("Daemon set [Serial]", func() {
 	})
 
 	/*
+	  Release : v1.10
 	  Testname: DaemonSet-NodeSelection
 	  Description: A conformant Kubernetes distribution MUST support DaemonSet Pod node selection via label
 	  selectors.
@@ -273,6 +275,7 @@ var _ = SIGDescribe("Daemon set [Serial]", func() {
 	})
 
 	/*
+	  Release : v1.10
 	  Testname: DaemonSet-FailedPodCreation
 	  Description: A conformant Kubernetes distribution MUST create new DaemonSet Pods when they fail.
 	*/
@@ -352,6 +355,7 @@ var _ = SIGDescribe("Daemon set [Serial]", func() {
 	})
 
 	/*
+	  Release : v1.10
 	  Testname: DaemonSet-RollingUpdate
 	  Description: A conformant Kubernetes distribution MUST support DaemonSet RollingUpdates.
 	*/
@@ -408,6 +412,7 @@ var _ = SIGDescribe("Daemon set [Serial]", func() {
 	})
 
 	/*
+	  Release : v1.10
 	  Testname: DaemonSet-Rollback
 	  Description: A conformant Kubernetes distribution MUST support automated, minimally disruptive
 	  rollback of updates to a DaemonSet.

--- a/test/e2e/apps/deployment.go
+++ b/test/e2e/apps/deployment.go
@@ -83,6 +83,7 @@ var _ = SIGDescribe("Deployment", func() {
 		testDeleteDeployment(f)
 	})
 	/*
+	  Release : v1.12
 	  Testname: Deployment RollingUpdate
 	  Description: A conformant Kubernetes distribution MUST support the Deployment with RollingUpdate strategy.
 	*/
@@ -90,6 +91,7 @@ var _ = SIGDescribe("Deployment", func() {
 		testRollingUpdateDeployment(f)
 	})
 	/*
+	  Release : v1.12
 	  Testname: Deployment Recreate
 	  Description: A conformant Kubernetes distribution MUST support the Deployment with Recreate strategy.
 	*/
@@ -97,6 +99,7 @@ var _ = SIGDescribe("Deployment", func() {
 		testRecreateDeployment(f)
 	})
 	/*
+	  Release : v1.12
 	  Testname: Deployment RevisionHistoryLimit
 	  Description: A conformant Kubernetes distribution MUST clean up Deployment's ReplicaSets based on
 	  the Deployment's `.spec.revisionHistoryLimit`.
@@ -105,6 +108,7 @@ var _ = SIGDescribe("Deployment", func() {
 		testDeploymentCleanUpPolicy(f)
 	})
 	/*
+	  Release : v1.12
 	  Testname: Deployment Rollover
 	  Description: A conformant Kubernetes distribution MUST support Deployment rollover,
 	    i.e. allow arbitrary number of changes to desired state during rolling update
@@ -120,6 +124,7 @@ var _ = SIGDescribe("Deployment", func() {
 		testDeploymentsControllerRef(f)
 	})
 	/*
+	  Release : v1.12
 	  Testname: Deployment Proportional Scaling
 	  Description: A conformant Kubernetes distribution MUST support Deployment
 	    proportional scaling, i.e. proportionally scale a Deployment's ReplicaSets


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it:**
This PR adds missing release metadata to conformance test.
This is needed to ensure accurate conformance test data.

**Testgrid Link**


**Which issue(s) this PR fixes:**
#92273

**Special notes for your reviewer:**
None

**Does this PR introduce a user-facing change?:**
```
NONE
```
**Release note:**
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:**
[Conformance Test Comment Metadata](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/conformance-tests.md#conformance-test-comment-metadata)

/sig testing
/sig architecture
/area conformance
