### PR TITLE
Add logging for making it easier to debug e2e flakes

### DIFF
--- a/test/e2e/framework/pods.go
+++ b/test/e2e/framework/pods.go
@@ -100,9 +100,11 @@ func (c *PodClient) Create(pod *v1.Pod) *v1.Pod {
 func (c *PodClient) CreateSync(pod *v1.Pod) *v1.Pod {
 	namespace := c.f.Namespace.Name
 	p := c.Create(pod)
-	ExpectNoError(e2epod.WaitForPodNameRunningInNamespace(c.f.ClientSet, p.Name, namespace))
+	err := e2epod.WaitForPodNameRunningInNamespace(c.f.ClientSet, p.Name, namespace)
+	LogPodStartErrorIfAny(p, err)
+	ExpectNoError(err)
 	// Get the newest pod after it becomes running, some status may change after pod created, such as pod ip.
-	p, err := c.Get(context.TODO(), p.Name, metav1.GetOptions{})
+	p, err = c.Get(context.TODO(), p.Name, metav1.GetOptions{})
 	ExpectNoError(err)
 	return p
 }

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -806,6 +806,7 @@ func (f *Framework) MatchContainerOutput(
 
 	// Wait for client pod to complete.
 	podErr := e2epod.WaitForPodSuccessInNamespace(f.ClientSet, createdPod.Name, ns)
+	LogPodStartErrorIfAny(createdPod, podErr)
 
 	// Grab its logs.  Get host first.
 	podStatus, err := podClient.Get(context.TODO(), createdPod.Name, metav1.GetOptions{})

--- a/test/e2e/framework/volume/fixtures.go
+++ b/test/e2e/framework/volume/fixtures.go
@@ -335,7 +335,9 @@ func startVolumeServer(client clientset.Interface, config TestConfig) *v1.Pod {
 		framework.ExpectNoError(e2epod.WaitForPodSuccessInNamespace(client, serverPod.Name, serverPod.Namespace))
 		framework.ExpectNoError(podClient.Delete(context.TODO(), serverPod.Name, metav1.DeleteOptions{}))
 	} else {
-		framework.ExpectNoError(e2epod.WaitForPodRunningInNamespace(client, serverPod))
+		err = e2epod.WaitForPodRunningInNamespace(client, serverPod)
+		framework.LogPodStartErrorIfAny(serverPod, err)
+		framework.ExpectNoError(err)
 		if pod == nil {
 			ginkgo.By(fmt.Sprintf("locating the %q server pod", serverPodName))
 			pod, err = podClient.Get(context.TODO(), serverPodName, metav1.GetOptions{})
@@ -444,6 +446,7 @@ func runVolumeTesterPod(client clientset.Interface, config TestConfig, podSuffix
 		err = e2epod.WaitForPodRunningInNamespace(client, clientPod)
 	}
 	if err != nil {
+		framework.LogPodStartErrorIfAny(clientPod, err)
 		e2epod.DeletePodOrFail(client, clientPod.Namespace, clientPod.Name)
 		e2epod.WaitForPodToDisappear(client, clientPod.Namespace, clientPod.Name, labels.Everything(), framework.Poll, framework.PodDeleteTimeout)
 		return nil, err

--- a/test/e2e/storage/csi_mock_volume.go
+++ b/test/e2e/storage/csi_mock_volume.go
@@ -279,6 +279,7 @@ var _ = utils.SIGDescribe("CSI mock volume", func() {
 					return
 				}
 				err = e2epod.WaitForPodNameRunningInNamespace(m.cs, pod.Name, pod.Namespace)
+				framework.LogPodStartErrorIfAny(pod, err)
 				framework.ExpectNoError(err, "Failed to start pod: %v", err)
 
 				ginkgo.By("Checking if VolumeAttachment was created for the pod")
@@ -365,6 +366,7 @@ var _ = utils.SIGDescribe("CSI mock volume", func() {
 					return
 				}
 				err = e2epod.WaitForPodNameRunningInNamespace(m.cs, pod.Name, pod.Namespace)
+				framework.LogPodStartErrorIfAny(pod, err)
 				framework.ExpectNoError(err, "Failed to start pod: %v", err)
 
 				// If we expect an ephemeral volume, the feature has to be enabled.
@@ -406,12 +408,14 @@ var _ = utils.SIGDescribe("CSI mock volume", func() {
 			gomega.Expect(pod1).NotTo(gomega.BeNil(), "while creating first pod")
 
 			err = e2epod.WaitForPodNameRunningInNamespace(m.cs, pod1.Name, pod1.Namespace)
+			framework.LogPodStartErrorIfAny(pod1, err)
 			framework.ExpectNoError(err, "Failed to start pod1: %v", err)
 
 			_, _, pod2 := createPod(false)
 			gomega.Expect(pod2).NotTo(gomega.BeNil(), "while creating second pod")
 
 			err = e2epod.WaitForPodNameRunningInNamespace(m.cs, pod2.Name, pod2.Namespace)
+			framework.LogPodStartErrorIfAny(pod2, err)
 			framework.ExpectNoError(err, "Failed to start pod2: %v", err)
 
 			_, _, pod3 := createPod(false)
@@ -472,6 +476,7 @@ var _ = utils.SIGDescribe("CSI mock volume", func() {
 				framework.ExpectEqual(*sc.AllowVolumeExpansion, true, "failed creating sc with allowed expansion")
 
 				err = e2epod.WaitForPodNameRunningInNamespace(m.cs, pod.Name, pod.Namespace)
+				framework.LogPodStartErrorIfAny(pod, err)
 				framework.ExpectNoError(err, "Failed to start pod1: %v", err)
 
 				ginkgo.By("Expanding current pvc")
@@ -565,6 +570,7 @@ var _ = utils.SIGDescribe("CSI mock volume", func() {
 				framework.ExpectEqual(*sc.AllowVolumeExpansion, true, "failed creating sc with allowed expansion")
 
 				err = e2epod.WaitForPodNameRunningInNamespace(m.cs, pod.Name, pod.Namespace)
+				framework.LogPodStartErrorIfAny(pod, err)
 				framework.ExpectNoError(err, "Failed to start pod1: %v", err)
 
 				ginkgo.By("Expanding current pvc")
@@ -719,6 +725,7 @@ var _ = utils.SIGDescribe("CSI mock volume", func() {
 				if test.expectPodRunning {
 					ginkgo.By("Waiting for pod to be running")
 					err := e2epod.WaitForPodNameRunningInNamespace(m.cs, pod.Name, pod.Namespace)
+					framework.LogPodStartErrorIfAny(pod, err)
 					framework.ExpectNoError(err, "Failed to start pod: %v", err)
 				}
 
@@ -839,6 +846,7 @@ var _ = utils.SIGDescribe("CSI mock volume", func() {
 				framework.ExpectEqual(*sc.VolumeBindingMode, bindingMode, "volume binding mode")
 
 				err = e2epod.WaitForPodNameRunningInNamespace(m.cs, pod.Name, pod.Namespace)
+				framework.LogPodStartErrorIfAny(pod, err)
 				framework.ExpectNoError(err, "failed to start pod")
 				err = e2epod.DeletePodWithWait(m.cs, pod)
 				framework.ExpectNoError(err, "failed to delete pod")
@@ -1059,6 +1067,7 @@ var _ = utils.SIGDescribe("CSI mock volume", func() {
 						framework.Failf("unexpected error while waiting for pod: %v", err)
 					}
 				} else {
+					framework.LogPodStartErrorIfAny(pod, err)
 					framework.ExpectNoError(err, "failed to start pod")
 				}
 

--- a/test/e2e/storage/empty_dir_wrapper.go
+++ b/test/e2e/storage/empty_dir_wrapper.go
@@ -419,6 +419,7 @@ func testNoWrappedVolumeRace(f *framework.Framework, volumes []v1.Volume, volume
 			continue
 		}
 		err = e2epod.WaitForPodNameRunningInNamespace(f.ClientSet, pod.Name, f.Namespace.Name)
+		framework.LogPodStartErrorIfAny(&pod, err)
 		framework.ExpectNoError(err, "Failed waiting for pod %s to enter running state", pod.Name)
 	}
 }

--- a/test/e2e/storage/flexvolume_online_resize.go
+++ b/test/e2e/storage/flexvolume_online_resize.go
@@ -158,6 +158,7 @@ var _ = utils.SIGDescribe("Mounted flexvolume volume expand [Slow] [Feature:Expa
 
 		ginkgo.By("Waiting for pod to go to 'running' state")
 		err = e2epod.WaitForPodNameRunningInNamespace(f.ClientSet, pod.ObjectMeta.Name, f.Namespace.Name)
+		framework.LogPodStartErrorIfAny(pod, err)
 		framework.ExpectNoError(err, "Pod didn't go to 'running' state %v", err)
 
 		ginkgo.By("Expanding current pvc")

--- a/test/e2e/storage/generic_persistent_volume-disruptive.go
+++ b/test/e2e/storage/generic_persistent_volume-disruptive.go
@@ -113,6 +113,7 @@ func createPodPVCFromSC(f *framework.Framework, c clientset.Interface, ns string
 		SeLinuxLabel: e2epv.SELinuxLabel,
 	}
 	pod, err := e2epod.CreateSecPod(c, &podConfig, framework.PodStartTimeout)
+	framework.LogPodStartErrorIfAny(pod, err)
 	framework.ExpectNoError(err, "While creating pods for kubelet restart test")
 	return pod, pvc, pvs[0]
 }

--- a/test/e2e/storage/nfs_persistent_volume-disruptive.go
+++ b/test/e2e/storage/nfs_persistent_volume-disruptive.go
@@ -180,6 +180,7 @@ var _ = utils.SIGDescribe("NFSPersistentVolumes[Disruptive][Flaky]", func() {
 
 			ginkgo.By("Attaching both PVC's to a single pod")
 			clientPod, err = e2epod.CreatePod(c, ns, nil, []*v1.PersistentVolumeClaim{pvc1, pvc2}, true, "")
+			framework.LogPodStartErrorIfAny(clientPod, err)
 			framework.ExpectNoError(err)
 		})
 

--- a/test/e2e/storage/pd.go
+++ b/test/e2e/storage/pd.go
@@ -148,7 +148,9 @@ var _ = utils.SIGDescribe("Pod Disks", func() {
 					fmtPod = testPDPod([]string{diskName}, host0Name, false, 1)
 					_, err = podClient.Create(context.TODO(), fmtPod, metav1.CreateOptions{})
 					framework.ExpectNoError(err, "Failed to create fmtPod")
-					framework.ExpectNoError(e2epod.WaitForPodRunningInNamespaceSlow(f.ClientSet, fmtPod.Name, f.Namespace.Name))
+					err = e2epod.WaitForPodRunningInNamespaceSlow(f.ClientSet, fmtPod.Name, f.Namespace.Name)
+					framework.LogPodStartErrorIfAny(fmtPod, err)
+					framework.ExpectNoError(err)
 
 					ginkgo.By("deleting the fmtPod")
 					framework.ExpectNoError(podClient.Delete(context.TODO(), fmtPod.Name, *metav1.NewDeleteOptions(0)), "Failed to delete fmtPod")
@@ -176,7 +178,9 @@ var _ = utils.SIGDescribe("Pod Disks", func() {
 				ginkgo.By("creating host0Pod on node0")
 				_, err = podClient.Create(context.TODO(), host0Pod, metav1.CreateOptions{})
 				framework.ExpectNoError(err, fmt.Sprintf("Failed to create host0Pod: %v", err))
-				framework.ExpectNoError(e2epod.WaitForPodRunningInNamespaceSlow(f.ClientSet, host0Pod.Name, f.Namespace.Name))
+				err = e2epod.WaitForPodRunningInNamespaceSlow(f.ClientSet, host0Pod.Name, f.Namespace.Name)
+				framework.LogPodStartErrorIfAny(host0Pod, err)
+				framework.ExpectNoError(err)
 				framework.Logf("host0Pod: %q, node0: %q", host0Pod.Name, host0Name)
 
 				var containerName, testFile, testFileContents string
@@ -200,7 +204,9 @@ var _ = utils.SIGDescribe("Pod Disks", func() {
 				ginkgo.By("creating host1Pod on node1")
 				_, err = podClient.Create(context.TODO(), host1Pod, metav1.CreateOptions{})
 				framework.ExpectNoError(err, "Failed to create host1Pod")
-				framework.ExpectNoError(e2epod.WaitForPodRunningInNamespaceSlow(f.ClientSet, host1Pod.Name, f.Namespace.Name))
+				err = e2epod.WaitForPodRunningInNamespaceSlow(f.ClientSet, host1Pod.Name, f.Namespace.Name)
+				framework.LogPodStartErrorIfAny(host1Pod, err)
+				framework.ExpectNoError(err)
 				framework.Logf("host1Pod: %q, node1: %q", host1Pod.Name, host1Name)
 
 				if readOnly {
@@ -282,7 +288,9 @@ var _ = utils.SIGDescribe("Pod Disks", func() {
 					host0Pod = testPDPod(diskNames, host0Name, false /* readOnly */, numContainers)
 					_, err = podClient.Create(context.TODO(), host0Pod, metav1.CreateOptions{})
 					framework.ExpectNoError(err, fmt.Sprintf("Failed to create host0Pod: %v", err))
-					framework.ExpectNoError(e2epod.WaitForPodRunningInNamespaceSlow(f.ClientSet, host0Pod.Name, f.Namespace.Name))
+					err = e2epod.WaitForPodRunningInNamespaceSlow(f.ClientSet, host0Pod.Name, f.Namespace.Name)
+					framework.LogPodStartErrorIfAny(host0Pod, err)
+					framework.ExpectNoError(err)
 
 					ginkgo.By(fmt.Sprintf("writing %d file(s) via a container", numPDs))
 					containerName := "mycontainer"
@@ -385,7 +393,9 @@ var _ = utils.SIGDescribe("Pod Disks", func() {
 				_, err = podClient.Create(context.TODO(), host0Pod, metav1.CreateOptions{})
 				framework.ExpectNoError(err, fmt.Sprintf("Failed to create host0Pod: %v", err))
 				ginkgo.By("waiting for host0Pod to be running")
-				framework.ExpectNoError(e2epod.WaitForPodRunningInNamespaceSlow(f.ClientSet, host0Pod.Name, f.Namespace.Name))
+				err = e2epod.WaitForPodRunningInNamespaceSlow(f.ClientSet, host0Pod.Name, f.Namespace.Name)
+				framework.LogPodStartErrorIfAny(host0Pod, err)
+				framework.ExpectNoError(err)
 
 				ginkgo.By("writing content to host0Pod")
 				testFile := "/testpd1/tracker"
@@ -474,7 +484,9 @@ var _ = utils.SIGDescribe("Pod Disks", func() {
 		ginkgo.By("Creating test pod with same volume")
 		_, err = podClient.Create(context.TODO(), pod, metav1.CreateOptions{})
 		framework.ExpectNoError(err, "Failed to create pod")
-		framework.ExpectNoError(e2epod.WaitForPodRunningInNamespaceSlow(f.ClientSet, pod.Name, f.Namespace.Name))
+		err = e2epod.WaitForPodRunningInNamespaceSlow(f.ClientSet, pod.Name, f.Namespace.Name)
+		framework.LogPodStartErrorIfAny(pod, err)
+		framework.ExpectNoError(err)
 
 		ginkgo.By("deleting the pod")
 		framework.ExpectNoError(podClient.Delete(context.TODO(), pod.Name, *metav1.NewDeleteOptions(0)), "Failed to delete pod")

--- a/test/e2e/storage/persistent_volumes-gce.go
+++ b/test/e2e/storage/persistent_volumes-gce.go
@@ -52,6 +52,7 @@ func initializeGCETestSpec(c clientset.Interface, ns string, pvConfig e2epv.Pers
 
 	ginkgo.By("Creating the Client Pod")
 	clientPod, err := e2epod.CreateClientPod(c, ns, pvc)
+	framework.LogPodStartErrorIfAny(clientPod, err)
 	framework.ExpectNoError(err)
 	return clientPod, pv, pvc
 }

--- a/test/e2e/storage/persistent_volumes-local.go
+++ b/test/e2e/storage/persistent_volumes-local.go
@@ -1031,7 +1031,9 @@ func createLocalPod(config *localTestConfig, volume *localTestVolume, fsGroup *i
 		SeLinuxLabel: selinuxLabel,
 		FsGroup:      fsGroup,
 	}
-	return e2epod.CreateSecPod(config.client, &podConfig, framework.PodStartShortTimeout)
+	pod, err := e2epod.CreateSecPod(config.client, &podConfig, framework.PodStartShortTimeout)
+	framework.LogPodStartErrorIfAny(pod, err)
+	return pod, err
 }
 
 func createWriteCmd(testDir string, testFile string, writeTestFileContent string, volumeType localVolumeType) string {

--- a/test/e2e/storage/pvc_protection.go
+++ b/test/e2e/storage/pvc_protection.go
@@ -18,12 +18,13 @@ package storage
 
 import (
 	"context"
+
 	"github.com/onsi/ginkgo"
 
 	"fmt"
 	"time"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"
@@ -91,6 +92,7 @@ var _ = utils.SIGDescribe("PVC Protection", func() {
 		ginkgo.By("Creating a Pod that becomes Running and therefore is actively using the PVC")
 		pvcClaims := []*v1.PersistentVolumeClaim{pvc}
 		pod, err = e2epod.CreatePod(client, nameSpace, nil, pvcClaims, false, "")
+		framework.LogPodStartErrorIfAny(pod, err)
 		framework.ExpectNoError(err, "While creating pod that uses the PVC or waiting for the Pod to become Running")
 
 		ginkgo.By("Waiting for PVC to become Bound")

--- a/test/e2e/storage/testsuites/disruptive.go
+++ b/test/e2e/storage/testsuites/disruptive.go
@@ -168,6 +168,7 @@ func (s *disruptiveTestSuite) DefineTests(driver TestDriver, pattern testpattern
 						NodeSelection:       l.config.ClientNodeSelection,
 					}
 					l.pod, err = e2epod.CreateSecPodWithNodeSelection(l.cs, &podConfig, framework.PodStartTimeout)
+					framework.LogPodStartErrorIfAny(l.pod, err)
 					framework.ExpectNoError(err, "While creating pods for kubelet restart test")
 
 					if pattern.VolMode == v1.PersistentVolumeBlock && t.runTestBlock != nil {

--- a/test/e2e/storage/testsuites/multivolume.go
+++ b/test/e2e/storage/testsuites/multivolume.go
@@ -411,6 +411,7 @@ func testAccessMultipleVolumes(f *framework.Framework, cs clientset.Interface, n
 	defer func() {
 		framework.ExpectNoError(e2epod.DeletePodWithWait(cs, pod))
 	}()
+	framework.LogPodStartErrorIfAny(pod, err)
 	framework.ExpectNoError(err)
 
 	byteLen := 64
@@ -491,6 +492,7 @@ func TestConcurrentAccessToSingleVolume(f *framework.Framework, cs clientset.Int
 			framework.ExpectNoError(e2epod.DeletePodWithWait(cs, pod))
 		}()
 		framework.ExpectNoError(err)
+		framework.LogPodStartErrorIfAny(pod, err)
 		pod, err = cs.CoreV1().Pods(pod.Namespace).Get(context.TODO(), pod.Name, metav1.GetOptions{})
 		pods = append(pods, pod)
 		framework.ExpectNoError(err, fmt.Sprintf("get pod%d", index))
@@ -646,5 +648,6 @@ func initializeVolume(cs clientset.Interface, ns string, pvc *v1.PersistentVolum
 	defer func() {
 		framework.ExpectNoError(e2epod.DeletePodWithWait(cs, pod))
 	}()
+	framework.LogPodStartErrorIfAny(pod, err)
 	framework.ExpectNoError(err)
 }

--- a/test/e2e/storage/testsuites/provisioning.go
+++ b/test/e2e/storage/testsuites/provisioning.go
@@ -361,6 +361,7 @@ func (t StorageClassTest) TestDynamicProvisioning() *v1.PersistentVolume {
 			var pod *v1.Pod
 			pod, err := e2epod.CreatePod(t.Client, claim.Namespace, nil /* nodeSelector */, []*v1.PersistentVolumeClaim{claim}, true /* isPrivileged */, "" /* command */)
 			// Delete pod now, otherwise PV can't be deleted below
+			framework.LogPodStartErrorIfAny(pod, err)
 			framework.ExpectNoError(err)
 			e2epod.DeletePodOrFail(t.Client, pod.Namespace, pod.Name)
 		}
@@ -606,6 +607,7 @@ func (t StorageClassTest) TestBindingWaitForFirstConsumerMultiPVC(claims []*v1.P
 		pod, err = e2epod.CreateUnschedulablePod(t.Client, namespace, nodeSelector, createdClaims, true /* isPrivileged */, "" /* command */)
 	} else {
 		pod, err = e2epod.CreatePod(t.Client, namespace, nil /* nodeSelector */, createdClaims, true /* isPrivileged */, "" /* command */)
+		framework.LogPodStartErrorIfAny(pod, err)
 	}
 	framework.ExpectNoError(err)
 	defer func() {

--- a/test/e2e/storage/testsuites/subpath.go
+++ b/test/e2e/storage/testsuites/subpath.go
@@ -847,6 +847,7 @@ func testPodContainerRestartWithHooks(f *framework.Framework, pod *v1.Pod, hooks
 		e2epod.DeletePodWithWait(f.ClientSet, pod)
 	}()
 	err = e2epod.WaitForPodRunningInNamespace(f.ClientSet, pod)
+	framework.LogPodStartErrorIfAny(pod, err)
 	framework.ExpectNoError(err, "while waiting for pod to be running")
 
 	ginkgo.By("Failing liveness probe")

--- a/test/e2e/storage/testsuites/volume_expand.go
+++ b/test/e2e/storage/testsuites/volume_expand.go
@@ -176,6 +176,8 @@ func (v *volumeExpandTestSuite) DefineTests(driver TestDriver, pattern testpatte
 				err = e2epod.DeletePodWithWait(f.ClientSet, l.pod)
 				framework.ExpectNoError(err, "while cleaning up pod already deleted in resize test")
 			}()
+			framework.LogPodStartErrorIfAny(l.pod, err)
+
 			framework.ExpectNoError(err, "While creating pods for resizing")
 
 			ginkgo.By("Deleting the previously created pod")
@@ -219,6 +221,7 @@ func (v *volumeExpandTestSuite) DefineTests(driver TestDriver, pattern testpatte
 				err = e2epod.DeletePodWithWait(f.ClientSet, l.pod2)
 				framework.ExpectNoError(err, "while cleaning up pod before exiting resizing test")
 			}()
+			framework.LogPodStartErrorIfAny(l.pod2, err)
 			framework.ExpectNoError(err, "while recreating pod for resizing")
 
 			ginkgo.By("Waiting for file system resize to finish")

--- a/test/e2e/storage/vsphere/vsphere_scale.go
+++ b/test/e2e/storage/vsphere/vsphere_scale.go
@@ -213,6 +213,7 @@ func VolumeCreateAndAttach(client clientset.Interface, namespace string, sc []*s
 		nodeSelector := nodeSelectorList[nodeSelectorIndex%len(nodeSelectorList)]
 		// Create pod to attach Volume to Node
 		pod, err := e2epod.CreatePod(client, namespace, map[string]string{nodeSelector.labelKey: nodeSelector.labelValue}, pvclaims, false, "")
+		framework.LogPodStartErrorIfAny(pod, err)
 		framework.ExpectNoError(err)
 
 		for _, pv := range persistentvolumes {

--- a/test/e2e/storage/vsphere/vsphere_stress.go
+++ b/test/e2e/storage/vsphere/vsphere_stress.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/onsi/ginkgo"
 	"github.com/onsi/gomega"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"
@@ -146,6 +146,7 @@ func PerformVolumeLifeCycleInParallel(f *framework.Framework, client clientset.I
 		ginkgo.By(fmt.Sprintf("%v Creating Pod using the claim: %v", logPrefix, pvclaim.Name))
 		// Create pod to attach Volume to Node
 		pod, err := e2epod.CreatePod(client, namespace, nil, pvclaims, false, "")
+		framework.LogPodStartErrorIfAny(pod, err)
 		framework.ExpectNoError(err)
 
 		ginkgo.By(fmt.Sprintf("%v Waiting for the Pod: %v to be in the running state", logPrefix, pod.Name))

--- a/test/e2e/storage/vsphere/vsphere_volume_fstype.go
+++ b/test/e2e/storage/vsphere/vsphere_volume_fstype.go
@@ -129,6 +129,7 @@ func invokeTestForInvalidFstype(f *framework.Framework, client clientset.Interfa
 	pvclaims = append(pvclaims, pvclaim)
 	// Create pod to attach Volume to Node
 	pod, err := e2epod.CreatePod(client, namespace, nil, pvclaims, false, execCommand)
+	framework.LogPodStartErrorIfAny(pod, err)
 	framework.ExpectError(err)
 
 	eventList, err := client.CoreV1().Events(namespace).List(context.TODO(), metav1.ListOptions{})
@@ -173,6 +174,7 @@ func createPodAndVerifyVolumeAccessible(client clientset.Interface, namespace st
 	ginkgo.By("Creating pod to attach PV to the node")
 	// Create pod to attach Volume to Node
 	pod, err := e2epod.CreatePod(client, namespace, nil, pvclaims, false, execCommand)
+	framework.LogPodStartErrorIfAny(pod, err)
 	framework.ExpectNoError(err)
 
 	// Asserts: Right disk is attached to the pod

--- a/test/e2e/storage/vsphere/vsphere_volume_ops_storm.go
+++ b/test/e2e/storage/vsphere/vsphere_volume_ops_storm.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/onsi/ginkgo"
 	"github.com/onsi/gomega"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"
@@ -109,6 +109,7 @@ var _ = utils.SIGDescribe("Volume Operations Storm [Feature:vsphere]", func() {
 
 		ginkgo.By("Creating pod to attach PVs to the node")
 		pod, err := e2epod.CreatePod(client, namespace, nil, pvclaims, false, "")
+		framework.LogPodStartErrorIfAny(pod, err)
 		framework.ExpectNoError(err)
 
 		ginkgo.By("Verify all volumes are accessible and available in the pod")

--- a/test/e2e/storage/vsphere/vsphere_volume_perf.go
+++ b/test/e2e/storage/vsphere/vsphere_volume_perf.go
@@ -196,6 +196,7 @@ func invokeVolumeLifeCyclePerformance(f *framework.Framework, client clientset.I
 	for i, pvclaims := range totalpvclaims {
 		nodeSelector := nodeSelectorList[i%len(nodeSelectorList)]
 		pod, err := e2epod.CreatePod(client, namespace, map[string]string{nodeSelector.labelKey: nodeSelector.labelValue}, pvclaims, false, "")
+		framework.LogPodStartErrorIfAny(pod, err)
 		framework.ExpectNoError(err)
 		totalpods = append(totalpods, pod)
 

--- a/test/e2e/storage/vsphere/vsphere_volume_vsan_policy.go
+++ b/test/e2e/storage/vsphere/vsphere_volume_vsan_policy.go
@@ -277,6 +277,7 @@ func invokeValidPolicyTest(f *framework.Framework, client clientset.Interface, n
 	ginkgo.By("Creating pod to attach PV to the node")
 	// Create pod to attach Volume to Node
 	pod, err := e2epod.CreatePod(client, namespace, nil, pvclaims, false, "")
+	framework.LogPodStartErrorIfAny(pod, err)
 	framework.ExpectNoError(err)
 
 	ginkgo.By("Verify the volume is accessible and available in the pod")

--- a/test/e2e/storage/vsphere/vsphere_zone_support.go
+++ b/test/e2e/storage/vsphere/vsphere_zone_support.go
@@ -396,6 +396,7 @@ func verifyPVCAndPodCreationSucceeds(client clientset.Interface, namespace strin
 
 	ginkgo.By("Creating pod to attach PV to the node")
 	pod, err := e2epod.CreatePod(client, namespace, nil, pvclaims, false, "")
+	framework.LogPodStartErrorIfAny(pod, err)
 	framework.ExpectNoError(err)
 
 	if volumeBindingMode == storagev1.VolumeBindingWaitForFirstConsumer {

--- a/test/e2e/upgrades/storage/volume_mode.go
+++ b/test/e2e/upgrades/storage/volume_mode.go
@@ -101,6 +101,7 @@ func (t *VolumeModeDowngradeTest) Setup(f *framework.Framework) {
 		SeLinuxLabel: e2epv.SELinuxLabel,
 	}
 	t.pod, err = e2epod.CreateSecPod(cs, &podConfig, framework.PodStartTimeout)
+	framework.LogPodStartErrorIfAny(t.pod, err)
 	framework.ExpectNoError(err)
 
 	ginkgo.By("Checking if PV exists as expected volume mode")


### PR DESCRIPTION
This PR introduces logging for making it easier to debug pods that did not start running within expected timeout.

The purpose of logging pod's namespace/name, UID and PVC name (if available) is to build tools that can extract this information  automatically and more intelligently point to pods that failed to start and correlate that information with other bits of information in controller-manager or kubelet logs.


/sig storage
/kind cleanup
/release-note-none
