### PR TITLE
Deflake LimitRange e2e test

### DIFF
--- a/test/e2e/scheduling/limit_range.go
+++ b/test/e2e/scheduling/limit_range.go
@@ -38,7 +38,6 @@ import (
 	imageutils "k8s.io/kubernetes/test/utils/image"
 
 	"github.com/onsi/ginkgo"
-	"github.com/onsi/gomega"
 )
 
 const (
@@ -206,10 +205,8 @@ var _ = SIGDescribe("LimitRange", func() {
 		framework.ExpectNoError(err)
 
 		ginkgo.By("Verifying the LimitRange was deleted")
-		gomega.Expect(wait.Poll(time.Second*5, e2eservice.RespondingTimeout, func() (bool, error) {
-			selector := labels.SelectorFromSet(labels.Set(map[string]string{"name": limitRange.Name}))
-			options := metav1.ListOptions{LabelSelector: selector.String()}
-			limitRanges, err := f.ClientSet.CoreV1().LimitRanges(f.Namespace.Name).List(context.TODO(), options)
+		err = wait.Poll(time.Second*5, e2eservice.RespondingTimeout, func() (bool, error) {
+			limitRanges, err := f.ClientSet.CoreV1().LimitRanges(f.Namespace.Name).List(context.TODO(), metav1.ListOptions{})
 
 			if err != nil {
 				framework.Logf("Unable to retrieve LimitRanges: %v", err)
@@ -221,19 +218,14 @@ var _ = SIGDescribe("LimitRange", func() {
 				return true, nil
 			}
 
-			if len(limitRanges.Items) > 0 {
-				if limitRanges.Items[0].ObjectMeta.DeletionTimestamp == nil {
-					framework.Logf("deletion has not yet been observed")
-					return false, nil
-				}
-				return true, nil
+			for i := range limitRanges.Items {
+				lr := limitRanges.Items[i]
+				framework.Logf("LimitRange %v/%v has not yet been deleted", lr.Namespace, lr.Name)
 			}
 
 			return false, nil
-
-		}))
-
-		framework.ExpectNoError(err, "kubelet never observed the termination notice")
+		})
+		framework.ExpectNoError(err)
 
 		ginkgo.By("Creating a Pod with more than former max resources")
 		pod = newTestPod(podName+"2", getResourceList("600m", "600Mi", "600Gi"), v1.ResourceList{})


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
/kind flake
/sig scheduling
/priority critical-urgent

**What this PR does / why we need it**:

The old LimitRange e2e test has 2 major problems on verifying LimitRange gets deleted:

- it returns true when LimitRange is still present (L229 below)
    https://github.com/kubernetes/kubernetes/blob/a6405451674428172956116b4c93710ac03ebddd/test/e2e/scheduling/limit_range.go#L224-L229
- error of polling logic is totally bypassed due to a regression introduced in #76328 (the plain `gomega.Expect()` is an no-op)

This PR tries to fix the above two problems.

**Which issue(s) this PR fixes**:

Fixes #93782

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
