### PR TITLE
warn user about resource being deleted

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/diff/diff.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/diff/diff.go
@@ -548,6 +548,9 @@ func (o *DiffOptions) Run() error {
 				break
 			}
 		}
+
+		apply.WarnIfDeleting(info.Object, o.Diff.ErrOut)
+
 		return err
 	})
 	if err != nil {


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Detect "kubectl apply" to resources currently being deleted and warn user.

**Which issue(s) this PR fixes**:
Ref #93363

**Special notes for your reviewer**:
/cc @apelisse 
Not sure if i should use Fixes keyword so used Ref instead.

**Does this PR introduce a user-facing change?**:
```release-note
Warns user when executing kubectl apply/diff to resource currently being deleted.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
