### PR TITLE
Migrate prober.probe logs to structured logging

### DIFF
--- a/pkg/kubelet/prober/prober.go
+++ b/pkg/kubelet/prober/prober.go
@@ -101,9 +101,8 @@ func (pb *prober) probe(probeType probeType, pod *v1.Pod, status v1.PodStatus, c
 		return results.Failure, fmt.Errorf("unknown probe type: %q", probeType)
 	}
 
-	ctrName := fmt.Sprintf("%s:%s", format.Pod(pod), container.Name)
 	if probeSpec == nil {
-		klog.Warningf("%s probe for %s is nil", probeType, ctrName)
+		klog.InfoS("Probe is nil", "probeType", probeType, "pod", klog.KObj(pod), "podUID", pod.UID, "container", container.Name)
 		return results.Success, nil
 	}
 
@@ -111,19 +110,19 @@ func (pb *prober) probe(probeType probeType, pod *v1.Pod, status v1.PodStatus, c
 	if err != nil || (result != probe.Success && result != probe.Warning) {
 		// Probe failed in one way or another.
 		if err != nil {
-			klog.V(1).Infof("%s probe for %q errored: %v", probeType, ctrName, err)
+			klog.V(1).ErrorS(err, "Probe errored", "probeType", probeType, "pod", klog.KObj(pod), "podUID", pod.UID, "container", container.Name)
 			pb.recordContainerEvent(pod, &container, v1.EventTypeWarning, events.ContainerUnhealthy, "%s probe errored: %v", probeType, err)
 		} else { // result != probe.Success
-			klog.V(1).Infof("%s probe for %q failed (%v): %s", probeType, ctrName, result, output)
+			klog.V(1).InfoS("Probe failed", "probeType", probeType, "pod", klog.KObj(pod), "podUID", pod.UID, "container", container.Name, "probeResult", result, "output", output)
 			pb.recordContainerEvent(pod, &container, v1.EventTypeWarning, events.ContainerUnhealthy, "%s probe failed: %s", probeType, output)
 		}
 		return results.Failure, err
 	}
 	if result == probe.Warning {
 		pb.recordContainerEvent(pod, &container, v1.EventTypeWarning, events.ContainerProbeWarning, "%s probe warning: %s", probeType, output)
-		klog.V(3).Infof("%s probe for %q succeeded with a warning: %s", probeType, ctrName, output)
+		klog.V(3).InfoS("Probe succeeded with a warning", "probeType", probeType, "pod", klog.KObj(pod), "podUID", pod.UID, "container", container.Name, "output", output)
 	} else {
-		klog.V(3).Infof("%s probe for %q succeeded", probeType, ctrName)
+		klog.V(3).InfoS("Probe succeeded", "probeType", probeType, "pod", klog.KObj(pod), "podUID", pod.UID, "container", container.Name)
 	}
 	return results.Success, nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Ref:
* [keps/sig-instrumentation/1602-structured-logging](https://github.com/kubernetes/enhancements/tree/master/keps/sig-instrumentation/1602-structured-logging)
* [Structured Logging migration instructions](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/migration-to-structured-logging.md)


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Verify log output**
Log output "Probe is nil"
```
# before
W1206 23:02:02.337481   31606 prober.go:106] Startup probe for kube-controller-manager-base-vm_kube-system(4cd8806580e432b1c63883b56257bc25):kube-controller-manager is nil

# after
I1206 23:06:44.267132   32349 prober.go:105] "Probe is nil" probeType="Liveness" pod="kube-system/kube-controller-manager-base-vm" podUID=4cd8806580e432b1c63883b56257bc25 container="kube-controller-manager"
```

Log output for "Probe succeeded"
```
# before
I1206 20:17:47.037248    1639 prober.go:126] Readiness probe for "goldpinger-x4brf_kube-system(c1520e6b-d0d3-4de9-9c77-3ccd5274f2e9):goldpinger" succeeded

# after
I1205 05:59:13.870209   26485 prober.go:126] "Probe succeeded" probeType="Readiness" pod="kube-system/goldpinger-vsx6p" podUID=bd4f52ad-2dd1-48f7-9e3e-c36b2110e18a container="goldpinger"
```


Log output for "Probe failed"
```
# before
I1206 20:29:49.515531   14870 prober.go:117] Liveness probe for "goldpinger-6nhdw_kube-system(18ce9b70-c8da-4e27-bb5c-e8490fc32e06):goldpinger" failed (failure): Get "http://100.96.0.31:8081/healthz": dial tcp 100.96.0.31:8081: connect: connection refused

# after
I1206 04:13:50.341041   11875 prober.go:117] "Probe failed" probeType="Liveness" pod="kube-system/goldpinger-8trpg" podUID=f119e663-3996-4b8e-8a43-2eed332a1b59 container="goldpinger" probeResult=failure output="Get \"http://100.96.0.15:8081/healthz\": dial tcp 100.96.0.15:8081: connect: connection refused"
```


Log output for "Probe errored"
```
# before
I1206 22:02:04.426351   12917 prober.go:114] Liveness probe for "testpod_default(9e67df23-47d3-4155-b5b8-fbb2b3406562):test" errored: rpc error: code = DeadlineExceeded desc = failed to exec in container: timeout 2s exceeded: context deadline exceeded

# after
E1206 22:52:25.670555   29450 prober.go:114] "Probe errored" err="some error" probeType="Liveness" pod="kube-system/coredns-f9fd979d6-bnk8l" podUID=3c6f90a9-9401-44ee-98a0-29e2a8e14969 container="coredns"
```

Log output for "Probe succeeded with a warning"
```
# before
I1206 22:56:14.129965   30273 prober.go:125] Readiness probe for "coredns-f9fd979d6-5wm5l_kube-system(50ad0836-ec52-4909-bcb1-afc938010b05):coredns" succeeded with a warning: OK

# after
I1206 22:58:33.453114   30767 prober.go:124] "Probe succeeded with a warning" probeType="Readiness" pod="kube-system/kube-apiserver-base-vm" podUID=7e0fc438e5bc254e28ac1bc58e27e32b container="kube-apiserver" output="ok"
```