### PR TITLE
DaemonSet controller respects MaxSurge during update

### DIFF
--- a/pkg/api/v1/pod/util.go
+++ b/pkg/api/v1/pod/util.go
@@ -290,7 +290,7 @@ func IsPodAvailable(pod *v1.Pod, minReadySeconds int32, now metav1.Time) bool {
 
 	c := GetPodReadyCondition(pod.Status)
 	minReadySecondsDuration := time.Duration(minReadySeconds) * time.Second
-	if minReadySeconds == 0 || !c.LastTransitionTime.IsZero() && c.LastTransitionTime.Add(minReadySecondsDuration).Before(now.Time) {
+	if minReadySeconds == 0 || (!c.LastTransitionTime.IsZero() && c.LastTransitionTime.Add(minReadySecondsDuration).Before(now.Time)) {
 		return true
 	}
 	return false

--- a/pkg/controller/daemon/daemon_controller_test.go
+++ b/pkg/controller/daemon/daemon_controller_test.go
@@ -1983,7 +1983,6 @@ func TestNodeShouldRunDaemonPod(t *testing.T) {
 		nodeUnschedulable                bool
 		ds                               *apps.DaemonSet
 		shouldRun, shouldContinueRunning bool
-		err                              error
 	}{
 		{
 			predicateName: "ShouldRunDaemonPod",
@@ -2262,16 +2261,13 @@ func TestNodeShouldRunDaemonPod(t *testing.T) {
 				manager.podNodeIndex.Add(p)
 			}
 			c.ds.Spec.UpdateStrategy = *strategy
-			shouldRun, shouldContinueRunning, err := manager.nodeShouldRunDaemonPod(node, c.ds)
+			shouldRun, shouldContinueRunning := manager.nodeShouldRunDaemonPod(node, c.ds)
 
 			if shouldRun != c.shouldRun {
 				t.Errorf("[%v] strategy: %v, predicateName: %v expected shouldRun: %v, got: %v", i, c.ds.Spec.UpdateStrategy.Type, c.predicateName, c.shouldRun, shouldRun)
 			}
 			if shouldContinueRunning != c.shouldContinueRunning {
 				t.Errorf("[%v] strategy: %v, predicateName: %v expected shouldContinueRunning: %v, got: %v", i, c.ds.Spec.UpdateStrategy.Type, c.predicateName, c.shouldContinueRunning, shouldContinueRunning)
-			}
-			if err != c.err {
-				t.Errorf("[%v] strategy: %v, predicateName: %v expected err: %v, got: %v", i, c.predicateName, c.ds.Spec.UpdateStrategy.Type, c.err, err)
 			}
 		}
 	}

--- a/pkg/controller/daemon/update.go
+++ b/pkg/controller/daemon/update.go
@@ -26,12 +26,11 @@ import (
 	"k8s.io/klog/v2"
 
 	apps "k8s.io/api/apps/v1"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
-	intstrutil "k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/json"
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 	"k8s.io/kubernetes/pkg/controller"
@@ -46,37 +45,146 @@ func (dsc *DaemonSetsController) rollingUpdate(ds *apps.DaemonSet, nodeList []*v
 	if err != nil {
 		return fmt.Errorf("couldn't get node to daemon pod mapping for daemon set %q: %v", ds.Name, err)
 	}
-
-	_, oldPods := dsc.getAllDaemonSetPods(ds, nodeToDaemonPods, hash)
-	maxUnavailable, numUnavailable, err := dsc.getUnavailableNumbers(ds, nodeList, nodeToDaemonPods)
+	maxSurge, maxUnavailable, numUnavailable, err := dsc.getUnavailableNumbers(ds, nodeList, nodeToDaemonPods)
 	if err != nil {
 		return fmt.Errorf("couldn't get unavailable numbers: %v", err)
 	}
-	oldAvailablePods, oldUnavailablePods := util.SplitByAvailablePods(ds.Spec.MinReadySeconds, oldPods)
 
-	// for oldPods delete all not running pods
+	now := dsc.failedPodsBackoff.Clock.Now()
+
+	// When not surging, we delete just enough pods to stay under the maxUnavailable limit, if any
+	// are necessary, and let the core loop create new instances on those nodes.
+	if maxSurge == 0 {
+		_, oldPods := dsc.getAllDaemonSetPods(ds, nodeToDaemonPods, hash)
+		oldAvailablePods, oldUnavailablePods := util.SplitByAvailablePods(ds.Spec.MinReadySeconds, oldPods, now)
+
+		var oldPodsToDelete []string
+		klog.V(4).Infof("Marking all unavailable old pods for deletion")
+		for _, pod := range oldUnavailablePods {
+			// Skip terminating pods. We won't delete them again
+			if pod.DeletionTimestamp != nil {
+				continue
+			}
+			klog.V(4).Infof("Marking pod %s/%s for deletion", ds.Name, pod.Name)
+			oldPodsToDelete = append(oldPodsToDelete, pod.Name)
+		}
+		for _, pod := range oldAvailablePods {
+			if numUnavailable >= maxUnavailable {
+				klog.V(4).Infof("Number of unavailable DaemonSet pods: %d, is equal to or exceeds allowed maximum: %d", numUnavailable, maxUnavailable)
+				break
+			}
+
+			klog.V(4).Infof("Marking pod %s/%s for deletion", ds.Name, pod.Name)
+			oldPodsToDelete = append(oldPodsToDelete, pod.Name)
+			numUnavailable++
+		}
+		return dsc.syncNodes(ds, oldPodsToDelete, nil, hash)
+	}
+
+	// When surging, we create new pods whenever an old pod is unavailable, and we can create up
+	// to maxSurge extra pods
+	//
+	// Assumptions:
+	// * Expect manage loop to allow no more than two pods per node, one old, one new
+	// * Expect manage loop will create new pods if there are no pods on node
+	// * Expect manage loop will handle failed pods
+	// * Deleted pods do not count as unavailable so that updates make progress when nodes are down
+	// Invariants:
+	// * A node with an unavailable old pod is a candidate for immediate new pod creation
+	// * An old available pod is deleted if a new pod is available
+	// * No more than maxSurge new pods are created for old available pods at any one time
+	//
 	var oldPodsToDelete []string
-	klog.V(4).Infof("Marking all unavailable old pods for deletion")
-	for _, pod := range oldUnavailablePods {
-		// Skip terminating pods. We won't delete them again
+	var candidateNewNodes []string
+	var allowedNewNodes []string
+	var numSurge int
+
+	for nodeName, pods := range nodeToDaemonPods {
+		newPod, oldPod, ok := findSurgePodsOnNode(ds, pods, hash)
+		if !ok {
+			// let the manage loop clean up this node, and treat it as a surge node
+			klog.V(3).Infof("DaemonSet %s/%s has excess pods on node %s, skipping to allow the core loop to process", ds.Namespace, ds.Name, nodeName)
+			numSurge++
+			continue
+		}
+		switch {
+		case oldPod == nil:
+			// we don't need to do anything to this node, the manage loop will handle it
+		case newPod == nil:
+			// this is a surge candidate
+			switch {
+			case !podutil.IsPodAvailable(oldPod, ds.Spec.MinReadySeconds, metav1.Time{Time: now}):
+				// the old pod isn't available, allow it to become a replacement
+				klog.V(5).Infof("Pod %s on node %s is out of date and not available, allowing replacement", ds.Namespace, ds.Name, oldPod.Name, nodeName)
+				// record the replacement
+				if allowedNewNodes == nil {
+					allowedNewNodes = make([]string, 0, len(nodeList))
+				}
+				allowedNewNodes = append(allowedNewNodes, nodeName)
+			case numSurge >= maxSurge:
+				// no point considering any other candidates
+				continue
+			default:
+				klog.V(5).Infof("DaemonSet %s/%s pod %s on node %s is out of date, this is a surge candidate", ds.Namespace, ds.Name, oldPod.Name, nodeName)
+				// record the candidate
+				if candidateNewNodes == nil {
+					candidateNewNodes = make([]string, 0, maxSurge)
+				}
+				candidateNewNodes = append(candidateNewNodes, nodeName)
+			}
+		default:
+			// we have already surged onto this node, determine our state
+			if !podutil.IsPodAvailable(newPod, ds.Spec.MinReadySeconds, metav1.Time{Time: now}) {
+				// we're waiting to go available here
+				numSurge++
+				continue
+			}
+			// we're available, delete the old pod
+			klog.V(5).Infof("DaemonSet %s/%s pod %s on node %s is available, remove %s", ds.Namespace, ds.Name, newPod.Name, nodeName, oldPod.Name)
+			oldPodsToDelete = append(oldPodsToDelete, oldPod.Name)
+		}
+	}
+
+	// use any of the candidates we can, including the allowedNewNodes
+	klog.V(5).Infof("DaemonSet %s/%s allowing %d replacements, surge up to %d, %d are in progress, %d candidates", ds.Namespace, ds.Name, len(allowedNewNodes), maxSurge, numSurge, len(candidateNewNodes))
+	remainingSurge := maxSurge - numSurge
+	if remainingSurge < 0 {
+		remainingSurge = 0
+	}
+	if max := len(candidateNewNodes); remainingSurge > max {
+		remainingSurge = max
+	}
+	newNodesToCreate := append(allowedNewNodes, candidateNewNodes[:remainingSurge]...)
+
+	return dsc.syncNodes(ds, oldPodsToDelete, newNodesToCreate, hash)
+}
+
+// findSurgePodsOnNode looks at non-deleted pods on a given node and returns true if there
+// is at most one of each old and new pods, or false if there are multiples. We can skip
+// processing the particular node in those scenarios and let the manage loop prune the
+// excess pods for our next time around.
+func findSurgePodsOnNode(ds *apps.DaemonSet, podsOnNode []*v1.Pod, hash string) (newPod, oldPod *v1.Pod, ok bool) {
+	for _, pod := range podsOnNode {
 		if pod.DeletionTimestamp != nil {
 			continue
 		}
-		klog.V(4).Infof("Marking pod %s/%s for deletion", ds.Name, pod.Name)
-		oldPodsToDelete = append(oldPodsToDelete, pod.Name)
-	}
-
-	klog.V(4).Infof("Marking old pods for deletion")
-	for _, pod := range oldAvailablePods {
-		if numUnavailable >= maxUnavailable {
-			klog.V(4).Infof("Number of unavailable DaemonSet pods: %d, is equal to or exceeds allowed maximum: %d", numUnavailable, maxUnavailable)
-			break
+		generation, err := util.GetTemplateGeneration(ds)
+		if err != nil {
+			generation = nil
 		}
-		klog.V(4).Infof("Marking pod %s/%s for deletion", ds.Name, pod.Name)
-		oldPodsToDelete = append(oldPodsToDelete, pod.Name)
-		numUnavailable++
+		if util.IsPodUpdated(pod, hash, generation) {
+			if newPod != nil {
+				return nil, nil, false
+			}
+			newPod = pod
+		} else {
+			if oldPod != nil {
+				return nil, nil, false
+			}
+			oldPod = pod
+		}
 	}
-	return dsc.syncNodes(ds, oldPodsToDelete, []string{}, hash)
+	return newPod, oldPod, true
 }
 
 // constructHistory finds all histories controlled by the given DaemonSet, and
@@ -385,14 +493,18 @@ func (dsc *DaemonSetsController) getAllDaemonSetPods(ds *apps.DaemonSet, nodeToD
 	return newPods, oldPods
 }
 
-func (dsc *DaemonSetsController) getUnavailableNumbers(ds *apps.DaemonSet, nodeList []*v1.Node, nodeToDaemonPods map[string][]*v1.Pod) (int, int, error) {
+// getUnavailableNumbers calculates the true number of allowed unavailable or surge pods.
+// TODO: This method duplicates calculations in the main update loop and should be refactored
+//   to remove the need to calculate availability twice (once here, and once in the main loops)
+func (dsc *DaemonSetsController) getUnavailableNumbers(ds *apps.DaemonSet, nodeList []*v1.Node, nodeToDaemonPods map[string][]*v1.Pod) (int, int, int, error) {
 	klog.V(4).Infof("Getting unavailable numbers")
+	now := dsc.failedPodsBackoff.Clock.Now()
 	var numUnavailable, desiredNumberScheduled int
 	for i := range nodeList {
 		node := nodeList[i]
 		wantToRun, _, err := dsc.nodeShouldRunDaemonPod(node, ds)
 		if err != nil {
-			return -1, -1, err
+			return -1, -1, -1, err
 		}
 		if !wantToRun {
 			continue
@@ -405,8 +517,8 @@ func (dsc *DaemonSetsController) getUnavailableNumbers(ds *apps.DaemonSet, nodeL
 		}
 		available := false
 		for _, pod := range daemonPods {
-			//for the purposes of update we ensure that the Pod is both available and not terminating
-			if podutil.IsPodAvailable(pod, ds.Spec.MinReadySeconds, metav1.Now()) && pod.DeletionTimestamp == nil {
+			// for the purposes of update we ensure that the Pod is both available and not terminating
+			if podutil.IsPodAvailable(pod, ds.Spec.MinReadySeconds, metav1.Time{Time: now}) && pod.DeletionTimestamp == nil {
 				available = true
 				break
 			}
@@ -415,12 +527,25 @@ func (dsc *DaemonSetsController) getUnavailableNumbers(ds *apps.DaemonSet, nodeL
 			numUnavailable++
 		}
 	}
-	maxUnavailable, err := intstrutil.GetScaledValueFromIntOrPercent(ds.Spec.UpdateStrategy.RollingUpdate.MaxUnavailable, desiredNumberScheduled, true)
+
+	maxUnavailable, err := util.UnavailableCount(ds, desiredNumberScheduled)
 	if err != nil {
-		return -1, -1, fmt.Errorf("invalid value for MaxUnavailable: %v", err)
+		return -1, -1, -1, fmt.Errorf("invalid value for MaxUnavailable: %v", err)
 	}
-	klog.V(4).Infof(" DaemonSet %s/%s, maxUnavailable: %d, numUnavailable: %d", ds.Namespace, ds.Name, maxUnavailable, numUnavailable)
-	return maxUnavailable, numUnavailable, nil
+
+	maxSurge, err := util.SurgeCount(ds, desiredNumberScheduled)
+	if err != nil {
+		return -1, -1, -1, fmt.Errorf("invalid value for MaxSurge: %v", err)
+	}
+
+	// if the daemonset returned with an impossible configuration, obey the default of unavailable=1 (in the
+	// event the apiserver returns 0 for both surge and unavailability)
+	if desiredNumberScheduled > 0 && maxUnavailable == 0 && maxSurge == 0 {
+		klog.Warningf("DaemonSet %s/%s is not configured for surge or unavailability, defaulting to accepting unavailability", ds.Namespace, ds.Name)
+		maxUnavailable = 1
+	}
+	klog.V(0).Infof("DaemonSet %s/%s, maxSurge: %d, maxUnavailable: %d, numUnavailable: %d", ds.Namespace, ds.Name, maxSurge, maxUnavailable, numUnavailable)
+	return maxSurge, maxUnavailable, numUnavailable, nil
 }
 
 type historiesByRevision []*apps.ControllerRevision

--- a/pkg/controller/daemon/update.go
+++ b/pkg/controller/daemon/update.go
@@ -521,10 +521,7 @@ func (dsc *DaemonSetsController) updatedDesiredNodeCounts(ds *apps.DaemonSet, no
 	var desiredNumberScheduled int
 	for i := range nodeList {
 		node := nodeList[i]
-		wantToRun, _, err := dsc.nodeShouldRunDaemonPod(node, ds)
-		if err != nil {
-			return -1, -1, err
-		}
+		wantToRun, _ := dsc.nodeShouldRunDaemonPod(node, ds)
 		if !wantToRun {
 			continue
 		}

--- a/pkg/controller/daemon/update_test.go
+++ b/pkg/controller/daemon/update_test.go
@@ -18,12 +18,20 @@ package daemon
 
 import (
 	"testing"
+	"time"
 
 	apps "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/clock"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
+	"k8s.io/klog/v2"
+	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
+	"k8s.io/kubernetes/pkg/controller/daemon/util"
+	"k8s.io/kubernetes/pkg/features"
 )
 
 func TestDaemonSetUpdatesPods(t *testing.T) {
@@ -65,6 +73,48 @@ func TestDaemonSetUpdatesPods(t *testing.T) {
 	clearExpectations(t, manager, ds, podControl)
 	expectSyncDaemonSets(t, manager, ds, podControl, 0, 0, 0)
 	clearExpectations(t, manager, ds, podControl)
+}
+
+func TestDaemonSetUpdatesPodsWithMaxSurge(t *testing.T) {
+	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.DaemonSetUpdateSurge, true)()
+	ds := newDaemonSet("foo")
+	manager, podControl, _, err := newTestController(ds)
+	if err != nil {
+		t.Fatalf("error creating DaemonSets controller: %v", err)
+	}
+	addNodes(manager.nodeStore, 0, 5, nil)
+	manager.dsStore.Add(ds)
+	expectSyncDaemonSets(t, manager, ds, podControl, 5, 0, 0)
+	markPodsReady(podControl.podStore)
+
+	// surge is thhe controlling amount
+	maxSurge := 2
+	ds.Spec.Template.Spec.Containers[0].Image = "foo2/bar2"
+	ds.Spec.UpdateStrategy = newUpdateSurge(intstr.FromInt(maxSurge))
+	manager.dsStore.Update(ds)
+
+	clearExpectations(t, manager, ds, podControl)
+	expectSyncDaemonSets(t, manager, ds, podControl, maxSurge, 0, 0)
+	clearExpectations(t, manager, ds, podControl)
+	expectSyncDaemonSets(t, manager, ds, podControl, 0, 0, 0)
+	markPodsReady(podControl.podStore)
+
+	clearExpectations(t, manager, ds, podControl)
+	expectSyncDaemonSets(t, manager, ds, podControl, maxSurge, maxSurge, 0)
+	clearExpectations(t, manager, ds, podControl)
+	expectSyncDaemonSets(t, manager, ds, podControl, 0, 0, 0)
+	markPodsReady(podControl.podStore)
+
+	clearExpectations(t, manager, ds, podControl)
+	expectSyncDaemonSets(t, manager, ds, podControl, 5%maxSurge, maxSurge, 0)
+	clearExpectations(t, manager, ds, podControl)
+	expectSyncDaemonSets(t, manager, ds, podControl, 0, 0, 0)
+	markPodsReady(podControl.podStore)
+
+	clearExpectations(t, manager, ds, podControl)
+	expectSyncDaemonSets(t, manager, ds, podControl, 0, 5%maxSurge, 0)
+	clearExpectations(t, manager, ds, podControl)
+	expectSyncDaemonSets(t, manager, ds, podControl, 0, 0, 0)
 }
 
 func TestDaemonSetUpdatesWhenNewPosIsNotReady(t *testing.T) {
@@ -138,6 +188,149 @@ func TestDaemonSetUpdatesAllOldPodsNotReady(t *testing.T) {
 	clearExpectations(t, manager, ds, podControl)
 }
 
+func TestDaemonSetUpdatesAllOldPodsNotReadyMaxSurge(t *testing.T) {
+	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.DaemonSetUpdateSurge, true)()
+	ds := newDaemonSet("foo")
+	manager, podControl, _, err := newTestController(ds)
+	if err != nil {
+		t.Fatalf("error creating DaemonSets controller: %v", err)
+	}
+	addNodes(manager.nodeStore, 0, 5, nil)
+	manager.dsStore.Add(ds)
+	expectSyncDaemonSets(t, manager, ds, podControl, 5, 0, 0)
+
+	maxSurge := 3
+	ds.Spec.Template.Spec.Containers[0].Image = "foo2/bar2"
+	ds.Spec.UpdateStrategy = newUpdateSurge(intstr.FromInt(maxSurge))
+	manager.dsStore.Update(ds)
+
+	// all old pods are unavailable so should be surged
+	manager.failedPodsBackoff.Clock = clock.NewFakeClock(time.Unix(100, 0))
+	clearExpectations(t, manager, ds, podControl)
+	expectSyncDaemonSets(t, manager, ds, podControl, 5, 0, 0)
+
+	// waiting for pods to go ready, old pods are deleted
+	manager.failedPodsBackoff.Clock = clock.NewFakeClock(time.Unix(200, 0))
+	clearExpectations(t, manager, ds, podControl)
+	expectSyncDaemonSets(t, manager, ds, podControl, 0, 5, 0)
+
+	setPodReadiness(t, manager, true, 5, func(_ *v1.Pod) bool { return true })
+	ds.Spec.MinReadySeconds = 15
+	ds.Spec.Template.Spec.Containers[0].Image = "foo3/bar3"
+	manager.dsStore.Update(ds)
+
+	manager.failedPodsBackoff.Clock = clock.NewFakeClock(time.Unix(300, 0))
+	clearExpectations(t, manager, ds, podControl)
+	expectSyncDaemonSets(t, manager, ds, podControl, 3, 0, 0)
+
+	hash, err := currentDSHash(manager, ds)
+	if err != nil {
+		t.Fatal(err)
+	}
+	currentPods := podsByNodeMatchingHash(manager, hash)
+	// mark two updated pods as ready at time 300
+	setPodReadiness(t, manager, true, 2, func(pod *v1.Pod) bool {
+		return pod.Labels[apps.ControllerRevisionHashLabelKey] == hash
+	})
+	// mark one of the old pods that is on a node without an updated pod as unready
+	setPodReadiness(t, manager, false, 1, func(pod *v1.Pod) bool {
+		nodeName, err := util.GetTargetNodeName(pod)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return pod.Labels[apps.ControllerRevisionHashLabelKey] != hash && len(currentPods[nodeName]) == 0
+	})
+
+	// the new pods should still be considered waiting to hit min readiness, so one pod should be created to replace
+	// the deleted old pod
+	manager.failedPodsBackoff.Clock = clock.NewFakeClock(time.Unix(310, 0))
+	clearExpectations(t, manager, ds, podControl)
+	expectSyncDaemonSets(t, manager, ds, podControl, 1, 0, 0)
+
+	// the new pods are now considered available, so delete the old pods
+	manager.failedPodsBackoff.Clock = clock.NewFakeClock(time.Unix(320, 0))
+	clearExpectations(t, manager, ds, podControl)
+	expectSyncDaemonSets(t, manager, ds, podControl, 1, 3, 0)
+
+	// mark all updated pods as ready at time 320
+	currentPods = podsByNodeMatchingHash(manager, hash)
+	setPodReadiness(t, manager, true, 3, func(pod *v1.Pod) bool {
+		return pod.Labels[apps.ControllerRevisionHashLabelKey] == hash
+	})
+
+	// the new pods are now considered available, so delete the old pods
+	manager.failedPodsBackoff.Clock = clock.NewFakeClock(time.Unix(340, 0))
+	clearExpectations(t, manager, ds, podControl)
+	expectSyncDaemonSets(t, manager, ds, podControl, 0, 2, 0)
+
+	// controller has completed upgrade
+	manager.failedPodsBackoff.Clock = clock.NewFakeClock(time.Unix(350, 0))
+	clearExpectations(t, manager, ds, podControl)
+	expectSyncDaemonSets(t, manager, ds, podControl, 0, 0, 0)
+}
+
+func podsByNodeMatchingHash(dsc *daemonSetsController, hash string) map[string][]string {
+	byNode := make(map[string][]string)
+	for _, obj := range dsc.podStore.List() {
+		pod := obj.(*v1.Pod)
+		if pod.Labels[apps.ControllerRevisionHashLabelKey] != hash {
+			continue
+		}
+		nodeName, err := util.GetTargetNodeName(pod)
+		if err != nil {
+			panic(err)
+		}
+		byNode[nodeName] = append(byNode[nodeName], pod.Name)
+	}
+	return byNode
+}
+
+func setPodReadiness(t *testing.T, dsc *daemonSetsController, ready bool, count int, fn func(*v1.Pod) bool) {
+	t.Helper()
+	for _, obj := range dsc.podStore.List() {
+		if count <= 0 {
+			break
+		}
+		pod := obj.(*v1.Pod)
+		if pod.DeletionTimestamp != nil {
+			continue
+		}
+		if podutil.IsPodReady(pod) == ready {
+			continue
+		}
+		if !fn(pod) {
+			continue
+		}
+		condition := v1.PodCondition{Type: v1.PodReady}
+		if ready {
+			condition.Status = v1.ConditionTrue
+		} else {
+			condition.Status = v1.ConditionFalse
+		}
+		if !podutil.UpdatePodCondition(&pod.Status, &condition) {
+			t.Fatal("failed to update pod")
+		}
+		// TODO: workaround UpdatePodCondition calling time.Now() directly
+		setCondition := podutil.GetPodReadyCondition(pod.Status)
+		setCondition.LastTransitionTime.Time = dsc.failedPodsBackoff.Clock.Now()
+		klog.Infof("marked pod %s ready=%t", pod.Name, ready)
+		count--
+	}
+	if count > 0 {
+		t.Fatalf("could not mark %d pods ready=%t", count, ready)
+	}
+}
+
+func currentDSHash(dsc *daemonSetsController, ds *apps.DaemonSet) (string, error) {
+	// Construct histories of the DaemonSet, and get the hash of current history
+	cur, _, err := dsc.constructHistory(ds)
+	if err != nil {
+		return "", err
+	}
+	return cur.Labels[apps.DefaultDaemonSetUniqueLabelKey], nil
+
+}
+
 func TestDaemonSetUpdatesNoTemplateChanged(t *testing.T) {
 	ds := newDaemonSet("foo")
 	manager, podControl, _, err := newTestController(ds)
@@ -163,12 +356,34 @@ func TestDaemonSetUpdatesNoTemplateChanged(t *testing.T) {
 	clearExpectations(t, manager, ds, podControl)
 }
 
+func newUpdateSurge(value intstr.IntOrString) apps.DaemonSetUpdateStrategy {
+	zero := intstr.FromInt(0)
+	return apps.DaemonSetUpdateStrategy{
+		Type: apps.RollingUpdateDaemonSetStrategyType,
+		RollingUpdate: &apps.RollingUpdateDaemonSet{
+			MaxUnavailable: &zero,
+			MaxSurge:       &value,
+		},
+	}
+}
+
+func newUpdateUnavailable(value intstr.IntOrString) apps.DaemonSetUpdateStrategy {
+	return apps.DaemonSetUpdateStrategy{
+		Type: apps.RollingUpdateDaemonSetStrategyType,
+		RollingUpdate: &apps.RollingUpdateDaemonSet{
+			MaxUnavailable: &value,
+		},
+	}
+}
+
 func TestGetUnavailableNumbers(t *testing.T) {
 	cases := []struct {
 		name           string
 		Manager        *daemonSetsController
 		ds             *apps.DaemonSet
 		nodeToPods     map[string][]*v1.Pod
+		enableSurge    bool
+		maxSurge       int
 		maxUnavailable int
 		numUnavailable int
 		Err            error
@@ -184,8 +399,7 @@ func TestGetUnavailableNumbers(t *testing.T) {
 			}(),
 			ds: func() *apps.DaemonSet {
 				ds := newDaemonSet("x")
-				intStr := intstr.FromInt(0)
-				ds.Spec.UpdateStrategy.RollingUpdate = &apps.RollingUpdateDaemonSet{MaxUnavailable: &intStr}
+				ds.Spec.UpdateStrategy = newUpdateUnavailable(intstr.FromInt(0))
 				return ds
 			}(),
 			nodeToPods:     make(map[string][]*v1.Pod),
@@ -204,8 +418,7 @@ func TestGetUnavailableNumbers(t *testing.T) {
 			}(),
 			ds: func() *apps.DaemonSet {
 				ds := newDaemonSet("x")
-				intStr := intstr.FromInt(1)
-				ds.Spec.UpdateStrategy.RollingUpdate = &apps.RollingUpdateDaemonSet{MaxUnavailable: &intStr}
+				ds.Spec.UpdateStrategy = newUpdateUnavailable(intstr.FromInt(1))
 				return ds
 			}(),
 			nodeToPods: func() map[string][]*v1.Pod {
@@ -233,8 +446,7 @@ func TestGetUnavailableNumbers(t *testing.T) {
 			}(),
 			ds: func() *apps.DaemonSet {
 				ds := newDaemonSet("x")
-				intStr := intstr.FromInt(0)
-				ds.Spec.UpdateStrategy.RollingUpdate = &apps.RollingUpdateDaemonSet{MaxUnavailable: &intStr}
+				ds.Spec.UpdateStrategy = newUpdateUnavailable(intstr.FromInt(0))
 				return ds
 			}(),
 			nodeToPods: func() map[string][]*v1.Pod {
@@ -244,7 +456,32 @@ func TestGetUnavailableNumbers(t *testing.T) {
 				mapping["node-0"] = []*v1.Pod{pod0}
 				return mapping
 			}(),
-			maxUnavailable: 0,
+			maxUnavailable: 1,
+			numUnavailable: 1,
+		},
+		{
+			name: "Two nodes, one node without pods, surge",
+			Manager: func() *daemonSetsController {
+				manager, _, _, err := newTestController()
+				if err != nil {
+					t.Fatalf("error creating DaemonSets controller: %v", err)
+				}
+				addNodes(manager.nodeStore, 0, 2, nil)
+				return manager
+			}(),
+			ds: func() *apps.DaemonSet {
+				ds := newDaemonSet("x")
+				ds.Spec.UpdateStrategy = newUpdateSurge(intstr.FromInt(0))
+				return ds
+			}(),
+			nodeToPods: func() map[string][]*v1.Pod {
+				mapping := make(map[string][]*v1.Pod)
+				pod0 := newPod("pod-0", "node-0", simpleDaemonSetLabel, nil)
+				markPodReady(pod0)
+				mapping["node-0"] = []*v1.Pod{pod0}
+				return mapping
+			}(),
+			maxUnavailable: 1,
 			numUnavailable: 1,
 		},
 		{
@@ -259,8 +496,7 @@ func TestGetUnavailableNumbers(t *testing.T) {
 			}(),
 			ds: func() *apps.DaemonSet {
 				ds := newDaemonSet("x")
-				intStr := intstr.FromString("50%")
-				ds.Spec.UpdateStrategy.RollingUpdate = &apps.RollingUpdateDaemonSet{MaxUnavailable: &intStr}
+				ds.Spec.UpdateStrategy = newUpdateUnavailable(intstr.FromString("50%"))
 				return ds
 			}(),
 			nodeToPods: func() map[string][]*v1.Pod {
@@ -277,6 +513,66 @@ func TestGetUnavailableNumbers(t *testing.T) {
 			numUnavailable: 0,
 		},
 		{
+			name: "Two nodes with pods, MaxUnavailable in percents, surge",
+			Manager: func() *daemonSetsController {
+				manager, _, _, err := newTestController()
+				if err != nil {
+					t.Fatalf("error creating DaemonSets controller: %v", err)
+				}
+				addNodes(manager.nodeStore, 0, 2, nil)
+				return manager
+			}(),
+			ds: func() *apps.DaemonSet {
+				ds := newDaemonSet("x")
+				ds.Spec.UpdateStrategy = newUpdateSurge(intstr.FromString("50%"))
+				return ds
+			}(),
+			nodeToPods: func() map[string][]*v1.Pod {
+				mapping := make(map[string][]*v1.Pod)
+				pod0 := newPod("pod-0", "node-0", simpleDaemonSetLabel, nil)
+				pod1 := newPod("pod-1", "node-1", simpleDaemonSetLabel, nil)
+				markPodReady(pod0)
+				markPodReady(pod1)
+				mapping["node-0"] = []*v1.Pod{pod0}
+				mapping["node-1"] = []*v1.Pod{pod1}
+				return mapping
+			}(),
+			enableSurge:    true,
+			maxSurge:       1,
+			maxUnavailable: 0,
+			numUnavailable: 0,
+		},
+		{
+			name: "Two nodes with pods, MaxUnavailable is 100%, surge",
+			Manager: func() *daemonSetsController {
+				manager, _, _, err := newTestController()
+				if err != nil {
+					t.Fatalf("error creating DaemonSets controller: %v", err)
+				}
+				addNodes(manager.nodeStore, 0, 2, nil)
+				return manager
+			}(),
+			ds: func() *apps.DaemonSet {
+				ds := newDaemonSet("x")
+				ds.Spec.UpdateStrategy = newUpdateSurge(intstr.FromString("100%"))
+				return ds
+			}(),
+			nodeToPods: func() map[string][]*v1.Pod {
+				mapping := make(map[string][]*v1.Pod)
+				pod0 := newPod("pod-0", "node-0", simpleDaemonSetLabel, nil)
+				pod1 := newPod("pod-1", "node-1", simpleDaemonSetLabel, nil)
+				markPodReady(pod0)
+				markPodReady(pod1)
+				mapping["node-0"] = []*v1.Pod{pod0}
+				mapping["node-1"] = []*v1.Pod{pod1}
+				return mapping
+			}(),
+			enableSurge:    true,
+			maxSurge:       2,
+			maxUnavailable: 0,
+			numUnavailable: 0,
+		},
+		{
 			name: "Two nodes with pods, MaxUnavailable in percents, pod terminating",
 			Manager: func() *daemonSetsController {
 				manager, _, _, err := newTestController()
@@ -288,8 +584,7 @@ func TestGetUnavailableNumbers(t *testing.T) {
 			}(),
 			ds: func() *apps.DaemonSet {
 				ds := newDaemonSet("x")
-				intStr := intstr.FromString("50%")
-				ds.Spec.UpdateStrategy.RollingUpdate = &apps.RollingUpdateDaemonSet{MaxUnavailable: &intStr}
+				ds.Spec.UpdateStrategy = newUpdateUnavailable(intstr.FromString("50%"))
 				return ds
 			}(),
 			nodeToPods: func() map[string][]*v1.Pod {
@@ -310,20 +605,26 @@ func TestGetUnavailableNumbers(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		c.Manager.dsStore.Add(c.ds)
-		nodeList, err := c.Manager.nodeLister.List(labels.Everything())
-		if err != nil {
-			t.Fatalf("error listing nodes: %v", err)
-		}
-		maxUnavailable, numUnavailable, err := c.Manager.getUnavailableNumbers(c.ds, nodeList, c.nodeToPods)
-		if err != nil && c.Err != nil {
-			if c.Err != err {
-				t.Errorf("Test case: %s. Expected error: %v but got: %v", c.name, c.Err, err)
+		t.Run(c.name, func(t *testing.T) {
+			defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.DaemonSetUpdateSurge, c.enableSurge)()
+
+			c.Manager.dsStore.Add(c.ds)
+			nodeList, err := c.Manager.nodeLister.List(labels.Everything())
+			if err != nil {
+				t.Fatalf("error listing nodes: %v", err)
 			}
-		} else if err != nil {
-			t.Errorf("Test case: %s. Unexpected error: %v", c.name, err)
-		} else if maxUnavailable != c.maxUnavailable || numUnavailable != c.numUnavailable {
-			t.Errorf("Test case: %s. Wrong values. maxUnavailable: %d, expected: %d, numUnavailable: %d. expected: %d", c.name, maxUnavailable, c.maxUnavailable, numUnavailable, c.numUnavailable)
-		}
+			maxSurge, maxUnavailable, numUnavailable, err := c.Manager.getUnavailableNumbers(c.ds, nodeList, c.nodeToPods)
+			if err != nil && c.Err != nil {
+				if c.Err != err {
+					t.Fatalf("Expected error: %v but got: %v", c.Err, err)
+				}
+			}
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+			if maxSurge != c.maxSurge || maxUnavailable != c.maxUnavailable || numUnavailable != c.numUnavailable {
+				t.Fatalf("Wrong values. maxSurge: %d, expected %d, maxUnavailable: %d, expected: %d, numUnavailable: %d. expected: %d", maxSurge, c.maxSurge, maxUnavailable, c.maxUnavailable, numUnavailable, c.numUnavailable)
+			}
+		})
 	}
 }

--- a/pkg/controller/daemon/util/daemonset_util.go
+++ b/pkg/controller/daemon/util/daemonset_util.go
@@ -19,13 +19,17 @@ package util
 import (
 	"fmt"
 	"strconv"
+	"time"
 
 	apps "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	extensions "k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	intstrutil "k8s.io/apimachinery/pkg/util/intstr"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 	v1helper "k8s.io/kubernetes/pkg/apis/core/v1/helper"
+	"k8s.io/kubernetes/pkg/features"
 )
 
 // GetTemplateGeneration gets the template generation associated with a v1.DaemonSet by extracting it from the
@@ -122,6 +126,43 @@ func CreatePodTemplate(template v1.PodTemplateSpec, generation *int64, hash stri
 	return newTemplate
 }
 
+// AllowsSurge returns true if the daemonset allows more than a single pod on any node.
+func AllowsSurge(ds *apps.DaemonSet) bool {
+	maxSurge, err := SurgeCount(ds, 1)
+	return err == nil && maxSurge > 0
+}
+
+// SurgeCount returns 0 if surge is not requested, the expected surge number to allow
+// out of numberToSchedule if surge is configured, or an error if the surge percentage
+// requested is invalid.
+func SurgeCount(ds *apps.DaemonSet, numberToSchedule int) (int, error) {
+	if ds.Spec.UpdateStrategy.Type != apps.RollingUpdateDaemonSetStrategyType {
+		return 0, nil
+	}
+	if !utilfeature.DefaultFeatureGate.Enabled(features.DaemonSetUpdateSurge) {
+		return 0, nil
+	}
+	r := ds.Spec.UpdateStrategy.RollingUpdate
+	if r == nil {
+		return 0, nil
+	}
+	return intstrutil.GetScaledValueFromIntOrPercent(r.MaxSurge, numberToSchedule, true)
+}
+
+// UnavailableCount returns 0 if unavailability is not requested, the expected
+// unavailability number to allow out of numberToSchedule if requested, or an error if
+// the unavailability percentage requested is invalid.
+func UnavailableCount(ds *apps.DaemonSet, numberToSchedule int) (int, error) {
+	if ds.Spec.UpdateStrategy.Type != apps.RollingUpdateDaemonSetStrategyType {
+		return 0, nil
+	}
+	r := ds.Spec.UpdateStrategy.RollingUpdate
+	if r == nil {
+		return 0, nil
+	}
+	return intstrutil.GetScaledValueFromIntOrPercent(r.MaxUnavailable, numberToSchedule, true)
+}
+
 // IsPodUpdated checks if pod contains label value that either matches templateGeneration or hash
 func IsPodUpdated(pod *v1.Pod, hash string, dsTemplateGeneration *int64) bool {
 	// Compare with hash to see if the pod is updated, need to maintain backward compatibility of templateGeneration
@@ -131,12 +172,12 @@ func IsPodUpdated(pod *v1.Pod, hash string, dsTemplateGeneration *int64) bool {
 	return hashMatches || templateMatches
 }
 
-// SplitByAvailablePods splits provided daemon set pods by availability
-func SplitByAvailablePods(minReadySeconds int32, pods []*v1.Pod) ([]*v1.Pod, []*v1.Pod) {
-	unavailablePods := []*v1.Pod{}
-	availablePods := []*v1.Pod{}
+// SplitByAvailablePods splits provided daemon set pods by availability.
+func SplitByAvailablePods(minReadySeconds int32, pods []*v1.Pod, now time.Time) ([]*v1.Pod, []*v1.Pod) {
+	availablePods := make([]*v1.Pod, 0, len(pods))
+	var unavailablePods []*v1.Pod
 	for _, pod := range pods {
-		if podutil.IsPodAvailable(pod, minReadySeconds, metav1.Now()) {
+		if podutil.IsPodAvailable(pod, minReadySeconds, metav1.Time{Time: now}) {
 			availablePods = append(availablePods, pod)
 		} else {
 			unavailablePods = append(unavailablePods, pod)

--- a/pkg/controller/daemon/util/daemonset_util.go
+++ b/pkg/controller/daemon/util/daemonset_util.go
@@ -19,7 +19,6 @@ package util
 import (
 	"fmt"
 	"strconv"
-	"time"
 
 	apps "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
@@ -27,7 +26,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	intstrutil "k8s.io/apimachinery/pkg/util/intstr"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
-	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 	v1helper "k8s.io/kubernetes/pkg/apis/core/v1/helper"
 	"k8s.io/kubernetes/pkg/features"
 )
@@ -170,20 +168,6 @@ func IsPodUpdated(pod *v1.Pod, hash string, dsTemplateGeneration *int64) bool {
 		pod.Labels[extensions.DaemonSetTemplateGenerationKey] == fmt.Sprint(dsTemplateGeneration)
 	hashMatches := len(hash) > 0 && pod.Labels[extensions.DefaultDaemonSetUniqueLabelKey] == hash
 	return hashMatches || templateMatches
-}
-
-// SplitByAvailablePods splits provided daemon set pods by availability.
-func SplitByAvailablePods(minReadySeconds int32, pods []*v1.Pod, now time.Time) ([]*v1.Pod, []*v1.Pod) {
-	availablePods := make([]*v1.Pod, 0, len(pods))
-	var unavailablePods []*v1.Pod
-	for _, pod := range pods {
-		if podutil.IsPodAvailable(pod, minReadySeconds, metav1.Time{Time: now}) {
-			availablePods = append(availablePods, pod)
-		} else {
-			unavailablePods = append(unavailablePods, pod)
-		}
-	}
-	return availablePods, unavailablePods
 }
 
 // ReplaceDaemonSetPodNodeNameNodeAffinity replaces the RequiredDuringSchedulingIgnoredDuringExecution


### PR DESCRIPTION
If MaxSurge is set, the controller will attempt to launch updated pods on up to MaxSurge nodes and wait for them to be ready before deleting the old pods. If any old pod goes unready during update, a new pod is added to the node (regardless of MaxSurge) and the old pod is deleted.

This implements the logic behind #96375

/kind feature

```release-note
DaemonSets accept a MaxSurge integer or percent on their rolling update strategy that will launch the updated pod on nodes and wait for those pods to go ready before marking the old out-of-date pods as deleted. This allows workloads to avoid downtime during upgrades when deployed using DaemonSets. This feature is alpha and is behind the DaemonSetUpdateSurge feature gate.
```

```docs
- [KEP]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-apps/1591-daemonset-surge
```