### PR TITLE
fix: correct glbc ClusterRole

### DIFF
--- a/cluster/addons/rbac/cluster-loadbalancing/glbc/roles.yaml
+++ b/cluster/addons/rbac/cluster-loadbalancing/glbc/roles.yaml
@@ -35,7 +35,7 @@ rules:
 - apiGroups: ["extensions", "networking.k8s.io"]
   resources: ["ingresses"]
   verbs: ["get", "list", "watch"]
-# For now, GLBC annotates ingress resources with various state and statuses: 
+# For now, GLBC annotates ingress resources with various state and statuses:
 # https://github.com/kubernetes/ingress-gce/blob/50d49b077d9ab4362a02fae05f94e433cd3f08dc/pkg/controller/controller.go#L579
 # TODO(rramkumar1): Remove unnecessary `update` permission once statuses are propagated through `ingresses/status`
 - apiGroups: ["extensions", "networking.k8s.io"]
@@ -44,12 +44,16 @@ rules:
 - apiGroups: ["extensions", "networking.k8s.io"]
   resources: ["ingresses/status"]
   verbs: ["update", "patch"]
-# GLBC ensures that the `cloud.google.com/backendconfigs` CRD exists in a desired state:
-# https://github.com/kubernetes/ingress-gce/blob/4918eb2f0f484f09ac9e5a975907a9b16ed2b344/cmd/glbc/main.go#L93
+# GLBC ensures that the `cloud.google.com/backendconfigs` and `networking.gke.io/servicenetworkendpointgroups` CRD exists in a desired state:
+# https://github.com/kubernetes/ingress-gce/blob/5c3fcb5845e74b92ea8bd52929b15fc5c9fa7970/cmd/glbc/main.go#L108
+# https://github.com/kubernetes/ingress-gce/blob/5c3fcb5845e74b92ea8bd52929b15fc5c9fa7970/cmd/glbc/main.go#L133
 # TODO(rramkumar1): https://github.com/kubernetes/ingress-gce/issues/744
 - apiGroups: ["apiextensions.k8s.io"]
   resources: ["customresourcedefinitions"]
   verbs: ["get", "list", "watch", "update", "create", "patch"]
 - apiGroups: ["cloud.google.com"]
   resources: ["backendconfigs"]
+  verbs: ["get", "list", "watch", "update", "create", "patch"]
+- apiGroups: ["networking.gke.io"]
+  resources: ["servicenetworkendpointgroups"]
   verbs: ["get", "list", "watch", "update", "create", "patch"]


### PR DESCRIPTION
Signed-off-by: knight42 <anonymousknight96@gmail.com>

**What type of PR is this?**

/kind failing-test

**What this PR does / why we need it**:

From the log of glbc https://storage.googleapis.com/kubernetes-jenkins/logs/ci-ingress-gce-e2e/1308560052008783872/artifacts/e2e-588b1b9a56-58614-master/glbc.log:
```
I0923 00:21:08.296721       1 controller.go:263] Waiting for initial sync
I0923 00:21:09.295783       1 node.go:75] Waiting for hasSynced (6.002066879s elapsed)
I0923 00:21:10.295960       1 node.go:75] Waiting for hasSynced (7.002248118s elapsed)
I0923 00:21:11.296097       1 node.go:75] Waiting for hasSynced (8.002385129s elapsed)
I0923 00:21:12.211710       1 reflector.go:211] Listing and watching *v1beta1.ServiceNetworkEndpointGroup from pkg/mod/k8s.io/client-go@v0.18.0/tools/cache/reflector.go:125
E0923 00:21:12.213438       1 reflector.go:178] pkg/mod/k8s.io/client-go@v0.18.0/tools/cache/reflector.go:125: Failed to list *v1beta1.ServiceNetworkEndpointGroup: servicenetworkendpointgroups.networking.gke.io is forbidden: User "system:controller:glbc" cannot list resource "servicenetworkendpointgroups" in API group "networking.gke.io" at the cluster scope
```
We could tell that glbc fail to perform initial sync because it is forbidden to list resource in API group "networking.gke.io". This PR fix the ClusterRole to grant appropriate privileges to glbc.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #93693

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
