### PR TITLE
Fix du command to be portable (#95172)

### DIFF
--- a/pkg/volume/testing/testing.go
+++ b/pkg/volume/testing/testing.go
@@ -1427,15 +1427,14 @@ func FindEmptyDirectoryUsageOnTmpfs() (*resource.Quantity, error) {
 		return nil, err
 	}
 	defer os.RemoveAll(tmpDir)
-	out, err := exec.New().Command("nice", "-n", "19", "du", "-x", "-s", "-B", "1", tmpDir).CombinedOutput()
+	out, err := exec.New().Command("nice", "-n", "19", "du", "-x", "-s", "-k", tmpDir).CombinedOutput()
 	if err != nil {
 		return nil, fmt.Errorf("failed command 'du' on %s with error %v", tmpDir, err)
 	}
-	used, err := resource.ParseQuantity(strings.Fields(string(out))[0])
+	used, err := resource.ParseQuantity(strings.Fields(string(out))[0] + "Ki")
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse 'du' output %s due to error %v", out, err)
 	}
-	used.Format = resource.BinarySI
 	return &used, nil
 }
 

--- a/pkg/volume/util/fs/fs.go
+++ b/pkg/volume/util/fs/fs.go
@@ -67,16 +67,14 @@ func DiskUsage(path string) (*resource.Quantity, error) {
 		return nil, fmt.Errorf("unable to retrieve disk consumption via quota for %s: %v", path, err)
 	}
 	// Uses the same niceness level as cadvisor.fs does when running du
-	// Uses -B 1 to always scale to a blocksize of 1 byte
-	out, err := exec.Command("nice", "-n", "19", "du", "-x", "-s", "-B", "1", path).CombinedOutput()
+	out, err := exec.Command("nice", "-n", "19", "du", "-x", "-s", "-k", path).CombinedOutput()
 	if err != nil {
-		return nil, fmt.Errorf("failed command 'du' ($ nice -n 19 du -x -s -B 1) on path %s with error %v", path, err)
+		return nil, fmt.Errorf("failed command 'du' ($ nice -n 19 du -x -s -k) on path %s with error %v", path, err)
 	}
-	used, err := resource.ParseQuantity(strings.Fields(string(out))[0])
+	used, err := resource.ParseQuantity(strings.Fields(string(out))[0] + "Ki")
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse 'du' output %s due to error %v", out, err)
 	}
-	used.Format = resource.BinarySI
 	return &used, nil
 }
 


### PR DESCRIPTION
The `-B 1` argument is not defiend in POSIX du[1] and does not work with
busybox du. Fix this by using `-k` and append "Ki" for the ParseQuantity
call.

`resource.ParseQuantity()` will set the format to `BinarySI` when there
is a "Ki" suffix so we can remove the explicit set of the format.

[1]: https://pubs.opengroup.org/onlinepubs/9699919799/utilities/du.html

Signed-off-by: Natanael Copa <ncopa@mirantis.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

Makes kubernetes work with `busybox du` used on Alpine Linux without depending on GNU coreutils `du` implementaion.

**Which issue(s) this PR fixes**:
Fixes #95172

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [Other doc]: https://pubs.opengroup.org/onlinepubs/9699919799/utilities/du.html
```
