### PR TITLE
Update Write AppsV1Deployment resource lifecycle test by clarifying fetch status and log messages

### DIFF
--- a/test/e2e/apps/deployment.go
+++ b/test/e2e/apps/deployment.go
@@ -356,15 +356,16 @@ var _ = SIGDescribe("Deployment", func() {
 			if deployment, ok := event.Object.(*appsv1.Deployment); ok {
 				found := deployment.ObjectMeta.Name == testDeployment.Name &&
 					deployment.ObjectMeta.Labels["test-deployment-static"] == "true" &&
-					deployment.Status.ReadyReplicas == testDeploymentDefaultReplicas
+					deployment.Status.ReadyReplicas == testDeploymentMinimumReplicas
 				if !found {
 					framework.Logf("observed Deployment %v in namespace %v with ReadyReplicas %v and labels %v", deployment.ObjectMeta.Name, deployment.ObjectMeta.Namespace, deployment.Status.ReadyReplicas, deployment.ObjectMeta.Labels)
 				}
+				framework.Logf("observed Deployment %v in namespace %v with ReadyReplicas %v and labels %v", deployment.ObjectMeta.Name, deployment.ObjectMeta.Namespace, deployment.Status.ReadyReplicas, deployment.ObjectMeta.Labels)
 				return found, nil
 			}
 			return false, nil
 		})
-		framework.ExpectNoError(err, "failed to see replicas of %v in namespace %v scale to requested amount of %v", testDeployment.Name, testNamespaceName, testDeploymentDefaultReplicas)
+		framework.ExpectNoError(err, "failed to fetch DeploymentStatus: %v in namespace %v", testDeployment.Name, testNamespaceName)
 
 		ginkgo.By("patching the DeploymentStatus")
 		deploymentStatusPatch, err := json.Marshal(map[string]interface{}{
@@ -408,16 +409,17 @@ var _ = SIGDescribe("Deployment", func() {
 			if deployment, ok := event.Object.(*appsv1.Deployment); ok {
 				found := deployment.ObjectMeta.Name == testDeployment.Name &&
 					deployment.ObjectMeta.Labels["test-deployment-static"] == "true" &&
-					deployment.Status.ReadyReplicas == testDeploymentDefaultReplicas &&
+					deployment.Status.ReadyReplicas == testDeploymentMinimumReplicas &&
 					deployment.Spec.Template.Spec.Containers[0].Image == testDeploymentUpdateImage
 				if !found {
 					framework.Logf("observed Deployment %v in namespace %v with ReadyReplicas %v", deployment.ObjectMeta.Name, deployment.ObjectMeta.Namespace, deployment.Status.ReadyReplicas)
 				}
+				framework.Logf("observed Deployment %v in namespace %v with ReadyReplicas %v", deployment.ObjectMeta.Name, deployment.ObjectMeta.Namespace, deployment.Status.ReadyReplicas)
 				return found, nil
 			}
 			return false, nil
 		})
-		framework.ExpectNoError(err, "failed to see replicas of %v in namespace %v scale to requested amount of %v", testDeployment.Name, testNamespaceName, testDeploymentDefaultReplicas)
+		framework.ExpectNoError(err, "failed to fetch DeploymentStatus: %v in namespace %v", testDeployment.Name, testNamespaceName)
 
 		ginkgo.By("deleting the Deployment")
 		err = f.ClientSet.AppsV1().Deployments(testNamespaceName).DeleteCollection(context.TODO(), metav1.DeleteOptions{GracePeriodSeconds: &zero}, metav1.ListOptions{LabelSelector: testDeploymentLabelsFlat})


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

What this PR does / why we need it:
This PR support Write AppsV1Deployment resource lifecycle test - +6 endpoint coverage [#93458](https://github.com/kubernetes/kubernetes/pull/93458)

A single flaking test run was found in the [Testgrid](https://testgrid.k8s.io/sig-apps#gce&include-filter-by-regex=Deployment&include-filter-by-regex=should%20run%20the%20lifecycle%20of%20a%20Deployment&width=5)
![image](https://user-images.githubusercontent.com/61125752/98588879-4a309680-2331-11eb-863e-8d1ca635e6a5.png)

To ensure better test stability and no flaking the "Default replicas" was changed to "Minimal Replicas" and the related log message was clarified.


**The PR Support:**
PR #93458

**Special notes for your reviewer:**
A minimal change to ensure no further flakes would occur.

**Does this PR introduce a user-facing change?:**
```
NONE
```

**Release note:**
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:**
```
NONE
```

/sig testing
/sig architecture
