### PR TITLE
vsphere: remove inactive members from OWNERS

### DIFF
--- a/pkg/volume/vsphere_volume/OWNERS
+++ b/pkg/volume/vsphere_volume/OWNERS
@@ -7,11 +7,10 @@ approvers:
 - SandeepPissay
 - divyenpatel
 - BaluDontu
-- abrarshivani
 emeritus_approvers:
 - matchstick
-reviewers:
 - abrarshivani
+reviewers:
 - saad-ali
 - justinsb
 - jsafrane

--- a/staging/src/k8s.io/legacy-cloud-providers/vsphere/OWNERS
+++ b/staging/src/k8s.io/legacy-cloud-providers/vsphere/OWNERS
@@ -1,14 +1,12 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-- abrarshivani
 - baludontu
 - divyenpatel
 - frapposelli
 - dougm
 - SandeepPissay
 reviewers:
-- abrarshivani
 - baludontu
 - divyenpatel
 - frapposelli
@@ -16,3 +14,4 @@ reviewers:
 - SandeepPissay
 emeritus_approvers:
 - imkin
+- abrarshivani

--- a/test/e2e/framework/providers/vsphere/OWNERS
+++ b/test/e2e/framework/providers/vsphere/OWNERS
@@ -7,15 +7,14 @@ approvers:
 - SandeepPissay
 - divyenpatel
 - BaluDontu
-- abrarshivani
 - imkin
 - frapposelli
 - dougm
 - sandeeppsunny
 emeritus_approvers:
 - matchstick
-reviewers:
 - abrarshivani
+reviewers:
 - saad-ali
 - justinsb
 - jsafrane


### PR DESCRIPTION
Ref: kubernetes/org#2076

As a part of cleaning up inactive members (who haven't been active since
beginning of 2019) from OWNERS files, this commit moves abrarshivani to
emeritus_approvers section.

cc @abrarshivani @mrbobbytables 

/kind cleanup
/assign @divyenpatel 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
