### PR TITLE
Automated cherry pick of #90927: remove oom TestStartingWatcher ""unit"" test

### DIFF
--- a/pkg/kubelet/oom/oom_watcher_linux_test.go
+++ b/pkg/kubelet/oom/oom_watcher_linux_test.go
@@ -38,17 +38,6 @@ func (fs *fakeStreamer) StreamOoms(outStream chan<- *oomparser.OomInstance) {
 	}
 }
 
-// TestStartingWatcher tests that the watcher, using the actual streamer
-// and not the fake, starts successfully.
-func TestStartingWatcher(t *testing.T) {
-	fakeRecorder := &record.FakeRecorder{}
-	node := &v1.ObjectReference{}
-
-	oomWatcher, err := NewWatcher(fakeRecorder)
-	assert.NoError(t, err)
-	assert.NoError(t, oomWatcher.Start(node))
-}
-
 // TestWatcherRecordsEventsForOomEvents ensures that our OomInstances coming
 // from `StreamOoms` are translated into events in our recorder.
 func TestWatcherRecordsEventsForOomEvents(t *testing.T) {


### PR DESCRIPTION
Cherry pick of #90927 on release-1.18.

#90927: remove oom TestStartingWatcher ""unit"" test

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.