### PR TITLE
Kubelet exit on lock contention E2E test

### DIFF
--- a/test/e2e_node/lock_contention_test.go
+++ b/test/e2e_node/lock_contention_test.go
@@ -1,0 +1,45 @@
+// +build linux
+
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2enode
+
+import (
+	"os"
+	"time"
+
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
+	"k8s.io/kubernetes/test/e2e/framework"
+)
+
+var contentionFile = "/var/run/kubelet.lock"
+
+var _ = SIGDescribe("Lock contention [Slow] [Disruptive] [NodeFeature:LockContention]", func() {
+	ginkgo.It("should stop kubelet when the contention file is created.", func() {
+		ginkgo.By("create the lock contention file")
+
+		_, err := os.Create(contentionFile)
+		framework.ExpectNoError(err)
+
+		ginkgo.By("verifying the kubelet is not running anymore.")
+		gomega.Eventually(func() string {
+			_, kubeletService := kubeletRunningStatus()
+			return kubeletService
+		}, 10*time.Second, time.Second).Should(gomega.Not(gomega.HavePrefix("kubelet-")))
+	})
+})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature
/sig node

**What this PR does / why we need it**:
Add E2E `disruptive` tests for Kubelet lock contention flags:
```
--exit-on-lock-contention --lock-file=/var/run/kubelet.lock
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #96766

**Special notes for your reviewer**:
This test will kill Kubelet when the file is created, further `test-infra` setup must isolate the tab to avoid flaky tests due to Kubelet downtime.

`"TEST_ARGS=--restart-kubelet"`

must be added on Prow job with the previous Kubelet flags.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
