### PR TITLE
git Add datapolicy tags to  staging/src/k8s.io/kubectl/

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/create_authinfo.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/create_authinfo.go
@@ -40,9 +40,9 @@ type createAuthInfoOptions struct {
 	name              string
 	clientCertificate cliflag.StringFlag
 	clientKey         cliflag.StringFlag
-	token             cliflag.StringFlag
+	token             cliflag.StringFlag `datapolicy:"token"`
 	username          cliflag.StringFlag
-	password          cliflag.StringFlag
+	password          cliflag.StringFlag `datapolicy:"password"`
 	embedCertData     cliflag.Tristate
 	authProvider      cliflag.StringFlag
 

--- a/staging/src/k8s.io/kubectl/pkg/generate/versioned/secret_for_docker_registry.go
+++ b/staging/src/k8s.io/kubectl/pkg/generate/versioned/secret_for_docker_registry.go
@@ -38,7 +38,7 @@ type SecretForDockerRegistryGeneratorV1 struct {
 	// Email for registry (optional)
 	Email string
 	// Password for registry (required)
-	Password string
+	Password string `datapolicy:"password"`
 	// Server for registry (required)
 	Server string
 	// AppendHash; if true, derive a hash from the Secret and append it to the name
@@ -171,9 +171,9 @@ func encodeDockerConfigFieldAuth(username, password string) string {
 // DockerConfigJSON represents a local docker auth config file
 // for pulling images.
 type DockerConfigJSON struct {
-	Auths DockerConfig `json:"auths"`
+	Auths DockerConfig `json:"auths" datapolicy:"token"`
 	// +optional
-	HttpHeaders map[string]string `json:"HttpHeaders,omitempty"`
+	HttpHeaders map[string]string `json:"HttpHeaders,omitempty" datapolicy:"token"`
 }
 
 // DockerConfig represents the config file used by the docker CLI.
@@ -183,7 +183,7 @@ type DockerConfig map[string]DockerConfigEntry
 
 type DockerConfigEntry struct {
 	Username string `json:"username,omitempty"`
-	Password string `json:"password,omitempty"`
+	Password string `json:"password,omitempty" datapolicy:"password"`
 	Email    string `json:"email,omitempty"`
-	Auth     string `json:"auth,omitempty"`
+	Auth     string `json:"auth,omitempty" datapolicy:"token"`
 }


### PR DESCRIPTION
/kind feature

**What this PR does / why we need it**:
This PR adds "datapolicy" tags to golang structures as described in [Kubernetes system components logs sanitization KEP](https://github.com/kubernetes/enhancements/tree/master/keps/sig-instrumentation/1753-logs-sanitization). Those tags will be used by for ensuring this data will not be written to logs by Kubernetes system components. 

List of datapolicy tags available:
* `security-key` - for TLS certificate keys. Keywords: `key`, `cert`, `pem` 
* `token` - for HTTP authorization tokens. Keywords: `token`, `secret`, `header`, `auth`
* `password` - anything passwordlike. Keywords: `password`

**Special notes for your reviewer**:

Due to size of Kubernetes codebase first iteration of tagging was done based on greping for particular keyword. Please ensure that tagged fields do contain type of sensitive data that matches their tag. Feel free to suggest any additional places that you think should be tagged.

**Does this PR introduce a user-facing change?**:
No
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs
- [KEP]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-instrumentation/1753-logs-sanitization
```

/cc @PurelyApplied
/sig instrumentation security
/priority important-soon
/milestone v1.20