### PR TITLE
WIP Logarithmic timestamp comparison for dowscaling

### DIFF
--- a/pkg/controller/replicaset/replica_set.go
+++ b/pkg/controller/replicaset/replica_set.go
@@ -822,7 +822,7 @@ func getPodsRankedByRelatedPodsOnSameNode(podsToRank, relatedPods []*v1.Pod) con
 	for i, pod := range podsToRank {
 		ranks[i] = podsOnNode[pod.Spec.NodeName]
 	}
-	return controller.ActivePodsWithRanks{Pods: podsToRank, Rank: ranks}
+	return controller.ActivePodsWithRanks{Pods: podsToRank, Rank: ranks, Now: metav1.Now()}
 }
 
 func getPodKeys(pods []*v1.Pod) []string {


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Compares ready and creation timestamps in a logarithmic scale. This allows for some level of randomness when Pods are quick-sorted to get downscaling candidates.

Used base 2. This means that (roughly) if a Pod A has been created/running for less than half the time of Pod B, then Pod A will be downscaled first. But if Pod A has been created/running for more than half the time of Pod B, they can be equally downscaled.

**Which issue(s) this PR fixes**:

Ref #96748

**Special notes for your reviewer**:

This is a proposal that has very low overhead compared to #96748. Since behavior is not backwards compatible, we could release with a FeatureGate first. Then, from feedback, we can adjust the logarithmic base or, if we find out that the behavior might not be desired by everyone, we could make it a configuration option.

**Does this PR introduce a user-facing change?**:

```release-note
When downscaling ReplicaSets, ready and creation timestamps are compared in a logarithmic scale.
```