### PR TITLE
update ResourceMetricsAPI tests

### DIFF
--- a/test/e2e_node/BUILD
+++ b/test/e2e_node/BUILD
@@ -156,7 +156,6 @@ go_test(
         "//pkg/kubelet:go_default_library",
         "//pkg/kubelet/apis/config:go_default_library",
         "//pkg/kubelet/apis/podresources/v1alpha1:go_default_library",
-        "//pkg/kubelet/apis/resourcemetrics/v1alpha1:go_default_library",
         "//pkg/kubelet/apis/stats/v1alpha1:go_default_library",
         "//pkg/kubelet/cm:go_default_library",
         "//pkg/kubelet/cm/cpumanager:go_default_library",

--- a/test/e2e_node/resource_metrics_test.go
+++ b/test/e2e_node/resource_metrics_test.go
@@ -21,7 +21,6 @@ import (
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	kubeletresourcemetricsv1alpha1 "k8s.io/kubernetes/pkg/kubelet/apis/resourcemetrics/v1alpha1"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2ekubectl "k8s.io/kubernetes/test/e2e/framework/kubectl"
 	e2emetrics "k8s.io/kubernetes/test/e2e/framework/metrics"
@@ -41,16 +40,16 @@ const (
 	maxStatsAge = time.Minute
 )
 
-var _ = framework.KubeDescribe("ResourceMetricsAPI", func() {
+var _ = framework.KubeDescribe("ResourceMetricsAPI [NodeFeature:ResourceMetrics]", func() {
 	f := framework.NewDefaultFramework("resource-metrics")
 	ginkgo.Context("when querying /resource/metrics", func() {
 		ginkgo.BeforeEach(func() {
-			ginkgo.By("Creating test pods")
+			ginkgo.By("Creating test pods to measure their resource usage")
 			numRestarts := int32(1)
 			pods := getSummaryTestPods(f, numRestarts, pod0, pod1)
 			f.PodClient().CreateBatch(pods)
 
-			ginkgo.By("Waiting for test pods to restart the desired number of times")
+			ginkgo.By("restarting the containers to ensure container metrics are still being gathered after a container is restarted")
 			gomega.Eventually(func() error {
 				for _, pod := range pods {
 					err := verifyPodRestartCount(f, pod.Name, len(pod.Spec.Containers), numRestarts)
@@ -64,13 +63,13 @@ var _ = framework.KubeDescribe("ResourceMetricsAPI", func() {
 			ginkgo.By("Waiting 15 seconds for cAdvisor to collect 2 stats points")
 			time.Sleep(15 * time.Second)
 		})
-		ginkgo.It("should report resource usage through the v1alpha1 resouce metrics api", func() {
-			ginkgo.By("Fetching node so we can know proper node memory bounds for unconstrained cgroups")
+		ginkgo.It("should report resource usage through the resouce metrics api", func() {
+			ginkgo.By("Fetching node so we can match against an appropriate memory limit")
 			node := getLocalNode(f)
 			memoryCapacity := node.Status.Capacity["memory"]
 			memoryLimit := memoryCapacity.Value()
 
-			matchV1alpha1Expectations := gstruct.MatchAllKeys(gstruct.Keys{
+			matchResourceMetrics := gstruct.MatchAllKeys(gstruct.Keys{
 				"scrape_error": gstruct.Ignore(),
 				"node_cpu_usage_seconds_total": gstruct.MatchAllElements(nodeID, gstruct.Elements{
 					"": boundedSample(1, 1e6),
@@ -90,14 +89,15 @@ var _ = framework.KubeDescribe("ResourceMetricsAPI", func() {
 				}),
 			})
 			ginkgo.By("Giving pods a minute to start up and produce metrics")
-			gomega.Eventually(getV1alpha1ResourceMetrics, 1*time.Minute, 15*time.Second).Should(matchV1alpha1Expectations)
+			gomega.Eventually(getResourceMetrics, 1*time.Minute, 15*time.Second).Should(matchResourceMetrics)
 			ginkgo.By("Ensuring the metrics match the expectations a few more times")
-			gomega.Consistently(getV1alpha1ResourceMetrics, 1*time.Minute, 15*time.Second).Should(matchV1alpha1Expectations)
+			gomega.Consistently(getResourceMetrics, 1*time.Minute, 15*time.Second).Should(matchResourceMetrics)
 		})
 		ginkgo.AfterEach(func() {
 			ginkgo.By("Deleting test pods")
-			f.PodClient().DeleteSync(pod0, metav1.DeleteOptions{}, 10*time.Minute)
-			f.PodClient().DeleteSync(pod1, metav1.DeleteOptions{}, 10*time.Minute)
+			var zero int64 = 0
+			f.PodClient().DeleteSync(pod0, metav1.DeleteOptions{GracePeriodSeconds: &zero}, 10*time.Minute)
+			f.PodClient().DeleteSync(pod1, metav1.DeleteOptions{GracePeriodSeconds: &zero}, 10*time.Minute)
 			if !ginkgo.CurrentGinkgoTestDescription().Failed {
 				return
 			}
@@ -110,8 +110,9 @@ var _ = framework.KubeDescribe("ResourceMetricsAPI", func() {
 	})
 })
 
-func getV1alpha1ResourceMetrics() (e2emetrics.KubeletMetrics, error) {
-	return e2emetrics.GrabKubeletMetricsWithoutProxy(framework.TestContext.NodeName+":10255", "/metrics/resource/"+kubeletresourcemetricsv1alpha1.Version)
+func getResourceMetrics() (e2emetrics.KubeletMetrics, error) {
+	ginkgo.By("getting stable resource metrics API")
+	return e2emetrics.GrabKubeletMetricsWithoutProxy(framework.TestContext.NodeName+":10255", "/metrics/resource")
 }
 
 func nodeID(element interface{}) string {


### PR DESCRIPTION
/metrics/resource/v1alpha1 was deprecated and moved to
/metrics/resource

Renames to remove v1alpha1 from function names and matcher variables.

Pod deletion was taking multiple minutes, so set GracePeriodSeconds to 0.

Removed restart loop during test pod startup.

Move ResourceMetricsAPI out of Orphans by giving it a NodeFeature tag.

API removed in 7b7c73bf8754f2d9c7c3bfa7f3a196fdb19e74f1 #88568
Test created 6051664c0fb0eb78a84cea8bf5a1e1e4584de50e #73946

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind cleanup
/kind failing-test

**What this PR does / why we need it**:
API moved without updating test.

**Which issue(s) this PR fixes**:
Failing tests in https://testgrid.k8s.io/sig-node-kubelet#node-kubelet-orphans

**Special notes for your reviewer**:
/cc @vpickard 
/assign @dashpole 
Is there an explanation for the restart loop? It looks like it may have been a copy and paste from the garbage collection test.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
