### PR TITLE
tombstone-ing IPFamily field(15)

### DIFF
--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -4142,6 +4142,9 @@ type ServiceSpec struct {
 	// +optional
 	SessionAffinityConfig *SessionAffinityConfig `json:"sessionAffinityConfig,omitempty" protobuf:"bytes,14,opt,name=sessionAffinityConfig"`
 
+	// IPFamily is tombstoned to show why 15 is a reserved protobuf tag.
+	// IPFamily *IPFamily `json:"ipFamily,omitempty" protobuf:"bytes,15,opt,name=ipFamily,Configcasttype=IPFamily"`
+
 	// IPFamilies identifies all the IPFamilies assigned for this Service. If a value
 	// was not provided for IPFamilies it will be defaulted based on the cluster
 	// configuration and the value of service.spec.ipFamilyPolicy. A maximum of two


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
implements this request https://github.com/kubernetes/kubernetes/pull/91824#issuecomment-717001486 as a follow up for https://github.com/kubernetes/kubernetes/pull/91824

Tombstones tag #15 (IPFamilies field of ServiceSpec)

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A

**Does this PR introduce a user-facing change?**:
```release-note
None
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
