### PR TITLE
Use cache of LUNs that are being attached.

### DIFF
--- a/pkg/volume/azuredd/azure_dd.go
+++ b/pkg/volume/azuredd/azure_dd.go
@@ -54,8 +54,10 @@ type DiskController interface {
 
 	// Get the LUN number of the disk that is attached to the host
 	GetDiskLun(diskName, diskURI string, nodeName types.NodeName) (int32, error)
-	// Get the next available LUN number to attach a new VHD
-	GetNextDiskLun(nodeName types.NodeName) (int32, error)
+	// Allocate the next available LUN number to attach a new VHD.
+	AllocateDiskLun(nodeName types.NodeName) (int32, error)
+	// Free previously allocated LUN after attach finishes or fails.
+	FreeAttachingDiskLun(nodeName types.NodeName, lun int32)
 
 	// Create a VHD blob
 	CreateVolume(name, storageAccount, storageAccountType, location string, requestGB int) (string, string, int, error)

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure.go
@@ -32,6 +32,7 @@ import (
 	"github.com/Azure/go-autorest/autorest/azure"
 
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
@@ -706,6 +707,7 @@ func initDiskControllers(az *Cloud) error {
 		subscriptionID:        az.SubscriptionID,
 		cloud:                 az,
 		vmLockMap:             newLockMap(),
+		vmLunAttachingMap:     make(map[types.NodeName]sets.Int32),
 	}
 
 	az.BlobDiskController = &BlobDiskController{common: common}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Azure Disk in-tree volume plugin serializes each AttachDisk() call on a single node, so all volumes are attached in sequence, not in parallel. When a single attach is slowed down due to internal Azure, all attaches must wait for the slow one to finish. It seems to me that the serialization is used only to make sure that each AttachDisk calls uses unique LUN for the attached volume.

In this PR, I remove this serialization of `AttachDisk()` calls and use a cache instead to keep LUNs that are being attached to make sure two disks use different LUNs when attaching them to a single node.

@andyzhangx @kubernetes/provider-azure, PTAL

**Which issue(s) this PR fixes**:
**Does this PR introduce a user-facing change?**:
```release-note
Azure: volumes are attached to a single node in parallel, not in sequence.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
