### PR TITLE
Fix bug in reflector not detecting "Too large resource version" error

### DIFF
--- a/staging/src/k8s.io/client-go/tools/cache/reflector.go
+++ b/staging/src/k8s.io/client-go/tools/cache/reflector.go
@@ -570,5 +570,26 @@ func isExpiredError(err error) bool {
 }
 
 func isTooLargeResourceVersionError(err error) bool {
-	return apierrors.HasStatusCause(err, metav1.CauseTypeResourceVersionTooLarge)
+	if apierrors.HasStatusCause(err, metav1.CauseTypeResourceVersionTooLarge) {
+		return true
+	}
+	// In Kubernetes 1.17.0-1.18.5, the api server doesn't set the error status cause to
+	// metav1.CauseTypeResourceVersionTooLarge to indicate that the requested minimum resource
+	// version is larger than the largest currently available resource version. To ensure backward
+	// compatibility with these server versions we also need to detect the error based on the content
+	// of the error message field.
+	if !apierrors.IsTimeout(err) {
+		return false
+	}
+	apierr, ok := err.(apierrors.APIStatus)
+	if !ok || apierr == nil || apierr.Status().Details == nil {
+		return false
+	}
+	for _, cause := range apierr.Status().Details.Causes {
+		// Matches the message returned by api server 1.17.0-1.18.5 for this error condition
+		if cause.Message == "Too large resource version" {
+			return true
+		}
+	}
+	return false
 }

--- a/staging/src/k8s.io/client-go/tools/cache/reflector_test.go
+++ b/staging/src/k8s.io/client-go/tools/cache/reflector_test.go
@@ -738,9 +738,14 @@ func TestReflectorFullListIfTooLarge(t *testing.T) {
 				err := apierrors.NewTimeoutError("too large resource version", 1)
 				err.ErrStatus.Details.Causes = []metav1.StatusCause{{Type: metav1.CauseTypeResourceVersionTooLarge}}
 				return nil, err
+			// relist after the initial list (covers the error format used in api server 1.17.0-1.18.5)
+			case "30":
+				err := apierrors.NewTimeoutError("too large resource version", 1)
+				err.ErrStatus.Details.Causes = []metav1.StatusCause{{Message: "Too large resource version"}}
+				return nil, err
 			// relist from etcd after "too large" error
 			case "":
-				return &v1.PodList{ListMeta: metav1.ListMeta{ResourceVersion: "10"}}, nil
+				return &v1.PodList{ListMeta: metav1.ListMeta{ResourceVersion: "30"}}, nil
 			default:
 				return nil, fmt.Errorf("unexpected List call: %s", options.ResourceVersion)
 			}
@@ -759,12 +764,15 @@ func TestReflectorFullListIfTooLarge(t *testing.T) {
 	// may be synced to a different version and they will never converge.
 	// TODO: We should use etcd progress-notify feature to avoid this behavior but until this is
 	// done we simply try to relist from now to avoid continuous errors on relists.
-	stopCh = make(chan struct{})
-	if err := r.ListAndWatch(stopCh); err != nil {
-		t.Fatal(err)
+	for i := 1; i <= 2; i++ {
+		// relist twice to cover the two variants of TooLargeResourceVersion api errors
+		stopCh = make(chan struct{})
+		if err := r.ListAndWatch(stopCh); err != nil {
+			t.Fatal(err)
+		}
 	}
 
-	expectedRVs := []string{"0", "20", ""}
+	expectedRVs := []string{"0", "20", "", "30", ""}
 	if !reflect.DeepEqual(listCallRVs, expectedRVs) {
 		t.Errorf("Expected series of list calls with resource version of %#v but got: %#v", expectedRVs, listCallRVs)
 	}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Fixes a bug in reflector that causes client to not recover from "Too large resource version" errors

The previous attempt at fixing this fails to detect the "Too large resource version"  error when the API server is running version v1.18.5 or earlier. These server versions do not set the `Cause` field in the error details that the check implemented in previous fix is expecting: https://github.com/kubernetes/kubernetes/pull/92537/files#diff-df2b34adba86da0485290415620d737aR571-R574

**Which issue(s) this PR fixes**:

- #94315 
- #91073 (follow-up)


**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixed a regression in 1.19 versions of the client-go reflector that couldn't recover from "Too large resource version" errors with API servers 1.17.0-1.18.5
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
