### PR TITLE
Fixes high CPU usage in kubectl drain

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/drain/drain.go
+++ b/staging/src/k8s.io/kubectl/pkg/drain/drain.go
@@ -349,7 +349,6 @@ func (d *Helper) evictPods(pods []corev1.Pod, policyGroupVersion string, getPodF
 			if err != nil {
 				errors = append(errors, err)
 			}
-		default:
 		}
 	}
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
The for loop in func evictPods remains busy because the default clause of the select statement will never block. This is causing high CPU usage when draining a node with Pods containing a PodDisruptionBudget.

Ref.: https://groups.google.com/g/golang-nuts/c/jrKI-kwbkj8

**Which issue(s) this PR fixes**:
Fixes #93784

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
Fixes high CPU usage in kubectl drain
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs

```
/sig cli
/priority important-soon