### PR TITLE
Automated cherry pick of #94629: Sort list of formats for --logging-format description to make

### DIFF
--- a/staging/src/k8s.io/component-base/logs/registry.go
+++ b/staging/src/k8s.io/component-base/logs/registry.go
@@ -18,6 +18,7 @@ package logs
 
 import (
 	"fmt"
+	"sort"
 
 	"github.com/go-logr/logr"
 	json "k8s.io/component-base/logs/json"
@@ -84,12 +85,13 @@ func (lfr *LogFormatRegistry) Delete(name string) error {
 	return nil
 }
 
-// List names of registered log formats
+// List names of registered log formats (sorted)
 func (lfr *LogFormatRegistry) List() []string {
 	formats := make([]string, 0, len(lfr.registry))
 	for f := range lfr.registry {
 		formats = append(formats, f)
 	}
+	sort.Strings(formats)
 	return formats
 }
 


### PR DESCRIPTION
Cherry pick of #94629 on release-1.19.

#94629: Sort list of formats for --logging-format description to make

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.