### PR TITLE
[release-1.20] Use non privileged ports in scheduling conformance test

### DIFF
--- a/test/e2e/scheduling/predicates.go
+++ b/test/e2e/scheduling/predicates.go
@@ -1090,11 +1090,11 @@ func createHostPortPodOnNode(f *framework.Framework, podName, ns, hostIP string,
 				{
 					Name:  "agnhost",
 					Image: imageutils.GetE2EImage(imageutils.Agnhost),
-					Args:  []string{"netexec", "--http-port=80", "--udp-port=80"},
+					Args:  []string{"netexec", "--http-port=8080", "--udp-port=8080"},
 					Ports: []v1.ContainerPort{
 						{
 							HostPort:      port,
-							ContainerPort: 80,
+							ContainerPort: 8080,
 							Protocol:      protocol,
 							HostIP:        hostIP,
 						},
@@ -1104,7 +1104,7 @@ func createHostPortPodOnNode(f *framework.Framework, podName, ns, hostIP string,
 							HTTPGet: &v1.HTTPGetAction{
 								Path: "/hostname",
 								Port: intstr.IntOrString{
-									IntVal: int32(80),
+									IntVal: int32(8080),
 								},
 								Scheme: v1.URISchemeHTTP,
 							},


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
backport of https://github.com/kubernetes/kubernetes/pull/97235

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
@kubernetes/sig-scheduling-pr-reviews