### PR TITLE
(KEP-2436) implementation of leader migration for controller manager.

### DIFF
--- a/cmd/kube-controller-manager/app/options/options_test.go
+++ b/cmd/kube-controller-manager/app/options/options_test.go
@@ -35,6 +35,7 @@ import (
 	"k8s.io/component-base/metrics"
 	cmconfig "k8s.io/controller-manager/config"
 	cmoptions "k8s.io/controller-manager/options"
+	migration "k8s.io/controller-manager/pkg/leadermigration/options"
 	kubecontrollerconfig "k8s.io/kubernetes/cmd/kube-controller-manager/app/config"
 	kubectrlmgrconfig "k8s.io/kubernetes/pkg/controller/apis/config"
 	csrsigningconfig "k8s.io/kubernetes/pkg/controller/certificates/signer/config"
@@ -197,6 +198,7 @@ func TestAddFlags(t *testing.T) {
 					EnableContentionProfiling: true,
 				},
 			},
+			LeaderMigration: &migration.LeaderMigrationOptions{},
 		},
 		KubeCloudShared: &cpoptions.KubeCloudSharedOptions{
 			KubeCloudSharedConfiguration: &cpconfig.KubeCloudSharedConfiguration{

--- a/staging/src/k8s.io/cloud-provider/options/options_test.go
+++ b/staging/src/k8s.io/cloud-provider/options/options_test.go
@@ -31,6 +31,7 @@ import (
 	componentbaseconfig "k8s.io/component-base/config"
 	cmconfig "k8s.io/controller-manager/config"
 	cmoptions "k8s.io/controller-manager/options"
+	migration "k8s.io/controller-manager/pkg/leadermigration/options"
 )
 
 func TestDefaultFlags(t *testing.T) {
@@ -65,6 +66,7 @@ func TestDefaultFlags(t *testing.T) {
 					EnableContentionProfiling: false,
 				},
 			},
+			LeaderMigration: &migration.LeaderMigrationOptions{},
 		},
 		KubeCloudShared: &KubeCloudSharedOptions{
 			KubeCloudSharedConfiguration: &cpconfig.KubeCloudSharedConfiguration{
@@ -203,6 +205,7 @@ func TestAddFlags(t *testing.T) {
 					EnableContentionProfiling: true,
 				},
 			},
+			LeaderMigration: &migration.LeaderMigrationOptions{},
 		},
 		KubeCloudShared: &KubeCloudSharedOptions{
 			KubeCloudSharedConfiguration: &cpconfig.KubeCloudSharedConfiguration{

--- a/staging/src/k8s.io/controller-manager/options/generic.go
+++ b/staging/src/k8s.io/controller-manager/options/generic.go
@@ -42,7 +42,7 @@ func NewGenericControllerManagerConfigurationOptions(cfg *cmconfig.GenericContro
 	o := &GenericControllerManagerConfigurationOptions{
 		GenericControllerManagerConfiguration: cfg,
 		Debugging:                             RecommendedDebuggingOptions(),
-		LeaderMigration:                       nil,
+		LeaderMigration:                       &migration.LeaderMigrationOptions{},
 	}
 
 	return o

--- a/staging/src/k8s.io/controller-manager/pkg/leadermigration/filter.go
+++ b/staging/src/k8s.io/controller-manager/pkg/leadermigration/filter.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package leadermigration
+
+// FilterResult indicates whether and how the controller manager should start the controller.
+type FilterResult int32
+
+const (
+	// ControllerOwned indicates that the controller is owned by another controller manager
+	//  and thus should NOT be started by this controller manager.
+	ControllerUnowned = iota
+	// ControllerMigrated indicates that the controller manager should start this controller
+	//  with thte migration lock.
+	ControllerMigrated
+	// ControllerNonMigrated indicates that the controller manager should start this controller
+	//  with thte main lock.
+	ControllerNonMigrated
+)
+
+// FilterFunc takes a name of controller, returning a FilterResult indicating how to start controller.
+type FilterFunc func(controllerName string) FilterResult

--- a/staging/src/k8s.io/controller-manager/pkg/leadermigration/migrator.go
+++ b/staging/src/k8s.io/controller-manager/pkg/leadermigration/migrator.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package leadermigration
+
+import (
+	internal "k8s.io/controller-manager/config"
+)
+
+// LeaderMigrator holds information required by the leader migration process.
+type LeaderMigrator struct {
+	config              *internal.LeaderMigrationConfiguration
+	migratedControllers map[string]bool
+	// component indicates the name of the control-plane component that uses leader migration,
+	//  which should be a controller manager, i.e. kube-controller-manager or cloud-controller-manager
+	component string
+}
+
+// FilterFunc takes a name of controller, returning whether the controller should be started.
+type FilterFunc func(controllerName string) bool
+
+// NewLeaderMigrator creates a LeaderMigrator with given config for the given component. The component
+//  indicates which controller manager is requesting this leader migration, and it should be consistent
+//  with the component field of ControllerLeaderConfiguration.
+func NewLeaderMigrator(config *internal.LeaderMigrationConfiguration, component string) *LeaderMigrator {
+	migratedControllers := make(map[string]bool)
+	for _, leader := range config.ControllerLeaders {
+		migratedControllers[leader.Name] = leader.Component == component
+	}
+	return &LeaderMigrator{
+		config:              config,
+		migratedControllers: migratedControllers,
+		component:           component,
+	}
+}
+
+// FilterFunc returns the filter function that, when migrated == true
+//  - returns true if the controller should start under the migration lock
+//  - returns false if the controller should start under the main lock
+// when migrated == false, the result is inverted.
+func (m *LeaderMigrator) FilterFunc(migrated bool) FilterFunc {
+	return func(controllerName string) bool {
+		shouldRun, ok := m.migratedControllers[controllerName]
+		if !ok {
+			// The controller is not included in the migration
+			// If the caller wants the controllers outside migration, then we should include it.
+			return !migrated
+		}
+		// The controller is included in the migration
+		// If the caller wants the controllers within migration, we should only include it
+		//  if current component should run the controller
+		return migrated && shouldRun
+	}
+}

--- a/staging/src/k8s.io/controller-manager/pkg/leadermigration/migrator.go
+++ b/staging/src/k8s.io/controller-manager/pkg/leadermigration/migrator.go
@@ -22,6 +22,10 @@ import (
 
 // LeaderMigrator holds information required by the leader migration process.
 type LeaderMigrator struct {
+	// MigrationReady is closed after the coontroller manager finishes preparing for the migration lock.
+	// After this point, the leader migration process will proceed to acquire the migration lock.
+	MigrationReady chan struct{}
+
 	config              *internal.LeaderMigrationConfiguration
 	migratedControllers map[string]bool
 	// component indicates the name of the control-plane component that uses leader migration,
@@ -41,6 +45,7 @@ func NewLeaderMigrator(config *internal.LeaderMigrationConfiguration, component 
 		migratedControllers[leader.Name] = leader.Component == component
 	}
 	return &LeaderMigrator{
+		MigrationReady:      make(chan struct{}),
 		config:              config,
 		migratedControllers: migratedControllers,
 		component:           component,

--- a/staging/src/k8s.io/controller-manager/pkg/leadermigration/migrator_test.go
+++ b/staging/src/k8s.io/controller-manager/pkg/leadermigration/migrator_test.go
@@ -1,0 +1,119 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package leadermigration
+
+import (
+	"testing"
+
+	internal "k8s.io/controller-manager/config"
+)
+
+func TestLeaderMigratorFilterFunc(t *testing.T) {
+	fromConfig := &internal.LeaderMigrationConfiguration{
+		ResourceLock: "leases",
+		LeaderName:   "cloud-provider-extraction-migration",
+		ControllerLeaders: []internal.ControllerLeaderConfiguration{
+			{
+				Name:      "route",
+				Component: "kube-controller-manager",
+			}, {
+				Name:      "service",
+				Component: "kube-controller-manager",
+			}, {
+				Name:      "cloud-node-lifecycle",
+				Component: "kube-controller-manager",
+			},
+		},
+	}
+	toConfig := &internal.LeaderMigrationConfiguration{
+		ResourceLock: "leases",
+		LeaderName:   "cloud-provider-extraction-migration",
+		ControllerLeaders: []internal.ControllerLeaderConfiguration{
+			{
+				Name:      "route",
+				Component: "cloud-controller-manager",
+			}, {
+				Name:      "service",
+				Component: "cloud-controller-manager",
+			}, {
+				Name:      "cloud-node-lifecycle",
+				Component: "cloud-controller-manager",
+			},
+		},
+	}
+	for _, tc := range []struct {
+		name         string
+		config       *internal.LeaderMigrationConfiguration
+		component    string
+		migrated     bool
+		expectResult map[string]FilterResult
+	}{
+		{
+			name:      "from config, kcm",
+			config:    fromConfig,
+			component: "kube-controller-manager",
+			expectResult: map[string]FilterResult{
+				"deployment":           ControllerNonMigrated,
+				"route":                ControllerMigrated,
+				"service":              ControllerMigrated,
+				"cloud-node-lifecycle": ControllerMigrated,
+			},
+		},
+		{
+			name:      "from config, ccm",
+			config:    fromConfig,
+			component: "cloud-controller-manager",
+			expectResult: map[string]FilterResult{
+				"cloud-node":           ControllerNonMigrated,
+				"route":                ControllerUnowned,
+				"service":              ControllerUnowned,
+				"cloud-node-lifecycle": ControllerUnowned,
+			},
+		},
+		{
+			name:      "to config, kcm",
+			config:    toConfig,
+			component: "kube-controller-manager",
+			expectResult: map[string]FilterResult{
+				"deployment":           ControllerNonMigrated,
+				"route":                ControllerUnowned,
+				"service":              ControllerUnowned,
+				"cloud-node-lifecycle": ControllerUnowned,
+			},
+		},
+		{
+			name:      "to config, ccm",
+			config:    toConfig,
+			component: "cloud-controller-manager",
+			expectResult: map[string]FilterResult{
+				"cloud-node":           ControllerNonMigrated,
+				"route":                ControllerMigrated,
+				"service":              ControllerMigrated,
+				"cloud-node-lifecycle": ControllerMigrated,
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			migrator := NewLeaderMigrator(tc.config, tc.component)
+			for name, expected := range tc.expectResult {
+				if result := migrator.FilterFunc(name); expected != result {
+					t.Errorf("controller %s, expect %v, got %v", name, expected, result)
+				}
+			}
+		})
+	}
+}

--- a/staging/src/k8s.io/controller-manager/pkg/leadermigration/util.go
+++ b/staging/src/k8s.io/controller-manager/pkg/leadermigration/util.go
@@ -19,6 +19,7 @@ package leadermigration
 import config "k8s.io/controller-manager/config"
 
 // Enabled checks whether Leader Migration should be enabled, given the GenericControllerManagerConfiguration.
+// It considers the feature gate first, and will always return false if the feature gate is not enabled.
 func Enabled(genericConfig *config.GenericControllerManagerConfiguration) bool {
-	return genericConfig.LeaderElection.LeaderElect && genericConfig.LeaderMigrationEnabled
+	return FeatureEnabled() && genericConfig.LeaderElection.LeaderElect && genericConfig.LeaderMigrationEnabled
 }

--- a/staging/src/k8s.io/controller-manager/pkg/leadermigration/util.go
+++ b/staging/src/k8s.io/controller-manager/pkg/leadermigration/util.go
@@ -1,0 +1,24 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package leadermigration
+
+import config "k8s.io/controller-manager/config"
+
+// Enabled checks whether Leader Migration should be enabled, given the GenericControllerManagerConfiguration.
+func Enabled(genericConfig *config.GenericControllerManagerConfiguration) bool {
+	return genericConfig.LeaderElection.LeaderElect && genericConfig.LeaderMigrationEnabled
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:

This PR includes implementation of KEP-2436, https://github.com/kubernetes/enhancements/issues/2436, Leader Migration for controller managers, going alpha in 1.21


**Special notes for your reviewer**:
Due to the limitation of testing capability, any real-world tests cases, including e2e tests on a complete upgrade process,
cannot be really tested automatically. I am happy to make improvement to the testing framework, but it is unlikely in time for this milestone.

Full e2e test is needed for beta graduation.

The implementation has been split into multiple PRs to ease reviewing.
    - https://github.com/kubernetes/kubernetes/pull/96226 
    - https://github.com/kubernetes/kubernetes/pull/96133 
    - https://github.com/kubernetes/kubernetes/pull/94205
    - https://github.com/kubernetes/kubernetes/pull/99507
   
The doc showing a process of manual testing.
<https://docs.google.com/document/d/1k1KF-IohtV9R9JEXZYYd177uTgH0_zEMFdamatIkcFM/>

Please ignore test pull-kubernetes-bazel-build. Any Bazel-related tests have already been removed, leaving stale status reports.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <https://github.com/kubernetes/enhancements/tree/master/keps/sig-cloud-provider/2436-controller-manager-leader-migration>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

https://github.com/kubernetes/enhancements/tree/master/keps/sig-cloud-provider/2436-controller-manager-leader-migration

```
/priority important-soon