### PR TITLE
fix cmd/cloud-controller-manager/app/apis/config/v1alpha1

### DIFF
--- a/cmd/cloud-controller-manager/app/apis/config/v1alpha1/defaults.go
+++ b/cmd/cloud-controller-manager/app/apis/config/v1alpha1/defaults.go
@@ -29,7 +29,9 @@ func addDefaultingFuncs(scheme *runtime.Scheme) error {
 	return RegisterDefaults(scheme)
 }
 
-func SetDefaults_CloudControllerManagerConfiguration(obj *CloudControllerManagerConfiguration) {
+// SetDefaultsCloudControllerManagerConfiguration is used to set default values for
+// some CloudControllerManagerConfiguration's fields
+func SetDefaultsCloudControllerManagerConfiguration(obj *CloudControllerManagerConfiguration) {
 	zero := metav1.Duration{}
 	if obj.NodeStatusUpdateFrequency == zero {
 		obj.NodeStatusUpdateFrequency = metav1.Duration{Duration: 5 * time.Minute}

--- a/cmd/cloud-controller-manager/app/apis/config/v1alpha1/defaults_test.go
+++ b/cmd/cloud-controller-manager/app/apis/config/v1alpha1/defaults_test.go
@@ -28,7 +28,7 @@ import (
 
 func TestCloudControllerManagerDefaultsRoundTrip(t *testing.T) {
 	ks1 := &CloudControllerManagerConfiguration{}
-	SetDefaults_CloudControllerManagerConfiguration(ks1)
+	SetDefaultsCloudControllerManagerConfiguration(ks1)
 	cm, err := convertObjToConfigMap("CloudControllerManagerConfiguration", ks1)
 	if err != nil {
 		t.Errorf("unexpected ConvertObjToConfigMap error %v", err)

--- a/cmd/cloud-controller-manager/app/apis/config/v1alpha1/register.go
+++ b/cmd/cloud-controller-manager/app/apis/config/v1alpha1/register.go
@@ -25,7 +25,7 @@ import (
 const GroupName = "cloudcontrollermanager.config.k8s.io"
 
 var (
-	// GroupName is the group name use in this package
+	// SchemeGroupVersion is group version used to register these objects
 	SchemeGroupVersion = schema.GroupVersion{Group: GroupName, Version: "v1alpha1"}
 	// SchemeBuilder is the scheme builder with scheme init functions to run for this API package
 	SchemeBuilder = runtime.NewSchemeBuilder(addKnownTypes)

--- a/cmd/cloud-controller-manager/app/apis/config/v1alpha1/types.go
+++ b/cmd/cloud-controller-manager/app/apis/config/v1alpha1/types.go
@@ -23,6 +23,7 @@ import (
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
+// CloudControllerManagerConfiguration contains elements describing cloud-controller manager.
 type CloudControllerManagerConfiguration struct {
 	metav1.TypeMeta `json:",inline"`
 

--- a/cmd/cloud-controller-manager/app/apis/config/v1alpha1/zz_generated.defaults.go
+++ b/cmd/cloud-controller-manager/app/apis/config/v1alpha1/zz_generated.defaults.go
@@ -36,6 +36,6 @@ func RegisterDefaults(scheme *runtime.Scheme) error {
 }
 
 func SetObjectDefaults_CloudControllerManagerConfiguration(in *CloudControllerManagerConfiguration) {
-	SetDefaults_CloudControllerManagerConfiguration(in)
+	SetDefaultsCloudControllerManagerConfiguration(in)
 	configv1alpha1.SetDefaults_KubeCloudSharedConfiguration(&in.KubeCloudShared)
 }

--- a/hack/.golint_failures
+++ b/hack/.golint_failures
@@ -1,5 +1,4 @@
 # Apart from this line, only trailing comments are supported
-cmd/cloud-controller-manager/app/apis/config/v1alpha1
 cmd/kube-apiserver/app
 cmd/kubeadm/app/apis/kubeadm/v1beta1
 cmd/kubeadm/app/apis/kubeadm/v1beta2


### PR DESCRIPTION
fix cmd/cloud-controller-manager/app/apis/config/v1alpha1 

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
According to this issue: #68026, i fix cmd/cloud-controller-manager/app/apis/config/v1alpha1

The golint failures are fixed:
```shell
Errors from golint:
cmd/cloud-controller-manager/app/apis/config/v1alpha1/defaults.go:32:1: exported function SetDefaults_CloudControllerManagerConfiguration should have comment or be unexported
cmd/cloud-controller-manager/app/apis/config/v1alpha1/defaults.go:32:6: don't use underscores in Go names; func SetDefaults_CloudControllerManagerConfiguration should be SetDefaultsCloudControllerManagerConfiguration
cmd/cloud-controller-manager/app/apis/config/v1alpha1/register.go:28:2: comment on exported var SchemeGroupVersion should be of the form "SchemeGroupVersion ..."
cmd/cloud-controller-manager/app/apis/config/v1alpha1/types.go:26:6: exported type CloudControllerManagerConfiguration should have comment or be unexported
```
**Which issue(s) this PR fixes**:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #68026

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
none
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
