### PR TITLE
fix nodelifecyle controller not add NoExecute taint bug

### DIFF
--- a/pkg/controller/nodelifecycle/node_lifecycle_controller.go
+++ b/pkg/controller/nodelifecycle/node_lifecycle_controller.go
@@ -1477,13 +1477,13 @@ func (nc *Controller) markNodeForTainting(node *v1.Node, status v1.ConditionStat
 	defer nc.evictorLock.Unlock()
 	if status == v1.ConditionFalse {
 		if !taintutils.TaintExists(node.Spec.Taints, NotReadyTaintTemplate) {
-			nc.zoneNoExecuteTainter[utilnode.GetZoneKey(node)].SetRemove(node.Name)
+			nc.zoneNoExecuteTainter[utilnode.GetZoneKey(node)].Remove(node.Name)
 		}
 	}
 
 	if status == v1.ConditionUnknown {
 		if !taintutils.TaintExists(node.Spec.Taints, UnreachableTaintTemplate) {
-			nc.zoneNoExecuteTainter[utilnode.GetZoneKey(node)].SetRemove(node.Name)
+			nc.zoneNoExecuteTainter[utilnode.GetZoneKey(node)].Remove(node.Name)
 		}
 	}
 

--- a/pkg/controller/nodelifecycle/node_lifecycle_controller_test.go
+++ b/pkg/controller/nodelifecycle/node_lifecycle_controller_test.go
@@ -2782,6 +2782,239 @@ func TestApplyNoExecuteTaints(t *testing.T) {
 	}
 }
 
+// TestApplyNoExecuteTaintsToNodesEnqueueTwice ensures we taint every node with NoExecute even if enqueued twice
+func TestApplyNoExecuteTaintsToNodesEnqueueTwice(t *testing.T) {
+	fakeNow := metav1.Date(2017, 1, 1, 12, 0, 0, 0, time.UTC)
+	evictionTimeout := 10 * time.Minute
+
+	fakeNodeHandler := &testutil.FakeNodeHandler{
+		Existing: []*v1.Node{
+			// Unreachable Taint with effect 'NoExecute' should be applied to this node.
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "node0",
+					CreationTimestamp: metav1.Date(2012, 1, 1, 0, 0, 0, 0, time.UTC),
+					Labels: map[string]string{
+						v1.LabelTopologyRegion:          "region1",
+						v1.LabelTopologyZone:            "zone1",
+						v1.LabelFailureDomainBetaRegion: "region1",
+						v1.LabelFailureDomainBetaZone:   "zone1",
+					},
+				},
+				Status: v1.NodeStatus{
+					Conditions: []v1.NodeCondition{
+						{
+							Type:               v1.NodeReady,
+							Status:             v1.ConditionUnknown,
+							LastHeartbeatTime:  metav1.Date(2015, 1, 1, 12, 0, 0, 0, time.UTC),
+							LastTransitionTime: metav1.Date(2015, 1, 1, 12, 0, 0, 0, time.UTC),
+						},
+					},
+				},
+			},
+			// Because of the logic that prevents NC from evicting anything when all Nodes are NotReady
+			// we need second healthy node in tests.
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "node1",
+					CreationTimestamp: metav1.Date(2012, 1, 1, 0, 0, 0, 0, time.UTC),
+					Labels: map[string]string{
+						v1.LabelTopologyRegion:          "region1",
+						v1.LabelTopologyZone:            "zone1",
+						v1.LabelFailureDomainBetaRegion: "region1",
+						v1.LabelFailureDomainBetaZone:   "zone1",
+					},
+				},
+				Status: v1.NodeStatus{
+					Conditions: []v1.NodeCondition{
+						{
+							Type:               v1.NodeReady,
+							Status:             v1.ConditionTrue,
+							LastHeartbeatTime:  metav1.Date(2017, 1, 1, 12, 0, 0, 0, time.UTC),
+							LastTransitionTime: metav1.Date(2017, 1, 1, 12, 0, 0, 0, time.UTC),
+						},
+					},
+				},
+			},
+			// NotReady Taint with NoExecute effect should be applied to this node.
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "node2",
+					CreationTimestamp: metav1.Date(2012, 1, 1, 0, 0, 0, 0, time.UTC),
+					Labels: map[string]string{
+						v1.LabelTopologyRegion:          "region1",
+						v1.LabelTopologyZone:            "zone1",
+						v1.LabelFailureDomainBetaRegion: "region1",
+						v1.LabelFailureDomainBetaZone:   "zone1",
+					},
+				},
+				Status: v1.NodeStatus{
+					Conditions: []v1.NodeCondition{
+						{
+							Type:               v1.NodeReady,
+							Status:             v1.ConditionFalse,
+							LastHeartbeatTime:  metav1.Date(2015, 1, 1, 12, 0, 0, 0, time.UTC),
+							LastTransitionTime: metav1.Date(2015, 1, 1, 12, 0, 0, 0, time.UTC),
+						},
+					},
+				},
+			},
+		},
+		Clientset: fake.NewSimpleClientset(&v1.PodList{Items: []v1.Pod{*testutil.NewPod("pod0", "node0")}}),
+	}
+	healthyNodeNewStatus := v1.NodeStatus{
+		Conditions: []v1.NodeCondition{
+			{
+				Type:               v1.NodeReady,
+				Status:             v1.ConditionTrue,
+				LastHeartbeatTime:  metav1.Date(2017, 1, 1, 12, 10, 0, 0, time.UTC),
+				LastTransitionTime: metav1.Date(2017, 1, 1, 12, 0, 0, 0, time.UTC),
+			},
+		},
+	}
+	nodeController, _ := newNodeLifecycleControllerFromClient(
+		fakeNodeHandler,
+		evictionTimeout,
+		testRateLimiterQPS,
+		testRateLimiterQPS,
+		testLargeClusterThreshold,
+		testUnhealthyThreshold,
+		testNodeMonitorGracePeriod,
+		testNodeStartupGracePeriod,
+		testNodeMonitorPeriod,
+		true)
+	nodeController.now = func() metav1.Time { return fakeNow }
+	nodeController.recorder = testutil.NewFakeRecorder()
+	nodeController.getPodsAssignedToNode = fakeGetPodsAssignedToNode(fakeNodeHandler.Clientset)
+	if err := nodeController.syncNodeStore(fakeNodeHandler); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	// 1. monitor node health twice, add untainted node once
+	if err := nodeController.monitorNodeHealth(); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if err := nodeController.monitorNodeHealth(); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	// 2. mark node0 healthy
+	node0, err := fakeNodeHandler.Get(context.TODO(), "node0", metav1.GetOptions{})
+	if err != nil {
+		t.Errorf("Can't get current node0...")
+		return
+	}
+	node0.Status = healthyNodeNewStatus
+	_, err = fakeNodeHandler.UpdateStatus(context.TODO(), node0, metav1.UpdateOptions{})
+	if err != nil {
+		t.Errorf(err.Error())
+		return
+	}
+
+	// add other notReady nodes
+	fakeNodeHandler.Existing = append(fakeNodeHandler.Existing, []*v1.Node{
+		// Unreachable Taint with effect 'NoExecute' should be applied to this node.
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "node3",
+				CreationTimestamp: metav1.Date(2012, 1, 1, 0, 0, 0, 0, time.UTC),
+				Labels: map[string]string{
+					v1.LabelTopologyRegion:          "region1",
+					v1.LabelTopologyZone:            "zone1",
+					v1.LabelFailureDomainBetaRegion: "region1",
+					v1.LabelFailureDomainBetaZone:   "zone1",
+				},
+			},
+			Status: v1.NodeStatus{
+				Conditions: []v1.NodeCondition{
+					{
+						Type:               v1.NodeReady,
+						Status:             v1.ConditionUnknown,
+						LastHeartbeatTime:  metav1.Date(2015, 1, 1, 12, 0, 0, 0, time.UTC),
+						LastTransitionTime: metav1.Date(2015, 1, 1, 12, 0, 0, 0, time.UTC),
+					},
+				},
+			},
+		},
+		// Because of the logic that prevents NC from evicting anything when all Nodes are NotReady
+		// we need second healthy node in tests.
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "node4",
+				CreationTimestamp: metav1.Date(2012, 1, 1, 0, 0, 0, 0, time.UTC),
+				Labels: map[string]string{
+					v1.LabelTopologyRegion:          "region1",
+					v1.LabelTopologyZone:            "zone1",
+					v1.LabelFailureDomainBetaRegion: "region1",
+					v1.LabelFailureDomainBetaZone:   "zone1",
+				},
+			},
+			Status: v1.NodeStatus{
+				Conditions: []v1.NodeCondition{
+					{
+						Type:               v1.NodeReady,
+						Status:             v1.ConditionTrue,
+						LastHeartbeatTime:  metav1.Date(2017, 1, 1, 12, 0, 0, 0, time.UTC),
+						LastTransitionTime: metav1.Date(2017, 1, 1, 12, 0, 0, 0, time.UTC),
+					},
+				},
+			},
+		},
+		// NotReady Taint with NoExecute effect should be applied to this node.
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "node5",
+				CreationTimestamp: metav1.Date(2012, 1, 1, 0, 0, 0, 0, time.UTC),
+				Labels: map[string]string{
+					v1.LabelTopologyRegion:          "region1",
+					v1.LabelTopologyZone:            "zone1",
+					v1.LabelFailureDomainBetaRegion: "region1",
+					v1.LabelFailureDomainBetaZone:   "zone1",
+				},
+			},
+			Status: v1.NodeStatus{
+				Conditions: []v1.NodeCondition{
+					{
+						Type:               v1.NodeReady,
+						Status:             v1.ConditionFalse,
+						LastHeartbeatTime:  metav1.Date(2015, 1, 1, 12, 0, 0, 0, time.UTC),
+						LastTransitionTime: metav1.Date(2015, 1, 1, 12, 0, 0, 0, time.UTC),
+					},
+				},
+			},
+		},
+	}...)
+	if err := nodeController.syncNodeStore(fakeNodeHandler); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	// 3. start monitor node health again, add untainted node twice, construct UniqueQueue with duplicated node cache
+	if err := nodeController.monitorNodeHealth(); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	// 4. do NoExecute taint pass
+	// when processing with node0, condition.Status is NodeReady, and return true with default case
+	// then remove the set value and queue value both, the taint job never stuck
+	nodeController.doNoExecuteTaintingPass()
+
+	// 5. get node3 and node5, see if it has ready got NoExecute taint
+	node3, err := fakeNodeHandler.Get(context.TODO(), "node3", metav1.GetOptions{})
+	if err != nil {
+		t.Errorf("Can't get current node3...")
+		return
+	}
+	if !taintutils.TaintExists(node3.Spec.Taints, UnreachableTaintTemplate) || len(node3.Spec.Taints) == 0 {
+		t.Errorf("Not found taint %v in %v, which should be present in %s", UnreachableTaintTemplate, node3.Spec.Taints, node3.Name)
+	}
+	node5, err := fakeNodeHandler.Get(context.TODO(), "node5", metav1.GetOptions{})
+	if err != nil {
+		t.Errorf("Can't get current node5...")
+		return
+	}
+	if !taintutils.TaintExists(node5.Spec.Taints, NotReadyTaintTemplate) || len(node5.Spec.Taints) == 0 {
+		t.Errorf("Not found taint %v in %v, which should be present in %s", NotReadyTaintTemplate, node5.Spec.Taints, node5.Name)
+	}
+}
+
 func TestSwapUnreachableNotReadyTaints(t *testing.T) {
 	fakeNow := metav1.Date(2017, 1, 1, 12, 0, 0, 0, time.UTC)
 	evictionTimeout := 10 * time.Minute

--- a/pkg/controller/nodelifecycle/scheduler/rate_limited_queue.go
+++ b/pkg/controller/nodelifecycle/scheduler/rate_limited_queue.go
@@ -194,15 +194,6 @@ func (q *UniqueQueue) Clear() {
 	}
 }
 
-// SetRemove remove value from the set if value existed
-func (q *UniqueQueue) SetRemove(value string) {
-	q.lock.Lock()
-	defer q.lock.Unlock()
-	if q.set.Has(value) {
-		q.set.Delete(value)
-	}
-}
-
 // RateLimitedTimedQueue is a unique item priority queue ordered by
 // the expected next time of execution. It is also rate limited.
 type RateLimitedTimedQueue struct {
@@ -287,11 +278,6 @@ func (q *RateLimitedTimedQueue) Remove(value string) bool {
 // Clear removes all items from the queue
 func (q *RateLimitedTimedQueue) Clear() {
 	q.queue.Clear()
-}
-
-// SetRemove remove value from the set of the queue
-func (q *RateLimitedTimedQueue) SetRemove(value string) {
-	q.queue.SetRemove(value)
 }
 
 // SwapLimiter safely swaps current limiter for this queue with the

--- a/pkg/controller/nodelifecycle/scheduler/rate_limited_queue_test.go
+++ b/pkg/controller/nodelifecycle/scheduler/rate_limited_queue_test.go
@@ -282,17 +282,6 @@ func TestClear(t *testing.T) {
 	}
 }
 
-func TestSetRemove(t *testing.T) {
-	evictor := NewRateLimitedTimedQueue(flowcontrol.NewFakeAlwaysRateLimiter())
-	evictor.Add("first", "11111")
-
-	evictor.SetRemove("first")
-
-	if evictor.queue.set.Len() != 0 {
-		t.Fatalf("SetRemove should remove element from the set.")
-	}
-}
-
 func TestSwapLimiter(t *testing.T) {
 	evictor := NewRateLimitedTimedQueue(flowcontrol.NewFakeAlwaysRateLimiter())
 	fakeAlways := flowcontrol.NewFakeAlwaysRateLimiter()


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
this PR https://github.com/kubernetes/kubernetes/pull/89059 try to fix reconcile problem, so every 5s `monitorNodeHealth()`  run `processTaintBaseEviction()`, add nodes to `zoneNoExecuteTainter` cause these nodes' status is `Unknown` or `False`. 

However, every time we need add untainted nodes to `RateLimitedTimedQueue`, this PR try to delete it first in order to enter queue every time. Delete action use a additional func `SetRemve()` as below instead of `Remove()`:
```go
func (q *UniqueQueue) SetRemove(value string) {
	q.lock.Lock()
	defer q.lock.Unlock()
        // *************************************************
        // only delete set value, leave queue data behind
        // *************************************************
	if q.set.Has(value) {
		q.set.Delete(value)
	}
}

func (q *UniqueQueue) Remove(value string) bool {
	q.lock.Lock()
	defer q.lock.Unlock()

	if !q.set.Has(value) {
		return false
	}
	q.set.Delete(value)
	for i, val := range q.queue {
		if val.Value == value {
			heap.Remove(&q.queue, i)
			return true
		}
	}
	return true
}
```
When taintManager start working(`doNoExecuteTaintingPass()`) and its QPS defaults as `0.1`, so here is a scenario may case nodes will never get `NoExecute` taint except kube-controller-manager restart and reconstruct its queue data:

1. Suppose there are 3 nodes' status are unknown, and monitor these 3 node, add them in queue, the `UniqueQueue` inside `RateLimitedTimedQueue` looks like this:

| queue |  TimedValue{node0, id0} |  TimedValue{node1, id1} |  TimedValue{node2, id2} | 
| ------- | --------------------------- | -------------------------- | --------------------------- |
| set      |  node0                              |  node1                            |  node2                             | 

2. `doNoExecuteTaintingPass()` not finish the taint job, and `monitNodeHealth()` run in next period, and enqueue 3 nodes again with set data removed but queue data left, and the `UniqueQueue` inside `RateLimitedTimedQueue` looks like this:

| queue |  TimedValue{node0, id0}(dirty data) |  TimedValue{node1, id1}(dirty data) |  TimedValue{node2, id2}(dirty data)  | TimedValue{node0, id0} |  TimedValue{node1, id1} |  TimedValue{node2, id2} | 
| ---- | ---- | ---- | ---- | ---- |  ---- |  ---- |  
| set  | ~~node0~~ |  ~~node1~~ | ~~node2~~| node0 |  node1 | node2 |

3. `doNoExecuteTaintingPass()` continue to deal with these untainted nodes, this func fetch data from queue not set one by one, start with dirty data, suppose that before handling the duplicated data "node0", node0 return normal (same as node1 and node2), so `ActionFunc()` in `nc.zoneNoExecuteTainter[k].Try(fn ActionFunc)` returns true, and func `Try()` calls `q.queue.RemoveFromQueue(val.Value)`, but it cannot be removed because the set value is not existed. So queue's head cannot be removed normally, next running circle still get the dirty data, and the taint job go stuck forever
```go
func (q *UniqueQueue) RemoveFromQueue(value string) bool {
	q.lock.Lock()
	defer q.lock.Unlock()

	if !q.set.Has(value) {
		return false
	}
	for i, val := range q.queue {
		if val.Value == value {
			heap.Remove(&q.queue, i)
			return true
		}
	}
	return false
}
```

**Which issue(s) this PR fixes**:
Fix:  #94183 #96183

**Special notes for your reviewer**:
I write a helper func to print values inside `RateLimitedTimedQueue`, and unit test running log as below, and log display the dirty data inside queue field.

before set `SetRemove()` to `Remove()`
```
TestApplyNoExecuteTaintsToNodesEnqueueTwice
=== RUN   TestApplyNoExecuteTaintsToNodesEnqueueTwice
I1126 20:27:44.590489   60621 node_lifecycle_controller.go:380] Sending events to api server.
I1126 20:27:44.591383   60621 taint_manager.go:163] Sending events to api server.
I1126 20:27:44.591550   60621 node_lifecycle_controller.go:508] Controller will reconcile labels.
I1126 20:27:44.591803   60621 node_lifecycle_controller.go:1428] Initializing eviction metric for zone: region1::zone1
W1126 20:27:44.591895   60621 node_lifecycle_controller.go:1043] Missing timestamp for Node node1. Assuming now as a timestamp.
W1126 20:27:44.592092   60621 node_lifecycle_controller.go:1043] Missing timestamp for Node node2. Assuming now as a timestamp.
W1126 20:27:44.592187   60621 node_lifecycle_controller.go:1043] Missing timestamp for Node node0. Assuming now as a timestamp.
I1126 20:27:44.592273   60621 node_lifecycle_controller.go:1244] Controller detected that zone region1::zone1 is now in state Normal.
----------------------------------dirty data-----------------------------------
q.queue: node2,node0,node2,node0,
q.set: map[node0:{} node2:{}]
----------------------------------dirty data-----------------------------------
W1126 20:27:44.592663   60621 node_lifecycle_controller.go:1043] Missing timestamp for Node node3. Assuming now as a timestamp.
W1126 20:27:44.592753   60621 node_lifecycle_controller.go:1043] Missing timestamp for Node node4. Assuming now as a timestamp.
W1126 20:27:44.592817   60621 node_lifecycle_controller.go:1043] Missing timestamp for Node node5. Assuming now as a timestamp.
----------------------------------dirty data-----------------------------------
q.queue: node0,node0,node2,node5,node3,node0,
q.set: map[node0:{} node3:{} node5:{}]
map[node0:{} node3:{} node5:{}]
node0 true
map[node0:{} node3:{} node5:{}]
node2 false
----------------------------------dirty data-----------------------------------
    node_lifecycle_controller_test.go:291: Not found taint &Taint{Key:node.kubernetes.io/unreachable,Value:,Effect:NoExecute,TimeAdded:<nil>,} in [], which should be present in node3
    node_lifecycle_controller_test.go:299: Not found taint &Taint{Key:node.kubernetes.io/not-ready,Value:,Effect:NoExecute,TimeAdded:<nil>,} in [], which should be present in node5
--- FAIL: TestApplyNoExecuteTaintsToNodesEnqueueTwice (0.01s)
FAIL
FAIL	k8s.io/kubernetes/pkg/controller/nodelifecycle	0.030s
FAIL
```

After:
```
=== RUN   TestApplyNoExecuteTaintsToNodesEnqueueTwice
I1126 20:27:56.167537   36972 node_lifecycle_controller.go:380] Sending events to api server.
I1126 20:27:56.167790   36972 taint_manager.go:163] Sending events to api server.
I1126 20:27:56.167879   36972 node_lifecycle_controller.go:508] Controller will reconcile labels.
I1126 20:27:56.167988   36972 node_lifecycle_controller.go:1429] Initializing eviction metric for zone: region1::zone1
W1126 20:27:56.168036   36972 node_lifecycle_controller.go:1044] Missing timestamp for Node node0. Assuming now as a timestamp.
W1126 20:27:56.168097   36972 node_lifecycle_controller.go:1044] Missing timestamp for Node node1. Assuming now as a timestamp.
W1126 20:27:56.168139   36972 node_lifecycle_controller.go:1044] Missing timestamp for Node node2. Assuming now as a timestamp.
I1126 20:27:56.168184   36972 node_lifecycle_controller.go:1245] Controller detected that zone region1::zone1 is now in state Normal.
----------------------------------clean data-----------------------------------
q.queue: node0,node2,
q.set: map[node0:{} node2:{}]
----------------------------------clean data-----------------------------------
W1126 20:27:56.168407   36972 node_lifecycle_controller.go:1044] Missing timestamp for Node node3. Assuming now as a timestamp.
W1126 20:27:56.168447   36972 node_lifecycle_controller.go:1044] Missing timestamp for Node node4. Assuming now as a timestamp.
W1126 20:27:56.168488   36972 node_lifecycle_controller.go:1044] Missing timestamp for Node node5. Assuming now as a timestamp.
----------------------------------clean data-----------------------------------
q.queue: node2,node3,node5,
q.set: map[node2:{} node3:{} node5:{}]
node2 true
node3 true
node5 true
----------------------------------clean data-----------------------------------
--- PASS: TestApplyNoExecuteTaintsToNodesEnqueueTwice (0.00s)
PASS
ok  	k8s.io/kubernetes/pkg/controller/nodelifecycle	0.027s
```

**Does this PR introduce a user-facing change?**
```release-note
fixing a regression in 1.19+ where a failed node may not have the NoExecute taint set correctly
```