### PR TITLE
Automated cherry pick of #86232: Clean up conformance tar test data

### DIFF
--- a/cluster/images/conformance/go-runner/BUILD
+++ b/cluster/images/conformance/go-runner/BUILD
@@ -41,7 +41,6 @@ go_test(
         "env_test.go",
         "tar_test.go",
     ],
-    data = glob(["testdata/**"]),
     embed = [":go_default_library"],
     deps = ["//vendor/github.com/pkg/errors:go_default_library"],
 )

--- a/cluster/images/conformance/go-runner/tar_test.go
+++ b/cluster/images/conformance/go-runner/tar_test.go
@@ -32,6 +32,25 @@ import (
 )
 
 func TestTar(t *testing.T) {
+	tmp, err := ioutil.TempDir("", "testtar")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmp)
+
+	if err := os.Mkdir(filepath.Join(tmp, "subdir"), os.FileMode(0755)); err != nil {
+		t.Fatal(err)
+	}
+	if err := ioutil.WriteFile(filepath.Join(tmp, "file1"), []byte(`file1 data`), os.FileMode(0644)); err != nil {
+		t.Fatal(err)
+	}
+	if err := ioutil.WriteFile(filepath.Join(tmp, "file2"), []byte(`file2 data`), os.FileMode(0644)); err != nil {
+		t.Fatal(err)
+	}
+	if err := ioutil.WriteFile(filepath.Join(tmp, "subdir", "file4"), []byte(`file4 data`), os.FileMode(0644)); err != nil {
+		t.Fatal(err)
+	}
+
 	testCases := []struct {
 		desc      string
 		dir       string
@@ -41,8 +60,8 @@ func TestTar(t *testing.T) {
 	}{
 		{
 			desc:    "Contents preserved and no self-reference",
-			dir:     "testdata/tartest",
-			outpath: "testdata/tartest/out.tar.gz",
+			dir:     tmp,
+			outpath: filepath.Join(tmp, "out.tar.gz"),
 			expect: map[string]string{
 				"file1":        "file1 data",
 				"file2":        "file2 data",
@@ -50,8 +69,8 @@ func TestTar(t *testing.T) {
 			},
 		}, {
 			desc:      "Errors if directory does not exist",
-			dir:       "testdata/does-not-exist",
-			outpath:   "testdata/tartest/out.tar.gz",
+			dir:       filepath.Join(tmp, "does-not-exist"),
+			outpath:   filepath.Join(tmp, "out.tar.gz"),
 			expectErr: "tar unable to stat directory",
 		},
 	}

--- a/cluster/images/conformance/go-runner/testdata/tartest/file1
+++ b/cluster/images/conformance/go-runner/testdata/tartest/file1
@@ -1,1 +1,0 @@
-file1 data

--- a/cluster/images/conformance/go-runner/testdata/tartest/file2
+++ b/cluster/images/conformance/go-runner/testdata/tartest/file2
@@ -1,1 +1,0 @@
-file2 data

--- a/cluster/images/conformance/go-runner/testdata/tartest/subdir/file4
+++ b/cluster/images/conformance/go-runner/testdata/tartest/subdir/file4
@@ -1,1 +1,0 @@
-file4 data


### PR DESCRIPTION
Cherry pick of #86232 on release-1.16.

#86232: Clean up conformance tar test data

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.