### PR TITLE
Deprioritize extensions/v1beta1 in discovery

### DIFF
--- a/cmd/kube-apiserver/app/aggregator.go
+++ b/cmd/kube-apiserver/app/aggregator.go
@@ -234,9 +234,6 @@ type priority struct {
 // That ripples out every bit as far as you'd expect, so for 1.7 we'll include the list here instead of being built up during storage.
 var apiVersionPriorities = map[schema.GroupVersion]priority{
 	{Group: "", Version: "v1"}: {group: 18000, version: 1},
-	// extensions is above the rest for CLI compatibility, though the level of unqualified resource compatibility we
-	// can reasonably expect seems questionable.
-	{Group: "extensions", Version: "v1beta1"}: {group: 17900, version: 1},
 	// to my knowledge, nothing below here collides
 	{Group: "apps", Version: "v1"}:                               {group: 17800, version: 15},
 	{Group: "events.k8s.io", Version: "v1"}:                      {group: 17750, version: 15},
@@ -255,6 +252,7 @@ var apiVersionPriorities = map[schema.GroupVersion]priority{
 	{Group: "certificates.k8s.io", Version: "v1beta1"}:           {group: 17300, version: 9},
 	{Group: "networking.k8s.io", Version: "v1"}:                  {group: 17200, version: 15},
 	{Group: "networking.k8s.io", Version: "v1beta1"}:             {group: 17200, version: 9},
+	{Group: "extensions", Version: "v1beta1"}:                    {group: 17150, version: 1}, // prioritize below networking.k8s.io, which contains the GA version of Ingress, the only resource remaining in extensions/v1beta1
 	{Group: "policy", Version: "v1beta1"}:                        {group: 17100, version: 9},
 	{Group: "rbac.authorization.k8s.io", Version: "v1"}:          {group: 17000, version: 15},
 	{Group: "rbac.authorization.k8s.io", Version: "v1beta1"}:     {group: 17000, version: 12},


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Ingress is the only resource remaining in extensions/v1beta1, has been deprecated since 1.14, has a target removal of 1.22, and has a GA replacement in networking.k8s.io/v1 as of 1.19.

Deprioritize the extensions/v1beta1 API group so that an unqualified `kubectl get ingresses` prefers the GA version.

**Does this PR introduce a user-facing change?**:
```release-note
`kubectl get ingress` now prefers the `networking.k8s.io/v1` over `extensions/v1beta1` (deprecated since v1.14). To explicitly request the deprecated version, use `kubectl get ingress.v1beta1.extensions`.
```

/sig cli
/sig networking

/cc @soltysh 
similar to https://github.com/kubernetes/kubernetes/pull/88119; I'm more convinced now that we have a GA alternative and that `kubectl get ingress` would return a deprecation warning.

/cc @robscott 
for networking / ingress visibility