### PR TITLE
Deprecating PodUnknown podPhase

### DIFF
--- a/pkg/apis/core/types.go
+++ b/pkg/apis/core/types.go
@@ -2304,6 +2304,7 @@ const (
 	PodFailed PodPhase = "Failed"
 	// PodUnknown means that for some reason the state of the pod could not be obtained, typically due
 	// to an error in communicating with the host of the pod.
+	// Deprecated in v1.21: It isn't being set since 2015 (74da3b14b0c0f658b3bb8d2def5094686d0e9095)
 	PodUnknown PodPhase = "Unknown"
 )
 

--- a/pkg/controller/deployment/recreate.go
+++ b/pkg/controller/deployment/recreate.go
@@ -18,7 +18,7 @@ package deployment
 
 import (
 	apps "k8s.io/api/apps/v1"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/kubernetes/pkg/controller"
 	"k8s.io/kubernetes/pkg/controller/deployment/util"
@@ -110,7 +110,9 @@ func oldPodsRunning(newRS *apps.ReplicaSet, oldRSs []*apps.ReplicaSet, podMap ma
 				// Don't count pods in terminal state.
 				continue
 			case v1.PodUnknown:
-				// This happens in situation like when the node is temporarily disconnected from the cluster.
+				// v1.PodUnknown is a deprecated status.
+				// This logic is kept for backward compatibility.
+				// This used to happen in situation like when the node is temporarily disconnected from the cluster.
 				// If we can't be sure that the pod is not running, we have to count it.
 				return true
 			default:

--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -2522,6 +2522,7 @@ const (
 	PodFailed PodPhase = "Failed"
 	// PodUnknown means that for some reason the state of the pod could not be obtained, typically due
 	// to an error in communicating with the host of the pod.
+	// Deprecated: It isn't being set since 2015 (74da3b14b0c0f658b3bb8d2def5094686d0e9095)
 	PodUnknown PodPhase = "Unknown"
 )
 

--- a/test/e2e/common/node/container.go
+++ b/test/e2e/common/node/container.go
@@ -91,7 +91,8 @@ func (cc *ConformanceContainer) IsReady() (bool, error) {
 func (cc *ConformanceContainer) GetPhase() (v1.PodPhase, error) {
 	pod, err := cc.PodClient.Get(context.TODO(), cc.podName, metav1.GetOptions{})
 	if err != nil {
-		return v1.PodUnknown, err
+		// it doesn't matter what phase to return as error would not be nil
+		return v1.PodSucceeded, err
 	}
 	return pod.Status.Phase, nil
 }

--- a/test/e2e/storage/persistent_volumes-local.go
+++ b/test/e2e/storage/persistent_volumes-local.go
@@ -605,8 +605,7 @@ var _ = utils.SIGDescribe("PersistentVolumes-local ", func() {
 				defer podsLock.Unlock()
 
 				for _, pod := range podsList.Items {
-					switch pod.Status.Phase {
-					case v1.PodSucceeded:
+					if pod.Status.Phase == v1.PodSucceeded {
 						// Delete pod and its PVCs
 						if err := deletePodAndPVCs(config, &pod); err != nil {
 							return false, err
@@ -614,9 +613,6 @@ var _ = utils.SIGDescribe("PersistentVolumes-local ", func() {
 						delete(pods, pod.Name)
 						numFinished++
 						framework.Logf("%v/%v pods finished", numFinished, totalPods)
-					case v1.PodUnknown:
-						return false, fmt.Errorf("pod %v is in %v phase", pod.Name, pod.Status.Phase)
-					case v1.PodFailed:
 					}
 				}
 


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup
/kind api-change
/kind deprecation
/sig node

**What this PR does / why we need it**:

Copying from #88073

> Since the end of pod cache in 2015 nothing is actually setting pod phase to PodUnknown. Traced this back to [74da3b1](https://github.com/kubernetes/kubernetes/commit/74da3b14b0c0f658b3bb8d2def5094686d0e9095) . Users and developers are confused to how it can get into such state. The deprecation makes it clear it is not being used anymore and gives us the option to remove it in the future.

This PR also cleans up all the use of `PodUnknown` - comparison functions and a few getters.

**Which issue(s) this PR fixes**:

Replacing #88073

**Special notes for your reviewer**:

I was thinking of https://github.com/kubernetes/kubernetes/pull/88073#pullrequestreview-357515729. Perhaps I can add some `panic` checking if anybody set this podPhase. But I didn't find examples of this kind of deprecation and it feels a bit excessive. So perhaps just a note on description would be sufficient.

**Does this PR introduce a user-facing change?**:
```release-note
PodUnknown phase is now deprecated.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
