### PR TITLE
Add performance benchmark for the preemption with volume

### DIFF
--- a/test/integration/scheduler_perf/config/performance-config.yaml
+++ b/test/integration/scheduler_perf/config/performance-config.yaml
@@ -396,6 +396,31 @@
       initPods: 20000
       measurePods: 5000
 
+- name: PreemptionPVs
+  workloadTemplate:
+  - opcode: createNodes
+    countParam: $initNodes
+  - opcode: createPods
+    countParam: $initPods
+    podTemplatePath: config/pod-low-priority.yaml
+  - opcode: createPods
+    countParam: $measurePods
+    podTemplatePath: config/pod-high-priority.yaml
+    persistentVolumeTemplatePath: config/pv-aws.yaml
+    persistentVolumeClaimTemplatePath: config/pvc.yaml
+    collectMetrics: true
+  workloads:
+  - name: 500Nodes
+    params:
+      initNodes: 500
+      initPods: 2000
+      measurePods: 500
+  - name: 5000Nodes
+    params:
+      initNodes: 5000
+      initPods: 20000
+      measurePods: 5000
+
 - name: Unschedulable
   workloadTemplate:
   - opcode: createNodes


### PR DESCRIPTION
If node has nominated Pods associated, the `CycleState` will be expanded to include pod information from nominated node, the `CycleState` is a clone of original `CycleState`. As to `VolumeBinding` plugin, the `stateData` has a map field, and map is a reference which means we need to have a deep copy to make sure it won't collide with other goroutines.

Signed-off-by: Dave Chen <dave.chen@arm.com>

please see details here: https://github.com/kubernetes/kubernetes/issues/96832

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

Add one of the following kinds:
/kind bug



**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes 

**Special notes for your reviewer**:
check with "-race" for the testcase of `PreemptionPV` will reveal another data race which related with GVK, see code here https://github.com/kubernetes/kubernetes/blob/ad2bf99f9b8f27113cd3b0c9e0ad72e568947e43/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/meta.go#L122-L129
 
However, this doesn't prevent us from executing the testcase successfully, we can fix it in another PR or hold on until we see some failure around this race.
```
go test -race k8s.io/kubernetes/test/integration/scheduler_perf  -test.bench="BenchmarkPerfScheduling/PreemptionPV/500Nodes/2000InitPods/500PodsToSchedule" -alsologtostderr=false -logtostderr=false -test.benchtime=1ns
```

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
