### PR TITLE
Check Spec.AllocateLoadBalancerNodePorts for NodePort quota

### DIFF
--- a/pkg/quota/v1/evaluator/core/BUILD
+++ b/pkg/quota/v1/evaluator/core/BUILD
@@ -54,6 +54,7 @@ go_test(
         "//staging/src/k8s.io/apimachinery/pkg/util/clock:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/quota/v1:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/quota/v1/generic:go_default_library",
+        "//staging/src/k8s.io/utils/pointer:go_default_library",
     ],
 )
 

--- a/pkg/quota/v1/evaluator/core/BUILD
+++ b/pkg/quota/v1/evaluator/core/BUILD
@@ -54,7 +54,7 @@ go_test(
         "//staging/src/k8s.io/apimachinery/pkg/util/clock:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/quota/v1:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/quota/v1/generic:go_default_library",
-        "//staging/src/k8s.io/utils/pointer:go_default_library",
+        "//vendor/k8s.io/utils/pointer:go_default_library",
     ],
 )
 

--- a/pkg/quota/v1/evaluator/core/services.go
+++ b/pkg/quota/v1/evaluator/core/services.go
@@ -128,9 +128,12 @@ func (p *serviceEvaluator) Usage(item runtime.Object) (corev1.ResourceList, erro
 		value := resource.NewQuantity(int64(ports), resource.DecimalSI)
 		result[corev1.ResourceServicesNodePorts] = *value
 	case corev1.ServiceTypeLoadBalancer:
-		// load balancer services need to count node ports and load balancers
-		value := resource.NewQuantity(int64(ports), resource.DecimalSI)
-		result[corev1.ResourceServicesNodePorts] = *value
+		// load balancer services need to count node ports unless creation of node ports
+		// is suspressed.
+		if svc.Spec.AllocateLoadBalancerNodePorts == nil || *svc.Spec.AllocateLoadBalancerNodePorts == true {
+			value := resource.NewQuantity(int64(ports), resource.DecimalSI)
+			result[corev1.ResourceServicesNodePorts] = *value
+		}
 		result[corev1.ResourceServicesLoadBalancers] = *(resource.NewQuantity(1, resource.DecimalSI))
 	}
 	return result, nil

--- a/pkg/quota/v1/evaluator/core/services_test.go
+++ b/pkg/quota/v1/evaluator/core/services_test.go
@@ -183,6 +183,30 @@ func TestServiceEvaluatorUsage(t *testing.T) {
 				generic.ObjectCountQuotaResourceNameFor(schema.GroupResource{Resource: "services"}): resource.MustParse("1"),
 			},
 		},
+		"nodeports-disabled-but-specified": {
+			service: &api.Service{
+				Spec: api.ServiceSpec{
+					Type: api.ServiceTypeLoadBalancer,
+					Ports: []api.ServicePort{
+						{
+							Port:     27443,
+							NodePort: 32001,
+						},
+						{
+							Port:     27444,
+							NodePort: 32002,
+						},
+					},
+					AllocateLoadBalancerNodePorts: utilpointer.BoolPtr(false),
+				},
+			},
+			usage: corev1.ResourceList{
+				corev1.ResourceServices:              resource.MustParse("1"),
+				corev1.ResourceServicesNodePorts:     resource.MustParse("2"),
+				corev1.ResourceServicesLoadBalancers: resource.MustParse("1"),
+				generic.ObjectCountQuotaResourceNameFor(schema.GroupResource{Resource: "services"}): resource.MustParse("1"),
+			},
+		},
 	}
 	for testName, testCase := range testCases {
 		actual, err := evaluator.Usage(testCase.service)


### PR DESCRIPTION
When Spec.AllocateLoadBalancerNodePorts is "false" NodePort shall
not be included when computing quota for type:LoadBalancer.

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

For type:LoadBalancer NodePorts are not allocaded if `allocateLoadBalancerNodePorts: false`, e.g

```
apiVersion: v1
kind: Service
metadata:
  name: xsvc-1
spec:
  allocateLoadBalancerNodePorts: false
  selector:
    app: mserver-deployment
  ports:
  - port: 5001
    name: mconnect
  - port: 5003
    name: ctraffic
  type: LoadBalancer
```
With feature gate `ServiceLBNodePortControl=true`.


**Which issue(s) this PR fixes**:

Relates to #73628, see https://github.com/kubernetes/kubernetes/issues/73628#issuecomment-741921976.


**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
