### PR TITLE
Fix default values for logrotate in /var/log/

### DIFF
--- a/cluster/gce/config-default.sh
+++ b/cluster/gce/config-default.sh
@@ -427,7 +427,7 @@ METADATA_CLOBBERS_CONFIG="${METADATA_CLOBBERS_CONFIG:-false}"
 ENABLE_BIG_CLUSTER_SUBNETS="${ENABLE_BIG_CLUSTER_SUBNETS:-false}"
 
 # Optional: Enable log rotation for k8s services
-ENABLE_LOGROTATE_FILES="${ENABLE_LOGROTATE_FILES:-false}"
+ENABLE_LOGROTATE_FILES="${ENABLE_LOGROTATE_FILES:-true}"
 PROVIDER_VARS="${PROVIDER_VARS:-} ENABLE_LOGROTATE_FILES"
 if [[ -n "${LOGROTATE_FILES_MAX_COUNT:-}" ]]; then
   PROVIDER_VARS="${PROVIDER_VARS:-} LOGROTATE_FILES_MAX_COUNT"
@@ -525,7 +525,7 @@ export KONNECTIVITY_SERVICE_PROXY_PROTOCOL_MODE="${KUBE_KONNECTIVITY_SERVICE_PRO
 # Optional: Enable Windows CSI-Proxy
 export ENABLE_CSI_PROXY="${ENABLE_CSI_PROXY:-true}"
 
-# ETCD_LISTEN_ON_HOST_IP decides whether etcd servers should also listen on host IP, 
+# ETCD_LISTEN_ON_HOST_IP decides whether etcd servers should also listen on host IP,
 # in addition to listening to 127.0.0.1, and whether kube-apiserver should connect to etcd servers
 # through host IP.
 export ETCD_LISTEN_ON_HOST_IP="${ETCD_LISTEN_ON_HOST_IP:-false}"

--- a/cluster/gce/config-test.sh
+++ b/cluster/gce/config-test.sh
@@ -469,7 +469,7 @@ ADVANCED_AUDIT_LOG_MODE=${ADVANCED_AUDIT_LOG_MODE:-batch} # batch, blocking
 ENABLE_BIG_CLUSTER_SUBNETS=${ENABLE_BIG_CLUSTER_SUBNETS:-false}
 
 # Optional: Enable log rotation for k8s services
-ENABLE_LOGROTATE_FILES="${ENABLE_LOGROTATE_FILES:-false}"
+ENABLE_LOGROTATE_FILES="${ENABLE_LOGROTATE_FILES:-true}"
 PROVIDER_VARS="${PROVIDER_VARS:-} ENABLE_LOGROTATE_FILES"
 if [[ -n "${LOGROTATE_FILES_MAX_COUNT:-}" ]]; then
   PROVIDER_VARS="${PROVIDER_VARS:-} LOGROTATE_FILES_MAX_COUNT"
@@ -572,7 +572,7 @@ export GCE_UPLOAD_KUBCONFIG_TO_MASTER_METADATA=true
 # Optoinal: Enable Windows CSI-Proxy
 export ENABLE_CSI_PROXY="${ENABLE_CSI_PROXY:-true}"
 
-# ETCD_LISTEN_ON_HOST_IP decides whether etcd servers should also listen on host IP, 
+# ETCD_LISTEN_ON_HOST_IP decides whether etcd servers should also listen on host IP,
 # in addition to listening to 127.0.0.1, and whether kube-apiserver should connect to etcd servers
 # through host IP.
 export ETCD_LISTEN_ON_HOST_IP="${ETCD_LISTEN_ON_HOST_IP:-false}"

--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -502,7 +502,7 @@ function ensure-local-ssds-ephemeral-storage() {
 function setup-logrotate() {
   mkdir -p /etc/logrotate.d/
 
-  if [[ "${ENABLE_LOGROTATE_FILES:-false}" = "true" ]]; then
+  if [[ "${ENABLE_LOGROTATE_FILES:-true}" = "true" ]]; then
     # Configure log rotation for all logs in /var/log, which is where k8s services
     # are configured to write their log files. Whenever logrotate is ran, this
     # config will:


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Fix issues introduced in [#93781](https://github.com/kubernetes/kubernetes/pull/93781), that logs in `/var/log` weren't rotated.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```