### PR TITLE
Informer Lifecycle Improvements

### DIFF
--- a/pkg/controller/garbagecollector/garbagecollector_test.go
+++ b/pkg/controller/garbagecollector/garbagecollector_test.go
@@ -87,7 +87,7 @@ func TestGarbageCollectorConstruction(t *testing.T) {
 	client := fake.NewSimpleClientset()
 
 	sharedInformers := informers.NewSharedInformerFactory(client, 0)
-	metadataInformers := metadatainformer.NewSharedInformerFactory(metadataClient, 0)
+	metadataInformers := metadatainformer.NewSharedInformerFactoryWithOptions(metadataClient, 0, metadatainformer.WithStopOnZeroEventHandlers(true))
 	// No monitor will be constructed for the non-core resource, but the GC
 	// construction will not fail.
 	alwaysStarted := make(chan struct{})
@@ -210,7 +210,7 @@ func setupGC(t *testing.T, config *restclient.Config) garbageCollector {
 	}
 
 	client := fake.NewSimpleClientset()
-	sharedInformers := informers.NewSharedInformerFactory(client, 0)
+	sharedInformers := informers.NewSharedInformerFactoryWithOptions(client, 0)
 	alwaysStarted := make(chan struct{})
 	close(alwaysStarted)
 	gc, err := NewGarbageCollector(client, metadataClient, &testRESTMapper{testrestmapper.TestOnlyStaticRESTMapper(legacyscheme.Scheme)}, ignoredResources, sharedInformers, alwaysStarted)
@@ -843,7 +843,7 @@ func TestGarbageCollectorSync(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	sharedInformers := informers.NewSharedInformerFactory(client, 0)
+	sharedInformers := informers.NewSharedInformerFactoryWithOptions(client, 0)
 	alwaysStarted := make(chan struct{})
 	close(alwaysStarted)
 	gc, err := NewGarbageCollector(client, metadataClient, rm, map[schema.GroupResource]struct{}{}, sharedInformers, alwaysStarted)

--- a/pkg/controller/garbagecollector/patch.go
+++ b/pkg/controller/garbagecollector/patch.go
@@ -74,7 +74,7 @@ func (gc *GarbageCollector) getMetadata(apiVersion, kind, namespace, name string
 	if len(namespace) != 0 {
 		key = namespace + "/" + name
 	}
-	raw, exist, err := m.store.GetByKey(key)
+	raw, exist, err := m.informer.GetStore().GetByKey(key)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/replication/conversion.go
+++ b/pkg/controller/replication/conversion.go
@@ -180,6 +180,9 @@ func (h conversionEventHandler) OnDelete(obj interface{}) {
 	h.handler.OnDelete(rs)
 }
 
+func (h conversionEventHandler) OnError(err error) {
+}
+
 type clientsetAdapter struct {
 	clientset.Interface
 }

--- a/staging/src/k8s.io/client-go/dynamic/dynamicinformer/informer.go
+++ b/staging/src/k8s.io/client-go/dynamic/dynamicinformer/informer.go
@@ -32,23 +32,8 @@ import (
 	"k8s.io/client-go/tools/cache"
 )
 
-// NewDynamicSharedInformerFactory constructs a new instance of dynamicSharedInformerFactory for all namespaces.
-func NewDynamicSharedInformerFactory(client dynamic.Interface, defaultResync time.Duration) DynamicSharedInformerFactory {
-	return NewFilteredDynamicSharedInformerFactory(client, defaultResync, metav1.NamespaceAll, nil)
-}
-
-// NewFilteredDynamicSharedInformerFactory constructs a new instance of dynamicSharedInformerFactory.
-// Listers obtained via this factory will be subject to the same filters as specified here.
-func NewFilteredDynamicSharedInformerFactory(client dynamic.Interface, defaultResync time.Duration, namespace string, tweakListOptions TweakListOptionsFunc) DynamicSharedInformerFactory {
-	return &dynamicSharedInformerFactory{
-		client:           client,
-		defaultResync:    defaultResync,
-		namespace:        namespace,
-		informers:        map[schema.GroupVersionResource]informers.GenericInformer{},
-		startedInformers: make(map[schema.GroupVersionResource]bool),
-		tweakListOptions: tweakListOptions,
-	}
-}
+// DynamicSharedInformerOption defines the functional option type for SharedInformerFactory.
+type DynamicSharedInformerOption func(*dynamicSharedInformerFactory) *dynamicSharedInformerFactory
 
 type dynamicSharedInformerFactory struct {
 	client        dynamic.Interface
@@ -59,11 +44,67 @@ type dynamicSharedInformerFactory struct {
 	informers map[schema.GroupVersionResource]informers.GenericInformer
 	// startedInformers is used for tracking which informers have been started.
 	// This allows Start() to be called multiple times safely.
-	startedInformers map[schema.GroupVersionResource]bool
-	tweakListOptions TweakListOptionsFunc
+	startedInformers        map[schema.GroupVersionResource]bool
+	tweakListOptions        TweakListOptionsFunc
+	stopOnZeroEventHandlers bool
 }
 
 var _ DynamicSharedInformerFactory = &dynamicSharedInformerFactory{}
+
+// WithStopOnZerror indicates to shut down individual informers
+// if they have zero event handlers registered on them.
+func WithStopOnZeroEventHandlers(stopOnZeroEventHandlers bool) DynamicSharedInformerOption {
+	return func(factory *dynamicSharedInformerFactory) *dynamicSharedInformerFactory {
+		factory.stopOnZeroEventHandlers = stopOnZeroEventHandlers
+		return factory
+	}
+}
+
+// WithTweakListOptions sets a custom filter on all listers of the configured SharedInformerFactory.
+func WithTweakListOptions(tweakListOptions TweakListOptionsFunc) DynamicSharedInformerOption {
+	return func(factory *dynamicSharedInformerFactory) *dynamicSharedInformerFactory {
+		factory.tweakListOptions = tweakListOptions
+		return factory
+	}
+}
+
+// WithNamespace limits the SharedInformerFactory to the specified namespace.
+func WithNamespace(namespace string) DynamicSharedInformerOption {
+	return func(factory *dynamicSharedInformerFactory) *dynamicSharedInformerFactory {
+		factory.namespace = namespace
+		return factory
+	}
+}
+
+// NewDynamicSharedInformerFactory constructs a new instance of dynamicSharedInformerFactory for all namespaces.
+func NewDynamicSharedInformerFactory(client dynamic.Interface, defaultResync time.Duration) DynamicSharedInformerFactory {
+	return NewDynamicSharedInformerFactoryWithOptions(client, defaultResync)
+}
+
+// NewFilteredDynamicSharedInformerFactory constructs a new instance of dynamicSharedInformerFactory.
+// Listers obtained via this factory will be subject to the same filters as specified here.
+// Deprecated: Please use NewDynamicSharedInformerFactoryWithOptions instead
+func NewFilteredDynamicSharedInformerFactory(client dynamic.Interface, defaultResync time.Duration, namespace string, tweakListOptions TweakListOptionsFunc) DynamicSharedInformerFactory {
+	return NewDynamicSharedInformerFactoryWithOptions(client, defaultResync, WithNamespace(namespace), WithTweakListOptions(tweakListOptions))
+}
+
+// NewDynamicSharedInformerFactoryWithOptions constructs a new instance of a dynamicSharedInformerFactory with additional options.
+func NewDynamicSharedInformerFactoryWithOptions(client dynamic.Interface, defaultResync time.Duration, options ...DynamicSharedInformerOption) DynamicSharedInformerFactory {
+	factory := &dynamicSharedInformerFactory{
+		client:           client,
+		defaultResync:    defaultResync,
+		namespace:        metav1.NamespaceAll,
+		informers:        map[schema.GroupVersionResource]informers.GenericInformer{},
+		startedInformers: make(map[schema.GroupVersionResource]bool),
+	}
+
+	// Apply all options
+	for _, opt := range options {
+		factory = opt(factory)
+	}
+
+	return factory
+}
 
 func (f *dynamicSharedInformerFactory) ForResource(gvr schema.GroupVersionResource) informers.GenericInformer {
 	f.lock.Lock()
@@ -81,14 +122,41 @@ func (f *dynamicSharedInformerFactory) ForResource(gvr schema.GroupVersionResour
 	return informer
 }
 
-// Start initializes all requested informers.
+func (f *dynamicSharedInformerFactory) informerStopped(informerType schema.GroupVersionResource) {
+	f.lock.Lock()
+	defer f.lock.Unlock()
+	delete(f.startedInformers, informerType)
+	delete(f.informers, informerType)
+}
+
+// Start initializes all requested informers with the stop options provided, defaulting to
+// the old, non-existent stop options (only stopping via closure of stopCh).
+// It makes sure remove an informer from the list of informers and started informers when the informer is stopped
+// to prevent a race where InformerFor gives the user back a stopped informer that will never be started again.
 func (f *dynamicSharedInformerFactory) Start(stopCh <-chan struct{}) {
 	f.lock.Lock()
 	defer f.lock.Unlock()
 
+	stopOptions := cache.StopOptions{
+		StopOnZeroEventHandlers: f.stopOnZeroEventHandlers,
+	}
 	for informerType, informer := range f.informers {
+		informerType := informerType
+		informer := informer
 		if !f.startedInformers[informerType] {
-			go informer.Informer().Run(stopCh)
+			infCtx, infCancel := context.WithCancel(context.TODO())
+			go func() {
+				select {
+				case <-stopCh:
+					infCancel()
+				case <-infCtx.Done():
+				}
+			}()
+			go func() {
+				defer f.informerStopped(informerType)
+				defer infCancel()
+				informer.Informer().RunWithStopOptions(infCtx, stopOptions)
+			}()
 			f.startedInformers[informerType] = true
 		}
 	}

--- a/staging/src/k8s.io/client-go/tools/cache/controller.go
+++ b/staging/src/k8s.io/client-go/tools/cache/controller.go
@@ -209,10 +209,14 @@ func (c *controller) processLoop() {
 //      it will get an object of type DeletedFinalStateUnknown. This can
 //      happen if the watch is closed and misses the delete event and we don't
 //      notice the deletion until the subsequent re-list.
+//  * OnError will get errors that come from the ListAndWatch when it is
+//      unable to continue receiving events and drops the connection to the
+//      apiserver with an error.
 type ResourceEventHandler interface {
 	OnAdd(obj interface{})
 	OnUpdate(oldObj, newObj interface{})
 	OnDelete(obj interface{})
+	OnError(err error)
 }
 
 // ResourceEventHandlerFuncs is an adaptor to let you easily specify as many or
@@ -223,6 +227,7 @@ type ResourceEventHandlerFuncs struct {
 	AddFunc    func(obj interface{})
 	UpdateFunc func(oldObj, newObj interface{})
 	DeleteFunc func(obj interface{})
+	ErrorFunc  func(err error)
 }
 
 // OnAdd calls AddFunc if it's not nil.
@@ -243,6 +248,13 @@ func (r ResourceEventHandlerFuncs) OnUpdate(oldObj, newObj interface{}) {
 func (r ResourceEventHandlerFuncs) OnDelete(obj interface{}) {
 	if r.DeleteFunc != nil {
 		r.DeleteFunc(obj)
+	}
+}
+
+// OnError calls ErrorFunc if it's not nil.
+func (r ResourceEventHandlerFuncs) OnError(err error) {
+	if r.ErrorFunc != nil {
+		r.ErrorFunc(err)
 	}
 }
 
@@ -286,6 +298,11 @@ func (r FilteringResourceEventHandler) OnDelete(obj interface{}) {
 		return
 	}
 	r.Handler.OnDelete(obj)
+}
+
+// OnError calls the nested handler for all errors
+func (r FilteringResourceEventHandler) OnError(err error) {
+	r.Handler.OnError(err)
 }
 
 // DeletionHandlingMetaNamespaceKeyFunc checks for

--- a/test/integration/client/exec_test.go
+++ b/test/integration/client/exec_test.go
@@ -430,6 +430,9 @@ func (es *informerSpy) OnDelete(obj interface{}) {
 	es.deletes = append(es.deletes, obj)
 }
 
+func (es *informerSpy) OnError(err error) {
+}
+
 // waitForEvents waits for adds, updates, and deletes to be filled with at least one event.
 func (es *informerSpy) waitForEvents(t *testing.T) {
 	if err := wait.PollImmediate(time.Millisecond*250, time.Second*20, func() (bool, error) {

--- a/test/integration/garbagecollector/cluster_scoped_owner_test.go
+++ b/test/integration/garbagecollector/cluster_scoped_owner_test.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	kubeapiservertesting "k8s.io/kubernetes/cmd/kube-apiserver/app/testing"
 	"k8s.io/kubernetes/test/integration/framework"
+	"k8s.io/kubernetes/test/integration/util"
 )
 
 type roundTripFunc func(req *http.Request) (*http.Response, error)
@@ -71,8 +72,8 @@ func TestClusterScopedOwners(t *testing.T) {
 
 	_, clientSet := ctx.gc, ctx.clientSet
 
-	ns := createNamespaceOrDie("gc-cluster-scope-deletion", clientSet, t)
-	defer deleteNamespaceOrDie(ns.Name, clientSet, t)
+	ns := util.CreateNamespaceOrDie("gc-cluster-scope-deletion", clientSet, t)
+	defer util.DeleteNamespaceOrDie(ns.Name, clientSet, t)
 
 	t.Log("Create a pair of objects")
 	pv, err := clientSet.CoreV1().PersistentVolumes().Create(context.TODO(), &v1.PersistentVolume{

--- a/test/integration/quota/quota_test.go
+++ b/test/integration/quota/quota_test.go
@@ -21,10 +21,14 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"testing"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
+	apiextensionsclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	apiextensionstestserver "k8s.io/apiextensions-apiserver/test/integration/fixtures"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
@@ -35,16 +39,23 @@ import (
 	"k8s.io/apiserver/pkg/admission/plugin/resourcequota"
 	resourcequotaapi "k8s.io/apiserver/pkg/admission/plugin/resourcequota/apis/resourcequota"
 	"k8s.io/apiserver/pkg/quota/v1/generic"
+	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
 	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/metadata"
+	"k8s.io/client-go/metadata/metadatainformer"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/record"
 	watchtools "k8s.io/client-go/tools/watch"
+	"k8s.io/controller-manager/pkg/informerfactory"
+	kubeapiservertesting "k8s.io/kubernetes/cmd/kube-apiserver/app/testing"
 	"k8s.io/kubernetes/pkg/controller"
 	replicationcontroller "k8s.io/kubernetes/pkg/controller/replication"
 	resourcequotacontroller "k8s.io/kubernetes/pkg/controller/resourcequota"
 	quotainstall "k8s.io/kubernetes/pkg/quota/v1/install"
 	"k8s.io/kubernetes/test/integration/framework"
+	"k8s.io/kubernetes/test/integration/util"
 )
 
 // 1.2 code gets:
@@ -62,7 +73,8 @@ func TestQuota(t *testing.T) {
 	}))
 
 	admissionCh := make(chan struct{})
-	clientset := clientset.NewForConfigOrDie(&restclient.Config{QPS: -1, Host: s.URL, ContentConfig: restclient.ContentConfig{GroupVersion: &schema.GroupVersion{Group: "", Version: "v1"}}})
+	clientConfig := &restclient.Config{QPS: -1, Host: s.URL, ContentConfig: restclient.ContentConfig{GroupVersion: &schema.GroupVersion{Group: "", Version: "v1"}}}
+	clientset := clientset.NewForConfigOrDie(clientConfig)
 	config := &resourcequotaapi.Configuration{}
 	admission, err := resourcequota.NewResourceQuota(config, 5, admissionCh)
 	if err != nil {
@@ -88,10 +100,12 @@ func TestQuota(t *testing.T) {
 	controllerCh := make(chan struct{})
 	defer close(controllerCh)
 
-	informers := informers.NewSharedInformerFactory(clientset, controller.NoResyncPeriodFunc())
+	metadataClient := metadata.NewForConfigOrDie(clientConfig)
+	metadataInformers := metadatainformer.NewSharedInformerFactoryWithOptions(metadataClient, controller.NoResyncPeriodFunc(), metadatainformer.WithStopOnZeroEventHandlers(true))
+	informers := informerfactory.NewInformerFactory(internalInformers, metadataInformers)
 	rm := replicationcontroller.NewReplicationManager(
-		informers.Core().V1().Pods(),
-		informers.Core().V1().ReplicationControllers(),
+		internalInformers.Core().V1().Pods(),
+		internalInformers.Core().V1().ReplicationControllers(),
 		clientset,
 		replicationcontroller.BurstReplicas,
 	)
@@ -104,7 +118,7 @@ func TestQuota(t *testing.T) {
 	informersStarted := make(chan struct{})
 	resourceQuotaControllerOptions := &resourcequotacontroller.ControllerOptions{
 		QuotaClient:               clientset.CoreV1(),
-		ResourceQuotaInformer:     informers.Core().V1().ResourceQuotas(),
+		ResourceQuotaInformer:     internalInformers.Core().V1().ResourceQuotas(),
 		ResyncPeriod:              controller.NoResyncPeriodFunc,
 		InformerFactory:           informers,
 		ReplenishmentResyncPeriod: controller.NoResyncPeriodFunc,
@@ -150,15 +164,17 @@ func TestQuota(t *testing.T) {
 	t.Logf("Took %v to scale up with quota", endTime.Sub(startTime))
 }
 
-func waitForQuota(t *testing.T, quota *v1.ResourceQuota, clientset *clientset.Clientset) {
+func waitForQuota(t *testing.T, quota *v1.ResourceQuota, clientset clientset.Interface) {
 	w, err := clientset.CoreV1().ResourceQuotas(quota.Namespace).Watch(context.TODO(), metav1.SingleObject(metav1.ObjectMeta{Name: quota.Name}))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if _, err := clientset.CoreV1().ResourceQuotas(quota.Namespace).Create(context.TODO(), quota, metav1.CreateOptions{}); err != nil {
+	q, err := clientset.CoreV1().ResourceQuotas(quota.Namespace).Create(context.TODO(), quota, metav1.CreateOptions{})
+	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	t.Logf("created quota %v", q)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
 	defer cancel()
@@ -369,5 +385,226 @@ func TestQuotaLimitedResourceDenial(t *testing.T) {
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// TestCRDQuotaUninstalledResources confirms that the quota controller continues to operate on CRDs that
+// are uninstalled and reinstalled on the cluster between quota controller syncs.
+func TestCRDQuotaUninstallReinstall(t *testing.T) {
+	ctx := setup(t, 2)
+	defer ctx.tearDown()
+	// install crd on cluster
+	ns := util.CreateNamespaceOrDie("test-crd", ctx.clientSet, t)
+	definition, resourceClient := util.CreateRandomCustomResourceDefinition(t, ctx.apiExtensionClient, ctx.dynamicClient, ns.Name)
+	time.Sleep(ctx.syncPeriod)
+	n := 3
+	quotaName := "quota"
+	hard := v1.ResourceList{}
+	resourceName := v1.ResourceName(fmt.Sprintf("count/%s.%s", definition.Spec.Names.Plural, definition.Spec.Group))
+	hard[resourceName] = resource.MustParse(strconv.Itoa(n))
+	quota := &v1.ResourceQuota{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      quotaName,
+			Namespace: ns.Name,
+		},
+		Spec: v1.ResourceQuotaSpec{
+			Hard: hard,
+		},
+	}
+	waitForQuota(t, quota, ctx.clientSet)
+	// create the crd instance
+	_, err := resourceClient.Create(context.TODO(), util.NewCRDInstance(definition, ns.Name, fmt.Sprintf("crd-%d", 1)), metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("failed to create crd instance 1, err: %v", err)
+	}
+
+	// confirm crd instance shows up in quota used count
+	err = pollExpectedQuota(ctx.clientSet, 1, resourceName, quotaName, ns.Name)
+	if err != nil {
+		t.Fatalf("err %v", err)
+	}
+
+	// retrieve the informer before deletion to check it's been stopped.
+	gvr := schema.GroupVersionResource{Group: definition.Spec.Group, Version: definition.Spec.Versions[0].Name, Resource: definition.Spec.Names.Plural}
+	informer, err := ctx.informers.ForResource(gvr)
+	if err != nil {
+		t.Fatalf("error getting informer for resource")
+	}
+	if informer.Informer().IsStopped() {
+		t.Fatalf("informer stopped unexpectedly prior to deletion")
+	}
+
+	// delete the definition which will cascade to the instance
+	if err := apiextensionstestserver.DeleteV1CustomResourceDefinition(definition, ctx.apiExtensionClient); err != nil {
+		t.Fatalf("failed to delete %q: %v", definition.Name, err)
+	}
+
+	// ensure the informer is stopped upon CRD deletion
+	if err := wait.Poll(1*time.Second, 30*time.Second, func() (bool, error) {
+		return informer.Informer().IsStopped(), nil
+	}); err != nil {
+		t.Fatalf("CRD informer failed to stop upon deletion")
+	}
+
+	// check quota used count is now 0 after deletion
+	err = pollExpectedQuota(ctx.clientSet, 0, resourceName, quotaName, ns.Name)
+	if err != nil {
+		t.Fatalf("failed to reset quota count after CRD deletion")
+	}
+
+	// reinstall the definition
+	accessor := meta.NewAccessor()
+	accessor.SetResourceVersion(definition, "")
+	_, err = apiextensionstestserver.CreateNewV1CustomResourceDefinition(definition, ctx.apiExtensionClient, ctx.dynamicClient)
+	if err != nil {
+		t.Fatalf("failed to create CustomResourceDefinition on round 2: %v", err)
+	}
+
+	// create instance
+	_, err = resourceClient.Create(context.TODO(), util.NewCRDInstance(definition, ns.Name, fmt.Sprintf("crd-%d", 2)), metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("failed to create crd instance 2, err: %v", err)
+	}
+
+	// confirm quota is updated with new instance in used count
+	err = pollExpectedQuota(ctx.clientSet, 1, resourceName, quotaName, ns.Name)
+	if err != nil {
+		t.Fatalf("err %v", err)
+	}
+}
+
+func TestCRDQuota(t *testing.T) {
+	ctx := setup(t, 2)
+	defer ctx.tearDown()
+
+	// install crd on cluster, give it time to sync
+	ns := util.CreateNamespaceOrDie("test-crd", ctx.clientSet, t)
+	definition, resourceClient := util.CreateRandomCustomResourceDefinition(t, ctx.apiExtensionClient, ctx.dynamicClient, ns.Name)
+	time.Sleep(ctx.syncPeriod)
+
+	// create crd quota N
+	n := 3
+	quotaName := "quota"
+	hard := v1.ResourceList{}
+	resourceName := v1.ResourceName(fmt.Sprintf("count/%s.%s", definition.Spec.Names.Plural, definition.Spec.Group))
+	hard[resourceName] = resource.MustParse(strconv.Itoa(n))
+	quota := &v1.ResourceQuota{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      quotaName,
+			Namespace: ns.Name,
+		},
+		Spec: v1.ResourceQuotaSpec{
+			Hard: hard,
+		},
+	}
+	waitForQuota(t, quota, ctx.clientSet)
+	// create n+1 crd objects, confirm failure of the last one
+	for i := 1; i < n+1; i++ {
+		// create a new crd instance
+		_, err := resourceClient.Create(context.TODO(), util.NewCRDInstance(definition, ns.Name, fmt.Sprintf("crd-%d", i)), metav1.CreateOptions{})
+		if err != nil {
+			if i != n+1 {
+				t.Fatalf("failed to create crd instance on iteration: %d, err: %v", i, err)
+			}
+		} else {
+			// confirm that eventually, the resource quota used field
+			// equals the number of crd instances created
+			err := pollExpectedQuota(ctx.clientSet, i, resourceName, quotaName, ns.Name)
+			if err != nil {
+				t.Fatalf("failed polling the expected quota:  %v", err)
+			}
+		}
+	}
+
+}
+
+func pollExpectedQuota(clientSet kubernetes.Interface, target int, resourceName v1.ResourceName, quotaName, ns string) error {
+	return wait.Poll(time.Second, time.Minute, func() (bool, error) {
+		q, err := clientSet.CoreV1().ResourceQuotas(ns).Get(context.TODO(), quotaName, metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+		used, ok := q.Status.Used[resourceName]
+		if ok && used.AsDec().UnscaledBig().Int64() == int64(target) {
+			return true, nil
+		}
+		return false, nil
+	})
+
+}
+
+type testContext struct {
+	tearDown           func()
+	rq                 *resourcequotacontroller.Controller
+	clientSet          clientset.Interface
+	apiExtensionClient apiextensionsclientset.Interface
+	dynamicClient      dynamic.Interface
+	metadataClient     metadata.Interface
+	startRQ            func(workers int)
+	informers          informerfactory.InformerFactory
+	// syncPeriod is how often the RQ started with startRQ will be resynced.
+	syncPeriod time.Duration
+}
+
+// if workerCount > 0, will start the RQ, otherwise it's up to the caller to Run() the RQ.
+func setup(t *testing.T, workerCount int) *testContext {
+	return setupWithServer(t, kubeapiservertesting.StartTestServerOrDie(t, nil, nil, framework.SharedEtcd()), workerCount)
+}
+
+func setupWithServer(t *testing.T, result *kubeapiservertesting.TestServer, workerCount int) *testContext {
+	ctx := util.ExtensionSetup(t, result, workerCount)
+	rm := replicationcontroller.NewReplicationManager(
+		ctx.SharedInformers.Core().V1().Pods(),
+		ctx.SharedInformers.Core().V1().ReplicationControllers(),
+		ctx.ClientSet,
+		replicationcontroller.BurstReplicas,
+	)
+	rm.SetEventRecorder(&record.FakeRecorder{})
+	go rm.Run(3, ctx.StopCh)
+
+	discoveryFunc := ctx.ClientSet.Discovery().ServerPreferredNamespacedResources
+	listerFuncForResource := generic.ListerFuncForResourceFunc(ctx.SharedInformers.ForResource)
+	qc := quotainstall.NewQuotaConfigurationForControllers(listerFuncForResource)
+	informersStarted := make(chan struct{})
+	informers := informerfactory.NewInformerFactory(ctx.SharedInformers, ctx.MetadataInformers)
+	resourceQuotaControllerOptions := &resourcequotacontroller.ControllerOptions{
+		QuotaClient:               ctx.ClientSet.CoreV1(),
+		ResourceQuotaInformer:     ctx.SharedInformers.Core().V1().ResourceQuotas(),
+		ResyncPeriod:              controller.NoResyncPeriodFunc,
+		InformerFactory:           informers,
+		ReplenishmentResyncPeriod: controller.NoResyncPeriodFunc,
+		DiscoveryFunc:             discoveryFunc,
+		IgnoredResourcesFunc:      qc.IgnoredResources,
+		InformersStarted:          informersStarted,
+		Registry:                  generic.NewRegistry(qc.Evaluators()),
+	}
+	resourceQuotaController, err := resourcequotacontroller.NewController(resourceQuotaControllerOptions)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+
+	syncPeriod := 5 * time.Second
+	startRQ := func(workers int) {
+		go wait.Until(func() {
+			ctx.RESTMapper.Reset()
+		}, syncPeriod, ctx.StopCh)
+		go resourceQuotaController.Run(1, ctx.StopCh)
+		go resourceQuotaController.Sync(discoveryFunc, syncPeriod, ctx.StopCh)
+	}
+	if workerCount > 0 {
+		startRQ(workerCount)
+		informers.Start(ctx.StopCh)
+		close(informersStarted)
+	}
+	return &testContext{
+		tearDown:           ctx.TearDown,
+		rq:                 resourceQuotaController,
+		clientSet:          ctx.ClientSet,
+		apiExtensionClient: ctx.APIExtensionClient,
+		dynamicClient:      ctx.DynamicClient,
+		metadataClient:     ctx.MetadataClient,
+		startRQ:            startRQ,
+		informers:          informers,
+		syncPeriod:         syncPeriod,
 	}
 }

--- a/test/integration/util/extension.go
+++ b/test/integration/util/extension.go
@@ -1,0 +1,158 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"context"
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apiextensionsclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	apiextensionstestserver "k8s.io/apiextensions-apiserver/test/integration/fixtures"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	cacheddiscovery "k8s.io/client-go/discovery/cached/memory"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/informers"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/metadata"
+	"k8s.io/client-go/metadata/metadatainformer"
+	"k8s.io/client-go/restmapper"
+	kubeapiservertesting "k8s.io/kubernetes/cmd/kube-apiserver/app/testing"
+)
+
+// ExtensionTestContext holds state from ExtensionSetup
+type ExtensionTestContext struct {
+	StopCh             <-chan struct{}
+	TearDown           func()
+	ClientSet          clientset.Interface
+	RESTMapper         *restmapper.DeferredDiscoveryRESTMapper
+	APIExtensionClient apiextensionsclientset.Interface
+	SharedInformers    informers.SharedInformerFactory
+	MetadataInformers  metadatainformer.SharedInformerFactory
+	MetadataClient     metadata.Interface
+	DynamicClient      dynamic.Interface
+}
+
+// ExtensionSetup performs shared setup
+func ExtensionSetup(t *testing.T, result *kubeapiservertesting.TestServer, workerCount int) *ExtensionTestContext {
+	clientSet, err := clientset.NewForConfig(result.ClientConfig)
+	if err != nil {
+		t.Fatalf("error creating clientset: %v", err)
+	}
+
+	// Helpful stuff for testing CRD.
+	apiExtensionClient, err := apiextensionsclientset.NewForConfig(result.ClientConfig)
+	if err != nil {
+		t.Fatalf("error creating extension clientset: %v", err)
+	}
+	// CreateCRDUsingRemovedAPI wants to use this namespace for verifying
+	// namespace-scoped CRD creation.
+	CreateNamespaceOrDie("aval", clientSet, t)
+
+	discoveryClient := cacheddiscovery.NewMemCacheClient(clientSet.Discovery())
+	restMapper := restmapper.NewDeferredDiscoveryRESTMapper(discoveryClient)
+	restMapper.Reset()
+	config := *result.ClientConfig
+	metadataClient, err := metadata.NewForConfig(&config)
+	if err != nil {
+		t.Fatalf("failed to create metadataClient: %v", err)
+	}
+	dynamicClient, err := dynamic.NewForConfig(&config)
+	if err != nil {
+		t.Fatalf("failed to create dynamicClient: %v", err)
+	}
+	sharedInformers := informers.NewSharedInformerFactory(clientSet, 0)
+	metadataInformers := metadatainformer.NewSharedInformerFactoryWithOptions(metadataClient, 0, metadatainformer.WithStopOnZeroEventHandlers(true))
+
+	// controller creation
+	stopCh := make(chan struct{})
+	tearDown := func() {
+		close(stopCh)
+		result.TearDownFn()
+	}
+
+	return &ExtensionTestContext{
+		StopCh:             stopCh,
+		TearDown:           tearDown,
+		RESTMapper:         restMapper,
+		ClientSet:          clientSet,
+		APIExtensionClient: apiExtensionClient,
+		DynamicClient:      dynamicClient,
+		SharedInformers:    sharedInformers,
+		MetadataInformers:  metadataInformers,
+		MetadataClient:     metadataClient,
+	}
+}
+
+func NewCRDInstance(definition *apiextensionsv1.CustomResourceDefinition, namespace, name string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"kind":       definition.Spec.Names.Kind,
+			"apiVersion": definition.Spec.Group + "/" + definition.Spec.Versions[0].Name,
+			"metadata": map[string]interface{}{
+				"name":      name,
+				"namespace": namespace,
+			},
+		},
+	}
+}
+
+func CreateRandomCustomResourceDefinition(t *testing.T, apiExtensionClient apiextensionsclientset.Interface, dynamicClient dynamic.Interface, namespace string) (*apiextensionsv1.CustomResourceDefinition, dynamic.ResourceInterface) {
+	// Create a random custom resource definition and ensure it's available for
+	// use.
+	definition := apiextensionstestserver.NewRandomNameV1CustomResourceDefinition(apiextensionsv1.NamespaceScoped)
+
+	definition, err := apiextensionstestserver.CreateNewV1CustomResourceDefinition(definition, apiExtensionClient, dynamicClient)
+	if err != nil {
+		t.Fatalf("failed to create CustomResourceDefinition: %v", err)
+	}
+
+	// Get a client for the custom resource.
+	gvr := schema.GroupVersionResource{Group: definition.Spec.Group, Version: definition.Spec.Versions[0].Name, Resource: definition.Spec.Names.Plural}
+
+	resourceClient := dynamicClient.Resource(gvr).Namespace(namespace)
+
+	return definition, resourceClient
+}
+
+func CreateNamespaceOrDie(name string, c clientset.Interface, t *testing.T) *v1.Namespace {
+	ns := &v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: name}}
+	if _, err := c.CoreV1().Namespaces().Create(context.TODO(), ns, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("failed to create namespace: %v", err)
+	}
+	falseVar := false
+	_, err := c.CoreV1().ServiceAccounts(ns.Name).Create(context.TODO(), &v1.ServiceAccount{
+		ObjectMeta:                   metav1.ObjectMeta{Name: "default"},
+		AutomountServiceAccountToken: &falseVar,
+	}, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("failed to create service account: %v", err)
+	}
+	return ns
+}
+
+func DeleteNamespaceOrDie(name string, c clientset.Interface, t *testing.T) {
+	zero := int64(0)
+	background := metav1.DeletePropagationBackground
+	err := c.CoreV1().Namespaces().Delete(context.TODO(), name, metav1.DeleteOptions{GracePeriodSeconds: &zero, PropagationPolicy: &background})
+	if err != nil {
+		t.Fatalf("failed to delete namespace %q: %v", name, err)
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature


**What this PR does / why we need it**:
Implementation of Informer Lifecycle Managemt [design doc](https://docs.google.com/document/d/17QrTaxfIEUNOEAt61Za3Mu0M76x-iEkcmR51q0a5lis/edit?usp=sharing)
Discussed at the Nov 4 sig-api-machinery meeting:[video](https://youtu.be/Vc8V8xVxK3k?t=27)

It does a few things that are broken up by commit:
1. Adds the OnError method to the ResourceEventHandler interface so that the handler is notified of ListAndWatch errors. 
2. Adds the ability to define stop conditions when running individual informers via the new `RunWithStopOptions()` method on the `SharedInformer` interface. It exposes running informers with stop options on the various informer factories (currently only supports global stop options that apply to all informers of an informer factory)
3. Modifies the metadata informer factory and dynamic informer factory to start informers via `RunWithStopOptions()` and provides a way to retrieve the stop channel for given informer to determine when an individual informer is stopped. 
4. Refactors some CRD specific integration testing helpers out of the GC integration test into a shared util package so that RQ integration test can also use them without duplicating code.
5. Modifies GC controller to recognize when a CRD informer has stopped and removes the monitor for it.
6. Modifies RQ controller to recognize when a CRD informer has stopped and removes the monitor for it.
7. Modifies controller-manager to run the GC and RQ controllers with RunWithStopOptions (meaning it always stops an informer upon reflector ListAndWatch error).


This is tested manually by modifying controller-runtime to use the new interfaces. Also by running the resource quota controller and GC controller with the new interfaces to verify that the informer shuts down as expected.

Unit testing has been added to the relevant pieces of tools/cache and metadatainformer/dynamicinformer. Integration tests for both the garbage collector and quota controller test that the install CRD/uninstall CRD/reinstall CRD flow continues to work while the informer gets stopped and restarted as expected.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #79610
Unblocks work relating to https://github.com/kubernetes-sigs/controller-runtime/pull/1192

```release-note
1. Adds the OnError method to the ResourceEventHandler interface so that the handler is notified of ListAndWatch errors. 
2. Adds the ability to define stop conditions when running individual informers via the new `RunWithStopOptions()` method on the `SharedInformer` interface. It exposes running informers with stop options on the various informer factories (currently only supports global stop options that apply to all informers of an informer factory)
3. Modifies the metadata informer factory and dynamic informer factory to start informers via `RunWithStopOptions()` and provides a way to retrieve the stop channel for given informer to determine when an individual informer is stopped. 
4. Refactors some CRD specific integration testing helpers out of the GC integration test into a shared util package so that RQ integration test can also use them without duplicating code.
5. Modifies GC controller to recognize when a CRD informer has stopped and removes the monitor for it.
6. Modifies RQ controller to recognize when a CRD informer has stopped and removes the monitor for it.
7. Modifies controller-manager to run the GC and RQ controllers with RunWithStopOptions (meaning it always stops an informer upon reflector ListAndWatch error).
```

based on https://github.com/kubernetes/kubernetes/pull/98657