### PR TITLE
PV Controller: Add plugin name and volume mode to PV metrics

### DIFF
--- a/pkg/controller/volume/persistentvolume/metrics/BUILD
+++ b/pkg/controller/volume/persistentvolume/metrics/BUILD
@@ -6,6 +6,7 @@ go_library(
     importpath = "k8s.io/kubernetes/pkg/controller/volume/persistentvolume/metrics",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/volume:go_default_library",
         "//pkg/volume/util:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/component-base/metrics:go_default_library",

--- a/pkg/controller/volume/persistentvolume/pv_controller_base.go
+++ b/pkg/controller/volume/persistentvolume/pv_controller_base.go
@@ -317,7 +317,7 @@ func (ctrl *PersistentVolumeController) Run(stopCh <-chan struct{}) {
 	go wait.Until(ctrl.volumeWorker, time.Second, stopCh)
 	go wait.Until(ctrl.claimWorker, time.Second, stopCh)
 
-	metrics.Register(ctrl.volumes.store, ctrl.claims)
+	metrics.Register(ctrl.volumes.store, ctrl.claims, &ctrl.volumePluginMgr)
 
 	<-stopCh
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
The PV Controller contains pv_collector_(un)bound_pv_count metrics that count nubmer of PVs by the StorageName. The StorageName is however not that important information when monitoring larger number of clusters since it doesn't really determine the type of storage. The PR makes this metric more informative by adding also the plugin name and volume mode to the metric.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
There is a new pv_collector_total_pv_count metric that counts persistent volumes by the volume plugin name and volume mode.
```