### PR TITLE
Deflake TestServiceRegistryExternalTrafficHealthCheckNodePortUserAllocation

### DIFF
--- a/pkg/registry/core/service/storage/BUILD
+++ b/pkg/registry/core/service/storage/BUILD
@@ -32,7 +32,6 @@ go_test(
         "//staging/src/k8s.io/apimachinery/pkg/util/diff:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/intstr:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/net:go_default_library",
-        "//staging/src/k8s.io/apimachinery/pkg/util/rand:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/watch:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/endpoints/request:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/registry/generic:go_default_library",


### PR DESCRIPTION
**What type of PR is this?**

/kind failing-test
/kind flake

**What this PR does / why we need it**:
Deflakes [TestServiceRegistryExternalTrafficHealthCheckNodePortUserAllocation](https://github.com/kubernetes/kubernetes/pull/93605#issuecomment-668141670) to unblock https://github.com/kubernetes/kubernetes/pull/93605 until https://github.com/kubernetes/kubernetes/pull/93922 is reviewed/merged

**Special notes for your reviewer**:
The hard-coded health check port was conflicting with an auto-allocated nodeport 1 out of 1000 times. This hard-codes both to ensure they are different (and drops the randomness on the health check port, which wasn't really exercising anything since we only ran the scenario once).

```release-note
NONE
```

/cc @bowei @knight42 
/sig network