### PR TITLE
Mark ProjectedVolumeSource.Sources as optional

### DIFF
--- a/pkg/apis/core/types.go
+++ b/pkg/apis/core/types.go
@@ -1549,6 +1549,7 @@ type ServiceAccountTokenProjection struct {
 // ProjectedVolumeSource represents a projected volume source
 type ProjectedVolumeSource struct {
 	// list of volume projections
+	// +optional
 	Sources []VolumeProjection
 	// Mode bits to use on created files by default. Must be a value between
 	// 0 and 0777.

--- a/staging/src/k8s.io/api/core/v1/generated.proto
+++ b/staging/src/k8s.io/api/core/v1/generated.proto
@@ -3853,6 +3853,7 @@ message Probe {
 // Represents a projected volume source
 message ProjectedVolumeSource {
   // list of volume projections
+  // +optional
   repeated VolumeProjection sources = 1;
 
   // Mode bits used to set permissions on created files by default.

--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -1615,6 +1615,7 @@ type ServiceAccountTokenProjection struct {
 // Represents a projected volume source
 type ProjectedVolumeSource struct {
 	// list of volume projections
+	// +optional
 	Sources []VolumeProjection `json:"sources" protobuf:"bytes,1,rep,name=sources"`
 	// Mode bits used to set permissions on created files by default.
 	// Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
/kind api-change

**What this PR does / why we need it**:

This change allows generated clients to parse a ProjectedVolumeSource with an empty Sources field.

**Which issue(s) this PR fixes**:

Fixes #93903

**Special notes for your reviewer**:

None

**Does this PR introduce a user-facing change?**:

```release-note
The sources field of ProjectedVolumeSource is no longer required for client validation
```

/sig storage