### PR TITLE
local-up-cluster.sh: Pass CLUSTER_CIDR to kube-proxy

### DIFF
--- a/hack/local-up-cluster.sh
+++ b/hack/local-up-cluster.sh
@@ -852,6 +852,10 @@ EOF
       done
     fi >>/tmp/kube-proxy.yaml
 
+    if [[ "${NET_PLUGIN}" == "kubenet" && -n ${CLUSTER_CIDR} ]]; then
+        echo "clusterCIDR: \"${CLUSTER_CIDR}\"" >> /tmp/kube-proxy.yaml
+    fi
+
     if [[ "${REUSE_CERTS}" != true ]]; then
         generate_kubeproxy_certs
     fi


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
/sig testing

**What this PR does / why we need it**:
This patch fixes the local-up-cluster.sh to pass CLUSTER_CIDR to kube-proxy.
Previously, CLUSTER_CIDR was passed only to controller manager and cloud controller manager.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs
NONE
```
