### PR TITLE
cluster/addons/dashboard: remove inactive members from OWNERS

### DIFF
--- a/cluster/addons/dashboard/OWNERS
+++ b/cluster/addons/dashboard/OWNERS
@@ -6,8 +6,6 @@ approvers:
 - jeefy
 - maciaszczykm
 reviewers:
-- cheld
 - danielromlein
 - ianlewis
-- konryd
 - rf232


### PR DESCRIPTION
Ref: https://github.com/kubernetes/org/issues/2076

As a part of cleaning up inactive members (who haven't been active since
beginning of 2019) from OWNERS files, this commit removes konryd and
cheld from the list of reviewers.

cc @konryd @cheld @mrbobbytables 

/kind cleanup
/assign @jeefy 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
