### PR TITLE
Count storage requests as whole byte values in quota

### DIFF
--- a/pkg/quota/v1/evaluator/core/persistent_volume_claims.go
+++ b/pkg/quota/v1/evaluator/core/persistent_volume_claims.go
@@ -161,6 +161,13 @@ func (p *pvcEvaluator) Usage(item runtime.Object) (corev1.ResourceList, error) {
 
 	// charge for storage
 	if request, found := pvc.Spec.Resources.Requests[corev1.ResourceStorage]; found {
+		roundedRequest := request.DeepCopy()
+		if !roundedRequest.RoundUp(0) {
+			// Ensure storage requests are counted as whole byte values, to pass resourcequota validation.
+			// See http://issue.k8s.io/94313
+			request = roundedRequest
+		}
+
 		result[corev1.ResourceRequestsStorage] = request
 		// charge usage to the storage class (if present)
 		if len(storageClassRef) > 0 {


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

PVCs are allowed to be created with fractional storage requests, but resource quota objects are not allowed to persist fractional storage usage. Round up to the nearest byte in the quota evaluator to allow persisting quota.

**Which issue(s) this PR fixes**:
Fixes #94313

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/sig storage
