### PR TITLE
Remove external driver duplicated misleading SupportedSizeRange

### DIFF
--- a/test/e2e/storage/external/BUILD
+++ b/test/e2e/storage/external/BUILD
@@ -15,6 +15,7 @@ go_library(
         "//staging/src/k8s.io/client-go/kubernetes/scheme:go_default_library",
         "//test/e2e/framework:go_default_library",
         "//test/e2e/framework/config:go_default_library",
+        "//test/e2e/framework/log:go_default_library",
         "//test/e2e/framework/pod:go_default_library",
         "//test/e2e/framework/skipper:go_default_library",
         "//test/e2e/framework/volume:go_default_library",

--- a/test/e2e/storage/external/external.go
+++ b/test/e2e/storage/external/external.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2econfig "k8s.io/kubernetes/test/e2e/framework/config"
+	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
 	e2evolume "k8s.io/kubernetes/test/e2e/framework/volume"
@@ -120,10 +121,6 @@ type driverDefinition struct {
 		ReadOnly bool
 	}
 
-	// SupportedSizeRange defines the desired size of dynamically
-	// provisioned volumes.
-	SupportedSizeRange e2evolume.SizeRange
-
 	// ClientNodeName selects a specific node for scheduling test pods.
 	// Can be left empty. Most drivers should not need this and instead
 	// use topology to ensure that pods land on the right node(s).
@@ -158,6 +155,7 @@ func (t testDriverParameter) Set(filename string) error {
 // to define the tests.
 func AddDriverDefinition(filename string) error {
 	driver, err := loadDriverDefinition(filename)
+	e2elog.Logf("Driver loaded from path [%s]: %+v", filename, driver)
 	if err != nil {
 		return err
 	}
@@ -187,9 +185,9 @@ func loadDriverDefinition(filename string) (*driverDefinition, error) {
 			SupportedFsType: sets.NewString(
 				"", // Default fsType
 			),
-		},
-		SupportedSizeRange: e2evolume.SizeRange{
-			Min: "5Gi",
+			SupportedSizeRange: e2evolume.SizeRange{
+				Min: "5Gi",
+			},
 		},
 	}
 	// TODO: strict checking of the file content once https://github.com/kubernetes/kubernetes/pull/71589

--- a/test/e2e/storage/external/external_test.go
+++ b/test/e2e/storage/external/external_test.go
@@ -33,9 +33,9 @@ func TestDriverParameter(t *testing.T) {
 			SupportedFsType: sets.NewString(
 				"", // Default fsType
 			),
-		},
-		SupportedSizeRange: e2evolume.SizeRange{
-			Min: "5Gi",
+			SupportedSizeRange: e2evolume.SizeRange{
+				Min: "10Gi",
+			},
 		},
 	}
 	testcases := []struct {

--- a/test/e2e/storage/external/testdata/driver.json
+++ b/test/e2e/storage/external/testdata/driver.json
@@ -1,1 +1,1 @@
-{"DriverInfo": {"Name": "foo.example.com"}, "ShortName": "foo"}
+{"DriverInfo": {"Name": "foo.example.com", "SupportedSizeRange": { "Min": "10Gi"}}, "ShortName": "foo"}

--- a/test/e2e/storage/external/testdata/driver.yaml
+++ b/test/e2e/storage/external/testdata/driver.yaml
@@ -1,3 +1,5 @@
 DriverInfo:
   Name: foo.example.com
+  SupportedSizeRange:
+    Min: 10Gi
 ShortName: foo

--- a/test/e2e/storage/testsuites/base.go
+++ b/test/e2e/storage/testsuites/base.go
@@ -236,7 +236,8 @@ func CreateVolumeResource(driver TestDriver, config *PerTestConfig, pattern test
 			driverVolumeSizeRange := dDriver.GetDriverInfo().SupportedSizeRange
 			claimSize, err := getSizeRangesIntersection(testVolumeSizeRange, driverVolumeSizeRange)
 			framework.ExpectNoError(err, "determine intersection of test size range %+v and driver size range %+v", testVolumeSizeRange, driverVolumeSizeRange)
-			framework.Logf("Using claimSize:%s, test suite supported size:%v, driver(%s) supported size:%v ", claimSize, testVolumeSizeRange, dDriver.GetDriverInfo().Name, testVolumeSizeRange)
+			framework.Logf("Using claimSize:%s, test suite supported size:%v, driver(%s) supported size:%v ",
+				claimSize, testVolumeSizeRange, dDriver.GetDriverInfo().Name, driverVolumeSizeRange)
 			r.Sc = dDriver.GetDynamicProvisionStorageClass(r.Config, pattern.FsType)
 
 			if pattern.BindingMode != "" {


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
I dont understand why we have two SupportedSizeRange in the external driver parsing. Clearly one of them is not being used. The actual SupportedSizeRange being used now is in driverinfo

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/cc @msau42 @chrishenzie 
/assign @jingxu97 
/sig storage