### PR TITLE
Copy the same storageclass instead of constructing one in external test

### DIFF
--- a/test/e2e/storage/external/external.go
+++ b/test/e2e/storage/external/external.go
@@ -299,7 +299,7 @@ func (d *driverDefinition) GetDynamicProvisionStorageClass(e2econfig *testsuites
 		// reconsidered if we eventually need to move in-tree storage tests out.
 		sc.Parameters["csi.storage.k8s.io/fstype"] = fsType
 	}
-	return testsuites.GetStorageClass(sc.Provisioner, sc.Parameters, sc.VolumeBindingMode, f.Namespace.Name, "e2e-sc")
+	return testsuites.CopyStorageClass(sc, f.Namespace.Name, "e2e-sc")
 }
 
 func loadSnapshotClass(filename string) (*unstructured.Unstructured, error) {

--- a/test/e2e/storage/testsuites/base.go
+++ b/test/e2e/storage/testsuites/base.go
@@ -242,9 +242,7 @@ func CreateVolumeResource(driver TestDriver, config *PerTestConfig, pattern test
 			if pattern.BindingMode != "" {
 				r.Sc.VolumeBindingMode = &pattern.BindingMode
 			}
-			if pattern.AllowExpansion != false {
-				r.Sc.AllowVolumeExpansion = &pattern.AllowExpansion
-			}
+			r.Sc.AllowVolumeExpansion = &pattern.AllowExpansion
 
 			ginkgo.By("creating a StorageClass " + r.Sc.Name)
 

--- a/test/e2e/storage/testsuites/driveroperations.go
+++ b/test/e2e/storage/testsuites/driveroperations.go
@@ -54,6 +54,16 @@ func CreateVolume(driver TestDriver, config *PerTestConfig, volType testpatterns
 	return nil
 }
 
+// CopyStorageClass constructs a new StorageClass instance
+// with a unique name that is based on namespace + suffix
+// using the same storageclass setting from the parameter
+func CopyStorageClass(sc *storagev1.StorageClass, ns string, suffix string) *storagev1.StorageClass {
+	copy := sc.DeepCopy()
+	copy.ObjectMeta.Name = names.SimpleNameGenerator.GenerateName(ns + "-" + suffix)
+	copy.ResourceVersion = ""
+	return copy
+}
+
 // GetStorageClass constructs a new StorageClass instance
 // with a unique name that is based on namespace + suffix.
 func GetStorageClass(

--- a/test/e2e/storage/testsuites/volume_expand.go
+++ b/test/e2e/storage/testsuites/volume_expand.go
@@ -156,7 +156,9 @@ func (v *volumeExpandTestSuite) DefineTests(driver TestDriver, pattern testpatte
 			defer cleanup()
 
 			var err error
-			gomega.Expect(l.resource.Sc.AllowVolumeExpansion).To(gomega.BeNil())
+			gomega.Expect(l.resource.Sc.AllowVolumeExpansion).NotTo(gomega.BeNil())
+			allowVolumeExpansion := *l.resource.Sc.AllowVolumeExpansion
+			gomega.Expect(allowVolumeExpansion).To(gomega.BeFalse())
 			ginkgo.By("Expanding non-expandable pvc")
 			currentPvcSize := l.resource.Pvc.Spec.Resources.Requests[v1.ResourceStorage]
 			newSize := currentPvcSize.DeepCopy()


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
In the external testsuite, we let the user pass the storageclass. However, we are constructing the storageclass instead of taking everything inside it. This can miss something from the existing storageclass. For example, mountOptions.

This PR adds the function to copy the StorageClass instead of construct a new one.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/sig storage
/area testing
/cc @msau42 @jingxu97 