### PR TITLE
test(apply): deflake run_kubectl_apply_tests(round 3)

### DIFF
--- a/test/cmd/apply.sh
+++ b/test/cmd/apply.sh
@@ -159,7 +159,7 @@ __EOF__
   # Dry-run create the CR
   kubectl "${kube_flags[@]:?}" apply --dry-run=server -f hack/testdata/CRD/resource.yaml "${kube_flags[@]:?}"
   # Make sure that the CR doesn't exist
-  ! kubectl "${kube_flags[@]:?}" get resource/myobj || exit 1
+  ! kubectl "${kube_flags[@]:?}" get resource/myobj 2>/dev/null || exit 1
 
   # clean-up
   kubectl "${kube_flags[@]:?}" delete customresourcedefinition resources.mygroup.example.com
@@ -173,11 +173,8 @@ __EOF__
   kube::test::get_object_assert 'pods a -n nsb' "{{${id_field:?}}}" 'a'
   # apply b with namespace
   kubectl apply --namespace nsb --prune -l prune-group=true -f hack/testdata/prune/b.yaml "${kube_flags[@]:?}"
-  # check right pod exists
-  kube::test::get_object_assert 'pods b -n nsb' "{{${id_field:?}}}" 'b'
-  # check wrong pod doesn't exist
-  output_message=$(! kubectl get pods a -n nsb 2>&1 "${kube_flags[@]:?}")
-  kube::test::if_has_string "${output_message}" 'pods "a" not found'
+  # check right pod exists and wrong pod doesn't exist
+  kube::test::wait_object_assert 'pods -n nsb' "{{range.items}}{{${id_field:?}}}:{{end}}" 'b:'
 
   # cleanup
   kubectl delete pods b -n nsb
@@ -191,8 +188,7 @@ __EOF__
   # check right pod exists
   kube::test::get_object_assert 'pods a' "{{${id_field:?}}}" 'a'
   # check wrong pod doesn't exist
-  output_message=$(! kubectl get pods b -n nsb 2>&1 "${kube_flags[@]:?}")
-  kube::test::if_has_string "${output_message}" 'pods "b" not found'
+  kube::test::wait_object_assert 'pods -n nsb' "{{range.items}}{{${id_field:?}}}:{{end}}" ''
 
   # apply b
   kubectl apply -l prune-group=true -f hack/testdata/prune/b.yaml "${kube_flags[@]:?}"
@@ -254,11 +250,8 @@ __EOF__
   kube::test::get_object_assert 'pods b -n nsb' "{{${id_field:?}}}" 'b'
   # apply --prune must prune a
   kubectl apply --prune --all -f hack/testdata/prune/b.yaml
-  # check wrong pod doesn't exist
-  output_message=$(! kubectl get pods a -n nsb 2>&1 "${kube_flags[@]:?}")
-  kube::test::if_has_string "${output_message}" 'pods "a" not found'
-  # check right pod exists
-  kube::test::get_object_assert 'pods b -n nsb' "{{${id_field:?}}}" 'b'
+  # check wrong pod doesn't exist and right pod exists
+  kube::test::wait_object_assert 'pods -n nsb' "{{range.items}}{{${id_field:?}}}:{{end}}" 'b:'
 
   # cleanup
   kubectl delete ns nsb
@@ -471,7 +464,7 @@ __EOF__
   # Dry-run create the CR
   kubectl "${kube_flags[@]:?}" apply --server-side --dry-run=server -f hack/testdata/CRD/resource.yaml "${kube_flags[@]:?}"
   # Make sure that the CR doesn't exist
-  ! kubectl "${kube_flags[@]:?}" get resource/myobj || exit 1
+  ! kubectl "${kube_flags[@]:?}" get resource/myobj 2>/dev/null || exit 1
 
   # clean-up
   kubectl "${kube_flags[@]:?}" delete customresourcedefinition resources.mygroup.example.com


### PR DESCRIPTION
Signed-off-by: knight42 <anonymousknight96@gmail.com>


**What type of PR is this?**

/kind flake

**What this PR does / why we need it**:

The message
```
Error from server (NotFound): resources.mygroup.example.com "myobj" not found
```
is misleading, it is actually expected and caused by https://github.com/kubernetes/kubernetes/blob/3eb90c19d0cf90b756c3e08e32c6495b91e0aeed/test/cmd/apply.sh#L159-L162 and https://github.com/kubernetes/kubernetes/blob/3eb90c19d0cf90b756c3e08e32c6495b91e0aeed/test/cmd/apply.sh#L471-L474

From the log https://storage.googleapis.com/kubernetes-jenkins/logs/ci-kubernetes-integration-master/1305183184433975296/build-log.txt, we could see that
```
[32mapply.sh:177: Successful get pods b -n nsb {{.metadata.name}}: b
(B[m!!! [0913 16:45:10] Call tree:
!!! [0913 16:45:10]  1: /home/prow/go/src/k8s.io/kubernetes/test/cmd/../../third_party/forked/shell2junit/sh2ju.sh:47 run_kubectl_apply_tests(...)
!!! [0913 16:45:10]  2: /home/prow/go/src/k8s.io/kubernetes/test/cmd/../../third_party/forked/shell2junit/sh2ju.sh:112 eVal(...)
!!! [0913 16:45:10]  3: /home/prow/go/src/k8s.io/kubernetes/test/cmd/legacy-script.sh:131 juLog(...)
!!! [0913 16:45:10]  4: /home/prow/go/src/k8s.io/kubernetes/test/cmd/legacy-script.sh:521 record_command(...)
!!! [0913 16:45:10]  5: hack/make-rules/test-cmd.sh:152 runTests(...)
+++ exit code: 1
+++ error: 1
Error when running run_kubectl_apply_tests
Recording: run_kubectl_server_side_apply_tests
Running command: run_kubectl_server_side_apply_tests
```

The last line run in the test is # 177, and we could take a look at the script https://github.com/kubernetes/kubernetes/blob/3eb90c19d0cf90b756c3e08e32c6495b91e0aeed/test/cmd/apply.sh#L177-L180
If line # 180 was run, it would print message to the log, but we didn't see it, so it is reasonable to suspect it is line # 179 
```sh
output_message=$(! kubectl get pods a -n nsb 2>&1 "${kube_flags[@]:?}")
```
that cause the test to fail.

Note that three options are set in the script:
```sh
set -o errexit
set -o nounset
set -o pipefail
```
and it is possible that pod `a` still exists(maybe in `Terminating` state) when line # 179 was executed in the test, so the test script exit at once.

A minimal reproducer:
```sh
$ cat test.sh
#!/bin/bash

set -o errexit
set -o nounset
set -o pipefail

succeed() {
    echo success
    return 0
}

fail() {
    echo failure
    return 1
}

out=$(! succeed)
echo $out
$ ./test.sh; echo $?
1
```

**Which issue(s) this PR fixes**:

Fixes #93651

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
