### PR TITLE
pause image: Stricter registry prefix regex

### DIFF
--- a/build/pause/Makefile
+++ b/build/pause/Makefile
@@ -88,9 +88,12 @@ push-manifest:
 	# For Windows images, we also need to include the "os.version" in the manifest list, so the Windows node can pull the proper image it needs.
 	# At the moment, docker manifest annotate doesn't allow us to set the os.version, so we'll have to it ourselves. The manifest list can be found locally as JSONs.
 	# See: https://github.com/moby/moby/issues/41417
+	# If the ${REGISTRY} is on dockerhub, the prefix "docker.io/" is optional. However, we need the full
+	# registry name for setting the os.version for Windows images below.
+	# If the registry name does not contain any slashes, we prepend "docker.io/"
 	# TODO(claudiub): Clean this up once the above issue has been fixed.
 	set -x; \
-	registry_prefix=$(shell (echo ${REGISTRY} | grep -Eq "[a-z]*") && echo "docker.io/" || echo ""); \
+	registry_prefix=$(shell (echo ${REGISTRY} | grep -Eq ".*\/.*") && echo "" || echo "docker.io/"); \
 	manifest_image_folder=`echo "$${registry_prefix}${IMAGE}" | sed "s|/|_|g" | sed "s/:/-/"`; \
 	for arch in $(ALL_ARCH.windows);  do \
 		for osversion in ${ALL_OSVERSIONS.windows}; do \


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

/sig node
/sig release

/priority important-soon

**What this PR does / why we need it**:

If the ``${REGISTRY}`` is on dockerhub, the prefix ``docker.io/`` is optional. However, we need the full registry name for setting the ``os.version`` for Windows images. Because of this, If the registry name does not contain any slashes, we need to prepend ``docker.io/``.

Currently, ``docker.io/`` is not prepended properly, leading the current image building failure [1].

[1] http://storage.googleapis.com/k8s-staging-kubernetes-gcb/logs/log-8094b639-77d0-4e6f-9cd8-fab3b8a201c5.txt

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

Without this PR, image built with REGISTRY=docker.io/claudiubelu : https://paste.ubuntu.com/p/tkwdWdwTWw/
With this PR, Image built with REGISTRY=claudiubelu : https://paste.ubuntu.com/p/G39m7NvCwD/
With this PR, Image built with REGISTRY=docker.io/claudiubelu : https://paste.ubuntu.com/p/xKZkB6fRSC/

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
