### PR TITLE
get: -o yaml, json set ServerPrint false

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/get/get.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/get/get.go
@@ -215,7 +215,7 @@ func (o *GetOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []stri
 	// TODO (soltysh): currently we don't support custom columns
 	// with server side print. So in these cases force the old behavior.
 	outputOption := cmd.Flags().Lookup("output").Value.String()
-	if outputOption == "custom-columns" {
+	if strings.Contains(outputOption, "custom-columns") || outputOption == "yaml" || strings.Contains(outputOption, "json") {
 		o.ServerPrint = false
 	}
 


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Currently, with `kubectl get resource -o yaml|json|jsonpath=..|jsonpath-file=..|custom-columns=.. -v=2`  this warning is shown:
```
I0812 14:41:47.938840   81833 table_printer.go:45] Unable to decode server response into a Table. Falling back to hardcoded types: attempt to decode non-Table object
```
Instead, should set ServerPrint=false for those outputOptions (this PR) or, in the least, move that log level up - it's a 2 now.
Also, the current check to set ServerPrint=false if -o == "custom-columns" is flawed, need to check if contains, since users pass `custom-columns=...` 

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```