### PR TITLE
Fail instead of panic when HNS network cannot be created in test.

### DIFF
--- a/pkg/proxy/winkernel/hns_test.go
+++ b/pkg/proxy/winkernel/hns_test.go
@@ -110,10 +110,7 @@ func TestDeleteLoadBalancer(t *testing.T) {
 	testDeleteLoadBalancer(t, hnsV2)
 }
 func testGetNetworkByName(t *testing.T, hns HostNetworkService) {
-	Network, err := createTestNetwork()
-	if err != nil {
-		t.Error(err)
-	}
+	Network := mustTestNetwork(t)
 
 	network, err := hns.getNetworkByName(Network.Name)
 	if err != nil {
@@ -129,10 +126,7 @@ func testGetNetworkByName(t *testing.T, hns HostNetworkService) {
 	}
 }
 func testGetEndpointByID(t *testing.T, hns HostNetworkService) {
-	Network, err := createTestNetwork()
-	if err != nil {
-		t.Error(err)
-	}
+	Network := mustTestNetwork(t)
 
 	ipConfig := &hcn.IpConfig{
 		IpAddress: epIpAddress,
@@ -146,7 +140,7 @@ func testGetEndpointByID(t *testing.T, hns HostNetworkService) {
 		},
 	}
 
-	Endpoint, err = Network.CreateEndpoint(Endpoint)
+	Endpoint, err := Network.CreateEndpoint(Endpoint)
 	if err != nil {
 		t.Error(err)
 	}
@@ -169,10 +163,7 @@ func testGetEndpointByID(t *testing.T, hns HostNetworkService) {
 	}
 }
 func testGetEndpointByIpAddress(t *testing.T, hns HostNetworkService) {
-	Network, err := createTestNetwork()
-	if err != nil {
-		t.Error(err)
-	}
+	Network := mustTestNetwork(t)
 
 	ipConfig := &hcn.IpConfig{
 		IpAddress: epIpAddress,
@@ -185,7 +176,7 @@ func testGetEndpointByIpAddress(t *testing.T, hns HostNetworkService) {
 			Minor: 0,
 		},
 	}
-	Endpoint, err = Network.CreateEndpoint(Endpoint)
+	Endpoint, err := Network.CreateEndpoint(Endpoint)
 	if err != nil {
 		t.Error(err)
 	}
@@ -211,10 +202,7 @@ func testGetEndpointByIpAddress(t *testing.T, hns HostNetworkService) {
 	}
 }
 func testCreateEndpointLocal(t *testing.T, hns HostNetworkService) {
-	Network, err := createTestNetwork()
-	if err != nil {
-		t.Error(err)
-	}
+	Network := mustTestNetwork(t)
 
 	endpoint := &endpointsInfo{
 		ip:         epIpAddress,
@@ -222,7 +210,7 @@ func testCreateEndpointLocal(t *testing.T, hns HostNetworkService) {
 		isLocal:    true,
 	}
 
-	endpoint, err = hns.createEndpoint(endpoint, Network.Name)
+	endpoint, err := hns.createEndpoint(endpoint, Network.Name)
 	if err != nil {
 		t.Error(err)
 	}
@@ -250,10 +238,7 @@ func testCreateEndpointLocal(t *testing.T, hns HostNetworkService) {
 	}
 }
 func testCreateEndpointRemote(t *testing.T, hns HostNetworkService, providerAddress string) {
-	Network, err := createTestNetwork()
-	if err != nil {
-		t.Error(err)
-	}
+	Network := mustTestNetwork(t)
 
 	endpoint := &endpointsInfo{
 		ip:              epIpAddressRemote,
@@ -262,7 +247,7 @@ func testCreateEndpointRemote(t *testing.T, hns HostNetworkService, providerAddr
 		providerAddress: providerAddress,
 	}
 
-	endpoint, err = hns.createEndpoint(endpoint, Network.Name)
+	endpoint, err := hns.createEndpoint(endpoint, Network.Name)
 	if err != nil {
 		t.Error(err)
 	}
@@ -293,10 +278,7 @@ func testCreateEndpointRemote(t *testing.T, hns HostNetworkService, providerAddr
 	}
 }
 func testDeleteEndpoint(t *testing.T, hns HostNetworkService) {
-	Network, err := createTestNetwork()
-	if err != nil {
-		t.Error(err)
-	}
+	Network := mustTestNetwork(t)
 
 	ipConfig := &hcn.IpConfig{
 		IpAddress: epIpAddress,
@@ -309,7 +291,7 @@ func testDeleteEndpoint(t *testing.T, hns HostNetworkService) {
 			Minor: 0,
 		},
 	}
-	Endpoint, err = Network.CreateEndpoint(Endpoint)
+	Endpoint, err := Network.CreateEndpoint(Endpoint)
 	if err != nil {
 		t.Error(err)
 	}
@@ -330,10 +312,7 @@ func testDeleteEndpoint(t *testing.T, hns HostNetworkService) {
 }
 
 func testGetLoadBalancerExisting(t *testing.T, hns HostNetworkService) {
-	Network, err := createTestNetwork()
-	if err != nil {
-		t.Error(err)
-	}
+	Network := mustTestNetwork(t)
 
 	ipConfig := &hcn.IpConfig{
 		IpAddress: epIpAddress,
@@ -346,7 +325,7 @@ func testGetLoadBalancerExisting(t *testing.T, hns HostNetworkService) {
 			Minor: 0,
 		},
 	}
-	Endpoint, err = Network.CreateEndpoint(Endpoint)
+	Endpoint, err := Network.CreateEndpoint(Endpoint)
 	if err != nil {
 		t.Error(err)
 	}
@@ -394,10 +373,7 @@ func testGetLoadBalancerExisting(t *testing.T, hns HostNetworkService) {
 	}
 }
 func testGetLoadBalancerNew(t *testing.T, hns HostNetworkService) {
-	Network, err := createTestNetwork()
-	if err != nil {
-		t.Error(err)
-	}
+	Network := mustTestNetwork(t)
 
 	ipConfig := &hcn.IpConfig{
 		IpAddress: epIpAddress,
@@ -410,7 +386,7 @@ func testGetLoadBalancerNew(t *testing.T, hns HostNetworkService) {
 			Minor: 0,
 		},
 	}
-	Endpoint, err = Network.CreateEndpoint(Endpoint)
+	Endpoint, err := Network.CreateEndpoint(Endpoint)
 	if err != nil {
 		t.Error(err)
 	}
@@ -445,10 +421,7 @@ func testGetLoadBalancerNew(t *testing.T, hns HostNetworkService) {
 	}
 }
 func testDeleteLoadBalancer(t *testing.T, hns HostNetworkService) {
-	Network, err := createTestNetwork()
-	if err != nil {
-		t.Error(err)
-	}
+	Network := mustTestNetwork(t)
 
 	ipConfig := &hcn.IpConfig{
 		IpAddress: epIpAddress,
@@ -461,7 +434,7 @@ func testDeleteLoadBalancer(t *testing.T, hns HostNetworkService) {
 			Minor: 0,
 		},
 	}
-	Endpoint, err = Network.CreateEndpoint(Endpoint)
+	Endpoint, err := Network.CreateEndpoint(Endpoint)
 	if err != nil {
 		t.Error(err)
 	}
@@ -498,6 +471,16 @@ func testDeleteLoadBalancer(t *testing.T, hns HostNetworkService) {
 	if err != nil {
 		t.Error(err)
 	}
+}
+func mustTestNetwork(t *testing.T) *hcn.HostComputeNetwork {
+	network, err := createTestNetwork()
+	if err != nil {
+		t.Fatalf("cannot create test network: %v", err)
+	}
+	if network == nil {
+		t.Fatal("test network was nil without error")
+	}
+	return network
 }
 func createTestNetwork() (*hcn.HostComputeNetwork, error) {
 	network := &hcn.HostComputeNetwork{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
`hns_test.go` panics if the test network cannot be provisioned. This change improves the test feedback by not abruptly panic'ing and instead gracefully reports failure per test case.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
