### PR TITLE
fix deletionTimestamp issue in CSI VolumeAttachment

### DIFF
--- a/pkg/volume/csi/csi_attacher.go
+++ b/pkg/volume/csi/csi_attacher.go
@@ -615,11 +615,6 @@ func verifyAttachmentStatus(attachment *storage.VolumeAttachment, volumeHandle s
 		klog.Error(log("VolumeAttachment [%s] has been deleted, will not continue to wait for attachment", volumeHandle))
 		return false, errors.New("volume attachment has been deleted")
 	}
-	// if being deleted, fail fast
-	if attachment.GetDeletionTimestamp() != nil {
-		klog.Error(log("VolumeAttachment [%s] has deletion timestamp, will not continue to wait for attachment", attachment.Name))
-		return false, errors.New("volume attachment is being deleted")
-	}
 	// attachment OK
 	if attachment.Status.Attached {
 		return true, nil
@@ -629,6 +624,11 @@ func verifyAttachmentStatus(attachment *storage.VolumeAttachment, volumeHandle s
 	if attachErr != nil {
 		klog.Error(log("attachment for %v failed: %v", volumeHandle, attachErr.Message))
 		return false, errors.New(attachErr.Message)
+	}
+	// if being deleted, fail fast
+	if attachment.GetDeletionTimestamp() != nil {
+		klog.Error(log("VolumeAttachment [%s] has deletion timestamp, will not continue to wait for attachment", attachment.Name))
+		return false, errors.New("volume attachment is being deleted")
 	}
 	return false, nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
fix deletionTimestamp issue in VolumeAttachment

There is case that `deletionTimestamp` is not empty and we always hit following error, delete VolumeAttachment or `deletionTimestamp` does not work either , this PR move the `deletionTimestamp` check to the end of the func `verifyAttachmentStatus` to get rid of such case.

```
Events:
  Type     Reason              Age                   From                               Message
  ----     ------              ----                  ----                               -------
  Warning  FailedMount         38m (x50 over 8h)     kubelet, k8s-agentpool-28749203-1  Unable to attach or mount volumes: unmounted volumes=[azurefile01], unattached volumes=[default-token-28z2s azurefile01]: timed out waiting for the condition
  Warning  FailedMount         18m (x163 over 8h)    kubelet, k8s-agentpool-28749203-1  Unable to attach or mount volumes: unmounted volumes=[azurefile01], unattached volumes=[azurefile01 default-token-28z2s]: timed out waiting for the condition
  Warning  FailedAttachVolume  8m19s (x252 over 8h)  attachdetach-controller            AttachVolume.Attach failed for volume "pvc-5ce576eb-9dc3-4223-bdc5-96fe820f36c2" : volume attachment is being deleted
  Warning  FailedMount         3m41s (x254 over 8h)  kubelet, k8s-agentpool-28749203-1  MountVolume.WaitForAttach failed for volume "pvc-5ce576eb-9dc3-4223-bdc5-96fe820f36c2" : volume attachment is being deleted
```

```yaml
# k get VolumeAttachment csi-0e4e8d6e0077022980b3de60b3fd46060b4cd8feca96eef7126a4f5e75a65680 -o yaml
apiVersion: storage.k8s.io/v1
kind: VolumeAttachment
metadata:
  annotations:
    csi.alpha.kubernetes.io/node-id: k8s-agentpool-28749203-1
  creationTimestamp: "2020-11-28T02:16:33Z"
  deletionGracePeriodSeconds: 0
  deletionTimestamp: "2020-11-28T15:07:50Z"
  finalizers:
  - external-attacher/file-csi-azure-com
  managedFields:
  - apiVersion: storage.k8s.io/v1
    fieldsType: FieldsV1
    fieldsV1:
      f:metadata:
        f:annotations:
          .: {}
          f:csi.alpha.kubernetes.io/node-id: {}
        f:finalizers:
          .: {}
          v:"external-attacher/file-csi-azure-com": {}
      f:status:
        f:attached: {}
    manager: csi-attacher
    operation: Update
    time: "2020-11-28T02:16:33Z"
  - apiVersion: storage.k8s.io/v1
    fieldsType: FieldsV1
    fieldsV1:
      f:spec:
        f:attacher: {}
        f:nodeName: {}
        f:source:
          f:persistentVolumeName: {}
    manager: kube-controller-manager
    operation: Update
    time: "2020-11-28T02:16:33Z"
  name: csi-0e4e8d6e0077022980b3de60b3fd46060b4cd8feca96eef7126a4f5e75a65680
  resourceVersion: "12209758"
  selfLink: /apis/storage.k8s.io/v1/volumeattachments/csi-0e4e8d6e0077022980b3de60b3fd46060b4cd8feca96eef7126a4f5e75a65680
  uid: e24d3374-979c-4fe1-9a87-d97ae8fad84c
spec:
  attacher: file.csi.azure.com
  nodeName: k8s-agentpool-28749203-1
  source:
    persistentVolumeName: pvc-5ce576eb-9dc3-4223-bdc5-96fe820f36c2
status:
  attached: true
```

```console
# k delete VolumeAttachment csi-0e4e8d6e0077022980b3de60b3fd46060b4cd8feca96eef7126a4f5e75a65680 --force --grace-period=0
warning: Immediate deletion does not wait for confirmation that the running resource has been terminated. The resource may continue to run on the cluster indefinitely.
volumeattachment.storage.k8s.io "csi-0e4e8d6e0077022980b3de60b3fd46060b4cd8feca96eef7126a4f5e75a65680" force deleted
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
fix deletionTimestamp issue in VolumeAttachment
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
fix deletionTimestamp issue in VolumeAttachment
```

/kind bug
/priority important-soon
/sig storage
/triage accepted

/assign @cwdsuzhou @jsafrane 