### PR TITLE
netpol: Add CRUD tests for NetworkPolicy API

### DIFF
--- a/test/e2e/network/network_policy.go
+++ b/test/e2e/network/network_policy.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
+	"time"
 
 	v1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
@@ -28,6 +29,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
@@ -2266,3 +2269,179 @@ func cleanupNetworkPolicy(f *framework.Framework, policy *networkingv1.NetworkPo
 		framework.Failf("unable to cleanup policy %v: %v", policy.Name, err)
 	}
 }
+
+var _ = SIGDescribe("NetworkPolicy API", func() {
+	f := framework.NewDefaultFramework("networkpolicies")
+	/*
+		Release: v1.20
+		Testname: NetworkPolicies API
+		Description:
+		- The networking.k8s.io API group MUST exist in the /apis discovery document.
+		- The networking.k8s.io/v1 API group/version MUST exist in the /apis/networking.k8s.io discovery document.
+		- The NetworkPolicies resources MUST exist in the /apis/networking.k8s.io/v1 discovery document.
+		- The NetworkPolicies resource must support create, get, list, watch, update, patch, delete, and deletecollection.
+	*/
+
+	ginkgo.It("should support creating NetworkPolicy API operations", func() {
+		// Setup
+		ns := f.Namespace.Name
+		npVersion := "v1"
+		npClient := f.ClientSet.NetworkingV1().NetworkPolicies(ns)
+		npTemplate := &networkingv1.NetworkPolicy{
+			ObjectMeta: metav1.ObjectMeta{GenerateName: "e2e-example-netpol",
+				Labels: map[string]string{
+					"special-label": f.UniqueName,
+				}},
+			Spec: networkingv1.NetworkPolicySpec{
+				// Apply this policy to the Server
+				PodSelector: metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						"pod-name": "test-pod",
+					},
+				},
+				// Allow traffic only from client-a in namespace-b
+				Ingress: []networkingv1.NetworkPolicyIngressRule{{
+					From: []networkingv1.NetworkPolicyPeer{{
+						NamespaceSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								"ns-name": "pod-b",
+							},
+						},
+						PodSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								"pod-name": "client-a",
+							},
+						},
+					}},
+				}},
+			},
+		}
+		// Discovery
+		ginkgo.By("getting /apis")
+		{
+			discoveryGroups, err := f.ClientSet.Discovery().ServerGroups()
+			framework.ExpectNoError(err)
+			found := false
+			for _, group := range discoveryGroups.Groups {
+				if group.Name == networkingv1.GroupName {
+					for _, version := range group.Versions {
+						if version.Version == npVersion {
+							found = true
+							break
+						}
+					}
+				}
+			}
+			framework.ExpectEqual(found, true, fmt.Sprintf("expected networking API group/version, got %#v", discoveryGroups.Groups))
+		}
+		ginkgo.By("getting /apis/networking.k8s.io")
+		{
+			group := &metav1.APIGroup{}
+			err := f.ClientSet.Discovery().RESTClient().Get().AbsPath("/apis/networking.k8s.io").Do(context.TODO()).Into(group)
+			framework.ExpectNoError(err)
+			found := false
+			for _, version := range group.Versions {
+				if version.Version == npVersion {
+					found = true
+					break
+				}
+			}
+			framework.ExpectEqual(found, true, fmt.Sprintf("expected networking API version, got %#v", group.Versions))
+		}
+		ginkgo.By("getting /apis/networking.k8s.io" + npVersion)
+		{
+			resources, err := f.ClientSet.Discovery().ServerResourcesForGroupVersion(networkingv1.SchemeGroupVersion.String())
+			framework.ExpectNoError(err)
+			foundNetPol := false
+			for _, resource := range resources.APIResources {
+				switch resource.Name {
+				case "networkpolicies":
+					foundNetPol = true
+				}
+			}
+			framework.ExpectEqual(foundNetPol, true, fmt.Sprintf("expected networkpolicies, got %#v", resources.APIResources))
+		}
+		// NetPol resource create/read/update/watch verbs
+		ginkgo.By("creating")
+		_, err := npClient.Create(context.TODO(), npTemplate, metav1.CreateOptions{})
+		framework.ExpectNoError(err)
+		_, err = npClient.Create(context.TODO(), npTemplate, metav1.CreateOptions{})
+		framework.ExpectNoError(err)
+		createdNetPol, err := npClient.Create(context.TODO(), npTemplate, metav1.CreateOptions{})
+		framework.ExpectNoError(err)
+
+		ginkgo.By("getting")
+		gottenNetPol, err := npClient.Get(context.TODO(), createdNetPol.Name, metav1.GetOptions{})
+		framework.ExpectNoError(err)
+		framework.ExpectEqual(gottenNetPol.UID, createdNetPol.UID)
+
+		ginkgo.By("listing")
+		nps, err := npClient.List(context.TODO(), metav1.ListOptions{LabelSelector: "special-label=" + f.UniqueName})
+		framework.ExpectNoError(err)
+		framework.ExpectEqual(len(nps.Items), 3, "filtered list should have 3 items")
+
+		ginkgo.By("watching")
+		framework.Logf("starting watch")
+		npWatch, err := npClient.Watch(context.TODO(), metav1.ListOptions{ResourceVersion: nps.ResourceVersion, LabelSelector: "special-label=" + f.UniqueName})
+		framework.ExpectNoError(err)
+		// Test cluster-wide list and watch
+		clusterNPClient := f.ClientSet.NetworkingV1().NetworkPolicies("")
+		ginkgo.By("cluster-wide listing")
+		clusterNPs, err := clusterNPClient.List(context.TODO(), metav1.ListOptions{LabelSelector: "special-label=" + f.UniqueName})
+		framework.ExpectNoError(err)
+		framework.ExpectEqual(len(clusterNPs.Items), 3, "filtered list should have 3 items")
+
+		ginkgo.By("cluster-wide watching")
+		framework.Logf("starting watch")
+		_, err = clusterNPClient.Watch(context.TODO(), metav1.ListOptions{ResourceVersion: nps.ResourceVersion, LabelSelector: "special-label=" + f.UniqueName})
+		framework.ExpectNoError(err)
+
+		ginkgo.By("patching")
+		patchedNetPols, err := npClient.Patch(context.TODO(), createdNetPol.Name, types.MergePatchType, []byte(`{"metadata":{"annotations":{"patched":"true"}}}`), metav1.PatchOptions{})
+		framework.ExpectNoError(err)
+		framework.ExpectEqual(patchedNetPols.Annotations["patched"], "true", "patched object should have the applied annotation")
+
+		ginkgo.By("updating")
+		npToUpdate := patchedNetPols.DeepCopy()
+		npToUpdate.Annotations["updated"] = "true"
+		updatedNetPols, err := npClient.Update(context.TODO(), npToUpdate, metav1.UpdateOptions{})
+		framework.ExpectNoError(err)
+		framework.ExpectEqual(updatedNetPols.Annotations["updated"], "true", "updated object should have the applied annotation")
+
+		framework.Logf("waiting for watch events with expected annotations")
+		for sawAnnotations := false; !sawAnnotations; {
+			select {
+			case evt, ok := <-npWatch.ResultChan():
+				framework.ExpectEqual(ok, true, "watch channel should not close")
+				framework.ExpectEqual(evt.Type, watch.Modified)
+				watchedNetPol, isNetPol := evt.Object.(*networkingv1.NetworkPolicy)
+				framework.ExpectEqual(isNetPol, true, fmt.Sprintf("expected NetworkPolicy, got %T", evt.Object))
+				if watchedNetPol.Annotations["patched"] == "true" && watchedNetPol.Annotations["updated"] == "true" {
+					framework.Logf("saw patched and updated annotations")
+					sawAnnotations = true
+					npWatch.Stop()
+				} else {
+					framework.Logf("missing expected annotations, waiting: %#v", watchedNetPol.Annotations)
+				}
+			case <-time.After(wait.ForeverTestTimeout):
+				framework.Fail("timed out waiting for watch event")
+			}
+		}
+		// NetPol resource delete operations
+		ginkgo.By("deleting")
+		err = npClient.Delete(context.TODO(), createdNetPol.Name, metav1.DeleteOptions{})
+		framework.ExpectNoError(err)
+		_, err = npClient.Get(context.TODO(), createdNetPol.Name, metav1.GetOptions{})
+		framework.ExpectEqual(apierrors.IsNotFound(err), true, fmt.Sprintf("expected 404, got %#v", err))
+		nps, err = npClient.List(context.TODO(), metav1.ListOptions{LabelSelector: "special-label=" + f.UniqueName})
+		framework.ExpectNoError(err)
+		framework.ExpectEqual(len(nps.Items), 2, "filtered list should have 2 items")
+
+		ginkgo.By("deleting a collection")
+		err = npClient.DeleteCollection(context.TODO(), metav1.DeleteOptions{}, metav1.ListOptions{LabelSelector: "special-label=" + f.UniqueName})
+		framework.ExpectNoError(err)
+		nps, err = npClient.List(context.TODO(), metav1.ListOptions{LabelSelector: "special-label=" + f.UniqueName})
+		framework.ExpectNoError(err)
+		framework.ExpectEqual(len(nps.Items), 0, "filtered list should have 0 items")
+	})
+})


### PR DESCRIPTION
**What type of PR is this?**
/kind feature
/area conformance
/area test

**What this PR does / why we need it**:
- Adds CRUD API tests for the V1 NetworkPolicy suitable for promotion to conformance.
- CRUD operations are the extent of conformance testing that we can add
for NetworkPolicy tests since we require a 3rd party plugin like CNI for enforcement.


**Which issue(s) this PR fixes**:
xref: #94776

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

