### PR TITLE
Comment default behaviour of kubectl drain.GracePeriodSeconds

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/drain/drain.go
+++ b/staging/src/k8s.io/kubectl/pkg/drain/drain.go
@@ -46,10 +46,15 @@ const (
 
 // Helper contains the parameters to control the behaviour of drainer
 type Helper struct {
-	Ctx                 context.Context
-	Client              kubernetes.Interface
-	Force               bool
-	GracePeriodSeconds  int
+	Ctx    context.Context
+	Client kubernetes.Interface
+	Force  bool
+
+	// GracePeriodSeconds is how long to wait for a pod to terminate.
+	// IMPORTANT: 0 means "delete immediately"; set to a negative value
+	// to use the pod's terminationGracePeriodSeconds.
+	GracePeriodSeconds int
+
 	IgnoreAllDaemonSets bool
 	Timeout             time.Duration
 	DeleteEmptyDirData  bool


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

It took me a while to spot this subtlety.

**Which issue(s) this PR fixes**:
Relates to https://github.com/kubernetes/kubectl/issues/982

```release-note
NONE
```
