### PR TITLE
apiserver: print unknown responsewriter error strings, not only %#+v

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/status.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/status.go
@@ -68,7 +68,7 @@ func ErrorToAPIStatus(err error) *metav1.Status {
 		// by REST storage - these typically indicate programmer
 		// error by not using pkg/api/errors, or unexpected failure
 		// cases.
-		runtime.HandleError(fmt.Errorf("apiserver received an error that is not an metav1.Status: %#+v", err))
+		runtime.HandleError(fmt.Errorf("apiserver received an error that is not an metav1.Status: %#+v: %v", err, err))
 		return &metav1.Status{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       "Status",


### PR DESCRIPTION
The old error message is not that helpful:
```
apiserver received an error that is not an metav1.Status: &url.Error{Op:"Get", URL:"https://172.31.0.1:443/api/v1/namespaces/openshift-monitoring", Err:(*errors.errorString)(0xc000092270)}
```

/kind bug

```release-note
NONE
```