### PR TITLE
kubeadm: add some output to the generate-csr command

### DIFF
--- a/cmd/kubeadm/app/cmd/alpha/certs.go
+++ b/cmd/kubeadm/app/cmd/alpha/certs.go
@@ -101,7 +101,7 @@ func NewCmdCertsUtility(out io.Writer) *cobra.Command {
 	cmd.AddCommand(newCmdCertsRenewal(out))
 	cmd.AddCommand(newCmdCertsExpiration(out, constants.KubernetesDir))
 	cmd.AddCommand(newCmdCertificateKey())
-	cmd.AddCommand(newCmdGenCSR())
+	cmd.AddCommand(newCmdGenCSR(out))
 	return cmd
 }
 
@@ -147,7 +147,7 @@ func (o *genCSRConfig) load() (err error) {
 }
 
 // newCmdGenCSR returns cobra.Command for generating keys and CSRs
-func newCmdGenCSR() *cobra.Command {
+func newCmdGenCSR(out io.Writer) *cobra.Command {
 	config := newGenCSRConfig()
 
 	cmd := &cobra.Command{
@@ -160,7 +160,7 @@ func newCmdGenCSR() *cobra.Command {
 			if err := config.load(); err != nil {
 				return err
 			}
-			return runGenCSR(config)
+			return runGenCSR(out, config)
 		},
 	}
 	config.addFlagSet(cmd.Flags())
@@ -168,11 +168,11 @@ func newCmdGenCSR() *cobra.Command {
 }
 
 // runGenCSR contains the logic of the generate-csr sub-command.
-func runGenCSR(config *genCSRConfig) error {
-	if err := certsphase.CreateDefaultKeysAndCSRFiles(config.kubeadmConfig); err != nil {
+func runGenCSR(out io.Writer, config *genCSRConfig) error {
+	if err := certsphase.CreateDefaultKeysAndCSRFiles(out, config.kubeadmConfig); err != nil {
 		return err
 	}
-	if err := kubeconfigphase.CreateDefaultKubeConfigsAndCSRFiles(config.kubeConfigDir, config.kubeadmConfig); err != nil {
+	if err := kubeconfigphase.CreateDefaultKubeConfigsAndCSRFiles(out, config.kubeConfigDir, config.kubeadmConfig); err != nil {
 		return err
 	}
 	return nil

--- a/cmd/kubeadm/app/cmd/alpha/certs_test.go
+++ b/cmd/kubeadm/app/cmd/alpha/certs_test.go
@@ -334,7 +334,7 @@ func TestRunGenCSR(t *testing.T) {
 		},
 	}
 
-	err := runGenCSR(&config)
+	err := runGenCSR(nil, &config)
 	require.NoError(t, err, "expected runGenCSR to not fail")
 
 	t.Log("The command generates key and CSR files in the configured --cert-dir")

--- a/cmd/kubeadm/app/phases/certs/certlist.go
+++ b/cmd/kubeadm/app/phases/certs/certlist.go
@@ -19,6 +19,8 @@ package certs
 import (
 	"crypto"
 	"crypto/x509"
+	"fmt"
+	"io"
 
 	"github.com/pkg/errors"
 
@@ -477,14 +479,20 @@ func createKeyAndCSR(kubeadmConfig *kubeadmapi.InitConfiguration, cert *KubeadmC
 
 // CreateDefaultKeysAndCSRFiles is used in ExternalCA mode to create key files
 // and adjacent CSR files.
-func CreateDefaultKeysAndCSRFiles(config *kubeadmapi.InitConfiguration) error {
+func CreateDefaultKeysAndCSRFiles(out io.Writer, config *kubeadmapi.InitConfiguration) error {
 	certificates, err := leafCertificates(GetDefaultCertList())
 	if err != nil {
 		return err
 	}
+	if out != nil {
+		fmt.Fprintf(out, "generating keys and CSRs in %s\n", config.CertificatesDir)
+	}
 	for _, cert := range certificates {
 		if err := createKeyAndCSR(config, cert); err != nil {
 			return err
+		}
+		if out != nil {
+			fmt.Fprintf(out, "  %s\n", cert.BaseName)
 		}
 	}
 	return nil

--- a/cmd/kubeadm/app/phases/kubeconfig/kubeconfig.go
+++ b/cmd/kubeadm/app/phases/kubeconfig/kubeconfig.go
@@ -508,14 +508,20 @@ func createKubeConfigAndCSR(kubeConfigDir string, kubeadmConfig *kubeadmapi.Init
 
 // CreateDefaultKubeConfigsAndCSRFiles is used in ExternalCA mode to create
 // kubeconfig files and adjacent CSR files.
-func CreateDefaultKubeConfigsAndCSRFiles(kubeConfigDir string, kubeadmConfig *kubeadmapi.InitConfiguration) error {
+func CreateDefaultKubeConfigsAndCSRFiles(out io.Writer, kubeConfigDir string, kubeadmConfig *kubeadmapi.InitConfiguration) error {
 	kubeConfigs, err := getKubeConfigSpecsBase(kubeadmConfig)
 	if err != nil {
 		return err
 	}
+	if out != nil {
+		fmt.Fprintf(out, "generating keys and CSRs in %s\n", kubeConfigDir)
+	}
 	for name, spec := range kubeConfigs {
 		if err := createKubeConfigAndCSR(kubeConfigDir, kubeadmConfig, name, spec); err != nil {
 			return err
+		}
+		if out != nil {
+			fmt.Fprintf(out, "  %s\n", name)
 		}
 	}
 	return nil


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently the "generate-csr" command does not have any output.
Pass an io.Writer (bound to os.Stdout from /cmd) to the functions
responsible for generating the kubeconfig / certs keys and CSRs.

If nil is passed these functions don't output anything.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
NONE

**Special notes for your reviewer**:
NONE

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
