### PR TITLE
Fix flaky kubectl test

### DIFF
--- a/test/e2e/kubectl/kubectl.go
+++ b/test/e2e/kubectl/kubectl.go
@@ -1481,6 +1481,7 @@ metadata:
 			time.Sleep(2500 * time.Millisecond) // ensure that startup logs on the node are seen as older than 1s
 			recentOut := framework.RunKubectlOrDie(ns, "logs", podName, containerName, nsFlag, "--since=1s")
 			recent := len(strings.Split(recentOut, "\n"))
+			time.Sleep(2500 * time.Millisecond) // ensure that enough logs on the node are created past previous call
 			olderOut := framework.RunKubectlOrDie(ns, "logs", podName, containerName, nsFlag, "--since=24h")
 			older := len(strings.Split(olderOut, "\n"))
 			gomega.Expect(recent).To(gomega.BeNumerically("<", older), "expected recent(%v) to be less than older(%v)\nrecent lines:\n%v\nolder lines:\n%v\n", recent, older, recentOut, olderOut)


### PR DESCRIPTION
**What type of PR is this?**
/kind flake
/sig cli
/area kubectl

**What this PR does / why we need it**:

A race condition could occur where the two calls to `kubectl logs` in the `[sig-cli] Kubectl client Kubectl logs should be able to retrieve and filter logs [Conformance]` e2e test would not have enough logs generated between them.

This PR adds a delay between test calls to `kubectl logs` to ensure that enough logs have been generated.

**Which issue(s) this PR fixes**:

Fixes #92468 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
