### PR TITLE
[minor] kube-proxy ginkgo metadata

### DIFF
--- a/test/e2e/apps/daemon_restart.go
+++ b/test/e2e/apps/daemon_restart.go
@@ -329,7 +329,7 @@ var _ = SIGDescribe("DaemonRestart [Disruptive]", func() {
 		}
 	})
 
-	ginkgo.It("Kube-proxy should recover after being killed accidentally", func() {
+	ginkgo.It("kube-proxy should recover after being killed accidentally", func() {
 		nodeIPs, err := e2enode.GetPublicIps(f.ClientSet)
 		if err != nil {
 			framework.Logf("Unexpected error occurred: %v", err)

--- a/test/e2e/network/service.go
+++ b/test/e2e/network/service.go
@@ -2716,7 +2716,7 @@ var _ = SIGDescribe("Services", func() {
 		framework.ExpectNoError(verifyServeHostnameServiceDown(cs, host, svcHeadlessIP, servicePort))
 	})
 
-	ginkgo.It("should be rejected when no endpoints exist", func() {
+	ginkgo.It("should be rejected when no endpoints exist (kube-proxy)", func() {
 		namespace := f.Namespace.Name
 		serviceName := "no-pods"
 		jig := e2eservice.NewTestJig(cs, namespace, serviceName)


### PR DESCRIPTION
add kube-proxy  metadata to a test which was, historically, built to verify that kube-proxy is working correctly...

over time might add more kube-proxy tags where applicable 

**What type of PR is this?**

/kind cleanup
 
**What this PR does / why we need it**:

 this test is known to fail on certain CNIs (like calico 3.12) so its nice to know meta-data wise, what it is testing, and be able to filter against it.

avoided using a ginkgo [tag] bc there are specific expectations around how we tag things

-->
```release-note
NONE
```
