### PR TITLE
Provide options for tests to filter out particular API errors

### DIFF
--- a/test/integration/scheduler_perf/BUILD
+++ b/test/integration/scheduler_perf/BUILD
@@ -46,6 +46,7 @@ go_test(
         "//pkg/volume/util:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/api/storage/v1beta1:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/resource:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/wait:go_default_library",


### PR DESCRIPTION
**What type of PR is this?**

/kind feature
/sig scheduling

**What this PR does / why we need it**:

We used to have universal functions to bypass particular API errors and then retry. This behavior was mutated in #95495 - in that PR's discussion, it's more preferable to fail the error early, and leave the error filtering decision to client instead of a one-off function.

In terms of scheduler performance testing, it doesn't really care about transient API errors. As described in #96651, it's not favorable to abort the whole test upon a single tolerable API error. So this PR adds an option for tests to be able to filter out particular API errors.

**Which issue(s) this PR fixes**:

Fixes #96651

**Special notes for your reviewer**:

Note that, apart from `CreatePod()`, this PR doesn't apply the option to all other `CreateXYZ` functions.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```