### PR TITLE
Add datapolicy tags to  pkg/kubelet/

### DIFF
--- a/pkg/kubelet/apis/config/types.go
+++ b/pkg/kubelet/apis/config/types.go
@@ -92,7 +92,7 @@ type KubeletConfiguration struct {
 	// staticPodURL is the URL for accessing static pods to run
 	StaticPodURL string
 	// staticPodURLHeader is a map of slices with HTTP headers to use when accessing the podURL
-	StaticPodURLHeader map[string][]string
+	StaticPodURLHeader map[string][]string `datapolicy:"token"`
 	// address is the IP address for the Kubelet to serve on (set to 0.0.0.0
 	// for all interfaces)
 	Address string

--- a/pkg/kubelet/client/kubelet_client.go
+++ b/pkg/kubelet/client/kubelet_client.go
@@ -48,7 +48,7 @@ type KubeletClientConfig struct {
 	restclient.TLSClientConfig
 
 	// Server requires Bearer authentication
-	BearerToken string
+	BearerToken string `datapolicy:"token"`
 
 	// HTTPTimeout is used by the client to timeout http requests to Kubelet.
 	HTTPTimeout time.Duration

--- a/pkg/kubelet/cri/streaming/request_cache.go
+++ b/pkg/kubelet/cri/streaming/request_cache.go
@@ -56,7 +56,7 @@ type requestCache struct {
 type request interface{}
 
 type cacheEntry struct {
-	token      string
+	token      string `datapolicy:"token"`
 	req        request
 	expireTime time.Time
 }


### PR DESCRIPTION
/kind feature

**What this PR does / why we need it**:
This PR adds "datapolicy" tags to golang structures as described in [Defend against logging secrets via static analysis](https://github.com/kubernetes/enhancements/issues/1933). Those tags will be used by for ensuring this data will not be written to logs by Kubernetes system components. 

List of datapolicy tags available:
* `security-key` - for TLS certificate keys. Keywords: `key`, `cert`, `pem` 
* `token` - for HTTP authorization tokens. Keywords: `token`, `secret`, `header`, `auth`
* `password` - anything passwordlike. Keywords: `password`

**Special notes for your reviewer**:

Due to size of Kubernetes codebase first iteration of tagging was done based on greping for particular keyword. Please ensure that tagged fields do contain type of sensitive data that matches their tag. Feel free to suggest any additional places that you think should be tagged.

**Does this PR introduce a user-facing change?**:
No
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs
- [KEP]: https://github.com/kubernetes/enhancements/issues/1933
```

/cc @PurelyApplied
/sig instrumentation security
/priority important-soon
/milestone v1.20