### PR TITLE
cluster/gce: allow setting custom API rate limits

### DIFF
--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -2065,6 +2065,12 @@ function start-kube-controller-manager {
   if [[ -n "${RUN_CONTROLLERS:-}" ]]; then
     params+=("--controllers=${RUN_CONTROLLERS}")
   fi
+  if [[ -n "${KUBE_CONTROLLER_MANAGER_API_QPS:-}" ]]; then
+    params+=("--kube-api-qps=${KUBE_CONTROLLER_MANAGER_API_QPS}")
+  fi
+  if [[ -n "${KUBE_CONTROLLER_MANAGER_API_BURST:-}" ]]; then
+    params+=("--kube-api-burst=${KUBE_CONTROLLER_MANAGER_API_BURST}")
+  fi
 
   local -r kube_rc_docker_tag=$(cat /home/kubernetes/kube-docker-files/kube-controller-manager.docker_tag)
   local container_env=""
@@ -2135,6 +2141,15 @@ function start-kube-scheduler {
       params+=("--use-legacy-policy-config")
       params+=("--policy-config-file=/etc/srv/kubernetes/kube-scheduler/policy-config")
     fi
+  fi
+
+  # Set rate limit parameters (QPS and burst limits) for the scheduler when
+  # talking to the API server.
+  if [[ -n "${KUBE_SCHEDULER_API_QPS:-}" ]]; then
+    params+=("--kube-api-qps=${KUBE_SCHEDULER_API_QPS}")
+  fi
+  if [[ -n "${KUBE_SCHEDULER_API_BURST:-}" ]]; then
+    params+=("--kube-api-burst=${KUBE_SCHEDULER_API_BURST}")
   fi
 
   local paramstring

--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -1245,6 +1245,26 @@ EOF
     cat >>"$file" <<EOF
 EOF
   fi
+  if [ -n "${KUBE_SCHEDULER_API_QPS:-}" ]; then
+    cat >>"$file" <<EOF
+KUBE_SCHEDULER_API_QPS: $(yaml-quote "${KUBE_SCHEDULER_API_QPS}")
+EOF
+  fi
+  if [ -n "${KUBE_SCHEDULER_API_BURST:-}" ]; then
+    cat >>"$file" <<EOF
+KUBE_SCHEDULER_API_BURST: $(yaml-quote "${KUBE_SCHEDULER_API_BURST}")
+EOF
+  fi
+  if [ -n "${KUBE_CONTROLLER_MANAGER_API_QPS:-}" ]; then
+    cat >>"$file" <<EOF
+KUBE_CONTROLLER_MANAGER_API_QPS: $(yaml-quote "${KUBE_CONTROLLER_MANAGER_API_QPS}")
+EOF
+  fi
+  if [ -n "${KUBE_CONTROLLER_MANAGER_API_BURST:-}" ]; then
+    cat >>"$file" <<EOF
+KUBE_CONTROLLER_MANAGER_API_BURST: $(yaml-quote "${KUBE_CONTROLLER_MANAGER_API_BURST}")
+EOF
+  fi
   if [ -n "${KUBE_APISERVER_REQUEST_TIMEOUT:-}" ]; then
     cat >>"$file" <<EOF
 KUBE_APISERVER_REQUEST_TIMEOUT: $(yaml-quote "${KUBE_APISERVER_REQUEST_TIMEOUT}")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**: The controller manager and the scheduler have command-line options to set QPS limits, but they were missing from the cluster up scripts. sig/scheduling is interested in improving the scheduler's overall throughput in future versions and this change allows us to do experiments in test-infra with larger QPS limits.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

cc @ahg-g 
/sig scheduling