### PR TITLE
Fix e2e endpoint slice flake test

### DIFF
--- a/test/e2e/network/endpointslice.go
+++ b/test/e2e/network/endpointslice.go
@@ -521,7 +521,11 @@ func hasMatchingEndpointSlices(cs clientset.Interface, ns, svcName string, numEn
 	for _, endpointSlice := range esList.Items {
 		actualNumEndpoints += len(endpointSlice.Endpoints)
 	}
-	if actualNumEndpoints != numEndpoints {
+	// In some cases the EndpointSlice controller will create more
+	// EndpointSlices than necessary resulting in some duplication. This is
+	// valid and tests should only fail here if less EndpointSlices than
+	// expected are added.
+	if actualNumEndpoints < numEndpoints {
 		framework.Logf("EndpointSlices for %s/%s Service have %d/%d endpoints", ns, svcName, actualNumEndpoints, numEndpoints)
 		return esList.Items, false
 	}


### PR DESCRIPTION
    In some cases the EndpointSlice controller will create more
    EndpointSlices than necessary resulting in some duplication. This is
    valid and tests should only fail here if less EndpointSlices than
    expected are added.

/kind flake

```release-note
NONE
```

Fixes: https://github.com/kubernetes/kubernetes/issues/94998