### PR TITLE
fix staticcheck: vendor/k8s.io/apiserver/pkg/registry/{generic/rest,rest/resttest}

### DIFF
--- a/hack/.staticcheck_failures
+++ b/hack/.staticcheck_failures
@@ -25,8 +25,6 @@ vendor/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager
 vendor/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters
 vendor/k8s.io/apiserver/pkg/endpoints/metrics
 vendor/k8s.io/apiserver/pkg/registry/generic/registry
-vendor/k8s.io/apiserver/pkg/registry/generic/rest
-vendor/k8s.io/apiserver/pkg/registry/rest/resttest
 vendor/k8s.io/apiserver/pkg/server/dynamiccertificates
 vendor/k8s.io/apiserver/pkg/server/filters
 vendor/k8s.io/apiserver/pkg/server/httplog

--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/rest/streamer_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/rest/streamer_test.go
@@ -75,7 +75,6 @@ func TestInputStreamNullLocation(t *testing.T) {
 
 type testTransport struct {
 	body string
-	err  error
 }
 
 func (tt *testTransport) RoundTrip(req *http.Request) (*http.Response, error) {

--- a/staging/src/k8s.io/apiserver/pkg/registry/rest/resttest/resttest.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/rest/resttest/resttest.go
@@ -206,6 +206,8 @@ func (t *Tester) TestDelete(valid runtime.Object, createFn CreateFunc, getFn Get
 	t.testDeleteNoGraceful(valid.DeepCopyObject(), createFn, getFn, isNotFoundFn, false)
 	t.testDeleteWithUID(valid.DeepCopyObject(), createFn, getFn, isNotFoundFn, dryRunOpts)
 	t.testDeleteWithUID(valid.DeepCopyObject(), createFn, getFn, isNotFoundFn, opts)
+	t.testDeleteWithResourceVersion(valid.DeepCopyObject(), createFn, getFn, isNotFoundFn, dryRunOpts)
+	t.testDeleteWithResourceVersion(valid.DeepCopyObject(), createFn, getFn, isNotFoundFn, opts)
 }
 
 // Test gracefully deleting an object.
@@ -918,11 +920,17 @@ func (t *Tester) testDeleteWithResourceVersion(obj runtime.Object, createFn Crea
 	foo := obj.DeepCopyObject()
 	t.setObjectMeta(foo, t.namer(1))
 	objectMeta := t.getObjectMetaOrFail(foo)
-	objectMeta.SetResourceVersion("RV0000")
 	if err := createFn(ctx, foo); err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
-	opts.Preconditions = metav1.NewRVDeletionPrecondition("RV1111").Preconditions
+
+	storedFoo, err := getFn(ctx, foo)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	storedObjectMeta := t.getObjectMetaOrFail(storedFoo)
+
+	opts.Preconditions = metav1.NewRVDeletionPrecondition("1111").Preconditions
 	_, wasDeleted, err := t.storage.(rest.GracefulDeleter).Delete(ctx, objectMeta.GetName(), rest.ValidateAllObjectFunc, &opts)
 	if err == nil || !errors.IsConflict(err) {
 		t.Errorf("unexpected error: %v", err)
@@ -930,7 +938,7 @@ func (t *Tester) testDeleteWithResourceVersion(obj runtime.Object, createFn Crea
 	if wasDeleted {
 		t.Errorf("unexpected, object %s should not have been deleted immediately", objectMeta.GetName())
 	}
-	obj, _, err = t.storage.(rest.GracefulDeleter).Delete(ctx, objectMeta.GetName(), rest.ValidateAllObjectFunc, metav1.NewRVDeletionPrecondition("RV0000"))
+	obj, _, err = t.storage.(rest.GracefulDeleter).Delete(ctx, objectMeta.GetName(), rest.ValidateAllObjectFunc, metav1.NewRVDeletionPrecondition(storedObjectMeta.GetResourceVersion()))
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Which issue(s) this PR fixes**:
Part of #92402

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
