### PR TITLE
Update autoscaling e2e test after an event message was changed

### DIFF
--- a/test/e2e/autoscaling/cluster_size_autoscaling.go
+++ b/test/e2e/autoscaling/cluster_size_autoscaling.go
@@ -178,7 +178,7 @@ var _ = SIGDescribe("Cluster size autoscaling [Slow]", func() {
 			framework.ExpectNoError(err)
 
 			for _, e := range events.Items {
-				if e.InvolvedObject.Kind == "Pod" && e.Reason == "NotTriggerScaleUp" && strings.Contains(e.Message, "it wouldn't fit if a new node is added") {
+				if e.InvolvedObject.Kind == "Pod" && e.Reason == "NotTriggerScaleUp" {
 					ginkgo.By("NotTriggerScaleUp event found")
 					eventFound = true
 					break EventsLoop


### PR DESCRIPTION
The test no longer passes because it checks for a part of an event
message which has recently been removed from Cluster Autoscaler.

/kind bug
/kind failing-test

```release-note
NONE
```