### PR TITLE
Exclude KEP-1933 from verify-all.sh until after alpha status.

### DIFF
--- a/hack/make-rules/verify.sh
+++ b/hack/make-rules/verify.sh
@@ -34,6 +34,7 @@ EXCLUDED_PATTERNS=(
   "verify-all.sh"                # this script calls the make rule and would cause a loop
   "verify-linkcheck.sh"          # runs in separate Jenkins job once per day due to high network usage
   "verify-*-dockerized.sh"       # Don't run any scripts that intended to be run dockerized
+  "verify-govet-levee.sh"        # Do not run levee analysis by default while KEP-1933 implementation is in alpha.
   )
 
 # Exclude generated-files-remake in certain cases, if they're running in a separate job.


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:
Recently, #94661 merged `verify-govet-levee.sh` as a testing target for static analysis defending against leaking credentials to logs.  Due to an oversight, this has been prematurely included in blocking Prow testing as part of `verify-all.sh`.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
- [KEP-1933](kubernetes/enhancements/blob/master/keps/sig-instrumentation/1933-secret-logging-static-analysis/README.md)
