### PR TITLE
Fix failing test "Services should only allow access from service loadbalancer source ranges"

### DIFF
--- a/pkg/proxy/iptables/proxier.go
+++ b/pkg/proxy/iptables/proxier.go
@@ -399,6 +399,13 @@ var iptablesJumpChains = []iptablesJumpChain{
 	{utiliptables.TableNAT, kubePostroutingChain, utiliptables.ChainPostrouting, "kubernetes postrouting rules", nil},
 }
 
+var iptablesEnsureChains = []struct {
+	table utiliptables.Table
+	chain utiliptables.Chain
+}{
+	{utiliptables.TableNAT, KubeMarkDropChain},
+}
+
 var iptablesCleanupOnlyChains = []iptablesJumpChain{}
 
 // CleanupLeftovers removes all iptables rules and chains created by the Proxier
@@ -864,6 +871,14 @@ func (proxier *Proxier) syncProxyRules() {
 		)
 		if _, err := proxier.iptables.EnsureRule(utiliptables.Prepend, jump.table, jump.srcChain, args...); err != nil {
 			klog.Errorf("Failed to ensure that %s chain %s jumps to %s: %v", jump.table, jump.srcChain, jump.dstChain, err)
+			return
+		}
+	}
+
+	// ensure KUBE-MARK-DROP chain exist but do not change any rules
+	for _, ch := range iptablesEnsureChains {
+		if _, err := proxier.iptables.EnsureChain(ch.table, ch.chain); err != nil {
+			klog.Errorf("Failed to ensure that %s chain %s exists: %v", ch.table, ch.chain, err)
 			return
 		}
 	}


### PR DESCRIPTION

**What type of PR is this?**

/kind bug
/kind failing-test

**What this PR does / why we need it**:

kube-proxy IPVS mode will check `KUBE-MARK-DROP` chain in each sync, which will result in kube-proxy cleanup rules associated to the `KUBE-MARK-DROP` chain, and this will break firewall logic.

And this result in "Services should only allow access from service loadbalancer source ranges" case keep failing.

This pr removed check  `KUBE-MARK-DROP` in ipvs mode, to make sure kubelet and kube-proxy handle their own rules.


**Which issue(s) this PR fixes**:
Fixes #94356

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
