### PR TITLE
Support status.podIPs field selector

### DIFF
--- a/pkg/registry/core/pod/strategy.go
+++ b/pkg/registry/core/pod/strategy.go
@@ -240,18 +240,22 @@ func ToSelectableFields(pod *api.Pod) fields.Set {
 	// amount of allocations needed to create the fields.Set. If you add any
 	// field here or the number of object-meta related fields changes, this should
 	// be adjusted.
-	podSpecificFieldsSet := make(fields.Set, 9)
+	podSpecificFieldsSet := make(fields.Set, 10)
 	podSpecificFieldsSet["spec.nodeName"] = pod.Spec.NodeName
 	podSpecificFieldsSet["spec.restartPolicy"] = string(pod.Spec.RestartPolicy)
 	podSpecificFieldsSet["spec.schedulerName"] = string(pod.Spec.SchedulerName)
 	podSpecificFieldsSet["spec.serviceAccountName"] = string(pod.Spec.ServiceAccountName)
 	podSpecificFieldsSet["status.phase"] = string(pod.Status.Phase)
-	// TODO: add podIPs as a downward API value(s) with proper format
 	podIP := ""
+	var podIPs []string
 	if len(pod.Status.PodIPs) > 0 {
 		podIP = string(pod.Status.PodIPs[0].IP)
+		for _, v := range pod.Status.PodIPs {
+			podIPs = append(podIPs, v.IP)
+		}
 	}
 	podSpecificFieldsSet["status.podIP"] = podIP
+	podSpecificFieldsSet["status.podIPs"] = strings.Join(podIPs, ",")
 	podSpecificFieldsSet["status.nominatedNodeName"] = string(pod.Status.NominatedNodeName)
 	return generic.AddObjectMetaFieldsSet(podSpecificFieldsSet, &pod.ObjectMeta, true)
 }

--- a/pkg/registry/core/pod/strategy_test.go
+++ b/pkg/registry/core/pod/strategy_test.go
@@ -146,6 +146,30 @@ func TestMatchPod(t *testing.T) {
 		},
 		{
 			in: &api.Pod{
+				Status: api.PodStatus{
+					PodIPs: []api.PodIP{
+						{IP: "1.2.3.4"},
+						{IP: "fd00::6"},
+					},
+				},
+			},
+			fieldSelector: fields.ParseSelectorOrDie("status.podIPs=1.2.3.4\\,fd00::6"),
+			expectMatch:   true,
+		},
+		{
+			in: &api.Pod{
+				Status: api.PodStatus{
+					PodIPs: []api.PodIP{
+						{IP: "1.2.3.4"},
+						{IP: "fd00::6"},
+					},
+				},
+			},
+			fieldSelector: fields.ParseSelectorOrDie("status.podIPs=1.2.3.4"),
+			expectMatch:   false,
+		},
+		{
+			in: &api.Pod{
 				Status: api.PodStatus{NominatedNodeName: "node1"},
 			},
 			fieldSelector: fields.ParseSelectorOrDie("status.nominatedNodeName=node1"),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature
/kind bug

**What this PR does / why we need it**:
This actually comes from another [issue](https://github.com/kubernetes/kubernetes/issues/94719).
But when I'm tesing `kubectl get pods --field-selector 'status.podIPs'` in my cluster with pod:
```
  podIP: 172.29.174.178
  podIPs:
  - ip: 172.29.174.178
  - ip: fdff:ffff:ffff:ffff::24d0:aea9
``` 
I'll get :
```
[root@10-6-150-83 ~]# kubectl get pods --field-selector 'status.podIPs=172.29.174.178\,fdff:ffff:ffff:ffff::24d0:aea9' -n default
No resources found in default namespace.
```
Then I realise there's a `TODO` which block this field selector, so after this PR:
```
[root@10-6-150-83 ~]# kubectl get pods --field-selector 'status.podIPs=172.29.174.178\,fdff:ffff:ffff:ffff::24d0:aea9' -n default
NAME                        READY   STATUS    RESTARTS   AGE
nginx-6d6dfbb6ff-hs6zh   1/1     Running   1          28d
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
/assign @liggitt 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Support status.podIPs field selector
```

