### PR TITLE
Fixed a bug where initialPopulationCount should be based on the key length not list size in DeltaFIFO#Replace()

### DIFF
--- a/staging/src/k8s.io/client-go/tools/cache/delta_fifo.go
+++ b/staging/src/k8s.io/client-go/tools/cache/delta_fifo.go
@@ -572,7 +572,7 @@ func (f *DeltaFIFO) Replace(list []interface{}, resourceVersion string) error {
 			f.populated = true
 			// While there shouldn't be any queued deletions in the initial
 			// population of the queue, it's better to be on the safe side.
-			f.initialPopulationCount = len(list) + queuedDeletions
+			f.initialPopulationCount = keys.Len() + queuedDeletions
 		}
 
 		return nil
@@ -602,7 +602,7 @@ func (f *DeltaFIFO) Replace(list []interface{}, resourceVersion string) error {
 
 	if !f.populated {
 		f.populated = true
-		f.initialPopulationCount = len(list) + queuedDeletions
+		f.initialPopulationCount = keys.Len() + queuedDeletions
 	}
 
 	return nil

--- a/staging/src/k8s.io/client-go/tools/cache/delta_fifo_test.go
+++ b/staging/src/k8s.io/client-go/tools/cache/delta_fifo_test.go
@@ -633,6 +633,15 @@ func TestDeltaFIFO_HasSynced(t *testing.T) {
 			},
 			expectedSynced: true,
 		},
+		{
+			// This test case won't happen in practice since a Reflector, the only producer for delta_fifo today, always passes a complete snapshot consistent in time;
+			// there cannot be duplicate keys in the list or apiserver is broken.
+			actions: []func(f *DeltaFIFO){
+				func(f *DeltaFIFO) { f.Replace([]interface{}{mkFifoObj("a", 1), mkFifoObj("a", 2)}, "0") },
+				func(f *DeltaFIFO) { Pop(f) },
+			},
+			expectedSynced: true,
+		},
 	}
 
 	for i, test := range tests {


### PR DESCRIPTION

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:
Fixed a bug where initialPopulationCount should be based on the key length not list size in DeltaFIFO#Replace()

**Which issue(s) this PR fixes**:
NONE

**Special notes for your reviewer**:
```
func (f *DeltaFIFO) Pop(process PopProcessFunc) (interface{}, error) {
                ...
		id := f.queue[0]
		f.queue = f.queue[1:]
		if f.initialPopulationCount > 0 {
			f.initialPopulationCount--       # One key of Deltas is popped off. 
		}
```

In practice, this bug is harmless since the keys of each element in the list to replace should be unique. 

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
