### PR TITLE
Increase timeout for pod lifecycle test to reach pod status=ready

### DIFF
--- a/test/e2e/common/pods.go
+++ b/test/e2e/common/pods.go
@@ -59,7 +59,7 @@ const (
 	maxBackOffTolerance  = time.Duration(1.3 * float64(kubelet.MaxContainerBackOff))
 	podRetryPeriod       = 1 * time.Second
 	podRetryTimeout      = 1 * time.Minute
-	podReadyTimeout      = 1 * time.Minute
+	podReadyTimeout      = 2 * time.Minute
 )
 
 // testHostIP tests that a pod gets a host IP


### PR DESCRIPTION
We had a single flake in a couple weeks.
It seems we were able to reach PodScheduled, but just needed a bit more time for it to reach state running.

```
[It] should run through the lifecycle of Pods and PodStatus
  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/pods.go:887
ï¿½[1mSTEPï¿½[0m: creating a Pod with a static label
ï¿½[1mSTEPï¿½[0m: watching for Pod to be ready
Nov 18 13:28:04.312: INFO: observed Pod pod-test in namespace pods-5897 in phase Pending conditions []
Nov 18 13:28:04.360: INFO: observed Pod pod-test in namespace pods-5897 in phase Pending conditions [{PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2020-11-18 13:28:04 +0000 UTC  }]
Nov 18 13:29:04.265: FAIL: failed to see Pod pod-test in namespace pods-5897 running
Unexpected error:
    <*errors.errorString | 0xc0002781f0>: {
        s: "timed out waiting for the condition",
    }
    timed out waiting for the condition
occurred
```