### PR TITLE
kubectl debug: allow set-image-only invocation

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/debug/debug_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/debug/debug_test.go
@@ -868,7 +868,6 @@ func TestGeneratePodCopyWithDebugContainer(t *testing.T) {
 			name: "Change image for all containers with set-image",
 			opts: &DebugOptions{
 				CopyTo:    "myapp-copy",
-				Container: "app",
 				SetImages: map[string]string{"*": "busybox"},
 			},
 			havePod: &corev1.Pod{
@@ -898,7 +897,6 @@ func TestGeneratePodCopyWithDebugContainer(t *testing.T) {
 			name: "Change image for multiple containers with set-image",
 			opts: &DebugOptions{
 				CopyTo:    "myapp-copy",
-				Container: "app",
 				SetImages: map[string]string{"*": "busybox", "app": "app-debugger"},
 			},
 			havePod: &corev1.Pod{
@@ -1362,6 +1360,19 @@ func TestCompleteAndValidate(t *testing.T) {
 			},
 		},
 		{
+			name: "Pod copy: explicit attach",
+			args: "mypod --image=busybox --copy-to=my-debugger --attach -- sleep 1d",
+			wantOpts: &DebugOptions{
+				Args:           []string{"sleep", "1d"},
+				Attach:         true,
+				CopyTo:         "my-debugger",
+				Image:          "busybox",
+				Namespace:      "default",
+				ShareProcesses: true,
+				TargetNames:    []string{"mypod"},
+			},
+		},
+		{
 			name: "Pod copy: replace single image of existing container",
 			args: "mypod --image=busybox --container=my-container --copy-to=my-debugger",
 			wantOpts: &DebugOptions{
@@ -1441,6 +1452,11 @@ func TestCompleteAndValidate(t *testing.T) {
 		{
 			name:      "Pod copy: invalid --set-image",
 			args:      "mypod --set-image=*=SUPERGOODIMAGE#1!!!! --copy-to=my-debugger",
+			wantError: true,
+		},
+		{
+			name:      "Pod copy: specifying attach without existing or newly created container",
+			args:      "mypod --set-image=*=busybox --copy-to=my-debugger --attach",
 			wantError: true,
 		},
 		{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**: This fixes a bug when using the new `--set-image` flag for `kubectl debug` without specifying `--container`.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #96261

**Special notes for your reviewer**: This also adds a check for user specifying `--attach` without also specifying or creating a container, which is an edge case that occurred to me while fixing this bug.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
