### PR TITLE
Remove golang.org exception for preferring latest minimal version

### DIFF
--- a/hack/lint-dependencies.sh
+++ b/hack/lint-dependencies.sh
@@ -38,26 +38,6 @@ fi
 kube::golang::verify_go_version
 kube::util::require-jq
 
-case "${1:-}" in
-"--all")
-  echo "Checking all dependencies"
-  filter=''
-  ;;
-"-a")
-  echo "Checking all dependencies"
-  filter=''
-  ;;
-"")
-  # by default, skip checking golang.org/x/... dependencies... we pin to levels that match our go version for those
-  echo "Skipping golang.org/x/... dependencies, pass --all to include"
-  filter='select(.Path | startswith("golang.org/x/") | not) |'
-  ;;
-*)
-  kube::log::error "Unrecognized arg: ${1}"
-  exit 1
-  ;;
-esac
-
 # let us log all errors before we exit
 rc=0
 
@@ -78,7 +58,6 @@ done
 outdated=$(go list -m -json all | jq -r "
   select(.Replace.Version != null) |
   select(.Version != .Replace.Version) |
-  ${filter}
   select(.Path) |
   \"\(.Path)
     pinned:    \(.Replace.Version)


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Removes the golang.org exception for preferring the latest minimal version, per https://github.com/kubernetes/kubernetes/pull/93264#issuecomment-663933730

```release-note
NONE
```

/cc @justaugustus 