### PR TITLE
fix wrong indentation level in describe node

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/describe/describe.go
+++ b/staging/src/k8s.io/kubectl/pkg/describe/describe.go
@@ -3315,7 +3315,7 @@ func describeNode(node *corev1.Node, nodeNonTerminatedPodsList *corev1.PodList, 
 			sort.Sort(SortableResourceNames(resources))
 			for _, resource := range resources {
 				value := resourceList[resource]
-				w.Write(LEVEL_0, "  %s:\t%s\n", resource, value.String())
+				w.Write(LEVEL_1, "%s:\t%s\n", resource, value.String())
 			}
 		}
 
@@ -3329,16 +3329,16 @@ func describeNode(node *corev1.Node, nodeNonTerminatedPodsList *corev1.PodList, 
 		}
 
 		w.Write(LEVEL_0, "System Info:\n")
-		w.Write(LEVEL_0, "  Machine ID:\t%s\n", node.Status.NodeInfo.MachineID)
-		w.Write(LEVEL_0, "  System UUID:\t%s\n", node.Status.NodeInfo.SystemUUID)
-		w.Write(LEVEL_0, "  Boot ID:\t%s\n", node.Status.NodeInfo.BootID)
-		w.Write(LEVEL_0, "  Kernel Version:\t%s\n", node.Status.NodeInfo.KernelVersion)
-		w.Write(LEVEL_0, "  OS Image:\t%s\n", node.Status.NodeInfo.OSImage)
-		w.Write(LEVEL_0, "  Operating System:\t%s\n", node.Status.NodeInfo.OperatingSystem)
-		w.Write(LEVEL_0, "  Architecture:\t%s\n", node.Status.NodeInfo.Architecture)
-		w.Write(LEVEL_0, "  Container Runtime Version:\t%s\n", node.Status.NodeInfo.ContainerRuntimeVersion)
-		w.Write(LEVEL_0, "  Kubelet Version:\t%s\n", node.Status.NodeInfo.KubeletVersion)
-		w.Write(LEVEL_0, "  Kube-Proxy Version:\t%s\n", node.Status.NodeInfo.KubeProxyVersion)
+		w.Write(LEVEL_1, "Machine ID:\t%s\n", node.Status.NodeInfo.MachineID)
+		w.Write(LEVEL_1, "System UUID:\t%s\n", node.Status.NodeInfo.SystemUUID)
+		w.Write(LEVEL_1, "Boot ID:\t%s\n", node.Status.NodeInfo.BootID)
+		w.Write(LEVEL_1, "Kernel Version:\t%s\n", node.Status.NodeInfo.KernelVersion)
+		w.Write(LEVEL_1, "OS Image:\t%s\n", node.Status.NodeInfo.OSImage)
+		w.Write(LEVEL_1, "Operating System:\t%s\n", node.Status.NodeInfo.OperatingSystem)
+		w.Write(LEVEL_1, "Architecture:\t%s\n", node.Status.NodeInfo.Architecture)
+		w.Write(LEVEL_1, "Container Runtime Version:\t%s\n", node.Status.NodeInfo.ContainerRuntimeVersion)
+		w.Write(LEVEL_1, "Kubelet Version:\t%s\n", node.Status.NodeInfo.KubeletVersion)
+		w.Write(LEVEL_1, "Kube-Proxy Version:\t%s\n", node.Status.NodeInfo.KubeProxyVersion)
 
 		// remove when .PodCIDR is depreciated
 		if len(node.Spec.PodCIDR) > 0 {

--- a/staging/src/k8s.io/kubectl/pkg/describe/describe_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/describe/describe_test.go
@@ -3993,6 +3993,18 @@ func TestDescribeNode(t *testing.T) {
 			Status: corev1.NodeStatus{
 				Capacity:    nodeCapacity,
 				Allocatable: nodeAllocatable,
+				NodeInfo: corev1.NodeSystemInfo{
+					MachineID:               "55d2ccaefc9847c9a69356e7f3bd23f4",
+					SystemUUID:              "fe312784-2364-4bba-a55e-f56051539c21",
+					BootID:                  "b6c44522-c4d5-443d-924b-b54d6831b5e8",
+					KernelVersion:           "4.19.76-linuxkit",
+					OSImage:                 "Ubuntu 20.04 LTS",
+					ContainerRuntimeVersion: "docker://19.3.8",
+					KubeletVersion:          "v1.19.2",
+					KubeProxyVersion:        "v1.19.2",
+					OperatingSystem:         "linux",
+					Architecture:            "amd64",
+				},
 			},
 		},
 		&coordinationv1.Lease{
@@ -4047,6 +4059,27 @@ func TestDescribeNode(t *testing.T) {
 	}
 
 	expectedOut := []string{"Unschedulable", "true", "holder",
+		`Capacity:
+  cpu:            8
+  hugepages-1Gi:  0
+  hugepages-2Mi:  4Gi
+  memory:         24Gi
+Allocatable:
+  cpu:            4
+  hugepages-1Gi:  0
+  hugepages-2Mi:  2Gi
+  memory:         12Gi
+System Info:
+  Machine ID:                 55d2ccaefc9847c9a69356e7f3bd23f4
+  System UUID:                fe312784-2364-4bba-a55e-f56051539c21
+  Boot ID:                    b6c44522-c4d5-443d-924b-b54d6831b5e8
+  Kernel Version:             4.19.76-linuxkit
+  OS Image:                   Ubuntu 20.04 LTS
+  Operating System:           linux
+  Architecture:               amd64
+  Container Runtime Version:  docker://19.3.8
+  Kubelet Version:            v1.19.2
+  Kube-Proxy Version:         v1.19.2`,
 		`Allocated resources:
   (Total limits may be over 100 percent, i.e., overcommitted.)
   Resource           Requests     Limits


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:

This PR fixed a wrong indentation level in "kubectl describe node" output. This is the current output.

![image](https://user-images.githubusercontent.com/60682957/96225284-d4543c00-0fcb-11eb-98b2-4afb5707a373.png)

Items in "Capacity", "Allocatable" and "System Info" have only 1 spaces at the head. Originally they were declared as `LEVEL_0` with 2 spaces, but for some reasons it outputs with only 1 space.

Because any other parts are using "2-spaces" indentation level, for consistency, it should be fixed.
This PR changes them to use `LEVEL_1` to keep the indentation 2 spaces.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #95638

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fix wrong indentation level in "kubectl describe node" output.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
