### PR TITLE
Add datapolicy tags to cmd/kubeadm directory

### DIFF
--- a/cmd/kubeadm/app/cmd/join.go
+++ b/cmd/kubeadm/app/cmd/join.go
@@ -124,7 +124,7 @@ var (
 // supported by this api will be exposed as a flag.
 type joinOptions struct {
 	cfgPath               string
-	token                 string
+	token                 string `datapolicy:"token"`
 	controlPlane          bool
 	ignorePreflightErrors []string
 	externalcfg           *kubeadmapiv1beta2.JoinConfiguration

--- a/cmd/kubeadm/app/cmd/options/token.go
+++ b/cmd/kubeadm/app/cmd/options/token.go
@@ -39,7 +39,7 @@ func NewBootstrapTokenOptions() *BootstrapTokenOptions {
 // TODO: In the future, we might want to group the flags in a better way than adding them all individually like this
 type BootstrapTokenOptions struct {
 	*kubeadmapiv1beta2.BootstrapToken
-	TokenStr string
+	TokenStr string `datapolicy:"token"`
 }
 
 // AddTokenFlag adds the --token flag to the given flagset

--- a/cmd/kubeadm/app/phases/kubeconfig/kubeconfig.go
+++ b/cmd/kubeadm/app/phases/kubeconfig/kubeconfig.go
@@ -53,7 +53,7 @@ type clientCertAuth struct {
 
 // tokenAuth struct holds info required to use a token to provide authentication info in a kubeconfig object
 type tokenAuth struct {
-	Token string
+	Token string `datapolicy:"token"`
 }
 
 // kubeConfigSpec struct holds info required to build a KubeConfig object
@@ -61,8 +61,8 @@ type kubeConfigSpec struct {
 	CACert         *x509.Certificate
 	APIServer      string
 	ClientName     string
-	TokenAuth      *tokenAuth
-	ClientCertAuth *clientCertAuth
+	TokenAuth      *tokenAuth      `datapolicy:"token"`
+	ClientCertAuth *clientCertAuth `datapolicy:"security-key"`
 }
 
 // CreateJoinControlPlaneKubeConfigFiles will create and write to disk the kubeconfig files required by kubeadm

--- a/cmd/kubeadm/app/phases/selfhosting/selfhosting_volumes.go
+++ b/cmd/kubeadm/app/phases/selfhosting/selfhosting_volumes.go
@@ -29,7 +29,7 @@ import (
 	"k8s.io/kubernetes/cmd/kubeadm/app/util/apiclient"
 )
 
-type tlsKeyPair struct {
+type tlsKeyPairPath struct {
 	name string
 	cert string
 	key  string
@@ -310,8 +310,8 @@ func createOpaqueSecretFromFile(secretName, file string) (*v1.Secret, error) {
 	}, nil
 }
 
-func getTLSKeyPairs() []*tlsKeyPair {
-	return []*tlsKeyPair{
+func getTLSKeyPairs() []*tlsKeyPairPath {
+	return []*tlsKeyPairPath{
 		{
 			name: kubeadmconstants.CACertAndKeyBaseName,
 			cert: kubeadmconstants.CACertName,


### PR DESCRIPTION
/kind feature

**What this PR does / why we need it**:
This PR adds "datapolicy" tags to golang structures as described in [Kubernetes system components logs sanitization KEP](https://github.com/kubernetes/enhancements/tree/master/keps/sig-instrumentation/1753-logs-sanitization). Those tags will be used by for ensuring this data will not be written to logs by Kubernetes system components. 

List of datapolicy tags available:
* `security-key` - for TLS certificate keys. Keywords: `key`, `cert`, `pem` 
* `token` - for HTTP authorization tokens. Keywords: `token`, `secret`, `header`, `auth`
* `password` - anything passwordlike. Keywords: `password`

**Special notes for your reviewer**:

Due to size of Kubernetes codebase first iteration of tagging was done based on greping for particular keyword. Please ensure that tagged fields do contain type of sensitive data that matches their tag. Feel free to suggest any additional places that you think should be tagged.

**Does this PR introduce a user-facing change?**:
No
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs
- [KEP]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-instrumentation/1753-logs-sanitization
```

/cc @PurelyApplied
/sig instrumentation security
/priority important-soon
/milestone v1.20