### PR TITLE
Add datapolicy tags to pkg/serviceaccount/

### DIFF
--- a/pkg/serviceaccount/claims.go
+++ b/pkg/serviceaccount/claims.go
@@ -49,7 +49,7 @@ type kubernetes struct {
 	Namespace string          `json:"namespace,omitempty"`
 	Svcacct   ref             `json:"serviceaccount,omitempty"`
 	Pod       *ref            `json:"pod,omitempty"`
-	Secret    *ref            `json:"secret,omitempty"`
+	Secret    *ref            `json:"secret,omitempty" datapolicy:"token"`
 	WarnAfter jwt.NumericDate `json:"warnafter,omitempty"`
 }
 


### PR DESCRIPTION
/kind feature

**What this PR does / why we need it**:
This PR adds "datapolicy" tags to golang structures as described in [Kubernetes system components logs sanitization KEP](https://github.com/kubernetes/enhancements/tree/master/keps/sig-instrumentation/1753-logs-sanitization). Those tags will be used by for ensuring this data will not be written to logs by Kubernetes system components. 

List of datapolicy tags available:
* `security-key` - for TLS certificate keys. Keywords: `key`, `cert`, `pem` 
* `token` - for HTTP authorization tokens. Keywords: `token`, `secret`, `header`, `auth`
* `password` - anything passwordlike. Keywords: `password`

**Special notes for your reviewer**:

Due to size of Kubernetes codebase first iteration of tagging was done based on greping for particular keyword. Please ensure that tagged fields do contain type of sensitive data that matches their tag. Feel free to suggest any additional places that you think should be tagged.

**Does this PR introduce a user-facing change?**:
No
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs
- [KEP]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-instrumentation/1753-logs-sanitization
```

/cc @PurelyApplied
/sig instrumentation security
/priority important-soon
/milestone v1.20