### PR TITLE
ensure /etc/hosts file permission 644 so that non-root application ca…

### DIFF
--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -334,7 +334,14 @@ func ensureHostsFile(fileName string, hostIPs []string, hostName, hostDomainName
 		hostsFileContent = managedHostsFileContent(hostIPs, hostName, hostDomainName, hostAliases)
 	}
 
-	return ioutil.WriteFile(fileName, hostsFileContent, 0644)
+	oldMask, err := util.Umask(0)
+	if err != nil {
+		klog.Warning("failed to reset umask to zero, %v", err)
+	}
+
+	err = ioutil.WriteFile(fileName, hostsFileContent, 0644)
+	util.Umask(oldMask)
+	return err
 }
 
 // nodeHostsFileContent reads the content of node's hosts file.

--- a/pkg/kubelet/util/util_unix.go
+++ b/pkg/kubelet/util/util_unix.go
@@ -152,3 +152,8 @@ func IsUnixDomainSocket(filePath string) (bool, error) {
 func NormalizePath(path string) string {
 	return path
 }
+
+// Umask is a wrapper for `unix.Umask()` on non-Windows platforms
+func Umask(mask int) (old int, err error) {
+	return unix.Umask(mask), nil
+}

--- a/pkg/kubelet/util/util_unsupported.go
+++ b/pkg/kubelet/util/util_unsupported.go
@@ -53,3 +53,8 @@ func LocalEndpoint(path, file string) (string, error) {
 func GetBootTime() (time.Time, error) {
 	return time.Time{}, fmt.Errorf("GetBootTime is unsupported in this build")
 }
+
+// Umask empty implementation
+func Umask(mask int) (old int, err error) {
+	return 0, fmt.Errorf("platform and architecture is not supported")
+}

--- a/pkg/kubelet/util/util_windows.go
+++ b/pkg/kubelet/util/util_windows.go
@@ -152,3 +152,8 @@ func NormalizePath(path string) string {
 	}
 	return path
 }
+
+// Umask returns an error on Windows
+func Umask(mask int) (old int, err error) {
+	return 0, fmt.Errorf("platform and architecture is not supported")
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Reset umask before write /etc/hosts file so that the file can have the right permission. And then ,restore the old mask.
**Which issue(s) this PR fixes**:
Fixes #96342

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
NONE

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
