### PR TITLE
Fix typos and add comments in functions for `kubectl create` subcommands

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_cronjob.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_cronjob.go
@@ -49,6 +49,7 @@ var (
 		kubectl create cronjob my-job --image=busybox --schedule="*/1 * * * *" -- date`)
 )
 
+// CreateCronJobOptions is returned by NewCreateCronJobOptions
 type CreateCronJobOptions struct {
 	PrintFlags *genericclioptions.PrintFlags
 
@@ -72,6 +73,7 @@ type CreateCronJobOptions struct {
 	genericclioptions.IOStreams
 }
 
+// NewCreateCronJobOptions returns an initialized CreateCronJobOptions instance
 func NewCreateCronJobOptions(ioStreams genericclioptions.IOStreams) *CreateCronJobOptions {
 	return &CreateCronJobOptions{
 		PrintFlags: genericclioptions.NewPrintFlags("created").WithTypeSetter(scheme.Scheme),
@@ -110,6 +112,7 @@ func NewCmdCreateCronJob(f cmdutil.Factory, ioStreams genericclioptions.IOStream
 	return cmd
 }
 
+// Complete completes all the required options
 func (o *CreateCronJobOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []string) error {
 	name, err := NameFromCommandArgs(cmd, args)
 	if err != nil {
@@ -165,6 +168,7 @@ func (o *CreateCronJobOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, a
 	return nil
 }
 
+// Run performs the execution of 'create cronjob' sub command
 func (o *CreateCronJobOptions) Run() error {
 	cronjob := o.createCronJob()
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_deployment.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_deployment.go
@@ -79,6 +79,7 @@ type CreateDeploymentOptions struct {
 	genericclioptions.IOStreams
 }
 
+// NewCreateDeploymentOptions returns an initialized CreateDeploymentOptions instance
 func NewCreateDeploymentOptions(ioStreams genericclioptions.IOStreams) *CreateDeploymentOptions {
 	return &CreateDeploymentOptions{
 		Port:       -1,
@@ -173,6 +174,7 @@ func (o *CreateDeploymentOptions) Complete(f cmdutil.Factory, cmd *cobra.Command
 	return nil
 }
 
+// Validate makes sure there is no discrepency in provided option values
 func (o *CreateDeploymentOptions) Validate() error {
 	if len(o.Images) > 1 && len(o.Command) > 0 {
 		return fmt.Errorf("cannot specify multiple --image options and command")

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_priorityclass.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_priorityclass.go
@@ -71,6 +71,7 @@ type PriorityClassOptions struct {
 	genericclioptions.IOStreams
 }
 
+// NewPriorityClassOptions returns an initialized PriorityClassOptions instance
 func NewPriorityClassOptions(ioStreams genericclioptions.IOStreams) *PriorityClassOptions {
 	return &PriorityClassOptions{
 		Value:            0,

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_rolebinding.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_rolebinding.go
@@ -45,7 +45,7 @@ var (
 		  kubectl create rolebinding admin --clusterrole=admin --user=user1 --user=user2 --group=group1`))
 )
 
-// RoleBindingOpts holds the options for 'create rolebinding' sub command
+// RoleBindingOptions holds the options for 'create rolebinding' sub command
 type RoleBindingOptions struct {
 	PrintFlags *genericclioptions.PrintFlags
 	PrintObj   func(obj runtime.Object) error


### PR DESCRIPTION
Certain missing comments and typos in comments are fixed in the files
that implement `kubectl create` subcommands.

Hope these are the right labels!
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup /sig cli

**What this PR does / why we need it**:
FIxes typos and adds comments.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
/cc @dims 