### PR TITLE
Promote AppsV1Deployment resource lifecycle test - +6 endpoint coverage

### DIFF
--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -1191,6 +1191,14 @@
     before the rollout finishes.
   release: v1.12
   file: test/e2e/apps/deployment.go
+- testname: Deployment, completes the lifecycle of a Deployment
+  codename: '[sig-apps] Deployment should run the lifecycle of a Deployment [Conformance]'
+  description: When a Deployment is created it MUST succeed with the required number
+    of replicas. It MUST succeed when the Deployment is patched. When scaling the
+    deployment is MUST succeed. When fetching and patching the DeploymentStatus it
+    MUST succeed. It MUST succeed when deleting the Deployment.
+  release: v1.20
+  file: test/e2e/apps/deployment.go
 - testname: Jobs, orphan pods, re-adoption
   codename: '[sig-apps] Job should adopt matching orphans and release non-matching
     pods [Conformance]'

--- a/test/e2e/apps/deployment.go
+++ b/test/e2e/apps/deployment.go
@@ -152,7 +152,15 @@ var _ = SIGDescribe("Deployment", func() {
 	// TODO: add tests that cover deployment.Spec.MinReadySeconds once we solved clock-skew issues
 	// See https://github.com/kubernetes/kubernetes/issues/29229
 
-	ginkgo.It("should run the lifecycle of a Deployment", func() {
+	/*
+		Release: v1.20
+		Testname: Deployment, completes the lifecycle of a Deployment
+		Description: When a Deployment is created it MUST succeed with the required number of replicas.
+		It MUST succeed when the Deployment is patched. When scaling the deployment is MUST succeed.
+		When fetching and patching the DeploymentStatus it MUST succeed. It MUST succeed when deleting
+		the Deployment.
+	*/
+	framework.ConformanceIt("should run the lifecycle of a Deployment", func() {
 		zero := int64(0)
 		deploymentResource := schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}
 		testNamespaceName := f.Namespace.Name


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it:**
This PR adds a test to test the following untested endpoints:
* deleteAppsV1CollectionNamespacedDeployment
* listAppsV1DeploymentForAllNamespaces
* patchAppsV1NamespacedDeployment
* patchAppsV1NamespacedDeploymentStatus
* readAppsV1NamespacedDeploymentStatus
* replaceAppsV1NamespacedDeploymentStatus

**Which issue(s) this PR fixes:**
Fixes #90916
[Testgrid link](https://testgrid.k8s.io/sig-apps#gce&include-filter-by-regex=Deployment&include-filter-by-regex=should%20run%20the%20lifecycle%20of%20a%20Deployment&width=5)

**Special notes for your reviewer:**
Adds +6 endpoint test coverage (good for conformance)

**Does this PR introduce a user-facing change?:**
```
NONE

```

**Release note:**
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:**
```
NONE

```

/sig testing
/sig architecture
/area conformance