### PR TITLE
[WIP] Support multiple certificates for AWS network loadbalancers (legacy-aws-cloud-provider)

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/aws/aws.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/aws/aws.go
@@ -413,6 +413,10 @@ type ELBV2 interface {
 	DeleteListener(*elbv2.DeleteListenerInput) (*elbv2.DeleteListenerOutput, error)
 	ModifyListener(*elbv2.ModifyListenerInput) (*elbv2.ModifyListenerOutput, error)
 
+	AddListenerCertificates(*elbv2.AddListenerCertificatesInput) (*elbv2.AddListenerCertificatesOutput, error)
+	DescribeListenerCertificates(*elbv2.DescribeListenerCertificatesInput) (*elbv2.DescribeListenerCertificatesOutput, error)
+	RemoveListenerCertificates(*elbv2.RemoveListenerCertificatesInput) (*elbv2.RemoveListenerCertificatesOutput, error)
+
 	WaitUntilLoadBalancersDeleted(*elbv2.DescribeLoadBalancersInput) error
 }
 

--- a/staging/src/k8s.io/legacy-cloud-providers/aws/aws_fakes.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/aws/aws_fakes.go
@@ -607,6 +607,21 @@ func (elb *FakeELBV2) ModifyListener(*elbv2.ModifyListenerInput) (*elbv2.ModifyL
 	panic("Not implemented")
 }
 
+// AddListenerCertificates is not implemented but is required for interface conformance
+func (elb *FakeELBV2) AddListenerCertificates(*elbv2.AddListenerCertificatesInput) (*elbv2.AddListenerCertificatesOutput, error) {
+	panic("Not implemented")
+}
+
+// DescribeListenerCertificates is not implemented but is required for interface conformance
+func (elb *FakeELBV2) DescribeListenerCertificates(*elbv2.DescribeListenerCertificatesInput) (*elbv2.DescribeListenerCertificatesOutput, error) {
+	panic("Not implemented")
+}
+
+// RemoveListenerCertificates is not implemented but is required for interface conformance
+func (elb *FakeELBV2) RemoveListenerCertificates(*elbv2.RemoveListenerCertificatesInput) (*elbv2.RemoveListenerCertificatesOutput, error) {
+	panic("Not implemented")
+}
+
 // WaitUntilLoadBalancersDeleted is not implemented but is required for
 // interface conformance
 func (elb *FakeELBV2) WaitUntilLoadBalancersDeleted(*elbv2.DescribeLoadBalancersInput) error {


### PR DESCRIPTION
The new aws lb controller supports multiple certificates (https://github.com/kubernetes-sigs/aws-alb-ingress-controller). This commit backports the feature to the legacy aws cloud provider.

The behavior is similar to the new controller in that multiple
certificates are comma separated and the first one in the list is the
default certificate.

For update behavior, the target group is deleted and re-created in order
to support replacing the default certificate.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
(no sure if bug or feature since its not "expected" behavior for legacy aws provider)
/kind feature
<!--
Add one of the following kinds:

/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes # https://github.com/kubernetes/cloud-provider-aws/issues/80

**Special notes for your reviewer**:
- I'm unable to locate any aws integration tests to add this to. Working on a cleaner set of screenshots to demo this. 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
- Support for multiple certificates with HTTPS NLB Target Groups
```

**Examples Of Usage**
![image](https://user-images.githubusercontent.com/1918646/94748661-a5389c00-0336-11eb-9c96-858f98e763ef.png)
```
apiVersion: v1
kind: Service
metadata:
  name: apple
  namespace: default
  labels:
    app: apple
  annotations:
    service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
    service.beta.kubernetes.io/aws-load-balancer-ssl-cert: arn:aws:acm:us-east-1:841246781991:certificate/---redacted---,arn:aws:acm:us-east-1:841246781991:certificate/---redacted---
spec:
  externalTrafficPolicy: Local
  ports:
  - name: http
    port: 80
    protocol: TCP
    targetPort: 5678
  selector:
    app: apple
  type: LoadBalancer
```
