### PR TITLE
Moving SetHostnameAsFQDn e2e tests to e2e_node directory to include tests in Node Testgrid

### DIFF
--- a/test/e2e/node/BUILD
+++ b/test/e2e/node/BUILD
@@ -12,7 +12,6 @@ go_library(
         "mount_propagation.go",
         "node_problem_detector.go",
         "pod_gc.go",
-        "pod_hostnamefqdn.go",
         "pods.go",
         "pre_stop.go",
         "recreate_node.go",

--- a/test/e2e_node/BUILD
+++ b/test/e2e_node/BUILD
@@ -132,6 +132,7 @@ go_test(
         "node_container_manager_test.go",
         "node_perf_test.go",
         "pids_test.go",
+        "pod_hostnamefqdn_test.go",
         "pods_container_manager_test.go",
         "quota_lsci_test.go",
         "resource_metrics_test.go",

--- a/test/e2e_node/pod_hostnamefqdn_test.go
+++ b/test/e2e_node/pod_hostnamefqdn_test.go
@@ -18,7 +18,7 @@ limitations under the License.
  * expected.
  */
 
-package node
+package e2enode
 
 import (
 	"crypto/rand"


### PR DESCRIPTION
I still do not see these tests in the node alpha feature CI. Looking more into it I just realized that we are not supposed to add tests to the test/e2e directory. Moving the tests to e2e_node. 
/cleanup
/area test

