### PR TITLE
[1.17 cherrypick] Check Annotations map against nil for ConfigMapLock#Update()

### DIFF
--- a/staging/src/k8s.io/client-go/tools/leaderelection/resourcelock/configmaplock.go
+++ b/staging/src/k8s.io/client-go/tools/leaderelection/resourcelock/configmaplock.go
@@ -87,6 +87,9 @@ func (cml *ConfigMapLock) Update(ler LeaderElectionRecord) error {
 	if err != nil {
 		return err
 	}
+	if cml.cm.Annotations == nil {
+		cml.cm.Annotations = make(map[string]string)
+	}
 	cml.cm.Annotations[LeaderElectionRecordAnnotationKey] = string(recordBytes)
 	cml.cm, err = cml.Client.ConfigMaps(cml.ConfigMapMeta.Namespace).Update(cml.cm)
 	return err


### PR DESCRIPTION
Cherry-picking #87821 (already in 1.18 via #89909).

**What type of PR is this?**

/kind bug

**What this PR does / why we need it:**

**Which issue(s) this PR fixes:**

Fixes #87800
Reported against 1.17 clients in [rhbz#1886600](https://bugzilla.redhat.com/show_bug.cgi?id=1886600).

**Does this PR introduce a user-facing change?:**

No

```release-note
NONE
```