### PR TITLE
Fix `kubectl describe ingress` format

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/describe/describe.go
+++ b/staging/src/k8s.io/kubectl/pkg/describe/describe.go
@@ -2465,7 +2465,7 @@ func (i *IngressDescriber) describeBackendV1(ns string, backend *networkingv1.In
 			}
 		}
 		ep := formatEndpoints(endpoints, sets.NewString(spName))
-		return fmt.Sprintf("%s\t %s)", sb, ep)
+		return fmt.Sprintf("%s (%s)", sb, ep)
 	}
 	if backend.Resource != nil {
 		ic := backend.Resource
@@ -2518,7 +2518,7 @@ func (i *IngressDescriber) describeIngressV1(ing *networkingv1.Ingress, events *
 			}
 		}
 		if count == 0 {
-			w.Write(LEVEL_1, "\t%s %s\n", "*", "*", i.describeBackendV1(ns, def))
+			w.Write(LEVEL_1, "%s\t%s\t%s\n", "*", "*", i.describeBackendV1(ns, def))
 		}
 		printAnnotationsMultiline(w, "Annotations", ing.Annotations)
 

--- a/staging/src/k8s.io/kubectl/pkg/describe/describe_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/describe/describe_test.go
@@ -1924,6 +1924,28 @@ Rules:
 Annotations:   <none>
 Events:        <none>` + "\n",
 		},
+		"DefaultBackend": {
+			input: fake.NewSimpleClientset(&networkingv1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "bar",
+					Namespace: "foo",
+				},
+				Spec: networkingv1.IngressSpec{
+					DefaultBackend: &backendV1,
+				},
+			}),
+			output: `Name:             bar
+Namespace:        foo
+Address:          
+Default backend:  default-backend:80 (<error: endpoints "default-backend" not found>)
+Rules:
+  Host        Path  Backends
+  ----        ----  --------
+  *           *     default-backend:80 (<error: endpoints "default-backend" not found>)
+Annotations:  <none>
+Events:       <none>
+`,
+		},
 	}
 
 	for name, test := range tests {


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes/issues/94980

Fixes two formatting issues:
* Un-opened parenthesis (`10.244.0.6:8080)`)
* Bad format string and spacing

Before this PR:
```
Name:             example-ingress
Namespace:        default
Address:
Default backend:  istio-ingressgateway:80 (<error: endpoints "istio-ingressgateway" not found>)
Rules:
  Host                                                                                                      Path  Backends
  ----                                                                                                      ----  --------
                                                                                                            * *
%!(EXTRA string=istio-ingressgateway:80 (<error: endpoints "istio-ingressgateway" not found>))Annotations:  <none>
Events:                                                                                                     <none>
```

After this PR:
```
Name:             example-ingress
Namespace:        default
Address:
Default backend:  istio-ingressgateway:80 (<error: endpoints "istio-ingressgateway" not found>)
Rules:
  Host        Path  Backends
  ----        ----  --------
  *           *     istio-ingressgateway:80 (<error: endpoints "istio-ingressgateway" not found>)
Annotations:  <none>
Events:       <none>
```

Compare to an old kubectl without the bug:
```
Name:             example-ingress
Namespace:        default
Address:
Default backend:  istio-ingressgateway:80 (<none>)
Rules:
  Host  Path  Backends
  ----  ----  --------
  *     *     istio-ingressgateway:80 (<none>)
Annotations:
  kubectl.kubernetes.io/last-applied-configuration: ...

Events:  <none>
```

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:



**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #94980

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
Fixed a bug causing incorrect formatting of `kubectl describe ingress`.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
