### PR TITLE
proxy: Add tests for kube-proxy config defaulting

### DIFF
--- a/pkg/proxy/apis/config/v1alpha1/BUILD
+++ b/pkg/proxy/apis/config/v1alpha1/BUILD
@@ -3,6 +3,7 @@ package(default_visibility = ["//visibility:public"])
 load(
     "@io_bazel_rules_go//go:def.bzl",
     "go_library",
+    "go_test",
 )
 
 go_library(
@@ -42,4 +43,16 @@ filegroup(
     name = "all-srcs",
     srcs = [":package-srcs"],
     tags = ["automanaged"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["defaults_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//staging/src/k8s.io/component-base/config/v1alpha1:go_default_library",
+        "//staging/src/k8s.io/kube-proxy/config/v1alpha1:go_default_library",
+        "//vendor/github.com/google/go-cmp/cmp:go_default_library",
+    ],
 )

--- a/pkg/proxy/apis/config/v1alpha1/defaults_test.go
+++ b/pkg/proxy/apis/config/v1alpha1/defaults_test.go
@@ -1,0 +1,117 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	componentbaseconfig "k8s.io/component-base/config/v1alpha1"
+	kubeproxyconfigv1alpha1 "k8s.io/kube-proxy/config/v1alpha1"
+)
+
+func TestDefaultsKubeProxyConfiguration(t *testing.T) {
+	masqBit := int32(14)
+	oomScore := int32(-999)
+	ctMaxPerCore := int32(32768)
+	ctMin := int32(131072)
+	testCases := []struct {
+		name     string
+		original *kubeproxyconfigv1alpha1.KubeProxyConfiguration
+		expected *kubeproxyconfigv1alpha1.KubeProxyConfiguration
+	}{
+		{
+			name:     "empty-config",
+			original: &kubeproxyconfigv1alpha1.KubeProxyConfiguration{},
+			expected: &kubeproxyconfigv1alpha1.KubeProxyConfiguration{
+				FeatureGates:       map[string]bool{},
+				BindAddress:        "0.0.0.0",
+				HealthzBindAddress: "0.0.0.0:10256",
+				MetricsBindAddress: "127.0.0.1:10249",
+				ClientConnection: componentbaseconfig.ClientConnectionConfiguration{
+					ContentType: "application/vnd.kubernetes.protobuf",
+					QPS:         5,
+					Burst:       10,
+				},
+				IPTables: kubeproxyconfigv1alpha1.KubeProxyIPTablesConfiguration{
+					MasqueradeBit: &masqBit,
+					MasqueradeAll: false,
+					SyncPeriod:    metav1.Duration{Duration: 30 * time.Second},
+					MinSyncPeriod: metav1.Duration{Duration: 1 * time.Second},
+				},
+				IPVS: kubeproxyconfigv1alpha1.KubeProxyIPVSConfiguration{
+					SyncPeriod: metav1.Duration{Duration: 30 * time.Second},
+				},
+				OOMScoreAdj:    &oomScore,
+				UDPIdleTimeout: metav1.Duration{Duration: 250 * time.Millisecond},
+				Conntrack: kubeproxyconfigv1alpha1.KubeProxyConntrackConfiguration{
+					MaxPerCore:            &ctMaxPerCore,
+					Min:                   &ctMin,
+					TCPEstablishedTimeout: &metav1.Duration{Duration: 24 * time.Hour},
+					TCPCloseWaitTimeout:   &metav1.Duration{Duration: 1 * time.Hour},
+				},
+				ConfigSyncPeriod: metav1.Duration{Duration: 15 * time.Minute},
+			},
+		},
+		{
+			name: "metrics and healthz address with no port",
+			original: &kubeproxyconfigv1alpha1.KubeProxyConfiguration{
+				MetricsBindAddress: "127.0.0.1",
+				HealthzBindAddress: "127.0.0.1",
+			},
+			expected: &kubeproxyconfigv1alpha1.KubeProxyConfiguration{
+				FeatureGates:       map[string]bool{},
+				BindAddress:        "0.0.0.0",
+				HealthzBindAddress: "127.0.0.1:10256",
+				MetricsBindAddress: "127.0.0.1:10249",
+				ClientConnection: componentbaseconfig.ClientConnectionConfiguration{
+					ContentType: "application/vnd.kubernetes.protobuf",
+					QPS:         5,
+					Burst:       10,
+				},
+				IPTables: kubeproxyconfigv1alpha1.KubeProxyIPTablesConfiguration{
+					MasqueradeBit: &masqBit,
+					MasqueradeAll: false,
+					SyncPeriod:    metav1.Duration{Duration: 30 * time.Second},
+					MinSyncPeriod: metav1.Duration{Duration: 1 * time.Second},
+				},
+				IPVS: kubeproxyconfigv1alpha1.KubeProxyIPVSConfiguration{
+					SyncPeriod: metav1.Duration{Duration: 30 * time.Second},
+				},
+				OOMScoreAdj:    &oomScore,
+				UDPIdleTimeout: metav1.Duration{Duration: 250 * time.Millisecond},
+				Conntrack: kubeproxyconfigv1alpha1.KubeProxyConntrackConfiguration{
+					MaxPerCore:            &ctMaxPerCore,
+					Min:                   &ctMin,
+					TCPEstablishedTimeout: &metav1.Duration{Duration: 24 * time.Hour},
+					TCPCloseWaitTimeout:   &metav1.Duration{Duration: 1 * time.Hour},
+				},
+				ConfigSyncPeriod: metav1.Duration{Duration: 15 * time.Minute},
+			},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			SetDefaults_KubeProxyConfiguration(tc.original)
+			if diff := cmp.Diff(tc.expected, tc.original); diff != "" {
+				t.Errorf("Got unexpected defaults (-want, +got):\n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind feature
/kind cleanup
/area test
/sig network

**What this PR does / why we need it**:
- Adds tests for default logic in kube-proxy configuration

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

