### PR TITLE
Add NotEquals support for ParseToLabelSelector

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/helpers.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/helpers.go
@@ -126,7 +126,7 @@ func ParseToLabelSelector(selector string) (*LabelSelector, error) {
 			continue
 		case selection.In:
 			op = LabelSelectorOpIn
-		case selection.NotIn:
+		case selection.NotIn, selection.NotEquals:
 			op = LabelSelectorOpNotIn
 		case selection.Exists:
 			op = LabelSelectorOpExists

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/helpers_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/helpers_test.go
@@ -124,8 +124,8 @@ func TestParseToLabelSelector(t *testing.T) {
 			expectErr: false,
 		},
 		{
-			in: "app gt 1",
-			out: nil,
+			in:        "app gt 1",
+			out:       nil,
 			expectErr: true,
 		},
 		{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
`Requirement` support `NotEquals`,  but `LabelSelectorRequirement` ignore this operator.
I use `NotIn` instead of it, but I don't know if this is reasonable.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
No

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

No
