### PR TITLE
[WIP] Convert Kubelet to use legacyflag

### DIFF
--- a/cmd/kubelet/app/options/BUILD
+++ b/cmd/kubelet/app/options/BUILD
@@ -41,6 +41,7 @@ go_library(
         "//staging/src/k8s.io/kubelet/config/v1beta1:go_default_library",
         "//vendor/github.com/spf13/pflag:go_default_library",
         "//vendor/k8s.io/klog/v2:go_default_library",
+        "//vendor/sigs.k8s.io/legacyflag/pkg/legacyflag:go_default_library",
     ] + select({
         "@io_bazel_rules_go//go/platform:android": [
             "//vendor/github.com/google/cadvisor/container/common:go_default_library",

--- a/cmd/kubelet/app/options/options.go
+++ b/cmd/kubelet/app/options/options.go
@@ -41,6 +41,7 @@ import (
 	"k8s.io/kubernetes/pkg/master/ports"
 	utilflag "k8s.io/kubernetes/pkg/util/flag"
 	utiltaints "k8s.io/kubernetes/pkg/util/taints"
+	"sigs.k8s.io/legacyflag/pkg/legacyflag"
 )
 
 const defaultRootDir = "/var/lib/kubelet"
@@ -383,9 +384,12 @@ func (f *KubeletFlags) AddFlags(mainfs *pflag.FlagSet) {
 	fs.MarkDeprecated("experimental-allocatable-ignore-eviction", "will be removed in 1.23.")
 }
 
-// AddKubeletConfigFlags adds flags for a specific kubeletconfig.KubeletConfiguration to the specified FlagSet
-func AddKubeletConfigFlags(mainfs *pflag.FlagSet, c *kubeletconfig.KubeletConfiguration) {
-	fs := pflag.NewFlagSet("", pflag.ExitOnError)
+// AddKubeletConfigFlags adds flags that map to a KubeletConfiguration to fs
+// and returns a function that can apply flag values to arbitrary KubeletConfigurations.
+// The help argument only provides default values for flag help text, and is not
+// used by the returned apply function.
+func AddKubeletConfigFlags(fs *pflag.FlagSet, help *kubeletconfig.KubeletConfiguration) func(c *kubeletconfig.KubeletConfiguration) {
+	lfs := legacyflag.NewFlagSet("")
 	defer func() {
 		// All KubeletConfiguration flags are now deprecated, and any new flags that point to
 		// KubeletConfiguration fields are deprecated-on-creation. When removing flags at the end
@@ -394,150 +398,883 @@ func AddKubeletConfigFlags(mainfs *pflag.FlagSet, c *kubeletconfig.KubeletConfig
 		// e.g. if a flag was added after this deprecation function, it may not be at the end
 		// of its lifetime yet, even if the rest are.
 		deprecated := "This parameter should be set via the config file specified by the Kubelet's --config flag. See https://kubernetes.io/docs/tasks/administer-cluster/kubelet-config-file/ for more information."
-		fs.VisitAll(func(f *pflag.Flag) {
+		pfs := lfs.PflagFlagSet()
+		pfs.VisitAll(func(f *pflag.Flag) {
 			f.Deprecated = deprecated
 		})
-		mainfs.AddFlagSet(fs)
+		fs.AddFlagSet(pfs)
 	}()
 
-	fs.BoolVar(&c.EnableServer, "enable-server", c.EnableServer, "Enable the Kubelet's server")
+	// apply functions copy values from parsed flags to a config struct
+	as := []func(c *kubeletconfig.KubeletConfiguration){}
 
-	fs.BoolVar(&c.FailSwapOn, "fail-swap-on", c.FailSwapOn, "Makes the Kubelet fail to start if swap is enabled on the node. ")
-	fs.StringVar(&c.StaticPodPath, "pod-manifest-path", c.StaticPodPath, "Path to the directory containing static pod files to run, or the path to a single static pod file. Files starting with dots will be ignored.")
-	fs.DurationVar(&c.SyncFrequency.Duration, "sync-frequency", c.SyncFrequency.Duration, "Max period between synchronizing running containers and config")
-	fs.DurationVar(&c.FileCheckFrequency.Duration, "file-check-frequency", c.FileCheckFrequency.Duration, "Duration between checking config files for new data")
-	fs.DurationVar(&c.HTTPCheckFrequency.Duration, "http-check-frequency", c.HTTPCheckFrequency.Duration, "Duration between checking http for new data")
-	fs.StringVar(&c.StaticPodURL, "manifest-url", c.StaticPodURL, "URL for accessing additional Pod specifications to run")
-	fs.Var(cliflag.NewColonSeparatedMultimapStringString(&c.StaticPodURLHeader), "manifest-url-header", "Comma-separated list of HTTP headers to use when accessing the url provided to --manifest-url. Multiple headers with the same name will be added in the same order provided. This flag can be repeatedly invoked. For example: --manifest-url-header 'a:hello,b:again,c:world' --manifest-url-header 'b:beautiful'")
-	fs.Var(utilflag.IPVar{Val: &c.Address}, "address", "The IP address for the Kubelet to serve on (set to '0.0.0.0' for all IPv4 interfaces and '::' for all IPv6 interfaces)")
-	fs.Int32Var(&c.Port, "port", c.Port, "The port for the Kubelet to serve on.")
-	fs.Int32Var(&c.ReadOnlyPort, "read-only-port", c.ReadOnlyPort, "The read-only port for the Kubelet to serve on with no authentication/authorization (set to 0 to disable)")
+	// Register flags and make apply functions. Apply functions create closures
+	// around values returned from flag registrations (scratch space for parsing
+	// flags), and use predefined value methods to apply flags to configuration.
+	{
+		v := lfs.BoolVar("enable-server", help.EnableServer,
+			"Enable the Kubelet's server")
+		as = append(as, func(c *kubeletconfig.KubeletConfiguration) {
+			v.Set(&c.EnableServer)
+		})
+	}
+	{
+		v := lfs.BoolVar("fail-swap-on", help.FailSwapOn,
+			"Makes the Kubelet fail to start if swap is enabled on the node. ")
+		as = append(as, func(c *kubeletconfig.KubeletConfiguration) {
+			v.Set(&c.FailSwapOn)
+		})
+	}
+	{
+		v := lfs.StringVar("pod-manifest-path", help.StaticPodPath, ""+
+			"Path to the directory containing static pod files to run, or the "+
+			"path to a single static pod file. Files starting with dots will "+
+			"be ignored.")
+		as = append(as, func(c *kubeletconfig.KubeletConfiguration) {
+			v.Set(&c.StaticPodPath)
+		})
+	}
+	{
+		v := lfs.DurationVar("sync-frequency", help.SyncFrequency.Duration,
+			"Max period between synchronizing running containers and config")
+		as = append(as, func(c *kubeletconfig.KubeletConfiguration) {
+			v.Set(&c.SyncFrequency.Duration)
+		})
+	}
+	{
+		v := lfs.DurationVar("file-check-frequency", help.FileCheckFrequency.Duration,
+			"Duration between checking config files for new data")
+		as = append(as, func(c *kubeletconfig.KubeletConfiguration) {
+			v.Set(&c.FileCheckFrequency.Duration)
+		})
+	}
+	{
+		v := lfs.DurationVar("http-check-frequency", help.HTTPCheckFrequency.Duration,
+			"Duration between checking http for new data")
+		as = append(as, func(c *kubeletconfig.KubeletConfiguration) {
+			v.Set(&c.HTTPCheckFrequency.Duration)
+		})
+	}
+	{
+		v := lfs.StringVar("manifest-url", help.StaticPodURL,
+			"URL for accessing additional Pod specifications to run")
+		as = append(as, func(c *kubeletconfig.KubeletConfiguration) {
+			v.Set(&c.StaticPodURL)
+		})
+	}
+	{
+		// Copy any default into the scratch space, so it appears in help text
+		// when we register the flag, but allows us to avoid mutating the help
+		// KubeletConfiguration when flags are parsed.
+		val := cliflag.NewColonSeparatedMultimapStringString(
+			&help.StaticPodURLHeader).DeepCopy()
+		v := lfs.Var(val, "manifest-url-header", ""+
+			"Comma-separated list of HTTP headers to use when accessing the "+
+			"url provided to --manifest-url. Multiple headers with the same "+
+			"name will be added in the same order provided. This flag can be "+
+			"repeatedly invoked. For example: "+
+			"--manifest-url-header 'a:hello,b:again,c:world' --manifest-url-header 'b:beautiful'")
+		as = append(as, func(c *kubeletconfig.KubeletConfiguration) {
+			v.Apply(func() {
+				tmp := val.DeepCopy()
+				c.StaticPodURLHeader = *tmp.Multimap
+			})
+		})
+	}
+	{
+		// Strings are immutable in Go, we don't need to worry about deep copy.
+		val := utilflag.IPVar{Val: &help.Address}
+		v := lfs.Var(val, "address", ""+
+			"The IP address for the Kubelet to serve on (set to '0.0.0.0' for "+
+			"all IPv4 interfaces and '::' for all IPv6 interfaces)")
+		as = append(as, func(c *kubeletconfig.KubeletConfiguration) {
+			v.Apply(func() {
+				c.Address = *val.Val
+			})
+		})
+	}
+	{
+		v := lfs.Int32Var("port", help.Port, "The port for the Kubelet to serve on.")
+		as = append(as, func(c *kubeletconfig.KubeletConfiguration) {
+			v.Set(&c.Port)
+		})
+	}
+	{
+		v := lfs.Int32Var("read-only-port", help.ReadOnlyPort, ""+
+			"The read-only port for the Kubelet to serve on with no "+
+			"authentication/authorization (set to 0 to disable)")
+		as = append(as, func(c *kubeletconfig.KubeletConfiguration) {
+			v.Set(&c.ReadOnlyPort)
+		})
+	}
 
 	// Authentication
-	fs.BoolVar(&c.Authentication.Anonymous.Enabled, "anonymous-auth", c.Authentication.Anonymous.Enabled, ""+
-		"Enables anonymous requests to the Kubelet server. Requests that are not rejected by another "+
-		"authentication method are treated as anonymous requests. Anonymous requests have a username "+
-		"of system:anonymous, and a group name of system:unauthenticated.")
-	fs.BoolVar(&c.Authentication.Webhook.Enabled, "authentication-token-webhook", c.Authentication.Webhook.Enabled, ""+
-		"Use the TokenReview API to determine authentication for bearer tokens.")
-	fs.DurationVar(&c.Authentication.Webhook.CacheTTL.Duration, "authentication-token-webhook-cache-ttl", c.Authentication.Webhook.CacheTTL.Duration, ""+
-		"The duration to cache responses from the webhook token authenticator.")
-	fs.StringVar(&c.Authentication.X509.ClientCAFile, "client-ca-file", c.Authentication.X509.ClientCAFile, ""+
-		"If set, any request presenting a client certificate signed by one of the authorities in the client-ca-file "+
-		"is authenticated with an identity corresponding to the CommonName of the client certificate.")
+	{
+		v := lfs.BoolVar("anonymous-auth", help.Authentication.Anonymous.Enabled, ""+
+			"Enables anonymous requests to the Kubelet server. Requests "+
+			"that are not rejected by another authentication method are "+
+			"treated as anonymous requests. Anonymous requests have a "+
+			"username of system:anonymous, and a group name of "+
+			"system:unauthenticated.")
+		as = append(as, func(c *kubeletconfig.KubeletConfiguration) {
+			v.Set(&c.Authentication.Anonymous.Enabled)
+		})
+	}
+	{
+		v := lfs.BoolVar("authentication-token-webhook",
+			help.Authentication.Webhook.Enabled,
+			"Use the TokenReview API to determine authentication for bearer tokens.")
+		as = append(as, func(c *kubeletconfig.KubeletConfiguration) {
+			v.Set(&c.Authentication.Webhook.Enabled)
+		})
+	}
+	{
+		v := lfs.DurationVar("authentication-token-webhook-cache-ttl",
+			help.Authentication.Webhook.CacheTTL.Duration,
+			"The duration to cache responses from the webhook token authenticator.")
+		as = append(as, func(c *kubeletconfig.KubeletConfiguration) {
+			v.Set(&c.Authentication.Webhook.CacheTTL.Duration)
+		})
+	}
+	{
+		v := lfs.StringVar("client-ca-file",
+			help.Authentication.X509.ClientCAFile, ""+
+				"If set, any request presenting a client certificate signed by "+
+				"one of the authorities in the client-ca-file is authenticated "+
+				"with an identity corresponding to the CommonName of the client "+
+				"certificate.")
+		as = append(as, func(c *kubeletconfig.KubeletConfiguration) {
+			v.Set(&c.Authentication.X509.ClientCAFile)
+		})
+	}
 
 	// Authorization
-	fs.StringVar((*string)(&c.Authorization.Mode), "authorization-mode", string(c.Authorization.Mode), ""+
-		"Authorization mode for Kubelet server. Valid options are AlwaysAllow or Webhook. "+
-		"Webhook mode uses the SubjectAccessReview API to determine authorization.")
-	fs.DurationVar(&c.Authorization.Webhook.CacheAuthorizedTTL.Duration, "authorization-webhook-cache-authorized-ttl", c.Authorization.Webhook.CacheAuthorizedTTL.Duration, ""+
-		"The duration to cache 'authorized' responses from the webhook authorizer.")
-	fs.DurationVar(&c.Authorization.Webhook.CacheUnauthorizedTTL.Duration, "authorization-webhook-cache-unauthorized-ttl", c.Authorization.Webhook.CacheUnauthorizedTTL.Duration, ""+
-		"The duration to cache 'unauthorized' responses from the webhook authorizer.")
-
-	fs.StringVar(&c.TLSCertFile, "tls-cert-file", c.TLSCertFile, ""+
-		"File containing x509 Certificate used for serving HTTPS (with intermediate certs, if any, concatenated after server cert). "+
-		"If --tls-cert-file and --tls-private-key-file are not provided, a self-signed certificate and key "+
-		"are generated for the public address and saved to the directory passed to --cert-dir.")
-	fs.StringVar(&c.TLSPrivateKeyFile, "tls-private-key-file", c.TLSPrivateKeyFile, "File containing x509 private key matching --tls-cert-file.")
-	fs.BoolVar(&c.ServerTLSBootstrap, "rotate-server-certificates", c.ServerTLSBootstrap, "Auto-request and rotate the kubelet serving certificates by requesting new certificates from the kube-apiserver when the certificate expiration approaches. Requires the RotateKubeletServerCertificate feature gate to be enabled, and approval of the submitted CertificateSigningRequest objects.")
-
-	tlsCipherPreferredValues := cliflag.PreferredTLSCipherNames()
-	tlsCipherInsecureValues := cliflag.InsecureTLSCipherNames()
-	fs.StringSliceVar(&c.TLSCipherSuites, "tls-cipher-suites", c.TLSCipherSuites,
-		"Comma-separated list of cipher suites for the server. "+
+	{
+		v := lfs.StringVar("authorization-mode", string(help.Authorization.Mode), ""+
+			"Authorization mode for Kubelet server. Valid options are "+
+			"AlwaysAllow or Webhook. Webhook mode uses the SubjectAccessReview "+
+			"API to determine authorization.")
+		as = append(as, func(c *kubeletconfig.KubeletConfiguration) {
+			v.Set((*string)(&c.Authorization.Mode))
+		})
+	}
+	{
+		v := lfs.DurationVar("authorization-webhook-cache-authorized-ttl",
+			help.Authorization.Webhook.CacheAuthorizedTTL.Duration,
+			"The duration to cache 'authorized' responses from the webhook authorizer.")
+		as = append(as, func(c *kubeletconfig.KubeletConfiguration) {
+			v.Set(&c.Authorization.Webhook.CacheAuthorizedTTL.Duration)
+		})
+	}
+	{
+		v := lfs.DurationVar("authorization-webhook-cache-unauthorized-ttl",
+			help.Authorization.Webhook.CacheUnauthorizedTTL.Duration,
+			"The duration to cache 'unauthorized' responses from the webhook authorizer.")
+		as = append(as, func(c *kubeletconfig.KubeletConfiguration) {
+			v.Set(&c.Authorization.Webhook.CacheUnauthorizedTTL.Duration)
+		})
+	}
+	{
+		v := lfs.StringVar("tls-cert-file", help.TLSCertFile, ""+
+			"File containing x509 Certificate used for serving HTTPS (with "+
+			"intermediate certs, if any, concatenated after server cert). "+
+			"If --tls-cert-file and --tls-private-key-file are not provided, "+
+			"a self-signed certificate and key are generated for the public "+
+			"address and saved to the directory passed to --cert-dir.")
+		as = append(as, func(c *kubeletconfig.KubeletConfiguration) {
+			v.Set(&c.TLSCertFile)
+		})
+	}
+	{
+		v := lfs.StringVar("tls-private-key-file", help.TLSPrivateKeyFile,
+			"File containing x509 private key matching --tls-cert-file.")
+		as = append(as, func(c *kubeletconfig.KubeletConfiguration) {
+			v.Set(&c.TLSPrivateKeyFile)
+		})
+	}
+	{
+		v := lfs.BoolVar("rotate-server-certificates", help.ServerTLSBootstrap, ""+
+			"Auto-request and rotate the kubelet serving certificates by "+
+			"requesting new certificates from the kube-apiserver when the "+
+			"certificate expiration approaches. Requires the "+
+			"RotateKubeletServerCertificate feature gate to be enabled, and "+
+			"approval of the submitted CertificateSigningRequest objects.")
+		as = append(as, func(c *kubeletconfig.KubeletConfiguration) {
+			v.Set(&c.ServerTLSBootstrap)
+		})
+	}
+	{
+		tlsCipherPreferredValues := cliflag.PreferredTLSCipherNames()
+		tlsCipherInsecureValues := cliflag.InsecureTLSCipherNames()
+		v := lfs.StringSliceVar("tls-cipher-suites", help.TLSCipherSuites, ""+
+			"Comma-separated list of cipher suites for the server. "+
 			"If omitted, the default Go cipher suites will be used. \n"+
 			"Preferred values: "+strings.Join(tlsCipherPreferredValues, ", ")+". \n"+
 			"Insecure values: "+strings.Join(tlsCipherInsecureValues, ", ")+".")
-	tlsPossibleVersions := cliflag.TLSPossibleVersions()
-	fs.StringVar(&c.TLSMinVersion, "tls-min-version", c.TLSMinVersion,
-		"Minimum TLS version supported. "+
+		as = append(as, func(c *kubeletconfig.KubeletConfiguration) {
+			v.Set(&c.TLSCipherSuites)
+		})
+	}
+	{
+		tlsPossibleVersions := cliflag.TLSPossibleVersions()
+		v := lfs.StringVar("tls-min-version", help.TLSMinVersion, ""+
+			"Minimum TLS version supported. "+
 			"Possible values: "+strings.Join(tlsPossibleVersions, ", "))
-	fs.BoolVar(&c.RotateCertificates, "rotate-certificates", c.RotateCertificates, "<Warning: Beta feature> Auto rotate the kubelet client certificates by requesting new certificates from the kube-apiserver when the certificate expiration approaches.")
+		as = append(as, func(c *kubeletconfig.KubeletConfiguration) {
+			v.Set(&c.TLSMinVersion)
+		})
+	}
+	{
+		v := lfs.BoolVar("rotate-certificates", help.RotateCertificates, ""+
+			"<Warning: Beta feature> Auto rotate the kubelet client "+
+			"certificates by requesting new certificates from the "+
+			"kube-apiserver when the certificate expiration approaches.")
+		as = append(as, func(c *kubeletconfig.KubeletConfiguration) {
+			v.Set(&c.RotateCertificates)
+		})
+	}
+	{
+		v := lfs.Int32Var("registry-qps", help.RegistryPullQPS,
+			"If > 0, limit registry pull QPS to this value.  If 0, unlimited.")
+		as = append(as, func(c *kubeletconfig.KubeletConfiguration) {
+			v.Set(&c.RegistryPullQPS)
+		})
+	}
+	{
+		v := lfs.Int32Var("registry-burst", help.RegistryBurst, ""+
+			"Maximum size of a bursty pulls, temporarily allows pulls to "+
+			"burst to this number, while still not exceeding registry-qps. "+
+			"Only used if --registry-qps > 0")
+		as = append(as, func(c *kubeletconfig.KubeletConfiguration) {
+			v.Set(&c.RegistryBurst)
+		})
+	}
+	{
+		v := lfs.Int32Var("event-qps", help.EventRecordQPS,
+			"If > 0, limit event creations per second to this value. If 0, unlimited.")
+		as = append(as, func(c *kubeletconfig.KubeletConfiguration) {
+			v.Set(&c.EventRecordQPS)
+		})
+	}
+	{
+		v := lfs.Int32Var("event-burst", help.EventBurst, ""+
+			"Maximum size of a bursty event records, temporarily allows "+
+			"event records to burst to this number, while still not exceeding "+
+			"event-qps. Only used if --event-qps > 0")
+		as = append(as, func(c *kubeletconfig.KubeletConfiguration) {
+			v.Set(&c.EventBurst)
+		})
+	}
 
-	fs.Int32Var(&c.RegistryPullQPS, "registry-qps", c.RegistryPullQPS, "If > 0, limit registry pull QPS to this value.  If 0, unlimited.")
-	fs.Int32Var(&c.RegistryBurst, "registry-burst", c.RegistryBurst, "Maximum size of a bursty pulls, temporarily allows pulls to burst to this number, while still not exceeding registry-qps. Only used if --registry-qps > 0")
-	fs.Int32Var(&c.EventRecordQPS, "event-qps", c.EventRecordQPS, "If > 0, limit event creations per second to this value. If 0, unlimited.")
-	fs.Int32Var(&c.EventBurst, "event-burst", c.EventBurst, "Maximum size of a bursty event records, temporarily allows event records to burst to this number, while still not exceeding event-qps. Only used if --event-qps > 0")
+	{
+		v := lfs.BoolVar("enable-debugging-handlers", help.EnableDebuggingHandlers, ""+
+			"Enables server endpoints for log collection and local running of "+
+			"containers and commands")
+		as = append(as, func(c *kubeletconfig.KubeletConfiguration) {
+			v.Set(&c.EnableDebuggingHandlers)
+		})
+	}
+	{
+		v := lfs.BoolVar("contention-profiling", help.EnableContentionProfiling,
+			"Enable lock contention profiling, if profiling is enabled")
+		as = append(as, func(c *kubeletconfig.KubeletConfiguration) {
+			v.Set(&c.EnableContentionProfiling)
+		})
+	}
+	{
+		v := lfs.Int32Var("healthz-port", help.HealthzPort,
+			"The port of the localhost healthz endpoint (set to 0 to disable)")
+		as = append(as, func(c *kubeletconfig.KubeletConfiguration) {
+			v.Set(&c.HealthzPort)
+		})
+	}
+	{
+		// Strings are immutable in Go, we don't need to worry about deep copy.
+		val := utilflag.IPVar{Val: &help.HealthzBindAddress}
+		v := lfs.Var(val, "healthz-bind-address", ""+
+			"The IP address for the healthz server to serve on (set to '0.0.0.0' "+
+			"for all IPv4 interfaces and '::' for all IPv6 interfaces)")
+		as = append(as, func(c *kubeletconfig.KubeletConfiguration) {
+			v.Apply(func() {
+				c.HealthzBindAddress = *val.Val
+			})
+		})
+	}
+	{
+		v := lfs.Int32Var("oom-score-adj", help.OOMScoreAdj, ""+
+			"The oom-score-adj value for kubelet process. Values must be within "+
+			"the range [-1000, 1000]")
+		as = append(as, func(c *kubeletconfig.KubeletConfiguration) {
+			v.Set(&c.OOMScoreAdj)
+		})
+	}
+	{
+		v := lfs.StringVar("cluster-domain", help.ClusterDomain, ""+
+			"Domain for this cluster.  If set, kubelet will configure all "+
+			"containers to search this domain in addition to the host's search "+
+			"domains")
+		as = append(as, func(c *kubeletconfig.KubeletConfiguration) {
+			v.Set(&c.ClusterDomain)
+		})
+	}
+	{
+		v := lfs.StringVar("volume-plugin-dir", help.VolumePluginDir, ""+
+			"The full path of the directory in which to search for additional "+
+			"third party volume plugins")
+		as = append(as, func(c *kubeletconfig.KubeletConfiguration) {
+			v.Set(&c.VolumePluginDir)
+		})
+	}
+	{
+		v := lfs.StringSliceVar("cluster-dns", help.ClusterDNS, ""+
+			"Comma-separated list of DNS server IP address.  This value is "+
+			"used for containers DNS server in case of Pods with "+
+			"\"dnsPolicy=ClusterFirst\". Note: all DNS servers appearing in "+
+			"the list MUST serve the same set of records otherwise name "+
+			"resolution within the cluster may not work correctly. There is "+
+			"no guarantee as to which DNS server may be contacted for name "+
+			"resolution.")
+		as = append(as, func(c *kubeletconfig.KubeletConfiguration) {
+			v.Set(&c.ClusterDNS)
+		})
+	}
+	{
+		v := lfs.DurationVar("streaming-connection-idle-timeout",
+			help.StreamingConnectionIdleTimeout.Duration, ""+
+				"Maximum time a streaming connection can be idle before the "+
+				"connection is automatically closed. 0 indicates no timeout. "+
+				"Example: '5m'")
+		as = append(as, func(c *kubeletconfig.KubeletConfiguration) {
+			v.Set(&c.StreamingConnectionIdleTimeout.Duration)
+		})
+	}
+	{
+		v := lfs.DurationVar("node-status-update-frequency", help.NodeStatusUpdateFrequency.Duration, ""+
+			"Specifies how often kubelet posts node status to master. "+
+			"Note: be cautious when changing the constant, it must work "+
+			"with nodeMonitorGracePeriod in nodecontroller.")
+		as = append(as, func(c *kubeletconfig.KubeletConfiguration) {
+			v.Set(&c.NodeStatusUpdateFrequency.Duration)
+		})
+	}
+	{
+		v := lfs.DurationVar("minimum-image-ttl-duration", help.ImageMinimumGCAge.Duration, ""+
+			"Minimum age for an unused image before it is garbage collected. "+
+			"Examples: '300ms', '10s' or '2h45m'.")
+		as = append(as, func(c *kubeletconfig.KubeletConfiguration) {
+			v.Set(&c.ImageMinimumGCAge.Duration)
+		})
+	}
+	{
+		v := lfs.Int32Var("image-gc-high-threshold", help.ImageGCHighThresholdPercent, ""+
+			"The percent of disk usage after which image garbage collection "+
+			"is always run. Values must be within the range [0, 100], To "+
+			"disable image garbage collection, set to 100. ")
+		as = append(as, func(c *kubeletconfig.KubeletConfiguration) {
+			v.Set(&c.ImageGCHighThresholdPercent)
+		})
+	}
+	{
+		v := lfs.Int32Var("image-gc-low-threshold", help.ImageGCLowThresholdPercent, ""+
+			"The percent of disk usage before which image garbage collection "+
+			"is never run. Lowest disk usage to garbage collect to. Values "+
+			"must be within the range [0, 100] and should not be larger than "+
+			"that of --image-gc-high-threshold.")
+		as = append(as, func(c *kubeletconfig.KubeletConfiguration) {
+			v.Set(&c.ImageGCLowThresholdPercent)
+		})
+	}
+	{
+		v := lfs.DurationVar("volume-stats-agg-period", help.VolumeStatsAggPeriod.Duration, ""+
+			"Specifies interval for kubelet to calculate and cache the "+
+			"volume disk usage for all pods and volumes.  To disable volume "+
+			"calculations, set to 0.")
+		as = append(as, func(c *kubeletconfig.KubeletConfiguration) {
+			v.Set(&c.VolumeStatsAggPeriod.Duration)
+		})
+	}
 
-	fs.BoolVar(&c.EnableDebuggingHandlers, "enable-debugging-handlers", c.EnableDebuggingHandlers, "Enables server endpoints for log collection and local running of containers and commands")
-	fs.BoolVar(&c.EnableContentionProfiling, "contention-profiling", c.EnableContentionProfiling, "Enable lock contention profiling, if profiling is enabled")
-	fs.Int32Var(&c.HealthzPort, "healthz-port", c.HealthzPort, "The port of the localhost healthz endpoint (set to 0 to disable)")
-	fs.Var(utilflag.IPVar{Val: &c.HealthzBindAddress}, "healthz-bind-address", "The IP address for the healthz server to serve on (set to '0.0.0.0' for all IPv4 interfaces and '::' for all IPv6 interfaces)")
-	fs.Int32Var(&c.OOMScoreAdj, "oom-score-adj", c.OOMScoreAdj, "The oom-score-adj value for kubelet process. Values must be within the range [-1000, 1000]")
-	fs.StringVar(&c.ClusterDomain, "cluster-domain", c.ClusterDomain, "Domain for this cluster.  If set, kubelet will configure all containers to search this domain in addition to the host's search domains")
+	{
+		// TODO(mtaufen): When I wrote legacyflag, I based MapStringBool on cliflag's
+		// version, double-check that the implementations are still compatible.
+		// TODO(mtaufen): Consider updating legacyflag so MapOptions comes before
+		// the help text, perhaps even make it the first argument (since our
+		// conventional order is roughly "conctruct pflag.Var implementation",
+		// then "name", "default", "help text").
+		v := lfs.MapStringBoolVar("feature-gates", help.FeatureGates, ""+
+			"A set of key=value pairs that enable or disable gated features. "+
+			"Options are:\n"+
+			strings.Join(utilfeature.DefaultFeatureGate.KnownFeatures(), "\n"),
+			&legacyflag.MapOptions{})
+		as = append(as, func(c *kubeletconfig.KubeletConfiguration) {
+			// Merge piecewise copies values that were set via the flag over
+			// the target FeatureGates. This is required for feature gates,
+			// where each gate can be independently set via flags or config
+			// files.
+			v.Merge(&c.FeatureGates)
+		})
+	}
+	{
+		v := lfs.StringVar("kubelet-cgroups", help.KubeletCgroups,
+			"Optional absolute name of cgroups to create and run the Kubelet in.")
+		as = append(as, func(c *kubeletconfig.KubeletConfiguration) {
+			v.Set(&c.KubeletCgroups)
+		})
+	}
+	{
+		v := lfs.StringVar("system-cgroups", help.SystemCgroups, ""+
+			"Optional absolute name of cgroups in which to place all "+
+			"non-kernel processes that are not already inside a cgroup "+
+			"under '/'. Empty for no container. Rolling back the flag "+
+			"requires a reboot.")
+		as = append(as, func(c *kubeletconfig.KubeletConfiguration) {
+			v.Set(&c.SystemCgroups)
+		})
+	}
+	{
+		v := lfs.StringVar("provider-id", help.ProviderID, ""+
+			"Unique identifier for identifying the node in a machine database, "+
+			"i.e cloudprovider")
+		as = append(as, func(c *kubeletconfig.KubeletConfiguration) {
+			v.Set(&c.ProviderID)
+		})
+	}
+	{
+		v := lfs.BoolVar("cgroups-per-qos", help.CgroupsPerQOS, ""+
+			"Enable creation of QoS cgroup hierarchy, if true top level QoS "+
+			"and pod cgroups are created.")
+		as = append(as, func(c *kubeletconfig.KubeletConfiguration) {
+			v.Set(&c.CgroupsPerQOS)
+		})
+	}
+	{
+		v := lfs.StringVar("cgroup-driver", help.CgroupDriver, ""+
+			"Driver that the kubelet uses to manipulate cgroups on the host. "+
+			"Possible values: 'cgroupfs', 'systemd'")
+		as = append(as, func(c *kubeletconfig.KubeletConfiguration) {
+			v.Set(&c.CgroupDriver)
+		})
+	}
+	{
+		v := lfs.StringVar("cgroup-root", help.CgroupRoot, ""+
+			"Optional root cgroup to use for pods. This is handled by the "+
+			"container runtime on a best effort basis. Default: '', which "+
+			"means use the container runtime default.")
+		as = append(as, func(c *kubeletconfig.KubeletConfiguration) {
+			v.Set(&c.CgroupRoot)
+		})
+	}
+	{
+		v := lfs.StringVar("cpu-manager-policy", help.CPUManagerPolicy, ""+
+			"CPU Manager policy to use. Possible values: 'none', 'static'. "+
+			"Default: 'none'")
+		as = append(as, func(c *kubeletconfig.KubeletConfiguration) {
+			v.Set(&c.CPUManagerPolicy)
+		})
+	}
+	{
+		v := lfs.DurationVar("cpu-manager-reconcile-period",
+			help.CPUManagerReconcilePeriod.Duration, ""+
+				"<Warning: Alpha feature> CPU Manager reconciliation period. "+
+				"Examples: '10s', or '1m'. If not supplied, defaults to "+
+				"'NodeStatusUpdateFrequency'")
+		as = append(as, func(c *kubeletconfig.KubeletConfiguration) {
+			v.Set(&c.CPUManagerReconcilePeriod.Duration)
+		})
+	}
+	{
+		v := lfs.MapStringStringVar("qos-reserved", help.QOSReserved, ""+
+			"<Warning: Alpha feature> A set of ResourceName=Percentage "+
+			"(e.g. memory=50%) pairs that describe how pod resource requests "+
+			"are reserved at the QoS level. Currently only memory is supported. "+
+			"Requires the QOSReserved feature gate to be enabled.",
+			&legacyflag.MapOptions{})
+		as = append(as, func(c *kubeletconfig.KubeletConfiguration) {
+			v.Set(&c.QOSReserved)
+		})
+	}
+	{
+		v := lfs.StringVar("topology-manager-policy", help.TopologyManagerPolicy, ""+
+			"Topology Manager policy to use. Possible values: "+
+			"'none', 'best-effort', 'restricted', 'single-numa-node'.")
+		as = append(as, func(c *kubeletconfig.KubeletConfiguration) {
+			v.Set(&c.TopologyManagerPolicy)
+		})
+	}
+	{
+		v := lfs.DurationVar("runtime-request-timeout",
+			help.RuntimeRequestTimeout.Duration, ""+
+				"Timeout of all runtime requests except long running requests: "+
+				"pull, logs, exec and attach. When timeout exceeded, kubelet "+
+				"will cancel the request, throw out an error and retry later.")
+		as = append(as, func(c *kubeletconfig.KubeletConfiguration) {
+			v.Set(&c.RuntimeRequestTimeout.Duration)
+		})
+	}
+	{
+		v := lfs.StringVar("hairpin-mode", help.HairpinMode, ""+
+			"How should the kubelet setup hairpin NAT. This allows endpoints "+
+			"of a Service to loadbalance back to themselves if they should try "+
+			"to access their own Service. Valid values are: "+
+			"\"promiscuous-bridge\", \"hairpin-veth\" and \"none\".")
+		as = append(as, func(c *kubeletconfig.KubeletConfiguration) {
+			v.Set(&c.HairpinMode)
+		})
+	}
+	{
+		v := lfs.Int32Var("max-pods", help.MaxPods,
+			"Number of Pods that can run on this Kubelet.")
+		as = append(as, func(c *kubeletconfig.KubeletConfiguration) {
+			v.Set(&c.MaxPods)
+		})
+	}
+	{
+		v := lfs.StringVar("pod-cidr", help.PodCIDR, ""+
+			"The CIDR to use for pod IP addresses, only used in standalone mode. "+
+			"In cluster mode, this is obtained from the master. For IPv6, the "+
+			"maximum number of IP's allocated is 65536.")
+		as = append(as, func(c *kubeletconfig.KubeletConfiguration) {
+			v.Set(&c.PodCIDR)
+		})
+	}
+	{
+		v := lfs.Int64Var("pod-max-pids", help.PodPidsLimit, ""+
+			"Set the maximum number of processes per pod.  If -1, the kubelet "+
+			"defaults to the node allocatable pid capacity.")
+		as = append(as, func(c *kubeletconfig.KubeletConfiguration) {
+			v.Set(&c.PodPidsLimit)
+		})
+	}
+	{
+		v := lfs.StringVar("resolv-conf", help.ResolverConfig, ""+
+			"Resolver configuration file used as the basis for the container "+
+			"DNS resolution configuration.")
+		as = append(as, func(c *kubeletconfig.KubeletConfiguration) {
+			v.Set(&c.ResolverConfig)
+		})
+	}
+	{
+		v := lfs.BoolVar("runonce", help.RunOnce, ""+
+			"If true, exit after spawning pods from static pod files or remote "+
+			"urls. Exclusive with --enable-server.")
+		as = append(as, func(c *kubeletconfig.KubeletConfiguration) {
+			v.Set(&c.RunOnce)
+		})
+	}
+	{
+		v := lfs.BoolVar("cpu-cfs-quota", help.CPUCFSQuota, ""+
+			"Enable CPU CFS quota enforcement for containers that specify "+
+			"CPU limits.")
+		as = append(as, func(c *kubeletconfig.KubeletConfiguration) {
+			v.Set(&c.CPUCFSQuota)
+		})
+	}
+	{
+		v := lfs.DurationVar("cpu-cfs-quota-period", help.CPUCFSQuotaPeriod.Duration, ""+
+			"Sets CPU CFS quota period value, cpu.cfs_period_us, defaults "+
+			"to Linux Kernel default")
+		as = append(as, func(c *kubeletconfig.KubeletConfiguration) {
+			v.Set(&c.CPUCFSQuotaPeriod.Duration)
+		})
+	}
+	{
+		v := lfs.BoolVar("enable-controller-attach-detach", help.EnableControllerAttachDetach, ""+
+			"Enables the Attach/Detach controller to manage attachment/"+
+			"detachment of volumes scheduled to this node, and disables "+
+			"kubelet from executing any attach/detach operations")
+		as = append(as, func(c *kubeletconfig.KubeletConfiguration) {
+			v.Set(&c.EnableControllerAttachDetach)
+		})
+	}
+	{
+		v := lfs.BoolVar("make-iptables-util-chains", help.MakeIPTablesUtilChains, ""+
+			"If true, kubelet will ensure iptables utility rules are present "+
+			"on host.")
+		as = append(as, func(c *kubeletconfig.KubeletConfiguration) {
+			v.Set(&c.MakeIPTablesUtilChains)
+		})
+	}
+	{
+		v := lfs.Int32Var("iptables-masquerade-bit", help.IPTablesMasqueradeBit, ""+
+			"The bit of the fwmark space to mark packets for SNAT. Must be "+
+			"within the range [0, 31]. Please match this parameter with "+
+			"corresponding parameter in kube-proxy.")
+		as = append(as, func(c *kubeletconfig.KubeletConfiguration) {
+			v.Set(&c.IPTablesMasqueradeBit)
+		})
+	}
+	{
+		v := lfs.Int32Var("iptables-drop-bit", help.IPTablesDropBit, ""+
+			"The bit of the fwmark space to mark packets for dropping. "+
+			"Must be within the range [0, 31].")
+		as = append(as, func(c *kubeletconfig.KubeletConfiguration) {
+			v.Set(&c.IPTablesDropBit)
+		})
+	}
+	{
+		v := lfs.StringVar("container-log-max-size", help.ContainerLogMaxSize, ""+
+			"<Warning: Beta feature> Set the maximum size (e.g. 10Mi) of "+
+			"container log file before it is rotated. This flag can only be "+
+			"used with --container-runtime=remote.")
+		as = append(as, func(c *kubeletconfig.KubeletConfiguration) {
+			v.Set(&c.ContainerLogMaxSize)
+		})
+	}
+	{
+		v := lfs.Int32Var("container-log-max-files", help.ContainerLogMaxFiles, ""+
+			"<Warning: Beta feature> Set the maximum number of container log "+
+			"files that can be present for a container. The number must be >= 2. "+
+			"This flag can only be used with --container-runtime=remote.")
+		as = append(as, func(c *kubeletconfig.KubeletConfiguration) {
+			v.Set(&c.ContainerLogMaxFiles)
+		})
+	}
+	{
+		v := lfs.StringSliceVar("allowed-unsafe-sysctls", help.AllowedUnsafeSysctls, ""+
+			"Comma-separated whitelist of unsafe sysctls or unsafe sysctl "+
+			"patterns (ending in *). Use these at your own risk.")
+		as = append(as, func(c *kubeletconfig.KubeletConfiguration) {
+			v.Set(&c.AllowedUnsafeSysctls)
+		})
+	}
+	{
+		v := lfs.Int32Var("node-status-max-images", help.NodeStatusMaxImages, ""+
+			"The maximum number of images to report in Node.Status.Images. "+
+			"If -1 is specified, no cap will be applied.")
+		as = append(as, func(c *kubeletconfig.KubeletConfiguration) {
+			v.Set(&c.NodeStatusMaxImages)
+		})
+	}
+	{
+		v := lfs.BoolVar("kernel-memcg-notification", help.KernelMemcgNotification, ""+
+			"If enabled, the kubelet will integrate with the kernel memcg "+
+			"notification to determine if memory eviction thresholds are "+
+			"crossed rather than polling.")
+		as = append(as, func(c *kubeletconfig.KubeletConfiguration) {
+			v.Set(&c.KernelMemcgNotification)
+		})
+	}
 
-	fs.StringVar(&c.VolumePluginDir, "volume-plugin-dir", c.VolumePluginDir, "The full path of the directory in which to search for additional third party volume plugins")
-	fs.StringSliceVar(&c.ClusterDNS, "cluster-dns", c.ClusterDNS, "Comma-separated list of DNS server IP address.  This value is used for containers DNS server in case of Pods with \"dnsPolicy=ClusterFirst\". Note: all DNS servers appearing in the list MUST serve the same set of records otherwise name resolution within the cluster may not work correctly. There is no guarantee as to which DNS server may be contacted for name resolution.")
-	fs.DurationVar(&c.StreamingConnectionIdleTimeout.Duration, "streaming-connection-idle-timeout", c.StreamingConnectionIdleTimeout.Duration, "Maximum time a streaming connection can be idle before the connection is automatically closed. 0 indicates no timeout. Example: '5m'")
-	fs.DurationVar(&c.NodeStatusUpdateFrequency.Duration, "node-status-update-frequency", c.NodeStatusUpdateFrequency.Duration, "Specifies how often kubelet posts node status to master. Note: be cautious when changing the constant, it must work with nodeMonitorGracePeriod in nodecontroller.")
-	fs.DurationVar(&c.ImageMinimumGCAge.Duration, "minimum-image-ttl-duration", c.ImageMinimumGCAge.Duration, "Minimum age for an unused image before it is garbage collected.  Examples: '300ms', '10s' or '2h45m'.")
-	fs.Int32Var(&c.ImageGCHighThresholdPercent, "image-gc-high-threshold", c.ImageGCHighThresholdPercent, "The percent of disk usage after which image garbage collection is always run. Values must be within the range [0, 100], To disable image garbage collection, set to 100. ")
-	fs.Int32Var(&c.ImageGCLowThresholdPercent, "image-gc-low-threshold", c.ImageGCLowThresholdPercent, "The percent of disk usage before which image garbage collection is never run. Lowest disk usage to garbage collect to. Values must be within the range [0, 100] and should not be larger than that of --image-gc-high-threshold.")
-	fs.DurationVar(&c.VolumeStatsAggPeriod.Duration, "volume-stats-agg-period", c.VolumeStatsAggPeriod.Duration, "Specifies interval for kubelet to calculate and cache the volume disk usage for all pods and volumes.  To disable volume calculations, set to 0.")
-	fs.Var(cliflag.NewMapStringBool(&c.FeatureGates), "feature-gates", "A set of key=value pairs that describe feature gates for alpha/experimental features. "+
-		"Options are:\n"+strings.Join(utilfeature.DefaultFeatureGate.KnownFeatures(), "\n"))
-	fs.StringVar(&c.KubeletCgroups, "kubelet-cgroups", c.KubeletCgroups, "Optional absolute name of cgroups to create and run the Kubelet in.")
-	fs.StringVar(&c.SystemCgroups, "system-cgroups", c.SystemCgroups, "Optional absolute name of cgroups in which to place all non-kernel processes that are not already inside a cgroup under '/'. Empty for no container. Rolling back the flag requires a reboot.")
-
-	fs.StringVar(&c.ProviderID, "provider-id", c.ProviderID, "Unique identifier for identifying the node in a machine database, i.e cloudprovider")
-
-	fs.BoolVar(&c.CgroupsPerQOS, "cgroups-per-qos", c.CgroupsPerQOS, "Enable creation of QoS cgroup hierarchy, if true top level QoS and pod cgroups are created.")
-	fs.StringVar(&c.CgroupDriver, "cgroup-driver", c.CgroupDriver, "Driver that the kubelet uses to manipulate cgroups on the host.  Possible values: 'cgroupfs', 'systemd'")
-	fs.StringVar(&c.CgroupRoot, "cgroup-root", c.CgroupRoot, "Optional root cgroup to use for pods. This is handled by the container runtime on a best effort basis. Default: '', which means use the container runtime default.")
-	fs.StringVar(&c.CPUManagerPolicy, "cpu-manager-policy", c.CPUManagerPolicy, "CPU Manager policy to use. Possible values: 'none', 'static'. Default: 'none'")
-	fs.DurationVar(&c.CPUManagerReconcilePeriod.Duration, "cpu-manager-reconcile-period", c.CPUManagerReconcilePeriod.Duration, "<Warning: Alpha feature> CPU Manager reconciliation period. Examples: '10s', or '1m'. If not supplied, defaults to 'NodeStatusUpdateFrequency'")
-	fs.Var(cliflag.NewMapStringString(&c.QOSReserved), "qos-reserved", "<Warning: Alpha feature> A set of ResourceName=Percentage (e.g. memory=50%) pairs that describe how pod resource requests are reserved at the QoS level. Currently only memory is supported. Requires the QOSReserved feature gate to be enabled.")
-	fs.StringVar(&c.TopologyManagerPolicy, "topology-manager-policy", c.TopologyManagerPolicy, "Topology Manager policy to use. Possible values: 'none', 'best-effort', 'restricted', 'single-numa-node'.")
-	fs.DurationVar(&c.RuntimeRequestTimeout.Duration, "runtime-request-timeout", c.RuntimeRequestTimeout.Duration, "Timeout of all runtime requests except long running request - pull, logs, exec and attach. When timeout exceeded, kubelet will cancel the request, throw out an error and retry later.")
-	fs.StringVar(&c.HairpinMode, "hairpin-mode", c.HairpinMode, "How should the kubelet setup hairpin NAT. This allows endpoints of a Service to loadbalance back to themselves if they should try to access their own Service. Valid values are \"promiscuous-bridge\", \"hairpin-veth\" and \"none\".")
-	fs.Int32Var(&c.MaxPods, "max-pods", c.MaxPods, "Number of Pods that can run on this Kubelet.")
-
-	fs.StringVar(&c.PodCIDR, "pod-cidr", c.PodCIDR, "The CIDR to use for pod IP addresses, only used in standalone mode.  In cluster mode, this is obtained from the master. For IPv6, the maximum number of IP's allocated is 65536")
-	fs.Int64Var(&c.PodPidsLimit, "pod-max-pids", c.PodPidsLimit, "Set the maximum number of processes per pod.  If -1, the kubelet defaults to the node allocatable pid capacity.")
-
-	fs.StringVar(&c.ResolverConfig, "resolv-conf", c.ResolverConfig, "Resolver configuration file used as the basis for the container DNS resolution configuration.")
-
-	fs.BoolVar(&c.RunOnce, "runonce", c.RunOnce, "If true, exit after spawning pods from static pod files or remote urls. Exclusive with --enable-server")
-
-	fs.BoolVar(&c.CPUCFSQuota, "cpu-cfs-quota", c.CPUCFSQuota, "Enable CPU CFS quota enforcement for containers that specify CPU limits")
-	fs.DurationVar(&c.CPUCFSQuotaPeriod.Duration, "cpu-cfs-quota-period", c.CPUCFSQuotaPeriod.Duration, "Sets CPU CFS quota period value, cpu.cfs_period_us, defaults to Linux Kernel default")
-	fs.BoolVar(&c.EnableControllerAttachDetach, "enable-controller-attach-detach", c.EnableControllerAttachDetach, "Enables the Attach/Detach controller to manage attachment/detachment of volumes scheduled to this node, and disables kubelet from executing any attach/detach operations")
-	fs.BoolVar(&c.MakeIPTablesUtilChains, "make-iptables-util-chains", c.MakeIPTablesUtilChains, "If true, kubelet will ensure iptables utility rules are present on host.")
-	fs.Int32Var(&c.IPTablesMasqueradeBit, "iptables-masquerade-bit", c.IPTablesMasqueradeBit, "The bit of the fwmark space to mark packets for SNAT. Must be within the range [0, 31]. Please match this parameter with corresponding parameter in kube-proxy.")
-	fs.Int32Var(&c.IPTablesDropBit, "iptables-drop-bit", c.IPTablesDropBit, "The bit of the fwmark space to mark packets for dropping. Must be within the range [0, 31].")
-	fs.StringVar(&c.ContainerLogMaxSize, "container-log-max-size", c.ContainerLogMaxSize, "<Warning: Beta feature> Set the maximum size (e.g. 10Mi) of container log file before it is rotated. This flag can only be used with --container-runtime=remote.")
-	fs.Int32Var(&c.ContainerLogMaxFiles, "container-log-max-files", c.ContainerLogMaxFiles, "<Warning: Beta feature> Set the maximum number of container log files that can be present for a container. The number must be >= 2. This flag can only be used with --container-runtime=remote.")
-	fs.StringSliceVar(&c.AllowedUnsafeSysctls, "allowed-unsafe-sysctls", c.AllowedUnsafeSysctls, "Comma-separated whitelist of unsafe sysctls or unsafe sysctl patterns (ending in *). Use these at your own risk.")
-
-	fs.Int32Var(&c.NodeStatusMaxImages, "node-status-max-images", c.NodeStatusMaxImages, "The maximum number of images to report in Node.Status.Images. If -1 is specified, no cap will be applied.")
-	fs.BoolVar(&c.KernelMemcgNotification, "kernel-memcg-notification", c.KernelMemcgNotification, "If enabled, the kubelet will integrate with the kernel memcg notification to determine if memory eviction thresholds are crossed rather than polling.")
-
-	// Flags intended for testing, not recommended used in production environments.
-	fs.Int64Var(&c.MaxOpenFiles, "max-open-files", c.MaxOpenFiles, "Number of files that can be opened by Kubelet process.")
-
-	fs.StringVar(&c.ContentType, "kube-api-content-type", c.ContentType, "Content type of requests sent to apiserver.")
-	fs.Int32Var(&c.KubeAPIQPS, "kube-api-qps", c.KubeAPIQPS, "QPS to use while talking with kubernetes apiserver. Doesn't cover events and node heartbeat apis which rate limiting is controlled by a different set of flags")
-	fs.Int32Var(&c.KubeAPIBurst, "kube-api-burst", c.KubeAPIBurst, "Burst to use while talking with kubernetes apiserver. Doesn't cover events and node heartbeat apis which rate limiting is controlled by a different set of flags")
-	fs.BoolVar(&c.SerializeImagePulls, "serialize-image-pulls", c.SerializeImagePulls, "Pull images one at a time. We recommend *not* changing the default value on nodes that run docker daemon with version < 1.9 or an Aufs storage backend. Issue #10959 has more details.")
-
-	fs.Var(cliflag.NewLangleSeparatedMapStringString(&c.EvictionHard), "eviction-hard", "A set of eviction thresholds (e.g. memory.available<1Gi) that if met would trigger a pod eviction.")
-	fs.Var(cliflag.NewLangleSeparatedMapStringString(&c.EvictionSoft), "eviction-soft", "A set of eviction thresholds (e.g. memory.available<1.5Gi) that if met over a corresponding grace period would trigger a pod eviction.")
-	fs.Var(cliflag.NewMapStringString(&c.EvictionSoftGracePeriod), "eviction-soft-grace-period", "A set of eviction grace periods (e.g. memory.available=1m30s) that correspond to how long a soft eviction threshold must hold before triggering a pod eviction.")
-	fs.DurationVar(&c.EvictionPressureTransitionPeriod.Duration, "eviction-pressure-transition-period", c.EvictionPressureTransitionPeriod.Duration, "Duration for which the kubelet has to wait before transitioning out of an eviction pressure condition.")
-	fs.Int32Var(&c.EvictionMaxPodGracePeriod, "eviction-max-pod-grace-period", c.EvictionMaxPodGracePeriod, "Maximum allowed grace period (in seconds) to use when terminating pods in response to a soft eviction threshold being met.  If negative, defer to pod specified value.")
-	fs.Var(cliflag.NewMapStringString(&c.EvictionMinimumReclaim), "eviction-minimum-reclaim", "A set of minimum reclaims (e.g. imagefs.available=2Gi) that describes the minimum amount of resource the kubelet will reclaim when performing a pod eviction if that resource is under pressure.")
-	fs.Int32Var(&c.PodsPerCore, "pods-per-core", c.PodsPerCore, "Number of Pods per core that can run on this Kubelet. The total number of Pods on this Kubelet cannot exceed max-pods, so max-pods will be used if this calculation results in a larger number of Pods allowed on the Kubelet. A value of 0 disables this limit.")
-	fs.BoolVar(&c.ProtectKernelDefaults, "protect-kernel-defaults", c.ProtectKernelDefaults, "Default kubelet behaviour for kernel tuning. If set, kubelet errors if any of kernel tunables is different than kubelet defaults.")
-	fs.StringVar(&c.ReservedSystemCPUs, "reserved-cpus", c.ReservedSystemCPUs, "A comma-separated list of CPUs or CPU ranges that are reserved for system and kubernetes usage. This specific list will supersede cpu counts in --system-reserved and --kube-reserved.")
-	// Node Allocatable Flags
-	fs.Var(cliflag.NewMapStringString(&c.SystemReserved), "system-reserved", "A set of ResourceName=ResourceQuantity (e.g. cpu=200m,memory=500Mi,ephemeral-storage=1Gi) pairs that describe resources reserved for non-kubernetes components. Currently only cpu and memory are supported. See http://kubernetes.io/docs/user-guide/compute-resources for more detail. [default=none]")
-	fs.Var(cliflag.NewMapStringString(&c.KubeReserved), "kube-reserved", "A set of ResourceName=ResourceQuantity (e.g. cpu=200m,memory=500Mi,ephemeral-storage=1Gi) pairs that describe resources reserved for kubernetes system components. Currently cpu, memory and local ephemeral storage for root file system are supported. See http://kubernetes.io/docs/user-guide/compute-resources for more detail. [default=none]")
-	fs.StringSliceVar(&c.EnforceNodeAllocatable, "enforce-node-allocatable", c.EnforceNodeAllocatable, "A comma separated list of levels of node allocatable enforcement to be enforced by kubelet. Acceptable options are 'none', 'pods', 'system-reserved', and 'kube-reserved'. If the latter two options are specified, '--system-reserved-cgroup' and '--kube-reserved-cgroup' must also be set, respectively. If 'none' is specified, no additional options should be set. See https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/ for more details.")
-	fs.StringVar(&c.SystemReservedCgroup, "system-reserved-cgroup", c.SystemReservedCgroup, "Absolute name of the top level cgroup that is used to manage non-kubernetes components for which compute resources were reserved via '--system-reserved' flag. Ex. '/system-reserved'. [default='']")
-	fs.StringVar(&c.KubeReservedCgroup, "kube-reserved-cgroup", c.KubeReservedCgroup, "Absolute name of the top level cgroup that is used to manage kubernetes components for which compute resources were reserved via '--kube-reserved' flag. Ex. '/kube-reserved'. [default='']")
-	fs.StringVar(&c.Logging.Format, "logging-format", c.Logging.Format, `Sets the log format. Permitted formats: "text", "json".\nNon-default formats don't honor these flags: -add_dir_header, --alsologtostderr, --log_backtrace_at, --log_dir, --log_file, --log_file_max_size, --logtostderr, --skip_headers, --skip_log_headers, --stderrthreshold, --log-flush-frequency.\nNon-default choices are currently alpha and subject to change without warning.`)
+	{
+		v := lfs.Int64Var("max-open-files", help.MaxOpenFiles,
+			"Number of files that can be opened by Kubelet process.")
+		as = append(as, func(c *kubeletconfig.KubeletConfiguration) {
+			v.Set(&c.MaxOpenFiles)
+		})
+	}
+	{
+		v := lfs.StringVar("kube-api-content-type", help.ContentType,
+			"Content type of requests sent to apiserver.")
+		as = append(as, func(c *kubeletconfig.KubeletConfiguration) {
+			v.Set(&c.ContentType)
+		})
+	}
+	{
+		v := lfs.Int32Var("kube-api-qps", help.KubeAPIQPS, ""+
+			"QPS to use while talking with kubernetes apiserver. Doesn't "+
+			"cover events and node heartbeat apis which rate limiting is "+
+			"controlled by a different set of flags")
+		as = append(as, func(c *kubeletconfig.KubeletConfiguration) {
+			v.Set(&c.KubeAPIQPS)
+		})
+	}
+	{
+		v := lfs.Int32Var("kube-api-burst", help.KubeAPIBurst, ""+
+			"Burst to use while talking with kubernetes apiserver. Doesn't "+
+			"cover events and node heartbeat apis which rate limiting is "+
+			"controlled by a different set of flags")
+		as = append(as, func(c *kubeletconfig.KubeletConfiguration) {
+			v.Set(&c.KubeAPIBurst)
+		})
+	}
+	{
+		v := lfs.BoolVar("serialize-image-pulls", help.SerializeImagePulls, ""+
+			"Pull images one at a time. We recommend *not* changing the "+
+			"default value on nodes that run docker daemon with version < 1.9 "+
+			"or an Aufs storage backend. Issue #10959 has more details.")
+		as = append(as, func(c *kubeletconfig.KubeletConfiguration) {
+			v.Set(&c.SerializeImagePulls)
+		})
+	}
+	{
+		v := lfs.MapStringStringVar("eviction-hard", help.EvictionHard, ""+
+			"A set of eviction thresholds (e.g. memory.available<1Gi) that if "+
+			"met would trigger a pod eviction.",
+			&legacyflag.MapOptions{
+				KeyValueSep: "<",
+			})
+		as = append(as, func(c *kubeletconfig.KubeletConfiguration) {
+			v.Set(&c.EvictionHard)
+		})
+	}
+	{
+		v := lfs.MapStringStringVar("eviction-soft", help.EvictionSoft, ""+
+			"A set of eviction thresholds (e.g. memory.available<1.5Gi) that "+
+			"if met over a corresponding grace period would trigger a "+
+			"pod eviction.",
+			&legacyflag.MapOptions{
+				KeyValueSep: "<",
+			})
+		as = append(as, func(c *kubeletconfig.KubeletConfiguration) {
+			v.Set(&c.EvictionSoft)
+		})
+	}
+	{
+		v := lfs.MapStringStringVar("eviction-soft-grace-period", help.EvictionSoftGracePeriod, ""+
+			"A set of eviction grace periods (e.g. memory.available=1m30s) "+
+			"that correspond to how long a soft eviction threshold must hold "+
+			"before triggering a pod eviction.",
+			&legacyflag.MapOptions{})
+		as = append(as, func(c *kubeletconfig.KubeletConfiguration) {
+			v.Set(&c.EvictionSoftGracePeriod)
+		})
+	}
+	{
+		v := lfs.DurationVar("eviction-pressure-transition-period",
+			help.EvictionPressureTransitionPeriod.Duration, ""+
+				"Duration for which the kubelet has to wait before "+
+				"transitioning out of an eviction pressure condition.")
+		as = append(as, func(c *kubeletconfig.KubeletConfiguration) {
+			v.Set(&c.EvictionPressureTransitionPeriod.Duration)
+		})
+	}
+	{
+		v := lfs.Int32Var("eviction-max-pod-grace-period", help.EvictionMaxPodGracePeriod, ""+
+			"Maximum allowed grace period (in seconds) to use when terminating "+
+			"pods in response to a soft eviction threshold being met. "+
+			"If negative, defer to pod specified value.")
+		as = append(as, func(c *kubeletconfig.KubeletConfiguration) {
+			v.Set(&c.EvictionMaxPodGracePeriod)
+		})
+	}
+	{
+		v := lfs.MapStringStringVar("eviction-minimum-reclaim", help.EvictionMinimumReclaim, ""+
+			"A set of minimum reclaims (e.g. imagefs.available=2Gi) that "+
+			"describes the minimum amount of resource the kubelet will reclaim "+
+			"when performing a pod eviction if that resource is under pressure.",
+			&legacyflag.MapOptions{},
+		)
+		as = append(as, func(c *kubeletconfig.KubeletConfiguration) {
+			v.Set(&c.EvictionMinimumReclaim)
+		})
+	}
+	{
+		v := lfs.Int32Var("pods-per-core", help.PodsPerCore, ""+
+			"Number of Pods per core that can run on this Kubelet. The total "+
+			"number of Pods on this Kubelet cannot exceed max-pods, so max-pods "+
+			"will be used if this calculation results in a larger number of "+
+			"Pods allowed on the Kubelet. A value of 0 disables this limit.")
+		as = append(as, func(c *kubeletconfig.KubeletConfiguration) {
+			v.Set(&c.PodsPerCore)
+		})
+	}
+	{
+		v := lfs.BoolVar("protect-kernel-defaults", help.ProtectKernelDefaults, ""+
+			"Default kubelet behaviour for kernel tuning. If set, kubelet "+
+			"errors if any of kernel tunables is different than kubelet "+
+			"defaults.")
+		as = append(as, func(c *kubeletconfig.KubeletConfiguration) {
+			v.Set(&c.ProtectKernelDefaults)
+		})
+	}
+	{
+		v := lfs.StringVar("reserved-cpus", help.ReservedSystemCPUs, ""+
+			"A comma-separated list of CPUs or CPU ranges that are reserved "+
+			"for system and kubernetes usage. This specific list will "+
+			"supersede cpu counts in --system-reserved and --kube-reserved.")
+		as = append(as, func(c *kubeletconfig.KubeletConfiguration) {
+			v.Set(&c.ReservedSystemCPUs)
+		})
+	}
+	{
+		v := lfs.MapStringStringVar("system-reserved", help.SystemReserved, ""+
+			"A set of ResourceName=ResourceQuantity "+
+			"(e.g. cpu=200m,memory=500Mi,ephemeral-storage=1Gi) pairs that "+
+			"describe resources reserved for non-kubernetes components. "+
+			"Currently only cpu and memory are supported. See "+
+			"http://kubernetes.io/docs/user-guide/compute-resources for more "+
+			"detail. [default=none]",
+			&legacyflag.MapOptions{},
+		)
+		as = append(as, func(c *kubeletconfig.KubeletConfiguration) {
+			v.Set(&c.SystemReserved)
+		})
+	}
+	{
+		v := lfs.MapStringStringVar("kube-reserved", help.KubeReserved, ""+
+			"A set of ResourceName=ResourceQuantity "+
+			"(e.g. cpu=200m,memory=500Mi,ephemeral-storage=1Gi) pairs that "+
+			"describe resources reserved for kubernetes system components. "+
+			"Currently cpu, memory and local ephemeral storage for root file "+
+			"system are supported. See "+
+			"http://kubernetes.io/docs/user-guide/compute-resources for more "+
+			"detail. [default=none]",
+			&legacyflag.MapOptions{},
+		)
+		as = append(as, func(c *kubeletconfig.KubeletConfiguration) {
+			v.Set(&c.KubeReserved)
+		})
+	}
+	{
+		v := lfs.StringSliceVar("enforce-node-allocatable", help.EnforceNodeAllocatable, ""+
+			"A comma separated list of levels of node allocatable enforcement "+
+			"to be enforced by kubelet. Acceptable options are 'none', "+
+			"'pods', 'system-reserved', and 'kube-reserved'. If the latter "+
+			"two options are specified, '--system-reserved-cgroup' and "+
+			"'--kube-reserved-cgroup' must also be set, respectively. If "+
+			"'none' is specified, no additional options should be set. See "+
+			"https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/ "+
+			"for more details.")
+		as = append(as, func(c *kubeletconfig.KubeletConfiguration) {
+			v.Set(&c.EnforceNodeAllocatable)
+		})
+	}
+	{
+		v := lfs.StringVar("system-reserved-cgroup", help.SystemReservedCgroup, ""+
+			"Absolute name of the top level cgroup that is used to manage "+
+			"non-kubernetes components for which compute resources were "+
+			"reserved via '--system-reserved' flag. Ex. '/system-reserved'. "+
+			"[default='']")
+		as = append(as, func(c *kubeletconfig.KubeletConfiguration) {
+			v.Set(&c.SystemReservedCgroup)
+		})
+	}
+	{
+		v := lfs.StringVar("kube-reserved-cgroup", help.KubeReservedCgroup, ""+
+			"Absolute name of the top level cgroup that is used to manage "+
+			"kubernetes components for which compute resources were reserved "+
+			"via '--kube-reserved' flag. Ex. '/kube-reserved'. [default='']")
+		as = append(as, func(c *kubeletconfig.KubeletConfiguration) {
+			v.Set(&c.KubeReservedCgroup)
+		})
+	}
+	{
+		v := lfs.StringVar("logging-format", help.Logging.Format, ""+
+			"Sets the log format. Permitted formats: 'text', 'json'. "+
+			"Non-default formats don't honor these flags: -add_dir_header, "+
+			"--alsologtostderr, --log_backtrace_at, --log_dir, --log_file, "+
+			"--log_file_max_size, --logtostderr, --skip_headers, "+
+			"--skip_log_headers, --stderrthreshold, --log-flush-frequency. "+
+			"Non-default choices are currently alpha and subject to change "+
+			"without warning.")
+		as = append(as, func(c *kubeletconfig.KubeletConfiguration) {
+			v.Set(&c.Logging.Format)
+		})
+	}
 
 	// Graduated experimental flags, kept for backward compatibility
-	fs.BoolVar(&c.KernelMemcgNotification, "experimental-kernel-memcg-notification", c.KernelMemcgNotification, "Use kernelMemcgNotification configuration, this flag will be removed in 1.23.")
+	{
+		v := lfs.BoolVar("experimental-kernel-memcg-notification", help.KernelMemcgNotification, ""+
+			"Use kernelMemcgNotification configuration, this flag will be "+
+			"removed in 1.23.")
+		as = append(as, func(c *kubeletconfig.KubeletConfiguration) {
+			v.Set(&c.KernelMemcgNotification)
+		})
+	}
+
+	return func(c *kubeletconfig.KubeletConfiguration) {
+		for _, apply := range as {
+			apply(c)
+		}
+	}
 }

--- a/go.mod
+++ b/go.mod
@@ -497,6 +497,7 @@ replace (
 	rsc.io/pdf => rsc.io/pdf v0.1.1
 	sigs.k8s.io/apiserver-network-proxy/konnectivity-client => sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.9
 	sigs.k8s.io/kustomize => sigs.k8s.io/kustomize v2.0.3+incompatible
+	sigs.k8s.io/legacyflag => sigs.k8s.io/legacyflag v0.1.0
 	sigs.k8s.io/structured-merge-diff/v3 => sigs.k8s.io/structured-merge-diff/v3 v3.0.1-0.20200706213357-43c19bbb7fba
 	sigs.k8s.io/yaml => sigs.k8s.io/yaml v1.2.0
 	vbom.ml/util => vbom.ml/util v0.0.0-20160121211510-db5cfe13f5cc

--- a/staging/src/k8s.io/component-base/cli/flag/colon_separated_multimap_string_string.go
+++ b/staging/src/k8s.io/component-base/cli/flag/colon_separated_multimap_string_string.go
@@ -100,3 +100,27 @@ func (m *ColonSeparatedMultimapStringString) Type() string {
 func (m *ColonSeparatedMultimapStringString) Empty() bool {
 	return len(*m.Multimap) == 0
 }
+
+// DeepCopy returns a deep copy of the ColonSeparatedMultimapStringString.
+func (m *ColonSeparatedMultimapStringString) DeepCopy() *ColonSeparatedMultimapStringString {
+	var pmm *map[string][]string
+	if m.Multimap != nil {
+		var mm map[string][]string
+		if *m.Multimap != nil {
+			mm = map[string][]string{}
+			for k, ls := range *m.Multimap {
+				var newls []string
+				if ls != nil {
+					newls = make([]string, len(ls))
+					copy(newls, ls)
+				}
+				mm[k] = newls
+			}
+		}
+		pmm = &mm
+	}
+	return &ColonSeparatedMultimapStringString{
+		Multimap:    pmm,
+		initialized: m.initialized,
+	}
+}

--- a/staging/src/k8s.io/component-base/cli/flag/colon_separated_multimap_string_string_test.go
+++ b/staging/src/k8s.io/component-base/cli/flag/colon_separated_multimap_string_string_test.go
@@ -240,3 +240,35 @@ func TestEmptyColonSeparatedMultimapStringString(t *testing.T) {
 		})
 	}
 }
+
+func TestDeepCopyColonSeparatedMultimapStringString(t *testing.T) {
+	var nilMap map[string][]string
+	cases := []struct {
+		desc string
+		in   *ColonSeparatedMultimapStringString
+	}{
+		{"nil pointer", NewColonSeparatedMultimapStringString(
+			nil)},
+		{"nil map", NewColonSeparatedMultimapStringString(
+			&nilMap)},
+		{"empty map", NewColonSeparatedMultimapStringString(
+			&map[string][]string{})},
+		{"non-empty map, empty slice", NewColonSeparatedMultimapStringString(
+			&map[string][]string{"foo": {}})},
+		{"non-empty map, non-empty slice", NewColonSeparatedMultimapStringString(
+			&map[string][]string{"foo": {"bar"}})},
+		{"non-empty map, empty and non-empty slice", NewColonSeparatedMultimapStringString(
+			&map[string][]string{"foo": {}, "bar": {"baz"}})},
+	}
+	for _, c := range cases {
+		t.Run(c.desc, func(t *testing.T) {
+			out := c.in.DeepCopy()
+			if c.in.Multimap != nil && c.in.Multimap == out.Multimap {
+				t.Fatalf("got shallow copy, want deep copy")
+			}
+			if !reflect.DeepEqual(c.in.Multimap, out.Multimap) {
+				t.Fatalf("expect deep copy to exactly equal source")
+			}
+		})
+	}
+}

--- a/vendor/BUILD
+++ b/vendor/BUILD
@@ -521,6 +521,7 @@ filegroup(
         "//vendor/sigs.k8s.io/kustomize/pkg/target:all-srcs",
         "//vendor/sigs.k8s.io/kustomize/pkg/transformers:all-srcs",
         "//vendor/sigs.k8s.io/kustomize/pkg/types:all-srcs",
+        "//vendor/sigs.k8s.io/legacyflag/pkg/legacyflag:all-srcs",
         "//vendor/sigs.k8s.io/structured-merge-diff/v3/fieldpath:all-srcs",
         "//vendor/sigs.k8s.io/structured-merge-diff/v3/merge:all-srcs",
         "//vendor/sigs.k8s.io/structured-merge-diff/v3/schema:all-srcs",

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -2499,6 +2499,7 @@ sigs.k8s.io/kustomize/pkg/transformers
 sigs.k8s.io/kustomize/pkg/transformers/config
 sigs.k8s.io/kustomize/pkg/transformers/config/defaultconfig
 sigs.k8s.io/kustomize/pkg/types
+# sigs.k8s.io/legacyflag => sigs.k8s.io/legacyflag v0.1.0
 # sigs.k8s.io/structured-merge-diff/v3 v3.0.1-0.20200706213357-43c19bbb7fba => sigs.k8s.io/structured-merge-diff/v3 v3.0.1-0.20200706213357-43c19bbb7fba
 # sigs.k8s.io/structured-merge-diff/v3 => sigs.k8s.io/structured-merge-diff/v3 v3.0.1-0.20200706213357-43c19bbb7fba
 sigs.k8s.io/structured-merge-diff/v3/fieldpath

--- a/vendor/sigs.k8s.io/legacyflag/LICENSE
+++ b/vendor/sigs.k8s.io/legacyflag/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/sigs.k8s.io/legacyflag/pkg/legacyflag/BUILD
+++ b/vendor/sigs.k8s.io/legacyflag/pkg/legacyflag/BUILD
@@ -1,0 +1,52 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "bool.go",
+        "bool_slice.go",
+        "flag.go",
+        "float32.go",
+        "float64.go",
+        "global.go",
+        "int.go",
+        "int16.go",
+        "int32.go",
+        "int64.go",
+        "int8.go",
+        "int_slice.go",
+        "map.go",
+        "map_string_bool.go",
+        "map_string_string.go",
+        "net_ip.go",
+        "net_ipnet.go",
+        "string.go",
+        "string_slice.go",
+        "time_duration.go",
+        "uint.go",
+        "uint16.go",
+        "uint32.go",
+        "uint64.go",
+        "uint8.go",
+        "uint_slice.go",
+        "var.go",
+    ],
+    importmap = "k8s.io/kubernetes/vendor/sigs.k8s.io/legacyflag/pkg/legacyflag",
+    importpath = "sigs.k8s.io/legacyflag/pkg/legacyflag",
+    visibility = ["//visibility:public"],
+    deps = ["//vendor/github.com/spf13/pflag:go_default_library"],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/vendor/sigs.k8s.io/legacyflag/pkg/legacyflag/bool.go
+++ b/vendor/sigs.k8s.io/legacyflag/pkg/legacyflag/bool.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This file is generated. DO NOT EDIT.
+
+package legacyflag
+
+import(
+	"github.com/spf13/pflag"
+	
+)
+
+// BoolValue is a reference to a registered bool flag value.
+type BoolValue struct {
+	name string
+	value bool
+	fs *pflag.FlagSet
+}
+
+// BoolVar registers a flag for bool against the FlagSet, and returns
+// a BoolValue reference to the registered flag value.
+func (fs *FlagSet) BoolVar(name string, def bool, usage string) *BoolValue {
+	v := &BoolValue{
+		name: name,
+		fs: fs.fs,
+	}
+	fs.fs.BoolVar(&v.value, name, def, usage)
+	return v
+}
+
+// Set copies the flag value to the target if the flag was set.
+func (v *BoolValue) Set(target *bool) {
+	if v.fs.Changed(v.name) {
+		*target = v.value
+	}
+}
+
+// Apply calls the apply func with the flag value if the flag was set.
+func (v *BoolValue) Apply(apply func(value bool)) {
+	if v.fs.Changed(v.name) {
+		apply(v.value)
+	}
+}

--- a/vendor/sigs.k8s.io/legacyflag/pkg/legacyflag/bool_slice.go
+++ b/vendor/sigs.k8s.io/legacyflag/pkg/legacyflag/bool_slice.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This file is generated. DO NOT EDIT.
+
+package legacyflag
+
+import(
+	"github.com/spf13/pflag"
+	
+)
+
+// BoolSliceValue is a reference to a registered []bool flag value.
+type BoolSliceValue struct {
+	name string
+	value []bool
+	fs *pflag.FlagSet
+}
+
+// BoolSliceVar registers a flag for []bool against the FlagSet, and
+// returns a BoolSliceValue reference to the registered flag value.
+func (fs *FlagSet) BoolSliceVar(name string, def []bool, usage string) *BoolSliceValue {
+	v := &BoolSliceValue{
+		name: name,
+		fs: fs.fs,
+	}
+	fs.fs.BoolSliceVar(&v.value, name, def, usage)
+	return v
+}
+
+// Set copies the flag value to the target if the flag was set.
+func (v *BoolSliceValue) Set(target *[]bool) {
+	if v.fs.Changed(v.name) {
+		*target = make([]bool, len(v.value))
+		copy(*target, v.value)
+	}
+}
+
+// Apply calls the apply func with the flag value if the flag was set.
+func (v *BoolSliceValue) Apply(apply func(value []bool)) {
+	if v.fs.Changed(v.name) {
+		apply(v.value)
+	}
+}

--- a/vendor/sigs.k8s.io/legacyflag/pkg/legacyflag/flag.go
+++ b/vendor/sigs.k8s.io/legacyflag/pkg/legacyflag/flag.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package legacyflag
+
+import (
+	"github.com/spf13/pflag"
+)
+
+// FlagSet tracks the registered flags.
+type FlagSet struct {
+	fs *pflag.FlagSet
+}
+
+// NewFlagSet constructs a new FlagSet.
+func NewFlagSet(name string) *FlagSet {
+	return &FlagSet{
+		fs: pflag.NewFlagSet(name, pflag.ContinueOnError),
+	}
+}
+
+// NewFromPFlagSet creates a new FlagSet given a PFlagSet.
+func NewFromPFlagSet(fs *pflag.FlagSet) *FlagSet {
+	return &FlagSet{fs: fs}
+}
+
+// PflagFlagSet returns the underlying pflag.FlagSet.
+func (fs *FlagSet) PflagFlagSet() *pflag.FlagSet {
+	return fs.fs
+}
+
+// Parse parses the flags.
+func (fs *FlagSet) Parse(args []string) error {
+	return fs.fs.Parse(args)
+}
+
+// MarkDeprecated marks a flag as deprecated.
+func (fs *FlagSet) MarkDeprecated(name, message string) error {
+	return fs.fs.MarkDeprecated(name, message)
+}

--- a/vendor/sigs.k8s.io/legacyflag/pkg/legacyflag/float32.go
+++ b/vendor/sigs.k8s.io/legacyflag/pkg/legacyflag/float32.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This file is generated. DO NOT EDIT.
+
+package legacyflag
+
+import(
+	"github.com/spf13/pflag"
+	
+)
+
+// Float32Value is a reference to a registered float32 flag value.
+type Float32Value struct {
+	name string
+	value float32
+	fs *pflag.FlagSet
+}
+
+// Float32Var registers a flag for float32 against the FlagSet, and returns
+// a Float32Value reference to the registered flag value.
+func (fs *FlagSet) Float32Var(name string, def float32, usage string) *Float32Value {
+	v := &Float32Value{
+		name: name,
+		fs: fs.fs,
+	}
+	fs.fs.Float32Var(&v.value, name, def, usage)
+	return v
+}
+
+// Set copies the flag value to the target if the flag was set.
+func (v *Float32Value) Set(target *float32) {
+	if v.fs.Changed(v.name) {
+		*target = v.value
+	}
+}
+
+// Apply calls the apply func with the flag value if the flag was set.
+func (v *Float32Value) Apply(apply func(value float32)) {
+	if v.fs.Changed(v.name) {
+		apply(v.value)
+	}
+}

--- a/vendor/sigs.k8s.io/legacyflag/pkg/legacyflag/float64.go
+++ b/vendor/sigs.k8s.io/legacyflag/pkg/legacyflag/float64.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This file is generated. DO NOT EDIT.
+
+package legacyflag
+
+import(
+	"github.com/spf13/pflag"
+	
+)
+
+// Float64Value is a reference to a registered float64 flag value.
+type Float64Value struct {
+	name string
+	value float64
+	fs *pflag.FlagSet
+}
+
+// Float64Var registers a flag for float64 against the FlagSet, and returns
+// a Float64Value reference to the registered flag value.
+func (fs *FlagSet) Float64Var(name string, def float64, usage string) *Float64Value {
+	v := &Float64Value{
+		name: name,
+		fs: fs.fs,
+	}
+	fs.fs.Float64Var(&v.value, name, def, usage)
+	return v
+}
+
+// Set copies the flag value to the target if the flag was set.
+func (v *Float64Value) Set(target *float64) {
+	if v.fs.Changed(v.name) {
+		*target = v.value
+	}
+}
+
+// Apply calls the apply func with the flag value if the flag was set.
+func (v *Float64Value) Apply(apply func(value float64)) {
+	if v.fs.Changed(v.name) {
+		apply(v.value)
+	}
+}

--- a/vendor/sigs.k8s.io/legacyflag/pkg/legacyflag/global.go
+++ b/vendor/sigs.k8s.io/legacyflag/pkg/legacyflag/global.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package legacyflag
+
+import (
+	"flag"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/pflag"
+)
+
+// Based on the Kubelet's k8s.io/kubernetes/cmd/kubelet/app/options/globalflags.go
+
+// MustAddGlobalFlag adds the flag from the global Go flag command line, and
+// panics if the flag doesn't exist.
+func (fs *FlagSet) MustAddGlobalFlag(name string) {
+	if f := flag.CommandLine.Lookup(name); f != nil {
+		pflagFlag := pflag.PFlagFromGoFlag(f)
+		pflagFlag.Name = normalize(pflagFlag.Name)
+		fs.fs.AddFlag(pflagFlag)
+	} else {
+		panic(fmt.Sprintf("failed to find flag in global flagset (flag): %s", name))
+	}
+}
+
+// MustAddGlobalPflag adds the flag from the global pflag command line, and
+// panics if the flag doesn't exist.
+func (fs *FlagSet) MustAddGlobalPflag(name string) {
+	if f := pflag.CommandLine.Lookup(name); f != nil {
+		f.Name = normalize(f.Name)
+		fs.fs.AddFlag(f)
+	} else {
+		panic(fmt.Sprintf("failed to find flag in global flagset (pflag): %s", name))
+	}
+}
+
+// For legacy reasons, components may wish to mark global
+// flags deprecated before removing them:
+
+const deprecated = "This flag has been deprecated and will be removed in a future version."
+
+// MustAddDeprecatedGlobalFlag adds the flag from the global Go flag command
+// line, marks it deprecated, and panics if the flag doesn't exist.
+func (fs *FlagSet) MustAddDeprecatedGlobalFlag(name string) {
+	fs.MustAddGlobalFlag(name)
+	fs.fs.Lookup(normalize(name)).Deprecated = deprecated
+}
+
+// MustAddDeprecatedGlobalPflag adds the flag from the global pflag command
+// line, marks it deprecated, and panics if the flag doesn't exist.
+func (fs *FlagSet) MustAddDeprecatedGlobalPflag(name string) {
+	fs.MustAddGlobalPflag(name)
+	fs.fs.Lookup(normalize(name)).Deprecated = deprecated
+}
+
+// normalize replaces underscores with hyphens
+func normalize(s string) string {
+	return strings.Replace(s, "_", "-", -1)
+}

--- a/vendor/sigs.k8s.io/legacyflag/pkg/legacyflag/int.go
+++ b/vendor/sigs.k8s.io/legacyflag/pkg/legacyflag/int.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This file is generated. DO NOT EDIT.
+
+package legacyflag
+
+import(
+	"github.com/spf13/pflag"
+	
+)
+
+// IntValue is a reference to a registered int flag value.
+type IntValue struct {
+	name string
+	value int
+	fs *pflag.FlagSet
+}
+
+// IntVar registers a flag for int against the FlagSet, and returns
+// a IntValue reference to the registered flag value.
+func (fs *FlagSet) IntVar(name string, def int, usage string) *IntValue {
+	v := &IntValue{
+		name: name,
+		fs: fs.fs,
+	}
+	fs.fs.IntVar(&v.value, name, def, usage)
+	return v
+}
+
+// Set copies the flag value to the target if the flag was set.
+func (v *IntValue) Set(target *int) {
+	if v.fs.Changed(v.name) {
+		*target = v.value
+	}
+}
+
+// Apply calls the apply func with the flag value if the flag was set.
+func (v *IntValue) Apply(apply func(value int)) {
+	if v.fs.Changed(v.name) {
+		apply(v.value)
+	}
+}

--- a/vendor/sigs.k8s.io/legacyflag/pkg/legacyflag/int16.go
+++ b/vendor/sigs.k8s.io/legacyflag/pkg/legacyflag/int16.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This file is generated. DO NOT EDIT.
+
+package legacyflag
+
+import(
+	"github.com/spf13/pflag"
+	
+)
+
+// Int16Value is a reference to a registered int16 flag value.
+type Int16Value struct {
+	name string
+	value int16
+	fs *pflag.FlagSet
+}
+
+// Int16Var registers a flag for int16 against the FlagSet, and returns
+// a Int16Value reference to the registered flag value.
+func (fs *FlagSet) Int16Var(name string, def int16, usage string) *Int16Value {
+	v := &Int16Value{
+		name: name,
+		fs: fs.fs,
+	}
+	fs.fs.Int16Var(&v.value, name, def, usage)
+	return v
+}
+
+// Set copies the flag value to the target if the flag was set.
+func (v *Int16Value) Set(target *int16) {
+	if v.fs.Changed(v.name) {
+		*target = v.value
+	}
+}
+
+// Apply calls the apply func with the flag value if the flag was set.
+func (v *Int16Value) Apply(apply func(value int16)) {
+	if v.fs.Changed(v.name) {
+		apply(v.value)
+	}
+}

--- a/vendor/sigs.k8s.io/legacyflag/pkg/legacyflag/int32.go
+++ b/vendor/sigs.k8s.io/legacyflag/pkg/legacyflag/int32.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This file is generated. DO NOT EDIT.
+
+package legacyflag
+
+import(
+	"github.com/spf13/pflag"
+	
+)
+
+// Int32Value is a reference to a registered int32 flag value.
+type Int32Value struct {
+	name string
+	value int32
+	fs *pflag.FlagSet
+}
+
+// Int32Var registers a flag for int32 against the FlagSet, and returns
+// a Int32Value reference to the registered flag value.
+func (fs *FlagSet) Int32Var(name string, def int32, usage string) *Int32Value {
+	v := &Int32Value{
+		name: name,
+		fs: fs.fs,
+	}
+	fs.fs.Int32Var(&v.value, name, def, usage)
+	return v
+}
+
+// Set copies the flag value to the target if the flag was set.
+func (v *Int32Value) Set(target *int32) {
+	if v.fs.Changed(v.name) {
+		*target = v.value
+	}
+}
+
+// Apply calls the apply func with the flag value if the flag was set.
+func (v *Int32Value) Apply(apply func(value int32)) {
+	if v.fs.Changed(v.name) {
+		apply(v.value)
+	}
+}

--- a/vendor/sigs.k8s.io/legacyflag/pkg/legacyflag/int64.go
+++ b/vendor/sigs.k8s.io/legacyflag/pkg/legacyflag/int64.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This file is generated. DO NOT EDIT.
+
+package legacyflag
+
+import(
+	"github.com/spf13/pflag"
+	
+)
+
+// Int64Value is a reference to a registered int64 flag value.
+type Int64Value struct {
+	name string
+	value int64
+	fs *pflag.FlagSet
+}
+
+// Int64Var registers a flag for int64 against the FlagSet, and returns
+// a Int64Value reference to the registered flag value.
+func (fs *FlagSet) Int64Var(name string, def int64, usage string) *Int64Value {
+	v := &Int64Value{
+		name: name,
+		fs: fs.fs,
+	}
+	fs.fs.Int64Var(&v.value, name, def, usage)
+	return v
+}
+
+// Set copies the flag value to the target if the flag was set.
+func (v *Int64Value) Set(target *int64) {
+	if v.fs.Changed(v.name) {
+		*target = v.value
+	}
+}
+
+// Apply calls the apply func with the flag value if the flag was set.
+func (v *Int64Value) Apply(apply func(value int64)) {
+	if v.fs.Changed(v.name) {
+		apply(v.value)
+	}
+}

--- a/vendor/sigs.k8s.io/legacyflag/pkg/legacyflag/int8.go
+++ b/vendor/sigs.k8s.io/legacyflag/pkg/legacyflag/int8.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This file is generated. DO NOT EDIT.
+
+package legacyflag
+
+import(
+	"github.com/spf13/pflag"
+	
+)
+
+// Int8Value is a reference to a registered int8 flag value.
+type Int8Value struct {
+	name string
+	value int8
+	fs *pflag.FlagSet
+}
+
+// Int8Var registers a flag for int8 against the FlagSet, and returns
+// a Int8Value reference to the registered flag value.
+func (fs *FlagSet) Int8Var(name string, def int8, usage string) *Int8Value {
+	v := &Int8Value{
+		name: name,
+		fs: fs.fs,
+	}
+	fs.fs.Int8Var(&v.value, name, def, usage)
+	return v
+}
+
+// Set copies the flag value to the target if the flag was set.
+func (v *Int8Value) Set(target *int8) {
+	if v.fs.Changed(v.name) {
+		*target = v.value
+	}
+}
+
+// Apply calls the apply func with the flag value if the flag was set.
+func (v *Int8Value) Apply(apply func(value int8)) {
+	if v.fs.Changed(v.name) {
+		apply(v.value)
+	}
+}

--- a/vendor/sigs.k8s.io/legacyflag/pkg/legacyflag/int_slice.go
+++ b/vendor/sigs.k8s.io/legacyflag/pkg/legacyflag/int_slice.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This file is generated. DO NOT EDIT.
+
+package legacyflag
+
+import(
+	"github.com/spf13/pflag"
+	
+)
+
+// IntSliceValue is a reference to a registered []int flag value.
+type IntSliceValue struct {
+	name string
+	value []int
+	fs *pflag.FlagSet
+}
+
+// IntSliceVar registers a flag for []int against the FlagSet, and
+// returns a IntSliceValue reference to the registered flag value.
+func (fs *FlagSet) IntSliceVar(name string, def []int, usage string) *IntSliceValue {
+	v := &IntSliceValue{
+		name: name,
+		fs: fs.fs,
+	}
+	fs.fs.IntSliceVar(&v.value, name, def, usage)
+	return v
+}
+
+// Set copies the flag value to the target if the flag was set.
+func (v *IntSliceValue) Set(target *[]int) {
+	if v.fs.Changed(v.name) {
+		*target = make([]int, len(v.value))
+		copy(*target, v.value)
+	}
+}
+
+// Apply calls the apply func with the flag value if the flag was set.
+func (v *IntSliceValue) Apply(apply func(value []int)) {
+	if v.fs.Changed(v.name) {
+		apply(v.value)
+	}
+}

--- a/vendor/sigs.k8s.io/legacyflag/pkg/legacyflag/map.go
+++ b/vendor/sigs.k8s.io/legacyflag/pkg/legacyflag/map.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package legacyflag
+
+// TODO(mtaufen): wait until https://github.com/kubernetes/kubernetes/pull/76354
+// is finalized and port those decisions to here.
+
+// MapOptions contains options that control how the values are parsed
+type MapOptions struct {
+	// DisableCommaSeparatedPairs disables parsing multiple comma-separated
+	// key-value pairs from a single invocation. Instead, the entire string
+	// after the = separator will be parsed as the value. This can be convenient
+	// if values contain commas.
+	DisableCommaSeparatedPairs bool
+
+	// KeyValueSep is the separator between a key and its corresponding value.
+	// Default: equals sign (=).
+	KeyValueSep string
+
+	// PairSep is the separator between key-value pairs.
+	// Default: comma (,).
+	PairSep string
+}
+
+// Default applies defaults to uninitialized values in MapOptions.
+func (o *MapOptions) Default() {
+	if o.KeyValueSep == "" {
+		o.KeyValueSep = "="
+	}
+	if o.PairSep == "" {
+		o.PairSep = ","
+	}
+}

--- a/vendor/sigs.k8s.io/legacyflag/pkg/legacyflag/map_string_bool.go
+++ b/vendor/sigs.k8s.io/legacyflag/pkg/legacyflag/map_string_bool.go
@@ -1,0 +1,168 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package legacyflag
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/spf13/pflag"
+)
+
+// MapStringBoolValue is a reference to a registered map[string]bool flag value.
+type MapStringBoolValue struct {
+	name  string
+	value map[string]bool
+	fs    *pflag.FlagSet
+}
+
+// MapStringBoolVar registers a flag for map[string]bool against the FlagSet,
+// and returns a MapStringBoolValue reference to the registered flag value.
+// Format: `--flag "string=bool"`.
+// Multiple comma-separated key-value pairs in a single invocation are supported.
+// Example usage: `--flag "a=true,b=false"`.
+// Multiple flag invocations are supported.
+// Example usage: `--flag "a=true" --flag "b=false"`.
+func (fs *FlagSet) MapStringBoolVar(name string, def map[string]bool, usage string, options *MapOptions) *MapStringBoolValue {
+	val := &MapStringBoolValue{
+		name:  name,
+		value: make(map[string]bool),
+		fs:    fs.fs,
+	}
+	for k, v := range def {
+		val.value[k] = v
+	}
+	fs.fs.Var(newMapStringBool(&val.value, options), name, usage)
+	return val
+}
+
+// Set copies the map over the target if the flag was set.
+// It completely overwrites any existing target.
+func (v *MapStringBoolValue) Set(target *map[string]bool) {
+	if v.fs.Changed(v.name) {
+		*target = make(map[string]bool)
+		for k, v := range v.value {
+			(*target)[k] = v
+		}
+	}
+}
+
+// Merge copies the map keys/values piecewise into the target if the flag
+// was set. Values in the flag's map override values for corresponding
+// keys in the target map.
+func (v *MapStringBoolValue) Merge(target *map[string]bool) {
+	if v.fs.Changed(v.name) {
+		if *target == nil {
+			*target = make(map[string]bool)
+		}
+		for k, v := range v.value {
+			(*target)[k] = v
+		}
+	}
+}
+
+// Apply calls the user-provided apply function with the map if the flag was set.
+func (v *MapStringBoolValue) Apply(apply func(value map[string]bool)) {
+	if v.fs.Changed(v.name) {
+		apply(v.value)
+	}
+}
+
+// mapStringBool implements pflag.Value for map[string]bool
+type mapStringBool struct {
+	m           *map[string]bool
+	initialized bool
+	options     *MapOptions
+}
+
+// newMapStringBool takes a pointer to a map[string]string and returns the
+// mapStringBool flag parsing shim for that map
+func newMapStringBool(m *map[string]bool, o *MapOptions) *mapStringBool {
+	o.Default()
+	return &mapStringBool{m: m, options: o}
+}
+
+// String implements github.com/spf13/pflag.Value
+func (m *mapStringBool) String() string {
+	if m == nil || m.m == nil {
+		return ""
+	}
+	pairs := []string{}
+	for k, v := range *m.m {
+		pairs = append(pairs, fmt.Sprintf("%s%s%t", k, m.options.KeyValueSep, v))
+	}
+	sort.Strings(pairs)
+	return strings.Join(pairs, m.options.PairSep)
+}
+
+// Set implements github.com/spf13/pflag.Value
+func (m *mapStringBool) Set(value string) error {
+	if m.m == nil {
+		return fmt.Errorf("no target (nil pointer to map[string]bool)")
+	}
+	if !m.initialized || *m.m == nil {
+		// clear default values, or allocate if no existing map
+		*m.m = make(map[string]bool)
+		m.initialized = true
+	}
+	if !m.options.DisableCommaSeparatedPairs {
+		for _, s := range strings.Split(value, m.options.PairSep) {
+			if len(s) == 0 {
+				continue
+			}
+			arr := strings.SplitN(s, m.options.KeyValueSep, 2)
+			if len(arr) != 2 {
+				return fmt.Errorf("malformed pair, expect string%sbool", m.options.KeyValueSep)
+			}
+			k := strings.TrimSpace(arr[0])
+			v := strings.TrimSpace(arr[1])
+			boolValue, err := strconv.ParseBool(v)
+			if err != nil {
+				return fmt.Errorf("invalid value of %s: %s, err: %v", k, v, err)
+			}
+			(*m.m)[k] = boolValue
+		}
+		return nil
+	}
+
+	// account for only one key-value pair in a single invocation
+	arr := strings.SplitN(value, m.options.KeyValueSep, 2)
+	if len(arr) != 2 {
+		return fmt.Errorf("malformed pair, expect string%sbool", m.options.KeyValueSep)
+	}
+	k := strings.TrimSpace(arr[0])
+	v := strings.TrimSpace(arr[1])
+	boolValue, err := strconv.ParseBool(v)
+	if err != nil {
+		return fmt.Errorf("invalid value of %s: %s, err: %v", k, v, err)
+	}
+	(*m.m)[k] = boolValue
+
+	return nil
+}
+
+// Type implements github.com/spf13/pflag.Value
+func (*mapStringBool) Type() string {
+	return "mapStringBool"
+}
+
+// Empty implements OmitEmpty
+func (m *mapStringBool) Empty() bool {
+	return len(*m.m) == 0
+}

--- a/vendor/sigs.k8s.io/legacyflag/pkg/legacyflag/map_string_string.go
+++ b/vendor/sigs.k8s.io/legacyflag/pkg/legacyflag/map_string_string.go
@@ -1,0 +1,162 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package legacyflag
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/spf13/pflag"
+)
+
+// MapStringStringValue is a reference to a registered map[string]string flag value.
+type MapStringStringValue struct {
+	name  string
+	value map[string]string
+	fs    *pflag.FlagSet
+}
+
+// MapStringStringVar registers a flag for map[string]string against the FlagSet,
+// and returns a MapStringStringValue reference to the registered flag value.
+// Format: `--flag "string=string"`.
+// Multiple comma-separated key-value pairs in a single invocation are supported,
+// when MapOptions.DisableBatch=false.
+// For example: `--flag "a=foo,b=bar"`.
+// Multiple flag invocations are supported.
+// For example: `--flag "a=foo" --flag "b=bar"`.
+func (fs *FlagSet) MapStringStringVar(name string, def map[string]string, usage string, options *MapOptions) *MapStringStringValue {
+	val := &MapStringStringValue{
+		name:  name,
+		value: make(map[string]string),
+		fs:    fs.fs,
+	}
+	for k, v := range def {
+		val.value[k] = v
+	}
+	fs.fs.Var(newMapStringString(&val.value, options), name, usage)
+	return val
+}
+
+// Set copies the map over the target if the flag was set.
+// It completely overwrites any existing target.
+func (v *MapStringStringValue) Set(target *map[string]string) {
+	if v.fs.Changed(v.name) {
+		*target = make(map[string]string)
+		for k, v := range v.value {
+			(*target)[k] = v
+		}
+	}
+}
+
+// Merge copies the map keys/values piecewise into the target if the flag
+// was set. Values in the flag's map override values for corresponding
+// keys in the target map.
+func (v *MapStringStringValue) Merge(target *map[string]string) {
+	if v.fs.Changed(v.name) {
+		if *target == nil {
+			*target = make(map[string]string)
+		}
+		for k, v := range v.value {
+			(*target)[k] = v
+		}
+	}
+}
+
+// Apply calls the user-provided apply function with the map if the flag was set.
+func (v *MapStringStringValue) Apply(apply func(value map[string]string)) {
+	if v.fs.Changed(v.name) {
+		apply(v.value)
+	}
+}
+
+// mapStringString implements plfag.Value for map[string]string
+type mapStringString struct {
+	m           *map[string]string
+	initialized bool
+	options     *MapOptions
+}
+
+// newMapStringString takes a pointer to a map[string]string and returns the
+// mapStringString flag parsing shim for that map.
+func newMapStringString(m *map[string]string, o *MapOptions) *mapStringString {
+	o.Default()
+	return &mapStringString{m: m, options: o}
+}
+
+// String implements github.com/spf13/pflag.Value
+func (m *mapStringString) String() string {
+	if m == nil || m.m == nil {
+		return ""
+	}
+	pairs := []string{}
+	for k, v := range *m.m {
+		pairs = append(pairs, fmt.Sprintf("%s%s%s", k, m.options.KeyValueSep, v))
+	}
+	sort.Strings(pairs)
+	return strings.Join(pairs, m.options.PairSep)
+}
+
+// Set implements github.com/spf13/pflag.Value
+func (m *mapStringString) Set(value string) error {
+	if m.m == nil {
+		return fmt.Errorf("no target (nil pointer to map[string]string)")
+	}
+	if !m.initialized || *m.m == nil {
+		// clear default values, or allocate if no existing map
+		*m.m = make(map[string]string)
+		m.initialized = true
+	}
+
+	// account for multiple key-value pairs in a single invocation
+	if !m.options.DisableCommaSeparatedPairs {
+		for _, s := range strings.Split(value, m.options.PairSep) {
+			if len(s) == 0 {
+				continue
+			}
+			arr := strings.SplitN(s, m.options.KeyValueSep, 2)
+			if len(arr) != 2 {
+				return fmt.Errorf("malformed pair, expect string%sstring", m.options.KeyValueSep)
+			}
+			k := strings.TrimSpace(arr[0])
+			v := strings.TrimSpace(arr[1])
+			(*m.m)[k] = v
+		}
+		return nil
+	}
+
+	// account for only one key-value pair in a single invocation
+	arr := strings.SplitN(value, m.options.KeyValueSep, 2)
+	if len(arr) != 2 {
+		return fmt.Errorf("malformed pair, expect string%sstring", m.options.KeyValueSep)
+	}
+	k := strings.TrimSpace(arr[0])
+	v := strings.TrimSpace(arr[1])
+	(*m.m)[k] = v
+	return nil
+
+}
+
+// Type implements github.com/spf13/pflag.Value
+func (*mapStringString) Type() string {
+	return "mapStringString"
+}
+
+// Empty implements OmitEmpty
+func (m *mapStringString) Empty() bool {
+	return len(*m.m) == 0
+}

--- a/vendor/sigs.k8s.io/legacyflag/pkg/legacyflag/net_ip.go
+++ b/vendor/sigs.k8s.io/legacyflag/pkg/legacyflag/net_ip.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This file is generated. DO NOT EDIT.
+
+package legacyflag
+
+import(
+	"github.com/spf13/pflag"
+	"net"
+)
+
+// IPValue is a reference to a registered net.IP flag value.
+type IPValue struct {
+	name string
+	value net.IP
+	fs *pflag.FlagSet
+}
+
+// IPVar registers a flag for net.IP against the FlagSet, and returns
+// a IPValue reference to the registered flag value.
+func (fs *FlagSet) IPVar(name string, def net.IP, usage string) *IPValue {
+	v := &IPValue{
+		name: name,
+		fs: fs.fs,
+	}
+	fs.fs.IPVar(&v.value, name, def, usage)
+	return v
+}
+
+// Set copies the flag value to the target if the flag was set.
+func (v *IPValue) Set(target *net.IP) {
+	if v.fs.Changed(v.name) {
+		*target = v.value
+	}
+}
+
+// Apply calls the apply func with the flag value if the flag was set.
+func (v *IPValue) Apply(apply func(value net.IP)) {
+	if v.fs.Changed(v.name) {
+		apply(v.value)
+	}
+}

--- a/vendor/sigs.k8s.io/legacyflag/pkg/legacyflag/net_ipnet.go
+++ b/vendor/sigs.k8s.io/legacyflag/pkg/legacyflag/net_ipnet.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This file is generated. DO NOT EDIT.
+
+package legacyflag
+
+import(
+	"github.com/spf13/pflag"
+	"net"
+)
+
+// IPNetValue is a reference to a registered net.IPNet flag value.
+type IPNetValue struct {
+	name string
+	value net.IPNet
+	fs *pflag.FlagSet
+}
+
+// IPNetVar registers a flag for net.IPNet against the FlagSet, and returns
+// a IPNetValue reference to the registered flag value.
+func (fs *FlagSet) IPNetVar(name string, def net.IPNet, usage string) *IPNetValue {
+	v := &IPNetValue{
+		name: name,
+		fs: fs.fs,
+	}
+	fs.fs.IPNetVar(&v.value, name, def, usage)
+	return v
+}
+
+// Set copies the flag value to the target if the flag was set.
+func (v *IPNetValue) Set(target *net.IPNet) {
+	if v.fs.Changed(v.name) {
+		*target = v.value
+	}
+}
+
+// Apply calls the apply func with the flag value if the flag was set.
+func (v *IPNetValue) Apply(apply func(value net.IPNet)) {
+	if v.fs.Changed(v.name) {
+		apply(v.value)
+	}
+}

--- a/vendor/sigs.k8s.io/legacyflag/pkg/legacyflag/string.go
+++ b/vendor/sigs.k8s.io/legacyflag/pkg/legacyflag/string.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This file is generated. DO NOT EDIT.
+
+package legacyflag
+
+import(
+	"github.com/spf13/pflag"
+	
+)
+
+// StringValue is a reference to a registered string flag value.
+type StringValue struct {
+	name string
+	value string
+	fs *pflag.FlagSet
+}
+
+// StringVar registers a flag for string against the FlagSet, and returns
+// a StringValue reference to the registered flag value.
+func (fs *FlagSet) StringVar(name string, def string, usage string) *StringValue {
+	v := &StringValue{
+		name: name,
+		fs: fs.fs,
+	}
+	fs.fs.StringVar(&v.value, name, def, usage)
+	return v
+}
+
+// Set copies the flag value to the target if the flag was set.
+func (v *StringValue) Set(target *string) {
+	if v.fs.Changed(v.name) {
+		*target = v.value
+	}
+}
+
+// Apply calls the apply func with the flag value if the flag was set.
+func (v *StringValue) Apply(apply func(value string)) {
+	if v.fs.Changed(v.name) {
+		apply(v.value)
+	}
+}

--- a/vendor/sigs.k8s.io/legacyflag/pkg/legacyflag/string_slice.go
+++ b/vendor/sigs.k8s.io/legacyflag/pkg/legacyflag/string_slice.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This file is generated. DO NOT EDIT.
+
+package legacyflag
+
+import(
+	"github.com/spf13/pflag"
+	
+)
+
+// StringSliceValue is a reference to a registered []string flag value.
+type StringSliceValue struct {
+	name string
+	value []string
+	fs *pflag.FlagSet
+}
+
+// StringSliceVar registers a flag for []string against the FlagSet, and
+// returns a StringSliceValue reference to the registered flag value.
+func (fs *FlagSet) StringSliceVar(name string, def []string, usage string) *StringSliceValue {
+	v := &StringSliceValue{
+		name: name,
+		fs: fs.fs,
+	}
+	fs.fs.StringSliceVar(&v.value, name, def, usage)
+	return v
+}
+
+// Set copies the flag value to the target if the flag was set.
+func (v *StringSliceValue) Set(target *[]string) {
+	if v.fs.Changed(v.name) {
+		*target = make([]string, len(v.value))
+		copy(*target, v.value)
+	}
+}
+
+// Apply calls the apply func with the flag value if the flag was set.
+func (v *StringSliceValue) Apply(apply func(value []string)) {
+	if v.fs.Changed(v.name) {
+		apply(v.value)
+	}
+}

--- a/vendor/sigs.k8s.io/legacyflag/pkg/legacyflag/time_duration.go
+++ b/vendor/sigs.k8s.io/legacyflag/pkg/legacyflag/time_duration.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This file is generated. DO NOT EDIT.
+
+package legacyflag
+
+import(
+	"github.com/spf13/pflag"
+	"time"
+)
+
+// DurationValue is a reference to a registered time.Duration flag value.
+type DurationValue struct {
+	name string
+	value time.Duration
+	fs *pflag.FlagSet
+}
+
+// DurationVar registers a flag for time.Duration against the FlagSet, and returns
+// a DurationValue reference to the registered flag value.
+func (fs *FlagSet) DurationVar(name string, def time.Duration, usage string) *DurationValue {
+	v := &DurationValue{
+		name: name,
+		fs: fs.fs,
+	}
+	fs.fs.DurationVar(&v.value, name, def, usage)
+	return v
+}
+
+// Set copies the flag value to the target if the flag was set.
+func (v *DurationValue) Set(target *time.Duration) {
+	if v.fs.Changed(v.name) {
+		*target = v.value
+	}
+}
+
+// Apply calls the apply func with the flag value if the flag was set.
+func (v *DurationValue) Apply(apply func(value time.Duration)) {
+	if v.fs.Changed(v.name) {
+		apply(v.value)
+	}
+}

--- a/vendor/sigs.k8s.io/legacyflag/pkg/legacyflag/uint.go
+++ b/vendor/sigs.k8s.io/legacyflag/pkg/legacyflag/uint.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This file is generated. DO NOT EDIT.
+
+package legacyflag
+
+import(
+	"github.com/spf13/pflag"
+	
+)
+
+// UintValue is a reference to a registered uint flag value.
+type UintValue struct {
+	name string
+	value uint
+	fs *pflag.FlagSet
+}
+
+// UintVar registers a flag for uint against the FlagSet, and returns
+// a UintValue reference to the registered flag value.
+func (fs *FlagSet) UintVar(name string, def uint, usage string) *UintValue {
+	v := &UintValue{
+		name: name,
+		fs: fs.fs,
+	}
+	fs.fs.UintVar(&v.value, name, def, usage)
+	return v
+}
+
+// Set copies the flag value to the target if the flag was set.
+func (v *UintValue) Set(target *uint) {
+	if v.fs.Changed(v.name) {
+		*target = v.value
+	}
+}
+
+// Apply calls the apply func with the flag value if the flag was set.
+func (v *UintValue) Apply(apply func(value uint)) {
+	if v.fs.Changed(v.name) {
+		apply(v.value)
+	}
+}

--- a/vendor/sigs.k8s.io/legacyflag/pkg/legacyflag/uint16.go
+++ b/vendor/sigs.k8s.io/legacyflag/pkg/legacyflag/uint16.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This file is generated. DO NOT EDIT.
+
+package legacyflag
+
+import(
+	"github.com/spf13/pflag"
+	
+)
+
+// Uint16Value is a reference to a registered uint16 flag value.
+type Uint16Value struct {
+	name string
+	value uint16
+	fs *pflag.FlagSet
+}
+
+// Uint16Var registers a flag for uint16 against the FlagSet, and returns
+// a Uint16Value reference to the registered flag value.
+func (fs *FlagSet) Uint16Var(name string, def uint16, usage string) *Uint16Value {
+	v := &Uint16Value{
+		name: name,
+		fs: fs.fs,
+	}
+	fs.fs.Uint16Var(&v.value, name, def, usage)
+	return v
+}
+
+// Set copies the flag value to the target if the flag was set.
+func (v *Uint16Value) Set(target *uint16) {
+	if v.fs.Changed(v.name) {
+		*target = v.value
+	}
+}
+
+// Apply calls the apply func with the flag value if the flag was set.
+func (v *Uint16Value) Apply(apply func(value uint16)) {
+	if v.fs.Changed(v.name) {
+		apply(v.value)
+	}
+}

--- a/vendor/sigs.k8s.io/legacyflag/pkg/legacyflag/uint32.go
+++ b/vendor/sigs.k8s.io/legacyflag/pkg/legacyflag/uint32.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This file is generated. DO NOT EDIT.
+
+package legacyflag
+
+import(
+	"github.com/spf13/pflag"
+	
+)
+
+// Uint32Value is a reference to a registered uint32 flag value.
+type Uint32Value struct {
+	name string
+	value uint32
+	fs *pflag.FlagSet
+}
+
+// Uint32Var registers a flag for uint32 against the FlagSet, and returns
+// a Uint32Value reference to the registered flag value.
+func (fs *FlagSet) Uint32Var(name string, def uint32, usage string) *Uint32Value {
+	v := &Uint32Value{
+		name: name,
+		fs: fs.fs,
+	}
+	fs.fs.Uint32Var(&v.value, name, def, usage)
+	return v
+}
+
+// Set copies the flag value to the target if the flag was set.
+func (v *Uint32Value) Set(target *uint32) {
+	if v.fs.Changed(v.name) {
+		*target = v.value
+	}
+}
+
+// Apply calls the apply func with the flag value if the flag was set.
+func (v *Uint32Value) Apply(apply func(value uint32)) {
+	if v.fs.Changed(v.name) {
+		apply(v.value)
+	}
+}

--- a/vendor/sigs.k8s.io/legacyflag/pkg/legacyflag/uint64.go
+++ b/vendor/sigs.k8s.io/legacyflag/pkg/legacyflag/uint64.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This file is generated. DO NOT EDIT.
+
+package legacyflag
+
+import(
+	"github.com/spf13/pflag"
+	
+)
+
+// Uint64Value is a reference to a registered uint64 flag value.
+type Uint64Value struct {
+	name string
+	value uint64
+	fs *pflag.FlagSet
+}
+
+// Uint64Var registers a flag for uint64 against the FlagSet, and returns
+// a Uint64Value reference to the registered flag value.
+func (fs *FlagSet) Uint64Var(name string, def uint64, usage string) *Uint64Value {
+	v := &Uint64Value{
+		name: name,
+		fs: fs.fs,
+	}
+	fs.fs.Uint64Var(&v.value, name, def, usage)
+	return v
+}
+
+// Set copies the flag value to the target if the flag was set.
+func (v *Uint64Value) Set(target *uint64) {
+	if v.fs.Changed(v.name) {
+		*target = v.value
+	}
+}
+
+// Apply calls the apply func with the flag value if the flag was set.
+func (v *Uint64Value) Apply(apply func(value uint64)) {
+	if v.fs.Changed(v.name) {
+		apply(v.value)
+	}
+}

--- a/vendor/sigs.k8s.io/legacyflag/pkg/legacyflag/uint8.go
+++ b/vendor/sigs.k8s.io/legacyflag/pkg/legacyflag/uint8.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This file is generated. DO NOT EDIT.
+
+package legacyflag
+
+import(
+	"github.com/spf13/pflag"
+	
+)
+
+// Uint8Value is a reference to a registered uint8 flag value.
+type Uint8Value struct {
+	name string
+	value uint8
+	fs *pflag.FlagSet
+}
+
+// Uint8Var registers a flag for uint8 against the FlagSet, and returns
+// a Uint8Value reference to the registered flag value.
+func (fs *FlagSet) Uint8Var(name string, def uint8, usage string) *Uint8Value {
+	v := &Uint8Value{
+		name: name,
+		fs: fs.fs,
+	}
+	fs.fs.Uint8Var(&v.value, name, def, usage)
+	return v
+}
+
+// Set copies the flag value to the target if the flag was set.
+func (v *Uint8Value) Set(target *uint8) {
+	if v.fs.Changed(v.name) {
+		*target = v.value
+	}
+}
+
+// Apply calls the apply func with the flag value if the flag was set.
+func (v *Uint8Value) Apply(apply func(value uint8)) {
+	if v.fs.Changed(v.name) {
+		apply(v.value)
+	}
+}

--- a/vendor/sigs.k8s.io/legacyflag/pkg/legacyflag/uint_slice.go
+++ b/vendor/sigs.k8s.io/legacyflag/pkg/legacyflag/uint_slice.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This file is generated. DO NOT EDIT.
+
+package legacyflag
+
+import(
+	"github.com/spf13/pflag"
+	
+)
+
+// UintSliceValue is a reference to a registered []uint flag value.
+type UintSliceValue struct {
+	name string
+	value []uint
+	fs *pflag.FlagSet
+}
+
+// UintSliceVar registers a flag for []uint against the FlagSet, and
+// returns a UintSliceValue reference to the registered flag value.
+func (fs *FlagSet) UintSliceVar(name string, def []uint, usage string) *UintSliceValue {
+	v := &UintSliceValue{
+		name: name,
+		fs: fs.fs,
+	}
+	fs.fs.UintSliceVar(&v.value, name, def, usage)
+	return v
+}
+
+// Set copies the flag value to the target if the flag was set.
+func (v *UintSliceValue) Set(target *[]uint) {
+	if v.fs.Changed(v.name) {
+		*target = make([]uint, len(v.value))
+		copy(*target, v.value)
+	}
+}
+
+// Apply calls the apply func with the flag value if the flag was set.
+func (v *UintSliceValue) Apply(apply func(value []uint)) {
+	if v.fs.Changed(v.name) {
+		apply(v.value)
+	}
+}

--- a/vendor/sigs.k8s.io/legacyflag/pkg/legacyflag/var.go
+++ b/vendor/sigs.k8s.io/legacyflag/pkg/legacyflag/var.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package legacyflag
+
+import (
+	"github.com/spf13/pflag"
+)
+
+// VarValue references a registered Var flag.
+type VarValue struct {
+	name string
+	fs   *pflag.FlagSet
+}
+
+// Var registers a flag for a type that implements the pflag.Value interface
+// against the FlagSet, and returns a VarValue that references this flag.
+func (fs *FlagSet) Var(value pflag.Value, name string, usage string) *VarValue {
+	v := &VarValue{
+		name: name,
+		fs:   fs.fs,
+	}
+	fs.fs.Var(value, name, usage)
+	return v
+}
+
+// Apply calls the apply function if the flag associated with VarValue was set.
+// Since users supply the scratch-space when constructing the VarValue, they
+// must read the scratch space directly in their apply function.
+func (v *VarValue) Apply(apply func()) {
+	if v.fs.Changed(v.name) {
+		apply()
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
This converts Kubelet flag registrations that target Kubelet's ComponentConfig type (KubeletConfiguration) to use the legacyflag approach. Flag registrations become more verbose, but enforcing "flag precedence" (#56171) when parsing various sources of KubeletConfiguration becomes much more straightforward, because we no longer have to re-parse the command-line multiple times (with careful logic to avoid unwanted side-effects). Instead, legacyflag lets us parse the command-line once, store values for flags that target KubeletConfiguration in a scratch space, and apply values from explicitly set flags onto multiple KubeletConfigurations with no risk of distant side-effects.

legacyflag: https://github.com/kubernetes-sigs/legacyflag
legacyflag KEP: https://github.com/kubernetes/enhancements/blob/master/keps/sig-api-machinery/20190129-legacyflag.md

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/assign @liggitt @sttts
/cc @stealthybox 

PTAL when you have a chance. I'm only working on this as I have time, but fortunately had some time today to get this started.
