### PR TITLE
[flaky test] fix devicemanager TestDevicePluginReRegistrationProbeMode failed

### DIFF
--- a/pkg/kubelet/cm/devicemanager/manager_test.go
+++ b/pkg/kubelet/cm/devicemanager/manager_test.go
@@ -282,8 +282,8 @@ func setup(t *testing.T, devs []*pluginapi.Device, callback monitorCallback, soc
 
 func setupInProbeMode(t *testing.T, devs []*pluginapi.Device, callback monitorCallback, socketName string, pluginSocketName string) (Manager, <-chan interface{}, *Stub, pluginmanager.PluginManager) {
 	m, updateChan := setupDeviceManager(t, devs, callback, socketName)
-	pm := setupPluginManager(t, pluginSocketName, m)
 	p := setupDevicePlugin(t, devs, pluginSocketName)
+	pm := setupPluginManager(t, pluginSocketName, m)
 	return m, updateChan, p, pm
 }
 

--- a/pkg/kubelet/pluginmanager/reconciler/reconciler.go
+++ b/pkg/kubelet/pluginmanager/reconciler/reconciler.go
@@ -100,7 +100,11 @@ func (rc *reconciler) getHandlers() map[string]cache.PluginHandler {
 	rc.RLock()
 	defer rc.RUnlock()
 
-	return rc.handlers
+	var copyHandlers = make(map[string]cache.PluginHandler)
+	for pluginType, handler := range rc.handlers {
+		copyHandlers[pluginType] = handler
+	}
+	return copyHandlers
 }
 
 func (rc *reconciler) reconcile() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug
/kind flake
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:

- How to reproduce it ?

```
go test -race -c ./pkg/kubelet/cm/devicemanager
stress ./devicemanager.test -test.run TestDevicePluginReRegistrationProbeMode   
```

- two modify place:
1.  start device plugin "device-plugin.sock" before starting pluginmanager

The origin problem is that the test start `pluginmanager` before starting device plugin "device-plugin.sock".
after pluginmanager start,  fswatcher in pluginmanager will listen `socketDir` 

https://github.com/fsnotify/fsnotify/blob/7f4cf4dd2b522a984eaca51d1ccee54101d3414a/inotify.go#L59

And also it will register the socket dir plugin later 

https://github.com/kubernetes/kubernetes/blob/fb02a59a6a10623b971107231b3c823fed6c43a8/pkg/kubelet/pluginmanager/pluginwatcher/plugin_watcher.go#L67

I add log to watch register event as fellow:
```
@@ -74,6 +87,7 @@ func (w *Watcher) Start(stopCh <-chan struct{}) error {
                        case event := <-fsWatcher.Events:
                                //TODO: Handle errors by taking corrective measures
                                if event.Op&fsnotify.Create == fsnotify.Create {
+                                       klog.Errorf("<-- go func(fsWatcher *fsnotify.Watcher)")
                                        err := w.handleCreateEvent(event)
                                        if err != nil {
                                                klog.Errorf("error %v when handling create event: %s", err, event)
@@ -142,6 +162,7 @@ func (w *Watcher) traversePluginDir(dir string) error {
                                Op:   fsnotify.Create,
                        }
                        //TODO: Handle errors by taking corrective measures
+                       klog.Errorf("<-- traversePluginDir -> handleCreateEvent")
                        if err := w.handleCreateEvent(event); err != nil {
                                klog.Errorf("error %v when handling create event: %s", err, event)
                        }

 func (w *Watcher) handleCreateEvent(event fsnotify.Event) error {
-       klog.V(6).Infof("Handling create event: %v", event)
+       klog.Errorf("Handling create event: %v", event)
 
        fi, err := os.Stat(event.Name)
        if err != nil {

@@ -194,7 +215,7 @@ func (w *Watcher) handlePluginRegistration(socketPath string) error {
        // a possibility that it has been deleted and recreated again before it is
        // removed from the desired world cache, so we still need to call AddOrUpdatePlugin
        // in this case to update the timestamp
-       klog.V(2).Infof("Adding socket path or updating timestamp %s to desired state cache", socketPath)
+       klog.Errorf("Adding socket path or updating timestamp %s to desired state cache", socketPath)
        err := w.desiredStateOfWorld.AddOrUpdatePlugin(socketPath)
        if err != nil {
                return fmt.Errorf("error adding socket path %s or updating timestamp to desired state cache: %v", socketPath, err)
```

if test success, the log will as fellow.
```
=== RUN   TestDevicePluginReRegistrationProbeMode
I1210 09:24:31.872465 1130377 fake_topology_manager.go:30] [fake topologymanager] NewFakeManager
W1210 09:24:31.872586 1130377 manager.go:602] Failed to retrieve checkpoint for "kubelet_internal_checkpoint": checkpoint is not found
I1210 09:24:31.873085 1130377 device_plugin_stub.go:142] Starting to serve on /tmp/device_plugin498043817/device-plugin.sock
E1210 09:24:31.873220 1130377 plugin_watcher.go:152] <--  traversePluginDir -> handleCreateEvent
E1210 09:24:31.873224 1130377 plugin_watcher.go:168] Handling create event: "/tmp/device_plugin498043817/device-plugin.sock": CREATE
E1210 09:24:31.873261 1130377 plugin_watcher.go:205] Adding socket path or updating timestamp /tmp/device_plugin498043817/device-plugin.sock to desired state cache
E1210 09:24:31.873271 1130377 plugin_watcher.go:152] <--  traversePluginDir -> handleCreateEvent
E1210 09:24:31.873273 1130377 plugin_watcher.go:168] Handling create event: "/tmp/device_plugin498043817/server.sock": CREATE
E1210 09:24:31.873279 1130377 plugin_watcher.go:205] Adding socket path or updating timestamp /tmp/device_plugin498043817/server.sock to desired state cache
I1210 09:24:31.873287 1130377 plugin_manager.go:114] Starting Kubelet Plugin Manager
I1210 09:24:31.874110 1130377 device_plugin_stub.go:164] GetInfo
E1210 09:24:31.874247 1130377 manager.go:315] sch: Registering Plugin fake-domain/resource at endpoint /tmp/device_plugin498043817/device-plugin.sock
E1210 09:24:31.874251 1130377 goroutinemap.go:150] Operation for "/tmp/device_plugin498043817/server.sock" failed. No retries permitted until 2020-12-10 09:24:32.374223872 +0800 CST m=+0.517294492 (durationBeforeRetry 500ms). Error: "RegisterPlugin error -- failed to get plugin info using RPC GetInfo at socket /tmp/device_plugin498043817/server.sock, err: rpc error: code = Unimplemented desc = unknown service pluginregistration.Registration"
```
we can see the one register from socket `device-plugin.sock` 

if the test failed, the output as fellow
```
=== RUN   TestDevicePluginReRegistrationProbeMode
I1210 15:18:45.864453 1148592 fake_topology_manager.go:30] [fake topologymanager] NewFakeManager
W1210 15:18:45.864700 1148592 manager.go:602] Failed to retrieve checkpoint for "kubelet_internal_checkpoint": checkpoint is not found
E1210 15:18:45.866062 1148592 plugin_watcher.go:165] <--  traversePluginDir -> handleCreateEvent
E1210 15:18:45.867240 1148592 plugin_watcher.go:181] Handling create event: "/tmp/device_plugin658673309/device-plugin.sock": CREATE
E1210 15:18:45.867331 1148592 plugin_watcher.go:218] Adding socket path or updating timestamp /tmp/device_plugin658673309/device-plugin.sock to desired state cache
E1210 15:18:45.867380 1148592 plugin_watcher.go:165] <--  traversePluginDir -> handleCreateEvent
E1210 15:18:45.867400 1148592 plugin_watcher.go:181] Handling create event: "/tmp/device_plugin658673309/server.sock": CREATE
E1210 15:18:45.867481 1148592 plugin_watcher.go:218] Adding socket path or updating timestamp /tmp/device_plugin658673309/server.sock to desired state cache
I1210 15:18:45.867684 1148592 plugin_manager.go:114] Starting Kubelet Plugin Manager
E1210 15:18:45.867742 1148592 plugin_watcher.go:90] <--  go func(fsWatcher *fsnotify.Watcher)
E1210 15:18:45.867796 1148592 plugin_watcher.go:181] Handling create event: "/tmp/device_plugin658673309/device-plugin.sock": CREATE
E1210 15:18:45.868013 1148592 plugin_watcher.go:218] Adding socket path or updating timestamp /tmp/device_plugin658673309/device-plugin.sock to desired state cache
I1210 15:18:45.869102 1148592 device_plugin_stub.go:148] Starting to serve on /tmp/device_plugin658673309/device-plugin.sock
I1210 15:18:45.874331 1148592 device_plugin_stub.go:170] GetInfo
E1210 15:18:45.875066 1148592 goroutinemap.go:150] Operation for "/tmp/device_plugin658673309/server.sock" failed. No retries permitted until 2020-12-10 15:18:46.37491185 +0800 CST m=+0.578446851 (durationBeforeRetry 500ms). Error: "RegisterPlugin error -- failed to get plugin info using RPC GetInfo at socket /tmp/device_plugin658673309/server.sock, err: rpc error: code = Unimplemented desc = unknown service pluginregistration.Registration"
I1210 15:18:45.878416 1148592 device_plugin_stub.go:244] ListAndWatch
```
we can see device-plugin.sock register twice and this break the test's rhythm later and case the error. 

This is becase there are some interval between fswatch's `readEvents` and `traversePluginDir`. if socket `device-plugin.sock` created in this interval, it will register twice.

2. fix reconcile's field `handler` data race problem.

when I  change place 1, and rerun the stress.  And meet a race 
output as fellow:
```
=== RUN   TestDevicePluginReRegistrationProbeMode
I1210 15:46:16.502065 1153099 fake_topology_manager.go:30] [fake topologymanager] NewFakeManager
W1210 15:46:16.502308 1153099 manager.go:594] Failed to retrieve checkpoint for "kubelet_internal_checkpoint": checkpoint is not found
I1210 15:46:16.504720 1153099 device_plugin_stub.go:142] Starting to serve on /tmp/device_plugin187177318/device-plugin.sock
I1210 15:46:16.505182 1153099 plugin_manager.go:114] Starting Kubelet Plugin Manager
E1210 15:46:16.512303 1153099 goroutinemap.go:150] Operation for "/tmp/device_plugin187177318/server.sock" failed. No retries permitted until 2020-12-10 15:46:17.012208711 +0800 CST m=+0.582032894 (durationBeforeRetry 500ms). Error: "RegisterPlugin error -- failed to get plugin info using RPC GetInfo at socket /tmp/device_plugin187177318/server.sock, err: rpc error: code = Unimplemented desc = unknown service pluginregistration.Registration"
I1210 15:46:16.515055 1153099 device_plugin_stub.go:164] GetInfo
==================
WARNING: DATA RACE
Read at 0x00c0001f6990 by goroutine 39:
  runtime.mapaccess2_faststr()
      /usr/local/go/src/runtime/map_faststr.go:107 +0x0
  k8s.io/kubernetes/pkg/kubelet/pluginmanager/operationexecutor.(*operationGenerator).GenerateRegisterPluginFunc.func1()
      /opt/workspace/myspace/src/k8s.io/kubernetes/pkg/kubelet/pluginmanager/operationexecutor/operation_generator.go:95 +0x4de
  k8s.io/kubernetes/pkg/util/goroutinemap.(*goRoutineMap).Run.func1()
      /opt/workspace/myspace/src/k8s.io/kubernetes/pkg/util/goroutinemap/goroutinemap.go:115 +0x147

Previous write at 0x00c0001f6990 by goroutine 23:
  runtime.mapassign_faststr()
      /usr/local/go/src/runtime/map_faststr.go:202 +0x0
  k8s.io/kubernetes/pkg/kubelet/pluginmanager/reconciler.(*reconciler).AddHandler()
      /opt/workspace/myspace/src/k8s.io/kubernetes/pkg/kubelet/pluginmanager/reconciler/reconciler.go:96 +0xeb
  k8s.io/kubernetes/pkg/kubelet/pluginmanager.(*pluginManager).AddHandler()
      /opt/workspace/myspace/src/k8s.io/kubernetes/pkg/kubelet/pluginmanager/plugin_manager.go:123 +0x83
  k8s.io/kubernetes/pkg/kubelet/cm/devicemanager.setupPluginManager()
      /opt/workspace/myspace/src/k8s.io/kubernetes/pkg/kubelet/cm/devicemanager/manager_test.go:268 +0x145
  k8s.io/kubernetes/pkg/kubelet/cm/devicemanager.setupInProbeMode()
      /opt/workspace/myspace/src/k8s.io/kubernetes/pkg/kubelet/cm/devicemanager/manager_test.go:286 +0x15d
  k8s.io/kubernetes/pkg/kubelet/cm/devicemanager.TestDevicePluginReRegistrationProbeMode()
      /opt/workspace/myspace/src/k8s.io/kubernetes/pkg/kubelet/cm/devicemanager/manager_test.go:178 +0x4d1
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1127 +0x202
```
It is obvious that field handler get from `getHandlers` is a reference. if we set it `AddHandler`, they will compete.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fix https://github.com/kubernetes/kubernetes/issues/96908

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
