### PR TITLE
scheduler: expose Run[Pre]ScorePlugins functions to PreemptionHandle(through PluginRunner)

### DIFF
--- a/pkg/scheduler/framework/v1alpha1/interface.go
+++ b/pkg/scheduler/framework/v1alpha1/interface.go
@@ -555,6 +555,10 @@ type PodNominator interface {
 // This is used by preemption PostFilter plugins when evaluating the feasibility of
 // scheduling the pod on nodes when certain running pods get evicted.
 type PluginsRunner interface {
+	// RunPreScorePlugins runs the set of configured PreScore plugins for pod on the given nodes
+	RunPreScorePlugins(context.Context, *CycleState, *v1.Pod, []*v1.Node) *Status
+	// RunScorePlugins runs the set of configured Score plugins for pod on the given nodes
+	RunScorePlugins(context.Context, *CycleState, *v1.Pod, []*v1.Node) (PluginToNodeScores, *Status)
 	// RunFilterPlugins runs the set of configured filter plugins for pod on the given node.
 	RunFilterPlugins(context.Context, *CycleState, *v1.Pod, *NodeInfo) PluginToStatus
 	// RunPreFilterExtensionAddPod calls the AddPod interface for the set of configured PreFilter plugins.

--- a/test/integration/scheduler/framework_test.go
+++ b/test/integration/scheduler/framework_test.go
@@ -407,10 +407,17 @@ func (pp *PostFilterPlugin) PostFilter(ctx context.Context, state *framework.Cyc
 	if err != nil {
 		return nil, framework.NewStatus(framework.Error, err.Error())
 	}
+
 	ph := pp.fh.PreemptHandle()
 	for _, nodeInfo := range nodeInfos {
 		ph.RunFilterPlugins(ctx, state, pod, nodeInfo)
 	}
+	var nodes []*v1.Node
+	for _, nodeInfo := range nodeInfos {
+		nodes = append(nodes, nodeInfo.Node())
+	}
+	ph.RunScorePlugins(ctx, state, pod, nodes)
+
 	if pp.failPostFilter {
 		return nil, framework.NewStatus(framework.Error, fmt.Sprintf("injecting failure for pod %v", pod.Name))
 	}
@@ -578,30 +585,52 @@ func TestPostFilterPlugin(t *testing.T) {
 	numNodes := 1
 	tests := []struct {
 		name                      string
+		numNodes                  int
 		rejectFilter              bool
+		failScore                 bool
 		rejectPostFilter          bool
 		expectFilterNumCalled     int
+		expectScoreNumCalled      int32
 		expectPostFilterNumCalled int
 	}{
 		{
-			name:                      "Filter passed",
+			name:                      "Filter passed and Score success",
+			numNodes:                  3,
 			rejectFilter:              false,
+			failScore:                 false,
 			rejectPostFilter:          false,
-			expectFilterNumCalled:     numNodes,
+			expectFilterNumCalled:     3,
+			expectScoreNumCalled:      3,
 			expectPostFilterNumCalled: 0,
 		},
 		{
 			name:                      "Filter failed and PostFilter passed",
+			numNodes:                  numNodes,
 			rejectFilter:              true,
+			failScore:                 false,
 			rejectPostFilter:          false,
 			expectFilterNumCalled:     numNodes * 2,
+			expectScoreNumCalled:      1,
 			expectPostFilterNumCalled: 1,
 		},
 		{
 			name:                      "Filter failed and PostFilter failed",
+			numNodes:                  numNodes,
 			rejectFilter:              true,
+			failScore:                 false,
 			rejectPostFilter:          true,
 			expectFilterNumCalled:     numNodes * 2,
+			expectScoreNumCalled:      1,
+			expectPostFilterNumCalled: 1,
+		},
+		{
+			name:                      "Score failed and PostFilter failed",
+			numNodes:                  numNodes,
+			rejectFilter:              true,
+			failScore:                 true,
+			rejectPostFilter:          true,
+			expectFilterNumCalled:     numNodes * 2,
+			expectScoreNumCalled:      1,
 			expectPostFilterNumCalled: 1,
 		},
 	}
@@ -611,12 +640,15 @@ func TestPostFilterPlugin(t *testing.T) {
 			// Create a plugin registry for testing. Register a combination of filter and postFilter plugin.
 			var (
 				filterPlugin     = &FilterPlugin{}
+				scorePlugin      = &ScorePlugin{}
 				postFilterPlugin = &PostFilterPlugin{}
 			)
 			filterPlugin.rejectFilter = tt.rejectFilter
+			scorePlugin.failScore = tt.failScore
 			postFilterPlugin.rejectPostFilter = tt.rejectPostFilter
 			registry := frameworkruntime.Registry{
 				filterPluginName:     newPlugin(filterPlugin),
+				scorePluginName:      newPlugin(scorePlugin),
 				postfilterPluginName: newPostFilterPlugin(postFilterPlugin),
 			}
 
@@ -627,6 +659,16 @@ func TestPostFilterPlugin(t *testing.T) {
 					Filter: &schedulerconfig.PluginSet{
 						Enabled: []schedulerconfig.Plugin{
 							{Name: filterPluginName},
+						},
+					},
+					Score: &schedulerconfig.PluginSet{
+						Enabled: []schedulerconfig.Plugin{
+							{Name: scorePluginName},
+						},
+						// disable default in-tree Score plugins
+						// to make it easy to control configured ScorePlugins failure
+						Disabled: []schedulerconfig.Plugin{
+							{Name: "*"},
 						},
 					},
 					PostFilter: &schedulerconfig.PluginSet{
@@ -646,7 +688,7 @@ func TestPostFilterPlugin(t *testing.T) {
 			testCtx := initTestSchedulerForFrameworkTest(
 				t,
 				testutils.InitTestMaster(t, fmt.Sprintf("postfilter%v-", i), nil),
-				numNodes,
+				tt.numNodes,
 				scheduler.WithProfiles(prof),
 				scheduler.WithFrameworkOutOfTreeRegistry(registry),
 			)
@@ -662,8 +704,12 @@ func TestPostFilterPlugin(t *testing.T) {
 				if err = wait.Poll(10*time.Millisecond, 10*time.Second, podUnschedulable(testCtx.ClientSet, pod.Namespace, pod.Name)); err != nil {
 					t.Errorf("Didn't expect the pod to be scheduled.")
 				}
+
 				if filterPlugin.numFilterCalled < tt.expectFilterNumCalled {
 					t.Errorf("Expected the filter plugin to be called at least %v times, but got %v.", tt.expectFilterNumCalled, filterPlugin.numFilterCalled)
+				}
+				if numScoreCalled := atomic.LoadInt32(&scorePlugin.numScoreCalled); numScoreCalled < tt.expectScoreNumCalled {
+					t.Errorf("Expected the score plugin to be called at least %v times, but got %v.", tt.expectScoreNumCalled, numScoreCalled)
 				}
 				if postFilterPlugin.numPostFilterCalled < tt.expectPostFilterNumCalled {
 					t.Errorf("Expected the postfilter plugin to be called at least %v times, but got %v.", tt.expectPostFilterNumCalled, postFilterPlugin.numPostFilterCalled)
@@ -674,6 +720,9 @@ func TestPostFilterPlugin(t *testing.T) {
 				}
 				if filterPlugin.numFilterCalled != tt.expectFilterNumCalled {
 					t.Errorf("Expected the filter plugin to be called %v times, but got %v.", tt.expectFilterNumCalled, filterPlugin.numFilterCalled)
+				}
+				if numScoreCalled := atomic.LoadInt32(&scorePlugin.numScoreCalled); numScoreCalled != tt.expectScoreNumCalled {
+					t.Errorf("Expected the score plugin to be called %v times, but got %v.", tt.expectScoreNumCalled, numScoreCalled)
 				}
 				if postFilterPlugin.numPostFilterCalled != tt.expectPostFilterNumCalled {
 					t.Errorf("Expected the postfilter plugin to be called %v times, but got %v.", tt.expectPostFilterNumCalled, postFilterPlugin.numPostFilterCalled)

--- a/test/integration/scheduler/framework_test.go
+++ b/test/integration/scheduler/framework_test.go
@@ -797,7 +797,7 @@ func TestScorePlugin(t *testing.T) {
 				}
 			}
 
-			if scorePlugin.numScoreCalled == 0 {
+			if numScoreCalled := atomic.LoadInt32(&scorePlugin.numScoreCalled); numScoreCalled == 0 {
 				t.Errorf("Expected the score plugin to be called.")
 			}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature
/sig scheduling

**What this PR does / why we need it**:

As discussed in https://github.com/kubernetes/kubernetes/pull/90711#discussion_r424416139, adding `RunScorePlugins` into `PreemptHanlde`(though `PluginRunner` interface) can give out-of-tree plugins more flexibility to implement their preemption plugins, without reinventing existing Score algorithms.

I think just adding `RunScorePlugins` definitions in `PluginRunner` can achieve this.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Scheduling Framework: expose Run[Pre]ScorePlugins functions to PreemptionHandle which can be used in PostFilter extention point.
```
