### PR TITLE
fix staticcheck failures for kubectl scale and add error check for Visit()

### DIFF
--- a/hack/.staticcheck_failures
+++ b/hack/.staticcheck_failures
@@ -52,4 +52,3 @@ vendor/k8s.io/client-go/discovery
 vendor/k8s.io/client-go/rest
 vendor/k8s.io/client-go/rest/watch
 vendor/k8s.io/client-go/transport
-vendor/k8s.io/kubectl/pkg/cmd/scale

--- a/staging/src/k8s.io/kubectl/pkg/cmd/scale/scale.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/scale/scale.go
@@ -209,7 +209,7 @@ func (o *ScaleOptions) RunScale() error {
 	}
 
 	infos := []*resource.Info{}
-	err = r.Visit(func(info *resource.Info, err error) error {
+	_ = r.Visit(func(info *resource.Info, err error) error {
 		if err == nil {
 			infos = append(infos, info)
 		}


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
fixes pkg/kubectl static checks for
- staging/src/k8s.io/kubectl/pkg/cmd/scale/scale.go

**Which issue(s) this PR fixes**:
Part of #92402

**Special notes for your reviewer**:
Is the err [here](https://github.com/kubernetes/kubernetes/blob/b2730aa48321d55ec166329f9d33782a054b9aba/staging/src/k8s.io/kubectl/pkg/cmd/scale/scale.go#L212) ignored intentionally or is a check needed?
/cc @soltysh 
/cc @seans3 
tagging as suggested by @liggitt in [PR](https://github.com/kubernetes/kubernetes/pull/95180)
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
