### PR TITLE
Fix a memory leak of EndpointReconciler

### DIFF
--- a/pkg/controlplane/instance.go
+++ b/pkg/controlplane/instance.go
@@ -270,13 +270,13 @@ func (c *Config) createLeaseReconciler() reconcilers.EndpointReconciler {
 	if err != nil {
 		klog.Fatalf("Error determining service IP ranges: %v", err)
 	}
-	leaseStorage, _, err := storagefactory.Create(*config, nil)
+	leaseStorage, destroyFunc, err := storagefactory.Create(*config, nil)
 	if err != nil {
 		klog.Fatalf("Error creating storage factory: %v", err)
 	}
 	masterLeases := reconcilers.NewLeases(leaseStorage, "/masterleases/", ttl)
 
-	return reconcilers.NewLeaseEndpointReconciler(endpointsAdapter, masterLeases)
+	return reconcilers.NewLeaseEndpointReconciler(endpointsAdapter, masterLeases, destroyFunc)
 }
 
 func (c *Config) createEndpointReconciler() reconcilers.EndpointReconciler {

--- a/pkg/controlplane/reconcilers/lease_test.go
+++ b/pkg/controlplane/reconcilers/lease_test.go
@@ -458,7 +458,7 @@ func TestLeaseEndpointReconciler(t *testing.T) {
 		}
 
 		epAdapter := EndpointsAdapter{endpointClient: clientset.CoreV1()}
-		r := NewLeaseEndpointReconciler(epAdapter, fakeLeases)
+		r := NewLeaseEndpointReconciler(epAdapter, fakeLeases, func() {})
 		err := r.ReconcileEndpoints(test.serviceName, net.ParseIP(test.ip), test.endpointPorts, true)
 		if err != nil {
 			t.Errorf("case %q: unexpected error: %v", test.testName, err)
@@ -559,7 +559,7 @@ func TestLeaseEndpointReconciler(t *testing.T) {
 				}
 			}
 			epAdapter := EndpointsAdapter{endpointClient: clientset.CoreV1()}
-			r := NewLeaseEndpointReconciler(epAdapter, fakeLeases)
+			r := NewLeaseEndpointReconciler(epAdapter, fakeLeases, func() {})
 			err := r.ReconcileEndpoints(test.serviceName, net.ParseIP(test.ip), test.endpointPorts, false)
 			if err != nil {
 				t.Errorf("case %q: unexpected error: %v", test.testName, err)
@@ -679,7 +679,7 @@ func TestLeaseRemoveEndpoints(t *testing.T) {
 				}
 			}
 			epAdapter := EndpointsAdapter{endpointClient: clientset.CoreV1()}
-			r := NewLeaseEndpointReconciler(epAdapter, fakeLeases)
+			r := NewLeaseEndpointReconciler(epAdapter, fakeLeases, func() {})
 			err := r.RemoveEndpoints(test.serviceName, net.ParseIP(test.ip), test.endpointPorts)
 			if err != nil {
 				t.Errorf("case %q: unexpected error: %v", test.testName, err)


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
The endpoint entry is created in ```etcd``` when the ```EndpointReconciler``` is created, but even if the ```EndpointReconciler``` is destroyed, the endpoint entry remains. This PR modifies the endpoint entry to be deleted by calling ```destroyFunc```.

The endpoint entry in ```etcd``` is allocated at here.
https://github.com/kubernetes/kubernetes/blob/e3de62298a730415c5d2ab72607ef6adadd6304d/vendor/go.etcd.io/etcd/clientv3/balancer/resolver/endpoint/endpoint.go#L141

This issue could occur when running this integration test.
```
$ make test-integration WHAT=./test/integration/apiserver/apply
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs
NONE
```
