### PR TITLE
fail early if not on linux in local-up-cluster.sh

### DIFF
--- a/hack/local-up-cluster.sh
+++ b/hack/local-up-cluster.sh
@@ -20,6 +20,14 @@ KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 # this as root to allow kubelet to open docker's socket, and to write the test
 # CA in /var/run/kubernetes.
 # Usage: `hack/local-up-cluster.sh`.
+# NOTE: kubelet only works on Linux! It will more or less turn the host
+# into a node ...
+if [[ "$(uname)" != "Linux" && "${START_MODE:-}" != "nokubelet" ]]; then
+  echo "ERROR: local-up-cluster.sh requires disabling kubelet unless run on Linux!" 1>&2
+  echo "You must set START_MODE=nokubelet to disable kubelet." 1>&2
+  echo "On other platforms you can use http://sigs.k8s.io/kind to create a cluster from source including kubelet." 1>&2
+  exit 1
+fi
 
 DOCKER_OPTS=${DOCKER_OPTS:-""}
 export DOCKER=(docker "${DOCKER_OPTS[@]}")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->


/kind cleanup

**What this PR does / why we need it**: Instead of failing during bringup on non-linux platforms, check `uname` and automatically fail fast if not on `Linux`. This prevents issues like https://github.com/kubernetes/kubernetes/issues/94164

Further, automating the response from https://github.com/kubernetes/kubernetes/issues/94164 by including a pointer to [kind](https://github.com/kubernetes/kubernetes/issues/94164) which, while not quite the same, does work on most platforms now to create a local cluster from source.

I can drop the latter if we don't want to do this, but it seems more helpful than just failing, and both are upstream.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/sig testing