### PR TITLE
[Draft] Update config for go-flow-levee analysis

### DIFF
--- a/hack/testdata/levee/levee-config.yaml
+++ b/hack/testdata/levee/levee-config.yaml
@@ -17,42 +17,164 @@ FieldTags:
 # This preliminary collection of source types should be removed once
 # KEP-1753 adds tags to the relevant fields.
 Sources:
-  - PackageRE: ""
-    TypeRE: "^(?:admin)?Secret$|Token"
-    FieldRE: ""
-  - PackageRE: "k8s.io/client-go/tools/clientcmd/api(?:/v1)?"
-    TypeRE: "^(?:Named)?AuthInfo$"
-    FieldRE: ""
-  - PackageRE: "k8s.io/kubernetes/pkg/credentialprovider"
-    TypeRE: "DockerConfigEntry"
-    FieldRE: "Password"
-  - PackageRE: "k8s.io/client-go/transport"
-    TypeRE: "requestInfo"
-    FieldRE: "RequestHeaders"
-  - PackageRE: "k8s.io/kubernetes/pkg/volume/rbd"
-    TypeRE: "rbdMounter"
-    FieldRE: "adminSecret"
-  - PackageRE: "^k8s.io/client-go/rest$"
-    TypeRE: "^TLSClientConfig$"
-    FieldRE: "Password|BearerToken$|"
-  - PackageRE: "^k8s.io/client-go/rest$"
-    TypeRE: "^Config$"
-    FieldRE: "Password|BearerToken$|"
+# The following fields are tagged in #95994
+- PackageRE: "k8s.io/kubernetes/test/e2e/storage/vsphere"
+  TypeRE: "Config"
+  FieldRE: "Password"
+- PackageRE: "k8s.io/kubernetes/test/e2e/storage/vsphere"
+  TypeRE: "ConfigFile"
+  FieldRE: "Global"  # Global is of unnamed type, contains the field Password.
+
+# The following fields are tagged in #95997
+- PackageRE: "k8s.io/kubelet/config/v1beta1"
+  TypeRE: "KubeletConfiguration"
+  FieldRE: "StaticPodURLHeader"
+
+# The following fields are tagged in #95998
+- PackageRE: "k8s.io/kube-scheduler/config/v1"
+  TypeRE: "ExtenderTLSConfig"
+  FieldRE: "KeyData"
+
+# The following fields are tagged in #956000
+- PackageRE: "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+  TypeRE: "AuthConfig"
+  FieldRE: "Password|IdentityToken|RegistryToken"
+
+# The following fields are tagged in #96001
+- PackageRE: "k8s.io/client-go/pkg/apis/clientauthentication"
+  TypeRE: "ExecCredentialStatus"
+  FieldRE: "Token|ClientKeyData|ClientCertificateData"
+- PackageRE: "k8s.io/client-go/pkg/apis/clientauthentication"
+  TypeRE: "Response"
+  FieldRE: "Header"
+- PackageRE: "k8s.io/client-go/plugin/pkg/client/auth/exec"
+  TypeRE: "credentials"
+  FieldRE: "token|cert"
+- PackageRE: "k8s.io/client-go/plugin/pkg/client/auth/gcp"
+  TypeRE: "cachedTokenSource"
+  FieldRE: "accessToken"
+- PackageRE: "k8s.io/client-go/plugin/pkg/client/auth/gcp"
+  TypeRE: "commandTokenSource"
+  FieldRE: "tokenKey|expiryKey"
+- PackageRE: "^k8s.io/client-go/rest$"
+  TypeRE: "^Config$"
+  FieldRE: "Password|BearerToken$|"
+- PackageRE: "^k8s.io/client-go/rest$"
+  TypeRE: "^TLSClientConfig$"
+  FieldRE: "Password|BearerToken$|"
+- PackageRE: "k8s.io/client-go/tools/auth"
+  TypeRE: "Info"
+  FieldRE: "Password|BearerToken"
+- PackageRE: "k8s.io/client-go/tools/clientcmd/api(?:/v1)?"
+  TypeRE: "^(?:Named)?AuthInfo$"
+  FieldRE: "ClientKeyData|Token|Password"
+- PackageRE: "k8s.io/client-go/tools/clientcmd"
+  TypeRE: "promptedCredentials"
+  FieldRE: "password"
+- PackageRE: "k8s.io/client-go/transport"
+  TypeRE: "requestInfo"
+  FieldRE: "RequestHeaders"
+- PackageRE: "k8s.io/client-go/transport"
+  TypeRE: "tlsCacheKey"
+  FieldRE: "keyData"
+- PackageRE: "k8s.io/client-go/transport"
+  TypeRE: "Config"
+  FieldRE: "Password|BearerToken"
+- PackageRE: "k8s.io/client-go/transport"
+  TypeRE: "basicAuthRoundTripper"
+  FieldRE: "password"
+- PackageRE: "k8s.io/client-go/transport"
+  TypeRE: "requestInfo"
+  FieldRE: "RequestHeaders"
+- PackageRE: "k8s.io/client-go/util/certificate"
+  TypeRE: "Config"
+  FieldRE: "BootstrapKeyPEM"
+
+# The following fields are tagged in #96002
+- PackageRE: "k8s.io/apiserver/pkg/apis/apiserver" # multiple versions
+  TypeRE: "TLSConfig"
+  FieldRE: "ClientKey"
+- PackageRE: "k8s.io/apiserver/pkg/apis/config" # multiple versions
+  TypeRE: "Key"
+  FieldRE: "Secret"
+- PackageRE: "k8s.io/apiserver/pkg/authentication/request/headerrequest"
+  TypeRE: "requestHeaderBundle"
+  FieldRE: "UsernameHeaders|GroupHeaders"
+- PackageRE: "k8s.io/apiserver/pkg/server/dynamiccertificates"
+  TypeRE: "certKeyContent"
+  FieldRE: "key"
+- PackageRE: "k8s.io/apiserver/pkg/server/dynamiccertificates"
+  TypeRE: "DynamicCertKeyPairContent"
+  FieldRE: "certKeyPair"
+- PackageRE: "k8s.io/apiserver/pkg/server/options"
+  TypeRE: "RequestHeaderAuthenticationOptions"
+  FieldRE: "UsernameHeaders|GroupHeaders"
+- PackageRE: "k8s.io/apiserver/plugin/pkg/authenticator/token/oidc"
+  TypeRE: "endpoint"
+  FieldRE: "AccessToken"
+
+# The following fields are tagged in #96003
+- PackageRE: "k8s.io/cli-runtime/pkg/genericclioptions"
+  TypeRE: "ConfigFlags"
+  FieldRE: "BearerToken|Password"
+
+# The following fields are tagged in #96004
+- PackageRE: "k8s.io/kubernetes/pkg/kubelet/apis/config"
+  TypeRE: "KubeletConfiguration"
+  FieldRE: "StaticPodURLHeader"
+- PackageRE: "k8s.io/kubernetes/pkg/kubelet/client"
+  TypeRE: "KubeletClientConfig"
+  FieldRE: "BearerToken"
+- PackageRE: "k8s.io/kubernetes/pkg/kubelet/cri/streaming"
+  TypeRE: "cacheEntry"
+  FieldRE: "token"
+
+# The following fields are tagged in #96005
+- PackageRE: "k8s.io/api/authentication/v1"
+  TypeRE: "TokenReviewSpec|TokenRequestStatus"
+  FieldRE: " Token"
+- PackageRE: "k8s.io/api/authentication/v1beta1"
+  TypeRE: "TokenReviewSpec"
+  FieldRE: " Token"
+
+# # The following fields are tagged in #96007
+- PackageRE: "k8s.io/kubernetes/pkg/credentialprovider/azure"
+  TypeRE: "acrAuthResponse"
+  FieldRE: "RefreshToken"
+- PackageRE: "k8s.io/kubernetes/pkg/credentialprovider"
+  TypeRE: "DockerConfigEntry"
+  FieldRE: "Password"
+- PackageRE: "k8s.io/kubernetes/pkg/credentialprovider"
+  TypeRE: "DockerConfigJSON"
+  FieldRE: "Auths|HTTPHeaders"
+- PackageRE: "k8s.io/kubernetes/pkg/credentialprovider"
+  TypeRE: "dockerConfigEntryWithAuth"
+  FieldRE: "Password|Auth"
+- PackageRE: "k8s.io/kubernetes/pkg/credentialprovider/gcp"
+  TypeRE: "tokenBlob"
+  FieldRE: "AccessToken"
+- PackageRE: "k8s.io/kubernetes/pkg/credentialprovider"
+  TypeRE: "AuthConfig"
+  FieldRE: "Password|Auth|IdentityToken|RegistryToken"
+
+# The following fields are tagged in #96008
+- PackageRE: "k8s.io/kubernetes/pkg/controller/certificates/authority"
+  TypeRE: "CertificateAuthority"
+  FieldRE: "RawKey"
 
 # Sinks are functions that should not be called with source or source-tainted arguments.
 # This configuration should capture all log unfiltered log calls.
 Sinks:
-  - PackageRE: "\bk?log\b"
-    ReceiverRE: ""
-    MethodRE: "Info|Warning|Error|Fatal|Exit"
-  - PackageRE: "\bk?log\b"
-    ReceiverRE: "Verbose"
-    MethodRE: "Info|Error"
+- PackageRE: "k?log"
+  # Empty regexp receiver will match both top-level klog functions and klog.Verbose methods.
+  ReceiverRE: ""
+  MethodRE: "Info|Warning|Error|Fatal|Exit"
 
 # Sanitizers permit a source to reach a sink by explicitly removing the source data.
 Sanitizers:
-  - PackageRE: "k8s.io/client-go/transport"
-    MethodRE: "maskValue"
+# maskValue strips bearer tokens from request headers
+- PackageRE: "k8s.io/client-go/transport"
+  MethodRE: "maskValue"
 
 # False positives may be suppressed here.
 # Exclude reporting within a given function by specifying it similar to Sinks, i.e.,


### PR DESCRIPTION
* remove \b boundary for sinks; Unicode \b != regexp \b
* Specify those source type fields that have not yet been tagged.

-----

/kind cleanup
/sig security

/okay-to-test
/test pull-kubernetes-verify-govet-levee

**What this PR does / why we need it**:

(a) Updates analysis configuration to include those potential identified in the currently-open datapolicy PRs, and
(b) Removes from configuration incorrect boundary regexp `\b`, currently parsed as unicode `\b` (the backspace character).

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
- KEP: https://github.com/kubernetes/enhancements/issues/1933

(CC:) @mlevesquedion 