### PR TITLE
[WIP] Fix stuck StatefulSet rollover

### DIFF
--- a/test/e2e/framework/statefulset/fixtures.go
+++ b/test/e2e/framework/statefulset/fixtures.go
@@ -33,6 +33,38 @@ import (
 	imageutils "k8s.io/kubernetes/test/utils/image"
 )
 
+func NewSimpleStatefulSet(name string, replicas int32) *appsv1.StatefulSet {
+	labels := map[string]string{
+		"app": name,
+	}
+
+	return &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: labels,
+			},
+			Replicas: func(i int32) *int32 { return &i }(replicas),
+			Template: v1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: labels,
+				},
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Name:  "sleep",
+							Image: imageutils.GetE2EImage(imageutils.Pause),
+						},
+					},
+				},
+			},
+			UpdateStrategy: appsv1.StatefulSetUpdateStrategy{Type: appsv1.RollingUpdateStatefulSetStrategyType},
+		},
+	}
+}
+
 // NewStatefulSet creates a new Webserver StatefulSet for testing. The StatefulSet is named name, is in namespace ns,
 // statefulPodsMounts are the mounts that will be backed by PVs. podsMounts are the mounts that are mounted directly
 // to the Pod. labels are the labels that will be usd for the StatefulSet selector.


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
When you update the StatefulSet with a change that makes the new pod never go Ready (like ImagePullBackoff or bad probe), StatefulSet gets stuck waiting on the pod to be ready and even if you correct the change in the StatefulSet it will never rollout the corrected pod because it first waits on all pods to be ready.

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes/kubernetes/issues/78007
Fixes https://github.com/kubernetes/kubernetes/issues/67250

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
None
```

/sig apps