### PR TITLE
Fixing a flaky EndpointSliceMirroring integration test

### DIFF
--- a/test/integration/endpointslice/endpointslicemirroring_test.go
+++ b/test/integration/endpointslice/endpointslicemirroring_test.go
@@ -84,7 +84,7 @@ func TestEndpointSliceMirroring(t *testing.T) {
 	testCases := []struct {
 		testName                     string
 		service                      *corev1.Service
-		endpoints                    *corev1.Endpoints
+		customEndpoints              *corev1.Endpoints
 		expectEndpointSlice          bool
 		expectEndpointSliceManagedBy string
 	}{{
@@ -102,11 +102,6 @@ func TestEndpointSliceMirroring(t *testing.T) {
 				},
 			},
 		},
-		endpoints: &corev1.Endpoints{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "test-123",
-			},
-		},
 		expectEndpointSlice:          true,
 		expectEndpointSliceManagedBy: "endpointslice-controller.k8s.io",
 	}, {
@@ -121,7 +116,7 @@ func TestEndpointSliceMirroring(t *testing.T) {
 				}},
 			},
 		},
-		endpoints: &corev1.Endpoints{
+		customEndpoints: &corev1.Endpoints{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "test-123",
 			},
@@ -151,13 +146,13 @@ func TestEndpointSliceMirroring(t *testing.T) {
 				},
 			},
 		},
-		endpoints:                    nil,
+		customEndpoints:              nil,
 		expectEndpointSlice:          true,
 		expectEndpointSliceManagedBy: "endpointslice-controller.k8s.io",
 	}, {
 		testName: "Endpoints without Service",
 		service:  nil,
-		endpoints: &corev1.Endpoints{
+		customEndpoints: &corev1.Endpoints{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "test-123",
 			},
@@ -180,10 +175,10 @@ func TestEndpointSliceMirroring(t *testing.T) {
 				}
 			}
 
-			if tc.endpoints != nil {
-				resourceName = tc.endpoints.Name
-				tc.endpoints.Namespace = ns.Name
-				_, err = client.CoreV1().Endpoints(ns.Name).Create(context.TODO(), tc.endpoints, metav1.CreateOptions{})
+			if tc.customEndpoints != nil {
+				resourceName = tc.customEndpoints.Name
+				tc.customEndpoints.Namespace = ns.Name
+				_, err = client.CoreV1().Endpoints(ns.Name).Create(context.TODO(), tc.customEndpoints, metav1.CreateOptions{})
 				if err != nil {
 					t.Fatalf("Error creating endpoints: %v", err)
 				}


### PR DESCRIPTION
**What type of PR is this?**
/kind failing-test

**What this PR does / why we need it**:
This test was trying to create an Endpoints resource that the Endpoints controller would also attempt to create. This could result in a failure if the Endpoints controller created the resource before the test did.

**Which issue(s) this PR fixes**:
This should fix at least part of https://github.com/kubernetes/kubernetes/issues/93496. 

/sig network
/priority critical-urgent
/cc @freehan @liggitt 