### PR TITLE
Add support for new AWS EBS volume types: gp3,io2

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/aws/aws.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/aws/aws.go
@@ -439,8 +439,10 @@ type EC2Metadata interface {
 const (
 	// Provisioned IOPS SSD
 	VolumeTypeIO1 = "io1"
+	VolumeTypeIO2 = "io2"
 	// General Purpose SSD
 	VolumeTypeGP2 = "gp2"
+	VolumeTypeGP3 = "gp3"
 	// Cold HDD (sc1)
 	VolumeTypeSC1 = "sc1"
 	// Throughput Optimized HDD
@@ -2522,10 +2524,10 @@ func (c *Cloud) CreateDisk(volumeOptions *VolumeOptions) (KubernetesVolumeID, er
 	var createType string
 	var iops int64
 	switch volumeOptions.VolumeType {
-	case VolumeTypeGP2, VolumeTypeSC1, VolumeTypeST1:
+	case VolumeTypeGP2, VolumeTypeGP3, VolumeTypeSC1, VolumeTypeST1:
 		createType = volumeOptions.VolumeType
 
-	case VolumeTypeIO1:
+	case VolumeTypeIO1, VolumeTypeIO2:
 		// See http://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateVolume.html
 		// for IOPS constraints. AWS will throw an error if IOPS per GB gets out
 		// of supported bounds, no need to check it here.

--- a/test/e2e/storage/volume_provisioning.go
+++ b/test/e2e/storage/volume_provisioning.go
@@ -214,6 +214,25 @@ var _ = utils.SIGDescribe("Dynamic Provisioning", func() {
 					},
 				},
 				{
+					Name:           "gp3 EBS on AWS",
+					CloudProviders: []string{"aws"},
+					Timeouts:       f.Timeouts,
+					Provisioner:    "kubernetes.io/aws-ebs",
+					Parameters: map[string]string{
+						"type": "gp3",
+						"zone": getRandomClusterZone(c),
+					},
+					ClaimSize:    "1.5Gi",
+					ExpectedSize: "2Gi",
+					PvCheck: func(claim *v1.PersistentVolumeClaim) {
+						volume := testsuites.PVWriteReadSingleNodeCheck(c, f.Timeouts, claim, e2epod.NodeSelection{})
+						gomega.Expect(volume).NotTo(gomega.BeNil(), "get bound PV")
+
+						err := checkAWSEBS(volume, "gp3", false)
+						framework.ExpectNoError(err, "checkAWSEBS gp3")
+					},
+				},
+				{
 					Name:           "io1 EBS on AWS",
 					CloudProviders: []string{"aws"},
 					Timeouts:       f.Timeouts,
@@ -230,6 +249,25 @@ var _ = utils.SIGDescribe("Dynamic Provisioning", func() {
 
 						err := checkAWSEBS(volume, "io1", false)
 						framework.ExpectNoError(err, "checkAWSEBS io1")
+					},
+				},
+				{
+					Name:           "io2 EBS on AWS",
+					CloudProviders: []string{"aws"},
+					Timeouts:       f.Timeouts,
+					Provisioner:    "kubernetes.io/aws-ebs",
+					Parameters: map[string]string{
+						"type":      "io2",
+						"iopsPerGB": "50",
+					},
+					ClaimSize:    "3.5Gi",
+					ExpectedSize: "4Gi", // 4 GiB is minimum for io2
+					PvCheck: func(claim *v1.PersistentVolumeClaim) {
+						volume := testsuites.PVWriteReadSingleNodeCheck(c, f.Timeouts, claim, e2epod.NodeSelection{})
+						gomega.Expect(volume).NotTo(gomega.BeNil(), "get bound PV")
+
+						err := checkAWSEBS(volume, "io2", false)
+						framework.ExpectNoError(err, "checkAWSEBS io2")
 					},
 				},
 				{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
Allows defining a storageclass with gp3 or io2 as volume type on AWS based clusters when using the "legacy" cluster provider.

https://aws.amazon.com/blogs/aws/new-amazon-ebs-gp3-volume-lets-you-provision-performance-separate-from-capacity-and-offers-20-lower-price/
https://aws.amazon.com/blogs/aws/new-ebs-volume-type-io2-more-iops-gib-higher-durability/

https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ebs-volume-types.html


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Add support for new AWS EBS volume types: gp3,io2
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
