### PR TITLE
Automated cherry pick of #95933: Fix bug in JSON path parser where an error occurs when a

### DIFF
--- a/staging/src/k8s.io/client-go/util/jsonpath/jsonpath.go
+++ b/staging/src/k8s.io/client-go/util/jsonpath/jsonpath.go
@@ -103,13 +103,23 @@ func (j *JSONPath) FindResults(data interface{}) ([][]reflect.Value, error) {
 		if j.beginRange > 0 {
 			j.beginRange--
 			j.inRange++
-			for _, value := range results {
+			if len(results) > 0 {
+				for _, value := range results {
+					j.parser.Root.Nodes = nodes[i+1:]
+					nextResults, err := j.FindResults(value.Interface())
+					if err != nil {
+						return nil, err
+					}
+					fullResult = append(fullResult, nextResults...)
+				}
+			} else {
+				// If the range has no results, we still need to process the nodes within the range
+				// so the position will advance to the end node
 				j.parser.Root.Nodes = nodes[i+1:]
-				nextResults, err := j.FindResults(value.Interface())
+				_, err := j.FindResults(nil)
 				if err != nil {
 					return nil, err
 				}
-				fullResult = append(fullResult, nextResults...)
 			}
 			j.inRange--
 

--- a/staging/src/k8s.io/client-go/util/jsonpath/jsonpath_test.go
+++ b/staging/src/k8s.io/client-go/util/jsonpath/jsonpath_test.go
@@ -393,6 +393,21 @@ func TestKubernetes(t *testing.T) {
 	testJSONPathSortOutput(randomPrintOrderTests, t)
 }
 
+func TestEmptyRange(t *testing.T) {
+	var input = []byte(`{"items":[]}`)
+	var emptyList interface{}
+	err := json.Unmarshal(input, &emptyList)
+	if err != nil {
+		t.Error(err)
+	}
+
+	tests := []jsonpathTest{
+		{"empty range", `{range .items[*]}{.metadata.name}{end}`, &emptyList, "", false},
+		{"empty nested range", `{range .items[*]}{.metadata.name}{":"}{range @.spec.containers[*]}{.name}{","}{end}{"+"}{end}`, &emptyList, "", false},
+	}
+	testJSONPath(tests, true, t)
+}
+
 func TestNestedRanges(t *testing.T) {
 	var input = []byte(`{
 		"items": [


### PR DESCRIPTION
Cherry pick of #95933 on release-1.19.

#95933: Fix bug in JSON path parser where an error occurs when a

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Fix a regression in 1.19 in JSON path parser where an error occurs when a range is empty
```
