### PR TITLE
Verify iptable rules are applied for tcp, udp and icmp

### DIFF
--- a/test/e2e_node/remote/utils.go
+++ b/test/e2e_node/remote/utils.go
@@ -19,7 +19,6 @@ package remote
 import (
 	"fmt"
 	"path/filepath"
-	"strings"
 
 	"k8s.io/klog/v2"
 )
@@ -79,35 +78,21 @@ func setupCNI(host, workspace string) error {
 
 // configureFirewall configures iptable firewall rules.
 func configureFirewall(host string) error {
-	klog.V(2).Infof("Configure iptables firewall rules on %q", host)
-	// TODO: consider calling bootstrap script to configure host based on OS
-	output, err := SSH(host, "iptables", "-L", "INPUT")
+	klog.V(2).Infof("Configure iptables HEYHO firewall rules on %q", host)
+
+	// Since the goal is to enable connectivity without taking into account current rule,
+	// we can just prepend the accept rules directly without any check
+	cmd := getSSHCommand("&&",
+		"iptables -I INPUT 1 -w -p tcp -j ACCEPT",
+		"iptables -I INPUT 1 -w -p udp -j ACCEPT",
+		"iptables -I INPUT 1 -w -p icmp -j ACCEPT",
+		"iptables -I FORWARD 1 -w -p tcp -j ACCEPT",
+		"iptables -I FORWARD 1 -w -p udp -j ACCEPT",
+		"iptables -I FORWARD 1 -w -p icmp -j ACCEPT",
+	)
+	output, err := SSH(host, "sh", "-c", cmd)
 	if err != nil {
-		return fmt.Errorf("failed to get iptables INPUT on %q: %v output: %q", host, err, output)
-	}
-	if strings.Contains(output, "Chain INPUT (policy DROP)") {
-		cmd := getSSHCommand("&&",
-			"(iptables -C INPUT -w -p TCP -j ACCEPT || iptables -A INPUT -w -p TCP -j ACCEPT)",
-			"(iptables -C INPUT -w -p UDP -j ACCEPT || iptables -A INPUT -w -p UDP -j ACCEPT)",
-			"(iptables -C INPUT -w -p ICMP -j ACCEPT || iptables -A INPUT -w -p ICMP -j ACCEPT)")
-		output, err := SSH(host, "sh", "-c", cmd)
-		if err != nil {
-			return fmt.Errorf("failed to configured firewall on %q: %v output: %v", host, err, output)
-		}
-	}
-	output, err = SSH(host, "iptables", "-L", "FORWARD")
-	if err != nil {
-		return fmt.Errorf("failed to get iptables FORWARD on %q: %v output: %q", host, err, output)
-	}
-	if strings.Contains(output, "Chain FORWARD (policy DROP)") {
-		cmd := getSSHCommand("&&",
-			"(iptables -C FORWARD -w -p TCP -j ACCEPT || iptables -A FORWARD -w -p TCP -j ACCEPT)",
-			"(iptables -C FORWARD -w -p UDP -j ACCEPT || iptables -A FORWARD -w -p UDP -j ACCEPT)",
-			"(iptables -C FORWARD -w -p ICMP -j ACCEPT || iptables -A FORWARD -w -p ICMP -j ACCEPT)")
-		output, err = SSH(host, "sh", "-c", cmd)
-		if err != nil {
-			return fmt.Errorf("failed to configured firewall on %q: %v output: %v", host, err, output)
-		}
+		return fmt.Errorf("failed to configured firewall on %q: %v output: %v", host, err, output)
 	}
 	return nil
 }


### PR DESCRIPTION
Signed-off-by: Harshal Patil <harpatil@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind failing-test

**What this PR does / why we need it**:
The test infra currently checks if [existing iptable policy](https://github.com/kubernetes/kubernetes/blob/master/test/e2e_node/remote/utils.go#L88) is to DROP or not.

But like in case of Fedora CoreOS, the iptables policy might be ACCEPT but it still lacks the individual rule for tcp, udp and icmp.

```bash
# iptables -L INPUT
Chain INPUT (policy ACCEPT)
target     prot opt source               destination
# iptables -L FORWARD         
Chain FORWARD (policy ACCEPT)
target     prot opt source               destination 
```
In that case, since the iptables policy is not set to `DROP` the test infra doesn't attempt to add any required iptable rules for `tcp`, `udp` and `icmp`.

To fix this we need to see if the iptable policy is not set to DROP plus check if the rules of `tcp`, `udp` and `icmp` are actually present or not. Then we see the iptable rules are correctly applied,

```bash
# iptables -L INPUT
Chain INPUT (policy ACCEPT)
target     prot opt source               destination         
ACCEPT     tcp  --  anywhere             anywhere            
ACCEPT     udp  --  anywhere             anywhere            
ACCEPT     icmp --  anywhere             anywhere            
# iptables -L FORWARD
Chain FORWARD (policy ACCEPT)
target     prot opt source               destination         
ACCEPT     tcp  --  anywhere             anywhere            
ACCEPT     udp  --  anywhere             anywhere            
ACCEPT     icmp --  anywhere             anywhere  
```



**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #95905

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
