### PR TITLE
Fix nil panic in PDB tests

### DIFF
--- a/test/e2e/apps/disruption.go
+++ b/test/e2e/apps/disruption.go
@@ -491,7 +491,7 @@ func waitForPodsOrDie(cs kubernetes.Interface, ns string, n int) {
 		ready := 0
 		for i := range pods.Items {
 			pod := pods.Items[i]
-			if podutil.IsPodReady(&pod) && pod.ObjectMeta.DeletionTimestamp.IsZero() {
+			if podutil.IsPodReady(&pod) && pod.ObjectMeta.DeletionTimestamp == nil {
 				ready++
 			}
 		}
@@ -550,7 +550,7 @@ func locateRunningPod(cs kubernetes.Interface, ns string) (pod *v1.Pod, err erro
 
 		for i := range podList.Items {
 			p := podList.Items[i]
-			if podutil.IsPodReady(&p) && p.ObjectMeta.DeletionTimestamp.IsZero() {
+			if podutil.IsPodReady(&p) && p.ObjectMeta.DeletionTimestamp == nil {
 				pod = &p
 				return true, nil
 			}


### PR DESCRIPTION
**What type of PR is this?**
/kind failing-test

**What this PR does / why we need it**:
DeletionTimestamp is a pointer so accessing it when nil will panic

**Which issue(s) this PR fixes**:
fixes https://github.com/kubernetes/kubernetes/pull/92991/files#r461425286

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/cc @hasheddan @BenTheElder @kubernetes/sig-apps-pr-reviews 