### PR TITLE
Non-zero cfs quota period duration requires feature flag

### DIFF
--- a/pkg/kubelet/apis/config/validation/BUILD
+++ b/pkg/kubelet/apis/config/validation/BUILD
@@ -19,6 +19,7 @@ go_library(
         "//pkg/kubelet/apis/config:go_default_library",
         "//pkg/kubelet/cm/cpuset:go_default_library",
         "//pkg/kubelet/types:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/errors:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/validation:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",

--- a/pkg/kubelet/apis/config/validation/validation_test.go
+++ b/pkg/kubelet/apis/config/validation/validation_test.go
@@ -52,7 +52,10 @@ func TestValidateKubeletConfiguration(t *testing.T) {
 		RegistryPullQPS:             5,
 		HairpinMode:                 kubeletconfig.PromiscuousBridge,
 		NodeLeaseDurationSeconds:    1,
-		CPUCFSQuotaPeriod:           metav1.Duration{Duration: 100 * time.Millisecond},
+		CPUCFSQuotaPeriod:           metav1.Duration{Duration: 25 * time.Millisecond},
+		FeatureGates: map[string]bool{
+			"CustomCPUCFSQuotaPeriod": true,
+		},
 	}
 	if allErrors := ValidateKubeletConfiguration(successCase1); allErrors != nil {
 		t.Errorf("expect no errors, got %v", allErrors)
@@ -84,8 +87,11 @@ func TestValidateKubeletConfiguration(t *testing.T) {
 		RegistryPullQPS:             5,
 		HairpinMode:                 kubeletconfig.PromiscuousBridge,
 		NodeLeaseDurationSeconds:    1,
-		CPUCFSQuotaPeriod:           metav1.Duration{Duration: 100 * time.Millisecond},
+		CPUCFSQuotaPeriod:           metav1.Duration{Duration: 50 * time.Millisecond},
 		ReservedSystemCPUs:          "0-3",
+		FeatureGates: map[string]bool{
+			"CustomCPUCFSQuotaPeriod": true,
+		},
 	}
 	if allErrors := ValidateKubeletConfiguration(successCase2); allErrors != nil {
 		t.Errorf("expect no errors, got %v", allErrors)
@@ -115,7 +121,7 @@ func TestValidateKubeletConfiguration(t *testing.T) {
 		RegistryPullQPS:             -10,
 		HairpinMode:                 "foo",
 		NodeLeaseDurationSeconds:    -1,
-		CPUCFSQuotaPeriod:           metav1.Duration{Duration: 0},
+		CPUCFSQuotaPeriod:           metav1.Duration{Duration: 100 * time.Millisecond},
 	}
 	const numErrsErrorCase1 = 25
 	if allErrors := ValidateKubeletConfiguration(errorCase1); len(allErrors.(utilerrors.Aggregate).Errors()) != numErrsErrorCase1 {
@@ -148,8 +154,11 @@ func TestValidateKubeletConfiguration(t *testing.T) {
 		RegistryPullQPS:             5,
 		HairpinMode:                 kubeletconfig.PromiscuousBridge,
 		NodeLeaseDurationSeconds:    1,
-		CPUCFSQuotaPeriod:           metav1.Duration{Duration: 100 * time.Millisecond},
+		CPUCFSQuotaPeriod:           metav1.Duration{Duration: 50 * time.Millisecond},
 		ReservedSystemCPUs:          "0-3",
+		FeatureGates: map[string]bool{
+			"CustomCPUCFSQuotaPeriod": true,
+		},
 	}
 	const numErrsErrorCase2 = 1
 	if allErrors := ValidateKubeletConfiguration(errorCase2); len(allErrors.(utilerrors.Aggregate).Errors()) != numErrsErrorCase2 {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Validates that the feature flag is set if `CPUCFSQuotaPeriod` is specified in kubelet config.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #94686

**Special notes for your reviewer**:

`CPUCFSQuotaPeriod` is defaulted to 100ms. So if that's set, then we do not enforce this validation.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Require feature flag CustomCPUCFSQuotaPeriod if setting a non-default cpuCFSQuotaPeriod in kubelet config.
```