### PR TITLE
apiextensions: allow metadata description

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/validation.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/validation.go
@@ -160,6 +160,7 @@ func validateStructuralInvariants(s *Structural, lvl level, fldPath *field.Path)
 			metadata.Properties = nil
 		}
 		metadata.Type = ""
+		metadata.Description = ""
 		metadata.Default.Object = nil // this is checked in API validation (and also tested)
 		if metadata.ValueValidation == nil {
 			metadata.ValueValidation = &ValueValidation{}

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/validation_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/validation_test.go
@@ -1517,6 +1517,17 @@ properties:
 			expectedViolations: []string{},
 		},
 		{
+			desc: "metadata with description",
+			globalSchema: `
+type: object
+properties:
+ metadata:
+   description: 'Standard object metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+   type: object
+`,
+			expectedViolations: []string{},
+		},
+		{
 			desc: "metadata under junctors",
 			globalSchema: `
 type: object


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

When restricting any specification of metadata fields, the existing validation also restricts any description of the metadata itself, for which there doesn't seem to be any reason. While controller-tools has been updated to drop its metadata field specifications, it leaves any metadata description, which then causes validation to fail. The current workaround is to remove any documentation on Go struct metadata fields for custom resources, which is not ideal for users (e.g. [Prometheus](https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#prometheus)).

**Which issue(s) this PR fixes**:

N/A

Relates to https://github.com/kubernetes/kubernetes/issues/74620, https://github.com/kubernetes/kubernetes/pull/77653, https://github.com/kubernetes-sigs/controller-tools/issues/216, and https://github.com/kubernetes-sigs/controller-tools/pull/266

**Special notes for your reviewer**:

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs
- [KEP]: https://github.com/kubernetes/enhancements/blob/bb44066fbeaa571fb824c164742c37a289cbd608/keps/sig-api-machinery/20190425-structural-openapi.md
- [Other]: https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#specifying-a-structural-schema
```
