### PR TITLE
fix: pass bearer token to curl using --header instead of --oauth2-bearer

### DIFF
--- a/hack/lib/util.sh
+++ b/hack/lib/util.sh
@@ -45,7 +45,6 @@ kube::util::wait_for_url() {
   local wait=${3:-1}
   local times=${4:-30}
   local maxtime=${5:-1}
-  local extra_args=${6:-}
 
   command -v curl >/dev/null || {
     kube::log::usage "curl must be installed"
@@ -55,9 +54,7 @@ kube::util::wait_for_url() {
   local i
   for i in $(seq 1 "${times}"); do
     local out
-    # shellcheck disable=SC2086
-    # Disabling because "${extra_args}" needs to allow for expansion here
-    if out=$(curl --max-time "${maxtime}" -gkfs $extra_args "${url}" 2>/dev/null); then
+    if out=$(curl --max-time "${maxtime}" -gkfs "${@:6}" "${url}" 2>/dev/null); then
       kube::log::status "On try ${i}, ${prefix}: ${out}"
       return 0
     fi
@@ -75,7 +72,7 @@ kube::util::wait_for_url_with_bearer_token() {
   local times=${5:-30}
   local maxtime=${6:-1}
 
-  kube::util::wait_for_url "${url}" "${prefix}" "${wait}" "${times}" "${maxtime}" "--oauth2-bearer ${token}"
+  kube::util::wait_for_url "${url}" "${prefix}" "${wait}" "${times}" "${maxtime}" -H "Authorization: Bearer ${token}"
 }
 
 # Example:  kube::util::wait_for_success 120 5 "kubectl get nodes|grep localhost"

--- a/hack/update-openapi-spec.sh
+++ b/hack/update-openapi-spec.sh
@@ -97,7 +97,7 @@ fi
 
 kube::log::status "Updating " "${OPENAPI_ROOT_DIR}"
 
-curl -w "\n" -kfs --oauth2-bearer dummy_token "https://${API_HOST}:${API_PORT}/openapi/v2" | jq -S '.info.version="unversioned"' > "${OPENAPI_ROOT_DIR}/swagger.json"
+curl -w "\n" -kfsS -H 'Authorization: Bearer dummy_token' "https://${API_HOST}:${API_PORT}/openapi/v2" | jq -S '.info.version="unversioned"' > "${OPENAPI_ROOT_DIR}/swagger.json"
 
 kube::log::status "SUCCESS"
 

--- a/test/cmd/authorization.sh
+++ b/test/cmd/authorization.sh
@@ -30,7 +30,7 @@ run_authorization_tests() {
   kubectl create -f test/fixtures/pkg/kubectl/cmd/create/sar-v1beta1.json --validate=false
 
   SAR_RESULT_FILE="${KUBE_TEMP}/sar-result.json"
-  curl -kfsS -H "Content-Type:" --oauth2-bearer admin-token "https://localhost:${SECURE_API_PORT}/apis/authorization.k8s.io/v1beta1/subjectaccessreviews" -XPOST -d @test/fixtures/pkg/kubectl/cmd/create/sar-v1beta1.json > "${SAR_RESULT_FILE}"
+  curl -kfsS -H "Content-Type:" -H 'Authorization: Bearer admin-token' "https://localhost:${SECURE_API_PORT}/apis/authorization.k8s.io/v1beta1/subjectaccessreviews" -XPOST -d @test/fixtures/pkg/kubectl/cmd/create/sar-v1beta1.json > "${SAR_RESULT_FILE}"
   if grep -q '"allowed": true' "${SAR_RESULT_FILE}"; then
     kube::log::status "\"authorization.k8s.io/subjectaccessreviews\" returns as expected: $(cat "${SAR_RESULT_FILE}")"
   else
@@ -40,7 +40,7 @@ run_authorization_tests() {
   rm "${SAR_RESULT_FILE}"
 
   SAR_RESULT_FILE="${KUBE_TEMP}/sar-result.json"
-  curl -kfsS -H "Content-Type:" --oauth2-bearer admin-token "https://localhost:${SECURE_API_PORT}/apis/authorization.k8s.io/v1/subjectaccessreviews" -XPOST -d @test/fixtures/pkg/kubectl/cmd/create/sar-v1.json > "${SAR_RESULT_FILE}"
+  curl -kfsS -H "Content-Type:" -H 'Authorization: Bearer admin-token' "https://localhost:${SECURE_API_PORT}/apis/authorization.k8s.io/v1/subjectaccessreviews" -XPOST -d @test/fixtures/pkg/kubectl/cmd/create/sar-v1.json > "${SAR_RESULT_FILE}"
   if grep -q '"allowed": true' "${SAR_RESULT_FILE}"; then
     kube::log::status "\"authorization.k8s.io/subjectaccessreviews\" returns as expected: $(cat "${SAR_RESULT_FILE}")"
   else

--- a/test/cmd/discovery.sh
+++ b/test/cmd/discovery.sh
@@ -120,7 +120,7 @@ run_swagger_tests() {
 
   # Verify schema
   file="${KUBE_TEMP}/schema.json"
-  curl -kfs --oauth2-bearer admin-token "https://127.0.0.1:${SECURE_API_PORT}/openapi/v2" > "${file}"
+  curl -kfsS -H 'Authorization: Bearer admin-token' "https://127.0.0.1:${SECURE_API_PORT}/openapi/v2" > "${file}"
   grep -q "list of returned" "${file}"
   grep -q "List of services" "${file}"
   grep -q "Watch for changes to the described resources" "${file}"


### PR DESCRIPTION


**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

The flag `--oauth2-bearer` might have no effect in some environment.

**Which issue(s) this PR fixes**:

Fixes #96161

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
