### PR TITLE
Mitigate wind-up problem in AP&F: prevent queue virtualStart lag

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/queueset/queueset_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/queueset/queueset_test.go
@@ -125,7 +125,8 @@ type uniformScenario struct {
 	clients                                  []uniformClient
 	concurrencyLimit                         int
 	evalDuration                             time.Duration
-	expectFair                               []bool
+	expectedFair                             []bool
+	expectedFairnessMargin                   []float64
 	expectAllRequests                        bool
 	evalInqueueMetrics, evalExecutingMetrics bool
 	rejectReason                             string
@@ -182,9 +183,9 @@ func (uss *uniformScenarioState) exercise() {
 		}
 	}
 	if uss.doSplit {
-		uss.evalTo(uss.startTime.Add(uss.evalDuration/2), false, uss.expectFair[0])
+		uss.evalTo(uss.startTime.Add(uss.evalDuration/2), false, uss.expectedFair[0], uss.expectedFairnessMargin[0])
 	}
-	uss.evalTo(uss.startTime.Add(uss.evalDuration), true, uss.expectFair[len(uss.expectFair)-1])
+	uss.evalTo(uss.startTime.Add(uss.evalDuration), true, uss.expectedFair[len(uss.expectedFair)-1], uss.expectedFairnessMargin[len(uss.expectedFairnessMargin)-1])
 	uss.clk.Run(nil)
 	uss.finalReview()
 }
@@ -252,7 +253,7 @@ func (ust *uniformScenarioThread) callK(k int) {
 	}
 }
 
-func (uss *uniformScenarioState) evalTo(lim time.Time, last, expectFair bool) {
+func (uss *uniformScenarioState) evalTo(lim time.Time, last, expectFair bool, margin float64) {
 	uss.clk.Run(&lim)
 	uss.clk.SetTime(lim)
 	if uss.doSplit && !last {
@@ -275,10 +276,11 @@ func (uss *uniformScenarioState) evalTo(lim time.Time, last, expectFair bool) {
 		var gotFair bool
 		if fairAverages[i] > 0 {
 			relDiff := (averages[i] - fairAverages[i]) / fairAverages[i]
-			gotFair = math.Abs(relDiff) <= 0.1
+			gotFair = math.Abs(relDiff) <= margin
 		} else {
-			gotFair = math.Abs(averages[i]) <= 0.1
+			gotFair = math.Abs(averages[i]) <= margin
 		}
+
 		if gotFair != expectFair {
 			uss.t.Errorf("%s client %d last=%v got an Average of %v but the fair average was %v", uss.name, i, last, averages[i], fairAverages[i])
 		} else {
@@ -371,12 +373,13 @@ func TestNoRestraint(t *testing.T) {
 			{1001001001, 5, 10, time.Second, time.Second, false},
 			{2002002002, 2, 10, time.Second, time.Second / 2, false},
 		},
-		concurrencyLimit:  10,
-		evalDuration:      time.Second * 15,
-		expectFair:        []bool{true},
-		expectAllRequests: true,
-		clk:               clk,
-		counter:           counter,
+		concurrencyLimit:       10,
+		evalDuration:           time.Second * 15,
+		expectedFair:           []bool{true},
+		expectedFairnessMargin: []float64{0.1},
+		expectAllRequests:      true,
+		clk:                    clk,
+		counter:                counter,
 	}.exercise(t)
 }
 
@@ -405,14 +408,15 @@ func TestUniformFlowsHandSize1(t *testing.T) {
 			{1001001001, 8, 20, time.Second, time.Second - 1, false},
 			{2002002002, 8, 20, time.Second, time.Second - 1, false},
 		},
-		concurrencyLimit:     4,
-		evalDuration:         time.Second * 50,
-		expectFair:           []bool{true},
-		expectAllRequests:    true,
-		evalInqueueMetrics:   true,
-		evalExecutingMetrics: true,
-		clk:                  clk,
-		counter:              counter,
+		concurrencyLimit:       4,
+		evalDuration:           time.Second * 50,
+		expectedFair:           []bool{true},
+		expectedFairnessMargin: []float64{0.1},
+		expectAllRequests:      true,
+		evalInqueueMetrics:     true,
+		evalExecutingMetrics:   true,
+		clk:                    clk,
+		counter:                counter,
 	}.exercise(t)
 }
 
@@ -440,14 +444,15 @@ func TestUniformFlowsHandSize3(t *testing.T) {
 			{1001001001, 8, 30, time.Second, time.Second - 1, false},
 			{2002002002, 8, 30, time.Second, time.Second - 1, false},
 		},
-		concurrencyLimit:     4,
-		evalDuration:         time.Second * 60,
-		expectFair:           []bool{true},
-		expectAllRequests:    true,
-		evalInqueueMetrics:   true,
-		evalExecutingMetrics: true,
-		clk:                  clk,
-		counter:              counter,
+		concurrencyLimit:       4,
+		evalDuration:           time.Second * 60,
+		expectedFair:           []bool{true},
+		expectedFairnessMargin: []float64{0.1},
+		expectAllRequests:      true,
+		evalInqueueMetrics:     true,
+		evalExecutingMetrics:   true,
+		clk:                    clk,
+		counter:                counter,
 	}.exercise(t)
 }
 
@@ -476,14 +481,15 @@ func TestDifferentFlowsExpectEqual(t *testing.T) {
 			{1001001001, 8, 20, time.Second, time.Second, false},
 			{2002002002, 7, 30, time.Second, time.Second / 2, false},
 		},
-		concurrencyLimit:     4,
-		evalDuration:         time.Second * 40,
-		expectFair:           []bool{true},
-		expectAllRequests:    true,
-		evalInqueueMetrics:   true,
-		evalExecutingMetrics: true,
-		clk:                  clk,
-		counter:              counter,
+		concurrencyLimit:       4,
+		evalDuration:           time.Second * 40,
+		expectedFair:           []bool{true},
+		expectedFairnessMargin: []float64{0.1},
+		expectAllRequests:      true,
+		evalInqueueMetrics:     true,
+		evalExecutingMetrics:   true,
+		clk:                    clk,
+		counter:                counter,
 	}.exercise(t)
 }
 
@@ -512,14 +518,15 @@ func TestDifferentFlowsExpectUnequal(t *testing.T) {
 			{1001001001, 4, 20, time.Second, time.Second - 1, false},
 			{2002002002, 2, 20, time.Second, time.Second - 1, false},
 		},
-		concurrencyLimit:     3,
-		evalDuration:         time.Second * 20,
-		expectFair:           []bool{true},
-		expectAllRequests:    true,
-		evalInqueueMetrics:   true,
-		evalExecutingMetrics: true,
-		clk:                  clk,
-		counter:              counter,
+		concurrencyLimit:       3,
+		evalDuration:           time.Second * 20,
+		expectedFair:           []bool{true},
+		expectedFairnessMargin: []float64{0.1},
+		expectAllRequests:      true,
+		evalInqueueMetrics:     true,
+		evalExecutingMetrics:   true,
+		clk:                    clk,
+		counter:                counter,
 	}.exercise(t)
 }
 
@@ -547,14 +554,15 @@ func TestWindup(t *testing.T) {
 			{1001001001, 2, 40, time.Second, -1, false},
 			{2002002002, 2, 40, time.Second, -1, true},
 		},
-		concurrencyLimit:     3,
-		evalDuration:         time.Second * 40,
-		expectFair:           []bool{true, false},
-		expectAllRequests:    true,
-		evalInqueueMetrics:   true,
-		evalExecutingMetrics: true,
-		clk:                  clk,
-		counter:              counter,
+		concurrencyLimit:       3,
+		evalDuration:           time.Second * 40,
+		expectedFair:           []bool{true, true},
+		expectedFairnessMargin: []float64{0.1, 0.26},
+		expectAllRequests:      true,
+		evalInqueueMetrics:     true,
+		evalExecutingMetrics:   true,
+		clk:                    clk,
+		counter:                counter,
 	}.exercise(t)
 }
 
@@ -580,13 +588,14 @@ func TestDifferentFlowsWithoutQueuing(t *testing.T) {
 			{1001001001, 6, 10, time.Second, 57 * time.Millisecond, false},
 			{2002002002, 4, 15, time.Second, 750 * time.Millisecond, false},
 		},
-		concurrencyLimit:     4,
-		evalDuration:         time.Second * 13,
-		expectFair:           []bool{false},
-		evalExecutingMetrics: true,
-		rejectReason:         "concurrency-limit",
-		clk:                  clk,
-		counter:              counter,
+		concurrencyLimit:       4,
+		evalDuration:           time.Second * 13,
+		expectedFair:           []bool{false},
+		expectedFairnessMargin: []float64{0.1},
+		evalExecutingMetrics:   true,
+		rejectReason:           "concurrency-limit",
+		clk:                    clk,
+		counter:                counter,
 	}.exercise(t)
 }
 
@@ -614,14 +623,15 @@ func TestTimeout(t *testing.T) {
 		clients: []uniformClient{
 			{1001001001, 5, 100, time.Second, time.Second, false},
 		},
-		concurrencyLimit:     1,
-		evalDuration:         time.Second * 10,
-		expectFair:           []bool{true},
-		evalInqueueMetrics:   true,
-		evalExecutingMetrics: true,
-		rejectReason:         "time-out",
-		clk:                  clk,
-		counter:              counter,
+		concurrencyLimit:       1,
+		evalDuration:           time.Second * 10,
+		expectedFair:           []bool{true},
+		expectedFairnessMargin: []float64{0.1},
+		evalInqueueMetrics:     true,
+		evalExecutingMetrics:   true,
+		rejectReason:           "time-out",
+		clk:                    clk,
+		counter:                counter,
 	}.exercise(t)
 }
 


### PR DESCRIPTION
```release-note
NONE
```
here is simpler simulation how the max-min fairness issue happens for the [wind-up test](https://github.com/kubernetes/kubernetes/blob/ecfcd5fe596b2683d5419b8ce2460272889f2d94/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/queueset/queueset_test.go#L526-L559) where the global virtual time proceeds 1.5/s because `rate = ConcurrencyLimit/NEQ` hence `1.5 = 3/2` and at the beginning of the test Q1 demands 2/s and Q2 demands 1/s, at the middle of test, we double the demand for Q2 to 2/s:
```
# VS(queue) = virtual start for the queue,  VSE(queue) = virtual start for the queue excluding the estimated service time
# GVT = global virtual time, or per-queue-set virtual time, RT = real world time

(before this PR)
---------------------------------------------------------------------
| RT      |  1  |  2  |  3  | ... | 20 |  21  | 22 |  23  | ...| 40 | 
---------------------------------------------------------------------
| VSE(Q1) |  2  |  4  |  6  | ... | 40 |  41  | 42 |  43  | ...| 60 | 
---------------------------------------------------------------------
| VSE(Q2) |  1  |  2  |  3  | ... | 20 |  22  | 24 |  26  | ...| 60 |
---------------------------------------------------------------------
| GVT     | 1.5 |  3  | 4.5 | ... | 30 | 31.5 | 33 | 34.5 | ...| 60 |
---------------------------------------------------------------------
                                    ^                               ^
        (we double the throughput for Q2 at this point)         (VSE reaches equal for Q1 and Q2 at this point)                                                            



(after this PR)
------------------------------------------------------------------------------------
| RT      |  1  |  2  |  3  | ... | 20 |  21  | 22 |  23  | ...| 30 |  31  | ...| 40 |
------------------------------------------------------------------------------------
| VSE(Q1) |  2  |  4  |  6  | ... | 40 |  41  | 42 |  43  | ...| 50 | 51.5 | ...| 65 | 
------------------------------------------------------------------------------------
| VSE(Q2) | 1.5 |  3  | 4.5 | ... | 30 |  32  | 34 |  36  | ...| 50 | 51.5 | ...| 65 |
------------------------------------------------------------------------------------
| GVT     | 1.5 |  3  | 4.5 | ... | 30 | 31.5 | 33 | 34.5 | ...| 45 | 46.5 | ...| 60 |
------------------------------------------------------------------------------------
                                    ^                               ^
        (we double the throughput for Q2 at this point)         (VSE reaches equal for Q1 and Q2 at this point)                
```

then let's generalize the ratio of demanding concurrency of Q1:Q2 from `2:1` to `n:1`, if the credit accumulates for a period of real time `T`, then Q2 will take `T/n` real time to catch up with Q1's VSE. hence the bigger burst of credit accumulation we have, the shorter period of time it takes to ease the burst.

btw the tests are adjusted to introduce a margin value for evaluating fairness.
