### PR TITLE
Fix number of retries for Job with restartPolicy OnFailure

### DIFF
--- a/pkg/controller/job/job_controller.go
+++ b/pkg/controller/job/job_controller.go
@@ -645,10 +645,7 @@ func pastBackoffLimitOnFailure(job *batch.Job, pods []*v1.Pod) bool {
 			}
 		}
 	}
-	if *job.Spec.BackoffLimit == 0 {
-		return result > 0
-	}
-	return result >= *job.Spec.BackoffLimit
+	return result > *job.Spec.BackoffLimit
 }
 
 // pastActiveDeadline checks if job has ActiveDeadlineSeconds field set and if it is exceeded.

--- a/pkg/controller/job/job_controller_test.go
+++ b/pkg/controller/job/job_controller_test.go
@@ -1428,43 +1428,43 @@ func TestJobBackoffForOnFailure(t *testing.T) {
 			true, []int32{0}, v1.PodRunning,
 			1, 0, 0, nil, "",
 		},
-		"backoffLimit 1 with restartCount 0 should have 1 pod active": {
-			1, 1, 1,
-			true, []int32{0}, v1.PodRunning,
-			1, 0, 0, nil, "",
-		},
-		"backoffLimit 1 with restartCount 1 and podRunning should have 0 pod active": {
+		"backoffLimit 1 with restartCount 1 should have 1 pod active": {
 			1, 1, 1,
 			true, []int32{1}, v1.PodRunning,
+			1, 0, 0, nil, "",
+		},
+		"backoffLimit 1 with restartCount 2 and podRunning should have 0 pod active": {
+			1, 1, 1,
+			true, []int32{2}, v1.PodRunning,
 			0, 0, 1, &jobConditionFailed, "BackoffLimitExceeded",
 		},
-		"backoffLimit 1 with restartCount 1 and podPending should have 0 pod active": {
+		"backoffLimit 1 with restartCount 2 and podPending should have 0 pod active": {
 			1, 1, 1,
-			true, []int32{1}, v1.PodPending,
+			true, []int32{2}, v1.PodPending,
 			0, 0, 1, &jobConditionFailed, "BackoffLimitExceeded",
 		},
 		"too many job failures with podRunning - single pod": {
 			1, 5, 2,
-			true, []int32{2}, v1.PodRunning,
+			true, []int32{3}, v1.PodRunning,
 			0, 0, 1, &jobConditionFailed, "BackoffLimitExceeded",
 		},
 		"too many job failures with podPending - single pod": {
 			1, 5, 2,
-			true, []int32{2}, v1.PodPending,
+			true, []int32{3}, v1.PodPending,
 			0, 0, 1, &jobConditionFailed, "BackoffLimitExceeded",
 		},
 		"too many job failures with podRunning - multiple pods": {
-			2, 5, 2,
+			2, 5, 1,
 			true, []int32{1, 1}, v1.PodRunning,
 			0, 0, 2, &jobConditionFailed, "BackoffLimitExceeded",
 		},
 		"too many job failures with podPending - multiple pods": {
-			2, 5, 2,
+			2, 5, 1,
 			true, []int32{1, 1}, v1.PodPending,
 			0, 0, 2, &jobConditionFailed, "BackoffLimitExceeded",
 		},
 		"not enough failures": {
-			2, 5, 3,
+			2, 5, 2,
 			true, []int32{1, 1}, v1.PodRunning,
 			2, 0, 0, nil, "",
 		},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:
When running a Job with `restartPolicy=OnFailure` and `backoffLimit > 0` the number of retry attempts until considering the job as Failed is currently `backoffLimit-1`.
According to docs the value of `backoffLimit` specifies the number of retries before considering a Job as failed.
This PR sets the max number of retires to equal to `backoffLimit` for `restartPolicy=OnFailure`.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #95433

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**: 
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
NONE
For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
/sig apps
