### PR TITLE
Automated cherry pick of #93011: fix: azure disk resize error if source does not exist

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure.go
@@ -241,7 +241,7 @@ type Cloud struct {
 
 	ResourceRequestBackoff wait.Backoff
 	metadata               *InstanceMetadataService
-	vmSet                  VMSet
+	VMSet                  VMSet
 
 	// ipv6DualStack allows overriding for unit testing.  It's normally initialized from featuregates
 	ipv6DualStackEnabled bool
@@ -484,12 +484,12 @@ func (az *Cloud) InitializeCloudFromConfig(config *Config, fromSecret bool) erro
 	}
 
 	if strings.EqualFold(vmTypeVMSS, az.Config.VMType) {
-		az.vmSet, err = newScaleSet(az)
+		az.VMSet, err = newScaleSet(az)
 		if err != nil {
 			return err
 		}
 	} else {
-		az.vmSet = newAvailabilitySet(az)
+		az.VMSet = newAvailabilitySet(az)
 	}
 
 	az.vmCache, err = az.newVMCache()

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_backoff.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_backoff.go
@@ -111,7 +111,7 @@ func (az *Cloud) getPrivateIPsForMachineWithRetry(nodeName types.NodeName) ([]st
 	var privateIPs []string
 	err := wait.ExponentialBackoff(az.RequestBackoff(), func() (bool, error) {
 		var retryErr error
-		privateIPs, retryErr = az.vmSet.GetPrivateIPsByNodeName(string(nodeName))
+		privateIPs, retryErr = az.VMSet.GetPrivateIPsByNodeName(string(nodeName))
 		if retryErr != nil {
 			// won't retry since the instance doesn't exist on Azure.
 			if retryErr == cloudprovider.InstanceNotFound {
@@ -135,7 +135,7 @@ func (az *Cloud) GetIPForMachineWithRetry(name types.NodeName) (string, string, 
 	var ip, publicIP string
 	err := wait.ExponentialBackoff(az.RequestBackoff(), func() (bool, error) {
 		var retryErr error
-		ip, publicIP, retryErr = az.vmSet.GetIPByNodeName(string(name))
+		ip, publicIP, retryErr = az.VMSet.GetIPByNodeName(string(name))
 		if retryErr != nil {
 			klog.Errorf("GetIPForMachineWithRetry(%s): backoff failure, will retry,err=%v", name, retryErr)
 			return false, nil

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_controller_common.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_controller_common.go
@@ -90,15 +90,15 @@ type controllerCommon struct {
 
 // getNodeVMSet gets the VMSet interface based on config.VMType and the real virtual machine type.
 func (c *controllerCommon) getNodeVMSet(nodeName types.NodeName, crt azcache.AzureCacheReadType) (VMSet, error) {
-	// 1. vmType is standard, return cloud.vmSet directly.
+	// 1. vmType is standard, return cloud.VMSet directly.
 	if c.cloud.VMType == vmTypeStandard {
-		return c.cloud.vmSet, nil
+		return c.cloud.VMSet, nil
 	}
 
 	// 2. vmType is Virtual Machine Scale Set (vmss), convert vmSet to scaleSet.
-	ss, ok := c.cloud.vmSet.(*scaleSet)
+	ss, ok := c.cloud.VMSet.(*scaleSet)
 	if !ok {
-		return nil, fmt.Errorf("error of converting vmSet (%q) to scaleSet with vmType %q", c.cloud.vmSet, c.cloud.VMType)
+		return nil, fmt.Errorf("error of converting vmSet (%q) to scaleSet with vmType %q", c.cloud.VMSet, c.cloud.VMType)
 	}
 
 	// 3. If the node is managed by availability set, then return ss.availabilitySet.

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_controller_standard_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_controller_standard_test.go
@@ -58,7 +58,7 @@ func TestStandardAttachDisk(t *testing.T) {
 
 	for i, test := range testCases {
 		testCloud := GetTestCloud(ctrl)
-		vmSet := testCloud.vmSet
+		vmSet := testCloud.VMSet
 		setTestVirtualMachines(testCloud, map[string]string{"vm1": "PowerState/Running"}, false)
 
 		err := vmSet.AttachDisk(true, "",
@@ -98,7 +98,7 @@ func TestStandardDetachDisk(t *testing.T) {
 
 	for i, test := range testCases {
 		testCloud := GetTestCloud(ctrl)
-		vmSet := testCloud.vmSet
+		vmSet := testCloud.VMSet
 		setTestVirtualMachines(testCloud, map[string]string{"vm1": "PowerState/Running"}, false)
 
 		err := vmSet.DetachDisk(test.diskName, "", test.nodeName)
@@ -155,7 +155,7 @@ func TestGetDataDisks(t *testing.T) {
 	}
 	for i, test := range testCases {
 		testCloud := GetTestCloud(ctrl)
-		vmSet := testCloud.vmSet
+		vmSet := testCloud.VMSet
 		setTestVirtualMachines(testCloud, map[string]string{"vm1": "PowerState/Running"}, false)
 
 		dataDisks, err := vmSet.GetDataDisks(test.nodeName, test.crt)

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_fakes.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_fakes.go
@@ -765,6 +765,10 @@ func (fDC *fakeDisksClient) ListByResourceGroup(ctx context.Context, resourceGro
 	return []compute.Disk{}, nil
 }
 
+func (fDC *fakeDisksClient) Update(ctx context.Context, resourceGroupName string, diskName string, diskParameter compute.DiskUpdate) *retry.Error {
+	return nil
+}
+
 // GetTestCloud returns a fake azure cloud for unit tests in Azure related CSI drivers
 func GetTestCloud(ctrl *gomock.Controller) (az *Cloud) {
 	az = &Cloud{

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_fakes.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_fakes.go
@@ -761,6 +761,10 @@ func (fDC *fakeDisksClient) Get(ctx context.Context, resourceGroupName string, d
 		errors.New("Not such Disk"))
 }
 
+func (fDC *fakeDisksClient) ListByResourceGroup(ctx context.Context, resourceGroupName string) ([]compute.Disk, *retry.Error) {
+	return []compute.Disk{}, nil
+}
+
 // GetTestCloud returns a fake azure cloud for unit tests in Azure related CSI drivers
 func GetTestCloud(ctrl *gomock.Controller) (az *Cloud) {
 	az = &Cloud{
@@ -800,7 +804,7 @@ func GetTestCloud(ctrl *gomock.Controller) (az *Cloud) {
 	az.VirtualMachineScaleSetsClient = newFakeVirtualMachineScaleSetsClient()
 	az.VirtualMachineScaleSetVMsClient = newFakeVirtualMachineScaleSetVMsClient()
 	az.VirtualMachinesClient = newFakeAzureVirtualMachinesClient()
-	az.vmSet = newAvailabilitySet(az)
+	az.VMSet = newAvailabilitySet(az)
 	az.vmCache, _ = az.newVMCache()
 	az.lbCache, _ = az.newLBCache()
 	az.nsgCache, _ = az.newNSGCache()

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_instances.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_instances.go
@@ -94,11 +94,11 @@ func (az *Cloud) NodeAddresses(ctx context.Context, name types.NodeName) ([]v1.N
 
 		// Not local instance, get addresses from Azure ARM API.
 		if !isLocalInstance {
-			if az.vmSet != nil {
+			if az.VMSet != nil {
 				return addressGetter(name)
 			}
 
-			// vmSet == nil indicates credentials are not provided.
+			// VMSet == nil indicates credentials are not provided.
 			return nil, fmt.Errorf("no credentials provided for Azure cloud provider")
 		}
 
@@ -164,7 +164,7 @@ func (az *Cloud) NodeAddressesByProviderID(ctx context.Context, providerID strin
 		return nil, nil
 	}
 
-	name, err := az.vmSet.GetNodeNameByProviderID(providerID)
+	name, err := az.VMSet.GetNodeNameByProviderID(providerID)
 	if err != nil {
 		return nil, err
 	}
@@ -185,7 +185,7 @@ func (az *Cloud) InstanceExistsByProviderID(ctx context.Context, providerID stri
 		return true, nil
 	}
 
-	name, err := az.vmSet.GetNodeNameByProviderID(providerID)
+	name, err := az.VMSet.GetNodeNameByProviderID(providerID)
 	if err != nil {
 		if err == cloudprovider.InstanceNotFound {
 			return false, nil
@@ -210,7 +210,7 @@ func (az *Cloud) InstanceShutdownByProviderID(ctx context.Context, providerID st
 		return false, nil
 	}
 
-	nodeName, err := az.vmSet.GetNodeNameByProviderID(providerID)
+	nodeName, err := az.VMSet.GetNodeNameByProviderID(providerID)
 	if err != nil {
 		// Returns false, so the controller manager will continue to check InstanceExistsByProviderID().
 		if err == cloudprovider.InstanceNotFound {
@@ -220,7 +220,7 @@ func (az *Cloud) InstanceShutdownByProviderID(ctx context.Context, providerID st
 		return false, err
 	}
 
-	powerStatus, err := az.vmSet.GetPowerStatusByNodeName(string(nodeName))
+	powerStatus, err := az.VMSet.GetPowerStatusByNodeName(string(nodeName))
 	if err != nil {
 		// Returns false, so the controller manager will continue to check InstanceExistsByProviderID().
 		if err == cloudprovider.InstanceNotFound {
@@ -287,8 +287,8 @@ func (az *Cloud) InstanceID(ctx context.Context, name types.NodeName) (string, e
 
 		// Not local instance, get instanceID from Azure ARM API.
 		if !isLocalInstance {
-			if az.vmSet != nil {
-				return az.vmSet.GetInstanceIDByNodeName(nodeName)
+			if az.VMSet != nil {
+				return az.VMSet.GetInstanceIDByNodeName(nodeName)
 			}
 
 			// vmSet == nil indicates credentials are not provided.
@@ -317,7 +317,7 @@ func (az *Cloud) InstanceID(ctx context.Context, name types.NodeName) (string, e
 		return az.getVmssMachineID(subscriptionID, resourceGroup, ssName, instanceID), nil
 	}
 
-	return az.vmSet.GetInstanceIDByNodeName(nodeName)
+	return az.VMSet.GetInstanceIDByNodeName(nodeName)
 }
 
 // InstanceTypeByProviderID returns the cloudprovider instance type of the node with the specified unique providerID
@@ -334,7 +334,7 @@ func (az *Cloud) InstanceTypeByProviderID(ctx context.Context, providerID string
 		return "", nil
 	}
 
-	name, err := az.vmSet.GetNodeNameByProviderID(providerID)
+	name, err := az.VMSet.GetNodeNameByProviderID(providerID)
 	if err != nil {
 		return "", err
 	}
@@ -372,8 +372,8 @@ func (az *Cloud) InstanceType(ctx context.Context, name types.NodeName) (string,
 			return "", err
 		}
 		if !isLocalInstance {
-			if az.vmSet != nil {
-				return az.vmSet.GetInstanceTypeByNodeName(string(name))
+			if az.VMSet != nil {
+				return az.VMSet.GetInstanceTypeByNodeName(string(name))
 			}
 
 			// vmSet == nil indicates credentials are not provided.
@@ -385,7 +385,7 @@ func (az *Cloud) InstanceType(ctx context.Context, name types.NodeName) (string,
 		}
 	}
 
-	return az.vmSet.GetInstanceTypeByNodeName(string(name))
+	return az.VMSet.GetInstanceTypeByNodeName(string(name))
 }
 
 // AddSSHKeyToAllInstances adds an SSH public key as a legal identity for all instances

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_loadbalancer.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_loadbalancer.go
@@ -258,7 +258,7 @@ func (az *Cloud) getLoadBalancerResourceGroup() string {
 func (az *Cloud) getServiceLoadBalancer(service *v1.Service, clusterName string, nodes []*v1.Node, wantLb bool) (lb *network.LoadBalancer, status *v1.LoadBalancerStatus, exists bool, err error) {
 	isInternal := requiresInternalLoadBalancer(service)
 	var defaultLB *network.LoadBalancer
-	primaryVMSetName := az.vmSet.GetPrimaryVMSetName()
+	primaryVMSetName := az.VMSet.GetPrimaryVMSetName()
 	defaultLBName := az.getAzureLoadBalancerName(clusterName, primaryVMSetName, isInternal)
 
 	existingLBs, err := az.ListLB(service)
@@ -331,7 +331,7 @@ func (az *Cloud) selectLoadBalancer(clusterName string, service *v1.Service, exi
 	isInternal := requiresInternalLoadBalancer(service)
 	serviceName := getServiceName(service)
 	klog.V(2).Infof("selectLoadBalancer for service (%s): isInternal(%v) - start", serviceName, isInternal)
-	vmSetNames, err := az.vmSet.GetVMSetNames(service, nodes)
+	vmSetNames, err := az.VMSet.GetVMSetNames(service, nodes)
 	if err != nil {
 		klog.Errorf("az.selectLoadBalancer: cluster(%s) service(%s) isInternal(%t) - az.GetVMSetNames failed, err=(%v)", clusterName, serviceName, isInternal, err)
 		return nil, false, err
@@ -937,7 +937,7 @@ func (az *Cloud) reconcileLoadBalancer(clusterName string, service *v1.Service, 
 				// Remove backend pools from vmSets. This is required for virtual machine scale sets before removing the LB.
 				vmSetName := az.mapLoadBalancerNameToVMSet(lbName, clusterName)
 				klog.V(10).Infof("EnsureBackendPoolDeleted(%s,%s) for service %s: start", lbBackendPoolID, vmSetName, serviceName)
-				err := az.vmSet.EnsureBackendPoolDeleted(service, lbBackendPoolID, vmSetName, lb.BackendAddressPools)
+				err := az.VMSet.EnsureBackendPoolDeleted(service, lbBackendPoolID, vmSetName, lb.BackendAddressPools)
 				if err != nil {
 					klog.Errorf("EnsureBackendPoolDeleted(%s) for service %s failed: %v", lbBackendPoolID, serviceName, err)
 					return nil, err
@@ -981,7 +981,7 @@ func (az *Cloud) reconcileLoadBalancer(clusterName string, service *v1.Service, 
 		vmSetName := az.mapLoadBalancerNameToVMSet(lbName, clusterName)
 		// Etag would be changed when updating backend pools, so invalidate lbCache after it.
 		defer az.lbCache.Delete(lbName)
-		err := az.vmSet.EnsureHostsInPool(service, nodes, lbBackendPoolID, vmSetName, isInternal)
+		err := az.VMSet.EnsureHostsInPool(service, nodes, lbBackendPoolID, vmSetName, isInternal)
 		if err != nil {
 			return nil, err
 		}

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_managedDiskController.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_managedDiskController.go
@@ -287,11 +287,15 @@ func (c *ManagedDiskController) ResizeDisk(diskURI string, oldSize resource.Quan
 		return newSizeQuant, nil
 	}
 
-	result.DiskProperties.DiskSizeGB = &requestGiB
+	diskParameter := compute.DiskUpdate{
+		DiskUpdateProperties: &compute.DiskUpdateProperties{
+			DiskSizeGB: &requestGiB,
+		},
+	}
 
 	ctx, cancel = getContextWithCancel()
 	defer cancel()
-	if rerr := c.common.cloud.DisksClient.CreateOrUpdate(ctx, resourceGroup, diskName, result); rerr != nil {
+	if rerr := c.common.cloud.DisksClient.Update(ctx, resourceGroup, diskName, diskParameter); rerr != nil {
 		return oldSize, rerr.Error()
 	}
 

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_routes_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_routes_test.go
@@ -117,7 +117,7 @@ func TestCreateRoute(t *testing.T) {
 
 	cloud := &Cloud{
 		RouteTablesClient: routeTableClient,
-		vmSet:             mockVMSet,
+		VMSet:             mockVMSet,
 		Config: Config{
 			RouteTableResourceGroup: "foo",
 			RouteTableName:          "bar",

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_standard.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_standard.go
@@ -135,7 +135,7 @@ func (az *Cloud) getNetworkResourceSubscriptionID() string {
 func (az *Cloud) mapLoadBalancerNameToVMSet(lbName string, clusterName string) (vmSetName string) {
 	vmSetName = strings.TrimSuffix(lbName, InternalLoadBalancerNameSuffix)
 	if strings.EqualFold(clusterName, vmSetName) {
-		vmSetName = az.vmSet.GetPrimaryVMSetName()
+		vmSetName = az.VMSet.GetPrimaryVMSetName()
 	}
 
 	return vmSetName
@@ -150,7 +150,7 @@ func (az *Cloud) getAzureLoadBalancerName(clusterName string, vmSetName string, 
 		clusterName = az.LoadBalancerName
 	}
 	lbNamePrefix := vmSetName
-	if strings.EqualFold(vmSetName, az.vmSet.GetPrimaryVMSetName()) || az.useStandardLoadBalancer() {
+	if strings.EqualFold(vmSetName, az.VMSet.GetPrimaryVMSetName()) || az.useStandardLoadBalancer() {
 		lbNamePrefix = clusterName
 	}
 	if isInternal {
@@ -732,7 +732,7 @@ func (as *availabilitySet) EnsureHostInPool(service *v1.Service, nodeName types.
 			return "", "", "", nil, nil
 		}
 
-		klog.Errorf("error: az.EnsureHostInPool(%s), az.vmSet.GetPrimaryInterface.Get(%s, %s), err=%v", nodeName, vmName, vmSetName, err)
+		klog.Errorf("error: az.EnsureHostInPool(%s), az.VMSet.GetPrimaryInterface.Get(%s, %s), err=%v", nodeName, vmName, vmSetName, err)
 		return "", "", "", nil, err
 	}
 

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_test.go
@@ -1802,7 +1802,7 @@ func TestGetNodeNameByProviderID(t *testing.T) {
 	}
 
 	for _, test := range providers {
-		name, err := az.vmSet.GetNodeNameByProviderID(test.providerID)
+		name, err := az.VMSet.GetNodeNameByProviderID(test.providerID)
 		if (err != nil) != test.fail {
 			t.Errorf("Expected to fail=%t, with pattern %v", test.fail, test)
 		}

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_zones.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_zones.go
@@ -87,7 +87,7 @@ func (az *Cloud) GetZone(ctx context.Context) (cloudprovider.Zone, error) {
 	if err != nil {
 		return cloudprovider.Zone{}, fmt.Errorf("failure getting hostname from kernel")
 	}
-	return az.vmSet.GetZoneByNodeName(strings.ToLower(hostname))
+	return az.VMSet.GetZoneByNodeName(strings.ToLower(hostname))
 }
 
 // GetZoneByProviderID implements Zones.GetZoneByProviderID
@@ -104,7 +104,7 @@ func (az *Cloud) GetZoneByProviderID(ctx context.Context, providerID string) (cl
 		return cloudprovider.Zone{}, nil
 	}
 
-	nodeName, err := az.vmSet.GetNodeNameByProviderID(providerID)
+	nodeName, err := az.VMSet.GetNodeNameByProviderID(providerID)
 	if err != nil {
 		return cloudprovider.Zone{}, err
 	}
@@ -126,5 +126,5 @@ func (az *Cloud) GetZoneByNodeName(ctx context.Context, nodeName types.NodeName)
 		return cloudprovider.Zone{}, nil
 	}
 
-	return az.vmSet.GetZoneByNodeName(string(nodeName))
+	return az.VMSet.GetZoneByNodeName(string(nodeName))
 }

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/clients/diskclient/BUILD
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/clients/diskclient/BUILD
@@ -32,6 +32,7 @@ go_test(
         "//staging/src/k8s.io/legacy-cloud-providers/azure/clients:go_default_library",
         "//staging/src/k8s.io/legacy-cloud-providers/azure/clients/armclient:go_default_library",
         "//staging/src/k8s.io/legacy-cloud-providers/azure/clients/armclient/mockarmclient:go_default_library",
+        "//staging/src/k8s.io/legacy-cloud-providers/azure/retry:go_default_library",
         "//vendor/github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2019-07-01/compute:go_default_library",
         "//vendor/github.com/Azure/go-autorest/autorest:go_default_library",
         "//vendor/github.com/Azure/go-autorest/autorest/to:go_default_library",

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/clients/diskclient/BUILD
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/clients/diskclient/BUILD
@@ -19,6 +19,7 @@ go_library(
         "//vendor/github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2019-07-01/compute:go_default_library",
         "//vendor/github.com/Azure/go-autorest/autorest:go_default_library",
         "//vendor/github.com/Azure/go-autorest/autorest/azure:go_default_library",
+        "//vendor/github.com/Azure/go-autorest/autorest/to:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
     ],
 )

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/clients/diskclient/azure_diskclient.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/clients/diskclient/azure_diskclient.go
@@ -206,6 +206,74 @@ func (c *Client) createOrUpdateResponder(resp *http.Response) (*compute.Disk, *r
 	return result, retry.GetError(resp, err)
 }
 
+// Update creates or updates a Disk.
+func (c *Client) Update(ctx context.Context, resourceGroupName string, diskName string, diskParameter compute.DiskUpdate) *retry.Error {
+	mc := metrics.NewMetricContext("disks", "update", resourceGroupName, c.subscriptionID, "")
+
+	// Report errors if the client is rate limited.
+	if !c.rateLimiterWriter.TryAccept() {
+		mc.RateLimitedCount()
+		return retry.GetRateLimitError(true, "DiskUpdate")
+	}
+
+	// Report errors if the client is throttled.
+	if c.RetryAfterWriter.After(time.Now()) {
+		mc.ThrottledCount()
+		rerr := retry.GetThrottlingError("DiskUpdate", "client throttled", c.RetryAfterWriter)
+		return rerr
+	}
+
+	rerr := c.updateDisk(ctx, resourceGroupName, diskName, diskParameter)
+	mc.Observe(rerr.Error())
+	if rerr != nil {
+		if rerr.IsThrottled() {
+			// Update RetryAfterReader so that no more requests would be sent until RetryAfter expires.
+			c.RetryAfterWriter = rerr.RetryAfter
+		}
+
+		return rerr
+	}
+
+	return nil
+}
+
+// updateDisk updates a Disk.
+func (c *Client) updateDisk(ctx context.Context, resourceGroupName string, diskName string, diskParameter compute.DiskUpdate) *retry.Error {
+	resourceID := armclient.GetResourceID(
+		c.subscriptionID,
+		resourceGroupName,
+		"Microsoft.Compute/disks",
+		diskName,
+	)
+
+	response, rerr := c.armClient.PatchResource(ctx, resourceID, diskParameter)
+	defer c.armClient.CloseResponse(ctx, response)
+	if rerr != nil {
+		klog.V(5).Infof("Received error in %s: resourceID: %s, error: %s", "disk.put.request", resourceID, rerr.Error())
+		return rerr
+	}
+
+	if response != nil && response.StatusCode != http.StatusNoContent {
+		_, rerr = c.updateResponder(response)
+		if rerr != nil {
+			klog.V(5).Infof("Received error in %s: resourceID: %s, error: %s", "disk.put.respond", resourceID, rerr.Error())
+			return rerr
+		}
+	}
+
+	return nil
+}
+
+func (c *Client) updateResponder(resp *http.Response) (*compute.Disk, *retry.Error) {
+	result := &compute.Disk{}
+	err := autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusCreated),
+		autorest.ByUnmarshallingJSON(&result))
+	result.Response = autorest.Response{Response: resp}
+	return result, retry.GetError(resp, err)
+}
+
 // Delete deletes a Disk by name.
 func (c *Client) Delete(ctx context.Context, resourceGroupName string, diskName string) *retry.Error {
 	mc := metrics.NewMetricContext("disks", "delete", resourceGroupName, c.subscriptionID, "")

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/clients/diskclient/azure_diskclient_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/clients/diskclient/azure_diskclient_test.go
@@ -97,6 +97,49 @@ func TestCreateOrUpdate(t *testing.T) {
 	assert.Nil(t, rerr)
 }
 
+func TestUpdate(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	resourceID := "/subscriptions/subscriptionID/resourceGroups/rg/providers/Microsoft.Compute/disks/disk1"
+	diskUpdate := getTestDiskUpdate()
+	armClient := mockarmclient.NewMockInterface(ctrl)
+	response := &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       ioutil.NopCloser(bytes.NewReader([]byte(""))),
+	}
+	armClient.EXPECT().PatchResource(gomock.Any(), resourceID, diskUpdate).Return(response, nil).Times(1)
+	armClient.EXPECT().CloseResponse(gomock.Any(), gomock.Any()).Times(1)
+
+	diskClient := getTestDiskClient(armClient)
+	rerr := diskClient.Update(context.TODO(), "rg", "disk1", diskUpdate)
+	assert.Nil(t, rerr)
+
+	response = &http.Response{
+		StatusCode: http.StatusTooManyRequests,
+		Body:       ioutil.NopCloser(bytes.NewReader([]byte("{}"))),
+	}
+	throttleErr := &retry.Error{
+		HTTPStatusCode: http.StatusTooManyRequests,
+		RawError:       fmt.Errorf("error"),
+		Retriable:      true,
+		RetryAfter:     time.Unix(100, 0),
+	}
+
+	armClient.EXPECT().PatchResource(gomock.Any(), resourceID, diskUpdate).Return(response, throttleErr).Times(1)
+	armClient.EXPECT().CloseResponse(gomock.Any(), gomock.Any()).Times(1)
+	rerr = diskClient.Update(context.TODO(), "rg", "disk1", diskUpdate)
+	assert.Equal(t, throttleErr, rerr)
+}
+
+func getTestDiskUpdate() compute.DiskUpdate {
+	return compute.DiskUpdate{
+		DiskUpdateProperties: &compute.DiskUpdateProperties{
+			DiskSizeGB: to.Int32Ptr(100),
+		},
+	}
+}
+
 func TestDelete(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/clients/diskclient/azure_diskclient_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/clients/diskclient/azure_diskclient_test.go
@@ -25,6 +25,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2019-07-01/compute"
 	"github.com/Azure/go-autorest/autorest"
@@ -35,6 +36,7 @@ import (
 	azclients "k8s.io/legacy-cloud-providers/azure/clients"
 	"k8s.io/legacy-cloud-providers/azure/clients/armclient"
 	"k8s.io/legacy-cloud-providers/azure/clients/armclient/mockarmclient"
+	"k8s.io/legacy-cloud-providers/azure/retry"
 )
 
 func TestGetNotFound(t *testing.T) {

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/clients/diskclient/interface.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/clients/diskclient/interface.go
@@ -40,6 +40,9 @@ type Interface interface {
 	// CreateOrUpdate creates or updates a Disk.
 	CreateOrUpdate(ctx context.Context, resourceGroupName string, diskName string, diskParameter compute.Disk) *retry.Error
 
+	// Update updates a Disk.
+	Update(ctx context.Context, resourceGroupName string, diskName string, diskParameter compute.DiskUpdate) *retry.Error
+
 	// Delete deletes a Disk by name.
 	Delete(ctx context.Context, resourceGroupName string, diskName string) *retry.Error
 

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/clients/diskclient/interface.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/clients/diskclient/interface.go
@@ -42,4 +42,7 @@ type Interface interface {
 
 	// Delete deletes a Disk by name.
 	Delete(ctx context.Context, resourceGroupName string, diskName string) *retry.Error
+
+	// ListByResourceGroup lists all the disks under a resource group.
+	ListByResourceGroup(ctx context.Context, resourceGroupName string) ([]compute.Disk, *retry.Error)
 }

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/clients/diskclient/mockdiskclient/interface.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/clients/diskclient/mockdiskclient/interface.go
@@ -79,6 +79,20 @@ func (mr *MockInterfaceMockRecorder) CreateOrUpdate(ctx, resourceGroupName, disk
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateOrUpdate", reflect.TypeOf((*MockInterface)(nil).CreateOrUpdate), ctx, resourceGroupName, diskName, diskParameter)
 }
 
+// Update mocks base method
+func (m *MockInterface) Update(ctx context.Context, resourceGroupName, diskName string, diskParameter compute.DiskUpdate) *retry.Error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Update", ctx, resourceGroupName, diskName, diskParameter)
+	ret0, _ := ret[0].(*retry.Error)
+	return ret0
+}
+
+// Update indicates an expected call of Update
+func (mr *MockInterfaceMockRecorder) Update(ctx, resourceGroupName, diskName, diskParameter interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Update", reflect.TypeOf((*MockInterface)(nil).Update), ctx, resourceGroupName, diskName, diskParameter)
+}
+
 // Delete mocks base method
 func (m *MockInterface) Delete(ctx context.Context, resourceGroupName, diskName string) *retry.Error {
 	m.ctrl.T.Helper()

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/clients/diskclient/mockdiskclient/interface.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/clients/diskclient/mockdiskclient/interface.go
@@ -92,3 +92,18 @@ func (mr *MockInterfaceMockRecorder) Delete(ctx, resourceGroupName, diskName int
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockInterface)(nil).Delete), ctx, resourceGroupName, diskName)
 }
+
+// ListByResourceGroup mocks base method
+func (m *MockInterface) ListByResourceGroup(ctx context.Context, resourceGroupName string) ([]compute.Disk, *retry.Error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListByResourceGroup", ctx, resourceGroupName)
+	ret0, _ := ret[0].([]compute.Disk)
+	ret1, _ := ret[1].(*retry.Error)
+	return ret0, ret1
+}
+
+// ListByResourceGroup indicates an expected call of ListByResourceGroup
+func (mr *MockInterfaceMockRecorder) ListByResourceGroup(ctx, resourceGroupName interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListByResourceGroup", reflect.TypeOf((*MockInterface)(nil).Delete), ctx, resourceGroupName)
+}


### PR DESCRIPTION
Cherry pick of #93011 on release-1.18.

#93011: chore: add diskclient.ListByResourceGroup interface

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.