### PR TITLE
storage verson integration test: wait for CR to show up in discovery

### DIFF
--- a/test/integration/storageversion/OWNERS
+++ b/test/integration/storageversion/OWNERS
@@ -1,0 +1,5 @@
+approvers:
+- roycaihw
+- caesarxuchao
+labels:
+- sig/api-machinery


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

Deflakes `pull-kubernetes-integration: TestStorageVersionBootstrap`. Since we restarted the test server, wait for CR to show up in discovery again before sending requests. 

Fixes #96457

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```