### PR TITLE
Add tests and set-image option to kubectl debug

### DIFF
--- a/build/visible_to/BUILD
+++ b/build/visible_to/BUILD
@@ -248,6 +248,7 @@ package_group(
         "//staging/src/k8s.io/kubectl/pkg/cmd/config",
         "//staging/src/k8s.io/kubectl/pkg/cmd/cp",
         "//staging/src/k8s.io/kubectl/pkg/cmd/create",
+        "//staging/src/k8s.io/kubectl/pkg/cmd/debug",
         "//staging/src/k8s.io/kubectl/pkg/cmd/delete",
         "//staging/src/k8s.io/kubectl/pkg/cmd/describe",
         "//staging/src/k8s.io/kubectl/pkg/cmd/drain",

--- a/staging/src/k8s.io/kubectl/pkg/cmd/debug/BUILD
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/debug/BUILD
@@ -58,7 +58,10 @@ go_test(
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/cli-runtime/pkg/genericclioptions:go_default_library",
+        "//staging/src/k8s.io/kubectl/pkg/cmd/testing:go_default_library",
         "//vendor/github.com/google/go-cmp/cmp:go_default_library",
+        "//vendor/github.com/google/go-cmp/cmp/cmpopts:go_default_library",
+        "//vendor/github.com/spf13/cobra:go_default_library",
         "//vendor/k8s.io/utils/pointer:go_default_library",
     ],
 )

--- a/staging/src/k8s.io/kubectl/pkg/cmd/debug/debug_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/debug/debug_test.go
@@ -250,10 +250,9 @@ func TestGeneratePodCopyWithDebugContainer(t *testing.T) {
 	}
 
 	for _, tc := range []struct {
-		name     string
-		opts     *DebugOptions
-		pod      *corev1.Pod
-		expected *corev1.Pod
+		name             string
+		opts             *DebugOptions
+		havePod, wantPod *corev1.Pod
 	}{
 		{
 			name: "basic",
@@ -263,7 +262,7 @@ func TestGeneratePodCopyWithDebugContainer(t *testing.T) {
 				Image:      "busybox",
 				PullPolicy: corev1.PullIfNotPresent,
 			},
-			pod: &corev1.Pod{
+			havePod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "target",
 				},
@@ -276,17 +275,16 @@ func TestGeneratePodCopyWithDebugContainer(t *testing.T) {
 					NodeName: "node-1",
 				},
 			},
-			expected: &corev1.Pod{
+			wantPod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "debugger",
 				},
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{
 						{
-							Name:                     "debugger",
-							Image:                    "busybox",
-							ImagePullPolicy:          corev1.PullIfNotPresent,
-							TerminationMessagePolicy: corev1.TerminationMessageReadFile,
+							Name:            "debugger",
+							Image:           "busybox",
+							ImagePullPolicy: corev1.PullIfNotPresent,
 						},
 					},
 				},
@@ -301,7 +299,7 @@ func TestGeneratePodCopyWithDebugContainer(t *testing.T) {
 				PullPolicy: corev1.PullIfNotPresent,
 				SameNode:   true,
 			},
-			pod: &corev1.Pod{
+			havePod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "target",
 				},
@@ -314,17 +312,16 @@ func TestGeneratePodCopyWithDebugContainer(t *testing.T) {
 					NodeName: "node-1",
 				},
 			},
-			expected: &corev1.Pod{
+			wantPod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "debugger",
 				},
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{
 						{
-							Name:                     "debugger",
-							Image:                    "busybox",
-							ImagePullPolicy:          corev1.PullIfNotPresent,
-							TerminationMessagePolicy: corev1.TerminationMessageReadFile,
+							Name:            "debugger",
+							Image:           "busybox",
+							ImagePullPolicy: corev1.PullIfNotPresent,
 						},
 					},
 					NodeName: "node-1",
@@ -339,7 +336,7 @@ func TestGeneratePodCopyWithDebugContainer(t *testing.T) {
 				Image:      "busybox",
 				PullPolicy: corev1.PullIfNotPresent,
 			},
-			pod: &corev1.Pod{
+			havePod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "target",
 					Labels: map[string]string{
@@ -359,7 +356,7 @@ func TestGeneratePodCopyWithDebugContainer(t *testing.T) {
 					},
 				},
 			},
-			expected: &corev1.Pod{
+			wantPod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "debugger",
 					Annotations: map[string]string{
@@ -369,10 +366,9 @@ func TestGeneratePodCopyWithDebugContainer(t *testing.T) {
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{
 						{
-							Name:                     "debugger",
-							Image:                    "busybox",
-							ImagePullPolicy:          corev1.PullIfNotPresent,
-							TerminationMessagePolicy: corev1.TerminationMessageReadFile,
+							Name:            "debugger",
+							Image:           "busybox",
+							ImagePullPolicy: corev1.PullIfNotPresent,
 						},
 					},
 				},
@@ -386,7 +382,7 @@ func TestGeneratePodCopyWithDebugContainer(t *testing.T) {
 				Image:      "busybox",
 				PullPolicy: corev1.PullIfNotPresent,
 			},
-			pod: &corev1.Pod{
+			havePod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "target",
 				},
@@ -398,7 +394,7 @@ func TestGeneratePodCopyWithDebugContainer(t *testing.T) {
 					},
 				},
 			},
-			expected: &corev1.Pod{
+			wantPod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "debugger",
 				},
@@ -429,7 +425,7 @@ func TestGeneratePodCopyWithDebugContainer(t *testing.T) {
 					Value: "test",
 				}},
 			},
-			pod: &corev1.Pod{
+			havePod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "target",
 				},
@@ -441,7 +437,7 @@ func TestGeneratePodCopyWithDebugContainer(t *testing.T) {
 					},
 				},
 			},
-			expected: &corev1.Pod{
+			wantPod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "debugger",
 				},
@@ -473,7 +469,7 @@ func TestGeneratePodCopyWithDebugContainer(t *testing.T) {
 				Image:      "busybox",
 				PullPolicy: corev1.PullIfNotPresent,
 			},
-			pod: &corev1.Pod{
+			havePod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "target",
 				},
@@ -485,7 +481,7 @@ func TestGeneratePodCopyWithDebugContainer(t *testing.T) {
 					},
 				},
 			},
-			expected: &corev1.Pod{
+			wantPod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "debugger",
 				},
@@ -515,7 +511,7 @@ func TestGeneratePodCopyWithDebugContainer(t *testing.T) {
 				Image:      "busybox",
 				PullPolicy: corev1.PullIfNotPresent,
 			},
-			pod: &corev1.Pod{
+			havePod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "target",
 				},
@@ -527,7 +523,7 @@ func TestGeneratePodCopyWithDebugContainer(t *testing.T) {
 					},
 				},
 			},
-			expected: &corev1.Pod{
+			wantPod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "debugger",
 				},
@@ -553,24 +549,25 @@ func TestGeneratePodCopyWithDebugContainer(t *testing.T) {
 				CopyTo:     "debugger",
 				Container:  "debugger",
 				Args:       []string{"sleep", "1d"},
-				Image:      "busybox",
 				PullPolicy: corev1.PullIfNotPresent,
 			},
-			pod: &corev1.Pod{
+			havePod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "target",
 				},
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{
 						{
-							Name:    "debugger",
-							Command: []string{"echo"},
-							Args:    []string{"one", "two", "three"},
+							Name:                     "debugger",
+							Command:                  []string{"echo"},
+							Image:                    "app",
+							Args:                     []string{"one", "two", "three"},
+							TerminationMessagePolicy: corev1.TerminationMessageReadFile,
 						},
 					},
 				},
 			},
-			expected: &corev1.Pod{
+			wantPod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "debugger",
 				},
@@ -578,7 +575,7 @@ func TestGeneratePodCopyWithDebugContainer(t *testing.T) {
 					Containers: []corev1.Container{
 						{
 							Name:                     "debugger",
-							Image:                    "busybox",
+							Image:                    "app",
 							Command:                  []string{"sleep", "1d"},
 							ImagePullPolicy:          corev1.PullIfNotPresent,
 							TerminationMessagePolicy: corev1.TerminationMessageReadFile,
@@ -594,7 +591,7 @@ func TestGeneratePodCopyWithDebugContainer(t *testing.T) {
 				Image:      "busybox",
 				PullPolicy: corev1.PullIfNotPresent,
 			},
-			pod: &corev1.Pod{
+			havePod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "target",
 				},
@@ -606,7 +603,7 @@ func TestGeneratePodCopyWithDebugContainer(t *testing.T) {
 					},
 				},
 			},
-			expected: &corev1.Pod{
+			wantPod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "debugger",
 				},
@@ -632,7 +629,7 @@ func TestGeneratePodCopyWithDebugContainer(t *testing.T) {
 				Image:      "busybox",
 				PullPolicy: corev1.PullIfNotPresent,
 			},
-			pod: &corev1.Pod{
+			havePod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "target",
 				},
@@ -644,7 +641,7 @@ func TestGeneratePodCopyWithDebugContainer(t *testing.T) {
 					},
 				},
 			},
-			expected: &corev1.Pod{
+			wantPod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "debugger",
 				},
@@ -670,7 +667,7 @@ func TestGeneratePodCopyWithDebugContainer(t *testing.T) {
 				Image:      "busybox",
 				PullPolicy: corev1.PullIfNotPresent,
 			},
-			pod: &corev1.Pod{
+			havePod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "target",
 				},
@@ -690,7 +687,7 @@ func TestGeneratePodCopyWithDebugContainer(t *testing.T) {
 					},
 				},
 			},
-			expected: &corev1.Pod{
+			wantPod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "debugger",
 				},
@@ -724,7 +721,7 @@ func TestGeneratePodCopyWithDebugContainer(t *testing.T) {
 				Image:      "busybox",
 				PullPolicy: corev1.PullIfNotPresent,
 			},
-			pod: &corev1.Pod{
+			havePod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "target",
 				},
@@ -748,7 +745,7 @@ func TestGeneratePodCopyWithDebugContainer(t *testing.T) {
 					},
 				},
 			},
-			expected: &corev1.Pod{
+			wantPod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "debugger",
 				},
@@ -777,20 +774,22 @@ func TestGeneratePodCopyWithDebugContainer(t *testing.T) {
 				ShareProcesses:        true,
 				shareProcessedChanged: true,
 			},
-			pod: &corev1.Pod{
+			havePod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "target",
 				},
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{
 						{
-							Name: "debugger",
+							Name:                     "debugger",
+							ImagePullPolicy:          corev1.PullAlways,
+							TerminationMessagePolicy: corev1.TerminationMessageReadFile,
 						},
 					},
 					NodeName: "node-1",
 				},
 			},
-			expected: &corev1.Pod{
+			wantPod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "debugger",
 				},
@@ -807,17 +806,215 @@ func TestGeneratePodCopyWithDebugContainer(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "Change image for a named container",
+			opts: &DebugOptions{
+				Args:        []string{},
+				CopyTo:      "myapp-copy",
+				Container:   "app",
+				Image:       "busybox",
+				TargetNames: []string{"myapp"},
+			},
+			havePod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "myapp"},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "app", Image: "appimage"},
+						{Name: "sidecar", Image: "sidecarimage"},
+					},
+				},
+			},
+			wantPod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "myapp-copy"},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "app", Image: "busybox"},
+						{Name: "sidecar", Image: "sidecarimage"},
+					},
+				},
+			},
+		},
+		{
+			name: "Change image for a named container with set-image",
+			opts: &DebugOptions{
+				CopyTo:    "myapp-copy",
+				Container: "app",
+				SetImages: map[string]string{"app": "busybox"},
+			},
+			havePod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "myapp",
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "app", Image: "appimage"},
+						{Name: "sidecar", Image: "sidecarimage"},
+					},
+				},
+			},
+			wantPod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "myapp-copy",
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "app", Image: "busybox"},
+						{Name: "sidecar", Image: "sidecarimage"},
+					},
+				},
+			},
+		},
+		{
+			name: "Change image for all containers with set-image",
+			opts: &DebugOptions{
+				CopyTo:    "myapp-copy",
+				Container: "app",
+				SetImages: map[string]string{"*": "busybox"},
+			},
+			havePod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "myapp",
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "app", Image: "appimage"},
+						{Name: "sidecar", Image: "sidecarimage"},
+					},
+				},
+			},
+			wantPod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "myapp-copy",
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "app", Image: "busybox"},
+						{Name: "sidecar", Image: "busybox"},
+					},
+				},
+			},
+		},
+		{
+			name: "Change image for multiple containers with set-image",
+			opts: &DebugOptions{
+				CopyTo:    "myapp-copy",
+				Container: "app",
+				SetImages: map[string]string{"*": "busybox", "app": "app-debugger"},
+			},
+			havePod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "myapp",
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "app", Image: "appimage"},
+						{Name: "sidecar", Image: "sidecarimage"},
+					},
+				},
+			},
+			wantPod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "myapp-copy",
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "app", Image: "app-debugger"},
+						{Name: "sidecar", Image: "busybox"},
+					},
+				},
+			},
+		},
+		{
+			name: "Add interactive debug container minimal args",
+			opts: &DebugOptions{
+				Args:        []string{},
+				Attach:      true,
+				CopyTo:      "my-debugger",
+				Image:       "busybox",
+				Interactive: true,
+				TargetNames: []string{"mypod"},
+				TTY:         true,
+			},
+			havePod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "mypod"},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "app", Image: "appimage"},
+						{Name: "sidecar", Image: "sidecarimage"},
+					},
+				},
+			},
+			wantPod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "my-debugger"},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "app", Image: "appimage"},
+						{Name: "sidecar", Image: "sidecarimage"},
+						{
+							Name:                     "debugger-1",
+							Image:                    "busybox",
+							Stdin:                    true,
+							TerminationMessagePolicy: corev1.TerminationMessageReadFile,
+							TTY:                      true,
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Pod copy: add container and also mutate images",
+			opts: &DebugOptions{
+				Args:        []string{},
+				Attach:      true,
+				CopyTo:      "my-debugger",
+				Image:       "debian",
+				Interactive: true,
+				Namespace:   "default",
+				SetImages: map[string]string{
+					"app":     "app:debug",
+					"sidecar": "sidecar:debug",
+				},
+				ShareProcesses: true,
+				TargetNames:    []string{"mypod"},
+				TTY:            true,
+			},
+			havePod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "mypod"},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "app", Image: "appimage"},
+						{Name: "sidecar", Image: "sidecarimage"},
+					},
+				},
+			},
+			wantPod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "my-debugger"},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "app", Image: "app:debug"},
+						{Name: "sidecar", Image: "sidecar:debug"},
+						{
+							Name:                     "debugger-1",
+							Image:                    "debian",
+							TerminationMessagePolicy: corev1.TerminationMessageReadFile,
+							Stdin:                    true,
+							TTY:                      true,
+						},
+					},
+				},
+			},
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			tc.opts.IOStreams = genericclioptions.NewTestIOStreamsDiscard()
 			suffixCounter = 0
 
-			if tc.pod == nil {
-				tc.pod = &corev1.Pod{}
+			if tc.havePod == nil {
+				tc.havePod = &corev1.Pod{}
 			}
-			pod, _ := tc.opts.generatePodCopyWithDebugContainer(tc.pod)
-			if diff := cmp.Diff(tc.expected, pod); diff != "" {
-				t.Error("unexpected diff in generated object: (-want +got):\n", diff)
+			gotPod, _, _ := tc.opts.generatePodCopyWithDebugContainer(tc.havePod)
+			if diff := cmp.Diff(tc.wantPod, gotPod); diff != "" {
+				t.Error("TestGeneratePodCopyWithDebugContainer: diff in generated object: (-want +got):\n", diff)
 			}
 		})
 	}
@@ -1074,13 +1271,10 @@ func TestCompleteAndValidate(t *testing.T) {
 		},
 		{
 			name: "Set environment variables",
-			args: "--image=busybox --env=FOO=BAR,BAZ=BAZ mypod",
+			args: "--image=busybox --env=FOO=BAR mypod",
 			wantOpts: &DebugOptions{
-				Args: []string{},
-				Env: []v1.EnvVar{
-					{Name: "FOO", Value: "BAR"},
-					{Name: "BAZ", Value: "BAZ"},
-				},
+				Args:           []string{},
+				Env:            []v1.EnvVar{{Name: "FOO", Value: "BAR"}},
 				Image:          "busybox",
 				Namespace:      "default",
 				ShareProcesses: true,
@@ -1115,8 +1309,13 @@ func TestCompleteAndValidate(t *testing.T) {
 			},
 		},
 		{
-			name:      "Ephemeral container: image not specified",
+			name:      "Ephemeral container: no image specified",
 			args:      "mypod",
+			wantError: true,
+		},
+		{
+			name:      "Ephemeral container: no image but args",
+			args:      "mypod -- echo 1 2",
 			wantError: true,
 		},
 		{
@@ -1127,6 +1326,11 @@ func TestCompleteAndValidate(t *testing.T) {
 		{
 			name:      "Ephemeral container: same-node not allowed",
 			args:      "--same-node --image=busybox mypod",
+			wantError: true,
+		},
+		{
+			name:      "Ephemeral container: incompatible with --set-image",
+			args:      "--set-image=*=busybox mypod",
 			wantError: true,
 		},
 		{
@@ -1158,13 +1362,85 @@ func TestCompleteAndValidate(t *testing.T) {
 			},
 		},
 		{
+			name: "Pod copy: replace single image of existing container",
+			args: "mypod --image=busybox --container=my-container --copy-to=my-debugger",
+			wantOpts: &DebugOptions{
+				Args:           []string{},
+				Container:      "my-container",
+				CopyTo:         "my-debugger",
+				Image:          "busybox",
+				Namespace:      "default",
+				ShareProcesses: true,
+				TargetNames:    []string{"mypod"},
+			},
+		},
+		{
+			name: "Pod copy: mutate existing container images",
+			args: "mypod --set-image=*=busybox,app=app-debugger --copy-to=my-debugger",
+			wantOpts: &DebugOptions{
+				Args:      []string{},
+				CopyTo:    "my-debugger",
+				Namespace: "default",
+				SetImages: map[string]string{
+					"*":   "busybox",
+					"app": "app-debugger",
+				},
+				ShareProcesses: true,
+				TargetNames:    []string{"mypod"},
+			},
+		},
+		{
+			name: "Pod copy: add container and also mutate images",
+			args: "mypod -it --copy-to=my-debugger --image=debian --set-image=app=app:debug,sidecar=sidecar:debug",
+			wantOpts: &DebugOptions{
+				Args:        []string{},
+				Attach:      true,
+				CopyTo:      "my-debugger",
+				Image:       "debian",
+				Interactive: true,
+				Namespace:   "default",
+				SetImages: map[string]string{
+					"app":     "app:debug",
+					"sidecar": "sidecar:debug",
+				},
+				ShareProcesses: true,
+				TargetNames:    []string{"mypod"},
+				TTY:            true,
+			},
+		},
+		{
+			name: "Pod copy: change command",
+			args: "mypod -it --copy-to=my-debugger --container=mycontainer -- sh",
+			wantOpts: &DebugOptions{
+				Attach:         true,
+				Args:           []string{"sh"},
+				Container:      "mycontainer",
+				CopyTo:         "my-debugger",
+				Interactive:    true,
+				Namespace:      "default",
+				ShareProcesses: true,
+				TargetNames:    []string{"mypod"},
+				TTY:            true,
+			},
+		},
+		{
 			name:      "Pod copy: no image specified",
 			args:      "mypod -it --copy-to=my-debugger",
 			wantError: true,
 		},
 		{
+			name:      "Pod copy: args but no image specified",
+			args:      "mypod --copy-to=my-debugger -- echo milo",
+			wantError: true,
+		},
+		{
 			name:      "Pod copy: --target not allowed",
 			args:      "mypod --target --image=busybox --copy-to=my-debugger",
+			wantError: true,
+		},
+		{
+			name:      "Pod copy: invalid --set-image",
+			args:      "mypod --set-image=*=SUPERGOODIMAGE#1!!!! --copy-to=my-debugger",
 			wantError: true,
 		},
 		{
@@ -1187,13 +1463,18 @@ func TestCompleteAndValidate(t *testing.T) {
 			wantError: true,
 		},
 		{
-			name:      "Node: replace not allowed",
+			name:      "Node: --replace not allowed",
 			args:      "--image=busybox --replace node/mynode",
 			wantError: true,
 		},
 		{
-			name:      "Node: same-node not allowed",
+			name:      "Node: --same-node not allowed",
 			args:      "--image=busybox --same-node node/mynode",
+			wantError: true,
+		},
+		{
+			name:      "Node: --set-image not allowed",
+			args:      "--image=busybox --set-image=*=busybox node/mynode",
 			wantError: true,
 		},
 		{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind feature
/sig cli
/priority important-soon

**What this PR does / why we need it**: Implements feature and tests for kubernetes/enhancements#1441

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #94855

**Special notes for your reviewer**: Slight change in KEP for how image mutations are specified. See examples in `debug.go`.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
`kubectl debug` gains support for changing container images when copying a pod for debugging, similar to how `kubectl set image` works. See `kubectl help debug` for more information.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-cli/1441-kubectl-debug
```
