### PR TITLE
fix unbound variable on upgrade

### DIFF
--- a/cluster/gce/upgrade.sh
+++ b/cluster/gce/upgrade.sh
@@ -462,7 +462,9 @@ function update-coredns-config() {
 
   # clean up
   cleanup() {
-    rm -rf "${download_dir}"
+    if [ -n "${download_dir:-}" ]; then
+      rm -rf "${download_dir}"
+    fi
   }
   trap cleanup RETURN
 


### PR DESCRIPTION
The `ci-kubernetes-e2e-gce-stable1-beta-upgrade-cluster-parallel` is failing constantly.

It has about 20 sig-api-machinery tests failing, most of them

```
Oct 23 18:02:03.124: waiting for webhook configuration to be ready
Unexpected error:
    <*errors.errorString | 0xc0000a1fe0>: {
        s: "timed out waiting for the condition",
    }
    timed out waiting for the condition
occurred
```

but when it tries to cleanup the job it fails with

> workspace/kubernetes_skew/cluster/gce/upgrade.sh: line 465: download_dir: unbound variable\n"

This PR fixes the unbound variable error only

xref: 
* https://storage.googleapis.com/k8s-gubernator/triage/index.html?job=ci-kubernetes-e2e-gce-stable1-beta-upgrade-cluster-parallel
* https://prow.k8s.io/job-history/gs/kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-stable1-beta-upgrade-cluster-parallel

/kind bug
/kind cleanup
```release-note
NONE
```
