### PR TITLE
cli-runtime: expose option to set discovery burst

### DIFF
--- a/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/config_flags.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/config_flags.go
@@ -105,6 +105,9 @@ type ConfigFlags struct {
 	// propagate the config to the places that need it, rather than
 	// loading the config multiple times
 	usePersistentConfig bool
+	// Allows increasing burst used for discovery, this is useful
+	// in clusters with many registered resources
+	discoveryBurst int
 }
 
 // ToRESTConfig implements RESTClientGetter.
@@ -224,7 +227,7 @@ func (f *ConfigFlags) ToDiscoveryClient() (discovery.CachedDiscoveryInterface, e
 	// The more groups you have, the more discovery requests you need to make.
 	// given 25 groups (our groups + a few custom resources) with one-ish version each, discovery needs to make 50 requests
 	// double it just so we don't end up here again for a while.  This config is only used for discovery.
-	config.Burst = 100
+	config.Burst = f.discoveryBurst
 
 	cacheDir := defaultCacheDir
 
@@ -320,6 +323,12 @@ func (f *ConfigFlags) WithDeprecatedPasswordFlag() *ConfigFlags {
 	return f
 }
 
+// WithDiscoveryBurst sets the RESTClient burst for discovery.
+func (f *ConfigFlags) WithDiscoveryBurst(discoveryBurst int) *ConfigFlags {
+	f.discoveryBurst = discoveryBurst
+	return f
+}
+
 // NewConfigFlags returns ConfigFlags with default values set
 func NewConfigFlags(usePersistentConfig bool) *ConfigFlags {
 	impersonateGroup := []string{}
@@ -345,6 +354,10 @@ func NewConfigFlags(usePersistentConfig bool) *ConfigFlags {
 		ImpersonateGroup: &impersonateGroup,
 
 		usePersistentConfig: usePersistentConfig,
+		// The more groups you have, the more discovery requests you need to make.
+		// given 25 groups (our groups + a few custom resources) with one-ish version each, discovery needs to make 50 requests
+		// double it just so we don't end up here again for a while.  This config is only used for discovery.
+		discoveryBurst: 100,
 	}
 }
 


### PR DESCRIPTION
**What type of PR is this?**
/kind feature
/priority backlog
/sig cli

**What this PR does / why we need it**:
On cluster with ever-increasing number of resources it is possible that the Discovery operation will be client-throttled due to hard coded limit set currently to 100. This PR exposes the ability to increase that number. 

**Special notes for your reviewer**:
/assign @deads2k 

```release-note
NONE
```
