### PR TITLE
remove suffixes from generated StorageClasses and VolumeSnapshotClass

### DIFF
--- a/test/e2e/storage/drivers/csi.go
+++ b/test/e2e/storage/drivers/csi.go
@@ -154,9 +154,8 @@ func (h *hostpathCSIDriver) GetDynamicProvisionStorageClass(config *storageframe
 	provisioner := config.GetUniqueDriverName()
 	parameters := map[string]string{}
 	ns := config.Framework.Namespace.Name
-	suffix := fmt.Sprintf("%s-sc", provisioner)
 
-	return storageframework.GetStorageClass(provisioner, parameters, nil, ns, suffix)
+	return storageframework.GetStorageClass(provisioner, parameters, nil, ns)
 }
 
 func (h *hostpathCSIDriver) GetVolume(config *storageframework.PerTestConfig, volumeNumber int) (map[string]string, bool, bool) {
@@ -346,9 +345,8 @@ func (m *mockCSIDriver) GetDynamicProvisionStorageClass(config *storageframework
 	provisioner := config.GetUniqueDriverName()
 	parameters := map[string]string{}
 	ns := config.Framework.Namespace.Name
-	suffix := fmt.Sprintf("%s-sc", provisioner)
 
-	return storageframework.GetStorageClass(provisioner, parameters, nil, ns, suffix)
+	return storageframework.GetStorageClass(provisioner, parameters, nil, ns)
 }
 
 func (m *mockCSIDriver) GetSnapshotClass(config *storageframework.PerTestConfig) *unstructured.Unstructured {
@@ -555,7 +553,6 @@ func (g *gcePDCSIDriver) SkipUnsupportedTest(pattern storageframework.TestPatter
 func (g *gcePDCSIDriver) GetDynamicProvisionStorageClass(config *storageframework.PerTestConfig, fsType string) *storagev1.StorageClass {
 	ns := config.Framework.Namespace.Name
 	provisioner := g.driverInfo.Name
-	suffix := fmt.Sprintf("%s-sc", g.driverInfo.Name)
 
 	parameters := map[string]string{"type": "pd-standard"}
 	if fsType != "" {
@@ -563,7 +560,7 @@ func (g *gcePDCSIDriver) GetDynamicProvisionStorageClass(config *storageframewor
 	}
 	delayedBinding := storagev1.VolumeBindingWaitForFirstConsumer
 
-	return storageframework.GetStorageClass(provisioner, parameters, &delayedBinding, ns, suffix)
+	return storageframework.GetStorageClass(provisioner, parameters, &delayedBinding, ns)
 }
 
 func (g *gcePDCSIDriver) GetSnapshotClass(config *storageframework.PerTestConfig) *unstructured.Unstructured {

--- a/test/e2e/storage/drivers/in_tree.go
+++ b/test/e2e/storage/drivers/in_tree.go
@@ -151,9 +151,8 @@ func (n *nfsDriver) GetDynamicProvisionStorageClass(config *storageframework.Per
 	provisioner := n.externalPluginName
 	parameters := map[string]string{"mountOptions": "vers=4.1"}
 	ns := config.Framework.Namespace.Name
-	suffix := fmt.Sprintf("%s-sc", n.driverInfo.Name)
 
-	return storageframework.GetStorageClass(provisioner, parameters, nil, ns, suffix)
+	return storageframework.GetStorageClass(provisioner, parameters, nil, ns)
 }
 
 func (n *nfsDriver) PrepareTest(f *framework.Framework) (*storageframework.PerTestConfig, func()) {
@@ -1132,9 +1131,8 @@ func (c *cinderDriver) GetDynamicProvisionStorageClass(config *storageframework.
 		parameters["fsType"] = fsType
 	}
 	ns := config.Framework.Namespace.Name
-	suffix := fmt.Sprintf("%s-sc", c.driverInfo.Name)
 
-	return storageframework.GetStorageClass(provisioner, parameters, nil, ns, suffix)
+	return storageframework.GetStorageClass(provisioner, parameters, nil, ns)
 }
 
 func (c *cinderDriver) PrepareTest(f *framework.Framework) (*storageframework.PerTestConfig, func()) {
@@ -1343,10 +1341,9 @@ func (g *gcePdDriver) GetDynamicProvisionStorageClass(config *storageframework.P
 		parameters["fsType"] = fsType
 	}
 	ns := config.Framework.Namespace.Name
-	suffix := fmt.Sprintf("%s-sc", g.driverInfo.Name)
 	delayedBinding := storagev1.VolumeBindingWaitForFirstConsumer
 
-	return storageframework.GetStorageClass(provisioner, parameters, &delayedBinding, ns, suffix)
+	return storageframework.GetStorageClass(provisioner, parameters, &delayedBinding, ns)
 }
 
 func (g *gcePdDriver) PrepareTest(f *framework.Framework) (*storageframework.PerTestConfig, func()) {
@@ -1486,9 +1483,8 @@ func (v *vSphereDriver) GetDynamicProvisionStorageClass(config *storageframework
 		parameters["fsType"] = fsType
 	}
 	ns := config.Framework.Namespace.Name
-	suffix := fmt.Sprintf("%s-sc", v.driverInfo.Name)
 
-	return storageframework.GetStorageClass(provisioner, parameters, nil, ns, suffix)
+	return storageframework.GetStorageClass(provisioner, parameters, nil, ns)
 }
 
 func (v *vSphereDriver) PrepareTest(f *framework.Framework) (*storageframework.PerTestConfig, func()) {
@@ -1617,10 +1613,9 @@ func (a *azureDiskDriver) GetDynamicProvisionStorageClass(config *storageframewo
 		parameters["fsType"] = fsType
 	}
 	ns := config.Framework.Namespace.Name
-	suffix := fmt.Sprintf("%s-sc", a.driverInfo.Name)
 	delayedBinding := storagev1.VolumeBindingWaitForFirstConsumer
 
-	return storageframework.GetStorageClass(provisioner, parameters, &delayedBinding, ns, suffix)
+	return storageframework.GetStorageClass(provisioner, parameters, &delayedBinding, ns)
 }
 
 func (a *azureDiskDriver) PrepareTest(f *framework.Framework) (*storageframework.PerTestConfig, func()) {
@@ -1750,10 +1745,9 @@ func (a *awsDriver) GetDynamicProvisionStorageClass(config *storageframework.Per
 		parameters["fsType"] = fsType
 	}
 	ns := config.Framework.Namespace.Name
-	suffix := fmt.Sprintf("%s-sc", a.driverInfo.Name)
 	delayedBinding := storagev1.VolumeBindingWaitForFirstConsumer
 
-	return storageframework.GetStorageClass(provisioner, parameters, &delayedBinding, ns, suffix)
+	return storageframework.GetStorageClass(provisioner, parameters, &delayedBinding, ns)
 }
 
 func (a *awsDriver) PrepareTest(f *framework.Framework) (*storageframework.PerTestConfig, func()) {

--- a/test/e2e/storage/framework/driver_operations.go
+++ b/test/e2e/storage/framework/driver_operations.go
@@ -67,7 +67,6 @@ func GetStorageClass(
 	parameters map[string]string,
 	bindingMode *storagev1.VolumeBindingMode,
 	ns string,
-	suffix string,
 ) *storagev1.StorageClass {
 	if bindingMode == nil {
 		defaultBindingMode := storagev1.VolumeBindingImmediate
@@ -79,8 +78,7 @@ func GetStorageClass(
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			// Name must be unique, so let's base it on namespace name and use GenerateName
-			// TODO(#96234): Remove unnecessary suffix.
-			Name: names.SimpleNameGenerator.GenerateName(ns + "-" + suffix),
+			Name: names.SimpleNameGenerator.GenerateName(ns),
 		},
 		Provisioner:       provisioner,
 		Parameters:        parameters,


### PR DESCRIPTION
What type of PR is this?
/kind cleanup

What this PR does / why we need it:
Remove redundant suffix to improve readability.
Which issue(s) this PR fixes:
Fixes #96234

Special notes for your reviewer:

Does this PR introduce a user-facing change?:
NONE

Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.: