### PR TITLE
Update: Write Read Status, Patch & List APIService test +3 endpoints

### DIFF
--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -659,7 +659,7 @@
     API Server using the current Aggregator [Conformance]'
   description: Ensure that the sample-apiserver code from 1.17 and compiled against
     1.17 will work on the current Aggregator/API-Server.
-  release: v1.17
+  release: v1.17, v1.21
   file: test/e2e/apimachinery/aggregator.go
 - testname: Custom Resource Definition Conversion Webhook, convert mixed version list
   codename: '[sig-api-machinery] CustomResourceConversionWebhook [Privileged:ClusterAdmin]

--- a/test/e2e/apimachinery/aggregator.go
+++ b/test/e2e/apimachinery/aggregator.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	unstructuredv1 "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/discovery"
@@ -90,7 +91,7 @@ var _ = SIGDescribe("Aggregator", func() {
 	})
 
 	/*
-		    Release: v1.17
+		    Release: v1.17, v1.21
 		    Testname: aggregator-supports-the-sample-apiserver
 		    Description: Ensure that the sample-apiserver code from 1.17 and compiled against 1.17
 			will work on the current Aggregator/API-Server.
@@ -99,6 +100,7 @@ var _ = SIGDescribe("Aggregator", func() {
 		// Testing a 1.17 version of the sample-apiserver
 		TestSampleAPIServer(f, aggrclient, imageutils.GetE2EImage(imageutils.APIServer))
 	})
+
 })
 
 func cleanTest(client clientset.Interface, aggrclient *aggregatorclient.Clientset, namespace string) {
@@ -490,6 +492,49 @@ func TestSampleAPIServer(f *framework.Framework, aggrclient *aggregatorclient.Cl
 	if len(unstructuredList.Items) != 1 {
 		framework.Failf("failed to get back the correct flunders list %v from the dynamic client", unstructuredList)
 	}
+
+	ginkgo.By("Read Status for v1alpha1.wardle.example.com")
+	statusContent, err := restClient.Get().
+		AbsPath("/apis/apiregistration.k8s.io/v1/apiservices/v1alpha1.wardle.example.com/status").
+		SetHeader("Accept", "application/json").DoRaw(context.TODO())
+	framework.ExpectNoError(err, "No response for .../apiservices/v1alpha1.wardle.example.com/status. Error: %v", err)
+
+	var jr *apiregistrationv1.APIService
+	err = json.Unmarshal([]byte(statusContent), &jr)
+	framework.ExpectNoError(err, "Failed to process statusContent: %v | err: %v ", string(statusContent), err)
+	framework.ExpectEqual(jr.Status.Conditions[0].Message, "all checks passed", "The Message returned was %v", jr.Status.Conditions[0].Message)
+
+	ginkgo.By("kubectl patch apiservice v1alpha1.wardle.example.com -p '{\"spec\":{\"versionPriority\": 400}}'")
+	patchContent, err := restClient.Patch(types.MergePatchType).
+		AbsPath("/apis/apiregistration.k8s.io/v1/apiservices/v1alpha1.wardle.example.com").
+		SetHeader("Accept", "application/json").
+		Body([]byte(`{"spec":{"versionPriority": 400}}`)).DoRaw(context.TODO())
+
+	framework.ExpectNoError(err, "Patch failed for .../apiservices/v1alpha1.wardle.example.com. Error: %v", err)
+	err = json.Unmarshal([]byte(patchContent), &jr)
+	framework.ExpectNoError(err, "Failed to process patchContent: %v | err: %v ", string(patchContent), err)
+	framework.ExpectEqual(jr.Spec.VersionPriority, int32(400), "The VersionPriority returned was %d", jr.Spec.VersionPriority)
+
+	ginkgo.By("List APIServices")
+	listApiservices, err := restClient.Get().
+		AbsPath("/apis/apiregistration.k8s.io/v1/apiservices").
+		SetHeader("Accept", "application/json").DoRaw(context.TODO())
+
+	framework.ExpectNoError(err, "No response for /apis/apiregistration.k8s.io/v1/apiservices Error: %v", err)
+
+	var list *apiregistrationv1.APIServiceList
+	err = json.Unmarshal([]byte(listApiservices), &list)
+	framework.ExpectNoError(err, "Failed to process APIServiceList: %v | err: %v ", list, err)
+
+	locatedWardle := false
+	for _, item := range list.Items {
+		if item.Name == "v1alpha1.wardle.example.com" {
+			framework.Logf("Found v1alpha1.wardle.example.com in APIServiceList")
+			locatedWardle = true
+			break
+		}
+	}
+	framework.ExpectEqual(locatedWardle, true, "Unable to find v1alpha1.wardle.example.com in APIServiceList")
 
 	// kubectl delete flunder test-flunder
 	err = dynamicClient.Delete(context.TODO(), flunderName, metav1.DeleteOptions{})


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it:**
This PR adds a test to test the following untested endpoints:
- readApiregistrationV1APIServiceStatus
- patchApiregistrationV1APIService
- listApiregistrationV1APIService


**Which issue(s) this PR fixes:**
Fixes #97271

**Testgrid Link:**

**Special notes for your reviewer:**
Adds +3 endpoint test coverage (good for conformance)
This PR will replace #97272 by integrating the test with an existing test to reduce overhead.

**Does this PR introduce a user-facing change?:**
```
NONE

```

**Release note:**
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:**
```
NONE

```

/sig testing
/sig architecture
/area conformance