### PR TITLE
test(kubelet): deflake TestRotateShutsDownConnections

### DIFF
--- a/pkg/kubelet/certificate/BUILD
+++ b/pkg/kubelet/certificate/BUILD
@@ -42,6 +42,7 @@ go_test(
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/typed/certificates/v1beta1:go_default_library",
         "//staging/src/k8s.io/client-go/rest:go_default_library",
     ],


### PR DESCRIPTION
Signed-off-by: knight42 <anonymousknight96@gmail.com>

**What type of PR is this?**

/kind flake

**What this PR does / why we need it**:

https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/periodic-kubernetes-bazel-test-master/1305407411762237441
```
=== RUN   TestRotateShutsDownConnections
    transport_test.go:220: certificate rotated but client never reconnected with new cert
--- FAIL: TestRotateShutsDownConnections (0.08s)
FAIL
```

I added the folloing debugging:
```patch
diff --git pkg/kubelet/certificate/transport.go pkg/kubelet/certificate/transport.go
index d19c4ecbcec..b489a7b2426 100644
--- pkg/kubelet/certificate/transport.go
+++ pkg/kubelet/certificate/transport.go
@@ -97,6 +97,7 @@ func addCertRotation(stopCh <-chan struct{}, period time.Duration, clientConfig
 	lastCertAvailable := time.Now()
 	lastCert := clientCertificateManager.Current()
 	go wait.Until(func() {
+		fmt.Println("Try rotating cert")
 		curr := clientCertificateManager.Current()
 
 		if exitAfter > 0 {
@@ -125,11 +126,12 @@ func addCertRotation(stopCh <-chan struct{}, period time.Duration, clientConfig
 
 		if curr == nil || lastCert == curr {
 			// Cert hasn't been rotated.
+			fmt.Println("Not rotated")
 			return
 		}
 		lastCert = curr
 
-		klog.Infof("certificate rotation detected, shutting down client connections to start using new credentials")
+		fmt.Println("certificate rotation detected, shutting down client connections to start using new credentials")
 		// The cert has been rotated. Close all existing connections to force the client
 		// to reperform its TLS handshake with new cert.
 		//
```
and got:
```
=== RUN   TestRotateShutsDownConnections
Try rotating cert
Not rotated
Try rotating cert
Not rotated
Try rotating cert
Not rotated
Try rotating cert
    transport_test.go:220: certificate rotated but client never reconnected with new cert
--- FAIL: TestRotateShutsDownConnections (0.15s)
FAIL
```

looks like the current timeout is too tight, it might be better to increase the timeout.

**Which issue(s) this PR fixes**:

Part of #94528

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
