### PR TITLE
Automated cherry pick of #94666: Handle nil elements when sorting, instead of panicking

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/get/sorter.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/get/sorter.go
@@ -206,6 +206,13 @@ func isLess(i, j reflect.Value) (bool, error) {
 		return true, nil
 
 	case reflect.Interface:
+		if i.IsNil() && j.IsNil() {
+			return false, nil
+		} else if i.IsNil() {
+			return true, nil
+		} else if j.IsNil() {
+			return false, nil
+		}
 		switch itype := i.Interface().(type) {
 		case uint8:
 			if jtype, ok := j.Interface().(uint8); ok {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/get/sorter_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/get/sorter_test.go
@@ -409,6 +409,32 @@ func TestSortingPrinter(t *testing.T) {
 			field:       "{.invalid}",
 			expectedErr: "couldn't find any field with path \"{.invalid}\" in the list of objects",
 		},
+		{
+			name: "empty fields",
+			obj: &corev1.EventList{
+				Items: []corev1.Event{
+					{
+						ObjectMeta:    metav1.ObjectMeta{CreationTimestamp: metav1.Unix(300, 0)},
+						LastTimestamp: metav1.Unix(300, 0),
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{CreationTimestamp: metav1.Unix(200, 0)},
+					},
+				},
+			},
+			sort: &corev1.EventList{
+				Items: []corev1.Event{
+					{
+						ObjectMeta: metav1.ObjectMeta{CreationTimestamp: metav1.Unix(200, 0)},
+					},
+					{
+						ObjectMeta:    metav1.ObjectMeta{CreationTimestamp: metav1.Unix(300, 0)},
+						LastTimestamp: metav1.Unix(300, 0),
+					},
+				},
+			},
+			field: "{.lastTimestamp}",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name+" table", func(t *testing.T) {


### PR DESCRIPTION
Cherry pick of #94666 on release-1.18.

#94666: Handle nil elements when sorting, instead of panicking

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.