### PR TITLE
Run verify-typecheck in serial to reduce memory usage

### DIFF
--- a/hack/verify-typecheck.sh
+++ b/hack/verify-typecheck.sh
@@ -35,7 +35,7 @@ make --no-print-directory -C "${KUBE_ROOT}" generated_files
 # force this tooling to run in a fake GOPATH.
 ret=0
 hack/run-in-gopath.sh \
-    go run test/typecheck/main.go "$@" || ret=$?
+    go run test/typecheck/main.go --serial "$@" || ret=$?
 if [[ $ret -ne 0 ]]; then
   echo "!!! Type Check has failed. This may cause cross platform build failures." >&2
   echo "!!! Please see https://git.k8s.io/kubernetes/test/typecheck for more information." >&2


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind failing-test

**What this PR does / why we need it**:

verify-typecheck is currently hitting memory limits in periodic CI jobs.
This changes it to run checks for each platform serially to reduce
memory usage at the expense of a slightly longer run time.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Ref: https://github.com/kubernetes/kubernetes/issues/93532

**Special notes for your reviewer**:

This was mostly based off local runs. It looks like when we have successful run this takes 2-3 minutes (ref: https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/ci-kubernetes-verify-master/1288169770910224385). Running serially should have a linear effect on duration while drastically reducing the required memory allocation for the `verify-*` jobs. It would be good to circle back here and see if running platform checks in parallel can be improved. Note also that `typecheck-dockerless` appears to experience a similar problem, but I wanted to test this out here before also running serially there.

/cc @BenTheElder @spiffxp @liggitt 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
