### PR TITLE
test(tools::events): deflake TestEventSeriesf

### DIFF
--- a/staging/src/k8s.io/client-go/tools/events/eventseries_test.go
+++ b/staging/src/k8s.io/client-go/tools/events/eventseries_test.go
@@ -69,7 +69,6 @@ func TestEventSeriesf(t *testing.T) {
 
 	testPod := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			SelfLink:  "/api/v1/namespaces/baz/pods/foo",
 			Name:      "foo",
 			Namespace: "baz",
 			UID:       "bar",
@@ -158,7 +157,11 @@ func TestEventSeriesf(t *testing.T) {
 	}
 	eventBroadcaster := newBroadcaster(&testEvents, 0, map[eventKey]*eventsv1.Event{})
 	recorder := eventBroadcaster.NewRecorder(scheme.Scheme, "eventTest")
-	eventBroadcaster.StartRecordingToSink(stopCh)
+	broadcaster := eventBroadcaster.(*eventBroadcasterImpl)
+	// Don't call StartRecordingToSink, as we don't need neither refreshing event
+	// series nor finishing them in this tests and additional events updated would
+	// race with our expected ones.
+	broadcaster.startRecordingEvents(stopCh)
 	recorder.Eventf(regarding, related, isomorphicEvent.Type, isomorphicEvent.Reason, isomorphicEvent.Action, isomorphicEvent.Note, []interface{}{1})
 	// read from the chan as this was needed only to populate the cache
 	<-createEvent


### PR DESCRIPTION
Signed-off-by: knight42 <anonymousknight96@gmail.com>


**What type of PR is this?**

/kind flake

**What this PR does / why we need it**:

I added the following logging:
```patch
diff --git staging/src/k8s.io/client-go/tools/events/event_broadcaster.go staging/src/k8s.io/client-go/tools/events/event_broadcaster.go
index 3c6870a20d5..dec9b6289a2 100644
--- staging/src/k8s.io/client-go/tools/events/event_broadcaster.go
+++ staging/src/k8s.io/client-go/tools/events/event_broadcaster.go
@@ -126,6 +126,8 @@ func (e *eventBroadcasterImpl) refreshExistingEventSeries() {
        // TODO: Investigate whether lock contention won't be a problem
        e.mu.Lock()
        defer e.mu.Unlock()
+       klog.Infof("refreshExistingEventSeries called, len(e.eventCache)=%d", len(e.eventCache))
+       defer klog.Infof("refreshExistingEventSeries done")
        for isomorphicKey, event := range e.eventCache {
                if event.Series != nil {
                        if recordedEvent, retry := recordEvent(e.sink, event); !retry {
@@ -321,6 +323,7 @@ func (e *eventBroadcasterImpl) StartRecordingToSink(stopCh <-chan struct{}) {
                        klog.Errorf("unexpected type, expected eventsv1.Event")
                        return
                }
+               klog.Infof("eventHandler: ev:action=%s\n", event.Action)
                e.recordToSink(event, clock.RealClock{})
        }
        stopWatcher := e.StartEventWatcher(eventHandler)
```

And got:
```
#### Success
=== RUN   TestEventSeriesf
I0906 16:25:05.865725   17547 event_broadcaster.go:129] refreshExistingEventSeries called, len(e.eventCache)=0
I0906 16:25:05.865946   17547 event_broadcaster.go:140] refreshExistingEventSeries done
I0906 16:25:05.866273   17547 event_broadcaster.go:326] eventHandler: ev:action=started
I0906 16:25:05.866498   17547 event_broadcaster.go:326] eventHandler: ev:action=started
    eventseries_test.go:174: 0 - validating event affected by patch request
I0906 16:25:05.868587   17547 event_broadcaster.go:326] eventHandler: ev:action=stopped
    eventseries_test.go:178: 1 - validating event affected by a create request
--- PASS: TestEventSeriesf (0.00s)
PASS


#### Failure
=== RUN   TestEventSeriesf
I0906 16:26:06.276915   25517 event_broadcaster.go:326] eventHandler: ev:action=started
I0906 16:26:06.277625   25517 event_broadcaster.go:326] eventHandler: ev:action=started
I0906 16:26:06.277914   25517 event_broadcaster.go:129] refreshExistingEventSeries called, len(e.eventCache)=1
    eventseries_test.go:174: 0 - validating event affected by patch request
I0906 16:26:06.282881   25517 event_broadcaster.go:326] eventHandler: ev:action=stopped
panic: test timed out after 2s
```

I think the cause is  an extra patch event might be created by `refreshExistingEventSeries` https://github.com/kubernetes/kubernetes/blob/16ea9dc6bc260c37589e6b104a47009680c26772/staging/src/k8s.io/client-go/tools/events/event_broadcaster.go#L125-L131 between the 2 test cases.
Since `refreshExistingEventSeries` will lock the broadcaster and we don't consume the `patchEvent` channel in the second test case, if channel `patchEvent` is not buffered, `refreshExistingEventSeries` would not release the lock that `recordToSink` try to acquire https://github.com/kubernetes/kubernetes/blob/16ea9dc6bc260c37589e6b104a47009680c26772/staging/src/k8s.io/client-go/tools/events/event_broadcaster.go#L168-L174, so the create event would not be created during the second test and we got stuck.

**Which issue(s) this PR fixes**:

Fixes #94569 
Part of #94528

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
