### PR TITLE
auto nominate aojea to test reviewers

### DIFF
--- a/test/OWNERS
+++ b/test/OWNERS
@@ -1,6 +1,7 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 reviewers:
+  - aojea
   - neolit123
   - johnSchnake
   - SataQiu


### PR DESCRIPTION
following the communite guidelines I'd like to ask to be included as a reviewer in the `test/OWNERS`
I've been doing reviews and contributing in the test area for almost 2 years now, mainly in networking related bits, 
just I want to formalize it because I will keep doing it ;)

```release-note
NONE
```
