### PR TITLE
Fix vendor/k8s.io/client-go/discovery/cached/memory staticcheck

### DIFF
--- a/hack/.staticcheck_failures
+++ b/hack/.staticcheck_failures
@@ -50,7 +50,6 @@ vendor/k8s.io/apiserver/plugin/pkg/authenticator/token/webhook
 vendor/k8s.io/apiserver/plugin/pkg/authorizer/webhook
 vendor/k8s.io/cli-runtime/pkg/printers
 vendor/k8s.io/client-go/discovery
-vendor/k8s.io/client-go/discovery/cached/memory
 vendor/k8s.io/client-go/dynamic/fake
 vendor/k8s.io/client-go/metadata/fake
 vendor/k8s.io/client-go/rest

--- a/staging/src/k8s.io/client-go/discovery/cached/memory/memcache_test.go
+++ b/staging/src/k8s.io/client-go/discovery/cached/memory/memcache_test.go
@@ -95,6 +95,9 @@ func TestClient(t *testing.T) {
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
+	if e, a := fake.groupList, g; !reflect.DeepEqual(e, a) {
+		t.Errorf("Expected %#v, got %#v", e, a)
+	}
 	if !c.Fresh() {
 		t.Errorf("Expected fresh.")
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Fixes staticcheck failure for vendor/k8s.io/client-go/discovery/cached/memory by validating return value (g).
```
Errors from staticcheck:                                                                                                                                      
vendor/k8s.io/client-go/discovery/cached/memory/memcache_test.go:94:2: this value of g is never used (SA4006)
```

**Which issue(s) this PR fixes**:
Part of #92402

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
NONE

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
