### PR TITLE
Wrap errors from VolumeBinding and DefaultBinder plugins

### DIFF
--- a/pkg/scheduler/framework/plugins/defaultbinder/default_binder.go
+++ b/pkg/scheduler/framework/plugins/defaultbinder/default_binder.go
@@ -55,7 +55,7 @@ func (b DefaultBinder) Bind(ctx context.Context, state *framework.CycleState, p 
 	}
 	err := b.handle.ClientSet().CoreV1().Pods(binding.Namespace).Bind(ctx, binding, metav1.CreateOptions{})
 	if err != nil {
-		return framework.NewStatus(framework.Error, err.Error())
+		return framework.AsStatus(err)
 	}
 	return nil
 }

--- a/pkg/scheduler/framework/plugins/volumebinding/volume_binding.go
+++ b/pkg/scheduler/framework/plugins/volumebinding/volume_binding.go
@@ -99,7 +99,7 @@ func (pl *VolumeBinding) PreFilter(ctx context.Context, state *framework.CycleSt
 	}
 	boundClaims, claimsToBind, unboundClaimsImmediate, err := pl.Binder.GetPodVolumes(pod)
 	if err != nil {
-		return framework.NewStatus(framework.Error, err.Error())
+		return framework.AsStatus(err)
 	}
 	if len(unboundClaimsImmediate) > 0 {
 		// Return UnschedulableAndUnresolvable error if immediate claims are
@@ -153,7 +153,7 @@ func (pl *VolumeBinding) Filter(ctx context.Context, cs *framework.CycleState, p
 
 	state, err := getStateData(cs)
 	if err != nil {
-		return framework.NewStatus(framework.Error, err.Error())
+		return framework.AsStatus(err)
 	}
 
 	if state.skip {
@@ -184,14 +184,14 @@ func (pl *VolumeBinding) Filter(ctx context.Context, cs *framework.CycleState, p
 func (pl *VolumeBinding) Reserve(ctx context.Context, cs *framework.CycleState, pod *v1.Pod, nodeName string) *framework.Status {
 	state, err := getStateData(cs)
 	if err != nil {
-		return framework.NewStatus(framework.Error, err.Error())
+		return framework.AsStatus(err)
 	}
 	// we don't need to hold the lock as only one node will be reserved for the given pod
 	podVolumes, ok := state.podVolumesByNode[nodeName]
 	if ok {
 		allBound, err := pl.Binder.AssumePodVolumes(pod, nodeName, podVolumes)
 		if err != nil {
-			return framework.NewStatus(framework.Error, err.Error())
+			return framework.AsStatus(err)
 		}
 		state.allBound = allBound
 	} else {
@@ -209,7 +209,7 @@ func (pl *VolumeBinding) Reserve(ctx context.Context, cs *framework.CycleState, 
 func (pl *VolumeBinding) PreBind(ctx context.Context, cs *framework.CycleState, pod *v1.Pod, nodeName string) *framework.Status {
 	s, err := getStateData(cs)
 	if err != nil {
-		return framework.NewStatus(framework.Error, err.Error())
+		return framework.AsStatus(err)
 	}
 	if s.allBound {
 		// no need to bind volumes
@@ -218,13 +218,13 @@ func (pl *VolumeBinding) PreBind(ctx context.Context, cs *framework.CycleState, 
 	// we don't need to hold the lock as only one node will be pre-bound for the given pod
 	podVolumes, ok := s.podVolumesByNode[nodeName]
 	if !ok {
-		return framework.NewStatus(framework.Error, fmt.Sprintf("no pod volumes found for node %q", nodeName))
+		return framework.AsStatus(fmt.Errorf("no pod volumes found for node %q", nodeName))
 	}
 	klog.V(5).Infof("Trying to bind volumes for pod \"%v/%v\"", pod.Namespace, pod.Name)
 	err = pl.Binder.BindPodVolumes(pod, podVolumes)
 	if err != nil {
 		klog.V(1).Infof("Failed to bind volumes for pod \"%v/%v\": %v", pod.Namespace, pod.Name, err)
-		return framework.NewStatus(framework.Error, err.Error())
+		return framework.AsStatus(err)
 	}
 	klog.V(5).Infof("Success binding volumes for pod \"%v/%v\"", pod.Namespace, pod.Name)
 	return nil

--- a/pkg/scheduler/framework/runtime/framework.go
+++ b/pkg/scheduler/framework/runtime/framework.go
@@ -743,9 +743,9 @@ func (f *frameworkImpl) RunBindPlugins(ctx context.Context, state *framework.Cyc
 			continue
 		}
 		if !status.IsSuccess() {
-			msg := fmt.Sprintf("plugin %q failed to bind pod \"%v/%v\": %v", bp.Name(), pod.Namespace, pod.Name, status.Message())
-			klog.Error(msg)
-			return framework.NewStatus(framework.Error, msg)
+			err := fmt.Errorf("plugin %q failed to bind pod \"%v/%v\": %w", bp.Name(), pod.Namespace, pod.Name, status.AsError())
+			klog.Error(err)
+			return framework.AsStatus(err)
 		}
 		return status
 	}

--- a/pkg/scheduler/framework/runtime/framework.go
+++ b/pkg/scheduler/framework/runtime/framework.go
@@ -710,9 +710,9 @@ func (f *frameworkImpl) RunPreBindPlugins(ctx context.Context, state *framework.
 	for _, pl := range f.preBindPlugins {
 		status = f.runPreBindPlugin(ctx, pl, state, pod, nodeName)
 		if !status.IsSuccess() {
-			msg := fmt.Sprintf("error while running %q prebind plugin for pod %q: %v", pl.Name(), pod.Name, status.Message())
-			klog.Error(msg)
-			return framework.NewStatus(framework.Error, msg)
+			err := fmt.Errorf("error while running %q prebind plugin for pod %q: %w", pl.Name(), pod.Name, status.AsError())
+			klog.Error(err)
+			return framework.AsStatus(err)
 		}
 	}
 	return nil

--- a/pkg/scheduler/framework/runtime/framework_test.go
+++ b/pkg/scheduler/framework/runtime/framework_test.go
@@ -18,6 +18,7 @@ package runtime
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"reflect"
 	"strings"
@@ -1138,6 +1139,7 @@ func TestPostFilterPlugins(t *testing.T) {
 }
 
 func TestPreBindPlugins(t *testing.T) {
+	injectedStatusErr := errors.New("injected status")
 	tests := []struct {
 		name       string
 		plugins    []*TestPlugin
@@ -1166,7 +1168,7 @@ func TestPreBindPlugins(t *testing.T) {
 					inj:  injectedResult{PreBindStatus: int(v1alpha1.Unschedulable)},
 				},
 			},
-			wantStatus: v1alpha1.NewStatus(v1alpha1.Error, `error while running "TestPlugin" prebind plugin for pod "": injected status`),
+			wantStatus: v1alpha1.AsStatus(fmt.Errorf(`error while running "TestPlugin" prebind plugin for pod "": %w`, injectedStatusErr)),
 		},
 		{
 			name: "ErrorPreBindPlugin",
@@ -1176,7 +1178,7 @@ func TestPreBindPlugins(t *testing.T) {
 					inj:  injectedResult{PreBindStatus: int(v1alpha1.Error)},
 				},
 			},
-			wantStatus: v1alpha1.NewStatus(v1alpha1.Error, `error while running "TestPlugin" prebind plugin for pod "": injected status`),
+			wantStatus: v1alpha1.AsStatus(fmt.Errorf(`error while running "TestPlugin" prebind plugin for pod "": %w`, injectedStatusErr)),
 		},
 		{
 			name: "UnschedulablePreBindPlugin",
@@ -1186,7 +1188,7 @@ func TestPreBindPlugins(t *testing.T) {
 					inj:  injectedResult{PreBindStatus: int(v1alpha1.UnschedulableAndUnresolvable)},
 				},
 			},
-			wantStatus: v1alpha1.NewStatus(v1alpha1.Error, `error while running "TestPlugin" prebind plugin for pod "": injected status`),
+			wantStatus: v1alpha1.AsStatus(fmt.Errorf(`error while running "TestPlugin" prebind plugin for pod "": %w`, injectedStatusErr)),
 		},
 		{
 			name: "SuccessErrorPreBindPlugins",
@@ -1200,7 +1202,7 @@ func TestPreBindPlugins(t *testing.T) {
 					inj:  injectedResult{PreBindStatus: int(v1alpha1.Error)},
 				},
 			},
-			wantStatus: v1alpha1.NewStatus(v1alpha1.Error, `error while running "TestPlugin 1" prebind plugin for pod "": injected status`),
+			wantStatus: v1alpha1.AsStatus(fmt.Errorf(`error while running "TestPlugin 1" prebind plugin for pod "": %w`, injectedStatusErr)),
 		},
 		{
 			name: "ErrorSuccessPreBindPlugin",
@@ -1214,7 +1216,7 @@ func TestPreBindPlugins(t *testing.T) {
 					inj:  injectedResult{PreBindStatus: int(v1alpha1.Success)},
 				},
 			},
-			wantStatus: v1alpha1.NewStatus(v1alpha1.Error, `error while running "TestPlugin" prebind plugin for pod "": injected status`),
+			wantStatus: v1alpha1.AsStatus(fmt.Errorf(`error while running "TestPlugin" prebind plugin for pod "": %w`, injectedStatusErr)),
 		},
 		{
 			name: "SuccessSuccessPreBindPlugin",
@@ -1242,7 +1244,7 @@ func TestPreBindPlugins(t *testing.T) {
 					inj:  injectedResult{PreBindStatus: int(v1alpha1.Error)},
 				},
 			},
-			wantStatus: v1alpha1.NewStatus(v1alpha1.Error, `error while running "TestPlugin" prebind plugin for pod "": injected status`),
+			wantStatus: v1alpha1.AsStatus(fmt.Errorf(`error while running "TestPlugin" prebind plugin for pod "": %w`, injectedStatusErr)),
 		},
 		{
 			name: "UnschedulableAndSuccessPreBindPlugin",
@@ -1256,7 +1258,7 @@ func TestPreBindPlugins(t *testing.T) {
 					inj:  injectedResult{PreBindStatus: int(v1alpha1.Success)},
 				},
 			},
-			wantStatus: v1alpha1.NewStatus(v1alpha1.Error, `error while running "TestPlugin" prebind plugin for pod "": injected status`),
+			wantStatus: v1alpha1.AsStatus(fmt.Errorf(`error while running "TestPlugin" prebind plugin for pod "": %w`, injectedStatusErr)),
 		},
 	}
 

--- a/pkg/scheduler/framework/v1alpha1/interface.go
+++ b/pkg/scheduler/framework/v1alpha1/interface.go
@@ -21,7 +21,6 @@ package v1alpha1
 import (
 	"context"
 	"errors"
-	"fmt"
 	"math"
 	"strings"
 	"time"
@@ -149,7 +148,7 @@ func (s *Status) AsError() error {
 	if s.err != nil {
 		return s.err
 	}
-	return fmt.Errorf("%s: %s", s.code.String(), s.Message())
+	return errors.New(s.Message())
 }
 
 // NewStatus makes a Status out of the given arguments and returns its pointer.

--- a/pkg/scheduler/framework/v1alpha1/interface.go
+++ b/pkg/scheduler/framework/v1alpha1/interface.go
@@ -21,6 +21,7 @@ package v1alpha1
 import (
 	"context"
 	"errors"
+	"fmt"
 	"math"
 	"strings"
 	"time"
@@ -92,12 +93,14 @@ const (
 	MaxTotalScore int64 = math.MaxInt64
 )
 
-// Status indicates the result of running a plugin. It consists of a code and a
-// message. When the status code is not `Success`, the reasons should explain why.
+// Status indicates the result of running a plugin. It consists of a code, a
+// message and (optionally) an error. When the status code is not `Success`,
+// the reasons should explain why.
 // NOTE: A nil Status is also considered as Success.
 type Status struct {
 	code    Code
 	reasons []string
+	err     error
 }
 
 // Code returns code of the Status.
@@ -143,14 +146,30 @@ func (s *Status) AsError() error {
 	if s.IsSuccess() {
 		return nil
 	}
-	return errors.New(s.Message())
+	if s.err != nil {
+		return s.err
+	}
+	return fmt.Errorf("%s: %s", s.code.String(), s.Message())
 }
 
 // NewStatus makes a Status out of the given arguments and returns its pointer.
 func NewStatus(code Code, reasons ...string) *Status {
-	return &Status{
+	s := &Status{
 		code:    code,
 		reasons: reasons,
+	}
+	if code == Error {
+		s.err = errors.New(s.Message())
+	}
+	return s
+}
+
+// AsStatus wraps an error in a Status.
+func AsStatus(err error) *Status {
+	return &Status{
+		code:    Error,
+		reasons: []string{err.Error()},
+		err:     err,
 	}
 }
 
@@ -166,10 +185,10 @@ func (p PluginToStatus) Merge() *Status {
 	}
 
 	finalStatus := NewStatus(Success)
-	var hasError, hasUnschedulableAndUnresolvable, hasUnschedulable bool
+	var hasUnschedulableAndUnresolvable, hasUnschedulable bool
 	for _, s := range p {
 		if s.Code() == Error {
-			hasError = true
+			finalStatus.err = s.AsError()
 		} else if s.Code() == UnschedulableAndUnresolvable {
 			hasUnschedulableAndUnresolvable = true
 		} else if s.Code() == Unschedulable {
@@ -181,7 +200,7 @@ func (p PluginToStatus) Merge() *Status {
 		}
 	}
 
-	if hasError {
+	if finalStatus.err != nil {
 		finalStatus.code = Error
 	} else if hasUnschedulableAndUnresolvable {
 		finalStatus.code = UnschedulableAndUnresolvable

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -211,6 +211,7 @@ func TestSchedulerScheduleOne(t *testing.T) {
 	eventBroadcaster := events.NewBroadcaster(&events.EventSinkImpl{Interface: client.EventsV1()})
 	errS := errors.New("scheduler")
 	errB := errors.New("binder")
+	preBindErr := errors.New("on PreBind")
 
 	table := []struct {
 		name                string
@@ -256,12 +257,12 @@ func TestSchedulerScheduleOne(t *testing.T) {
 			sendPod: podWithID("foo", ""),
 			algo:    mockScheduler{core.ScheduleResult{SuggestedHost: testNode.Name, EvaluatedNodes: 1, FeasibleNodes: 1}, nil},
 			registerPluginFuncs: []st.RegisterPluginFunc{
-				st.RegisterPreBindPlugin("FakePreBind", st.NewFakePreBindPlugin(framework.NewStatus(framework.Error, "prebind error"))),
+				st.RegisterPreBindPlugin("FakePreBind", st.NewFakePreBindPlugin(framework.AsStatus(preBindErr))),
 			},
 			expectErrorPod:   podWithID("foo", testNode.Name),
 			expectForgetPod:  podWithID("foo", testNode.Name),
 			expectAssumedPod: podWithID("foo", testNode.Name),
-			expectError:      errors.New(`error while running "FakePreBind" prebind plugin for pod "foo": prebind error`),
+			expectError:      fmt.Errorf(`error while running "FakePreBind" prebind plugin for pod "foo": %w`, preBindErr),
 			eventReason:      "FailedScheduling",
 		},
 		{


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

/kind regression

**What this PR does / why we need it**:

When using framework's Status, we recreate errors from messages. This loses error information necessary for error handling. In particular #94437 raised the concern that we are missing deleted nodes errors which were used to for a node deletion.

This is an outcome of the migration to scheduler framework.

In this patch, we fix the PreBind and Bind framework runtime to wrap the errors in a Status. We fix the DefaultBinder and VolumeBinding plugins to wrap API errors.

**Which issue(s) this PR fixes**:

Ref #94437

**Special notes for your reviewer**:

This is a minimal patch that can be potentially patched to 1.19 and 1.18. In particular, there are several unwrapped errors (for extension points that don't access the API) that are left because they require significantly more refactoring.

They will be fixed in follow ups.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```