### PR TITLE
Bug Fix for process_start_time_metric initialization

### DIFF
--- a/staging/src/k8s.io/component-base/metrics/processstarttime.go
+++ b/staging/src/k8s.io/component-base/metrics/processstarttime.go
@@ -43,6 +43,12 @@ func RegisterProcessStartTime(registrationFunc func(Registerable) error) error {
 		klog.Errorf("Could not get process start time, %v", err)
 		start = float64(time.Now().Unix())
 	}
+	// processStartTime is a lazy metric which only get initialized after registered.
+	// so we have to explicitly create it before setting the label value. Otherwise
+	// it is a noop.
+	if !processStartTime.IsCreated() {
+		processStartTime.initializeMetric()
+	}
 	processStartTime.WithLabelValues().Set(start)
 	return registrationFunc(processStartTime)
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
processStartTime uses a "lazy-metric" which only get created during the first time registration.
This is problematic in the current `RegisterProcessStartTime` code because we are setting the label which is a noop in the first call.

https://github.com/kubernetes/component-base/blob/92d83a5bfee5978cd79ae75eec9b7eef1e0fec42/metrics/gauge.go#L132-L137

The issue is discovered in the kubernetes-csi/csi-lib-utils. So we find that calling the RegisterProcessStartTime once does not take affect.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```

/wg component-standard
/sig api-machinery

/cc @logicalhan 
/cc @RainbowMango 
/cc @msau42 
/cc @saad-ali 
/cc @verult 
/cc @jingxu97 