### PR TITLE
Fix auto-allocated ports conflicting with explicitly specified ports on service create

### DIFF
--- a/pkg/registry/core/service/storage/BUILD
+++ b/pkg/registry/core/service/storage/BUILD
@@ -32,6 +32,7 @@ go_test(
         "//staging/src/k8s.io/apimachinery/pkg/util/diff:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/intstr:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/net:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/rand:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/watch:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/endpoints/request:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/registry/generic:go_default_library",


### PR DESCRIPTION
Signed-off-by: knight42 <anonymousknight96@gmail.com>

**What type of PR is this?**

/kind flake
/kind bug

**What this PR does / why we need it**:

I added the following debugging:
```diff
diff --git pkg/registry/core/service/storage/rest.go pkg/registry/core/service/storage/rest.go
index 0d5379f8c11..8095f386431 100644
--- pkg/registry/core/service/storage/rest.go
+++ pkg/registry/core/service/storage/rest.go
@@ -208,6 +208,8 @@ func (rs *REST) Create(ctx context.Context, obj runtime.Object, createValidation
        // Handle ExternalTraffic related fields during service creation.
        if apiservice.NeedsHealthCheck(service) {
                if err := allocateHealthCheckNodePort(service, nodePortOp); err != nil {
+                       spec := service.Spec
+                       fmt.Printf("NodePort: %d, HealthCheckPort: %d\n", spec.Ports[0].NodePort, spec.HealthCheckNodePort)
                        return nil, errors.NewInternalError(err)
                }
        }
```

and got:
```
WARNING: Package "github.com/golang/protobuf/protoc-gen-go/generator" is deprecated.
        A future release of golang/protobuf will delete this package,
        which has long been excluded from the compatibility promise.

I0812 17:52:19.904068   78356 client.go:360] parsed scheme: "endpoint"
I0812 17:52:19.904194   78356 endpoint.go:68] ccResolverWrapper: sending new addresses to cc: [{unix://localhost:83760927833799529510  <nil> 0 <nil>}]
I0812 17:52:19.908507   78356 client.go:360] parsed scheme: "endpoint"
I0812 17:52:19.908588   78356 endpoint.go:68] ccResolverWrapper: sending new addresses to cc: [{unix://localhost:83760927833799529510  <nil> 0 <nil>}]
I0812 17:52:19.909254   78356 once.go:66] CPU time info is unavailable on non-linux or appengine environment.
I0812 17:52:19.914674   78356 client.go:360] parsed scheme: "endpoint"
I0812 17:52:19.914761   78356 endpoint.go:68] ccResolverWrapper: sending new addresses to cc: [{unix://localhost:83760927833799529510  <nil> 0 <nil>}]
I0812 17:52:19.918666   78356 client.go:360] parsed scheme: "endpoint"
I0812 17:52:19.918736   78356 endpoint.go:68] ccResolverWrapper: sending new addresses to cc: [{unix://localhost:83760927833799529510  <nil> 0 <nil>}]

NodePort: 30773, HealthCheckPort: 30773  <-- Please notice this line

W0812 17:52:19.961603   78356 clientconn.go:1223] grpc: addrConn.createTransport failed to connect to {unix://localhost:83760927833799529510  <nil> 0 <nil>}. Err :connection error: desc = "transport: Error while dialing dial unix localhost:83760927833799529510: connect: no such file or directory". Reconnecting...
W0812 17:52:19.961638   78356 clientconn.go:1223] grpc: addrConn.createTransport failed to connect to {unix://localhost:83760927833799529510  <nil> 0 <nil>}. Err :connection error: desc = "transport: Error while dialing dial unix localhost:83760927833799529510: connect: no such file or directory". Reconnecting...
W0812 17:52:19.961971   78356 clientconn.go:1223] grpc: addrConn.createTransport failed to connect to {unix://localhost:83760927833799529510  <nil> 0 <nil>}. Err :connection error: desc = "transport: Error while dialing dial unix localhost:83760927833799529510: connect: no such file or directory". Reconnecting...
--- FAIL: TestServiceRegistryExternalTrafficHealthCheckNodePortUserAllocation (1.98s)
    rest_test.go:2214: Unexpected failure creating service :Internal error occurred: failed to allocate requested HealthCheck NodePort 30773: provided port is already allocated
FAIL

ERROR: exit status 1
```

The log shows the root cause is the randomly generated health check nodePort happens to be the same as the service nodePort allocated later.

The flake also uncovers a bug that apiserver could potenially allocate a same port as the user-specified HealthCheck NodePort to be the Service NodePort when creating `NodePort` or `LoadBalancer` Service.

**Which issue(s) this PR fixes**:

xref: https://github.com/kubernetes/kubernetes/pull/93605#issuecomment-668141670

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
Fix a bug that apiserver could potenially allocate a same port as the user-specified HealthCheck NodePort to be the Service NodePort when creating `NodePort` or `LoadBalancer` Service.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
