### PR TITLE
Fix missing type error in Get-RemoteFile by loading System.Net.Http assembly.

### DIFF
--- a/cluster/gce/windows/common.psm1
+++ b/cluster/gce/windows/common.psm1
@@ -202,6 +202,11 @@ function Get-RemoteFile {
     [parameter(Mandatory = $false)] [System.Collections.IDictionary]$Headers = @{}
   )
 
+  # Load the System.Net.Http assembly if it's not loaded yet.
+  if ("System.Net.Http.HttpClient" -as [type]) {} else {
+    Add-Type -AssemblyName System.Net.Http
+  }
+
   $timeout = New-TimeSpan -Minutes 5
 
   try {
@@ -215,19 +220,19 @@ function Get-RemoteFile {
     # If the URL is for GCS and the node has dev storage scope, add the
     # service account OAuth2 bearer token to the request headers.
     # https://cloud.google.com/compute/docs/access/create-enable-service-accounts-for-instances#applications
-    if (($Url -match "^https://storage`.googleapis`.com.*") -And $(Check-StorageScope)) {
+    if (($Url -match "^https://storage`.googleapis`.com.*") -and $(Check-StorageScope)) {
       $httpClient.DefaultRequestHeaders.Add("Authorization", "Bearer $(Get-Credentials)")
     }
 
     # Attempt to download the file
     $httpResponseMessage = $httpClient.GetAsync([System.Uri]::new($Url))
     $httpResponseMessage.Wait()
-    if (-Not $httpResponseMessage.IsCanceled) {
+    if (-not $httpResponseMessage.IsCanceled) {
       # Check if the request was successful.
       # 
       # DO NOT replace with EnsureSuccessStatusCode(), it prints the
       # OAuth2 bearer token.
-      if (-Not $httpResponseMessage.Result.IsSuccessStatusCode) {
+      if (-not $httpResponseMessage.Result.IsSuccessStatusCode) {
         $statusCode = $httpResponseMessage.Result.StatusCode
         throw "Downloading ${Url} returned status code ${statusCode}, retrying."
       }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug
/kind regression
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
Closes #97210
PR #96661 broken file downloads on some version of Windows because the System.Net.Http assembly is not loaded in the default powershell context.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
