### PR TITLE
Mark SecondaryRangeName as deprecated.

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/gce/gce.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/gce/gce.go
@@ -129,7 +129,8 @@ type Cloud struct {
 	unsafeIsLegacyNetwork bool
 	// unsafeSubnetworkURL should be used only via SubnetworkURL() accessor,
 	// to ensure it was properly initialized.
-	unsafeSubnetworkURL      string
+	unsafeSubnetworkURL string
+	// DEPRECATED: Do not rely on this value as it may be incorrect.
 	secondaryRangeName       string
 	networkProjectID         string
 	onXPN                    bool
@@ -179,6 +180,7 @@ type ConfigGlobal struct {
 	NetworkProjectID string `gcfg:"network-project-id"`
 	NetworkName      string `gcfg:"network-name"`
 	SubnetworkName   string `gcfg:"subnetwork-name"`
+	// DEPRECATED: Do not rely on this value as it may be incorrect.
 	// SecondaryRangeName is the name of the secondary range to allocate IP
 	// aliases. The secondary range must be present on the subnetwork the
 	// cluster is attached to.
@@ -226,12 +228,13 @@ type CloudConfig struct {
 	NetworkURL           string
 	SubnetworkName       string
 	SubnetworkURL        string
-	SecondaryRangeName   string
-	NodeTags             []string
-	NodeInstancePrefix   string
-	TokenSource          oauth2.TokenSource
-	UseMetadataServer    bool
-	AlphaFeatureGate     *AlphaFeatureGate
+	// DEPRECATED: Do not rely on this value as it may be incorrect.
+	SecondaryRangeName string
+	NodeTags           []string
+	NodeInstancePrefix string
+	TokenSource        oauth2.TokenSource
+	UseMetadataServer  bool
+	AlphaFeatureGate   *AlphaFeatureGate
 }
 
 func init() {


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Mark gce.GlobalConfig.SecondaryRangeName as deprecated. We want to discourage additional further use as the field can be incorrect.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
