### PR TITLE
testing: fix failing test on go 1.15.3

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_rolebinding_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_rolebinding_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package create
 
 import (
+	"fmt"
 	"testing"
 
 	rbac "k8s.io/api/rbac/v1"
@@ -72,7 +73,7 @@ func TestCreateRoleBinding(t *testing.T) {
 	}
 
 	for i, tc := range tests {
-		t.Run(string(i), func(t *testing.T) {
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
 			roleBinding, err := tc.options.createRoleBinding()
 			if err != nil {
 				t.Errorf("unexpected error:\n%#v\n", err)

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_rolebinding_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_rolebinding_test.go
@@ -17,7 +17,7 @@ limitations under the License.
 package create
 
 import (
-	"fmt"
+	"strconv"
 	"testing"
 
 	rbac "k8s.io/api/rbac/v1"
@@ -73,7 +73,7 @@ func TestCreateRoleBinding(t *testing.T) {
 	}
 
 	for i, tc := range tests {
-		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			roleBinding, err := tc.options.createRoleBinding()
 			if err != nil {
 				t.Errorf("unexpected error:\n%#v\n", err)


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind failing-test
<!--
Add one of the following kinds:

/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation

/kind flake
/kind regression
-->

**What this PR does / why we need it**:
This fixes a failing test in: `staging/src/k8s.io/kubectl/pkg/cmd/create/create_rolebinding_test.go:TestCreateRoleBinding`

On go version 1.15.3, casting int to string using `string(int)` causes
the test to fail with this error:

> k8s.io/kubernetes/vendor/k8s.io/kubectl/pkg/cmd/create
vendor/k8s.io/kubectl/pkg/cmd/create/create_rolebinding_test.go:75:9:    conversion from int to string yields a string of one rune, not a    string of digits (did you mean fmt.Sprint(x)?)
FAIL    k8s.io/kubernetes/vendor/k8s.io/kubectl/pkg/cmd/create    [build failed]
FAIL
make: *** [Makefile:185: test] Error 1

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #96210

**Special notes for your reviewer**:
See the linked issue's description for more info.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
