### PR TITLE
kubectl: Add maintainer FAQ

### DIFF
--- a/staging/src/k8s.io/kubectl/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/staging/src/k8s.io/kubectl/.github/ISSUE_TEMPLATE/bug-report.md
@@ -9,6 +9,9 @@ labels: kind/bug
 
 If the matter is security related, please disclose it privately via https://kubernetes.io/security/
 -->
+<!-- Please review the
+[FAQ](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/kubectl/docs/maintainers/faq.md)
+before submitting -->
 
 **What happened**:
 

--- a/staging/src/k8s.io/kubectl/.github/ISSUE_TEMPLATE/enhancement.md
+++ b/staging/src/k8s.io/kubectl/.github/ISSUE_TEMPLATE/enhancement.md
@@ -5,6 +5,9 @@ labels: kind/feature
 
 ---
 <!-- Please only use this template for submitting enhancement requests -->
+<!-- Please review the
+[FAQ](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/kubectl/docs/maintainers/faq.md)
+before submitting -->
 
 **What would you like to be added**:
 

--- a/staging/src/k8s.io/kubectl/docs/maintainers/faq.md
+++ b/staging/src/k8s.io/kubectl/docs/maintainers/faq.md
@@ -1,0 +1,36 @@
+# kubectl Maintainer FAQ
+
+This document serves as a knowledge bank of SIG-Cli's stance on certain
+recurring issues and historical decisions. 
+
+## Enhancing kubectl create/run
+
+TODO: Condense https://github.com/kubernetes/kubectl/issues/914
+
+## kubectl get all
+
+`kubectl get all` is a legacy command and is actually implemented with a
+hardcoded server side list that is not easy to maintain. There is potential that
+it will be removed in the future and therefore will not be expanded upon or
+improved.
+
+https://github.com/kubernetes/kubectl/issues/151
+
+We recommend using [ketall](https://github.com/corneliusweig/ketall) which can
+be installed standalone or via [krew](https://krew.sigs.k8s.io/).
+
+## Confirmation when using `--all`
+
+Introducing `--all` would be a breaking change. We’ve made an attempt in the
+past (see https://github.com/kubernetes/kubernetes/pull/62167) and we’ve decided
+that the suggested approach is to encourage cluster owners to implement
+something like https://github.com/kubernetes/kubernetes/pull/17740 or currently
+using validating webhooks (see
+https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#validatingwebhookconfiguration-v1-admissionregistration-k8s-io)
+but no such effort will be undertaken in kubectl itself.
+
+## Supported versions
+
+The Kubernetes project maintains release branches for the most recent three
+minor releases (1.19, 1.18, 1.17 as of this writing). [Kubernetes Version Skew
+Policy](https://kubernetes.io/docs/setup/release/version-skew-policy/#supported-versions)


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation
/sig cli
/area kubectl

**What this PR does / why we need it**:

This PR adds a maintainer FAQ for kubectl to serve as a point of reference for recurring issues and requests.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

Migrating from this [Google doc](https://docs.google.com/document/d/1xk5IW8srHWSjDBwezBYOnnQJkrHONWJDKl1i96SNwg0/edit?usp=sharing).

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
