### PR TITLE
Automated cherry pick of #94728: portforward: Fix UDP-only ports calculation

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/portforward/portforward_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/portforward/portforward_test.go
@@ -880,7 +880,7 @@ func TestCheckUDPPort(t *testing.T) {
 			expectError: true,
 		},
 		{
-			name: "Pod has ports with both TCP and UDP protocol",
+			name: "Pod has ports with both TCP and UDP protocol (UDP first)",
 			pod: &corev1.Pod{
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{
@@ -888,6 +888,22 @@ func TestCheckUDPPort(t *testing.T) {
 							Ports: []corev1.ContainerPort{
 								{Protocol: corev1.ProtocolUDP, ContainerPort: 53},
 								{Protocol: corev1.ProtocolTCP, ContainerPort: 53},
+							},
+						},
+					},
+				},
+			},
+			ports: []string{":53"},
+		},
+		{
+			name: "Pod has ports with both TCP and UDP protocol (TCP first)",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Ports: []corev1.ContainerPort{
+								{Protocol: corev1.ProtocolTCP, ContainerPort: 53},
+								{Protocol: corev1.ProtocolUDP, ContainerPort: 53},
 							},
 						},
 					},
@@ -921,12 +937,24 @@ func TestCheckUDPPort(t *testing.T) {
 			expectError: true,
 		},
 		{
-			name: "Service has ports with both TCP and UDP protocol",
+			name: "Service has ports with both TCP and UDP protocol (UDP first)",
 			service: &corev1.Service{
 				Spec: corev1.ServiceSpec{
 					Ports: []corev1.ServicePort{
 						{Protocol: corev1.ProtocolUDP, Port: 53},
 						{Protocol: corev1.ProtocolTCP, Port: 53},
+					},
+				},
+			},
+			ports: []string{"53"},
+		},
+		{
+			name: "Service has ports with both TCP and UDP protocol (TCP first)",
+			service: &corev1.Service{
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{Protocol: corev1.ProtocolTCP, Port: 53},
+						{Protocol: corev1.ProtocolUDP, Port: 53},
 					},
 				},
 			},


### PR DESCRIPTION
Cherry pick of #94728 on release-1.19.

#94728: portforward: Fix UDP-only ports calculation

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Fixed a regression in 1.19 that sometimes prevented `kubectl portforward` to work when TCP and UDP services were configured on the same port
```