### PR TITLE
tryWinKernelspaceProxy: handle kernelspace not allowed, make ServiceInfo same as kernelspace, comment all functionality WRT go proxy

### DIFF
--- a/cmd/kube-proxy/app/server.go
+++ b/cmd/kube-proxy/app/server.go
@@ -302,13 +302,15 @@ func (o *Options) Validate() error {
 	return nil
 }
 
-// Run runs the specified ProxyServer.
+// Run is the OS-neutral entrypoint to kube-proxy, it runs a new ProxyServer.  The implementation of ProxyServer is Compiled into the binary.  Depending
+// on what OS you compiled against, a different implementation will be called.
 func (o *Options) Run() error {
 	defer close(o.errCh)
 	if len(o.WriteConfigTo) > 0 {
 		return o.writeConfigFile()
 	}
 
+	// see the server_* +build information in the server_* files
 	proxyServer, err := NewProxyServer(o)
 	if err != nil {
 		return err

--- a/cmd/kube-proxy/app/server_windows.go
+++ b/cmd/kube-proxy/app/server_windows.go
@@ -188,10 +188,9 @@ func getProxyMode(proxyMode string, kcompat winkernel.KernelCompatTester) string
 			fmt.Errorf("Can't determine whether to use windows kernel proxy %v (using proxy mode: %v)", err, proxyModeActual)
 		}
 		return proxyModeActual
-	} else {
-		klog.V(1).Infof("Using userspace proxy, unknown proxy input %v", proxyMode)
-		return proxyModeUserspace
 	}
+	klog.V(1).Infof("Using userspace proxy, unknown proxy input %v", proxyMode)
+	return proxyModeUserspace
 }
 
 // tryWinKernelSpaceProxy attempts to use the kernelspace proxy, based on the version (because HNS needs to be working properly for kernel proxying to work)

--- a/cmd/kube-proxy/app/server_windows.go
+++ b/cmd/kube-proxy/app/server_windows.go
@@ -178,14 +178,15 @@ func newProxyServer(config *proxyconfigapi.KubeProxyConfiguration, cleanupAndExi
 	}, nil
 }
 
-// getProxyMode attempts to use the kernel proxy (if requested), but will fall back to user space if necessary.  In cases where an unknown proxy is sent, userspace proxy is also used.
+// getProxyMode attempts to use the kernel proxy (if possible), otherwise will fall back to userspace in default or kernel space unsupported scenarios.
 func getProxyMode(proxyMode string, kcompat winkernel.KernelCompatTester) string {
+	// assume userspace is possible if they ask for it
 	if proxyMode == proxyModeUserspace {
 		return proxyModeUserspace
 	} else if proxyMode == proxyModeKernelspace {
 		proxyModeActual, err := tryWinKernelSpaceProxy(kcompat)
 		if err != nil {
-			fmt.Errorf("Can't determine whether to use windows kernel proxy %v (using proxy mode: %v)", err, proxyModeActual)
+			klog.Warningf("Can't determine whether to use windows kernel proxy %v, (using proxy mode: %v)", err, proxyModeActual)
 		}
 		return proxyModeActual
 	}

--- a/cmd/kube-proxy/app/server_windows.go
+++ b/cmd/kube-proxy/app/server_windows.go
@@ -190,7 +190,7 @@ func getProxyMode(proxyMode string, kcompat winkernel.KernelCompatTester) string
 		}
 		return proxyModeActual
 	}
-	klog.V(1).Infof("Using userspace proxy, unknown proxy input %v", proxyMode)
+	klog.V(1).Infof("Unkown proxy mode %v, using userspace proxy", proxyMode)
 	return proxyModeUserspace
 }
 

--- a/pkg/proxy/config/config.go
+++ b/pkg/proxy/config/config.go
@@ -107,8 +107,6 @@ type EndpointsConfig struct {
 
 // NewEndpointsConfig creates a new EndpointsConfig.
 func NewEndpointsConfig(endpointsInformer coreinformers.EndpointsInformer, resyncPeriod time.Duration) *EndpointsConfig {
-	klog.Infof("creating new endpoints config with resync period of %v", resyncPeriod)
-
 	result := &EndpointsConfig{
 		listerSynced: endpointsInformer.Informer().HasSynced,
 	}

--- a/pkg/proxy/config/config.go
+++ b/pkg/proxy/config/config.go
@@ -107,6 +107,8 @@ type EndpointsConfig struct {
 
 // NewEndpointsConfig creates a new EndpointsConfig.
 func NewEndpointsConfig(endpointsInformer coreinformers.EndpointsInformer, resyncPeriod time.Duration) *EndpointsConfig {
+	klog.Infof("creating new endpoints config with resync period of %v", resyncPeriod)
+
 	result := &EndpointsConfig{
 		listerSynced: endpointsInformer.Informer().HasSynced,
 	}
@@ -198,6 +200,8 @@ type EndpointSliceConfig struct {
 
 // NewEndpointSliceConfig creates a new EndpointSliceConfig.
 func NewEndpointSliceConfig(endpointSliceInformer discoveryinformers.EndpointSliceInformer, resyncPeriod time.Duration) *EndpointSliceConfig {
+	klog.Infof("creating new endpoint slice config with resync period of %v", resyncPeriod)
+
 	result := &EndpointSliceConfig{
 		listerSynced: endpointSliceInformer.Informer().HasSynced,
 	}
@@ -324,6 +328,8 @@ func (c *ServiceConfig) Run(stopCh <-chan struct{}) {
 	}
 }
 
+// handleAddService calls every ServiceHandler implementation and triggers its OnServiceAdd implementation.  This
+// is specific to your underlying proxy technology (i.e. this ultimately might result in iptables or netsh rules being added)
 func (c *ServiceConfig) handleAddService(obj interface{}) {
 	service, ok := obj.(*v1.Service)
 	if !ok {
@@ -336,6 +342,8 @@ func (c *ServiceConfig) handleAddService(obj interface{}) {
 	}
 }
 
+// handleUpdateService calls every ServiceHandler and triggers OnServiceUpdate implementation. This is
+// specific to your underlying proxy technology.
 func (c *ServiceConfig) handleUpdateService(oldObj, newObj interface{}) {
 	oldService, ok := oldObj.(*v1.Service)
 	if !ok {
@@ -353,6 +361,8 @@ func (c *ServiceConfig) handleUpdateService(oldObj, newObj interface{}) {
 	}
 }
 
+// handleDeleteService calls every ServiceHandler and triggers OnServiceUpdate implementation. This is
+// specific to your underlying proxy technology.
 func (c *ServiceConfig) handleDeleteService(obj interface{}) {
 	service, ok := obj.(*v1.Service)
 	if !ok {
@@ -372,8 +382,7 @@ func (c *ServiceConfig) handleDeleteService(obj interface{}) {
 	}
 }
 
-// NodeHandler is an abstract interface of objects which receive
-// notifications about node object changes.
+// NodeHandler is an interface of objects which receive notifications about node object changes.
 type NodeHandler interface {
 	// OnNodeAdd is called whenever creation of new node object
 	// is observed.

--- a/pkg/proxy/types.go
+++ b/pkg/proxy/types.go
@@ -34,9 +34,8 @@ type Provider interface {
 
 	// Sync immediately synchronizes the Provider's current state to proxy rules.
 	Sync()
-	// SyncLoop runs periodic work.
-	// This is expected to run as a goroutine or as the main loop of the app.
-	// It does not return.
+	// SyncLoop runs periodic work which isn't done via events/watches, and is expected to run as a goroutine or as the main loop of the app.
+	// It does not return.  For example, the SyncLoop might do the work of cleaning up old sessions that have timed out.
 	SyncLoop()
 }
 

--- a/pkg/proxy/userspace/loadbalancer.go
+++ b/pkg/proxy/userspace/loadbalancer.go
@@ -17,10 +17,11 @@ limitations under the License.
 package userspace
 
 import (
-	"k8s.io/api/core/v1"
+	"net"
+
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/kubernetes/pkg/proxy"
 	proxyconfig "k8s.io/kubernetes/pkg/proxy/config"
-	"net"
 )
 
 // LoadBalancer is an interface for distributing incoming requests to service endpoints.

--- a/pkg/proxy/winkernel/proxier_test.go
+++ b/pkg/proxy/winkernel/proxier_test.go
@@ -182,9 +182,9 @@ func TestCreateServiceVip(t *testing.T) {
 	proxier.syncProxyRules()
 
 	svc := proxier.serviceMap[svcPortName]
-	svcInfo, ok := svc.(*serviceInfo)
+	svcInfo, ok := svc.(*ServiceInfo)
 	if !ok {
-		t.Errorf("Failed to cast serviceInfo %q", svcPortName.String())
+		t.Errorf("Failed to cast ServiceInfo %q", svcPortName.String())
 
 	} else {
 		if svcInfo.remoteEndpoint == nil {
@@ -694,9 +694,9 @@ func TestCreateLoadBalancer(t *testing.T) {
 	proxier.syncProxyRules()
 
 	svc := proxier.serviceMap[svcPortName]
-	svcInfo, ok := svc.(*serviceInfo)
+	svcInfo, ok := svc.(*ServiceInfo)
 	if !ok {
-		t.Errorf("Failed to cast serviceInfo %q", svcPortName.String())
+		t.Errorf("Failed to cast ServiceInfo %q", svcPortName.String())
 
 	} else {
 		if svcInfo.hnsID != guid {
@@ -754,9 +754,9 @@ func TestCreateDsrLoadBalancer(t *testing.T) {
 	proxier.syncProxyRules()
 
 	svc := proxier.serviceMap[svcPortName]
-	svcInfo, ok := svc.(*serviceInfo)
+	svcInfo, ok := svc.(*ServiceInfo)
 	if !ok {
-		t.Errorf("Failed to cast serviceInfo %q", svcPortName.String())
+		t.Errorf("Failed to cast ServiceInfo %q", svcPortName.String())
 
 	} else {
 		if svcInfo.hnsID != guid {
@@ -819,9 +819,9 @@ func TestEndpointSlice(t *testing.T) {
 	proxier.syncProxyRules()
 
 	svc := proxier.serviceMap[svcPortName]
-	svcInfo, ok := svc.(*serviceInfo)
+	svcInfo, ok := svc.(*ServiceInfo)
 	if !ok {
-		t.Errorf("Failed to cast serviceInfo %q", svcPortName.String())
+		t.Errorf("Failed to cast ServiceInfo %q", svcPortName.String())
 
 	} else {
 		if svcInfo.hnsID != guid {

--- a/pkg/proxy/winuserspace/loadbalancer.go
+++ b/pkg/proxy/winuserspace/loadbalancer.go
@@ -17,10 +17,11 @@ limitations under the License.
 package winuserspace
 
 import (
-	"k8s.io/api/core/v1"
+	"net"
+
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/kubernetes/pkg/proxy"
 	proxyconfig "k8s.io/kubernetes/pkg/proxy/config"
-	"net"
 )
 
 // LoadBalancer is an interface for distributing incoming requests to service endpoints.

--- a/pkg/proxy/winuserspace/proxier.go
+++ b/pkg/proxy/winuserspace/proxier.go
@@ -262,7 +262,7 @@ func (proxier *Proxier) addServiceOnPortPortal(servicePortPortalName ServicePort
 	return si, nil
 }
 
-// closeServicePortPortal
+// closeServicePortPortal closes the "portal" created for a given service, this involves changing netsh routing rules.
 func (proxier *Proxier) closeServicePortPortal(servicePortPortalName ServicePortPortalName, info *ServiceInfo) error {
 	// turn off the proxy
 	if err := proxier.stopProxy(servicePortPortalName, info); err != nil {

--- a/pkg/proxy/winuserspace/proxier_test.go
+++ b/pkg/proxy/winuserspace/proxier_test.go
@@ -29,7 +29,7 @@ import (
 	"testing"
 	"time"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	discovery "k8s.io/api/discovery/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -208,7 +208,7 @@ func waitForNumProxyLoops(t *testing.T, p *Proxier, want int32) {
 	t.Errorf("expected %d ProxyLoops running, got %d", want, got)
 }
 
-func waitForNumProxyClients(t *testing.T, s *serviceInfo, want int, timeout time.Duration) {
+func waitForNumProxyClients(t *testing.T, s *ServiceInfo, want int, timeout time.Duration) {
 	var got int
 	now := time.Now()
 	deadline := now.Add(timeout)
@@ -251,14 +251,11 @@ func TestTCPProxy(t *testing.T) {
 	})
 
 	listenIP := "0.0.0.0"
-	p, err := createProxier(lb, net.ParseIP(listenIP), netshtest.NewFake(), net.ParseIP("127.0.0.1"), time.Minute, udpIdleTimeoutForTest)
-	if err != nil {
-		t.Fatal(err)
-	}
+	p := createProxier(lb, net.ParseIP(listenIP), netshtest.NewFake(), net.ParseIP("127.0.0.1"), time.Minute, udpIdleTimeoutForTest)
 	waitForNumProxyLoops(t, p, 0)
 
 	servicePortPortalName := ServicePortPortalName{NamespacedName: types.NamespacedName{Namespace: service.Namespace, Name: service.Name}, Port: service.Port, PortalIPName: listenIP}
-	svcInfo, err := p.addServicePortPortal(servicePortPortalName, "TCP", listenIP, 0, time.Second)
+	svcInfo, err := p.addServiceOnPortPortal(servicePortPortalName, "TCP", listenIP, 0, time.Second)
 	if err != nil {
 		t.Fatalf("error adding new service: %#v", err)
 	}
@@ -278,14 +275,11 @@ func TestUDPProxy(t *testing.T) {
 	})
 
 	listenIP := "0.0.0.0"
-	p, err := createProxier(lb, net.ParseIP(listenIP), netshtest.NewFake(), net.ParseIP("127.0.0.1"), time.Minute, udpIdleTimeoutForTest)
-	if err != nil {
-		t.Fatal(err)
-	}
+	p := createProxier(lb, net.ParseIP(listenIP), netshtest.NewFake(), net.ParseIP("127.0.0.1"), time.Minute, udpIdleTimeoutForTest)
 	waitForNumProxyLoops(t, p, 0)
 
 	servicePortPortalName := ServicePortPortalName{NamespacedName: types.NamespacedName{Namespace: service.Namespace, Name: service.Name}, Port: service.Port, PortalIPName: listenIP}
-	svcInfo, err := p.addServicePortPortal(servicePortPortalName, "UDP", listenIP, 0, time.Second)
+	svcInfo, err := p.addServiceOnPortPortal(servicePortPortalName, "UDP", listenIP, 0, time.Second)
 	if err != nil {
 		t.Fatalf("error adding new service: %#v", err)
 	}
@@ -305,14 +299,11 @@ func TestUDPProxyTimeout(t *testing.T) {
 	})
 
 	listenIP := "0.0.0.0"
-	p, err := createProxier(lb, net.ParseIP(listenIP), netshtest.NewFake(), net.ParseIP("127.0.0.1"), time.Minute, udpIdleTimeoutForTest)
-	if err != nil {
-		t.Fatal(err)
-	}
+	p := createProxier(lb, net.ParseIP(listenIP), netshtest.NewFake(), net.ParseIP("127.0.0.1"), time.Minute, udpIdleTimeoutForTest)
 	waitForNumProxyLoops(t, p, 0)
 
 	servicePortPortalName := ServicePortPortalName{NamespacedName: types.NamespacedName{Namespace: service.Namespace, Name: service.Name}, Port: service.Port, PortalIPName: listenIP}
-	svcInfo, err := p.addServicePortPortal(servicePortPortalName, "UDP", listenIP, 0, time.Second)
+	svcInfo, err := p.addServiceOnPortPortal(servicePortPortalName, "UDP", listenIP, 0, time.Second)
 	if err != nil {
 		t.Fatalf("error adding new service: %#v", err)
 	}
@@ -344,14 +335,11 @@ func TestMultiPortProxy(t *testing.T) {
 	})
 
 	listenIP := "0.0.0.0"
-	p, err := createProxier(lb, net.ParseIP(listenIP), netshtest.NewFake(), net.ParseIP("127.0.0.1"), time.Minute, udpIdleTimeoutForTest)
-	if err != nil {
-		t.Fatal(err)
-	}
+	p := createProxier(lb, net.ParseIP(listenIP), netshtest.NewFake(), net.ParseIP("127.0.0.1"), time.Minute, udpIdleTimeoutForTest)
 	waitForNumProxyLoops(t, p, 0)
 
 	servicePortPortalNameP := ServicePortPortalName{NamespacedName: types.NamespacedName{Namespace: serviceP.Namespace, Name: serviceP.Name}, Port: serviceP.Port, PortalIPName: listenIP}
-	svcInfoP, err := p.addServicePortPortal(servicePortPortalNameP, "TCP", listenIP, 0, time.Second)
+	svcInfoP, err := p.addServiceOnPortPortal(servicePortPortalNameP, "TCP", listenIP, 0, time.Second)
 	if err != nil {
 		t.Fatalf("error adding new service: %#v", err)
 	}
@@ -359,7 +347,7 @@ func TestMultiPortProxy(t *testing.T) {
 	waitForNumProxyLoops(t, p, 1)
 
 	servicePortPortalNameQ := ServicePortPortalName{NamespacedName: types.NamespacedName{Namespace: serviceQ.Namespace, Name: serviceQ.Name}, Port: serviceQ.Port, PortalIPName: listenIP}
-	svcInfoQ, err := p.addServicePortPortal(servicePortPortalNameQ, "UDP", listenIP, 0, time.Second)
+	svcInfoQ, err := p.addServiceOnPortPortal(servicePortPortalNameQ, "UDP", listenIP, 0, time.Second)
 	if err != nil {
 		t.Fatalf("error adding new service: %#v", err)
 	}
@@ -374,10 +362,7 @@ func TestMultiPortOnServiceAdd(t *testing.T) {
 	serviceX := proxy.ServicePortName{NamespacedName: types.NamespacedName{Namespace: "testnamespace", Name: "echo"}, Port: "x"}
 
 	listenIP := "0.0.0.0"
-	p, err := createProxier(lb, net.ParseIP(listenIP), netshtest.NewFake(), net.ParseIP("127.0.0.1"), time.Minute, udpIdleTimeoutForTest)
-	if err != nil {
-		t.Fatal(err)
-	}
+	p := createProxier(lb, net.ParseIP(listenIP), netshtest.NewFake(), net.ParseIP("127.0.0.1"), time.Minute, udpIdleTimeoutForTest)
 	waitForNumProxyLoops(t, p, 0)
 
 	p.OnServiceAdd(&v1.Service{
@@ -440,14 +425,12 @@ func TestTCPProxyStop(t *testing.T) {
 	})
 
 	listenIP := "0.0.0.0"
-	p, err := createProxier(lb, net.ParseIP(listenIP), netshtest.NewFake(), net.ParseIP("127.0.0.1"), time.Minute, udpIdleTimeoutForTest)
-	if err != nil {
-		t.Fatal(err)
-	}
+	p := createProxier(lb, net.ParseIP(listenIP), netshtest.NewFake(), net.ParseIP("127.0.0.1"), time.Minute, udpIdleTimeoutForTest)
+
 	waitForNumProxyLoops(t, p, 0)
 
 	servicePortPortalName := ServicePortPortalName{NamespacedName: types.NamespacedName{Namespace: service.Namespace, Name: service.Name}, Port: service.Port, PortalIPName: listenIP}
-	svcInfo, err := p.addServicePortPortal(servicePortPortalName, "TCP", listenIP, 0, time.Second)
+	svcInfo, err := p.addServiceOnPortPortal(servicePortPortalName, "TCP", listenIP, 0, time.Second)
 	if err != nil {
 		t.Fatalf("error adding new service: %#v", err)
 	}
@@ -484,14 +467,11 @@ func TestUDPProxyStop(t *testing.T) {
 	})
 
 	listenIP := "0.0.0.0"
-	p, err := createProxier(lb, net.ParseIP(listenIP), netshtest.NewFake(), net.ParseIP("127.0.0.1"), time.Minute, udpIdleTimeoutForTest)
-	if err != nil {
-		t.Fatal(err)
-	}
+	p := createProxier(lb, net.ParseIP(listenIP), netshtest.NewFake(), net.ParseIP("127.0.0.1"), time.Minute, udpIdleTimeoutForTest)
 	waitForNumProxyLoops(t, p, 0)
 
 	servicePortPortalName := ServicePortPortalName{NamespacedName: types.NamespacedName{Namespace: service.Namespace, Name: service.Name}, Port: service.Port, PortalIPName: listenIP}
-	svcInfo, err := p.addServicePortPortal(servicePortPortalName, "UDP", listenIP, 0, time.Second)
+	svcInfo, err := p.addServiceOnPortPortal(servicePortPortalName, "UDP", listenIP, 0, time.Second)
 	if err != nil {
 		t.Fatalf("error adding new service: %#v", err)
 	}
@@ -522,14 +502,11 @@ func TestTCPProxyUpdateDelete(t *testing.T) {
 	})
 
 	listenIP := "0.0.0.0"
-	p, err := createProxier(lb, net.ParseIP(listenIP), netshtest.NewFake(), net.ParseIP("127.0.0.1"), time.Minute, udpIdleTimeoutForTest)
-	if err != nil {
-		t.Fatal(err)
-	}
+	p := createProxier(lb, net.ParseIP(listenIP), netshtest.NewFake(), net.ParseIP("127.0.0.1"), time.Minute, udpIdleTimeoutForTest)
 	waitForNumProxyLoops(t, p, 0)
 
 	servicePortPortalName := ServicePortPortalName{NamespacedName: types.NamespacedName{Namespace: service.Namespace, Name: service.Name}, Port: service.Port, PortalIPName: listenIP}
-	svcInfo, err := p.addServicePortPortal(servicePortPortalName, "TCP", listenIP, 0, time.Second)
+	svcInfo, err := p.addServiceOnPortPortal(servicePortPortalName, "TCP", listenIP, 0, time.Second)
 	if err != nil {
 		t.Fatalf("error adding new service: %#v", err)
 	}
@@ -567,14 +544,11 @@ func TestUDPProxyUpdateDelete(t *testing.T) {
 	})
 
 	listenIP := "0.0.0.0"
-	p, err := createProxier(lb, net.ParseIP(listenIP), netshtest.NewFake(), net.ParseIP("127.0.0.1"), time.Minute, udpIdleTimeoutForTest)
-	if err != nil {
-		t.Fatal(err)
-	}
+	p := createProxier(lb, net.ParseIP(listenIP), netshtest.NewFake(), net.ParseIP("127.0.0.1"), time.Minute, udpIdleTimeoutForTest)
 	waitForNumProxyLoops(t, p, 0)
 
 	servicePortPortalName := ServicePortPortalName{NamespacedName: types.NamespacedName{Namespace: service.Namespace, Name: service.Name}, Port: service.Port, PortalIPName: listenIP}
-	svcInfo, err := p.addServicePortPortal(servicePortPortalName, "UDP", listenIP, 0, time.Second)
+	svcInfo, err := p.addServiceOnPortPortal(servicePortPortalName, "UDP", listenIP, 0, time.Second)
 	if err != nil {
 		t.Fatalf("error adding new service: %#v", err)
 	}
@@ -612,14 +586,11 @@ func TestTCPProxyUpdateDeleteUpdate(t *testing.T) {
 	lb.OnEndpointsAdd(endpoint)
 
 	listenIP := "0.0.0.0"
-	p, err := createProxier(lb, net.ParseIP(listenIP), netshtest.NewFake(), net.ParseIP("127.0.0.1"), time.Minute, udpIdleTimeoutForTest)
-	if err != nil {
-		t.Fatal(err)
-	}
+	p := createProxier(lb, net.ParseIP(listenIP), netshtest.NewFake(), net.ParseIP("127.0.0.1"), time.Minute, udpIdleTimeoutForTest)
 	waitForNumProxyLoops(t, p, 0)
 
 	servicePortPortalName := ServicePortPortalName{NamespacedName: types.NamespacedName{Namespace: service.Namespace, Name: service.Name}, Port: service.Port, PortalIPName: listenIP}
-	svcInfo, err := p.addServicePortPortal(servicePortPortalName, "TCP", listenIP, 0, time.Second)
+	svcInfo, err := p.addServiceOnPortPortal(servicePortPortalName, "TCP", listenIP, 0, time.Second)
 	if err != nil {
 		t.Fatalf("error adding new service: %#v", err)
 	}
@@ -674,14 +645,11 @@ func TestUDPProxyUpdateDeleteUpdate(t *testing.T) {
 	lb.OnEndpointsAdd(endpoint)
 
 	listenIP := "0.0.0.0"
-	p, err := createProxier(lb, net.ParseIP(listenIP), netshtest.NewFake(), net.ParseIP("127.0.0.1"), time.Minute, udpIdleTimeoutForTest)
-	if err != nil {
-		t.Fatal(err)
-	}
+	p := createProxier(lb, net.ParseIP(listenIP), netshtest.NewFake(), net.ParseIP("127.0.0.1"), time.Minute, udpIdleTimeoutForTest)
 	waitForNumProxyLoops(t, p, 0)
 
 	servicePortPortalName := ServicePortPortalName{NamespacedName: types.NamespacedName{Namespace: service.Namespace, Name: service.Name}, Port: service.Port, PortalIPName: listenIP}
-	svcInfo, err := p.addServicePortPortal(servicePortPortalName, "UDP", listenIP, 0, time.Second)
+	svcInfo, err := p.addServiceOnPortPortal(servicePortPortalName, "UDP", listenIP, 0, time.Second)
 	if err != nil {
 		t.Fatalf("error adding new service: %#v", err)
 	}
@@ -735,14 +703,11 @@ func TestTCPProxyUpdatePort(t *testing.T) {
 	})
 
 	listenIP := "0.0.0.0"
-	p, err := createProxier(lb, net.ParseIP(listenIP), netshtest.NewFake(), net.ParseIP("127.0.0.1"), time.Minute, udpIdleTimeoutForTest)
-	if err != nil {
-		t.Fatal(err)
-	}
+	p := createProxier(lb, net.ParseIP(listenIP), netshtest.NewFake(), net.ParseIP("127.0.0.1"), time.Minute, udpIdleTimeoutForTest)
 	waitForNumProxyLoops(t, p, 0)
 
 	servicePortPortalName := ServicePortPortalName{NamespacedName: types.NamespacedName{Namespace: service.Namespace, Name: service.Name}, Port: service.Port, PortalIPName: listenIP}
-	svcInfo, err := p.addServicePortPortal(servicePortPortalName, "TCP", listenIP, 0, time.Second)
+	svcInfo, err := p.addServiceOnPortPortal(servicePortPortalName, "TCP", listenIP, 0, time.Second)
 	if err != nil {
 		t.Fatalf("error adding new service: %#v", err)
 	}
@@ -783,14 +748,11 @@ func TestUDPProxyUpdatePort(t *testing.T) {
 	})
 
 	listenIP := "0.0.0.0"
-	p, err := createProxier(lb, net.ParseIP(listenIP), netshtest.NewFake(), net.ParseIP("127.0.0.1"), time.Minute, udpIdleTimeoutForTest)
-	if err != nil {
-		t.Fatal(err)
-	}
+	p := createProxier(lb, net.ParseIP(listenIP), netshtest.NewFake(), net.ParseIP("127.0.0.1"), time.Minute, udpIdleTimeoutForTest)
 	waitForNumProxyLoops(t, p, 0)
 
 	servicePortPortalName := ServicePortPortalName{NamespacedName: types.NamespacedName{Namespace: service.Namespace, Name: service.Name}, Port: service.Port, PortalIPName: listenIP}
-	svcInfo, err := p.addServicePortPortal(servicePortPortalName, "UDP", listenIP, 0, time.Second)
+	svcInfo, err := p.addServiceOnPortPortal(servicePortPortalName, "UDP", listenIP, 0, time.Second)
 	if err != nil {
 		t.Fatalf("error adding new service: %#v", err)
 	}
@@ -828,14 +790,11 @@ func TestProxyUpdatePublicIPs(t *testing.T) {
 	})
 
 	listenIP := "0.0.0.0"
-	p, err := createProxier(lb, net.ParseIP(listenIP), netshtest.NewFake(), net.ParseIP("127.0.0.1"), time.Minute, udpIdleTimeoutForTest)
-	if err != nil {
-		t.Fatal(err)
-	}
+	p := createProxier(lb, net.ParseIP(listenIP), netshtest.NewFake(), net.ParseIP("127.0.0.1"), time.Minute, udpIdleTimeoutForTest)
 	waitForNumProxyLoops(t, p, 0)
 
 	servicePortPortalName := ServicePortPortalName{NamespacedName: types.NamespacedName{Namespace: service.Namespace, Name: service.Name}, Port: service.Port, PortalIPName: listenIP}
-	svcInfo, err := p.addServicePortPortal(servicePortPortalName, "TCP", listenIP, 0, time.Second)
+	svcInfo, err := p.addServiceOnPortPortal(servicePortPortalName, "TCP", listenIP, 0, time.Second)
 	if err != nil {
 		t.Fatalf("error adding new service: %#v", err)
 	}
@@ -881,14 +840,11 @@ func TestProxyUpdatePortal(t *testing.T) {
 	lb.OnEndpointsAdd(endpoint)
 
 	listenIP := "0.0.0.0"
-	p, err := createProxier(lb, net.ParseIP(listenIP), netshtest.NewFake(), net.ParseIP("127.0.0.1"), time.Minute, udpIdleTimeoutForTest)
-	if err != nil {
-		t.Fatal(err)
-	}
+	p := createProxier(lb, net.ParseIP(listenIP), netshtest.NewFake(), net.ParseIP("127.0.0.1"), time.Minute, udpIdleTimeoutForTest)
 	waitForNumProxyLoops(t, p, 0)
 
 	servicePortPortalName := ServicePortPortalName{NamespacedName: types.NamespacedName{Namespace: service.Namespace, Name: service.Name}, Port: service.Port, PortalIPName: listenIP}
-	svcInfo, err := p.addServicePortPortal(servicePortPortalName, "TCP", listenIP, 0, time.Second)
+	svcInfo, err := p.addServiceOnPortPortal(servicePortPortalName, "TCP", listenIP, 0, time.Second)
 	if err != nil {
 		t.Fatalf("error adding new service: %#v", err)
 	}

--- a/pkg/proxy/winuserspace/roundrobin_test.go
+++ b/pkg/proxy/winuserspace/roundrobin_test.go
@@ -20,7 +20,7 @@ import (
 	"net"
 	"testing"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/kubernetes/pkg/proxy"
@@ -111,7 +111,7 @@ func TestLoadBalanceWorksWithMultipleEndpoints(t *testing.T) {
 	}
 	loadBalancer.OnEndpointsAdd(endpoints)
 
-	shuffledEndpoints := loadBalancer.services[service].endpoints
+	shuffledEndpoints := loadBalancer.winLoadbalancedServices[service].endpoints
 	if !stringsInSlice(shuffledEndpoints, "endpoint:1", "endpoint:2", "endpoint:3") {
 		t.Errorf("did not find expected endpoints: %v", shuffledEndpoints)
 	}
@@ -144,7 +144,7 @@ func TestLoadBalanceWorksWithMultipleEndpointsMultiplePorts(t *testing.T) {
 	}
 	loadBalancer.OnEndpointsAdd(endpoints)
 
-	shuffledEndpoints := loadBalancer.services[serviceP].endpoints
+	shuffledEndpoints := loadBalancer.winLoadbalancedServices[serviceP].endpoints
 	if !stringsInSlice(shuffledEndpoints, "endpoint1:1", "endpoint2:1", "endpoint3:3") {
 		t.Errorf("did not find expected endpoints: %v", shuffledEndpoints)
 	}
@@ -153,7 +153,7 @@ func TestLoadBalanceWorksWithMultipleEndpointsMultiplePorts(t *testing.T) {
 	expectEndpoint(t, loadBalancer, serviceP, shuffledEndpoints[2], nil)
 	expectEndpoint(t, loadBalancer, serviceP, shuffledEndpoints[0], nil)
 
-	shuffledEndpoints = loadBalancer.services[serviceQ].endpoints
+	shuffledEndpoints = loadBalancer.winLoadbalancedServices[serviceQ].endpoints
 	if !stringsInSlice(shuffledEndpoints, "endpoint1:2", "endpoint2:2", "endpoint3:4") {
 		t.Errorf("did not find expected endpoints: %v", shuffledEndpoints)
 	}
@@ -190,7 +190,7 @@ func TestLoadBalanceWorksWithMultipleEndpointsAndUpdates(t *testing.T) {
 	}
 	loadBalancer.OnEndpointsAdd(endpointsv1)
 
-	shuffledEndpoints := loadBalancer.services[serviceP].endpoints
+	shuffledEndpoints := loadBalancer.winLoadbalancedServices[serviceP].endpoints
 	if !stringsInSlice(shuffledEndpoints, "endpoint1:1", "endpoint2:2", "endpoint3:3") {
 		t.Errorf("did not find expected endpoints: %v", shuffledEndpoints)
 	}
@@ -199,7 +199,7 @@ func TestLoadBalanceWorksWithMultipleEndpointsAndUpdates(t *testing.T) {
 	expectEndpoint(t, loadBalancer, serviceP, shuffledEndpoints[2], nil)
 	expectEndpoint(t, loadBalancer, serviceP, shuffledEndpoints[0], nil)
 
-	shuffledEndpoints = loadBalancer.services[serviceQ].endpoints
+	shuffledEndpoints = loadBalancer.winLoadbalancedServices[serviceQ].endpoints
 	if !stringsInSlice(shuffledEndpoints, "endpoint1:10", "endpoint2:20", "endpoint3:30") {
 		t.Errorf("did not find expected endpoints: %v", shuffledEndpoints)
 	}
@@ -225,7 +225,7 @@ func TestLoadBalanceWorksWithMultipleEndpointsAndUpdates(t *testing.T) {
 	}
 	loadBalancer.OnEndpointsUpdate(endpointsv1, endpointsv2)
 
-	shuffledEndpoints = loadBalancer.services[serviceP].endpoints
+	shuffledEndpoints = loadBalancer.winLoadbalancedServices[serviceP].endpoints
 	if !stringsInSlice(shuffledEndpoints, "endpoint4:4", "endpoint5:5") {
 		t.Errorf("did not find expected endpoints: %v", shuffledEndpoints)
 	}
@@ -234,7 +234,7 @@ func TestLoadBalanceWorksWithMultipleEndpointsAndUpdates(t *testing.T) {
 	expectEndpoint(t, loadBalancer, serviceP, shuffledEndpoints[0], nil)
 	expectEndpoint(t, loadBalancer, serviceP, shuffledEndpoints[1], nil)
 
-	shuffledEndpoints = loadBalancer.services[serviceQ].endpoints
+	shuffledEndpoints = loadBalancer.winLoadbalancedServices[serviceQ].endpoints
 	if !stringsInSlice(shuffledEndpoints, "endpoint4:40", "endpoint5:50") {
 		t.Errorf("did not find expected endpoints: %v", shuffledEndpoints)
 	}
@@ -281,14 +281,14 @@ func TestLoadBalanceWorksWithServiceRemoval(t *testing.T) {
 	}
 	loadBalancer.OnEndpointsAdd(endpoints1)
 	loadBalancer.OnEndpointsAdd(endpoints2)
-	shuffledFooEndpoints := loadBalancer.services[fooServiceP].endpoints
+	shuffledFooEndpoints := loadBalancer.winLoadbalancedServices[fooServiceP].endpoints
 	expectEndpoint(t, loadBalancer, fooServiceP, shuffledFooEndpoints[0], nil)
 	expectEndpoint(t, loadBalancer, fooServiceP, shuffledFooEndpoints[1], nil)
 	expectEndpoint(t, loadBalancer, fooServiceP, shuffledFooEndpoints[2], nil)
 	expectEndpoint(t, loadBalancer, fooServiceP, shuffledFooEndpoints[0], nil)
 	expectEndpoint(t, loadBalancer, fooServiceP, shuffledFooEndpoints[1], nil)
 
-	shuffledBarEndpoints := loadBalancer.services[barServiceP].endpoints
+	shuffledBarEndpoints := loadBalancer.winLoadbalancedServices[barServiceP].endpoints
 	expectEndpoint(t, loadBalancer, barServiceP, shuffledBarEndpoints[0], nil)
 	expectEndpoint(t, loadBalancer, barServiceP, shuffledBarEndpoints[1], nil)
 	expectEndpoint(t, loadBalancer, barServiceP, shuffledBarEndpoints[2], nil)
@@ -445,7 +445,7 @@ func TestStickyLoadBalanaceWorksWithMultipleEndpointsRemoveOne(t *testing.T) {
 		},
 	}
 	loadBalancer.OnEndpointsAdd(endpointsv1)
-	shuffledEndpoints := loadBalancer.services[service].endpoints
+	shuffledEndpoints := loadBalancer.winLoadbalancedServices[service].endpoints
 	expectEndpoint(t, loadBalancer, service, shuffledEndpoints[0], client1)
 	client1Endpoint := shuffledEndpoints[0]
 	expectEndpoint(t, loadBalancer, service, shuffledEndpoints[0], client1)
@@ -465,7 +465,7 @@ func TestStickyLoadBalanaceWorksWithMultipleEndpointsRemoveOne(t *testing.T) {
 		},
 	}
 	loadBalancer.OnEndpointsUpdate(endpointsv1, endpointsv2)
-	shuffledEndpoints = loadBalancer.services[service].endpoints
+	shuffledEndpoints = loadBalancer.winLoadbalancedServices[service].endpoints
 	if client1Endpoint == "endpoint:3" {
 		client1Endpoint = shuffledEndpoints[0]
 	} else if client2Endpoint == "endpoint:3" {
@@ -487,7 +487,7 @@ func TestStickyLoadBalanaceWorksWithMultipleEndpointsRemoveOne(t *testing.T) {
 		},
 	}
 	loadBalancer.OnEndpointsUpdate(endpointsv2, endpointsv3)
-	shuffledEndpoints = loadBalancer.services[service].endpoints
+	shuffledEndpoints = loadBalancer.winLoadbalancedServices[service].endpoints
 	expectEndpoint(t, loadBalancer, service, client1Endpoint, client1)
 	expectEndpoint(t, loadBalancer, service, client2Endpoint, client2)
 	expectEndpoint(t, loadBalancer, service, client3Endpoint, client3)
@@ -518,7 +518,7 @@ func TestStickyLoadBalanceWorksWithMultipleEndpointsAndUpdates(t *testing.T) {
 		},
 	}
 	loadBalancer.OnEndpointsAdd(endpointsv1)
-	shuffledEndpoints := loadBalancer.services[service].endpoints
+	shuffledEndpoints := loadBalancer.winLoadbalancedServices[service].endpoints
 	expectEndpoint(t, loadBalancer, service, shuffledEndpoints[0], client1)
 	expectEndpoint(t, loadBalancer, service, shuffledEndpoints[0], client1)
 	expectEndpoint(t, loadBalancer, service, shuffledEndpoints[1], client2)
@@ -538,7 +538,7 @@ func TestStickyLoadBalanceWorksWithMultipleEndpointsAndUpdates(t *testing.T) {
 		},
 	}
 	loadBalancer.OnEndpointsUpdate(endpointsv1, endpointsv2)
-	shuffledEndpoints = loadBalancer.services[service].endpoints
+	shuffledEndpoints = loadBalancer.winLoadbalancedServices[service].endpoints
 	expectEndpoint(t, loadBalancer, service, shuffledEndpoints[0], client1)
 	expectEndpoint(t, loadBalancer, service, shuffledEndpoints[1], client2)
 	expectEndpoint(t, loadBalancer, service, shuffledEndpoints[0], client1)
@@ -590,7 +590,7 @@ func TestStickyLoadBalanceWorksWithServiceRemoval(t *testing.T) {
 	loadBalancer.OnEndpointsAdd(endpoints1)
 	loadBalancer.OnEndpointsAdd(endpoints2)
 
-	shuffledFooEndpoints := loadBalancer.services[fooService].endpoints
+	shuffledFooEndpoints := loadBalancer.winLoadbalancedServices[fooService].endpoints
 	expectEndpoint(t, loadBalancer, fooService, shuffledFooEndpoints[0], client1)
 	expectEndpoint(t, loadBalancer, fooService, shuffledFooEndpoints[1], client2)
 	expectEndpoint(t, loadBalancer, fooService, shuffledFooEndpoints[2], client3)
@@ -601,7 +601,7 @@ func TestStickyLoadBalanceWorksWithServiceRemoval(t *testing.T) {
 	expectEndpoint(t, loadBalancer, fooService, shuffledFooEndpoints[2], client3)
 	expectEndpoint(t, loadBalancer, fooService, shuffledFooEndpoints[2], client3)
 
-	shuffledBarEndpoints := loadBalancer.services[barService].endpoints
+	shuffledBarEndpoints := loadBalancer.winLoadbalancedServices[barService].endpoints
 	expectEndpoint(t, loadBalancer, barService, shuffledBarEndpoints[0], client1)
 	expectEndpoint(t, loadBalancer, barService, shuffledBarEndpoints[1], client2)
 	expectEndpoint(t, loadBalancer, barService, shuffledBarEndpoints[0], client1)
@@ -617,7 +617,7 @@ func TestStickyLoadBalanceWorksWithServiceRemoval(t *testing.T) {
 	}
 
 	// but bar is still there, and we continue RR from where we left off.
-	shuffledBarEndpoints = loadBalancer.services[barService].endpoints
+	shuffledBarEndpoints = loadBalancer.winLoadbalancedServices[barService].endpoints
 	expectEndpoint(t, loadBalancer, barService, shuffledBarEndpoints[0], client1)
 	expectEndpoint(t, loadBalancer, barService, shuffledBarEndpoints[1], client2)
 	expectEndpoint(t, loadBalancer, barService, shuffledBarEndpoints[0], client1)

--- a/pkg/proxy/winuserspace/roundrobin_test.go
+++ b/pkg/proxy/winuserspace/roundrobin_test.go
@@ -111,7 +111,7 @@ func TestLoadBalanceWorksWithMultipleEndpoints(t *testing.T) {
 	}
 	loadBalancer.OnEndpointsAdd(endpoints)
 
-	shuffledEndpoints := loadBalancer.winLoadbalancedServices[service].endpoints
+	shuffledEndpoints := loadBalancer.services[service].endpoints
 	if !stringsInSlice(shuffledEndpoints, "endpoint:1", "endpoint:2", "endpoint:3") {
 		t.Errorf("did not find expected endpoints: %v", shuffledEndpoints)
 	}
@@ -144,7 +144,7 @@ func TestLoadBalanceWorksWithMultipleEndpointsMultiplePorts(t *testing.T) {
 	}
 	loadBalancer.OnEndpointsAdd(endpoints)
 
-	shuffledEndpoints := loadBalancer.winLoadbalancedServices[serviceP].endpoints
+	shuffledEndpoints := loadBalancer.services[serviceP].endpoints
 	if !stringsInSlice(shuffledEndpoints, "endpoint1:1", "endpoint2:1", "endpoint3:3") {
 		t.Errorf("did not find expected endpoints: %v", shuffledEndpoints)
 	}
@@ -153,7 +153,7 @@ func TestLoadBalanceWorksWithMultipleEndpointsMultiplePorts(t *testing.T) {
 	expectEndpoint(t, loadBalancer, serviceP, shuffledEndpoints[2], nil)
 	expectEndpoint(t, loadBalancer, serviceP, shuffledEndpoints[0], nil)
 
-	shuffledEndpoints = loadBalancer.winLoadbalancedServices[serviceQ].endpoints
+	shuffledEndpoints = loadBalancer.services[serviceQ].endpoints
 	if !stringsInSlice(shuffledEndpoints, "endpoint1:2", "endpoint2:2", "endpoint3:4") {
 		t.Errorf("did not find expected endpoints: %v", shuffledEndpoints)
 	}
@@ -190,7 +190,7 @@ func TestLoadBalanceWorksWithMultipleEndpointsAndUpdates(t *testing.T) {
 	}
 	loadBalancer.OnEndpointsAdd(endpointsv1)
 
-	shuffledEndpoints := loadBalancer.winLoadbalancedServices[serviceP].endpoints
+	shuffledEndpoints := loadBalancer.services[serviceP].endpoints
 	if !stringsInSlice(shuffledEndpoints, "endpoint1:1", "endpoint2:2", "endpoint3:3") {
 		t.Errorf("did not find expected endpoints: %v", shuffledEndpoints)
 	}
@@ -199,7 +199,7 @@ func TestLoadBalanceWorksWithMultipleEndpointsAndUpdates(t *testing.T) {
 	expectEndpoint(t, loadBalancer, serviceP, shuffledEndpoints[2], nil)
 	expectEndpoint(t, loadBalancer, serviceP, shuffledEndpoints[0], nil)
 
-	shuffledEndpoints = loadBalancer.winLoadbalancedServices[serviceQ].endpoints
+	shuffledEndpoints = loadBalancer.services[serviceQ].endpoints
 	if !stringsInSlice(shuffledEndpoints, "endpoint1:10", "endpoint2:20", "endpoint3:30") {
 		t.Errorf("did not find expected endpoints: %v", shuffledEndpoints)
 	}
@@ -225,7 +225,7 @@ func TestLoadBalanceWorksWithMultipleEndpointsAndUpdates(t *testing.T) {
 	}
 	loadBalancer.OnEndpointsUpdate(endpointsv1, endpointsv2)
 
-	shuffledEndpoints = loadBalancer.winLoadbalancedServices[serviceP].endpoints
+	shuffledEndpoints = loadBalancer.services[serviceP].endpoints
 	if !stringsInSlice(shuffledEndpoints, "endpoint4:4", "endpoint5:5") {
 		t.Errorf("did not find expected endpoints: %v", shuffledEndpoints)
 	}
@@ -234,7 +234,7 @@ func TestLoadBalanceWorksWithMultipleEndpointsAndUpdates(t *testing.T) {
 	expectEndpoint(t, loadBalancer, serviceP, shuffledEndpoints[0], nil)
 	expectEndpoint(t, loadBalancer, serviceP, shuffledEndpoints[1], nil)
 
-	shuffledEndpoints = loadBalancer.winLoadbalancedServices[serviceQ].endpoints
+	shuffledEndpoints = loadBalancer.services[serviceQ].endpoints
 	if !stringsInSlice(shuffledEndpoints, "endpoint4:40", "endpoint5:50") {
 		t.Errorf("did not find expected endpoints: %v", shuffledEndpoints)
 	}
@@ -281,14 +281,14 @@ func TestLoadBalanceWorksWithServiceRemoval(t *testing.T) {
 	}
 	loadBalancer.OnEndpointsAdd(endpoints1)
 	loadBalancer.OnEndpointsAdd(endpoints2)
-	shuffledFooEndpoints := loadBalancer.winLoadbalancedServices[fooServiceP].endpoints
+	shuffledFooEndpoints := loadBalancer.services[fooServiceP].endpoints
 	expectEndpoint(t, loadBalancer, fooServiceP, shuffledFooEndpoints[0], nil)
 	expectEndpoint(t, loadBalancer, fooServiceP, shuffledFooEndpoints[1], nil)
 	expectEndpoint(t, loadBalancer, fooServiceP, shuffledFooEndpoints[2], nil)
 	expectEndpoint(t, loadBalancer, fooServiceP, shuffledFooEndpoints[0], nil)
 	expectEndpoint(t, loadBalancer, fooServiceP, shuffledFooEndpoints[1], nil)
 
-	shuffledBarEndpoints := loadBalancer.winLoadbalancedServices[barServiceP].endpoints
+	shuffledBarEndpoints := loadBalancer.services[barServiceP].endpoints
 	expectEndpoint(t, loadBalancer, barServiceP, shuffledBarEndpoints[0], nil)
 	expectEndpoint(t, loadBalancer, barServiceP, shuffledBarEndpoints[1], nil)
 	expectEndpoint(t, loadBalancer, barServiceP, shuffledBarEndpoints[2], nil)
@@ -445,7 +445,7 @@ func TestStickyLoadBalanaceWorksWithMultipleEndpointsRemoveOne(t *testing.T) {
 		},
 	}
 	loadBalancer.OnEndpointsAdd(endpointsv1)
-	shuffledEndpoints := loadBalancer.winLoadbalancedServices[service].endpoints
+	shuffledEndpoints := loadBalancer.services[service].endpoints
 	expectEndpoint(t, loadBalancer, service, shuffledEndpoints[0], client1)
 	client1Endpoint := shuffledEndpoints[0]
 	expectEndpoint(t, loadBalancer, service, shuffledEndpoints[0], client1)
@@ -465,7 +465,7 @@ func TestStickyLoadBalanaceWorksWithMultipleEndpointsRemoveOne(t *testing.T) {
 		},
 	}
 	loadBalancer.OnEndpointsUpdate(endpointsv1, endpointsv2)
-	shuffledEndpoints = loadBalancer.winLoadbalancedServices[service].endpoints
+	shuffledEndpoints = loadBalancer.services[service].endpoints
 	if client1Endpoint == "endpoint:3" {
 		client1Endpoint = shuffledEndpoints[0]
 	} else if client2Endpoint == "endpoint:3" {
@@ -487,7 +487,7 @@ func TestStickyLoadBalanaceWorksWithMultipleEndpointsRemoveOne(t *testing.T) {
 		},
 	}
 	loadBalancer.OnEndpointsUpdate(endpointsv2, endpointsv3)
-	shuffledEndpoints = loadBalancer.winLoadbalancedServices[service].endpoints
+	shuffledEndpoints = loadBalancer.services[service].endpoints
 	expectEndpoint(t, loadBalancer, service, client1Endpoint, client1)
 	expectEndpoint(t, loadBalancer, service, client2Endpoint, client2)
 	expectEndpoint(t, loadBalancer, service, client3Endpoint, client3)
@@ -518,7 +518,7 @@ func TestStickyLoadBalanceWorksWithMultipleEndpointsAndUpdates(t *testing.T) {
 		},
 	}
 	loadBalancer.OnEndpointsAdd(endpointsv1)
-	shuffledEndpoints := loadBalancer.winLoadbalancedServices[service].endpoints
+	shuffledEndpoints := loadBalancer.services[service].endpoints
 	expectEndpoint(t, loadBalancer, service, shuffledEndpoints[0], client1)
 	expectEndpoint(t, loadBalancer, service, shuffledEndpoints[0], client1)
 	expectEndpoint(t, loadBalancer, service, shuffledEndpoints[1], client2)
@@ -538,7 +538,7 @@ func TestStickyLoadBalanceWorksWithMultipleEndpointsAndUpdates(t *testing.T) {
 		},
 	}
 	loadBalancer.OnEndpointsUpdate(endpointsv1, endpointsv2)
-	shuffledEndpoints = loadBalancer.winLoadbalancedServices[service].endpoints
+	shuffledEndpoints = loadBalancer.services[service].endpoints
 	expectEndpoint(t, loadBalancer, service, shuffledEndpoints[0], client1)
 	expectEndpoint(t, loadBalancer, service, shuffledEndpoints[1], client2)
 	expectEndpoint(t, loadBalancer, service, shuffledEndpoints[0], client1)
@@ -590,7 +590,7 @@ func TestStickyLoadBalanceWorksWithServiceRemoval(t *testing.T) {
 	loadBalancer.OnEndpointsAdd(endpoints1)
 	loadBalancer.OnEndpointsAdd(endpoints2)
 
-	shuffledFooEndpoints := loadBalancer.winLoadbalancedServices[fooService].endpoints
+	shuffledFooEndpoints := loadBalancer.services[fooService].endpoints
 	expectEndpoint(t, loadBalancer, fooService, shuffledFooEndpoints[0], client1)
 	expectEndpoint(t, loadBalancer, fooService, shuffledFooEndpoints[1], client2)
 	expectEndpoint(t, loadBalancer, fooService, shuffledFooEndpoints[2], client3)
@@ -601,7 +601,7 @@ func TestStickyLoadBalanceWorksWithServiceRemoval(t *testing.T) {
 	expectEndpoint(t, loadBalancer, fooService, shuffledFooEndpoints[2], client3)
 	expectEndpoint(t, loadBalancer, fooService, shuffledFooEndpoints[2], client3)
 
-	shuffledBarEndpoints := loadBalancer.winLoadbalancedServices[barService].endpoints
+	shuffledBarEndpoints := loadBalancer.services[barService].endpoints
 	expectEndpoint(t, loadBalancer, barService, shuffledBarEndpoints[0], client1)
 	expectEndpoint(t, loadBalancer, barService, shuffledBarEndpoints[1], client2)
 	expectEndpoint(t, loadBalancer, barService, shuffledBarEndpoints[0], client1)
@@ -617,7 +617,7 @@ func TestStickyLoadBalanceWorksWithServiceRemoval(t *testing.T) {
 	}
 
 	// but bar is still there, and we continue RR from where we left off.
-	shuffledBarEndpoints = loadBalancer.winLoadbalancedServices[barService].endpoints
+	shuffledBarEndpoints = loadBalancer.services[barService].endpoints
 	expectEndpoint(t, loadBalancer, barService, shuffledBarEndpoints[0], client1)
 	expectEndpoint(t, loadBalancer, barService, shuffledBarEndpoints[1], client2)
 	expectEndpoint(t, loadBalancer, barService, shuffledBarEndpoints[0], client1)


### PR DESCRIPTION
**What type of PR is this?**

<!--
/kind cleanup
-->

**What this PR does / why we need it**:

Make it easier to reason about the kube-proxy windows codepath

**Which issue(s) this PR fixes**:

No issue, this is just a cleanup PR mostly 


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
 