### PR TITLE
Set ContainerStatuses[i].Ready to false when container not started

### DIFF
--- a/pkg/kubelet/prober/prober_manager.go
+++ b/pkg/kubelet/prober/prober_manager.go
@@ -247,9 +247,7 @@ func (m *manager) UpdatePodStatus(podUID types.UID, podStatus *v1.PodStatus) {
 
 		if started {
 			var ready bool
-			if c.State.Running == nil {
-				ready = false
-			} else if result, ok := m.readinessManager.Get(kubecontainer.ParseContainerID(c.ContainerID)); ok {
+			if result, ok := m.readinessManager.Get(kubecontainer.ParseContainerID(c.ContainerID)); ok {
 				ready = result == results.Success
 			} else {
 				// The check whether there is a probe which hasn't run yet.
@@ -257,6 +255,8 @@ func (m *manager) UpdatePodStatus(podUID types.UID, podStatus *v1.PodStatus) {
 				ready = !exists
 			}
 			podStatus.ContainerStatuses[i].Ready = ready
+		} else {
+			podStatus.ContainerStatuses[i].Ready = false
 		}
 	}
 	// init containers are ready if they have exited with success or if a readiness probe has


### PR DESCRIPTION
What type of PR is this?
/kind bug

What this PR does / why we need it:
The ContainerStatuses of pod does not change to not ready when the container without readnessprobe exits abnormally

Which issue(s) this PR fixes:
#96804

Special notes for your reviewer:

Does this PR introduce a user-facing change?:
NONE

Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.: