### PR TITLE
Improve ability to debug Events e2e failure

### DIFF
--- a/staging/src/k8s.io/client-go/tools/record/event.go
+++ b/staging/src/k8s.io/client-go/tools/record/event.go
@@ -270,7 +270,7 @@ func recordEvent(sink EventSink, event *v1.Event, patch []byte, updateExistingEv
 	default:
 		// This case includes actual http transport errors. Go ahead and retry.
 	}
-	klog.Errorf("Unable to write event: '%v' (may retry after sleeping)", err)
+	klog.Errorf("Unable to write event: '%#v': '%v'(may retry after sleeping)", event, err)
 	return false
 }
 


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Improve ability to debug flakes we see in our downstream CI setup for Event testing on some platforms.
see: https://bugzilla.redhat.com/show_bug.cgi?id=1846529

This lets us see why kubelets are not able to send an event on earlier attempts.
Related test: https://github.com/kubernetes/kubernetes/blob/master/test/e2e/node/events.go

```release-note
NONE
```