### PR TITLE
[KEP-1933] Update config for go-flow-levee analysis

### DIFF
--- a/hack/testdata/levee/levee-config.yaml
+++ b/hack/testdata/levee/levee-config.yaml
@@ -1,3 +1,17 @@
+# Copyright 2015 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # This file holds configuration for taint propagation analysis of Kubernetes source via go-flow-levee.
 # It defines sources which may contain credentials and sinks where these should not be logged.
 # Sources may be identified by the FieldTags element, or by matching package, type, and field explicitly in the Sources element.
@@ -5,7 +19,9 @@
 # False positives may be suppressed in the Exclude block.
 # Note that `*RE` keys have regexp values.
 ---
-# These field tags were introduced by KEP-1753 to fields which may contain credentials
+# TODO Refer to documentation link
+
+# These field tags were introduced by KEP-1753 to indicate fields which may contain credentials
 FieldTags:
   - Key: "datapolicy"
     Val: "security-key"
@@ -17,44 +33,128 @@ FieldTags:
 # This preliminary collection of source types should be removed once
 # KEP-1753 adds tags to the relevant fields.
 Sources:
-  - PackageRE: ""
-    TypeRE: "^(?:admin)?Secret$|Token"
-    FieldRE: ""
-  - PackageRE: "k8s.io/client-go/tools/clientcmd/api(?:/v1)?"
-    TypeRE: "^(?:Named)?AuthInfo$"
-    FieldRE: ""
-  - PackageRE: "k8s.io/kubernetes/pkg/credentialprovider"
-    TypeRE: "DockerConfigEntry"
-    FieldRE: "Password"
-  - PackageRE: "k8s.io/client-go/transport"
-    TypeRE: "requestInfo"
-    FieldRE: "RequestHeaders"
-  - PackageRE: "k8s.io/kubernetes/pkg/volume/rbd"
-    TypeRE: "rbdMounter"
-    FieldRE: "adminSecret"
-  - PackageRE: "^k8s.io/client-go/rest$"
-    TypeRE: "^TLSClientConfig$"
-    FieldRE: "Password|BearerToken$|"
-  - PackageRE: "^k8s.io/client-go/rest$"
-    TypeRE: "^Config$"
-    FieldRE: "Password|BearerToken$|"
+# The following fields are tagged in #95994
+- PackageRE: "k8s.io/kubernetes/test/e2e/storage/vsphere"
+  TypeRE: "Config"
+  FieldRE: "Password"
+- PackageRE: "k8s.io/kubernetes/test/e2e/storage/vsphere"
+  TypeRE: "ConfigFile"
+  FieldRE: "Global"  # Global is of unnamed type, contains the field Password.
+
+# The following fields are tagged in #95997
+- PackageRE: "k8s.io/kubelet/config/v1beta1"
+  TypeRE: "KubeletConfiguration"
+  FieldRE: "StaticPodURLHeader"
+
+# The following fields are tagged in #95998
+- PackageRE: "k8s.io/kube-scheduler/config/v1"
+  TypeRE: "ExtenderTLSConfig"
+  FieldRE: "KeyData"
+
+# The following fields are tagged in #95600
+- PackageRE: "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+  TypeRE: "AuthConfig"
+  FieldRE: "Password|IdentityToken|RegistryToken"
+
+# The following fields are tagged in #96002
+- PackageRE: "k8s.io/apiserver/pkg/apis/apiserver" # multiple versions
+  TypeRE: "TLSConfig"
+  FieldRE: "ClientKey"
+- PackageRE: "k8s.io/apiserver/pkg/apis/config" # multiple versions
+  TypeRE: "Key"
+  FieldRE: "Secret"
+- PackageRE: "k8s.io/apiserver/pkg/authentication/request/headerrequest"
+  TypeRE: "requestHeaderBundle"
+  FieldRE: "UsernameHeaders|GroupHeaders"
+- PackageRE: "k8s.io/apiserver/pkg/server/dynamiccertificates"
+  TypeRE: "certKeyContent"
+  FieldRE: "key"
+- PackageRE: "k8s.io/apiserver/pkg/server/dynamiccertificates"
+  TypeRE: "DynamicCertKeyPairContent"
+  FieldRE: "certKeyPair"
+- PackageRE: "k8s.io/apiserver/pkg/server/options"
+  TypeRE: "RequestHeaderAuthenticationOptions"
+  FieldRE: "UsernameHeaders|GroupHeaders"
+- PackageRE: "k8s.io/apiserver/plugin/pkg/authenticator/token/oidc"
+  TypeRE: "endpoint"
+  FieldRE: "AccessToken"
+
+# The following fields are tagged in #96003
+- PackageRE: "k8s.io/cli-runtime/pkg/genericclioptions"
+  TypeRE: "ConfigFlags"
+  FieldRE: "BearerToken|Password"
+
+# The following fields are tagged in #96004
+- PackageRE: "k8s.io/kubernetes/pkg/kubelet/apis/config"
+  TypeRE: "KubeletConfiguration"
+  FieldRE: "StaticPodURLHeader"
+- PackageRE: "k8s.io/kubernetes/pkg/kubelet/client"
+  TypeRE: "KubeletClientConfig"
+  FieldRE: "BearerToken"
+- PackageRE: "k8s.io/kubernetes/pkg/kubelet/cri/streaming"
+  TypeRE: "cacheEntry"
+  FieldRE: "token"
+
+# The following fields are tagged in #96005
+- PackageRE: "k8s.io/api/authentication/v1"
+  TypeRE: "TokenReviewSpec|TokenRequestStatus"
+  FieldRE: " Token"
+- PackageRE: "k8s.io/api/authentication/v1beta1"
+  TypeRE: "TokenReviewSpec"
+  FieldRE: " Token"
+
+# The following fields are tagged in #96007
+- PackageRE: "k8s.io/kubernetes/pkg/credentialprovider/azure"
+  TypeRE: "acrAuthResponse"
+  FieldRE: "RefreshToken"
+- PackageRE: "k8s.io/kubernetes/pkg/credentialprovider"
+  TypeRE: "DockerConfigEntry"
+  FieldRE: "Password"
+- PackageRE: "k8s.io/kubernetes/pkg/credentialprovider"
+  TypeRE: "DockerConfigJSON"
+  FieldRE: "Auths|HTTPHeaders"
+- PackageRE: "k8s.io/kubernetes/pkg/credentialprovider"
+  TypeRE: "dockerConfigEntryWithAuth"
+  FieldRE: "Password|Auth"
+- PackageRE: "k8s.io/kubernetes/pkg/credentialprovider/gcp"
+  TypeRE: "tokenBlob"
+  FieldRE: "AccessToken"
+- PackageRE: "k8s.io/kubernetes/pkg/credentialprovider"
+  TypeRE: "AuthConfig"
+  FieldRE: "Password|Auth|IdentityToken|RegistryToken"
+
+# The following fields are tagged in #96008
+- PackageRE: "k8s.io/kubernetes/pkg/controller/certificates/authority"
+  TypeRE: "CertificateAuthority"
+  FieldRE: "RawKey"
 
 # Sinks are functions that should not be called with source or source-tainted arguments.
 # This configuration should capture all log unfiltered log calls.
 Sinks:
-  - PackageRE: "\bk?log\b"
-    ReceiverRE: ""
-    MethodRE: "Info|Warning|Error|Fatal|Exit"
-  - PackageRE: "\bk?log\b"
-    ReceiverRE: "Verbose"
-    MethodRE: "Info|Error"
+- PackageRE: "k?log"
+  # Empty regexp receiver will match both top-level klog functions and klog.Verbose methods.
+  ReceiverRE: ""
+  MethodRE: "Info|Warning|Error|Fatal|Exit"
 
 # Sanitizers permit a source to reach a sink by explicitly removing the source data.
 Sanitizers:
-  - PackageRE: "k8s.io/client-go/transport"
-    MethodRE: "maskValue"
+# maskValue strips bearer tokens from request headers
+- PackageRE: "k8s.io/client-go/transport"
+  MethodRE: "maskValue"
 
 # False positives may be suppressed here.
 # Exclude reporting within a given function by specifying it similar to Sinks, i.e.,
 # PackageRE | ReceiverRE | MethodRE regexp
-Exclude: []
+Exclude:
+# Corrected in <pending>
+- PackageRE: "k8s.io/kubernetes/cmd/kubelet/app"
+  # Regexp matches anonymized inner function
+  MethodRE: "initConfigz|NewKubeletCommand|run"
+# Corrected by go-flow-levee version update in <pending>
+- PackageRE: "pkg/credentialprovider"
+  ReceiverRE: "BasicDockerKeyring"
+  MethodRE: "Add"
+# Corrected in #96576.
+- PackageRE: "k8s.io/kubernetes/pkg/credentialprovider/gcp"
+  ReceiverRE: "containerRegistryProvider"
+  MethodRE: "Provide"

--- a/hack/testdata/levee/levee-config.yaml
+++ b/hack/testdata/levee/levee-config.yaml
@@ -147,11 +147,11 @@ Sanitizers:
 # Exclude reporting within a given function by specifying it similar to Sinks, i.e.,
 # PackageRE | ReceiverRE | MethodRE regexp
 Exclude:
-# Corrected in <pending>
+# Corrected in #97000
 - PackageRE: "k8s.io/kubernetes/cmd/kubelet/app"
   # Regexp matches anonymized inner function
   MethodRE: "initConfigz|NewKubeletCommand|run"
-# Corrected by go-flow-levee version update in <pending>
+# Corrected by go-flow-levee version update in #96999
 - PackageRE: "pkg/credentialprovider"
   ReceiverRE: "BasicDockerKeyring"
   MethodRE: "Add"

--- a/hack/testdata/levee/levee-config.yaml
+++ b/hack/testdata/levee/levee-config.yaml
@@ -18,8 +18,9 @@
 # Sanitizers permit sources to safely reach a sink.
 # False positives may be suppressed in the Exclude block.
 # Note that `*RE` keys have regexp values.
+
+# For additional details, see KEP-1933.
 ---
-# TODO Refer to documentation link
 
 # These field tags were introduced by KEP-1753 to indicate fields which may contain credentials
 FieldTags:


### PR DESCRIPTION
* Remove \b boundary for sinks; Unicode backspace \b != regexp boundary \b.
* Specify those source type fields that have not yet been tagged.
* Add exclusions for current false-positive set.

-----

/sig security
/sig testing
/kind cleanup

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

Running the static analysis introduced by KEP-1933 currently does not produce meaningful results due to the configuration using `\b` for a boundary regexp.  When parsed by YAML, however, this parses as the Unicode `\b` backspace rather than the regexp `\b` boundary.  

This PR updates configuration to remove this boundary check.  It also updates the configuration to include those fields which have been identified to contain credentials that should not be logged, but for which field tagging have not get been merged.

With this updated configuration, analysis would fail due to (broadly) three instances of a credential reaching logs.  One is a false positive that can be corrected when the tool is updated to a newer version.  The others are minor issues that will be corrected in other PRs.

~~This PR will be in `Draft` until related PRs are in place and properly cross-referenced.~~

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
- KEP: https://github.com/kubernetes/enhancements/issues/1933
- Usage and documentation: [Draft PR](https://github.com/kubernetes/community/pull/5349)
