### PR TITLE
Fix the issue that hack/update-translations.sh does not work

### DIFF
--- a/hack/update-translations.sh
+++ b/hack/update-translations.sh
@@ -21,7 +21,7 @@
 KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 source "${KUBE_ROOT}/hack/lib/util.sh"
 
-KUBECTL_FILES="pkg/kubectl/cmd/*.go pkg/kubectl/cmd/*/*.go"
+kube::util::read-array KUBECTL_FILES < <(find pkg/kubectl/cmd -name "*.go")
 
 generate_pot="false"
 generate_mo="false"
@@ -36,7 +36,7 @@ while getopts "hf:xg" opt; do
       exit 0
       ;;
     f)
-      KUBECTL_FILES="${OPTARG}"
+      IFS=" " read -r -a KUBECTL_FILES <<< "${OPTARG}"
       ;;
     x)
       generate_pot="true"
@@ -65,7 +65,7 @@ fi
 
 if [[ "${generate_pot}" == "true" ]]; then
   echo "Extracting strings to POT"
-  go-xgettext -k=i18n.T "${KUBECTL_FILES}" > tmp.pot
+  go-xgettext -k=i18n.T "${KUBECTL_FILES[@]}" > tmp.pot
   perl -pi -e 's/CHARSET/UTF-8/' tmp.pot
   perl -pi -e 's/\\\(/\\\\\(/g' tmp.pot
   perl -pi -e 's/\\\)/\\\\\)/g' tmp.pot


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
`hack/update-translations.sh` does not work with the following message.
```
$ hack/update-translations.sh -x
Extracting strings to POT
panic: open pkg/kubectl/cmd/*.go pkg/kubectl/cmd/*/*.go: no such file or directory

goroutine 1 [running]:
main.processSingleGoSource(0xc0000200c0, 0x7ffc43d996da, 0x2b, 0xc0000104b0, 0x2)
        /home/user/go/src/github.com/gosexy/gettext/go-xgettext/main.go:226 +0x198
main.processFiles(0xc0000104c0, 0x1, 0x2, 0x3, 0x3)
        /home/user/go/src/github.com/gosexy/gettext/go-xgettext/main.go:215 +0xa9
main.main()
        /home/user/go/src/github.com/gosexy/gettext/go-xgettext/main.go:344 +0x139
No changes in generated bindata file: test/e2e/generated/bindata.go
Generated bindata file : staging/src/k8s.io/kubectl/pkg/generated/bindata.go has 20865 staging/src/k8s.io/kubectl/pkg/generated/bindata.go lines of lovely automated artifacts
```

I believe that this failure is caused by the following lines.

"hack/update-translations.sh"
```
KUBECTL_FILES="pkg/kubectl/cmd/*.go pkg/kubectl/cmd/*/*.go"
...
   go-xgettext -k=i18n.T "${KUBECTL_FILES}" > tmp.pot
```

`${KUBECTL_FILES}` is enclosed in double quotes, so it cannot extract the file list. This PR fixes it.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
