### PR TITLE
Fixes the unit tests to be more tolerant with error messages

### DIFF
--- a/pkg/kubelet/cm/cpumanager/state/state_checkpoint_test.go
+++ b/pkg/kubelet/cm/cpumanager/state/state_checkpoint_test.go
@@ -227,8 +227,8 @@ func TestCheckpointStateRestore(t *testing.T) {
 			restoredState, err := NewCheckpointState(testingDir, testingCheckpoint, tc.policyName, tc.initialContainers)
 			if err != nil {
 				if strings.TrimSpace(tc.expectedError) != "" {
-					tc.expectedError = "could not restore state from checkpoint: " + tc.expectedError
-					if strings.HasPrefix(err.Error(), tc.expectedError) {
+					if strings.Contains(err.Error(), "could not restore state from checkpoint") &&
+						strings.Contains(err.Error(), tc.expectedError) {
 						t.Logf("got expected error: %v", err)
 						return
 					}

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/rest_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/rest_test.go
@@ -123,7 +123,7 @@ func TestStrategicMergePatchInvalid(t *testing.T) {
 	if !apierrors.IsBadRequest(err) {
 		t.Errorf("expected HTTP status: BadRequest, got: %#v", apierrors.ReasonForError(err))
 	}
-	if err.Error() != expectedError {
+	if !strings.Contains(err.Error(), expectedError) {
 		t.Errorf("expected %#v, got %#v", expectedError, err.Error())
 	}
 }
@@ -171,7 +171,7 @@ func TestJSONPatch(t *testing.T) {
 				t.Errorf("%s: expect no error when applying json patch, but got %v", test.name, err)
 				continue
 			}
-			if err.Error() != test.expectedError {
+			if !strings.Contains(err.Error(), test.expectedError) {
 				t.Errorf("%s: expected error %v, but got %v", test.name, test.expectedError, err)
 			}
 			if test.expectedErrorType != apierrors.ReasonForError(err) {

--- a/staging/src/k8s.io/client-go/tools/remotecommand/v4_test.go
+++ b/staging/src/k8s.io/client-go/tools/remotecommand/v4_test.go
@@ -18,6 +18,7 @@ package remotecommand
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 )
 
@@ -36,7 +37,7 @@ func TestV4ErrorDecoder(t *testing.T) {
 		},
 		{
 			message: "{",
-			err:     "error stream protocol error: unexpected end of JSON input in \"{\"",
+			err:     "unexpected end of JSON input in \"{\"",
 		},
 		{
 			message: `{"status": "Success" }`,
@@ -64,7 +65,7 @@ func TestV4ErrorDecoder(t *testing.T) {
 		if want == "" {
 			want = "<nil>"
 		}
-		if got := fmt.Sprintf("%v", err); got != want {
+		if got := fmt.Sprintf("%v", err); !strings.Contains(got, want) {
 			t.Errorf("wrong error for message %q: want=%q, got=%q", test.message, want, got)
 		}
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
Fixes the Below Unit test Failures when run with master golang. Make the error messages more tolerant to avoid failures due to mismatch in messages.

    k8s.io/kubernetes/pkg/kubelet/cm/cpumanager/state: TestCheckpointStateRestore/Restore_checkpoint_with_invalid_JSON
    error:=== RUN TestCheckpointStateRestore/Restore_checkpoint_with_invalid_JSON
    I1124 05:38:14.686883 60889 state_mem.go:36] [cpumanager] initializing new in-memory state store
    state_checkpoint_test.go:236: unexpected error while creatng checkpointState: could not restore state from checkpoint: json: unexpected end of JSON input, please drain this node and delete the CPU manager checkpoint file "/tmp/cpumanager_state_test479660663/cpumanager_checkpoint_test" before restarting Kubelet
    --- FAIL: TestCheckpointStateRestore/Restore_checkpoint_with_invalid_JSON (0.00s)
    k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/endpoints/handlers: TestStrategicMergePatchInvalid
    error:=== RUN TestStrategicMergePatchInvalid
    rest_test.go:127: expected "invalid character 'b' looking for beginning of value", got "json: invalid character 'b' looking for beginning of value"
    --- FAIL: TestStrategicMergePatchInvalid (0.00s)
    k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/endpoints/handlers: TestJSONPatch
    error:=== RUN TestJSONPatch
    rest_test.go:175: invalid-syntax: expected error invalid character 'i' looking for beginning of value, but got json: invalid character 'i' looking for beginning of value
    --- FAIL: TestJSONPatch (0.00s)
    k8s.io/kubernetes/vendor/k8s.io/client-go/tools/remotecommand: TestV4ErrorDecoder expand_less
    error:=== RUN TestV4ErrorDecoder
    v4_test.go:68: wrong error for message "{": want="error stream protocol error: unexpected end of JSON input in "{"", got="error stream protocol error: json: unexpected end of JSON input in "{""
    --- FAIL: TestV4ErrorDecoder (0.00s


<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
To run UT with latest aster golang without failures.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #96853
```
