### PR TITLE
Document blocking behaviour of RunOrDie and Run

### DIFF
--- a/staging/src/k8s.io/client-go/tools/leaderelection/leaderelection.go
+++ b/staging/src/k8s.io/client-go/tools/leaderelection/leaderelection.go
@@ -193,7 +193,9 @@ type LeaderElector struct {
 	name string
 }
 
-// Run starts the leader election loop
+// Run starts the leader election loop. Run will not return
+// before leader election loop is stopped by ctx or it has
+// stopped holding the leader lease
 func (le *LeaderElector) Run(ctx context.Context) {
 	defer runtime.HandleCrash()
 	defer func() {
@@ -210,7 +212,8 @@ func (le *LeaderElector) Run(ctx context.Context) {
 }
 
 // RunOrDie starts a client with the provided config or panics if the config
-// fails to validate.
+// fails to validate. RunOrDie blocks until leader election loop is
+// stopped by ctx or it has stopped holding the leader lease
 func RunOrDie(ctx context.Context, lec LeaderElectionConfig) {
 	le, err := NewLeaderElector(lec)
 	if err != nil {


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
`RunOrDie` being a blocking function without mentioning might be confusing. 

`RunOrDie` starts a `LeaderElector` at https://github.com/kubernetes/kubernetes/blob/72a62bcade268183e7a1a5d40b4d2663c30507ed/staging/src/k8s.io/client-go/tools/leaderelection/leaderelection.go#L222 which will not return, blocking at https://github.com/kubernetes/kubernetes/blob/72a62bcade268183e7a1a5d40b4d2663c30507ed/staging/src/k8s.io/client-go/tools/leaderelection/leaderelection.go#L203 or at https://github.com/kubernetes/kubernetes/blob/72a62bcade268183e7a1a5d40b4d2663c30507ed/staging/src/k8s.io/client-go/tools/leaderelection/leaderelection.go#L209

If anyone need to avoid this blocking behaviour need to call `RunOrDie` in async mode with `go RunOrDie(...)`

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

Related to https://github.com/kubernetes/client-go/issues/837, cc: @liggitt 
