### PR TITLE
Automated cherry pick of #95316: Mask bearer token in logs when logLevel >= 9

### DIFF
--- a/staging/src/k8s.io/client-go/transport/round_trippers.go
+++ b/staging/src/k8s.io/client-go/transport/round_trippers.go
@@ -340,6 +340,7 @@ func (r *requestInfo) toCurl() string {
 	headers := ""
 	for key, values := range r.RequestHeaders {
 		for _, value := range values {
+			value = maskValue(key, value)
 			headers += fmt.Sprintf(` -H %q`, fmt.Sprintf("%s: %s", key, value))
 		}
 	}


### PR DESCRIPTION
Cherry pick of #95316 on release-1.17.

#95316: Mask bearer token in logs when logLevel >= 9

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.