### PR TITLE
test: add integration and e2e tests for EndpointSlice terminating endpoints

### DIFF
--- a/test/e2e/network/BUILD
+++ b/test/e2e/network/BUILD
@@ -97,6 +97,7 @@ go_library(
         "//vendor/github.com/onsi/gomega:go_default_library",
         "//vendor/google.golang.org/api/compute/v1:go_default_library",
         "//vendor/k8s.io/utils/net:go_default_library",
+        "//vendor/k8s.io/utils/pointer:go_default_library",
     ],
 )
 

--- a/test/integration/endpoints/endpoints_test.go
+++ b/test/integration/endpoints/endpoints_test.go
@@ -156,6 +156,158 @@ func TestEndpointUpdates(t *testing.T) {
 
 }
 
+// TestEndpointWithTerminatingPod tests that terminating pods are NOT included in Endpoints
+func TestEndpointWithTerminatingPod(t *testing.T) {
+	masterConfig := framework.NewIntegrationTestMasterConfig()
+	_, server, closeFn := framework.RunAMaster(masterConfig)
+	defer closeFn()
+
+	config := restclient.Config{Host: server.URL}
+	client, err := clientset.NewForConfig(&config)
+	if err != nil {
+		t.Fatalf("Error creating clientset: %v", err)
+	}
+
+	informers := informers.NewSharedInformerFactory(client, 0)
+
+	epController := endpoint.NewEndpointController(
+		informers.Core().V1().Pods(),
+		informers.Core().V1().Services(),
+		informers.Core().V1().Endpoints(),
+		client,
+		0)
+
+	// Start informer and controllers
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	informers.Start(stopCh)
+	go epController.Run(1, stopCh)
+
+	// Create namespace
+	ns := framework.CreateTestingNamespace("test-endpoints-terminating", server, t)
+	defer framework.DeleteTestingNamespace(ns, server, t)
+
+	// Create a pod with labels
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "test-pod",
+			Labels: labelMap(),
+		},
+		Spec: v1.PodSpec{
+			NodeName: "fake-node",
+			Containers: []v1.Container{
+				{
+					Name:  "fakename",
+					Image: "fakeimage",
+					Ports: []v1.ContainerPort{
+						{
+							Name:          "port-443",
+							ContainerPort: 443,
+						},
+					},
+				},
+			},
+		},
+		Status: v1.PodStatus{
+			Phase: v1.PodRunning,
+			Conditions: []v1.PodCondition{
+				{
+					Type:   v1.PodReady,
+					Status: v1.ConditionTrue,
+				},
+			},
+			PodIP: "10.0.0.1",
+			PodIPs: []v1.PodIP{
+				{
+					IP: "10.0.0.1",
+				},
+			},
+		},
+	}
+
+	createdPod, err := client.CoreV1().Pods(ns.Name).Create(context.TODO(), pod, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("Failed to create pod %s: %v", pod.Name, err)
+	}
+
+	createdPod.Status = pod.Status
+	_, err = client.CoreV1().Pods(ns.Name).UpdateStatus(context.TODO(), createdPod, metav1.UpdateOptions{})
+	if err != nil {
+		t.Fatalf("Failed to update status of pod %s: %v", pod.Name, err)
+	}
+
+	// Create a service associated to the pod
+	svc := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-service",
+			Namespace: ns.Name,
+			Labels: map[string]string{
+				"foo": "bar",
+			},
+		},
+		Spec: v1.ServiceSpec{
+			Selector: map[string]string{
+				"foo": "bar",
+			},
+			Ports: []v1.ServicePort{
+				{Name: "port-443", Port: 443, Protocol: "TCP", TargetPort: intstr.FromInt(443)},
+			},
+		},
+	}
+	_, err = client.CoreV1().Services(ns.Name).Create(context.TODO(), svc, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("Failed to create service %s: %v", svc.Name, err)
+	}
+
+	// poll until associated Endpoints to the previously created Service exists
+	if err := wait.PollImmediate(1*time.Second, wait.ForeverTestTimeout, func() (bool, error) {
+		endpoints, err := client.CoreV1().Endpoints(ns.Name).Get(context.TODO(), svc.Name, metav1.GetOptions{})
+		if err != nil {
+			return false, nil
+		}
+
+		numEndpoints := 0
+		for _, subset := range endpoints.Subsets {
+			numEndpoints += len(subset.Addresses)
+		}
+
+		if numEndpoints == 0 {
+			return false, nil
+		}
+
+		return true, nil
+	}); err != nil {
+		t.Fatalf("endpoints not found: %v", err)
+	}
+
+	err = client.CoreV1().Pods(ns.Name).Delete(context.TODO(), pod.Name, metav1.DeleteOptions{})
+	if err != nil {
+		t.Fatalf("error deleting test pod: %v", err)
+	}
+
+	// poll until endpoint for deleted Pod is no longer in Endpoints. Use a stricter timeout value
+	// since we should try to catch regressions in the time it takes to remove terminated endpoints.
+	if err := wait.PollImmediate(1*time.Second, 10*time.Second, func() (bool, error) {
+		endpoints, err := client.CoreV1().Endpoints(ns.Name).Get(context.TODO(), svc.Name, metav1.GetOptions{})
+		if err != nil {
+			return false, nil
+		}
+
+		numEndpoints := 0
+		for _, subset := range endpoints.Subsets {
+			numEndpoints += len(subset.Addresses)
+		}
+
+		if numEndpoints > 0 {
+			return false, nil
+		}
+
+		return true, nil
+	}); err != nil {
+		t.Fatalf("error checking for no endpoints with terminating pods: %v", err)
+	}
+}
+
 func labelMap() map[string]string {
 	return map[string]string{"foo": "bar"}
 }

--- a/test/integration/endpointslice/BUILD
+++ b/test/integration/endpointslice/BUILD
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_test")
 go_test(
     name = "go_default_test",
     srcs = [
+        "endpointslice_terminating_test.go",
         "endpointslicemirroring_test.go",
         "main_test.go",
     ],
@@ -11,14 +12,19 @@ go_test(
         "//pkg/controller/endpoint:go_default_library",
         "//pkg/controller/endpointslice:go_default_library",
         "//pkg/controller/endpointslicemirroring:go_default_library",
+        "//pkg/features:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/api/discovery/v1beta1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/intstr:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/wait:go_default_library",
+        "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",
         "//staging/src/k8s.io/client-go/informers:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes:go_default_library",
         "//staging/src/k8s.io/client-go/rest:go_default_library",
+        "//staging/src/k8s.io/component-base/featuregate/testing:go_default_library",
         "//test/integration/framework:go_default_library",
+        "//vendor/k8s.io/utils/pointer:go_default_library",
     ],
 )
 

--- a/test/integration/endpointslice/endpointslice_terminating_test.go
+++ b/test/integration/endpointslice/endpointslice_terminating_test.go
@@ -1,0 +1,416 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package endpointslice
+
+import (
+	"context"
+	"reflect"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	discovery "k8s.io/api/discovery/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/wait"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	"k8s.io/client-go/informers"
+	clientset "k8s.io/client-go/kubernetes"
+	restclient "k8s.io/client-go/rest"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
+	"k8s.io/kubernetes/pkg/controller/endpointslice"
+	"k8s.io/kubernetes/pkg/features"
+	"k8s.io/kubernetes/test/integration/framework"
+	utilpointer "k8s.io/utils/pointer"
+)
+
+// TestEndpointSliceTerminating tests that terminating pods are NOT included in EndpointSlice when
+// the feature gate EndpointSliceTerminatingCondition is off. If the gate is on, it tests that
+// terminating endpoints are included but with the correct conditions set for ready, serving and terminating.
+func TestEndpointSliceTerminating(t *testing.T) {
+	testcases := []struct {
+		name            string
+		pod             *corev1.Pod
+		endpoints       []discovery.Endpoint
+		terminatingGate bool
+	}{
+		{
+			name: "ready terminating pods not included, terminating gate off",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-pod",
+					Labels: map[string]string{
+						"foo": "bar",
+					},
+				},
+				Spec: corev1.PodSpec{
+					NodeName: "fake-node",
+					Containers: []corev1.Container{
+						{
+							Name:  "fakename",
+							Image: "fakeimage",
+							Ports: []corev1.ContainerPort{
+								{
+									Name:          "port-80",
+									ContainerPort: 80,
+								},
+								{
+									Name:          "port-443",
+									ContainerPort: 443,
+								},
+							},
+						},
+					},
+				},
+				Status: corev1.PodStatus{
+					Phase: corev1.PodRunning,
+					Conditions: []corev1.PodCondition{
+						{
+							Type:   corev1.PodReady,
+							Status: corev1.ConditionTrue,
+						},
+					},
+					PodIP: "10.0.0.1",
+					PodIPs: []corev1.PodIP{
+						{
+							IP: "10.0.0.1",
+						},
+					},
+				},
+			},
+			endpoints:       []discovery.Endpoint{},
+			terminatingGate: false,
+		},
+		{
+			name: "not ready terminating pods not included, terminating gate off",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-pod",
+					Labels: map[string]string{
+						"foo": "bar",
+					},
+				},
+				Spec: corev1.PodSpec{
+					NodeName: "fake-node",
+					Containers: []corev1.Container{
+						{
+							Name:  "fakename",
+							Image: "fakeimage",
+							Ports: []corev1.ContainerPort{
+								{
+									Name:          "port-80",
+									ContainerPort: 80,
+								},
+								{
+									Name:          "port-443",
+									ContainerPort: 443,
+								},
+							},
+						},
+					},
+				},
+				Status: corev1.PodStatus{
+					Phase: corev1.PodRunning,
+					Conditions: []corev1.PodCondition{
+						{
+							Type:   corev1.PodReady,
+							Status: corev1.ConditionFalse,
+						},
+					},
+					PodIP: "10.0.0.1",
+					PodIPs: []corev1.PodIP{
+						{
+							IP: "10.0.0.1",
+						},
+					},
+				},
+			},
+			endpoints:       []discovery.Endpoint{},
+			terminatingGate: false,
+		},
+		{
+			name: "ready terminating pods included, terminating gate on",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-pod",
+					Labels: map[string]string{
+						"foo": "bar",
+					},
+				},
+				Spec: corev1.PodSpec{
+					NodeName: "fake-node",
+					Containers: []corev1.Container{
+						{
+							Name:  "fakename",
+							Image: "fakeimage",
+							Ports: []corev1.ContainerPort{
+								{
+									Name:          "port-80",
+									ContainerPort: 80,
+								},
+								{
+									Name:          "port-443",
+									ContainerPort: 443,
+								},
+							},
+						},
+					},
+				},
+				Status: corev1.PodStatus{
+					Phase: corev1.PodRunning,
+					Conditions: []corev1.PodCondition{
+						{
+							Type:   corev1.PodReady,
+							Status: corev1.ConditionTrue,
+						},
+					},
+					PodIP: "10.0.0.1",
+					PodIPs: []corev1.PodIP{
+						{
+							IP: "10.0.0.1",
+						},
+					},
+				},
+			},
+			endpoints: []discovery.Endpoint{
+				{
+					Addresses: []string{"10.0.0.1"},
+					Conditions: discovery.EndpointConditions{
+						Ready:       utilpointer.BoolPtr(false),
+						Serving:     utilpointer.BoolPtr(true),
+						Terminating: utilpointer.BoolPtr(true),
+					},
+				},
+			},
+			terminatingGate: true,
+		},
+		{
+			name: "not ready terminating pods included, terminating gate on",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-pod",
+					Labels: map[string]string{
+						"foo": "bar",
+					},
+				},
+				Spec: corev1.PodSpec{
+					NodeName: "fake-node",
+					Containers: []corev1.Container{
+						{
+							Name:  "fakename",
+							Image: "fakeimage",
+							Ports: []corev1.ContainerPort{
+								{
+									Name:          "port-80",
+									ContainerPort: 80,
+								},
+								{
+									Name:          "port-443",
+									ContainerPort: 443,
+								},
+							},
+						},
+					},
+				},
+				Status: corev1.PodStatus{
+					Phase: corev1.PodRunning,
+					Conditions: []corev1.PodCondition{
+						{
+							Type:   corev1.PodReady,
+							Status: corev1.ConditionFalse,
+						},
+					},
+					PodIP: "10.0.0.1",
+					PodIPs: []corev1.PodIP{
+						{
+							IP: "10.0.0.1",
+						},
+					},
+				},
+			},
+			endpoints: []discovery.Endpoint{
+				{
+					Addresses: []string{"10.0.0.1"},
+					Conditions: discovery.EndpointConditions{
+						Ready:       utilpointer.BoolPtr(false),
+						Serving:     utilpointer.BoolPtr(false),
+						Terminating: utilpointer.BoolPtr(true),
+					},
+				},
+			},
+			terminatingGate: true,
+		},
+	}
+
+	for _, testcase := range testcases {
+		t.Run(testcase.name, func(t *testing.T) {
+			defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.EndpointSliceTerminatingCondition, testcase.terminatingGate)()
+
+			masterConfig := framework.NewIntegrationTestMasterConfig()
+			_, server, closeFn := framework.RunAMaster(masterConfig)
+			defer closeFn()
+
+			config := restclient.Config{Host: server.URL}
+			client, err := clientset.NewForConfig(&config)
+			if err != nil {
+				t.Fatalf("Error creating clientset: %v", err)
+			}
+
+			resyncPeriod := 12 * time.Hour
+			informers := informers.NewSharedInformerFactory(client, resyncPeriod)
+
+			epsController := endpointslice.NewController(
+				informers.Core().V1().Pods(),
+				informers.Core().V1().Services(),
+				informers.Core().V1().Nodes(),
+				informers.Discovery().V1beta1().EndpointSlices(),
+				int32(100),
+				client,
+				1*time.Second)
+
+			// Start informer and controllers
+			stopCh := make(chan struct{})
+			defer close(stopCh)
+			informers.Start(stopCh)
+			go epsController.Run(5, stopCh)
+
+			// Create namespace
+			ns := framework.CreateTestingNamespace("test-endpoints-terminating", server, t)
+			defer framework.DeleteTestingNamespace(ns, server, t)
+
+			node := &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "fake-node",
+				},
+			}
+
+			_, err = client.CoreV1().Nodes().Create(context.TODO(), node, metav1.CreateOptions{})
+			if err != nil {
+				t.Fatalf("Failed to create test node: %v", err)
+			}
+
+			svc := &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-service",
+					Namespace: ns.Name,
+					Labels: map[string]string{
+						"foo": "bar",
+					},
+				},
+				Spec: corev1.ServiceSpec{
+					Selector: map[string]string{
+						"foo": "bar",
+					},
+					Ports: []corev1.ServicePort{
+						{Name: "port-80", Port: 80, Protocol: "TCP", TargetPort: intstr.FromInt(80)},
+						{Name: "port-443", Port: 443, Protocol: "TCP", TargetPort: intstr.FromInt(443)},
+					},
+				},
+			}
+
+			_, err = client.CoreV1().Services(ns.Name).Create(context.TODO(), svc, metav1.CreateOptions{})
+			if err != nil {
+				t.Fatalf("Failed to create test Service: %v", err)
+			}
+
+			pod, err := client.CoreV1().Pods(ns.Name).Create(context.TODO(), testcase.pod, metav1.CreateOptions{})
+			if err != nil {
+				t.Fatalf("Failed to create test ready pod: %v", err)
+			}
+
+			pod.Status = testcase.pod.Status
+			_, err = client.CoreV1().Pods(ns.Name).UpdateStatus(context.TODO(), pod, metav1.UpdateOptions{})
+			if err != nil {
+				t.Fatalf("Failed to update status for test ready pod: %v", err)
+			}
+
+			// first check that endpoints are included, test should always have 1 initial endpoint
+			err = wait.PollImmediate(1*time.Second, wait.ForeverTestTimeout, func() (bool, error) {
+				esList, err := client.DiscoveryV1beta1().EndpointSlices(ns.Name).List(context.TODO(), metav1.ListOptions{
+					LabelSelector: discovery.LabelServiceName + "=" + svc.Name,
+				})
+
+				if err != nil {
+					return false, err
+				}
+
+				if len(esList.Items) == 0 {
+					return false, nil
+				}
+
+				numEndpoints := 0
+				for _, slice := range esList.Items {
+					numEndpoints += len(slice.Endpoints)
+				}
+
+				if numEndpoints > 0 {
+					return true, nil
+				}
+
+				return false, nil
+			})
+			if err != nil {
+				t.Errorf("Error waiting for endpoint slices: %v", err)
+			}
+
+			// Delete endpoint and check endpoints slice conditions
+			err = client.CoreV1().Pods(ns.Name).Delete(context.TODO(), pod.Name, metav1.DeleteOptions{})
+			if err != nil {
+				t.Fatalf("Failed to delete pod in terminating state: %v", err)
+			}
+
+			var endpoints []discovery.Endpoint
+			err = wait.PollImmediate(1*time.Second, wait.ForeverTestTimeout, func() (bool, error) {
+				esList, err := client.DiscoveryV1beta1().EndpointSlices(ns.Name).List(context.TODO(), metav1.ListOptions{
+					LabelSelector: discovery.LabelServiceName + "=" + svc.Name,
+				})
+
+				if err != nil {
+					return false, err
+				}
+
+				if len(esList.Items) == 0 {
+					return false, nil
+				}
+
+				endpoints = esList.Items[0].Endpoints
+				if len(endpoints) == 0 && len(testcase.endpoints) == 0 {
+					return true, nil
+				}
+
+				if len(endpoints) != len(testcase.endpoints) {
+					return false, nil
+				}
+
+				if !reflect.DeepEqual(endpoints[0].Addresses, testcase.endpoints[0].Addresses) {
+					return false, nil
+				}
+
+				if !reflect.DeepEqual(endpoints[0].Conditions, testcase.endpoints[0].Conditions) {
+					return false, nil
+				}
+
+				return true, nil
+			})
+			if err != nil {
+				t.Logf("actual endpoints: %v", endpoints)
+				t.Logf("expected endpoints: %v", testcase.endpoints)
+				t.Errorf("unexpected endpoints: %v", err)
+			}
+		})
+	}
+}

--- a/test/integration/endpointslice/endpointslice_terminating_test.go
+++ b/test/integration/endpointslice/endpointslice_terminating_test.go
@@ -43,150 +43,69 @@ import (
 // terminating endpoints are included but with the correct conditions set for ready, serving and terminating.
 func TestEndpointSliceTerminating(t *testing.T) {
 	testcases := []struct {
-		name            string
-		pod             *corev1.Pod
-		endpoints       []discovery.Endpoint
-		terminatingGate bool
+		name              string
+		podStatus         corev1.PodStatus
+		expectedEndpoints []discovery.Endpoint
+		terminatingGate   bool
 	}{
 		{
 			name: "ready terminating pods not included, terminating gate off",
-			pod: &corev1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "test-pod",
-					Labels: map[string]string{
-						"foo": "bar",
+			podStatus: corev1.PodStatus{
+				Phase: corev1.PodRunning,
+				Conditions: []corev1.PodCondition{
+					{
+						Type:   corev1.PodReady,
+						Status: corev1.ConditionTrue,
 					},
 				},
-				Spec: corev1.PodSpec{
-					NodeName: "fake-node",
-					Containers: []corev1.Container{
-						{
-							Name:  "fakename",
-							Image: "fakeimage",
-							Ports: []corev1.ContainerPort{
-								{
-									Name:          "port-80",
-									ContainerPort: 80,
-								},
-								{
-									Name:          "port-443",
-									ContainerPort: 443,
-								},
-							},
-						},
-					},
-				},
-				Status: corev1.PodStatus{
-					Phase: corev1.PodRunning,
-					Conditions: []corev1.PodCondition{
-						{
-							Type:   corev1.PodReady,
-							Status: corev1.ConditionTrue,
-						},
-					},
-					PodIP: "10.0.0.1",
-					PodIPs: []corev1.PodIP{
-						{
-							IP: "10.0.0.1",
-						},
+				PodIP: "10.0.0.1",
+				PodIPs: []corev1.PodIP{
+					{
+						IP: "10.0.0.1",
 					},
 				},
 			},
-			endpoints:       []discovery.Endpoint{},
-			terminatingGate: false,
+			expectedEndpoints: []discovery.Endpoint{},
+			terminatingGate:   false,
 		},
 		{
 			name: "not ready terminating pods not included, terminating gate off",
-			pod: &corev1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "test-pod",
-					Labels: map[string]string{
-						"foo": "bar",
+			podStatus: corev1.PodStatus{
+				Phase: corev1.PodRunning,
+				Conditions: []corev1.PodCondition{
+					{
+						Type:   corev1.PodReady,
+						Status: corev1.ConditionFalse,
 					},
 				},
-				Spec: corev1.PodSpec{
-					NodeName: "fake-node",
-					Containers: []corev1.Container{
-						{
-							Name:  "fakename",
-							Image: "fakeimage",
-							Ports: []corev1.ContainerPort{
-								{
-									Name:          "port-80",
-									ContainerPort: 80,
-								},
-								{
-									Name:          "port-443",
-									ContainerPort: 443,
-								},
-							},
-						},
-					},
-				},
-				Status: corev1.PodStatus{
-					Phase: corev1.PodRunning,
-					Conditions: []corev1.PodCondition{
-						{
-							Type:   corev1.PodReady,
-							Status: corev1.ConditionFalse,
-						},
-					},
-					PodIP: "10.0.0.1",
-					PodIPs: []corev1.PodIP{
-						{
-							IP: "10.0.0.1",
-						},
+				PodIP: "10.0.0.1",
+				PodIPs: []corev1.PodIP{
+					{
+						IP: "10.0.0.1",
 					},
 				},
 			},
-			endpoints:       []discovery.Endpoint{},
-			terminatingGate: false,
+			expectedEndpoints: []discovery.Endpoint{},
+			terminatingGate:   false,
 		},
 		{
 			name: "ready terminating pods included, terminating gate on",
-			pod: &corev1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "test-pod",
-					Labels: map[string]string{
-						"foo": "bar",
+			podStatus: corev1.PodStatus{
+				Phase: corev1.PodRunning,
+				Conditions: []corev1.PodCondition{
+					{
+						Type:   corev1.PodReady,
+						Status: corev1.ConditionTrue,
 					},
 				},
-				Spec: corev1.PodSpec{
-					NodeName: "fake-node",
-					Containers: []corev1.Container{
-						{
-							Name:  "fakename",
-							Image: "fakeimage",
-							Ports: []corev1.ContainerPort{
-								{
-									Name:          "port-80",
-									ContainerPort: 80,
-								},
-								{
-									Name:          "port-443",
-									ContainerPort: 443,
-								},
-							},
-						},
-					},
-				},
-				Status: corev1.PodStatus{
-					Phase: corev1.PodRunning,
-					Conditions: []corev1.PodCondition{
-						{
-							Type:   corev1.PodReady,
-							Status: corev1.ConditionTrue,
-						},
-					},
-					PodIP: "10.0.0.1",
-					PodIPs: []corev1.PodIP{
-						{
-							IP: "10.0.0.1",
-						},
+				PodIP: "10.0.0.1",
+				PodIPs: []corev1.PodIP{
+					{
+						IP: "10.0.0.1",
 					},
 				},
 			},
-			endpoints: []discovery.Endpoint{
+			expectedEndpoints: []discovery.Endpoint{
 				{
 					Addresses: []string{"10.0.0.1"},
 					Conditions: discovery.EndpointConditions{
@@ -200,49 +119,22 @@ func TestEndpointSliceTerminating(t *testing.T) {
 		},
 		{
 			name: "not ready terminating pods included, terminating gate on",
-			pod: &corev1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "test-pod",
-					Labels: map[string]string{
-						"foo": "bar",
+			podStatus: corev1.PodStatus{
+				Phase: corev1.PodRunning,
+				Conditions: []corev1.PodCondition{
+					{
+						Type:   corev1.PodReady,
+						Status: corev1.ConditionFalse,
 					},
 				},
-				Spec: corev1.PodSpec{
-					NodeName: "fake-node",
-					Containers: []corev1.Container{
-						{
-							Name:  "fakename",
-							Image: "fakeimage",
-							Ports: []corev1.ContainerPort{
-								{
-									Name:          "port-80",
-									ContainerPort: 80,
-								},
-								{
-									Name:          "port-443",
-									ContainerPort: 443,
-								},
-							},
-						},
-					},
-				},
-				Status: corev1.PodStatus{
-					Phase: corev1.PodRunning,
-					Conditions: []corev1.PodCondition{
-						{
-							Type:   corev1.PodReady,
-							Status: corev1.ConditionFalse,
-						},
-					},
-					PodIP: "10.0.0.1",
-					PodIPs: []corev1.PodIP{
-						{
-							IP: "10.0.0.1",
-						},
+				PodIP: "10.0.0.1",
+				PodIPs: []corev1.PodIP{
+					{
+						IP: "10.0.0.1",
 					},
 				},
 			},
-			endpoints: []discovery.Endpoint{
+			expectedEndpoints: []discovery.Endpoint{
 				{
 					Addresses: []string{"10.0.0.1"},
 					Conditions: discovery.EndpointConditions{
@@ -286,7 +178,7 @@ func TestEndpointSliceTerminating(t *testing.T) {
 			stopCh := make(chan struct{})
 			defer close(stopCh)
 			informers.Start(stopCh)
-			go epsController.Run(5, stopCh)
+			go epsController.Run(1, stopCh)
 
 			// Create namespace
 			ns := framework.CreateTestingNamespace("test-endpoints-terminating", server, t)
@@ -316,7 +208,6 @@ func TestEndpointSliceTerminating(t *testing.T) {
 						"foo": "bar",
 					},
 					Ports: []corev1.ServicePort{
-						{Name: "port-80", Port: 80, Protocol: "TCP", TargetPort: intstr.FromInt(80)},
 						{Name: "port-443", Port: 443, Protocol: "TCP", TargetPort: intstr.FromInt(443)},
 					},
 				},
@@ -327,12 +218,36 @@ func TestEndpointSliceTerminating(t *testing.T) {
 				t.Fatalf("Failed to create test Service: %v", err)
 			}
 
-			pod, err := client.CoreV1().Pods(ns.Name).Create(context.TODO(), testcase.pod, metav1.CreateOptions{})
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-pod",
+					Labels: map[string]string{
+						"foo": "bar",
+					},
+				},
+				Spec: corev1.PodSpec{
+					NodeName: "fake-node",
+					Containers: []corev1.Container{
+						{
+							Name:  "fakename",
+							Image: "fakeimage",
+							Ports: []corev1.ContainerPort{
+								{
+									Name:          "port-443",
+									ContainerPort: 443,
+								},
+							},
+						},
+					},
+				},
+			}
+
+			pod, err = client.CoreV1().Pods(ns.Name).Create(context.TODO(), pod, metav1.CreateOptions{})
 			if err != nil {
 				t.Fatalf("Failed to create test ready pod: %v", err)
 			}
 
-			pod.Status = testcase.pod.Status
+			pod.Status = testcase.podStatus
 			_, err = client.CoreV1().Pods(ns.Name).UpdateStatus(context.TODO(), pod, metav1.UpdateOptions{})
 			if err != nil {
 				t.Fatalf("Failed to update status for test ready pod: %v", err)
@@ -367,14 +282,16 @@ func TestEndpointSliceTerminating(t *testing.T) {
 				t.Errorf("Error waiting for endpoint slices: %v", err)
 			}
 
-			// Delete endpoint and check endpoints slice conditions
+			// Delete pod and check endpoints slice conditions
 			err = client.CoreV1().Pods(ns.Name).Delete(context.TODO(), pod.Name, metav1.DeleteOptions{})
 			if err != nil {
 				t.Fatalf("Failed to delete pod in terminating state: %v", err)
 			}
 
+			// Validate that terminating the endpoint will result in the expected endpoints in EndpointSlice.
+			// Use a stricter timeout value here since we should try to catch regressions in the time it takes to remove terminated endpoints.
 			var endpoints []discovery.Endpoint
-			err = wait.PollImmediate(1*time.Second, wait.ForeverTestTimeout, func() (bool, error) {
+			err = wait.PollImmediate(1*time.Second, 10*time.Second, func() (bool, error) {
 				esList, err := client.DiscoveryV1beta1().EndpointSlices(ns.Name).List(context.TODO(), metav1.ListOptions{
 					LabelSelector: discovery.LabelServiceName + "=" + svc.Name,
 				})
@@ -388,19 +305,19 @@ func TestEndpointSliceTerminating(t *testing.T) {
 				}
 
 				endpoints = esList.Items[0].Endpoints
-				if len(endpoints) == 0 && len(testcase.endpoints) == 0 {
+				if len(endpoints) == 0 && len(testcase.expectedEndpoints) == 0 {
 					return true, nil
 				}
 
-				if len(endpoints) != len(testcase.endpoints) {
+				if len(endpoints) != len(testcase.expectedEndpoints) {
 					return false, nil
 				}
 
-				if !reflect.DeepEqual(endpoints[0].Addresses, testcase.endpoints[0].Addresses) {
+				if !reflect.DeepEqual(endpoints[0].Addresses, testcase.expectedEndpoints[0].Addresses) {
 					return false, nil
 				}
 
-				if !reflect.DeepEqual(endpoints[0].Conditions, testcase.endpoints[0].Conditions) {
+				if !reflect.DeepEqual(endpoints[0].Conditions, testcase.expectedEndpoints[0].Conditions) {
 					return false, nil
 				}
 
@@ -408,7 +325,7 @@ func TestEndpointSliceTerminating(t *testing.T) {
 			})
 			if err != nil {
 				t.Logf("actual endpoints: %v", endpoints)
-				t.Logf("expected endpoints: %v", testcase.endpoints)
+				t.Logf("expected endpoints: %v", testcase.expectedEndpoints)
 				t.Errorf("unexpected endpoints: %v", err)
 			}
 		})


### PR DESCRIPTION
Signed-off-by: Andrew Sy Kim <kim.andrewsy@gmail.com>

**What type of PR is this?**
/kind cleanup
(wishing there was a `testing` kind label)

**What this PR does / why we need it**:
In https://github.com/kubernetes/kubernetes/pull/92968 we added alpha support for EndpointSlice to track terminating endpoints. This feature is off by default going into v1.20. This PR adds e2es to test that the current behaviour to _exclude_ terminating endpoints is consistent and that introduction of the alpha feature is not breaking current behavior until we turn it on by default in the next release.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
