### PR TITLE
Remove the deprecated metrics from scheduler 

### DIFF
--- a/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption.go
+++ b/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption.go
@@ -23,7 +23,6 @@ import (
 	"math/rand"
 	"sort"
 	"sync/atomic"
-	"time"
 
 	"k8s.io/klog/v2"
 
@@ -89,10 +88,8 @@ func New(dpArgs runtime.Object, fh framework.Handle) (framework.Plugin, error) {
 
 // PostFilter invoked at the postFilter extension point.
 func (pl *DefaultPreemption) PostFilter(ctx context.Context, state *framework.CycleState, pod *v1.Pod, m framework.NodeToStatusMap) (*framework.PostFilterResult, *framework.Status) {
-	preemptionStartTime := time.Now()
 	defer func() {
 		metrics.PreemptionAttempts.Inc()
-		metrics.DeprecatedSchedulingAlgorithmPreemptionEvaluationDuration.Observe(metrics.SinceInSeconds(preemptionStartTime))
 	}()
 
 	nnn, err := pl.preempt(ctx, state, pod, m)

--- a/pkg/scheduler/metrics/metrics.go
+++ b/pkg/scheduler/metrics/metrics.go
@@ -67,26 +67,6 @@ var (
 			StabilityLevel: metrics.ALPHA,
 		},
 	)
-	DeprecatedSchedulingAlgorithmPreemptionEvaluationDuration = metrics.NewHistogram(
-		&metrics.HistogramOpts{
-			Subsystem:         SchedulerSubsystem,
-			Name:              "scheduling_algorithm_preemption_evaluation_seconds",
-			Help:              "Scheduling algorithm preemption evaluation duration in seconds",
-			Buckets:           metrics.ExponentialBuckets(0.001, 2, 15),
-			StabilityLevel:    metrics.ALPHA,
-			DeprecatedVersion: "1.20.0",
-		},
-	)
-	DeprecatedBindingLatency = metrics.NewHistogram(
-		&metrics.HistogramOpts{
-			Subsystem:         SchedulerSubsystem,
-			Name:              "binding_duration_seconds",
-			Help:              "Binding latency in seconds",
-			Buckets:           metrics.ExponentialBuckets(0.001, 2, 15),
-			StabilityLevel:    metrics.ALPHA,
-			DeprecatedVersion: "1.20.0",
-		},
-	)
 	PreemptionVictims = metrics.NewHistogram(
 		&metrics.HistogramOpts{
 			Subsystem: SchedulerSubsystem,
@@ -191,8 +171,6 @@ var (
 		scheduleAttempts,
 		e2eSchedulingLatency,
 		SchedulingAlgorithmLatency,
-		DeprecatedBindingLatency,
-		DeprecatedSchedulingAlgorithmPreemptionEvaluationDuration,
 		PreemptionVictims,
 		PreemptionAttempts,
 		pendingPods,

--- a/test/integration/scheduler_perf/scheduler_perf_test.go
+++ b/test/integration/scheduler_perf/scheduler_perf_test.go
@@ -51,9 +51,7 @@ var (
 		Metrics: []string{
 			"scheduler_scheduling_algorithm_predicate_evaluation_seconds",
 			"scheduler_scheduling_algorithm_priority_evaluation_seconds",
-			"scheduler_binding_duration_seconds",
 			"scheduler_e2e_scheduling_duration_seconds",
-			"scheduler_scheduling_algorithm_preemption_evaluation_seconds",
 			"scheduler_pod_scheduling_duration_seconds",
 		},
 	}


### PR DESCRIPTION
metrics data is not exactly the same due to the different code path, here is a sample collected from  `BenchmarkPerfScheduling/Preemption/500Nodes` after https://github.com/kubernetes/kubernetes/pull/96258 get merged.

indicator  |         scheduler_binding_duration_seconds           |  scheduler_framework_extension_point_duration_seconds/Bind                    
-----------|---------------------------| -------------------------- 
Average (ms)   | 2.145300516800011  | 2.1417367068000033  
Perc50 (ms)     | 1.4517583408476107    | 1.3645197740112995  
Perc90 (ms)     |5.7379310344827585     | 5.611111111111112    
Perc99  (ms)    | 7.462068965517242   | 8.469461077844311    

**What type of PR is this?**
/kind feature

Depends: https://github.com/kubernetes/kubernetes/pull/96258

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Remove the deprecated metrics "scheduling_algorithm_preemption_evaluation_seconds" and "binding_duration_seconds", suggest to use "scheduler_framework_extension_point_duration_seconds" instead.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
