### PR TITLE
Show the available container names when the user misses the container name in exec

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/exec/exec.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/exec/exec.go
@@ -326,10 +326,8 @@ func (p *ExecOptions) Run() error {
 	containerName := p.ContainerName
 	if len(containerName) == 0 {
 		if len(pod.Spec.Containers) > 1 {
-			fmt.Fprintf(p.ErrOut, "Defaulting container name to %s.\n", pod.Spec.Containers[0].Name)
-			if p.EnableSuggestedCmdUsage {
-				fmt.Fprintf(p.ErrOut, "Use '%s describe pod/%s -n %s' to see all of the containers in this pod.\n", p.ParentCommandName, pod.Name, p.Namespace)
-			}
+			containerNames := polymorphichelpers.getContainerNames(pod.Spec.Containers)
+			fmt.Fprintf(p.ErrOut, "Defaulting container name to %s; Available containers: [%s]\n", pod.Spec.Containers[0].Name, containerNames)
 		}
 		containerName = pod.Spec.Containers[0].Name
 	}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/exec/exec.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/exec/exec.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"net/url"
 	"time"
+	"strings"
 
 	dockerterm "github.com/moby/term"
 	"github.com/spf13/cobra"

--- a/staging/src/k8s.io/kubectl/pkg/cmd/exec/exec.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/exec/exec.go
@@ -286,6 +286,15 @@ func (o *StreamOptions) SetupTTY() term.TTY {
 	return t
 }
 
+// getContainerNames returns a formatted string containing the container names
+func getContainerNames(containers []corev1.Container) string {
+	names := []string{}
+	for _, c := range containers {
+		names = append(names, c.Name)
+	}
+	return strings.Join(names, " ")
+}
+
 // Run executes a validated remote execution against a pod.
 func (p *ExecOptions) Run() error {
 	var err error
@@ -326,7 +335,7 @@ func (p *ExecOptions) Run() error {
 	containerName := p.ContainerName
 	if len(containerName) == 0 {
 		if len(pod.Spec.Containers) > 1 {
-			containerNames := polymorphichelpers.getContainerNames(pod.Spec.Containers)
+			containerNames := getContainerNames(pod.Spec.Containers)
 			fmt.Fprintf(p.ErrOut, "Defaulting container name to %s; Available containers: [%s]\n", pod.Spec.Containers[0].Name, containerNames)
 		}
 		containerName = pod.Spec.Containers[0].Name

--- a/staging/src/k8s.io/kubectl/pkg/cmd/exec/exec.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/exec/exec.go
@@ -21,8 +21,8 @@ import (
 	"fmt"
 	"io"
 	"net/url"
-	"time"
 	"strings"
+	"time"
 
 	dockerterm "github.com/moby/term"
 	"github.com/spf13/cobra"


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
Show the available container names when the user misses -c/--container option in the 'kubectl exec' command for the multi-container pod; this saves time and improves the user experience instead of executing the 'pod describe' command to get the available containers.

**Which issue(s) this PR fixes**:
NONE

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

Before this fix:
--------------

Defaulting container name to nginx.
Use 'kubectl describe pod/nginx -n default' to see all of the containers in this pod.

After this fix:
------------

Defaulting container name to nginx; Available containers: [nginx db]