### PR TITLE
Build non-static Kubernetes binaries as position-independent executables (PIE)

### DIFF
--- a/cmd/kubelet/BUILD
+++ b/cmd/kubelet/BUILD
@@ -10,6 +10,7 @@ load("//staging/src/k8s.io/component-base/version:def.bzl", "version_x_defs")
 go_binary(
     name = "kubelet",
     embed = [":go_default_library"],
+    linkmode = "pie",
     x_defs = version_x_defs(),
 )
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
Currently, `kubelet` which is dynamically-linked is not built as position-independent executable. This PR applies Go's buildmode=pie flag to the non-static binaries. Building them as PIE enables the [ASLR](https://en.wikipedia.org/wiki/Address_space_layout_randomization) security mechanism, which facilitates defense in depth when building the binaries. This fix does not apply to statically-linked binaries. 

Bottlerocket applies this [patch](https://github.com/bottlerocket-os/bottlerocket/blob/41a72fe21400fa227543fcbed2e59eb0a8b633c1/packages/kubernetes-1.17/0003-enable-PIE-for-platform-binaries.patch) for Kubernetes 1.17 to build dynamically linked binaries as PIE, but bearing security in mind, it is recommended to set PIE as default in upstream Kubernetes. This fix also allows removal of similar patches from downstream Kubernetes.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes [#90311](https://github.com/kubernetes/kubernetes/issues/90311)

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Release Notes**
```
Apply Go's buildmode=pie flag to enable ASLR for non-static binary builds
```
<!--
**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:


This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
