### PR TITLE
kubeadm: remove the --kubelet-version flag for "upgrade node"

### DIFF
--- a/cmd/kubeadm/app/cmd/phases/upgrade/node/data.go
+++ b/cmd/kubeadm/app/cmd/phases/upgrade/node/data.go
@@ -28,7 +28,6 @@ type Data interface {
 	EtcdUpgrade() bool
 	RenewCerts() bool
 	DryRun() bool
-	KubeletVersion() string
 	Cfg() *kubeadmapi.InitConfiguration
 	IsControlPlaneNode() bool
 	Client() clientset.Interface

--- a/cmd/kubeadm/app/cmd/phases/upgrade/node/kubeletconfig.go
+++ b/cmd/kubeadm/app/cmd/phases/upgrade/node/kubeletconfig.go
@@ -50,7 +50,6 @@ func NewKubeletConfigPhase() workflow.Phase {
 		InheritFlags: []string{
 			options.DryRun,
 			options.KubeconfigPath,
-			options.KubeletVersion,
 		},
 	}
 	return phase
@@ -76,17 +75,7 @@ func runKubeletConfigPhase() func(c workflow.RunData) error {
 		// TODO: Checkpoint the current configuration first so that if something goes wrong it can be recovered
 
 		// Store the kubelet component configuration.
-		// By default the kubelet version is expected to be equal to cfg.ClusterConfiguration.KubernetesVersion, but
-		// users can specify a different kubelet version (this is a legacy of the original implementation
-		// of `kubeadm upgrade node config` which we are preserving in order to not break the GA contract)
-		if data.KubeletVersion() != "" && data.KubeletVersion() != cfg.ClusterConfiguration.KubernetesVersion {
-			fmt.Printf("[upgrade] Using kubelet config version %s, while kubernetes-version is %s\n", data.KubeletVersion(), cfg.ClusterConfiguration.KubernetesVersion)
-			if err := kubeletphase.DownloadConfig(data.Client(), data.KubeletVersion(), kubeletDir); err != nil {
-				return err
-			}
-
-			// WriteConfigToDisk is what we should be calling since we already have the correct component config loaded
-		} else if err = kubeletphase.WriteConfigToDisk(&cfg.ClusterConfiguration, kubeletDir); err != nil {
+		if err = kubeletphase.WriteConfigToDisk(&cfg.ClusterConfiguration, kubeletDir); err != nil {
 			return err
 		}
 

--- a/cmd/kubeadm/app/cmd/upgrade/node.go
+++ b/cmd/kubeadm/app/cmd/upgrade/node.go
@@ -39,7 +39,6 @@ import (
 // supported by this api will be exposed as a flag.
 type nodeOptions struct {
 	kubeConfigPath        string
-	kubeletVersion        string
 	etcdUpgrade           bool
 	renewCerts            bool
 	dryRun                bool
@@ -57,7 +56,6 @@ type nodeData struct {
 	etcdUpgrade           bool
 	renewCerts            bool
 	dryRun                bool
-	kubeletVersion        string
 	cfg                   *kubeadmapi.InitConfiguration
 	isControlPlaneNode    bool
 	client                clientset.Interface
@@ -117,8 +115,6 @@ func newNodeOptions() *nodeOptions {
 func addUpgradeNodeFlags(flagSet *flag.FlagSet, nodeOptions *nodeOptions) {
 	options.AddKubeConfigFlag(flagSet, &nodeOptions.kubeConfigPath)
 	flagSet.BoolVar(&nodeOptions.dryRun, options.DryRun, nodeOptions.dryRun, "Do not change any state, just output the actions that would be performed.")
-	flagSet.StringVar(&nodeOptions.kubeletVersion, options.KubeletVersion, nodeOptions.kubeletVersion, "The *desired* version for the kubelet config after the upgrade. If not specified, the KubernetesVersion from the kubeadm-config ConfigMap will be used")
-	flagSet.MarkDeprecated(options.KubeletVersion, "This flag is deprecated and will be removed in a future version.")
 	flagSet.BoolVar(&nodeOptions.renewCerts, options.CertificateRenewal, nodeOptions.renewCerts, "Perform the renewal of certificates used by component changed during upgrades.")
 	flagSet.BoolVar(&nodeOptions.etcdUpgrade, options.EtcdUpgrade, nodeOptions.etcdUpgrade, "Perform the upgrade of etcd.")
 	flagSet.StringSliceVar(&nodeOptions.ignorePreflightErrors, options.IgnorePreflightErrors, nodeOptions.ignorePreflightErrors, "A list of checks whose errors will be shown as warnings. Example: 'IsPrivilegedUser,Swap'. Value 'all' ignores errors from all checks.")
@@ -160,7 +156,6 @@ func newNodeData(cmd *cobra.Command, args []string, options *nodeOptions) (*node
 		etcdUpgrade:           options.etcdUpgrade,
 		renewCerts:            options.renewCerts,
 		dryRun:                options.dryRun,
-		kubeletVersion:        options.kubeletVersion,
 		cfg:                   cfg,
 		client:                client,
 		isControlPlaneNode:    isControlPlaneNode,
@@ -183,11 +178,6 @@ func (d *nodeData) EtcdUpgrade() bool {
 // RenewCerts returns the renewCerts flag.
 func (d *nodeData) RenewCerts() bool {
 	return d.renewCerts
-}
-
-// KubeletVersion returns the kubeletVersion flag.
-func (d *nodeData) KubeletVersion() string {
-	return d.kubeletVersion
 }
 
 // Cfg returns initConfiguration.


### PR DESCRIPTION
**What this PR does / why we need it**:
The flag was deprecated as it is problematic since it allows
overrides of the kubelet configuration that is downloaded
from the cluster during upgrade.

Kubeadm node upgrades already download the KubeletConfiguration
and store it in the internal ClusterConfiguration type. It is then
only a matter of writing that KubeletConfiguration to disk.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubeadm/issues/2021

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kubeadm: remove the deprecated --kubelet-config flag for the command "kubeadm upgrade node"
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
