### PR TITLE
cleanup: remove dup key VolumeStatsUsedBytesKey in test

### DIFF
--- a/test/e2e/storage/volume_metrics.go
+++ b/test/e2e/storage/volume_metrics.go
@@ -223,7 +223,7 @@ var _ = utils.SIGDescribe("[Serial] Volume metrics", func() {
 			kubeletmetrics.VolumeStatsUsedBytesKey,
 			kubeletmetrics.VolumeStatsCapacityBytesKey,
 			kubeletmetrics.VolumeStatsAvailableBytesKey,
-			kubeletmetrics.VolumeStatsUsedBytesKey,
+			kubeletmetrics.VolumeStatsInodesKey,
 			kubeletmetrics.VolumeStatsInodesFreeKey,
 			kubeletmetrics.VolumeStatsInodesUsedKey,
 		}


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup


**What this PR does / why we need it**:

- [x] During investigating  #97138, I find the test case here has a dup key.

You can ignore below comments:
- [x] try to know why volume_stats metrics are missing sometimes, even it is alpha feature. Per  https://github.com/kubernetes/kubernetes/issues/97138#issuecomment-743134435 
> It seems to be working as expected. 

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
only a small clean up during investigating #97138
https://github.com/kubernetes/kubernetes/blob/c82626f96f754e0eb87eaa1380bb672be42e6f0d/test/e2e/storage/volume_metrics.go#L223-L228

L223 is the same as L226

**Does this PR introduce a user-facing change?**:

```release-note
None
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs
None
```
