### PR TITLE
cleanup: legacy 'ENV name value' syntax deprecated(Docker 20.10)

### DIFF
--- a/build/build-image/Dockerfile
+++ b/build/build-image/Dockerfile
@@ -27,14 +27,14 @@ RUN mkdir /var/run/kubernetes && chmod a+rwx /var/run/kubernetes
 
 # The kubernetes source is expected to be mounted here.  This will be the base
 # of operations.
-ENV HOME /go/src/k8s.io/kubernetes
+ENV HOME=/go/src/k8s.io/kubernetes
 WORKDIR ${HOME}
 
 # Make output from the dockerized build go someplace else
-ENV KUBE_OUTPUT_SUBPATH _output/dockerized
+ENV KUBE_OUTPUT_SUBPATH=_output/dockerized
 
 # Pick up version stuff here as we don't copy our .git over.
-ENV KUBE_GIT_VERSION_FILE ${HOME}/.dockerized-kube-version-defs
+ENV KUBE_GIT_VERSION_FILE=${HOME}/.dockerized-kube-version-defs
 
 # Add system-wide git user information
 RUN git config --system user.email "nobody@k8s.io" \

--- a/test/images/node-perf/tf-wide-deep/Dockerfile
+++ b/test/images/node-perf/tf-wide-deep/Dockerfile
@@ -33,6 +33,6 @@ RUN wget https://github.com/tensorflow/models/archive/v1.9.0.tar.gz \
 && rm -f v1.9.0.tar.gz
 
 WORKDIR $HOME/models-1.9.0/official/wide_deep
-ENV PYTHONPATH $PYTHONPATH:$HOME/models-1.9.0
+ENV PYTHONPATH=$PYTHONPATH:$HOME/models-1.9.0
 
 ENTRYPOINT python ./wide_deep.py


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
https://github.com/docker/cli/pull/2743
- deprecate Dockerfile legacy 'ENV name value' syntax #2743


It seems that `ENV name=value` is more standardized than `ENV name value`.

**Which issue(s) this PR fixes**:
https://docs.docker.com/engine/release-notes/#20100
Docker v20.10.0 is released 🎉 .

Another improvement in Dockerfile is `ARG ONE TWO THREE` （lower Version doesn't support it, so we should not use it now.）
For instance, https://github.com/kubernetes/kubernetes/blob/master/test/images/agnhost/Dockerfile_windows#L15-L17
It will make less layers in the image.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```