### PR TITLE
Include the path in the dial address if scheme is UDS

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/preflight/checks.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/preflight/checks.go
@@ -36,7 +36,11 @@ func (EtcdConnection) serverReachable(connURL *url.URL) bool {
 	if scheme == "http" || scheme == "https" || scheme == "tcp" {
 		scheme = "tcp"
 	}
-	if conn, err := net.DialTimeout(scheme, connURL.Host, connectionTimeout); err == nil {
+	addr := connURL.Host
+	if scheme == "unix" {
+		addr = connURL.Host + connURL.Path
+	}
+	if conn, err := net.DialTimeout(scheme, addr, connectionTimeout); err == nil {
 		defer conn.Close()
 		return true
 	}

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/preflight/checks_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/preflight/checks_test.go
@@ -37,14 +37,18 @@ func TestParseServerURIGood(t *testing.T) {
 }
 
 func TestParseServerURIGoodUnix(t *testing.T) {
-	connURL, err := parseServerURI("unix://127.0.0.1:21002112605")
+	connURL, err := parseServerURI("unix://127.0.0.1:21002112605/etcd.socket")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	reference := "127.0.0.1:21002112605"
-	if connURL.Host != reference {
+	host := "127.0.0.1:21002112605"
+	if connURL.Host != host {
 		t.Fatalf("server uri was not parsed correctly, host %s was invalid", connURL.Host)
+	}
+	path := "/etcd.socket"
+	if connURL.Path != path {
+		t.Fatalf("server uri was not parsed correctly, path %s was invalid", connURL.Path)
 	}
 }
 


### PR DESCRIPTION
/kind bug
/sig api-machinery

To dial to a UDS address, the url.Path part must be included in the address.