### PR TITLE
kubelet/eviction: eliminate redundant allocations when handling eventfd

### DIFF
--- a/pkg/kubelet/eviction/threshold_notifier_linux.go
+++ b/pkg/kubelet/eviction/threshold_notifier_linux.go
@@ -107,6 +107,7 @@ func (n *linuxCgroupNotifier) Start(eventCh chan<- struct{}) {
 		klog.Warningf("eviction manager: error adding epoll eventfd: %v", err)
 		return
 	}
+	buf := make([]byte, eventSize)
 	for {
 		select {
 		case <-n.stop:
@@ -122,7 +123,6 @@ func (n *linuxCgroupNotifier) Start(eventCh chan<- struct{}) {
 			continue
 		}
 		// Consume the event from the eventfd
-		buf := make([]byte, eventSize)
 		_, err = unix.Read(n.eventfd, buf)
 		if err != nil {
 			klog.Warningf("eviction manager: error reading memcg events: %v", err)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Eliminate the unnecessary memory allocations when reading from eventfd.

**Which issue(s) this PR fixes**:

None

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs
NONE
```
