### PR TITLE
coredns dep.Severity is newdefault, not newDefault

### DIFF
--- a/cmd/kubeadm/app/phases/addons/dns/dns.go
+++ b/cmd/kubeadm/app/phases/addons/dns/dns.go
@@ -380,7 +380,7 @@ func isCoreDNSConfigMapMigrationRequired(corefile, currentInstalledCoreDNSVersio
 
 	// Check if there are any plugins/options which needs to be removed or is a new default
 	for _, dep := range deprecated {
-		if dep.Severity == "removed" || dep.Severity == "newDefault" {
+		if dep.Severity == "removed" || dep.Severity == "newdefault" {
 			isMigrationRequired = true
 		}
 	}


### PR DESCRIPTION
https://github.com/kubernetes/kubernetes/blob/5ed4b76a03b5eddc62939a1569b61532b4a06a72/vendor/github.com/coredns/corefile-migration/migration/notice.go#L43

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
typo in code which makes that migration is not triggerred

**Which issue(s) this PR fixes**:

During investigating the  #96833 , I find this issue

**Special notes for your reviewer**:


**Does this PR introduce a user-facing change?**:

```release-note
kubeadm: fix coredns migration should be triggered when there are newdefault configs during kubeadm upgrade
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```

![image](https://user-images.githubusercontent.com/2010320/101282501-8c55d680-3810-11eb-8b31-ad1f15c267d0.png)
