### PR TITLE
[release-1.18] Fix kubectl CRD validation with preserve-unknown-fields

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/openapi/builder/builder_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/openapi/builder/builder_test.go
@@ -172,8 +172,7 @@ func TestNewBuilder(t *testing.T) {
     },
     "embedded-object": {
       "x-kubernetes-embedded-resource": true,
-      "x-kubernetes-preserve-unknown-fields": true,
-      "type":"object"
+      "x-kubernetes-preserve-unknown-fields": true
     }
   },
   "x-kubernetes-group-version-kind":[{"group":"bar.k8s.io","kind":"Foo","version":"v1"}]

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/openapi/v2/BUILD
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/openapi/v2/BUILD
@@ -24,6 +24,7 @@ go_test(
         "//vendor/github.com/googleapis/gnostic/compiler:go_default_library",
         "//vendor/gopkg.in/yaml.v2:go_default_library",
         "//vendor/k8s.io/kube-openapi/pkg/util/proto:go_default_library",
+        "//vendor/k8s.io/utils/pointer:go_default_library",
     ],
 )
 

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/openapi/v2/conversion.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/openapi/v2/conversion.go
@@ -73,6 +73,14 @@ func ToStructuralOpenAPIV2(in *structuralschema.Structural) *structuralschema.St
 				changed = true
 			}
 
+			if s.Items == nil && s.Type == "array" {
+				// kubectl cannot cope with array without item schema, e.g. due to XPreserveUnknownFields case above
+				// https://github.com/kubernetes/kube-openapi/blob/64514a1d5d596b96e6f957e2be275ae14d6b0804/pkg/util/proto/document.go#L185
+				s.Type = ""
+
+				changed = true
+			}
+
 			for f, fs := range s.Properties {
 				if fs.Nullable {
 					s.ValueValidation.Required, changed = filterOut(s.ValueValidation.Required, f)

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/openapi/v2/conversion.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/openapi/v2/conversion.go
@@ -81,6 +81,13 @@ func ToStructuralOpenAPIV2(in *structuralschema.Structural) *structuralschema.St
 				changed = true
 			}
 
+			if s.XPreserveUnknownFields && s.Type == "object" {
+				// similar as above, kubectl doesn't properly handle object fields with `x-kubernetes-preserve-unknown-fields: true`
+				s.Type = ""
+
+				changed = true
+			}
+
 			for f, fs := range s.Properties {
 				if fs.Nullable {
 					s.ValueValidation.Required, changed = filterOut(s.ValueValidation.Required, f)

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/openapi/v2/conversion_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/openapi/v2/conversion_test.go
@@ -666,8 +666,7 @@ func Test_ConvertJSONSchemaPropsToOpenAPIv2SchemaByType(t *testing.T) {
 					},
 				},
 			},
-			expected: withVendorExtensions(new(spec.Schema), "x-kubernetes-preserve-unknown-fields", true).
-				Typed("object", ""),
+			expected: withVendorExtensions(new(spec.Schema), "x-kubernetes-preserve-unknown-fields", true),
 		},
 	}
 

--- a/test/e2e/apimachinery/crd_publish_openapi.go
+++ b/test/e2e/apimachinery/crd_publish_openapi.go
@@ -230,7 +230,7 @@ var _ = SIGDescribe("CustomResourcePublishOpenAPI [Privileged:ClusterAdmin]", fu
 		ns := fmt.Sprintf("--namespace=%v", f.Namespace.Name)
 
 		ginkgo.By("client-side validation (kubectl create and apply) allows request with any unknown properties")
-		randomCR := fmt.Sprintf(`{%s,"spec":{"b":[{"c":"d"}]}}`, meta)
+		randomCR := fmt.Sprintf(`{%s,"spec":{"a":null,"b":[{"c":"d"}]}}`, meta)
 		if _, err := framework.RunKubectlInput(f.Namespace.Name, randomCR, ns, "create", "-f", "-"); err != nil {
 			framework.Failf("failed to create random CR %s for CRD that allows unknown properties in a nested object: %v", randomCR, err)
 		}


### PR DESCRIPTION
/kind bug
/priority important-soon

Backports https://github.com/kubernetes/kubernetes/pull/94888 https://github.com/kubernetes/kubernetes/pull/96369

```release-note
Fixed a bug that prevents kubectl to validate CRDs with schema using x-kubernetes-preserve-unknown-fields on object fields.
Fix regression in kubectl validation in 1.18+ on CRDs with schema using x-kubernetes-preserve-unknown-fields on array types.
```