### PR TITLE
fix documentation and maybe validation of NetworkPolicy CIDRs

### DIFF
--- a/pkg/apis/networking/types.go
+++ b/pkg/apis/networking/types.go
@@ -144,15 +144,15 @@ type NetworkPolicyPort struct {
 	Port *intstr.IntOrString
 }
 
-// IPBlock describes a particular CIDR (Ex. "192.168.1.1/24","2001:db9::/64") that is allowed
+// IPBlock describes a particular CIDR (Ex. "192.168.1.0/24","2001:db9::/64") that is allowed
 // to the pods matched by a NetworkPolicySpec's podSelector. The except entry describes CIDRs
 // that should not be included within this rule.
 type IPBlock struct {
 	// CIDR is a string representing the IP Block
-	// Valid examples are "192.168.1.1/24" or "2001:db9::/64"
+	// Valid examples are "192.168.1.0/24" or "2001:db9::/64"
 	CIDR string
 	// Except is a slice of CIDRs that should not be included within an IP Block
-	// Valid examples are "192.168.1.1/24" or "2001:db9::/64"
+	// Valid examples are "192.168.1.1/32" or "2001:db9::/64"
 	// Except values will be rejected if they are outside the CIDR range
 	// +optional
 	Except []string

--- a/pkg/apis/networking/validation/validation_test.go
+++ b/pkg/apis/networking/validation/validation_test.go
@@ -681,6 +681,26 @@ func TestValidateNetworkPolicy(t *testing.T) {
 				},
 			},
 		},
+		"invalid ambiguous cidr": {
+			ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "bar"},
+			Spec: networking.NetworkPolicySpec{
+				PodSelector: metav1.LabelSelector{
+					MatchLabels: map[string]string{"a": "b"},
+				},
+				Ingress: []networking.NetworkPolicyIngressRule{
+					{
+						From: []networking.NetworkPolicyPeer{
+							{
+								IPBlock: &networking.IPBlock{
+									CIDR:   "192.168.5.6/24",
+									Except: []string{"192.168.1.0/24", "192.168.2.0/24"},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 		"except field is an empty string": {
 			ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "bar"},
 			Spec: networking.NetworkPolicySpec{
@@ -713,7 +733,27 @@ func TestValidateNetworkPolicy(t *testing.T) {
 							{
 								IPBlock: &networking.IPBlock{
 									CIDR:   "192.168.8.0/24",
-									Except: []string{"192.168.9.1/24"},
+									Except: []string{"192.168.9.1/32"},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"invalid ambiguous except CIDR": {
+			ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "bar"},
+			Spec: networking.NetworkPolicySpec{
+				PodSelector: metav1.LabelSelector{
+					MatchLabels: map[string]string{"a": "b"},
+				},
+				Ingress: []networking.NetworkPolicyIngressRule{
+					{
+						From: []networking.NetworkPolicyPeer{
+							{
+								IPBlock: &networking.IPBlock{
+									CIDR:   "192.168.8.0/24",
+									Except: []string{"192.168.8.1/24"},
 								},
 							},
 						},

--- a/staging/src/k8s.io/api/networking/v1/types.go
+++ b/staging/src/k8s.io/api/networking/v1/types.go
@@ -147,15 +147,15 @@ type NetworkPolicyPort struct {
 	Port *intstr.IntOrString `json:"port,omitempty" protobuf:"bytes,2,opt,name=port"`
 }
 
-// IPBlock describes a particular CIDR (Ex. "192.168.1.1/24","2001:db9::/64") that is allowed
+// IPBlock describes a particular CIDR (Ex. "192.168.1.0/24","2001:db9::/64") that is allowed
 // to the pods matched by a NetworkPolicySpec's podSelector. The except entry describes CIDRs
 // that should not be included within this rule.
 type IPBlock struct {
 	// CIDR is a string representing the IP Block
-	// Valid examples are "192.168.1.1/24" or "2001:db9::/64"
+	// Valid examples are "192.168.1.0/24" or "2001:db9::/64"
 	CIDR string `json:"cidr" protobuf:"bytes,1,name=cidr"`
 	// Except is a slice of CIDRs that should not be included within an IP Block
-	// Valid examples are "192.168.1.1/24" or "2001:db9::/64"
+	// Valid examples are "192.168.1.1/32" or "2001:db9::/64"
 	// Except values will be rejected if they are outside the CIDR range
 	// +optional
 	Except []string `json:"except,omitempty" protobuf:"bytes,2,rep,name=except"`

--- a/staging/src/k8s.io/api/networking/v1/types_swagger_doc_generated.go
+++ b/staging/src/k8s.io/api/networking/v1/types_swagger_doc_generated.go
@@ -48,9 +48,9 @@ func (HTTPIngressRuleValue) SwaggerDoc() map[string]string {
 }
 
 var map_IPBlock = map[string]string{
-	"":       "IPBlock describes a particular CIDR (Ex. \"192.168.1.1/24\",\"2001:db9::/64\") that is allowed to the pods matched by a NetworkPolicySpec's podSelector. The except entry describes CIDRs that should not be included within this rule.",
-	"cidr":   "CIDR is a string representing the IP Block Valid examples are \"192.168.1.1/24\" or \"2001:db9::/64\"",
-	"except": "Except is a slice of CIDRs that should not be included within an IP Block Valid examples are \"192.168.1.1/24\" or \"2001:db9::/64\" Except values will be rejected if they are outside the CIDR range",
+	"":       "IPBlock describes a particular CIDR (Ex. \"192.168.1.0/24\",\"2001:db9::/64\") that is allowed to the pods matched by a NetworkPolicySpec's podSelector. The except entry describes CIDRs that should not be included within this rule.",
+	"cidr":   "CIDR is a string representing the IP Block Valid examples are \"192.168.1.0/24\" or \"2001:db9::/64\"",
+	"except": "Except is a slice of CIDRs that should not be included within an IP Block Valid examples are \"192.168.1.1/32\" or \"2001:db9::/64\" Except values will be rejected if they are outside the CIDR range",
 }
 
 func (IPBlock) SwaggerDoc() map[string]string {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
/kind api-change

**What this PR does / why we need it**:
Currently it is possible to create a NetworkPolicy with an invalid `ipBlock` CIDR such as

    ipBlock:
      cidr: 192.168.1.1/24

For purposes of matching/filtering traffic, it only makes sense to allow CIDR strings where all bits outside of the mask are 0; ie, this should be either 192.168.1.**0**/24 (ie, "192.168.1.1 and everything else in the same subnet") or 192.168.1.1/**32** ("just 192.168.1.1"). Either of those CIDR strings could plausibly be used in a NetworkPolicy, depending on what the user wanted, so there is no way to just guess which version the user meant.

Network plugins encountering this ambiguous syntax might:
- Intentionally or accidentally interpret it as "192.168.1.0/24"
- Intentionally or accidentally interpret it as "192.168.1.1/32"
- Pass the string unchanged to some lower-level software (eg iptables), which will then do one of the above
- Notice the problem and ignore the `ipBlock` rather than possibly allowing incorrect traffic

This PR makes the apiserver reject NetworkPolicies like the above as invalid. I realize this might be considered an API break and not possible. I guess in that case plan B would probably be to define a specific required interpretation of such CIDR values, and update the e2e tests to enforce that. The safest, most-restrictive intepretation would be:

- If `cidr` is ambiguous:
  - if there are `except` values, then interpret the `cidr` value as a subnet, not a host (since it wouldn't make sense to have exceptions if `cidr` only identified a single IP)
  - otherwise interpret the `cidr` as a host
- If any `except` item is ambiguous, interpret it as a subnet 

That ensures that the policy might block traffic the user meant to allow, but it will not allow traffic the user meant to block.

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NetworkPolicy validation is now more restrictive, and policies that were previously
allowed may now be rejected for containing invalid CIDR match strings such as
"192.168.1.1/24" in ipBlocks. These need to be replaced with the correct values (eg,
"192.168.1.0/24" or "192.168.1.1/32" depending on which was meant.)
```

/sig network
/priority important-soon