### PR TITLE
Map SelectorSpreadPriority to PodTopologySpread plugin 

### DIFF
--- a/pkg/scheduler/framework/plugins/BUILD
+++ b/pkg/scheduler/framework/plugins/BUILD
@@ -9,6 +9,7 @@ go_library(
     importpath = "k8s.io/kubernetes/pkg/scheduler/framework/plugins",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/features:go_default_library",
         "//pkg/scheduler/apis/config:go_default_library",
         "//pkg/scheduler/framework/plugins/defaultbinder:go_default_library",
         "//pkg/scheduler/framework/plugins/defaultpreemption:go_default_library",
@@ -32,6 +33,7 @@ go_library(
         "//pkg/scheduler/framework/plugins/volumezone:go_default_library",
         "//pkg/scheduler/framework/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
+        "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",
         "//vendor/k8s.io/klog/v2:go_default_library",
     ],
 )
@@ -79,10 +81,21 @@ go_test(
     srcs = ["legacy_registry_test.go"],
     embed = [":go_default_library"],
     deps = [
+        "//pkg/features:go_default_library",
         "//pkg/scheduler/apis/config:go_default_library",
+        "//pkg/scheduler/framework/plugins/imagelocality:go_default_library",
+        "//pkg/scheduler/framework/plugins/interpodaffinity:go_default_library",
+        "//pkg/scheduler/framework/plugins/nodeaffinity:go_default_library",
+        "//pkg/scheduler/framework/plugins/nodepreferavoidpods:go_default_library",
+        "//pkg/scheduler/framework/plugins/noderesources:go_default_library",
         "//pkg/scheduler/framework/plugins/nodeunschedulable:go_default_library",
+        "//pkg/scheduler/framework/plugins/podtopologyspread:go_default_library",
+        "//pkg/scheduler/framework/plugins/selectorspread:go_default_library",
         "//pkg/scheduler/framework/plugins/tainttoleration:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
+        "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",
+        "//staging/src/k8s.io/component-base/featuregate:go_default_library",
+        "//staging/src/k8s.io/component-base/featuregate/testing:go_default_library",
         "//vendor/github.com/google/go-cmp/cmp:go_default_library",
     ],
 )


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Map SelectorSpreadPriority to PodTopologySpread plugin when DefaultPodTopologySpread feature is enabled

If SelectorSpreadPriority is in use, PodTopologySpread gets inevitably enabled.
When only EvenPodsSpreadPriority is in use, PodTopologySpread is configured without system defaults.

**Which issue(s) this PR fixes**:

Part of #94863

kubernetes/enhancements#1258

**Special notes for your reviewer**:

Builds on top of #95048

```release-note
SelectorSpreadPriority maps to PodTopologySpread plugin when DefaultPodTopologySpread feature is enabled
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:


```docs
- [KEP]: https://git.k8s.io/enhancements/keps/sig-scheduling/1258-default-pod-topology-spread
```
