### PR TITLE
staging/publishing: add release-1.20 rules

### DIFF
--- a/staging/publishing/rules.yaml
+++ b/staging/publishing/rules.yaml
@@ -27,6 +27,10 @@ rules:
       dir: staging/src/k8s.io/code-generator
     name: release-1.19
     go: 1.15.5
+  - source:
+      branch: release-1.20
+      dir: staging/src/k8s.io/code-generator
+    name: release-1.20
 
 - destination: apimachinery
   library: true
@@ -50,6 +54,10 @@ rules:
       dir: staging/src/k8s.io/apimachinery
     name: release-1.19
     go: 1.15.5
+  - source:
+      branch: release-1.20
+      dir: staging/src/k8s.io/apimachinery
+    name: release-1.20
 
 - destination: api
   library: true
@@ -85,6 +93,13 @@ rules:
     dependencies:
       - repository: apimachinery
         branch: release-1.19
+  - source:
+      branch: release-1.20
+      dir: staging/src/k8s.io/api
+    name: release-1.20
+    dependencies:
+      - repository: apimachinery
+        branch: release-1.20
 
 - destination: client-go
   library: true
@@ -128,6 +143,15 @@ rules:
         branch: release-1.19
       - repository: api
         branch: release-1.19
+  - source:
+      branch: release-1.20
+      dir: staging/src/k8s.io/client-go
+    name: release-1.20
+    dependencies:
+      - repository: apimachinery
+        branch: release-1.20
+      - repository: api
+        branch: release-1.20
   smoke-test: |
     # assumes GO111MODULE=on
     go build ./...
@@ -183,6 +207,17 @@ rules:
       branch: release-1.19
     - repository: client-go
       branch: release-1.19
+  - source:
+      branch: release-1.20
+      dir: staging/src/k8s.io/component-base
+    name: release-1.20
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.20
+    - repository: api
+      branch: release-1.20
+    - repository: client-go
+      branch: release-1.20
 
 - destination: component-helpers
   library: true
@@ -257,6 +292,19 @@ rules:
       branch: release-1.19
     - repository: component-base
       branch: release-1.19
+  - source:
+      branch: release-1.20
+      dir: staging/src/k8s.io/apiserver
+    name: release-1.20
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.20
+    - repository: api
+      branch: release-1.20
+    - repository: client-go
+      branch: release-1.20
+    - repository: component-base
+      branch: release-1.20
 
 - destination: kube-aggregator
   branches:
@@ -331,6 +379,23 @@ rules:
       branch: release-1.19
     - repository: code-generator
       branch: release-1.19
+  - source:
+      branch: release-1.20
+      dir: staging/src/k8s.io/kube-aggregator
+    name: release-1.20
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.20
+    - repository: api
+      branch: release-1.20
+    - repository: client-go
+      branch: release-1.20
+    - repository: apiserver
+      branch: release-1.20
+    - repository: component-base
+      branch: release-1.20
+    - repository: code-generator
+      branch: release-1.20
 
 - destination: sample-apiserver
   branches:
@@ -413,6 +478,25 @@ rules:
       branch: release-1.19
     required-packages:
     - k8s.io/code-generator
+  - source:
+      branch: release-1.20
+      dir: staging/src/k8s.io/sample-apiserver
+    name: release-1.20
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.20
+    - repository: api
+      branch: release-1.20
+    - repository: client-go
+      branch: release-1.20
+    - repository: apiserver
+      branch: release-1.20
+    - repository: code-generator
+      branch: release-1.20
+    - repository: component-base
+      branch: release-1.20
+    required-packages:
+    - k8s.io/code-generator
   smoke-test: |
     # assumes GO111MODULE=on
     go build .
@@ -480,6 +564,21 @@ rules:
       branch: release-1.19
     - repository: code-generator
       branch: release-1.19
+    required-packages:
+    - k8s.io/code-generator
+  - source:
+      branch: release-1.20
+      dir: staging/src/k8s.io/sample-controller
+    name: release-1.20
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.20
+    - repository: api
+      branch: release-1.20
+    - repository: client-go
+      branch: release-1.20
+    - repository: code-generator
+      branch: release-1.20
     required-packages:
     - k8s.io/code-generator
   smoke-test: |
@@ -567,6 +666,25 @@ rules:
       branch: release-1.19
     required-packages:
     - k8s.io/code-generator
+  - source:
+      branch: release-1.20
+      dir: staging/src/k8s.io/apiextensions-apiserver
+    name: release-1.20
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.20
+    - repository: api
+      branch: release-1.20
+    - repository: client-go
+      branch: release-1.20
+    - repository: apiserver
+      branch: release-1.20
+    - repository: code-generator
+      branch: release-1.20
+    - repository: component-base
+      branch: release-1.20
+    required-packages:
+    - k8s.io/code-generator
 
 - destination: metrics
   library: true
@@ -626,6 +744,19 @@ rules:
       branch: release-1.19
     - repository: code-generator
       branch: release-1.19
+  - source:
+      branch: release-1.20
+      dir: staging/src/k8s.io/metrics
+    name: release-1.20
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.20
+    - repository: api
+      branch: release-1.20
+    - repository: client-go
+      branch: release-1.20
+    - repository: code-generator
+      branch: release-1.20
 
 - destination: cli-runtime
   library: true
@@ -677,6 +808,17 @@ rules:
       branch: release-1.19
     - repository: client-go
       branch: release-1.19
+  - source:
+      branch: release-1.20
+      dir: staging/src/k8s.io/cli-runtime
+    name: release-1.20
+    dependencies:
+    - repository: api
+      branch: release-1.20
+    - repository: apimachinery
+      branch: release-1.20
+    - repository: client-go
+      branch: release-1.20
 
 - destination: sample-cli-plugin
   library: false
@@ -736,6 +878,19 @@ rules:
       branch: release-1.19
     - repository: client-go
       branch: release-1.19
+  - source:
+      branch: release-1.20
+      dir: staging/src/k8s.io/sample-cli-plugin
+    name: release-1.20
+    dependencies:
+    - repository: api
+      branch: release-1.20
+    - repository: apimachinery
+      branch: release-1.20
+    - repository: cli-runtime
+      branch: release-1.20
+    - repository: client-go
+      branch: release-1.20
 
 - destination: kube-proxy
   library: true
@@ -795,6 +950,19 @@ rules:
       branch: release-1.19
     - repository: client-go
       branch: release-1.19
+  - source:
+      branch: release-1.20
+      dir: staging/src/k8s.io/kube-proxy
+    name: release-1.20
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.20
+    - repository: component-base
+      branch: release-1.20
+    - repository: api
+      branch: release-1.20
+    - repository: client-go
+      branch: release-1.20
 
 - destination: kubelet
   library: true
@@ -846,6 +1014,19 @@ rules:
       branch: release-1.19
     - repository: component-base
       branch: release-1.19
+  - source:
+      branch: release-1.20
+      dir: staging/src/k8s.io/kubelet
+    name: release-1.20
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.20
+    - repository: api
+      branch: release-1.20
+    - repository: client-go
+      branch: release-1.20
+    - repository: component-base
+      branch: release-1.20
 
 - destination: kube-scheduler
   library: true
@@ -905,6 +1086,19 @@ rules:
       branch: release-1.19
     - repository: client-go
       branch: release-1.19
+  - source:
+      branch: release-1.20
+      dir: staging/src/k8s.io/kube-scheduler
+    name: release-1.20
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.20
+    - repository: component-base
+      branch: release-1.20
+    - repository: api
+      branch: release-1.20
+    - repository: client-go
+      branch: release-1.20
 
 - destination: controller-manager
   library: true
@@ -929,6 +1123,21 @@ rules:
       dir: staging/src/k8s.io/controller-manager
     name: release-1.19
     go: 1.15.5
+  - source:
+      branch: release-1.20
+      dir: staging/src/k8s.io/controller-manager
+    name: release-1.20
+    dependencies:
+    - repository: api
+      branch: release-1.20
+    - repository: apimachinery
+      branch: release-1.20
+    - repository: client-go
+      branch: release-1.20
+    - repository: component-base
+      branch: release-1.20
+    - repository: apiserver
+      branch: release-1.20
 
 - destination: cloud-provider
   library: true
@@ -988,6 +1197,23 @@ rules:
       branch: release-1.19
     - repository: component-base
       branch: release-1.19
+  - source:
+      branch: release-1.20
+      dir: staging/src/k8s.io/cloud-provider
+    name: release-1.20
+    dependencies:
+    - repository: api
+      branch: release-1.20
+    - repository: apimachinery
+      branch: release-1.20
+    - repository: apiserver
+      branch: release-1.20
+    - repository: client-go
+      branch: release-1.20
+    - repository: component-base
+      branch: release-1.20
+    - repository: controller-manager
+      branch: release-1.20
 
 - destination: kube-controller-manager
   library: true
@@ -1053,6 +1279,25 @@ rules:
       branch: release-1.19
     - repository: client-go
       branch: release-1.19
+  - source:
+      branch: release-1.20
+      dir: staging/src/k8s.io/kube-controller-manager
+    name: release-1.20
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.20
+    - repository: apiserver
+      branch: release-1.20
+    - repository: component-base
+      branch: release-1.20
+    - repository: api
+      branch: release-1.20
+    - repository: client-go
+      branch: release-1.20
+    - repository: controller-manager
+      branch: release-1.20
+    - repository: cloud-provider
+      branch: release-1.20
 
 - destination: cluster-bootstrap
   library: true
@@ -1096,6 +1341,15 @@ rules:
       branch: release-1.19
     - repository: api
       branch: release-1.19
+  - source:
+      branch: release-1.20
+      dir: staging/src/k8s.io/cluster-bootstrap
+    name: release-1.20
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.20
+    - repository: api
+      branch: release-1.20
 
 - destination: csi-translation-lib
   library: true
@@ -1153,6 +1407,15 @@ rules:
       branch: release-1.19
     - repository: component-base
       branch: release-1.19
+  - source:
+      branch: release-1.20
+      dir: staging/src/k8s.io/csi-translation-lib
+    name: release-1.20
+    dependencies:
+    - repository: api
+      branch: release-1.20
+    - repository: apimachinery
+      branch: release-1.20
 
 - destination: legacy-cloud-providers
   library: true
@@ -1238,6 +1501,27 @@ rules:
       branch: release-1.19
     - repository: component-base
       branch: release-1.19
+  - source:
+      branch: release-1.20
+      dir: staging/src/k8s.io/legacy-cloud-providers
+    name: release-1.20
+    dependencies:
+    - repository: api
+      branch: release-1.20
+    - repository: apimachinery
+      branch: release-1.20
+    - repository: client-go
+      branch: release-1.20
+    - repository: cloud-provider
+      branch: release-1.20
+    - repository: csi-translation-lib
+      branch: release-1.20
+    - repository: apiserver
+      branch: release-1.20
+    - repository: component-base
+      branch: release-1.20
+    - repository: controller-manager
+      branch: release-1.20
 
 - destination: node-api
   library: true
@@ -1279,6 +1563,10 @@ rules:
       dir: staging/src/k8s.io/cri-api
     name: release-1.19
     go: 1.15.5
+  - source:
+      branch: release-1.20
+      dir: staging/src/k8s.io/cri-api
+    name: release-1.20
 
 - destination: kubectl
   library: true
@@ -1364,6 +1652,27 @@ rules:
       branch: release-1.19
     - repository: metrics
       branch: release-1.19
+  - source:
+      branch: release-1.20
+      dir: staging/src/k8s.io/kubectl
+    name: release-1.20
+    dependencies:
+    - repository: api
+      branch: release-1.20
+    - repository: apimachinery
+      branch: release-1.20
+    - repository: cli-runtime
+      branch: release-1.20
+    - repository: client-go
+      branch: release-1.20
+    - repository: code-generator
+      branch: release-1.20
+    - repository: component-base
+      branch: release-1.20
+    - repository: component-helpers
+      branch: release-1.20
+    - repository: metrics
+      branch: release-1.20
 
 - destination: mount-utils
   library: true
@@ -1372,3 +1681,7 @@ rules:
       branch: master
       dir: staging/src/k8s.io/mount-utils
     name: master
+  - source:
+      branch: release-1.20
+      dir: staging/src/k8s.io/mount-utils
+    name: release-1.20


### PR DESCRIPTION
Fixes https://github.com/kubernetes/api/issues/35

Looks like we missed adding `release-1.20` rules to the publishing-bot...

This PR will ensure that the rc tag is published to all repos.

Thanks to @aanm and @smira for catching this!

/kind cleanup
/assign @dims @justaugustus 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

