### PR TITLE
test: Fix deprecated --dry-run parameter

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/apply/apply_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apply/apply_test.go
@@ -314,7 +314,7 @@ func TestRunApplyPrintsValidObjectList(t *testing.T) {
 	cmd := NewCmdApply("kubectl", tf, ioStreams)
 	cmd.Flags().Set("filename", filenameCM)
 	cmd.Flags().Set("output", "json")
-	cmd.Flags().Set("dry-run", "true")
+	cmd.Flags().Set("dry-run", "client")
 	cmd.Run(cmd, []string{})
 
 	// ensure that returned list can be unmarshaled back into a configmap list

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_clusterrole_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_clusterrole_test.go
@@ -151,7 +151,7 @@ func TestCreateClusterRole(t *testing.T) {
 	for name, test := range tests {
 		ioStreams, _, buf, _ := genericclioptions.NewTestIOStreams()
 		cmd := NewCmdCreateClusterRole(tf, ioStreams)
-		cmd.Flags().Set("dry-run", "true")
+		cmd.Flags().Set("dry-run", "client")
 		cmd.Flags().Set("output", "yaml")
 		cmd.Flags().Set("verb", test.verbs)
 		cmd.Flags().Set("resource", test.resources)

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_pdb_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_pdb_test.go
@@ -55,7 +55,7 @@ func TestCreatePdb(t *testing.T) {
 	cmd := NewCmdCreatePodDisruptionBudget(tf, ioStreams)
 	cmd.Flags().Set("min-available", "1")
 	cmd.Flags().Set("selector", "app=rails")
-	cmd.Flags().Set("dry-run", "true")
+	cmd.Flags().Set("dry-run", "client")
 	cmd.Flags().Set("output", outputFormat)
 
 	printFlags := genericclioptions.NewPrintFlags("created").WithTypeSetter(scheme.Scheme)

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_priorityclass_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_priorityclass_test.go
@@ -56,7 +56,7 @@ func TestCreatePriorityClass(t *testing.T) {
 	cmd.Flags().Set("value", "1000")
 	cmd.Flags().Set("global-default", "true")
 	cmd.Flags().Set("description", "my priority")
-	cmd.Flags().Set("dry-run", "true")
+	cmd.Flags().Set("dry-run", "client")
 	cmd.Flags().Set("output", outputFormat)
 	cmd.Flags().Set("preemption-policy", "Never")
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_role_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_role_test.go
@@ -134,7 +134,7 @@ func TestCreateRole(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			ioStreams, _, buf, _ := genericclioptions.NewTestIOStreams()
 			cmd := NewCmdCreateRole(tf, ioStreams)
-			cmd.Flags().Set("dry-run", "true")
+			cmd.Flags().Set("dry-run", "client")
 			cmd.Flags().Set("output", "yaml")
 			cmd.Flags().Set("verb", test.verbs)
 			cmd.Flags().Set("resource", test.resources)


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Some unit tests throw this warning.

```
W1013 09:06:21.581870  176998 helpers.go:567] --dry-run=true is deprecated (boolean value) and can be replaced with --dry-run=client.
```

This patch removes the warning by using ```--dry-run=client``` instead of ```--dry-run=true```.

The unit tests that are affected are:

```
$ make test WHAT=./vendor/k8s.io/kubectl/pkg/cmd/apply GOFLAGS=-v
$ make test WHAT=./vendor/k8s.io/kubectl/pkg/cmd/create GOFLAGS=-v
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs
NONE
```
