### PR TITLE
Switch "Events" conformance metadata from v1.19 to v1.20 to reflect actual applicable release

### DIFF
--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -815,7 +815,7 @@
   description: A set of events is created with a label selector which MUST be found
     when listed. The set of events is deleted and MUST NOT show up when listed by
     its label selector.
-  release: v1.19
+  release: v1.20
   file: test/e2e/apimachinery/events.go
 - testname: Event resource lifecycle
   codename: '[sig-api-machinery] Events should ensure that an event can be fetched,
@@ -823,7 +823,7 @@
   description: Create an event, the event MUST exist. The event is patched with a
     new message, the check MUST have the update message. The event is deleted and
     MUST NOT show up when listing all events.
-  release: v1.19
+  release: v1.20
   file: test/e2e/apimachinery/events.go
 - testname: Garbage Collector, delete deployment,  propagation policy background
   codename: '[sig-api-machinery] Garbage collector should delete RS created by deployment

--- a/test/e2e/apimachinery/events.go
+++ b/test/e2e/apimachinery/events.go
@@ -39,7 +39,7 @@ var _ = ginkgo.Describe("[sig-api-machinery] Events", func() {
 	f := framework.NewDefaultFramework("events")
 
 	/*
-			   Release: v1.19
+			   Release: v1.20
 			   Testname: Event resource lifecycle
 			   Description: Create an event, the event MUST exist.
 		           The event is patched with a new message, the check MUST have the update message.
@@ -124,7 +124,7 @@ var _ = ginkgo.Describe("[sig-api-machinery] Events", func() {
 	})
 
 	/*
-	   Release: v1.19
+	   Release: v1.20
 	   Testname: Event, delete a collection
 	   Description: A set of events is created with a label selector which MUST be found when listed.
 	   The set of events is deleted and MUST NOT show up when listed by its label selector.


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it:**
This PR correct the meta data for Event endpoints promoted to conformance that did not show up 1.19.
PR [#95388](https://github.com/kubernetes/kubernetes/pull/95388) and [#19502](https://github.com/kubernetes/test-infra/pull/19502) corrected the status.
Original promotion to conformance was done in [#92813](https://github.com/kubernetes/kubernetes/pull/92813) & [#89753](https://github.com/kubernetes/kubernetes/pull/89753)
The following endpoints are affected:
deleteCoreV1NamespacedEvent
listCoreV1EventForAllNamespaces
patchCoreV1NamespacedEvent
readCoreV1NamespacedEvent
createCoreV1NamespacedEvent
deleteCoreV1CollectionNamespacedEvent
listCoreV1NamespacedEvent

**Which issue(s) this PR fixes:**
Fixes [#362](https://github.com/cncf/apisnoop/issues/362)

**Special notes for your reviewer:**
Adds +7 endpoint test coverage (good for conformance)

**Does this PR introduce a user-facing change?:**
```
NONE

```

**Release note:**
```release-note
NONE
```

**Additional** documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```
NONE

```

/sig testing
/sig architecture
/area conformance