### PR TITLE
update features to indicate beta in comment

### DIFF
--- a/hack/.staticcheck_failures
+++ b/hack/.staticcheck_failures
@@ -27,7 +27,6 @@ vendor/k8s.io/apiserver/pkg/endpoints/request
 vendor/k8s.io/apiserver/pkg/registry/generic/registry
 vendor/k8s.io/apiserver/pkg/registry/generic/rest
 vendor/k8s.io/apiserver/pkg/registry/rest/resttest
-vendor/k8s.io/apiserver/pkg/server
 vendor/k8s.io/apiserver/pkg/server/dynamiccertificates
 vendor/k8s.io/apiserver/pkg/server/filters
 vendor/k8s.io/apiserver/pkg/server/httplog

--- a/staging/src/k8s.io/apiserver/pkg/features/kube_features.go
+++ b/staging/src/k8s.io/apiserver/pkg/features/kube_features.go
@@ -61,6 +61,7 @@ const (
 
 	// owner: @ilackams
 	// alpha: v1.7
+	// beta: v1.16
 	//
 	// Enables compression of REST responses (GET and LIST only)
 	APIResponseCompression featuregate.Feature = "APIResponseCompression"
@@ -85,6 +86,7 @@ const (
 
 	// owner: @caesarxuchao
 	// alpha: v1.15
+	// beta: v1.16
 	//
 	// Allow apiservers to show a count of remaining items in the response
 	// to a chunking list request.

--- a/staging/src/k8s.io/apiserver/pkg/server/genericapiserver.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/genericapiserver.go
@@ -182,10 +182,6 @@ type GenericAPIServer struct {
 	// and the kind associated with a given resource. As resources are installed, they are registered here.
 	EquivalentResourceRegistry runtime.EquivalentResourceRegistry
 
-	// enableAPIResponseCompression indicates whether API Responses should support compression
-	// if the client requests it via Accept-Encoding
-	enableAPIResponseCompression bool
-
 	// delegationTarget is the next delegate in the chain. This is never nil.
 	delegationTarget DelegationTarget
 


### PR DESCRIPTION
Fixing comments on our featuregates to match reality and cleaning up a dead field I found going through.


/kind cleanup
/priority important-long-term
@kubernetes/sig-api-machinery-pr-reviews 

```release-note
NONE
```