### PR TITLE
dedupe IsNodeConditionSetAsExpected test function

### DIFF
--- a/test/e2e/framework/node/resource.go
+++ b/test/e2e/framework/node/resource.go
@@ -90,12 +90,12 @@ func FirstAddress(nodelist *v1.NodeList, addrType v1.NodeAddressType) string {
 
 // IsConditionSetAsExpected returns a wantTrue value if the node has a match to the conditionType, otherwise returns an opposite value of the wantTrue with detailed logging.
 func IsConditionSetAsExpected(node *v1.Node, conditionType v1.NodeConditionType, wantTrue bool) bool {
-	return testutils.IsNodeConditionSetAsExpected(node, conditionType, wantTrue, false)
+	return testutils.IsNodeConditionSetAsExpected(node, conditionType, wantTrue, false, e2elog.Logf)
 }
 
 // IsConditionSetAsExpectedSilent returns a wantTrue value if the node has a match to the conditionType, otherwise returns an opposite value of the wantTrue.
 func IsConditionSetAsExpectedSilent(node *v1.Node, conditionType v1.NodeConditionType, wantTrue bool) bool {
-	return testutils.IsNodeConditionSetAsExpected(node, conditionType, wantTrue, true)
+	return testutils.IsNodeConditionSetAsExpected(node, conditionType, wantTrue, true, e2elog.Logf)
 }
 
 // isConditionUnset returns true if conditions of the given node do not have a match to the given conditionType, otherwise false.

--- a/test/integration/framework/util.go
+++ b/test/integration/framework/util.go
@@ -21,7 +21,6 @@ package framework
 import (
 	"context"
 	"fmt"
-	"k8s.io/klog/v2"
 	"net/http/httptest"
 	"strings"
 	"testing"
@@ -32,6 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/util/wait"
 	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/klog/v2"
 	v1helper "k8s.io/kubernetes/pkg/apis/core/v1/helper"
 	testutils "k8s.io/kubernetes/test/utils"
 )

--- a/test/integration/framework/util.go
+++ b/test/integration/framework/util.go
@@ -21,6 +21,7 @@ package framework
 import (
 	"context"
 	"fmt"
+	"k8s.io/klog/v2"
 	"net/http/httptest"
 	"strings"
 	"testing"
@@ -146,12 +147,12 @@ func IsNodeReady(node *v1.Node) bool {
 
 // IsConditionSetAsExpected returns a wantTrue value if the node has a match to the conditionType, otherwise returns an opposite value of the wantTrue with detailed logging.
 func IsConditionSetAsExpected(node *v1.Node, conditionType v1.NodeConditionType, wantTrue bool) bool {
-	return testutils.IsNodeConditionSetAsExpected(node, conditionType, wantTrue, false)
+	return testutils.IsNodeConditionSetAsExpected(node, conditionType, wantTrue, false, klog.Infof)
 }
 
 // IsConditionSetAsExpectedSilent returns a wantTrue value if the node has a match to the conditionType, otherwise returns an opposite value of the wantTrue.
 func IsConditionSetAsExpectedSilent(node *v1.Node, conditionType v1.NodeConditionType, wantTrue bool) bool {
-	return testutils.IsNodeConditionSetAsExpected(node, conditionType, wantTrue, true)
+	return testutils.IsNodeConditionSetAsExpected(node, conditionType, wantTrue, true, klog.Infof)
 }
 
 // isConditionUnset returns true if conditions of the given node do not have a match to the given conditionType, otherwise false.

--- a/test/utils/node.go
+++ b/test/utils/node.go
@@ -16,7 +16,27 @@ limitations under the License.
 
 package utils
 
-import "k8s.io/api/core/v1"
+import (
+	"fmt"
+	"k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
+)
+
+var (
+	// unreachableTaintTemplate is the taint for when a node becomes unreachable.
+	// Copied from pkg/controller/nodelifecycle to avoid pulling extra dependencies
+	unreachableTaintTemplate = &v1.Taint{
+		Key:    v1.TaintNodeUnreachable,
+		Effect: v1.TaintEffectNoExecute,
+	}
+
+	// notReadyTaintTemplate is the taint for when a node is not ready for executing pods.
+	// Copied from pkg/controller/nodelifecycle to avoid pulling extra dependencies
+	notReadyTaintTemplate = &v1.Taint{
+		Key:    v1.TaintNodeNotReady,
+		Effect: v1.TaintEffectNoExecute,
+	}
+)
 
 // GetNodeCondition extracts the provided condition from the given status and returns that.
 // Returns nil and -1 if the condition is not present, and the index of the located condition.
@@ -30,4 +50,64 @@ func GetNodeCondition(status *v1.NodeStatus, conditionType v1.NodeConditionType)
 		}
 	}
 	return -1, nil
+}
+
+func IsNodeConditionSetAsExpected(node *v1.Node, conditionType v1.NodeConditionType, wantTrue, silent bool) bool {
+	// Check the node readiness condition (logging all).
+	for _, cond := range node.Status.Conditions {
+		// Ensure that the condition type and the status matches as desired.
+		if cond.Type == conditionType {
+			// For NodeReady condition we need to check Taints as well
+			if cond.Type == v1.NodeReady {
+				hasNodeControllerTaints := false
+				// For NodeReady we need to check if Taints are gone as well
+				taints := node.Spec.Taints
+				for _, taint := range taints {
+					if taint.MatchTaint(unreachableTaintTemplate) || taint.MatchTaint(notReadyTaintTemplate) {
+						hasNodeControllerTaints = true
+						break
+					}
+				}
+				if wantTrue {
+					if (cond.Status == v1.ConditionTrue) && !hasNodeControllerTaints {
+						return true
+					}
+					msg := ""
+					if !hasNodeControllerTaints {
+						msg = fmt.Sprintf("Condition %s of node %s is %v instead of %t. Reason: %v, message: %v",
+							conditionType, node.Name, cond.Status == v1.ConditionTrue, wantTrue, cond.Reason, cond.Message)
+					} else {
+						msg = fmt.Sprintf("Condition %s of node %s is %v, but Node is tainted by NodeController with %v. Failure",
+							conditionType, node.Name, cond.Status == v1.ConditionTrue, taints)
+					}
+					if !silent {
+						klog.Infof(msg)
+					}
+					return false
+				}
+				// TODO: check if the Node is tainted once we enable NC notReady/unreachable taints by default
+				if cond.Status != v1.ConditionTrue {
+					return true
+				}
+				if !silent {
+					klog.Infof("Condition %s of node %s is %v instead of %t. Reason: %v, message: %v",
+						conditionType, node.Name, cond.Status == v1.ConditionTrue, wantTrue, cond.Reason, cond.Message)
+				}
+				return false
+			}
+			if (wantTrue && (cond.Status == v1.ConditionTrue)) || (!wantTrue && (cond.Status != v1.ConditionTrue)) {
+				return true
+			}
+			if !silent {
+				klog.Infof("Condition %s of node %s is %v instead of %t. Reason: %v, message: %v",
+					conditionType, node.Name, cond.Status == v1.ConditionTrue, wantTrue, cond.Reason, cond.Message)
+			}
+			return false
+		}
+
+	}
+	if !silent {
+		klog.Infof("Couldn't find condition %v on node %v", conditionType, node.Name)
+	}
+	return false
 }

--- a/test/utils/node.go
+++ b/test/utils/node.go
@@ -19,7 +19,6 @@ package utils
 import (
 	"fmt"
 	"k8s.io/api/core/v1"
-	"k8s.io/klog/v2"
 )
 
 var (
@@ -52,7 +51,7 @@ func GetNodeCondition(status *v1.NodeStatus, conditionType v1.NodeConditionType)
 	return -1, nil
 }
 
-func IsNodeConditionSetAsExpected(node *v1.Node, conditionType v1.NodeConditionType, wantTrue, silent bool) bool {
+func IsNodeConditionSetAsExpected(node *v1.Node, conditionType v1.NodeConditionType, wantTrue, silent bool, logFunc func(fmt string, args ...interface{})) bool {
 	// Check the node readiness condition (logging all).
 	for _, cond := range node.Status.Conditions {
 		// Ensure that the condition type and the status matches as desired.
@@ -81,7 +80,7 @@ func IsNodeConditionSetAsExpected(node *v1.Node, conditionType v1.NodeConditionT
 							conditionType, node.Name, cond.Status == v1.ConditionTrue, taints)
 					}
 					if !silent {
-						klog.Infof(msg)
+						logFunc(msg)
 					}
 					return false
 				}
@@ -90,7 +89,7 @@ func IsNodeConditionSetAsExpected(node *v1.Node, conditionType v1.NodeConditionT
 					return true
 				}
 				if !silent {
-					klog.Infof("Condition %s of node %s is %v instead of %t. Reason: %v, message: %v",
+					logFunc("Condition %s of node %s is %v instead of %t. Reason: %v, message: %v",
 						conditionType, node.Name, cond.Status == v1.ConditionTrue, wantTrue, cond.Reason, cond.Message)
 				}
 				return false
@@ -99,7 +98,7 @@ func IsNodeConditionSetAsExpected(node *v1.Node, conditionType v1.NodeConditionT
 				return true
 			}
 			if !silent {
-				klog.Infof("Condition %s of node %s is %v instead of %t. Reason: %v, message: %v",
+				logFunc("Condition %s of node %s is %v instead of %t. Reason: %v, message: %v",
 					conditionType, node.Name, cond.Status == v1.ConditionTrue, wantTrue, cond.Reason, cond.Message)
 			}
 			return false
@@ -107,7 +106,7 @@ func IsNodeConditionSetAsExpected(node *v1.Node, conditionType v1.NodeConditionT
 
 	}
 	if !silent {
-		klog.Infof("Couldn't find condition %v on node %v", conditionType, node.Name)
+		logFunc("Couldn't find condition %v on node %v", conditionType, node.Name)
 	}
 	return false
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

The IsNodeConditionSetAsExpected function is duplicated in two places, this PR moves the implementation into testutils where both callsites can use the common implementation.

**Which issue(s) this PR fixes**:

Fixes https://github.com/kubernetes/kubernetes/issues/93965

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
