### PR TITLE
revert some changes of PR66807 to fix OpenAPI spec

### DIFF
--- a/pkg/registry/core/node/rest/BUILD
+++ b/pkg/registry/core/node/rest/BUILD
@@ -15,6 +15,7 @@ go_library(
         "//pkg/kubelet/client:go_default_library",
         "//pkg/registry/core/node:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/net:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/proxy:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/registry/generic/registry:go_default_library",

--- a/pkg/registry/core/node/rest/proxy.go
+++ b/pkg/registry/core/node/rest/proxy.go
@@ -23,6 +23,7 @@ import (
 	"net/url"
 
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/net"
 	"k8s.io/apimachinery/pkg/util/proxy"
 	genericregistry "k8s.io/apiserver/pkg/registry/generic/registry"
@@ -43,7 +44,15 @@ type ProxyREST struct {
 // Implement Connecter
 var _ = rest.Connecter(&ProxyREST{})
 
+// Implement GroupVersionKindProvider
+var _ = rest.GroupVersionKindProvider(&ProxyREST{})
+
 var proxyMethods = []string{"GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"}
+
+// GroupVersionKind tells the ApiServer to treat this REST sub resource as a Node in the API spec
+func (r *ProxyREST) GroupVersionKind(containingGV schema.GroupVersion) schema.GroupVersionKind {
+	return schema.GroupVersionKind{Version: "v1", Kind: "Node"}
+}
 
 // New returns an empty nodeProxyOptions object.
 func (r *ProxyREST) New() runtime.Object {

--- a/pkg/registry/core/pod/rest/BUILD
+++ b/pkg/registry/core/pod/rest/BUILD
@@ -23,6 +23,7 @@ go_library(
         "//pkg/registry/core/pod:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/net:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/proxy:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/features:go_default_library",

--- a/pkg/registry/core/pod/rest/subresources.go
+++ b/pkg/registry/core/pod/rest/subresources.go
@@ -23,6 +23,7 @@ import (
 	"net/url"
 
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/net"
 	"k8s.io/apimachinery/pkg/util/proxy"
 	genericfeatures "k8s.io/apiserver/pkg/features"
@@ -44,7 +45,15 @@ type ProxyREST struct {
 // Implement Connecter
 var _ = rest.Connecter(&ProxyREST{})
 
+// Implement GroupVersionKindProvider
+var _ = rest.GroupVersionKindProvider(&ProxyREST{})
+
 var proxyMethods = []string{"GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"}
+
+// GroupVersionKind tells the ApiServer to treat this REST sub resource as a Node in the API spec
+func (r *ProxyREST) GroupVersionKind(containingGV schema.GroupVersion) schema.GroupVersionKind {
+	return schema.GroupVersionKind{Version: "v1", Kind: "Pod"}
+}
 
 // New returns an empty podProxyOptions object.
 func (r *ProxyREST) New() runtime.Object {
@@ -88,6 +97,14 @@ type AttachREST struct {
 // Implement Connecter
 var _ = rest.Connecter(&AttachREST{})
 
+// Implement GroupVersionKindProvider
+var _ = rest.GroupVersionKindProvider(&AttachREST{})
+
+// GroupVersionKind tells the ApiServer to treat this REST sub resource as a Node in the API spec
+func (r *AttachREST) GroupVersionKind(containingGV schema.GroupVersion) schema.GroupVersionKind {
+	return schema.GroupVersionKind{Version: "v1", Kind: "Pod"}
+}
+
 // New creates a new podAttachOptions object.
 func (r *AttachREST) New() runtime.Object {
 	return &api.PodAttachOptions{}
@@ -125,6 +142,14 @@ type ExecREST struct {
 // Implement Connecter
 var _ = rest.Connecter(&ExecREST{})
 
+// Implement GroupVersionKindProvider
+var _ = rest.GroupVersionKindProvider(&ExecREST{})
+
+// GroupVersionKind tells the ApiServer to treat this REST sub resource as a Node in the API spec
+func (r *ExecREST) GroupVersionKind(containingGV schema.GroupVersion) schema.GroupVersionKind {
+	return schema.GroupVersionKind{Version: "v1", Kind: "Pod"}
+}
+
 // New creates a new podExecOptions object.
 func (r *ExecREST) New() runtime.Object {
 	return &api.PodExecOptions{}
@@ -161,6 +186,14 @@ type PortForwardREST struct {
 
 // Implement Connecter
 var _ = rest.Connecter(&PortForwardREST{})
+
+// Implement GroupVersionKindProvider
+var _ = rest.GroupVersionKindProvider(&PortForwardREST{})
+
+// GroupVersionKind tells the ApiServer to treat this REST sub resource as a Node in the API spec
+func (r *PortForwardREST) GroupVersionKind(containingGV schema.GroupVersion) schema.GroupVersionKind {
+	return schema.GroupVersionKind{Version: "v1", Kind: "Pod"}
+}
 
 // New returns an empty podPortForwardOptions object
 func (r *PortForwardREST) New() runtime.Object {

--- a/pkg/registry/core/service/BUILD
+++ b/pkg/registry/core/service/BUILD
@@ -21,6 +21,7 @@ go_library(
         "//pkg/capabilities:go_default_library",
         "//pkg/features:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/net:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/proxy:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/validation/field:go_default_library",

--- a/pkg/registry/core/service/proxy.go
+++ b/pkg/registry/core/service/proxy.go
@@ -23,6 +23,7 @@ import (
 	"net/url"
 
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/net"
 	"k8s.io/apimachinery/pkg/util/proxy"
 	"k8s.io/apiserver/pkg/registry/rest"
@@ -39,7 +40,15 @@ type ProxyREST struct {
 // Implement Connecter
 var _ = rest.Connecter(&ProxyREST{})
 
+// Implement GroupVersionKindProvider
+var _ = rest.GroupVersionKindProvider(&ProxyREST{})
+
 var proxyMethods = []string{"GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"}
+
+// GroupVersionKind tells the ApiServer to treat this REST sub resource as a Node in the API spec
+func (r *ProxyREST) GroupVersionKind(containingGV schema.GroupVersion) schema.GroupVersionKind {
+	return schema.GroupVersionKind{Version: "v1", Kind: "Service"}
+}
 
 // New returns an empty service resource
 func (r *ProxyREST) New() runtime.Object {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Make OpenAPI spec correct again

**Which issue(s) this PR fixes**:
Ref #95052


**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
