### PR TITLE
Wrap InstanceNotFound into ErrorNotVmssInstance

### DIFF
--- a/pkg/volume/azure_dd/attacher.go
+++ b/pkg/volume/azure_dd/attacher.go
@@ -19,6 +19,7 @@ limitations under the License.
 package azure_dd
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -70,7 +71,7 @@ func (a *azureDiskAttacher) Attach(spec *volume.Spec, nodeName types.NodeName) (
 	}
 
 	lun, err := diskController.GetDiskLun(volumeSource.DiskName, volumeSource.DataDiskURI, nodeName)
-	if err == cloudprovider.InstanceNotFound {
+	if errors.Is(err, cloudprovider.InstanceNotFound) {
 		// Log error and continue with attach
 		klog.Warningf(
 			"Error checking if volume is already attached to current node (%q). Will continue and try attach anyway. err=%v",

--- a/pkg/volume/gcepd/attacher_test.go
+++ b/pkg/volume/gcepd/attacher_test.go
@@ -300,7 +300,7 @@ func TestVerifyVolumesAttached(t *testing.T) {
 			test: func(testcase *testcase) error {
 				attacher := newAttacher(testcase)
 				_, err := attacher.VolumesAreAttached([]*volume.Spec{diskASpec}, nodeName1)
-				if err != cloudprovider.InstanceNotFound {
+				if !errors.Is(err, cloudprovider.InstanceNotFound) {
 					return fmt.Errorf("expected InstanceNotFound error, but got %v", err)
 				}
 				return err

--- a/staging/src/k8s.io/cloud-provider/controllers/node/node_controller.go
+++ b/staging/src/k8s.io/cloud-provider/controllers/node/node_controller.go
@@ -543,7 +543,7 @@ func ensureNodeExistsByProviderID(ctx context.Context, instances cloudprovider.I
 		var err error
 		providerID, err = instances.InstanceID(ctx, types.NodeName(node.Name))
 		if err != nil {
-			if err == cloudprovider.InstanceNotFound {
+			if errors.Is(err, cloudprovider.InstanceNotFound) {
 				return false, nil
 			}
 			return false, err

--- a/staging/src/k8s.io/cloud-provider/controllers/nodelifecycle/node_lifecycle_controller.go
+++ b/staging/src/k8s.io/cloud-provider/controllers/nodelifecycle/node_lifecycle_controller.go
@@ -225,7 +225,7 @@ func ensureNodeExistsByProviderID(ctx context.Context, cloud cloudprovider.Inter
 		var err error
 		providerID, err = instances.InstanceID(ctx, types.NodeName(node.Name))
 		if err != nil {
-			if err == cloudprovider.InstanceNotFound {
+			if errors.Is(err, cloudprovider.InstanceNotFound) {
 				return false, nil
 			}
 			return false, err

--- a/staging/src/k8s.io/legacy-cloud-providers/aws/aws.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/aws/aws.go
@@ -1688,7 +1688,7 @@ func (c *Cloud) InstanceID(ctx context.Context, nodeName types.NodeName) (string
 	}
 	inst, err := c.getInstanceByNodeName(nodeName)
 	if err != nil {
-		if err == cloudprovider.InstanceNotFound {
+		if errors.Is(err, cloudprovider.InstanceNotFound) {
 			// The Instances interface requires that we return InstanceNotFound (without wrapping)
 			return "", err
 		}

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_backoff.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_backoff.go
@@ -19,6 +19,7 @@ limitations under the License.
 package azure
 
 import (
+	"errors"
 	"net/http"
 	"strings"
 
@@ -71,7 +72,7 @@ func (az *Cloud) GetVirtualMachineWithRetry(name types.NodeName, crt azcache.Azu
 	var retryErr error
 	err := wait.ExponentialBackoff(az.RequestBackoff(), func() (bool, error) {
 		machine, retryErr = az.getVirtualMachine(name, crt)
-		if retryErr == cloudprovider.InstanceNotFound {
+		if errors.Is(retryErr, cloudprovider.InstanceNotFound) {
 			return true, cloudprovider.InstanceNotFound
 		}
 		if retryErr != nil {
@@ -114,7 +115,7 @@ func (az *Cloud) getPrivateIPsForMachineWithRetry(nodeName types.NodeName) ([]st
 		privateIPs, retryErr = az.vmSet.GetPrivateIPsByNodeName(string(nodeName))
 		if retryErr != nil {
 			// won't retry since the instance doesn't exist on Azure.
-			if retryErr == cloudprovider.InstanceNotFound {
+			if errors.Is(retryErr, cloudprovider.InstanceNotFound) {
 				return true, retryErr
 			}
 			klog.Errorf("GetPrivateIPsByNodeName(%s): backoff failure, will retry,err=%v", nodeName, retryErr)

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_controller_common.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_controller_common.go
@@ -20,6 +20,7 @@ package azure
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"path"
@@ -190,7 +191,7 @@ func (c *controllerCommon) AttachDisk(isManagedDisk bool, diskName, diskURI stri
 func (c *controllerCommon) DetachDisk(diskName, diskURI string, nodeName types.NodeName) error {
 	_, err := c.cloud.InstanceID(context.TODO(), nodeName)
 	if err != nil {
-		if err == cloudprovider.InstanceNotFound {
+		if errors.Is(err, cloudprovider.InstanceNotFound) {
 			// if host doesn't exist, no need to detach
 			klog.Warningf("azureDisk - failed to get azure instance id(%q), DetachDisk(%s) will assume disk is already detached",
 				nodeName, diskURI)
@@ -314,7 +315,7 @@ func (c *controllerCommon) DisksAreAttached(diskNames []string, nodeName types.N
 	// loop runs after the Attach/Disk OP which will reflect the latest model.
 	disks, err := c.getNodeDataDisks(nodeName, azcache.CacheReadTypeUnsafe)
 	if err != nil {
-		if err == cloudprovider.InstanceNotFound {
+		if errors.Is(err, cloudprovider.InstanceNotFound) {
 			// if host doesn't exist, no need to detach
 			klog.Warningf("azureDisk - Cannot find node %q, DisksAreAttached will assume disks %v are not attached to it.",
 				nodeName, diskNames)

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_controller_vmss_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_controller_vmss_test.go
@@ -60,7 +60,7 @@ func TestAttachDiskWithVMSS(t *testing.T) {
 			isManagedDisk:  false,
 			existedDisk:    compute.Disk{Name: to.StringPtr("disk-name")},
 			expectedErr:    true,
-			expectedErrMsg: fmt.Errorf("not a vmss instance"),
+			expectedErrMsg: ErrorNotVmssInstance,
 		},
 		{
 			desc:          "no error shall be returned if everything is good with managed disk",
@@ -159,7 +159,7 @@ func TestDetachDiskWithVMSS(t *testing.T) {
 			vmssvmName:     "vm1",
 			existedDisk:    compute.Disk{Name: to.StringPtr(diskName)},
 			expectedErr:    true,
-			expectedErrMsg: fmt.Errorf("not a vmss instance"),
+			expectedErrMsg: ErrorNotVmssInstance,
 		},
 		{
 			desc:        "no error shall be returned if everything is good",

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_instances.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_instances.go
@@ -20,6 +20,7 @@ package azure
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -191,7 +192,7 @@ func (az *Cloud) InstanceExistsByProviderID(ctx context.Context, providerID stri
 
 	name, err := az.vmSet.GetNodeNameByProviderID(providerID)
 	if err != nil {
-		if err == cloudprovider.InstanceNotFound {
+		if errors.Is(err, cloudprovider.InstanceNotFound) {
 			return false, nil
 		}
 		return false, err
@@ -199,7 +200,7 @@ func (az *Cloud) InstanceExistsByProviderID(ctx context.Context, providerID stri
 
 	_, err = az.InstanceID(ctx, name)
 	if err != nil {
-		if err == cloudprovider.InstanceNotFound {
+		if errors.Is(err, cloudprovider.InstanceNotFound) {
 			return false, nil
 		}
 		return false, err
@@ -217,7 +218,7 @@ func (az *Cloud) InstanceShutdownByProviderID(ctx context.Context, providerID st
 	nodeName, err := az.vmSet.GetNodeNameByProviderID(providerID)
 	if err != nil {
 		// Returns false, so the controller manager will continue to check InstanceExistsByProviderID().
-		if err == cloudprovider.InstanceNotFound {
+		if errors.Is(err, cloudprovider.InstanceNotFound) {
 			return false, nil
 		}
 
@@ -227,7 +228,7 @@ func (az *Cloud) InstanceShutdownByProviderID(ctx context.Context, providerID st
 	powerStatus, err := az.vmSet.GetPowerStatusByNodeName(string(nodeName))
 	if err != nil {
 		// Returns false, so the controller manager will continue to check InstanceExistsByProviderID().
-		if err == cloudprovider.InstanceNotFound {
+		if errors.Is(err, cloudprovider.InstanceNotFound) {
 			return false, nil
 		}
 

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_standard.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_standard.go
@@ -397,7 +397,7 @@ func (as *availabilitySet) GetInstanceIDByNodeName(name string) (string, error) 
 	var err error
 
 	machine, err = as.getVirtualMachine(types.NodeName(name), azcache.CacheReadTypeUnsafe)
-	if err == cloudprovider.InstanceNotFound {
+	if errors.Is(err, cloudprovider.InstanceNotFound) {
 		return "", cloudprovider.InstanceNotFound
 	}
 	if err != nil {

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_vmss.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_vmss.go
@@ -19,7 +19,6 @@ limitations under the License.
 package azure
 
 import (
-	"errors"
 	"fmt"
 	"regexp"
 	"sort"
@@ -45,7 +44,7 @@ var (
 	virtualMachineScaleSetsDeallocating = "Deallocating"
 
 	// ErrorNotVmssInstance indicates an instance is not belonging to any vmss.
-	ErrorNotVmssInstance = errors.New("not a vmss instance")
+	ErrorNotVmssInstance = fmt.Errorf("%w: not a vmss instance", cloudprovider.InstanceNotFound)
 
 	scaleSetNameRE         = regexp.MustCompile(`.*/subscriptions/(?:.*)/Microsoft.Compute/virtualMachineScaleSets/(.+)/virtualMachines(?:.*)`)
 	resourceGroupRE        = regexp.MustCompile(`.*/subscriptions/(?:.*)/resourceGroups/(.+)/providers/Microsoft.Compute/virtualMachineScaleSets/(?:.*)/virtualMachines(?:.*)`)

--- a/staging/src/k8s.io/legacy-cloud-providers/gce/gce_disks.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/gce/gce_disks.go
@@ -21,6 +21,7 @@ package gce
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -585,7 +586,7 @@ func (g *Cloud) DetachDisk(devicePath string, nodeName types.NodeName) error {
 	instanceName := mapNodeNameToInstanceName(nodeName)
 	inst, err := g.getInstanceByName(instanceName)
 	if err != nil {
-		if err == cloudprovider.InstanceNotFound {
+		if errors.Is(err, cloudprovider.InstanceNotFound) {
 			// If instance no longer exists, safe to assume volume is not attached.
 			klog.Warningf(
 				"Instance %q does not exist. DetachDisk will assume PD %q is not attached to it.",
@@ -606,7 +607,7 @@ func (g *Cloud) DiskIsAttached(diskName string, nodeName types.NodeName) (bool, 
 	instanceName := mapNodeNameToInstanceName(nodeName)
 	instance, err := g.getInstanceByName(instanceName)
 	if err != nil {
-		if err == cloudprovider.InstanceNotFound {
+		if errors.Is(err, cloudprovider.InstanceNotFound) {
 			// If instance no longer exists, safe to assume volume is not attached.
 			klog.Warningf(
 				"Instance %q does not exist. DiskIsAttached will assume PD %q is not attached to it.",
@@ -638,7 +639,7 @@ func (g *Cloud) DisksAreAttached(diskNames []string, nodeName types.NodeName) (m
 	instanceName := mapNodeNameToInstanceName(nodeName)
 	instance, err := g.getInstanceByName(instanceName)
 	if err != nil {
-		if err == cloudprovider.InstanceNotFound {
+		if errors.Is(err, cloudprovider.InstanceNotFound) {
 			// If instance no longer exists, safe to assume volume is not attached.
 			klog.Warningf(
 				"Instance %q does not exist. DisksAreAttached will assume PD %v are not attached to it.",

--- a/staging/src/k8s.io/legacy-cloud-providers/gce/gce_instances.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/gce/gce_instances.go
@@ -20,6 +20,7 @@ package gce
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -244,7 +245,7 @@ func (g *Cloud) InstanceTypeByProviderID(ctx context.Context, providerID string)
 func (g *Cloud) InstanceExistsByProviderID(ctx context.Context, providerID string) (bool, error) {
 	_, err := g.instanceByProviderID(providerID)
 	if err != nil {
-		if err == cloudprovider.InstanceNotFound {
+		if errors.Is(err, cloudprovider.InstanceNotFound) {
 			return false, nil
 		}
 		return false, err

--- a/staging/src/k8s.io/legacy-cloud-providers/vsphere/vsphere_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/vsphere/vsphere_test.go
@@ -23,6 +23,7 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"errors"
 	"flag"
 	"io/ioutil"
 	"log"
@@ -757,7 +758,7 @@ func TestInstances(t *testing.T) {
 	t.Logf("Found InstanceID(%s) = %s\n", nodeName, instanceID)
 
 	_, err = i.InstanceID(context.TODO(), nonExistingVM)
-	if err == cloudprovider.InstanceNotFound {
+	if errors.Is(err, cloudprovider.InstanceNotFound) {
 		t.Logf("VM %s was not found as expected\n", nonExistingVM)
 	} else if err == nil {
 		t.Fatalf("Instances.InstanceID did not fail as expected, VM %s was found", nonExistingVM)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

This is a long shot but I've troubles on Azure with a 1.13.12 cluster (yeah I know ...) which randomly fails to detach and re-attach disks from a node to another one when draining.

The current patch aims to fix the following scenario:

- 1 "full" "old" node (a VMSS instance) with several (2) pods with Azure disks PVC  / 1 "empty" "new" node (also a VMSS instance)
- "old" node is drained -> workloads are migrated to the "new" node
- 1 azure disks fails to be detached from the old node so it can't be re-attached to the new node
- the cluster autoscaler kicks in and remove the old node so the azure disk is "physically" detached from the old node
- kubernetes does not find the old node anymore and refuses to go further in the process of re-attaching the disk to the new node

In the logs I see the following:

```
E0811 09:02:57.562954 1 attacher.go:119] azureDisk - Error checking if volumes ([k8s12-EUW-test-dynamic-pvc-f79095d2-5ad4-11e9-829e-000d3a43e398]) are attached to current node ("k8s12-euw-test-agentmntr1-vmss_3"). err=not a vmss instance
E0811 09:02:57.563011 1 operation_generator.go:190] VolumesAreAttached failed for checking on node "k8s12-euw-test-agentmntr1-vmss_3" with: not a vmss instance
```

 (I've backported 05d7570 in 1.13.12 and I am running it on the cluster, see https://github.com/sylr/kubernetes/commits/v1.13.12%2Bsylr).

[I have tried a less subtle version of this patch](https://github.com/sylr/kubernetes/commit/588fa9744f17b56833cd08fa574b02264109af14) and it seems to unblock my problem as long as the drained node is actually deleted by the cluster autoscaler.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
