### PR TITLE
fix index test: multi index check for empty list

### DIFF
--- a/staging/src/k8s.io/client-go/tools/cache/index_test.go
+++ b/staging/src/k8s.io/client-go/tools/cache/index_test.go
@@ -76,7 +76,7 @@ func TestMultiIndexKeys(t *testing.T) {
 	expected["bert"] = sets.NewString("one", "two")
 	expected["elmo"] = sets.NewString("tre")
 	expected["oscar"] = sets.NewString("two")
-	expected["elmo"] = sets.NewString() // let's just make sure we don't get anything back in this case
+	expected["elmo1"] = sets.NewString()
 	{
 		for k, v := range expected {
 			found := sets.String{}
@@ -87,9 +87,8 @@ func TestMultiIndexKeys(t *testing.T) {
 			for _, item := range indexResults {
 				found.Insert(item.(*v1.Pod).Name)
 			}
-			items := v.List()
-			if !found.HasAll(items...) {
-				t.Errorf("missing items, index %s, expected %v but found %v", k, items, found.List())
+			if !found.Equal(v) {
+				t.Errorf("missing items, index %s, expected %v but found %v", k, v.List(), found.List())
 			}
 		}
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
/sig testing

**What this PR does / why we need it**:
Per  #96862 , empty expected set here will always success no matter what index is found.

**Which issue(s) this PR fixes**:

Fixes #96862 

**Special notes for your reviewer**:
size/len check is for empty list.

**Does this PR introduce a user-facing change?**:

```release-note
None
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs
None
```
