### PR TITLE
RuntimeHandler test - mark as serial instead of disruptive and provide non-serial alternative

### DIFF
--- a/test/e2e/node/runtimeclass.go
+++ b/test/e2e/node/runtimeclass.go
@@ -24,6 +24,7 @@ import (
 	nodev1beta1 "k8s.io/api/node/v1beta1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/uuid"
 	runtimeclasstest "k8s.io/kubernetes/pkg/kubelet/runtimeclass/testing"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
@@ -38,9 +39,11 @@ var _ = ginkgo.Describe("[sig-node] RuntimeClass", func() {
 	f := framework.NewDefaultFramework("runtimeclass")
 
 	ginkgo.It("should reject a Pod requesting a RuntimeClass with conflicting node selector", func() {
+		labelFooName := "foo-" + string(uuid.NewUUID())
+
 		scheduling := &nodev1beta1.Scheduling{
 			NodeSelector: map[string]string{
-				"foo": "conflict",
+				labelFooName: "conflict",
 			},
 		}
 
@@ -51,22 +54,25 @@ var _ = ginkgo.Describe("[sig-node] RuntimeClass", func() {
 
 		pod := e2enode.NewRuntimeClassPod(rc.GetName())
 		pod.Spec.NodeSelector = map[string]string{
-			"foo": "bar",
+			labelFooName: "bar",
 		}
 		_, err = f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(context.TODO(), pod, metav1.CreateOptions{})
 		framework.ExpectError(err, "should be forbidden")
 		framework.ExpectEqual(apierrors.IsForbidden(err), true, "should be forbidden error")
 	})
 
-	ginkgo.It("should run a Pod requesting a RuntimeClass with scheduling [NodeFeature:RuntimeHandler] [Disruptive] ", func() {
+	ginkgo.It("should run a Pod requesting a RuntimeClass with scheduling with taints [Serial] ", func() {
+		labelFooName := "foo-" + string(uuid.NewUUID())
+		labelFizzName := "fizz-" + string(uuid.NewUUID())
+
 		nodeName := scheduling.GetNodeThatCanRunPod(f)
 		nodeSelector := map[string]string{
-			"foo":  "bar",
-			"fizz": "buzz",
+			labelFooName:  "bar",
+			labelFizzName: "buzz",
 		}
 		tolerations := []v1.Toleration{
 			{
-				Key:      "foo",
+				Key:      labelFooName,
 				Operator: v1.TolerationOpEqual,
 				Value:    "bar",
 				Effect:   v1.TaintEffectNoSchedule,
@@ -86,7 +92,7 @@ var _ = ginkgo.Describe("[sig-node] RuntimeClass", func() {
 
 		ginkgo.By("Trying to apply taint on the found node.")
 		taint := v1.Taint{
-			Key:    "foo",
+			Key:    labelFooName,
 			Value:  "bar",
 			Effect: v1.TaintEffectNoSchedule,
 		}
@@ -102,7 +108,7 @@ var _ = ginkgo.Describe("[sig-node] RuntimeClass", func() {
 
 		pod := e2enode.NewRuntimeClassPod(rc.GetName())
 		pod.Spec.NodeSelector = map[string]string{
-			"foo": "bar",
+			labelFooName: "bar",
 		}
 		pod = f.PodClient().Create(pod)
 
@@ -114,6 +120,47 @@ var _ = ginkgo.Describe("[sig-node] RuntimeClass", func() {
 		framework.ExpectEqual(nodeName, scheduledPod.Spec.NodeName)
 		framework.ExpectEqual(nodeSelector, pod.Spec.NodeSelector)
 		gomega.Expect(pod.Spec.Tolerations).To(gomega.ContainElement(tolerations[0]))
+	})
+
+	ginkgo.It("should run a Pod requesting a RuntimeClass with scheduling without taints ", func() {
+		labelFooName := "foo-" + string(uuid.NewUUID())
+		labelFizzName := "fizz-" + string(uuid.NewUUID())
+
+		nodeName := scheduling.GetNodeThatCanRunPod(f)
+		nodeSelector := map[string]string{
+			labelFooName:  "bar",
+			labelFizzName: "buzz",
+		}
+		scheduling := &nodev1beta1.Scheduling{
+			NodeSelector: nodeSelector,
+		}
+
+		ginkgo.By("Trying to apply a label on the found node.")
+		for key, value := range nodeSelector {
+			framework.AddOrUpdateLabelOnNode(f.ClientSet, nodeName, key, value)
+			framework.ExpectNodeHasLabel(f.ClientSet, nodeName, key, value)
+			defer framework.RemoveLabelOffNode(f.ClientSet, nodeName, key)
+		}
+
+		ginkgo.By("Trying to create runtimeclass and pod")
+		runtimeClass := newRuntimeClass(f.Namespace.Name, "non-conflict-runtimeclass", framework.TestContext.ContainerRuntime)
+		runtimeClass.Scheduling = scheduling
+		rc, err := f.ClientSet.NodeV1beta1().RuntimeClasses().Create(context.TODO(), runtimeClass, metav1.CreateOptions{})
+		framework.ExpectNoError(err, "failed to create RuntimeClass resource")
+
+		pod := e2enode.NewRuntimeClassPod(rc.GetName())
+		pod.Spec.NodeSelector = map[string]string{
+			labelFooName: "bar",
+		}
+		pod = f.PodClient().Create(pod)
+
+		framework.ExpectNoError(e2epod.WaitForPodNotPending(f.ClientSet, f.Namespace.Name, pod.Name))
+
+		// check that pod got scheduled on specified node.
+		scheduledPod, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Get(context.TODO(), pod.Name, metav1.GetOptions{})
+		framework.ExpectNoError(err)
+		framework.ExpectEqual(nodeName, scheduledPod.Spec.NodeName)
+		framework.ExpectEqual(nodeSelector, pod.Spec.NodeSelector)
 	})
 })
 


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup
/sig node
/priority important-longterm

**What this PR does / why we need it**:
As part of [GA of RuntimeClass](https://docs.google.com/document/d/17nROj6ayPsUpx09mhLrzOkRLgo-8sn6Vgfyy-gmyuo4/edit#) checking on e2e test coverage. This test was marked disruptive https://github.com/kubernetes/kubernetes/pull/83647 with the intention to provide less disruptive alternative.

I wonder if Serial can/should be used instead of Disruptive? Test clears up taints after execution.

I also created a copy of the test the labels selector. I wonder if adding labels considered disruptive as well? This is why it is WIP.

**Which issue(s) this PR fixes**:

Relates to #83647

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs
NONE
```
