### PR TITLE
intra-pod test improvements for bug-triage and node-level reporting

### DIFF
--- a/test/e2e/common/networking.go
+++ b/test/e2e/common/networking.go
@@ -50,12 +50,12 @@ var _ = ginkgo.Describe("[sig-network] Networking", func() {
 					framework.Logf("Warning: Test failure (%v) will occur due to %v", len(errors)+1, err) // convenient error message for diagnosis... how many pods failed, and on what hosts?
 				}
 			}
-			if len(errors) == 0 {
+			if len(errors) > 0 {
 				framework.Logf("Pod polling failure summary:")
 				for _, e := range errors {
 					framework.Logf("%v", e)
 				}
-				framework.Failf("Failed due to %v errors polling %v pods", errors, len(config.EndpointPods))
+				framework.Failf("Failed due to %v errors polling %v pods", len(errors), len(config.EndpointPods))
 			}
 		})
 

--- a/test/e2e/common/networking.go
+++ b/test/e2e/common/networking.go
@@ -103,7 +103,9 @@ var _ = ginkgo.Describe("[sig-network] Networking", func() {
 		*/
 		framework.ConformanceIt("should function for node-pod communication: http [LinuxOnly] [NodeConformance]", func() {
 			config := e2enetwork.NewCoreNetworkingTestConfig(f, true)
-			checkNodeConnectivity(config, "http", e2enetwork.EndpointHTTPPort)
+			for _, endpointPod := range config.EndpointPods {
+				config.DialFromNode("http", endpointPod.Status.PodIP, e2enetwork.EndpointHTTPPort, config.MaxTries, 0, sets.NewString(endpointPod.Name))
+			}
 		})
 
 		/*
@@ -115,7 +117,9 @@ var _ = ginkgo.Describe("[sig-network] Networking", func() {
 		*/
 		framework.ConformanceIt("should function for node-pod communication: udp [LinuxOnly] [NodeConformance]", func() {
 			config := e2enetwork.NewCoreNetworkingTestConfig(f, true)
-			checkNodeConnectivity(config, "udp", e2enetwork.EndpointUDPPort)
+			for _, endpointPod := range config.EndpointPods {
+				config.DialFromNode("udp", endpointPod.Status.PodIP, e2enetwork.EndpointUDPPort, config.MaxTries, 0, sets.NewString(endpointPod.Name))
+			}
 		})
 	})
 })

--- a/test/e2e/common/networking.go
+++ b/test/e2e/common/networking.go
@@ -52,7 +52,6 @@ var _ = ginkgo.Describe("[sig-network] Networking", func() {
 					framework.Logf("Now attempting to probe pod [[[ %v ]]]", endpointPod.Status.PodIP)
 					if err := config.DialFromTestContainer(protocol, endpointPod.Status.PodIP, port, config.MaxTries, 0, sets.NewString(endpointPod.Name)); err != nil {
 						errors = append(errors, err)
-						framework.Logf("Warning: Test failure (%v) will occur due to %v", len(errors), err) // convenient error message for diagnosis... how many pods failed, and on what hosts?
 					} else {
 						framework.Logf("Was able to reach %v on %v ", endpointPod.Status.PodIP, endpointPod.Status.HostIP)
 					}

--- a/test/e2e/framework/network/utils.go
+++ b/test/e2e/framework/network/utils.go
@@ -280,11 +280,10 @@ func (config *NetworkingTestConfig) DialFromContainer(protocol, dialCommand, con
 		// TODO: get rid of this delay #36281
 		time.Sleep(hitEndpointRetryDelay)
 	}
-
 	if dialCommand == echoHostname {
 		config.diagnoseMissingEndpoints(responses)
 	}
-	return fmt.Errorf("Did not find expected responses... \nTries %d\nCommand %v\nretrieved %v\nexpected %v\n", maxTries, cmd, responses, expectedResponses)
+	return fmt.Errorf("did not find expected responses... \nTries %d\nCommand %v\nretrieved %v\nexpected %v", maxTries, cmd, responses, expectedResponses)
 }
 
 // GetEndpointsFromTestContainer executes a curl via kubectl exec in a test container.

--- a/test/e2e/framework/network/utils.go
+++ b/test/e2e/framework/network/utils.go
@@ -681,6 +681,7 @@ func (config *NetworkingTestConfig) setupCore(selector map[string]string) {
 
 	epCount := len(config.EndpointPods)
 	config.MaxTries = epCount*epCount + testTries
+	framework.Logf("Setting MaxTries for pod polling to %v for networking test based on endpoint count %v", config.MaxTries, epCount)
 }
 
 // setup includes setupCore and also sets up services

--- a/test/e2e/framework/network/utils.go
+++ b/test/e2e/framework/network/utils.go
@@ -248,8 +248,7 @@ func makeCURLDialCommand(ipPort, dialCmd, protocol, targetIP string, targetPort 
 // maxTries == minTries will confirm that we see the expected endpoints and no
 // more for maxTries. Use this if you want to eg: fail a readiness check on a
 // pod and confirm it doesn't show up as an endpoint.
-//
-// returns nil if no error, or error message if failed after trying maxTries.
+// Returns nil if no error, or error message if failed after trying maxTries.
 func (config *NetworkingTestConfig) DialFromContainer(protocol, dialCommand, containerIP, targetIP string, containerHTTPPort, targetPort, maxTries, minTries int, expectedResponses sets.String) error {
 	ipPort := net.JoinHostPort(containerIP, strconv.Itoa(containerHTTPPort))
 	cmd := makeCURLDialCommand(ipPort, dialCommand, protocol, targetIP, targetPort)

--- a/test/e2e/framework/network/utils.go
+++ b/test/e2e/framework/network/utils.go
@@ -275,6 +275,7 @@ func (config *NetworkingTestConfig) DialFromContainer(protocol, dialCommand, con
 
 		// Check against i+1 so we exit if minTries == maxTries.
 		if (responses.Equal(expectedResponses) || responses.Len() == 0 && expectedResponses.Len() == 0) && i+1 >= minTries {
+			framework.Logf("reached %v after %v/%v tries", targetIP, i, maxTries)
 			return nil
 		}
 		// TODO: get rid of this delay #36281
@@ -283,7 +284,10 @@ func (config *NetworkingTestConfig) DialFromContainer(protocol, dialCommand, con
 	if dialCommand == echoHostname {
 		config.diagnoseMissingEndpoints(responses)
 	}
-	return fmt.Errorf("did not find expected responses... \nTries %d\nCommand %v\nretrieved %v\nexpected %v", maxTries, cmd, responses, expectedResponses)
+	returnMsg := fmt.Errorf("did not find expected responses... \nTries %d\nCommand %v\nretrieved %v\nexpected %v", maxTries, cmd, responses, expectedResponses)
+	framework.Logf("encountered error during dial (%v)", returnMsg)
+	return returnMsg
+
 }
 
 // GetEndpointsFromTestContainer executes a curl via kubectl exec in a test container.


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

- breadth first polling of pods
- fine grained debugging of pods that fail the first poll attempt
- summary of how many pods failed at the end

1) A breadth first poll is implemented like so, showing each host in the logs.  This way if one or two host are down you can clearly see which ones.

```
Aug 11 12:06:46.829: INFO: Breadth first check of 192.168.150.148 on host 172.18.0.2...
... 
Aug 11 11:57:27.078: INFO: reached 192.168.150.147 after 22/79 tries
```

This PR also adds a logging statement to clarify the way that "79" is calculated (as a function of the number of nodes ^2 + 30 :))... no clue where that all comes from. 
2) So, the logs now summarize:
```
Aug 11 12:06:47.169: INFO: reached 192.168.217.84 after 0/1 tries
Aug 11 12:06:47.169: INFO: Going to retry 0 out of 7 pods....
```
Fixes #93833 


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
     Added fine grained debugging to the intra-pod conformance test for helping easily resolve networking issues for nodes that might be unhealthy when running conformance or sonobuoy tests.
```
