### PR TITLE
Update the example for kubectl port-forward

### DIFF
--- a/staging/src/k8s.io/kubectl/docs/book/pages/container_debugging/port_forward_to_pods.md
+++ b/staging/src/k8s.io/kubectl/docs/book/pages/container_debugging/port_forward_to_pods.md
@@ -42,6 +42,20 @@ kubectl port-forward deployment/mydeployment 5000 6000
 ---
 
 {% method %}
+## Pod in a Service
+
+Listen on port 8443 locally, forwarding to the targetPort of the service's port named "https" in a pod selected by the service
+{% sample lang="yaml" %}
+
+```bash
+kubectl port-forward service/myservice 8443:https
+```
+
+{% endmethod %}
+
+---
+
+{% method %}
 ## Different Local and Remote Ports
 
 Listen on port 8888 locally, forwarding to 5000 in the pod

--- a/staging/src/k8s.io/kubectl/pkg/cmd/portforward/portforward.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/portforward/portforward.go
@@ -76,8 +76,8 @@ var (
 		# Listen on ports 5000 and 6000 locally, forwarding data to/from ports 5000 and 6000 in a pod selected by the deployment
 		kubectl port-forward deployment/mydeployment 5000 6000
 
-		# Listen on ports 5000 and 6000 locally, forwarding data to/from ports 5000 and 6000 in a pod selected by the service
-		kubectl port-forward service/myservice 5000 6000
+		# Listen on port 8443 locally, forwarding to the targetPort of the service's port named "https" in a pod selected by the service
+		kubectl port-forward service/myservice 8443:https
 
 		# Listen on port 8888 locally, forwarding to 5000 in the pod
 		kubectl port-forward pod/mypod 8888:5000


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation
/sig cli

**What this PR does / why we need it**:

Clarifies that `REMOTE_PORT` is interpreted as identifying a _Service_ port when provided `TYPE` is `service`.
Also, highlights support for specifying a named port as `REMOTE_PORT`.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

Support for resolving a service port to it's targetPort was added in https://github.com/kubernetes/kubernetes/pull/59809.
Support for specifying a named port for `REMOTE_PORT` was added in https://github.com/kubernetes/kubernetes/pull/69477.
See https://github.com/kubernetes/kubectl/issues/947 for the related issue.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```