### PR TITLE
Fix stale object causing a panic on DELETE event

### DIFF
--- a/staging/src/k8s.io/client-go/tools/watch/informerwatcher.go
+++ b/staging/src/k8s.io/client-go/tools/watch/informerwatcher.go
@@ -127,7 +127,7 @@ func NewIndexerInformerWatcher(lw cache.ListerWatcher, objType runtime.Object) (
 				// We have no means of passing the additional information down using
 				// watch API based on watch.Event but the caller can filter such
 				// objects by checking if metadata.deletionTimestamp is set
-				obj = staleObj
+				obj = staleObj.Obj
 			}
 
 			e.push(watch.Event{

--- a/staging/src/k8s.io/client-go/tools/watch/informerwatcher_test.go
+++ b/staging/src/k8s.io/client-go/tools/watch/informerwatcher_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/davecgh/go-spew/spew"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -275,4 +276,89 @@ func TestNewInformerWatcher(t *testing.T) {
 		})
 	}
 
+}
+
+// TestInformerWatcherDeletedFinalStateUnknown tests the code path when `DeleteFunc`
+// in `NewIndexerInformerWatcher` receives a `cache.DeletedFinalStateUnknown`
+// object from the underlying `DeltaFIFO`. The triggering condition is described
+// at https://github.com/kubernetes/kubernetes/blob/dc39ab2417bfddcec37be4011131c59921fdbe98/staging/src/k8s.io/client-go/tools/cache/delta_fifo.go#L736-L739.
+//
+// Code from @liggitt
+func TestInformerWatcherDeletedFinalStateUnknown(t *testing.T) {
+	listCalls := 0
+	watchCalls := 0
+	lw := &cache.ListWatch{
+		ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+			retval := &corev1.SecretList{}
+			if listCalls == 0 {
+				// Return a list with items in it
+				retval.ResourceVersion = "1"
+				retval.Items = []corev1.Secret{{ObjectMeta: metav1.ObjectMeta{Name: "secret1", Namespace: "ns1", ResourceVersion: "123"}}}
+			} else {
+				// Return empty lists after the first call
+				retval.ResourceVersion = "2"
+			}
+			listCalls++
+			return retval, nil
+		},
+		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+			w := watch.NewFake()
+			if options.ResourceVersion == "1" {
+				go func() {
+					// Close with a "Gone" error when trying to start a watch from the first list
+					w.Error(&apierrors.NewGone("gone").ErrStatus)
+					w.Stop()
+				}()
+			}
+			watchCalls++
+			return w, nil
+		},
+	}
+	_, _, w, done := NewIndexerInformerWatcher(lw, &corev1.Secret{})
+
+	// Expect secret add
+	select {
+	case event, ok := <-w.ResultChan():
+		if !ok {
+			t.Fatal("unexpected close")
+		}
+		if event.Type != watch.Added {
+			t.Fatalf("expected Added event, got %#v", event)
+		}
+		if event.Object.(*corev1.Secret).ResourceVersion != "123" {
+			t.Fatalf("expected added Secret with rv=123, got %#v", event.Object)
+		}
+	case <-time.After(time.Second * 10):
+		t.Fatal("timeout")
+	}
+
+	// Expect secret delete because the relist was missing the secret
+	select {
+	case event, ok := <-w.ResultChan():
+		if !ok {
+			t.Fatal("unexpected close")
+		}
+		if event.Type != watch.Deleted {
+			t.Fatalf("expected Deleted event, got %#v", event)
+		}
+		if event.Object.(*corev1.Secret).ResourceVersion != "123" {
+			t.Fatalf("expected deleted Secret with rv=123, got %#v", event.Object)
+		}
+	case <-time.After(time.Second * 10):
+		t.Fatal("timeout")
+	}
+
+	w.Stop()
+	select {
+	case <-done:
+	case <-time.After(time.Second * 10):
+		t.Fatal("timeout")
+	}
+
+	if listCalls < 2 {
+		t.Fatalf("expected at least 2 list calls, got %d", listCalls)
+	}
+	if watchCalls < 1 {
+		t.Fatalf("expected at least 1 watch call, got %d", watchCalls)
+	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
This PR fixes a panic when the deleted object is stale. `cache.DeletedFinalStateUnknown` does not implement `runtime.Object` and can cause a panic at https://github.com/kubernetes/kubernetes/blob/0e2bf1e49f704b6d5f56d2c7ec8e10cfb2545bb6/staging/src/k8s.io/client-go/tools/watch/informerwatcher.go#L135
In such case, I believe it is supposed to get `runtime.Obj` from the `Obj` field of `cache.DeletedFinalStateUnknown` instead, similar to other usages https://github.com/kubernetes/kubernetes/search?q=%22DeletedFinalStateUnknown%22+%22.Obj%22.

Unfortunately, I don't know how to add a test for this, but we patched our `k8s.io/client-go` with this change in February and the panic below has gone away since.
```
E0211 23:10:08.521653       1 runtime.go:73] Observed a panic: &runtime.TypeAssertionError{_interface:(*runtime._type)(nil), concrete:(*runtime._type)(0x3c75500), asserted:(*runtime._type)(0x3ae5a80), missingMethod:"DeepCopyObject"} (interface conversion: cache.DeletedFinalStateUnknown is not runtime.Object: missing method DeepCopyObject)
goroutine 73 [running]:
<redacted>/vendor/k8s.io/apimachinery/pkg/util/runtime.logPanic(0x3aad640, 0xc000c3a3f0)
	/go/src/<redacted>/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:69 +0x7b
<redacted>/vendor/k8s.io/apimachinery/pkg/util/runtime.HandleCrash(0x0, 0x0, 0x0)
	/go/src/<redacted>/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:51 +0x82
panic(0x3aad640, 0xc000c3a3f0)
	/usr/local/go/src/runtime/panic.go:522 +0x1b5
<redacted>/vendor/k8s.io/apimachinery/pkg/util/runtime.HandleCrash(0x0, 0x0, 0x0)
	/go/src/<redacted>/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:58 +0x105
panic(0x3aad640, 0xc000c3a3f0)
	/usr/local/go/src/runtime/panic.go:522 +0x1b5
<redacted>/vendor/k8s.io/client-go/tools/watch.NewIndexerInformerWatcher.func3(0x3c75500, 0xc000c059a0)
	/go/src/<redacted>/vendor/k8s.io/client-go/tools/watch/informerwatcher.go:135 +0x9d
<redacted>/vendor/k8s.io/client-go/tools/cache.ResourceEventHandlerFuncs.OnDelete(...)
	/go/src/<redacted>/vendor/k8s.io/client-go/tools/cache/controller.go:209
<redacted>/vendor/k8s.io/client-go/tools/cache.newInformer.func1(0x3ac89a0, 0xc000e36ec0, 0x1, 0xc000e36ec0)
	/go/src/<redacted>/vendor/k8s.io/client-go/tools/cache/controller.go:373 +0x37f
<redacted>/vendor/k8s.io/client-go/tools/cache.(*DeltaFIFO).Pop(0xc0003f91e0, 0xc000bfdf80, 0x0, 0x0, 0x0, 0x0)
	/go/src/<redacted>/vendor/k8s.io/client-go/tools/cache/delta_fifo.go:422 +0x209
<redacted>/vendor/k8s.io/client-go/tools/cache.(*controller).processLoop(0xc000ef9680)
	/go/src/<redacted>/vendor/k8s.io/client-go/tools/cache/controller.go:150 +0x40
<redacted>/vendor/k8s.io/apimachinery/pkg/util/wait.JitterUntil.func1(0xc000031f70)
	/go/src/<redacted>/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:152 +0x54
<redacted>/vendor/k8s.io/apimachinery/pkg/util/wait.JitterUntil(0xc00061df70, 0x3b9aca00, 0x0, 0xc0009a8701, 0xc000c17920)
	/go/src/<redacted>/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:153 +0xf8
<redacted>/vendor/k8s.io/apimachinery/pkg/util/wait.Until(...)
	/go/src/<redacted>/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:88
<redacted>/vendor/k8s.io/client-go/tools/cache.(*controller).Run(0xc000ef9680, 0xc000c17920)
	/go/src/<redacted>/vendor/k8s.io/client-go/tools/cache/controller.go:124 +0x2a8
<redacted>/vendor/k8s.io/client-go/tools/watch.NewIndexerInformerWatcher.func4(0xc000c179e0, 0xc000bfde60, 0x4bf21e0, 0xc000ef9680, 0xc000d12cc0)
	/go/src/<redacted>/vendor/k8s.io/client-go/tools/watch/informerwatcher.go:146 +0x90
created by <redacted>/vendor/k8s.io/client-go/tools/watch.NewIndexerInformerWatcher
	/go/src/<redacted>/vendor/k8s.io/client-go/tools/watch/informerwatcher.go:143 +0x3b0
panic: interface conversion: cache.DeletedFinalStateUnknown is not runtime.Object: missing method DeepCopyObject [recovered]
	panic: interface conversion: cache.DeletedFinalStateUnknown is not runtime.Object: missing method DeepCopyObject [recovered]
	panic: interface conversion: cache.DeletedFinalStateUnknown is not runtime.Object: missing method DeepCopyObject

goroutine 73 [running]:
<redacted>/vendor/k8s.io/apimachinery/pkg/util/runtime.HandleCrash(0x0, 0x0, 0x0)
	/go/src/<redacted>/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:58 +0x105
panic(0x3aad640, 0xc000c3a3f0)
	/usr/local/go/src/runtime/panic.go:522 +0x1b5
<redacted>/vendor/k8s.io/apimachinery/pkg/util/runtime.HandleCrash(0x0, 0x0, 0x0)
	/go/src/<redacted>/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:58 +0x105
panic(0x3aad640, 0xc000c3a3f0)
	/usr/local/go/src/runtime/panic.go:522 +0x1b5
<redacted>/vendor/k8s.io/client-go/tools/watch.NewIndexerInformerWatcher.func3(0x3c75500, 0xc000c059a0)
	/go/src/<redacted>/vendor/k8s.io/client-go/tools/watch/informerwatcher.go:135 +0x9d
<redacted>/vendor/k8s.io/client-go/tools/cache.ResourceEventHandlerFuncs.OnDelete(...)
	/go/src/<redacted>/vendor/k8s.io/client-go/tools/cache/controller.go:209
<redacted>/vendor/k8s.io/client-go/tools/cache.newInformer.func1(0x3ac89a0, 0xc000e36ec0, 0x1, 0xc000e36ec0)
	/go/src/<redacted>/vendor/k8s.io/client-go/tools/cache/controller.go:373 +0x37f
<redacted>/vendor/k8s.io/client-go/tools/cache.(*DeltaFIFO).Pop(0xc0003f91e0, 0xc000bfdf80, 0x0, 0x0, 0x0, 0x0)
	/go/src/<redacted>/vendor/k8s.io/client-go/tools/cache/delta_fifo.go:422 +0x209
<redacted>/vendor/k8s.io/client-go/tools/cache.(*controller).processLoop(0xc000ef9680)
	/go/src/<redacted>/vendor/k8s.io/client-go/tools/cache/controller.go:150 +0x40
<redacted>/vendor/k8s.io/apimachinery/pkg/util/wait.JitterUntil.func1(0xc000031f70)
	/go/src/<redacted>/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:152 +0x54
<redacted>/vendor/k8s.io/apimachinery/pkg/util/wait.JitterUntil(0xc00061df70, 0x3b9aca00, 0x0, 0xc0009a8701, 0xc000c17920)
	/go/src/<redacted>/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:153 +0xf8
<redacted>/vendor/k8s.io/apimachinery/pkg/util/wait.Until(...)
	/go/src/<redacted>/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:88
<redacted>/vendor/k8s.io/client-go/tools/cache.(*controller).Run(0xc000ef9680, 0xc000c17920)
	/go/src/<redacted>/vendor/k8s.io/client-go/tools/cache/controller.go:124 +0x2a8
<redacted>/vendor/k8s.io/client-go/tools/watch.NewIndexerInformerWatcher.func4(0xc000c179e0, 0xc000bfde60, 0x4bf21e0, 0xc000ef9680, 0xc000d12cc0)
	/go/src/<redacted>/vendor/k8s.io/client-go/tools/watch/informerwatcher.go:146 +0x90
created by <redacted>/vendor/k8s.io/client-go/tools/watch.NewIndexerInformerWatcher
	/go/src/<redacted>/vendor/k8s.io/client-go/tools/watch/informerwatcher.go:143 +0x3b0
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
I'm open to write a test for this fix if someone can point me to the right direction.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
