### PR TITLE
Api-server: Add parallelism for rbac storageProvider postStartHook

### DIFF
--- a/pkg/registry/rbac/rest/BUILD
+++ b/pkg/registry/rbac/rest/BUILD
@@ -43,6 +43,7 @@ go_library(
         "//staging/src/k8s.io/client-go/kubernetes:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1:go_default_library",
         "//staging/src/k8s.io/client-go/util/retry:go_default_library",
+        "//staging/src/k8s.io/client-go/util/workqueue:go_default_library",
         "//staging/src/k8s.io/component-helpers/auth/rbac/reconciliation:go_default_library",
         "//vendor/k8s.io/klog/v2:go_default_library",
     ],

--- a/pkg/registry/rbac/rest/BUILD
+++ b/pkg/registry/rbac/rest/BUILD
@@ -13,6 +13,7 @@ go_library(
     deps = [
         "//pkg/api/legacyscheme:go_default_library",
         "//pkg/apis/rbac:go_default_library",
+        "//pkg/registry/rbac:go_default_library",
         "//pkg/registry/rbac/clusterrole:go_default_library",
         "//pkg/registry/rbac/clusterrole/policybased:go_default_library",
         "//pkg/registry/rbac/clusterrole/storage:go_default_library",
@@ -67,7 +68,10 @@ go_test(
     srcs = ["storage_rbac_test.go"],
     embed = [":go_default_library"],
     deps = [
+        "//pkg/registry/rbac:go_default_library",
         "//plugin/pkg/auth/authorizer/rbac/bootstrappolicy:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/fake:go_default_library",
+        "//staging/src/k8s.io/client-go/testing:go_default_library",
     ],
 )

--- a/pkg/registry/rbac/rest/storage_rbac.go
+++ b/pkg/registry/rbac/rest/storage_rbac.go
@@ -37,9 +37,10 @@ import (
 	"k8s.io/apiserver/pkg/registry/rest"
 	genericapiserver "k8s.io/apiserver/pkg/server"
 	serverstorage "k8s.io/apiserver/pkg/server/storage"
-	clientset "k8s.io/client-go/kubernetes"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 	rbacv1client "k8s.io/client-go/kubernetes/typed/rbac/v1"
 	"k8s.io/client-go/util/retry"
+	"k8s.io/client-go/util/workqueue"
 	"k8s.io/component-helpers/auth/rbac/reconciliation"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	"k8s.io/kubernetes/pkg/apis/rbac"
@@ -65,7 +66,10 @@ type RESTStorageProvider struct {
 	Authorizer authorizer.Authorizer
 }
 
-var _ genericapiserver.PostStartHookProvider = RESTStorageProvider{}
+var (
+	_           genericapiserver.PostStartHookProvider = RESTStorageProvider{}
+	parallelism                                        = 16
+)
 
 func (p RESTStorageProvider) NewRESTStorage(apiResourceConfigSource serverstorage.APIResourceConfigSource, restOptionsGetter generic.RESTOptionsGetter) (genericapiserver.APIGroupInfo, bool, error) {
 	apiGroupInfo := genericapiserver.NewDefaultAPIGroupInfo(rbac.GroupName, legacyscheme.Scheme, legacyscheme.ParameterCodec, legacyscheme.Codecs)
@@ -171,15 +175,187 @@ func retryOnConflictOrServiceUnavailable(backoff wait.Backoff, fn func() error) 
 
 func (p *PolicyData) EnsureRBACPolicy() genericapiserver.PostStartHookFunc {
 	return func(hookContext genericapiserver.PostStartHookContext) error {
+		ctx := context.Background()
+
 		// initializing roles is really important.  On some e2e runs, we've seen cases where etcd is down when the server
 		// starts, the roles don't initialize, and nothing works.
 		err := wait.Poll(1*time.Second, 30*time.Second, func() (done bool, err error) {
-			client, err := clientset.NewForConfig(hookContext.LoopbackClientConfig)
+			failedReconciliation := false
+
+			coreclientset, err := corev1client.NewForConfig(hookContext.LoopbackClientConfig)
 			if err != nil {
-				utilruntime.HandleError(fmt.Errorf("unable to initialize client set: %v", err))
+				utilruntime.HandleError(fmt.Errorf("unable to initialize client: %v", err))
 				return false, nil
 			}
-			return ensureRBACPolicy(p, client)
+
+			clientset, err := rbacv1client.NewForConfig(hookContext.LoopbackClientConfig)
+			if err != nil {
+				utilruntime.HandleError(fmt.Errorf("unable to initialize client: %v", err))
+				return false, nil
+			}
+			// Make sure etcd is responding before we start reconciling
+			if _, err := clientset.ClusterRoles().List(context.TODO(), metav1.ListOptions{}); err != nil {
+				utilruntime.HandleError(fmt.Errorf("unable to initialize clusterroles: %v", err))
+				return false, nil
+			}
+			if _, err := clientset.ClusterRoleBindings().List(context.TODO(), metav1.ListOptions{}); err != nil {
+				utilruntime.HandleError(fmt.Errorf("unable to initialize clusterrolebindings: %v", err))
+				return false, nil
+			}
+
+			// if the new cluster roles to aggregate do not yet exist, then we need to copy the old roles if they don't exist
+			// in new locations
+			if err := primeAggregatedClusterRoles(p.ClusterRolesToAggregate, clientset); err != nil {
+				utilruntime.HandleError(fmt.Errorf("unable to prime aggregated clusterroles: %v", err))
+				return false, nil
+			}
+
+			if err := primeSplitClusterRoleBindings(p.ClusterRoleBindingsToSplit, clientset); err != nil {
+				utilruntime.HandleError(fmt.Errorf("unable to prime split ClusterRoleBindings: %v", err))
+				return false, nil
+			}
+
+			// ensure bootstrap roles are created or reconciled
+			processClusterRoles := func(i int) {
+				clusterRole := p.ClusterRoles[i]
+				opts := reconciliation.ReconcileRoleOptions{
+					Role:    reconciliation.ClusterRoleRuleOwner{ClusterRole: &clusterRole},
+					Client:  reconciliation.ClusterRoleModifier{Client: clientset.ClusterRoles()},
+					Confirm: true,
+				}
+				// ServiceUnavailble error is returned when the API server is blocked by storage version updates
+				err := retryOnConflictOrServiceUnavailable(retry.DefaultBackoff, func() error {
+					result, err := opts.Run()
+					if err != nil {
+						return err
+					}
+					switch {
+					case result.Protected && result.Operation != reconciliation.ReconcileNone:
+						klog.Warningf("skipped reconcile-protected clusterrole.%s/%s with missing permissions: %v", rbac.GroupName, clusterRole.Name, result.MissingRules)
+					case result.Operation == reconciliation.ReconcileUpdate:
+						klog.V(2).Infof("updated clusterrole.%s/%s with additional permissions: %v", rbac.GroupName, clusterRole.Name, result.MissingRules)
+					case result.Operation == reconciliation.ReconcileCreate:
+						klog.V(2).Infof("created clusterrole.%s/%s", rbac.GroupName, clusterRole.Name)
+					}
+					return nil
+				})
+				if err != nil {
+					// don't fail on failures, try to create as many as you can
+					utilruntime.HandleError(fmt.Errorf("unable to reconcile clusterrole.%s/%s: %v", rbac.GroupName, clusterRole.Name, err))
+					failedReconciliation = true
+				}
+			}
+			workqueue.ParallelizeUntil(ctx, parallelism, len(p.ClusterRoles), processClusterRoles)
+
+			// ensure bootstrap rolebindings are created or reconciled
+			processClusterRoleBindings := func(i int) {
+				clusterRoleBinding := p.ClusterRoleBindings[i]
+				opts := reconciliation.ReconcileRoleBindingOptions{
+					RoleBinding: reconciliation.ClusterRoleBindingAdapter{ClusterRoleBinding: &clusterRoleBinding},
+					Client:      reconciliation.ClusterRoleBindingClientAdapter{Client: clientset.ClusterRoleBindings()},
+					Confirm:     true,
+				}
+				// ServiceUnavailble error is returned when the API server is blocked by storage version updates
+				err := retryOnConflictOrServiceUnavailable(retry.DefaultBackoff, func() error {
+					result, err := opts.Run()
+					if err != nil {
+						return err
+					}
+					switch {
+					case result.Protected && result.Operation != reconciliation.ReconcileNone:
+						klog.Warningf("skipped reconcile-protected clusterrolebinding.%s/%s with missing subjects: %v", rbac.GroupName, clusterRoleBinding.Name, result.MissingSubjects)
+					case result.Operation == reconciliation.ReconcileUpdate:
+						klog.V(2).Infof("updated clusterrolebinding.%s/%s with additional subjects: %v", rbac.GroupName, clusterRoleBinding.Name, result.MissingSubjects)
+					case result.Operation == reconciliation.ReconcileCreate:
+						klog.V(2).Infof("created clusterrolebinding.%s/%s", rbac.GroupName, clusterRoleBinding.Name)
+					case result.Operation == reconciliation.ReconcileRecreate:
+						klog.V(2).Infof("recreated clusterrolebinding.%s/%s", rbac.GroupName, clusterRoleBinding.Name)
+					}
+					return nil
+				})
+				if err != nil {
+					// don't fail on failures, try to create as many as you can
+					utilruntime.HandleError(fmt.Errorf("unable to reconcile clusterrolebinding.%s/%s: %v", rbac.GroupName, clusterRoleBinding.Name, err))
+					failedReconciliation = true
+				}
+			}
+			workqueue.ParallelizeUntil(ctx, parallelism, len(p.ClusterRoleBindings), processClusterRoleBindings)
+
+			// ensure bootstrap namespaced roles are created or reconciled
+			for namespace, roles := range p.Roles {
+				processRoles := func(i int) {
+					role := roles[i]
+					opts := reconciliation.ReconcileRoleOptions{
+						Role:    reconciliation.RoleRuleOwner{Role: &role},
+						Client:  reconciliation.RoleModifier{Client: clientset, NamespaceClient: coreclientset.Namespaces()},
+						Confirm: true,
+					}
+					// ServiceUnavailble error is returned when the API server is blocked by storage version updates
+					err := retryOnConflictOrServiceUnavailable(retry.DefaultBackoff, func() error {
+						result, err := opts.Run()
+						if err != nil {
+							return err
+						}
+						switch {
+						case result.Protected && result.Operation != reconciliation.ReconcileNone:
+							klog.Warningf("skipped reconcile-protected role.%s/%s in %v with missing permissions: %v", rbac.GroupName, role.Name, namespace, result.MissingRules)
+						case result.Operation == reconciliation.ReconcileUpdate:
+							klog.V(2).Infof("updated role.%s/%s in %v with additional permissions: %v", rbac.GroupName, role.Name, namespace, result.MissingRules)
+						case result.Operation == reconciliation.ReconcileCreate:
+							klog.V(2).Infof("created role.%s/%s in %v", rbac.GroupName, role.Name, namespace)
+						}
+						return nil
+					})
+					if err != nil {
+						// don't fail on failures, try to create as many as you can
+						utilruntime.HandleError(fmt.Errorf("unable to reconcile role.%s/%s in %v: %v", rbac.GroupName, role.Name, namespace, err))
+						failedReconciliation = true
+					}
+				}
+				workqueue.ParallelizeUntil(ctx, parallelism, len(roles), processRoles)
+			}
+
+			// ensure bootstrap namespaced rolebindings are created or reconciled
+			for namespace, roleBindings := range p.RoleBindings {
+				processRoleBindings := func(i int) {
+					roleBinding := roleBindings[i]
+					opts := reconciliation.ReconcileRoleBindingOptions{
+						RoleBinding: reconciliation.RoleBindingAdapter{RoleBinding: &roleBinding},
+						Client:      reconciliation.RoleBindingClientAdapter{Client: clientset, NamespaceClient: coreclientset.Namespaces()},
+						Confirm:     true,
+					}
+					// ServiceUnavailble error is returned when the API server is blocked by storage version updates
+					err := retryOnConflictOrServiceUnavailable(retry.DefaultBackoff, func() error {
+						result, err := opts.Run()
+						if err != nil {
+							return err
+						}
+						switch {
+						case result.Protected && result.Operation != reconciliation.ReconcileNone:
+							klog.Warningf("skipped reconcile-protected rolebinding.%s/%s in %v with missing subjects: %v", rbac.GroupName, roleBinding.Name, namespace, result.MissingSubjects)
+						case result.Operation == reconciliation.ReconcileUpdate:
+							klog.V(2).Infof("updated rolebinding.%s/%s in %v with additional subjects: %v", rbac.GroupName, roleBinding.Name, namespace, result.MissingSubjects)
+						case result.Operation == reconciliation.ReconcileCreate:
+							klog.V(2).Infof("created rolebinding.%s/%s in %v", rbac.GroupName, roleBinding.Name, namespace)
+						case result.Operation == reconciliation.ReconcileRecreate:
+							klog.V(2).Infof("recreated rolebinding.%s/%s in %v", rbac.GroupName, roleBinding.Name, namespace)
+						}
+						return nil
+					})
+					if err != nil {
+						// don't fail on failures, try to create as many as you can
+						utilruntime.HandleError(fmt.Errorf("unable to reconcile rolebinding.%s/%s in %v: %v", rbac.GroupName, roleBinding.Name, namespace, err))
+						failedReconciliation = true
+					}
+				}
+				workqueue.ParallelizeUntil(ctx, parallelism, len(roleBindings), processRoleBindings)
+			}
+			// failed to reconcile some objects, retry
+			if failedReconciliation {
+				return false, nil
+			}
+
+			return true, nil
 		})
 		// if we're never able to make it through initialization, kill the API server
 		if err != nil {
@@ -188,165 +364,6 @@ func (p *PolicyData) EnsureRBACPolicy() genericapiserver.PostStartHookFunc {
 
 		return nil
 	}
-}
-
-func ensureRBACPolicy(p *PolicyData, client clientset.Interface) (done bool, err error) {
-	failedReconciliation := false
-	// Make sure etcd is responding before we start reconciling
-	if _, err := client.RbacV1().ClusterRoles().List(context.TODO(), metav1.ListOptions{}); err != nil {
-		utilruntime.HandleError(fmt.Errorf("unable to initialize clusterroles: %v", err))
-		return false, nil
-	}
-	if _, err := client.RbacV1().ClusterRoleBindings().List(context.TODO(), metav1.ListOptions{}); err != nil {
-		utilruntime.HandleError(fmt.Errorf("unable to initialize clusterrolebindings: %v", err))
-		return false, nil
-	}
-
-	// if the new cluster roles to aggregate do not yet exist, then we need to copy the old roles if they don't exist
-	// in new locations
-	if err := primeAggregatedClusterRoles(p.ClusterRolesToAggregate, client.RbacV1()); err != nil {
-		utilruntime.HandleError(fmt.Errorf("unable to prime aggregated clusterroles: %v", err))
-		return false, nil
-	}
-
-	if err := primeSplitClusterRoleBindings(p.ClusterRoleBindingsToSplit, client.RbacV1()); err != nil {
-		utilruntime.HandleError(fmt.Errorf("unable to prime split ClusterRoleBindings: %v", err))
-		return false, nil
-	}
-
-	// ensure bootstrap roles are created or reconciled
-	for _, clusterRole := range p.ClusterRoles {
-		opts := reconciliation.ReconcileRoleOptions{
-			Role:    reconciliation.ClusterRoleRuleOwner{ClusterRole: &clusterRole},
-			Client:  reconciliation.ClusterRoleModifier{Client: client.RbacV1().ClusterRoles()},
-			Confirm: true,
-		}
-		// ServiceUnavailble error is returned when the API server is blocked by storage version updates
-		err := retryOnConflictOrServiceUnavailable(retry.DefaultBackoff, func() error {
-			result, err := opts.Run()
-			if err != nil {
-				return err
-			}
-			switch {
-			case result.Protected && result.Operation != reconciliation.ReconcileNone:
-				klog.Warningf("skipped reconcile-protected clusterrole.%s/%s with missing permissions: %v", rbac.GroupName, clusterRole.Name, result.MissingRules)
-			case result.Operation == reconciliation.ReconcileUpdate:
-				klog.V(2).Infof("updated clusterrole.%s/%s with additional permissions: %v", rbac.GroupName, clusterRole.Name, result.MissingRules)
-			case result.Operation == reconciliation.ReconcileCreate:
-				klog.V(2).Infof("created clusterrole.%s/%s", rbac.GroupName, clusterRole.Name)
-			}
-			return nil
-		})
-		if err != nil {
-			// don't fail on failures, try to create as many as you can
-			utilruntime.HandleError(fmt.Errorf("unable to reconcile clusterrole.%s/%s: %v", rbac.GroupName, clusterRole.Name, err))
-			failedReconciliation = true
-		}
-	}
-
-	// ensure bootstrap rolebindings are created or reconciled
-	for _, clusterRoleBinding := range p.ClusterRoleBindings {
-		opts := reconciliation.ReconcileRoleBindingOptions{
-			RoleBinding: reconciliation.ClusterRoleBindingAdapter{ClusterRoleBinding: &clusterRoleBinding},
-			Client:      reconciliation.ClusterRoleBindingClientAdapter{Client: client.RbacV1().ClusterRoleBindings()},
-			Confirm:     true,
-		}
-		// ServiceUnavailble error is returned when the API server is blocked by storage version updates
-		err := retryOnConflictOrServiceUnavailable(retry.DefaultBackoff, func() error {
-			result, err := opts.Run()
-			if err != nil {
-				return err
-			}
-			switch {
-			case result.Protected && result.Operation != reconciliation.ReconcileNone:
-				klog.Warningf("skipped reconcile-protected clusterrolebinding.%s/%s with missing subjects: %v", rbac.GroupName, clusterRoleBinding.Name, result.MissingSubjects)
-			case result.Operation == reconciliation.ReconcileUpdate:
-				klog.V(2).Infof("updated clusterrolebinding.%s/%s with additional subjects: %v", rbac.GroupName, clusterRoleBinding.Name, result.MissingSubjects)
-			case result.Operation == reconciliation.ReconcileCreate:
-				klog.V(2).Infof("created clusterrolebinding.%s/%s", rbac.GroupName, clusterRoleBinding.Name)
-			case result.Operation == reconciliation.ReconcileRecreate:
-				klog.V(2).Infof("recreated clusterrolebinding.%s/%s", rbac.GroupName, clusterRoleBinding.Name)
-			}
-			return nil
-		})
-		if err != nil {
-			// don't fail on failures, try to create as many as you can
-			utilruntime.HandleError(fmt.Errorf("unable to reconcile clusterrolebinding.%s/%s: %v", rbac.GroupName, clusterRoleBinding.Name, err))
-			failedReconciliation = true
-		}
-	}
-
-	// ensure bootstrap namespaced roles are created or reconciled
-	for namespace, roles := range p.Roles {
-		for _, role := range roles {
-			opts := reconciliation.ReconcileRoleOptions{
-				Role:    reconciliation.RoleRuleOwner{Role: &role},
-				Client:  reconciliation.RoleModifier{Client: client.RbacV1(), NamespaceClient: client.CoreV1().Namespaces()},
-				Confirm: true,
-			}
-			// ServiceUnavailble error is returned when the API server is blocked by storage version updates
-			err := retryOnConflictOrServiceUnavailable(retry.DefaultBackoff, func() error {
-				result, err := opts.Run()
-				if err != nil {
-					return err
-				}
-				switch {
-				case result.Protected && result.Operation != reconciliation.ReconcileNone:
-					klog.Warningf("skipped reconcile-protected role.%s/%s in %v with missing permissions: %v", rbac.GroupName, role.Name, namespace, result.MissingRules)
-				case result.Operation == reconciliation.ReconcileUpdate:
-					klog.V(2).Infof("updated role.%s/%s in %v with additional permissions: %v", rbac.GroupName, role.Name, namespace, result.MissingRules)
-				case result.Operation == reconciliation.ReconcileCreate:
-					klog.V(2).Infof("created role.%s/%s in %v", rbac.GroupName, role.Name, namespace)
-				}
-				return nil
-			})
-			if err != nil {
-				// don't fail on failures, try to create as many as you can
-				utilruntime.HandleError(fmt.Errorf("unable to reconcile role.%s/%s in %v: %v", rbac.GroupName, role.Name, namespace, err))
-				failedReconciliation = true
-			}
-		}
-	}
-
-	// ensure bootstrap namespaced rolebindings are created or reconciled
-	for namespace, roleBindings := range p.RoleBindings {
-		for _, roleBinding := range roleBindings {
-			opts := reconciliation.ReconcileRoleBindingOptions{
-				RoleBinding: reconciliation.RoleBindingAdapter{RoleBinding: &roleBinding},
-				Client:      reconciliation.RoleBindingClientAdapter{Client: client.RbacV1(), NamespaceClient: client.CoreV1().Namespaces()},
-				Confirm:     true,
-			}
-			// ServiceUnavailble error is returned when the API server is blocked by storage version updates
-			err := retryOnConflictOrServiceUnavailable(retry.DefaultBackoff, func() error {
-				result, err := opts.Run()
-				if err != nil {
-					return err
-				}
-				switch {
-				case result.Protected && result.Operation != reconciliation.ReconcileNone:
-					klog.Warningf("skipped reconcile-protected rolebinding.%s/%s in %v with missing subjects: %v", rbac.GroupName, roleBinding.Name, namespace, result.MissingSubjects)
-				case result.Operation == reconciliation.ReconcileUpdate:
-					klog.V(2).Infof("updated rolebinding.%s/%s in %v with additional subjects: %v", rbac.GroupName, roleBinding.Name, namespace, result.MissingSubjects)
-				case result.Operation == reconciliation.ReconcileCreate:
-					klog.V(2).Infof("created rolebinding.%s/%s in %v", rbac.GroupName, roleBinding.Name, namespace)
-				case result.Operation == reconciliation.ReconcileRecreate:
-					klog.V(2).Infof("recreated rolebinding.%s/%s in %v", rbac.GroupName, roleBinding.Name, namespace)
-				}
-				return nil
-			})
-			if err != nil {
-				// don't fail on failures, try to create as many as you can
-				utilruntime.HandleError(fmt.Errorf("unable to reconcile rolebinding.%s/%s in %v: %v", rbac.GroupName, roleBinding.Name, namespace, err))
-				failedReconciliation = true
-			}
-		}
-	}
-	// failed to reconcile some objects, retry
-	if failedReconciliation {
-		return false, nil
-	}
-
-	return true, nil
 }
 
 func (p RESTStorageProvider) GroupName() string {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:

Parallelize start-post-hook of rbac RestStorageProvider. This can decrease api-server starting time. Part of #97119.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fix #97119

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
none
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
none
```
