### PR TITLE
test-integration: Fix using not allowed AnonymousAuth

### DIFF
--- a/test/integration/apiserver/admissionwebhook/admission_test.go
+++ b/test/integration/apiserver/admissionwebhook/admission_test.go
@@ -480,6 +480,8 @@ func testWebhookAdmission(t *testing.T, watchCache bool) {
 		"--disable-admission-plugins=ServiceAccount,StorageObjectInUseProtection",
 		// force enable all resources so we can check storage.
 		"--runtime-config=api/all=true",
+		// disable AnonymousAuth
+		"--anonymous-auth=false",
 		// enable feature-gates that protect resources to check their storage, too.
 		"--feature-gates=EphemeralContainers=true",
 	}, etcdConfig)

--- a/test/integration/apiserver/admissionwebhook/broken_webhook_test.go
+++ b/test/integration/apiserver/admissionwebhook/broken_webhook_test.go
@@ -45,7 +45,9 @@ func TestBrokenWebhook(t *testing.T) {
 	}()
 
 	etcdConfig := framework.SharedEtcd()
-	server := kubeapiservertesting.StartTestServerOrDie(t, nil, nil, etcdConfig)
+	server := kubeapiservertesting.StartTestServerOrDie(t, nil, []string{
+		"--anonymous-auth=false",
+	}, etcdConfig)
 	tearDownFn = server.TearDownFn
 
 	client, err := kubernetes.NewForConfig(server.ClientConfig)
@@ -80,7 +82,9 @@ func TestBrokenWebhook(t *testing.T) {
 	t.Logf("Restarting apiserver")
 	tearDownFn = nil
 	server.TearDownFn()
-	server = kubeapiservertesting.StartTestServerOrDie(t, nil, nil, etcdConfig)
+	server = kubeapiservertesting.StartTestServerOrDie(t, nil, []string{
+		"--anonymous-auth=false",
+	}, etcdConfig)
 	tearDownFn = server.TearDownFn
 
 	client, err = kubernetes.NewForConfig(server.ClientConfig)

--- a/test/integration/apiserver/admissionwebhook/client_auth_test.go
+++ b/test/integration/apiserver/admissionwebhook/client_auth_test.go
@@ -138,6 +138,7 @@ plugins:
 		"--disable-admission-plugins=ServiceAccount",
 		fmt.Sprintf("--enable-aggregator-routing=%v", enableAggregatorRouting),
 		"--admission-control-config-file=" + admissionConfigFile.Name(),
+		"--anonymous-auth=false",
 	}, framework.SharedEtcd())
 	defer s.TearDownFn()
 

--- a/test/integration/apiserver/admissionwebhook/load_balance_test.go
+++ b/test/integration/apiserver/admissionwebhook/load_balance_test.go
@@ -85,6 +85,7 @@ func TestWebhookLoadBalance(t *testing.T) {
 
 	s := kubeapiservertesting.StartTestServerOrDie(t, kubeapiservertesting.NewDefaultTestServerOptions(), []string{
 		"--disable-admission-plugins=ServiceAccount",
+		"--anonymous-auth=false",
 	}, framework.SharedEtcd())
 	defer s.TearDownFn()
 

--- a/test/integration/apiserver/admissionwebhook/reinvocation_test.go
+++ b/test/integration/apiserver/admissionwebhook/reinvocation_test.go
@@ -292,6 +292,7 @@ func testWebhookReinvocationPolicy(t *testing.T, watchCache bool) {
 		"--audit-log-version", "audit.k8s.io/v1",
 		"--audit-log-mode", "blocking",
 		"--audit-log-path", logFile.Name(),
+		"--anonymous-auth=false",
 	}, framework.SharedEtcd())
 	defer s.TearDownFn()
 

--- a/test/integration/apiserver/admissionwebhook/timeout_test.go
+++ b/test/integration/apiserver/admissionwebhook/timeout_test.go
@@ -160,6 +160,7 @@ func testWebhookTimeout(t *testing.T, watchCache bool) {
 	s := kubeapiservertesting.StartTestServerOrDie(t, kubeapiservertesting.NewDefaultTestServerOptions(), []string{
 		"--disable-admission-plugins=ServiceAccount",
 		fmt.Sprintf("--watch-cache=%v", watchCache),
+		"--anonymous-auth=false",
 	}, framework.SharedEtcd())
 	defer s.TearDownFn()
 

--- a/test/integration/apiserver/apply/apply_crd_test.go
+++ b/test/integration/apiserver/apply/apply_crd_test.go
@@ -43,7 +43,9 @@ import (
 func TestApplyCRDNoSchema(t *testing.T) {
 	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, genericfeatures.ServerSideApply, true)()
 
-	server, err := apiservertesting.StartTestServer(t, apiservertesting.NewDefaultTestServerOptions(), nil, framework.SharedEtcd())
+	server, err := apiservertesting.StartTestServer(t, apiservertesting.NewDefaultTestServerOptions(), []string{
+		"--anonymous-auth=false",
+	}, framework.SharedEtcd())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -200,7 +202,9 @@ spec:
 func TestApplyCRDStructuralSchema(t *testing.T) {
 	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, genericfeatures.ServerSideApply, true)()
 
-	server, err := apiservertesting.StartTestServer(t, apiservertesting.NewDefaultTestServerOptions(), nil, framework.SharedEtcd())
+	server, err := apiservertesting.StartTestServer(t, apiservertesting.NewDefaultTestServerOptions(), []string{
+		"--anonymous-auth=false",
+	}, framework.SharedEtcd())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -474,7 +478,9 @@ spec:
 func TestApplyCRDNonStructuralSchema(t *testing.T) {
 	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, genericfeatures.ServerSideApply, true)()
 
-	server, err := apiservertesting.StartTestServer(t, apiservertesting.NewDefaultTestServerOptions(), nil, framework.SharedEtcd())
+	server, err := apiservertesting.StartTestServer(t, apiservertesting.NewDefaultTestServerOptions(), []string{
+		"--anonymous-auth=false",
+	}, framework.SharedEtcd())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -712,7 +718,9 @@ func verifyNumPorts(t *testing.T, b []byte, n int) {
 func TestApplyCRDUnhandledSchema(t *testing.T) {
 	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, genericfeatures.ServerSideApply, true)()
 
-	server, err := apiservertesting.StartTestServer(t, apiservertesting.NewDefaultTestServerOptions(), nil, framework.SharedEtcd())
+	server, err := apiservertesting.StartTestServer(t, apiservertesting.NewDefaultTestServerOptions(), []string{
+		"--anonymous-auth=false",
+	}, framework.SharedEtcd())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/integration/apiserver/apply/status_test.go
+++ b/test/integration/apiserver/apply/status_test.go
@@ -107,7 +107,10 @@ func createMapping(groupVersion string, resource metav1.APIResource) (*meta.REST
 // TestApplyStatus makes sure that applying the status works for all known types.
 func TestApplyStatus(t *testing.T) {
 	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, genericfeatures.ServerSideApply, true)()
-	server, err := apiservertesting.StartTestServer(t, apiservertesting.NewDefaultTestServerOptions(), []string{"--disable-admission-plugins", "ServiceAccount,TaintNodesByCondition"}, framework.SharedEtcd())
+	server, err := apiservertesting.StartTestServer(t, apiservertesting.NewDefaultTestServerOptions(), []string{
+		"--disable-admission-plugins", "ServiceAccount,TaintNodesByCondition",
+		"--anonymous-auth=false",
+	}, framework.SharedEtcd())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/integration/certificates/admission_subjectrestriction_test.go
+++ b/test/integration/certificates/admission_subjectrestriction_test.go
@@ -52,7 +52,9 @@ func TestCertificateSubjectRestrictionPlugin(t *testing.T) {
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			// Run an apiserver with the default configuration options.
-			s := kubeapiservertesting.StartTestServerOrDie(t, kubeapiservertesting.NewDefaultTestServerOptions(), []string{""}, framework.SharedEtcd())
+			s := kubeapiservertesting.StartTestServerOrDie(t, kubeapiservertesting.NewDefaultTestServerOptions(), []string{
+				"--anonymous-auth=false",
+			}, framework.SharedEtcd())
 			defer s.TearDownFn()
 			client := clientset.NewForConfigOrDie(s.ClientConfig)
 

--- a/test/integration/certificates/controller_approval_test.go
+++ b/test/integration/certificates/controller_approval_test.go
@@ -95,7 +95,9 @@ func TestController_AutoApproval(t *testing.T) {
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			// Run an apiserver with the default configuration options.
-			s := kubeapiservertesting.StartTestServerOrDie(t, kubeapiservertesting.NewDefaultTestServerOptions(), []string{""}, framework.SharedEtcd())
+			s := kubeapiservertesting.StartTestServerOrDie(t, kubeapiservertesting.NewDefaultTestServerOptions(), []string{
+				"--anonymous-auth=false",
+			}, framework.SharedEtcd())
 			defer s.TearDownFn()
 			client := clientset.NewForConfigOrDie(s.ClientConfig)
 			informers := informers.NewSharedInformerFactory(clientset.NewForConfigOrDie(restclient.AddUserAgent(s.ClientConfig, "certificatesigningrequest-informers")), time.Second)

--- a/test/integration/client/cert_rotation_test.go
+++ b/test/integration/client/cert_rotation_test.go
@@ -65,6 +65,7 @@ func TestCertRotation(t *testing.T) {
 
 	server := apiservertesting.StartTestServerOrDie(t, apiservertesting.NewDefaultTestServerOptions(), []string{
 		"--client-ca-file=" + clientCAFilename,
+		"--anonymous-auth=false",
 	}, framework.SharedEtcd())
 	defer server.TearDownFn()
 
@@ -135,6 +136,7 @@ func TestCertRotationContinuousRequests(t *testing.T) {
 
 	server := apiservertesting.StartTestServerOrDie(t, apiservertesting.NewDefaultTestServerOptions(), []string{
 		"--client-ca-file=" + clientCAFilename,
+		"--anonymous-auth=false",
 	}, framework.SharedEtcd())
 	defer server.TearDownFn()
 

--- a/test/integration/client/client_test.go
+++ b/test/integration/client/client_test.go
@@ -49,7 +49,10 @@ import (
 )
 
 func TestClient(t *testing.T) {
-	result := kubeapiservertesting.StartTestServerOrDie(t, nil, []string{"--disable-admission-plugins", "ServiceAccount"}, framework.SharedEtcd())
+	result := kubeapiservertesting.StartTestServerOrDie(t, nil, []string{
+		"--disable-admission-plugins", "ServiceAccount",
+		"--anonymous-auth=false",
+	}, framework.SharedEtcd())
 	defer result.TearDownFn()
 
 	client := clientset.NewForConfigOrDie(result.ClientConfig)
@@ -118,7 +121,10 @@ func TestClient(t *testing.T) {
 }
 
 func TestAtomicPut(t *testing.T) {
-	result := kubeapiservertesting.StartTestServerOrDie(t, nil, []string{"--disable-admission-plugins", "ServiceAccount"}, framework.SharedEtcd())
+	result := kubeapiservertesting.StartTestServerOrDie(t, nil, []string{
+		"--disable-admission-plugins", "ServiceAccount",
+		"--anonymous-auth=false",
+	}, framework.SharedEtcd())
 	defer result.TearDownFn()
 
 	c := clientset.NewForConfigOrDie(result.ClientConfig)
@@ -207,7 +213,10 @@ func TestAtomicPut(t *testing.T) {
 }
 
 func TestPatch(t *testing.T) {
-	result := kubeapiservertesting.StartTestServerOrDie(t, nil, []string{"--disable-admission-plugins", "ServiceAccount"}, framework.SharedEtcd())
+	result := kubeapiservertesting.StartTestServerOrDie(t, nil, []string{
+		"--disable-admission-plugins", "ServiceAccount",
+		"--anonymous-auth=false",
+	}, framework.SharedEtcd())
 	defer result.TearDownFn()
 
 	c := clientset.NewForConfigOrDie(result.ClientConfig)
@@ -326,7 +335,9 @@ func TestPatch(t *testing.T) {
 }
 
 func TestPatchWithCreateOnUpdate(t *testing.T) {
-	result := kubeapiservertesting.StartTestServerOrDie(t, nil, nil, framework.SharedEtcd())
+	result := kubeapiservertesting.StartTestServerOrDie(t, nil, []string{
+		"--anonymous-auth=false",
+	}, framework.SharedEtcd())
 	defer result.TearDownFn()
 
 	c := clientset.NewForConfigOrDie(result.ClientConfig)
@@ -434,7 +445,9 @@ func TestPatchWithCreateOnUpdate(t *testing.T) {
 }
 
 func TestAPIVersions(t *testing.T) {
-	result := kubeapiservertesting.StartTestServerOrDie(t, nil, nil, framework.SharedEtcd())
+	result := kubeapiservertesting.StartTestServerOrDie(t, nil, []string{
+		"--anonymous-auth=false",
+	}, framework.SharedEtcd())
 	defer result.TearDownFn()
 
 	c := clientset.NewForConfigOrDie(result.ClientConfig)
@@ -456,7 +469,9 @@ func TestAPIVersions(t *testing.T) {
 }
 
 func TestSingleWatch(t *testing.T) {
-	result := kubeapiservertesting.StartTestServerOrDie(t, nil, nil, framework.SharedEtcd())
+	result := kubeapiservertesting.StartTestServerOrDie(t, nil, []string{
+		"--anonymous-auth=false",
+	}, framework.SharedEtcd())
 	defer result.TearDownFn()
 
 	client := clientset.NewForConfigOrDie(result.ClientConfig)
@@ -540,7 +555,9 @@ func TestMultiWatch(t *testing.T) {
 	const watcherCount = 50
 	rt.GOMAXPROCS(watcherCount)
 
-	result := kubeapiservertesting.StartTestServerOrDie(t, nil, nil, framework.SharedEtcd())
+	result := kubeapiservertesting.StartTestServerOrDie(t, nil, []string{
+		"--anonymous-auth=false",
+	}, framework.SharedEtcd())
 	defer result.TearDownFn()
 
 	client := clientset.NewForConfigOrDie(result.ClientConfig)
@@ -795,7 +812,10 @@ func runSelfLinkTestOnNamespace(t *testing.T, c clientset.Interface, namespace s
 func TestSelfLinkOnNamespace(t *testing.T) {
 	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.RemoveSelfLink, false)()
 
-	result := kubeapiservertesting.StartTestServerOrDie(t, nil, []string{"--disable-admission-plugins", "ServiceAccount"}, framework.SharedEtcd())
+	result := kubeapiservertesting.StartTestServerOrDie(t, nil, []string{
+		"--disable-admission-plugins", "ServiceAccount",
+		"--anonymous-auth=false",
+	}, framework.SharedEtcd())
 	defer result.TearDownFn()
 
 	c := clientset.NewForConfigOrDie(result.ClientConfig)

--- a/test/integration/client/dynamic_client_test.go
+++ b/test/integration/client/dynamic_client_test.go
@@ -39,7 +39,10 @@ import (
 )
 
 func TestDynamicClient(t *testing.T) {
-	result := kubeapiservertesting.StartTestServerOrDie(t, nil, []string{"--disable-admission-plugins", "ServiceAccount"}, framework.SharedEtcd())
+	result := kubeapiservertesting.StartTestServerOrDie(t, nil, []string{
+		"--disable-admission-plugins", "ServiceAccount",
+		"--anonymous-auth=false",
+	}, framework.SharedEtcd())
 	defer result.TearDownFn()
 
 	client := clientset.NewForConfigOrDie(result.ClientConfig)
@@ -121,7 +124,9 @@ func TestDynamicClient(t *testing.T) {
 }
 
 func TestDynamicClientWatch(t *testing.T) {
-	result := kubeapiservertesting.StartTestServerOrDie(t, nil, nil, framework.SharedEtcd())
+	result := kubeapiservertesting.StartTestServerOrDie(t, nil, []string{
+		"--anonymous-auth=false",
+	}, framework.SharedEtcd())
 	defer result.TearDownFn()
 
 	client := clientset.NewForConfigOrDie(result.ClientConfig)

--- a/test/integration/disruption/disruption_test.go
+++ b/test/integration/disruption/disruption_test.go
@@ -46,7 +46,10 @@ import (
 )
 
 func setup(t *testing.T) (*kubeapiservertesting.TestServer, *disruption.DisruptionController, informers.SharedInformerFactory, clientset.Interface, *apiextensionsclientset.Clientset, dynamic.Interface) {
-	server := kubeapiservertesting.StartTestServerOrDie(t, nil, []string{"--disable-admission-plugins", "ServiceAccount"}, framework.SharedEtcd())
+	server := kubeapiservertesting.StartTestServerOrDie(t, nil, []string{
+		"--disable-admission-plugins", "ServiceAccount",
+		"--anonymous-auth=false",
+	}, framework.SharedEtcd())
 
 	clientSet, err := clientset.NewForConfig(server.ClientConfig)
 	if err != nil {

--- a/test/integration/dryrun/dryrun_test.go
+++ b/test/integration/dryrun/dryrun_test.go
@@ -215,6 +215,7 @@ func TestDryRun(t *testing.T) {
 	s, err := kubeapiservertesting.StartTestServer(t, kubeapiservertesting.NewDefaultTestServerOptions(), []string{
 		"--disable-admission-plugins=ServiceAccount,StorageObjectInUseProtection",
 		"--runtime-config=api/all=true",
+		"--anonymous-auth=false",
 	}, framework.SharedEtcd())
 	if err != nil {
 		t.Fatal(err)

--- a/test/integration/events/events_test.go
+++ b/test/integration/events/events_test.go
@@ -36,7 +36,10 @@ import (
 )
 
 func TestEventCompatibility(t *testing.T) {
-	result := kubeapiservertesting.StartTestServerOrDie(t, nil, []string{"--disable-admission-plugins", "ServiceAccount"}, framework.SharedEtcd())
+	result := kubeapiservertesting.StartTestServerOrDie(t, nil, []string{
+		"--disable-admission-plugins", "ServiceAccount",
+		"--anonymous-auth=false",
+	}, framework.SharedEtcd())
 	defer result.TearDownFn()
 
 	client := clientset.NewForConfigOrDie(result.ClientConfig)

--- a/test/integration/examples/apiserver_test.go
+++ b/test/integration/examples/apiserver_test.go
@@ -59,7 +59,9 @@ func TestAggregatedAPIServer(t *testing.T) {
 	stopCh := make(chan struct{})
 	defer close(stopCh)
 
-	testServer := kastesting.StartTestServerOrDie(t, &kastesting.TestServerInstanceOptions{EnableCertAuth: true}, nil, framework.SharedEtcd())
+	testServer := kastesting.StartTestServerOrDie(t, &kastesting.TestServerInstanceOptions{EnableCertAuth: true}, []string{
+		"--anonymous-auth=false",
+	}, framework.SharedEtcd())
 	defer testServer.TearDownFn()
 	kubeClientConfig := rest.CopyConfig(testServer.ClientConfig)
 	// force json because everything speaks it

--- a/test/integration/garbagecollector/cluster_scoped_owner_test.go
+++ b/test/integration/garbagecollector/cluster_scoped_owner_test.go
@@ -52,7 +52,9 @@ func (b *readDelayer) Read(p []byte) (n int, err error) {
 
 func TestClusterScopedOwners(t *testing.T) {
 	// Start the test server and wrap the client to delay PV watch responses
-	server := kubeapiservertesting.StartTestServerOrDie(t, nil, nil, framework.SharedEtcd())
+	server := kubeapiservertesting.StartTestServerOrDie(t, nil, []string{
+		"--anonymous-auth=false",
+	}, framework.SharedEtcd())
 	server.ClientConfig.WrapTransport = func(rt http.RoundTripper) http.RoundTripper {
 		return roundTripFunc(func(req *http.Request) (*http.Response, error) {
 			if req.URL.Query().Get("watch") != "true" || !strings.Contains(req.URL.String(), "persistentvolumes") {

--- a/test/integration/garbagecollector/garbage_collector_test.go
+++ b/test/integration/garbagecollector/garbage_collector_test.go
@@ -211,7 +211,9 @@ type testContext struct {
 
 // if workerCount > 0, will start the GC, otherwise it's up to the caller to Run() the GC.
 func setup(t *testing.T, workerCount int) *testContext {
-	return setupWithServer(t, kubeapiservertesting.StartTestServerOrDie(t, nil, nil, framework.SharedEtcd()), workerCount)
+	return setupWithServer(t, kubeapiservertesting.StartTestServerOrDie(t, nil, []string{
+		"--anonymous-auth=false",
+	}, framework.SharedEtcd()), workerCount)
 }
 
 func setupWithServer(t *testing.T, result *kubeapiservertesting.TestServer, workerCount int) *testContext {

--- a/test/integration/kubelet/watch_manager_test.go
+++ b/test/integration/kubelet/watch_manager_test.go
@@ -37,7 +37,9 @@ import (
 
 func TestWatchBasedManager(t *testing.T) {
 	testNamespace := "test-watch-based-manager"
-	server := kubeapiservertesting.StartTestServerOrDie(t, nil, nil, framework.SharedEtcd())
+	server := kubeapiservertesting.StartTestServerOrDie(t, nil, []string{
+		"--anonymous-auth=false",
+	}, framework.SharedEtcd())
 	defer server.TearDownFn()
 
 	const n = 10

--- a/test/integration/master/audit_test.go
+++ b/test/integration/master/audit_test.go
@@ -234,7 +234,9 @@ func runTestWithVersion(t *testing.T, version string) {
 			"--audit-policy-file", policyFile.Name(),
 			"--audit-log-version", version,
 			"--audit-log-mode", "blocking",
-			"--audit-log-path", logFile.Name()},
+			"--audit-log-path", logFile.Name(),
+			"--anonymous-auth=false",
+		},
 		framework.SharedEtcd())
 	defer result.TearDownFn()
 

--- a/test/integration/master/crd_test.go
+++ b/test/integration/master/crd_test.go
@@ -42,7 +42,9 @@ import (
 )
 
 func TestCRDShadowGroup(t *testing.T) {
-	result := kubeapiservertesting.StartTestServerOrDie(t, nil, nil, framework.SharedEtcd())
+	result := kubeapiservertesting.StartTestServerOrDie(t, nil, []string{
+		"--anonymous-auth=false",
+	}, framework.SharedEtcd())
 	defer result.TearDownFn()
 
 	testNamespace := "test-crd-shadow-group"
@@ -104,7 +106,9 @@ func TestCRDShadowGroup(t *testing.T) {
 }
 
 func TestCRD(t *testing.T) {
-	result := kubeapiservertesting.StartTestServerOrDie(t, nil, nil, framework.SharedEtcd())
+	result := kubeapiservertesting.StartTestServerOrDie(t, nil, []string{
+		"--anonymous-auth=false",
+	}, framework.SharedEtcd())
 	defer result.TearDownFn()
 
 	testNamespace := "test-crd"
@@ -151,7 +155,9 @@ func TestCRD(t *testing.T) {
 }
 
 func TestCRDOpenAPI(t *testing.T) {
-	result := kubeapiservertesting.StartTestServerOrDie(t, nil, nil, framework.SharedEtcd())
+	result := kubeapiservertesting.StartTestServerOrDie(t, nil, []string{
+		"--anonymous-auth=false",
+	}, framework.SharedEtcd())
 	defer result.TearDownFn()
 	kubeclient, err := kubernetes.NewForConfig(result.ClientConfig)
 	if err != nil {

--- a/test/integration/master/graceful_shutdown_test.go
+++ b/test/integration/master/graceful_shutdown_test.go
@@ -31,7 +31,9 @@ import (
 )
 
 func TestGracefulShutdown(t *testing.T) {
-	server := kubeapiservertesting.StartTestServerOrDie(t, nil, nil, framework.SharedEtcd())
+	server := kubeapiservertesting.StartTestServerOrDie(t, nil, []string{
+		"--anonymous-auth=false",
+	}, framework.SharedEtcd())
 
 	tearDownOnce := sync.Once{}
 	defer tearDownOnce.Do(server.TearDownFn)

--- a/test/integration/master/kube_apiserver_test.go
+++ b/test/integration/master/kube_apiserver_test.go
@@ -52,7 +52,9 @@ const (
 )
 
 func TestRun(t *testing.T) {
-	server := kubeapiservertesting.StartTestServerOrDie(t, nil, nil, framework.SharedEtcd())
+	server := kubeapiservertesting.StartTestServerOrDie(t, nil, []string{
+		"--anonymous-auth=false",
+	}, framework.SharedEtcd())
 	defer server.TearDownFn()
 
 	client, err := kubernetes.NewForConfig(server.ClientConfig)
@@ -111,7 +113,10 @@ func endpointReturnsStatusOK(client *kubernetes.Clientset, path string) (bool, e
 }
 
 func TestLivezAndReadyz(t *testing.T) {
-	server := kubeapiservertesting.StartTestServerOrDie(t, nil, []string{"--livez-grace-period", "0s"}, framework.SharedEtcd())
+	server := kubeapiservertesting.StartTestServerOrDie(t, nil, []string{
+		"--livez-grace-period", "0s",
+		"--anonymous-auth=false",
+	}, framework.SharedEtcd())
 	defer server.TearDownFn()
 
 	client, err := kubernetes.NewForConfig(server.ClientConfig)
@@ -131,7 +136,9 @@ func TestLivezAndReadyz(t *testing.T) {
 // apiextensions-server and the kube-aggregator server, both part of
 // the delegation chain in kube-apiserver.
 func TestOpenAPIDelegationChainPlumbing(t *testing.T) {
-	server := kubeapiservertesting.StartTestServerOrDie(t, nil, nil, framework.SharedEtcd())
+	server := kubeapiservertesting.StartTestServerOrDie(t, nil, []string{
+		"--anonymous-auth=false",
+	}, framework.SharedEtcd())
 	defer server.TearDownFn()
 
 	kubeclient, err := kubernetes.NewForConfig(server.ClientConfig)
@@ -189,7 +196,9 @@ func TestOpenAPIDelegationChainPlumbing(t *testing.T) {
 }
 
 func TestOpenAPIApiextensionsOverlapProtection(t *testing.T) {
-	server := kubeapiservertesting.StartTestServerOrDie(t, nil, nil, framework.SharedEtcd())
+	server := kubeapiservertesting.StartTestServerOrDie(t, nil, []string{
+		"--anonymous-auth=false",
+	}, framework.SharedEtcd())
 	defer server.TearDownFn()
 	apiextensionsclient, err := apiextensionsclientset.NewForConfig(server.ClientConfig)
 	if err != nil {
@@ -435,6 +444,7 @@ func testReconcilersMasterLease(t *testing.T, leaseCount int, masterCount int) {
 				"--endpoint-reconciler-type", "master-count",
 				"--advertise-address", fmt.Sprintf("10.0.1.%v", i+1),
 				"--apiserver-count", fmt.Sprintf("%v", masterCount),
+				"--anonymous-auth=false",
 			}, etcd)
 			masterCountServers[i] = server
 		}(i)
@@ -466,6 +476,7 @@ func testReconcilersMasterLease(t *testing.T, leaseCount int, masterCount int) {
 			options := []string{
 				"--endpoint-reconciler-type", "lease",
 				"--advertise-address", fmt.Sprintf("10.0.1.%v", i+10),
+				"--anonymous-auth=false",
 			}
 			server := kubeapiservertesting.StartTestServerOrDie(t, instanceOptions, options, etcd)
 			leaseServers[i] = server
@@ -533,6 +544,7 @@ func TestMultiMasterNodePortAllocation(t *testing.T) {
 		t.Logf("starting api server: %d", i)
 		server := kubeapiservertesting.StartTestServerOrDie(t, instanceOptions, []string{
 			"--advertise-address", fmt.Sprintf("10.0.1.%v", i+1),
+			"--anonymous-auth=false",
 		}, etcd)
 		kubeAPIServers = append(kubeAPIServers, server)
 

--- a/test/integration/master/transformation_testcase.go
+++ b/test/integration/master/transformation_testcase.go
@@ -80,7 +80,7 @@ func newTransformTest(l kubeapiservertesting.Logger, transformerConfigYAML strin
 		}
 	}
 
-	if e.kubeAPIServer, err = kubeapiservertesting.StartTestServer(l, nil, e.getEncryptionOptions(), e.storageConfig); err != nil {
+	if e.kubeAPIServer, err = kubeapiservertesting.StartTestServer(l, nil, append(e.getEncryptionOptions(), "--anonymous-auth=false"), e.storageConfig); err != nil {
 		return nil, fmt.Errorf("failed to start KubeAPI server: %v", err)
 	}
 	klog.Infof("Started kube-apiserver %v", e.kubeAPIServer.ClientConfig.Host)

--- a/test/integration/scale/scale_test.go
+++ b/test/integration/scale/scale_test.go
@@ -51,6 +51,7 @@ func TestScaleSubresources(t *testing.T) {
 	clientSet, tearDown := setupWithOptions(t, nil, []string{
 		"--runtime-config",
 		"api/all=true",
+		"--anonymous-auth=false",
 	})
 	defer tearDown()
 

--- a/test/integration/statefulset/statefulset_test.go
+++ b/test/integration/statefulset/statefulset_test.go
@@ -35,7 +35,9 @@ import (
 // TestVolumeTemplateNoopUpdate ensures embedded StatefulSet objects with embedded PersistentVolumes can be updated
 func TestVolumeTemplateNoopUpdate(t *testing.T) {
 	// Start the server with default storage setup
-	server, err := apiservertesting.StartTestServer(t, apiservertesting.NewDefaultTestServerOptions(), nil, framework.SharedEtcd())
+	server, err := apiservertesting.StartTestServer(t, apiservertesting.NewDefaultTestServerOptions(), []string{
+		"--anonymous-auth=false",
+	}, framework.SharedEtcd())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/integration/tls/ciphers_test.go
+++ b/test/integration/tls/ciphers_test.go
@@ -28,7 +28,10 @@ import (
 )
 
 func runBasicSecureAPIServer(t *testing.T, ciphers []string) (kubeapiservertesting.TearDownFunc, int) {
-	flags := []string{"--tls-cipher-suites", strings.Join(ciphers, ",")}
+	flags := []string{
+		"--tls-cipher-suites", strings.Join(ciphers, ","),
+		"--anonymous-auth=false",
+	}
 	testServer := kubeapiservertesting.StartTestServerOrDie(t, nil, flags, framework.SharedEtcd())
 	return testServer.TearDownFn, testServer.ServerOpts.SecureServing.BindPort
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Some integration tests through a warning caused by using AnonymousAuth.

This is an example of the warning.
```
$ make test-integration WHAT=./test/integration/apiserver/admissionwebhook GOFLAGS="-v"
W1009 08:45:23.367232  129261 authentication.go:504] AnonymousAuth is not allowed with the AlwaysAllow authorizer. Resetting AnonymousAuth to false. You should use a different authorizer
```
This patch removes all the warnings by setting AnonymousAuth to false.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
NONE

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs
NONE
```
