### PR TITLE
Modify LeaderElectionConfiguration .ResourceNamespace comment

### DIFF
--- a/staging/src/k8s.io/component-base/config/types.go
+++ b/staging/src/k8s.io/component-base/config/types.go
@@ -65,7 +65,7 @@ type LeaderElectionConfiguration struct {
 	// resourceName indicates the name of resource object that will be used to lock
 	// during leader election cycles.
 	ResourceName string
-	// resourceName indicates the namespace of resource object that will be used to lock
+	// resourceNamespace indicates the namespace of resource object that will be used to lock
 	// during leader election cycles.
 	ResourceNamespace string
 }


### PR DESCRIPTION
LeaderElectionConfiguration struct:
ResourceNamespace has a wrong comment.