### PR TITLE
Increase watch timeout when scaling Deployment Replicas

### DIFF
--- a/test/e2e/apps/deployment.go
+++ b/test/e2e/apps/deployment.go
@@ -359,7 +359,7 @@ var _ = SIGDescribe("Deployment", func() {
 		framework.ExpectEqual(deploymentGet.Spec.Template.Spec.Containers[0].Image, testDeploymentUpdateImage, "failed to update image")
 		framework.ExpectEqual(deploymentGet.ObjectMeta.Labels["test-deployment"], "updated", "failed to update labels")
 
-		ctx, cancel = context.WithTimeout(context.Background(), 30*time.Second)
+		ctx, cancel = context.WithTimeout(context.Background(), 1*time.Minute)
 		defer cancel()
 		_, err = watchtools.Until(ctx, deploymentsList.ResourceVersion, w, func(event watch.Event) (bool, error) {
 			if deployment, ok := event.Object.(*appsv1.Deployment); ok {


### PR DESCRIPTION
We've had a single flake on this test in the past few weeks.
The flake is during *fetching the DeploymentStatus* and times out at 30 seconds.
There is a precedent for using at least a one minute timeout for waiting for Deployments to scale within the same file.
Updating the timeout should address this singular flake.

https://testgrid.k8s.io/sig-apps#gce&include-filter-by-regex=Deployment&include-filter-by-regex=should%20run%20the%20lifecycle%20of%20a%20Deployment&width=5

![image](https://user-images.githubusercontent.com/31331/98983605-e3f08180-2585-11eb-816a-1ca2879fd42f.png)

https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce/1325082859735617536
```
ï¿½[1mSTEPï¿½[0m: fetching the DeploymentStatus
Nov  7 14:40:13.077: INFO: observed Deployment test-deployment in namespace deployment-5489 with ReadyReplicas 1 and labels map[test-deployment:updated test-deployment-static:true]
Nov  7 14:40:13.077: INFO: observed Deployment test-deployment in namespace deployment-5489 with ReadyReplicas 1 and labels map[test-deployment:updated test-deployment-static:true]
Nov  7 14:40:13.078: INFO: observed Deployment test-deployment in namespace deployment-5489 with ReadyReplicas 1 and labels map[test-deployment:updated test-deployment-static:true]
Nov  7 14:40:13.078: INFO: observed Deployment test-deployment in namespace deployment-5489 with ReadyReplicas 1 and labels map[test-deployment:updated test-deployment-static:true]
Nov  7 14:40:13.212: INFO: observed Deployment test-deployment in namespace deployment-5489 with ReadyReplicas 1 and labels map[test-deployment:updated test-deployment-static:true]
Nov  7 14:40:13.429: INFO: observed Deployment test-deployment in namespace deployment-5489 with ReadyReplicas 1 and labels map[test-deployment:updated test-deployment-static:true]
Nov  7 14:40:13.563: INFO: observed Deployment test-deployment in namespace deployment-5489 with ReadyReplicas 1 and labels map[test-deployment:updated test-deployment-static:true]
Nov  7 14:40:43.027: FAIL: failed to see replicas of test-deployment in namespace deployment-5489 scale to requested amount of 2
Unexpected error:
    <*errors.errorString | 0xc00026a1f0>: {
        s: "timed out waiting for the condition",
    }
    timed out waiting for the condition
occurred
```