### PR TITLE
Avoid logging JSON blob on error.

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/gce/gcpcredential/gcpcredential.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/gce/gcpcredential/gcpcredential.go
@@ -112,7 +112,7 @@ func ProvideContainerRegistry(client *http.Client, image string) credentialconfi
 
 	var parsedBlob TokenBlob
 	if err := json.Unmarshal([]byte(tokenJSONBlob), &parsedBlob); err != nil {
-		klog.Errorf("while parsing json blob %s: %v", tokenJSONBlob, err)
+		klog.Errorf("error while parsing json blob of length %d", len(tokenJSONBlob))
 		return cfg
 	}
 


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
/sig auth security

**What this PR does / why we need it**:
While vanishingly unlikely to present an actual security risk, we should not log a JSON blob that we expect to hold a security token.

**Special notes for your reviewer**:
This is unlikely to present an actual security risk because:
* Exposure of tokens depends on the response from metadata server to be both malformed but to contain the token.
* MDS communication is done over TCP loopback.  This handles dropped packets well and is hardened against flipped bits.
* It is likely that the MDS response will be contained in a single packet, so any response received is likely to be complete.

(Thank you to @ahmedtd for filling in my understanding of metadata server communication.)

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
Discovered loosely in association to the safe-logging KEPs [1933](https://github.com/kubernetes/enhancements/blob/1ab4b6ef93ad8101b73e0c168caa4ea5bf63f263/keps/sig-instrumentation/1933-secret-logging-static-analysis/README.md) and [1753](https://github.com/kubernetes/enhancements/tree/1ab4b6ef93ad8101b73e0c168caa4ea5bf63f263/keps/sig-instrumentation/1753-logs-sanitization).
