### PR TITLE
[Flaky test]kubectl log test never restart pod

### DIFF
--- a/test/e2e/kubectl/kubectl.go
+++ b/test/e2e/kubectl/kubectl.go
@@ -1416,7 +1416,7 @@ metadata:
 			ginkgo.By("creating an pod")
 			nsFlag = fmt.Sprintf("--namespace=%v", ns)
 			// Agnhost image generates logs for a total of 100 lines over 20s.
-			framework.RunKubectlOrDie(ns, "run", podName, "--image="+agnhostImage, nsFlag, "--", "logs-generator", "--log-lines-total", "100", "--run-duration", "20s")
+			framework.RunKubectlOrDie(ns, "run", podName, "--image="+agnhostImage, nsFlag, "--restart=Never", "--", "logs-generator", "--log-lines-total", "100", "--run-duration", "20s")
 		})
 		ginkgo.AfterEach(func() {
 			framework.RunKubectlOrDie(ns, "delete", "pod", podName, nsFlag)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind flake


**What this PR does / why we need it**:
This PR fixes part of the flaky test #92468, #88996
The flaky logs shows:
```
/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:721
Jul 29 11:30:39.509: expected recent(6) to be less than older(6)
recent lines:
I0729 11:30:34.559283       1 logs_generator.go:76] 86 POST /api/v1/namespaces/kube-system/pods/ppxw 313
I0729 11:30:34.761470       1 logs_generator.go:76] 87 GET /api/v1/namespaces/default/pods/5jl 271
I0729 11:30:34.959287       1 logs_generator.go:76] 88 PUT /api/v1/namespaces/kube-system/pods/tpb7 505
I0729 11:30:35.159277       1 logs_generator.go:76] 89 POST /api/v1/namespaces/default/pods/69g 247
I0729 11:30:35.359274       1 logs_generator.go:76] 90 PUT /api/v1/namespaces/kube-system/pods/tn26 434

older lines:
I0729 11:30:38.286090       1 logs_generator.go:76] 0 PUT /api/v1/namespaces/default/pods/k7c 598
I0729 11:30:38.486277       1 logs_generator.go:76] 1 PUT /api/v1/namespaces/kube-system/pods/8vp 344
I0729 11:30:38.686318       1 logs_generator.go:76] 2 PUT /api/v1/namespaces/ns/pods/r52 580
I0729 11:30:38.886403       1 logs_generator.go:76] 3 PUT /api/v1/namespaces/ns/pods/p8fd 203
I0729 11:30:39.086306       1 logs_generator.go:76] 4 POST /api/v1/namespaces/default/pods/xbs 571


Expected
    <int>: 6
to be <
    <int>: 6
/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/kubectl/kubectl.go:1428
```

The pod actually will generate log 1 to 100 and will stop. As the flaky log shows above, the pod is restarted after showing `86, 87, 88, 89, 90` and starts to show `0, 1, 2, 3, 4`. 
The test will compare the number of log with `--since 1s` and `--since 24h`. Since the pod is restarted so the there's no comparability between them.

This PR will set the `restart policy` to `never` to prevent the flaky happen.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```


