### PR TITLE
kubelet: add AppArmor profile values to CRI

### DIFF
--- a/pkg/kubelet/kuberuntime/security_context.go
+++ b/pkg/kubelet/kuberuntime/security_context.go
@@ -42,6 +42,7 @@ func (m *kubeGenericRuntimeManager) determineEffectiveSecurityContext(pod *v1.Po
 
 	// set ApparmorProfile.
 	synthesized.ApparmorProfile = apparmor.GetProfileNameFromPodAnnotations(pod.Annotations, container.Name)
+	synthesized.Apparmor = apparmor.GetProfile(pod.Annotations, container.Name)
 
 	// set RunAsUser.
 	if synthesized.RunAsUser == nil {

--- a/pkg/security/apparmor/helpers_test.go
+++ b/pkg/security/apparmor/helpers_test.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apparmor
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	v1 "k8s.io/api/core/v1"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+)
+
+func TestGetProfile(t *testing.T) {
+	for _, tc := range []struct {
+		annotations   map[string]string
+		containerName string
+		expected      *runtimeapi.SecurityProfile
+	}{
+		{ // No annotation
+			annotations: map[string]string{},
+			expected: &runtimeapi.SecurityProfile{
+				ProfileType: runtimeapi.SecurityProfile_Unconfined,
+			},
+		},
+		{ // Unconfined
+			annotations: map[string]string{
+				v1.AppArmorBetaContainerAnnotationKeyPrefix + "ctr": v1.AppArmorBetaProfileNameUnconfined,
+			},
+			containerName: "ctr",
+			expected: &runtimeapi.SecurityProfile{
+				ProfileType: runtimeapi.SecurityProfile_Unconfined,
+			},
+		},
+		{ // RuntimeDefault
+			annotations: map[string]string{
+				v1.AppArmorBetaContainerAnnotationKeyPrefix + "ctr": v1.AppArmorBetaProfileRuntimeDefault,
+			},
+			containerName: "ctr",
+			expected: &runtimeapi.SecurityProfile{
+				ProfileType: runtimeapi.SecurityProfile_RuntimeDefault,
+			},
+		},
+		{ // Localhost
+			annotations: map[string]string{
+				v1.AppArmorBetaContainerAnnotationKeyPrefix + "ctr": "some-profile",
+			},
+			containerName: "ctr",
+			expected: &runtimeapi.SecurityProfile{
+				ProfileType:  runtimeapi.SecurityProfile_Localhost,
+				LocalhostRef: "some-profile",
+			},
+		},
+	} {
+		res := GetProfile(tc.annotations, tc.containerName)
+		require.Equal(t, tc.expected, res)
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

To make the new AppArmor profile fields work in the CRI, we now extract
them from the pod annotations.

**Which issue(s) this PR fixes**:

This is a part of moving CRI to beta and a follow-up of #96281
Refers to https://github.com/kubernetes/enhancements/issues/2040

**Special notes for your reviewer**:

AppArmor profiles for Pods are right now not supported, but this will change with the graduation with AppArmor to GA:
https://github.com/kubernetes/enhancements/pull/1444

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```
