### PR TITLE
Add vCenter info metric

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/vsphere/vclib/connection.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/vsphere/vclib/connection.go
@@ -65,6 +65,7 @@ func (connection *VSphereConnection) Connect(ctx context.Context) error {
 			klog.Errorf("Failed to create govmomi client. err: %+v", err)
 			return err
 		}
+		setVCenterInfoMetric(connection)
 		return nil
 	}
 	m := session.NewManager(connection.Client)
@@ -83,6 +84,7 @@ func (connection *VSphereConnection) Connect(ctx context.Context) error {
 		klog.Errorf("Failed to create govmomi client. err: %+v", err)
 		return err
 	}
+	setVCenterInfoMetric(connection)
 	return nil
 }
 


### PR DESCRIPTION
Metric provides information about used vCenter version
for every connected vCenter host. Metric displays the info about `vCenter` version, build and hostname

![image](https://user-images.githubusercontent.com/32226600/92380512-95e47b00-f109-11ea-9334-42e706f1a1af.png)


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:


Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:

Currently, the vCenter version is unknown to the Kubernetes cluster. Adding this metric will report the existing vCenter version for every connected host defined in `vsphere.conf` file.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubernetes/issues/94651

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Add a new `vSphere` metric: `cloudprovider_vsphere_vcenter_versions`. It's content show `vCenter` hostnames with the associated server version.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
