### PR TITLE
test images: Adds BASEIMAGE for windows/amd64/2004 and windows/amd64/20H2

### DIFF
--- a/test/images/agnhost/BASEIMAGE
+++ b/test/images/agnhost/BASEIMAGE
@@ -7,3 +7,4 @@ windows/amd64/1809=REGISTRY/busybox:1.29-windows-amd64-1809
 windows/amd64/1903=REGISTRY/busybox:1.29-windows-amd64-1903
 windows/amd64/1909=REGISTRY/busybox:1.29-windows-amd64-1909
 windows/amd64/2004=REGISTRY/busybox:1.29-windows-amd64-2004
+windows/amd64/20H2=REGISTRY/busybox:1.29-windows-amd64-20H2

--- a/test/images/agnhost/BASEIMAGE
+++ b/test/images/agnhost/BASEIMAGE
@@ -6,3 +6,4 @@ linux/s390x=s390x/alpine:3.6
 windows/amd64/1809=REGISTRY/busybox:1.29-windows-amd64-1809
 windows/amd64/1903=REGISTRY/busybox:1.29-windows-amd64-1903
 windows/amd64/1909=REGISTRY/busybox:1.29-windows-amd64-1909
+windows/amd64/2004=REGISTRY/busybox:1.29-windows-amd64-2004

--- a/test/images/busybox/BASEIMAGE
+++ b/test/images/busybox/BASEIMAGE
@@ -2,3 +2,4 @@ windows/amd64/1809=mcr.microsoft.com/windows/nanoserver:1809
 windows/amd64/1903=mcr.microsoft.com/windows/nanoserver:1903
 windows/amd64/1909=mcr.microsoft.com/windows/nanoserver:1909
 windows/amd64/2004=mcr.microsoft.com/windows/nanoserver:2004
+windows/amd64/20H2=mcr.microsoft.com/windows/nanoserver:20H2

--- a/test/images/busybox/BASEIMAGE
+++ b/test/images/busybox/BASEIMAGE
@@ -1,3 +1,4 @@
 windows/amd64/1809=mcr.microsoft.com/windows/nanoserver:1809
 windows/amd64/1903=mcr.microsoft.com/windows/nanoserver:1903
 windows/amd64/1909=mcr.microsoft.com/windows/nanoserver:1909
+windows/amd64/2004=mcr.microsoft.com/windows/nanoserver:2004

--- a/test/images/echoserver/BASEIMAGE
+++ b/test/images/echoserver/BASEIMAGE
@@ -7,3 +7,4 @@ windows/amd64/1809=REGISTRY/busybox:1.29-windows-amd64-1809
 windows/amd64/1903=REGISTRY/busybox:1.29-windows-amd64-1903
 windows/amd64/1909=REGISTRY/busybox:1.29-windows-amd64-1909
 windows/amd64/2004=REGISTRY/busybox:1.29-windows-amd64-2004
+windows/amd64/20H2=REGISTRY/busybox:1.29-windows-amd64-20H2

--- a/test/images/echoserver/BASEIMAGE
+++ b/test/images/echoserver/BASEIMAGE
@@ -6,3 +6,4 @@ linux/s390x=s390x/nginx:1.15-alpine
 windows/amd64/1809=REGISTRY/busybox:1.29-windows-amd64-1809
 windows/amd64/1903=REGISTRY/busybox:1.29-windows-amd64-1903
 windows/amd64/1909=REGISTRY/busybox:1.29-windows-amd64-1909
+windows/amd64/2004=REGISTRY/busybox:1.29-windows-amd64-2004

--- a/test/images/jessie-dnsutils/BASEIMAGE
+++ b/test/images/jessie-dnsutils/BASEIMAGE
@@ -6,3 +6,4 @@ linux/s390x=s390x/debian:jessie
 windows/amd64/1809=REGISTRY/busybox:1.29-windows-amd64-1809
 windows/amd64/1903=REGISTRY/busybox:1.29-windows-amd64-1903
 windows/amd64/1909=REGISTRY/busybox:1.29-windows-amd64-1909
+windows/amd64/2004=REGISTRY/busybox:1.29-windows-amd64-2004

--- a/test/images/jessie-dnsutils/BASEIMAGE
+++ b/test/images/jessie-dnsutils/BASEIMAGE
@@ -7,3 +7,4 @@ windows/amd64/1809=REGISTRY/busybox:1.29-windows-amd64-1809
 windows/amd64/1903=REGISTRY/busybox:1.29-windows-amd64-1903
 windows/amd64/1909=REGISTRY/busybox:1.29-windows-amd64-1909
 windows/amd64/2004=REGISTRY/busybox:1.29-windows-amd64-2004
+windows/amd64/20H2=REGISTRY/busybox:1.29-windows-amd64-20H2

--- a/test/images/kitten/BASEIMAGE
+++ b/test/images/kitten/BASEIMAGE
@@ -1,8 +1,9 @@
-linux/amd64=REGISTRY/agnhost:2.21-linux-amd64
-linux/arm=REGISTRY/agnhost:2.21-linux-arm
-linux/arm64=REGISTRY/agnhost:2.21-linux-arm64
-linux/ppc64le=REGISTRY/agnhost:2.21-linux-ppc64le
-linux/s390x=REGISTRY/agnhost:2.21-linux-s390x
-windows/amd64/1809=REGISTRY/agnhost:2.21-windows-amd64-1809
-windows/amd64/1903=REGISTRY/agnhost:2.21-windows-amd64-1903
-windows/amd64/1909=REGISTRY/agnhost:2.21-windows-amd64-1909
+linux/amd64=REGISTRY/agnhost:2.25-linux-amd64
+linux/arm=REGISTRY/agnhost:2.25-linux-arm
+linux/arm64=REGISTRY/agnhost:2.25-linux-arm64
+linux/ppc64le=REGISTRY/agnhost:2.25-linux-ppc64le
+linux/s390x=REGISTRY/agnhost:2.25-linux-s390x
+windows/amd64/1809=REGISTRY/agnhost:2.25-windows-amd64-1809
+windows/amd64/1903=REGISTRY/agnhost:2.25-windows-amd64-1903
+windows/amd64/1909=REGISTRY/agnhost:2.25-windows-amd64-1909
+windows/amd64/2004=REGISTRY/agnhost:2.25-windows-amd64-2004

--- a/test/images/kitten/BASEIMAGE
+++ b/test/images/kitten/BASEIMAGE
@@ -7,3 +7,4 @@ windows/amd64/1809=REGISTRY/agnhost:2.25-windows-amd64-1809
 windows/amd64/1903=REGISTRY/agnhost:2.25-windows-amd64-1903
 windows/amd64/1909=REGISTRY/agnhost:2.25-windows-amd64-1909
 windows/amd64/2004=REGISTRY/agnhost:2.25-windows-amd64-2004
+windows/amd64/20H2=REGISTRY/agnhost:2.25-windows-amd64-20H2

--- a/test/images/nautilus/BASEIMAGE
+++ b/test/images/nautilus/BASEIMAGE
@@ -1,8 +1,9 @@
-linux/amd64=REGISTRY/agnhost:2.21-linux-amd64
-linux/arm=REGISTRY/agnhost:2.21-linux-arm
-linux/arm64=REGISTRY/agnhost:2.21-linux-arm64
-linux/ppc64le=REGISTRY/agnhost:2.21-linux-ppc64le
-linux/s390x=REGISTRY/agnhost:2.21-linux-s390x
-windows/amd64/1809=REGISTRY/agnhost:2.21-windows-amd64-1809
-windows/amd64/1903=REGISTRY/agnhost:2.21-windows-amd64-1903
-windows/amd64/1909=REGISTRY/agnhost:2.21-windows-amd64-1909
+linux/amd64=REGISTRY/agnhost:2.25-linux-amd64
+linux/arm=REGISTRY/agnhost:2.25-linux-arm
+linux/arm64=REGISTRY/agnhost:2.25-linux-arm64
+linux/ppc64le=REGISTRY/agnhost:2.25-linux-ppc64le
+linux/s390x=REGISTRY/agnhost:2.25-linux-s390x
+windows/amd64/1809=REGISTRY/agnhost:2.25-windows-amd64-1809
+windows/amd64/1903=REGISTRY/agnhost:2.25-windows-amd64-1903
+windows/amd64/1909=REGISTRY/agnhost:2.25-windows-amd64-1909
+windows/amd64/2004=REGISTRY/agnhost:2.25-windows-amd64-2004

--- a/test/images/nautilus/BASEIMAGE
+++ b/test/images/nautilus/BASEIMAGE
@@ -7,3 +7,4 @@ windows/amd64/1809=REGISTRY/agnhost:2.25-windows-amd64-1809
 windows/amd64/1903=REGISTRY/agnhost:2.25-windows-amd64-1903
 windows/amd64/1909=REGISTRY/agnhost:2.25-windows-amd64-1909
 windows/amd64/2004=REGISTRY/agnhost:2.25-windows-amd64-2004
+windows/amd64/20H2=REGISTRY/agnhost:2.25-windows-amd64-20H2

--- a/test/images/nonroot/BASEIMAGE
+++ b/test/images/nonroot/BASEIMAGE
@@ -6,3 +6,4 @@ linux/s390x=k8s.gcr.io/debian-base-s390x:v1.0.0
 windows/amd64/1809=mcr.microsoft.com/windows/nanoserver:1809
 windows/amd64/1903=mcr.microsoft.com/windows/nanoserver:1903
 windows/amd64/1909=mcr.microsoft.com/windows/nanoserver:1909
+windows/amd64/2004=mcr.microsoft.com/windows/nanoserver:2004

--- a/test/images/nonroot/BASEIMAGE
+++ b/test/images/nonroot/BASEIMAGE
@@ -7,3 +7,4 @@ windows/amd64/1809=mcr.microsoft.com/windows/nanoserver:1809
 windows/amd64/1903=mcr.microsoft.com/windows/nanoserver:1903
 windows/amd64/1909=mcr.microsoft.com/windows/nanoserver:1909
 windows/amd64/2004=mcr.microsoft.com/windows/nanoserver:2004
+windows/amd64/20H2=mcr.microsoft.com/windows/nanoserver:20H2

--- a/test/images/redis/BASEIMAGE
+++ b/test/images/redis/BASEIMAGE
@@ -7,3 +7,4 @@ windows/amd64/1809=REGISTRY/busybox:1.29-windows-amd64-1809
 windows/amd64/1903=REGISTRY/busybox:1.29-windows-amd64-1903
 windows/amd64/1909=REGISTRY/busybox:1.29-windows-amd64-1909
 windows/amd64/2004=REGISTRY/busybox:1.29-windows-amd64-2004
+windows/amd64/20H2=REGISTRY/busybox:1.29-windows-amd64-20H2

--- a/test/images/redis/BASEIMAGE
+++ b/test/images/redis/BASEIMAGE
@@ -6,3 +6,4 @@ linux/s390x=s390x/alpine:3.6
 windows/amd64/1809=REGISTRY/busybox:1.29-windows-amd64-1809
 windows/amd64/1903=REGISTRY/busybox:1.29-windows-amd64-1903
 windows/amd64/1909=REGISTRY/busybox:1.29-windows-amd64-1909
+windows/amd64/2004=REGISTRY/busybox:1.29-windows-amd64-2004

--- a/test/images/sample-apiserver/BASEIMAGE
+++ b/test/images/sample-apiserver/BASEIMAGE
@@ -6,3 +6,4 @@ linux/s390x=s390x/alpine:3.8
 windows/amd64/1809=mcr.microsoft.com/windows/nanoserver:1809
 windows/amd64/1903=mcr.microsoft.com/windows/nanoserver:1903
 windows/amd64/1909=mcr.microsoft.com/windows/nanoserver:1909
+windows/amd64/2004=mcr.microsoft.com/windows/nanoserver:2004

--- a/test/images/sample-apiserver/BASEIMAGE
+++ b/test/images/sample-apiserver/BASEIMAGE
@@ -7,3 +7,4 @@ windows/amd64/1809=mcr.microsoft.com/windows/nanoserver:1809
 windows/amd64/1903=mcr.microsoft.com/windows/nanoserver:1903
 windows/amd64/1909=mcr.microsoft.com/windows/nanoserver:1909
 windows/amd64/2004=mcr.microsoft.com/windows/nanoserver:2004
+windows/amd64/20H2=mcr.microsoft.com/windows/nanoserver:20H2


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/sig windows
/sig testing

**What this PR does / why we need it**:

Adds ``windows/amd64/2004`` and ``windows/amd64/20H2`` base images to the BASEIMAGE files, so that an image will be built for that OS version and which will then be included in the manifest list.

The Windows Server 20H2 has been released in the second half of 2020. We are going to need test images built for it in order to test it.

The windows-servercore-cache has already been updated [1].

[1] https://github.com/kubernetes/kubernetes/pull/97247

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
