### PR TITLE
[sig-scheduling] SchedulerPriorities [Serial] Pod should avoid nodes that have avoidPod annotation: clean remaining pods

### DIFF
--- a/test/e2e/scheduling/predicates.go
+++ b/test/e2e/scheduling/predicates.go
@@ -887,8 +887,8 @@ func initPausePod(f *framework.Framework, conf pausePodConfig) *v1.Pod {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            conf.Name,
 			Namespace:       conf.Namespace,
-			Labels:          conf.Labels,
-			Annotations:     conf.Annotations,
+			Labels:          map[string]string{},
+			Annotations:     map[string]string{},
 			OwnerReferences: conf.OwnerReferences,
 		},
 		Spec: v1.PodSpec{
@@ -907,6 +907,12 @@ func initPausePod(f *framework.Framework, conf pausePodConfig) *v1.Pod {
 			PriorityClassName:             conf.PriorityClassName,
 			TerminationGracePeriodSeconds: &gracePeriod,
 		},
+	}
+	for key, value := range conf.Labels {
+		pod.ObjectMeta.Labels[key] = value
+	}
+	for key, value := range conf.Annotations {
+		pod.ObjectMeta.Annotations[key] = value
 	}
 	// TODO: setting the Pod's nodeAffinity instead of setting .spec.nodeName works around the
 	// Preemption e2e flake (#88441), but we should investigate deeper to get to the bottom of it.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
In some cases when running "[sig-scheduling] SchedulerPredicates [Serial] validates resource limits of pods that are allowed to run"
"scheduler-priority-avoid-pod-XXX" filler pods from "[sig-scheduling] SchedulerPriorities [Serial] Pod should avoid nodes that have avoidPod annotation" are still being
terminated in the cluster. Which can cause "validates resource limits of pods that are allowed to run" to flake since the filler
pods dissappear before "additional-pod" is scheduled. Causing the calculated filler-pods to consume less than they are supposed to.

/kind bug

**What this PR does / why we need it**:
Reduce flakiness of `[sig-scheduling] SchedulerPredicates [Serial] validates resource limits of pods that are allowed to run`


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #94715

**Special notes for your reviewer**:

Scheduler logs around the time of flakiness:
```
I0904 13:19:21.079071       1 debugger.go:65] "Dumping node infos" node="master-0.ci-op-qfypnb1x-18a82.origin-ci-int-aws.dev.rhcloud.com" requested="[memory=5579Mi pods=0 ephemeral-storage=0 cpu=1895m]"
I0904 13:19:21.079095       1 debugger.go:65] "Dumping node infos" node="master-1.ci-op-qfypnb1x-18a82.origin-ci-int-aws.dev.rhcloud.com" requested="[cpu=1720m memory=5049Mi pods=0 ephemeral-storage=0]"
I0904 13:19:21.079108       1 debugger.go:65] "Dumping node infos" node="master-2.ci-op-qfypnb1x-18a82.origin-ci-int-aws.dev.rhcloud.com" requested="[ephemeral-storage=0 cpu=1934m memory=5999Mi pods=0]"
I0904 13:19:21.079121       1 debugger.go:65] "Dumping node infos" node="worker-0.ci-op-qfypnb1x-18a82.origin-ci-int-aws.dev.rhcloud.com" requested="[cpu=773m memory=3097Mi pods=0 ephemeral-storage=0]"
I0904 13:19:21.079133       1 debugger.go:65] "Dumping node infos" node="worker-2.ci-op-qfypnb1x-18a82.origin-ci-int-aws.dev.rhcloud.com" requested="[memory=3282Mi pods=0 ephemeral-storage=0 cpu=572m]"
I0904 13:19:21.079145       1 debugger.go:65] "Dumping node infos" node="worker-1.ci-op-qfypnb1x-18a82.origin-ci-int-aws.dev.rhcloud.com" requested="[cpu=468m memory=2931Mi pods=0 ephemeral-storage=0]"
I0904 13:19:21.083259       1 scheduler.go:598] "Successfully bound pod to node" pod="e2e-sched-priority-3802/ead2872e-4ad3-4244-bb02-9f7ff0b6a428-0" node="worker-0.ci-op-qfypnb1x-18a82.origin-ci-int-aws.dev.rhcloud.com" evaluatedNodes=6 feasibleNodes=1
I0904 13:19:26.257626       1 debugger.go:65] "Dumping node infos" node="master-0.ci-op-qfypnb1x-18a82.origin-ci-int-aws.dev.rhcloud.com" requested="[cpu=1895m memory=5579Mi pods=0 ephemeral-storage=0]"
I0904 13:19:26.257646       1 debugger.go:65] "Dumping node infos" node="master-1.ci-op-qfypnb1x-18a82.origin-ci-int-aws.dev.rhcloud.com" requested="[cpu=1720m memory=5049Mi pods=0 ephemeral-storage=0]"
I0904 13:19:26.257656       1 debugger.go:65] "Dumping node infos" node="master-2.ci-op-qfypnb1x-18a82.origin-ci-int-aws.dev.rhcloud.com" requested="[cpu=1934m memory=5999Mi pods=0 ephemeral-storage=0]"
I0904 13:19:26.257668       1 debugger.go:65] "Dumping node infos" node="worker-0.ci-op-qfypnb1x-18a82.origin-ci-int-aws.dev.rhcloud.com" requested="[cpu=3650m memory=14938440Ki pods=0 ephemeral-storage=0]"
I0904 13:19:26.257677       1 debugger.go:65] "Dumping node infos" node="worker-2.ci-op-qfypnb1x-18a82.origin-ci-int-aws.dev.rhcloud.com" requested="[cpu=572m memory=3282Mi pods=0 ephemeral-storage=0]"
I0904 13:19:26.257689       1 debugger.go:65] "Dumping node infos" node="worker-1.ci-op-qfypnb1x-18a82.origin-ci-int-aws.dev.rhcloud.com" requested="[memory=2931Mi pods=0 ephemeral-storage=0 cpu=468m]"
I0904 13:19:26.263121       1 scheduler.go:598] "Successfully bound pod to node" pod="e2e-sched-priority-3802/67e791a6-f170-4aff-b2b1-e42a0a6a7c3c-0" node="worker-1.ci-op-qfypnb1x-18a82.origin-ci-int-aws.dev.rhcloud.com" evaluatedNodes=6 feasibleNodes=1
I0904 13:19:31.436220       1 debugger.go:65] "Dumping node infos" node="master-0.ci-op-qfypnb1x-18a82.origin-ci-int-aws.dev.rhcloud.com" requested="[cpu=1895m memory=5579Mi pods=0 ephemeral-storage=0]"
I0904 13:19:31.436239       1 debugger.go:65] "Dumping node infos" node="master-1.ci-op-qfypnb1x-18a82.origin-ci-int-aws.dev.rhcloud.com" requested="[ephemeral-storage=0 cpu=1720m memory=5049Mi pods=0]"
I0904 13:19:31.436251       1 debugger.go:65] "Dumping node infos" node="master-2.ci-op-qfypnb1x-18a82.origin-ci-int-aws.dev.rhcloud.com" requested="[cpu=1934m memory=5999Mi pods=0 ephemeral-storage=0]"
I0904 13:19:31.436264       1 debugger.go:65] "Dumping node infos" node="worker-0.ci-op-qfypnb1x-18a82.origin-ci-int-aws.dev.rhcloud.com" requested="[ephemeral-storage=0 cpu=3650m memory=14938440Ki pods=0]"
I0904 13:19:31.436275       1 debugger.go:65] "Dumping node infos" node="worker-2.ci-op-qfypnb1x-18a82.origin-ci-int-aws.dev.rhcloud.com" requested="[cpu=572m memory=3282Mi pods=0 ephemeral-storage=0]"
I0904 13:19:31.436288       1 debugger.go:65] "Dumping node infos" node="worker-1.ci-op-qfypnb1x-18a82.origin-ci-int-aws.dev.rhcloud.com" requested="[cpu=3650m memory=14874430Ki pods=0 ephemeral-storage=0]"
I0904 13:19:31.440420       1 scheduler.go:598] "Successfully bound pod to node" pod="e2e-sched-priority-3802/ffecd964-0982-4541-ba35-bc53ef1bcd52-0" node="worker-2.ci-op-qfypnb1x-18a82.origin-ci-int-aws.dev.rhcloud.com" evaluatedNodes=6 feasibleNodes=1
I0904 13:19:40.139882       1 debugger.go:65] "Dumping node infos" node="master-0.ci-op-qfypnb1x-18a82.origin-ci-int-aws.dev.rhcloud.com" requested="[cpu=1895m memory=5579Mi pods=0 ephemeral-storage=0]"
I0904 13:19:40.139904       1 debugger.go:65] "Dumping node infos" node="master-1.ci-op-qfypnb1x-18a82.origin-ci-int-aws.dev.rhcloud.com" requested="[cpu=1720m memory=5049Mi pods=0 ephemeral-storage=0]"
I0904 13:19:40.139914       1 debugger.go:65] "Dumping node infos" node="master-2.ci-op-qfypnb1x-18a82.origin-ci-int-aws.dev.rhcloud.com" requested="[cpu=1934m memory=5999Mi pods=0 ephemeral-storage=0]"
I0904 13:19:40.139922       1 debugger.go:65] "Dumping node infos" node="worker-0.ci-op-qfypnb1x-18a82.origin-ci-int-aws.dev.rhcloud.com" requested="[pods=0 ephemeral-storage=0 cpu=3650m memory=14938440Ki]"
I0904 13:19:40.139930       1 debugger.go:65] "Dumping node infos" node="worker-2.ci-op-qfypnb1x-18a82.origin-ci-int-aws.dev.rhcloud.com" requested="[memory=15231428607 pods=0 ephemeral-storage=0 cpu=3650m]"
I0904 13:19:40.139942       1 debugger.go:65] "Dumping node infos" node="worker-1.ci-op-qfypnb1x-18a82.origin-ci-int-aws.dev.rhcloud.com" requested="[pods=0 ephemeral-storage=0 cpu=3650m memory=14874430Ki]"
I0904 13:19:40.145351       1 scheduler.go:598] "Successfully bound pod to node" pod="e2e-sched-priority-3802/scheduler-priority-avoid-pod-j72gx" node="worker-1.ci-op-qfypnb1x-18a82.origin-ci-int-aws.dev.rhcloud.com" evaluatedNodes=6 feasibleNodes=3
I0904 13:19:40.146963       1 debugger.go:65] "Dumping node infos" node="master-0.ci-op-qfypnb1x-18a82.origin-ci-int-aws.dev.rhcloud.com" requested="[pods=0 ephemeral-storage=0 cpu=1895m memory=5579Mi]"
I0904 13:19:40.147004       1 debugger.go:65] "Dumping node infos" node="master-1.ci-op-qfypnb1x-18a82.origin-ci-int-aws.dev.rhcloud.com" requested="[pods=0 ephemeral-storage=0 cpu=1720m memory=5049Mi]"
I0904 13:19:40.147026       1 debugger.go:65] "Dumping node infos" node="master-2.ci-op-qfypnb1x-18a82.origin-ci-int-aws.dev.rhcloud.com" requested="[cpu=1934m memory=5999Mi pods=0 ephemeral-storage=0]"
I0904 13:19:40.147046       1 debugger.go:65] "Dumping node infos" node="worker-0.ci-op-qfypnb1x-18a82.origin-ci-int-aws.dev.rhcloud.com" requested="[cpu=3650m memory=14938440Ki pods=0 ephemeral-storage=0]"
I0904 13:19:40.147068       1 debugger.go:65] "Dumping node infos" node="worker-2.ci-op-qfypnb1x-18a82.origin-ci-int-aws.dev.rhcloud.com" requested="[memory=15231428607 pods=0 ephemeral-storage=0 cpu=3650m]"
I0904 13:19:40.147092       1 debugger.go:65] "Dumping node infos" node="worker-1.ci-op-qfypnb1x-18a82.origin-ci-int-aws.dev.rhcloud.com" requested="[memory=14976830Ki pods=0 ephemeral-storage=0 cpu=3750m]"
I0904 13:19:40.150793       1 scheduler.go:598] "Successfully bound pod to node" pod="e2e-sched-priority-3802/scheduler-priority-avoid-pod-j6kgx" node="worker-2.ci-op-qfypnb1x-18a82.origin-ci-int-aws.dev.rhcloud.com" evaluatedNodes=6 feasibleNodes=3
I0904 13:20:00.462039       1 debugger.go:65] "Dumping node infos" node="master-0.ci-op-qfypnb1x-18a82.origin-ci-int-aws.dev.rhcloud.com" requested="[cpu=1895m memory=5579Mi pods=0 ephemeral-storage=0]"
I0904 13:20:00.462066       1 debugger.go:65] "Dumping node infos" node="master-1.ci-op-qfypnb1x-18a82.origin-ci-int-aws.dev.rhcloud.com" requested="[cpu=1720m memory=5049Mi pods=0 ephemeral-storage=0]"
I0904 13:20:00.462079       1 debugger.go:65] "Dumping node infos" node="master-2.ci-op-qfypnb1x-18a82.origin-ci-int-aws.dev.rhcloud.com" requested="[cpu=1934m memory=5999Mi pods=0 ephemeral-storage=0]"
I0904 13:20:00.462091       1 debugger.go:65] "Dumping node infos" node="worker-0.ci-op-qfypnb1x-18a82.origin-ci-int-aws.dev.rhcloud.com" requested="[pods=0 ephemeral-storage=0 cpu=3650m memory=14938440Ki]"
I0904 13:20:00.462103       1 debugger.go:65] "Dumping node infos" node="worker-2.ci-op-qfypnb1x-18a82.origin-ci-int-aws.dev.rhcloud.com" requested="[cpu=3650m memory=15231428607 pods=0 ephemeral-storage=0]"
I0904 13:20:00.462122       1 debugger.go:65] "Dumping node infos" node="worker-1.ci-op-qfypnb1x-18a82.origin-ci-int-aws.dev.rhcloud.com" requested="[ephemeral-storage=0 cpu=3650m memory=14874430Ki pods=0]"
I0904 13:20:00.466956       1 scheduler.go:598] "Successfully bound pod to node" pod="e2e-sched-pred-4521/filler-pod-5be568c0-1552-4f2e-8ff2-869c5cd610f7" node="worker-0.ci-op-qfypnb1x-18a82.origin-ci-int-aws.dev.rhcloud.com" evaluatedNodes=6 feasibleNodes=1
I0904 13:20:00.541768       1 debugger.go:65] "Dumping node infos" node="master-0.ci-op-qfypnb1x-18a82.origin-ci-int-aws.dev.rhcloud.com" requested="[pods=0 ephemeral-storage=0 cpu=1895m memory=5579Mi]"
I0904 13:20:00.541793       1 debugger.go:65] "Dumping node infos" node="master-1.ci-op-qfypnb1x-18a82.origin-ci-int-aws.dev.rhcloud.com" requested="[cpu=1720m memory=5049Mi pods=0 ephemeral-storage=0]"
I0904 13:20:00.541806       1 debugger.go:65] "Dumping node infos" node="master-2.ci-op-qfypnb1x-18a82.origin-ci-int-aws.dev.rhcloud.com" requested="[cpu=1934m memory=5999Mi pods=0 ephemeral-storage=0]"
I0904 13:20:00.541818       1 debugger.go:65] "Dumping node infos" node="worker-0.ci-op-qfypnb1x-18a82.origin-ci-int-aws.dev.rhcloud.com" requested="[cpu=6345m memory=14938440Ki pods=0 ephemeral-storage=0]"
I0904 13:20:00.541833       1 debugger.go:65] "Dumping node infos" node="worker-2.ci-op-qfypnb1x-18a82.origin-ci-int-aws.dev.rhcloud.com" requested="[cpu=3650m memory=15231428607 pods=0 ephemeral-storage=0]"
I0904 13:20:00.541847       1 debugger.go:65] "Dumping node infos" node="worker-1.ci-op-qfypnb1x-18a82.origin-ci-int-aws.dev.rhcloud.com" requested="[cpu=3650m memory=14874430Ki pods=0 ephemeral-storage=0]"
I0904 13:20:00.545296       1 scheduler.go:598] "Successfully bound pod to node" pod="e2e-sched-pred-4521/filler-pod-8e8309c7-b858-481c-8052-246ba24580d0" node="worker-1.ci-op-qfypnb1x-18a82.origin-ci-int-aws.dev.rhcloud.com" evaluatedNodes=6 feasibleNodes=1
I0904 13:20:00.622148       1 debugger.go:65] "Dumping node infos" node="master-0.ci-op-qfypnb1x-18a82.origin-ci-int-aws.dev.rhcloud.com" requested="[memory=5579Mi pods=0 ephemeral-storage=0 cpu=1895m]"
I0904 13:20:00.622175       1 debugger.go:65] "Dumping node infos" node="master-1.ci-op-qfypnb1x-18a82.origin-ci-int-aws.dev.rhcloud.com" requested="[memory=5049Mi pods=0 ephemeral-storage=0 cpu=1720m]"
I0904 13:20:00.622188       1 debugger.go:65] "Dumping node infos" node="master-2.ci-op-qfypnb1x-18a82.origin-ci-int-aws.dev.rhcloud.com" requested="[ephemeral-storage=0 cpu=1934m memory=5999Mi pods=0]"
I0904 13:20:00.622199       1 debugger.go:65] "Dumping node infos" node="worker-0.ci-op-qfypnb1x-18a82.origin-ci-int-aws.dev.rhcloud.com" requested="[cpu=6345m memory=14938440Ki pods=0 ephemeral-storage=0]"
I0904 13:20:00.622213       1 debugger.go:65] "Dumping node infos" node="worker-2.ci-op-qfypnb1x-18a82.origin-ci-int-aws.dev.rhcloud.com" requested="[cpu=3650m memory=15231428607 pods=0 ephemeral-storage=0]"
I0904 13:20:00.622229       1 debugger.go:65] "Dumping node infos" node="worker-1.ci-op-qfypnb1x-18a82.origin-ci-int-aws.dev.rhcloud.com" requested="[pods=0 ephemeral-storage=0 cpu=6345m memory=14874430Ki]"
I0904 13:20:00.625867       1 scheduler.go:598] "Successfully bound pod to node" pod="e2e-sched-pred-4521/filler-pod-e98507a6-2221-4312-9f1b-34b7d1124b91" node="worker-2.ci-op-qfypnb1x-18a82.origin-ci-int-aws.dev.rhcloud.com" evaluatedNodes=6 feasibleNodes=1
I0904 13:20:05.309985       1 debugger.go:65] "Dumping node infos" node="master-0.ci-op-qfypnb1x-18a82.origin-ci-int-aws.dev.rhcloud.com" requested="[cpu=1895m memory=5579Mi pods=0 ephemeral-storage=0]"
I0904 13:20:05.310011       1 debugger.go:65] "Dumping node infos" node="master-1.ci-op-qfypnb1x-18a82.origin-ci-int-aws.dev.rhcloud.com" requested="[cpu=1720m memory=5049Mi pods=0 ephemeral-storage=0]"
I0904 13:20:05.310021       1 debugger.go:65] "Dumping node infos" node="master-2.ci-op-qfypnb1x-18a82.origin-ci-int-aws.dev.rhcloud.com" requested="[ephemeral-storage=0 cpu=1934m memory=5999Mi pods=0]"
I0904 13:20:05.310029       1 debugger.go:65] "Dumping node infos" node="worker-0.ci-op-qfypnb1x-18a82.origin-ci-int-aws.dev.rhcloud.com" requested="[cpu=3468m memory=3097Mi pods=0 ephemeral-storage=0]"
I0904 13:20:05.310037       1 debugger.go:65] "Dumping node infos" node="worker-2.ci-op-qfypnb1x-18a82.origin-ci-int-aws.dev.rhcloud.com" requested="[ephemeral-storage=0 cpu=3267m memory=3282Mi pods=0]"
I0904 13:20:05.310044       1 debugger.go:65] "Dumping node infos" node="worker-1.ci-op-qfypnb1x-18a82.origin-ci-int-aws.dev.rhcloud.com" requested="[pods=0 ephemeral-storage=0 cpu=6345m memory=14874430Ki]"
I0904 13:20:05.314450       1 scheduler.go:598] "Successfully bound pod to node" pod="e2e-sched-pred-4521/additional-pod" node="worker-2.ci-op-qfypnb1x-18a82.origin-ci-int-aws.dev.rhcloud.com" evaluatedNodes=6 feasibleNodes=2
```

Notice the change of cpu on `worker-0.ci-op-qfypnb1x-18a82.origin-ci-int-aws.dev.rhcloud.com` right before `e2e-sched-pred-4521/additional-pod` is scheduled. Requested cpu of all pods on the node dropped from `cpu=6345m` to `cpu=3468m` as `ead2872e-4ad3-4244-bb02-9f7ff0b6a428-0` pod finally disappeared.

Before that the total requested cpu was computed through:
```
Sep  4 13:20:00.412: INFO: Pod 67e791a6-f170-4aff-b2b1-e42a0a6a7c3c-0 requesting resource cpu=3182m on Node worker-1.ci-op-qfypnb1x-18a82.origin-ci-int-aws.dev.rhcloud.com
Sep  4 13:20:00.412: INFO: Pod ead2872e-4ad3-4244-bb02-9f7ff0b6a428-0 requesting resource cpu=2877m on Node worker-0.ci-op-qfypnb1x-18a82.origin-ci-int-aws.dev.rhcloud.com
Sep  4 13:20:00.412: INFO: Pod ffecd964-0982-4541-ba35-bc53ef1bcd52-0 requesting resource cpu=3078m on Node worker-2.ci-op-qfypnb1x-18a82.origin-ci-int-aws.dev.rhcloud.com
Sep  4 13:20:00.412: INFO: Pod tuned-cmmn2 requesting resource cpu=10m on Node worker-2.ci-op-qfypnb1x-18a82.origin-ci-int-aws.dev.rhcloud.com
Sep  4 13:20:00.412: INFO: Pod tuned-tljds requesting resource cpu=10m on Node worker-0.ci-op-qfypnb1x-18a82.origin-ci-int-aws.dev.rhcloud.com
Sep  4 13:20:00.412: INFO: Pod tuned-v48gt requesting resource cpu=10m on Node worker-1.ci-op-qfypnb1x-18a82.origin-ci-int-aws.dev.rhcloud.com
Sep  4 13:20:00.412: INFO: Pod dns-default-rc6ht requesting resource cpu=65m on Node worker-2.ci-op-qfypnb1x-18a82.origin-ci-int-aws.dev.rhcloud.com
Sep  4 13:20:00.412: INFO: Pod dns-default-tbqpg requesting resource cpu=65m on Node worker-0.ci-op-qfypnb1x-18a82.origin-ci-int-aws.dev.rhcloud.com
Sep  4 13:20:00.412: INFO: Pod dns-default-x9v97 requesting resource cpu=65m on Node worker-1.ci-op-qfypnb1x-18a82.origin-ci-int-aws.dev.rhcloud.com
Sep  4 13:20:00.412: INFO: Pod image-registry-7cf7d78fd6-4mxr9 requesting resource cpu=100m on Node worker-0.ci-op-qfypnb1x-18a82.origin-ci-int-aws.dev.rhcloud.com
Sep  4 13:20:00.412: INFO: Pod node-ca-72247 requesting resource cpu=10m on Node worker-2.ci-op-qfypnb1x-18a82.origin-ci-int-aws.dev.rhcloud.com
Sep  4 13:20:00.412: INFO: Pod node-ca-8nmtz requesting resource cpu=10m on Node worker-1.ci-op-qfypnb1x-18a82.origin-ci-int-aws.dev.rhcloud.com
Sep  4 13:20:00.412: INFO: Pod node-ca-zr995 requesting resource cpu=10m on Node worker-0.ci-op-qfypnb1x-18a82.origin-ci-int-aws.dev.rhcloud.com
Sep  4 13:20:00.412: INFO: Pod router-default-556cc9b846-8zrxd requesting resource cpu=100m on Node worker-0.ci-op-qfypnb1x-18a82.origin-ci-int-aws.dev.rhcloud.com
Sep  4 13:20:00.412: INFO: Pod router-default-556cc9b846-x8j5j requesting resource cpu=100m on Node worker-2.ci-op-qfypnb1x-18a82.origin-ci-int-aws.dev.rhcloud.com
Sep  4 13:20:00.412: INFO: Pod migrator-865bcf9488-tkjff requesting resource cpu=100m on Node worker-0.ci-op-qfypnb1x-18a82.origin-ci-int-aws.dev.rhcloud.com
Sep  4 13:20:00.412: INFO: Pod machine-config-daemon-7gnl4 requesting resource cpu=40m on Node worker-2.ci-op-qfypnb1x-18a82.origin-ci-int-aws.dev.rhcloud.com
Sep  4 13:20:00.412: INFO: Pod machine-config-daemon-n895c requesting resource cpu=40m on Node worker-0.ci-op-qfypnb1x-18a82.origin-ci-int-aws.dev.rhcloud.com
Sep  4 13:20:00.412: INFO: Pod machine-config-daemon-wf995 requesting resource cpu=40m on Node worker-1.ci-op-qfypnb1x-18a82.origin-ci-int-aws.dev.rhcloud.com
Sep  4 13:20:00.412: INFO: Pod certified-operators-c4kzf requesting resource cpu=10m on Node worker-0.ci-op-qfypnb1x-18a82.origin-ci-int-aws.dev.rhcloud.com
Sep  4 13:20:00.412: INFO: Pod certified-operators-whjv4 requesting resource cpu=10m on Node worker-0.ci-op-qfypnb1x-18a82.origin-ci-int-aws.dev.rhcloud.com
Sep  4 13:20:00.412: INFO: Pod community-operators-88cwp requesting resource cpu=10m on Node worker-0.ci-op-qfypnb1x-18a82.origin-ci-int-aws.dev.rhcloud.com
Sep  4 13:20:00.412: INFO: Pod community-operators-qvc86 requesting resource cpu=10m on Node worker-0.ci-op-qfypnb1x-18a82.origin-ci-int-aws.dev.rhcloud.com
Sep  4 13:20:00.412: INFO: Pod redhat-marketplace-dxk6r requesting resource cpu=10m on Node worker-0.ci-op-qfypnb1x-18a82.origin-ci-int-aws.dev.rhcloud.com
Sep  4 13:20:00.412: INFO: Pod redhat-marketplace-fnsfv requesting resource cpu=10m on Node worker-0.ci-op-qfypnb1x-18a82.origin-ci-int-aws.dev.rhcloud.com
Sep  4 13:20:00.412: INFO: Pod redhat-operators-n9vwc requesting resource cpu=10m on Node worker-0.ci-op-qfypnb1x-18a82.origin-ci-int-aws.dev.rhcloud.com
Sep  4 13:20:00.412: INFO: Pod redhat-operators-xz9qd requesting resource cpu=10m on Node worker-0.ci-op-qfypnb1x-18a82.origin-ci-int-aws.dev.rhcloud.com
Sep  4 13:20:00.412: INFO: Pod alertmanager-main-0 requesting resource cpu=8m on Node worker-1.ci-op-qfypnb1x-18a82.origin-ci-int-aws.dev.rhcloud.com
Sep  4 13:20:00.412: INFO: Pod alertmanager-main-1 requesting resource cpu=8m on Node worker-0.ci-op-qfypnb1x-18a82.origin-ci-int-aws.dev.rhcloud.com
Sep  4 13:20:00.412: INFO: Pod alertmanager-main-2 requesting resource cpu=8m on Node worker-2.ci-op-qfypnb1x-18a82.origin-ci-int-aws.dev.rhcloud.com
Sep  4 13:20:00.412: INFO: Pod grafana-5dc687d5df-mltbk requesting resource cpu=5m on Node worker-2.ci-op-qfypnb1x-18a82.origin-ci-int-aws.dev.rhcloud.com
Sep  4 13:20:00.412: INFO: Pod kube-state-metrics-747cdddc64-frwfw requesting resource cpu=4m on Node worker-0.ci-op-qfypnb1x-18a82.origin-ci-int-aws.dev.rhcloud.com
Sep  4 13:20:00.412: INFO: Pod node-exporter-mjnv9 requesting resource cpu=9m on Node worker-1.ci-op-qfypnb1x-18a82.origin-ci-int-aws.dev.rhcloud.com
Sep  4 13:20:00.412: INFO: Pod node-exporter-rklqh requesting resource cpu=9m on Node worker-2.ci-op-qfypnb1x-18a82.origin-ci-int-aws.dev.rhcloud.com
Sep  4 13:20:00.412: INFO: Pod node-exporter-w8279 requesting resource cpu=9m on Node worker-0.ci-op-qfypnb1x-18a82.origin-ci-int-aws.dev.rhcloud.com
Sep  4 13:20:00.412: INFO: Pod openshift-state-metrics-59c8cd5968-5rdz7 requesting resource cpu=3m on Node worker-0.ci-op-qfypnb1x-18a82.origin-ci-int-aws.dev.rhcloud.com
Sep  4 13:20:00.412: INFO: Pod prometheus-adapter-6b7f847c77-pc945 requesting resource cpu=1m on Node worker-1.ci-op-qfypnb1x-18a82.origin-ci-int-aws.dev.rhcloud.com
Sep  4 13:20:00.412: INFO: Pod prometheus-adapter-6b7f847c77-xs5kb requesting resource cpu=1m on Node worker-0.ci-op-qfypnb1x-18a82.origin-ci-int-aws.dev.rhcloud.com
Sep  4 13:20:00.412: INFO: Pod prometheus-k8s-0 requesting resource cpu=76m on Node worker-2.ci-op-qfypnb1x-18a82.origin-ci-int-aws.dev.rhcloud.com
Sep  4 13:20:00.412: INFO: Pod prometheus-k8s-1 requesting resource cpu=76m on Node worker-1.ci-op-qfypnb1x-18a82.origin-ci-int-aws.dev.rhcloud.com
Sep  4 13:20:00.412: INFO: Pod telemeter-client-657bd8cbd6-7ll4v requesting resource cpu=3m on Node worker-0.ci-op-qfypnb1x-18a82.origin-ci-int-aws.dev.rhcloud.com
Sep  4 13:20:00.412: INFO: Pod thanos-querier-5c57566d79-c5n5d requesting resource cpu=9m on Node worker-1.ci-op-qfypnb1x-18a82.origin-ci-int-aws.dev.rhcloud.com
Sep  4 13:20:00.412: INFO: Pod thanos-querier-5c57566d79-zc2sf requesting resource cpu=9m on Node worker-2.ci-op-qfypnb1x-18a82.origin-ci-int-aws.dev.rhcloud.com
Sep  4 13:20:00.412: INFO: Pod multus-9p7zj requesting resource cpu=10m on Node worker-0.ci-op-qfypnb1x-18a82.origin-ci-int-aws.dev.rhcloud.com
Sep  4 13:20:00.412: INFO: Pod multus-b6z24 requesting resource cpu=10m on Node worker-2.ci-op-qfypnb1x-18a82.origin-ci-int-aws.dev.rhcloud.com
Sep  4 13:20:00.412: INFO: Pod multus-h7dtf requesting resource cpu=10m on Node worker-1.ci-op-qfypnb1x-18a82.origin-ci-int-aws.dev.rhcloud.com
Sep  4 13:20:00.412: INFO: Pod network-metrics-daemon-9nvjv requesting resource cpu=20m on Node worker-1.ci-op-qfypnb1x-18a82.origin-ci-int-aws.dev.rhcloud.com
Sep  4 13:20:00.412: INFO: Pod network-metrics-daemon-cmnw6 requesting resource cpu=20m on Node worker-2.ci-op-qfypnb1x-18a82.origin-ci-int-aws.dev.rhcloud.com
Sep  4 13:20:00.412: INFO: Pod network-metrics-daemon-k2xxs requesting resource cpu=20m on Node worker-0.ci-op-qfypnb1x-18a82.origin-ci-int-aws.dev.rhcloud.com
Sep  4 13:20:00.412: INFO: Pod ovs-k7n5z requesting resource cpu=100m on Node worker-0.ci-op-qfypnb1x-18a82.origin-ci-int-aws.dev.rhcloud.com
Sep  4 13:20:00.412: INFO: Pod ovs-shgxf requesting resource cpu=100m on Node worker-2.ci-op-qfypnb1x-18a82.origin-ci-int-aws.dev.rhcloud.com
Sep  4 13:20:00.412: INFO: Pod ovs-ssnc6 requesting resource cpu=100m on Node worker-1.ci-op-qfypnb1x-18a82.origin-ci-int-aws.dev.rhcloud.com
Sep  4 13:20:00.412: INFO: Pod sdn-sblm6 requesting resource cpu=110m on Node worker-2.ci-op-qfypnb1x-18a82.origin-ci-int-aws.dev.rhcloud.com
Sep  4 13:20:00.412: INFO: Pod sdn-wzgwj requesting resource cpu=110m on Node worker-0.ci-op-qfypnb1x-18a82.origin-ci-int-aws.dev.rhcloud.com
Sep  4 13:20:00.412: INFO: Pod sdn-xw75k requesting resource cpu=110m on Node worker-1.ci-op-qfypnb1x-18a82.origin-ci-int-aws.dev.rhcloud.com
```

where clearly `67e791a6-f170-4aff-b2b1-e42a0a6a7c3c-0`, `ead2872e-4ad3-4244-bb02-9f7ff0b6a428-0` and `ffecd964-0982-4541-ba35-bc53ef1bcd52-0` are taken into account when they should not.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
