### PR TITLE
configure docker on containerd nodes so it wouldn't reserver 172.17 s…

### DIFF
--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -1453,6 +1453,14 @@ function create-master-etcd-apiserver-auth {
    fi
 }
 
+function docker-installed {
+    if systemctl cat docker.service &> /dev/null ; then
+        return 0
+    else
+        return 1
+    fi
+}
+
 function assemble-docker-flags {
   echo "Assemble docker command line flags"
   local docker_opts="-p /var/run/docker.pid --iptables=false --ip-masq=false"
@@ -3077,8 +3085,13 @@ function main() {
   if [[ "${container_runtime}" == "docker" ]]; then
     assemble-docker-flags
   elif [[ "${container_runtime}" == "containerd" ]]; then
-    # stop docker if it is present as we want to use just containerd
-    systemctl stop docker || echo "unable to stop docker"
+    if docker-installed; then
+      # We still need to configure docker so it wouldn't reserver the 172.17.0/16 subnet
+      # And if somebody will start docker to build or pull something, logging will also be set up
+      assemble-docker-flags
+      # stop docker if it is present as we want to use just containerd
+      systemctl stop docker || echo "unable to stop docker"
+    fi
     setup-containerd
   fi
 


### PR DESCRIPTION
…ubnet


**What type of PR is this?**

/kind bug
/sig node

**What this PR does / why we need it**:

On containerd nodes the default Docker's subnet is conflicting with the some VPNs. 

This will not execute:

https://github.com/kubernetes/kubernetes/blob/dfb8cfc768f959b2734c04e885cb96d733619a78/cluster/gce/gci/configure-helper.sh#L1464-L1469

when containerd is used:

https://github.com/kubernetes/kubernetes/blob/dfb8cfc768f959b2734c04e885cb96d733619a78/cluster/gce/gci/configure-helper.sh#L3076-L3083

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
There may be a better fix - maybe it can be preconfigured on COS. I'm also not sure when Docker is started for the first time. In any case, bug affecting some customers and the introduced delay might be OK.

I also figured setting up logging is also OK. So just caling the entire method

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
