### PR TITLE
Add context to metric interface in component-base/mertic

### DIFF
--- a/staging/src/k8s.io/component-base/metrics/counter.go
+++ b/staging/src/k8s.io/component-base/metrics/counter.go
@@ -17,6 +17,7 @@ limitations under the License.
 package metrics
 
 import (
+	"context"
 	"github.com/blang/semver"
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -77,6 +78,11 @@ func (c *Counter) initializeMetric() {
 func (c *Counter) initializeDeprecatedMetric() {
 	c.CounterOpts.markDeprecated()
 	c.initializeMetric()
+}
+
+// WithContext allows the normal Counter metric to pass in context. The context is no-op now.
+func (c *Counter) WithContext(ctx context.Context) CounterMetric {
+	return c.CounterMetric
 }
 
 // CounterVec is the internal representation of our wrapping struct around prometheus
@@ -175,4 +181,28 @@ func (v *CounterVec) Reset() {
 	}
 
 	v.CounterVec.Reset()
+}
+
+// WithContext returns wrapped CounterVec with context
+func (v *CounterVec) WithContext(ctx context.Context) *CounterVecWithContext {
+	return &CounterVecWithContext{
+		ctx:        ctx,
+		CounterVec: *v,
+	}
+}
+
+// CounterVecWithContext is the wrapper of CounterVec with context.
+type CounterVecWithContext struct {
+	CounterVec
+	ctx context.Context
+}
+
+// WithLabelValues is the wrapper of CounterVec.WithLabelValues.
+func (vc *CounterVecWithContext) WithLabelValues(lvs ...string) CounterMetric {
+	return vc.CounterVec.WithLabelValues(lvs...)
+}
+
+// With is the wrapper of CounterVec.With.
+func (vc *CounterVecWithContext) With(labels map[string]string) CounterMetric {
+	return vc.CounterVec.With(labels)
 }

--- a/staging/src/k8s.io/component-base/metrics/summary.go
+++ b/staging/src/k8s.io/component-base/metrics/summary.go
@@ -17,6 +17,7 @@ limitations under the License.
 package metrics
 
 import (
+	"context"
 	"github.com/blang/semver"
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -72,6 +73,11 @@ func (s *Summary) initializeMetric() {
 func (s *Summary) initializeDeprecatedMetric() {
 	s.SummaryOpts.markDeprecated()
 	s.initializeMetric()
+}
+
+// WithContext allows the normal Summary metric to pass in context. The context is no-op now.
+func (s *Summary) WithContext(ctx context.Context) ObserverMetric {
+	return s.ObserverMetric
 }
 
 // SummaryVec is the internal representation of our wrapping struct around prometheus
@@ -168,4 +174,28 @@ func (v *SummaryVec) Reset() {
 	}
 
 	v.SummaryVec.Reset()
+}
+
+// WithContext returns wrapped SummaryVec with context
+func (v *SummaryVec) WithContext(ctx context.Context) *SummaryVecWithContext {
+	return &SummaryVecWithContext{
+		ctx:        ctx,
+		SummaryVec: *v,
+	}
+}
+
+// SummaryVecWithContext is the wrapper of SummaryVec with context.
+type SummaryVecWithContext struct {
+	SummaryVec
+	ctx context.Context
+}
+
+// WithLabelValues is the wrapper of SummaryVec.WithLabelValues.
+func (vc *SummaryVecWithContext) WithLabelValues(lvs ...string) ObserverMetric {
+	return vc.SummaryVec.WithLabelValues(lvs...)
+}
+
+// With is the wrapper of SummaryVec.With.
+func (vc *SummaryVecWithContext) With(labels map[string]string) ObserverMetric {
+	return vc.SummaryVec.With(labels)
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

 This PR adds interfaces to record normal metric and vector metric with context. It makes thing flexible if we want to pass in value with context. For now, the context is no-op.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
