### PR TITLE
Avoid hanging during panic unwind on defer ... Wait()

### DIFF
--- a/staging/src/k8s.io/client-go/tools/cache/controller.go
+++ b/staging/src/k8s.io/client-go/tools/cache/controller.go
@@ -144,11 +144,11 @@ func (c *controller) Run(stopCh <-chan struct{}) {
 	c.reflectorMutex.Unlock()
 
 	var wg wait.Group
-	defer wg.Wait()
 
 	wg.StartWithChannel(stopCh, r.Run)
 
 	wait.Until(c.processLoop, time.Second, stopCh)
+	wg.Wait()
 }
 
 // Returns true once this controller has completed an initial resource listing

--- a/staging/src/k8s.io/client-go/tools/cache/shared_informer.go
+++ b/staging/src/k8s.io/client-go/tools/cache/shared_informer.go
@@ -397,7 +397,6 @@ func (s *sharedIndexInformer) Run(stopCh <-chan struct{}) {
 	// Separate stop channel because Processor should be stopped strictly after controller
 	processorStopCh := make(chan struct{})
 	var wg wait.Group
-	defer wg.Wait()              // Wait for Processor to stop
 	defer close(processorStopCh) // Tell Processor to stop
 	wg.StartWithChannel(processorStopCh, s.cacheMutationDetector.Run)
 	wg.StartWithChannel(processorStopCh, s.processor.run)
@@ -408,6 +407,7 @@ func (s *sharedIndexInformer) Run(stopCh <-chan struct{}) {
 		s.stopped = true // Don't want any new listeners
 	}()
 	s.controller.Run(stopCh)
+	wg.Wait() // Wait for Processor to stop
 }
 
 func (s *sharedIndexInformer) HasSynced() bool {


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:
Instead of waiting and possibly hanging, simply call `Wait()` at the end of the function, so that line will be skipped in the event of a panic.

Note that, during panic handling, all deferred functions are called before unwinding moves to the next stack level.
So waiting is always a dangerous thing to do in `defer`.

**Which issue(s) this PR fixes**:
Fixes #93641

**Special notes for your reviewer**:
This is an alternative fix to #93646

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
