### PR TITLE
Tweak kubeadm config docs for reference generation

### DIFF
--- a/cmd/kubeadm/app/apis/kubeadm/v1beta1/doc.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1beta1/doc.go
@@ -19,263 +19,281 @@ limitations under the License.
 // +k8s:deepcopy-gen=package
 // +k8s:conversion-gen=k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm
 
-// Package v1beta1 has been deprecated by v1beta2
+// **Package v1beta1 has been deprecated by v1beta2**
+//
 // Package v1beta1 defines the v1beta1 version of the kubeadm configuration file format.
 // This version graduates the configuration format to BETA and is a big step towards GA.
 //
-//A list of changes since v1alpha3:
-//	- "apiServerEndpoint" in InitConfiguration was renamed to "localAPIEndpoint" for better clarity of what the field
-//	represents.
-//	- Common fields in ClusterConfiguration such as "*extraArgs" and "*extraVolumes" for control plane components are now moved
-//	under component structs - i.e. "apiServer", "controllerManager", "scheduler".
-//	- "auditPolicy" was removed from ClusterConfiguration. Please use "extraArgs" in "apiServer" to configure this feature instead.
-//	- "unifiedControlPlaneImage" in ClusterConfiguration was changed to a boolean field called "useHyperKubeImage".
-//	- ClusterConfiguration now has a "dns" field which can be used to select and configure the cluster DNS addon.
-//	- "featureGates" still exists under ClusterConfiguration, but there are no supported feature gates in 1.13.
-//	See the Kubernetes 1.13 changelog for further details.
-//	- Both "localEtcd" and "dns" configurations now support custom image repositories.
-//	- The "controlPlane*"-related fields in JoinConfiguration were refactored into a sub-structure.
-//	- "clusterName" was removed from JoinConfiguration and the name is now fetched from the existing cluster.
+// A list of changes since v1alpha3:
 //
-// Migration from old kubeadm config versions
+// - `apiServerEndpoint` in `InitConfiguration` was renamed to `localAPIEndpoint` for better clarity of what the field
+//   represents.
+// - Common fields in ClusterConfiguration such as `*extraArgs` and `*extraVolumes` for control plane components are now moved
+//   under component structs - i.e. `apiServer`, `controllerManager`, `scheduler`.
+// - `auditPolicy` was removed from ClusterConfiguration. Use `extraArgs` in `apiServer` to configure this feature instead.
+// - `unifiedControlPlaneImage` in ClusterConfiguration was changed to a boolean field called `useHyperKubeImage`.
+// - ClusterConfiguration now has a `dns` field which can be used to select and configure the cluster DNS addon.
+// - `featureGates` still exists under ClusterConfiguration, but there are no supported feature gates in 1.13.
+//   See the Kubernetes 1.13 changelog for further details.
+// - Both `localEtcd` and `dns` configurations now support custom image repositories.
+// - The `controlPlane*`-related fields in JoinConfiguration were refactored into a sub-structure.
+// - `clusterName` was removed from JoinConfiguration and the name is now fetched from the existing cluster.
 //
-// Please convert your v1alpha3 configuration files to v1beta1 using the "kubeadm config migrate" command of kubeadm v1.13.x
-// (conversion from older releases of kubeadm config files requires older release of kubeadm as well e.g.
-//	kubeadm v1.11 should be used to migrate v1alpha1 to v1alpha2; kubeadm v1.12 should be used to translate v1alpha2 to v1alpha3)
+// **Migration from old kubeadm config versions**
 //
-// Nevertheless, kubeadm v1.13.x will support reading from v1alpha3 version of the kubeadm config file format, but this support
-// will be dropped in the v1.14 release.
+// Please convert your v1alpha3 configuration files to v1beta1 using the `kubeadm config migrate` command of kubeadm v1.13.x
 //
-// Basics
+// **Basics**
 //
-// The preferred way to configure kubeadm is to pass an YAML configuration file with the --config option. Some of the
+// The preferred way to configure kubeadm is to pass an YAML configuration file with the `--config` option. Some of the
 // configuration options defined in the kubeadm config file are also available as command line flags, but only
 // the most common/simple use case are supported with this approach.
 //
-// A kubeadm config file could contain multiple configuration types separated using three dashes (“---”).
+// A kubeadm config file could contain multiple configuration types separated using three dashes (`---`).
 //
 // kubeadm supports the following configuration types:
 //
-//     apiVersion: kubeadm.k8s.io/v1beta1
-//     kind: InitConfiguration
+// ```yaml
+// apiVersion: kubeadm.k8s.io/v1beta1
+// kind: InitConfiguration
+// ```
+// ```yaml
+// apiVersion: kubeadm.k8s.io/v1beta1
+// kind: ClusterConfiguration
+// ```
+// ```yaml
+// apiVersion: kubelet.config.k8s.io/v1beta1
+// kind: KubeletConfiguration
+// ```
+// ```yaml
+// apiVersion: kubeproxy.config.k8s.io/v1alpha1
+// kind: KubeProxyConfiguration
+// ```
+// ```yaml
+// apiVersion: kubeadm.k8s.io/v1beta1
+// kind: JoinConfiguration
+// ```
 //
-//     apiVersion: kubeadm.k8s.io/v1beta1
-//     kind: ClusterConfiguration
+// To print the defaults for `init` and `join` actions use the following commands:
 //
-//     apiVersion: kubelet.config.k8s.io/v1beta1
-//     kind: KubeletConfiguration
-//
-//     apiVersion: kubeproxy.config.k8s.io/v1alpha1
-//     kind: KubeProxyConfiguration
-//
-//     apiVersion: kubeadm.k8s.io/v1beta1
-//     kind: JoinConfiguration
-//
-// To print the defaults for "init" and "join" actions use the following commands:
-//  kubeadm config print init-defaults
-//  kubeadm config print join-defaults
+// ```shell
+// kubeadm config print init-defaults
+// kubeadm config print join-defaults
+// ```
 //
 // The list of configuration types that must be included in a configuration file depends by the action you are
 // performing (init or join) and by the configuration options you are going to use (defaults or advanced customization).
 //
-// If some configuration types are not provided, or provided only partially, kubeadm will use default values; defaults
-// provided by kubeadm includes also enforcing consistency of values across components when required (e.g.
-// cluster-cidr flag on controller manager and clusterCIDR on kube-proxy).
+// If some configuration types are not provided, or provided only partially, kubeadm will use default values.
+// Defaults provided by kubeadm help enforce consistency of values across components when required (e.g.
+// `--cluster-cidr` flag on controller manager and `clusterCIDR` on kube-proxy).
 //
-// Users are always allowed to override default values, with the only exception of a small subset of setting with
-// relevance for security (e.g. enforce authorization-mode Node and RBAC on api server)
+// Users are always allowed to override default values, with the exception of a small subset of setting
+// related to security (e.g. enforce authorization-mode Node and RBAC on the API server)
+// If the user provides a configuration types that is not expected for the action you are performing,
+// kubeadm will ignore those types and print a warning.
 //
-// If the user provides a configuration types that is not expected for the action you are performing, kubeadm will
-// ignore those types and print a warning.
+// **Kubeadm init configuration types**
 //
-// Kubeadm init configuration types
+// When executing `kubeadm init` with the `--config` option, the following configuration types could be used:
+// `InitConfiguration`, `ClusterConfiguration`, `KubeProxyConfiguration`, `KubeletConfiguration`, but only one
+// between `InitConfiguration` and `ClusterConfiguration` is mandatory.
 //
-// When executing kubeadm init with the --config option, the following configuration types could be used:
-// InitConfiguration, ClusterConfiguration, KubeProxyConfiguration, KubeletConfiguration, but only one
-// between InitConfiguration and ClusterConfiguration is mandatory.
+// ```yaml
+// apiVersion: kubeadm.k8s.io/v1beta1
+// kind: InitConfiguration
+// bootstrapTokens:
+//   # ...
+// nodeRegistration:
+//   # ...
+// ```
 //
-//     apiVersion: kubeadm.k8s.io/v1beta1
-//     kind: InitConfiguration
-//     bootstrapTokens:
-//         ...
-//     nodeRegistration:
-//         ...
-//
-// The InitConfiguration type should be used to configure runtime settings, that in case of kubeadm init
-// are the configuration of the bootstrap token and all the setting which are specific to the node where kubeadm
+// The `InitConfiguration` type is used to configure runtime settings. In the case of `kubeadm init`,
+// it contains the bootstrap token configuration and all the setting specific to the node where kubeadm
 // is executed, including:
 //
-// - NodeRegistration, that holds fields that relate to registering the new node to the cluster;
-// use it to customize the node name, the CRI socket to use or any other settings that should apply to this
-// node only (e.g. the node ip).
+// - `NodeRegistration`: fields related to registering the new node to the cluster.
+//   You can use it to customize the node name, the CRI socket to use or any other
+//   settings that should apply to this node only (for example. the node IP).
 //
-// - LocalAPIEndpoint, that represents the endpoint of the instance of the API server to be deployed on this node;
-// use it e.g. to customize the API server advertise address.
+// - `LocalAPIEndpoint`: the endpoint of the API server instance to be deployed on this node.
+//   You can use it to customize the API server advertise address, for example.
 //
-//     apiVersion: kubeadm.k8s.io/v1beta1
-//     kind: ClusterConfiguration
-//     networking:
-//         ...
-//     etcd:
-//         ...
-//     apiServer:
-//       extraArgs:
-//         ...
-//       extraVolumes:
-//         ...
-//     ...
+//   ```yaml
+//   apiVersion: kubeadm.k8s.io/v1beta1
+//   kind: ClusterConfiguration
+//   networking:
+//     # ...
+//   etcd:
+//     # ...
+//   apiServer:
+//     extraArgs:
+//       # ...
+//     extraVolumes:
+//       #  ...
+//   # ...
+//   ```
 //
-// The ClusterConfiguration type should be used to configure cluster-wide settings,
-// including settings for:
+// The `ClusterConfiguration` type is used to configure cluster-wide settings, including:
 //
-// - Networking, that holds configuration for the networking topology of the cluster; use it e.g. to customize
-// node subnet or services subnet.
+// - Networking, holds configuration for the networking topology of the cluster.
+//   For example, you can use it to customize node subnet or services subnet.
 //
-// - Etcd configurations; use it e.g. to customize the local etcd or to configure the API server
-// for using an external etcd cluster.
+// - Etcd configurations that can be used to customize the local etcd or to configure
+//   the API server for using an external etcd cluster.
 //
-// - kube-apiserver, kube-scheduler, kube-controller-manager configurations; use it to customize control-plane
-// components by adding customized setting or overriding kubeadm default settings.
+// - kube-apiserver, kube-scheduler, kube-controller-manager configurations.
+//   You can use it to customize control-plane components by adding customized setting
+//   or overriding kubeadm default settings.
 //
-//    apiVersion: kubeproxy.config.k8s.io/v1alpha1
-//    kind: KubeProxyConfiguration
-//       ...
+// ```yaml
+// apiVersion: kubeproxy.config.k8s.io/v1alpha1
+// kind: KubeProxyConfiguration
+// # ...
+// ```
 //
-// The KubeProxyConfiguration type should be used to change the configuration passed to kube-proxy instances deployed
-// in the cluster. If this object is not provided or provided only partially, kubeadm applies defaults.
+// The `KubeProxyConfiguration` type should be used to change the configuration passed to
+// kube-proxy instances deployed in the cluster. If this object is not provided or provided
+// only partially, kubeadm applies defaults.
+// See [kube-proxy reference](https://kubernetes.io/docs/reference/command-line-tools-reference/kube-proxy/) or
+// [kube-proxy source code](https://godoc.org/k8s.io/kube-proxy/config/v1alpha1#KubeProxyConfiguration)
+// for more information.
 //
-// See https://kubernetes.io/docs/reference/command-line-tools-reference/kube-proxy/ or https://godoc.org/k8s.io/kube-proxy/config/v1alpha1#KubeProxyConfiguration
-// for kube proxy official documentation.
+// ```yaml
+// apiVersion: kubelet.config.k8s.io/v1beta1
+// kind: KubeletConfiguration
+// # ...
+// ```
 //
-//    apiVersion: kubelet.config.k8s.io/v1beta1
-//    kind: KubeletConfiguration
-//       ...
-//
-// The KubeletConfiguration type should be used to change the configurations that will be passed to all kubelet instances
+// The `KubeletConfiguration` type is used to change the configurations passed to all kubelet instances
 // deployed in the cluster. If this object is not provided or provided only partially, kubeadm applies defaults.
-//
-// See https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/ or https://godoc.org/k8s.io/kubelet/config/v1beta1#KubeletConfiguration
-// for kubelet official documentation.
+// See [kubelet reference](https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/) or
+// [kubelet source code](https://godoc.org/k8s.io/kubelet/config/v1beta1#KubeletConfiguration)
+// for more information.
 //
 // Here is a fully populated example of a single YAML file containing multiple
 // configuration types to be used during a `kubeadm init` run.
 //
-// 	apiVersion: kubeadm.k8s.io/v1beta1
-// 	kind: InitConfiguration
-// 	bootstrapTokens:
-// 	- token: "9a08jv.c0izixklcxtmnze7"
-// 	  description: "kubeadm bootstrap token"
-// 	  ttl: "24h"
-// 	- token: "783bde.3f89s0fje9f38fhf"
-// 	  description: "another bootstrap token"
-// 	  usages:
-// 	  - authentication
-// 	  - signing
-// 	  groups:
-// 	  - system:bootstrappers:kubeadm:default-node-token
-// 	nodeRegistration:
-// 	  name: "ec2-10-100-0-1"
-// 	  criSocket: "/var/run/dockershim.sock"
-// 	  taints:
-// 	  - key: "kubeadmNode"
-// 	    value: "master"
-// 	    effect: "NoSchedule"
-// 	  kubeletExtraArgs:
-// 	    cgroup-driver: "cgroupfs"
-// 	localAPIEndpoint:
-// 	  advertiseAddress: "10.100.0.1"
-// 	  bindPort: 6443
-// 	---
-// 	apiVersion: kubeadm.k8s.io/v1beta1
-// 	kind: ClusterConfiguration
-// 	etcd:
-// 	  # one of local or external
-// 	  local:
-// 	    imageRepository: "k8s.gcr.io"
-// 	    imageTag: "3.2.24"
-// 	    dataDir: "/var/lib/etcd"
-// 	    extraArgs:
-// 	      listen-client-urls: "http://10.100.0.1:2379"
-// 	    serverCertSANs:
-// 	    -  "ec2-10-100-0-1.compute-1.amazonaws.com"
-// 	    peerCertSANs:
-// 	    - "10.100.0.1"
-// 	  # external:
-// 	    # endpoints:
-// 	    # - "10.100.0.1:2379"
-// 	    # - "10.100.0.2:2379"
-// 	    # caFile: "/etcd/kubernetes/pki/etcd/etcd-ca.crt"
-// 	    # certFile: "/etcd/kubernetes/pki/etcd/etcd.crt"
-// 	    # keyFile: "/etcd/kubernetes/pki/etcd/etcd.key"
-// 	networking:
-// 	  serviceSubnet: "10.96.0.0/12"
-// 	  podSubnet: "10.100.0.1/24"
-// 	  dnsDomain: "cluster.local"
-// 	kubernetesVersion: "v1.12.0"
-// 	controlPlaneEndpoint: "10.100.0.1:6443"
-// 	apiServer:
-// 	  extraArgs:
-// 	    authorization-mode: "Node,RBAC"
-// 	  extraVolumes:
-// 	  - name: "some-volume"
-// 	    hostPath: "/etc/some-path"
-// 	    mountPath: "/etc/some-pod-path"
-// 	    readOnly: false
-// 	    pathType: File
-// 	  certSANs:
-// 	  - "10.100.1.1"
-// 	  - "ec2-10-100-0-1.compute-1.amazonaws.com"
-// 	  timeoutForControlPlane: 4m0s
-// 	controllerManager:
-// 	  extraArgs:
-// 	    "node-cidr-mask-size": "20"
-// 	  extraVolumes:
-// 	  - name: "some-volume"
-// 	    hostPath: "/etc/some-path"
-// 	    mountPath: "/etc/some-pod-path"
-// 	    readOnly: false
-// 	    pathType: File
-// 	scheduler:
-// 	  extraArgs:
-// 	    address: "10.100.0.1"
-// 	  extraVolumes:
-// 	  - name: "some-volume"
-// 	    hostPath: "/etc/some-path"
-// 	    mountPath: "/etc/some-pod-path"
-// 	    readOnly: false
-// 	    pathType: File
-// 	certificatesDir: "/etc/kubernetes/pki"
-// 	imageRepository: "k8s.gcr.io"
-// 	useHyperKubeImage: false
-// 	clusterName: "example-cluster"
-// 	---
-// 	apiVersion: kubelet.config.k8s.io/v1beta1
-// 	kind: KubeletConfiguration
-// 	# kubelet specific options here
-// 	---
-// 	apiVersion: kubeproxy.config.k8s.io/v1alpha1
-// 	kind: KubeProxyConfiguration
-// 	# kube-proxy specific options here
+// ```yaml
+// apiVersion: kubeadm.k8s.io/v1beta1
+// kind: InitConfiguration
+// bootstrapTokens:
+// - token: "9a08jv.c0izixklcxtmnze7"
+//   description: "kubeadm bootstrap token"
+//   ttl: "24h"
+// - token: "783bde.3f89s0fje9f38fhf"
+//   description: "another bootstrap token"
+//   usages:
+//   - authentication
+//   - signing
+//   groups:
+//   - system:bootstrappers:kubeadm:default-node-token
+// nodeRegistration:
+//   name: "ec2-10-100-0-1"
+//   criSocket: "/var/run/dockershim.sock"
+//   taints:
+//   - key: "kubeadmNode"
+//     value: "master"
+//     effect: "NoSchedule"
+//   kubeletExtraArgs:
+//     cgroup-driver: "cgroupfs"
+// localAPIEndpoint:
+//   advertiseAddress: "10.100.0.1"
+//   bindPort: 6443
+// ---
+// apiVersion: kubeadm.k8s.io/v1beta1
+// kind: ClusterConfiguration
+// etcd:
+//   # one of local or external
+//   local:
+//     imageRepository: "k8s.gcr.io"
+//     imageTag: "3.2.24"
+//     dataDir: "/var/lib/etcd"
+//     extraArgs:
+//       listen-client-urls: "http://10.100.0.1:2379"
+//     serverCertSANs:
+//     -  "ec2-10-100-0-1.compute-1.amazonaws.com"
+//     peerCertSANs:
+//     - "10.100.0.1"
+//   # external:
+//     # endpoints:
+//     # - "10.100.0.1:2379"
+//     # - "10.100.0.2:2379"
+//     # caFile: "/etcd/kubernetes/pki/etcd/etcd-ca.crt"
+//     # certFile: "/etcd/kubernetes/pki/etcd/etcd.crt"
+//     # keyFile: "/etcd/kubernetes/pki/etcd/etcd.key"
+// networking:
+//   serviceSubnet: "10.96.0.0/12"
+//   podSubnet: "10.100.0.1/24"
+//   dnsDomain: "cluster.local"
+// kubernetesVersion: "v1.12.0"
+// controlPlaneEndpoint: "10.100.0.1:6443"
+// apiServer:
+//   extraArgs:
+//     authorization-mode: "Node,RBAC"
+//   extraVolumes:
+//   - name: "some-volume"
+//     hostPath: "/etc/some-path"
+//     mountPath: "/etc/some-pod-path"
+//     readOnly: false
+//     pathType: File
+//   certSANs:
+//   - "10.100.1.1"
+//   - "ec2-10-100-0-1.compute-1.amazonaws.com"
+//   timeoutForControlPlane: 4m0s
+// controllerManager:
+//   extraArgs:
+//     "node-cidr-mask-size": "20"
+//   extraVolumes:
+//   - name: "some-volume"
+//     hostPath: "/etc/some-path"
+//     mountPath: "/etc/some-pod-path"
+//     readOnly: false
+//     pathType: File
+// scheduler:
+//   extraArgs:
+//     address: "10.100.0.1"
+//   extraVolumes:
+//   - name: "some-volume"
+//     hostPath: "/etc/some-path"
+//     mountPath: "/etc/some-pod-path"
+//     readOnly: false
+//     pathType: File
+// certificatesDir: "/etc/kubernetes/pki"
+// imageRepository: "k8s.gcr.io"
+// useHyperKubeImage: false
+// clusterName: "example-cluster"
+// ---
+// apiVersion: kubelet.config.k8s.io/v1beta1
+// kind: KubeletConfiguration
+// # kubelet specific options here
+// ---
+// apiVersion: kubeproxy.config.k8s.io/v1alpha1
+// kind: KubeProxyConfiguration
+// # kube-proxy specific options here
+// ```
 //
-// Kubeadm join configuration types
+// **Kubeadm join configuration types**
 //
-// When executing kubeadm join with the --config option, the JoinConfiguration type should be provided.
+// When executing `kubeadm join` with the `--config` option, the `JoinConfiguration` type should be provided.
 //
-//    apiVersion: kubeadm.k8s.io/v1beta1
-//    kind: JoinConfiguration
-//       ...
+// ```yaml
+// apiVersion: kubeadm.k8s.io/v1beta1
+// kind: JoinConfiguration
+// # ...
+// ```
 //
-// The JoinConfiguration type should be used to configure runtime settings, that in case of kubeadm join
-// are the discovery method used for accessing the cluster info and all the setting which are specific
+// The `JoinConfiguration` type is used to configure runtime settings. In the case of `kubeadm join`,
+// it contains the discovery method used for accessing the cluster info and all the setting which are specific
 // to the node where kubeadm is executed, including:
 //
-// - NodeRegistration, that holds fields that relate to registering the new node to the cluster;
-// use it to customize the node name, the CRI socket to use or any other settings that should apply to this
-// node only (e.g. the node ip).
+// - `NodeRegistration`: fields related to registering the new node to the cluster.
+//   You can use it to customize the node name, the CRI socket to use or any other
+//   settings that should apply to this node only (e.g. the node ip).
 //
-// - APIEndpoint, that represents the endpoint of the instance of the API server to be eventually deployed on this node.
+// - `APIEndpoint`: the endpoint of the API server instance to be eventually deployed on this node.
 //
-package v1beta1 // import "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta1"
+package v1beta1
 
 //TODO: The BootstrapTokenString object should move out to either k8s.io/client-go or k8s.io/api in the future
 //(probably as part of Bootstrap Tokens going GA). It should not be staged under the kubeadm API as it is now.

--- a/cmd/kubeadm/app/apis/kubeadm/v1beta1/types.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1beta1/types.go
@@ -23,123 +23,120 @@ import (
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
-// DEPRECATED - This group version of InitConfiguration is deprecated by apis/kubeadm/v1beta2/InitConfiguration.
-// InitConfiguration contains a list of elements that is specific "kubeadm init"-only runtime
-// information.
+// DEPRECATED - This group version of InitConfiguration is deprecated by apis/kubeadm/v1beta2.InitConfiguration.
+// InitConfiguration contains runtime information that are specific to "kubeadm init".
 type InitConfiguration struct {
 	metav1.TypeMeta `json:",inline"`
 
-	// ClusterConfiguration holds the cluster-wide information, and embeds that struct (which can be (un)marshalled separately as well)
+	// This field holds the cluster-wide information, and embeds that struct (which can be (un)marshalled separately as well)
 	// When InitConfiguration is marshalled to bytes in the external version, this information IS NOT preserved (which can be seen from
 	// the `json:"-"` tag. This is due to that when InitConfiguration is (un)marshalled, it turns into two YAML documents, one for the
 	// InitConfiguration and ClusterConfiguration. Hence, the information must not be duplicated, and is therefore omitted here.
 	ClusterConfiguration `json:"-"`
 
-	// `kubeadm init`-only information. These fields are solely used the first time `kubeadm init` runs.
-	// After that, the information in the fields IS NOT uploaded to the `kubeadm-config` ConfigMap
-	// that is used by `kubeadm upgrade` for instance. These fields must be omitempty.
-
-	// BootstrapTokens is respected at `kubeadm init` time and describes a set of Bootstrap Tokens to create.
-	// This information IS NOT uploaded to the kubeadm cluster configmap, partly because of its sensitive nature
+	// `bootstrapTokens` describes a set of Bootstrap Tokens to create during `kubeadm init`.
+	// This information is NOT uploaded to the `kubeadm-config` ConfigMap, partly because of its sensitive nature
 	BootstrapTokens []BootstrapToken `json:"bootstrapTokens,omitempty"`
 
-	// NodeRegistration holds fields that relate to registering the new control-plane node to the cluster
+	// `nodeRegistration` holds fields related to registering the new control-plane node to the cluster.
 	NodeRegistration NodeRegistrationOptions `json:"nodeRegistration,omitempty"`
 
-	// LocalAPIEndpoint represents the endpoint of the API server instance that's deployed on this control plane node
-	// In HA setups, this differs from ClusterConfiguration.ControlPlaneEndpoint in the sense that ControlPlaneEndpoint
-	// is the global endpoint for the cluster, which then loadbalances the requests to each individual API server. This
-	// configuration object lets you customize what IP/DNS name and port the local API server advertises it's accessible
-	// on. By default, kubeadm tries to auto-detect the IP of the default interface and use that, but in case that process
-	// fails you may set the desired value here.
+	// `localAPIEndpoint` represents the endpoint of the API server instance that's deployed on this control plane
+	// instance.  In HA setups, this differs from `ClusterConfiguration.controlPlaneEndpoint` in the sense that
+	// `controlPlaneEndpoint` is the global endpoint for the cluster, which loadbalances the requests to each individual
+	// API server. This configuration object lets you customize what IP/DNS name and port on which the local API server
+	// is accessible. By default, kubeadm tries to auto-detect the IP of the default interface and use that, but in
+	// case that process fails you may set the desired value here.
 	LocalAPIEndpoint APIEndpoint `json:"localAPIEndpoint,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
-// DEPRECATED - This group version of ClusterConfiguration is deprecated by apis/kubeadm/v1beta2/ClusterConfiguration.
-// ClusterConfiguration contains cluster-wide configuration for a kubeadm cluster
+// DEPRECATED - This group version of ClusterConfiguration is deprecated by apis/kubeadm/v1beta2.ClusterConfiguration.
+// ClusterConfiguration contains cluster-wide configuration for a kubeadm cluster.
 type ClusterConfiguration struct {
 	metav1.TypeMeta `json:",inline"`
 
-	// Etcd holds configuration for etcd.
+	// `etcd` holds configuration for etcd.
 	Etcd Etcd `json:"etcd"`
 
-	// Networking holds configuration for the networking topology of the cluster.
+	// `networking` holds configuration for the networking topology of the cluster.
 	Networking Networking `json:"networking"`
 
-	// KubernetesVersion is the target version of the control plane.
+	// `kubernetesVersion` is the target version of the control plane.
 	KubernetesVersion string `json:"kubernetesVersion"`
 
-	// ControlPlaneEndpoint sets a stable IP address or DNS name for the control plane; it
-	// can be a valid IP address or a RFC-1123 DNS subdomain, both with optional TCP port.
-	// In case the ControlPlaneEndpoint is not specified, the AdvertiseAddress + BindPort
-	// are used; in case the ControlPlaneEndpoint is specified but without a TCP port,
-	// the BindPort is used.
+	// `controlPlaneEndpoint` sets a stable IP address or DNS name for the control plane.
+	// It can be a valid IP address or a RFC-1123 DNS subdomain, both with optional TCP port.
+	// If `controlPlaneEndpoint` is not specified, the `advertiseAddress` + `bindPort`
+	// are used. If `controlPlaneEndpoint` is specified without a TCP port, the `bindPort` is used.
 	// Possible usages are:
-	// e.g. In a cluster with more than one control plane instances, this field should be
-	// assigned the address of the external load balancer in front of the
-	// control plane instances.
-	// e.g.  in environments with enforced node recycling, the ControlPlaneEndpoint
-	// could be used for assigning a stable DNS to the control plane.
+	//
+	// - In a cluster with more than one control plane nodes, this field should be
+	//   assigned the address of the external load balancer in front of the
+	//   control plane nodes.
+	// - In environments with enforced node recycling, the `controlPlaneEndpoint`
+	//   could be used for assigning a stable DNS to the control plane.
 	ControlPlaneEndpoint string `json:"controlPlaneEndpoint"`
 
-	// APIServer contains extra settings for the API server control plane component
+	// `apiServer` contains extra settings for the API server.
 	APIServer APIServer `json:"apiServer,omitempty"`
 
-	// ControllerManager contains extra settings for the controller manager control plane component
+	// `controllerManager` contains extra settings for the controller manager.
 	ControllerManager ControlPlaneComponent `json:"controllerManager,omitempty"`
 
-	// Scheduler contains extra settings for the scheduler control plane component
+	// `scheduler` contains extra settings for the scheduler.
 	Scheduler ControlPlaneComponent `json:"scheduler,omitempty"`
 
-	// DNS defines the options for the DNS add-on installed in the cluster.
+	// `dns` defines the options for the DNS add-on installed in the cluster.
 	DNS DNS `json:"dns"`
 
-	// CertificatesDir specifies where to store or look for all required certificates.
+	// `certificatesDir` specifies where to store or look for all required certificates.
 	CertificatesDir string `json:"certificatesDir"`
 
-	// ImageRepository sets the container registry to pull images from.
-	// If empty, `k8s.gcr.io` will be used by default; in case of kubernetes version is a CI build (kubernetes version starts with `ci/` or `ci-cross/`)
-	// `gcr.io/kubernetes-ci-images` will be used as a default for control plane components and for kube-proxy, while `k8s.gcr.io`
-	// will be used for all the other images.
+	// `imageRepository` specifies the container registry from which images are pulled.
+	// If empty, `k8s.gcr.io` will be used. If kubernetes version is a CI build (starts with `ci/` or `ci-cross/`)
+	// `gcr.io/kubernetes-ci-images` will be used for control plane components and
+	// kube-proxy, while `k8s.gcr.io` will be used for all the other images.
 	ImageRepository string `json:"imageRepository"`
 
-	// UseHyperKubeImage controls if hyperkube should be used for Kubernetes components instead of their respective separate images
-	// DEPRECATED: As hyperkube is itself deprecated, this fields is too. It will be removed in future kubeadm config versions, kubeadm
-	// will print multiple warnings when set to true, and at some point it may become ignored.
+	// `useHyperKubeImage` controls if hyperkube should be used for Kubernetes components
+	// instead of their respective separate images.
+	// DEPRECATED: As hyperkube is deprecated, this field is deprecated too.
+	// It will be removed in future kubeadm config versions. Kubeadm may print multiple
+	// warnings or ignore it when this is set to true.
 	UseHyperKubeImage bool `json:"useHyperKubeImage,omitempty"`
 
-	// FeatureGates enabled by the user.
+	// `featureGates` is a map containing the feature gates to be enabled.
 	FeatureGates map[string]bool `json:"featureGates,omitempty"`
 
-	// The cluster name
+	// `clusterName` contains the cluster name.
 	ClusterName string `json:"clusterName,omitempty"`
 }
 
 // ControlPlaneComponent holds settings common to control plane component of the cluster
 type ControlPlaneComponent struct {
-	// ExtraArgs is an extra set of flags to pass to the control plane component.
+	// `extraArgs` is an extra set of flags to pass to the control plane components.
 	// TODO: This is temporary and ideally we would like to switch all components to
 	// use ComponentConfig + ConfigMaps.
 	ExtraArgs map[string]string `json:"extraArgs,omitempty"`
 
-	// ExtraVolumes is an extra set of host volumes, mounted to the control plane component.
+	// `extraVolumes` is an extra set of HostPath volumes to be mounted by the control plane component.
 	ExtraVolumes []HostPathMount `json:"extraVolumes,omitempty"`
 }
 
-// APIServer holds settings necessary for API server deployments in the cluster
+// APIServer holds settings necessary for API server instances in the cluster
 type APIServer struct {
 	ControlPlaneComponent `json:",inline"`
 
-	// CertSANs sets extra Subject Alternative Names for the API Server signing cert.
+	// `certSANs` sets extra Subject Alternative Names (SANs) for the API Server signing cert.
 	CertSANs []string `json:"certSANs,omitempty"`
 
-	// TimeoutForControlPlane controls the timeout that we use for API server to appear
+	// `timeoutForControlPlane` controls the timeout that kubeadm waits for the API server to appear.
 	TimeoutForControlPlane *metav1.Duration `json:"timeoutForControlPlane,omitempty"`
 }
 
-// DNSAddOnType defines string identifying DNS add-on types
+// DNSAddOnType defines string identifying DNS add-on types.
 type DNSAddOnType string
 
 const (
@@ -150,24 +147,25 @@ const (
 	KubeDNS DNSAddOnType = "kube-dns"
 )
 
-// DNS defines the DNS addon that should be used in the cluster
+// DNS defines the DNS add-on that should be used in the cluster
 type DNS struct {
-	// Type defines the DNS add-on to be used
+	// `type` defines the DNS add-on to be used. Can be one of "CoreDNS" or "kube-dns".
 	Type DNSAddOnType `json:"type"`
 
-	// ImageMeta allows to customize the image used for the DNS component
+	// `imageMeta` is used to customize the image used for the DNS add-on.
 	ImageMeta `json:",inline"`
 }
 
 // ImageMeta allows to customize the image used for components that are not
 // originated from the Kubernetes/Kubernetes release process
 type ImageMeta struct {
-	// ImageRepository sets the container registry to pull images from.
-	// if not set, the ImageRepository defined in ClusterConfiguration will be used instead.
+	// `imageRepository` sets the container registry to pull images from.
+	// If not set, the `imageRepository` defined in ClusterConfiguration will be used instead.
 	ImageRepository string `json:"imageRepository,omitempty"`
 
-	// ImageTag allows to specify a tag for the image.
-	// In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.
+	// `imageTag` allows for specifying a tag for the image.
+	// When this value is set, kubeadm does not automatically change the version
+	// of the above components during upgrades.
 	ImageTag string `json:"imageTag,omitempty"`
 
 	//TODO: evaluate if we need also a ImageName based on user feedbacks
@@ -175,220 +173,228 @@ type ImageMeta struct {
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
-// ClusterStatus contains the cluster status. The ClusterStatus will be stored in the kubeadm-config
-// ConfigMap in the cluster, and then updated by kubeadm when additional control plane instance joins or leaves the cluster.
+// ClusterStatus contains the cluster status. The ClusterStatus will be stored in the `kubeadm-config` ConfigMap in the
+// cluster, and then updated by kubeadm when additional control plane nodes joins or leaves the cluster.
 type ClusterStatus struct {
 	metav1.TypeMeta `json:",inline"`
 
-	// APIEndpoints currently available in the cluster, one for each control plane/api server instance.
-	// The key of the map is the IP of the host's default interface
+	// `apiEndpoints` contains a list of API endpoints currently available in the cluster,
+	// one for each control-plane or API server instance. The key of the map is the IP
+	// of the node's default interface.
 	APIEndpoints map[string]APIEndpoint `json:"apiEndpoints"`
 }
 
 // APIEndpoint struct contains elements of API server instance deployed on a node.
 type APIEndpoint struct {
-	// AdvertiseAddress sets the IP address for the API server to advertise.
+	// `advertiseAddress` sets the IP address for the API server to advertise.
 	AdvertiseAddress string `json:"advertiseAddress"`
 
-	// BindPort sets the secure port for the API Server to bind to.
-	// Defaults to 6443.
+	// `bindPort` sets the secure port for the API Server to bind to. Defaults to 6443.
 	BindPort int32 `json:"bindPort"`
 }
 
 // NodeRegistrationOptions holds fields that relate to registering a new control-plane or node to the cluster, either via "kubeadm init" or "kubeadm join"
 type NodeRegistrationOptions struct {
-
-	// Name is the `.Metadata.Name` field of the Node API object that will be created in this `kubeadm init` or `kubeadm join` operation.
-	// This field is also used in the CommonName field of the kubelet's client certificate to the API server.
-	// Defaults to the hostname of the node if not provided.
+	// `name` is the `.metadata.name` field of the Node API object that will be created in this `kubeadm init` or
+	// `kubeadm join` operation. This field is also used in the CommonName field of the kubelet's
+	// client certificate to the API server. Defaults to the hostname of the node.
 	Name string `json:"name,omitempty"`
 
-	// CRISocket is used to retrieve container runtime info. This information will be annotated to the Node API object, for later re-use
+	// `criSocket` is used to retrieve container runtime information. This information will be
+	// annotated to the Node API object, for later re-use.
 	CRISocket string `json:"criSocket,omitempty"`
 
-	// Taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process
-	// it will be defaulted to []v1.Taint{'node-role.kubernetes.io/master=""'}. If you don't want to taint your control-plane node, set this field to an
-	// empty slice, i.e. `taints: []` in the YAML file. This field is solely used for Node registration.
+	// `taints` specifies the taints the Node API object should be registered with. If this field is not set, i.e. nil,
+	// it will be defaulted to `['node-role.kubernetes.io/master=""']` during `kubeadm init`.
+	// If you don't want to taint your control-plane node, set this field to an empty list (`[]`).
+	// This field is only used for node registration.
 	Taints []v1.Taint `json:"taints,omitempty"`
 
-	// KubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file
-	// kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config-1.X ConfigMap
-	// Flags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.
+	// `kubeletExtraArgs` contains extra arguments to pass to the kubelet. Kubeadm writes these arguments into an
+	// environment file for the kubelet to source.
+	// This overrides the generic base-level configuration in the `kubelet-config-1.x` ConfigMap
+	// Command line flags have higher priority when parsing.
+	// These values are local and specific to the node kubeadm is executing on.
 	KubeletExtraArgs map[string]string `json:"kubeletExtraArgs,omitempty"`
 }
 
 // Networking contains elements describing cluster's networking configuration
 type Networking struct {
-	// ServiceSubnet is the subnet used by k8s services. Defaults to "10.96.0.0/12".
+	// `serviceSubnet` is the subnet used by Services. Defaults to "10.96.0.0/12".
 	ServiceSubnet string `json:"serviceSubnet"`
-	// PodSubnet is the subnet used by pods.
+
+	// `podSubnet` is the subnet used by Pods.
 	PodSubnet string `json:"podSubnet"`
-	// DNSDomain is the dns domain used by k8s services. Defaults to "cluster.local".
+
+	// `dnsDomain` is the DNS domain used by Services. Defaults to "cluster.local".
 	DNSDomain string `json:"dnsDomain"`
 }
 
 // BootstrapToken describes one bootstrap token, stored as a Secret in the cluster
 type BootstrapToken struct {
-	// Token is used for establishing bidirectional trust between nodes and control-planes.
+	// `token` is used for establishing bidirectional trust between nodes and control-planes.
 	// Used for joining nodes in the cluster.
 	Token *BootstrapTokenString `json:"token"`
-	// Description sets a human-friendly message why this token exists and what it's used
+
+	// `description` contains a human-friendly message why this token exists and what it's used
 	// for, so other administrators can know its purpose.
 	Description string `json:"description,omitempty"`
-	// TTL defines the time to live for this token. Defaults to 24h.
-	// Expires and TTL are mutually exclusive.
+
+	// `ttl`  defines the time to live (TTL) for this token. Defaults to `24h`.
+	// The `expires` field and the `ttl` field are mutually exclusive.
 	TTL *metav1.Duration `json:"ttl,omitempty"`
-	// Expires specifies the timestamp when this token expires. Defaults to being set
-	// dynamically at runtime based on the TTL. Expires and TTL are mutually exclusive.
+
+	// `expires` specifies the timestamp when this token expires. Defaults to being set
+	// dynamically at runtime based on the `ttl`. The `expires` field and the `ttl` field are
+	// mutually exclusive.
 	Expires *metav1.Time `json:"expires,omitempty"`
-	// Usages describes the ways in which this token can be used. Can by default be used
+
+	// `usages` describes the ways in which this token can be used. Can by default be used
 	// for establishing bidirectional trust, but that can be changed here.
 	Usages []string `json:"usages,omitempty"`
-	// Groups specifies the extra groups that this token will authenticate as when/if
-	// used for authentication
+
+	// `groups` specifies the extra groups that this token will authenticate as when/if
+	// used for authentication.
 	Groups []string `json:"groups,omitempty"`
 }
 
 // Etcd contains elements describing Etcd configuration.
 type Etcd struct {
-
-	// Local provides configuration knobs for configuring the local etcd instance
-	// Local and External are mutually exclusive
+	// `local` provides configurations for the local etcd instance.
+	// The `local` field and the `external` field are mutually exclusive.
 	Local *LocalEtcd `json:"local,omitempty"`
 
-	// External describes how to connect to an external etcd cluster
-	// Local and External are mutually exclusive
+	// `external` describes how to connect to an external etcd service.
+	// The `local` field and the `external` field are mutually exclusive.
 	External *ExternalEtcd `json:"external,omitempty"`
 }
 
 // LocalEtcd describes that kubeadm should run an etcd cluster locally
 type LocalEtcd struct {
-	// ImageMeta allows to customize the container used for etcd
 	ImageMeta `json:",inline"`
 
-	// DataDir is the directory etcd will place its data.
-	// Defaults to "/var/lib/etcd".
+	// `dataDir` is the directory for etcd to place its data. Defaults to "/var/lib/etcd".
 	DataDir string `json:"dataDir"`
 
-	// ExtraArgs are extra arguments provided to the etcd binary
-	// when run inside a static pod.
+	// `extraArgs` are extra arguments provided to the etcd binary when run inside a static pod.
 	ExtraArgs map[string]string `json:"extraArgs,omitempty"`
 
-	// ServerCertSANs sets extra Subject Alternative Names for the etcd server signing cert.
+	// `serverCertSANs` sets extra Subject Alternative Names (SANs) for the etcd server signing cert.
 	ServerCertSANs []string `json:"serverCertSANs,omitempty"`
-	// PeerCertSANs sets extra Subject Alternative Names for the etcd peer signing cert.
+
+	// `peerCertSANs` sets extra Subject Alternative Names (SANs) for the etcd peer signing cert.
 	PeerCertSANs []string `json:"peerCertSANs,omitempty"`
 }
 
 // ExternalEtcd describes an external etcd cluster.
 // Kubeadm has no knowledge of where certificate files live and they must be supplied.
 type ExternalEtcd struct {
-	// Endpoints of etcd members. Required for ExternalEtcd.
+	// `endpoints` contains a list of etcd members. This field is required.
 	Endpoints []string `json:"endpoints"`
 
-	// CAFile is an SSL Certificate Authority file used to secure etcd communication.
+	// `caFile` is an SSL Certificate Authority (CA) file used to secure etcd communication.
 	// Required if using a TLS connection.
 	CAFile string `json:"caFile"`
 
-	// CertFile is an SSL certification file used to secure etcd communication.
+	// `certFile` is an SSL certification file used to secure etcd communication.
 	// Required if using a TLS connection.
 	CertFile string `json:"certFile"`
 
-	// KeyFile is an SSL key file used to secure etcd communication.
+	// `keyFile` is an SSL key file used to secure etcd communication.
 	// Required if using a TLS connection.
 	KeyFile string `json:"keyFile"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
-// DEPRECATED - This group version of JoinConfiguration is deprecated by apis/kubeadm/v1beta2/JoinConfiguration.
+// DEPRECATED - This group version of JoinConfiguration is deprecated by apis/kubeadm/v1beta2.JoinConfiguration.
 // JoinConfiguration contains elements describing a particular node.
 type JoinConfiguration struct {
 	metav1.TypeMeta `json:",inline"`
 
-	// NodeRegistration holds fields that relate to registering the new control-plane node to the cluster
+	// `nodeRegistration` holds fields related to registering a new control-plane node to the cluster
 	NodeRegistration NodeRegistrationOptions `json:"nodeRegistration"`
 
-	// CACertPath is the path to the SSL certificate authority used to
-	// secure comunications between node and control-plane.
+	// `caCertPath` is the path to the SSL certificate authority (CA) used to
+	// secure comunications between the node and the control-plane.
 	// Defaults to "/etc/kubernetes/pki/ca.crt".
 	CACertPath string `json:"caCertPath"`
 
-	// Discovery specifies the options for the kubelet to use during the TLS Bootstrap process
+	// `discovery` specifies the options for the kubelet to use during the TLS Bootstrap process.
 	Discovery Discovery `json:"discovery"`
 
-	// ControlPlane defines the additional control plane instance to be deployed on the joining node.
-	// If nil, no additional control plane instance will be deployed.
+	// `controlPlane` defines the additional control plane instance to be deployed on the joining node.
+	// If not specified, no additional control plane instance will be deployed.
 	ControlPlane *JoinControlPlane `json:"controlPlane,omitempty"`
 }
 
 // JoinControlPlane contains elements describing an additional control plane instance to be deployed on the joining node.
 type JoinControlPlane struct {
-	// LocalAPIEndpoint represents the endpoint of the API server instance to be deployed on this node.
+	// `localAPIEndpoint` represents the endpoint of the API server instance to be deployed on this node.
 	LocalAPIEndpoint APIEndpoint `json:"localAPIEndpoint,omitempty"`
 }
 
 // Discovery specifies the options for the kubelet to use during the TLS Bootstrap process
 type Discovery struct {
-	// BootstrapToken is used to set the options for bootstrap token based discovery
-	// BootstrapToken and File are mutually exclusive
+	// `bootstrapToken` is used to set the options for bootstrap token based discovery.
+	// The `bootstrapToken` field and the `file` field are mutually exclusive.
 	BootstrapToken *BootstrapTokenDiscovery `json:"bootstrapToken,omitempty"`
 
-	// File is used to specify a file or URL to a kubeconfig file from which to load cluster information
-	// BootstrapToken and File are mutually exclusive
+	// `file` is used to specify a file or URL to a kubeconfig file from which to load cluster information.
+	// The `bootstrapToken` field and the `file` field are mutually exclusive.
 	File *FileDiscovery `json:"file,omitempty"`
 
-	// TLSBootstrapToken is a token used for TLS bootstrapping.
-	// If .BootstrapToken is set, this field is defaulted to .BootstrapToken.Token, but can be overridden.
-	// If .File is set, this field **must be set** in case the KubeConfigFile does not contain any other authentication information
+	// `tlsBootstrapToken` is a token used for TLS bootstrapping.
+	// If `bootstrapToken` is set, this field is defaulted to `.bootstrapToken.token`, but can be overridden.
+	// If `file` is set, this field **must be set** in case the KubeConfigFile does not contain any other
+	// authentication information.
 	TLSBootstrapToken string `json:"tlsBootstrapToken"`
 
-	// Timeout modifies the discovery timeout
+	// `timeout` is used to customize timeout period for the discovery.
 	Timeout *metav1.Duration `json:"timeout,omitempty"`
 }
 
-// BootstrapTokenDiscovery is used to set the options for bootstrap token based discovery
+// BootstrapTokenDiscovery is used to set the options for bootstrap token based discovery.
 type BootstrapTokenDiscovery struct {
-	// Token is a token used to validate cluster information
-	// fetched from the control-plane.
+	// `token` is a token used to validate cluster information fetched from the control-plane.
 	Token string `json:"token"`
 
-	// APIServerEndpoint is an IP or domain name to the API server from which info will be fetched.
+	// `apiServerEndpoint` is an IP or domain name for the API server from which info will be fetched.
 	APIServerEndpoint string `json:"apiServerEndpoint,omitempty"`
 
-	// CACertHashes specifies a set of public key pins to verify
-	// when token-based discovery is used. The root CA found during discovery
-	// must match one of these values. Specifying an empty set disables root CA
-	// pinning, which can be unsafe. Each hash is specified as "<type>:<value>",
-	// where the only currently supported type is "sha256". This is a hex-encoded
-	// SHA-256 hash of the Subject Public Key Info (SPKI) object in DER-encoded
-	// ASN.1. These hashes can be calculated using, for example, OpenSSL.
+	// `caCertHashes` specifies a set of public key pins to verify when token-based discovery is used.
+	// The root CA found during discovery must match one of these values. Specifying an empty set disables
+	// root CA pinning, which can be unsafe. Each hash is specified as `<type>:<value>`, where the only
+	// type currently supported is "sha256". This is a hex-encoded SHA-256 hash of the Subject Public Key
+	// Info (SPKI) object in DER-encoded ASN.1. These hashes can be calculated using, for example, OpenSSL.
 	CACertHashes []string `json:"caCertHashes,omitempty"`
 
-	// UnsafeSkipCAVerification allows token-based discovery
-	// without CA verification via CACertHashes. This can weaken
-	// the security of kubeadm since other nodes can impersonate the control-plane.
+	// `unsafeSkipCAVerification` allows token-based discovery without CA verification via `caCertHashes`.
+	// This can weaken the kubeadm security since other nodes can impersonate the control-plane.
 	UnsafeSkipCAVerification bool `json:"unsafeSkipCAVerification"`
 }
 
-// FileDiscovery is used to specify a file or URL to a kubeconfig file from which to load cluster information
+// FileDiscovery is used to specify a file or a URL to a kubeconfig file from which to load cluster information.
 type FileDiscovery struct {
-	// KubeConfigPath is used to specify the actual file path or URL to the kubeconfig file from which to load cluster information
+	// `kubeConfigPath` is used to specify the file path or a URL to the kubeconfig file from which
+	// to load cluster information
 	KubeConfigPath string `json:"kubeConfigPath"`
 }
 
-// HostPathMount contains elements describing volumes that are mounted from the
-// host.
+// HostPathMount contains elements describing volumes that are mounted from the host.
 type HostPathMount struct {
-	// Name of the volume inside the pod template.
+	// `name` is the name of the volume inside the Pod template.
 	Name string `json:"name"`
-	// HostPath is the path in the host that will be mounted inside
-	// the pod.
+
+	// `hostPath` is the path on the host that will be mounted inside the Pod.
 	HostPath string `json:"hostPath"`
-	// MountPath is the path inside the pod where hostPath will be mounted.
+
+	// `mountPath` is the path inside the Pod where `hostPath` will be mounted.
 	MountPath string `json:"mountPath"`
-	// ReadOnly controls write access to the volume
+
+	// `readOnly` indicates whether the volume is mounted in read-only mode.
 	ReadOnly bool `json:"readOnly,omitempty"`
-	// PathType is the type of the HostPath.
+
+	// `pathType` is the type of the HostPath, for example, "DirectoryOrCreate", "File", etc.
 	PathType v1.HostPathType `json:"pathType,omitempty"`
 }

--- a/cmd/kubeadm/app/apis/kubeadm/v1beta2/doc.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1beta2/doc.go
@@ -23,252 +23,271 @@ limitations under the License.
 // This version improves on the v1beta1 format by fixing some minor issues and adding a few new fields.
 //
 // A list of changes since v1beta1:
-//	- "certificateKey" field is added to InitConfiguration and JoinConfiguration.
-//	- "ignorePreflightErrors" field is added to the NodeRegistrationOptions.
-//	- The JSON "omitempty" tag is used in a more places where appropriate.
-//	- The JSON "omitempty" tag of the "taints" field (inside NodeRegistrationOptions) is removed.
-//	See the Kubernetes 1.15 changelog for further details.
 //
-// Migration from old kubeadm config versions
+// - `certificateKey` field is added to `InitConfiguration` and `JoinConfiguration`.
+// - `ignorePreflightErrors` field is added to the `NodeRegistrationOptions`.
+// - The JSON `omitempty` tag is used in more places where appropriate.
+// - The JSON `omitempty` tag of the "taints" field (in `NodeRegistrationOptions`) is removed.
 //
-// Please convert your v1beta1 configuration files to v1beta2 using the "kubeadm config migrate" command of kubeadm v1.15.x
-// (conversion from older releases of kubeadm config files requires older release of kubeadm as well e.g.
-//	kubeadm v1.11 should be used to migrate v1alpha1 to v1alpha2; kubeadm v1.12 should be used to translate v1alpha2 to v1alpha3;
-//	kubeadm v1.13 or v1.14 should be used to translate v1alpha3 to v1beta1)
+// See the Kubernetes 1.15 changelog for further details.
 //
-// Nevertheless, kubeadm v1.15.x will support reading from v1beta1 version of the kubeadm config file format.
+// **Migration from old kubeadm config versions**
 //
-// Basics
+// Please convert your v1beta1 configuration files to v1beta2 using the `kubeadm config migrate` command of kubeadm
+// v1.15.x. kubeadm v1.15.x supports reading from v1beta1 version of the kubeadm config file format.
 //
-// The preferred way to configure kubeadm is to pass an YAML configuration file with the --config option. Some of the
+// **Basics**
+//
+// The preferred way to configure kubeadm is to pass an YAML configuration file with the `--config` option. Some of the
 // configuration options defined in the kubeadm config file are also available as command line flags, but only
 // the most common/simple use case are supported with this approach.
 //
-// A kubeadm config file could contain multiple configuration types separated using three dashes (“---”).
+// A kubeadm config file could contain multiple configuration types separated using three dashes (`---`).
 //
 // kubeadm supports the following configuration types:
 //
-//     apiVersion: kubeadm.k8s.io/v1beta2
-//     kind: InitConfiguration
+// ```yaml
+// apiVersion: kubeadm.k8s.io/v1beta2
+// kind: InitConfiguration
+// ```
+// ```yaml
+// apiVersion: kubeadm.k8s.io/v1beta2
+// kind: ClusterConfiguration
+// ```
+// ```yaml
+// apiVersion: kubelet.config.k8s.io/v1beta1
+// kind: KubeletConfiguration
+// ```
+// ```yaml
+// apiVersion: kubeproxy.config.k8s.io/v1alpha1
+// kind: KubeProxyConfiguration
+// ```
+// ```yaml
+// apiVersion: kubeadm.k8s.io/v1beta2
+// kind: JoinConfiguration
+// ```
 //
-//     apiVersion: kubeadm.k8s.io/v1beta2
-//     kind: ClusterConfiguration
+// To print the defaults for `init` and `join` actions use the following commands:
 //
-//     apiVersion: kubelet.config.k8s.io/v1beta1
-//     kind: KubeletConfiguration
-//
-//     apiVersion: kubeproxy.config.k8s.io/v1alpha1
-//     kind: KubeProxyConfiguration
-//
-//     apiVersion: kubeadm.k8s.io/v1beta2
-//     kind: JoinConfiguration
-//
-// To print the defaults for "init" and "join" actions use the following commands:
-//  kubeadm config print init-defaults
-//  kubeadm config print join-defaults
+// ```shell
+// kubeadm config print init-defaults
+// kubeadm config print join-defaults
+// ```
 //
 // The list of configuration types that must be included in a configuration file depends by the action you are
-// performing (init or join) and by the configuration options you are going to use (defaults or advanced customization).
+// performing (`init` or `join`) and by the configuration options you are going to use (defaults or advanced customization).
 //
-// If some configuration types are not provided, or provided only partially, kubeadm will use default values; defaults
-// provided by kubeadm includes also enforcing consistency of values across components when required (e.g.
-// cluster-cidr flag on controller manager and clusterCIDR on kube-proxy).
+// If some configuration types are not provided, or provided only partially, kubeadm will use default values.
+// Defaults provided by kubeadm help enforce consistency of values across components when required (e.g.
+// `--cluster-cidr` flag on controller manager and `clusterCIDR` on kube-proxy).
 //
-// Users are always allowed to override default values, with the only exception of a small subset of setting with
-// relevance for security (e.g. enforce authorization-mode Node and RBAC on api server)
-//
+// Users are always allowed to override default values, with the only exception of a small subset of setting
+// related to security (e.g. enforce authorization-mode Node and RBAC on the API server)
 // If the user provides a configuration types that is not expected for the action you are performing, kubeadm will
 // ignore those types and print a warning.
 //
-// Kubeadm init configuration types
+// **Kubeadm init configuration types**
 //
-// When executing kubeadm init with the --config option, the following configuration types could be used:
-// InitConfiguration, ClusterConfiguration, KubeProxyConfiguration, KubeletConfiguration, but only one
-// between InitConfiguration and ClusterConfiguration is mandatory.
+// When executing kubeadm init with the `--config` option, the following configuration types could be used:
+// `InitConfiguration`, `ClusterConfiguration`, `KubeProxyConfiguration`, `KubeletConfiguration`, but only one
+// between `InitConfiguration` and `ClusterConfiguration` is mandatory.
 //
-//     apiVersion: kubeadm.k8s.io/v1beta2
-//     kind: InitConfiguration
-//     bootstrapTokens:
-//         ...
-//     nodeRegistration:
-//         ...
+// ```yaml
+// apiVersion: kubeadm.k8s.io/v1beta2
+// kind: InitConfiguration
+// bootstrapTokens:
+//   # ...
+// nodeRegistration:
+//   # ...
+// ```
 //
-// The InitConfiguration type should be used to configure runtime settings, that in case of kubeadm init
-// are the configuration of the bootstrap token and all the setting which are specific to the node where kubeadm
-// is executed, including:
+// The `InitConfiguration` type is used to configure runtime settings. In the case of `kubeadm init`,
+// it includes the configuration of the bootstrap token and all the setting specific to the node
+// where kubeadm is executed, including:
 //
-// - NodeRegistration, that holds fields that relate to registering the new node to the cluster;
-// use it to customize the node name, the CRI socket to use or any other settings that should apply to this
-// node only (e.g. the node ip).
+// - `nodeRegistration`: fields that relate to registering the new node to the cluster.
+//   You can use it to customize the node name, the CRI socket to use or any other
+//   settings that should apply to this node only (for example. the node IP).
 //
-// - LocalAPIEndpoint, that represents the endpoint of the instance of the API server to be deployed on this node;
-// use it e.g. to customize the API server advertise address.
+// - `localAPIEndpoint`: the endpoint of the API server instance to be deployed on this node.
+//   For example, you can use it to customize the API server advertise address.
 //
-//     apiVersion: kubeadm.k8s.io/v1beta2
-//     kind: ClusterConfiguration
-//     networking:
-//         ...
-//     etcd:
-//         ...
-//     apiServer:
-//       extraArgs:
-//         ...
-//       extraVolumes:
-//         ...
-//     ...
+//   ```yaml
+//   apiVersion: kubeadm.k8s.io/v1beta2
+//   kind: ClusterConfiguration
+//   networking:
+//     # ...
+//   etcd:
+//     # ...
+//   apiServer:
+//     extraArgs:
+//       # ...
+//     extraVolumes:
+//       # ...
+//   # ...
+//   ```
 //
-// The ClusterConfiguration type should be used to configure cluster-wide settings,
-// including settings for:
+// The `ClusterConfiguration` type can be used to configure cluster-wide settings, including:
 //
-// - Networking, that holds configuration for the networking topology of the cluster; use it e.g. to customize
-// node subnet or services subnet.
+// - Networking, that holds configuration for the networking topology of the cluster;
+//   For example, uou can use it to customize node subnet or services subnet.
 //
-// - Etcd configurations; use it e.g. to customize the local etcd or to configure the API server
-// for using an external etcd cluster.
+// - Etcd configurations that can be used for customizing the local etcd or to configure
+//   the API server for using an external etcd cluster.
 //
-// - kube-apiserver, kube-scheduler, kube-controller-manager configurations; use it to customize control-plane
-// components by adding customized setting or overriding kubeadm default settings.
+// - kube-apiserver, kube-scheduler, kube-controller-manager configurations.
+//   You can use it to customize control-plane components by adding customized setting
+//   or overriding kubeadm default settings.
 //
-//    apiVersion: kubeproxy.config.k8s.io/v1alpha1
-//    kind: KubeProxyConfiguration
-//       ...
+// ```yaml
+// apiVersion: kubeproxy.config.k8s.io/v1alpha1
+// kind: KubeProxyConfiguration
+// # ...
+// ```
 //
-// The KubeProxyConfiguration type should be used to change the configuration passed to kube-proxy instances deployed
-// in the cluster. If this object is not provided or provided only partially, kubeadm applies defaults.
+// The `KubeProxyConfiguration` type is used to change the configurations passed to the kube-proxy
+// instances deployed in the cluster. If this object is not provided or provided only partially,
+// kubeadm applies defaults.
+// See [kube-proxy reference](https://kubernetes.io/docs/reference/command-line-tools-reference/kube-proxy/)
+// or [kube-proxy GoDoc](https://godoc.org/k8s.io/kube-proxy/config/v1alpha1#KubeProxyConfiguration)
+// for the official documentation.
 //
-// See https://kubernetes.io/docs/reference/command-line-tools-reference/kube-proxy/ or https://godoc.org/k8s.io/kube-proxy/config/v1alpha1#KubeProxyConfiguration
-// for kube proxy official documentation.
+// ```yaml
+// apiVersion: kubelet.config.k8s.io/v1beta1
+// kind: KubeletConfiguration
+// # ...
+// ```
 //
-//    apiVersion: kubelet.config.k8s.io/v1beta1
-//    kind: KubeletConfiguration
-//       ...
-//
-// The KubeletConfiguration type should be used to change the configurations that will be passed to all kubelet instances
+// The `KubeletConfiguration` type is used to change the configurations passed to all kubelet instances
 // deployed in the cluster. If this object is not provided or provided only partially, kubeadm applies defaults.
-//
-// See https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/ or https://godoc.org/k8s.io/kubelet/config/v1beta1#KubeletConfiguration
-// for kubelet official documentation.
+// See [kubelet reference](https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/) or
+// [kubelet GoDoc](https://godoc.org/k8s.io/kubelet/config/v1beta1#KubeletConfiguration)
+// for the official documentation.
 //
 // Here is a fully populated example of a single YAML file containing multiple
 // configuration types to be used during a `kubeadm init` run.
 //
-// 	apiVersion: kubeadm.k8s.io/v1beta2
-// 	kind: InitConfiguration
-// 	bootstrapTokens:
-// 	- token: "9a08jv.c0izixklcxtmnze7"
-// 	  description: "kubeadm bootstrap token"
-// 	  ttl: "24h"
-// 	- token: "783bde.3f89s0fje9f38fhf"
-// 	  description: "another bootstrap token"
-// 	  usages:
-// 	  - authentication
-// 	  - signing
-// 	  groups:
-// 	  - system:bootstrappers:kubeadm:default-node-token
-// 	nodeRegistration:
-// 	  name: "ec2-10-100-0-1"
-// 	  criSocket: "/var/run/dockershim.sock"
-// 	  taints:
-// 	  - key: "kubeadmNode"
-// 	    value: "master"
-// 	    effect: "NoSchedule"
-// 	  kubeletExtraArgs:
-// 	    cgroup-driver: "cgroupfs"
-//	  ignorePreflightErrors:
-//	  - IsPrivilegedUser
-// 	localAPIEndpoint:
-// 	  advertiseAddress: "10.100.0.1"
-// 	  bindPort: 6443
-//	certificateKey: "e6a2eb8581237ab72a4f494f30285ec12a9694d750b9785706a83bfcbbbd2204"
-// 	---
-// 	apiVersion: kubeadm.k8s.io/v1beta2
-// 	kind: ClusterConfiguration
-// 	etcd:
-// 	  # one of local or external
-// 	  local:
-// 	    imageRepository: "k8s.gcr.io"
-// 	    imageTag: "3.2.24"
-// 	    dataDir: "/var/lib/etcd"
-// 	    extraArgs:
-// 	      listen-client-urls: "http://10.100.0.1:2379"
-// 	    serverCertSANs:
-// 	    -  "ec2-10-100-0-1.compute-1.amazonaws.com"
-// 	    peerCertSANs:
-// 	    - "10.100.0.1"
-// 	  # external:
-// 	    # endpoints:
-// 	    # - "10.100.0.1:2379"
-// 	    # - "10.100.0.2:2379"
-// 	    # caFile: "/etcd/kubernetes/pki/etcd/etcd-ca.crt"
-// 	    # certFile: "/etcd/kubernetes/pki/etcd/etcd.crt"
-// 	    # keyFile: "/etcd/kubernetes/pki/etcd/etcd.key"
-// 	networking:
-// 	  serviceSubnet: "10.96.0.0/12"
-// 	  podSubnet: "10.100.0.1/24"
-// 	  dnsDomain: "cluster.local"
-// 	kubernetesVersion: "v1.12.0"
-// 	controlPlaneEndpoint: "10.100.0.1:6443"
-// 	apiServer:
-// 	  extraArgs:
-// 	    authorization-mode: "Node,RBAC"
-// 	  extraVolumes:
-// 	  - name: "some-volume"
-// 	    hostPath: "/etc/some-path"
-// 	    mountPath: "/etc/some-pod-path"
-// 	    readOnly: false
-// 	    pathType: File
-// 	  certSANs:
-// 	  - "10.100.1.1"
-// 	  - "ec2-10-100-0-1.compute-1.amazonaws.com"
-// 	  timeoutForControlPlane: 4m0s
-// 	controllerManager:
-// 	  extraArgs:
-// 	    "node-cidr-mask-size": "20"
-// 	  extraVolumes:
-// 	  - name: "some-volume"
-// 	    hostPath: "/etc/some-path"
-// 	    mountPath: "/etc/some-pod-path"
-// 	    readOnly: false
-// 	    pathType: File
-// 	scheduler:
-// 	  extraArgs:
-// 	    address: "10.100.0.1"
-// 	  extraVolumes:
-// 	  - name: "some-volume"
-// 	    hostPath: "/etc/some-path"
-// 	    mountPath: "/etc/some-pod-path"
-// 	    readOnly: false
-// 	    pathType: File
-// 	certificatesDir: "/etc/kubernetes/pki"
-// 	imageRepository: "k8s.gcr.io"
-// 	useHyperKubeImage: false
-// 	clusterName: "example-cluster"
-// 	---
-// 	apiVersion: kubelet.config.k8s.io/v1beta1
-// 	kind: KubeletConfiguration
-// 	# kubelet specific options here
-// 	---
-// 	apiVersion: kubeproxy.config.k8s.io/v1alpha1
-// 	kind: KubeProxyConfiguration
-// 	# kube-proxy specific options here
+// ```yaml
+// apiVersion: kubeadm.k8s.io/v1beta2
+// kind: InitConfiguration
+// bootstrapTokens:
+// - token: "9a08jv.c0izixklcxtmnze7"
+//   description: "kubeadm bootstrap token"
+//   ttl: "24h"
+// - token: "783bde.3f89s0fje9f38fhf"
+//   description: "another bootstrap token"
+//   usages:
+//   - authentication
+//   - signing
+//   groups:
+//   - system:bootstrappers:kubeadm:default-node-token
+// nodeRegistration:
+//   name: "ec2-10-100-0-1"
+//   criSocket: "/var/run/dockershim.sock"
+//   taints:
+//   - key: "kubeadmNode"
+//     value: "master"
+//     effect: "NoSchedule"
+//   kubeletExtraArgs:
+//     cgroup-driver: "cgroupfs"
+//   ignorePreflightErrors:
+//   - IsPrivilegedUser
+// localAPIEndpoint:
+//   advertiseAddress: "10.100.0.1"
+//   bindPort: 6443
+// certificateKey: "e6a2eb8581237ab72a4f494f30285ec12a9694d750b9785706a83bfcbbbd2204"
+// ---
+// apiVersion: kubeadm.k8s.io/v1beta2
+// kind: ClusterConfiguration
+// etcd:
+//   # one of local or external
+//   local:
+//     imageRepository: "k8s.gcr.io"
+//     imageTag: "3.2.24"
+//     dataDir: "/var/lib/etcd"
+//     extraArgs:
+//       listen-client-urls: "http://10.100.0.1:2379"
+//     serverCertSANs:
+//     -  "ec2-10-100-0-1.compute-1.amazonaws.com"
+//     peerCertSANs:
+//     - "10.100.0.1"
+//   # external:
+//     # endpoints:
+//     # - "10.100.0.1:2379"
+//     # - "10.100.0.2:2379"
+//     # caFile: "/etcd/kubernetes/pki/etcd/etcd-ca.crt"
+//     # certFile: "/etcd/kubernetes/pki/etcd/etcd.crt"
+//     # keyFile: "/etcd/kubernetes/pki/etcd/etcd.key"
+// networking:
+//   serviceSubnet: "10.96.0.0/12"
+//   podSubnet: "10.100.0.1/24"
+//   dnsDomain: "cluster.local"
+// kubernetesVersion: "v1.12.0"
+// controlPlaneEndpoint: "10.100.0.1:6443"
+// apiServer:
+//   extraArgs:
+//     authorization-mode: "Node,RBAC"
+//   extraVolumes:
+//   - name: "some-volume"
+//     hostPath: "/etc/some-path"
+//     mountPath: "/etc/some-pod-path"
+//     readOnly: false
+//     pathType: File
+//   certSANs:
+//   - "10.100.1.1"
+//   - "ec2-10-100-0-1.compute-1.amazonaws.com"
+//   timeoutForControlPlane: 4m0s
+// controllerManager:
+//   extraArgs:
+//     "node-cidr-mask-size": "20"
+//   extraVolumes:
+//   - name: "some-volume"
+//     hostPath: "/etc/some-path"
+//     mountPath: "/etc/some-pod-path"
+//     readOnly: false
+//     pathType: File
+// scheduler:
+//   extraArgs:
+//     address: "10.100.0.1"
+//   extraVolumes:
+//   - name: "some-volume"
+//     hostPath: "/etc/some-path"
+//     mountPath: "/etc/some-pod-path"
+//     readOnly: false
+//     pathType: File
+// certificatesDir: "/etc/kubernetes/pki"
+// imageRepository: "k8s.gcr.io"
+// useHyperKubeImage: false
+// clusterName: "example-cluster"
+// ---
+// apiVersion: kubelet.config.k8s.io/v1beta1
+// kind: KubeletConfiguration
+// # kubelet specific options here
+// ---
+// apiVersion: kubeproxy.config.k8s.io/v1alpha1
+// kind: KubeProxyConfiguration
+// # kube-proxy specific options here
+// ```
 //
-// Kubeadm join configuration types
+// **Kubeadm join configuration types**
 //
-// When executing kubeadm join with the --config option, the JoinConfiguration type should be provided.
+// When executing `kubeadm join` with the `--config` option, the `JoinConfiguration` type should be provided.
 //
-//    apiVersion: kubeadm.k8s.io/v1beta2
-//    kind: JoinConfiguration
-//       ...
+// ```yaml
+// apiVersion: kubeadm.k8s.io/v1beta2
+// kind: JoinConfiguration
+// # ...
+// ```
 //
-// The JoinConfiguration type should be used to configure runtime settings, that in case of kubeadm join
-// are the discovery method used for accessing the cluster info and all the setting which are specific
+// The `JoinConfiguration` type is used to configure runtime settings. In the case of `kubeadm join`,
+// it contains the discovery method used for accessing the cluster info and all the setting which are specific
 // to the node where kubeadm is executed, including:
 //
-// - NodeRegistration, that holds fields that relate to registering the new node to the cluster;
-// use it to customize the node name, the CRI socket to use or any other settings that should apply to this
-// node only (e.g. the node ip).
+// - `nodeRegistration`: fields related to registering the new node to the cluster.
+//   You can use it to customize the node name, the CRI socket to use or any other settings that should
+//   apply to this node only (e.g. the node ip).
 //
-// - APIEndpoint, that represents the endpoint of the instance of the API server to be eventually deployed on this node.
+// - `apiEndpoint`: the endpoint of the API server instance to be eventually deployed on this node.
 //
 package v1beta2 // import "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta2"
 


### PR DESCRIPTION
This PR tweaks the comments for kubeadm config types for better documentation.
Additional notes are extracted from the validation logic and added to the
comments where appropriate.

**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note

```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
