### PR TITLE
ipset: Address a TODO, add test for netmask

### DIFF
--- a/pkg/util/ipset/ipset_test.go
+++ b/pkg/util/ipset/ipset_test.go
@@ -1457,8 +1457,7 @@ func TestValidateEntry(t *testing.T) {
 				IP:       "10.20.30.40",
 				Protocol: ProtocolTCP,
 				Port:     53,
-				// TODO: CIDR /32 may not be valid
-				Net: "10.20.30.0/24",
+				Net:      "10.20.30.0/24",
 			},
 			set: &IPSet{
 				Name: "abc",
@@ -1567,6 +1566,58 @@ func TestValidateEntry(t *testing.T) {
 			},
 			set: &IPSet{
 				Name: "negative-port-number",
+			},
+			valid: false,
+		},
+		{ // case[30]
+			entry: &Entry{
+				SetType:  HashIPPortNet,
+				IP:       "10.20.30.40",
+				Protocol: ProtocolTCP,
+				Port:     53,
+				Net:      "192.168.3.0/0",
+			},
+			set: &IPSet{
+				Name: "net mask boundary 0",
+			},
+			valid: true,
+		},
+		{ // case[31]
+			entry: &Entry{
+				SetType:  HashIPPortNet,
+				IP:       "10.20.30.40",
+				Protocol: ProtocolTCP,
+				Port:     53,
+				Net:      "192.168.3.0/32",
+			},
+			set: &IPSet{
+				Name: "net mask boundary 32",
+			},
+			valid: true,
+		},
+		{ // case[32]
+			entry: &Entry{
+				SetType:  HashIPPortNet,
+				IP:       "10.20.30.40",
+				Protocol: ProtocolTCP,
+				Port:     53,
+				Net:      "192.168.3.1/33",
+			},
+			set: &IPSet{
+				Name: "invalid net mask",
+			},
+			valid: false,
+		},
+		{ // case[33]
+			entry: &Entry{
+				SetType:  HashIPPortNet,
+				IP:       "10.20.30.40",
+				Protocol: ProtocolTCP,
+				Port:     53,
+				Net:      "192.168.3.1/-1",
+			},
+			set: &IPSet{
+				Name: "invalid net mask",
 			},
 			valid: false,
 		},


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
/area test

**What this PR does / why we need it**:
This PR removes a TODO comment by adding some netmask tests. The TODO comment
introduced by commit e768924a6269 "validate entry in ipset".

```
// TODO: CIDR /32 may not be valid
```

The comment says that 32 is invalid netmask, but in reality values ​​from 0 to
32 are valid because the result of the Linux ipset command says so.

```
$ sudo ipset create foo hash:ip,port,net
$ sudo ipset add foo 10.20.30.40,53,192.168.3.1/33
ipset v7.5: Syntax error: '33' is out of range 0-32
$ sudo ipset --version
ipset v7.5, protocol version: 7
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs
NONE
```
