### PR TITLE
vendor: update cAdvisor to v0.38.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -53,7 +53,7 @@ require (
 	github.com/gogo/protobuf v1.3.1
 	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e
 	github.com/golang/mock v1.4.1
-	github.com/google/cadvisor v0.38.4
+	github.com/google/cadvisor v0.38.5
 	github.com/google/go-cmp v0.5.2
 	github.com/google/gofuzz v1.1.0
 	github.com/google/uuid v1.1.2
@@ -281,7 +281,7 @@ replace (
 	github.com/golangplus/fmt => github.com/golangplus/fmt v0.0.0-20150411045040-2a5d6d7d2995
 	github.com/golangplus/testing => github.com/golangplus/testing v0.0.0-20180327235837-af21d9c3145e
 	github.com/google/btree => github.com/google/btree v1.0.0
-	github.com/google/cadvisor => github.com/google/cadvisor v0.38.4
+	github.com/google/cadvisor => github.com/google/cadvisor v0.38.5
 	github.com/google/go-cmp => github.com/google/go-cmp v0.5.2
 	github.com/google/gofuzz => github.com/google/gofuzz v1.1.0
 	github.com/google/martian => github.com/google/martian v2.1.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -234,8 +234,8 @@ github.com/golangplus/testing v0.0.0-20180327235837-af21d9c3145e h1:KhcknUwkWHKZ
 github.com/golangplus/testing v0.0.0-20180327235837-af21d9c3145e/go.mod h1:0AA//k/eakGydO4jKRoRL2j92ZKSzTgj9tclaCrvXHk=
 github.com/google/btree v1.0.0 h1:0udJVsspx3VBr5FwtLhQQtuAsVc79tTq0ocGIPAU6qo=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
-github.com/google/cadvisor v0.38.4 h1:16HEU2icAgbzUSdrKZvb1dMRhvaqvaGyHnDy9nlbwts=
-github.com/google/cadvisor v0.38.4/go.mod h1:1OFB9sOOMkBdUBGCO/1SArawTnDscgMzTodacVDe8mA=
+github.com/google/cadvisor v0.38.5 h1:XOvqjL2+xMEuDORcLMv77NystZvQB7YgGxcKpRul/vE=
+github.com/google/cadvisor v0.38.5/go.mod h1:1OFB9sOOMkBdUBGCO/1SArawTnDscgMzTodacVDe8mA=
 github.com/google/go-cmp v0.5.2 h1:X2ev0eStA3AbceY54o37/0PQ/UWqKEiiO2dKL5OPaFM=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/gofuzz v1.1.0 h1:Hsa8mG0dQ46ij8Sl2AYJDUv1oA9/d6Vk+3LG99Oe02g=

--- a/vendor/github.com/google/cadvisor/accelerators/nvidia.go
+++ b/vendor/github.com/google/cadvisor/accelerators/nvidia.go
@@ -58,9 +58,7 @@ func NewNvidiaManager(includedMetrics container.MetricSet) stats.Manager {
 	manager := &nvidiaManager{}
 	err := manager.setup()
 	if err != nil {
-		klog.Warningf("NVIDIA GPU metrics will not be available: %s", err)
-		manager.Destroy()
-		return &stats.NoopManager{}
+		klog.V(2).Infof("NVIDIA setup failed: %s", err)
 	}
 	return manager
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -521,9 +521,9 @@ github.com/golang/protobuf/ptypes/wrappers
 # github.com/google/btree v1.0.0 => github.com/google/btree v1.0.0
 github.com/google/btree
 # github.com/google/btree => github.com/google/btree v1.0.0
-# github.com/google/cadvisor v0.38.4 => github.com/google/cadvisor v0.38.4
+# github.com/google/cadvisor v0.38.5 => github.com/google/cadvisor v0.38.5
 ## explicit
-# github.com/google/cadvisor => github.com/google/cadvisor v0.38.4
+# github.com/google/cadvisor => github.com/google/cadvisor v0.38.5
 github.com/google/cadvisor/accelerators
 github.com/google/cadvisor/cache/memory
 github.com/google/cadvisor/client/v2


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug


**What this PR does / why we need it**:

This PR is needed to bump cAdvisor version to v0.38.5 which fixes an issue initializing `NVML` which can result in cAdvisor failing to report GPU metrics. 

Ref:
* cAdvisor issue -- https://github.com/google/cadvisor/pull/2732
* k8s failing test issue --  https://github.com/kubernetes/kubernetes/issues/96519#issuecomment-727151810
* Related cherrypick to release-1.19 for the same issue -- https://github.com/kubernetes/kubernetes/pull/96695

**Special notes for your reviewer**:

Ran the following:

```
$ hack/pin-dependency.sh github.com/google/cadvisor v0.38.5
$ hack/update-vendor.sh
$ hack/lint-dependencies.sh
All pinned versions of checked dependencies match their preferred version.
```

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```