### PR TITLE
Fail a test on pre-provisioned Cinder volume deletion error

### DIFF
--- a/test/e2e/storage/drivers/in_tree.go
+++ b/test/e2e/storage/drivers/in_tree.go
@@ -1191,6 +1191,7 @@ func (c *cinderDriver) CreateVolume(config *testsuites.PerTestConfig, volType te
 }
 
 func (v *cinderVolume) DeleteVolume() {
+	id := v.volumeID
 	name := v.volumeName
 
 	// Try to delete the volume for several seconds - it takes
@@ -1199,16 +1200,16 @@ func (v *cinderVolume) DeleteVolume() {
 	var err error
 	timeout := time.Second * 120
 
-	framework.Logf("Waiting up to %v for removal of cinder volume %s", timeout, name)
+	framework.Logf("Waiting up to %v for removal of cinder volume %s / %s", timeout, id, name)
 	for start := time.Now(); time.Since(start) < timeout; time.Sleep(5 * time.Second) {
-		output, err = exec.Command("cinder", "delete", name).CombinedOutput()
+		output, err = exec.Command("cinder", "delete", id).CombinedOutput()
 		if err == nil {
-			framework.Logf("Cinder volume %s deleted", name)
+			framework.Logf("Cinder volume %s deleted", id)
 			return
 		}
-		framework.Logf("Failed to delete volume %s: %v", name, err)
+		framework.Logf("Failed to delete volume %s / %s: %v\n%s", id, name, err, string(output))
 	}
-	framework.Logf("Giving up deleting volume %s: %v\n%s", name, err, string(output[:]))
+	framework.Logf("Giving up deleting volume %s / %s: %v\n%s", id, name, err, string(output[:]))
 }
 
 // GCE

--- a/test/e2e/storage/drivers/in_tree.go
+++ b/test/e2e/storage/drivers/in_tree.go
@@ -1209,6 +1209,13 @@ func (v *cinderVolume) DeleteVolume() {
 		}
 		framework.Logf("Failed to delete volume %s / %s: %v\n%s", id, name, err, string(output))
 	}
+	// Timed out, try to get "cinder show <volume>" output for easier debugging
+	showOutput, showErr := exec.Command("cinder", "show", id).CombinedOutput()
+	if showErr != nil {
+		framework.Logf("Failed to show volume %s / %s: %v\n%s", id, name, showErr, string(showOutput))
+	} else {
+		framework.Logf("Volume %s / %s:\n%s", id, name, string(showOutput))
+	}
 	framework.Logf("Giving up deleting volume %s / %s: %v\n%s", id, name, err, string(output[:]))
 }
 

--- a/test/e2e/storage/drivers/in_tree.go
+++ b/test/e2e/storage/drivers/in_tree.go
@@ -1216,7 +1216,7 @@ func (v *cinderVolume) DeleteVolume() {
 	} else {
 		framework.Logf("Volume %s / %s:\n%s", id, name, string(showOutput))
 	}
-	framework.Logf("Giving up deleting volume %s / %s: %v\n%s", id, name, err, string(output[:]))
+	framework.Failf("Failed to delete pre-provisioned volume %s / %s: %v\n%s", id, name, err, string(output[:]))
 }
 
 // GCE


### PR DESCRIPTION
/kind cleanup
**What this PR does / why we need it**:

We see number of leaked Cinder volumes in a downstream test suite. While we're debugging this, we noticed a few issues:

1. The tests should log error output of each failed `cinder delete <xyz>`.
2. The tests should use volume ID instead of volume name in `cinder delete <xyz>`, since multiple CI jobs can run in a single OpenStack project and accidentally choose the same volume name.
3. The tests should be marked as failed when pre-provisioned volume deletion fails.

In addition, I added `cinder show <xyz>` output when something fails, to be able to diagnose volume health from Cinder point of view.

This PR does not fix the leak, that one is still under investigation.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
