### PR TITLE
Fix seccomp PSP docker/default annotation handling

### DIFF
--- a/pkg/security/podsecuritypolicy/seccomp/BUILD
+++ b/pkg/security/podsecuritypolicy/seccomp/BUILD
@@ -13,6 +13,7 @@ go_library(
     deps = [
         "//pkg/api/pod:go_default_library",
         "//pkg/apis/core:go_default_library",
+        "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/validation/field:go_default_library",
     ],
 )

--- a/pkg/security/podsecuritypolicy/seccomp/strategy_test.go
+++ b/pkg/security/podsecuritypolicy/seccomp/strategy_test.go
@@ -21,7 +21,7 @@ import (
 	"strings"
 	"testing"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	api "k8s.io/kubernetes/pkg/apis/core"
 )
@@ -44,6 +44,12 @@ var (
 	}
 	allowSpecificLocalhost = map[string]string{
 		AllowedProfilesAnnotationKey: v1.SeccompLocalhostProfileNamePrefix + "foo",
+	}
+	allowSpecificDockerDefault = map[string]string{
+		AllowedProfilesAnnotationKey: v1.DeprecatedSeccompProfileDockerDefault,
+	}
+	allowSpecificRuntimeDefault = map[string]string{
+		AllowedProfilesAnnotationKey: v1.SeccompProfileRuntimeDefault,
 	}
 )
 
@@ -253,6 +259,20 @@ func TestValidatePod(t *testing.T) {
 			seccompProfile: &api.SeccompProfile{
 				Type:             api.SeccompProfileTypeLocalhost,
 				LocalhostProfile: &foo,
+			},
+			expectedError: "",
+		},
+		"docker/default PSP annotation automatically allows runtime/default pods": {
+			pspAnnotations: allowSpecificDockerDefault,
+			podAnnotations: map[string]string{
+				api.SeccompPodAnnotationKey: v1.SeccompProfileRuntimeDefault,
+			},
+			expectedError: "",
+		},
+		"runtime/default PSP annotation automatically allows docker/default pods": {
+			pspAnnotations: allowSpecificRuntimeDefault,
+			podAnnotations: map[string]string{
+				api.SeccompPodAnnotationKey: v1.DeprecatedSeccompProfileDockerDefault,
 			},
 			expectedError: "",
 		},


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
/kind regression

**What this PR does / why we need it**:

With the graduation of seccomp to GA we automatically convert the deprecated seccomp profile annotation `docker/default` to
`runtime/default`. This means that we now have to automatically allow `runtime/default` if a user specifies `docker/default` and vice versa in an allowed PSP seccomp profile.

**Which issue(s) this PR fixes**:

Fixes https://github.com/kubernetes/kubernetes/issues/95817

**Special notes for your reviewer**:

Has to be cherry-picked to release-1.19 branch.

**Does this PR introduce a user-facing change?**:

```release-note
Fixed a regression in 1.19 which prevented pods with `docker/default` seccomp annotations from being created in 1.19 if a PodSecurityPolicy was in place which did not allow `runtime/default` seccomp profiles.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs
- KEP: https://github.com/kubernetes/enhancements/blob/d80faa7/keps/sig-node/20190717-seccomp-ga.md
```
