### PR TITLE
Fix bug in JSON path parser where an error occurs when a range is empty

### DIFF
--- a/staging/src/k8s.io/client-go/util/jsonpath/jsonpath.go
+++ b/staging/src/k8s.io/client-go/util/jsonpath/jsonpath.go
@@ -103,13 +103,23 @@ func (j *JSONPath) FindResults(data interface{}) ([][]reflect.Value, error) {
 		if j.beginRange > 0 {
 			j.beginRange--
 			j.inRange++
-			for _, value := range results {
+			if len(results) > 0 {
+				for _, value := range results {
+					j.parser.Root.Nodes = nodes[i+1:]
+					nextResults, err := j.FindResults(value.Interface())
+					if err != nil {
+						return nil, err
+					}
+					fullResult = append(fullResult, nextResults...)
+				}
+			} else {
+				// If the range has no results, we still need to process the nodes within the range
+				// so the position will advance to the end node
 				j.parser.Root.Nodes = nodes[i+1:]
-				nextResults, err := j.FindResults(value.Interface())
+				_, err := j.FindResults(nil)
 				if err != nil {
 					return nil, err
 				}
-				fullResult = append(fullResult, nextResults...)
 			}
 			j.inRange--
 

--- a/staging/src/k8s.io/client-go/util/jsonpath/jsonpath_test.go
+++ b/staging/src/k8s.io/client-go/util/jsonpath/jsonpath_test.go
@@ -393,6 +393,21 @@ func TestKubernetes(t *testing.T) {
 	testJSONPathSortOutput(randomPrintOrderTests, t)
 }
 
+func TestEmptyRange(t *testing.T) {
+	var input = []byte(`{"items":[]}`)
+	var emptyList interface{}
+	err := json.Unmarshal(input, &emptyList)
+	if err != nil {
+		t.Error(err)
+	}
+
+	tests := []jsonpathTest{
+		{"empty range", `{range .items[*]}{.metadata.name}{end}`, &emptyList, "", false},
+		{"empty nested range", `{range .items[*]}{.metadata.name}{":"}{range @.spec.containers[*]}{.name}{","}{end}{"+"}{end}`, &emptyList, "", false},
+	}
+	testJSONPath(tests, true, t)
+}
+
 func TestNestedRanges(t *testing.T) {
 	var input = []byte(`{
 		"items": [


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Fix bug in JSON path parser where an error occurs when a range is empty.

The problem was that if the range contained no results, the position of the parser loop was not advanced to the end node, so when it reached the end node in the loop it seemed like there was no open range.

The fix is to make sure even if there are not results in the range, that it still advances to the end node as if it had processed something.

(BTW, this whole file seems sort of fragile and hard to conceptualize due to all the counters that are used across functions. Seems like there should be some opportunity to improve this, but that is for another time)

**Which issue(s) this PR fixes**:
Fixes #95882

**Special notes for your reviewer**:
This probably needs to be cherry-picked back to 1.19, where the problem was introduced.

**Does this PR introduce a user-facing change?**:
```release-note
Fix a regression in 1.19 in JSON path parser where an error occurs when a range is empty
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
