### PR TITLE
kubelet: do not rerun init containers if any main containers have status

### DIFF
--- a/pkg/kubelet/kuberuntime/kuberuntime_container.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container.go
@@ -744,6 +744,18 @@ func findNextInitContainerToRun(pod *v1.Pod, podStatus *kubecontainer.PodStatus)
 		return nil, nil, true
 	}
 
+	// If any of the main containers have status and are Running, then all init containers must
+	// have been executed at some point in the past.  However, they could have been removed
+	// from the container runtime now, and if we proceed, it would appear as if they
+	// never ran and will re-execute improperly.
+	for i := range pod.Spec.Containers {
+		container := &pod.Spec.Containers[i]
+		status := podStatus.FindContainerStatusByName(container.Name)
+		if status != nil && status.State == kubecontainer.ContainerStateRunning {
+			return nil, nil, true
+		}
+	}
+
 	// If there are failed containers, return the status of the last failed one.
 	for i := len(pod.Spec.InitContainers) - 1; i >= 0; i-- {
 		container := &pod.Spec.InitContainers[i]


### PR DESCRIPTION
xref https://bugzilla.redhat.com/show_bug.cgi?id=1770017

When init containers are GCed by the kubelet (or anything) the kubelet will re-execute them, even if the main containers are already running.  This is a violation of the pod lifecycle state machine.

This PR changes the code that determines if an init container should be run to first check if the any of the main containers have status.  If so, the pod is beyond the init container phase of the pod lifecycle and thus all init containers will have already run, even if the container runtime no longer has an exited container reflecting that the init container(s) ran.

@derekwaynecarr @rphillips @joelsmith 

/sig node
```release-note
None
```