### PR TITLE
Remove unnecessary updates in deployment controller

### DIFF
--- a/pkg/controller/deployment/deployment_controller.go
+++ b/pkg/controller/deployment/deployment_controller.go
@@ -592,10 +592,6 @@ func (dc *DeploymentController) syncDeployment(key string) error {
 	everything := metav1.LabelSelector{}
 	if reflect.DeepEqual(d.Spec.Selector, &everything) {
 		dc.eventRecorder.Eventf(d, v1.EventTypeWarning, "SelectingAll", "This deployment is selecting all pods. A non-empty selector is required.")
-		if d.Status.ObservedGeneration < d.Generation {
-			d.Status.ObservedGeneration = d.Generation
-			dc.client.AppsV1().Deployments(d.Namespace).UpdateStatus(context.TODO(), d, metav1.UpdateOptions{})
-		}
 		return nil
 	}
 


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Code for overlapping deployment was added in #34952, but removed from #47579 later and This part should also have been cleaned up. The empty selector always return immediately, so there is no need to update the Generation. 

```release-note
NONE
```