### PR TITLE
Don't add empty AZ labels to OpenStack pre-provisioned PVs

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/openstack/openstack_volumes.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/openstack/openstack_volumes.go
@@ -744,8 +744,12 @@ func (os *OpenStack) GetLabelsForVolume(ctx context.Context, pv *v1.PersistentVo
 
 	// Construct Volume Labels
 	labels := make(map[string]string)
-	labels[v1.LabelZoneFailureDomain] = volume.AvailabilityZone
-	labels[v1.LabelZoneRegion] = os.region
+	if volume.AvailabilityZone != "" {
+		labels[v1.LabelZoneFailureDomain] = volume.AvailabilityZone
+	}
+	if os.region != "" {
+		labels[v1.LabelZoneRegion] = os.region
+	}
 	klog.V(4).Infof("The Volume %s has labels %v", pv.Spec.Cinder.VolumeID, labels)
 
 	return labels, nil


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
There is a discrepancy in OpenStack PVLabeler implementation between the dynamic and manual PV provisioning. In case of dynamic provisioning the AZ labels are being added only if they're not empty, however for pre-provisioned volumes the labels are added always which may result in scheduling conflict on clusters with empty region. 

Dynamic provisioner AZ labeling code:
https://github.com/kubernetes/kubernetes/blob/master/pkg/volume/cinder/cinder_util.go#L228-L237

```release-note
NONE
```