### PR TITLE
fix staticcheck errors in resourcequota

### DIFF
--- a/hack/.staticcheck_failures
+++ b/hack/.staticcheck_failures
@@ -1,7 +1,6 @@
 cluster/images/etcd/migrate
 pkg/controller/podautoscaler
 pkg/controller/replicaset
-pkg/controller/resourcequota
 pkg/volume/azure_dd
 pkg/volume/testing
 test/e2e/autoscaling

--- a/pkg/controller/resourcequota/resource_quota_controller_test.go
+++ b/pkg/controller/resourcequota/resource_quota_controller_test.go
@@ -25,7 +25,7 @@ import (
 	"testing"
 	"time"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -807,7 +807,7 @@ func TestSyncResourceQuota(t *testing.T) {
 			}
 		}
 		if usage == nil {
-			t.Errorf("test: %s,\nExpected update action usage, got none: actions:\n%v", testName, actions)
+			t.Fatalf("test: %s,\nExpected update action usage, got none: actions:\n%v", testName, actions)
 		}
 
 		// ensure usage is as expected
@@ -1138,7 +1138,7 @@ func expectSyncNotBlocked(fakeDiscoveryClient *fakeServerResources, workerLock *
 	workerLockAcquired := make(chan struct{})
 	go func() {
 		workerLock.Lock()
-		workerLock.Unlock()
+		defer workerLock.Unlock()
 		close(workerLockAcquired)
 	}()
 	select {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**: 
fixes staticcheck errors in `pkg/controller/resourcequota`
```
pkg/controller/resourcequota/resource_quota_controller_test.go:814:16: possible nil pointer dereference (SA5011)
pkg/controller/resourcequota/resource_quota_controller_test.go:809:6: this check suggests that the pointer can be nil
pkg/controller/resourcequota/resource_quota_controller_test.go:817:16: possible nil pointer dereference (SA5011)
pkg/controller/resourcequota/resource_quota_controller_test.go:809:6: this check suggests that the pointer can be nil
pkg/controller/resourcequota/resource_quota_controller_test.go:1141:3: empty critical section (SA2001)
```

**Which issue(s) this PR fixes**:
Part of #92402 

**Special notes for your reviewer**:
There is another open PR related to this error, however it hasn't been updated in a while: https://github.com/kubernetes/kubernetes/pull/92414

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```

```