### PR TITLE
benchmark-dockerized.sh: set KUBE_ROOT

### DIFF
--- a/hack/jenkins/benchmark-dockerized.sh
+++ b/hack/jenkins/benchmark-dockerized.sh
@@ -31,6 +31,10 @@ retry() {
   "$@"
 }
 
+# The root of the build/dist directory
+KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/../..
+export KUBE_ROOT
+
 # Runs benchmark integration tests, producing pretty-printed results
 # in ${WORKSPACE}/artifacts. This script can also be run within a
 # kubekins-test container with a kubernetes repo mounted (at the path


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
/kind failing-test

**What this PR does / why we need it**: KUBE_ROOT isn't set at the head of the script. This causes failures in prow. See https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/ci-benchmark-scheduler-perf-master/1291080206085263361 for an example of this script failing.

**Which issue(s) this PR fixes**:

Related to https://github.com/kubernetes/kubernetes/issues/85686

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

/sig scheduling
/sig testing
/cc @liggitt 