### PR TITLE
Automated cherry pick of 95812 upstream release 1.19

### DIFF
--- a/pkg/scheduler/framework/plugins/podtopologyspread/filtering.go
+++ b/pkg/scheduler/framework/plugins/podtopologyspread/filtering.go
@@ -285,7 +285,7 @@ func (pl *PodTopologySpread) Filter(ctx context.Context, cycleState *framework.C
 	}
 
 	// However, "empty" preFilterState is legit which tolerates every toSchedule Pod.
-	if len(s.TpPairToMatchNum) == 0 || len(s.Constraints) == 0 {
+	if len(s.Constraints) == 0 {
 		return nil
 	}
 

--- a/pkg/scheduler/framework/plugins/podtopologyspread/filtering_test.go
+++ b/pkg/scheduler/framework/plugins/podtopologyspread/filtering_test.go
@@ -1264,6 +1264,20 @@ func TestSingleConstraint(t *testing.T) {
 			},
 		},
 		{
+			name: "pod cannot be scheduled as all nodes don't have label 'rack'",
+			pod: st.MakePod().Name("p").Label("foo", "").SpreadConstraint(
+				1, "rack", v1.DoNotSchedule, st.MakeLabelSelector().Exists("foo").Obj(),
+			).Obj(),
+			nodes: []*v1.Node{
+				st.MakeNode().Name("node-a").Label("zone", "zone1").Label("node", "node-a").Obj(),
+				st.MakeNode().Name("node-x").Label("zone", "zone2").Label("node", "node-x").Obj(),
+			},
+			wantStatusCode: map[string]framework.Code{
+				"node-a": framework.UnschedulableAndUnresolvable,
+				"node-x": framework.UnschedulableAndUnresolvable,
+			},
+		},
+		{
 			name: "pods spread across nodes as 2/1/0/3, only node-x fits",
 			pod: st.MakePod().Name("p").Label("foo", "").SpreadConstraint(
 				1, "node", v1.DoNotSchedule, st.MakeLabelSelector().Exists("foo").Obj(),


### PR DESCRIPTION
Cherry pick of #95812 on release-1.19.

#95812: Fix a bug that Pods with topologySpreadConstraints get

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Fix a bug that Pods with topologySpreadConstraints get scheduled to nodes without required labels
```

---

Note that this is a manual created PR, while #95845 was created from `hack/cherry_pick_pull.sh`. And this PR's branch name doesn't have the `#` character.