### PR TITLE
resource/suffix.go: Fix int overflow via incorrect ParseInt bitSize value

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/suffix.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/suffix.go
@@ -187,7 +187,7 @@ func (sh *suffixHandler) interpret(suffix suffix) (base, exponent int32, fmt For
 	}
 
 	if len(suffix) > 1 && (suffix[0] == 'E' || suffix[0] == 'e') {
-		parsed, err := strconv.ParseInt(string(suffix[1:]), 10, 64)
+		parsed, err := strconv.ParseInt(string(suffix[1:]), 10, 32)
 		if err != nil {
 			return 0, 0, DecimalExponent, false
 		}


### PR DESCRIPTION
Before this PR, the `parsed` number could parse an int64 value which would then be overflowed when returning by the `int32(parsed)`.

I haven't tested this code, but it is unlikely the code depends on an int overflow.
