### PR TITLE
Promote ReplicationController lifecycle test - +7 endpoint coverage

### DIFF
--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -1260,6 +1260,13 @@
     namespace quota. The creation MUST fail
   release: v1.15
   file: test/e2e/apps/rc.go
+- testname: Replication Controller, lifecycle
+  codename: '[sig-apps] ReplicationController should test the lifecycle of a ReplicationController
+    [Conformance]'
+  description: A Replication Controller (RC) is created, read, patched, and deleted
+    with verification.
+  release: v1.20
+  file: test/e2e/apps/rc.go
 - testname: StatefulSet, Burst Scaling
   codename: '[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
     Burst scaling should run to completion even with unhealthy pods [Slow] [Conformance]'

--- a/test/e2e/apps/rc.go
+++ b/test/e2e/apps/rc.go
@@ -99,7 +99,12 @@ var _ = SIGDescribe("ReplicationController", func() {
 		testRCReleaseControlledNotMatching(f)
 	})
 
-	ginkgo.It("[Flaky] should test the lifecycle of a ReplicationController", func() {
+	/*
+		Release: v1.20
+		Testname: Replication Controller, lifecycle
+		Description: A Replication Controller (RC) is created, read, patched, and deleted with verification.
+	*/
+	framework.ConformanceIt("should test the lifecycle of a ReplicationController", func() {
 		testRcName := "rc-test"
 		testRcNamespace := ns
 		testRcInitialReplicaCount := int32(1)


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it:**
This PR adds a test to test the following untested endpoints:
getApiregistrationAPIGroup
replaceCoreV1NamespacedReplicationControllerStatus
readCoreV1NamespacedReplicationControllerStatus
patchCoreV1NamespacedReplicationControllerStatus
patchCoreV1NamespacedReplicationControllerScale
patchCoreV1NamespacedReplicationController
listCoreV1ReplicationControllerForAllNamespaces
deleteCoreV1CollectionNamespacedReplicationController

**Which issue(s) this PR fixes:**
Fixes #90881

**Testgrid Link:**
[Testgrid](https://testgrid.k8s.io/google-gce#gci-gce-flaky&include-filter-by-regex=should%20test%20the%20lifecycle%20of%20a%20ReplicationController)

**Special notes for your reviewer:**
Adds +7 endpoint test coverage (good for conformance)

**Does this PR introduce a user-facing change?:**
```
NONE

```

**Release note:**
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:**
```
NONE

```

/sig testing
/sig architecture
/area conformance