### PR TITLE
Revert "Use host IP instead of localhost for control plane component …

### DIFF
--- a/cluster/gce/config-default.sh
+++ b/cluster/gce/config-default.sh
@@ -554,9 +554,6 @@ export KUBE_APISERVER_HEALTHCHECK_ON_HOST_IP="${KUBE_APISERVER_HEALTHCHECK_ON_HO
 # ETCD_PROGRESS_NOTIFY_INTERVAL defines the interval for etcd watch progress notify events.
 export ETCD_PROGRESS_NOTIFY_INTERVAL="${ETCD_PROGRESS_NOTIFY_INTERVAL:-10m}"
 
-# Use host IP instead of localhost in control plane kubeconfig files.
-export KUBECONFIG_USE_HOST_IP="${KUBECONFIG_USE_HOST_IP:-false}"
-
 # Optional: Install Pigz on Windows.
 # Pigz is a multi-core optimized version of unzip.exe.
 # It improves container image pull performance since most time is spent

--- a/cluster/gce/config-test.sh
+++ b/cluster/gce/config-test.sh
@@ -590,9 +590,6 @@ export KUBE_APISERVER_HEALTHCHECK_ON_HOST_IP="${KUBE_APISERVER_HEALTHCHECK_ON_HO
 # ETCD_PROGRESS_NOTIFY_INTERVAL defines the interval for etcd watch progress notify events.
 export ETCD_PROGRESS_NOTIFY_INTERVAL="${ETCD_PROGRESS_NOTIFY_INTERVAL:-10m}"
 
-# Use host IP instead of localhost in control plane kubeconfig files.
-export KUBECONFIG_USE_HOST_IP="${KUBECONFIG_USE_HOST_IP:-false}"
-
 # Optional: Install Pigz on Windows.
 # Pigz is a multi-core optimized version of unzip.exe.
 # It improves container image pull performance since most time is spent

--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -1266,18 +1266,11 @@ EOF
   fi
 }
 
-# Create kubeconfig files for control plane components.
 function create-kubeconfig {
   local component=$1
   local token=$2
   echo "Creating kubeconfig file for component ${component}"
   mkdir -p "/etc/srv/kubernetes/${component}"
-
-  local kube_apiserver="localhost"
-  if [[ ${KUBECONFIG_USE_HOST_IP:-} == "true" ]] ; then
-    kube_apiserver=$(hostname -i)
-  fi
-  
   cat <<EOF >"/etc/srv/kubernetes/${component}/kubeconfig"
 apiVersion: v1
 kind: Config
@@ -1289,7 +1282,7 @@ clusters:
 - name: local
   cluster:
     insecure-skip-tls-verify: true
-    server: https://${kube_apiserver}:443
+    server: https://localhost:443
 contexts:
 - context:
     cluster: local


### PR DESCRIPTION
…kubeconfig files."

This reverts commit 49afcfa5f2062ebc8cb03c5f57df751a6b8468e2.

Commit 49afcfa5f2062ebc8cb03c5f57df751a6b8468e2 inadvertently allows unverified TLS connection over non-loopback interface. This creates a risk to leak the replayable bootstrap token. 

**What type of PR is this?**

/kind bug security

```release-note
NONE
```