### PR TITLE
Fixes variable expansion false positive

### DIFF
--- a/test/e2e/common/expansion.go
+++ b/test/e2e/common/expansion.go
@@ -181,11 +181,16 @@ var _ = framework.KubeDescribe("Variable Expansion", func() {
 		Description: Make sure a container's subpath can not be set using an expansion of environment variables when absolute path is supplied.
 	*/
 	framework.ConformanceIt("should fail substituting values in a volume subpath with absolute path [sig-storage][Slow]", func() {
+		absolutePath := "/tmp"
+		if framework.NodeOSDistroIs("windows") {
+			// Windows does not typically have a C:\tmp folder.
+			absolutePath = "C:\\Users"
+		}
 
 		envVars := []v1.EnvVar{
 			{
 				Name:  "POD_NAME",
-				Value: "/tmp",
+				Value: absolutePath,
 			},
 		}
 		mounts := []v1.VolumeMount{

--- a/test/e2e/common/expansion.go
+++ b/test/e2e/common/expansion.go
@@ -367,8 +367,8 @@ func testPodFailSubpath(f *framework.Framework, pod *v1.Pod) {
 		e2epod.DeletePodWithWait(f.ClientSet, pod)
 	}()
 
-	err := e2epod.WaitTimeoutForPodRunningInNamespace(f.ClientSet, pod.Name, pod.Namespace, framework.PodStartShortTimeout)
-	framework.ExpectError(err, "while waiting for pod to be running")
+	err := e2epod.WaitForPodContainerToFail(f.ClientSet, pod.Namespace, pod.Name, 0, "CreateContainerConfigError", framework.PodStartShortTimeout)
+	framework.ExpectNoError(err, "while waiting for the pod container to fail")
 }
 
 func newPod(command []string, envVars []v1.EnvVar, mounts []v1.VolumeMount, volumes []v1.Volume) *v1.Pod {

--- a/test/e2e/framework/pod/wait.go
+++ b/test/e2e/framework/pod/wait.go
@@ -537,3 +537,10 @@ func WaitForNRestartablePods(ps *testutils.PodStore, expect int, timeout time.Du
 	}
 	return podNames, nil
 }
+
+// WaitForPodContainerToFail waits for the given Pod container to fail with the given reason, specifically due to
+// invalid container configuration. In this case, the container will remain in a waiting state with a specific
+// reason set, which should match the given reason.
+func WaitForPodContainerToFail(c clientset.Interface, namespace, podName string, containerIndex int, reason string, timeout time.Duration) error {
+	return wait.PollImmediate(poll, timeout, podContainerFailed(c, namespace, podName, containerIndex, reason))
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

/sig testing
/sig windows

**What this PR does / why we need it**:

Some of the tests are negative test cases which are supposed to ensure that those invalid usecases are handled properly.

However, some of the tests are false positives, they can pass due to various reasons. One such example is: ``should fail substituting values in a volume subpath with absolute path``.
This test can pass if:

- the Pod cannot start due to various reasons (e.g.: the container image cannot be pulled or does
  not exist).
- the Pod ran to completion, even though the container was not supposed to start in the first place.

``filepath.IsAbs`` does not consider ``/`` or ``\`` prefixed paths on Windows as absolute, even though in the end they are treated as such. Because of this, absolute paths can be mounted as volume subpaths in Windows.

The test ``should fail substituting values in a volume subpath with absolute path`` previously passed on Windows because of a false positive in the test: the test did not specifically check that the container failed to be created, instead it checked if it was not Running (in most cases, the container was running to Completion instead, which is indeed not Running, but not correct).

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #94006

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
