### PR TITLE
Fix #95429. Add response status metrics on kubelet server.

### DIFF
--- a/pkg/kubelet/server/metrics/metrics.go
+++ b/pkg/kubelet/server/metrics/metrics.go
@@ -40,7 +40,7 @@ var (
 		// server_type aims to differentiate the readonly server and the readwrite server.
 		// long_running marks whether the request is long-running or not.
 		// Currently, long-running requests include exec/attach/portforward/debug.
-		[]string{"method", "path", "server_type", "long_running"},
+		[]string{"method", "path", "server_type", "long_running", "code"},
 	)
 	// HTTPRequestsDuration tracks the duration in seconds to serve http requests.
 	HTTPRequestsDuration = metrics.NewHistogramVec(
@@ -52,7 +52,7 @@ var (
 			Buckets:        metrics.DefBuckets,
 			StabilityLevel: metrics.ALPHA,
 		},
-		[]string{"method", "path", "server_type", "long_running"},
+		[]string{"method", "path", "server_type", "long_running", "code"},
 	)
 	// HTTPInflightRequests tracks the number of the inflight http requests.
 	HTTPInflightRequests = metrics.NewGaugeVec(
@@ -62,7 +62,7 @@ var (
 			Help:           "Number of the inflight http requests",
 			StabilityLevel: metrics.ALPHA,
 		},
-		[]string{"method", "path", "server_type", "long_running"},
+		[]string{"method", "path", "server_type", "long_running", "code"},
 	)
 )
 

--- a/pkg/kubelet/server/server.go
+++ b/pkg/kubelet/server/server.go
@@ -924,13 +924,13 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 
 	longRunning := strconv.FormatBool(isLongRunningRequest(path))
 
-	servermetrics.HTTPRequests.WithLabelValues(method, path, serverType, longRunning).Inc()
+	servermetrics.HTTPRequests.WithLabelValues(method, path, serverType, longRunning, strconv.Itoa(http.StatusOK)).Inc()
 
-	servermetrics.HTTPInflightRequests.WithLabelValues(method, path, serverType, longRunning).Inc()
-	defer servermetrics.HTTPInflightRequests.WithLabelValues(method, path, serverType, longRunning).Dec()
+	servermetrics.HTTPInflightRequests.WithLabelValues(method, path, serverType, longRunning, strconv.Itoa(http.StatusOK)).Inc()
+	defer servermetrics.HTTPInflightRequests.WithLabelValues(method, path, serverType, longRunning, strconv.Itoa(http.StatusOK)).Dec()
 
 	startTime := time.Now()
-	defer servermetrics.HTTPRequestsDuration.WithLabelValues(method, path, serverType, longRunning).Observe(servermetrics.SinceInSeconds(startTime))
+	defer servermetrics.HTTPRequestsDuration.WithLabelValues(method, path, serverType, longRunning, strconv.Itoa(http.StatusOK)).Observe(servermetrics.SinceInSeconds(startTime))
 
 	handler.ServeHTTP(w, req)
 }


### PR DESCRIPTION
Fixes #95429

