### PR TITLE
remove comment for cache sync because code was removed

### DIFF
--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -307,7 +307,7 @@ func initPolicyFromConfigMap(client clientset.Interface, policyRef *schedulerapi
 	return nil
 }
 
-// Run begins watching and scheduling. It waits for cache to be synced, then starts scheduling and blocked until the context is done.
+// Run begins watching and scheduling. It starts scheduling and blocked until the context is done.
 func (sched *Scheduler) Run(ctx context.Context) {
 	sched.SchedulingQueue.Run()
 	wait.UntilWithContext(ctx, sched.scheduleOne, 0)


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Code about waiting cache synced has been removed, so remove the annotation accordingly.

**Which issue(s) this PR fixes**:
No

**Special notes for your reviewer**:
No

**Does this PR introduce a user-facing change?**:
No

```release-note
   NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
No
