### PR TITLE
Create example component for integrating with component-base

### DIFF
--- a/staging/src/k8s.io/component-base/logs/example/README.md
+++ b/staging/src/k8s.io/component-base/logs/example/README.md
@@ -1,0 +1,52 @@
+# Example
+
+This directory includes example logger setup allowing users to easily check and test impact of logging configuration. 
+
+Below we can see examples of how some features work.
+
+## Default
+
+Run:
+```console
+go run ./staging/src/k8s.io/component-base/logs/example/cmd/logger.go
+```
+
+Expected output:
+```
+I0605 22:03:07.224293 3228948 logger.go:58] Log using Infof, key: value
+I0605 22:03:07.224378 3228948 logger.go:59] "Log using InfoS" key="value"
+E0605 22:03:07.224393 3228948 logger.go:61] Log using Errorf, err: fail
+E0605 22:03:07.224402 3228948 logger.go:62] "Log using ErrorS" err="fail"
+I0605 22:03:07.224407 3228948 logger.go:64] Log message has been redacted. Log argument #0 contains: [secret-key]
+```
+
+## JSON 
+
+Run:
+```console
+go run ./staging/src/k8s.io/component-base/logs/example/cmd/logger.go --logging-format json
+```
+
+Expected output:
+```
+{"ts":1622923409719.5137,"msg":"Log using Infof, key: value\n","v":0}
+{"ts":1622923409719.5403,"msg":"Log using InfoS","v":0,"key":"value"}
+{"ts":1622923409719.6025,"msg":"Log using Errorf, err: fail\n","v":0}
+{"ts":1622923409719.6077,"msg":"Log using ErrorS","err":"fail","v":0}
+{"ts":1622923409719.6467,"msg":"Log with sensitive key, data: {\"secret\"}\n","v":0}
+```
+
+## Logging sanitization
+
+```console
+go run ./staging/src/k8s.io/component-base/logs/example/cmd/logger.go --experimental-logging-sanitization
+```
+
+Expected output:
+```
+I0605 22:04:02.019609 3229645 logger.go:58] Log using Infof, key: value
+I0605 22:04:02.019677 3229645 logger.go:59] "Log using InfoS" key="value"
+E0605 22:04:02.019698 3229645 logger.go:61] Log using Errorf, err: fail
+E0605 22:04:02.019709 3229645 logger.go:62] "Log using ErrorS" err="fail"
+I0605 22:04:02.019714 3229645 logger.go:64] Log message has been redacted. Log argument #0 contains: [secret-key]
+```

--- a/staging/src/k8s.io/component-base/logs/example/cmd/logger.go
+++ b/staging/src/k8s.io/component-base/logs/example/cmd/logger.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"k8s.io/component-base/logs"
+	"k8s.io/klog/v2"
+)
+
+func main() {
+	command := NewLoggerCommand()
+	logs.InitLogs()
+	defer logs.FlushLogs()
+
+	if err := command.Execute(); err != nil {
+		os.Exit(1)
+	}
+}
+
+func NewLoggerCommand() *cobra.Command {
+	o := logs.NewOptions()
+	cmd := &cobra.Command{
+		Run: func(cmd *cobra.Command, args []string) {
+			errs := o.Validate()
+			if len(errs) != 0 {
+				fmt.Fprintf(os.Stderr, "%v\n", errs)
+				os.Exit(1)
+			}
+			o.Apply()
+			runLogger()
+		},
+	}
+	o.AddFlags(cmd.Flags())
+	return cmd
+}
+
+func runLogger() {
+	klog.Infof("Log using Infof, key: %s", "value")
+	klog.InfoS("Log using InfoS", "key", "value")
+	err := errors.New("fail")
+	klog.Errorf("Log using Errorf, err: %v", err)
+	klog.ErrorS(err, "Log using ErrorS")
+	data := SensitiveData{Key: "secret"}
+	klog.Infof("Log with sensitive key, data: %q", data)
+}
+
+type SensitiveData struct {
+	Key string `json:"key" datapolicy:"secret-key"`
+}


### PR DESCRIPTION
/cc @mtaufen 

For logging sanitization we would like to introduce tests that would verity that enabling new flag will impact logs written by component. Idea was to create very simple binary based on k8s.io/component-base, run it and check if results match. 

This PR shows example of creating example component and configuring logging options on it. As next step we would automate testing logs written possibly by running it from bazel.

Before moving forward with this example component for logging I would like to discuss this idea with component-base owners if we can expand this idea.
/cc @mtaufen 

```release-note
NONE
```