### PR TITLE
Fix the default KubeletReadOnlyPort value to 0 (disabled)

### DIFF
--- a/pkg/cluster/ports/ports.go
+++ b/pkg/cluster/ports/ports.go
@@ -33,10 +33,7 @@ const (
 	InsecureKubeControllerManagerPort = 10252
 	// KubeletReadOnlyPort exposes basic read-only services from the kubelet.
 	// May be overridden by a flag at startup.
-	// This is necessary for heapster to collect monitoring stats from the kubelet
-	// until heapster can transition to using the SSL endpoint.
-	// TODO(roberthbailey): Remove this once we have a better solution for heapster.
-	KubeletReadOnlyPort = 10255
+	KubeletReadOnlyPort = 0
 	// ProxyHealthzPort is the default port for the proxy healthz server.
 	// May be overridden by a flag at startup.
 	ProxyHealthzPort = 10256


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind cleanup


**What this PR does / why we need it**:
"--read-only-port" field description (default 10255) is confusing, fix it.

Before:
```
 root@william  ~/go/src/k8s.io/kubernetes  _output/local/bin/linux/amd64/kubelet --help | grep read-only                                        ✔  ⚡  7962  15:42:18
      --read-only-port int32                                     The read-only port for the Kubelet to serve on with no authentication/authorization (set to 0 to disable) (default 10255) (DEPRECATED: This parameter should be set via the config file specified by the Kubelet's --config flag. See https://kubernetes.io/docs/tasks/administer-cluster/kubelet-config-file/ for more information.)
 root@william  ~/go/src/k8s.io/kubernetes                                                                                                       ✔  ⚡  7963  15:42:25
```

After:
```
 root@william  ~/go/src/k8s.io/kubernetes  _output/local/bin/linux/amd64/kubelet --help | grep read-only                                        ✔  ⚡  7968  16:33:12
      --read-only-port int32                                     The read-only port for the Kubelet to serve on with no authentication/authorization (set to 0 to disable) (DEPRECATED: This parameter should be set via the config file specified by the Kubelet's --config flag. See https://kubernetes.io/docs/tasks/administer-cluster/kubelet-config-file/ for more information.)
 root@william  ~/go/src/k8s.io/kubernetes                                                                                                       ✔  ⚡  7969  16:33:17
```

**Which issue(s) this PR fixes**:
Fixes #94550

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
N/A
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
