### PR TITLE
"unbound immediate PersistentVolumeClaims" should be UnschedulableAnd…

### DIFF
--- a/pkg/controller/volume/scheduling/scheduler_binder.go
+++ b/pkg/controller/volume/scheduling/scheduler_binder.go
@@ -61,6 +61,8 @@ const (
 	ErrReasonBindConflict ConflictReason = "node(s) didn't find available persistent volumes to bind"
 	// ErrReasonNodeConflict is used for VolumeNodeAffinityConflict predicate error.
 	ErrReasonNodeConflict ConflictReason = "node(s) had volume node affinity conflict"
+	// ErrUnboundImmediatePVC is used when the pod has an unbound PVC in immedate binding mode.
+	ErrUnboundImmediatePVC ConflictReason = "pod has unbound immediate PersistentVolumeClaims"
 )
 
 // InTreeToCSITranslator contains methods required to check migratable status
@@ -258,7 +260,7 @@ func (b *volumeBinder) FindPodVolumes(pod *v1.Pod, node *v1.Node) (reasons Confl
 
 	// Immediate claims should be bound
 	if len(unboundClaimsImmediate) > 0 {
-		return nil, fmt.Errorf("pod has unbound immediate PersistentVolumeClaims")
+		return ConflictReasons{ErrUnboundImmediatePVC}, nil
 	}
 
 	// Check PV node affinity on bound volumes

--- a/pkg/controller/volume/scheduling/scheduler_binder_test.go
+++ b/pkg/controller/volume/scheduling/scheduler_binder_test.go
@@ -809,9 +809,9 @@ func TestFindPodVolumesWithoutProvisioning(t *testing.T) {
 			shouldFail: true,
 		},
 		"prebound-pvc": {
-			podPVCs:    []*v1.PersistentVolumeClaim{preboundPVC},
-			pvs:        []*v1.PersistentVolume{pvNode1aBound},
-			shouldFail: true,
+			podPVCs: []*v1.PersistentVolumeClaim{preboundPVC},
+			pvs:     []*v1.PersistentVolume{pvNode1aBound},
+			reasons: ConflictReasons{ErrUnboundImmediatePVC},
 		},
 		"unbound-pvc,pv-same-node": {
 			podPVCs:          []*v1.PersistentVolumeClaim{unboundPVC},
@@ -850,9 +850,9 @@ func TestFindPodVolumesWithoutProvisioning(t *testing.T) {
 			reasons: ConflictReasons{ErrReasonBindConflict},
 		},
 		"one-prebound,one-unbound": {
-			podPVCs:    []*v1.PersistentVolumeClaim{unboundPVC, preboundPVC},
-			pvs:        []*v1.PersistentVolume{pvNode1a, pvNode1b},
-			shouldFail: true,
+			podPVCs: []*v1.PersistentVolumeClaim{unboundPVC, preboundPVC},
+			pvs:     []*v1.PersistentVolume{pvNode1a, pvNode1b},
+			reasons: ConflictReasons{ErrUnboundImmediatePVC},
 		},
 		"immediate-bound-pvc": {
 			podPVCs: []*v1.PersistentVolumeClaim{immediateBoundPVC},
@@ -864,17 +864,17 @@ func TestFindPodVolumesWithoutProvisioning(t *testing.T) {
 			reasons: ConflictReasons{ErrReasonNodeConflict},
 		},
 		"immediate-unbound-pvc": {
-			podPVCs:    []*v1.PersistentVolumeClaim{immediateUnboundPVC},
-			shouldFail: true,
+			podPVCs: []*v1.PersistentVolumeClaim{immediateUnboundPVC},
+			reasons: ConflictReasons{ErrUnboundImmediatePVC},
 		},
 		"immediate-unbound-pvc,delayed-mode-bound": {
-			podPVCs:    []*v1.PersistentVolumeClaim{immediateUnboundPVC, boundPVC},
-			pvs:        []*v1.PersistentVolume{pvBound},
-			shouldFail: true,
+			podPVCs: []*v1.PersistentVolumeClaim{immediateUnboundPVC, boundPVC},
+			pvs:     []*v1.PersistentVolume{pvBound},
+			reasons: ConflictReasons{ErrUnboundImmediatePVC},
 		},
 		"immediate-unbound-pvc,delayed-mode-unbound": {
-			podPVCs:    []*v1.PersistentVolumeClaim{immediateUnboundPVC, unboundPVC},
-			shouldFail: true,
+			podPVCs: []*v1.PersistentVolumeClaim{immediateUnboundPVC, unboundPVC},
+			reasons: ConflictReasons{ErrUnboundImmediatePVC},
 		},
 	}
 
@@ -965,8 +965,8 @@ func TestFindPodVolumesWithProvisioning(t *testing.T) {
 			expectedProvisions: []*v1.PersistentVolumeClaim{selectedNodePVC},
 		},
 		"immediate-unbound-pvc": {
-			podPVCs:    []*v1.PersistentVolumeClaim{immediateUnboundPVC},
-			shouldFail: true,
+			podPVCs: []*v1.PersistentVolumeClaim{immediateUnboundPVC},
+			reasons: ConflictReasons{ErrUnboundImmediatePVC},
 		},
 		"one-immediate-bound,one-provisioned": {
 			podPVCs:            []*v1.PersistentVolumeClaim{immediateBoundPVC, provisionedPVC},


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

"unbound immediate PersistentVolumeClaims" should be UnschedulableAndUnresolvable error
    
This was fixed in 1.19 by refactoring that part into PreFilter in https://github.com/kubernetes/kubernetes/pull/91775

This is a bug because it is currently causing incorrect reporting in scheduling_attempts metric (internal error vs unschedulable).

**Which issue(s) this PR fixes**:
Fixes ##91755

**Does this PR introduce a user-facing change?**:
```release-note
"unbound immediate PersistentVolumeClaims" causes UnschedulableAndUnresolvable status rather than an Error in the scheduler. 
```

