### PR TITLE
Deflake TestServiceRegistryUpdateDryRun test

### DIFF
--- a/pkg/registry/core/service/storage/rest_test.go
+++ b/pkg/registry/core/service/storage/rest_test.go
@@ -1182,10 +1182,10 @@ func TestServiceRegistryUpdateDryRun(t *testing.T) {
 			}},
 		},
 	}, rest.ValidateAllObjectFunc, &metav1.CreateOptions{})
-	svc := obj.(*api.Service)
 	if err != nil {
 		t.Fatalf("Expected no error: %v", err)
 	}
+	svc := obj.(*api.Service)
 
 	// Test dry run update request external name to node port
 	updatedSvc, created, err := storage.Update(ctx, svc.Name, rest.DefaultUpdatedObjectInfo(&api.Service{
@@ -1251,6 +1251,7 @@ func TestServiceRegistryUpdateDryRun(t *testing.T) {
 			Selector:        map[string]string{"bar": "baz"},
 			SessionAffinity: api.ServiceAffinityNone,
 			Type:            api.ServiceTypeNodePort,
+			ClusterIP:       "1.2.3.5",
 			Ports: []api.ServicePort{{
 				NodePort:   30020,
 				Port:       6502,
@@ -1259,10 +1260,11 @@ func TestServiceRegistryUpdateDryRun(t *testing.T) {
 			}},
 		},
 	}, rest.ValidateAllObjectFunc, &metav1.CreateOptions{})
-	svc = obj.(*api.Service)
 	if err != nil {
 		t.Fatalf("Expected no error: %v", err)
 	}
+	svc = obj.(*api.Service)
+
 	_, _, err = storage.Update(ctx, svc.Name, rest.DefaultUpdatedObjectInfo(&api.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            svc.Name,
@@ -1301,10 +1303,10 @@ func TestServiceRegistryUpdateDryRun(t *testing.T) {
 			}},
 		},
 	}, rest.ValidateAllObjectFunc, &metav1.CreateOptions{})
-	svc = obj.(*api.Service)
 	if err != nil {
 		t.Fatalf("Expected no error: %v", err)
 	}
+	svc = obj.(*api.Service)
 	_, _, err = storage.Update(ctx, svc.Name, rest.DefaultUpdatedObjectInfo(&api.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            svc.Name,


### PR DESCRIPTION
    The test suite was using a /24 cluster network for the allocator.
    The ip allocator, if no ip is specified when creating the cluster,
    picks one randomly, that means that we had 1/256 chances of
    collision.
    
    The TestServiceRegistryUpdateDryRun was creating a service without
    a ClusterIP, the ip allocator assigned one random, and it was
    never deleting it. The same test was checking later if one
    specific IP was not allocated, not taking into consideration
    that the same ip may have allocated to the first Service.
    
    To avoid any randomness, we create the first Service with a specific
    IP address.


```release-note
NONE
```

/kind flake

Fixes: #93899