### PR TITLE
[DO NOT MERGE] Adding logging to empty dir teardown

### DIFF
--- a/pkg/volume/emptydir/empty_dir.go
+++ b/pkg/volume/emptydir/empty_dir.go
@@ -538,6 +538,9 @@ func (ed *emptyDir) teardownTmpfsOrHugetlbfs(dir string) error {
 	if err := os.RemoveAll(dir); err != nil {
 		return err
 	}
+	klog.Infof("checking if %s has been deleted", dir)
+	_, err := os.Stat(dir)
+	klog.Infof("has %s been deleted? %t, %v", dir, os.IsNotExist(err), err)
 	return nil
 }
 


### PR DESCRIPTION
/sig storage
/kind bug
/kind flake

@jingxu97 

Debugging https://github.com/kubernetes/kubernetes/issues/96565, leading theory is somehow this `os.RemoveAll()` call is not actually deleting this unmounted directory, but need to confirm here with logs.