### PR TITLE
[WIP] Add ACCEPT rule for health check node port

### DIFF
--- a/pkg/proxy/iptables/proxier.go
+++ b/pkg/proxy/iptables/proxier.go
@@ -1238,6 +1238,17 @@ func (proxier *Proxier) syncProxyRules() {
 			}
 		}
 
+		// Capture healthCheckNodePorts
+		if hcNodePort, exists := serviceUpdateResult.HCServiceNodePorts[svcName.NamespacedName]; exists {
+			writeLine(proxier.filterRules,
+				"-A", string(fwChain),
+				"-m", "comment", "--comment", fmt.Sprintf(`"%s healthCheckNodePort"`, svcNameString),
+				"-m", protocol, "-p", protocol,
+				"--dport", strconv.Itoa(int(hcNodePort)),
+				"-j", "ACCEPT",
+			)
+		}
+
 		// Capture nodeports.  If we had more than 2 rules it might be
 		// worthwhile to make a new per-service chain for nodeport rules, but
 		// with just 2 rules it ends up being a waste and a cognitive burden.


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This PR adds iptable ACCEPT rule for service.spec.healthCheckNodePort if there is any.  Currently the accessibility of `spec.healthCheckNodePort` depends on the default policy in iptables.


**Which issue(s) this PR fixes**:
Fixes #97225 

**Special notes for your reviewer**:
This PR only covers change for iptables.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
N/A