### PR TITLE
Allow to map the same container port to different host ports

### DIFF
--- a/pkg/kubelet/container/helpers.go
+++ b/pkg/kubelet/container/helpers.go
@@ -335,7 +335,7 @@ func MakePortMappings(container *v1.Container) (ports []PortMapping) {
 
 		var name string = p.Name
 		if name == "" {
-			name = fmt.Sprintf("%s-%s:%d", family, p.Protocol, p.ContainerPort)
+			name = fmt.Sprintf("%s-%s-%s:%d:%d", family, p.Protocol, p.HostIP, p.ContainerPort, p.HostPort)
 		}
 
 		// Protect against a port name being used more than once in a container.

--- a/pkg/kubelet/container/helpers_test.go
+++ b/pkg/kubelet/container/helpers_test.go
@@ -580,8 +580,6 @@ func TestMakePortMappings(t *testing.T) {
 					port("foo", v1.ProtocolUDP, 555, 5555, ""),
 					// Duplicated, should be ignored.
 					port("foo", v1.ProtocolUDP, 888, 8888, ""),
-					// Duplicated, should be ignored.
-					port("", v1.ProtocolTCP, 80, 8888, "127.0.0.1"),
 					// Duplicated with different address family, shouldn't be ignored
 					port("", v1.ProtocolTCP, 80, 8080, "::"),
 					// No address family specified
@@ -594,6 +592,47 @@ func TestMakePortMappings(t *testing.T) {
 				portMapping(v1.ProtocolUDP, 555, 5555, ""),
 				portMapping(v1.ProtocolTCP, 80, 8080, "::"),
 				portMapping(v1.ProtocolTCP, 1234, 5678, ""),
+			},
+		},
+		{
+			// The same container port can be mapped to different host ports
+			&v1.Container{
+				Name: "fooContainer",
+				Ports: []v1.ContainerPort{
+					port("", v1.ProtocolTCP, 443, 4343, "192.168.0.1"),
+					port("", v1.ProtocolTCP, 4343, 4343, "192.168.0.1"),
+				},
+			},
+			[]PortMapping{
+				portMapping(v1.ProtocolTCP, 443, 4343, "192.168.0.1"),
+				portMapping(v1.ProtocolTCP, 4343, 4343, "192.168.0.1"),
+			},
+		},
+		{
+			// The same container port AND same container host is not OK
+			&v1.Container{
+				Name: "fooContainer",
+				Ports: []v1.ContainerPort{
+					port("", v1.ProtocolTCP, 443, 4343, ""),
+					port("", v1.ProtocolTCP, 443, 4343, ""),
+				},
+			},
+			[]PortMapping{
+				portMapping(v1.ProtocolTCP, 443, 4343, ""),
+			},
+		},
+		{
+			// multihomed nodes - multiple IP scenario
+			&v1.Container{
+				Name: "fooContainer",
+				Ports: []v1.ContainerPort{
+					port("", v1.ProtocolTCP, 443, 4343, "192.168.0.1"),
+					port("", v1.ProtocolTCP, 443, 4343, "172.16.0.1"),
+				},
+			},
+			[]PortMapping{
+				portMapping(v1.ProtocolTCP, 443, 4343, "192.168.0.1"),
+				portMapping(v1.ProtocolTCP, 443, 4343, "172.16.0.1"),
 			},
 		},
 	}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:
This PR is a replacement for https://github.com/kubernetes/kubernetes/pull/80470 (by @zouyee). It relaxes the validation in kubelet before passing node port mappings to CNI. Stated use case for this is to allow port transition for daemons. So both ports (old and new) are configured for the transition period and after some time old port being removed.

**Which issue(s) this PR fixes**:
Fixes  #63906

**Special notes for your reviewer**:

There is a question of whether this deduplication of port mappings is needed at all. For example, once the mapping is named, no duplication is happening and needs to be handled by CNI anyway. But removing this deduplication is a bigger change that may require a larger announcement and can potentially affect payload.

This PR also includes the relaxing of deduplication by hostIP. Similar to https://github.com/kubernetes/kubernetes/pull/94382 Same port is allows to be configured on different IPs.


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
port mapping allows to map the same `containerPort` to multiple `hostPort` without naming the mapping explicitly.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
