### PR TITLE
[do not merge] verify that local-up-cluster fails in CI

### DIFF
--- a/hack/local-up-cluster.sh
+++ b/hack/local-up-cluster.sh
@@ -14,6 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Note:
+# Conformance tests on this cluster will fail because of https://github.com/kubernetes/test-infra/pull/19142"
+
 KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 
 # This script builds and runs a local kubernetes cluster. You may need to run


### PR DESCRIPTION
This is a test to probe wether or not local-e2e.yaml test jobs in test-infra are capable of passing.

I think the fix for this test, is https://github.com/kubernetes/test-infra/pull/19142.