### PR TITLE
fix azure file migration panic

### DIFF
--- a/staging/src/k8s.io/csi-translation-lib/plugins/azure_file.go
+++ b/staging/src/k8s.io/csi-translation-lib/plugins/azure_file.go
@@ -119,8 +119,10 @@ func (t *azureFileCSITranslator) TranslateInTreePVToCSI(pv *v1.PersistentVolume)
 		accountName = azureSource.SecretName
 	}
 	resourceGroup := ""
-	if v, ok := pv.ObjectMeta.Annotations[resourceGroupAnnotation]; ok {
-		resourceGroup = v
+	if pv.ObjectMeta.Annotations != nil {
+		if v, ok := pv.ObjectMeta.Annotations[resourceGroupAnnotation]; ok {
+			resourceGroup = v
+		}
 	}
 	volumeID := fmt.Sprintf(volumeIDTemplate, resourceGroup, accountName, azureSource.ShareName, "")
 
@@ -183,6 +185,9 @@ func (t *azureFileCSITranslator) TranslateCSIPVToInTree(pv *v1.PersistentVolume)
 	pv.Spec.CSI = nil
 	pv.Spec.AzureFile = azureSource
 	if resourceGroup != "" {
+		if pv.ObjectMeta.Annotations == nil {
+			pv.ObjectMeta.Annotations = map[string]string{}
+		}
 		pv.ObjectMeta.Annotations[resourceGroupAnnotation] = resourceGroup
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
fix azure file migration panic
Since `pv.ObjectMeta.Annotations` is a map, need to check whether it's nil first

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

```
func TestTest(t *testing.T) {
	var m map[string]string

	if m == nil {
		fmt.Println("m is nil")
	}

	if _, ok := m["abc"]; ok {
		fmt.Println("abc exists")
	} else {
		fmt.Println("abc not exists")
	}

	m["abc"] = "test"
}

>go test -run TestTest
m is nil
abc not exists
--- FAIL: TestTest (0.00s)
panic: assignment to entry in nil map [recovered]
        panic: assignment to entry in nil map

goroutine 21 [running]:
testing.tRunner.func1(0xc00019e100)
        c:/go/src/testing/testing.go:874 +0x3aa
panic(0xbbea60, 0xd7bbb0)
        c:/go/src/runtime/panic.go:679 +0x1c0
k8s.io/csi-translation-lib/plugins.TestTest(0xc00019e100)
        C:/Users/xiazhang/go/src/k8s.io/kubernetes/staging/src/k8s.io/csi-translation-lib/plugins/azure_file_test.go:329 +0x13f
testing.tRunner(0xc00019e100, 0xce0878)
        c:/go/src/testing/testing.go:909 +0xd0
created by testing.(*T).Run
        c:/go/src/testing/testing.go:960 +0x357
exit status 2
FAIL    k8s.io/csi-translation-lib/plugins      0.415s
```

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
fix azure file migration panic
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
fix azure file migration panic
```

/kind bug
/assign @msau42
/priority important-soon
/sig cloud-provider
/area provider/azure