### PR TITLE
tests: Enable some [LinuxOnly] tests for Windows Containerd

### DIFF
--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -1585,37 +1585,6 @@
     that the pre-stop is executed.
   release: v1.9
   file: test/e2e/common/node/lifecycle_hook.go
-- testname: Container Runtime, TerminationMessage, from log output of succeeding container
-  codename: '[sig-node] Container Runtime blackbox test on terminated container should
-    report termination message [LinuxOnly] as empty when pod succeeds and TerminationMessagePolicy
-    FallbackToLogsOnError is set [NodeConformance] [Conformance]'
-  description: 'Create a pod with an container. Container''s output is recorded in
-    log and container exits successfully without an error. When container is terminated,
-    terminationMessage MUST have no content as container succeed. [LinuxOnly]: Cannot
-    mount files in Windows Containers.'
-  release: v1.15
-  file: test/e2e/common/node/runtime.go
-- testname: Container Runtime, TerminationMessage, from file of succeeding container
-  codename: '[sig-node] Container Runtime blackbox test on terminated container should
-    report termination message [LinuxOnly] from file when pod succeeds and TerminationMessagePolicy
-    FallbackToLogsOnError is set [NodeConformance] [Conformance]'
-  description: 'Create a pod with an container. Container''s output is recorded in
-    a file and the container exits successfully without an error. When container is
-    terminated, terminationMessage MUST match with the content from file. [LinuxOnly]:
-    Cannot mount files in Windows Containers.'
-  release: v1.15
-  file: test/e2e/common/node/runtime.go
-- testname: Container Runtime, TerminationMessage, from container's log output of
-    failing container
-  codename: '[sig-node] Container Runtime blackbox test on terminated container should
-    report termination message [LinuxOnly] from log output if TerminationMessagePolicy
-    FallbackToLogsOnError is set [NodeConformance] [Conformance]'
-  description: 'Create a pod with an container. Container''s output is recorded in
-    log and container exits with an error. When container is terminated, termination
-    message MUST match the expected output recorded from container''s log. [LinuxOnly]:
-    Cannot mount files in Windows Containers.'
-  release: v1.15
-  file: test/e2e/common/node/runtime.go
 - testname: Container Runtime, TerminationMessagePath, non-root user and non-default
     path
   codename: '[sig-node] Container Runtime blackbox test on terminated container should
@@ -1626,6 +1595,37 @@
     successfully. When the container is terminated, the termination message MUST match
     the expected output logged in the provided custom path. [LinuxOnly]: Tagged LinuxOnly
     due to use of ''uid'' and unable to mount files in Windows Containers.'
+  release: v1.15
+  file: test/e2e/common/node/runtime.go
+- testname: Container Runtime, TerminationMessage, from log output of succeeding container
+  codename: '[sig-node] Container Runtime blackbox test on terminated container should
+    report termination message as empty when pod succeeds and TerminationMessagePolicy
+    FallbackToLogsOnError is set [Excluded:WindowsDocker] [NodeConformance] [Conformance]'
+  description: 'Create a pod with an container. Container''s output is recorded in
+    log and container exits successfully without an error. When container is terminated,
+    terminationMessage MUST have no content as container succeed. [Excluded:WindowsDocker]:
+    Cannot mount files in Windows Containers created by Docker.'
+  release: v1.15
+  file: test/e2e/common/node/runtime.go
+- testname: Container Runtime, TerminationMessage, from file of succeeding container
+  codename: '[sig-node] Container Runtime blackbox test on terminated container should
+    report termination message from file when pod succeeds and TerminationMessagePolicy
+    FallbackToLogsOnError is set [Excluded:WindowsDocker] [NodeConformance] [Conformance]'
+  description: 'Create a pod with an container. Container''s output is recorded in
+    a file and the container exits successfully without an error. When container is
+    terminated, terminationMessage MUST match with the content from file. [Excluded:WindowsDocker]:
+    Cannot mount files in Windows Containers created by Docker.'
+  release: v1.15
+  file: test/e2e/common/node/runtime.go
+- testname: Container Runtime, TerminationMessage, from container's log output of
+    failing container
+  codename: '[sig-node] Container Runtime blackbox test on terminated container should
+    report termination message from log output if TerminationMessagePolicy FallbackToLogsOnError
+    is set [Excluded:WindowsDocker] [NodeConformance] [Conformance]'
+  description: 'Create a pod with an container. Container''s output is recorded in
+    log and container exits with an error. When container is terminated, termination
+    message MUST match the expected output recorded from container''s log. [Excluded:WindowsDocker]:
+    Cannot mount files in Windows Containers created by Docker.'
   release: v1.15
   file: test/e2e/common/node/runtime.go
 - testname: Container Runtime, Restart Policy, Pod Phases
@@ -2953,43 +2953,46 @@
   file: test/e2e/common/storage/secrets_volume.go
 - testname: 'SubPath: Reading content from a configmap volume.'
   codename: '[sig-storage] Subpath Atomic writer volumes should support subpaths with
-    configmap pod [LinuxOnly] [Conformance]'
+    configmap pod [Excluded:WindowsDocker] [Conformance]'
   description: Containers in a pod can read content from a configmap mounted volume
-    which was configured with a subpath. This test is marked LinuxOnly since Windows
-    cannot mount individual files in Containers.
+    which was configured with a subpath. This test is marked [Excluded:WindowsDocker]
+    since Docker does not support creating individual file mounts for containers on
+    Windows.
   release: v1.12
   file: test/e2e/storage/subpath.go
 - testname: 'SubPath: Reading content from a configmap volume.'
   codename: '[sig-storage] Subpath Atomic writer volumes should support subpaths with
-    configmap pod with mountPath of existing file [LinuxOnly] [Conformance]'
+    configmap pod with mountPath of existing file [Excluded:WindowsDocker] [Conformance]'
   description: Containers in a pod can read content from a configmap mounted volume
     which was configured with a subpath and also using a mountpath that is a specific
-    file. This test is marked LinuxOnly since Windows cannot mount individual files
-    in Containers.
+    file. This test is marked [Excluded:WindowsDocker] since Docker does not support
+    creating individual file mounts for containers on Windows.
   release: v1.12
   file: test/e2e/storage/subpath.go
 - testname: 'SubPath: Reading content from a downwardAPI volume.'
   codename: '[sig-storage] Subpath Atomic writer volumes should support subpaths with
-    downward pod [LinuxOnly] [Conformance]'
+    downward pod [Excluded:WindowsDocker] [Conformance]'
   description: Containers in a pod can read content from a downwardAPI mounted volume
-    which was configured with a subpath. This test is marked LinuxOnly since Windows
-    cannot mount individual files in Containers.
+    which was configured with a subpath. This test is marked [Excluded:WindowsDocker]
+    since Docker does not support creating individual file mounts for containers on
+    Windows.
   release: v1.12
   file: test/e2e/storage/subpath.go
 - testname: 'SubPath: Reading content from a projected volume.'
   codename: '[sig-storage] Subpath Atomic writer volumes should support subpaths with
-    projected pod [LinuxOnly] [Conformance]'
+    projected pod [Excluded:WindowsDocker] [Conformance]'
   description: Containers in a pod can read content from a projected mounted volume
-    which was configured with a subpath. This test is marked LinuxOnly since Windows
-    cannot mount individual files in Containers.
+    which was configured with a subpath. This test is marked [Excluded:WindowsDocker]
+    since Docker does not support creating individual file mounts for containers on
+    Windows.
   release: v1.12
   file: test/e2e/storage/subpath.go
 - testname: 'SubPath: Reading content from a secret volume.'
   codename: '[sig-storage] Subpath Atomic writer volumes should support subpaths with
-    secret pod [LinuxOnly] [Conformance]'
+    secret pod [Excluded:WindowsDocker] [Conformance]'
   description: Containers in a pod can read content from a secret mounted volume which
-    was configured with a subpath. This test is marked LinuxOnly since Windows cannot
-    mount individual files in Containers.
+    was configured with a subpath. This test is marked [Excluded:WindowsDocker] since
+    Docker does not support creating individual file mounts for containers on Windows.
   release: v1.12
   file: test/e2e/storage/subpath.go
 

--- a/test/e2e/common/node/runtime.go
+++ b/test/e2e/common/node/runtime.go
@@ -168,9 +168,9 @@ while true; do sleep 1; done
 				gomega.Expect(c.Delete()).To(gomega.Succeed())
 			}
 
-			ginkgo.It("should report termination message [LinuxOnly] if TerminationMessagePath is set [NodeConformance]", func() {
-				// Cannot mount files in Windows Containers.
-				// TODO(claudiub): Remove [LinuxOnly] tag once Containerd becomes the default
+			ginkgo.It("should report termination message if TerminationMessagePath is set [Excluded:WindowsDocker] [NodeConformance]", func() {
+				// Cannot mount files in Windows Containers created by Docker.
+				// TODO(claudiub): Remove [Excluded:WindowsDocker] tag if Containerd becomes the only
 				// container runtime on Windows.
 				container := v1.Container{
 					Image:                  framework.BusyBoxImage,
@@ -215,9 +215,9 @@ while true; do sleep 1; done
 				Release: v1.15
 				Testname: Container Runtime, TerminationMessage, from container's log output of failing container
 				Description: Create a pod with an container. Container's output is recorded in log and container exits with an error. When container is terminated, termination message MUST match the expected output recorded from container's log.
-				[LinuxOnly]: Cannot mount files in Windows Containers.
+				[Excluded:WindowsDocker]: Cannot mount files in Windows Containers created by Docker.
 			*/
-			framework.ConformanceIt("should report termination message [LinuxOnly] from log output if TerminationMessagePolicy FallbackToLogsOnError is set [NodeConformance]", func() {
+			framework.ConformanceIt("should report termination message from log output if TerminationMessagePolicy FallbackToLogsOnError is set [Excluded:WindowsDocker] [NodeConformance]", func() {
 				container := v1.Container{
 					Image:                    framework.BusyBoxImage,
 					Command:                  []string{"/bin/sh", "-c"},
@@ -232,9 +232,9 @@ while true; do sleep 1; done
 				Release: v1.15
 				Testname: Container Runtime, TerminationMessage, from log output of succeeding container
 				Description: Create a pod with an container. Container's output is recorded in log and container exits successfully without an error. When container is terminated, terminationMessage MUST have no content as container succeed.
-				[LinuxOnly]: Cannot mount files in Windows Containers.
+				[Excluded:WindowsDocker]: Cannot mount files in Windows Containers created by Docker.
 			*/
-			framework.ConformanceIt("should report termination message [LinuxOnly] as empty when pod succeeds and TerminationMessagePolicy FallbackToLogsOnError is set [NodeConformance]", func() {
+			framework.ConformanceIt("should report termination message as empty when pod succeeds and TerminationMessagePolicy FallbackToLogsOnError is set [Excluded:WindowsDocker] [NodeConformance]", func() {
 				container := v1.Container{
 					Image:                    framework.BusyBoxImage,
 					Command:                  []string{"/bin/sh", "-c"},
@@ -249,9 +249,9 @@ while true; do sleep 1; done
 				Release: v1.15
 				Testname: Container Runtime, TerminationMessage, from file of succeeding container
 				Description: Create a pod with an container. Container's output is recorded in a file and the container exits successfully without an error. When container is terminated, terminationMessage MUST match with the content from file.
-				[LinuxOnly]: Cannot mount files in Windows Containers.
+				[Excluded:WindowsDocker]: Cannot mount files in Windows Containers created by Docker.
 			*/
-			framework.ConformanceIt("should report termination message [LinuxOnly] from file when pod succeeds and TerminationMessagePolicy FallbackToLogsOnError is set [NodeConformance]", func() {
+			framework.ConformanceIt("should report termination message from file when pod succeeds and TerminationMessagePolicy FallbackToLogsOnError is set [Excluded:WindowsDocker] [NodeConformance]", func() {
 				container := v1.Container{
 					Image:                    framework.BusyBoxImage,
 					Command:                  []string{"/bin/sh", "-c"},

--- a/test/e2e/storage/subpath.go
+++ b/test/e2e/storage/subpath.go
@@ -54,10 +54,10 @@ var _ = utils.SIGDescribe("Subpath", func() {
 		  Release: v1.12
 		  Testname: SubPath: Reading content from a secret volume.
 		  Description: Containers in a pod can read content from a secret mounted volume which was configured with a subpath.
-		  This test is marked LinuxOnly since Windows cannot mount individual files in Containers.
+		  This test is marked [Excluded:WindowsDocker] since Docker does not support creating individual file mounts for containers on Windows.
 		*/
-		framework.ConformanceIt("should support subpaths with secret pod [LinuxOnly]", func() {
-			// TODO(claudiub): Remove [LinuxOnly] tag once Containerd becomes the default container runtime on Windows.
+		framework.ConformanceIt("should support subpaths with secret pod [Excluded:WindowsDocker]", func() {
+			// TODO(claudiub): Remove [Excluded:WindowsDocker] tag if Containerd becomes the default container runtime on Windows.
 			pod := testsuites.SubpathTestPod(f, "secret-key", "secret", &v1.VolumeSource{Secret: &v1.SecretVolumeSource{SecretName: "my-secret"}}, privilegedSecurityContext)
 			testsuites.TestBasicSubpath(f, "secret-value", pod)
 		})
@@ -66,10 +66,10 @@ var _ = utils.SIGDescribe("Subpath", func() {
 		  Release: v1.12
 		  Testname: SubPath: Reading content from a configmap volume.
 		  Description: Containers in a pod can read content from a configmap mounted volume which was configured with a subpath.
-		  This test is marked LinuxOnly since Windows cannot mount individual files in Containers.
+		  This test is marked [Excluded:WindowsDocker] since Docker does not support creating individual file mounts for containers on Windows.
 		*/
-		framework.ConformanceIt("should support subpaths with configmap pod [LinuxOnly]", func() {
-			// TODO(claudiub): Remove [LinuxOnly] tag once Containerd becomes the default container runtime on Windows.
+		framework.ConformanceIt("should support subpaths with configmap pod [Excluded:WindowsDocker]", func() {
+			// TODO(claudiub): Remove [Excluded:WindowsDocker] tag if Containerd becomes the only container runtime on Windows.
 			pod := testsuites.SubpathTestPod(f, "configmap-key", "configmap", &v1.VolumeSource{ConfigMap: &v1.ConfigMapVolumeSource{LocalObjectReference: v1.LocalObjectReference{Name: "my-configmap"}}}, privilegedSecurityContext)
 			testsuites.TestBasicSubpath(f, "configmap-value", pod)
 		})
@@ -78,10 +78,10 @@ var _ = utils.SIGDescribe("Subpath", func() {
 		  Release: v1.12
 		  Testname: SubPath: Reading content from a configmap volume.
 		  Description: Containers in a pod can read content from a configmap mounted volume which was configured with a subpath and also using a mountpath that is a specific file.
-		  This test is marked LinuxOnly since Windows cannot mount individual files in Containers.
+		  This test is marked [Excluded:WindowsDocker] since Docker does not support creating individual file mounts for containers on Windows.
 		*/
-		framework.ConformanceIt("should support subpaths with configmap pod with mountPath of existing file [LinuxOnly]", func() {
-			// TODO(claudiub): Remove [LinuxOnly] tag once Containerd becomes the default container runtime on Windows.
+		framework.ConformanceIt("should support subpaths with configmap pod with mountPath of existing file [Excluded:WindowsDocker]", func() {
+			// TODO(claudiub): Remove [Excluded:WindowsDocker] tag if Containerd becomes the default container runtime on Windows.
 			pod := testsuites.SubpathTestPod(f, "configmap-key", "configmap", &v1.VolumeSource{ConfigMap: &v1.ConfigMapVolumeSource{LocalObjectReference: v1.LocalObjectReference{Name: "my-configmap"}}}, privilegedSecurityContext)
 			file := "/etc/resolv.conf"
 			pod.Spec.Containers[0].VolumeMounts[0].MountPath = file
@@ -92,10 +92,10 @@ var _ = utils.SIGDescribe("Subpath", func() {
 		  Release: v1.12
 		  Testname: SubPath: Reading content from a downwardAPI volume.
 		  Description: Containers in a pod can read content from a downwardAPI mounted volume which was configured with a subpath.
-		  This test is marked LinuxOnly since Windows cannot mount individual files in Containers.
+		  This test is marked [Excluded:WindowsDocker] since Docker does not support creating individual file mounts for containers on Windows.
 		*/
-		framework.ConformanceIt("should support subpaths with downward pod [LinuxOnly]", func() {
-			// TODO(claudiub): Remove [LinuxOnly] tag once Containerd becomes the default container runtime on Windows.
+		framework.ConformanceIt("should support subpaths with downward pod [Excluded:WindowsDocker]", func() {
+			// TODO(claudiub): Remove [Excluded:WindowsDocker] tag if Containerd becomes the default container runtime on Windows.
 			pod := testsuites.SubpathTestPod(f, "downward/podname", "downwardAPI", &v1.VolumeSource{
 				DownwardAPI: &v1.DownwardAPIVolumeSource{
 					Items: []v1.DownwardAPIVolumeFile{{Path: "downward/podname", FieldRef: &v1.ObjectFieldSelector{APIVersion: "v1", FieldPath: "metadata.name"}}},
@@ -108,10 +108,10 @@ var _ = utils.SIGDescribe("Subpath", func() {
 		  Release: v1.12
 		  Testname: SubPath: Reading content from a projected volume.
 		  Description: Containers in a pod can read content from a projected mounted volume which was configured with a subpath.
-		  This test is marked LinuxOnly since Windows cannot mount individual files in Containers.
+		  This test is marked [Excluded:WindowsDocker] since Docker does not support creating individual file mounts for containers on Windows.
 		*/
-		framework.ConformanceIt("should support subpaths with projected pod [LinuxOnly]", func() {
-			// TODO(claudiub): Remove [LinuxOnly] tag once Containerd becomes the default container runtime on Windows.
+		framework.ConformanceIt("should support subpaths with projected pod [Excluded:WindowsDocker]", func() {
+			// TODO(claudiub): Remove [Excluded:WindowsDocker] tag once Containerd becomes the default container runtime on Windows.
 			pod := testsuites.SubpathTestPod(f, "projected/configmap-key", "projected", &v1.VolumeSource{
 				Projected: &v1.ProjectedVolumeSource{
 					Sources: []v1.VolumeProjection{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/sig windows
/sig testing

**What this PR does / why we need it**:

Windows Containerd has more features than Windows Docker. One of them is single file mappings, allowing us to also map individual files into containers, not just folders.

This will set the tag ``[Excluded:WindowsDocker]`` for those tests instead of ``[LinuxOnly]``.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
