### PR TITLE
scheduler_perf/MixedSchedulingBasePod: label nodes for pod affinity

### DIFF
--- a/test/integration/scheduler_perf/config/performance-config.yaml
+++ b/test/integration/scheduler_perf/config/performance-config.yaml
@@ -212,6 +212,11 @@
     numPodsToSchedule: 2000
 - template:
     desc: MixedSchedulingBasePod
+    nodes:
+      nodeTemplatePath: config/node-default.yaml
+      labelNodePrepareStrategy:
+        labelKey: "topology.kubernetes.io/zone"
+        labelValues: ["zone1"]
     initPods:
     - podTemplatePath: config/pod-default.yaml
     - podTemplatePath: config/pod-with-pod-affinity.yaml


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
/kind failing-test

**What this PR does / why we need it**: the `MixedSchedulingBasePod` test was failing due to the lack of a node label. Also, the `failure-domain.beta.kubernetes.io/zone` label has been deprecated in favour of `topology.kubernetes.io/zone`. 

**Which issue(s) this PR fixes**:

Fixes https://github.com/kubernetes/kubernetes/issues/93729

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
```

/sig scheduling
/cc @alculquicondor 
