### PR TITLE
Automated cherry pick of #94987 upstream release 1.18

### DIFF
--- a/cluster/gce/upgrade.sh
+++ b/cluster/gce/upgrade.sh
@@ -451,15 +451,21 @@ function update-coredns-config() {
   cleanup() {
     rm -rf "${download_dir}"
   }
-  trap cleanup EXIT
+  trap cleanup RETURN
 
   # Get the new installed CoreDNS version
-  echo "Waiting for CoreDNS to update"
-  until [[ $(${KUBE_ROOT}/cluster/kubectl.sh -n kube-system get deployment coredns -o=jsonpath='{$.metadata.resourceVersion}') -ne ${COREDNS_DEPLOY_RESOURCE_VERSION} ]]; do
+  echo "== Waiting for CoreDNS to update =="
+  local -r endtime=$(date -ud "3 minute" +%s)
+  until [[ $("${KUBE_ROOT}"/cluster/kubectl.sh -n kube-system get deployment coredns -o=jsonpath='{$.metadata.resourceVersion}') -ne ${COREDNS_DEPLOY_RESOURCE_VERSION} ]] || [[ $(date -u +%s) -gt $endtime ]]; do
      sleep 1
   done
-  echo "Fetching the latest installed CoreDNS version"
-  NEW_COREDNS_VERSION=$(${KUBE_ROOT}/cluster/kubectl.sh -n kube-system get deployment coredns -o=jsonpath='{$.spec.template.spec.containers[:1].image}' | cut -d ":" -f 2)
+
+  if [[ $("${KUBE_ROOT}"/cluster/kubectl.sh -n kube-system get deployment coredns -o=jsonpath='{$.metadata.resourceVersion}') -ne ${COREDNS_DEPLOY_RESOURCE_VERSION} ]]; then
+    echo "== CoreDNS ResourceVersion changed =="
+  fi
+
+  echo "== Fetching the latest installed CoreDNS version =="
+  NEW_COREDNS_VERSION=$("${KUBE_ROOT}"/cluster/kubectl.sh -n kube-system get deployment coredns -o=jsonpath='{$.spec.template.spec.containers[:1].image}' | cut -d ":" -f 2)
 
   case "$(uname -m)" in
       x86_64*)


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup
/kind failing-test

**What this PR does / why we need it**:

cherrypick https://github.com/kubernetes/kubernetes/pull/94987, which would partially fix upgrade test. see https://github.com/kubernetes/kubernetes/issues/94487.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```