### PR TITLE
add tests that update services while gate is off

### DIFF
--- a/test/integration/dualstack/BUILD
+++ b/test/integration/dualstack/BUILD
@@ -12,6 +12,7 @@ go_test(
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/intstr:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",
@@ -19,6 +20,7 @@ go_test(
         "//staging/src/k8s.io/client-go/rest:go_default_library",
         "//staging/src/k8s.io/component-base/featuregate/testing:go_default_library",
         "//test/integration/framework:go_default_library",
+        "//vendor/github.com/evanphx/json-patch:go_default_library",
         "//vendor/k8s.io/utils/net:go_default_library",
     ],
 )


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:
add tests to dual stack battery of tests. Ensures that ClusterIPs <=> ClusterIP are normalized correctly for old clients using various update methods:
- Put
- JsonPatch
- StrategicMergePatch

This ensures that we are backward compatible with old clients whatever method of update they use.

**Which issue(s) this PR fixes**:
**Special notes for your reviewer**:
**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

/sig network