### PR TITLE
Automated cherry pick of #94506: kubeadm: remove the CoreDNS check for supported image digests

### DIFF
--- a/cmd/kubeadm/app/phases/addons/dns/dns.go
+++ b/cmd/kubeadm/app/phases/addons/dns/dns.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
-	"regexp"
 	"strings"
 
 	"github.com/caddyserver/caddy/caddyfile"
@@ -268,22 +267,15 @@ func createCoreDNSAddon(deploymentBytes, serviceBytes, configBytes []byte, clien
 		return errors.Wrap(err, "unable to fetch CoreDNS current installed version and ConfigMap.")
 	}
 
-	canMigrateCorefile, err := isCoreDNSVersionSupported(client)
-	if err != nil {
-		return err
-	}
-
 	corefileMigrationRequired, err := isCoreDNSConfigMapMigrationRequired(corefile, currentInstalledCoreDNSVersion)
 	if err != nil {
 		return err
 	}
 
-	if !canMigrateCorefile {
-		klog.Warningf("the CoreDNS Configuration will not be migrated due to unsupported version of CoreDNS. " +
-			"The existing CoreDNS Corefile configuration and deployment has been retained.")
-	}
+	// Assume that migration is always possible, rely on migrateCoreDNSCorefile() to fail if not.
+	canMigrateCorefile := true
 
-	if corefileMigrationRequired && canMigrateCorefile {
+	if corefileMigrationRequired {
 		if err := migrateCoreDNSCorefile(client, coreDNSConfigMap, corefile, currentInstalledCoreDNSVersion); err != nil {
 			// Errors in Corefile Migration is verified during preflight checks. This part will be executed when a user has chosen
 			// to ignore preflight check errors.
@@ -390,37 +382,6 @@ func isCoreDNSConfigMapMigrationRequired(corefile, currentInstalledCoreDNSVersio
 	}
 
 	return isMigrationRequired, nil
-}
-
-var (
-	// imageDigestMatcher is used to match the SHA256 digest from the ImageID of the CoreDNS pods
-	imageDigestMatcher = regexp.MustCompile(`^.*(?i:sha256:([[:alnum:]]{64}))$`)
-)
-
-func isCoreDNSVersionSupported(client clientset.Interface) (bool, error) {
-	isValidVersion := true
-	coreDNSPodList, err := client.CoreV1().Pods(metav1.NamespaceSystem).List(
-		context.TODO(),
-		metav1.ListOptions{
-			LabelSelector: "k8s-app=kube-dns",
-		},
-	)
-	if err != nil {
-		return false, errors.Wrap(err, "unable to list CoreDNS pods")
-	}
-
-	for _, pod := range coreDNSPodList.Items {
-		imageID := imageDigestMatcher.FindStringSubmatch(pod.Status.ContainerStatuses[0].ImageID)
-		if len(imageID) != 2 {
-			return false, errors.Errorf("unable to match SHA256 digest ID in %q", pod.Status.ContainerStatuses[0].ImageID)
-		}
-		// The actual digest should be at imageID[1]
-		if !migration.Released(imageID[1]) {
-			isValidVersion = false
-		}
-	}
-
-	return isValidVersion, nil
 }
 
 func migrateCoreDNSCorefile(client clientset.Interface, cm *v1.ConfigMap, corefile, currentInstalledCoreDNSVersion string) error {


### PR DESCRIPTION
Cherry pick of #94506 on release-1.19.

#94506: kubeadm: remove the CoreDNS check for supported image digests

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.