### PR TITLE
convert the runtimeclass API tests to conformance

### DIFF
--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -1957,6 +1957,16 @@
     The PodTemplate must be deleted.
   release: v1.19
   file: test/e2e/common/podtemplates.go
+- testname: RuntimeClass API
+  codename: '[sig-node] RuntimeClass  should support RuntimeClasses API operations
+    [Conformance]'
+  description: ' The node.k8s.io API group MUST exist in the /apis discovery document.
+    The node.k8s.io/v1 API group/version MUST exist in the /apis/mode.k8s.io discovery
+    document. The runtimeclasses resource MUST exist in the /apis/node.k8s.io/v1 discovery
+    document. The runtimeclasses resource must support create, get, list, watch, update,
+    patch, delete, and deletecollection.'
+  release: v1.20
+  file: test/e2e/common/runtimeclass.go
 - testname: LimitRange, resources
   codename: '[sig-scheduling] LimitRange should create a LimitRange with defaults
     and ensure pod has those defaults applied. [Conformance]'

--- a/test/e2e/common/runtimeclass.go
+++ b/test/e2e/common/runtimeclass.go
@@ -97,7 +97,7 @@ var _ = ginkgo.Describe("[sig-node] RuntimeClass", func() {
 		The runtimeclasses resource MUST exist in the /apis/node.k8s.io/v1 discovery document.
 		The runtimeclasses resource must support create, get, list, watch, update, patch, delete, and deletecollection.
 	*/
-	ginkgo.It(" [NodeConformance] should support RuntimeClasses API operations", func() {
+	framework.ConformanceIt(" should support RuntimeClasses API operations", func() {
 		// Setup
 		rcVersion := "v1"
 		rcClient := f.ClientSet.NodeV1().RuntimeClasses()


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup
/sig node

**What this PR does / why we need it**:

Promoting the RuntimeClasses API v1 that was just GA'd to conformance

**Which issue(s) this PR fixes**:
Fixes #96524

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

Please use the following format for linking documentation:

- KEP: kubernetes/enhancements#585
