### PR TITLE
test(proxy::config): deflake TestInitialSync

### DIFF
--- a/pkg/proxy/config/api_test.go
+++ b/pkg/proxy/config/api_test.go
@@ -18,15 +18,15 @@ package config
 
 import (
 	"reflect"
-	"sync"
 	"testing"
 	"time"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
-	informers "k8s.io/client-go/informers"
+	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
 	ktesting "k8s.io/client-go/testing"
 )
@@ -148,34 +148,6 @@ func TestNewEndpointsSourceApi_UpdatesAndMultipleEndpoints(t *testing.T) {
 	handler.ValidateEndpoints(t, []*v1.Endpoints{})
 }
 
-func newSvcHandler(t *testing.T, svcs []*v1.Service, done func()) ServiceHandler {
-	shm := &ServiceHandlerMock{
-		state: make(map[types.NamespacedName]*v1.Service),
-	}
-	var callDoneOnce sync.Once
-	shm.process = func(services []*v1.Service) {
-		defer callDoneOnce.Do(done)
-		if !reflect.DeepEqual(services, svcs) {
-			t.Errorf("Unexpected services: %#v, expected: %#v", services, svcs)
-		}
-	}
-	return shm
-}
-
-func newEpsHandler(t *testing.T, eps []*v1.Endpoints, done func()) EndpointsHandler {
-	ehm := &EndpointsHandlerMock{
-		state: make(map[types.NamespacedName]*v1.Endpoints),
-	}
-	var callDoneOnce sync.Once
-	ehm.process = func(endpoints []*v1.Endpoints) {
-		defer callDoneOnce.Do(done)
-		if !reflect.DeepEqual(eps, endpoints) {
-			t.Errorf("Unexpected endpoints: %#v, expected: %#v", endpoints, eps)
-		}
-	}
-	return ehm
-}
-
 func TestInitialSync(t *testing.T) {
 	svc1 := &v1.Service{
 		ObjectMeta: metav1.ObjectMeta{Namespace: "testnamespace", Name: "foo"},
@@ -192,25 +164,73 @@ func TestInitialSync(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Namespace: "testnamespace", Name: "bar"},
 	}
 
-	var wg sync.WaitGroup
-	// Wait for both services and endpoints handler.
-	wg.Add(2)
+	expectedSvcState := map[types.NamespacedName]*v1.Service{
+		{Name: svc1.Name, Namespace: svc1.Namespace}: svc1,
+		{Name: svc2.Name, Namespace: svc2.Namespace}: svc2,
+	}
+	expectedEpsState := map[types.NamespacedName]*v1.Endpoints{
+		{Name: eps1.Name, Namespace: eps1.Namespace}: eps1,
+		{Name: eps2.Name, Namespace: eps2.Namespace}: eps2,
+	}
 
 	// Setup fake api client.
 	client := fake.NewSimpleClientset(svc1, svc2, eps2, eps1)
 	sharedInformers := informers.NewSharedInformerFactory(client, 0)
 
 	svcConfig := NewServiceConfig(sharedInformers.Core().V1().Services(), 0)
-	epsConfig := NewEndpointsConfig(sharedInformers.Core().V1().Endpoints(), 0)
-	svcHandler := newSvcHandler(t, []*v1.Service{svc2, svc1}, wg.Done)
+	svcHandler := NewServiceHandlerMock()
 	svcConfig.RegisterEventHandler(svcHandler)
-	epsHandler := newEpsHandler(t, []*v1.Endpoints{eps2, eps1}, wg.Done)
+
+	epsConfig := NewEndpointsConfig(sharedInformers.Core().V1().Endpoints(), 0)
+	epsHandler := NewEndpointsHandlerMock()
 	epsConfig.RegisterEventHandler(epsHandler)
 
 	stopCh := make(chan struct{})
 	defer close(stopCh)
-	go sharedInformers.Start(stopCh)
-	go svcConfig.Run(stopCh)
-	go epsConfig.Run(stopCh)
-	wg.Wait()
+	sharedInformers.Start(stopCh)
+
+	err := wait.PollImmediate(time.Millisecond*10, wait.ForeverTestTimeout, func() (bool, error) {
+		svcHandler.lock.Lock()
+		defer svcHandler.lock.Unlock()
+		if reflect.DeepEqual(svcHandler.state, expectedSvcState) {
+			return true, nil
+		}
+		return false, nil
+	})
+	if err != nil {
+		t.Fatal("Timed out waiting for the completion of handler `OnServiceAdd`")
+	}
+
+	err = wait.PollImmediate(time.Millisecond*10, wait.ForeverTestTimeout, func() (bool, error) {
+		epsHandler.lock.Lock()
+		defer epsHandler.lock.Unlock()
+		if reflect.DeepEqual(epsHandler.state, expectedEpsState) {
+			return true, nil
+		}
+		return false, nil
+	})
+	if err != nil {
+		t.Fatal("Timed out waiting for the completion of handler `OnEndpointsAdd`")
+	}
+
+	svcConfig.Run(stopCh)
+	epsConfig.Run(stopCh)
+
+	gotSvc := <-svcHandler.updated
+	gotSvcState := make(map[types.NamespacedName]*v1.Service, len(gotSvc))
+	for _, svc := range gotSvc {
+		gotSvcState[types.NamespacedName{Namespace: svc.Namespace, Name: svc.Name}] = svc
+	}
+	if !reflect.DeepEqual(gotSvcState, expectedSvcState) {
+		t.Fatalf("Expected service state: %v\nGot: %v\n", expectedSvcState, gotSvcState)
+	}
+
+	gotEps := <-epsHandler.updated
+	gotEpsState := make(map[types.NamespacedName]*v1.Endpoints, len(gotEps))
+	for _, eps := range gotEps {
+		gotEpsState[types.NamespacedName{Namespace: eps.Namespace, Name: eps.Name}] = eps
+	}
+	if !reflect.DeepEqual(gotEpsState, expectedEpsState) {
+		t.Fatalf("Expected endpoints state: %v\nGot: %v\n", expectedEpsState, gotEpsState)
+	}
 }


### PR DESCRIPTION
Signed-off-by: knight42 <anonymousknight96@gmail.com>


**What type of PR is this?**

/kind flake

**What this PR does / why we need it**:

https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/94556/pull-kubernetes-bazel-test/1302309891905425412

```
=== RUN   TestInitialSync
I0905 18:24:19.320048      23 config.go:315] Starting service config controller
I0905 18:24:19.320662      23 shared_informer.go:240] Waiting for caches to sync for service config
I0905 18:24:19.324410      23 shared_informer.go:247] Caches are synced for service config 
I0905 18:24:19.320602      23 config.go:133] Starting endpoints config controller
I0905 18:24:19.325287      23 shared_informer.go:240] Waiting for caches to sync for endpoints config
I0905 18:24:19.325457      23 shared_informer.go:247] Caches are synced for endpoints config 
    api_test.go:171: Unexpected endpoints: []*v1.Endpoints{(*v1.Endpoints)(0xc0000dc500)}, expected: []*v1.Endpoints{(*v1.Endpoints)(0xc0003e5cc0), (*v1.Endpoints)(0xc0003e5b80)}
--- FAIL: TestInitialSync (0.01s)
```

The error could be reproduced by the following patch:
```diff
diff --git pkg/proxy/config/config_test.go pkg/proxy/config/config_test.go
index 531b3b1a089..bec2aca56d9 100644
--- pkg/proxy/config/config_test.go
+++ pkg/proxy/config/config_test.go
@@ -23,7 +23,7 @@ import (
 	"testing"
 	"time"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -161,6 +161,7 @@ func NewEndpointsHandlerMock() *EndpointsHandlerMock {
 }
 
 func (h *EndpointsHandlerMock) OnEndpointsAdd(endpoints *v1.Endpoints) {
+	time.Sleep(time.Second)
 	h.lock.Lock()
 	defer h.lock.Unlock()
 	namespacedName := types.NamespacedName{Namespace: endpoints.Namespace, Name: endpoints.Name}
```

I think the root cause is even after the cache is synced, the execution of event handlers, such as [`OnEndpointsAdd`](https://github.com/kubernetes/kubernetes/blob/master/pkg/proxy/config/config_test.go#L163), might not have completed yet, so the function in `process` field received unexpected endpoints.

**Which issue(s) this PR fixes**:

Part of #94528

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
