### PR TITLE
remove label dependency on k8s api in Azure

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure.go
@@ -93,6 +93,12 @@ const (
 
 	externalResourceGroupLabel = "kubernetes.azure.com/resource-group"
 	managedByAzureLabel        = "kubernetes.azure.com/managed"
+
+	// LabelFailureDomainBetaZone refer to https://github.com/kubernetes/api/blob/8519c5ea46199d57724725d5b969c5e8e0533692/core/v1/well_known_labels.go#L22-L23
+	LabelFailureDomainBetaZone = "failure-domain.beta.kubernetes.io/zone"
+
+	// LabelFailureDomainBetaRegion failure-domain region label
+	LabelFailureDomainBetaRegion = "failure-domain.beta.kubernetes.io/region"
 )
 
 const (
@@ -736,8 +742,8 @@ func (az *Cloud) SetInformers(informerFactory informers.SharedInformerFactory) {
 		UpdateFunc: func(prev, obj interface{}) {
 			prevNode := prev.(*v1.Node)
 			newNode := obj.(*v1.Node)
-			if newNode.Labels[v1.LabelFailureDomainBetaZone] ==
-				prevNode.Labels[v1.LabelFailureDomainBetaZone] {
+			if newNode.Labels[LabelFailureDomainBetaZone] ==
+				prevNode.Labels[LabelFailureDomainBetaZone] {
 				return
 			}
 			az.updateNodeCaches(prevNode, newNode)
@@ -771,7 +777,7 @@ func (az *Cloud) updateNodeCaches(prevNode, newNode *v1.Node) {
 
 	if prevNode != nil {
 		// Remove from nodeZones cache.
-		prevZone, ok := prevNode.ObjectMeta.Labels[v1.LabelFailureDomainBetaZone]
+		prevZone, ok := prevNode.ObjectMeta.Labels[LabelFailureDomainBetaZone]
 		if ok && az.isAvailabilityZone(prevZone) {
 			az.nodeZones[prevZone].Delete(prevNode.ObjectMeta.Name)
 			if az.nodeZones[prevZone].Len() == 0 {
@@ -794,7 +800,7 @@ func (az *Cloud) updateNodeCaches(prevNode, newNode *v1.Node) {
 
 	if newNode != nil {
 		// Add to nodeZones cache.
-		newZone, ok := newNode.ObjectMeta.Labels[v1.LabelFailureDomainBetaZone]
+		newZone, ok := newNode.ObjectMeta.Labels[LabelFailureDomainBetaZone]
 		if ok && az.isAvailabilityZone(newZone) {
 			if az.nodeZones[newZone] == nil {
 				az.nodeZones[newZone] = sets.NewString()

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_managedDiskController.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_managedDiskController.go
@@ -351,7 +351,7 @@ func (c *Cloud) GetAzureDiskLabels(diskURI string) (map[string]string, error) {
 	}
 
 	labels := map[string]string{
-		v1.LabelFailureDomainBetaRegion: c.Location,
+		LabelFailureDomainBetaRegion: c.Location,
 	}
 	// no azure credential is set, return nil
 	if c.DisksClient == nil {
@@ -380,6 +380,6 @@ func (c *Cloud) GetAzureDiskLabels(diskURI string) (map[string]string, error) {
 
 	zone := c.makeZone(c.Location, zoneID)
 	klog.V(4).Infof("Got zone %q for Azure disk %q", zone, diskName)
-	labels[v1.LabelFailureDomainBetaZone] = zone
+	labels[LabelFailureDomainBetaZone] = zone
 	return labels, nil
 }

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_managedDiskController_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_managedDiskController_test.go
@@ -417,8 +417,8 @@ func TestGetLabelsForVolume(t *testing.T) {
 			},
 			existedDisk: compute.Disk{Name: to.StringPtr(diskName), DiskProperties: &compute.DiskProperties{DiskSizeGB: &diskSizeGB}, Zones: &[]string{"1"}},
 			expected: map[string]string{
-				v1.LabelFailureDomainBetaRegion: testCloud0.Location,
-				v1.LabelFailureDomainBetaZone:   testCloud0.makeZone(testCloud0.Location, 1),
+				LabelFailureDomainBetaRegion: testCloud0.Location,
+				LabelFailureDomainBetaZone:   testCloud0.makeZone(testCloud0.Location, 1),
 			},
 			expectedErr: false,
 		},
@@ -454,7 +454,7 @@ func TestGetLabelsForVolume(t *testing.T) {
 			},
 			existedDisk: compute.Disk{Name: to.StringPtr(diskName), DiskProperties: &compute.DiskProperties{DiskSizeGB: &diskSizeGB}},
 			expected: map[string]string{
-				v1.LabelFailureDomainBetaRegion: testCloud0.Location,
+				LabelFailureDomainBetaRegion: testCloud0.Location,
 			},
 			expectedErr:    false,
 			expectedErrMsg: nil,

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_test.go
@@ -3248,9 +3248,9 @@ func TestUpdateNodeCaches(t *testing.T) {
 	prevNode := v1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Labels: map[string]string{
-				v1.LabelFailureDomainBetaZone: zone,
-				externalResourceGroupLabel:    "true",
-				managedByAzureLabel:           "false",
+				LabelFailureDomainBetaZone: zone,
+				externalResourceGroupLabel: "true",
+				managedByAzureLabel:        "false",
 			},
 			Name: "prevNode",
 		},
@@ -3264,9 +3264,9 @@ func TestUpdateNodeCaches(t *testing.T) {
 	newNode := v1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Labels: map[string]string{
-				v1.LabelFailureDomainBetaZone: zone,
-				externalResourceGroupLabel:    "true",
-				managedByAzureLabel:           "false",
+				LabelFailureDomainBetaZone: zone,
+				externalResourceGroupLabel: "true",
+				managedByAzureLabel:        "false",
 			},
 			Name: "newNode",
 		},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
remove label dependency on k8s api in Azure, `LabelFailureDomainBetaZone` is only in k8s/api on master branch, it's hard to update vendor in CSI driver.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
hit following build error when vendor azure cloud provider:
```
# make
CGO_ENABLED=0 GOOS=linux go build -a -ldflags "-X sigs.k8s.io/azuredisk-csi-driver/pkg/azuredisk.driverVersion=v0.10.0 -X sigs.k8s.io/azuredisk-csi-driver/pkg/azuredisk.gitCommit=1e1866b4ee11dd5370925e22d5842d76b0d9afd0 -X sigs.k8s.io/azuredisk-csi-driver/pkg/azuredisk.buildDate=2020-11-10T11:21:30Z -X sigs.k8s.io/azuredisk-csi-driver/pkg/azuredisk.DriverName=disk.csi.azure.com -X sigs.k8s.io/azuredisk-csi-driver/pkg/azuredisk.topologyKey=topology.disk.csi.azure.com/zone -extldflags "-static"" -o _output/azurediskplugin ./pkg/azurediskplugin
# k8s.io/legacy-cloud-providers/azure
/root/go/pkg/mod/k8s.io/legacy-cloud-providers@v0.0.0-20201110084802-6c6df2081e1b/azure/azure.go:739:22: undefined: "k8s.io/api/core/v1".LabelFailureDomainBetaZone
/root/go/pkg/mod/k8s.io/legacy-cloud-providers@v0.0.0-20201110084802-6c6df2081e1b/azure/azure.go:740:21: undefined: "k8s.io/api/core/v1".LabelFailureDomainBetaZone
/root/go/pkg/mod/k8s.io/legacy-cloud-providers@v0.0.0-20201110084802-6c6df2081e1b/azure/azure.go:774:46: undefined: "k8s.io/api/core/v1".LabelFailureDomainBetaZone
/root/go/pkg/mod/k8s.io/legacy-cloud-providers@v0.0.0-20201110084802-6c6df2081e1b/azure/azure.go:797:44: undefined: "k8s.io/api/core/v1".LabelFailureDomainBetaZone
/root/go/pkg/mod/k8s.io/legacy-cloud-providers@v0.0.0-20201110084802-6c6df2081e1b/azure/azure_managedDiskController.go:354:3: undefined: "k8s.io/api/core/v1".LabelFailureDomainBetaRegion
/root/go/pkg/mod/k8s.io/legacy-cloud-providers@v0.0.0-20201110084802-6c6df2081e1b/azure/azure_managedDiskController.go:383:9: undefined: "k8s.io/api/core/v1".LabelFailureDomainBetaZone
Makefile:114: recipe for target 'azuredisk' failed
make: *** [azuredisk] Error 2
```

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
none
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
none
```

/priority important-soon
/sig cloud-provider
/area provider/azure
/triage accepted
/assign @feiskyer 