### PR TITLE
Do not remove non namespaced resources when the namespace is enforced

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/apply/prune.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apply/prune.go
@@ -83,9 +83,11 @@ func (p *pruner) pruneAll(o *ApplyOptions) error {
 			}
 		}
 	}
-	for _, m := range nonNamespacedRESTMappings {
-		if err := p.prune(metav1.NamespaceNone, m); err != nil {
-			return fmt.Errorf("error pruning nonNamespaced object %v: %v", m.GroupVersionKind, err)
+	if !o.EnforceNamespace {
+		for _, m := range nonNamespacedRESTMappings {
+			if err := p.prune(metav1.NamespaceNone, m); err != nil {
+				return fmt.Errorf("error pruning nonNamespaced object %v: %v", m.GroupVersionKind, err)
+			}
 		}
 	}
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Removing non-namespaced resources when the namespace is enforced will
lead to irreversible incidents such as removing other namespaces,
removing PVC, etc.

**Which issue(s) this PR fixes**:

Achieves what this comment doing: https://github.com/kubernetes/kubernetes/issues/74414#issuecomment-702896322

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
`kubectl apply --prune --namespace NS` will not prune non-namespaced resources anymore.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
