### PR TITLE
Automated cherry pick of #83507: correctly handle resetting cpuacct in a live container

### DIFF
--- a/pkg/kubelet/stats/cri_stats_provider.go
+++ b/pkg/kubelet/stats/cri_stats_provider.go
@@ -649,7 +649,7 @@ func (p *criStatsProvider) getAndUpdateContainerUsageNanoCores(stats *runtimeapi
 		defer p.mutex.Unlock()
 
 		cached, ok := p.cpuUsageCache[id]
-		if !ok || cached.stats.UsageCoreNanoSeconds == nil {
+		if !ok || cached.stats.UsageCoreNanoSeconds == nil || stats.Cpu.UsageCoreNanoSeconds.Value < cached.stats.UsageCoreNanoSeconds.Value {
 			// Cannot compute the usage now, but update the cached stats anyway
 			p.cpuUsageCache[id] = &cpuUsageRecord{stats: stats.Cpu, usageNanoCores: nil}
 			return nil, nil

--- a/pkg/kubelet/stats/cri_stats_provider_test.go
+++ b/pkg/kubelet/stats/cri_stats_provider_test.go
@@ -857,7 +857,6 @@ func TestGetContainerUsageNanoCores(t *testing.T) {
 			expected: &value1,
 		},
 	}
-
 	for _, test := range tests {
 		provider := &criStatsProvider{cpuUsageCache: test.cpuUsageCache}
 		// Before the update, the cached value should be nil


### PR DESCRIPTION
Cherry pick of #83507 on release-1.16.

#83507: correctly handle resetting cpuacct in a live container

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
correctly handle resetting cpuacct in a live container
```