### PR TITLE
Make parallel build memory threshold configurable

### DIFF
--- a/hack/lib/golang.sh
+++ b/hack/lib/golang.sh
@@ -305,9 +305,10 @@ readonly KUBE_TEST_SERVER_BINARIES=("${KUBE_TEST_SERVER_TARGETS[@]##*/}")
 readonly KUBE_TEST_SERVER_PLATFORMS=("${KUBE_SERVER_PLATFORMS[@]:+"${KUBE_SERVER_PLATFORMS[@]}"}")
 
 # Gigabytes necessary for parallel platform builds.
-# As of January 2018, RAM usage is exceeding 30G
-# Setting to 40 to provide some headroom
-readonly KUBE_PARALLEL_BUILD_MEMORY=40
+# As of January 2018, RAM usage is exceeding 30G.
+# This variable can be overwritten at your own risk.
+# It's defaulting to 40G to provide some headroom
+readonly KUBE_PARALLEL_BUILD_MEMORY=${KUBE_PARALLEL_BUILD_MEMORY:-40}
 
 readonly KUBE_ALL_TARGETS=(
   "${KUBE_SERVER_TARGETS[@]}"


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

The amount of memory required to build binaries in parallel is right now
set to 40GiB. We now make this variable to be able to build artifacts in
parallel even with a lower amount of memory.

This enables SIG Release to speed-up the build time drastically in
Google Cloud Build (GCB).

**Which issue(s) this PR fixes**:

None

**Special notes for your reviewer**:

cc @kubernetes/release-engineering 
/sig release

**Does this PR introduce a user-facing change?**:

```release-note
None
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs
None
```
