### PR TITLE
[WIP] force pods to use TCP for dns resolution

### DIFF
--- a/pkg/kubeapiserver/options/BUILD
+++ b/pkg/kubeapiserver/options/BUILD
@@ -39,6 +39,7 @@ go_library(
         "//plugin/pkg/admission/noderestriction:go_default_library",
         "//plugin/pkg/admission/nodetaint:go_default_library",
         "//plugin/pkg/admission/podnodeselector:go_default_library",
+        "//plugin/pkg/admission/podtcpresolution:go_default_library",
         "//plugin/pkg/admission/podtolerationrestriction:go_default_library",
         "//plugin/pkg/admission/priority:go_default_library",
         "//plugin/pkg/admission/runtimeclass:go_default_library",

--- a/pkg/kubeapiserver/options/plugins.go
+++ b/pkg/kubeapiserver/options/plugins.go
@@ -41,6 +41,7 @@ import (
 	"k8s.io/kubernetes/plugin/pkg/admission/noderestriction"
 	"k8s.io/kubernetes/plugin/pkg/admission/nodetaint"
 	"k8s.io/kubernetes/plugin/pkg/admission/podnodeselector"
+	"k8s.io/kubernetes/plugin/pkg/admission/podtcpresolution"
 	"k8s.io/kubernetes/plugin/pkg/admission/podtolerationrestriction"
 	podpriority "k8s.io/kubernetes/plugin/pkg/admission/priority"
 	"k8s.io/kubernetes/plugin/pkg/admission/runtimeclass"
@@ -93,6 +94,7 @@ var AllOrderedPlugins = []string{
 	certsigning.PluginName,                  // CertificateSigning
 	certsubjectrestriction.PluginName,       // CertificateSubjectRestriction
 	defaultingressclass.PluginName,          // DefaultIngressClass
+	podtcpresolution.PluginName,             // PodTCPResolution
 
 	// new admission plugins should generally be inserted above here
 	// webhook, resourcequota, and deny plugins must go at the end
@@ -127,6 +129,7 @@ func RegisterAllAdmissionPlugins(plugins *admission.Plugins) {
 	podtolerationrestriction.Register(plugins)
 	runtimeclass.Register(plugins)
 	resourcequota.Register(plugins)
+	podtcpresolution.Register(plugins)
 	podsecuritypolicy.Register(plugins)
 	podpriority.Register(plugins)
 	scdeny.Register(plugins)

--- a/pkg/kubeapiserver/options/plugins.go
+++ b/pkg/kubeapiserver/options/plugins.go
@@ -162,6 +162,7 @@ func DefaultOffAdmissionPlugins() sets.String {
 		certsigning.PluginName,                  // CertificateSigning
 		certsubjectrestriction.PluginName,       // CertificateSubjectRestriction
 		defaultingressclass.PluginName,          //DefaultIngressClass
+		podtcpresolution.PluginName,             // PodTCPResolution
 	)
 
 	return sets.NewString(AllOrderedPlugins...).Difference(defaultOnPlugins)

--- a/plugin/BUILD
+++ b/plugin/BUILD
@@ -29,6 +29,7 @@ filegroup(
         "//plugin/pkg/admission/noderestriction:all-srcs",
         "//plugin/pkg/admission/nodetaint:all-srcs",
         "//plugin/pkg/admission/podnodeselector:all-srcs",
+        "//plugin/pkg/admission/podtcpresolution:all-srcs",
         "//plugin/pkg/admission/podtolerationrestriction:all-srcs",
         "//plugin/pkg/admission/priority:all-srcs",
         "//plugin/pkg/admission/resourcequota:all-srcs",

--- a/plugin/pkg/admission/podtcpresolution/BUILD
+++ b/plugin/pkg/admission/podtcpresolution/BUILD
@@ -1,0 +1,47 @@
+package(default_visibility = ["//visibility:public"])
+
+load(
+    "@io_bazel_rules_go//go:def.bzl",
+    "go_library",
+    "go_test",
+)
+
+go_library(
+    name = "go_default_library",
+    srcs = ["admission.go"],
+    importpath = "k8s.io/kubernetes/plugin/pkg/admission/podtcpresolution",
+    deps = [
+        "//pkg/apis/core:go_default_library",
+        "//pkg/apis/core/pods:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/api/errors:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/errors:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/validation/field:go_default_library",
+        "//staging/src/k8s.io/apiserver/pkg/admission:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["admission_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//pkg/apis/core:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
+        "//staging/src/k8s.io/apiserver/pkg/admission:go_default_library",
+        "//staging/src/k8s.io/apiserver/pkg/admission/testing:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+)

--- a/plugin/pkg/admission/podtcpresolution/admission.go
+++ b/plugin/pkg/admission/podtcpresolution/admission.go
@@ -1,0 +1,134 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package podtcpresolution contains an admission controller that modifies every new Pod,
+// that uses the GNU libc library, to force the DNS resolution to use TCP.
+// This is useful in busy clusters that may have issues due to UDP packet drops.
+// With this admission controller enabled, an environment variable, RES_OPTIONS=use-vc,
+// is added to each POD. This variable only works for applications and systems that use
+// the libc library resolver, other applications will be working as always.
+// ref: https://man7.org/linux/man-pages/man5/resolv.conf.5.html
+package podtcpresolution
+
+import (
+	"context"
+	"io"
+	"strings"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/apiserver/pkg/admission"
+	"k8s.io/kubernetes/pkg/apis/core"
+	api "k8s.io/kubernetes/pkg/apis/core"
+	"k8s.io/kubernetes/pkg/apis/core/pods"
+)
+
+// PluginName indicates name of admission plugin.
+const PluginName = "PodTCPResolution"
+
+// Register registers a plugin
+func Register(plugins *admission.Plugins) {
+	plugins.Register(PluginName, func(config io.Reader) (admission.Interface, error) {
+		return NewPodTCPResolution(), nil
+	})
+}
+
+// PodTCPResolution is an implementation of admission.Interface.
+// It looks at all new pods and sets the environment variable RES_OPTIONS in all containers .
+type PodTCPResolution struct {
+	*admission.Handler
+}
+
+var _ admission.MutationInterface = &PodTCPResolution{}
+var _ admission.ValidationInterface = &PodTCPResolution{}
+
+// Admit makes an admission decision based on the request attributes
+func (a *PodTCPResolution) Admit(ctx context.Context, attributes admission.Attributes, o admission.ObjectInterfaces) (err error) {
+	// Ignore all calls to subresources or resources other than pods.
+	if shouldIgnore(attributes) {
+		return nil
+	}
+	pod, ok := attributes.GetObject().(*api.Pod)
+	if !ok {
+		return apierrors.NewBadRequest("Resource was marked with kind Pod but was unable to be converted")
+	}
+
+	pods.VisitContainersWithPath(&pod.Spec, field.NewPath("spec"), func(c *api.Container, _ *field.Path) bool {
+		idx, value := getEnvValueByName("RES_OPTIONS", c.Env)
+		// append the environment variable if it doesn't exist
+		if value == "" {
+			c.Env = append(c.Env, api.EnvVar{Name: "RES_OPTIONS", Value: "use-vc"})
+		} else if !strings.Contains(value, "use-vc") {
+			c.Env[idx].Value = value + " use-vc"
+		}
+		return true
+	})
+	return nil
+}
+
+// Validate makes sure that all containers are set to always pull images
+func (*PodTCPResolution) Validate(ctx context.Context, attributes admission.Attributes, o admission.ObjectInterfaces) (err error) {
+	if shouldIgnore(attributes) {
+		return nil
+	}
+
+	pod, ok := attributes.GetObject().(*api.Pod)
+	if !ok {
+		return apierrors.NewBadRequest("Resource was marked with kind Pod but was unable to be converted")
+	}
+
+	var allErrs []error
+	pods.VisitContainersWithPath(&pod.Spec, field.NewPath("spec"), func(c *api.Container, p *field.Path) bool {
+		_, value := getEnvValueByName("RES_OPTIONS", c.Env)
+		if value == "" || !strings.Contains(value, "use-vc") {
+			allErrs = append(allErrs, field.NotFound(p.Child("env"), "RES_OPTIONS=\"use-vc\" to force tcp dns resolution"))
+		}
+		return true
+	})
+	if len(allErrs) > 0 {
+		return utilerrors.NewAggregate(allErrs)
+	}
+
+	return nil
+}
+
+func shouldIgnore(attributes admission.Attributes) bool {
+	// Ignore all calls to subresources or resources other than pods.
+	if len(attributes.GetSubresource()) != 0 || attributes.GetResource().GroupResource() != api.Resource("pods") {
+		return true
+	}
+
+	return false
+}
+
+// getEnvValueByName returns the value and position in the slice of the environment variable specified
+// or empty if not found
+func getEnvValueByName(name string, envVars []core.EnvVar) (int, string) {
+	for idx, env := range envVars {
+		if env.Name == name {
+			return idx, env.Value
+		}
+	}
+	return 0, ""
+}
+
+// NewPodTCPResolution creates a new force DNS TCP admission control handler
+func NewPodTCPResolution() *PodTCPResolution {
+	return &PodTCPResolution{
+		Handler: admission.NewHandler(admission.Create, admission.Update),
+	}
+}

--- a/plugin/pkg/admission/podtcpresolution/admission_test.go
+++ b/plugin/pkg/admission/podtcpresolution/admission_test.go
@@ -1,0 +1,171 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package podtcpresolution
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apiserver/pkg/admission"
+	admissiontesting "k8s.io/apiserver/pkg/admission/testing"
+	api "k8s.io/kubernetes/pkg/apis/core"
+)
+
+// TestAdmission verifies all create requests for pods result in every container has
+// the environment variable RES_OPTION=use-vc
+func TestAdmission(t *testing.T) {
+	namespace := "test"
+	handler := admissiontesting.WithReinvocationTesting(t, &PodTCPResolution{})
+	pod := api.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "123", Namespace: namespace},
+		Spec: api.PodSpec{
+			InitContainers: []api.Container{
+				{Name: "init1", Image: "image"},
+				{Name: "init2", Image: "image", Env: []api.EnvVar{{Name: "POD_IP", Value: "192.168.2.1"}}},
+				{Name: "init3", Image: "image"},
+				{Name: "init4", Image: "image"},
+			},
+			Containers: []api.Container{
+				{Name: "ctr1", Image: "image"},
+				{Name: "ctr2", Image: "image", Env: []api.EnvVar{{Name: "RES_OPTIONS", Value: "use-vc"}}},
+				{Name: "ctr3", Image: "image", Env: []api.EnvVar{{Name: "RES_OPTIONS", Value: "ndots:2"}}},
+				{Name: "ctr4", Image: "image", Env: []api.EnvVar{{Name: "RES_OPTIONS", Value: "ndots:2 use-vc"}}},
+			},
+		},
+	}
+	err := handler.Admit(context.TODO(), admission.NewAttributesRecord(&pod, nil, api.Kind("Pod").WithVersion("version"), pod.Namespace, pod.Name, api.Resource("pods").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, nil), nil)
+	if err != nil {
+		t.Errorf("Unexpected error returned from admission handler")
+	}
+	for _, c := range pod.Spec.InitContainers {
+		_, value := getEnvValueByName("RES_OPTIONS", c.Env)
+		if !strings.Contains(value, "use-vc") {
+			t.Errorf("Container %v: not expected env variable RES_OPTIONS=use-vc, got %v", c, c.Env)
+		}
+	}
+	for _, c := range pod.Spec.Containers {
+		_, value := getEnvValueByName("RES_OPTIONS", c.Env)
+		if !strings.Contains(value, "use-vc") {
+			t.Errorf("Container %v: expected RES_OPTIONS=use-vc, got %v", c, c.Env)
+		}
+	}
+}
+
+func TestValidate(t *testing.T) {
+	namespace := "test"
+	handler := &PodTCPResolution{}
+	pod := api.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "123", Namespace: namespace},
+		Spec: api.PodSpec{
+			InitContainers: []api.Container{
+				{Name: "init1", Image: "image"},
+				{Name: "init2", Image: "image", Env: []api.EnvVar{{Name: "POD_IP", Value: "192.168.2.1"}}},
+				{Name: "init3", Image: "image"},
+				{Name: "init4", Image: "image"},
+			},
+			Containers: []api.Container{
+				{Name: "ctr1", Image: "image"},
+				{Name: "ctr2", Image: "image", Env: []api.EnvVar{{Name: "RES_OPTIONS", Value: "use-vc"}}},
+				{Name: "ctr3", Image: "image", Env: []api.EnvVar{{Name: "RES_OPTIONS", Value: "ndots:2"}}},
+				{Name: "ctr4", Image: "image", Env: []api.EnvVar{{Name: "RES_OPTIONS", Value: "ndots:2 use-vc"}}},
+			},
+		},
+	}
+	expectedError := `[` +
+		`spec.initContainers[0].env: Not found: "RES_OPTIONS=\"use-vc\" to force tcp dns resolution", ` +
+		`spec.initContainers[1].env: Not found: "RES_OPTIONS=\"use-vc\" to force tcp dns resolution", ` +
+		`spec.initContainers[2].env: Not found: "RES_OPTIONS=\"use-vc\" to force tcp dns resolution", ` +
+		`spec.initContainers[3].env: Not found: "RES_OPTIONS=\"use-vc\" to force tcp dns resolution", ` +
+		`spec.containers[0].env: Not found: "RES_OPTIONS=\"use-vc\" to force tcp dns resolution", ` +
+		`spec.containers[2].env: Not found: "RES_OPTIONS=\"use-vc\" to force tcp dns resolution"]`
+	err := handler.Validate(context.TODO(), admission.NewAttributesRecord(&pod, nil, api.Kind("Pod").WithVersion("version"), pod.Namespace, pod.Name, api.Resource("pods").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, nil), nil)
+	if err == nil {
+		t.Fatal("missing expected error")
+	}
+	if err.Error() != expectedError {
+		t.Fatal(err)
+	}
+}
+
+// TestOtherResources ensures that this admission controller is a no-op for other resources,
+// subresources, and non-pods.
+func TestOtherResources(t *testing.T) {
+	namespace := "testnamespace"
+	name := "testname"
+	pod := &api.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Spec: api.PodSpec{
+			Containers: []api.Container{
+				{Name: "ctr2", Image: "image"},
+			},
+		},
+	}
+	tests := []struct {
+		name        string
+		kind        string
+		resource    string
+		subresource string
+		object      runtime.Object
+		expectError bool
+	}{
+		{
+			name:     "non-pod resource",
+			kind:     "Foo",
+			resource: "foos",
+			object:   pod,
+		},
+		{
+			name:        "pod subresource",
+			kind:        "Pod",
+			resource:    "pods",
+			subresource: "exec",
+			object:      pod,
+		},
+		{
+			name:        "non-pod object",
+			kind:        "Pod",
+			resource:    "pods",
+			object:      &api.Service{},
+			expectError: true,
+		},
+	}
+
+	for _, tc := range tests {
+		handler := admissiontesting.WithReinvocationTesting(t, &PodTCPResolution{})
+
+		err := handler.Admit(context.TODO(), admission.NewAttributesRecord(tc.object, nil, api.Kind(tc.kind).WithVersion("version"), namespace, name, api.Resource(tc.resource).WithVersion("version"), tc.subresource, admission.Create, &metav1.CreateOptions{}, false, nil), nil)
+
+		if tc.expectError {
+			if err == nil {
+				t.Errorf("%s: unexpected nil error", tc.name)
+			}
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("%s: unexpected error: %v", tc.name, err)
+			continue
+		}
+
+		if len(pod.Spec.Containers[0].Env) > 0 {
+			t.Errorf("%s: container environment variables has changed %v", tc.name, pod.Spec.Containers[0].Env)
+		}
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

on systems using the libc resolver for DNS resolution,
you can force the resolver to use TCP, setting the
option use-vc

use-vc (since glibc 2.14)
	Sets RES_USEVC in _res.options.  This option forces the
	use of TCP for DNS resolutions.

The options keyword of a system's resolv.conf file can be amended on
a per-process basis by setting the environment variable RES_OPTIONS
to a space-separated list of resolver options as explained above
under options.

However, this options is not available in other libraries like
musl-libc, setting the environment variable instead of modifying
the resolv.conf file make it compatible with all the different
systems and applications.

The admision controller modifies the Containers on Pods and sets the
environment variable RES_OPTIONS in all of them to have the value
use-vc

ref: https://man7.org/linux/man-pages/man5/resolv.conf.5.html

```release-note
TBD
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs
- [KEP]: <link>TBD
- [Usage]: <link>TBD
- [Other doc]: <link>TBD
```
