### PR TITLE
Fix prefixed global flags for kubectl plugins

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/cmd_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/cmd_test.go
@@ -65,6 +65,12 @@ func TestKubectlCommandHandlesPlugins(t *testing.T) {
 			name:             "test that normal commands are able to be executed, when no plugin overshadows them",
 			args:             []string{"kubectl", "get", "foo"},
 			expectPlugin:     "",
+			expectPluginArgs: nil,
+		},
+		{
+			name:             "test that a plugin executable is found with no flags",
+			args:             []string{"kubectl", "foo"},
+			expectPlugin:     "plugin/testdata/kubectl-foo",
 			expectPluginArgs: []string{},
 		},
 		{
@@ -103,8 +109,8 @@ func TestKubectlCommandHandlesPlugins(t *testing.T) {
 				t.Fatalf("unexpected plugin execution: expected %q, got %q", test.expectPlugin, pluginsHandler.executedPlugin)
 			}
 
-			if len(pluginsHandler.withArgs) != len(test.expectPluginArgs) {
-				t.Fatalf("unexpected plugin execution args: expected %q, got %q", test.expectPluginArgs, pluginsHandler.withArgs)
+			if !reflect.DeepEqual(pluginsHandler.withArgs, test.expectPluginArgs) {
+				t.Fatalf("unexpected plugin execution args: expected %#v, got %#v", test.expectPluginArgs, pluginsHandler.withArgs)
 			}
 		})
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

**What this PR does / why we need it**:

For normal kubectl commands, global flags can be used anywhere within
the command line:

```
  $ kubectl --kubeconfig admin.conf get pod
  No resources found in default namespace.
  $ kubectl get --kubeconfig admin.conf pod
  No resources found in default namespace.
  $ kubectl get pod --kubeconfig admin.conf
  No resources found in default namespace.
```

However, without this patch, when calling a plugin as a subcommand, the
flag can only work if it comes after the plugin subcommand:

```
  $ kubectl --kubeconfig admin.conf hns tree default
  Error: unknown command "hns" for "kubectl"
  Run 'kubectl --help' for usage.
  $ kubectl hns --kubeconfig admin.conf tree default
  default
  $ kubectl hns tree --kubeconfig admin.conf default
  default
  $ kubectl hns tree default --kubeconfig admin.conf
  default
```

This is an inconsistency that can lead to the user confusion regarding
whether they have installed the plugin correctly and so is an unfriendly
user experience. This patch corrects the issue for plugin handling by
relocating persistent flags to the end of the argument list before
attempting to search for the plugin binary.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #93432

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixed parsing of prefixed global flags for kubectl plugins.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
