### PR TITLE
e2e can't use both pod.Name and pod.GenerateName

### DIFF
--- a/test/e2e/framework/pod/resource.go
+++ b/test/e2e/framework/pod/resource.go
@@ -456,7 +456,9 @@ func NewExecPodSpec(ns, name string, hostNetwork bool) *v1.Pod {
 
 // newExecPodSpec returns the pod spec of exec pod
 func newExecPodSpec(ns, generateName string) *v1.Pod {
-	pod := NewAgnhostPod(ns, "agnhost-pod", nil, nil, nil)
+	// GenerateName is an optional prefix, used by the server,
+	// to generate a unique name ONLY IF the Name field has not been provided
+	pod := NewAgnhostPod(ns, "", nil, nil, nil)
 	pod.ObjectMeta.GenerateName = generateName
 	return pod
 }


### PR DESCRIPTION
This fixes a problem when using the framework helper
e2epod.CreateExecPodOrFail() more than once in the same test.

The problem is that this function was creating pods with both the
pod.Name and pod.GenerateName set.
The second pod failed to be created with a 500 with Reason ServerTimeout
indicating a unique name could not be found in the time allotted,
xref https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/

/kind bug
/kind failing-test

This was introduced during this refactor

https://github.com/kubernetes/kubernetes/pull/87266/

and it seems that the failures matches 
https://storage.googleapis.com/k8s-gubernator/triage/index.html?pr=1&test=should%20only%20allow


Fixes: https://github.com/kubernetes/kubernetes/issues/95225

```release-note
NONE
```
