### PR TITLE
Allow ServicePorts with same name, different protocol

### DIFF
--- a/pkg/apis/core/validation/validation_test.go
+++ b/pkg/apis/core/validation/validation_test.go
@@ -10402,6 +10402,24 @@ func TestValidateServiceCreate(t *testing.T) {
 			numErrs: 0,
 		},
 		{
+			name: "duplicate service name (same protocol)",
+			tweakSvc: func(s *core.Service) {
+				s.Spec.Type = core.ServiceTypeClusterIP
+				s.Spec.Ports = append(s.Spec.Ports, core.ServicePort{Name: "q", Port: 88, Protocol: "TCP", TargetPort: intstr.FromInt(88)})
+				s.Spec.Ports = append(s.Spec.Ports, core.ServicePort{Name: "q", Port: 8888, Protocol: "TCP", TargetPort: intstr.FromInt(8888)})
+			},
+			numErrs: 1,
+		},
+		{
+			name: "duplicate service name (different protocols)",
+			tweakSvc: func(s *core.Service) {
+				s.Spec.Type = core.ServiceTypeClusterIP
+				s.Spec.Ports = append(s.Spec.Ports, core.ServicePort{Name: "q", Port: 88, Protocol: "TCP", TargetPort: intstr.FromInt(88)})
+				s.Spec.Ports = append(s.Spec.Ports, core.ServicePort{Name: "q", Port: 88, Protocol: "UDP", TargetPort: intstr.FromInt(88)})
+			},
+			numErrs: 0,
+		},
+		{
 			name: "valid type - cluster",
 			tweakSvc: func(s *core.Service) {
 				s.Spec.Type = core.ServiceTypeClusterIP


### PR DESCRIPTION
*Hello!  This is my first kubernetes PR.  I have no idea what tests
I need to add yet, or whether a KEP is required for this change.  I
also haven't tested this change to see if other components also need
modification to adapt to this change.  Is is presented as a POC and
initial starting point to address #97149*.

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Creating a service with two ports that have the same name, but
different protocol, fails:

    $ cat service-test.yaml
    apiVersion: v1
    kind: Service
    metadata:
      name: service-test
      labels:
        app: service-test
    spec:
      selector:
        app: service-test
      clusterIP: None
      ports:
      - name: ldap
        protocol: TCP
        port: 389
      - name: kerberos
        protocol: TCP
        port: 88
      - name: kerberos
        protocol: UDP
        port: 88

    $ oc replace -f service-test.yaml
    The Service "service-test" is invalid:
    spec.ports[2].name: Duplicate value: "kerberos"

Some services operate over both TCP and UDP (e.g. DNS).
Furthermore, some of these also require DNS SRV records for both
\_tcp and \_udp with the same service name (e.g. Kerberos).  The
current ServicePort validation behaviour - `name` must be unique -
does not admit this use case.

Relax the uniqueness check, ensuring that name/protocol *pairs* are
unique.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**Which issue(s) this PR fixes**:

Fixes https://github.com/kubernetes/kubernetes/issues/97149

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
Service ports now allow duplicate `name` values, as long as the
combination of `name` and `protocol` is unique.  This supports the
creation of correct DNS SRV records for applications that work over
both TCP and UDP.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```