### PR TITLE
test/integration: add integration tests for service.spec.allocateLoadBalancerNodePorts

### DIFF
--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -75,6 +75,7 @@ filegroup(
         "//test/integration/scheduler:all-srcs",
         "//test/integration/scheduler_perf:all-srcs",
         "//test/integration/secrets:all-srcs",
+        "//test/integration/service:all-srcs",
         "//test/integration/serviceaccount:all-srcs",
         "//test/integration/serving:all-srcs",
         "//test/integration/statefulset:all-srcs",

--- a/test/integration/service/BUILD
+++ b/test/integration/service/BUILD
@@ -1,0 +1,35 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_test")
+
+go_test(
+    name = "go_default_test",
+    srcs = [
+        "loadbalancer_test.go",
+        "main_test.go",
+    ],
+    tags = ["integration"],
+    deps = [
+        "//pkg/features:go_default_library",
+        "//staging/src/k8s.io/api/core/v1:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",
+        "//staging/src/k8s.io/client-go/kubernetes:go_default_library",
+        "//staging/src/k8s.io/client-go/rest:go_default_library",
+        "//staging/src/k8s.io/component-base/featuregate/testing:go_default_library",
+        "//test/integration/framework:go_default_library",
+        "//vendor/k8s.io/utils/pointer:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/test/integration/service/loadbalancer_test.go
+++ b/test/integration/service/loadbalancer_test.go
@@ -1,0 +1,151 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package service
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	clientset "k8s.io/client-go/kubernetes"
+	restclient "k8s.io/client-go/rest"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
+	"k8s.io/kubernetes/pkg/features"
+	"k8s.io/kubernetes/test/integration/framework"
+	utilpointer "k8s.io/utils/pointer"
+)
+
+// Test_ServiceLoadBalancerAllocateNodePorts tests that a Service with spec.allocateLoadBalancerNodePorts=false
+// does not allocate node ports for the Service.
+func Test_ServiceLoadBalancerDisableAllocateNodePorts(t *testing.T) {
+	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.ServiceLBNodePortControl, true)()
+
+	masterConfig := framework.NewIntegrationTestMasterConfig()
+	_, server, closeFn := framework.RunAMaster(masterConfig)
+	defer closeFn()
+
+	config := restclient.Config{Host: server.URL}
+	client, err := clientset.NewForConfig(&config)
+	if err != nil {
+		t.Fatalf("Error creating clientset: %v", err)
+	}
+
+	ns := framework.CreateTestingNamespace("test-service-allocate-node-ports", server, t)
+	defer framework.DeleteTestingNamespace(ns, server, t)
+
+	service := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-123",
+		},
+		Spec: corev1.ServiceSpec{
+			Type:                          corev1.ServiceTypeLoadBalancer,
+			AllocateLoadBalancerNodePorts: utilpointer.BoolPtr(false),
+			Ports: []corev1.ServicePort{{
+				Port: int32(80),
+			}},
+			Selector: map[string]string{
+				"foo": "bar",
+			},
+		},
+	}
+
+	service, err = client.CoreV1().Services(ns.Name).Create(context.TODO(), service, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("Error creating test service: %v", err)
+	}
+
+	foundNodePorts := false
+	for _, port := range service.Spec.Ports {
+		if port.NodePort > 0 {
+			foundNodePorts = true
+		}
+	}
+
+	if foundNodePorts {
+		t.Error("found node ports when none was expected")
+	}
+}
+
+// Test_ServiceLoadBalancerSwitchToDeallocatedNodePorts test that switching a Service
+// to spec.allocateLoadBalancerNodePorts=false, does not de-allocate existing node ports.
+func Test_ServiceLoadBalancerEnableThenDisableAllocatedNodePorts(t *testing.T) {
+	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.ServiceLBNodePortControl, true)()
+
+	masterConfig := framework.NewIntegrationTestMasterConfig()
+	_, server, closeFn := framework.RunAMaster(masterConfig)
+	defer closeFn()
+
+	config := restclient.Config{Host: server.URL}
+	client, err := clientset.NewForConfig(&config)
+	if err != nil {
+		t.Fatalf("Error creating clientset: %v", err)
+	}
+
+	ns := framework.CreateTestingNamespace("test-service-deallocate-node-ports", server, t)
+	defer framework.DeleteTestingNamespace(ns, server, t)
+
+	service := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-123",
+		},
+		Spec: corev1.ServiceSpec{
+			Type:                          corev1.ServiceTypeLoadBalancer,
+			AllocateLoadBalancerNodePorts: utilpointer.BoolPtr(true),
+			Ports: []corev1.ServicePort{{
+				Port: int32(80),
+			}},
+			Selector: map[string]string{
+				"foo": "bar",
+			},
+		},
+	}
+
+	service, err = client.CoreV1().Services(ns.Name).Create(context.TODO(), service, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("Error creating test service: %v", err)
+	}
+
+	foundNodePorts := false
+	for _, port := range service.Spec.Ports {
+		if port.NodePort > 0 {
+			foundNodePorts = true
+		}
+	}
+
+	if !foundNodePorts {
+		t.Error("expected node ports but found none")
+	}
+
+	service.Spec.AllocateLoadBalancerNodePorts = utilpointer.BoolPtr(false)
+	service, err = client.CoreV1().Services(ns.Name).Update(context.TODO(), service, metav1.UpdateOptions{})
+	if err != nil {
+		t.Fatalf("Error updating test service: %v", err)
+	}
+
+	foundNodePorts = false
+	for _, port := range service.Spec.Ports {
+		if port.NodePort > 0 {
+			foundNodePorts = true
+		}
+	}
+
+	if !foundNodePorts {
+		t.Error("node ports were unexpectedly deallocated")
+	}
+}

--- a/test/integration/service/loadbalancer_test.go
+++ b/test/integration/service/loadbalancer_test.go
@@ -70,14 +70,7 @@ func Test_ServiceLoadBalancerDisableAllocateNodePorts(t *testing.T) {
 		t.Fatalf("Error creating test service: %v", err)
 	}
 
-	foundNodePorts := false
-	for _, port := range service.Spec.Ports {
-		if port.NodePort > 0 {
-			foundNodePorts = true
-		}
-	}
-
-	if foundNodePorts {
+	if serviceHasNodePorts(service) {
 		t.Error("found node ports when none was expected")
 	}
 }
@@ -121,14 +114,7 @@ func Test_ServiceLoadBalancerEnableThenDisableAllocatedNodePorts(t *testing.T) {
 		t.Fatalf("Error creating test service: %v", err)
 	}
 
-	foundNodePorts := false
-	for _, port := range service.Spec.Ports {
-		if port.NodePort > 0 {
-			foundNodePorts = true
-		}
-	}
-
-	if !foundNodePorts {
+	if !serviceHasNodePorts(service) {
 		t.Error("expected node ports but found none")
 	}
 
@@ -138,14 +124,17 @@ func Test_ServiceLoadBalancerEnableThenDisableAllocatedNodePorts(t *testing.T) {
 		t.Fatalf("Error updating test service: %v", err)
 	}
 
-	foundNodePorts = false
-	for _, port := range service.Spec.Ports {
+	if !serviceHasNodePorts(service) {
+		t.Error("node ports were unexpectedly deallocated")
+	}
+}
+
+func serviceHasNodePorts(svc *corev1.Service) bool {
+	for _, port := range svc.Spec.Ports {
 		if port.NodePort > 0 {
-			foundNodePorts = true
+			return true
 		}
 	}
 
-	if !foundNodePorts {
-		t.Error("node ports were unexpectedly deallocated")
-	}
+	return false
 }

--- a/test/integration/service/main_test.go
+++ b/test/integration/service/main_test.go
@@ -1,0 +1,27 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package service
+
+import (
+	"testing"
+
+	"k8s.io/kubernetes/test/integration/framework"
+)
+
+func TestMain(m *testing.M) {
+	framework.EtcdMain(m.Run)
+}


### PR DESCRIPTION
Signed-off-by: Andrew Sy Kim <kim.andrewsy@gmail.com>

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
In https://github.com/kubernetes/kubernetes/pull/92744 we added a new field in Service that allows users to opt-out of node port allocation for Service Type=LB. This PR adds integration tests for this behavior.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
