### PR TITLE
HTTP Probe: Removes Accept-Encoding header from http probe

### DIFF
--- a/pkg/probe/http/http_test.go
+++ b/pkg/probe/http/http_test.go
@@ -158,13 +158,37 @@ func TestHTTPProbeChecker(t *testing.T) {
 			handler:    headerCounterHandler,
 			reqHeaders: http.Header{},
 			health:     probe.Success,
-			accBody:    "4",
+			accBody:    "3",
 		},
 		{
 			handler:    headerKeysNamesHandler,
 			reqHeaders: http.Header{},
 			health:     probe.Success,
-			accBody:    "Accept\nAccept-Encoding\nConnection\nUser-Agent",
+			accBody:    "Accept\nConnection\nUser-Agent",
+		},
+		{
+			handler: headerEchoHandler,
+			reqHeaders: http.Header{
+				"Accept-Encoding": {"gzip"},
+			},
+			health:  probe.Success,
+			accBody: "Accept-Encoding: gzip",
+		},
+		{
+			handler: headerEchoHandler,
+			reqHeaders: http.Header{
+				"Accept-Encoding": {"foo"},
+			},
+			health:  probe.Success,
+			accBody: "Accept-Encoding: foo",
+		},
+		{
+			handler: headerEchoHandler,
+			reqHeaders: http.Header{
+				"Accept-Encoding": {""},
+			},
+			health:  probe.Success,
+			accBody: "Accept-Encoding: \n",
 		},
 		{
 			handler: headerEchoHandler,


### PR DESCRIPTION
/sig node
/sig network
/kind cleanup

**What this PR does / why we need it**:

The `Accept-Encoding` header is added by default because compression is enabled by default. 
By removing it we are reducing the sent payload.

Also it relates with https://github.com/kubernetes/kubernetes/pull/95641

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Changed: default "Accept-Encoding" header removed from HTTP probes. See https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#http-probes

```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
