### PR TITLE
test: Add service cluster IP range unit test

### DIFF
--- a/cmd/kube-apiserver/app/server_test.go
+++ b/cmd/kube-apiserver/app/server_test.go
@@ -31,7 +31,32 @@ func TestGetServiceIPAndRanges(t *testing.T) {
 		{"", "10.0.0.1", "10.0.0.0/24", "<nil>", false},
 		{"192.0.2.1/24", "192.0.2.1", "192.0.2.0/24", "<nil>", false},
 		{"192.0.2.1/24,192.168.128.0/17", "192.0.2.1", "192.0.2.0/24", "192.168.128.0/17", false},
+		// Dual stack IPv4/IPv6
+		{"192.0.2.1/24,2001:db2:1:3:4::1/112", "192.0.2.1", "192.0.2.0/24", "2001:db2:1:3:4::/112", false},
+		// Dual stack IPv6/IPv4
+		{"2001:db2:1:3:4::1/112,192.0.2.1/24", "2001:db2:1:3:4::1", "2001:db2:1:3:4::/112", "192.0.2.0/24", false},
+
 		{"192.0.2.1/30,192.168.128.0/17", "<nil>", "<nil>", "<nil>", true},
+		// Invalid ip range[0] IPv4 mask
+		{"192.0.2.1/33,192.168.128.0/17", "<nil>", "<nil>", "<nil>", true},
+		// Invalid ip range[1] IPv4 mask
+		{"192.0.2.1/24,192.168.128.0/33", "<nil>", "<nil>", "<nil>", true},
+		// Invalid ip range[0] IPv6 mask
+		{"2001:db2:1:3:4::1/129,192.0.2.1/24", "<nil>", "<nil>", "<nil>", true},
+		// Invalid ip range[1] IPv6 mask
+		{"192.0.2.1/24,2001:db2:1:3:4::1/129", "<nil>", "<nil>", "<nil>", true},
+		// Invalid ip range[0] missing IPv4 mask
+		{"192.0.2.1,192.168.128.0/17", "<nil>", "<nil>", "<nil>", true},
+		// Invalid ip range[1] missing IPv4 mask
+		{"192.0.2.1/24,192.168.128.1", "<nil>", "<nil>", "<nil>", true},
+		// Invalid ip range[0] missing IPv6 mask
+		{"2001:db2:1:3:4::1,192.0.2.1/24", "<nil>", "<nil>", "<nil>", true},
+		// Invalid ip range[1] missing IPv6 mask
+		{"192.0.2.1/24,2001:db2:1:3:4::1", "<nil>", "<nil>", "<nil>", true},
+		// Invalid ip range[0] IP address format
+		{"bad.ip.range,192.168.0.2/24", "<nil>", "<nil>", "<nil>", true},
+		// Invalid ip range[1] IP address format
+		{"192.168.0.2/24,bad.ip.range", "<nil>", "<nil>", "<nil>", true},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
/area test

**What this PR does / why we need it**:
test: Add service cluster IP range unit test

This PR adds trailing unit tests to check the service cluster IP range and improves the code coverage of ```k8s.io/kubernetes/cmd/kube-apiserver/app``` from 5.7% to 6.2%.

1) Dual stack IPv4/IPv6
2) Invalid IPv4, IPv6 mask
3) missing IPv4, IPv6 mask
4) invalid IP address format

The tests 2, 3, 4 are suggsted by @aojea.

**Which issue(s) this PR fixes**:
NONE

**Special notes for your reviewer**:
NONE

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs
NONE
```
