### PR TITLE
Automated cherry pick of #96705: fix: resize Azure disk issue when it's in attached state

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_managedDiskController.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_managedDiskController.go
@@ -278,6 +278,9 @@ func (c *ManagedDiskController) ResizeDisk(diskURI string, oldSize resource.Quan
 		return newSizeQuant, nil
 	}
 
+	if result.DiskProperties.DiskState != compute.Unattached {
+		return oldSize, fmt.Errorf("azureDisk - disk resize is only supported on Unattached disk, current disk state: %s, already attached to %s", result.DiskProperties.DiskState, to.String(result.ManagedBy))
+	}
 	result.DiskProperties.DiskSizeGB = &requestGiB
 
 	ctx, cancel = getContextWithCancel()


### PR DESCRIPTION
Cherry pick of #96705 on release-1.17.

#96705: fix: resize Azure disk issue when it's in attached state

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.