### PR TITLE
Fix log dumping for GKE

### DIFF
--- a/cluster/log-dump/log-dump.sh
+++ b/cluster/log-dump/log-dump.sh
@@ -344,7 +344,7 @@ function run-in-docker-container() {
 }
 
 function dump_masters() {
-  local master_names
+  local master_names=()
   if [[ -n "${use_custom_instance_list}" ]]; then
     while IFS='' read -r line; do master_names+=("$line"); done < <(log_dump_custom_get_instances master)
   elif [[ ! "${master_ssh_supported_providers}" =~ ${KUBERNETES_PROVIDER} ]]; then


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Recent `log-dump.sh` change in https://github.com/kubernetes/kubernetes/pull/94762 has broken log dumping in GKE. According to the build log the log dumping process fails [here](https://github.com/kubernetes/kubernetes/blob/e3d7d067abefc2792d90a5237bcc2b95ea703a0d/cluster/log-dump/log-dump.sh#L363) because `master_names` variable is unbound. I traced the change and found out that the relevant part of bash was changed from
```bash
local master_names
if [[ -n "${use_custom_instance_list}" ]]; then
    master_names=( $(log_dump_custom_get_instances master)
(...)
fi
(...)
if [[ "${#master_names[@]}" == 0 ]]; then
  echo "No masters found?"
  return
fi
```
to
```bash
local master_names
if [[ -n "${use_custom_instance_list}" ]]; then
  while IFS='' read -r line; do master_names+=("$line"); done < <(log_dump_custom_get_instances master)
(...)
fi
if [[ "${#master_names[@]}" == 0 ]]; then
  echo 'No masters found?'
  return
fi
```
Because `log_dump_custom_get_instances` doesn't `echo` anything for GKE, we end up with unbound `master_names` variable. Initializing it to the empty array `()` resolves this problem.

**Which issue(s) this PR fixes**:
No issue is opened for that.

**Special notes for your reviewer**:
/sig scalability
/assign @wojtek-t @jkaniuk 

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
