### PR TITLE
Enable Logging of event requests to audit log in cluster/gce/gci/configure-helper.sh

### DIFF
--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -1175,7 +1175,7 @@ rules:
       - /version
       - /swagger*
 
-  # Don't log events requests.
+  # Don't log events requests because of performance impact.
   - level: None
     resources:
       - group: "" # core


### PR DESCRIPTION
Enabling Event requests for GCE/GCI clusters would allow detection (within the audit logs) of event api usage.
In initial checks this didn't seem to increase the log size by very much, but gave more comprehensive audit coverage.

A longer writeup is available: https://github.com/cncf/apisnoop/blob/cbc02f014869f9fc1a87585a63ef9fb1f165ee58/org/explorations/missing_events.md#gcegci-audit-policy