### PR TITLE
Updating to cadvisor v0.37.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -53,7 +53,7 @@ require (
 	github.com/gogo/protobuf v1.3.1
 	github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7
 	github.com/golang/mock v1.3.1
-	github.com/google/cadvisor v0.37.0
+	github.com/google/cadvisor v0.37.1
 	github.com/google/go-cmp v0.4.0
 	github.com/google/gofuzz v1.1.0
 	github.com/google/uuid v1.1.1
@@ -274,7 +274,7 @@ replace (
 	github.com/golangplus/fmt => github.com/golangplus/fmt v0.0.0-20150411045040-2a5d6d7d2995
 	github.com/golangplus/testing => github.com/golangplus/testing v0.0.0-20180327235837-af21d9c3145e
 	github.com/google/btree => github.com/google/btree v1.0.0
-	github.com/google/cadvisor => github.com/google/cadvisor v0.37.0
+	github.com/google/cadvisor => github.com/google/cadvisor v0.37.1
 	github.com/google/go-cmp => github.com/google/go-cmp v0.4.0
 	github.com/google/gofuzz => github.com/google/gofuzz v1.1.0
 	github.com/google/martian => github.com/google/martian v2.1.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -223,8 +223,8 @@ github.com/golangplus/testing v0.0.0-20180327235837-af21d9c3145e h1:KhcknUwkWHKZ
 github.com/golangplus/testing v0.0.0-20180327235837-af21d9c3145e/go.mod h1:0AA//k/eakGydO4jKRoRL2j92ZKSzTgj9tclaCrvXHk=
 github.com/google/btree v1.0.0 h1:0udJVsspx3VBr5FwtLhQQtuAsVc79tTq0ocGIPAU6qo=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
-github.com/google/cadvisor v0.37.0 h1:t3txV4zNZZGTuwuA/Onm3HToPhg16GjigAHZHEVIz+c=
-github.com/google/cadvisor v0.37.0/go.mod h1:OhDE+goNVel0eGY8mR7Ifq1QUI1in5vJBIgIpcajK/I=
+github.com/google/cadvisor v0.37.1 h1:P5KDKzZurwXlltf5jqnC8YFKv+JgBtltFEPvlfOJcnU=
+github.com/google/cadvisor v0.37.1/go.mod h1:OhDE+goNVel0eGY8mR7Ifq1QUI1in5vJBIgIpcajK/I=
 github.com/google/go-cmp v0.4.0 h1:xsAVV57WRhGj6kEIi8ReJzQlHHqcBYCElAvkovg3B/4=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/gofuzz v1.1.0 h1:Hsa8mG0dQ46ij8Sl2AYJDUv1oA9/d6Vk+3LG99Oe02g=

--- a/vendor/github.com/google/cadvisor/accelerators/nvidia.go
+++ b/vendor/github.com/google/cadvisor/accelerators/nvidia.go
@@ -58,9 +58,7 @@ func NewNvidiaManager(includedMetrics container.MetricSet) stats.Manager {
 	manager := &nvidiaManager{}
 	err := manager.setup()
 	if err != nil {
-		klog.Warningf("NVIDIA GPU metrics will not be available: %s", err)
-		manager.Destroy()
-		return &stats.NoopManager{}
+		klog.V(2).Infof("NVIDIA setup failed: %s", err)
 	}
 	return manager
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -507,9 +507,9 @@ github.com/golang/protobuf/ptypes/wrappers
 # github.com/google/btree v1.0.0 => github.com/google/btree v1.0.0
 github.com/google/btree
 # github.com/google/btree => github.com/google/btree v1.0.0
-# github.com/google/cadvisor v0.37.0 => github.com/google/cadvisor v0.37.0
+# github.com/google/cadvisor v0.37.1 => github.com/google/cadvisor v0.37.1
 ## explicit
-# github.com/google/cadvisor => github.com/google/cadvisor v0.37.0
+# github.com/google/cadvisor => github.com/google/cadvisor v0.37.1
 github.com/google/cadvisor/accelerators
 github.com/google/cadvisor/cache/memory
 github.com/google/cadvisor/client/v2


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug
/kind regression
<!--
Add one of the following kinds:
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake

-->

**What this PR does / why we need it**:
cadvisor v0.37 returns a `NoopManager` when it fails to initialize NVML: https://github.com/google/cadvisor/pull/2419/files#diff-bd4495842459f1c8cdcb90c14dc169abdcd738596d7e7710daa2f9a9aa7a7ba5. 

This is a problem because if the NVML library is loaded after the kubelet starts (e.g. loaded by a daemonset), cadvisor will return the `NoopManager` and will fail to report GPU metrics. A recent example can be found here: https://github.com/kubernetes/kubernetes/issues/96519#issuecomment-727151810.

See more details at: https://github.com/google/cadvisor/pull/2732


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

Note that this change does not fix the failing gpu test (https://github.com/kubernetes/kubernetes/issues/96519), but does fix the regression of GPU metric exporting. 

Also, this change will only go to release-1.19 branch.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
fixes a regression in 1.19 that prevents gpu metrics from being detected correctly
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
