### PR TITLE
e2e network granular check poll NodePorts on all nodes

### DIFF
--- a/test/e2e/framework/network/utils.go
+++ b/test/e2e/framework/network/utils.go
@@ -190,12 +190,12 @@ type NetworkingTestConfig struct {
 	ClusterIP string
 	// The SecondaryClusterIP of the Service created by this test config.
 	SecondaryClusterIP string
-	// NodeIP it's an ExternalIP if the node has one,
-	// or an InternalIP if not, for use in nodePort testing.
-	NodeIP string
-	// SecondaryNodeIP it's an ExternalIP of the secondary IP family if the node has one,
-	// or an InternalIP if not, for usein nodePort testing.
-	SecondaryNodeIP string
+	// NodeIPs are the ExternalIPs if the nodes have one,
+	// or the InternalIP if not, for use in nodePort testing.
+	NodeIPs []string
+	// SecondaryNodeIP are the ExternalIP of the secondary IP family if the nodes have one,
+	// or the InternalIPs if not, for use in nodePort testing.
+	SecondaryNodeIPs []string
 	// The http/udp/sctp nodePorts of the Service.
 	NodeHTTPPort int
 	NodeUDPPort  int
@@ -793,14 +793,14 @@ func (config *NetworkingTestConfig) setup(selector map[string]string) {
 		secondaryFamily = v1.IPv4Protocol
 	}
 	// Get Node IPs from the cluster, ExternalIPs take precedence
-	config.NodeIP = e2enode.FirstAddressByTypeAndFamily(nodeList, v1.NodeExternalIP, family)
-	if config.NodeIP == "" {
-		config.NodeIP = e2enode.FirstAddressByTypeAndFamily(nodeList, v1.NodeInternalIP, family)
+	config.NodeIPs = e2enode.CollectAddressesByFamily(nodeList, v1.NodeExternalIP, family)
+	if len(config.NodeIPs) < 2 {
+		config.NodeIPs = e2enode.CollectAddressesByFamily(nodeList, v1.NodeInternalIP, family)
 	}
 	if config.DualStackEnabled {
-		config.SecondaryNodeIP = e2enode.FirstAddressByTypeAndFamily(nodeList, v1.NodeExternalIP, secondaryFamily)
-		if config.SecondaryNodeIP == "" {
-			config.SecondaryNodeIP = e2enode.FirstAddressByTypeAndFamily(nodeList, v1.NodeInternalIP, secondaryFamily)
+		config.SecondaryNodeIPs = e2enode.CollectAddressesByFamily(nodeList, v1.NodeExternalIP, secondaryFamily)
+		if len(config.SecondaryNodeIPs) < 2 {
+			config.SecondaryNodeIPs = e2enode.CollectAddressesByFamily(nodeList, v1.NodeInternalIP, secondaryFamily)
 		}
 	}
 

--- a/test/e2e/framework/node/resource.go
+++ b/test/e2e/framework/node/resource.go
@@ -300,6 +300,15 @@ func CollectAddresses(nodes *v1.NodeList, addressType v1.NodeAddressType) []stri
 	return ips
 }
 
+// CollectAddressesByFamily returns a list of addresses of the given addressType and family for the given list of nodes
+func CollectAddressesByFamily(nodes *v1.NodeList, addressType v1.NodeAddressType, family v1.IPFamily) []string {
+	ips := []string{}
+	for i := range nodes.Items {
+		ips = append(ips, GetAddressesByTypeAndFamily(&nodes.Items[i], addressType, family)...)
+	}
+	return ips
+}
+
 // PickIP picks one public node IP
 func PickIP(c clientset.Interface) (string, error) {
 	publicIps, err := GetPublicIps(c)

--- a/test/e2e/network/dual_stack.go
+++ b/test/e2e/network/dual_stack.go
@@ -447,8 +447,10 @@ var _ = SIGDescribe("[Feature:IPv6DualStackAlphaFeature] [LinuxOnly]", func() {
 			ginkgo.By(fmt.Sprintf("dialing(http) %v --> %v:%v (config.clusterIP)", config.TestContainerPod.Name, config.SecondaryClusterIP, e2enetwork.ClusterHTTPPort))
 			config.DialFromTestContainer("http", config.SecondaryClusterIP, e2enetwork.ClusterHTTPPort, config.MaxTries, 0, config.EndpointHostnames())
 
-			ginkgo.By(fmt.Sprintf("dialing(http) %v --> %v:%v (nodeIP)", config.TestContainerPod.Name, config.SecondaryNodeIP, config.NodeHTTPPort))
-			config.DialFromTestContainer("http", config.SecondaryNodeIP, config.NodeHTTPPort, config.MaxTries, 0, config.EndpointHostnames())
+			for _, ip := range config.SecondaryNodeIPs {
+				ginkgo.By(fmt.Sprintf("dialing(http) %v --> %v:%v (nodeIP)", config.TestContainerPod.Name, ip, config.NodeHTTPPort))
+				config.DialFromTestContainer("http", ip, config.NodeHTTPPort, config.MaxTries, 0, config.EndpointHostnames())
+			}
 		})
 
 		ginkgo.It("should function for pod-Service: udp", func() {
@@ -456,8 +458,10 @@ var _ = SIGDescribe("[Feature:IPv6DualStackAlphaFeature] [LinuxOnly]", func() {
 			ginkgo.By(fmt.Sprintf("dialing(udp) %v --> %v:%v (config.clusterIP)", config.TestContainerPod.Name, config.SecondaryClusterIP, e2enetwork.ClusterUDPPort))
 			config.DialFromTestContainer("udp", config.SecondaryClusterIP, e2enetwork.ClusterUDPPort, config.MaxTries, 0, config.EndpointHostnames())
 
-			ginkgo.By(fmt.Sprintf("dialing(udp) %v --> %v:%v (nodeIP)", config.TestContainerPod.Name, config.SecondaryNodeIP, config.NodeUDPPort))
-			config.DialFromTestContainer("udp", config.SecondaryNodeIP, config.NodeUDPPort, config.MaxTries, 0, config.EndpointHostnames())
+			for _, ip := range config.SecondaryNodeIPs {
+				ginkgo.By(fmt.Sprintf("dialing(udp) %v --> %v:%v (nodeIP)", config.TestContainerPod.Name, ip, config.NodeUDPPort))
+				config.DialFromTestContainer("udp", ip, config.NodeUDPPort, config.MaxTries, 0, config.EndpointHostnames())
+			}
 		})
 
 		// [Disruptive] because it conflicts with tests that call CheckSCTPModuleLoadedOnNodes
@@ -466,26 +470,32 @@ var _ = SIGDescribe("[Feature:IPv6DualStackAlphaFeature] [LinuxOnly]", func() {
 			ginkgo.By(fmt.Sprintf("dialing(sctp) %v --> %v:%v (config.clusterIP)", config.TestContainerPod.Name, config.SecondaryClusterIP, e2enetwork.ClusterSCTPPort))
 			config.DialFromTestContainer("sctp", config.SecondaryClusterIP, e2enetwork.ClusterSCTPPort, config.MaxTries, 0, config.EndpointHostnames())
 
-			ginkgo.By(fmt.Sprintf("dialing(sctp) %v --> %v:%v (nodeIP)", config.TestContainerPod.Name, config.SecondaryNodeIP, config.NodeSCTPPort))
-			config.DialFromTestContainer("sctp", config.SecondaryNodeIP, config.NodeSCTPPort, config.MaxTries, 0, config.EndpointHostnames())
+			for _, ip := range config.SecondaryNodeIPs {
+				ginkgo.By(fmt.Sprintf("dialing(sctp) %v --> %v:%v (nodeIP)", config.TestContainerPod.Name, ip, config.NodeSCTPPort))
+				config.DialFromTestContainer("sctp", ip, config.NodeSCTPPort, config.MaxTries, 0, config.EndpointHostnames())
+			}
 		})
 
 		ginkgo.It("should function for node-Service: http", func() {
 			config := e2enetwork.NewNetworkingTestConfig(f, e2enetwork.EnableDualStack, e2enetwork.UseHostNetwork)
-			ginkgo.By(fmt.Sprintf("dialing(http) %v (node) --> %v:%v (config.clusterIP)", config.SecondaryNodeIP, config.SecondaryClusterIP, e2enetwork.ClusterHTTPPort))
+			ginkgo.By(fmt.Sprintf("dialing(http) %v (node) --> %v:%v (config.clusterIP)", config.HostTestContainerPod.Spec.NodeName, config.SecondaryClusterIP, e2enetwork.ClusterHTTPPort))
 			config.DialFromNode("http", config.SecondaryClusterIP, e2enetwork.ClusterHTTPPort, config.MaxTries, 0, config.EndpointHostnames())
 
-			ginkgo.By(fmt.Sprintf("dialing(http) %v (node) --> %v:%v (nodeIP)", config.SecondaryNodeIP, config.SecondaryNodeIP, config.NodeHTTPPort))
-			config.DialFromNode("http", config.SecondaryNodeIP, config.NodeHTTPPort, config.MaxTries, 0, config.EndpointHostnames())
+			for _, ip := range config.SecondaryNodeIPs {
+				ginkgo.By(fmt.Sprintf("dialing(http) %v (node) --> %v:%v (nodeIP)", config.HostTestContainerPod.Spec.NodeName, ip, config.NodeHTTPPort))
+				config.DialFromNode("http", ip, config.NodeHTTPPort, config.MaxTries, 0, config.EndpointHostnames())
+			}
 		})
 
 		ginkgo.It("should function for node-Service: udp", func() {
 			config := e2enetwork.NewNetworkingTestConfig(f, e2enetwork.EnableDualStack, e2enetwork.UseHostNetwork)
-			ginkgo.By(fmt.Sprintf("dialing(udp) %v (node) --> %v:%v (config.clusterIP)", config.SecondaryNodeIP, config.SecondaryClusterIP, e2enetwork.ClusterUDPPort))
+			ginkgo.By(fmt.Sprintf("dialing(udp) %v (node) --> %v:%v (config.clusterIP)", config.HostTestContainerPod.Spec.NodeName, config.SecondaryClusterIP, e2enetwork.ClusterUDPPort))
 			config.DialFromNode("udp", config.SecondaryClusterIP, e2enetwork.ClusterUDPPort, config.MaxTries, 0, config.EndpointHostnames())
 
-			ginkgo.By(fmt.Sprintf("dialing(udp) %v (node) --> %v:%v (nodeIP)", config.SecondaryNodeIP, config.SecondaryNodeIP, config.NodeUDPPort))
-			config.DialFromNode("udp", config.SecondaryNodeIP, config.NodeUDPPort, config.MaxTries, 0, config.EndpointHostnames())
+			for _, ip := range config.SecondaryNodeIPs {
+				ginkgo.By(fmt.Sprintf("dialing(udp) %v (node) --> %v:%v (nodeIP)", config.HostTestContainerPod.Spec.NodeName, ip, config.NodeUDPPort))
+				config.DialFromNode("udp", ip, config.NodeUDPPort, config.MaxTries, 0, config.EndpointHostnames())
+			}
 		})
 
 		ginkgo.It("should function for endpoint-Service: http", func() {
@@ -493,8 +503,10 @@ var _ = SIGDescribe("[Feature:IPv6DualStackAlphaFeature] [LinuxOnly]", func() {
 			ginkgo.By(fmt.Sprintf("dialing(http) %v (endpoint) --> %v:%v (config.clusterIP)", config.EndpointPods[0].Name, config.SecondaryClusterIP, e2enetwork.ClusterHTTPPort))
 			config.DialFromEndpointContainer("http", config.SecondaryClusterIP, e2enetwork.ClusterHTTPPort, config.MaxTries, 0, config.EndpointHostnames())
 
-			ginkgo.By(fmt.Sprintf("dialing(http) %v (endpoint) --> %v:%v (nodeIP)", config.EndpointPods[0].Name, config.SecondaryNodeIP, config.NodeHTTPPort))
-			config.DialFromEndpointContainer("http", config.SecondaryNodeIP, config.NodeHTTPPort, config.MaxTries, 0, config.EndpointHostnames())
+			for _, ip := range config.SecondaryNodeIPs {
+				ginkgo.By(fmt.Sprintf("dialing(http) %v (endpoint) --> %v:%v (nodeIP)", config.EndpointPods[0].Name, ip, config.NodeHTTPPort))
+				config.DialFromEndpointContainer("http", ip, config.NodeHTTPPort, config.MaxTries, 0, config.EndpointHostnames())
+			}
 		})
 
 		ginkgo.It("should function for endpoint-Service: udp", func() {
@@ -502,8 +514,10 @@ var _ = SIGDescribe("[Feature:IPv6DualStackAlphaFeature] [LinuxOnly]", func() {
 			ginkgo.By(fmt.Sprintf("dialing(udp) %v (endpoint) --> %v:%v (config.clusterIP)", config.EndpointPods[0].Name, config.SecondaryClusterIP, e2enetwork.ClusterUDPPort))
 			config.DialFromEndpointContainer("udp", config.SecondaryClusterIP, e2enetwork.ClusterUDPPort, config.MaxTries, 0, config.EndpointHostnames())
 
-			ginkgo.By(fmt.Sprintf("dialing(udp) %v (endpoint) --> %v:%v (nodeIP)", config.EndpointPods[0].Name, config.SecondaryNodeIP, config.NodeUDPPort))
-			config.DialFromEndpointContainer("udp", config.SecondaryNodeIP, config.NodeUDPPort, config.MaxTries, 0, config.EndpointHostnames())
+			for _, ip := range config.SecondaryNodeIPs {
+				ginkgo.By(fmt.Sprintf("dialing(udp) %v (endpoint) --> %v:%v (nodeIP)", config.EndpointPods[0].Name, ip, config.NodeUDPPort))
+				config.DialFromEndpointContainer("udp", ip, config.NodeUDPPort, config.MaxTries, 0, config.EndpointHostnames())
+			}
 		})
 
 		ginkgo.It("should update endpoints: http", func() {

--- a/test/e2e/network/networking.go
+++ b/test/e2e/network/networking.go
@@ -155,12 +155,15 @@ var _ = SIGDescribe("Networking", func() {
 			if err != nil {
 				framework.Failf("failed dialing endpoint, %v", err)
 			}
-			ginkgo.By(fmt.Sprintf("dialing(http) %v --> %v:%v (nodeIP)", config.TestContainerPod.Name, config.NodeIP, config.NodeHTTPPort))
 
-			err = config.DialFromTestContainer("http", config.NodeIP, config.NodeHTTPPort, config.MaxTries, 0, config.EndpointHostnames())
-			if err != nil {
-				framework.Failf("failed dialing endpoint, %v", err)
+			for _, ip := range config.NodeIPs {
+				ginkgo.By(fmt.Sprintf("dialing(http) %v --> %v:%v (nodeIP)", config.TestContainerPod.Name, ip, config.NodeHTTPPort))
+				err = config.DialFromTestContainer("http", ip, config.NodeHTTPPort, config.MaxTries, 0, config.EndpointHostnames())
+				if err != nil {
+					framework.Failf("failed dialing endpoint, %v", err)
+				}
 			}
+
 		})
 
 		ginkgo.It("should function for pod-Service: udp", func() {
@@ -171,10 +174,12 @@ var _ = SIGDescribe("Networking", func() {
 				framework.Failf("failed dialing endpoint, %v", err)
 			}
 
-			ginkgo.By(fmt.Sprintf("dialing(udp) %v --> %v:%v (nodeIP)", config.TestContainerPod.Name, config.NodeIP, config.NodeUDPPort))
-			err = config.DialFromTestContainer("udp", config.NodeIP, config.NodeUDPPort, config.MaxTries, 0, config.EndpointHostnames())
-			if err != nil {
-				framework.Failf("failed dialing endpoint, %v", err)
+			for _, ip := range config.NodeIPs {
+				ginkgo.By(fmt.Sprintf("dialing(udp) %v --> %v:%v (nodeIP)", config.TestContainerPod.Name, ip, config.NodeUDPPort))
+				err = config.DialFromTestContainer("udp", ip, config.NodeUDPPort, config.MaxTries, 0, config.EndpointHostnames())
+				if err != nil {
+					framework.Failf("failed dialing endpoint, %v", err)
+				}
 			}
 		})
 
@@ -186,38 +191,44 @@ var _ = SIGDescribe("Networking", func() {
 			if err != nil {
 				framework.Failf("failed dialing endpoint, %v", err)
 			}
-			ginkgo.By(fmt.Sprintf("dialing(sctp) %v --> %v:%v (nodeIP)", config.TestContainerPod.Name, config.NodeIP, config.NodeSCTPPort))
-			err = config.DialFromTestContainer("sctp", config.NodeIP, config.NodeSCTPPort, config.MaxTries, 0, config.EndpointHostnames())
-			if err != nil {
-				framework.Failf("failed dialing endpoint, %v", err)
+			for _, ip := range config.NodeIPs {
+				ginkgo.By(fmt.Sprintf("dialing(sctp) %v --> %v:%v (nodeIP)", config.TestContainerPod.Name, ip, config.NodeSCTPPort))
+				err = config.DialFromTestContainer("sctp", ip, config.NodeSCTPPort, config.MaxTries, 0, config.EndpointHostnames())
+				if err != nil {
+					framework.Failf("failed dialing endpoint, %v", err)
+				}
 			}
 		})
 
 		ginkgo.It("should function for node-Service: http", func() {
 			config := e2enetwork.NewNetworkingTestConfig(f, e2enetwork.UseHostNetwork)
-			ginkgo.By(fmt.Sprintf("dialing(http) %v (node) --> %v:%v (config.clusterIP)", config.NodeIP, config.ClusterIP, e2enetwork.ClusterHTTPPort))
+			ginkgo.By(fmt.Sprintf("dialing(http) %v (node) --> %v:%v (config.clusterIP)", config.HostTestContainerPod.Spec.NodeName, config.ClusterIP, e2enetwork.ClusterHTTPPort))
 			err := config.DialFromNode("http", config.ClusterIP, e2enetwork.ClusterHTTPPort, config.MaxTries, 0, config.EndpointHostnames())
 			if err != nil {
 				framework.Failf("failed dialing endpoint, %v", err)
 			}
-			ginkgo.By(fmt.Sprintf("dialing(http) %v (node) --> %v:%v (nodeIP)", config.NodeIP, config.NodeIP, config.NodeHTTPPort))
-			err = config.DialFromNode("http", config.NodeIP, config.NodeHTTPPort, config.MaxTries, 0, config.EndpointHostnames())
-			if err != nil {
-				framework.Failf("failed dialing endpoint, %v", err)
+			for _, ip := range config.NodeIPs {
+				ginkgo.By(fmt.Sprintf("dialing(http) %v (node) --> %v:%v (nodeIP)", config.HostTestContainerPod.Spec.NodeName, ip, config.NodeHTTPPort))
+				err = config.DialFromNode("http", ip, config.NodeHTTPPort, config.MaxTries, 0, config.EndpointHostnames())
+				if err != nil {
+					framework.Failf("failed dialing endpoint, %v", err)
+				}
 			}
 		})
 
 		ginkgo.It("should function for node-Service: udp", func() {
 			config := e2enetwork.NewNetworkingTestConfig(f, e2enetwork.UseHostNetwork)
-			ginkgo.By(fmt.Sprintf("dialing(udp) %v (node) --> %v:%v (config.clusterIP)", config.NodeIP, config.ClusterIP, e2enetwork.ClusterUDPPort))
+			ginkgo.By(fmt.Sprintf("dialing(udp) %v (node) --> %v:%v (config.clusterIP)", config.HostTestContainerPod.Spec.NodeName, config.ClusterIP, e2enetwork.ClusterUDPPort))
 			err := config.DialFromNode("udp", config.ClusterIP, e2enetwork.ClusterUDPPort, config.MaxTries, 0, config.EndpointHostnames())
 			if err != nil {
 				framework.Failf("failed dialing endpoint, %v", err)
 			}
-			ginkgo.By(fmt.Sprintf("dialing(udp) %v (node) --> %v:%v (nodeIP)", config.NodeIP, config.NodeIP, config.NodeUDPPort))
-			err = config.DialFromNode("udp", config.NodeIP, config.NodeUDPPort, config.MaxTries, 0, config.EndpointHostnames())
-			if err != nil {
-				framework.Failf("failed dialing endpoint, %v", err)
+			for _, ip := range config.NodeIPs {
+				ginkgo.By(fmt.Sprintf("dialing(udp) %v (node) --> %v:%v (nodeIP)", config.HostTestContainerPod.Spec.NodeName, ip, config.NodeUDPPort))
+				err = config.DialFromNode("udp", ip, config.NodeUDPPort, config.MaxTries, 0, config.EndpointHostnames())
+				if err != nil {
+					framework.Failf("failed dialing endpoint, %v", err)
+				}
 			}
 		})
 
@@ -225,15 +236,17 @@ var _ = SIGDescribe("Networking", func() {
 		ginkgo.It("should function for node-Service: sctp [Feature:SCTPConnectivity][Disruptive]", func() {
 			ginkgo.Skip("Skipping SCTP node to service test until DialFromNode supports SCTP #96482")
 			config := e2enetwork.NewNetworkingTestConfig(f, e2enetwork.EnableSCTP)
-			ginkgo.By(fmt.Sprintf("dialing(sctp) %v (node) --> %v:%v (config.clusterIP)", config.NodeIP, config.ClusterIP, e2enetwork.ClusterSCTPPort))
+			ginkgo.By(fmt.Sprintf("dialing(sctp) %v (node) --> %v:%v (config.clusterIP)", config.HostTestContainerPod.Spec.NodeName, config.ClusterIP, e2enetwork.ClusterSCTPPort))
 			err := config.DialFromNode("sctp", config.ClusterIP, e2enetwork.ClusterSCTPPort, config.MaxTries, 0, config.EndpointHostnames())
 			if err != nil {
 				framework.Failf("failed dialing endpoint, %v", err)
 			}
-			ginkgo.By(fmt.Sprintf("dialing(sctp) %v (node) --> %v:%v (nodeIP)", config.NodeIP, config.NodeIP, config.NodeSCTPPort))
-			err = config.DialFromNode("sctp", config.NodeIP, config.NodeSCTPPort, config.MaxTries, 0, config.EndpointHostnames())
-			if err != nil {
-				framework.Failf("failed dialing endpoint, %v", err)
+			for _, ip := range config.NodeIPs {
+				ginkgo.By(fmt.Sprintf("dialing(sctp) %v (node) --> %v:%v (nodeIP)", config.HostTestContainerPod.Spec.NodeName, ip, config.NodeSCTPPort))
+				err = config.DialFromNode("sctp", ip, config.NodeSCTPPort, config.MaxTries, 0, config.EndpointHostnames())
+				if err != nil {
+					framework.Failf("failed dialing endpoint, %v", err)
+				}
 			}
 		})
 
@@ -244,10 +257,12 @@ var _ = SIGDescribe("Networking", func() {
 			if err != nil {
 				framework.Failf("failed dialing endpoint, %v", err)
 			}
-			ginkgo.By(fmt.Sprintf("dialing(http) %v (endpoint) --> %v:%v (nodeIP)", config.EndpointPods[0].Name, config.NodeIP, config.NodeHTTPPort))
-			err = config.DialFromEndpointContainer("http", config.NodeIP, config.NodeHTTPPort, config.MaxTries, 0, config.EndpointHostnames())
-			if err != nil {
-				framework.Failf("failed dialing endpoint, %v", err)
+			for _, ip := range config.NodeIPs {
+				ginkgo.By(fmt.Sprintf("dialing(http) %v (endpoint) --> %v:%v (nodeIP)", config.EndpointPods[0].Name, ip, config.NodeHTTPPort))
+				err = config.DialFromEndpointContainer("http", ip, config.NodeHTTPPort, config.MaxTries, 0, config.EndpointHostnames())
+				if err != nil {
+					framework.Failf("failed dialing endpoint, %v", err)
+				}
 			}
 		})
 
@@ -258,11 +273,13 @@ var _ = SIGDescribe("Networking", func() {
 			if err != nil {
 				framework.Failf("failed dialing endpoint, %v", err)
 			}
+			for _, ip := range config.NodeIPs {
+				ginkgo.By(fmt.Sprintf("dialing(udp) %v (endpoint) --> %v:%v (nodeIP)", config.EndpointPods[0].Name, ip, config.NodeUDPPort))
+				err = config.DialFromEndpointContainer("udp", ip, config.NodeUDPPort, config.MaxTries, 0, config.EndpointHostnames())
+				if err != nil {
+					framework.Failf("failed dialing endpoint, %v", err)
+				}
 
-			ginkgo.By(fmt.Sprintf("dialing(udp) %v (endpoint) --> %v:%v (nodeIP)", config.EndpointPods[0].Name, config.NodeIP, config.NodeUDPPort))
-			err = config.DialFromEndpointContainer("udp", config.NodeIP, config.NodeUDPPort, config.MaxTries, 0, config.EndpointHostnames())
-			if err != nil {
-				framework.Failf("failed dialing endpoint, %v", err)
 			}
 		})
 
@@ -274,11 +291,12 @@ var _ = SIGDescribe("Networking", func() {
 			if err != nil {
 				framework.Failf("failed dialing endpoint, %v", err)
 			}
-
-			ginkgo.By(fmt.Sprintf("dialing(sctp) %v (endpoint) --> %v:%v (nodeIP)", config.EndpointPods[0].Name, config.NodeIP, config.NodeSCTPPort))
-			err = config.DialFromEndpointContainer("sctp", config.NodeIP, config.NodeSCTPPort, config.MaxTries, 0, config.EndpointHostnames())
-			if err != nil {
-				framework.Failf("failed dialing endpoint, %v", err)
+			for _, ip := range config.NodeIPs {
+				ginkgo.By(fmt.Sprintf("dialing(sctp) %v (endpoint) --> %v:%v (nodeIP)", config.EndpointPods[0].Name, ip, config.NodeSCTPPort))
+				err = config.DialFromEndpointContainer("sctp", ip, config.NodeSCTPPort, config.MaxTries, 0, config.EndpointHostnames())
+				if err != nil {
+					framework.Failf("failed dialing endpoint, %v", err)
+				}
 			}
 		})
 
@@ -295,10 +313,12 @@ var _ = SIGDescribe("Networking", func() {
 			if err != nil {
 				framework.Failf("failed dialing endpoint, %v", err)
 			}
-			ginkgo.By(fmt.Sprintf("dialing(http) %v (endpoint) --> %v:%v (nodeIP)", config.EndpointPods[0].Name, config.NodeIP, config.NodeHTTPPort))
-			err = config.DialFromEndpointContainer("http", config.NodeIP, config.NodeHTTPPort, config.MaxTries, 0, config.EndpointHostnames())
-			if err != nil {
-				framework.Failf("failed dialing endpoint, %v", err)
+			for _, ip := range config.NodeIPs {
+				ginkgo.By(fmt.Sprintf("dialing(http) %v (endpoint) --> %v:%v (nodeIP)", config.EndpointPods[0].Name, ip, config.NodeHTTPPort))
+				err = config.DialFromEndpointContainer("http", ip, config.NodeHTTPPort, config.MaxTries, 0, config.EndpointHostnames())
+				if err != nil {
+					framework.Failf("failed dialing endpoint, %v", err)
+				}
 			}
 			// Dial second service
 			ginkgo.By(fmt.Sprintf("dialing(http) %v (endpoint) --> %v:%v (svc2.clusterIP)", config.EndpointPods[0].Name, svc2.Spec.ClusterIP, e2enetwork.ClusterHTTPPort))
@@ -306,11 +326,12 @@ var _ = SIGDescribe("Networking", func() {
 			if err != nil {
 				framework.Failf("failed dialing endpoint, %v", err)
 			}
-
-			ginkgo.By(fmt.Sprintf("dialing(http) %v (endpoint) --> %v:%v (nodeIP)", config.EndpointPods[0].Name, config.NodeIP, httpPort))
-			err = config.DialFromEndpointContainer("http", config.NodeIP, httpPort, config.MaxTries, 0, config.EndpointHostnames())
-			if err != nil {
-				framework.Failf("failed dialing endpoint, %v", err)
+			for _, ip := range config.NodeIPs {
+				ginkgo.By(fmt.Sprintf("dialing(http) %v (endpoint) --> %v:%v (nodeIP)", config.EndpointPods[0].Name, ip, httpPort))
+				err = config.DialFromEndpointContainer("http", ip, httpPort, config.MaxTries, 0, config.EndpointHostnames())
+				if err != nil {
+					framework.Failf("failed dialing endpoint, %v", err)
+				}
 			}
 
 			ginkgo.By("deleting the original node port service")
@@ -322,10 +343,12 @@ var _ = SIGDescribe("Networking", func() {
 			if err != nil {
 				framework.Failf("failed dialing endpoint, %v", err)
 			}
-			ginkgo.By(fmt.Sprintf("dialing(http) %v (endpoint) --> %v:%v (nodeIP)", config.EndpointPods[0].Name, config.NodeIP, httpPort))
-			err = config.DialFromEndpointContainer("http", config.NodeIP, httpPort, config.MaxTries, 0, config.EndpointHostnames())
-			if err != nil {
-				framework.Failf("failed dialing endpoint, %v", err)
+			for _, ip := range config.NodeIPs {
+				ginkgo.By(fmt.Sprintf("dialing(http) %v (endpoint) --> %v:%v (nodeIP)", config.EndpointPods[0].Name, ip, httpPort))
+				err = config.DialFromEndpointContainer("http", ip, httpPort, config.MaxTries, 0, config.EndpointHostnames())
+				if err != nil {
+					framework.Failf("failed dialing endpoint, %v", err)
+				}
 			}
 		})
 
@@ -366,47 +389,57 @@ var _ = SIGDescribe("Networking", func() {
 		// Slow because we confirm that the nodePort doesn't serve traffic, which requires a period of polling.
 		ginkgo.It("should update nodePort: http [Slow]", func() {
 			config := e2enetwork.NewNetworkingTestConfig(f, e2enetwork.UseHostNetwork)
-			ginkgo.By(fmt.Sprintf("dialing(http) %v (node) --> %v:%v (nodeIP) and getting ALL host endpoints", config.NodeIP, config.NodeIP, config.NodeHTTPPort))
-			err := config.DialFromNode("http", config.NodeIP, config.NodeHTTPPort, config.MaxTries, 0, config.EndpointHostnames())
-			if err != nil {
-				framework.Failf("Error dialing http from node: %v", err)
+			for _, ip := range config.NodeIPs {
+				ginkgo.By(fmt.Sprintf("dialing(http) %v (node) --> %v:%v (nodeIP) and getting ALL host endpoints", config.HostTestContainerPod.Spec.NodeName, ip, config.NodeHTTPPort))
+				err := config.DialFromNode("http", ip, config.NodeHTTPPort, config.MaxTries, 0, config.EndpointHostnames())
+				if err != nil {
+					framework.Failf("Error dialing http from node: %v", err)
+				}
 			}
 			ginkgo.By("Deleting the node port access point")
 			config.DeleteNodePortService()
 
-			ginkgo.By(fmt.Sprintf("dialing(http) %v (node) --> %v:%v (nodeIP) and getting ZERO host endpoints", config.NodeIP, config.NodeIP, config.NodeHTTPPort))
-			err = config.DialFromNode("http", config.NodeIP, config.NodeHTTPPort, config.MaxTries, config.MaxTries, sets.NewString())
-			if err != nil {
-				framework.Failf("Error dialing http from node: %v", err)
+			for _, ip := range config.NodeIPs {
+				ginkgo.By(fmt.Sprintf("dialing(http) %v (node) --> %v:%v (nodeIP) and getting ZERO host endpoints", config.HostTestContainerPod.Spec.NodeName, ip, config.NodeHTTPPort))
+				err := config.DialFromNode("http", ip, config.NodeHTTPPort, config.MaxTries, config.MaxTries, sets.NewString())
+				if err != nil {
+					framework.Failf("Error dialing http from node: %v", err)
+				}
 			}
 		})
 
 		// quick validation of udp, next test confirms that this services update as well after endpoints are removed, but is slower.
 		ginkgo.It("should support basic nodePort: udp functionality", func() {
 			config := e2enetwork.NewNetworkingTestConfig(f, e2enetwork.UseHostNetwork)
-			ginkgo.By(fmt.Sprintf("dialing(udp) %v (node) --> %v:%v (nodeIP) and getting ALL host endpoints", config.NodeIP, config.NodeIP, config.NodeUDPPort))
-			err := config.DialFromNode("udp", config.NodeIP, config.NodeUDPPort, config.MaxTries, 0, config.EndpointHostnames())
-			if err != nil {
-				framework.Failf("Failure validating that nodePort service WAS forwarding properly: %v", err)
+			for _, ip := range config.NodeIPs {
+				ginkgo.By(fmt.Sprintf("dialing(udp) %v (node) --> %v:%v (nodeIP) and getting ALL host endpoints", config.HostTestContainerPod.Spec.NodeName, ip, config.NodeUDPPort))
+				err := config.DialFromNode("udp", ip, config.NodeUDPPort, config.MaxTries, 0, config.EndpointHostnames())
+				if err != nil {
+					framework.Failf("Failure validating that nodePort service WAS forwarding properly: %v", err)
+				}
 			}
 		})
 
 		// Slow because we confirm that the nodePort doesn't serve traffic, which requires a period of polling.
 		ginkgo.It("should update nodePort: udp [Slow]", func() {
 			config := e2enetwork.NewNetworkingTestConfig(f, e2enetwork.UseHostNetwork)
-			ginkgo.By(fmt.Sprintf("dialing(udp) %v (node) --> %v:%v (nodeIP) and getting ALL host endpoints", config.NodeIP, config.NodeIP, config.NodeUDPPort))
-			err := config.DialFromNode("udp", config.NodeIP, config.NodeUDPPort, config.MaxTries, 0, config.EndpointHostnames())
-			if err != nil {
-				framework.Failf("Failure validating that nodePort service WAS forwarding properly: %v", err)
+			for _, ip := range config.NodeIPs {
+				ginkgo.By(fmt.Sprintf("dialing(udp) %v (node) --> %v:%v (nodeIP) and getting ALL host endpoints", config.HostTestContainerPod.Spec.NodeName, ip, config.NodeUDPPort))
+				err := config.DialFromNode("udp", ip, config.NodeUDPPort, config.MaxTries, 0, config.EndpointHostnames())
+				if err != nil {
+					framework.Failf("Failure validating that nodePort service WAS forwarding properly: %v", err)
+				}
 			}
 
 			ginkgo.By("Deleting the node port access point")
 			config.DeleteNodePortService()
 
-			ginkgo.By(fmt.Sprintf("dialing(udp) %v (node) --> %v:%v (nodeIP) and getting ZERO host endpoints", config.NodeIP, config.NodeIP, config.NodeUDPPort))
-			err = config.DialFromNode("udp", config.NodeIP, config.NodeUDPPort, config.MaxTries, config.MaxTries, sets.NewString())
-			if err != nil {
-				framework.Failf("Failure validating that node port service STOPPED removed properly: %v", err)
+			for _, ip := range config.NodeIPs {
+				ginkgo.By(fmt.Sprintf("dialing(udp) %v (node) --> %v:%v (nodeIP) and getting ZERO host endpoints", config.HostTestContainerPod.Spec.NodeName, ip, config.NodeUDPPort))
+				err := config.DialFromNode("udp", ip, config.NodeUDPPort, config.MaxTries, config.MaxTries, sets.NewString())
+				if err != nil {
+					framework.Failf("Failure validating that node port service STOPPED removed properly: %v", err)
+				}
 			}
 		})
 
@@ -477,10 +510,12 @@ var _ = SIGDescribe("Networking", func() {
 				framework.Failf("failed dialing endpoint, %v", err)
 			}
 
-			ginkgo.By(fmt.Sprintf("dialing(udp) %v --> %v:%v (nodeIP)", config.TestContainerPod.Name, config.NodeIP, config.NodeUDPPort))
-			err = config.DialFromTestContainer("udp", config.NodeIP, config.NodeUDPPort, config.MaxTries, 0, config.EndpointHostnames())
-			if err != nil {
-				framework.Failf("failed dialing endpoint, %v", err)
+			for _, ip := range config.NodeIPs {
+				ginkgo.By(fmt.Sprintf("dialing(udp) %v --> %v:%v (nodeIP)", config.TestContainerPod.Name, ip, config.NodeUDPPort))
+				err = config.DialFromTestContainer("udp", ip, config.NodeUDPPort, config.MaxTries, 0, config.EndpointHostnames())
+				if err != nil {
+					framework.Failf("failed dialing endpoint, %v", err)
+				}
 			}
 		})
 
@@ -491,34 +526,36 @@ var _ = SIGDescribe("Networking", func() {
 			config := e2enetwork.NewNetworkingTestConfig(f, e2enetwork.UseHostNetwork, e2enetwork.EndpointsUseHostNetwork)
 
 			ginkgo.By("pod-Service(hostNetwork): http")
-
 			ginkgo.By(fmt.Sprintf("dialing(http) %v --> %v:%v (config.clusterIP)", config.TestContainerPod.Name, config.ClusterIP, e2enetwork.ClusterHTTPPort))
 			err := config.DialFromTestContainer("http", config.ClusterIP, e2enetwork.ClusterHTTPPort, config.MaxTries, 0, config.EndpointHostnames())
 			if err != nil {
 				framework.Failf("failed dialing endpoint, %v", err)
 			}
-			ginkgo.By(fmt.Sprintf("dialing(http) %v --> %v:%v (nodeIP)", config.TestContainerPod.Name, config.NodeIP, config.NodeHTTPPort))
-			err = config.DialFromTestContainer("http", config.NodeIP, config.NodeHTTPPort, config.MaxTries, 0, config.EndpointHostnames())
-			if err != nil {
-				framework.Failf("failed dialing endpoint, %v", err)
-			}
-
 			ginkgo.By("node-Service(hostNetwork): http")
-
-			ginkgo.By(fmt.Sprintf("dialing(http) %v (node) --> %v:%v (config.clusterIP)", config.NodeIP, config.ClusterIP, e2enetwork.ClusterHTTPPort))
+			ginkgo.By(fmt.Sprintf("dialing(http) %v (node) --> %v:%v (config.clusterIP)", config.HostTestContainerPod.Spec.NodeName, config.ClusterIP, e2enetwork.ClusterHTTPPort))
 			config.DialFromNode("http", config.ClusterIP, e2enetwork.ClusterHTTPPort, config.MaxTries, 0, config.EndpointHostnames())
-			ginkgo.By(fmt.Sprintf("dialing(http) %v (node) --> %v:%v (nodeIP)", config.NodeIP, config.NodeIP, config.NodeHTTPPort))
-			config.DialFromNode("http", config.NodeIP, config.NodeHTTPPort, config.MaxTries, 0, config.EndpointHostnames())
 
 			ginkgo.By("node-Service(hostNetwork): udp")
-
-			ginkgo.By(fmt.Sprintf("dialing(udp) %v (node) --> %v:%v (config.clusterIP)", config.NodeIP, config.ClusterIP, e2enetwork.ClusterUDPPort))
+			ginkgo.By(fmt.Sprintf("dialing(udp) %v (node) --> %v:%v (config.clusterIP)", config.HostTestContainerPod.Spec.NodeName, config.ClusterIP, e2enetwork.ClusterUDPPort))
 			config.DialFromNode("udp", config.ClusterIP, e2enetwork.ClusterUDPPort, config.MaxTries, 0, config.EndpointHostnames())
-			ginkgo.By(fmt.Sprintf("dialing(udp) %v (node) --> %v:%v (nodeIP)", config.NodeIP, config.NodeIP, config.NodeUDPPort))
-			config.DialFromNode("udp", config.NodeIP, config.NodeUDPPort, config.MaxTries, 0, config.EndpointHostnames())
+
+			for _, ip := range config.NodeIPs {
+				ginkgo.By(fmt.Sprintf("dialing(http) %v --> %v:%v (nodeIP)", config.TestContainerPod.Name, ip, config.NodeHTTPPort))
+				err = config.DialFromTestContainer("http", ip, config.NodeHTTPPort, config.MaxTries, 0, config.EndpointHostnames())
+				if err != nil {
+					framework.Failf("failed dialing endpoint, %v", err)
+				}
+
+				ginkgo.By("node-Service(hostNetwork): http")
+				ginkgo.By(fmt.Sprintf("dialing(http) %v (node) --> %v:%v (nodeIP)", config.HostTestContainerPod.Spec.NodeName, ip, config.NodeHTTPPort))
+				config.DialFromNode("http", ip, config.NodeHTTPPort, config.MaxTries, 0, config.EndpointHostnames())
+
+				ginkgo.By("node-Service(hostNetwork): udp")
+				ginkgo.By(fmt.Sprintf("dialing(udp) %v (node) --> %v:%v (nodeIP)", config.HostTestContainerPod.Spec.NodeName, ip, config.NodeUDPPort))
+				config.DialFromNode("udp", ip, config.NodeUDPPort, config.MaxTries, 0, config.EndpointHostnames())
+			}
 
 			ginkgo.By("handle large requests: http(hostNetwork)")
-
 			ginkgo.By(fmt.Sprintf("dialing(http) %v --> %v:%v (config.clusterIP)", config.TestContainerPod.Name, config.ClusterIP, e2enetwork.ClusterHTTPPort))
 			message := strings.Repeat("42", 1000)
 			err = config.DialEchoFromTestContainer("http", config.ClusterIP, e2enetwork.ClusterHTTPPort, config.MaxTries, 0, message)


### PR DESCRIPTION

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

The e2e test for services, was picking a NodeIP randomly from the
nodes that were running in the cluster. This IP is used to probe
the NodePort services.

It may happen that the test container poll the NodePort service
in the same node, not testing if the NodePort is available from
outside so, if the cluster has a firewall that blocks access
to the NodePorts, the test is sucessful when it should fail.

Since NodePort must listen in all nodes, we ckeck the NodePort
in all the cluster nodes.


**Which issue(s) this PR fixes**:
Fixes #95339

**Special notes for your reviewer**:

```release-note
NONE
```
