### PR TITLE
Run unit tests 2 instead of 3 times via bazel

### DIFF
--- a/build/root/.bazelrc
+++ b/build/root/.bazelrc
@@ -28,7 +28,7 @@ test:unit --features=race
 
 test:unit --build_tests_only
 test:unit --test_tag_filters=-e2e,-integration
-test:unit --runs_per_test=3
+test:unit --runs_per_test=2
 
 test:integration --local_test_jobs 4
 test:integration --test_tag_filters=integration


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup
/kind flake

**What this PR does / why we need it**:

Followup to https://github.com/kubernetes/kubernetes/pull/93605 which changed from retryng 3 times to avoid flakes, to requiring a pass 3 times.

In order to migrate the pull-kubernetes-bazel-test job to a communty owned cluster with dedicated resources, we need to stop using RBE.  When we did so, we started seeing many more flakes. (ref: https://github.com/kubernetes/test-infra/issues/19070#issuecomment-690348770)

RBE fans out to a large pool of compute, whereas now we're running in a single pod on a single node.

It may be that using 2 runs instead of 3 will relieve some resource contention, giving us an appropriate compromise between not ignoring flakes but not leaning all the way into causing them. (ref: https://github.com/kubernetes/test-infra/issues/19070#issuecomment-690354428)

**Which issue(s) this PR fixes**:
n/a

**Special notes for your reviewer**:

/hold
I'd like to see if the behavior of pull-kubernetes-bazel-test improves now that we've given it 7 CPUs instead of 4. I'm teeing this up as a further mitigation if we decide that's not enough, or if 7 CPUs is excessive resource consumption.

```release-note
NONE
```

/cc @liggitt @BenTheElder