### PR TITLE
32bit > 4GB integer overflow edge case fix

### DIFF
--- a/cmd/kubeadm/app/preflight/checks_linux.go
+++ b/cmd/kubeadm/app/preflight/checks_linux.go
@@ -51,8 +51,8 @@ func (mc MemCheck) Check() (warnings, errorList []error) {
 		errorList = append(errorList, errors.Wrapf(err, "failed to get system info"))
 	}
 
-	// Totalram returns bytes; convert to MB
-	actual := uint64(info.Totalram) / 1024 / 1024
+	// Totalram holds the total usable memory. Unit holds the size of a memory unit in bytes. Multiply them and convert to MB
+	actual := uint64(info.Totalram) * uint64(info.Unit) / 1024 / 1024
 	if actual < mc.Mem {
 		errorList = append(errorList, errors.Errorf("the system RAM (%d MB) is less than the minimum %d MB", actual, mc.Mem))
 	}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug


**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes kubernetes/kubeadm#2365

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

Users will no longer get error incorrect when init'ing a master node on a 32-bit Linux Machine with > 4GB of Memory

```release-note
kubeadm: fix a bug in the host memory detection code on 32bit Linux platforms
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs

```
