### PR TITLE
Revert "add e2e test for Service ExternalIPs"

### DIFF
--- a/test/e2e/framework/service/jig.go
+++ b/test/e2e/framework/service/jig.go
@@ -829,10 +829,6 @@ func testReachabilityOverClusterIP(clusterIP string, sp v1.ServicePort, execPod 
 	return nil
 }
 
-func testReachabilityOverExternalIP(externalIP string, sp v1.ServicePort, execPod *v1.Pod) error {
-	return testEndpointReachability(externalIP, sp.Port, sp.Protocol, execPod)
-}
-
 func testReachabilityOverNodePorts(nodes *v1.NodeList, sp v1.ServicePort, pod *v1.Pod, clusterIP string) error {
 	internalAddrs := e2enode.CollectAddresses(nodes, v1.NodeInternalIP)
 	externalAddrs := e2enode.CollectAddresses(nodes, v1.NodeExternalIP)
@@ -915,7 +911,6 @@ func testEndpointReachability(endpoint string, port int32, protocol v1.Protocol,
 func (j *TestJig) checkClusterIPServiceReachability(svc *v1.Service, pod *v1.Pod) error {
 	clusterIP := svc.Spec.ClusterIP
 	servicePorts := svc.Spec.Ports
-	externalIPs := svc.Spec.ExternalIPs
 
 	err := j.waitForAvailableEndpoint(ServiceEndpointsTimeout)
 	if err != nil {
@@ -930,14 +925,6 @@ func (j *TestJig) checkClusterIPServiceReachability(svc *v1.Service, pod *v1.Pod
 		err = testReachabilityOverClusterIP(clusterIP, servicePort, pod)
 		if err != nil {
 			return err
-		}
-		if len(externalIPs) > 0 {
-			for _, externalIP := range externalIPs {
-				err = testReachabilityOverExternalIP(externalIP, servicePort, pod)
-				if err != nil {
-					return err
-				}
-			}
 		}
 	}
 	return nil

--- a/test/e2e/network/service.go
+++ b/test/e2e/network/service.go
@@ -1179,37 +1179,6 @@ var _ = SIGDescribe("Services", func() {
 		framework.ExpectNoError(err)
 	})
 
-	/*
-		Create a ClusterIP service with an External IP that is not assigned to an interface.
-		The IP ranges here are reserved for documentation according to
-		[RFC 5737](https://tools.ietf.org/html/rfc5737) Section 3 and should not be used by any host.
-	*/
-	ginkgo.It("should be possible to connect to a service via ExternalIP when the external IP is not assigned to a node", func() {
-		serviceName := "externalip-test"
-		ns := f.Namespace.Name
-		externalIP := "203.0.113.250"
-		if framework.TestContext.ClusterIsIPv6() {
-			externalIP = "2001:DB8::cb00:71fa"
-		}
-
-		jig := e2eservice.NewTestJig(cs, ns, serviceName)
-
-		ginkgo.By("creating service " + serviceName + " with type=clusterIP in namespace " + ns)
-		clusterIPService, err := jig.CreateTCPService(func(svc *v1.Service) {
-			svc.Spec.Type = v1.ServiceTypeClusterIP
-			svc.Spec.ExternalIPs = []string{externalIP}
-			svc.Spec.Ports = []v1.ServicePort{
-				{Port: 80, Name: "http", Protocol: v1.ProtocolTCP, TargetPort: intstr.FromInt(9376)},
-			}
-		})
-		framework.ExpectNoError(err)
-		err = jig.CreateServicePods(2)
-		framework.ExpectNoError(err)
-		execPod := e2epod.CreateExecPodOrFail(cs, ns, "execpod", nil)
-		err = jig.CheckServiceReachability(clusterIPService, execPod)
-		framework.ExpectNoError(err)
-	})
-
 	// TODO: Get rid of [DisabledForLargeClusters] tag when issue #56138 is fixed.
 	ginkgo.It("should be able to change the type and ports of a service [Slow] [DisabledForLargeClusters]", func() {
 		// requires cloud load-balancer support


### PR DESCRIPTION
This reverts commit 0ed8fd6dc9befb1d19ca05edf5b042ff26dcb94d.

It turns out that ExternalIPs are not allowed to be reachable from
pods unless the IP is present in the node.
However, due to a kube-proxy limitation it was working in environment
that used CNIs without bridges for the pods.


/kind failing-test
```release-note
NONE
```

Fixes: https://github.com/kubernetes/kubernetes/issues/96222