### PR TITLE
volume: Change owner of symlinks too

### DIFF
--- a/pkg/volume/volume_linux.go
+++ b/pkg/volume/volume_linux.go
@@ -89,30 +89,20 @@ func legacyOwnershipChange(mounter Mounter, fsGroup *int64) error {
 }
 
 func changeFilePermission(filename string, fsGroup *int64, readonly bool, info os.FileInfo) error {
-	// chown and chmod pass through to the underlying file for symlinks.
+	err := os.Lchown(filename, -1, int(*fsGroup))
+	if err != nil {
+		klog.Errorf("Lchown failed on %v: %v", filename, err)
+	}
+
+	// chmod passes through to the underlying file for symlinks.
 	// Symlinks have a mode of 777 but this really doesn't mean anything.
 	// The permissions of the underlying file are what matter.
 	// However, if one reads the mode of a symlink then chmods the symlink
 	// with that mode, it changes the mode of the underlying file, overridden
 	// the defaultMode and permissions initialized by the volume plugin, which
-	// is not what we want; thus, we skip chown/chmod for symlinks.
+	// is not what we want; thus, we skip chmod for symlinks.
 	if info.Mode()&os.ModeSymlink != 0 {
 		return nil
-	}
-
-	stat, ok := info.Sys().(*syscall.Stat_t)
-	if !ok {
-		return nil
-	}
-
-	if stat == nil {
-		klog.Errorf("Got nil stat_t for path %v while setting ownership of volume", filename)
-		return nil
-	}
-
-	err := os.Chown(filename, int(stat.Uid), int(*fsGroup))
-	if err != nil {
-		klog.Errorf("Chown failed on %v: %v", filename, err)
 	}
 
 	mask := rwMask


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
This commit uses Lchown instead of Chown to change the owner of symlinks too.
It doesn't change any behaviour. However, it could avoid some confusions as the
symlinks are updated to the correct owner too.

Please consider the following Pod with a configMap:
```
apiVersion: v1
kind: ConfigMap
metadata:
  name: myconfigmap
  namespace: default
data:
  content: '"This is a ConfigMap"'
---
apiVersion: v1
kind: Pod
metadata:
  name: mypod
spec:
  securityContext:
    fsGroup: 2000
  containers:
  - name: container1
    image: busybox
    command: ["sh"]
    args: ["-c", "sleep infinity"]
    volumeMounts:
    - name: config-volume
      mountPath: /etc/configmap/content
  volumes:
  - name: config-volume
    configMap:
      name: myconfigmap
      defaultMode: 0400
```

The current behaviour shows that the group owner is `0` for the symlink point to the real content file:
```
$ kubectl exec -it mypod -- /bin/sh -c 'ls -la /etc/configmap/content/content'
lrwxrwxrwx    1 0     0            14 Sep 18 15:15 /etc/configmap/content/content -> ..data/content
```

The behaviour after this PR shows as group owner `2000` as specified in `fsGroup`:
```
kubectl exec -it mypod -- /bin/sh -c 'ls -la /etc/configmap/content/content'
lrwxrwxrwx    1 0     2000            14 Sep 18 15:15 /etc/configmap/content/content -> ..data/content
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
