### PR TITLE
test(azure): Deflake TestCacheNoConcurrentGet

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/azure/cache/azure_cache.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/cache/azure_cache.go
@@ -103,6 +103,15 @@ func (t *TimedCache) getInternal(key string) (*AzureCacheEntry, error) {
 	t.Lock.Lock()
 	defer t.Lock.Unlock()
 
+	// Another goroutine might have written the same key.
+	entry, exists, err = t.Store.GetByKey(key)
+	if err != nil {
+		return nil, err
+	}
+	if exists {
+		return entry.(*AzureCacheEntry), nil
+	}
+
 	// Still not found, add new entry with nil data.
 	// Note the data will be filled later by getter.
 	newEntry := &AzureCacheEntry{

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/cache/azure_cache_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/cache/azure_cache_test.go
@@ -195,8 +195,10 @@ func TestCacheNoConcurrentGet(t *testing.T) {
 	var wg sync.WaitGroup
 	for i := 0; i < 5; i++ {
 		wg.Add(1)
-		go cache.Get(key, CacheReadTypeDefault)
-		wg.Done()
+		go func() {
+			defer wg.Done()
+			_, _ = cache.Get(key, CacheReadTypeDefault)
+		}()
 	}
 	v, err := cache.Get(key, CacheReadTypeDefault)
 	wg.Wait()


### PR DESCRIPTION

**What type of PR is this?**

/kind flake
/kind bug

**What this PR does / why we need it**:

There are two kinds of flake in `TestCacheNoConcurrentGet`:

1. A test-only issue
```
==================
WARNING: DATA RACE
Write at 0x00c000110060 by goroutine 19:
  k8s.io/legacy-cloud-providers/azure/cache.(*fakeDataSource).get()
      /Users/knight/go/src/k8s.io/kubernetes/staging/src/k8s.io/legacy-cloud-providers/azure/cache/azure_cache_test.go:46 +0xdd
  k8s.io/legacy-cloud-providers/azure/cache.(*fakeDataSource).get-fm()
      /Users/knight/go/src/k8s.io/kubernetes/staging/src/k8s.io/legacy-cloud-providers/azure/cache/azure_cache_test.go:42 +0x59
  k8s.io/legacy-cloud-providers/azure/cache.(*TimedCache).Get()
      /Users/knight/go/src/k8s.io/kubernetes/staging/src/k8s.io/legacy-cloud-providers/azure/cache/azure_cache.go:140 +0x18e

Previous read at 0x00c000110060 by goroutine 14:
  k8s.io/legacy-cloud-providers/azure/cache.TestCacheNoConcurrentGet()
      /Users/knight/go/src/k8s.io/kubernetes/staging/src/k8s.io/legacy-cloud-providers/azure/cache/azure_cache_test.go:204 +0x2a8
  testing.tRunner()
      /usr/local/Cellar/go/1.15/libexec/src/testing/testing.go:1108 +0x202

Goroutine 19 (running) created at:
  k8s.io/legacy-cloud-providers/azure/cache.TestCacheNoConcurrentGet()
      /Users/knight/go/src/k8s.io/kubernetes/staging/src/k8s.io/legacy-cloud-providers/azure/cache/azure_cache_test.go:198 +0x1be
  testing.tRunner()
      /usr/local/Cellar/go/1.15/libexec/src/testing/testing.go:1108 +0x202

Goroutine 14 (running) created at:
  testing.(*T).Run()
      /usr/local/Cellar/go/1.15/libexec/src/testing/testing.go:1159 +0x796
  testing.runTests.func1()
      /usr/local/Cellar/go/1.15/libexec/src/testing/testing.go:1430 +0xa6
  testing.tRunner()
      /usr/local/Cellar/go/1.15/libexec/src/testing/testing.go:1108 +0x202
  testing.runTests()
      /usr/local/Cellar/go/1.15/libexec/src/testing/testing.go:1428 +0x5aa
  testing.(*M).Run()
      /usr/local/Cellar/go/1.15/libexec/src/testing/testing.go:1338 +0x4eb
  main.main()
      _testmain.go:55 +0x236
==================
```
When we are accessing `dataSource.called` in the test https://github.com/kubernetes/kubernetes/blob/a23cf7077ea8d463674382043aeff10322c840ce/staging/src/k8s.io/legacy-cloud-providers/azure/cache/azure_cache_test.go#L204, goroutines created at https://github.com/kubernetes/kubernetes/blob/a23cf7077ea8d463674382043aeff10322c840ce/staging/src/k8s.io/legacy-cloud-providers/azure/cache/azure_cache_test.go#L198 might still be running, so `dataSource.called` might be modified.

2. A non-critical bug, imho
```
--- FAIL: TestCacheNoConcurrentGet (2.01s)
    azure_cache_test.go:204: 
        	Error Trace:	azure_cache_test.go:204
        	Error:      	Not equal: 
        	            	expected: 1
        	            	actual  : 2
        	Test:       	TestCacheNoConcurrentGet
    testing.go:1023: race detected during execution of test
FAIL
```

I added the following debugging:
```diff
diff --git staging/src/k8s.io/legacy-cloud-providers/azure/cache/azure_cache.go staging/src/k8s.io/legacy-cloud-providers/azure/cache/azure_cache.go
index 39c679ebc8d..7f61895b3af 100644
--- staging/src/k8s.io/legacy-cloud-providers/azure/cache/azure_cache.go
+++ staging/src/k8s.io/legacy-cloud-providers/azure/cache/azure_cache.go
@@ -97,6 +97,7 @@ func (t *TimedCache) getInternal(key string) (*AzureCacheEntry, error) {
        if exists {
                return entry.(*AzureCacheEntry), nil
        }
+       fmt.Printf("getInternal: key=%s, exists=%v\n", key, exists)

        // lock here to ensure if entry doesn't exist, we add a new entry
        // avoiding overwrites
```

If the test fails, I got:
```
getInternal: key=key1, exists=false
getInternal: key=key1, exists=false
--- FAIL: TestCacheNoConcurrentGet (2.00s)
    azure_cache_test.go:206: 
        	Error Trace:	azure_cache_test.go:206
        	Error:      	Not equal: 
        	            	expected: 1
        	            	actual  : 2
        	Test:       	TestCacheNoConcurrentGet
FAIL
```

If the test passes:
```
getInternal: key=key1, exists=false
PASS
```

I think the cause is If there are multiple goroutines getting a same key, these goroutines might invoke `TimedCache.getInternal` at the same time when this key does not exist, i.e. they reach https://github.com/kubernetes/kubernetes/blob/a23cf7077ea8d463674382043aeff10322c840ce/staging/src/k8s.io/legacy-cloud-providers/azure/cache/azure_cache.go#L101-L104 at the same time. When a goroutine save the entry in the store, another goroutine may overwrite it later.



**Which issue(s) this PR fixes**:

Part of #94528

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
