### PR TITLE
Handle empty list in RemoveStatusCondition

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/api/meta/conditions.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/meta/conditions.go
@@ -57,7 +57,7 @@ func SetStatusCondition(conditions *[]metav1.Condition, newCondition metav1.Cond
 // RemoveStatusCondition removes the corresponding conditionType from conditions.
 // conditions must be non-nil.
 func RemoveStatusCondition(conditions *[]metav1.Condition, conditionType string) {
-	if conditions == nil {
+	if conditions == nil || len(*conditions) == 0 {
 		return
 	}
 	newConditions := make([]metav1.Condition, 0, len(*conditions)-1)


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fix the panic when RemoveStatusCondition() takes an empty Condition list as input.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
