### PR TITLE
Automated cherry pick of #94781: Don't attempt to detach an FC device… on release-1.19

### DIFF
--- a/pkg/volume/fc/attacher.go
+++ b/pkg/volume/fc/attacher.go
@@ -165,6 +165,11 @@ func (detacher *fcDetacher) UnmountDevice(deviceMountPath string) error {
 	if err != nil {
 		return fmt.Errorf("fc: failed to unmount: %s\nError: %v", deviceMountPath, err)
 	}
+	// GetDeviceNameFromMount from above returns an empty string if deviceMountPath is not a mount point
+	// There is no need to DetachDisk if this is the case (and DetachDisk will throw an error if we attempt)
+	if devName == "" {
+		return nil
+	}
 	unMounter := volumeSpecToUnmounter(detacher.mounter)
 	err = detacher.manager.DetachDisk(*unMounter, devName)
 	if err != nil {


### PR DESCRIPTION
Cherry pick of #94781 on release-1.19.

#94781: Don't attempt to detach an FC device if we don't know its name

For details on the cherry pick process, see the cherry pick requests page.