### PR TITLE
Add keep_time_key setting to fluentd configuration

### DIFF
--- a/cluster/gce/windows/k8s-node-setup.psm1
+++ b/cluster/gce/windows/k8s-node-setup.psm1
@@ -1732,6 +1732,7 @@ $FLUENTD_CONFIG = @'
       format json
       time_key time
       time_format %Y-%m-%dT%H:%M:%S.%NZ
+      keep_time_key
     </pattern>
     <pattern>
       format /^(?<time>.+) (?<stream>stdout|stderr) [^ ]* (?<log>.*)$/


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:
Add keep_time_key setting to fluentd configuration so that explicit time key is provided to ensure timestamp is parsed correctly. 

**Which issue(s) this PR fixes**:
Without explicit time key, the Cloud Logging output plugin will take the internal fluentd timestamp of the record and convert it to a Time object which is created by default in the current timezone. fluentd parser parses the incoming timestamp using UTC, hence the double conversion when container timezone is set to non UTC.

**Special notes for your reviewer**:
The fix has been fully tested and the risk is quite low.

```release-note
NONE
```
