### PR TITLE
Validate nfconntrack regardless of kernel version

### DIFF
--- a/pkg/proxy/ipvs/proxier.go
+++ b/pkg/proxy/ipvs/proxier.go
@@ -627,7 +627,6 @@ func (handle *LinuxKernelHandler) GetModules() ([]string, error) {
 		}
 		return bmods, nil
 	}
-
 	if err != nil {
 		return nil, fmt.Errorf("failed to read file /proc/modules with error %w", err)
 	}
@@ -640,7 +639,6 @@ func (handle *LinuxKernelHandler) GetModules() ([]string, error) {
 
 	bmods, nfconntrack, err = utilipvs.BuiltinIPVSModules(false, kernelVersionStr)
 	if err != nil {
-<<<<<<< HEAD
 		klog.ErrorS(err, "Failed to read builtin modules file, you can ignore this message when kube-proxy is running inside container without mounting /lib/modules", "filePath", builtinModsFilePath)
 	}
 
@@ -657,26 +655,7 @@ func (handle *LinuxKernelHandler) GetModules() ([]string, error) {
 				lmods = append(lmods, module)
 			}
 		}
-||||||| parent of 5b88c3962f3 (Validate nfconntrack regardless of kernel version)
-		klog.Warningf("Failed to read file %s with error %v. You can ignore this message when kube-proxy is running inside container without mounting /lib/modules", builtinModsFilePath, err)
-	}
-
-	for _, module := range ipvsModules {
-		if match, _ := regexp.Match(module+".ko", b); match {
-			bmods = append(bmods, module)
-		} else {
-			// Try to load the required IPVS kernel modules if not built in
-			err := handle.executor.Command("modprobe", "--", module).Run()
-			if err != nil {
-				klog.Warningf("Failed to load kernel module %v with modprobe. "+
-					"You can ignore this message when kube-proxy is running inside container without mounting /lib/modules", module)
-			} else {
-				lmods = append(lmods, module)
-			}
-		}
-=======
 		return nil, fmt.Errorf("Failed to get kernel built-in modules")
->>>>>>> 5b88c3962f3 (Validate nfconntrack regardless of kernel version)
 	}
 
 	mods = append(mods, bmods...)

--- a/pkg/proxy/ipvs/proxier_test.go
+++ b/pkg/proxy/ipvs/proxier_test.go
@@ -371,6 +371,14 @@ func TestCanUseIPVSProxier(t *testing.T) {
 			ipsetVersion:  MinIPSetCheckVersion,
 			ok:            false,
 		},
+		// case 11, missing nf_conntrack_modules
+		{
+			mods:          []string{"ip_vs", "ip_vs_rr", "ip_vs_wrr", "ip_vs_sh", "ip_vs_dh"},
+			scheduler:     "dh",
+			kernelVersion: "4.19",
+			ipsetVersion:  MinIPSetCheckVersion,
+			ok:            false,
+		},
 	}
 
 	for i := range testCases {

--- a/pkg/util/ipvs/ipvs.go
+++ b/pkg/util/ipvs/ipvs.go
@@ -131,8 +131,13 @@ func (rs *RealServer) Equal(other *RealServer) bool {
 func GetRequiredIPVSModules() []string {
 	// "nf_conntrack_ipv4" has been removed since v4.19
 	// see https://github.com/torvalds/linux/commit/a0ae2562c6c4b2721d9fddba63b7286c13517d9f
-	return []string{KernelModuleIPVS, KernelModuleIPVSRR, KernelModuleIPVSWRR, KernelModuleIPVSSH, KernelModuleNfConntrack, KernelModuleNfConntrackIPV4}
-
+	return []string{
+		KernelModuleIPVS,
+		KernelModuleIPVSRR,
+		KernelModuleIPVSWRR,
+		KernelModuleIPVSSH,
+		KernelModuleNfConntrack,
+		KernelModuleNfConntrackIPV4}
 }
 
 // BuiltinIPVSModules checks modules that are already built-in into the kernel

--- a/pkg/util/ipvs/ipvs_test.go
+++ b/pkg/util/ipvs/ipvs_test.go
@@ -392,19 +392,13 @@ func TestGetRequiredIPVSModules(t *testing.T) {
 		want          []string
 	}{
 		{
-			name:          "kernel version < 4.19",
-			kernelVersion: version.MustParseGeneric("4.18"),
-			want:          []string{KernelModuleIPVS, KernelModuleIPVSRR, KernelModuleIPVSWRR, KernelModuleIPVSSH, KernelModuleNfConntrackIPV4},
-		},
-		{
-			name:          "kernel version 4.19",
-			kernelVersion: version.MustParseGeneric("4.19"),
-			want:          []string{KernelModuleIPVS, KernelModuleIPVSRR, KernelModuleIPVSWRR, KernelModuleIPVSSH, KernelModuleNfConntrack},
+			name: "GetIPVSModules",
+			want: []string{KernelModuleIPVS, KernelModuleIPVSRR, KernelModuleIPVSWRR, KernelModuleIPVSSH, KernelModuleNfConntrackIPV4, KernelModuleNfConntrack},
 		},
 	}
 	for _, test := range Tests {
 		t.Run(test.name, func(t *testing.T) {
-			got := GetRequiredIPVSModules(test.kernelVersion)
+			got := GetRequiredIPVSModules()
 			sort.Strings(got)
 			sort.Strings(test.want)
 			if !reflect.DeepEqual(got, test.want) {


### PR DESCRIPTION
Signed-off-by: Ricardo Pchevuzinske Katz <ricardo.katz@gmail.com>

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**: Due to Red Hat 8.3+ using Kernel 4.18 but new nf_conntrack, kube-proxy does not try to load nf_conntrack correctly.

This PR removes the validation based in kernel version and validates the ability to use kube-proxy IPVS based in the existence of nf_conntrack or nf_conntrack_v4

**Which issue(s) this PR fixes**:  
Fixes #97052

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

/sig network
/priority backlog

/assign @danwinship @andrewsykim 
