### PR TITLE
cleanup dated wording "NominatedNodeName annotation"

### DIFF
--- a/test/integration/scheduler/preemption_test.go
+++ b/test/integration/scheduler/preemption_test.go
@@ -65,7 +65,7 @@ func waitForNominatedNodeNameWithTimeout(cs clientset.Interface, pod *v1.Pod, ti
 		}
 		return false, err
 	}); err != nil {
-		return fmt.Errorf("Pod %v/%v annotation did not get set: %v", pod.Namespace, pod.Name, err)
+		return fmt.Errorf(".status.nominatedNodeName of Pod %v/%v did not get set: %v", pod.Namespace, pod.Name, err)
 	}
 	return nil
 }
@@ -795,9 +795,9 @@ func TestPreemptionStarvation(t *testing.T) {
 			if err != nil {
 				t.Errorf("Error while creating the preempting pod: %v", err)
 			}
-			// Check that the preemptor pod gets the annotation for nominated node name.
+			// Check if .status.nominatedNodeName of the preemptor pod gets set.
 			if err := waitForNominatedNodeName(cs, preemptor); err != nil {
-				t.Errorf("NominatedNodeName annotation was not set for pod %v/%v: %v", preemptor.Namespace, preemptor.Name, err)
+				t.Errorf(".status.nominatedNodeName was not set for pod %v/%v: %v", preemptor.Namespace, preemptor.Name, err)
 			}
 			// Make sure that preemptor is scheduled after preemptions.
 			if err := testutils.WaitForPodToScheduleWithTimeout(cs, preemptor, 60*time.Second); err != nil {
@@ -896,7 +896,7 @@ func TestPreemptionRaces(t *testing.T) {
 				}
 				// Check that the preemptor pod gets nominated node name.
 				if err := waitForNominatedNodeName(cs, preemptor); err != nil {
-					t.Errorf("NominatedNodeName annotation was not set for pod %v/%v: %v", preemptor.Namespace, preemptor.Name, err)
+					t.Errorf(".status.nominatedNodeName was not set for pod %v/%v: %v", preemptor.Namespace, preemptor.Name, err)
 				}
 				// Make sure that preemptor is scheduled after preemptions.
 				if err := testutils.WaitForPodToScheduleWithTimeout(cs, preemptor, 60*time.Second); err != nil {
@@ -986,9 +986,9 @@ func TestNominatedNodeCleanUp(t *testing.T) {
 	if err != nil {
 		t.Errorf("Error while creating the medium priority pod: %v", err)
 	}
-	// Step 3. Check that nominated node name of the medium priority pod is set.
+	// Step 3. Check if .status.nominatedNodeName of the medium priority pod is set.
 	if err := waitForNominatedNodeName(cs, medPriPod); err != nil {
-		t.Errorf("NominatedNodeName annotation was not set for pod %v/%v: %v", medPriPod.Namespace, medPriPod.Name, err)
+		t.Errorf(".status.nominatedNodeName was not set for pod %v/%v: %v", medPriPod.Namespace, medPriPod.Name, err)
 	}
 	// Step 4. Create a high priority pod.
 	podConf = initPausePod(&pausePodConfig{
@@ -1004,11 +1004,11 @@ func TestNominatedNodeCleanUp(t *testing.T) {
 	if err != nil {
 		t.Errorf("Error while creating the high priority pod: %v", err)
 	}
-	// Step 5. Check that nominated node name of the high priority pod is set.
+	// Step 5. Check if .status.nominatedNodeName of the high priority pod is set.
 	if err := waitForNominatedNodeName(cs, highPriPod); err != nil {
-		t.Errorf("NominatedNodeName annotation was not set for pod %v/%v: %v", highPriPod.Namespace, highPriPod.Name, err)
+		t.Errorf(".status.nominatedNodeName was not set for pod %v/%v: %v", highPriPod.Namespace, highPriPod.Name, err)
 	}
-	// And the nominated node name of the medium priority pod is cleared.
+	// And .status.nominatedNodeName of the medium priority pod is cleared.
 	if err := wait.Poll(100*time.Millisecond, wait.ForeverTestTimeout, func() (bool, error) {
 		pod, err := cs.CoreV1().Pods(medPriPod.Namespace).Get(context.TODO(), medPriPod.Name, metav1.GetOptions{})
 		if err != nil {
@@ -1019,7 +1019,7 @@ func TestNominatedNodeCleanUp(t *testing.T) {
 		}
 		return false, err
 	}); err != nil {
-		t.Errorf("The nominated node name of the medium priority pod was not cleared: %v", err)
+		t.Errorf(".status.nominatedNodeName of the medium priority pod was not cleared: %v", err)
 	}
 }
 
@@ -1299,10 +1299,10 @@ func TestPDBInPreemption(t *testing.T) {
 					}
 				}
 			}
-			// Also check that the preemptor pod gets the annotation for nominated node name.
+			// Also check if .status.nominatedNodeName of the preemptor pod gets set.
 			if len(test.preemptedPodIndexes) > 0 {
 				if err := waitForNominatedNodeName(cs, preemptor); err != nil {
-					t.Errorf("Test [%v]: NominatedNodeName annotation was not set for pod %v/%v: %v", test.name, preemptor.Namespace, preemptor.Name, err)
+					t.Errorf("Test [%v]: .status.nominatedNodeName was not set for pod %v/%v: %v", test.name, preemptor.Namespace, preemptor.Name, err)
 				}
 			}
 


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup
/sig scheduling

**What this PR does / why we need it**:

"NominatedNodeName annotation" was used when preemption feature was alpha, it's no longer valid as Preemption has GAed for a long time. This PR replaces the dated wordings with ".status.nominatedNodeName".

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```