### PR TITLE
Refresh root, build, cluster OWNERS files from main branch

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -21,16 +21,6 @@ filters:
     emeritus_approvers:
       - jbeda
 
-  # Bazel build infrastructure changes often touch files throughout the tree
-  "\\.bzl$":
-    reviewers:
-      - ixdy
-    approvers:
-      - ixdy
-  "BUILD(\\.bazel)?$":
-    approvers:
-      - ixdy
-
   # go.{mod,sum} files relate to go dependencies, and should be reviewed by the
   # dep-approvers
   "go\\.(mod|sum)$":
@@ -38,3 +28,8 @@ filters:
       - kubernetes/dep-approvers
     labels:
       - area/dependency
+  # metrics.go files are sig-instrumentation related, and should be tagged
+  # and reviewed by sig-instrumentation
+  "metrics\\.go$":
+    labels:
+      - sig/instrumentation

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -113,19 +113,22 @@ aliases:
 
   # SIG Release
   sig-release-approvers:
-    - calebamiles # SIG Chair
+    - alejandrox1 # SIG Technical Lead
     - justaugustus # SIG Chair
+    - saschagrunert # SIG Technical Lead
     - tpepper # SIG Chair
   release-engineering-approvers:
-    - calebamiles # SIG Chair
+    - alejandrox1 # SIG Technical Lead
     - justaugustus # SIG Chair
-    - tpepper # SIG Chair / Patch Release Team
+    - saschagrunert # SIG Technical Lead
+    - tpepper # SIG Chair
   release-engineering-reviewers:
-    - aleksandra-malinowska # Patch Release Team
-    - calebamiles # SIG Chair
+    - cpanato # Branch Manager
     - feiskyer # Patch Release Team
+    - hasheddan # Branch Manager
     - hoegaarden # Patch Release Team
     - justaugustus # SIG Chair
+    - saschagrunert # Branch Manager
     - tpepper # SIG Chair / Patch Release Team
   build-image-approvers:
     - BenTheElder
@@ -140,19 +143,36 @@ aliases:
     - justaugustus
     - listx
 
+  sig-storage-approvers:
+    - saad-ali
+    - thockin
+    - jsafrane
+    - gnufied
+    - msau42
+  # emeritus:
+  # - rootfs
   sig-storage-reviewers:
     - saad-ali
+    - jsafrane
+    - rootfs
+    - jingxu97
+    - msau42
+    - gnufied
+    - verult
+    - humblec
+  # emeritus:
+  # - davidz627
 
   sig-scheduling-maintainers:
     - alculquicondor
-    - bsalamat
     - k82cn
     - wojtek-t
     - ravisantoshgudimetla
     - Huang-Wei
     - ahg-g
+  # emeritus:
+  # - bsalamat
   sig-scheduling:
-    - bsalamat
     - k82cn
     - resouer
     - ravisantoshgudimetla
@@ -163,9 +183,9 @@ aliases:
     - hex108
     - alculquicondor
     - liu-cong
+    - damemi
 
   sig-cli-maintainers:
-    - adohe
     - brendandburns
     - deads2k
     - janetkuo
@@ -177,20 +197,24 @@ aliases:
     - mengqiy
     - smarterclayton
     - soltysh
+    - pwittrock
+  # emeritus:
+  # - adohe
   sig-cli:
-    - adohe
+    - brianpursley
     - deads2k
     - derekwaynecarr
     - dixudx
     - dims
-    - eparis
-    - juanvallejo
     - mengqiy
     - rootfs
     - seans3
     - shiywang
     - smarterclayton
     - soltysh
+    - pwittrock
+    - zhouya0
+
   sig-testing-reviewers:
     - bentheelder
     - cblecker
@@ -209,7 +233,6 @@ aliases:
     - Random-Liu
     - dchen1107
     - derekwaynecarr
-    - tallclair
     - vishh
     - yujuhong
   sig-node-reviewers:
@@ -223,12 +246,17 @@ aliases:
     - pmorie
     - resouer
     - sjenning
-    - tallclair
     - vishh
     - yifan-gu
     - yujuhong
     - krmayankk
     - mattjmcnaughton
+    - matthyx
+    - odinuge
+  sig-network-driver-approvers:
+    - dcbw
+    - freehan
+
   sig-network-approvers:
     - andrewsykim
     - bowei
@@ -279,8 +307,11 @@ aliases:
     - MaciekPytel
     - mwielgus
   sig-instrumentation-approvers:
-    - piosz
     - brancz
+    - logicalhan
+    - dashpole
+    - ehashman
+    - RainbowMango
     - serathius
   sig-instrumentation-reviewers:
     - kawych
@@ -359,7 +390,7 @@ aliases:
     - smarterclayton
     - thockin
     - liggitt
-  
+
   api-reviewers:
     - erictune
     - lavalamp
@@ -381,7 +412,6 @@ aliases:
     - sttts
     - dchen1107
     - saad-ali
-    - zmerlynn
     - luxas
     - janetkuo
     - justinsb
@@ -389,7 +419,6 @@ aliases:
     - ncdc
     - tallclair
     - yifan-gu
-    - eparis
     - mwielgus
     - timothysc
     - soltysh
@@ -398,16 +427,16 @@ aliases:
 
   # api-reviewers targeted by sig area
   # see https://git.k8s.io/community/sig-architecture/api-review-process.md#training-reviews
-  
+
   sig-api-machinery-api-reviewers:
     - caesarxuchao
     - deads2k
     - jpbetz
     - sttts
-  
+
   # sig-apps-api-reviewers:
-  #   - 
-  #   - 
+  #   -
+  #   -
 
   sig-auth-api-reviewers:
     - enj
@@ -420,11 +449,11 @@ aliases:
   sig-cloud-provider-api-reviewers:
     - andrewsykim
     - cheftako
-  
+
   # sig-cluster-lifecycle-api-reviewers:
-  #   - 
   #   -
-  
+  #   -
+
   sig-node-api-reviewers:
     - dchen1107
     - derekwaynecarr
@@ -438,24 +467,24 @@ aliases:
   sig-scalability-reviewers:
     - mm4tt
     - wojtek-t
-  
-  sig-scheduling-api-reviewers:
-      - bsalamat
-      - k82cn
-  
+
+  # sig-scheduling-api-reviewers:
+  #   -
+  #   -
+
   sig-storage-api-reviewers:
+    - deads2k
     - saad-ali
     - msau42
     - jsafrane
 
-  
+
   sig-windows-api-reviewers:
     - patricklang
     - ddebroy
     - benmoss
 
   dep-approvers:
-    - apelisse
     - BenTheElder
     - cblecker
     - dims
@@ -466,7 +495,7 @@ aliases:
     - andrewsykim     # Cloud Provider
     - bgrant0607      # Architecture
     - brancz          # Instrumentation
-    - bsalamat        # Scheduling
+    - ahg-g           # Scheduling
     - calebamiles     # Release
     - caseydavenport  # Network
     - countspongebob  # Scalability
@@ -475,13 +504,12 @@ aliases:
     - dchen1107       # Node
     - deads2k         # API Machinery
     - derekwaynecarr  # Node
-    - dghubble        # On Premise
-    - jdumars         # Architecture, Cluster Ops, Release
+    - dims            # Architecture
+    - jdumars         # Architecture, Release
     - kow3ns          # Apps
     - lavalamp        # API Machinery
     - liggitt         # Auth
     - luxas           # Cluster Lifecycle
-    - marcoceppi      # On Premise
     - mattfarina      # Apps
     - michmike        # Windows
     - mwielgus        # Autoscaling
@@ -497,10 +525,10 @@ aliases:
     - thockin         # Network
     - timothysc       # Cluster Lifecycle, Scheduling
     - wojtek-t        # Scalability
-    - zehicle         # Cluster Ops
 
   # conformance aliases https://git.k8s.io/enhancements/keps/sig-architecture/20190412-conformance-behaviors.md
   conformance-behavior-approvers:
     - bgrant0607
     - smarterclayton
     - johnbelamaric
+    - spiffxp

--- a/build/OWNERS
+++ b/build/OWNERS
@@ -13,6 +13,7 @@ approvers:
   - fejta
   - lavalamp
   - mikedanese
+  - spiffxp
 emeritus_approvers:
   - jbeda
   - zmerlynn

--- a/build/OWNERS
+++ b/build/OWNERS
@@ -11,6 +11,7 @@ approvers:
   - bentheelder
   - cblecker
   - fejta
+  - justaugustus
   - lavalamp
   - mikedanese
   - spiffxp

--- a/cluster/OWNERS
+++ b/cluster/OWNERS
@@ -2,18 +2,19 @@
 
 reviewers:
   - bentheelder
-  - eparis
-  - jbeda
-  - Katharine
-  - mikedanese
-  - zmerlynn
-approvers:
-  - eparis
-  - jbeda
+  - cheftako
+  - dims
+  - justaugustus
   - mikedanese
   - spiffxp
-  - zmerlynn
+approvers:
+  - bentheelder
+  - cheftako
+  - dims
+  - mikedanese
+  - spiffxp
 emeritus_approvers:
+  - eparis
   - roberthbailey   # 2019-03-08
-labels:
-- sig/cluster-lifecycle
+  - jbeda
+  - zmerlynn


### PR DESCRIPTION
Cherry pick of #93935 on release-1.16. EDIT: Plus a manually added commit, see comments below

#93935: Promote spiffxp to build/ approver

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.