### PR TITLE
test(endpointslice): deflake TestSyncEndpoints

### DIFF
--- a/pkg/controller/endpointslicemirroring/BUILD
+++ b/pkg/controller/endpointslicemirroring/BUILD
@@ -65,6 +65,7 @@ go_test(
         "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/rand:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//staging/src/k8s.io/client-go/informers:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/fake:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/scheme:go_default_library",


### PR DESCRIPTION
Signed-off-by: knight42 <anonymousknight96@gmail.com>

**What type of PR is this?**

/kind flake

**What this PR does / why we need it**:

https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/93605/pull-kubernetes-bazel-test/1297925434742149121
```
=== RUN   TestSyncEndpoints/Endpoints_with_1001_addresses_-_1_should_not_be_mirrored
W0824 16:06:59.118771      23 reconciler.go:122] 1 addresses in default/testing-sync-endpoints Endpoints were skipped due to exceeding MaxEndpointsPerSubset
    endpointslicemirroring_controller_test.go:207: Expected 2 additional client actions, got 1: []testing.Action{testing.CreateActionImpl{ActionImpl:testing.ActionImpl{Namespace:"default", Verb:"create", Resource:schema.GroupVersionResource{Group:"discovery.k8s.io", Version:"v1beta1", Resource:"endpointslices"}, Subresource:""}, Name:"", Object:(*v1beta1.EndpointSlice)(0xc00037f760)}}
--- FAIL: TestSyncEndpoints (0.41s)
```

The test `Endpoints with 1001 addresses - 1 should not be mirrored` expects 2 additional creation actions, one for creating `EndpointSlices`, the other for creating warning event https://github.com/kubernetes/kubernetes/blob/4db3a096ce8ac730b2280494422e1c4cf5fe875e/pkg/controller/endpointslicemirroring/reconciler.go#L119-L125

This test is flaky because we expects something has been done in a separate goroutine without any synchronization(a super common cause of flakes). The warning event is created in a separate goroutine, so it is not guaranteed the expected warning event is created after reconcilation. The error could be reproduced by the following patch:
```patch
diff --git staging/src/k8s.io/client-go/tools/record/event.go staging/src/k8s.io/client-go/tools/record/event.go
index fce4410c0dd..f39a24e0318 100644
--- staging/src/k8s.io/client-go/tools/record/event.go
+++ staging/src/k8s.io/client-go/tools/record/event.go
@@ -341,6 +341,7 @@ func (recorder *recorderImpl) generateEvent(object runtime.Object, annotations m
        go func() {
                // NOTE: events should be a non-blocking operation
                defer utilruntime.HandleCrash()
+               time.Sleep(time.Second)
                recorder.Action(watch.Added, event)
        }()
 }
```

IMHO this flake does not indicate an internal bug, waiting until the expected event shows up seems to be sufficient.

**Which issue(s) this PR fixes**:

Part of #93605

**Special notes for your reviewer**:

### Alternative

We could probably refactor the `endpointSliceMirroringController` to ultilize [`FakeRecorder`](https://github.com/kubernetes/kubernetes/blob/4db3a096ce8ac730b2280494422e1c4cf5fe875e/pkg/controller/testutil/test_utils.go#L352-L358) in testing, which creates events synchronously and saves all events https://github.com/kubernetes/kubernetes/blob/4db3a096ce8ac730b2280494422e1c4cf5fe875e/pkg/controller/testutil/test_utils.go#L375-L386, so that we could check the events directly.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
