### PR TITLE
fix staticcheck:vendor/k8s.io/kubectl/pkg/cmd/scale

### DIFF
--- a/hack/.staticcheck_failures
+++ b/hack/.staticcheck_failures
@@ -48,4 +48,3 @@ vendor/k8s.io/client-go/rest
 vendor/k8s.io/client-go/rest/watch
 vendor/k8s.io/client-go/transport
 vendor/k8s.io/cloud-provider/sample
-vendor/k8s.io/kubectl/pkg/cmd/scale

--- a/staging/src/k8s.io/kubectl/pkg/cmd/scale/scale.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/scale/scale.go
@@ -209,7 +209,7 @@ func (o *ScaleOptions) RunScale() error {
 	}
 
 	infos := []*resource.Info{}
-	err = r.Visit(func(info *resource.Info, err error) error {
+	r.Visit(func(info *resource.Info, err error) error {
 		if err == nil {
 			infos = append(infos, info)
 		}


### PR DESCRIPTION
What type of PR is this?
/kind cleanup

What this PR does / why we need it:
fix staticcheck:vendor/k8s.io/kubectl/pkg/cmd/scale
vendor/k8s.io/kubectl/pkg/cmd/scale/scale.go:212:2: this value of err is never used (SA4006)

Which issue(s) this PR fixes:
Part of #92402

Special notes for your reviewer:

Does this PR introduce a user-facing change?:
NONE

Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.: