### PR TITLE
staging/publishing: cleanup import restrictions for csi-translation-lib

### DIFF
--- a/staging/publishing/import-restrictions.yaml
+++ b/staging/publishing/import-restrictions.yaml
@@ -248,7 +248,6 @@
   - k8s.io/api
   - k8s.io/apimachinery
   - k8s.io/klog
-  - k8s.io/cloud-provider
   - k8s.io/csi-translation-lib
 
 - baseImportPath: "./vendor/k8s.io/component-helpers/"


### PR DESCRIPTION
Follow up of https://github.com/kubernetes/kubernetes/pull/95543

/area code-organization
/kind cleanup
/cc @dims @cici37 @wawa0210 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

