### PR TITLE
remove secondary client retries in e2e tests

### DIFF
--- a/test/e2e/apps/daemon_set.go
+++ b/test/e2e/apps/daemon_set.go
@@ -23,6 +23,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -39,10 +41,6 @@ import (
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
 	e2eresource "k8s.io/kubernetes/test/e2e/framework/resource"
-	testutils "k8s.io/kubernetes/test/utils"
-
-	"github.com/onsi/ginkgo"
-	"github.com/onsi/gomega"
 )
 
 const (
@@ -69,9 +67,6 @@ func updateDaemonSetWithRetries(c clientset.Interface, namespace, name string, a
 	var updateErr error
 	pollErr := wait.PollImmediate(10*time.Millisecond, 1*time.Minute, func() (bool, error) {
 		if ds, err = daemonsets.Get(context.TODO(), name, metav1.GetOptions{}); err != nil {
-			if testutils.IsRetryableAPIError(err) {
-				return false, nil
-			}
 			return false, err
 		}
 		// Apply the update, then attempt to push it to the apiserver.

--- a/test/e2e/cloud/gcp/addon_update.go
+++ b/test/e2e/cloud/gcp/addon_update.go
@@ -34,7 +34,6 @@ import (
 	e2enetwork "k8s.io/kubernetes/test/e2e/framework/network"
 	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
 	e2essh "k8s.io/kubernetes/test/e2e/framework/ssh"
-	testutils "k8s.io/kubernetes/test/utils"
 	imageutils "k8s.io/kubernetes/test/utils/image"
 
 	"github.com/onsi/ginkgo"
@@ -391,7 +390,7 @@ func waitForServiceWithSelector(c clientset.Interface, namespace string, selecto
 		case len(services.Items) == 0:
 			framework.Logf("Service with %s in namespace %s disappeared.", selector.String(), namespace)
 			return !exist, nil
-		case !testutils.IsRetryableAPIError(err):
+		case err != nil:
 			framework.Logf("Non-retryable failure while listing service.")
 			return false, err
 		default:

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -193,9 +193,6 @@ func waitForDaemonSets(c clientset.Interface, ns string, allowedNotReadyNodes in
 		dsList, err := c.AppsV1().DaemonSets(ns).List(context.TODO(), metav1.ListOptions{})
 		if err != nil {
 			framework.Logf("Error getting daemonsets in namespace: '%s': %v", ns, err)
-			if testutils.IsRetryableAPIError(err) {
-				return false, nil
-			}
 			return false, err
 		}
 		var notReadyDaemonSets []string

--- a/test/e2e/framework/ingress/ingress_utils.go
+++ b/test/e2e/framework/ingress/ingress_utils.go
@@ -732,9 +732,6 @@ func (j *TestJig) WaitForIngressAddress(c clientset.Interface, ns, ingName strin
 		ipOrNameList, err := getIngressAddress(c, ns, ingName, j.Class)
 		if err != nil || len(ipOrNameList) == 0 {
 			j.Logger.Errorf("Waiting for Ingress %s/%s to acquire IP, error: %v, ipOrNameList: %v", ns, ingName, err, ipOrNameList)
-			if testutils.IsRetryableAPIError(err) {
-				return false, nil
-			}
 			return false, err
 		}
 		address = ipOrNameList[0]
@@ -892,9 +889,6 @@ func getPortURL(client clientset.Interface, ns, name string, svcPort int) (strin
 			"spec.unschedulable": "false",
 		}.AsSelector().String()})
 		if err != nil {
-			if testutils.IsRetryableAPIError(err) {
-				return false, nil
-			}
 			return false, err
 		}
 		return true, nil

--- a/test/e2e/framework/network/BUILD
+++ b/test/e2e/framework/network/BUILD
@@ -22,7 +22,6 @@ go_library(
         "//test/e2e/framework/pod:go_default_library",
         "//test/e2e/framework/skipper:go_default_library",
         "//test/e2e/framework/ssh:go_default_library",
-        "//test/utils:go_default_library",
         "//test/utils/image:go_default_library",
         "//vendor/github.com/onsi/ginkgo:go_default_library",
     ],

--- a/test/e2e/framework/network/utils.go
+++ b/test/e2e/framework/network/utils.go
@@ -44,7 +44,6 @@ import (
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
 	e2essh "k8s.io/kubernetes/test/e2e/framework/ssh"
-	testutils "k8s.io/kubernetes/test/utils"
 	imageutils "k8s.io/kubernetes/test/utils/image"
 )
 
@@ -1050,7 +1049,7 @@ func WaitForService(c clientset.Interface, namespace, name string, exist bool, i
 		case apierrors.IsNotFound(err):
 			framework.Logf("Service %s in namespace %s disappeared.", name, namespace)
 			return !exist, nil
-		case !testutils.IsRetryableAPIError(err):
+		case err != nil:
 			framework.Logf("Non-retryable failure while getting service.")
 			return false, err
 		default:

--- a/test/e2e/framework/node/BUILD
+++ b/test/e2e/framework/node/BUILD
@@ -24,7 +24,6 @@ go_library(
         "//staging/src/k8s.io/client-go/kubernetes:go_default_library",
         "//staging/src/k8s.io/client-go/util/retry:go_default_library",
         "//test/e2e/framework/log:go_default_library",
-        "//test/utils:go_default_library",
         "//test/utils/image:go_default_library",
         "//vendor/github.com/onsi/ginkgo:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
@@ -38,7 +37,6 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//staging/src/k8s.io/api/core/v1:go_default_library",
-        "//staging/src/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/fake:go_default_library",

--- a/test/e2e/framework/node/wait.go
+++ b/test/e2e/framework/node/wait.go
@@ -28,7 +28,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	clientset "k8s.io/client-go/kubernetes"
 	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
-	testutils "k8s.io/kubernetes/test/utils"
 )
 
 const sleepTime = 20 * time.Second
@@ -57,9 +56,6 @@ func WaitForTotalHealthy(c clientset.Interface, timeout time.Duration) error {
 		// It should be OK to list unschedulable Nodes here.
 		nodes, err := c.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{ResourceVersion: "0"})
 		if err != nil {
-			if testutils.IsRetryableAPIError(err) {
-				return false, nil
-			}
 			return false, err
 		}
 		for _, node := range nodes.Items {
@@ -184,9 +180,6 @@ func waitListSchedulableNodes(c clientset.Interface) (*v1.NodeList, error) {
 			"spec.unschedulable": "false",
 		}.AsSelector().String()})
 		if err != nil {
-			if testutils.IsRetryableAPIError(err) {
-				return false, nil
-			}
 			return false, err
 		}
 		return true, nil
@@ -219,9 +212,6 @@ func CheckReadyForTests(c clientset.Interface, nonblockingTaints string, allowed
 		allNodes, err := c.CoreV1().Nodes().List(context.TODO(), opts)
 		if err != nil {
 			e2elog.Logf("Unexpected error listing nodes: %v", err)
-			if testutils.IsRetryableAPIError(err) {
-				return false, nil
-			}
 			return false, err
 		}
 		for _, node := range allNodes.Items {

--- a/test/e2e/framework/node/wait_test.go
+++ b/test/e2e/framework/node/wait_test.go
@@ -21,7 +21,6 @@ import (
 	"testing"
 
 	v1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
@@ -155,10 +154,6 @@ func TestCheckReadyForTests(t *testing.T) {
 			nodeListErr: errors.New("Forced error"),
 			expected:    false,
 			expectedErr: "Forced error",
-		}, {
-			desc:        "Retryable errors from node list are reported but still return false",
-			nodeListErr: apierrors.NewTimeoutError("Retryable error", 10),
-			expected:    false,
 		},
 	}
 

--- a/test/e2e/framework/pod/resource.go
+++ b/test/e2e/framework/pod/resource.go
@@ -476,9 +476,6 @@ func CreateExecPodOrFail(client clientset.Interface, ns, generateName string, tw
 	err = wait.PollImmediate(poll, 5*time.Minute, func() (bool, error) {
 		retrievedPod, err := client.CoreV1().Pods(execPod.Namespace).Get(context.TODO(), execPod.Name, metav1.GetOptions{})
 		if err != nil {
-			if testutils.IsRetryableAPIError(err) {
-				return false, nil
-			}
 			return false, err
 		}
 		return retrievedPod.Status.Phase == v1.PodRunning, nil

--- a/test/e2e/framework/pod/wait.go
+++ b/test/e2e/framework/pod/wait.go
@@ -128,9 +128,6 @@ func WaitForPodsRunningReady(c clientset.Interface, ns string, minPods, allowedN
 		if err != nil {
 			e2elog.Logf("Error getting replication controllers in namespace '%s': %v", ns, err)
 			lastAPIError = err
-			if testutils.IsRetryableAPIError(err) {
-				return false, nil
-			}
 			return false, err
 		}
 		for _, rc := range rcList.Items {
@@ -142,9 +139,6 @@ func WaitForPodsRunningReady(c clientset.Interface, ns string, minPods, allowedN
 		if err != nil {
 			lastAPIError = err
 			e2elog.Logf("Error getting replication sets in namespace %q: %v", ns, err)
-			if testutils.IsRetryableAPIError(err) {
-				return false, nil
-			}
 			return false, err
 		}
 		for _, rs := range rsList.Items {
@@ -156,9 +150,6 @@ func WaitForPodsRunningReady(c clientset.Interface, ns string, minPods, allowedN
 		if err != nil {
 			lastAPIError = err
 			e2elog.Logf("Error getting pods in namespace '%s': %v", ns, err)
-			if testutils.IsRetryableAPIError(err) {
-				return false, nil
-			}
 			return false, err
 		}
 		nOk := int32(0)
@@ -406,9 +397,6 @@ func WaitForPodToDisappear(c clientset.Interface, ns, podName string, label labe
 		options := metav1.ListOptions{LabelSelector: label.String()}
 		pods, err := c.CoreV1().Pods(ns).List(context.TODO(), options)
 		if err != nil {
-			if testutils.IsRetryableAPIError(err) {
-				return false, nil
-			}
 			return false, err
 		}
 		found := false
@@ -459,9 +447,6 @@ func WaitForPodsWithLabel(c clientset.Interface, ns string, label labels.Selecto
 		options := metav1.ListOptions{LabelSelector: label.String()}
 		pods, err = c.CoreV1().Pods(ns).List(context.TODO(), options)
 		if err != nil {
-			if testutils.IsRetryableAPIError(err) {
-				continue
-			}
 			return
 		}
 		if len(pods.Items) > 0 {
@@ -483,9 +468,6 @@ func WaitForPodsWithLabelRunningReady(c clientset.Interface, ns string, label la
 			pods, err = WaitForPodsWithLabel(c, ns, label)
 			if err != nil {
 				e2elog.Logf("Failed to list pods: %v", err)
-				if testutils.IsRetryableAPIError(err) {
-					return false, nil
-				}
 				return false, err
 			}
 			current = 0

--- a/test/e2e/framework/ssh/BUILD
+++ b/test/e2e/framework/ssh/BUILD
@@ -12,7 +12,6 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes:go_default_library",
         "//test/e2e/framework/log:go_default_library",
-        "//test/utils:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
         "//vendor/golang.org/x/crypto/ssh:go_default_library",
     ],

--- a/test/e2e/framework/ssh/ssh.go
+++ b/test/e2e/framework/ssh/ssh.go
@@ -36,7 +36,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	clientset "k8s.io/client-go/kubernetes"
 	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
-	testutils "k8s.io/kubernetes/test/utils"
 )
 
 const (
@@ -393,9 +392,6 @@ func waitListSchedulableNodes(c clientset.Interface) (*v1.NodeList, error) {
 			"spec.unschedulable": "false",
 		}.AsSelector().String()})
 		if err != nil {
-			if testutils.IsRetryableAPIError(err) {
-				return false, nil
-			}
 			return false, err
 		}
 		return true, nil

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -1121,9 +1121,6 @@ func AllNodesReady(c clientset.Interface, timeout time.Duration) error {
 		// It should be OK to list unschedulable Nodes here.
 		nodes, err := c.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
 		if err != nil {
-			if testutils.IsRetryableAPIError(err) {
-				return false, nil
-			}
 			return false, err
 		}
 		for i := range nodes.Items {

--- a/test/e2e/scheduling/priorities.go
+++ b/test/e2e/scheduling/priorities.go
@@ -70,9 +70,6 @@ func addOrUpdateAvoidPodOnNode(c clientset.Interface, nodeName string, avoidPods
 	err := wait.PollImmediate(framework.Poll, framework.SingleCallTimeout, func() (bool, error) {
 		node, err := c.CoreV1().Nodes().Get(context.TODO(), nodeName, metav1.GetOptions{})
 		if err != nil {
-			if testutils.IsRetryableAPIError(err) {
-				return false, nil
-			}
 			return false, err
 		}
 
@@ -102,9 +99,6 @@ func removeAvoidPodsOffNode(c clientset.Interface, nodeName string) {
 	err := wait.PollImmediate(framework.Poll, framework.SingleCallTimeout, func() (bool, error) {
 		node, err := c.CoreV1().Nodes().Get(context.TODO(), nodeName, metav1.GetOptions{})
 		if err != nil {
-			if testutils.IsRetryableAPIError(err) {
-				return false, nil
-			}
 			return false, err
 		}
 

--- a/test/integration/framework/perf_utils.go
+++ b/test/integration/framework/perf_utils.go
@@ -19,7 +19,7 @@ package framework
 import (
 	"context"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"
@@ -90,7 +90,7 @@ func (p *IntegrationTestNodePreparer) PrepareNodes(nextNodeIndex int) error {
 		var err error
 		for retry := 0; retry < retries; retry++ {
 			_, err = p.client.CoreV1().Nodes().Create(context.TODO(), baseNode, metav1.CreateOptions{})
-			if err == nil || !testutils.IsRetryableAPIError(err) {
+			if err == nil {
 				break
 			}
 		}

--- a/test/integration/framework/util.go
+++ b/test/integration/framework/util.go
@@ -26,7 +26,7 @@ import (
 	"testing"
 	"time"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -34,7 +34,6 @@ import (
 	"k8s.io/klog/v2"
 	v1helper "k8s.io/kubernetes/pkg/apis/core/v1/helper"
 	nodectlr "k8s.io/kubernetes/pkg/controller/nodelifecycle"
-	testutils "k8s.io/kubernetes/test/utils"
 )
 
 const (
@@ -101,9 +100,6 @@ func waitListSchedulableNodes(c clientset.Interface) (*v1.NodeList, error) {
 			"spec.unschedulable": "false",
 		}.AsSelector().String()})
 		if err != nil {
-			if testutils.IsRetryableAPIError(err) {
-				return false, nil
-			}
 			return false, err
 		}
 		return true, nil

--- a/test/utils/BUILD
+++ b/test/utils/BUILD
@@ -49,7 +49,6 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/json:go_default_library",
-        "//staging/src/k8s.io/apimachinery/pkg/util/net:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/strategicpatch:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/uuid:go_default_library",

--- a/test/utils/delete_resources.go
+++ b/test/utils/delete_resources.go
@@ -63,9 +63,6 @@ func DeleteResourceWithRetries(c clientset.Interface, kind schema.GroupKind, nam
 		if err == nil || apierrors.IsNotFound(err) {
 			return true, nil
 		}
-		if IsRetryableAPIError(err) {
-			return false, nil
-		}
 		return false, fmt.Errorf("Failed to delete object with non-retriable error: %v", err)
 	}
 	return RetryWithExponentialBackOff(deleteFunc)

--- a/test/utils/update_resources.go
+++ b/test/utils/update_resources.go
@@ -38,9 +38,6 @@ const (
 func RetryErrorCondition(condition wait.ConditionFunc) wait.ConditionFunc {
 	return func() (bool, error) {
 		done, err := condition()
-		if err != nil && IsRetryableAPIError(err) {
-			return false, nil
-		}
 		return done, err
 	}
 }


### PR DESCRIPTION
This logic was introduced in https://github.com/kubernetes/kubernetes/pull/60209, but since then our client-go code has retries based on safe retry conditions.  This logic was only used for a subset of client actions, not all of them.  The result of this partially applied retry logic is that only some connection failures are caught, making it hard to find a true determination of how often they happen and making it harder to debug.

/assign @liggitt @wojtek-t 

/kind bug
/priority important-soon

```release-note
NONE
```