### PR TITLE
Add datapolicy tags to pkg/controller/

### DIFF
--- a/pkg/controller/certificates/authority/authority.go
+++ b/pkg/controller/certificates/authority/authority.go
@@ -33,7 +33,7 @@ type CertificateAuthority struct {
 	// RawCert is an optional field to determine if signing cert/key pairs have changed
 	RawCert []byte
 	// RawKey is an optional field to determine if signing cert/key pairs have changed
-	RawKey []byte
+	RawKey []byte `datapolicy:"security-key"`
 
 	Certificate *x509.Certificate
 	PrivateKey  crypto.Signer


### PR DESCRIPTION
/kind feature

**What this PR does / why we need it**:
This PR adds "datapolicy" tags to golang structures as described in [Kubernetes system components logs sanitization KEP](https://github.com/kubernetes/enhancements/blob/master/keps/sig-security/1753-logs-sanitization/README.md). Those tags will be used by for ensuring this data will not be written to logs by Kubernetes system components. 

List of datapolicy tags available:
* `security-key` - for TLS certificate keys. Keywords: `key`, `cert`, `pem` 
* `token` - for HTTP authorization tokens. Keywords: `token`, `secret`, `header`, `auth`
* `password` - anything passwordlike. Keywords: `password`

**Special notes for your reviewer**:

Due to size of Kubernetes codebase first iteration of tagging was done based on greping for particular keyword. Please ensure that tagged fields do contain type of sensitive data that matches their tag. Feel free to suggest any additional places that you think should be tagged.

**Does this PR introduce a user-facing change?**:
No
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs
- [KEP]: https://github.com/kubernetes/enhancements/blob/master/keps/sig-security/1753-logs-sanitization/README.md
```

/cc @PurelyApplied
/sig instrumentation security
/priority important-soon
/milestone v1.20