### PR TITLE
Make CSIDriver.spec.podInfoOnMount mutable

### DIFF
--- a/pkg/apis/storage/validation/validation.go
+++ b/pkg/apis/storage/validation/validation.go
@@ -404,12 +404,11 @@ func ValidateCSIDriver(csiDriver *storage.CSIDriver) field.ErrorList {
 // ValidateCSIDriverUpdate validates a CSIDriver.
 func ValidateCSIDriverUpdate(new, old *storage.CSIDriver) field.ErrorList {
 	allErrs := ValidateCSIDriver(new)
-
-	// Spec is read-only
-	// If this ever relaxes in the future, make sure to increment the Generation number in PrepareForUpdate
-	if !apiequality.Semantic.DeepEqual(old.Spec, new.Spec) {
-		allErrs = append(allErrs, field.Invalid(field.NewPath("spec"), new.Spec, "field is immutable"))
-	}
+	allErrs = append(allErrs, apivalidation.ValidateImmutableField(old.Spec.AttachRequired, new.Spec.AttachRequired, field.NewPath("spec", "attachRequired"))...)
+	allErrs = append(allErrs, apivalidation.ValidateImmutableField(old.Spec.FSGroupPolicy, new.Spec.FSGroupPolicy, field.NewPath("spec", "fsGroupPolicy"))...)
+	allErrs = append(allErrs, apivalidation.ValidateImmutableField(old.Spec.VolumeLifecycleModes, new.Spec.VolumeLifecycleModes, field.NewPath("spec", "volumeLifecycleModes"))...)
+	allErrs = append(allErrs, apivalidation.ValidateImmutableField(old.Spec.StorageCapacity, new.Spec.StorageCapacity, field.NewPath("spec", "storageCapacity"))...)
+	// PodInfoOnMount is excluded because it is mutable.
 	return allErrs
 }
 

--- a/pkg/registry/storage/csidriver/BUILD
+++ b/pkg/registry/storage/csidriver/BUILD
@@ -13,6 +13,7 @@ go_library(
         "//pkg/apis/storage:go_default_library",
         "//pkg/apis/storage/validation:go_default_library",
         "//pkg/features:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/api/equality:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/validation/field:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/storage/names:go_default_library",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind feature
/kind api-change


**What this PR does / why we need it**:

This PR makes the `CSIDriver.spec.podInfoOnMount` field mutable. This is useful for configuring CSIDrivers that do not currently support this, but will in the near future (such as the [AWS EFS CSI driver](https://github.com/kubernetes-sigs/aws-efs-csi-driver)), and removes the need to delete / recreate these objects once these drivers are upgraded.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #95627

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
The podInfoOnMount field in the CSIDriver spec is now mutable.
```

**Tests**

Unit test coverage, and manual test coverage, see below:

```
$ kubectl apply -f csi-driver.yaml
csidriver.storage.k8s.io/efs.csi.aws.com created

$ kubectl describe CSIDriver efs.csi.aws.com
...
Metadata:
  ...
  Generation:          1
  ...
Spec:
  Attach Required:    false
  Pod Info On Mount:  false
  ...
...

# Updating spec.podInfoOnMount
$ kubectl apply -f csi-driver.yaml
csidriver.storage.k8s.io/efs.csi.aws.com configured

$ kubectl describe CSIDriver efs.csi.aws.com
...
Metadata:
  ...
  Generation:          2
  ...
Spec:
  Attach Required:    false
  Pod Info On Mount:  true
  ...
...

# Updating spec.attachRequired
$ kubectl apply -f csi-driver.yaml
The CSIDriver "efs.csi.aws.com" is invalid: spec.attachRequired: Invalid value: false: field is immutable
```

@msau42 