### PR TITLE
Use etcdctl endpoint health as a etcd's livenessProbe

### DIFF
--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -1718,7 +1718,8 @@ function prepare-etcd-manifest {
   local etcd_apiserver_creds="${ETCD_APISERVER_CREDS:-}"
   local etcd_extra_args="${ETCD_EXTRA_ARGS:-}"
   local suffix="$1"
-  local etcd_livenessprobe_port="$2"
+  local etcd_listen_metrics_port="$2"
+  local etcdctl_certs=""
 
   if [[ -n "${INITIAL_ETCD_CLUSTER_STATE:-}" ]]; then
     cluster_state="${INITIAL_ETCD_CLUSTER_STATE}"
@@ -1731,9 +1732,10 @@ function prepare-etcd-manifest {
   # mTLS should only be enabled for etcd server but not etcd-events. if $1 suffix is empty, it's etcd server.
   if [[ -z "${suffix}" && -n "${ETCD_APISERVER_CA_KEY:-}" && -n "${ETCD_APISERVER_CA_CERT:-}" && -n "${ETCD_APISERVER_SERVER_KEY:-}" && -n "${ETCD_APISERVER_SERVER_CERT:-}" && -n "${ETCD_APISERVER_CLIENT_KEY:-}" && -n "${ETCD_APISERVER_CLIENT_CERT:-}" ]]; then
     etcd_apiserver_creds=" --client-cert-auth --trusted-ca-file ${ETCD_APISERVER_CA_CERT_PATH} --cert-file ${ETCD_APISERVER_SERVER_CERT_PATH} --key-file ${ETCD_APISERVER_SERVER_KEY_PATH} "
+    etcdctl_certs="--cacert ${ETCD_APISERVER_CA_CERT_PATH} --cert ${ETCD_APISERVER_CLIENT_CERT_PATH} --key ${ETCD_APISERVER_CLIENT_KEY_PATH}"
     etcd_apiserver_protocol="https"
-    etcd_livenessprobe_port="2382"
-    etcd_extra_args+=" --listen-metrics-urls=http://${ETCD_LISTEN_CLIENT_IP:-127.0.0.1}:${etcd_livenessprobe_port} "
+    etcd_listen_metrics_port="2382"
+    etcd_extra_args+=" --listen-metrics-urls=http://${ETCD_LISTEN_CLIENT_IP:-127.0.0.1}:${etcd_listen_metrics_port} "
   fi
 
   if [[ -n "${ETCD_PROGRESS_NOTIFY_INTERVAL:-}" ]]; then
@@ -1787,9 +1789,9 @@ function prepare-etcd-manifest {
   sed -i -e "s@{{ *etcd_protocol *}}@$etcd_protocol@g" "${temp_file}"
   sed -i -e "s@{{ *etcd_apiserver_protocol *}}@$etcd_apiserver_protocol@g" "${temp_file}"
   sed -i -e "s@{{ *etcd_creds *}}@$etcd_creds@g" "${temp_file}"
+  sed -i -e "s@{{ *etcdctl_certs *}}@$etcdctl_certs@g" "${temp_file}"
   sed -i -e "s@{{ *etcd_apiserver_creds *}}@$etcd_apiserver_creds@g" "${temp_file}"
   sed -i -e "s@{{ *etcd_extra_args *}}@$etcd_extra_args@g" "${temp_file}"
-  sed -i -e "s@{{ *etcd_livenessprobe_port *}}@$etcd_livenessprobe_port@g" "${temp_file}"
   if [[ -n "${ETCD_VERSION:-}" ]]; then
     sed -i -e "s@{{ *pillar\.get('etcd_version', '\(.*\)') *}}@${ETCD_VERSION}@g" "${temp_file}"
   else

--- a/cluster/gce/manifests/etcd.manifest
+++ b/cluster/gce/manifests/etcd.manifest
@@ -61,13 +61,17 @@
       }
         ],
     "livenessProbe": {
-      "httpGet": {
-        "host": "127.0.0.1",
-        "port": {{ etcd_livenessprobe_port }},
-        "path": "/health"
+      "exec": {
+        "command": [
+          "/bin/sh",
+          "-c",
+          "set -x; exec /usr/local/bin/etcdctl --endpoints=127.0.0.1:{{ port }} {{ etcdctl_certs }} --command-timeout=15s endpoint health"
+        ]
       },
       "initialDelaySeconds": {{ liveness_probe_initial_delay }},
-      "timeoutSeconds": 15
+      "timeoutSeconds": 15,
+      "periodSeconds": 5,
+      "failureThreshold": 5
     },
     "ports": [
       { "name": "serverport",

--- a/cluster/images/etcd/Dockerfile
+++ b/cluster/images/etcd/Dockerfile
@@ -29,6 +29,7 @@ WORKDIR /
 COPY --from=builder /sh /bin/
 
 EXPOSE 2379 2380 4001 7001
+# etcdctl is used by etcd.manifest for livenessProbe.
 COPY etcd* etcdctl* /usr/local/bin/
 COPY cp* /bin/
 COPY migrate-if-needed.sh migrate /usr/local/bin/


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Without this PR, the current etcd's livenessProbe is using /health endpoint fails if one of the conditions is met ([src](https://github.com/etcd-io/etcd/blob/v3.4.14/etcdserver/api/etcdhttp/metrics.go#L95)):
* there is an active Alarm (there are two kinds of alarm: NOSPACE and CORRUPT)
* there is no raft leader
* the latency of a QGET request doesn't exceed 1s

The problem is that in most of those cases, etcd's restart **isn't** a right behavior:
* if there is NOSPACE alarm, the restart will not free that space
* if there is no raft leader
* if the request latency > 1s, the etcd cluster is overloaded which is bad, but restart will generate even more load

The new livenessProbe, etctctl endpoint health checks the following condition ([src](https://github.com/etcd-io/etcd/blob/34bd797e6754911ee540e8c87f708f88ffe89f37/etcdctl/ctlv3/command/ep_command.go#L109-L132))
* checks if **linearized** (so using quorum) Get finishes in **adjustable** time

The etcd restart is usually very expensive and should be done only if etcd is permanently down anyway.
To achieve that, this PR changes the logic to:
* call etcdctl endpoint health with 30s timeout
* changes periodSecond to 30s (to accommodate increased timeout)
* changes failureThreshold to 5

This basically means that if etcd was failing to get a key with 30s timeout, 5 times in a row (so in 2.5m time window), then we are going to restart it.

This is significantly stronger condition than the previous one (30 second window of >1s get latency) + avoids restarting etcd on alarms (such as NOSPACE or CORRUPT) where restart isn't right behavior, as read-only and delete calls should still work: https://etcd.io/docs/v3.4.0/op-guide/maintenance/#space-quota

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #96886

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/hold
Adding hold as I want to make sure that this works as I understood from the docs: i.e.: NOSPACE alarm will not make livenessProbe failing, lack of raft quorum will fail the probe.

/cc @wojtek-t @jpbetz @mm4tt @ptabor
