### PR TITLE
staging/publishing: remove release-1.16 rules

### DIFF
--- a/staging/publishing/rules.yaml
+++ b/staging/publishing/rules.yaml
@@ -13,11 +13,6 @@ rules:
       dir: staging/src/k8s.io/code-generator
     name: master
   - source:
-      branch: release-1.16
-      dir: staging/src/k8s.io/code-generator
-    name: release-1.16
-    go: 1.13.15
-  - source:
       branch: release-1.17
       dir: staging/src/k8s.io/code-generator
     name: release-1.17
@@ -40,11 +35,6 @@ rules:
       branch: master
       dir: staging/src/k8s.io/apimachinery
     name: master
-  - source:
-      branch: release-1.16
-      dir: staging/src/k8s.io/apimachinery
-    name: release-1.16
-    go: 1.13.15
   - source:
       branch: release-1.17
       dir: staging/src/k8s.io/apimachinery
@@ -71,14 +61,6 @@ rules:
     dependencies:
     - repository: apimachinery
       branch: master
-  - source:
-      branch: release-1.16
-      dir: staging/src/k8s.io/api
-    name: release-1.16
-    go: 1.13.15
-    dependencies:
-      - repository: apimachinery
-        branch: release-1.16
   - source:
       branch: release-1.17
       dir: staging/src/k8s.io/api
@@ -116,16 +98,6 @@ rules:
       branch: master
     - repository: api
       branch: master
-  - source:
-      branch: release-1.16
-      dir: staging/src/k8s.io/client-go
-    name: release-13.0
-    go: 1.13.15
-    dependencies:
-      - repository: apimachinery
-        branch: release-1.16
-      - repository: api
-        branch: release-1.16
   - source:
       branch: release-1.17
       dir: staging/src/k8s.io/client-go
@@ -175,18 +147,6 @@ rules:
       branch: master
     - repository: client-go
       branch: master
-  - source:
-      branch: release-1.16
-      dir: staging/src/k8s.io/component-base
-    name: release-1.16
-    go: 1.13.15
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.16
-    - repository: api
-      branch: release-1.16
-    - repository: client-go
-      branch: release-13.0
   - source:
       branch: release-1.17
       dir: staging/src/k8s.io/component-base
@@ -240,20 +200,6 @@ rules:
       branch: master
     - repository: component-base
       branch: master
-  - source:
-      branch: release-1.16
-      dir: staging/src/k8s.io/apiserver
-    name: release-1.16
-    go: 1.13.15
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.16
-    - repository: api
-      branch: release-1.16
-    - repository: client-go
-      branch: release-13.0
-    - repository: component-base
-      branch: release-1.16
   - source:
       branch: release-1.17
       dir: staging/src/k8s.io/apiserver
@@ -316,24 +262,6 @@ rules:
       branch: master
     - repository: code-generator
       branch: master
-  - source:
-      branch: release-1.16
-      dir: staging/src/k8s.io/kube-aggregator
-    name: release-1.16
-    go: 1.13.15
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.16
-    - repository: api
-      branch: release-1.16
-    - repository: client-go
-      branch: release-13.0
-    - repository: apiserver
-      branch: release-1.16
-    - repository: component-base
-      branch: release-1.16
-    - repository: code-generator
-      branch: release-1.16
   - source:
       branch: release-1.17
       dir: staging/src/k8s.io/kube-aggregator
@@ -408,26 +336,6 @@ rules:
       branch: master
     - repository: component-base
       branch: master
-    required-packages:
-    - k8s.io/code-generator
-  - source:
-      branch: release-1.16
-      dir: staging/src/k8s.io/sample-apiserver
-    name: release-1.16
-    go: 1.13.15
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.16
-    - repository: api
-      branch: release-1.16
-    - repository: client-go
-      branch: release-13.0
-    - repository: apiserver
-      branch: release-1.16
-    - repository: code-generator
-      branch: release-1.16
-    - repository: component-base
-      branch: release-1.16
     required-packages:
     - k8s.io/code-generator
   - source:
@@ -512,22 +420,6 @@ rules:
     required-packages:
     - k8s.io/code-generator
   - source:
-      branch: release-1.16
-      dir: staging/src/k8s.io/sample-controller
-    name: release-1.16
-    go: 1.13.15
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.16
-    - repository: api
-      branch: release-1.16
-    - repository: client-go
-      branch: release-13.0
-    - repository: code-generator
-      branch: release-1.16
-    required-packages:
-    - k8s.io/code-generator
-  - source:
       branch: release-1.17
       dir: staging/src/k8s.io/sample-controller
     name: release-1.17
@@ -598,26 +490,6 @@ rules:
       branch: master
     - repository: component-base
       branch: master
-    required-packages:
-    - k8s.io/code-generator
-  - source:
-      branch: release-1.16
-      dir: staging/src/k8s.io/apiextensions-apiserver
-    name: release-1.16
-    go: 1.13.15
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.16
-    - repository: api
-      branch: release-1.16
-    - repository: client-go
-      branch: release-13.0
-    - repository: apiserver
-      branch: release-1.16
-    - repository: code-generator
-      branch: release-1.16
-    - repository: component-base
-      branch: release-1.16
     required-packages:
     - k8s.io/code-generator
   - source:
@@ -698,20 +570,6 @@ rules:
     - repository: code-generator
       branch: master
   - source:
-      branch: release-1.16
-      dir: staging/src/k8s.io/metrics
-    name: release-1.16
-    go: 1.13.15
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.16
-    - repository: api
-      branch: release-1.16
-    - repository: client-go
-      branch: release-13.0
-    - repository: code-generator
-      branch: release-1.16
-  - source:
       branch: release-1.17
       dir: staging/src/k8s.io/metrics
     name: release-1.17
@@ -769,18 +627,6 @@ rules:
     - repository: client-go
       branch: master
   - source:
-      branch: release-1.16
-      dir: staging/src/k8s.io/cli-runtime
-    name: release-1.16
-    go: 1.13.15
-    dependencies:
-    - repository: api
-      branch: release-1.16
-    - repository: apimachinery
-      branch: release-1.16
-    - repository: client-go
-      branch: release-13.0
-  - source:
       branch: release-1.17
       dir: staging/src/k8s.io/cli-runtime
     name: release-1.17
@@ -833,20 +679,6 @@ rules:
       branch: master
     - repository: client-go
       branch: master
-  - source:
-      branch: release-1.16
-      dir: staging/src/k8s.io/sample-cli-plugin
-    name: release-1.16
-    go: 1.13.15
-    dependencies:
-    - repository: api
-      branch: release-1.16
-    - repository: apimachinery
-      branch: release-1.16
-    - repository: cli-runtime
-      branch: release-1.16
-    - repository: client-go
-      branch: release-13.0
   - source:
       branch: release-1.17
       dir: staging/src/k8s.io/sample-cli-plugin
@@ -907,20 +739,6 @@ rules:
     - repository: client-go
       branch: master
   - source:
-      branch: release-1.16
-      dir: staging/src/k8s.io/kube-proxy
-    name: release-1.16
-    go: 1.13.15
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.16
-    - repository: component-base
-      branch: release-1.16
-    - repository: api
-      branch: release-1.16
-    - repository: client-go
-      branch: release-13.0
-  - source:
       branch: release-1.17
       dir: staging/src/k8s.io/kube-proxy
     name: release-1.17
@@ -980,16 +798,6 @@ rules:
     - repository: component-base
       branch: master
   - source:
-      branch: release-1.16
-      dir: staging/src/k8s.io/kubelet
-    name: release-1.16
-    go: 1.13.15
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.16
-    - repository: api
-      branch: release-1.16
-  - source:
       branch: release-1.17
       dir: staging/src/k8s.io/kubelet
     name: release-1.17
@@ -1040,20 +848,6 @@ rules:
       branch: master
     - repository: client-go
       branch: master
-  - source:
-      branch: release-1.16
-      dir: staging/src/k8s.io/kube-scheduler
-    name: release-1.16
-    go: 1.13.15
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.16
-    - repository: component-base
-      branch: release-1.16
-    - repository: api
-      branch: release-1.16
-    - repository: client-go
-      branch: release-13.0
   - source:
       branch: release-1.17
       dir: staging/src/k8s.io/kube-scheduler
@@ -1142,18 +936,6 @@ rules:
     - repository: controller-manager
       branch: master
   - source:
-      branch: release-1.16
-      dir: staging/src/k8s.io/cloud-provider
-    name: release-1.16
-    go: 1.13.15
-    dependencies:
-    - repository: api
-      branch: release-1.16
-    - repository: apimachinery
-      branch: release-1.16
-    - repository: client-go
-      branch: release-13.0
-  - source:
       branch: release-1.17
       dir: staging/src/k8s.io/cloud-provider
     name: release-1.17
@@ -1215,20 +997,6 @@ rules:
     - repository: cloud-provider
       branch: master
   - source:
-      branch: release-1.16
-      dir: staging/src/k8s.io/kube-controller-manager
-    name: release-1.16
-    go: 1.13.15
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.16
-    - repository: component-base
-      branch: release-1.16
-    - repository: api
-      branch: release-1.16
-    - repository: client-go
-      branch: release-13.0
-  - source:
       branch: release-1.17
       dir: staging/src/k8s.io/kube-controller-manager
     name: release-1.17
@@ -1284,16 +1052,6 @@ rules:
     - repository: api
       branch: master
   - source:
-      branch: release-1.16
-      dir: staging/src/k8s.io/cluster-bootstrap
-    name: release-1.16
-    go: 1.13.15
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.16
-    - repository: api
-      branch: release-1.16
-  - source:
       branch: release-1.17
       dir: staging/src/k8s.io/cluster-bootstrap
     name: release-1.17
@@ -1346,20 +1104,6 @@ rules:
       branch: master
     - repository: controller-manager
       branch: master
-  - source:
-      branch: release-1.16
-      dir: staging/src/k8s.io/csi-translation-lib
-    name: release-1.16
-    go: 1.13.15
-    dependencies:
-    - repository: api
-      branch: release-1.16
-    - repository: apimachinery
-      branch: release-1.16
-    - repository: client-go
-      branch: release-13.0
-    - repository: cloud-provider
-      branch: release-1.16
   - source:
       branch: release-1.17
       dir: staging/src/k8s.io/csi-translation-lib
@@ -1430,26 +1174,6 @@ rules:
     - repository: controller-manager
       branch: master
   - source:
-      branch: release-1.16
-      dir: staging/src/k8s.io/legacy-cloud-providers
-    name: release-1.16
-    go: 1.13.15
-    dependencies:
-    - repository: api
-      branch: release-1.16
-    - repository: apimachinery
-      branch: release-1.16
-    - repository: client-go
-      branch: release-13.0
-    - repository: cloud-provider
-      branch: release-1.16
-    - repository: csi-translation-lib
-      branch: release-1.16
-    - repository: apiserver
-      branch: release-1.16
-    - repository: component-base
-      branch: release-1.16
-  - source:
       branch: release-1.17
       dir: staging/src/k8s.io/legacy-cloud-providers
     name: release-1.17
@@ -1514,20 +1238,6 @@ rules:
   library: true
   branches:
   - source:
-      branch: release-1.16
-      dir: staging/src/k8s.io/node-api
-    name: release-1.16
-    go: 1.13.15
-    dependencies:
-    - repository: api
-      branch: release-1.16
-    - repository: apimachinery
-      branch: release-1.16
-    - repository: client-go
-      branch: release-13.0
-    - repository: code-generator
-      branch: release-1.16
-  - source:
       branch: release-1.17
       dir: staging/src/k8s.io/node-api
     name: release-1.17
@@ -1549,11 +1259,6 @@ rules:
       branch: master
       dir: staging/src/k8s.io/cri-api
     name: master
-  - source:
-      branch: release-1.16
-      dir: staging/src/k8s.io/cri-api
-    name: release-1.16
-    go: 1.13.15
   - source:
       branch: release-1.17
       dir: staging/src/k8s.io/cri-api
@@ -1592,26 +1297,6 @@ rules:
       branch: master
     - repository: metrics
       branch: master
-  - source:
-      branch: release-1.16
-      dir: staging/src/k8s.io/kubectl
-    name: release-1.16
-    go: 1.13.15
-    dependencies:
-    - repository: api
-      branch: release-1.16
-    - repository: apimachinery
-      branch: release-1.16
-    - repository: cli-runtime
-      branch: release-1.16
-    - repository: client-go
-      branch: release-13.0
-    - repository: code-generator
-      branch: release-1.16
-    - repository: component-base
-      branch: release-1.16
-    - repository: metrics
-      branch: release-1.16
   - source:
       branch: release-1.17
       dir: staging/src/k8s.io/kubectl


### PR DESCRIPTION
1.16 is no longer supported.

/kind cleanup
/assign @dims 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

