### PR TITLE
Remove duplicate nodeSelector

### DIFF
--- a/cluster/addons/dns-horizontal-autoscaler/dns-horizontal-autoscaler.yaml
+++ b/cluster/addons/dns-horizontal-autoscaler/dns-horizontal-autoscaler.yaml
@@ -105,6 +105,4 @@ spec:
       tolerations:
       - key: "CriticalAddonsOnly"
         operator: "Exists"
-      nodeSelector:
-        kubernetes.io/os: linux
       serviceAccountName: kube-dns-autoscaler


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:

Makes the dns-horizontal-autoscaler.yaml file valid yaml.
