### PR TITLE
cloud-controller-manager: routes controller should not depend on --allocate-node-cidrs

### DIFF
--- a/staging/src/k8s.io/cloud-provider/app/core.go
+++ b/staging/src/k8s.io/cloud-provider/app/core.go
@@ -112,7 +112,7 @@ func startRouteController(ctx *config.CompletedConfig, cloud cloudprovider.Inter
 	// If CIDRs should be allocated for pods and set on the CloudProvider, then start the route controller
 	routes, ok := cloud.Routes()
 	if !ok {
-		klog.Warning("configure-cloud-routes is set, but cloud provider does not support routes. Will not configure cloud provider routes.")
+		klog.Warning("--configure-cloud-routes is set, but cloud provider does not support routes. Will not configure cloud provider routes.")
 		return nil, false, nil
 	}
 

--- a/staging/src/k8s.io/cloud-provider/app/core.go
+++ b/staging/src/k8s.io/cloud-provider/app/core.go
@@ -104,8 +104,8 @@ func startServiceController(ctx *config.CompletedConfig, cloud cloudprovider.Int
 }
 
 func startRouteController(ctx *config.CompletedConfig, cloud cloudprovider.Interface, stopCh <-chan struct{}) (http.Handler, bool, error) {
-	if !ctx.ComponentConfig.KubeCloudShared.AllocateNodeCIDRs || !ctx.ComponentConfig.KubeCloudShared.ConfigureCloudRoutes {
-		klog.Infof("Will not configure cloud provider routes for allocate-node-cidrs: %v, configure-cloud-routes: %v.", ctx.ComponentConfig.KubeCloudShared.AllocateNodeCIDRs, ctx.ComponentConfig.KubeCloudShared.ConfigureCloudRoutes)
+	if !ctx.ComponentConfig.KubeCloudShared.ConfigureCloudRoutes {
+		klog.Infof("Will not configure cloud provider routes, --configure-cloud-routes: %v", ctx.ComponentConfig.KubeCloudShared.ConfigureCloudRoutes)
 		return nil, false, nil
 	}
 

--- a/staging/src/k8s.io/cloud-provider/fake/fake.go
+++ b/staging/src/k8s.io/cloud-provider/fake/fake.go
@@ -56,6 +56,12 @@ var _ cloudprovider.Clusters = (*Cloud)(nil)
 
 // Cloud is a test-double implementation of Interface, LoadBalancer, Instances, and Routes. It is useful for testing.
 type Cloud struct {
+	DisableInstances     bool
+	DisableRoutes        bool
+	DisableLoadBalancers bool
+	DisableZones         bool
+	DisableClusters      bool
+
 	Exists bool
 	Err    error
 
@@ -126,7 +132,7 @@ func (f *Cloud) Master(ctx context.Context, name string) (string, error) {
 
 // Clusters returns a clusters interface.  Also returns true if the interface is supported, false otherwise.
 func (f *Cloud) Clusters() (cloudprovider.Clusters, bool) {
-	return f, true
+	return f, !f.DisableClusters
 }
 
 // ProviderName returns the cloud provider ID.
@@ -145,14 +151,14 @@ func (f *Cloud) HasClusterID() bool {
 // LoadBalancer returns a fake implementation of LoadBalancer.
 // Actually it just returns f itself.
 func (f *Cloud) LoadBalancer() (cloudprovider.LoadBalancer, bool) {
-	return f, true
+	return f, !f.DisableLoadBalancers
 }
 
 // Instances returns a fake implementation of Instances.
 //
 // Actually it just returns f itself.
 func (f *Cloud) Instances() (cloudprovider.Instances, bool) {
-	return f, true
+	return f, !f.DisableInstances
 }
 
 // InstancesV2 returns a fake implementation of InstancesV2.
@@ -167,12 +173,12 @@ func (f *Cloud) InstancesV2() (cloudprovider.InstancesV2, bool) {
 
 // Zones returns a zones interface. Also returns true if the interface is supported, false otherwise.
 func (f *Cloud) Zones() (cloudprovider.Zones, bool) {
-	return f, true
+	return f, !f.DisableZones
 }
 
 // Routes returns a routes interface along with whether the interface is supported.
 func (f *Cloud) Routes() (cloudprovider.Routes, bool) {
-	return f, true
+	return f, !f.DisableRoutes
 }
 
 // GetLoadBalancer is a stub implementation of LoadBalancer.GetLoadBalancer.

--- a/test/integration/serving/serving_test.go
+++ b/test/integration/serving/serving_test.go
@@ -327,5 +327,7 @@ func intPtr(x int) *int {
 }
 
 func fakeCloudProviderFactory(io.Reader) (cloudprovider.Interface, error) {
-	return &fake.Cloud{}, nil
+	return &fake.Cloud{
+		DisableRoutes: true, // disable routes for server tests, otherwise --cluster-cidr is required
+	}, nil
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:
Enabling routes controller should be independent from `--allocate-node-cidrs`. Checking `--allocate-node-cidrs` made a lot of sense in `kube-controller-manager`, where node IPAM was required to ensure routes controller had `node.spec.podCIDR` set correctly. In cloud-controller-manager, this is not necessarily true since it does not run node IPAM (in most clusters) and instead depends on nodeipam controller running in kube-controller-manager. In some cases, an external controller may actually be allocated CIDRs to `node.spec.podCIDR`. Enablement of the routes controller should only depend on the `--configure-cloud-routes` flag.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
cloud-controller-manager: routes controller should not depend on --allocate-node-cidrs
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
