### PR TITLE
Implement e2e tests for pod scope alignment

### DIFF
--- a/test/e2e_node/numa_alignment.go
+++ b/test/e2e_node/numa_alignment.go
@@ -181,6 +181,7 @@ type testEnvInfo struct {
 	numaNodes         int
 	sriovResourceName string
 	policy            string
+	scope             string
 }
 
 func containerWantsDevices(cnt *v1.Container, envInfo *testEnvInfo) bool {


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
It provides e2e tests for pod-level affinity (details in the update to the KEP)

**Special notes for your reviewer**:
It tests pod-level alignment in addition to current container-level resource (e.g. memory, CPU) NUMA affinity.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:**

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
\[KEP\]: [kubernetes/enhancements#1752](https://github.com/kubernetes/enhancements/pull/1752)
