### PR TITLE
Adding support for ALPN policy for AWS NLBs

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/aws/aws.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/aws/aws.go
@@ -235,7 +235,7 @@ const ServiceAnnotationLoadBalancerTargetNodeLabels = "service.beta.kubernetes.i
 
 // ServiceAnnotationLoadBalancerALPNPolicy is the annotation used on the
 // service to specify ALPN policy. Supported values are:
-// `http1only`, `http2only`, `http2optional`, `http2preferred`.
+// `HTTP1Only`, `HTTP2Only`, `HTTP2Optional`, `HTTP2Preferred`.
 // Only supported on elbv2 (NLB) with SSL listeners.
 const ServiceAnnotationLoadBalancerALPNPolicy = "service.beta.kubernetes.io/aws-load-balancer-alpn-policy"
 

--- a/staging/src/k8s.io/legacy-cloud-providers/aws/aws.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/aws/aws.go
@@ -233,6 +233,12 @@ const ServiceAnnotationLoadBalancerEIPAllocations = "service.beta.kubernetes.io/
 // For example: "Key1=Val1,Key2=Val2,KeyNoVal1=,KeyNoVal2"
 const ServiceAnnotationLoadBalancerTargetNodeLabels = "service.beta.kubernetes.io/aws-load-balancer-target-node-labels"
 
+// ServiceAnnotationLoadBalancerALPNPolicy is the annotation used on the
+// service to specify ALPN policy. Supported values are:
+// `http1only`, `http2only`, `http2optional`, `http2preferred`.
+// Only supported on elbv2 (NLB) with SSL listeners.
+const ServiceAnnotationLoadBalancerALPNPolicy = "service.beta.kubernetes.io/aws-load-balancer-alpn-policy"
+
 // Event key when a volume is stuck on attaching state when being attached to a volume
 const volumeAttachmentStuck = "VolumeAttachmentStuck"
 
@@ -3828,6 +3834,7 @@ func (c *Cloud) EnsureLoadBalancer(ctx context.Context, clusterName string, apiS
 				portMapping.FrontendProtocol = elbv2.ProtocolEnumTls
 				portMapping.SSLCertificateARN = certificateARN
 				portMapping.SSLPolicy = annotations[ServiceAnnotationLoadBalancerSSLNegotiationPolicy]
+				portMapping.ALPNPolicy = annotations[ServiceAnnotationLoadBalancerALPNPolicy]
 
 				if backendProtocol := annotations[ServiceAnnotationLoadBalancerBEProtocol]; backendProtocol == "ssl" {
 					portMapping.TrafficProtocol = elbv2.ProtocolEnumTls

--- a/staging/src/k8s.io/legacy-cloud-providers/aws/aws_loadbalancer.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/aws/aws_loadbalancer.go
@@ -32,9 +32,9 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/elb"
 	"github.com/aws/aws-sdk-go/service/elbv2"
-	v1 "k8s.io/api/core/v1"
 	"k8s.io/klog/v2"
 
+	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 )


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
It implements support for setting ALPN policy on listeners of AWS NLB. Currently, if you want to prefer HTTP/2, you'll have to set it via the console.

**Which issue(s) this PR fixes**:
Fixes #92653 

**Special notes for your reviewer**:
I haven't managed to find a place in which I could test this change, so some guidance would be appreciated.

**Does this PR introduce a user-facing change?**:
```release-note
Setting of the ALPN policy on AWS NLBs is now possible with the new "service.beta.kubernetes.io/aws-load-balancer-alpn-policy" service annotation.
"action required"
Users who previously set the policy manually are required to add this annotation, in order to avoid setting it to back to "None"
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
```docs

```
-->
