### PR TITLE
kubectl: Fix TCP and UDP port forward

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/portforward/portforward_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/portforward/portforward_test.go
@@ -880,7 +880,7 @@ func TestCheckUDPPort(t *testing.T) {
 			expectError: true,
 		},
 		{
-			name: "Pod has ports with both TCP and UDP protocol",
+			name: "Pod has ports with both TCP and UDP protocol (UDP first)",
 			pod: &corev1.Pod{
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{
@@ -888,6 +888,22 @@ func TestCheckUDPPort(t *testing.T) {
 							Ports: []corev1.ContainerPort{
 								{Protocol: corev1.ProtocolUDP, ContainerPort: 53},
 								{Protocol: corev1.ProtocolTCP, ContainerPort: 53},
+							},
+						},
+					},
+				},
+			},
+			ports: []string{":53"},
+		},
+		{
+			name: "Pod has ports with both TCP and UDP protocol (TCP first)",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Ports: []corev1.ContainerPort{
+								{Protocol: corev1.ProtocolTCP, ContainerPort: 53},
+								{Protocol: corev1.ProtocolUDP, ContainerPort: 53},
 							},
 						},
 					},
@@ -921,12 +937,24 @@ func TestCheckUDPPort(t *testing.T) {
 			expectError: true,
 		},
 		{
-			name: "Service has ports with both TCP and UDP protocol",
+			name: "Service has ports with both TCP and UDP protocol (UDP first)",
 			service: &corev1.Service{
 				Spec: corev1.ServiceSpec{
 					Ports: []corev1.ServicePort{
 						{Protocol: corev1.ProtocolUDP, Port: 53},
 						{Protocol: corev1.ProtocolTCP, Port: 53},
+					},
+				},
+			},
+			ports: []string{"53"},
+		},
+		{
+			name: "Service has ports with both TCP and UDP protocol (TCP first)",
+			service: &corev1.Service{
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{Protocol: corev1.ProtocolTCP, Port: 53},
+						{Protocol: corev1.ProtocolUDP, Port: 53},
 					},
 				},
 			},


### PR DESCRIPTION
/kind bug
/kind regression

**What this PR does / why we need it**:
Fix a regression in kubectl portforward.

The regression is introduced in 1.19.0-0. Please see https://github.com/kubernetes/kubectl/issues/929 for more details

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubectl/issues/929

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixed a regression in 1.19 that sometimes prevented `kubectl portforward` to work when TCP and UDP services were configured on the same port
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
