### PR TITLE
Make similar buckets for api and etcd request duration histogram

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/metrics/metrics.go
@@ -35,8 +35,12 @@ import (
 var (
 	etcdRequestLatency = compbasemetrics.NewHistogramVec(
 		&compbasemetrics.HistogramOpts{
-			Name:           "etcd_request_duration_seconds",
-			Help:           "Etcd request latency in seconds for each operation and object type.",
+			Name: "etcd_request_duration_seconds",
+			Help: "Etcd request latency in seconds for each operation and object type.",
+			// Keeping it similar to the buckets used by the apiserver_request_duration_seconds metric so that
+			// api latency and etcd latency can be more comparable side by side.
+			Buckets: []float64{.005, .01, .025, 0.05, 0.1, 0.15, 0.2, 0.25, 0.3, 0.35, 0.4, 0.45, 0.5, 0.6, 0.7,
+				0.8, 0.9, 1.0, 1.25, 1.5, 1.75, 2.0, 2.5, 3.0, 3.5, 4.0, 4.5, 5, 6, 7, 8, 9, 10, 15, 20, 25, 30, 40, 50, 60},
 			StabilityLevel: compbasemetrics.ALPHA,
 		},
 		[]string{"operation", "type"},


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
`etcd_request_duration_seconds` uses the default buckets provided by prometheus client library. 
`DefBuckets = []float64{.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10}`
The maximum bucket size is `10s`. On the other hand, `apiserver_request_duration_seconds` uses more fine grained bucket sizes and the maximum bucket size is `60s`

![image](https://user-images.githubusercontent.com/7385775/90800726-08202780-e2e3-11ea-99ad-453eafe1c43e.png)

The left panel shows latency for `Deployment-DELETE` api (metric=`apiserver_request_duration_seconds`), this is taking about  `40s` to complete. On the other hand, etcd latency (metric=`etcd_request_duration_seconds`) for the same object  `apps.Deployment-delete` is capped at `10s`. Now the difference in latency is hard to account for. It cloud be latency from ectd but we can't answer this question by looking at the metrics. 

If the etcd metric has similar bucket sizes, we could account for the difference in latency. 

This PR makes the bucket sizes for both metrics similar. Also,  no existing bucket for `etcd_request_duration_seconds` was dropped.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs
NONE
```
