### PR TITLE
cleanup NamespaceScoped() comments of validating and mutating WebhookConfigurationStrategy

### DIFF
--- a/pkg/registry/admissionregistration/mutatingwebhookconfiguration/strategy.go
+++ b/pkg/registry/admissionregistration/mutatingwebhookconfiguration/strategy.go
@@ -39,7 +39,7 @@ type mutatingWebhookConfigurationStrategy struct {
 // Strategy is the default logic that applies when creating and updating mutatingWebhookConfiguration objects.
 var Strategy = mutatingWebhookConfigurationStrategy{legacyscheme.Scheme, names.SimpleNameGenerator}
 
-// NamespaceScoped returns true because all mutatingWebhookConfiguration' need to be within a namespace.
+// NamespaceScoped returns false because all mutatingWebhookConfiguration' are global.
 func (mutatingWebhookConfigurationStrategy) NamespaceScoped() bool {
 	return false
 }

--- a/pkg/registry/admissionregistration/validatingwebhookconfiguration/strategy.go
+++ b/pkg/registry/admissionregistration/validatingwebhookconfiguration/strategy.go
@@ -39,7 +39,7 @@ type validatingWebhookConfigurationStrategy struct {
 // Strategy is the default logic that applies when creating and updating validatingWebhookConfiguration objects.
 var Strategy = validatingWebhookConfigurationStrategy{legacyscheme.Scheme, names.SimpleNameGenerator}
 
-// NamespaceScoped returns true because all validatingWebhookConfiguration' need to be within a namespace.
+// NamespaceScoped returns false because all validatingWebhookConfiguration' are global.
 func (validatingWebhookConfigurationStrategy) NamespaceScoped() bool {
 	return false
 }


### PR DESCRIPTION
The comments for NamespaceScoped() method of validating and mutating WebhookConfigurationStrategy are misleading, saying that the method returns false. However, the method returns true insted.

This PR is just to fix this.