### PR TITLE
Fix --dry-run invocation in kubectl e2e

### DIFF
--- a/test/e2e/kubectl/kubectl.go
+++ b/test/e2e/kubectl/kubectl.go
@@ -923,7 +923,7 @@ metadata:
 			if !strings.Contains(podJSON, busyboxImage) {
 				framework.Failf("Failed replacing image from %s to %s in:\n%s\n", httpdImage, busyboxImage, podJSON)
 			}
-			framework.RunKubectlOrDieInput(ns, podJSON, "replace", "-f", "-", "--dry-run", "server")
+			framework.RunKubectlOrDieInput(ns, podJSON, "replace", "-f", "-", "--dry-run=server")
 
 			ginkgo.By("verifying the pod " + podName + " has the right image " + httpdImage)
 			pod, err := c.CoreV1().Pods(ns).Get(context.TODO(), podName, metav1.GetOptions{})


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
/priority backlog
/sig cli

**What this PR does / why we need it**:
`--dry-run` should be used with an equal sign to pass value, otherwise it's read as the old boolean value.

**Special notes for your reviewer**:
/assign @sallyom 

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
