### PR TITLE
Fix command and arg in NPD e2e

### DIFF
--- a/test/e2e_node/node_problem_detector_linux.go
+++ b/test/e2e_node/node_problem_detector_linux.go
@@ -235,11 +235,37 @@ var _ = framework.KubeDescribe("NodeProblemDetector [NodeFeature:NodeProblemDete
 							},
 						},
 					},
+					InitContainers: []v1.Container{
+						{
+							Name:    "init-log-file",
+							Image:   "debian",
+							Command: []string{"/bin/sh"},
+							Args: []string{
+								"-c",
+								fmt.Sprintf("touch %s", logFile),
+							},
+							VolumeMounts: []v1.VolumeMount{
+								{
+									Name:      logVolume,
+									MountPath: path.Dir(logFile),
+								},
+								{
+									Name:      localtimeVolume,
+									MountPath: etcLocaltime,
+								},
+							},
+						},
+					},
 					Containers: []v1.Container{
 						{
 							Name:    name,
 							Image:   image,
-							Command: []string{"sh", "-c", "touch " + logFile + " && /node-problem-detector --logtostderr --system-log-monitors=" + configFile + fmt.Sprintf(" --apiserver-override=%s?inClusterConfig=true", framework.TestContext.Host)},
+							Command: []string{"/node-problem-detector"},
+							Args: []string{
+								"--logtostderr",
+								fmt.Sprintf("--system-log-monitors=%s", configFile),
+								fmt.Sprintf(" --apiserver-override=%s?inClusterConfig=true", framework.TestContext.Host),
+							},
 							Env: []v1.EnvVar{
 								{
 									Name: "NODE_NAME",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind failing-test

**What this PR does / why we need it**:

See discussion in https://github.com/kubernetes/kubernetes/pull/96262

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Not fix, but helps with #95955.

**Special notes for your reviewer**:

This PR alone won't fix the test. When https://github.com/kubernetes/kubernetes/pull/96262 is rebased on top of this, the test is green:

```
• [SLOW TEST:92.239 seconds]
[k8s.io] NodeProblemDetector [NodeFeature:NodeProblemDetector] [Serial]
/usr/local/google/home/karangoel/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:624
  [k8s.io] SystemLogMonitor
  /usr/local/google/home/karangoel/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:624
    should generate node condition and events for corresponding errors
    _output/local/go/src/k8s.io/kubernetes/test/e2e_node/node_problem_detector_linux.go:315
------------------------------
I1109 18:49:04.390509    6755 e2e_node_suite_test.go:224] Stopping node services...
I1109 18:49:04.390540    6755 server.go:257] Kill server "services"
I1109 18:49:04.390558    6755 server.go:294] Killing process 7052 (services) with -TERM
E1109 18:49:04.439423    6755 services.go:95] Failed to stop services: error stopping "services": waitid: no child processes
I1109 18:49:04.439446    6755 server.go:257] Kill server "kubelet"
I1109 18:49:04.450477    6755 services.go:156] Fetching log files...
I1109 18:49:04.450546    6755 services.go:165] Get log file "cloud-init.log" with journalctl command [-u cloud*].
I1109 18:49:04.737151    6755 services.go:165] Get log file "docker.log" with journalctl command [-u docker].
I1109 18:49:04.741245    6755 services.go:165] Get log file "containerd.log" with journalctl command [-u containerd].
I1109 18:49:04.745445    6755 services.go:165] Get log file "kubelet.log" with journalctl command [-u kubelet-20201109T104705.service].
I1109 18:49:04.773150    6755 services.go:165] Get log file "kern.log" with journalctl command [-k].
I1109 18:49:04.780138    6755 e2e_node_suite_test.go:229] Tests Finished


Ran 1 of 330 Specs in 111.176 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 329 Skipped
```

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
