### PR TITLE
Deflake TestRestoreAllWaitOldIptablesRestore

### DIFF
--- a/pkg/util/iptables/iptables.go
+++ b/pkg/util/iptables/iptables.go
@@ -186,8 +186,11 @@ const WaitIntervalString = "-W"
 // WaitIntervalUsecondsValue a constant for specifying the default wait interval useconds
 const WaitIntervalUsecondsValue = "100000"
 
-// LockfilePath16x is the iptables lock file acquired by any process that's making any change in the iptable rule
+// LockfilePath16x is the iptables 1.6.x lock file acquired by any process that's making any change in the iptable rule
 const LockfilePath16x = "/run/xtables.lock"
+
+// LockfilePath14x is the iptables 1.4.x lock file acquired by any process that's making any change in the iptable rule
+const LockfilePath14x = "@xtables"
 
 // runner implements Interface in terms of exec("iptables").
 type runner struct {
@@ -198,20 +201,24 @@ type runner struct {
 	hasRandomFully  bool
 	waitFlag        []string
 	restoreWaitFlag []string
-	lockfilePath    string
+	lockfilePath14x string
+	lockfilePath16x string
 }
 
 // newInternal returns a new Interface which will exec iptables, and allows the
 // caller to change the iptables-restore lockfile path
-func newInternal(exec utilexec.Interface, protocol Protocol, lockfilePath string) Interface {
+func newInternal(exec utilexec.Interface, protocol Protocol, lockfilePath14x, lockfilePath16x string) Interface {
 	version, err := getIPTablesVersion(exec, protocol)
 	if err != nil {
 		klog.Warningf("Error checking iptables version, assuming version at least %s: %v", MinCheckVersion, err)
 		version = MinCheckVersion
 	}
 
-	if lockfilePath == "" {
-		lockfilePath = LockfilePath16x
+	if lockfilePath16x == "" {
+		lockfilePath16x = LockfilePath16x
+	}
+	if lockfilePath14x == "" {
+		lockfilePath14x = LockfilePath14x
 	}
 
 	runner := &runner{
@@ -221,14 +228,15 @@ func newInternal(exec utilexec.Interface, protocol Protocol, lockfilePath string
 		hasRandomFully:  version.AtLeast(RandomFullyMinVersion),
 		waitFlag:        getIPTablesWaitFlag(version),
 		restoreWaitFlag: getIPTablesRestoreWaitFlag(version, exec, protocol),
-		lockfilePath:    lockfilePath,
+		lockfilePath14x: lockfilePath14x,
+		lockfilePath16x: lockfilePath16x,
 	}
 	return runner
 }
 
 // New returns a new Interface which will exec iptables.
 func New(exec utilexec.Interface, protocol Protocol) Interface {
-	return newInternal(exec, protocol, "")
+	return newInternal(exec, protocol, "", "")
 }
 
 // EnsureChain is part of Interface.
@@ -390,7 +398,7 @@ func (runner *runner) restoreInternal(args []string, data []byte, flush FlushFla
 	// from stepping on each other.  iptables-restore 1.6.2 will have
 	// a --wait option like iptables itself, but that's not widely deployed.
 	if len(runner.restoreWaitFlag) == 0 {
-		locker, err := grabIptablesLocks(runner.lockfilePath)
+		locker, err := grabIptablesLocks(runner.lockfilePath14x, runner.lockfilePath16x)
 		if err != nil {
 			return err
 		}

--- a/pkg/util/iptables/iptables_linux.go
+++ b/pkg/util/iptables/iptables_linux.go
@@ -49,7 +49,7 @@ func (l *locker) Close() error {
 	return utilerrors.NewAggregate(errList)
 }
 
-func grabIptablesLocks(lockfilePath string) (iptablesLocker, error) {
+func grabIptablesLocks(lockfilePath14x, lockfilePath16x string) (iptablesLocker, error) {
 	var err error
 	var success bool
 
@@ -66,9 +66,9 @@ func grabIptablesLocks(lockfilePath string) (iptablesLocker, error) {
 	// can't assume which lock method it'll use.
 
 	// Roughly duplicate iptables 1.6.x xtables_lock() function.
-	l.lock16, err = os.OpenFile(lockfilePath, os.O_CREATE, 0600)
+	l.lock16, err = os.OpenFile(lockfilePath16x, os.O_CREATE, 0600)
 	if err != nil {
-		return nil, fmt.Errorf("failed to open iptables lock %s: %v", lockfilePath, err)
+		return nil, fmt.Errorf("failed to open iptables lock %s: %v", lockfilePath16x, err)
 	}
 
 	if err := wait.PollImmediate(200*time.Millisecond, 2*time.Second, func() (bool, error) {
@@ -82,7 +82,7 @@ func grabIptablesLocks(lockfilePath string) (iptablesLocker, error) {
 
 	// Roughly duplicate iptables 1.4.x xtables_lock() function.
 	if err := wait.PollImmediate(200*time.Millisecond, 2*time.Second, func() (bool, error) {
-		l.lock14, err = net.ListenUnix("unix", &net.UnixAddr{Name: "@xtables", Net: "unix"})
+		l.lock14, err = net.ListenUnix("unix", &net.UnixAddr{Name: lockfilePath14x, Net: "unix"})
 		if err != nil {
 			return false, nil
 		}

--- a/pkg/util/iptables/iptables_unsupported.go
+++ b/pkg/util/iptables/iptables_unsupported.go
@@ -23,7 +23,7 @@ import (
 	"os"
 )
 
-func grabIptablesLocks(lockfilePath string) (iptablesLocker, error) {
+func grabIptablesLocks(lock14filePath, lock16filePath string) (iptablesLocker, error) {
 	return nil, fmt.Errorf("iptables unsupported on this platform")
 }
 


### PR DESCRIPTION
Signed-off-by: knight42 <anonymousknight96@gmail.com>

**What type of PR is this?**

/kind flake


**What this PR does / why we need it**:

https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/periodic-kubernetes-bazel-test-master/1302138009876959232

```
=== RUN   TestRestoreAllWaitOldIptablesRestore
I0905 07:22:09.261781  188833 trace.go:205] Trace[1298498081]: "iptables restore" (05-Sep-2020 07:22:07.260) (total time: 2000ms):
Trace[1298498081]: [2.000885887s] [2.000885887s] END
    iptables_test.go:1028: expected success, got failed to acquire old iptables lock: timed out waiting for the condition
--- FAIL: TestRestoreAllWaitOldIptablesRestore (2.00s)
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of #94528

**Special notes for your reviewer**:

Since this test could only be run on linux, I have not verified the fix locally.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
