### PR TITLE
Automated cherry pick of #95647: If we set SelectPolicy MinPolicySelect on scaleUp behavior or

### DIFF
--- a/pkg/controller/podautoscaler/horizontal_test.go
+++ b/pkg/controller/podautoscaler/horizontal_test.go
@@ -2993,6 +2993,50 @@ func TestConvertDesiredReplicasWithRules(t *testing.T) {
 	}
 }
 
+func TestCalculateScaleUpLimitWithScalingRules(t *testing.T) {
+	policy := autoscalingv2.MinPolicySelect
+
+	calculated := calculateScaleUpLimitWithScalingRules(1, []timestampedScaleEvent{}, &autoscalingv2.HPAScalingRules{
+		StabilizationWindowSeconds: utilpointer.Int32Ptr(300),
+		SelectPolicy:               &policy,
+		Policies: []autoscalingv2.HPAScalingPolicy{
+			{
+				Type:          autoscalingv2.PodsScalingPolicy,
+				Value:         2,
+				PeriodSeconds: 60,
+			},
+			{
+				Type:          autoscalingv2.PercentScalingPolicy,
+				Value:         50,
+				PeriodSeconds: 60,
+			},
+		},
+	})
+	assert.Equal(t, calculated, int32(2))
+}
+
+func TestCalculateScaleDownLimitWithBehaviors(t *testing.T) {
+	policy := autoscalingv2.MinPolicySelect
+
+	calculated := calculateScaleDownLimitWithBehaviors(5, []timestampedScaleEvent{}, &autoscalingv2.HPAScalingRules{
+		StabilizationWindowSeconds: utilpointer.Int32Ptr(300),
+		SelectPolicy:               &policy,
+		Policies: []autoscalingv2.HPAScalingPolicy{
+			{
+				Type:          autoscalingv2.PodsScalingPolicy,
+				Value:         2,
+				PeriodSeconds: 60,
+			},
+			{
+				Type:          autoscalingv2.PercentScalingPolicy,
+				Value:         50,
+				PeriodSeconds: 60,
+			},
+		},
+	})
+	assert.Equal(t, calculated, int32(3))
+}
+
 func generateScalingRules(pods, podsPeriod, percent, percentPeriod, stabilizationWindow int32) *autoscalingv2.HPAScalingRules {
 	policy := autoscalingv2.MaxPolicySelect
 	directionBehavior := autoscalingv2.HPAScalingRules{


### PR DESCRIPTION
Cherry pick of #95647 on release-1.19.

#95647: If we set SelectPolicy MinPolicySelect on scaleUp behavior or

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.