### PR TITLE
Separate in-tree gcepd driver for windows

### DIFF
--- a/test/e2e/storage/drivers/in_tree.go
+++ b/test/e2e/storage/drivers/in_tree.go
@@ -1229,17 +1229,12 @@ var _ testsuites.DynamicPVTestDriver = &gcePdDriver{}
 
 // InitGcePdDriver returns gcePdDriver that implements TestDriver interface
 func InitGcePdDriver() testsuites.TestDriver {
-	// In current test structure, it first initialize the driver and then set up
-	// the new framework, so we cannot get the correct OS here. So here set to
-	// support all fs types including both linux and windows. We have code to check Node OS later
-	// during test.
 	supportedTypes := sets.NewString(
 		"", // Default fsType
 		"ext2",
 		"ext3",
 		"ext4",
 		"xfs",
-		"ntfs",
 	)
 	return &gcePdDriver{
 		driverInfo: testsuites.DriverInfo{
@@ -1260,6 +1255,38 @@ func InitGcePdDriver() testsuites.TestDriver {
 				testsuites.CapMultiPODs:           true,
 				testsuites.CapControllerExpansion: true,
 				testsuites.CapNodeExpansion:       true,
+				// GCE supports volume limits, but the test creates large
+				// number of volumes and times out test suites.
+				testsuites.CapVolumeLimits: false,
+				testsuites.CapTopology:     true,
+			},
+		},
+	}
+}
+
+// InitWindowsGcePdDriver returns gcePdDriver running on Windows cluster that implements TestDriver interface
+// In current test structure, it first initialize the driver and then set up
+// the new framework, so we cannot get the correct OS here and select which file system is supported.
+// So here uses a separate Windows in-tree gce pd driver
+func InitWindowsGcePdDriver() testsuites.TestDriver {
+	supportedTypes := sets.NewString(
+		"ntfs",
+	)
+	return &gcePdDriver{
+		driverInfo: testsuites.DriverInfo{
+			Name:             "windows-gcepd",
+			InTreePluginName: "kubernetes.io/gce-pd",
+			MaxFileSize:      testpatterns.FileSizeMedium,
+			SupportedSizeRange: e2evolume.SizeRange{
+				Min: "1Gi",
+			},
+			SupportedFsType: supportedTypes,
+			TopologyKeys:    []string{v1.LabelZoneFailureDomain},
+			Capabilities: map[testsuites.Capability]bool{
+				testsuites.CapControllerExpansion: false,
+				testsuites.CapPersistence:         true,
+				testsuites.CapExec:                true,
+				testsuites.CapMultiPODs:           true,
 				// GCE supports volume limits, but the test creates large
 				// number of volumes and times out test suites.
 				testsuites.CapVolumeLimits: false,

--- a/test/e2e/storage/in_tree_volumes.go
+++ b/test/e2e/storage/in_tree_volumes.go
@@ -35,6 +35,7 @@ var testDrivers = []func() testsuites.TestDriver{
 	drivers.InitEmptydirDriver,
 	drivers.InitCinderDriver,
 	drivers.InitGcePdDriver,
+	drivers.InitWindowsGcePdDriver,
 	drivers.InitVSphereDriver,
 	drivers.InitAzureDiskDriver,
 	drivers.InitAwsDriver,


### PR DESCRIPTION
Add a separate in-tree gcepd driver for windows cluster because it does
not support certain features as Linux driver.

Change-Id: I2fca86b3f32f17db7703c46a36944d9ee51f355f

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
