### PR TITLE
test/e2e: fail test rather than flooding logs if PVC watch is closed prematurely

### DIFF
--- a/test/e2e/storage/csi_mock_volume.go
+++ b/test/e2e/storage/csi_mock_volume.go
@@ -892,7 +892,11 @@ var _ = utils.SIGDescribe("CSI mock volume", func() {
 			loop:
 				for {
 					select {
-					case event := <-pvcWatch.ResultChan():
+					case event, ok := <-pvcWatch.ResultChan():
+						if !ok {
+							framework.Failf("PVC watch ended prematurely")
+						}
+
 						framework.Logf("PVC event %s: %#v", event.Type, event.Object)
 						switch event.Type {
 						case watch.Modified:


### PR DESCRIPTION
If the watch is closed prematurely the for/select loop will
spew "PVC event : <nil>" as fast as possible until the test times
out, flooding logs.

```
STEP: Checking PVC events
Aug  3 16:35:53.930: INFO: PVC event ADDED: &v1.PersistentVolumeClaim{TypeMeta:v1.TypeMeta{Kind:"", APIVersion:""}, ObjectMeta:v1.ObjectMeta{Name:"pvc-zrchk", GenerateName:"pvc-", Namespace:"e2e-csi-mock-volumes-5292", SelfLink:"/api/v1/namespaces/e2e-csi-mock-volumes-5292/persistentvolumeclaims/pvc-zrchk", UID:"221369cd-50c3-48be-8c08-dc4d8f6f36e0", ResourceVersion:"42154", Generation:0, CreationTimestamp:v1.Time{Time:time.Time{wall:0x0, ext:63732069329, loc:(*time.Location)(0x9e74040)}}, DeletionTimestamp:(*v1.Time)(nil), DeletionGracePeriodSeconds:(*int64)(nil), Labels:map[string]string(nil), Annotations:map[string]string(nil), OwnerReferences:[]v1.OwnerReference(nil), Finalizers:[]string{"kubernetes.io/pvc-protection"}, ClusterName:"", ManagedFields:[]v1.ManagedFieldsEntry{v1.ManagedFieldsEntry{Manager:"openshift-tests", Operation:"Update", APIVersion:"v1", Time:(*v1.Time)(0xc001639060), FieldsType:"FieldsV1", FieldsV1:(*v1.FieldsV1)(0xc001639080)}}}, Spec:v1.PersistentVolumeClaimSpec{AccessModes:[]v1.PersistentVolumeAccessMode{"ReadWriteOnce"}, Selector:(*v1.LabelSelector)(nil), Resources:v1.ResourceRequirements{Limits:v1.ResourceList(nil), Requests:v1.ResourceList{"storage":resource.Quantity{i:resource.int64Amount{value:1073741824, scale:0}, d:resource.infDecAmount{Dec:(*inf.Dec)(nil)}, s:"1Gi", Format:"BinarySI"}}}, VolumeName:"", StorageClassName:(*string)(0xc000876e90), VolumeMode:(*v1.PersistentVolumeMode)(0xc000876ec0), DataSource:(*v1.TypedLocalObjectReference)(nil)}, Status:v1.PersistentVolumeClaimStatus{Phase:"Pending", AccessModes:[]v1.PersistentVolumeAccessMode(nil), Capacity:v1.ResourceList(nil), Conditions:[]v1.PersistentVolumeClaimCondition(nil)}}
Aug  3 16:35:53.930: INFO: PVC event MODIFIED: &v1.PersistentVolumeClaim{TypeMeta:v1.TypeMeta{Kind:"", APIVersion:""}, ObjectMeta:v1.ObjectMeta{Name:"pvc-zrchk", GenerateName:"pvc-", Namespace:"e2e-csi-mock-volumes-5292", SelfLink:"/api/v1/namespaces/e2e-csi-mock-volumes-5292/persistentvolumeclaims/pvc-zrchk", UID:"221369cd-50c3-48be-8c08-dc4d8f6f36e0", ResourceVersion:"42159", Generation:0, CreationTimestamp:v1.Time{Time:time.Time{wall:0x0, ext:63732069329, loc:(*time.Location)(0x9e74040)}}, DeletionTimestamp:(*v1.Time)(nil), DeletionGracePeriodSeconds:(*int64)(nil), Labels:map[string]string(nil), Annotations:map[string]string{"volume.beta.kubernetes.io/storage-provisioner":"csi-mock-e2e-csi-mock-volumes-5292"}, OwnerReferences:[]v1.OwnerReference(nil), Finalizers:[]string{"kubernetes.io/pvc-protection"}, ClusterName:"", ManagedFields:[]v1.ManagedFieldsEntry{v1.ManagedFieldsEntry{Manager:"kube-controller-manager", Operation:"Update", APIVersion:"v1", Time:(*v1.Time)(0xc0016a6060), FieldsType:"FieldsV1", FieldsV1:(*v1.FieldsV1)(0xc0016a6080)}, v1.ManagedFieldsEntry{Manager:"openshift-tests", Operation:"Update", APIVersion:"v1", Time:(*v1.Time)(0xc0016a60a0), FieldsType:"FieldsV1", FieldsV1:(*v1.FieldsV1)(0xc0016a60c0)}}}, Spec:v1.PersistentVolumeClaimSpec{AccessModes:[]v1.PersistentVolumeAccessMode{"ReadWriteOnce"}, Selector:(*v1.LabelSelector)(nil), Resources:v1.ResourceRequirements{Limits:v1.ResourceList(nil), Requests:v1.ResourceList{"storage":resource.Quantity{i:resource.int64Amount{value:1073741824, scale:0}, d:resource.infDecAmount{Dec:(*inf.Dec)(nil)}, s:"1Gi", Format:"BinarySI"}}}, VolumeName:"", StorageClassName:(*string)(0xc0012aa020), VolumeMode:(*v1.PersistentVolumeMode)(0xc0012aa030), DataSource:(*v1.TypedLocalObjectReference)(nil)}, Status:v1.PersistentVolumeClaimStatus{Phase:"Pending", AccessModes:[]v1.PersistentVolumeAccessMode(nil), Capacity:v1.ResourceList(nil), Conditions:[]v1.PersistentVolumeClaimCondition(nil)}}
Aug  3 16:35:53.930: INFO: PVC event MODIFIED: &v1.PersistentVolumeClaim{TypeMeta:v1.TypeMeta{Kind:"", APIVersion:""}, ObjectMeta:v1.ObjectMeta{Name:"pvc-zrchk", GenerateName:"pvc-", Namespace:"e2e-csi-mock-volumes-5292", SelfLink:"/api/v1/namespaces/e2e-csi-mock-volumes-5292/persistentvolumeclaims/pvc-zrchk", UID:"221369cd-50c3-48be-8c08-dc4d8f6f36e0", ResourceVersion:"43201", Generation:0, CreationTimestamp:v1.Time{Time:time.Time{wall:0x0, ext:63732069329, loc:(*time.Location)(0x9e74040)}}, DeletionTimestamp:(*v1.Time)(nil), DeletionGracePeriodSeconds:(*int64)(nil), Labels:map[string]string(nil), Annotations:map[string]string{"pv.kubernetes.io/bind-completed":"yes", "pv.kubernetes.io/bound-by-controller":"yes", "volume.beta.kubernetes.io/storage-provisioner":"csi-mock-e2e-csi-mock-volumes-5292"}, OwnerReferences:[]v1.OwnerReference(nil), Finalizers:[]string{"kubernetes.io/pvc-protection"}, ClusterName:"", ManagedFields:[]v1.ManagedFieldsEntry{v1.ManagedFieldsEntry{Manager:"openshift-tests", Operation:"Update", APIVersion:"v1", Time:(*v1.Time)(0xc0016a6100), FieldsType:"FieldsV1", FieldsV1:(*v1.FieldsV1)(0xc0016a6120)}, v1.ManagedFieldsEntry{Manager:"kube-controller-manager", Operation:"Update", APIVersion:"v1", Time:(*v1.Time)(0xc0016a6140), FieldsType:"FieldsV1", FieldsV1:(*v1.FieldsV1)(0xc0016a6160)}}}, Spec:v1.PersistentVolumeClaimSpec{AccessModes:[]v1.PersistentVolumeAccessMode{"ReadWriteOnce"}, Selector:(*v1.LabelSelector)(nil), Resources:v1.ResourceRequirements{Limits:v1.ResourceList(nil), Requests:v1.ResourceList{"storage":resource.Quantity{i:resource.int64Amount{value:1073741824, scale:0}, d:resource.infDecAmount{Dec:(*inf.Dec)(nil)}, s:"1Gi", Format:"BinarySI"}}}, VolumeName:"pvc-221369cd-50c3-48be-8c08-dc4d8f6f36e0", StorageClassName:(*string)(0xc0012aa090), VolumeMode:(*v1.PersistentVolumeMode)(0xc0012aa0a0), DataSource:(*v1.TypedLocalObjectReference)(nil)}, Status:v1.PersistentVolumeClaimStatus{Phase:"Pending", AccessModes:[]v1.PersistentVolumeAccessMode(nil), Capacity:v1.ResourceList(nil), Conditions:[]v1.PersistentVolumeClaimCondition(nil)}}
Aug  3 16:35:53.930: INFO: PVC event MODIFIED: &v1.PersistentVolumeClaim{TypeMeta:v1.TypeMeta{Kind:"", APIVersion:""}, ObjectMeta:v1.ObjectMeta{Name:"pvc-zrchk", GenerateName:"pvc-", Namespace:"e2e-csi-mock-volumes-5292", SelfLink:"/api/v1/namespaces/e2e-csi-mock-volumes-5292/persistentvolumeclaims/pvc-zrchk", UID:"221369cd-50c3-48be-8c08-dc4d8f6f36e0", ResourceVersion:"43203", Generation:0, CreationTimestamp:v1.Time{Time:time.Time{wall:0x0, ext:63732069329, loc:(*time.Location)(0x9e74040)}}, DeletionTimestamp:(*v1.Time)(nil), DeletionGracePeriodSeconds:(*int64)(nil), Labels:map[string]string(nil), Annotations:map[string]string{"pv.kubernetes.io/bind-completed":"yes", "pv.kubernetes.io/bound-by-controller":"yes", "volume.beta.kubernetes.io/storage-provisioner":"csi-mock-e2e-csi-mock-volumes-5292"}, OwnerReferences:[]v1.OwnerReference(nil), Finalizers:[]string{"kubernetes.io/pvc-protection"}, ClusterName:"", ManagedFields:[]v1.ManagedFieldsEntry{v1.ManagedFieldsEntry{Manager:"openshift-tests", Operation:"Update", APIVersion:"v1", Time:(*v1.Time)(0xc0016a6600), FieldsType:"FieldsV1", FieldsV1:(*v1.FieldsV1)(0xc0016a6620)}, v1.ManagedFieldsEntry{Manager:"kube-controller-manager", Operation:"Update", APIVersion:"v1", Time:(*v1.Time)(0xc0016a6660), FieldsType:"FieldsV1", FieldsV1:(*v1.FieldsV1)(0xc0016a6680)}}}, Spec:v1.PersistentVolumeClaimSpec{AccessModes:[]v1.PersistentVolumeAccessMode{"ReadWriteOnce"}, Selector:(*v1.LabelSelector)(nil), Resources:v1.ResourceRequirements{Limits:v1.ResourceList(nil), Requests:v1.ResourceList{"storage":resource.Quantity{i:resource.int64Amount{value:1073741824, scale:0}, d:resource.infDecAmount{Dec:(*inf.Dec)(nil)}, s:"1Gi", Format:"BinarySI"}}}, VolumeName:"pvc-221369cd-50c3-48be-8c08-dc4d8f6f36e0", StorageClassName:(*string)(0xc0012aa450), VolumeMode:(*v1.PersistentVolumeMode)(0xc0012aa460), DataSource:(*v1.TypedLocalObjectReference)(nil)}, Status:v1.PersistentVolumeClaimStatus{Phase:"Bound", AccessModes:[]v1.PersistentVolumeAccessMode{"ReadWriteOnce"}, Capacity:v1.ResourceList{"storage":resource.Quantity{i:resource.int64Amount{value:1073741824, scale:0}, d:resource.infDecAmount{Dec:(*inf.Dec)(nil)}, s:"1Gi", Format:"BinarySI"}}, Conditions:[]v1.PersistentVolumeClaimCondition(nil)}}
Aug  3 16:35:53.930: INFO: PVC event : <nil>
Aug  3 16:35:53.930: INFO: PVC event : <nil>
Aug  3 16:35:53.930: INFO: PVC event : <nil>
Aug  3 16:35:53.930: INFO: PVC event : <nil>
Aug  3 16:35:53.930: INFO: PVC event : <nil>
Aug  3 16:35:53.930: INFO: PVC event : <nil>
Aug  3 16:35:53.930: INFO: PVC event : <nil>
Aug  3 16:35:53.930: INFO: PVC event : <nil>
Aug  3 16:35:53.930: INFO: PVC event : <nil>
<11 million lines later...>
Aug  3 16:36:26.571: INFO: PVC event : <nil>
Aug  3 16:36:26.571: INFO: PVC event : <nil>
Aug  3 16:36:26.571: INFO: PVC event : <nil>
Aug  3 16:36:26.571: INFO: PVC event : <nil>
<test times out>
```

/kind failing-test
/sig testing
/sig storage
/priority important-soon
/milestone v1.19

```release-note
NONE
```