### PR TITLE
Automated cherry pick of #93935: Promote spiffxp to build/ approver

### DIFF
--- a/build/OWNERS
+++ b/build/OWNERS
@@ -14,6 +14,7 @@ approvers:
   - justaugustus
   - lavalamp
   - mikedanese
+  - spiffxp
 emeritus_approvers:
   - jbeda
   - zmerlynn


### PR DESCRIPTION
Cherry pick of #93935 on release-1.19.

#93935: Promote spiffxp to build/ approver

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.