### PR TITLE
Automated cherry pick of #96777: fix: concurrent map writes error in VolumeBinding plugin during Filter

### DIFF
--- a/pkg/scheduler/framework/plugins/volumebinding/volume_binding.go
+++ b/pkg/scheduler/framework/plugins/volumebinding/volume_binding.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
@@ -51,6 +52,7 @@ type stateData struct {
 	// phase for each node
 	// it's initialized in the PreFilter phase
 	podVolumesByNode map[string]*scheduling.PodVolumes
+	sync.Mutex
 }
 
 func (d *stateData) Clone() framework.StateData {
@@ -174,9 +176,10 @@ func (pl *VolumeBinding) Filter(ctx context.Context, cs *framework.CycleState, p
 		return status
 	}
 
-	cs.Lock()
+	// multiple goroutines call `Filter` on different nodes simultaneously and the `CycleState` may be duplicated, so we must use a local lock here
+	state.Lock()
 	state.podVolumesByNode[node.Name] = podVolumes
-	cs.Unlock()
+	state.Unlock()
 	return nil
 }
 


### PR DESCRIPTION
Cherry pick of #96777 on release-1.19.

#96777 : fix: concurrent map writes error in VolumeBinding plugin during Filter

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Fixes a regression in 1.19 where concurrent map write can be encountered in the scheduler in the VolumeBinding plugin filter
```
