### PR TITLE
Disable cluster-info dump test in large clusters

### DIFF
--- a/test/e2e/kubectl/kubectl.go
+++ b/test/e2e/kubectl/kubectl.go
@@ -1095,7 +1095,7 @@ metadata:
 		})
 	})
 
-	ginkgo.Describe("Kubectl cluster-info dump", func() {
+	ginkgo.Describe("Kubectl cluster-info dump [DisabledForLargeClusters]", func() {
 		ginkgo.It("should check if cluster-info dump succeeds", func() {
 			ginkgo.By("running cluster-info dump")
 			framework.RunKubectlOrDie(ns, "cluster-info", "dump")


### PR DESCRIPTION
Disable cluster-info dump test in large clusters

It is probably the test consuming the most memory in 5k correctness tests.

Ref: https://github.com/kubernetes/kubernetes/issues/93506

/kind failing-test

**What this PR does / why we need it**:
cluster-info dump test eats 15GB memory in 5k correctness tests

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs

```

/cc @wojtek-t
/cc @jprzychodzen 