### PR TITLE
kubeproxy: migrate WriteConfigTo flag to configfile option

### DIFF
--- a/cmd/kube-proxy/app/server.go
+++ b/cmd/kube-proxy/app/server.go
@@ -143,7 +143,7 @@ func (o *Options) AddFlags(fs *pflag.FlagSet) {
 	o.addOSFlags(fs)
 
 	fs.StringVar(&o.ConfigFile, "config", o.ConfigFile, "The path to the configuration file.")
-	fs.StringVar(&o.WriteConfigTo, "write-config-to", o.WriteConfigTo, "If set, write the default configuration values to this file and exit.")
+	fs.StringVar(&o.config.WriteConfigTo, "write-config-to", o.config.WriteConfigTo, "If set, write the default configuration values to this file and exit.")
 	fs.StringVar(&o.config.ClientConnection.Kubeconfig, "kubeconfig", o.config.ClientConnection.Kubeconfig, "Path to kubeconfig file with authorization information (the master location can be overridden by the master flag).")
 	fs.StringVar(&o.config.ClusterCIDR, "cluster-cidr", o.config.ClusterCIDR, "The CIDR range of pods in the cluster. When configured, traffic sent to a Service cluster IP from outside this range will be masqueraded and traffic sent from pods to an external LoadBalancer IP will be directed to the respective cluster IP instead")
 	fs.StringVar(&o.config.ClientConnection.ContentType, "kube-api-content-type", o.config.ClientConnection.ContentType, "Content type of requests sent to apiserver.")
@@ -222,8 +222,8 @@ func NewOptions() *Options {
 
 // Complete completes all the required options.
 func (o *Options) Complete() error {
-	if len(o.ConfigFile) == 0 && len(o.WriteConfigTo) == 0 {
-		klog.Warning("WARNING: all flags other than --config, --write-config-to, and --cleanup are deprecated. Please begin using a config file ASAP.")
+	if len(o.ConfigFile) == 0 {
+		klog.Warning("WARNING: all flags other than --config and --cleanup are deprecated. Please begin using a config file ASAP.")
 		o.config.HealthzBindAddress = addressFromDeprecatedFlags(o.config.HealthzBindAddress, o.healthzPort)
 		o.config.MetricsBindAddress = addressFromDeprecatedFlags(o.config.MetricsBindAddress, o.metricsPort)
 	}
@@ -305,7 +305,7 @@ func (o *Options) Validate() error {
 // Run runs the specified ProxyServer.
 func (o *Options) Run() error {
 	defer close(o.errCh)
-	if len(o.WriteConfigTo) > 0 {
+	if len(o.config.WriteConfigTo) > 0 {
 		return o.writeConfigFile()
 	}
 
@@ -352,7 +352,7 @@ func (o *Options) writeConfigFile() (err error) {
 
 	encoder := proxyconfigscheme.Codecs.EncoderForVersion(info.Serializer, v1alpha1.SchemeGroupVersion)
 
-	configFile, err := os.Create(o.WriteConfigTo)
+	configFile, err := os.Create(o.config.WriteConfigTo)
 	if err != nil {
 		return err
 	}
@@ -368,7 +368,7 @@ func (o *Options) writeConfigFile() (err error) {
 		return err
 	}
 
-	klog.Infof("Wrote configuration to: %s\n", o.WriteConfigTo)
+	klog.Infof("Wrote configuration to: %s\n", o.config.WriteConfigTo)
 
 	return nil
 }

--- a/pkg/proxy/apis/config/scheme/testdata/KubeProxyConfiguration/after/v1alpha1.yaml
+++ b/pkg/proxy/apis/config/scheme/testdata/KubeProxyConfiguration/after/v1alpha1.yaml
@@ -44,3 +44,4 @@ winkernel:
   enableDSR: false
   networkName: ""
   sourceVip: ""
+writeConfigTo: ""

--- a/pkg/proxy/apis/config/scheme/testdata/KubeProxyConfiguration/roundtrip/default/v1alpha1.yaml
+++ b/pkg/proxy/apis/config/scheme/testdata/KubeProxyConfiguration/roundtrip/default/v1alpha1.yaml
@@ -44,3 +44,4 @@ winkernel:
   enableDSR: false
   networkName: ""
   sourceVip: ""
+writeConfigTo: ""

--- a/pkg/proxy/apis/config/types.go
+++ b/pkg/proxy/apis/config/types.go
@@ -168,6 +168,7 @@ type KubeProxyConfiguration struct {
 	ShowHiddenMetricsForVersion string
 	// DetectLocalMode determines mode to use for detecting local traffic, defaults to LocalModeClusterCIDR
 	DetectLocalMode LocalMode
+	WriteConfigTo   string
 }
 
 // Currently, three modes of proxy are available in Linux platform: 'userspace' (older, going to be EOL), 'iptables'

--- a/pkg/proxy/apis/config/v1alpha1/zz_generated.conversion.go
+++ b/pkg/proxy/apis/config/v1alpha1/zz_generated.conversion.go
@@ -123,6 +123,7 @@ func autoConvert_v1alpha1_KubeProxyConfiguration_To_config_KubeProxyConfiguratio
 	}
 	out.ShowHiddenMetricsForVersion = in.ShowHiddenMetricsForVersion
 	out.DetectLocalMode = config.LocalMode(in.DetectLocalMode)
+	out.WriteConfigTo = in.WriteConfigTo
 	return nil
 }
 
@@ -163,6 +164,7 @@ func autoConvert_config_KubeProxyConfiguration_To_v1alpha1_KubeProxyConfiguratio
 	}
 	out.ShowHiddenMetricsForVersion = in.ShowHiddenMetricsForVersion
 	out.DetectLocalMode = v1alpha1.LocalMode(in.DetectLocalMode)
+	out.WriteConfigTo = in.WriteConfigTo
 	return nil
 }
 

--- a/staging/src/k8s.io/kube-proxy/config/v1alpha1/types.go
+++ b/staging/src/k8s.io/kube-proxy/config/v1alpha1/types.go
@@ -164,6 +164,8 @@ type KubeProxyConfiguration struct {
 	ShowHiddenMetricsForVersion string `json:"showHiddenMetricsForVersion"`
 	// DetectLocalMode determines mode to use for detecting local traffic, defaults to LocalModeClusterCIDR
 	DetectLocalMode LocalMode `json:"detectLocalMode"`
+	// WriteConfigTo if set, write the default configuration values to this file and exit
+	WriteConfigTo string `json:"writeConfigTo"`
 }
 
 // Currently, three modes of proxy are available in Linux platform: 'userspace' (older, going to be EOL), 'iptables'


### PR DESCRIPTION

Signed-off-by: Christopher M. Luciano <cmluciano@us.ibm.com>

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
This change moves the WriteConfigTo flag to the kube-proxy
configuration file.

**Which issue(s) this PR fixes**:
xref #86024

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
