### PR TITLE
kubeadm: Avoid logging token in RunDeleteTokens

### DIFF
--- a/cmd/kubeadm/app/cmd/token.go
+++ b/cmd/kubeadm/app/cmd/token.go
@@ -420,13 +420,13 @@ func RunDeleteTokens(out io.Writer, client clientset.Interface, tokenIDsOrTokens
 	for _, tokenIDOrToken := range tokenIDsOrTokens {
 		// Assume this is a token id and try to parse it
 		tokenID := tokenIDOrToken
-		klog.V(1).Infof("[token] parsing token %q", tokenIDOrToken)
+		klog.V(1).Info("[token] parsing token")
 		if !bootstraputil.IsValidBootstrapTokenID(tokenIDOrToken) {
 			// Okay, the full token with both id and secret was probably passed. Parse it and extract the ID only
 			bts, err := kubeadmapiv1beta2.NewBootstrapTokenString(tokenIDOrToken)
 			if err != nil {
-				return errors.Errorf("given token %q didn't match pattern %q or %q",
-					tokenIDOrToken, bootstrapapi.BootstrapTokenIDPattern, bootstrapapi.BootstrapTokenIDPattern)
+				return errors.Errorf("given token didn't match pattern %q or %q",
+					bootstrapapi.BootstrapTokenIDPattern, bootstrapapi.BootstrapTokenIDPattern)
 			}
 			tokenID = bts.ID
 		}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This PR fixes a (small) vulnerability in `kubeadm`. I have reported the vulnerability to [HackerOne](https://hackerone.com/kubernetes) and they have informed me that based on the high attack complexity and low severity, they think this can be reported and fixed publicly.  Details are in this issue: https://github.com/kubernetes/kubeadm/issues/2287

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
