### PR TITLE
fix hpa setStatus error "currentMetrics invalid value null"

### DIFF
--- a/pkg/controller/podautoscaler/horizontal.go
+++ b/pkg/controller/podautoscaler/horizontal.go
@@ -1082,10 +1082,12 @@ func (a *HorizontalController) setStatus(hpa *autoscalingv2.HorizontalPodAutosca
 		CurrentReplicas: currentReplicas,
 		DesiredReplicas: desiredReplicas,
 		LastScaleTime:   hpa.Status.LastScaleTime,
-		CurrentMetrics:  metricStatuses,
+		CurrentMetrics:  hpa.Status.CurrentMetrics,
 		Conditions:      hpa.Status.Conditions,
 	}
-
+	if metricStatuses != nil {
+		hpa.Status.CurrentMetrics = metricStatuses
+	}
 	if rescale {
 		now := metav1.NewTime(time.Now())
 		hpa.Status.LastScaleTime = &now


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug


**What this PR does / why we need it**:
When minReplicas or maxreplicas take effect, hpa generates the following event, currentReplicas and desiredReplicas fail to be updated.
```
Warning  FailedUpdateStatus  26m   HPA  xxx is invalid: status.currentMetrics: Invalid value: "null": status.currentMetrics in body must be of type array: "null"  
```

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```