### PR TITLE
APF defaults.go: use already defined catch-all name constant

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/apis/flowcontrol/bootstrap/default.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/flowcontrol/bootstrap/default.go
@@ -83,7 +83,7 @@ var (
 		},
 	)
 	MandatoryPriorityLevelConfigurationCatchAll = newPriorityLevelConfiguration(
-		"catch-all",
+		flowcontrol.PriorityLevelConfigurationNameCatchAll,
 		flowcontrol.PriorityLevelConfigurationSpec{
 			Type: flowcontrol.PriorityLevelEnablementLimited,
 			Limited: &flowcontrol.LimitedPriorityLevelConfiguration{
@@ -126,8 +126,8 @@ var (
 	// "catch-all" priority-level only gets a minimal positive share of concurrency and won't be reaching
 	// ideally unless you intentionally deleted the suggested "global-default".
 	MandatoryFlowSchemaCatchAll = newFlowSchema(
-		"catch-all",
-		"catch-all",
+		flowcontrol.FlowSchemaNameCatchAll,
+		flowcontrol.PriorityLevelConfigurationNameCatchAll,
 		10000, // matchingPrecedence
 		flowcontrol.FlowDistinguisherMethodByUserType, // distinguisherMethodType
 		flowcontrol.PolicyRulesWithSubjects{


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

Something minor I noticed when I was looking through defaults.go. I've confirmed that "catch-all" is not used anywhere else in the code (except comments).

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/sig api-machinery
cc @MikeSpreitzer 