### PR TITLE
e2e don't use hardcoded name for containers name

### DIFF
--- a/test/e2e/network/dns_common.go
+++ b/test/e2e/network/dns_common.go
@@ -128,7 +128,7 @@ func (t *dnsTestCommon) runDig(dnsName, target string) []string {
 		Command:       cmd,
 		Namespace:     t.f.Namespace.Name,
 		PodName:       t.utilPod.Name,
-		ContainerName: "util",
+		ContainerName: t.utilPod.Spec.Containers[0].Name,
 		CaptureStdout: true,
 		CaptureStderr: true,
 	})


### PR DESCRIPTION
The e2e code was refactored to use the agnhost pod constructor, but doing this we've lost the container names, because the constructors creates all the containers with the same name ??`agnhost-continer`??

The DNS configmap tests were using the previous containername, that no longer exist, hence all the tests fail.

We avoid hardcoding the container name in the tests, and get it directly from the Spec.Container[0].Name

```release-note
NONE
```

Fixes: #95671