### PR TITLE
Allocate IP address before running tests

### DIFF
--- a/test/e2e/network/ingress.go
+++ b/test/e2e/network/ingress.go
@@ -89,7 +89,7 @@ var _ = SIGDescribe("Loadbalancing: L7", func() {
 	// TODO: write similar tests for nginx, haproxy and AWS Ingress.
 	ginkgo.Describe("GCE [Slow] [Feature:Ingress]", func() {
 		var gceController *gce.IngressController
-
+		var ipAddress string
 		// Platform specific setup
 		ginkgo.BeforeEach(func() {
 			e2eskipper.SkipUnlessProviderIs("gce", "gke")
@@ -101,6 +101,8 @@ var _ = SIGDescribe("Loadbalancing: L7", func() {
 			}
 			err := gceController.Init()
 			framework.ExpectNoError(err)
+			ipAddress = gceController.CreateStaticIP(ns)
+			ginkgo.By(fmt.Sprintf("allocated static ip: %v through the GCE cloud provider", ipAddress))
 		})
 
 		// Platform specific cleanup


### PR DESCRIPTION
Signed-off-by: Ricardo Pchevuzinske Katz <ricardo.katz@gmail.com>


**What type of PR is this?**

/kind failing-test
/kind flake

**What this PR does / why we need it**: This PR allocates an IP address for the ingress before each test.

**Which issue(s) this PR fixes**:
Fixes #94806 

**Special notes for your reviewer**: There are some thoughts in the original issue, about if this is the real root cause of the flake (a previous IP allocation has been removed from a test that would run later) of if there's something that changed in GCP or in the way IP addresses are allocated.

Otherwise I couldn't find other plausible reason for the flake

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
