### PR TITLE
Do not add namespace to a request when creating it using SSA

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/request/requestinfo.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/request/requestinfo.go
@@ -178,7 +178,12 @@ func (r *RequestInfoFactory) NewRequestInfo(req *http.Request) (*RequestInfo, er
 
 	// URL forms: /namespaces/{namespace}/{kind}/*, where parts are adjusted to be relative to kind
 	if currentParts[0] == "namespaces" {
-		if len(currentParts) > 1 {
+		// When creating a new namespace using server-side apply a PATCH request is
+		// sent at /namespaces/new-namespace.  In this case, we don't want to add
+		// the namespace to the request.
+		if len(currentParts) == 2 && requestInfo.Verb == "patch" {
+			requestInfo.Namespace = metav1.NamespaceNone
+		} else if len(currentParts) > 1 {
 			requestInfo.Namespace = currentParts[1]
 
 			// if there is another step after the namespace name and it is not a known namespace subresource

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/request/requestinfo_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/request/requestinfo_test.go
@@ -55,6 +55,8 @@ func TestGetAPIRequestInfo(t *testing.T) {
 		{"GET", "/api/v1/namespaces/other/pods/foo", "get", "api", "", "v1", "other", "pods", "", "foo", []string{"pods", "foo"}},
 		{"GET", "/api/v1/namespaces/other/pods", "list", "api", "", "v1", "other", "pods", "", "", []string{"pods"}},
 
+		{"PATCH", "/api/v1/namespaces/new-namespace", "patch", "api", "", "v1", "", "namespaces", "", "new-namespace", []string{"namespaces", "new-namespace"}},
+
 		// special verbs
 		{"GET", "/api/v1/proxy/namespaces/other/pods/foo", "proxy", "api", "", "v1", "other", "pods", "", "foo", []string{"pods", "foo"}},
 		{"GET", "/api/v1/proxy/namespaces/other/pods/foo/subpath/not/a/subresource", "proxy", "api", "", "v1", "other", "pods", "", "foo", []string{"pods", "foo", "subpath", "not", "a", "subresource"}},


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

When creating a new namespace using server-side apply a`PATCH` request is sent at `/namespaces/new-namespace`.  In this case, we don't want to add the namespace to the request.

The namespace is fetched [here](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/patch.go#L92) and then used all subsequent requests in the webhooks, which caused the issue below.

**Which issue(s) this PR fixes**:

Fixes #94168

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```