### PR TITLE
Automated cherry pick of #94853: fix azure file migration panic

### DIFF
--- a/staging/src/k8s.io/csi-translation-lib/plugins/azure_file.go
+++ b/staging/src/k8s.io/csi-translation-lib/plugins/azure_file.go
@@ -119,8 +119,10 @@ func (t *azureFileCSITranslator) TranslateInTreePVToCSI(pv *v1.PersistentVolume)
 		accountName = azureSource.SecretName
 	}
 	resourceGroup := ""
-	if v, ok := pv.ObjectMeta.Annotations[resourceGroupAnnotation]; ok {
-		resourceGroup = v
+	if pv.ObjectMeta.Annotations != nil {
+		if v, ok := pv.ObjectMeta.Annotations[resourceGroupAnnotation]; ok {
+			resourceGroup = v
+		}
 	}
 	volumeID := fmt.Sprintf(volumeIDTemplate, resourceGroup, accountName, azureSource.ShareName, "")
 
@@ -183,6 +185,9 @@ func (t *azureFileCSITranslator) TranslateCSIPVToInTree(pv *v1.PersistentVolume)
 	pv.Spec.CSI = nil
 	pv.Spec.AzureFile = azureSource
 	if resourceGroup != "" {
+		if pv.ObjectMeta.Annotations == nil {
+			pv.ObjectMeta.Annotations = map[string]string{}
+		}
 		pv.ObjectMeta.Annotations[resourceGroupAnnotation] = resourceGroup
 	}
 


### PR DESCRIPTION
Cherry pick of #94853 on release-1.19.

#94853: fix azure file migration panic

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.