### PR TITLE
Log conntrack operations

### DIFF
--- a/pkg/proxy/iptables/proxier.go
+++ b/pkg/proxy/iptables/proxier.go
@@ -1625,11 +1625,13 @@ func (proxier *Proxier) syncProxyRules() {
 
 	// Finish housekeeping.
 	// TODO: these could be made more consistent.
+	klog.V(4).Infof("Deleting stale services IPs: %v", staleServices.UnsortedList())
 	for _, svcIP := range staleServices.UnsortedList() {
 		if err := conntrack.ClearEntriesForIP(proxier.exec, svcIP, v1.ProtocolUDP); err != nil {
 			klog.Errorf("Failed to delete stale service IP %s connections, error: %v", svcIP, err)
 		}
 	}
+	klog.V(4).Infof("Deleting stale endpoint connections: %v", endpointUpdateResult.StaleEndpoints)
 	proxier.deleteEndpointConnections(endpointUpdateResult.StaleEndpoints)
 }
 

--- a/pkg/util/conntrack/BUILD
+++ b/pkg/util/conntrack/BUILD
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//staging/src/k8s.io/api/core/v1:go_default_library",
+        "//vendor/k8s.io/klog/v2:go_default_library",
         "//vendor/k8s.io/utils/exec:go_default_library",
         "//vendor/k8s.io/utils/net:go_default_library",
     ],

--- a/pkg/util/conntrack/conntrack.go
+++ b/pkg/util/conntrack/conntrack.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
 	"k8s.io/utils/exec"
 	utilnet "k8s.io/utils/net"
 )
@@ -62,10 +63,12 @@ func Exec(execer exec.Interface, parameters ...string) error {
 	if err != nil {
 		return fmt.Errorf("error looking for path of conntrack: %v", err)
 	}
+	klog.V(4).Infof("Clearing conntrack entries %v", parameters)
 	output, err := execer.Command(conntrackPath, parameters...).CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("conntrack command returned: %q, error message: %s", string(output), err)
 	}
+	klog.V(4).Infof("Conntrack entries deleted %s", string(output))
 	return nil
 }
 


### PR DESCRIPTION
/kind cleanup
/kind flake

```release-note
UDP and SCTP protocols can left stale connections that need to be cleared to avoid services disruption, but they can cause problems that are hard to debug.
Kubernetes components using a loglevel greater or equal than 4 will log the conntrack operations and its output, to show the entries that were deleted.
```

xref: https://github.com/kubernetes/kubernetes/issues/91236