### PR TITLE
Add a new way to generate leader election lock

### DIFF
--- a/staging/src/k8s.io/client-go/tools/leaderelection/resourcelock/BUILD
+++ b/staging/src/k8s.io/client-go/tools/leaderelection/resourcelock/BUILD
@@ -18,8 +18,10 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
+        "//staging/src/k8s.io/client-go/kubernetes:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/typed/coordination/v1:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/typed/core/v1:go_default_library",
+        "//staging/src/k8s.io/client-go/rest:go_default_library",
     ],
 )
 

--- a/staging/src/k8s.io/client-go/tools/leaderelection/resourcelock/interface.go
+++ b/staging/src/k8s.io/client-go/tools/leaderelection/resourcelock/interface.go
@@ -19,6 +19,9 @@ package resourcelock
 import (
 	"context"
 	"fmt"
+	clientset "k8s.io/client-go/kubernetes"
+	restclient "k8s.io/client-go/rest"
+	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -139,4 +142,17 @@ func New(lockType string, ns string, name string, coreClient corev1.CoreV1Interf
 	default:
 		return nil, fmt.Errorf("Invalid lock-type %s", lockType)
 	}
+}
+
+// NewFromKubeconfig will create a lock of a given type according to the input parameters.
+func NewFromKubeconfig(lockType string, ns string, name string, rlc ResourceLockConfig, kubeconfig *restclient.Config, renewDeadline time.Duration) (Interface, error) {
+	// shallow copy, do not modify the kubeconfig
+	config := *kubeconfig
+	timeout := ((renewDeadline / time.Millisecond) / 2) * time.Millisecond
+	if timeout < time.Second {
+		timeout = time.Second
+	}
+	config.Timeout = timeout
+	leaderElectionClient := clientset.NewForConfigOrDie(restclient.AddUserAgent(&config, "leader-election"))
+	return New(lockType, ns, name, leaderElectionClient.CoreV1(), leaderElectionClient.CoordinationV1(), rlc)
 }


### PR DESCRIPTION
**What type of PR is this?**:

/kind bug

**What this PR does / why we need it**:

This change adds a new path to create resource lock in a backward compatible way. Currently, timeout for kube-apiserver client is set in a library's client dependent way, allowing setting unreasonable values for client timeout. This code provide an unified way to create clients used by resources and provides a constraint for a client timeout.

Too high value for client timeout resulted in a fragile leader election, failing with only a single timeout. This PR sets client timeout equal to MAX(50%*RenewDeadline, 1s).

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
This is another approach to #95319

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/assign @wojtekt-t
/assign @liggitt 
