### PR TITLE
Ensure tags on AWS NLB load balancer services are consistent

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/aws/aws.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/aws/aws.go
@@ -387,6 +387,8 @@ type ELB interface {
 // ELBV2 is a simple pass-through of AWS' ELBV2 client interface, which allows for testing
 type ELBV2 interface {
 	AddTags(input *elbv2.AddTagsInput) (*elbv2.AddTagsOutput, error)
+	DescribeTags(*elbv2.DescribeTagsInput) (*elbv2.DescribeTagsOutput, error)
+	RemoveTags(*elbv2.RemoveTagsInput) (*elbv2.RemoveTagsOutput, error)
 
 	CreateLoadBalancer(*elbv2.CreateLoadBalancerInput) (*elbv2.CreateLoadBalancerOutput, error)
 	DescribeLoadBalancers(*elbv2.DescribeLoadBalancersInput) (*elbv2.DescribeLoadBalancersOutput, error)

--- a/staging/src/k8s.io/legacy-cloud-providers/aws/aws_fakes.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/aws/aws_fakes.go
@@ -307,7 +307,14 @@ func (ec2i *FakeEC2Impl) ModifyInstanceAttribute(request *ec2.ModifyInstanceAttr
 
 // DescribeVpcs returns fake VPC descriptions
 func (ec2i *FakeEC2Impl) DescribeVpcs(request *ec2.DescribeVpcsInput) (*ec2.DescribeVpcsOutput, error) {
-	return &ec2.DescribeVpcsOutput{Vpcs: []*ec2.Vpc{{CidrBlock: aws.String("172.20.0.0/16")}}}, nil
+	return &ec2.DescribeVpcsOutput{Vpcs: []*ec2.Vpc{{
+		CidrBlock: aws.String("172.20.0.0/16"),
+		CidrBlockAssociationSet: []*ec2.VpcCidrBlockAssociation{
+			{
+				CidrBlock: aws.String("172.20.0.0/16"),
+			},
+		},
+	}}}, nil
 }
 
 // FakeMetadata is a fake EC2 metadata service client used for testing
@@ -610,6 +617,16 @@ func (elb *FakeELBV2) ModifyListener(*elbv2.ModifyListenerInput) (*elbv2.ModifyL
 // WaitUntilLoadBalancersDeleted is not implemented but is required for
 // interface conformance
 func (elb *FakeELBV2) WaitUntilLoadBalancersDeleted(*elbv2.DescribeLoadBalancersInput) error {
+	panic("Not implemented")
+}
+
+// DescribeTags is not implemented but is required for interface conformance
+func (elb *FakeELBV2) DescribeTags(*elbv2.DescribeTagsInput) (*elbv2.DescribeTagsOutput, error) {
+	panic("Not implemented")
+}
+
+// RemoveTags is not implemented but is required for interface conformance
+func (elb *FakeELBV2) RemoveTags(*elbv2.RemoveTagsInput) (*elbv2.RemoveTagsOutput, error) {
 	panic("Not implemented")
 }
 

--- a/staging/src/k8s.io/legacy-cloud-providers/aws/aws_loadbalancer.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/aws/aws_loadbalancer.go
@@ -369,6 +369,10 @@ func (c *Cloud) ensureLoadBalancerv2(namespacedName types.NamespacedName, loadBa
 			return nil, err
 		}
 
+		if err := c.reconcileELBv2Tags(*loadBalancer.LoadBalancerArn, tags); err != nil {
+			return nil, err
+		}
+
 		// Subnets cannot be modified on NLBs
 		if dirty {
 			loadBalancers, err := c.elbv2.DescribeLoadBalancers(
@@ -385,6 +389,50 @@ func (c *Cloud) ensureLoadBalancerv2(namespacedName types.NamespacedName, loadBa
 		}
 	}
 	return loadBalancer, nil
+}
+
+func (c *Cloud) reconcileELBv2Tags(arn string, tags map[string]string) error {
+	elbv2Tags, err := c.elbv2.DescribeTags(&elbv2.DescribeTagsInput{ResourceArns: []*string{aws.String(arn)}})
+	if err != nil {
+		return err
+	}
+
+	existingTags := mapFromELBv2Tags(elbv2Tags.TagDescriptions[0].Tags)
+
+	var removal []*string
+	var additions []*elbv2.Tag
+
+	for k, v := range existingTags {
+		if newValue, ok := tags[k]; ok {
+			if v != newValue {
+				additions = append(additions, &elbv2.Tag{Key: aws.String(k), Value: aws.String(newValue)})
+			}
+		} else {
+			removal = append(removal, aws.String(k))
+		}
+	}
+
+	for k, v := range tags {
+		if _, ok := existingTags[k]; !ok {
+			additions = append(additions, &elbv2.Tag{Key: aws.String(k), Value: aws.String(v)})
+		}
+	}
+
+	if len(removal) != 0 {
+		klog.V(2).Infof("Removing tags from %q", arn)
+		if _, err := c.elbv2.RemoveTags(&elbv2.RemoveTagsInput{ResourceArns: []*string{aws.String(arn)}, TagKeys: removal}); err != nil {
+			return err
+		}
+	}
+
+	if len(additions) != 0 {
+		klog.V(2).Infof("Adding tags to %q", arn)
+		if _, err := c.elbv2.AddTags(&elbv2.AddTagsInput{ResourceArns: []*string{aws.String(arn)}, Tags: additions}); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 func (c *Cloud) reconcileLBAttributes(loadBalancerArn string, annotations map[string]string) error {
@@ -591,12 +639,7 @@ func (c *Cloud) ensureTargetGroup(targetGroup *elbv2.TargetGroup, serviceName ty
 		}
 
 		if len(tags) != 0 {
-			targetGroupTags := make([]*elbv2.Tag, 0, len(tags))
-			for k, v := range tags {
-				targetGroupTags = append(targetGroupTags, &elbv2.Tag{
-					Key: aws.String(k), Value: aws.String(v),
-				})
-			}
+			targetGroupTags := mapToELBv2Tags(tags)
 			tgArn := aws.StringValue(result.TargetGroups[0].TargetGroupArn)
 			if _, err := c.elbv2.AddTags(&elbv2.AddTagsInput{
 				ResourceArns: []*string{aws.String(tgArn)},
@@ -687,6 +730,10 @@ func (c *Cloud) ensureTargetGroup(targetGroup *elbv2.TargetGroup, serviceName ty
 			}
 			dirty = true
 		}
+	}
+
+	if err := c.reconcileELBv2Tags(aws.StringValue(targetGroup.TargetGroupArn), tags); err != nil {
+		return nil, err
 	}
 
 	// ensure the health check is correct

--- a/staging/src/k8s.io/legacy-cloud-providers/aws/aws_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/aws/aws_test.go
@@ -67,6 +67,20 @@ func (m *MockedFakeEC2) expectDescribeSecurityGroups(clusterID, groupName string
 	}}).Return([]*ec2.SecurityGroup{{Tags: tags}})
 }
 
+func (m *MockedFakeEC2) expectDescribeSecurityGroupsWithoutFilters(clusterID, groupID string, ingress ...*ec2.IpPermission) {
+	tags := []*ec2.Tag{
+		{Key: aws.String(TagNameKubernetesClusterLegacy), Value: aws.String(clusterID)},
+		{Key: aws.String(fmt.Sprintf("%s%s", TagNameKubernetesClusterPrefix, clusterID)), Value: aws.String(ResourceLifecycleOwned)},
+	}
+
+	m.On("DescribeSecurityGroups", &ec2.DescribeSecurityGroupsInput{}).
+		Return([]*ec2.SecurityGroup{{
+			GroupId:       aws.String(groupID),
+			IpPermissions: ingress,
+			Tags:          tags,
+		}})
+}
+
 func (m *MockedFakeEC2) DescribeVolumes(request *ec2.DescribeVolumesInput) ([]*ec2.Volume, error) {
 	args := m.Called(request)
 	return args.Get(0).([]*ec2.Volume), nil
@@ -138,6 +152,89 @@ func (m *MockedFakeELB) expectConfigureHealthCheck(loadBalancerName *string, exp
 	} else {
 		call.Return(&elb.ConfigureHealthCheckOutput{}, nil)
 	}
+}
+
+type MockedFakeELBv2 struct {
+	*FakeELBV2
+	mock.Mock
+}
+
+func (m *MockedFakeELBv2) AddTags(input *elbv2.AddTagsInput) (*elbv2.AddTagsOutput, error) {
+	args := m.Called(input)
+	return args.Get(0).(*elbv2.AddTagsOutput), args.Error(1)
+}
+
+func (m *MockedFakeELBv2) expectAddTags(arn string, tags map[string]string) {
+	m.On("AddTags", &elbv2.AddTagsInput{ResourceArns: []*string{aws.String(arn)}, Tags: mapToELBv2Tags(tags)}).
+		Return(&elbv2.AddTagsOutput{}, nil)
+}
+
+func (m *MockedFakeELBv2) DescribeListeners(input *elbv2.DescribeListenersInput) (*elbv2.DescribeListenersOutput, error) {
+	args := m.Called(input)
+	return args.Get(0).(*elbv2.DescribeListenersOutput), args.Error(1)
+}
+
+func (m *MockedFakeELBv2) expectDescribeListeners(lbArn string, listeners ...*elbv2.Listener) {
+	m.On("DescribeListeners", &elbv2.DescribeListenersInput{LoadBalancerArn: aws.String(lbArn)}).
+		Return(&elbv2.DescribeListenersOutput{Listeners: listeners}, nil)
+}
+
+func (m *MockedFakeELBv2) DescribeLoadBalancers(input *elbv2.DescribeLoadBalancersInput) (*elbv2.DescribeLoadBalancersOutput, error) {
+	args := m.Called(input)
+	return args.Get(0).(*elbv2.DescribeLoadBalancersOutput), args.Error(1)
+}
+
+func (m *MockedFakeELBv2) expectDescribeLoadBalancersByName(lbName string, detail *elbv2.LoadBalancer) {
+	m.On("DescribeLoadBalancers", &elbv2.DescribeLoadBalancersInput{Names: []*string{aws.String(lbName)}}).
+		Return(&elbv2.DescribeLoadBalancersOutput{LoadBalancers: []*elbv2.LoadBalancer{detail}}, nil)
+}
+
+func (m *MockedFakeELBv2) expectDescribeLoadBalancersByArn(arn string, detail *elbv2.LoadBalancer) {
+	m.On("DescribeLoadBalancers", &elbv2.DescribeLoadBalancersInput{LoadBalancerArns: []*string{aws.String(arn)}}).
+		Return(&elbv2.DescribeLoadBalancersOutput{LoadBalancers: []*elbv2.LoadBalancer{detail}}, nil)
+}
+
+func (m *MockedFakeELBv2) DescribeLoadBalancerAttributes(input *elbv2.DescribeLoadBalancerAttributesInput) (*elbv2.DescribeLoadBalancerAttributesOutput, error) {
+	args := m.Called(input)
+	return args.Get(0).(*elbv2.DescribeLoadBalancerAttributesOutput), args.Error(1)
+}
+
+func (m *MockedFakeELBv2) expectDescribeLoadBalancerAttributes(lbName string, attributes ...*elbv2.LoadBalancerAttribute) {
+	m.On("DescribeLoadBalancerAttributes", &elbv2.DescribeLoadBalancerAttributesInput{LoadBalancerArn: aws.String(lbName)}).
+		Return(&elbv2.DescribeLoadBalancerAttributesOutput{Attributes: attributes}, nil)
+}
+
+func (m *MockedFakeELBv2) DescribeTargetGroups(input *elbv2.DescribeTargetGroupsInput) (*elbv2.DescribeTargetGroupsOutput, error) {
+	args := m.Called(input)
+	return args.Get(0).(*elbv2.DescribeTargetGroupsOutput), args.Error(1)
+}
+
+func (m *MockedFakeELBv2) expectDescribeTargetGroups(lbName string, targetGroups ...*elbv2.TargetGroup) {
+	m.On("DescribeTargetGroups", &elbv2.DescribeTargetGroupsInput{LoadBalancerArn: aws.String(lbName)}).
+		Return(&elbv2.DescribeTargetGroupsOutput{TargetGroups: targetGroups}, nil)
+}
+
+func (m *MockedFakeELBv2) DescribeTags(input *elbv2.DescribeTagsInput) (*elbv2.DescribeTagsOutput, error) {
+	args := m.Called(input)
+	return args.Get(0).(*elbv2.DescribeTagsOutput), args.Error(1)
+}
+
+func (m *MockedFakeELBv2) expectDescribeTags(arn string, tags map[string]string) {
+	m.On("DescribeTags", &elbv2.DescribeTagsInput{ResourceArns: []*string{aws.String(arn)}}).
+		Return(&elbv2.DescribeTagsOutput{TagDescriptions: []*elbv2.TagDescription{{
+			ResourceArn: aws.String(arn),
+			Tags:        mapToELBv2Tags(tags),
+		}}}, nil)
+}
+
+func (m *MockedFakeELBv2) DescribeTargetHealth(input *elbv2.DescribeTargetHealthInput) (*elbv2.DescribeTargetHealthOutput, error) {
+	args := m.Called(input)
+	return args.Get(0).(*elbv2.DescribeTargetHealthOutput), args.Error(1)
+}
+
+func (m *MockedFakeELBv2) expectDescribeTargetHealth(targetGroupArn string, targetHealths ...*elbv2.TargetHealthDescription) {
+	m.On("DescribeTargetHealth", &elbv2.DescribeTargetHealthInput{TargetGroupArn: aws.String(targetGroupArn)}).
+		Return(&elbv2.DescribeTargetHealthOutput{TargetHealthDescriptions: targetHealths}, nil)
 }
 
 func TestReadAWSCloudConfig(t *testing.T) {
@@ -2092,6 +2189,123 @@ func TestNodeNameToProviderID(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestCloud_EnsureLoadBalancer_TagAddedToNLB(t *testing.T) {
+	fakeAWS := newMockedFakeAWSServices(TestClusterID)
+	c, err := newAWSCloud(CloudConfig{}, fakeAWS)
+	require.NoError(t, err)
+
+	fakeAWS.instances = append(fakeAWS.instances, &ec2.Instance{
+		InstanceId:     aws.String("i-02bce90670bb0c7cd"),
+		SecurityGroups: []*ec2.GroupIdentifier{{GroupId: aws.String("k8s-elb-aid")}},
+		Tags: []*ec2.Tag{
+			{
+				Key:   aws.String(TagNameKubernetesClusterLegacy),
+				Value: aws.String(TestClusterID),
+			},
+		},
+	})
+	_, err = fakeAWS.ec2.CreateSubnet(constructSubnet("first-subnet", "eu-west-1a"))
+	require.NoError(t, err)
+	_, err = fakeAWS.ec2.CreateRouteTable(constructRouteTable("first-subnet", true))
+	require.NoError(t, err)
+
+	fakeAWS.elbv2.(*MockedFakeELBv2).expectDescribeLoadBalancersByName("aid", &elbv2.LoadBalancer{
+		LoadBalancerArn: aws.String("expected-lb-arn"),
+		Type:            aws.String(elbv2.LoadBalancerTypeEnumNetwork),
+		VpcId:           aws.String("vpc-id"),
+	})
+	fakeAWS.elbv2.(*MockedFakeELBv2).expectDescribeListeners("expected-lb-arn", &elbv2.Listener{
+		Port:     aws.Int64(53),
+		Protocol: aws.String("TCP"),
+	})
+	fakeAWS.elbv2.(*MockedFakeELBv2).expectDescribeTargetGroups("expected-lb-arn", &elbv2.TargetGroup{
+		TargetGroupArn:      aws.String("expected-tg-arn"),
+		Port:                aws.Int64(31456),
+		HealthCheckProtocol: aws.String("TCP"),
+		HealthCheckPort:     aws.String("31456"),
+		Protocol:            aws.String("TCP"),
+	})
+	fakeAWS.elbv2.(*MockedFakeELBv2).expectDescribeTargetHealth("expected-tg-arn", &elbv2.TargetHealthDescription{
+		HealthCheckPort: nil,
+		Target:          &elbv2.TargetDescription{Id: aws.String("i-02bce90670bb0c7cd")},
+		TargetHealth:    &elbv2.TargetHealth{Reason: aws.String("healthy")},
+	})
+	fakeAWS.elbv2.(*MockedFakeELBv2).expectDescribeTags("expected-tg-arn", map[string]string{
+		"kubernetes.io/service-name":           "/myservice",
+		"KubernetesCluster":                    "clusterid.test",
+		"kubernetes.io/cluster/clusterid.test": "owned",
+	})
+	fakeAWS.elbv2.(*MockedFakeELBv2).expectDescribeTags("expected-lb-arn", map[string]string{
+		"kubernetes.io/service-name":           "/myservice",
+		"KubernetesCluster":                    "clusterid.test",
+		"kubernetes.io/cluster/clusterid.test": "owned",
+	})
+	fakeAWS.elbv2.(*MockedFakeELBv2).expectAddTags("expected-tg-arn", map[string]string{
+		"Key1": "Value1",
+	})
+	fakeAWS.elbv2.(*MockedFakeELBv2).expectAddTags("expected-lb-arn", map[string]string{
+		"Key1": "Value1",
+	})
+	fakeAWS.elbv2.(*MockedFakeELBv2).expectDescribeLoadBalancerAttributes("expected-lb-arn", &elbv2.LoadBalancerAttribute{
+		Key:   aws.String("load_balancing.cross_zone.enabled"),
+		Value: aws.String("false"),
+	}, &elbv2.LoadBalancerAttribute{
+		Key:   aws.String("access_logs.s3.enabled"),
+		Value: aws.String("false"),
+	})
+	fakeAWS.elbv2.(*MockedFakeELBv2).expectDescribeLoadBalancersByArn("expected-lb-arn", &elbv2.LoadBalancer{
+		LoadBalancerArn: aws.String("expected-lb-arn"),
+		Type:            aws.String(elbv2.LoadBalancerTypeEnumNetwork),
+		VpcId:           aws.String("vpc-id"),
+		DNSName:         aws.String("lb-dns-name"),
+		State:           &elbv2.LoadBalancerState{Code: aws.String(elbv2.LoadBalancerStateEnumActive)},
+	})
+	fakeAWS.ec2.(*MockedFakeEC2).expectDescribeSecurityGroupsWithoutFilters(TestClusterID, "k8s-elb-aid", &ec2.IpPermission{
+		FromPort:   aws.Int64(31456),
+		ToPort:     aws.Int64(31456),
+		IpProtocol: aws.String("tcp"),
+		IpRanges: []*ec2.IpRange{
+			{CidrIp: aws.String("172.20.0.0/16"), Description: aws.String("kubernetes.io/rule/nlb/health=aid")},
+			{CidrIp: aws.String("0.0.0.0/0"), Description: aws.String("kubernetes.io/rule/nlb/client=aid")},
+		},
+	})
+
+	svc := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "myservice",
+			UID:  "id",
+			Annotations: map[string]string{
+				ServiceAnnotationLoadBalancerType:           "nlb",
+				ServiceAnnotationLoadBalancerAdditionalTags: "Key1=Value1",
+			},
+		},
+		Spec: v1.ServiceSpec{
+			SessionAffinity: v1.ServiceAffinityNone,
+			Ports: []v1.ServicePort{
+				{
+					Name:       "dns-tcp",
+					Protocol:   "TCP",
+					Port:       53,
+					TargetPort: intstr.IntOrString{IntVal: 9153},
+					NodePort:   31456,
+				},
+			},
+		},
+	}
+
+	status, err := c.EnsureLoadBalancer(context.TODO(), TestClusterID, svc, []*v1.Node{{
+		ObjectMeta: metav1.ObjectMeta{Name: "node1", UID: "id1"},
+		Spec: v1.NodeSpec{
+			ProviderID: "aws:///eu-west-1a/i-02bce90670bb0c7cd",
+		},
+	}})
+
+	assert.NoError(t, err)
+	assert.Equal(t, "lb-dns-name", status.Ingress[0].Hostname)
+
+	fakeAWS.elbv2.(*MockedFakeELBv2).AssertExpectations(t)
+}
+
 func informerSynced() bool {
 	return true
 }
@@ -2693,6 +2907,7 @@ func newMockedFakeAWSServices(id string) *FakeAWSServices {
 	s := NewFakeAWSServices(id)
 	s.ec2 = &MockedFakeEC2{FakeEC2Impl: s.ec2.(*FakeEC2Impl)}
 	s.elb = &MockedFakeELB{FakeELB: s.elb.(*FakeELB)}
+	s.elbv2 = &MockedFakeELBv2{FakeELBV2: s.elbv2.(*FakeELBV2)}
 	return s
 }
 

--- a/staging/src/k8s.io/legacy-cloud-providers/aws/aws_utils.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/aws/aws_utils.go
@@ -20,6 +20,7 @@ package aws
 
 import (
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/elbv2"
 
 	"k8s.io/apimachinery/pkg/util/sets"
 )
@@ -44,4 +45,24 @@ func stringSetFromPointers(in []*string) sets.String {
 		out.Insert(aws.StringValue(in[i]))
 	}
 	return out
+}
+
+func mapToELBv2Tags(in map[string]string) []*elbv2.Tag {
+	targetGroupTags := make([]*elbv2.Tag, 0, len(in))
+	for k, v := range in {
+		targetGroupTags = append(targetGroupTags, &elbv2.Tag{
+			Key: aws.String(k), Value: aws.String(v),
+		})
+	}
+
+	return targetGroupTags
+}
+
+func mapFromELBv2Tags(in []*elbv2.Tag) map[string]string {
+	tags := map[string]string{}
+	for _, v := range in {
+		tags[*v.Key] = *v.Value
+	}
+
+	return tags
 }


### PR DESCRIPTION
Ensure that tags on an NLB are updated when they are changed in the external load balancer service.

Also add a test to start covering the NLB side of `EnsureLoadBalancer`.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Currently, when the `service.beta.kubernetes.io/aws-load-balancer-additional-resource-tags` annotation of an NLB `LoadBalancer` service gets updated, the NLB created for that service doesn't get modified. This PR ensures that the NLB tags get updated when the `service.beta.kubernetes.io/aws-load-balancer-additional-resource-tags` annotation gets modified. 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
action required: Clusters running within AWS need to be granted elasticloadbalancing:DescribeTags elasticloadbalancing:RemoveTags and elasticloadbalancing:AddTags
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
