### PR TITLE
Capture defaulted plugin configs from framework

### DIFF
--- a/pkg/scheduler/BUILD
+++ b/pkg/scheduler/BUILD
@@ -67,6 +67,7 @@ go_test(
         "//pkg/scheduler/framework/plugins:go_default_library",
         "//pkg/scheduler/framework/plugins/defaultbinder:go_default_library",
         "//pkg/scheduler/framework/plugins/interpodaffinity:go_default_library",
+        "//pkg/scheduler/framework/plugins/nodeaffinity:go_default_library",
         "//pkg/scheduler/framework/plugins/nodelabel:go_default_library",
         "//pkg/scheduler/framework/plugins/nodeports:go_default_library",
         "//pkg/scheduler/framework/plugins/noderesources:go_default_library",

--- a/pkg/scheduler/factory.go
+++ b/pkg/scheduler/factory.go
@@ -138,12 +138,8 @@ func (c *Configurator) create() (*Scheduler, error) {
 		frameworkruntime.WithSnapshotSharedLister(c.nodeInfoSnapshot),
 		frameworkruntime.WithRunAllFilters(c.alwaysCheckAllPredicates),
 		frameworkruntime.WithPodNominator(nominator),
+		frameworkruntime.WithCaptureProfile(frameworkruntime.CaptureProfile(c.frameworkCapturer)),
 	)
-	for _, p := range c.profiles {
-		if c.frameworkCapturer != nil {
-			c.frameworkCapturer(p)
-		}
-	}
 	if err != nil {
 		return nil, fmt.Errorf("initializing profiles: %v", err)
 	}


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Some plugin configs are not produced until the framework is instantiated. Add a callback to capture them inside the framework constructor.

**Which issue(s) this PR fixes**:

Should enable #93718

**Special notes for your reviewer**:

Feel free to lgtm this or incorporate in your PR.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

/sig scheduling
/triage accepted