### PR TITLE
test: Fix using deprecated default cluster IPs

### DIFF
--- a/pkg/controlplane/instance_test.go
+++ b/pkg/controlplane/instance_test.go
@@ -72,6 +72,7 @@ func setUp(t *testing.T) (*etcd3testing.EtcdTestServer, Config, *assert.Assertio
 			APIServerServicePort:    443,
 			MasterCount:             1,
 			EndpointReconcilerType:  reconcilers.MasterCountReconcilerType,
+			ServiceIPRange:          net.IPNet{IP: net.ParseIP("10.0.0.0"), Mask: net.CIDRMask(24, 32)},
 		},
 	}
 


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
The unit test for controlplane produces a warning caused by using deprecated default cluster IPs.
```
make test WHAT=./pkg/controlplane GOFLAGS=-v
W1015 07:42:59.203836  111754 services.go:37] No CIDR for service cluster IPs specified. Default value which was 10.0.0.0/24 is deprecated and will be removed in future releases. Please specify it using --service-cluster-ip-range on kube-apiserver.
```

This warning appears in six tests, ```TestValidOpenAPISpec```, ```TestLegacyRestStorageStrategies```, ```TestCertificatesRestStorageStrategies```, ```TestVersion```, ```TestAPIVersionOfDiscoveryEndpoints```, ```TestStorageVersionHashes``` and ```TestStorageVersionHashEqualities```.

This patch fixes the warning by passing ServiceIPRange.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
My previous PR  #95397 was for integration tests, but this PR is for unit tests.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs
NONE
```
