### PR TITLE
Clean up daemonset test names

### DIFF
--- a/test/integration/daemonset/daemonset_test.go
+++ b/test/integration/daemonset/daemonset_test.go
@@ -416,7 +416,7 @@ func updateDS(t *testing.T, dsClient appstyped.DaemonSetInterface, dsName string
 
 func forEachStrategy(t *testing.T, tf func(t *testing.T, strategy *apps.DaemonSetUpdateStrategy)) {
 	for _, strategy := range updateStrategies() {
-		t.Run(fmt.Sprintf("%s (%v)", t.Name(), strategy),
+		t.Run(fmt.Sprintf("%s_%s", t.Name(), strategy.Type),
 			func(tt *testing.T) { tf(tt, strategy) })
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
/priority backlog
/sig apps
/milestone v1.20

**What this PR does / why we need it**:

Avoids test names like `TestUnschedulableNodeDaemonDoesLaunchPod/TestUnschedulableNodeDaemonDoesLaunchPod_(&DaemonSetUpdateStrategy{Type:OnDelete,RollingUpdate:nil,})`

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```