### PR TITLE
Change bucket for apiserver_request_filter_duration_seconds metric

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics.go
@@ -200,7 +200,7 @@ var (
 		&compbasemetrics.HistogramOpts{
 			Name:           "apiserver_request_filter_duration_seconds",
 			Help:           "Request filter latency distribution in seconds, for each filter type",
-			Buckets:        []float64{0.0, 0.0003, 0.001, 0.003, 0.01, 0.03, 0.1, 0.3, 1.0, 5.0},
+			Buckets:        []float64{0.0001, 0.0003, 0.001, 0.003, 0.01, 0.03, 0.1, 0.3, 1.0, 5.0},
 			StabilityLevel: compbasemetrics.ALPHA,
 		},
 		[]string{"filter"},


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:
Change the `0.0s` bucket to `0.0001s` for `apiserver_request_filter_duration_seconds` metric


**Does this PR introduce a user-facing change?**:
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
