### PR TITLE
 KCM crashes  when bunk podCIDRs are on a specific node

### DIFF
--- a/pkg/controller/node/nodecontroller.go
+++ b/pkg/controller/node/nodecontroller.go
@@ -343,7 +343,7 @@ func NewNodeController(
 		}
 
 		if err != nil {
-			return nil, err
+			glog.Errorf("Failed to allocate cidr for a node: %v... this may result in invalid pods later on", err)
 		}
 
 		nodeInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{


### PR DESCRIPTION

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
it seems like the node controller can be brought down by a single invalid metadata field in a node spec

**Which issue(s) this PR fixes**:
Fixes #95948


**Does this PR introduce a user-facing change?**:
```release-note
Node controller now doesnt crash if a podCidr is invalid on a single node
```
