### PR TITLE
sort internal ips based on device number

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/aws/aws.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/aws/aws.go
@@ -1556,13 +1556,16 @@ func parseMetadataLocalHostname(metadata string) (string, []string) {
 
 // extractNodeAddresses maps the instance information from EC2 to an array of NodeAddresses
 func extractNodeAddresses(instance *ec2.Instance) ([]v1.NodeAddress, error) {
-	// Not clear if the order matters here, but we might as well indicate a sensible preference order
+	// We want the IPs to end up in order by interface (in particular, we want eth0's
+	// IPs first)
 
 	if instance == nil {
 		return nil, fmt.Errorf("nil instance passed to extractNodeAddresses")
 	}
 
 	addresses := []v1.NodeAddress{}
+
+	interfaceIPs := make(map[int][]string)
 
 	// handle internal network interfaces
 	for _, networkInterface := range instance.NetworkInterfaces {
@@ -1571,14 +1574,25 @@ func extractNodeAddresses(instance *ec2.Instance) ([]v1.NodeAddress, error) {
 			continue
 		}
 
+		ips := []string{}
+
 		for _, internalIP := range networkInterface.PrivateIpAddresses {
 			if ipAddress := aws.StringValue(internalIP.PrivateIpAddress); ipAddress != "" {
 				ip := net.ParseIP(ipAddress)
 				if ip == nil {
 					return nil, fmt.Errorf("EC2 instance had invalid private address: %s (%q)", aws.StringValue(instance.InstanceId), ipAddress)
 				}
-				addresses = append(addresses, v1.NodeAddress{Type: v1.NodeInternalIP, Address: ip.String()})
+				ips = append(ips, ip.String())
 			}
+		}
+
+		interfaceIPs[int(*networkInterface.Attachment.DeviceIndex)] = ip
+	}
+
+	for i := 0; i < len(interfaceIPs); i++ {
+		internalIPs := interfaceIPs[i]
+		for _, internalIP := range internalIPs {
+			addresses = append(addresses, v1.NodeAddress{Type: v1.NodeInternalIP, Address: internalIP})
 		}
 	}
 

--- a/staging/src/k8s.io/legacy-cloud-providers/aws/aws.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/aws/aws.go
@@ -1586,7 +1586,7 @@ func extractNodeAddresses(instance *ec2.Instance) ([]v1.NodeAddress, error) {
 			}
 		}
 
-		interfaceIPs[int(*networkInterface.Attachment.DeviceIndex)] = ip
+		interfaceIPs[int(*networkInterface.Attachment.DeviceIndex)] = ips
 	}
 
 	for i := 0; i < len(interfaceIPs); i++ {

--- a/staging/src/k8s.io/legacy-cloud-providers/aws/aws_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/aws/aws_test.go
@@ -603,9 +603,11 @@ func makeInstance(num int, privateIP, publicIP, privateDNSName, publicDNSName st
 		},
 	}
 	if setNetInterface == true {
+		deviceIndex := int64(0)
 		instance.NetworkInterfaces = []*ec2.InstanceNetworkInterface{
 			{
-				Status: aws.String(ec2.NetworkInterfaceStatusInUse),
+				Status:     aws.String(ec2.NetworkInterfaceStatusInUse),
+				Attachment: &ec2.InstanceNetworkInterfaceAttachment{DeviceIndex: &deviceIndex},
 				PrivateIpAddresses: []*ec2.InstancePrivateIpAddress{
 					{
 						PrivateIpAddress: aws.String(privateIP),


### PR DESCRIPTION

/kind bug


/kind flake


**What this PR does / why we need it**:

This pull relates to #61921. For k8s nodes that on AWS that have multiple NICs the IPs aren't sorted. The original work only sorted by device id for the host running the cloud-controller (masters for us). Node IPs are retrieved in a different manner and didn't sort. As a result, commands such as kubelet exec and kubelet logs attempt to forward to an IP address where the kubelet isn't listening.

**Which issue(s) this PR fixes**:

Fixes #61921

**Special notes for your reviewer**:


```release-note
NONE
```


