### PR TITLE
Fix providerless kubelet startup

### DIFF
--- a/cmd/kubelet/app/options/BUILD
+++ b/cmd/kubelet/app/options/BUILD
@@ -13,6 +13,7 @@ go_library(
         "globalflags.go",
         "globalflags_linux.go",
         "globalflags_other.go",
+        "globalflags_providers.go",
         "options.go",
         "osflags_others.go",
         "osflags_windows.go",

--- a/cmd/kubelet/app/options/globalflags.go
+++ b/cmd/kubelet/app/options/globalflags.go
@@ -84,9 +84,7 @@ func addCredentialProviderFlags(fs *pflag.FlagSet) {
 	global := pflag.CommandLine
 	local := pflag.NewFlagSet(os.Args[0], pflag.ExitOnError)
 
-	// TODO(#58034): This is not a static file, so it's not quite as straightforward as --google-json-key.
-	// We need to figure out how ACR users can dynamically provide pull credentials before we can deprecate this.
-	pflagRegister(global, local, "azure-container-registry-config")
+	addLegacyCloudProviderCredentialProviderFlags(global, local)
 
 	fs.AddFlagSet(local)
 }

--- a/cmd/kubelet/app/options/globalflags_providerless.go
+++ b/cmd/kubelet/app/options/globalflags_providerless.go
@@ -1,0 +1,27 @@
+// +build providerless
+
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package options
+
+import (
+	"github.com/spf13/pflag"
+)
+
+func addLegacyCloudProviderCredentialProviderFlags(global, local *pflag.FlagSet) {
+	// no-op when no legacy providers are compiled in
+}

--- a/cmd/kubelet/app/options/globalflags_providers.go
+++ b/cmd/kubelet/app/options/globalflags_providers.go
@@ -1,0 +1,29 @@
+// +build !providerless
+
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package options
+
+import (
+	"github.com/spf13/pflag"
+)
+
+func addLegacyCloudProviderCredentialProviderFlags(global, local *pflag.FlagSet) {
+	// TODO(#58034): This is not a static file, so it's not quite as straightforward as --google-json-key.
+	// We need to figure out how ACR users can dynamically provide pull credentials before we can deprecate this.
+	pflagRegister(global, local, "azure-container-registry-config")
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Follow up from https://github.com/kubernetes/kubernetes/pull/93579

That PR made the registration of the azure flags conditional (excluded in providerless builds), but the kubelet assumed the flag would be available when registering credential provider flags.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/cc @BenTheElder @aojea 