### PR TITLE
k8s support basic auth for etcd v3

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/storage/objectreader.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/storage/objectreader.go
@@ -118,7 +118,9 @@ func GetEtcdClients(config storagebackend.TransportConfig) (*clientv3.Client, cl
 		DialOptions: []grpc.DialOption{
 			grpc.WithBlock(), // block until the underlying connection is up
 		},
-		TLS: tlsConfig,
+		TLS:      tlsConfig,
+		Username: config.Username,
+		Password: config.Password,
 	}
 
 	c, err := clientv3.New(cfg)

--- a/staging/src/k8s.io/apiserver/pkg/server/options/etcd.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/etcd.go
@@ -165,6 +165,12 @@ func (s *EtcdOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&s.StorageConfig.Transport.TrustedCAFile, "etcd-cafile", s.StorageConfig.Transport.TrustedCAFile,
 		"SSL Certificate Authority file used to secure etcd communication.")
 
+	fs.StringVar(&s.StorageConfig.Transport.Username, "etcd-username", s.StorageConfig.Transport.Username,
+		"Username to use for etcd v3 BasicAuth.")
+
+	fs.StringVar(&s.StorageConfig.Transport.Password, "etcd-password", s.StorageConfig.Transport.Password,
+		"Password to use for etcd v3 BasicAuth.")
+
 	fs.StringVar(&s.EncryptionProviderConfigFilepath, "experimental-encryption-provider-config", s.EncryptionProviderConfigFilepath,
 		"The file containing configuration for encryption providers to be used for storing secrets in etcd")
 	fs.MarkDeprecated("experimental-encryption-provider-config", "use --encryption-provider-config.")

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/testing/test_server.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/testing/test_server.go
@@ -303,3 +303,22 @@ func NewUnsecuredEtcd3TestClientServer(t *testing.T) (*EtcdTestServer, *storageb
 	}
 	return server, config
 }
+
+// NewBasicAuthEtcd3TestClientServer creates a new client and server for testing
+func NewBasicAuthEtcd3TestClientServer(t *testing.T) (*EtcdTestServer, *storagebackend.Config) {
+	server := &EtcdTestServer{
+		v3Cluster: integration.NewClusterV3(t, &integration.ClusterConfig{Size: 1}),
+	}
+	server.V3Client = server.v3Cluster.RandClient()
+	config := &storagebackend.Config{
+		Type:   "etcd3",
+		Prefix: PathPrefix(),
+		Transport: storagebackend.TransportConfig{
+			ServerList: server.V3Client.Endpoints(),
+			Username:   server.V3Client.Username,
+			Password:   server.V3Client.Password,
+		},
+		Paging: true,
+	}
+	return server, config
+}

--- a/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/config.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/config.go
@@ -40,6 +40,9 @@ type TransportConfig struct {
 	KeyFile       string
 	CertFile      string
 	TrustedCAFile string
+	// BasicAuth
+	Username string
+	Password string
 	// function to determine the egress dialer. (i.e. konnectivity server dialer)
 	EgressLookup egressselector.Lookup
 }

--- a/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/factory/etcd3.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/factory/etcd3.go
@@ -148,6 +148,8 @@ func newETCD3Client(c storagebackend.TransportConfig) (*clientv3.Client, error) 
 		DialOptions:          dialOptions,
 		Endpoints:            c.ServerList,
 		TLS:                  tlsConfig,
+		Username:             c.Username,
+		Password:             c.Password,
 	}
 
 	return clientv3.New(cfg)


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:
for security, we need support basic auth for etcd

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
add two options: 

--etcd-username: Username to use for etcd v3 BasicAuth

--etcd-password: Password to use for etcd v3 BasicAuth

```

