### PR TITLE
Remove the additional goroutine and dependency on time in the time budget implementation

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher.go
@@ -341,7 +341,7 @@ func NewCacherFromConfig(config Config) (*Cacher, error) {
 		},
 		// TODO: Figure out the correct value for the buffer size.
 		incoming:              make(chan watchCacheEvent, 100),
-		dispatchTimeoutBudget: newTimeBudget(stopCh),
+		dispatchTimeoutBudget: newTimeBudget(clock.RealClock{}),
 		// We need to (potentially) stop both:
 		// - wait.Until go-routine
 		// - reflector.ListAndWatch

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/time_budget_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/time_budget_test.go
@@ -19,13 +19,21 @@ package cacher
 import (
 	"testing"
 	"time"
+
+	"k8s.io/apimachinery/pkg/util/clock"
 )
 
 func TestTimeBudget(t *testing.T) {
+	inputClock := clock.NewFakeClock(time.Now())
+
 	budget := &timeBudgetImpl{
-		budget:    time.Duration(0),
-		maxBudget: time.Duration(200),
+		budget:          time.Duration(0),
+		maxBudget:       time.Duration(200),
+		refresh:         time.Duration(50),
+		clock:           inputClock,
+		lastRefreshTime: inputClock.Now(),
 	}
+
 	if res := budget.takeAvailable(); res != time.Duration(0) {
 		t.Errorf("Expected: %v, got: %v", time.Duration(0), res)
 	}
@@ -49,5 +57,40 @@ func TestTimeBudget(t *testing.T) {
 	budget.returnUnused(time.Duration(500))
 	if res := budget.takeAvailable(); res != time.Duration(200) {
 		t.Errorf("Expected: %v, got: %v", time.Duration(200), res)
+	}
+
+	// test replenishment of budget over a time duration
+	// take all available budget to reset budget and lastRefreshTime
+	budget.takeAvailable()
+	// fake wait for 2 seconds
+	waitSeconds := 2
+	inputClock.Step(time.Duration(waitSeconds) * time.Second)
+	// expect (2 seconds * 50ms/second)=100ms of budget
+	expectedBudget := time.Duration(waitSeconds) * budget.refresh
+	if res := budget.takeAvailable(); res != expectedBudget {
+		t.Errorf("Expected: %v, got: %v", expectedBudget, res)
+	}
+
+	// calling takeAvailable in intervals of less than a second
+	// should not reset the budget
+	budget.budget = time.Duration(0)
+	budget.lastRefreshTime = inputClock.Now()
+	// fake wait for 0.5 seconds
+	inputClock.Step(500 * time.Millisecond)
+	expectedBudget = 0 * budget.refresh
+	if res := budget.takeAvailable(); res != expectedBudget {
+		t.Errorf("Expected: %v, got: %v", expectedBudget, res)
+	}
+	// fake wait for 0.25 seconds
+	inputClock.Step(250 * time.Millisecond)
+	expectedBudget = 0 * budget.refresh
+	if res := budget.takeAvailable(); res != expectedBudget {
+		t.Errorf("Expected: %v, got: %v", expectedBudget, res)
+	}
+	inputClock.Step(500 * time.Millisecond)
+	// expect (1 second * 50ms/second)=50s of budget
+	expectedBudget = 1 * budget.refresh
+	if res := budget.takeAvailable(); res != expectedBudget {
+		t.Errorf("Expected: %v, got: %v", expectedBudget, res)
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup
/sig api-machinery

**What this PR does / why we need it**:

The factory method `newTimeBudget` now takes a `clock` and uses that
clock for all time related operations.

The `takeAvailable` method now calculates the available budget by
looking at the time elapsed since the last time the method was called.

The instances where the time budget logic is called are also updated
since the implementation does not require a channel to denote stopping
signals anymore.

**Which issue(s) this PR fixes**:

Fixes #95875 

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

Signed-off-by: Nabarun Pal <pal.nabarun95@gmail.com>