### PR TITLE
kubelet: remove periodic messages from log-level 2

### DIFF
--- a/pkg/kubelet/cm/container_manager_linux.go
+++ b/pkg/kubelet/cm/container_manager_linux.go
@@ -983,7 +983,6 @@ func ensureSystemCgroups(rootCgroupPath string, manager cgroups.Manager) error {
 
 			pids = append(pids, pid)
 		}
-		klog.Infof("Found %d PIDs in root, %d of them are not to be moved", len(allPids), len(allPids)-len(pids))
 
 		// Check if we have moved all the non-kernel PIDs.
 		if len(pids) == 0 {

--- a/pkg/kubelet/nodestatus/setters.go
+++ b/pkg/kubelet/nodestatus/setters.go
@@ -26,7 +26,7 @@ import (
 
 	cadvisorapiv1 "github.com/google/cadvisor/info/v1"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/errors"
@@ -83,13 +83,13 @@ func NodeAddress(nodeIPs []net.IP, // typically Kubelet.nodeIPs
 			if err := validateNodeIPFunc(nodeIP); err != nil {
 				return fmt.Errorf("failed to validate nodeIP: %v", err)
 			}
-			klog.V(2).Infof("Using node IP: %q", nodeIP.String())
+			klog.V(4).Infof("Using node IP: %q", nodeIP.String())
 		}
 		if secondaryNodeIPSpecified {
 			if err := validateNodeIPFunc(secondaryNodeIP); err != nil {
 				return fmt.Errorf("failed to validate secondaryNodeIP: %v", err)
 			}
-			klog.V(2).Infof("Using secondary node IP: %q", secondaryNodeIP.String())
+			klog.V(4).Infof("Using secondary node IP: %q", secondaryNodeIP.String())
 		}
 
 		if externalCloudProvider {


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
The kubelet generally limits periodic non-error messages to log-level 3 or higher.  There are currently two exceptions that this PR fixes.

Example kubelet logging at 2:
```
17:24:08.074087 2003099 container_manager_linux.go:988] Found 132 PIDs in root, 132 of them are not to be moved
17:24:08.582165 2003099 setters.go:77] Using node IP: "10.42.11.112"
17:24:18.589713 2003099 setters.go:77] Using node IP: "10.42.11.112"
17:24:28.596933 2003099 setters.go:77] Using node IP: "10.42.11.112"
17:24:38.603891 2003099 setters.go:77] Using node IP: "10.42.11.112"
17:24:48.611768 2003099 setters.go:77] Using node IP: "10.42.11.112"
17:24:58.618912 2003099 setters.go:77] Using node IP: "10.42.11.112"
17:25:08.078024 2003099 container_manager_linux.go:988] Found 132 PIDs in root, 132 of them are not to be moved
17:25:08.669373 2003099 setters.go:77] Using node IP: "10.42.11.112"
17:25:18.736921 2003099 setters.go:77] Using node IP: "10.42.11.112"
17:25:28.810629 2003099 setters.go:77] Using node IP: "10.42.11.112"
17:25:38.877864 2003099 setters.go:77] Using node IP: "10.42.11.112"
17:25:48.940386 2003099 setters.go:77] Using node IP: "10.42.11.112"
17:25:59.004711 2003099 setters.go:77] Using node IP: "10.42.11.112"
```

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/sig node
/cc @rphillips @dims