### PR TITLE
Add --experimental-logging-sanitization flag to control plane components

### DIFF
--- a/staging/src/k8s.io/component-base/logs/BUILD
+++ b/staging/src/k8s.io/component-base/logs/BUILD
@@ -17,6 +17,7 @@ go_library(
     deps = [
         "//staging/src/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//staging/src/k8s.io/component-base/logs/json:go_default_library",
+        "//staging/src/k8s.io/component-base/logs/sanitization:go_default_library",
         "//vendor/github.com/go-logr/logr:go_default_library",
         "//vendor/github.com/spf13/pflag:go_default_library",
         "//vendor/k8s.io/klog/v2:go_default_library",

--- a/staging/src/k8s.io/component-base/logs/options.go
+++ b/staging/src/k8s.io/component-base/logs/options.go
@@ -24,6 +24,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/spf13/pflag"
 
+	"k8s.io/component-base/logs/sanitization"
 	"k8s.io/klog/v2"
 )
 
@@ -40,7 +41,8 @@ var supportedLogsFlags = map[string]struct{}{
 
 // Options has klog format parameters
 type Options struct {
-	LogFormat string
+	LogFormat       string
+	LogSanitization bool
 }
 
 // NewOptions return new klog options
@@ -88,6 +90,8 @@ func (o *Options) AddFlags(fs *pflag.FlagSet) {
 
 	// No new log formats should be added after generation is of flag options
 	logRegistry.Freeze()
+	fs.BoolVar(&o.LogSanitization, "experimental-logging-sanitization", false, `[Experimental] When enabled prevents logging of fields that tagged as sensitive (passwords, keys, tokens).
+Runtime log sanitization may introduce significant computation overhead and therefore should not be enabled in production.`)
 }
 
 // Apply set klog logger from LogFormat type
@@ -95,6 +99,9 @@ func (o *Options) Apply() {
 	// if log format not exists, use nil loggr
 	loggr, _ := o.Get()
 	klog.SetLogger(loggr)
+	if o.LogSanitization {
+		klog.SetLogFilter(&sanitization.SanitizingFilter{})
+	}
 }
 
 // Get logger with LogFormat field

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -2206,8 +2206,10 @@ k8s.io/component-base/configz
 k8s.io/component-base/featuregate
 k8s.io/component-base/featuregate/testing
 k8s.io/component-base/logs
+k8s.io/component-base/logs/datapol
 k8s.io/component-base/logs/json
 k8s.io/component-base/logs/logreduction
+k8s.io/component-base/logs/sanitization
 k8s.io/component-base/metrics
 k8s.io/component-base/metrics/legacyregistry
 k8s.io/component-base/metrics/prometheus/clientgo


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

Adds --logging-sanitization flag to control plane components.


```release-note
Add --experimental-logging-sanitization flag enabling runtime protection from leaking sensitive data in logs
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs
- [KEP]: https://github.com/kubernetes/enhancements/tree/59e5c698639a8489ee3808c13fc9526f746c5fc4/keps/sig-instrumentation/1753-logs-sanitization
```

/assign @44past4
/sig instrumentation
/milestone v1.20
/priority important-soon