### PR TITLE
fix vendor/k8s.io/metrics/pkg/client/custom_metrics staticcheck

### DIFF
--- a/hack/.staticcheck_failures
+++ b/hack/.staticcheck_failures
@@ -62,4 +62,3 @@ vendor/k8s.io/client-go/transport
 vendor/k8s.io/kubectl/pkg/cmd/get
 vendor/k8s.io/kubectl/pkg/cmd/scale
 vendor/k8s.io/kubectl/pkg/cmd/testing
-vendor/k8s.io/metrics/pkg/client/custom_metrics

--- a/staging/src/k8s.io/metrics/pkg/client/custom_metrics/BUILD
+++ b/staging/src/k8s.io/metrics/pkg/client/custom_metrics/BUILD
@@ -49,12 +49,16 @@ filegroup(
 
 go_test(
     name = "go_default_test",
-    srcs = ["util_test.go"],
+    srcs = [
+        "multi_client_test.go",
+        "util_test.go",
+    ],
     embed = [":go_default_library"],
     deps = [
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
+        "//staging/src/k8s.io/client-go/discovery/fake:go_default_library",
         "//staging/src/k8s.io/metrics/pkg/apis/custom_metrics:go_default_library",
         "//staging/src/k8s.io/metrics/pkg/apis/custom_metrics/v1beta1:go_default_library",
         "//staging/src/k8s.io/metrics/pkg/apis/custom_metrics/v1beta2:go_default_library",

--- a/staging/src/k8s.io/metrics/pkg/client/custom_metrics/multi_client.go
+++ b/staging/src/k8s.io/metrics/pkg/client/custom_metrics/multi_client.go
@@ -46,7 +46,7 @@ func PeriodicallyInvalidate(cache AvailableAPIsGetter, interval time.Duration, s
 		case <-ticker.C:
 			cache.Invalidate()
 		case <-stopCh:
-			break
+			return
 		}
 	}
 }

--- a/staging/src/k8s.io/metrics/pkg/client/custom_metrics/multi_client_test.go
+++ b/staging/src/k8s.io/metrics/pkg/client/custom_metrics/multi_client_test.go
@@ -1,0 +1,77 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package custom_metrics
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/discovery/fake"
+	cmint "k8s.io/metrics/pkg/apis/custom_metrics"
+)
+
+type fakeDiscovery struct {
+	*fake.FakeDiscovery
+
+	groupList *metav1.APIGroupList
+}
+
+func (c *fakeDiscovery) ServerGroups() (*metav1.APIGroupList, error) {
+	if c.groupList == nil {
+		return nil, errors.New("doesn't exist")
+	}
+	return c.groupList, nil
+}
+
+func TestPeriodicallyInvalidate(t *testing.T) {
+	fake := &fakeDiscovery{
+		groupList: &metav1.APIGroupList{
+			Groups: []metav1.APIGroup{{
+				Name: cmint.GroupName,
+				Versions: []metav1.GroupVersionForDiscovery{{
+					GroupVersion: cmint.SchemeGroupVersion.String(),
+				}},
+			}},
+		},
+	}
+
+	apiVersionsGetter := NewAvailableAPIsGetter(fake)
+	cache := apiVersionsGetter.(*apiVersionsFromDiscovery)
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+
+	_, err := apiVersionsGetter.PreferredVersion()
+	require.NoError(t, err)
+	require.NotNil(t, cache.prefVersion)
+	require.Equal(t, cache.prefVersion.Group, cmint.GroupName)
+
+	go PeriodicallyInvalidate(
+		apiVersionsGetter,
+		200*time.Millisecond,
+		stopCh,
+	)
+
+	// Wait for cache invalidation.
+	time.Sleep(1 * time.Second)
+
+	cache.mu.Lock()
+	defer cache.mu.Unlock()
+	require.Nil(t, cache.prefVersion)
+}

--- a/staging/src/k8s.io/metrics/pkg/client/custom_metrics/versioned_client.go
+++ b/staging/src/k8s.io/metrics/pkg/client/custom_metrics/versioned_client.go
@@ -24,7 +24,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/util/flowcontrol"
 
@@ -34,10 +33,7 @@ import (
 	"k8s.io/metrics/pkg/client/custom_metrics/scheme"
 )
 
-var (
-	codecs           = serializer.NewCodecFactory(scheme.Scheme)
-	versionConverter = NewMetricConverter()
-)
+var versionConverter = NewMetricConverter()
 
 type customMetricsClient struct {
 	client  rest.Interface


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
 -->
/kind cleanup
<!--
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:

Fixes `vendor/k8s.io/metrics/pkg/client/custom_metrics` staticcheck errors:

```sh
vendor/k8s.io/metrics/pkg/client/custom_metrics/multi_client.go:49:4: ineffective break statement. Did you mean to break out of the outer loop? (SA4011)
vendor/k8s.io/metrics/pkg/client/custom_metrics/versioned_client.go:38:2: var codecs is unused (U1000)
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of #92402

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
