### PR TITLE
kube-apiserver: Remove deprecated default service cluster IP support

### DIFF
--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -731,24 +731,15 @@ func buildServiceResolver(enabledAggregatorRouting bool, hostname string, inform
 }
 
 func getServiceIPAndRanges(serviceClusterIPRanges string) (net.IP, net.IPNet, net.IPNet, error) {
-	serviceClusterIPRangeList := []string{}
-	if serviceClusterIPRanges != "" {
-		serviceClusterIPRangeList = strings.Split(serviceClusterIPRanges, ",")
+	if serviceClusterIPRanges == "" {
+		return net.IP{}, net.IPNet{}, net.IPNet{}, fmt.Errorf("Specify service cluster IP range(s)")
 	}
+
+	serviceClusterIPRangeList := strings.Split(serviceClusterIPRanges, ",")
 
 	var apiServerServiceIP net.IP
 	var primaryServiceIPRange net.IPNet
 	var secondaryServiceIPRange net.IPNet
-	var err error
-	// nothing provided by user, use default range (only applies to the Primary)
-	if len(serviceClusterIPRangeList) == 0 {
-		var primaryServiceClusterCIDR net.IPNet
-		primaryServiceIPRange, apiServerServiceIP, err = controlplane.ServiceIPRange(primaryServiceClusterCIDR)
-		if err != nil {
-			return net.IP{}, net.IPNet{}, net.IPNet{}, fmt.Errorf("error determining service IP ranges: %v", err)
-		}
-		return apiServerServiceIP, primaryServiceIPRange, net.IPNet{}, nil
-	}
 
 	if len(serviceClusterIPRangeList) > 0 {
 		_, primaryServiceClusterCIDR, err := net.ParseCIDR(serviceClusterIPRangeList[0])

--- a/cmd/kube-apiserver/app/server_test.go
+++ b/cmd/kube-apiserver/app/server_test.go
@@ -28,7 +28,7 @@ func TestGetServiceIPAndRanges(t *testing.T) {
 		secondaryServiceIPRange string
 		expectedError           bool
 	}{
-		{"", "10.0.0.1", "10.0.0.0/24", "<nil>", false},
+		{"", "<nil>", "<nil>", "<nil>", true},
 		{"192.0.2.1/24", "192.0.2.1", "192.0.2.0/24", "<nil>", false},
 		{"192.0.2.1/24,192.168.128.0/17", "192.0.2.1", "192.0.2.0/24", "192.168.128.0/17", false},
 		// Dual stack IPv4/IPv6


### PR DESCRIPTION
**What type of PR is this?**
/kind deprecation

**What this PR does / why we need it**:
```TestGetServiceIPAndRanges``` in Unit test is testing ```getServiceIPAndRanges() ```and prints the following warning:

```
W1015 07:41:49.639419   98549 services.go:37] No CIDR for service cluster IPs specified. Default value which was 10.0.0.0/24 is deprecated and will be removed in future releases. Please specify it using --service-cluster-ip-range on kube-apiserver.
```
As this warning says, the default service cluster IP is deprecated. So this PR modifies ```getServiceIPAndRanges()``` not to use this default. Due to the change, if ```getServiceIPAndRanges()``` receives a ```""``` argument, an error will occur.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Another fix is ​​to ```getServiceIPAndRanges()``` return the default service cluster IP even after the default service cluster IP in ```controlplane.ServiceIPRange()``` is removed. I've fixed it this PR way for consistency, but any comments on this are appreciated!


**Does this PR introduce a user-facing change?**:
```release-note
The default value of 10.0.0.0/24 for the API server startup flag --service-cluster-ip-range is deprecated, so user need to specify some value.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs
NONE
```
