### PR TITLE
Improve speed of dockerized verify/update scripts

### DIFF
--- a/hack/lib/logging.sh
+++ b/hack/lib/logging.sh
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 # Controls verbosity of the script output and logging.
-KUBE_VERBOSE="${KUBE_VERBOSE:-5}"
+KUBE_VERBOSE="${KUBE_VERBOSE:-2}"
 
 # Handler for when we exit automatically on an error.
 # Borrowed from https://gist.github.com/ahendrix/7030300

--- a/hack/lib/protoc.sh
+++ b/hack/lib/protoc.sh
@@ -27,10 +27,7 @@ source "${KUBE_ROOT}/hack/lib/init.sh"
 # $1: Full path to the directory where the api.proto file is
 function kube::protoc::generate_proto() {
   kube::golang::setup_env
-  local bins=(
-    vendor/k8s.io/code-generator/cmd/go-to-protobuf/protoc-gen-gogo
-  )
-  make -C "${KUBE_ROOT}" WHAT="${bins[*]}"
+  go install k8s.io/kubernetes/vendor/k8s.io/code-generator/cmd/go-to-protobuf/protoc-gen-gogo
 
   kube::protoc::check_protoc
 

--- a/hack/lib/swagger.sh
+++ b/hack/lib/swagger.sh
@@ -51,7 +51,12 @@ kube::swagger::gen_types_swagger_doc() {
 EOF
   } > "${TMPFILE}"
 
-  go run cmd/genswaggertypedocs/swagger_type_docs.go -s \
+  if ! which genswaggertypedocs >/dev/null; then
+    # build if needed
+    go install k8s.io/kubernetes/cmd/genswaggertypedocs
+  fi
+
+  genswaggertypedocs -s \
     "${gv_dir}/types.go" \
     -f - \
     >>  "${TMPFILE}"

--- a/hack/lib/util.sh
+++ b/hack/lib/util.sh
@@ -200,6 +200,13 @@ kube::util::find-binary-for-platform() {
     "${KUBE_ROOT}/_output/local/bin/${platform}/${lookfor}"
     "${KUBE_ROOT}/platforms/${platform}/${lookfor}"
   )
+  # if we're looking for the host platform, add local non-platform-qualified search paths
+  if [[ "${platform}" = "$(kube::util::host_platform)" ]]; then
+    locations+=(
+      "${KUBE_ROOT}/_output/local/go/bin/${lookfor}"
+      "${KUBE_ROOT}/_output/dockerized/go/bin/${lookfor}"
+    );
+  fi
   # Also search for binary in bazel build tree.
   # The bazel go rules place some binaries in subtrees like
   # "bazel-bin/source/path/linux_amd64_pure_stripped/binaryname", so make sure

--- a/hack/make-rules/vet.sh
+++ b/hack/make-rules/vet.sh
@@ -31,10 +31,6 @@ if [[ "${CALLED_FROM_MAIN_MAKEFILE:-""}" == "" ]]; then
     exit 1
 fi
 
-# This is required before we run govet for the results to be correct.
-# See https://github.com/golang/go/issues/16086 for details.
-go install ./cmd/...
-
 # Filter out arguments that start with "-" and move them to goflags.
 targets=()
 for arg; do

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -26,12 +26,9 @@ source "${KUBE_ROOT}/hack/lib/init.sh"
 
 kube::golang::setup_env
 
-BUILD_TARGETS=(
-  vendor/k8s.io/code-generator/cmd/client-gen
-  vendor/k8s.io/code-generator/cmd/lister-gen
-  vendor/k8s.io/code-generator/cmd/informer-gen
-)
-make -C "${KUBE_ROOT}" WHAT="${BUILD_TARGETS[*]}"
+go install k8s.io/kubernetes/vendor/k8s.io/code-generator/cmd/client-gen
+go install k8s.io/kubernetes/vendor/k8s.io/code-generator/cmd/lister-gen
+go install k8s.io/kubernetes/vendor/k8s.io/code-generator/cmd/informer-gen
 
 clientgen=$(kube::util::find-binary "client-gen")
 listergen=$(kube::util::find-binary "lister-gen")

--- a/hack/update-generated-kms-dockerized.sh
+++ b/hack/update-generated-kms-dockerized.sh
@@ -24,10 +24,7 @@ source "${KUBE_ROOT}/hack/lib/init.sh"
 
 kube::golang::setup_env
 
-BINS=(
-	vendor/k8s.io/code-generator/cmd/go-to-protobuf/protoc-gen-gogo
-)
-make -C "${KUBE_ROOT}" WHAT="${BINS[*]}"
+go install k8s.io/kubernetes/vendor/k8s.io/code-generator/cmd/go-to-protobuf/protoc-gen-gogo
 
 if [[ -z "$(which protoc)" || "$(protoc --version)" != "libprotoc 3."* ]]; then
   echo "Generating protobuf requires protoc 3.0.0-beta1 or newer. Please download and"

--- a/hack/update-generated-protobuf-dockerized.sh
+++ b/hack/update-generated-protobuf-dockerized.sh
@@ -28,11 +28,8 @@ source "${KUBE_ROOT}/hack/lib/init.sh"
 
 kube::golang::setup_env
 
-BINS=(
-	vendor/k8s.io/code-generator/cmd/go-to-protobuf
-	vendor/k8s.io/code-generator/cmd/go-to-protobuf/protoc-gen-gogo
-)
-make -C "${KUBE_ROOT}" WHAT="${BINS[*]}"
+go install k8s.io/kubernetes/vendor/k8s.io/code-generator/cmd/go-to-protobuf
+go install k8s.io/kubernetes/vendor/k8s.io/code-generator/cmd/go-to-protobuf/protoc-gen-gogo
 
 if [[ -z "$(which protoc)" || "$(protoc --version)" != "libprotoc 3."* ]]; then
   echo "Generating protobuf requires protoc 3.0.0-beta1 or newer. Please download and"

--- a/hack/update-generated-runtime-dockerized.sh
+++ b/hack/update-generated-runtime-dockerized.sh
@@ -27,10 +27,7 @@ source "${KUBE_ROOT}/hack/lib/init.sh"
 
 kube::golang::setup_env
 
-BINS=(
-	vendor/k8s.io/code-generator/cmd/go-to-protobuf/protoc-gen-gogo
-)
-make -C "${KUBE_ROOT}" WHAT="${BINS[*]}"
+go install k8s.io/kubernetes/vendor/k8s.io/code-generator/cmd/go-to-protobuf/protoc-gen-gogo
 
 if [[ -z "$(which protoc)" || "$(protoc --version)" != "libprotoc 3."* ]]; then
   echo "Generating protobuf requires protoc 3.0.0-beta1 or newer. Please download and"

--- a/hack/update-generated-swagger-docs.sh
+++ b/hack/update-generated-swagger-docs.sh
@@ -35,6 +35,8 @@ IFS=" " read -r -a GROUP_VERSIONS <<< "meta/v1 meta/v1beta1 ${KUBE_AVAILABLE_GRO
 for group_version in "${GROUP_VERSIONS[@]}"; do
   rm -f "$(kube::util::group-version-to-pkg-path "${group_version}")/types_swagger_doc_generated.go"
 done
+# ensure we have the latest genswaggertypedocs built
+go install k8s.io/kubernetes/cmd/genswaggertypedocs
 for group_version in "${GROUP_VERSIONS[@]}"; do
   kube::swagger::gen_types_swagger_doc "${group_version}" "$(kube::util::group-version-to-pkg-path "${group_version}")"
 done

--- a/hack/verify-import-boss.sh
+++ b/hack/verify-import-boss.sh
@@ -28,7 +28,7 @@ source "${KUBE_ROOT}/hack/lib/init.sh"
 
 kube::golang::setup_env
 
-make -C "${KUBE_ROOT}" WHAT=vendor/k8s.io/code-generator/cmd/import-boss
+go install k8s.io/kubernetes/vendor/k8s.io/code-generator/cmd/import-boss
 
 packages=(
   "k8s.io/kubernetes/pkg/..."


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
* lowers default verbosity from 5 to 2 (takes successful job log from ~50000 to 2460 lines)
* builds code-generator tools directly, rather than using make (which was triggering the generated_files target whether they were needed or not)
  * verify-generated-device-plugin: saves ~2 minutes
  * verify-generated-kms: saves ~1.5 minutes
  * verify-generated-runtime: saves ~1 minute
  * verify-generated-plugin-registration: saves ~5 minutes
  * generated-pod-resources: saves ~1 minute
* avoids rebuilding genswaggerdocs per API package (saves ~1-2 minutes)
* avoids building all commands and generated files before calling `go vet` (was only being done as a workaround for a bug fixed in vet ~2 years ago)

Estimated savings: 10-15 minutes, logs that are much more usable

**Which issue(s) this PR fixes**:
xref https://github.com/kubernetes/kubernetes/issues/87807#issuecomment-662532855

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
