### PR TITLE
add testcases for kubelet getters

### DIFF
--- a/pkg/kubelet/kubelet_getters_test.go
+++ b/pkg/kubelet/kubelet_getters_test.go
@@ -21,6 +21,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"k8s.io/kubernetes/pkg/kubelet/cm"
 )
 
 func TestKubeletDirs(t *testing.T) {
@@ -39,6 +41,10 @@ func TestKubeletDirs(t *testing.T) {
 	exp = filepath.Join(root, "plugins")
 	assert.Equal(t, exp, got)
 
+	got = kubelet.getPluginsRegistrationDir()
+	exp = filepath.Join(root, "plugins_registry")
+	assert.Equal(t, exp, got)
+
 	got = kubelet.getPluginDir("foobar")
 	exp = filepath.Join(root, "plugins/foobar")
 	assert.Equal(t, exp, got)
@@ -55,6 +61,14 @@ func TestKubeletDirs(t *testing.T) {
 	exp = filepath.Join(root, "pods/abc123/volumes/plugin/foobar")
 	assert.Equal(t, exp, got)
 
+	got = kubelet.getPodVolumeDevicesDir("abc123")
+	exp = filepath.Join(root, "pods/abc123/volumeDevices")
+	assert.Equal(t, exp, got)
+
+	got = kubelet.getPodVolumeDeviceDir("abc123", "plugin")
+	exp = filepath.Join(root, "pods/abc123/volumeDevices/plugin")
+	assert.Equal(t, exp, got)
+
 	got = kubelet.getPodPluginsDir("abc123")
 	exp = filepath.Join(root, "pods/abc123/plugins")
 	assert.Equal(t, exp, got)
@@ -63,7 +77,29 @@ func TestKubeletDirs(t *testing.T) {
 	exp = filepath.Join(root, "pods/abc123/plugins/foobar")
 	assert.Equal(t, exp, got)
 
+	got = kubelet.getVolumeDevicePluginsDir()
+	exp = filepath.Join(root, "plugins")
+	assert.Equal(t, exp, got)
+
+	got = kubelet.getVolumeDevicePluginDir("foobar")
+	exp = filepath.Join(root, "plugins", "foobar", "volumeDevices")
+	assert.Equal(t, exp, got)
+
 	got = kubelet.getPodContainerDir("abc123", "def456")
 	exp = filepath.Join(root, "pods/abc123/containers/def456")
+	assert.Equal(t, exp, got)
+
+	got = kubelet.getPodResourcesDir()
+	exp = filepath.Join(root, "pod-resources")
+	assert.Equal(t, exp, got)
+
+	// GetNodeConfig for containerManagerStub returns an empty node config
+	gotCfg := kubelet.GetNodeConfig()
+	expCfg := cm.NodeConfig{}
+	assert.Equal(t, expCfg, gotCfg)
+
+	// GetPodCgroupRoot for containerManagerStub returns an empty string
+	got = kubelet.GetPodCgroupRoot()
+	exp = ""
 	assert.Equal(t, exp, got)
 }

--- a/pkg/kubelet/kubelet_getters_test.go
+++ b/pkg/kubelet/kubelet_getters_test.go
@@ -21,8 +21,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-
-	"k8s.io/kubernetes/pkg/kubelet/cm"
 )
 
 func TestKubeletDirs(t *testing.T) {
@@ -91,15 +89,5 @@ func TestKubeletDirs(t *testing.T) {
 
 	got = kubelet.getPodResourcesDir()
 	exp = filepath.Join(root, "pod-resources")
-	assert.Equal(t, exp, got)
-
-	// GetNodeConfig for containerManagerStub returns an empty node config
-	gotCfg := kubelet.GetNodeConfig()
-	expCfg := cm.NodeConfig{}
-	assert.Equal(t, expCfg, gotCfg)
-
-	// GetPodCgroupRoot for containerManagerStub returns an empty string
-	got = kubelet.GetPodCgroupRoot()
-	exp = ""
 	assert.Equal(t, exp, got)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Add test cases for kubelet getters on `TestKubeletDirs`.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
