### PR TITLE
enable benchmark by matching test config

### DIFF
--- a/test/e2e_node/resource_usage_test.go
+++ b/test/e2e_node/resource_usage_test.go
@@ -105,7 +105,7 @@ var _ = SIGDescribe("Resource-usage [Serial] [Slow]", func() {
 				podsNr: 35,
 			},
 			{
-				podsNr: 105,
+				podsNr: 90,
 			},
 		}
 


### PR DESCRIPTION
Change kubernetes/test-infra@fc3e91a from 105 -> 90 causes this test
not to be run.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug
/kind regression

**What this PR does / why we need it**:
Enables test that has not been running. Runs both in dockerd and containerd as separate prow jobs
https://testgrid.k8s.io/sig-node-kubelet#node-kubelet-benchmark&sort-by-name=
https://testgrid.k8s.io/sig-node-containerd#node-e2e-benchmark
I'm assuming good faith that someone does want this to run. 
It has not been running since June.
I think we do not need it and we should remove these tests/benchmarks.

**Which issue(s) this PR fixes**:
Found while investigating #95043

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/cc @dims @bart0sh 
/assign @dchen1107 