### PR TITLE
Graduate kubeadm alpha certs command

### DIFF
--- a/cmd/kubeadm/app/cmd/alpha/alpha.go
+++ b/cmd/kubeadm/app/cmd/alpha/alpha.go
@@ -29,9 +29,24 @@ func NewCmdAlpha(in io.Reader, out io.Writer) *cobra.Command {
 		Short: "Kubeadm experimental sub-commands",
 	}
 
-	cmd.AddCommand(newCmdCertsUtility(out))
 	cmd.AddCommand(newCmdKubeConfigUtility(out))
 	cmd.AddCommand(NewCmdSelfhosting(in))
 
+	certsCommand := NewCmdCertsUtility(out)
+	deprecateCertsCommand(certsCommand)
+	cmd.AddCommand(certsCommand)
+
 	return cmd
+}
+
+func deprecateCertsCommand(cmds ...*cobra.Command) {
+	const deprecatedMessage = "please use the same command under \"kubeadm certs\""
+
+	for _, cmd := range cmds {
+		cmd.Deprecated = deprecatedMessage
+		childCmds := cmd.Commands()
+		if len(childCmds) > 0 {
+			deprecateCertsCommand(childCmds...)
+		}
+	}
 }

--- a/cmd/kubeadm/app/cmd/alpha/certs.go
+++ b/cmd/kubeadm/app/cmd/alpha/certs.go
@@ -90,8 +90,8 @@ var (
 `)
 )
 
-// newCmdCertsUtility returns main command for certs phase
-func newCmdCertsUtility(out io.Writer) *cobra.Command {
+// NewCmdCertsUtility returns main command for certs phase
+func NewCmdCertsUtility(out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "certs",
 		Aliases: []string{"certificates"},

--- a/cmd/kubeadm/app/cmd/cmd.go
+++ b/cmd/kubeadm/app/cmd/cmd.go
@@ -90,8 +90,11 @@ func NewKubeadmCommand(in io.Reader, out, err io.Writer) *cobra.Command {
 	cmds.AddCommand(NewCmdToken(out, err))
 	cmds.AddCommand(upgrade.NewCmdUpgrade(out))
 	cmds.AddCommand(alpha.NewCmdAlpha(in, out))
-
 	options.AddKubeadmOtherFlags(cmds.PersistentFlags(), &rootfsPath)
+
+	// TODO: remove "certs" from "alpha"
+	// https://github.com/kubernetes/kubeadm/issues/2291
+	cmds.AddCommand(alpha.NewCmdCertsUtility(out))
 
 	return cmds
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind feature
/kind deprecation

**What this PR does / why we need it**:
Graduates kubeadm alpha certs to kubeadm certs

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
https://github.com/kubernetes/kubeadm/issues/2291

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
action required: kubeadm: graduate the "kubeadm alpha certs" command to a parent command "kubeadm certs". The command "kubeadm alpha certs" is deprecated and will be removed in a future release. Please migrate.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
