### PR TITLE
Promote Pod+PodStatus resource lifecycle test - +4 endpoint coverage

### DIFF
--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -269,6 +269,14 @@
     IP address.
   release: v1.9
   file: test/e2e/common/pods.go
+- testname: Pods, completes the lifecycle of a Pod and the PodStatus
+  codename: '[k8s.io] Pods should run through the lifecycle of Pods and PodStatus
+    [Conformance]'
+  description: A Pod is created with a static label which MUST succeed. It MUST succeed
+    when patching the label and the pod data. When checking and replacing the PodStatus
+    it MUST succeed. It MUST succeed when deleting the Pod.
+  release: v1.20
+  file: test/e2e/common/pods.go
 - testname: Pods, remote command execution over websocket
   codename: '[k8s.io] Pods should support remote command execution over websockets
     [NodeConformance] [Conformance]'

--- a/test/e2e/common/pods.go
+++ b/test/e2e/common/pods.go
@@ -884,7 +884,14 @@ var _ = framework.KubeDescribe("Pods", func() {
 		framework.ExpectNoError(err, "found a pod(s)")
 	})
 
-	ginkgo.It("should run through the lifecycle of Pods and PodStatus", func() {
+	/*
+		Release: v1.20
+		Testname: Pods, completes the lifecycle of a Pod and the PodStatus
+		Description: A Pod is created with a static label which MUST succeed. It MUST succeed when
+		patching the label and the pod data. When checking and replacing the PodStatus it MUST
+		succeed. It MUST succeed when deleting the Pod.
+	*/
+	framework.ConformanceIt("should run through the lifecycle of Pods and PodStatus", func() {
 		podResource := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"}
 		testNamespaceName := f.Namespace.Name
 		testPodName := "pod-test"


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it:**
This PR adds a test to test the following untested endpoints:
* replaceCoreV1NamespacedPodStatus
* readCoreV1NamespacedPodStatus
* listCoreV1PodForAllNamespaces
* deleteCoreV1CollectionNamespacedPod

**Which issue(s) this PR fixes:**
Fixes #90936
[Testgrid link](https://testgrid.k8s.io/sig-release-master-blocking#gce-cos-master-default&width=5&include-filter-by-regex=should%20run%20through%20the%20lifecycle%20of%20Pods%20and%20PodStatus&graph-metrics=test-duration-minutes)

**Special notes for your reviewer:**
Adds +4 endpoint test coverage (good for conformance)

**Does this PR introduce a user-facing change?:**
```
NONE

```

**Release note:**
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:**
```
NONE

```

/sig testing
/sig architecture
/area conformance