### PR TITLE
Update triage/support label references to kind/support

### DIFF
--- a/.github/ISSUE_TEMPLATE/support.md
+++ b/.github/ISSUE_TEMPLATE/support.md
@@ -1,7 +1,7 @@
 ---
 name: Support Request
 about: Support request or question relating to Kubernetes
-labels: triage/support
+labels: kind/support
 
 ---
 


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup


**What this PR does / why we need it**:

The label triage/support has been reclassified as kind/support. The
kind/* family of labels makes more logical sense, as they describe the
"kind" of thing an issue or PR is.

For more information, see the announcement email:
https://groups.google.com/g/kubernetes-dev/c/YcaJpsjjLKw/m/i15cLLx5CAAJ

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

/assign @nikhita @cblecker 