### PR TITLE
Bump Cluster Autoscaler to v1.20.0

### DIFF
--- a/cluster/gce/manifests/cluster-autoscaler.manifest
+++ b/cluster/gce/manifests/cluster-autoscaler.manifest
@@ -19,7 +19,7 @@
         "containers": [
             {
                 "name": "cluster-autoscaler",
-                "image": "k8s.gcr.io/autoscaling/cluster-autoscaler:v1.19.0",
+                "image": "k8s.gcr.io/autoscaling/cluster-autoscaler:v1.20.0",
                 "livenessProbe": {
                     "httpGet": {
                         "path": "/health-check",


### PR DESCRIPTION
/kind bug

```
## Changelog

### General
* Fix priority expander falling back to a random choice even though there is a higher priority option to choose
* Clone `kubernetes/kubernetes` in `update-vendor.sh` shallowly, instead of fetching all revisions
* Speed up binpacking by reducing the number of PreFilter calls (call once per pod instead of #pods*#nodes times)
* Speed up finding unneeded nodes by 5x+ in very large clusters by reducing the number of PreFilter calls
* Expose `--max-nodes-total` as a metric
* Errors in `IncreaseSize` changed fromt type `apiError` to `cloudProviderError`
* Make `build-in-docker` and `test-in-docker` work on Linux systems with SELinux enabled
* Fix an error where existing nodes were not considered as destinations while finding place for pods in scale-down simulations
* Remove redundant log lines and reduce severity around parsing kubeEnv
* Don't treat nodes created by virtual kuebelet as nodes from non-autoscaled node groups
* Remove redundant logging around calculating node utilization
* Add configurable `--network` and `--rm` flags for docker in `Makefile`
* Substract DaemonSet pods' requests from node allocatable in the denominator while computing node utilization
* Include taints by condition when determining if a node is unready/still starting
* Fix `update-vendor.sh` to work on OSX and zsh
* Add best-effort eviction for DaemonSet pods while scaling down non-empty nodes
* Add build support for ARM64

### AliCloud
* Add missing daemonsets and replicasets to ALI example cluster role

### Apache CloudStack
* Add support for Apache CloudStack

### AWS
* Regenerate list of EC2 instances
* Fix pricing endpoint in AWS China Region

### Azure
* Add optional jitter on initial VMSS VM cache refresh, keep the refreshes spread over time
* Serve from cache for the whole period of ongoing throttling
* Fix unwanted VMSS VMs cache invalidations
* Enforce setting the number of retries if cloud provider backoff is enabled
* Don't update capacity if VMSS provisioning state is updating
* Support allocatable resources overrides via VMSS tags
* Add missing stable labels in template nodes
* Proactively set instance status to deleting on node deletions

### Cluster API
* Migrate interaction with the API from using internal types to using Unstructured
* Improve tests to work better with constrained resources
* Add support for node autodiscovery
* Add support for `--cloud-config`
* Update group identifier to use for Cluster API annotations

### Exoscale
* Add support for Exoscale

### GCE
* Decrease the number of GCE Read Requests made while deleting nodes
* Base pricing of custom instances on their instance family type
* Add pricing information for missing machine types
* Add pricing information for different GPU types
* Ignore the new `topology.gke.io/zone` label when comparing groups
* Add missing stable labels to template nodes

### HuaweiCloud
* Add auto scaling group support
* Implement node group by AS
* Implement getting desired instance number of node group
* Implement increasing node group size
* Implement TemplateNodeInfo
* Implement caching instances

### IONOS
* Add support for IONOS

### Kubemark
* Skip non-kubemark nodes while computing node infos for node groups.

### Magnum
* Add Magnum support in the Cluster Autoscaler helm chart

### Packet
* Allow empty nodepools
* Add support for multiple nodepools
* Add pricing support

## Image
Image: `k8s.gcr.io/autoscaling/cluster-autoscaler:v1.20.0`
```

```release-note
cluster autoscaler updated to v1.20.0
```