### PR TITLE
Make clustername configurable in generation of kubeconfig using kubeadm command

### DIFF
--- a/cmd/kubeadm/app/cmd/alpha/kubeconfig.go
+++ b/cmd/kubeadm/app/cmd/alpha/kubeconfig.go
@@ -99,6 +99,7 @@ func newCmdUserKubeConfig(out io.Writer) *cobra.Command {
 
 	// Add ClusterConfiguration backed flags to the command
 	cmd.Flags().StringVar(&clusterCfg.CertificatesDir, options.CertificatesDir, clusterCfg.CertificatesDir, "The path where certificates are stored")
+	cmd.Flags().StringVar(&clusterCfg.ClusterName, "cluster-name", clusterCfg.ClusterName, "Cluster name to be used in kubeconfig")
 
 	// Add InitConfiguration backed flags to the command
 	cmd.Flags().StringVar(&initCfg.LocalAPIEndpoint.AdvertiseAddress, options.APIServerAdvertiseAddress, initCfg.LocalAPIEndpoint.AdvertiseAddress, "The IP address the API server is accessible on")

--- a/cmd/kubeadm/app/cmd/alpha/kubeconfig_test.go
+++ b/cmd/kubeadm/app/cmd/alpha/kubeconfig_test.go
@@ -56,6 +56,7 @@ func TestKubeConfigSubCommandsThatWritesToOut(t *testing.T) {
 		command         string
 		withClientCert  bool
 		withToken       bool
+		withClusterName bool
 		additionalFlags []string
 	}{
 		{
@@ -64,10 +65,24 @@ func TestKubeConfigSubCommandsThatWritesToOut(t *testing.T) {
 			withClientCert: true,
 		},
 		{
+			name:            "user subCommand withClientCert",
+			command:         "user",
+			withClientCert:  true,
+			withClusterName: true,
+			additionalFlags: []string{"--cluster-name=my-cluster"},
+		},
+		{
 			name:            "user subCommand withToken",
 			withToken:       true,
 			command:         "user",
 			additionalFlags: []string{"--token=123456"},
+		},
+		{
+			name:            "user subCommand withToken",
+			withToken:       true,
+			command:         "user",
+			withClusterName: true,
+			additionalFlags: []string{"--token=123456", "--cluster-name=my-cluster"},
 		},
 	}
 
@@ -103,6 +118,11 @@ func TestKubeConfigSubCommandsThatWritesToOut(t *testing.T) {
 			if test.withToken {
 				// checks that kubeconfig files have expected token
 				kubeconfigtestutil.AssertKubeConfigCurrentAuthInfoWithToken(t, config, "myUser", "123456")
+			}
+
+			if test.withClusterName {
+				// checks that kubeconfig files have expected cluster name
+				kubeconfigtestutil.AssertKubeConfigCurrentContextWithClusterName(t, config, "my-cluster")
 			}
 		})
 	}

--- a/cmd/kubeadm/test/kubeconfig/util.go
+++ b/cmd/kubeadm/test/kubeconfig/util.go
@@ -98,3 +98,15 @@ func AssertKubeConfigCurrentAuthInfoWithToken(t *testing.T, config *clientcmdapi
 		return
 	}
 }
+
+// AssertKubeConfigCurrentContextWithClusterName is a utility function for kubeadm testing that asserts if the Current Cluster config in
+// the given KubeConfig object refers to expected cluster name
+func AssertKubeConfigCurrentContextWithClusterName(t *testing.T, config *clientcmdapi.Config, expectedClusterName string) {
+	currentContext := config.Contexts[config.CurrentContext]
+
+	// assert cluster name
+	if currentContext.Cluster != expectedClusterName {
+		t.Errorf("kubeconfig.currentContext.clusterName [%s], expected [%s]", currentContext.Cluster, expectedClusterName)
+		return
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
Add a flag `--cluster-name` to `kubeadm alpha kubeconfig user` command which make cluster name configurable in kubeconfig. If this option is not configured, it will use default cluster name `kubernetes`.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes [#2258](https://github.com/kubernetes/kubeadm/issues/2258)

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**: Yes
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kubeadm: add the "--cluster-name" flag to the "kubeadm alpha kubeconfig user" to allow configuring the cluster name in the generated kubeconfig file
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
