### PR TITLE
add permissions required by endpoints controller for blockOwnerDeletion

### DIFF
--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/controller_policy.go
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/controller_policy.go
@@ -168,6 +168,10 @@ func buildControllerRoles() ([]rbacv1.ClusterRole, []rbacv1.ClusterRoleBinding) 
 				// The controller needs to be able to set a service's finalizers to be able to create an EndpointSlice
 				// resource that is owned by the service and sets blockOwnerDeletion=true in its ownerRef.
 				rbacv1helpers.NewRule("update").Groups(legacyGroup).Resources("services/finalizers").RuleOrDie(),
+				// The controller needs to be able to set a service's finalizers to be able to create an EndpointSlice
+				// resource that is owned by the endpoint and sets blockOwnerDeletion=true in its ownerRef.
+				// see https://github.com/openshift/kubernetes/blob/8691466059314c3f7d6dcffcbb76d14596ca716c/pkg/controller/endpointslicemirroring/utils.go#L87-L88
+				rbacv1helpers.NewRule("update").Groups(legacyGroup).Resources("endpoints/finalizers").RuleOrDie(),
 				rbacv1helpers.NewRule("get", "list", "create", "update", "delete").Groups(discoveryGroup).Resources("endpointslices").RuleOrDie(),
 				eventsRule(),
 			},

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/controller-roles.yaml
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/controller-roles.yaml
@@ -545,6 +545,12 @@ items:
     verbs:
     - update
   - apiGroups:
+    - ""
+    resources:
+    - endpoints/finalizers
+    verbs:
+    - update
+  - apiGroups:
     - discovery.k8s.io
     resources:
     - endpointslices


### PR DESCRIPTION
The endpoint mirroring controller requires permission to set blockOwnerDeletion on the endpoints owner ref. See code here https://github.com/openshift/kubernetes/blob/8691466059314c3f7d6dcffcbb76d14596ca716c/pkg/controller/endpointslicemirroring/utils.go#L87-L88 .  Without this, the controller loops in a failing mode like

```json
{
  "kind": "Event",
  "apiVersion": "audit.k8s.io/v1",
  "level": "Metadata",
  "auditID": "927dfba2-1d15-4c6c-804e-3c21eca8f9e1",
  "stage": "ResponseComplete",
  "requestURI": "/apis/discovery.k8s.io/v1beta1/namespaces/kube-system/endpointslices",
  "verb": "create",
  "user": {
    "username": "system:serviceaccount:kube-system:endpointslicemirroring-controller",
    "uid": "0180be95-b9fd-4472-bacc-b3453b9f6df6",
    "groups": [
      "system:serviceaccounts",
      "system:serviceaccounts:kube-system",
      "system:authenticated"
    ]
  },
  "sourceIPs": [
    "10.0.0.5"
  ],
  "userAgent": "kube-controller-manager/v1.19.0 (linux/amd64) kubernetes/53f1b9d/system:serviceaccount:kube-system:endpointslicemirroring-controller",
  "objectRef": {
    "resource": "endpointslices",
    "namespace": "kube-system",
    "apiGroup": "discovery.k8s.io",
    "apiVersion": "v1beta1"
  },
  "responseStatus": {
    "metadata": {},
    "status": "Failure",
    "reason": "Forbidden",
    "code": 403
  },
  "requestReceivedTimestamp": "2020-07-28T07:06:14.625018Z",
  "stageTimestamp": "2020-07-28T07:06:14.628415Z",
  "annotations": {
    "authorization.k8s.io/decision": "allow",
    "authorization.k8s.io/reason": "RBAC: allowed by ClusterRoleBinding \"system:controller:endpointslicemirroring-controller\" of ClusterRole \"system:controller:endpointslicemirroring-controller\" to ServiceAccount \"endpointslicemirroring-controller/kube-system\""
  }
}

```

/kind bug
/priority important-soon
@kubernetes/sig-network-bugs 
/milestone v1.19

```release-note
NONE
```