### PR TITLE
always collect containerd logs during e2e-node tests

### DIFF
--- a/test/e2e_node/services/logs.go
+++ b/test/e2e_node/services/logs.go
@@ -79,6 +79,11 @@ var requiredLogs = []LogFileData{
 		Files:             []string{"/var/log/docker.log", "/var/log/upstart/docker.log"},
 		JournalctlCommand: []string{"-u", "docker"},
 	},
+	{
+		Name:              "containerd.log",
+		Files:             []string{"/var/log/containerd.log"},
+		JournalctlCommand: []string{"-u", "containerd"},
+	},
 }
 
 // getLogFiles get all logs to collect after the test.


### PR DESCRIPTION
containerd is almost always running, even below docker

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:
Instead of configuring all of the tests that use containerd to collect the containerd logs, it looks better to collect the containerd logs by default, as it is almost always running.

**Which issue(s) this PR fixes**:
Helping to debug tests.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:


/cc @mikebrow 
/assign @dims 