### PR TITLE
Automated cherry pick of #94988: kubeadm: warn but do not error out on missing CA keys on

### DIFF
--- a/cmd/kubeadm/app/phases/certs/certs_test.go
+++ b/cmd/kubeadm/app/phases/certs/certs_test.go
@@ -402,6 +402,19 @@ func TestSharedCertificateExists(t *testing.T) {
 			expectedError: true,
 		},
 		{
+			name: "missing ca.key",
+			files: certstestutil.PKIFiles{
+				"ca.crt":             caCert,
+				"front-proxy-ca.crt": caCert,
+				"front-proxy-ca.key": caKey,
+				"sa.pub":             publicKey,
+				"sa.key":             key,
+				"etcd/ca.crt":        caCert,
+				"etcd/ca.key":        caKey,
+			},
+			expectedError: false,
+		},
+		{
 			name: "missing sa.key",
 			files: certstestutil.PKIFiles{
 				"ca.crt":             caCert,
@@ -642,7 +655,7 @@ func TestValidateMethods(t *testing.T) {
 			name:            "validateCACertAndKey (key missing)",
 			validateFunc:    validateCACertAndKey,
 			loc:             certKeyLocation{caBaseName: "ca", baseName: "", uxName: "CA"},
-			expectedSuccess: false,
+			expectedSuccess: true,
 		},
 		{
 			name: "validateSignedCert",
@@ -665,6 +678,15 @@ func TestValidateMethods(t *testing.T) {
 			validateFunc:    validatePrivatePublicKey,
 			loc:             certKeyLocation{baseName: "sa", uxName: "service account"},
 			expectedSuccess: true,
+		},
+		{
+			name: "validatePrivatePublicKey (missing key)",
+			files: certstestutil.PKIFiles{
+				"sa.pub": key.Public(),
+			},
+			validateFunc:    validatePrivatePublicKey,
+			loc:             certKeyLocation{baseName: "sa", uxName: "service account"},
+			expectedSuccess: false,
 		},
 	}
 


### PR DESCRIPTION
Cherry pick of #94988 on release-1.19.

#94988: kubeadm: warn but do not error out on missing CA keys on

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.