### PR TITLE
Automated cherry pick of #88532: Drop alpha gate for network tier annotation

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/gce/gce_addresses.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/gce/gce_addresses.go
@@ -23,7 +23,6 @@ import (
 
 	"k8s.io/klog"
 
-	computealpha "google.golang.org/api/compute/v0.alpha"
 	computebeta "google.golang.org/api/compute/v0.beta"
 	compute "google.golang.org/api/compute/v1"
 
@@ -80,15 +79,6 @@ func (g *Cloud) ReserveRegionAddress(addr *compute.Address, region string) error
 	return mc.Observe(g.c.Addresses().Insert(ctx, meta.RegionalKey(addr.Name, region), addr))
 }
 
-// ReserveAlphaRegionAddress creates an Alpha, regional address.
-func (g *Cloud) ReserveAlphaRegionAddress(addr *computealpha.Address, region string) error {
-	ctx, cancel := cloud.ContextWithCallTimeout()
-	defer cancel()
-
-	mc := newAddressMetricContext("reserve", region)
-	return mc.Observe(g.c.AlphaAddresses().Insert(ctx, meta.RegionalKey(addr.Name, region), addr))
-}
-
 // ReserveBetaRegionAddress creates a beta region address
 func (g *Cloud) ReserveBetaRegionAddress(addr *computebeta.Address, region string) error {
 	ctx, cancel := cloud.ContextWithCallTimeout()
@@ -114,16 +104,6 @@ func (g *Cloud) GetRegionAddress(name, region string) (*compute.Address, error) 
 
 	mc := newAddressMetricContext("get", region)
 	v, err := g.c.Addresses().Get(ctx, meta.RegionalKey(name, region))
-	return v, mc.Observe(err)
-}
-
-// GetAlphaRegionAddress returns the Alpha, regional address by name.
-func (g *Cloud) GetAlphaRegionAddress(name, region string) (*computealpha.Address, error) {
-	ctx, cancel := cloud.ContextWithCallTimeout()
-	defer cancel()
-
-	mc := newAddressMetricContext("get", region)
-	v, err := g.c.AlphaAddresses().Get(ctx, meta.RegionalKey(name, region))
 	return v, mc.Observe(err)
 }
 
@@ -185,14 +165,12 @@ func (g *Cloud) GetBetaRegionAddressByIP(region, ipAddress string) (*computebeta
 	return nil, makeGoogleAPINotFoundError(fmt.Sprintf("Address with IP %q was not found in region %q", ipAddress, region))
 }
 
-// TODO(#51665): retire this function once Network Tiers becomes Beta in GCP.
 func (g *Cloud) getNetworkTierFromAddress(name, region string) (string, error) {
-	if !g.AlphaFeatureGate.Enabled(AlphaFeatureNetworkTiers) {
-		return cloud.NetworkTierDefault.ToGCEValue(), nil
-	}
-	addr, err := g.GetAlphaRegionAddress(name, region)
+
+	addr, err := g.GetRegionAddress(name, region)
 	if err != nil {
-		return handleAlphaNetworkTierGetError(err)
+		// Can't get the network tier, just return an error.
+		return "", err
 	}
 	return addr.NetworkTier, nil
 }

--- a/staging/src/k8s.io/legacy-cloud-providers/gce/gce_alpha.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/gce/gce_alpha.go
@@ -19,11 +19,6 @@ limitations under the License.
 package gce
 
 const (
-	// AlphaFeatureNetworkTiers allows Services backed by a GCP load balancer to choose
-	// what network tier to use. Currently supports "Standard" and "Premium" (default).
-	//
-	// alpha: v1.8 (for Services)
-	AlphaFeatureNetworkTiers = "NetworkTiers"
 	// AlphaFeatureILBSubsets allows InternalLoadBalancer services to include a subset
 	// of cluster nodes as backends instead of all nodes.
 	AlphaFeatureILBSubsets = "ILBSubsets"

--- a/staging/src/k8s.io/legacy-cloud-providers/gce/gce_forwardingrule.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/gce/gce_forwardingrule.go
@@ -182,14 +182,11 @@ func (g *Cloud) DeleteRegionForwardingRule(name, region string) error {
 	return mc.Observe(g.c.ForwardingRules().Delete(ctx, meta.RegionalKey(name, region)))
 }
 
-// TODO(#51665): retire this function once Network Tiers becomes Beta in GCP.
 func (g *Cloud) getNetworkTierFromForwardingRule(name, region string) (string, error) {
-	if !g.AlphaFeatureGate.Enabled(AlphaFeatureNetworkTiers) {
-		return cloud.NetworkTierDefault.ToGCEValue(), nil
-	}
-	fwdRule, err := g.GetAlphaRegionForwardingRule(name, region)
+	fwdRule, err := g.GetRegionForwardingRule(name, region)
 	if err != nil {
-		return handleAlphaNetworkTierGetError(err)
+		// Can't get the network tier, just return an error.
+		return "", err
 	}
 	return fwdRule.NetworkTier, nil
 }

--- a/staging/src/k8s.io/legacy-cloud-providers/gce/gce_interfaces.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/gce/gce_interfaces.go
@@ -19,7 +19,6 @@ limitations under the License.
 package gce
 
 import (
-	computealpha "google.golang.org/api/compute/v0.alpha"
 	computebeta "google.golang.org/api/compute/v0.beta"
 	compute "google.golang.org/api/compute/v1"
 )
@@ -34,16 +33,11 @@ type CloudAddressService interface {
 	DeleteRegionAddress(name, region string) error
 	// TODO: Mock Global endpoints
 
-	// Alpha API.
-	GetAlphaRegionAddress(name, region string) (*computealpha.Address, error)
-	ReserveAlphaRegionAddress(addr *computealpha.Address, region string) error
-
 	// Beta API
 	ReserveBetaRegionAddress(address *computebeta.Address, region string) error
 	GetBetaRegionAddress(name string, region string) (*computebeta.Address, error)
 	GetBetaRegionAddressByIP(region, ipAddress string) (*computebeta.Address, error)
 
-	// TODO(#51665): Remove this once the Network Tiers becomes Alpha in GCP.
 	getNetworkTierFromAddress(name, region string) (string, error)
 }
 
@@ -54,10 +48,6 @@ type CloudForwardingRuleService interface {
 	CreateRegionForwardingRule(rule *compute.ForwardingRule, region string) error
 	DeleteRegionForwardingRule(name, region string) error
 
-	// Alpha API.
-	GetAlphaRegionForwardingRule(name, region string) (*computealpha.ForwardingRule, error)
-	CreateAlphaRegionForwardingRule(rule *computealpha.ForwardingRule, region string) error
-
-	// Needed for the Alpha "Network Tiers" feature.
+	// Needed for the "Network Tiers" feature.
 	getNetworkTierFromForwardingRule(name, region string) (string, error)
 }

--- a/staging/src/k8s.io/legacy-cloud-providers/gce/gce_loadbalancer_external.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/gce/gce_loadbalancer_external.go
@@ -81,9 +81,7 @@ func (g *Cloud) ensureExternalLoadBalancer(clusterName string, clusterID string,
 		return nil, err
 	}
 	klog.V(4).Infof("ensureExternalLoadBalancer(%s): Desired network tier %q.", lbRefStr, netTier)
-	if g.AlphaFeatureGate.Enabled(AlphaFeatureNetworkTiers) {
-		g.deleteWrongNetworkTieredResources(loadBalancerName, lbRefStr, netTier)
-	}
+	g.deleteWrongNetworkTieredResources(loadBalancerName, lbRefStr, netTier)
 
 	// Check if the forwarding rule exists, and if so, what its IP is.
 	fwdRuleExists, fwdRuleNeedsUpdate, fwdRuleIP, err := g.forwardingRuleNeedsUpdate(loadBalancerName, g.region, requestedIP, ports)
@@ -1072,9 +1070,6 @@ func ensureStaticIP(s CloudAddressService, name, serviceName, region, existingIP
 }
 
 func (g *Cloud) getServiceNetworkTier(svc *v1.Service) (cloud.NetworkTier, error) {
-	if !g.AlphaFeatureGate.Enabled(AlphaFeatureNetworkTiers) {
-		return cloud.NetworkTierDefault, nil
-	}
 	tier, err := GetServiceNetworkTier(svc)
 	if err != nil {
 		// Returns an error if the annotation is invalid.

--- a/staging/src/k8s.io/legacy-cloud-providers/gce/gce_loadbalancer_external_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/gce/gce_loadbalancer_external_test.go
@@ -233,9 +233,6 @@ func TestDeleteAddressWithWrongTier(t *testing.T) {
 	s, err := fakeGCECloud(DefaultTestClusterValues())
 	require.NoError(t, err)
 
-	// Enable the cloud.NetworkTiers feature
-	s.AlphaFeatureGate.features[AlphaFeatureNetworkTiers] = true
-
 	for desc, tc := range map[string]struct {
 		addrName     string
 		netTier      cloud.NetworkTier
@@ -419,8 +416,6 @@ func TestLoadBalancerWrongTierResourceDeletion(t *testing.T) {
 	gce, err := fakeGCECloud(vals)
 	require.NoError(t, err)
 
-	// Enable the cloud.NetworkTiers feature
-	gce.AlphaFeatureGate.features[AlphaFeatureNetworkTiers] = true
 	svc := fakeLoadbalancerService("")
 	svc.Annotations = map[string]string{NetworkTierAnnotationKey: "Premium"}
 
@@ -478,8 +473,6 @@ func TestEnsureExternalLoadBalancerFailsIfInvalidNetworkTier(t *testing.T) {
 	nodes, err := createAndInsertNodes(gce, nodeNames, vals.ZoneName)
 	require.NoError(t, err)
 
-	// Enable the cloud.NetworkTiers feature
-	gce.AlphaFeatureGate.features[AlphaFeatureNetworkTiers] = true
 	svc := fakeLoadbalancerService("")
 	svc.Annotations = map[string]string{NetworkTierAnnotationKey: wrongTier}
 
@@ -852,7 +845,6 @@ func TestDeleteWrongNetworkTieredResourcesSucceedsWhenNotFound(t *testing.T) {
 	gce, err := fakeGCECloud(DefaultTestClusterValues())
 	require.NoError(t, err)
 
-	gce.AlphaFeatureGate.features[AlphaFeatureNetworkTiers] = true
 	assert.Nil(t, gce.deleteWrongNetworkTieredResources("Wrong_LB_Name", "", cloud.NetworkTier("")))
 }
 

--- a/staging/src/k8s.io/legacy-cloud-providers/gce/gce_util.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/gce/gce_util.go
@@ -281,18 +281,6 @@ func makeGoogleAPINotFoundError(message string) error {
 	return &googleapi.Error{Code: http.StatusNotFound, Message: message}
 }
 
-// TODO(#51665): Remove this once Network Tiers becomes Beta in GCP.
-func handleAlphaNetworkTierGetError(err error) (string, error) {
-	if isForbidden(err) {
-		// Network tier is still an Alpha feature in GCP, and not every project
-		// is whitelisted to access the API. If we cannot access the API, just
-		// assume the tier is premium.
-		return cloud.NetworkTierDefault.ToGCEValue(), nil
-	}
-	// Can't get the network tier, just return an error.
-	return "", err
-}
-
 // containsCIDR returns true if outer contains inner.
 func containsCIDR(outer, inner *net.IPNet) bool {
 	return outer.Contains(firstIPInRange(inner)) && outer.Contains(lastIPInRange(inner))

--- a/test/e2e/network/BUILD
+++ b/test/e2e/network/BUILD
@@ -86,7 +86,6 @@ go_library(
         "//vendor/github.com/miekg/dns:go_default_library",
         "//vendor/github.com/onsi/ginkgo:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
-        "//vendor/google.golang.org/api/compute/v0.alpha:go_default_library",
         "//vendor/google.golang.org/api/compute/v1:go_default_library",
         "//vendor/k8s.io/utils/net:go_default_library",
     ],


### PR DESCRIPTION
Cherry pick of #88532 on release-1.18.

#88532: Drop alpha gate for network tier annotation

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.