### PR TITLE
Add constraint selector to pod template

### DIFF
--- a/test/integration/scheduler_perf/config/pod-with-preferred-topology-spreading.yaml
+++ b/test/integration/scheduler_perf/config/pod-with-preferred-topology-spreading.yaml
@@ -2,11 +2,16 @@ apiVersion: v1
 kind: Pod
 metadata:
   generateName: spreading-pod-
+  labels:
+    color: blue
 spec:
   topologySpreadConstraints:
     - maxSkew: 5
       topologyKey: topology.kubernetes.io/zone
       whenUnsatisfiable: ScheduleAnyway
+      labelSelector:
+        matchLabels:
+          color: blue
   containers:
   - image: k8s.gcr.io/pause:3.2
     name: pause

--- a/test/integration/scheduler_perf/config/pod-with-topology-spreading.yaml
+++ b/test/integration/scheduler_perf/config/pod-with-topology-spreading.yaml
@@ -2,11 +2,16 @@ apiVersion: v1
 kind: Pod
 metadata:
   generateName: spreading-pod-
+  labels:
+    color: blue
 spec:
   topologySpreadConstraints:
     - maxSkew: 5
       topologyKey: topology.kubernetes.io/zone
       whenUnsatisfiable: DoNotSchedule
+      labelSelector:
+        matchLabels:
+          color: blue
   containers:
   - image: k8s.gcr.io/pause:3.2
     name: pause


### PR DESCRIPTION
PodTopologySpread plugin will only count the existing pod when that
pod's label matches with `constraint.Selector`, which means all pods
could be scheduled to one topology zone when the constraint does not
have any selector defined.

Signed-off-by: Dave Chen <dave.chen@arm.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

Add one of the following kinds:
/kind cleanup



**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
My recent testing on the  PodTopologySpread shows that is possible to schedule all the pod into the one zone without this change, here is the how the pods are counted,

https://github.com/kubernetes/kubernetes/blob/a744bddbf497ab718a40bee1c730e7e848e471ed/pkg/scheduler/framework/plugins/podtopologyspread/filtering.go#L251-L259

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
