### PR TITLE
Initialize OIDC verifier immediately

### DIFF
--- a/staging/src/k8s.io/apiserver/plugin/pkg/authenticator/token/oidc/oidc.go
+++ b/staging/src/k8s.io/apiserver/plugin/pkg/authenticator/token/oidc/oidc.go
@@ -218,7 +218,7 @@ func New(opts Options) (*Authenticator, error) {
 	return newAuthenticator(opts, func(ctx context.Context, a *Authenticator, config *oidc.Config) {
 		// Asynchronously attempt to initialize the authenticator. This enables
 		// self-hosted providers, providers that run on top of Kubernetes itself.
-		go wait.PollUntil(time.Second*10, func() (done bool, err error) {
+		go wait.PollImmediateUntil(time.Second*10, func() (done bool, err error) {
 			provider, err := oidc.NewProvider(ctx, a.issuerURL)
 			if err != nil {
 				klog.Errorf("oidc authenticator: initializing plugin: %v", err)


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Attempt to initialize the OIDC verifier immediately rather than artificially waiting 10 seconds.

Shortens the time the API server could be up without an initialized OIDC validator in the happy path (when the OIDC discovery doc is available and quickly fetchable).

**Which issue(s) this PR fixes**:
xref #65785

/sig auth

```release-note
NONE
```