### PR TITLE
Fix linting failures in pkg/apis/rbac/validation

### DIFF
--- a/hack/.golint_failures
+++ b/hack/.golint_failures
@@ -39,7 +39,6 @@ pkg/apis/policy/v1beta1
 pkg/apis/rbac/v1
 pkg/apis/rbac/v1alpha1
 pkg/apis/rbac/v1beta1
-pkg/apis/rbac/validation
 pkg/apis/scheduling/v1
 pkg/apis/scheduling/v1alpha1
 pkg/apis/scheduling/v1beta1

--- a/pkg/apis/rbac/validation/validation.go
+++ b/pkg/apis/rbac/validation/validation.go
@@ -33,6 +33,7 @@ func ValidateRBACName(name string, prefix bool) []string {
 	return path.IsValidPathSegmentName(name)
 }
 
+// ValidateRole validates a Role object.
 func ValidateRole(role *rbac.Role) field.ErrorList {
 	allErrs := field.ErrorList{}
 	allErrs = append(allErrs, validation.ValidateObjectMeta(&role.ObjectMeta, true, ValidateRBACName, field.NewPath("metadata"))...)
@@ -48,6 +49,7 @@ func ValidateRole(role *rbac.Role) field.ErrorList {
 	return nil
 }
 
+// ValidateRoleUpdate validates a Role object update.
 func ValidateRoleUpdate(role *rbac.Role, oldRole *rbac.Role) field.ErrorList {
 	allErrs := ValidateRole(role)
 	allErrs = append(allErrs, validation.ValidateObjectMetaUpdate(&role.ObjectMeta, &oldRole.ObjectMeta, field.NewPath("metadata"))...)
@@ -55,6 +57,7 @@ func ValidateRoleUpdate(role *rbac.Role, oldRole *rbac.Role) field.ErrorList {
 	return allErrs
 }
 
+// ValidateClusterRole validates a new ClusterRole object.
 func ValidateClusterRole(role *rbac.ClusterRole) field.ErrorList {
 	allErrs := field.ErrorList{}
 	allErrs = append(allErrs, validation.ValidateObjectMeta(&role.ObjectMeta, false, ValidateRBACName, field.NewPath("metadata"))...)
@@ -86,6 +89,7 @@ func ValidateClusterRole(role *rbac.ClusterRole) field.ErrorList {
 	return nil
 }
 
+// ValidateClusterRoleUpdate validates a ClusterRole object update.
 func ValidateClusterRoleUpdate(role *rbac.ClusterRole, oldRole *rbac.ClusterRole) field.ErrorList {
 	allErrs := ValidateClusterRole(role)
 	allErrs = append(allErrs, validation.ValidateObjectMetaUpdate(&role.ObjectMeta, &oldRole.ObjectMeta, field.NewPath("metadata"))...)
@@ -119,6 +123,7 @@ func ValidatePolicyRule(rule rbac.PolicyRule, isNamespaced bool, fldPath *field.
 	return allErrs
 }
 
+// ValidateRoleBinding validates a new RoleBinding object.
 func ValidateRoleBinding(roleBinding *rbac.RoleBinding) field.ErrorList {
 	allErrs := field.ErrorList{}
 	allErrs = append(allErrs, validation.ValidateObjectMeta(&roleBinding.ObjectMeta, true, ValidateRBACName, field.NewPath("metadata"))...)
@@ -152,6 +157,7 @@ func ValidateRoleBinding(roleBinding *rbac.RoleBinding) field.ErrorList {
 	return allErrs
 }
 
+// ValidateRoleBindingUpdate validates a RoleBinding object update.
 func ValidateRoleBindingUpdate(roleBinding *rbac.RoleBinding, oldRoleBinding *rbac.RoleBinding) field.ErrorList {
 	allErrs := ValidateRoleBinding(roleBinding)
 	allErrs = append(allErrs, validation.ValidateObjectMetaUpdate(&roleBinding.ObjectMeta, &oldRoleBinding.ObjectMeta, field.NewPath("metadata"))...)
@@ -163,6 +169,7 @@ func ValidateRoleBindingUpdate(roleBinding *rbac.RoleBinding, oldRoleBinding *rb
 	return allErrs
 }
 
+// ValidateClusterRoleBinding validates a new ClusterRoleBinding object.
 func ValidateClusterRoleBinding(roleBinding *rbac.ClusterRoleBinding) field.ErrorList {
 	allErrs := field.ErrorList{}
 	allErrs = append(allErrs, validation.ValidateObjectMeta(&roleBinding.ObjectMeta, false, ValidateRBACName, field.NewPath("metadata"))...)
@@ -196,6 +203,7 @@ func ValidateClusterRoleBinding(roleBinding *rbac.ClusterRoleBinding) field.Erro
 	return allErrs
 }
 
+// ValidateClusterRoleBindingUpdate validates a ClusterRoleBinding object update.
 func ValidateClusterRoleBindingUpdate(roleBinding *rbac.ClusterRoleBinding, oldRoleBinding *rbac.ClusterRoleBinding) field.ErrorList {
 	allErrs := ValidateClusterRoleBinding(roleBinding)
 	allErrs = append(allErrs, validation.ValidateObjectMetaUpdate(&roleBinding.ObjectMeta, &oldRoleBinding.ObjectMeta, field.NewPath("metadata"))...)


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:
Fixing linting issues in pkg/apis/rbac/validation.

**Which issue(s) this PR fixes**:
Ref #68026

**Special notes for your reviewer**:
I'm not sure whether these comments are essential for such self-describing function names, but since linter fails it's better to have something written than not.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
