### PR TITLE
Maintain sampleAndWaterMarkHistograms in server handlers

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/filters/priority-and-fairness.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/filters/priority-and-fairness.go
@@ -79,6 +79,8 @@ func WithPriorityAndFairness(
 	startOnce.Do(func() {
 		startRecordingUsage(watermark)
 		startRecordingUsage(waitingMark)
+		startMaintainingObservation(watermark)
+		startMaintainingObservation(waitingMark)
 	})
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:
According to the problem statement in https://github.com/kubernetes/kubernetes/issues/94145, the same would happen to maxinflight handler and apf handler. 

This PR adds goroutines in both handlers to avoid iterations in `sampleAndWaterMarkHistograms.innerSet` from blocking requests.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
https://github.com/kubernetes/kubernetes/pull/94146#issuecomment-678949641

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
