### PR TITLE
Fix go lint on folder apimachinery/pkg/runtime/serializer/json

### DIFF
--- a/hack/.golint_failures
+++ b/hack/.golint_failures
@@ -252,7 +252,6 @@ staging/src/k8s.io/apimachinery/pkg/conversion
 staging/src/k8s.io/apimachinery/pkg/runtime
 staging/src/k8s.io/apimachinery/pkg/runtime/schema
 staging/src/k8s.io/apimachinery/pkg/runtime/serializer
-staging/src/k8s.io/apimachinery/pkg/runtime/serializer/json
 staging/src/k8s.io/apimachinery/pkg/runtime/serializer/protobuf
 staging/src/k8s.io/apimachinery/pkg/runtime/serializer/recognizer
 staging/src/k8s.io/apimachinery/pkg/runtime/serializer/streaming

--- a/pkg/api/testing/serialization_test.go
+++ b/pkg/api/testing/serialization_test.go
@@ -631,7 +631,7 @@ func BenchmarkDecodeIntoJSONCodecGenConfigCompatibleWithStandardLibrary(b *testi
 	}
 
 	b.ResetTimer()
-	iter := json.CaseSensitiveJsonIterator()
+	iter := json.CaseSensitiveJSONIterator()
 	for i := 0; i < b.N; i++ {
 		obj := v1.Pod{}
 		if err := iter.Unmarshal(encoded[i%width], &obj); err != nil {

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/objectmeta/coerce.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/objectmeta/coerce.go
@@ -25,7 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/serializer/json"
 )
 
-var encodingjson = json.CaseSensitiveJsonIterator()
+var encodingjson = json.CaseSensitiveJSONIterator()
 
 // GetObjectMeta does conversion of JSON to ObjectMeta. It first tries json.Unmarshal into a metav1.ObjectMeta
 // type. If that does not work and dropMalformedFields is true, it does field-by-field best-effort conversion

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/group_version_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/group_version_test.go
@@ -47,7 +47,7 @@ func TestGroupVersionUnmarshalJSON(t *testing.T) {
 			t.Errorf("JSON codec failed to unmarshal input '%s': expected %+v, got %+v", c.input, c.expect, result.GV)
 		}
 		// test the json-iterator codec
-		iter := json.CaseSensitiveJsonIterator()
+		iter := json.CaseSensitiveJSONIterator()
 		if err := iter.Unmarshal(c.input, &result); err != nil {
 			t.Errorf("json-iterator codec failed to unmarshal input '%v': %v", c.input, err)
 		}

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/types_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/types_test.go
@@ -56,7 +56,7 @@ func TestVerbsJsonIterUnmarshalJSON(t *testing.T) {
 		{`{"verbs":["delete"]}`, APIResource{Verbs: Verbs([]string{"delete"})}},
 	}
 
-	iter := json.CaseSensitiveJsonIterator()
+	iter := json.CaseSensitiveJSONIterator()
 	for i, c := range cases {
 		var result APIResource
 		if err := iter.Unmarshal([]byte(c.input), &result); err != nil {

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/json/json.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/json/json.go
@@ -96,6 +96,7 @@ type SerializerOptions struct {
 	Strict bool
 }
 
+// Serializer handles encoding versioned objects into the proper JSON form
 type Serializer struct {
 	meta    MetaFactory
 	options SerializerOptions
@@ -144,10 +145,10 @@ func (customNumberDecoder) Decode(ptr unsafe.Pointer, iter *jsoniter.Iterator) {
 	}
 }
 
-// CaseSensitiveJsonIterator returns a jsoniterator API that's configured to be
+// CaseSensitiveJSONIterator returns a jsoniterator API that's configured to be
 // case-sensitive when unmarshalling, and otherwise compatible with
 // the encoding/json standard library.
-func CaseSensitiveJsonIterator() jsoniter.API {
+func CaseSensitiveJSONIterator() jsoniter.API {
 	config := jsoniter.Config{
 		EscapeHTML:             true,
 		SortMapKeys:            true,
@@ -159,10 +160,10 @@ func CaseSensitiveJsonIterator() jsoniter.API {
 	return config
 }
 
-// StrictCaseSensitiveJsonIterator returns a jsoniterator API that's configured to be
+// StrictCaseSensitiveJSONIterator returns a jsoniterator API that's configured to be
 // case-sensitive, but also disallows unknown fields when unmarshalling. It is compatible with
 // the encoding/json standard library.
-func StrictCaseSensitiveJsonIterator() jsoniter.API {
+func StrictCaseSensitiveJSONIterator() jsoniter.API {
 	config := jsoniter.Config{
 		EscapeHTML:             true,
 		SortMapKeys:            true,
@@ -179,8 +180,8 @@ func StrictCaseSensitiveJsonIterator() jsoniter.API {
 // from outside. Still does not protect from package level jsoniter.Register*() functions - someone calling them
 // in some other library will mess with every usage of the jsoniter library in the whole program.
 // See https://github.com/json-iterator/go/issues/265
-var caseSensitiveJsonIterator = CaseSensitiveJsonIterator()
-var strictCaseSensitiveJsonIterator = StrictCaseSensitiveJsonIterator()
+var caseSensitiveJSONIterator = CaseSensitiveJSONIterator()
+var strictCaseSensitiveJSONIterator = StrictCaseSensitiveJSONIterator()
 
 // gvkWithDefaults returns group kind and version defaulting from provided default
 func gvkWithDefaults(actual, defaultGVK schema.GroupVersionKind) schema.GroupVersionKind {
@@ -236,7 +237,7 @@ func (s *Serializer) Decode(originalData []byte, gvk *schema.GroupVersionKind, i
 		types, _, err := s.typer.ObjectKinds(into)
 		switch {
 		case runtime.IsNotRegisteredError(err), isUnstructured:
-			if err := caseSensitiveJsonIterator.Unmarshal(data, into); err != nil {
+			if err := caseSensitiveJSONIterator.Unmarshal(data, into); err != nil {
 				return nil, actual, err
 			}
 			return into, actual, nil
@@ -260,7 +261,7 @@ func (s *Serializer) Decode(originalData []byte, gvk *schema.GroupVersionKind, i
 		return nil, actual, err
 	}
 
-	if err := caseSensitiveJsonIterator.Unmarshal(data, obj); err != nil {
+	if err := caseSensitiveJSONIterator.Unmarshal(data, obj); err != nil {
 		return nil, actual, err
 	}
 
@@ -285,7 +286,7 @@ func (s *Serializer) Decode(originalData []byte, gvk *schema.GroupVersionKind, i
 	// due to that a matching field doesn't exist in the object. hence we can return a typed strictDecoderError,
 	// the actual error is that the object contains unknown field.
 	strictObj := obj.DeepCopyObject()
-	if err := strictCaseSensitiveJsonIterator.Unmarshal(altered, strictObj); err != nil {
+	if err := strictCaseSensitiveJSONIterator.Unmarshal(altered, strictObj); err != nil {
 		return nil, actual, runtime.NewStrictDecodingError(err.Error(), string(originalData))
 	}
 	// Always return the same object as the non-strict serializer to avoid any deviations.
@@ -302,7 +303,7 @@ func (s *Serializer) Encode(obj runtime.Object, w io.Writer) error {
 
 func (s *Serializer) doEncode(obj runtime.Object, w io.Writer) error {
 	if s.options.Yaml {
-		json, err := caseSensitiveJsonIterator.Marshal(obj)
+		json, err := caseSensitiveJSONIterator.Marshal(obj)
 		if err != nil {
 			return err
 		}
@@ -315,7 +316,7 @@ func (s *Serializer) doEncode(obj runtime.Object, w io.Writer) error {
 	}
 
 	if s.options.Pretty {
-		data, err := caseSensitiveJsonIterator.MarshalIndent(obj, "", "  ")
+		data, err := caseSensitiveJSONIterator.MarshalIndent(obj, "", "  ")
 		if err != nil {
 			return err
 		}

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/json/json_limit_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/json/json_limit_test.go
@@ -123,7 +123,7 @@ func testcases() []testcase {
 var decoders = map[string]func([]byte, interface{}) error{
 	"gojson":   gojson.Unmarshal,
 	"utiljson": utiljson.Unmarshal,
-	"jsoniter": CaseSensitiveJsonIterator().Unmarshal,
+	"jsoniter": CaseSensitiveJSONIterator().Unmarshal,
 }
 
 func TestJSONLimits(t *testing.T) {

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/json/json_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/json/json_test.go
@@ -60,21 +60,21 @@ type DecodableSpec struct {
 func (d *testDecodable) GetObjectKind() schema.ObjectKind                { return d }
 func (d *testDecodable) SetGroupVersionKind(gvk schema.GroupVersionKind) { d.gvk = gvk }
 func (d *testDecodable) GroupVersionKind() schema.GroupVersionKind       { return d.gvk }
-func (in *testDecodable) DeepCopyObject() runtime.Object {
-	if in == nil {
+func (d *testDecodable) DeepCopyObject() runtime.Object {
+	if d == nil {
 		return nil
 	}
 	out := new(testDecodable)
-	in.DeepCopyInto(out)
+	d.DeepCopyInto(out)
 	return out
 }
-func (in *testDecodable) DeepCopyInto(out *testDecodable) {
-	*out = *in
-	out.Other = in.Other
-	out.Value = in.Value
-	out.Spec = in.Spec
-	out.Interface = in.Interface
-	out.gvk = in.gvk
+func (d *testDecodable) DeepCopyInto(out *testDecodable) {
+	*out = *d
+	out.Other = d.Other
+	out.Value = d.Value
+	out.Spec = d.Spec
+	out.Interface = d.Interface
+	out.gvk = d.gvk
 	return
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/mutating/dispatcher.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/mutating/dispatcher.go
@@ -57,7 +57,7 @@ const (
 	MutationAuditAnnotationPrefix = "mutation.webhook.admission.k8s.io/"
 )
 
-var encodingjson = json.CaseSensitiveJsonIterator()
+var encodingjson = json.CaseSensitiveJSONIterator()
 
 type mutatingDispatcher struct {
 	cm     *webhookutil.ClientManager

--- a/staging/src/k8s.io/cli-runtime/pkg/resource/metadata_decoder.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/resource/metadata_decoder.go
@@ -24,7 +24,7 @@ import (
 )
 
 // hold a single instance of the case-sensitive decoder
-var caseSensitiveJsonIterator = json.CaseSensitiveJsonIterator()
+var caseSensitiveJsonIterator = json.CaseSensitiveJSONIterator()
 
 // metadataValidatingDecoder wraps a decoder and additionally ensures metadata schema fields decode before returning an unstructured object
 type metadataValidatingDecoder struct {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Fixed go lint error in apimachinery/pkg/runtime/serializer/json

**Which issue(s) this PR fixes**:

Part of #68026


**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
