### PR TITLE
test: e2e: fix race in pods test

### DIFF
--- a/test/e2e/node/pods.go
+++ b/test/e2e/node/pods.go
@@ -263,6 +263,7 @@ var _ = SIGDescribe("Pods Extended", func() {
 						start := time.Now()
 						created := podClient.Create(pod)
 						ch := make(chan []watch.Event)
+						waitForWatch := make(chan struct{})
 						go func() {
 							defer ginkgo.GinkgoRecover()
 							defer close(ch)
@@ -275,6 +276,7 @@ var _ = SIGDescribe("Pods Extended", func() {
 								return
 							}
 							defer w.Stop()
+							close(waitForWatch)
 							events := []watch.Event{
 								{Type: watch.Added, Object: created},
 							}
@@ -291,6 +293,10 @@ var _ = SIGDescribe("Pods Extended", func() {
 							ch <- events
 						}()
 
+						select {
+						case <-ch: // in case the goroutine above exits before establishing the watch
+						case <-waitForWatch: // when the watch is established
+						}
 						t := time.Duration(rand.Intn(delay)) * time.Millisecond
 						time.Sleep(t)
 						err := podClient.Delete(context.TODO(), pod.Name, metav1.DeleteOptions{})


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
/kind flake

**What this PR does / why we need it**:
There is a race in the `Pods Extended [k8s.io] Pod Container Status should never report success for a pending container` test where the watch for an event could be established after the delete event has already gone by.

xref https://bugzilla.redhat.com/show_bug.cgi?id=1884697

@deads2k @smarterclayton @mrunalp @derekwaynecarr 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
No
```release-note
NONE
```