### PR TITLE
Fix AWS orphaned NLB on updating service from LoadBalancer to ClusterIp

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/aws/aws.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/aws/aws.go
@@ -4448,16 +4448,14 @@ func (c *Cloud) EnsureLoadBalancerDeleted(ctx context.Context, clusterName strin
 	}
 	loadBalancerName := c.GetLoadBalancerName(ctx, clusterName, service)
 
-	if isNLB(service.Annotations) {
-		lb, err := c.describeLoadBalancerv2(loadBalancerName)
+	lb, err := c.describeLoadBalancerv2(loadBalancerName)
+
+	// Handle deletion of NLB
+	// Workaround for load balancer type annotation no longer available
+	if lb != nil {
 		if err != nil {
 			return err
 		}
-		if lb == nil {
-			klog.Info("Load balancer already deleted: ", loadBalancerName)
-			return nil
-		}
-
 		// Delete the LoadBalancer and target groups
 		//
 		// Deleting a target group while associated with a load balancer will


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Updating a Service from type LoadBalancer (NLB) to ClusterIp should delete the NLB, its Target Group and SecurityGroupRules. However, this does not seem to be working properly as the NLB and its resources would not be deleted, resulting in an orphaned NLB. 

Updating the service in EKS would update the service and delete the NLB and its resources in AWS successfully. 

However, removing the properties below from the service YAML file would not delete the NLB and its resources:
```
metadata.annotations.service.beta.kubernetes.io/aws-load-balancer-type: nlb
spec.externalTrafficPolicy: Cluster
spec.ports.nodePort: 32188
spec.type: LoadBalancer
```

When a load balancer needs to be deleted, the `EnsureLoadBalancerDeleted()` function will be invoked and the function will validate if the load balancer is a NLB or CLB using the [following code block](https://github.com/kubernetes/kubernetes/blob/ac101cbdda382d4c23485a3aa5583d79e5379e31/staging/src/k8s.io/legacy-cloud-providers/aws/aws.go#L4451-L4498):
```go
if isNLB(service.Annotations) {
    lb, err := c.describeLoadBalancerv2(loadBalancerName)
       <TRUNCATED>
}
```
Since the type annotations are no longer available, the code within the condition block that handles the cleanup of the NLB and its resources would not be executed. 

This PR fixes the issue by adding a workaround to check if the LoadBalancer is a NLB without using the annotations.

**Which issue(s) this PR fixes**:
Fixes #95042

**Special notes for your reviewer**:
I'm still getting familiar with the code in AWS cloud provider so I'm not sure if this is the best way to fix this. I'd gladly accept any advice or pointer if there is a better way to check if a load balancer is a NLB without using the annotations. Thanks!

**Release note**:
```release-note
Fix AWS orphaned NLB on updating service from LoadBalancer to ClusterIp
```

/sig cloud-provider
/area provider/aws
