### PR TITLE
Remove TODO in cmd/kube-scheduler/app/options/options.go

### DIFF
--- a/cmd/kube-scheduler/app/options/options.go
+++ b/cmd/kube-scheduler/app/options/options.go
@@ -347,7 +347,6 @@ func createClients(config componentbaseconfig.ClientConnectionConfiguration, mas
 	kubeConfig.AcceptContentTypes = config.AcceptContentTypes
 	kubeConfig.ContentType = config.ContentType
 	kubeConfig.QPS = config.QPS
-	//TODO make config struct use int instead of int32?
 	kubeConfig.Burst = int(config.Burst)
 
 	client, err := clientset.NewForConfig(restclient.AddUserAgent(kubeConfig, "scheduler"))


### PR DESCRIPTION
Fix TODO in [`cmd/kube-scheduler/app/options/options.go`](https://github.com/kubernetes/kubernetes/blob/fd74333a971e2048b5fb2b692a9e043483d63fba/cmd/kube-scheduler/app/options/options.go#L350) line 350:

```go
        //TODO make config struct use int instead of int32?
	kubeConfig.Burst = config.Burst
```

**What type of PR is this?**
/kind cleanup

**Which issue(s) this PR fixes**:
NONE

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
NONE

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs
None
```

