### PR TITLE
Passes a context to the drain helper object

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/drain/cordon.go
+++ b/staging/src/k8s.io/kubectl/pkg/drain/cordon.go
@@ -73,6 +73,12 @@ func (c *CordonHelper) UpdateIfRequired(desired bool) bool {
 // JSON, or if either patch or update calls fail; it will also return a second error
 // whenever creating a patch has failed
 func (c *CordonHelper) PatchOrReplace(clientset kubernetes.Interface, serverDryRun bool) (error, error) {
+	return c.PatchOrReplaceWithContext(context.TODO(), clientset, serverDryRun)
+}
+
+// PatchOrReplaceWithContext provides the option to pass a custom context while updating
+// the node status
+func (c *CordonHelper) PatchOrReplaceWithContext(clientCtx context.Context, clientset kubernetes.Interface, serverDryRun bool) (error, error) {
 	client := clientset.CoreV1().Nodes()
 
 	oldData, err := json.Marshal(c.node)
@@ -93,13 +99,13 @@ func (c *CordonHelper) PatchOrReplace(clientset kubernetes.Interface, serverDryR
 		if serverDryRun {
 			patchOptions.DryRun = []string{metav1.DryRunAll}
 		}
-		_, err = client.Patch(context.TODO(), c.node.Name, types.StrategicMergePatchType, patchBytes, patchOptions)
+		_, err = client.Patch(clientCtx, c.node.Name, types.StrategicMergePatchType, patchBytes, patchOptions)
 	} else {
 		updateOptions := metav1.UpdateOptions{}
 		if serverDryRun {
 			updateOptions.DryRun = []string{metav1.DryRunAll}
 		}
-		_, err = client.Update(context.TODO(), c.node, updateOptions)
+		_, err = client.Update(clientCtx, c.node, updateOptions)
 	}
 	return err, patchErr
 }

--- a/staging/src/k8s.io/kubectl/pkg/drain/default.go
+++ b/staging/src/k8s.io/kubectl/pkg/drain/default.go
@@ -57,7 +57,7 @@ func RunCordonOrUncordon(drainer *Helper, node *corev1.Node, desired bool) error
 		return nil
 	}
 
-	err, patchErr := c.PatchOrReplace(drainer.Client, false)
+	err, patchErr := c.PatchOrReplaceWithContext(drainer.Ctx, drainer.Client, false)
 	if err != nil {
 		if patchErr != nil {
 			return fmt.Errorf("cordon error: %s; merge patch error: %s", err.Error(), patchErr.Error())


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
This PR updates the patch or replace method of the cordon helper to accept a user supplied context for use by the client to update the status of the node before cordon/uncordon operations. 

**Which issue(s) this PR fixes**:
fixes #97133

**Special notes for your reviewer**:
[Slack thread](https://kubernetes.slack.com/archives/C2GL57FJ4/p1607124045229400) around the same discussion in the #sig-cli channel.

**Does this PR introduce a user-facing change?**:
NONE

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
NONE