### PR TITLE
Add NC, SCTP support and stages to Jig verifier

### DIFF
--- a/test/images/agnhost/Dockerfile
+++ b/test/images/agnhost/Dockerfile
@@ -27,7 +27,7 @@ CROSS_BUILD_COPY qemu-QEMUARCH-static /usr/bin/
 # - iproute2: includes ss used in NodePort tests
 # from iperf image
 # install necessary packages: iperf, bash
-RUN apk --update add bind-tools curl netcat-openbsd iproute2 iperf bash && rm -rf /var/cache/apk/* \
+RUN apk --update add bind-tools curl nmap-ncat iproute2 iperf bash && rm -rf /var/cache/apk/* \
   && ln -s /usr/bin/iperf /usr/local/bin/iperf \
   && ls -altrh /usr/local/bin/iperf
 


### PR DESCRIPTION
**What type of PR is this?**

Fixes #94598

- Test jig method vs functions arent really needed as they're al internal to the Jig stuff
- The addition of test methods to to Jig mean that they can reuse the client and other fixtures we might eventually add
- We need SCTP verification as well

This might allow us to also use the JIG as the driver in the netpol test that is going on, and is part of an overall effort to make the E2Es more fixture driven for better reasoning over time.

/kind cleanup

**What this PR does / why we need it**:

Adding SCTP support to Test-jig and having it pre-verify execution target

Might be adopted in #91592

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```