### PR TITLE
cloud-provider: update docs and guidance for InstanceV2 and Zones

### DIFF
--- a/staging/src/k8s.io/cloud-provider/cloud.go
+++ b/staging/src/k8s.io/cloud-provider/cloud.go
@@ -51,11 +51,12 @@ type Interface interface {
 	Instances() (Instances, bool)
 	// InstancesV2 is an implementation for instances and should only be implemented by external cloud providers.
 	// Implementing InstancesV2 is behaviorally identical to Instances but is optimized to significantly reduce
-	// API calls to the cloud provider when registering and syncing nodes.
-	// Also returns true if the interface is supported, false otherwise.
-	// WARNING: InstancesV2 is an experimental interface and is subject to change in v1.20.
+	// API calls to the cloud provider when registering and syncing nodes. Implementation of this interface will
+	// disable calls to the Zones interface. Also returns true if the interface is supported, false otherwise.
 	InstancesV2() (InstancesV2, bool)
 	// Zones returns a zones interface. Also returns true if the interface is supported, false otherwise.
+	// DEPRECATED: Zones is deprecated in favor of retrieving zone/region information from InstancesV2.
+	// This interface will not be called if InstancesV2 is enabled.
 	Zones() (Zones, bool)
 	// Clusters returns a clusters interface.  Also returns true if the interface is supported, false otherwise.
 	Clusters() (Clusters, bool)
@@ -194,7 +195,7 @@ type Instances interface {
 
 // InstancesV2 is an abstract, pluggable interface for cloud provider instances.
 // Unlike the Instances interface, it is designed for external cloud providers and should only be used by them.
-// WARNING: InstancesV2 is an experimental interface and is subject to change in v1.20.
+// Implementation of this interface will disable calls to the Zones interface.
 type InstancesV2 interface {
 	// InstanceExists returns true if the instance for the given node exists according to the cloud provider.
 	// Use the node.name or node.spec.providerID field to find the node in the cloud provider.
@@ -203,8 +204,10 @@ type InstancesV2 interface {
 	// Use the node.name or node.spec.providerID field to find the node in the cloud provider.
 	InstanceShutdown(ctx context.Context, node *v1.Node) (bool, error)
 	// InstanceMetadata returns the instance's metadata. The values returned in InstanceMetadata are
-	// translated into specific fields in the Node object on registration.
-	// Use the node.name or node.spec.providerID field to find the node in the cloud provider.
+	// translated into specific fields and labels in the Node object on registration.
+	// Implementations should always check node.spec.providerID first when trying to discover the instance
+	// for a given node. In cases where node.spec.providerID is empty, implementations can use other
+	// properties of the node like its name, labels and annotations.
 	InstanceMetadata(ctx context.Context, node *v1.Node) (*InstanceMetadata, error)
 }
 
@@ -250,6 +253,8 @@ type Zone struct {
 }
 
 // Zones is an abstract, pluggable interface for zone enumeration.
+// DEPRECATED: Zones is deprecated in favor of retrieving zone/region information from InstancesV2.
+// This interface will not be called if InstancesV2 is enabled.
 type Zones interface {
 	// GetZone returns the Zone containing the current failure zone and locality region that the program is running in
 	// In most cases, this method is called from the kubelet querying a local metadata service to acquire its zone.
@@ -274,7 +279,7 @@ type PVLabeler interface {
 }
 
 // InstanceMetadata contains metadata about a specific instance.
-// Values returned in InstanceMetadata are translated into specific fields in Node.
+// Values returned in InstanceMetadata are translated into specific fields and labels for Node.
 type InstanceMetadata struct {
 	// ProviderID is a unique ID used to idenfitify an instance on the cloud provider.
 	// The ProviderID set here will be set on the node's spec.providerID field.


### PR DESCRIPTION
Signed-off-by: Andrew Sy Kim <kim.andrewsy@gmail.com>

**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
Updates docs and guidance on cloud provider InstancesV2 and Zones interface for external cloud providers:
* removes experimental warning for InstancesV2
* document that implementation of InstancesV2 will disable calls to Zones
* deprecate Zones in favor of InstancesV2

In https://github.com/kubernetes/kubernetes/pull/93569 we updated the InstanceMetadata hook to include zone/region information for a node. This made sense because almost always you can retrieve zone/region information for an instance using the same API calls you would when registering the node. This reduces the number of API calls the cloud provider has to make to register a node.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Updates docs and guidance on cloud provider InstancesV2 and Zones interface for external cloud providers:
* removes experimental warning for InstancesV2
* document that implementation of InstancesV2 will disable calls to Zones
* deprecate Zones in favor of InstancesV2
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
