### PR TITLE
test: ensure WaitForCacheSync is called after starting sharedInformerFacotry

### DIFF
--- a/pkg/controller/deployment/sync_test.go
+++ b/pkg/controller/deployment/sync_test.go
@@ -428,6 +428,7 @@ func TestDeploymentController_cleanupDeployment(t *testing.T) {
 		stopCh := make(chan struct{})
 		defer close(stopCh)
 		informers.Start(stopCh)
+		informers.WaitForCacheSync(stopCh)
 
 		t.Logf(" &test.revisionHistoryLimit: %d", test.revisionHistoryLimit)
 		d := newDeployment("foo", 1, &test.revisionHistoryLimit, nil, nil, map[string]string{"foo": "bar"})

--- a/pkg/controller/replicaset/replica_set_test.go
+++ b/pkg/controller/replicaset/replica_set_test.go
@@ -31,7 +31,7 @@ import (
 	"time"
 
 	apps "k8s.io/api/apps/v1"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -599,6 +599,7 @@ func TestWatchControllers(t *testing.T) {
 		BurstReplicas,
 	)
 	informers.Start(stopCh)
+	informers.WaitForCacheSync(stopCh)
 
 	var testRSSpec apps.ReplicaSet
 	received := make(chan string)
@@ -1151,6 +1152,7 @@ func TestExpectationsOnRecreate(t *testing.T) {
 		100,
 	)
 	f.Start(stopCh)
+	f.WaitForCacheSync(stopCh)
 	fakePodControl := controller.FakePodControl{}
 	manager.podControl = &fakePodControl
 

--- a/pkg/controller/volume/persistentvolume/pv_controller_test.go
+++ b/pkg/controller/volume/persistentvolume/pv_controller_test.go
@@ -322,13 +322,12 @@ func TestControllerSync(t *testing.T) {
 		// Start the controller
 		stopCh := make(chan struct{})
 		informers.Start(stopCh)
+		informers.WaitForCacheSync(stopCh)
 		go ctrl.Run(stopCh)
 
 		// Wait for the controller to pass initial sync and fill its caches.
 		err = wait.Poll(10*time.Millisecond, wait.ForeverTestTimeout, func() (bool, error) {
-			return ctrl.volumeListerSynced() &&
-				ctrl.claimListerSynced() &&
-				len(ctrl.claims.ListKeys()) >= len(test.initialClaims) &&
+			return len(ctrl.claims.ListKeys()) >= len(test.initialClaims) &&
 				len(ctrl.volumes.store.ListKeys()) >= len(test.initialVolumes), nil
 		})
 		if err != nil {

--- a/pkg/volume/csi/csi_test.go
+++ b/pkg/volume/csi/csi_test.go
@@ -255,6 +255,7 @@ func TestCSI_VolumeAll(t *testing.T) {
 				csiDriverInformer.Informer().GetStore().Add(driverInfo)
 			}
 			factory.Start(wait.NeverStop)
+			factory.WaitForCacheSync(wait.NeverStop)
 
 			host := volumetest.NewFakeVolumeHostWithCSINodeName(t,
 				tmpDir,


### PR DESCRIPTION
Signed-off-by: knight42 <anonymousknight96@gmail.com>

**What type of PR is this?**

/kind flake

**What this PR does / why we need it**:

https://prow.k8s.io/view/gcs/kubernetes-jenkins/pr-logs/directory/pull-kubernetes-bazel-test/1304635954161520642
```
=== RUN   TestExpectationsOnRecreate
    replica_set_test.go:1172: initial RS didn't result in new item in the queue: timed out waiting for the condition
--- FAIL: TestExpectationsOnRecreate (30.01s)
```

We need to call `WaitForCacheSync` after starting shared informer, otherwise we might miss events.

**Which issue(s) this PR fixes**:

Part of #94528

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
