### PR TITLE
Add datapolicy tags to pkg/credentialprovider/

### DIFF
--- a/pkg/credentialprovider/azure/azure_acr_helper.go
+++ b/pkg/credentialprovider/azure/azure_acr_helper.go
@@ -66,7 +66,7 @@ type authDirective struct {
 }
 
 type acrAuthResponse struct {
-	RefreshToken string `json:"refresh_token"`
+	RefreshToken string `json:"refresh_token" datapolicy:"token"`
 }
 
 // 5 minutes buffer time to allow timeshift between local machine and AAD

--- a/pkg/credentialprovider/config.go
+++ b/pkg/credentialprovider/config.go
@@ -39,9 +39,9 @@ const (
 // DockerConfigJSON represents ~/.docker/config.json file info
 // see https://github.com/docker/docker/pull/12009
 type DockerConfigJSON struct {
-	Auths DockerConfig `json:"auths"`
+	Auths DockerConfig `json:"auths" datapolicy:"token"`
 	// +optional
-	HTTPHeaders map[string]string `json:"HttpHeaders,omitempty"`
+	HTTPHeaders map[string]string `json:"HttpHeaders,omitempty" datapolicy:"token"`
 }
 
 // DockerConfig represents the config file used by the docker CLI.
@@ -52,7 +52,7 @@ type DockerConfig map[string]DockerConfigEntry
 // DockerConfigEntry wraps a docker config as a entry
 type DockerConfigEntry struct {
 	Username string
-	Password string
+	Password string `datapolicy:"password"`
 	Email    string
 	Provider DockerConfigProvider
 }
@@ -254,11 +254,11 @@ type dockerConfigEntryWithAuth struct {
 	// +optional
 	Username string `json:"username,omitempty"`
 	// +optional
-	Password string `json:"password,omitempty"`
+	Password string `json:"password,omitempty" datapolicy:"password"`
 	// +optional
 	Email string `json:"email,omitempty"`
 	// +optional
-	Auth string `json:"auth,omitempty"`
+	Auth string `json:"auth,omitempty" datapolicy:"token"`
 }
 
 // UnmarshalJSON implements the json.Unmarshaler interface.

--- a/pkg/credentialprovider/gcp/metadata.go
+++ b/pkg/credentialprovider/gcp/metadata.go
@@ -261,7 +261,7 @@ func (g *containerRegistryProvider) Enabled() bool {
 // tokenBlob is used to decode the JSON blob containing an access token
 // that is returned by GCE metadata.
 type tokenBlob struct {
-	AccessToken string `json:"access_token"`
+	AccessToken string `json:"access_token" datapolicy:"token"`
 }
 
 // Provide implements DockerConfigProvider

--- a/pkg/credentialprovider/keyring.go
+++ b/pkg/credentialprovider/keyring.go
@@ -55,8 +55,8 @@ type providersDockerKeyring struct {
 // This type mirrors "github.com/docker/docker/api/types.AuthConfig"
 type AuthConfig struct {
 	Username string `json:"username,omitempty"`
-	Password string `json:"password,omitempty"`
-	Auth     string `json:"auth,omitempty"`
+	Password string `json:"password,omitempty" datapolicy:"password"`
+	Auth     string `json:"auth,omitempty" datapolicy:"token"`
 
 	// Email is an optional value associated with the username.
 	// This field is deprecated and will be removed in a later
@@ -67,10 +67,10 @@ type AuthConfig struct {
 
 	// IdentityToken is used to authenticate the user and get
 	// an access token for the registry.
-	IdentityToken string `json:"identitytoken,omitempty"`
+	IdentityToken string `json:"identitytoken,omitempty" datapolicy:"token"`
 
 	// RegistryToken is a bearer token to be sent to a registry
-	RegistryToken string `json:"registrytoken,omitempty"`
+	RegistryToken string `json:"registrytoken,omitempty" datapolicy:"token"`
 }
 
 // Add add some docker config in basic docker keyring


### PR DESCRIPTION
/kind feature

**What this PR does / why we need it**:
This PR adds "datapolicy" tags to golang structures as described in [Kubernetes system components logs sanitization KEP](https://github.com/kubernetes/enhancements/tree/master/keps/sig-instrumentation/1753-logs-sanitization). Those tags will be used by for ensuring this data will not be written to logs by Kubernetes system components. 

List of datapolicy tags available:
* `security-key` - for TLS certificate keys. Keywords: `key`, `cert`, `pem` 
* `token` - for HTTP authorization tokens. Keywords: `token`, `secret`, `header`, `auth`
* `password` - anything passwordlike. Keywords: `password`

**Special notes for your reviewer**:

Due to size of Kubernetes codebase first iteration of tagging was done based on greping for particular keyword. Please ensure that tagged fields do contain type of sensitive data that matches their tag. Feel free to suggest any additional places that you think should be tagged.

**Does this PR introduce a user-facing change?**:
No
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs
- [KEP]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-instrumentation/1753-logs-sanitization
```

/cc @PurelyApplied
/sig instrumentation security
/priority important-soon
/milestone v1.20