### PR TITLE
Increase preemption timeout from 1 minute to 2 minutes

### DIFF
--- a/test/e2e/scheduling/predicates.go
+++ b/test/e2e/scheduling/predicates.go
@@ -928,8 +928,12 @@ func createPausePod(f *framework.Framework, conf pausePodConfig) *v1.Pod {
 }
 
 func runPausePod(f *framework.Framework, conf pausePodConfig) *v1.Pod {
+	return runPausePodWithTimeout(f, conf, framework.PollShortTimeout)
+}
+
+func runPausePodWithTimeout(f *framework.Framework, conf pausePodConfig, timeout time.Duration) *v1.Pod {
 	pod := createPausePod(f, conf)
-	framework.ExpectNoError(e2epod.WaitTimeoutForPodRunningInNamespace(f.ClientSet, pod.Name, pod.Namespace, framework.PollShortTimeout))
+	framework.ExpectNoError(e2epod.WaitTimeoutForPodRunningInNamespace(f.ClientSet, pod.Name, pod.Namespace, timeout))
 	pod, err := f.ClientSet.CoreV1().Pods(pod.Namespace).Get(context.TODO(), conf.Name, metav1.GetOptions{})
 	framework.ExpectNoError(err)
 	return pod

--- a/test/e2e/scheduling/preemption.go
+++ b/test/e2e/scheduling/preemption.go
@@ -178,14 +178,14 @@ var _ = SIGDescribe("SchedulerPreemption [Serial]", func() {
 
 		ginkgo.By("Run a high priority pod that has same requirements as that of lower priority pod")
 		// Create a high priority pod and make sure it is scheduled on the same node as the low priority pod.
-		runPausePod(f, pausePodConfig{
+		runPausePodWithTimeout(f, pausePodConfig{
 			Name:              "preemptor-pod",
 			PriorityClassName: highPriorityClassName,
 			Resources: &v1.ResourceRequirements{
 				Requests: podRes,
 				Limits:   podRes,
 			},
-		})
+		}, framework.PodStartShortTimeout)
 
 		preemptedPod, err := cs.CoreV1().Pods(pods[0].Namespace).Get(context.TODO(), pods[0].Name, metav1.GetOptions{})
 		podPreempted := (err != nil && apierrors.IsNotFound(err)) ||
@@ -271,7 +271,7 @@ var _ = SIGDescribe("SchedulerPreemption [Serial]", func() {
 				framework.Failf("Error cleanup pod `%s/%s`: %v", metav1.NamespaceSystem, "critical-pod", err)
 			}
 		}()
-		runPausePod(f, pausePodConfig{
+		runPausePodWithTimeout(f, pausePodConfig{
 			Name:              "critical-pod",
 			Namespace:         metav1.NamespaceSystem,
 			PriorityClassName: scheduling.SystemClusterCritical,
@@ -279,7 +279,7 @@ var _ = SIGDescribe("SchedulerPreemption [Serial]", func() {
 				Requests: podRes,
 				Limits:   podRes,
 			},
-		})
+		}, framework.PodStartShortTimeout)
 
 		defer func() {
 			// Clean-up the critical pod


### PR DESCRIPTION
**What type of PR is this?**

/kind flake
/sig scheduling

**What this PR does / why we need it**:

To wait for a preemptor pod to be running, in terms of a preemption e2e test, the time spans the following phases:

1. preemptor being scheduled and evict low-priority pods
1. low-priority pods being terminating -> reported by kubelet that the victims have been deleted
1. scheduler gets notifications from API server that the victims have been deleted
1. preemptor gets scheduled
1. kubelet reports the preemptor is running.

The total time to finish the whole cycle may vary upon envs. It's different with integration test where where kubelet isn't involved. The flake #96955 implied the current setting (1 minute) seems to be too strict.

**Which issue(s) this PR fixes**:

Fixes #96955 #97039.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```