### PR TITLE
apiextensions: prune array type without items in published OpenAPI

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/openapi/v2/BUILD
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/openapi/v2/BUILD
@@ -24,6 +24,7 @@ go_test(
         "//vendor/github.com/googleapis/gnostic/openapiv2:go_default_library",
         "//vendor/gopkg.in/yaml.v2:go_default_library",
         "//vendor/k8s.io/kube-openapi/pkg/util/proto:go_default_library",
+        "//vendor/k8s.io/utils/pointer:go_default_library",
     ],
 )
 

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/openapi/v2/conversion.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/openapi/v2/conversion.go
@@ -73,6 +73,14 @@ func ToStructuralOpenAPIV2(in *structuralschema.Structural) *structuralschema.St
 				changed = true
 			}
 
+			if s.Items == nil && s.Type == "array" {
+				// kubectl cannot cope with array without item schema, e.g. due to XPreserveUnknownFields case above
+				// https://github.com/kubernetes/kube-openapi/blob/64514a1d5d596b96e6f957e2be275ae14d6b0804/pkg/util/proto/document.go#L185
+				s.Type = ""
+
+				changed = true
+			}
+
 			for f, fs := range s.Properties {
 				if fs.Nullable {
 					s.ValueValidation.Required, changed = filterOut(s.ValueValidation.Required, f)


### PR DESCRIPTION
kubectl falls over arrays without item schema. Hence, we have to publish a less precise OpenAPI spec (similar to other pruning we already do for the same reason).

Without this kubectl will show e.g.

```
error: SchemaError(io.openshift.tuned.v1.Tuned.spec.recommend.match.match): array should have exactly one sub-item
```

for the following schema in a CRD:

```yaml
type: array
x-kubernetes-preserve-unknown-fields: true
items:
  type: string
```

/kind bug

```release-note
Fix regression in kubectl validation in 1.18+ on CRDs with schema using x-kubernetes-preserve-unknown-fields on array types.
```