### PR TITLE
Promote spiffxp to build/ approver

### DIFF
--- a/build/OWNERS
+++ b/build/OWNERS
@@ -14,6 +14,7 @@ approvers:
   - justaugustus
   - lavalamp
   - mikedanese
+  - spiffxp
 emeritus_approvers:
   - jbeda
   - zmerlynn


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Promote spiffxp to build/ approver

I've been a reviewer here for nearly 2 years, and am now part of the team
that builds the google-hosted .dep and .rpm packages

**Special notes for your reviewer**:
I plan on cherry-picking this back to other release branches

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```