### PR TITLE
Automated cherry pick of #90227: kubectl: fix the Scheduled eventTime is <unknown> when use

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/describe/versioned/describe.go
+++ b/staging/src/k8s.io/kubectl/pkg/describe/versioned/describe.go
@@ -3552,6 +3552,9 @@ func DescribeEvents(el *corev1.EventList, w PrefixWriter) {
 			interval = fmt.Sprintf("%s (x%d over %s)", translateTimestampSince(e.LastTimestamp), e.Count, translateTimestampSince(e.FirstTimestamp))
 		} else {
 			interval = translateTimestampSince(e.FirstTimestamp)
+			if e.FirstTimestamp.IsZero() {
+				interval = translateMicroTimestampSince(e.EventTime)
+			}
 		}
 		w.Write(LEVEL_1, "%v\t%v\t%s\t%v\t%v\n",
 			e.Type,
@@ -4617,6 +4620,16 @@ func shorten(s string, maxLength int) string {
 		return s[:maxLength] + "..."
 	}
 	return s
+}
+
+// translateMicroTimestampSince returns the elapsed time since timestamp in
+// human-readable approximation.
+func translateMicroTimestampSince(timestamp metav1.MicroTime) string {
+	if timestamp.IsZero() {
+		return "<unknown>"
+	}
+
+	return duration.HumanDuration(time.Since(timestamp.Time))
 }
 
 // translateTimestampSince returns the elapsed time since timestamp in


### PR DESCRIPTION
Cherry pick of #90227 on release-1.17.

#90227: kubectl: fix the Scheduled eventTime is <unknown> when use

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.