### PR TITLE
kubeadm: adjust the logic around etcd data directory creation

### DIFF
--- a/cmd/kubeadm/app/cmd/phases/init/BUILD
+++ b/cmd/kubeadm/app/cmd/phases/init/BUILD
@@ -44,6 +44,7 @@ go_library(
         "//cmd/kubeadm/app/preflight:go_default_library",
         "//cmd/kubeadm/app/util/apiclient:go_default_library",
         "//cmd/kubeadm/app/util/dryrun:go_default_library",
+        "//cmd/kubeadm/app/util/etcd:go_default_library",
         "//cmd/kubeadm/app/util/pkiutil:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",

--- a/cmd/kubeadm/app/cmd/phases/init/etcd.go
+++ b/cmd/kubeadm/app/cmd/phases/init/etcd.go
@@ -18,7 +18,6 @@ package phases
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/pkg/errors"
 	"k8s.io/klog/v2"
@@ -26,6 +25,7 @@ import (
 	"k8s.io/kubernetes/cmd/kubeadm/app/cmd/phases/workflow"
 	cmdutil "k8s.io/kubernetes/cmd/kubeadm/app/cmd/util"
 	etcdphase "k8s.io/kubernetes/cmd/kubeadm/app/phases/etcd"
+	etcdutil "k8s.io/kubernetes/cmd/kubeadm/app/util/etcd"
 )
 
 var (
@@ -87,8 +87,9 @@ func runEtcdPhaseLocal() func(c workflow.RunData) error {
 		if cfg.Etcd.External == nil {
 			// creates target folder if doesn't exist already
 			if !data.DryRun() {
-				if err := os.MkdirAll(cfg.Etcd.Local.DataDir, 0700); err != nil {
-					return errors.Wrapf(err, "failed to create etcd directory %q", cfg.Etcd.Local.DataDir)
+				// Create the etcd data directory
+				if err := etcdutil.CreateDataDirectory(cfg.Etcd.Local.DataDir); err != nil {
+					return err
 				}
 			} else {
 				fmt.Printf("[dryrun] Would ensure that %q directory is present\n", cfg.Etcd.Local.DataDir)

--- a/cmd/kubeadm/app/cmd/phases/join/BUILD
+++ b/cmd/kubeadm/app/cmd/phases/join/BUILD
@@ -29,6 +29,7 @@ go_library(
         "//cmd/kubeadm/app/phases/uploadconfig:go_default_library",
         "//cmd/kubeadm/app/preflight:go_default_library",
         "//cmd/kubeadm/app/util/apiclient:go_default_library",
+        "//cmd/kubeadm/app/util/etcd:go_default_library",
         "//cmd/kubeadm/app/util/kubeconfig:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/errors:go_default_library",

--- a/cmd/kubeadm/app/cmd/phases/join/controlplanejoin.go
+++ b/cmd/kubeadm/app/cmd/phases/join/controlplanejoin.go
@@ -29,6 +29,7 @@ import (
 	etcdphase "k8s.io/kubernetes/cmd/kubeadm/app/phases/etcd"
 	markcontrolplanephase "k8s.io/kubernetes/cmd/kubeadm/app/phases/markcontrolplane"
 	uploadconfigphase "k8s.io/kubernetes/cmd/kubeadm/app/phases/uploadconfig"
+	etcdutil "k8s.io/kubernetes/cmd/kubeadm/app/util/etcd"
 )
 
 var controlPlaneJoinExample = cmdutil.Examples(`
@@ -129,6 +130,11 @@ func runEtcdPhase(c workflow.RunData) error {
 	if cfg.Etcd.External != nil {
 		fmt.Println("[control-plane-join] using external etcd - no local stacked instance added")
 		return nil
+	}
+
+	// Create the etcd data directory
+	if err := etcdutil.CreateDataDirectory(cfg.Etcd.Local.DataDir); err != nil {
+		return err
 	}
 
 	// Adds a new etcd instance; in order to do this the new etcd instance should be "announced" to

--- a/cmd/kubeadm/app/util/etcd/BUILD
+++ b/cmd/kubeadm/app/util/etcd/BUILD
@@ -2,7 +2,10 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
-    srcs = ["etcd.go"],
+    srcs = [
+        "etcd.go",
+        "etcddata.go",
+    ],
     importpath = "k8s.io/kubernetes/cmd/kubeadm/app/util/etcd",
     visibility = ["//visibility:public"],
     deps = [

--- a/cmd/kubeadm/app/util/etcd/etcddata.go
+++ b/cmd/kubeadm/app/util/etcd/etcddata.go
@@ -1,0 +1,31 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package etcd
+
+import (
+	"os"
+
+	"github.com/pkg/errors"
+)
+
+// CreateDataDirectory creates the etcd data directory (commonly /var/lib/etcd) with the right permissions.
+func CreateDataDirectory(dir string) error {
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return errors.Wrapf(err, "failed to create the etcd data directory: %q", dir)
+	}
+	return nil
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

- Ensure the directory is created with 0700 via a new function
called CreateDataDirectory().
- Call this function in the init phases instead of the manual call
to MkdirAll.
- Call this function when joining control-plane nodes with local etcd.

If the directory creation is left to the kubelet via the
static Pod hostPath mounts, it will end up with 0755
which is not desired.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
xref https://github.com/kubernetes/kubeadm/issues/2256

**Special notes for your reviewer**:
should be backported in case older versions of kubeadm decide to use newer etcd, which is a supported scenario by kubeadm.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kubeadm: ensure the etcd data directory is created with 0700 permissions during control-plane init and join
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
