### PR TITLE
Add priority flag kube proxy

### DIFF
--- a/cmd/kube-proxy/app/BUILD
+++ b/cmd/kube-proxy/app/BUILD
@@ -254,6 +254,7 @@ go_library(
             "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
             "//staging/src/k8s.io/apimachinery/pkg/util/net:go_default_library",
             "//staging/src/k8s.io/component-base/metrics:go_default_library",
+            "//vendor/golang.org/x/sys/windows:go_default_library",
             "//vendor/k8s.io/utils/net:go_default_library",
         ],
         "//conditions:default": [],
@@ -263,6 +264,7 @@ go_library(
 go_test(
     name = "go_default_test",
     srcs = [
+        "init_windows_test.go",
         "server_others_test.go",
         "server_test.go",
     ],

--- a/cmd/kube-proxy/app/init_others.go
+++ b/cmd/kube-proxy/app/init_others.go
@@ -22,7 +22,7 @@ import (
 	"github.com/spf13/pflag"
 )
 
-func initForOS(service bool) error {
+func initForOS(service bool, windowsPriorityClass string) error {
 	return nil
 }
 

--- a/cmd/kube-proxy/app/init_windows.go
+++ b/cmd/kube-proxy/app/init_windows.go
@@ -19,16 +19,46 @@ limitations under the License.
 package app
 
 import (
-	"k8s.io/kubernetes/pkg/windows/service"
+	"fmt"
 
 	"github.com/spf13/pflag"
+	"golang.org/x/sys/windows"
+	"k8s.io/klog/v2"
+	"k8s.io/kubernetes/pkg/windows/service"
 )
 
 const (
 	serviceName = "kube-proxy"
 )
 
-func initForOS(windowsService bool) error {
+// getPriorityValue returns the value associated with a Windows process priorityClass
+// Ref: https://docs.microsoft.com/en-us/windows/win32/cimwin32prov/setpriority-method-in-class-win32-process
+// TODO: Think of a better way to share code between kubelet and kube-proxy as this function definition is same as what
+// 		 we have cmd/kubelet/app
+func getPriorityValue(priorityClassName string) uint32 {
+	var priorityClassMap = map[string]uint32{
+		"IDLE_PRIORITY_CLASS":         uint32(64),
+		"BELOW_NORMAL_PRIORITY_CLASS": uint32(16384),
+		"NORMAL_PRIORITY_CLASS":       uint32(32),
+		"ABOVE_NORMAL_PRIORITY_CLASS": uint32(32768),
+		"HIGH_PRIORITY_CLASS":         uint32(128),
+		"REALTIME_PRIORITY_CLASS":     uint32(256),
+	}
+	return priorityClassMap[priorityClassName]
+}
+
+func initForOS(windowsService bool, windowsPriorityClass string) error {
+	priority := getPriorityValue(windowsPriorityClass)
+	if priority == 0 {
+		return fmt.Errorf("unknown priority class %s, valid ones are available at "+
+			"https://docs.microsoft.com/en-us/windows/win32/procthread/scheduling-priorities", windowsPriorityClass)
+	}
+	kubeProxyProcessHandle := windows.CurrentProcess()
+	// Set the priority of the kube-proxy process to given priority
+	klog.Infof("Setting the priority of kube-proxy process to %s", windowsPriorityClass)
+	if err := windows.SetPriorityClass(kubeProxyProcessHandle, priority); err != nil {
+		return err
+	}
 	if windowsService {
 		return service.InitService(serviceName)
 	}
@@ -37,6 +67,12 @@ func initForOS(windowsService bool) error {
 
 func (o *Options) addOSFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&o.WindowsService, "windows-service", o.WindowsService, "Enable Windows Service Control Manager API integration")
+	// The default priority class associated with any process in Windows is NORMAL_PRIORITY_CLASS. Keeping it as is
+	// to maintain backwards compatibility.
+	// Source: https://docs.microsoft.com/en-us/windows/win32/procthread/scheduling-priorities
+	fs.StringVar(&o.WindowsPriorityClass, "windows-priorityclass", "NORMAL_PRIORITY_CLASS",
+		"Set the PriorityClass associated with kube-proxy process, the default ones are available at "+
+			"https://docs.microsoft.com/en-us/windows/win32/procthread/scheduling-priorities")
 	fs.StringVar(&o.config.Winkernel.SourceVip, "source-vip", o.config.Winkernel.SourceVip, "The IP address of the source VIP for non-DSR.")
 	fs.StringVar(&o.config.Winkernel.NetworkName, "network-name", o.config.Winkernel.NetworkName, "The name of the cluster network.")
 	fs.BoolVar(&o.config.Winkernel.EnableDSR, "enable-dsr", o.config.Winkernel.EnableDSR, "If true make kube-proxy apply DSR policies for service VIP")

--- a/cmd/kube-proxy/app/init_windows_test.go
+++ b/cmd/kube-proxy/app/init_windows_test.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package app
+
+import "testing"
+
+func TestIsValidPriorityClass(t *testing.T) {
+	testCases := []struct {
+		description           string
+		priorityClassName     string
+		expectedPriorityValue uint32
+	}{
+		{
+			description:           "Invalid Priority Class",
+			priorityClassName:     "myPriorityClass",
+			expectedPriorityValue: 0,
+		},
+		{
+			description:           "Valid Priority Class",
+			priorityClassName:     "IDLE_PRIORITY_CLASS",
+			expectedPriorityValue: uint32(64),
+		},
+	}
+	for _, test := range testCases {
+		actualPriorityValue := getPriorityValue(test.priorityClassName)
+		if test.expectedPriorityValue != actualPriorityValue {
+			t.Fatalf("unexpected error for %s", test.description)
+		}
+	}
+}

--- a/cmd/kube-proxy/app/server.go
+++ b/cmd/kube-proxy/app/server.go
@@ -113,6 +113,12 @@ type Options struct {
 	// WindowsService should be set to true if kube-proxy is running as a service on Windows.
 	// Its corresponding flag only gets registered in Windows builds
 	WindowsService bool
+	// WindowsPriorityClass sets the priority class associated with the kube-proxy process
+	// Its corresponding flag only gets registered in Windows builds
+	// The default priority class associated with any process in Windows is NORMAL_PRIORITY_CLASS. Keeping it as is
+	// to maintain backwards compatibility.
+	// Source: https://docs.microsoft.com/en-us/windows/win32/procthread/scheduling-priorities
+	WindowsPriorityClass string
 	// config is the proxy server's configuration object.
 	config *kubeproxyconfig.KubeProxyConfiguration
 	// watcher is used to watch on the update change of ConfigFile
@@ -480,7 +486,7 @@ with the apiserver API to configure the proxy.`,
 			verflag.PrintAndExitIfRequested()
 			cliflag.PrintFlags(cmd.Flags())
 
-			if err := initForOS(opts.WindowsService); err != nil {
+			if err := initForOS(opts.WindowsService, opts.WindowsPriorityClass); err != nil {
 				klog.Fatalf("failed OS init: %v", err)
 			}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature


**What this PR does / why we need it**:
 Introduce windows-priorityclass flag to set priority for the kubelet running on Windows nodes

**Which issue(s) this PR fixes**:

Partially Fixes https://github.com/kubernetes/kubernetes/issues/96935

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Add a new flag to set priority for the kube-proxy on Windows nodes so that workloads cannot overwhelm the node there by disrupting kube-proxy process.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
Allow user to specify priority of the kube-proxy process on Windows nodes.
```

/sig windows
cc @marosset @jsturtevant