### PR TITLE
local-up-cluster kubelet option opening readonly port

### DIFF
--- a/hack/local-up-cluster.sh
+++ b/hack/local-up-cluster.sh
@@ -222,6 +222,8 @@ KUBELET_HOST=${KUBELET_HOST:-"127.0.0.1"}
 # By default only allow CORS for requests on localhost
 API_CORS_ALLOWED_ORIGINS=${API_CORS_ALLOWED_ORIGINS:-/127.0.0.1(:[0-9]+)?$,/localhost(:[0-9]+)?$}
 KUBELET_PORT=${KUBELET_PORT:-10250}
+# By default we use 0(close it) for it's insecure
+KUBELET_READ_ONLY_PORT=${KUBELET_READ_ONLY_PORT:-0}
 LOG_LEVEL=${LOG_LEVEL:-3}
 # Use to increase verbosity on particular files, e.g. LOG_SPEC=token_controller*=5,other_controller*=4
 LOG_SPEC=${LOG_SPEC:-""}
@@ -781,6 +783,7 @@ enableControllerAttachDetach: ${ENABLE_CONTROLLER_ATTACH_DETACH}
 evictionPressureTransitionPeriod: "${EVICTION_PRESSURE_TRANSITION_PERIOD}"
 failSwapOn: ${FAIL_SWAP_ON}
 port: ${KUBELET_PORT}
+readOnlyPort: ${KUBELET_READ_ONLY_PORT}
 rotateCertificates: true
 runtimeRequestTimeout: "${RUNTIME_REQUEST_TIMEOUT}"
 staticPodPath: "${POD_MANIFEST_PATH}"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:

After MR(https://github.com/kubernetes/kubernetes/pull/96095) merged, I run local-up-cluster.sh, find that kubelet wont open readonly port which is different from the before.

```
λ /opt/workspace/myspace/src/k8s.io/kubernetes/ master* netstat -anp | grep kubelet
tcp        0      0 127.0.0.1:10248         0.0.0.0:*               LISTEN      524188/kubelet      
tcp        0      0 127.0.0.1:37449         0.0.0.0:*               LISTEN      524188/kubelet      
tcp        0      0 127.0.0.1:10250         0.0.0.0:*               LISTEN      524188/kubelet      
tcp6       0      0 ::1:36670               ::1:6443                ESTABLISHED 524188/kubelet      
tcp6       0      0 ::1:36754               ::1:6443                ESTABLISHED 524188/kubelet
```
openning it is convenient for us to debug something.

The problem is that MR(#96095) migrate the kubelet the starting parameter to config file.
In the code,  `kubeletConfig` will reload config from file.
https://github.com/kubernetes/kubernetes/blob/5ed4b76a03b5eddc62939a1569b61532b4a06a72/cmd/kubelet/app/server.go#L195-L199

And it will cover the default config setting before in 

https://github.com/kubernetes/kubernetes/blob/5ed4b76a03b5eddc62939a1569b61532b4a06a72/cmd/kubelet/app/options/options.go#L267

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
