### PR TITLE
fix(azure): set default value of VmssVirtualMachinesCacheTTLInSeconds when initializing scaleSet

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_vmss.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_vmss.go
@@ -83,13 +83,16 @@ type scaleSet struct {
 
 // newScaleSet creates a new scaleSet.
 func newScaleSet(az *Cloud) (VMSet, error) {
-	var err error
+	if az.Config.VmssVirtualMachinesCacheTTLInSeconds == 0 {
+		az.Config.VmssVirtualMachinesCacheTTLInSeconds = vmssVirtualMachinesCacheTTLDefaultInSeconds
+	}
 	ss := &scaleSet{
 		Cloud:           az,
 		availabilitySet: newAvailabilitySet(az),
 		vmssVMCache:     &sync.Map{},
 	}
 
+	var err error
 	if !ss.DisableAvailabilitySetNodes {
 		ss.availabilitySetNodesCache, err = ss.newAvailabilitySetNodesCache()
 		if err != nil {

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_vmss_cache.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_vmss_cache.go
@@ -154,9 +154,6 @@ func (ss *scaleSet) gcVMSSVMCache() error {
 
 // newVMSSVirtualMachinesCache instanciates a new VMs cache for VMs belonging to the provided VMSS.
 func (ss *scaleSet) newVMSSVirtualMachinesCache(resourceGroupName, vmssName, cacheKey string) (*azcache.TimedCache, error) {
-	if ss.Config.VmssVirtualMachinesCacheTTLInSeconds == 0 {
-		ss.Config.VmssVirtualMachinesCacheTTLInSeconds = vmssVirtualMachinesCacheTTLDefaultInSeconds
-	}
 	vmssVirtualMachinesCacheTTL := time.Duration(ss.Config.VmssVirtualMachinesCacheTTLInSeconds) * time.Second
 
 	getter := func(key string) (interface{}, error) {


### PR DESCRIPTION
Signed-off-by: knight42 <anonymousknight96@gmail.com>


**What type of PR is this?**

/kind flake

**What this PR does / why we need it**:

Set the default value of `VmssVirtualMachinesCacheTTLInSeconds` when we are initializing `scaleSet` rather than every time we invoke `newVMSSVirtualMachinesCache` to prevent data race.

**Which issue(s) this PR fixes**:

xref: https://github.com/kubernetes/kubernetes/pull/93605#issuecomment-671236187

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
