### PR TITLE
PodReasonUnschedulable is not a pod condition type

### DIFF
--- a/pkg/kubelet/types/pod_status.go
+++ b/pkg/kubelet/types/pod_status.go
@@ -17,7 +17,7 @@ limitations under the License.
 package types
 
 import (
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 )
 
 // PodConditionsByKubelet is the list of pod conditions owned by kubelet
@@ -25,7 +25,6 @@ var PodConditionsByKubelet = []v1.PodConditionType{
 	v1.PodScheduled,
 	v1.PodReady,
 	v1.PodInitialized,
-	v1.PodReasonUnschedulable,
 	v1.ContainersReady,
 }
 

--- a/pkg/kubelet/types/pod_status_test.go
+++ b/pkg/kubelet/types/pod_status_test.go
@@ -17,8 +17,9 @@ limitations under the License.
 package types
 
 import (
-	"k8s.io/api/core/v1"
 	"testing"
+
+	v1 "k8s.io/api/core/v1"
 )
 
 func TestPodConditionByKubelet(t *testing.T) {
@@ -26,7 +27,7 @@ func TestPodConditionByKubelet(t *testing.T) {
 		v1.PodScheduled,
 		v1.PodReady,
 		v1.PodInitialized,
-		v1.PodReasonUnschedulable,
+		v1.ContainersReady,
 	}
 
 	for _, tc := range trueCases {
@@ -37,6 +38,7 @@ func TestPodConditionByKubelet(t *testing.T) {
 
 	falseCases := []v1.PodConditionType{
 		v1.PodConditionType("abcd"),
+		v1.PodConditionType(v1.PodReasonUnschedulable),
 	}
 
 	for _, tc := range falseCases {


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup
/sig node

**What this PR does / why we need it**:

This is a follow up from this PR: https://github.com/kubernetes/kubernetes/pull/93403. While investigating PR I found that PodReasonUnschedulable was added into the list of pod condition types while it is not a condition type. It was very confusing and set me on the wrong track chasing the history of the change. So simple clean up of the code to avoid potential confusion in future.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

See this note for details on that this is not a pod condition type:  https://github.com/kubernetes/website/issues/12051#issuecomment-452934782. I didn't find any mentions that anything changed since.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
