### PR TITLE
kube-proxy: remove EndpointSlice NodeName feature gate check

### DIFF
--- a/pkg/proxy/BUILD
+++ b/pkg/proxy/BUILD
@@ -19,7 +19,6 @@ go_library(
     importpath = "k8s.io/kubernetes/pkg/proxy",
     deps = [
         "//pkg/api/v1/service:go_default_library",
-        "//pkg/features:go_default_library",
         "//pkg/proxy/config:go_default_library",
         "//pkg/proxy/metrics:go_default_library",
         "//pkg/proxy/util:go_default_library",
@@ -27,7 +26,6 @@ go_library(
         "//staging/src/k8s.io/api/discovery/v1beta1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
-        "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",
         "//staging/src/k8s.io/client-go/tools/record:go_default_library",
         "//vendor/k8s.io/klog/v2:go_default_library",
         "//vendor/k8s.io/utils/net:go_default_library",


### PR DESCRIPTION
Signed-off-by: Andrew Sy Kim <kim.andrewsy@gmail.com>

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
kube-proxy shouldn't check for the EndpointSliceNodeName feature gate. If apiserver allowed the field to be set and the field is not nil, kube-proxy (as a client) should use it. This allows kube-proxy to handle downgrade scenarios gracefully where NodeName may have been set from a newer version. If using the field was feature gated, kube-proxy would ignore it, even though resources had it set. This is most concerning if `topology` is not set, which for most EndpointSlices shouldn't be the case since we did not remove setting topology (yet).   

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
