### PR TITLE
Make sure the volume name is not empty when the PVC is bound

### DIFF
--- a/test/utils/runners.go
+++ b/test/utils/runners.go
@@ -1369,6 +1369,7 @@ func CreatePodWithPersistentVolume(client clientset.Interface, namespace string,
 			pv.Status.Phase = v1.VolumeBound
 
 			// bind pvc to "pv-$i"
+			pvc.Spec.VolumeName = pv.Name
 			pvc.Status.Phase = v1.ClaimBound
 		} else {
 			pv.Status.Phase = v1.VolumeAvailable


### PR DESCRIPTION
Current logic to check whether a PVC is fully bound are:
1. PVC's volume name is not empty
2. Annotation "pv.kubernetes.io/bind-completed" is properly set

https://github.com/kubernetes/kubernetes/blob/45ce2fae405bfc4d4f1b125a7ec7ba9b69148cb3/pkg/controller/volume/scheduling/scheduler_binder.go#L720-L722

The behavior in the test case only set the annotation, and leave the
volume name to be set by a `FakePVController`.

This will cause a problem for us to run some testcase like scheduler's perf test, scheduling pod with volume as an example, the first try will always hit "unbound immediate PersistentVolumeClaims" exception.

```
        "scheduler-perf-9k75q": *{
                code: UnschedulableAndUnresolvable (3),
                reasons: []string len: 1, cap: 1, [
                        "pod has unbound immediate PersistentVolumeClaims",
                ],
                err: error nil,},
        "scheduler-perf-dp9mg": *{
                code: UnschedulableAndUnresolvable (3),
                reasons: []string len: 1, cap: 1, [
                        "pod has unbound immediate PersistentVolumeClaims",
                ],
                err: error nil,},
		...
```

As a result, the metric data "schedule_attempts_total", or "scheduling_algorithm_duration_seconds" etc. will not accurate enough.

Signed-off-by: Dave Chen <dave.chen@arm.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**


Add one of the following kinds:
/kind bug


**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```


/sig testing
/sig scheduling

