### PR TITLE
apiserver: remove inactive members from OWNERS

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -4,7 +4,6 @@ aliases:
     - sttts
     - tallclair
   sig-auth-audit-reviewers:
-    - CaoShuFeng
     - hzxuzhonghu
     - lavalamp
     - sttts

--- a/cmd/kube-apiserver/OWNERS
+++ b/cmd/kube-apiserver/OWNERS
@@ -23,7 +23,6 @@ reviewers:
 - ncdc
 - sttts
 - hzxuzhonghu
-- CaoShuFeng
 - logicalhan
 - yue9944882
 labels:

--- a/staging/src/k8s.io/apiserver/OWNERS
+++ b/staging/src/k8s.io/apiserver/OWNERS
@@ -17,7 +17,6 @@ reviewers:
 - ncdc
 - enj
 - hzxuzhonghu
-- CaoShuFeng
 - jennybuckley
 - apelisse
 - jpbetz

--- a/staging/src/k8s.io/apiserver/pkg/registry/rest/OWNERS
+++ b/staging/src/k8s.io/apiserver/pkg/registry/rest/OWNERS
@@ -17,7 +17,6 @@ reviewers:
 - dims
 - hongchaodeng
 - krousey
-- euank
 - ingvagabund
 - jianhuiz
 - sdminonne


### PR DESCRIPTION
Ref: https://github.com/kubernetes/org/issues/2076

As a part of cleaning up inactive members (who haven't been active since
beginning of 2019) from OWNERS files, this commit removes euank and
CaoShuFeng from the list of reviewers.

/kind cleanup
cc @euank @CaoShuFeng @mrbobbytables 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
