### PR TITLE
Enable XFS tests for recent GKE COS versions

### DIFF
--- a/test/e2e/storage/testsuites/base.go
+++ b/test/e2e/storage/testsuites/base.go
@@ -172,7 +172,7 @@ func skipUnsupportedTest(driver TestDriver, pattern testpatterns.TestPattern) {
 	if !dInfo.SupportedFsType.Has(pattern.FsType) {
 		e2eskipper.Skipf("Driver %s doesn't support %v -- skipping", dInfo.Name, pattern.FsType)
 	}
-	if pattern.FsType == "xfs" && framework.NodeOSDistroIs("gci", "cos", "windows") {
+	if pattern.FsType == "xfs" && framework.NodeOSDistroIs("windows") {
 		e2eskipper.Skipf("Distro doesn't support xfs -- skipping")
 	}
 	if pattern.FsType == "ntfs" && !framework.NodeOSDistroIs("windows") {


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:
Recent versions of GKE (v1.18 and above) now support XFS on COS node images. This PR changes storage e2e tests to allow XFS tests on those deployments.

**Special notes for your reviewer**:
I could not find a way to get the cluster version, hence I added a kubectl version call. Please let me know if there's a cleaner way to do it. Alternatively, we could just look at the COS version and enable tests on 5.4 and above. I couldn't figure out where to find that version either, though.

```release-note
NONE
```

/assign @msau42 