### PR TITLE
Fix staticcheck failuers

### DIFF
--- a/hack/.staticcheck_failures
+++ b/hack/.staticcheck_failures
@@ -1,5 +1,4 @@
 cluster/images/etcd/migrate
-pkg/controller/replicaset
 pkg/kubelet/dockershim
 pkg/volume/testing
 test/e2e/autoscaling
@@ -9,14 +8,12 @@ test/integration/garbagecollector
 test/integration/scheduler_perf
 vendor/k8s.io/apimachinery/pkg/api/apitesting/roundtrip
 vendor/k8s.io/apimachinery/pkg/apis/meta/v1/validation
-vendor/k8s.io/apimachinery/pkg/runtime
 vendor/k8s.io/apimachinery/pkg/runtime/serializer/json
 vendor/k8s.io/apimachinery/pkg/util/httpstream/spdy
 vendor/k8s.io/apimachinery/pkg/util/net
 vendor/k8s.io/apimachinery/pkg/util/sets/types
 vendor/k8s.io/apimachinery/pkg/util/strategicpatch
 vendor/k8s.io/apimachinery/pkg/util/wait
-vendor/k8s.io/apiserver/pkg/admission/initializer
 vendor/k8s.io/apiserver/pkg/authentication/request/x509
 vendor/k8s.io/apiserver/pkg/endpoints
 vendor/k8s.io/apiserver/pkg/endpoints/filters
@@ -31,7 +28,6 @@ vendor/k8s.io/apiserver/pkg/server/dynamiccertificates
 vendor/k8s.io/apiserver/pkg/server/filters
 vendor/k8s.io/apiserver/pkg/server/httplog
 vendor/k8s.io/apiserver/pkg/server/routes
-vendor/k8s.io/apiserver/pkg/storage
 vendor/k8s.io/apiserver/pkg/storage/cacher
 vendor/k8s.io/apiserver/pkg/storage/etcd3
 vendor/k8s.io/apiserver/pkg/storage/tests

--- a/pkg/controller/replicaset/replica_set_test.go
+++ b/pkg/controller/replicaset/replica_set_test.go
@@ -504,13 +504,6 @@ func TestPodControllerLookup(t *testing.T) {
 	}
 }
 
-// byName sorts pods by their names.
-type byName []*v1.Pod
-
-func (pods byName) Len() int           { return len(pods) }
-func (pods byName) Swap(i, j int)      { pods[i], pods[j] = pods[j], pods[i] }
-func (pods byName) Less(i, j int) bool { return pods[i].Name < pods[j].Name }
-
 func TestRelatedPodsLookup(t *testing.T) {
 	someRS := newReplicaSet(1, map[string]string{"foo": "bar"})
 	someRS.Name = "foo1"
@@ -1125,7 +1118,7 @@ func TestDeleteControllerAndExpectations(t *testing.T) {
 	manager.deleteRS(rs)
 	manager.syncReplicaSet(GetKey(rs, t))
 
-	if _, exists, err = manager.expectations.GetExpectations(rsKey); exists {
+	if _, exists, _ = manager.expectations.GetExpectations(rsKey); exists {
 		t.Errorf("Found expectations, expected none since the ReplicaSet has been deleted.")
 	}
 
@@ -1218,7 +1211,7 @@ func TestExpectationsOnRecreate(t *testing.T) {
 		t.Fatalf("Deleting RS didn't result in new item in the queue: %v", err)
 	}
 
-	rsExp, exists, err = manager.expectations.GetExpectations(oldRSKey)
+	_, exists, err = manager.expectations.GetExpectations(oldRSKey)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/scheme.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/scheme.go
@@ -129,12 +129,6 @@ func (s *Scheme) nameFunc(t reflect.Type) string {
 	return gvks[0].Kind
 }
 
-// fromScope gets the input version, desired output version, and desired Scheme
-// from a conversion.Scope.
-func (s *Scheme) fromScope(scope conversion.Scope) *Scheme {
-	return s
-}
-
 // Converter allows access to the converter for the scheme
 func (s *Scheme) Converter() *conversion.Converter {
 	return s.converter

--- a/staging/src/k8s.io/apiserver/pkg/admission/initializer/initializer_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/initializer/initializer_test.go
@@ -120,15 +120,3 @@ type TestAuthorizer struct{}
 func (t *TestAuthorizer) Authorize(ctx context.Context, a authorizer.Attributes) (authorized authorizer.Decision, reason string, err error) {
 	return authorizer.DecisionNoOpinion, "", nil
 }
-
-// wantClientCert is a test stub for testing that fulfulls the WantsClientCert interface.
-type clientCertWanter struct {
-	gotCert, gotKey []byte
-}
-
-func (s *clientCertWanter) SetClientCert(cert, key []byte) { s.gotCert, s.gotKey = cert, key }
-func (s *clientCertWanter) Admit(ctx context.Context, a admission.Attributes, o admission.ObjectInterfaces) error {
-	return nil
-}
-func (s *clientCertWanter) Handles(o admission.Operation) bool { return false }
-func (s *clientCertWanter) ValidateInitialization() error      { return nil }

--- a/staging/src/k8s.io/apiserver/pkg/server/filters/goaway_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/filters/goaway_test.go
@@ -105,10 +105,6 @@ var (
 	// for watch request, test GOAWAY server push 1 byte in every second.
 	responseBody = []byte("hello")
 
-	// responseBodySize is the size of response body which test GOAWAY server sent for watch request,
-	// used to check if watch request was broken by GOAWAY frame.
-	responseBodySize = len(responseBody)
-
 	// requestPostBody is the request body which client must send to test GOAWAY server for POST method,
 	// otherwise, test GOAWAY server will respond 400 HTTP status code.
 	requestPostBody = responseBody

--- a/staging/src/k8s.io/apiserver/pkg/storage/selection_predicate_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/selection_predicate_test.go
@@ -30,17 +30,10 @@ type Ignored struct {
 	ID string
 }
 
-type IgnoredList struct {
-	Items []Ignored
-}
+func (obj *Ignored) GetObjectKind() schema.ObjectKind { return schema.EmptyObjectKind }
 
-func (obj *Ignored) GetObjectKind() schema.ObjectKind     { return schema.EmptyObjectKind }
-func (obj *IgnoredList) GetObjectKind() schema.ObjectKind { return schema.EmptyObjectKind }
 func (obj *Ignored) DeepCopyObject() runtime.Object {
 	panic("Ignored does not support DeepCopy")
-}
-func (obj *IgnoredList) DeepCopyObject() runtime.Object {
-	panic("IgnoredList does not support DeepCopy")
 }
 
 func TestSelectionPredicate(t *testing.T) {

--- a/test/e2e/autoscaling/custom_metrics_stackdriver_autoscaling.go
+++ b/test/e2e/autoscaling/custom_metrics_stackdriver_autoscaling.go
@@ -233,6 +233,9 @@ func (tc *CustomMetricTestCase) Run() {
 
 	ctx := context.Background()
 	client, err := google.DefaultClient(ctx, gcm.CloudPlatformScope)
+	if err != nil {
+		framework.Failf("Failed to get an HTTP Client, %v", err)
+	}
 
 	// Hack for running tests locally, needed to authenticate in Stackdriver
 	// If this is your use case, create application default credentials:

--- a/test/e2e/autoscaling/horizontal_pod_autoscaling.go
+++ b/test/e2e/autoscaling/horizontal_pod_autoscaling.go
@@ -106,7 +106,6 @@ type HPAScaleTest struct {
 	firstScaleStasis            time.Duration
 	cpuBurst                    int
 	secondScale                 int32
-	secondScaleStasis           time.Duration
 }
 
 // run is a method which runs an HPA lifecycle, from a starting state, to an expected

--- a/test/integration/framework/etcd.go
+++ b/test/integration/framework/etcd.go
@@ -100,7 +100,7 @@ func RunCustomEtcd(dataDir string, customFlags []string) (url string, stopFn fun
 	// TODO: Check for valid etcd version.
 	etcdPath, err := getEtcdPath()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, installEtcd)
+		fmt.Fprint(os.Stderr, installEtcd)
 		return "", nil, fmt.Errorf("could not find etcd in PATH: %v", err)
 	}
 	etcdPort, err := getAvailablePort()


### PR DESCRIPTION
Fix staticcheck failuers

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
Fix staticcheck failures :

pkg/controller/replicaset/replica_set_test.go:508:6: type byName is unused (U1000)
pkg/controller/replicaset/replica_set_test.go:1128:5: this value of err is never used (SA4006)
pkg/controller/replicaset/replica_set_test.go:1221:2: this value of rsExp is never used (SA4006)
vendor/k8s.io/cli-runtime/pkg/printers/tableprinter.go:97:2: this value of w is never used (SA4006)
vendor/k8s.io/apiserver/pkg/admission/initializer/initializer_test.go:125:6: type clientCertWanter is unused (U1000)
vendor/k8s.io/apiserver/pkg/server/filters/goaway_test.go:114:6: func newTestGOAWAYServer is unused (U1000)
vendor/k8s.io/apiserver/pkg/storage/selection_predicate_test.go:33:6: type IgnoredList is unused (U1000)
test/e2e/autoscaling/horizontal_pod_autoscaling.go:109:2: field secondScaleStasis is unused (U1000)
test/integration/framework/etcd.go:103:3: printf-style function with dynamic format string and no further arguments should use print-style function instead (SA1006)

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of #92402

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```NONE

```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
```
