### PR TITLE
Mask bearer token in logs when logLevel >= 9

### DIFF
--- a/staging/src/k8s.io/client-go/transport/round_trippers.go
+++ b/staging/src/k8s.io/client-go/transport/round_trippers.go
@@ -340,6 +340,7 @@ func (r *requestInfo) toCurl() string {
 	headers := ""
 	for key, values := range r.RequestHeaders {
 		for _, value := range values {
+			value = maskValue(key, value)
 			headers += fmt.Sprintf(` -H %q`, fmt.Sprintf("%s: %s", key, value))
 		}
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
credentials/secrets should not be exposed in logs, even at high logging levels

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Earlier fix: https://github.com/kubernetes/kubernetes/pull/81330

`toCurl()` is only used in `round_trippers.go:RoundTrip()`:

```
func (rt *debuggingRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
    reqInfo := newRequestInfo(req)

    if rt.levels[debugJustURL] {
        klog.Infof("%s %s", reqInfo.RequestVerb, reqInfo.RequestURL)
    }
    if rt.levels[debugCurlCommand] {
        klog.Infof("%s", reqInfo.toCurl())

    }
```

Log level needs to be >=9 for `toCurl()` to be called:

```// DebugWrappers wraps a round tripper and logs based on the current log level.
func DebugWrappers(rt http.RoundTripper) http.RoundTripper {
    switch {
    case bool(klog.V(9).Enabled()):
        rt = newDebuggingRoundTripper(rt, debugCurlCommand, debugURLTiming, debugResponseHeaders)
    case bool(klog.V(8).Enabled()):
        rt = newDebuggingRoundTripper(rt, debugJustURL, debugRequestHeaders, debugResponseStatus, debugResponseHeaders)
```

**Does this PR introduce a user-facing change?**:
```release-note
client-go header logging (at verbosity levels >= 9) now masks `Authorization` header contents

```