### PR TITLE
Ensure backoff step is set to 1 for Azure armclient

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/azure/clients/armclient/azure_armclient.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/clients/armclient/azure_armclient.go
@@ -64,10 +64,11 @@ func New(authorizer autorest.Authorizer, baseURI, userAgent, apiVersion, clientR
 
 	backoff := clientBackoff
 	if backoff == nil {
+		backoff = &retry.Backoff{}
+	}
+	if backoff.Steps == 0 {
 		// 1 steps means no retry.
-		backoff = &retry.Backoff{
-			Steps: 1,
-		}
+		backoff.Steps = 1
 	}
 
 	return &Client{

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/clients/armclient/azure_armclient_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/clients/armclient/azure_armclient_test.go
@@ -36,6 +36,22 @@ const (
 	testResourceID = "/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/testPIP"
 )
 
+func TestNew(t *testing.T) {
+	backoff := &retry.Backoff{Steps: 3}
+	armClient := New(nil, "", "test", "2019-01-01", "eastus", backoff)
+	assert.NotNil(t, armClient.backoff)
+	assert.Equal(t, 3, armClient.backoff.Steps, "Backoff steps should be same as the value passed in")
+
+	backoff = &retry.Backoff{Steps: 0}
+	armClient = New(nil, "", "test", "2019-01-01", "eastus", backoff)
+	assert.NotNil(t, armClient.backoff)
+	assert.Equal(t, 1, armClient.backoff.Steps, "Backoff steps should be default to 1 if it is 0")
+
+	armClient = New(nil, "", "test", "2019-01-01", "eastus", nil)
+	assert.NotNil(t, armClient.backoff)
+	assert.Equal(t, 1, armClient.backoff.Steps, "Backoff steps should be default to 1 if it is not set")
+}
+
 func TestSend(t *testing.T) {
 	count := 0
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:

Ensure backoff step is set to 1 for Azure armclient. When the clients passed in a non-nil clientBackoff, the backoff steps may be 0, which would cause client panic:

https://github.com/kubernetes/kubernetes/blob/14a11060a0775ed609f0810898ebdbe737c59441/staging/src/k8s.io/legacy-cloud-providers/azure/clients/armclient/azure_armclient.go#L65-L71

This PR fixes the issue by ensuring the backoff step is 1 on such case.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

Refer https://github.com/kubernetes/kubernetes/pull/94078#discussion_r474742015.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Ensure backoff step is set to 1 for Azure armclient.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
