### PR TITLE
test(kuberuntime): deflake TestRemoveContainer

### DIFF
--- a/pkg/kubelet/kuberuntime/kuberuntime_container_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container_test.go
@@ -79,9 +79,12 @@ func TestRemoveContainer(t *testing.T) {
 
 	err = m.removeContainer(containerID)
 	assert.NoError(t, err)
-	// Verify container log is removed
 
-	assert.Equal(t, []string{expectedContainerLogPath, expectedContainerLogPathRotated, expectedContainerLogSymlink}, fakeOS.Removes)
+	// Verify container log is removed.
+	// We could not predict the order of `fakeOS.Removes`, so we use `assert.ElementsMatch` here.
+	assert.ElementsMatch(t,
+		[]string{expectedContainerLogSymlink, expectedContainerLogPath, expectedContainerLogPathRotated},
+		fakeOS.Removes)
 	// Verify container is removed
 	assert.Contains(t, fakeRuntime.Called, "RemoveContainer")
 	containers, err := fakeRuntime.ListContainers(&runtimeapi.ContainerFilter{Id: containerID})


### PR DESCRIPTION
Signed-off-by: knight42 <anonymousknight96@gmail.com>

**What type of PR is this?**

/kind flake

**What this PR does / why we need it**:

https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/93605/pull-kubernetes-bazel-test/1297588838339710977
```
=== RUN   TestRemoveContainer
    kuberuntime_container_test.go:84: 
        	Error Trace:	kuberuntime_container_test.go:84
        	Error:      	Not equal: 
        	            	expected: []string{"/var/log/pods/new_bar_12345678/foo/0.log", "/var/log/pods/new_bar_12345678/foo/0.log.20060102-150405", "/var/log/containers/bar_new_foo-bar_new_12345678_0_foo_0.log"}
        	            	actual  : []string{"/var/log/pods/new_bar_12345678/foo/0.log.20060102-150405", "/var/log/pods/new_bar_12345678/foo/0.log", "/var/log/containers/bar_new_foo-bar_new_12345678_0_foo_0.log"}
        	            	
        	            	Diff:
        	            	--- Expected
        	            	+++ Actual
        	            	@@ -1,4 +1,4 @@
        	            	 ([]string) (len=3) {
        	            	+ (string) (len=56) "/var/log/pods/new_bar_12345678/foo/0.log.20060102-150405",
        	            	  (string) (len=40) "/var/log/pods/new_bar_12345678/foo/0.log",
        	            	- (string) (len=56) "/var/log/pods/new_bar_12345678/foo/0.log.20060102-150405",
        	            	  (string) (len=60) "/var/log/containers/bar_new_foo-bar_new_12345678_0_foo_0.log"
        	Test:       	TestRemoveContainer
```

The paths are not sorted before verifying, so the test becomes flaky.

**Which issue(s) this PR fixes**:

Part of #93605 
Fixes #94194 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
