### PR TITLE
Set DeprecatedLastTimestamp and DeprecatedFirstTimestamp so LastTimestamp and FirstTimestamp are still set

### DIFF
--- a/staging/src/k8s.io/client-go/tools/events/event_recorder.go
+++ b/staging/src/k8s.io/client-go/tools/events/event_recorder.go
@@ -87,7 +87,8 @@ func (recorder *recorderImpl) makeEvent(refRegarding *v1.ObjectReference, refRel
 		Type:                eventtype,
 		// TODO: remove this when we change conversion to convert eventSource
 		// to reportingController
-		DeprecatedSource:        v1.EventSource{Component: reportingController},
-		DeprecatedLastTimestamp: t,
+		DeprecatedSource:         v1.EventSource{Component: reportingController},
+		DeprecatedLastTimestamp:  t,
+		DeprecatedFirstTimestamp: t,
 	}
 }

--- a/staging/src/k8s.io/client-go/tools/events/event_recorder.go
+++ b/staging/src/k8s.io/client-go/tools/events/event_recorder.go
@@ -87,6 +87,7 @@ func (recorder *recorderImpl) makeEvent(refRegarding *v1.ObjectReference, refRel
 		Type:                eventtype,
 		// TODO: remove this when we change conversion to convert eventSource
 		// to reportingController
-		DeprecatedSource: v1.EventSource{Component: reportingController},
+		DeprecatedSource:        v1.EventSource{Component: reportingController},
+		DeprecatedLastTimestamp: t,
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

Set `DeprecatedLastTimestamp` and `DeprecatedFirstTimestamp` so `LastTimestamp` and `FirstTimestamp` are still set when listing events with Last Seen column, resp. describing events when running `kubectl describe pod ...`

Also, when "oc get events --sort-by='.lastTimestamp'" it's essential to have all lastTimestamp fields
set. Otherwise, the following error message is produced:

```
F0715 09:18:21.343259   22629 sorter.go:354] Field {.lastTimestamp} in [][][]reflect.Value is an unsortable type: interface, err: unsortable interface: interface
```

The current output (LAST SEEN column is shown as `<unknown> ` when `LastTimestamp` is not set.
```
$ oc get events
LAST SEEN   TYPE      REASON                                OBJECT                                             MESSAGE
<unknown>   Normal    Scheduled                             pod/test                                           Successfully assigned default/test to ip-10-0-181-188.us-west-2.compute.internal
<unknown>   Normal    Scheduled                             pod/test                                           Successfully assigned default/test to ip-10-0-181-188.us-west-2.compute.internal
<unknown>   Normal    Scheduled                             pod/test                                           Successfully assigned default/test to ip-10-0-181-188.us-west-2.compute.internal

```

When neither of `LastTimestamp` nor `FirstTimestamp` are set:
```
Name:         annotation-second-scheduler
Namespace:    default
Events:
  Type    Reason          Age        From                                                 Message
  ----    ------          ----       ----                                                 -------
  Normal  Scheduled       <unknown>                                                       Successfully assigned default/annotation-second-scheduler to ip-xxx

```

Info: it's still valid to set lastTimestamp field when converting v1betav1/v1 event type to the core one before 1.19 (where the validation forbids the field to be set: https://github.com/kubernetes/kubernetes/pull/91645)

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #89689

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
