### PR TITLE
e2e hostexec commands does not need sudo

### DIFF
--- a/test/e2e/network/service.go
+++ b/test/e2e/network/service.go
@@ -3934,9 +3934,9 @@ var _ = SIGDescribe("SCTP [Feature:SCTP] [LinuxOnly]", func() {
 			framework.ExpectNoError(err, "failed to delete pod: %s in namespace: %s", podName, f.Namespace.Name)
 		}()
 		// wait until host port manager syncs rules
-		cmd = "sudo iptables-save"
+		cmd = "iptables-save"
 		if framework.TestContext.ClusterIsIPv6() {
-			cmd = "sudo ip6tables-save"
+			cmd = "ip6tables-save"
 		}
 		err = wait.PollImmediate(framework.Poll, framework.PollShortTimeout, func() (bool, error) {
 			framework.Logf("Executing cmd %q on node %v", cmd, node.Name)
@@ -3997,9 +3997,9 @@ var _ = SIGDescribe("SCTP [Feature:SCTP] [LinuxOnly]", func() {
 		defer hostExec.Cleanup()
 		node, err := e2enode.GetRandomReadySchedulableNode(cs)
 		framework.ExpectNoError(err)
-		cmd := "sudo iptables-save"
+		cmd := "iptables-save"
 		if framework.TestContext.ClusterIsIPv6() {
-			cmd = "sudo ip6tables-save"
+			cmd = "ip6tables-save"
 		}
 		err = wait.PollImmediate(framework.Poll, e2eservice.KubeProxyLagTimeout, func() (bool, error) {
 			framework.Logf("Executing cmd %q on node %v", cmd, node.Name)


### PR DESCRIPTION

/kind failing-test

commands executed using the hostexec pod does not need sudo because they are running in a privileged pod

```release-note
NONE
```

It fixes SCTP test failures on https://testgrid.k8s.io/sig-network-kind#sig-network-kind,%20master