### PR TITLE
automatically build modified e2e images 

### DIFF
--- a/test/images/cloudbuild.yaml
+++ b/test/images/cloudbuild.yaml
@@ -38,4 +38,4 @@ substitutions:
   # a branch like 'master' or 'release-0.2', or a tag like 'v0.2'.
   _PULL_BASE_REF: 'master'
   # _WHAT will contain the image name to be built and published to the staging registry.
-  _WHAT: 'all-conformance'
+  _WHAT: 'updated-images'

--- a/test/images/image-util.sh
+++ b/test/images/image-util.sh
@@ -262,6 +262,15 @@ if [[ "${WHAT}" == "all-conformance" ]]; then
   for image in "${conformance_images[@]}"; do
     eval "${TASK}" "${image}" "$@"
   done
+elif [[ "${WHAT}" == "updated-images" ]]; then
+  # if updated-images is selected it obtains the images modified respect master and updates them
+  # this is required for the postsubmit job used to update the stating repo and not having to
+  # rebuild all the images. This script is assumed to run always against master.
+  shift
+  updated_images=$(git diff --dirstat=files,0 master -- "${KUBE_ROOT}"/test/images/* | cut -d "/" -f 3)
+  for image in ${updated_images}; do
+    eval "${TASK}" "${image}" "$@"
+  done
 else
   eval "${TASK}" "$@"
 fi

--- a/test/images/regression-issue-74839/BASEIMAGE
+++ b/test/images/regression-issue-74839/BASEIMAGE
@@ -1,0 +1,5 @@
+linux/amd64=alpine:3.8
+linux/arm=arm32v6/alpine:3.8
+linux/arm64=arm64v8/alpine:3.8
+linux/ppc64le=ppc64le/alpine:3.8
+linux/s390x=s390x/alpine:3.8

--- a/test/images/regression-issue-74839/Dockerfile
+++ b/test/images/regression-issue-74839/Dockerfile
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM gcr.io/distroless/base
+ARG BASEIMAGE
+FROM $BASEIMAGE
 
 ADD regression-issue-74839 /regression-issue-74839
 


### PR DESCRIPTION
/kind cleanup

**What this PR does / why we need it**:
    
    We were building all the e2e conformance images if some of images
    in the folder test/images was modified.
    This is suboptimal, because it may happen that we are not modifying
    any of these. Also, this doesn't work for images that are rarely
    updated.
    Instead, we can obtain the modified images from the git diff and
    update only those.


I need this in order to be able to upload the new image to staging, so I can promote it later
https://github.com/kubernetes/kubernetes/pull/95328#issuecomment-716463984

This way I think the job https://github.com/kubernetes/test-infra/blob/b6a3b30009d28054eda88515dc9c0f25e94d343e/config/jobs/image-pushing/k8s-staging-e2e-test-images.yaml#L6 will pick it up automatically

**Which issue(s) this PR fixes**:
```release-note
NONE
```
