### PR TITLE
Fix bug in Member Exists Join for Kubeadm etcd join

### DIFF
--- a/cmd/kubeadm/app/phases/etcd/local.go
+++ b/cmd/kubeadm/app/phases/etcd/local.go
@@ -162,9 +162,13 @@ func CreateStackedEtcdStaticPodManifestFile(client clientset.Interface, manifest
 	// only add the new member if it doesn't already exists
 	var exists bool
 	klog.V(1).Infof("[etcd] Checking if the etcd member already exists: %s", etcdPeerAddress)
-	for _, member := range initialCluster {
-		if member.PeerURL == etcdPeerAddress {
+	for i := range initialCluster {
+		if initialCluster[i].PeerURL == etcdPeerAddress {
 			exists = true
+			if len(initialCluster[i].Name) == 0 {
+				klog.V(1).Infof("[etcd] etcd member name is empty. Setting it to the node name: %s", nodeName)
+				initialCluster[i].Name = nodeName
+			}
 			break
 		}
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:

In kubeadm etcd join there is a a bug that exists where,
if a peer already exists in etcd, it attempts to mitigate
by continuing and generating the etcd manifest file. However,
this existing "member name" may actually be unset, causing
subsequent etcd consistency checks to fail.

This change checks if the member name is empty - if it is,
it sets the member name to the node name, and resumes.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
No issue filed (found internally). However, a summary of the issue is as such:

When running `kubeadm join phase control-plane-join etcd ...`, on a potentially very slow machine, the original join would time out, and a subsequent attempt might occur. In this subsequent attempt, the resulting `etcd` manifest file may have an erroneous setup where the node name is missing in the `--initial-cluster` field;

```
    - --initial-cluster=422646179bda93c41a8dffdb3f18d7cf=https://10.192.179.175:2380,=https://10.192.175.85:2380,42260c0581b89af2fe9aaf27c2f92f68=https://10.192.172.211:2380
```

Notice the second entry (after the first `,`), which specifies `=https://10.192.175.85:2380`.

This change forces this node name to never be empty.

**Special notes for your reviewer**:

@neolit123 is aware of this issue.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
kubeadm: fix a bug where "kubeadm join" would not properly handle missing names for existing etcd members.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
