### PR TITLE
[Failing Test] Reserve Static IP in Ingress test

### DIFF
--- a/test/e2e/network/ingress.go
+++ b/test/e2e/network/ingress.go
@@ -136,6 +136,8 @@ var _ = SIGDescribe("Loadbalancing: L7", func() {
 
 		ginkgo.It("should support multiple TLS certs", func() {
 			ginkgo.By("Creating an ingress with no certs.")
+
+			_ = gceController.CreateStaticIP(ns)
 			jig.CreateIngress(filepath.Join(e2eingress.IngressManifestPath, "multiple-certs"), ns, map[string]string{
 				e2eingress.IngressStaticIPKey: ns,
 			}, map[string]string{})


### PR DESCRIPTION
/kind failing-test

Issue: #93693

**What this PR does / why we need it:**

Previously the ingress controller would create the static IP specified if it didn't exist.  Since that behavior changed in (https://github.com/kubernetes/ingress-gce/pull/1080), this updates the ingress test to create the static IP first.  Tested in e2e cluster.

```release-note
NONE
```