### PR TITLE
Only lock statuses map when status isn't successful

### DIFF
--- a/pkg/scheduler/core/generic_scheduler.go
+++ b/pkg/scheduler/core/generic_scheduler.go
@@ -333,11 +333,11 @@ func (g *genericScheduler) findNodesThatPassFilters(ctx context.Context, prof *p
 				feasibleNodes[length-1] = nodeInfo.Node()
 			}
 		} else {
-			statusesLock.Lock()
 			if !status.IsSuccess() {
+				statusesLock.Lock()
 				statuses[nodeInfo.Node().Name] = status
+				statusesLock.Unlock()
 			}
-			statusesLock.Unlock()
 		}
 	}
 


### PR DESCRIPTION
Determine the status successful or not first, that will reduce the chance
of lock contention.

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

