### PR TITLE
Update configMapGenerator docs for envs list

### DIFF
--- a/staging/src/k8s.io/kubectl/docs/book/pages/app_management/secrets_and_configmaps.md
+++ b/staging/src/k8s.io/kubectl/docs/book/pages/app_management/secrets_and_configmaps.md
@@ -126,8 +126,8 @@ data:
 
 ConfigMap Resources may be generated from key-value pairs much the same as using the literals option
 but taking the key-value pairs from an environment file. These generally end in `.env`.
-To generate a ConfigMap Resource from an environment file, add an entry to `configMapGenerator` with a
-single `env` entry, e.g. `env: config.env`.
+To generate a ConfigMap Resource from an environment file, add an entry to `configMapGenerator` with an
+`envs` entry listing all environment files to include, e.g. `envs: [config.env]`.
 
 {% panel style="info", title="Environment File Syntax" %}
 - The key/value pairs inside of the environment file are separated by a `=` sign (left side is the key)
@@ -146,7 +146,8 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 configMapGenerator:
 - name: tracing-options
-  env: tracing.env
+  envs:
+  - tracing.env
 ```
 
 ```bash


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind documentation
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:

Cleanup the confusion between docs for `kubectl` ([this page](https://kubectl.docs.kubernetes.io/pages/app_management/secrets_and_configmaps.html#)) and `kustomize` ([this page](https://kubernetes-sigs.github.io/kustomize/guides/plugins/builtins/#_configmapgenerator_))  about `configMapGenerator` environment files usage. Lately (since https://github.com/kubernetes-sigs/kustomize/pull/1041)  the singular `env` property was removed and users are expected to use `envs` list instead. Instead of a warning though, the build just fails. This causes confusion since the kubectl docs were not updated accordingly.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Related to https://github.com/kubernetes-sigs/kustomize/issues/1069, https://github.com/kubernetes-sigs/kustomize/pull/1041

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
