### PR TITLE
Add datapolicy tags to staging/src/k8s.io/client-go/

### DIFF
--- a/staging/src/k8s.io/client-go/pkg/apis/clientauthentication/types.go
+++ b/staging/src/k8s.io/client-go/pkg/apis/clientauthentication/types.go
@@ -66,13 +66,13 @@ type ExecCredentialStatus struct {
 	ExpirationTimestamp *metav1.Time
 	// Token is a bearer token used by the client for request authentication.
 	// +optional
-	Token string
+	Token string `datapolicy:"token"`
 	// PEM-encoded client TLS certificate.
 	// +optional
 	ClientCertificateData string
 	// PEM-encoded client TLS private key.
 	// +optional
-	ClientKeyData string
+	ClientKeyData string `datapolicy:"secret-key"`
 }
 
 // Response defines metadata about a failed request, including HTTP status code and

--- a/staging/src/k8s.io/client-go/pkg/apis/clientauthentication/v1alpha1/types.go
+++ b/staging/src/k8s.io/client-go/pkg/apis/clientauthentication/v1alpha1/types.go
@@ -61,11 +61,11 @@ type ExecCredentialStatus struct {
 	// +optional
 	ExpirationTimestamp *metav1.Time `json:"expirationTimestamp,omitempty"`
 	// Token is a bearer token used by the client for request authentication.
-	Token string `json:"token,omitempty"`
+	Token string `json:"token,omitempty" datapolicy:"token"`
 	// PEM-encoded client TLS certificates (including intermediates, if any).
 	ClientCertificateData string `json:"clientCertificateData,omitempty"`
 	// PEM-encoded private key for the above certificate.
-	ClientKeyData string `json:"clientKeyData,omitempty"`
+	ClientKeyData string `json:"clientKeyData,omitempty" datapolicy:"security-key"`
 }
 
 // Response defines metadata about a failed request, including HTTP status code and

--- a/staging/src/k8s.io/client-go/pkg/apis/clientauthentication/v1beta1/types.go
+++ b/staging/src/k8s.io/client-go/pkg/apis/clientauthentication/v1beta1/types.go
@@ -58,11 +58,11 @@ type ExecCredentialStatus struct {
 	// +optional
 	ExpirationTimestamp *metav1.Time `json:"expirationTimestamp,omitempty"`
 	// Token is a bearer token used by the client for request authentication.
-	Token string `json:"token,omitempty"`
+	Token string `json:"token,omitempty" datapolicy:"token"`
 	// PEM-encoded client TLS certificates (including intermediates, if any).
 	ClientCertificateData string `json:"clientCertificateData,omitempty"`
 	// PEM-encoded private key for the above certificate.
-	ClientKeyData string `json:"clientKeyData,omitempty"`
+	ClientKeyData string `json:"clientKeyData,omitempty" datapolicy:"security-key"`
 }
 
 // Cluster contains information to allow an exec plugin to communicate

--- a/staging/src/k8s.io/client-go/plugin/pkg/client/auth/exec/exec.go
+++ b/staging/src/k8s.io/client-go/plugin/pkg/client/auth/exec/exec.go
@@ -241,8 +241,8 @@ type Authenticator struct {
 }
 
 type credentials struct {
-	token string
-	cert  *tls.Certificate
+	token string           `datapolicy:"token"`
+	cert  *tls.Certificate `datapolicy:"secret-key"`
 }
 
 // UpdateTransportConfig updates the transport.Config to use credentials

--- a/staging/src/k8s.io/client-go/plugin/pkg/client/auth/gcp/gcp.go
+++ b/staging/src/k8s.io/client-go/plugin/pkg/client/auth/gcp/gcp.go
@@ -188,7 +188,7 @@ func (g *gcpAuthProvider) Login() error { return nil }
 type cachedTokenSource struct {
 	lk          sync.Mutex
 	source      oauth2.TokenSource
-	accessToken string
+	accessToken string `datapolicy:"token"`
 	expiry      time.Time
 	persister   restclient.AuthProviderConfigPersister
 	cache       map[string]string
@@ -269,8 +269,8 @@ func (t *cachedTokenSource) baseCache() map[string]string {
 type commandTokenSource struct {
 	cmd       string
 	args      []string
-	tokenKey  string
-	expiryKey string
+	tokenKey  string `datapolicy:"token"`
+	expiryKey string `datapolicy:"secret-key"`
 	timeFmt   string
 }
 

--- a/staging/src/k8s.io/client-go/rest/config.go
+++ b/staging/src/k8s.io/client-go/rest/config.go
@@ -65,12 +65,12 @@ type Config struct {
 
 	// Server requires Basic authentication
 	Username string
-	Password string
+	Password string `datapolicy:"password"`
 
 	// Server requires Bearer authentication. This client will not attempt to use
 	// refresh tokens for an OAuth2 flow.
 	// TODO: demonstrate an OAuth2 compatible client.
-	BearerToken string
+	BearerToken string `datapolicy:"token"`
 
 	// Path to a file containing a BearerToken.
 	// If set, the contents are periodically read.
@@ -231,7 +231,7 @@ type TLSClientConfig struct {
 	CertData []byte
 	// KeyData holds PEM-encoded bytes (typically read from a client certificate key file).
 	// KeyData takes precedence over KeyFile
-	KeyData []byte
+	KeyData []byte `datapolicy:"security-key"`
 	// CAData holds PEM-encoded bytes (typically read from a root certificates bundle).
 	// CAData takes precedence over CAFile
 	CAData []byte

--- a/staging/src/k8s.io/client-go/tools/auth/clientauth.go
+++ b/staging/src/k8s.io/client-go/tools/auth/clientauth.go
@@ -75,11 +75,11 @@ import (
 // to be read/written from a file as a JSON object.
 type Info struct {
 	User        string
-	Password    string
+	Password    string `datapolicy:"password"`
 	CAFile      string
 	CertFile    string
 	KeyFile     string
-	BearerToken string
+	BearerToken string `datapolicy:"token"`
 	Insecure    *bool
 }
 

--- a/staging/src/k8s.io/client-go/tools/clientcmd/api/types.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/api/types.go
@@ -114,10 +114,10 @@ type AuthInfo struct {
 	ClientKey string `json:"client-key,omitempty"`
 	// ClientKeyData contains PEM-encoded data from a client key file for TLS. Overrides ClientKey
 	// +optional
-	ClientKeyData []byte `json:"client-key-data,omitempty"`
+	ClientKeyData []byte `json:"client-key-data,omitempty" datapolicy:"security-key"`
 	// Token is the bearer token for authentication to the kubernetes cluster.
 	// +optional
-	Token string `json:"token,omitempty"`
+	Token string `json:"token,omitempty" datapolicy:"token"`
 	// TokenFile is a pointer to a file that contains a bearer token (as described above).  If both Token and TokenFile are present, Token takes precedence.
 	// +optional
 	TokenFile string `json:"tokenFile,omitempty"`
@@ -135,7 +135,7 @@ type AuthInfo struct {
 	Username string `json:"username,omitempty"`
 	// Password is the password for basic authentication to the kubernetes cluster.
 	// +optional
-	Password string `json:"password,omitempty"`
+	Password string `json:"password,omitempty" datapolicy:"password"`
 	// AuthProvider specifies a custom authentication plugin for the kubernetes cluster.
 	// +optional
 	AuthProvider *AuthProviderConfig `json:"auth-provider,omitempty"`

--- a/staging/src/k8s.io/client-go/tools/clientcmd/api/v1/types.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/api/v1/types.go
@@ -104,10 +104,10 @@ type AuthInfo struct {
 	ClientKey string `json:"client-key,omitempty"`
 	// ClientKeyData contains PEM-encoded data from a client key file for TLS. Overrides ClientKey
 	// +optional
-	ClientKeyData []byte `json:"client-key-data,omitempty"`
+	ClientKeyData []byte `json:"client-key-data,omitempty" datapolicy:"security-key"`
 	// Token is the bearer token for authentication to the kubernetes cluster.
 	// +optional
-	Token string `json:"token,omitempty"`
+	Token string `json:"token,omitempty" datapolicy:"token"`
 	// TokenFile is a pointer to a file that contains a bearer token (as described above).  If both Token and TokenFile are present, Token takes precedence.
 	// +optional
 	TokenFile string `json:"tokenFile,omitempty"`
@@ -125,7 +125,7 @@ type AuthInfo struct {
 	Username string `json:"username,omitempty"`
 	// Password is the password for basic authentication to the kubernetes cluster.
 	// +optional
-	Password string `json:"password,omitempty"`
+	Password string `json:"password,omitempty" datapolicy:"password"`
 	// AuthProvider specifies a custom authentication plugin for the kubernetes cluster.
 	// +optional
 	AuthProvider *AuthProviderConfig `json:"auth-provider,omitempty"`

--- a/staging/src/k8s.io/client-go/tools/clientcmd/client_config.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/client_config.go
@@ -77,7 +77,7 @@ type PersistAuthProviderConfigForUser func(user string) restclient.AuthProviderC
 
 type promptedCredentials struct {
 	username string
-	password string
+	password string `datapolicy:"password"`
 }
 
 // DirectClientConfig is a ClientConfig interface that is backed by a clientcmdapi.Config, options overrides, and an optional fallbackReader for auth information

--- a/staging/src/k8s.io/client-go/transport/cache.go
+++ b/staging/src/k8s.io/client-go/transport/cache.go
@@ -44,7 +44,7 @@ type tlsCacheKey struct {
 	insecure           bool
 	caData             string
 	certData           string
-	keyData            string
+	keyData            string `datapolicy:"security-key"`
 	certFile           string
 	keyFile            string
 	serverName         string

--- a/staging/src/k8s.io/client-go/transport/config.go
+++ b/staging/src/k8s.io/client-go/transport/config.go
@@ -35,10 +35,10 @@ type Config struct {
 
 	// Username and password for basic authentication
 	Username string
-	Password string
+	Password string `datapolicy:"password"`
 
 	// Bearer token for authentication
-	BearerToken string
+	BearerToken string `datapolicy:"token"`
 
 	// Path to a file containing a BearerToken.
 	// If set, the contents are periodically read.

--- a/staging/src/k8s.io/client-go/transport/round_trippers.go
+++ b/staging/src/k8s.io/client-go/transport/round_trippers.go
@@ -167,7 +167,7 @@ func (rt *userAgentRoundTripper) WrappedRoundTripper() http.RoundTripper { retur
 
 type basicAuthRoundTripper struct {
 	username string
-	password string
+	password string `datapolicy:"password"`
 	rt       http.RoundTripper
 }
 
@@ -305,7 +305,7 @@ func (rt *bearerAuthRoundTripper) WrappedRoundTripper() http.RoundTripper { retu
 
 // requestInfo keeps track of information about a request/response combination
 type requestInfo struct {
-	RequestHeaders http.Header
+	RequestHeaders http.Header `datapolicy:"token"`
 	RequestVerb    string
 	RequestURL     string
 

--- a/staging/src/k8s.io/client-go/util/certificate/certificate_manager.go
+++ b/staging/src/k8s.io/client-go/util/certificate/certificate_manager.go
@@ -114,7 +114,7 @@ type Config struct {
 	// This is intended to allow the first boot of a component to be
 	// initialized using a generic, multi-use cert/key pair which will be
 	// quickly replaced with a unique cert/key pair.
-	BootstrapKeyPEM []byte
+	BootstrapKeyPEM []byte `datapolicy:"security-key"`
 	// CertificateRotation will record a metric showing the time in seconds
 	// that certificates lived before being rotated. This metric is a histogram
 	// because there is value in keeping a history of rotation cadences. It


### PR DESCRIPTION
/kind feature

**What this PR does / why we need it**:
This PR adds "datapolicy" tags to golang structures as described in [Kubernetes system components logs sanitization KEP](https://github.com/kubernetes/enhancements/tree/master/keps/sig-instrumentation/1753-logs-sanitization). Those tags will be used by for ensuring this data will not be written to logs by Kubernetes system components. 

List of datapolicy tags available:
* `security-key` - for TLS certificate keys. Keywords: `key`, `cert`, `pem` 
* `token` - for HTTP authorization tokens. Keywords: `token`, `secret`, `header`, `auth`
* `password` - anything passwordlike. Keywords: `password`

**Special notes for your reviewer**:

Due to size of Kubernetes codebase first iteration of tagging was done based on greping for particular keyword. Please ensure that tagged fields do contain type of sensitive data that matches their tag. Feel free to suggest any additional places that you think should be tagged.

**Does this PR introduce a user-facing change?**:
No
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs
- [KEP]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-instrumentation/1753-logs-sanitization
```

/cc @PurelyApplied
/sig instrumentation security
/priority important-soon
/milestone v1.20