### PR TITLE
APF e2e: disable drown-out tests temporarily

### DIFF
--- a/test/e2e/apimachinery/flowcontrol.go
+++ b/test/e2e/apimachinery/flowcontrol.go
@@ -74,6 +74,9 @@ var _ = SIGDescribe("API priority and fairness", func() {
 	// higher QPS client cannot drown out the other one despite having higher
 	// priority.
 	ginkgo.It("should ensure that requests can't be drowned out (priority)", func() {
+		// See https://github.com/kubernetes/kubernetes/issues/96710
+		ginkgo.Skip("skipping test until flakiness is resolved")
+
 		flowSchemaNamePrefix := "e2e-testing-flowschema-" + f.UniqueName
 		priorityLevelNamePrefix := "e2e-testing-prioritylevel-" + f.UniqueName
 		loadDuration := 10 * time.Second
@@ -83,13 +86,13 @@ var _ = SIGDescribe("API priority and fairness", func() {
 		type client struct {
 			username                    string
 			qps                         float64
-			priorityLevelName           string
-			concurrencyMultiplier       float64
+			priorityLevelName           string  //lint:ignore U1000 field is actually used
+			concurrencyMultiplier       float64 //lint:ignore U1000 field is actually used
 			concurrency                 int32
-			flowSchemaName              string
-			matchingPrecedence          int32
+			flowSchemaName              string //lint:ignore U1000 field is actually used
+			matchingPrecedence          int32  //lint:ignore U1000 field is actually used
 			completedRequests           int32
-			expectedCompletedPercentage float64
+			expectedCompletedPercentage float64 //lint:ignore U1000 field is actually used
 		}
 		clients := []client{
 			// "highqps" refers to a client that creates requests at a much higher
@@ -154,6 +157,9 @@ var _ = SIGDescribe("API priority and fairness", func() {
 	// the two clients and not allow one client to drown out the other despite
 	// having a higher QPS.
 	ginkgo.It("should ensure that requests can't be drowned out (fairness)", func() {
+		// See https://github.com/kubernetes/kubernetes/issues/96710
+		ginkgo.Skip("skipping test until flakiness is resolved")
+
 		priorityLevelName := "e2e-testing-prioritylevel-" + f.UniqueName
 		flowSchemaName := "e2e-testing-flowschema-" + f.UniqueName
 		loadDuration := 10 * time.Second
@@ -171,10 +177,10 @@ var _ = SIGDescribe("API priority and fairness", func() {
 		type client struct {
 			username                    string
 			qps                         float64
-			concurrencyMultiplier       float64
+			concurrencyMultiplier       float64 //lint:ignore U1000 field is actually used
 			concurrency                 int32
 			completedRequests           int32
-			expectedCompletedPercentage float64
+			expectedCompletedPercentage float64 //lint:ignore U1000 field is actually used
 		}
 		clients := []client{
 			{username: highQPSClientName, qps: 100.0, concurrencyMultiplier: 2.0, expectedCompletedPercentage: 0.75},
@@ -242,6 +248,7 @@ func createPriorityLevel(f *framework.Framework, priorityLevelName string, assur
 	}
 }
 
+//lint:ignore U1000 function is actually referenced
 func getPriorityLevelConcurrency(f *framework.Framework, priorityLevelName string) int32 {
 	resp, err := f.ClientSet.CoreV1().RESTClient().Get().RequestURI("/metrics").DoRaw(context.TODO())
 	framework.ExpectNoError(err)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind failing-test

**What this PR does / why we need it**: The test is severely flaky due to test-environment factors. While we have merged a mitigation, the issue seems to persist. We recommend disabling the test temporarily and figuring out a way to resolve the root cause of the flakiness after.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Related to https://github.com/kubernetes/kubernetes/issues/96710 (do not close the issue until the true root cause for the flake is fixed)

**Special notes for your reviewer**:

/cc @lavalamp @fedebongio @hasheddan @kubernetes/release-team @kubernetes/release-managers 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/sig api-machinery