### PR TITLE
verify-generated-swagger-docs: remove unnecessary build

### DIFF
--- a/hack/verify-generated-swagger-docs.sh
+++ b/hack/verify-generated-swagger-docs.sh
@@ -28,21 +28,6 @@ source "${KUBE_ROOT}/hack/lib/init.sh"
 
 kube::golang::setup_env
 
-make -C "${KUBE_ROOT}" WHAT=cmd/genswaggertypedocs
-
-# Find binary
-genswaggertypedocs=$(kube::util::find-binary "genswaggertypedocs")
-
-if [[ ! -x "$genswaggertypedocs" ]]; then
-  {
-    echo "It looks as if you don't have a compiled genswaggertypedocs binary"
-    echo
-    echo "If you are running from a clone of the git repo, please run"
-    echo "'make WHAT=cmd/genswaggertypedocs'."
-  } >&2
-  exit 1
-fi
-
 _tmpdir="$(kube::realpath "$(mktemp -d -t swagger-docs.XXXXXX)")"
 function swagger_cleanup {
   rm -rf "${_tmpdir}"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
As part of `make verify` (prow job `pull-kubernetes-verify`), `verify-generated-swagger-docs` gets invoked with a dirty directory. The make rule triggers `gen_conversion`, which doesn't work well with dirty dir and causes https://github.com/kubernetes/kubernetes/issues/94691. 

Removing the make, since the binary is unused (the [update script](https://github.com/kubernetes/kubernetes/blob/965137a992ed755474f17fa6377ee3555745addd/hack/update-generated-swagger-docs.sh#L39) installs the binary separatelly), and this way doesn't affect users who run this script stand-alone. 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #94691

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

/cc @wojtek-t 
/sig api-machinery