### PR TITLE
Revert "dump conntrack table on e2e conntrack failures"

### DIFF
--- a/test/e2e/network/conntrack.go
+++ b/test/e2e/network/conntrack.go
@@ -17,7 +17,6 @@ limitations under the License.
 package network
 
 import (
-	"context"
 	"fmt"
 	"strings"
 	"time"
@@ -117,9 +116,6 @@ var _ = SIGDescribe("Conntrack", func() {
 	})
 
 	ginkgo.It("should be able to preserve UDP traffic when server pod cycles for a NodePort service", func() {
-		// TODO(#91236): Remove once the test is debugged and fixed.
-		// dump conntrack table for debugging
-		defer dumpConntrack(cs)
 
 		// Create a NodePort service
 		udpJig := e2eservice.NewTestJig(cs, ns, serviceName)
@@ -197,9 +193,6 @@ var _ = SIGDescribe("Conntrack", func() {
 	})
 
 	ginkgo.It("should be able to preserve UDP traffic when server pod cycles for a ClusterIP service", func() {
-		// TODO(#91236): Remove once the test is debugged and fixed.
-		// dump conntrack table for debugging
-		defer dumpConntrack(cs)
 
 		// Create a ClusterIP service
 		udpJig := e2eservice.NewTestJig(cs, ns, serviceName)
@@ -276,24 +269,3 @@ var _ = SIGDescribe("Conntrack", func() {
 		}
 	})
 })
-
-func dumpConntrack(cs clientset.Interface) {
-	// Dump conntrack table of each node for troubleshooting using the kube-proxy pods
-	namespace := "kube-system"
-	pods, err := cs.CoreV1().Pods(namespace).List(context.TODO(), metav1.ListOptions{})
-	if err != nil || len(pods.Items) == 0 {
-		framework.Logf("failed to list kube-proxy pods in namespace: %s", namespace)
-		return
-	}
-	cmd := "conntrack -L"
-	for _, pod := range pods.Items {
-		if strings.Contains(pod.Name, "kube-proxy") {
-			stdout, err := framework.RunHostCmd(namespace, pod.Name, cmd)
-			if err != nil {
-				framework.Logf("Failed to dump conntrack table of node %s: %v", pod.Spec.NodeName, err)
-				continue
-			}
-			framework.Logf("conntrack table of node %s: %s", pod.Spec.NodeName, stdout)
-		}
-	}
-}


### PR DESCRIPTION


**What type of PR is this?**
/kind cleanup
/kind bug

**What this PR does / why we need it**:

This reverts commit 0ef7f27fc134a3d7914ecbf555aa89933ff85357.
It was dumping the conntrck rules once the test finished, for debugging

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
