### PR TITLE
Remove special case for node e2e tests when expecting pod rejection

### DIFF
--- a/test/e2e/common/runtimeclass.go
+++ b/test/e2e/common/runtimeclass.go
@@ -97,16 +97,9 @@ func createRuntimeClass(f *framework.Framework, name, handler string) string {
 }
 
 func expectPodRejection(f *framework.Framework, pod *v1.Pod) {
-	// The Node E2E doesn't run the RuntimeClass admission controller, so we expect the rejection to
-	// happen by the Kubelet.
-	if framework.TestContext.NodeE2E {
-		pod = f.PodClient().Create(pod)
-		expectSandboxFailureEvent(f, pod, fmt.Sprintf("\"%s\" not found", *pod.Spec.RuntimeClassName))
-	} else {
-		_, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(context.TODO(), pod, metav1.CreateOptions{})
-		framework.ExpectError(err, "should be forbidden")
-		framework.ExpectEqual(apierrors.IsForbidden(err), true, "should be forbidden error")
-	}
+	_, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(context.TODO(), pod, metav1.CreateOptions{})
+	framework.ExpectError(err, "should be forbidden")
+	framework.ExpectEqual(apierrors.IsForbidden(err), true, "should be forbidden error")
 }
 
 // expectPodSuccess waits for the given pod to terminate successfully.


### PR DESCRIPTION
**What type of PR is this?**
/kind failing-test

**What this PR does / why we need it**:
See periodic e2e job: https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-kubernetes-e2enode-ubuntu1-k8sbeta-gkespec/1288587113490550786

The following two tests fail with error `pods \"test-runtimeclass-runtimeclass-9403-nonexistent-\" is forbidden: pod rejected: RuntimeClass \"runtimeclass-9403-nonexistent\" not found`:

* [sig-node] RuntimeClass should reject a Pod requesting a non-existent RuntimeClass
* [sig-node] RuntimeClass should reject a Pod requesting a deleted RuntimeClass

The problem is that this comment is no longer true:
```
	// The Node E2E doesn't run the RuntimeClass admission controller, so we expect the rejection to
	// happen by the Kubelet.
```

In a previous commit there was a [change made to include RuntimeClass in the enabled admission controllers for testing](https://github.com/kubernetes/kubernetes/commit/a4f8ee17ee5d5beb1efb2a28fa8466ed3ca70ad3).

Also, RuntimeClass is on by default (it looks like since 1.17)
https://github.com/kubernetes/kubernetes/blob/master/pkg/kubeapiserver/options/plugins.go#L160
https://github.com/kubernetes/kubernetes/blob/master/pkg/features/kube_features.go#L713

This PR removes the special case handling for `framework.TestContext.NodeE2E` which is no longer needed.

**Which issue(s) this PR fixes**:
No issue created

**Special notes for your reviewer**:
/cc @liggitt 

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs

```
