### PR TITLE
[flaky test] fix race in TestVersion in pkg/kubelet/cri/remote

### DIFF
--- a/pkg/kubelet/cri/remote/BUILD
+++ b/pkg/kubelet/cri/remote/BUILD
@@ -52,6 +52,7 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//pkg/kubelet/cri/remote/fake:go_default_library",
+        "//pkg/kubelet/cri/remote/util:go_default_library",
         "//staging/src/k8s.io/cri-api/pkg/apis:go_default_library",
         "//staging/src/k8s.io/cri-api/pkg/apis/testing:go_default_library",
         "//vendor/github.com/stretchr/testify/assert:go_default_library",

--- a/pkg/kubelet/cri/remote/fake/BUILD
+++ b/pkg/kubelet/cri/remote/fake/BUILD
@@ -23,7 +23,51 @@ go_library(
         "//staging/src/k8s.io/cri-api/pkg/apis/testing:go_default_library",
         "//vendor/google.golang.org/grpc:go_default_library",
         "//vendor/k8s.io/utils/exec:go_default_library",
-    ],
+    ] + select({
+        "@io_bazel_rules_go//go/platform:aix": [
+            "//staging/src/k8s.io/apimachinery/pkg/util/rand:go_default_library",
+        ],
+        "@io_bazel_rules_go//go/platform:android": [
+            "//staging/src/k8s.io/apimachinery/pkg/util/rand:go_default_library",
+        ],
+        "@io_bazel_rules_go//go/platform:darwin": [
+            "//staging/src/k8s.io/apimachinery/pkg/util/rand:go_default_library",
+        ],
+        "@io_bazel_rules_go//go/platform:dragonfly": [
+            "//staging/src/k8s.io/apimachinery/pkg/util/rand:go_default_library",
+        ],
+        "@io_bazel_rules_go//go/platform:freebsd": [
+            "//staging/src/k8s.io/apimachinery/pkg/util/rand:go_default_library",
+        ],
+        "@io_bazel_rules_go//go/platform:illumos": [
+            "//staging/src/k8s.io/apimachinery/pkg/util/rand:go_default_library",
+        ],
+        "@io_bazel_rules_go//go/platform:ios": [
+            "//staging/src/k8s.io/apimachinery/pkg/util/rand:go_default_library",
+        ],
+        "@io_bazel_rules_go//go/platform:js": [
+            "//staging/src/k8s.io/apimachinery/pkg/util/rand:go_default_library",
+        ],
+        "@io_bazel_rules_go//go/platform:linux": [
+            "//staging/src/k8s.io/apimachinery/pkg/util/rand:go_default_library",
+        ],
+        "@io_bazel_rules_go//go/platform:nacl": [
+            "//staging/src/k8s.io/apimachinery/pkg/util/rand:go_default_library",
+        ],
+        "@io_bazel_rules_go//go/platform:netbsd": [
+            "//staging/src/k8s.io/apimachinery/pkg/util/rand:go_default_library",
+        ],
+        "@io_bazel_rules_go//go/platform:openbsd": [
+            "//staging/src/k8s.io/apimachinery/pkg/util/rand:go_default_library",
+        ],
+        "@io_bazel_rules_go//go/platform:plan9": [
+            "//staging/src/k8s.io/apimachinery/pkg/util/rand:go_default_library",
+        ],
+        "@io_bazel_rules_go//go/platform:solaris": [
+            "//staging/src/k8s.io/apimachinery/pkg/util/rand:go_default_library",
+        ],
+        "//conditions:default": [],
+    }),
 )
 
 filegroup(

--- a/pkg/kubelet/cri/remote/fake/endpoint.go
+++ b/pkg/kubelet/cri/remote/fake/endpoint.go
@@ -18,11 +18,17 @@ limitations under the License.
 
 package fake
 
+import (
+	"fmt"
+	"k8s.io/apimachinery/pkg/util/rand"
+)
+
 const (
-	defaultUnixEndpoint = "unix:///tmp/kubelet_remote.sock"
+	defaultUnixEndpoint = "unix:///tmp/kubelet_remote_%v.sock"
 )
 
 // GenerateEndpoint generates a new unix socket server of grpc server.
 func GenerateEndpoint() (string, error) {
-	return defaultUnixEndpoint, nil
+	// use random int be a part fo file name
+	return fmt.Sprintf(defaultUnixEndpoint, rand.Int()), nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug
/kind flake

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:

The problem cause from use the same defaultUnixEndpoint

https://github.com/kubernetes/kubernetes/blob/98bc258bf5516b6c60860e06845b899eab29825d/pkg/kubelet/cri/remote/fake/endpoint.go#L22

use the random int be a part of  endpoint name  to give different routine different endpoint name.

the result as fellow 
```
323880 runs so far, 0 failures
325010 runs so far, 0 failures
326139 runs so far, 0 failures
```


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubernetes/issues/96950

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

