### PR TITLE
don't add pod to podQueue when the NodeName of pod is not empty

### DIFF
--- a/pkg/scheduler/factory_test.go
+++ b/pkg/scheduler/factory_test.go
@@ -19,6 +19,7 @@ package scheduler
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -550,6 +551,35 @@ func TestDefaultErrorFunc_NodeNotFound(t *testing.T) {
 				t.Errorf("Unexpected nodes (-want, +got): %s", diff)
 			}
 		})
+	}
+}
+
+func TestDefaultErrorFunc_PodAlreadyBound(t *testing.T) {
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+
+	nodeFoo := v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "foo"}}
+	testPod := &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default"}, Spec: v1.PodSpec{NodeName: "foo"}}
+
+	client := fake.NewSimpleClientset(&v1.PodList{Items: []v1.Pod{*testPod}}, &v1.NodeList{Items: []v1.Node{nodeFoo}})
+	informerFactory := informers.NewSharedInformerFactory(client, 0)
+	podInformer := informerFactory.Core().V1().Pods()
+	// Need to add testPod to the store.
+	podInformer.Informer().GetStore().Add(testPod)
+
+	queue := internalqueue.NewPriorityQueue(nil, internalqueue.WithClock(clock.NewFakeClock(time.Now())))
+	schedulerCache := internalcache.New(30*time.Second, stopCh)
+
+	// Add node to schedulerCache no matter it's deleted in API server or not.
+	schedulerCache.AddNode(&nodeFoo)
+
+	testPodInfo := &framework.QueuedPodInfo{Pod: testPod}
+	errFunc := MakeDefaultErrorFunc(client, podInformer.Lister(), queue, schedulerCache)
+	errFunc(testPodInfo, fmt.Errorf("binding rejected: timeout"))
+
+	pod := getPodFromPriorityQueue(queue, testPod)
+	if pod != nil {
+		t.Fatalf("Unexpected pod: %v should not be in PriorityQueue when the NodeName of pod is not empty", pod.Name)
 	}
 }
 


### PR DESCRIPTION
What type of PR is this?
/kind bug

What this PR does / why we need it:
The extended scheduler with webhook will retry bind pod forever when the pod is bind successed but the bind request timeout 

Which issue(s) this PR fixes:
#96579

Special notes for your reviewer:

Does this PR introduce a user-facing change?:
NONE

Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.: