### PR TITLE
remove note E2eScheduling

### DIFF
--- a/pkg/scheduler/metrics/metrics.go
+++ b/pkg/scheduler/metrics/metrics.go
@@ -37,7 +37,6 @@ const (
 	PreemptionEvaluation = "preemption_evaluation"
 	// Binding - binding operation label value
 	Binding = "binding"
-	// E2eScheduling - e2e scheduling operation label value
 )
 
 // All the histogram based metrics have 1ms as size for the smallest bucket.


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
E2eScheduling has been removed, so remove the note.

**Which issue(s) this PR fixes**:
No

**Special notes for your reviewer**:
No

**Does this PR introduce a user-facing change?**:
No

```release-note
   NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
No
