### PR TITLE
Automated cherry pick of #92203: add sjenning as kubelet approver

### DIFF
--- a/pkg/kubelet/OWNERS
+++ b/pkg/kubelet/OWNERS
@@ -8,6 +8,7 @@ approvers:
 - vishh
 - yujuhong
 - dashpole
+- sjenning
 reviewers:
 - sig-node-reviewers
 labels:

--- a/pkg/kubelet/cadvisor/OWNERS
+++ b/pkg/kubelet/cadvisor/OWNERS
@@ -1,4 +1,0 @@
-# See the OWNERS docs at https://go.k8s.io/owners
-
-approvers:
-- sjenning

--- a/pkg/kubelet/cm/OWNERS
+++ b/pkg/kubelet/cm/OWNERS
@@ -8,7 +8,6 @@ approvers:
 - vishh
 - yujuhong
 - ConnorDoyle
-- sjenning
 - klueska
 reviewers:
 - sig-node-reviewers

--- a/pkg/kubelet/cm/cpumanager/OWNERS
+++ b/pkg/kubelet/cm/cpumanager/OWNERS
@@ -4,7 +4,6 @@ approvers:
 - derekwaynecarr
 - vishh
 - ConnorDoyle
-- sjenning
 - balajismaniam
 reviewers:
 - klueska

--- a/pkg/kubelet/cm/cpuset/OWNERS
+++ b/pkg/kubelet/cm/cpuset/OWNERS
@@ -4,4 +4,3 @@ approvers:
 - derekwaynecarr
 - vishh
 - ConnorDoyle
-- sjenning

--- a/pkg/kubelet/eviction/OWNERS
+++ b/pkg/kubelet/eviction/OWNERS
@@ -1,4 +1,0 @@
-# See the OWNERS docs at https://go.k8s.io/owners
-
-approvers:
-- sjenning

--- a/pkg/kubelet/images/OWNERS
+++ b/pkg/kubelet/images/OWNERS
@@ -1,4 +1,0 @@
-# See the OWNERS docs at https://go.k8s.io/owners
-
-approvers:
-- sjenning

--- a/pkg/kubelet/metrics/OWNERS
+++ b/pkg/kubelet/metrics/OWNERS
@@ -1,4 +1,0 @@
-# See the OWNERS docs at https://go.k8s.io/owners
-
-approvers:
-- sjenning

--- a/pkg/kubelet/preemption/OWNERS
+++ b/pkg/kubelet/preemption/OWNERS
@@ -1,4 +1,0 @@
-# See the OWNERS docs at https://go.k8s.io/owners
-
-approvers:
-- sjenning


### PR DESCRIPTION
Cherry pick of #92203 on release-1.18.

#92203: add sjenning as kubelet approver

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.