### PR TITLE
netpol: promote CRUD API tests for v1 to conformance

### DIFF
--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -1642,6 +1642,16 @@
     watch, update, patch, delete, and deletecollection.'
   release: v1.19
   file: test/e2e/network/ingressclass.go
+- testname: NetworkPolicies API
+  codename: '[sig-network] NetworkPolicy API should support creating NetworkPolicy
+    API operations [Conformance]'
+  description: ' - The networking.k8s.io API group MUST exist in the /apis discovery
+    document. - The networking.k8s.io/v1 API group/version MUST exist in the /apis/networking.k8s.io
+    discovery document. - The NetworkPolicies resources MUST exist in the /apis/networking.k8s.io/v1
+    discovery document. - The NetworkPolicies resource must support create, get, list,
+    watch, update, patch, delete, and deletecollection.'
+  release: v1.20
+  file: test/e2e/network/network_policy.go
 - testname: Networking, intra pod http
   codename: '[sig-network] Networking Granular Checks: Pods should function for intra-pod
     communication: http [NodeConformance] [Conformance]'

--- a/test/e2e/network/network_policy.go
+++ b/test/e2e/network/network_policy.go
@@ -2192,7 +2192,7 @@ var _ = SIGDescribe("NetworkPolicy API", func() {
 		- The NetworkPolicies resource must support create, get, list, watch, update, patch, delete, and deletecollection.
 	*/
 
-	ginkgo.It("should support creating NetworkPolicy API operations", func() {
+	framework.ConformanceIt("should support creating NetworkPolicy API operations", func() {
 		// Setup
 		ns := f.Namespace.Name
 		npVersion := "v1"


### PR DESCRIPTION
**What type of PR is this?**
/kind feature
/kind api-change
/area conformance

**What this PR does / why we need it**:
- Bump stable API CRUD tests for NetPol to conformance level

**Which issue(s) this PR fixes**:
Fixes #94776

**Special notes for your reviewer**:

Run history:
* [gce-cos-master](https://testgrid.k8s.io/sig-release-master-blocking#gce-cos-master-default&include-filter-by-regex=sig-network.*NetworkPolicy.*AP&width=5)
* [kind-master-parallel](https://testgrid.k8s.io/sig-release-master-blocking#kind-master-parallel&include-filter-by-regex=sig-network.*NetworkPolicy.*API&width=5)
* current API coverage of those tests against the v1 API visible at https://apisnoop.cncf.io/latest/stable/networking


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
netpol: promote CRUD API tests for v1 to conformance
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:


