### PR TITLE
Fix index out of range panic for kubectl alpha debug

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/debug/debug.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/debug/debug.go
@@ -485,6 +485,8 @@ func (o *DebugOptions) generatePodCopyWithDebugContainer(pod *corev1.Pod) (*core
 		},
 		Spec: *pod.Spec.DeepCopy(),
 	}
+	// set EphemeralContainers to nil so that the copy of pod can be created
+	copied.Spec.EphemeralContainers = nil
 	// change ShareProcessNamespace configuration only when commanded explicitly
 	if o.shareProcessedChanged {
 		copied.Spec.ShareProcessNamespace = pointer.BoolPtr(o.ShareProcesses)
@@ -544,11 +546,11 @@ func containerNameToRef(pod *corev1.Pod) map[string]*corev1.Container {
 		names[ref.Name] = ref
 	}
 	for i := range pod.Spec.InitContainers {
-		ref := &pod.Spec.Containers[i]
+		ref := &pod.Spec.InitContainers[i]
 		names[ref.Name] = ref
 	}
 	for i := range pod.Spec.EphemeralContainers {
-		ref := &pod.Spec.Containers[i]
+		ref := (*corev1.Container)(&pod.Spec.EphemeralContainers[i].EphemeralContainerCommon)
 		names[ref.Name] = ref
 	}
 	return names

--- a/staging/src/k8s.io/kubectl/pkg/cmd/debug/debug_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/debug/debug_test.go
@@ -153,6 +153,74 @@ func TestGenerateDebugContainer(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "pod with init containers",
+			opts: &DebugOptions{
+				Image:      "busybox",
+				PullPolicy: corev1.PullIfNotPresent,
+			},
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					InitContainers: []corev1.Container{
+						{
+							Name: "init-container-1",
+						},
+						{
+							Name: "init-container-2",
+						},
+					},
+					Containers: []corev1.Container{
+						{
+							Name: "debugger",
+						},
+					},
+				},
+			},
+			expected: &corev1.EphemeralContainer{
+				EphemeralContainerCommon: corev1.EphemeralContainerCommon{
+					Name:                     "debugger-1",
+					Image:                    "busybox",
+					ImagePullPolicy:          "IfNotPresent",
+					TerminationMessagePolicy: "File",
+				},
+			},
+		},
+		{
+			name: "pod with ephemeral containers",
+			opts: &DebugOptions{
+				Image:      "busybox",
+				PullPolicy: corev1.PullIfNotPresent,
+			},
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "debugger",
+						},
+					},
+					EphemeralContainers: []corev1.EphemeralContainer{
+						{
+							EphemeralContainerCommon: corev1.EphemeralContainerCommon{
+								Name: "ephemeral-container-1",
+							},
+						},
+						{
+							EphemeralContainerCommon: corev1.EphemeralContainerCommon{
+								Name: "ephemeral-container-2",
+							},
+						},
+					},
+				},
+			},
+			expected: &corev1.EphemeralContainer{
+				EphemeralContainerCommon: corev1.EphemeralContainerCommon{
+					Name:                     "debugger-1",
+					Image:                    "busybox",
+					ImagePullPolicy:          "IfNotPresent",
+					TerminationMessagePolicy: "File",
+				},
+			},
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			tc.opts.IOStreams = genericclioptions.NewTestIOStreamsDiscard()
@@ -567,6 +635,110 @@ func TestGeneratePodCopyWithDebugContainer(t *testing.T) {
 					Containers: []corev1.Container{
 						{
 							Name: "debugger-1",
+						},
+					},
+				},
+			},
+			expected: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "debugger",
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "debugger-1",
+						},
+						{
+							Name:                     "debugger-2",
+							Image:                    "busybox",
+							ImagePullPolicy:          corev1.PullIfNotPresent,
+							TerminationMessagePolicy: corev1.TerminationMessageReadFile,
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "pod with init containers",
+			opts: &DebugOptions{
+				CopyTo:     "debugger",
+				Image:      "busybox",
+				PullPolicy: corev1.PullIfNotPresent,
+			},
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "target",
+				},
+				Spec: corev1.PodSpec{
+					InitContainers: []corev1.Container{
+						{
+							Name: "init-container-1",
+						},
+						{
+							Name: "init-container-2",
+						},
+					},
+					Containers: []corev1.Container{
+						{
+							Name: "debugger-1",
+						},
+					},
+				},
+			},
+			expected: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "debugger",
+				},
+				Spec: corev1.PodSpec{
+					InitContainers: []corev1.Container{
+						{
+							Name: "init-container-1",
+						},
+						{
+							Name: "init-container-2",
+						},
+					},
+					Containers: []corev1.Container{
+						{
+							Name: "debugger-1",
+						},
+						{
+							Name:                     "debugger-2",
+							Image:                    "busybox",
+							ImagePullPolicy:          corev1.PullIfNotPresent,
+							TerminationMessagePolicy: corev1.TerminationMessageReadFile,
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "pod with ephemeral containers",
+			opts: &DebugOptions{
+				CopyTo:     "debugger",
+				Image:      "busybox",
+				PullPolicy: corev1.PullIfNotPresent,
+			},
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "target",
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "debugger-1",
+						},
+					},
+					EphemeralContainers: []corev1.EphemeralContainer{
+						{
+							EphemeralContainerCommon: corev1.EphemeralContainerCommon{
+								Name: "ephemeral-container-1",
+							},
+						},
+						{
+							EphemeralContainerCommon: corev1.EphemeralContainerCommon{
+								Name: "ephemeral-container-2",
+							},
 						},
 					},
 				},


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
When using `kubectl alpha debug` to create a debug container for a pod that has multiple init containers or ephemeral containers, `kubectl alpha debug` fails with `panic: runtime error: index out of range`. This PR fixes this issue.

**Which issue(s) this PR fixes**:
Fixes #94579

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
Fixed a panic in kubectl debug when pod has multiple init containers or ephemeral containers
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```

/sig cli