### PR TITLE
ARM client: survive empty response and error

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/azure/clients/armclient/azure_armclient.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/clients/armclient/azure_armclient.go
@@ -109,6 +109,11 @@ func (c *Client) sendRequest(ctx context.Context, request *http.Request) (*http.
 		request,
 		retry.DoExponentialBackoffRetry(&sendBackoff),
 	)
+
+	if response == nil && err == nil {
+		return response, retry.NewError(false, fmt.Errorf("Empty response and no HTTP code"))
+	}
+
 	return response, retry.GetError(response, err)
 }
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

We're seeing legacy-cloud-providers/azure/clients (in our case, the synchronised copy used by cluster-autoscaler 1.19) segfaulting under heavy pressure and ARM throttling:
```
I0809 17:11:56.963285      49 azure_cache.go:83] Invalidating unowned instance cache
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0x1b595b5]
cluster-autoscaler-all-79b9478bf5-cgkg8 cluster-autoscaler
goroutine 82 [running]:
k8s.io/autoscaler/cluster-autoscaler/vendor/k8s.io/legacy-cloud-providers/azure/clients/armclient.(*Client).Send(0xc00052f520, 0x3b6dc40, 0xc000937440, 0xc000933f00, 0x0, 0x0)
        /home/jb/go/src/k8s.io/autoscaler/cluster-autoscaler/vendor/k8s.io/legacy-cloud-providers/azure/clients/armclient/azure_armclient.go:122 +0xb5
k8s.io/autoscaler/cluster-autoscaler/vendor/k8s.io/legacy-cloud-providers/azure/clients/armclient.(*Client).GetResource(0xc00052f520, 0x3b6dc40, 0xc000937440, 0xc000998630, 0x82, 0x0, 0x0, 0xc000d0f8b0, 0xb)
        /home/jb/go/src/k8s.io/autoscaler/cluster-autoscaler/vendor/k8s.io/legacy-cloud-providers/azure/clients/armclient/azure_armclient.go:312 +0x3a0
k8s.io/autoscaler/cluster-autoscaler/vendor/k8s.io/legacy-cloud-providers/azure/clients/vmssclient.(*Client).listVMSS(0xc000758700, 0x3b6dc40, 0xc000937440, 0xc000d0f8b0, 0xb, 0x0, 0x0, 0x0, 0x0)
        /home/jb/go/src/k8s.io/autoscaler/cluster-autoscaler/vendor/k8s.io/legacy-cloud-providers/azure/clients/vmssclient/azure_vmssclient.go:181 +0x316
k8s.io/autoscaler/cluster-autoscaler/vendor/k8s.io/legacy-cloud-providers/azure/clients/vmssclient.(*Client).List(0xc000758700, 0x3b6dc40, 0xc000937440, 0xc000d0f8b0, 0xb, 0x57517d7, 0x57, 0x13d056b, 0x1c5b8c1)
        /home/jb/go/src/k8s.io/autoscaler/cluster-autoscaler/vendor/k8s.io/legacy-cloud-providers/azure/clients/vmssclient/azure_vmssclient.go:158 +0x331
k8s.io/autoscaler/cluster-autoscaler/cloudprovider/azure.(*AzureManager).listScaleSets(0xc000a1f200, 0xc00091afe0, 0x1, 0x1, 0x0, 0x0, 0x0, 0x0, 0x0)
        /home/jb/go/src/k8s.io/autoscaler/cluster-autoscaler/cloudprovider/azure/azure_manager.go:646 +0xe0
k8s.io/autoscaler/cluster-autoscaler/cloudprovider/azure.(*AzureManager).getFilteredAutoscalingGroups(0xc000a1f200, 0xc00091afe0, 0x1, 0x1, 0x8, 0x8199ee, 0x5834f80, 0x8, 0x0)
        /home/jb/go/src/k8s.io/autoscaler/cluster-autoscaler/cloudprovider/azure/azure_manager.go:626 +0x194
k8s.io/autoscaler/cluster-autoscaler/cloudprovider/azure.(*AzureManager).fetchAutoAsgs(0xc000a1f200, 0x2, 0x2)
        /home/jb/go/src/k8s.io/autoscaler/cluster-autoscaler/cloudprovider/azure/azure_manager.go:549 +0x67
k8s.io/autoscaler/cluster-autoscaler/cloudprovider/azure.(*AzureManager).forceRefresh(0xc000a1f200, 0x0, 0x0)
        /home/jb/go/src/k8s.io/autoscaler/cluster-autoscaler/cloudprovider/azure/azure_manager.go:534 +0x40
k8s.io/autoscaler/cluster-autoscaler/cloudprovider/azure.CreateAzureManager(0x3b15060, 0xc00091af30, 0x0, 0x0, 0x0, 0xc00044bed0, 0x1, 0x1, 0x1, 0xc00018aa80, ...)
        /home/jb/go/src/k8s.io/autoscaler/cluster-autoscaler/cloudprovider/azure/azure_manager.go:472 +0x5ff
k8s.io/autoscaler/cluster-autoscaler/cloudprovider/azure.BuildAzure(0xa, 0x3f847ae147ae147b, 0x3fe0000000000000, 0x8bb2c97000, 0x1176592e000, 0x0, 0x1e84800, 0x0, 0xf4240000000000, 0x0, ...)
        /home/jb/go/src/k8s.io/autoscaler/cluster-autoscaler/cloudprovider/azure/azure_cloud_provider.go:165 +0x1d0
k8s.io/autoscaler/cluster-autoscaler/cloudprovider/builder.buildCloudProvider(0xa, 0x3f847ae147ae147b, 0x3fe0000000000000, 0x8bb2c97000, 0x1176592e000, 0x0, 0x1e84800, 0x0, 0xf4240000000000, 0x0, ...)
        /home/jb/go/src/k8s.io/autoscaler/cluster-autoscaler/cloudprovider/builder/builder_all.go:57 +0x262
k8s.io/autoscaler/cluster-autoscaler/cloudprovider/builder.NewCloudProvider(0xa, 0x3f847ae147ae147b, 0x3fe0000000000000, 0x8bb2c97000, 0x1176592e000, 0x0, 0x1e84800, 0x0, 0xf4240000000000, 0x0, ...)
        /home/jb/go/src/k8s.io/autoscaler/cluster-autoscaler/cloudprovider/builder/cloud_provider_builder.go:45 +0x1e7
k8s.io/autoscaler/cluster-autoscaler/core.initializeDefaultOptions(0xc00090b790, 0x203000, 0x0)
        /home/jb/go/src/k8s.io/autoscaler/cluster-autoscaler/core/autoscaler.go:101 +0x31a
k8s.io/autoscaler/cluster-autoscaler/core.NewAutoscaler(0xa, 0x3f847ae147ae147b, 0x3fe0000000000000, 0x8bb2c97000, 0x1176592e000, 0x0, 0x1e84800, 0x0, 0xf4240000000000, 0x0, ...)
        /home/jb/go/src/k8s.io/autoscaler/cluster-autoscaler/core/autoscaler.go:65 +0x43
main.buildAutoscaler(0x0, 0x0, 0x0, 0x0)
        /home/jb/go/src/k8s.io/autoscaler/cluster-autoscaler/main.go:320 +0x33a
main.run(0xc0000a0c30)
        /home/jb/go/src/k8s.io/autoscaler/cluster-autoscaler/main.go:326 +0x39
main.main.func2(0x3b6dc40, 0xc000936200)
        /home/jb/go/src/k8s.io/autoscaler/cluster-autoscaler/main.go:430 +0x2a
created by k8s.io/autoscaler/cluster-autoscaler/vendor/k8s.io/client-go/tools/leaderelection.(*LeaderElector).Run
        /home/jb/go/src/k8s.io/autoscaler/cluster-autoscaler/vendor/k8s.io/client-go/tools/leaderelection/leaderelection.go:208 +0x113
```

In `k8s.io/legacy-cloud-providers/azure/clients/armclient/azure_armclient.go`,
we assume ARM requests would either return either a non nil *retry.Error, or a non nil *http.Response:
```
func (c *Client) Send(ctx context.Context, request *http.Request) (*http.Response, *retry.Error) {
        response, rerr := c.sendRequest(ctx, request)
        if rerr != nil {
                return response, rerr
        }

        if response.StatusCode != http.StatusNotFound || c.clientRegion == "" {
                return response, rerr
        }
        ...
```

But really, it does not offer such guarantee:
```
# vendor/vendor/k8s.io/legacy-cloud-providers/azure/clients/armclient/azure_armclient.go
func (c *Client) sendRequest(ctx context.Context, request *http.Request) (*http.Response, *retry.Error) {
        ...
        return response, retry.GetError(response, err)
}

# vendor/k8s.io/legacy-cloud-providers/azure/retry/azure_error.go
func GetError(resp *http.Response, err error) *Error {
        if err == nil && resp == nil {
                return nil
        }
        ...
```

**Which issue(s) this PR fixes**:

Fixes #94077

**Does this PR introduce a user-facing change?**:

```release-note
Azure ARM client: don't segfault on empty response and http error
```

/assign @andyzhangx @feiskyer
/sig cloud-provider
/area provider/azure