### PR TITLE
Write Pod- & ServiceProxy Test - +12 endpoint coverage

### DIFF
--- a/test/e2e/network/proxy.go
+++ b/test/e2e/network/proxy.go
@@ -367,8 +367,117 @@ var _ = common.SIGDescribe("Proxy", func() {
 				framework.ExpectNoError(err, "Service didn't start within time out period. %v", pollErr)
 			}
 		})
+
+		ginkgo.It("A set of valid responses are returned for both pod and service Proxy", func() {
+
+			ns := f.Namespace.Name
+			msg := "foo"
+			testSvcName := "e2e-proxy-test-service"
+			testSvcLabels := map[string]string{"e2e-test": "proxy-endpoints"}
+
+			framework.Logf("Creating pod...")
+			_, err := f.ClientSet.CoreV1().Pods(ns).Create(context.TODO(), &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "agnhost",
+					Labels: map[string]string{
+						"e2e-test": "proxy-endpoints"},
+				},
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{{
+						Image:   imageutils.GetE2EImage(imageutils.Agnhost),
+						Name:    "agnhost",
+						Command: []string{"/agnhost", "porter", "--json-response"},
+						Env: []v1.EnvVar{{
+							Name:  "SERVE_PORT_80",
+							Value: msg,
+						}},
+					}},
+					RestartPolicy: v1.RestartPolicyNever,
+				}}, metav1.CreateOptions{})
+			framework.ExpectNoError(err, "failed to create pod")
+
+			err = wait.PollImmediate(podRetryPeriod, podRetryTimeout, checkPodStatus(f, "e2e-test=proxy-endpoints"))
+			framework.ExpectNoError(err, "Pod didn't start within time out period")
+
+			framework.Logf("Creating service...")
+			_, err = f.ClientSet.CoreV1().Services(ns).Create(context.TODO(), &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testSvcName,
+					Namespace: ns,
+					Labels:    testSvcLabels,
+				},
+				Spec: v1.ServiceSpec{
+					Ports: []v1.ServicePort{{
+						Port:       80,
+						TargetPort: intstr.FromInt(80),
+						Protocol:   v1.ProtocolTCP,
+					}},
+					Selector: map[string]string{
+						"e2e-test": "proxy-endpoints",
+					},
+				}}, metav1.CreateOptions{})
+			framework.ExpectNoError(err, "Failed to create the service")
+
+			transportCfg, err := f.ClientConfig().TransportConfig()
+			framework.ExpectNoError(err, "Error creating transportCfg")
+			restTransport, err := transport.New(transportCfg)
+			framework.ExpectNoError(err, "Error creating restTransport")
+
+			client := &http.Client{
+				CheckRedirect: func(req *http.Request, via []*http.Request) error {
+					return http.ErrUseLastResponse
+				},
+				Transport: restTransport,
+			}
+
+			// All methods for Pod Proxy return 200
+			// The response body returns 'foo' with the received http method
+			httpVerbs := []string{"DELETE", "OPTIONS", "PATCH", "POST", "PUT"}
+			for _, httpVerb := range httpVerbs {
+
+				urlString := f.ClientConfig().Host + "/api/v1/namespaces/" + ns + "/pods/agnhost/proxy?method=" + httpVerb
+				framework.Logf("Starting http.Client for %s", urlString)
+
+				pollErr := wait.PollImmediate(requestRetryPeriod, requestRetryTimeout, validateProxyVerbRequest(client, urlString, httpVerb, msg))
+				framework.ExpectNoError(pollErr, "Pod didn't start within time out period. %v", pollErr)
+			}
+
+			// All methods for Service Proxy return 200
+			// The response body returns 'foo' with the received http method
+			for _, httpVerb := range httpVerbs {
+
+				urlString := f.ClientConfig().Host + "/api/v1/namespaces/" + ns + "/services/" + testSvcName + "/proxy?method=" + httpVerb
+				framework.Logf("Starting http.Client for %s", urlString)
+
+				pollErr := wait.PollImmediate(requestRetryPeriod, requestRetryTimeout, validateProxyVerbRequest(client, urlString, httpVerb, msg))
+				framework.ExpectNoError(pollErr, "Service didn't start within time out period. %v", pollErr)
+			}
+
+			// Test that each method returns 301 for both pod and service endpoints
+			redirectVerbs := []string{"GET", "HEAD"}
+			for _, redirectVerb := range redirectVerbs {
+				urlString := f.ClientConfig().Host + "/api/v1/namespaces/" + ns + "/pods/agnhost/proxy?method=" + redirectVerb
+				validateRedirectRequest(client, redirectVerb, urlString)
+
+				urlString = f.ClientConfig().Host + "/api/v1/namespaces/" + ns + "/services/" + testSvcName + "/proxy?method=" + redirectVerb
+				validateRedirectRequest(client, redirectVerb, urlString)
+			}
+		})
 	})
 })
+
+func validateRedirectRequest(client *http.Client, redirectVerb string, urlString string) {
+	framework.Logf("Starting http.Client for %s", urlString)
+	request, err := http.NewRequest(redirectVerb, urlString, nil)
+	framework.ExpectNoError(err, "processing request")
+
+	resp, err := client.Do(request)
+	framework.ExpectNoError(err, "processing response")
+	defer resp.Body.Close()
+
+	framework.Logf("http.Client request:%s StatusCode:%d", redirectVerb, resp.StatusCode)
+	framework.ExpectEqual(resp.StatusCode, 301, "The resp.StatusCode returned: %d", resp.StatusCode)
+}
 
 func checkPodStatus(f *framework.Framework, label string) func() (bool, error) {
 	return func() (bool, error) {


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it:**
This PR adds a test to test the following untested endpoints:
connectCoreV1DeleteNamespacedPodProxy
connectCoreV1DeleteNamespacedServiceProxy
connectCoreV1OptionsNamespacedPodProxy
connectCoreV1OptionsNamespacedServiceProxy
connectCoreV1PatchNamespacedPodProxy
connectCoreV1PatchNamespacedServiceProxy
connectCoreV1PostNamespacedPodProxy
connectCoreV1PostNamespacedServiceProxy
connectCoreV1PutNamespacedPodProxy
connectCoreV1PutNamespacedServiceProxy
connectCoreV1HeadNamespacedPodProxy
onnectCoreV1HeadNamespacedServiceProxy

**Which issue(s) this PR fixes:**
Fixes #92949

**Testgrid Link:**

**Special notes for your reviewer:**
Adds +12 endpoint test coverage (good for conformance)

**Does this PR introduce a user-facing change?:**
```
NONE

```

**Release note:**
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:**
```
NONE

```

/sig testing
/sig architecture
/area conformance