### PR TITLE
Make CSI mock driver log parse more flexible

### DIFF
--- a/test/e2e/storage/csi_mock_volume.go
+++ b/test/e2e/storage/csi_mock_volume.go
@@ -69,6 +69,8 @@ const (
 	driverPodName = "csi-mockplugin-0"
 	// Name of CSI driver container name
 	driverContainerName = "mock"
+	// Prefix of the mock driver grpc log
+	grpcCallPrefix = "gRPCCall:"
 )
 
 // csiCall represents an expected call from Kubernetes to CSI mock driver and
@@ -1360,10 +1362,11 @@ func parseMockLogs(cs clientset.Interface, namespace, driverPodName, driverConta
 	logLines := strings.Split(log, "\n")
 	var calls []mockCSICall
 	for _, line := range logLines {
-		if !strings.HasPrefix(line, "gRPCCall:") {
+		index := strings.Index(line, grpcCallPrefix)
+		if index == -1 {
 			continue
 		}
-		line = strings.TrimPrefix(line, "gRPCCall:")
+		line = line[index+len(grpcCallPrefix):]
 		call := mockCSICall{
 			json: string(line),
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup

**What this PR does / why we need it**:
This PR makes the mock CSI driver log parse function more flexible to embrace the future change where we use klog instead of `fmt.print` for mock csi driver logging.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes 

**Special notes for your reviewer**:
This is for #93358. It would be good if we can get an idea of the timestamps of all the events happened in mock CSI driver. But in order to do that, we need to flexible the tests first.

This is a prerequisite for this PR: https://github.com/kubernetes-csi/csi-test/pull/279

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/cc @msau42 
/cc @pohly 
/cc @gnufied 
/sig storage
