### PR TITLE
resume CloudControllerManagerPort to hardcode in port.go

### DIFF
--- a/pkg/cluster/ports/BUILD
+++ b/pkg/cluster/ports/BUILD
@@ -12,9 +12,6 @@ go_library(
         "ports.go",
     ],
     importpath = "k8s.io/kubernetes/pkg/cluster/ports",
-    deps = [
-        "//staging/src/k8s.io/cloud-provider:go_default_library",
-    ],
 )
 
 filegroup(

--- a/pkg/cluster/ports/ports.go
+++ b/pkg/cluster/ports/ports.go
@@ -16,10 +16,8 @@ limitations under the License.
 
 package ports
 
-import (
-	"k8s.io/cloud-provider"
-)
-
+// In this file, we can see all default port of cluster.
+// It's also a important documentation for us. So don't remove them easily.
 const (
 	// ProxyStatusPort is the default port for the proxy metrics server.
 	// May be overridden by a flag at startup.
@@ -45,5 +43,5 @@ const (
 	KubeControllerManagerPort = 10257
 	// CloudControllerManagerPort is the default port for the cloud controller manager server.
 	// This value may be overridden by a flag at startup.
-	CloudControllerManagerPort = cloudprovider.CloudControllerManagerPort
+	CloudControllerManagerPort = 10258
 )


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:

resume `CloudControllerManagerPort` to hardcode 10258 for easy reading.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
