### PR TITLE
[kubelet] Allow priority to be set for kubelet process on Windows

### DIFF
--- a/cmd/kubelet/app/BUILD
+++ b/cmd/kubelet/app/BUILD
@@ -134,6 +134,7 @@ go_library(
         ],
         "@io_bazel_rules_go//go/platform:windows": [
             "//pkg/windows/service:go_default_library",
+            "//vendor/golang.org/x/sys/windows:go_default_library",
         ],
         "//conditions:default": [],
     }),
@@ -142,6 +143,7 @@ go_library(
 go_test(
     name = "go_default_test",
     srcs = [
+        "init_windows_test.go",
         "server_bootstrap_test.go",
         "server_test.go",
     ],

--- a/cmd/kubelet/app/init_others.go
+++ b/cmd/kubelet/app/init_others.go
@@ -18,6 +18,6 @@ limitations under the License.
 
 package app
 
-func initForOS(service bool) error {
+func initForOS(service bool, priorityClass string) error {
 	return nil
 }

--- a/cmd/kubelet/app/init_windows_test.go
+++ b/cmd/kubelet/app/init_windows_test.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package app
+
+import "testing"
+
+func TestIsValidPriorityClass(t *testing.T) {
+	testCases := []struct {
+		description           string
+		priorityClassName     string
+		expectedPriorityValue uint32
+	}{
+		{
+			description:           "Invalid Priority Class",
+			priorityClassName:     "myPriorityClass",
+			expectedPriorityValue: 0,
+		},
+		{
+			description:           "Valid Priority Class",
+			priorityClassName:     "IDLE_PRIORITY_CLASS",
+			expectedPriorityValue: uint32(64),
+		},
+	}
+	for _, test := range testCases {
+		actualPriorityValue := getPriorityValue(test.priorityClassName)
+		if test.expectedPriorityValue != actualPriorityValue {
+			t.Fatalf("unexpected error for %s", test.description)
+		}
+	}
+}

--- a/cmd/kubelet/app/options/options.go
+++ b/cmd/kubelet/app/options/options.go
@@ -111,6 +111,13 @@ type KubeletFlags struct {
 	// Its corresponding flag only gets registered in Windows builds.
 	WindowsService bool
 
+	// WindowsPriorityClass sets the priority class associated with the Kubelet process
+	// Its corresponding flag only gets registered in Windows builds
+	// The default priority class associated with any process in Windows is NORMAL_PRIORITY_CLASS. Keeping it as is
+	// to maintain backwards compatibility.
+	// Source: https://docs.microsoft.com/en-us/windows/win32/procthread/scheduling-priorities
+	WindowsPriorityClass string
+
 	// remoteRuntimeEndpoint is the endpoint of remote runtime service
 	RemoteRuntimeEndpoint string
 	// remoteImageEndpoint is the endpoint of remote image service

--- a/cmd/kubelet/app/options/osflags_windows.go
+++ b/cmd/kubelet/app/options/osflags_windows.go
@@ -24,4 +24,10 @@ import (
 
 func (f *KubeletFlags) addOSFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&f.WindowsService, "windows-service", f.WindowsService, "Enable Windows Service Control Manager API integration")
+	// The default priority class associated with any process in Windows is NORMAL_PRIORITY_CLASS. Keeping it as is
+	// to maintain backwards compatibility.
+	// Source: https://docs.microsoft.com/en-us/windows/win32/procthread/scheduling-priorities
+	fs.StringVar(&f.WindowsPriorityClass, "windows-priorityclass", "NORMAL_PRIORITY_CLASS",
+		"Set the PriorityClass associated with kubelet process, the default ones are available at "+
+			"https://docs.microsoft.com/en-us/windows/win32/procthread/scheduling-priorities")
 }

--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -414,7 +414,7 @@ func Run(ctx context.Context, s *options.KubeletServer, kubeDeps *kubelet.Depend
 	logOption.Apply()
 	// To help debugging, immediately log version
 	klog.Infof("Version: %+v", version.Get())
-	if err := initForOS(s.KubeletFlags.WindowsService); err != nil {
+	if err := initForOS(s.KubeletFlags.WindowsService, s.KubeletFlags.WindowsPriorityClass); err != nil {
 		return fmt.Errorf("failed OS init: %v", err)
 	}
 	if err := run(ctx, s, kubeDeps, featureGate); err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Introduce `windows-priorityclass` flag to set priority for the kubelet running on Windows nodes

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Partially Fixes #95735

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
Add a new flag to set priority for the kubelet on Windows nodes so that workloads cannot overwhelm the node there by disrupting kubelet process.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
Allow user to specify priority of the kubelet process on Windows nodes.
```

/sig windows
cc @marosset @jsturtevant 