### PR TITLE
Warning log callback in client-go

### DIFF
--- a/staging/publishing/import-restrictions.yaml
+++ b/staging/publishing/import-restrictions.yaml
@@ -30,6 +30,7 @@
   - k8s.io/cli-runtime/pkg/resource
   - k8s.io/cli-runtime/pkg/kustomize
   - k8s.io/utils/pointer
+  - k8s.io/klog
 
 - baseImportPath: "./vendor/k8s.io/apimachinery/"
   allowedImports:

--- a/staging/src/k8s.io/cli-runtime/go.mod
+++ b/staging/src/k8s.io/cli-runtime/go.mod
@@ -21,6 +21,7 @@ require (
 	k8s.io/api v0.0.0
 	k8s.io/apimachinery v0.0.0
 	k8s.io/client-go v0.0.0
+	k8s.io/klog/v2 v2.5.0
 	k8s.io/kube-openapi v0.0.0-20210305001622-591a79e4bda7
 	sigs.k8s.io/kustomize v2.0.3+incompatible
 	sigs.k8s.io/yaml v1.2.0

--- a/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/config_flags.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/config_flags.go
@@ -142,7 +142,7 @@ func (f *ConfigFlags) ToRawKubeConfigLoader() clientcmd.ClientConfig {
 
 func (f *ConfigFlags) toRawKubeConfigLoader() clientcmd.ClientConfig {
 	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
-	loadingRules.Warner = klog.Warning
+	loadingRules.WarningHandler = klog.Warning
 
 	// use the standard defaults for this client command
 	// DEPRECATED: remove and replace with something more accurate

--- a/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/config_flags.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/config_flags.go
@@ -17,6 +17,7 @@ limitations under the License.
 package genericclioptions
 
 import (
+	"k8s.io/klog/v2"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -141,6 +142,8 @@ func (f *ConfigFlags) ToRawKubeConfigLoader() clientcmd.ClientConfig {
 
 func (f *ConfigFlags) toRawKubeConfigLoader() clientcmd.ClientConfig {
 	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
+	loadingRules.Warner = klog.Warning
+
 	// use the standard defaults for this client command
 	// DEPRECATED: remove and replace with something more accurate
 	loadingRules.DefaultClientConfig = &clientcmd.DefaultClientConfig

--- a/staging/src/k8s.io/client-go/tools/clientcmd/loader.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/loader.go
@@ -130,14 +130,14 @@ type ClientConfigLoadingRules struct {
 	// In case of missing files, it warns the user about the missing files.
 	WarnIfAllMissing bool
 
-	// Warner is the warning log callback to use in case of missing files.
-	Warner WarningHandler
+	// WarningHandler is the warning log callback to use in case of missing files.
+	WarningHandler WarningHandlerFunc
 }
 
-// WarningHandler allows to set the logging function to use
-type WarningHandler func(...interface{})
+// WarningHandlerFunc allows to set the logging function to use
+type WarningHandlerFunc func(...interface{})
 
-func (handler WarningHandler) Warn(message string) {
+func (handler WarningHandlerFunc) Warn(message string) {
 	if handler == nil {
 		klog.V(1).Info(message)
 	} else {
@@ -234,7 +234,7 @@ func (rules *ClientConfigLoadingRules) Load() (*clientcmdapi.Config, error) {
 	if rules.WarnIfAllMissing && len(missingList) > 0 && len(kubeconfigs) == 0 {
 		missingString := strings.Join(missingList, ", ")
 
-		rules.Warner.Warn(fmt.Sprintf("Config not found: %s", missingString))
+		rules.WarningHandler.Warn(fmt.Sprintf("Config not found: %s", missingString))
 	}
 
 	// first merge all of our maps

--- a/staging/src/k8s.io/client-go/tools/clientcmd/loader_test.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/loader_test.go
@@ -146,7 +146,7 @@ func TestToleratingMissingFiles(t *testing.T) {
 
 	expectedLog := fmt.Sprintf("Config not found: %s", envVarvalue)
 	if !strings.Contains(buffer.String(), expectedLog) {
-		t.Fatalf("expected log: \"%s\"", expectedLog)
+		t.Fatalf("actual log \"%s\" not matching with the expected one: \"%s\"", buffer.String(), expectedLog)
 	}
 }
 
@@ -172,7 +172,7 @@ func TestWarningMissingFiles(t *testing.T) {
 
 	expectedLog := fmt.Sprintf("Config not found: %s", envVarvalue)
 	if !strings.Contains(buffer.String(), expectedLog) {
-		t.Fatalf("expected log: \"%s\"", expectedLog)
+		t.Fatalf("actual log \"%s\" not matching with the expected one: \"%s\"", buffer.String(), expectedLog)
 	}
 }
 

--- a/staging/src/k8s.io/client-go/tools/clientcmd/loader_test.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/loader_test.go
@@ -18,8 +18,10 @@ package clientcmd
 
 import (
 	"bytes"
+	"flag"
 	"fmt"
 	"io/ioutil"
+	"k8s.io/klog/v2"
 	"os"
 	"path"
 	"path/filepath"
@@ -121,13 +123,56 @@ func TestNonExistentCommandLineFile(t *testing.T) {
 }
 
 func TestToleratingMissingFiles(t *testing.T) {
+	envVarvalue := "bogus"
 	loadingRules := ClientConfigLoadingRules{
-		Precedence: []string{"bogus1", "bogus2", "bogus3"},
+		Precedence:       []string{"bogus1", "bogus2", "bogus3"},
+		WarnIfAllMissing: true,
+		Warner:           klog.Warning,
 	}
+
+	buffer := &bytes.Buffer{}
+
+	flags := &flag.FlagSet{}
+	klog.InitFlags(flags)
+	flags.Set("logtostderr", "false")
+	klog.SetOutput(buffer)
 
 	_, err := loadingRules.Load()
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	klog.Flush()
+
+	expectedLog := fmt.Sprintf("Config not found: %s", envVarvalue)
+	if !strings.Contains(buffer.String(), expectedLog) {
+		t.Fatalf("expected log: \"%s\"", expectedLog)
+	}
+}
+
+func TestWarningMissingFiles(t *testing.T) {
+	envVarvalue := "bogus"
+	os.Setenv(RecommendedConfigPathEnvVar, envVarvalue)
+	loadingRules := NewDefaultClientConfigLoadingRules()
+
+	buffer := &bytes.Buffer{}
+
+	flags := &flag.FlagSet{}
+	klog.InitFlags(flags)
+	flags.Set("logtostderr", "false")
+	flags.Set("v", "1")
+	klog.SetOutput(buffer)
+
+	_, err := loadingRules.Load()
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	klog.Flush()
+
+	expectedLog := fmt.Sprintf("Config not found: %s", envVarvalue)
+	if !strings.Contains(buffer.String(), expectedLog) {
+		t.Fatalf("expected log: \"%s\"", expectedLog)
 	}
 }
 

--- a/staging/src/k8s.io/client-go/tools/clientcmd/loader_test.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/loader_test.go
@@ -127,7 +127,7 @@ func TestToleratingMissingFiles(t *testing.T) {
 	loadingRules := ClientConfigLoadingRules{
 		Precedence:       []string{"bogus1", "bogus2", "bogus3"},
 		WarnIfAllMissing: true,
-		Warner:           klog.Warning,
+		WarningHandler:   klog.Warning,
 	}
 
 	buffer := &bytes.Buffer{}


### PR DESCRIPTION
 This PR introduces a callback for custom logging to use in the case of `ClientConfigLoadingRules.WarnIfAllMissing` is `true` and there are missing files.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:

The `ClientConfigLoadingRules` fields have been enriched with a new callback to allow the customization of the logging function to use in the case of `WarnIfAllMissing` field is true and there are missing files. This approach allows both to specify a logging function different from `klog.Warningf` and not to log. 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #94428

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
The `klog.Warningf` in `ClientConfigLoadingRules.Load` has been replaced by a call of the exported callback field `ClientConfigLoadingRules.WarnIfAllMissingCallback` that is configured by default to `klog.Warningf`, but can be replaced with any `func(string, ...interface{})` or nil if no log is desired. (#94428, @smarterclayton)
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
