### PR TITLE
test(workqueue): deflake TestMetrics

### DIFF
--- a/staging/src/k8s.io/client-go/util/workqueue/metrics_test.go
+++ b/staging/src/k8s.io/client-go/util/workqueue/metrics_test.go
@@ -252,13 +252,17 @@ func TestMetrics(t *testing.T) {
 	// use a channel to ensure we don't look at the metric before it's
 	// been set.
 	ch := make(chan struct{}, 1)
+	longestCh := make(chan struct{}, 1)
 	mp.unfinished.notifyCh = ch
+	mp.longest.notifyCh = longestCh
 	c.Step(time.Millisecond)
 	<-ch
 	mp.unfinished.notifyCh = nil
 	if e, a := .001, mp.unfinished.gaugeValue(); e != a {
 		t.Errorf("expected %v, got %v", e, a)
 	}
+	<-longestCh
+	mp.longest.notifyCh = nil
 	if e, a := .001, mp.longest.gaugeValue(); e != a {
 		t.Errorf("expected %v, got %v", e, a)
 	}


### PR DESCRIPTION
Signed-off-by: knight42 <anonymousknight96@gmail.com>

**What type of PR is this?**

/kind flake

**What this PR does / why we need it**:

We need to ensure https://github.com/kubernetes/kubernetes/blob/1f708f6e6272a8f4c5b9a32cc3aea33ff79aeec1/staging/src/k8s.io/client-go/util/workqueue/metrics.go#L141 has been called before invoking `mp.longest.gaugeValue()`.

**Which issue(s) this PR fixes**:

Fixes #94545 
Part of #94528

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
