### PR TITLE
Fix metrics fake clientset resource and kind match

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/api/meta/restmapper.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/meta/restmapper.go
@@ -117,6 +117,12 @@ var unpluralizedSuffixes = []string{
 	"endpoints",
 }
 
+// specialSuffixes is a list of resource suffixes that their kind and resource form are not plural relation.
+var specialSuffixes = map[string]string{
+	"podmetrics":  "pods",
+	"nodemetrics": "nodes",
+}
+
 // UnsafeGuessKindToResource converts Kind to a resource name.
 // Broken. This method only "sort of" works when used outside of this package.  It assumes that Kinds and Resources match
 // and they aren't guaranteed to do so.
@@ -131,6 +137,12 @@ func UnsafeGuessKindToResource(kind schema.GroupVersionKind) ( /*plural*/ schema
 	for _, skip := range unpluralizedSuffixes {
 		if strings.HasSuffix(singularName, skip) {
 			return singular, singular
+		}
+	}
+
+	for k, v := range specialSuffixes {
+		if strings.HasSuffix(singularName, k) {
+			return kind.GroupVersion().WithResource(v), singular
 		}
 	}
 

--- a/staging/src/k8s.io/metrics/pkg/client/clientset_test/BUILD
+++ b/staging/src/k8s.io/metrics/pkg/client/clientset_test/BUILD
@@ -4,7 +4,10 @@ go_test(
     name = "go_default_test",
     srcs = ["clientset_test.go"],
     deps = [
+        "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
+        "//staging/src/k8s.io/metrics/pkg/apis/metrics/v1beta1:go_default_library",
         "//staging/src/k8s.io/metrics/pkg/client/clientset/versioned/fake:go_default_library",
     ],
 )


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug


**What this PR does / why we need it**:
As shown in [issue](https://github.com/kubernetes/kubernetes/issues/95421): It seems impossible to mock metrics client `GET` method api .

It's because in method `UnsafeGuessKindToResource`, it will try to make a guess to store the `gvr` info. But for metrics, we will get `PodMetrics` with `// +resourceName=pods` and `NodeMetrics` with `// +resourceName=nodes`.

So the function `UnsafeGuessKindToResource` will store the wrong resource name and finanlly, in the mock test, it will have the `not found` error.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #95421

**Special notes for your reviewer**:
/cc @monchier

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```


