### PR TITLE
Add client listening URLs configuration to etcd migrate.

### DIFF
--- a/cluster/images/etcd/migrate/migrate.go
+++ b/cluster/images/etcd/migrate/migrate.go
@@ -65,8 +65,8 @@ func runMigrate() {
 	}
 
 	migrate(
-		opts.name, opts.port, opts.peerListenUrls, opts.peerAdvertiseUrls, opts.binDir,
-		opts.dataDir, opts.etcdDataPrefix, opts.ttlKeysDirectory, opts.initialCluster,
+		opts.name, opts.port, opts.peerListenUrls, opts.peerAdvertiseUrls, opts.clientListenUrls,
+		opts.binDir, opts.dataDir, opts.etcdDataPrefix, opts.ttlKeysDirectory, opts.initialCluster,
 		target, opts.supportedVersions, opts.etcdServerArgs)
 }
 
@@ -84,7 +84,8 @@ func copyBinaries() {
 }
 
 // migrate opens or initializes the etcd data directory, configures the migrator, and starts the migration.
-func migrate(name string, port uint64, peerListenUrls string, peerAdvertiseUrls string, binPath string, dataDirPath string, etcdDataPrefix string, ttlKeysDirectory string,
+func migrate(name string, port uint64, peerListenUrls string, peerAdvertiseUrls string, clientListenUrls string,
+	binPath string, dataDirPath string, etcdDataPrefix string, ttlKeysDirectory string,
 	initialCluster string, target *EtcdVersionPair, bundledVersions SupportedVersions, etcdServerArgs string) {
 
 	dataDir, err := OpenOrCreateDataDirectory(dataDirPath)
@@ -98,6 +99,7 @@ func migrate(name string, port uint64, peerListenUrls string, peerAdvertiseUrls 
 		port:              port,
 		peerListenUrls:    peerListenUrls,
 		peerAdvertiseUrls: peerAdvertiseUrls,
+		clientListenUrls:  clientListenUrls,
 		etcdDataPrefix:    etcdDataPrefix,
 		ttlKeysDirectory:  ttlKeysDirectory,
 		initialCluster:    initialCluster,

--- a/cluster/images/etcd/migrate/migrate_server.go
+++ b/cluster/images/etcd/migrate/migrate_server.go
@@ -39,6 +39,7 @@ func NewEtcdMigrateServer(cfg *EtcdMigrateCfg, client EtcdMigrateClient) *EtcdMi
 }
 
 // Start starts an etcd server as a separate process, waits until it has started, and returns a exec.Cmd.
+// TODO: Add support for listening to client via TLS.
 func (r *EtcdMigrateServer) Start(version *EtcdVersion) error {
 	etcdCmd := exec.Command(
 		fmt.Sprintf("%s/etcd-%s", r.cfg.binPath, version),
@@ -46,7 +47,7 @@ func (r *EtcdMigrateServer) Start(version *EtcdVersion) error {
 		"--initial-cluster", r.cfg.initialCluster,
 		"--debug",
 		"--data-dir", r.cfg.dataDirectory,
-		"--listen-client-urls", fmt.Sprintf("http://127.0.0.1:%d", r.cfg.port),
+		"--listen-client-urls", r.cfg.clientListenUrls,
 		"--advertise-client-urls", fmt.Sprintf("http://127.0.0.1:%d", r.cfg.port),
 		"--listen-peer-urls", r.cfg.peerListenUrls,
 		"--initial-advertise-peer-urls", r.cfg.peerAdvertiseUrls,

--- a/cluster/images/etcd/migrate/migrator.go
+++ b/cluster/images/etcd/migrate/migrator.go
@@ -33,6 +33,7 @@ type EtcdMigrateCfg struct {
 	port              uint64
 	peerListenUrls    string
 	peerAdvertiseUrls string
+	clientListenUrls  string
 	etcdDataPrefix    string
 	ttlKeysDirectory  string
 	supportedVersions SupportedVersions


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:


**Which issue(s) this PR fixes**:
This PR adds capacity to include additional client listening URLs to etcd migrate.

**Special notes for your reviewer**:
The code change is originally from https://github.com/kubernetes/kubernetes/pull/95312 and split out for easier review.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```