### PR TITLE
Turn off unnecessary informers startup

### DIFF
--- a/cmd/kube-scheduler/app/server.go
+++ b/cmd/kube-scheduler/app/server.go
@@ -283,8 +283,9 @@ func getRecorderFactory(cc *schedulerserverconfig.CompletedConfig) profile.Recor
 		return cc.EventBroadcaster.NewRecorder(name)
 	}
 }
+
 // startInformers starts the informers that the scheduler needed.
-func startInformers(factory informers.SharedInformerFactory,stopChan <- chan struct{}){
+func startInformers(factory informers.SharedInformerFactory, stopChan <-chan struct{}) {
 	// Start Informers
 	go factory.Core().V1().Pods().Informer().Run(stopChan)
 	go factory.Core().V1().PersistentVolumes().Informer().Run(stopChan)

--- a/cmd/kube-scheduler/app/server.go
+++ b/cmd/kube-scheduler/app/server.go
@@ -36,6 +36,7 @@ import (
 	"k8s.io/apiserver/pkg/server/healthz"
 	"k8s.io/apiserver/pkg/server/mux"
 	"k8s.io/apiserver/pkg/server/routes"
+	"k8s.io/client-go/informers"
 	"k8s.io/client-go/tools/events"
 	"k8s.io/client-go/tools/leaderelection"
 	cliflag "k8s.io/component-base/cli/flag"


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

If we directly use `cc.InformerFactory.Start(ctx.Done())` to start, it will cause many informers that are not related to the scheduler to start, such as:
- v1.StatefulSet
- v1.ReplicationController
...

But these informers have nothing to do with the scheduler logic and do not need to start these informers.

Moreover, `cc.InformerFactory` starts a redundant pod informer at the same time. So, when there are too many pods and workloads in the cluster, this causes a waste of memory.

We only need to start some infomer necessary for the scheduler.

**Does this PR introduce a user-facing change?**:
NONE


```release-note
NONE
```


