### PR TITLE
Improve error message on "CLOSE_WAIT" test failure

### DIFF
--- a/test/e2e/network/kube_proxy.go
+++ b/test/e2e/network/kube_proxy.go
@@ -236,7 +236,7 @@ var _ = SIGDescribe("KubeProxy", func() {
 			}
 			return false, fmt.Errorf("wrong TCP CLOSE_WAIT timeout: %v expected: %v", timeoutSeconds, expectedTimeoutSeconds)
 		}); err != nil {
-			framework.Failf("no conntrack entry for port %d on node %s", testDaemonTCPPort, serverNodeInfo.nodeIP)
+			framework.Failf("no valid conntrack entry for port %d on node %s: %v", testDaemonTCPPort, serverNodeInfo.nodeIP, err)
 		}
 	})
 


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
If the `CLOSE_WAIT` e2e test fails, it doesn't log _why_ it failed

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/sig network
/priority backlog