### PR TITLE
Fix sctp job flakes

### DIFF
--- a/test/e2e/network/service.go
+++ b/test/e2e/network/service.go
@@ -4001,6 +4001,9 @@ var _ = SIGDescribe("SCTP [Feature:SCTP] [LinuxOnly]", func() {
 
 		ginkgo.By("dumping iptables rules on the node")
 		cmd = "sudo iptables-save"
+		if framework.TestContext.ClusterIsIPv6() {
+			cmd = "sudo ip6tables-save"
+		}
 		framework.Logf("Executing cmd %q on node %v", cmd, node.Name)
 		result, err := hostExec.IssueCommandWithResult(cmd, node)
 		if err != nil {
@@ -4061,6 +4064,9 @@ var _ = SIGDescribe("SCTP [Feature:SCTP] [LinuxOnly]", func() {
 		node, err := e2enode.GetRandomReadySchedulableNode(cs)
 		framework.ExpectNoError(err)
 		cmd := "sudo iptables-save"
+		if framework.TestContext.ClusterIsIPv6() {
+			cmd = "sudo ip6tables-save"
+		}
 		framework.Logf("Executing cmd %q on node %v", cmd, node.Name)
 		result, err := hostExec.IssueCommandWithResult(cmd, node)
 		if err != nil {

--- a/test/e2e/network/service.go
+++ b/test/e2e/network/service.go
@@ -3998,27 +3998,28 @@ var _ = SIGDescribe("SCTP [Feature:SCTP] [LinuxOnly]", func() {
 			err := cs.CoreV1().Pods(f.Namespace.Name).Delete(context.TODO(), podName, metav1.DeleteOptions{})
 			framework.ExpectNoError(err, "failed to delete pod: %s in namespace: %s", podName, f.Namespace.Name)
 		}()
-
-		ginkgo.By("dumping iptables rules on the node")
+		// wait until host port manager syncs rules
 		cmd = "sudo iptables-save"
 		if framework.TestContext.ClusterIsIPv6() {
 			cmd = "sudo ip6tables-save"
 		}
-		framework.Logf("Executing cmd %q on node %v", cmd, node.Name)
-		result, err := hostExec.IssueCommandWithResult(cmd, node)
-		if err != nil {
-			framework.Failf("Interrogation of iptables rules failed on node %v", node.Name)
-		}
-
-		ginkgo.By("checking that iptables contains the necessary iptables rules")
-		found := false
-		for _, line := range strings.Split(result, "\n") {
-			if strings.Contains(line, "-p sctp") && strings.Contains(line, "--dport 5060") {
-				found = true
-				break
+		err = wait.PollImmediate(framework.Poll, framework.PollShortTimeout, func() (bool, error) {
+			framework.Logf("Executing cmd %q on node %v", cmd, node.Name)
+			result, err := hostExec.IssueCommandWithResult(cmd, node)
+			if err != nil {
+				framework.Logf("Interrogation of iptables rules failed on node %v", node.Name)
+				return false, nil
 			}
-		}
-		if !found {
+
+			for _, line := range strings.Split(result, "\n") {
+				if strings.Contains(line, "-p sctp") && strings.Contains(line, "--dport 5060") {
+					return true, nil
+				}
+			}
+			framework.Logf("retrying ... not hostport sctp iptables rules found on node %v", node.Name)
+			return false, nil
+		})
+		if err != nil {
 			framework.Failf("iptables rules are not set for a pod with sctp hostport")
 		}
 		ginkgo.By("validating sctp module is still not loaded")
@@ -4057,8 +4058,6 @@ var _ = SIGDescribe("SCTP [Feature:SCTP] [LinuxOnly]", func() {
 
 		err = e2enetwork.WaitForService(f.ClientSet, ns, serviceName, true, 5*time.Second, e2eservice.TestTimeout)
 		framework.ExpectNoError(err, fmt.Sprintf("error while waiting for service:%s err: %v", serviceName, err))
-
-		ginkgo.By("dumping iptables rules on a node")
 		hostExec := utils.NewHostExec(f)
 		defer hostExec.Cleanup()
 		node, err := e2enode.GetRandomReadySchedulableNode(cs)
@@ -4067,21 +4066,23 @@ var _ = SIGDescribe("SCTP [Feature:SCTP] [LinuxOnly]", func() {
 		if framework.TestContext.ClusterIsIPv6() {
 			cmd = "sudo ip6tables-save"
 		}
-		framework.Logf("Executing cmd %q on node %v", cmd, node.Name)
-		result, err := hostExec.IssueCommandWithResult(cmd, node)
-		if err != nil {
-			framework.Failf("Interrogation of iptables rules failed on node %v", node.Name)
-		}
-
-		ginkgo.By("checking that iptables contains the necessary iptables rules")
-		kubeService := false
-		for _, line := range strings.Split(result, "\n") {
-			if strings.Contains(line, "-A KUBE-SERVICES") && strings.Contains(line, "-p sctp") {
-				kubeService = true
-				break
+		err = wait.PollImmediate(framework.Poll, e2eservice.KubeProxyLagTimeout, func() (bool, error) {
+			framework.Logf("Executing cmd %q on node %v", cmd, node.Name)
+			result, err := hostExec.IssueCommandWithResult(cmd, node)
+			if err != nil {
+				framework.Logf("Interrogation of iptables rules failed on node %v", node.Name)
+				return false, nil
 			}
-		}
-		if !kubeService {
+
+			for _, line := range strings.Split(result, "\n") {
+				if strings.Contains(line, "-A KUBE-SERVICES") && strings.Contains(line, "-p sctp") {
+					return true, nil
+				}
+			}
+			framework.Logf("retrying ... no iptables rules found for service with sctp ports on node %v", node.Name)
+			return false, nil
+		})
+		if err != nil {
 			framework.Failf("iptables rules are not set for a clusterip service with sctp ports")
 		}
 		ginkgo.By("validating sctp module is still not loaded")


### PR DESCRIPTION
We were only checking that the services or pods are created, but we should wait until the iptables rules are programmed by the corresponding components before checking.

Adding sleeps are not great but is the simpler solution and 5 seconds should be more than enough for kube-proxy or the host port manager to write the iptables rules.

It also adds support for ipv6 to the tests

/kind flake

Fixes: #92041 

```release-note
NONE
```
