### PR TITLE
[WIP] ignore node ready condition as they're handled by taint manager

### DIFF
--- a/pkg/controller/nodelifecycle/node_lifecycle_controller.go
+++ b/pkg/controller/nodelifecycle/node_lifecycle_controller.go
@@ -624,12 +624,15 @@ func (nc *Controller) doNoScheduleTaintingPass(nodeName string) error {
 	// Map node's condition to Taints.
 	var taints []v1.Taint
 	for _, condition := range node.Status.Conditions {
-		if taintMap, found := nodeConditionToTaintKeyStatusMap[condition.Type]; found {
-			if taintKey, found := taintMap[condition.Status]; found {
-				taints = append(taints, v1.Taint{
-					Key:    taintKey,
-					Effect: v1.TaintEffectNoSchedule,
-				})
+		// ingnore nodeReady conditions as they're handled by the taint manager
+		if nc.runTaintManager && condition.Type != v1.NodeReady {
+			if taintMap, found := nodeConditionToTaintKeyStatusMap[condition.Type]; found {
+				if taintKey, found := taintMap[condition.Status]; found {
+					taints = append(taints, v1.Taint{
+						Key:    taintKey,
+						Effect: v1.TaintEffectNoSchedule,
+					})
+				}
 			}
 		}
 	}

--- a/pkg/controller/nodelifecycle/node_lifecycle_controller_test.go
+++ b/pkg/controller/nodelifecycle/node_lifecycle_controller_test.go
@@ -2986,14 +2986,6 @@ func TestTaintsNodeByCondition(t *testing.T) {
 		Key:    v1.TaintNodeNetworkUnavailable,
 		Effect: v1.TaintEffectNoSchedule,
 	}
-	notReadyTaint := &v1.Taint{
-		Key:    v1.TaintNodeNotReady,
-		Effect: v1.TaintEffectNoSchedule,
-	}
-	unreachableTaint := &v1.Taint{
-		Key:    v1.TaintNodeUnreachable,
-		Effect: v1.TaintEffectNoSchedule,
-	}
 
 	tests := []struct {
 		Name           string
@@ -3088,7 +3080,7 @@ func TestTaintsNodeByCondition(t *testing.T) {
 					},
 				},
 			},
-			ExpectedTaints: []*v1.Taint{notReadyTaint},
+			ExpectedTaints: []*v1.Taint{},
 		},
 		{
 			Name: "Ready is unknown",
@@ -3114,7 +3106,7 @@ func TestTaintsNodeByCondition(t *testing.T) {
 					},
 				},
 			},
-			ExpectedTaints: []*v1.Taint{unreachableTaint},
+			ExpectedTaints: []*v1.Taint{},
 		},
 	}
 


### PR DESCRIPTION
Signed-off-by: Yassine TIJANI <ytijani@vmware.com>

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**: This PR ignores the node Ready condition from being processed by taintByNodeCondition feature as this condition should be handled by the taint manager. Before this PR,  nodes were tainted as `NoSchedule` where they should be tainted as `NoExecute` (using `NoExecute` should be fine wrt pod safety)

**Which issue(s) this PR fixes**: Fixes #

**Special notes for your reviewer**:

/assign @wojtek-t 
cc @andrewsykim 

**Does this PR introduce a user-facing change?**:

```release-note

```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:


```docs

```
