### PR TITLE
Fix a bug that Pods with topologySpreadConstraints get scheduled to nodes without required labels

### DIFF
--- a/pkg/scheduler/framework/plugins/podtopologyspread/filtering.go
+++ b/pkg/scheduler/framework/plugins/podtopologyspread/filtering.go
@@ -285,7 +285,7 @@ func (pl *PodTopologySpread) Filter(ctx context.Context, cycleState *framework.C
 	}
 
 	// However, "empty" preFilterState is legit which tolerates every toSchedule Pod.
-	if len(s.TpPairToMatchNum) == 0 || len(s.Constraints) == 0 {
+	if len(s.Constraints) == 0 {
 		return nil
 	}
 

--- a/pkg/scheduler/framework/plugins/podtopologyspread/filtering_test.go
+++ b/pkg/scheduler/framework/plugins/podtopologyspread/filtering_test.go
@@ -1262,6 +1262,20 @@ func TestSingleConstraint(t *testing.T) {
 			},
 		},
 		{
+			name: "pod cannot be scheduled as all nodes don't have label 'rack'",
+			pod: st.MakePod().Name("p").Label("foo", "").SpreadConstraint(
+				1, "rack", v1.DoNotSchedule, st.MakeLabelSelector().Exists("foo").Obj(),
+			).Obj(),
+			nodes: []*v1.Node{
+				st.MakeNode().Name("node-a").Label("zone", "zone1").Label("node", "node-a").Obj(),
+				st.MakeNode().Name("node-x").Label("zone", "zone2").Label("node", "node-x").Obj(),
+			},
+			wantStatusCode: map[string]framework.Code{
+				"node-a": framework.UnschedulableAndUnresolvable,
+				"node-x": framework.UnschedulableAndUnresolvable,
+			},
+		},
+		{
 			name: "pods spread across nodes as 2/1/0/3, only node-x fits",
 			pod: st.MakePod().Name("p").Label("foo", "").SpreadConstraint(
 				1, "node", v1.DoNotSchedule, st.MakeLabelSelector().Exists("foo").Obj(),


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
/sig scheduling

**What this PR does / why we need it**:

This PR fixes a bug that Pods with topologySpreadConstraints get scheduled to nodes without required labels.

YAML to reproduce this issue:

```yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: foo
spec:
  replicas: 2
  selector:
    matchLabels:
      foo: ""
  template:
    metadata:
      labels:
        foo: ""
    spec:
      topologySpreadConstraints:
      - maxSkew: 1
        topologyKey: rack # special topology key that all nodes doesn't have
        whenUnsatisfiable: DoNotSchedule
        labelSelector:
          matchLabels:
            foo: ""
      containers:
      - name: pause
        image: k8s.gcr.io/pause:3.2
```

Pods are scheduled anyway even if all nodes don't have the label "rack":

```script
# k get po -o wide
NAME                   READY   STATUS    RESTARTS   AGE   IP           NODE           NOMINATED NODE   READINESS GATES
foo-57c5989dcf-vrz9l   1/1     Running   0          73m   10.244.3.3   kind-worker2   <none>           <none>
foo-57c5989dcf-xgs5p   1/1     Running   0          73m   10.244.1.4   kind-worker    <none>           <none>
```

**Which issue(s) this PR fixes**:

Fixes #95808

**Special notes for your reviewer**:

This issue exists in master, 1.19 and 1.18 versions.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
