### PR TITLE
Create new slice to avoid modify original fake data

### DIFF
--- a/pkg/scheduler/internal/cache/node_tree_test.go
+++ b/pkg/scheduler/internal/cache/node_tree_test.go
@@ -428,14 +428,14 @@ func TestNodeTreeMultiOperations(t *testing.T) {
 		},
 		{
 			name:           "add more nodes to an exhausted zone",
-			nodesToAdd:     append(allNodes[4:9], allNodes[3]),
+			nodesToAdd:     append(allNodes[4:9:9], allNodes[3]),
 			nodesToRemove:  nil,
 			operations:     []string{"add", "add", "add", "add", "add", "next", "next", "next", "next", "add", "next", "next", "next"},
-			expectedOutput: []string{"node-4", "node-6", "node-7", "node-8", "node-3", "node-4", "node-6"},
+			expectedOutput: []string{"node-4", "node-5", "node-6", "node-7", "node-3", "node-8", "node-4"},
 		},
 		{
 			name:           "remove zone and add new to ensure exhausted is reset correctly",
-			nodesToAdd:     append(allNodes[3:5], allNodes[6:8]...),
+			nodesToAdd:     append(allNodes[3:5:5], allNodes[6:8]...),
 			nodesToRemove:  allNodes[3:5],
 			operations:     []string{"add", "add", "next", "next", "remove", "add", "add", "next", "next", "remove", "next", "next"},
 			expectedOutput: []string{"node-3", "node-4", "node-6", "node-7", "node-6", "node-7"},


### PR DESCRIPTION
When create fake data for the nodeTree unittests, The 'append' is invoked
on the common fake data set. That makes the unittests is running with unexpected
fake data after that.


**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

The common fake data set is modified through each test, which makes the unit test is running with unexpected fake data.

**Special notes for your reviewer**:
None

**Does this PR introduce a user-facing change?**:
None

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
None
