### PR TITLE
Scheduler: do not set default value for invalid healthz and metrics IP

### DIFF
--- a/pkg/scheduler/apis/config/v1beta1/defaults.go
+++ b/pkg/scheduler/apis/config/v1beta1/defaults.go
@@ -62,7 +62,6 @@ func SetDefaults_KubeSchedulerConfiguration(obj *v1beta1.KubeSchedulerConfigurat
 	// 1. If the value is nil, default to 0.0.0.0 and default scheduler port
 	// 2. If there is a value set, attempt to split it. If it's just a port (ie, ":1234"), default to 0.0.0.0 with that port
 	// 3. If splitting the value fails, check if the value is even a valid IP. If so, use that with the default port.
-	// Otherwise use the default bind address
 	defaultBindAddress := net.JoinHostPort("0.0.0.0", strconv.Itoa(config.DefaultInsecureSchedulerPort))
 	if obj.HealthzBindAddress == nil {
 		obj.HealthzBindAddress = &defaultBindAddress
@@ -79,9 +78,6 @@ func SetDefaults_KubeSchedulerConfiguration(obj *v1beta1.KubeSchedulerConfigurat
 			if host := net.ParseIP(*obj.HealthzBindAddress); host != nil {
 				hostPort := net.JoinHostPort(*obj.HealthzBindAddress, strconv.Itoa(config.DefaultInsecureSchedulerPort))
 				obj.HealthzBindAddress = &hostPort
-			} else {
-				// TODO: in v1beta1 we should let this error instead of stomping with a default value
-				obj.HealthzBindAddress = &defaultBindAddress
 			}
 		}
 	}
@@ -101,9 +97,6 @@ func SetDefaults_KubeSchedulerConfiguration(obj *v1beta1.KubeSchedulerConfigurat
 			if host := net.ParseIP(*obj.MetricsBindAddress); host != nil {
 				hostPort := net.JoinHostPort(*obj.MetricsBindAddress, strconv.Itoa(config.DefaultInsecureSchedulerPort))
 				obj.MetricsBindAddress = &hostPort
-			} else {
-				// TODO: in v1beta1 we should let this error instead of stomping with a default value
-				obj.MetricsBindAddress = &defaultBindAddress
 			}
 		}
 	}

--- a/pkg/scheduler/apis/config/v1beta1/defaults_test.go
+++ b/pkg/scheduler/apis/config/v1beta1/defaults_test.go
@@ -260,6 +260,42 @@ func TestSchedulerDefaults(t *testing.T) {
 			},
 		},
 		{
+			name: "metrics and healthz port cannot be split successfully",
+			config: &v1beta1.KubeSchedulerConfiguration{
+				MetricsBindAddress: pointer.StringPtr("0.0.0.0::12345"),
+				HealthzBindAddress: pointer.StringPtr("0.0.0.0::12345"),
+			},
+			expected: &v1beta1.KubeSchedulerConfiguration{
+				Parallelism:        pointer.Int32Ptr(16),
+				HealthzBindAddress: pointer.StringPtr("0.0.0.0::12345"),
+				MetricsBindAddress: pointer.StringPtr("0.0.0.0::12345"),
+				DebuggingConfiguration: componentbaseconfig.DebuggingConfiguration{
+					EnableProfiling:           &enable,
+					EnableContentionProfiling: &enable,
+				},
+				LeaderElection: componentbaseconfig.LeaderElectionConfiguration{
+					LeaderElect:       pointer.BoolPtr(true),
+					LeaseDuration:     metav1.Duration{Duration: 15 * time.Second},
+					RenewDeadline:     metav1.Duration{Duration: 10 * time.Second},
+					RetryPeriod:       metav1.Duration{Duration: 2 * time.Second},
+					ResourceLock:      "leases",
+					ResourceNamespace: "kube-system",
+					ResourceName:      "kube-scheduler",
+				},
+				ClientConnection: componentbaseconfig.ClientConnectionConfiguration{
+					QPS:         50,
+					Burst:       100,
+					ContentType: "application/vnd.kubernetes.protobuf",
+				},
+				PercentageOfNodesToScore: pointer.Int32Ptr(0),
+				PodInitialBackoffSeconds: pointer.Int64Ptr(1),
+				PodMaxBackoffSeconds:     pointer.Int64Ptr(10),
+				Profiles: []v1beta1.KubeSchedulerProfile{
+					{SchedulerName: pointer.StringPtr("default-scheduler")},
+				},
+			},
+		},
+		{
 			name: "set non default parallelism",
 			config: &v1beta1.KubeSchedulerConfiguration{
 				Parallelism: pointer.Int32Ptr(8),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:

Take action for "// TODO: in v1beta1 we should let this error instead of stomping with a default value".

For backwards compatibility, when healthz and metrics bind address cannot be split successfully in config, scheduler will set `defaultBindAddress` for them. It is no more needed in v1beta1.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
none
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
none
```

/cc @damemi 