### PR TITLE
Fix FakeClock::Reset to always succeed

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/clock/clock_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/clock/clock_test.go
@@ -217,8 +217,8 @@ func TestFakeTimer(t *testing.T) {
 		t.Errorf("unexpected channel read")
 	default:
 	}
-	if twoSec.Reset(time.Second) {
-		t.Errorf("Expected twoSec.Reset() to return false")
+	if !twoSec.Reset(time.Second) {
+		t.Errorf("Expected twoSec.Reset() to return true")
 	}
 	if !treSec.Reset(time.Second) {
 		t.Errorf("Expected treSec.Reset() to return true")
@@ -238,8 +238,9 @@ func TestFakeTimer(t *testing.T) {
 	case <-oneSec.C():
 		t.Errorf("unexpected channel read")
 	case <-twoSec.C():
-		t.Errorf("unexpected channel read")
+		// Expected!
 	default:
+		t.Errorf("unexpected channel non-read")
 	}
 	select {
 	case <-treSec.C():


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
Currently, FakeClock::Reset only successfully resets the timer and returns true when the timer has neither fired nor been stopped.

This is incorrect behavior as real clocks allow for resetting in both of those situations (as long has the channel has been drained).

This is useful in tests that use a fake clock to test wait.BackofManager, as the timer resets after each iteration of Backoff() after the timer has already fired.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```


