### PR TITLE
remove client QPS limit

### DIFF
--- a/staging/src/k8s.io/client-go/rest/config.go
+++ b/staging/src/k8s.io/client-go/rest/config.go
@@ -42,7 +42,6 @@ import (
 )
 
 const (
-	DefaultQPS   float32 = 5.0
 	DefaultBurst int     = 10
 )
 
@@ -113,7 +112,7 @@ type Config struct {
 	WrapTransport transport.WrapperFunc
 
 	// QPS indicates the maximum QPS to the master from this client.
-	// If it's zero, the created RESTClient will use DefaultQPS: 5
+	// If it's zero, means no limits of QPS
 	QPS float32
 
 	// Maximum burst for throttle.
@@ -321,9 +320,6 @@ func RESTClientFor(config *Config) (*RESTClient, error) {
 	rateLimiter := config.RateLimiter
 	if rateLimiter == nil {
 		qps := config.QPS
-		if config.QPS == 0.0 {
-			qps = DefaultQPS
-		}
 		burst := config.Burst
 		if config.Burst == 0 {
 			burst = DefaultBurst


### PR DESCRIPTION
What type of PR is this?

/kind bug

What this PR does / why we need it:

Recently we are using client-go in my cloud server in which we will interact with k8s cluster. When there are a lot of requests reached our server, we will allocate one goroutine per request. In the request we will use client in client-go to invoke k8s apiserver. After a while, we found a lot of goroutines got stucked in `r.tryThrottle()` in Do() and in result **caused goroutines' leak in our server**.

```
// func (r *Request) Do(ctx context.Context) Result { ... }

if err := r.tryThrottle(ctx); err != nil {
	return err
}
```

The QPS limit of client will influence client-go's performance, how about using no rate limiting when new a client ? 

As API Server has already had --max-mutating-requests-inflight and --max-requests-inflight to prevent API Server overload from client requests, and API Server use this client in most scenes when client request is accepted. So I think we should remove this client QPS limit to raise client-go's concurrency. 

Otherwise many developer will get stuck on this bug.

 This pr is similar to the same bug of apiserver. https://github.com/kubernetes/kubernetes/pull/80465

Which issue(s) this PR fixes:

just same as the bug mentioned in #78766

Special notes for your reviewer:


Does this PR introduce a user-facing change?
```
None
```
Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.
```
None
```

```release-note
NONE
```