### PR TITLE
modify proto for ipv6 route filter

### DIFF
--- a/pkg/proxy/ipvs/netlink_linux.go
+++ b/pkg/proxy/ipvs/netlink_linux.go
@@ -177,6 +177,16 @@ func (h *netlinkHandle) GetLocalAddresses(dev, filterDev string) (sets.String, e
 	if err != nil {
 		return nil, fmt.Errorf("error list route table, err: %v", err)
 	}
+
+	if h.isIPv6 {
+		unsRouteFilter := &netlink.Route{
+			Table:    unix.RT_TABLE_LOCAL,
+			Type:     unix.RTN_LOCAL,
+			Protocol: unix.RTPROT_UNSPEC,
+		}
+		unsroutes, _ := h.RouteListFiltered(netlink.FAMILY_V6, unsRouteFilter, filterMask)
+		routes = append(routes, unsroutes...)
+	}
 	res := sets.NewString()
 	for _, route := range routes {
 		if route.LinkIndex == filterLinkIndex {


### PR DESCRIPTION
What type of PR is this?
/kind bug

What this PR does / why we need it:
because the protocol type in  local table for ipv6 is none but not kernal，which is present in local table for ipv4.:
```json
local ::1 dev lo  proto none  metric 0  pref medium
local 100::1 dev lo  proto none  metric 0  pref medium
local 300::3 dev lo  proto none  metric 0  pref medium

local 10.46.177.110 dev ens3  proto kernel  scope host  src 10.46.177.110
broadcast 10.46.177.255 dev ens3  proto kernel  scope link  src 10.46.177.110
local 10.254.0.1 dev kube-ipvs0  proto kernel  scope host  src 10.254.0.1

```
 the case in function 'RouteListFiltered'  in the file of  vendor/github.com/vishvananda/netlink/route_linux.go could not work well
```go
case filterMask&RT_FILTER_PROTOCOL != 0 && route.Protocol != filter.Protocol:
				continue
```
 because of the inconsistencies between IPv4 and IPv6kernel.
For example, the 'NodePort'   is affected and cannot open the local port

Which issue(s) this PR fixes:
Fixes #
area/ipvs
/release-note-none
/priority backlog
