### PR TITLE
kubeadm: deprecate self-hosting support

### DIFF
--- a/cmd/kubeadm/app/cmd/alpha/alpha.go
+++ b/cmd/kubeadm/app/cmd/alpha/alpha.go
@@ -30,7 +30,15 @@ func NewCmdAlpha(in io.Reader, out io.Writer) *cobra.Command {
 	}
 
 	cmd.AddCommand(newCmdKubeConfigUtility(out))
-	cmd.AddCommand(NewCmdSelfhosting(in))
+
+	const shDeprecatedMessage = "self-hosting support in kubeadm is deprecated " +
+		"and will be removed in a future release"
+	shCommand := NewCmdSelfhosting(in)
+	shCommand.Deprecated = shDeprecatedMessage
+	for _, cmd := range shCommand.Commands() {
+		cmd.Deprecated = shDeprecatedMessage
+	}
+	cmd.AddCommand(shCommand)
 
 	certsCommand := NewCmdCertsUtility(out)
 	deprecateCertsCommand(certsCommand)


### PR DESCRIPTION
**What this PR does / why we need it**:

Deprecate the experimental command "alpha self-hosting" and its
sub-command "pivot" that can be used to create a self-hosting
control-plane from static Pods.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
xref https://github.com/kubernetes/kubeadm/issues/2299

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kubeadm: deprecate self-hosting support. The experimental command "kubeadm alpha self-hosting" is now deprecated and will be removed in a future release.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
