### PR TITLE
Fix resource location for ipv6 pods

### DIFF
--- a/pkg/registry/core/pod/strategy.go
+++ b/pkg/registry/core/pod/strategy.go
@@ -26,7 +26,7 @@ import (
 	"strings"
 	"time"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
@@ -317,7 +317,13 @@ func ResourceLocation(ctx context.Context, getter ResourceGetter, rt http.RoundT
 		Scheme: scheme,
 	}
 	if port == "" {
-		loc.Host = podIP
+		// when using an ipv6 IP as a hostname in a URL, it must be wrapped in [...]
+		// net.JoinHostPort does this for you.
+		if strings.Contains(podIP, ":") {
+			loc.Host = "[" + podIP + "]"
+		} else {
+			loc.Host = podIP
+		}
 	} else {
 		loc.Host = net.JoinHostPort(podIP, port)
 	}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Fixes the URL we construct for proxying to IPv6 pods without a specified port to be a valid url that can be parsed.

xref https://github.com/kubernetes/kubernetes/pull/94786#issuecomment-693440769

**Special notes for your reviewer**:

go <=1.11 tolerated this (along with many other malformed URLs)
go >=1.12 requires the host to be a valid rfc host, which means wrapping ipv6 addresses in square brackets

**Does this PR introduce a user-facing change?**:
```release-note
Fixes an issue proxying to ipv6 pods without specifying a port
```

/sig api-machinery
/sig network
/cc @aojea 