### PR TITLE
sig-network: remove inactive members from OWNERS_ALIASES

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -266,7 +266,6 @@ aliases:
     - freehan
     - johnbelamaric
     - mrhohn
-    - nicksardo
     - thockin
   sig-network-reviewers:
     - andrewsykim
@@ -280,7 +279,6 @@ aliases:
     - johnbelamaric
     - m1093782566
     - mrhohn
-    - nicksardo
     - rramkumar1
     - thockin
   sig-apps-approvers:


### PR DESCRIPTION
Ref: kubernetes/org#2076

As a part of cleaning up inactive members (who haven't been active since
beginning of 2019) from OWNERS files, this commit removes nicksardo from
sig-network aliases in OWNERS_ALIASES.

cc @nicksardo @mrbobbytables 

/kind cleanup
/assign @MrHohn 


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```