### PR TITLE
Avoid logging headers from kubelet configuration

### DIFF
--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -263,8 +263,14 @@ HTTP server: The kubelet can also listen for HTTP and respond to a simple API
 			// set up signal context here in order to be reused by kubelet and docker shim
 			ctx := genericapiserver.SetupSignalContext()
 
-			// run the kubelet
+			// make kubelet configuration safe for logging
+			for k := range kubeletServer.KubeletConfiguration.StaticPodURLHeader {
+				kubeletServer.KubeletConfiguration.StaticPodURLHeader[k] = []string{"<redacted>"}
+			}
+
 			klog.V(5).Infof("KubeletConfiguration: %#v", kubeletServer.KubeletConfiguration)
+
+			// run the kubelet
 			if err := Run(ctx, kubeletServer, kubeletDeps, utilfeature.DefaultFeatureGate); err != nil {
 				klog.Fatal(err)
 			}

--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -266,7 +266,7 @@ HTTP server: The kubelet can also listen for HTTP and respond to a simple API
 			// make the kubelet's config safe for logging
 			config := kubeletServer.KubeletConfiguration.DeepCopy()
 			for k := range config.StaticPodURLHeader {
-				config.StaticPodURLHeader[k] = []string{"<redacted>"}
+				config.StaticPodURLHeader[k] = []string{"<masked>"}
 			}
 			// log the kubelet's config for inspection
 			klog.V(5).Infof("KubeletConfiguration: %#v", config)

--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -75,6 +75,7 @@ import (
 	"k8s.io/kubernetes/pkg/credentialprovider"
 	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/kubelet"
+	kubeletconfig "k8s.io/kubernetes/pkg/kubelet/apis/config"
 	kubeletconfiginternal "k8s.io/kubernetes/pkg/kubelet/apis/config"
 	kubeletscheme "k8s.io/kubernetes/pkg/kubelet/apis/config/scheme"
 	kubeletconfigvalidation "k8s.io/kubernetes/pkg/kubelet/apis/config/validation"
@@ -263,12 +264,8 @@ HTTP server: The kubelet can also listen for HTTP and respond to a simple API
 			// set up signal context here in order to be reused by kubelet and docker shim
 			ctx := genericapiserver.SetupSignalContext()
 
-			// make kubelet configuration safe for logging
-			for k := range kubeletServer.KubeletConfiguration.StaticPodURLHeader {
-				kubeletServer.KubeletConfiguration.StaticPodURLHeader[k] = []string{"<redacted>"}
-			}
-
-			klog.V(5).Infof("KubeletConfiguration: %#v", kubeletServer.KubeletConfiguration)
+			// log the kubelet's config for inspection
+			logConfig(kubeletServer.KubeletConfiguration)
 
 			// run the kubelet
 			if err := Run(ctx, kubeletServer, kubeletDeps, utilfeature.DefaultFeatureGate); err != nil {
@@ -305,6 +302,15 @@ func newFlagSetWithGlobals() *pflag.FlagSet {
 	// explicitly add flags from libs that register global flags
 	options.AddGlobalFlags(fs)
 	return fs
+}
+
+// logConfig logs the kubelet's configuration.
+// Special care is taken to avoid logging sensitive parts of the configuration.
+func logConfig(config kubeletconfig.KubeletConfiguration) {
+	for k := range config.StaticPodURLHeader {
+		config.StaticPodURLHeader[k] = []string{"<redacted>"}
+	}
+	klog.V(5).Infof("KubeletConfiguration: %#v", config)
 }
 
 // newFakeFlagSet constructs a pflag.FlagSet with the same flags as fs, but where


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

This PR fixes unsafe code in the `kubelet` command, specifically `kubernetes/cmd/kubelet/app/server.go`, on line 267:

`klog.V(5).Infof("KubeletConfiguration: %#v", kubeletServer.KubeletConfiguration)`

The `%#v` format verb produces a Go-syntax representation of the configuration. The issue here is that `KubeletConfiguration` contains a field which may contain sensitive data: the `StaticPodURLHeader` field, which contains headers used to communicate with the `StaticPodURL`. (FYI this field is being marked as sensitive via a fieldtag in this PR: #96004.)

I have reported this issue to [HackerOne](https://hackerone.com/kubernetes) and they have told me that this can be fixed with a public PR.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

Not really? Log levels need to be quite high for this info to be logged in the first place, and this change is only hiding the header values.