### PR TITLE
BearerToken is not assigned to rest client config

### DIFF
--- a/staging/src/k8s.io/client-go/tools/clientcmd/client_config.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/client_config.go
@@ -152,6 +152,8 @@ func (config *DirectClientConfig) ClientConfig() (*restclient.Config, error) {
 
 	clientConfig := &restclient.Config{}
 	clientConfig.Host = configClusterInfo.Server
+	clientConfig.BearerToken = configAuthInfo.Token
+	
 	if configClusterInfo.ProxyURL != "" {
 		u, err := parseProxyURL(configClusterInfo.ProxyURL)
 		if err != nil {


### PR DESCRIPTION
It breaks Helm client when only BearerToken and ApiServer is passed to the HelmClient. This PR fixes that issue. etc. Please see [here](https://github.com/helm/helm/issues/8844)

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Fixes the BearerToken issue that is propogating to Helm Cliemt.

**Which issue(s) this PR fixes**:
Fixes https://github.com/helm/helm/issues/8844

**Does this PR introduce a user-facing change?**:
NONE

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:


