### PR TITLE
Increase the default size to 2Gi

### DIFF
--- a/test/e2e/storage/testsuites/volume_expand.go
+++ b/test/e2e/storage/testsuites/volume_expand.go
@@ -64,7 +64,7 @@ func InitVolumeExpandTestSuite() TestSuite {
 				testpatterns.BlockVolModeDynamicPVAllowExpansion,
 			},
 			SupportedSizeRange: e2evolume.SizeRange{
-				Min: "1Mi",
+				Min: "2Gi",
 			},
 		},
 	}


### PR DESCRIPTION
1Mi is too small of size to create initial volume and expect volume expansion. Increase default size to 2Gi.

xref - https://github.com/kubernetes/kubernetes/issues/90866

