### PR TITLE
Stop ignoring unit test flakes

### DIFF
--- a/build/root/.bazelrc
+++ b/build/root/.bazelrc
@@ -28,7 +28,7 @@ test:unit --features=race
 
 test:unit --build_tests_only
 test:unit --test_tag_filters=-e2e,-integration
-test:unit --flaky_test_attempts=3
+test:unit --runs_per_test=3
 
 test:integration --local_test_jobs 4
 test:integration --test_tag_filters=integration


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

* Stops ignoring unit test flakes. They mask real test issues and bugs.
* Increases the number of times a test must pass from 1/3 to 3

Flakes and bugs found via this PR:

Fixed + merged:
- [x] Make toKubeContainerImageSpec deterministic - #93610
- [x] Test_NodesDeleted data race - https://github.com/kubernetes/kubernetes/pull/93605#issuecomment-667407692, https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/93605/pull-kubernetes-bazel-test/1289323742211608581 - https://github.com/kubernetes/kubernetes/pull/93619
- [x] CSR fuzzing did not match defaulting - https://github.com/kubernetes/kubernetes/pull/93614
- [x] TestControllerSync - https://github.com/kubernetes/kubernetes/pull/93605#issuecomment-667428441, https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/93605/pull-kubernetes-bazel-test/1289323742211608581 - https://github.com/kubernetes/kubernetes/pull/93655
- [x] Daemonset controller failing consistently - https://github.com/kubernetes/kubernetes/issues/93604 / https://github.com/kubernetes/kubernetes/pull/93617
- [x] TestUpdateNodeStatusWithLease race - https://github.com/kubernetes/kubernetes/pull/93605#issuecomment-668141263 - https://github.com/kubernetes/kubernetes/issues/93715, https://github.com/kubernetes/kubernetes/pull/93717
- [x] TestEnsureBackendPoolDeletedConcurrently race - https://github.com/kubernetes/kubernetes/pull/93846
- [x] timeout on //pkg/scheduler - TestSchedulerMultipleProfilesScheduling - https://github.com/kubernetes/kubernetes/pull/93605#issuecomment-668127993, fixed in https://github.com/kubernetes/kubernetes/pull/93893
- [x] TestWatchHTTPTimeout - https://github.com/kubernetes/kubernetes/pull/93605#issuecomment-668332578 - https://github.com/kubernetes/kubernetes/issues/93891, fixed in https://github.com/kubernetes/kubernetes/pull/93895
- [x] (bug) TestPluginRegistration timeout - https://github.com/kubernetes/kubernetes/pull/93605#issuecomment-667316127 - #93622
- [x] [TestServiceRegistryUpdateDryRun](https://github.com/kubernetes/kubernetes/pull/93605#issuecomment-668142138) - https://github.com/kubernetes/kubernetes/issues/93899, https://github.com/kubernetes/kubernetes/pull/93906
- [x] node - TestRemoveContainer - https://github.com/kubernetes/kubernetes/issues/94194, https://github.com/kubernetes/kubernetes/pull/94185
- [x] network - TestSyncEndpoints, https://github.com/kubernetes/kubernetes/pull/94214
- [x] sig-node - TestInvalidPodFiltered, https://github.com/kubernetes/kubernetes/issues/93905, https://github.com/kubernetes/kubernetes/pull/93985
- [x] sig-network - TestTCPProxyUpdateDeleteUpdate, https://github.com/kubernetes/kubernetes/issues/93904, https://github.com/kubernetes/kubernetes/pull/93979
- [x] sig-storage - [TestAttacherWithCSIDriver](https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/93605/pull-kubernetes-bazel-test/1293963409628336128), https://github.com/kubernetes/kubernetes/issues/93970, https://github.com/kubernetes/kubernetes/pull/94031
- [x] sig-network (bug) - [TestServiceRegistryExternalTrafficHealthCheckNodePortUserAllocation](https://github.com/kubernetes/kubernetes/pull/93605#issuecomment-668141670), https://github.com/kubernetes/kubernetes/pull/94488, https://github.com/kubernetes/kubernetes/pull/93922
- [x] cmd/kube-scheduler/app: TestSetup - @liggitt, https://github.com/kubernetes/kubernetes/pull/94529
- [x] pkg/probe/http: TestHTTPProbeProxy - @liggitt, https://github.com/kubernetes/kubernetes/pull/94529
- [x] k8s.io/apiserver/pkg/server/filters: TestClientReceivedGOAWAY, TestGOAWAYConcurrency - @knight42 , https://github.com/kubernetes/kubernetes/pull/94530, https://github.com/kubernetes/kubernetes/pull/94529
- [x] [pkg/util/iptables](https://testgrid.k8s.io/sig-release-master-blocking#bazel-test-master&width=20&sort-by-name=&include-filter-by-regex=pkg/util/iptables) - TestRestoreAllGrabOldLock, @knight42, https://github.com/kubernetes/kubernetes/pull/94534
- [x] [k8s.io/apiserver/pkg/server/options](https://testgrid.k8s.io/sig-release-master-blocking#bazel-test-master&width=20&sort-by-name=&include-filter-by-regex=k8s.io/apiserver/pkg/server/options/go), @liggitt, https://github.com/kubernetes/kubernetes/pull/94544
- [x] [pkg/kubelet/cm/devicemanager](https://testgrid.k8s.io/sig-release-master-blocking#bazel-test-master&width=20&sort-by-name=&include-filter-by-regex=pkg/kubelet/cm/devicemanager) - @liggitt, https://github.com/kubernetes/kubernetes/pull/94539
- [x] [pkg/client/tests](https://testgrid.k8s.io/sig-release-master-blocking#bazel-test-master&width=20&sort-by-name=&include-filter-by-regex=pkg/client/tests) - @liggitt, https://github.com/kubernetes/kubernetes/pull/94543
- [x] [pkg/kubelet/cm/cpumanager/state](https://testgrid.k8s.io/sig-release-master-blocking#bazel-test-master&width=20&sort-by-name=&include-filter-by-regex=pkg/kubelet/cm/cpumanager/state), @liggitt, https://github.com/kubernetes/kubernetes/pull/94541
- [x] [cmd/kubeadm/app/phases/upgrade](https://testgrid.k8s.io/sig-release-master-blocking#bazel-test-master&width=20&sort-by-name=&include-filter-by-regex=cmd/kubeadm/app/phases/upgrade) - @liggitt, https://github.com/kubernetes/kubernetes/pull/94535
- [x] bug - [k8s.io/legacy-cloud-providers/azure/cache](https://testgrid.k8s.io/sig-release-master-blocking#bazel-test-master&width=20&sort-by-name=&include-filter-by-regex=k8s.io/legacy-cloud-providers/azure/cache) - @knight42, https://github.com/kubernetes/kubernetes/pull/94537
- [x] [k8s.io/client-go/tools/watch](https://testgrid.k8s.io/sig-release-master-blocking#bazel-test-master&width=20&sort-by-name=&include-filter-by-regex=k8s.io/client-go/tools/watch/go), @knight42, https://github.com/kubernetes/kubernetes/pull/94554
- [x] [pkg/kubelet/kuberuntime](https://testgrid.k8s.io/sig-release-master-blocking#bazel-test-master&width=20&sort-by-name=&include-filter-by-regex=pkg/kubelet/kuberuntime), @knight42, https://github.com/kubernetes/kubernetes/pull/94549
- [x] [k8s.io/client-go/util/workqueue](https://testgrid.k8s.io/sig-release-master-blocking#bazel-test-master&width=20&sort-by-name=&include-filter-by-regex=k8s.io/client-go/util/workqueue), @knight42, #94545, https://github.com/kubernetes/kubernetes/pull/94556
- [x] [pkg/util/iptables](https://testgrid.k8s.io/sig-release-master-blocking#bazel-test-master&width=20&sort-by-name=&include-filter-by-regex=pkg/util/iptables) - TestRestoreAllWaitOldIptablesRestore, @knight42, https://github.com/kubernetes/kubernetes/pull/94553
- [x] [pkg/kubelet/cm/devicemanager](https://testgrid.k8s.io/sig-release-master-blocking#bazel-test-master&width=20&sort-by-name=&include-filter-by-regex=pkg/kubelet/cm/devicemanager) - TestDevicePluginReRegistrationProbeMode #94547 https://github.com/kubernetes/kubernetes/pull/96048


Unresolved flakes:
- [ ] [k8s.io/client-go/tools/events](https://testgrid.k8s.io/sig-release-master-blocking#bazel-test-master&width=20&sort-by-name=&include-filter-by-regex=k8s.io/client-go/tools/events/go)
- [ ] [pkg/kubelet/volumemanager/reconciler](https://testgrid.k8s.io/sig-release-master-blocking#bazel-test-master&width=20&sort-by-name=&include-filter-by-regex=pkg/kubelet/volumemanager/reconciler/go)
- [ ] [k8s.io/legacy-cloud-providers/vsphere](https://testgrid.k8s.io/sig-release-master-blocking#bazel-test-master&width=20&sort-by-name=&include-filter-by-regex=k8s.io/legacy-cloud-providers/vsphere/go)
- [ ] [pkg/kubelet/config](https://testgrid.k8s.io/sig-release-master-blocking#bazel-test-master&width=20&sort-by-name=&include-filter-by-regex=pkg/kubelet/config)
- [ ] [pkg/controller/volume/attachdetach/reconciler](https://testgrid.k8s.io/sig-release-master-blocking#bazel-test-master&width=20&sort-by-name=&include-filter-by-regex=pkg/controller/volume/attachdetach/reconciler)

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

cc @kubernetes/sig-testing 
