### PR TITLE
Add WithNamespace option to cli-runtime name printer

### DIFF
--- a/staging/src/k8s.io/cli-runtime/pkg/printers/BUILD
+++ b/staging/src/k8s.io/cli-runtime/pkg/printers/BUILD
@@ -39,6 +39,7 @@ go_test(
     srcs = [
         "json_test.go",
         "jsonpath_test.go",
+        "name_test.go",
         "sourcechecker_test.go",
         "tableprinter_test.go",
         "template_test.go",

--- a/staging/src/k8s.io/cli-runtime/pkg/printers/name.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/printers/name.go
@@ -40,7 +40,7 @@ type NamePrinter struct {
 	Operation string
 	// WithNamespace indicates whether a namespace should be
 	// printed along side the "resource/name" pair for an object.
-	// This flag effective useful when operations across all
+	// This flag is effective when operations across all
 	// namespace are done.
 	WithNamespace bool
 }

--- a/staging/src/k8s.io/cli-runtime/pkg/printers/name.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/printers/name.go
@@ -40,6 +40,8 @@ type NamePrinter struct {
 	Operation string
 	// WithNamespace indicates whether a namespace should be
 	// printed along side the "resource/name" pair for an object.
+	// This flag effective useful when operations across all
+	// namespace are done.
 	WithNamespace bool
 }
 

--- a/staging/src/k8s.io/cli-runtime/pkg/printers/name.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/printers/name.go
@@ -89,11 +89,7 @@ func (p *NamePrinter) PrintObj(obj runtime.Object, w io.Writer) error {
 			name = n
 		}
 		if p.WithNamespace {
-			if ns := acc.GetNamespace(); len(ns) > 0 {
-				namespace = ns
-			} else {
-				namespace = "<unknown>"
-			}
+			namespace = acc.GetNamespace()
 		}
 	}
 

--- a/staging/src/k8s.io/cli-runtime/pkg/printers/name_test.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/printers/name_test.go
@@ -60,7 +60,7 @@ func TestNamePrinter_PrintObj(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "print object with operation",
+			name: "print object with operation option",
 			fields: fields{
 				Operation: "created",
 			},
@@ -79,7 +79,27 @@ func TestNamePrinter_PrintObj(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "print object with namespace",
+			name: "print object with operation and short-output options",
+			fields: fields{
+				Operation:   "created",
+				ShortOutput: true,
+			},
+			args: args{
+				obj: &corev1.Pod{
+					TypeMeta: metav1.TypeMeta{
+						Kind: "Pod",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-pod",
+						Namespace: "test-namespace",
+					},
+				},
+			},
+			wantW:   "pod/test-pod\n",
+			wantErr: false,
+		},
+		{
+			name: "print object with namespace option",
 			fields: fields{
 				WithNamespace: true,
 			},
@@ -95,6 +115,44 @@ func TestNamePrinter_PrintObj(t *testing.T) {
 				},
 			},
 			wantW:   "test-namespace/pod/test-pod\n",
+			wantErr: false,
+		},
+		{
+			name: "print cluster-scoped object with namespace option",
+			fields: fields{
+				WithNamespace: true,
+			},
+			args: args{
+				obj: &corev1.PersistentVolume{
+					TypeMeta: metav1.TypeMeta{
+						Kind: "PersistentVolume",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-pv",
+					},
+				},
+			},
+			wantW:   "persistentvolume/test-pv\n",
+			wantErr: false,
+		},
+		{
+			name: "print object with operation and namespace options",
+			fields: fields{
+				Operation:     "created",
+				WithNamespace: true,
+			},
+			args: args{
+				obj: &corev1.Pod{
+					TypeMeta: metav1.TypeMeta{
+						Kind: "Pod",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-pod",
+						Namespace: "test-namespace",
+					},
+				},
+			},
+			wantW:   "test-namespace/pod/test-pod created\n",
 			wantErr: false,
 		},
 	}

--- a/staging/src/k8s.io/cli-runtime/pkg/printers/name_test.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/printers/name_test.go
@@ -1,0 +1,126 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package printers
+
+import (
+	"bytes"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func TestNamePrinter_PrintObj(t *testing.T) {
+	type fields struct {
+		ShortOutput   bool
+		Operation     string
+		WithNamespace bool
+	}
+	type args struct {
+		obj runtime.Object
+	}
+
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		wantW   string
+		wantErr bool
+	}{
+		{
+			name:   "print object without options",
+			fields: fields{},
+			args: args{
+				obj: &corev1.Pod{
+					TypeMeta: metav1.TypeMeta{
+						Kind: "Pod",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-pod",
+						Namespace: "test-namespace",
+					},
+				},
+			},
+			wantW:   "pod/test-pod\n",
+			wantErr: false,
+		},
+		{
+			name: "print object with operation",
+			fields: fields{
+				Operation: "created",
+			},
+			args: args{
+				obj: &corev1.Pod{
+					TypeMeta: metav1.TypeMeta{
+						Kind: "Pod",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-pod",
+						Namespace: "test-namespace",
+					},
+				},
+			},
+			wantW:   "pod/test-pod created\n",
+			wantErr: false,
+		},
+		{
+			name: "print object with namespace",
+			fields: fields{
+				WithNamespace: true,
+			},
+			args: args{
+				obj: &corev1.Pod{
+					TypeMeta: metav1.TypeMeta{
+						Kind: "Pod",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-pod",
+						Namespace: "test-namespace",
+					},
+				},
+			},
+			wantW:   "test-namespace/pod/test-pod\n",
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			p := &NamePrinter{
+				ShortOutput:   tt.fields.ShortOutput,
+				Operation:     tt.fields.Operation,
+				WithNamespace: tt.fields.WithNamespace,
+			}
+
+			w := &bytes.Buffer{}
+
+			if err := p.PrintObj(tt.args.obj, w); (err != nil) != tt.wantErr {
+				t.Errorf("NamePrinter.PrintObj() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if gotW := w.String(); gotW != tt.wantW {
+				t.Errorf("NamePrinter.PrintObj() = %v, want %v", gotW, tt.wantW)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

This PR adds an option to `k8s.io/cli-runtime/pkg/printers.NamePrinter` in order to put namespace prefixes.

The output of the current `NamePrinter.PrintObj` is like:

```
configmap/test-cm-1 deleted
configmap/test-cm-1 deleted
configmap/test-cm-2 deleted
```

The output I'd like to opt-in is like (if `WithNamespace` == `true`):

```
my-namespace-1/configmap/test-cm-1 deleted
my-namespace-2/configmap/test-cm-1 deleted
my-namespace-2/configmap/test-cm-2 deleted
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #94917

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
