### PR TITLE
kubectl: allow users to use args with KUBECTL_EXTERNAL_DIFF

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/diff/diff.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/diff/diff.go
@@ -22,6 +22,8 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"regexp"
+	"strings"
 
 	"github.com/jonboulle/clockwork"
 	"github.com/spf13/cobra"
@@ -55,7 +57,10 @@ var (
 		Output is always YAML.
 
 		KUBECTL_EXTERNAL_DIFF environment variable can be used to select your own
-		diff command. By default, the "diff" command available in your path will be
+		diff command. Users can use external commands with params too, example:
+		KUBECTL_EXTERNAL_DIFF="colordiff -N -u"
+
+		By default, the "diff" command available in your path will be
 		run with "-u" (unified diff) and "-N" (treat absent files as empty) options.
 
 		Exit status:
@@ -168,7 +173,18 @@ type DiffProgram struct {
 func (d *DiffProgram) getCommand(args ...string) (string, exec.Cmd) {
 	diff := ""
 	if envDiff := os.Getenv("KUBECTL_EXTERNAL_DIFF"); envDiff != "" {
-		diff = envDiff
+		diffCommand := strings.Split(envDiff, " ")
+		diff = diffCommand[0]
+
+		if len(diffCommand) > 1 {
+			// Regex accepts: Alphanumeric (case-insensitive) and dash
+			isValidChar := regexp.MustCompile(`^[a-zA-Z0-9-]+$`).MatchString
+			for i := 1; i < len(diffCommand); i++ {
+				if isValidChar(diffCommand[i]) {
+					args = append(args, diffCommand[i])
+				}
+			}
+		}
 	} else {
 		diff = "diff"
 		args = append([]string{"-u", "-N"}, args...)


### PR DESCRIPTION
Currently, if users try to use external diff command with arguments
will fail because the entire command won't be available through $PATH.
This patch allow users to use external diff tools with args (or not)
via KUBECTL_EXTERNAL_DIFF env.

Reference: https://github.com/kubernetes/kubectl/issues/937

Signed-off-by: Douglas Schilling Landgraf <dougsland@redhat.com>

/kind feature

**What this PR does / why we need it**:
Allow kubectl users provide external diff commands with args.

**Which issue(s) this PR fixes**:
Fixes # https://github.com/kubernetes/kubectl/issues/937

**Does this PR introduce a user-facing change?**:
```release-note
kubectl: Previously users cannot provide arguments to a external diff tool via KUBECTL_EXTERNAL_DIFF env. This release now allow users to specify args to KUBECTL_EXTERNAL_DIFF env.
```