### PR TITLE
update predicateOrdering according to filter pluginset

### DIFF
--- a/pkg/scheduler/framework/plugins/legacy_registry.go
+++ b/pkg/scheduler/framework/plugins/legacy_registry.go
@@ -133,13 +133,15 @@ const (
 
 // predicateOrdering is the ordering of predicate execution.
 var predicateOrdering = []string{
+	GeneralPred,
 	CheckNodeUnschedulablePred,
-	GeneralPred, HostNamePred, PodFitsHostPortsPred,
-	MatchNodeSelectorPred, PodFitsResourcesPred, NoDiskConflictPred,
-	PodToleratesNodeTaintsPred, CheckNodeLabelPresencePred,
-	CheckServiceAffinityPred, MaxEBSVolumeCountPred, MaxGCEPDVolumeCountPred, MaxCSIVolumeCountPred,
-	MaxAzureDiskVolumeCountPred, MaxCinderVolumeCountPred, CheckVolumeBindingPred, NoVolumeZoneConflictPred,
+	HostNamePred, PodToleratesNodeTaintsPred,
+	MatchNodeSelectorPred, CheckServiceAffinityPred, PodFitsHostPortsPred,
+	PodFitsResourcesPred, NoDiskConflictPred, MaxCinderVolumeCountPred,
+	MaxEBSVolumeCountPred, MaxGCEPDVolumeCountPred, MaxCSIVolumeCountPred, MaxAzureDiskVolumeCountPred,
+	CheckVolumeBindingPred, NoVolumeZoneConflictPred,
 	EvenPodsSpreadPred, MatchInterPodAffinityPred,
+	CheckNodeLabelPresencePred,
 }
 
 // LegacyRegistry is used to store current state of registered predicates and priorities.


### PR DESCRIPTION
What type of PR is this?
/kind bug

What this PR does / why we need it:
In #95539, Filter PuginSet has been re-ordered as following:
Filter: &schedulerapi.PluginSet{
Enabled: []schedulerapi.Plugin{
{Name: nodeunschedulable.Name},
{Name: nodename.Name},
{Name: tainttoleration.Name},
{Name: nodeaffinity.Name},
{Name: nodeports.Name},
{Name: noderesources.FitName},
{Name: volumerestrictions.Name},
{Name: nodevolumelimits.EBSName},
{Name: nodevolumelimits.GCEPDName},
{Name: nodevolumelimits.CSIName},
{Name: nodevolumelimits.AzureDiskName},
{Name: volumebinding.Name},
{Name: volumezone.Name},
{Name: podtopologyspread.Name},
{Name: interpodaffinity.Name},
},
},
but predicateOrdering is still not changed:

var predicateOrdering = []string{
GeneralPred,
CheckNodeUnschedulablePred,
GeneralPred, HostNamePred, PodFitsHostPortsPred,
MatchNodeSelectorPred, PodFitsResourcesPred, NoDiskConflictPred,
PodToleratesNodeTaintsPred, CheckNodeLabelPresencePred,
CheckServiceAffinityPred, MaxEBSVolumeCountPred, MaxGCEPDVolumeCountPred, MaxCSIVolumeCountPred,
MaxAzureDiskVolumeCountPred, MaxCinderVolumeCountPred, CheckVolumeBindingPred, NoVolumeZoneConflictPred,
}

so predicateOrdering should be re-ordered according to Filter PluginSet.

Which issue(s) this PR fixes:
No

Special notes for your reviewer:
No

Does this PR introduce a user-facing change?:
No

```release-note
   update predicateOrdering according to filter pluginset
```

Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
No