### PR TITLE
Retry on the failure of object creation

### DIFF
--- a/test/utils/create_resources.go
+++ b/test/utils/create_resources.go
@@ -26,6 +26,7 @@ import (
 	apps "k8s.io/api/apps/v1"
 	batch "k8s.io/api/batch/v1"
 	storage "k8s.io/api/storage/v1"
+	"k8s.io/klog/v2"
 
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -62,7 +63,8 @@ func CreatePodWithRetries(c clientset.Interface, namespace string, obj *v1.Pod) 
 		if err == nil || apierrors.IsAlreadyExists(err) {
 			return true, nil
 		}
-		return false, fmt.Errorf("Failed to create object with non-retriable error: %v", err)
+		klog.Errorf("Failed to create Pod with error: %v", err)
+		return false, nil
 	}
 	return RetryWithExponentialBackOff(createFunc)
 }
@@ -76,7 +78,8 @@ func CreateRCWithRetries(c clientset.Interface, namespace string, obj *v1.Replic
 		if err == nil || apierrors.IsAlreadyExists(err) {
 			return true, nil
 		}
-		return false, fmt.Errorf("Failed to create object with non-retriable error: %v", err)
+		klog.Errorf("Failed to create ReplicationController with error: %v", err)
+		return false, nil
 	}
 	return RetryWithExponentialBackOff(createFunc)
 }
@@ -90,7 +93,8 @@ func CreateReplicaSetWithRetries(c clientset.Interface, namespace string, obj *a
 		if err == nil || apierrors.IsAlreadyExists(err) {
 			return true, nil
 		}
-		return false, fmt.Errorf("Failed to create object with non-retriable error: %v", err)
+		klog.Errorf("Failed to create ReplicaSet with error: %v", err)
+		return false, nil
 	}
 	return RetryWithExponentialBackOff(createFunc)
 }
@@ -104,7 +108,8 @@ func CreateDeploymentWithRetries(c clientset.Interface, namespace string, obj *a
 		if err == nil || apierrors.IsAlreadyExists(err) {
 			return true, nil
 		}
-		return false, fmt.Errorf("Failed to create object with non-retriable error: %v", err)
+		klog.Errorf("Failed to create Deployment with error: %v", err)
+		return false, nil
 	}
 	return RetryWithExponentialBackOff(createFunc)
 }
@@ -118,7 +123,8 @@ func CreateDaemonSetWithRetries(c clientset.Interface, namespace string, obj *ap
 		if err == nil || apierrors.IsAlreadyExists(err) {
 			return true, nil
 		}
-		return false, fmt.Errorf("Failed to create object with non-retriable error: %v", err)
+		klog.Errorf("Failed to create DaemonSet with error: %v", err)
+		return false, nil
 	}
 	return RetryWithExponentialBackOff(createFunc)
 }
@@ -132,7 +138,8 @@ func CreateJobWithRetries(c clientset.Interface, namespace string, obj *batch.Jo
 		if err == nil || apierrors.IsAlreadyExists(err) {
 			return true, nil
 		}
-		return false, fmt.Errorf("Failed to create object with non-retriable error: %v", err)
+		klog.Errorf("Failed to create Job with error: %v", err)
+		return false, nil
 	}
 	return RetryWithExponentialBackOff(createFunc)
 }
@@ -146,7 +153,8 @@ func CreateSecretWithRetries(c clientset.Interface, namespace string, obj *v1.Se
 		if err == nil || apierrors.IsAlreadyExists(err) {
 			return true, nil
 		}
-		return false, fmt.Errorf("Failed to create object with non-retriable error: %v", err)
+		klog.Errorf("Failed to create Secret with error: %v", err)
+		return false, nil
 	}
 	return RetryWithExponentialBackOff(createFunc)
 }
@@ -160,7 +168,8 @@ func CreateConfigMapWithRetries(c clientset.Interface, namespace string, obj *v1
 		if err == nil || apierrors.IsAlreadyExists(err) {
 			return true, nil
 		}
-		return false, fmt.Errorf("Failed to create object with non-retriable error: %v", err)
+		klog.Errorf("Failed to create ConfigMap with error: %v", err)
+		return false, nil
 	}
 	return RetryWithExponentialBackOff(createFunc)
 }
@@ -174,7 +183,8 @@ func CreateServiceWithRetries(c clientset.Interface, namespace string, obj *v1.S
 		if err == nil || apierrors.IsAlreadyExists(err) {
 			return true, nil
 		}
-		return false, fmt.Errorf("Failed to create object with non-retriable error: %v", err)
+		klog.Errorf("Failed to create Service with error: %v", err)
+		return false, nil
 	}
 	return RetryWithExponentialBackOff(createFunc)
 }
@@ -188,7 +198,8 @@ func CreateStorageClassWithRetries(c clientset.Interface, obj *storage.StorageCl
 		if err == nil || apierrors.IsAlreadyExists(err) {
 			return true, nil
 		}
-		return false, fmt.Errorf("Failed to create object with non-retriable error: %v", err)
+		klog.Errorf("Failed to create StorageClass with error: %v", err)
+		return false, nil
 	}
 	return RetryWithExponentialBackOff(createFunc)
 }
@@ -202,7 +213,8 @@ func CreateResourceQuotaWithRetries(c clientset.Interface, namespace string, obj
 		if err == nil || apierrors.IsAlreadyExists(err) {
 			return true, nil
 		}
-		return false, fmt.Errorf("Failed to create object with non-retriable error: %v", err)
+		klog.Errorf("Failed to create ResourceQuota with error: %v", err)
+		return false, nil
 	}
 	return RetryWithExponentialBackOff(createFunc)
 }
@@ -216,7 +228,8 @@ func CreatePersistentVolumeWithRetries(c clientset.Interface, obj *v1.Persistent
 		if err == nil || apierrors.IsAlreadyExists(err) {
 			return true, nil
 		}
-		return false, fmt.Errorf("Failed to create object with non-retriable error: %v", err)
+		klog.Errorf("Failed to create PersistentVolume with error: %v", err)
+		return false, nil
 	}
 	return RetryWithExponentialBackOff(createFunc)
 }
@@ -230,7 +243,8 @@ func CreatePersistentVolumeClaimWithRetries(c clientset.Interface, namespace str
 		if err == nil || apierrors.IsAlreadyExists(err) {
 			return true, nil
 		}
-		return false, fmt.Errorf("Failed to create object with non-retriable error: %v", err)
+		klog.Errorf("Failed to create PersistentVolumeClaim with error: %v", err)
+		return false, nil
 	}
 	return RetryWithExponentialBackOff(createFunc)
 }


### PR DESCRIPTION
Signed-off-by: Dave Chen <dave.chen@arm.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**


Add one of the following kinds:
/kind bug




**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubernetes/issues/96703

**Special notes for your reviewer**:
please see the bug https://github.com/kubernetes/kubernetes/issues/96703 for how this impact integration test in `scheduler_perf`, and the alternative fix.
 
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
