### PR TITLE
Optimization log in replica_set.go

### DIFF
--- a/pkg/controller/replicaset/replica_set.go
+++ b/pkg/controller/replicaset/replica_set.go
@@ -198,7 +198,7 @@ func (rsc *ReplicaSetController) Run(workers int, stopCh <-chan struct{}) {
 func (rsc *ReplicaSetController) getReplicaSetsWithSameController(rs *apps.ReplicaSet) []*apps.ReplicaSet {
 	controllerRef := metav1.GetControllerOf(rs)
 	if controllerRef == nil {
-		utilruntime.HandleError(fmt.Errorf("ReplicaSet has no controller: %v", rs))
+		utilruntime.HandleError(fmt.Errorf("ReplicaSet has no controller: %s[%v]", rs.Name, rs.Status))
 		return nil
 	}
 


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it:**
When ReplicaSet has no controller in getReplicaSetsWithSameController, it will print error log with the complete information of the rs. While, the length of the rs' Spec is very long, about 3K~4K. It is not necessary to print all the information of the rs. We can print the necessary information only. So I optimized it.

**Which issue(s) this PR fixes:**

Fixes #

Special notes for your reviewer:

Does this PR introduce a user-facing change?:

Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

/release-note-none
/priority backlog