### PR TITLE
Ensuring default DNS cluster-domain of Kubelet is cluster.local

### DIFF
--- a/hack/make-rules/test-e2e-node.sh
+++ b/hack/make-rules/test-e2e-node.sh
@@ -140,6 +140,10 @@ if [ "${remote}" = true ] ; then
        done
   fi
 
+  # Use cluster.local as default dns-domain
+  test_args='--dns-domain="'${KUBE_DNS_DOMAIN:-cluster.local}'" '${test_args}
+  test_args='--kubelet-flags="--cluster-domain='${KUBE_DNS_DOMAIN:-cluster.local}'" '${test_args}
+
   # Output the configuration we will try to run
   echo "Running tests remotely using"
   echo "Project: ${project}"
@@ -183,6 +187,9 @@ else
   # Runtime flags
   test_args='--kubelet-flags="--container-runtime='${runtime}'" '${test_args}
 
+  # Use cluster.local as default dns-domain
+  test_args='--dns-domain="'${KUBE_DNS_DOMAIN:-cluster.local}'" '${test_args}
+  test_args='--kubelet-flags="--cluster-domain='${KUBE_DNS_DOMAIN:-cluster.local}'" '${test_args}
   # Test using the host the script was run on
   # Provided for backwards compatibility
   go run test/e2e_node/runner/local/run_local.go \

--- a/test/e2e_node/e2e_node_suite_test.go
+++ b/test/e2e_node/e2e_node_suite_test.go
@@ -84,6 +84,7 @@ func registerNodeFlags(flags *flag.FlagSet) {
 	flags.StringVar(&framework.TestContext.SystemSpecName, "system-spec-name", "", "The name of the system spec (e.g., gke) that's used in the node e2e test. The system specs are in test/e2e_node/system/specs/. This is used by the test framework to determine which tests to run for validating the system requirements.")
 	flags.Var(cliflag.NewMapStringString(&framework.TestContext.ExtraEnvs), "extra-envs", "The extra environment variables needed for node e2e tests. Format: a list of key=value pairs, e.g., env1=val1,env2=val2")
 	flags.StringVar(&framework.TestContext.SriovdpConfigMapFile, "sriovdp-configmap-file", "", "The name of the SRIOV device plugin Config Map to load.")
+	flag.StringVar(&framework.TestContext.ClusterDNSDomain, "dns-domain", "cluster.local", "The DNS Domain of the cluster.")
 }
 
 func init() {


### PR DESCRIPTION
Currently e2e tests run under test-e2e-node have a cluster-domain
equals to "". This change makes test-e2e-node consistent with other
e2e tests. For example, in hack/ginkgo-e2e.sh, cluster-domain
defaults to cluster.local and it can be changed by defining KUBE_DNS_DOMAIN.

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
This PR allows test-e2e-node tests to have a DNS cluster-domain instead of empty String.

/sig node
/area testing