### PR TITLE
[go115] Require go1.15 in build helper scripts

### DIFF
--- a/hack/lib/golang.sh
+++ b/hack/lib/golang.sh
@@ -467,7 +467,7 @@ EOF
   local go_version
   IFS=" " read -ra go_version <<< "$(go version)"
   local minimum_go_version
-  minimum_go_version=go1.14.4
+  minimum_go_version=go1.15.0
   if [[ "${minimum_go_version}" != $(echo -e "${minimum_go_version}\n${go_version[2]}" | sort -s -t. -k 1,1 -k 2,2n -k 3,3n | head -n1) && "${go_version[2]}" != "devel" ]]; then
     kube::log::usage_from_stdin <<EOF
 Detected go version: ${go_version[*]}.


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Requires scripts like hack/update-gofmt.sh to be run with go1.15+

/milestone v1.19

```release-note
NONE
```

/cc @justaugustus 