### PR TITLE
Verify pod termination with E2E PreStop hook

### DIFF
--- a/test/e2e/node/pre_stop.go
+++ b/test/e2e/node/pre_stop.go
@@ -187,10 +187,11 @@ var _ = SIGDescribe("PreStop", func() {
 		err = podClient.Delete(context.TODO(), pod.Name, *metav1.NewDeleteOptions(gracefulTerminationPeriodSeconds))
 		framework.ExpectNoError(err, "failed to delete pod")
 
-		//wait up to graceful termination period seconds
-		time.Sleep(30 * time.Second)
+		// wait for less than the gracePeriod termination ensuring the
+		// preStop hook is still executing.
+		time.Sleep(15 * time.Second)
 
-		ginkgo.By("verifying the pod running state after graceful termination")
+		ginkgo.By("verifying the pod is running while in the graceful period termination")
 		result := &v1.PodList{}
 		err = wait.Poll(time.Second*5, time.Second*60, func() (bool, error) {
 			client, err := e2ekubelet.ProxyRequest(f.ClientSet, pod.Spec.NodeName, "pods", ports.KubeletPort)


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
/kind flake
/sig node
/sig testing

**What this PR does / why we need it**:

This PR de-flaky the PreStop E2E node test by reducing the wait time period for checking the preStop hook test is being executed.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Related #94918

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
