### PR TITLE
Testsuite pattern&driver cleanup

### DIFF
--- a/test/e2e/storage/testpatterns/testpattern.go
+++ b/test/e2e/storage/testpatterns/testpattern.go
@@ -112,10 +112,8 @@ var (
 	}
 	// DefaultFsDynamicPV is TestPattern for "Dynamic PV (default fs)"
 	DefaultFsDynamicPV = TestPattern{
-		Name:                   "Dynamic PV (default fs)",
-		VolType:                DynamicPV,
-		SnapshotType:           DynamicCreatedSnapshot,
-		SnapshotDeletionPolicy: DeleteSnapshot,
+		Name:    "Dynamic PV (default fs)",
+		VolType: DynamicPV,
 	}
 
 	// Definitions for ext3
@@ -287,11 +285,9 @@ var (
 	}
 	// BlockVolModeDynamicPV is TestPattern for "Dynamic PV (block)"
 	BlockVolModeDynamicPV = TestPattern{
-		Name:                   "Dynamic PV (block volmode)",
-		VolType:                DynamicPV,
-		VolMode:                v1.PersistentVolumeBlock,
-		SnapshotType:           DynamicCreatedSnapshot,
-		SnapshotDeletionPolicy: DeleteSnapshot,
+		Name:    "Dynamic PV (block volmode)",
+		VolType: DynamicPV,
+		VolMode: v1.PersistentVolumeBlock,
 	}
 
 	// Definitions for snapshot case
@@ -323,6 +319,14 @@ var (
 		SnapshotType:           PreprovisionedCreatedSnapshot,
 		SnapshotDeletionPolicy: RetainSnapshot,
 		VolType:                DynamicPV,
+	}
+	// DynamicBlockSnapshotDelete is TestPattern for "Dynamic snapshot (block)"
+	DynamicBlockSnapshotDelete = TestPattern{
+		Name:                   "Dynamic Snapshot (block volmode)(delete policy)",
+		VolType:                DynamicPV,
+		VolMode:                v1.PersistentVolumeBlock,
+		SnapshotType:           DynamicCreatedSnapshot,
+		SnapshotDeletionPolicy: DeleteSnapshot,
 	}
 
 	// Definitions for volume expansion case

--- a/test/e2e/storage/testsuites/multivolume.go
+++ b/test/e2e/storage/testsuites/multivolume.go
@@ -87,11 +87,10 @@ func (t *multiVolumeTestSuite) DefineTests(driver TestDriver, pattern testpatter
 		l     local
 	)
 
+	// Testsuite level preconditions for driver, pattern compatibility with the test suites
+	// This will be executed first to prevent any unnecessary resource allocation
 	ginkgo.BeforeEach(func() {
-		// Check preconditions.
-		if pattern.VolMode == v1.PersistentVolumeBlock && !dInfo.Capabilities[CapBlock] {
-			e2eskipper.Skipf("Driver %s doesn't support %v -- skipping", dInfo.Name, pattern.VolMode)
-		}
+		SkipUnsupportedDriverPatternCombination(driver, pattern)
 	})
 
 	// This intentionally comes after checking the preconditions because it

--- a/test/e2e/storage/testsuites/snapshottable.go
+++ b/test/e2e/storage/testsuites/snapshottable.go
@@ -78,6 +78,7 @@ func InitSnapshottableTestSuite() TestSuite {
 				testpatterns.DynamicSnapshotRetain,
 				testpatterns.PreprovisionedSnapshotDelete,
 				testpatterns.PreprovisionedSnapshotRetain,
+				testpatterns.DynamicBlockSnapshotDelete,
 			},
 			SupportedSizeRange: e2evolume.SizeRange{
 				Min: "1Mi",
@@ -95,7 +96,11 @@ func (s *snapshottableTestSuite) SkipRedundantSuite(driver TestDriver, pattern t
 }
 
 func (s *snapshottableTestSuite) DefineTests(driver TestDriver, pattern testpatterns.TestPattern) {
+
+	// Testsuite level preconditions for driver, pattern compatibility with the test suites
+	// This will be executed first to prevent any unnecessary resource allocation
 	ginkgo.BeforeEach(func() {
+		SkipUnsupportedDriverPatternCombination(driver, pattern)
 		// Check preconditions.
 		dInfo := driver.GetDriverInfo()
 		ok := false

--- a/test/e2e/storage/testsuites/snapshottable_stress.go
+++ b/test/e2e/storage/testsuites/snapshottable_stress.go
@@ -91,8 +91,10 @@ func (t *snapshottableStressTestSuite) DefineTests(driver TestDriver, pattern te
 		stressTest          *snapshottableStressTest
 	)
 
-	// Check preconditions before setting up namespace via framework below.
+	// Testsuite level preconditions for driver, pattern compatibility with the test suites
+	// This will be executed first to prevent any unnecessary resource allocation
 	ginkgo.BeforeEach(func() {
+		SkipUnsupportedDriverPatternCombination(driver, pattern)
 		driverInfo = driver.GetDriverInfo()
 		if driverInfo.VolumeSnapshotStressTestOptions == nil {
 			e2eskipper.Skipf("Driver %s doesn't specify snapshot stress test options -- skipping", driverInfo.Name)

--- a/test/e2e/storage/testsuites/subpath.go
+++ b/test/e2e/storage/testsuites/subpath.go
@@ -106,7 +106,11 @@ func (s *subPathTestSuite) DefineTests(driver TestDriver, pattern testpatterns.T
 	}
 	var l local
 
-	// No preconditions to test. Normally they would be in a BeforeEach here.
+	// Testsuite level preconditions for driver, pattern compatibility with the test suites
+	// This will be executed first to prevent any unnecessary resource allocation
+	ginkgo.BeforeEach(func() {
+		SkipUnsupportedDriverPatternCombination(driver, pattern)
+	})
 
 	// This intentionally comes after checking the preconditions because it
 	// registers its own BeforeEach which creates the namespace. Beware that it

--- a/test/e2e/storage/testsuites/topology.go
+++ b/test/e2e/storage/testsuites/topology.go
@@ -84,8 +84,11 @@ func (t *topologyTestSuite) DefineTests(driver TestDriver, pattern testpatterns.
 		err     error
 	)
 
+	// Testsuite level preconditions for driver, pattern compatibility with the test suites
+	// This will be executed first to prevent any unnecessary resource allocation
 	ginkgo.BeforeEach(func() {
-		// Check preconditions.
+		SkipUnsupportedDriverPatternCombination(driver, pattern)
+
 		ok := false
 		dDriver, ok = driver.(DynamicPVTestDriver)
 		if !ok {

--- a/test/e2e/storage/testsuites/volume_expand.go
+++ b/test/e2e/storage/testsuites/volume_expand.go
@@ -99,11 +99,11 @@ func (v *volumeExpandTestSuite) DefineTests(driver TestDriver, pattern testpatte
 	}
 	var l local
 
+	// Testsuite level preconditions for driver, pattern compatibility with the test suites
+	// This will be executed first to prevent any unnecessary resource allocation
 	ginkgo.BeforeEach(func() {
-		// Check preconditions.
-		if !driver.GetDriverInfo().Capabilities[CapBlock] && pattern.VolMode == v1.PersistentVolumeBlock {
-			e2eskipper.Skipf("Driver %q does not support block volume mode - skipping", driver.GetDriverInfo().Name)
-		}
+		SkipUnsupportedDriverPatternCombination(driver, pattern)
+
 		if !driver.GetDriverInfo().Capabilities[CapControllerExpansion] {
 			e2eskipper.Skipf("Driver %q does not support volume expansion - skipping", driver.GetDriverInfo().Name)
 		}

--- a/test/e2e/storage/testsuites/volume_io.go
+++ b/test/e2e/storage/testsuites/volume_io.go
@@ -102,7 +102,11 @@ func (t *volumeIOTestSuite) DefineTests(driver TestDriver, pattern testpatterns.
 		l     local
 	)
 
-	// No preconditions to test. Normally they would be in a BeforeEach here.
+	// Testsuite level preconditions for driver, pattern compatibility with the test suites
+	// This will be executed first to prevent any unnecessary resource allocation
+	ginkgo.BeforeEach(func() {
+		SkipUnsupportedDriverPatternCombination(driver, pattern)
+	})
 
 	// This intentionally comes after checking the preconditions because it
 	// registers its own BeforeEach which creates the namespace. Beware that it

--- a/test/e2e/storage/testsuites/volume_stress.go
+++ b/test/e2e/storage/testsuites/volume_stress.go
@@ -84,8 +84,11 @@ func (t *volumeStressTestSuite) DefineTests(driver TestDriver, pattern testpatte
 		l     *volumeStressTest
 	)
 
-	// Check preconditions before setting up namespace via framework below.
+	// Testsuite level preconditions for driver, pattern compatibility with the test suites
+	// This will be executed first to prevent any unnecessary resource allocation
 	ginkgo.BeforeEach(func() {
+		SkipUnsupportedDriverPatternCombination(driver, pattern)
+
 		if dInfo.StressTestOptions == nil {
 			e2eskipper.Skipf("Driver %s doesn't specify stress test options -- skipping", dInfo.Name)
 		}
@@ -98,10 +101,6 @@ func (t *volumeStressTestSuite) DefineTests(driver TestDriver, pattern testpatte
 
 		if _, ok := driver.(DynamicPVTestDriver); !ok {
 			e2eskipper.Skipf("Driver %s doesn't implement DynamicPVTestDriver -- skipping", dInfo.Name)
-		}
-
-		if !driver.GetDriverInfo().Capabilities[CapBlock] && pattern.VolMode == v1.PersistentVolumeBlock {
-			e2eskipper.Skipf("Driver %q does not support block volume mode - skipping", dInfo.Name)
 		}
 	})
 

--- a/test/e2e/storage/testsuites/volumelimits.go
+++ b/test/e2e/storage/testsuites/volumelimits.go
@@ -99,7 +99,16 @@ func (t *volumeLimitsTestSuite) DefineTests(driver TestDriver, pattern testpatte
 		l local
 	)
 
-	// No preconditions to test. Normally they would be in a BeforeEach here.
+	// Testsuite level preconditions for driver, pattern compatibility with the test suites
+	// This will be executed first to prevent any unnecessary resource allocation
+	ginkgo.BeforeEach(func() {
+		SkipUnsupportedDriverPatternCombination(driver, pattern)
+	})
+
+	// This intentionally comes after checking the preconditions because it
+	// registers its own BeforeEach which creates the namespace. Beware that it
+	// also registers an AfterEach which renders f unusable. Any code using
+	// f must run inside an It or Context callback.
 	f := framework.NewDefaultFramework("volumelimits")
 
 	// This checks that CSIMaxVolumeLimitChecker works as expected.

--- a/test/e2e/storage/testsuites/volumemode.go
+++ b/test/e2e/storage/testsuites/volumemode.go
@@ -96,7 +96,11 @@ func (t *volumeModeTestSuite) DefineTests(driver TestDriver, pattern testpattern
 		l     local
 	)
 
-	// No preconditions to test. Normally they would be in a BeforeEach here.
+	// Testsuite level preconditions for driver, pattern compatibility with the test suites
+	// This will be executed first to prevent any unnecessary resource allocation
+	ginkgo.BeforeEach(func() {
+		SkipUnsupportedDriverPatternCombination(driver, pattern)
+	})
 
 	// This intentionally comes after checking the preconditions because it
 	// registers its own BeforeEach which creates the namespace. Beware that it

--- a/test/e2e/storage/testsuites/volumes.go
+++ b/test/e2e/storage/testsuites/volumes.go
@@ -114,7 +114,11 @@ func (t *volumesTestSuite) DefineTests(driver TestDriver, pattern testpatterns.T
 	var dInfo = driver.GetDriverInfo()
 	var l local
 
-	// No preconditions to test. Normally they would be in a BeforeEach here.
+	// Testsuite level preconditions for driver, pattern compatibility with the test suites
+	// This will be executed first to prevent any unnecessary resource allocation
+	ginkgo.BeforeEach(func() {
+		SkipUnsupportedDriverPatternCombination(driver, pattern)
+	})
 
 	// This intentionally comes after checking the preconditions because it
 	// registers its own BeforeEach which creates the namespace. Beware that it


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
1. This PR makes sure all testsuite call SkipUnsupportedDriverPatternCombination() before they initialize any resources.
2. Cleanup test pattern&driver compatibility to reduce redundant code.
3. Change the testpattern for default FS and default block to remove unnecessary snapshot setting. 
4. And add a new type  DynamicBlockSnapshotDelete which is a combination of block support + snapshot. 
5. Add DynamicBlockSnapshotDelete testpattern to snapshottable test so it has block coverage.


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/sig storage
/cc @msau42 
/cc @xing-yang 