### PR TITLE
Refactor locks logic on registeredNodesLock to be non-blocking

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/vsphere/nodemanager.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/vsphere/nodemanager.go
@@ -259,6 +259,16 @@ func (nm *NodeManager) GetNode(nodeName k8stypes.NodeName) (v1.Node, error) {
 	return *node, nil
 }
 
+func (nm *NodeManager) getNodes() map[string]*v1.Node {
+	nm.registeredNodesLock.RLock()
+	defer nm.registeredNodesLock.RUnlock()
+	registeredNodes := make(map[string]*v1.Node, len(nm.registeredNodes))
+	for nodeName, node := range nm.registeredNodes {
+		registeredNodes[nodeName] = node
+	}
+	return registeredNodes
+}
+
 func (nm *NodeManager) addNode(node *v1.Node) {
 	nm.registeredNodesLock.Lock()
 	nm.registeredNodes[node.ObjectMeta.Name] = node
@@ -288,11 +298,9 @@ func (nm *NodeManager) GetNodeInfo(nodeName k8stypes.NodeName) (NodeInfo, error)
 //
 // This method is a getter but it can cause side-effect of updating NodeInfo objects.
 func (nm *NodeManager) GetNodeDetails() ([]NodeDetails, error) {
-	nm.registeredNodesLock.Lock()
-	defer nm.registeredNodesLock.Unlock()
 	var nodeDetails []NodeDetails
 
-	for nodeName, nodeObj := range nm.registeredNodes {
+	for nodeName, nodeObj := range nm.getNodes() {
 		nodeInfo, err := nm.GetNodeInfoWithNodeObject(nodeObj)
 		if err != nil {
 			return nil, err
@@ -304,10 +312,7 @@ func (nm *NodeManager) GetNodeDetails() ([]NodeDetails, error) {
 }
 
 func (nm *NodeManager) refreshNodes() (errList []error) {
-	nm.registeredNodesLock.Lock()
-	defer nm.registeredNodesLock.Unlock()
-
-	for nodeName := range nm.registeredNodes {
+	for nodeName := range nm.getNodes() {
 		nodeInfo, err := nm.getRefreshedNodeInfo(convertToK8sType(nodeName))
 		if err != nil {
 			errList = append(errList, err)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug
/kind regression

**What this PR does / why we need it**:

Refactor locks on `GetNodeDetails` and `refreshNodes` calls.

This lock was blocking volume creation and destroying the ability to provision
volume with `thin` SC.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubernetes/issues/93973

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
