### PR TITLE
Change kubectl clusterinfo to non offensive words

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/clusterinfo/clusterinfo.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/clusterinfo/clusterinfo.go
@@ -38,11 +38,11 @@ import (
 
 var (
 	longDescr = templates.LongDesc(i18n.T(`
-  Display addresses of the master and services with label kubernetes.io/cluster-service=true
+  Display addresses of the control plane and services with label kubernetes.io/cluster-service=true
   To further debug and diagnose cluster problems, use 'kubectl cluster-info dump'.`))
 
 	clusterinfoExample = templates.Examples(i18n.T(`
-		# Print the address of the master and cluster services
+		# Print the address of the control plane and cluster services
 		kubectl cluster-info`))
 )
 
@@ -103,7 +103,7 @@ func (o *ClusterInfoOptions) Run() error {
 		if err != nil {
 			return err
 		}
-		printService(o.Out, "Kubernetes master", o.Client.Host)
+		printService(o.Out, "Kubernetes control plane", o.Client.Host)
 
 		services := r.Object.(*corev1.ServiceList).Items
 		for _, service := range services {

--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -1391,9 +1391,9 @@
   file: test/e2e/kubectl/kubectl.go
 - testname: Kubectl, cluster info
   codename: '[sig-cli] Kubectl client Kubectl cluster-info should check if Kubernetes
-    master services is included in cluster-info  [Conformance]'
+    control plane services is included in cluster-info  [Conformance]'
   description: Call kubectl to get cluster-info, output MUST contain cluster-info
-    returned and Kubernetes Master SHOULD be running.
+    returned and Kubernetes control plane SHOULD be running.
   release: v1.9
   file: test/e2e/kubectl/kubectl.go
 - testname: Kubectl, describe pod or rc

--- a/test/e2e/kubectl/kubectl.go
+++ b/test/e2e/kubectl/kubectl.go
@@ -1069,13 +1069,13 @@ metadata:
 		/*
 			Release: v1.9
 			Testname: Kubectl, cluster info
-			Description: Call kubectl to get cluster-info, output MUST contain cluster-info returned and Kubernetes Master SHOULD be running.
+			Description: Call kubectl to get cluster-info, output MUST contain cluster-info returned and Kubernetes control plane SHOULD be running.
 		*/
-		framework.ConformanceIt("should check if Kubernetes master services is included in cluster-info ", func() {
+		framework.ConformanceIt("should check if Kubernetes control plane services is included in cluster-info ", func() {
 			ginkgo.By("validating cluster-info")
 			output := framework.RunKubectlOrDie(ns, "cluster-info")
 			// Can't check exact strings due to terminal control commands (colors)
-			requiredItems := []string{"Kubernetes master", "is running at"}
+			requiredItems := []string{"Kubernetes control plane", "is running at"}
 			for _, item := range requiredItems {
 				if !strings.Contains(output, item) {
 					framework.Failf("Missing %s in kubectl cluster-info", item)


### PR DESCRIPTION
Signed-off-by: Ricardo Pchevuzinske Katz <ricardo.katz@gmail.com>


**What type of PR is this?**
/kind cleanup


**What this PR does / why we need it**: As ``kubectl cluster-info`` is usually one of the first commands shown in tutorials and docs, this PR changes words used in kubectl cluster-info to reference to the API Server components as ``control plane``


**Special notes for your reviewer**: No issue has been opened, can open before merging

**Does this PR introduce a user-facing change?**:
```release-note
Remove offensive words from kubectl cluster-info command
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:


/sig cli
/wg naming