### PR TITLE
webhook config manager: HasSynced returns true when the manager is synced with existing webhookconfig objects at startup

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/admission/configuration/mutating_webhook_manager.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/configuration/mutating_webhook_manager.go
@@ -36,6 +36,11 @@ type mutatingWebhookConfigurationManager struct {
 	configuration *atomic.Value
 	lister        admissionregistrationlisters.MutatingWebhookConfigurationLister
 	hasSynced     func() bool
+	// initialConfigurationSynced stores a boolean value, which tracks if
+	// the existing webhook configs have been synced (honored) by the
+	// manager at startup-- the informer has synced and either has no items
+	// or has finished executing updateConfiguration() once.
+	initialConfigurationSynced *atomic.Value
 }
 
 var _ generic.Source = &mutatingWebhookConfigurationManager{}
@@ -43,13 +48,15 @@ var _ generic.Source = &mutatingWebhookConfigurationManager{}
 func NewMutatingWebhookConfigurationManager(f informers.SharedInformerFactory) generic.Source {
 	informer := f.Admissionregistration().V1().MutatingWebhookConfigurations()
 	manager := &mutatingWebhookConfigurationManager{
-		configuration: &atomic.Value{},
-		lister:        informer.Lister(),
-		hasSynced:     informer.Informer().HasSynced,
+		configuration:              &atomic.Value{},
+		lister:                     informer.Lister(),
+		hasSynced:                  informer.Informer().HasSynced,
+		initialConfigurationSynced: &atomic.Value{},
 	}
 
 	// Start with an empty list
 	manager.configuration.Store([]webhook.WebhookAccessor{})
+	manager.initialConfigurationSynced.Store(false)
 
 	// On any change, rebuild the config
 	informer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
@@ -66,8 +73,27 @@ func (m *mutatingWebhookConfigurationManager) Webhooks() []webhook.WebhookAccess
 	return m.configuration.Load().([]webhook.WebhookAccessor)
 }
 
+// HasSynced returns true when the manager is synced with existing webhookconfig
+// objects at startup-- which means the informer is synced and either has no items
+// or updateConfiguration() has completed.
 func (m *mutatingWebhookConfigurationManager) HasSynced() bool {
-	return m.hasSynced()
+	if !m.hasSynced() {
+		return false
+	}
+	if m.initialConfigurationSynced.Load().(bool) {
+		// the informer has synced and configuration has been updated
+		return true
+	}
+	if configurations, err := m.lister.List(labels.Everything()); err == nil && len(configurations) == 0 {
+		// the empty list we initially stored is valid to use.
+		// Setting initialConfigurationSynced to true, so subsequent checks
+		// would be able to take the fast path on the atomic boolean in a
+		// cluster without any admission webhooks configured.
+		m.initialConfigurationSynced.Store(true)
+		// the informer has synced and we don't have any items
+		return true
+	}
+	return false
 }
 
 func (m *mutatingWebhookConfigurationManager) updateConfiguration() {
@@ -77,6 +103,7 @@ func (m *mutatingWebhookConfigurationManager) updateConfiguration() {
 		return
 	}
 	m.configuration.Store(mergeMutatingWebhookConfigurations(configurations))
+	m.initialConfigurationSynced.Store(true)
 }
 
 func mergeMutatingWebhookConfigurations(configurations []*v1.MutatingWebhookConfiguration) []webhook.WebhookAccessor {

--- a/staging/src/k8s.io/apiserver/pkg/admission/configuration/validating_webhook_manager.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/configuration/validating_webhook_manager.go
@@ -36,6 +36,11 @@ type validatingWebhookConfigurationManager struct {
 	configuration *atomic.Value
 	lister        admissionregistrationlisters.ValidatingWebhookConfigurationLister
 	hasSynced     func() bool
+	// initialConfigurationSynced stores a boolean value, which tracks if
+	// the existing webhook configs have been synced (honored) by the
+	// manager at startup-- the informer has synced and either has no items
+	// or has finished executing updateConfiguration() once.
+	initialConfigurationSynced *atomic.Value
 }
 
 var _ generic.Source = &validatingWebhookConfigurationManager{}
@@ -43,13 +48,15 @@ var _ generic.Source = &validatingWebhookConfigurationManager{}
 func NewValidatingWebhookConfigurationManager(f informers.SharedInformerFactory) generic.Source {
 	informer := f.Admissionregistration().V1().ValidatingWebhookConfigurations()
 	manager := &validatingWebhookConfigurationManager{
-		configuration: &atomic.Value{},
-		lister:        informer.Lister(),
-		hasSynced:     informer.Informer().HasSynced,
+		configuration:              &atomic.Value{},
+		lister:                     informer.Lister(),
+		hasSynced:                  informer.Informer().HasSynced,
+		initialConfigurationSynced: &atomic.Value{},
 	}
 
 	// Start with an empty list
 	manager.configuration.Store([]webhook.WebhookAccessor{})
+	manager.initialConfigurationSynced.Store(false)
 
 	// On any change, rebuild the config
 	informer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
@@ -66,9 +73,28 @@ func (v *validatingWebhookConfigurationManager) Webhooks() []webhook.WebhookAcce
 	return v.configuration.Load().([]webhook.WebhookAccessor)
 }
 
-// HasSynced returns true if the shared informers have synced.
+// HasSynced returns true when the manager is synced with existing webhookconfig
+// objects at startup-- which means the informer is synced and either has no items
+// or updateConfiguration() has completed.
 func (v *validatingWebhookConfigurationManager) HasSynced() bool {
-	return v.hasSynced()
+	if !v.hasSynced() {
+		return false
+	}
+	if v.initialConfigurationSynced.Load().(bool) {
+		// the informer has synced and configuration has been updated
+		return true
+	}
+	if configurations, err := v.lister.List(labels.Everything()); err == nil && len(configurations) == 0 {
+		// the empty list we initially stored is valid to use.
+		// Setting initialConfigurationSynced to true, so subsequent checks
+		// would be able to take the fast path on the atomic boolean in a
+		// cluster without any admission webhooks configured.
+		v.initialConfigurationSynced.Store(true)
+		// the informer has synced and we don't have any items
+		return true
+	}
+	return false
+
 }
 
 func (v *validatingWebhookConfigurationManager) updateConfiguration() {
@@ -78,6 +104,7 @@ func (v *validatingWebhookConfigurationManager) updateConfiguration() {
 		return
 	}
 	v.configuration.Store(mergeValidatingWebhookConfigurations(configurations))
+	v.initialConfigurationSynced.Store(true)
 }
 
 func mergeValidatingWebhookConfigurations(configurations []*v1.ValidatingWebhookConfiguration) []webhook.WebhookAccessor {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
~~Fix a webhook unittest flake. The test waits for informers to be synced, which guarantees the watch events being sent (the delta fifo queue in the informer has no initial object left), but it doesn't guarantee the webhook configuration manager finishing processing those watch events. Adding a marker to wait for webhook registration, like what we do in the [e2e tests](https://github.com/kubernetes/kubernetes/blob/ededd08ba131b727e60f663bd7217fffaaccd448/test/e2e/apimachinery/webhook.go#L2401-L2404).~~ 

The original race can be reliably reproduced by adding a sleep to the [configuration managers](https://github.com/kubernetes/kubernetes/blob/ededd08ba131b727e60f663bd7217fffaaccd448/staging/src/k8s.io/apiserver/pkg/admission/configuration/validating_webhook_manager.go#L74). 

What happened: webhook config manager `HasSynced()` function returned true if the informer was synced, which could cause requests being allowed without existing webhook configurations being effective at startup. 

[EDIT] Thanks to @liggitt who pointed out that this isn't just a test issue and suggested the proper fix-- on API server startup, the webhook waits to admit anything until it is synced with existing webhookconfig objects, meaning `validatingWebhookConfigurationManager#HasSynced` and `mutatingWebhookConfigurationManager#HasSynced` shouldn't return true until the informer is synced and either has no items or `updateConfiguration()` has completed. This fix guarantees that at no point should requests be allowed into a restarted API server without those previously created webhook configurations being effective. 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #94810, #99911, #100070

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixed a race condition on API server startup ensuring previously created webhook configurations are effective before the first write request is admitted.
```

/sig api-machinery
/cc @sttts