### PR TITLE
Enable, rate limit, and test APF config consumer controller fights

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/apf_controller.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/apf_controller.go
@@ -237,6 +237,21 @@ func newTestableController(config TestableConfig) *configController {
 		UpdateFunc: func(oldObj, newObj interface{}) {
 			newFS := newObj.(*flowcontrol.FlowSchema)
 			oldFS := oldObj.(*flowcontrol.FlowSchema)
+			// Changes to either Spec or Status are relevant.  The
+			// concern is that we might, in some future release, want
+			// different behavior than is implemented now. One of the
+			// hardest questions is how does an operator roll out the
+			// new release in a cluster with multiple kube-apiservers
+			// --- in a way that works no matter what servers crash
+			// and restart when. If this handler reacts only to
+			// changes in Spec then we have a scenario in which the
+			// rollout leaves the old Status in place. The scenario
+			// ends with this subsequence: deploy the last new server
+			// before deleting the last old server, and in between
+			// those two operations the last old server crashes and
+			// recovers. The chosen solution is making this controller
+			// insist on maintaining the particular state that it
+			// establishes.
 			if !(apiequality.Semantic.DeepEqual(oldFS.Spec, newFS.Spec) &&
 				apiequality.Semantic.DeepEqual(oldFS.Status, newFS.Status)) {
 				klog.V(7).Infof("Triggered API priority and fairness config reloading due to spec and/or status update of FS %s", newFS.Name)
@@ -300,7 +315,7 @@ func (cfgCtlr *configController) Run(stopCh <-chan struct{}) error {
 	return nil
 }
 
-// this func is the logic of the one and only worker goroutine.  We
+// runWorker is the logic of the one and only worker goroutine.  We
 // limit the number to one in order to obviate explicit
 // synchronization around access to `cfgCtlr.mostRecentUpdates`.
 func (cfgCtlr *configController) runWorker() {
@@ -308,7 +323,8 @@ func (cfgCtlr *configController) runWorker() {
 	}
 }
 
-// only invoke this in the one and only worker goroutine
+// processNextWorkItem works on one entry from the work queue.
+// Only invoke this in the one and only worker goroutine.
 func (cfgCtlr *configController) processNextWorkItem() bool {
 	obj, shutdown := cfgCtlr.configQueue.Get()
 	if shutdown {
@@ -359,9 +375,6 @@ func (cfgCtlr *configController) SyncOne(flowSchemaRVs map[string]string) SyncRe
 		return SyncReport{NeedRetry: true}
 	}
 	suggestedDelay, err := cfgCtlr.digestConfigObjects(newPLs, newFSs, flowSchemaRVs)
-	//if suggestedDelay > 0 {
-	//	cfgCtlr.configQueue.AddAfter(0, suggestedDelay)
-	//}
 	if err == nil {
 		return SyncReport{NeededSpecificWait: suggestedDelay}
 	}
@@ -825,7 +838,9 @@ func (cfgCtlr *configController) startRequest(ctx context.Context, rd RequestDig
 	return selectedFlowSchema, plState.pl, false, req, startWaitingTime
 }
 
-// Call this after getting a clue that the given priority level is undesired and idle
+// maybeReap will remove the last internal traces of the named
+// priority level if it has no more use.  Call this after getting a
+// clue that the given priority level is undesired and idle.
 func (cfgCtlr *configController) maybeReap(plName string) {
 	cfgCtlr.lock.Lock()
 	defer cfgCtlr.lock.Unlock()
@@ -845,8 +860,11 @@ func (cfgCtlr *configController) maybeReap(plName string) {
 	cfgCtlr.configQueue.Add(0)
 }
 
-// Call this if both (1) plState.queues is non-nil and reported being
-// idle, and (2) cfgCtlr's lock has not been released since then.
+// maybeReapLocked requires the cfgCtlr's lock to already be held and
+// will remove the last internal traces of the named priority level if
+// it has no more use.  Call this if both (1) plState.queues is
+// non-nil and reported being idle, and (2) cfgCtlr's lock has not
+// been released since then.
 func (cfgCtlr *configController) maybeReapLocked(plName string, plState *priorityLevelState) {
 	if !(plState.quiescing && plState.numPending == 0) {
 		return

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/apf_controller.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/apf_controller.go
@@ -357,11 +357,11 @@ func (cfgCtlr *configController) SyncOne(flowSchemaRVs map[string]string) (speci
 	all := labels.Everything()
 	newPLs, err := cfgCtlr.plLister.List(all)
 	if err != nil {
-		return 0, fmt.Errorf("Unable to list PriorityLevelConfiguration objects: %w", err)
+		return 0, fmt.Errorf("unable to list PriorityLevelConfiguration objects: %w", err)
 	}
 	newFSs, err := cfgCtlr.fsLister.List(all)
 	if err != nil {
-		return 0, fmt.Errorf("Unable to list FlowSchema objects: %w", err)
+		return 0, fmt.Errorf("unable to list FlowSchema objects: %w", err)
 	}
 	return cfgCtlr.digestConfigObjects(newPLs, newFSs, flowSchemaRVs)
 }

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/apf_controller.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/apf_controller.go
@@ -433,10 +433,10 @@ func (cfgCtlr *configController) digestConfigObjects(newPLs []*flowcontrol.Prior
 		fsIfc := cfgCtlr.flowcontrolClient.FlowSchemas()
 		patchBytes := []byte(fmt.Sprintf(`{"status": {"conditions": [ %s ] } }`, string(enc)))
 		patchOptions := metav1.PatchOptions{FieldManager: cfgCtlr.asFieldManager}
-		fs2, err := fsIfc.Patch(context.TODO(), fsu.flowSchema.Name, apitypes.StrategicMergePatchType, patchBytes, patchOptions, "status")
+		patchedFlowSchema, err := fsIfc.Patch(context.TODO(), fsu.flowSchema.Name, apitypes.StrategicMergePatchType, patchBytes, patchOptions, "status")
 		if err == nil {
-			key, _ := cache.MetaNamespaceKeyFunc(fs2)
-			flowSchemaRVs[key] = fs2.ResourceVersion
+			key, _ := cache.MetaNamespaceKeyFunc(patchedFlowSchema)
+			flowSchemaRVs[key] = patchedFlowSchema.ResourceVersion
 		} else if apierrors.IsNotFound(err) {
 			// This object has been deleted.  A notification is coming
 			// and nothing more needs to be done here.

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/apf_controller.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/apf_controller.go
@@ -28,7 +28,6 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -36,6 +35,7 @@ import (
 	apitypes "k8s.io/apimachinery/pkg/types"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 	fcboot "k8s.io/apiserver/pkg/apis/flowcontrol/bootstrap"
 	"k8s.io/apiserver/pkg/authentication/user"
@@ -122,6 +122,13 @@ type configController struct {
 	// name to the state for that level.  Every name referenced from a
 	// member of `flowSchemas` has an entry here.
 	priorityLevelStates map[string]*priorityLevelState
+
+	tenMostRecentUpdates []updateResult
+}
+
+type updateResult struct {
+	timeUpdated  time.Time
+	updatedItems sets.String
 }
 
 // priorityLevelState holds the state specific to a priority level.
@@ -291,7 +298,10 @@ func (cfgCtlr *configController) syncOne() bool {
 		klog.Errorf("Unable to list FlowSchema objects: %s", err.Error())
 		return false
 	}
-	err = cfgCtlr.digestConfigObjects(newPLs, newFSs)
+	suggestedDelay, err := cfgCtlr.digestConfigObjects(newPLs, newFSs)
+	if suggestedDelay > 0 {
+		cfgCtlr.configQueue.AddAfter(0, suggestedDelay)
+	}
 	if err == nil {
 		return true
 	}
@@ -336,10 +346,24 @@ type fsStatusUpdate struct {
 
 // digestConfigObjects is given all the API objects that configure
 // cfgCtlr and writes its consequent new configState.
-func (cfgCtlr *configController) digestConfigObjects(newPLs []*flowcontrol.PriorityLevelConfiguration, newFSs []*flowcontrol.FlowSchema) error {
+func (cfgCtlr *configController) digestConfigObjects(newPLs []*flowcontrol.PriorityLevelConfiguration, newFSs []*flowcontrol.FlowSchema) (time.Duration, error) {
 	fsStatusUpdates := cfgCtlr.lockAndDigestConfigObjects(newPLs, newFSs)
 	var errs []error
+	currResult := updateResult{
+		timeUpdated:  time.Now(),
+		updatedItems: sets.String{},
+	}
+	suggestedDelay := 0 * time.Minute
 	for _, fsu := range fsStatusUpdates {
+		// if we should skip this name, indicate we will need a delay, but continue with other entries
+		if cfgCtlr.shouldDelayUpdate(fsu.flowSchema.Name) {
+			suggestedDelay = 1 * time.Minute // our memory is only one minute long.
+			continue
+		}
+
+		// if we are going to issue an update, be sure we track every name we update so we know if we update it too often.
+		currResult.updatedItems.Insert(fsu.flowSchema.Name)
+
 		enc, err := json.Marshal(fsu.condition)
 		if err != nil {
 			// should never happen because these conditions are created here and well formed
@@ -361,10 +385,39 @@ func (cfgCtlr *configController) digestConfigObjects(newPLs []*flowcontrol.Prior
 			errs = append(errs, errors.Wrap(err, fmt.Sprintf("failed to set a status.condition for FlowSchema %s", fsu.flowSchema.Name)))
 		}
 	}
+	cfgCtlr.addUpdateResult(currResult)
+
 	if len(errs) == 0 {
-		return nil
+		return suggestedDelay, nil
 	}
-	return utilerrors.NewAggregate(errs)
+	return suggestedDelay, utilerrors.NewAggregate(errs)
+}
+
+// shouldDelayUpdate checks to see if a flowschema has been updated too often and returns true if a delay is needed.
+func (cfgCtlr *configController) shouldDelayUpdate(flowSchemaName string) bool {
+	numUpdatesInPastMinute := 0
+	oneMinuteAgo := time.Now().Add(-1 * time.Minute)
+	for _, update := range cfgCtlr.tenMostRecentUpdates {
+		if update.timeUpdated.After(oneMinuteAgo) {
+			continue
+		}
+		if update.updatedItems.Has(flowSchemaName) {
+			numUpdatesInPastMinute++
+		}
+	}
+	if numUpdatesInPastMinute > 5 {
+		return true
+	}
+	return false
+}
+
+// addUpdateResult adds the result and keeps the only the most recent 10. It isn't a ring buffer because I'm lazy and
+// this is small and rate limited
+func (cfgCtlr *configController) addUpdateResult(result updateResult) {
+	cfgCtlr.tenMostRecentUpdates = append([]updateResult{result}, cfgCtlr.tenMostRecentUpdates...)
+	if len(cfgCtlr.tenMostRecentUpdates) > 10 {
+		cfgCtlr.tenMostRecentUpdates = cfgCtlr.tenMostRecentUpdates[:10]
+	}
 }
 
 func (cfgCtlr *configController) lockAndDigestConfigObjects(newPLs []*flowcontrol.PriorityLevelConfiguration, newFSs []*flowcontrol.FlowSchema) []fsStatusUpdate {

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/apf_filter.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/apf_filter.go
@@ -106,7 +106,10 @@ type TestableInterface interface {
 	// SyncOne attempts to sync all the API Priority and Fairness
 	// config objects.  Writes to FlowSchema objects are recorded in
 	// the given map, with an entry mapping
-	// `cache.MetaNamespaceKeyFunc(fs)` to `fs.ResourceVersion`.
+	// `cache.MetaNamespaceKeyFunc(fs)` to `fs.ResourceVersion`.  This
+	// method is public so that integration tests can exercise
+	// controller functionality synchronously rather than having to
+	// sleep and hope the sleep was long enough.
 	SyncOne(flowSchemaRVs map[string]string) SyncReport
 }
 
@@ -124,12 +127,18 @@ type TestableConfig struct {
 	// case of a delete, it might be a `DeletedFinalStateUnknown`.
 	FinishHandlingNotification func(wq workqueue.RateLimitingInterface, obj interface{})
 
-	// AsFieldManager is the string to use in the metadata for server-side apply
+	// AsFieldManager is the string to use in the metadata for
+	// server-side apply.  Normally this is
+	// `ConfigConsumerAsFieldManager`.  This is exposed as a parameter
+	// so that a test of competing controllers can supply different
+	// values.
 	AsFieldManager string
 
 	// FoundToDangling maps the boolean indicating whether a
 	// FlowSchema's referenced PLC exists to the boolean indicating
-	// that FlowSchema's status should indicate a dangling reference
+	// that FlowSchema's status should indicate a dangling reference.
+	// This is a parameter so that we can write tests of what happens
+	// when servers disagree on that bit of Status.
 	FoundToDangling func(bool) bool
 
 	// InformerFactory to use in building the controller

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/apf_filter.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/apf_filter.go
@@ -110,7 +110,7 @@ type TestableInterface interface {
 	// method is public so that integration tests can exercise
 	// controller functionality synchronously rather than having to
 	// sleep and hope the sleep was long enough.
-	SyncOne(flowSchemaRVs map[string]string) SyncReport
+	SyncOne(flowSchemaRVs map[string]string) (specificDelay time.Duration, err error)
 }
 
 // TestableConfig carries the parameters to an implementation that is testable

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/controller_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/controller_test.go
@@ -384,12 +384,18 @@ func TestAPFControllerWithGracefulShutdown(t *testing.T) {
 		queues:          map[string]*ctlrTestQueueSet{},
 	}
 	controller := newTestableController(TestableConfig{
-		informerFactory,
-		flowcontrolClient,
-		100,
-		time.Minute,
-		metrics.PriorityLevelConcurrencyObserverPairGenerator,
-		cts,
+
+		Name:                       "Controller",
+		Clock:                      clock.RealClock{},
+		FinishHandlingNotification: enqueueEverything,
+		AsFieldManager:             ConfigConsumerAsFieldManager,
+		FoundToDangling:            func(found bool) bool { return !found },
+		InformerFactory:            informerFactory,
+		FlowcontrolClient:          flowcontrolClient,
+		ServerConcurrencyLimit:     100,
+		RequestWaitLimit:           time.Minute,
+		ObsPairGenerator:           metrics.PriorityLevelConcurrencyObserverPairGenerator,
+		QueueSetFactory:            cts,
 	})
 
 	stopCh, controllerCompletedCh := make(chan struct{}), make(chan struct{})

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/controller_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/controller_test.go
@@ -28,6 +28,7 @@ import (
 
 	flowcontrol "k8s.io/api/flowcontrol/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/clock"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 	fcboot "k8s.io/apiserver/pkg/apis/flowcontrol/bootstrap"
@@ -251,12 +252,17 @@ func TestConfigConsumer(t *testing.T) {
 				queues:          map[string]*ctlrTestQueueSet{},
 			}
 			ctlr := newTestableController(TestableConfig{
-				InformerFactory:        informerFactory,
-				FlowcontrolClient:      flowcontrolClient,
-				ServerConcurrencyLimit: 100,
-				RequestWaitLimit:       time.Minute,
-				ObsPairGenerator:       metrics.PriorityLevelConcurrencyObserverPairGenerator,
-				QueueSetFactory:        cts,
+				Name:                       "Controller",
+				Clock:                      clock.RealClock{},
+				FinishHandlingNotification: enqueueEverything,
+				AsFieldManager:             ConfigConsumerAsFieldManager,
+				FoundToDangling:            func(found bool) bool { return !found },
+				InformerFactory:            informerFactory,
+				FlowcontrolClient:          flowcontrolClient,
+				ServerConcurrencyLimit:     100,         // server concurrency limit
+				RequestWaitLimit:           time.Minute, // request wait limit
+				ObsPairGenerator:           metrics.PriorityLevelConcurrencyObserverPairGenerator,
+				QueueSetFactory:            cts,
 			})
 			cts.cfgCtlr = ctlr
 			persistingPLNames := sets.NewString()

--- a/test/integration/apiserver/flowcontrol/fight_test.go
+++ b/test/integration/apiserver/flowcontrol/fight_test.go
@@ -1,0 +1,286 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flowcontrol
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"sync"
+	"testing"
+	"time"
+
+	flowcontrol "k8s.io/api/flowcontrol/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/clock"
+	"k8s.io/apimachinery/pkg/util/wait"
+	fcboot "k8s.io/apiserver/pkg/apis/flowcontrol/bootstrap"
+	genericfeatures "k8s.io/apiserver/pkg/features"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	utilfc "k8s.io/apiserver/pkg/util/flowcontrol"
+	fqtesting "k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/testing"
+	"k8s.io/apiserver/pkg/util/flowcontrol/metrics"
+	"k8s.io/client-go/informers"
+	clientset "k8s.io/client-go/kubernetes"
+	flowcontrolclient "k8s.io/client-go/kubernetes/typed/flowcontrol/v1beta1"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
+	"k8s.io/klog/v2"
+)
+
+const timeFmt = "2006-01-02T15:04:05.999"
+
+type fightTest struct {
+	t              *testing.T
+	ctx            context.Context
+	loopbackConfig *rest.Config
+	size           int
+	stopCh         chan struct{}
+	now            time.Time
+	clk            *clock.FakeClock
+	ctlrs          map[bool][]utilfc.TestableInterface
+	lastRVs        map[string]string // FlowSchema key to ResourceVersion
+	rvMutex        sync.Mutex        // hold when accessing notifiedRVs
+	// maps invert -> i -> FS key -> last notified ResourceVersion
+	notifiedRVs  map[bool][]map[string]string
+	someTimedOut bool
+	iteration    int
+	// maps invert -> i -> FS name -> write times (oldest first)
+	writeHistories map[bool][]map[string][]time.Time
+}
+
+func newFightTest(t *testing.T, loopbackConfig *rest.Config, size int) *fightTest {
+	now := time.Now()
+	ft := &fightTest{
+		t:              t,
+		ctx:            context.Background(),
+		loopbackConfig: loopbackConfig,
+		size:           size,
+		stopCh:         make(chan struct{}),
+		now:            now,
+		clk:            clock.NewFakeClock(now),
+		ctlrs: map[bool][]utilfc.TestableInterface{
+			false: make([]utilfc.TestableInterface, size),
+			true:  make([]utilfc.TestableInterface, size)},
+		notifiedRVs: map[bool][]map[string]string{
+			false: make([]map[string]string, size),
+			true:  make([]map[string]string, size)},
+		writeHistories: map[bool][]map[string][]time.Time{
+			false: make([]map[string][]time.Time, size),
+			true:  make([]map[string][]time.Time, size)},
+	}
+	ft.foreach(func(invert bool, i int) {
+		ft.rvMutex.Lock()
+		defer ft.rvMutex.Unlock()
+		ft.notifiedRVs[invert][i] = map[string]string{}
+		ft.writeHistories[invert][i] = map[string][]time.Time{}
+	})
+	return ft
+}
+
+func (ft *fightTest) createController(invert bool, i int) {
+	myConfig := rest.CopyConfig(ft.loopbackConfig)
+	myConfig = rest.AddUserAgent(myConfig, fmt.Sprintf("invert=%v, i=%d", invert, i))
+	myClientset := clientset.NewForConfigOrDie(myConfig)
+	fcIfc := myClientset.FlowcontrolV1beta1()
+	if ft.lastRVs == nil {
+		var err error
+		ft.lastRVs, err = getResourceVersionOfEachFlowSchema(ft.t, fcIfc.FlowSchemas())
+		if err != nil {
+			ft.t.Fatal(err)
+		}
+	}
+	informerFactory := informers.NewSharedInformerFactory(myClientset, 0)
+	fieldMgr := utilfc.ConfigConsumerAsFieldManager
+	foundToDangling := func(found bool) bool { return !found }
+	if invert {
+		fieldMgr = fieldMgr + "x"
+		foundToDangling = func(found bool) bool { return found }
+	}
+	ctlr := utilfc.NewTestable(utilfc.TestableConfig{
+		Name:  fmt.Sprintf("Controller%d[invert=%v]", i, invert),
+		Clock: ft.clk,
+		FinishHandlingNotification: func(wq workqueue.RateLimitingInterface, obj interface{}) {
+			ft.t.Logf("For invert=%v, i=%v, notified of %#+v", invert, i, obj)
+			obj = peel(obj)
+			switch typed := obj.(type) {
+			case *flowcontrol.FlowSchema:
+				key, _ := cache.MetaNamespaceKeyFunc(obj)
+				ft.rvMutex.Lock()
+				defer ft.rvMutex.Unlock()
+				ft.notifiedRVs[invert][i][key] = typed.ResourceVersion
+			}
+		},
+		AsFieldManager:         fieldMgr,
+		FoundToDangling:        foundToDangling,
+		InformerFactory:        informerFactory,
+		FlowcontrolClient:      fcIfc,
+		ServerConcurrencyLimit: 200,         // server concurrency limit
+		RequestWaitLimit:       time.Minute, // request wait limit
+		ObsPairGenerator:       metrics.PriorityLevelConcurrencyObserverPairGenerator,
+		QueueSetFactory:        fqtesting.NewNoRestraintFactory(),
+	})
+	ft.ctlrs[invert][i] = ctlr
+	informerFactory.Start(ft.stopCh)
+	if ctlr.WaitForCacheSync(ft.stopCh) {
+		ft.t.Logf("Achieved initial sync for invert=%v, i=%v", invert, i)
+	} else {
+		ft.t.Fatalf("Never achieved initial sync for invert=%v, i=%v", invert, i)
+	}
+}
+
+func (ft *fightTest) waitForLastRVs() {
+	AOK := false
+	// wait until notifiedRVs[invert][i] covers lastRVs for all invert, i
+	for k := 1; k < 11 && !AOK; k++ {
+		ft.t.Logf("For size=%d, iteration=%d, k=%d, starting to wait for lastRVs=%v", ft.size, ft.iteration, k, ft.lastRVs)
+		time.Sleep(time.Millisecond * time.Duration(k*100))
+		AOK = true
+		ft.foreach(func(invert bool, i int) {
+			ft.rvMutex.Lock()
+			defer ft.rvMutex.Unlock()
+			for key, rv := range ft.lastRVs {
+				if ft.notifiedRVs[invert][i][key] != rv {
+					AOK = false
+				}
+			}
+		})
+	}
+	if !AOK {
+		func() {
+			ft.rvMutex.Lock()
+			defer ft.rvMutex.Unlock()
+			ft.t.Logf("For size=%d, iteration=%d, lastRVs=%v but notifiedRVs=%#+v", ft.size, ft.iteration, ft.lastRVs, ft.notifiedRVs)
+		}()
+		ft.someTimedOut = true
+	}
+}
+
+func (ft *fightTest) updateAndCheckHistories(invert bool, i int, ctlrRVs map[string]string) int {
+	timeLimit := ft.now.Add(-time.Minute)
+	var nWrites int
+	for key, rv := range ctlrRVs {
+		ft.t.Logf("For invert=%v, i=%v, iteration=%d, wrote to %q", invert, i, ft.iteration, key)
+		ft.lastRVs[key] = rv
+		nWrites++
+		hist := ft.writeHistories[invert][i][key]
+		hist = append(hist, ft.now)
+		for idx, updateTime := range hist {
+			if updateTime.After(timeLimit) {
+				hist = hist[idx:]
+				break
+			}
+		}
+		ft.writeHistories[invert][i][key] = hist
+		if len(hist) > 6 {
+			ft.t.Errorf("For invert=%v, i=%v, iteration=%v, FlowSchema %q, found %d updates in the last minute (%#+v)", invert, i, ft.iteration, key, len(hist), hist)
+		}
+	}
+	return nWrites
+}
+
+func TestConfigConsumerFight(t *testing.T) {
+	// Disable the APF FeatureGate so that the normal config consumer
+	// controller does not interfere
+	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, genericfeatures.APIPriorityAndFairness, false)()
+	_, loopbackConfig, closeFn := setup(t, 100, 100)
+	defer closeFn()
+	const size = 3
+	ft := newFightTest(t, loopbackConfig, size)
+	ft.foreach(ft.createController)
+	t.Logf("After initial sync, lastRVs=%v", ft.lastRVs)
+	nextTime := ft.clk.Now()
+	lastTime := nextTime.Add(601 * time.Second)
+	for ft.iteration = 0; lastTime.After(nextTime); ft.iteration++ {
+		ft.waitForLastRVs()
+		ft.now = nextTime
+		ft.clk.SetTime(ft.now)
+		t.Logf("Syncing[size=%d, iteration=%d] at %s", ft.size, ft.iteration, ft.now.Format(timeFmt))
+		klog.V(3).Infof("Syncing size=%d, iteration=%d at %s", ft.size, ft.iteration, ft.now.Format(timeFmt))
+		ft.lastRVs = make(map[string]string)
+		const highTime = 2 * time.Minute
+		wait := highTime
+		ft.foreach(func(invert bool, i int) {
+			ctlr := ft.ctlrs[invert][i]
+			ctlrRVs := make(map[string]string)
+			report := ctlr.SyncOne(ctlrRVs)
+			nWrites := ft.updateAndCheckHistories(invert, i, ctlrRVs)
+			if report.NeedRetry {
+				t.Errorf("Error for invert=%v, i=%d", invert, i)
+			}
+			t.Logf("For invert=%v, i=%d: nWrites=%d, NeededSpecificWait=%s", invert, i, nWrites, report.NeededSpecificWait)
+			if report.NeededSpecificWait > 0 {
+				wait = durationMin(wait, report.NeededSpecificWait)
+			}
+		})
+		t.Logf("For size=%d, iteration=%d at %s, lastRVs = %v", size, ft.iteration, ft.now.Format(timeFmt), ft.lastRVs)
+		if wait == highTime {
+			wait = time.Second * 4
+		}
+		nextTime = ft.now.Add(wait)
+	}
+	close(ft.stopCh)
+	if ft.someTimedOut {
+		t.Error("Some timed out")
+	}
+}
+
+func (ft *fightTest) foreach(visit func(invert bool, i int)) {
+	for i := 0; i < ft.size; i++ {
+		// The order of the following iteration is not deterministic,
+		// and that is good.
+		invert := rand.Intn(2) == 0
+		visit(invert, i)
+		visit(!invert, i)
+	}
+}
+
+func getResourceVersionOfEachFlowSchema(t *testing.T, fsIfc flowcontrolclient.FlowSchemaInterface) (map[string]string, error) {
+	lastRVs := make(map[string]string)
+	// Wait until every FlowSchema is defined, and record its RV
+	allFlowSchemas := append(fcboot.MandatoryFlowSchemas, fcboot.SuggestedFlowSchemas...)
+	err := wait.Poll(time.Second, wait.ForeverTestTimeout, func() (bool, error) {
+		for _, fs := range allFlowSchemas {
+			fs2, err := fsIfc.Get(context.Background(), fs.Name, metav1.GetOptions{})
+			if err != nil {
+				return false, err
+			}
+			t.Logf("Got initial FlowSchema %#+v", fs2)
+			key, _ := cache.MetaNamespaceKeyFunc(fs2)
+			lastRVs[key] = fs2.ResourceVersion
+		}
+		return true, nil
+	})
+	return lastRVs, err
+}
+
+func peel(obj interface{}) interface{} {
+	if d, ok := obj.(cache.DeletedFinalStateUnknown); ok {
+		return d.Obj
+	}
+	return obj
+}
+
+// durationMin computes the minimum of two time.Duration values
+func durationMin(x, y time.Duration) time.Duration {
+	if x < y {
+		return x
+	}
+	return y
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1840,6 +1840,7 @@ k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing
 k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/promise
 k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/promise/lockingpromise
 k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/queueset
+k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/testing
 k8s.io/apiserver/pkg/util/flowcontrol/format
 k8s.io/apiserver/pkg/util/flowcontrol/metrics
 k8s.io/apiserver/pkg/util/flushwriter


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

**What this PR does / why we need it**:
1. This PR makes the API Priority and Fairness config controllers, which update FlowSchemaStatus, respond to conflicting settings by re-asserting their own desired setting.  Prior to this PR, conflicting settings of FlowSchemaStatus provoked no response.
2. This PR limits the rate at which the desired settings are re-asserted.
3. This PR adds a test of this new behavior.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
This builds on #97024 and #97370, and is an alternative to #90541 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
