### PR TITLE
test(e2e::storage): avoid deleting primary and driver namespace twice

### DIFF
--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -393,6 +393,8 @@ func (f *Framework) AfterEach() {
 					} else {
 						Logf("Namespace %v was already deleted", ns.Name)
 					}
+				} else if err := WaitForNamespacesDeleted(f.ClientSet, []string{ns.Name}, DefaultNamespaceDeletionTimeout); err != nil {
+					Logf("Timed out waiting for namespace %s to be deleted: %v", ns.Name, err)
 				}
 			}
 		} else {

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -341,7 +341,7 @@ func CreateTestingNS(baseName string, c clientset.Interface, labels map[string]s
 	}
 	// Be robust about making the namespace creation call.
 	var got *v1.Namespace
-	if err := wait.PollImmediate(Poll, 30*time.Second, func() (bool, error) {
+	if err := wait.PollImmediate(Poll, wait.ForeverTestTimeout, func() (bool, error) {
 		var err error
 		got, err = c.CoreV1().Namespaces().Create(context.TODO(), namespaceObj, metav1.CreateOptions{})
 		if err != nil {

--- a/test/e2e/storage/drivers/csi.go
+++ b/test/e2e/storage/drivers/csi.go
@@ -173,7 +173,6 @@ func (h *hostpathCSIDriver) PrepareTest(f *framework.Framework) (*testsuites.Per
 	// Create secondary namespace which will be used for creating driver
 	driverNamespace := utils.CreateDriverNamespace(f)
 	ns2 := driverNamespace.Name
-	ns1 := f.Namespace.Name
 
 	ginkgo.By(fmt.Sprintf("deploying %s driver", h.driverInfo.Name))
 	cancelLogging := testsuites.StartPodLogs(f, driverNamespace)
@@ -210,11 +209,6 @@ func (h *hostpathCSIDriver) PrepareTest(f *framework.Framework) (*testsuites.Per
 	// Cleanup CSI driver and namespaces. This function needs to be idempotent and can be
 	// concurrently called from defer (or AfterEach) and AfterSuite action hooks.
 	cleanupFunc := func() {
-		ginkgo.By(fmt.Sprintf("deleting the test namespace: %s", ns1))
-		// Delete the primary namespace but its okay to fail here because this namespace will
-		// also be deleted by framework.Aftereach hook
-		tryFunc(deleteNamespaceFunc(f.ClientSet, ns1, framework.DefaultNamespaceDeletionTimeout))
-
 		ginkgo.By("uninstalling csi mock driver")
 		tryFunc(cleanup)
 		tryFunc(cancelLogging)
@@ -332,7 +326,6 @@ func (m *mockCSIDriver) PrepareTest(f *framework.Framework) (*testsuites.PerTest
 	// Create secondary namespace which will be used for creating driver
 	driverNamespace := utils.CreateDriverNamespace(f)
 	ns2 := driverNamespace.Name
-	ns1 := f.Namespace.Name
 
 	ginkgo.By("deploying csi mock driver")
 	cancelLogging := testsuites.StartPodLogs(f, driverNamespace)
@@ -413,11 +406,6 @@ func (m *mockCSIDriver) PrepareTest(f *framework.Framework) (*testsuites.PerTest
 	// Cleanup CSI driver and namespaces. This function needs to be idempotent and can be
 	// concurrently called from defer (or AfterEach) and AfterSuite action hooks.
 	cleanupFunc := func() {
-		ginkgo.By(fmt.Sprintf("deleting the test namespace: %s", ns1))
-		// Delete the primary namespace but its okay to fail here because this namespace will
-		// also be deleted by framework.Aftereach hook
-		tryFunc(deleteNamespaceFunc(f.ClientSet, ns1, framework.DefaultNamespaceDeletionTimeout))
-
 		ginkgo.By("uninstalling csi mock driver")
 		tryFunc(func() {
 			err := f.ClientSet.CoreV1().ConfigMaps(ns2).Delete(context.TODO(), hooksConfigMapName, metav1.DeleteOptions{})
@@ -537,7 +525,6 @@ func (g *gcePDCSIDriver) PrepareTest(f *framework.Framework) (*testsuites.PerTes
 	// Create secondary namespace which will be used for creating driver
 	driverNamespace := utils.CreateDriverNamespace(f)
 	ns2 := driverNamespace.Name
-	ns1 := f.Namespace.Name
 
 	cancelLogging := testsuites.StartPodLogs(f, driverNamespace)
 	// It would be safer to rename the gcePD driver, but that
@@ -574,11 +561,6 @@ func (g *gcePDCSIDriver) PrepareTest(f *framework.Framework) (*testsuites.PerTes
 	// Cleanup CSI driver and namespaces. This function needs to be idempotent and can be
 	// concurrently called from defer (or AfterEach) and AfterSuite action hooks.
 	cleanupFunc := func() {
-		ginkgo.By(fmt.Sprintf("deleting the test namespace: %s", ns1))
-		// Delete the primary namespace but its okay to fail here because this namespace will
-		// also be deleted by framework.Aftereach hook
-		tryFunc(deleteNamespaceFunc(f.ClientSet, ns1, framework.DefaultNamespaceDeletionTimeout))
-
 		ginkgo.By("uninstalling csi mock driver")
 		tryFunc(cleanup)
 		tryFunc(cancelLogging)


### PR DESCRIPTION
Signed-off-by: knight42 <anonymousknight96@gmail.com>

**What type of PR is this?**

/kind flake

**What this PR does / why we need it**:

As described in https://github.com/kubernetes/kubernetes/issues/94221#issuecomment-680147677, the root cause is the namespace would be deleted twice in the test, it is more obvious if we take a closer look at the access log of apiserver:
```
# created namespace "provisioning-9612" in test "subPath should support existing single file"
45875:I0824 21:48:27.739634       9 httplog.go:89] "HTTP" verb="POST" URI="/api/v1/namespaces" latency="10.521185ms" userAgent="e2e.test/v1.20.0 (linux/amd64) kubernetes/3229073 -- [sig-storage] In-tree Volumes [Driver: local][LocalVolumeType: dir] [Testpattern: Pre-provisioned PV (default fs)] subPath should support existing single file [LinuxOnly]" srcIP="34.121.82.231:58558" resp=201

# deleted namespace "provisioning-9612" in test "subPath should support existing single file"
122918:I0824 21:52:03.923611       9 httplog.go:89] "HTTP" verb="DELETE" URI="/api/v1/namespaces/provisioning-9612" latency="5.37683ms" userAgent="e2e.test/v1.20.0 (linux/amd64) kubernetes/3229073 -- [sig-storage] CSI Volumes [Driver: csi-hostpath] [Testpattern: Dynamic PV (default fs)] subPath should support existing single file [LinuxOnly]" srcIP="34.121.82.231:58578" resp=200

# created namespace "provisioning-9612" in test "subPath should support file as subpath"
127903:I0824 21:52:18.766531       9 httplog.go:89] "HTTP" verb="POST" URI="/api/v1/namespaces" latency="3.974101ms" userAgent="e2e.test/v1.20.0 (linux/amd64) kubernetes/3229073 -- [sig-storage] In-tree Volumes [Driver: gluster] [Testpattern: Pre-provisioned PV (default fs)] subPath should support file as subpath [LinuxOnly]" srcIP="34.121.82.231:33176" resp=201

# deleted namespace "provisioning-9612" in test "subPath should support existing single file"
130263:I0824 21:52:28.584696       9 httplog.go:89] "HTTP" verb="DELETE" URI="/api/v1/namespaces/provisioning-9612" latency="13.93603ms" userAgent="e2e.test/v1.20.0 (linux/amd64) kubernetes/3229073 -- [sig-storage] CSI Volumes [Driver: csi-hostpath] [Testpattern: Dynamic PV (default fs)] subPath should support existing single file [LinuxOnly]" srcIP="34.121.82.231:58578" resp=200

# deleted namespace "provisioning-9612" in test "subPath should support file as subpath"
132603:I0824 21:52:37.288535       9 httplog.go:89] "HTTP" verb="DELETE" URI="/api/v1/namespaces/provisioning-9612" latency="2.292099ms" userAgent="e2e.test/v1.20.0 (linux/amd64) kubernetes/3229073 -- [sig-storage] In-tree Volumes [Driver: gluster] [Testpattern: Pre-provisioned PV (default fs)] subPath should support file as subpath [LinuxOnly]" srcIP="34.121.82.231:33176" resp=200
```

Perhaps I am missing something, but I think we don't need to delete the namespace during the test, as the namespace would be deleted after the test: https://github.com/kubernetes/kubernetes/blob/4db3a096ce8ac730b2280494422e1c4cf5fe875e/test/e2e/framework/framework.go#L375-L395

**Which issue(s) this PR fixes**:

Fixes #94221

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
