### PR TITLE
[1.19] build: Fix go-runner arch in server images

### DIFF
--- a/build/common.sh
+++ b/build/common.sh
@@ -94,7 +94,6 @@ readonly KUBE_CONTAINER_RSYNC_PORT=8730
 # $1 - server architecture
 kube::build::get_docker_wrapped_binaries() {
   local arch=$1
-  local debian_base_version=v2.1.3
   local debian_iptables_version=v12.1.2
   local go_runner_version=buster-v2.0.0
   ### If you change any of these lists, please also update DOCKERIZED_BINARIES

--- a/build/common.sh
+++ b/build/common.sh
@@ -93,7 +93,6 @@ readonly KUBE_CONTAINER_RSYNC_PORT=8730
 #
 # $1 - server architecture
 kube::build::get_docker_wrapped_binaries() {
-  local arch=$1
   local debian_iptables_version=v12.1.2
   local go_runner_version=buster-v2.0.0
   ### If you change any of these lists, please also update DOCKERIZED_BINARIES
@@ -102,7 +101,7 @@ kube::build::get_docker_wrapped_binaries() {
     "kube-apiserver,${KUBE_BASE_IMAGE_REGISTRY}/go-runner:${go_runner_version}"
     "kube-controller-manager,${KUBE_BASE_IMAGE_REGISTRY}/go-runner:${go_runner_version}"
     "kube-scheduler,${KUBE_BASE_IMAGE_REGISTRY}/go-runner:${go_runner_version}"
-    "kube-proxy,${KUBE_BASE_IMAGE_REGISTRY}/debian-iptables-${arch}:${debian_iptables_version}"
+    "kube-proxy,${KUBE_BASE_IMAGE_REGISTRY}/debian-iptables:${debian_iptables_version}"
   )
 
   echo "${targets[@]}"

--- a/build/dependencies.yaml
+++ b/build/dependencies.yaml
@@ -118,8 +118,6 @@ dependencies:
   - name: "k8s.gcr.io/debian-base: dependents"
     version: 2.1.3
     refPaths:
-    - path: build/common.sh
-      match: debian_base_version=
     - path: build/workspace.bzl
       match: tag =
     - path: cluster/images/etcd/Makefile

--- a/build/lib/release.sh
+++ b/build/lib/release.sh
@@ -334,7 +334,7 @@ function kube::release::create_docker_images_for_server() {
     local images_dir
     binary_dir="$1"
     arch="$2"
-    binaries=$(kube::build::get_docker_wrapped_binaries "${arch}")
+    binaries=$(kube::build::get_docker_wrapped_binaries)
     images_dir="${RELEASE_IMAGES}/${arch}"
     mkdir -p "${images_dir}"
 
@@ -375,7 +375,7 @@ function kube::release::create_docker_images_for_server() {
         ln "${KUBE_ROOT}/build/nsswitch.conf" "${docker_build_path}/nsswitch.conf"
         chmod 0644 "${docker_build_path}/nsswitch.conf"
         cat <<EOF > "${docker_file_path}"
-FROM ${base_image}
+FROM --platform=linux/${arch} ${base_image}
 COPY ${binary_name} /usr/local/bin/${binary_name}
 EOF
         # ensure /etc/nsswitch.conf exists so go's resolver respects /etc/hosts


### PR DESCRIPTION
**What type of PR is this?**

/kind bug regression
/area release-eng dependency
/priority critical-urgent
/sig release

**What this PR dos / why we need it**:

**Cherry pick of https://github.com/kubernetes/kubernetes/pull/94552.**

- build/lib/release: Explicitly use '--platform' in building server images

  When we switched to go-runner for building the apiserver,
  controller-manager, and scheduler server components, we no longer
  reference the individual architectures in the image names, specifically
  in the 'FROM' directive of the server image Dockerfiles.
  
  As a result, server images for non-amd64 images copy in the go-runner
  amd64 binary instead of the go-runner that matches that architecture.
  
  This commit explicitly sets the '--platform=linux/${arch}' to ensure
  we're pulling the correct go-runner arch from the manifest list.
  
  Before:
  ```dockerfile
  FROM ${base_image}
  ```

  After:
  ```dockerfile
  FROM --platform=linux/${arch} ${base_image}
  ```

- build/common.sh: Remove extraneous reference to debian-base image

  debian-base is no longer used for building core Kubernetes server
  components, so we remove the unnecessary local variable referencing it
  from `kube::build::get_docker_wrapped_binaries()`.

**Which issue(s) this PR fixes**:

Reported in https://github.com/kubernetes/kubernetes/issues/94540.

/assign @liggitt @dims 
cc: @kubernetes/release-engineering 

**Special notes for your reviewer**:


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixed a regression in non-amd64 server images in 1.19 that would not use the correct architecture base image
```


**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
