### PR TITLE
Storage testsuite redesign & cleanup

### DIFF
--- a/test/e2e/storage/csi_volumes.go
+++ b/test/e2e/storage/csi_volumes.go
@@ -37,7 +37,7 @@ var _ = utils.SIGDescribe("CSI Volumes", func() {
 		curDriver := initDriver()
 
 		ginkgo.Context(testsuites.GetDriverNameWithFeatureTags(curDriver), func() {
-			testsuites.DefineTestSuite(curDriver, testsuites.CSISuites)
+			testsuites.DefineTestSuites(curDriver, testsuites.CSISuites)
 		})
 	}
 })

--- a/test/e2e/storage/external/external.go
+++ b/test/e2e/storage/external/external.go
@@ -167,7 +167,7 @@ func AddDriverDefinition(filename string) error {
 
 	description := "External Storage " + testsuites.GetDriverNameWithFeatureTags(driver)
 	ginkgo.Describe(description, func() {
-		testsuites.DefineTestSuite(driver, testsuites.CSISuites)
+		testsuites.DefineTestSuites(driver, testsuites.CSISuites)
 	})
 
 	return nil

--- a/test/e2e/storage/external/testdata/example.yaml
+++ b/test/e2e/storage/external/testdata/example.yaml
@@ -1,0 +1,19 @@
+StorageClass:
+  FromExistingClassName: example
+DriverInfo:
+  Name: example
+  RequiredAccessModes:
+  - ReadWriteOnce
+  Capabilities:
+    persistence: true
+    multipods: true
+    exec: true
+    block: true
+    fsGroup: true
+    topology: true
+    controllerExpansion: true
+    nodeExpansion: true
+    volumeLimits: false
+  StressTestOptions:
+    NumPods: 10
+    NumRestarts: 20

--- a/test/e2e/storage/in_tree_volumes.go
+++ b/test/e2e/storage/in_tree_volumes.go
@@ -54,7 +54,7 @@ var _ = utils.SIGDescribe("In-tree Volumes", func() {
 		curDriver := initDriver()
 
 		ginkgo.Context(testsuites.GetDriverNameWithFeatureTags(curDriver), func() {
-			testsuites.DefineTestSuite(curDriver, testsuites.BaseSuites)
+			testsuites.DefineTestSuites(curDriver, testsuites.BaseSuites)
 		})
 	}
 })

--- a/test/e2e/storage/testsuites/api_test.go
+++ b/test/e2e/storage/testsuites/api_test.go
@@ -31,10 +31,15 @@ import (
 	"k8s.io/kubernetes/test/e2e/storage/testsuites"
 )
 
+// test suite will have to explicitly set TestSuiteInterface in their stuct.
+// In order to define tests, they will have to use TestSuiteHandler
 type fakeSuite struct {
+	testsuites.TestSuiteInterface
 }
 
-func (f *fakeSuite) GetTestSuiteInfo() testsuites.TestSuiteInfo {
+//lint:ignore U1000 we dont need this to be called because the custom volume test suite
+// defined below compile is the test.
+func (f *fakeSuite) getTestSuiteInfo() testsuites.TestSuiteInfo {
 	return testsuites.TestSuiteInfo{
 		Name:               "fake",
 		FeatureTag:         "",
@@ -43,10 +48,14 @@ func (f *fakeSuite) GetTestSuiteInfo() testsuites.TestSuiteInfo {
 	}
 }
 
-func (f *fakeSuite) DefineTests(testsuites.TestDriver, testpatterns.TestPattern) {
+//lint:ignore U1000 we dont need this to be called because the custom volume test suite
+// defined below compile is the test.
+func (f *fakeSuite) defineTests(testsuites.TestDriver, testpatterns.TestPattern) {
 }
 
-func (f *fakeSuite) SkipRedundantSuite(testsuites.TestDriver, testpatterns.TestPattern) {
+//lint:ignore U1000 we dont need this to be called because the custom volume test suite
+// defined below compile is the test.
+func (f *fakeSuite) skipUnsupportedTests(testsuites.TestDriver, testpatterns.TestPattern) {
 }
 
-var _ testsuites.TestSuite = &fakeSuite{}
+var _ testsuites.TestSuiteInterface = &fakeSuite{}

--- a/test/e2e/storage/testsuites/disruptive.go
+++ b/test/e2e/storage/testsuites/disruptive.go
@@ -25,43 +25,52 @@ import (
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 	e2epv "k8s.io/kubernetes/test/e2e/framework/pv"
-	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
 	"k8s.io/kubernetes/test/e2e/storage/testpatterns"
 	"k8s.io/kubernetes/test/e2e/storage/utils"
 )
 
 type disruptiveTestSuite struct {
+	TestSuiteInterface
 	tsInfo TestSuiteInfo
 }
 
-var _ TestSuite = &disruptiveTestSuite{}
-
-// InitDisruptiveTestSuite returns subPathTestSuite that implements TestSuite interface
-func InitDisruptiveTestSuite() TestSuite {
-	return &disruptiveTestSuite{
-		tsInfo: TestSuiteInfo{
-			Name:       "disruptive",
-			FeatureTag: "[Disruptive][LinuxOnly]",
-			TestPatterns: []testpatterns.TestPattern{
-				// FSVolMode is already covered in subpath testsuite
-				testpatterns.DefaultFsInlineVolume,
-				testpatterns.FsVolModePreprovisionedPV,
-				testpatterns.FsVolModeDynamicPV,
-				testpatterns.BlockVolModePreprovisionedPV,
-				testpatterns.BlockVolModeDynamicPV,
+// InitCustomDisruptiveTestSuite returns subPathTestSuite that implements TestSuite interface
+// using custom test patterns
+func InitCustomDisruptiveTestSuite(patterns []testpatterns.TestPattern) TestSuiteHandler {
+	return TestSuiteHandler{
+		testSuite: &disruptiveTestSuite{
+			tsInfo: TestSuiteInfo{
+				Name:         "disruptive",
+				FeatureTag:   "[Disruptive][LinuxOnly]",
+				TestPatterns: patterns,
 			},
 		},
 	}
 }
-func (s *disruptiveTestSuite) GetTestSuiteInfo() TestSuiteInfo {
+
+// InitDisruptiveTestSuite returns subPathTestSuite that implements TestSuite interface
+// using test suite default patterns
+func InitDisruptiveTestSuite() TestSuiteHandler {
+	testPatterns := []testpatterns.TestPattern{
+		// FSVolMode is already covered in subpath testsuite
+		testpatterns.DefaultFsInlineVolume,
+		testpatterns.FsVolModePreprovisionedPV,
+		testpatterns.FsVolModeDynamicPV,
+		testpatterns.BlockVolModePreprovisionedPV,
+		testpatterns.BlockVolModeDynamicPV,
+	}
+	return InitCustomDisruptiveTestSuite(testPatterns)
+}
+
+func (s *disruptiveTestSuite) getTestSuiteInfo() TestSuiteInfo {
 	return s.tsInfo
 }
 
-func (s *disruptiveTestSuite) SkipRedundantSuite(driver TestDriver, pattern testpatterns.TestPattern) {
+func (s *disruptiveTestSuite) skipUnsupportedTests(driver TestDriver, pattern testpatterns.TestPattern) {
 	skipVolTypePatterns(pattern, driver, testpatterns.NewVolTypeMap(testpatterns.PreprovisionedPV))
 }
 
-func (s *disruptiveTestSuite) DefineTests(driver TestDriver, pattern testpatterns.TestPattern) {
+func (s *disruptiveTestSuite) defineTests(driver TestDriver, pattern testpatterns.TestPattern) {
 	type local struct {
 		config        *PerTestConfig
 		driverCleanup func()
@@ -75,11 +84,7 @@ func (s *disruptiveTestSuite) DefineTests(driver TestDriver, pattern testpattern
 	}
 	var l local
 
-	// No preconditions to test. Normally they would be in a BeforeEach here.
-
-	// This intentionally comes after checking the preconditions because it
-	// registers its own BeforeEach which creates the namespace. Beware that it
-	// also registers an AfterEach which renders f unusable. Any code using
+	// Beware that it also registers an AfterEach which renders f unusable. Any code using
 	// f must run inside an It or Context callback.
 	f := framework.NewDefaultFramework("disruptive")
 
@@ -91,11 +96,7 @@ func (s *disruptiveTestSuite) DefineTests(driver TestDriver, pattern testpattern
 		// Now do the more expensive test initialization.
 		l.config, l.driverCleanup = driver.PrepareTest(f)
 
-		if pattern.VolMode == v1.PersistentVolumeBlock && !driver.GetDriverInfo().Capabilities[CapBlock] {
-			e2eskipper.Skipf("Driver %s doesn't support %v -- skipping", driver.GetDriverInfo().Name, pattern.VolMode)
-		}
-
-		testVolumeSizeRange := s.GetTestSuiteInfo().SupportedSizeRange
+		testVolumeSizeRange := s.getTestSuiteInfo().SupportedSizeRange
 		l.resource = CreateVolumeResource(driver, l.config, pattern, testVolumeSizeRange)
 	}
 

--- a/test/e2e/storage/testsuites/provisioning.go
+++ b/test/e2e/storage/testsuites/provisioning.go
@@ -61,36 +61,53 @@ type StorageClassTest struct {
 }
 
 type provisioningTestSuite struct {
+	TestSuiteInterface
 	tsInfo TestSuiteInfo
 }
 
-var _ TestSuite = &provisioningTestSuite{}
-
-// InitProvisioningTestSuite returns provisioningTestSuite that implements TestSuite interface
-func InitProvisioningTestSuite() TestSuite {
-	return &provisioningTestSuite{
-		tsInfo: TestSuiteInfo{
-			Name: "provisioning",
-			TestPatterns: []testpatterns.TestPattern{
-				testpatterns.DefaultFsDynamicPV,
-				testpatterns.BlockVolModeDynamicPV,
-				testpatterns.NtfsDynamicPV,
-			},
-			SupportedSizeRange: e2evolume.SizeRange{
-				Min: "1Mi",
+// InitCustomProvisioningTestSuite returns provisioningTestSuite that implements TestSuite interface
+// using custom test patterns
+func InitCustomProvisioningTestSuite(patterns []testpatterns.TestPattern) TestSuiteHandler {
+	return TestSuiteHandler{
+		testSuite: &provisioningTestSuite{
+			tsInfo: TestSuiteInfo{
+				Name:         "provisioning",
+				TestPatterns: patterns,
+				SupportedSizeRange: e2evolume.SizeRange{
+					Min: "1Mi",
+				},
 			},
 		},
 	}
 }
 
-func (p *provisioningTestSuite) GetTestSuiteInfo() TestSuiteInfo {
+// InitProvisioningTestSuite returns provisioningTestSuite that implements TestSuite interface\
+// using test suite default patterns
+func InitProvisioningTestSuite() TestSuiteHandler {
+	patterns := []testpatterns.TestPattern{
+		testpatterns.DefaultFsDynamicPV,
+		testpatterns.BlockVolModeDynamicPV,
+		testpatterns.NtfsDynamicPV,
+	}
+	return InitCustomProvisioningTestSuite(patterns)
+}
+
+func (p *provisioningTestSuite) getTestSuiteInfo() TestSuiteInfo {
 	return p.tsInfo
 }
 
-func (p *provisioningTestSuite) SkipRedundantSuite(driver TestDriver, pattern testpatterns.TestPattern) {
+func (p *provisioningTestSuite) skipUnsupportedTests(driver TestDriver, pattern testpatterns.TestPattern) {
+	// Check preconditions.
+	if pattern.VolType != testpatterns.DynamicPV {
+		e2eskipper.Skipf("Suite %q does not support %v", p.tsInfo.Name, pattern.VolType)
+	}
+	dInfo := driver.GetDriverInfo()
+	if pattern.VolMode == v1.PersistentVolumeBlock && !dInfo.Capabilities[CapBlock] {
+		e2eskipper.Skipf("Driver %s doesn't support %v -- skipping", dInfo.Name, pattern.VolMode)
+	}
 }
 
-func (p *provisioningTestSuite) DefineTests(driver TestDriver, pattern testpatterns.TestPattern) {
+func (p *provisioningTestSuite) defineTests(driver TestDriver, pattern testpatterns.TestPattern) {
 	type local struct {
 		config        *PerTestConfig
 		driverCleanup func()
@@ -109,36 +126,18 @@ func (p *provisioningTestSuite) DefineTests(driver TestDriver, pattern testpatte
 		l       local
 	)
 
-	ginkgo.BeforeEach(func() {
-		// Check preconditions.
-		if pattern.VolType != testpatterns.DynamicPV {
-			e2eskipper.Skipf("Suite %q does not support %v", p.tsInfo.Name, pattern.VolType)
-		}
-		if pattern.VolMode == v1.PersistentVolumeBlock && !dInfo.Capabilities[CapBlock] {
-			e2eskipper.Skipf("Driver %q does not support block volumes - skipping", dInfo.Name)
-		}
-
-		ok := false
-		dDriver, ok = driver.(DynamicPVTestDriver)
-		if !ok {
-			e2eskipper.Skipf("Driver %s doesn't support %v -- skipping", dInfo.Name, pattern.VolType)
-		}
-	})
-
-	// This intentionally comes after checking the preconditions because it
-	// registers its own BeforeEach which creates the namespace. Beware that it
-	// also registers an AfterEach which renders f unusable. Any code using
+	// Beware that it also registers an AfterEach which renders f unusable. Any code using
 	// f must run inside an It or Context callback.
 	f := framework.NewDefaultFramework("provisioning")
 
 	init := func() {
 		l = local{}
-
+		dDriver, _ = driver.(DynamicPVTestDriver)
 		// Now do the more expensive test initialization.
 		l.config, l.driverCleanup = driver.PrepareTest(f)
 		l.migrationCheck = newMigrationOpCheck(f.ClientSet, dInfo.InTreePluginName)
 		l.cs = l.config.Framework.ClientSet
-		testVolumeSizeRange := p.GetTestSuiteInfo().SupportedSizeRange
+		testVolumeSizeRange := p.getTestSuiteInfo().SupportedSizeRange
 		driverVolumeSizeRange := dDriver.GetDriverInfo().SupportedSizeRange
 		claimSize, err := getSizeRangesIntersection(testVolumeSizeRange, driverVolumeSizeRange)
 		framework.ExpectNoError(err, "determine intersection of test size range %+v and driver size range %+v", testVolumeSizeRange, driverVolumeSizeRange)


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
1. Refactor of testsuite. Define the TestSuite interface in a way that
caller has to use a new Handler called TestSuiteHandler to actually
register tests. The advantage is that we will now have a guaranteed
`SkipInvalidDriverPatternCombination()` and `skipUnsupportedTests()` function
called before all the Specs are defined. 

2. Add a `InitCustomXXXTestSuite(patterns []testpattern.TestPattern)` function for each TestSuite to enable custom testsuite creation.

3. Cleanup all the `f.BeforeEach()` before new framework creation.

New TestSuite interface looks like this:
```golang
type TestSuiteInterface interface {
	getTestSuiteInfo() TestSuiteInfo
	// defineTests defines tests of the testpattern for the driver.
	// Called inside a Ginkgo context that reflects the current driver and test pattern,
	// so the test suite can define tests directly with ginkgo.It.
	defineTests(TestDriver, testpatterns.TestPattern)
	// skipUnsupportedTests will skip the test suite based on the given TestPattern, TestDriver
	// Testsuite should check if the given pattern and driver works for the "whole testsuite"
	// Testcase specific check should happen inside defineTests
	skipUnsupportedTests(TestDriver, testpatterns.TestPattern)
}
```
The functions are made explicitly only have package access so that other callers will have to use TestSuiteHandler. And the TestSuiteHandler which is actually the handler that can DefineTests looks like this:
```golang
type TestSuiteHandler struct {
	testSuite TestSuiteInterface
}

// GetTestSuiteInfo returns the TestSuiteInfo for a given testsuite wrapper
func (h *TestSuiteHandler) GetTestSuiteInfo() TestSuiteInfo {
	return h.testSuite.getTestSuiteInfo()
}

// RegisterTests register the driver + pattern combination to the inside TestSuite
// This function actually register tests inside testsuite
func (h *TestSuiteHandler) RegisterTests(driver TestDriver, pattern testpatterns.TestPattern) {
        ginkgo.Context(getTestNameStr(h, pattern), func() {
		ginkgo.BeforeEach(func() {
			// skip all the invalid combination of driver and pattern first
			SkipInvalidDriverPatternCombination(driver, pattern)
			// skip the invalid test pattern and driver combination
			h.testSuite.skipUnsupportedTests(driver, pattern)
		})
		// actually define the tests
		// at this step the testsuite should not worry about if the pattern and driver
		// does not fit for the whole testsuite. But driver&pattern check
		// might still needed for specific independent test cases.
		h.testSuite.defineTests(driver, pattern)
	})
}
```

By doing it this way, we can guarantee invalid pattern&driver combination is filtered both globally and in each testsuite before any Spec defined.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```

/sig storage
/sig testing
/cc @msau42 
/cc @jingxu97 
/cc @gnufied 
