### PR TITLE
Remove debug print from create quota

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_quota.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_quota.go
@@ -204,7 +204,6 @@ func (o *QuotaOpts) createQuota() (*corev1.ResourceQuota, error) {
 	if o.EnforceNamespace {
 		namespace = o.Namespace
 	}
-	fmt.Println(corev1.SchemeGroupVersion.String())
 	resourceQuota := &corev1.ResourceQuota{
 		TypeMeta: metav1.TypeMeta{APIVersion: corev1.SchemeGroupVersion.String(), Kind: "ResourceQuota"},
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

While using kubectl create quota a leading line is being printed with the api version used. 
```
_output/bin/kubectl --context=kind-kind create quota lala  --hard=pods=100
v1 #this is the extra print
resourcequota/lala created
```

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```

/sig cli
/priority backlog