### PR TITLE
Fix test "[sig-windows] DNS should support configurable pod DNS servers" 

### DIFF
--- a/test/e2e/windows/dns.go
+++ b/test/e2e/windows/dns.go
@@ -67,7 +67,7 @@ var _ = SIGDescribe("DNS", func() {
 			Command:       cmd,
 			Namespace:     f.Namespace.Name,
 			PodName:       testUtilsPod.Name,
-			ContainerName: "util",
+			ContainerName: "agnhost-container",
 			CaptureStdout: true,
 			CaptureStderr: true,
 		})


### PR DESCRIPTION
With the changes introduced by agnhost refactoring PR, this test was left searching for a invalid container name. Updated to the proper name.

/sig windows

```release-note
NONE
```