### PR TITLE
Always set relevant variables for cross compiling

### DIFF
--- a/hack/lib/golang.sh
+++ b/hack/lib/golang.sh
@@ -392,30 +392,36 @@ kube::golang::set_platform_envs() {
 
   export GOOS=${platform%/*}
   export GOARCH=${platform##*/}
-
-  # Do not set CC when building natively on a platform, only if cross-compiling from linux/amd64
-  if [[ $(kube::golang::host_platform) == "linux/amd64" ]]; then
-    # Dynamic CGO linking for other server architectures than linux/amd64 goes here
-    # If you want to include support for more server platforms than these, add arch-specific gcc names here
-    case "${platform}" in
-      "linux/arm")
-        export CGO_ENABLED=1
-        export CC=arm-linux-gnueabihf-gcc
-        ;;
-      "linux/arm64")
-        export CGO_ENABLED=1
-        export CC=aarch64-linux-gnu-gcc
-        ;;
-      "linux/ppc64le")
-        export CGO_ENABLED=1
-        export CC=powerpc64le-linux-gnu-gcc
-        ;;
-      "linux/s390x")
-        export CGO_ENABLED=1
-        export CC=s390x-linux-gnu-gcc
-        ;;
-    esac
+  # Apply standard values for CGO_ENABLED and CC unless KUBE_BUILD_PLATFORMS is set.
+  if [ -z "${KUBE_BUILD_PLATFORMS:-}" ] ; then
+      export CGO_ENABLED=0
+      export CC=gcc
+      return
   fi
+  # Dynamic CGO linking for other server architectures goes here
+  # If you want to include support for more server platforms than these, add arch-specific gcc names here
+  case "${platform}" in
+    "linux/amd64")
+      export CGO_ENABLED=1
+      export CC=${LINUX_AMD64_CC:-gcc}
+      ;;
+    "linux/arm")
+      export CGO_ENABLED=1
+      export CC=${LINUX_ARM_CC:-arm-linux-gnueabihf-gcc}
+      ;;
+    "linux/arm64")
+      export CGO_ENABLED=1
+      export CC=${LINUX_ARM64_CC:-aarch64-linux-gnu-gcc}
+      ;;
+    "linux/ppc64le")
+      export CGO_ENABLED=1
+      export CC=${LINUX_PPC64LE_CC:-powerpc64le-linux-gnu-gcc}
+      ;;
+    "linux/s390x")
+      export CGO_ENABLED=1
+      export CC=${LINUX_S390X_CC:-s390x-linux-gnu-gcc}
+      ;;
+  esac
 }
 
 kube::golang::unset_platform_envs() {

--- a/hack/lib/golang.sh
+++ b/hack/lib/golang.sh
@@ -392,36 +392,30 @@ kube::golang::set_platform_envs() {
 
   export GOOS=${platform%/*}
   export GOARCH=${platform##*/}
-  # Apply standard values for CGO_ENABLED and CC unless KUBE_BUILD_PLATFORMS is set.
-  if [ -z "${KUBE_BUILD_PLATFORMS:-}" ] ; then
-      export CGO_ENABLED=0
-      export CC=gcc
-      return
+
+  # Do not set CC when building natively on a platform, only if cross-compiling from linux/amd64
+  if [[ $(kube::golang::host_platform) == "linux/amd64" ]]; then
+    # Dynamic CGO linking for other server architectures than linux/amd64 goes here
+    # If you want to include support for more server platforms than these, add arch-specific gcc names here
+    case "${platform}" in
+      "linux/arm")
+        export CGO_ENABLED=1
+        export CC=${KUBE_LINUX_ARM_CC:-arm-linux-gnueabihf-gcc}
+        ;;
+      "linux/arm64")
+        export CGO_ENABLED=1
+        export CC=${KUBE_LINUX_ARM64_CC:-aarch64-linux-gnu-gcc}
+        ;;
+      "linux/ppc64le")
+        export CGO_ENABLED=1
+        export CC=${KUBE_LINUX_PPC64LE_CC:-powerpc64le-linux-gnu-gcc}
+        ;;
+      "linux/s390x")
+        export CGO_ENABLED=1
+        export CC=${KUBE_LINUX_S390X_CC:-s390x-linux-gnu-gcc}
+        ;;
+    esac
   fi
-  # Dynamic CGO linking for other server architectures goes here
-  # If you want to include support for more server platforms than these, add arch-specific gcc names here
-  case "${platform}" in
-    "linux/amd64")
-      export CGO_ENABLED=1
-      export CC=${LINUX_AMD64_CC:-gcc}
-      ;;
-    "linux/arm")
-      export CGO_ENABLED=1
-      export CC=${LINUX_ARM_CC:-arm-linux-gnueabihf-gcc}
-      ;;
-    "linux/arm64")
-      export CGO_ENABLED=1
-      export CC=${LINUX_ARM64_CC:-aarch64-linux-gnu-gcc}
-      ;;
-    "linux/ppc64le")
-      export CGO_ENABLED=1
-      export CC=${LINUX_PPC64LE_CC:-powerpc64le-linux-gnu-gcc}
-      ;;
-    "linux/s390x")
-      export CGO_ENABLED=1
-      export CC=${LINUX_S390X_CC:-s390x-linux-gnu-gcc}
-      ;;
-  esac
 }
 
 kube::golang::unset_platform_envs() {


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
1. Right now, there seems to be no way to override the platform specific cc flags that kubernetes sets. We should be able to override those values.
For example, bottlerocket sets customized CC flags for different platforms using this [patch](https://github.com/bottlerocket-os/bottlerocket/blob/41a72fe21400fa227543fcbed2e59eb0a8b633c1/packages/kubernetes-1.17/0001-always-set-relevant-variables-for-cross-compiling.patch). We should be able to override the default values in kubernetes using environment variables or build time flags and build kubernetes with customized gcc variants that bottlerocket uses. 
2. We want to be able to build kubernetes on host platforms other than amd64. For example, we may want to build amd64 targets on arm platforms. For that to happen, we need to remove the condition that checks if the build platform is amd64. If no platform is specified, we can use default values.

**Which issue(s) this PR fixes**:
Fixes #94291

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md


-->
```
```
**Release note**:
```release-note
Allow cross compilation of kubernetes on different platforms.
```

