### PR TITLE
can-i: Return "no" for non existent resource or verb

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/auth/cani.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/auth/cani.go
@@ -62,6 +62,8 @@ type CanIOptions struct {
 	ResourceName   string
 	List           bool
 
+	allowed bool
+
 	genericclioptions.IOStreams
 }
 
@@ -103,6 +105,7 @@ var (
 // NewCmdCanI returns an initialized Command for 'auth can-i' sub command
 func NewCmdCanI(f cmdutil.Factory, streams genericclioptions.IOStreams) *cobra.Command {
 	o := &CanIOptions{
+		allowed:   true,
 		IOStreams: streams,
 	}
 
@@ -245,6 +248,11 @@ func (o *CanIOptions) RunAccessList() error {
 
 // RunAccessCheck checks if user has access to a certain resource or non resource URL
 func (o *CanIOptions) RunAccessCheck() (bool, error) {
+	if !o.allowed {
+		fmt.Fprintln(o.Out, "no")
+		return false, nil
+	}
+
 	var sar *authorizationv1.SelfSubjectAccessReview
 	if o.NonResourceURL == "" {
 		sar = &authorizationv1.SelfSubjectAccessReview{
@@ -309,6 +317,7 @@ func (o *CanIOptions) resourceFor(mapper meta.RESTMapper, resourceArg string) sc
 			} else {
 				fmt.Fprintf(o.ErrOut, "Warning: the server doesn't have a resource type '%s' in group '%s'\n", groupResource.Resource, groupResource.Group)
 			}
+			o.allowed = false
 			return schema.GroupVersionResource{Resource: resourceArg}
 		}
 	}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/auth/cani.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/auth/cani.go
@@ -210,6 +210,7 @@ func (o *CanIOptions) Validate() error {
 		}
 		if !isKnownNonResourceVerb(o.Verb) {
 			fmt.Fprintf(o.ErrOut, "Warning: verb '%s' is not a known verb\n", o.Verb)
+			o.allowed = false
 		}
 	} else if !o.Resource.Empty() && !o.AllNamespaces && o.DiscoveryClient != nil {
 		if namespaced, err := isNamespaced(o.Resource, o.DiscoveryClient); err == nil && !namespaced {
@@ -221,6 +222,7 @@ func (o *CanIOptions) Validate() error {
 		}
 		if !isKnownResourceVerb(o.Verb) {
 			fmt.Fprintf(o.ErrOut, "Warning: verb '%s' is not a known verb\n", o.Verb)
+			o.allowed = false
 		}
 
 	}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/auth/cani_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/auth/cani_test.go
@@ -149,6 +149,28 @@ func TestRunAccessCheck(t *testing.T) {
 				`{"resourceAttributes":{"namespace":"test","verb":"get","group":"extensions","resource":"deployments"}}`,
 			},
 		},
+		{
+			name: "nonExistentVerb1",
+			o: &CanIOptions{
+				allowed: true,
+			},
+			args:    []string{"foo", "pod"},
+			allowed: false,
+			expectedBodyStrings: []string{
+				`{"resourceAttributes":{"namespace":"test","verb":"foo","resource":"pods"}}`,
+			},
+		},
+		{
+			name: "nonExistentVerb2",
+			o: &CanIOptions{
+				allowed: true,
+			},
+			args:    []string{"foo", "/logs"},
+			allowed: false,
+			expectedBodyStrings: []string{
+				`{"nonResourceAttributes":{"path":"/logs","verb":"foo"}}`,
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/auth/cani_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/auth/cani_test.go
@@ -45,8 +45,10 @@ func TestRunAccessCheck(t *testing.T) {
 		expectedBodyStrings []string
 	}{
 		{
-			name:    "restmapping for args",
-			o:       &CanIOptions{},
+			name: "restmapping for args",
+			o: &CanIOptions{
+				allowed: true,
+			},
 			args:    []string{"get", "replicaset"},
 			allowed: true,
 			expectedBodyStrings: []string{
@@ -54,8 +56,10 @@ func TestRunAccessCheck(t *testing.T) {
 			},
 		},
 		{
-			name:    "simple success",
-			o:       &CanIOptions{},
+			name: "simple success",
+			o: &CanIOptions{
+				allowed: true,
+			},
 			args:    []string{"get", "deployments.extensions/foo"},
 			allowed: true,
 			expectedBodyStrings: []string{
@@ -66,6 +70,7 @@ func TestRunAccessCheck(t *testing.T) {
 			name: "all namespaces",
 			o: &CanIOptions{
 				AllNamespaces: true,
+				allowed:       true,
 			},
 			args:    []string{"get", "deployments.extensions/foo"},
 			allowed: true,
@@ -77,6 +82,7 @@ func TestRunAccessCheck(t *testing.T) {
 			name: "disallowed",
 			o: &CanIOptions{
 				AllNamespaces: true,
+				allowed:       true,
 			},
 			args:    []string{"get", "deployments.extensions/foo"},
 			allowed: false,
@@ -88,6 +94,7 @@ func TestRunAccessCheck(t *testing.T) {
 			name: "forcedError",
 			o: &CanIOptions{
 				AllNamespaces: true,
+				allowed:       true,
 			},
 			args:      []string{"get", "deployments.extensions/foo"},
 			allowed:   false,
@@ -101,6 +108,7 @@ func TestRunAccessCheck(t *testing.T) {
 			o: &CanIOptions{
 				AllNamespaces: true,
 				Subresource:   "log",
+				allowed:       true,
 			},
 			args:    []string{"get", "pods"},
 			allowed: true,
@@ -109,12 +117,36 @@ func TestRunAccessCheck(t *testing.T) {
 			},
 		},
 		{
-			name:    "nonResourceURL",
-			o:       &CanIOptions{},
+			name: "nonResourceURL",
+			o: &CanIOptions{
+				allowed: true,
+			},
 			args:    []string{"get", "/logs"},
 			allowed: true,
 			expectedBodyStrings: []string{
 				`{"nonResourceAttributes":{"path":"/logs","verb":"get"}}`,
+			},
+		},
+		{
+			name: "nonExistentResource1",
+			o: &CanIOptions{
+				allowed: true,
+			},
+			args:    []string{"get", "foo"},
+			allowed: false,
+			expectedBodyStrings: []string{
+				`{"resourceAttributes":{"namespace":"test","verb":"get","resource":"foo"}}`,
+			},
+		},
+		{
+			name: "nonExistentResource2",
+			o: &CanIOptions{
+				allowed: true,
+			},
+			args:    []string{"get", "deployment.extensions"},
+			allowed: false,
+			expectedBodyStrings: []string{
+				`{"resourceAttributes":{"namespace":"test","verb":"get","group":"extensions","resource":"deployments"}}`,
 			},
 		},
 	}
@@ -187,7 +219,10 @@ func TestRunAccessCheck(t *testing.T) {
 
 func TestRunAccessList(t *testing.T) {
 	t.Run("test access list", func(t *testing.T) {
-		options := &CanIOptions{List: true}
+		options := &CanIOptions{
+			List:    true,
+			allowed: true,
+		}
 		expectedOutput := "Resources   Non-Resource URLs   Resource Names    Verbs\n" +
 			"job.*       []                  [test-resource]   [get list]\n" +
 			"pod.*       []                  [test-resource]   [get list]\n" +

--- a/test/cmd/legacy-script.sh
+++ b/test/cmd/legacy-script.sh
@@ -787,6 +787,9 @@ runTests() {
     output_message=$(! kubectl auth can-i get invalid_resource 2>&1 "${kube_flags[@]}")
     kube::test::if_has_string "${output_message}" "the server doesn't have a resource type"
 
+    output_message=$(! kubectl auth can-i invalid_verb pods 2>&1 "${kube_flags[@]}")
+    kube::test::if_has_string "${output_message}" "Warning: verb 'invalid_verb' is not a known verb"
+
     output_message=$(kubectl auth can-i get /logs/ 2>&1 "${kube_flags[@]}")
     kube::test::if_has_string "${output_message}" "yes"
 

--- a/test/cmd/legacy-script.sh
+++ b/test/cmd/legacy-script.sh
@@ -784,7 +784,7 @@ runTests() {
     output_message=$(kubectl auth can-i get pods --subresource=log 2>&1 "${kube_flags[@]}")
     kube::test::if_has_string "${output_message}" "yes"
 
-    output_message=$(kubectl auth can-i get invalid_resource 2>&1 "${kube_flags[@]}")
+    output_message=$(! kubectl auth can-i get invalid_resource 2>&1 "${kube_flags[@]}")
     kube::test::if_has_string "${output_message}" "the server doesn't have a resource type"
 
     output_message=$(kubectl auth can-i get /logs/ 2>&1 "${kube_flags[@]}")
@@ -807,7 +807,7 @@ runTests() {
     kube::test::if_has_not_string "${output_message}" "Warning"
 
     # kubectl auth can-i get foo does not print a namespaced warning message, and only prints a single lookup error
-    output_message=$(kubectl auth can-i get foo 2>&1 "${kube_flags[@]}")
+    output_message=$(! kubectl auth can-i get foo 2>&1 "${kube_flags[@]}")
     kube::test::if_has_string "${output_message}" "Warning: the server doesn't have a resource type 'foo'"
     kube::test::if_has_not_string "${output_message}" "Warning: resource 'foo' is not namespace scoped"
 


### PR DESCRIPTION

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Previous can-i returns "yes" when non existent resource is specified.

```
$ kubectl auth can-i create xxx
Warning: the server doesn't have a resource type 'xxx'
yes

$ kubectl auth can-i get deployments.extensions
Warning: the server doesn't have a resource type 'deployments' in group 'extensions'
yes
```

Previous can-i returns "yes" when non existent verb is specified as well.

```
$ kubectl auth can-i xxx pod
Warning: verb 'xxx' is not a known verb
yes

$ kubectl auth can-i xxx /logs
Warning: verb 'xxx' is not a known verb
yes
```

This patch fixes the issue by returning "no".

**Which issue(s) this PR fixes**:
NONE

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
can-i : Return "no" when non existent resource or verb is specified
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs
NONE
```
