### PR TITLE
Remove stale analytics links from docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,5 +7,3 @@ The [Kubernetes community repo](https://github.com/kubernetes/community) contain
 ## Sign the CLA
 
 You must sign the [Contributor License Agreement](https://git.k8s.io/community/contributors/guide/README.md#sign-the-cla) in order to contribute.
-
-[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/CONTRIBUTING.md?pixel)]()

--- a/cluster/addons/addon-manager/CHANGELOG.md
+++ b/cluster/addons/addon-manager/CHANGELOG.md
@@ -86,6 +86,3 @@
 
 ### Version 1 (Thu May 5 2016 Mike Danese @mikedanese)
  - Run kube-addon-manager in a pod
-
-
-[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/cluster/addons/addon-manager/CHANGELOG.md?pixel)]()

--- a/cluster/addons/dashboard/MAINTAINERS.md
+++ b/cluster/addons/dashboard/MAINTAINERS.md
@@ -2,5 +2,3 @@
 
 Piotr Bryk <bryk@google.com> and committers to the https://github.com/kubernetes/dashboard repository.
 
-
-[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/cluster/addons/dashboard/MAINTAINERS.md?pixel)]()

--- a/cluster/addons/fluentd-gcp/fluentd-gcp-image/README.md
+++ b/cluster/addons/fluentd-gcp/fluentd-gcp-image/README.md
@@ -2,5 +2,3 @@
 
 The image was moved to the
 [new location](https://github.com/kubernetes/contrib/tree/master/fluentd/fluentd-gcp-image).
-
-[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/cluster/addons/fluentd-gcp/fluentd-gcp-image/README.md?pixel)]()

--- a/cluster/addons/metrics-server/README.md
+++ b/cluster/addons/metrics-server/README.md
@@ -16,5 +16,3 @@ Decreasing resource requirements for cluster addons may cause system instability
   - `kubectl top` not working (starting with Kubernetes 1.10)
 
 Overwritten configuration persists through cluster updates, therefore may cause all effects above after a cluster update.
-
-[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/cluster/addons/cluster-monitoring/README.md?pixel)]()

--- a/cluster/gce/gci/README.md
+++ b/cluster/gce/gci/README.md
@@ -106,5 +106,3 @@ family as a prefix, e.g cos-dev, cos-beta, cos-stable. However, the milestone
 number in those families may change when channel promotions happen. Only when a milestone becomes LTS, the
 image will have a new family, and the milestone number in the image name stays the same. The image
 will be always there even after the milestone is deprecated.
-
-[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/cluster/gce/gci/README.md?pixel)]()

--- a/cluster/images/conformance/README.md
+++ b/cluster/images/conformance/README.md
@@ -38,4 +38,3 @@ If you don't want to push the images, run `make` or `make build` instead
 kubectl create -f conformance-e2e.yaml
 ```
 
-[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/cluster/images/conformance/README.md?pixel)]()

--- a/cluster/images/etcd/README.md
+++ b/cluster/images/etcd/README.md
@@ -73,6 +73,3 @@ $ make build ARCH=ppc64le
 ```
 
 If you don't want to push the images, run `make` or `make build` instead
-
-
-[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/cluster/images/etcd/README.md?pixel)]()

--- a/staging/src/k8s.io/code-generator/cmd/client-gen/README.md
+++ b/staging/src/k8s.io/code-generator/cmd/client-gen/README.md
@@ -1,4 +1,2 @@
 See [generating-clientset.md](https://git.k8s.io/community/contributors/devel/sig-api-machinery/generating-clientset.md)
 
-
-[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/staging/src/k8s.io/code-generator/client-gen/README.md?pixel)]()

--- a/staging/src/k8s.io/legacy-cloud-providers/openstack/MAINTAINERS.md
+++ b/staging/src/k8s.io/legacy-cloud-providers/openstack/MAINTAINERS.md
@@ -2,5 +2,3 @@
 
 * [Angus Lees](https://github.com/anguslees)
 
-
-[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/staging/src/k8s.io/legacy-cloud-providers/openstack/MAINTAINERS.md?pixel)]()

--- a/test/images/agnhost/README.md
+++ b/test/images/agnhost/README.md
@@ -304,9 +304,6 @@ kubectl run logs-generator \
   -- logs-generator -t 10 -d 1s
 ```
 
-[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/test/images/logs-generator/README.md?pixel)]()
-
-
 ### mounttest
 
 The `mounttest` subcommand can be used to create files with various permissions, read files,
@@ -372,8 +369,6 @@ HTTP server:
     kubectl exec test-agnhost -- curl -v -X POST localhost:8889/run/nat-closewait-server \
         -d '{"LocalAddr":"127.0.0.1:9999"}'
 ```
-
-[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/test/images/net/README.md?pixel)]()
 
 ### netexec
 
@@ -571,9 +566,6 @@ Usage:
     kubectl exec test-agnhost -- /agnhost porter
 ```
 
-[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/test/images/porter/README.md?pixel)]()
-
-
 ### resource-consumer-controller
 
 This subcommand starts an HTTP server that spreads requests around resource consumers. The HTTP server has the same endpoints and usage as the one spawned by the ``resource-consumer`` subcommand.
@@ -612,11 +604,6 @@ Usage:
 ```console
     kubectl exec test-agnhost -- /agnhost serve-hostname [--tcp] [--udp] [--http] [--close] [--port <port>]
 ```
-
-[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/contrib/for-demos/serve_hostname/README.md?pixel)]()
-
-[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/test/images/serve_hostname/README.md?pixel)]()
-
 
 ### test-webserver
 

--- a/test/images/pets/redis-installer/README.md
+++ b/test/images/pets/redis-installer/README.md
@@ -8,5 +8,3 @@ docker run -it k8s.gcr.io/redis-install-3.2.0:e2e --cmd --install-into=/opt --wo
 ```
 To share the installation with other containers mount the appropriate volumes as `--install-into` and `--work-dir`, where `install-into` is the directory to install redis into, and `work-dir` is the directory to install the user/admin supplied on-{start,change} hook scripts.
 
-
-[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/test/images/pets/redis/README.md?pixel)]()

--- a/test/images/pets/zookeeper-installer/README.md
+++ b/test/images/pets/zookeeper-installer/README.md
@@ -8,5 +8,3 @@ docker run -it k8s.gcr.io/zookeeper-install-3.5.0-alpha:e2e --cmd --install-into
 ```
 To share the installation with other containers mount the appropriate volumes as `--install-into` and `--work-dir`, where `install-into` is the directory to install zookeeper into, and `work-dir` is the directory to install the user/admin supplied on-{start,change} hook scripts.
 
-
-[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/test/images/pets/zookeeper/README.md?pixel)]()

--- a/test/images/resource-consumer/README.md
+++ b/test/images/resource-consumer/README.md
@@ -79,5 +79,3 @@ Docker image of Resource Consumer can be found in Google Container Registry as g
 1. Create consuming pod and start consuming appropriate amount of resources
 2. Observed that limits has been increased
 
-
-[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/test/images/resource-consumer/README.md?pixel)]()

--- a/test/images/volume/gluster/README.md
+++ b/test/images/volume/gluster/README.md
@@ -4,5 +4,3 @@ This container exports test_vol volume with an index.html inside.
 
 Used by test/e2e/* to test GlusterfsVolumeSource. Not for production use!
 
-
-[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/test/images/volumes-tester/gluster/README.md?pixel)]()

--- a/test/images/volume/iscsi/README.md
+++ b/test/images/volume/iscsi/README.md
@@ -10,5 +10,3 @@ Inspired by https://github.com/rvykydal/dockerfile-iscsid
 
 block.tar.gz is a small ext2 filesystem created by `create_block.sh` (run as root!)
 
-
-[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/test/images/volumes-tester/iscsi/README.md?pixel)]()

--- a/test/images/volume/nfs/README.md
+++ b/test/images/volume/nfs/README.md
@@ -9,5 +9,3 @@ Inspired by https://github.com/cpuguy83/docker-nfs-server.
 
 Used by test/e2e/* to test NFSVolumeSource. Not for production use!
 
-
-[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/test/images/volumes-tester/nfs/README.md?pixel)]()


### PR DESCRIPTION
Many README files and other docs contained a link to a an appspot
tracking app that is no longer active. Following the links leads to an
error about Go 1.9 no longer being supported. Go 1.9 support was dropped
in appspot in 2019 and disabled June 2020.

This also resulted in a broken image link displaying when viewing these
files on GitHub. Since the app is no longer functioning, and since it
causes a potentially (but granted, minor) confusing error to display,
this just removes those links as I don't believe they are needed
anymore.

/kind cleanup
/kind documentation

```release-note
NONE
```