### PR TITLE
Automated cherry pick of #93909: Update snapshot controller to use k8s.gcr.io

### DIFF
--- a/cluster/addons/volumesnapshots/volume-snapshot-controller/volume-snapshot-controller-deployment.yaml
+++ b/cluster/addons/volumesnapshots/volume-snapshot-controller/volume-snapshot-controller-deployment.yaml
@@ -22,8 +22,6 @@ spec:
       serviceAccount: volume-snapshot-controller
       containers:
         - name: volume-snapshot-controller
-          # TODO(xyang): Replace with an official image when it is released
-          image: gcr.io/k8s-staging-csi/snapshot-controller:v2.0.0-rc2
+          image: k8s.gcr.io/sig-storage/snapshot-controller:v2.1.1
           args:
             - "--v=5"
-          imagePullPolicy: Always


### PR DESCRIPTION
Cherry pick of #93909 on release-1.19.

#93909: Update snapshot controller to use k8s.gcr.io

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.