### PR TITLE
vendor/k8s.io/metrics/pkg/client/custom_metrics: fix static check

### DIFF
--- a/hack/.staticcheck_failures
+++ b/hack/.staticcheck_failures
@@ -53,4 +53,3 @@ vendor/k8s.io/client-go/rest
 vendor/k8s.io/client-go/rest/watch
 vendor/k8s.io/client-go/transport
 vendor/k8s.io/kubectl/pkg/cmd/scale
-vendor/k8s.io/metrics/pkg/client/custom_metrics

--- a/staging/src/k8s.io/metrics/pkg/client/custom_metrics/multi_client.go
+++ b/staging/src/k8s.io/metrics/pkg/client/custom_metrics/multi_client.go
@@ -46,7 +46,7 @@ func PeriodicallyInvalidate(cache AvailableAPIsGetter, interval time.Duration, s
 		case <-ticker.C:
 			cache.Invalidate()
 		case <-stopCh:
-			break
+			return
 		}
 	}
 }

--- a/staging/src/k8s.io/metrics/pkg/client/custom_metrics/versioned_client.go
+++ b/staging/src/k8s.io/metrics/pkg/client/custom_metrics/versioned_client.go
@@ -24,7 +24,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/util/flowcontrol"
 
@@ -34,10 +33,7 @@ import (
 	"k8s.io/metrics/pkg/client/custom_metrics/scheme"
 )
 
-var (
-	codecs           = serializer.NewCodecFactory(scheme.Scheme)
-	versionConverter = NewMetricConverter()
-)
+var versionConverter = NewMetricConverter()
 
 type customMetricsClient struct {
 	client  rest.Interface


### PR DESCRIPTION
What type of PR is this?
/kind cleanup

What this PR does / why we need it:
fix vendor/k8s.io/metrics/pkg/client/custom_metrics static check following，
multi_client.go:49:4: ineffective break statement. Did you mean to break out of the outer loop? (SA4011)
versioned_client.go:38:2: var codecs is unused (U1000)

Which issue(s) this PR fixes:
Part of #92402

Special notes for your reviewer:

Does this PR introduce a user-facing change?:
NONE

Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.: