### PR TITLE
Optimize string building for NamespacedName

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/types/namespacedname.go
+++ b/staging/src/k8s.io/apimachinery/pkg/types/namespacedname.go
@@ -16,10 +16,6 @@ limitations under the License.
 
 package types
 
-import (
-	"fmt"
-)
-
 // NamespacedName comprises a resource name, with a mandatory namespace,
 // rendered as "<namespace>/<name>".  Being a type captures intent and
 // helps make sure that UIDs, namespaced names and non-namespaced names
@@ -39,5 +35,5 @@ const (
 
 // String returns the general purpose string representation
 func (n NamespacedName) String() string {
-	return fmt.Sprintf("%s%c%s", n.Namespace, Separator, n.Name)
+	return n.Namespace + string(Separator) + n.Name
 }


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind cleanup
-->

**What this PR does / why we need it**:

This applies a microoptimization to the `String()` function of `types.NamespacedName`. It's something we carry around downstream and I don't quite see a reason not to upstream it.

Based on this benchmark

```golang
func BenchmarkNamespacedName(b *testing.B) {
	name := types.NamespacedName{
		Namespace: "test-namespace",
		Name:      "test-name",
	}

	for i := 0; i < b.N; i++ {
		_ = name.String()
	}
}
```

The results are

```
benchmark                      old ns/op     new ns/op     delta
BenchmarkNamespacedName-16     187           18.9          -89.89%

benchmark                      old allocs     new allocs     delta
BenchmarkNamespacedName-16     3              0              -100.00%

benchmark                      old bytes     new bytes     delta
BenchmarkNamespacedName-16     64            0             -100.00%
```

Which is almost too good to be true :joy:. Maybe I'm missing something obvious here.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```