### PR TITLE
Use gsutil to download kube binaries and release artifacts

### DIFF
--- a/cluster/get-kube-binaries.sh
+++ b/cluster/get-kube-binaries.sh
@@ -156,7 +156,10 @@ function download_tarball() {
   fi
   url="${DOWNLOAD_URL_PREFIX}/${file}"
   mkdir -p "${download_path}"
-  if [[ $(which curl) ]]; then
+
+  if [[ $(which gsutil) ]] && [[ "$url" =~ ^https://storage.googleapis.com/.* ]]; then
+    gsutil cp "${url//'https://storage.googleapis.com/'/'gs://'}" "${download_path}/${file}"
+  elif [[ $(which curl) ]]; then
     # if the url belongs to GCS API we should use oauth2_token in the headers
     curl_headers=""
     if { [[ "${KUBERNETES_PROVIDER:-gce}" == "gce" ]] || [[ "${KUBERNETES_PROVIDER}" == "gke" ]] ; } &&
@@ -167,7 +170,7 @@ function download_tarball() {
   elif [[ $(which wget) ]]; then
     wget "${url}" -O "${download_path}/${file}"
   else
-    echo "Couldn't find curl or wget.  Bailing out." >&2
+    echo "Couldn't find gsutil, curl, or wget.  Bailing out." >&2
     exit 4
   fi
   echo

--- a/cluster/get-kube.sh
+++ b/cluster/get-kube.sh
@@ -240,7 +240,9 @@ if [[ -z "${KUBERNETES_SKIP_CONFIRM-}" ]]; then
 fi
 
 if "${need_download}"; then
-  if [[ $(which curl) ]]; then
+  if [[ $(which gsutil) ]] && [[ "$kubernetes_tar_url" =~ ^https://storage.googleapis.com/.* ]]; then
+    gsutil cp "${kubernetes_tar_url//'https://storage.googleapis.com/'/'gs://'}" "${file}"
+  elif [[ $(which curl) ]]; then
     # if the url belongs to GCS API we should use oauth2_token in the headers
     curl_headers=""
     if { [[ "${KUBERNETES_PROVIDER:-gce}" == "gce" ]] || [[ "${KUBERNETES_PROVIDER}" == "gke" ]] ; } &&
@@ -251,7 +253,7 @@ if "${need_download}"; then
   elif [[ $(which wget) ]]; then
     wget "${kubernetes_tar_url}"
   else
-    echo "Couldn't find curl or wget.  Bailing out."
+    echo "Couldn't find gsutil, curl, or wget.  Bailing out."
     exit 1
   fi
 fi


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup
/kind flake

**What this PR does / why we need it**:

This PR defaults to using `gsutil` if available to download kube binaries and release artifacts inside of `cluster/get-kube.sh` and `cluster/get-kube-binaries.sh`.

This will hopefully resolve test flakes related to network instability when downloading with curl.

**Which issue(s) this PR fixes**:

Fixes https://github.com/kubernetes/test-infra/issues/19386

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
