### PR TITLE
fix: detach azure disk broken on Azure Stack

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_controller_standard.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_controller_standard.go
@@ -141,7 +141,11 @@ func (as *availabilitySet) DetachDisk(diskName, diskURI string, nodeName types.N
 			(disk.ManagedDisk != nil && diskURI != "" && strings.EqualFold(*disk.ManagedDisk.ID, diskURI)) {
 			// found the disk
 			klog.V(2).Infof("azureDisk - detach disk: name %q uri %q", diskName, diskURI)
-			disks[i].ToBeDetached = to.BoolPtr(true)
+			if strings.EqualFold(as.cloud.Environment.Name, "AZURESTACKCLOUD") {
+				disks = append(disks[:i], disks[i+1:]...)
+			} else {
+				disks[i].ToBeDetached = to.BoolPtr(true)
+			}
 			bFoundDisk = true
 			break
 		}

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_controller_vmss.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_controller_vmss.go
@@ -143,7 +143,11 @@ func (ss *scaleSet) DetachDisk(diskName, diskURI string, nodeName types.NodeName
 			(disk.ManagedDisk != nil && diskURI != "" && strings.EqualFold(*disk.ManagedDisk.ID, diskURI)) {
 			// found the disk
 			klog.V(2).Infof("azureDisk - detach disk: name %q uri %q", diskName, diskURI)
-			disks[i].ToBeDetached = to.BoolPtr(true)
+			if strings.EqualFold(ss.cloud.Environment.Name, "AZURESTACKCLOUD") {
+				disks = append(disks[:i], disks[i+1:]...)
+			} else {
+				disks[i].ToBeDetached = to.BoolPtr(true)
+			}
 			bFoundDisk = true
 			break
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
fix: detach azure disk broken on Azure Stack
`toBeDetached` flag is not supported on Azure Stack, should switch to use original way to remove a disk from data disk list

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #94886

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
fix: detach azure disk broken on Azure Stack
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
fix: detach azure disk broken on Azure Stack
```

/kind bug
/assign @feiskyer 
/priority important-soon
/sig cloud-provider
/area provider/azure