### PR TITLE
Graduating AppProtocol to GA

### DIFF
--- a/pkg/apis/core/types.go
+++ b/pkg/apis/core/types.go
@@ -3736,8 +3736,6 @@ type ServicePort struct {
 	// RFC-6335 and http://www.iana.org/assignments/service-names).
 	// Non-standard protocols should use prefixed names such as
 	// mycompany.com/my-custom-protocol.
-	// This is a beta field that is guarded by the ServiceAppProtocol feature
-	// gate and enabled by default.
 	// +optional
 	AppProtocol *string
 
@@ -3888,8 +3886,6 @@ type EndpointPort struct {
 	// RFC-6335 and http://www.iana.org/assignments/service-names).
 	// Non-standard protocols should use prefixed names such as
 	// mycompany.com/my-custom-protocol.
-	// This is a beta field that is guarded by the ServiceAppProtocol feature
-	// gate and enabled by default.
 	// +optional
 	AppProtocol *string
 }

--- a/pkg/apis/core/validation/validation_test.go
+++ b/pkg/apis/core/validation/validation_test.go
@@ -9898,10 +9898,9 @@ func TestValidateServiceCreate(t *testing.T) {
 	preferDualStack := core.IPFamilyPolicyPreferDualStack
 
 	testCases := []struct {
-		name               string
-		tweakSvc           func(svc *core.Service) // given a basic valid service, each test case can customize it
-		numErrs            int
-		appProtocolEnabled bool
+		name     string
+		tweakSvc func(svc *core.Service) // given a basic valid service, each test case can customize it
+		numErrs  int
 	}{
 		{
 			name: "missing namespace",
@@ -11008,8 +11007,7 @@ func TestValidateServiceCreate(t *testing.T) {
 					AppProtocol: utilpointer.StringPtr("HTTP"),
 				}}
 			},
-			appProtocolEnabled: true,
-			numErrs:            0,
+			numErrs: 0,
 		},
 		{
 			name: `valid custom appProtocol`,
@@ -11021,8 +11019,7 @@ func TestValidateServiceCreate(t *testing.T) {
 					AppProtocol: utilpointer.StringPtr("example.com/protocol"),
 				}}
 			},
-			appProtocolEnabled: true,
-			numErrs:            0,
+			numErrs: 0,
 		},
 		{
 			name: `invalid appProtocol`,
@@ -11034,8 +11031,7 @@ func TestValidateServiceCreate(t *testing.T) {
 					AppProtocol: utilpointer.StringPtr("example.com/protocol_with{invalid}[characters]"),
 				}}
 			},
-			appProtocolEnabled: true,
-			numErrs:            1,
+			numErrs: 1,
 		},
 
 		{
@@ -11059,8 +11055,6 @@ func TestValidateServiceCreate(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.ServiceAppProtocol, true)()
-
 			svc := makeValidService()
 			tc.tweakSvc(&svc)
 			errs := ValidateServiceCreate(&svc)
@@ -12624,10 +12618,9 @@ func TestValidateServiceUpdate(t *testing.T) {
 	preferDualStack := core.IPFamilyPolicyPreferDualStack
 	singleStack := core.IPFamilyPolicySingleStack
 	testCases := []struct {
-		name               string
-		tweakSvc           func(oldSvc, newSvc *core.Service) // given basic valid services, each test case can customize them
-		numErrs            int
-		appProtocolEnabled bool
+		name     string
+		tweakSvc func(oldSvc, newSvc *core.Service) // given basic valid services, each test case can customize them
+		numErrs  int
 	}{
 		{
 			name: "no change",
@@ -13496,47 +13489,26 @@ func TestValidateServiceUpdate(t *testing.T) {
 			},
 			numErrs: 1,
 		},
-
 		{
-			name: "update with valid app protocol, field unset, gate disabled",
+			name: "update to valid app protocol",
 			tweakSvc: func(oldSvc, newSvc *core.Service) {
 				oldSvc.Spec.Ports = []core.ServicePort{{Name: "a", Port: 443, TargetPort: intstr.FromInt(3000), Protocol: "TCP"}}
-				newSvc.Spec.Ports = []core.ServicePort{{Name: "a", Port: 443, TargetPort: intstr.FromInt(3000), Protocol: "TCP", AppProtocol: utilpointer.StringPtr("https")}}
-			},
-			numErrs: 1,
-		},
-		{
-			name: "update to valid app protocol, field set, gate disabled",
-			tweakSvc: func(oldSvc, newSvc *core.Service) {
-				oldSvc.Spec.Ports = []core.ServicePort{{Name: "a", Port: 443, TargetPort: intstr.FromInt(3000), Protocol: "TCP", AppProtocol: utilpointer.StringPtr("http")}}
 				newSvc.Spec.Ports = []core.ServicePort{{Name: "a", Port: 443, TargetPort: intstr.FromInt(3000), Protocol: "TCP", AppProtocol: utilpointer.StringPtr("https")}}
 			},
 			numErrs: 0,
 		},
 		{
-			name: "update to valid app protocol, gate enabled",
-			tweakSvc: func(oldSvc, newSvc *core.Service) {
-				oldSvc.Spec.Ports = []core.ServicePort{{Name: "a", Port: 443, TargetPort: intstr.FromInt(3000), Protocol: "TCP"}}
-				newSvc.Spec.Ports = []core.ServicePort{{Name: "a", Port: 443, TargetPort: intstr.FromInt(3000), Protocol: "TCP", AppProtocol: utilpointer.StringPtr("https")}}
-			},
-			appProtocolEnabled: true,
-			numErrs:            0,
-		},
-		{
-			name: "update to invalid app protocol, gate enabled",
+			name: "update to invalid app protocol",
 			tweakSvc: func(oldSvc, newSvc *core.Service) {
 				oldSvc.Spec.Ports = []core.ServicePort{{Name: "a", Port: 443, TargetPort: intstr.FromInt(3000), Protocol: "TCP"}}
 				newSvc.Spec.Ports = []core.ServicePort{{Name: "a", Port: 443, TargetPort: intstr.FromInt(3000), Protocol: "TCP", AppProtocol: utilpointer.StringPtr("~https")}}
 			},
-			appProtocolEnabled: true,
-			numErrs:            1,
+			numErrs: 1,
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.ServiceAppProtocol, tc.appProtocolEnabled)()
-
 			oldSvc := makeValidService()
 			newSvc := makeValidService()
 			tc.tweakSvc(&oldSvc, &newSvc)
@@ -14833,8 +14805,7 @@ func TestValidateSSHAuthSecret(t *testing.T) {
 
 func TestValidateEndpointsCreate(t *testing.T) {
 	successCases := map[string]struct {
-		endpoints          core.Endpoints
-		appProtocolEnabled bool
+		endpoints core.Endpoints
 	}{
 		"simple endpoint": {
 			endpoints: core.Endpoints{
@@ -14877,7 +14848,6 @@ func TestValidateEndpointsCreate(t *testing.T) {
 					},
 				},
 			},
-			appProtocolEnabled: true,
 		},
 		"empty ports": {
 			endpoints: core.Endpoints{
@@ -14893,7 +14863,6 @@ func TestValidateEndpointsCreate(t *testing.T) {
 
 	for name, tc := range successCases {
 		t.Run(name, func(t *testing.T) {
-			defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.ServiceAppProtocol, tc.appProtocolEnabled)()
 			errs := ValidateEndpointsCreate(&tc.endpoints)
 			if len(errs) != 0 {
 				t.Errorf("Expected no validation errors, got %v", errs)
@@ -14903,10 +14872,9 @@ func TestValidateEndpointsCreate(t *testing.T) {
 	}
 
 	errorCases := map[string]struct {
-		endpoints          core.Endpoints
-		appProtocolEnabled bool
-		errorType          field.ErrorType
-		errorDetail        string
+		endpoints   core.Endpoints
+		errorType   field.ErrorType
+		errorDetail string
 	}{
 		"missing namespace": {
 			endpoints: core.Endpoints{ObjectMeta: metav1.ObjectMeta{Name: "mysvc"}},
@@ -15074,15 +15042,13 @@ func TestValidateEndpointsCreate(t *testing.T) {
 					},
 				},
 			},
-			appProtocolEnabled: true,
-			errorType:          "FieldValueInvalid",
-			errorDetail:        "name part must consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character",
+			errorType:   "FieldValueInvalid",
+			errorDetail: "name part must consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character",
 		},
 	}
 
 	for k, v := range errorCases {
 		t.Run(k, func(t *testing.T) {
-			defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.ServiceAppProtocol, v.appProtocolEnabled)()
 			if errs := ValidateEndpointsCreate(&v.endpoints); len(errs) == 0 || errs[0].Type != v.errorType || !strings.Contains(errs[0].Detail, v.errorDetail) {
 				t.Errorf("Expected error type %s with detail %q, got %v", v.errorType, v.errorDetail, errs)
 			}
@@ -15099,54 +15065,32 @@ func TestValidateEndpointsUpdate(t *testing.T) {
 	}
 
 	testCases := map[string]struct {
-		tweakOldEndpoints  func(ep *core.Endpoints)
-		tweakNewEndpoints  func(ep *core.Endpoints)
-		appProtocolEnabled bool
-		numExpectedErrors  int
+		tweakOldEndpoints func(ep *core.Endpoints)
+		tweakNewEndpoints func(ep *core.Endpoints)
+		numExpectedErrors int
 	}{
-		"update with valid app protocol, field unset, gate not enabled": {
+		"update to valid app protocol": {
 			tweakOldEndpoints: func(ep *core.Endpoints) {
 				ep.Subsets[0].Ports = []core.EndpointPort{{Name: "a", Port: 8675, Protocol: "TCP"}}
-			},
-			tweakNewEndpoints: func(ep *core.Endpoints) {
-				ep.Subsets[0].Ports = []core.EndpointPort{{Name: "a", Port: 8675, Protocol: "TCP", AppProtocol: utilpointer.StringPtr("https")}}
-			},
-			numExpectedErrors: 1,
-		},
-		"update with valid app protocol, field set, gate not enabled": {
-			tweakOldEndpoints: func(ep *core.Endpoints) {
-				ep.Subsets[0].Ports = []core.EndpointPort{{Name: "a", Port: 8675, Protocol: "TCP", AppProtocol: utilpointer.StringPtr("http")}}
 			},
 			tweakNewEndpoints: func(ep *core.Endpoints) {
 				ep.Subsets[0].Ports = []core.EndpointPort{{Name: "a", Port: 8675, Protocol: "TCP", AppProtocol: utilpointer.StringPtr("https")}}
 			},
 			numExpectedErrors: 0,
 		},
-		"update to valid app protocol, gate enabled": {
-			tweakOldEndpoints: func(ep *core.Endpoints) {
-				ep.Subsets[0].Ports = []core.EndpointPort{{Name: "a", Port: 8675, Protocol: "TCP"}}
-			},
-			tweakNewEndpoints: func(ep *core.Endpoints) {
-				ep.Subsets[0].Ports = []core.EndpointPort{{Name: "a", Port: 8675, Protocol: "TCP", AppProtocol: utilpointer.StringPtr("https")}}
-			},
-			appProtocolEnabled: true,
-			numExpectedErrors:  0,
-		},
-		"update to invalid app protocol, gate enabled": {
+		"update to invalid app protocol": {
 			tweakOldEndpoints: func(ep *core.Endpoints) {
 				ep.Subsets[0].Ports = []core.EndpointPort{{Name: "a", Port: 8675, Protocol: "TCP"}}
 			},
 			tweakNewEndpoints: func(ep *core.Endpoints) {
 				ep.Subsets[0].Ports = []core.EndpointPort{{Name: "a", Port: 8675, Protocol: "TCP", AppProtocol: utilpointer.StringPtr("~https")}}
 			},
-			appProtocolEnabled: true,
-			numExpectedErrors:  1,
+			numExpectedErrors: 1,
 		},
 	}
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.ServiceAppProtocol, tc.appProtocolEnabled)()
 			oldEndpoints := baseEndpoints.DeepCopy()
 			tc.tweakOldEndpoints(oldEndpoints)
 			newEndpoints := baseEndpoints.DeepCopy()
@@ -15696,7 +15640,7 @@ func TestEndpointAddressNodeNameUpdateRestrictions(t *testing.T) {
 	updatedEndpoint := newNodeNameEndpoint("kubernetes-changed-nodename")
 	// Check that NodeName can be changed during update, this is to accommodate the case where nodeIP or PodCIDR is reused.
 	// The same ip will now have a different nodeName.
-	errList := ValidateEndpoints(updatedEndpoint, false)
+	errList := ValidateEndpoints(updatedEndpoint)
 	errList = append(errList, ValidateEndpointsUpdate(updatedEndpoint, oldEndpoint)...)
 	if len(errList) != 0 {
 		t.Error("Endpoint should allow changing of Subset.Addresses.NodeName on update")
@@ -15706,7 +15650,7 @@ func TestEndpointAddressNodeNameUpdateRestrictions(t *testing.T) {
 func TestEndpointAddressNodeNameInvalidDNSSubdomain(t *testing.T) {
 	// Check NodeName DNS validation
 	endpoint := newNodeNameEndpoint("illegal*.nodename")
-	errList := ValidateEndpoints(endpoint, false)
+	errList := ValidateEndpoints(endpoint)
 	if len(errList) == 0 {
 		t.Error("Endpoint should reject invalid NodeName")
 	}
@@ -15714,7 +15658,7 @@ func TestEndpointAddressNodeNameInvalidDNSSubdomain(t *testing.T) {
 
 func TestEndpointAddressNodeNameCanBeAnIPAddress(t *testing.T) {
 	endpoint := newNodeNameEndpoint("10.10.1.1")
-	errList := ValidateEndpoints(endpoint, false)
+	errList := ValidateEndpoints(endpoint)
 	if len(errList) != 0 {
 		t.Error("Endpoint should accept a NodeName that is an IP address")
 	}

--- a/pkg/controller/endpoint/endpoints_controller.go
+++ b/pkg/controller/endpoint/endpoints_controller.go
@@ -639,12 +639,10 @@ func shouldPodBeInEndpoints(pod *v1.Pod) bool {
 
 func endpointPortFromServicePort(servicePort *v1.ServicePort, portNum int) *v1.EndpointPort {
 	epp := &v1.EndpointPort{
-		Name:     servicePort.Name,
-		Port:     int32(portNum),
-		Protocol: servicePort.Protocol,
-	}
-	if utilfeature.DefaultFeatureGate.Enabled(features.ServiceAppProtocol) {
-		epp.AppProtocol = servicePort.AppProtocol
+		Name:        servicePort.Name,
+		Port:        int32(portNum),
+		Protocol:    servicePort.Protocol,
+		AppProtocol: servicePort.AppProtocol,
 	}
 	return epp
 }

--- a/pkg/controller/endpoint/endpoints_controller_test.go
+++ b/pkg/controller/endpoint/endpoints_controller_test.go
@@ -1984,27 +1984,14 @@ func TestSyncEndpointsServiceNotFound(t *testing.T) {
 func TestEndpointPortFromServicePort(t *testing.T) {
 	http := utilpointer.StringPtr("http")
 	testCases := map[string]struct {
-		featureGateEnabled           bool
 		serviceAppProtocol           *string
 		expectedEndpointsAppProtocol *string
 	}{
-		"feature gate disabled, empty app protocol": {
-			featureGateEnabled:           false,
+		"empty app protocol": {
 			serviceAppProtocol:           nil,
 			expectedEndpointsAppProtocol: nil,
 		},
-		"feature gate disabled, http app protocol": {
-			featureGateEnabled:           false,
-			serviceAppProtocol:           http,
-			expectedEndpointsAppProtocol: nil,
-		},
-		"feature gate enabled, empty app protocol": {
-			featureGateEnabled:           true,
-			serviceAppProtocol:           nil,
-			expectedEndpointsAppProtocol: nil,
-		},
-		"feature gate enabled, http app protocol": {
-			featureGateEnabled:           true,
+		"http app protocol": {
 			serviceAppProtocol:           http,
 			expectedEndpointsAppProtocol: http,
 		},
@@ -2012,8 +1999,6 @@ func TestEndpointPortFromServicePort(t *testing.T) {
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.ServiceAppProtocol, tc.featureGateEnabled)()
-
 			epp := endpointPortFromServicePort(&v1.ServicePort{Name: "test", AppProtocol: tc.serviceAppProtocol}, 80)
 
 			if epp.AppProtocol != tc.expectedEndpointsAppProtocol {

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -576,6 +576,7 @@ const (
 	// owner: @robscott
 	// alpha: v1.18
 	// beta:  v1.19
+	// ga:    v1.20
 	//
 	// Enables AppProtocol field for Services and Endpoints.
 	ServiceAppProtocol featuregate.Feature = "ServiceAppProtocol"
@@ -755,7 +756,7 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 	AllowInsecureBackendProxy:                      {Default: true, PreRelease: featuregate.Beta},
 	PodDisruptionBudget:                            {Default: true, PreRelease: featuregate.Beta},
 	ServiceTopology:                                {Default: false, PreRelease: featuregate.Alpha},
-	ServiceAppProtocol:                             {Default: true, PreRelease: featuregate.Beta},
+	ServiceAppProtocol:                             {Default: true, PreRelease: featuregate.GA, LockToDefault: true},
 	ImmutableEphemeralVolumes:                      {Default: true, PreRelease: featuregate.Beta},
 	HugePageStorageMediumSize:                      {Default: true, PreRelease: featuregate.Beta},
 	ExternalPolicyForExternalIP:                    {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.22


### PR DESCRIPTION
**What type of PR is this?**
/kind feature
/kind api-change

**What this PR does / why we need it**:
This graduates the AppProtocol field on Services and Endpoints to GA.

**Does this PR introduce a user-facing change?**:
```release-note
AppProtocol is now GA for Endpoints and Services. The ServiceAppProtocol feature gate will be deprecated in 1.21.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
Enhancement Issue: https://github.com/kubernetes/enhancements/issues/1507

/sig network
/cc @bowei 
/assign @thockin 
/priority important-soon