### PR TITLE
test(apiserver): deflake TestClientReceivedGOAWAY

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/filters/goaway_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/filters/goaway_test.go
@@ -342,6 +342,7 @@ func TestClientReceivedGOAWAY(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
+			var mu sync.Mutex
 			// localAddr indicates how many TCP connection set up
 			localAddr := make([]string, 0)
 
@@ -350,7 +351,10 @@ func TestClientReceivedGOAWAY(t *testing.T) {
 				if err != nil {
 					t.Fatalf("unexpect connection err: %v", err)
 				}
+
+				mu.Lock()
 				localAddr = append(localAddr, conn.LocalAddr().String())
+				mu.Unlock()
 				return
 			})
 			if err != nil {


### PR DESCRIPTION
Signed-off-by: knight42 <anonymousknight96@gmail.com>

**What type of PR is this?**

/kind failing-test

**What this PR does / why we need it**:

From the log:
```
=== RUN   TestClientReceivedGOAWAY
=== RUN   TestClientReceivedGOAWAY/all_normal_requests_use_only_one_connection
=== RUN   TestClientReceivedGOAWAY/got_GOAWAY_after_set-up_watch
==================
WARNING: DATA RACE
Read at 0x00c00023a240 by goroutine 19:
  k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/server/filters.TestClientReceivedGOAWAY.func1.1()
      staging/src/k8s.io/apiserver/pkg/server/filters/goaway_test.go:353 +0x1c4
  k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/server/filters.newGOAWAYClient.func1()
      staging/src/k8s.io/apiserver/pkg/server/filters/goaway_test.go:208 +0x86
  net/http.(*Transport).customDialTLS()
      GOROOT/src/net/http/transport.go:1289 +0xe9
  net/http.(*Transport).dialConn()
      GOROOT/src/net/http/transport.go:1551 +0x504
  net/http.(*Transport).dialConnFor()
      GOROOT/src/net/http/transport.go:1421 +0x151

Previous write at 0x00c00023a240 by goroutine 32:
  k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/server/filters.TestClientReceivedGOAWAY.func1.1()
      staging/src/k8s.io/apiserver/pkg/server/filters/goaway_test.go:353 +0x251
  k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/server/filters.newGOAWAYClient.func1()
      staging/src/k8s.io/apiserver/pkg/server/filters/goaway_test.go:208 +0x86
  net/http.(*Transport).customDialTLS()
      GOROOT/src/net/http/transport.go:1289 +0xe9
  net/http.(*Transport).dialConn()
      GOROOT/src/net/http/transport.go:1551 +0x504
  net/http.(*Transport).dialConnFor()
      GOROOT/src/net/http/transport.go:1421 +0x151

Goroutine 19 (running) created at:
  net/http.(*Transport).queueForDial()
      GOROOT/src/net/http/transport.go:1390 +0x6af
  net/http.(*Transport).getConn()
      GOROOT/src/net/http/transport.go:1344 +0x7e7
  net/http.(*Transport).roundTrip()
      GOROOT/src/net/http/transport.go:569 +0xaa4
  net/http.(*Transport).RoundTrip()
      GOROOT/src/net/http/roundtrip.go:17 +0x46
  net/http.send()
      GOROOT/src/net/http/client.go:252 +0x6da
  net/http.(*Client).send()
      GOROOT/src/net/http/client.go:176 +0x1d5
  net/http.(*Client).do()
      GOROOT/src/net/http/client.go:718 +0x2d7
  net/http.(*Client).Do()
      GOROOT/src/net/http/client.go:586 +0x390
  k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/server/filters.requestGOAWAYServer()
      staging/src/k8s.io/apiserver/pkg/server/filters/goaway_test.go:240 +0x37a
  k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/server/filters.TestClientReceivedGOAWAY.func1()
      staging/src/k8s.io/apiserver/pkg/server/filters/goaway_test.go:362 +0x35b
  testing.tRunner()
      GOROOT/src/testing/testing.go:1108 +0x202

Goroutine 32 (running) created at:
  net/http.(*Transport).queueForDial()
      GOROOT/src/net/http/transport.go:1390 +0x6af
  net/http.(*Transport).getConn()
      GOROOT/src/net/http/transport.go:1344 +0x7e7
  net/http.(*Transport).roundTrip()
      GOROOT/src/net/http/transport.go:569 +0xaa4
  net/http.(*Transport).RoundTrip()
      GOROOT/src/net/http/roundtrip.go:17 +0x46
  net/http.send()
      GOROOT/src/net/http/client.go:252 +0x6da
  net/http.(*Client).send()
      GOROOT/src/net/http/client.go:176 +0x1d5
  net/http.(*Client).do()
      GOROOT/src/net/http/client.go:718 +0x2d7
  net/http.(*Client).Do()
      GOROOT/src/net/http/client.go:586 +0x390
  k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/server/filters.requestGOAWAYServer()
      staging/src/k8s.io/apiserver/pkg/server/filters/goaway_test.go:240 +0x37a
  k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/server/filters.TestClientReceivedGOAWAY.func1()
      staging/src/k8s.io/apiserver/pkg/server/filters/goaway_test.go:362 +0x35b
  testing.tRunner()
      GOROOT/src/testing/testing.go:1108 +0x202
==================
```

Apparently the cause is `localAddr` was read and written by multiple goroutine: https://github.com/kubernetes/kubernetes/blob/3cdfdfccc9e46858f556cc7d43abdb8966a52e45/staging/src/k8s.io/apiserver/pkg/server/filters/goaway_test.go#L346-L353

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of #94528

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
