### PR TITLE
Use /usr/bin/env bash in Makefiles and scripts

### DIFF
--- a/build/root/Makefile
+++ b/build/root/Makefile
@@ -30,7 +30,7 @@ endif
 #   clean: Clean up.
 
 # It's necessary to set this because some environments don't link sh -> bash.
-SHELL := /bin/bash
+SHELL := /usr/bin/env bash
 
 # We don't need make's built-in rules.
 MAKEFLAGS += --no-builtin-rules

--- a/build/root/Makefile.generated_files
+++ b/build/root/Makefile.generated_files
@@ -30,7 +30,7 @@ endif
 
 
 # It's necessary to set this because some environments don't link sh -> bash.
-SHELL := /bin/bash
+SHELL := /usr/bin/env bash
 
 # This rule collects all the generated file sets into a single rule.  Other
 # rules should depend on this to ensure generated files are rebuilt.

--- a/hack/update-workspace-mirror.sh
+++ b/hack/update-workspace-mirror.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright 2018 The Kubernetes Authors.
 #


### PR DESCRIPTION

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:
This allows the execution of the Makefiles from distributions which do
have `bash` in a different path.
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
None

**Special notes for your reviewer**:
None
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```
