### PR TITLE
kubelet: Fix the bug of getting the number of windows cpu

### DIFF
--- a/pkg/kubelet/winstats/perfcounter_nodestats.go
+++ b/pkg/kubelet/winstats/perfcounter_nodestats.go
@@ -26,6 +26,7 @@ import (
 	"runtime"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 	"unsafe"
 
@@ -50,9 +51,12 @@ type MemoryStatusEx struct {
 }
 
 var (
-	modkernel32              = windows.NewLazySystemDLL("kernel32.dll")
-	procGlobalMemoryStatusEx = modkernel32.NewProc("GlobalMemoryStatusEx")
+	modkernel32                 = windows.NewLazySystemDLL("kernel32.dll")
+	procGlobalMemoryStatusEx    = modkernel32.NewProc("GlobalMemoryStatusEx")
+	procGetActiveProcessorCount = modkernel32.NewProc("GetActiveProcessorCount")
 )
+
+const allProcessorGroups = 0xFFFF
 
 // NewPerfCounterClient creates a client using perf counters
 func NewPerfCounterClient() (Client, error) {
@@ -140,11 +144,31 @@ func (p *perfCounterNodeStatsClient) getMachineInfo() (*cadvisorapi.MachineInfo,
 	}
 
 	return &cadvisorapi.MachineInfo{
-		NumCores:       runtime.NumCPU(),
+		NumCores:       processorCount(),
 		MemoryCapacity: p.nodeInfo.memoryPhysicalCapacityBytes,
 		MachineID:      hostname,
 		SystemUUID:     systemUUID,
 	}, nil
+}
+
+// runtime.NumCPU() will only return the information for a single Processor Group.
+// Since a single group can only hold 64 logical processors, this
+// means when there are more they will be divided into multiple groups.
+// For the above reason, procGetActiveProcessorCount is used to get the
+// cpu count for all processor groups of the windows node.
+// more notes for this issue:
+// same issue in moby: https://github.com/moby/moby/issues/38935#issuecomment-744638345
+// solution in hcsshim: https://github.com/microsoft/hcsshim/blob/master/internal/processorinfo/processor_count.go
+func processorCount() int {
+	if amount := getActiveProcessorCount(allProcessorGroups); amount != 0 {
+		return int(amount)
+	}
+	return runtime.NumCPU()
+}
+
+func getActiveProcessorCount(groupNumber uint16) int {
+	r0, _, _ := syscall.Syscall(procGetActiveProcessorCount.Addr(), 1, uintptr(groupNumber), 0, 0)
+	return int(r0)
 }
 
 func (p *perfCounterNodeStatsClient) getVersionInfo() (*cadvisorapi.VersionInfo, error) {


### PR DESCRIPTION
fix the bug that the number of cpu cannot be obtained normally under Windows

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:

In some cases, kubelet will return an error value when obtaining the number of CPUs, only half of the correct value will be returned.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

I found the way to fix in https://github.com/microsoft/hcsshim/blob/master/internal/processorinfo/processor_count.go

same issue in moby: https://github.com/moby/moby/issues/38935#issuecomment-744638345


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kubelet: Fixed the bug of getting the number of cpu when the number of cpu logical processors is more than 64 in windows
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
