### PR TITLE
Migrate pkg/scheduler logs to structured logging

### DIFF
--- a/pkg/scheduler/eventhandlers.go
+++ b/pkg/scheduler/eventhandlers.go
@@ -169,7 +169,7 @@ func (sched *Scheduler) onCSINodeUpdate(oldObj, newObj interface{}) {
 
 func (sched *Scheduler) addPodToSchedulingQueue(obj interface{}) {
 	pod := obj.(*v1.Pod)
-	klog.V(3).Infof("add event for unscheduled pod %s/%s", pod.Namespace, pod.Name)
+	klog.V(3).InfoS("Add event for unscheduled pod", "pod", klog.KObj(pod))
 	if err := sched.SchedulingQueue.Add(pod); err != nil {
 		utilruntime.HandleError(fmt.Errorf("unable to queue %T: %v", obj, err))
 	}
@@ -206,7 +206,7 @@ func (sched *Scheduler) deletePodFromSchedulingQueue(obj interface{}) {
 		utilruntime.HandleError(fmt.Errorf("unable to handle object in %T: %T", sched, obj))
 		return
 	}
-	klog.V(3).Infof("delete event for unscheduled pod %s/%s", pod.Namespace, pod.Name)
+	klog.V(3).InfoS("Delete event for unscheduled pod", "pod", klog.KObj(pod))
 	if err := sched.SchedulingQueue.Delete(pod); err != nil {
 		utilruntime.HandleError(fmt.Errorf("unable to dequeue %T: %v", obj, err))
 	}
@@ -226,7 +226,7 @@ func (sched *Scheduler) addPodToCache(obj interface{}) {
 		klog.Errorf("cannot convert to *v1.Pod: %v", obj)
 		return
 	}
-	klog.V(3).Infof("add event for scheduled pod %s/%s ", pod.Namespace, pod.Name)
+	klog.V(3).InfoS("Add event for scheduled pod", "pod", klog.KObj(pod))
 
 	if err := sched.SchedulerCache.AddPod(pod); err != nil {
 		klog.Errorf("scheduler cache AddPod failed: %v", err)
@@ -284,7 +284,7 @@ func (sched *Scheduler) deletePodFromCache(obj interface{}) {
 		klog.Errorf("cannot convert to *v1.Pod: %v", t)
 		return
 	}
-	klog.V(3).Infof("delete event for scheduled pod %s/%s ", pod.Namespace, pod.Name)
+	klog.V(3).InfoS("Delete event for scheduled pod", "pod", klog.KObj(pod))
 	// NOTE: Updates must be written to scheduler cache before invalidating
 	// equivalence cache, because we could snapshot equivalence cache after the
 	// invalidation and then snapshot the cache itself. If the cache is

--- a/pkg/scheduler/framework/plugins/defaultbinder/default_binder.go
+++ b/pkg/scheduler/framework/plugins/defaultbinder/default_binder.go
@@ -48,7 +48,7 @@ func (b DefaultBinder) Name() string {
 
 // Bind binds pods to nodes using the k8s client.
 func (b DefaultBinder) Bind(ctx context.Context, state *framework.CycleState, p *v1.Pod, nodeName string) *framework.Status {
-	klog.V(3).Infof("Attempting to bind %v/%v to %v", p.Namespace, p.Name, nodeName)
+	klog.V(3).InfoS("Attempting to bind pod to node", "pod", klog.KObj(p), "node", nodeName)
 	binding := &v1.Binding{
 		ObjectMeta: metav1.ObjectMeta{Namespace: p.Namespace, Name: p.Name, UID: p.UID},
 		Target:     v1.ObjectReference{Kind: "Node", Name: nodeName},

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -340,7 +340,7 @@ func (sched *Scheduler) recordSchedulingFailure(fwk framework.Framework, podInfo
 }
 
 func updatePod(client clientset.Interface, pod *v1.Pod, condition *v1.PodCondition, nominatedNode string) error {
-	klog.V(3).Infof("Updating pod condition for %s/%s to (%s==%s, Reason=%s)", pod.Namespace, pod.Name, condition.Type, condition.Status, condition.Reason)
+	klog.V(3).InfoS("Updating pod condition", "pod", klog.KObj(pod), "conditionType", condition.Type, "conditionStatus", condition.Status, "conditionReason", condition.Reason)
 	podCopy := pod.DeepCopy()
 	// NominatedNodeName is updated only if we are trying to set it, and the value is
 	// different from the existing one.
@@ -442,7 +442,7 @@ func (sched *Scheduler) scheduleOne(ctx context.Context) {
 		return
 	}
 
-	klog.V(3).Infof("Attempting to schedule pod: %v/%v", pod.Namespace, pod.Name)
+	klog.V(3).InfoS("Attempting to schedule pod", "pod", klog.KObj(pod))
 
 	// Synchronously attempt to find a fit for the pod.
 	start := time.Now()
@@ -621,7 +621,7 @@ func (sched *Scheduler) skipPodSchedule(fwk framework.Framework, pod *v1.Pod) bo
 	// Case 1: pod is being deleted.
 	if pod.DeletionTimestamp != nil {
 		fwk.EventRecorder().Eventf(pod, nil, v1.EventTypeWarning, "FailedScheduling", "Scheduling", "skip schedule deleting pod: %v/%v", pod.Namespace, pod.Name)
-		klog.V(3).Infof("Skip schedule deleting pod: %v/%v", pod.Namespace, pod.Name)
+		klog.V(3).InfoS("Skip schedule deleting pod", "pod", klog.KObj(pod))
 		return true
 	}
 


### PR DESCRIPTION
in pkg/scheduler/eventhandlers.go
  * add event for unscheduled pod
  * delete event for unscheduled pod
  * add event for scheduled pod
  * delete event for scheduled pod
  
in pkg/scheduler/framework/plugins/defaultbinder/default_binder.go
  * Attempting to bind pod to node
  
in pkg/scheduler/scheduler.go
  * Updating pod condition
  * Attempting to schedule pod
  * Skip schedule deleting pod

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Ref:
* [keps/sig-instrumentation/1602-structured-logging](https://github.com/kubernetes/enhancements/tree/master/keps/sig-instrumentation/1602-structured-logging)
* [Structured Logging migration instructions](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/migration-to-structured-logging.md)

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Verify log output**

add event for unscheduled pod
```
# before
eventhandlers.go:172] add event for unscheduled pod kube-system/kube-proxy-kczjv

# after
eventhandlers.go:172] "Add event for unscheduled pod" pod="kube-system/coredns-58b6774b9c-c844b"
```

delete event for unscheduled pod
```
# before
eventhandlers.go:209] delete event for unscheduled pod kube-system/kube-proxy-kczjv

# after
eventhandlers.go:209] "Delete event for unscheduled pod" pod="kube-system/coredns-f9fd979d6-l4kct"
```

add event for scheduled pod
```
# before
eventhandlers.go:229] add event for scheduled pod kube-system/kube-proxy-55xlf

# after
eventhandlers.go:229] "Add event for scheduled pod" pod="kube-system/kube-flannel-ds-7khwv"
```

delete event for scheduled pod
```
# before
eventhandlers.go:287] delete event for scheduled pod kube-system/kube-proxy-55xlf

# after
eventhandlers.go:287] "Delete event for scheduled pod" pod="kube-system/coredns-f9fd979d6-fj98w"
```

Attempting to bind pod to node
```
# before
default_binder.go:51] Attempting to bind kube-system/kube-proxy-kczjv to base-vm

# after
default_binder.go:51] "Attempting to bind pod to node" pod="kube-system/coredns-f9fd979d6-l4kct" node="base-vm"
```

Updating pod condition
```
# before
scheduler.go:343] Updating pod condition for kube-system/coredns-fdf45f9-h7m7w to (PodScheduled==False, Reason=Unschedulable)

# after
scheduler.go:343] "Updating pod condition" pod="kube-system/coredns-58b6774b9c-c844b" conditionType=PodScheduled conditionStatus=False conditionReason="Unschedulable"
```

Attempting to schedule pod
```
# before
scheduler.go:445] Attempting to schedule pod: kube-system/coredns-fdf45f9-h7m7w

# after
scheduler.go:445] "Attempting to schedule pod" pod="kube-system/coredns-f9fd979d6-l4kct"
```

Skip schedule deleting pod
```
# before
scheduler.go:624] Skip schedule deleting pod: kube-system/coredns-fdf45f9-vsmnz

# after
scheduler.go:624] "Skip schedule deleting pod" pod="kube-system/coredns-fdf45f9-cjlbp"
```
