### PR TITLE
staging/publishing: fix rules for 1.20

### DIFF
--- a/staging/publishing/rules.yaml
+++ b/staging/publishing/rules.yaml
@@ -233,6 +233,17 @@ rules:
       branch: master
     - repository: client-go
       branch: master
+  - source:
+      branch: release-1.20
+      dir: staging/src/k8s.io/component-helpers
+    name: release-1.20
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.20
+    - repository: api
+      branch: release-1.20
+    - repository: client-go
+      branch: release-1.20
 
 - destination: apiserver
   library: true


### PR DESCRIPTION
Follow up of https://github.com/kubernetes/kubernetes/pull/96993
ref: https://github.com/kubernetes/api/issues/35

/kind cleanup
/priority critical-urgent
/cc @dims @kubernetes/release-team-leads 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

