### PR TITLE
Less restrictions for AWS NLB health check config

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/aws/aws.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/aws/aws.go
@@ -3771,14 +3771,6 @@ func (c *Cloud) buildNLBHealthCheckConfiguration(svc *v1.Service) (healthCheckCo
 		return healthCheckConfig{}, err
 	}
 
-	if hc.HealthyThreshold != hc.UnhealthyThreshold {
-		return healthCheckConfig{}, fmt.Errorf("Health check healthy threshold and unhealthy threshold must be equal")
-	}
-
-	if hc.Interval != 10 && hc.Interval != 30 {
-		return healthCheckConfig{}, fmt.Errorf("Invalid health check interval '%v', must be either 10 or 30", hc.Interval)
-	}
-
 	if hc.Port != defaultHealthCheckPort {
 		if _, err := strconv.ParseInt(hc.Port, 10, 0); err != nil {
 			return healthCheckConfig{}, fmt.Errorf("Invalid health check port '%v'", hc.Port)

--- a/staging/src/k8s.io/legacy-cloud-providers/aws/aws_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/aws/aws_test.go
@@ -2961,7 +2961,7 @@ func TestCloud_buildNLBHealthCheckConfiguration(t *testing.T) {
 			wantError: false,
 		},
 		{
-			name: "invalid interval",
+			name: "interval not 10 or 30",
 			service: &v1.Service{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-svc",
@@ -2982,8 +2982,15 @@ func TestCloud_buildNLBHealthCheckConfiguration(t *testing.T) {
 					},
 				},
 			},
-			want:      healthCheckConfig{},
-			wantError: true,
+			want: healthCheckConfig{
+				Port:               "traffic-port",
+				Protocol:           elbv2.ProtocolEnumTcp,
+				Interval:           23,
+				Timeout:            10,
+				HealthyThreshold:   3,
+				UnhealthyThreshold: 3,
+			},
+			wantError: false,
 		},
 		{
 			name: "invalid timeout",
@@ -3033,8 +3040,15 @@ func TestCloud_buildNLBHealthCheckConfiguration(t *testing.T) {
 					},
 				},
 			},
-			want:      healthCheckConfig{},
-			wantError: true,
+			want:      healthCheckConfig{
+				Port:               "traffic-port",
+				Protocol:           elbv2.ProtocolEnumTcp,
+				Interval:           30,
+				Timeout:            10,
+				HealthyThreshold:   7,
+				UnhealthyThreshold: 5,
+			},
+			wantError: false,
 		},
 	}
 

--- a/staging/src/k8s.io/legacy-cloud-providers/aws/aws_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/aws/aws_test.go
@@ -3040,7 +3040,7 @@ func TestCloud_buildNLBHealthCheckConfiguration(t *testing.T) {
 					},
 				},
 			},
-			want:      healthCheckConfig{
+			want: healthCheckConfig{
 				Port:               "traffic-port",
 				Protocol:           elbv2.ProtocolEnumTcp,
 				Interval:           30,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup
**What this PR does / why we need it**:
This PR removes the restrictions on NLB healthcheck interval, healthy and unhealthy thresholds. This is to ensure that all newly created target groups can take advantage of the improved health check functionality of the AWS NLB target groups. 
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
After this change, it will be up to the end user to configure appropriate values for the annotations.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Users will now be able to configure all supported values for AWS NLB health check interval and thresholds for new resources.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
