### PR TITLE
fix-todo-in-pkg/util/taints

### DIFF
--- a/pkg/util/taints/taints.go
+++ b/pkg/util/taints/taints.go
@@ -131,8 +131,8 @@ func ReorganizeTaints(node *v1.Node, overwrite bool, taintsToAdd []v1.Taint, tai
 	newTaints := append([]v1.Taint{}, taintsToAdd...)
 	oldTaints := node.Spec.Taints
 	// add taints that already existing but not updated to newTaints
-	addedTaints, added := addedTaints(oldTaints, newTaints)
-	newTaints = append(newTaints, addedTaints...)
+	existedTaints, added := addedTaints(oldTaints, append([]v1.Taint{}, taintsToAdd...))
+	newTaints = append(existedTaints, newTaints...)
 	allErrs, deleted := deleteTaints(taintsToRemove, &newTaints)
 	if (added && deleted) || overwrite {
 		return MODIFIED, newTaints, utilerrors.NewAggregate(allErrs)

--- a/pkg/util/taints/taints.go
+++ b/pkg/util/taints/taints.go
@@ -132,7 +132,7 @@ func ReorganizeTaints(node *v1.Node, overwrite bool, taintsToAdd []v1.Taint, tai
 	oldTaints := node.Spec.Taints
 	// add taints that already existing but not updated to newTaints
 	existedTaints, added := addedTaints(oldTaints, append([]v1.Taint{}, taintsToAdd...))
-	newTaints = append(existedTaints, newTaints...)
+	newTaints = append(newTaints, existedTaints...)
 	allErrs, deleted := deleteTaints(taintsToRemove, &newTaints)
 	if (added && deleted) || overwrite {
 		return MODIFIED, newTaints, utilerrors.NewAggregate(allErrs)


### PR DESCRIPTION

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:
Found a todo and want to fix it.
// TODO: This needs a rewrite to take only the new values instead of appended newTaints list to be consistent.


**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
I did my best to not change the original code to avoid errors.

Do I need to create an Issues first？

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

# Test 
```bash
ArideMacBook-Air:kubernetes abser$ make test WHAT=./pkg/util/taints
WARNING: ulimit -n (files) should be at least 1000, is 256, may cause test failure
+++ [1017 00:52:00] Running tests without code coverage
ok  	k8s.io/kubernetes/pkg/util/taints	3.352s
```