### PR TITLE
Make go-runner use stdlib-only methods

### DIFF
--- a/build/go-runner/go.mod
+++ b/build/go-runner/go.mod
@@ -1,5 +1,3 @@
 module k8s.io/kubernetes/build/go-runner
 
 go 1.15
-
-require github.com/pkg/errors v0.9.1

--- a/build/go-runner/go.sum
+++ b/build/go-runner/go.sum
@@ -1,2 +1,0 @@
-github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
-github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Removes need to fetch go modules, which is causing issues on s390x due to a qemu bug (xref https://github.com/kubernetes/release/pull/1499#issuecomment-678267382 https://github.com/golang/go/issues/40949)

```release-note
NONE
```

/cc @dims @justaugustus 
