### PR TITLE
Improve update time of readiness state

### DIFF
--- a/pkg/kubelet/prober/BUILD
+++ b/pkg/kubelet/prober/BUILD
@@ -27,6 +27,7 @@ go_library(
         "//pkg/probe/tcp:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/clock:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/intstr:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",

--- a/test/e2e/common/container_probe.go
+++ b/test/e2e/common/container_probe.go
@@ -374,7 +374,8 @@ var _ = framework.KubeDescribe("Probing container", func() {
 		Description: A Pod is created with startup and readiness probes. The Container is started by creating /tmp/startup after 45 seconds, delaying the ready state by this amount of time. This is similar to the "Pod readiness probe, with initial delay" test.
 	*/
 	ginkgo.It("should not be ready until startupProbe succeeds", func() {
-		cmd := []string{"/bin/sh", "-c", "echo ok >/tmp/health; sleep 45; echo ok >/tmp/startup; sleep 600"}
+		sleepBeforeStarted := time.Duration(15)
+		cmd := []string{"/bin/sh", "-c", fmt.Sprintf("echo ok >/tmp/health; sleep %d; echo ok >/tmp/startup; sleep 600", sleepBeforeStarted)}
 		readinessProbe := &v1.Probe{
 			Handler: v1.Handler{
 				Exec: &v1.ExecAction{
@@ -382,6 +383,7 @@ var _ = framework.KubeDescribe("Probing container", func() {
 				},
 			},
 			InitialDelaySeconds: 0,
+			PeriodSeconds:       60,
 		}
 		startupProbe := &v1.Probe{
 			Handler: v1.Handler{
@@ -390,7 +392,8 @@ var _ = framework.KubeDescribe("Probing container", func() {
 				},
 			},
 			InitialDelaySeconds: 0,
-			FailureThreshold:    60,
+			PeriodSeconds:       1,
+			FailureThreshold:    600,
 		}
 		p := podClient.Create(startupPodSpec(startupProbe, readinessProbe, nil, cmd))
 
@@ -413,9 +416,13 @@ var _ = framework.KubeDescribe("Probing container", func() {
 		startedTime, err := GetContainerStartedTime(p, "busybox")
 		framework.ExpectNoError(err)
 
+		startedIn := readyTime.Sub(startedTime)
 		framework.Logf("Container started at %v, pod became ready at %v", startedTime, readyTime)
-		if readyTime.Sub(startedTime) < 40*time.Second {
+		if startedIn < sleepBeforeStarted*time.Second {
 			framework.Failf("Pod became ready before startupProbe succeeded")
+		}
+		if startedIn > (sleepBeforeStarted+5)*time.Second {
+			framework.Failf("Pod became ready in %v, more than 5s after startupProbe succeeded", startedIn)
 		}
 	})
 })


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
Ensure a fast detection of a ready state, without paying the cost of an aggressive probing pace on the readinessProbe.
This is one of the design goals of the startupProbe, i.e. allowing to change the probing strategy before/after a container startup.
Due to some mitigation of cpu strain during a kubelet start, and a ticker that starts with the proberManager, one could have to wait more than the readinessProbe's periodSeconds period for the pod to receive traffic.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #96731

**Special notes for your reviewer**:

There are 2 strategies here to improve the detection of a ready state:
1. skip the jitter sleep unless the kubelet has recently started
1. trigger a readinessProbe run immediately after the container has started

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
