### PR TITLE
Increasing allowed delay for EndpointSlice mirroring integration tests

### DIFF
--- a/test/integration/endpointslice/endpointslicemirroring_test.go
+++ b/test/integration/endpointslice/endpointslicemirroring_test.go
@@ -189,7 +189,7 @@ func TestEndpointSliceMirroring(t *testing.T) {
 				}
 			}
 
-			err = wait.PollImmediate(1*time.Second, 5*time.Second, func() (bool, error) {
+			err = wait.PollImmediate(1*time.Second, wait.ForeverTestTimeout, func() (bool, error) {
 				lSelector := discovery.LabelServiceName + "=" + resourceName
 				esList, err := client.DiscoveryV1beta1().EndpointSlices(ns.Name).List(context.TODO(), metav1.ListOptions{LabelSelector: lSelector})
 				if err != nil {


### PR DESCRIPTION
**What type of PR is this?**
/kind failing-test

**What this PR does / why we need it**:
This increases the allowed delay for EndpointSlice mirroring integration tests from 5s to 30s. The shorter 5s delay had become a source of flakes.

**Which issue(s) this PR fixes**:
Fixes #93496

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/sig network
/priority critical-urgent
/assign @liggitt 