### PR TITLE
Enable per-zone logexporter pods creation

### DIFF
--- a/cluster/log-dump/log-dump.sh
+++ b/cluster/log-dump/log-dump.sh
@@ -503,6 +503,9 @@ function dump_nodes_with_logexporter() {
   local -r cloud_provider="${KUBERNETES_PROVIDER}"
   local -r enable_hollow_node_logs="${ENABLE_HOLLOW_NODE_LOGS:-false}"
   local -r logexport_sleep_seconds="$(( 90 + NUM_NODES / 3 ))"
+  if [[ -z "${ZONE_NODE_SELECTOR_DISABLED:-}" ]]; then
+    local -r node_selector="${ZONE_NODE_SELECTOR_LABEL:-topology.kubernetes.io/zone}: ${ZONE}"
+  fi
 
   # Fill in the parameters in the logexporter daemonset template.
   local -r tmp="${KUBE_TEMP}/logexporter"
@@ -510,6 +513,7 @@ function dump_nodes_with_logexporter() {
   mkdir -p "${tmp}"
   cp "${KUBE_ROOT}/cluster/log-dump/logexporter-daemonset.yaml" "${manifest_yaml}"
 
+  sed -i'' -e "s@{{.NodeSelector}}@${node_selector:-}@g" "${manifest_yaml}"
   sed -i'' -e "s@{{.LogexporterNamespace}}@${logexporter_namespace}@g" "${manifest_yaml}"
   sed -i'' -e "s@{{.ServiceAccountCredentials}}@${service_account_credentials}@g" "${manifest_yaml}"
   sed -i'' -e "s@{{.CloudProvider}}@${cloud_provider}@g" "${manifest_yaml}"

--- a/cluster/log-dump/logexporter-daemonset.yaml
+++ b/cluster/log-dump/logexporter-daemonset.yaml
@@ -67,6 +67,8 @@ spec:
           requests:
             cpu: 10m
             memory: 10Mi
+      nodeSelector:
+        {{.NodeSelector}}
       volumes:
       - name: service
         secret:


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Follow-up to https://github.com/kubernetes/test-infra/pull/17982 needed for multizonal and regional clusters in order not to duplicate creations of logexporter pods. Now logexporter daemonset pods will be bound to nodes that live in a particular zone (based on nodes' [topology.kubernetes.io/zone](https://kubernetes.io/docs/reference/kubernetes-api/labels-annotations-taints/#topologykubernetesiozone) label value).

Past logexporter behavior persists if one doesn't provide `ZONE` env var.

**Which issue(s) this PR fixes**:
No issue is opened for that.

**Special notes for your reviewer**:
/sig scalability
/cc mm4tt
/cc jkaniuk
/cc wojtek-t

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
