### PR TITLE
README: Change badge to pkg.go.dev from godoc.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,8 +79,8 @@ That said, if you have questions, reach out to us
 [developer's documentation]: https://git.k8s.io/community/contributors/devel#readme
 [Docker environment]: https://docs.docker.com/engine
 [Go environment]: https://golang.org/doc/install
-[GoDoc]: https://godoc.org/k8s.io/kubernetes
-[GoDoc Widget]: https://godoc.org/k8s.io/kubernetes?status.svg
+[GoDoc]: https://pkg.go.dev/k8s.io/kubernetes
+[GoDoc Widget]: https://pkg.go.dev/badge/k8s.io/kubernetes
 [interactive tutorial]: https://kubernetes.io/docs/tutorials/kubernetes-basics
 [kubernetes.io]: https://kubernetes.io
 [Scalable Microservices with Kubernetes]: https://www.udacity.com/course/scalable-microservices-with-kubernetes--ud615


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:

I changed the badge.

old: [![GoDoc](https://godoc.org/k8s.io/kubernetes?status.svg)](https://godoc.org/k8s.io/kubernetes)
new: [![GoDoc](https://pkg.go.dev/badge/k8s.io/kubernetes)](https://pkg.go.dev/k8s.io/kubernetes)

Because `The Go Blog` announced to migrate to pkg.go.dev from godoc.org.
→ https://blog.golang.org/pkg.go.dev-2020

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
