### PR TITLE
kubeadm: support certificate chain validation

### DIFF
--- a/cmd/kubeadm/app/cmd/phases/init/certs.go
+++ b/cmd/kubeadm/app/cmd/phases/init/certs.go
@@ -263,7 +263,7 @@ func runCertPhase(cert *certsphase.KubeadmCert, caCert *certsphase.KubeadmCert) 
 			return nil
 		}
 
-		if certData, _, err := pkiutil.TryLoadCertAndKeyFromDisk(data.CertificateDir(), cert.BaseName); err == nil {
+		if certData, intermediates, err := pkiutil.TryLoadCertChainFromDisk(data.CertificateDir(), cert.BaseName); err == nil {
 			certsphase.CheckCertificatePeriodValidity(cert.BaseName, certData)
 
 			caCertData, err := pkiutil.TryLoadCertFromDisk(data.CertificateDir(), caCert.BaseName)
@@ -273,7 +273,7 @@ func runCertPhase(cert *certsphase.KubeadmCert, caCert *certsphase.KubeadmCert) 
 
 			certsphase.CheckCertificatePeriodValidity(caCert.BaseName, caCertData)
 
-			if err := certData.CheckSignatureFrom(caCertData); err != nil {
+			if err := pkiutil.VerifyCertChain(certData, intermediates, caCertData); err != nil {
 				return errors.Wrapf(err, "[certs] certificate %s not signed by CA certificate %s", cert.BaseName, caCert.BaseName)
 			}
 

--- a/cmd/kubeadm/app/phases/certs/certs.go
+++ b/cmd/kubeadm/app/phases/certs/certs.go
@@ -229,8 +229,14 @@ func writeCertificateFilesIfNotExist(pkiDir string, baseName string, signingCert
 
 	// Checks if the signed certificate exists in the PKI directory
 	if pkiutil.CertOrKeyExist(pkiDir, baseName) {
-		// Try to load signed certificate .crt and .key from the PKI directory
-		signedCert, _, err := pkiutil.TryLoadCertAndKeyFromDisk(pkiDir, baseName)
+		// Try to load key from the PKI directory
+		_, err := pkiutil.TryLoadKeyFromDisk(pkiDir, baseName)
+		if err != nil {
+			return errors.Wrapf(err, "failure loading %s key", baseName)
+		}
+
+		// Try to load certificate from the PKI directory
+		signedCert, intermediates, err := pkiutil.TryLoadCertChainFromDisk(pkiDir, baseName)
 		if err != nil {
 			return errors.Wrapf(err, "failure loading %s certificate", baseName)
 		}
@@ -238,7 +244,7 @@ func writeCertificateFilesIfNotExist(pkiDir string, baseName string, signingCert
 		CheckCertificatePeriodValidity(baseName, signedCert)
 
 		// Check if the existing cert is signed by the given CA
-		if err := signedCert.CheckSignatureFrom(signingCert); err != nil {
+		if err := pkiutil.VerifyCertChain(signedCert, intermediates, signingCert); err != nil {
 			return errors.Errorf("certificate %s is not signed by corresponding CA", baseName)
 		}
 
@@ -416,10 +422,17 @@ func validateSignedCert(l certKeyLocation) error {
 	return validateSignedCertWithCA(l, caCert)
 }
 
-// validateSignedCertWithCA tries to load a certificate and validate it with the given caCert
+// validateSignedCertWithCA tries to load a certificate and private key and
+// validates that the cert is signed by the given caCert
 func validateSignedCertWithCA(l certKeyLocation, caCert *x509.Certificate) error {
-	// Try to load key and signed certificate
-	signedCert, _, err := pkiutil.TryLoadCertAndKeyFromDisk(l.pkiDir, l.baseName)
+	// Try to load key from the PKI directory
+	_, err := pkiutil.TryLoadKeyFromDisk(l.pkiDir, l.baseName)
+	if err != nil {
+		return errors.Wrapf(err, "failure loading key for %s", l.baseName)
+	}
+
+	// Try to load certificate from the PKI directory
+	signedCert, intermediates, err := pkiutil.TryLoadCertChainFromDisk(l.pkiDir, l.baseName)
 	if err != nil {
 		return errors.Wrapf(err, "failure loading certificate for %s", l.uxName)
 	}
@@ -427,7 +440,7 @@ func validateSignedCertWithCA(l certKeyLocation, caCert *x509.Certificate) error
 	CheckCertificatePeriodValidity(l.uxName, signedCert)
 
 	// Check if the cert is signed by the CA
-	if err := signedCert.CheckSignatureFrom(caCert); err != nil {
+	if err := pkiutil.VerifyCertChain(signedCert, intermediates, caCert); err != nil {
 		return errors.Wrapf(err, "certificate %s is not signed by corresponding CA", l.uxName)
 	}
 	return nil

--- a/cmd/kubeadm/app/util/pkiutil/pki_helpers_test.go
+++ b/cmd/kubeadm/app/util/pkiutil/pki_helpers_test.go
@@ -199,9 +199,24 @@ func TestWriteCert(t *testing.T) {
 	actual := WriteCert(tmpdir, "foo", caCert)
 	if actual != nil {
 		t.Errorf(
-			"failed WriteCertAndKey with an error: %v",
+			"failed WriteCert with an error: %v",
 			actual,
 		)
+	}
+}
+
+func TestWriteCertBundle(t *testing.T) {
+	tmpdir, err := ioutil.TempDir("", "")
+	if err != nil {
+		t.Fatalf("Couldn't create tmpdir")
+	}
+	defer os.RemoveAll(tmpdir)
+
+	certs := []*x509.Certificate{{}, {}}
+
+	actual := WriteCertBundle(tmpdir, "foo", certs)
+	if actual != nil {
+		t.Errorf("failed WriteCertBundle with an error: %v", actual)
 	}
 }
 
@@ -309,14 +324,14 @@ func TestTryLoadCertAndKeyFromDisk(t *testing.T) {
 		Config: certutil.Config{CommonName: "kubernetes"},
 	})
 	if err != nil {
-		t.Errorf(
+		t.Fatalf(
 			"failed to create cert and key with an error: %v",
 			err,
 		)
 	}
 	err = WriteCertAndKey(tmpdir, "foo", caCert, caKey)
 	if err != nil {
-		t.Errorf(
+		t.Fatalf(
 			"failed to write cert and key with an error: %v",
 			err,
 		)
@@ -366,14 +381,14 @@ func TestTryLoadCertFromDisk(t *testing.T) {
 		Config: certutil.Config{CommonName: "kubernetes"},
 	})
 	if err != nil {
-		t.Errorf(
+		t.Fatalf(
 			"failed to create cert and key with an error: %v",
 			err,
 		)
 	}
 	err = WriteCert(tmpdir, "foo", caCert)
 	if err != nil {
-		t.Errorf(
+		t.Fatalf(
 			"failed to write cert and key with an error: %v",
 			err,
 		)
@@ -406,6 +421,91 @@ func TestTryLoadCertFromDisk(t *testing.T) {
 					"failed TryLoadCertAndKeyFromDisk:\n\texpected: %t\n\t  actual: %t",
 					rt.expected,
 					(actual == nil),
+				)
+			}
+		})
+	}
+}
+
+func TestTryLoadCertChainFromDisk(t *testing.T) {
+	tmpdir, err := ioutil.TempDir("", "")
+	if err != nil {
+		t.Fatalf("Couldn't create tmpdir")
+	}
+	defer os.RemoveAll(tmpdir)
+
+	caCert, caKey, err := NewCertificateAuthority(&CertConfig{
+		Config: certutil.Config{CommonName: "Intermediate CA"},
+	})
+	if err != nil {
+		t.Fatalf("failed to create intermediate CA cert and key with an error: %v", err)
+	}
+
+	cert, _, err := NewCertAndKey(caCert, caKey, &CertConfig{
+		Config: certutil.Config{
+			CommonName: "kubernetes",
+			Usages:     []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		},
+	})
+	if err != nil {
+		t.Fatalf("failed to create leaf cert and key with an error: %v", err)
+	}
+
+	err = WriteCert(tmpdir, "leaf", cert)
+	if err != nil {
+		t.Fatalf("failed to write cert: %v", err)
+	}
+
+	bundle := []*x509.Certificate{cert, caCert}
+	err = WriteCertBundle(tmpdir, "bundle", bundle)
+	if err != nil {
+		t.Fatalf("failed to write cert bundle: %v", err)
+	}
+
+	var tests = []struct {
+		desc          string
+		path          string
+		name          string
+		expected      bool
+		intermediates int
+	}{
+		{
+			desc:          "empty path and name",
+			path:          "",
+			name:          "",
+			expected:      false,
+			intermediates: 0,
+		},
+		{
+			desc:          "leaf certificate",
+			path:          tmpdir,
+			name:          "leaf",
+			expected:      true,
+			intermediates: 0,
+		},
+		{
+			desc:          "certificate bundle",
+			path:          tmpdir,
+			name:          "bundle",
+			expected:      true,
+			intermediates: 1,
+		},
+	}
+	for _, rt := range tests {
+		t.Run(rt.desc, func(t *testing.T) {
+			_, intermediates, actual := TryLoadCertChainFromDisk(rt.path, rt.name)
+			if (actual == nil) != rt.expected {
+				t.Errorf(
+					"failed TryLoadCertChainFromDisk:\n\texpected: %t\n\t  actual: %t",
+					rt.expected,
+					(actual == nil),
+				)
+			}
+			if len(intermediates) != rt.intermediates {
+				t.Errorf(
+					"TryLoadCertChainFromDisk returned the wrong number of intermediate certificates:\n\texpected: %d\n\t  actual: %d",
+					rt.intermediates,
+					len(intermediates),
 				)
 			}
 		})
@@ -802,5 +902,99 @@ func TestRemoveDuplicateAltNames(t *testing.T) {
 		if !reflect.DeepEqual(tt.args, tt.want) {
 			t.Errorf("Wanted %v, got %v", tt.want, tt.args)
 		}
+	}
+}
+
+func TestVerifyCertChain(t *testing.T) {
+	tmpdir, err := ioutil.TempDir("", "")
+	if err != nil {
+		t.Fatalf("Couldn't create tmpdir")
+	}
+	defer os.RemoveAll(tmpdir)
+
+	rootCert1, rootKey1, err := NewCertificateAuthority(&CertConfig{
+		Config: certutil.Config{CommonName: "Root CA 1"},
+	})
+	if err != nil {
+		t.Errorf("failed to create root CA cert and key with an error: %v", err)
+	}
+
+	leafCert1, _, err := NewCertAndKey(rootCert1, rootKey1, &CertConfig{
+		Config: certutil.Config{
+			CommonName: "Leaf Certificate 1",
+			Usages:     []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		},
+	})
+	if err != nil {
+		t.Errorf("failed to create leaf cert and key with an error: %v", err)
+	}
+
+	rootCert2, rootKey2, err := NewCertificateAuthority(&CertConfig{
+		Config: certutil.Config{CommonName: "Root CA 2"},
+	})
+	if err != nil {
+		t.Errorf("failed to create root CA cert and key with an error: %v", err)
+	}
+
+	intCert2, intKey2, err := NewIntermediateCertificateAuthority(rootCert2, rootKey2, &CertConfig{
+		Config: certutil.Config{
+			CommonName: "Intermediate CA 2",
+			Usages:     []x509.ExtKeyUsage{},
+		},
+	})
+	if err != nil {
+		t.Errorf("failed to create intermediate CA cert and key with an error: %v", err)
+	}
+
+	leafCert2, _, err := NewCertAndKey(intCert2, intKey2, &CertConfig{
+		Config: certutil.Config{
+			CommonName: "Leaf Certificate 2",
+			Usages:     []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		},
+	})
+	if err != nil {
+		t.Errorf("failed to create leaf cert and key with an error: %v", err)
+	}
+
+	var tests = []struct {
+		desc          string
+		leaf          *x509.Certificate
+		intermediates []*x509.Certificate
+		root          *x509.Certificate
+		expected      bool
+	}{
+		{
+			desc:          "without any intermediate CAs",
+			leaf:          leafCert1,
+			intermediates: []*x509.Certificate{},
+			root:          rootCert1,
+			expected:      true,
+		},
+		{
+			desc:          "missing intermediate CA",
+			leaf:          leafCert2,
+			intermediates: []*x509.Certificate{},
+			root:          rootCert2,
+			expected:      false,
+		},
+		{
+			desc:          "with one intermediate CA",
+			leaf:          leafCert2,
+			intermediates: []*x509.Certificate{intCert2},
+			root:          rootCert2,
+			expected:      true,
+		},
+	}
+	for _, rt := range tests {
+		t.Run(rt.desc, func(t *testing.T) {
+			actual := VerifyCertChain(rt.leaf, rt.intermediates, rt.root)
+			if (actual == nil) != rt.expected {
+				t.Errorf(
+					"failed VerifyCertChain:\n\texpected: %t\n\t  actual: %t",
+					rt.expected,
+					(actual == nil),
+				)
+			}
+		})
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Fixes an issue where some kubeadm phases fail if a certificate file contains a certificate chain with one or more intermediate CA certificates. This two-tier CA configuration is required to allow a short expiry to be used on the CA used to sign certificates without resorting to frequent manual rotations of the root CA.

The proposal is to change the validation algorithm from requiring that a certificate was signed directly by the root CA to requiring that there is a valid certificate chain back to the root CA. The fix itself is quite simple, most of the complexity is in the PKI helper functions required to unit test this change properly.

**Which issue(s) this PR fixes**:

Fixes the first part of https://github.com/kubernetes/kubeadm/issues/2360

**Special notes for your reviewer**:

N/A

**Does this PR introduce a user-facing change?**:

```release-note
kubeadm: add support for certificate chain validation. When using kubeadm in external CA mode, this allows an intermediate CA to be used to sign the certificates. The intermediate CA certificate must be appended to each signed certificate for this to work correctly.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

N/A
