### PR TITLE
Automated cherry pick of #94299: fix kubeadm update coredns with skip pending pod

### DIFF
--- a/cmd/kubeadm/app/phases/addons/dns/BUILD
+++ b/cmd/kubeadm/app/phases/addons/dns/BUILD
@@ -46,6 +46,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/scheme:go_default_library",
         "//vendor/github.com/caddyserver/caddy/caddyfile:go_default_library",


### PR DESCRIPTION
Cherry pick of #94299 on release-1.19.

#94299: fix kubeadm update coredns with skip pending pod

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
kubeadm: avoid a panic when determining if the running version of CoreDNS is supported during upgrades
```