### PR TITLE
fix sctp hostPort test

### DIFF
--- a/test/e2e/network/service.go
+++ b/test/e2e/network/service.go
@@ -3842,6 +3842,7 @@ var _ = SIGDescribe("SCTP [Feature:SCTP] [LinuxOnly]", func() {
 		podName := "hostport"
 		ports := []v1.ContainerPort{{Protocol: v1.ProtocolSCTP, ContainerPort: 5060, HostPort: 5060}}
 		podSpec := e2epod.NewAgnhostPod(f.Namespace.Name, podName, nil, nil, ports)
+		podSpec.Spec.NodeName = node.Name
 
 		ginkgo.By(fmt.Sprintf("Launching the pod on node %v", node.Name))
 		f.PodClient().CreateSync(podSpec)


### PR DESCRIPTION

/kind failing-test
/kind flake

**What this PR does / why we need it**:

The test create a pod with a hostPort to expose an SCTP port, then
it checks if the iptables rules were installed correctly in the host.

The iptables rules MUST be checked in the same host where the pod
is running :)

**Which issue(s) this PR fixes**:

These tests were flaking for a while https://testgrid.k8s.io/sig-network-kind#sig-network-kind,%20master, however, since there is a cleanup going on for those I didn´t pay the necessary attention

**Special notes for your reviewer**:

During the refactor we forget to set the node name on the pod, hence the test was flaky, because it had to schedule the pod and the hostexec pod in the same node, I guess that for kind is a 50% if the control-plane node is not considered.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
