### PR TITLE
apiserver: support 'controlplane' as an egress selector type

### DIFF
--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -562,7 +562,7 @@ func BuildAuthorizer(s *options.ServerRunOptions, EgressSelector *egressselector
 	authorizationConfig := s.Authorization.ToAuthorizationConfig(versionedInformers)
 
 	if EgressSelector != nil {
-		egressDialer, err := EgressSelector.Lookup(egressselector.Master.AsNetworkContext())
+		egressDialer, err := EgressSelector.Lookup(egressselector.ControlPlane.AsNetworkContext())
 		if err != nil {
 			return nil, nil, err
 		}

--- a/pkg/kubeapiserver/options/authentication.go
+++ b/pkg/kubeapiserver/options/authentication.go
@@ -477,7 +477,7 @@ func (o *BuiltInAuthenticationOptions) ApplyTo(authInfo *genericapiserver.Authen
 	)
 
 	if egressSelector != nil {
-		egressDialer, err := egressSelector.Lookup(egressselector.Master.AsNetworkContext())
+		egressDialer, err := egressSelector.Lookup(egressselector.ControlPlane.AsNetworkContext())
 		if err != nil {
 			return err
 		}

--- a/staging/src/k8s.io/apiserver/pkg/apis/apiserver/types.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/apiserver/types.go
@@ -62,8 +62,8 @@ type EgressSelectorConfiguration struct {
 // EgressSelection provides the configuration for a single egress selection client.
 type EgressSelection struct {
 	// Name is the name of the egress selection.
-	// Currently supported values are "ControlPlane", "Master", "Etcd" and "Cluster"
-	// The "Master" egress selector is deprecated in favor of "ControlPlane"
+	// Currently supported values are "controlplane", "master", "etcd" and "cluster"
+	// The "master" egress selector is deprecated in favor of "controlplane"
 	Name string
 
 	// Connection is the exact information used to configure the egress selection

--- a/staging/src/k8s.io/apiserver/pkg/apis/apiserver/types.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/apiserver/types.go
@@ -62,7 +62,8 @@ type EgressSelectorConfiguration struct {
 // EgressSelection provides the configuration for a single egress selection client.
 type EgressSelection struct {
 	// Name is the name of the egress selection.
-	// Currently supported values are "Master", "Etcd" and "Cluster"
+	// Currently supported values are "ControlPlane", "Master", "Etcd" and "Cluster"
+	// The "Master" egress selector is deprecated in favor of "ControlPlane"
 	Name string
 
 	// Connection is the exact information used to configure the egress selection

--- a/staging/src/k8s.io/apiserver/pkg/apis/apiserver/v1alpha1/types.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/apiserver/v1alpha1/types.go
@@ -62,7 +62,8 @@ type EgressSelectorConfiguration struct {
 // EgressSelection provides the configuration for a single egress selection client.
 type EgressSelection struct {
 	// name is the name of the egress selection.
-	// Currently supported values are "Master", "Etcd" and "Cluster"
+	// Currently supported values are "ControlPlane", "Master", "Etcd" and "Cluster"
+	// The "Master" egress selector is deprecated in favor of "ControlPlane"
 	Name string `json:"name"`
 
 	// connection is the exact information used to configure the egress selection

--- a/staging/src/k8s.io/apiserver/pkg/apis/apiserver/v1alpha1/types.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/apiserver/v1alpha1/types.go
@@ -62,8 +62,8 @@ type EgressSelectorConfiguration struct {
 // EgressSelection provides the configuration for a single egress selection client.
 type EgressSelection struct {
 	// name is the name of the egress selection.
-	// Currently supported values are "ControlPlane", "Master", "Etcd" and "Cluster"
-	// The "Master" egress selector is deprecated in favor of "ControlPlane"
+	// Currently supported values are "controlplane", "master", "etcd" and "cluster"
+	// The "master" egress selector is deprecated in favor of "controlplane"
 	Name string `json:"name"`
 
 	// connection is the exact information used to configure the egress selection

--- a/staging/src/k8s.io/apiserver/pkg/apis/apiserver/v1beta1/types.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/apiserver/v1beta1/types.go
@@ -33,8 +33,8 @@ type EgressSelectorConfiguration struct {
 // EgressSelection provides the configuration for a single egress selection client.
 type EgressSelection struct {
 	// name is the name of the egress selection.
-	// Currently supported values are "ControlPlane", "Master", "Etcd" and "Cluster"
-	// The "Master" egress selector is deprecated in favor of "ControlPlane"
+	// Currently supported values are "controlplane", "master", "etcd" and "cluster"
+	// The "master" egress selector is deprecated in favor of "controlplane"
 	Name string `json:"name"`
 
 	// connection is the exact information used to configure the egress selection

--- a/staging/src/k8s.io/apiserver/pkg/apis/apiserver/v1beta1/types.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/apiserver/v1beta1/types.go
@@ -33,7 +33,8 @@ type EgressSelectorConfiguration struct {
 // EgressSelection provides the configuration for a single egress selection client.
 type EgressSelection struct {
 	// name is the name of the egress selection.
-	// Currently supported values are "Master", "Etcd" and "Cluster"
+	// Currently supported values are "ControlPlane", "Master", "Etcd" and "Cluster"
+	// The "Master" egress selector is deprecated in favor of "ControlPlane"
 	Name string `json:"name"`
 
 	// connection is the exact information used to configure the egress selection

--- a/staging/src/k8s.io/apiserver/pkg/server/egressselector/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/server/egressselector/BUILD
@@ -12,6 +12,7 @@ go_library(
     deps = [
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/net:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/validation/field:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/apis/apiserver:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/apis/apiserver/install:go_default_library",

--- a/staging/src/k8s.io/apiserver/pkg/server/egressselector/config_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/egressselector/config_test.go
@@ -70,6 +70,86 @@ egressSelections:
           caBundle: "/etc/srv/kubernetes/pki/konnectivity-server/ca.crt"
           clientKey: "/etc/srv/kubernetes/pki/konnectivity-server/client.key"
           clientCert: "/etc/srv/kubernetes/pki/konnectivity-server/client.crt"
+- name: "controlplane"
+  connection:
+    proxyProtocol: "HTTPConnect"
+    transport:
+      tcp:
+        url: "https://127.0.0.1:8132"
+        tlsConfig:
+          caBundle: "/etc/srv/kubernetes/pki/konnectivity-server-master/ca.crt"
+          clientKey: "/etc/srv/kubernetes/pki/konnectivity-server-master/client.key"
+          clientCert: "/etc/srv/kubernetes/pki/konnectivity-server-master/client.crt"
+- name: "etcd"
+  connection:
+    proxyProtocol: "Direct"
+`,
+			expectedResult: &apiserver.EgressSelectorConfiguration{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "",
+					APIVersion: "",
+				},
+				EgressSelections: []apiserver.EgressSelection{
+					{
+						Name: "cluster",
+						Connection: apiserver.Connection{
+							ProxyProtocol: "HTTPConnect",
+							Transport: &apiserver.Transport{
+								TCP: &apiserver.TCPTransport{
+									URL: "https://127.0.0.1:8131",
+
+									TLSConfig: &apiserver.TLSConfig{
+										CABundle:   "/etc/srv/kubernetes/pki/konnectivity-server/ca.crt",
+										ClientKey:  "/etc/srv/kubernetes/pki/konnectivity-server/client.key",
+										ClientCert: "/etc/srv/kubernetes/pki/konnectivity-server/client.crt",
+									},
+								},
+							},
+						},
+					},
+					{
+						Name: "controlplane",
+						Connection: apiserver.Connection{
+							ProxyProtocol: "HTTPConnect",
+							Transport: &apiserver.Transport{
+								TCP: &apiserver.TCPTransport{
+									URL: "https://127.0.0.1:8132",
+									TLSConfig: &apiserver.TLSConfig{
+										CABundle:   "/etc/srv/kubernetes/pki/konnectivity-server-master/ca.crt",
+										ClientKey:  "/etc/srv/kubernetes/pki/konnectivity-server-master/client.key",
+										ClientCert: "/etc/srv/kubernetes/pki/konnectivity-server-master/client.crt",
+									},
+								},
+							},
+						},
+					},
+					{
+						Name: "etcd",
+						Connection: apiserver.Connection{
+							ProxyProtocol: "Direct",
+						},
+					},
+				},
+			},
+			expectedError: nil,
+		},
+		{
+			name:       "v1beta1 using deprecated 'master' type",
+			createFile: true,
+			contents: `
+apiVersion: apiserver.k8s.io/v1beta1
+kind: EgressSelectorConfiguration
+egressSelections:
+- name: "cluster"
+  connection:
+    proxyProtocol: "HTTPConnect"
+    transport:
+      tcp:
+        url: "https://127.0.0.1:8131"
+        tlsConfig:
+          caBundle: "/etc/srv/kubernetes/pki/konnectivity-server/ca.crt"
+          clientKey: "/etc/srv/kubernetes/pki/konnectivity-server/client.key"
+          clientCert: "/etc/srv/kubernetes/pki/konnectivity-server/client.crt"
 - name: "master"
   connection:
     proxyProtocol: "HTTPConnect"
@@ -240,7 +320,7 @@ func TestValidateEgressSelectorConfiguration(t *testing.T) {
 				},
 				EgressSelections: []apiserver.EgressSelection{
 					{
-						Name: "master",
+						Name: "controlplane",
 						Connection: apiserver.Connection{
 							ProxyProtocol: apiserver.ProtocolDirect,
 						},

--- a/staging/src/k8s.io/apiserver/pkg/server/egressselector/config_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/egressselector/config_test.go
@@ -413,6 +413,48 @@ func TestValidateEgressSelectorConfiguration(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:        "invalid egress selection name",
+			expectError: true,
+			contents: &apiserver.EgressSelectorConfiguration{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "",
+					APIVersion: "",
+				},
+				EgressSelections: []apiserver.EgressSelection{
+					{
+						Name: "invalid",
+						Connection: apiserver.Connection{
+							ProxyProtocol: apiserver.ProtocolDirect,
+						},
+					},
+				},
+			},
+		},
+		{
+			name:        "both master and controlplane egress selection configured",
+			expectError: true,
+			contents: &apiserver.EgressSelectorConfiguration{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "",
+					APIVersion: "",
+				},
+				EgressSelections: []apiserver.EgressSelection{
+					{
+						Name: "controlplane",
+						Connection: apiserver.Connection{
+							ProxyProtocol: apiserver.ProtocolDirect,
+						},
+					},
+					{
+						Name: "master",
+						Connection: apiserver.Connection{
+							ProxyProtocol: apiserver.ProtocolDirect,
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, tc := range testcases {

--- a/staging/src/k8s.io/apiserver/pkg/server/egressselector/egress_selector_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/egressselector/egress_selector_test.go
@@ -90,7 +90,7 @@ func TestEgressSelector(t *testing.T) {
 					nil,
 				},
 				{
-					Master,
+					ControlPlane,
 					validateDirectDialer,
 					nil,
 					nil,

--- a/staging/src/k8s.io/apiserver/pkg/server/options/audit.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/audit.go
@@ -306,7 +306,7 @@ func (o *AuditOptions) ApplyTo(
 			klog.V(2).Info("No audit policy file provided, no events will be recorded for webhook backend")
 		} else {
 			if c.EgressSelector != nil {
-				egressDialer, err := c.EgressSelector.Lookup(egressselector.Master.AsNetworkContext())
+				egressDialer, err := c.EgressSelector.Lookup(egressselector.ControlPlane.AsNetworkContext())
 				if err != nil {
 					return err
 				}

--- a/staging/src/k8s.io/apiserver/pkg/util/webhook/authentication.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/webhook/authentication.go
@@ -55,7 +55,7 @@ func NewDefaultAuthenticationInfoResolverWrapper(
 				}
 
 				if egressSelector != nil {
-					networkContext := egressselector.Master.AsNetworkContext()
+					networkContext := egressselector.ControlPlane.AsNetworkContext()
 					var egressDialer utilnet.DialFunc
 					egressDialer, err = egressSelector.Lookup(networkContext)
 


### PR DESCRIPTION
**What type of PR is this?**

/kind api-change
/kind deprecation

**What this PR does / why we need it**:
Adds a new egress selection type "controlplane", which will deprecate and replace "master". "master" will still be a valid egress selection until removed (in v1.22?). 

This PR also adds:
* validation logic for EgressSelectorConfiguration so only valid egress selector names are accepted
* update API docs for EgressSelectorConfiguration to use canonical names for egress selector names.

Reason for proposed rename is that "controlplane" better represents what the egress selector is targetting, the comments for the "Master" egress type itself refers to "control plane" today as well:

https://github.com/kubernetes/kubernetes/blob/89fdf5e7d3769aa9b826fba90fa08c414ef79d39/staging/src/k8s.io/apiserver/pkg/server/egressselector/egress_selector.go#L54-L55

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Support 'controlplane' as a valid EgressSelection type in the EgressSelectorConfiguration API. 'Master' is deprecated and will be removed in v1.22.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
