### PR TITLE
Bug 1893926: Enable wrongly skipped "Dynamic PV (block volmode)" pattern sig-storage e2e test

### DIFF
--- a/test/e2e/storage/testpatterns/testpattern.go
+++ b/test/e2e/storage/testpatterns/testpattern.go
@@ -287,11 +287,9 @@ var (
 	}
 	// BlockVolModeDynamicPV is TestPattern for "Dynamic PV (block)"
 	BlockVolModeDynamicPV = TestPattern{
-		Name:                   "Dynamic PV (block volmode)",
-		VolType:                DynamicPV,
-		VolMode:                v1.PersistentVolumeBlock,
-		SnapshotType:           DynamicCreatedSnapshot,
-		SnapshotDeletionPolicy: DeleteSnapshot,
+		Name:    "Dynamic PV (block volmode)",
+		VolType: DynamicPV,
+		VolMode: v1.PersistentVolumeBlock,
 	}
 
 	// Definitions for snapshot case

--- a/test/e2e/storage/testpatterns/testpattern.go
+++ b/test/e2e/storage/testpatterns/testpattern.go
@@ -112,10 +112,8 @@ var (
 	}
 	// DefaultFsDynamicPV is TestPattern for "Dynamic PV (default fs)"
 	DefaultFsDynamicPV = TestPattern{
-		Name:                   "Dynamic PV (default fs)",
-		VolType:                DynamicPV,
-		SnapshotType:           DynamicCreatedSnapshot,
-		SnapshotDeletionPolicy: DeleteSnapshot,
+		Name:    "Dynamic PV (default fs)",
+		VolType: DynamicPV,
 	}
 
 	// Definitions for ext3

--- a/test/e2e/storage/testsuites/provisioning.go
+++ b/test/e2e/storage/testsuites/provisioning.go
@@ -211,6 +211,11 @@ func (p *provisioningTestSuite) DefineTests(driver TestDriver, pattern testpatte
 		init()
 		defer cleanup()
 
+		if pattern.Name == testpatterns.BlockVolModeDynamicPV.Name || pattern.Name == testpatterns.DefaultFsDynamicPV.Name {
+			pattern.SnapshotType = testpatterns.DynamicCreatedSnapshot
+			pattern.SnapshotDeletionPolicy = testpatterns.DeleteSnapshot
+		}
+
 		dc := l.config.Framework.DynamicClient
 		testConfig := convertTestConfig(l.config)
 		expectedContent := fmt.Sprintf("Hello from namespace %s", f.Namespace.Name)


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
"Dynamic PV (block volmode)" pattern sig-storage e2e test are skipped for "Driver aws doesn't support snapshot type DynamicSnapshot -- skipping". This is not correct, block volume mode dynamic provisioning is not related with snapshot.

**Which issue(s) this PR fixes**:


**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```
NONE
