### PR TITLE
Automated cherry pick of #95541: report UnschedulableAndUnresolvable status instead of an

### DIFF
--- a/pkg/controller/volume/scheduling/scheduler_binder.go
+++ b/pkg/controller/volume/scheduling/scheduler_binder.go
@@ -68,6 +68,8 @@ const (
 	ErrReasonNodeConflict ConflictReason = "node(s) had volume node affinity conflict"
 	// ErrReasonNotEnoughSpace is used when a pod cannot start on a node because not enough storage space is available.
 	ErrReasonNotEnoughSpace = "node(s) did not have enough free storage"
+	// ErrReasonPVNotExist is used when a PVC can't find the bound persistent volumes"
+	ErrReasonPVNotExist = "pvc(s) bound to non-existent pv(s)"
 )
 
 // BindingInfo holds a binding between PV and PVC.
@@ -246,6 +248,7 @@ func (b *volumeBinder) FindPodVolumes(pod *v1.Pod, boundClaims, claimsToBind []*
 	unboundVolumesSatisfied := true
 	boundVolumesSatisfied := true
 	sufficientStorage := true
+	boundPVsFound := true
 	defer func() {
 		if err != nil {
 			return
@@ -258,6 +261,9 @@ func (b *volumeBinder) FindPodVolumes(pod *v1.Pod, boundClaims, claimsToBind []*
 		}
 		if !sufficientStorage {
 			reasons = append(reasons, ErrReasonNotEnoughSpace)
+		}
+		if !boundPVsFound {
+			reasons = append(reasons, ErrReasonPVNotExist)
 		}
 	}()
 
@@ -288,7 +294,7 @@ func (b *volumeBinder) FindPodVolumes(pod *v1.Pod, boundClaims, claimsToBind []*
 
 	// Check PV node affinity on bound volumes
 	if len(boundClaims) > 0 {
-		boundVolumesSatisfied, err = b.checkBoundClaims(boundClaims, node, podName)
+		boundVolumesSatisfied, boundPVsFound, err = b.checkBoundClaims(boundClaims, node, podName)
 		if err != nil {
 			return
 		}
@@ -762,7 +768,7 @@ func (b *volumeBinder) GetPodVolumes(pod *v1.Pod) (boundClaims []*v1.PersistentV
 	return boundClaims, unboundClaimsDelayBinding, unboundClaimsImmediate, nil
 }
 
-func (b *volumeBinder) checkBoundClaims(claims []*v1.PersistentVolumeClaim, node *v1.Node, podName string) (bool, error) {
+func (b *volumeBinder) checkBoundClaims(claims []*v1.PersistentVolumeClaim, node *v1.Node, podName string) (bool, bool, error) {
 	csiNode, err := b.csiNodeLister.Get(node.Name)
 	if err != nil {
 		// TODO: return the error once CSINode is created by default
@@ -773,24 +779,27 @@ func (b *volumeBinder) checkBoundClaims(claims []*v1.PersistentVolumeClaim, node
 		pvName := pvc.Spec.VolumeName
 		pv, err := b.pvCache.GetPV(pvName)
 		if err != nil {
-			return false, err
+			if _, ok := err.(*errNotFound); ok {
+				err = nil
+			}
+			return true, false, err
 		}
 
 		pv, err = b.tryTranslatePVToCSI(pv, csiNode)
 		if err != nil {
-			return false, err
+			return false, true, err
 		}
 
 		err = volumeutil.CheckNodeAffinity(pv, node.Labels)
 		if err != nil {
 			klog.V(4).Infof("PersistentVolume %q, Node %q mismatch for Pod %q: %v", pvName, node.Name, podName, err)
-			return false, nil
+			return false, true, nil
 		}
 		klog.V(5).Infof("PersistentVolume %q, Node %q matches for Pod %q", pvName, node.Name, podName)
 	}
 
 	klog.V(4).Infof("All bound volumes for Pod %q match with Node %q", podName, node.Name)
-	return true, nil
+	return true, true, nil
 }
 
 // findMatchingVolumes tries to find matching volumes for given claims,

--- a/pkg/controller/volume/scheduling/scheduler_binder_test.go
+++ b/pkg/controller/volume/scheduling/scheduler_binder_test.go
@@ -880,7 +880,8 @@ func TestFindPodVolumesWithoutProvisioning(t *testing.T) {
 		},
 		"bound-pvc,pv-not-exists": {
 			podPVCs:    []*v1.PersistentVolumeClaim{boundPVC},
-			shouldFail: true,
+			shouldFail: false,
+			reasons:    ConflictReasons{ErrReasonPVNotExist},
 		},
 		"prebound-pvc": {
 			podPVCs:    []*v1.PersistentVolumeClaim{preboundPVC},

--- a/pkg/scheduler/framework/plugins/volumebinding/volume_binding_test.go
+++ b/pkg/scheduler/framework/plugins/volumebinding/volume_binding_test.go
@@ -227,7 +227,7 @@ func TestVolumeBinding(t *testing.T) {
 				claimsToBind:     []*v1.PersistentVolumeClaim{},
 				podVolumesByNode: map[string]*scheduling.PodVolumes{},
 			},
-			wantFilterStatus: framework.NewStatus(framework.Error, `could not find v1.PersistentVolume "pv-a"`),
+			wantFilterStatus: framework.NewStatus(framework.UnschedulableAndUnresolvable, `pvc(s) bound to non-existent pv(s)`),
 		},
 	}
 


### PR DESCRIPTION
Cherry pick of #95541 on release-1.19.

#95541: report UnschedulableAndUnresolvable status instead of an

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
report UnschedulableAndUnresolvable status instead of an error when bound PVs not found
```
