### PR TITLE
Bump kubectl in addon manager to 1.19

### DIFF
--- a/cluster/addons/addon-manager/CHANGELOG.md
+++ b/cluster/addons/addon-manager/CHANGELOG.md
@@ -1,3 +1,6 @@
+### Version 9.1.3 (Mon November 30 2020 Spencer Peterson <spencerjp@google.com>)
+ - Update kubectl to v1.19.3.
+
 ### Version 9.1.2 (Thu August 6 2020 Spencer Peterson <spencerjp@google.com>)
  - Fix `start_addon` overwriting resources with `addonmanager.kubernetes.io/mode=EnsureExists`.
 

--- a/cluster/addons/addon-manager/Makefile
+++ b/cluster/addons/addon-manager/Makefile
@@ -15,8 +15,8 @@
 IMAGE=gcr.io/k8s-staging-addon-manager/kube-addon-manager
 ARCH?=amd64
 TEMP_DIR:=$(shell mktemp -d)
-VERSION=v9.1.2
-KUBECTL_VERSION?=v1.13.2
+VERSION=v9.1.3
+KUBECTL_VERSION?=v1.19.3
 
 BASEIMAGE=k8s.gcr.io/debian-base-$(ARCH):v1.0.0
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->
/kind cleanup

The version of kubectl being shipped in the kube-addon-manager is six versions out of date (1.13.2, current is 1.19.3). The kube-addon-manager does not match the developer experiencing when testing addons. Six versions is additionally far outside of the two major version skew policy.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

