### PR TITLE
Automated cherry pick of #89857: Correctly parse X-Stream-Protocol-Version header

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/httpstream/httpstream.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/httpstream/httpstream.go
@@ -114,6 +114,18 @@ func negotiateProtocol(clientProtocols, serverProtocols []string) string {
 	return ""
 }
 
+func commaSeparatedHeaderValues(header []string) []string {
+	var parsedClientProtocols []string
+	for i := range header {
+		for _, clientProtocol := range strings.Split(header[i], ",") {
+			if proto := strings.Trim(clientProtocol, " "); len(proto) > 0 {
+				parsedClientProtocols = append(parsedClientProtocols, proto)
+			}
+		}
+	}
+	return parsedClientProtocols
+}
+
 // Handshake performs a subprotocol negotiation. If the client did request a
 // subprotocol, Handshake will select the first common value found in
 // serverProtocols. If a match is found, Handshake adds a response header
@@ -121,7 +133,7 @@ func negotiateProtocol(clientProtocols, serverProtocols []string) string {
 // returned, along with a response header containing the list of protocols the
 // server can accept.
 func Handshake(req *http.Request, w http.ResponseWriter, serverProtocols []string) (string, error) {
-	clientProtocols := req.Header[http.CanonicalHeaderKey(HeaderProtocolVersion)]
+	clientProtocols := commaSeparatedHeaderValues(req.Header[http.CanonicalHeaderKey(HeaderProtocolVersion)])
 	if len(clientProtocols) == 0 {
 		// Kube 1.0 clients didn't support subprotocol negotiation.
 		// TODO require clientProtocols once Kube 1.0 is no longer supported

--- a/staging/src/k8s.io/apimachinery/pkg/util/httpstream/httpstream_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/httpstream/httpstream_test.go
@@ -63,8 +63,19 @@ func TestHandshake(t *testing.T) {
 			expectedProtocol: "",
 			expectError:      true,
 		},
+		"no common protocol with comma separated list": {
+			clientProtocols:  []string{"c, d"},
+			serverProtocols:  []string{"a", "b"},
+			expectedProtocol: "",
+			expectError:      true,
+		},
 		"common protocol": {
 			clientProtocols:  []string{"b"},
+			serverProtocols:  []string{"a", "b"},
+			expectedProtocol: "b",
+		},
+		"common protocol with comma separated list": {
+			clientProtocols:  []string{"b, c"},
 			serverProtocols:  []string{"a", "b"},
 			expectedProtocol: "b",
 		},


### PR DESCRIPTION
Cherry pick of #89857 on release-1.17.

#89857: Correctly parse X-Stream-Protocol-Version header

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

Fixes #95733