### PR TITLE
cm: GetRuntimeContainer always uses runtimeCgroups when set

### DIFF
--- a/pkg/kubelet/cm/helpers_linux.go
+++ b/pkg/kubelet/cm/helpers_linux.go
@@ -307,7 +307,7 @@ func GetKubeletContainer(kubeletCgroups string) (string, error) {
 
 // GetRuntimeContainer returns the cgroup used by the container runtime
 func GetRuntimeContainer(containerRuntime, runtimeCgroups string) (string, error) {
-	if containerRuntime == "docker" {
+	if runtimeCgroups == "" && containerRuntime == "docker" {
 		cont, err := getContainerNameForProcess(dockerProcessName, dockerPidFile)
 		if err != nil {
 			return "", fmt.Errorf("failed to get container name for docker process: %v", err)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

**What this PR does / why we need it**:

This fixes the warning mentioned in https://github.com/kubernetes/kubernetes/issues/56850 when there is a mismatch between the current cgroup of dockerd and the value passed in as `--runtime-cgroup`. Here's why:

1. Cadvisor does a one-time thing on kubelet boot where it [initializes](https://github.com/kubernetes/kubernetes/blob/1df1f882c4421d313abb468fef5c15f89983471c/vendor/github.com/google/cadvisor/manager/manager.go#L302) some containers by going through the cgroups and deciding which container to add and which not. In the raw handler case, it looks at the `raw_cgroup_prefix_whitelist` flag and ignores all containers that do not have the right prefix. One of the values in `raw_cgroup_prefix_whitelist` is the cgroup of the docker container that is being calculated [here](https://github.com/kubernetes/kubernetes/blob/35dc4cdc26cfcb6614059c4c6e836e5f0dc61dee/cmd/kubelet/app/server.go#L616-L622) **by checking the current cgroup of the docker process**.
2.  We're asking for the stats of the runtime container [here](https://github.com/kubernetes/kubernetes/blob/35dc4cdc26cfcb6614059c4c6e836e5f0dc61dee/pkg/kubelet/server/stats/summary_sys_containers.go#L36). The value of `nodeConfig.RuntimeCgroupsName` comes from the `--runtime-cgroup` flag.

Since kubelet hasn't moved dockerd in the cgroup defined by `--runtime-cgroup` by the time cadvisor initialises, it adds the wrong value as a container and then fails with this when trying to get the stats for the runtime container:
```
Nov 26 10:37:47 master-n7bgx-5f56c9767d-k4nls kubelet[1868]: I1126 10:37:47.331887    1868 factory.go:170] Factory
"raw" can handle container "/kubereserved.slice", but ignoring.
Nov 26 10:37:47 master-n7bgx-5f56c9767d-k4nls kubelet[1868]: I1126 10:37:47.331896    1868 manager.go:908] ignoring
container "/kubereserved.slice"
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubernetes/issues/56850

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
