### PR TITLE
Add additional test cases for dualstack ip family validation

### DIFF
--- a/pkg/apis/core/validation/conditional_validation_test.go
+++ b/pkg/apis/core/validation/conditional_validation_test.go
@@ -461,6 +461,28 @@ func TestValidateServiceIPFamily(t *testing.T) {
 			},
 			expectErr: nil,
 		},
+		{
+			name:             "provided IP Family not in allowed list (IPv6)",
+			dualStackEnabled: true,
+			ipFamilies:       []api.IPFamily{api.IPv4Protocol},
+			svc: &api.Service{
+				Spec: api.ServiceSpec{
+					IPFamily: &ipv6,
+				},
+			},
+			expectErr: []string{"spec.ipFamily: Invalid value: \"IPv6\": only the following families are allowed: IPv4"},
+		},
+		{
+			name:             "provided IP Family not in allowed list (IPv4)",
+			dualStackEnabled: true,
+			ipFamilies:       []api.IPFamily{api.IPv6Protocol},
+			svc: &api.Service{
+				Spec: api.ServiceSpec{
+					IPFamily: &ipv4,
+				},
+			},
+			expectErr: []string{"spec.ipFamily: Invalid value: \"IPv4\": only the following families are allowed: IPv6"},
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind api-change
> /kind bug

 /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

I added two additional test case to the dualstack `ipFamily` validation to make it more clear that we also catch the case that users provide the wrong `ipFamily`. I stumbled over this here: https://github.com/kubernetes/kubernetes/issues/93509. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
