### PR TITLE
fix kube-proxy cleanup / better missing iptables errors

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -35,7 +35,6 @@ import (
 
 	cadvisorapi "github.com/google/cadvisor/info/v1"
 	"k8s.io/mount-utils"
-	utilexec "k8s.io/utils/exec"
 	"k8s.io/utils/integer"
 	utilnet "k8s.io/utils/net"
 
@@ -111,7 +110,6 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/volumemanager"
 	"k8s.io/kubernetes/pkg/security/apparmor"
 	sysctlwhitelist "k8s.io/kubernetes/pkg/security/podsecuritypolicy/sysctl"
-	utilipt "k8s.io/kubernetes/pkg/util/iptables"
 	"k8s.io/kubernetes/pkg/util/oom"
 	"k8s.io/kubernetes/pkg/util/selinux"
 	"k8s.io/kubernetes/pkg/volume"
@@ -466,10 +464,8 @@ func NewMainKubelet(kubeCfg *kubeletconfiginternal.KubeletConfiguration,
 	}
 	httpClient := &http.Client{}
 	parsedNodeIP := net.ParseIP(nodeIP)
-	protocol := utilipt.ProtocolIPv4
 	if utilnet.IsIPv6(parsedNodeIP) {
 		klog.V(0).Infof("IPv6 node IP (%s), assume IPv6 operation", nodeIP)
-		protocol = utilipt.ProtocolIPv6
 	}
 
 	klet := &Kubelet{
@@ -518,7 +514,6 @@ func NewMainKubelet(kubeCfg *kubeletconfiginternal.KubeletConfiguration,
 		nodeIPValidator:                         validateNodeIP,
 		clock:                                   clock.RealClock{},
 		enableControllerAttachDetach:            kubeCfg.EnableControllerAttachDetach,
-		iptClient:                               utilipt.New(utilexec.New(), protocol),
 		makeIPTablesUtilChains:                  kubeCfg.MakeIPTablesUtilChains,
 		iptablesMasqueradeBit:                   int(kubeCfg.IPTablesMasqueradeBit),
 		iptablesDropBit:                         int(kubeCfg.IPTablesDropBit),
@@ -819,7 +814,6 @@ type Kubelet struct {
 	runtimeCache    kubecontainer.RuntimeCache
 	kubeClient      clientset.Interface
 	heartbeatClient clientset.Interface
-	iptClient       utilipt.Interface
 	rootDirectory   string
 
 	lastObservedNodeAddressesMux sync.RWMutex

--- a/pkg/kubelet/kubelet_network_linux.go
+++ b/pkg/kubelet/kubelet_network_linux.go
@@ -41,21 +41,6 @@ func (kl *Kubelet) initNetworkUtil() {
 // 2. 	In nat table, KUBE-MARK-MASQ rule to mark connections for SNAT
 // 	Marked connection will get SNAT on POSTROUTING Chain in nat table
 func (kl *Kubelet) syncNetworkUtil() {
-	if kl.iptablesMasqueradeBit < 0 || kl.iptablesMasqueradeBit > 31 {
-		klog.Errorf("invalid iptables-masquerade-bit %v not in [0, 31]", kl.iptablesMasqueradeBit)
-		return
-	}
-
-	if kl.iptablesDropBit < 0 || kl.iptablesDropBit > 31 {
-		klog.Errorf("invalid iptables-drop-bit %v not in [0, 31]", kl.iptablesDropBit)
-		return
-	}
-
-	if kl.iptablesDropBit == kl.iptablesMasqueradeBit {
-		klog.Errorf("iptables-masquerade-bit %v and iptables-drop-bit %v must be different", kl.iptablesMasqueradeBit, kl.iptablesDropBit)
-		return
-	}
-
 	// Setup KUBE-MARK-DROP rules
 	dropMark := getIPTablesMark(kl.iptablesDropBit)
 	if _, err := kl.iptClient.EnsureChain(utiliptables.TableNAT, KubeMarkDropChain); err != nil {

--- a/pkg/kubelet/kubelet_network_linux.go
+++ b/pkg/kubelet/kubelet_network_linux.go
@@ -25,13 +25,22 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
 	utiliptables "k8s.io/kubernetes/pkg/util/iptables"
+	utilexec "k8s.io/utils/exec"
+	utilnet "k8s.io/utils/net"
 )
 
 func (kl *Kubelet) initNetworkUtil() {
-	kl.syncNetworkUtil()
-	go kl.iptClient.Monitor(utiliptables.Chain("KUBE-KUBELET-CANARY"),
+	protocol := utiliptables.ProtocolIPv4
+	if utilnet.IsIPv6(kl.nodeIP) {
+		protocol = utiliptables.ProtocolIPv6
+	}
+	iptClient := utiliptables.New(utilexec.New(), protocol)
+
+	kl.syncNetworkUtil(iptClient)
+	go iptClient.Monitor(utiliptables.Chain("KUBE-KUBELET-CANARY"),
 		[]utiliptables.Table{utiliptables.TableMangle, utiliptables.TableNAT, utiliptables.TableFilter},
-		kl.syncNetworkUtil, 1*time.Minute, wait.NeverStop)
+		func() { kl.syncNetworkUtil(iptClient) },
+		1*time.Minute, wait.NeverStop)
 }
 
 // syncNetworkUtil ensures the network utility are present on host.
@@ -40,22 +49,22 @@ func (kl *Kubelet) initNetworkUtil() {
 // 	Marked connection will be drop on INPUT/OUTPUT Chain in filter table
 // 2. 	In nat table, KUBE-MARK-MASQ rule to mark connections for SNAT
 // 	Marked connection will get SNAT on POSTROUTING Chain in nat table
-func (kl *Kubelet) syncNetworkUtil() {
+func (kl *Kubelet) syncNetworkUtil(iptClient utiliptables.Interface) {
 	// Setup KUBE-MARK-DROP rules
 	dropMark := getIPTablesMark(kl.iptablesDropBit)
-	if _, err := kl.iptClient.EnsureChain(utiliptables.TableNAT, KubeMarkDropChain); err != nil {
+	if _, err := iptClient.EnsureChain(utiliptables.TableNAT, KubeMarkDropChain); err != nil {
 		klog.Errorf("Failed to ensure that %s chain %s exists: %v", utiliptables.TableNAT, KubeMarkDropChain, err)
 		return
 	}
-	if _, err := kl.iptClient.EnsureRule(utiliptables.Append, utiliptables.TableNAT, KubeMarkDropChain, "-j", "MARK", "--or-mark", dropMark); err != nil {
+	if _, err := iptClient.EnsureRule(utiliptables.Append, utiliptables.TableNAT, KubeMarkDropChain, "-j", "MARK", "--or-mark", dropMark); err != nil {
 		klog.Errorf("Failed to ensure marking rule for %v: %v", KubeMarkDropChain, err)
 		return
 	}
-	if _, err := kl.iptClient.EnsureChain(utiliptables.TableFilter, KubeFirewallChain); err != nil {
+	if _, err := iptClient.EnsureChain(utiliptables.TableFilter, KubeFirewallChain); err != nil {
 		klog.Errorf("Failed to ensure that %s chain %s exists: %v", utiliptables.TableFilter, KubeFirewallChain, err)
 		return
 	}
-	if _, err := kl.iptClient.EnsureRule(utiliptables.Append, utiliptables.TableFilter, KubeFirewallChain,
+	if _, err := iptClient.EnsureRule(utiliptables.Append, utiliptables.TableFilter, KubeFirewallChain,
 		"-m", "comment", "--comment", "kubernetes firewall for dropping marked packets",
 		"-m", "mark", "--mark", fmt.Sprintf("%s/%s", dropMark, dropMark),
 		"-j", "DROP"); err != nil {
@@ -65,8 +74,8 @@ func (kl *Kubelet) syncNetworkUtil() {
 
 	// drop all non-local packets to localhost if they're not part of an existing
 	// forwarded connection. See #90259
-	if !kl.iptClient.IsIPv6() { // ipv6 doesn't have this issue
-		if _, err := kl.iptClient.EnsureRule(utiliptables.Append, utiliptables.TableFilter, KubeFirewallChain,
+	if !iptClient.IsIPv6() { // ipv6 doesn't have this issue
+		if _, err := iptClient.EnsureRule(utiliptables.Append, utiliptables.TableFilter, KubeFirewallChain,
 			"-m", "comment", "--comment", "block incoming localnet connections",
 			"--dst", "127.0.0.0/8",
 			"!", "--src", "127.0.0.0/8",
@@ -78,30 +87,30 @@ func (kl *Kubelet) syncNetworkUtil() {
 		}
 	}
 
-	if _, err := kl.iptClient.EnsureRule(utiliptables.Prepend, utiliptables.TableFilter, utiliptables.ChainOutput, "-j", string(KubeFirewallChain)); err != nil {
+	if _, err := iptClient.EnsureRule(utiliptables.Prepend, utiliptables.TableFilter, utiliptables.ChainOutput, "-j", string(KubeFirewallChain)); err != nil {
 		klog.Errorf("Failed to ensure that %s chain %s jumps to %s: %v", utiliptables.TableFilter, utiliptables.ChainOutput, KubeFirewallChain, err)
 		return
 	}
-	if _, err := kl.iptClient.EnsureRule(utiliptables.Prepend, utiliptables.TableFilter, utiliptables.ChainInput, "-j", string(KubeFirewallChain)); err != nil {
+	if _, err := iptClient.EnsureRule(utiliptables.Prepend, utiliptables.TableFilter, utiliptables.ChainInput, "-j", string(KubeFirewallChain)); err != nil {
 		klog.Errorf("Failed to ensure that %s chain %s jumps to %s: %v", utiliptables.TableFilter, utiliptables.ChainInput, KubeFirewallChain, err)
 		return
 	}
 
 	// Setup KUBE-MARK-MASQ rules
 	masqueradeMark := getIPTablesMark(kl.iptablesMasqueradeBit)
-	if _, err := kl.iptClient.EnsureChain(utiliptables.TableNAT, KubeMarkMasqChain); err != nil {
+	if _, err := iptClient.EnsureChain(utiliptables.TableNAT, KubeMarkMasqChain); err != nil {
 		klog.Errorf("Failed to ensure that %s chain %s exists: %v", utiliptables.TableNAT, KubeMarkMasqChain, err)
 		return
 	}
-	if _, err := kl.iptClient.EnsureChain(utiliptables.TableNAT, KubePostroutingChain); err != nil {
+	if _, err := iptClient.EnsureChain(utiliptables.TableNAT, KubePostroutingChain); err != nil {
 		klog.Errorf("Failed to ensure that %s chain %s exists: %v", utiliptables.TableNAT, KubePostroutingChain, err)
 		return
 	}
-	if _, err := kl.iptClient.EnsureRule(utiliptables.Append, utiliptables.TableNAT, KubeMarkMasqChain, "-j", "MARK", "--or-mark", masqueradeMark); err != nil {
+	if _, err := iptClient.EnsureRule(utiliptables.Append, utiliptables.TableNAT, KubeMarkMasqChain, "-j", "MARK", "--or-mark", masqueradeMark); err != nil {
 		klog.Errorf("Failed to ensure marking rule for %v: %v", KubeMarkMasqChain, err)
 		return
 	}
-	if _, err := kl.iptClient.EnsureRule(utiliptables.Prepend, utiliptables.TableNAT, utiliptables.ChainPostrouting,
+	if _, err := iptClient.EnsureRule(utiliptables.Prepend, utiliptables.TableNAT, utiliptables.ChainPostrouting,
 		"-m", "comment", "--comment", "kubernetes postrouting rules", "-j", string(KubePostroutingChain)); err != nil {
 		klog.Errorf("Failed to ensure that %s chain %s jumps to %s: %v", utiliptables.TableNAT, utiliptables.ChainPostrouting, KubePostroutingChain, err)
 		return
@@ -110,7 +119,7 @@ func (kl *Kubelet) syncNetworkUtil() {
 	// Set up KUBE-POSTROUTING to unmark and masquerade marked packets
 	// NB: THIS MUST MATCH the corresponding code in the iptables and ipvs
 	// modes of kube-proxy
-	if _, err := kl.iptClient.EnsureRule(utiliptables.Append, utiliptables.TableNAT, KubePostroutingChain,
+	if _, err := iptClient.EnsureRule(utiliptables.Append, utiliptables.TableNAT, KubePostroutingChain,
 		"-m", "mark", "!", "--mark", fmt.Sprintf("%s/%s", masqueradeMark, masqueradeMark),
 		"-j", "RETURN"); err != nil {
 		klog.Errorf("Failed to ensure filtering rule for %v: %v", KubePostroutingChain, err)
@@ -119,7 +128,7 @@ func (kl *Kubelet) syncNetworkUtil() {
 	// Clear the mark to avoid re-masquerading if the packet re-traverses the network stack.
 	// We know the mark bit is currently set so we can use --xor-mark to clear it (without needing
 	// to Sprintf another bitmask).
-	if _, err := kl.iptClient.EnsureRule(utiliptables.Append, utiliptables.TableNAT, KubePostroutingChain,
+	if _, err := iptClient.EnsureRule(utiliptables.Append, utiliptables.TableNAT, KubePostroutingChain,
 		"-j", "MARK", "--xor-mark", masqueradeMark); err != nil {
 		klog.Errorf("Failed to ensure unmarking rule for %v: %v", KubePostroutingChain, err)
 		return
@@ -128,10 +137,10 @@ func (kl *Kubelet) syncNetworkUtil() {
 		"-m", "comment", "--comment", "kubernetes service traffic requiring SNAT",
 		"-j", "MASQUERADE",
 	}
-	if kl.iptClient.HasRandomFully() {
+	if iptClient.HasRandomFully() {
 		masqRule = append(masqRule, "--random-fully")
 	}
-	if _, err := kl.iptClient.EnsureRule(utiliptables.Append, utiliptables.TableNAT, KubePostroutingChain, masqRule...); err != nil {
+	if _, err := iptClient.EnsureRule(utiliptables.Append, utiliptables.TableNAT, KubePostroutingChain, masqRule...); err != nil {
 		klog.Errorf("Failed to ensure SNAT rule for packets marked by %v in %v chain %v: %v", KubeMarkMasqChain, utiliptables.TableNAT, KubePostroutingChain, err)
 		return
 	}

--- a/pkg/kubelet/kubelet_network_linux.go
+++ b/pkg/kubelet/kubelet_network_linux.go
@@ -34,7 +34,11 @@ func (kl *Kubelet) initNetworkUtil() {
 	if utilnet.IsIPv6(kl.nodeIP) {
 		protocol = utiliptables.ProtocolIPv6
 	}
-	iptClient := utiliptables.New(utilexec.New(), protocol)
+	iptClient, err := utiliptables.New(utilexec.New(), protocol)
+	if err != nil {
+		klog.Errorf("Could not initialize iptables chains for %s: %v", protocol, err)
+		return
+	}
 
 	kl.syncNetworkUtil(iptClient)
 	go iptClient.Monitor(utiliptables.Chain("KUBE-KUBELET-CANARY"),

--- a/pkg/util/iptables/iptables_test.go
+++ b/pkg/util/iptables/iptables_test.go
@@ -60,7 +60,7 @@ func testIPTablesVersionCmds(t *testing.T, protocol Protocol) {
 			func(cmd string, args ...string) exec.Cmd { return fakeexec.InitFakeCmd(&fcmd, cmd, args...) },
 		},
 	}
-	_ = New(&fexec, protocol)
+	_, _ = New(&fexec, protocol)
 
 	// Check that proper iptables version command was used during runner instantiation
 	if !sets.NewString(fcmd.CombinedOutputLog[0]...).HasAll(iptablesCmd, "--version") {
@@ -102,7 +102,7 @@ func testEnsureChain(t *testing.T, protocol Protocol) {
 			func(cmd string, args ...string) exec.Cmd { return fakeexec.InitFakeCmd(&fcmd, cmd, args...) },
 		},
 	}
-	runner := New(&fexec, protocol)
+	runner, _ := New(&fexec, protocol)
 	// Success.
 	exists, err := runner.EnsureChain(TableNAT, Chain("FOOBAR"))
 	if err != nil {
@@ -159,7 +159,7 @@ func TestFlushChain(t *testing.T) {
 			func(cmd string, args ...string) exec.Cmd { return fakeexec.InitFakeCmd(&fcmd, cmd, args...) },
 		},
 	}
-	runner := New(&fexec, ProtocolIPv4)
+	runner, _ := New(&fexec, ProtocolIPv4)
 	// Success.
 	err := runner.FlushChain(TableNAT, Chain("FOOBAR"))
 	if err != nil {
@@ -196,7 +196,7 @@ func TestDeleteChain(t *testing.T) {
 			func(cmd string, args ...string) exec.Cmd { return fakeexec.InitFakeCmd(&fcmd, cmd, args...) },
 		},
 	}
-	runner := New(&fexec, ProtocolIPv4)
+	runner, _ := New(&fexec, ProtocolIPv4)
 	// Success.
 	err := runner.DeleteChain(TableNAT, Chain("FOOBAR"))
 	if err != nil {
@@ -232,7 +232,7 @@ func TestEnsureRuleAlreadyExists(t *testing.T) {
 			func(cmd string, args ...string) exec.Cmd { return fakeexec.InitFakeCmd(&fcmd, cmd, args...) },
 		},
 	}
-	runner := New(&fexec, ProtocolIPv4)
+	runner, _ := New(&fexec, ProtocolIPv4)
 	exists, err := runner.EnsureRule(Append, TableNAT, ChainOutput, "abc", "123")
 	if err != nil {
 		t.Errorf("expected success, got %v", err)
@@ -268,7 +268,7 @@ func TestEnsureRuleNew(t *testing.T) {
 			func(cmd string, args ...string) exec.Cmd { return fakeexec.InitFakeCmd(&fcmd, cmd, args...) },
 		},
 	}
-	runner := New(&fexec, ProtocolIPv4)
+	runner, _ := New(&fexec, ProtocolIPv4)
 	exists, err := runner.EnsureRule(Append, TableNAT, ChainOutput, "abc", "123")
 	if err != nil {
 		t.Errorf("expected success, got %v", err)
@@ -301,7 +301,7 @@ func TestEnsureRuleErrorChecking(t *testing.T) {
 			func(cmd string, args ...string) exec.Cmd { return fakeexec.InitFakeCmd(&fcmd, cmd, args...) },
 		},
 	}
-	runner := New(&fexec, ProtocolIPv4)
+	runner, _ := New(&fexec, ProtocolIPv4)
 	_, err := runner.EnsureRule(Append, TableNAT, ChainOutput, "abc", "123")
 	if err == nil {
 		t.Errorf("expected failure")
@@ -331,7 +331,7 @@ func TestEnsureRuleErrorCreating(t *testing.T) {
 			func(cmd string, args ...string) exec.Cmd { return fakeexec.InitFakeCmd(&fcmd, cmd, args...) },
 		},
 	}
-	runner := New(&fexec, ProtocolIPv4)
+	runner, _ := New(&fexec, ProtocolIPv4)
 	_, err := runner.EnsureRule(Append, TableNAT, ChainOutput, "abc", "123")
 	if err == nil {
 		t.Errorf("expected failure")
@@ -358,7 +358,7 @@ func TestDeleteRuleDoesNotExist(t *testing.T) {
 			func(cmd string, args ...string) exec.Cmd { return fakeexec.InitFakeCmd(&fcmd, cmd, args...) },
 		},
 	}
-	runner := New(&fexec, ProtocolIPv4)
+	runner, _ := New(&fexec, ProtocolIPv4)
 	err := runner.DeleteRule(TableNAT, ChainOutput, "abc", "123")
 	if err != nil {
 		t.Errorf("expected success, got %v", err)
@@ -391,7 +391,7 @@ func TestDeleteRuleExists(t *testing.T) {
 			func(cmd string, args ...string) exec.Cmd { return fakeexec.InitFakeCmd(&fcmd, cmd, args...) },
 		},
 	}
-	runner := New(&fexec, ProtocolIPv4)
+	runner, _ := New(&fexec, ProtocolIPv4)
 	err := runner.DeleteRule(TableNAT, ChainOutput, "abc", "123")
 	if err != nil {
 		t.Errorf("expected success, got %v", err)
@@ -421,7 +421,7 @@ func TestDeleteRuleErrorChecking(t *testing.T) {
 			func(cmd string, args ...string) exec.Cmd { return fakeexec.InitFakeCmd(&fcmd, cmd, args...) },
 		},
 	}
-	runner := New(&fexec, ProtocolIPv4)
+	runner, _ := New(&fexec, ProtocolIPv4)
 	err := runner.DeleteRule(TableNAT, ChainOutput, "abc", "123")
 	if err == nil {
 		t.Errorf("expected failure")
@@ -451,7 +451,7 @@ func TestDeleteRuleErrorDeleting(t *testing.T) {
 			func(cmd string, args ...string) exec.Cmd { return fakeexec.InitFakeCmd(&fcmd, cmd, args...) },
 		},
 	}
-	runner := New(&fexec, ProtocolIPv4)
+	runner, _ := New(&fexec, ProtocolIPv4)
 	err := runner.DeleteRule(TableNAT, ChainOutput, "abc", "123")
 	if err == nil {
 		t.Errorf("expected failure")
@@ -486,11 +486,28 @@ func TestGetIPTablesHasCheckCommand(t *testing.T) {
 				func(cmd string, args ...string) exec.Cmd { return fakeexec.InitFakeCmd(&fcmd, cmd, args...) },
 			},
 		}
-		ipt := New(&fexec, ProtocolIPv4)
+		ipt, _ := New(&fexec, ProtocolIPv4)
 		runner := ipt.(*runner)
 		if testCase.Expected != runner.hasCheck {
 			t.Errorf("Expected result: %v, Got result: %v", testCase.Expected, runner.hasCheck)
 		}
+	}
+}
+
+func TestIPTablesNotAvailable(t *testing.T) {
+	fcmd := fakeexec.FakeCmd{
+		CombinedOutputScript: []fakeexec.FakeAction{
+			func() ([]byte, []byte, error) { return nil, nil, exec.ErrExecutableNotFound },
+		},
+	}
+	fexec := fakeexec.FakeExec{
+		CommandScript: []fakeexec.FakeCommandAction{
+			func(cmd string, args ...string) exec.Cmd { return fakeexec.InitFakeCmd(&fcmd, cmd, args...) },
+		},
+	}
+	_, err := New(&fexec, ProtocolIPv4)
+	if err == nil {
+		t.Errorf("New() succeeded despite missing iptables binary")
 	}
 }
 
@@ -647,7 +664,7 @@ func TestWaitFlagUnavailable(t *testing.T) {
 			func(cmd string, args ...string) exec.Cmd { return fakeexec.InitFakeCmd(&fcmd, cmd, args...) },
 		},
 	}
-	runner := New(&fexec, ProtocolIPv4)
+	runner, _ := New(&fexec, ProtocolIPv4)
 	err := runner.DeleteChain(TableNAT, Chain("FOOBAR"))
 	if err != nil {
 		t.Errorf("expected success, got %v", err)
@@ -678,7 +695,7 @@ func TestWaitFlagOld(t *testing.T) {
 			func(cmd string, args ...string) exec.Cmd { return fakeexec.InitFakeCmd(&fcmd, cmd, args...) },
 		},
 	}
-	runner := New(&fexec, ProtocolIPv4)
+	runner, _ := New(&fexec, ProtocolIPv4)
 	err := runner.DeleteChain(TableNAT, Chain("FOOBAR"))
 	if err != nil {
 		t.Errorf("expected success, got %v", err)
@@ -712,7 +729,7 @@ func TestWaitFlagNew(t *testing.T) {
 			func(cmd string, args ...string) exec.Cmd { return fakeexec.InitFakeCmd(&fcmd, cmd, args...) },
 		},
 	}
-	runner := New(&fexec, ProtocolIPv4)
+	runner, _ := New(&fexec, ProtocolIPv4)
 	err := runner.DeleteChain(TableNAT, Chain("FOOBAR"))
 	if err != nil {
 		t.Errorf("expected success, got %v", err)
@@ -743,7 +760,7 @@ func TestWaitIntervalFlagNew(t *testing.T) {
 			func(cmd string, args ...string) exec.Cmd { return fakeexec.InitFakeCmd(&fcmd, cmd, args...) },
 		},
 	}
-	runner := New(&fexec, ProtocolIPv4)
+	runner, _ := New(&fexec, ProtocolIPv4)
 	err := runner.DeleteChain(TableNAT, Chain("FOOBAR"))
 	if err != nil {
 		t.Errorf("expected success, got %v", err)
@@ -788,7 +805,7 @@ COMMIT
 			func(cmd string, args ...string) exec.Cmd { return fakeexec.InitFakeCmd(&fcmd, cmd, args...) },
 		},
 	}
-	runner := New(&fexec, protocol)
+	runner, _ := New(&fexec, protocol)
 	buffer := bytes.NewBuffer(nil)
 
 	// Success.
@@ -856,7 +873,7 @@ func testRestore(t *testing.T, protocol Protocol) {
 			func(cmd string, args ...string) exec.Cmd { return fakeexec.InitFakeCmd(&fcmd, cmd, args...) },
 		},
 	}
-	runner := New(&fexec, protocol)
+	runner, _ := New(&fexec, protocol)
 
 	// both flags true
 	err := runner.Restore(TableNAT, []byte{}, FlushTables, RestoreCounters)
@@ -939,7 +956,7 @@ func TestRestoreAll(t *testing.T) {
 		},
 	}
 	lockPath14x, lockPath16x := getLockPaths()
-	runner := newInternal(&fexec, ProtocolIPv4, lockPath14x, lockPath16x)
+	runner, _ := newInternal(&fexec, ProtocolIPv4, lockPath14x, lockPath16x)
 
 	err := runner.RestoreAll([]byte{}, NoFlushTables, RestoreCounters)
 	if err != nil {
@@ -980,7 +997,7 @@ func TestRestoreAllWait(t *testing.T) {
 		},
 	}
 	lockPath14x, lockPath16x := getLockPaths()
-	runner := newInternal(&fexec, ProtocolIPv4, lockPath14x, lockPath16x)
+	runner, _ := newInternal(&fexec, ProtocolIPv4, lockPath14x, lockPath16x)
 
 	err := runner.RestoreAll([]byte{}, NoFlushTables, RestoreCounters)
 	if err != nil {
@@ -1025,7 +1042,7 @@ func TestRestoreAllWaitOldIptablesRestore(t *testing.T) {
 		},
 	}
 	lockPath14x, lockPath16x := getLockPaths()
-	runner := newInternal(&fexec, ProtocolIPv4, lockPath14x, lockPath16x)
+	runner, _ := newInternal(&fexec, ProtocolIPv4, lockPath14x, lockPath16x)
 
 	err := runner.RestoreAll([]byte{}, NoFlushTables, RestoreCounters)
 	if err != nil {
@@ -1070,7 +1087,7 @@ func TestRestoreAllGrabNewLock(t *testing.T) {
 		},
 	}
 	lockPath14x, lockPath16x := getLockPaths()
-	runner := newInternal(&fexec, ProtocolIPv4, lockPath14x, lockPath16x)
+	runner, _ := newInternal(&fexec, ProtocolIPv4, lockPath14x, lockPath16x)
 
 	// Grab the /run lock and ensure the RestoreAll fails
 	runLock, err := os.OpenFile(lockPath16x, os.O_CREATE, 0600)
@@ -1111,7 +1128,7 @@ func TestRestoreAllGrabOldLock(t *testing.T) {
 		},
 	}
 	lockPath14x, lockPath16x := getLockPaths()
-	runner := newInternal(&fexec, ProtocolIPv4, lockPath14x, lockPath16x)
+	runner, _ := newInternal(&fexec, ProtocolIPv4, lockPath14x, lockPath16x)
 
 	var runLock *net.UnixListener
 	// Grab the abstract @xtables socket, will retry if the socket exists
@@ -1163,7 +1180,7 @@ func TestRestoreAllWaitBackportedIptablesRestore(t *testing.T) {
 		},
 	}
 	lockPath14x, lockPath16x := getLockPaths()
-	runner := newInternal(&fexec, ProtocolIPv4, lockPath14x, lockPath16x)
+	runner, _ := newInternal(&fexec, ProtocolIPv4, lockPath14x, lockPath16x)
 
 	err := runner.RestoreAll([]byte{}, NoFlushTables, RestoreCounters)
 	if err != nil {

--- a/pkg/util/iptables/monitor_test.go
+++ b/pkg/util/iptables/monitor_test.go
@@ -180,7 +180,7 @@ func (mfc *monitorFakeCmd) Stop() {
 
 func TestIPTablesMonitor(t *testing.T) {
 	mfe := newMonitorFakeExec()
-	ipt := New(mfe, ProtocolIPv4)
+	ipt, _ := New(mfe, ProtocolIPv4)
 
 	var reloads uint32
 	stopCh := make(chan struct{})


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Combines #94915 with part of #94474, to:
- Fix a regression in `kube-proxy --cleanup` where it now unnecessarily requires a kubeconfig
- Make `kube-proxy --cleanup` attempt to clean up both IPv4 and IPv6 kube-proxy rules
- Not give spurious errors if `ip6tables` is not installed when it doesn't _definitely_ need dual-stack support.

**Which issue(s) this PR fixes**:
Fixes #94914 

**Special notes for your reviewer**:
Follow-up from discussion on #94915, to handle clusters of unknown-dual-stack-ness better by explicitly noticing when `ip6tables` is unavailable. Reorganizing the commits in this way will allow this commit to be backported to 1.19 to fix the `kube-proxy --cleanup` regression there, without having to backport new kubelet dual-stack functionality, or causing spurious error messages.

**Does this PR introduce a user-facing change?**:
```release-note
Fixes a regression in `kube-proxy --cleanup` where it would sometimes no longer
work without access to a kubeconfig.
```

cc @Lion-Wei @aojea 