### PR TITLE
remove --verbose_failures from .bazelrc

### DIFF
--- a/build/root/.bazelrc
+++ b/build/root/.bazelrc
@@ -6,7 +6,6 @@ startup --expand_configs_in_place
 build --host_force_python=PY2
 
 # Show us information about failures.
-build --verbose_failures
 test --test_output=errors
 
 # Include git version info


### PR DESCRIPTION
This was added a long time ago, and it makes build failure output in CI terrible.

### Before

<details>

ERROR: /usr/local/google/home/mikedanese/go/src/k8s.io/kubernetes/test/integration/auth/BUILD:8:1: GoCompilePkg test/integration/auth/linux_amd64_stripped/go_default_test%/test/integration/auth/go_default_test.a failed (Exit 1): builder failed: error executing command 
  (cd /usr/local/google/home/mikedanese/.cache/bazel/_bazel_mikedanese/6c65a147ac17188f348dcacc7c554ab3/sandbox/linux-sandbox/3373/execroot/io_k8s_kubernetes && \
  exec env - \
    CGO_ENABLED=1 \
    GOARCH=amd64 \
    GOOS=linux \
    GOPATH='' \
    GOROOT=external/go_sdk \
    GOROOT_FINAL=GOROOT \
    PATH=/usr/bin:/bin \
  bazel-out/host/bin/external/go_sdk/builder compilepkg -sdk external/go_sdk -installsuffix linux_amd64 -tags selinux -src test/integration/auth/accessreview_test.go -src test/integration/auth/auth_test.go -src test/integration/auth/bootstraptoken_test.go -src test/integration/auth/dynamic_client_test.go -src test/integration/auth/main_test.go -src test/integration/auth/node_test.go -src test/integration/auth/rbac_test.go -src test/integration/auth/svcaccttoken_test.go -arc 'k8s.io/kubernetes/cmd/kube-apiserver/app/options=k8s.io/kubernetes/cmd/kube-apiserver/app/options=bazel-out/k8-fastbuild/bin/cmd/kube-apiserver/app/options/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/cmd/kube-apiserver/app/options.a=' -arc 'k8s.io/kubernetes/cmd/kube-apiserver/app/testing=k8s.io/kubernetes/cmd/kube-apiserver/app/testing=bazel-out/k8-fastbuild/bin/cmd/kube-apiserver/app/testing/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/cmd/kube-apiserver/app/testing.a=' -arc 'k8s.io/kubernetes/pkg/api/legacyscheme=k8s.io/kubernetes/pkg/api/legacyscheme=bazel-out/k8-fastbuild/bin/pkg/api/legacyscheme/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/pkg/api/legacyscheme.a=' -arc 'k8s.io/kubernetes/pkg/apis/autoscaling=k8s.io/kubernetes/pkg/apis/autoscaling=bazel-out/k8-fastbuild/bin/pkg/apis/autoscaling/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/pkg/apis/autoscaling.a=' -arc 'k8s.io/kubernetes/pkg/apis/core=k8s.io/kubernetes/pkg/apis/core=bazel-out/k8-fastbuild/bin/pkg/apis/core/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/pkg/apis/core.a=' -arc 'k8s.io/kubernetes/pkg/apis/extensions=k8s.io/kubernetes/pkg/apis/extensions=bazel-out/k8-fastbuild/bin/pkg/apis/extensions/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/pkg/apis/extensions.a=' -arc 'k8s.io/kubernetes/pkg/apis/rbac/v1=k8s.io/kubernetes/pkg/apis/rbac/v1=bazel-out/k8-fastbuild/bin/pkg/apis/rbac/v1/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/pkg/apis/rbac/v1.a=' -arc 'k8s.io/kubernetes/pkg/auth/authorizer/abac=k8s.io/kubernetes/pkg/auth/authorizer/abac=bazel-out/k8-fastbuild/bin/pkg/auth/authorizer/abac/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/pkg/auth/authorizer/abac.a=' -arc 'k8s.io/kubernetes/pkg/controller=k8s.io/kubernetes/pkg/controller=bazel-out/k8-fastbuild/bin/pkg/controller/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/pkg/controller.a=' -arc 'k8s.io/kubernetes/pkg/controller/serviceaccount=k8s.io/kubernetes/pkg/controller/serviceaccount=bazel-out/k8-fastbuild/bin/pkg/controller/serviceaccount/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/pkg/controller/serviceaccount.a=' -arc 'k8s.io/kubernetes/pkg/features=k8s.io/kubernetes/pkg/features=bazel-out/k8-fastbuild/bin/pkg/features/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/pkg/features.a=' -arc 'k8s.io/kubernetes/pkg/kubeapiserver/options=k8s.io/kubernetes/pkg/kubeapiserver/options=bazel-out/k8-fastbuild/bin/pkg/kubeapiserver/options/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/pkg/kubeapiserver/options.a=' -arc 'k8s.io/kubernetes/pkg/master=k8s.io/kubernetes/pkg/master=bazel-out/k8-fastbuild/bin/pkg/master/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/pkg/master.a=' -arc 'k8s.io/kubernetes/pkg/registry/rbac/clusterrole=k8s.io/kubernetes/pkg/registry/rbac/clusterrole=bazel-out/k8-fastbuild/bin/pkg/registry/rbac/clusterrole/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/pkg/registry/rbac/clusterrole.a=' -arc 'k8s.io/kubernetes/pkg/registry/rbac/clusterrole/storage=k8s.io/kubernetes/pkg/registry/rbac/clusterrole/storage=bazel-out/k8-fastbuild/bin/pkg/registry/rbac/clusterrole/storage/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/pkg/registry/rbac/clusterrole/storage.a=' -arc 'k8s.io/kubernetes/pkg/registry/rbac/clusterrolebinding=k8s.io/kubernetes/pkg/registry/rbac/clusterrolebinding=bazel-out/k8-fastbuild/bin/pkg/registry/rbac/clusterrolebinding/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/pkg/registry/rbac/clusterrolebinding.a=' -arc 'k8s.io/kubernetes/pkg/registry/rbac/clusterrolebinding/storage=k8s.io/kubernetes/pkg/registry/rbac/clusterrolebinding/storage=bazel-out/k8-fastbuild/bin/pkg/registry/rbac/clusterrolebinding/storage/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/pkg/registry/rbac/clusterrolebinding/storage.a=' -arc 'k8s.io/kubernetes/pkg/registry/rbac/role=k8s.io/kubernetes/pkg/registry/rbac/role=bazel-out/k8-fastbuild/bin/pkg/registry/rbac/role/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/pkg/registry/rbac/role.a=' -arc 'k8s.io/kubernetes/pkg/registry/rbac/role/storage=k8s.io/kubernetes/pkg/registry/rbac/role/storage=bazel-out/k8-fastbuild/bin/pkg/registry/rbac/role/storage/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/pkg/registry/rbac/role/storage.a=' -arc 'k8s.io/kubernetes/pkg/registry/rbac/rolebinding=k8s.io/kubernetes/pkg/registry/rbac/rolebinding=bazel-out/k8-fastbuild/bin/pkg/registry/rbac/rolebinding/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/pkg/registry/rbac/rolebinding.a=' -arc 'k8s.io/kubernetes/pkg/registry/rbac/rolebinding/storage=k8s.io/kubernetes/pkg/registry/rbac/rolebinding/storage=bazel-out/k8-fastbuild/bin/pkg/registry/rbac/rolebinding/storage/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/pkg/registry/rbac/rolebinding/storage.a=' -arc 'k8s.io/kubernetes/pkg/serviceaccount=k8s.io/kubernetes/pkg/serviceaccount=bazel-out/k8-fastbuild/bin/pkg/serviceaccount/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/pkg/serviceaccount.a=' -arc 'k8s.io/kubernetes/plugin/pkg/auth/authenticator/token/bootstrap=k8s.io/kubernetes/plugin/pkg/auth/authenticator/token/bootstrap=bazel-out/k8-fastbuild/bin/plugin/pkg/auth/authenticator/token/bootstrap/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/plugin/pkg/auth/authenticator/token/bootstrap.a=' -arc 'k8s.io/kubernetes/plugin/pkg/auth/authorizer/rbac=k8s.io/kubernetes/plugin/pkg/auth/authorizer/rbac=bazel-out/k8-fastbuild/bin/plugin/pkg/auth/authorizer/rbac/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/plugin/pkg/auth/authorizer/rbac.a=' -arc 'k8s.io/api/authentication/v1=k8s.io/kubernetes/vendor/k8s.io/api/authentication/v1=bazel-out/k8-fastbuild/bin/staging/src/k8s.io/api/authentication/v1/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/vendor/k8s.io/api/authentication/v1.a=' -arc 'k8s.io/api/authentication/v1beta1=k8s.io/kubernetes/vendor/k8s.io/api/authentication/v1beta1=bazel-out/k8-fastbuild/bin/staging/src/k8s.io/api/authentication/v1beta1/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/vendor/k8s.io/api/authentication/v1beta1.a=' -arc 'k8s.io/api/authorization/v1=k8s.io/kubernetes/vendor/k8s.io/api/authorization/v1=bazel-out/k8-fastbuild/bin/staging/src/k8s.io/api/authorization/v1/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/vendor/k8s.io/api/authorization/v1.a=' -arc 'k8s.io/api/coordination/v1=k8s.io/kubernetes/vendor/k8s.io/api/coordination/v1=bazel-out/k8-fastbuild/bin/staging/src/k8s.io/api/coordination/v1/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/vendor/k8s.io/api/coordination/v1.a=' -arc 'k8s.io/api/core/v1=k8s.io/kubernetes/vendor/k8s.io/api/core/v1=bazel-out/k8-fastbuild/bin/staging/src/k8s.io/api/core/v1/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/vendor/k8s.io/api/core/v1.a=' -arc 'k8s.io/api/policy/v1beta1=k8s.io/kubernetes/vendor/k8s.io/api/policy/v1beta1=bazel-out/k8-fastbuild/bin/staging/src/k8s.io/api/policy/v1beta1/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/vendor/k8s.io/api/policy/v1beta1.a=' -arc 'k8s.io/api/rbac/v1=k8s.io/kubernetes/vendor/k8s.io/api/rbac/v1=bazel-out/k8-fastbuild/bin/staging/src/k8s.io/api/rbac/v1/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/vendor/k8s.io/api/rbac/v1.a=' -arc 'k8s.io/api/storage/v1=k8s.io/kubernetes/vendor/k8s.io/api/storage/v1=bazel-out/k8-fastbuild/bin/staging/src/k8s.io/api/storage/v1/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/vendor/k8s.io/api/storage/v1.a=' -arc 'k8s.io/apimachinery/pkg/api/errors=k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/api/errors=bazel-out/k8-fastbuild/bin/staging/src/k8s.io/apimachinery/pkg/api/errors/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/api/errors.a=' -arc 'k8s.io/apimachinery/pkg/api/resource=k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/api/resource=bazel-out/k8-fastbuild/bin/staging/src/k8s.io/apimachinery/pkg/api/resource/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/api/resource.a=' -arc 'k8s.io/apimachinery/pkg/apis/meta/v1=k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/apis/meta/v1=bazel-out/k8-fastbuild/bin/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/apis/meta/v1.a=' -arc 'k8s.io/apimachinery/pkg/labels=k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/labels=bazel-out/k8-fastbuild/bin/staging/src/k8s.io/apimachinery/pkg/labels/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/labels.a=' -arc 'k8s.io/apimachinery/pkg/runtime/schema=k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/runtime/schema=bazel-out/k8-fastbuild/bin/staging/src/k8s.io/apimachinery/pkg/runtime/schema/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/runtime/schema.a=' -arc 'k8s.io/apimachinery/pkg/types=k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/types=bazel-out/k8-fastbuild/bin/staging/src/k8s.io/apimachinery/pkg/types/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/types.a=' -arc 'k8s.io/apimachinery/pkg/util/net=k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/net=bazel-out/k8-fastbuild/bin/staging/src/k8s.io/apimachinery/pkg/util/net/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/net.a=' -arc 'k8s.io/apimachinery/pkg/util/wait=k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/wait=bazel-out/k8-fastbuild/bin/staging/src/k8s.io/apimachinery/pkg/util/wait/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/wait.a=' -arc 'k8s.io/apimachinery/pkg/watch=k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/watch=bazel-out/k8-fastbuild/bin/staging/src/k8s.io/apimachinery/pkg/watch/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/watch.a=' -arc 'k8s.io/apiserver/pkg/authentication/authenticator=k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/authentication/authenticator=bazel-out/k8-fastbuild/bin/staging/src/k8s.io/apiserver/pkg/authentication/authenticator/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/authentication/authenticator.a=' -arc 'k8s.io/apiserver/pkg/authentication/group=k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/authentication/group=bazel-out/k8-fastbuild/bin/staging/src/k8s.io/apiserver/pkg/authentication/group/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/authentication/group.a=' -arc 'k8s.io/apiserver/pkg/authentication/request/bearertoken=k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/authentication/request/bearertoken=bazel-out/k8-fastbuild/bin/staging/src/k8s.io/apiserver/pkg/authentication/request/bearertoken/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/authentication/request/bearertoken.a=' -arc 'k8s.io/apiserver/pkg/authentication/serviceaccount=k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/authentication/serviceaccount=bazel-out/k8-fastbuild/bin/staging/src/k8s.io/apiserver/pkg/authentication/serviceaccount/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/authentication/serviceaccount.a=' -arc 'k8s.io/apiserver/pkg/authentication/token/cache=k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/authentication/token/cache=bazel-out/k8-fastbuild/bin/staging/src/k8s.io/apiserver/pkg/authentication/token/cache/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/authentication/token/cache.a=' -arc 'k8s.io/apiserver/pkg/authentication/token/tokenfile=k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/authentication/token/tokenfile=bazel-out/k8-fastbuild/bin/staging/src/k8s.io/apiserver/pkg/authentication/token/tokenfile/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/authentication/token/tokenfile.a=' -arc 'k8s.io/apiserver/pkg/authentication/user=k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/authentication/user=bazel-out/k8-fastbuild/bin/staging/src/k8s.io/apiserver/pkg/authentication/user/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/authentication/user.a=' -arc 'k8s.io/apiserver/pkg/authorization/authorizer=k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/authorization/authorizer=bazel-out/k8-fastbuild/bin/staging/src/k8s.io/apiserver/pkg/authorization/authorizer/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/authorization/authorizer.a=' -arc 'k8s.io/apiserver/pkg/authorization/authorizerfactory=k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/authorization/authorizerfactory=bazel-out/k8-fastbuild/bin/staging/src/k8s.io/apiserver/pkg/authorization/authorizerfactory/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/authorization/authorizerfactory.a=' -arc 'k8s.io/apiserver/pkg/features=k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/features=bazel-out/k8-fastbuild/bin/staging/src/k8s.io/apiserver/pkg/features/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/features.a=' -arc 'k8s.io/apiserver/pkg/registry/generic=k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/registry/generic=bazel-out/k8-fastbuild/bin/staging/src/k8s.io/apiserver/pkg/registry/generic/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/registry/generic.a=' -arc 'k8s.io/apiserver/pkg/util/feature=k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/util/feature=bazel-out/k8-fastbuild/bin/staging/src/k8s.io/apiserver/pkg/util/feature/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/util/feature.a=' -arc 'k8s.io/apiserver/plugin/pkg/authenticator/token/tokentest=k8s.io/kubernetes/vendor/k8s.io/apiserver/plugin/pkg/authenticator/token/tokentest=bazel-out/k8-fastbuild/bin/staging/src/k8s.io/apiserver/plugin/pkg/authenticator/token/tokentest/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/vendor/k8s.io/apiserver/plugin/pkg/authenticator/token/tokentest.a=' -arc 'k8s.io/apiserver/plugin/pkg/authenticator/token/webhook=k8s.io/kubernetes/vendor/k8s.io/apiserver/plugin/pkg/authenticator/token/webhook=bazel-out/k8-fastbuild/bin/staging/src/k8s.io/apiserver/plugin/pkg/authenticator/token/webhook/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/vendor/k8s.io/apiserver/plugin/pkg/authenticator/token/webhook.a=' -arc 'k8s.io/client-go/kubernetes=k8s.io/kubernetes/vendor/k8s.io/client-go/kubernetes=bazel-out/k8-fastbuild/bin/staging/src/k8s.io/client-go/kubernetes/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/vendor/k8s.io/client-go/kubernetes.a=' -arc 'k8s.io/client-go/listers/core/v1=k8s.io/kubernetes/vendor/k8s.io/client-go/listers/core/v1=bazel-out/k8-fastbuild/bin/staging/src/k8s.io/client-go/listers/core/v1/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/vendor/k8s.io/client-go/listers/core/v1.a=' -arc 'k8s.io/client-go/rest=k8s.io/kubernetes/vendor/k8s.io/client-go/rest=bazel-out/k8-fastbuild/bin/staging/src/k8s.io/client-go/rest/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/vendor/k8s.io/client-go/rest.a=' -arc 'k8s.io/client-go/tools/cache=k8s.io/kubernetes/vendor/k8s.io/client-go/tools/cache=bazel-out/k8-fastbuild/bin/staging/src/k8s.io/client-go/tools/cache/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/vendor/k8s.io/client-go/tools/cache.a=' -arc 'k8s.io/client-go/tools/clientcmd/api/v1=k8s.io/kubernetes/vendor/k8s.io/client-go/tools/clientcmd/api/v1=bazel-out/k8-fastbuild/bin/staging/src/k8s.io/client-go/tools/clientcmd/api/v1/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/vendor/k8s.io/client-go/tools/clientcmd/api/v1.a=' -arc 'k8s.io/client-go/tools/watch=k8s.io/kubernetes/vendor/k8s.io/client-go/tools/watch=bazel-out/k8-fastbuild/bin/staging/src/k8s.io/client-go/tools/watch/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/vendor/k8s.io/client-go/tools/watch.a=' -arc 'k8s.io/client-go/transport=k8s.io/kubernetes/vendor/k8s.io/client-go/transport=bazel-out/k8-fastbuild/bin/staging/src/k8s.io/client-go/transport/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/vendor/k8s.io/client-go/transport.a=' -arc 'k8s.io/client-go/util/keyutil=k8s.io/kubernetes/vendor/k8s.io/client-go/util/keyutil=bazel-out/k8-fastbuild/bin/staging/src/k8s.io/client-go/util/keyutil/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/vendor/k8s.io/client-go/util/keyutil.a=' -arc 'k8s.io/cluster-bootstrap/token/api=k8s.io/kubernetes/vendor/k8s.io/cluster-bootstrap/token/api=bazel-out/k8-fastbuild/bin/staging/src/k8s.io/cluster-bootstrap/token/api/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/vendor/k8s.io/cluster-bootstrap/token/api.a=' -arc 'k8s.io/component-base/featuregate/testing=k8s.io/kubernetes/vendor/k8s.io/component-base/featuregate/testing=bazel-out/k8-fastbuild/bin/staging/src/k8s.io/component-base/featuregate/testing/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/vendor/k8s.io/component-base/featuregate/testing.a=' -arc 'k8s.io/kubernetes/test/e2e/lifecycle/bootstrap=k8s.io/kubernetes/test/e2e/lifecycle/bootstrap=bazel-out/k8-fastbuild/bin/test/e2e/lifecycle/bootstrap/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/test/e2e/lifecycle/bootstrap.a=' -arc 'k8s.io/kubernetes/test/integration=k8s.io/kubernetes/test/integration=bazel-out/k8-fastbuild/bin/test/integration/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/test/integration.a=' -arc 'k8s.io/kubernetes/test/integration/framework=k8s.io/kubernetes/test/integration/framework=bazel-out/k8-fastbuild/bin/test/integration/framework/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/test/integration/framework.a=' -arc 'gopkg.in/square/go-jose.v2=k8s.io/kubernetes/vendor/gopkg.in/square/go-jose.v2=bazel-out/k8-fastbuild/bin/vendor/gopkg.in/square/go-jose.v2/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/vendor/gopkg.in/square/go-jose.v2.a=' -arc 'gopkg.in/square/go-jose.v2/jwt=k8s.io/kubernetes/vendor/gopkg.in/square/go-jose.v2/jwt=bazel-out/k8-fastbuild/bin/vendor/gopkg.in/square/go-jose.v2/jwt/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/vendor/gopkg.in/square/go-jose.v2/jwt.a=' -arc 'k8s.io/klog/v2=k8s.io/kubernetes/vendor/k8s.io/klog/v2=bazel-out/k8-fastbuild/bin/vendor/k8s.io/klog/v2/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/vendor/k8s.io/klog/v2.a=' -arc 'k8s.io/utils/pointer=k8s.io/kubernetes/vendor/k8s.io/utils/pointer=bazel-out/k8-fastbuild/bin/vendor/k8s.io/utils/pointer/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/vendor/k8s.io/utils/pointer.a=' -p test/integration/auth/go_default_test -package_list bazel-out/host/bin/external/go_sdk/packages.txt -o bazel-out/k8-fastbuild/bin/test/integration/auth/linux_amd64_stripped/go_default_test%/test/integration/auth/go_default_test.a -testfilter exclude -gcflags '' -asmflags '')
Execution platform: @local_config_platform//:host

Use --sandbox_debug to see verbose messages from the sandbox builder failed: error executing command 
  (cd /usr/local/google/home/mikedanese/.cache/bazel/_bazel_mikedanese/6c65a147ac17188f348dcacc7c554ab3/sandbox/linux-sandbox/3373/execroot/io_k8s_kubernetes && \
  exec env - \
    CGO_ENABLED=1 \
    GOARCH=amd64 \
    GOOS=linux \
    GOPATH='' \
    GOROOT=external/go_sdk \
    GOROOT_FINAL=GOROOT \
    PATH=/usr/bin:/bin \
  bazel-out/host/bin/external/go_sdk/builder compilepkg -sdk external/go_sdk -installsuffix linux_amd64 -tags selinux -src test/integration/auth/accessreview_test.go -src test/integration/auth/auth_test.go -src test/integration/auth/bootstraptoken_test.go -src test/integration/auth/dynamic_client_test.go -src test/integration/auth/main_test.go -src test/integration/auth/node_test.go -src test/integration/auth/rbac_test.go -src test/integration/auth/svcaccttoken_test.go -arc 'k8s.io/kubernetes/cmd/kube-apiserver/app/options=k8s.io/kubernetes/cmd/kube-apiserver/app/options=bazel-out/k8-fastbuild/bin/cmd/kube-apiserver/app/options/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/cmd/kube-apiserver/app/options.a=' -arc 'k8s.io/kubernetes/cmd/kube-apiserver/app/testing=k8s.io/kubernetes/cmd/kube-apiserver/app/testing=bazel-out/k8-fastbuild/bin/cmd/kube-apiserver/app/testing/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/cmd/kube-apiserver/app/testing.a=' -arc 'k8s.io/kubernetes/pkg/api/legacyscheme=k8s.io/kubernetes/pkg/api/legacyscheme=bazel-out/k8-fastbuild/bin/pkg/api/legacyscheme/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/pkg/api/legacyscheme.a=' -arc 'k8s.io/kubernetes/pkg/apis/autoscaling=k8s.io/kubernetes/pkg/apis/autoscaling=bazel-out/k8-fastbuild/bin/pkg/apis/autoscaling/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/pkg/apis/autoscaling.a=' -arc 'k8s.io/kubernetes/pkg/apis/core=k8s.io/kubernetes/pkg/apis/core=bazel-out/k8-fastbuild/bin/pkg/apis/core/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/pkg/apis/core.a=' -arc 'k8s.io/kubernetes/pkg/apis/extensions=k8s.io/kubernetes/pkg/apis/extensions=bazel-out/k8-fastbuild/bin/pkg/apis/extensions/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/pkg/apis/extensions.a=' -arc 'k8s.io/kubernetes/pkg/apis/rbac/v1=k8s.io/kubernetes/pkg/apis/rbac/v1=bazel-out/k8-fastbuild/bin/pkg/apis/rbac/v1/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/pkg/apis/rbac/v1.a=' -arc 'k8s.io/kubernetes/pkg/auth/authorizer/abac=k8s.io/kubernetes/pkg/auth/authorizer/abac=bazel-out/k8-fastbuild/bin/pkg/auth/authorizer/abac/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/pkg/auth/authorizer/abac.a=' -arc 'k8s.io/kubernetes/pkg/controller=k8s.io/kubernetes/pkg/controller=bazel-out/k8-fastbuild/bin/pkg/controller/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/pkg/controller.a=' -arc 'k8s.io/kubernetes/pkg/controller/serviceaccount=k8s.io/kubernetes/pkg/controller/serviceaccount=bazel-out/k8-fastbuild/bin/pkg/controller/serviceaccount/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/pkg/controller/serviceaccount.a=' -arc 'k8s.io/kubernetes/pkg/features=k8s.io/kubernetes/pkg/features=bazel-out/k8-fastbuild/bin/pkg/features/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/pkg/features.a=' -arc 'k8s.io/kubernetes/pkg/kubeapiserver/options=k8s.io/kubernetes/pkg/kubeapiserver/options=bazel-out/k8-fastbuild/bin/pkg/kubeapiserver/options/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/pkg/kubeapiserver/options.a=' -arc 'k8s.io/kubernetes/pkg/master=k8s.io/kubernetes/pkg/master=bazel-out/k8-fastbuild/bin/pkg/master/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/pkg/master.a=' -arc 'k8s.io/kubernetes/pkg/registry/rbac/clusterrole=k8s.io/kubernetes/pkg/registry/rbac/clusterrole=bazel-out/k8-fastbuild/bin/pkg/registry/rbac/clusterrole/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/pkg/registry/rbac/clusterrole.a=' -arc 'k8s.io/kubernetes/pkg/registry/rbac/clusterrole/storage=k8s.io/kubernetes/pkg/registry/rbac/clusterrole/storage=bazel-out/k8-fastbuild/bin/pkg/registry/rbac/clusterrole/storage/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/pkg/registry/rbac/clusterrole/storage.a=' -arc 'k8s.io/kubernetes/pkg/registry/rbac/clusterrolebinding=k8s.io/kubernetes/pkg/registry/rbac/clusterrolebinding=bazel-out/k8-fastbuild/bin/pkg/registry/rbac/clusterrolebinding/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/pkg/registry/rbac/clusterrolebinding.a=' -arc 'k8s.io/kubernetes/pkg/registry/rbac/clusterrolebinding/storage=k8s.io/kubernetes/pkg/registry/rbac/clusterrolebinding/storage=bazel-out/k8-fastbuild/bin/pkg/registry/rbac/clusterrolebinding/storage/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/pkg/registry/rbac/clusterrolebinding/storage.a=' -arc 'k8s.io/kubernetes/pkg/registry/rbac/role=k8s.io/kubernetes/pkg/registry/rbac/role=bazel-out/k8-fastbuild/bin/pkg/registry/rbac/role/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/pkg/registry/rbac/role.a=' -arc 'k8s.io/kubernetes/pkg/registry/rbac/role/storage=k8s.io/kubernetes/pkg/registry/rbac/role/storage=bazel-out/k8-fastbuild/bin/pkg/registry/rbac/role/storage/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/pkg/registry/rbac/role/storage.a=' -arc 'k8s.io/kubernetes/pkg/registry/rbac/rolebinding=k8s.io/kubernetes/pkg/registry/rbac/rolebinding=bazel-out/k8-fastbuild/bin/pkg/registry/rbac/rolebinding/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/pkg/registry/rbac/rolebinding.a=' -arc 'k8s.io/kubernetes/pkg/registry/rbac/rolebinding/storage=k8s.io/kubernetes/pkg/registry/rbac/rolebinding/storage=bazel-out/k8-fastbuild/bin/pkg/registry/rbac/rolebinding/storage/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/pkg/registry/rbac/rolebinding/storage.a=' -arc 'k8s.io/kubernetes/pkg/serviceaccount=k8s.io/kubernetes/pkg/serviceaccount=bazel-out/k8-fastbuild/bin/pkg/serviceaccount/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/pkg/serviceaccount.a=' -arc 'k8s.io/kubernetes/plugin/pkg/auth/authenticator/token/bootstrap=k8s.io/kubernetes/plugin/pkg/auth/authenticator/token/bootstrap=bazel-out/k8-fastbuild/bin/plugin/pkg/auth/authenticator/token/bootstrap/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/plugin/pkg/auth/authenticator/token/bootstrap.a=' -arc 'k8s.io/kubernetes/plugin/pkg/auth/authorizer/rbac=k8s.io/kubernetes/plugin/pkg/auth/authorizer/rbac=bazel-out/k8-fastbuild/bin/plugin/pkg/auth/authorizer/rbac/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/plugin/pkg/auth/authorizer/rbac.a=' -arc 'k8s.io/api/authentication/v1=k8s.io/kubernetes/vendor/k8s.io/api/authentication/v1=bazel-out/k8-fastbuild/bin/staging/src/k8s.io/api/authentication/v1/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/vendor/k8s.io/api/authentication/v1.a=' -arc 'k8s.io/api/authentication/v1beta1=k8s.io/kubernetes/vendor/k8s.io/api/authentication/v1beta1=bazel-out/k8-fastbuild/bin/staging/src/k8s.io/api/authentication/v1beta1/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/vendor/k8s.io/api/authentication/v1beta1.a=' -arc 'k8s.io/api/authorization/v1=k8s.io/kubernetes/vendor/k8s.io/api/authorization/v1=bazel-out/k8-fastbuild/bin/staging/src/k8s.io/api/authorization/v1/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/vendor/k8s.io/api/authorization/v1.a=' -arc 'k8s.io/api/coordination/v1=k8s.io/kubernetes/vendor/k8s.io/api/coordination/v1=bazel-out/k8-fastbuild/bin/staging/src/k8s.io/api/coordination/v1/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/vendor/k8s.io/api/coordination/v1.a=' -arc 'k8s.io/api/core/v1=k8s.io/kubernetes/vendor/k8s.io/api/core/v1=bazel-out/k8-fastbuild/bin/staging/src/k8s.io/api/core/v1/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/vendor/k8s.io/api/core/v1.a=' -arc 'k8s.io/api/policy/v1beta1=k8s.io/kubernetes/vendor/k8s.io/api/policy/v1beta1=bazel-out/k8-fastbuild/bin/staging/src/k8s.io/api/policy/v1beta1/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/vendor/k8s.io/api/policy/v1beta1.a=' -arc 'k8s.io/api/rbac/v1=k8s.io/kubernetes/vendor/k8s.io/api/rbac/v1=bazel-out/k8-fastbuild/bin/staging/src/k8s.io/api/rbac/v1/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/vendor/k8s.io/api/rbac/v1.a=' -arc 'k8s.io/api/storage/v1=k8s.io/kubernetes/vendor/k8s.io/api/storage/v1=bazel-out/k8-fastbuild/bin/staging/src/k8s.io/api/storage/v1/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/vendor/k8s.io/api/storage/v1.a=' -arc 'k8s.io/apimachinery/pkg/api/errors=k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/api/errors=bazel-out/k8-fastbuild/bin/staging/src/k8s.io/apimachinery/pkg/api/errors/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/api/errors.a=' -arc 'k8s.io/apimachinery/pkg/api/resource=k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/api/resource=bazel-out/k8-fastbuild/bin/staging/src/k8s.io/apimachinery/pkg/api/resource/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/api/resource.a=' -arc 'k8s.io/apimachinery/pkg/apis/meta/v1=k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/apis/meta/v1=bazel-out/k8-fastbuild/bin/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/apis/meta/v1.a=' -arc 'k8s.io/apimachinery/pkg/labels=k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/labels=bazel-out/k8-fastbuild/bin/staging/src/k8s.io/apimachinery/pkg/labels/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/labels.a=' -arc 'k8s.io/apimachinery/pkg/runtime/schema=k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/runtime/schema=bazel-out/k8-fastbuild/bin/staging/src/k8s.io/apimachinery/pkg/runtime/schema/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/runtime/schema.a=' -arc 'k8s.io/apimachinery/pkg/types=k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/types=bazel-out/k8-fastbuild/bin/staging/src/k8s.io/apimachinery/pkg/types/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/types.a=' -arc 'k8s.io/apimachinery/pkg/util/net=k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/net=bazel-out/k8-fastbuild/bin/staging/src/k8s.io/apimachinery/pkg/util/net/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/net.a=' -arc 'k8s.io/apimachinery/pkg/util/wait=k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/wait=bazel-out/k8-fastbuild/bin/staging/src/k8s.io/apimachinery/pkg/util/wait/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/wait.a=' -arc 'k8s.io/apimachinery/pkg/watch=k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/watch=bazel-out/k8-fastbuild/bin/staging/src/k8s.io/apimachinery/pkg/watch/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/watch.a=' -arc 'k8s.io/apiserver/pkg/authentication/authenticator=k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/authentication/authenticator=bazel-out/k8-fastbuild/bin/staging/src/k8s.io/apiserver/pkg/authentication/authenticator/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/authentication/authenticator.a=' -arc 'k8s.io/apiserver/pkg/authentication/group=k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/authentication/group=bazel-out/k8-fastbuild/bin/staging/src/k8s.io/apiserver/pkg/authentication/group/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/authentication/group.a=' -arc 'k8s.io/apiserver/pkg/authentication/request/bearertoken=k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/authentication/request/bearertoken=bazel-out/k8-fastbuild/bin/staging/src/k8s.io/apiserver/pkg/authentication/request/bearertoken/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/authentication/request/bearertoken.a=' -arc 'k8s.io/apiserver/pkg/authentication/serviceaccount=k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/authentication/serviceaccount=bazel-out/k8-fastbuild/bin/staging/src/k8s.io/apiserver/pkg/authentication/serviceaccount/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/authentication/serviceaccount.a=' -arc 'k8s.io/apiserver/pkg/authentication/token/cache=k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/authentication/token/cache=bazel-out/k8-fastbuild/bin/staging/src/k8s.io/apiserver/pkg/authentication/token/cache/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/authentication/token/cache.a=' -arc 'k8s.io/apiserver/pkg/authentication/token/tokenfile=k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/authentication/token/tokenfile=bazel-out/k8-fastbuild/bin/staging/src/k8s.io/apiserver/pkg/authentication/token/tokenfile/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/authentication/token/tokenfile.a=' -arc 'k8s.io/apiserver/pkg/authentication/user=k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/authentication/user=bazel-out/k8-fastbuild/bin/staging/src/k8s.io/apiserver/pkg/authentication/user/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/authentication/user.a=' -arc 'k8s.io/apiserver/pkg/authorization/authorizer=k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/authorization/authorizer=bazel-out/k8-fastbuild/bin/staging/src/k8s.io/apiserver/pkg/authorization/authorizer/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/authorization/authorizer.a=' -arc 'k8s.io/apiserver/pkg/authorization/authorizerfactory=k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/authorization/authorizerfactory=bazel-out/k8-fastbuild/bin/staging/src/k8s.io/apiserver/pkg/authorization/authorizerfactory/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/authorization/authorizerfactory.a=' -arc 'k8s.io/apiserver/pkg/features=k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/features=bazel-out/k8-fastbuild/bin/staging/src/k8s.io/apiserver/pkg/features/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/features.a=' -arc 'k8s.io/apiserver/pkg/registry/generic=k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/registry/generic=bazel-out/k8-fastbuild/bin/staging/src/k8s.io/apiserver/pkg/registry/generic/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/registry/generic.a=' -arc 'k8s.io/apiserver/pkg/util/feature=k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/util/feature=bazel-out/k8-fastbuild/bin/staging/src/k8s.io/apiserver/pkg/util/feature/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/util/feature.a=' -arc 'k8s.io/apiserver/plugin/pkg/authenticator/token/tokentest=k8s.io/kubernetes/vendor/k8s.io/apiserver/plugin/pkg/authenticator/token/tokentest=bazel-out/k8-fastbuild/bin/staging/src/k8s.io/apiserver/plugin/pkg/authenticator/token/tokentest/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/vendor/k8s.io/apiserver/plugin/pkg/authenticator/token/tokentest.a=' -arc 'k8s.io/apiserver/plugin/pkg/authenticator/token/webhook=k8s.io/kubernetes/vendor/k8s.io/apiserver/plugin/pkg/authenticator/token/webhook=bazel-out/k8-fastbuild/bin/staging/src/k8s.io/apiserver/plugin/pkg/authenticator/token/webhook/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/vendor/k8s.io/apiserver/plugin/pkg/authenticator/token/webhook.a=' -arc 'k8s.io/client-go/kubernetes=k8s.io/kubernetes/vendor/k8s.io/client-go/kubernetes=bazel-out/k8-fastbuild/bin/staging/src/k8s.io/client-go/kubernetes/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/vendor/k8s.io/client-go/kubernetes.a=' -arc 'k8s.io/client-go/listers/core/v1=k8s.io/kubernetes/vendor/k8s.io/client-go/listers/core/v1=bazel-out/k8-fastbuild/bin/staging/src/k8s.io/client-go/listers/core/v1/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/vendor/k8s.io/client-go/listers/core/v1.a=' -arc 'k8s.io/client-go/rest=k8s.io/kubernetes/vendor/k8s.io/client-go/rest=bazel-out/k8-fastbuild/bin/staging/src/k8s.io/client-go/rest/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/vendor/k8s.io/client-go/rest.a=' -arc 'k8s.io/client-go/tools/cache=k8s.io/kubernetes/vendor/k8s.io/client-go/tools/cache=bazel-out/k8-fastbuild/bin/staging/src/k8s.io/client-go/tools/cache/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/vendor/k8s.io/client-go/tools/cache.a=' -arc 'k8s.io/client-go/tools/clientcmd/api/v1=k8s.io/kubernetes/vendor/k8s.io/client-go/tools/clientcmd/api/v1=bazel-out/k8-fastbuild/bin/staging/src/k8s.io/client-go/tools/clientcmd/api/v1/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/vendor/k8s.io/client-go/tools/clientcmd/api/v1.a=' -arc 'k8s.io/client-go/tools/watch=k8s.io/kubernetes/vendor/k8s.io/client-go/tools/watch=bazel-out/k8-fastbuild/bin/staging/src/k8s.io/client-go/tools/watch/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/vendor/k8s.io/client-go/tools/watch.a=' -arc 'k8s.io/client-go/transport=k8s.io/kubernetes/vendor/k8s.io/client-go/transport=bazel-out/k8-fastbuild/bin/staging/src/k8s.io/client-go/transport/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/vendor/k8s.io/client-go/transport.a=' -arc 'k8s.io/client-go/util/keyutil=k8s.io/kubernetes/vendor/k8s.io/client-go/util/keyutil=bazel-out/k8-fastbuild/bin/staging/src/k8s.io/client-go/util/keyutil/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/vendor/k8s.io/client-go/util/keyutil.a=' -arc 'k8s.io/cluster-bootstrap/token/api=k8s.io/kubernetes/vendor/k8s.io/cluster-bootstrap/token/api=bazel-out/k8-fastbuild/bin/staging/src/k8s.io/cluster-bootstrap/token/api/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/vendor/k8s.io/cluster-bootstrap/token/api.a=' -arc 'k8s.io/component-base/featuregate/testing=k8s.io/kubernetes/vendor/k8s.io/component-base/featuregate/testing=bazel-out/k8-fastbuild/bin/staging/src/k8s.io/component-base/featuregate/testing/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/vendor/k8s.io/component-base/featuregate/testing.a=' -arc 'k8s.io/kubernetes/test/e2e/lifecycle/bootstrap=k8s.io/kubernetes/test/e2e/lifecycle/bootstrap=bazel-out/k8-fastbuild/bin/test/e2e/lifecycle/bootstrap/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/test/e2e/lifecycle/bootstrap.a=' -arc 'k8s.io/kubernetes/test/integration=k8s.io/kubernetes/test/integration=bazel-out/k8-fastbuild/bin/test/integration/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/test/integration.a=' -arc 'k8s.io/kubernetes/test/integration/framework=k8s.io/kubernetes/test/integration/framework=bazel-out/k8-fastbuild/bin/test/integration/framework/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/test/integration/framework.a=' -arc 'gopkg.in/square/go-jose.v2=k8s.io/kubernetes/vendor/gopkg.in/square/go-jose.v2=bazel-out/k8-fastbuild/bin/vendor/gopkg.in/square/go-jose.v2/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/vendor/gopkg.in/square/go-jose.v2.a=' -arc 'gopkg.in/square/go-jose.v2/jwt=k8s.io/kubernetes/vendor/gopkg.in/square/go-jose.v2/jwt=bazel-out/k8-fastbuild/bin/vendor/gopkg.in/square/go-jose.v2/jwt/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/vendor/gopkg.in/square/go-jose.v2/jwt.a=' -arc 'k8s.io/klog/v2=k8s.io/kubernetes/vendor/k8s.io/klog/v2=bazel-out/k8-fastbuild/bin/vendor/k8s.io/klog/v2/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/vendor/k8s.io/klog/v2.a=' -arc 'k8s.io/utils/pointer=k8s.io/kubernetes/vendor/k8s.io/utils/pointer=bazel-out/k8-fastbuild/bin/vendor/k8s.io/utils/pointer/linux_amd64_stripped/go_default_library%/k8s.io/kubernetes/vendor/k8s.io/utils/pointer.a=' -p test/integration/auth/go_default_test -package_list bazel-out/host/bin/external/go_sdk/packages.txt -o bazel-out/k8-fastbuild/bin/test/integration/auth/linux_amd64_stripped/go_default_test%/test/integration/auth/go_default_test.a -testfilter exclude -gcflags '' -asmflags '')
Execution platform: @local_config_platform//:host

Use --sandbox_debug to see verbose messages from the sandbox
compilepkg: error running subcommand: exit status 2
/usr/local/google/home/mikedanese/.cache/bazel/_bazel_mikedanese/6c65a147ac17188f348dcacc7c554ab3/sandbox/linux-sandbox/3373/execroot/io_k8s_kubernetes/test/integration/auth/svcaccttoken_test.go:69:2: undefined: hi
INFO: Elapsed time: 0.758s, Critical Path: 0.28s
INFO: 0 processes.
FAILED: Build did NOT complete successfully
//test/integration/auth:go_default_test                         FAILED TO BUILD

Executed 0 out of 1 test: 1 fails to build.
FAILED: Build did NOT complete successfully

</details>


### After

ERROR: /usr/local/google/home/mikedanese/go/src/k8s.io/kubernetes/test/integration/auth/BUILD:8:1: GoCompilePkg test/integration/auth/linux_amd64_stripped/go_default_test%/test/integration/auth/go_default_test.a failed (Exit 1) builder failed: error executing command bazel-out/host/bin/external/go_sdk/builder compilepkg -sdk external/go_sdk -installsuffix linux_amd64 -tags selinux -src test/integration/auth/accessreview_test.go -src ... (remaining 169 argument(s) skipped)

Use --sandbox_debug to see verbose messages from the sandbox
compilepkg: error running subcommand: exit status 2
/usr/local/google/home/mikedanese/.cache/bazel/_bazel_mikedanese/6c65a147ac17188f348dcacc7c554ab3/sandbox/linux-sandbox/3374/execroot/io_k8s_kubernetes/test/integration/auth/svcaccttoken_test.go:69:2: undefined: hi
INFO: Elapsed time: 0.625s, Critical Path: 0.24s
INFO: 0 processes.
FAILED: Build did NOT complete successfully
//test/integration/auth:go_default_test                         FAILED TO BUILD

Executed 0 out of 1 test: 1 fails to build.
FAILED: Build did NOT complete successfully

/kind cleanup
/sig testing

```release-note
NONE
```

