### PR TITLE
fix GetZoneKey nil pointer and add some testcase

### DIFF
--- a/pkg/util/node/node.go
+++ b/pkg/util/node/node.go
@@ -182,6 +182,9 @@ func GetNodeIP(client clientset.Interface, name string) net.IP {
 // GetZoneKey will first check failure-domain.beta.kubernetes.io/zone and if not exists, will then check
 // topology.kubernetes.io/zone
 func GetZoneKey(node *v1.Node) string {
+	if node == nil {
+		return ""
+	}
 	labels := node.Labels
 	if labels == nil {
 		return ""

--- a/pkg/util/node/node_test.go
+++ b/pkg/util/node/node_test.go
@@ -274,6 +274,18 @@ func Test_GetZoneKey(t *testing.T) {
 		zone string
 	}{
 		{
+			name: "nil node",
+			node: nil,
+			zone:"",
+		},
+		{
+			name: "nil label",
+			node: &v1.Node{
+				ObjectMeta: metav1.ObjectMeta{Labels: nil},
+			},
+			zone:"",
+		},
+		{
 			name: "has no zone or region keys",
 			node: &v1.Node{
 				ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
fix nil pointer error in GetZoneKey, or it will lead to scheduler panic when the node is nil
**Which issue(s) this PR fixes**:
fix the nil pointer panic when the param node is nil, and avoid scheduler panic

we find it in our production env, the scheduler panic and restart all the time
![image](https://user-images.githubusercontent.com/8846958/99664644-753e8700-2aa3-11eb-83be-65970e287b69.png)


**Special notes for your reviewer**:
no

**Does this PR introduce a user-facing change?**:
no

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
