### PR TITLE
fix duplicate testcase names in TestValidateCachedClient

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/testing/testcase.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/testing/testcase.go
@@ -1006,7 +1006,7 @@ func NewCachedClientTestcases(url *url.URL) []CachedTest {
 			ExpectCacheMiss: true,
 		},
 		{
-			Name: "cached: service webhook, path 'allow'",
+			Name: "cached: url webhook, path 'allow'",
 			Webhooks: []registrationv1.ValidatingWebhook{{
 				Name:                    "cache5",
 				ClientConfig:            ccfgURL("allow"),


### PR DESCRIPTION
/kind cleanup

The two testcases [L981](https://github.com/kubernetes/kubernetes/blob/2aa1cd25f373912cfd27d59ca8f099f81a275868/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/testing/testcase.go#L981) and [L1009](https://github.com/kubernetes/kubernetes/blob/2aa1cd25f373912cfd27d59ca8f099f81a275868/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/testing/testcase.go#L1009) share the same name, which makes test failure like [this one](https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/periodic-kubernetes-bazel-test-master/1304705789046296577) confusing (ref https://github.com/kubernetes/kubernetes/issues/94810). L1009 should be named `url webhook`, according to its ClientConfig type. 

```release-note
NONE
```

/sig api-machinery