### PR TITLE
Add damemi to sig-scheduling-maintainers

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -175,6 +175,7 @@ aliases:
     - ravisantoshgudimetla
     - Huang-Wei
     - ahg-g
+    - damemi
   # emeritus:
   # - bsalamat
   sig-scheduling:


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

I nominate @damemi as an approver for SIG Scheduling. Mike is an active contributor and I trust that he understands the scheduler's codebase. His contributions include:

- A reviewer since Feb 2020 #87982
- Led [Taint Based Evictions](https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/20200127-taint-based-evictions.md) to GA.
- [25 PRs to sig-scheduling](https://github.com/kubernetes/kubernetes/pulls?q=is%3Apr+author%3Adamemi+is%3Amerged+label%3Asig%2Fscheduling) working on:
  - Taints
  - Component Config
  - Cleaning up dependencies so that scheduler code is more reusable
  - Critical bug fixes
- [52 reviewed PRs in sig-scheduling](https://github.com/kubernetes/kubernetes/pulls?q=is%3Apr+-author%3Adamemi+is%3Amerged+label%3Asig%2Fscheduling+reviewed-by%3Adamemi)
- A maintainer of the Descheduler subproject https://github.com/kubernetes-sigs/descheduler/blob/master/OWNERS
- An attendee of most SIG meetings.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

/cc @Huang-Wei @ahg-g 
/sig scheduling