### PR TITLE
Remove dependency on behaviors for conformance walk.go

### DIFF
--- a/test/conformance/BUILD
+++ b/test/conformance/BUILD
@@ -9,7 +9,6 @@ go_library(
     importpath = "k8s.io/kubernetes/test/conformance",
     visibility = ["//visibility:private"],
     deps = [
-        "//test/conformance/behaviors:go_default_library",
         "//vendor/github.com/onsi/ginkgo/types:go_default_library",
         "//vendor/gopkg.in/yaml.v2:go_default_library",
     ],
@@ -79,7 +78,6 @@ go_test(
     srcs = ["walk_test.go"],
     data = glob(["testdata/**"]),
     embed = [":go_default_library"],
-    deps = ["//test/conformance/behaviors:go_default_library"],
 )
 
 genrule(

--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -244,9 +244,6 @@
     Query for the Pod with the new value for the label MUST be successful.
   release: v1.9
   file: test/e2e/common/pods.go
-  behaviors:
-  - pod/spec/label/create
-  - pod/spec/label/patch
 - testname: Pods, service environment variables
   codename: '[k8s.io] Pods should contain environment variables for services [NodeConformance]
     [Conformance]'
@@ -484,8 +481,6 @@
     have QOSClass set to PodQOSGuaranteed.
   release: v1.9
   file: test/e2e/node/pods.go
-  behaviors:
-  - pod/spec/container/resources
 - testname: Pods, prestop hook
   codename: '[k8s.io] [sig-node] PreStop should call prestop when killing a pod  [Conformance]'
   description: Create a server pod with a rest endpoint '/write' that changes state.Received

--- a/test/conformance/walk_test.go
+++ b/test/conformance/walk_test.go
@@ -20,8 +20,6 @@ import (
 	"fmt"
 	"reflect"
 	"testing"
-
-	"k8s.io/kubernetes/test/conformance/behaviors"
 )
 
 func TestConformance(t *testing.T) {
@@ -30,7 +28,7 @@ func TestConformance(t *testing.T) {
 		filename    string
 		code        string
 		targetFrame frame
-		output      *behaviors.ConformanceData
+		output      *ConformanceData
 	}{
 		{
 			desc:     "Grabs comment above test",
@@ -47,7 +45,7 @@ func TestConformance(t *testing.T) {
 	*/
 	 framework.ConformanceIt("validates describe with ConformanceIt", func() {})
 	})`,
-			output: &behaviors.ConformanceData{
+			output: &ConformanceData{
 				URL:         "https://github.com/kubernetes/kubernetes/tree/master/test/list/main_test.go#L11",
 				TestName:    "Kubelet-OutputToLogs",
 				Description: `By default the stdout and stderr from the process being executed in a pod MUST be sent to the pod's logs.`,
@@ -67,7 +65,7 @@ func TestConformance(t *testing.T) {
 				   framework.ConformanceIt("should work", func() {})
 		   })
 	})`,
-			output: &behaviors.ConformanceData{
+			output: &ConformanceData{
 				URL:         "https://github.com/kubernetes/kubernetes/tree/master/e2e/foo.go#L8",
 				TestName:    "Test with spaces",
 				Description: `Should pick up testname even if it is not within 3 spaces even when executed from memory.`,
@@ -91,7 +89,7 @@ func TestConformance(t *testing.T) {
 				   framework.ConformanceIt("should work", func() {})
 		   })
 	})`,
-			output: &behaviors.ConformanceData{
+			output: &ConformanceData{
 				URL:         "https://github.com/kubernetes/kubernetes/tree/master/e2e/foo.go#L13",
 				TestName:    "Second test",
 				Description: `Should target the correct test/comment based on the line numbers`,
@@ -114,7 +112,7 @@ func TestConformance(t *testing.T) {
 				   framework.ConformanceIt("should work", func() {})
 		   })
 	})`,
-			output: &behaviors.ConformanceData{
+			output: &ConformanceData{
 				URL:         "https://github.com/kubernetes/kubernetes/tree/master/e2e/foo.go#L8",
 				TestName:    "First test",
 				Description: `Should target the correct test/comment based on the line numbers`,
@@ -141,7 +139,7 @@ func TestCommentToConformanceData(t *testing.T) {
 	tcs := []struct {
 		desc     string
 		input    string
-		expected *behaviors.ConformanceData
+		expected *ConformanceData
 	}{
 		{
 			desc: "Empty comment leads to nil",
@@ -154,19 +152,11 @@ func TestCommentToConformanceData(t *testing.T) {
 		}, {
 			desc:     "Testname but no Release does not result in nil",
 			input:    "Testname: mytest\nDescription: foo",
-			expected: &behaviors.ConformanceData{TestName: "mytest", Description: "foo"},
+			expected: &ConformanceData{TestName: "mytest", Description: "foo"},
 		}, {
 			desc:     "All fields parsed and newlines and whitespace removed from description",
 			input:    "Release: v1.1\n\t\tTestname: mytest\n\t\tDescription: foo\n\t\tbar\ndone",
-			expected: &behaviors.ConformanceData{TestName: "mytest", Release: "v1.1", Description: "foo bar done"},
-		}, {
-			desc:     "Behaviors are read",
-			input:    "Testname: behaviors\nBehaviors:\n- should behave\n- second behavior",
-			expected: &behaviors.ConformanceData{TestName: "behaviors", Behaviors: []string{"should behave", "second behavior"}},
-		}, {
-			desc:     "Multiple behaviors are parsed",
-			input:    "Testname: behaviors2\nBehaviors:\n- first behavior\n- second behavior",
-			expected: &behaviors.ConformanceData{TestName: "behaviors2", Behaviors: []string{"first behavior", "second behavior"}},
+			expected: &ConformanceData{TestName: "mytest", Release: "v1.1", Description: "foo bar done"},
 		},
 	}
 

--- a/test/e2e/common/pods.go
+++ b/test/e2e/common/pods.go
@@ -339,9 +339,6 @@ var _ = framework.KubeDescribe("Pods", func() {
 		Release: v1.9
 		Testname: Pods, update
 		Description: Create a Pod with a unique label. Query for the Pod with the label as selector MUST be successful. Update the pod to change the value of the Label. Query for the Pod with the new value for the label MUST be successful.
-		Behaviors:
-		- pod/spec/label/create
-		- pod/spec/label/patch
 	*/
 	framework.ConformanceIt("should be updated [NodeConformance]", func() {
 		ginkgo.By("creating the pod")

--- a/test/e2e/node/pods.go
+++ b/test/e2e/node/pods.go
@@ -168,8 +168,6 @@ var _ = SIGDescribe("Pods Extended", func() {
 			Release: v1.9
 			Testname: Pods, QOS
 			Description:  Create a Pod with CPU and Memory request and limits. Pod status MUST have QOSClass set to PodQOSGuaranteed.
-			Behaviors:
-			- pod/spec/container/resources
 		*/
 		framework.ConformanceIt("should be set on Pods with matching resource requests and limits for memory and cpu", func() {
 			ginkgo.By("creating the pod")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind cleanup
**What this PR does / why we need it**:
KEP has been [withdrawn](https://github.com/kubernetes/enhancements/commit/5828f033b41abf5f771cc3a67929df04d4a9b38d). Remove dependencies on the behavior code when generating conformance behaviors. The actual behaviors code will be removed in a follow up PR.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
/assign @johnbelamaric 