### PR TITLE
Fix golint failures in pkg/volume/util/volumepathhandler

### DIFF
--- a/pkg/volume/util/volumepathhandler/volume_path_handler.go
+++ b/pkg/volume/util/volumepathhandler/volume_path_handler.go
@@ -30,9 +30,11 @@ import (
 )
 
 const (
-	losetupPath           = "losetup"
-	statPath              = "stat"
-	ErrDeviceNotFound     = "device not found"
+	losetupPath = "losetup"
+	statPath    = "stat"
+	// ErrDeviceNotFound code for NotFound Errors.
+	ErrDeviceNotFound = "device not found"
+	// ErrDeviceNotSupported code for NotSupported Errors.
 	ErrDeviceNotSupported = "device not supported"
 )
 

--- a/pkg/volume/util/volumepathhandler/volume_path_handler_unsupported.go
+++ b/pkg/volume/util/volumepathhandler/volume_path_handler_unsupported.go
@@ -27,22 +27,22 @@ import (
 // AttachFileDevice takes a path to a regular file and makes it available as an
 // attached block device.
 func (v VolumePathHandler) AttachFileDevice(path string) (string, error) {
-	return "", fmt.Errorf("AttachFileDevice not supported for this build.")
+	return "", fmt.Errorf("AttachFileDevice not supported for this build")
 }
 
 // DetachFileDevice takes a path to the attached block device and
 // detach it from block device.
 func (v VolumePathHandler) DetachFileDevice(path string) error {
-	return fmt.Errorf("DetachFileDevice not supported for this build.")
+	return fmt.Errorf("DetachFileDevice not supported for this build")
 }
 
 // GetLoopDevice returns the full path to the loop device associated with the given path.
 func (v VolumePathHandler) GetLoopDevice(path string) (string, error) {
-	return "", fmt.Errorf("GetLoopDevice not supported for this build.")
+	return "", fmt.Errorf("GetLoopDevice not supported for this build")
 }
 
 // FindGlobalMapPathUUIDFromPod finds {pod uuid} bind mount under globalMapPath
 // corresponding to map path symlink, and then return global map path with pod uuid.
 func (v VolumePathHandler) FindGlobalMapPathUUIDFromPod(pluginDir, mapPath string, podUID types.UID) (string, error) {
-	return "", fmt.Errorf("FindGlobalMapPathUUIDFromPod not supported for this build.")
+	return "", fmt.Errorf("FindGlobalMapPathUUIDFromPod not supported for this build")
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

According to this issue: #68026, I revise some errors about golint in kubernetes.

**What this PR does / why we need it**:

Fixing linting issues in pkg/volume/util/volumepathhandler.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

**Special notes for your reviewer**:

I revised some errors about golint in the following package:
+ pkg/volume/util/volumepathhandler

After I revised above errors, I run hack/update-bazel.sh and hack/update-gofmt.sh to make sure I fix any problems with gofmt or bazel.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
