### PR TITLE
Remove unnecessary snapshot ability check for external driver

### DIFF
--- a/test/e2e/storage/external/external.go
+++ b/test/e2e/storage/external/external.go
@@ -247,18 +247,6 @@ func (d *driverDefinition) SkipUnsupportedTest(pattern testpatterns.TestPattern)
 		e2eskipper.Skipf("Driver %q does not support volume type %q - skipping", d.DriverInfo.Name, pattern.VolType)
 	}
 
-	supported = false
-	switch pattern.SnapshotType {
-	case "":
-		supported = true
-	case testpatterns.DynamicCreatedSnapshot, testpatterns.PreprovisionedCreatedSnapshot:
-		if d.SnapshotClass.FromName || d.SnapshotClass.FromFile != "" || d.SnapshotClass.FromExistingClassName != "" {
-			supported = true
-		}
-	}
-	if !supported {
-		e2eskipper.Skipf("Driver %q does not support snapshot type %q - skipping", d.DriverInfo.Name, pattern.SnapshotType)
-	}
 }
 
 func (d *driverDefinition) GetDynamicProvisionStorageClass(e2econfig *testsuites.PerTestConfig, fsType string) *storagev1.StorageClass {


### PR DESCRIPTION
It is unnecessary to check snapshot ability for external driver since the snapshottable testsuite has already checked the snapshot ability before executing the tests. 

Adding this check in the driver will unexpected skip dynamic default fs testpattern since right now it has snapshottype. So drivers without snapshot ability cannot execute some non-snapshot related testsuites.

```release-note
NONE
```

/assign @jingxu97 
/cc @msau42 
/sig storage
/area testing