### PR TITLE
Automated cherry pick of #95463: fix azure disk attach failure for disk size bigger than 4TB

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_controller_common.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_controller_common.go
@@ -42,6 +42,9 @@ const (
 	maxStorageAccounts                     = 100 // max # is 200 (250 with special request). this allows 100 for everything else including stand alone disks
 	maxDisksPerStorageAccounts             = 60
 	storageAccountUtilizationBeforeGrowing = 0.5
+	// Disk Caching is not supported for disks 4 TiB and larger
+	// https://docs.microsoft.com/en-us/azure/virtual-machines/premium-storage-performance#disk-caching
+	diskCachingLimit = 4096 // GiB
 
 	maxLUN               = 64 // max number of LUNs per VM
 	errLeaseFailed       = "AcquireDiskLeaseFailed"
@@ -136,9 +139,19 @@ func (c *controllerCommon) AttachDisk(isManagedDisk bool, diskName, diskURI stri
 			return -1, danglingErr
 		}
 
-		if disk.DiskProperties != nil && disk.DiskProperties.Encryption != nil &&
-			disk.DiskProperties.Encryption.DiskEncryptionSetID != nil {
-			diskEncryptionSetID = *disk.DiskProperties.Encryption.DiskEncryptionSetID
+		if disk.DiskProperties != nil {
+			if disk.DiskProperties.DiskSizeGB != nil && *disk.DiskProperties.DiskSizeGB >= diskCachingLimit && cachingMode != compute.CachingTypesNone {
+				// Disk Caching is not supported for disks 4 TiB and larger
+				// https://docs.microsoft.com/en-us/azure/virtual-machines/premium-storage-performance#disk-caching
+				cachingMode = compute.CachingTypesNone
+				klog.Warningf("size of disk(%s) is %dGB which is bigger than limit(%dGB), set cacheMode as None",
+					diskURI, *disk.DiskProperties.DiskSizeGB, diskCachingLimit)
+			}
+
+			if disk.DiskProperties.Encryption != nil &&
+				disk.DiskProperties.Encryption.DiskEncryptionSetID != nil {
+				diskEncryptionSetID = *disk.DiskProperties.Encryption.DiskEncryptionSetID
+			}
 		}
 	}
 


### PR DESCRIPTION
Cherry pick of #95463 on release-1.17.

#95463: fix azure disk attach failure for disk size bigger than 4TB

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.