### PR TITLE
Add a link to liggitt's deflake docs in Flake template

### DIFF
--- a/.github/ISSUE_TEMPLATE/flaking-test.md
+++ b/.github/ISSUE_TEMPLATE/flaking-test.md
@@ -18,3 +18,5 @@ labels: kind/flake
 **Anything else we need to know**:
 - links to go.k8s.io/triage appreciated
 - links to specific failures in spyglass appreciated
+
+<!-- Please see the deflaking doc (https://gist.github.com/liggitt/6a3a2217fa5f846b52519acfc0ffece0) for more guidance! -->

--- a/.github/ISSUE_TEMPLATE/flaking-test.md
+++ b/.github/ISSUE_TEMPLATE/flaking-test.md
@@ -19,4 +19,4 @@ labels: kind/flake
 - links to go.k8s.io/triage appreciated
 - links to specific failures in spyglass appreciated
 
-<!-- Please see the deflaking doc (https://gist.github.com/liggitt/6a3a2217fa5f846b52519acfc0ffece0) for more guidance! -->
+<!-- Please see the deflaking doc (https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/flaky-tests.md) for more guidance! -->


### PR DESCRIPTION
We could have prow bot link comment the link but I think this should be enough to increase visibility to the doc when people encounter a flake

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind documentation
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
Increases visibility of @liggitt 's wonderful deflake document

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
/cc @spiffxp @liggitt 
