### PR TITLE
Check Kubelet is running with correct Windows Permissions

### DIFF
--- a/cmd/kubelet/app/server_others.go
+++ b/cmd/kubelet/app/server_others.go
@@ -1,0 +1,33 @@
+// +build !windows
+
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package app
+
+import (
+	"fmt"
+	"os"
+)
+
+func checkPermissions() error {
+	if uid := os.Getuid(); uid != 0 {
+		return fmt.Errorf("kubelet needs to run as uid `0`. It is being run as %d", uid)
+	}
+	// TODO: Check if kubelet is running in the `initial` user namespace.
+	// http://man7.org/linux/man-pages/man7/user_namespaces.7.html
+	return nil
+}

--- a/cmd/kubelet/app/server_windows.go
+++ b/cmd/kubelet/app/server_windows.go
@@ -1,0 +1,85 @@
+// +build windows
+
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package app
+
+import (
+	"fmt"
+	"os/user"
+
+	"golang.org/x/sys/windows"
+)
+
+func isAdmin() (bool, error) {
+	// Get current user
+	u, err := user.Current()
+	if err != nil {
+		return false, fmt.Errorf("Error retrieving current user: %s", err)
+	}
+	// Get IDs of group user is a member of
+	ids, err := u.GroupIds()
+	if err != nil {
+		return false, fmt.Errorf("Error retrieving group ids: %s", err)
+	}
+
+	// Check for existence of BUILTIN\ADMINISTRATORS group id
+	for i := range ids {
+		// BUILTIN\ADMINISTRATORS
+		if "S-1-5-32-544" == ids[i] {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func checkPermissions() error {
+	//https://github.com/golang/go/issues/28804#issuecomment-505326268
+	var sid *windows.SID
+	var userIsAdmin bool
+
+	// https://docs.microsoft.com/en-us/windows/desktop/api/securitybaseapi/nf-securitybaseapi-checktokenmembership
+	err := windows.AllocateAndInitializeSid(
+		&windows.SECURITY_NT_AUTHORITY,
+		2,
+		windows.SECURITY_BUILTIN_DOMAIN_RID,
+		windows.DOMAIN_ALIAS_RID_ADMINS,
+		0, 0, 0, 0, 0, 0,
+		&sid)
+	if err != nil {
+		return fmt.Errorf("Error while checking for elevated permissions: %s", err)
+	}
+
+	//We must free the sid to prevent security token leaks
+	defer windows.FreeSid(sid)
+	token := windows.Token(0)
+
+	userIsAdmin, err = isAdmin()
+	if err != nil {
+		return fmt.Errorf("Error while checking admin group membership: %s", err)
+	}
+
+	member, err := token.IsMember(sid)
+	if err != nil {
+		return fmt.Errorf("Error while checking for elevated permissions: %s", err)
+	}
+	if !member {
+		return fmt.Errorf("kubelet needs to run with administrator permissions. Run as admin is: %t, User in admin group: %t", member, userIsAdmin)
+	}
+
+	return nil
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This PR adds a Windows-specific permissions check on the kubelet startup. Currently, the log file outputs an error on windows stating that the UID is -1 as UID does not exist in a windows context.  
**Which issue(s) this PR fixes**:

Fixes #96512

**Special notes for your reviewer**:
As part of this PR I have moved the existing checkPermissions function to server_others.go to replicate similar behaviour in kube-proxy as the checkPermissions is not linux specific it should be build whenever not running on windows.  

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
NONE


**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
The `token.IsMember(sid)` returns TRUE if the caller's process is a member of the Administrators local group. Caller is NOT
expected to be impersonating anyone and is expected to be able to open its own process and process token. In order for the process to "Run as administrator" the excuting user must be in the BUILTIN\Administrators Group so I have added a check for that too.  

More information about this can be found in in the [c++ implementation routine](https://docs.microsoft.com/en-us/windows/desktop/api/securitybaseapi/nf-securitybaseapi-checktokenmembership) and this [go issue](https://github.com/golang/go/issues/28804#issuecomment-505326268)

**Release Notes**
```release-note
Kubelet.exe on Windows now checks that the process running as administrator and the executing user account is listed in the built-in administrators group.  This is the equivalent to checking the process is running as uid 0.
```
