### PR TITLE
Fix verify-typecheck-providerless

### DIFF
--- a/cmd/cloud-controller-manager/BUILD
+++ b/cmd/cloud-controller-manager/BUILD
@@ -16,7 +16,10 @@ go_binary(
 
 go_library(
     name = "go_default_library",
-    srcs = ["controller-manager.go"],
+    srcs = [
+        "controller-manager.go",
+        "providers.go",
+    ],
     importpath = "k8s.io/kubernetes/cmd/cloud-controller-manager",
     deps = [
         "//cmd/cloud-controller-manager/app:go_default_library",

--- a/cmd/cloud-controller-manager/controller-manager.go
+++ b/cmd/cloud-controller-manager/controller-manager.go
@@ -27,15 +27,8 @@ import (
 	"k8s.io/component-base/logs"
 	"k8s.io/kubernetes/cmd/cloud-controller-manager/app"
 
-	_ "k8s.io/component-base/metrics/prometheus/version" // for version metric registration
-	// NOTE: Importing all in-tree cloud-providers is not required when
-	// implementing an out-of-tree cloud-provider.
 	_ "k8s.io/component-base/metrics/prometheus/clientgo" // load all the prometheus client-go plugins
-	_ "k8s.io/legacy-cloud-providers/aws"
-	_ "k8s.io/legacy-cloud-providers/azure"
-	_ "k8s.io/legacy-cloud-providers/gce"
-	_ "k8s.io/legacy-cloud-providers/openstack"
-	_ "k8s.io/legacy-cloud-providers/vsphere"
+	_ "k8s.io/component-base/metrics/prometheus/version"  // for version metric registration
 )
 
 func main() {

--- a/cmd/cloud-controller-manager/providers.go
+++ b/cmd/cloud-controller-manager/providers.go
@@ -1,7 +1,7 @@
 // +build !providerless
 
 /*
-Copyright 2019 The Kubernetes Authors.
+Copyright 2020 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -16,10 +16,17 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package cloudprovider
+// The external controller manager is responsible for running controller loops that
+// are cloud provider dependent. It uses the API to listen to new events on resources.
+
+package main
 
 import (
-	// transitive test dependencies are not vendored by go modules
-	// so we have to explicitly import them here
-	_ "k8s.io/legacy-cloud-providers/vsphere/testing"
+	// NOTE: Importing all in-tree cloud-providers is not required when
+	// implementing an out-of-tree cloud-provider.
+	_ "k8s.io/legacy-cloud-providers/aws"
+	_ "k8s.io/legacy-cloud-providers/azure"
+	_ "k8s.io/legacy-cloud-providers/gce"
+	_ "k8s.io/legacy-cloud-providers/openstack"
+	_ "k8s.io/legacy-cloud-providers/vsphere"
 )

--- a/pkg/controller/nodeipam/node_ipam_controller_test.go
+++ b/pkg/controller/nodeipam/node_ipam_controller_test.go
@@ -1,3 +1,5 @@
+// +build !providerless
+
 /*
 Copyright 2018 The Kubernetes Authors.
 
@@ -23,7 +25,7 @@ import (
 	"strings"
 	"testing"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"

--- a/pkg/credentialprovider/azure/BUILD
+++ b/pkg/credentialprovider/azure/BUILD
@@ -11,6 +11,7 @@ go_library(
     srcs = [
         "azure_acr_helper.go",
         "azure_credentials.go",
+        "doc.go",
     ],
     importpath = "k8s.io/kubernetes/pkg/credentialprovider/azure",
     deps = [

--- a/pkg/credentialprovider/azure/azure_acr_helper.go
+++ b/pkg/credentialprovider/azure/azure_acr_helper.go
@@ -1,3 +1,5 @@
+// +build !providerless
+
 /*
 Copyright 2016 The Kubernetes Authors.
 

--- a/pkg/credentialprovider/azure/azure_credentials.go
+++ b/pkg/credentialprovider/azure/azure_credentials.go
@@ -1,3 +1,5 @@
+// +build !providerless
+
 /*
 Copyright 2016 The Kubernetes Authors.
 

--- a/pkg/credentialprovider/azure/azure_credentials_test.go
+++ b/pkg/credentialprovider/azure/azure_credentials_test.go
@@ -1,3 +1,5 @@
+// +build !providerless
+
 /*
 Copyright 2016 The Kubernetes Authors.
 

--- a/pkg/credentialprovider/azure/doc.go
+++ b/pkg/credentialprovider/azure/doc.go
@@ -1,7 +1,5 @@
-// +build !providerless
-
 /*
-Copyright 2019 The Kubernetes Authors.
+Copyright 2020 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -16,10 +14,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package cloudprovider
-
-import (
-	// transitive test dependencies are not vendored by go modules
-	// so we have to explicitly import them here
-	_ "k8s.io/legacy-cloud-providers/vsphere/testing"
-)
+package azure

--- a/test/typecheck/main.go
+++ b/test/typecheck/main.go
@@ -297,6 +297,7 @@ func main() {
 			errors, err := c.verify(plat)
 			if err != nil {
 				serialFprintf(os.Stderr, "ERROR(%s): failed to verify: %v\n", plat, err)
+				f = true
 			} else if len(errors) > 0 {
 				for _, e := range errors {
 					// Special case CGo errors which may depend on headers we


### PR DESCRIPTION
**What type of PR is this?**
/kind failing-test

**What this PR does / why we need it**:
* Fixes errors in the verify-typecheck-providerless job
* Partitions provider imports to build-tagged files
* Catch errors encountered loading packages

**Which issue(s) this PR fixes**:
Fixes #93574 

```release-note
NONE
```