### PR TITLE
Make the nodelease controller take nodeclient, and leaseclient

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -789,7 +789,9 @@ func NewMainKubelet(kubeCfg *kubeletconfiginternal.KubeletConfiguration,
 	klet.softAdmitHandlers.AddPodAdmitHandler(lifecycle.NewNoNewPrivsAdmitHandler(klet.containerRuntime))
 	klet.softAdmitHandlers.AddPodAdmitHandler(lifecycle.NewProcMountAdmitHandler(klet.containerRuntime))
 
-	klet.nodeLeaseController = nodelease.NewController(klet.clock, klet.heartbeatClient, string(klet.nodeName), kubeCfg.NodeLeaseDurationSeconds, klet.onRepeatedHeartbeatFailure)
+	leaseClient := klet.heartbeatClient.CoordinationV1().Leases(v1.NamespaceNodeLease)
+	nodeClient := klet.heartbeatClient.CoreV1().Nodes()
+	klet.nodeLeaseController = nodelease.NewController(klet.clock, nodeClient, leaseClient, string(klet.nodeName), kubeCfg.NodeLeaseDurationSeconds, klet.onRepeatedHeartbeatFailure)
 
 	// Finally, put the most recent version of the config on the Kubelet, so
 	// people can see how it was configured.


### PR DESCRIPTION
This changes the interface for the nodelease controller for initialization,
in that it makes it so that you can initialize it without having to have
an entire clientset.

This is handy in situations where you want to use this controller outside
of Kubernetes (we specifically want to use it in virtual-kubelet).


**What type of PR is this?**

/kind cleanup
/release-note-none

**What this PR does / why we need it**:
It changes the API to initialize the nodelease controller from the kubelet to pass the nodes and lease clients directly, as opposed to the entire clientset. This makes it a little bit easier to use elsewhere, and reduces the (external) testing surface area. 
