### PR TITLE
Using UpperCamelCase event reason - DeletingNode, instead of verbose msg

### DIFF
--- a/staging/src/k8s.io/cloud-provider/controllers/nodelifecycle/node_lifecycle_controller.go
+++ b/staging/src/k8s.io/cloud-provider/controllers/nodelifecycle/node_lifecycle_controller.go
@@ -19,7 +19,6 @@ package cloud
 import (
 	"context"
 	"errors"
-	"fmt"
 	"time"
 
 	"k8s.io/api/core/v1"
@@ -162,9 +161,8 @@ func (c *CloudNodeLifecycleController) MonitorNodes() {
 				Namespace: "",
 			}
 
-			c.recorder.Eventf(ref, v1.EventTypeNormal,
-				fmt.Sprintf("Deleting node %v because it does not exist in the cloud provider", node.Name),
-				"Node %s event: %s", node.Name, deleteNodeEvent)
+			c.recorder.Eventf(ref, v1.EventTypeNormal, deleteNodeEvent,
+				"Deleting node %s because it does not exist in the cloud provider", node.Name)
 
 			if err := c.kubeClient.CoreV1().Nodes().Delete(context.TODO(), node.Name, metav1.DeleteOptions{}); err != nil {
 				klog.Errorf("unable to delete node %q: %v", node.Name, err)


### PR DESCRIPTION
Node lifecycle controller currently emits a verbose event reason like `Deleting node xxxxxx-xxxxxxxxxxx because it does not exist in the cloud provider `

From https://github.com/kubernetes/client-go/blob/v12.0.0/tools/record/event.go#L93

> 'reason' is the reason this event is generated. 'reason' should be short and unique; it should be in UpperCamelCase format (starting with a capital letter). "reason" will be used to automate handling of events, so imagine people writing switch statements to handle them. You want to make that easy.

This PR changes the reason to `DeletingNode` which is already defined in `node_lifecycle_controller.go`  as `deleteNodeEvent`.