### PR TITLE
Set tokencleaner resync to 10 minutes.

### DIFF
--- a/pkg/controller/bootstrap/tokencleaner.go
+++ b/pkg/controller/bootstrap/tokencleaner.go
@@ -54,6 +54,7 @@ type TokenCleanerOptions struct {
 func DefaultTokenCleanerOptions() TokenCleanerOptions {
 	return TokenCleanerOptions{
 		TokenSecretNamespace: api.NamespaceSystem,
+		SecretResync:         10 * time.Minute,
 	}
 }
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

The tokencleaner controller is expected to clean up bootstrap tokens secret
objects that are
stale(https://kubernetes.io/docs/reference/access-authn-authz/bootstrap-tokens/#enabling-bootstrap-token-authentication):

> Expired tokens can be deleted automatically by enabling the tokencleaner controller on the controller manager.

it has however been observed to only clean up bootstrap tokens on startup and
not periodically.

From reviewing the controller code it was observed that the controller is
setup with a resync period set to 0 as seen in the below code paths:

- https://github.com/kubernetes/kubernetes/blob/ac996a37f65a8f11640808a883e9522832ed364f/cmd/kube-controller-manager/app/bootstrap.go#L45
- https://github.com/kubernetes/kubernetes/blob/ac996a37f65a8f11640808a883e9522832ed364f/pkg/controller/bootstrap/tokencleaner.go#L54-L58

The
[`SecretResync`](https://github.com/kubernetes/kubernetes/blob/ac996a37f65a8f11640808a883e9522832ed364f/pkg/controller/bootstrap/tokencleaner.go#L47-L49)
is not set hence its zero value of `0` is used, the underlying sharedInformer
skips
[resyncing](https://github.com/kubernetes/kubernetes/blob/ac996a37f65a8f11640808a883e9522832ed364f/staging/src/k8s.io/client-go/tools/cache/shared_informer.go#L789-L800)
when the resyncPeriod is `0` this leads to the tokencleaner controller
ignoring all bootstrap tokens after its initial seeding by the sharedInformer
and introduces bloat in the `kube-system` namespace, in some observed cases of
over 3000 bootstrap tokens. When an encryption provider is used, listing
secrets in any namespace with over a thousand secret objects becomes expensive
causing a drain on tools that rely on listing secret objects in such
namespace.

This patchset sets the resync period to 10 minutes, so that the
tokencleaner controller can delete expired bootstrap token secrets every
10 minutes or thereabouts.

Fixes #96191

**Special notes for your reviewer**:

Is 10 minutes adequate for resync period?

```release-note
tokencleaner controller will now delete expired bootstrap secret tokens that have expired every 10minutes
```