### PR TITLE
Automated cherry pick of #94730: Ensuring EndpointSlices are recreated after Service

### DIFF
--- a/pkg/controller/endpointslice/utils.go
+++ b/pkg/controller/endpointslice/utils.go
@@ -201,6 +201,17 @@ func objectRefPtrChanged(ref1, ref2 *corev1.ObjectReference) bool {
 	return false
 }
 
+// ownedBy returns true if the provided EndpointSlice is owned by the provided
+// Service.
+func ownedBy(endpointSlice *discovery.EndpointSlice, svc *corev1.Service) bool {
+	for _, o := range endpointSlice.OwnerReferences {
+		if o.UID == svc.UID && o.Kind == "Service" && o.APIVersion == "v1" {
+			return true
+		}
+	}
+	return false
+}
+
 // getSliceToFill will return the EndpointSlice that will be closest to full
 // when numEndpoints are added. If no EndpointSlice can be found, a nil pointer
 // will be returned.


### PR DESCRIPTION
Cherry pick of #94730 on release-1.19.

#94730: Ensuring EndpointSlices are recreated after Service

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Fixes a regression in 1.19 where EndpointSlices would not be recreated after rapid Service recreation.
```