### PR TITLE
test(userspace): deflake TestTCPProxyUpdateDeleteUpdate

### DIFF
--- a/pkg/proxy/userspace/proxier_test.go
+++ b/pkg/proxy/userspace/proxier_test.go
@@ -30,7 +30,7 @@ import (
 	"testing"
 	"time"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	discovery "k8s.io/api/discovery/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -650,6 +650,8 @@ func TestTCPProxyUpdateDeleteUpdate(t *testing.T) {
 		t.Fatalf(err.Error())
 	}
 	waitForNumProxyLoops(t, p, 0)
+
+	p.syncProxyRules() // ensure the endpoint has been deleted
 
 	// need to add endpoint here because it got clean up during service delete
 	lb.OnEndpointsAdd(endpoint)


### PR DESCRIPTION
Signed-off-by: knight42 <anonymousknight96@gmail.com>


**What type of PR is this?**

/kind flake

**What this PR does / why we need it**:

I added the following logging:
```diff
diff --git pkg/proxy/userspace/roundrobin.go pkg/proxy/userspace/roundrobin.go
index 1a223bdd145..5c5de1d2dba 100644
--- pkg/proxy/userspace/roundrobin.go
+++ pkg/proxy/userspace/roundrobin.go
@@ -109,6 +109,7 @@ func (lb *LoadBalancerRR) DeleteService(svcPort proxy.ServicePortName) {
        klog.V(4).Infof("LoadBalancerRR DeleteService %q", svcPort)
        lb.lock.Lock()
        defer lb.lock.Unlock()
+       fmt.Println("DeleteService")
        delete(lb.services, svcPort)
 }

@@ -138,6 +139,7 @@ func (lb *LoadBalancerRR) NextEndpoint(svcPort proxy.ServicePortName, srcAddr ne
        // can prove it matters.
        lb.lock.Lock()
        defer lb.lock.Unlock()
+       fmt.Println("NextEndpoint")

        state, exists := lb.services[svcPort]
        if !exists || state == nil {
@@ -225,10 +227,10 @@ func (lb *LoadBalancerRR) OnEndpointsAdd(endpoints *v1.Endpoints) {

        lb.lock.Lock()
        defer lb.lock.Unlock()
+       fmt.Printf("OnEndpointsAdd: len(services)=%v\n", len(lb.services))

        for portname := range portsToEndpoints {
                svcPort := proxy.ServicePortName{NamespacedName: types.NamespacedName{Namespace: endpoints.Namespace, Name: endpoints.Name}, Port: portname}
                newEndpoints := portsToEndpoints[portname]
```
and got
```
...
OnEndpointsAdd: len(services)=0
NextEndpoint
DeleteService
OnEndpointsAdd: len(services)=0
NextEndpoint
PASS
OnEndpointsAdd: len(services)=0
NextEndpoint
NextEndpoint
OnEndpointsAdd: len(services)=1
DeleteService
NextEndpoint
E0812 13:06:39.707190   30332 proxysocket.go:98] Couldn't find an endpoint for testnamespace/echo:p: missing endpoints
E0812 13:06:39.707567   30332 proxysocket.go:144] Failed to connect to balancer: missing endpoints
--- FAIL: TestTCPProxyUpdateDeleteUpdate (0.06s)
    proxier_test.go:181: error connecting to server: Get "http://127.0.0.1:55175/aaaaa": EOF
FAIL
```

The log indicates that the service has not been deleted before we add the endpoint back at https://github.com/kubernetes/kubernetes/blob/fa13dc11d12ba9cab8c462db4a3fee5fd09d9b07/pkg/proxy/userspace/proxier_test.go#L654-L655, and the service is deleted after that which also removes the endpoint, hence the test fails.

To fix the problem, I decided to call `p.syncProxyRules()` after we delete the service to ensure the service is deleted before we add back the endpoint.

**Which issue(s) this PR fixes**:

Fixes #93904

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
