### PR TITLE
Delaying EndpointSlice controller syncs until cache is updated

### DIFF
--- a/pkg/controller/endpointslice/reconciler_test.go
+++ b/pkg/controller/endpointslice/reconciler_test.go
@@ -983,13 +983,16 @@ func expectActions(t *testing.T, actions []k8stesting.Action, num int, verb, res
 }
 
 func expectTrackedResourceVersion(t *testing.T, tracker *endpointSliceTracker, slice *discovery.EndpointSlice, expectedRV string) {
-	rrv, _ := tracker.relatedResourceVersions(slice)
-	rv, tracked := rrv[slice.Name]
-	if !tracked {
+	serviceStatus, ok := tracker.serviceStatusForSlice(slice)
+	if !ok {
+		t.Fatalf("Expected Service to be tracked for EndpointSlices %s", slice.Name)
+	}
+	sliceStatus, ok := serviceStatus.statusBySlice[slice.Name]
+	if !ok {
 		t.Fatalf("Expected EndpointSlice %s to be tracked", slice.Name)
 	}
-	if rv != expectedRV {
-		t.Errorf("Expected ResourceVersion of %s to be %s, got %s", slice.Name, expectedRV, rv)
+	if sliceStatus.resourceVersion != expectedRV {
+		t.Errorf("Expected ResourceVersion of %s to be %s, got %s", slice.Name, expectedRV, sliceStatus.resourceVersion)
 	}
 }
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
/kind failing-test

**What this PR does / why we need it**:
This updates the EndpointSlice controller to wait until the cache is updated (or a max delay of 3 seconds is exceeded) before running a sync for a Service. This should help avoid race conditions that would result in duplicate EndpointSlices or failed attempts to update stale EndpointSlices.

**Which issue(s) this PR fixes**:
This will eventually fix #93374 and #92928.

**Special notes for your reviewer**:
This is very much still a WIP. I filed this early to get some initial feedback to at least see if I'm working in a reasonable direction. I do not love this approach but haven't thought of a better one yet, so very open to alternative ideas here.

I'd initially hoped that I could rely on the retry mechanism in the queue to simplify this implementation but that simply does not work since so many events can trigger a new sync. Currently I'm planning on updating the endpointSliceTracker to also track the last time the controller modified an EndpointSlice for each Service and then updating the logic to bypass the outdated cache check after a set number of seconds have passed since the last update. Other significant todos here include adding some test coverage and ensuring that a cache being outdated at one point in time does not forever doom a Service to slow sync times.

**Does this PR introduce a user-facing change?**:
```release-note
EndpointSlice controller syncs now wait for cache updates to limit caching issues.
```

/sig network
/cc @liggitt @freehan