### PR TITLE
Automated cherry pick of #93600: Fix panic on /readyz

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/healthz/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/server/healthz/BUILD
@@ -11,6 +11,7 @@ go_test(
     srcs = ["healthz_test.go"],
     embed = [":go_default_library"],
     deps = [
+        "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
     ],
 )
@@ -27,7 +28,6 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/server/httplog:go_default_library",
-        "//staging/src/k8s.io/client-go/informers:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
     ],
 )


### PR DESCRIPTION
Cherry pick of #93600 on release-1.16.

#93600: Fix panic on /readyz

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Fixes a regression in kube-apiserver causing 500 errors from the `/readyz` endpoint
```