### PR TITLE
pause image: Disable DiagTrack service on Windows image

### DIFF
--- a/build/pause/Dockerfile_windows
+++ b/build/pause/Dockerfile_windows
@@ -18,6 +18,11 @@ ARG ARCH
 ADD bin/pause-windows-${ARCH}.exe /pause.exe
 ADD bin/wincat-windows-amd64 /Windows/System32/wincat.exe
 
+# NOTE(claudiub): We're replacing the diagtrack.dll as a means to disable the
+# DiagTrack service (it cannot run without this DLL). We do not need this
+# service in the pause image and there's no reason for it to have any CPU usage.
+ADD windows/pause.c /Windows/System32/diagtrack.dll
+
 # NOTE(claudiub): docker buildx sets the PATH env variable to a Linux-like PATH,
 # which is not desirable. See: https://github.com/moby/buildkit/issues/1560
 # TODO(claudiub): remove this once the issue has been resolved.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

/sig windows
/sig node

**What this PR does / why we need it**:

It has been observed that the DiagTrack service in the pause image is consuming a non-trivial amount of CPU. We don't need
this service in the pause image, so we should disable it.

We can disable the service by running chntpw in a docker buildx Linux stage and then copy the SYSTEM file back to the final Windows image.

Co-Authored-By: Mark Rossetti <marosset@microsoft.com>

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Partially Fixes #95735

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
