### PR TITLE
Automated cherry pick of #94294: Remove duplicate nodeSelector

### DIFF
--- a/cluster/addons/dns-horizontal-autoscaler/dns-horizontal-autoscaler.yaml
+++ b/cluster/addons/dns-horizontal-autoscaler/dns-horizontal-autoscaler.yaml
@@ -105,6 +105,4 @@ spec:
       tolerations:
       - key: "CriticalAddonsOnly"
         operator: "Exists"
-      nodeSelector:
-        kubernetes.io/os: linux
       serviceAccountName: kube-dns-autoscaler


### PR DESCRIPTION
Cherry pick of #94294 on release-1.18.

#94294: Remove duplicate nodeSelector

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.