### PR TITLE
kubectl create ingress

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/BUILD
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/BUILD
@@ -37,6 +37,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/intstr:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/rand:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//staging/src/k8s.io/cli-runtime/pkg/genericclioptions:go_default_library",

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_ingress_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_ingress_test.go
@@ -17,49 +17,327 @@ limitations under the License.
 package create
 
 import (
-	"strings"
 	"testing"
 
-	"k8s.io/api/networking/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	v1 "k8s.io/api/networking/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func TestCreateIngress(t *testing.T) {
-	ingressName := "fake-ingress"
+func TestCreateIngressValidation(t *testing.T) {
 	tests := map[string]struct {
-		name         string
-		host         string
-		serviceName  string
-		servicePort  string
-		path         string
-		expectErrMsg string
-		expect       *v1.Ingress
+		defaultbackend string
+		ingressclass   string
+		rules          []string
+		expected       string
 	}{
-		"test-valid-case": {
-			name:        "fake-ingress",
-			host:        "foo.bar.com",
-			serviceName: "fake-service",
-			servicePort: "https",
-			path:        "/api",
-			expect: &v1.Ingress{
-				TypeMeta: metav1.TypeMeta{APIVersion: v1.SchemeGroupVersion.String(), Kind: "Ingress"},
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "fake-ingress",
+		"no default backend and rule": {
+			defaultbackend: "",
+			rules:          []string{},
+			expected:       "not enough information provided: every ingress has to either specify a default-backend (which catches all traffic) or a list of rules (which catch specific paths)",
+		},
+		"invalid default backend separator": {
+			defaultbackend: "xpto,4444",
+			expected:       "default-backend should be in format servicename:serviceport",
+		},
+		"default backend without port": {
+			defaultbackend: "xpto",
+			expected:       "default-backend should be in format servicename:serviceport",
+		},
+		"default backend is ok": {
+			defaultbackend: "xpto:4444",
+			expected:       "",
+		},
+		"multiple conformant rules": {
+			rules: []string{
+				"foo.com/path*=svc:8080",
+				"bar.com/admin*=svc2:http",
+			},
+			expected: "",
+		},
+		"one invalid and two valid rules": {
+			rules: []string{
+				"foo.com=svc:redis,tls",
+				"foo.com/path/subpath*=othersvc:8080",
+				"foo.com/*=svc:8080,tls=secret1",
+			},
+			expected: "rule foo.com=svc:redis,tls is invalid and should be in format host/path=svcname:svcport[,tls[=secret]]",
+		},
+		"service without port": {
+			rules: []string{
+				"foo.com/=svc,tls",
+			},
+			expected: "rule foo.com/=svc,tls is invalid and should be in format host/path=svcname:svcport[,tls[=secret]]",
+		},
+		"valid tls rule without secret": {
+			rules: []string{
+				"foo.com/=svc:http,tls=",
+			},
+			expected: "",
+		},
+		"valid tls rule with secret": {
+			rules: []string{
+				"foo.com/=svc:http,tls=secret123",
+			},
+			expected: "",
+		},
+		"valid path with type prefix": {
+			rules: []string{
+				"foo.com/admin*=svc:8080",
+			},
+			expected: "",
+		},
+		"wildcard host": {
+			rules: []string{
+				"*.foo.com/admin*=svc:8080",
+			},
+			expected: "",
+		},
+		"invalid separation between ingress and service": {
+			rules: []string{
+				"*.foo.com/path,svc:8080",
+			},
+			expected: "rule *.foo.com/path,svc:8080 is invalid and should be in format host/path=svcname:svcport[,tls[=secret]]",
+		},
+		"two invalid and one valid rule": {
+			rules: []string{
+				"foo.com/path/subpath*=svc:redis,tls=blo",
+				"foo.com=othersvc:8080",
+				"foo.com/admin=svc,tls=secret1",
+			},
+			expected: "rule foo.com=othersvc:8080 is invalid and should be in format host/path=svcname:svcport[,tls[=secret]]",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			o := &CreateIngressOptions{
+				DefaultBackend: tc.defaultbackend,
+				Rules:          tc.rules,
+				IngressClass:   tc.ingressclass,
+			}
+
+			err := o.Validate()
+			if err != nil && err.Error() != tc.expected {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if tc.expected != "" && err == nil {
+				t.Errorf("expected error, got no error")
+			}
+
+		})
+	}
+}
+
+func TestCreateIngress(t *testing.T) {
+	ingressName := "test-ingress"
+	ingressClass := "nginx"
+	pathTypeExact := networkingv1.PathTypeExact
+	pathTypePrefix := networkingv1.PathTypePrefix
+	tests := map[string]struct {
+		defaultbackend string
+		rules          []string
+		ingressclass   string
+		annotations    []string
+		expected       *networkingv1.Ingress
+	}{
+		"catch all host and default backend with default TLS returns empty TLS": {
+			rules: []string{
+				"_/=catchall:8080,tls=",
+			},
+			ingressclass:   ingressClass,
+			defaultbackend: "service1:https",
+			annotations:    []string{},
+			expected: &networkingv1.Ingress{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: networkingv1.SchemeGroupVersion.String(),
+					Kind:       "Ingress",
 				},
-				Spec: v1.IngressSpec{
-					Rules: []v1.IngressRule{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        ingressName,
+					Annotations: map[string]string{},
+				},
+				Spec: networkingv1.IngressSpec{
+					IngressClassName: &ingressClass,
+					DefaultBackend: &networkingv1.IngressBackend{
+						Service: &networkingv1.IngressServiceBackend{
+							Name: "service1",
+							Port: networkingv1.ServiceBackendPort{
+								Name: "https",
+							},
+						},
+					},
+					TLS: []v1.IngressTLS{},
+					Rules: []networkingv1.IngressRule{
 						{
-							Host: "foo.bar.com",
-							IngressRuleValue: v1.IngressRuleValue{
-								HTTP: &v1.HTTPIngressRuleValue{
-									Paths: []v1.HTTPIngressPath{
+							Host: "",
+							IngressRuleValue: networkingv1.IngressRuleValue{
+								HTTP: &networkingv1.HTTPIngressRuleValue{
+									Paths: []networkingv1.HTTPIngressPath{
 										{
-											Path: "/api",
-											Backend: v1.IngressBackend{
-												Service: &v1.IngressServiceBackend{
-													Name: "fake-service",
-													Port: v1.ServiceBackendPort{
+											Path:     "/",
+											PathType: &pathTypeExact,
+											Backend: networkingv1.IngressBackend{
+												Service: &networkingv1.IngressServiceBackend{
+													Name: "catchall",
+													Port: networkingv1.ServiceBackendPort{
+														Number: 8080,
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"mixed hosts with mixed TLS configuration and a default backend": {
+			rules: []string{
+				"foo.com/=foo-svc:8080,tls=",
+				"foo.com/admin=foo-admin-svc:http,tls=",
+				"bar.com/prefix*=bar-svc:8080,tls=bar-secret",
+				"bar.com/noprefix=barnp-svc:8443,tls",
+				"foobar.com/*=foobar-svc:https",
+				"foobar1.com/*=foobar1-svc:https,tls=bar-secret",
+			},
+			defaultbackend: "service2:8080",
+			annotations:    []string{},
+			expected: &networkingv1.Ingress{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: networkingv1.SchemeGroupVersion.String(),
+					Kind:       "Ingress",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        ingressName,
+					Annotations: map[string]string{},
+				},
+				Spec: networkingv1.IngressSpec{
+					DefaultBackend: &networkingv1.IngressBackend{
+						Service: &networkingv1.IngressServiceBackend{
+							Name: "service2",
+							Port: networkingv1.ServiceBackendPort{
+								Number: 8080,
+							},
+						},
+					},
+					TLS: []v1.IngressTLS{
+						{
+							Hosts: []string{
+								"foo.com",
+							},
+						},
+						{
+							Hosts: []string{
+								"bar.com",
+								"foobar1.com",
+							},
+							SecretName: "bar-secret",
+						},
+					},
+					Rules: []networkingv1.IngressRule{
+						{
+							Host: "foo.com",
+							IngressRuleValue: networkingv1.IngressRuleValue{
+								HTTP: &networkingv1.HTTPIngressRuleValue{
+									Paths: []networkingv1.HTTPIngressPath{
+										{
+											Path:     "/",
+											PathType: &pathTypeExact,
+											Backend: networkingv1.IngressBackend{
+												Service: &networkingv1.IngressServiceBackend{
+													Name: "foo-svc",
+													Port: networkingv1.ServiceBackendPort{
+														Number: 8080,
+													},
+												},
+											},
+										},
+										{
+											Path:     "/admin",
+											PathType: &pathTypeExact,
+											Backend: networkingv1.IngressBackend{
+												Service: &networkingv1.IngressServiceBackend{
+													Name: "foo-admin-svc",
+													Port: networkingv1.ServiceBackendPort{
+														Name: "http",
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+						{
+							Host: "bar.com",
+							IngressRuleValue: networkingv1.IngressRuleValue{
+								HTTP: &networkingv1.HTTPIngressRuleValue{
+									Paths: []networkingv1.HTTPIngressPath{
+										{
+											Path:     "/prefix",
+											PathType: &pathTypePrefix,
+											Backend: networkingv1.IngressBackend{
+												Service: &networkingv1.IngressServiceBackend{
+													Name: "bar-svc",
+													Port: networkingv1.ServiceBackendPort{
+														Number: 8080,
+													},
+												},
+											},
+										},
+										{
+											Path:     "/noprefix",
+											PathType: &pathTypeExact,
+											Backend: networkingv1.IngressBackend{
+												Service: &networkingv1.IngressServiceBackend{
+													Name: "barnp-svc",
+													Port: networkingv1.ServiceBackendPort{
+														Number: 8443,
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+						{
+							Host: "foobar.com",
+							IngressRuleValue: networkingv1.IngressRuleValue{
+								HTTP: &networkingv1.HTTPIngressRuleValue{
+									Paths: []networkingv1.HTTPIngressPath{
+										{
+											Path:     "/",
+											PathType: &pathTypePrefix,
+											Backend: networkingv1.IngressBackend{
+												Service: &networkingv1.IngressServiceBackend{
+													Name: "foobar-svc",
+													Port: networkingv1.ServiceBackendPort{
+														Name: "https",
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+						{
+							Host: "foobar1.com",
+							IngressRuleValue: networkingv1.IngressRuleValue{
+								HTTP: &networkingv1.HTTPIngressRuleValue{
+									Paths: []networkingv1.HTTPIngressPath{
+										{
+											Path:     "/",
+											PathType: &pathTypePrefix,
+											Backend: networkingv1.IngressBackend{
+												Service: &networkingv1.IngressServiceBackend{
+													Name: "foobar1-svc",
+													Port: networkingv1.ServiceBackendPort{
 														Name: "https",
 													},
 												},
@@ -73,56 +351,90 @@ func TestCreateIngress(t *testing.T) {
 				},
 			},
 		},
+		"simple ingress with annotation": {
+			rules: []string{
+				"foo.com/=svc:8080,tls=secret1",
+				"foo.com/subpath*=othersvc:8080,tls=secret1",
+			},
+			annotations: []string{
+				"ingress.kubernetes.io/annotation1=bla",
+				"ingress.kubernetes.io/annotation2=blo",
+				"ingress.kubernetes.io/annotation3=ble",
+			},
+			expected: &networkingv1.Ingress{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: networkingv1.SchemeGroupVersion.String(),
+					Kind:       "Ingress",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: ingressName,
+					Annotations: map[string]string{
+						"ingress.kubernetes.io/annotation1": "bla",
+						"ingress.kubernetes.io/annotation3": "ble",
+						"ingress.kubernetes.io/annotation2": "blo",
+					},
+				},
+				Spec: networkingv1.IngressSpec{
+					TLS: []v1.IngressTLS{
+						{
+							Hosts: []string{
+								"foo.com",
+							},
+							SecretName: "secret1",
+						},
+					},
+					Rules: []networkingv1.IngressRule{
+						{
+							Host: "foo.com",
+							IngressRuleValue: networkingv1.IngressRuleValue{
+								HTTP: &networkingv1.HTTPIngressRuleValue{
+									Paths: []networkingv1.HTTPIngressPath{
+										{
+											Path:     "/",
+											PathType: &pathTypeExact,
+											Backend: networkingv1.IngressBackend{
+												Service: &networkingv1.IngressServiceBackend{
+													Name: "svc",
+													Port: networkingv1.ServiceBackendPort{
+														Number: 8080,
+													},
+												},
+											},
+										},
+										{
+											Path:     "/subpath",
+											PathType: &pathTypePrefix,
+											Backend: networkingv1.IngressBackend{
+												Service: &networkingv1.IngressServiceBackend{
+													Name: "othersvc",
+													Port: networkingv1.ServiceBackendPort{
+														Number: 8080,
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
+
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			o := &CreateIngressOptions{
-				Name:        ingressName,
-				Host:        tc.host,
-				ServiceName: tc.serviceName,
-				ServicePort: tc.servicePort,
-				Path:        tc.path,
+				Name:           ingressName,
+				IngressClass:   tc.ingressclass,
+				Annotations:    tc.annotations,
+				DefaultBackend: tc.defaultbackend,
+				Rules:          tc.rules,
 			}
 			ingress := o.createIngress()
-			if !apiequality.Semantic.DeepEqual(ingress, tc.expect) {
-				t.Errorf("expected:\n%+v\ngot:\n%+v", tc.expect, ingress)
-			}
-		})
-	}
-
-}
-
-func TestCreateIngressValidation(t *testing.T) {
-	tests := map[string]struct {
-		name        string
-		host        string
-		serviceName string
-		servicePort string
-		path        string
-		expect      string
-	}{
-		"test-missing-host": {
-			serviceName: "fake-ingress",
-			expect:      "--host must be specified",
-		},
-		"test-missing-service": {
-			host:   "foo.bar.com",
-			expect: "--service-name must be specified",
-		},
-	}
-
-	for name, tc := range tests {
-		t.Run(name, func(t *testing.T) {
-			o := &CreateIngressOptions{
-				Host:        tc.host,
-				ServiceName: tc.serviceName,
-				ServicePort: tc.servicePort,
-				Path:        tc.path,
-			}
-
-			err := o.Validate()
-			if err != nil && !strings.Contains(err.Error(), tc.expect) {
-				t.Errorf("unexpected error: %v", err)
+			if !apiequality.Semantic.DeepEqual(ingress, tc.expected) {
+				t.Errorf("expected:\n%#v\ngot:\n%#v", tc.expected, ingress)
 			}
 		})
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**: Add ``kubectl create ingress``

**Which issue(s) this PR fixes**:
Fixes #93267

**Special notes for your reviewer**:
* Discussion: https://groups.google.com/g/kubernetes-sig-network/c/QZYWzBFcU-s
* Unit tests are pending, asking for the review of the code logic right now and if this is compliant with sig/cli guidelines
* Because of the "complexity" of rules, there are some "strings split" in the code and also a Regex used for the rule validation. If sig-cli is ok with that maybe using named groups from the regex would be better than using that bunch of strings.split in the code.

**Does this PR introduce a user-facing change?**:
```release-note
kubectl create now supports creating ingress objects.
```

TODO:
* [x] Unit tests
* [x] Write the necessary validations in ``Validate()`` method, like if the referenced secret or service exists (otherwise decide if issue a Warning or an Error)
* [x] Adjust the ingressExample (as this has been copied and adapted from create_deployment)
* [x] Add support for DefaultBackend
* [x] Add support for TLS flags
* [x] add support for TLS secret without host definition

/sig cli
/sig network





