### PR TITLE
fix typos in cmd/kubeadm and cmd/kube-scheduler

### DIFF
--- a/cmd/kube-scheduler/app/options/insecure_serving.go
+++ b/cmd/kube-scheduler/app/options/insecure_serving.go
@@ -92,7 +92,7 @@ func (o *CombinedInsecureServingOptions) ApplyTo(c *schedulerappconfig.Config, c
 	return o.applyTo(c, componentConfig)
 }
 
-// ApplyToFromLoadedConfig updates the insecure serving options from the component config and then appies it to the given scheduler app configuration.
+// ApplyToFromLoadedConfig updates the insecure serving options from the component config and then applies it to the given scheduler app configuration.
 func (o *CombinedInsecureServingOptions) ApplyToFromLoadedConfig(c *schedulerappconfig.Config, componentConfig *kubeschedulerconfig.KubeSchedulerConfiguration) error {
 	if o == nil {
 		return nil

--- a/cmd/kubeadm/app/phases/certs/renewal/filerenewer.go
+++ b/cmd/kubeadm/app/phases/certs/renewal/filerenewer.go
@@ -23,13 +23,13 @@ import (
 	"k8s.io/kubernetes/cmd/kubeadm/app/util/pkiutil"
 )
 
-// FileRenewer define a certificate renewer implementation that uses given CA cert and key for generating new certficiates
+// FileRenewer define a certificate renewer implementation that uses given CA cert and key for generating new certificates
 type FileRenewer struct {
 	caCert *x509.Certificate
 	caKey  crypto.Signer
 }
 
-// NewFileRenewer returns a new certificate renewer that uses given CA cert and key for generating new certficiates
+// NewFileRenewer returns a new certificate renewer that uses given CA cert and key for generating new certificates
 func NewFileRenewer(caCert *x509.Certificate, caKey crypto.Signer) *FileRenewer {
 	return &FileRenewer{
 		caCert: caCert,


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Fix some typo.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
