### PR TITLE
Remove alpha from kubectl debug command invocation

### DIFF
--- a/pkg/kubectl/cmd/BUILD
+++ b/pkg/kubectl/cmd/BUILD
@@ -27,6 +27,7 @@ go_library(
         "//staging/src/k8s.io/kubectl/pkg/cmd/config:go_default_library",
         "//staging/src/k8s.io/kubectl/pkg/cmd/cp:go_default_library",
         "//staging/src/k8s.io/kubectl/pkg/cmd/create:go_default_library",
+        "//staging/src/k8s.io/kubectl/pkg/cmd/debug:go_default_library",
         "//staging/src/k8s.io/kubectl/pkg/cmd/delete:go_default_library",
         "//staging/src/k8s.io/kubectl/pkg/cmd/describe:go_default_library",
         "//staging/src/k8s.io/kubectl/pkg/cmd/diff:go_default_library",

--- a/pkg/kubectl/cmd/cmd.go
+++ b/pkg/kubectl/cmd/cmd.go
@@ -44,6 +44,7 @@ import (
 	cmdconfig "k8s.io/kubectl/pkg/cmd/config"
 	"k8s.io/kubectl/pkg/cmd/cp"
 	"k8s.io/kubectl/pkg/cmd/create"
+	"k8s.io/kubectl/pkg/cmd/debug"
 	"k8s.io/kubectl/pkg/cmd/delete"
 	"k8s.io/kubectl/pkg/cmd/describe"
 	"k8s.io/kubectl/pkg/cmd/diff"
@@ -555,6 +556,7 @@ func NewKubectlCommand(in io.Reader, out, err io.Writer) *cobra.Command {
 				proxy.NewCmdProxy(f, ioStreams),
 				cp.NewCmdCp(f, ioStreams),
 				auth.NewCmdAuth(f, ioStreams),
+				debug.NewCmdDebug(f, ioStreams, false),
 			},
 		},
 		{

--- a/staging/src/k8s.io/kubectl/pkg/cmd/alpha.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/alpha.go
@@ -36,7 +36,7 @@ func NewCmdAlpha(f cmdutil.Factory, streams genericclioptions.IOStreams) *cobra.
 
 	// Alpha commands should be added here. As features graduate from alpha they should move
 	// from here to the CommandGroups defined by NewKubeletCommand() in cmd.go.
-	cmd.AddCommand(debug.NewCmdDebug(f, streams))
+	cmd.AddCommand(debug.NewCmdDebug(f, streams, true))
 
 	// NewKubeletCommand() will hide the alpha command if it has no subcommands. Overriding
 	// the help function ensures a reasonable message if someone types the hidden command anyway.

--- a/test/cmd/debug.sh
+++ b/test/cmd/debug.sh
@@ -31,7 +31,7 @@ run_kubectl_debug_pod_tests() {
   kubectl run target "--image=${IMAGE_NGINX:?}" "${kube_flags[@]:?}"
   kube::test::get_object_assert pod "{{range.items}}{{${id_field:?}}}:{{end}}" 'target:'
   # Command: create a copy of target with a new debug container
-  kubectl alpha debug target -it --copy-to=target-copy --image=busybox --container=debug-container --attach=false "${kube_flags[@]:?}"
+  kubectl debug target -it --copy-to=target-copy --image=busybox --container=debug-container --attach=false "${kube_flags[@]:?}"
   # Post-Conditions
   kube::test::get_object_assert pod "{{range.items}}{{${id_field:?}}}:{{end}}" 'target:target-copy:'
   kube::test::get_object_assert pod/target-copy '{{range.spec.containers}}{{.name}}:{{end}}' 'target:debug-container:'
@@ -43,7 +43,7 @@ run_kubectl_debug_pod_tests() {
   kubectl run target "--image=${IMAGE_NGINX:?}" "${kube_flags[@]:?}"
   kube::test::get_object_assert pod "{{range.items}}{{${id_field:?}}}:{{end}}" 'target:'
   # Command: create a copy of target with a new debug container replacing the previous pod
-  kubectl alpha debug target -it --copy-to=target-copy --image=busybox --container=debug-container --attach=false --replace "${kube_flags[@]:?}"
+  kubectl debug target -it --copy-to=target-copy --image=busybox --container=debug-container --attach=false --replace "${kube_flags[@]:?}"
   # Post-Conditions
   kube::test::get_object_assert pod "{{range.items}}{{${id_field:?}}}:{{end}}" 'target-copy:'
   kube::test::get_object_assert pod/target-copy '{{range.spec.containers}}{{.name}}:{{end}}' 'target:debug-container:'
@@ -56,7 +56,7 @@ run_kubectl_debug_pod_tests() {
   kube::test::get_object_assert pod "{{range.items}}{{${id_field:?}}}:{{end}}" 'target:'
   kube::test::get_object_assert pod/target '{{(index .spec.containers 0).name}}' 'target'
   # Command: copy the pod and replace the image of an existing container
-  kubectl alpha debug target --image=busybox --container=target --copy-to=target-copy "${kube_flags[@]:?}" -- sleep 1m
+  kubectl debug target --image=busybox --container=target --copy-to=target-copy "${kube_flags[@]:?}" -- sleep 1m
   # Post-Conditions
   kube::test::get_object_assert pod "{{range.items}}{{${id_field:?}}}:{{end}}" 'target:target-copy:'
   kube::test::get_object_assert pod/target-copy "{{(len .spec.containers)}}:{{${image_field:?}}}" '1:busybox'
@@ -79,7 +79,7 @@ run_kubectl_debug_node_tests() {
   # Pre-Condition: Pod "nginx" is created
   kube::test::get_object_assert nodes "{{range.items}}{{${id_field:?}}}:{{end}}" '127.0.0.1:'
   # Command: create a new node debugger pod
-  output_message=$(kubectl alpha debug node/127.0.0.1 --image=busybox --attach=false "${kube_flags[@]:?}" -- true)
+  output_message=$(kubectl debug node/127.0.0.1 --image=busybox --attach=false "${kube_flags[@]:?}" -- true)
   # Post-Conditions
   kube::test::get_object_assert pod "{{(len .items)}}" '1'
   debugger=$(kubectl get pod -o go-template="{{(index .items 0)${id_field:?}}}")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind feature
/sig cli
/priority important-soon

**What this PR does / why we need it**: This PR graduates `kubectl alpha debug` to `kubectl debug`

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
`kubectl alpha debug` has graduated to beta and is now `kubectl debug`.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-cli/1441-kubectl-debug
```
