### PR TITLE
Fix flaky unit test Test_Run_Positive_VolumeMountControllerAttachEnabledRace data race

### DIFF
--- a/pkg/kubelet/volumemanager/reconciler/reconciler_test.go
+++ b/pkg/kubelet/volumemanager/reconciler/reconciler_test.go
@@ -48,14 +48,14 @@ import (
 const (
 	// reconcilerLoopSleepDuration is the amount of time the reconciler loop
 	// waits between successive executions
-	reconcilerLoopSleepDuration time.Duration = 1 * time.Nanosecond
+	reconcilerLoopSleepDuration = 1 * time.Nanosecond
 	// waitForAttachTimeout is the maximum amount of time a
 	// operationexecutor.Mount call will wait for a volume to be attached.
-	waitForAttachTimeout         time.Duration     = 1 * time.Second
-	nodeName                     k8stypes.NodeName = k8stypes.NodeName("mynodename")
-	kubeletPodsDir               string            = "fake-dir"
-	testOperationBackOffDuration time.Duration     = 100 * time.Millisecond
-	reconcilerSyncWaitDuration   time.Duration     = 10 * time.Second
+	waitForAttachTimeout         = 1 * time.Second
+	nodeName                     = k8stypes.NodeName("mynodename")
+	kubeletPodsDir               = "fake-dir"
+	testOperationBackOffDuration = 100 * time.Millisecond
+	reconcilerSyncWaitDuration   = 10 * time.Second
 )
 
 func hasAddedPods() bool { return true }
@@ -1791,6 +1791,7 @@ func Test_Run_Positive_VolumeMountControllerAttachEnabledRace(t *testing.T) {
 	<-stoppedChan
 
 	finished := make(chan interface{})
+	fakePlugin.Lock()
 	fakePlugin.UnmountDeviceHook = func(mountPath string) error {
 		// Act:
 		// 3. While a volume is being unmounted, add it back to the desired state of world
@@ -1812,6 +1813,7 @@ func Test_Run_Positive_VolumeMountControllerAttachEnabledRace(t *testing.T) {
 		close(finished)
 		return devicePath, nil
 	}
+	fakePlugin.Unlock()
 
 	// Start the reconciler again.
 	go reconciler.Run(wait.NeverStop)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug
/kind flake

**What this PR does / why we need it**:

1.  what's the failed

one failed output

```
WARNING: DATA RACE
Write at 0x00c000116ba0 by goroutine 20:
  k8s.io/kubernetes/pkg/kubelet/volumemanager/reconciler.Test_Run_Positive_VolumeMountControllerAttachEnabledRace()
      /opt/workspace/myspace/k8s/kubernetes/pkg/kubelet/volumemanager/reconciler/reconciler_test.go:1794 +0x12fe
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1108 +0x202

Previous read at 0x00c000116ba0 by goroutine 25:
  k8s.io/kubernetes/pkg/volume/testing.(*FakeVolumePlugin).getFakeVolume()
      /opt/workspace/myspace/k8s/kubernetes/pkg/volume/testing/testing.go:416 +0x5bd
  k8s.io/kubernetes/pkg/volume/testing.(*FakeVolumePlugin).NewAttacher()
      /opt/workspace/myspace/k8s/kubernetes/pkg/volume/testing/testing.go:560 +0xf9
  k8s.io/kubernetes/pkg/volume/testing.(*FakeVolumePlugin).NewDeviceMounter()
      /opt/workspace/myspace/k8s/kubernetes/pkg/volume/testing/testing.go:564 +0x3c
  k8s.io/kubernetes/pkg/volume/util/operationexecutor.(*operationGenerator).GenerateMountVolumeFunc.func1()
      /opt/workspace/myspace/k8s/kubernetes/pkg/volume/util/operationexecutor/operation_generator.go:540 +0x2251
  k8s.io/kubernetes/pkg/volume/util/types.(*GeneratedOperations).Run()
      /opt/workspace/myspace/k8s/kubernetes/pkg/volume/util/types/types.go:54 +0x142
  k8s.io/kubernetes/pkg/volume/util/nestedpendingoperations.(*nestedPendingOperations).Run.func1()
/opt/workspace/myspace/k8s/kubernetes/pkg/volume/util/nestedpendingoperations/nestedpendingoperations.go:183 +0x159

Goroutine 20 (running) created at:
  testing.(*T).Run()
      /usr/local/go/src/testing/testing.go:1159 +0x796
  testing.runTests.func1()
      /usr/local/go/src/testing/testing.go:1430 +0xa6
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1108 +0x202
  testing.runTests()
      /usr/local/go/src/testing/testing.go:1428 +0x5aa
  testing.(*M).Run()
      /usr/local/go/src/testing/testing.go:1338 +0x4eb
  main.main()
      _testmain.go:73 +0x236

Goroutine 25 (running) created at: 
  k8s.io/kubernetes/pkg/volume/util/nestedpendingoperations.(*nestedPendingOperations).Run()
      /opt/workspace/myspace/k8s/kubernetes/pkg/volume/util/nestedpendingoperations/nestedpendingoperations.go:178 +0x5b2
  k8s.io/kubernetes/pkg/volume/util/operationexecutor.(*operationExecutor).MountVolume()
      /opt/workspace/myspace/k8s/kubernetes/pkg/volume/util/operationexecutor/operation_executor.go:839 +0x2b0
  k8s.io/kubernetes/pkg/kubelet/volumemanager/reconciler.(*reconciler).mountAttachVolumes()
      /opt/workspace/myspace/k8s/kubernetes/pkg/kubelet/volumemanager/reconciler/reconciler.go:255 +0x974
I0909 22:54:05.010993   24541 operation_generator.go:595] MountVolume.MountDevice succeeded for volume "volume-name" (UniqueName: "fake-plugin/fake-device1") pod "pod1" (UID: "pod1uid") device mount path ""
  k8s.io/kubernetes/pkg/kubelet/volumemanager/reconciler.(*reconciler).reconcile()
      /opt/workspace/myspace/k8s/kubernetes/pkg/kubelet/volumemanager/reconciler/reconciler.go:174 +0x46
  k8s.io/kubernetes/pkg/kubelet/volumemanager/reconciler.(*reconciler).reconciliationLoopFunc.func1()
      /opt/workspace/myspace/k8s/kubernetes/pkg/kubelet/volumemanager/reconciler/reconciler.go:151 +0x4a
  k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1()
      /opt/workspace/myspace/k8s/kubernetes/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:155 +0x75
  k8s.io/apimachinery/pkg/util/wait.BackoffUntil()
      /opt/workspace/myspace/k8s/kubernetes/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:156 +0xba
  k8s.io/apimachinery/pkg/util/wait.JitterUntil()
      /opt/workspace/myspace/k8s/kubernetes/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:133 +0x114
  k8s.io/apimachinery/pkg/util/wait.Until()
      /opt/workspace/myspace/k8s/kubernetes/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:90 +0x8e
  k8s.io/kubernetes/pkg/kubelet/volumemanager/reconciler.(*reconciler).Run()
      /opt/workspace/myspace/k8s/kubernetes/pkg/kubelet/volumemanager/reconciler/reconciler.go:146 +0x2f
  k8s.io/kubernetes/pkg/kubelet/volumemanager/reconciler.Test_Run_Positive_VolumeMountControllerAttachEnabledRace.func1()
      /opt/workspace/myspace/k8s/kubernetes/pkg/kubelet/volumemanager/reconciler/reconciler_test.go:1785 +0x48

```

from the output, we can find the two routine run the race to `WaitForAttachHook` and `UnmountDeviceHook` of  FakeVolumePlugin.  

one routine  created at 

https://github.com/kubernetes/kubernetes/blob/c3b888f647f99eba246468ac3e13afc49542c06d/pkg/volume/util/nestedpendingoperations/nestedpendingoperations.go#L183

and most origin from Test_Run_Positive_VolumeMountControllerAttachEnabledRace

https://github.com/kubernetes/kubernetes/blob/c3b888f647f99eba246468ac3e13afc49542c06d/pkg/kubelet/volumemanager/reconciler/reconciler_test.go#L1785

this  children routine read field  `WaitForAttachHook` and `UnmountDeviceHook` from FakeVolumePlugin

https://github.com/kubernetes/kubernetes/blob/c3b888f647f99eba246468ac3e13afc49542c06d/pkg/volume/testing/testing.go#L415-L416

while main routine in Test_Run_Positive_VolumeMountControllerAttachEnabledRace reset field `WaitForAttachHook` and `UnmountDeviceHook` of  FakeVolumePlugin

https://github.com/kubernetes/kubernetes/blob/c3b888f647f99eba246468ac3e13afc49542c06d/pkg/kubelet/volumemanager/reconciler/reconciler_test.go#L1794
 
https://github.com/kubernetes/kubernetes/blob/c3b888f647f99eba246468ac3e13afc49542c06d/pkg/kubelet/volumemanager/reconciler/reconciler_test.go#L1804

and they case the data race.(one read data and the other set data)

2. how to deal with it

children routine's trace code is in method `getFakeVolume`, the the caller is the method `NewAttacher`

https://github.com/kubernetes/kubernetes/blob/c3b888f647f99eba246468ac3e13afc49542c06d/pkg/volume/testing/testing.go#L556-L561

so in FakeVolumePlugin object, it has a lock to sync the data changing.

https://github.com/kubernetes/kubernetes/blob/c3b888f647f99eba246468ac3e13afc49542c06d/pkg/volume/testing/testing.go#L370-L372

so from the outside in Test_Run_Positive_VolumeMountControllerAttachEnabledRace,  we should acquire lock before we reset the field `WaitForAttachHook` and `UnmountDeviceHook` of  FakeVolumePlugin. 


3. result  of test when using my fix

running result on  my local robot. 
```
34017 runs so far, 0 failures
34096 runs so far, 0 failures
```

**Which issue(s) this PR fixes**:

Fixes # https://github.com/kubernetes/kubernetes/issues/94568
Part of # https://github.com/kubernetes/kubernetes/issues/94528#issuecomment-687250557

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```


