### PR TITLE
Add a deprecation note to k/k/cluster/log-dump directory

### DIFF
--- a/cluster/log-dump/README.md
+++ b/cluster/log-dump/README.md
@@ -1,0 +1,19 @@
+## This directory is deprecated!
+
+Log dumping utility was ported from kubernetes/kubernetes repository to
+[kubernetes/test-infra](https://github.com/kubernetes/test-infra/tree/master/logexporter/cluster).
+If you require changes to this script, please consider migrating your jobs to use the new
+log dumping mechanism first.
+
+Currently, `log-dump.sh` file is added to every newly released `kubekins-e2e` image.
+In order to leverage that script, add `USE_KUBEKINS_LOG_DUMPING` environment variable
+to your test job and set its value to `true`.
+
+## Migration steps
+
+For the time being, only GCE and GKE providers are supported by the log-dump mechanism.
+To make the mechanism support your Kubernetes provider in tests using `kubekins-e2e`, modify
+the `logDumpPath` function in
+[kubetest](https://github.com/kubernetes/test-infra/tree/master/kubetest) to handle your provider and
+adapt [log-dump.sh](https://github.com/kubernetes/test-infra/blob/master/logexporter/cluster/log-dump.sh)
+in accord to your needs.

--- a/cluster/log-dump/log-dump.sh
+++ b/cluster/log-dump/log-dump.sh
@@ -71,6 +71,15 @@ logexporter_failed=0
 # process will exit with a non-zero exit code).
 readonly log_dump_expected_success_percentage="${LOG_DUMP_EXPECTED_SUCCESS_PERCENTAGE:-0}"
 
+function print-deprecation-note() {
+  local -r dashline=$(printf -- '-%.0s' {1..100})
+  echo "${dashline}"
+  echo "k/k version of the log-dump.sh script is deprecated!"
+  echo "Please migrate your test job to use test-infra's repo version of log-dump.sh!"
+  echo "Migration steps can be found in the readme file."
+  echo "${dashline}"
+}
+
 # TODO: Get rid of all the sourcing of bash dependencies eventually.
 function setup() {
   KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/../..
@@ -670,6 +679,7 @@ function detect_node_failures() {
 }
 
 function main() {
+  print-deprecation-note
   setup
   kube::util::ensure-temp-dir
   # Copy master logs to artifacts dir locally (through SSH).


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
/kind documentation

**What this PR does / why we need it**:
`log-dump.sh` is dead, long live the `log-dump.sh`.

The note is to inform the customers of this directory that it's deprecated and to encourage them to adjust their jobs to use the test-infra's version of the log dumping script.

**Which issue(s) this PR fixes**:
No issue is opened for that.

**Special notes for your reviewer**:
/sig scalability
/assign @jkaniuk 

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```