### PR TITLE
Automated cherry pick of #92878: cleanup: print warning message only if the function does not finish within 30 seconds

### DIFF
--- a/pkg/volume/volume_linux.go
+++ b/pkg/volume/volume_linux.go
@@ -23,6 +23,7 @@ import (
 	"syscall"
 
 	"os"
+	"time"
 
 	"k8s.io/klog"
 )
@@ -42,7 +43,10 @@ func SetVolumeOwnership(mounter Mounter, fsGroup *int64) error {
 		return nil
 	}
 
-	klog.Warningf("Setting volume ownership for %s and fsGroup set. If the volume has a lot of files then setting volume ownership could be slow, see https://github.com/kubernetes/kubernetes/issues/69699", mounter.GetPath())
+	timer := time.AfterFunc(30*time.Second, func() {
+		klog.Warningf("Setting volume ownership for %s and fsGroup set. If the volume has a lot of files then setting volume ownership could be slow, see https://github.com/kubernetes/kubernetes/issues/69699", mounter.GetPath())
+	})
+	defer timer.Stop()
 
 	return filepath.Walk(mounter.GetPath(), func(path string, info os.FileInfo, err error) error {
 		if err != nil {

--- a/pkg/volume/volume_linux.go
+++ b/pkg/volume/volume_linux.go
@@ -42,7 +42,7 @@ func SetVolumeOwnership(mounter Mounter, fsGroup *int64) error {
 		return nil
 	}
 
-	klog.Warningf("Setting volume ownership for %s and fsGroup set. If the volume has a lot of files then setting volume ownership could be slow, see https://github.com/kubernetes/kubernetes/issues/69699", mounter.GetPath())
+	klog.V(3).Infof("Setting volume ownership for %s and fsGroup set. If the volume has a lot of files then setting volume ownership could be slow, see https://github.com/kubernetes/kubernetes/issues/69699", mounter.GetPath())
 
 	return filepath.Walk(mounter.GetPath(), func(path string, info os.FileInfo, err error) error {
 		if err != nil {

--- a/pkg/volume/volume_linux.go
+++ b/pkg/volume/volume_linux.go
@@ -42,7 +42,7 @@ func SetVolumeOwnership(mounter Mounter, fsGroup *int64) error {
 		return nil
 	}
 
-	klog.V(3).Infof("Setting volume ownership for %s and fsGroup set. If the volume has a lot of files then setting volume ownership could be slow, see https://github.com/kubernetes/kubernetes/issues/69699", mounter.GetPath())
+	klog.Warningf("Setting volume ownership for %s and fsGroup set. If the volume has a lot of files then setting volume ownership could be slow, see https://github.com/kubernetes/kubernetes/issues/69699", mounter.GetPath())
 
 	return filepath.Walk(mounter.GetPath(), func(path string, info os.FileInfo, err error) error {
 		if err != nil {


### PR DESCRIPTION
Cherry pick of #92878 on release-1.17.

#92878: cleanup: decrease log level from warn to v3

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.