### PR TITLE
fix staticcheck for kubectl pkg files

### DIFF
--- a/hack/.staticcheck_failures
+++ b/hack/.staticcheck_failures
@@ -58,7 +58,5 @@ vendor/k8s.io/client-go/rest/watch
 vendor/k8s.io/client-go/restmapper
 vendor/k8s.io/client-go/tools/leaderelection
 vendor/k8s.io/client-go/transport
-vendor/k8s.io/kubectl/pkg/cmd/get
 vendor/k8s.io/kubectl/pkg/cmd/scale
-vendor/k8s.io/kubectl/pkg/cmd/testing
 vendor/k8s.io/metrics/pkg/client/custom_metrics

--- a/staging/src/k8s.io/kubectl/pkg/cmd/get/customcolumn.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/get/customcolumn.go
@@ -162,8 +162,8 @@ func (s *CustomColumnsPrinter) PrintObj(obj runtime.Object, out io.Writer) error
 		return fmt.Errorf(printers.InternalObjectPrinterErr)
 	}
 
-	if w, found := out.(*tabwriter.Writer); !found {
-		w = printers.GetNewTabWriter(out)
+	if _, found := out.(*tabwriter.Writer); !found {
+		w := printers.GetNewTabWriter(out)
 		out = w
 		defer w.Flush()
 	}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/get/get_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/get/get_test.go
@@ -55,7 +55,6 @@ import (
 )
 
 var (
-	openapiSchemaPath  = filepath.Join("..", "..", "..", "testdata", "openapi", "swagger.json")
 	grace              = int64(30)
 	enableServiceLinks = corev1.DefaultEnableServiceLinks
 )
@@ -90,6 +89,7 @@ func testComponentStatusData() *corev1.ComponentStatusList {
 // Verifies that schemas that are not in the master tree of Kubernetes can be retrieved via Get.
 func TestGetUnknownSchemaObject(t *testing.T) {
 	t.Skip("This test is completely broken.  The first thing it does is add the object to the scheme!")
+	var openapiSchemaPath = filepath.Join("..", "..", "..", "testdata", "openapi", "swagger.json")
 	tf := cmdtesting.NewTestFactory().WithNamespace("test")
 	defer tf.Cleanup()
 	_, _, codec := cmdtesting.NewExternalScheme()

--- a/staging/src/k8s.io/kubectl/pkg/cmd/testing/fake.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/testing/fake.go
@@ -18,7 +18,6 @@ package testing
 
 import (
 	"bytes"
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -270,8 +269,6 @@ func convertExternalNamespacedType2ToInternalNamespacedType(in *ExternalNamespac
 	out.Namespace = in.Namespace
 	return nil
 }
-
-var errInvalidVersion = errors.New("not a version")
 
 // ValidVersion of API
 var ValidVersion = "v1"


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
fixes pkg/kubectl static checks for
- staging/src/k8s.io/kubectl/pkg/cmd/get/customcolumn.go
- staging/src/k8s.io/kubectl/pkg/cmd/get/get_test.go
- staging/src/k8s.io/kubectl/pkg/cmd/testing/fake.go

**Which issue(s) this PR fixes**:
Part of #92402

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
