### PR TITLE
Release lock on cancel for KCM and CCM

### DIFF
--- a/cmd/cloud-controller-manager/app/controllermanager.go
+++ b/cmd/cloud-controller-manager/app/controllermanager.go
@@ -220,8 +220,9 @@ func Run(c *cloudcontrollerconfig.CompletedConfig, stopCh <-chan struct{}) error
 				klog.Fatalf("leaderelection lost")
 			},
 		},
-		WatchDog: electionChecker,
-		Name:     "cloud-controller-manager",
+		WatchDog:        electionChecker,
+		Name:            "cloud-controller-manager",
+		ReleaseOnCancel: true,
 	})
 	panic("unreachable")
 }

--- a/cmd/kube-controller-manager/app/controllermanager.go
+++ b/cmd/kube-controller-manager/app/controllermanager.go
@@ -293,8 +293,9 @@ func Run(c *config.CompletedConfig, stopCh <-chan struct{}) error {
 				klog.Fatalf("leaderelection lost")
 			},
 		},
-		WatchDog: electionChecker,
-		Name:     "kube-controller-manager",
+		WatchDog:        electionChecker,
+		Name:            "kube-controller-manager",
+		ReleaseOnCancel: true,
 	})
 	panic("unreachable")
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
When KCM and CCM are exiting they should release the lock they are holding so another instance can takeover faster and doesn't have to wait for the lock to expire.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
