### PR TITLE
client-go/tools: kubectl port-forward should stop when an error occur

### DIFF
--- a/staging/src/k8s.io/client-go/tools/portforward/portforward.go
+++ b/staging/src/k8s.io/client-go/tools/portforward/portforward.go
@@ -23,6 +23,7 @@ import (
 	"io/ioutil"
 	"net"
 	"net/http"
+	"os"
 	"sort"
 	"strconv"
 	"strings"
@@ -398,6 +399,7 @@ func (pf *PortForwarder) handleConnection(conn net.Conn, port ForwardedPort) {
 	err = <-errorChan
 	if err != nil {
 		runtime.HandleError(err)
+		os.Exit(1)
 	}
 }
 


### PR DESCRIPTION
Currently, if kubectl port-forward trigger an error during execution
it won't come back and will keep consuming resources forwarding
a port to an non existent container id.
   
Example of scenario:
An user deleted a pod which was receiving connections
from port 8080 and forwarding to 80 port. After the container
were terminated, there is no http service available for
forwarding as the container id was gone. The users will receive
the following message while the kubectl still working for
port-forwarding: "Error: No such container: abcd123"
    
This patch adds the possibility to kubectl exists if an error occur.
    
Reference: https://github.com/kubernetes/kubectl/issues/686
    
Signed-off-by: Douglas Schilling Landgraf <dougsland@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This patch adds the possibility to kubectl portforward exists if an error occur.

**Which issue(s) this PR fixes**:
Fixes #https://github.com/kubernetes/kubectl/issues/686

**Special notes for your reviewer**:
I am open for others solutions.

**Does this PR introduce a user-facing change?**:
"NONE"