### PR TITLE
Add support to size memory backed volumes

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -657,6 +657,12 @@ const (
 	//
 	// Enable Terminating condition in Endpoint Slices.
 	EndpointSliceTerminatingCondition featuregate.Feature = "EndpointSliceTerminatingCondition"
+
+	// owner: @derekwaynecarr
+	// alpha: v1.20
+	//
+	// Enables kubelet support to size memory backed volumes
+	SizeMemoryBackedVolumes featuregate.Feature = "SizeMemoryBackedVolumes"
 )
 
 func init() {
@@ -756,6 +762,7 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 	DisableAcceleratorUsageMetrics:                 {Default: true, PreRelease: featuregate.Beta},
 	HPAContainerMetrics:                            {Default: false, PreRelease: featuregate.Alpha},
 	RootCAConfigMap:                                {Default: true, PreRelease: featuregate.Beta},
+	SizeMemoryBackedVolumes:                        {Default: false, PreRelease: featuregate.Alpha},
 
 	// inherited features from generic apiserver, relisted here to get a conflict if it is changed
 	// unintentionally on either side:

--- a/pkg/volume/emptydir/BUILD
+++ b/pkg/volume/emptydir/BUILD
@@ -17,6 +17,8 @@ go_library(
     importpath = "k8s.io/kubernetes/pkg/volume/emptydir",
     deps = [
         "//pkg/apis/core/v1/helper:go_default_library",
+        "//pkg/features:go_default_library",
+        "//pkg/kubelet/cm:go_default_library",
         "//pkg/volume:go_default_library",
         "//pkg/volume/util:go_default_library",
         "//pkg/volume/util/fsquota:go_default_library",
@@ -24,6 +26,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/api/resource:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
+        "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",
         "//staging/src/k8s.io/mount-utils:go_default_library",
         "//vendor/k8s.io/klog/v2:go_default_library",
         "//vendor/k8s.io/utils/strings:go_default_library",

--- a/pkg/volume/emptydir/empty_dir_test.go
+++ b/pkg/volume/emptydir/empty_dir_test.go
@@ -25,7 +25,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -914,6 +914,112 @@ func TestGetPageSize(t *testing.T) {
 			}
 			if err == nil && pageSize.Cmp(testCase.expectedResult) != 0 {
 				t.Errorf("%s: Unexpected result: %s, expected: %s", testCaseName, pageSize.String(), testCase.expectedResult.String())
+			}
+		})
+	}
+}
+
+func TestCalculateEmptyDirMemorySize(t *testing.T) {
+	testCases := map[string]struct {
+		pod                   *v1.Pod
+		nodeAllocatableMemory resource.Quantity
+		emptyDirSizeLimit     resource.Quantity
+		expectedResult        resource.Quantity
+		featureGateEnabled    bool
+	}{
+		"SizeMemoryBackedVolumesDisabled": {
+			pod: &v1.Pod{
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Resources: v1.ResourceRequirements{
+								Requests: v1.ResourceList{
+									v1.ResourceName("memory"): resource.MustParse("10Gi"),
+								},
+							},
+						},
+					},
+				},
+			},
+			nodeAllocatableMemory: resource.MustParse("16Gi"),
+			emptyDirSizeLimit:     resource.MustParse("1Gi"),
+			expectedResult:        resource.MustParse("0"),
+			featureGateEnabled:    false,
+		},
+		"EmptyDirLocalLimit": {
+			pod: &v1.Pod{
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Resources: v1.ResourceRequirements{
+								Limits: v1.ResourceList{
+									v1.ResourceName("memory"): resource.MustParse("10Gi"),
+								},
+							},
+						},
+					},
+				},
+			},
+			nodeAllocatableMemory: resource.MustParse("16Gi"),
+			emptyDirSizeLimit:     resource.MustParse("1Gi"),
+			expectedResult:        resource.MustParse("1Gi"),
+			featureGateEnabled:    true,
+		},
+		"PodLocalLimit": {
+			pod: &v1.Pod{
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Resources: v1.ResourceRequirements{
+								Limits: v1.ResourceList{
+									v1.ResourceName("memory"): resource.MustParse("10Gi"),
+								},
+							},
+						},
+					},
+				},
+			},
+			nodeAllocatableMemory: resource.MustParse("16Gi"),
+			emptyDirSizeLimit:     resource.MustParse("0"),
+			expectedResult:        resource.MustParse("10Gi"),
+			featureGateEnabled:    true,
+		},
+		"NodeAllocatableLimit": {
+			pod: &v1.Pod{
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Resources: v1.ResourceRequirements{
+								Requests: v1.ResourceList{
+									v1.ResourceName("memory"): resource.MustParse("10Gi"),
+								},
+							},
+						},
+					},
+				},
+			},
+			nodeAllocatableMemory: resource.MustParse("16Gi"),
+			emptyDirSizeLimit:     resource.MustParse("0"),
+			expectedResult:        resource.MustParse("16Gi"),
+			featureGateEnabled:    true,
+		},
+	}
+
+	for testCaseName, testCase := range testCases {
+		t.Run(testCaseName, func(t *testing.T) {
+			defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.SizeMemoryBackedVolumes, testCase.featureGateEnabled)()
+			spec := &volume.Spec{
+				Volume: &v1.Volume{
+					VolumeSource: v1.VolumeSource{
+						EmptyDir: &v1.EmptyDirVolumeSource{
+							Medium:    v1.StorageMediumMemory,
+							SizeLimit: &testCase.emptyDirSizeLimit,
+						},
+					},
+				}}
+			result := calculateEmptyDirMemorySize(&testCase.nodeAllocatableMemory, spec, testCase.pod)
+			if result.Cmp(testCase.expectedResult) != 0 {
+				t.Errorf("%s: Unexpected result.  Expected %v, got %v", testCaseName, testCase.expectedResult.String(), result.String())
 			}
 		})
 	}

--- a/test/e2e/common/BUILD
+++ b/test/e2e/common/BUILD
@@ -45,6 +45,7 @@ go_library(
     deps = [
         "//pkg/api/v1/pod:go_default_library",
         "//pkg/client/conditions:go_default_library",
+        "//pkg/features:go_default_library",
         "//pkg/kubelet:go_default_library",
         "//pkg/kubelet/events:go_default_library",
         "//pkg/kubelet/images:go_default_library",
@@ -66,6 +67,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/util/uuid:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/watch:go_default_library",
+        "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes:go_default_library",
         "//staging/src/k8s.io/client-go/tools/cache:go_default_library",
         "//staging/src/k8s.io/client-go/tools/watch:go_default_library",

--- a/test/e2e/common/empty_dir.go
+++ b/test/e2e/common/empty_dir.go
@@ -17,14 +17,19 @@ limitations under the License.
 package common
 
 import (
+	"context"
 	"fmt"
 	"path"
 
 	"github.com/onsi/ginkgo"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/uuid"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/test/e2e/framework"
+	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
 	imageutils "k8s.io/kubernetes/test/utils/image"
 )
@@ -282,6 +287,78 @@ var _ = ginkgo.Describe("[sig-storage] EmptyDir volumes", func() {
 		ginkgo.By("Reading file content from the nginx-container")
 		result := f.ExecShellInContainer(pod.Name, busyBoxMainContainerName, fmt.Sprintf("cat %s", busyBoxMainVolumeFilePath))
 		framework.ExpectEqual(result, message, "failed to match expected string %s with %s", message, resultString)
+	})
+
+	/*
+		Release: v1.20
+		Testname: EmptyDir, Memory backed volume is sized to specified limit
+		Description: A Pod created with an 'emptyDir' Volume backed by memory should be sized to user provided value.
+	*/
+	ginkgo.It("pod should support memory backed volumes of specified size", func() {
+		// skip if feature gate is not enabled, this could be elevated to conformance in future if on Linux.
+		if !utilfeature.DefaultFeatureGate.Enabled(features.SizeMemoryBackedVolumes) {
+			return
+		}
+
+		var (
+			volumeName                 = "shared-data"
+			busyBoxMainVolumeMountPath = "/usr/share/volumeshare"
+			busyBoxMainContainerName   = "busybox-main-container"
+			expectedResult             = "10240" // equal to 10Mi
+			deletionGracePeriod        = int64(0)
+			sizeLimit                  = resource.MustParse("10Mi")
+		)
+
+		pod := &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "pod-size-memory-volume-" + string(uuid.NewUUID()),
+			},
+			Spec: v1.PodSpec{
+				Volumes: []v1.Volume{
+					{
+						Name: volumeName,
+						VolumeSource: v1.VolumeSource{
+							EmptyDir: &v1.EmptyDirVolumeSource{
+								Medium:    v1.StorageMediumMemory,
+								SizeLimit: &sizeLimit,
+							},
+						},
+					},
+				},
+				Containers: []v1.Container{
+					{
+						Name:    busyBoxMainContainerName,
+						Image:   imageutils.GetE2EImage(imageutils.BusyBox),
+						Command: []string{"/bin/sh"},
+						Args:    []string{"-c", "sleep 100000"},
+						VolumeMounts: []v1.VolumeMount{
+							{
+								Name:      volumeName,
+								MountPath: busyBoxMainVolumeMountPath,
+							},
+						},
+					},
+				},
+				TerminationGracePeriodSeconds: &deletionGracePeriod,
+				RestartPolicy:                 v1.RestartPolicyNever,
+			},
+		}
+
+		var err error
+		ginkgo.By("Creating Pod")
+		pod = f.PodClient().CreateSync(pod)
+
+		ginkgo.By("Waiting for the pod running")
+		err = e2epod.WaitForPodNameRunningInNamespace(f.ClientSet, pod.Name, f.Namespace.Name)
+		framework.ExpectNoError(err, "failed to deploy pod %s", pod.Name)
+
+		ginkgo.By("Getting the pod")
+		pod, err = f.PodClient().Get(context.TODO(), pod.Name, metav1.GetOptions{})
+		framework.ExpectNoError(err, "failed to get pod %s", pod.Name)
+
+		ginkgo.By("Reading empty dir size")
+		result := f.ExecShellInContainer(pod.Name, busyBoxMainContainerName, fmt.Sprintf("df | grep %s | awk '{print $2}'", busyBoxMainVolumeMountPath))
+		framework.ExpectEqual(result, expectedResult, "failed to match expected string %s with %s", expectedResult, result)
 	})
 })
 


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Size memory backed emptyDir volumes as the min of memory available to pod and local emptyDir sizeLimit.  This is important for applications that want more reliable emptyDir sizing than 50% of node memory (which is Linux default) when or if their applications run on variety of node sources.

**Does this PR introduce a user-facing change?**:
```release-note
Add feature to size memory backed volumes
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs
- [KEP]: https://github.com/kubernetes/enhancements/pull/1968
```
