### PR TITLE
Use host IP instead of 127.0.0.1 for kube-apiserver healthcheck.

### DIFF
--- a/cluster/gce/config-default.sh
+++ b/cluster/gce/config-default.sh
@@ -539,7 +539,11 @@ export KONNECTIVITY_SERVICE_PROXY_PROTOCOL_MODE="${KUBE_KONNECTIVITY_SERVICE_PRO
 # Optional: Enable Windows CSI-Proxy
 export ENABLE_CSI_PROXY="${ENABLE_CSI_PROXY:-true}"
 
-# ETCD_LISTEN_ON_HOST_IP decides whether etcd servers should also listen on host IP,
+# KUBE_APISERVER_HEALTHCHECK_ON_HOST_IP decides whether
+# kube-apiserver is healthchecked on host IP instead of 127.0.0.1.
+export KUBE_APISERVER_HEALTHCHECK_ON_HOST_IP="${KUBE_APISERVER_HEALTHCHECK_ON_HOST_IP:-false}"
+
+# ETCD_LISTEN_ON_HOST_IP decides whether etcd servers should also listen on host IP, 
 # in addition to listening to 127.0.0.1, and whether kube-apiserver should connect to etcd servers
 # through host IP.
 export ETCD_LISTEN_ON_HOST_IP="${ETCD_LISTEN_ON_HOST_IP:-false}"

--- a/cluster/gce/config-test.sh
+++ b/cluster/gce/config-test.sh
@@ -575,7 +575,11 @@ export GCE_UPLOAD_KUBCONFIG_TO_MASTER_METADATA=true
 # Optoinal: Enable Windows CSI-Proxy
 export ENABLE_CSI_PROXY="${ENABLE_CSI_PROXY:-true}"
 
-# ETCD_LISTEN_ON_HOST_IP decides whether etcd servers should also listen on host IP,
+# KUBE_APISERVER_HEALTHCHECK_ON_HOST_IP decides whether
+# kube-apiserver is healthchecked on host IP instead of 127.0.0.1.
+export KUBE_APISERVER_HEALTHCHECK_ON_HOST_IP="${KUBE_APISERVER_HEALTHCHECK_ON_HOST_IP:-false}"
+
+# ETCD_LISTEN_ON_HOST_IP decides whether etcd servers should also listen on host IP, 
 # in addition to listening to 127.0.0.1, and whether kube-apiserver should connect to etcd servers
 # through host IP.
 export ETCD_LISTEN_ON_HOST_IP="${ETCD_LISTEN_ON_HOST_IP:-false}"

--- a/cluster/gce/gci/configure-kubeapiserver.sh
+++ b/cluster/gce/gci/configure-kubeapiserver.sh
@@ -374,6 +374,11 @@ function start-kube-apiserver {
   # params is passed by reference, so no "$"
   setup-etcd-encryption "${src_file}" params
 
+  local healthcheck_ip="127.0.0.1"
+  if [[ ${KUBE_APISERVER_HEALTHCHECK_ON_HOST_IP:-} == "true" ]]; then
+    healthcheck_ip=$(hostname -i)
+  fi
+
   params="$(convert-manifest-params "${params}")"
   # Evaluate variables.
   local -r kube_apiserver_docker_tag="${KUBE_API_SERVER_DOCKER_TAG:-$(cat /home/kubernetes/kube-docker-files/kube-apiserver.docker_tag)}"
@@ -404,6 +409,7 @@ function start-kube-apiserver {
   sed -i -e "s@{{webhook_exec_auth_plugin_volume}}@${webhook_exec_auth_plugin_volume}@g" "${src_file}"
   sed -i -e "s@{{konnectivity_socket_mount}}@${default_konnectivity_socket_mnt}@g" "${src_file}"
   sed -i -e "s@{{konnectivity_socket_volume}}@${default_konnectivity_socket_vol}@g" "${src_file}"
+  sed -i -e "s@{{healthcheck_ip}}@${healthcheck_ip}@g" "${src_file}"
 
   cp "${src_file}" "${ETC_MANIFESTS:-/etc/kubernetes/manifests}"
 }

--- a/cluster/gce/manifests/kube-apiserver.manifest
+++ b/cluster/gce/manifests/kube-apiserver.manifest
@@ -37,7 +37,7 @@
     "livenessProbe": {
       "httpGet": {
         "scheme": "HTTPS",
-        "host": "127.0.0.1",
+        "host": "{{healthcheck_ip}}",
         "port": {{secure_port}},
         "path": "/livez?exclude=etcd&exclude=kms-provider-0&exclude=kms-provider-1"
       },
@@ -47,7 +47,7 @@
     "readinessProbe": {
       "httpGet": {
         "scheme": "HTTPS",
-        "host": "127.0.0.1",
+        "host": "{{healthcheck_ip}}",
         "port": {{secure_port}},
         "path": "/readyz"
       },


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
This change allows GKE kube-apiserver to be healthchecked on host IP instead of 127.0.0.1.
This is a part of a bigger change to isolate kube-apiserver into its own network namespace, 
which requires control plane Pods to not use loopback interface.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
