### PR TITLE
Fix empty package license generation

### DIFF
--- a/hack/update-vendor-licenses.sh
+++ b/hack/update-vendor-licenses.sh
@@ -197,18 +197,24 @@ for PACKAGE in $(go list -m -json all | jq -r .Path | sort -f); do
     continue
   fi
   # Skip a directory if 1) it has no files and 2) all the subdirectories contain a go.mod file.
-  if [[ -z "$(find "${DEPS_DIR}/${PACKAGE}/" -mindepth 1 -maxdepth 1 -type f)" ]]; then
-      misses_go_mod=false
+  misses_go_mod=false
+  DEPS_SUBDIR="${DEPS_DIR}/${PACKAGE}"
+  search_for_mods () {
+    if [[ -z "$(find "${DEPS_SUBDIR}/" -mindepth 1 -maxdepth 1 -type f)" ]]; then
       while read -d "" -r SUBDIR; do
           if [[ ! -e "${SUBDIR}/go.mod" ]]; then
-              misses_go_mod=true
-              break
+              DEPS_SUBDIR=${SUBDIR}
+              search_for_mods
           fi
-      done < <(find "${DEPS_DIR}/${PACKAGE}/" -mindepth 1 -maxdepth 1 -type d -print0)
-      if [[ $misses_go_mod = false ]]; then
-          echo "${PACKAGE} has no files, skipping" >&2
-          continue
-      fi
+      done < <(find "${DEPS_SUBDIR}/" -mindepth 1 -maxdepth 1 -type d -print0)
+    else
+      misses_go_mod=true
+    fi
+  }
+  search_for_mods
+  if [[ $misses_go_mod = false ]]; then
+      echo "${PACKAGE} has no files, skipping" >&2
+      continue
   fi
   echo "${PACKAGE}"
 


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

We currently skip vendor packages that don't have go files, but where subdirectories do have a go.mod file.  For example,
Skip `github.com/foo/bar` if `github.com/foo/bar/baz/go.mod` exists.
However, the current logic will not allow skipping `github.com/foo/bar` if `github.com/foo/bar/baz/abc/go.mod` exists.

This PR extends the logic added in https://github.com/kubernetes/kubernetes/pull/91366 to support that case.

**Special notes for your reviewer**:

Found while working on https://github.com/kubernetes/kubernetes/pull/94942.
I want to use `go.opentelemetry.io/contrib/instrumentation/net/http`, and it added `go.opentelemetry.io/contrib` to go.mod as well, but didn't put any files in vendor.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/assign @liggitt @giuseppe 