### PR TITLE
cloud provider: add zone/region to InstanceMetadata

### DIFF
--- a/staging/src/k8s.io/cloud-provider/cloud.go
+++ b/staging/src/k8s.io/cloud-provider/cloud.go
@@ -294,4 +294,15 @@ type InstanceMetadata struct {
 	// NodeAddress contains information for the instance's address.
 	// The node addresses returned here will be set on the node's status.addresses field.
 	NodeAddresses []v1.NodeAddress
+
+	// Zone is the zone that the instance is in.
+	// The value set here is applied as the following labels on the node:
+	//   * topology.kubernetes.io/zone=<zone>
+	//   * failure-domain.beta.kubernetes.io/zone=<zone> (DEPRECATED)
+	Zone string
+	// Region is the region that the instance is in.
+	// The value set here is applied as the following labels on the node:
+	//   * topology.kubernetes.io/region=<region>
+	//   * failure-domain.beta.kubernetes.io/region=<region> (DEPRECATED)
+	Region string
 }

--- a/staging/src/k8s.io/cloud-provider/fake/fake.go
+++ b/staging/src/k8s.io/cloud-provider/fake/fake.go
@@ -325,6 +325,8 @@ func (f *Cloud) InstanceMetadata(ctx context.Context, node *v1.Node) (*cloudprov
 		ProviderID:    node.Spec.ProviderID,
 		InstanceType:  f.InstanceTypes[types.NodeName(node.Spec.ProviderID)],
 		NodeAddresses: f.Addresses,
+		Zone:          f.Zone.FailureDomain,
+		Region:        f.Zone.Region,
 	}, f.Err
 }
 


### PR DESCRIPTION
Signed-off-by: Andrew Sy Kim <kim.andrewsy@gmail.com>

**What type of PR is this?**
/kind feature

The existing Zones interface was mainly created for the kubelet
to interface with a local metadata server to fetch a node's zone
and region. With external cloud providers, it makes more sense for
the zone/region logic to be coupled to the Instances interface.
This commit adds zone/region information to the recently added
InstanceMetadata type we're using as part of the new InstancesV2
interface in the cloud provider.

**What this PR does / why we need it**:
In most cases the zone/region information is contained in the "get instance" API call of a cloud provider. This change would reduce that extra call for zone/region in the cloud provider if the new instance v2 interface is enabled. 

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
