### PR TITLE
sig-cli: Add --token-file flag to kubectl

### DIFF
--- a/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/config_flags.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/config_flags.go
@@ -47,6 +47,7 @@ const (
 	flagKeyFile          = "client-key"
 	flagCAFile           = "certificate-authority"
 	flagBearerToken      = "token"
+	flagBearerTokenFile  = "token-file"
 	flagImpersonate      = "as"
 	flagImpersonateGroup = "as-group"
 	flagUsername         = "username"
@@ -93,6 +94,7 @@ type ConfigFlags struct {
 	KeyFile          *string
 	CAFile           *string
 	BearerToken      *string
+	BearerTokenFile  *string
 	Impersonate      *string
 	ImpersonateGroup *[]string
 	Username         *string
@@ -146,6 +148,9 @@ func (f *ConfigFlags) toRawKubeConfigLoader() clientcmd.ClientConfig {
 	}
 	if f.BearerToken != nil {
 		overrides.AuthInfo.Token = *f.BearerToken
+	}
+	if f.BearerTokenFile != nil {
+		overrides.AuthInfo.TokenFile = *f.BearerTokenFile
 	}
 	if f.Impersonate != nil {
 		overrides.AuthInfo.Impersonate = *f.Impersonate
@@ -270,6 +275,9 @@ func (f *ConfigFlags) AddFlags(flags *pflag.FlagSet) {
 	if f.BearerToken != nil {
 		flags.StringVar(f.BearerToken, flagBearerToken, *f.BearerToken, "Bearer token for authentication to the API server")
 	}
+	if f.BearerTokenFile != nil {
+		flags.StringVar(f.BearerTokenFile, flagBearerTokenFile, *f.BearerTokenFile, "Bearer token file for authentication to the API server")
+	}
 	if f.Impersonate != nil {
 		flags.StringVar(f.Impersonate, flagImpersonate, *f.Impersonate, "Username to impersonate for the operation")
 	}
@@ -341,6 +349,7 @@ func NewConfigFlags(usePersistentConfig bool) *ConfigFlags {
 		KeyFile:          stringptr(""),
 		CAFile:           stringptr(""),
 		BearerToken:      stringptr(""),
+		BearerTokenFile:  stringptr(""),
 		Impersonate:      stringptr(""),
 		ImpersonateGroup: &impersonateGroup,
 

--- a/staging/src/k8s.io/client-go/tools/clientcmd/overrides.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/overrides.go
@@ -52,6 +52,7 @@ type AuthOverrideFlags struct {
 	ClientCertificate FlagInfo
 	ClientKey         FlagInfo
 	Token             FlagInfo
+	TokenFile         FlagInfo
 	Impersonate       FlagInfo
 	ImpersonateGroups FlagInfo
 	Username          FlagInfo
@@ -153,6 +154,7 @@ const (
 	FlagCAFile           = "certificate-authority"
 	FlagEmbedCerts       = "embed-certs"
 	FlagBearerToken      = "token"
+	FlagBearerTokenFile  = "token-file"
 	FlagImpersonate      = "as"
 	FlagImpersonateGroup = "as-group"
 	FlagUsername         = "username"
@@ -178,6 +180,7 @@ func RecommendedAuthOverrideFlags(prefix string) AuthOverrideFlags {
 		ClientCertificate: FlagInfo{prefix + FlagCertFile, "", "", "Path to a client certificate file for TLS"},
 		ClientKey:         FlagInfo{prefix + FlagKeyFile, "", "", "Path to a client key file for TLS"},
 		Token:             FlagInfo{prefix + FlagBearerToken, "", "", "Bearer token for authentication to the API server"},
+		TokenFile:         FlagInfo{prefix + FlagBearerTokenFile, "", "", "Bearer token file for authentication to the API server"},
 		Impersonate:       FlagInfo{prefix + FlagImpersonate, "", "", "Username to impersonate for the operation"},
 		ImpersonateGroups: FlagInfo{prefix + FlagImpersonateGroup, "", "", "Group to impersonate for the operation, this flag can be repeated to specify multiple groups."},
 		Username:          FlagInfo{prefix + FlagUsername, "", "", "Username for basic authentication to the API server"},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Adds the `--token-file` flag to the `kubectl` CLI, providing a more secure way of providing tokens on the command line.  This extends the existing support within the SDK for using token files to the CLI.

This also would now allow all in-cluster config options to be specified on the CLI, which would allow a user to utilize in-cluster config with additional options as a work around to problems like https://github.com/kubernetes/kubernetes/issues/49343

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
/sig cli

**Does this PR introduce a user-facing change?**:
```release-note
Adds the --token-file flag to kubectl for reading a bearer token from file
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
