### PR TITLE
optimize the logic of noderesources comparision

### DIFF
--- a/pkg/scheduler/framework/plugins/noderesources/fit.go
+++ b/pkg/scheduler/framework/plugins/noderesources/fit.go
@@ -248,7 +248,7 @@ func fitsRequest(podRequest *preFilterState, nodeInfo *framework.NodeInfo, ignor
 		return insufficientResources
 	}
 
-	if nodeInfo.Allocatable.MilliCPU < podRequest.MilliCPU+nodeInfo.Requested.MilliCPU {
+	if podRequest.MilliCPU > (nodeInfo.Allocatable.MilliCPU - nodeInfo.Requested.MilliCPU) {
 		insufficientResources = append(insufficientResources, InsufficientResource{
 			v1.ResourceCPU,
 			"Insufficient cpu",
@@ -257,7 +257,7 @@ func fitsRequest(podRequest *preFilterState, nodeInfo *framework.NodeInfo, ignor
 			nodeInfo.Allocatable.MilliCPU,
 		})
 	}
-	if nodeInfo.Allocatable.Memory < podRequest.Memory+nodeInfo.Requested.Memory {
+	if podRequest.Memory > (nodeInfo.Allocatable.Memory - nodeInfo.Requested.Memory) {
 		insufficientResources = append(insufficientResources, InsufficientResource{
 			v1.ResourceMemory,
 			"Insufficient memory",
@@ -266,7 +266,7 @@ func fitsRequest(podRequest *preFilterState, nodeInfo *framework.NodeInfo, ignor
 			nodeInfo.Allocatable.Memory,
 		})
 	}
-	if nodeInfo.Allocatable.EphemeralStorage < podRequest.EphemeralStorage+nodeInfo.Requested.EphemeralStorage {
+	if podRequest.EphemeralStorage > (nodeInfo.Allocatable.EphemeralStorage - nodeInfo.Requested.EphemeralStorage) {
 		insufficientResources = append(insufficientResources, InsufficientResource{
 			v1.ResourceEphemeralStorage,
 			"Insufficient ephemeral-storage",

--- a/pkg/scheduler/framework/plugins/noderesources/requested_to_capacity_ratio.go
+++ b/pkg/scheduler/framework/plugins/noderesources/requested_to_capacity_ratio.go
@@ -38,9 +38,9 @@ const (
 type functionShape []functionShapePoint
 
 type functionShapePoint struct {
-	// Utilization is function argument.
+	// utilization is function argument.
 	utilization int64
-	// Score is function value.
+	// score is function value.
 	score int64
 }
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
In kube-scheduler, noderesoures plugin, comparion of resources like this:
if nodeInfo.Allocatable.MilliCPU < podRequest.MilliCPU+nodeInfo.Requested.MilliCPU
but this plugin is to deploy pod to node, so we should compare pod request to resources left in node, just like:
if podRequest.MilliCPU > (nodeInfo.Allocatable.MilliCPU - nodeInfo.Requested.MilliCPU)
which express the meaning of noderesources plugin more clearly.

**Which issue(s) this PR fixes**:
no

**Special notes for your reviewer**:
no

**Does this PR introduce a user-facing change?**:
no

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
   optimize the logic of noderesources comparision
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
