### PR TITLE
Automated cherry pick of #95260: Fixes high CPU usage in kubectl drain

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/drain/drain.go
+++ b/staging/src/k8s.io/kubectl/pkg/drain/drain.go
@@ -250,7 +250,6 @@ func (d *Helper) evictPods(pods []corev1.Pod, policyGroupVersion string, getPodF
 			if err != nil {
 				errors = append(errors, err)
 			}
-		default:
 		}
 	}
 


### PR DESCRIPTION
Cherry pick of #95260 on release-1.17.

#95260: Fixes high CPU usage in kubectl drain

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.