### PR TITLE
Automated cherry pick of #94853: fix azure file migration panic

### DIFF
--- a/staging/src/k8s.io/csi-translation-lib/plugins/azure_file_test.go
+++ b/staging/src/k8s.io/csi-translation-lib/plugins/azure_file_test.go
@@ -243,6 +243,120 @@ func TestTranslateAzureFileInTreePVToCSI(t *testing.T) {
 	}
 }
 
+func TestTranslateCSIPVToInTree(t *testing.T) {
+	translator := NewAzureFileCSITranslator()
+
+	secretNamespace := "secretnamespace"
+	mp := make(map[string]string)
+	mp["shareName"] = "unit-test"
+	cases := []struct {
+		name   string
+		volume *corev1.PersistentVolume
+		expVol *corev1.PersistentVolume
+		expErr bool
+	}{
+		{
+			name:   "empty volume",
+			expErr: true,
+		},
+		{
+			name: "resource group empty",
+			volume: &corev1.PersistentVolume{
+				Spec: corev1.PersistentVolumeSpec{
+					PersistentVolumeSource: corev1.PersistentVolumeSource{
+						CSI: &corev1.CSIPersistentVolumeSource{
+							NodeStageSecretRef: &corev1.SecretReference{
+								Name:      "ut",
+								Namespace: secretNamespace,
+							},
+							ReadOnly:         true,
+							VolumeAttributes: mp,
+						},
+					},
+				},
+			},
+			expVol: &corev1.PersistentVolume{
+				Spec: corev1.PersistentVolumeSpec{
+					PersistentVolumeSource: corev1.PersistentVolumeSource{
+						AzureFile: &corev1.AzureFilePersistentVolumeSource{
+							SecretName:      "ut",
+							SecretNamespace: &secretNamespace,
+							ReadOnly:        true,
+							ShareName:       "unit-test",
+						},
+					},
+				},
+			},
+			expErr: false,
+		},
+		{
+			name: "translate from volume handle error",
+			volume: &corev1.PersistentVolume{
+				Spec: corev1.PersistentVolumeSpec{
+					PersistentVolumeSource: corev1.PersistentVolumeSource{
+						CSI: &corev1.CSIPersistentVolumeSource{
+							VolumeHandle:     "unit-test",
+							ReadOnly:         true,
+							VolumeAttributes: mp,
+						},
+					},
+				},
+			},
+			expErr: true,
+		},
+		{
+			name: "translate from volume handle",
+			volume: &corev1.PersistentVolume{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "file.csi.azure.com-sharename",
+				},
+				Spec: corev1.PersistentVolumeSpec{
+					PersistentVolumeSource: corev1.PersistentVolumeSource{
+						CSI: &corev1.CSIPersistentVolumeSource{
+							VolumeHandle:     "rg#st#pvc-file-dynamic#diskname.vhd",
+							ReadOnly:         true,
+							VolumeAttributes: mp,
+						},
+					},
+				},
+			},
+			expVol: &corev1.PersistentVolume{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "file.csi.azure.com-sharename",
+					Annotations: map[string]string{resourceGroupAnnotation: "rg"},
+				},
+				Spec: corev1.PersistentVolumeSpec{
+					PersistentVolumeSource: corev1.PersistentVolumeSource{
+						AzureFile: &corev1.AzureFilePersistentVolumeSource{
+							SecretName: "azure-storage-account-st-secret",
+							ShareName:  "pvc-file-dynamic",
+							ReadOnly:   true,
+						},
+					},
+				},
+			},
+			expErr: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Logf("Testing %v", tc.name)
+		got, err := translator.TranslateCSIPVToInTree(tc.volume)
+		if err != nil && !tc.expErr {
+			t.Errorf("Did not expect error but got: %v", err)
+		}
+
+		if err == nil && tc.expErr {
+			t.Errorf("Expected error, but did not get one.")
+		}
+
+		if !reflect.DeepEqual(got, tc.expVol) {
+			t.Errorf("Got parameters: %v, expected :%v", got, tc.expVol)
+		}
+	}
+
+}
+
 func TestGetStorageAccount(t *testing.T) {
 	tests := []struct {
 		secretName     string


### PR DESCRIPTION
Cherry pick of #94853 on release-1.18.

#94853: fix azure file migration panic

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.