### PR TITLE
fix staticcheck failures on vendor/k8s.io/apiserver/pkg/endpoints

### DIFF
--- a/hack/.staticcheck_failures
+++ b/hack/.staticcheck_failures
@@ -14,7 +14,6 @@ vendor/k8s.io/apimachinery/pkg/util/net
 vendor/k8s.io/apimachinery/pkg/util/sets/types
 vendor/k8s.io/apimachinery/pkg/util/strategicpatch
 vendor/k8s.io/apimachinery/pkg/util/wait
-vendor/k8s.io/apiserver/pkg/endpoints
 vendor/k8s.io/apiserver/pkg/endpoints/filters
 vendor/k8s.io/apiserver/pkg/endpoints/handlers
 vendor/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/apiserver_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/apiserver_test.go
@@ -356,11 +356,7 @@ type SimpleRESTStorage struct {
 	requestedResourceVersion   string
 	requestedResourceNamespace string
 
-	// The id requested, and location to return for ResourceLocation
-	requestedResourceLocationID string
-	resourceLocation            *url.URL
-	resourceLocationTransport   http.RoundTripper
-	expectedResourceNamespace   string
+	expectedResourceNamespace string
 
 	// If non-nil, called inside the WorkFunc when answering update, delete, create.
 	// obj receives the original input to the update, delete, or create call.

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/watch_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/watch_test.go
@@ -922,7 +922,7 @@ func runWatchHTTPBenchmark(b *testing.B, items []example.Pod) {
 	go func() {
 		defer response.Body.Close()
 		if _, err := io.Copy(ioutil.Discard, response.Body); err != nil {
-			b.Fatal(err)
+			b.Error(err)
 		}
 		wg.Done()
 	}()
@@ -962,7 +962,7 @@ func BenchmarkWatchWebsocket(b *testing.B) {
 	go func() {
 		defer ws.Close()
 		if _, err := io.Copy(ioutil.Discard, ws); err != nil {
-			b.Fatal(err)
+			b.Error(err)
 		}
 		wg.Done()
 	}()
@@ -1011,7 +1011,7 @@ func BenchmarkWatchProtobuf(b *testing.B) {
 	go func() {
 		defer response.Body.Close()
 		if _, err := io.Copy(ioutil.Discard, response.Body); err != nil {
-			b.Fatal(err)
+			b.Error(err)
 		}
 		wg.Done()
 	}()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
fix staticcheck failures on vendor/k8s.io/apiserver/pkg/endpoints

vendor/k8s.io/apiserver/pkg/endpoints/apiserver_test.go:357:2: field requestedResourceLocationID is unused (U1000)
vendor/k8s.io/apiserver/pkg/endpoints/apiserver_test.go:358:2: field resourceLocation is unused (U1000)
vendor/k8s.io/apiserver/pkg/endpoints/apiserver_test.go:359:2: field resourceLocationTransport is unused (U1000)
vendor/k8s.io/apiserver/pkg/endpoints/watch_test.go:922:2: the goroutine calls T.Fatal, which must be called in the same goroutine as the test (SA2002)
vendor/k8s.io/apiserver/pkg/endpoints/watch_test.go:925:4: call to T.Fatal
vendor/k8s.io/apiserver/pkg/endpoints/watch_test.go:962:2: the goroutine calls T.Fatal, which must be called in the same goroutine as the test (SA2002)
vendor/k8s.io/apiserver/pkg/endpoints/watch_test.go:965:4: call to T.Fatal
vendor/k8s.io/apiserver/pkg/endpoints/watch_test.go:1011:2: the goroutine calls T.Fatal, which must be called in the same goroutine as the test (SA2002)
vendor/k8s.io/apiserver/pkg/endpoints/watch_test.go:1014:4: call to T.Fatal

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of #92402

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
