### PR TITLE
Initialize candidate directly instead of iterating the array of candidates

### DIFF
--- a/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption.go
+++ b/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption.go
@@ -332,13 +332,15 @@ func SelectCandidate(candidates []Candidate) Candidate {
 
 	// Same as candidatesToVictimsMap, this logic is not applicable for out-of-tree
 	// preemption plugins that exercise different candidates on the same nominated node.
-	for _, candidate := range candidates {
-		if candidateNode == candidate.Name() {
-			return candidate
+	if victims := victimsMap[candidateNode]; victims != nil {
+		return &candidate{
+			victims: victims,
+			name:    candidateNode,
 		}
 	}
+
 	// We shouldn't reach here.
-	klog.Errorf("None candidate can be picked from %v.", candidates)
+	klog.Errorf("should not reach here, no candidate selected from %v.", candidates)
 	// To not break the whole flow, return the first candidate.
 	return candidates[0]
 }


### PR DESCRIPTION
Using existing victimsMap to get the victims, then it is easy to build candidate
directly.

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
