### PR TITLE
Use volumeHandle as PV name when translating EBS inline volume

### DIFF
--- a/staging/src/k8s.io/csi-translation-lib/plugins/aws_ebs.go
+++ b/staging/src/k8s.io/csi-translation-lib/plugins/aws_ebs.go
@@ -98,7 +98,7 @@ func (t *awsElasticBlockStoreCSITranslator) TranslateInTreeInlineVolumeToCSI(vol
 		ObjectMeta: metav1.ObjectMeta{
 			// Must be unique per disk as it is used as the unique part of the
 			// staging path
-			Name: fmt.Sprintf("%s-%s", AWSEBSDriverName, ebsSource.VolumeID),
+			Name: fmt.Sprintf("%s-%s", AWSEBSDriverName, volumeHandle),
 		},
 		Spec: v1.PersistentVolumeSpec{
 			PersistentVolumeSource: v1.PersistentVolumeSource{


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**: EBS CSI inline migration/translation does not work if the volumeID is in the "uri" format and has a colon in it, like 
```
  volumes:
  - awsElasticBlockStore:
      fsType: ext4
      volumeID: aws://us-west-2a/vol-0818b380d4fc22bec
    name: aws-volume-0
```
1. This translation function sets PV name to `ebs.csi.aws.com-aws://us-west-2a/vol-0818b380d4fc22bec` which is not a valid object name.
2. spec.Name() which points to this invalid PV name is set as CSI mounter's specVolumeID.https://github.com/kubernetes/kubernetes/blob/6d5cb36d36f34cb4f5735b6adcd5ea8ebb4440ba/pkg/volume/csi/csi_plugin.go#L430
3. CSI mounter returns a path including specVolumeID `/var/lib/kubelet/pods/017390c5-0c21-404b-a850-228c4311dd36/volumes/kubernetes.io~csi/ebs.csi.aws.com-aws:~~us-west-2a~vol-0a4910df43136ea3e/mount` https://github.com/kubernetes/kubernetes/blob/6d5cb36d36f34cb4f5735b6adcd5ea8ebb4440ba/pkg/volume/csi/csi_mounter.go#L87
4. kubelet tries to create the container with this mount and since it contains a colon, it fails the assumption that the mount will be of format `host path:container path:mode` https://github.com/kubernetes/kubernetes/blob/cea1d4e20b4a7886d8ff65f34c6d4f95efcb4742/pkg/kubelet/dockershim/helpers.go#L120 resulting in this error from container runtime (docker):
```

    state:
      waiting:
        message: 'Error response from daemon: invalid mode: /opt/0'
        reason: CreateContainerError
```

**Which issue(s) this PR fixes**:


**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fix CSI-migrated inline EBS volumes failing to mount if their volumeID is prefixed by aws://
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
