### PR TITLE
add response status metrics on kubelet server

### DIFF
--- a/pkg/kubelet/server/metrics/metrics.go
+++ b/pkg/kubelet/server/metrics/metrics.go
@@ -40,7 +40,7 @@ var (
 		// server_type aims to differentiate the readonly server and the readwrite server.
 		// long_running marks whether the request is long-running or not.
 		// Currently, long-running requests include exec/attach/portforward/debug.
-		[]string{"method", "path", "server_type", "long_running"},
+		[]string{"method", "path", "server_type", "long_running", "code"},
 	)
 	// HTTPRequestsDuration tracks the duration in seconds to serve http requests.
 	HTTPRequestsDuration = metrics.NewHistogramVec(
@@ -52,7 +52,7 @@ var (
 			Buckets:        metrics.DefBuckets,
 			StabilityLevel: metrics.ALPHA,
 		},
-		[]string{"method", "path", "server_type", "long_running"},
+		[]string{"method", "path", "server_type", "long_running", "code"},
 	)
 	// HTTPInflightRequests tracks the number of the inflight http requests.
 	HTTPInflightRequests = metrics.NewGaugeVec(


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:
see  https://github.com/kubernetes/kubernetes/issues/95307

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubernetes/issues/95307

**Special notes for your reviewer**:

@tallclair @ehashman

**Does this PR introduce a user-facing change?**:
```release-note
Add Kubelet server metrics for response status 
```


