### PR TITLE
kubectl proxy: append context host path to request path

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/proxy/upgradeaware.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/proxy/upgradeaware.go
@@ -60,6 +60,8 @@ type UpgradeAwareHandler struct {
 	// Location is the location of the upstream proxy. It is used as the location to Dial on the upstream server
 	// for upgrade requests unless UseRequestLocationOnUpgrade is true.
 	Location *url.URL
+	// AppendLocationPath determines if the original path of the Location should be appended to the upstream proxy request path
+	AppendLocationPath bool
 	// Transport provides an optional round tripper to use to proxy. If nil, the default proxy transport is used
 	Transport http.RoundTripper
 	// UpgradeTransport, if specified, will be used as the backend transport when upgrade requests are provided.
@@ -239,7 +241,13 @@ func (h *UpgradeAwareHandler) ServeHTTP(w http.ResponseWriter, req *http.Request
 		newReq.Host = h.Location.Host
 	}
 
-	proxy := httputil.NewSingleHostReverseProxy(&url.URL{Scheme: h.Location.Scheme, Host: h.Location.Host})
+	// create the target location to use for the reverse proxy
+	reverseProxyLocation := &url.URL{Scheme: h.Location.Scheme, Host: h.Location.Host}
+	if h.AppendLocationPath {
+		reverseProxyLocation.Path = h.Location.Path
+	}
+
+	proxy := httputil.NewSingleHostReverseProxy(reverseProxyLocation)
 	proxy.Transport = h.Transport
 	proxy.FlushInterval = h.FlushInterval
 	proxy.ErrorLog = log.New(noSuppressPanicError{}, "", log.LstdFlags)
@@ -282,6 +290,9 @@ func (h *UpgradeAwareHandler) tryUpgrade(w http.ResponseWriter, req *http.Reques
 		location = *req.URL
 		location.Scheme = h.Location.Scheme
 		location.Host = h.Location.Host
+		if h.AppendLocationPath {
+			location.Path = singleJoiningSlash(h.Location.Path, location.Path)
+		}
 	}
 
 	clone := utilnet.CloneRequest(req)
@@ -412,6 +423,20 @@ func (h *UpgradeAwareHandler) tryUpgrade(w http.ResponseWriter, req *http.Reques
 	klog.V(6).Infof("Disconnecting from backend proxy %s\n  Headers: %v", &location, clone.Header)
 
 	return true
+}
+
+// FIXME: Taken from net/http/httputil/reverseproxy.go as singleJoiningSlash is not exported to be re-used.
+// See-also: https://github.com/golang/go/issues/44290
+func singleJoiningSlash(a, b string) string {
+	aslash := strings.HasSuffix(a, "/")
+	bslash := strings.HasPrefix(b, "/")
+	switch {
+	case aslash && bslash:
+		return a + b[1:]
+	case !aslash && !bslash:
+		return a + "/" + b
+	}
+	return a + b
 }
 
 func (h *UpgradeAwareHandler) DialForUpgrade(req *http.Request) (net.Conn, error) {

--- a/staging/src/k8s.io/apimachinery/pkg/util/proxy/upgradeaware_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/proxy/upgradeaware_test.go
@@ -163,6 +163,7 @@ func TestServeHTTP(t *testing.T) {
 		expectedRespHeader    map[string]string
 		notExpectedRespHeader []string
 		upgradeRequired       bool
+		appendLocationPath    bool
 		expectError           func(err error) bool
 		useLocationHost       bool
 	}{
@@ -246,6 +247,27 @@ func TestServeHTTP(t *testing.T) {
 			expectedPath:    "/some/path",
 			useLocationHost: true,
 		},
+		{
+			name:               "append server path to request path",
+			method:             "GET",
+			requestPath:        "/base",
+			expectedPath:       "/base/base",
+			appendLocationPath: true,
+		},
+		{
+			name:               "append server path to request path with ending slash",
+			method:             "GET",
+			requestPath:        "/base/",
+			expectedPath:       "/base/base/",
+			appendLocationPath: true,
+		},
+		{
+			name:               "don't append server path to request path",
+			method:             "GET",
+			requestPath:        "/base",
+			expectedPath:       "/base",
+			appendLocationPath: false,
+		},
 	}
 
 	for i, test := range tests {
@@ -269,6 +291,7 @@ func TestServeHTTP(t *testing.T) {
 			backendURL.Path = test.requestPath
 			proxyHandler := NewUpgradeAwareHandler(backendURL, nil, false, test.upgradeRequired, responder)
 			proxyHandler.UseLocationHost = test.useLocationHost
+			proxyHandler.AppendLocationPath = test.appendLocationPath
 			proxyServer := httptest.NewServer(proxyHandler)
 			defer proxyServer.Close()
 			proxyURL, _ := url.Parse(proxyServer.URL)

--- a/staging/src/k8s.io/kubectl/pkg/proxy/proxy_server.go
+++ b/staging/src/k8s.io/kubectl/pkg/proxy/proxy_server.go
@@ -173,8 +173,8 @@ func makeUpgradeTransport(config *rest.Config, keepalive time.Duration) (proxy.U
 
 // NewServer creates and installs a new Server.
 // 'filter', if non-nil, protects requests to the api only.
-func NewServer(filebase string, apiProxyPrefix string, staticPrefix string, filter *FilterServer, cfg *rest.Config, keepalive time.Duration) (*Server, error) {
-	proxyHandler, err := NewProxyHandler(apiProxyPrefix, filter, cfg, keepalive)
+func NewServer(filebase string, apiProxyPrefix string, staticPrefix string, filter *FilterServer, cfg *rest.Config, keepalive time.Duration, appendLocationPath bool) (*Server, error) {
+	proxyHandler, err := NewProxyHandler(apiProxyPrefix, filter, cfg, keepalive, appendLocationPath)
 	if err != nil {
 		return nil, err
 	}
@@ -189,7 +189,7 @@ func NewServer(filebase string, apiProxyPrefix string, staticPrefix string, filt
 }
 
 // NewProxyHandler creates an api proxy handler for the cluster
-func NewProxyHandler(apiProxyPrefix string, filter *FilterServer, cfg *rest.Config, keepalive time.Duration) (http.Handler, error) {
+func NewProxyHandler(apiProxyPrefix string, filter *FilterServer, cfg *rest.Config, keepalive time.Duration, appendLocationPath bool) (http.Handler, error) {
 	host := cfg.Host
 	if !strings.HasSuffix(host, "/") {
 		host = host + "/"
@@ -212,6 +212,7 @@ func NewProxyHandler(apiProxyPrefix string, filter *FilterServer, cfg *rest.Conf
 	proxy.UpgradeTransport = upgradeTransport
 	proxy.UseRequestLocation = true
 	proxy.UseLocationHost = true
+	proxy.AppendLocationPath = appendLocationPath
 
 	proxyServer := http.Handler(proxy)
 	if filter != nil {

--- a/staging/src/k8s.io/kubectl/pkg/proxy/proxy_server_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/proxy/proxy_server_test.go
@@ -433,17 +433,19 @@ func TestPathHandling(t *testing.T) {
 		prefix     string
 		reqPath    string
 		expectPath string
+		appendPath bool
 	}{
-		{"test1", "/api/", "/metrics", "404 page not found\n"},
-		{"test2", "/api/", "/api/metrics", "/api/metrics"},
-		{"test3", "/api/", "/api/v1/pods/", "/api/v1/pods/"},
-		{"test4", "/", "/metrics", "/metrics"},
-		{"test5", "/", "/api/v1/pods/", "/api/v1/pods/"},
-		{"test6", "/custom/", "/metrics", "404 page not found\n"},
-		{"test7", "/custom/", "/api/metrics", "404 page not found\n"},
-		{"test8", "/custom/", "/api/v1/pods/", "404 page not found\n"},
-		{"test9", "/custom/", "/custom/api/metrics", "/api/metrics"},
-		{"test10", "/custom/", "/custom/api/v1/pods/", "/api/v1/pods/"},
+		{"test1", "/api/", "/metrics", "404 page not found\n", false},
+		{"test2", "/api/", "/api/metrics", "/api/metrics", false},
+		{"test3", "/api/", "/api/v1/pods/", "/api/v1/pods/", false},
+		{"test4", "/", "/metrics", "/metrics", false},
+		{"test5", "/", "/api/v1/pods/", "/api/v1/pods/", false},
+		{"test6", "/custom/", "/metrics", "404 page not found\n", false},
+		{"test7", "/custom/", "/api/metrics", "404 page not found\n", false},
+		{"test8", "/custom/", "/api/v1/pods/", "404 page not found\n", false},
+		{"test9", "/custom/", "/custom/api/metrics", "/api/metrics", false},
+		{"test10", "/custom/", "/custom/api/v1/pods/", "/api/v1/pods/", false},
+		{"test11", "/custom/", "/custom/api/v1/services/", "/api/v1/services/", true},
 	}
 
 	cc := &rest.Config{
@@ -452,7 +454,7 @@ func TestPathHandling(t *testing.T) {
 
 	for _, tt := range table {
 		t.Run(tt.name, func(t *testing.T) {
-			p, err := NewServer("", tt.prefix, "/not/used/for/this/test", nil, cc, 0)
+			p, err := NewServer("", tt.prefix, "/not/used/for/this/test", nil, cc, 0, tt.appendPath)
 			if err != nil {
 				t.Fatalf("%#v: %v", tt, err)
 			}

--- a/test/integration/apimachinery/watch_timeout_test.go
+++ b/test/integration/apimachinery/watch_timeout_test.go
@@ -57,7 +57,7 @@ func TestWatchClientTimeout(t *testing.T) {
 	})
 
 	t.Run("kubectl proxy", func(t *testing.T) {
-		kubectlProxyServer, err := kubectlproxy.NewServer("", "/", "/static/", nil, &restclient.Config{Host: s.URL, Timeout: 2 * time.Second}, 0)
+		kubectlProxyServer, err := kubectlproxy.NewServer("", "/", "/static/", nil, &restclient.Config{Host: s.URL, Timeout: 2 * time.Second}, 0, false)
 		if err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
Signed-off-by: fabiankramm <fab.kramm@googlemail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind feature
<!--
Add one of the following kinds:
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:

This PR adds a new flag `--append-server-path` to `kubectl proxy` that changes the way how kube contexts are handled that specify a server with an appended path, e.g. `https://my-apiserver.com/path/to/kubernetes`. Before this change, `kubectl proxy` would always expose the api at `http://127.0.0.1:8001/path/to/kubernetes/...`, with this change and flag enabled it exposes the api at `http://127.0.0.1:8001/...` and automatically appends the kube context server path. 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #94280

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Added a new flag `--append-server-path` to `kubectl proxy` that will automatically append the kube context server path to each request.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
none
```
