### PR TITLE
WIP: debugger scheduler plugin

### DIFF
--- a/pkg/scheduler/algorithmprovider/BUILD
+++ b/pkg/scheduler/algorithmprovider/BUILD
@@ -13,6 +13,7 @@ go_library(
     deps = [
         "//pkg/features:go_default_library",
         "//pkg/scheduler/apis/config:go_default_library",
+        "//pkg/scheduler/framework/plugins/debugger:go_default_library",
         "//pkg/scheduler/framework/plugins/defaultbinder:go_default_library",
         "//pkg/scheduler/framework/plugins/defaultpreemption:go_default_library",
         "//pkg/scheduler/framework/plugins/imagelocality:go_default_library",

--- a/pkg/scheduler/algorithmprovider/registry.go
+++ b/pkg/scheduler/algorithmprovider/registry.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/features"
 	schedulerapi "k8s.io/kubernetes/pkg/scheduler/apis/config"
+	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/debugger"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/defaultbinder"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/defaultpreemption"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/imagelocality"
@@ -82,6 +83,7 @@ func getDefaultConfig() *schedulerapi.Plugins {
 				{Name: podtopologyspread.Name},
 				{Name: interpodaffinity.Name},
 				{Name: volumebinding.Name},
+				{Name: debugger.Name},
 			},
 		},
 		Filter: &schedulerapi.PluginSet{

--- a/pkg/scheduler/apis/config/testing/compatibility_test.go
+++ b/pkg/scheduler/apis/config/testing/compatibility_test.go
@@ -1384,6 +1384,7 @@ func TestAlgorithmProviderCompatibility(t *testing.T) {
 			{Name: "PodTopologySpread"},
 			{Name: "InterPodAffinity"},
 			{Name: "VolumeBinding"},
+			{Name: "Debugger"},
 		},
 		"FilterPlugin": {
 			{Name: "NodeUnschedulable"},
@@ -1454,6 +1455,7 @@ func TestAlgorithmProviderCompatibility(t *testing.T) {
 					{Name: "PodTopologySpread"},
 					{Name: "InterPodAffinity"},
 					{Name: "VolumeBinding"},
+					{Name: "Debugger"},
 				},
 				"FilterPlugin": {
 					{Name: "NodeUnschedulable"},
@@ -1544,6 +1546,7 @@ func TestPluginsConfigurationCompatibility(t *testing.T) {
 			{Name: "PodTopologySpread"},
 			{Name: "InterPodAffinity"},
 			{Name: "VolumeBinding"},
+			{Name: "Debugger"},
 		},
 		"FilterPlugin": {
 			{Name: "NodeUnschedulable"},
@@ -1741,6 +1744,7 @@ func TestPluginsConfigurationCompatibility(t *testing.T) {
 						{Name: "InterPodAffinity"},
 						{Name: "PodTopologySpread"},
 						{Name: "VolumeBinding"},
+						{Name: "Debugger"},
 					},
 				},
 				Filter: &config.PluginSet{
@@ -1827,6 +1831,7 @@ func TestPluginsConfigurationCompatibility(t *testing.T) {
 						{Name: "InterPodAffinity"},
 						{Name: "NodePorts"},
 						{Name: "NodeResourcesFit"},
+						{Name: "Debugger"},
 					},
 					Disabled: []config.Plugin{
 						{Name: "*"},
@@ -1891,6 +1896,7 @@ func TestPluginsConfigurationCompatibility(t *testing.T) {
 					{Name: "InterPodAffinity"},
 					{Name: "NodePorts"},
 					{Name: "NodeResourcesFit"},
+					{Name: "Debugger"},
 				},
 				"FilterPlugin": {
 					{Name: "InterPodAffinity"},

--- a/pkg/scheduler/framework/plugins/BUILD
+++ b/pkg/scheduler/framework/plugins/BUILD
@@ -10,6 +10,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/scheduler/apis/config:go_default_library",
+        "//pkg/scheduler/framework/plugins/debugger:go_default_library",
         "//pkg/scheduler/framework/plugins/defaultbinder:go_default_library",
         "//pkg/scheduler/framework/plugins/defaultpreemption:go_default_library",
         "//pkg/scheduler/framework/plugins/imagelocality:go_default_library",
@@ -47,6 +48,7 @@ filegroup(
     name = "all-srcs",
     srcs = [
         ":package-srcs",
+        "//pkg/scheduler/framework/plugins/debugger:all-srcs",
         "//pkg/scheduler/framework/plugins/defaultbinder:all-srcs",
         "//pkg/scheduler/framework/plugins/defaultpreemption:all-srcs",
         "//pkg/scheduler/framework/plugins/examples:all-srcs",

--- a/pkg/scheduler/framework/plugins/debugger/BUILD
+++ b/pkg/scheduler/framework/plugins/debugger/BUILD
@@ -1,0 +1,28 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["debugger.go"],
+    importpath = "k8s.io/kubernetes/pkg/scheduler/framework/plugins/debugger",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/scheduler/framework/v1alpha1:go_default_library",
+        "//staging/src/k8s.io/api/core/v1:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
+        "//vendor/k8s.io/klog/v2:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/pkg/scheduler/framework/plugins/debugger/debugger.go
+++ b/pkg/scheduler/framework/plugins/debugger/debugger.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package debugger
+
+import (
+	"context"
+	"fmt"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/klog/v2"
+	framework "k8s.io/kubernetes/pkg/scheduler/framework/v1alpha1"
+)
+
+// Debugger is a plugin that dumps node infos
+type Debugger struct {
+	handle framework.FrameworkHandle
+}
+
+var _ framework.PreFilterPlugin = &Debugger{}
+
+const (
+	// Name is the name of the plugin used in the plugin registry and configurations.
+	Name = "Debugger"
+
+	// ErrReason for node affinity/selector not matching.
+	ErrReason = "node(s) didn't match node selector"
+)
+
+// Name returns name of the plugin. It is used in logs, etc.
+func (pl *Debugger) Name() string {
+	return Name
+}
+
+func resourceListToString(resourceList v1.ResourceList) string {
+	var requested []string
+	for name, quantity := range resourceList {
+		requested = append(requested, fmt.Sprintf("%v=%v", name, quantity.String()))
+	}
+	return fmt.Sprintf("%v", requested)
+}
+
+func (pl *Debugger) PreFilter(ctx context.Context, state *framework.CycleState, pod *v1.Pod) *framework.Status {
+	// Dump the node cache with current resource consumption (e.g. cpu, memory, pods)
+	nodeInfos, err := pl.handle.SnapshotSharedLister().NodeInfos().List()
+	if err != nil {
+		return framework.NewStatus(framework.Error, "nodeInfos not found")
+	}
+	for _, nodeInfo := range nodeInfos {
+		node := nodeInfo.Node()
+		klog.InfoS(
+			"Dumping node infos",
+			"node", node.Name,
+			"requested", resourceListToString(nodeInfo.Requested.ResourceList()),
+		)
+	}
+	return nil
+}
+
+func (pl *Debugger) PreFilterExtensions() framework.PreFilterExtensions {
+	return nil
+}
+
+// New initializes a new plugin and returns it.
+func New(_ runtime.Object, h framework.FrameworkHandle) (framework.Plugin, error) {
+	return &Debugger{handle: h}, nil
+}

--- a/pkg/scheduler/framework/plugins/registry.go
+++ b/pkg/scheduler/framework/plugins/registry.go
@@ -17,6 +17,7 @@ limitations under the License.
 package plugins
 
 import (
+	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/debugger"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/defaultbinder"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/defaultpreemption"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/imagelocality"
@@ -73,5 +74,6 @@ func NewInTreeRegistry() runtime.Registry {
 		queuesort.Name:                             queuesort.New,
 		defaultbinder.Name:                         defaultbinder.New,
 		defaultpreemption.Name:                     defaultpreemption.New,
+		debugger.Name:                              debugger.New,
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

Exemplary output:

```
I0902 15:15:17.279872 2157873 scheduling_queue.go:812] About to try and schedule pod default/example
I0902 15:15:17.279908 2157873 scheduler.go:452] Attempting to schedule pod: default/example
I0902 15:15:17.280211 2157873 debugger.go:66] "Dumping node infos" node="ip-10-0-137-0.ec2.internal" requested="[ephemeral-storage=0 cpu=1694m memory=4909Mi pods=0]"
I0902 15:15:17.280277 2157873 debugger.go:66] "Dumping node infos" node="ip-10-0-156-201.ec2.internal" requested="[memory=3478Mi pods=0 ephemeral-storage=0 cpu=894m]"
I0902 15:15:17.280315 2157873 debugger.go:66] "Dumping node infos" node="ip-10-0-165-85.ec2.internal" requested="[cpu=562m memory=3476Mi pods=0 ephemeral-storage=0]"
I0902 15:15:17.280365 2157873 debugger.go:66] "Dumping node infos" node="ip-10-0-143-172.ec2.internal" requested="[cpu=627m memory=3462Mi pods=0 ephemeral-storage=0]"
I0902 15:15:17.280432 2157873 debugger.go:66] "Dumping node infos" node="ip-10-0-157-248.ec2.internal" requested="[cpu=1894m memory=5849Mi pods=0 ephemeral-storage=0]"
I0902 15:15:17.280489 2157873 debugger.go:66] "Dumping node infos" node="ip-10-0-168-41.ec2.internal" requested="[cpu=1911m memory=5459Mi pods=0 ephemeral-storage=0]"
I0902 15:15:17.282140 2157873 default_binder.go:51] Attempting to bind default/example to ip-10-0-143-172.ec2.internal
I0902 15:15:17.483962 2157873 cache.go:371] Finished binding for pod efa4a7d4-1393-41dd-a063-e8cc6bb8d6de. Can be expired.
```

**Which issue(s) this PR fixes**:
Fixes #94192

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
New debugger scheduler plugin for dumping state of the kube-scheduler (disabled by default) 
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
