### PR TITLE
kubeadm: improve the error messages when validating discovery CA hash

### DIFF
--- a/cmd/kubeadm/app/discovery/token/token.go
+++ b/cmd/kubeadm/app/discovery/token/token.go
@@ -62,7 +62,7 @@ func retrieveValidatedConfigInfo(client clientset.Interface, cfg *kubeadmapi.Dis
 	// Load the CACertHashes into a pubkeypin.Set
 	pubKeyPins := pubkeypin.NewSet()
 	if err = pubKeyPins.Allow(cfg.BootstrapToken.CACertHashes...); err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "invalid discovery token CA certificate hash")
 	}
 
 	duration := cfg.Timeout.Duration

--- a/cmd/kubeadm/app/util/pubkeypin/pubkeypin.go
+++ b/cmd/kubeadm/app/util/pubkeypin/pubkeypin.go
@@ -32,6 +32,11 @@ const (
 	formatSHA256 = "sha256"
 )
 
+var (
+	// supportedFormats enumerates the supported formats
+	supportedFormats = strings.Join([]string{formatSHA256}, ", ")
+)
+
 // Set is a set of pinned x509 public keys.
 type Set struct {
 	sha256Hashes map[string]bool
@@ -47,7 +52,8 @@ func (s *Set) Allow(pubKeyHashes ...string) error {
 	for _, pubKeyHash := range pubKeyHashes {
 		parts := strings.Split(pubKeyHash, ":")
 		if len(parts) != 2 {
-			return errors.New("invalid public key hash, expected \"format:value\"")
+			return errors.Errorf("invalid hash, expected \"format:hex-value\". "+
+				"Known format(s) are: %s", supportedFormats)
 		}
 		format, value := parts[0], parts[1]
 
@@ -55,7 +61,7 @@ func (s *Set) Allow(pubKeyHashes ...string) error {
 		case "sha256":
 			return s.allowSHA256(value)
 		default:
-			return errors.Errorf("unknown hash format %q", format)
+			return errors.Errorf("unknown hash format %q. Known format(s) are: %s", format, supportedFormats)
 		}
 	}
 	return nil
@@ -99,7 +105,7 @@ func (s *Set) allowSHA256(hash string) error {
 	// validate that the hash is valid hex
 	_, err := hex.DecodeString(hash)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "could not decode SHA-256 from hex")
 	}
 
 	// in the end, just store the original hex string in memory (in lowercase)


### PR DESCRIPTION
**What this PR does / why we need it**:

The error messages when the user feeds an invalid discovery token CA
hash are vague. Make sure to:
- Print the list of supported hash formats (currently only "sha256").
- Wrap the error from pubKeyPins.Allow() with a descriptive message.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubeadm/issues/1978

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
