### PR TITLE
Clarify error message when non-existing API object update fails with a conflict error because of a precondition

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store.go
@@ -278,7 +278,7 @@ func (s *store) GuaranteedUpdate(
 
 	transformContext := authenticatedDataString(key)
 	for {
-		if err := checkPreconditions(key, origState.obj, objFound, preconditions); err != nil {
+		if err := preconditions.SafeCheck(key, origState.obj, objFound); err != nil {
 			// If our data is already up to date, return the error
 			if !mustCheckData {
 				return err

--- a/staging/src/k8s.io/apiserver/pkg/storage/interfaces.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/interfaces.go
@@ -18,14 +18,11 @@ package storage
 
 import (
 	"context"
-	"fmt"
 
-	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/watch"
 )
 
@@ -106,51 +103,6 @@ type ValidateObjectFunc func(ctx context.Context, obj runtime.Object) error
 
 // ValidateAllObjectFunc is a "admit everything" instance of ValidateObjectFunc.
 func ValidateAllObjectFunc(ctx context.Context, obj runtime.Object) error {
-	return nil
-}
-
-// Preconditions must be fulfilled before an operation (update, delete, etc.) is carried out.
-type Preconditions struct {
-	// Specifies the target UID.
-	// +optional
-	UID *types.UID `json:"uid,omitempty"`
-	// Specifies the target ResourceVersion
-	// +optional
-	ResourceVersion *string `json:"resourceVersion,omitempty"`
-}
-
-// NewUIDPreconditions returns a Preconditions with UID set.
-func NewUIDPreconditions(uid string) *Preconditions {
-	u := types.UID(uid)
-	return &Preconditions{UID: &u}
-}
-
-func (p *Preconditions) Check(key string, obj runtime.Object) error {
-	if p == nil {
-		return nil
-	}
-	objMeta, err := meta.Accessor(obj)
-	if err != nil {
-		return NewInternalErrorf(
-			"can't enforce preconditions %v on un-introspectable object %v, got error: %v",
-			*p,
-			obj,
-			err)
-	}
-	if p.UID != nil && *p.UID != objMeta.GetUID() {
-		err := fmt.Sprintf(
-			"Precondition failed: UID in precondition: %v, UID in object meta: %v",
-			*p.UID,
-			objMeta.GetUID())
-		return NewInvalidObjError(key, err)
-	}
-	if p.ResourceVersion != nil && *p.ResourceVersion != objMeta.GetResourceVersion() {
-		err := fmt.Sprintf(
-			"Precondition failed: ResourceVersion in precondition: %v, ResourceVersion in object meta: %v",
-			*p.ResourceVersion,
-			objMeta.GetResourceVersion())
-		return NewInvalidObjError(key, err)
-	}
 	return nil
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/storage/preconditions.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/preconditions.go
@@ -1,0 +1,131 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package storage
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// Preconditions must be fulfilled before an operation (update, delete, etc.) is carried out.
+type Preconditions struct {
+	// Specifies the target UID.
+	// +optional
+	UID *types.UID `json:"uid,omitempty"`
+	// Specifies the target ResourceVersion
+	// +optional
+	ResourceVersion *string `json:"resourceVersion,omitempty"`
+}
+
+// NewPreconditions returns a Preconditions with UID and ResourceVersion set.
+func NewPreconditions(uid string, rv string) *Preconditions {
+	u := types.UID(uid)
+	return &Preconditions{
+		UID:             &u,
+		ResourceVersion: &rv,
+	}
+}
+
+// NewUIDPreconditions returns a Preconditions with UID set.
+func NewUIDPreconditions(uid string) *Preconditions {
+	u := types.UID(uid)
+	return &Preconditions{UID: &u}
+}
+
+// NewResourceVersionPreconditions returns a Preconditions with ResourceVersion
+// set.
+func NewResourceVersionPreconditions(rv string) *Preconditions {
+	return &Preconditions{ResourceVersion: &rv}
+}
+
+// Check is deprecated because it can produce confusing error messages if `obj`
+// does not exist. Details at https://github.com/kubernetes/kubernetes/issues/89985.
+// Use "SafeCheck" instead.
+func (p *Preconditions) Check(key string, obj runtime.Object) error {
+	if p == nil {
+		return nil
+	}
+	objMeta, err := meta.Accessor(obj)
+	if err != nil {
+		return NewInternalErrorf(
+			"can't enforce preconditions %v on un-introspectable object %v, got error: %v",
+			*p,
+			obj,
+			err)
+	}
+	if p.UID != nil && *p.UID != objMeta.GetUID() {
+		err := fmt.Sprintf(
+			"Precondition failed: UID in precondition: %v, UID in object meta: %v",
+			*p.UID,
+			objMeta.GetUID())
+		return NewInvalidObjError(key, err)
+	}
+	if p.ResourceVersion != nil && *p.ResourceVersion != objMeta.GetResourceVersion() {
+		err := fmt.Sprintf(
+			"Precondition failed: ResourceVersion in precondition: %v, ResourceVersion in object meta: %v",
+			*p.ResourceVersion,
+			objMeta.GetResourceVersion())
+		return NewInvalidObjError(key, err)
+	}
+	return nil
+}
+
+// SafeCheck checks whether `obj` meets the preconditions `p`. It is "safe" in
+// the sense that it takes into account the case where the preconditions fail
+// because `obj` does not exist (`objExists` is false) and produces a clearer
+// error message.
+func (p *Preconditions) SafeCheck(key string, obj runtime.Object, objExists bool) error {
+	if p == nil {
+		return nil
+	}
+	objMeta, err := meta.Accessor(obj)
+	if err != nil {
+		return NewInternalErrorf(
+			"can't enforce preconditions %v on un-introspectable object %v, got error: %v",
+			*p,
+			obj,
+			err)
+	}
+	if p.UID != nil && *p.UID != objMeta.GetUID() {
+		return newPreconditionFailError("UID", string(*p.UID), string(objMeta.GetUID()), key, objExists)
+	}
+	if p.ResourceVersion != nil && *p.ResourceVersion != objMeta.GetResourceVersion() {
+		return newPreconditionFailError("ResourceVersion", *p.ResourceVersion, objMeta.GetResourceVersion(), key, objExists)
+	}
+	return nil
+}
+
+func newPreconditionFailError(preconditionField, preconditionVal, objVal, objName string, objExists bool) error {
+	var msg string
+	if objExists {
+		msg = fmt.Sprintf(
+			"Precondition failed: %s in precondition: %s, %s in object meta: %s",
+			preconditionField,
+			preconditionVal,
+			preconditionField,
+			objVal)
+	} else {
+		msg = fmt.Sprintf(
+			"Precondition on %s (must be equal to %s) failed because the object does not exist",
+			preconditionField,
+			preconditionVal)
+	}
+	return NewInvalidObjError(objName, msg)
+}

--- a/staging/src/k8s.io/apiserver/pkg/storage/preconditions_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/preconditions_test.go
@@ -1,0 +1,192 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package storage
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apiserver/pkg/apis/example"
+)
+
+// Constant UID and ResourceVersion values used in tests.
+const (
+	uid1             = "u1111"
+	uid2             = "u2222"
+	resourceVersion1 = "rv1111"
+	resourceVersion2 = "rv2222"
+)
+
+func TestSafeCheck(t *testing.T) {
+	testCases := map[string]struct {
+		preconditions *Preconditions
+		objName       string
+		obj           runtime.Object
+		objExists     bool
+		// expectedErrorMessageWords contains the words that we expect in the
+		// error message returned by the preconditions check. A test passes if
+		// and only if there's at least one inner slice for which all words are
+		// present in the error message.
+		expectedErrorMessageWords [][]string
+	}{
+		"nil preconditions": {
+			preconditions: nil,
+			objName:       "foo",
+			obj:           &example.Pod{ObjectMeta: metav1.ObjectMeta{Name: "foo", UID: types.UID(uid1), ResourceVersion: resourceVersion1}},
+			objExists:     true,
+		},
+		"nil preconditions, object doesn't exist": {
+			preconditions: nil,
+			objName:       "foo",
+			obj:           &example.Pod{},
+			objExists:     false,
+		},
+		"empty preconditions": {
+			preconditions: &Preconditions{},
+			objName:       "foo",
+			obj:           &example.Pod{ObjectMeta: metav1.ObjectMeta{Name: "foo", UID: types.UID(uid1), ResourceVersion: resourceVersion1}},
+			objExists:     true,
+		},
+		"empty preconditions, object doesn't exist": {
+			preconditions: &Preconditions{},
+			objName:       "foo",
+			obj:           &example.Pod{},
+			objExists:     false,
+		},
+		"UID and ResourceVersion are met": {
+			preconditions: NewPreconditions(uid1, resourceVersion1),
+			objName:       "foo",
+			obj:           &example.Pod{ObjectMeta: metav1.ObjectMeta{Name: "foo", UID: types.UID(uid1), ResourceVersion: resourceVersion1}},
+			objExists:     true,
+		},
+		"UID is met": {
+			preconditions: NewUIDPreconditions(uid1),
+			objName:       "foo",
+			obj:           &example.Pod{ObjectMeta: metav1.ObjectMeta{Name: "foo", UID: types.UID(uid1)}},
+			objExists:     true,
+		},
+		"ResourceVersion is met": {
+			preconditions: NewResourceVersionPreconditions(resourceVersion1),
+			objName:       "foo",
+			obj:           &example.Pod{ObjectMeta: metav1.ObjectMeta{Name: "foo", ResourceVersion: resourceVersion1}},
+			objExists:     true,
+		},
+		"UID is met, ResourceVersion is not": {
+			preconditions: NewPreconditions(uid1, resourceVersion1),
+			objName:       "foo",
+			obj:           &example.Pod{ObjectMeta: metav1.ObjectMeta{Name: "foo", UID: types.UID(uid1), ResourceVersion: resourceVersion2}},
+			objExists:     true,
+			expectedErrorMessageWords: [][]string{
+				{"Precondition", "ResourceVersion", resourceVersion1, resourceVersion2},
+			},
+		},
+		"ResourceVersion is met, UID is not": {
+			preconditions: NewPreconditions(uid1, resourceVersion1),
+			objName:       "foo",
+			obj:           &example.Pod{ObjectMeta: metav1.ObjectMeta{Name: "foo", UID: types.UID(uid2), ResourceVersion: resourceVersion1}},
+			objExists:     true,
+			expectedErrorMessageWords: [][]string{
+				{"Precondition", "UID", uid1, uid2},
+			},
+		},
+		"neither UID nor ResourceVersion is met": {
+			preconditions: NewPreconditions(uid1, resourceVersion1),
+			objName:       "foo",
+			obj:           &example.Pod{ObjectMeta: metav1.ObjectMeta{Name: "foo", UID: types.UID(uid2), ResourceVersion: resourceVersion2}},
+			objExists:     true,
+			expectedErrorMessageWords: [][]string{
+				{"Precondition", "UID", uid1, uid2},
+				{"Precondition", "ResourceVersion", resourceVersion1, resourceVersion2},
+			},
+		},
+		"UID is not met because object doesn't exist": {
+			preconditions: NewUIDPreconditions(uid1),
+			obj:           &example.Pod{},
+			expectedErrorMessageWords: [][]string{
+				{"Precondition", "UID", "object", "exist"},
+			},
+		},
+		"ResourceVersion is not met because object doesn't exist": {
+			preconditions: NewResourceVersionPreconditions(resourceVersion1),
+			obj:           &example.Pod{},
+			expectedErrorMessageWords: [][]string{
+				{"Precondition", "ResourceVersion", "object", "exist"},
+			},
+		},
+		"neither UID nor ResourceVersion are met because object doesn't exist": {
+			preconditions: NewPreconditions(uid1, resourceVersion1),
+			obj:           &example.Pod{},
+			expectedErrorMessageWords: [][]string{
+				{"Precondition", "UID", "object", "exist"},
+				{"Precondition", "ResourceVersion", "object", "exist"},
+			},
+		},
+	}
+
+	for description, tc := range testCases {
+		t.Run(description, func(t *testing.T) {
+			gotErr := tc.preconditions.SafeCheck(tc.objName, tc.obj, tc.objExists)
+			if err := pass(gotErr, tc.expectedErrorMessageWords); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
+func pass(got error, expectedWordsSets [][]string) error {
+	if got == nil {
+		if len(expectedWordsSets) == 0 {
+			return nil
+		}
+		return fmt.Errorf("got: no error, expected: an error with message containing words: %s", formatExpectedWords(expectedWordsSets))
+	}
+	if !IsInvalidObj(got) {
+		return fmt.Errorf("expected error of type \"Invalid Object\", got error: \"%v\", of a different type", got)
+	}
+	errMsg := strings.ToLower(got.Error())
+	for _, anExpectedWordsSet := range expectedWordsSets {
+		allExpectedWordsFound := true
+		for _, expectedWord := range anExpectedWordsSet {
+			if !strings.Contains(errMsg, strings.ToLower(expectedWord)) {
+				allExpectedWordsFound = false
+				break
+			}
+		}
+		if allExpectedWordsFound {
+			return nil
+		}
+	}
+	return fmt.Errorf("got error with message \"%v\", expected message must contain words: %s", got, formatExpectedWords(expectedWordsSets))
+}
+
+func formatExpectedWords(expectedWordsSets [][]string) string {
+	var buffer strings.Builder
+	for i, ews := range expectedWordsSets {
+		buffer.WriteString("\n\n\t")
+		if _, err := buffer.WriteString(strings.Join(ews, ", ")); err != nil {
+			panic(fmt.Sprintf("failed to format expected words %v while preparing test failure output: %v", ews, err))
+		}
+		if i < len(expectedWordsSets)-1 {
+			buffer.WriteString("\n\n\tOR")
+		}
+	}
+	return buffer.String()
+}


### PR DESCRIPTION
Clarify the error message that is returned when an update precondition on UID or ResourceVersion fails because the updated object does not exist.
More precisely, clearly say that the update failed because the object does not exist rather than mentioning a generic precondition failure.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind documentation

<!--
Add one of the following kinds:
/kind bug
/kind cleanup

/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
Clarify an error message that was confusing to users.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #89985

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
The error message that is returned when an API object update fails because of a UID/ResourceVersion precondition failure caused by the fact that the API object does not exist now explicitly mentions that the object does not exist rather than talking about a generic precondition failure.

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
