### PR TITLE
Automated cherry pick of #86223: add dashpole as kubelet approver

### DIFF
--- a/pkg/kubelet/OWNERS
+++ b/pkg/kubelet/OWNERS
@@ -7,6 +7,7 @@ approvers:
 - tallclair
 - vishh
 - yujuhong
+- dashpole
 reviewers:
 - sig-node-reviewers
 labels:

--- a/pkg/kubelet/apis/podresources/OWNERS
+++ b/pkg/kubelet/apis/podresources/OWNERS
@@ -1,4 +1,0 @@
-# See the OWNERS docs at https://go.k8s.io/owners
-
-approvers:
-- dashpole

--- a/pkg/kubelet/apis/resourcemetrics/OWNERS
+++ b/pkg/kubelet/apis/resourcemetrics/OWNERS
@@ -1,4 +1,0 @@
-# See the OWNERS docs at https://go.k8s.io/owners
-
-approvers:
-- dashpole

--- a/pkg/kubelet/apis/stats/OWNERS
+++ b/pkg/kubelet/apis/stats/OWNERS
@@ -1,4 +1,0 @@
-# See the OWNERS docs at https://go.k8s.io/owners
-
-approvers:
-- dashpole

--- a/pkg/kubelet/cadvisor/OWNERS
+++ b/pkg/kubelet/cadvisor/OWNERS
@@ -1,5 +1,4 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-- dashpole
 - sjenning

--- a/pkg/kubelet/eviction/OWNERS
+++ b/pkg/kubelet/eviction/OWNERS
@@ -1,8 +1,4 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-- derekwaynecarr
-- vishh
-- dchen1107
-- dashpole
 - sjenning

--- a/pkg/kubelet/images/OWNERS
+++ b/pkg/kubelet/images/OWNERS
@@ -1,5 +1,4 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-- dashpole
 - sjenning

--- a/pkg/kubelet/metrics/OWNERS
+++ b/pkg/kubelet/metrics/OWNERS
@@ -1,5 +1,4 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-- dashpole
 - sjenning

--- a/pkg/kubelet/oom/OWNERS
+++ b/pkg/kubelet/oom/OWNERS
@@ -1,4 +1,0 @@
-# See the OWNERS docs at https://go.k8s.io/owners
-
-approvers:
-- dashpole

--- a/pkg/kubelet/preemption/OWNERS
+++ b/pkg/kubelet/preemption/OWNERS
@@ -1,5 +1,4 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-- dashpole
 - sjenning

--- a/pkg/kubelet/stats/OWNERS
+++ b/pkg/kubelet/stats/OWNERS
@@ -1,4 +1,0 @@
-# See the OWNERS docs at https://go.k8s.io/owners
-
-approvers:
-- dashpole


### PR DESCRIPTION
Cherry pick of #86223 on release-1.18.

#86223: add dashpole as kubelet approver

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.