### PR TITLE
Ipvs: non-local access to externalTrafficPolicy:Local

### DIFF
--- a/pkg/proxy/ipvs/proxier.go
+++ b/pkg/proxy/ipvs/proxier.go
@@ -1972,7 +1972,15 @@ func (proxier *Proxier) syncEndpoint(svcPortName proxy.ServicePortName, onlyNode
 	} else {
 		clusterEndpoints, localEndpoints, _, _ := proxy.CategorizeEndpoints(endpoints, svcInfo, proxier.nodeLabels)
 		if onlyNodeLocalEndpoints {
-			endpoints = localEndpoints
+			if len(localEndpoints) > 0 {
+				endpoints = localEndpoints
+			} else {
+				// https://github.com/kubernetes/kubernetes/pull/97081
+				// Allow access from local PODs even if no local endpoints exist.
+				// Traffic from an external source will be routed but the reply
+				// will have the POD address and will be discarded.
+				endpoints = clusterEndpoints
+			}
 		} else {
 			endpoints = clusterEndpoints
 		}

--- a/pkg/proxy/ipvs/proxier_test.go
+++ b/pkg/proxy/ipvs/proxier_test.go
@@ -5319,10 +5319,11 @@ func Test_EndpointSliceOnlyReadyAndTerminatingLocalWithFeatureGateDisabled(t *te
 	assert.Len(t, realServers1, 1, "Expected 1 real servers")
 	assert.Equal(t, realServers1[0].String(), "10.0.1.5:80")
 
-	// externalIP should have 0 endpoints since the feature gate is disabled.
+	// externalIP should have 1 (remote) endpoint since the feature gate is disabled.
 	realServers2, rsErr2 := ipvs.GetRealServers(externalIPServer)
 	assert.Nil(t, rsErr2, "Expected no error getting real servers")
-	assert.Len(t, realServers2, 0, "Expected 0 real servers")
+	assert.Len(t, realServers2, 1, "Expected 0 real servers")
+	assert.Equal(t, realServers2[0].String(), "10.0.1.5:80")
 
 	fp.OnEndpointSliceDelete(endpointSlice)
 	fp.syncProxyRules()


### PR DESCRIPTION
**What type of PR is this?**

This PR adds the fix presented by @jpiper in https://github.com/kubernetes/kubernetes/issues/75262#issuecomment-495184187.

/kind feature

**What this PR does / why we need it**:

Allow access to externalTrafficPolicy:Local services from PODs not on a node where a server executes. Problem described in #93456

The most common use-case is when a service is accessed from PODs but the service _may_ be local or on _another cluster_. The application want's to access the service in an uniform way using it's external (loadBalancer) IP. But for services with `externalTrafficPolicy:Local` this will fail if no server is executing on the local node.

The feature is already implemented for proxy-mode=iptables.

**Which issue(s) this PR fixes**:

Partially Fixes #93456

"Partially" because access from the main netns (e.g a `hostNetwork:True` POD) on a K8s node where the server POD does not execute will fail. This is not easily fixed since the route to the `kube-ipvs0` must be altered, please  see further https://github.com/kubernetes/kubernetes/issues/93456#issuecomment-733494978.

This PR will however fix the problem wast majority of users and it is quite small.

**Special notes for your reviewer**:



**Does this PR introduce a user-facing change?**:

```release-note
NONE
```


