### PR TITLE
e2e test for services using pods with hostNetwork as backend

### DIFF
--- a/test/e2e/framework/network/utils.go
+++ b/test/e2e/framework/network/utils.go
@@ -53,8 +53,9 @@ const (
 	// EndpointUDPPort is an endpoint UDP port for testing.
 	EndpointUDPPort = 8081
 	// EndpointSCTPPort is an endpoint SCTP port for testing.
-	EndpointSCTPPort      = 8082
-	testContainerHTTPPort = 8080
+	EndpointSCTPPort = 8082
+	// testContainerHTTPPort is the test container http port.
+	testContainerHTTPPort = 9080
 	// ClusterHTTPPort is a cluster HTTP port for testing.
 	ClusterHTTPPort = 80
 	// ClusterUDPPort is a cluster UDP port for testing.
@@ -573,8 +574,7 @@ func (config *NetworkingTestConfig) createTestPodSpec() *v1.Pod {
 					ImagePullPolicy: v1.PullIfNotPresent,
 					Args: []string{
 						"netexec",
-						fmt.Sprintf("--http-port=%d", EndpointHTTPPort),
-						fmt.Sprintf("--udp-port=%d", EndpointUDPPort),
+						fmt.Sprintf("--http-port=%d", testContainerHTTPPort),
 					},
 					Ports: []v1.ContainerPort{
 						{
@@ -585,10 +585,6 @@ func (config *NetworkingTestConfig) createTestPodSpec() *v1.Pod {
 				},
 			},
 		},
-	}
-	// we want sctp to be optional as it will load the sctp kernel module
-	if config.SCTPEnabled {
-		pod.Spec.Containers[0].Args = append(pod.Spec.Containers[0].Args, fmt.Sprintf("--sctp-port=%d", EndpointSCTPPort))
 	}
 	return pod
 }

--- a/test/e2e/network/networking.go
+++ b/test/e2e/network/networking.go
@@ -136,7 +136,7 @@ var _ = SIGDescribe("Networking", func() {
 	ginkgo.It("should check kube-proxy urls", func() {
 		// TODO: this is overkill we just need the host networking pod
 		// to hit kube-proxy urls.
-		config := e2enetwork.NewNetworkingTestConfig(f, true, false)
+		config := e2enetwork.NewNetworkingTestConfig(f, e2enetwork.UseHostNetwork)
 
 		ginkgo.By("checking kube-proxy URLs")
 		config.GetSelfURL(ports.ProxyHealthzPort, "/healthz", "200 OK")
@@ -149,7 +149,7 @@ var _ = SIGDescribe("Networking", func() {
 	ginkgo.Describe("Granular Checks: Services", func() {
 
 		ginkgo.It("should function for pod-Service: http", func() {
-			config := e2enetwork.NewNetworkingTestConfig(f, false, false)
+			config := e2enetwork.NewNetworkingTestConfig(f)
 			ginkgo.By(fmt.Sprintf("dialing(http) %v --> %v:%v (config.clusterIP)", config.TestContainerPod.Name, config.ClusterIP, e2enetwork.ClusterHTTPPort))
 			err := config.DialFromTestContainer("http", config.ClusterIP, e2enetwork.ClusterHTTPPort, config.MaxTries, 0, config.EndpointHostnames())
 			if err != nil {
@@ -164,7 +164,7 @@ var _ = SIGDescribe("Networking", func() {
 		})
 
 		ginkgo.It("should function for pod-Service: udp", func() {
-			config := e2enetwork.NewNetworkingTestConfig(f, false, false)
+			config := e2enetwork.NewNetworkingTestConfig(f)
 			ginkgo.By(fmt.Sprintf("dialing(udp) %v --> %v:%v (config.clusterIP)", config.TestContainerPod.Name, config.ClusterIP, e2enetwork.ClusterUDPPort))
 			err := config.DialFromTestContainer("udp", config.ClusterIP, e2enetwork.ClusterUDPPort, config.MaxTries, 0, config.EndpointHostnames())
 			if err != nil {
@@ -181,7 +181,7 @@ var _ = SIGDescribe("Networking", func() {
 		// Once basic tests checking for the sctp module not to be loaded are implemented, this
 		// needs to be marked as [Disruptive]
 		ginkgo.It("should function for pod-Service: sctp [Feature:SCTPConnectivity][Disruptive]", func() {
-			config := e2enetwork.NewNetworkingTestConfig(f, false, true)
+			config := e2enetwork.NewNetworkingTestConfig(f, e2enetwork.EnableSCTP)
 			ginkgo.By(fmt.Sprintf("dialing(sctp) %v --> %v:%v (config.clusterIP)", config.TestContainerPod.Name, config.ClusterIP, e2enetwork.ClusterSCTPPort))
 			err := config.DialFromTestContainer("sctp", config.ClusterIP, e2enetwork.ClusterSCTPPort, config.MaxTries, 0, config.EndpointHostnames())
 			if err != nil {
@@ -195,7 +195,7 @@ var _ = SIGDescribe("Networking", func() {
 		})
 
 		ginkgo.It("should function for node-Service: http", func() {
-			config := e2enetwork.NewNetworkingTestConfig(f, true, false)
+			config := e2enetwork.NewNetworkingTestConfig(f, e2enetwork.UseHostNetwork)
 			ginkgo.By(fmt.Sprintf("dialing(http) %v (node) --> %v:%v (config.clusterIP)", config.NodeIP, config.ClusterIP, e2enetwork.ClusterHTTPPort))
 			err := config.DialFromNode("http", config.ClusterIP, e2enetwork.ClusterHTTPPort, config.MaxTries, 0, config.EndpointHostnames())
 			if err != nil {
@@ -209,7 +209,7 @@ var _ = SIGDescribe("Networking", func() {
 		})
 
 		ginkgo.It("should function for node-Service: udp", func() {
-			config := e2enetwork.NewNetworkingTestConfig(f, true, false)
+			config := e2enetwork.NewNetworkingTestConfig(f, e2enetwork.UseHostNetwork)
 			ginkgo.By(fmt.Sprintf("dialing(udp) %v (node) --> %v:%v (config.clusterIP)", config.NodeIP, config.ClusterIP, e2enetwork.ClusterUDPPort))
 			err := config.DialFromNode("udp", config.ClusterIP, e2enetwork.ClusterUDPPort, config.MaxTries, 0, config.EndpointHostnames())
 			if err != nil {
@@ -223,7 +223,7 @@ var _ = SIGDescribe("Networking", func() {
 		})
 
 		ginkgo.It("should function for endpoint-Service: http", func() {
-			config := e2enetwork.NewNetworkingTestConfig(f, false, false)
+			config := e2enetwork.NewNetworkingTestConfig(f)
 			ginkgo.By(fmt.Sprintf("dialing(http) %v (endpoint) --> %v:%v (config.clusterIP)", config.EndpointPods[0].Name, config.ClusterIP, e2enetwork.ClusterHTTPPort))
 			err := config.DialFromEndpointContainer("http", config.ClusterIP, e2enetwork.ClusterHTTPPort, config.MaxTries, 0, config.EndpointHostnames())
 			if err != nil {
@@ -237,7 +237,7 @@ var _ = SIGDescribe("Networking", func() {
 		})
 
 		ginkgo.It("should function for endpoint-Service: udp", func() {
-			config := e2enetwork.NewNetworkingTestConfig(f, false, false)
+			config := e2enetwork.NewNetworkingTestConfig(f)
 			ginkgo.By(fmt.Sprintf("dialing(udp) %v (endpoint) --> %v:%v (config.clusterIP)", config.EndpointPods[0].Name, config.ClusterIP, e2enetwork.ClusterUDPPort))
 			err := config.DialFromEndpointContainer("udp", config.ClusterIP, e2enetwork.ClusterUDPPort, config.MaxTries, 0, config.EndpointHostnames())
 			if err != nil {
@@ -254,7 +254,7 @@ var _ = SIGDescribe("Networking", func() {
 		// This test ensures that in a situation where multiple services exist with the same selector,
 		// deleting one of the services does not affect the connectivity of the remaining service
 		ginkgo.It("should function for multiple endpoint-Services with same selector", func() {
-			config := e2enetwork.NewNetworkingTestConfig(f, false, false)
+			config := e2enetwork.NewNetworkingTestConfig(f)
 			ginkgo.By("creating a second service with same selector")
 			svc2, httpPort := createSecondNodePortService(f, config)
 
@@ -299,7 +299,7 @@ var _ = SIGDescribe("Networking", func() {
 		})
 
 		ginkgo.It("should update endpoints: http", func() {
-			config := e2enetwork.NewNetworkingTestConfig(f, false, false)
+			config := e2enetwork.NewNetworkingTestConfig(f)
 			ginkgo.By(fmt.Sprintf("dialing(http) %v --> %v:%v (config.clusterIP)", config.TestContainerPod.Name, config.ClusterIP, e2enetwork.ClusterHTTPPort))
 			err := config.DialFromTestContainer("http", config.ClusterIP, e2enetwork.ClusterHTTPPort, config.MaxTries, 0, config.EndpointHostnames())
 			if err != nil {
@@ -316,7 +316,7 @@ var _ = SIGDescribe("Networking", func() {
 		})
 
 		ginkgo.It("should update endpoints: udp", func() {
-			config := e2enetwork.NewNetworkingTestConfig(f, false, false)
+			config := e2enetwork.NewNetworkingTestConfig(f)
 			ginkgo.By(fmt.Sprintf("dialing(udp) %v --> %v:%v (config.clusterIP)", config.TestContainerPod.Name, config.ClusterIP, e2enetwork.ClusterUDPPort))
 			err := config.DialFromTestContainer("udp", config.ClusterIP, e2enetwork.ClusterUDPPort, config.MaxTries, 0, config.EndpointHostnames())
 			if err != nil {
@@ -334,7 +334,7 @@ var _ = SIGDescribe("Networking", func() {
 
 		// Slow because we confirm that the nodePort doesn't serve traffic, which requires a period of polling.
 		ginkgo.It("should update nodePort: http [Slow]", func() {
-			config := e2enetwork.NewNetworkingTestConfig(f, true, false)
+			config := e2enetwork.NewNetworkingTestConfig(f, e2enetwork.UseHostNetwork)
 			ginkgo.By(fmt.Sprintf("dialing(http) %v (node) --> %v:%v (nodeIP) and getting ALL host endpoints", config.NodeIP, config.NodeIP, config.NodeHTTPPort))
 			err := config.DialFromNode("http", config.NodeIP, config.NodeHTTPPort, config.MaxTries, 0, config.EndpointHostnames())
 			if err != nil {
@@ -352,7 +352,7 @@ var _ = SIGDescribe("Networking", func() {
 
 		// quick validation of udp, next test confirms that this services update as well after endpoints are removed, but is slower.
 		ginkgo.It("should support basic nodePort: udp functionality", func() {
-			config := e2enetwork.NewNetworkingTestConfig(f, true, false)
+			config := e2enetwork.NewNetworkingTestConfig(f, e2enetwork.UseHostNetwork)
 			ginkgo.By(fmt.Sprintf("dialing(udp) %v (node) --> %v:%v (nodeIP) and getting ALL host endpoints", config.NodeIP, config.NodeIP, config.NodeUDPPort))
 			err := config.DialFromNode("udp", config.NodeIP, config.NodeUDPPort, config.MaxTries, 0, config.EndpointHostnames())
 			if err != nil {
@@ -362,7 +362,7 @@ var _ = SIGDescribe("Networking", func() {
 
 		// Slow because we confirm that the nodePort doesn't serve traffic, which requires a period of polling.
 		ginkgo.It("should update nodePort: udp [Slow]", func() {
-			config := e2enetwork.NewNetworkingTestConfig(f, true, false)
+			config := e2enetwork.NewNetworkingTestConfig(f, e2enetwork.UseHostNetwork)
 			ginkgo.By(fmt.Sprintf("dialing(udp) %v (node) --> %v:%v (nodeIP) and getting ALL host endpoints", config.NodeIP, config.NodeIP, config.NodeUDPPort))
 			err := config.DialFromNode("udp", config.NodeIP, config.NodeUDPPort, config.MaxTries, 0, config.EndpointHostnames())
 			if err != nil {
@@ -381,7 +381,7 @@ var _ = SIGDescribe("Networking", func() {
 
 		// [LinuxOnly]: Windows does not support session affinity.
 		ginkgo.It("should function for client IP based session affinity: http [LinuxOnly]", func() {
-			config := e2enetwork.NewNetworkingTestConfig(f, false, false)
+			config := e2enetwork.NewNetworkingTestConfig(f)
 			ginkgo.By(fmt.Sprintf("dialing(http) %v --> %v:%v", config.TestContainerPod.Name, config.SessionAffinityService.Spec.ClusterIP, e2enetwork.ClusterHTTPPort))
 
 			// Check if number of endpoints returned are exactly one.
@@ -399,7 +399,7 @@ var _ = SIGDescribe("Networking", func() {
 
 		// [LinuxOnly]: Windows does not support session affinity.
 		ginkgo.It("should function for client IP based session affinity: udp [LinuxOnly]", func() {
-			config := e2enetwork.NewNetworkingTestConfig(f, false, false)
+			config := e2enetwork.NewNetworkingTestConfig(f)
 			ginkgo.By(fmt.Sprintf("dialing(udp) %v --> %v:%v", config.TestContainerPod.Name, config.SessionAffinityService.Spec.ClusterIP, e2enetwork.ClusterUDPPort))
 
 			// Check if number of endpoints returned are exactly one.
@@ -416,7 +416,7 @@ var _ = SIGDescribe("Networking", func() {
 		})
 
 		ginkgo.It("should be able to handle large requests: http", func() {
-			config := e2enetwork.NewNetworkingTestConfig(f, false, false)
+			config := e2enetwork.NewNetworkingTestConfig(f)
 			ginkgo.By(fmt.Sprintf("dialing(http) %v --> %v:%v (config.clusterIP)", config.TestContainerPod.Name, config.ClusterIP, e2enetwork.ClusterHTTPPort))
 			message := strings.Repeat("42", 1000)
 			err := config.DialEchoFromTestContainer("http", config.ClusterIP, e2enetwork.ClusterHTTPPort, config.MaxTries, 0, message)
@@ -426,7 +426,7 @@ var _ = SIGDescribe("Networking", func() {
 		})
 
 		ginkgo.It("should be able to handle large requests: udp", func() {
-			config := e2enetwork.NewNetworkingTestConfig(f, false, false)
+			config := e2enetwork.NewNetworkingTestConfig(f)
 			ginkgo.By(fmt.Sprintf("dialing(udp) %v --> %v:%v (config.clusterIP)", config.TestContainerPod.Name, config.ClusterIP, e2enetwork.ClusterUDPPort))
 			message := "n" + strings.Repeat("o", 1999)
 			err := config.DialEchoFromTestContainer("udp", config.ClusterIP, e2enetwork.ClusterUDPPort, config.MaxTries, 0, message)
@@ -439,7 +439,7 @@ var _ = SIGDescribe("Networking", func() {
 	// Once basic tests checking for the sctp module not to be loaded are implemented, this
 	// needs to be marked as [Disruptive]
 	ginkgo.It("should function for pod-pod: sctp [Feature:SCTPConnectivity][Disruptive]", func() {
-		config := e2enetwork.NewNetworkingTestConfig(f, false, true)
+		config := e2enetwork.NewNetworkingTestConfig(f, e2enetwork.EnableSCTP)
 		ginkgo.By(fmt.Sprintf("dialing(sctp) %v --> %v:%v (config.clusterIP)", config.TestContainerPod.Name, config.ClusterIP, e2enetwork.ClusterSCTPPort))
 		message := "hello"
 		err := config.DialEchoFromTestContainer("sctp", config.TestContainerPod.Status.PodIP, e2enetwork.EndpointSCTPPort, config.MaxTries, 0, message)

--- a/test/e2e/network/service.go
+++ b/test/e2e/network/service.go
@@ -2997,7 +2997,7 @@ var _ = SIGDescribe("ESIPP [Slow]", func() {
 			const threshold = 2
 			nodes, err := getEndpointNodesWithInternalIP(jig)
 			framework.ExpectNoError(err)
-			config := e2enetwork.NewNetworkingTestConfig(f, false, false)
+			config := e2enetwork.NewNetworkingTestConfig(f)
 			for _, internalIP := range nodes {
 				err := testHTTPHealthCheckNodePortFromTestContainer(
 					config,
@@ -3044,7 +3044,7 @@ var _ = SIGDescribe("ESIPP [Slow]", func() {
 		framework.ExpectNoError(err)
 
 		dialCmd := "clientip"
-		config := e2enetwork.NewNetworkingTestConfig(f, false, false)
+		config := e2enetwork.NewNetworkingTestConfig(f)
 
 		for nodeName, nodeIP := range endpointsNodeMap {
 			ginkgo.By(fmt.Sprintf("reading clientIP using the TCP service's NodePort, on node %v: %v:%v/%v", nodeName, nodeIP, tcpNodePort, dialCmd))
@@ -3095,7 +3095,7 @@ var _ = SIGDescribe("ESIPP [Slow]", func() {
 		svcTCPPort := int(svc.Spec.Ports[0].Port)
 
 		const threshold = 2
-		config := e2enetwork.NewNetworkingTestConfig(f, false, false)
+		config := e2enetwork.NewNetworkingTestConfig(f)
 		for i := 0; i < len(nodes.Items); i++ {
 			endpointNodeName := nodes.Items[i].Name
 
@@ -3260,7 +3260,7 @@ var _ = SIGDescribe("ESIPP [Slow]", func() {
 		path := "/clientip"
 		dialCmd := "clientip"
 
-		config := e2enetwork.NewNetworkingTestConfig(f, false, false)
+		config := e2enetwork.NewNetworkingTestConfig(f)
 
 		ginkgo.By(fmt.Sprintf("endpoints present on nodes %v, absent on nodes %v", endpointNodeMap, noEndpointNodeMap))
 		for nodeName, nodeIP := range noEndpointNodeMap {


### PR DESCRIPTION
we are missing tests that check the connectivity against services
that have backend pods with hostNetwork: true.

Because the tests run in parallel, it is possible that the pods used as
backends try to bind to the same port, and since all of them use the
host network, the scheduler will fail to create them due to port conflicts,
so we run them serially.

We have to skip networking tests with udp and endpoints using
hostNetwork, because they have a known issue.

```release-note
NONE
```
