### PR TITLE
fix: Azure/OIDC auth panics when no AuthProviderConfigPersister is nil

### DIFF
--- a/staging/src/k8s.io/client-go/rest/plugin.go
+++ b/staging/src/k8s.io/client-go/rest/plugin.go
@@ -47,6 +47,13 @@ type AuthProviderConfigPersister interface {
 	Persist(map[string]string) error
 }
 
+type noopPersister struct{}
+
+func (n *noopPersister) Persist(_ map[string]string) error {
+	// no operation persister
+	return nil
+}
+
 // All registered auth provider plugins.
 var pluginsLock sync.Mutex
 var plugins = make(map[string]Factory)
@@ -68,6 +75,9 @@ func GetAuthProvider(clusterAddress string, apc *clientcmdapi.AuthProviderConfig
 	p, ok := plugins[apc.Name]
 	if !ok {
 		return nil, fmt.Errorf("no Auth Provider found for name %q", apc.Name)
+	}
+	if persister == nil {
+		persister = &noopPersister{}
 	}
 	return p(clusterAddress, apc.Config, persister)
 }

--- a/staging/src/k8s.io/client-go/rest/plugin_test.go
+++ b/staging/src/k8s.io/client-go/rest/plugin_test.go
@@ -171,6 +171,28 @@ func TestAuthPluginPersist(t *testing.T) {
 
 }
 
+func Test_WhenNilPersister_NoOpPersisterIsAssigned(t *testing.T) {
+
+	if err := RegisterAuthProviderPlugin("anyPlugin", pluginPersistProvider); err != nil {
+		t.Errorf("unexpected error: failed to register 'anyPlugin': %v", err)
+	}
+	cfg := &clientcmdapi.AuthProviderConfig{
+		Name:   "anyPlugin",
+		Config: nil,
+	}
+	plugin, err := GetAuthProvider("127.0.0.1", cfg, nil)
+	if err != nil {
+		t.Errorf("unexpected error: failed to get 'anyPlugin': %v", err)
+	}
+
+	anyPlugin := plugin.(*pluginPersist)
+
+	if _, ok := anyPlugin.persister.(*noopPersister); !ok {
+		t.Errorf("expected to be No Operation persister")
+	}
+
+}
+
 // emptyTransport provides an empty http.Response with an initialized header
 // to allow wrapping RoundTrippers to set header values.
 type emptyTransport struct{}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Prevents the go-client from panicking.
Azure and OIDC auth plugins cause panic when used with go-client created via `DirectClientConfig` and having `DirectClientConfig.configAccess == nil`

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #97094 
Fixes #90766

**Special notes for your reviewer**:

There is a stale PR #90767 that addresses this bug in a bit different way 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```