### PR TITLE
test(endpoints): deflake TestWatchHTTPTimeout

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/watch_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/watch_test.go
@@ -844,7 +844,16 @@ func TestWatchHTTPTimeout(t *testing.T) {
 	close(timeoutCh)
 	select {
 	case <-done:
-		if !watcher.IsStopped() {
+		eventCh := watcher.ResultChan()
+		select {
+		case _, opened := <-eventCh:
+			if opened {
+				t.Errorf("Watcher received unexpected event")
+			}
+			if !watcher.IsStopped() {
+				t.Errorf("Watcher is not stopped")
+			}
+		case <-time.After(wait.ForeverTestTimeout):
 			t.Errorf("Leaked watch on timeout")
 		}
 	case <-time.After(wait.ForeverTestTimeout):


### PR DESCRIPTION
Signed-off-by: knight42 <anonymousknight96@gmail.com>


**What type of PR is this?**

/kind flake

**What this PR does / why we need it**:

I added the following logging
```diff
diff --git staging/src/k8s.io/apimachinery/pkg/watch/watch.go staging/src/k8s.io/apimachinery/pkg/watch/watch.go
index 1f4911a3113..3ea8049dcbb 100644
--- staging/src/k8s.io/apimachinery/pkg/watch/watch.go
+++ staging/src/k8s.io/apimachinery/pkg/watch/watch.go
@@ -112,6 +112,7 @@ func NewFakeWithChanSize(size int, blocking bool) *FakeWatcher {
 func (f *FakeWatcher) Stop() {
        f.Lock()
        defer f.Unlock()
+       fmt.Println("Stop called")
        if !f.stopped {
                klog.V(4).Infof("Stopping fake watcher.")
                close(f.result)
@@ -122,6 +123,7 @@ func (f *FakeWatcher) Stop() {
 func (f *FakeWatcher) IsStopped() bool {
        f.Lock()
        defer f.Unlock()
+       fmt.Println("IsStopped called")
        return f.stopped
 }
```
and notice when the test fails, `FakeWatcher.IsStopped` is invoked before `FakeWatcher.Stop`:
```
...
Stop called
IsStopped called
PASS
Stop called
IsStopped called
PASS
IsStopped called
Stop called
--- FAIL: TestWatchHTTPTimeout (0.00s)
    watch_test.go:848: Leaked watch on timeout
FAIL
```

----

To understand what is happening, we need to know there are two goroutines here:

```go
// simplified goroutine A: request handler
func(w http.ResponseWriter, req *http.Request) {
    defer watcher.Stop()

    watchServer.ServeHTTP(w, req)
}
```

```go
// simplified goroutine B: ServeHTTP
func (s *WatchServer) ServeHTTP(w http.ResponseWriter, req *http.Request) {
    defer close(done)

    select {
    case <-timeoutCh:
        return
    }
}
```

When we `close(timeoutCh)` at https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/apiserver/pkg/endpoints/watch_test.go#L844, goroutine B `close(done)` and returns, but `watcher.Stop` would only be called just before goroutine A returns. It is not guranteed that `watcher.Stop` has been invoked when we call `watcher.IsStopped` at https://github.com/kubernetes/kubernetes/blob/04362870ad9f9812f487ab8f89a40f6bf2daa588/staging/src/k8s.io/apiserver/pkg/endpoints/watch_test.go#L845-L849.

As a result, instead of invoking `watcher.IsStopped` I decide to check if `watcher.ResultChan()` is closed, which seems to be more robust.

**Which issue(s) this PR fixes**:

Fixes #93891 
Part of #93605 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
