### PR TITLE
Automated cherry pick of #95363 upstream release 1.19 

### DIFF
--- a/pkg/proxy/endpoints_test.go
+++ b/pkg/proxy/endpoints_test.go
@@ -1413,6 +1413,14 @@ func TestLastChangeTriggerTime(t *testing.T) {
 			},
 			expected: map[types.NamespacedName][]time.Time{createName("ns", "ep1"): {t2}},
 		},
+		{
+			name: "delete",
+			scenario: func(fp *FakeProxier) {
+				e := createEndpoints("ns", "ep1", t1)
+				fp.deleteEndpoints(e)
+			},
+			expected: map[types.NamespacedName][]time.Time{},
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
Cherry pick of #95363 on release-1.19
#95363 : Fix reporting network_programming_latency metrics in kube-proxy

/sig network
/sig scalability
/priority important-soon
/kind bug