### PR TITLE
Fix `kubectl wait --for=delete` ignore not found

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/wait/wait.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/wait/wait.go
@@ -247,7 +247,8 @@ func (o *WaitOptions) RunWait() error {
 		return err
 	}
 	visitor := o.ResourceFinder.Do()
-	if visitor, ok := visitor.(*resource.Result); ok && strings.ToLower(o.ForCondition) == "delete" {
+	isForDelete := strings.ToLower(o.ForCondition) == "delete"
+	if visitor, ok := visitor.(*resource.Result); ok && isForDelete {
 		visitor.IgnoreErrors(apierrors.IsNotFound)
 	}
 
@@ -255,7 +256,7 @@ func (o *WaitOptions) RunWait() error {
 	if err != nil {
 		return err
 	}
-	if visitCount == 0 {
+	if visitCount == 0 && !isForDelete {
 		return errNoMatchingResources
 	}
 	return err

--- a/staging/src/k8s.io/kubectl/pkg/cmd/wait/wait_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/wait/wait_test.go
@@ -801,15 +801,7 @@ func TestWaitForDeletionIgnoreNotFound(t *testing.T) {
 	listMapping := map[schema.GroupVersionResource]string{
 		{Group: "group", Version: "version", Resource: "theresource"}: "TheKindList",
 	}
-	infos := []*resource.Info{
-		{
-			Mapping: &meta.RESTMapping{
-				Resource: schema.GroupVersionResource{Group: "group", Version: "version", Resource: "theresource"},
-			},
-			Name:      "name-foo",
-			Namespace: "ns-foo",
-		},
-	}
+	infos := []*resource.Info{}
 	fakeClient := dynamicfakeclient.NewSimpleDynamicClientWithCustomListKinds(scheme, listMapping)
 
 	o := &WaitOptions{

--- a/test/e2e/kubectl/kubectl.go
+++ b/test/e2e/kubectl/kubectl.go
@@ -1827,6 +1827,14 @@ metadata:
 			}
 		})
 	})
+
+	ginkgo.Describe("kubectl wait", func() {
+		ginkgo.It("should ignore not found error with --for=delete", func() {
+			ginkgo.By("calling kubectl wait --for=delete")
+			framework.RunKubectlOrDie(ns, "wait", "--for=delete", "pod/doesnotexist")
+			framework.RunKubectlOrDie(ns, "wait", "--for=delete", "pod", "--selector=app.kubernetes.io/name=noexist")
+		})
+	})
 })
 
 // Checks whether the output split by line contains the required elements.


### PR DESCRIPTION
Signed-off-by: Ling Samuel <lingsamuelgrace@gmail.com>

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Ignore not found in `kubectl wait --for=delete` introduced by #90969 doesn't work correctly. If resources not found (by name or by selector), the command still raises an error.

The test in this PR doesn't test the situation "not found" correctly because:
1. cannot cast `genericclioptions.fakeResourceResult` to `resource.Result`, the code path actually no covered. It's hard to fix this without a refactor.
2. `infos` should be an empty list

**Which issue(s) this PR fixes**:
Fixes: #96676, fixes #87747, fixes #93365

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
kubectl wait --for=delete ignores not found error correctly now.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
