### PR TITLE
cleanup of leftover part of a comment. Follow up for #94109

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -2151,7 +2151,6 @@ func (kl *Kubelet) updateRuntimeUp() {
 		return
 	}
 	// Periodically log the whole runtime status for debugging.
-	// condition is unmet.
 	klog.V(4).Infof("Container runtime status: %v", s)
 	networkReady := s.GetRuntimeCondition(kubecontainer.NetworkReady)
 	if networkReady == nil || !networkReady.Status {


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup
/sig node
/priority backlog
/assign @derekwaynecarr

**What this PR does / why we need it**:

Follow up from https://github.com/kubernetes/kubernetes/pull/94109#event-3924240168 - one comment wasn't removed cleanly. Sorry for the small PR.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
