### PR TITLE
kubeadm: deprecate the "node-role.kubernetes.io/master" label / taint

### DIFF
--- a/cmd/kubeadm/app/constants/constants.go
+++ b/cmd/kubeadm/app/constants/constants.go
@@ -225,9 +225,12 @@ const (
 	// CertificateKeySize specifies the size of the key used to encrypt certificates on uploadcerts phase
 	CertificateKeySize = 32
 
-	// LabelNodeRoleMaster specifies that a node is a control-plane
-	// This is a duplicate definition of the constant in pkg/controller/service/controller.go
-	LabelNodeRoleMaster = "node-role.kubernetes.io/master"
+	// LabelNodeRoleOldControlPlane specifies that a node hosts control-plane components
+	// DEPRECATED: https://github.com/kubernetes/kubeadm/issues/2200
+	LabelNodeRoleOldControlPlane = "node-role.kubernetes.io/master"
+
+	// LabelNodeRoleControlPlane specifies that a node hosts control-plane components
+	LabelNodeRoleControlPlane = "node-role.kubernetes.io/control-plane"
 
 	// AnnotationKubeadmCRISocket specifies the annotation kubeadm uses to preserve the crisocket information given to kubeadm at
 	// init/join time for use later. kubeadm annotates the node object with this information
@@ -414,15 +417,29 @@ const (
 )
 
 var (
+	// OldControlPlaneTaint is the taint to apply on the PodSpec for being able to run that Pod on the control-plane
+	// DEPRECATED: https://github.com/kubernetes/kubeadm/issues/2200
+	OldControlPlaneTaint = v1.Taint{
+		Key:    LabelNodeRoleOldControlPlane,
+		Effect: v1.TaintEffectNoSchedule,
+	}
+
+	// OldControlPlaneToleration is the toleration to apply on the PodSpec for being able to run that Pod on the control-plane
+	// DEPRECATED: https://github.com/kubernetes/kubeadm/issues/2200
+	OldControlPlaneToleration = v1.Toleration{
+		Key:    LabelNodeRoleOldControlPlane,
+		Effect: v1.TaintEffectNoSchedule,
+	}
+
 	// ControlPlaneTaint is the taint to apply on the PodSpec for being able to run that Pod on the control-plane
 	ControlPlaneTaint = v1.Taint{
-		Key:    LabelNodeRoleMaster,
+		Key:    LabelNodeRoleControlPlane,
 		Effect: v1.TaintEffectNoSchedule,
 	}
 
 	// ControlPlaneToleration is the toleration to apply on the PodSpec for being able to run that Pod on the control-plane
 	ControlPlaneToleration = v1.Toleration{
-		Key:    LabelNodeRoleMaster,
+		Key:    LabelNodeRoleControlPlane,
 		Effect: v1.TaintEffectNoSchedule,
 	}
 

--- a/cmd/kubeadm/app/phases/addons/dns/dns.go
+++ b/cmd/kubeadm/app/phases/addons/dns/dns.go
@@ -135,18 +135,20 @@ func kubeDNSAddon(cfg *kubeadmapi.ClusterConfiguration, client clientset.Interfa
 
 	dnsDeploymentBytes, err := kubeadmutil.ParseTemplate(KubeDNSDeployment,
 		struct {
-			DeploymentName, KubeDNSImage, DNSMasqImage, SidecarImage, DNSBindAddr, DNSProbeAddr, DNSDomain, ControlPlaneTaintKey string
-			Replicas                                                                                                             *int32
+			DeploymentName, KubeDNSImage, DNSMasqImage, SidecarImage, DNSBindAddr, DNSProbeAddr, DNSDomain, OldControlPlaneTaintKey, ControlPlaneTaintKey string
+			Replicas                                                                                                                                      *int32
 		}{
-			DeploymentName:       kubeadmconstants.KubeDNSDeploymentName,
-			KubeDNSImage:         images.GetDNSImage(cfg, kubeadmconstants.KubeDNSKubeDNSImageName),
-			DNSMasqImage:         images.GetDNSImage(cfg, kubeadmconstants.KubeDNSDnsMasqNannyImageName),
-			SidecarImage:         images.GetDNSImage(cfg, kubeadmconstants.KubeDNSSidecarImageName),
-			DNSBindAddr:          dnsBindAddr,
-			DNSProbeAddr:         dnsProbeAddr,
-			DNSDomain:            cfg.Networking.DNSDomain,
-			ControlPlaneTaintKey: kubeadmconstants.LabelNodeRoleMaster,
-			Replicas:             replicas,
+			DeploymentName: kubeadmconstants.KubeDNSDeploymentName,
+			KubeDNSImage:   images.GetDNSImage(cfg, kubeadmconstants.KubeDNSKubeDNSImageName),
+			DNSMasqImage:   images.GetDNSImage(cfg, kubeadmconstants.KubeDNSDnsMasqNannyImageName),
+			SidecarImage:   images.GetDNSImage(cfg, kubeadmconstants.KubeDNSSidecarImageName),
+			DNSBindAddr:    dnsBindAddr,
+			DNSProbeAddr:   dnsProbeAddr,
+			DNSDomain:      cfg.Networking.DNSDomain,
+			// TODO: https://github.com/kubernetes/kubeadm/issues/2200
+			OldControlPlaneTaintKey: kubeadmconstants.LabelNodeRoleOldControlPlane,
+			ControlPlaneTaintKey:    kubeadmconstants.LabelNodeRoleControlPlane,
+			Replicas:                replicas,
 		})
 	if err != nil {
 		return errors.Wrap(err, "error when parsing kube-dns deployment template")
@@ -196,13 +198,15 @@ func createKubeDNSAddon(deploymentBytes, serviceBytes []byte, client clientset.I
 func coreDNSAddon(cfg *kubeadmapi.ClusterConfiguration, client clientset.Interface, replicas *int32) error {
 	// Get the YAML manifest
 	coreDNSDeploymentBytes, err := kubeadmutil.ParseTemplate(CoreDNSDeployment, struct {
-		DeploymentName, Image, ControlPlaneTaintKey string
-		Replicas                                    *int32
+		DeploymentName, Image, OldControlPlaneTaintKey, ControlPlaneTaintKey string
+		Replicas                                                             *int32
 	}{
-		DeploymentName:       kubeadmconstants.CoreDNSDeploymentName,
-		Image:                images.GetDNSImage(cfg, kubeadmconstants.CoreDNSImageName),
-		ControlPlaneTaintKey: kubeadmconstants.LabelNodeRoleMaster,
-		Replicas:             replicas,
+		DeploymentName: kubeadmconstants.CoreDNSDeploymentName,
+		Image:          images.GetDNSImage(cfg, kubeadmconstants.CoreDNSImageName),
+		// TODO: https://github.com/kubernetes/kubeadm/issues/2200
+		OldControlPlaneTaintKey: kubeadmconstants.LabelNodeRoleOldControlPlane,
+		ControlPlaneTaintKey:    kubeadmconstants.LabelNodeRoleControlPlane,
+		Replicas:                replicas,
 	})
 	if err != nil {
 		return errors.Wrap(err, "error when parsing CoreDNS deployment template")

--- a/cmd/kubeadm/app/phases/addons/dns/dns_test.go
+++ b/cmd/kubeadm/app/phases/addons/dns/dns_test.go
@@ -102,18 +102,19 @@ func TestCompileManifests(t *testing.T) {
 			name:     "KubeDNSDeployment manifest",
 			manifest: KubeDNSDeployment,
 			data: struct {
-				DeploymentName, KubeDNSImage, DNSMasqImage, SidecarImage, DNSBindAddr, DNSProbeAddr, DNSDomain, ControlPlaneTaintKey string
-				Replicas                                                                                                             *int32
+				DeploymentName, KubeDNSImage, DNSMasqImage, SidecarImage, DNSBindAddr, DNSProbeAddr, DNSDomain, OldControlPlaneTaintKey, ControlPlaneTaintKey string
+				Replicas                                                                                                                                      *int32
 			}{
-				DeploymentName:       "foo",
-				KubeDNSImage:         "foo",
-				DNSMasqImage:         "foo",
-				SidecarImage:         "foo",
-				DNSBindAddr:          "foo",
-				DNSProbeAddr:         "foo",
-				DNSDomain:            "foo",
-				ControlPlaneTaintKey: "foo",
-				Replicas:             &replicas,
+				DeploymentName:          "foo",
+				KubeDNSImage:            "foo",
+				DNSMasqImage:            "foo",
+				SidecarImage:            "foo",
+				DNSBindAddr:             "foo",
+				DNSProbeAddr:            "foo",
+				DNSDomain:               "foo",
+				OldControlPlaneTaintKey: "foo",
+				ControlPlaneTaintKey:    "foo",
+				Replicas:                &replicas,
 			},
 		},
 		{
@@ -127,13 +128,14 @@ func TestCompileManifests(t *testing.T) {
 			name:     "CoreDNSDeployment manifest",
 			manifest: CoreDNSDeployment,
 			data: struct {
-				DeploymentName, Image, ControlPlaneTaintKey string
-				Replicas                                    *int32
+				DeploymentName, Image, OldControlPlaneTaintKey, ControlPlaneTaintKey string
+				Replicas                                                             *int32
 			}{
-				DeploymentName:       "foo",
-				Image:                "foo",
-				ControlPlaneTaintKey: "foo",
-				Replicas:             &replicas,
+				DeploymentName:          "foo",
+				Image:                   "foo",
+				OldControlPlaneTaintKey: "foo",
+				ControlPlaneTaintKey:    "foo",
+				Replicas:                &replicas,
 			},
 		},
 		{
@@ -506,32 +508,34 @@ func TestDeploymentsHaveSystemClusterCriticalPriorityClassName(t *testing.T) {
 			name:     "KubeDNSDeployment",
 			manifest: KubeDNSDeployment,
 			data: struct {
-				DeploymentName, KubeDNSImage, DNSMasqImage, SidecarImage, DNSBindAddr, DNSProbeAddr, DNSDomain, ControlPlaneTaintKey string
-				Replicas                                                                                                             *int32
+				DeploymentName, KubeDNSImage, DNSMasqImage, SidecarImage, DNSBindAddr, DNSProbeAddr, DNSDomain, OldControlPlaneTaintKey, ControlPlaneTaintKey string
+				Replicas                                                                                                                                      *int32
 			}{
-				DeploymentName:       "foo",
-				KubeDNSImage:         "foo",
-				DNSMasqImage:         "foo",
-				SidecarImage:         "foo",
-				DNSBindAddr:          "foo",
-				DNSProbeAddr:         "foo",
-				DNSDomain:            "foo",
-				ControlPlaneTaintKey: "foo",
-				Replicas:             &replicas,
+				DeploymentName:          "foo",
+				KubeDNSImage:            "foo",
+				DNSMasqImage:            "foo",
+				SidecarImage:            "foo",
+				DNSBindAddr:             "foo",
+				DNSProbeAddr:            "foo",
+				DNSDomain:               "foo",
+				OldControlPlaneTaintKey: "foo",
+				ControlPlaneTaintKey:    "foo",
+				Replicas:                &replicas,
 			},
 		},
 		{
 			name:     "CoreDNSDeployment",
 			manifest: CoreDNSDeployment,
 			data: struct {
-				DeploymentName, Image, ControlPlaneTaintKey, CoreDNSConfigMapName string
-				Replicas                                                          *int32
+				DeploymentName, Image, OldControlPlaneTaintKey, ControlPlaneTaintKey, CoreDNSConfigMapName string
+				Replicas                                                                                   *int32
 			}{
-				DeploymentName:       "foo",
-				Image:                "foo",
-				ControlPlaneTaintKey: "foo",
-				CoreDNSConfigMapName: "foo",
-				Replicas:             &replicas,
+				DeploymentName:          "foo",
+				Image:                   "foo",
+				OldControlPlaneTaintKey: "foo",
+				ControlPlaneTaintKey:    "foo",
+				CoreDNSConfigMapName:    "foo",
+				Replicas:                &replicas,
 			},
 		},
 	}

--- a/cmd/kubeadm/app/phases/addons/dns/manifests.go
+++ b/cmd/kubeadm/app/phases/addons/dns/manifests.go
@@ -170,6 +170,8 @@ spec:
       tolerations:
       - key: CriticalAddonsOnly
         operator: Exists
+      - key: {{ .OldControlPlaneTaintKey }}
+        effect: NoSchedule
       - key: {{ .ControlPlaneTaintKey }}
         effect: NoSchedule
 `
@@ -238,6 +240,8 @@ spec:
       tolerations:
       - key: CriticalAddonsOnly
         operator: Exists
+      - key: {{ .OldControlPlaneTaintKey }}
+        effect: NoSchedule
       - key: {{ .ControlPlaneTaintKey }}
         effect: NoSchedule
       nodeSelector:

--- a/cmd/kubeadm/app/phases/markcontrolplane/markcontrolplane.go
+++ b/cmd/kubeadm/app/phases/markcontrolplane/markcontrolplane.go
@@ -28,7 +28,9 @@ import (
 // MarkControlPlane taints the control-plane and sets the control-plane label
 func MarkControlPlane(client clientset.Interface, controlPlaneName string, taints []v1.Taint) error {
 
-	fmt.Printf("[mark-control-plane] Marking the node %s as control-plane by adding the label \"%s=''\"\n", controlPlaneName, constants.LabelNodeRoleMaster)
+	// TODO: https://github.com/kubernetes/kubeadm/issues/2200
+	fmt.Printf("[mark-control-plane] Marking the node %s as control-plane by adding the labels \"%s=''\" and \"%s='' (deprecated)\"\n",
+		controlPlaneName, constants.LabelNodeRoleOldControlPlane, constants.LabelNodeRoleControlPlane)
 
 	if len(taints) > 0 {
 		taintStrs := []string{}
@@ -54,7 +56,9 @@ func taintExists(taint v1.Taint, taints []v1.Taint) bool {
 }
 
 func markControlPlaneNode(n *v1.Node, taints []v1.Taint) {
-	n.ObjectMeta.Labels[constants.LabelNodeRoleMaster] = ""
+	// TODO: https://github.com/kubernetes/kubeadm/issues/2200
+	n.ObjectMeta.Labels[constants.LabelNodeRoleOldControlPlane] = ""
+	n.ObjectMeta.Labels[constants.LabelNodeRoleControlPlane] = ""
 
 	for _, nt := range n.Spec.Taints {
 		if !taintExists(nt, taints) {

--- a/cmd/kubeadm/app/phases/selfhosting/podspec_mutation.go
+++ b/cmd/kubeadm/app/phases/selfhosting/podspec_mutation.go
@@ -85,21 +85,22 @@ func mutatePodSpec(mutators map[string][]PodSpecMutatorFunc, name string, podSpe
 // addNodeSelectorToPodSpec makes Pod require to be scheduled on a node marked with the control-plane label
 func addNodeSelectorToPodSpec(podSpec *v1.PodSpec) {
 	if podSpec.NodeSelector == nil {
-		podSpec.NodeSelector = map[string]string{kubeadmconstants.LabelNodeRoleMaster: ""}
+		podSpec.NodeSelector = map[string]string{kubeadmconstants.LabelNodeRoleOldControlPlane: ""}
 		return
 	}
 
-	podSpec.NodeSelector[kubeadmconstants.LabelNodeRoleMaster] = ""
+	podSpec.NodeSelector[kubeadmconstants.LabelNodeRoleOldControlPlane] = ""
 }
 
 // setControlPlaneTolerationOnPodSpec makes the Pod tolerate the control-plane taint
 func setControlPlaneTolerationOnPodSpec(podSpec *v1.PodSpec) {
 	if podSpec.Tolerations == nil {
-		podSpec.Tolerations = []v1.Toleration{kubeadmconstants.ControlPlaneToleration}
+		// TODO: https://github.com/kubernetes/kubeadm/issues/2200
+		podSpec.Tolerations = []v1.Toleration{kubeadmconstants.OldControlPlaneToleration}
 		return
 	}
 
-	podSpec.Tolerations = append(podSpec.Tolerations, kubeadmconstants.ControlPlaneToleration)
+	podSpec.Tolerations = append(podSpec.Tolerations, kubeadmconstants.OldControlPlaneToleration)
 }
 
 // setHostIPOnPodSpec sets the environment variable HOST_IP using downward API

--- a/cmd/kubeadm/app/phases/selfhosting/podspec_mutation_test.go
+++ b/cmd/kubeadm/app/phases/selfhosting/podspec_mutation_test.go
@@ -66,10 +66,10 @@ func TestMutatePodSpec(t *testing.T) {
 				},
 
 				NodeSelector: map[string]string{
-					kubeadmconstants.LabelNodeRoleMaster: "",
+					kubeadmconstants.LabelNodeRoleOldControlPlane: "",
 				},
 				Tolerations: []v1.Toleration{
-					kubeadmconstants.ControlPlaneToleration,
+					kubeadmconstants.OldControlPlaneToleration,
 				},
 				DNSPolicy: v1.DNSClusterFirstWithHostNet,
 			},
@@ -80,10 +80,10 @@ func TestMutatePodSpec(t *testing.T) {
 			podSpec:   &v1.PodSpec{},
 			expected: v1.PodSpec{
 				NodeSelector: map[string]string{
-					kubeadmconstants.LabelNodeRoleMaster: "",
+					kubeadmconstants.LabelNodeRoleOldControlPlane: "",
 				},
 				Tolerations: []v1.Toleration{
-					kubeadmconstants.ControlPlaneToleration,
+					kubeadmconstants.OldControlPlaneToleration,
 				},
 				DNSPolicy: v1.DNSClusterFirstWithHostNet,
 			},
@@ -94,10 +94,10 @@ func TestMutatePodSpec(t *testing.T) {
 			podSpec:   &v1.PodSpec{},
 			expected: v1.PodSpec{
 				NodeSelector: map[string]string{
-					kubeadmconstants.LabelNodeRoleMaster: "",
+					kubeadmconstants.LabelNodeRoleOldControlPlane: "",
 				},
 				Tolerations: []v1.Toleration{
-					kubeadmconstants.ControlPlaneToleration,
+					kubeadmconstants.OldControlPlaneToleration,
 				},
 				DNSPolicy: v1.DNSClusterFirstWithHostNet,
 			},
@@ -126,7 +126,7 @@ func TestAddNodeSelectorToPodSpec(t *testing.T) {
 			podSpec: &v1.PodSpec{},
 			expected: v1.PodSpec{
 				NodeSelector: map[string]string{
-					kubeadmconstants.LabelNodeRoleMaster: "",
+					kubeadmconstants.LabelNodeRoleOldControlPlane: "",
 				},
 			},
 		},
@@ -139,8 +139,8 @@ func TestAddNodeSelectorToPodSpec(t *testing.T) {
 			},
 			expected: v1.PodSpec{
 				NodeSelector: map[string]string{
-					"foo":                                "bar",
-					kubeadmconstants.LabelNodeRoleMaster: "",
+					"foo": "bar",
+					kubeadmconstants.LabelNodeRoleOldControlPlane: "",
 				},
 			},
 		},
@@ -168,7 +168,7 @@ func TestSetControlPlaneTolerationOnPodSpec(t *testing.T) {
 			podSpec: &v1.PodSpec{},
 			expected: v1.PodSpec{
 				Tolerations: []v1.Toleration{
-					kubeadmconstants.ControlPlaneToleration,
+					kubeadmconstants.OldControlPlaneToleration,
 				},
 			},
 		},
@@ -182,7 +182,7 @@ func TestSetControlPlaneTolerationOnPodSpec(t *testing.T) {
 			expected: v1.PodSpec{
 				Tolerations: []v1.Toleration{
 					{Key: "foo", Value: "bar"},
-					kubeadmconstants.ControlPlaneToleration,
+					kubeadmconstants.OldControlPlaneToleration,
 				},
 			},
 		},

--- a/cmd/kubeadm/app/phases/upgrade/health.go
+++ b/cmd/kubeadm/app/phases/upgrade/health.go
@@ -208,21 +208,34 @@ func deleteHealthCheckJob(client clientset.Interface, ns, jobName string) error 
 
 // controlPlaneNodesReady checks whether all control-plane Nodes in the cluster are in the Running state
 func controlPlaneNodesReady(client clientset.Interface, _ *kubeadmapi.ClusterConfiguration) error {
-	selector := labels.SelectorFromSet(labels.Set(map[string]string{
-		constants.LabelNodeRoleMaster: "",
+	// list nodes labeled with a "master" node-role
+	selectorOldControlPlane := labels.SelectorFromSet(labels.Set(map[string]string{
+		constants.LabelNodeRoleOldControlPlane: "",
 	}))
-	controlPlanes, err := client.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{
-		LabelSelector: selector.String(),
+	nodesWithOldLabel, err := client.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{
+		LabelSelector: selectorOldControlPlane.String(),
 	})
 	if err != nil {
-		return errors.Wrap(err, "couldn't list control-planes in cluster")
+		return errors.Wrapf(err, "could not list nodes labeled with %q", constants.LabelNodeRoleOldControlPlane)
 	}
 
-	if len(controlPlanes.Items) == 0 {
+	// list nodes labeled with a "control-plane" node-role
+	selectorControlPlane := labels.SelectorFromSet(labels.Set(map[string]string{
+		constants.LabelNodeRoleControlPlane: "",
+	}))
+	nodesControlPlane, err := client.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{
+		LabelSelector: selectorControlPlane.String(),
+	})
+	if err != nil {
+		return errors.Wrapf(err, "could not list nodes labeled with %q", constants.LabelNodeRoleControlPlane)
+	}
+
+	nodes := append(nodesWithOldLabel.Items, nodesControlPlane.Items...)
+	if len(nodes) == 0 {
 		return errors.New("failed to find any nodes with a control-plane role")
 	}
 
-	notReadyControlPlanes := getNotReadyNodes(controlPlanes.Items)
+	notReadyControlPlanes := getNotReadyNodes(nodes)
 	if len(notReadyControlPlanes) != 0 {
 		return errors.Errorf("there are NotReady control-planes in the cluster: %v", notReadyControlPlanes)
 	}

--- a/cmd/kubeadm/app/util/config/cluster_test.go
+++ b/cmd/kubeadm/app/util/config/cluster_test.go
@@ -303,7 +303,7 @@ func TestGetNodeRegistration(t *testing.T) {
 					},
 				},
 				Spec: v1.NodeSpec{
-					Taints: []v1.Taint{kubeadmconstants.ControlPlaneTaint},
+					Taints: []v1.Taint{kubeadmconstants.OldControlPlaneTaint},
 				},
 			},
 		},
@@ -583,7 +583,7 @@ func TestGetInitConfigurationFromCluster(t *testing.T) {
 					},
 				},
 				Spec: v1.NodeSpec{
-					Taints: []v1.Taint{kubeadmconstants.ControlPlaneTaint},
+					Taints: []v1.Taint{kubeadmconstants.OldControlPlaneTaint},
 				},
 			},
 		},
@@ -660,7 +660,7 @@ func TestGetInitConfigurationFromCluster(t *testing.T) {
 					},
 				},
 				Spec: v1.NodeSpec{
-					Taints: []v1.Taint{kubeadmconstants.ControlPlaneTaint},
+					Taints: []v1.Taint{kubeadmconstants.OldControlPlaneTaint},
 				},
 			},
 		},

--- a/cmd/kubeadm/app/util/config/initconfiguration.go
+++ b/cmd/kubeadm/app/util/config/initconfiguration.go
@@ -83,7 +83,7 @@ func SetBootstrapTokensDynamicDefaults(cfg *[]kubeadmapi.BootstrapToken) error {
 }
 
 // SetNodeRegistrationDynamicDefaults checks and sets configuration values for the NodeRegistration object
-func SetNodeRegistrationDynamicDefaults(cfg *kubeadmapi.NodeRegistrationOptions, ControlPlaneTaint bool) error {
+func SetNodeRegistrationDynamicDefaults(cfg *kubeadmapi.NodeRegistrationOptions, controlPlaneTaint bool) error {
 	var err error
 	cfg.Name, err = kubeadmutil.GetHostname(cfg.Name)
 	if err != nil {
@@ -91,8 +91,9 @@ func SetNodeRegistrationDynamicDefaults(cfg *kubeadmapi.NodeRegistrationOptions,
 	}
 
 	// Only if the slice is nil, we should append the control-plane taint. This allows the user to specify an empty slice for no default control-plane taint
-	if ControlPlaneTaint && cfg.Taints == nil {
-		cfg.Taints = []v1.Taint{kubeadmconstants.ControlPlaneTaint}
+	if controlPlaneTaint && cfg.Taints == nil {
+		// TODO: https://github.com/kubernetes/kubeadm/issues/2200
+		cfg.Taints = []v1.Taint{kubeadmconstants.OldControlPlaneTaint}
 	}
 
 	if cfg.CRISocket == "" {


### PR DESCRIPTION
**What this PR does / why we need it**:
please review the separate commits:

```
- Rename the constants.ControlPlane{Taint|Toleraton} to
constants.OldControlPlane{Taint|Toleraton} to manage the transition.
- Mark constants.OldControlPlane{{Taint|Toleraton} as deprecated.
- Use constants.OldControlPlane{{Taint|Toleraton} instead of
constants.ControlPlane{Taint|Toleraton} everywhere.
- Introduce constants.ControlPlane{Taint|Toleraton}.
- Add constants.ControlPlaneToleraton to the kube-dns / CoreDNS
Deployments to make them anticipate the introduction
of the "node-role.kubernetes.io/control-plane:NoSchedule"
taint (constants.ControlPlaneTaint) on kubeadm control-plane Nodes.
- During "kubeadm init/join" apply the label
"node-role.kubernetes.io/control-plane" to new control-plane nodes,
next to the existing "node-role.kubernetes.io/master" label.
- During "kubeadm upgrade apply", find all Nodes with the "master"
label and also apply the "control-plane" label to them
(if they don't have it).
- During upgrade health-checks collect Nodes labeled both "master"
and "control-plane".
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
xref https://github.com/kubernetes/kubeadm/issues/2200

**Special notes for your reviewer**:
NONE

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
ACTION REQUIRED: kubeadm:
- The label applied to control-plane nodes "node-role.kubernetes.io/master" is now deprecated and will be removed in a future release after a GA deprecation period.
- Introduce a new label "node-role.kubernetes.io/control-plane" that will be applied in parallel to "node-role.kubernetes.io/master" until the removal of the "node-role.kubernetes.io/master" label.
- Make "kubeadm upgrade apply" add the "node-role.kubernetes.io/control-plane" label on existing nodes that only have the "node-role.kubernetes.io/master" label during upgrade.
- Please adapt your tooling built on top of kubeadm to use the "node-role.kubernetes.io/control-plane" label.

- The taint applied to control-plane nodes "node-role.kubernetes.io/master:NoSchedule" is now deprecated and will be removed in a future release after a GA deprecation period.
- Apply toleration for a new, future taint "node-role.kubernetes.io/control-plane:NoSchedule" to the kubeadm CoreDNS / kube-dns managed manifests. Note that this taint is not yet applied to kubeadm control-plane nodes.
- Please adapt your workloads to tolerate the same future taint preemptively.

For more details see: http://git.k8s.io/enhancements/keps/sig-cluster-lifecycle/kubeadm/2067-rename-master-label-taint/README.md
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: http://git.k8s.io/enhancements/keps/sig-cluster-lifecycle/kubeadm/2067-rename-master-label-taint/README.md
```
