### PR TITLE
Deprecating KUBERNETES_MASTER env variable for client-go due to offensive reference

### DIFF
--- a/staging/src/k8s.io/client-go/examples/workqueue/main.go
+++ b/staging/src/k8s.io/client-go/examples/workqueue/main.go
@@ -146,14 +146,14 @@ func (c *Controller) runWorker() {
 
 func main() {
 	var kubeconfig string
-	var master string
+	var controlplane string
 
 	flag.StringVar(&kubeconfig, "kubeconfig", "", "absolute path to the kubeconfig file")
-	flag.StringVar(&master, "master", "", "master url")
+	flag.StringVar(&controlplane, "controlplane", "", "control plane url")
 	flag.Parse()
 
 	// creates the connection
-	config, err := clientcmd.BuildConfigFromFlags(master, kubeconfig)
+	config, err := clientcmd.BuildConfigFromFlags(controlplane, kubeconfig)
 	if err != nil {
 		klog.Fatal(err)
 	}

--- a/staging/src/k8s.io/client-go/rest/config.go
+++ b/staging/src/k8s.io/client-go/rest/config.go
@@ -112,7 +112,7 @@ type Config struct {
 	// instead of setting this value directly.
 	WrapTransport transport.WrapperFunc
 
-	// QPS indicates the maximum QPS to the master from this client.
+	// QPS indicates the maximum QPS to the control plane from this client.
 	// If it's zero, the created RESTClient will use DefaultQPS: 5
 	QPS float32
 
@@ -120,7 +120,7 @@ type Config struct {
 	// If it's zero, the created RESTClient will use DefaultBurst: 10.
 	Burst int
 
-	// Rate limiter for limiting connections to the master from this client. If present overwrites QPS/Burst
+	// Rate limiter for limiting connections to the control plane from this client. If present overwrites QPS/Burst
 	RateLimiter flowcontrol.RateLimiter
 
 	// WarningHandler handles warnings in server responses.

--- a/staging/src/k8s.io/client-go/tools/cache/reflector.go
+++ b/staging/src/k8s.io/client-go/tools/cache/reflector.go
@@ -288,7 +288,7 @@ func (r *Reflector) ListAndWatch(stopCh <-chan struct{}) error {
 				//
 				// With ResourceVersion != "", we have a possibility to list from watch cache,
 				// but we do that (for ResourceVersion != "0") only if Limit is unset.
-				// To avoid thundering herd on etcd (e.g. on master upgrades), we explicitly
+				// To avoid thundering herd on etcd (e.g. on control plane upgrades), we explicitly
 				// switch off pagination to force listing from watch cache (if enabled).
 				// With the existing semantic of RV (result is at least as fresh as provided RV),
 				// this is correct and doesn't lead to going back in time.

--- a/staging/src/k8s.io/client-go/tools/clientcmd/client_config.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/client_config.go
@@ -53,7 +53,7 @@ var (
 // getDefaultServer returns a default setting for DefaultClientConfig
 // DEPRECATED
 func getDefaultServer() string {
-	if server := os.Getenv("KUBERNETES_MASTER"); len(server) > 0 {
+	if server := os.Getenv("KUBERNETES_CONTROL_PLANE"); len(server) > 0 {
 		return server
 	}
 	return "http://localhost:8080"
@@ -604,14 +604,14 @@ func (config *inClusterClientConfig) Possible() bool {
 		err == nil && !fi.IsDir()
 }
 
-// BuildConfigFromFlags is a helper function that builds configs from a master
+// BuildConfigFromFlags is a helper function that builds configs from a control plane
 // url or a kubeconfig filepath. These are passed in as command line flags for cluster
-// components. Warnings should reflect this usage. If neither masterUrl or kubeconfigPath
+// components. Warnings should reflect this usage. If neither controlPlaneUrl or kubeconfigPath
 // are passed in we fallback to inClusterConfig. If inClusterConfig fails, we fallback
 // to the default config.
-func BuildConfigFromFlags(masterUrl, kubeconfigPath string) (*restclient.Config, error) {
-	if kubeconfigPath == "" && masterUrl == "" {
-		klog.Warningf("Neither --kubeconfig nor --master was specified.  Using the inClusterConfig.  This might not work.")
+func BuildConfigFromFlags(controlPlaneUrl, kubeconfigPath string) (*restclient.Config, error) {
+	if kubeconfigPath == "" && controlPlaneUrl == "" {
+		klog.Warningf("Neither --kubeconfig nor --controlplane was specified.  Using the inClusterConfig.  This might not work.")
 		kubeconfig, err := restclient.InClusterConfig()
 		if err == nil {
 			return kubeconfig, nil
@@ -620,15 +620,15 @@ func BuildConfigFromFlags(masterUrl, kubeconfigPath string) (*restclient.Config,
 	}
 	return NewNonInteractiveDeferredLoadingClientConfig(
 		&ClientConfigLoadingRules{ExplicitPath: kubeconfigPath},
-		&ConfigOverrides{ClusterInfo: clientcmdapi.Cluster{Server: masterUrl}}).ClientConfig()
+		&ConfigOverrides{ClusterInfo: clientcmdapi.Cluster{Server: controlPlaneUrl}}).ClientConfig()
 }
 
-// BuildConfigFromKubeconfigGetter is a helper function that builds configs from a master
+// BuildConfigFromKubeconfigGetter is a helper function that builds configs from a control plane
 // url and a kubeconfigGetter.
-func BuildConfigFromKubeconfigGetter(masterUrl string, kubeconfigGetter KubeconfigGetter) (*restclient.Config, error) {
+func BuildConfigFromKubeconfigGetter(controlPlaneUrl string, kubeconfigGetter KubeconfigGetter) (*restclient.Config, error) {
 	// TODO: We do not need a DeferredLoader here. Refactor code and see if we can use DirectClientConfig here.
 	cc := NewNonInteractiveDeferredLoadingClientConfig(
 		&ClientConfigGetter{kubeconfigGetter: kubeconfigGetter},
-		&ConfigOverrides{ClusterInfo: clientcmdapi.Cluster{Server: masterUrl}})
+		&ConfigOverrides{ClusterInfo: clientcmdapi.Cluster{Server: controlPlaneUrl}})
 	return cc.ClientConfig()
 }

--- a/staging/src/k8s.io/client-go/tools/clientcmd/validation.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/validation.go
@@ -30,7 +30,7 @@ import (
 
 var (
 	ErrNoContext   = errors.New("no context chosen")
-	ErrEmptyConfig = NewEmptyConfigError("no configuration has been provided, try setting KUBERNETES_MASTER environment variable")
+	ErrEmptyConfig = NewEmptyConfigError("no configuration has been provided, try setting KUBERNETES_CONTROL_PLANE environment variable")
 	// message is for consistency with old behavior
 	ErrEmptyCluster = errors.New("cluster has no server defined")
 )

--- a/staging/src/k8s.io/client-go/tools/events/event_broadcaster.go
+++ b/staging/src/k8s.io/client-go/tools/events/event_broadcaster.go
@@ -213,7 +213,7 @@ func (e *eventBroadcasterImpl) attemptRecording(event *eventsv1.Event) *eventsv1
 			return nil
 		}
 		// Randomize sleep so that various clients won't all be
-		// synced up if the master goes down.
+		// synced up if the control plane goes down.
 		time.Sleep(wait.Jitter(e.sleepDuration, 0.25))
 	}
 }

--- a/staging/src/k8s.io/client-go/tools/leaderelection/leaderelection.go
+++ b/staging/src/k8s.io/client-go/tools/leaderelection/leaderelection.go
@@ -37,7 +37,7 @@ limitations under the License.
 //
 // While not required, some method of clock synchronization between nodes in the
 // cluster is highly recommended. It's important to keep in mind when configuring
-// this client that the tolerance to skew rate varies inversely to master
+// this client that the tolerance to skew rate varies inversely to control plane
 // availability.
 //
 // Larger clusters often have a more lenient SLA for API latency. This should be
@@ -45,7 +45,7 @@ limitations under the License.
 // should be monitored and RetryPeriod and LeaseDuration should be increased
 // until the rate is stable and acceptably low. It's important to keep in mind
 // when configuring this client that the tolerance to API latency varies inversely
-// to master availability.
+// to control plane availability.
 //
 // DISCLAIMER: this is an alpha API. This library will likely change significantly
 // or even be removed entirely in subsequent releases. Depend on this API at
@@ -126,7 +126,7 @@ type LeaderElectionConfig struct {
 	//
 	// Core clients default this value to 15 seconds.
 	LeaseDuration time.Duration
-	// RenewDeadline is the duration that the acting master will retry
+	// RenewDeadline is the duration that the acting control plane will retry
 	// refreshing leadership before giving up.
 	//
 	// Core clients default this value to 10 seconds.

--- a/staging/src/k8s.io/client-go/tools/record/event.go
+++ b/staging/src/k8s.io/client-go/tools/record/event.go
@@ -219,7 +219,7 @@ func recordToSink(sink EventSink, event *v1.Event, eventCorrelator *EventCorrela
 			break
 		}
 		// Randomize the first sleep so that various clients won't all be
-		// synced up if the master goes down.
+		// synced up if the control plane goes down.
 		if tries == 1 {
 			time.Sleep(time.Duration(float64(sleepDuration) * rand.Float64()))
 		} else {

--- a/staging/src/k8s.io/client-go/util/certificate/certificate_manager.go
+++ b/staging/src/k8s.io/client-go/util/certificate/certificate_manager.go
@@ -434,7 +434,7 @@ func (m *manager) rotateCerts() (bool, error) {
 	// new private key.
 	reqName, reqUID, err := csr.RequestCertificate(clientSet, csrPEM, "", m.signerName, m.usages, privateKey)
 	if err != nil {
-		utilruntime.HandleError(fmt.Errorf("Failed while requesting a signed certificate from the master: %v", err))
+		utilruntime.HandleError(fmt.Errorf("Failed while requesting a signed certificate from the control plane: %v", err))
 		if m.certificateRenewFailure != nil {
 			m.certificateRenewFailure.Inc()
 		}
@@ -589,11 +589,11 @@ func (m *manager) updateServerError(err error) error {
 	defer m.certAccessLock.Unlock()
 	switch {
 	case errors.IsUnauthorized(err):
-		// SSL terminating proxies may report this error instead of the master
+		// SSL terminating proxies may report this error instead of the control plane
 		m.serverHealth = true
 	case errors.IsUnexpectedServerError(err):
 		// generally indicates a proxy or other load balancer problem, rather than a problem coming
-		// from the master
+		// from the control plane
 		m.serverHealth = false
 	default:
 		// Identify known errors that could be expected for a cert request that


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup
/kind deprecation

**What this PR does / why we need it**:

[According to the _Naming WG_](https://github.com/kubernetes/community/blob/master/wg-naming/recommendations/master-control-plane.md), we should remove the offensive language in the Kubernetes code base and domain language.

Since `client-go` is widely used across several projects of the ecosystem it must comply.

**Which issue(s) this PR fixes**:

Fixes kubernetes/client-go#892

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
The environment variable `KUBERNETES_MASTER` is deprecated in favor of `KUBERNETES_CONTROL_PLANE` and it applies to all tools using internally this variable as `kubectl`.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
