### PR TITLE
Add the metric data for different extension points

### DIFF
--- a/staging/src/k8s.io/component-base/metrics/testutil/metrics.go
+++ b/staging/src/k8s.io/component-base/metrics/testutil/metrics.go
@@ -262,10 +262,6 @@ func validateMetricFamily(gatherer metrics.Gatherer, metricName string) (*dto.Me
 		}
 	}
 
-	if metricFamily == nil {
-		return nil, fmt.Errorf("metric %q not found", metricName)
-	}
-
 	if metricFamily.GetMetric() == nil {
 		return nil, fmt.Errorf("metric %q is empty", metricName)
 	}
@@ -278,7 +274,7 @@ func validateMetricFamily(gatherer metrics.Gatherer, metricName string) (*dto.Me
 
 // GetHistogramVecFromGatherer collects a metric, that matches the input labelValue map
 // from a gatherer implementing k8s.io/component-base/metrics.Gatherer interface.
-// All metrics within the metricFamily will be assembled as a single HistogramVec. Quantle, Average etc. are caculated based on
+// All metrics within the metricFamily will be assembled as a single HistogramVec. Quantile, Average etc. are caculated based on
 // the accumulated data from the HistogramVec.
 // Used only for testing purposes where we need to gather metrics directly from a running binary (without metrics endpoint).
 func GetHistogramVecFromGatherer(gatherer metrics.Gatherer, metricName string, lvMap map[string]string) (HistogramVec, error) {
@@ -303,10 +299,10 @@ type LabeledHistogram struct {
 	Histogram Histogram
 }
 
-// GetHistogramFromGatherer collects a metric from a gatherer implementing k8s.io/component-base/metrics.Gatherer interface.
+// GetHistogramsFromGatherer collects a metric from a gatherer implementing k8s.io/component-base/metrics.Gatherer interface.
 // If the metric is a HistogramVec, each metric from the HistogramVec will be collected with a label map one by one.
 // Used only for testing purposes where we need to gather metrics directly from a running binary (without metrics endpoint).
-func GetHistogramFromGatherer(gatherer metrics.Gatherer, metricName string, lvMap map[string]string) ([]LabeledHistogram, error) {
+func GetHistogramsFromGatherer(gatherer metrics.Gatherer, metricName string, lvMap map[string]string) ([]LabeledHistogram, error) {
 	metricFamily, err := validateMetricFamily(gatherer, metricName)
 	if err != nil {
 		return nil, err

--- a/test/integration/scheduler_perf/scheduler_perf_test.go
+++ b/test/integration/scheduler_perf/scheduler_perf_test.go
@@ -71,11 +71,17 @@ const (
 
 var (
 	defaultMetricsCollectorConfig = metricsCollectorConfig{
-		Metrics: []string{
-			"scheduler_scheduling_algorithm_predicate_evaluation_seconds",
-			"scheduler_scheduling_algorithm_priority_evaluation_seconds",
-			"scheduler_e2e_scheduling_duration_seconds",
-			"scheduler_pod_scheduling_duration_seconds",
+		// Specify the filter as {"label": "value"} to filter out the specific metrics
+		// Specify "*" as {"label": "*"} denotes that all the metrics with the label should be collected.
+
+		// AggregatedMetric defines the metrics that will aggregate all the Histogram data within the same metricFamily.
+		AggregatedMetric: map[string]map[string]string{
+			"scheduler_e2e_scheduling_duration_seconds": nil,
+			"scheduler_pod_scheduling_duration_seconds": nil,
+		},
+		// HistogramMetric defines the metrics that will collect each of Histogram from the metricFamily one by one.
+		HistogramMetric: map[string]map[string]string{
+			"scheduler_framework_extension_point_duration_seconds": {"extension_point": "*"},
 		},
 	}
 )

--- a/test/integration/scheduler_perf/util.go
+++ b/test/integration/scheduler_perf/util.go
@@ -256,7 +256,7 @@ func collectHistogramVec(metric string, labels map[string]string, lvMap map[stri
 
 func collectHistogram(metric string, labels map[string]string, lvMap map[string]string) []DataItem {
 	var dataItems []DataItem
-	vec, err := testutil.GetHistogramFromGatherer(legacyregistry.DefaultGatherer, metric, lvMap)
+	vec, err := testutil.GetHistogramsFromGatherer(legacyregistry.DefaultGatherer, metric, lvMap)
 	if err != nil {
 		klog.Error(err)
 		return nil


### PR DESCRIPTION
Signed-off-by: Dave Chen <dave.chen@arm.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind feature


**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubernetes/issues/96252
Ref: https://github.com/kubernetes/kubernetes/issues/96354

**Special notes for your reviewer**:
The result looks like this,
```
    {
      "data": {
        "Average": 0.06262556699999997,
        "Perc50": 0.052246603970741906,
        "Perc90": 0.09404388714733543,
        "Perc99": 0.09926854754440961
      },
      "unit": "ms",
      "labels": {
        "Metric": "scheduler_framework_extension_point_duration_seconds",
        "Name": "BenchmarkPerfScheduling/SchedulingBasic/500Nodes/namespace-2",
        "extension_point": "PreScore"
      }
    },
    {
      "data": {
        "Average": 0.002850502999999999,
        "Perc50": 0.05,
        "Perc90": 0.09000000000000001,
        "Perc99": 0.095
      },
      "unit": "ms",
      "labels": {
        "Metric": "scheduler_framework_extension_point_duration_seconds",
        "Name": "BenchmarkPerfScheduling/SchedulingBasic/500Nodes/namespace-2",
        "extension_point": "Reserve"
      }
    },

```

pls refer to this file for the report from the `scheduler_perf`
[BenchmarkPerfScheduling_2021-07-28T08%3A55%3A50Z.txt](https://github.com/kubernetes/kubernetes/files/6891973/BenchmarkPerfScheduling_2021-07-28T08.3A55.3A50Z.txt)


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Metric data for different extension points have been provided in the `scheduler_perf`
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
