### PR TITLE
e2e: topology manager: use deletePodSync for faster delete

### DIFF
--- a/test/e2e_node/podresources_test.go
+++ b/test/e2e_node/podresources_test.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"strings"
-	"sync"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
@@ -148,19 +147,7 @@ func (tpd *testPodData) createPodsForTest(f *framework.Framework, podReqs []podD
 
 /* deletePodsForTest clean up all the pods run for a testcase. Must ensure proper cleanup */
 func (tpd *testPodData) deletePodsForTest(f *framework.Framework) {
-	podNS := f.Namespace.Name
-	var wg sync.WaitGroup
-	for podName := range tpd.PodMap {
-		wg.Add(1)
-		go func(podName string) {
-			defer ginkgo.GinkgoRecover()
-			defer wg.Done()
-
-			deletePodSyncByName(f, podName)
-			waitForAllContainerRemoval(podName, podNS)
-		}(podName)
-	}
-	wg.Wait()
+	deletePodsAsync(f, tpd.PodMap)
 }
 
 /* deletePod removes pod during a test. Should do a best-effort clean up */


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Cut down the topology manager execution time (wall clock) by doing pod deletion in parallel. There is no real reason to do it serially, we only need to guarantee that each pod created by each test is gone before to move forward,

**Special notes for your reviewer**:
General test improvement

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```