### PR TITLE
kubectl describe: print <none> when Annotations empty

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/describe/describe.go
+++ b/staging/src/k8s.io/kubectl/pkg/describe/describe.go
@@ -4970,6 +4970,11 @@ var maxAnnotationLen = 140
 func printAnnotationsMultiline(w PrefixWriter, title string, annotations map[string]string) {
 	w.Write(LEVEL_0, "%s:\t", title)
 
+	if len(annotations) == 0 {
+		w.WriteLine("<none>")
+		return
+	}
+
 	// to print labels in the sorted order
 	keys := make([]string, 0, len(annotations))
 	for key := range annotations {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
https://github.com/kubernetes/kubectl/issues/966

0-length annotations mess up Describe formatting

**Which issue(s) this PR fixes**:
https://github.com/kubernetes/kubectl/issues/966

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**: 
```release-note
Previously, using Describe on an object with no annotations would result in Annotations and Selector lines being joined.  We now print 'Annotations: <none>' and continue the description of Selectors on a new line.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs
NONE
```
