### PR TITLE
fake dynamic client: document that List does not preserve TypeMeta in UnstructuredList

### DIFF
--- a/staging/src/k8s.io/client-go/dynamic/fake/simple.go
+++ b/staging/src/k8s.io/client-go/dynamic/fake/simple.go
@@ -35,7 +35,9 @@ import (
 
 func NewSimpleDynamicClient(scheme *runtime.Scheme, objects ...runtime.Object) *FakeDynamicClient {
 	// In order to use List with this client, you have to have the v1.List registered in your scheme. Neat thing though
-	// it does NOT have to be the *same* list
+	// it does NOT have to be the *same* list. UnstructuredList returned from this fake client will NOT have apiVersion and kind set,
+	// but each Unstructured object in Items will preserve their respective apiVersion and kind. As a result, schema conversion for
+	// *List kinds will not work and conversion of each Unstructured object in Items will be required instead.
 	scheme.AddKnownTypeWithName(schema.GroupVersionKind{Group: "fake-dynamic-client-group", Version: "v1", Kind: "List"}, &unstructured.UnstructuredList{})
 
 	codecs := serializer.NewCodecFactory(scheme)


### PR DESCRIPTION
Signed-off-by: Andrew Sy Kim <kim.andrewsy@gmail.com>

**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
The fake dynamic client does not directly handle *List kinds (at least today) which results in UnstructuredList objects losing their TypeMeta (apiVersion + kind). This results in UnstructuredList to fail schema conversion since it's Kind is no longer defined. A reasonable workaround is to pass each Unstructured object in `Items` for conversion since each individual object will have it's TypeMeta preserved. This behavior in the fake dynamic client should be documented better. 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
fake dynamic client: document that List does not preserve TypeMeta in UnstructuredList
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
