### PR TITLE
Make toKubeContainerImageSpec deterministic

### DIFF
--- a/pkg/kubelet/kuberuntime/convert.go
+++ b/pkg/kubelet/kuberuntime/convert.go
@@ -17,6 +17,8 @@ limitations under the License.
 package kuberuntime
 
 import (
+	"sort"
+
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 )
@@ -26,11 +28,16 @@ import (
 func toKubeContainerImageSpec(image *runtimeapi.Image) kubecontainer.ImageSpec {
 	var annotations []kubecontainer.Annotation
 
-	if image.Spec != nil && image.Spec.Annotations != nil {
-		for k, v := range image.Spec.Annotations {
+	if image.Spec != nil && len(image.Spec.Annotations) > 0 {
+		annotationKeys := make([]string, 0, len(image.Spec.Annotations))
+		for k := range image.Spec.Annotations {
+			annotationKeys = append(annotationKeys, k)
+		}
+		sort.Strings(annotationKeys)
+		for _, k := range annotationKeys {
 			annotations = append(annotations, kubecontainer.Annotation{
 				Name:  k,
-				Value: v,
+				Value: image.Spec.Annotations[k],
 			})
 		}
 	}


### PR DESCRIPTION
The annotations added in https://github.com/kubernetes/kubernetes/pull/90061 in 1.19 are in non-deterministic order, because they are built by iterating over a map.

The unit test expects an exact order. Failure seen in https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/93605/pull-kubernetes-bazel-test/1289254188986929154

Bazel unit tests are currently running up to 3 times, masking this flake. Found this in https://github.com/kubernetes/kubernetes/pull/93605

In addition to stabilizing the test, this ensures anything downstream of this method has deterministic output for equality comparison

/kind bug
/sig node
/milestone v1.19