### PR TITLE
fix: ensure additional tags are created for existing AWS NLBs

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/aws/aws.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/aws/aws.go
@@ -2960,6 +2960,27 @@ func (c *Cloud) describeLoadBalancerv2(name string) (*elbv2.LoadBalancer, error)
 	return nil, fmt.Errorf("NLB '%s' could not be found", name)
 }
 
+func (c *Cloud) addLoadBalancerTagsv2(loadBalancerArn string, requested map[string]string) error {
+	var tags []*elbv2.Tag
+	for k, v := range requested {
+		tag := &elbv2.Tag{
+			Key:   aws.String(k),
+			Value: aws.String(v),
+		}
+		tags = append(tags, tag)
+	}
+
+	request := &elbv2.AddTagsInput{}
+	request.ResourceArns = []*string{&loadBalancerArn}
+	request.Tags = tags
+
+	_, err := c.elbv2.AddTags(request)
+	if err != nil {
+		return fmt.Errorf("error adding tags to load balancer: %v", err)
+	}
+	return nil
+}
+
 // Retrieves instance's vpc id from metadata
 func (c *Cloud) findVPCID() (string, error) {
 	macs, err := c.metadata.GetMetadata("network/interfaces/macs/")

--- a/staging/src/k8s.io/legacy-cloud-providers/aws/aws_loadbalancer.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/aws/aws_loadbalancer.go
@@ -32,9 +32,9 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/elb"
 	"github.com/aws/aws-sdk-go/service/elbv2"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/klog/v2"
 
-	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 )
@@ -365,6 +365,14 @@ func (c *Cloud) ensureLoadBalancerv2(namespacedName types.NamespacedName, loadBa
 						}
 						dirty = true
 					}
+				}
+			}
+
+			// add additional tags
+			if len(tags) > 0 {
+				err := c.addLoadBalancerTagsv2(aws.StringValue(loadBalancer.LoadBalancerArn), tags)
+				if err != nil {
+					return nil, fmt.Errorf("unable to create additional load balancer tags: %v", err)
 				}
 			}
 		}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Adding an annotation of type `service.beta.kubernetes.io/aws-load-balancer-additional-resource-tags` to an AWS NLB should trigger an update that will create the annotation tags on the target NLB. However, this seems to only work during the creation of new NLB instances whereas existing NLBs would not be updated with the new tags. 

This PR adds code to handle the creation of additional tags for existing NLBs. 

**Which issue(s) this PR fixes**:

Fixes #95106

**Release note**

```release-note
fix: ensure additional tags are created for existing AWS NLBs
```
