### PR TITLE
small refactor: admission update pod check in AlwaysPullImage

### DIFF
--- a/plugin/pkg/admission/alwayspullimages/admission.go
+++ b/plugin/pkg/admission/alwayspullimages/admission.go
@@ -121,6 +121,10 @@ func isUpdateWithNoNewImages(attributes admission.Attributes) bool {
 		return false
 	}
 
+	return hasNewImages(pod, oldPod)
+}
+
+func hasNewImages(pod *api.Pod, oldPod *api.Pod) bool {
 	oldImages := sets.NewString()
 	pods.VisitContainersWithPath(&oldPod.Spec, field.NewPath("spec"), func(c *api.Container, _ *field.Path) bool {
 		oldImages.Insert(c.Image)


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
According to https://github.com/kubernetes/kubernetes/pull/96668#issuecomment-741489355
- [x] refactor isUpdateWithNoNewImages as  utility function (Done in this pr)

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs
NONE
```
