### PR TITLE
Fix missing cadvisor machine metrics

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -551,6 +551,9 @@ func NewMainKubelet(kubeCfg *kubeletconfiginternal.KubeletConfiguration,
 	if err != nil {
 		return nil, err
 	}
+	// Avoid collector collects it as a timestamped metric
+	// See PR #95210 and #97006 for more details.
+	machineInfo.Timestamp = time.Time{}
 	klet.setCachedMachineInfo(machineInfo)
 
 	imageBackOff := flowcontrol.NewBackOff(backOffPeriod, MaxContainerBackOff)

--- a/pkg/kubelet/server/server.go
+++ b/pkg/kubelet/server/server.go
@@ -367,6 +367,7 @@ func (s *Server) InstallDefaultHandlers(enableCAdvisorJSONEndpoints bool) {
 		Recursive: true,
 	}
 	r.RawMustRegister(metrics.NewPrometheusCollector(prometheusHostAdapter{s.host}, containerPrometheusLabelsFunc(s.host), includedMetrics, clock.RealClock{}, cadvisorOpts))
+	r.RawMustRegister(metrics.NewPrometheusMachineCollector(prometheusHostAdapter{s.host}, includedMetrics))
 	s.restfulCont.Handle(cadvisorMetricsPath,
 		compbasemetrics.HandlerFor(r, compbasemetrics.HandlerOpts{ErrorHandling: compbasemetrics.ContinueOnError}),
 	)


### PR DESCRIPTION
Signed-off-by: Ling Samuel <lingsamuelgrace@gmail.com>


**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Fix missing cadvisor machine metrics.

From #95210 and [comment](https://github.com/kubernetes/kubernetes/pull/95210#issuecomment-726143798) since the author has not been active recently.

Should be backported to 1.19.

**Which issue(s) this PR fixes**:

Fixes #95204

**Special notes for your reviewer**:

1. Although the missing machine metrics data can now be provided normally, [its format has been changed](https://github.com/kubernetes/kubernetes/issues/95204#issuecomment-722929087)
2. According to [this comment](https://github.com/kubernetes/kubernetes/pull/95210#issuecomment-726143798), the timestamp is set to zero.

**Does this PR introduce a user-facing change?**:
```release-note
Fixes a regression in 1.19+ missing cadvisor machine metrics.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
