### PR TITLE
Return a customize error message in case re-auth is required.

### DIFF
--- a/staging/src/k8s.io/client-go/plugin/pkg/client/auth/gcp/gcp.go
+++ b/staging/src/k8s.io/client-go/plugin/pkg/client/auth/gcp/gcp.go
@@ -300,6 +300,9 @@ func (c *commandTokenSource) Token() (*oauth2.Token, error) {
 	cmd.Stderr = &stderr
 	output, err := cmd.Output()
 	if err != nil {
+		if bytes.Contains(stderr.Bytes(), []byte("Reauthentication required")) {
+			return nil, fmt.Errorf("Reauthentication required. Please run:\n\n  gcloud auth login\n\nto obtain new credentials.")
+		}
 		return nil, fmt.Errorf("error executing access token command %q: err=%v output=%s stderr=%s", fullCmd, err, output, string(stderr.Bytes()))
 	}
 	token, err := c.parseTokenCmdOutput(output)

--- a/staging/src/k8s.io/client-go/plugin/pkg/client/auth/gcp/gcp_test.go
+++ b/staging/src/k8s.io/client-go/plugin/pkg/client/auth/gcp/gcp_test.go
@@ -34,6 +34,7 @@ import (
 type fakeOutput struct {
 	args   []string
 	output string
+	stderr string
 }
 
 var (
@@ -87,6 +88,10 @@ var (
   "token_expiry": "sometime soon, idk"
   ------
 `},
+		"reauth": {
+			args: []string{},
+			stderr: "Reauthentication required.",
+		},
 	}
 )
 
@@ -114,6 +119,10 @@ func TestHelperProcess(t *testing.T) {
 		os.Exit(1)
 	}
 	fmt.Fprintf(os.Stdout, output.output)
+	if output.stderr != "" {
+		fmt.Fprintf(os.Stderr, output.stderr)
+		os.Exit(1)
+	}
 	os.Exit(0)
 }
 
@@ -342,6 +351,19 @@ func TestCmdTokenSource(t *testing.T) {
 			nil,
 			nil,
 			fmt.Errorf("invalid character '-' after object key:value pair"),
+		},
+		{
+			"reauth",
+			map[string]string{
+				"cmd-path": "reauth",
+			},
+			nil,
+			nil,
+			fmt.Errorf(`Reauthentication required. Please run:
+
+  gcloud auth login
+
+to obtain new credentials.`),
 		},
 	}
 


### PR DESCRIPTION
`gcloud` might require re-authentication. This might be in the form of
username / password, or a touch of security key, or asking users to
launch browser session to google.com. So it's best to bail here and ask
user to run `gcloud auth login` manually to re-auth.

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

See above or #96289.

**Which issue(s) this PR fixes**:

Fixes #96289.

**Special notes for your reviewer**:

Internal bug 169364378.

**Does this PR introduce a user-facing change?**:

```release-note
Better messaging in case `gcloud` requires re-authentication.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
