### PR TITLE
service.spec.AllocateLoadBalancerNodePorts followup

### DIFF
--- a/pkg/registry/core/service/BUILD
+++ b/pkg/registry/core/service/BUILD
@@ -49,6 +49,7 @@ go_test(
         "//staging/src/k8s.io/apiserver/pkg/registry/rest:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",
         "//staging/src/k8s.io/component-base/featuregate/testing:go_default_library",
+        "//vendor/k8s.io/utils/pointer:go_default_library",
     ],
 )
 


### PR DESCRIPTION
**What type of PR is this?**

Follow-up items from PR https://github.com/kubernetes/kubernetes/pull/92744. (See https://github.com/kubernetes/kubernetes/pull/92744#pullrequestreview-530116285)


- [x] CreateStrategy shouldn't drop spec.allocateLoadBalancerNodePorts if an exisitng Service was using it
- [x] dropTypeDependentFields should check if spec.allocateLoadBalancerNodePorts is changing when the service type also changes
- [x] unit tests for dropTypeDependentFields when type changes from LoadBalancer to something else.

/kind feature

**What this PR does / why we need it**:

Complete #92744 with items that did not make it before the v1.20 code freeze.

**Which issue(s) this PR fixes**:

N/A

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

