### PR TITLE
kubectl proxy: override request host

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/proxy/upgradeaware.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/proxy/upgradeaware.go
@@ -74,6 +74,12 @@ type UpgradeAwareHandler struct {
 	RequireSameHostRedirects bool
 	// UseRequestLocation will use the incoming request URL when talking to the backend server.
 	UseRequestLocation bool
+	// UseLocationHost overrides the HTTP host header in requests to the backend server to use the Host from Location.
+	// This will override the req.Host field of a request, while UseRequestLocation will override the req.URL field
+	// of a request. The req.URL.Host specifies the server to connect to, while the req.Host field
+	// specifies the Host header value to send in the HTTP request. If this is false, the incoming req.Host header will
+	// just be forwarded to the backend server.
+	UseLocationHost bool
 	// FlushInterval controls how often the standard HTTP proxy will flush content from the upstream.
 	FlushInterval time.Duration
 	// MaxBytesPerSec controls the maximum rate for an upstream connection. No rate is imposed if the value is zero.
@@ -227,6 +233,11 @@ func (h *UpgradeAwareHandler) ServeHTTP(w http.ResponseWriter, req *http.Request
 	if !h.UseRequestLocation {
 		newReq.URL = &loc
 	}
+	if h.UseLocationHost {
+		// exchanging req.Host with the backend location is necessary for backends that act on the HTTP host header (e.g. API gateways),
+		// because req.Host has preference over req.URL.Host in filling this header field
+		newReq.Host = h.Location.Host
+	}
 
 	proxy := httputil.NewSingleHostReverseProxy(&url.URL{Scheme: h.Location.Scheme, Host: h.Location.Host})
 	proxy.Transport = h.Transport
@@ -282,6 +293,9 @@ func (h *UpgradeAwareHandler) tryUpgrade(w http.ResponseWriter, req *http.Reques
 		backendConn, rawResponse, err = utilnet.ConnectWithRedirects(req.Method, &location, clone.Header, req.Body, utilnet.DialerFunc(h.DialForUpgrade), h.RequireSameHostRedirects)
 	} else {
 		klog.V(6).Infof("Connecting to backend proxy (direct dial) %s\n  Headers: %v", &location, clone.Header)
+		if h.UseLocationHost {
+			clone.Host = h.Location.Host
+		}
 		clone.URL = &location
 		backendConn, err = h.DialForUpgrade(clone)
 	}

--- a/staging/src/k8s.io/kubectl/pkg/proxy/proxy_server.go
+++ b/staging/src/k8s.io/kubectl/pkg/proxy/proxy_server.go
@@ -195,6 +195,7 @@ func NewServer(filebase string, apiProxyPrefix string, staticPrefix string, filt
 	proxy := proxy.NewUpgradeAwareHandler(target, transport, false, false, responder)
 	proxy.UpgradeTransport = upgradeTransport
 	proxy.UseRequestLocation = true
+	proxy.UseLocationHost = true
 
 	proxyServer := http.Handler(proxy)
 	if filter != nil {


### PR DESCRIPTION
Signed-off-by: fabiankramm <fab.kramm@googlemail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug
<!--
Add one of the following kinds:
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:

Currently `kubectl proxy` does not work correctly with many API Gateway proxies as backends (e.g. api server behind a nginx ingress controller). The problem behind this is that the `Host` header field that arrives at the backend still points to the `kubectl proxy` host of the original request. 

This is due to the go client preferring the `req.Host` over `req.URL.Host`.

https://github.com/golang/go/blob/a0d6420d8be2ae7164797051ec74fa2a2df466a1/src/net/http/h2_bundle.go#L7947-L7954

However, `httputil.ReverseProxy` and also upgrade path only set `req.URL.Host`. Hence, `req.Host` still points to the proxy host and is preferred by the client over `req.URL.Host` and sent to the backend server as `Host` header. 

https://github.com/golang/go/blob/a0d6420d8be2ae7164797051ec74fa2a2df466a1/src/net/http/httputil/reverseproxy.go#L105-L121

https://github.com/kubernetes/kubernetes/blob/979c644df2ad051015a8ccf6475e3476eda0cea0/staging/src/k8s.io/apimachinery/pkg/util/proxy/upgradeaware.go#L284-L286

This leads to the request being routed to the localhost again instead of the correct target location in the backend server. This PR fixes this issue by also setting `req.Host` in the request for the upgrade path and non upgrade path.

Relevant go issue: https://github.com/golang/go/issues/28168

Other people experiencing this bug: https://github.com/lensapp/lens/issues/873#issuecomment-692644642

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
none
```
