### PR TITLE
Make ProjectedVolumeSource optional

### DIFF
--- a/staging/src/k8s.io/api/core/v1/generated.proto
+++ b/staging/src/k8s.io/api/core/v1/generated.proto
@@ -3853,6 +3853,7 @@ message Probe {
 // Represents a projected volume source
 message ProjectedVolumeSource {
   // list of volume projections
+  // +optional
   repeated VolumeProjection sources = 1;
 
   // Mode bits used to set permissions on created files by default.

--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -1615,6 +1615,7 @@ type ServiceAccountTokenProjection struct {
 // Represents a projected volume source
 type ProjectedVolumeSource struct {
 	// list of volume projections
+	// +optional
 	Sources []VolumeProjection `json:"sources" protobuf:"bytes,1,rep,name=sources"`
 	// Mode bits used to set permissions on created files by default.
 	// Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**: Fixes API Definition for ProjectedVolumeSource to mark Sources as optional.

**Which issue(s) this PR fixes**:
Fixes #93903

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs

```
