### PR TITLE
Deflake node controller unit tests

### DIFF
--- a/staging/src/k8s.io/cloud-provider/controllers/node/BUILD
+++ b/staging/src/k8s.io/cloud-provider/controllers/node/BUILD
@@ -44,6 +44,7 @@ go_test(
         "//staging/src/k8s.io/cloud-provider/fake:go_default_library",
         "//vendor/github.com/google/go-cmp/cmp:go_default_library",
         "//vendor/github.com/stretchr/testify/assert:go_default_library",
+        "//vendor/k8s.io/klog/v2:go_default_library",
     ],
 )
 

--- a/staging/src/k8s.io/cloud-provider/controllers/node/node_controller_test.go
+++ b/staging/src/k8s.io/cloud-provider/controllers/node/node_controller_test.go
@@ -23,15 +23,16 @@ import (
 	"testing"
 	"time"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/klog/v2"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/tools/record"
-	"k8s.io/cloud-provider"
+	cloudprovider "k8s.io/cloud-provider"
 	cloudproviderapi "k8s.io/cloud-provider/api"
 	fakecloud "k8s.io/cloud-provider/fake"
 
@@ -1293,7 +1294,8 @@ func Test_AddCloudNode(t *testing.T) {
 				recorder:                  eventBroadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: "cloud-node-controller"}),
 				nodeStatusUpdateFrequency: 1 * time.Second,
 			}
-			eventBroadcaster.StartLogging(t.Logf)
+			w := eventBroadcaster.StartLogging(klog.Infof)
+			defer w.Stop()
 
 			cloudNodeController.AddCloudNode(context.TODO(), test.existingNode)
 
@@ -1371,7 +1373,8 @@ func TestGCEConditionV2(t *testing.T) {
 		recorder:                  eventBroadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: "cloud-node-controller"}),
 		nodeStatusUpdateFrequency: 1 * time.Second,
 	}
-	eventBroadcaster.StartLogging(t.Logf)
+	w := eventBroadcaster.StartLogging(klog.Infof)
+	defer w.Stop()
 
 	cloudNodeController.AddCloudNode(context.TODO(), existingNode)
 
@@ -1453,7 +1456,8 @@ func TestGCECondition(t *testing.T) {
 		recorder:                  eventBroadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: "cloud-node-controller"}),
 		nodeStatusUpdateFrequency: 1 * time.Second,
 	}
-	eventBroadcaster.StartLogging(t.Logf)
+	w := eventBroadcaster.StartLogging(klog.Infof)
+	defer w.Stop()
 
 	cloudNodeController.AddCloudNode(context.TODO(), existingNode)
 

--- a/staging/src/k8s.io/cloud-provider/controllers/nodelifecycle/node_lifecycle_controller_test.go
+++ b/staging/src/k8s.io/cloud-provider/controllers/nodelifecycle/node_lifecycle_controller_test.go
@@ -290,7 +290,8 @@ func Test_NodesDeleted(t *testing.T) {
 				nodeMonitorPeriod: 1 * time.Second,
 			}
 
-			eventBroadcaster.StartLogging(t.Logf)
+			w := eventBroadcaster.StartLogging(klog.Infof)
+			defer w.Stop()
 			cloudNodeLifecycleController.MonitorNodes()
 
 			updatedNode, err := clientset.CoreV1().Nodes().Get(context.TODO(), testcase.existingNode.Name, metav1.GetOptions{})
@@ -498,7 +499,8 @@ func Test_NodesShutdown(t *testing.T) {
 				nodeMonitorPeriod: 1 * time.Second,
 			}
 
-			eventBroadcaster.StartLogging(klog.Infof)
+			w := eventBroadcaster.StartLogging(klog.Infof)
+			defer w.Stop()
 			cloudNodeLifecycleController.MonitorNodes()
 
 			updatedNode, err := clientset.CoreV1().Nodes().Get(context.TODO(), testcase.existingNode.Name, metav1.GetOptions{})


### PR DESCRIPTION
**What type of PR is this?**
/kind flake

**What this PR does / why we need it**:

Avoid unsynchronized use of t.Logf after a t.Fatal call

These tests were wiring an asynchronous logger to t.Logf in a way that resulted in log messages propagating after a t.Fatalf call

This caused a data race inside the go testing library as seen in https://github.com/kubernetes/kubernetes/pull/93605#issuecomment-667407692

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/sig node
