### PR TITLE
Limit typecheck parallelism by default

### DIFF
--- a/test/typecheck/main.go
+++ b/test/typecheck/main.go
@@ -38,7 +38,8 @@ var (
 	platforms  = flag.String("platform", "", "comma-separated list of platforms to typecheck")
 	timings    = flag.Bool("time", false, "output times taken for each phase")
 	defuses    = flag.Bool("defuse", false, "output defs/uses")
-	serial     = flag.Bool("serial", false, "don't type check platforms in parallel")
+	serial     = flag.Bool("serial", false, "don't type check platforms in parallel (equivalent to --parallel=1)")
+	parallel   = flag.Int("parallel", 4, "limits how many platforms can be checked in parallel. 0 means no limit.")
 	skipTest   = flag.Bool("skip-test", false, "don't type check test code")
 	tags       = flag.String("tags", "", "comma-separated list of build tags to apply in addition to go's defaults")
 	ignoreDirs = flag.String("ignore-dirs", "", "comma-separated list of directories to ignore in addition to the default hardcoded list including staging, vendor, and hidden dirs")
@@ -273,9 +274,24 @@ func main() {
 	var wg sync.WaitGroup
 	var failMu sync.Mutex
 	failed := false
+
+	if *serial {
+		*parallel = 1
+	} else if *parallel == 0 {
+		*parallel = len(plats)
+	}
+	throttle := make(chan int, *parallel)
+
 	for _, plat := range plats {
 		wg.Add(1)
-		fn := func(plat string) {
+		go func(plat string) {
+			// block until there's room for this task
+			throttle <- 1
+			defer func() {
+				// indicate this task is done
+				<-throttle
+			}()
+
 			f := false
 			serialFprintf(os.Stdout, "type-checking %s\n", plat)
 			errors, err := c.verify(plat)
@@ -295,12 +311,7 @@ func main() {
 			failed = failed || f
 			failMu.Unlock()
 			wg.Done()
-		}
-		if *serial {
-			fn(plat)
-		} else {
-			go fn(plat)
-		}
+		}(plat)
 	}
 	wg.Wait()
 	if failed {


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

typecheck currently uses ~5GB of memory per platform check. This limits the parallel checks by default so we don't require ~50GB of memory to run this job and adds a parallel option to tune that further.

Alternative to https://github.com/kubernetes/kubernetes/pull/93544

Fixes #93532

```release-note
NONE
```

/cc @hasheddan @BenTheElder 