### PR TITLE
Restart logging agent if installed on windows node.

### DIFF
--- a/cluster/gce/windows/k8s-node-setup.psm1
+++ b/cluster/gce/windows/k8s-node-setup.psm1
@@ -1623,6 +1623,10 @@ function Install-LoggingAgent {
     # installer binary and searched for flags to do this but found nothing. Oh
     # well.
     Log-Output ("Skip: Stackdriver logging agent is already installed")
+
+    # Restarting logging agent forces it to reconnect with the metadata 
+    # server. This makes the startup more reliable.
+    Restart-LoggingAgent
     return
   }
   


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Fixes logging agent failure to connect to metadata server on startup.

**Special notes for your reviewer**:
This was present in earlier releases and was removed via https://github.com/kubernetes/kubernetes/commit/0239a7d85779a9cbbf4ceb81ecfdee927aa05ecf
Reverting a part of an earlier commit that removed this line.

**Does this PR introduce a user-facing change?**:
NONE