### PR TITLE
Add yaml util to unmarshal numbers into int/float

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/yaml/BUILD
+++ b/staging/src/k8s.io/apimachinery/pkg/util/yaml/BUILD
@@ -18,6 +18,7 @@ go_library(
     importmap = "k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/yaml",
     importpath = "k8s.io/apimachinery/pkg/util/yaml",
     deps = [
+        "//staging/src/k8s.io/apimachinery/pkg/util/json:go_default_library",
         "//vendor/k8s.io/klog/v2:go_default_library",
         "//vendor/sigs.k8s.io/yaml:go_default_library",
     ],

--- a/staging/src/k8s.io/apimachinery/pkg/util/yaml/decoder_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/yaml/decoder_test.go
@@ -430,3 +430,44 @@ stuff: 1
 		t.Fatalf("expected %q to be of type YAMLSyntaxError", err.Error())
 	}
 }
+
+func TestUnmarshal(t *testing.T) {
+	mapWithIntegerBytes := []byte(`replicas: 1`)
+	mapWithInteger := make(map[string]interface{})
+	if err := Unmarshal(mapWithIntegerBytes, &mapWithInteger); err != nil {
+		t.Fatalf("unexpected error unmarshaling yaml: %v", err)
+	}
+	if _, ok := mapWithInteger["replicas"].(int64); !ok {
+		t.Fatalf(`Expected number in map to be int64 but got "%T"`, mapWithInteger["replicas"])
+	}
+
+	sliceWithIntegerBytes := []byte(`- 1`)
+	var sliceWithInteger []interface{}
+	if err := Unmarshal(sliceWithIntegerBytes, &sliceWithInteger); err != nil {
+		t.Fatalf("unexpected error unmarshaling yaml: %v", err)
+	}
+	if _, ok := sliceWithInteger[0].(int64); !ok {
+		t.Fatalf(`Expected number in slice to be int64 but got "%T"`, sliceWithInteger[0])
+	}
+
+	integerBytes := []byte(`1`)
+	var integer interface{}
+	if err := Unmarshal(integerBytes, &integer); err != nil {
+		t.Fatalf("unexpected error unmarshaling yaml: %v", err)
+	}
+	if _, ok := integer.(int64); !ok {
+		t.Fatalf(`Expected number to be int64 but got "%T"`, integer)
+	}
+
+	otherTypeBytes := []byte(`123: 2`)
+	otherType := make(map[int]interface{})
+	if err := Unmarshal(otherTypeBytes, &otherType); err != nil {
+		t.Fatalf("unexpected error unmarshaling yaml: %v", err)
+	}
+	if _, ok := otherType[123].(int64); ok {
+		t.Fatalf(`Expected number not to be converted to int64`)
+	}
+	if _, ok := otherType[123].(float64); !ok {
+		t.Fatalf(`Expected number to be float64 but got "%T"`, otherType[123])
+	}
+}

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/BUILD
@@ -87,6 +87,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/strategicpatch:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/validation/field:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/yaml:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/watch:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/admission:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/audit:go_default_library",
@@ -108,7 +109,6 @@ go_library(
         "//vendor/google.golang.org/grpc/status:go_default_library",
         "//vendor/k8s.io/klog/v2:go_default_library",
         "//vendor/k8s.io/utils/trace:go_default_library",
-        "//vendor/sigs.k8s.io/yaml:go_default_library",
     ],
 )
 

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/patch.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/patch.go
@@ -38,6 +38,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/apimachinery/pkg/util/yaml"
 	"k8s.io/apiserver/pkg/admission"
 	"k8s.io/apiserver/pkg/audit"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
@@ -49,7 +50,6 @@ import (
 	"k8s.io/apiserver/pkg/util/dryrun"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	utiltrace "k8s.io/utils/trace"
-	"sigs.k8s.io/yaml"
 )
 
 const (


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

In the patch endpoint we are unmarshaling yaml using `sigs.k8s.io/yaml` (see [here](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/patch.go#L437)). However, `sigs.k8s.io/yaml` package does not preserve int/float, which causes problems in some cases (see  #95680).

This PR adds an `Unmarshal` function to the yaml utils that preserves int and float (similarly to [json.Unmarshal](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/apimachinery/pkg/util/json/json.go#L43) and uses it to unmarshal yaml in the patch endpoint.

**Which issue(s) this PR fixes**:

Fixes #95680

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

