### PR TITLE
Fix windows node startup failures for fluentbit installation

### DIFF
--- a/cluster/gce/windows/k8s-node-setup.psm1
+++ b/cluster/gce/windows/k8s-node-setup.psm1
@@ -1627,16 +1627,17 @@ function DownloadAndInstall-LoggingAgents {
       Log-Output 'Extracting Logging agent'
       Expand-Archive td.zip
       mv .\td\td-agent-bit-${LOGGINGAGENT_VERSION}-win64\ $LOGGINGAGENT_ROOT
+      cd C:\
       Remove-Item -Force -Recurse $install_dir
   }
 
   # Download Logging exporter if needed
   if (ShouldWrite-File $LOGGINGEXPORTER_ROOT\flb-exporter.exe) {
+      $url = ("https://storage.googleapis.com/gke-release/winnode/fluentbit-exporter/${LOGGINGEXPORTER_VERSION}/flb-exporter-${LOGGINGEXPORTER_VERSION}.exe")
       Log-Output 'Downloading logging exporter'
       New-Item $LOGGINGEXPORTER_ROOT -ItemType 'directory' -Force | Out-Null
       MustDownload-File `
-          -OutFile $LOGGINGEXPORTER_ROOT\flb-exporter.exe `
-          -URLs 'https://storage.googleapis.com/gke-release/winnode/fluentbit-exporter/${LOGGINGEXPORTER_VERSION}/flb-exporter-${LOGGINGEXPORTER_VERSION}.exe'
+          -OutFile $LOGGINGEXPORTER_ROOT\flb-exporter.exe -URLs $url
   }
 }
 


### PR DESCRIPTION
1. cd to root dir before removing temp installer path. It was failing because we were trying to remove while being in the same dir.
2. Expand variables in a regular string and use it in the command. Expansion was failing in single quotes.

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Fixes node startup failures for windows nodes.

**Special notes for your reviewer**:

Follow up to the earlier pull request #93912 


**Does this PR introduce a user-facing change?**:
```release-note
None
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
None