### PR TITLE
(wip) determine the container probing interval based on the previous probe result

### DIFF
--- a/pkg/apis/core/v1/defaults.go
+++ b/pkg/apis/core/v1/defaults.go
@@ -237,6 +237,9 @@ func SetDefaults_Probe(obj *v1.Probe) {
 	if obj.PeriodSeconds == 0 {
 		obj.PeriodSeconds = 10
 	}
+	if obj.FailedPeriodSeconds == 0 {
+		obj.FailedPeriodSeconds = obj.PeriodSeconds
+	}
 	if obj.SuccessThreshold == 0 {
 		obj.SuccessThreshold = 1
 	}

--- a/pkg/kubelet/prober/common_test.go
+++ b/pkg/kubelet/prober/common_test.go
@@ -19,6 +19,7 @@ package prober
 import (
 	"reflect"
 	"sync"
+	"time"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -150,4 +151,8 @@ func (p *syncExecProber) Probe(cmd exec.Cmd) (probe.Result, string, error) {
 	p.RLock()
 	defer p.RUnlock()
 	return p.fakeExecProber.Probe(cmd)
+}
+
+func secondsToDuration(seconds int32) time.Duration {
+	return time.Duration(seconds) * time.Second
 }

--- a/pkg/kubelet/prober/worker_test.go
+++ b/pkg/kubelet/prober/worker_test.go
@@ -166,9 +166,9 @@ func TestNextProbeTime(t *testing.T) {
 			FailedPeriodSeconds: 1,
 		}
 		w := newTestWorker(m, probeType, p)
-		require.Equal(t, secondsToDuration(p.PeriodSeconds), w.nextProbeTime())
+		require.Equal(t, secondsToDuration(p.PeriodSeconds), w.nextProbeInterval())
 		w.resultsManager.Set(w.containerID, results.Failure, w.pod)
-		require.Equal(t, secondsToDuration(p.FailedPeriodSeconds), w.nextProbeTime())
+		require.Equal(t, secondsToDuration(p.FailedPeriodSeconds), w.nextProbeInterval())
 	}
 }
 

--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -2111,7 +2111,7 @@ type Probe struct {
 	// How often (in seconds) to perform the probe if the last probe failed.
 	// Defaults to the value of PeriodSeconds
 	// +optional
-	FailedPeriodSeconds int32
+	FailedPeriodSeconds int32 `json:"failedPeriodSeconds,omitempty" protobuf:"varint,7,opt,name=failedPeriodSeconds"`
 	// Minimum consecutive successes for the probe to be considered successful after having failed.
 	// Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
 	// +optional

--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -2108,6 +2108,10 @@ type Probe struct {
 	// Default to 10 seconds. Minimum value is 1.
 	// +optional
 	PeriodSeconds int32 `json:"periodSeconds,omitempty" protobuf:"varint,4,opt,name=periodSeconds"`
+	// How often (in seconds) to perform the probe if the last probe failed.
+	// Defaults to the value of PeriodSeconds
+	// +optional
+	FailedPeriodSeconds int32
 	// Minimum consecutive successes for the probe to be considered successful after having failed.
 	// Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
 	// +optional


### PR DESCRIPTION
Signed-off-by: Clark McCauley <clarkmccauley@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature 

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
This PR changes the API of v1.Probe to support a new field called `FailedPeriodSeconds`. It allows a user to set the probing interval that should be used when the previous probe result is failing. The real-world use cases are provided in #96731. 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #96731

**Special notes for your reviewer**:
I haven't made changes to the Core API before, and would need a little guidance on generating the API conversion functions.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
This change adds a `FailedPeriodSeconds` to the `v1.Probe` API indicating the probing interval that should be used when the previous probe result is failing. By default it is set to equal `PeriodSeconds`. No changes to the v1.Probe usage are required.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
This PR would introduce changes to the usage documentation. I would be happy to provide the documentation if this PR gets closer to approval.

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
