### PR TITLE
Transfer ownership of logging analysis configuration to sig-security.

### DIFF
--- a/hack/testdata/levee/OWNERS
+++ b/hack/testdata/levee/OWNERS
@@ -1,6 +1,7 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-- spiffxp
+- sig-security
+
 reviewers:
-- spiffxp
+- sig-security

--- a/hack/testdata/levee/OWNERS
+++ b/hack/testdata/levee/OWNERS
@@ -1,7 +1,8 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-- sig-security
-
+- sig-security-approvers
 reviewers:
-- sig-security
+- sig-security-reviewers
+labels:
+- sig/security


### PR DESCRIPTION
/kind cleanup
/sig security

/assign spiffxp

**What this PR does / why we need it**:

When log analysis was introduced by KEP-1933 to its alpha stage, the newly formed sig-security did not yet have an `OWNERS_ALIASES` entry.  @spiffxp graciously accepted interim ownership in #94661.  Now that the alias exists, sig-security should own this configuration.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/issues/1933
```
