### PR TITLE
Add datapolicy tags to pkg/volume/

### DIFF
--- a/pkg/volume/cephfs/cephfs.go
+++ b/pkg/volume/cephfs/cephfs.go
@@ -189,7 +189,7 @@ type cephfs struct {
 	mon        []string
 	path       string
 	id         string
-	secret     string
+	secret     string `datapolicy:"token"`
 	secretFile string
 	readonly   bool
 	mounter    mount.Interface

--- a/pkg/volume/glusterfs/glusterfs.go
+++ b/pkg/volume/glusterfs/glusterfs.go
@@ -461,7 +461,7 @@ type provisionerConfig struct {
 	userKey            string
 	secretNamespace    string
 	secretName         string
-	secretValue        string
+	secretValue        string `datapolicy:"token"`
 	clusterID          string
 	gidMin             int
 	gidMax             int

--- a/pkg/volume/iscsi/iscsi.go
+++ b/pkg/volume/iscsi/iscsi.go
@@ -283,7 +283,7 @@ type iscsiDisk struct {
 	Iface         string
 	chapDiscovery bool
 	chapSession   bool
-	secret        map[string]string
+	secret        map[string]string `datapolicy:"token"`
 	InitiatorName string
 	plugin        *iscsiPlugin
 	// Utility interface that provides API calls to the provider to attach/detach disks.

--- a/pkg/volume/quobyte/quobyte.go
+++ b/pkg/volume/quobyte/quobyte.go
@@ -49,7 +49,7 @@ type quobytePlugin struct {
 // Quobyte API server and holds all information
 type quobyteAPIConfig struct {
 	quobyteUser      string
-	quobytePassword  string
+	quobytePassword  string `datapolicy:"password"`
 	quobyteAPIServer string
 }
 

--- a/pkg/volume/rbd/rbd.go
+++ b/pkg/volume/rbd/rbd.go
@@ -803,9 +803,9 @@ type rbdMounter struct {
 	Mon           []string
 	ID            string
 	Keyring       string
-	Secret        string
+	Secret        string `datapolicy:"token"`
 	fsType        string
-	adminSecret   string
+	adminSecret   string `datapolicy:"token"`
 	adminID       string
 	mountOptions  []string
 	imageFormat   string

--- a/pkg/volume/scaleio/sio_client.go
+++ b/pkg/volume/scaleio/sio_client.go
@@ -61,7 +61,7 @@ type sioClient struct {
 	client              *sio.Client
 	gateway             string
 	username            string
-	password            string
+	password            string `datapolicy:"password"`
 	insecure            bool
 	certsEnabled        bool
 	system              *siotypes.System


### PR DESCRIPTION
/kind feature

**What this PR does / why we need it**:
This PR adds "datapolicy" tags to golang structures as described in [Kubernetes system components logs sanitization KEP](https://github.com/kubernetes/enhancements/tree/master/keps/sig-instrumentation/1753-logs-sanitization). Those tags will be used by for ensuring this data will not be written to logs by Kubernetes system components. 

List of datapolicy tags available:
* `security-key` - for TLS certificate keys. Keywords: `key`, `cert`, `pem` 
* `token` - for HTTP authorization tokens. Keywords: `token`, `secret`, `header`, `auth`
* `password` - anything passwordlike. Keywords: `password`

**Special notes for your reviewer**:

Due to size of Kubernetes codebase first iteration of tagging was done based on greping for particular keyword. Please ensure that tagged fields do contain type of sensitive data that matches their tag. Feel free to suggest any additional places that you think should be tagged.

**Does this PR introduce a user-facing change?**:
No
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs
- [KEP]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-instrumentation/1753-logs-sanitization
```

/cc @PurelyApplied
/sig instrumentation security
/priority important-soon
/milestone v1.20