### PR TITLE
remove wrong example for kubectl create deploy

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_deployment.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_deployment.go
@@ -46,9 +46,6 @@ var (
 	# Create a deployment named my-dep that runs the busybox image.
 	kubectl create deployment my-dep --image=busybox
 
-	# Create a deployment with command
-	kubectl create deployment my-dep --image=busybox -- date
-
 	# Create a deployment named my-dep that runs the nginx image with 3 replicas.
 	kubectl create deployment my-dep --image=nginx --replicas=3
 
@@ -93,7 +90,7 @@ func NewCreateCreateDeploymentOptions(ioStreams genericclioptions.IOStreams) *Cr
 func NewCmdCreateDeployment(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *cobra.Command {
 	o := NewCreateCreateDeploymentOptions(ioStreams)
 	cmd := &cobra.Command{
-		Use:                   "deployment NAME --image=image -- [COMMAND] [args...]",
+		Use:                   "deployment NAME --image=image",
 		DisableFlagsInUseLine: true,
 		Aliases:               []string{"deploy"},
 		Short:                 deploymentLong,


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
/kind documentation


**What this PR does / why we need it**:
```
	kubectl create deployment my-dep --image=busybox -- date
```
is not a good example.  args "date" will not take effect.

**Which issue(s) this PR fixes**:
Fixes #94755

**Special notes for your reviewer**:
None

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
