### PR TITLE
Graduates the DisableAcceleratorUsageMetrics feature to beta

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -634,6 +634,7 @@ const (
 
 	// owner: @RenaudWasTaken @dashpole
 	// alpha: v1.19
+	// beta: v1.20
 	//
 	// Disables Accelerator Metrics Collected by Kubelet
 	DisableAcceleratorUsageMetrics featuregate.Feature = "DisableAcceleratorUsageMetrics"
@@ -733,7 +734,7 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 	SetHostnameAsFQDN:                              {Default: false, PreRelease: featuregate.Alpha},
 	WinOverlay:                                     {Default: true, PreRelease: featuregate.Beta},
 	WinDSR:                                         {Default: false, PreRelease: featuregate.Alpha},
-	DisableAcceleratorUsageMetrics:                 {Default: false, PreRelease: featuregate.Alpha},
+	DisableAcceleratorUsageMetrics:                 {Default: true, PreRelease: featuregate.Beta},
 
 	// inherited features from generic apiserver, relisted here to get a conflict if it is changed
 	// unintentionally on either side:


### PR DESCRIPTION
**What type of PR is this?**
/kind feature
/kind api-change

**What this PR does / why we need it**: Graduates the DisableAcceleratorUsageMetrics feature to beta
**Which issue(s) this PR fixes**:  See https://github.com/kubernetes/enhancements/issues/1867 (but does not fix)
**Special notes for your reviewer**: Will need to wait for the (kep)[https://github.com/kubernetes/enhancements/pull/2036] to be updated

**Does this PR introduce a user-facing change?**: Yes!
```release-note
GPU metrics provided by kubelet are now disabled by default
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs
- [KEP]: https://github.com/kubernetes/enhancements/pull/2036
```
