### PR TITLE
Bug 1893972: Skip the sig-storage e2e test as early as possible

### DIFF
--- a/test/e2e/storage/testsuites/base.go
+++ b/test/e2e/storage/testsuites/base.go
@@ -150,6 +150,9 @@ func skipUnsupportedTest(driver TestDriver, pattern testpatterns.TestPattern) {
 	dInfo := driver.GetDriverInfo()
 	var isSupported bool
 
+	// 0. Check with driver specific logic
+	driver.SkipUnsupportedTest(pattern)
+
 	// 1. Check if Whether volType is supported by driver from its interface
 	switch pattern.VolType {
 	case testpatterns.InlineVolume:
@@ -178,9 +181,6 @@ func skipUnsupportedTest(driver TestDriver, pattern testpatterns.TestPattern) {
 	if pattern.FsType == "ntfs" && !framework.NodeOSDistroIs("windows") {
 		e2eskipper.Skipf("Distro %s doesn't support ntfs -- skipping", framework.TestContext.NodeOSDistro)
 	}
-
-	// 3. Check with driver specific logic
-	driver.SkipUnsupportedTest(pattern)
 }
 
 // VolumeResource is a generic implementation of TestResource that wil be able to


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
When running e2e test on aws cluster, we can find some skip message like:
```
skip [k8s.io/kubernetes@v1.19.0/test/e2e/storage/testsuites/base.go:162]: Driver azure-disk doesn't support snapshot type DynamicSnapshot -- skipping
skip [k8s.io/kubernetes@v1.19.0/test/e2e/storage/testsuites/base.go:185]: Driver azure-disk doesn't support ntfs -- skipping
```
For these cases, we hope they can be skipped earlier when finding the provider is not azure.

**Which issue(s) this PR fixes**:


**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```
NONE
```