### PR TITLE
`exec` completion should behave the same as `logs`

### DIFF
--- a/pkg/kubectl/cmd/cmd.go
+++ b/pkg/kubectl/cmd/cmd.go
@@ -258,11 +258,11 @@ __kubectl_custom_func() {
             __kubectl_get_resource
             return
             ;;
-        kubectl_logs)
+        kubectl_logs | kubectl_exec)
             __kubectl_require_pod_and_container
             return
             ;;
-        kubectl_exec | kubectl_port-forward | kubectl_top_pod | kubectl_attach)
+        kubectl_port-forward | kubectl_top_pod | kubectl_attach)
             __kubectl_get_resource_pod
             return
             ;;

--- a/staging/src/k8s.io/kubectl/pkg/cmd/exec/exec.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/exec/exec.go
@@ -174,7 +174,7 @@ func (p *ExecOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, argsIn []s
 
 	// Also respect inline [Container] argument.
 	// This behavior is very similar to `kubectl logs`.
-	if len(argsIn) > 1 && argsLenAtDash > 1 {
+	if argsLenAtDash > 1 {
 		p.ContainerName = argsIn[1]
 	}
 	if argsLenAtDash > -1 {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/exec/exec.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/exec/exec.go
@@ -171,6 +171,12 @@ func (p *ExecOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, argsIn []s
 	if len(argsIn) > 0 && argsLenAtDash != 0 {
 		p.ResourceName = argsIn[0]
 	}
+
+	// Also respect inline [Container] argument.
+	// This behavior is very similar to `kubectl logs`.
+	if len(argsIn) > 1 && argsLenAtDash > 1 {
+		p.ContainerName = argsIn[1]
+	}
 	if argsLenAtDash > -1 {
 		p.Command = argsIn[argsLenAtDash:]
 	} else if len(argsIn) > 1 {


### PR DESCRIPTION
### What changed
1. `kubectl exec` command completion should have a similar behavior like
`kubectl logs`. That is, when you hit `TAB` after `kubectl exec <flags> <pod
name> <with/without -c>`, container completion should always be triggered.
2. Previously the `exec` command doesn't take inline [Container] argument, this
commit fixed it.

Fix https://github.com/kubernetes/kubectl/issues/890

### What's not fixed yet:
Still cannot stop completing even if a `-c <container_name>` argument has already existed. However completion doesn't work after `-c` if there has been an inline [Container] argument. Seems the completion always expects an inline [Container] argument. This is the same to `kubectl logs`.

### Release Note
```release-note
kubectl exec command performs completion for container names.
```