### PR TITLE
test images: Removes -p yes flag from qemu-user-static script call

### DIFF
--- a/test/images/Makefile
+++ b/test/images/Makefile
@@ -15,7 +15,7 @@
 REGISTRY ?= gcr.io/kubernetes-e2e-test-images
 GOARM ?= 7
 DOCKER_CERT_BASE_PATH ?=
-QEMUVERSION=v2.9.1
+QEMUVERSION=v5.1.0-2
 GOLANG_VERSION=1.15.2
 export
 

--- a/test/images/image-util.sh
+++ b/test/images/image-util.sh
@@ -149,7 +149,7 @@ build() {
         if [[ $(id -u) != 0 ]]; then
           sudo=sudo
         fi
-        ${sudo} "${KUBE_ROOT}/third_party/multiarch/qemu-user-static/register/register.sh" --reset -p yes
+        ${sudo} "${KUBE_ROOT}/third_party/multiarch/qemu-user-static/register/register.sh" --reset
         curl -sSL https://github.com/multiarch/qemu-user-static/releases/download/"${QEMUVERSION}"/x86_64_qemu-"${QEMUARCHS[$arch]}"-static.tar.gz | tar -xz -C "${temp_dir}"
         # Ensure we don't get surprised by umask settings
         chmod 0755 "${temp_dir}/qemu-${QEMUARCHS[$arch]}-static"

--- a/third_party/multiarch/qemu-user-static/README.kubernetes
+++ b/third_party/multiarch/qemu-user-static/README.kubernetes
@@ -1,1 +1,2 @@
-Files copied from https://github.com/multiarch/qemu-user-static at commit 22b0013668d2aed4a2cfd21650e85c664b1f21c6.
+qemu-binfmt-confg.sh comes from https://github.com/qemu/qemu/blob/7c81570d932268a9626457a662f1c5046ebc455e/scripts/qemu-binfmt-conf.sh
+register.sh comes from https://github.com/multiarch/qemu-user-static/blob/9898439ca975c9c4c0db2bdc4b3707d382559d09/containers/latest/register.sh


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug

/sig testing
/priority important-soon

**What this PR does / why we need it**:

Currently, the Image Builder job is failing as it cannot build images for other architecture types [1]. This happens because the Image Builder image (``gcr.io/k8s-testimages/gcb-docker-gcloud:v20190906-745fed4``) does not have any of the expected ``qemu-*`` binaries in ``/usr/bin/``, so the command ``${sudo} "${KUBE_ROOT}/third_party/multiarch/qemu-user-static/register/register.sh --reset -p yes"`` is not working properly. This can be reproduced locally:

    docker run -ti --rm --privileged -v /var/run/docker.sock:/var/run/docker.sock -v /home/atuvenie/kubernetes:/workspace/kubernetes -v /home/atuvenie/.docker:/root/.docker gcr.io/k8s-testimages/gcb-docker-gcloud:v20190906-745fed4 -c "cd kubernetes && make all-container WHAT=agnhost``

The resulting logs are: [2]. Because the ``qemu-*`` binaries are missing, errors like this can be observed in the logs:

    Registering qemu-*-static binaries in the kernel
    Setting /usr/bin/qemu-alpha-static as binfmt interpreter for alpha
    sh: write error: No such file or directory
    Setting /usr/bin/qemu-arm-static as binfmt interpreter for arm
    sh: write error: No such file or directory
    Setting /usr/bin/qemu-armeb-static as binfmt interpreter for armeb
    sh: write error: No such file or directory
    Setting /usr/bin/qemu-sparc-static as binfmt interpreter for sparc
    sh: write error: No such file or directory
    Setting /usr/bin/qemu-sparc32plus-static as binfmt interpreter for sparc32plus
    sh: write error: No such file or directory

The command ``docker run --rm --privileged multiarch/qemu-user-static --reset -p yes`` can be used instead for the same effect. This will result in images being buildable inside a ``gcr.io/k8s-testimages/gcb-docker-gcloud:v20190906-745fed4`` container: [3]

Note that this wasn't an issue for hosts that already have qemu installed, as the image ``multiarch/qemu-user-static`` contains the ``qemu-*`` binaries mentioned before.

The images can also be built inside the container if the ``qemu-*`` binaries are included in it: [4] (``find /usr/bin -type f -name 'qemu-*' -exec sh -c 'docker cp {} containerid:/usr/bin/' \;``)

Alternatively, we can remove the ``-p yes`` flag.

The QEMUVERSION in ``test/images/Makefile`` is also bumped to 5.1.0-2, which is the same version as the ``third_party/multiarch/qemu-user-static/register`` scripts.

[1] http://storage.googleapis.com/k8s-staging-e2e-test-images-gcb/logs/log-77718177-fddb-4a8e-980b-0a38e76f4907.txt
[2] https://paste.ubuntu.com/p/Ncx2jrb8MH/
[3] https://paste.ubuntu.com/p/xBN5fXSbZX/
[4] https://paste.ubuntu.com/p/SX7Zmd75bY/

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

This issue started appearing since https://github.com/kubernetes/kubernetes/pull/94777 merged.

Included the commit from: https://github.com/kubernetes/kubernetes/pull/94875

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
