### PR TITLE
kubelet/status: don't produce confusing logs

### DIFF
--- a/pkg/kubelet/status/status_manager.go
+++ b/pkg/kubelet/status/status_manager.go
@@ -426,7 +426,7 @@ func (m *manager) updateStatusInternal(pod *v1.Pod, status v1.PodStatus, forceUp
 	// The intent here is to prevent concurrent updates to a pod's status from
 	// clobbering each other so the phase of a pod progresses monotonically.
 	if isCached && isPodStatusByKubeletEqual(&cachedStatus.status, &status) && !forceUpdate {
-		klog.V(3).Infof("Ignoring same status for pod %q, status: %+v", format.Pod(pod), status)
+		klog.V(3).Infof("Ignoring same status for pod %q, status.Phase: %s", format.Pod(pod), status.Phase)
 		return false // No new status.
 	}
 
@@ -567,9 +567,9 @@ func (m *manager) syncPod(uid types.UID, status versionedPodStatus) {
 		return
 	}
 	if unchanged {
-		klog.V(3).Infof("Status for pod %q is up-to-date: (%d)", format.Pod(pod), status.version)
+		klog.V(3).Infof("Status for pod %q is up-to-date: (version: %d)", format.Pod(pod), status.version)
 	} else {
-		klog.V(3).Infof("Status for pod %q updated successfully: (%d, %+v)", format.Pod(pod), status.version, status.status)
+		klog.V(3).Infof("Status for pod %q updated successfully: (version: %d, phase: %s)", format.Pod(pod), status.version, status.status.Phase)
 		pod = newPod
 	}
 


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:

The debug log statement in syncPod was initially added by commit 1dabce981591
(PR #42662), and most recently modified by commit b2528654797e2
(PR #88591).

The problem is, some of the status.status sub-structures may contain
multi-line fields that are printed on a separate line (see example
at [1]) which is very confusing.

For now, let's just print status.Phase. If better debug info is needed,
I suggest it should be implemented as a custom DebugString() method
of PodStatus, which should make sure that those fields that could
contain newlines are either not printed, or the newlines are escaped.

Fix the debug log statement in updateStatusInternal the same way.

[1] https://bugzilla.redhat.com/show_bug.cgi?id=1821730

**Which issue(s) this PR fixes**:

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1821730

**Special notes for your reviewer**:

```release-note
NONE
```