### PR TITLE
fix detach azure disk issue when vm not exist

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_controller_common.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_controller_common.go
@@ -49,7 +49,9 @@ const (
 	errLeaseFailed       = "AcquireDiskLeaseFailed"
 	errLeaseIDMissing    = "LeaseIdMissing"
 	errContainerNotFound = "ContainerNotFound"
-	errDiskBlobNotFound  = "DiskBlobNotFound"
+	errStatusCode400     = "statuscode=400"
+	errInvalidParameter  = `code="invalidparameter"`
+	errTargetInstanceIds = `target="instanceids"`
 	sourceSnapshot       = "snapshot"
 	sourceVolume         = "volume"
 
@@ -214,24 +216,32 @@ func (c *controllerCommon) DetachDisk(diskName, diskURI string, nodeName types.N
 	c.diskAttachDetachMap.Delete(strings.ToLower(diskURI))
 	c.vmLockMap.UnlockEntry(strings.ToLower(string(nodeName)))
 
-	if err != nil && retry.IsErrorRetriable(err) && c.cloud.CloudProviderBackoff {
-		klog.V(2).Infof("azureDisk - update backing off: detach disk(%s, %s), err: %v", diskName, diskURI, err)
-		retryErr := kwait.ExponentialBackoff(c.cloud.RequestBackoff(), func() (bool, error) {
-			c.vmLockMap.LockEntry(strings.ToLower(string(nodeName)))
-			c.diskAttachDetachMap.Store(strings.ToLower(diskURI), "detaching")
-			err := vmset.DetachDisk(diskName, diskURI, nodeName)
-			c.diskAttachDetachMap.Delete(strings.ToLower(diskURI))
-			c.vmLockMap.UnlockEntry(strings.ToLower(string(nodeName)))
+	if err != nil {
+		if isInstanceNotFoundError(err) {
+			// if host doesn't exist, no need to detach
+			klog.Warningf("azureDisk - got InstanceNotFoundError(%v), DetachDisk(%s) will assume disk is already detached",
+				err, diskURI)
+			return nil
+		}
+		if retry.IsErrorRetriable(err) && c.cloud.CloudProviderBackoff {
+			klog.Warningf("azureDisk - update backing off: detach disk(%s, %s), err: %v", diskName, diskURI, err)
+			retryErr := kwait.ExponentialBackoff(c.cloud.RequestBackoff(), func() (bool, error) {
+				c.vmLockMap.LockEntry(strings.ToLower(string(nodeName)))
+				c.diskAttachDetachMap.Store(strings.ToLower(diskURI), "detaching")
+				err := vmset.DetachDisk(diskName, diskURI, nodeName)
+				c.diskAttachDetachMap.Delete(strings.ToLower(diskURI))
+				c.vmLockMap.UnlockEntry(strings.ToLower(string(nodeName)))
 
-			retriable := false
-			if err != nil && retry.IsErrorRetriable(err) {
-				retriable = true
+				retriable := false
+				if err != nil && retry.IsErrorRetriable(err) {
+					retriable = true
+				}
+				return !retriable, err
+			})
+			if retryErr != nil {
+				err = retryErr
+				klog.V(2).Infof("azureDisk - update abort backoff: detach disk(%s, %s), err: %v", diskName, diskURI, err)
 			}
-			return !retriable, err
-		})
-		if retryErr != nil {
-			err = retryErr
-			klog.V(2).Infof("azureDisk - update abort backoff: detach disk(%s, %s), err: %v", diskName, diskURI, err)
 		}
 	}
 	if err != nil {
@@ -425,4 +435,9 @@ func getValidCreationData(subscriptionID, resourceGroup, sourceResourceID, sourc
 		CreateOption:     compute.Copy,
 		SourceResourceID: &sourceResourceID,
 	}, nil
+}
+
+func isInstanceNotFoundError(err error) bool {
+	errMsg := strings.ToLower(err.Error())
+	return strings.Contains(errMsg, errStatusCode400) && strings.Contains(errMsg, errInvalidParameter) && strings.Contains(errMsg, errTargetInstanceIds)
 }

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_controller_common_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_controller_common_test.go
@@ -788,3 +788,32 @@ func TestFilterNonExistingDisksWithSpecialHTTPStatusCode(t *testing.T) {
 	assert.Equal(t, 1, len(filteredDisks))
 	assert.Equal(t, newDiskName, *filteredDisks[0].Name)
 }
+
+func TestIsInstanceNotFoundError(t *testing.T) {
+	testCases := []struct {
+		errMsg         string
+		expectedResult bool
+	}{
+		{
+			errMsg:         "",
+			expectedResult: false,
+		},
+		{
+			errMsg:         "other error",
+			expectedResult: false,
+		},
+		{
+			errMsg:         "not an active Virtual Machine scale set vm",
+			expectedResult: false,
+		},
+		{
+			errMsg:         `compute.VirtualMachineScaleSetVMsClient#Update: Failure sending request: StatusCode=400 -- Original Error: Code="InvalidParameter" Message="The provided instanceId 1181 is not an active Virtual Machine Scale Set VM instanceId." Target="instanceIds"`,
+			expectedResult: true,
+		},
+	}
+
+	for i, test := range testCases {
+		result := isInstanceNotFoundError(fmt.Errorf(test.errMsg))
+		assert.Equal(t, test.expectedResult, result, "TestCase[%d]", i, result)
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
fix detach azure disk issue when vm not exist

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #90986

**Special notes for your reviewer**:

 - following two instances were deleted 3min ago before kube-controller-manager trying to attach/detach

```
E0929 06:15:58.829232       1 azure_controller_common.go:201] azureDisk - detach disk(, /subscriptions/xxx/resourceGroups/mc_rg-corvette_corvette_northeurope/providers/Microsoft.Compute/disks/kubernetes-dynamic-pvc-313789cd-82a4-4a16-be0e-11a75b6cc7af) failed, err: compute.VirtualMachineScaleSetVMsClient#Update: Failure sending request: StatusCode=400 -- Original Error: Code="InvalidParameter" Message="The provided instanceId 1177 is not an active Virtual Machine Scale Set VM instanceId." Target="instanceIds"

E0929 06:15:43.823113       1 azure_controller_vmss.go:165] azureDisk - detach disk(, /subscriptions/xxx/resourceGroups/mc_rg-corvette_corvette_northeurope/providers/Microsoft.Compute/disks/kubernetes-dynamic-pvc-ce73f28d-3ad7-47ce-a1e3-07ff4dcce4c2) on rg(mc_rg-corvette_corvette_northeurope) vm(aks-platform-34667809-vmss0000w0) failed, err: compute.VirtualMachineScaleSetVMsClient#Update: Failure sending request: StatusCode=400 -- Original Error: Code="InvalidParameter" Message="The provided instanceId 1152 is not an active Virtual Machine Scale Set VM instanceId." Target="instanceIds"
```

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
fix detach azure disk issue when vm not exist
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
fix detach azure disk issue when vm not exist
```

/kind bug
/assign @feiskyer 
/priority important-soon
/sig cloud-provider
/area provider/azure