### PR TITLE
Add datapolicy tags to  staging/src/k8s.io/legacy-cloud-providers

### DIFF
--- a/pkg/volume/cinder/cinder_test.go
+++ b/pkg/volume/cinder/cinder_test.go
@@ -316,7 +316,7 @@ func getOpenstackConfig() openstack.Config {
 			AuthURL         string `gcfg:"auth-url"`
 			Username        string
 			UserID          string `gcfg:"user-id"`
-			Password        string
+			Password        string `datapolicy:"password"`
 			TenantID        string `gcfg:"tenant-id"`
 			TenantName      string `gcfg:"tenant-name"`
 			TrustID         string `gcfg:"trust-id"`

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/auth/azure_auth.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/auth/azure_auth.go
@@ -49,11 +49,11 @@ type AzureAuthConfig struct {
 	// The ClientID for an AAD application with RBAC access to talk to Azure RM APIs
 	AADClientID string `json:"aadClientId,omitempty" yaml:"aadClientId,omitempty"`
 	// The ClientSecret for an AAD application with RBAC access to talk to Azure RM APIs
-	AADClientSecret string `json:"aadClientSecret,omitempty" yaml:"aadClientSecret,omitempty"`
+	AADClientSecret string `json:"aadClientSecret,omitempty" yaml:"aadClientSecret,omitempty" datapolicy:"token"`
 	// The path of a client certificate for an AAD application with RBAC access to talk to Azure RM APIs
 	AADClientCertPath string `json:"aadClientCertPath,omitempty" yaml:"aadClientCertPath,omitempty"`
 	// The password of the client certificate for an AAD application with RBAC access to talk to Azure RM APIs
-	AADClientCertPassword string `json:"aadClientCertPassword,omitempty" yaml:"aadClientCertPassword,omitempty"`
+	AADClientCertPassword string `json:"aadClientCertPassword,omitempty" yaml:"aadClientCertPassword,omitempty" datapolicy:"password"`
 	// Use managed service identity for the virtual machine to access Azure ARM APIs
 	UseManagedIdentityExtension bool `json:"useManagedIdentityExtension,omitempty" yaml:"useManagedIdentityExtension,omitempty"`
 	// UserAssignedIdentityID contains the Client ID of the user assigned MSI which is assigned to the underlying VMs. If empty the user assigned identity is not used.

--- a/staging/src/k8s.io/legacy-cloud-providers/gce/gce.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/gce/gce.go
@@ -171,7 +171,7 @@ type Cloud struct {
 // TODO: replace gcfg with json
 type ConfigGlobal struct {
 	TokenURL  string `gcfg:"token-url"`
-	TokenBody string `gcfg:"token-body"`
+	TokenBody string `gcfg:"token-body" datapolicy:"token"`
 	// ProjectID and NetworkProjectID can either be the numeric or string-based
 	// unique identifier that starts with [a-z].
 	ProjectID string `gcfg:"project-id"`

--- a/staging/src/k8s.io/legacy-cloud-providers/gce/token_source.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/gce/token_source.go
@@ -75,7 +75,7 @@ func init() {
 type AltTokenSource struct {
 	oauthClient *http.Client
 	tokenURL    string
-	tokenBody   string
+	tokenBody   string `datapolicy:"token"`
 	throttle    flowcontrol.RateLimiter
 }
 
@@ -104,7 +104,7 @@ func (a *AltTokenSource) token() (*oauth2.Token, error) {
 		return nil, err
 	}
 	var tok struct {
-		AccessToken string    `json:"accessToken"`
+		AccessToken string    `json:"accessToken" datapolicy:"token"`
 		ExpireTime  time.Time `json:"expireTime"`
 	}
 	if err := json.NewDecoder(res.Body).Decode(&tok); err != nil {

--- a/staging/src/k8s.io/legacy-cloud-providers/openstack/openstack.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/openstack/openstack.go
@@ -158,7 +158,7 @@ type Config struct {
 		AuthURL         string `gcfg:"auth-url"`
 		Username        string
 		UserID          string `gcfg:"user-id"`
-		Password        string
+		Password        string `datapolicy:"password"`
 		TenantID        string `gcfg:"tenant-id"`
 		TenantName      string `gcfg:"tenant-name"`
 		TrustID         string `gcfg:"trust-id"`

--- a/staging/src/k8s.io/legacy-cloud-providers/vsphere/credentialmanager.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/vsphere/credentialmanager.go
@@ -53,7 +53,7 @@ type SecretCache struct {
 
 type Credential struct {
 	User     string `gcfg:"user"`
-	Password string `gcfg:"password"`
+	Password string `gcfg:"password" datapolicy:"password"`
 }
 
 type SecretCredentialManager struct {

--- a/staging/src/k8s.io/legacy-cloud-providers/vsphere/vclib/connection.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/vsphere/vclib/connection.go
@@ -37,7 +37,7 @@ import (
 type VSphereConnection struct {
 	Client            *vim25.Client
 	Username          string
-	Password          string
+	Password          string `datapolicy:"password"`
 	Hostname          string
 	Port              string
 	CACert            string

--- a/staging/src/k8s.io/legacy-cloud-providers/vsphere/vsphere.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/vsphere/vsphere.go
@@ -113,7 +113,7 @@ type VirtualCenterConfig struct {
 	// vCenter username.
 	User string `gcfg:"user"`
 	// vCenter password in clear text.
-	Password string `gcfg:"password"`
+	Password string `gcfg:"password" datapolicy:"password"`
 	// vCenter port.
 	VCenterPort string `gcfg:"port"`
 	// Datacenter in which VMs are located.
@@ -137,7 +137,7 @@ type VSphereConfig struct {
 		// vCenter username.
 		User string `gcfg:"user"`
 		// vCenter password in clear text.
-		Password string `gcfg:"password"`
+		Password string `gcfg:"password" datapolicy:"password"`
 		// Deprecated. Use VirtualCenter to specify multiple vCenter Servers.
 		// vCenter IP.
 		VCenterIP string `gcfg:"server"`


### PR DESCRIPTION
/kind feature

**What this PR does / why we need it**:
This PR adds "datapolicy" tags to golang structures as described in [Kubernetes system components logs sanitization KEP](https://github.com/kubernetes/enhancements/tree/master/keps/sig-instrumentation/1753-logs-sanitization). Those tags will be used by for ensuring this data will not be written to logs by Kubernetes system components. 

List of datapolicy tags available:
* `security-key` - for TLS certificate keys. Keywords: `key`, `cert`, `pem` 
* `token` - for HTTP authorization tokens. Keywords: `token`, `secret`, `header`, `auth`
* `password` - anything passwordlike. Keywords: `password`

**Special notes for your reviewer**:

Due to size of Kubernetes codebase first iteration of tagging was done based on greping for particular keyword. Please ensure that tagged fields do contain type of sensitive data that matches their tag. Feel free to suggest any additional places that you think should be tagged.

**Does this PR introduce a user-facing change?**:
No
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs
- [KEP]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-instrumentation/1753-logs-sanitization
```

/cc @PurelyApplied
/sig instrumentation security
/priority important-soon
/milestone v1.20