### PR TITLE
Fix the busybox image tag in kubemark hollow nodes

### DIFF
--- a/test/kubemark/resources/hollow-node_template.yaml
+++ b/test/kubemark/resources/hollow-node_template.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       initContainers:
       - name: init-inotify-limit
-        image: busybox
+        image: busybox:1.32
         command: ['sysctl', '-w', 'fs.inotify.max_user_instances=1000']
         securityContext:
           privileged: true


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
In Kubemark 5k nodes tests when all 5000 hollow nodes attempt pulling the `busybox` image, we get rate limited by Docker Hub. This is because when no image tag is specified, the default one is `latest` and with the `latest` tag the image pull is forced (per documentation: https://kubernetes.io/docs/concepts/containers/images/#updating-images).

**Which issue(s) this PR fixes**:
Fixes #95402.

**Special notes for your reviewer**:
/sig scalability
/assign @wojtek-t

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```