### PR TITLE
Enable to run all filters until any filter returned UnschedulableAndUnResolvable

### DIFF
--- a/pkg/scheduler/apis/config/types.go
+++ b/pkg/scheduler/apis/config/types.go
@@ -115,6 +115,10 @@ type KubeSchedulerProfile struct {
 	// is scheduled with this profile.
 	SchedulerName string
 
+	// RunFiltersUntilUnresolvable is the flag to control whether framework should exit early when any filter
+	// `UnschedulableAndUnresolvable`.
+	RunFiltersUntilUnresolvable bool
+
 	// Plugins specify the set of plugins that should be enabled or disabled.
 	// Enabled plugins are the ones that should be enabled in addition to the
 	// default plugins. Disabled plugins are any of the default plugins that

--- a/pkg/scheduler/apis/config/v1beta1/defaults.go
+++ b/pkg/scheduler/apis/config/v1beta1/defaults.go
@@ -53,6 +53,14 @@ func SetDefaults_KubeSchedulerConfiguration(obj *v1beta1.KubeSchedulerConfigurat
 		obj.Profiles[0].SchedulerName = pointer.StringPtr(api.DefaultSchedulerName)
 	}
 
+	for i := range obj.Profiles {
+		// Set default value for RunFiltersUntilUnresolvable
+		if obj.Profiles[i].RunFiltersUntilUnresolvable == nil {
+			RunFiltersUntilUnresolvable := true
+			obj.Profiles[i].RunFiltersUntilUnresolvable = &RunFiltersUntilUnresolvable
+		}
+	}
+
 	// For Healthz and Metrics bind addresses, we want to check:
 	// 1. If the value is nil, default to 0.0.0.0 and default scheduler port
 	// 2. If there is a value set, attempt to split it. If it's just a port (ie, ":1234"), default to 0.0.0.0 with that port

--- a/pkg/scheduler/apis/config/v1beta1/defaults_test.go
+++ b/pkg/scheduler/apis/config/v1beta1/defaults_test.go
@@ -69,7 +69,10 @@ func TestSchedulerDefaults(t *testing.T) {
 				PodInitialBackoffSeconds: pointer.Int64Ptr(1),
 				PodMaxBackoffSeconds:     pointer.Int64Ptr(10),
 				Profiles: []v1beta1.KubeSchedulerProfile{
-					{SchedulerName: pointer.StringPtr("default-scheduler")},
+					{
+						SchedulerName:               pointer.StringPtr("default-scheduler"),
+						RunFiltersUntilUnresolvable: pointer.BoolPtr(true),
+					},
 				},
 			},
 		},
@@ -114,6 +117,7 @@ func TestSchedulerDefaults(t *testing.T) {
 						PluginConfig: []v1beta1.PluginConfig{
 							{Name: "FooPlugin"},
 						},
+						RunFiltersUntilUnresolvable: pointer.BoolPtr(true),
 					},
 				},
 			},
@@ -126,6 +130,7 @@ func TestSchedulerDefaults(t *testing.T) {
 						PluginConfig: []v1beta1.PluginConfig{
 							{Name: "FooPlugin"},
 						},
+						RunFiltersUntilUnresolvable: pointer.BoolPtr(false),
 					},
 					{
 						SchedulerName: pointer.StringPtr("custom-scheduler"),
@@ -168,6 +173,7 @@ func TestSchedulerDefaults(t *testing.T) {
 						PluginConfig: []v1beta1.PluginConfig{
 							{Name: "FooPlugin"},
 						},
+						RunFiltersUntilUnresolvable: pointer.BoolPtr(false),
 					},
 					{
 						SchedulerName: pointer.StringPtr("custom-scheduler"),
@@ -178,6 +184,7 @@ func TestSchedulerDefaults(t *testing.T) {
 								},
 							},
 						},
+						RunFiltersUntilUnresolvable: pointer.BoolPtr(true),
 					},
 				},
 			},
@@ -213,7 +220,10 @@ func TestSchedulerDefaults(t *testing.T) {
 				PodInitialBackoffSeconds: pointer.Int64Ptr(1),
 				PodMaxBackoffSeconds:     pointer.Int64Ptr(10),
 				Profiles: []v1beta1.KubeSchedulerProfile{
-					{SchedulerName: pointer.StringPtr("default-scheduler")},
+					{
+						SchedulerName:               pointer.StringPtr("default-scheduler"),
+						RunFiltersUntilUnresolvable: pointer.BoolPtr(true),
+					},
 				},
 			},
 		},
@@ -248,7 +258,10 @@ func TestSchedulerDefaults(t *testing.T) {
 				PodInitialBackoffSeconds: pointer.Int64Ptr(1),
 				PodMaxBackoffSeconds:     pointer.Int64Ptr(10),
 				Profiles: []v1beta1.KubeSchedulerProfile{
-					{SchedulerName: pointer.StringPtr("default-scheduler")},
+					{
+						SchedulerName:               pointer.StringPtr("default-scheduler"),
+						RunFiltersUntilUnresolvable: pointer.BoolPtr(true),
+					},
 				},
 			},
 		},

--- a/pkg/scheduler/apis/config/v1beta1/zz_generated.conversion.go
+++ b/pkg/scheduler/apis/config/v1beta1/zz_generated.conversion.go
@@ -374,6 +374,9 @@ func autoConvert_v1beta1_KubeSchedulerProfile_To_config_KubeSchedulerProfile(in 
 	if err := metav1.Convert_Pointer_string_To_string(&in.SchedulerName, &out.SchedulerName, s); err != nil {
 		return err
 	}
+	if err := metav1.Convert_Pointer_bool_To_bool(&in.RunFiltersUntilUnresolvable, &out.RunFiltersUntilUnresolvable, s); err != nil {
+		return err
+	}
 	if in.Plugins != nil {
 		in, out := &in.Plugins, &out.Plugins
 		*out = new(config.Plugins)
@@ -404,6 +407,9 @@ func Convert_v1beta1_KubeSchedulerProfile_To_config_KubeSchedulerProfile(in *v1b
 
 func autoConvert_config_KubeSchedulerProfile_To_v1beta1_KubeSchedulerProfile(in *config.KubeSchedulerProfile, out *v1beta1.KubeSchedulerProfile, s conversion.Scope) error {
 	if err := metav1.Convert_string_To_Pointer_string(&in.SchedulerName, &out.SchedulerName, s); err != nil {
+		return err
+	}
+	if err := metav1.Convert_bool_To_Pointer_bool(&in.RunFiltersUntilUnresolvable, &out.RunFiltersUntilUnresolvable, s); err != nil {
 		return err
 	}
 	if in.Plugins != nil {

--- a/pkg/scheduler/factory.go
+++ b/pkg/scheduler/factory.go
@@ -98,6 +98,7 @@ func (c *Configurator) buildFramework(p schedulerapi.KubeSchedulerProfile, opts 
 		c.registry,
 		p.Plugins,
 		p.PluginConfig,
+		p.RunFiltersUntilUnresolvable,
 		opts...,
 	)
 }

--- a/staging/src/k8s.io/kube-scheduler/config/v1beta1/types.go
+++ b/staging/src/k8s.io/kube-scheduler/config/v1beta1/types.go
@@ -130,6 +130,10 @@ type KubeSchedulerProfile struct {
 	// is scheduled with this profile.
 	SchedulerName *string `json:"schedulerName,omitempty"`
 
+	// RunFiltersUntilUnresolvable is the flag to control whether framework should exit early when any filter
+	// `UnschedulableAndUnresolvable`.
+	RunFiltersUntilUnresolvable *bool `json:"RunFiltersUntilUnresolvable,omitempty"`
+
 	// Plugins specify the set of plugins that should be enabled or disabled.
 	// Enabled plugins are the ones that should be enabled in addition to the
 	// default plugins. Disabled plugins are any of the default plugins that


### PR DESCRIPTION
Currently, the preemption plugin doesn't consider to preempt on the node which is UnschedulableAndUnResolvable.

https://github.com/kubernetes/kubernetes/blob/4ca119f521bf6e3bf2af2d8ca7e0010c72b39e83/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption.go#L229

But the `framework.RunFiltersPlugin` will return early when any plugin returns `Unschedulable` or `UnschedulableAndUnResolvable` (with the default value of runAllfilters which is false).

https://github.com/kubernetes/kubernetes/blob/4ca119f521bf6e3bf2af2d8ca7e0010c72b39e83/pkg/scheduler/framework/runtime/framework.go#L502-L514

That means the preemption plugin may try to preempt on the node which is UnschedulableAndUnResolvable. That will be inefficient.

This PR adds new parameter `RunFiltersUntilUnResolvable` in the scheduler profile to indicate whether to run all filters until any filter returned `UnschedulableAndUnResolvable`. The default value is `true`.

When the preemption plugin enabled, the value of `RunFiltersUntilUnResolvable` suggested being `true`.

When the policy `alwaysCheckAllPredicates` is true, the behavior keeps the same as before, it will run all the filters whatever plugin returned.

This is inspired by issue #95442

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
To avoid preemption on invalid node

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

Yes, it is introducing a new parameter `RunFiltersUntilUnResolvable` for the scheduler profile.

It keeps the same behavior when the policy `alwaysCheckAllPredicates` is true. But when the policy `alwaysCheckAllPredicates` is false and `RunFiltersUntilUnResolvable` is true, the behavior change to run all filters until `UnschedulableAndUnResolvable` returned.

```release-note

```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
