### PR TITLE
Update PriorityClass conformance test to cover DeleteCollection

### DIFF
--- a/test/e2e/scheduling/BUILD
+++ b/test/e2e/scheduling/BUILD
@@ -58,6 +58,7 @@ go_library(
         "//test/e2e/framework/testfiles:go_default_library",
         "//test/utils:go_default_library",
         "//test/utils/image:go_default_library",
+        "//vendor/github.com/google/uuid:go_default_library",
         "//vendor/github.com/onsi/ginkgo:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
         "//vendor/github.com/stretchr/testify/assert:go_default_library",


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup
/sig scheduling

**What this PR does / why we need it**:

Supplemental of #95340 to ensure DeleteCollection is tested for PriorityClass endpoint. Ref https://github.com/kubernetes/kubernetes/pull/95340#discussion_r513152995.

**Which issue(s) this PR fixes**:

Supplemental of #95340

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```