### PR TITLE
leaderelection: Log and event on clean releases

### DIFF
--- a/staging/src/k8s.io/client-go/tools/leaderelection/leaderelection.go
+++ b/staging/src/k8s.io/client-go/tools/leaderelection/leaderelection.go
@@ -293,10 +293,13 @@ func (le *LeaderElector) release() bool {
 	leaderElectionRecord := rl.LeaderElectionRecord{
 		LeaderTransitions: le.observedRecord.LeaderTransitions,
 	}
+	desc := le.config.Lock.Describe()
 	if err := le.config.Lock.Update(context.TODO(), leaderElectionRecord); err != nil {
 		klog.Errorf("Failed to release lock: %v", err)
 		return false
 	}
+	le.config.Lock.RecordEvent("released leader lease")
+	klog.Infof("released lease %v", desc)
 	le.observedRecord = leaderElectionRecord
 	le.observedTime = le.clock.Now()
 	return true


### PR DESCRIPTION
We grew the ability to gracefully release leases in 09890b6c48 (#71490), but had no logging around that release until this commit.  This will help reduce some "is it working?" guesswork for folk attempting graceful releases.  Describe the lock before the Update attempt to reduce the amount of fiddling that happens between a successful release and the event/log.

```release-note
NONE
```