### PR TITLE
Promote: verify PriorityClass endpoints e2e test to Conformance +5 Endpoints

### DIFF
--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -2014,6 +2014,14 @@
     number of Replicas.
   release: v1.19
   file: test/e2e/scheduling/preemption.go
+- testname: Scheduler, Verify PriorityClass endpoints
+  codename: '[sig-scheduling] SchedulerPreemption [Serial] PriorityClass endpoints
+    verify PriorityClass endpoints can be operated with different HTTP methods [Conformance]'
+  description: Verify that PriorityClass endpoints can be listed. When any mutable
+    field is either patched or updated it MUST succeed. When any immutable field is
+    either patched or updated it MUST fail.
+  release: v1.20
+  file: test/e2e/scheduling/preemption.go
 - testname: Scheduler, Basic Preemption
   codename: '[sig-scheduling] SchedulerPreemption [Serial] validates basic preemption
     works [Conformance]'

--- a/test/e2e/scheduling/preemption.go
+++ b/test/e2e/scheduling/preemption.go
@@ -710,7 +710,14 @@ var _ = SIGDescribe("SchedulerPreemption [Serial]", func() {
 			}
 		})
 
-		ginkgo.It("verify PriorityClass endpoints can be operated with different HTTP methods", func() {
+		/*
+			Release: v1.20
+			Testname: Scheduler, Verify PriorityClass endpoints
+			Description: Verify that PriorityClass endpoints can be listed. When any mutable field is
+			either patched or updated it MUST succeed. When any immutable field is either patched or
+			updated it MUST fail.
+		*/
+		framework.ConformanceIt("verify PriorityClass endpoints can be operated with different HTTP methods", func() {
 			// 1. Patch/Update on immutable fields will fail.
 			pcCopy := pcs[0].DeepCopy()
 			pcCopy.Value = pcCopy.Value * 10


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it:**
This PR adds a test to test the following untested endpoints:
replaceSchedulingV1PriorityClass
readSchedulingV1PriorityClass
patchSchedulingV1PriorityClass
listSchedulingV1PriorityClass
deleteSchedulingV1CollectionPriorityClass

**Which issue(s) this PR fixes:**
Fixes #94954
**Testgrid Link:**
[Testgrid](https://testgrid.k8s.io/sig-scheduling#gce-serial&include-filter-by-regex=verify%20PriorityClass%20endpoints%20can%20be%20operated%20with%20different%20HTTP%20methods&include-filter-by-regex=verify%20PriorityClass%20endpoints%20can%20be%20operated%20with%20different%20HTTP%20methods&include-filter-by-regex=PriorityClass&include-filter-by-regex=Priority&include-filter-by-regex=PriorityClass)

**Special notes for your reviewer:**
Adds +5 endpoint test coverage (good for conformance)

**Does this PR introduce a user-facing change?:**
```
NONE

```

**Release note:**
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:**
```
NONE

```

/sig testing
/sig architecture
/area conformance