### PR TITLE
test images: Adds -p yes when calling register.sh

### DIFF
--- a/test/images/cloudbuild.yaml
+++ b/test/images/cloudbuild.yaml
@@ -9,7 +9,7 @@ options:
   substitution_option: ALLOW_LOOSE
   machineType: 'N1_HIGHCPU_8'
 steps:
-  - name: 'gcr.io/k8s-testimages/gcb-docker-gcloud:v20200422-b25d964'
+  - name: 'gcr.io/k8s-testimages/gcb-docker-gcloud:v20201130-750d12f'
     entrypoint: 'bash'
     dir: ./test/images/
     env:
@@ -21,11 +21,12 @@ steps:
     # The default cloudbuild has HOME=/builder/home and docker buildx is in /root/.docker/cli-plugins/docker-buildx
     # We need to set the HOME to /root explicitly since we're using docker buildx
     - HOME=/root
+    # NOTE(claudiub): we need to call register.sh before creating and bootstraping a docker buildx instance.
     args:
     - '-c'
     - |
       gcloud auth configure-docker \
-      && docker run --rm --privileged multiarch/qemu-user-static --reset -p yes \
+      && ../../third_party/multiarch/qemu-user-static/register/register.sh --reset -p yes \
       && export DOCKER_CLI_EXPERIMENTAL=enabled \
       && docker buildx create --name img-builder --use \
       && docker buildx inspect --bootstrap \

--- a/test/images/image-util.sh
+++ b/test/images/image-util.sh
@@ -21,6 +21,9 @@ set -o pipefail
 TASK=$1
 WHAT=$2
 
+# docker buildx command is still experimental as of Docker 19.03.0
+export DOCKER_CLI_EXPERIMENTAL="enabled"
+
 # Connecting to a Remote Docker requires certificates for authentication, which can be found
 # at this path. By default, they can be found in the ${HOME} folder. We're expecting to find
 # here ".docker-${os_version}" folders which contains the necessary certificates.
@@ -189,8 +192,6 @@ push() {
 
   kube::util::ensure-gnu-sed
 
-  # The manifest command is still experimental as of Docker 18.09.2
-  export DOCKER_CLI_EXPERIMENTAL="enabled"
   # reset manifest list; needed in case multiple images are being built / pushed.
   manifest=()
   # Make os_archs list into image manifest. Eg: 'linux/amd64 linux/ppc64le' to '${REGISTRY}/${image}:${TAG}-linux-amd64 ${REGISTRY}/${image}:${TAG}-linux-ppc64le'

--- a/test/images/image-util.sh
+++ b/test/images/image-util.sh
@@ -149,7 +149,7 @@ build() {
         if [[ $(id -u) != 0 ]]; then
           sudo=sudo
         fi
-        ${sudo} "${KUBE_ROOT}/third_party/multiarch/qemu-user-static/register/register.sh" --reset
+        ${sudo} "${KUBE_ROOT}/third_party/multiarch/qemu-user-static/register/register.sh" --reset -p yes
         curl -sSL https://github.com/multiarch/qemu-user-static/releases/download/"${QEMUVERSION}"/x86_64_qemu-"${QEMUARCHS[$arch]}"-static.tar.gz | tar -xz -C "${temp_dir}"
         # Ensure we don't get surprised by umask settings
         chmod 0755 "${temp_dir}/qemu-${QEMUARCHS[$arch]}-static"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug
/sig testing
/priority important-soon

**What this PR does / why we need it**:

The Image Builder postsubmit job still fails when building the s390x images. [1]

This PR proposes running:

```
docker run --rm --privileged multiarch/qemu-user-static:5.1.0-2 --reset -p yes
```

instead of:

```
${sudo} "${KUBE_ROOT}/third_party/multiarch/qemu-user-static/register/register.sh" --reset
```

The main difference being the ``-p yes`` flag (the scripts that are executed in both cases are otherwise the same.

The image also contains the QEMU binaries that are required for the ``-p yes`` flag.

The image ``gcr.io/k8s-testimages/gcb-docker-gcloud:v20200422-b25d964`` does not contain those QEMU binaries, which is why we cannot use the third_party script.

Building locally within a ``gcr.io/k8s-testimages/gcb-docker-gcloud:v20200422-b25d964`` container, works consistently [2].

This was proposed previously in another PR, before switching back to the third_party script but without the ``-p yes`` flag: [4]

Additionally, in order to build multiarch images with docker buildx, we need ``qemu`` and ``binfmt-support`` installed. They might not be installed or available for this OS (for example the image ``gcr.io/k8s-testimages/gcb-docker-gcloud:v20200422-b25d964`` does not have them, nor are there APKs available for ``binfmt-support``). Adding extra verbosity to the ``register.sh`` and ``qemu-binfmt-conf.sh` reveals that QEMU emulation is not being properly set up [5].

[1] http://storage.googleapis.com/k8s-staging-e2e-test-images-gcb/logs/log-0967610a-b13c-4979-85c1-739b6ca65a80.txt
[2] https://paste.ubuntu.com/p/xrMkhFNfZw/
[3] https://paste.ubuntu.com/p/gPmmBC9Njs/
[4] https://github.com/kubernetes/kubernetes/pull/95032
[5] https://paste.ubuntu.com/p/VphPmBQSrF/
[6] https://medium.com/@artur.klauser/building-multi-architecture-docker-images-with-buildx-27d80f7e2408

UPDATE:

We've added QEMU and the qemu-* binaries to the gcb-docker-gcloud image [7], and these changes are included in the image ``gcr.io/k8s-testimages/gcb-docker-gcloud:v20201130-750d12f``. Using this image, building ``agnhost`` was sucessful [8].

Before creating and bootstrapping a ``docker buildx`` instance, we need to call ``register.sh`` with the ``-p yes`` flag. Without this, the ``docker buildx`` instance will only support ``linux/amd64`` and ``linux/386`` platforms, meaning that it will fail when trying to build images for other architecture types.

[7]: https://github.com/kubernetes/test-infra/pull/20020
[8]: https://paste.ubuntu.com/p/CVVkWyR4FV/

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
