### PR TITLE
Fix openapi generator for alpha features

### DIFF
--- a/hack/update-openapi-spec.sh
+++ b/hack/update-openapi-spec.sh
@@ -75,6 +75,7 @@ kube::log::status "Starting kube-apiserver"
   --etcd-servers="http://${ETCD_HOST}:${ETCD_PORT}" \
   --advertise-address="10.10.10.10" \
   --cert-dir="${TMP_DIR}/certs" \
+  --feature-gates=AllAlpha=true \
   --runtime-config="api/all=true" \
   --token-auth-file="${TMP_DIR}/tokenauth.csv" \
   --authorization-mode=RBAC \


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
/kind documentation

**What this PR does / why we need it**:

This PR updates the script for generating OpenAPI v2 spec (aka. the swagger.json) file. Some API definitions (e.g. `storage/v1alpha1.CSIStorageCapacity`) are behind feature gates. These definitions should be included in the API spec no matter the feature gate is on or off. The alpha nature of the definition is already implied in its API version, i.e. `v1alpha1`.

**Which issue(s) this PR fixes**:

The definitions that are missing:

- io.k8s.api.core.v1.EphemeralContainers
- io.k8s.api.storage.v1alpha1.CSIStorageCapacity
- io.k8s.api.storage.v1alpha1.CSIStorageCapacityList

The operations that are missing:

- createStorageV1alpha1NamespacedCSIStorageCapacity
- deleteStorageV1alpha1CollectionNamespacedCSIStorageCapacity
- deleteStorageV1alpha1NamespacedCSIStorageCapacity
- listStorageV1alpha1CSIStorageCapacityForAllNamespaces
- listStorageV1alpha1NamespacedCSIStorageCapacity
- patchStorageV1alpha1NamespacedCSIStorageCapacity
- readStorageV1alpha1NamespacedCSIStorageCapacity
- replaceStorageV1alpha1NamespacedCSIStorageCapacity
- watchStorageV1alpha1CSIStorageCapacityListForAllNamespaces
- watchStorageV1alpha1NamespacedCSIStorageCapacity
- watchStorageV1alpha1NamespacedCSIStorageCapacityList

- patchCoreV1NamespacedPodEphemeralcontainers
- readCoreV1NamespacedPodEphemeralcontainers
- replaceCoreV1NamespacedPodEphemeralcontainers

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
