### PR TITLE
Deflake serving options, avoid hard-coding ports

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/options/serving_unix_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/serving_unix_test.go
@@ -19,31 +19,37 @@ limitations under the License.
 package options
 
 import (
+	"fmt"
 	"net"
 	"testing"
 )
 
 func TestCreateListenerSharePort(t *testing.T) {
-	addr := "127.0.0.1:12345"
 	c := net.ListenConfig{Control: permitPortReuse}
 
-	if _, _, err := CreateListener("tcp", addr, c); err != nil {
+	l, port, err := CreateListener("tcp", "127.0.0.1:0", c)
+	if err != nil {
 		t.Fatalf("failed to create listener: %v", err)
 	}
+	defer l.Close()
 
-	if _, _, err := CreateListener("tcp", addr, c); err != nil {
+	l2, _, err := CreateListener("tcp", fmt.Sprintf("127.0.0.1:%d", port), c)
+	if err != nil {
 		t.Fatalf("failed to create 2nd listener: %v", err)
 	}
+	defer l2.Close()
 }
 
 func TestCreateListenerPreventUpgrades(t *testing.T) {
-	addr := "127.0.0.1:12346"
-
-	if _, _, err := CreateListener("tcp", addr, net.ListenConfig{}); err != nil {
+	l, port, err := CreateListener("tcp", "127.0.0.1:0", net.ListenConfig{})
+	if err != nil {
 		t.Fatalf("failed to create listener: %v", err)
 	}
+	defer l.Close()
 
-	if _, _, err := CreateListener("tcp", addr, net.ListenConfig{Control: permitPortReuse}); err == nil {
+	l2, _, err := CreateListener("tcp", fmt.Sprintf("127.0.0.1:%d", port), net.ListenConfig{Control: permitPortReuse})
+	if err == nil {
+		l2.Close()
 		t.Fatalf("creating second listener without port sharing should fail")
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind flake

**What this PR does / why we need it**:
Avoids hard-coding ports in the serving tests, to avoid flakes if the ports are in use or the test is run multiple times in parallel

**Which issue(s) this PR fixes**:
xref https://github.com/kubernetes/kubernetes/issues/94528#issuecomment-687208028, https://testgrid.k8s.io/sig-release-master-blocking#bazel-test-master&width=20&sort-by-name=&include-filter-by-regex=k8s.io/apiserver/pkg/server/options/go


```release-note
NONE
```

/assign @sttts