### PR TITLE
Change GetBootTime to work specificaly with FreeBSD

### DIFF
--- a/pkg/kubelet/util/BUILD
+++ b/pkg/kubelet/util/BUILD
@@ -9,7 +9,8 @@ load(
 go_test(
     name = "go_default_test",
     srcs = [
-        "bootime_util_linux_test.go",
+        "boottime_util_freebsd_test.go",
+        "boottime_util_linux_test.go",
         "util_test.go",
         "util_unix_test.go",
         "util_windows_test.go",
@@ -45,6 +46,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "boottime_util_darwin.go",
+        "boottime_util_freebsd.go",
         "boottime_util_linux.go",
         "doc.go",
         "nodelease.go",

--- a/pkg/kubelet/util/boottime_util_freebsd.go
+++ b/pkg/kubelet/util/boottime_util_freebsd.go
@@ -1,7 +1,7 @@
-// +build linux
+// +build freebsd
 
 /*
-Copyright 2018 The Kubernetes Authors.
+Copyright 2020 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -23,14 +23,17 @@ import (
 	"time"
 
 	"golang.org/x/sys/unix"
+	"unsafe"
 )
 
 // GetBootTime returns the time at which the machine was started, truncated to the nearest second
 func GetBootTime() (time.Time, error) {
 	currentTime := time.Now()
-	var info unix.Sysinfo_t
-	if err := unix.Sysinfo(&info); err != nil {
-		return time.Time{}, fmt.Errorf("error getting system uptime: %s", err)
+	ts := &unix.Timeval{}
+	_, _, e1 := unix.Syscall(uintptr(unix.SYS_CLOCK_GETTIME), uintptr(unix.CLOCK_UPTIME), uintptr(unsafe.Pointer(ts)), 0)
+	if e1 != 0 {
+		return time.Time{}, fmt.Errorf("error getting system uptime")
 	}
-	return currentTime.Add(-time.Duration(info.Uptime) * time.Second).Truncate(time.Second), nil
+
+	return currentTime.Add(-time.Duration(ts.Sec) * time.Second).Truncate(time.Second), nil
 }

--- a/pkg/kubelet/util/boottime_util_freebsd_test.go
+++ b/pkg/kubelet/util/boottime_util_freebsd_test.go
@@ -1,7 +1,7 @@
-// +build linux
+// +build freebsd
 
 /*
-Copyright 2018 The Kubernetes Authors.
+Copyright 2020 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -19,18 +19,18 @@ limitations under the License.
 package util
 
 import (
-	"fmt"
+	"testing"
 	"time"
-
-	"golang.org/x/sys/unix"
 )
 
-// GetBootTime returns the time at which the machine was started, truncated to the nearest second
-func GetBootTime() (time.Time, error) {
-	currentTime := time.Now()
-	var info unix.Sysinfo_t
-	if err := unix.Sysinfo(&info); err != nil {
-		return time.Time{}, fmt.Errorf("error getting system uptime: %s", err)
+func TestGetBootTime(t *testing.T) {
+	boottime, err := GetBootTime()
+
+	if err != nil {
+		t.Errorf("Unable to get system uptime")
 	}
-	return currentTime.Add(-time.Duration(info.Uptime) * time.Second).Truncate(time.Second), nil
+
+	if !boottime.After(time.Time{}) {
+		t.Errorf("Invalid system uptime")
+	}
 }

--- a/pkg/kubelet/util/boottime_util_linux_test.go
+++ b/pkg/kubelet/util/boottime_util_linux_test.go
@@ -1,4 +1,4 @@
-// +build freebsd linux
+// +build linux
 
 /*
 Copyright 2018 The Kubernetes Authors.


### PR DESCRIPTION
Signed-off-by: Ricardo Pchevuzinske Katz <ricardo.katz@gmail.com>

/kind cleanup

**What this PR does / why we need it**: Kubernetes have some specific files to work in FreeBSD, but it doesn't actually compile in FreeBSD because the mode to get the uptime used in GetBootTime differs from Linux (and FreeBSD does not have a sysinfo syscall).

This PR uses the following syscall: https://www.freebsd.org/cgi/man.cgi?query=clock_gettime&apropos=0&sektion=0&manpath=FreeBSD+12.2-RELEASE&arch=default&format=html

**Special notes for your reviewer**: 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

/sig node
/priority backlog
