### PR TITLE
e2e test regression image multiarch

### DIFF
--- a/test/images/regression-issue-74839/BASEIMAGE
+++ b/test/images/regression-issue-74839/BASEIMAGE
@@ -1,0 +1,5 @@
+linux/amd64=k8s.gcr.io/debian-base-amd64:v1.0.0
+linux/arm=k8s.gcr.io/debian-base-arm:v1.0.0
+linux/arm64=k8s.gcr.io/debian-base-arm64:v1.0.0
+linux/ppc64le=k8s.gcr.io/debian-base-ppc64le:v1.0.0
+linux/s390x=k8s.gcr.io/debian-base-s390x:v1.0.0

--- a/test/images/regression-issue-74839/Dockerfile
+++ b/test/images/regression-issue-74839/Dockerfile
@@ -12,7 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM gcr.io/distroless/base
+ARG BASEIMAGE
+FROM $BASEIMAGE
+
+CROSS_BUILD_COPY qemu-QEMUARCH-static /usr/bin/
 
 ADD regression-issue-74839 /regression-issue-74839
 


### PR DESCRIPTION

**What type of PR is this?**

As part of fixing   #93281 with https://github.com/kubernetes/kubernetes/pull/95351, we need to promote the new image used in the test first.

This PR it also builds it for multiple architectures

/kind cleanup
/kind failing-test


```release-note
NONE
```
