### PR TITLE
Make log-dump's deprecation note up-to-date

### DIFF
--- a/cluster/log-dump/README.md
+++ b/cluster/log-dump/README.md
@@ -6,7 +6,7 @@ If you require changes to this script, please consider migrating your jobs to us
 log dumping mechanism first.
 
 Currently, `log-dump.sh` file is added to every newly released `kubekins-e2e` image.
-In order to leverage that script, add `USE_KUBEKINS_LOG_DUMPING` environment variable
+In order to leverage that script, add `USE_TEST_INFRA_LOG_DUMPING` environment variable
 to your test job and set its value to `true`.
 
 ## Migration steps


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
/kind documentation

**What this PR does / why we need it**:
We amended the name of the env var enabling the new log dumping mechanism in https://github.com/kubernetes/test-infra/pull/20228 and want to reflect this in the documentation.

**Which issue(s) this PR fixes**:
No issue is opened for that.

**Special notes for your reviewer**:
/sig scalability
/assign @wojtek-t 

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```