### PR TITLE
Verify running mirror pod has running containers

### DIFF
--- a/test/e2e_node/mirror_pod_test.go
+++ b/test/e2e_node/mirror_pod_test.go
@@ -192,6 +192,11 @@ func checkMirrorPodRunning(cl clientset.Interface, name, namespace string) error
 	if pod.Status.Phase != v1.PodRunning {
 		return fmt.Errorf("expected the mirror pod %q to be running, got %q", name, pod.Status.Phase)
 	}
+	for i := range pod.Status.ContainerStatuses {
+		if pod.Status.ContainerStatuses[i].State.Running == nil {
+			return fmt.Errorf("expected the mirror pod %q with container %q to be running", name, pod.Status.ContainerStatuses[i].Name)
+		}
+	}
 	return validateMirrorPod(cl, pod)
 }
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
/kind flake

**What this PR does / why we need it**:
Investigating logs for https://github.com/kubernetes/kubernetes/issues/94223 makes me suspicious that looking at pod phase alone is not sufficient.  Adding more verification in the test to ensure pod is running and all containers are running.

**Special notes for your reviewer**:
None

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```