### PR TITLE
Add BeginCreate and BeginUpdate REST hooks

### DIFF
--- a/pkg/registry/core/service/storage/storage_test.go
+++ b/pkg/registry/core/service/storage/storage_test.go
@@ -358,10 +358,9 @@ func TestServiceDefaultOnRead(t *testing.T) {
 	}
 
 	testCases := []struct {
-		name      string
-		input     runtime.Object
-		expectErr bool
-		expect    runtime.Object
+		name   string
+		input  runtime.Object
+		expect runtime.Object
 	}{{
 		name:   "no change v4",
 		input:  makeService(nil),
@@ -403,9 +402,8 @@ func TestServiceDefaultOnRead(t *testing.T) {
 		}),
 		expect: makeService(nil),
 	}, {
-		name:      "not Service or ServiceList",
-		input:     &api.Pod{},
-		expectErr: false,
+		name:  "not Service or ServiceList",
+		input: &api.Pod{},
 	}}
 
 	for _, tc := range testCases {
@@ -435,13 +433,7 @@ func TestServiceDefaultOnRead(t *testing.T) {
 			defer storage.Store.DestroyFunc()
 
 			tmp := tc.input.DeepCopyObject()
-			err := storage.defaultOnRead(tmp)
-			if err != nil && !tc.expectErr {
-				t.Errorf("unexpected error: %v", err)
-			}
-			if err == nil && tc.expectErr {
-				t.Errorf("unexpected success")
-			}
+			storage.defaultOnRead(tmp)
 
 			svc, ok := tmp.(*api.Service)
 			if !ok {

--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/BUILD
@@ -46,6 +46,7 @@ go_test(
         "//staging/src/k8s.io/apiserver/pkg/storage/storagebackend/factory:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/storage/testing:go_default_library",
         "//staging/src/k8s.io/client-go/tools/cache:go_default_library",
+        "//vendor/github.com/google/gofuzz:go_default_library",
     ],
 )
 

--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/decorated_watcher.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/decorated_watcher.go
@@ -21,17 +21,18 @@ import (
 	"net/http"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
 )
 
 type decoratedWatcher struct {
 	w         watch.Interface
-	decorator ObjectFunc
+	decorator func(runtime.Object)
 	cancel    context.CancelFunc
 	resultCh  chan watch.Event
 }
 
-func newDecoratedWatcher(w watch.Interface, decorator ObjectFunc) *decoratedWatcher {
+func newDecoratedWatcher(w watch.Interface, decorator func(runtime.Object)) *decoratedWatcher {
 	ctx, cancel := context.WithCancel(context.Background())
 	d := &decoratedWatcher{
 		w:         w,
@@ -56,11 +57,7 @@ func (d *decoratedWatcher) run(ctx context.Context) {
 			}
 			switch recv.Type {
 			case watch.Added, watch.Modified, watch.Deleted, watch.Bookmark:
-				err := d.decorator(recv.Object)
-				if err != nil {
-					send = makeStatusErrorEvent(err)
-					break
-				}
+				d.decorator(recv.Object)
 				send = recv
 			case watch.Error:
 				send = recv

--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/decorated_watcher_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/decorated_watcher_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package registry
 
 import (
-	"fmt"
 	"testing"
 	"time"
 
@@ -30,10 +29,9 @@ import (
 
 func TestDecoratedWatcher(t *testing.T) {
 	w := watch.NewFake()
-	decorator := func(obj runtime.Object) error {
+	decorator := func(obj runtime.Object) {
 		pod := obj.(*example.Pod)
 		pod.Annotations = map[string]string{"decorated": "true"}
-		return nil
 	}
 	dw := newDecoratedWatcher(w, decorator)
 	defer dw.Stop()
@@ -48,26 +46,6 @@ func TestDecoratedWatcher(t *testing.T) {
 		}
 		if pod.Annotations["decorated"] != "true" {
 			t.Errorf("pod.Annotations[\"decorated\"], want=%s, get=%s", "true", pod.Labels["decorated"])
-		}
-	case <-time.After(wait.ForeverTestTimeout):
-		t.Errorf("timeout after %v", wait.ForeverTestTimeout)
-	}
-}
-
-func TestDecoratedWatcherError(t *testing.T) {
-	w := watch.NewFake()
-	expErr := fmt.Errorf("expected error")
-	decorator := func(obj runtime.Object) error {
-		return expErr
-	}
-	dw := newDecoratedWatcher(w, decorator)
-	defer dw.Stop()
-
-	go w.Add(&example.Pod{ObjectMeta: metav1.ObjectMeta{Name: "foo"}})
-	select {
-	case e := <-dw.ResultChan():
-		if e.Type != watch.Error {
-			t.Errorf("event type want=%v, get=%v", watch.Error, e.Type)
 		}
 	case <-time.After(wait.ForeverTestTimeout):
 		t.Errorf("timeout after %v", wait.ForeverTestTimeout)

--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store.go
@@ -148,7 +148,7 @@ type Store struct {
 	// integrations that are above storage and should only be used for
 	// specific cases where storage of the value is not appropriate, since
 	// they cannot be watched.
-	Decorator ObjectFunc
+	Decorator func(runtime.Object)
 
 	// CreateStrategy implements resource-specific behavior during creation.
 	CreateStrategy rest.RESTCreateStrategy
@@ -322,9 +322,7 @@ func (e *Store) List(ctx context.Context, options *metainternalversion.ListOptio
 		return nil, err
 	}
 	if e.Decorator != nil {
-		if err := e.Decorator(out); err != nil {
-			return nil, err
-		}
+		e.Decorator(out)
 	}
 	return out, nil
 }
@@ -425,9 +423,7 @@ func (e *Store) Create(ctx context.Context, obj runtime.Object, createValidation
 		e.AfterCreate(out)
 	}
 	if e.Decorator != nil {
-		if err := e.Decorator(out); err != nil {
-			return nil, err
-		}
+		e.Decorator(out)
 	}
 	return out, nil
 }
@@ -672,9 +668,7 @@ func (e *Store) Update(ctx context.Context, name string, objInfo rest.UpdatedObj
 		}
 	}
 	if e.Decorator != nil {
-		if err := e.Decorator(out); err != nil {
-			return nil, false, err
-		}
+		e.Decorator(out)
 	}
 	return out, creating, nil
 }
@@ -701,9 +695,7 @@ func (e *Store) Get(ctx context.Context, name string, options *metav1.GetOptions
 		return nil, storeerr.InterpretGetError(err, e.qualifiedResourceFromContext(ctx), name)
 	}
 	if e.Decorator != nil {
-		if err := e.Decorator(obj); err != nil {
-			return nil, err
-		}
+		e.Decorator(obj)
 	}
 	return obj, nil
 }
@@ -1163,9 +1155,7 @@ func (e *Store) finalizeDelete(ctx context.Context, obj runtime.Object, runHooks
 	}
 	if e.ReturnDeletedObject {
 		if e.Decorator != nil {
-			if err := e.Decorator(obj); err != nil {
-				return nil, err
-			}
+			e.Decorator(obj)
 		}
 		return obj, nil
 	}

--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store.go
@@ -50,11 +50,6 @@ import (
 	"k8s.io/klog/v2"
 )
 
-// ObjectFunc is a function to act on a given object. An error may be returned
-// if the hook cannot be completed. An ObjectFunc may transform the provided
-// object.
-type ObjectFunc func(obj runtime.Object) error
-
 // FinishFunc is a function returned by Begin hooks to complete an operation.
 type FinishFunc func(ctx context.Context, success bool)
 

--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store.go
@@ -56,8 +56,14 @@ type FinishFunc func(ctx context.Context, success bool)
 // AfterDeleteFunc is the type used for the Store.AfterDelete hook.
 type AfterDeleteFunc func(obj runtime.Object, options *metav1.DeleteOptions)
 
+// BeginCreateFunc is the type used for the Store.BeginCreate hook.
+type BeginCreateFunc func(ctx context.Context, obj runtime.Object, options *metav1.CreateOptions) (FinishFunc, error)
+
 // AfterCreateFunc is the type used for the Store.AfterCreate hook.
 type AfterCreateFunc func(obj runtime.Object, options *metav1.CreateOptions)
+
+// BeginUpdateFunc is the type used for the Store.BeginUpdate hook.
+type BeginUpdateFunc func(ctx context.Context, obj, old runtime.Object, options *metav1.UpdateOptions) (FinishFunc, error)
 
 // AfterUpdateFunc is the type used for the Store.AfterUpdate hook.
 type AfterUpdateFunc func(obj runtime.Object, options *metav1.UpdateOptions)
@@ -162,7 +168,7 @@ type Store struct {
 	// but before AfterCreate and Decorator, indicating via the argument
 	// whether the operation succeeded.  If this returns an error, the function
 	// is not called.  Almost nobody should use this hook.
-	BeginCreate func(ctx context.Context, obj runtime.Object, options *metav1.CreateOptions) (FinishFunc, error)
+	BeginCreate BeginCreateFunc
 	// AfterCreate implements a further operation to run after a resource is
 	// created and before it is decorated, optional.
 	AfterCreate AfterCreateFunc
@@ -174,7 +180,7 @@ type Store struct {
 	// but before AfterUpdate and Decorator, indicating via the argument
 	// whether the operation succeeded.  If this returns an error, the function
 	// is not called.  Almost nobody should use this hook.
-	BeginUpdate func(ctx context.Context, obj, old runtime.Object, options *metav1.UpdateOptions) (FinishFunc, error)
+	BeginUpdate BeginUpdateFunc
 	// AfterUpdate implements a further operation to run after a resource is
 	// updated and before it is decorated, optional.
 	AfterUpdate AfterUpdateFunc

--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store_test.go
@@ -500,7 +500,7 @@ func TestStoreCreateHooks(t *testing.T) {
 		name        string
 		decorator   func(runtime.Object)
 		beginCreate func(context.Context, runtime.Object, *metav1.CreateOptions) (FinishFunc, error)
-		afterCreate func(runtime.Object)
+		afterCreate AfterCreateFunc
 		// the TTLFunc is an easy hook to force a failure
 		ttl              func(obj runtime.Object, existing uint64, update bool) (uint64, error)
 		expectError      bool
@@ -516,7 +516,7 @@ func TestStoreCreateHooks(t *testing.T) {
 		expectAnnotation: "DecoratorWasCalled",
 	}, {
 		name: "AfterCreate mutation",
-		afterCreate: func(obj runtime.Object) {
+		afterCreate: func(obj runtime.Object, opts *metav1.CreateOptions) {
 			setAnn(obj, "AfterCreateWasCalled")
 		},
 		expectAnnotation: "AfterCreateWasCalled",
@@ -532,7 +532,7 @@ func TestStoreCreateHooks(t *testing.T) {
 		decorator: func(obj runtime.Object) {
 			mile("Decorator")
 		},
-		afterCreate: func(obj runtime.Object) {
+		afterCreate: func(obj runtime.Object, opts *metav1.CreateOptions) {
 			mile("AfterCreate")
 		},
 		beginCreate: func(_ context.Context, obj runtime.Object, _ *metav1.CreateOptions) (FinishFunc, error) {
@@ -547,7 +547,7 @@ func TestStoreCreateHooks(t *testing.T) {
 		decorator: func(obj runtime.Object) {
 			mile("Decorator")
 		},
-		afterCreate: func(obj runtime.Object) {
+		afterCreate: func(obj runtime.Object, opts *metav1.CreateOptions) {
 			mile("AfterCreate")
 		},
 		beginCreate: func(_ context.Context, obj runtime.Object, _ *metav1.CreateOptions) (FinishFunc, error) {
@@ -568,7 +568,7 @@ func TestStoreCreateHooks(t *testing.T) {
 		decorator: func(obj runtime.Object) {
 			mile("Decorator")
 		},
-		afterCreate: func(obj runtime.Object) {
+		afterCreate: func(obj runtime.Object, opts *metav1.CreateOptions) {
 			mile("AfterCreate")
 		},
 		beginCreate: func(_ context.Context, obj runtime.Object, _ *metav1.CreateOptions) (FinishFunc, error) {
@@ -799,9 +799,9 @@ func TestStoreUpdateHooks(t *testing.T) {
 		decorator func(runtime.Object)
 		// create-on-update is tested elsewhere, but this proves non-use here
 		beginCreate      func(context.Context, runtime.Object, *metav1.CreateOptions) (FinishFunc, error)
-		afterCreate      func(runtime.Object)
+		afterCreate      AfterCreateFunc
 		beginUpdate      func(context.Context, runtime.Object, runtime.Object, *metav1.UpdateOptions) (FinishFunc, error)
-		afterUpdate      func(runtime.Object)
+		afterUpdate      AfterUpdateFunc
 		expectError      bool
 		expectAnnotation string   // to test object mutations
 		expectMilestones []string // to test sequence
@@ -815,7 +815,7 @@ func TestStoreUpdateHooks(t *testing.T) {
 		expectAnnotation: "DecoratorWasCalled",
 	}, {
 		name: "AfterUpdate mutation",
-		afterUpdate: func(obj runtime.Object) {
+		afterUpdate: func(obj runtime.Object, opts *metav1.UpdateOptions) {
 			setAnn(obj, "AfterUpdateWasCalled")
 		},
 		expectAnnotation: "AfterUpdateWasCalled",
@@ -831,7 +831,7 @@ func TestStoreUpdateHooks(t *testing.T) {
 		decorator: func(obj runtime.Object) {
 			mile("Decorator")
 		},
-		afterCreate: func(obj runtime.Object) {
+		afterCreate: func(obj runtime.Object, opts *metav1.CreateOptions) {
 			mile("AfterCreate")
 		},
 		beginCreate: func(_ context.Context, obj runtime.Object, _ *metav1.CreateOptions) (FinishFunc, error) {
@@ -840,7 +840,7 @@ func TestStoreUpdateHooks(t *testing.T) {
 				mile(fmt.Sprintf("FinishCreate(%v)", success))
 			}, nil
 		},
-		afterUpdate: func(obj runtime.Object) {
+		afterUpdate: func(obj runtime.Object, opts *metav1.UpdateOptions) {
 			mile("AfterUpdate")
 		},
 		beginUpdate: func(_ context.Context, obj, _ runtime.Object, _ *metav1.UpdateOptions) (FinishFunc, error) {
@@ -856,7 +856,7 @@ func TestStoreUpdateHooks(t *testing.T) {
 		decorator: func(obj runtime.Object) {
 			mile("Decorator")
 		},
-		afterUpdate: func(obj runtime.Object) {
+		afterUpdate: func(obj runtime.Object, opts *metav1.UpdateOptions) {
 			mile("AfterUpdate")
 		},
 		beginUpdate: func(_ context.Context, obj, _ runtime.Object, _ *metav1.UpdateOptions) (FinishFunc, error) {
@@ -928,9 +928,9 @@ func TestStoreCreateOnUpdateHooks(t *testing.T) {
 		name        string
 		decorator   func(runtime.Object)
 		beginCreate func(context.Context, runtime.Object, *metav1.CreateOptions) (FinishFunc, error)
-		afterCreate func(runtime.Object)
+		afterCreate AfterCreateFunc
 		beginUpdate func(context.Context, runtime.Object, runtime.Object, *metav1.UpdateOptions) (FinishFunc, error)
-		afterUpdate func(runtime.Object)
+		afterUpdate AfterUpdateFunc
 		// the TTLFunc is an easy hook to force a failure
 		ttl              func(obj runtime.Object, existing uint64, update bool) (uint64, error)
 		expectError      bool
@@ -942,7 +942,7 @@ func TestStoreCreateOnUpdateHooks(t *testing.T) {
 		decorator: func(obj runtime.Object) {
 			mile("Decorator")
 		},
-		afterCreate: func(obj runtime.Object) {
+		afterCreate: func(obj runtime.Object, opts *metav1.CreateOptions) {
 			mile("AfterCreate")
 		},
 		beginCreate: func(_ context.Context, obj runtime.Object, _ *metav1.CreateOptions) (FinishFunc, error) {
@@ -951,7 +951,7 @@ func TestStoreCreateOnUpdateHooks(t *testing.T) {
 				mile(fmt.Sprintf("FinishCreate(%v)", success))
 			}, nil
 		},
-		afterUpdate: func(obj runtime.Object) {
+		afterUpdate: func(obj runtime.Object, opts *metav1.UpdateOptions) {
 			mile("AfterUpdate")
 		},
 		beginUpdate: func(_ context.Context, obj, _ runtime.Object, _ *metav1.UpdateOptions) (FinishFunc, error) {
@@ -966,7 +966,7 @@ func TestStoreCreateOnUpdateHooks(t *testing.T) {
 		decorator: func(obj runtime.Object) {
 			mile("Decorator")
 		},
-		afterCreate: func(obj runtime.Object) {
+		afterCreate: func(obj runtime.Object, opts *metav1.CreateOptions) {
 			mile("AfterCreate")
 		},
 		beginCreate: func(_ context.Context, obj runtime.Object, _ *metav1.CreateOptions) (FinishFunc, error) {
@@ -975,7 +975,7 @@ func TestStoreCreateOnUpdateHooks(t *testing.T) {
 				mile(fmt.Sprintf("FinishCreate(%v)", success))
 			}, nil
 		},
-		afterUpdate: func(obj runtime.Object) {
+		afterUpdate: func(obj runtime.Object, opts *metav1.UpdateOptions) {
 			mile("AfterUpdate")
 		},
 		beginUpdate: func(_ context.Context, obj, _ runtime.Object, _ *metav1.UpdateOptions) (FinishFunc, error) {
@@ -996,7 +996,7 @@ func TestStoreCreateOnUpdateHooks(t *testing.T) {
 		decorator: func(obj runtime.Object) {
 			mile("Decorator")
 		},
-		afterCreate: func(obj runtime.Object) {
+		afterCreate: func(obj runtime.Object, opts *metav1.CreateOptions) {
 			mile("AfterCreate")
 		},
 		beginCreate: func(_ context.Context, obj runtime.Object, _ *metav1.CreateOptions) (FinishFunc, error) {
@@ -1005,7 +1005,7 @@ func TestStoreCreateOnUpdateHooks(t *testing.T) {
 				mile(fmt.Sprintf("FinishCreate(%v)", success))
 			}, fmt.Errorf("begin")
 		},
-		afterUpdate: func(obj runtime.Object) {
+		afterUpdate: func(obj runtime.Object, opts *metav1.UpdateOptions) {
 			mile("AfterUpdate")
 		},
 		beginUpdate: func(_ context.Context, obj, _ runtime.Object, _ *metav1.UpdateOptions) (FinishFunc, error) {
@@ -1082,7 +1082,7 @@ func TestStoreUpdateHooksInnerRetry(t *testing.T) {
 		name        string
 		decorator   func(runtime.Object)
 		beginUpdate func(context.Context, runtime.Object, runtime.Object, *metav1.UpdateOptions) (FinishFunc, error)
-		afterUpdate func(runtime.Object)
+		afterUpdate AfterUpdateFunc
 		// the TTLFunc is an easy hook to force an inner-loop retry
 		ttl              func(obj runtime.Object, existing uint64, update bool) (uint64, error)
 		expectError      bool
@@ -1092,7 +1092,7 @@ func TestStoreUpdateHooksInnerRetry(t *testing.T) {
 		decorator: func(obj runtime.Object) {
 			mile("Decorator")
 		},
-		afterUpdate: func(obj runtime.Object) {
+		afterUpdate: func(obj runtime.Object, opts *metav1.UpdateOptions) {
 			mile("AfterUpdate")
 		},
 		beginUpdate: func(_ context.Context, obj, _ runtime.Object, _ *metav1.UpdateOptions) (FinishFunc, error) {
@@ -1108,7 +1108,7 @@ func TestStoreUpdateHooksInnerRetry(t *testing.T) {
 		decorator: func(obj runtime.Object) {
 			mile("Decorator")
 		},
-		afterUpdate: func(obj runtime.Object) {
+		afterUpdate: func(obj runtime.Object, opts *metav1.UpdateOptions) {
 			mile("AfterUpdate")
 		},
 		beginUpdate: func(_ context.Context, obj, _ runtime.Object, _ *metav1.UpdateOptions) (FinishFunc, error) {

--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store_test.go
@@ -499,7 +499,7 @@ func TestStoreCreateHooks(t *testing.T) {
 	testCases := []struct {
 		name        string
 		decorator   func(runtime.Object)
-		beginCreate func(context.Context, runtime.Object, *metav1.CreateOptions) (FinishFunc, error)
+		beginCreate BeginCreateFunc
 		afterCreate AfterCreateFunc
 		// the TTLFunc is an easy hook to force a failure
 		ttl              func(obj runtime.Object, existing uint64, update bool) (uint64, error)
@@ -798,9 +798,9 @@ func TestStoreUpdateHooks(t *testing.T) {
 		name      string
 		decorator func(runtime.Object)
 		// create-on-update is tested elsewhere, but this proves non-use here
-		beginCreate      func(context.Context, runtime.Object, *metav1.CreateOptions) (FinishFunc, error)
+		beginCreate      BeginCreateFunc
 		afterCreate      AfterCreateFunc
-		beginUpdate      func(context.Context, runtime.Object, runtime.Object, *metav1.UpdateOptions) (FinishFunc, error)
+		beginUpdate      BeginUpdateFunc
 		afterUpdate      AfterUpdateFunc
 		expectError      bool
 		expectAnnotation string   // to test object mutations
@@ -927,9 +927,9 @@ func TestStoreCreateOnUpdateHooks(t *testing.T) {
 	testCases := []struct {
 		name        string
 		decorator   func(runtime.Object)
-		beginCreate func(context.Context, runtime.Object, *metav1.CreateOptions) (FinishFunc, error)
+		beginCreate BeginCreateFunc
 		afterCreate AfterCreateFunc
-		beginUpdate func(context.Context, runtime.Object, runtime.Object, *metav1.UpdateOptions) (FinishFunc, error)
+		beginUpdate BeginUpdateFunc
 		afterUpdate AfterUpdateFunc
 		// the TTLFunc is an easy hook to force a failure
 		ttl              func(obj runtime.Object, existing uint64, update bool) (uint64, error)

--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store_test.go
@@ -440,7 +440,7 @@ func TestStoreCreateHooks(t *testing.T) {
 		name        string
 		decorator   ObjectFunc
 		beginCreate func(context.Context, runtime.Object, *metav1.CreateOptions) (FinishFunc, error)
-		afterCreate ObjectFunc
+		afterCreate func(runtime.Object)
 		// the TTLFunc is an easy hook to force a failure
 		ttl              func(obj runtime.Object, existing uint64, update bool) (uint64, error)
 		expectError      bool
@@ -457,9 +457,8 @@ func TestStoreCreateHooks(t *testing.T) {
 		expectAnnotation: "DecoratorWasCalled",
 	}, {
 		name: "AfterCreate mutation",
-		afterCreate: func(obj runtime.Object) error {
+		afterCreate: func(obj runtime.Object) {
 			setAnn(obj, "AfterCreateWasCalled")
-			return nil
 		},
 		expectAnnotation: "AfterCreateWasCalled",
 	}, {
@@ -475,9 +474,8 @@ func TestStoreCreateHooks(t *testing.T) {
 			mile("Decorator")
 			return nil
 		},
-		afterCreate: func(obj runtime.Object) error {
+		afterCreate: func(obj runtime.Object) {
 			mile("AfterCreate")
-			return nil
 		},
 		beginCreate: func(_ context.Context, obj runtime.Object, _ *metav1.CreateOptions) (FinishFunc, error) {
 			mile("BeginCreate")
@@ -492,9 +490,8 @@ func TestStoreCreateHooks(t *testing.T) {
 			mile("Decorator")
 			return nil
 		},
-		afterCreate: func(obj runtime.Object) error {
+		afterCreate: func(obj runtime.Object) {
 			mile("AfterCreate")
-			return nil
 		},
 		beginCreate: func(_ context.Context, obj runtime.Object, _ *metav1.CreateOptions) (FinishFunc, error) {
 			mile("BeginCreate")
@@ -515,9 +512,8 @@ func TestStoreCreateHooks(t *testing.T) {
 			mile("Decorator")
 			return fmt.Errorf("decorator")
 		},
-		afterCreate: func(obj runtime.Object) error {
+		afterCreate: func(obj runtime.Object) {
 			mile("AfterCreate")
-			return nil
 		},
 		beginCreate: func(_ context.Context, obj runtime.Object, _ *metav1.CreateOptions) (FinishFunc, error) {
 			mile("BeginCreate")
@@ -527,33 +523,14 @@ func TestStoreCreateHooks(t *testing.T) {
 		},
 		expectMilestones: []string{"BeginCreate", "FinishCreate(true)", "AfterCreate", "Decorator"},
 	}, {
-		name:        "fail AfterCreate ordering",
-		expectError: true,
-		decorator: func(obj runtime.Object) error {
-			mile("Decorator")
-			return nil
-		},
-		afterCreate: func(obj runtime.Object) error {
-			mile("AfterCreate")
-			return fmt.Errorf("after")
-		},
-		beginCreate: func(_ context.Context, obj runtime.Object, _ *metav1.CreateOptions) (FinishFunc, error) {
-			mile("BeginCreate")
-			return func(_ context.Context, success bool) {
-				mile(fmt.Sprintf("FinishCreate(%v)", success))
-			}, nil
-		},
-		expectMilestones: []string{"BeginCreate", "FinishCreate(true)", "AfterCreate"},
-	}, {
 		name:        "fail BeginCreate ordering",
 		expectError: true,
 		decorator: func(obj runtime.Object) error {
 			mile("Decorator")
 			return nil
 		},
-		afterCreate: func(obj runtime.Object) error {
+		afterCreate: func(obj runtime.Object) {
 			mile("AfterCreate")
-			return nil
 		},
 		beginCreate: func(_ context.Context, obj runtime.Object, _ *metav1.CreateOptions) (FinishFunc, error) {
 			mile("BeginCreate")
@@ -783,9 +760,9 @@ func TestStoreUpdateHooks(t *testing.T) {
 		decorator ObjectFunc
 		// create-on-update is tested elsewhere, but this proves non-use here
 		beginCreate      func(context.Context, runtime.Object, *metav1.CreateOptions) (FinishFunc, error)
-		afterCreate      ObjectFunc
+		afterCreate      func(runtime.Object)
 		beginUpdate      func(context.Context, runtime.Object, runtime.Object, *metav1.UpdateOptions) (FinishFunc, error)
-		afterUpdate      ObjectFunc
+		afterUpdate      func(runtime.Object)
 		expectError      bool
 		expectAnnotation string   // to test object mutations
 		expectMilestones []string // to test sequence
@@ -800,9 +777,8 @@ func TestStoreUpdateHooks(t *testing.T) {
 		expectAnnotation: "DecoratorWasCalled",
 	}, {
 		name: "AfterUpdate mutation",
-		afterUpdate: func(obj runtime.Object) error {
+		afterUpdate: func(obj runtime.Object) {
 			setAnn(obj, "AfterUpdateWasCalled")
-			return nil
 		},
 		expectAnnotation: "AfterUpdateWasCalled",
 	}, {
@@ -818,9 +794,8 @@ func TestStoreUpdateHooks(t *testing.T) {
 			mile("Decorator")
 			return nil
 		},
-		afterCreate: func(obj runtime.Object) error {
+		afterCreate: func(obj runtime.Object) {
 			mile("AfterCreate")
-			return nil
 		},
 		beginCreate: func(_ context.Context, obj runtime.Object, _ *metav1.CreateOptions) (FinishFunc, error) {
 			mile("BeginCreate")
@@ -828,9 +803,8 @@ func TestStoreUpdateHooks(t *testing.T) {
 				mile(fmt.Sprintf("FinishCreate(%v)", success))
 			}, nil
 		},
-		afterUpdate: func(obj runtime.Object) error {
+		afterUpdate: func(obj runtime.Object) {
 			mile("AfterUpdate")
-			return nil
 		},
 		beginUpdate: func(_ context.Context, obj, _ runtime.Object, _ *metav1.UpdateOptions) (FinishFunc, error) {
 			mile("BeginUpdate")
@@ -846,9 +820,8 @@ func TestStoreUpdateHooks(t *testing.T) {
 			mile("Decorator")
 			return fmt.Errorf("decorator")
 		},
-		afterUpdate: func(obj runtime.Object) error {
+		afterUpdate: func(obj runtime.Object) {
 			mile("AfterUpdate")
-			return nil
 		},
 		beginUpdate: func(_ context.Context, obj, _ runtime.Object, _ *metav1.UpdateOptions) (FinishFunc, error) {
 			mile("BeginUpdate")
@@ -858,33 +831,14 @@ func TestStoreUpdateHooks(t *testing.T) {
 		},
 		expectMilestones: []string{"BeginUpdate", "FinishUpdate(true)", "AfterUpdate", "Decorator"},
 	}, {
-		name:        "fail AfterUpdate ordering",
-		expectError: true,
-		decorator: func(obj runtime.Object) error {
-			mile("Decorator")
-			return nil
-		},
-		afterUpdate: func(obj runtime.Object) error {
-			mile("AfterUpdate")
-			return fmt.Errorf("after")
-		},
-		beginUpdate: func(_ context.Context, obj, _ runtime.Object, _ *metav1.UpdateOptions) (FinishFunc, error) {
-			mile("BeginUpdate")
-			return func(_ context.Context, success bool) {
-				mile(fmt.Sprintf("FinishUpdate(%v)", success))
-			}, nil
-		},
-		expectMilestones: []string{"BeginUpdate", "FinishUpdate(true)", "AfterUpdate"},
-	}, {
 		name:        "fail BeginUpdate ordering",
 		expectError: true,
 		decorator: func(obj runtime.Object) error {
 			mile("Decorator")
 			return nil
 		},
-		afterUpdate: func(obj runtime.Object) error {
+		afterUpdate: func(obj runtime.Object) {
 			mile("AfterUpdate")
-			return nil
 		},
 		beginUpdate: func(_ context.Context, obj, _ runtime.Object, _ *metav1.UpdateOptions) (FinishFunc, error) {
 			mile("BeginUpdate")
@@ -955,9 +909,9 @@ func TestStoreCreateOnUpdateHooks(t *testing.T) {
 		name        string
 		decorator   ObjectFunc
 		beginCreate func(context.Context, runtime.Object, *metav1.CreateOptions) (FinishFunc, error)
-		afterCreate ObjectFunc
+		afterCreate func(runtime.Object)
 		beginUpdate func(context.Context, runtime.Object, runtime.Object, *metav1.UpdateOptions) (FinishFunc, error)
-		afterUpdate ObjectFunc
+		afterUpdate func(runtime.Object)
 		// the TTLFunc is an easy hook to force a failure
 		ttl              func(obj runtime.Object, existing uint64, update bool) (uint64, error)
 		expectError      bool
@@ -970,9 +924,8 @@ func TestStoreCreateOnUpdateHooks(t *testing.T) {
 			mile("Decorator")
 			return nil
 		},
-		afterCreate: func(obj runtime.Object) error {
+		afterCreate: func(obj runtime.Object) {
 			mile("AfterCreate")
-			return nil
 		},
 		beginCreate: func(_ context.Context, obj runtime.Object, _ *metav1.CreateOptions) (FinishFunc, error) {
 			mile("BeginCreate")
@@ -980,9 +933,8 @@ func TestStoreCreateOnUpdateHooks(t *testing.T) {
 				mile(fmt.Sprintf("FinishCreate(%v)", success))
 			}, nil
 		},
-		afterUpdate: func(obj runtime.Object) error {
+		afterUpdate: func(obj runtime.Object) {
 			mile("AfterUpdate")
-			return nil
 		},
 		beginUpdate: func(_ context.Context, obj, _ runtime.Object, _ *metav1.UpdateOptions) (FinishFunc, error) {
 			mile("BeginUpdate")
@@ -997,9 +949,8 @@ func TestStoreCreateOnUpdateHooks(t *testing.T) {
 			mile("Decorator")
 			return nil
 		},
-		afterCreate: func(obj runtime.Object) error {
+		afterCreate: func(obj runtime.Object) {
 			mile("AfterCreate")
-			return nil
 		},
 		beginCreate: func(_ context.Context, obj runtime.Object, _ *metav1.CreateOptions) (FinishFunc, error) {
 			mile("BeginCreate")
@@ -1007,9 +958,8 @@ func TestStoreCreateOnUpdateHooks(t *testing.T) {
 				mile(fmt.Sprintf("FinishCreate(%v)", success))
 			}, nil
 		},
-		afterUpdate: func(obj runtime.Object) error {
+		afterUpdate: func(obj runtime.Object) {
 			mile("AfterUpdate")
-			return nil
 		},
 		beginUpdate: func(_ context.Context, obj, _ runtime.Object, _ *metav1.UpdateOptions) (FinishFunc, error) {
 			mile("BeginUpdate")
@@ -1030,9 +980,8 @@ func TestStoreCreateOnUpdateHooks(t *testing.T) {
 			mile("Decorator")
 			return fmt.Errorf("decorator")
 		},
-		afterCreate: func(obj runtime.Object) error {
+		afterCreate: func(obj runtime.Object) {
 			mile("AfterCreate")
-			return nil
 		},
 		beginCreate: func(_ context.Context, obj runtime.Object, _ *metav1.CreateOptions) (FinishFunc, error) {
 			mile("BeginCreate")
@@ -1040,9 +989,8 @@ func TestStoreCreateOnUpdateHooks(t *testing.T) {
 				mile(fmt.Sprintf("FinishCreate(%v)", success))
 			}, nil
 		},
-		afterUpdate: func(obj runtime.Object) error {
+		afterUpdate: func(obj runtime.Object) {
 			mile("AfterUpdate")
-			return nil
 		},
 		beginUpdate: func(_ context.Context, obj, _ runtime.Object, _ *metav1.UpdateOptions) (FinishFunc, error) {
 			mile("BeginUpdate")
@@ -1052,43 +1000,14 @@ func TestStoreCreateOnUpdateHooks(t *testing.T) {
 		},
 		expectMilestones: []string{"BeginCreate", "FinishCreate(true)", "AfterCreate", "Decorator"},
 	}, {
-		name:        "fail AfterCreate ordering",
-		expectError: true,
-		decorator: func(obj runtime.Object) error {
-			mile("Decorator")
-			return nil
-		},
-		afterCreate: func(obj runtime.Object) error {
-			mile("AfterCreate")
-			return fmt.Errorf("after")
-		},
-		beginCreate: func(_ context.Context, obj runtime.Object, _ *metav1.CreateOptions) (FinishFunc, error) {
-			mile("BeginCreate")
-			return func(_ context.Context, success bool) {
-				mile(fmt.Sprintf("FinishCreate(%v)", success))
-			}, nil
-		},
-		afterUpdate: func(obj runtime.Object) error {
-			mile("AfterUpdate")
-			return nil
-		},
-		beginUpdate: func(_ context.Context, obj, _ runtime.Object, _ *metav1.UpdateOptions) (FinishFunc, error) {
-			mile("BeginUpdate")
-			return func(_ context.Context, success bool) {
-				mile(fmt.Sprintf("FinishUpdate(%v)", success))
-			}, nil
-		},
-		expectMilestones: []string{"BeginCreate", "FinishCreate(true)", "AfterCreate"},
-	}, {
 		name:        "fail BeginCreate ordering",
 		expectError: true,
 		decorator: func(obj runtime.Object) error {
 			mile("Decorator")
 			return nil
 		},
-		afterCreate: func(obj runtime.Object) error {
+		afterCreate: func(obj runtime.Object) {
 			mile("AfterCreate")
-			return nil
 		},
 		beginCreate: func(_ context.Context, obj runtime.Object, _ *metav1.CreateOptions) (FinishFunc, error) {
 			mile("BeginCreate")
@@ -1096,9 +1015,8 @@ func TestStoreCreateOnUpdateHooks(t *testing.T) {
 				mile(fmt.Sprintf("FinishCreate(%v)", success))
 			}, fmt.Errorf("begin")
 		},
-		afterUpdate: func(obj runtime.Object) error {
+		afterUpdate: func(obj runtime.Object) {
 			mile("AfterUpdate")
-			return nil
 		},
 		beginUpdate: func(_ context.Context, obj, _ runtime.Object, _ *metav1.UpdateOptions) (FinishFunc, error) {
 			mile("BeginUpdate")
@@ -1174,7 +1092,7 @@ func TestStoreUpdateHooksInnerRetry(t *testing.T) {
 		name        string
 		decorator   func(runtime.Object) error
 		beginUpdate func(context.Context, runtime.Object, runtime.Object, *metav1.UpdateOptions) (FinishFunc, error)
-		afterUpdate func(runtime.Object) error
+		afterUpdate func(runtime.Object)
 		// the TTLFunc is an easy hook to force an inner-loop retry
 		ttl              func(obj runtime.Object, existing uint64, update bool) (uint64, error)
 		expectError      bool
@@ -1185,9 +1103,8 @@ func TestStoreUpdateHooksInnerRetry(t *testing.T) {
 			mile("Decorator")
 			return nil
 		},
-		afterUpdate: func(obj runtime.Object) error {
+		afterUpdate: func(obj runtime.Object) {
 			mile("AfterUpdate")
-			return nil
 		},
 		beginUpdate: func(_ context.Context, obj, _ runtime.Object, _ *metav1.UpdateOptions) (FinishFunc, error) {
 			mile("BeginUpdate")
@@ -1203,9 +1120,8 @@ func TestStoreUpdateHooksInnerRetry(t *testing.T) {
 			mile("Decorator")
 			return nil
 		},
-		afterUpdate: func(obj runtime.Object) error {
+		afterUpdate: func(obj runtime.Object) {
 			mile("AfterUpdate")
-			return nil
 		},
 		beginUpdate: func(_ context.Context, obj, _ runtime.Object, _ *metav1.UpdateOptions) (FinishFunc, error) {
 			mile("BeginUpdate")

--- a/staging/src/k8s.io/apiserver/pkg/registry/rest/rest.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/rest/rest.go
@@ -214,7 +214,7 @@ type UpdatedObjectInfo interface {
 }
 
 // ValidateObjectFunc is a function to act on a given object. An error may be returned
-// if the hook cannot be completed. An ObjectFunc may NOT transform the provided
+// if the hook cannot be completed. A ValidateObjectFunc may NOT transform the provided
 // object.
 type ValidateObjectFunc func(ctx context.Context, obj runtime.Object) error
 


### PR DESCRIPTION
These hooks return a "cleanup" func which is called when the top-level
operation completes, with an indicator of which result.

This is to enable much simpler handling of allocations in Service's REST
implementation, in particular.

Some discussion in https://github.com/kubernetes/kubernetes/pull/95967

This also adds tests for the almost totally untested Decorator,
AfterCreate, and AfterUpdate hooks.  My gift to you as thanks for considering
these hooks :)


/kind feature

```release-note
NONE
```
