### PR TITLE
Change etcd datadir permission from 0777 to 0700

### DIFF
--- a/cluster/images/etcd/migrate/data_dir.go
+++ b/cluster/images/etcd/migrate/data_dir.go
@@ -45,7 +45,7 @@ func OpenOrCreateDataDirectory(path string) (*DataDirectory, error) {
 	}
 	if !exists {
 		klog.Infof("data directory '%s' does not exist, creating it", path)
-		err := os.MkdirAll(path, 0777)
+		err := os.MkdirAll(path, 0700)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create data directory %s: %v", path, err)
 		}
@@ -83,7 +83,7 @@ func (d *DataDirectory) Backup() error {
 	if err != nil {
 		return err
 	}
-	err = os.MkdirAll(backupDir, 0777)
+	err = os.MkdirAll(backupDir, 0700)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

* Set etcd data directory permissions to 0700, required in etcd v3.4.10+ [etcd-io/etcd#11798](https://github.com/etcd-io/etcd/pull/11798). This is needed for #94141.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Changed behavior on existing etcd data dir permission: previously, the permission was not checked on existing data directory and the directory used for automatically generating self-signed certificates for TLS connections with clients. Now a check is added to make sure those directories, if already exist, has a desired permission of 700 on Linux and 777 on Windows
```

/sig api-machinery
/cc @liggitt @wojtek-t @ptabor