### PR TITLE
Sync cache before starting scheduler test

### DIFF
--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -480,6 +480,7 @@ func TestSchedulerMultipleProfilesScheduling(t *testing.T) {
 
 	// Run scheduler.
 	informerFactory.Start(ctx.Done())
+	informerFactory.WaitForCacheSync(ctx.Done())
 	go sched.Run(ctx)
 
 	// Send pods to be scheduled.


### PR DESCRIPTION
**What type of PR is this?**

/kind failing-test

**What this PR does / why we need it**:

Cache needs to be synced before starting the scheduler routines.

**Which issue(s) this PR fixes**:

fixes #93890

**Special notes for your reviewer**:

Passes on:

```
go test ./pkg/scheduler -race -timeout=15s -count=100 -v -run TestSchedulerMultipleProfilesScheduling
```

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

/sig scheduling