### PR TITLE
Automated cherry pick of #94204: Add impersonated user to system:authenticated group

### DIFF
--- a/test/cmd/authorization.sh
+++ b/test/cmd/authorization.sh
@@ -71,8 +71,8 @@ run_impersonation_tests() {
 
     # --as-group
     kubectl create -f hack/testdata/csr.yml "${kube_flags_with_token[@]:?}" --as=user1 --as-group=group2 --as-group=group1 --as-group=,,,chameleon
-    kube::test::get_object_assert 'csr/foo' '{{len .spec.groups}}' '3'
-    kube::test::get_object_assert 'csr/foo' '{{range .spec.groups}}{{.}} {{end}}' 'group2 group1 ,,,chameleon '
+    kube::test::get_object_assert 'csr/foo' '{{len .spec.groups}}' '4'
+    kube::test::get_object_assert 'csr/foo' '{{range .spec.groups}}{{.}} {{end}}' 'group2 group1 ,,,chameleon system:authenticated '
     kubectl delete -f hack/testdata/csr.yml "${kube_flags_with_token[@]:?}"
   fi
 


### PR DESCRIPTION
Cherry pick of #94204 on release-1.18.

#94204: Add impersonated user to system:authenticated group

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
upon successful authorization check, an impersonated user is added to the system:authenticated group.
system:anonymous when impersonated is added to the system:unauthenticated group.
```
