### PR TITLE
Add runtime representation of []v1.PreferredSchedulingTerm 

### DIFF
--- a/pkg/scheduler/framework/plugins/helper/node_affinity.go
+++ b/pkg/scheduler/framework/plugins/helper/node_affinity.go
@@ -70,7 +70,7 @@ func PodMatchesNodeSelectorAndAffinityTerms(pod *v1.Pod, node *v1.Node) bool {
 // nodeMatchesNodeSelectorTerms checks if a node's labels satisfy a list of node selector terms,
 // terms are ORed, and an empty list of terms will match nothing.
 func nodeMatchesNodeSelectorTerms(node *v1.Node, nodeSelector *v1.NodeSelector) bool {
-	// TODO(@alculquicondor, #95738): parse this error earlier in the plugin so we only need to do it once per pod
+	// TODO(#96164): parse this error earlier in the plugin so we only need to do it once per Pod.
 	matches, _ := corev1.MatchNodeSelectorTerms(node, nodeSelector)
 	return matches
 }

--- a/pkg/scheduler/framework/plugins/nodeaffinity/BUILD
+++ b/pkg/scheduler/framework/plugins/nodeaffinity/BUILD
@@ -10,7 +10,7 @@ go_library(
         "//pkg/scheduler/framework/plugins/helper:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
-        "//staging/src/k8s.io/component-helpers/scheduling/corev1:go_default_library",
+        "//staging/src/k8s.io/component-helpers/scheduling/corev1/nodeaffinity:go_default_library",
     ],
 )
 

--- a/pkg/scheduler/framework/plugins/nodeaffinity/node_affinity.go
+++ b/pkg/scheduler/framework/plugins/nodeaffinity/node_affinity.go
@@ -22,7 +22,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/component-helpers/scheduling/corev1"
+	"k8s.io/component-helpers/scheduling/corev1/nodeaffinity"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
 	pluginhelper "k8s.io/kubernetes/pkg/scheduler/framework/plugins/helper"
 )
@@ -79,23 +79,12 @@ func (pl *NodeAffinity) Score(ctx context.Context, state *framework.CycleState, 
 	// An element of PreferredDuringSchedulingIgnoredDuringExecution that refers to an
 	// empty PreferredSchedulingTerm matches all objects.
 	if affinity != nil && affinity.NodeAffinity != nil && affinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution != nil {
-		// Match PreferredDuringSchedulingIgnoredDuringExecution term by term.
-		for i := range affinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution {
-			preferredSchedulingTerm := &affinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution[i]
-			if preferredSchedulingTerm.Weight == 0 {
-				continue
-			}
-
-			// TODO: Avoid computing it for all nodes if this becomes a performance problem.
-			matches, err := corev1.MatchNodeSelectorTerms(node, &v1.NodeSelector{NodeSelectorTerms: []v1.NodeSelectorTerm{preferredSchedulingTerm.Preference}})
-			if err != nil {
-				return 0, framework.AsStatus(err)
-			}
-
-			if matches {
-				count += int64(preferredSchedulingTerm.Weight)
-			}
+		// TODO(#96164): Do this in PreScore to avoid computing it for all nodes.
+		preferredNodeAffinity, err := nodeaffinity.NewPreferredSchedulingTerms(affinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution)
+		if err != nil {
+			return 0, framework.AsStatus(err)
 		}
+		count += preferredNodeAffinity.Score(node)
 	}
 
 	return count, nil


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

This object can be used for repeatedly scoring Nodes.
This allows an efficient implementation of #95738

**Special notes for your reviewer**:

Builds on top of #96064

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

/sig scheduling