### PR TITLE
use patch instead of replace to test the dry-run option

### DIFF
--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -1476,9 +1476,9 @@
   codename: '[sig-cli] Kubectl client Kubectl server-side dry-run should check if
     kubectl can dry-run update Pods [Conformance]'
   description: The command 'kubectl run' must create a pod with the specified image
-    name. After, the command 'kubectl replace --dry-run=server' should update the
-    Pod with the new image name and server-side dry-run enabled. The image name must
-    not change.
+    name. After, the command 'kubectl patch pod -p {...} --dry-run=server' should
+    update the Pod with the new image name and server-side dry-run enabled. The image
+    name must not change.
   release: v1.19
   file: test/e2e/kubectl/kubectl.go
 - testname: Kubectl, version


### PR DESCRIPTION
**What type of PR is this?**

/kind failing-test


**What this PR does / why we need it**:

Was observing some jobs for other fixes we have been changing and notice this test is failing a lot

can see in this job, for example, https://testgrid.k8s.io/sig-release-master-informing#capg-conformance-v1alpha3-k8s-master and https://testgrid.k8s.io/sig-release-master-informing#capa-conformance-v1alpha3-k8s-master&width=30

The test creates a pod and get the JSON spec right away and then replaces the image to perform the actual test. 
However, sometimes might have other reconciliation in the cluster that changes the resource version and when the test try to apply the change this the spec is old and the test fail.
Waiting for the pod to be running maybe is a good option and then get the spec and perform the test. 
Test locally and did not reproduce the issue with this change.


error in the job:
```

Kubernetes e2e suite: [sig-cli] Kubectl client Kubectl server-side dry-run should check if kubectl can dry-run update Pods [Conformance] expand_less | 2s
-- | --
/workspace/kubernetes/_output/local/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:629 Oct 22 21:18:04.003: Unexpected error:     
<exec.CodeExitError>: {       
  Err: {          
   s: "error running /workspace/kubernetes/_output/bin/kubectl --server=https://localhost:6443 --kubeconfig=/workspace/.kube/config --namespace=kubectl-4231 replace -f - --dry-run=server:\nCommand stdout:\n\nstderr:\nError from server (Conflict): error when replacing \"STDIN\": Operation cannot be fulfilled on pods \"e2e-test-httpd-pod\": the object has been modified; please apply your changes to the latest version and try again\n\nerror:\nexit status 1",        
 },         
Code: 1,    
 }     

error running /workspace/kubernetes/_output/bin/kubectl --server=https://localhost:6443 --kubeconfig=/workspace/.kube/config --namespace=kubectl-4231 replace -f - --dry-run=server:     Command stdout:          stderr:     Error from server (Conflict): error when replacing "STDIN": Operation cannot be fulfilled on pods "e2e-test-httpd-pod": the object has been modified; please apply your changes to the latest version and try again          error:     exit status 1 occurred /workspace/kubernetes/_output/local/go/src/k8s.io/kubernetes/test/e2e/framework/util.go:592


```


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes: https://github.com/kubernetes/kubernetes/issues/95832

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
