### PR TITLE
Ensuring EndpointSlices are recreated after Service recreation

### DIFF
--- a/pkg/controller/endpointslice/utils.go
+++ b/pkg/controller/endpointslice/utils.go
@@ -201,6 +201,17 @@ func objectRefPtrChanged(ref1, ref2 *corev1.ObjectReference) bool {
 	return false
 }
 
+// ownedBy returns true if the provided EndpointSlice is owned by the provided
+// Service.
+func ownedBy(endpointSlice *discovery.EndpointSlice, svc *corev1.Service) bool {
+	for _, o := range endpointSlice.OwnerReferences {
+		if o.UID == svc.UID && o.Kind == "Service" && o.APIVersion == "v1" {
+			return true
+		}
+	}
+	return false
+}
+
 // getSliceToFill will return the EndpointSlice that will be closest to full
 // when numEndpoints are added. If no EndpointSlice can be found, a nil pointer
 // will be returned.


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This fixes a bug that occurred when a Service was rapidly recreated. This relied on an unfortunate series of events:

1. When the Service is deleted, the EndpointSlice controller removes it from the EndpointSliceTracker along with any associated EndpointSlices.

2. When the Service is recreated, the EndpointSlice controller sees that there are still appropriate EndpointSlices for the Service and does nothing. (They have not yet been garbage collected).

3. When the EndpointSlice is deleted, the EndpointSlice controller checks with the EndpointSliceTracker to see if it thinks we should have this EndpointSlice (it does not because of step 1). This check was intended to ensure we wouldn't requeue a Service every time we delete an EndpointSlice for it.

This adds a check in reconciler to ensure that EndpointSlices it is working with are owned by a Service with a matching UID. If not, it will mark those EndpointSlices for deletion (assuming they're about to be garbage collected anyway) and create new EndpointSlices.

**Which issue(s) this PR fixes**:
Fixes #94720

**Does this PR introduce a user-facing change?**:
```release-note
Fixes a regression in 1.19 where EndpointSlices would not be recreated after rapid Service recreation.
```

/sig network
/priority critical-urgent
/cc @freehan @liggitt @qinqon