### PR TITLE
Configure StackdriverLogging Windows service to restart on failure.

### DIFF
--- a/cluster/gce/windows/k8s-node-setup.psm1
+++ b/cluster/gce/windows/k8s-node-setup.psm1
@@ -1180,7 +1180,7 @@ function Start-WorkerServices {
       "--cluster-cidr=$(${kube_env}['CLUSTER_IP_RANGE'])",
       "--hostname-override=${instance_name}"
   )
-  
+
   $kubeproxy_args = ${default_kubeproxy_args} + ${kubeproxy_args}
   Log-Output "Final kubeproxy_args: ${kubeproxy_args}"
 
@@ -1626,7 +1626,7 @@ function Install-LoggingAgent {
     Log-Output ("Skip: Fluentbit logging agent is already installed")
     return
   }
-  
+
   DownloadAndInstall-LoggingAgents
   Create-LoggingAgentServices
 }
@@ -1699,7 +1699,7 @@ $FLUENTBIT_CONFIG = @'
     Log_File      /var/log/fluentbit.log
     Daemon        off
     Parsers_File  parsers.conf
-    HTTP_Server   off 
+    HTTP_Server   off
     HTTP_Listen   0.0.0.0
     HTTP_PORT     2020
     plugins_file plugins.conf
@@ -1753,7 +1753,7 @@ $FLUENTBIT_CONFIG = @'
     # Channels Setup,Windows PowerShell
     Channels     application,system,security
     Tag          winevent.raw
-    DB           winlog.sqlite   # 
+    DB           winlog.sqlite   #
 
 
 # Json Log Example:
@@ -1767,9 +1767,9 @@ $FLUENTBIT_CONFIG = @'
     Mem_Buf_Limit    5MB
     Skip_Long_Lines  On
     Refresh_Interval 5
-    DB               flb_kube.db  
+    DB               flb_kube.db
 
-    # Settings from fluentd missing here.  
+    # Settings from fluentd missing here.
     # tag reform.*
     # format json
     # time_key time
@@ -2037,6 +2037,11 @@ function Configure-StackdriverAgent {
   $config = $FLUENTD_CONFIG.replace('NODE_NAME', (hostname))
   $config | Out-File -FilePath $fluentd_config_file -Encoding ASCII
   Log-Output "Wrote fluentd logging config to $fluentd_config_file"
+
+  # Configure StackdriverLogging to automatically restart on failure after 10
+  # seconds. The logging agent may die die to various disruptions but can be
+  # resumed.
+  sc.exe failure StackdriverLogging reset= 0 actions= restart/1000/restart/10000
 }
 
 # The NODE_NAME placeholder must be replaced with the node's name (hostname).


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This change configures the `StackdriverLogging` Windows service to automatically restart if it fails. This improves reliability of emitting Stackdriver log output when the host has disruptions that crash the logging agent. The service is configured to restart 1 second after first failure and then 10 seconds for subsequent failures.

Currently, there's a race between GCE/GKE metadata server being reachable and this service starting up. If the metadata server is unavailable it'll crash and never emit logs until manually started.

This change also improves the manual e2e testing documentation.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #94138


**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
NONE

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

