### PR TITLE
Drop pkg/apis/core/v1/helper.IsAttachableVolumeResourceName helper

### DIFF
--- a/pkg/apis/core/v1/helper/helpers.go
+++ b/pkg/apis/core/v1/helper/helpers.go
@@ -130,11 +130,6 @@ func IsOvercommitAllowed(name v1.ResourceName) bool {
 		!IsHugePageResourceName(name)
 }
 
-// IsAttachableVolumeResourceName returns true when the resource name is prefixed in attachable volume
-func IsAttachableVolumeResourceName(name v1.ResourceName) bool {
-	return strings.HasPrefix(string(name), v1.ResourceAttachableVolumesPrefix)
-}
-
 // IsServiceIPSet aims to check if the service's ClusterIP is set or not
 // the objective is not to perform validation here
 func IsServiceIPSet(service *v1.Service) bool {

--- a/pkg/scheduler/framework/plugins/nodevolumelimits/utils.go
+++ b/pkg/scheduler/framework/plugins/nodevolumelimits/utils.go
@@ -19,12 +19,11 @@ package nodevolumelimits
 import (
 	"strings"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	csilibplugins "k8s.io/csi-translation-lib/plugins"
-	v1helper "k8s.io/kubernetes/pkg/apis/core/v1/helper"
 	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
 )
@@ -86,7 +85,8 @@ func isCSIMigrationOn(csiNode *storagev1.CSINode, pluginName string) bool {
 func volumeLimits(n *framework.NodeInfo) map[v1.ResourceName]int64 {
 	volumeLimits := map[v1.ResourceName]int64{}
 	for k, v := range n.Allocatable.ScalarResources {
-		if v1helper.IsAttachableVolumeResourceName(k) {
+		// storage resource limits are prefixed with v1.ResourceAttachableVolumesPrefix
+		if strings.HasPrefix(string(k), v1.ResourceAttachableVolumesPrefix) {
 			volumeLimits[k] = v
 		}
 	}

--- a/pkg/scheduler/util/utils.go
+++ b/pkg/scheduler/util/utils.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
@@ -168,5 +169,9 @@ func ClearNominatedNodeName(cs kubernetes.Interface, pods ...*v1.Pod) utilerrors
 // IsScalarResourceName validates the resource for Extended, Hugepages, Native and AttachableVolume resources
 func IsScalarResourceName(name v1.ResourceName) bool {
 	return v1helper.IsExtendedResourceName(name) || v1helper.IsHugePageResourceName(name) ||
-		v1helper.IsPrefixedNativeResource(name) || v1helper.IsAttachableVolumeResourceName(name)
+		v1helper.IsPrefixedNativeResource(name) || isAttachableVolumeResourceName(name)
+}
+
+func isAttachableVolumeResourceName(name v1.ResourceName) bool {
+	return strings.HasPrefix(string(name), v1.ResourceAttachableVolumesPrefix)
 }

--- a/pkg/volume/util/BUILD
+++ b/pkg/volume/util/BUILD
@@ -61,7 +61,6 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//pkg/apis/core/install:go_default_library",
-        "//pkg/apis/core/v1/helper:go_default_library",
         "//pkg/features:go_default_library",
         "//pkg/util/slice:go_default_library",
         "//pkg/volume:go_default_library",

--- a/pkg/volume/util/attach_limit_test.go
+++ b/pkg/volume/util/attach_limit_test.go
@@ -19,10 +19,10 @@ package util
 import (
 	"crypto/sha1"
 	"encoding/hex"
+	"strings"
 	"testing"
 
-	"k8s.io/api/core/v1"
-	v1helper "k8s.io/kubernetes/pkg/apis/core/v1/helper"
+	v1 "k8s.io/api/core/v1"
 )
 
 func TestGetCSIAttachLimitKey(t *testing.T) {
@@ -35,7 +35,7 @@ func TestGetCSIAttachLimitKey(t *testing.T) {
 	// When driver is longer than 39 chars
 	longDriverName := "com.amazon.kubernetes.eks.ec2.ebs/csi-driver"
 	csiLimitKeyLonger := GetCSIAttachLimitKey(longDriverName)
-	if !v1helper.IsAttachableVolumeResourceName(v1.ResourceName(csiLimitKeyLonger)) {
+	if !strings.HasPrefix(csiLimitKeyLonger, v1.ResourceAttachableVolumesPrefix) {
 		t.Errorf("Expected %s to have attachable prefix", csiLimitKeyLonger)
 	}
 

--- a/test/e2e/storage/BUILD
+++ b/test/e2e/storage/BUILD
@@ -33,7 +33,6 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/api/v1/pod:go_default_library",
-        "//pkg/apis/core/v1/helper:go_default_library",
         "//pkg/apis/storage/v1/util:go_default_library",
         "//pkg/client/conditions:go_default_library",
         "//pkg/controller/volume/scheduling:go_default_library",

--- a/test/e2e/storage/volume_limits.go
+++ b/test/e2e/storage/volume_limits.go
@@ -17,10 +17,11 @@ limitations under the License.
 package storage
 
 import (
+	"strings"
+
 	"github.com/onsi/ginkgo"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	clientset "k8s.io/client-go/kubernetes"
-	v1helper "k8s.io/kubernetes/pkg/apis/core/v1/helper"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
 	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
@@ -54,7 +55,8 @@ func getVolumeLimit(node *v1.Node) map[v1.ResourceName]int64 {
 	volumeLimits := map[v1.ResourceName]int64{}
 	nodeAllocatables := node.Status.Allocatable
 	for k, v := range nodeAllocatables {
-		if v1helper.IsAttachableVolumeResourceName(k) {
+		// storage resource limits are prefixed with v1.ResourceAttachableVolumesPrefix
+		if strings.HasPrefix(string(k), v1.ResourceAttachableVolumesPrefix) {
 			volumeLimits[k] = v.Value()
 		}
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Minimize the number of helpers in `pkg/apis/core/v1/helper` that are needed by the scheduling framework to be moved under `k8s.io/component-helpers`. The idea is to either move definition of a helper from `pkg/apis/core/v1/helper` the scheduling framework depends on under the framework or under `k8s.io/component-helpers`.

In this case `IsAttachableVolumeResourceName` is just a wrapper around testing for a string prefix. From definition of `v1.ResourceAttachableVolumesPrefix`:
```
// Name prefix for storage resource limits
ResourceAttachableVolumesPrefix = "attachable-volumes-"
```

From the comment it is clear what is needed to decide if a resource is storage resource limits. No need to have a helper for it.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
