### PR TITLE
[WIP] Raise error if the user has multiple contexts but no current set

### DIFF
--- a/staging/src/k8s.io/client-go/tools/clientcmd/loader.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/loader.go
@@ -244,6 +244,9 @@ func (rules *ClientConfigLoadingRules) Load() (*clientcmdapi.Config, error) {
 	mergo.MergeWithOverwrite(config, mapConfig)
 	mergo.MergeWithOverwrite(config, nonMapConfig)
 
+	if (len(config.Contexts) > 1 && config.CurrentContext == "") {
+		errlist = append(errlist, ErrNoContextSet)
+	}
 	if rules.ResolvePaths() {
 		if err := ResolveLocalPaths(config); err != nil {
 			errlist = append(errlist, err)

--- a/staging/src/k8s.io/client-go/tools/clientcmd/validation.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/validation.go
@@ -29,8 +29,9 @@ import (
 )
 
 var (
-	ErrNoContext   = errors.New("no context chosen")
-	ErrEmptyConfig = NewEmptyConfigError("no configuration has been provided, try setting KUBERNETES_MASTER environment variable")
+	ErrNoContext    = errors.New("no context chosen")
+	ErrNoContextSet = errors.New("Multiple contexts found. However, no current-context is set in the configuration")
+	ErrEmptyConfig  = NewEmptyConfigError("no configuration has been provided, try setting KUBERNETES_MASTER environment variable")
 	// message is for consistency with old behavior
 	ErrEmptyCluster = errors.New("cluster has no server defined")
 )

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/create_authinfo.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/create_authinfo.go
@@ -200,7 +200,7 @@ func (o createAuthInfoOptions) run() error {
 	authInfo := o.modifyAuthInfo(*startingStanza)
 	config.AuthInfos[o.name] = &authInfo
 
-	if err := clientcmd.ModifyConfig(o.configAccess, *config, true); err != nil {
+	if err := clientcmd.ModifyConfig(o.configAccess, *config, true, false); err != nil {
 		return err
 	}
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/create_cluster.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/create_cluster.go
@@ -112,7 +112,7 @@ func (o createClusterOptions) run() error {
 	cluster := o.modifyCluster(*startingStanza)
 	config.Clusters[o.name] = &cluster
 
-	if err := clientcmd.ModifyConfig(o.configAccess, *config, true); err != nil {
+	if err := clientcmd.ModifyConfig(o.configAccess, *config, true, false); err != nil {
 		return err
 	}
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/create_context.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/create_context.go
@@ -107,7 +107,7 @@ func (o createContextOptions) run() (string, bool, error) {
 	context := o.modifyContext(*startingStanza)
 	config.Contexts[name] = &context
 
-	if err := clientcmd.ModifyConfig(o.configAccess, *config, true); err != nil {
+	if err := clientcmd.ModifyConfig(o.configAccess, *config, true, false); err != nil {
 		return name, exists, err
 	}
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/delete_cluster.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/delete_cluster.go
@@ -74,7 +74,7 @@ func runDeleteCluster(out io.Writer, configAccess clientcmd.ConfigAccess, cmd *c
 
 	delete(config.Clusters, name)
 
-	if err := clientcmd.ModifyConfig(configAccess, *config, true); err != nil {
+	if err := clientcmd.ModifyConfig(configAccess, *config, true, false); err != nil {
 		return err
 	}
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/delete_context.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/delete_context.go
@@ -78,7 +78,7 @@ func runDeleteContext(out, errOut io.Writer, configAccess clientcmd.ConfigAccess
 
 	delete(config.Contexts, name)
 
-	if err := clientcmd.ModifyConfig(configAccess, *config, true); err != nil {
+	if err := clientcmd.ModifyConfig(configAccess, *config, true, false); err != nil {
 		return err
 	}
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/get_contexts.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/get_contexts.go
@@ -17,6 +17,7 @@ limitations under the License.
 package config
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"sort"
@@ -111,7 +112,7 @@ func (o *GetContextsOptions) Complete(cmd *cobra.Command, args []string) error {
 // RunGetContexts implements all the necessary functionality for context retrieval.
 func (o GetContextsOptions) RunGetContexts() error {
 	config, err := o.configAccess.GetStartingConfig()
-	if err != nil {
+	if err != nil && !errors.Is(err, clientcmd.ErrNoContextSet){
 		return err
 	}
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/rename_context.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/rename_context.go
@@ -123,7 +123,7 @@ func (o RenameContextOptions) RunRenameContext(out io.Writer) error {
 		config.CurrentContext = o.newName
 	}
 
-	if err := clientcmd.ModifyConfig(o.configAccess, *config, true); err != nil {
+	if err := clientcmd.ModifyConfig(o.configAccess, *config, true, false); err != nil {
 		return err
 	}
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/set.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/set.go
@@ -111,7 +111,7 @@ func (o setOptions) run() error {
 		return err
 	}
 
-	if err := clientcmd.ModifyConfig(o.configAccess, *config, false); err != nil {
+	if err := clientcmd.ModifyConfig(o.configAccess, *config, false, false); err != nil {
 		return err
 	}
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/unset.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/unset.go
@@ -89,7 +89,7 @@ func (o unsetOptions) run(out io.Writer) error {
 		return err
 	}
 
-	if err := clientcmd.ModifyConfig(o.configAccess, *config, false); err != nil {
+	if err := clientcmd.ModifyConfig(o.configAccess, *config, false, false); err != nil {
 		return err
 	}
 	if _, err := fmt.Fprintf(out, "Property %q unset.\n", o.propertyName); err != nil {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/use_context.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/use_context.go
@@ -64,7 +64,7 @@ func NewCmdConfigUseContext(out io.Writer, configAccess clientcmd.ConfigAccess) 
 
 func (o useContextOptions) run() error {
 	config, err := o.configAccess.GetStartingConfig()
-	if err != nil {
+	if err != nil && !errors.Is(err, clientcmd.ErrNoContextSet){
 		return err
 	}
 
@@ -75,7 +75,7 @@ func (o useContextOptions) run() error {
 
 	config.CurrentContext = o.contextName
 
-	return clientcmd.ModifyConfig(o.configAccess, *config, true)
+	return clientcmd.ModifyConfig(o.configAccess, *config, true, true)
 }
 
 func (o *useContextOptions) complete(cmd *cobra.Command) error {


### PR DESCRIPTION
The current behavior is to ignore this and try to connect to `localhost:8080`.
[This is quite confusing, as reported in this issue][1].

This commit improves the UX by telling the users they need to explicitly choose a context, if there are multiple contexts:

```
$ kubectl get pods
error: Multiple contexts found. However, no current-context is set in the configuration
```

[1]: https://github.com/kubernetes/kubectl/issues/936

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This is an attept to improve a confusing error message. Please see the issue linked.

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes/kubectl/issues/936

**Special notes for your reviewer**:

I am aware that this PR is still missing test cases. However, I'm publishing this to solicit feedback, and I do not expect this to be merged at this state for the reasons explained below.
With the current patch, if you have not set a context, you see a clear error message. However, you can now only use an editor to fix the issue. That is because this patch disables the ability to use `kubeconfig config set-context`.
```
$ ./kubectl config use-context foo
error: Multiple contexts found. However, no current-context is set in the configuration
```
Users who are a bit familiar with the shell can circumvent the problem:
```
$ echo "current-context: foo" >> ~/.kube/config
```

IMHO, this would be a better interface to exclude the `config` sub-command from producing this error. There are two possible solutions I could think of:
1. Pass the sub-command to the config validator. 
2. Check for the number of contexts in each individual command, e.g. modify all entry points in `kubernetes/vendor/k8s.io/kubectl/pkg/cmd`.

I haven't implemented any yet. It's quite obvious that both approaches make the PR significantly larger. The latter approach makes even larger than the former approach.

Maybe there is another way I have not thought of or not aware of?
I would be happy to get some feedback.

In any case, once I know which approach is preferred I will add the required changes and include tests.

**Does this PR introduce a user-facing change?**:

```release-note
kubectl will now raise an error if the user has multiple contexts but no current set.
Previously, it simply tried to connect to localhost:8080.
```


