### PR TITLE
Set default schedulerName in REST handler

### DIFF
--- a/cmd/kubeadm/app/phases/selfhosting/selfhosting_test.go
+++ b/cmd/kubeadm/app/phases/selfhosting/selfhosting_test.go
@@ -181,6 +181,7 @@ spec:
       nodeSelector:
         node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
+      schedulerName: ""
       tolerations:
       - effect: NoSchedule
         key: node-role.kubernetes.io/master
@@ -333,6 +334,7 @@ spec:
       nodeSelector:
         node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
+      schedulerName: ""
       tolerations:
       - effect: NoSchedule
         key: node-role.kubernetes.io/master
@@ -448,6 +450,7 @@ spec:
       nodeSelector:
         node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
+      schedulerName: ""
       tolerations:
       - effect: NoSchedule
         key: node-role.kubernetes.io/master

--- a/pkg/api/pod/BUILD
+++ b/pkg/api/pod/BUILD
@@ -12,6 +12,7 @@ go_library(
     importpath = "k8s.io/kubernetes/pkg/api/pod",
     deps = [
         "//pkg/apis/core:go_default_library",
+        "//pkg/apis/core/helper/qos:go_default_library",
         "//pkg/features:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",

--- a/pkg/apis/apps/v1/defaults_test.go
+++ b/pkg/apis/apps/v1/defaults_test.go
@@ -30,7 +30,6 @@ import (
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	_ "k8s.io/kubernetes/pkg/apis/apps/install"
 	. "k8s.io/kubernetes/pkg/apis/apps/v1"
-	api "k8s.io/kubernetes/pkg/apis/core"
 	_ "k8s.io/kubernetes/pkg/apis/core/install"
 	utilpointer "k8s.io/utils/pointer"
 )
@@ -45,7 +44,6 @@ func TestSetDefaultDaemonSetSpec(t *testing.T) {
 			RestartPolicy:                 v1.RestartPolicyAlways,
 			SecurityContext:               &v1.PodSecurityContext{},
 			TerminationGracePeriodSeconds: &period,
-			SchedulerName:                 api.DefaultSchedulerName,
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Labels: defaultLabels,
@@ -57,7 +55,6 @@ func TestSetDefaultDaemonSetSpec(t *testing.T) {
 			RestartPolicy:                 v1.RestartPolicyAlways,
 			SecurityContext:               &v1.PodSecurityContext{},
 			TerminationGracePeriodSeconds: &period,
-			SchedulerName:                 api.DefaultSchedulerName,
 		},
 	}
 	tests := []struct {
@@ -182,7 +179,6 @@ func TestSetDefaultStatefulSet(t *testing.T) {
 			RestartPolicy:                 v1.RestartPolicyAlways,
 			SecurityContext:               &v1.PodSecurityContext{},
 			TerminationGracePeriodSeconds: &period,
-			SchedulerName:                 api.DefaultSchedulerName,
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Labels: defaultLabels,
@@ -322,7 +318,6 @@ func TestSetDefaultDeployment(t *testing.T) {
 			RestartPolicy:                 v1.RestartPolicyAlways,
 			SecurityContext:               &v1.PodSecurityContext{},
 			TerminationGracePeriodSeconds: &period,
-			SchedulerName:                 api.DefaultSchedulerName,
 		},
 	}
 	tests := []struct {

--- a/pkg/apis/apps/v1beta1/BUILD
+++ b/pkg/apis/apps/v1beta1/BUILD
@@ -53,7 +53,6 @@ go_test(
     deps = [
         "//pkg/api/legacyscheme:go_default_library",
         "//pkg/apis/apps/install:go_default_library",
-        "//pkg/apis/core:go_default_library",
         "//pkg/apis/core/install:go_default_library",
         "//staging/src/k8s.io/api/apps/v1beta1:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",

--- a/pkg/apis/apps/v1beta1/defaults_test.go
+++ b/pkg/apis/apps/v1beta1/defaults_test.go
@@ -29,7 +29,6 @@ import (
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	_ "k8s.io/kubernetes/pkg/apis/apps/install"
 	. "k8s.io/kubernetes/pkg/apis/apps/v1beta1"
-	api "k8s.io/kubernetes/pkg/apis/core"
 	_ "k8s.io/kubernetes/pkg/apis/core/install"
 	utilpointer "k8s.io/utils/pointer"
 )
@@ -44,7 +43,6 @@ func TestSetDefaultDeployment(t *testing.T) {
 			RestartPolicy:                 v1.RestartPolicyAlways,
 			SecurityContext:               &v1.PodSecurityContext{},
 			TerminationGracePeriodSeconds: &period,
-			SchedulerName:                 api.DefaultSchedulerName,
 		},
 	}
 	tests := []struct {

--- a/pkg/apis/apps/v1beta2/defaults_test.go
+++ b/pkg/apis/apps/v1beta2/defaults_test.go
@@ -30,7 +30,6 @@ import (
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	_ "k8s.io/kubernetes/pkg/apis/apps/install"
 	. "k8s.io/kubernetes/pkg/apis/apps/v1beta2"
-	api "k8s.io/kubernetes/pkg/apis/core"
 	_ "k8s.io/kubernetes/pkg/apis/core/install"
 	utilpointer "k8s.io/utils/pointer"
 )
@@ -45,7 +44,6 @@ func TestSetDefaultDaemonSetSpec(t *testing.T) {
 			RestartPolicy:                 v1.RestartPolicyAlways,
 			SecurityContext:               &v1.PodSecurityContext{},
 			TerminationGracePeriodSeconds: &period,
-			SchedulerName:                 api.DefaultSchedulerName,
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Labels: defaultLabels,
@@ -57,7 +55,6 @@ func TestSetDefaultDaemonSetSpec(t *testing.T) {
 			RestartPolicy:                 v1.RestartPolicyAlways,
 			SecurityContext:               &v1.PodSecurityContext{},
 			TerminationGracePeriodSeconds: &period,
-			SchedulerName:                 api.DefaultSchedulerName,
 		},
 	}
 	tests := []struct {
@@ -181,7 +178,6 @@ func TestSetDefaultStatefulSet(t *testing.T) {
 			RestartPolicy:                 v1.RestartPolicyAlways,
 			SecurityContext:               &v1.PodSecurityContext{},
 			TerminationGracePeriodSeconds: &period,
-			SchedulerName:                 api.DefaultSchedulerName,
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Labels: defaultLabels,
@@ -292,7 +288,6 @@ func TestSetDefaultDeployment(t *testing.T) {
 			RestartPolicy:                 v1.RestartPolicyAlways,
 			SecurityContext:               &v1.PodSecurityContext{},
 			TerminationGracePeriodSeconds: &period,
-			SchedulerName:                 api.DefaultSchedulerName,
 		},
 	}
 	tests := []struct {

--- a/pkg/apis/core/v1/defaults.go
+++ b/pkg/apis/core/v1/defaults.go
@@ -216,9 +216,6 @@ func SetDefaults_PodSpec(obj *v1.PodSpec) {
 		period := int64(v1.DefaultTerminationGracePeriodSeconds)
 		obj.TerminationGracePeriodSeconds = &period
 	}
-	if obj.SchedulerName == "" {
-		obj.SchedulerName = v1.DefaultSchedulerName
-	}
 }
 func SetDefaults_Probe(obj *v1.Probe) {
 	if obj.TimeoutSeconds == 0 {

--- a/pkg/apis/core/v1/defaults_test.go
+++ b/pkg/apis/core/v1/defaults_test.go
@@ -131,7 +131,6 @@ func TestWorkloadDefaults(t *testing.T) {
 		".Spec.InitContainers[0].TerminationMessagePath":                                              `"/dev/termination-log"`,
 		".Spec.InitContainers[0].TerminationMessagePolicy":                                            `"File"`,
 		".Spec.RestartPolicy":                                                                         `"Always"`,
-		".Spec.SchedulerName":                                                                         `"default-scheduler"`,
 		".Spec.SecurityContext":                                                                       `{}`,
 		".Spec.TerminationGracePeriodSeconds":                                                         `30`,
 		".Spec.Volumes[0].VolumeSource.AzureDisk.CachingMode":                                         `"ReadWrite"`,
@@ -255,7 +254,6 @@ func TestPodDefaults(t *testing.T) {
 		".Spec.InitContainers[0].StartupProbe.SuccessThreshold":                                       "1",
 		".Spec.InitContainers[0].StartupProbe.TimeoutSeconds":                                         "1",
 		".Spec.RestartPolicy":                                                                         `"Always"`,
-		".Spec.SchedulerName":                                                                         `"default-scheduler"`,
 		".Spec.SecurityContext":                                                                       `{}`,
 		".Spec.TerminationGracePeriodSeconds":                                                         `30`,
 		".Spec.Volumes[0].VolumeSource.AzureDisk.CachingMode":                                         `"ReadWrite"`,
@@ -1891,12 +1889,12 @@ func TestSetDefaultProbe(t *testing.T) {
 	}
 }
 
-func TestSetDefaultSchedulerName(t *testing.T) {
+func TestSetDefaultSchedulerNameEmpty(t *testing.T) {
 	pod := &v1.Pod{}
 
 	output := roundTrip(t, runtime.Object(pod)).(*v1.Pod)
-	if output.Spec.SchedulerName != v1.DefaultSchedulerName {
-		t.Errorf("Expected scheduler name: %+v\ngot: %+v\n", v1.DefaultSchedulerName, output.Spec.SchedulerName)
+	if output.Spec.SchedulerName != "" {
+		t.Errorf("Expected empty scheduler name, got: %+v\n", output.Spec.SchedulerName)
 	}
 }
 

--- a/pkg/apis/extensions/v1beta1/BUILD
+++ b/pkg/apis/extensions/v1beta1/BUILD
@@ -44,7 +44,6 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//pkg/api/legacyscheme:go_default_library",
-        "//pkg/apis/core:go_default_library",
         "//pkg/apis/core/install:go_default_library",
         "//pkg/apis/extensions/install:go_default_library",
         "//pkg/apis/networking:go_default_library",

--- a/pkg/apis/extensions/v1beta1/defaults_test.go
+++ b/pkg/apis/extensions/v1beta1/defaults_test.go
@@ -30,7 +30,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
-	api "k8s.io/kubernetes/pkg/apis/core"
 	_ "k8s.io/kubernetes/pkg/apis/core/install"
 	_ "k8s.io/kubernetes/pkg/apis/extensions/install"
 	. "k8s.io/kubernetes/pkg/apis/extensions/v1beta1"
@@ -46,7 +45,6 @@ func TestSetDefaultDaemonSetSpec(t *testing.T) {
 			RestartPolicy:                 v1.RestartPolicyAlways,
 			SecurityContext:               &v1.PodSecurityContext{},
 			TerminationGracePeriodSeconds: &period,
-			SchedulerName:                 api.DefaultSchedulerName,
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Labels: defaultLabels,
@@ -58,7 +56,6 @@ func TestSetDefaultDaemonSetSpec(t *testing.T) {
 			RestartPolicy:                 v1.RestartPolicyAlways,
 			SecurityContext:               &v1.PodSecurityContext{},
 			TerminationGracePeriodSeconds: &period,
-			SchedulerName:                 api.DefaultSchedulerName,
 		},
 	}
 	tests := []struct {
@@ -170,7 +167,6 @@ func TestSetDefaultDeployment(t *testing.T) {
 			RestartPolicy:                 v1.RestartPolicyAlways,
 			SecurityContext:               &v1.PodSecurityContext{},
 			TerminationGracePeriodSeconds: &period,
-			SchedulerName:                 api.DefaultSchedulerName,
 		},
 	}
 	tests := []struct {

--- a/pkg/registry/core/pod/BUILD
+++ b/pkg/registry/core/pod/BUILD
@@ -17,7 +17,6 @@ go_library(
         "//pkg/api/legacyscheme:go_default_library",
         "//pkg/api/pod:go_default_library",
         "//pkg/apis/core:go_default_library",
-        "//pkg/apis/core/helper/qos:go_default_library",
         "//pkg/apis/core/validation:go_default_library",
         "//pkg/features:go_default_library",
         "//pkg/kubelet/client:go_default_library",
@@ -62,6 +61,7 @@ go_test(
         "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",
         "//staging/src/k8s.io/client-go/tools/cache:go_default_library",
         "//staging/src/k8s.io/component-base/featuregate/testing:go_default_library",
+        "//vendor/github.com/google/go-cmp/cmp:go_default_library",
         "//vendor/github.com/stretchr/testify/require:go_default_library",
     ],
 )

--- a/pkg/registry/core/pod/strategy.go
+++ b/pkg/registry/core/pod/strategy.go
@@ -44,7 +44,6 @@ import (
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	podutil "k8s.io/kubernetes/pkg/api/pod"
 	api "k8s.io/kubernetes/pkg/apis/core"
-	"k8s.io/kubernetes/pkg/apis/core/helper/qos"
 	"k8s.io/kubernetes/pkg/apis/core/validation"
 	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/kubelet/client"
@@ -66,25 +65,21 @@ func (podStrategy) NamespaceScoped() bool {
 	return true
 }
 
-// PrepareForCreate clears fields that are not allowed to be set by end users on creation.
+// PrepareForCreate sets the default values and clears fields that are not
+// allowed to be set by end users on creation.
 func (podStrategy) PrepareForCreate(ctx context.Context, obj runtime.Object) {
 	pod := obj.(*api.Pod)
-	pod.Status = api.PodStatus{
-		Phase:    api.PodPending,
-		QOSClass: qos.GetPodQOS(pod),
-	}
-
+	podutil.SetDefaultPodValues(pod, nil)
 	podutil.DropDisabledPodFields(pod, nil)
-
 	applySeccompVersionSkew(pod)
 }
 
-// PrepareForUpdate clears fields that are not allowed to be set by end users on update.
+// PrepareForUpdate sets the default values and clears fields that are not
+// allowed to be set by end users on update.
 func (podStrategy) PrepareForUpdate(ctx context.Context, obj, old runtime.Object) {
 	newPod := obj.(*api.Pod)
 	oldPod := old.(*api.Pod)
-	newPod.Status = oldPod.Status
-
+	podutil.SetDefaultPodValues(newPod, oldPod)
 	podutil.DropDisabledPodFields(newPod, oldPod)
 }
 

--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -3055,7 +3055,7 @@ type PodSpec struct {
 	// If specified, the pod will be dispatched by specified scheduler.
 	// If not specified, the pod will be dispatched by default scheduler.
 	// +optional
-	SchedulerName string `json:"schedulerName,omitempty" protobuf:"bytes,19,opt,name=schedulerName"`
+	SchedulerName string `json:"schedulerName" protobuf:"bytes,19,opt,name=schedulerName"`
 	// If specified, the pod's tolerations.
 	// +optional
 	Tolerations []Toleration `json:"tolerations,omitempty" protobuf:"bytes,22,opt,name=tolerations"`

--- a/staging/src/k8s.io/kube-scheduler/extender/v1/types_test.go
+++ b/staging/src/k8s.io/kube-scheduler/extender/v1/types_test.go
@@ -53,7 +53,7 @@ func TestCompatibility(t *testing.T) {
 				NodeNameToVictims:     map[string]*Victims{"foo": {Pods: []*v1.Pod{&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "podname"}}}, NumPDBViolations: 1}},
 				NodeNameToMetaVictims: map[string]*MetaVictims{"foo": {Pods: []*MetaPod{{UID: "myuid"}}, NumPDBViolations: 1}},
 			},
-			expectJSON: `{"Pod":{"metadata":{"name":"podname","creationTimestamp":null},"spec":{"containers":null},"status":{}},"NodeNameToVictims":{"foo":{"Pods":[{"metadata":{"name":"podname","creationTimestamp":null},"spec":{"containers":null},"status":{}}],"NumPDBViolations":1}},"NodeNameToMetaVictims":{"foo":{"Pods":[{"UID":"myuid"}],"NumPDBViolations":1}}}`,
+			expectJSON: `{"Pod":{"metadata":{"name":"podname","creationTimestamp":null},"spec":{"containers":null,"schedulerName":""},"status":{}},"NodeNameToVictims":{"foo":{"Pods":[{"metadata":{"name":"podname","creationTimestamp":null},"spec":{"containers":null,"schedulerName":""},"status":{}}],"NumPDBViolations":1}},"NodeNameToMetaVictims":{"foo":{"Pods":[{"UID":"myuid"}],"NumPDBViolations":1}}}`,
 		},
 		{
 			emptyObj: &ExtenderArgs{},
@@ -62,7 +62,7 @@ func TestCompatibility(t *testing.T) {
 				Nodes:     &corev1.NodeList{Items: []corev1.Node{{ObjectMeta: metav1.ObjectMeta{Name: "nodename"}}}},
 				NodeNames: &[]string{"node1"},
 			},
-			expectJSON: `{"Pod":{"metadata":{"name":"podname","creationTimestamp":null},"spec":{"containers":null},"status":{}},"Nodes":{"metadata":{},"items":[{"metadata":{"name":"nodename","creationTimestamp":null},"spec":{},"status":{"daemonEndpoints":{"kubeletEndpoint":{"Port":0}},"nodeInfo":{"machineID":"","systemUUID":"","bootID":"","kernelVersion":"","osImage":"","containerRuntimeVersion":"","kubeletVersion":"","kubeProxyVersion":"","operatingSystem":"","architecture":""}}}]},"NodeNames":["node1"]}`,
+			expectJSON: `{"Pod":{"metadata":{"name":"podname","creationTimestamp":null},"spec":{"containers":null,"schedulerName":""},"status":{}},"Nodes":{"metadata":{},"items":[{"metadata":{"name":"nodename","creationTimestamp":null},"spec":{},"status":{"daemonEndpoints":{"kubeletEndpoint":{"Port":0}},"nodeInfo":{"machineID":"","systemUUID":"","bootID":"","kernelVersion":"","osImage":"","containerRuntimeVersion":"","kubeletVersion":"","kubeProxyVersion":"","operatingSystem":"","architecture":""}}}]},"NodeNames":["node1"]}`,
 		},
 		{
 			emptyObj: &ExtenderFilterResult{},

--- a/staging/src/k8s.io/kubectl/pkg/cmd/get/BUILD
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/get/BUILD
@@ -101,6 +101,7 @@ go_test(
         "//staging/src/k8s.io/kubectl/pkg/scheme:go_default_library",
         "//staging/src/k8s.io/kubectl/pkg/util/openapi:go_default_library",
         "//staging/src/k8s.io/kubectl/pkg/util/openapi/testing:go_default_library",
+        "//vendor/github.com/google/go-cmp/cmp:go_default_library",
         "//vendor/k8s.io/kube-openapi/pkg/util/proto:go_default_library",
     ],
 )

--- a/staging/src/k8s.io/kubectl/pkg/cmd/get/get_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/get/get_test.go
@@ -29,6 +29,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	batchv1 "k8s.io/api/batch/v1"
@@ -40,7 +41,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer/streaming"
-	"k8s.io/apimachinery/pkg/util/diff"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/cli-runtime/pkg/resource"
@@ -1433,6 +1433,7 @@ func TestGetMultipleTypeObjectsAsList(t *testing.T) {
                 "dnsPolicy": "ClusterFirst",
                 "enableServiceLinks": true,
                 "restartPolicy": "Always",
+                "schedulerName": "",
                 "securityContext": {},
                 "terminationGracePeriodSeconds": 30
             },
@@ -1452,6 +1453,7 @@ func TestGetMultipleTypeObjectsAsList(t *testing.T) {
                 "dnsPolicy": "ClusterFirst",
                 "enableServiceLinks": true,
                 "restartPolicy": "Always",
+                "schedulerName": "",
                 "securityContext": {},
                 "terminationGracePeriodSeconds": 30
             },
@@ -1482,8 +1484,8 @@ func TestGetMultipleTypeObjectsAsList(t *testing.T) {
     }
 }
 `
-	if e, a := expected, buf.String(); e != a {
-		t.Errorf("did not match: %v", diff.StringDiff(e, a))
+	if diff := cmp.Diff(expected, buf.String()); diff != "" {
+		t.Errorf("did not match (-want,+got):\n%s", diff)
 	}
 }
 
@@ -2339,10 +2341,10 @@ DELETED    test        pod/foo   0/0              0          <unknown>   <none> 
 		},
 		{
 			format: "json",
-			expected: `{"type":"ADDED","object":{"apiVersion":"v1","kind":"Pod","metadata":{"creationTimestamp":null,"name":"bar","namespace":"test","resourceVersion":"9"},"spec":{"containers":null,"dnsPolicy":"ClusterFirst","enableServiceLinks":true,"restartPolicy":"Always","securityContext":{},"terminationGracePeriodSeconds":30},"status":{}}}
-{"type":"ADDED","object":{"apiVersion":"v1","kind":"Pod","metadata":{"creationTimestamp":null,"name":"foo","namespace":"test","resourceVersion":"10"},"spec":{"containers":null,"dnsPolicy":"ClusterFirst","enableServiceLinks":true,"restartPolicy":"Always","securityContext":{},"terminationGracePeriodSeconds":30},"status":{}}}
-{"type":"MODIFIED","object":{"apiVersion":"v1","kind":"Pod","metadata":{"creationTimestamp":null,"name":"foo","namespace":"test","resourceVersion":"11"},"spec":{"containers":null,"dnsPolicy":"ClusterFirst","enableServiceLinks":true,"restartPolicy":"Always","securityContext":{},"terminationGracePeriodSeconds":30},"status":{}}}
-{"type":"DELETED","object":{"apiVersion":"v1","kind":"Pod","metadata":{"creationTimestamp":null,"name":"foo","namespace":"test","resourceVersion":"12"},"spec":{"containers":null,"dnsPolicy":"ClusterFirst","enableServiceLinks":true,"restartPolicy":"Always","securityContext":{},"terminationGracePeriodSeconds":30},"status":{}}}
+			expected: `{"type":"ADDED","object":{"apiVersion":"v1","kind":"Pod","metadata":{"creationTimestamp":null,"name":"bar","namespace":"test","resourceVersion":"9"},"spec":{"containers":null,"dnsPolicy":"ClusterFirst","enableServiceLinks":true,"restartPolicy":"Always","schedulerName":"","securityContext":{},"terminationGracePeriodSeconds":30},"status":{}}}
+{"type":"ADDED","object":{"apiVersion":"v1","kind":"Pod","metadata":{"creationTimestamp":null,"name":"foo","namespace":"test","resourceVersion":"10"},"spec":{"containers":null,"dnsPolicy":"ClusterFirst","enableServiceLinks":true,"restartPolicy":"Always","schedulerName":"","securityContext":{},"terminationGracePeriodSeconds":30},"status":{}}}
+{"type":"MODIFIED","object":{"apiVersion":"v1","kind":"Pod","metadata":{"creationTimestamp":null,"name":"foo","namespace":"test","resourceVersion":"11"},"spec":{"containers":null,"dnsPolicy":"ClusterFirst","enableServiceLinks":true,"restartPolicy":"Always","schedulerName":"","securityContext":{},"terminationGracePeriodSeconds":30},"status":{}}}
+{"type":"DELETED","object":{"apiVersion":"v1","kind":"Pod","metadata":{"creationTimestamp":null,"name":"foo","namespace":"test","resourceVersion":"12"},"spec":{"containers":null,"dnsPolicy":"ClusterFirst","enableServiceLinks":true,"restartPolicy":"Always","schedulerName":"","securityContext":{},"terminationGracePeriodSeconds":30},"status":{}}}
 `,
 		},
 		{
@@ -2360,6 +2362,7 @@ DELETED    test        pod/foo   0/0              0          <unknown>   <none> 
     dnsPolicy: ClusterFirst
     enableServiceLinks: true
     restartPolicy: Always
+    schedulerName: ""
     securityContext: {}
     terminationGracePeriodSeconds: 30
   status: {}
@@ -2378,6 +2381,7 @@ object:
     dnsPolicy: ClusterFirst
     enableServiceLinks: true
     restartPolicy: Always
+    schedulerName: ""
     securityContext: {}
     terminationGracePeriodSeconds: 30
   status: {}
@@ -2396,6 +2400,7 @@ object:
     dnsPolicy: ClusterFirst
     enableServiceLinks: true
     restartPolicy: Always
+    schedulerName: ""
     securityContext: {}
     terminationGracePeriodSeconds: 30
   status: {}
@@ -2414,6 +2419,7 @@ object:
     dnsPolicy: ClusterFirst
     enableServiceLinks: true
     restartPolicy: Always
+    schedulerName: ""
     securityContext: {}
     terminationGracePeriodSeconds: 30
   status: {}
@@ -2508,8 +2514,8 @@ pod/foo
 			}
 
 			cmd.Run(cmd, []string{"pods"})
-			if e, a := tc.expected, buf.String(); e != a {
-				t.Errorf("expected\n%v\ngot\n%v", e, a)
+			if diff := cmp.Diff(tc.expected, buf.String()); diff != "" {
+				t.Errorf("did not match (-want,+got):\n%s", diff)
 			}
 		})
 	}

--- a/staging/src/k8s.io/kubectl/pkg/polymorphichelpers/rollback_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/polymorphichelpers/rollback_test.go
@@ -62,7 +62,7 @@ func TestGetDeploymentPatch(t *testing.T) {
 		t.Errorf("expected strategic merge patch, got %v", patchType)
 	}
 	expectedPatch := `[` +
-		`{"op":"replace","path":"/spec/template","value":{"metadata":{"creationTimestamp":null},"spec":{"containers":[{"name":"","image":"foo","resources":{}}]}}},` +
+		`{"op":"replace","path":"/spec/template","value":{"metadata":{"creationTimestamp":null},"spec":{"containers":[{"name":"","image":"foo","resources":{}}],"schedulerName":""}}},` +
 		`{"op":"replace","path":"/metadata/annotations","value":{"a":"true"}}` +
 		`]`
 	if string(patchBytes) != expectedPatch {


### PR DESCRIPTION
**What type of PR is this?**

/kind feature
/kind api-change

**What this PR does / why we need it**:

Set default `Pod.spec.schedulerName` in REST handler instead of API defaults.

When the scheduler name is set in the API defaults, webhooks cannot distinguish between an explicit user intent or the default produced by the apiserver.
The defaulting now happens in the REST strategy for Create and Update.

`omitempty` was removed from field annotations. This is to avoid crashing webhooks that might expect a non-nil value.
The side effect of this is that the field will be included in all PodSpec serializations, even if empty, including those of Deployments, ReplicaSets, Jobs, etc.

**Which issue(s) this PR fixes**:

Fixes #93067

**Does this PR introduce a user-facing change?**:

```release-note
[ACTION REQUIRED]: Pod.spec.schedulerName is empty in webhooks if the Pod author didn't specify it. This can be used to apply a default in a mutating webhook.
```
