### PR TITLE
Bugfix missing rbac policy for kube-scheduler to read policy from configmap

### DIFF
--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
@@ -540,6 +540,7 @@ func ClusterRoles() []rbacv1.ClusterRole {
 
 		// Fundamental resources
 		rbacv1helpers.NewRule(Read...).Groups(legacyGroup).Resources("nodes").RuleOrDie(),
+		rbacv1helpers.NewRule("get").Groups(legacyGroup).Resources("configmaps").RuleOrDie(),
 		rbacv1helpers.NewRule("get", "list", "watch", "delete").Groups(legacyGroup).Resources("pods").RuleOrDie(),
 		rbacv1helpers.NewRule("create").Groups(legacyGroup).Resources("pods/binding", "bindings").RuleOrDie(),
 		rbacv1helpers.NewRule("patch", "update").Groups(legacyGroup).Resources("pods/status").RuleOrDie(),

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-roles.yaml
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-roles.yaml
@@ -744,6 +744,12 @@ items:
   - apiGroups:
     - ""
     resources:
+    - configmaps
+    verbs:
+    - get
+  - apiGroups:
+    - ""
+    resources:
     - pods
     verbs:
     - delete


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
kube-scheduler fails to start when policy is configured in configmap because of permission denied: 
```
I1022 16:25:34.817546       7 server.go:161] Starting Kubernetes Scheduler version v1.15.7-357+tess0-45-9.9ff513aba7a10f
couldn't get policy config map kube-system/kube-scheduler-extender-policy: configmaps "kube-scheduler-extender-policy" is forbidden: User "system:scheduler" cannot get resource "configmaps" in API group "" in the namespace "kube-system"
```
Related code can be found here:
https://github.com/kubernetes/kubernetes/blob/6268e6f990522289a6a2c25db5d9cacc0988171b/pkg/scheduler/scheduler.go#L284

This PR adds the missing `get secret` permission to scheduler so that it can start correctly.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
the bootstrap rbac policy of kube-scheduler

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
