### PR TITLE
Add docker_image_name file to release

### DIFF
--- a/build/lib/release.sh
+++ b/build/lib/release.sh
@@ -393,6 +393,7 @@ EOF
           "${DOCKER[@]}" tag "${docker_image_tag}" "${release_docker_image_tag}" 2>/dev/null
         fi
         "${DOCKER[@]}" save -o "${binary_file_path}.tar" "${docker_image_tag}" "${release_docker_image_tag}"
+        echo "${release_docker_image_tag}" > "${binary_file_path}.docker_image_name"
         echo "${docker_tag}" > "${binary_file_path}.docker_tag"
         rm -rf "${docker_build_path}"
         ln "${binary_file_path}.tar" "${images_dir}/"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind feature
/sig release
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:

Kubernetes releases docker image tar files (`<image>.tar`) along with a `.docker_tag` file. Tools such as kops [read the `.docker_tag` file](https://github.com/kubernetes/kops/blob/56f3cb33481ab7c1d073ddaac6e4873b0b264249/pkg/model/components/context.go#L161-L164) to know what version tag to apply running [`docker load`](https://github.com/kubernetes/kops/blob/a93febf5a6a9f3439c5c3d74c984a9f1609b855f/upup/pkg/fi/nodeup/nodetasks/load_image.go#L151) with these images, but there are no hints as to which image registry these images should be tagged with, so [kops hardcodes the registry to `k8s.gcr.io`](https://github.com/kubernetes/kops/blob/56f3cb33481ab7c1d073ddaac6e4873b0b264249/pkg/model/components/context.go#L171). By adding a `.docker_image_name` file, tooling such as kops can easily discover the image name for releases by other vendors that mirror the standard release structure but use a different image registry

In the EKS Distro, we've [added this file](https://github.com/aws/eks-distro/blob/18f31b9/projects/kubernetes/kubernetes/build/lib/images.sh#L61).

* [v1.18.9/bin/linux/arm64/kube-apiserver.tar](https://distro.eks.amazonaws.com/kubernetes-1-18/releases/1/artifacts/kubernetes/v1.18.9/bin/linux/arm64/kube-apiserver.tar) (warning: 210MB OCI tar file)
* [v1.18.9/bin/linux/arm64/kube-apiserver.docker_tag](https://distro.eks.amazonaws.com/kubernetes-1-18/releases/1/artifacts/kubernetes/v1.18.9/bin/linux/arm64/kube-apiserver.docker_tag) (small text file)
* [v1.18.9/bin/linux/arm64/kube-apiserver.docker_image_name](https://distro.eks.amazonaws.com/kubernetes-1-18/releases/1/artifacts/kubernetes/v1.18.9/bin/linux/arm64/kube-apiserver.docker_image_name) (small text file)


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
