### PR TITLE
Allow deletion of unhealthy pods if enough healthy

### DIFF
--- a/pkg/registry/core/pod/storage/BUILD
+++ b/pkg/registry/core/pod/storage/BUILD
@@ -14,6 +14,7 @@ go_test(
     ],
     embed = [":go_default_library"],
     deps = [
+        "//pkg/api/pod:go_default_library",
         "//pkg/apis/core:go_default_library",
         "//pkg/apis/policy:go_default_library",
         "//pkg/registry/registrytest:go_default_library",


### PR DESCRIPTION
**What type of PR is this?**

/kind bug


**What this PR does / why we need it**:
Currently, if you have a PDB with 0 disruptions
available and you attempt to evict a non-healthy
pod, the eviction request will always fail.  This
is because the eviction API does not currently
take in to account that the pod you are removing
is the unhealthy one.

This commit accounts for trying to evict an
unhealthy pod as long as there are enough healthy
pods to satisfy the PDB's requirements.  To
protect against race conditions, a ResourceVersion
constraint is enforced.  This will ensure that
the target pod does not go healthy and allow
any race condition to occur which might disrupt
too many pods at once.

This commit also exports a public function
from the disruption controller to ensure we
always calculate pod health in the same manner
as PDBs.  This will help prevent regressions.


**Which issue(s) this PR fixes**:

Fixes #80389

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
yes

```release-note
Unhealthy pods covered by PDBs can be successfully evicted if enough healthy pods are available.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
