### PR TITLE
fix: smb valid path error

### DIFF
--- a/staging/src/k8s.io/mount-utils/mount_windows.go
+++ b/staging/src/k8s.io/mount-utils/mount_windows.go
@@ -29,6 +29,10 @@ import (
 	"k8s.io/utils/keymutex"
 )
 
+const (
+	accessDenied string = "access is denied"
+)
+
 // Mounter provides the default implementation of mount.Interface
 // for the windows platform.  This implementation assumes that the
 // kubelet is running in the host's root mount namespace.
@@ -103,31 +107,28 @@ func (mounter *Mounter) MountSensitive(source string, target string, fstype stri
 		getSMBMountMutex.LockKey(source)
 		defer getSMBMountMutex.UnlockKey(source)
 
-		var output string
-		var err error
 		username := allOptions[0]
 		password := allOptions[1]
-		if output, err = newSMBMapping(username, password, source); err != nil {
+		if output, err := newSMBMapping(username, password, source); err != nil {
 			klog.Warningf("SMB Mapping(%s) returned with error(%v), output(%s)", source, err, string(output))
 			if isSMBMappingExist(source) {
-				valid, errPath := isValidPath(source)
-				if errPath != nil {
-					return errPath
-				}
-				if valid {
-					err = nil
-					klog.V(2).Infof("SMB Mapping(%s) already exists and is still valid, skip error", source)
-				} else {
-					klog.V(2).Infof("SMB Mapping(%s) already exists while it's not valid, now begin to remove and remount", source)
-					if output, err = removeSMBMapping(source); err != nil {
-						return fmt.Errorf("Remove-SmbGlobalMapping failed: %v, output: %q", err, output)
+				valid, err := isValidPath(source)
+				if !valid {
+					if err == nil || isAccessDeniedError(err) {
+						klog.V(2).Infof("SMB Mapping(%s) already exists while it's not valid, return error: %v, now begin to remove and remount", source, err)
+						if output, err = removeSMBMapping(source); err != nil {
+							return fmt.Errorf("Remove-SmbGlobalMapping failed: %v, output: %q", err, output)
+						}
+						if output, err := newSMBMapping(username, password, source); err != nil {
+							return fmt.Errorf("New-SmbGlobalMapping(%s) failed: %v, output: %q", source, err, output)
+						}
 					}
-					output, err = newSMBMapping(username, password, source)
+				} else {
+					klog.V(2).Infof("SMB Mapping(%s) already exists and is still valid, skip error(%v)", source, err)
 				}
+			} else {
+				return fmt.Errorf("New-SmbGlobalMapping(%s) failed: %v, output: %q", source, err, output)
 			}
-		}
-		if err != nil {
-			return fmt.Errorf("New-SmbGlobalMapping(%s) failed: %v, output: %q", source, err, output)
 		}
 	}
 
@@ -182,6 +183,10 @@ func isValidPath(remotepath string) (bool, error) {
 	}
 
 	return strings.HasPrefix(strings.ToLower(string(output)), "true"), nil
+}
+
+func isAccessDeniedError(err error) bool {
+	return err != nil && strings.Contains(strings.ToLower(err.Error()), accessDenied)
 }
 
 // remove SMB mapping

--- a/staging/src/k8s.io/mount-utils/mount_windows_test.go
+++ b/staging/src/k8s.io/mount-utils/mount_windows_test.go
@@ -361,3 +361,29 @@ func TestIsValidPath(t *testing.T) {
 		}
 	}
 }
+
+func TestIsAccessDeniedError(t *testing.T) {
+	tests := []struct {
+		err            error
+		expectedResult bool
+	}{
+		{
+			nil,
+			false,
+		},
+		{
+			fmt.Errorf("other error message"),
+			false,
+		},
+		{
+			fmt.Errorf(`PathValid(\\xxx\share) failed with returned output: Test-Path : Access is denied`),
+			true,
+		},
+	}
+
+	for _, test := range tests {
+		result := isAccessDeniedError(test.err)
+		assert.Equal(t, result, test.expectedResult, "Expect result not equal with isAccessDeniedError(%v) return: %q, expected: %q",
+			test.err, result, test.expectedResult)
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
fix: smb valid path error, ported from https://github.com/kubernetes/utils/pull/188

`isValidPath` func error should be ignored since if password changed, it would return following access error:
```
PathValid(\\xxx\share) failed with returned output: Test-Path : Access is denied
```

By that case, should remove original SMB remote path and mount again.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
/assign @jingxu97 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
fix: smb valid path error
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
fix: smb valid path error
```

/priority important-soon
/sig storage
/triage accepted
