### PR TITLE
Deflake ThrottledLogger test

### DIFF
--- a/staging/src/k8s.io/client-go/rest/request_test.go
+++ b/staging/src/k8s.io/client-go/rest/request_test.go
@@ -2228,14 +2228,18 @@ func TestRequestPreflightCheck(t *testing.T) {
 
 func TestThrottledLogger(t *testing.T) {
 	now := time.Now()
+	oldClock := globalThrottledLogger.clock
+	defer func() {
+		globalThrottledLogger.clock = oldClock
+	}()
 	clock := clock.NewFakeClock(now)
 	globalThrottledLogger.clock = clock
 
 	logMessages := 0
-	for i := 0; i < 10000; i++ {
+	for i := 0; i < 1000; i++ {
 		var wg sync.WaitGroup
-		wg.Add(100)
-		for j := 0; j < 100; j++ {
+		wg.Add(10)
+		for j := 0; j < 10; j++ {
 			go func() {
 				if _, ok := globalThrottledLogger.attemptToLog(); ok {
 					logMessages++
@@ -2248,7 +2252,7 @@ func TestThrottledLogger(t *testing.T) {
 		clock.SetTime(now)
 	}
 
-	if a, e := logMessages, 1000; a != e {
+	if a, e := logMessages, 100; a != e {
 		t.Fatalf("expected %v log messages, but got %v", e, a)
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind flake

**What this PR does / why we need it**:

Reduces the cost of the ThrottledLogger test to avoid flaking in low-resource environments, and restores the non-fake clock to the logger throttler after the test runs

Before
```
$ time go test -race -count=1 ./vendor/k8s.io/client-go/rest 
ok  	k8s.io/client-go/rest	48.587s

real	0m51.842s
user	1m0.237s
sys	0m17.276s
```

After:
```
time go test -race -count=1 ./vendor/k8s.io/client-go/rest 
ok  	k8s.io/client-go/rest	3.671s

real	0m6.526s
user	0m4.552s
sys	0m2.224s
```

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
