### PR TITLE
fix vendor/k8s.io/apimachinery/pkg/conversion staticcheck

### DIFF
--- a/hack/.staticcheck_failures
+++ b/hack/.staticcheck_failures
@@ -13,7 +13,6 @@ test/integration/ttlcontroller
 vendor/k8s.io/apimachinery/pkg/api/apitesting/roundtrip
 vendor/k8s.io/apimachinery/pkg/api/meta
 vendor/k8s.io/apimachinery/pkg/apis/meta/v1/validation
-vendor/k8s.io/apimachinery/pkg/conversion
 vendor/k8s.io/apimachinery/pkg/runtime
 vendor/k8s.io/apimachinery/pkg/runtime/serializer/json
 vendor/k8s.io/apimachinery/pkg/runtime/serializer/versioning

--- a/staging/src/k8s.io/apimachinery/pkg/conversion/BUILD
+++ b/staging/src/k8s.io/apimachinery/pkg/conversion/BUILD
@@ -13,7 +13,6 @@ go_test(
         "helper_test.go",
     ],
     embed = [":go_default_library"],
-    deps = ["//vendor/github.com/spf13/pflag:go_default_library"],
 )
 
 go_library(

--- a/staging/src/k8s.io/apimachinery/pkg/conversion/converter.go
+++ b/staging/src/k8s.io/apimachinery/pkg/conversion/converter.go
@@ -303,37 +303,6 @@ func (s *scope) errorf(message string, args ...interface{}) error {
 	return fmt.Errorf(where+message, args...)
 }
 
-// Verifies whether a conversion function has a correct signature.
-func verifyConversionFunctionSignature(ft reflect.Type) error {
-	if ft.Kind() != reflect.Func {
-		return fmt.Errorf("expected func, got: %v", ft)
-	}
-	if ft.NumIn() != 3 {
-		return fmt.Errorf("expected three 'in' params, got: %v", ft)
-	}
-	if ft.NumOut() != 1 {
-		return fmt.Errorf("expected one 'out' param, got: %v", ft)
-	}
-	if ft.In(0).Kind() != reflect.Ptr {
-		return fmt.Errorf("expected pointer arg for 'in' param 0, got: %v", ft)
-	}
-	if ft.In(1).Kind() != reflect.Ptr {
-		return fmt.Errorf("expected pointer arg for 'in' param 1, got: %v", ft)
-	}
-	scopeType := Scope(nil)
-	if e, a := reflect.TypeOf(&scopeType).Elem(), ft.In(2); e != a {
-		return fmt.Errorf("expected '%v' arg for 'in' param 2, got '%v' (%v)", e, a, ft)
-	}
-	var forErrorType error
-	// This convolution is necessary, otherwise TypeOf picks up on the fact
-	// that forErrorType is nil.
-	errorType := reflect.TypeOf(&forErrorType).Elem()
-	if ft.Out(0) != errorType {
-		return fmt.Errorf("expected error return, got: %v", ft)
-	}
-	return nil
-}
-
 // RegisterUntypedConversionFunc registers a function that converts between a and b by passing objects of those
 // types to the provided function. The function *must* accept objects of a and b - this machinery will not enforce
 // any other guarantee.
@@ -636,10 +605,6 @@ type kvValue interface {
 
 type stringMapAdaptor reflect.Value
 
-func (a stringMapAdaptor) len() int {
-	return reflect.Value(a).Len()
-}
-
 func (a stringMapAdaptor) keys() []string {
 	v := reflect.Value(a)
 	keys := make([]string, v.Len())
@@ -668,11 +633,6 @@ func (a stringMapAdaptor) confirmSet(key string, v reflect.Value) bool {
 }
 
 type structAdaptor reflect.Value
-
-func (a structAdaptor) len() int {
-	v := reflect.Value(a)
-	return v.Type().NumField()
-}
 
 func (a structAdaptor) keys() []string {
 	v := reflect.Value(a)

--- a/staging/src/k8s.io/apimachinery/pkg/conversion/converter_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/conversion/converter_test.go
@@ -21,11 +21,7 @@ import (
 	"reflect"
 	"strconv"
 	"testing"
-
-	flag "github.com/spf13/pflag"
 )
-
-var fuzzIters = flag.Int("fuzz-iters", 50, "How many fuzzing iterations to do.")
 
 func testLogger(t *testing.T) DebugLogger {
 	// We don't set logger to eliminate rubbish logs in tests.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
 -->
/kind cleanup
<!--
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:

Fixes `vendor/k8s.io/apimachinery/pkg/conversion` staticcheck errors:

```sh
vendor/k8s.io/apimachinery/pkg/conversion/converter.go:307:6: func verifyConversionFunctionSignature is unused (U1000)
vendor/k8s.io/apimachinery/pkg/conversion/converter.go:639:27: func stringMapAdaptor.len is unused (U1000)
vendor/k8s.io/apimachinery/pkg/conversion/converter.go:672:24: func structAdaptor.len is unused (U1000)
vendor/k8s.io/apimachinery/pkg/conversion/converter_test.go:28:5: var fuzzIters is unused (U1000)
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of #92402

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
