### PR TITLE
Deflake TestDevicePluginReRegistrationProbeMode: Devices of previous registered should be removed

### DIFF
--- a/pkg/kubelet/cm/devicemanager/BUILD
+++ b/pkg/kubelet/cm/devicemanager/BUILD
@@ -32,6 +32,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/api/resource:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/errors:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",
         "//staging/src/k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1:go_default_library",
         "//staging/src/k8s.io/kubelet/pkg/apis/pluginregistration/v1:go_default_library",


### PR DESCRIPTION
**What type of PR is this?**
/kind flake

**What this PR does / why we need it**:
There is a race when the GRPC server is coming up and the subsequent dial call for the unix socket. This fix waits within the stub with a retry to allow the server to start and the dial call to succeed.

```
=== RUN   TestDevicePluginReRegistrationProbeMode
I0904 23:07:54.382417 2813190 fake_topology_manager.go:29] [fake topologymanager] NewFakeManager
W0904 23:07:54.382652 2813190 manager.go:596] Failed to retrieve checkpoint for "kubelet_internal_checkpoint": checkpoint is not found
I0904 23:07:54.386357 2813190 plugin_manager.go:114] Starting Kubelet Plugin Manager
I0904 23:07:54.390968 2813190 device_plugin_stub.go:131] Starting to serve on /tmp/device_plugin394710885/device-plugin.sock
I0904 23:07:54.393796 2813190 device_plugin_stub.go:153] GetInfo
E0904 23:07:54.394527 2813190 goroutinemap.go:150] Operation for "/tmp/device_plugin394710885/server.sock" failed. No retries permitted until 2020-09-04 23:07:54.894365704 +0000 UTC m=+0.587686396 (durationBeforeRetry 500ms). Error: "RegisterPlugin error -- failed to get
 plugin info using RPC GetInfo at socket /tmp/device_plugin394710885/server.sock, err: rpc error: code = Unimplemented desc = unknown service pluginregistration.Registration"
I0904 23:07:54.401946 2813190 device_plugin_stub.go:227] ListAndWatch
I0904 23:07:54.408602 2813190 device_plugin_stub.go:131] Starting to serve on /tmp/device_plugin394710885/device-plugin.sock.new
E0904 23:07:55.390620 2813190 endpoint.go:107] listAndWatch ended unexpectedly for device plugin fake-domain/resource with error rpc error: code = Canceled desc = grpc: the client connection is closing
I0904 23:07:55.394203 2813190 device_plugin_stub.go:153] GetInfo
E0904 23:07:55.395579 2813190 goroutinemap.go:150] Operation for "/tmp/device_plugin394710885/server.sock" failed. No retries permitted until 2020-09-04 23:07:56.395409336 +0000 UTC m=+2.088730022 (durationBeforeRetry 1s). Error: "RegisterPlugin error -- failed to get pl
ugin info using RPC GetInfo at socket /tmp/device_plugin394710885/server.sock, err: rpc error: code = Unimplemented desc = unknown service pluginregistration.Registration"
I0904 23:07:55.402515 2813190 device_plugin_stub.go:153] GetInfo
I0904 23:07:55.407069 2813190 device_plugin_stub.go:227] ListAndWatch
I0904 23:07:55.410949 2813190 device_plugin_stub.go:227] ListAndWatch
I0904 23:07:55.416241 2813190 device_plugin_stub.go:131] Starting to serve on /tmp/device_plugin394710885/device-plugin.sock.third
    manager_test.go:222: 
        	Error Trace:	manager_test.go:222
        	Error:      	Not equal: 
        	            	expected: 1
        	            	actual  : 2
        	Test:       	TestDevicePluginReRegistrationProbeMode
        	Messages:   	Devices of previous registered should be removed
--- FAIL: TestDevicePluginReRegistrationProbeMode (1.04s)
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #94547

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs

```

/cc @sjenning @liggitt 