### PR TITLE
Allows "NEW CERTIFICATE REQUEST" header in the CSR content

### DIFF
--- a/pkg/apis/certificates/helpers.go
+++ b/pkg/apis/certificates/helpers.go
@@ -30,8 +30,8 @@ import (
 // ParseCSR extracts the CSR from the bytes and decodes it.
 func ParseCSR(pemBytes []byte) (*x509.CertificateRequest, error) {
 	block, _ := pem.Decode(pemBytes)
-	if block == nil || block.Type != "CERTIFICATE REQUEST" {
-		return nil, errors.New("PEM block type must be CERTIFICATE REQUEST")
+	if block == nil || (block.Type != "CERTIFICATE REQUEST" && block.Type != "NEW CERTIFICATE REQUEST") {
+		return nil, errors.New("PEM block type must be CERTIFICATE REQUEST or NEW CERTIFICATE REQUEST")
 	}
 	csr, err := x509.ParseCertificateRequest(block.Bytes)
 	if err != nil {


### PR DESCRIPTION

```release-note
NONE
```

/sig auth
/kind bug

the csr api fails the validation upon receiving the following CSR file:

```
-----BEGIN NEW CERTIFICATE REQUEST-----
MIICUzCCATsCAQAwDjEMMAoGA1UEAxMDZm9vMIIBIjANBgkqhkiG9w0BAQEFAAOC
AQ8AMIIBCgKCAQEA2mhkDXddpVAD/75bYKenCBgrxSQcxuZxbZW9YJZ4DzHEs5t/
gVpJGevZho7fyzRk/1xHJgAYReXYRCLSJJzITkD9G9YsgnxT8lQsTWMXc9IeZR2S
qc6hu0BehkVSw714x3Bc8FYHeHVliPFTk9vuupdT2sPYkB/P6IXuHGxB5igLqtXV
nMSBQVmJKwq1Tj3pP+vvXwIXG/cnMrSBBYcb6c+UdvLJnWF6mCyZzD5/qgVa4t6G
sSf4hSC9yvkSCgGcwnRFVPIZWW+LDfoO88ua2A2QufAHe+ws+YG699GsOKtp1m8n
DFNeRrks879D8xvKnq2TZ3wiypIh2LzJ80vbOwIDAQABoAAwDQYJKoZIhvcNAQEE
BQADggEBAKo3BzE83MK3NqQfXAw5NPkfgPmycqy1e3kCkcGYdY81EkX0r+ioKGJX
qCtAQ8jejTJZmR2tgA2V27tXCQcz2FrLLDdYWPM+cq7G7z/dXcn4jTV5aKwd5yPR
9SjlWTYPs97pdwmsDj7M7WG3agMY7/UeJlevWd2oVTxl5BsFmd26MYrV9RE57W/k
LgrfAFlRrX3MJluBEvPFnuwLK1O0sNuUfzFj50LmEw9t7h/yemR/qQu0v0ZytIm+
0fUorSjBccO3ESE7u3aIGYeZhhZ9TBsYOlAdf5HFW5+ssYAfnwafWADNgRukJPFj
JRBbQ7f6+icma+oh2AUXKcnrR0/WVKY=
-----END NEW CERTIFICATE REQUEST-----
```