### PR TITLE
update test to match validation filter of pods

### DIFF
--- a/pkg/kubelet/config/config_test.go
+++ b/pkg/kubelet/config/config_test.go
@@ -189,8 +189,8 @@ func TestInvalidPodFiltered(t *testing.T) {
 	channel <- podUpdate
 	expectPodUpdate(t, ch, CreatePodUpdate(kubetypes.ADD, TestSource, CreateValidPod("foo", "new")))
 
-	// add an invalid update
-	podUpdate = CreatePodUpdate(kubetypes.UPDATE, TestSource, &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "foo"}})
+	// add an invalid update, pod with the same name
+	podUpdate = CreatePodUpdate(kubetypes.ADD, TestSource, CreateValidPod("foo", "new"))
 	channel <- podUpdate
 	expectNoPodUpdate(t, ch)
 }


### PR DESCRIPTION
invalid pod filter changed to name only

changed for k8s v1.9 in 811447ea0a9928c326965f3bbd8195826b20daf8 #53194

**What type of PR is this?**
/kind cleanup
/kind flake

**What this PR does / why we need it**:
Full validation was removed for v1.9 and changed to a duplicate name only check.

I'm not sure if we want to fix it this way or by going back to a full validation with a `validation.ValidatePod(`.

**Which issue(s) this PR fixes**:
Fixes #93905

**Special notes for your reviewer**:
/assign @liggitt 
I ran the suggested stress for 20000.

/cc @knight42 
as was looking at the originating issue.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

