### PR TITLE
Automated cherry pick of #90897: Append suffix 'i' only if needed

### DIFF
--- a/pkg/volume/emptydir/empty_dir_linux.go
+++ b/pkg/volume/emptydir/empty_dir_linux.go
@@ -69,7 +69,11 @@ func getPageSize(path string, mounter mount.Interface) (*resource.Quantity, erro
 			// NOTE: Adding suffix 'i' as result should be comparable with a medium size.
 			// pagesize mount option is specified without a suffix,
 			// e.g. pagesize=2M or pagesize=1024M for x86 CPUs
-			pageSize, err := resource.ParseQuantity(strings.TrimPrefix(opt, prefix) + "i")
+			trimmedOpt := strings.TrimPrefix(opt, prefix)
+			if !strings.HasSuffix(trimmedOpt, "i") {
+				trimmedOpt = trimmedOpt + "i"
+			}
+			pageSize, err := resource.ParseQuantity(trimmedOpt)
 			if err != nil {
 				return nil, fmt.Errorf("error getting page size from '%s' mount option: %v", opt, err)
 			}

--- a/pkg/volume/emptydir/empty_dir_test.go
+++ b/pkg/volume/emptydir/empty_dir_test.go
@@ -837,6 +837,12 @@ func TestGetPageSize(t *testing.T) {
 				Opts:   []string{"rw", "relatime", "pagesize=2M"},
 			},
 			{
+				Device: "/dev/hugepages",
+				Type:   "hugetlbfs",
+				Path:   "/mnt/hugepages-2Mi",
+				Opts:   []string{"rw", "relatime", "pagesize=2Mi"},
+			},
+			{
 				Device: "sysfs",
 				Type:   "sysfs",
 				Path:   "/sys",


### PR DESCRIPTION
Cherry pick of #90897 on release-1.18.

#90897: Append suffix 'i' only if needed

Fixes: #90851 

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.