### PR TITLE
Update cloud-controller-manager samples to read --cloud-config flag

### DIFF
--- a/cmd/cloud-controller-manager/main.go
+++ b/cmd/cloud-controller-manager/main.go
@@ -33,7 +33,8 @@ import (
 	"time"
 
 	"github.com/spf13/pflag"
-	cloudprovider "k8s.io/cloud-provider"
+
+	"k8s.io/cloud-provider"
 	"k8s.io/cloud-provider/app"
 	cloudcontrollerconfig "k8s.io/cloud-provider/app/config"
 	"k8s.io/cloud-provider/options"
@@ -56,9 +57,6 @@ const (
 func main() {
 	rand.Seed(time.Now().UnixNano())
 
-	// cloudProviderConfigFile shows an sample of parse config file from flag option
-	var flagset *pflag.FlagSet = pflag.NewFlagSet("flagSet", pflag.ContinueOnError)
-	var cloudProviderConfigFile *string = flagset.String("cloud-provider-configfile", "", "This is the sample input for cloud provider config file")
 	pflag.CommandLine.ParseErrorsWhitelist.UnknownFlags = true
 	_ = pflag.CommandLine.Parse(os.Args[1:])
 
@@ -75,7 +73,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	cloud, err := cloudprovider.InitCloudProvider(cloudProviderName, *cloudProviderConfigFile)
+	cloud, err := cloudprovider.InitCloudProvider(cloudProviderName, c.ComponentConfig.KubeCloudShared.CloudProvider.CloudConfigFile)
 	if err != nil {
 		klog.Fatalf("Cloud provider could not be initialized: %v", err)
 	}

--- a/staging/src/k8s.io/cloud-provider/sample/advanced_main.go
+++ b/staging/src/k8s.io/cloud-provider/sample/advanced_main.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	"github.com/spf13/pflag"
+
 	"k8s.io/cloud-provider"
 	"k8s.io/cloud-provider/app"
 	"k8s.io/cloud-provider/options"
@@ -50,9 +51,6 @@ const (
 func advancedMain() {
 	rand.Seed(time.Now().UnixNano())
 
-	// cloudProviderConfigFile shows an sample of parse config file from flag option
-	var flagset *pflag.FlagSet = pflag.NewFlagSet("flagSet", pflag.ContinueOnError)
-	var cloudProviderConfigFile *string = flagset.String("cloud-provider-configfile", "", "This is the sample input for cloud provider config file")
 	pflag.CommandLine.ParseErrorsWhitelist.UnknownFlags = true
 	_ = pflag.CommandLine.Parse(os.Args[1:])
 
@@ -69,7 +67,7 @@ func advancedMain() {
 		os.Exit(1)
 	}
 
-	cloud, err := cloudprovider.InitCloudProvider(cloudProviderName, *cloudProviderConfigFile)
+	cloud, err := cloudprovider.InitCloudProvider(cloudProviderName, c.ComponentConfig.KubeCloudShared.CloudProvider.CloudConfigFile)
 	if err != nil {
 		klog.Fatalf("Cloud provider could not be initialized: %v", err)
 	}

--- a/staging/src/k8s.io/cloud-provider/sample/basic_main.go
+++ b/staging/src/k8s.io/cloud-provider/sample/basic_main.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	"github.com/spf13/pflag"
+
 	"k8s.io/cloud-provider"
 	"k8s.io/cloud-provider/app"
 	"k8s.io/cloud-provider/options"
@@ -45,8 +46,6 @@ const (
 
 	// sampleCloudProviderName shows an sample of using hard coded parameter for CloudProviderName
 	sampleCloudProviderName = "SampleCloudProviderName"
-	// sampleCloudProviderConfigFile shows an sample of using hard coded parameter for CloudProviderConfigFile
-	sampleCloudProviderConfigFile = "sampleCloudProviderConfigFile"
 )
 
 func main() {
@@ -63,7 +62,7 @@ func main() {
 	}
 
 	// initialize cloud provider with the cloud provider name and config file provided
-	cloud, err := cloudprovider.InitCloudProvider(sampleCloudProviderName, sampleCloudProviderConfigFile)
+	cloud, err := cloudprovider.InitCloudProvider(sampleCloudProviderName, c.ComponentConfig.KubeCloudShared.CloudProvider.CloudConfigFile)
 	if err != nil {
 		klog.Fatalf("Cloud provider could not be initialized: %v", err)
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
update cloud provider sample main to use cloud-config file instead of using a hardcoded path

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
