### PR TITLE
fix kube-dns federations check in kubeadm upgrade dns check preflight

### DIFF
--- a/cmd/kubeadm/app/phases/upgrade/preflight.go
+++ b/cmd/kubeadm/app/phases/upgrade/preflight.go
@@ -126,17 +126,17 @@ func checkMigration(client clientset.Interface) error {
 // checkKubeDNSConfigMap checks if the translation of kube-dns to CoreDNS ConfigMap is supported
 func checkKubeDNSConfigMap(client clientset.Interface) error {
 	kubeDNSConfigMap, err := client.CoreV1().ConfigMaps(metav1.NamespaceSystem).Get(context.TODO(), kubeadmconstants.KubeDNSConfigMap, metav1.GetOptions{})
-	if err != nil && !apierrors.IsNotFound(err) {
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
 		return err
-	}
-	if kubeDNSConfigMap == nil {
-		return nil
 	}
 
 	if _, ok := kubeDNSConfigMap.Data["federations"]; ok {
 		klog.V(1).Infoln("CoreDNS no longer supports Federation and " +
 			"hence will not translate the federation data from kube-dns to CoreDNS ConfigMap")
-		return errors.Wrap(err, "kube-dns Federation data will not be translated")
+		return errors.New("kube-dns Federation data will not be translated")
 	}
 	return nil
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
During looking into #96833 ,  I find that the logic will not work even I have a configmap named kube-dns with federations configured.

When kube-dns configmap found in your cluster,  the err would be nil after getting configmap.
```
//err is nil
errors.Wrap(err, "xxxx")
```
errors return nil when the err is nil, no matter what message is.

**So the function will always return nil.**

**Which issue(s) this PR fixes**:
During looking into #96833

**Special notes for your reviewer**:

BTW, empty configmap would be something like
```
&ConfigMap{ObjectMeta:{      0 0001-01-01 00:00:00 +0000 UTC <nil> <nil> map[] map[] [] []  []},Data:map[string]string{},BinaryData:map[string][]byte{},Immutable:nil,}
```
Not nil. 

`cm != nil ` not equals `errors.isNotFound()`

I fixed this as well. Of course, this is a small probability error like timeout.

**Does this PR introduce a user-facing change?**:

```release-note
None 
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs
None
```
