### PR TITLE
[WIP] Apply LeaseLock owner-refrences to Lease

### DIFF
--- a/staging/src/k8s.io/client-go/tools/leaderelection/resourcelock/leaselock.go
+++ b/staging/src/k8s.io/client-go/tools/leaderelection/resourcelock/leaselock.go
@@ -59,6 +59,7 @@ func (ll *LeaseLock) Create(ctx context.Context, ler LeaderElectionRecord) error
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      ll.LeaseMeta.Name,
 			Namespace: ll.LeaseMeta.Namespace,
+			OwnerReferences: ll.LeaseMeta.OwnerReferences,
 		},
 		Spec: LeaderElectionRecordToLeaseSpec(&ler),
 	}, metav1.CreateOptions{})


### PR DESCRIPTION
**What this PR does / why we need it**:
In `client-go` there's a lease lock. It could be useful for a user to set an owner ref such that the lock will get deleted once the locked object no longer exists.

There are other options to implement this:
1. Apply all object meta from lock to its object (not just name, namespace and owner-ref)
2. Copy the same logic to other lock types (endpoint and configmap lock)

The PR is submitted as draft until there's an agreement on which way we prefer.
I'll also add tests once that happens.


```release-note
NONE
```

/sig api-machinery
/kind feature ?