### PR TITLE
test-integration: Fix using deprecated default cluster IPs

### DIFF
--- a/test/integration/framework/master_utils.go
+++ b/test/integration/framework/master_utils.go
@@ -204,6 +204,9 @@ func startMasterOrDie(masterConfig *controlplane.Config, incomingServer *httptes
 		)
 	}
 
+	if masterConfig.ExtraConfig.ServiceIPRange.IP == nil {
+		masterConfig.ExtraConfig.ServiceIPRange = net.IPNet{IP: net.ParseIP("10.0.0.0"), Mask: net.CIDRMask(24, 32)}
+	}
 	m, err = masterConfig.Complete().New(genericapiserver.NewEmptyDelegate())
 	if err != nil {
 		// We log the error first so that even if closeFn crashes, the error is shown


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
/kind deprecation

**What this PR does / why we need it**:
The integration test for pods produces a warning caused by using deprecated default cluster IPs.

```
$ make test-integration WHAT=./test/integration/pods GOFLAGS="-v"
W1007 17:25:28.217410  100721 services.go:37] No CIDR for service cluster IPs specified. Default value which was 10.0.0.0/24 is deprecated and will be removed in future releases. Please specify it using --service-cluster-ip-range on kube-apiserver.
```

This warning appears 36 times after running all tests. This patch removes all the warnings.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
NONE

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs
NONE
```
