### PR TITLE
Fix cacher test after bumping fakeBudget timeout to 2 seconds

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_whitebox_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_whitebox_test.go
@@ -1081,7 +1081,7 @@ func TestDispatchEventWillNotBeBlockedByTimedOutWatcher(t *testing.T) {
 					shouldContinue = false
 				}
 			}
-		case <-time.After(2 * time.Second):
+		case <-time.After(wait.ForeverTestTimeout):
 			shouldContinue = false
 			w2.Stop()
 		}


### PR DESCRIPTION
Introduced in #95869 after bumping the timeout at the last moment.

Fix #95394

```release-note
NONE
```

/kind flake
/priority important-soon