### PR TITLE
Add --experimental-logging-sanitization flag to kubelet

### DIFF
--- a/cmd/kubelet/app/options/options.go
+++ b/cmd/kubelet/app/options/options.go
@@ -544,6 +544,8 @@ func AddKubeletConfigFlags(mainfs *pflag.FlagSet, c *kubeletconfig.KubeletConfig
 	fs.StringVar(&c.SystemReservedCgroup, "system-reserved-cgroup", c.SystemReservedCgroup, "Absolute name of the top level cgroup that is used to manage non-kubernetes components for which compute resources were reserved via '--system-reserved' flag. Ex. '/system-reserved'. [default='']")
 	fs.StringVar(&c.KubeReservedCgroup, "kube-reserved-cgroup", c.KubeReservedCgroup, "Absolute name of the top level cgroup that is used to manage kubernetes components for which compute resources were reserved via '--kube-reserved' flag. Ex. '/kube-reserved'. [default='']")
 	fs.StringVar(&c.Logging.Format, "logging-format", c.Logging.Format, `Sets the log format. Permitted formats: "text", "json".\nNon-default formats don't honor these flags: -add_dir_header, --alsologtostderr, --log_backtrace_at, --log_dir, --log_file, --log_file_max_size, --logtostderr, --skip_headers, --skip_log_headers, --stderrthreshold, --log-flush-frequency.\nNon-default choices are currently alpha and subject to change without warning.`)
+	fs.BoolVar(&c.Logging.Sanitization, "experimental-logging-sanitization", c.Logging.Sanitization, `[Experimental] When enabled prevents logging of fields tagged as sensitive (passwords, keys, tokens).
+Runtime log sanitization may introduce significant computation overhead and therefore should not be enabled in production.`)
 
 	// Graduated experimental flags, kept for backward compatibility
 	fs.BoolVar(&c.KernelMemcgNotification, "experimental-kernel-memcg-notification", c.KernelMemcgNotification, "Use kernelMemcgNotification configuration, this flag will be removed in 1.23.")

--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -410,6 +410,7 @@ func UnsecuredDependencies(s *options.KubeletServer, featureGate featuregate.Fea
 func Run(ctx context.Context, s *options.KubeletServer, kubeDeps *kubelet.Dependencies, featureGate featuregate.FeatureGate) error {
 	logOption := logs.NewOptions()
 	logOption.LogFormat = s.Logging.Format
+	logOption.LogSanitization = s.Logging.Sanitization
 	logOption.Apply()
 	// To help debugging, immediately log version
 	klog.Infof("Version: %+v", version.Get())

--- a/pkg/kubelet/apis/config/helpers_test.go
+++ b/pkg/kubelet/apis/config/helpers_test.go
@@ -184,6 +184,7 @@ var (
 		"HealthzBindAddress",
 		"HealthzPort",
 		"Logging.Format",
+		"Logging.Sanitization",
 		"TLSCipherSuites[*]",
 		"TLSMinVersion",
 		"IPTablesDropBit",

--- a/staging/src/k8s.io/component-base/config/types.go
+++ b/staging/src/k8s.io/component-base/config/types.go
@@ -80,9 +80,12 @@ type DebuggingConfiguration struct {
 }
 
 // LoggingConfiguration contains logging options
+// Refer [Logs Options](https://github.com/kubernetes/component-base/blob/master/logs/options.go) for more information.
 type LoggingConfiguration struct {
 	// Format Flag specifies the structure of log messages.
 	// default value of format is `text`
-	// Refer [Logs Options](https://github.com/kubernetes/component-base/blob/master/logs/options.go) for more information.
 	Format string
+	// [Experimental] When enabled prevents logging of fields tagged as sensitive (passwords, keys, tokens).
+	// Runtime log sanitization may introduce significant computation overhead and therefore should not be enabled in production.`)
+	Sanitization bool
 }

--- a/staging/src/k8s.io/component-base/config/v1alpha1/types.go
+++ b/staging/src/k8s.io/component-base/config/v1alpha1/types.go
@@ -82,9 +82,12 @@ type ClientConnectionConfiguration struct {
 }
 
 // LoggingConfiguration contains logging options
+// Refer [Logs Options](https://github.com/kubernetes/component-base/blob/master/logs/options.go) for more information.
 type LoggingConfiguration struct {
 	// Format Flag specifies the structure of log messages.
 	// default value of format is `text`
-	// Refer [Logs Options](https://github.com/kubernetes/component-base/blob/master/logs/options.go) for more information.
 	Format string `json:"format,omitempty"`
+	// [Experimental] When enabled prevents logging of fields tagged as sensitive (passwords, keys, tokens).
+	// Runtime log sanitization may introduce significant computation overhead and therefore should not be enabled in production.`)
+	Sanitization bool `json:"sanitization,omitempty"`
 }

--- a/staging/src/k8s.io/component-base/config/v1alpha1/zz_generated.conversion.go
+++ b/staging/src/k8s.io/component-base/config/v1alpha1/zz_generated.conversion.go
@@ -143,10 +143,12 @@ func autoConvert_config_LeaderElectionConfiguration_To_v1alpha1_LeaderElectionCo
 
 func autoConvert_v1alpha1_LoggingConfiguration_To_config_LoggingConfiguration(in *LoggingConfiguration, out *config.LoggingConfiguration, s conversion.Scope) error {
 	out.Format = in.Format
+	out.Sanitization = in.Sanitization
 	return nil
 }
 
 func autoConvert_config_LoggingConfiguration_To_v1alpha1_LoggingConfiguration(in *config.LoggingConfiguration, out *LoggingConfiguration, s conversion.Scope) error {
 	out.Format = in.Format
+	out.Sanitization = in.Sanitization
 	return nil
 }

--- a/staging/src/k8s.io/component-base/logs/options.go
+++ b/staging/src/k8s.io/component-base/logs/options.go
@@ -90,7 +90,7 @@ func (o *Options) AddFlags(fs *pflag.FlagSet) {
 
 	// No new log formats should be added after generation is of flag options
 	logRegistry.Freeze()
-	fs.BoolVar(&o.LogSanitization, "experimental-logging-sanitization", false, `[Experimental] When enabled prevents logging of fields that tagged as sensitive (passwords, keys, tokens).
+	fs.BoolVar(&o.LogSanitization, "experimental-logging-sanitization", o.LogSanitization, `[Experimental] When enabled prevents logging of fields tagged as sensitive (passwords, keys, tokens).
 Runtime log sanitization may introduce significant computation overhead and therefore should not be enabled in production.`)
 }
 


### PR DESCRIPTION
Work in progress as depends on  https://github.com/kubernetes/kubernetes/pull/96370

/kind feature

**What this PR does / why we need it**:

Adds --logging-sanitization flag to Kubelet

**Special notes for your reviewer**:

Release notes will be included in https://github.com/kubernetes/kubernetes/pull/96370

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs
https://github.com/kubernetes/enhancements/tree/59e5c698639a8489ee3808c13fc9526f746c5fc4/keps/sig-instrumentation/1753-logs-sanitization
```
/assign @44past4
/sig instrumentation
/sig node
/milestone v1.20
/priority important-soon