### PR TITLE
Revert "Merge pull request #93837 from jayunit100/DialFromContainerB"

### DIFF
--- a/test/e2e/common/networking.go
+++ b/test/e2e/common/networking.go
@@ -18,7 +18,6 @@ package common
 
 import (
 	"github.com/onsi/ginkgo"
-	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2enetwork "k8s.io/kubernetes/test/e2e/framework/network"
@@ -28,45 +27,6 @@ var _ = ginkgo.Describe("[sig-network] Networking", func() {
 	f := framework.NewDefaultFramework("pod-network-test")
 
 	ginkgo.Describe("Granular Checks: Pods", func() {
-
-		checkNodeConnectivity := func(config *e2enetwork.NetworkingTestConfig, protocol string, port int) {
-			// breadth first poll to quickly estimate failure.
-			failedPodsByHost := map[string][]*v1.Pod{}
-			// First time, we'll quickly try all pods, breadth first.
-			for _, endpointPod := range config.EndpointPods {
-				framework.Logf("Breadth first check of %v on host %v...", endpointPod.Status.PodIP, endpointPod.Status.HostIP)
-				if err := config.DialFromTestContainer(protocol, endpointPod.Status.PodIP, port, 1, 0, sets.NewString(endpointPod.Name)); err != nil {
-					if _, ok := failedPodsByHost[endpointPod.Status.HostIP]; !ok {
-						failedPodsByHost[endpointPod.Status.HostIP] = []*v1.Pod{}
-					}
-					failedPodsByHost[endpointPod.Status.HostIP] = append(failedPodsByHost[endpointPod.Status.HostIP], endpointPod)
-					framework.Logf("...failed...will try again in next pass")
-				}
-			}
-			errors := []error{}
-			// Second time, we pass through pods more carefully...
-			framework.Logf("Going to retry %v out of %v pods....", len(failedPodsByHost), len(config.EndpointPods))
-			for host, failedPods := range failedPodsByHost {
-				framework.Logf("Doublechecking %v pods in host %v which werent seen the first time.", len(failedPods), host)
-				for _, endpointPod := range failedPods {
-					framework.Logf("Now attempting to probe pod [[[ %v ]]]", endpointPod.Status.PodIP)
-					if err := config.DialFromTestContainer(protocol, endpointPod.Status.PodIP, port, config.MaxTries, 0, sets.NewString(endpointPod.Name)); err != nil {
-						errors = append(errors, err)
-					} else {
-						framework.Logf("Was able to reach %v on %v ", endpointPod.Status.PodIP, endpointPod.Status.HostIP)
-					}
-					framework.Logf("... Done probing pod [[[ %v ]]]", endpointPod.Status.PodIP)
-				}
-				framework.Logf("succeeded at polling %v out of %v connections", len(config.EndpointPods)-len(errors), len(config.EndpointPods))
-			}
-			if len(errors) > 0 {
-				framework.Logf("pod polling failure summary:")
-				for _, e := range errors {
-					framework.Logf("Collected error: %v", e)
-				}
-				framework.Failf("failed,  %v out of %v connections failed", len(errors), len(config.EndpointPods))
-			}
-		}
 
 		// Try to hit all endpoints through a test container, retry 5 times,
 		// expect exactly one unique hostname. Each of these endpoints reports
@@ -79,7 +39,9 @@ var _ = ginkgo.Describe("[sig-network] Networking", func() {
 		*/
 		framework.ConformanceIt("should function for intra-pod communication: http [NodeConformance]", func() {
 			config := e2enetwork.NewCoreNetworkingTestConfig(f, false)
-			checkNodeConnectivity(config, "http", e2enetwork.EndpointHTTPPort)
+			for _, endpointPod := range config.EndpointPods {
+				config.DialFromTestContainer("http", endpointPod.Status.PodIP, e2enetwork.EndpointHTTPPort, config.MaxTries, 0, sets.NewString(endpointPod.Name))
+			}
 		})
 
 		/*
@@ -90,7 +52,9 @@ var _ = ginkgo.Describe("[sig-network] Networking", func() {
 		*/
 		framework.ConformanceIt("should function for intra-pod communication: udp [NodeConformance]", func() {
 			config := e2enetwork.NewCoreNetworkingTestConfig(f, false)
-			checkNodeConnectivity(config, "udp", e2enetwork.EndpointUDPPort)
+			for _, endpointPod := range config.EndpointPods {
+				config.DialFromTestContainer("udp", endpointPod.Status.PodIP, e2enetwork.EndpointUDPPort, config.MaxTries, 0, sets.NewString(endpointPod.Name))
+			}
 		})
 
 		/*


### PR DESCRIPTION
This reverts commit 61490bba46ee2ad39690c682db0bee425b21798e, reversing
changes made to 9ecab1b4b2a76aa998dea2bdfa9eb9d892103f42.

Some methods from the networking e2e tools are dialing from a
containter to another container, and failing the test if there was no
connectivity. This PR modified the methods to return an error instead of
failing the test.
However, these methods were used by other tests in the framework, and
they are not checking if the method returns an error, expecting that
the method fail the test. With this change, any connectivity problem
will go unnoticed on the tests that are not asserting the error, so we
need to revert to previous state.


/kind bug
/kind failing-test


xref: https://github.com/kubernetes/kubernetes/pull/93837#discussion_r492991061

```release-note
NONE
```
