### PR TITLE
Mark componentstatus as deprecated

### DIFF
--- a/pkg/apis/core/types.go
+++ b/pkg/apis/core/types.go
@@ -5109,6 +5109,7 @@ type ComponentCondition struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // ComponentStatus (and ComponentStatusList) holds the cluster validation info.
+// Deprecated: This API is deprecated in v1.19+
 type ComponentStatus struct {
 	metav1.TypeMeta
 	// +optional
@@ -5121,6 +5122,7 @@ type ComponentStatus struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // ComponentStatusList represents the list of component statuses
+// Deprecated: This API is deprecated in v1.19+
 type ComponentStatusList struct {
 	metav1.TypeMeta
 	// +optional

--- a/staging/src/k8s.io/api/core/v1/BUILD
+++ b/staging/src/k8s.io/api/core/v1/BUILD
@@ -21,6 +21,7 @@ go_library(
         "annotation_key_constants.go",
         "doc.go",
         "generated.pb.go",
+        "lifecycle.go",
         "objectreference.go",
         "register.go",
         "resource.go",

--- a/staging/src/k8s.io/api/core/v1/generated.proto
+++ b/staging/src/k8s.io/api/core/v1/generated.proto
@@ -424,6 +424,7 @@ message ComponentCondition {
 }
 
 // ComponentStatus (and ComponentStatusList) holds the cluster validation info.
+// Deprecated: This API is deprecated in v1.19+
 message ComponentStatus {
   // Standard object's metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
@@ -438,6 +439,7 @@ message ComponentStatus {
 }
 
 // Status of all the conditions for the component as a list of ComponentStatus objects.
+// Deprecated: This API is deprecated in v1.19+
 message ComponentStatusList {
   // Standard list metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds

--- a/staging/src/k8s.io/api/core/v1/lifecycle.go
+++ b/staging/src/k8s.io/api/core/v1/lifecycle.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1
+
+// APILifecycleIntroduced returns the release in which the API struct was introduced as int versions of major and minor for comparison.
+func (in *ComponentStatus) APILifecycleIntroduced() (major, minor int) {
+	return 1, 0
+}
+
+// APILifecycleDeprecated returns the release in which the API struct was or will be deprecated as int versions of major and minor for comparison.
+func (in *ComponentStatus) APILifecycleDeprecated() (major, minor int) {
+	return 1, 19
+}
+
+// APILifecycleIntroduced returns the release in which the API struct was introduced as int versions of major and minor for comparison.
+func (in *ComponentStatusList) APILifecycleIntroduced() (major, minor int) {
+	return 1, 0
+}
+
+// APILifecycleDeprecated returns the release in which the API struct was or will be deprecated as int versions of major and minor for comparison.
+func (in *ComponentStatusList) APILifecycleDeprecated() (major, minor int) {
+	return 1, 19
+}

--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -5828,6 +5828,7 @@ type ComponentCondition struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // ComponentStatus (and ComponentStatusList) holds the cluster validation info.
+// Deprecated: This API is deprecated in v1.19+
 type ComponentStatus struct {
 	metav1.TypeMeta `json:",inline"`
 	// Standard object's metadata.
@@ -5845,6 +5846,7 @@ type ComponentStatus struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // Status of all the conditions for the component as a list of ComponentStatus objects.
+// Deprecated: This API is deprecated in v1.19+
 type ComponentStatusList struct {
 	metav1.TypeMeta `json:",inline"`
 	// Standard list metadata.

--- a/staging/src/k8s.io/api/core/v1/types_swagger_doc_generated.go
+++ b/staging/src/k8s.io/api/core/v1/types_swagger_doc_generated.go
@@ -230,7 +230,7 @@ func (ComponentCondition) SwaggerDoc() map[string]string {
 }
 
 var map_ComponentStatus = map[string]string{
-	"":           "ComponentStatus (and ComponentStatusList) holds the cluster validation info.",
+	"":           "ComponentStatus (and ComponentStatusList) holds the cluster validation info. Deprecated: This API is deprecated in v1.19+",
 	"metadata":   "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
 	"conditions": "List of component conditions observed",
 }
@@ -240,7 +240,7 @@ func (ComponentStatus) SwaggerDoc() map[string]string {
 }
 
 var map_ComponentStatusList = map[string]string{
-	"":         "Status of all the conditions for the component as a list of ComponentStatus objects.",
+	"":         "Status of all the conditions for the component as a list of ComponentStatus objects. Deprecated: This API is deprecated in v1.19+",
 	"metadata": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
 	"items":    "List of ComponentStatus objects.",
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind api-change
/kind deprecation

**What this PR does / why we need it**:
xref https://github.com/kubernetes/enhancements/issues/553#issuecomment-529591505 and  https://github.com/kubernetes/kubernetes/issues/19570

The current state of this API is problematic, and requires reversing the actual data flow (it requires the API server to call to its clients), and is not functional across deployment topologies.

Leaving it in place attracts new attempts to make additions to it (https://github.com/kubernetes/kubernetes/issues/74643, kubernetes/kubernetes#82247) and leads to confusion or bug reports for deployments that do not match its topology assumptions (https://github.com/kubernetes/kubernetes/issues/93342, https://github.com/kubernetes/kubernetes/issues/93472). It should be clearly marked as deprecated.

**Does this PR introduce a user-facing change?**:
```release-note
kube-apiserver: the componentstatus API is deprecated. This API provided status of etcd, kube-scheduler, and kube-controller-manager components, but only worked when those components were local to the API server, and when kube-scheduler and kube-controller-manager exposed unsecured health endpoints. Instead of this API, etcd health is included in the kube-apiserver health check and kube-scheduler/kube-controller-manager health checks can be made directly against those components' health endpoints.
```

/cc @deads2k @lavalamp @neolit123 
/sig api-machinery cluster-lifecycle