### PR TITLE
log metrics: drop error if runtime is not setup

### DIFF
--- a/pkg/kubelet/metrics/collectors/log_metrics.go
+++ b/pkg/kubelet/metrics/collectors/log_metrics.go
@@ -18,7 +18,6 @@ package collectors
 
 import (
 	"k8s.io/component-base/metrics"
-	"k8s.io/klog/v2"
 	statsapi "k8s.io/kubernetes/pkg/kubelet/apis/stats/v1alpha1"
 )
 
@@ -63,7 +62,6 @@ func (c *logMetricsCollector) DescribeWithStability(ch chan<- *metrics.Desc) {
 func (c *logMetricsCollector) CollectWithStability(ch chan<- metrics.Metric) {
 	podStats, err := c.podStats()
 	if err != nil {
-		klog.Errorf("failed to get pod stats: %v", err)
 		return
 	}
 


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**


/kind cleanup


**What this PR does / why we need it**:
kubelet initializes the LogMetricsCollector in its initializeModules() function. This function does not require the runtime to be up.
However, if the runtime is not up, running cadvisor.ListPodStats() before the runtime is up can cause an error: `failed to get pod stats: failed to get imageFs info: non-existent label "crio-images"`

Instead of outputting this error (which unnerves users), we should just silently ignore the error. This is in line with what the VolumeStatsCollector does

Signed-off-by: Peter Hunt <pehunt@redhat.com>
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
none
```
/area kubelet
**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
none
```
