### PR TITLE
check nil pointer in String method

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/validation/validation_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/validation/validation_test.go
@@ -262,22 +262,22 @@ func TestValidateCustomResource(t *testing.T) {
 			},
 			failingObjects: []failingObject{
 				{object: map[string]interface{}{"field": true}, expectErrs: []string{
-					`: Invalid value: "": "field" must validate at least one schema (anyOf)`,
+					`<nil>: Invalid value: "": "field" must validate at least one schema (anyOf)`,
 					`field: Invalid value: "boolean": field in body must be of type integer,string: "boolean"`,
 					`field: Invalid value: "boolean": field in body must be of type integer: "boolean"`,
 				}},
 				{object: map[string]interface{}{"field": 1.2}, expectErrs: []string{
-					`: Invalid value: "": "field" must validate at least one schema (anyOf)`,
+					`<nil>: Invalid value: "": "field" must validate at least one schema (anyOf)`,
 					`field: Invalid value: "number": field in body must be of type integer,string: "number"`,
 					`field: Invalid value: "number": field in body must be of type integer: "number"`,
 				}},
 				{object: map[string]interface{}{"field": map[string]interface{}{}}, expectErrs: []string{
-					`: Invalid value: "": "field" must validate at least one schema (anyOf)`,
+					`<nil>: Invalid value: "": "field" must validate at least one schema (anyOf)`,
 					`field: Invalid value: "object": field in body must be of type integer,string: "object"`,
 					`field: Invalid value: "object": field in body must be of type integer: "object"`,
 				}},
 				{object: map[string]interface{}{"field": []interface{}{}}, expectErrs: []string{
-					`: Invalid value: "": "field" must validate at least one schema (anyOf)`,
+					`<nil>: Invalid value: "": "field" must validate at least one schema (anyOf)`,
 					`field: Invalid value: "array": field in body must be of type integer,string: "array"`,
 					`field: Invalid value: "array": field in body must be of type integer: "array"`,
 				}},
@@ -308,26 +308,26 @@ func TestValidateCustomResource(t *testing.T) {
 			},
 			failingObjects: []failingObject{
 				{object: map[string]interface{}{"field": true}, expectErrs: []string{
-					`: Invalid value: "": "field" must validate all the schemas (allOf). None validated`,
-					`: Invalid value: "": "field" must validate at least one schema (anyOf)`,
+					`<nil>: Invalid value: "": "field" must validate all the schemas (allOf). None validated`,
+					`<nil>: Invalid value: "": "field" must validate at least one schema (anyOf)`,
 					`field: Invalid value: "boolean": field in body must be of type integer,string: "boolean"`,
 					`field: Invalid value: "boolean": field in body must be of type integer: "boolean"`,
 				}},
 				{object: map[string]interface{}{"field": 1.2}, expectErrs: []string{
-					`: Invalid value: "": "field" must validate all the schemas (allOf). None validated`,
-					`: Invalid value: "": "field" must validate at least one schema (anyOf)`,
+					`<nil>: Invalid value: "": "field" must validate all the schemas (allOf). None validated`,
+					`<nil>: Invalid value: "": "field" must validate at least one schema (anyOf)`,
 					`field: Invalid value: "number": field in body must be of type integer,string: "number"`,
 					`field: Invalid value: "number": field in body must be of type integer: "number"`,
 				}},
 				{object: map[string]interface{}{"field": map[string]interface{}{}}, expectErrs: []string{
-					`: Invalid value: "": "field" must validate all the schemas (allOf). None validated`,
-					`: Invalid value: "": "field" must validate at least one schema (anyOf)`,
+					`<nil>: Invalid value: "": "field" must validate all the schemas (allOf). None validated`,
+					`<nil>: Invalid value: "": "field" must validate at least one schema (anyOf)`,
 					`field: Invalid value: "object": field in body must be of type integer,string: "object"`,
 					`field: Invalid value: "object": field in body must be of type integer: "object"`,
 				}},
 				{object: map[string]interface{}{"field": []interface{}{}}, expectErrs: []string{
-					`: Invalid value: "": "field" must validate all the schemas (allOf). None validated`,
-					`: Invalid value: "": "field" must validate at least one schema (anyOf)`,
+					`<nil>: Invalid value: "": "field" must validate all the schemas (allOf). None validated`,
+					`<nil>: Invalid value: "": "field" must validate at least one schema (anyOf)`,
 					`field: Invalid value: "array": field in body must be of type integer,string: "array"`,
 					`field: Invalid value: "array": field in body must be of type integer: "array"`,
 				}},

--- a/staging/src/k8s.io/apimachinery/pkg/api/meta/restmapper.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/meta/restmapper.go
@@ -65,6 +65,9 @@ type DefaultRESTMapper struct {
 }
 
 func (m *DefaultRESTMapper) String() string {
+	if m == nil {
+		return "<nil>"
+	}
 	return fmt.Sprintf("DefaultRESTMapper{kindToPluralResource=%v}", m.kindToPluralResource)
 }
 

--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity.go
@@ -598,6 +598,9 @@ const int64QuantityExpectedBytes = 18
 // String is an expensive operation and caching this result significantly reduces the cost of
 // normal parse / marshal operations on Quantity.
 func (q *Quantity) String() string {
+	if q == nil {
+		return "<nil>"
+	}
 	if len(q.s) == 0 {
 		result := make([]byte, 0, int64QuantityExpectedBytes)
 		number, suffix := q.CanonicalizeBytes(result)

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/group_version.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/group_version.go
@@ -34,6 +34,9 @@ type GroupResource struct {
 }
 
 func (gr *GroupResource) String() string {
+	if gr == nil {
+		return "<nil>"
+	}
 	if len(gr.Group) == 0 {
 		return gr.Resource
 	}
@@ -51,6 +54,9 @@ type GroupVersionResource struct {
 }
 
 func (gvr *GroupVersionResource) String() string {
+	if gvr == nil {
+		return "<nil>"
+	}
 	return strings.Join([]string{gvr.Group, "/", gvr.Version, ", Resource=", gvr.Resource}, "")
 }
 
@@ -64,6 +70,9 @@ type GroupKind struct {
 }
 
 func (gk *GroupKind) String() string {
+	if gk == nil {
+		return "<nil>"
+	}
 	if len(gk.Group) == 0 {
 		return gk.Kind
 	}

--- a/staging/src/k8s.io/apimachinery/pkg/util/intstr/intstr.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/intstr/intstr.go
@@ -89,6 +89,9 @@ func (intstr *IntOrString) UnmarshalJSON(value []byte) error {
 
 // String returns the string value, or the Itoa of the int value.
 func (intstr *IntOrString) String() string {
+	if intstr == nil {
+		return "<nil>"
+	}
 	if intstr.Type == String {
 		return intstr.StrVal
 	}

--- a/staging/src/k8s.io/apimachinery/pkg/util/validation/field/path.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/validation/field/path.go
@@ -67,6 +67,9 @@ func (p *Path) Key(key string) *Path {
 
 // String produces a string representation of the Path.
 func (p *Path) String() string {
+	if p == nil {
+		return "<nil>"
+	}
 	// make a slice to iterate
 	elems := []*Path{}
 	for ; p != nil; p = p.parent {

--- a/staging/src/k8s.io/apimachinery/pkg/util/version/version.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/version/version.go
@@ -195,6 +195,9 @@ func (v *Version) WithBuildMetadata(buildMetadata string) *Version {
 // ParseGeneric, this will not include the trailing uninterpreted portion of the version
 // number.
 func (v *Version) String() string {
+	if v == nil {
+		return "<nil>"
+	}
 	var buffer bytes.Buffer
 
 	for i, comp := range v.components {


### PR DESCRIPTION
/kind bug


**What this PR does / why we need it**:

Quantity.String not check nil pointer. When debug kubernetes's program on macOS, the debugger always stop and broken at String function 

TestCase:
```
source := v1.EmptyDirVolumeSource{}  
fmt.Print(source)  
```

panic screenshoot
![image](https://user-images.githubusercontent.com/2086945/98494230-6c65de00-2277-11eb-8369-310e4f5f7df6.png)


