### PR TITLE
storage: Use FilteredDialContext in quobyte client

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -82,7 +82,7 @@ require (
 	github.com/prometheus/client_golang v1.7.1
 	github.com/prometheus/client_model v0.2.0
 	github.com/prometheus/common v0.10.0
-	github.com/quobyte/api v0.1.2
+	github.com/quobyte/api v0.1.8
 	github.com/robfig/cron v1.1.0
 	github.com/spf13/afero v1.2.2
 	github.com/spf13/cobra v1.1.1
@@ -401,7 +401,7 @@ replace (
 	github.com/prometheus/client_model => github.com/prometheus/client_model v0.2.0
 	github.com/prometheus/common => github.com/prometheus/common v0.10.0
 	github.com/prometheus/procfs => github.com/prometheus/procfs v0.1.3
-	github.com/quobyte/api => github.com/quobyte/api v0.1.2
+	github.com/quobyte/api => github.com/quobyte/api v0.1.8
 	github.com/remyoudompheng/bigfft => github.com/remyoudompheng/bigfft v0.0.0-20170806203942-52369c62f446
 	github.com/robfig/cron => github.com/robfig/cron v1.1.0
 	github.com/rogpeppe/fastuuid => github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af

--- a/go.sum
+++ b/go.sum
@@ -425,8 +425,8 @@ github.com/prometheus/common v0.10.0 h1:RyRA7RzGXQZiW+tGMr7sxa85G1z0yOpM1qq5c8lN
 github.com/prometheus/common v0.10.0/go.mod h1:Tlit/dnDKsSWFlCLTWaA1cyBgKHSMdTB80sz/V91rCo=
 github.com/prometheus/procfs v0.1.3 h1:F0+tqvhOksq22sc6iCHF5WGlWjdwj92p0udFh1VFBS8=
 github.com/prometheus/procfs v0.1.3/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4OA4YeYWdaU=
-github.com/quobyte/api v0.1.2 h1:lPHLsuvtjFyk8WhC4uHoHRkScijIHcffTWBBP+YpzYo=
-github.com/quobyte/api v0.1.2/go.mod h1:jL7lIHrmqQ7yh05OJ+eEEdHr0u/kmT1Ff9iHd+4H6VI=
+github.com/quobyte/api v0.1.8 h1:+sOX1gIlC/OaLipqVZWrHgly9Kh9Qo8OygeS0mWAg30=
+github.com/quobyte/api v0.1.8/go.mod h1:jL7lIHrmqQ7yh05OJ+eEEdHr0u/kmT1Ff9iHd+4H6VI=
 github.com/remyoudompheng/bigfft v0.0.0-20170806203942-52369c62f446/go.mod h1:uYEyJGbgTkfkS4+E/PavXkNJcbFIpEtjt2B0KDQ5+9M=
 github.com/robfig/cron v1.1.0 h1:jk4/Hud3TTdcrJgUOBgsqrZBarcxl6ADIjSC2iniwLY=
 github.com/robfig/cron v1.1.0/go.mod h1:JGuDeoQd7Z6yL4zQhZ3OPEVHB7fL6Ka6skscFHfmt2k=

--- a/pkg/volume/quobyte/BUILD
+++ b/pkg/volume/quobyte/BUILD
@@ -15,6 +15,7 @@ go_library(
     ],
     importpath = "k8s.io/kubernetes/pkg/volume/quobyte",
     deps = [
+        "//pkg/proxy/util:go_default_library",
         "//pkg/volume:go_default_library",
         "//pkg/volume/util:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",

--- a/pkg/volume/quobyte/quobyte_util.go
+++ b/pkg/volume/quobyte/quobyte_util.go
@@ -18,19 +18,22 @@ package quobyte
 
 import (
 	"net"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	volumehelpers "k8s.io/cloud-provider/volume/helpers"
+	proxyutil "k8s.io/kubernetes/pkg/proxy/util"
 
 	quobyteapi "github.com/quobyte/api"
 	"k8s.io/klog/v2"
 )
 
 type quobyteVolumeManager struct {
-	config *quobyteAPIConfig
+	config      *quobyteAPIConfig
+	dialOptions *proxyutil.FilteredDialOptions
 }
 
 func (manager *quobyteVolumeManager) createVolume(provisioner *quobyteVolumeProvisioner, createQuota bool) (quobyte *v1.QuobyteVolumeSource, size int, err error) {
@@ -77,11 +80,17 @@ func (manager *quobyteVolumeManager) deleteVolume(deleter *quobyteVolumeDeleter)
 }
 
 func (manager *quobyteVolumeManager) createQuobyteClient() *quobyteapi.QuobyteClient {
-	return quobyteapi.NewQuobyteClient(
+	client := quobyteapi.NewQuobyteClient(
 		manager.config.quobyteAPIServer,
 		manager.config.quobyteUser,
 		manager.config.quobytePassword,
 	)
+	// quobyte client library @v0.1.7 uses a zero-value http.Client with a nil
+	// transport which is equivalent to using http.DefaultTransport.
+	rt := http.DefaultTransport.(*http.Transport).Clone()
+	rt.DialContext = proxyutil.NewFilteredDialContext(rt.DialContext, nil, manager.dialOptions)
+	client.SetTransport(rt)
+	return client
 }
 
 func (mounter *quobyteMounter) pluginDirIsMounted(pluginDir string) (bool, error) {

--- a/vendor/github.com/quobyte/api/README.md
+++ b/vendor/github.com/quobyte/api/README.md
@@ -24,6 +24,10 @@ func main() {
         RootUserID:        "root",
         RootGroupID:       "root",
         ConfigurationName: "BASE",
+        Labels: []quobyte_api.Label{
+            {Name: "label1", Value: "value1"},
+            {Name: "label2", Value: "value2"},
+        },
     }
 
     volumeUUID, err := client.CreateVolume(req)

--- a/vendor/github.com/quobyte/api/quobyte.go
+++ b/vendor/github.com/quobyte/api/quobyte.go
@@ -32,6 +32,10 @@ func (client *QuobyteClient) GetAPIRetryPolicy() string {
 	return client.apiRetryPolicy
 }
 
+func (client *QuobyteClient) SetTransport(t http.RoundTripper) {
+	client.client.Transport = t
+}
+
 // NewQuobyteClient creates a new Quobyte API client
 func NewQuobyteClient(url string, username string, password string) *QuobyteClient {
 	return &QuobyteClient{

--- a/vendor/github.com/quobyte/api/rpc_client.go
+++ b/vendor/github.com/quobyte/api/rpc_client.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"log"
 	"math/rand"
@@ -112,7 +113,12 @@ func (client QuobyteClient) sendRequest(method string, request interface{}, resp
 	defer resp.Body.Close()
 
 	if resp.StatusCode < 200 || resp.StatusCode > 299 {
-		log.Printf("Warning: HTTP status code for request is %s\n", strconv.Itoa(resp.StatusCode))
+		log.Printf("Warning: HTTP status code for request is %s\n",
+			strconv.Itoa(resp.StatusCode))
+		if resp.StatusCode == 401 {
+			return errors.New("Unable to authenticate with Quobyte API service")
+		}
+		return fmt.Errorf("JsonRPC failed with error code %d", resp.StatusCode)
 	}
 	return decodeResponse(resp.Body, &response)
 }

--- a/vendor/github.com/quobyte/api/types.go
+++ b/vendor/github.com/quobyte/api/types.go
@@ -1,25 +1,31 @@
 package quobyte
 
 type retryPolicy struct {
-        RetryPolicy string `json:"retry,omitempty"`
+	RetryPolicy string `json:"retry,omitempty"`
 }
 
 // CreateVolumeRequest represents a CreateVolumeRequest
 type CreateVolumeRequest struct {
-        Name              string   `json:"name,omitempty"`
-        RootUserID        string   `json:"root_user_id,omitempty"`
-        RootGroupID       string   `json:"root_group_id,omitempty"`
-        ReplicaDeviceIDS  []uint64 `json:"replica_device_ids,string,omitempty"`
-        ConfigurationName string   `json:"configuration_name,omitempty"`
-        AccessMode        uint32   `json:"access_mode,string,omitempty"`
-        TenantID          string   `json:"tenant_id,omitempty"`
-        retryPolicy
+	Name              string   `json:"name,omitempty"`
+	RootUserID        string   `json:"root_user_id,omitempty"`
+	RootGroupID       string   `json:"root_group_id,omitempty"`
+	ReplicaDeviceIDS  []uint64 `json:"replica_device_ids,string,omitempty"`
+	ConfigurationName string   `json:"configuration_name,omitempty"`
+	Labels            []Label  `json:"label,omitempty"`
+	AccessMode        uint32   `json:"access_mode,uint32,omitempty"`
+	TenantID          string   `json:"tenant_id,omitempty"`
+	retryPolicy
+}
+
+type Label struct {
+	Name  string `json:"name,string,omitempty"`
+	Value string `json:"value,string,omitempty"`
 }
 
 type resolveVolumeNameRequest struct {
-        VolumeName   string `json:"volume_name,omitempty"`
-        TenantDomain string `json:"tenant_domain,omitempty"`
-        retryPolicy
+	VolumeName   string `json:"volume_name,omitempty"`
+	TenantDomain string `json:"tenant_domain,omitempty"`
+	retryPolicy
 }
 
 type resolveTenantNameRequest struct {
@@ -35,8 +41,8 @@ type volumeUUID struct {
 }
 
 type getClientListRequest struct {
-        TenantDomain string `json:"tenant_domain,omitempty"`
-        retryPolicy
+	TenantDomain string `json:"tenant_domain,omitempty"`
+	retryPolicy
 }
 
 type GetClientListResponse struct {
@@ -67,13 +73,13 @@ type quota struct {
 }
 
 type setQuotaRequest struct {
-        Quotas []*quota `json:"quotas,omitempty"`
-        retryPolicy
+	Quotas []*quota `json:"quotas,omitempty"`
+	retryPolicy
 }
 
 type getTenantRequest struct {
-        TenantIDs []string `json:"tenant_id,omitempty"`
-        retryPolicy
+	TenantIDs []string `json:"tenant_id,omitempty"`
+	retryPolicy
 }
 
 type GetTenantResponse struct {
@@ -94,8 +100,8 @@ type TenantDomainConfigurationVolumeAccess struct {
 }
 
 type setTenantRequest struct {
-        Tenants *TenantDomainConfiguration `json:"tenant,omitempty"`
-        retryPolicy
+	Tenants *TenantDomainConfiguration `json:"tenant,omitempty"`
+	retryPolicy
 }
 
 type setTenantResponse struct {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -975,10 +975,10 @@ github.com/prometheus/procfs
 # github.com/prometheus/procfs => github.com/prometheus/procfs v0.1.3
 github.com/prometheus/procfs/internal/fs
 github.com/prometheus/procfs/internal/util
-# github.com/quobyte/api v0.1.2 => github.com/quobyte/api v0.1.2
+# github.com/quobyte/api v0.1.8 => github.com/quobyte/api v0.1.8
 ## explicit
 github.com/quobyte/api
-# github.com/quobyte/api => github.com/quobyte/api v0.1.2
+# github.com/quobyte/api => github.com/quobyte/api v0.1.8
 # github.com/remyoudompheng/bigfft => github.com/remyoudompheng/bigfft v0.0.0-20170806203942-52369c62f446
 # github.com/robfig/cron v1.1.0 => github.com/robfig/cron v1.1.0
 ## explicit


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Update quobyte client library to v0.1.7

This update picks up https://github.com/quobyte/api/pull/19 which adds
the needed `SetTransport` option. With this update, we can add the IP
deny list into quobyte operations.

`pkg/volume/quobyte` is updated to use the same filtered DialContext as in https://github.com/quobyte/api/pull/20

**Which issue(s) this PR fixes**:

This is part of the fix for https://github.com/kubernetes/kubernetes/issues/91542

**Special notes for your reviewer**:

This allows us to copy the fix from https://github.com/kubernetes/kubernetes/pull/91785 onto our quobyte client.

**Does this PR introduce a user-facing change?**:

no

```release-note
Fix CVE-2020-8555 for Quobyte client connections.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
