### PR TITLE
Optimize NormalizeScore for PodTopologySpread

### DIFF
--- a/pkg/scheduler/framework/plugins/podtopologyspread/scoring_test.go
+++ b/pkg/scheduler/framework/plugins/podtopologyspread/scoring_test.go
@@ -807,6 +807,11 @@ var (
 			existingPodsNum: 10000,
 			allNodesNum:     1000,
 		},
+		{
+			name:            "5000nodes",
+			existingPodsNum: 50000,
+			allNodesNum:     5000,
+		},
 	}
 )
 


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Optimize NormalizeScore for PodTopologySpread by removing unnecessary map accesses.

Also adds an extra 5k nodes test case in separate commit

Comparisson (in ms)
```
Nodes | Old  | This PR
100   | 0.29 | 0.27
1000  | 1.41 | 1.28
5000  | 4.66 | 3.9
```

**Which issue(s) this PR fixes**:

Ref kubernetes/enhancements#1258

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```