### PR TITLE
kubeadm: add test name output for RunInitNodeChecks and RunJoinNodeChecks

### DIFF
--- a/cmd/kubeadm/app/preflight/checks_test.go
+++ b/cmd/kubeadm/app/preflight/checks_test.go
@@ -266,7 +266,7 @@ func TestRunJoinNodeChecks(t *testing.T) {
 		expected bool
 	}{
 		{
-			name: "Check empty JoinConfiguration",
+			name:     "Check empty JoinConfiguration",
 			cfg:      &kubeadmapi.JoinConfiguration{},
 			expected: false,
 		},

--- a/cmd/kubeadm/app/preflight/checks_test.go
+++ b/cmd/kubeadm/app/preflight/checks_test.go
@@ -237,6 +237,7 @@ func TestRunInitNodeChecks(t *testing.T) {
 			expected: false,
 		},
 		{
+			name: "Test APIEndpoint exists if exists",
 			cfg: &kubeadmapi.InitConfiguration{
 				LocalAPIEndpoint: kubeadmapi.APIEndpoint{AdvertiseAddress: "2001:1234::1:15"},
 			},
@@ -248,7 +249,8 @@ func TestRunInitNodeChecks(t *testing.T) {
 		actual := RunInitNodeChecks(exec.New(), rt.cfg, sets.NewString(), rt.isSecondaryControlPlane, rt.downloadCerts)
 		if (actual == nil) != rt.expected {
 			t.Errorf(
-				"failed RunInitNodeChecks:\n\texpected: %t\n\t  actual: %t\n\t error: %v",
+				"failed RunInitNodeChecks:%v\n\texpected: %t\n\t  actual: %t\n\t error: %v",
+				rt.name,
 				rt.expected,
 				(actual == nil),
 				actual,
@@ -259,14 +261,17 @@ func TestRunInitNodeChecks(t *testing.T) {
 
 func TestRunJoinNodeChecks(t *testing.T) {
 	var tests = []struct {
+		name     string
 		cfg      *kubeadmapi.JoinConfiguration
 		expected bool
 	}{
 		{
+			name: "Check empty JoinConfiguration",
 			cfg:      &kubeadmapi.JoinConfiguration{},
 			expected: false,
 		},
 		{
+			name: "Check TLS Bootstrap APIServerEndpoint IPv4 addr",
 			cfg: &kubeadmapi.JoinConfiguration{
 				Discovery: kubeadmapi.Discovery{
 					BootstrapToken: &kubeadmapi.BootstrapTokenDiscovery{
@@ -277,6 +282,7 @@ func TestRunJoinNodeChecks(t *testing.T) {
 			expected: false,
 		},
 		{
+			name: "Check TLS Bootstrap APIServerEndpoint IPv6 addr",
 			cfg: &kubeadmapi.JoinConfiguration{
 				Discovery: kubeadmapi.Discovery{
 					BootstrapToken: &kubeadmapi.BootstrapTokenDiscovery{
@@ -292,7 +298,8 @@ func TestRunJoinNodeChecks(t *testing.T) {
 		actual := RunJoinNodeChecks(exec.New(), rt.cfg, sets.NewString())
 		if (actual == nil) != rt.expected {
 			t.Errorf(
-				"failed RunJoinNodeChecks:\n\texpected: %t\n\t  actual: %t",
+				"failed RunJoinNodeChecks:%v\n\texpected: %t\n\t  actual: %t",
+				rt.name,
 				rt.expected,
 				(actual != nil),
 			)


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
/kind flake
**What this PR does / why we need it**:
Logs the name of the test case that caused a failure when [TestRunInitNodeChecks](https://github.com/kubernetes/kubernetes/blob/master/cmd/kubeadm/app/preflight/checks_test.go#L187) runs
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
This is intended to triage the flake reported on #93883

**Special notes for your reviewer**:
If you think that there are any other improvements that can be made to this test then I would be happy to implement them now.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
N/A