### PR TITLE
improve watchCache metric

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/metrics.go
@@ -56,12 +56,22 @@ var (
 		},
 		[]string{"resource"},
 	)
+
+	watchCacheCapacity = metrics.NewGaugeVec(
+		&metrics.GaugeOpts{
+			Name:           "watch_cache_capacity",
+			Help:           "Total capacity of watch cache broken by resource type.",
+			StabilityLevel: metrics.ALPHA,
+		},
+		[]string{"resource"},
+	)
 )
 
 func init() {
 	legacyregistry.MustRegister(initCounter)
 	legacyregistry.MustRegister(watchCacheCapacityIncreaseTotal)
 	legacyregistry.MustRegister(watchCacheCapacityDecreaseTotal)
+	legacyregistry.MustRegister(watchCacheCapacity)
 }
 
 // recordsWatchCacheCapacityChange record watchCache capacity resize(increase or decrease) operations.
@@ -71,4 +81,5 @@ func recordsWatchCacheCapacityChange(objType string, old, new int) {
 		return
 	}
 	watchCacheCapacityDecreaseTotal.WithLabelValues(objType).Inc()
+	watchCacheCapacity.WithLabelValues(objType).Set(float64(new))
 }

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache.go
@@ -216,6 +216,8 @@ func newWatchCache(
 		versioner:           versioner,
 		objectType:          objectType,
 	}
+	objType := objectType.String()
+	watchCacheCapacity.WithLabelValues(objType).Set(float64(wc.capacity))
 	wc.cond = sync.NewCond(wc.RLocker())
 	return wc
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake
>
> /kind feature
>
**What this PR does / why we need it**:
> Metrics improvement in watchCache size based on production experience
>
> added  a real-time monitoring metrics about  the size of watchCache
>
**Which issue(s) this PR fixes**:
>Ref: #90058

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
> ```
> None
> ```

```release-note
NONE

```