### PR TITLE
Update OWNERS for k8s.io/legacy-cloud-providers

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/OWNERS
+++ b/staging/src/k8s.io/legacy-cloud-providers/OWNERS
@@ -1,16 +1,18 @@
 # See the OWNERS docs at https://go.k8s.io/owners
-
+# We are no longer accepting features into k8s.io/legacy-cloud-providers.
+# Any kind/feature PRs must be approved by SIG Cloud Provider going forward.
+options:
+  no_parent_owners: true
 approvers:
-- mikedanese
-- dims
-- andrewsykim
-- cheftako
+- andrewsykim # SIG Cloud Provider lead, for approving bug fixes only
+- cheftako    # SIG Cloud Provider lead, for approving bug fixes only
+- dims        # For code organization / dependency updates only
+- liggitt     # For code organization / dependency updates only
 reviewers:
-- mikedanese
-- dims
 - andrewsykim
 - cheftako
 emeritus_approvers:
+- mikedanese
 - mcrute
 labels:
 - sig/cloud-provider

--- a/staging/src/k8s.io/legacy-cloud-providers/aws/OWNERS
+++ b/staging/src/k8s.io/legacy-cloud-providers/aws/OWNERS
@@ -1,11 +1,15 @@
 # See the OWNERS docs at https://go.k8s.io/owners
+# We are no longer accepting features into k8s.io/legacy-cloud-providers.
+# Any kind/feature PRs must be approved by SIG Cloud Provider going forward.
 
-approvers:
+emeritus_approvers:
 - justinsb
 - gnufied
 - jsafrane
 - micahhausler
 - m00nf1sh
+- zmerlynn
+- mcrute
 reviewers:
 - gnufied
 - jsafrane
@@ -14,6 +18,3 @@ reviewers:
 - nckturner
 - micahhausler
 - m00nf1sh
-emeritus_approvers:
-- zmerlynn
-- mcrute

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/OWNERS
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/OWNERS
@@ -1,6 +1,8 @@
 # See the OWNERS docs at https://go.k8s.io/owners
+# We are no longer accepting features into k8s.io/legacy-cloud-providers.
+# Any kind/feature PRs must be approved by SIG Cloud Provider going forward.
 
-approvers:
+emeritus_approvers:
 - andyzhangx
 - brendandburns
 - feiskyer

--- a/staging/src/k8s.io/legacy-cloud-providers/gce/OWNERS
+++ b/staging/src/k8s.io/legacy-cloud-providers/gce/OWNERS
@@ -1,6 +1,7 @@
 # See the OWNERS docs at https://go.k8s.io/owners
-
-approvers:
+# We are no longer accepting features into k8s.io/legacy-cloud-providers.
+# Any kind/feature PRs must be approved by SIG Cloud Provider going forward.
+emeritus_approvers:
 - saad-ali
 - jingxu97
 - bowei

--- a/staging/src/k8s.io/legacy-cloud-providers/openstack/OWNERS
+++ b/staging/src/k8s.io/legacy-cloud-providers/openstack/OWNERS
@@ -1,6 +1,8 @@
 # See the OWNERS docs at https://go.k8s.io/owners
+# We are no longer accepting features into k8s.io/legacy-cloud-providers.
+# Any kind/feature PRs must be approved by SIG Cloud Provider going forward.
 
-approvers:
+emeritus_approvers:
 - anguslees
 - NickrenREN
 - dims

--- a/staging/src/k8s.io/legacy-cloud-providers/vsphere/OWNERS
+++ b/staging/src/k8s.io/legacy-cloud-providers/vsphere/OWNERS
@@ -1,17 +1,16 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
-approvers:
+emeritus_approvers:
 - baludontu
 - divyenpatel
 - frapposelli
 - dougm
 - SandeepPissay
+- imkin
+- abrarshivani
 reviewers:
 - baludontu
 - divyenpatel
 - frapposelli
 - dougm
 - SandeepPissay
-emeritus_approvers:
-- imkin
-- abrarshivani


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Starting in v1.21, we are disallowing feature PRs into the built-in legacy cloud providers (i.e. `k8s.io/legacy-cloud-providers`). Any `kind/feature` PRs going forward will have to be approved by SIG Cloud Provider. See this mailing list thread for more details https://groups.google.com/g/kubernetes-sig-cloud-provider/c/UkG46pNc6Cw. TL;DR -- we are getting closer and closer to being able to remove the built-in cloud providers and freezing features going forward will incentivize development/adoption of external providers. 

I spoke with @nikhita on whether it would be possible for the prow approve plugin to check the kind label for PRs but it seems this is not really feasible because anyone can modify the kind label anyways. The only other alternative is to update the OWNERS file for k8s.io/legacy-cloud-providers so that only SIG leads can approve feature PRs after exceptions are approved. Unfortunately this also means that SIG leads _also_ have to approve `kind/bug` PRs as well going forward. For those PRs,  myself and @cheftako should lean heavily on emeritus approvers for review.

```release-note
NONE
```