### PR TITLE
Re-configuring kube-proxy to not be a privileged container

### DIFF
--- a/cluster/addons/kube-proxy/kube-proxy-ds.yaml
+++ b/cluster/addons/kube-proxy/kube-proxy-ds.yaml
@@ -49,7 +49,7 @@ spec:
           {{kube_cache_mutation_detector_env_value}}
         securityContext:
           capabilities:
-            add: ["NET_ADMIN", "SYS_MODULE", "SYS_ADMIN"]
+            add: ["NET_ADMIN", "SYS_MODULE", "DAC_OVERRIDE"]
         volumeMounts:
         - mountPath: /var/log
           name: varlog

--- a/cluster/addons/kube-proxy/kube-proxy-ds.yaml
+++ b/cluster/addons/kube-proxy/kube-proxy-ds.yaml
@@ -48,7 +48,9 @@ spec:
         {{kube_cache_mutation_detector_env_name}}
           {{kube_cache_mutation_detector_env_value}}
         securityContext:
-          privileged: true
+          capabiltiies:
+            add:
+            - NET_ADMIN 
         volumeMounts:
         - mountPath: /var/log
           name: varlog

--- a/cluster/addons/kube-proxy/kube-proxy-ds.yaml
+++ b/cluster/addons/kube-proxy/kube-proxy-ds.yaml
@@ -49,8 +49,7 @@ spec:
           {{kube_cache_mutation_detector_env_value}}
         securityContext:
           capabiltiies:
-            add:
-            - NET_ADMIN 
+            add: ["NET_ADMIN"]
         volumeMounts:
         - mountPath: /var/log
           name: varlog

--- a/cluster/addons/kube-proxy/kube-proxy-ds.yaml
+++ b/cluster/addons/kube-proxy/kube-proxy-ds.yaml
@@ -49,7 +49,7 @@ spec:
           {{kube_cache_mutation_detector_env_value}}
         securityContext:
           capabilities:
-            add: ["NET_ADMIN", "SYS_MODULE"]
+            add: ["NET_ADMIN", "SYS_MODULE", "SYS_ADMIN"]
         volumeMounts:
         - mountPath: /var/log
           name: varlog

--- a/cluster/addons/kube-proxy/kube-proxy-ds.yaml
+++ b/cluster/addons/kube-proxy/kube-proxy-ds.yaml
@@ -48,7 +48,7 @@ spec:
         {{kube_cache_mutation_detector_env_name}}
           {{kube_cache_mutation_detector_env_value}}
         securityContext:
-          capabiltiies:
+          capabilties:
             add: ["NET_ADMIN"]
         volumeMounts:
         - mountPath: /var/log

--- a/cluster/addons/kube-proxy/kube-proxy-ds.yaml
+++ b/cluster/addons/kube-proxy/kube-proxy-ds.yaml
@@ -49,7 +49,7 @@ spec:
           {{kube_cache_mutation_detector_env_value}}
         securityContext:
           capabilities:
-            add: ["NET_ADMIN"]
+            add: ["NET_ADMIN", "SYS_MODULE"]
         volumeMounts:
         - mountPath: /var/log
           name: varlog

--- a/cluster/addons/kube-proxy/kube-proxy-ds.yaml
+++ b/cluster/addons/kube-proxy/kube-proxy-ds.yaml
@@ -48,7 +48,7 @@ spec:
         {{kube_cache_mutation_detector_env_name}}
           {{kube_cache_mutation_detector_env_value}}
         securityContext:
-          capabilties:
+          capabilities:
             add: ["NET_ADMIN"]
         volumeMounts:
         - mountPath: /var/log

--- a/cluster/gce/manifests/kube-proxy.manifest
+++ b/cluster/gce/manifests/kube-proxy.manifest
@@ -32,7 +32,7 @@ spec:
       {{kube_cache_mutation_detector_env_value}}
     securityContext:
       capabilities:
-        add: ["NET_ADMIN", "SYS_MODULE", "SYS_ADMIN"]
+        add: ["NET_ADMIN", "SYS_MODULE", "DAC_OVERRIDE"]
     volumeMounts:
     - mountPath: /etc/ssl/certs
       name: etc-ssl-certs

--- a/cluster/gce/manifests/kube-proxy.manifest
+++ b/cluster/gce/manifests/kube-proxy.manifest
@@ -32,7 +32,7 @@ spec:
       {{kube_cache_mutation_detector_env_value}}
     securityContext:
       capabilities:
-        add: ["NET_ADMIN"]
+        add: ["NET_ADMIN", "SYS_MODULE"]
     volumeMounts:
     - mountPath: /etc/ssl/certs
       name: etc-ssl-certs

--- a/cluster/gce/manifests/kube-proxy.manifest
+++ b/cluster/gce/manifests/kube-proxy.manifest
@@ -32,7 +32,7 @@ spec:
       {{kube_cache_mutation_detector_env_value}}
     securityContext:
       capabilities:
-        add: ["NET_ADMIN", "SYS_MODULE"]
+        add: ["NET_ADMIN", "SYS_MODULE", "SYS_ADMIN"]
     volumeMounts:
     - mountPath: /etc/ssl/certs
       name: etc-ssl-certs

--- a/cluster/gce/manifests/kube-proxy.manifest
+++ b/cluster/gce/manifests/kube-proxy.manifest
@@ -31,7 +31,8 @@ spec:
     {{kube_cache_mutation_detector_env_name}}
       {{kube_cache_mutation_detector_env_value}}
     securityContext:
-      privileged: true
+      capabilities:
+        add: ["NET_ADMIN"]
     volumeMounts:
     - mountPath: /etc/ssl/certs
       name: etc-ssl-certs

--- a/cmd/kubeadm/app/phases/addons/proxy/manifests.go
+++ b/cmd/kubeadm/app/phases/addons/proxy/manifests.go
@@ -81,7 +81,7 @@ spec:
         - --hostname-override=$(NODE_NAME)
         securityContext:
           capabilities:
-	          add: ["NET_ADMIN"]
+	          add: ["NET_ADMIN", "SYS_MODULE"]
         volumeMounts:
         - mountPath: /var/lib/kube-proxy
           name: kube-proxy

--- a/cmd/kubeadm/app/phases/addons/proxy/manifests.go
+++ b/cmd/kubeadm/app/phases/addons/proxy/manifests.go
@@ -80,7 +80,9 @@ spec:
         - --config=/var/lib/kube-proxy/{{ .ProxyConfigMapKey }}
         - --hostname-override=$(NODE_NAME)
         securityContext:
-          privileged: true
+	  capabilities:
+	    add:
+	    - NET_ADMIN
         volumeMounts:
         - mountPath: /var/lib/kube-proxy
           name: kube-proxy

--- a/cmd/kubeadm/app/phases/addons/proxy/manifests.go
+++ b/cmd/kubeadm/app/phases/addons/proxy/manifests.go
@@ -81,7 +81,7 @@ spec:
         - --hostname-override=$(NODE_NAME)
         securityContext:
           capabilities:
-            add: ["NET_ADMIN", "SYS_MODULE", "SYS_ADMIN"]
+            add: ["NET_ADMIN", "SYS_MODULE", "DAC_OVERRIDE"]
         volumeMounts:
         - mountPath: /var/lib/kube-proxy
           name: kube-proxy

--- a/cmd/kubeadm/app/phases/addons/proxy/manifests.go
+++ b/cmd/kubeadm/app/phases/addons/proxy/manifests.go
@@ -81,7 +81,7 @@ spec:
         - --hostname-override=$(NODE_NAME)
         securityContext:
           capabilities:
-	          add: ["NET_ADMIN", "SYS_MODULE", "SYS_ADMIN"]
+            add: ["NET_ADMIN", "SYS_MODULE", "SYS_ADMIN"]
         volumeMounts:
         - mountPath: /var/lib/kube-proxy
           name: kube-proxy

--- a/cmd/kubeadm/app/phases/addons/proxy/manifests.go
+++ b/cmd/kubeadm/app/phases/addons/proxy/manifests.go
@@ -80,8 +80,8 @@ spec:
         - --config=/var/lib/kube-proxy/{{ .ProxyConfigMapKey }}
         - --hostname-override=$(NODE_NAME)
         securityContext:
-	  capabilities:
-	    add: ["NET_ADMIN"]
+          capabilities:
+	          add: ["NET_ADMIN"]
         volumeMounts:
         - mountPath: /var/lib/kube-proxy
           name: kube-proxy

--- a/cmd/kubeadm/app/phases/addons/proxy/manifests.go
+++ b/cmd/kubeadm/app/phases/addons/proxy/manifests.go
@@ -81,8 +81,7 @@ spec:
         - --hostname-override=$(NODE_NAME)
         securityContext:
 	  capabilities:
-	    add:
-	    - NET_ADMIN
+	    add: ["NET_ADMIN"]
         volumeMounts:
         - mountPath: /var/lib/kube-proxy
           name: kube-proxy

--- a/cmd/kubeadm/app/phases/addons/proxy/manifests.go
+++ b/cmd/kubeadm/app/phases/addons/proxy/manifests.go
@@ -81,7 +81,7 @@ spec:
         - --hostname-override=$(NODE_NAME)
         securityContext:
           capabilities:
-	          add: ["NET_ADMIN", "SYS_MODULE"]
+	          add: ["NET_ADMIN", "SYS_MODULE", "SYS_ADMIN"]
         volumeMounts:
         - mountPath: /var/lib/kube-proxy
           name: kube-proxy


### PR DESCRIPTION
I recommend not running the kube-proxy as a privileged container.  

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Currently the kube-proxy is run as a privileged container.  A privileged container can be a vector to obtaining host (node) access.  By removing the `privileged` clause in the security context and adding the `NET_ADMIN` Linux capability, the kube-proxy can preserve its function and prevent the mounting of cgroups in the container.   

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
