### PR TITLE
wip Change the default value authorizetion-mode to ..

### DIFF
--- a/pkg/kubeapiserver/options/authentication.go
+++ b/pkg/kubeapiserver/options/authentication.go
@@ -129,7 +129,7 @@ func (o *BuiltInAuthenticationOptions) WithAll() *BuiltInAuthenticationOptions {
 
 // WithAnonymous set default value for anonymous authentication
 func (o *BuiltInAuthenticationOptions) WithAnonymous() *BuiltInAuthenticationOptions {
-	o.Anonymous = &AnonymousAuthenticationOptions{Allow: true}
+	o.Anonymous = &AnonymousAuthenticationOptions{Allow: false}
 	return o
 }
 

--- a/pkg/kubeapiserver/options/authentication_test.go
+++ b/pkg/kubeapiserver/options/authentication_test.go
@@ -185,3 +185,16 @@ func TestToAuthenticationConfig(t *testing.T) {
 		t.Error(cmp.Diff(resultConfig, expectConfig))
 	}
 }
+
+func TestApplyAuthorization(t *testing.T) {
+	testOptions := NewBuiltInAuthenticationOptions().WithAll()
+	authorizationOptions := NewBuiltInAuthorizationOptions()
+
+	testOptions.ApplyAuthorization(authorizationOptions)
+	expectOptions:= NewBuiltInAuthenticationOptions().WithAll()
+
+	// Check ApplyAuthorization() does not change anything on default values
+	if !reflect.DeepEqual(testOptions, expectOptions) {
+		t.Error(cmp.Diff(testOptions, expectOptions))
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
/kind cleanup

**What this PR does / why we need it**:

If setting AnonymousAuth and AlwaysAllow, `ApplyAuthorization()` changes AnonymousAuth to false in the function with outputting the warning message like
```
W1015 18:10:27.803624    5870 authentication.go:504] AnonymousAuth is not allowed with the AlwaysAllow authorizer. Resetting AnonymousAuth to false. You should use a different authorizer
```

And the default values of these options made this situation.
This changes the default value of AnonymousAuth to false to avoid the warning message and keep current actual option values which are the same as `ApplyAuthorization()` changes.

Ref: https://github.com/kubernetes/kubernetes/pull/95474

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
The default value of AnonymousAuth is changed to false. Users need to enable the option explicitly if necessary.
```
