### PR TITLE
Fix staticcheck in test/integration/{examples,framework}

### DIFF
--- a/hack/.staticcheck_failures
+++ b/hack/.staticcheck_failures
@@ -3,8 +3,6 @@ pkg/controller/replicaset
 pkg/kubelet/dockershim
 pkg/volume/testing
 test/e2e/autoscaling
-test/integration/examples
-test/integration/framework
 test/integration/garbagecollector
 test/integration/scheduler_perf
 vendor/k8s.io/apimachinery/pkg/api/apitesting/roundtrip

--- a/test/integration/examples/apiserver_test.go
+++ b/test/integration/examples/apiserver_test.go
@@ -90,7 +90,7 @@ func TestAggregatedAPIServer(t *testing.T) {
 			"--kubeconfig", wardleToKASKubeConfigFile,
 		})
 		if err := wardleCmd.Execute(); err != nil {
-			t.Fatal(err)
+			t.Error(err)
 		}
 	}()
 	directWardleClientConfig, err := waitForWardleRunning(t, kubeClientConfig, wardleCertDir, wardlePort)
@@ -131,7 +131,7 @@ func TestAggregatedAPIServer(t *testing.T) {
 
 	// wait for the unavailable API service to be processed with updated status
 	err = wait.Poll(100*time.Millisecond, 5*time.Second, func() (done bool, err error) {
-		_, err = kubeClient.Discovery().ServerResources()
+		_, _, err = kubeClient.Discovery().ServerGroupsAndResources()
 		hasExpectedError := checkWardleUnavailableDiscoveryError(t, err)
 		return hasExpectedError, nil
 	})

--- a/test/integration/framework/etcd.go
+++ b/test/integration/framework/etcd.go
@@ -100,7 +100,7 @@ func RunCustomEtcd(dataDir string, customFlags []string) (url string, stopFn fun
 	// TODO: Check for valid etcd version.
 	etcdPath, err := getEtcdPath()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, installEtcd)
+		fmt.Fprint(os.Stderr, installEtcd)
 		return "", nil, fmt.Errorf("could not find etcd in PATH: %v", err)
 	}
 	etcdPort, err := getAvailablePort()

--- a/test/integration/framework/test_server.go
+++ b/test/integration/framework/test_server.go
@@ -127,7 +127,7 @@ func StartTestServer(t *testing.T, stopCh <-chan struct{}, setup TestServerSetup
 	}
 	go func() {
 		if err := kubeAPIServer.GenericAPIServer.PrepareRun().Run(stopCh); err != nil {
-			t.Fatal(err)
+			t.Error(err)
 		}
 	}()
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup


**What this PR does / why we need it**:
PR cleans up the issues identified by staticcheck in `test/integration/examples` and `test/integration/framework`:
```
test/integration/examples/apiserver_test.go:80:2: the goroutine calls T.Fatal, which must be called in the same goroutine as the test (SA2002)
test/integration/examples/apiserver_test.go:93:4: call to T.Fatal
test/integration/examples/apiserver_test.go:134:12: kubeClient.Discovery().ServerResources is deprecated: use ServerGroupsAndResources instead.  (SA1019)
test/integration/framework/etcd.go:103:3: printf-style function with dynamic format string and no further arguments should use print-style function instead (SA1006)
test/integration/framework/test_server.go:128:2: the goroutine calls T.Fatal, which must be called in the same goroutine as the test (SA2002)
test/integration/framework/test_server.go:130:4: call to T.Fatal
```

**Which issue(s) this PR fixes**:
Part of #92402

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
