### PR TITLE
[kubeadm]: Bump CoreDNS version to 1.8.0

### DIFF
--- a/build/dependencies.yaml
+++ b/build/dependencies.yaml
@@ -49,7 +49,7 @@ dependencies:
       match: k8s.gcr.io/coredns
 
   - name: "coredns-kubeadm"
-    version: 1.7.0
+    version: 1.8.0
     refPaths:
     - path: cmd/kubeadm/app/constants/constants.go
       match: CoreDNSVersion =

--- a/cmd/kubeadm/app/cmd/config_test.go
+++ b/cmd/kubeadm/app/cmd/config_test.go
@@ -249,7 +249,7 @@ k8s.gcr.io/kube-scheduler:{{.KubeVersion}}
 k8s.gcr.io/kube-proxy:{{.KubeVersion}}
 k8s.gcr.io/pause:{{.PauseVersion}}
 k8s.gcr.io/etcd:{{.EtcdVersion}}
-k8s.gcr.io/coredns:{{.CoreDNSVersion}}
+k8s.gcr.io/coredns/coredns:{{.CoreDNSVersion}}
 `,
 		},
 		{
@@ -268,7 +268,7 @@ k8s.gcr.io/coredns:{{.CoreDNSVersion}}
         "k8s.gcr.io/kube-proxy:{{.KubeVersion}}",
         "k8s.gcr.io/pause:{{.PauseVersion}}",
         "k8s.gcr.io/etcd:{{.EtcdVersion}}",
-        "k8s.gcr.io/coredns:{{.CoreDNSVersion}}"
+        "k8s.gcr.io/coredns/coredns:{{.CoreDNSVersion}}"
     ]
 }
 `,
@@ -287,7 +287,7 @@ images:
 - k8s.gcr.io/kube-proxy:{{.KubeVersion}}
 - k8s.gcr.io/pause:{{.PauseVersion}}
 - k8s.gcr.io/etcd:{{.EtcdVersion}}
-- k8s.gcr.io/coredns:{{.CoreDNSVersion}}
+- k8s.gcr.io/coredns/coredns:{{.CoreDNSVersion}}
 kind: Images
 `,
 		},
@@ -303,7 +303,7 @@ k8s.gcr.io/kube-scheduler:{{.KubeVersion}}
 k8s.gcr.io/kube-proxy:{{.KubeVersion}}
 k8s.gcr.io/pause:{{.PauseVersion}}
 k8s.gcr.io/etcd:{{.EtcdVersion}}
-k8s.gcr.io/coredns:{{.CoreDNSVersion}}
+k8s.gcr.io/coredns/coredns:{{.CoreDNSVersion}}
 `,
 		},
 		{
@@ -313,7 +313,7 @@ k8s.gcr.io/coredns:{{.CoreDNSVersion}}
 			},
 			outputFormat: `jsonpath={range.images[*]}{@} {end}`,
 			expectedOutput: "k8s.gcr.io/kube-apiserver:{{.KubeVersion}} k8s.gcr.io/kube-controller-manager:{{.KubeVersion}} k8s.gcr.io/kube-scheduler:{{.KubeVersion}} " +
-				"k8s.gcr.io/kube-proxy:{{.KubeVersion}} k8s.gcr.io/pause:{{.PauseVersion}} k8s.gcr.io/etcd:{{.EtcdVersion}} k8s.gcr.io/coredns:{{.CoreDNSVersion}} ",
+				"k8s.gcr.io/kube-proxy:{{.KubeVersion}} k8s.gcr.io/pause:{{.PauseVersion}} k8s.gcr.io/etcd:{{.EtcdVersion}} k8s.gcr.io/coredns/coredns:{{.CoreDNSVersion}} ",
 		},
 	}
 

--- a/cmd/kubeadm/app/constants/constants.go
+++ b/cmd/kubeadm/app/constants/constants.go
@@ -323,7 +323,7 @@ const (
 	CoreDNSDeploymentName = "coredns"
 
 	// CoreDNSImageName specifies the name of the image for CoreDNS add-on
-	CoreDNSImageName = "coredns"
+	CoreDNSImageName = "coredns/coredns"
 
 	// KubeDNSConfigMap specifies in what ConfigMap in the kube-system namespace the kube-dns config should be stored
 	KubeDNSConfigMap = "kube-dns"
@@ -344,7 +344,7 @@ const (
 	KubeDNSVersion = "1.14.13"
 
 	// CoreDNSVersion is the version of CoreDNS to be deployed if it is used
-	CoreDNSVersion = "1.7.0"
+	CoreDNSVersion = "v1.8.0"
 
 	// ClusterConfigurationKind is the string kind value for the ClusterConfiguration struct
 	ClusterConfigurationKind = "ClusterConfiguration"

--- a/cmd/kubeadm/app/phases/addons/dns/dns.go
+++ b/cmd/kubeadm/app/phases/addons/dns/dns.go
@@ -369,7 +369,7 @@ func isCoreDNSConfigMapMigrationRequired(corefile, currentInstalledCoreDNSVersio
 	if corefile == "" || migration.Default("", corefile) {
 		return isMigrationRequired, nil
 	}
-	deprecated, err := migration.Deprecated(currentInstalledCoreDNSVersion, kubeadmconstants.CoreDNSVersion, corefile)
+	deprecated, err := migration.Deprecated(currentInstalledCoreDNSVersion, strings.TrimLeft(kubeadmconstants.CoreDNSVersion, "v"), corefile)
 	if err != nil {
 		return isMigrationRequired, errors.Wrap(err, "unable to get list of changes to the configuration.")
 	}
@@ -386,7 +386,7 @@ func isCoreDNSConfigMapMigrationRequired(corefile, currentInstalledCoreDNSVersio
 
 func migrateCoreDNSCorefile(client clientset.Interface, cm *v1.ConfigMap, corefile, currentInstalledCoreDNSVersion string) error {
 	// Since the current configuration present is not the default version, try and migrate it.
-	updatedCorefile, err := migration.Migrate(currentInstalledCoreDNSVersion, kubeadmconstants.CoreDNSVersion, corefile, false)
+	updatedCorefile, err := migration.Migrate(currentInstalledCoreDNSVersion, strings.TrimLeft(kubeadmconstants.CoreDNSVersion, "v"), corefile, false)
 	if err != nil {
 		return errors.Wrap(err, "unable to migrate CoreDNS ConfigMap")
 	}
@@ -411,7 +411,7 @@ func migrateCoreDNSCorefile(client clientset.Interface, cm *v1.ConfigMap, corefi
 	}
 
 	fmt.Println("[addons] Migrating CoreDNS Corefile")
-	changes, err := migration.Deprecated(currentInstalledCoreDNSVersion, kubeadmconstants.CoreDNSVersion, corefile)
+	changes, err := migration.Deprecated(currentInstalledCoreDNSVersion, strings.TrimLeft(kubeadmconstants.CoreDNSVersion, "v"), corefile)
 	if err != nil {
 		return errors.Wrap(err, "unable to get list of changes to the configuration.")
 	}

--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/codegangsta/negroni v1.0.0 // indirect
 	github.com/container-storage-interface/spec v1.2.0
 	github.com/containernetworking/cni v0.8.0
-	github.com/coredns/corefile-migration v1.0.10
+	github.com/coredns/corefile-migration v1.0.11
 	github.com/coreos/go-oidc v2.1.0+incompatible
 	github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e
 	github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f
@@ -213,7 +213,7 @@ replace (
 	github.com/containerd/ttrpc => github.com/containerd/ttrpc v1.0.0
 	github.com/containerd/typeurl => github.com/containerd/typeurl v1.0.0
 	github.com/containernetworking/cni => github.com/containernetworking/cni v0.8.0
-	github.com/coredns/corefile-migration => github.com/coredns/corefile-migration v1.0.10
+	github.com/coredns/corefile-migration => github.com/coredns/corefile-migration v1.0.11
 	github.com/coreos/bbolt => github.com/coreos/bbolt v1.3.2
 	github.com/coreos/etcd => github.com/coreos/etcd v3.3.13+incompatible
 	github.com/coreos/go-oidc => github.com/coreos/go-oidc v2.1.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -113,8 +113,8 @@ github.com/containerd/typeurl v1.0.0 h1:7LMH7LfEmpWeCkGcIputvd4P0Rnd0LrIv1Jk2s5o
 github.com/containerd/typeurl v1.0.0/go.mod h1:Cm3kwCdlkCfMSHURc+r6fwoGH6/F1hH3S4sg0rLFWPc=
 github.com/containernetworking/cni v0.8.0 h1:BT9lpgGoH4jw3lFC7Odz2prU5ruiYKcgAjMCbgybcKI=
 github.com/containernetworking/cni v0.8.0/go.mod h1:LGwApLUm2FpoOfxTDEeq8T9ipbpZ61X79hmU3w8FmsY=
-github.com/coredns/corefile-migration v1.0.10 h1:7HI4r5S5Fne749a+JDxUZppqBpYoZK8Q53ZVK9cn3aM=
-github.com/coredns/corefile-migration v1.0.10/go.mod h1:RMy/mXdeDlYwzt0vdMEJvT2hGJ2I86/eO0UdXmH9XNI=
+github.com/coredns/corefile-migration v1.0.11 h1:ptBYGW2ADXIB7ZEBPrhhTvNwJLQfxE3Q9IUMBhJCEeI=
+github.com/coredns/corefile-migration v1.0.11/go.mod h1:RMy/mXdeDlYwzt0vdMEJvT2hGJ2I86/eO0UdXmH9XNI=
 github.com/coreos/bbolt v1.3.2 h1:wZwiHHUieZCquLkDL0B8UhzreNWsPHooDAG3q34zk0s=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.13+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=

--- a/vendor/github.com/coredns/corefile-migration/migration/migrate.go
+++ b/vendor/github.com/coredns/corefile-migration/migration/migrate.go
@@ -140,6 +140,15 @@ func Migrate(fromCoreDNSVersion, toCoreDNSVersion, corefileStr string, deprecati
 	v := fromCoreDNSVersion
 	for {
 		v = Versions[v].nextVersion
+
+		// apply any global corefile level pre-processing
+		if Versions[v].preProcess != nil {
+			cf, err = Versions[v].preProcess(cf)
+			if err != nil {
+				return "", err
+			}
+		}
+
 		newSrvs := []*corefile.Server{}
 		for _, s := range cf.Servers {
 			newPlugs := []*corefile.Plugin{}

--- a/vendor/github.com/coredns/corefile-migration/migration/versions.go
+++ b/vendor/github.com/coredns/corefile-migration/migration/versions.go
@@ -12,10 +12,11 @@ type release struct {
 	dockerImageSHA string            // the docker image SHA for this release
 	plugins        map[string]plugin // map of plugins with deprecation status and migration actions for this release
 
-	// postProcess is a post processing action to take on the corefile as a whole.  Used for complex migration
+	// pre/postProcess are processing actions to take on the corefile as a whole.  Used for complex migration
 	//   tasks that dont fit well into the modular plugin/option migration framework. For example, when the
 	//   action on a plugin would need to extend beyond the scope of that plugin (affecting other plugins, or
 	//   server blocks, etc). e.g. Splitting plugins out into separate server blocks.
+	preProcess corefileAction
 	postProcess corefileAction
 
 	// defaultConf holds the default Corefile template packaged with the corresponding k8sReleases.
@@ -29,7 +30,53 @@ type release struct {
 
 // Versions holds a map of plugin/option migrations per CoreDNS release (since 1.1.4)
 var Versions = map[string]release{
+	"1.8.0": {
+		priorVersion:   "1.7.1",
+		dockerImageSHA: "TBD",
+		plugins: map[string]plugin{
+			"errors":       plugins["errors"]["v2"],
+			"log":          plugins["log"]["v1"],
+			"health":       plugins["health"]["v1"],
+			"ready":        {},
+			"autopath":     {},
+			"kubernetes":   plugins["kubernetes"]["v8 remove transfer option"],
+			"k8s_external": plugins["k8s_external"]["v1"],
+			"prometheus":   {},
+			"forward":      plugins["forward"]["v3"],
+			"cache":        plugins["cache"]["v1"],
+			"loop":         {},
+			"reload":       {},
+			"loadbalance":  {},
+			"hosts":        plugins["hosts"]["v1"],
+			"rewrite":      plugins["rewrite"]["v2"],
+			"transfer":     plugins["transfer"]["v1"],
+		},
+		preProcess: copyKubernetesTransferOptToPlugin,
+	},
+	"1.7.1": {
+		nextVersion:    "1.8.0",
+		priorVersion:   "1.7.0",
+		dockerImageSHA: "4a6e0769130686518325b21b0c1d0688b54e7c79244d48e1b15634e98e40c6ef",
+		plugins: map[string]plugin{
+			"errors":       plugins["errors"]["v2"],
+			"log":          plugins["log"]["v1"],
+			"health":       plugins["health"]["v1"],
+			"ready":        {},
+			"autopath":     {},
+			"kubernetes":   plugins["kubernetes"]["v7"],
+			"k8s_external": plugins["k8s_external"]["v1"],
+			"prometheus":   {},
+			"forward":      plugins["forward"]["v3"],
+			"cache":        plugins["cache"]["v1"],
+			"loop":         {},
+			"reload":       {},
+			"loadbalance":  {},
+			"hosts":        plugins["hosts"]["v1"],
+			"rewrite":      plugins["rewrite"]["v2"],
+		},
+	},
 	"1.7.0": {
+		nextVersion:    "1.7.1",
 		priorVersion:   "1.6.9",
 		k8sReleases:    []string{"1.19"},
 		dockerImageSHA: "73ca82b4ce829766d4f1f10947c3a338888f876fbed0540dc849c89ff256e90c",
@@ -62,7 +109,7 @@ var Versions = map[string]release{
 			"kubernetes":   plugins["kubernetes"]["v7"],
 			"k8s_external": plugins["k8s_external"]["v1"],
 			"prometheus":   {},
-			"forward":      plugins["forward"]["v3"],
+			"forward":      plugins["forward"]["v3 add max_concurrent"],
 			"cache":        plugins["cache"]["v1"],
 			"loop":         {},
 			"reload":       {},
@@ -84,7 +131,7 @@ var Versions = map[string]release{
 			"kubernetes":   plugins["kubernetes"]["v6"],
 			"k8s_external": plugins["k8s_external"]["v1"],
 			"prometheus":   {},
-			"forward":      plugins["forward"]["v2"],
+			"forward":      plugins["forward"]["v3"],
 			"cache":        plugins["cache"]["v2"],
 			"loop":         {},
 			"reload":       {},

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -266,9 +266,9 @@ github.com/containernetworking/cni/pkg/types/020
 github.com/containernetworking/cni/pkg/types/current
 github.com/containernetworking/cni/pkg/utils
 github.com/containernetworking/cni/pkg/version
-# github.com/coredns/corefile-migration v1.0.10 => github.com/coredns/corefile-migration v1.0.10
+# github.com/coredns/corefile-migration v1.0.11 => github.com/coredns/corefile-migration v1.0.11
 ## explicit
-# github.com/coredns/corefile-migration => github.com/coredns/corefile-migration v1.0.10
+# github.com/coredns/corefile-migration => github.com/coredns/corefile-migration v1.0.11
 github.com/coredns/corefile-migration/migration
 github.com/coredns/corefile-migration/migration/corefile
 # github.com/coreos/bbolt => github.com/coreos/bbolt v1.3.2


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Bumps the CoreDNS version to v1.8.0 in kubeadm
Also updates the corefile-migration library to v1.0.11 which supports CoreDNS v1.8.0

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Kubeadm now includes CoreDNS v1.8.0.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
