### PR TITLE
scheduler: move percentagesOfNodesToScore to the scheduler profile

### DIFF
--- a/pkg/scheduler/apis/config/types.go
+++ b/pkg/scheduler/apis/config/types.go
@@ -85,6 +85,9 @@ type KubeSchedulerConfiguration struct {
 	// then scheduler stops finding further feasible nodes once it finds 150 feasible ones.
 	// When the value is 0, default percentage (5%--50% based on the size of the cluster) of the
 	// nodes will be scored.
+	// Note: It will be overridden by the profile-level score percentage when that is available.
+	// DEPRECATED: Please use scheduler profiles to configure this instead.
+	// TODO: remove this in v1beta2 (https://github.com/kubernetes/kubernetes/issues/95446)
 	PercentageOfNodesToScore int32
 
 	// PodInitialBackoffSeconds is the initial backoff for unschedulable pods.
@@ -114,6 +117,16 @@ type KubeSchedulerProfile struct {
 	// If SchedulerName matches with the pod's "spec.schedulerName", then the pod
 	// is scheduled with this profile.
 	SchedulerName string
+
+	// PercentageOfNodesToScore is the percentage of all nodes that once found feasible
+	// for running a pod, the scheduler stops its search for more feasible nodes in
+	// the cluster. This helps improve scheduler's performance. Scheduler always tries to find
+	// at least "minFeasibleNodesToFind" feasible nodes no matter what the value of this flag is.
+	// Example: if the cluster size is 500 nodes and the value of this flag is 30,
+	// then scheduler stops finding further feasible nodes once it finds 150 feasible ones.
+	// When the value is 0, adaptative percentage (5%--50% based on the size of the cluster) of the
+	// nodes will be scored.
+	PercentageOfNodesToScore int32
 
 	// Plugins specify the set of plugins that should be enabled or disabled.
 	// Enabled plugins are the ones that should be enabled in addition to the

--- a/pkg/scheduler/apis/config/v1beta1/zz_generated.conversion.go
+++ b/pkg/scheduler/apis/config/v1beta1/zz_generated.conversion.go
@@ -374,6 +374,9 @@ func autoConvert_v1beta1_KubeSchedulerProfile_To_config_KubeSchedulerProfile(in 
 	if err := metav1.Convert_Pointer_string_To_string(&in.SchedulerName, &out.SchedulerName, s); err != nil {
 		return err
 	}
+	if err := metav1.Convert_Pointer_int32_To_int32(&in.PercentageOfNodesToScore, &out.PercentageOfNodesToScore, s); err != nil {
+		return err
+	}
 	if in.Plugins != nil {
 		in, out := &in.Plugins, &out.Plugins
 		*out = new(config.Plugins)
@@ -404,6 +407,9 @@ func Convert_v1beta1_KubeSchedulerProfile_To_config_KubeSchedulerProfile(in *v1b
 
 func autoConvert_config_KubeSchedulerProfile_To_v1beta1_KubeSchedulerProfile(in *config.KubeSchedulerProfile, out *v1beta1.KubeSchedulerProfile, s conversion.Scope) error {
 	if err := metav1.Convert_string_To_Pointer_string(&in.SchedulerName, &out.SchedulerName, s); err != nil {
+		return err
+	}
+	if err := metav1.Convert_int32_To_Pointer_int32(&in.PercentageOfNodesToScore, &out.PercentageOfNodesToScore, s); err != nil {
 		return err
 	}
 	if in.Plugins != nil {

--- a/pkg/scheduler/apis/config/validation/validation.go
+++ b/pkg/scheduler/apis/config/validation/validation.go
@@ -81,6 +81,10 @@ func validateKubeSchedulerProfile(path *field.Path, profile *config.KubeSchedule
 	if len(profile.SchedulerName) == 0 {
 		allErrs = append(allErrs, field.Required(path.Child("schedulerName"), ""))
 	}
+	if profile.PercentageOfNodesToScore < 0 || profile.PercentageOfNodesToScore > 100 {
+		allErrs = append(allErrs, field.Invalid(path.Child("percentageOfNodesToScore"),
+			profile.PercentageOfNodesToScore, "not in valid range [0-100]"))
+	}
 	return allErrs
 }
 

--- a/pkg/scheduler/core/generic_scheduler.go
+++ b/pkg/scheduler/core/generic_scheduler.go
@@ -211,12 +211,15 @@ func (g *genericScheduler) selectHost(nodeScoreList framework.NodeScoreList) (st
 
 // numFeasibleNodesToFind returns the number of feasible nodes that once found, the scheduler stops
 // its search for more feasible nodes.
-func (g *genericScheduler) numFeasibleNodesToFind(numAllNodes int32) (numNodes int32) {
-	if numAllNodes < minFeasibleNodesToFind || g.percentageOfNodesToScore >= 100 {
+func (g *genericScheduler) numFeasibleNodesToFind(prof *profile.Profile, numAllNodes int32) (numNodes int32) {
+	adaptivePercentage := g.percentageOfNodesToScore
+	if prof.PercentageOfNodesToScore != 0 {
+		adaptivePercentage = prof.PercentageOfNodesToScore
+	}
+	if numAllNodes < minFeasibleNodesToFind || adaptivePercentage >= 100 {
 		return numAllNodes
 	}
 
-	adaptivePercentage := g.percentageOfNodesToScore
 	if adaptivePercentage <= 0 {
 		basePercentageOfNodesToScore := int32(50)
 		adaptivePercentage = basePercentageOfNodesToScore - numAllNodes/125
@@ -275,7 +278,7 @@ func (g *genericScheduler) findNodesThatPassFilters(ctx context.Context, prof *p
 		return nil, err
 	}
 
-	numNodesToFind := g.numFeasibleNodesToFind(int32(len(allNodes)))
+	numNodesToFind := g.numFeasibleNodesToFind(prof, int32(len(allNodes)))
 
 	// Create feasible list with enough space to avoid growing it
 	// and allow assigning.

--- a/pkg/scheduler/core/generic_scheduler_test.go
+++ b/pkg/scheduler/core/generic_scheduler_test.go
@@ -1119,39 +1119,53 @@ func TestNumFeasibleNodesToFind(t *testing.T) {
 	tests := []struct {
 		name                     string
 		percentageOfNodesToScore int32
+		prof                     *profile.Profile
 		numAllNodes              int32
 		wantNumNodes             int32
 	}{
 		{
 			name:         "not set percentageOfNodesToScore and nodes number not more than 50",
+			prof:         &profile.Profile{},
 			numAllNodes:  10,
 			wantNumNodes: 10,
 		},
 		{
 			name:                     "set percentageOfNodesToScore and nodes number not more than 50",
 			percentageOfNodesToScore: 40,
+			prof:                     &profile.Profile{},
 			numAllNodes:              10,
 			wantNumNodes:             10,
 		},
 		{
 			name:         "not set percentageOfNodesToScore and nodes number more than 50",
+			prof:         &profile.Profile{},
 			numAllNodes:  1000,
 			wantNumNodes: 420,
 		},
 		{
 			name:                     "set percentageOfNodesToScore and nodes number more than 50",
+			prof:                     &profile.Profile{},
 			percentageOfNodesToScore: 40,
 			numAllNodes:              1000,
 			wantNumNodes:             400,
 		},
 		{
 			name:         "not set percentageOfNodesToScore and nodes number more than 50*125",
+			prof:         &profile.Profile{},
 			numAllNodes:  6000,
 			wantNumNodes: 300,
 		},
 		{
 			name:                     "set percentageOfNodesToScore and nodes number more than 50*125",
 			percentageOfNodesToScore: 40,
+			prof:                     &profile.Profile{},
+			numAllNodes:              6000,
+			wantNumNodes:             2400,
+		},
+		{
+			name:                     "the percentageOfNodesToScore of Profile should override the global config",
+			percentageOfNodesToScore: 10,
+			prof:                     &profile.Profile{PercentageOfNodesToScore: 40},
 			numAllNodes:              6000,
 			wantNumNodes:             2400,
 		},
@@ -1161,7 +1175,7 @@ func TestNumFeasibleNodesToFind(t *testing.T) {
 			g := &genericScheduler{
 				percentageOfNodesToScore: tt.percentageOfNodesToScore,
 			}
-			if gotNumNodes := g.numFeasibleNodesToFind(tt.numAllNodes); gotNumNodes != tt.wantNumNodes {
+			if gotNumNodes := g.numFeasibleNodesToFind(tt.prof, tt.numAllNodes); gotNumNodes != tt.wantNumNodes {
 				t.Errorf("genericScheduler.numFeasibleNodesToFind() = %v, want %v", gotNumNodes, tt.wantNumNodes)
 			}
 		})
@@ -1190,7 +1204,7 @@ func TestFairEvaluationForNodes(t *testing.T) {
 	prof := &profile.Profile{Framework: fwk}
 	// To make numAllNodes % nodesToFind != 0
 	g.percentageOfNodesToScore = 30
-	nodesToFind := int(g.numFeasibleNodesToFind(int32(numAllNodes)))
+	nodesToFind := int(g.numFeasibleNodesToFind(prof, int32(numAllNodes)))
 
 	// Iterating over all nodes more than twice
 	for i := 0; i < 2*(numAllNodes/nodesToFind+1); i++ {

--- a/pkg/scheduler/profile/profile.go
+++ b/pkg/scheduler/profile/profile.go
@@ -39,8 +39,9 @@ type FrameworkFactory func(config.KubeSchedulerProfile, ...frameworkruntime.Opti
 // Profile is a scheduling profile.
 type Profile struct {
 	framework.Framework
-	Recorder events.EventRecorder
-	Name     string
+	Recorder                 events.EventRecorder
+	Name                     string
+	PercentageOfNodesToScore int32
 }
 
 // NewProfile builds a Profile for the given configuration.
@@ -53,9 +54,10 @@ func NewProfile(cfg config.KubeSchedulerProfile, frameworkFact FrameworkFactory,
 		return nil, err
 	}
 	return &Profile{
-		Name:      cfg.SchedulerName,
-		Framework: fwk,
-		Recorder:  recorder,
+		Name:                     cfg.SchedulerName,
+		Framework:                fwk,
+		Recorder:                 recorder,
+		PercentageOfNodesToScore: cfg.PercentageOfNodesToScore,
 	}, nil
 }
 

--- a/staging/src/k8s.io/kube-scheduler/config/v1beta1/types.go
+++ b/staging/src/k8s.io/kube-scheduler/config/v1beta1/types.go
@@ -69,6 +69,8 @@ type KubeSchedulerConfiguration struct {
 	// then scheduler stops finding further feasible nodes once it finds 150 feasible ones.
 	// When the value is 0, default percentage (5%--50% based on the size of the cluster) of the
 	// nodes will be scored.
+	// Note: It will be overridden by the profile-level score percentage when that is available.
+	// DEPRECATED: This will be removed in v1beta2, please use scheduler profiles to configure it instead.
 	PercentageOfNodesToScore *int32 `json:"percentageOfNodesToScore,omitempty"`
 
 	// PodInitialBackoffSeconds is the initial backoff for unschedulable pods.
@@ -129,6 +131,16 @@ type KubeSchedulerProfile struct {
 	// If SchedulerName matches with the pod's "spec.schedulerName", then the pod
 	// is scheduled with this profile.
 	SchedulerName *string `json:"schedulerName,omitempty"`
+
+	// PercentageOfNodesToScore is the percentage of all nodes that once found feasible
+	// for running a pod, the scheduler stops its search for more feasible nodes in
+	// the cluster. This helps improve scheduler's performance. Scheduler always tries to find
+	// at least "minFeasibleNodesToFind" feasible nodes no matter what the value of this flag is.
+	// Example: if the cluster size is 500 nodes and the value of this flag is 30,
+	// then scheduler stops finding further feasible nodes once it finds 150 feasible ones.
+	// When the value is 0, adaptative percentage (5%--50% based on the size of the cluster) of the
+	// nodes will be scored.
+	PercentageOfNodesToScore *int32 `json:"percentageOfNodesToScore,omitempty"`
 
 	// Plugins specify the set of plugins that should be enabled or disabled.
 	// Enabled plugins are the ones that should be enabled in addition to the

--- a/staging/src/k8s.io/kube-scheduler/config/v1beta1/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/kube-scheduler/config/v1beta1/zz_generated.deepcopy.go
@@ -158,6 +158,11 @@ func (in *KubeSchedulerProfile) DeepCopyInto(out *KubeSchedulerProfile) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.PercentageOfNodesToScore != nil {
+		in, out := &in.PercentageOfNodesToScore, &out.PercentageOfNodesToScore
+		*out = new(int32)
+		**out = **in
+	}
 	if in.Plugins != nil {
 		in, out := &in.Plugins, &out.Plugins
 		*out = new(Plugins)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature


**What this PR does / why we need it**:
scheduler: move percentagesOfNodesToScore to the scheduler profile

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #93270
Ref #95709

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
