### PR TITLE
Log defaulted kube-scheduler component config at startup

### DIFF
--- a/cmd/kube-scheduler/app/options/configfile.go
+++ b/cmd/kube-scheduler/app/options/configfile.go
@@ -19,6 +19,7 @@ package options
 import (
 	"fmt"
 	"io/ioutil"
+	"k8s.io/klog/v2"
 	"os"
 
 	"k8s.io/apimachinery/pkg/runtime"
@@ -48,8 +49,13 @@ func loadConfig(data []byte) (*kubeschedulerconfig.KubeSchedulerConfiguration, e
 	return nil, fmt.Errorf("couldn't decode as KubeSchedulerConfiguration, got %s: ", gvk)
 }
 
-// WriteConfigFile writes the config into the given file name as YAML.
-func WriteConfigFile(fileName string, cfg *kubeschedulerconfig.KubeSchedulerConfiguration) error {
+// LogOrWriteConfig logs the completed component config and writes it into the given file name as YAML, if either is enabled
+func LogOrWriteConfig(fileName string, cfg *kubeschedulerconfig.KubeSchedulerConfiguration, completedProfiles []kubeschedulerconfig.KubeSchedulerProfile) error {
+	if !(klog.V(2).Enabled() || len(fileName) > 0) {
+		return nil
+	}
+	cfg.Profiles = completedProfiles
+
 	const mediaType = runtime.ContentTypeYAML
 	info, ok := runtime.SerializerInfoForMediaType(kubeschedulerscheme.Codecs.SupportedMediaTypes(), mediaType)
 	if !ok {
@@ -57,15 +63,26 @@ func WriteConfigFile(fileName string, cfg *kubeschedulerconfig.KubeSchedulerConf
 	}
 
 	encoder := kubeschedulerscheme.Codecs.EncoderForVersion(info.Serializer, kubeschedulerconfigv1beta1.SchemeGroupVersion)
-
-	configFile, err := os.Create(fileName)
-	if err != nil {
-		return err
+	if klog.V(2).Enabled() {
+		bytes, err := runtime.Encode(encoder, cfg)
+		if err != nil {
+			return err
+		}
+		configString := string(bytes)
+		klog.Infof("Using component config:\n%+v\n", configString)
 	}
-	defer configFile.Close()
-	if err := encoder.Encode(cfg, configFile); err != nil {
-		return err
-	}
 
+	if len(fileName) > 0 {
+		configFile, err := os.Create(fileName)
+		if err != nil {
+			return err
+		}
+		defer configFile.Close()
+		if err := encoder.Encode(cfg, configFile); err != nil {
+			return err
+		}
+		klog.Infof("Wrote configuration to: %s\n", fileName)
+		os.Exit(0)
+	}
 	return nil
 }

--- a/cmd/kube-scheduler/app/server.go
+++ b/cmd/kube-scheduler/app/server.go
@@ -128,14 +128,6 @@ func runCommand(cmd *cobra.Command, opts *options.Options, registryOptions ...Op
 		return err
 	}
 
-	if len(opts.WriteConfigTo) > 0 {
-		if err := options.WriteConfigFile(opts.WriteConfigTo, &cc.ComponentConfig); err != nil {
-			return err
-		}
-		klog.Infof("Wrote configuration to: %s\n", opts.WriteConfigTo)
-		return nil
-	}
-
 	return Run(ctx, cc, sched)
 }
 
@@ -310,6 +302,7 @@ func Setup(ctx context.Context, opts *options.Options, outOfTreeRegistryOptions 
 	}
 
 	recorderFactory := getRecorderFactory(&cc)
+	completedProfiles := make([]kubeschedulerconfig.KubeSchedulerProfile, 0)
 	// Create the scheduler.
 	sched, err := scheduler.New(cc.Client,
 		cc.InformerFactory,
@@ -323,8 +316,15 @@ func Setup(ctx context.Context, opts *options.Options, outOfTreeRegistryOptions 
 		scheduler.WithPodInitialBackoffSeconds(cc.ComponentConfig.PodInitialBackoffSeconds),
 		scheduler.WithExtenders(cc.ComponentConfig.Extenders...),
 		scheduler.WithParallelism(cc.ComponentConfig.Parallelism),
+		scheduler.WithBuildFrameworkCapturer(func(profile kubeschedulerconfig.KubeSchedulerProfile) {
+			// Profiles are processed during Framework instantiation to set default plugins and configurations. Capturing them for logging
+			completedProfiles = append(completedProfiles, profile)
+		}),
 	)
 	if err != nil {
+		return nil, nil, err
+	}
+	if err := options.LogOrWriteConfig(opts.WriteConfigTo, &cc.ComponentConfig, completedProfiles); err != nil {
 		return nil, nil, err
 	}
 

--- a/pkg/scheduler/BUILD
+++ b/pkg/scheduler/BUILD
@@ -66,6 +66,7 @@ go_test(
         "//pkg/scheduler/framework/plugins:go_default_library",
         "//pkg/scheduler/framework/plugins/defaultbinder:go_default_library",
         "//pkg/scheduler/framework/plugins/interpodaffinity:go_default_library",
+        "//pkg/scheduler/framework/plugins/nodeaffinity:go_default_library",
         "//pkg/scheduler/framework/plugins/nodelabel:go_default_library",
         "//pkg/scheduler/framework/plugins/nodeports:go_default_library",
         "//pkg/scheduler/framework/plugins/noderesources:go_default_library",

--- a/pkg/scheduler/BUILD
+++ b/pkg/scheduler/BUILD
@@ -65,6 +65,7 @@ go_test(
         "//pkg/scheduler/framework:go_default_library",
         "//pkg/scheduler/framework/plugins:go_default_library",
         "//pkg/scheduler/framework/plugins/defaultbinder:go_default_library",
+        "//pkg/scheduler/framework/plugins/defaultpreemption:go_default_library",
         "//pkg/scheduler/framework/plugins/interpodaffinity:go_default_library",
         "//pkg/scheduler/framework/plugins/nodeaffinity:go_default_library",
         "//pkg/scheduler/framework/plugins/nodelabel:go_default_library",

--- a/pkg/scheduler/factory.go
+++ b/pkg/scheduler/factory.go
@@ -137,12 +137,8 @@ func (c *Configurator) create() (*Scheduler, error) {
 		frameworkruntime.WithSnapshotSharedLister(c.nodeInfoSnapshot),
 		frameworkruntime.WithRunAllFilters(c.alwaysCheckAllPredicates),
 		frameworkruntime.WithPodNominator(nominator),
+		frameworkruntime.WithCaptureProfile(frameworkruntime.CaptureProfile(c.frameworkCapturer)),
 	)
-	for _, p := range c.profiles {
-		if c.frameworkCapturer != nil {
-			c.frameworkCapturer(p)
-		}
-	}
 	if err != nil {
 		return nil, fmt.Errorf("initializing profiles: %v", err)
 	}

--- a/pkg/scheduler/factory_test.go
+++ b/pkg/scheduler/factory_test.go
@@ -39,10 +39,12 @@ import (
 	"k8s.io/kubernetes/pkg/scheduler/framework"
 	frameworkplugins "k8s.io/kubernetes/pkg/scheduler/framework/plugins"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/interpodaffinity"
+	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/nodeaffinity"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/nodelabel"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/noderesources"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/podtopologyspread"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/serviceaffinity"
+	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/volumebinding"
 	frameworkruntime "k8s.io/kubernetes/pkg/scheduler/framework/runtime"
 	internalcache "k8s.io/kubernetes/pkg/scheduler/internal/cache"
 	internalqueue "k8s.io/kubernetes/pkg/scheduler/internal/queue"
@@ -106,8 +108,37 @@ func TestCreateFromConfig(t *testing.T) {
 			}`),
 			wantPluginConfig: []schedulerapi.PluginConfig{
 				{
+					Name: interpodaffinity.Name,
+					Args: &schedulerapi.InterPodAffinityArgs{
+						HardPodAffinityWeight: 1,
+					},
+				},
+				{
+					Name: nodeaffinity.Name,
+					Args: &schedulerapi.NodeAffinityArgs{},
+				},
+				{
+					Name: noderesources.FitName,
+					Args: &schedulerapi.NodeResourcesFitArgs{},
+				},
+				{
+					Name: noderesources.LeastAllocatedName,
+					Args: &schedulerapi.NodeResourcesLeastAllocatedArgs{
+						Resources: []schedulerapi.ResourceSpec{
+							{Name: "cpu", Weight: 1},
+							{Name: "memory", Weight: 1},
+						},
+					},
+				},
+				{
 					Name: podtopologyspread.Name,
 					Args: &schedulerapi.PodTopologySpreadArgs{DefaultingType: schedulerapi.SystemDefaulting},
+				},
+				{
+					Name: volumebinding.Name,
+					Args: &schedulerapi.VolumeBindingArgs{
+						BindTimeoutSeconds: 600,
+					},
 				},
 			},
 			wantPlugins: &schedulerapi.Plugins{
@@ -201,19 +232,22 @@ func TestCreateFromConfig(t *testing.T) {
 			}`),
 			wantPluginConfig: []schedulerapi.PluginConfig{
 				{
+					Name: interpodaffinity.Name,
+					Args: &schedulerapi.InterPodAffinityArgs{
+						HardPodAffinityWeight: 1,
+					},
+				},
+				{
+					Name: nodeaffinity.Name,
+					Args: &schedulerapi.NodeAffinityArgs{},
+				},
+				{
 					Name: nodelabel.Name,
 					Args: &schedulerapi.NodeLabelArgs{
 						PresentLabels:           []string{"zone"},
 						AbsentLabels:            []string{"foo"},
 						PresentLabelsPreference: []string{"l1"},
 						AbsentLabelsPreference:  []string{"l2"},
-					},
-				},
-				{
-					Name: serviceaffinity.Name,
-					Args: &schedulerapi.ServiceAffinityArgs{
-						AffinityLabels:               []string{"zone", "foo"},
-						AntiAffinityLabelsPreference: []string{"rack", "zone"},
 					},
 				},
 				{
@@ -224,6 +258,13 @@ func TestCreateFromConfig(t *testing.T) {
 							{Utilization: 50, Score: 7},
 						},
 						Resources: []schedulerapi.ResourceSpec{},
+					},
+				},
+				{
+					Name: serviceaffinity.Name,
+					Args: &schedulerapi.ServiceAffinityArgs{
+						AffinityLabels:               []string{"zone", "foo"},
+						AntiAffinityLabelsPreference: []string{"rack", "zone"},
 					},
 				},
 			},
@@ -262,38 +303,24 @@ func TestCreateFromConfig(t *testing.T) {
 				"kind" : "Policy",
 				"apiVersion" : "v1",
 				"predicates" : [
-					{"name" : "TestZoneAffinity", "argument" : {"serviceAffinity" : {"labels" : ["zone"]}}},
-					{"name" : "TestRequireZone", "argument" : {"labelsPresence" : {"labels" : ["zone"], "presence" : true}}},
 					{"name" : "PodFitsResources"},
 					{"name" : "PodFitsHostPorts"}
 				],
 				"priorities" : [
-					{"name" : "RackSpread", "weight" : 3, "argument" : {"serviceAntiAffinity" : {"label" : "rack"}}},
-					{"name" : "NodeAffinityPriority", "weight" : 2},
-					{"name" : "ImageLocalityPriority", "weight" : 1},
 					{"name" : "InterPodAffinityPriority", "weight" : 1}
 				],
 				"hardPodAffinitySymmetricWeight" : 10
 			}`),
 			wantPluginConfig: []schedulerapi.PluginConfig{
 				{
-					Name: nodelabel.Name,
-					Args: &schedulerapi.NodeLabelArgs{
-						PresentLabels: []string{"zone"},
-					},
-				},
-				{
-					Name: serviceaffinity.Name,
-					Args: &schedulerapi.ServiceAffinityArgs{
-						AffinityLabels:               []string{"zone"},
-						AntiAffinityLabelsPreference: []string{"rack"},
-					},
-				},
-				{
 					Name: interpodaffinity.Name,
 					Args: &schedulerapi.InterPodAffinityArgs{
 						HardPodAffinityWeight: 10,
 					},
+				},
+				{
+					Name: "NodeResourcesFit",
+					Args: &schedulerapi.NodeResourcesFitArgs{},
 				},
 			},
 			wantPlugins: &schedulerapi.Plugins{
@@ -301,7 +328,6 @@ func TestCreateFromConfig(t *testing.T) {
 				PreFilter: &schedulerapi.PluginSet{Enabled: []schedulerapi.Plugin{
 					{Name: "NodePorts"},
 					{Name: "NodeResourcesFit"},
-					{Name: "ServiceAffinity"},
 				}},
 				Filter: &schedulerapi.PluginSet{
 					Enabled: []schedulerapi.Plugin{
@@ -309,18 +335,13 @@ func TestCreateFromConfig(t *testing.T) {
 						{Name: "NodePorts"},
 						{Name: "NodeResourcesFit"},
 						{Name: "TaintToleration"},
-						{Name: "NodeLabel"},
-						{Name: "ServiceAffinity"},
 					},
 				},
 				PostFilter: &schedulerapi.PluginSet{},
 				PreScore:   &schedulerapi.PluginSet{Enabled: []schedulerapi.Plugin{{Name: "InterPodAffinity"}}},
 				Score: &schedulerapi.PluginSet{
 					Enabled: []schedulerapi.Plugin{
-						{Name: "ImageLocality", Weight: 1},
 						{Name: "InterPodAffinity", Weight: 1},
-						{Name: "NodeAffinity", Weight: 2},
-						{Name: "ServiceAffinity", Weight: 3},
 					},
 				},
 				Reserve:  &schedulerapi.PluginSet{},

--- a/pkg/scheduler/factory_test.go
+++ b/pkg/scheduler/factory_test.go
@@ -38,6 +38,7 @@ import (
 	schedulerapi "k8s.io/kubernetes/pkg/scheduler/apis/config"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
 	frameworkplugins "k8s.io/kubernetes/pkg/scheduler/framework/plugins"
+	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/defaultpreemption"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/interpodaffinity"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/nodeaffinity"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/nodelabel"
@@ -107,6 +108,13 @@ func TestCreateFromConfig(t *testing.T) {
 				"apiVersion" : "v1"
 			}`),
 			wantPluginConfig: []schedulerapi.PluginConfig{
+				{
+					Name: defaultpreemption.Name,
+					Args: &schedulerapi.DefaultPreemptionArgs{
+						MinCandidateNodesPercentage: 10,
+						MinCandidateNodesAbsolute:   100,
+					},
+				},
 				{
 					Name: interpodaffinity.Name,
 					Args: &schedulerapi.InterPodAffinityArgs{
@@ -232,6 +240,13 @@ func TestCreateFromConfig(t *testing.T) {
 			}`),
 			wantPluginConfig: []schedulerapi.PluginConfig{
 				{
+					Name: defaultpreemption.Name,
+					Args: &schedulerapi.DefaultPreemptionArgs{
+						MinCandidateNodesPercentage: 10,
+						MinCandidateNodesAbsolute:   100,
+					},
+				},
+				{
 					Name: interpodaffinity.Name,
 					Args: &schedulerapi.InterPodAffinityArgs{
 						HardPodAffinityWeight: 1,
@@ -312,6 +327,13 @@ func TestCreateFromConfig(t *testing.T) {
 				"hardPodAffinitySymmetricWeight" : 10
 			}`),
 			wantPluginConfig: []schedulerapi.PluginConfig{
+				{
+					Name: defaultpreemption.Name,
+					Args: &schedulerapi.DefaultPreemptionArgs{
+						MinCandidateNodesPercentage: 10,
+						MinCandidateNodesAbsolute:   100,
+					},
+				},
 				{
 					Name: interpodaffinity.Name,
 					Args: &schedulerapi.InterPodAffinityArgs{


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
This PR passes the initialized ComponentConfig for kube-scheduler through the framework initialization functions, allowing the default plugin registry (and PluginArgs) to be presented to the user after plugin instantiation is filled out by API defaulting.

**Which issue(s) this PR fixes**:
Fixes #93718

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
kube-scheduler now logs processed component config at startup
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs

```
The output from a default scheduler with these changes looks like this:
```
I1110 20:13:58.509167       1 factory.go:193] Creating scheduler from algorithm provider 'DefaultProvider'
I1110 20:13:58.518715       1 configfile.go:66] Starting scheduler with component config:
apiVersion: kubescheduler.config.k8s.io/v1beta1
clientConnection:
  acceptContentTypes: ""
  burst: 100
  contentType: application/vnd.kubernetes.protobuf
  kubeconfig: /etc/kubernetes/scheduler.conf
  qps: 50
enableContentionProfiling: true
enableProfiling: true
healthzBindAddress: ""
kind: KubeSchedulerConfiguration
leaderElection:
  leaderElect: true
  leaseDuration: 15s
  renewDeadline: 10s
  resourceLock: leases
  resourceName: kube-scheduler
  resourceNamespace: kube-system
  retryPeriod: 2s
metricsBindAddress: ""
parallelism: 16
percentageOfNodesToScore: 0
podInitialBackoffSeconds: 1
podMaxBackoffSeconds: 10
profiles:
- pluginConfig:
  - args:
      apiVersion: kubescheduler.config.k8s.io/v1beta1
      kind: NodeAffinityArgs
    name: NodeAffinity
  - args:
      apiVersion: kubescheduler.config.k8s.io/v1beta1
      kind: NodeResourcesLeastAllocatedArgs
      resources:
      - name: cpu
        weight: 1
      - name: memory
        weight: 1
    name: NodeResourcesLeastAllocated
  - args:
      apiVersion: kubescheduler.config.k8s.io/v1beta1
      kind: NodeResourcesFitArgs
    name: NodeResourcesFit
  - args:
      apiVersion: kubescheduler.config.k8s.io/v1beta1
      bindTimeoutSeconds: 600
      kind: VolumeBindingArgs
    name: VolumeBinding
  - args:
      apiVersion: kubescheduler.config.k8s.io/v1beta1
      hardPodAffinityWeight: 1
      kind: InterPodAffinityArgs
    name: InterPodAffinity
  - args:
      apiVersion: kubescheduler.config.k8s.io/v1beta1
      kind: DefaultPreemptionArgs
      minCandidateNodesAbsolute: 100
      minCandidateNodesPercentage: 10
    name: DefaultPreemption
  - args:
      apiVersion: kubescheduler.config.k8s.io/v1beta1
      defaultingType: System
      kind: PodTopologySpreadArgs
    name: PodTopologySpread
  plugins:
    bind:
      enabled:
      - name: DefaultBinder
        weight: 0
    filter:
      enabled:
      - name: NodeUnschedulable
        weight: 0
      - name: NodeName
        weight: 0
      - name: TaintToleration
        weight: 0
      - name: NodeAffinity
        weight: 0
      - name: NodePorts
        weight: 0
      - name: NodeResourcesFit
        weight: 0
      - name: VolumeRestrictions
        weight: 0
      - name: EBSLimits
        weight: 0
      - name: GCEPDLimits
        weight: 0
      - name: NodeVolumeLimits
        weight: 0
      - name: AzureDiskLimits
        weight: 0
      - name: VolumeBinding
        weight: 0
      - name: VolumeZone
        weight: 0
      - name: PodTopologySpread
        weight: 0
      - name: InterPodAffinity
        weight: 0
    permit: {}
    postBind: {}
    postFilter:
      enabled:
      - name: DefaultPreemption
        weight: 0
    preBind:
      enabled:
      - name: VolumeBinding
        weight: 0
    preFilter:
      enabled:
      - name: NodeResourcesFit
        weight: 0
      - name: NodePorts
        weight: 0
      - name: PodTopologySpread
        weight: 0
      - name: InterPodAffinity
        weight: 0
      - name: VolumeBinding
        weight: 0
    preScore:
      enabled:
      - name: InterPodAffinity
        weight: 0
      - name: PodTopologySpread
        weight: 0
      - name: TaintToleration
        weight: 0
    queueSort:
      enabled:
      - name: PrioritySort
        weight: 0
    reserve:
      enabled:
      - name: VolumeBinding
        weight: 0
    score:
      enabled:
      - name: NodeResourcesBalancedAllocation
        weight: 1
      - name: ImageLocality
        weight: 1
      - name: InterPodAffinity
        weight: 1
      - name: NodeResourcesLeastAllocated
        weight: 1
      - name: NodeAffinity
        weight: 1
      - name: NodePreferAvoidPods
        weight: 10000
      - name: PodTopologySpread
        weight: 2
      - name: TaintToleration
        weight: 1
  schedulerName: default-scheduler

I1110 20:13:58.518819       1 server.go:141] Starting Kubernetes Scheduler version v1.20.0-beta.1.378+56da2806a4cc31-dirty
```
/sig scheduling