### PR TITLE
test(watch-tool): deflake TestRetryWatcherToFinishWithUnreadEvents

### DIFF
--- a/staging/src/k8s.io/client-go/tools/watch/retrywatcher_test.go
+++ b/staging/src/k8s.io/client-go/tools/watch/retrywatcher_test.go
@@ -587,11 +587,12 @@ func TestRetryWatcherToFinishWithUnreadEvents(t *testing.T) {
 
 	watcher.Stop()
 
+	maxTime := time.Second
 	select {
 	case <-watcher.Done():
 		break
-	case <-time.After(10 * time.Millisecond):
-		t.Error("Failed to close the watcher")
+	case <-time.After(maxTime):
+		t.Errorf("The watcher failed to be closed in %s", maxTime)
 	}
 
 	// RetryWatcher result channel should be closed


### PR DESCRIPTION
Signed-off-by: knight42 <anonymousknight96@gmail.com>

**What type of PR is this?**

/kind flake

**What this PR does / why we need it**:

https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/periodic-kubernetes-bazel-test-master/1302148076210753536
```
=== RUN   TestRetryWatcherToFinishWithUnreadEvents
I0905 08:00:46.207132  188302 retrywatcher.go:275] Stopping RetryWatcher.
    retrywatcher_test.go:594: Failed to close the watcher
--- FAIL: TestRetryWatcherToFinishWithUnreadEvents (0.04s)
```

The current timeout seems to be too tight, when I tested locally, the time cost to stop the watcher could be:
```
16.398244ms
10.165828ms
10.182775ms
10.197831ms
```
I think `20ms` is a more reasonable timeout.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of #94528

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
