### PR TITLE
Only process all nodes when incoming pod has no preferred affinity

### DIFF
--- a/pkg/scheduler/framework/plugins/interpodaffinity/scoring.go
+++ b/pkg/scheduler/framework/plugins/interpodaffinity/scoring.go
@@ -141,14 +141,14 @@ func (pl *InterPodAffinity) PreScore(
 	}
 
 	affinity := pod.Spec.Affinity
-	hasAffinityConstraints := affinity != nil && affinity.PodAffinity != nil
-	hasAntiAffinityConstraints := affinity != nil && affinity.PodAntiAffinity != nil
+	hasPreferredAffinityConstraints := affinity != nil && affinity.PodAffinity != nil && len(affinity.PodAffinity.PreferredDuringSchedulingIgnoredDuringExecution) > 0
+	hasPreferredAntiAffinityConstraints := affinity != nil && affinity.PodAntiAffinity != nil && len(affinity.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution) > 0
 
-	// Unless the pod being scheduled has affinity terms, we only
+	// Unless the pod being scheduled has preferred affinity terms, we only
 	// need to process nodes hosting pods with affinity.
 	var allNodes []*framework.NodeInfo
 	var err error
-	if hasAffinityConstraints || hasAntiAffinityConstraints {
+	if hasPreferredAffinityConstraints || hasPreferredAntiAffinityConstraints {
 		allNodes, err = pl.sharedLister.NodeInfos().List()
 		if err != nil {
 			framework.NewStatus(framework.Error, fmt.Sprintf("get all nodes from shared lister error, err: %v", err))
@@ -178,10 +178,10 @@ func (pl *InterPodAffinity) PreScore(
 		if nodeInfo.Node() == nil {
 			return
 		}
-		// Unless the pod being scheduled has affinity terms, we only
+		// Unless the pod being scheduled has preferred affinity terms, we only
 		// need to process pods with affinity in the node.
 		podsToProcess := nodeInfo.PodsWithAffinity
-		if hasAffinityConstraints || hasAntiAffinityConstraints {
+		if hasPreferredAffinityConstraints || hasPreferredAntiAffinityConstraints {
 			// We need to process all the pods.
 			podsToProcess = nodeInfo.Pods
 		}


### PR DESCRIPTION
To calculate the score for inter-pod affinity, the PreScore plugin needs to process the
two cases below:

1. The incoming pod's preferred affinity/anti-affinity matches with the existing pod.
2. The existing pod's preferred affinity/anti-affinity matches with the incoming pod.

For #1, if the incoming pod with any preferred affinity/anti-affinity terms, all the existing
pod on all nodes should be checked with the incoming pod's preferred affinity/anti-affinity
terms. 

For #2, if the existing pod with any preferred affinity/anti-affinity terms, then it should
check with the incoming pod.

If the incoming pod without any preferred affinity/anti-affinity terms, then only needs
to check the existing pod with preferred affinity/anti-affinity terms.

The current implementation only checks whether the incoming pod with affinity/anti-affinity or not,
to determine whether needs to check all the nodes. That will include the case of the
incoming pod with required affinity/anti-affinity terms, which isn't the case PreScore plugin cares about.

So this PR only checks the preferred affinity/anti-affinity to determine whether should
process all the nodes.

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
It is more efficient for reducing the number of nodes that need to be processed.
