### PR TITLE
Increasing acceptable timeout for EndpointSlice garbage collection

### DIFF
--- a/test/e2e/network/endpointslice.go
+++ b/test/e2e/network/endpointslice.go
@@ -144,8 +144,11 @@ var _ = SIGDescribe("EndpointSlice", func() {
 			framework.Failf("Endpoints resource not deleted after Service %s/%s was deleted: %s", svc.Namespace, svc.Name, err)
 		}
 
-		// Expect EndpointSlice resource to be deleted when Service is.
-		if err := wait.PollImmediate(2*time.Second, wait.ForeverTestTimeout, func() (bool, error) {
+		// Expect EndpointSlice resource to be deleted when Service is. Wait for
+		// up to 90 seconds since garbage collector only polls every 30 seconds
+		// and may need to retry informer resync at some point during an e2e
+		// run.
+		if err := wait.PollImmediate(2*time.Second, 90*time.Second, func() (bool, error) {
 			endpointSliceList, err := cs.DiscoveryV1beta1().EndpointSlices(svc.Namespace).List(context.TODO(), metav1.ListOptions{
 				LabelSelector: "kubernetes.io/service-name=" + svc.Name,
 			})


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
/kind flake

**What this PR does / why we need it**:
This should help minimize flakiness for these tests. A more reliable solution here would likely involve updating the EndpointSlice controller to also clean up EndpointSlices. That seems like it should not be necessary though.

**Which issue(s) this PR fixes**:
This should help with https://github.com/kubernetes/kubernetes/issues/92776

**Special notes for your reviewer**:
I'd missed following up on this earlier and noticed this test was still flakier than expected. https://storage.googleapis.com/k8s-gubernator/triage/index.html?text=EndpointSlice%20resource%20not%20deleted%20after%20Service

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/sig network
/priority important-soon
/cc @hasheddan 
/assign @liggitt 