### PR TITLE
Fix issue on skipTest in storage suits

### DIFF
--- a/test/e2e/storage/testsuites/base.go
+++ b/test/e2e/storage/testsuites/base.go
@@ -149,50 +149,36 @@ func skipUnsupportedTest(driver TestDriver, pattern testpatterns.TestPattern) {
 	dInfo := driver.GetDriverInfo()
 	var isSupported bool
 
-	// 1. Check if Whether SnapshotType is supported by driver from its interface
-	// if isSupported, we still execute the driver and suite tests
-	if len(pattern.SnapshotType) > 0 {
-		switch pattern.SnapshotType {
-		case testpatterns.DynamicCreatedSnapshot:
-			_, isSupported = driver.(SnapshottableTestDriver)
-		default:
-			isSupported = false
-		}
-		if !isSupported {
-			e2eskipper.Skipf("Driver %s doesn't support snapshot type %v -- skipping", dInfo.Name, pattern.SnapshotType)
-		}
-	} else {
-		// 2. Check if Whether volType is supported by driver from its interface
-		switch pattern.VolType {
-		case testpatterns.InlineVolume:
-			_, isSupported = driver.(InlineVolumeTestDriver)
-		case testpatterns.PreprovisionedPV:
-			_, isSupported = driver.(PreprovisionedPVTestDriver)
-		case testpatterns.DynamicPV, testpatterns.GenericEphemeralVolume:
-			_, isSupported = driver.(DynamicPVTestDriver)
-		case testpatterns.CSIInlineVolume:
-			_, isSupported = driver.(EphemeralTestDriver)
-		default:
-			isSupported = false
-		}
-
-		if !isSupported {
-			e2eskipper.Skipf("Driver %s doesn't support %v -- skipping", dInfo.Name, pattern.VolType)
-		}
-
-		// 3. Check if fsType is supported
-		if !dInfo.SupportedFsType.Has(pattern.FsType) {
-			e2eskipper.Skipf("Driver %s doesn't support %v -- skipping", dInfo.Name, pattern.FsType)
-		}
-		if pattern.FsType == "xfs" && framework.NodeOSDistroIs("gci", "cos", "windows") {
-			e2eskipper.Skipf("Distro doesn't support xfs -- skipping")
-		}
-		if pattern.FsType == "ntfs" && !framework.NodeOSDistroIs("windows") {
-			e2eskipper.Skipf("Distro %s doesn't support ntfs -- skipping", framework.TestContext.NodeOSDistro)
-		}
+	// 1. Check if Whether volType is supported by driver from its interface
+	switch pattern.VolType {
+	case testpatterns.InlineVolume:
+		_, isSupported = driver.(InlineVolumeTestDriver)
+	case testpatterns.PreprovisionedPV:
+		_, isSupported = driver.(PreprovisionedPVTestDriver)
+	case testpatterns.DynamicPV, testpatterns.GenericEphemeralVolume:
+		_, isSupported = driver.(DynamicPVTestDriver)
+	case testpatterns.CSIInlineVolume:
+		_, isSupported = driver.(EphemeralTestDriver)
+	default:
+		isSupported = false
 	}
 
-	// 4. Check with driver specific logic
+	if !isSupported {
+		e2eskipper.Skipf("Driver %s doesn't support %v -- skipping", dInfo.Name, pattern.VolType)
+	}
+
+	// 2. Check if fsType is supported
+	if !dInfo.SupportedFsType.Has(pattern.FsType) {
+		e2eskipper.Skipf("Driver %s doesn't support %v -- skipping", dInfo.Name, pattern.FsType)
+	}
+	if pattern.FsType == "xfs" && framework.NodeOSDistroIs("gci", "cos", "windows") {
+		e2eskipper.Skipf("Distro doesn't support xfs -- skipping")
+	}
+	if pattern.FsType == "ntfs" && !framework.NodeOSDistroIs("windows") {
+		e2eskipper.Skipf("Distro %s doesn't support ntfs -- skipping", framework.TestContext.NodeOSDistro)
+	}
+
+	// 3. Check with driver specific logic
 	driver.SkipUnsupportedTest(pattern)
 }
 


### PR DESCRIPTION
After PR https://github.com/kubernetes/kubernetes/pull/92555, there are a number of gce pd default fs tests skipped. Here the testpatten has SnapshotType set because some provisioning tests use snapshots. But for drivers such as In-tree gce pd driver, the tests will be skipped because of the logic in skipUnsupportedTesthttps://github.com/kubernetes/kubernetes/blob/master/test/e2e/storage/testsuites/base.go#L154
Since multiple drivers might test with the same pattern, so I think we need keep SnapshotType here.

This PR removes the part of the logic in skipUnsupportedTest. This should be ok because all snapshot tests will check whether a driver has snapshot capability or not.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubernetes/issues/94202

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
