### PR TITLE
Support IPv6 on the e2e test ""should resolve connection reset issue #74839 "

### DIFF
--- a/test/utils/image/manifest.go
+++ b/test/utils/image/manifest.go
@@ -240,7 +240,7 @@ func initImageConfigs() map[int]Config {
 	configs[PrometheusDummyExporter] = Config{gcRegistry, "prometheus-dummy-exporter", "v0.1.0"}
 	configs[PrometheusToSd] = Config{gcRegistry, "prometheus-to-sd", "v0.5.0"}
 	configs[Redis] = Config{dockerLibraryRegistry, "redis", "5.0.5-alpine"}
-	configs[RegressionIssue74839] = Config{e2eRegistry, "regression-issue-74839-amd64", "1.0"}
+	configs[RegressionIssue74839] = Config{promoterE2eRegistry, "regression-issue-74839", "1.2"}
 	configs[ResourceConsumer] = Config{e2eRegistry, "resource-consumer", "1.5"}
 	configs[SdDummyExporter] = Config{gcRegistry, "sd-dummy-exporter", "v0.2.0"}
 	configs[VolumeNFSServer] = Config{e2eVolumeRegistry, "nfs", "1.0"}


### PR DESCRIPTION
This adds IPv6 support to the e2e test that checks if conntrack invalid entries are dropped to avoid TCP connection resets.
It depends on an update to the container image used in the test, by https://github.com/kubernetes/kubernetes/pull/95328

/kind failing-test


```release-note
NONE
```

Fixes: https://github.com/kubernetes/kubernetes/issues/93281