### PR TITLE
Verify that an ingress with empty TLS is valid

### DIFF
--- a/pkg/apis/networking/validation/validation_test.go
+++ b/pkg/apis/networking/validation/validation_test.go
@@ -2072,6 +2072,67 @@ func TestValidateIngressTLS(t *testing.T) {
 	}
 }
 
+// TestValidateEmptyIngressTLS verifies that an empty TLS configuration can be
+// specified, which ingress controllers may interpret to mean that TLS should be
+// used with a default certificate that the ingress controller furnishes.
+func TestValidateEmptyIngressTLS(t *testing.T) {
+	pathTypeImplementationSpecific := networking.PathTypeImplementationSpecific
+	serviceBackend := &networking.IngressServiceBackend{
+		Name: "defaultbackend",
+		Port: networking.ServiceBackendPort{
+			Number: 443,
+		},
+	}
+	defaultBackend := networking.IngressBackend{
+		Service: serviceBackend,
+	}
+	newValid := func() networking.Ingress {
+		return networking.Ingress{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "foo",
+				Namespace: metav1.NamespaceDefault,
+			},
+			Spec: networking.IngressSpec{
+				Rules: []networking.IngressRule{
+					{
+						Host: "foo.bar.com",
+						IngressRuleValue: networking.IngressRuleValue{
+							HTTP: &networking.HTTPIngressRuleValue{
+								Paths: []networking.HTTPIngressPath{
+									{
+										PathType: &pathTypeImplementationSpecific,
+										Backend:  defaultBackend,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+	}
+
+	validCases := map[string]networking.Ingress{}
+	goodEmptyTLS := newValid()
+	goodEmptyTLS.Spec.TLS = []networking.IngressTLS{
+		{},
+	}
+	validCases[fmt.Sprintf("spec.tls[0]: Valid value: %v", goodEmptyTLS.Spec.TLS[0])] = goodEmptyTLS
+	goodEmptyHosts := newValid()
+	goodEmptyHosts.Spec.TLS = []networking.IngressTLS{
+		{
+			Hosts: []string{},
+		},
+	}
+	validCases[fmt.Sprintf("spec.tls[0]: Valid value: %v", goodEmptyHosts.Spec.TLS[0])] = goodEmptyHosts
+	for k, v := range validCases {
+		errs := validateIngress(&v, IngressValidationOptions{}, networkingv1beta1.SchemeGroupVersion)
+		if len(errs) != 0 {
+			t.Errorf("expected success for %q", k)
+		}
+	}
+}
+
 func TestValidateIngressStatusUpdate(t *testing.T) {
 	serviceBackend := &networking.IngressServiceBackend{
 		Name: "defaultbackend",


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:
#### 

Add a test that verifies that an ingress with an empty TLS value or with a TLS value that specifies an empty list of hosts passes validation.

* `pkg/apis/networking/validation/validation_test.go` (`TestValidateEmptyIngressTLS`): New test.

**Which issue(s) this PR fixes**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```

----