### PR TITLE
WIP: kubelet: use the calculated grace period for the kill pod options

### DIFF
--- a/pkg/kubelet/BUILD
+++ b/pkg/kubelet/BUILD
@@ -154,6 +154,7 @@ go_library(
         "//vendor/k8s.io/utils/exec:go_default_library",
         "//vendor/k8s.io/utils/integer:go_default_library",
         "//vendor/k8s.io/utils/path:go_default_library",
+        "//vendor/k8s.io/utils/pointer:go_default_library",
         "//vendor/k8s.io/utils/strings:go_default_library",
     ] + select({
         "@io_bazel_rules_go//go/platform:android": [
@@ -268,6 +269,7 @@ go_test(
         "//vendor/github.com/google/cadvisor/info/v2:go_default_library",
         "//vendor/github.com/stretchr/testify/assert:go_default_library",
         "//vendor/github.com/stretchr/testify/require:go_default_library",
+        "//vendor/k8s.io/utils/pointer:go_default_library",
     ],
 )
 

--- a/pkg/kubelet/pod_workers.go
+++ b/pkg/kubelet/pod_workers.go
@@ -22,7 +22,7 @@ import (
 	"sync"
 	"time"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -35,6 +35,7 @@ import (
 	kubetypes "k8s.io/kubernetes/pkg/kubelet/types"
 	"k8s.io/kubernetes/pkg/kubelet/util/format"
 	"k8s.io/kubernetes/pkg/kubelet/util/queue"
+	utilptr "k8s.io/utils/pointer"
 )
 
 // OnCompleteFunc is a function that is invoked when an operation completes.
@@ -323,7 +324,7 @@ func killPodNow(podWorkers PodWorkers, recorder record.EventRecorder) eviction.K
 				PodStatusFunc: func(p *v1.Pod, podStatus *kubecontainer.PodStatus) v1.PodStatus {
 					return status
 				},
-				PodTerminationGracePeriodSecondsOverride: gracePeriodOverride,
+				PodTerminationGracePeriodSecondsOverride: utilptr.Int64Ptr(gracePeriod),
 			},
 		})
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
The gracePeriod is calculated within killPodNow, but not used within KillPodOptions. Instead, defaultPeriodOverride (which is usually nil) is passed down, effectively ignoring the Pod's TerminationGracePeriodSeconds. This fix passes down the correct termination grace period.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
Eviction and critical pods now correctly honor the TerminationGracePeriodSeconds when the Kubelet kills them.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs

```
