### PR TITLE
test(kuberuntime): deflake TestRecordOperation

### DIFF
--- a/pkg/kubelet/kuberuntime/instrumented_services_test.go
+++ b/pkg/kubelet/kuberuntime/instrumented_services_test.go
@@ -34,17 +34,16 @@ func TestRecordOperation(t *testing.T) {
 	legacyregistry.MustRegister(metrics.RuntimeOperationsDuration)
 	legacyregistry.MustRegister(metrics.RuntimeOperationsErrors)
 
-	temporalServer := "127.0.0.1:1234"
-	l, err := net.Listen("tcp", temporalServer)
+	l, err := net.Listen("tcp", "127.0.0.1:0")
 	assert.NoError(t, err)
 	defer l.Close()
 
-	prometheusURL := "http://" + temporalServer + "/metrics"
+	prometheusURL := "http://" + l.Addr().String() + "/metrics"
 	mux := http.NewServeMux()
 	//lint:ignore SA1019 ignore deprecated warning until we move off of global registries
 	mux.Handle("/metrics", legacyregistry.Handler())
 	server := &http.Server{
-		Addr:    temporalServer,
+		Addr:    l.Addr().String(),
 		Handler: mux,
 	}
 	go func() {


### PR DESCRIPTION
Signed-off-by: knight42 <anonymousknight96@gmail.com>

**What type of PR is this?**

/kind flake

**What this PR does / why we need it**:

https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/periodic-kubernetes-bazel-test-master/1302097743879081990

```
=== RUN   TestRecordOperation
    instrumented_services_test.go:39: 
        	Error Trace:	instrumented_services_test.go:39
        	Error:      	Received unexpected error:
        	            	listen tcp 127.0.0.1:1234: bind: address already in use
        	Test:       	TestRecordOperation
--- FAIL: TestRecordOperation (0.00s)
```

Avoid using hard-coded port

**Which issue(s) this PR fixes**:

Part of #94528

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
