### PR TITLE
Automated cherry pick of #95985: Fix seccomp PSP docker/default annotation handling

### DIFF
--- a/pkg/security/podsecuritypolicy/seccomp/BUILD
+++ b/pkg/security/podsecuritypolicy/seccomp/BUILD
@@ -13,6 +13,7 @@ go_library(
     deps = [
         "//pkg/api/pod:go_default_library",
         "//pkg/apis/core:go_default_library",
+        "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/validation/field:go_default_library",
     ],
 )

--- a/pkg/security/podsecuritypolicy/seccomp/strategy_test.go
+++ b/pkg/security/podsecuritypolicy/seccomp/strategy_test.go
@@ -21,7 +21,7 @@ import (
 	"strings"
 	"testing"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	api "k8s.io/kubernetes/pkg/apis/core"
 )
@@ -44,6 +44,12 @@ var (
 	}
 	allowSpecificLocalhost = map[string]string{
 		AllowedProfilesAnnotationKey: v1.SeccompLocalhostProfileNamePrefix + "foo",
+	}
+	allowSpecificDockerDefault = map[string]string{
+		AllowedProfilesAnnotationKey: v1.DeprecatedSeccompProfileDockerDefault,
+	}
+	allowSpecificRuntimeDefault = map[string]string{
+		AllowedProfilesAnnotationKey: v1.SeccompProfileRuntimeDefault,
 	}
 )
 
@@ -253,6 +259,20 @@ func TestValidatePod(t *testing.T) {
 			seccompProfile: &api.SeccompProfile{
 				Type:             api.SeccompProfileTypeLocalhost,
 				LocalhostProfile: &foo,
+			},
+			expectedError: "",
+		},
+		"docker/default PSP annotation automatically allows runtime/default pods": {
+			pspAnnotations: allowSpecificDockerDefault,
+			podAnnotations: map[string]string{
+				api.SeccompPodAnnotationKey: v1.SeccompProfileRuntimeDefault,
+			},
+			expectedError: "",
+		},
+		"runtime/default PSP annotation automatically allows docker/default pods": {
+			pspAnnotations: allowSpecificRuntimeDefault,
+			podAnnotations: map[string]string{
+				api.SeccompPodAnnotationKey: v1.DeprecatedSeccompProfileDockerDefault,
 			},
 			expectedError: "",
 		},


### PR DESCRIPTION
Cherry pick of #95985 on release-1.19.

#95985: Fix seccomp PSP docker/default annotation handling

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-notes
Fixed a regression in 1.19 which prevented pods with `docker/default` seccomp annotations from being created in 1.19 if a PodSecurityPolicy was in place which did not allow `runtime/default` seccomp profiles.
```