### PR TITLE
volume: make pvc waiting for pods less event noisy

### DIFF
--- a/pkg/controller/volume/persistentvolume/binder_test.go
+++ b/pkg/controller/volume/persistentvolume/binder_test.go
@@ -182,9 +182,9 @@ func TestSync(t *testing.T) {
 			"1-13 - delayed binding",
 			newVolumeArray("volume1-1", "1Gi", "", "", v1.VolumeAvailable, v1.PersistentVolumeReclaimRetain, classWait),
 			newVolumeArray("volume1-1", "1Gi", "", "", v1.VolumeAvailable, v1.PersistentVolumeReclaimRetain, classWait),
-			newClaimArray("claim1-1", "uid1-1", "1Gi", "", v1.ClaimPending, &classWait),
-			newClaimArray("claim1-1", "uid1-1", "1Gi", "", v1.ClaimPending, &classWait),
-			[]string{"Normal WaitForFirstConsumer"},
+			claimsWithConditions([]v1.PersistentVolumeClaimCondition{{Type: v1.PersistentVolumeClaimWaitingForConsumer, Status: "True", Reason: "WaitingForConsumer"}}, newClaimArray("claim1-1", "uid1-1", "1Gi", "", v1.ClaimPending, &classWait)),
+			claimsWithConditions([]v1.PersistentVolumeClaimCondition{{Type: v1.PersistentVolumeClaimWaitingForConsumer, Status: "True", Reason: "WaitingForConsumer"}}, newClaimArray("claim1-1", "uid1-1", "1Gi", "", v1.ClaimPending, &classWait)),
+			[]string{},
 			noerrors, testSyncClaim,
 		},
 		{

--- a/pkg/controller/volume/persistentvolume/framework_test.go
+++ b/pkg/controller/volume/persistentvolume/framework_test.go
@@ -428,6 +428,14 @@ func newClaimArray(name, claimUID, capacity, boundToVolume string, phase v1.Pers
 	}
 }
 
+// claimsWithConditions add specified conditions into an array of claims.
+func claimsWithConditions(conditions []v1.PersistentVolumeClaimCondition, claims []*v1.PersistentVolumeClaim) []*v1.PersistentVolumeClaim {
+	for i := range claims {
+		claims[i].Status.Conditions = conditions
+	}
+	return claims
+}
+
 // claimWithAnnotation saves given annotation into given claims. Meant to be
 // used to compose claims specified inline in a test.
 // TODO(refactor): This helper function (and other helpers related to claim

--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -508,6 +508,8 @@ const (
 	PersistentVolumeClaimResizing PersistentVolumeClaimConditionType = "Resizing"
 	// PersistentVolumeClaimFileSystemResizePending - controller resize is finished and a file system resize is pending on node
 	PersistentVolumeClaimFileSystemResizePending PersistentVolumeClaimConditionType = "FileSystemResizePending"
+	// PersistentVolumeClaimWaitingForConsumer - persistent volume claim is waiting for the consumer to attach it
+	PersistentVolumeClaimWaitingForConsumer PersistentVolumeClaimConditionType = "WaitingForConsumer"
 )
 
 // PersistentVolumeClaimCondition contails details about state of pvc


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

A single PVC without pod/consumer generate ~700 events in 3 hours. While the events are likely correlated, if cluster has 3000 or 10000 PVC's like this, it generates a ton of spam.

This PR introduces a change, when a condition is set when the PVC waits for the consumer in addition to the event. On next reconciliation, if the condition is active, the event is skipped.

```release-note
NONE
```