### PR TITLE
Implement custom completions for some flags using Go

### DIFF
--- a/pkg/kubectl/cmd/BUILD
+++ b/pkg/kubectl/cmd/BUILD
@@ -4,6 +4,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "cmd.go",
+        "completion.go",
         "profiling.go",
     ],
     importpath = "k8s.io/kubernetes/pkg/kubectl/cmd",
@@ -54,6 +55,7 @@ go_library(
         "//staging/src/k8s.io/kubectl/pkg/cmd/util:go_default_library",
         "//staging/src/k8s.io/kubectl/pkg/cmd/version:go_default_library",
         "//staging/src/k8s.io/kubectl/pkg/cmd/wait:go_default_library",
+        "//staging/src/k8s.io/kubectl/pkg/completion:go_default_library",
         "//staging/src/k8s.io/kubectl/pkg/util/i18n:go_default_library",
         "//staging/src/k8s.io/kubectl/pkg/util/templates:go_default_library",
         "//staging/src/k8s.io/kubectl/pkg/util/term:go_default_library",

--- a/pkg/kubectl/cmd/completion.go
+++ b/pkg/kubectl/cmd/completion.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+	"k8s.io/kubectl/pkg/cmd/util"
+	"k8s.io/kubectl/pkg/completion"
+)
+
+func registerCompletionFuncForGlobalFlags(cmd *cobra.Command, f util.Factory) {
+	util.CheckErr(cmd.RegisterFlagCompletionFunc(
+		"namespace",
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completion.ListNamespaces(f, toComplete)
+		}))
+	util.CheckErr(cmd.RegisterFlagCompletionFunc(
+		"context",
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completion.ListContextsInKubeconfig(f, toComplete)
+		}))
+	util.CheckErr(cmd.RegisterFlagCompletionFunc(
+		"cluster",
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completion.ListClustersInKubeconfig(f, toComplete)
+		}))
+	util.CheckErr(cmd.RegisterFlagCompletionFunc(
+		"user",
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completion.ListUsersInKubeconfig(f, toComplete)
+		}))
+}

--- a/staging/src/k8s.io/kubectl/BUILD
+++ b/staging/src/k8s.io/kubectl/BUILD
@@ -12,6 +12,7 @@ filegroup(
         "//staging/src/k8s.io/kubectl/pkg/apply:all-srcs",
         "//staging/src/k8s.io/kubectl/pkg/apps:all-srcs",
         "//staging/src/k8s.io/kubectl/pkg/cmd:all-srcs",
+        "//staging/src/k8s.io/kubectl/pkg/completion:all-srcs",
         "//staging/src/k8s.io/kubectl/pkg/describe:all-srcs",
         "//staging/src/k8s.io/kubectl/pkg/drain:all-srcs",
         "//staging/src/k8s.io/kubectl/pkg/explain:all-srcs",

--- a/staging/src/k8s.io/kubectl/pkg/completion/BUILD
+++ b/staging/src/k8s.io/kubectl/pkg/completion/BUILD
@@ -1,0 +1,28 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["utils.go"],
+    importmap = "k8s.io/kubernetes/vendor/k8s.io/kubectl/pkg/completion",
+    importpath = "k8s.io/kubectl/pkg/completion",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//staging/src/k8s.io/kubectl/pkg/cmd/util:go_default_library",
+        "//vendor/github.com/spf13/cobra:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/staging/src/k8s.io/kubectl/pkg/completion/utils.go
+++ b/staging/src/k8s.io/kubectl/pkg/completion/utils.go
@@ -1,0 +1,94 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package completion
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/kubectl/pkg/cmd/util"
+)
+
+// ListNamespaces returns a list of namespaces which begins with `toComplete`.
+func ListNamespaces(f util.Factory, toComplete string) ([]string, cobra.ShellCompDirective) {
+	clientSet, err := f.KubernetesClientSet()
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveDefault
+	}
+	ctx, cancel := context.WithTimeout(context.TODO(), time.Second*3)
+	defer cancel()
+	namespaces, err := clientSet.CoreV1().Namespaces().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveDefault
+	}
+	var ret []string
+	for _, ns := range namespaces.Items {
+		if strings.HasPrefix(ns.Name, toComplete) {
+			ret = append(ret, ns.Name)
+		}
+	}
+	return ret, cobra.ShellCompDirectiveNoFileComp
+}
+
+// ListContextsInKubeconfig returns a list of context names which begins with `toComplete`.
+func ListContextsInKubeconfig(f util.Factory, toComplete string) ([]string, cobra.ShellCompDirective) {
+	config, err := f.ToRawKubeConfigLoader().RawConfig()
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+	var ret []string
+	for name := range config.Contexts {
+		if strings.HasPrefix(name, toComplete) {
+			ret = append(ret, name)
+		}
+	}
+	return ret, cobra.ShellCompDirectiveNoFileComp
+}
+
+// ListClustersInKubeconfig returns a list of cluster names which begins with `toComplete`.
+func ListClustersInKubeconfig(f util.Factory, toComplete string) ([]string, cobra.ShellCompDirective) {
+	config, err := f.ToRawKubeConfigLoader().RawConfig()
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+	var ret []string
+	for name := range config.Clusters {
+		if strings.HasPrefix(name, toComplete) {
+			ret = append(ret, name)
+		}
+	}
+	return ret, cobra.ShellCompDirectiveNoFileComp
+}
+
+// ListUsersInKubeconfig returns a list of user names which begins with `toComplete`.
+func ListUsersInKubeconfig(f util.Factory, toComplete string) ([]string, cobra.ShellCompDirective) {
+	config, err := f.ToRawKubeConfigLoader().RawConfig()
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+	var ret []string
+	for name := range config.AuthInfos {
+		if strings.HasPrefix(name, toComplete) {
+			ret = append(ret, name)
+		}
+	}
+	return ret, cobra.ShellCompDirectiveNoFileComp
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -2312,6 +2312,7 @@ k8s.io/kubectl/pkg/cmd/util/editor/crlf
 k8s.io/kubectl/pkg/cmd/util/sanity
 k8s.io/kubectl/pkg/cmd/version
 k8s.io/kubectl/pkg/cmd/wait
+k8s.io/kubectl/pkg/completion
 k8s.io/kubectl/pkg/describe
 k8s.io/kubectl/pkg/drain
 k8s.io/kubectl/pkg/explain


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Implement custom completions using Go for flag `--context`, `--cluster`, `--user` and `--namespace`.

**Which issue(s) this PR fixes**:

Part of https://github.com/kubernetes/kubectl/issues/882

**Special notes for your reviewer**:

### Test the new completion code

1. build kubectl from source
```sh
make WHAT=cmd/kubectl
```

2. generate completion code
```sh
# zsh
source <(./_output/bin/kubectl completion zsh)

# bash
source <(./_output/bin/kubectl completion bash)
```

3. play with it

Please note that the new completion code requires the new kubectl.

```
./_output/bin/kubectl get --context [TAB]

# debug
./_output/bin/kubectl __complete get --context ''
```

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
