### PR TITLE
Remove deprecated metrics in controller/volume

### DIFF
--- a/pkg/controller/volume/scheduling/metrics/metrics.go
+++ b/pkg/controller/volume/scheduling/metrics/metrics.go
@@ -35,18 +35,6 @@ var (
 		},
 		[]string{"operation"},
 	)
-	// VolumeSchedulingStageLatency tracks the latency of volume scheduling operations.
-	VolumeSchedulingStageLatency = metrics.NewHistogramVec(
-		&metrics.HistogramOpts{
-			Subsystem:         VolumeSchedulerSubsystem,
-			Name:              "scheduling_duration_seconds",
-			Help:              "Volume scheduling stage latency (Deprecated since 1.19.0)",
-			Buckets:           metrics.ExponentialBuckets(1000, 2, 15),
-			StabilityLevel:    metrics.ALPHA,
-			DeprecatedVersion: "1.19.0",
-		},
-		[]string{"operation"},
-	)
 	// VolumeSchedulingStageFailed tracks the number of failed volume scheduling operations.
 	VolumeSchedulingStageFailed = metrics.NewCounterVec(
 		&metrics.CounterOpts{
@@ -63,6 +51,5 @@ var (
 // used by scheduler process.
 func RegisterVolumeSchedulingMetrics() {
 	legacyregistry.MustRegister(VolumeBindingRequestSchedulerBinderCache)
-	legacyregistry.MustRegister(VolumeSchedulingStageLatency)
 	legacyregistry.MustRegister(VolumeSchedulingStageFailed)
 }

--- a/pkg/controller/volume/scheduling/scheduler_binder.go
+++ b/pkg/controller/volume/scheduling/scheduler_binder.go
@@ -261,9 +261,7 @@ func (b *volumeBinder) FindPodVolumes(pod *v1.Pod, boundClaims, claimsToBind []*
 		}
 	}()
 
-	start := time.Now()
 	defer func() {
-		metrics.VolumeSchedulingStageLatency.WithLabelValues("predicate").Observe(time.Since(start).Seconds())
 		if err != nil {
 			metrics.VolumeSchedulingStageFailed.WithLabelValues("predicate").Inc()
 		}
@@ -347,9 +345,7 @@ func (b *volumeBinder) AssumePodVolumes(assumedPod *v1.Pod, nodeName string, pod
 	podName := getPodName(assumedPod)
 
 	klog.V(4).Infof("AssumePodVolumes for pod %q, node %q", podName, nodeName)
-	start := time.Now()
 	defer func() {
-		metrics.VolumeSchedulingStageLatency.WithLabelValues("assume").Observe(time.Since(start).Seconds())
 		if err != nil {
 			metrics.VolumeSchedulingStageFailed.WithLabelValues("assume").Inc()
 		}
@@ -421,9 +417,7 @@ func (b *volumeBinder) BindPodVolumes(assumedPod *v1.Pod, podVolumes *PodVolumes
 	podName := getPodName(assumedPod)
 	klog.V(4).Infof("BindPodVolumes for pod %q, node %q", podName, assumedPod.Spec.NodeName)
 
-	start := time.Now()
 	defer func() {
-		metrics.VolumeSchedulingStageLatency.WithLabelValues("bind").Observe(time.Since(start).Seconds())
 		if err != nil {
 			metrics.VolumeSchedulingStageFailed.WithLabelValues("bind").Inc()
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind feature
/sig scheduling
/kind deprecation
/sig instrumentation

**What this PR does / why we need it**:

This PR removes deprecated metrics in controller/volume/scheduling .
This metrics is ALPHA and deprecated since 1.19.0 so we can remove it now.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
Removes deprecated metrics `scheduling_duration_seconds`
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

Does this PR also needs fix CHANGELOG ?
