### PR TITLE
limit the allocator bitmap to 65536 bits

### DIFF
--- a/pkg/registry/core/service/ipallocator/allocator_test.go
+++ b/pkg/registry/core/service/ipallocator/allocator_test.go
@@ -47,7 +47,33 @@ func TestAllocate(t *testing.T) {
 			alreadyAllocated: "192.168.1.1",
 		},
 		{
+			name:     "IPv4 large",
+			cidr:     "10.96.0.0/12", // 10.96.0.1 - 10.111.255.254
+			free:     65535,
+			released: "10.96.0.5",
+			outOfRange: []string{
+				"10.95.0.1",  // not in 10.96.0.0/12
+				"10.96.0.0",  // reserved (base address)
+				"10.97.1.1",  // not in the low 16 bits of 10.96.0.0/12
+				"10.112.0.1", // not in 10.96.0.0/12
+			},
+			alreadyAllocated: "10.96.0.1",
+		},
+		{
 			name:     "IPv6",
+			cidr:     "2001:db8:1::/120",
+			free:     255,
+			released: "2001:db8:1::5",
+			outOfRange: []string{
+				"2001:db8::1",     // not in 2001:db8:1::/48
+				"2001:db8:1::",    // reserved (base address)
+				"2001:db8:1::1:0", // not in the low 16 bits of 2001:db8:1::/48
+				"2001:db8:2::2",   // not in 2001:db8:1::/48
+			},
+			alreadyAllocated: "2001:db8:1::1",
+		},
+		{
+			name:     "IPv6 large",
 			cidr:     "2001:db8:1::/48",
 			free:     65535,
 			released: "2001:db8:1::5",


### PR DESCRIPTION
When creating 10K service using  a service subnet with a /12 mask, 
etcd runs out of space and the cluster needs manual intervention to
recover.

The service subnet uses a bitmap stored in etcd. Using a /12 subnet
imply that this bitmap can use 2^20 bits, something unnecessary
since Kubernetes is not validating more than 10K services.

We were already capping the bitmap to 2^16 bits for IPv6, this
just do the same for IPv4 subnets.

We still allow to configure /12 as subnet mask, but it won't be possible
to use IPs out of the lower 16 bits.


/kind bug

/kind failing-test

```release-note
the service IP allocator only allows to assign ClusterIPs in the lower 16 bits of the Service Subnet configured, despite it can have a maximum subnet mask of 20 bits (/12). This is the same behavior used for IPv6
```

Fixes: https://github.com/kubernetes/kubernetes/issues/94029
Related KEP: https://github.com/kubernetes/enhancements/pull/1881