### PR TITLE
Automated cherry pick of #96491: Avoid checking the entire backend service URL for FR

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/gce/BUILD
+++ b/staging/src/k8s.io/legacy-cloud-providers/gce/BUILD
@@ -75,6 +75,7 @@ go_library(
         "//vendor/github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/filter:go_default_library",
         "//vendor/github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta:go_default_library",
         "//vendor/github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/mock:go_default_library",
+        "//vendor/github.com/google/go-cmp/cmp:go_default_library",
         "//vendor/golang.org/x/oauth2:go_default_library",
         "//vendor/golang.org/x/oauth2/google:go_default_library",
         "//vendor/google.golang.org/api/compute/v0.alpha:go_default_library",

--- a/staging/src/k8s.io/legacy-cloud-providers/gce/gce_loadbalancer_internal.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/gce/gce_loadbalancer_internal.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud"
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
+	"github.com/google/go-cmp/cmp"
 	compute "google.golang.org/api/compute/v1"
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -173,12 +174,6 @@ func (g *Cloud) ensureInternalLoadBalancer(clusterName, clusterID string, svc *v
 		return nil, err
 	}
 
-	bsDescription := makeBackendServiceDescription(nm, sharedBackend)
-	err = g.ensureInternalBackendService(backendServiceName, bsDescription, svc.Spec.SessionAffinity, scheme, protocol, igLinks, hc.SelfLink)
-	if err != nil {
-		return nil, err
-	}
-
 	fwdRuleDescription := &forwardingRuleDescription{ServiceName: nm.String()}
 	fwdRuleDescriptionString, err := fwdRuleDescription.marshal()
 	if err != nil {
@@ -200,8 +195,31 @@ func (g *Cloud) ensureInternalLoadBalancer(clusterName, clusterID string, svc *v
 	if options.AllowGlobalAccess {
 		newFwdRule.AllowGlobalAccess = options.AllowGlobalAccess
 	}
-	if err := g.ensureInternalForwardingRule(existingFwdRule, newFwdRule); err != nil {
+
+	fwdRuleDeleted := false
+	if existingFwdRule != nil && !forwardingRulesEqual(existingFwdRule, newFwdRule) {
+		// Delete existing forwarding rule before making changes to the backend service. For example - changing protocol
+		// of backend service without first deleting forwarding rule will throw an error since the linked forwarding
+		// rule would show the old protocol.
+		frDiff := cmp.Diff(existingFwdRule, newFwdRule)
+		klog.V(2).Infof("ensureInternalLoadBalancer(%v): forwarding rule changed - Existing - %+v\n, New - %+v\n, Diff(-existing, +new) - %s\n. Deleting existing forwarding rule.", loadBalancerName, existingFwdRule, newFwdRule, frDiff)
+		if err = ignoreNotFound(g.DeleteRegionForwardingRule(loadBalancerName, g.region)); err != nil {
+			return nil, err
+		}
+		fwdRuleDeleted = true
+	}
+
+	bsDescription := makeBackendServiceDescription(nm, sharedBackend)
+	err = g.ensureInternalBackendService(backendServiceName, bsDescription, svc.Spec.SessionAffinity, scheme, protocol, igLinks, hc.SelfLink)
+	if err != nil {
 		return nil, err
+	}
+
+	if fwdRuleDeleted || existingFwdRule == nil {
+		// existing rule has been deleted, pass in nil
+		if err := g.ensureInternalForwardingRule(nil, newFwdRule); err != nil {
+			return nil, err
+		}
 	}
 
 	// Delete the previous internal load balancer resources if necessary
@@ -964,11 +982,16 @@ func (g *Cloud) ensureInternalForwardingRule(existingFwdRule, newFwdRule *comput
 }
 
 func forwardingRulesEqual(old, new *compute.ForwardingRule) bool {
+	// basepath could have differences like compute.googleapis.com vs www.googleapis.com, compare resourceIDs
+	oldResourceID, err := cloud.ParseResourceURL(old.BackendService)
+	klog.Errorf("forwardingRulesEqual(): failed to parse backend resource URL from existing FR, err - %v", err)
+	newResourceID, err := cloud.ParseResourceURL(new.BackendService)
+	klog.Errorf("forwardingRulesEqual(): failed to parse resource URL from new FR, err - %v", err)
 	return (old.IPAddress == "" || new.IPAddress == "" || old.IPAddress == new.IPAddress) &&
 		old.IPProtocol == new.IPProtocol &&
 		old.LoadBalancingScheme == new.LoadBalancingScheme &&
 		equalStringSets(old.Ports, new.Ports) &&
-		old.BackendService == new.BackendService &&
+		oldResourceID.Equal(newResourceID) &&
 		old.AllowGlobalAccess == new.AllowGlobalAccess &&
 		old.Subnetwork == new.Subnetwork
 }

--- a/staging/src/k8s.io/legacy-cloud-providers/gce/gce_loadbalancer_internal_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/gce/gce_loadbalancer_internal_test.go
@@ -328,7 +328,7 @@ func TestEnsureInternalLoadBalancerClearPreviousResources(t *testing.T) {
 	}
 
 	gce.CreateRegionBackendService(existingBS, gce.region)
-	existingFwdRule.BackendService = existingBS.Name
+	existingFwdRule.BackendService = cloud.SelfLink(meta.VersionGA, vals.ProjectID, "backendServices", meta.RegionalKey(existingBS.Name, gce.region))
 
 	_, err = createInternalLoadBalancer(gce, svc, existingFwdRule, []string{"test-node-1"}, vals.ClusterName, vals.ClusterID, vals.ZoneName)
 	assert.NoError(t, err)
@@ -1310,6 +1310,7 @@ func TestForwardingRulesEqual(t *testing.T) {
 			Ports:               []string{"123"},
 			IPProtocol:          "TCP",
 			LoadBalancingScheme: string(cloud.SchemeInternal),
+			BackendService:      "http://www.googleapis.com/projects/test/regions/us-central1/backendServices/bs1",
 		},
 		{
 			Name:                "tcp-fwd-rule",
@@ -1317,6 +1318,7 @@ func TestForwardingRulesEqual(t *testing.T) {
 			Ports:               []string{"123"},
 			IPProtocol:          "TCP",
 			LoadBalancingScheme: string(cloud.SchemeInternal),
+			BackendService:      "http://www.googleapis.com/projects/test/regions/us-central1/backendServices/bs1",
 		},
 		{
 			Name:                "udp-fwd-rule",
@@ -1324,6 +1326,7 @@ func TestForwardingRulesEqual(t *testing.T) {
 			Ports:               []string{"123"},
 			IPProtocol:          "UDP",
 			LoadBalancingScheme: string(cloud.SchemeInternal),
+			BackendService:      "http://www.googleapis.com/projects/test/regions/us-central1/backendServices/bs1",
 		},
 		{
 			Name:                "global-access-fwd-rule",
@@ -1332,6 +1335,16 @@ func TestForwardingRulesEqual(t *testing.T) {
 			IPProtocol:          "TCP",
 			LoadBalancingScheme: string(cloud.SchemeInternal),
 			AllowGlobalAccess:   true,
+			BackendService:      "http://www.googleapis.com/projects/test/regions/us-central1/backendServices/bs1",
+		},
+		{
+			Name:                "global-access-fwd-rule",
+			IPAddress:           "10.0.0.0",
+			Ports:               []string{"123"},
+			IPProtocol:          "TCP",
+			LoadBalancingScheme: string(cloud.SchemeInternal),
+			AllowGlobalAccess:   true,
+			BackendService:      "http://compute.googleapis.com/projects/test/regions/us-central1/backendServices/bs1",
 		},
 	}
 
@@ -1363,6 +1376,12 @@ func TestForwardingRulesEqual(t *testing.T) {
 			desc:       "same forwarding rule",
 			oldFwdRule: fwdRules[3],
 			newFwdRule: fwdRules[3],
+			expect:     true,
+		},
+		{
+			desc:       "same forwarding rule, different basepath",
+			oldFwdRule: fwdRules[3],
+			newFwdRule: fwdRules[4],
 			expect:     true,
 		},
 	} {


### PR DESCRIPTION
Cherry pick of #96491 on release-1.19.

#96491: Avoid checking the entire backend service URL for FR
#93423 : Fix GCE ILB code to support protocol change

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.