### PR TITLE
Use errors.Is in PluginArgs validation tests.

### DIFF
--- a/pkg/scheduler/apis/config/validation/validation_test.go
+++ b/pkg/scheduler/apis/config/validation/validation_test.go
@@ -18,7 +18,6 @@ package validation
 
 import (
 	"errors"
-	"fmt"
 	"testing"
 	"time"
 
@@ -226,53 +225,53 @@ func TestValidateKubeSchedulerConfiguration(t *testing.T) {
 func TestValidatePolicy(t *testing.T) {
 	tests := []struct {
 		policy   config.Policy
-		expected error
+		expected ValidateError
 		name     string
 	}{
 		{
 			name:     "no weight defined in policy",
 			policy:   config.Policy{Priorities: []config.PriorityPolicy{{Name: "NoWeightPriority"}}},
-			expected: errors.New("Priority NoWeightPriority should have a positive weight applied to it or it has overflown"),
+			expected: ValidateError{errMsg: "Priority NoWeightPriority should have a positive weight applied to it or it has overflown"},
 		},
 		{
 			name:     "policy weight is not positive",
 			policy:   config.Policy{Priorities: []config.PriorityPolicy{{Name: "NoWeightPriority", Weight: 0}}},
-			expected: errors.New("Priority NoWeightPriority should have a positive weight applied to it or it has overflown"),
+			expected: ValidateError{errMsg: "Priority NoWeightPriority should have a positive weight applied to it or it has overflown"},
 		},
 		{
 			name:     "valid weight priority",
 			policy:   config.Policy{Priorities: []config.PriorityPolicy{{Name: "WeightPriority", Weight: 2}}},
-			expected: nil,
+			expected: ValidateError{errMsg: ""},
 		},
 		{
 			name:     "invalid negative weight policy",
 			policy:   config.Policy{Priorities: []config.PriorityPolicy{{Name: "WeightPriority", Weight: -2}}},
-			expected: errors.New("Priority WeightPriority should have a positive weight applied to it or it has overflown"),
+			expected: ValidateError{errMsg: "Priority WeightPriority should have a positive weight applied to it or it has overflown"},
 		},
 		{
 			name:     "policy weight exceeds maximum",
 			policy:   config.Policy{Priorities: []config.PriorityPolicy{{Name: "WeightPriority", Weight: config.MaxWeight}}},
-			expected: errors.New("Priority WeightPriority should have a positive weight applied to it or it has overflown"),
+			expected: ValidateError{errMsg: "Priority WeightPriority should have a positive weight applied to it or it has overflown"},
 		},
 		{
 			name:     "valid weight in policy extender config",
 			policy:   config.Policy{Extenders: []config.Extender{{URLPrefix: "http://127.0.0.1:8081/extender", PrioritizeVerb: "prioritize", Weight: 2}}},
-			expected: nil,
+			expected: ValidateError{errMsg: ""},
 		},
 		{
 			name:     "invalid negative weight in policy extender config",
 			policy:   config.Policy{Extenders: []config.Extender{{URLPrefix: "http://127.0.0.1:8081/extender", PrioritizeVerb: "prioritize", Weight: -2}}},
-			expected: errors.New("extenders[0].weight: Invalid value: -2: must have a positive weight applied to it"),
+			expected: ValidateError{errMsg: "extenders[0].weight: Invalid value: -2: must have a positive weight applied to it"},
 		},
 		{
 			name:     "valid filter verb and url prefix",
 			policy:   config.Policy{Extenders: []config.Extender{{URLPrefix: "http://127.0.0.1:8081/extender", FilterVerb: "filter"}}},
-			expected: nil,
+			expected: ValidateError{errMsg: ""},
 		},
 		{
 			name:     "valid preemt verb and urlprefix",
 			policy:   config.Policy{Extenders: []config.Extender{{URLPrefix: "http://127.0.0.1:8081/extender", PreemptVerb: "preempt"}}},
-			expected: nil,
+			expected: ValidateError{errMsg: ""},
 		},
 		{
 			name: "invalid multiple extenders",
@@ -281,7 +280,7 @@ func TestValidatePolicy(t *testing.T) {
 					{URLPrefix: "http://127.0.0.1:8081/extender", BindVerb: "bind"},
 					{URLPrefix: "http://127.0.0.1:8082/extender", BindVerb: "bind"},
 				}},
-			expected: errors.New("extenders: Invalid value: \"found 2 extenders implementing bind\": only one extender can implement bind"),
+			expected: ValidateError{errMsg: "extenders: Invalid value: \"found 2 extenders implementing bind\": only one extender can implement bind"},
 		},
 		{
 			name: "invalid duplicate extender resource name",
@@ -290,7 +289,7 @@ func TestValidatePolicy(t *testing.T) {
 					{URLPrefix: "http://127.0.0.1:8081/extender", ManagedResources: []config.ExtenderManagedResource{{Name: "foo.com/bar"}}},
 					{URLPrefix: "http://127.0.0.1:8082/extender", BindVerb: "bind", ManagedResources: []config.ExtenderManagedResource{{Name: "foo.com/bar"}}},
 				}},
-			expected: errors.New("extenders[1].managedResources[0].name: Invalid value: \"foo.com/bar\": duplicate extender managed resource name"),
+			expected: ValidateError{errMsg: "extenders[1].managedResources[0].name: Invalid value: \"foo.com/bar\": duplicate extender managed resource name"},
 		},
 		{
 			name: "invalid extended resource name",
@@ -298,7 +297,7 @@ func TestValidatePolicy(t *testing.T) {
 				Extenders: []config.Extender{
 					{URLPrefix: "http://127.0.0.1:8081/extender", ManagedResources: []config.ExtenderManagedResource{{Name: "kubernetes.io/foo"}}},
 				}},
-			expected: errors.New("extenders[0].managedResources[0].name: Invalid value: \"kubernetes.io/foo\": kubernetes.io/foo is an invalid extended resource name"),
+			expected: ValidateError{errMsg: "extenders[0].managedResources[0].name: Invalid value: \"kubernetes.io/foo\": kubernetes.io/foo is an invalid extended resource name"},
 		},
 		{
 			name: "invalid redeclared RequestedToCapacityRatio custom priority",
@@ -308,7 +307,7 @@ func TestValidatePolicy(t *testing.T) {
 					{Name: "customPriority2", Weight: 1, Argument: &config.PriorityArgument{RequestedToCapacityRatioArguments: &config.RequestedToCapacityRatioArguments{}}},
 				},
 			},
-			expected: errors.New("Priority \"customPriority2\" redeclares custom priority \"RequestedToCapacityRatio\", from:\"customPriority1\""),
+			expected: ValidateError{errMsg: "Priority \"customPriority2\" redeclares custom priority \"RequestedToCapacityRatio\", from:\"customPriority1\""},
 		},
 		{
 			name: "different weights for LabelPreference custom priority",
@@ -318,7 +317,7 @@ func TestValidatePolicy(t *testing.T) {
 					{Name: "customPriority2", Weight: 2, Argument: &config.PriorityArgument{LabelPreference: &config.LabelPreference{}}},
 				},
 			},
-			expected: errors.New("LabelPreference  priority \"customPriority2\" has a different weight with \"customPriority1\""),
+			expected: ValidateError{errMsg: "LabelPreference  priority \"customPriority2\" has a different weight with \"customPriority1\""},
 		},
 		{
 			name: "different weights for ServiceAntiAffinity custom priority",
@@ -328,28 +327,32 @@ func TestValidatePolicy(t *testing.T) {
 					{Name: "customPriority2", Weight: 2, Argument: &config.PriorityArgument{ServiceAntiAffinity: &config.ServiceAntiAffinity{}}},
 				},
 			},
-			expected: errors.New("ServiceAntiAffinity  priority \"customPriority2\" has a different weight with \"customPriority1\""),
+			expected: ValidateError{errMsg: "ServiceAntiAffinity  priority \"customPriority2\" has a different weight with \"customPriority1\""},
 		},
 		{
 			name: "invalid hardPodAffinitySymmetricWeight, above the range",
 			policy: config.Policy{
 				HardPodAffinitySymmetricWeight: 101,
 			},
-			expected: errors.New("hardPodAffinitySymmetricWeight: Invalid value: 101: not in valid range [0-100]"),
+			expected: ValidateError{errMsg: "hardPodAffinitySymmetricWeight: Invalid value: 101: not in valid range [0-100]"},
 		},
 		{
 			name: "invalid hardPodAffinitySymmetricWeight, below the range",
 			policy: config.Policy{
 				HardPodAffinitySymmetricWeight: -1,
 			},
-			expected: errors.New("hardPodAffinitySymmetricWeight: Invalid value: -1: not in valid range [0-100]"),
+			expected: ValidateError{errMsg: "hardPodAffinitySymmetricWeight: Invalid value: -1: not in valid range [0-100]"},
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			actual := ValidatePolicy(test.policy)
-			if fmt.Sprint(test.expected) != fmt.Sprint(actual) {
+			actualMag := ""
+			if actual != nil {
+				actualMag = actual.Error()
+			}
+			if !errors.Is(test.expected, ValidateError{errMsg: actualMag}) {
 				t.Errorf("expected: %s, actual: %s", test.expected, actual)
 			}
 		})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #95047

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
