### PR TITLE
Update Error logging for Pod+PodStatus resource lifecycle test 

### DIFF
--- a/test/e2e/common/pods.go
+++ b/test/e2e/common/pods.go
@@ -939,8 +939,10 @@ var _ = framework.KubeDescribe("Pods", func() {
 					pod.Labels["test-pod-static"] == "true" &&
 					pod.Status.Phase == v1.PodRunning
 				if !found {
-					framework.Logf("observed Pod %v in namespace %v in phase %v conditions %v", pod.ObjectMeta.Name, pod.ObjectMeta.Namespace, pod.Status.Phase, pod.Status.Conditions)
+					framework.Logf("observed Pod %v in namespace %v in phase %v with labels: %v & conditions %v", pod.ObjectMeta.Name, pod.ObjectMeta.Namespace, pod.Status.Phase, pod.Labels, pod.Status.Conditions)
+					return false, nil
 				}
+				framework.Logf("Found Pod %v in namespace %v in phase %v with labels: %v & conditions %v", pod.ObjectMeta.Name, pod.ObjectMeta.Namespace, pod.Status.Phase, pod.Labels, pod.Status.Conditions)
 				return found, nil
 			}
 			return false, nil

--- a/test/e2e/common/pods.go
+++ b/test/e2e/common/pods.go
@@ -945,6 +945,7 @@ var _ = framework.KubeDescribe("Pods", func() {
 				framework.Logf("Found Pod %v in namespace %v in phase %v with labels: %v & conditions %v", pod.ObjectMeta.Name, pod.ObjectMeta.Namespace, pod.Status.Phase, pod.Labels, pod.Status.Conditions)
 				return found, nil
 			}
+			framework.Logf("Observed event: %+v", event.Object)
 			return false, nil
 		})
 		framework.ExpectNoError(err, "failed to see Pod %v in namespace %v running", testPod.ObjectMeta.Name, testNamespaceName)


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it:**
This is PR is in response to  the comments in [#96485](https://github.com/kubernetes/kubernetes/pull/96485#issuecomment-732335344) 
- was the watch event not for a Pod? - addressed in Line 498
- was the Pod missing the test-pod-static: true label? addressed in Line 942
- was the Pod's Phase not PodRunning? - addressed in Line 942 

**Which issue(s) this PR fixes:**
Fixes #96819

**Special notes for your reviewer:**
This PR will clarify logging of errors

**Does this PR introduce a user-facing change?:**
```
NONE

```

**Release note:**
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:**
```
NONE

```

/sig testing
/sig architecture

