### PR TITLE
k8s.io/code-generator: Enable generate-*  scripts usage as module deps

### DIFF
--- a/staging/src/k8s.io/code-generator/generate-groups.sh
+++ b/staging/src/k8s.io/code-generator/generate-groups.sh
@@ -47,10 +47,10 @@ GROUPS_WITH_VERSIONS="$4"
 shift 4
 
 (
-  # To support running this script from anywhere, we have to first cd into this directory
-  # so we can install the tools.
+  # To support running this script from anywhere, first cd into this directory,
+  # and then install with forced module mode on and fully qualified name.
   cd "$(dirname "${0}")"
-  go install ./cmd/{defaulter-gen,client-gen,lister-gen,informer-gen,deepcopy-gen}
+  GO111MODULE=on go install k8s.io/code-generator/cmd/{defaulter-gen,client-gen,lister-gen,informer-gen,deepcopy-gen}
 )
 # Go installs the above commands to get installed in $GOBIN if defined, and $GOPATH/bin otherwise:
 GOBIN="$(go env GOBIN)"

--- a/staging/src/k8s.io/code-generator/generate-internal-groups.sh
+++ b/staging/src/k8s.io/code-generator/generate-internal-groups.sh
@@ -47,7 +47,12 @@ EXT_APIS_PKG="$4"
 GROUPS_WITH_VERSIONS="$5"
 shift 5
 
-go install ./"$(dirname "${0}")"/cmd/{defaulter-gen,conversion-gen,client-gen,lister-gen,informer-gen,deepcopy-gen,openapi-gen}
+(
+  # To support running this script from anywhere, first cd into this directory,
+  # and then install with forced module mode on and fully qualified name.
+  cd "$(dirname "${0}")"
+  GO111MODULE=on go install k8s.io/code-generator/cmd/{defaulter-gen,conversion-gen,client-gen,lister-gen,informer-gen,deepcopy-gen,openapi-gen}
+)
 
 function codegen::join() { local IFS="$1"; shift; echo "$*"; }
 


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

So far, the generate scripts could not be required as dependencies
with Go Modules (e.g. in tools.go) as they were installed without
proper module context.

This commit enables the generator scripts to be used as versioned
dependencies with Go Modules by forcing installation into
the fully-qualified module directory.

**Which issue(s) this PR fixes**:
Fixes #91358 #85559

**Special notes for your reviewer**:
n/a

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs

```
/cc @liggitt @sttts 