### PR TITLE
fix filter algorithm order in factory_test.go

### DIFF
--- a/pkg/scheduler/factory_test.go
+++ b/pkg/scheduler/factory_test.go
@@ -124,12 +124,12 @@ func TestCreateFromConfig(t *testing.T) {
 				Filter: &schedulerapi.PluginSet{
 					Enabled: []schedulerapi.Plugin{
 						{Name: "NodeUnschedulable"},
-						{Name: "NodeResourcesFit"},
 						{Name: "NodeName"},
-						{Name: "NodePorts"},
-						{Name: "NodeAffinity"},
-						{Name: "VolumeRestrictions"},
 						{Name: "TaintToleration"},
+						{Name: "NodeAffinity"},
+						{Name: "NodePorts"},
+						{Name: "NodeResourcesFit"},
+						{Name: "VolumeRestrictions"},
 						{Name: "EBSLimits"},
 						{Name: "GCEPDLimits"},
 						{Name: "NodeVolumeLimits"},


### PR DESCRIPTION
What type of PR is this?
/kind bug

What this PR does / why we need it:
fix filter algorithm order in factory_test.go according to registry.go.

Which issue(s) this PR fixes:
No

Special notes for your reviewer:
No

Does this PR introduce a user-facing change?:
No

```release-note
   fix filter algorithm order in factory_test.go
```

Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
No