### PR TITLE
fix e2e test "should resolve connection reset"

### DIFF
--- a/test/e2e/network/kube_proxy.go
+++ b/test/e2e/network/kube_proxy.go
@@ -313,7 +313,7 @@ var _ = SIGDescribe("Network", func() {
 						Name:  "startup-script",
 						Image: imageutils.GetE2EImage(imageutils.BusyBox),
 						Command: []string{
-							"bash", "-c", "while true; do sleep 2; nc boom-server 9000& done",
+							"sh", "-c", "while true; do sleep 2; nc boom-server 9000& done",
 						},
 					},
 				},


### PR DESCRIPTION
the test is not working because is trying to execute bash in a
busybox image, that is not present. Using sh works.


/kind failing-test

```release-note
NONE
```
