### PR TITLE
Automated cherry pick of #94853: fix azure file migration panic

### DIFF
--- a/staging/src/k8s.io/csi-translation-lib/plugins/azure_file.go
+++ b/staging/src/k8s.io/csi-translation-lib/plugins/azure_file.go
@@ -24,7 +24,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	storage "k8s.io/api/storage/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 )
 
 const (
@@ -41,6 +41,8 @@ const (
 
 	secretNameTemplate     = "azure-storage-account-%s-secret"
 	defaultSecretNamespace = "default"
+
+	resourceGroupAnnotation = "kubernetes.io/azure-file-resource-group"
 )
 
 var _ InTreePlugin = &azureFileCSITranslator{}
@@ -116,7 +118,13 @@ func (t *azureFileCSITranslator) TranslateInTreePVToCSI(pv *v1.PersistentVolume)
 		klog.Warningf("getStorageAccountName(%s) returned with error: %v", azureSource.SecretName, err)
 		accountName = azureSource.SecretName
 	}
-	volumeID := fmt.Sprintf(volumeIDTemplate, "", accountName, azureSource.ShareName, "")
+	resourceGroup := ""
+	if pv.ObjectMeta.Annotations != nil {
+		if v, ok := pv.ObjectMeta.Annotations[resourceGroupAnnotation]; ok {
+			resourceGroup = v
+		}
+	}
+	volumeID := fmt.Sprintf(volumeIDTemplate, resourceGroup, accountName, azureSource.ShareName, "")
 
 	var (
 		// refer to https://github.com/kubernetes-sigs/azurefile-csi-driver/blob/master/docs/driver-parameters.md
@@ -155,6 +163,7 @@ func (t *azureFileCSITranslator) TranslateCSIPVToInTree(pv *v1.PersistentVolume)
 		ReadOnly: csiSource.ReadOnly,
 	}
 
+	resourceGroup := ""
 	if csiSource.NodeStageSecretRef != nil && csiSource.NodeStageSecretRef.Name != "" {
 		azureSource.SecretName = csiSource.NodeStageSecretRef.Name
 		azureSource.SecretNamespace = &csiSource.NodeStageSecretRef.Namespace
@@ -164,16 +173,23 @@ func (t *azureFileCSITranslator) TranslateCSIPVToInTree(pv *v1.PersistentVolume)
 			}
 		}
 	} else {
-		_, storageAccount, fileShareName, _, err := getFileShareInfo(csiSource.VolumeHandle)
+		rg, storageAccount, fileShareName, _, err := getFileShareInfo(csiSource.VolumeHandle)
 		if err != nil {
 			return nil, err
 		}
 		azureSource.ShareName = fileShareName
 		azureSource.SecretName = fmt.Sprintf(secretNameTemplate, storageAccount)
+		resourceGroup = rg
 	}
 
 	pv.Spec.CSI = nil
 	pv.Spec.AzureFile = azureSource
+	if resourceGroup != "" {
+		if pv.ObjectMeta.Annotations == nil {
+			pv.ObjectMeta.Annotations = map[string]string{}
+		}
+		pv.ObjectMeta.Annotations[resourceGroupAnnotation] = resourceGroup
+	}
 
 	return pv, nil
 }

--- a/staging/src/k8s.io/csi-translation-lib/plugins/azure_file.go
+++ b/staging/src/k8s.io/csi-translation-lib/plugins/azure_file.go
@@ -24,7 +24,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	storage "k8s.io/api/storage/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/klog/v2"
+	"k8s.io/klog"
 )
 
 const (

--- a/staging/src/k8s.io/csi-translation-lib/plugins/azure_file_test.go
+++ b/staging/src/k8s.io/csi-translation-lib/plugins/azure_file_test.go
@@ -243,6 +243,120 @@ func TestTranslateAzureFileInTreePVToCSI(t *testing.T) {
 	}
 }
 
+func TestTranslateCSIPVToInTree(t *testing.T) {
+	translator := NewAzureFileCSITranslator()
+
+	secretNamespace := "secretnamespace"
+	mp := make(map[string]string)
+	mp["shareName"] = "unit-test"
+	cases := []struct {
+		name   string
+		volume *corev1.PersistentVolume
+		expVol *corev1.PersistentVolume
+		expErr bool
+	}{
+		{
+			name:   "empty volume",
+			expErr: true,
+		},
+		{
+			name: "resource group empty",
+			volume: &corev1.PersistentVolume{
+				Spec: corev1.PersistentVolumeSpec{
+					PersistentVolumeSource: corev1.PersistentVolumeSource{
+						CSI: &corev1.CSIPersistentVolumeSource{
+							NodeStageSecretRef: &corev1.SecretReference{
+								Name:      "ut",
+								Namespace: secretNamespace,
+							},
+							ReadOnly:         true,
+							VolumeAttributes: mp,
+						},
+					},
+				},
+			},
+			expVol: &corev1.PersistentVolume{
+				Spec: corev1.PersistentVolumeSpec{
+					PersistentVolumeSource: corev1.PersistentVolumeSource{
+						AzureFile: &corev1.AzureFilePersistentVolumeSource{
+							SecretName:      "ut",
+							SecretNamespace: &secretNamespace,
+							ReadOnly:        true,
+							ShareName:       "unit-test",
+						},
+					},
+				},
+			},
+			expErr: false,
+		},
+		{
+			name: "translate from volume handle error",
+			volume: &corev1.PersistentVolume{
+				Spec: corev1.PersistentVolumeSpec{
+					PersistentVolumeSource: corev1.PersistentVolumeSource{
+						CSI: &corev1.CSIPersistentVolumeSource{
+							VolumeHandle:     "unit-test",
+							ReadOnly:         true,
+							VolumeAttributes: mp,
+						},
+					},
+				},
+			},
+			expErr: true,
+		},
+		{
+			name: "translate from volume handle",
+			volume: &corev1.PersistentVolume{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "file.csi.azure.com-sharename",
+				},
+				Spec: corev1.PersistentVolumeSpec{
+					PersistentVolumeSource: corev1.PersistentVolumeSource{
+						CSI: &corev1.CSIPersistentVolumeSource{
+							VolumeHandle:     "rg#st#pvc-file-dynamic#diskname.vhd",
+							ReadOnly:         true,
+							VolumeAttributes: mp,
+						},
+					},
+				},
+			},
+			expVol: &corev1.PersistentVolume{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "file.csi.azure.com-sharename",
+					Annotations: map[string]string{resourceGroupAnnotation: "rg"},
+				},
+				Spec: corev1.PersistentVolumeSpec{
+					PersistentVolumeSource: corev1.PersistentVolumeSource{
+						AzureFile: &corev1.AzureFilePersistentVolumeSource{
+							SecretName: "azure-storage-account-st-secret",
+							ShareName:  "pvc-file-dynamic",
+							ReadOnly:   true,
+						},
+					},
+				},
+			},
+			expErr: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Logf("Testing %v", tc.name)
+		got, err := translator.TranslateCSIPVToInTree(tc.volume)
+		if err != nil && !tc.expErr {
+			t.Errorf("Did not expect error but got: %v", err)
+		}
+
+		if err == nil && tc.expErr {
+			t.Errorf("Expected error, but did not get one.")
+		}
+
+		if !reflect.DeepEqual(got, tc.expVol) {
+			t.Errorf("Got parameters: %v, expected :%v", got, tc.expVol)
+		}
+	}
+
+}
+
 func TestGetStorageAccount(t *testing.T) {
 	tests := []struct {
 		secretName     string


### PR DESCRIPTION
Cherry pick of #94853 on release-1.17.

#94853: fix azure file migration panic

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.