### PR TITLE
e2e: topology manager: avoid sriov device plugin pod leak on test failures

### DIFF
--- a/test/e2e_node/topology_manager_test.go
+++ b/test/e2e_node/topology_manager_test.go
@@ -506,7 +506,7 @@ func teardownSRIOVConfigOrFail(f *framework.Framework, sd *sriovData) {
 		GracePeriodSeconds: &gp,
 	}
 
-	ginkgo.By("Delete SRIOV device plugin pod %s/%s")
+	ginkgo.By(fmt.Sprintf("Delete SRIOV device plugin pod %s/%s", sd.pod.Namespace, sd.pod.Name))
 	err = f.ClientSet.CoreV1().Pods(sd.pod.Namespace).Delete(context.TODO(), sd.pod.Name, deleteOptions)
 	framework.ExpectNoError(err)
 	waitForContainerRemoval(sd.pod.Spec.Containers[0].Name, sd.pod.Name, sd.pod.Namespace)

--- a/test/e2e_node/topology_manager_test.go
+++ b/test/e2e_node/topology_manager_test.go
@@ -527,6 +527,8 @@ func runTopologyManagerNodeAlignmentSuiteTests(f *framework.Framework, configMap
 	}
 
 	sd := setupSRIOVConfigOrFail(f, configMap)
+	defer teardownSRIOVConfigOrFail(f, sd)
+
 	envInfo := &testEnvInfo{
 		numaNodes:         numaNodes,
 		sriovResourceName: sd.resourceName,
@@ -695,7 +697,6 @@ func runTopologyManagerNodeAlignmentSuiteTests(f *framework.Framework, configMap
 		}
 		runTopologyManagerNegativeTest(f, 1, ctnAttrs, envInfo)
 	}
-	teardownSRIOVConfigOrFail(f, sd)
 }
 
 func runTopologyManagerTests(f *framework.Framework) {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

Optionally add one or more of the following kinds if applicable:
/kind flake

**What this PR does / why we need it**:
Should the topology manager e2e test run on multi-numa, sriov-enabled system, and fail, they will fail to cleanup the sriov device plugin, leading to failures in the following runs.
We want to make sure that the sriov device plugin is cleaned up when tests ends.
Additionally, we fix a ginkgo log which was lost in rebase. The bad ginkgo log had no effect except for worse readability.

**Special notes for your reviewer**:
You should never see this failure materialize in prow because we don't have a multi-numa, sriov-enabled lane yet.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
