### PR TITLE
Automated cherry pick of #95786: fix: add missing patch flag for kubeadm init phase

### DIFF
--- a/cmd/kubeadm/app/cmd/phases/init/controlplane.go
+++ b/cmd/kubeadm/app/cmd/phases/init/controlplane.go
@@ -101,6 +101,7 @@ func getControlPlanePhaseFlags(name string) []string {
 		options.KubernetesVersion,
 		options.ImageRepository,
 		options.Kustomize,
+		options.Patches,
 	}
 	if name == "all" || name == kubeadmconstants.KubeAPIServer {
 		flags = append(flags,


### PR DESCRIPTION
Cherry pick of #95786 on release-1.19.

#95786: fix: add missing patch flag for kubeadm init phase

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.