### PR TITLE
Fix panic on /readyz

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/healthz/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/server/healthz/BUILD
@@ -11,6 +11,7 @@ go_test(
     srcs = ["healthz_test.go"],
     embed = [":go_default_library"],
     deps = [
+        "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/endpoints/metrics:go_default_library",
         "//staging/src/k8s.io/component-base/metrics/legacyregistry:go_default_library",
@@ -31,7 +32,6 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/endpoints/metrics:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/server/httplog:go_default_library",
-        "//staging/src/k8s.io/client-go/informers:go_default_library",
         "//vendor/k8s.io/klog/v2:go_default_library",
     ],
 )

--- a/staging/src/k8s.io/apiserver/pkg/server/healthz/healthz.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/healthz/healthz.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"fmt"
 	"net/http"
+	"reflect"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -29,7 +30,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apiserver/pkg/endpoints/metrics"
 	"k8s.io/apiserver/pkg/server/httplog"
-	"k8s.io/client-go/informers"
 	"k8s.io/klog/v2"
 )
 
@@ -82,16 +82,20 @@ func (l *log) Check(_ *http.Request) error {
 	return fmt.Errorf("logging blocked")
 }
 
+type cacheSyncWaiter interface {
+	WaitForCacheSync(stopCh <-chan struct{}) map[reflect.Type]bool
+}
+
 type informerSync struct {
-	sharedInformerFactory informers.SharedInformerFactory
+	cacheSyncWaiter cacheSyncWaiter
 }
 
 var _ HealthChecker = &informerSync{}
 
-// NewInformerSyncHealthz returns a new HealthChecker that will pass only if all informers in the given sharedInformerFactory sync.
-func NewInformerSyncHealthz(sharedInformerFactory informers.SharedInformerFactory) HealthChecker {
+// NewInformerSyncHealthz returns a new HealthChecker that will pass only if all informers in the given cacheSyncWaiter sync.
+func NewInformerSyncHealthz(cacheSyncWaiter cacheSyncWaiter) HealthChecker {
 	return &informerSync{
-		sharedInformerFactory: sharedInformerFactory,
+		cacheSyncWaiter: cacheSyncWaiter,
 	}
 }
 
@@ -104,8 +108,8 @@ func (i *informerSync) Check(_ *http.Request) error {
 	// Close stopCh to force checking if informers are synced now.
 	close(stopCh)
 
-	var informersByStarted map[bool][]string
-	for informerType, started := range i.sharedInformerFactory.WaitForCacheSync(stopCh) {
+	informersByStarted := make(map[bool][]string)
+	for informerType, started := range i.cacheSyncWaiter.WaitForCacheSync(stopCh) {
 		informersByStarted[started] = append(informersByStarted[started], informerType.String())
 	}
 

--- a/staging/src/k8s.io/apiserver/pkg/server/healthz/healthz_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/healthz/healthz_test.go
@@ -26,6 +26,7 @@ import (
 	"strings"
 	"testing"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apiserver/pkg/endpoints/metrics"
 	"k8s.io/component-base/metrics/legacyregistry"
@@ -272,4 +273,44 @@ func createGetRequestWithUrl(rawUrlString string) *http.Request {
 		Proto:  "HTTP/1.1",
 		URL:    url,
 	}
+}
+
+func TestInformerSyncHealthChecker(t *testing.T) {
+	t.Run("test that check returns nil when all informers are started", func(t *testing.T) {
+		healthChecker := NewInformerSyncHealthz(cacheSyncWaiterStub{
+			startedByInformerType: map[reflect.Type]bool{
+				reflect.TypeOf(corev1.Pod{}): true,
+			},
+		})
+
+		err := healthChecker.Check(nil)
+		if err != nil {
+			t.Errorf("Got %v, expected no error", err)
+		}
+	})
+
+	t.Run("test that check returns err when there is not started informer", func(t *testing.T) {
+		healthChecker := NewInformerSyncHealthz(cacheSyncWaiterStub{
+			startedByInformerType: map[reflect.Type]bool{
+				reflect.TypeOf(corev1.Pod{}):     true,
+				reflect.TypeOf(corev1.Service{}): false,
+				reflect.TypeOf(corev1.Node{}):    true,
+			},
+		})
+
+		err := healthChecker.Check(nil)
+		if err == nil {
+			t.Errorf("expected error, got: %v", err)
+		}
+	})
+}
+
+type cacheSyncWaiterStub struct {
+	startedByInformerType map[reflect.Type]bool
+}
+
+// WaitForCacheSync is a stub implementation of the corresponding func
+// that simply returns the value passed during stub initialization.
+func (s cacheSyncWaiterStub) WaitForCacheSync(_ <-chan struct{}) map[reflect.Type]bool {
+	return s.startedByInformerType
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug
/kind regression

**What this PR does / why we need it**:
Fix /readyz panic caused by `assignment to entry in nil map`.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #93599

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
A panic in the apiserver caused by the `informer-sync` health checker is now fixed.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
