### PR TITLE
Remove unnecessary double-pointer

### DIFF
--- a/pkg/scheduler/core/extender.go
+++ b/pkg/scheduler/core/extender.go
@@ -394,7 +394,7 @@ func (h *HTTPExtender) Bind(binding *v1.Binding) error {
 		PodUID:       binding.UID,
 		Node:         binding.Target.Name,
 	}
-	if err := h.send(h.bindVerb, &req, &result); err != nil {
+	if err := h.send(h.bindVerb, req, &result); err != nil {
 		return err
 	}
 	if result.Error != "" {


### PR DESCRIPTION
**What type of PR is this?**

```
/kind cleanup
```

**What this PR does / why we need it**:

`req` is a pointer that is passed to `json.Marshal`. The underlying type of the variable passed to `json.Marshal` is a double pointer, ie it is `**extenderv1.ExtenderBindingArgs`.

I removed the second redundant `&` to convert it to `*extenderv1.ExtenderBindingArgs`. The existing implementation has no problem because `json.Marshal` dereferences the values, for example, even a value of type `***int` is marshaled the same way as one with type `int` ([playground example](https://play.golang.org/p/gzc7CjSXEmf)).


**Which issue(s) this PR fixes**:
```
NONE
```

**Special notes for your reviewer**:

```
NONE
```

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs
NONE
```
