### PR TITLE
Fix race condition in pluginWatcher

### DIFF
--- a/pkg/kubelet/pluginmanager/plugin_manager_test.go
+++ b/pkg/kubelet/pluginmanager/plugin_manager_test.go
@@ -20,6 +20,9 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path/filepath"
+	"reflect"
+	"strconv"
 	"sync"
 	"testing"
 	"time"
@@ -29,6 +32,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/record"
 	registerapi "k8s.io/kubelet/pkg/apis/pluginregistration/v1"
+
 	"k8s.io/kubernetes/pkg/kubelet/config"
 	"k8s.io/kubernetes/pkg/kubelet/pluginmanager/pluginwatcher"
 )
@@ -39,25 +43,19 @@ var (
 )
 
 type fakePluginHandler struct {
-	validatePluginCalled   bool
-	registerPluginCalled   bool
-	deregisterPluginCalled bool
+	events []string
 	sync.RWMutex
 }
 
 func newFakePluginHandler() *fakePluginHandler {
-	return &fakePluginHandler{
-		validatePluginCalled:   false,
-		registerPluginCalled:   false,
-		deregisterPluginCalled: false,
-	}
+	return &fakePluginHandler{}
 }
 
 // ValidatePlugin is a fake method
 func (f *fakePluginHandler) ValidatePlugin(pluginName string, endpoint string, versions []string) error {
 	f.Lock()
 	defer f.Unlock()
-	f.validatePluginCalled = true
+	f.events = append(f.events, "validate "+pluginName)
 	return nil
 }
 
@@ -65,7 +63,7 @@ func (f *fakePluginHandler) ValidatePlugin(pluginName string, endpoint string, v
 func (f *fakePluginHandler) RegisterPlugin(pluginName, endpoint string, versions []string) error {
 	f.Lock()
 	defer f.Unlock()
-	f.registerPluginCalled = true
+	f.events = append(f.events, "register "+pluginName)
 	return nil
 }
 
@@ -73,7 +71,13 @@ func (f *fakePluginHandler) RegisterPlugin(pluginName, endpoint string, versions
 func (f *fakePluginHandler) DeRegisterPlugin(pluginName string) {
 	f.Lock()
 	defer f.Unlock()
-	f.deregisterPluginCalled = true
+	f.events = append(f.events, "deregister "+pluginName)
+}
+
+func (f *fakePluginHandler) Reset() {
+	f.Lock()
+	defer f.Unlock()
+	f.events = nil
 }
 
 func init() {
@@ -90,15 +94,17 @@ func cleanup(t *testing.T) {
 	os.MkdirAll(socketDir, 0755)
 }
 
-func waitForRegistration(t *testing.T, fakePluginHandler *fakePluginHandler) {
+func waitForRegistration(t *testing.T, fakePluginHandler *fakePluginHandler, pluginName string) {
+	expected := []string{"validate " + pluginName, "register " + pluginName}
 	err := retryWithExponentialBackOff(
-		time.Duration(500*time.Millisecond),
+		100*time.Millisecond,
 		func() (bool, error) {
 			fakePluginHandler.Lock()
 			defer fakePluginHandler.Unlock()
-			if fakePluginHandler.validatePluginCalled && fakePluginHandler.registerPluginCalled {
+			if reflect.DeepEqual(fakePluginHandler.events, expected) {
 				return true, nil
 			}
+			t.Logf("expected %#v, got %#v, will retry", expected, fakePluginHandler.events)
 			return false, nil
 		},
 	)
@@ -134,19 +140,29 @@ func TestPluginRegistration(t *testing.T) {
 	fakeHandler := newFakePluginHandler()
 	pluginManager.AddHandler(registerapi.DevicePlugin, fakeHandler)
 
-	// Add a new plugin
-	socketPath := fmt.Sprintf("%s/plugin.sock", socketDir)
-	pluginName := "example-plugin"
-	p := pluginwatcher.NewTestExamplePlugin(pluginName, registerapi.DevicePlugin, socketPath, supportedVersions...)
-	require.NoError(t, p.Serve("v1beta1", "v1beta2"))
+	const maxDepth = 3
+	// Make sure the plugin manager is aware of the socket in subdirectories
+	for i := 0; i < maxDepth; i++ {
+		fakeHandler.Reset()
+		pluginDir := socketDir
 
-	// Verify that the plugin is registered
-	waitForRegistration(t, fakeHandler)
+		for j := 0; j < i; j++ {
+			pluginDir = filepath.Join(pluginDir, strconv.Itoa(j))
+		}
+		require.NoError(t, os.MkdirAll(pluginDir, os.ModePerm))
+		socketPath := filepath.Join(pluginDir, fmt.Sprintf("plugin-%d.sock", i))
+
+		// Add a new plugin
+		pluginName := fmt.Sprintf("example-plugin-%d", i)
+		p := pluginwatcher.NewTestExamplePlugin(pluginName, registerapi.DevicePlugin, socketPath, supportedVersions...)
+		require.NoError(t, p.Serve("v1beta1", "v1beta2"))
+
+		// Verify that the plugin is registered
+		waitForRegistration(t, fakeHandler, pluginName)
+	}
 }
 
-func newTestPluginManager(
-	sockDir string) PluginManager {
-
+func newTestPluginManager(sockDir string) PluginManager {
 	pm := NewPluginManager(
 		sockDir,
 		&record.FakeRecorder{},

--- a/pkg/kubelet/pluginmanager/pluginwatcher/plugin_watcher.go
+++ b/pkg/kubelet/pluginmanager/pluginwatcher/plugin_watcher.go
@@ -21,7 +21,6 @@ import (
 	"os"
 	"runtime"
 	"strings"
-	"time"
 
 	"github.com/fsnotify/fsnotify"
 	"k8s.io/klog/v2"
@@ -36,7 +35,6 @@ type Watcher struct {
 	path                string
 	fs                  utilfs.Filesystem
 	fsWatcher           *fsnotify.Watcher
-	stopped             chan struct{}
 	desiredStateOfWorld cache.DesiredStateOfWorld
 }
 
@@ -52,8 +50,6 @@ func NewWatcher(sockDir string, desiredStateOfWorld cache.DesiredStateOfWorld) *
 // Start watches for the creation and deletion of plugin sockets at the path
 func (w *Watcher) Start(stopCh <-chan struct{}) error {
 	klog.V(2).Infof("Plugin Watcher Start at %s", w.path)
-
-	w.stopped = make(chan struct{})
 
 	// Creating the directory to be watched if it doesn't exist yet,
 	// and walks through the directory to discover the existing plugins.
@@ -73,7 +69,6 @@ func (w *Watcher) Start(stopCh <-chan struct{}) error {
 	}
 
 	go func(fsWatcher *fsnotify.Watcher) {
-		defer close(w.stopped)
 		for {
 			select {
 			case event := <-fsWatcher.Events:
@@ -93,14 +88,6 @@ func (w *Watcher) Start(stopCh <-chan struct{}) error {
 				}
 				continue
 			case <-stopCh:
-				// In case of plugin watcher being stopped by plugin manager, stop
-				// probing the creation/deletion of plugin sockets.
-				// Also give all pending go routines a chance to complete
-				select {
-				case <-w.stopped:
-				case <-time.After(11 * time.Second):
-					klog.Errorf("timeout on stopping watcher")
-				}
 				w.fsWatcher.Close()
 				return
 			}
@@ -123,6 +110,12 @@ func (w *Watcher) init() error {
 // Walks through the plugin directory discover any existing plugin sockets.
 // Ignore all errors except root dir not being walkable
 func (w *Watcher) traversePluginDir(dir string) error {
+	// watch the new dir
+	err := w.fsWatcher.Add(dir)
+	if err != nil {
+		return fmt.Errorf("failed to watch %s, err: %v", w.path, err)
+	}
+	// traverse existing children in the dir
 	return w.fs.Walk(dir, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			if path == dir {
@@ -130,6 +123,11 @@ func (w *Watcher) traversePluginDir(dir string) error {
 			}
 
 			klog.Errorf("error accessing path: %s error: %v", path, err)
+			return nil
+		}
+
+		// do not call fsWatcher.Add twice on the root dir to avoid potential problems.
+		if path == dir {
 			return nil
 		}
 


### PR DESCRIPTION
Signed-off-by: knight42 <anonymousknight96@gmail.com>


**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature

/kind flake

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of #93605
xref: https://github.com/kubernetes/kubernetes/pull/93605#issuecomment-667316127

**Special notes for your reviewer**:

I add some logging with the following patch:
<details>

```
diff --git pkg/kubelet/pluginmanager/pluginwatcher/example_plugin.go pkg/kubelet/pluginmanager/pluginwatcher/example_plugin.go
index d0859cc8967..a67a214556e 100644
--- pkg/kubelet/pluginmanager/pluginwatcher/example_plugin.go
+++ pkg/kubelet/pluginmanager/pluginwatcher/example_plugin.go
@@ -29,9 +29,10 @@ import (
 	"k8s.io/klog/v2"
 
 	registerapi "k8s.io/kubelet/pkg/apis/pluginregistration/v1"
+
 	"k8s.io/kubernetes/pkg/kubelet/pluginmanager/cache"
-	v1beta1 "k8s.io/kubernetes/pkg/kubelet/pluginmanager/pluginwatcher/example_plugin_apis/v1beta1"
-	v1beta2 "k8s.io/kubernetes/pkg/kubelet/pluginmanager/pluginwatcher/example_plugin_apis/v1beta2"
+	"k8s.io/kubernetes/pkg/kubelet/pluginmanager/pluginwatcher/example_plugin_apis/v1beta1"
+	"k8s.io/kubernetes/pkg/kubelet/pluginmanager/pluginwatcher/example_plugin_apis/v1beta2"
 )
 
 // examplePlugin is a sample plugin to work with plugin watcher
@@ -96,6 +97,7 @@ func GetPluginInfo(plugin *examplePlugin) cache.PluginInfo {
 
 // GetInfo is the RPC invoked by plugin watcher
 func (e *examplePlugin) GetInfo(ctx context.Context, req *registerapi.InfoRequest) (*registerapi.PluginInfo, error) {
+	klog.Errorf("GetInfo called")
 	return &registerapi.PluginInfo{
 		Type:              e.pluginType,
 		Name:              e.pluginName,
@@ -146,6 +148,7 @@ func (e *examplePlugin) Serve(services ...string) error {
 	go func() {
 		defer e.wg.Done()
 		// Blocking call to accept incoming connections.
+		klog.Infof("listening on socket")
 		if err := e.grpcServer.Serve(lis); err != nil {
 			klog.Errorf("example server stopped serving: %v", err)
 		}
diff --git pkg/kubelet/pluginmanager/pluginwatcher/plugin_watcher.go pkg/kubelet/pluginmanager/pluginwatcher/plugin_watcher.go
index 30177f67bdc..e432d399032 100644
--- pkg/kubelet/pluginmanager/pluginwatcher/plugin_watcher.go
+++ pkg/kubelet/pluginmanager/pluginwatcher/plugin_watcher.go
@@ -49,7 +49,7 @@ func NewWatcher(sockDir string, desiredStateOfWorld cache.DesiredStateOfWorld) *
 
 // Start watches for the creation and deletion of plugin sockets at the path
 func (w *Watcher) Start(stopCh <-chan struct{}) error {
-	klog.V(2).Infof("Plugin Watcher Start at %s", w.path)
+	klog.Infof("Plugin Watcher Start at %s", w.path)
 
 	// Creating the directory to be watched if it doesn't exist yet,
 	// and walks through the directory to discover the existing plugins.
@@ -67,11 +67,13 @@ func (w *Watcher) Start(stopCh <-chan struct{}) error {
 	if err := w.traversePluginDir(w.path); err != nil {
 		klog.Errorf("failed to traverse plugin socket path %q, err: %v", w.path, err)
 	}
+	klog.Infof("list pluginDir")
 
 	go func(fsWatcher *fsnotify.Watcher) {
 		for {
 			select {
 			case event := <-fsWatcher.Events:
+				klog.Infof("receive event: %s", event)
 				//TODO: Handle errors by taking corrective measures
 				if event.Op&fsnotify.Create == fsnotify.Create {
 					err := w.handleCreateEvent(event)
@@ -130,6 +132,7 @@ func (w *Watcher) traversePluginDir(dir string) error {
 				Name: path,
 				Op:   fsnotify.Create,
 			}
+			klog.Infof("add existing socket: %s", path)
 			//TODO: Handle errors by taking corrective measures
 			if err := w.handleCreateEvent(event); err != nil {
 				klog.Errorf("error %v when handling create event: %s", err, event)
```

</details>

and find out that if the test fails, the output would be something like
```
=== RUN   TestPluginRegistration
I0801 11:43:21.268993   74831 example_plugin.go:121] starting example server at: /var/folders/bp/20yxytt90055krc_0hct5qrm0000gn/T/plugin_manager_test025788546/plugin.sock
I0801 11:43:21.269004   74831 plugin_watcher.go:52] Plugin Watcher Start at /var/folders/bp/20yxytt90055krc_0hct5qrm0000gn/T/plugin_manager_test025788546
I0801 11:43:21.269916   74831 example_plugin.go:127] example server started at: /var/folders/bp/20yxytt90055krc_0hct5qrm0000gn/T/plugin_manager_test025788546/plugin.sock
I0801 11:43:21.270146   74831 example_plugin.go:151] listening on socket
I0801 11:43:21.270248   74831 plugin_watcher.go:70] list pluginDir
I0801 11:43:21.270288   74831 plugin_manager.go:114] Starting Kubelet Plugin Manager # <---- stuck here
    TestPluginRegistration: plugin_manager_test.go:107: Timed out waiting for plugin to be added to actual state of world cache.
I0801 11:44:21.783013   74831 plugin_manager.go:119] Shutting down Kubelet Plugin Manager
--- FAIL: TestPluginRegistration (60.51s)
FAIL
exit status 1
FAIL    k8s.io/kubernetes/pkg/kubelet/pluginmanager     60.851s
```

while if the test passes, the output would be sth like
```
=== RUN   TestPluginRegistration
I0801 11:43:18.278273   74796 example_plugin.go:121] starting example server at: /var/folders/bp/20yxytt90055krc_0hct5qrm0000gn/T/plugin_manager_test291123507/plugin.sock
I0801 11:43:18.278302   74796 plugin_watcher.go:52] Plugin Watcher Start at /var/folders/bp/20yxytt90055krc_0hct5qrm0000gn/T/plugin_manager_test291123507
I0801 11:43:18.279166   74796 example_plugin.go:127] example server started at: /var/folders/bp/20yxytt90055krc_0hct5qrm0000gn/T/plugin_manager_test291123507/plugin.sock
I0801 11:43:18.279389   74796 example_plugin.go:151] listening on socket
I0801 11:43:18.279658   74796 plugin_watcher.go:135] add existing socket: /var/folders/bp/20yxytt90055krc_0hct5qrm0000gn/T/plugin_manager_test291123507/plugin.sock
I0801 11:43:18.279708   74796 plugin_watcher.go:70] list pluginDir
I0801 11:43:18.279730   74796 plugin_manager.go:114] Starting Kubelet Plugin Manager
E0801 11:43:18.280703   74796 example_plugin.go:100] GetInfo called
E0801 11:43:18.280951   74796 example_plugin.go:110] Registration is: &RegistrationStatus{PluginRegistered:true,Error:,}
I0801 11:43:18.779723   74796 plugin_manager.go:119] Shutting down Kubelet Plugin Manager
--- PASS: TestPluginRegistration (0.50s)
```

Or

```
=== RUN   TestPluginRegistration
I0801 11:43:13.759376   74763 example_plugin.go:121] starting example server at: /var/folders/bp/20yxytt90055krc_0hct5qrm0000gn/T/plugin_manager_test526537534/plugin.sock
I0801 11:43:13.759538   74763 plugin_watcher.go:52] Plugin Watcher Start at /var/folders/bp/20yxytt90055krc_0hct5qrm0000gn/T/plugin_manager_test526537534
I0801 11:43:13.760092   74763 plugin_watcher.go:70] list pluginDir
I0801 11:43:13.760104   74763 plugin_manager.go:114] Starting Kubelet Plugin Manager
I0801 11:43:13.760137   74763 example_plugin.go:127] example server started at: /var/folders/bp/20yxytt90055krc_0hct5qrm0000gn/T/plugin_manager_test526537534/plugin.sock
I0801 11:43:13.760198   74763 example_plugin.go:151] listening on socket
I0801 11:43:13.760342   74763 plugin_watcher.go:76] receive event: "/var/folders/bp/20yxytt90055krc_0hct5qrm0000gn/T/plugin_manager_test526537534/plugin.sock": CREATE
E0801 11:43:14.761989   74763 example_plugin.go:100] GetInfo called
E0801 11:43:14.762267   74763 example_plugin.go:110] Registration is: &RegistrationStatus{PluginRegistered:true,Error:,}
I0801 11:43:15.764041   74763 plugin_manager.go:119] Shutting down Kubelet Plugin Manager
--- PASS: TestPluginRegistration (2.01s)
```

EDIT:
See also https://github.com/kubernetes/kubernetes/pull/93622#issuecomment-669915496
I think the root cause is more likely to be concurrently creating the socket and adding the plugin dir to `w.fsWatcher` in the test. I guess the execution order might be:

1. The plugin socket has not been created, plugin watcher is traversing the plugin dir, just read dir names but not call `walkFn` yet https://github.com/golang/go/blob/6f08e89ec3280bf6577c2bdb01243cbeeb1a259d/src/path/filepath/path.go#L358-L364, so plugin watcher would not find the socket later
2. The plugin socket is created
3. `walkFn` is invoked and the plugin dir is added to the watcher, so the watcher would not receive any events later.

I decided to watch the socket dir before traversing it.
1. if the socket is created before we watching the dir, then we would find the socket while we are traversing the socket dir
2. if the socket is created after we watching the dir, then we would receive the CREATE event.

----
Please notice when the test fails, the plugin watcher could neither find any sockets in the socket dir nor receive "CREATE" event later. ~~I suspect `fsnotify` is not extremely reliable and might miss events in some cases.~~

~~As a result, I decide to make sure the example plugin server is started before plugin manager, so that the socket always exists when the plugin manager is started. I have run the test 100 times locally after this change, they all pass.~~


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kubelet: fix race condition in pluginWatcher 
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
