### PR TITLE
update running sample-controller command

### DIFF
--- a/staging/src/k8s.io/sample-controller/README.md
+++ b/staging/src/k8s.io/sample-controller/README.md
@@ -82,10 +82,6 @@ This is an example of how to build a kube-like controller with a single type.
 **Prerequisite**: Since the sample-controller uses `apps/v1` deployments, the Kubernetes cluster version should be greater than 1.9.
 
 ```sh
-# assumes you have a working kubeconfig, not required if operating in-cluster
-go build -o sample-controller .
-./sample-controller -kubeconfig=$HOME/.kube/config
-
 # create a CustomResourceDefinition
 kubectl create -f artifacts/examples/crd.yaml
 
@@ -94,6 +90,10 @@ kubectl create -f artifacts/examples/example-foo.yaml
 
 # check deployments created through the custom resource
 kubectl get deployments
+
+# assumes you have a working kubeconfig, not required if operating in-cluster
+go build -o sample-controller .
+./sample-controller -kubeconfig=$HOME/.kube/config
 ```
 
 ## Use Cases


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>

/kind bug
/kind documentation


**What this PR does / why we need it**:
yaml files need to be executed first
```
[root@node4 crd]# ./sample-controller -kubeconfig=$HOME/.kube/config
I0730 14:26:25.332001    7645 controller.go:115] Setting up event handlers
I0730 14:26:25.332112    7645 controller.go:156] Starting Foo controller
I0730 14:26:25.332122    7645 controller.go:159] Waiting for informer caches to sync
E0730 14:26:25.349064    7645 reflector.go:127] pkg/mod/k8s.io/client-go@v0.0.0-20200726131703-36233866f1c7/tools/cache/reflector.go:156: Failed to watch *v1alpha1.Foo: failed to list *v1alpha1.Foo: the server could not find the requested resource (get foos.samplecontroller.k8s.io)
E0730 14:26:26.634579    7645 reflector.go:127] pkg/mod/k8s.io/client-go@v0.0.0-20200726131703-36233866f1c7/tools/cache/reflector.go:156: Failed to watch *v1alpha1.Foo: failed to list *v1alpha1.Foo: the server could not find the requested resource (get foos.samplecontroller.k8s.io)
E0730 14:26:43.022170    7645 reflector.go:127] pkg/mod/k8s.io/client-go@v0.0.0-20200726131703-36233866f1c7/tools/cache/reflector.go:156: Failed to watch *v1alpha1.Foo: failed to list *v1alpha1.Foo: the server could not find the requested resource (get foos.samplecontroller.k8s.io)
^CF0730 14:26:43.809165    7645 main.go:75] Error running controller: failed to wait for caches to sync
```

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
