### PR TITLE
Fix bug where RBAC disallows a URL matching a rule if the URL has a query string

### DIFF
--- a/pkg/apis/rbac/v1/evaluation_helpers.go
+++ b/pkg/apis/rbac/v1/evaluation_helpers.go
@@ -97,11 +97,18 @@ func ResourceNameMatches(rule *rbacv1.PolicyRule, requestedName string) bool {
 }
 
 func NonResourceURLMatches(rule *rbacv1.PolicyRule, requestedURL string) bool {
+	var pathOnly string
+	if i := strings.Index(requestedURL, "?"); i >= 0 {
+		pathOnly = requestedURL[0:i]
+	} else {
+		pathOnly = requestedURL
+	}
+
 	for _, ruleURL := range rule.NonResourceURLs {
 		if ruleURL == rbacv1.NonResourceAll {
 			return true
 		}
-		if ruleURL == requestedURL {
+		if ruleURL == requestedURL || ruleURL == pathOnly {
 			return true
 		}
 		if strings.HasSuffix(ruleURL, "*") && strings.HasPrefix(requestedURL, strings.TrimRight(ruleURL, "*")) {

--- a/plugin/pkg/auth/authorizer/rbac/rbac_test.go
+++ b/plugin/pkg/auth/authorizer/rbac/rbac_test.go
@@ -356,6 +356,22 @@ func TestRuleMatches(t *testing.T) {
 			},
 		},
 		{
+			name: "star nonresource, exact match other with querystring",
+			rule: rbacv1helpers.NewRule("verb1").URLs("*").RuleOrDie(),
+			requestsToExpected: map[authorizer.AttributesRecord]bool{
+				nonresourceRequest("verb1").URL("/foo?timeout=32s").New():         true,
+				nonresourceRequest("verb1").URL("/foo/bar?timeout=32s").New():     true,
+				nonresourceRequest("verb1").URL("/foo/baz?timeout=32s").New():     true,
+				nonresourceRequest("verb1").URL("/foo/bar/one?timeout=32s").New(): true,
+				nonresourceRequest("verb1").URL("/foo/baz/one?timeout=32s").New(): true,
+				nonresourceRequest("verb2").URL("/foo?timeout=32s").New():         false,
+				nonresourceRequest("verb2").URL("/foo/bar?timeout=32s").New():     false,
+				nonresourceRequest("verb2").URL("/foo/baz?timeout=32s").New():     false,
+				nonresourceRequest("verb2").URL("/foo/bar/one?timeout=32s").New(): false,
+				nonresourceRequest("verb2").URL("/foo/baz/one?timeout=32s").New(): false,
+			},
+		},
+		{
 			name: "star nonresource subpath",
 			rule: rbacv1helpers.NewRule("verb1").URLs("/foo/*").RuleOrDie(),
 			requestsToExpected: map[authorizer.AttributesRecord]bool{
@@ -372,6 +388,22 @@ func TestRuleMatches(t *testing.T) {
 			},
 		},
 		{
+			name: "star nonresource subpath with querystring",
+			rule: rbacv1helpers.NewRule("verb1").URLs("/foo/*").RuleOrDie(),
+			requestsToExpected: map[authorizer.AttributesRecord]bool{
+				nonresourceRequest("verb1").URL("/foo?timeout=32s").New():            false,
+				nonresourceRequest("verb1").URL("/foo/bar?timeout=32s").New():        true,
+				nonresourceRequest("verb1").URL("/foo/baz?timeout=32s").New():        true,
+				nonresourceRequest("verb1").URL("/foo/bar/one?timeout=32s").New():    true,
+				nonresourceRequest("verb1").URL("/foo/baz/one?timeout=32s").New():    true,
+				nonresourceRequest("verb1").URL("/notfoo?timeout=32s").New():         false,
+				nonresourceRequest("verb1").URL("/notfoo/bar?timeout=32s").New():     false,
+				nonresourceRequest("verb1").URL("/notfoo/baz?timeout=32s").New():     false,
+				nonresourceRequest("verb1").URL("/notfoo/bar/one?timeout=32s").New(): false,
+				nonresourceRequest("verb1").URL("/notfoo/baz/one?timeout=32s").New(): false,
+			},
+		},
+		{
 			name: "star verb, exact nonresource",
 			rule: rbacv1helpers.NewRule("*").URLs("/foo", "/foo/bar/one").RuleOrDie(),
 			requestsToExpected: map[authorizer.AttributesRecord]bool{
@@ -385,6 +417,22 @@ func TestRuleMatches(t *testing.T) {
 				nonresourceRequest("verb2").URL("/foo/baz").New():     false,
 				nonresourceRequest("verb2").URL("/foo/bar/one").New(): true,
 				nonresourceRequest("verb2").URL("/foo/baz/one").New(): false,
+			},
+		},
+		{
+			name: "star verb, exact nonresource with querystring",
+			rule: rbacv1helpers.NewRule("*").URLs("/foo", "/foo/bar/one").RuleOrDie(),
+			requestsToExpected: map[authorizer.AttributesRecord]bool{
+				nonresourceRequest("verb1").URL("/foo?timeout=32s").New():         true,
+				nonresourceRequest("verb1").URL("/foo/bar?timeout=32s").New():     false,
+				nonresourceRequest("verb1").URL("/foo/baz?timeout=32s").New():     false,
+				nonresourceRequest("verb1").URL("/foo/bar/one?timeout=32s").New(): true,
+				nonresourceRequest("verb1").URL("/foo/baz/one?timeout=32s").New(): false,
+				nonresourceRequest("verb2").URL("/foo?timeout=32s").New():         true,
+				nonresourceRequest("verb2").URL("/foo/bar?timeout=32s").New():     false,
+				nonresourceRequest("verb2").URL("/foo/baz?timeout=32s").New():     false,
+				nonresourceRequest("verb2").URL("/foo/bar/one?timeout=32s").New(): true,
+				nonresourceRequest("verb2").URL("/foo/baz/one?timeout=32s").New(): false,
 			},
 		},
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

This PR fixes a bug in RBAC where a non-resource URL containing a query string fails to match a non-wildcard rule, even though the path matches the rule URL exactly.

For example a rule allowing `/api` was disallowing `/api?timeout=32s` even though the `/api` part of the URL matches exactly.

To fix this, the rule match is checked against both the original request URL and just the path part of the request URL.

I wanted to leave the original comparison in place in case someone had defined a specific RBAC rule including a query string. I'm not sure if this is a valid scenario or not, but wanted to maintain that compatibility.

Here is an example showing the problem before the fix.  Notice when impersonating with group `view`, the calls return a 403 Forbidden response:
```
$ kubectl api-resources --as=kubernetes-admin --as-group=view -v6
I1130 13:47:24.244686  330578 loader.go:375] Config loaded from file:  /home/bpursley/.kube/config
I1130 13:47:24.253600  330578 round_trippers.go:443] GET https://127.0.0.1:34763/api?timeout=32s 403 Forbidden in 8 milliseconds
I1130 13:47:24.261908  330578 round_trippers.go:443] GET https://127.0.0.1:34763/apis?timeout=32s 403 Forbidden in 1 milliseconds
I1130 13:47:24.267781  330578 cached_discovery.go:125] skipped caching discovery info, no groups found
NAME   SHORTNAMES   APIGROUP   NAMESPACED   KIND
```

After this fix, the command succeeds:
```
$ kubectl api-resources --as=kubernetes-admin --as-group=view -v6
I1130 13:54:13.382622  332197 loader.go:375] Config loaded from file:  /home/bpursley/.kube/config
I1130 13:54:13.423589  332197 round_trippers.go:443] GET https://192.168.200.11:6443/api?timeout=32s 200 OK in 40 milliseconds
I1130 13:54:13.438835  332197 round_trippers.go:443] GET https://192.168.200.11:6443/apis?timeout=32s 200 OK in 7 milliseconds
I1130 13:54:13.457733  332197 round_trippers.go:443] GET https://192.168.200.11:6443/apis/events.k8s.io/v1?timeout=32s 200 OK in 9 milliseconds
I1130 13:54:13.458990  332197 round_trippers.go:443] GET https://192.168.200.11:6443/apis/policy/v1beta1?timeout=32s 200 OK in 10 milliseconds
I1130 13:54:13.459013  332197 round_trippers.go:443] GET https://192.168.200.11:6443/apis/storage.k8s.io/v1?timeout=32s 200 OK in 10 milliseconds
I1130 13:54:13.459021  332197 round_trippers.go:443] GET https://192.168.200.11:6443/api/v1?timeout=32s 200 OK in 10 milliseconds
...
```

Additionally, impersonating `system:unauthenticated` still returns a 403 Forbidden, as expected:
```
$ kubectl api-resources --as=kubernetes-admin --as-group=system:unauthenticated -v6
I1130 13:53:24.656128  332032 loader.go:375] Config loaded from file:  /home/bpursley/.kube/config
I1130 13:53:24.686325  332032 round_trippers.go:443] GET https://192.168.200.11:6443/api?timeout=32s 403 Forbidden in 28 milliseconds
I1130 13:53:24.699135  332032 round_trippers.go:443] GET https://192.168.200.11:6443/apis?timeout=32s 403 Forbidden in 3 milliseconds
I1130 13:53:24.705274  332032 cached_discovery.go:125] skipped caching discovery info, no groups found
NAME   SHORTNAMES   APIGROUP   NAMESPACED   KIND
```

**Which issue(s) this PR fixes**:
This is *one* of the problems causing the issue described in kubectl-981 but this does not completely close that issue as there are more problems with diff requiring edit permission, unrelated to this fix, that will need to be investigated separately.

**Special notes for your reviewer**:
Appreciate any double-check on the security implications of this.  I think it should be OK, but don't want to introduce a security vulnerability.

**Does this PR introduce a user-facing change?**:
```release-note
Fixed a bug in RBAC where a non-resource URL containing a query string failed to match a non-wildcard rule, even though the path matches the rule URL exactly
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs

```
