### PR TITLE
kubectl: allow to fetch the list of Pods from cache when draining

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/drain/drain.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/drain/drain.go
@@ -328,7 +328,7 @@ func (o *DrainCmdOptions) RunDrain() error {
 }
 
 func (o *DrainCmdOptions) deleteOrEvictPodsSimple(nodeInfo *resource.Info) error {
-	list, errs := o.drainer.GetPodsForDeletion(nodeInfo.Name)
+	list, errs := o.drainer.GetPodsForDeletion(nodeInfo.Name, "")
 	if errs != nil {
 		return utilerrors.NewAggregate(errs)
 	}
@@ -343,7 +343,7 @@ func (o *DrainCmdOptions) deleteOrEvictPodsSimple(nodeInfo *resource.Info) error
 	}
 
 	if err := o.drainer.DeleteOrEvictPods(list.Pods()); err != nil {
-		pendingList, newErrs := o.drainer.GetPodsForDeletion(nodeInfo.Name)
+		pendingList, newErrs := o.drainer.GetPodsForDeletion(nodeInfo.Name, list.ResourceVersion)
 		if pendingList != nil {
 			pods := pendingList.Pods()
 			if len(pods) != 0 {

--- a/staging/src/k8s.io/kubectl/pkg/drain/default.go
+++ b/staging/src/k8s.io/kubectl/pkg/drain/default.go
@@ -32,7 +32,10 @@ import (
 // You should first cordon the node, e.g. using RunCordonOrUncordon
 func RunNodeDrain(drainer *Helper, nodeName string) error {
 	// TODO(justinsb): Ensure we have adequate e2e coverage of this function in library consumers
-	list, errs := drainer.GetPodsForDeletion(nodeName)
+	// note: using an empty resourceVersion will result in the list of Pods being fetched
+	// from the etcd backend skipping the apiserver cache. This behavior might cause high load
+	// on etcd in larger Kubernetes clusters.
+	list, errs := drainer.GetPodsForDeletion(nodeName, "")
 	if errs != nil {
 		return utilerrors.NewAggregate(errs)
 	}

--- a/staging/src/k8s.io/kubectl/pkg/drain/filters.go
+++ b/staging/src/k8s.io/kubectl/pkg/drain/filters.go
@@ -45,7 +45,8 @@ type PodDelete struct {
 
 // PodDeleteList is a wrapper around []PodDelete
 type PodDeleteList struct {
-	items []PodDelete
+	items           []PodDelete
+	ResourceVersion string
 }
 
 // Pods returns a list of all pods marked for deletion after filtering.


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

The `kubectl drain` command is currently always fetching the list of Pods to be deleted from a node when draining from the etcd backends (https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher.go#L599-L607).
In larger clusters, this can result in high-load on the etcd servers up until memory exhaustion (OOMKill).

In order to mitigate the impact of `kubectl drain` on cluster availability this PR extends the `drainer.GetPodsForDeletion` function in order to accept `resourceVersion` as parameter.
In case `resourceVersion` is nil, the list of Pods will be retrieved from the storage backend, otherwise the apiserver cache will be used. 
`resourceVersion` follows the semantic described at https://kubernetes.io/docs/reference/using-api/api-concepts/#the-resourceversion-parameter.

While the `kubectl drain` command will benefit from the change only in case of errors deleting the Pods, this will allow client implementing the kubectl library to explicitely control whether the list of pods should be returned from cache or not depending on their business logic.