### PR TITLE
test(kubectl): deflake run_kubectl_apply_tests(round 2)

### DIFF
--- a/test/cmd/apply.sh
+++ b/test/cmd/apply.sh
@@ -144,6 +144,18 @@ run_kubectl_apply_tests() {
 }
 __EOF__
 
+  # Ensure the API server has recognized and started serving the associated CR API
+  local tries=5
+  for i in $(seq 1 $tries); do
+      local output
+      output=$(kubectl "${kube_flags[@]:?}" api-resources --api-group mygroup.example.com -oname)
+      if kube::test::if_has_string "$output" resources.mygroup.example.com; then
+          break
+      fi
+      echo "${i}: Waiting for CR API to be available"
+      sleep "$i"
+  done
+
   # Dry-run create the CR
   kubectl "${kube_flags[@]:?}" apply --dry-run=server -f hack/testdata/CRD/resource.yaml "${kube_flags[@]:?}"
   # Make sure that the CR doesn't exist


### PR DESCRIPTION
Signed-off-by: knight42 <anonymousknight96@gmail.com>

**What type of PR is this?**

/kind flake

**What this PR does / why we need it**:

There are two places we create CRD in the test, we need to ensure the API server is serving the associated CR API in both places.

**Which issue(s) this PR fixes**:

complement #93657 

Fixes #93651

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
