### PR TITLE
Automated cherry pick of #95342: cloud node controller: handle empty providerID from

### DIFF
--- a/staging/src/k8s.io/cloud-provider/controllers/node/node_controller_test.go
+++ b/staging/src/k8s.io/cloud-provider/controllers/node/node_controller_test.go
@@ -764,6 +764,7 @@ func Test_AddCloudNode(t *testing.T) {
 							Effect: v1.TaintEffectNoSchedule,
 						},
 					},
+					ProviderID: "fake://12345",
 				},
 			},
 			updatedNode: &v1.Node{
@@ -924,9 +925,6 @@ func Test_AddCloudNode(t *testing.T) {
 						},
 					},
 				},
-				Spec: v1.NodeSpec{
-					ProviderID: "aws://12345",
-				},
 			},
 		},
 		{
@@ -973,6 +971,7 @@ func Test_AddCloudNode(t *testing.T) {
 							Effect: v1.TaintEffectNoSchedule,
 						},
 					},
+					ProviderID: "fake://12345",
 				},
 				Status: v1.NodeStatus{
 					Conditions: []v1.NodeCondition{


### PR DESCRIPTION
Cherry pick of #95342 on release-1.19.

#95342: cloud node controller: handle empty providerID from getProviderID
```release-note
cloud node controller: handle empty providerID from getProviderID
```

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.