### PR TITLE
Handle nil elements when sorting, instead of panicking

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/get/sorter.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/get/sorter.go
@@ -206,6 +206,13 @@ func isLess(i, j reflect.Value) (bool, error) {
 		return true, nil
 
 	case reflect.Interface:
+		if i.IsNil() && j.IsNil() {
+			return false, nil
+		} else if i.IsNil() {
+			return true, nil
+		} else if j.IsNil() {
+			return false, nil
+		}
 		switch itype := i.Interface().(type) {
 		case uint8:
 			if jtype, ok := j.Interface().(uint8); ok {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/get/sorter_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/get/sorter_test.go
@@ -409,6 +409,32 @@ func TestSortingPrinter(t *testing.T) {
 			field:       "{.invalid}",
 			expectedErr: "couldn't find any field with path \"{.invalid}\" in the list of objects",
 		},
+		{
+			name: "empty fields",
+			obj: &corev1.EventList{
+				Items: []corev1.Event{
+					{
+						ObjectMeta:    metav1.ObjectMeta{CreationTimestamp: metav1.Unix(300, 0)},
+						LastTimestamp: metav1.Unix(300, 0),
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{CreationTimestamp: metav1.Unix(200, 0)},
+					},
+				},
+			},
+			sort: &corev1.EventList{
+				Items: []corev1.Event{
+					{
+						ObjectMeta: metav1.ObjectMeta{CreationTimestamp: metav1.Unix(200, 0)},
+					},
+					{
+						ObjectMeta:    metav1.ObjectMeta{CreationTimestamp: metav1.Unix(300, 0)},
+						LastTimestamp: metav1.Unix(300, 0),
+					},
+				},
+			},
+			field: "{.lastTimestamp}",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name+" table", func(t *testing.T) {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
/sig cli

**What this PR does / why we need it**:
Currently if you try to sort using an optional field in the API, which can be empty you'll get a nasty error like this:
```
$ kubectl get events --sort-by='.lastTimestamp'
F0909 22:00:10.892563   61466 sorter.go:353] Field {.lastTimestamp} in [][][]reflect.Value is an unsortable type: interface, err: unsortable type: <nil>
goroutine 1 [running]:
k8s.io/kubernetes/vendor/k8s.io/klog/v2.stacks(0xc0000ca001, 0xc000554000, 0x99, 0xeb)
	/workspace/k8s/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/klog/v2/klog.go:996 +0xb8
k8s.io/kubernetes/vendor/k8s.io/klog/v2.(*loggingT).output(0x2f69600, 0xc000000003, 0x0, 0x0, 0xc0001560e0, 0x2d3c647, 0x9, 0x161, 0x0)
	/workspace/k8s/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/klog/v2/klog.go:945 +0x19d
k8s.io/kubernetes/vendor/k8s.io/klog/v2.(*loggingT).printf(0x2f69600, 0x3, 0x0, 0x0, 0x1bd95b8, 0x31, 0xc00067d6d0, 0x4, 0x4)
	/workspace/k8s/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/klog/v2/klog.go:733 +0x17b
k8s.io/kubernetes/vendor/k8s.io/klog/v2.Fatalf(...)
	/workspace/k8s/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/klog/v2/klog.go:1456
k8s.io/kubernetes/vendor/k8s.io/kubectl/pkg/cmd/get.(*TableSorter).Less(0xc0009618f0, 0x0, 0x2a, 0xc00067d868)
	/workspace/k8s/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/kubectl/pkg/cmd/get/sorter.go:353 +0x2d7
sort.medianOfThree(0x1e8a1e0, 0xc0009618f0, 0x0, 0x2a, 0x54)
	/.gvm/gos/go1.14.6/src/sort/sort.go:76 +0x49
sort.doPivot(0x1e8a1e0, 0xc0009618f0, 0x0, 0x150, 0xc000945e40, 0xc0003b6820)
	/.gvm/gos/go1.14.6/src/sort/sort.go:101 +0x5c5
sort.quickSort(0x1e8a1e0, 0xc0009618f0, 0x0, 0x150, 0x12)
	/.gvm/gos/go1.14.6/src/sort/sort.go:190 +0x9a
sort.Sort(0x1e8a1e0, 0xc0009618f0)
	/.gvm/gos/go1.14.6/src/sort/sort.go:218 +0x79
k8s.io/kubernetes/vendor/k8s.io/kubectl/pkg/cmd/get.(*TableSorter).Sort(...)
	/workspace/k8s/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/kubectl/pkg/cmd/get/sorter.go:359
k8s.io/kubernetes/vendor/k8s.io/kubectl/pkg/cmd/get.(*SortingPrinter).PrintObj(0xc0008d5800, 0x1e5aee0, 0xc00065e120, 0x1e4e200, 0xc0005c0540, 0x0, 0xc0005c0540)
	/workspace/k8s/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/kubectl/pkg/cmd/get/sorter.go:56 +0x208
k8s.io/kubernetes/vendor/k8s.io/kubectl/pkg/cmd/get.(*TablePrinter).PrintObj(0xc0008cd7f0, 0x1e5b020, 0xc000286018, 0x1e4e200, 0xc0005c0540, 0xc0003bdf00, 0xc00044357d)
	/workspace/k8s/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/kubectl/pkg/cmd/get/table_printer.go:41 +0x1ba
k8s.io/kubernetes/vendor/k8s.io/cli-runtime/pkg/printers.ResourcePrinterFunc.PrintObj(0xc000a05bc0, 0x1e5b020, 0xc000286018, 0x1e4e200, 0xc0005c0540, 0x0, 0x20)
	/workspace/k8s/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/cli-runtime/pkg/printers/interface.go:31 +0x4e
k8s.io/kubernetes/vendor/k8s.io/kubectl/pkg/cmd/get.(*GetOptions).Run(0xc0003f61e0, 0x1eaf580, 0xc000177bc0, 0xc0004018c0, 0xc0000cfa80, 0x1, 0x4, 0x0, 0x0)
	/workspace/k8s/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/kubectl/pkg/cmd/get/get.go:579 +0x83a
k8s.io/kubernetes/vendor/k8s.io/kubectl/pkg/cmd/get.NewCmdGet.func1(0xc0004018c0, 0xc0000cfa80, 0x1, 0x4)
	/workspace/k8s/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/kubectl/pkg/cmd/get/get.go:167 +0x12d
k8s.io/kubernetes/vendor/github.com/spf13/cobra.(*Command).execute(0xc0004018c0, 0xc0000cfa40, 0x4, 0x4, 0xc0004018c0, 0xc0000cfa40)
	/workspace/k8s/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/github.com/spf13/cobra/command.go:846 +0x29d
k8s.io/kubernetes/vendor/github.com/spf13/cobra.(*Command).ExecuteC(0xc0000f6000, 0xc0000cc180, 0xc0000cc120, 0x6)
	/workspace/k8s/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/github.com/spf13/cobra/command.go:950 +0x349
k8s.io/kubernetes/vendor/github.com/spf13/cobra.(*Command).Execute(...)
	/workspace/k8s/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/github.com/spf13/cobra/command.go:887
main.main()
	_output/local/go/src/k8s.io/kubernetes/cmd/kubectl/kubectl.go:49 +0x21d

goroutine 18 [chan receive]:
k8s.io/kubernetes/vendor/k8s.io/klog/v2.(*loggingT).flushDaemon(0x2f69600)
	/workspace/k8s/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/klog/v2/klog.go:1131 +0x8b
created by k8s.io/kubernetes/vendor/k8s.io/klog/v2.init.0
	/workspace/k8s/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/klog/v2/klog.go:416 +0xd6

goroutine 5 [select]:
k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/wait.BackoffUntil(0x1c7fed0, 0x1e4e800, 0xc00026c000, 0x1, 0xc0000a40c0)
	/workspace/k8s/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:167 +0x13f
k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/wait.JitterUntil(0x1c7fed0, 0x12a05f200, 0x0, 0x1, 0xc0000a40c0)
	/workspace/k8s/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:133 +0x98
k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/wait.Until(0x1c7fed0, 0x12a05f200, 0xc0000a40c0)
	/workspace/k8s/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:90 +0x4d
created by k8s.io/kubernetes/vendor/k8s.io/kubectl/pkg/util/logs.InitLogs
	/workspace/k8s/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/kubectl/pkg/util/logs/logs.go:51 +0x96

goroutine 25 [IO wait]:
internal/poll.runtime_pollWait(0x7f027e91bfe0, 0x72, 0xffffffffffffffff)
	/.gvm/gos/go1.14.6/src/runtime/netpoll.go:203 +0x55
internal/poll.(*pollDesc).wait(0xc0008f9098, 0x72, 0x3000, 0x309a, 0xffffffffffffffff)
	/.gvm/gos/go1.14.6/src/internal/poll/fd_poll_runtime.go:87 +0x45
internal/poll.(*pollDesc).waitRead(...)
	/.gvm/gos/go1.14.6/src/internal/poll/fd_poll_runtime.go:92
internal/poll.(*FD).Read(0xc0008f9080, 0xc0006b8000, 0x309a, 0x309a, 0x0, 0x0, 0x0)
	/.gvm/gos/go1.14.6/src/internal/poll/fd_unix.go:169 +0x19b
net.(*netFD).Read(0xc0008f9080, 0xc0006b8000, 0x309a, 0x309a, 0x203000, 0x63ac10, 0xc0003ba4b8)
	/.gvm/gos/go1.14.6/src/net/fd_unix.go:202 +0x4f
net.(*conn).Read(0xc00000e020, 0xc0006b8000, 0x309a, 0x309a, 0x0, 0x0, 0x0)
	/.gvm/gos/go1.14.6/src/net/net.go:184 +0x8e
crypto/tls.(*atLeastReader).Read(0xc0005ce020, 0xc0006b8000, 0x309a, 0x309a, 0x0, 0x2076, 0xc00009f9c8)
	/.gvm/gos/go1.14.6/src/crypto/tls/conn.go:760 +0x60
bytes.(*Buffer).ReadFrom(0xc0003ba5d8, 0x1e4d200, 0xc0005ce020, 0x40a545, 0x198a7a0, 0x1b0d120)
	/.gvm/gos/go1.14.6/src/bytes/buffer.go:204 +0xb1
crypto/tls.(*Conn).readFromUntil(0xc0003ba380, 0x1e4fd40, 0xc00000e020, 0x5, 0xc00000e020, 0x8)
	/.gvm/gos/go1.14.6/src/crypto/tls/conn.go:782 +0xec
crypto/tls.(*Conn).readRecordOrCCS(0xc0003ba380, 0x0, 0x0, 0xc00009fd38)
	/.gvm/gos/go1.14.6/src/crypto/tls/conn.go:589 +0x115
crypto/tls.(*Conn).readRecord(...)
	/.gvm/gos/go1.14.6/src/crypto/tls/conn.go:557
crypto/tls.(*Conn).Read(0xc0003ba380, 0xc000334000, 0x1000, 0x1000, 0x0, 0x0, 0x0)
	/.gvm/gos/go1.14.6/src/crypto/tls/conn.go:1233 +0x15b
bufio.(*Reader).Read(0xc000355ce0, 0xc00067e1f8, 0x9, 0x9, 0xc00009fd38, 0x1c80c00, 0x94ce55)
	/.gvm/gos/go1.14.6/src/bufio/bufio.go:226 +0x24f
io.ReadAtLeast(0x1e4d020, 0xc000355ce0, 0xc00067e1f8, 0x9, 0x9, 0x9, 0xc0000a6050, 0x0, 0x1e4d400)
	/.gvm/gos/go1.14.6/src/io/io.go:310 +0x87
io.ReadFull(...)
	/.gvm/gos/go1.14.6/src/io/io.go:329
k8s.io/kubernetes/vendor/golang.org/x/net/http2.readFrameHeader(0xc00067e1f8, 0x9, 0x9, 0x1e4d020, 0xc000355ce0, 0x0, 0x0, 0xc000a90030, 0x0)
	/workspace/k8s/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/golang.org/x/net/http2/frame.go:237 +0x87
k8s.io/kubernetes/vendor/golang.org/x/net/http2.(*Framer).ReadFrame(0xc00067e1c0, 0xc000a90030, 0x0, 0x0, 0x0)
	/workspace/k8s/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/golang.org/x/net/http2/frame.go:492 +0xa1
k8s.io/kubernetes/vendor/golang.org/x/net/http2.(*clientConnReadLoop).run(0xc00009ffa8, 0xc000066fb0, 0x738752)
	/workspace/k8s/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/golang.org/x/net/http2/transport.go:1746 +0x8d
k8s.io/kubernetes/vendor/golang.org/x/net/http2.(*ClientConn).readLoop(0xc000093500)
	/workspace/k8s/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/golang.org/x/net/http2/transport.go:1674 +0x6f
created by k8s.io/kubernetes/vendor/golang.org/x/net/http2.(*Transport).newClientConn
	/workspace/k8s/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/golang.org/x/net/http2/transport.go:674 +0x64a
```

This PR treats those nil elements as 0/empty and sorts them this way, it might not be consistent with the output from `kubectl get` because that fetches that data from other fields. With Event's `lastTimestamp` it sometimes is replaced with its `firstTimestamp`, see here: https://github.com/kubernetes/kubernetes/blob/b56d0acaf5bead31bd17d3b88d4a167fcbac7866/pkg/printers/internalversion/printers.go#L1724-L1732

**Special notes for your reviewer**:
/assign @sallyom 

**Does this PR introduce a user-facing change?**:
```release-note
Do not fail sorting empty elements. 
```
