### PR TITLE
Automated cherry pick of #94246: Fix issue on skipTest in storage suits

### DIFF
--- a/test/e2e/storage/testsuites/base.go
+++ b/test/e2e/storage/testsuites/base.go
@@ -149,50 +149,36 @@ func skipUnsupportedTest(driver TestDriver, pattern testpatterns.TestPattern) {
 	dInfo := driver.GetDriverInfo()
 	var isSupported bool
 
-	// 1. Check if Whether SnapshotType is supported by driver from its interface
-	// if isSupported, we still execute the driver and suite tests
-	if len(pattern.SnapshotType) > 0 {
-		switch pattern.SnapshotType {
-		case testpatterns.DynamicCreatedSnapshot:
-			_, isSupported = driver.(SnapshottableTestDriver)
-		default:
-			isSupported = false
-		}
-		if !isSupported {
-			e2eskipper.Skipf("Driver %s doesn't support snapshot type %v -- skipping", dInfo.Name, pattern.SnapshotType)
-		}
-	} else {
-		// 2. Check if Whether volType is supported by driver from its interface
-		switch pattern.VolType {
-		case testpatterns.InlineVolume:
-			_, isSupported = driver.(InlineVolumeTestDriver)
-		case testpatterns.PreprovisionedPV:
-			_, isSupported = driver.(PreprovisionedPVTestDriver)
-		case testpatterns.DynamicPV, testpatterns.GenericEphemeralVolume:
-			_, isSupported = driver.(DynamicPVTestDriver)
-		case testpatterns.CSIInlineVolume:
-			_, isSupported = driver.(EphemeralTestDriver)
-		default:
-			isSupported = false
-		}
-
-		if !isSupported {
-			e2eskipper.Skipf("Driver %s doesn't support %v -- skipping", dInfo.Name, pattern.VolType)
-		}
-
-		// 3. Check if fsType is supported
-		if !dInfo.SupportedFsType.Has(pattern.FsType) {
-			e2eskipper.Skipf("Driver %s doesn't support %v -- skipping", dInfo.Name, pattern.FsType)
-		}
-		if pattern.FsType == "xfs" && framework.NodeOSDistroIs("gci", "cos", "windows") {
-			e2eskipper.Skipf("Distro doesn't support xfs -- skipping")
-		}
-		if pattern.FsType == "ntfs" && !framework.NodeOSDistroIs("windows") {
-			e2eskipper.Skipf("Distro %s doesn't support ntfs -- skipping", framework.TestContext.NodeOSDistro)
-		}
+	// 1. Check if Whether volType is supported by driver from its interface
+	switch pattern.VolType {
+	case testpatterns.InlineVolume:
+		_, isSupported = driver.(InlineVolumeTestDriver)
+	case testpatterns.PreprovisionedPV:
+		_, isSupported = driver.(PreprovisionedPVTestDriver)
+	case testpatterns.DynamicPV, testpatterns.GenericEphemeralVolume:
+		_, isSupported = driver.(DynamicPVTestDriver)
+	case testpatterns.CSIInlineVolume:
+		_, isSupported = driver.(EphemeralTestDriver)
+	default:
+		isSupported = false
 	}
 
-	// 4. Check with driver specific logic
+	if !isSupported {
+		e2eskipper.Skipf("Driver %s doesn't support %v -- skipping", dInfo.Name, pattern.VolType)
+	}
+
+	// 2. Check if fsType is supported
+	if !dInfo.SupportedFsType.Has(pattern.FsType) {
+		e2eskipper.Skipf("Driver %s doesn't support %v -- skipping", dInfo.Name, pattern.FsType)
+	}
+	if pattern.FsType == "xfs" && framework.NodeOSDistroIs("gci", "cos", "windows") {
+		e2eskipper.Skipf("Distro doesn't support xfs -- skipping")
+	}
+	if pattern.FsType == "ntfs" && !framework.NodeOSDistroIs("windows") {
+		e2eskipper.Skipf("Distro %s doesn't support ntfs -- skipping", framework.TestContext.NodeOSDistro)
+	}
+
+	// 3. Check with driver specific logic
 	driver.SkipUnsupportedTest(pattern)
 }
 


### PR DESCRIPTION
Cherry pick of #94246 on release-1.19.

#94246: Fix issue on skipTest in storage suits

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.