### PR TITLE
Fix tODO in kube-proxy for --config option / update docker-links service inject statement

### DIFF
--- a/test/e2e/apimachinery/flowcontrol.go
+++ b/test/e2e/apimachinery/flowcontrol.go
@@ -100,8 +100,8 @@ var _ = SIGDescribe("API priority and fairness", func() {
 			// In contrast, "lowqps" stays under its concurrency shares.
 			// Additionally, the "highqps" client also has a higher matching
 			// precedence for its flow schema.
-			{username: highQPSClientName, qps: 85, concurrencyMultiplier: 2.0, matchingPrecedence: 999, expectedCompletedPercentage: 0.75},
-			{username: lowQPSClientName, qps: 4, concurrencyMultiplier: 0.5, matchingPrecedence: 1000, expectedCompletedPercentage: 0.75},
+			{username: highQPSClientName, qps: 90, concurrencyMultiplier: 2.0, matchingPrecedence: 999, expectedCompletedPercentage: 0.90},
+			{username: lowQPSClientName, qps: 4, concurrencyMultiplier: 0.5, matchingPrecedence: 1000, expectedCompletedPercentage: 0.90},
 		}
 
 		ginkgo.By("creating test priority levels and flow schemas")
@@ -183,12 +183,9 @@ var _ = SIGDescribe("API priority and fairness", func() {
 			expectedCompletedPercentage float64 //lint:ignore U1000 field is actually used
 		}
 		clients := []client{
-<<<<<<< HEAD
 			{username: highQPSClientName, qps: 90, concurrencyMultiplier: 2.0, expectedCompletedPercentage: 0.90},
-=======
-			{username: highQPSClientName, qps: 85, concurrencyMultiplier: 2.0, expectedCompletedPercentage: 0.75},
->>>>>>> Reduce expected goodput
-			{username: lowQPSClientName, qps: 4, concurrencyMultiplier: 0.5, expectedCompletedPercentage: 0.90},
+			{username: highQPSClientName, qps: 90, concurrencyMultiplier: 2.0, expectedCompletedPercentage: 0.90},
+			{username: lowQPSClientName, qps: 4, concurrencyMultiplier: 0.5, expectedCompletedPercentage: 0.90}
 		}
 
 		framework.Logf("getting real concurrency")

--- a/test/e2e/apimachinery/flowcontrol.go
+++ b/test/e2e/apimachinery/flowcontrol.go
@@ -100,8 +100,8 @@ var _ = SIGDescribe("API priority and fairness", func() {
 			// In contrast, "lowqps" stays under its concurrency shares.
 			// Additionally, the "highqps" client also has a higher matching
 			// precedence for its flow schema.
-			{username: highQPSClientName, qps: 90, concurrencyMultiplier: 2.0, matchingPrecedence: 999, expectedCompletedPercentage: 0.90},
-			{username: lowQPSClientName, qps: 4, concurrencyMultiplier: 0.5, matchingPrecedence: 1000, expectedCompletedPercentage: 0.90},
+			{username: highQPSClientName, qps: 85, concurrencyMultiplier: 2.0, matchingPrecedence: 999, expectedCompletedPercentage: 0.75},
+			{username: lowQPSClientName, qps: 4, concurrencyMultiplier: 0.5, matchingPrecedence: 1000, expectedCompletedPercentage: 0.75},
 		}
 
 		ginkgo.By("creating test priority levels and flow schemas")
@@ -183,7 +183,11 @@ var _ = SIGDescribe("API priority and fairness", func() {
 			expectedCompletedPercentage float64 //lint:ignore U1000 field is actually used
 		}
 		clients := []client{
+<<<<<<< HEAD
 			{username: highQPSClientName, qps: 90, concurrencyMultiplier: 2.0, expectedCompletedPercentage: 0.90},
+=======
+			{username: highQPSClientName, qps: 85, concurrencyMultiplier: 2.0, expectedCompletedPercentage: 0.75},
+>>>>>>> Reduce expected goodput
 			{username: lowQPSClientName, qps: 4, concurrencyMultiplier: 0.5, expectedCompletedPercentage: 0.90},
 		}
 


### PR DESCRIPTION

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Since docker supporting is moving out of tree we need to have explicit definitions for the way pods slurp env vars (and also, this function has a TODO related to the `config` name which is guaranteed not to occur as long as the `--config` option is self-consistent with the flag name.

**Which issue(s) this PR fixes**:

No issue since it fixes a TODO in the codebase.

