### PR TITLE
Fast return when no any matched anti-affinity terms

### DIFF
--- a/pkg/scheduler/framework/plugins/interpodaffinity/filtering.go
+++ b/pkg/scheduler/framework/plugins/interpodaffinity/filtering.go
@@ -330,11 +330,13 @@ func satisfyExistingPodsAntiAffinity(state *preFilterState, nodeInfo *framework.
 
 //  Checks if the node satisifies the incoming pod's anti-affinity rules.
 func satisfyPodAntiAffinity(state *preFilterState, nodeInfo *framework.NodeInfo) bool {
-	for _, term := range state.podInfo.RequiredAntiAffinityTerms {
-		if topologyValue, ok := nodeInfo.Node().Labels[term.TopologyKey]; ok {
-			tp := topologyPair{key: term.TopologyKey, value: topologyValue}
-			if state.topologyToMatchedAntiAffinityTerms[tp] > 0 {
-				return false
+	if len(state.topologyToMatchedAntiAffinityTerms) > 0 {
+		for _, term := range state.podInfo.RequiredAntiAffinityTerms {
+			if topologyValue, ok := nodeInfo.Node().Labels[term.TopologyKey]; ok {
+				tp := topologyPair{key: term.TopologyKey, value: topologyValue}
+				if state.topologyToMatchedAntiAffinityTerms[tp] > 0 {
+					return false
+				}
 			}
 		}
 	}


### PR DESCRIPTION
When check the incoming pod's anti-affinity rules, there is change to
return early when there is no any matched anti-affinity terms in the
whole cluster.

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
If there is no any matched anti-affinity terms in the whole cluster, there is no need to check each pod affinity term again.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
None

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

