### PR TITLE
[go1.15] Use errors.As to unwrap net errors

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/net/http.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/net/http.go
@@ -62,8 +62,11 @@ func JoinPreservingTrailingSlash(elem ...string) string {
 
 // IsTimeout returns true if the given error is a network timeout error
 func IsTimeout(err error) bool {
-	neterr, ok := err.(net.Error)
-	return ok && neterr != nil && neterr.Timeout()
+	var neterr net.Error
+	if errors.As(err, &neterr) {
+		return neterr != nil && neterr.Timeout()
+	}
+	return false
 }
 
 // IsProbableEOF returns true if the given error resembles a connection termination
@@ -76,7 +79,8 @@ func IsProbableEOF(err error) bool {
 	if err == nil {
 		return false
 	}
-	if uerr, ok := err.(*url.Error); ok {
+	var uerr *url.Error
+	if errors.As(err, &uerr) {
 		err = uerr.Err
 	}
 	msg := err.Error()

--- a/staging/src/k8s.io/apimachinery/pkg/util/net/util.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/net/util.go
@@ -17,9 +17,8 @@ limitations under the License.
 package net
 
 import (
+	"errors"
 	"net"
-	"net/url"
-	"os"
 	"reflect"
 	"syscall"
 )
@@ -40,34 +39,18 @@ func IPNetEqual(ipnet1, ipnet2 *net.IPNet) bool {
 
 // Returns if the given err is "connection reset by peer" error.
 func IsConnectionReset(err error) bool {
-	if urlErr, ok := err.(*url.Error); ok {
-		err = urlErr.Err
-	}
-	if opErr, ok := err.(*net.OpError); ok {
-		err = opErr.Err
-	}
-	if osErr, ok := err.(*os.SyscallError); ok {
-		err = osErr.Err
-	}
-	if errno, ok := err.(syscall.Errno); ok && errno == syscall.ECONNRESET {
-		return true
+	var errno syscall.Errno
+	if errors.As(err, &errno) {
+		return errno == syscall.ECONNRESET
 	}
 	return false
 }
 
 // Returns if the given err is "connection refused" error
 func IsConnectionRefused(err error) bool {
-	if urlErr, ok := err.(*url.Error); ok {
-		err = urlErr.Err
-	}
-	if opErr, ok := err.(*net.OpError); ok {
-		err = opErr.Err
-	}
-	if osErr, ok := err.(*os.SyscallError); ok {
-		err = osErr.Err
-	}
-	if errno, ok := err.(syscall.Errno); ok && errno == syscall.ECONNREFUSED {
-		return true
+	var errno syscall.Errno
+	if errors.As(err, &errno) {
+		return errno == syscall.ECONNREFUSED
 	}
 	return false
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Use errors.As to correctly unwrap permanent net errors returned by tls.Conn

See https://github.com/golang/go/issues/40554

```release-note
NONE
```

/cc @justaugustus 
/sig api-machinery