### PR TITLE
fix bug of Unreachable node no longer gets Unreachable taint with NoExecute node when kubelet has been stopped

### DIFF
--- a/pkg/controller/nodelifecycle/node_lifecycle_controller.go
+++ b/pkg/controller/nodelifecycle/node_lifecycle_controller.go
@@ -1477,13 +1477,13 @@ func (nc *Controller) markNodeForTainting(node *v1.Node, status v1.ConditionStat
 	defer nc.evictorLock.Unlock()
 	if status == v1.ConditionFalse {
 		if !taintutils.TaintExists(node.Spec.Taints, NotReadyTaintTemplate) {
-			nc.zoneNoExecuteTainter[utilnode.GetZoneKey(node)].SetRemove(node.Name)
+			nc.zoneNoExecuteTainter[utilnode.GetZoneKey(node)].Remove(node.Name)
 		}
 	}
 
 	if status == v1.ConditionUnknown {
 		if !taintutils.TaintExists(node.Spec.Taints, UnreachableTaintTemplate) {
-			nc.zoneNoExecuteTainter[utilnode.GetZoneKey(node)].SetRemove(node.Name)
+			nc.zoneNoExecuteTainter[utilnode.GetZoneKey(node)].Remove(node.Name)
 		}
 	}
 

--- a/pkg/controller/nodelifecycle/scheduler/rate_limited_queue.go
+++ b/pkg/controller/nodelifecycle/scheduler/rate_limited_queue.go
@@ -194,15 +194,6 @@ func (q *UniqueQueue) Clear() {
 	}
 }
 
-// SetRemove remove value from the set if value existed
-func (q *UniqueQueue) SetRemove(value string) {
-	q.lock.Lock()
-	defer q.lock.Unlock()
-	if q.set.Has(value) {
-		q.set.Delete(value)
-	}
-}
-
 // RateLimitedTimedQueue is a unique item priority queue ordered by
 // the expected next time of execution. It is also rate limited.
 type RateLimitedTimedQueue struct {
@@ -287,11 +278,6 @@ func (q *RateLimitedTimedQueue) Remove(value string) bool {
 // Clear removes all items from the queue
 func (q *RateLimitedTimedQueue) Clear() {
 	q.queue.Clear()
-}
-
-// SetRemove remove value from the set of the queue
-func (q *RateLimitedTimedQueue) SetRemove(value string) {
-	q.queue.SetRemove(value)
 }
 
 // SwapLimiter safely swaps current limiter for this queue with the

--- a/pkg/controller/nodelifecycle/scheduler/rate_limited_queue_test.go
+++ b/pkg/controller/nodelifecycle/scheduler/rate_limited_queue_test.go
@@ -282,17 +282,6 @@ func TestClear(t *testing.T) {
 	}
 }
 
-func TestSetRemove(t *testing.T) {
-	evictor := NewRateLimitedTimedQueue(flowcontrol.NewFakeAlwaysRateLimiter())
-	evictor.Add("first", "11111")
-
-	evictor.SetRemove("first")
-
-	if evictor.queue.set.Len() != 0 {
-		t.Fatalf("SetRemove should remove element from the set.")
-	}
-}
-
 func TestSwapLimiter(t *testing.T) {
 	evictor := NewRateLimitedTimedQueue(flowcontrol.NewFakeAlwaysRateLimiter())
 	fakeAlways := flowcontrol.NewFakeAlwaysRateLimiter()


### PR DESCRIPTION
What type of PR is this?
/kind bug

What this PR does / why we need it:
The kube-controller updates the node status every 5s, and will process the taint request every 10s. If nc.zoneNoExecuteTainter has cached the taint information of a node, after the markNodeForTainting method is executed again, there will be duplicates in the queue of zoneNoExecuteTainter, doNoExecuteTaintingPass will always read old data of the node,  so NoExecute won’t been tainted.  

When the nodes are joined in batches, the probability of this problem is 100%, this is a serious problem.

Which issue(s) this PR fixes:
#94183
#96183

Special notes for your reviewer:

Does this PR introduce a user-facing change?:
NONE

Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.: