### PR TITLE
Add datapolicy tags to staging/src/k8s.io/apiserver/

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/apis/apiserver/v1alpha1/types.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/apiserver/v1alpha1/types.go
@@ -139,7 +139,7 @@ type TLSConfig struct {
 	// Must be absent/empty if TCPTransport.URL is prefixed with http://
 	// Must be configured if TCPTransport.URL is prefixed with https://
 	// +optional
-	ClientKey string `json:"clientKey,omitempty"`
+	ClientKey string `json:"clientKey,omitempty" datapolicy:"security-key"`
 
 	// clientCert is the file location of the client certificate to be used in mtls handshakes with the konnectivity server.
 	// Must be absent/empty if TCPTransport.URL is prefixed with http://

--- a/staging/src/k8s.io/apiserver/pkg/apis/apiserver/v1beta1/types.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/apiserver/v1beta1/types.go
@@ -110,7 +110,7 @@ type TLSConfig struct {
 	// Must be absent/empty if TCPTransport.URL is prefixed with http://
 	// Must be configured if TCPTransport.URL is prefixed with https://
 	// +optional
-	ClientKey string `json:"clientKey,omitempty"`
+	ClientKey string `json:"clientKey,omitempty" datapolicy:"security-key"`
 
 	// clientCert is the file location of the client certificate to be used in mtls handshakes with the konnectivity server.
 	// Must be absent/empty if TCPTransport.URL is prefixed with http://

--- a/staging/src/k8s.io/apiserver/pkg/apis/config/types.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/config/types.go
@@ -73,7 +73,7 @@ type Key struct {
 	// name is the name of the key to be used while storing data to disk.
 	Name string
 	// secret is the actual key, encoded in base64.
-	Secret string
+	Secret string `datapolicy:"token"`
 }
 
 // String implements Stringer interface in a log safe way.

--- a/staging/src/k8s.io/apiserver/pkg/apis/config/v1/types.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/config/v1/types.go
@@ -73,7 +73,7 @@ type Key struct {
 	// name is the name of the key to be used while storing data to disk.
 	Name string `json:"name"`
 	// secret is the actual key, encoded in base64.
-	Secret string `json:"secret"`
+	Secret string `json:"secret" datapolicy:"token"`
 }
 
 // String implements Stringer interface in a log safe way.

--- a/staging/src/k8s.io/apiserver/pkg/authentication/request/headerrequest/requestheader_controller.go
+++ b/staging/src/k8s.io/apiserver/pkg/authentication/request/headerrequest/requestheader_controller.go
@@ -53,8 +53,8 @@ type RequestHeaderAuthRequestProvider interface {
 var _ RequestHeaderAuthRequestProvider = &RequestHeaderAuthRequestController{}
 
 type requestHeaderBundle struct {
-	UsernameHeaders     []string
-	GroupHeaders        []string
+	UsernameHeaders     []string `datapolicy:"token"`
+	GroupHeaders        []string `datapolicy:"token"`
 	ExtraHeaderPrefixes []string
 	AllowedClientNames  []string
 }

--- a/staging/src/k8s.io/apiserver/pkg/server/dynamiccertificates/cert_key.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/dynamiccertificates/cert_key.go
@@ -38,7 +38,7 @@ type SNICertKeyContentProvider interface {
 // certKeyContent holds the content for the cert and key
 type certKeyContent struct {
 	cert []byte
-	key  []byte
+	key  []byte `datapolicy:"security-key"`
 }
 
 func (c *certKeyContent) Equal(rhs *certKeyContent) bool {

--- a/staging/src/k8s.io/apiserver/pkg/server/dynamiccertificates/dynamic_serving_content.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/dynamiccertificates/dynamic_serving_content.go
@@ -39,7 +39,7 @@ type DynamicCertKeyPairContent struct {
 	keyFile string
 
 	// servingCert is a certKeyContent that contains the last read, non-zero length content of the key and cert
-	certKeyPair atomic.Value
+	certKeyPair atomic.Value `datapolicy:"security-key"`
 
 	listeners []Listener
 

--- a/staging/src/k8s.io/apiserver/pkg/server/options/authentication.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/authentication.go
@@ -41,8 +41,8 @@ type RequestHeaderAuthenticationOptions struct {
 	// before trusting usernames in headers.
 	ClientCAFile string
 
-	UsernameHeaders     []string
-	GroupHeaders        []string
+	UsernameHeaders     []string `datapolicy:"token"`
+	GroupHeaders        []string `datapolicy:"token"`
 	ExtraHeaderPrefixes []string
 	AllowedNames        []string
 }

--- a/staging/src/k8s.io/apiserver/plugin/pkg/authenticator/token/oidc/oidc.go
+++ b/staging/src/k8s.io/apiserver/plugin/pkg/authenticator/token/oidc/oidc.go
@@ -373,7 +373,7 @@ type endpoint struct {
 	// not used.  Access token is optional per the OIDC distributed claims
 	// specification.
 	// See: http://openid.net/specs/openid-connect-core-1_0.html#DistributedExample
-	AccessToken string `json:"access_token,omitempty"`
+	AccessToken string `json:"access_token,omitempty" datapolicy:"token"`
 	// JWT is the container for aggregated claims.  Not supported at the moment.
 	// See: http://openid.net/specs/openid-connect-core-1_0.html#AggregatedExample
 	JWT string `json:"JWT,omitempty"`


### PR DESCRIPTION
/kind feature

**What this PR does / why we need it**:
This PR adds "datapolicy" tags to golang structures as described in [Kubernetes system components logs sanitization KEP](https://github.com/kubernetes/enhancements/tree/master/keps/sig-instrumentation/1753-logs-sanitization). Those tags will be used by for ensuring this data will not be written to logs by Kubernetes system components. 

List of datapolicy tags available:
* `security-key` - for TLS certificate keys. Keywords: `key`, `cert`, `pem` 
* `token` - for HTTP authorization tokens. Keywords: `token`, `secret`, `header`, `auth`
* `password` - anything passwordlike. Keywords: `password`

**Special notes for your reviewer**:

Due to size of Kubernetes codebase first iteration of tagging was done based on greping for particular keyword. Please ensure that tagged fields do contain type of sensitive data that matches their tag. Feel free to suggest any additional places that you think should be tagged.

**Does this PR introduce a user-facing change?**:
No
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs
- [KEP]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-instrumentation/1753-logs-sanitization
```

/cc @PurelyApplied
/sig instrumentation security
/priority important-soon
/milestone v1.20