### PR TITLE
Automated cherry pick of #93521: Update e2e csi images to k8s.gcr.io

### DIFF
--- a/test/e2e/testing-manifests/storage-csi/gce-pd/controller_ss.yaml
+++ b/test/e2e/testing-manifests/storage-csi/gce-pd/controller_ss.yaml
@@ -21,7 +21,7 @@ spec:
       serviceAccountName: csi-gce-pd-controller-sa
       containers:
         - name: csi-snapshotter
-          image: gcr.io/k8s-staging-csi/csi-snapshotter:v2.0.1
+          image: gcr.io/gke-release/csi-snapshotter:v2.1.1-gke.0
           args:
             - "--v=5"
             - "--csi-address=/csi/csi.sock"
@@ -30,7 +30,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: csi-provisioner
-          image: gcr.io/gke-release/csi-provisioner:v1.5.0-gke.0
+          image: gcr.io/gke-release/csi-provisioner:v1.6.0-gke.0
           args:
             - "--v=5"
             - "--csi-address=/csi/csi.sock"
@@ -39,7 +39,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: csi-attacher
-          image: gcr.io/gke-release/csi-attacher:v2.1.1-gke.0
+          image: gcr.io/gke-release/csi-attacher:v2.2.0-gke.0
           args:
             - "--v=5"
             - "--csi-address=/csi/csi.sock"

--- a/test/e2e/testing-manifests/storage-csi/gce-pd/node_ds.yaml
+++ b/test/e2e/testing-manifests/storage-csi/gce-pd/node_ds.yaml
@@ -18,7 +18,7 @@ spec:
       hostNetwork: true
       containers:
         - name: csi-driver-registrar
-          image: gcr.io/gke-release/csi-node-driver-registrar:v1.2.0-gke.0
+          image: gcr.io/gke-release/csi-node-driver-registrar:v1.3.0-gke.0
           args:
             - "--v=5"
             - "--csi-address=/csi/csi.sock"
@@ -40,7 +40,7 @@ spec:
         - name: gce-pd-driver
           securityContext:
             privileged: true
-          image: gcr.io/gke-release/gcp-compute-persistent-disk-csi-driver:v0.6.2-gke.0
+          image: gcr.io/gke-release/gcp-compute-persistent-disk-csi-driver:v0.7.0-gke.0
           args:
             - "--v=5"
             - "--endpoint=unix:/csi/csi.sock"

--- a/test/e2e/testing-manifests/storage-csi/hostpath/hostpath/csi-hostpath-attacher.yaml
+++ b/test/e2e/testing-manifests/storage-csi/hostpath/hostpath/csi-hostpath-attacher.yaml
@@ -40,7 +40,7 @@ spec:
       serviceAccountName: csi-attacher
       containers:
         - name: csi-attacher
-          image: gcr.io/k8s-staging-csi/csi-attacher:v2.2.0
+          image: k8s.gcr.io/sig-storage/csi-attacher:v2.2.0
           args:
             - --v=5
             - --csi-address=/csi/csi.sock

--- a/test/e2e/testing-manifests/storage-csi/hostpath/hostpath/csi-hostpath-plugin.yaml
+++ b/test/e2e/testing-manifests/storage-csi/hostpath/hostpath/csi-hostpath-plugin.yaml
@@ -36,11 +36,7 @@ spec:
     spec:
       containers:
         - name: node-driver-registrar
-          image: gcr.io/k8s-staging-csi/csi-node-driver-registrar:v1.3.0
-          lifecycle:
-            preStop:
-              exec:
-                command: ["/bin/sh", "-c", "rm -rf /registration/csi-hostpath /registration/csi-hostpath-reg.sock"]
+          image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v1.3.0
           args:
             - --v=5
             - --csi-address=/csi/csi.sock
@@ -65,7 +61,7 @@ spec:
             name: csi-data-dir
 
         - name: hostpath
-          image: gcr.io/k8s-staging-csi/hostpathplugin:v1.4.0-rc2
+          image: k8s.gcr.io/sig-storage/hostpathplugin:v1.4.0
           args:
             - "--drivername=hostpath.csi.k8s.io"
             - "--v=5"
@@ -112,7 +108,7 @@ spec:
           volumeMounts:
           - mountPath: /csi
             name: socket-dir
-          image: gcr.io/k8s-staging-csi/livenessprobe:v1.1.0
+          image: k8s.gcr.io/sig-storage/livenessprobe:v1.1.0
           args:
           - --csi-address=/csi/csi.sock
           - --connection-timeout=3s

--- a/test/e2e/testing-manifests/storage-csi/hostpath/hostpath/csi-hostpath-provisioner.yaml
+++ b/test/e2e/testing-manifests/storage-csi/hostpath/hostpath/csi-hostpath-provisioner.yaml
@@ -40,7 +40,7 @@ spec:
       serviceAccountName: csi-provisioner
       containers:
         - name: csi-provisioner
-          image: gcr.io/k8s-staging-csi/csi-provisioner:v1.6.0
+          image: k8s.gcr.io/sig-storage/csi-provisioner:v1.6.0
           args:
             - -v=5
             - --csi-address=/csi/csi.sock

--- a/test/e2e/testing-manifests/storage-csi/hostpath/hostpath/csi-hostpath-resizer.yaml
+++ b/test/e2e/testing-manifests/storage-csi/hostpath/hostpath/csi-hostpath-resizer.yaml
@@ -30,7 +30,7 @@ spec:
       serviceAccountName: csi-resizer
       containers:
         - name: csi-resizer
-          image: gcr.io/k8s-staging-csi/csi-resizer:v0.5.0
+          image: k8s.gcr.io/sig-storage/csi-resizer:v0.5.0
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"

--- a/test/e2e/testing-manifests/storage-csi/hostpath/hostpath/csi-hostpath-snapshotter.yaml
+++ b/test/e2e/testing-manifests/storage-csi/hostpath/hostpath/csi-hostpath-snapshotter.yaml
@@ -30,7 +30,7 @@ spec:
       serviceAccount: csi-snapshotter
       containers:
       - name: csi-snapshotter
-        image: gcr.io/k8s-staging-csi/csi-snapshotter:v2.1.0
+        image: k8s.gcr.io/sig-storage/csi-snapshotter:v2.1.0
         args:
         - "--v=5"
         - "--csi-address=$(ADDRESS)"

--- a/test/e2e/testing-manifests/storage-csi/mock/csi-mock-driver-attacher.yaml
+++ b/test/e2e/testing-manifests/storage-csi/mock/csi-mock-driver-attacher.yaml
@@ -15,7 +15,7 @@ spec:
       serviceAccountName: csi-mock
       containers:
         - name: csi-attacher
-          image: gcr.io/k8s-staging-csi/csi-attacher:v2.2.0
+          image: k8s.gcr.io/sig-storage/csi-attacher:v2.2.0
           args:
             - --v=5
             - --csi-address=$(ADDRESS)

--- a/test/e2e/testing-manifests/storage-csi/mock/csi-mock-driver-resizer.yaml
+++ b/test/e2e/testing-manifests/storage-csi/mock/csi-mock-driver-resizer.yaml
@@ -15,7 +15,7 @@ spec:
       serviceAccountName: csi-mock
       containers:
         - name: csi-resizer
-          image: gcr.io/k8s-staging-csi/csi-resizer:v0.4.0
+          image: k8s.gcr.io/sig-storage/csi-resizer:v0.5.0
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"

--- a/test/e2e/testing-manifests/storage-csi/mock/csi-mock-driver.yaml
+++ b/test/e2e/testing-manifests/storage-csi/mock/csi-mock-driver.yaml
@@ -15,7 +15,7 @@ spec:
       serviceAccountName: csi-mock
       containers:
         - name: csi-provisioner
-          image: gcr.io/k8s-staging-csi/csi-provisioner:v1.6.0
+          image: k8s.gcr.io/sig-storage/csi-provisioner:v1.6.0
           args:
             - "--csi-address=$(ADDRESS)"
             - "--connection-timeout=15s"
@@ -26,7 +26,7 @@ spec:
             - mountPath: /csi
               name: socket-dir
         - name: driver-registrar
-          image: gcr.io/k8s-staging-csi/csi-node-driver-registrar:v1.2.0
+          image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v1.3.0
           args:
             - --v=5
             - --csi-address=/csi/csi.sock
@@ -45,7 +45,7 @@ spec:
           - mountPath: /registration
             name: registration-dir
         - name: mock
-          image: gcr.io/k8s-staging-csi/mock-driver:v3.1.0
+          image: k8s.gcr.io/sig-storage/mock-driver:v3.1.0
           args:
             - "--name=mock.storage.k8s.io"
             - "--permissive-target-path" # because of https://github.com/kubernetes/kubernetes/issues/75535

--- a/test/utils/image/manifest.go
+++ b/test/utils/image/manifest.go
@@ -34,11 +34,11 @@ type RegistryList struct {
 	PromoterE2eRegistry     string `yaml:"promoterE2eRegistry"`
 	InvalidRegistry         string `yaml:"invalidRegistry"`
 	GcRegistry              string `yaml:"gcRegistry"`
+	SigStorageRegistry      string `yaml:"sigStorageRegistry"`
 	GcrReleaseRegistry      string `yaml:"gcrReleaseRegistry"`
 	GoogleContainerRegistry string `yaml:"googleContainerRegistry"`
 	PrivateRegistry         string `yaml:"privateRegistry"`
 	SampleRegistry          string `yaml:"sampleRegistry"`
-	K8sCSI                  string `yaml:"k8sCSI"`
 }
 
 // Config holds an images registry, name, and version
@@ -73,11 +73,11 @@ func initReg() RegistryList {
 		PromoterE2eRegistry:     "us.gcr.io/k8s-artifacts-prod/e2e-test-images",
 		InvalidRegistry:         "invalid.com/invalid",
 		GcRegistry:              "k8s.gcr.io",
+		SigStorageRegistry:      "k8s.gcr.io/sig-storage",
 		GcrReleaseRegistry:      "gcr.io/gke-release",
 		GoogleContainerRegistry: "gcr.io/google-containers",
 		PrivateRegistry:         "gcr.io/k8s-authenticated-test",
 		SampleRegistry:          "gcr.io/google-samples",
-		K8sCSI:                  "gcr.io/k8s-staging-csi",
 	}
 	repoList := os.Getenv("KUBE_TEST_REPO_LIST")
 	if repoList == "" {
@@ -104,10 +104,10 @@ var (
 	promoterE2eRegistry     = registry.PromoterE2eRegistry
 	gcAuthenticatedRegistry = registry.GcAuthenticatedRegistry
 	gcRegistry              = registry.GcRegistry
+	sigStorageRegistry      = registry.SigStorageRegistry
 	gcrReleaseRegistry      = registry.GcrReleaseRegistry
 	googleContainerRegistry = registry.GoogleContainerRegistry
 	invalidRegistry         = registry.InvalidRegistry
-	k8sCSI                  = registry.K8sCSI
 	// PrivateRegistry is an image repository that requires authentication
 	PrivateRegistry = registry.PrivateRegistry
 	sampleRegistry  = registry.SampleRegistry
@@ -224,7 +224,7 @@ func initImageConfigs() map[int]Config {
 	configs[Mounttest] = Config{e2eRegistry, "mounttest", "1.0"}
 	configs[MounttestUser] = Config{e2eRegistry, "mounttest-user", "1.0"}
 	configs[Nautilus] = Config{e2eRegistry, "nautilus", "1.0"}
-	configs[NFSProvisioner] = Config{k8sCSI, "nfs-provisioner", "v2.2.2"}
+	configs[NFSProvisioner] = Config{sigStorageRegistry, "nfs-provisioner", "v2.2.2"}
 	configs[Nginx] = Config{dockerLibraryRegistry, "nginx", "1.14-alpine"}
 	configs[NginxNew] = Config{dockerLibraryRegistry, "nginx", "1.15-alpine"}
 	configs[Nonewprivs] = Config{e2eRegistry, "nonewprivs", "1.0"}
@@ -282,6 +282,8 @@ func ReplaceRegistryInImageURL(imageURL string) (string, error) {
 		registryAndUser = e2eRegistry
 	case "k8s.gcr.io":
 		registryAndUser = gcRegistry
+	case "k8s.gcr.io/sig-storage":
+		registryAndUser = sigStorageRegistry
 	case "gcr.io/k8s-authenticated-test":
 		registryAndUser = PrivateRegistry
 	case "gcr.io/google-samples":
@@ -290,8 +292,6 @@ func ReplaceRegistryInImageURL(imageURL string) (string, error) {
 		registryAndUser = gcrReleaseRegistry
 	case "docker.io/library":
 		registryAndUser = dockerLibraryRegistry
-	case "gcr.io/k8s-staging-csi":
-		registryAndUser = k8sCSI
 	default:
 		if countParts == 1 {
 			// We assume we found an image from docker hub library

--- a/test/utils/image/manifest_test.go
+++ b/test/utils/image/manifest_test.go
@@ -87,9 +87,9 @@ var registryTests = []struct {
 		},
 	},
 	{
-		"gcr.io/k8s-staging-csi/test:latest",
+		"k8s.gcr.io/sig-storage/test:latest",
 		result{
-			result: "test.io/k8s-staging-csi/test:latest",
+			result: "test.io/sig-storage/test:latest",
 			err:    nil,
 		},
 	},
@@ -111,7 +111,7 @@ func TestReplaceRegistryInImageURL(t *testing.T) {
 	gcrReleaseRegistry = "test.io/gke-release"
 	PrivateRegistry = "test.io/k8s-authenticated-test"
 	sampleRegistry = "test.io/google-samples"
-	k8sCSI = "test.io/k8s-staging-csi"
+	sigStorageRegistry = "test.io/sig-storage"
 
 	for _, tt := range registryTests {
 		t.Run(tt.in, func(t *testing.T) {


### PR DESCRIPTION
Cherry pick of #93521 on release-1.18.

#93521: Update e2e csi images to k8s.gcr.io

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.