### PR TITLE
Fix reporting network_programming_latency metrics in kube-proxy

### DIFF
--- a/pkg/proxy/endpoints_test.go
+++ b/pkg/proxy/endpoints_test.go
@@ -1413,6 +1413,14 @@ func TestLastChangeTriggerTime(t *testing.T) {
 			},
 			expected: map[types.NamespacedName][]time.Time{createName("ns", "ep1"): {t2}},
 		},
+		{
+			name: "delete",
+			scenario: func(fp *FakeProxier) {
+				e := createEndpoints("ns", "ep1", t1)
+				fp.deleteEndpoints(e)
+			},
+			expected: map[types.NamespacedName][]time.Time{},
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
This PR avoids reporting network_programming_latency for deletion of Endpoints/EndpointSlice objects, where we don't have a good timestamp as of now.

```release-note
Fix network_programming_latency metric reporting for Endpoints/EndpointSlice deletions, where we don't have correct timestamp
```

/sig network
/sig scalability
/kind bug
/priority important-soon