### PR TITLE
Calico: set IP=autodetect so preempted nodes learn new IP

### DIFF
--- a/cluster/addons/calico-policy-controller/calico-node-daemonset.yaml
+++ b/cluster/addons/calico-policy-controller/calico-node-daemonset.yaml
@@ -107,7 +107,7 @@ spec:
             - name: USE_POD_CIDR
               value: "true"
             - name: IP
-              value: ""
+              value: "autodetect"
             - name: NO_DEFAULT_POOLS
               value: "true"
             - name: NODENAME


### PR DESCRIPTION
With preemptible nodes, a cluster node (with a given hostname) can
boot the first time with IP1, then be preempted and boot again with
different IP2.

With IP="", Calico will autodetect IP1 on first boot, but will not
perform autodetection on subsequent boots and so will not release IP1
and detect IP2 instead.

With IP=autodetect, Calico will perform autodetection on all boots,
which is what we want.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
See start of Description.

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:
None

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
None
