### PR TITLE
clean rs by revision instead of creation timestamp in deployment controller

### DIFF
--- a/pkg/controller/deployment/BUILD
+++ b/pkg/controller/deployment/BUILD
@@ -78,6 +78,7 @@ go_test(
         "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/intstr:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/uuid:go_default_library",
         "//staging/src/k8s.io/client-go/informers:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/fake:go_default_library",

--- a/pkg/controller/deployment/sync.go
+++ b/pkg/controller/deployment/sync.go
@@ -448,7 +448,7 @@ func (dc *DeploymentController) cleanupDeployment(oldRSs []*apps.ReplicaSet, dep
 		return nil
 	}
 
-	sort.Sort(controller.ReplicaSetsByCreationTimestamp(cleanableRSes))
+	sort.Sort(deploymentutil.ReplicaSetsByRevision(cleanableRSes))
 	klog.V(4).Infof("Looking to cleanup old replica sets for deployment %q", deployment.Name)
 
 	for i := int32(0); i < diff; i++ {

--- a/pkg/controller/deployment/sync_test.go
+++ b/pkg/controller/deployment/sync_test.go
@@ -24,8 +24,10 @@ import (
 	apps "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
+	clienttesting "k8s.io/client-go/testing"
 	testclient "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/kubernetes/pkg/controller"
@@ -442,6 +444,148 @@ func TestDeploymentController_cleanupDeployment(t *testing.T) {
 		}
 		if gotDeletions != test.expectedDeletions {
 			t.Errorf("expect %v old replica sets been deleted, but got %v", test.expectedDeletions, gotDeletions)
+			continue
+		}
+	}
+}
+
+func TestDeploymentController_cleanupDeploymentOrder(t *testing.T) {
+	selector := map[string]string{"foo": "bar"}
+	now := metav1.Now()
+	duration := time.Minute
+
+	newRSWithRevisionAndCreationTimestamp := func(name string, replicas int, selector map[string]string, timestamp time.Time, revision string) *apps.ReplicaSet {
+		rs := rs(name, replicas, selector, metav1.NewTime(timestamp))
+		if revision != "" {
+			rs.Annotations = map[string]string{
+				deploymentutil.RevisionAnnotation: revision,
+			}
+		}
+		rs.Status = apps.ReplicaSetStatus{
+			Replicas: int32(replicas),
+		}
+		return rs
+	}
+
+	// for all test cases, creationTimestamp order keeps as: rs1 < rs2 < rs3 < r4
+	tests := []struct {
+		oldRSs               []*apps.ReplicaSet
+		revisionHistoryLimit int32
+		expectedDeletedRSs   sets.String
+	}{
+		{
+			// revision order: rs1 < rs2, delete rs1
+			oldRSs: []*apps.ReplicaSet{
+				newRSWithRevisionAndCreationTimestamp("foo-1", 0, selector, now.Add(-1*duration), "1"),
+				newRSWithRevisionAndCreationTimestamp("foo-2", 0, selector, now.Time, "2"),
+			},
+			revisionHistoryLimit: 1,
+			expectedDeletedRSs:   sets.NewString("foo-1"),
+		},
+		{
+			// revision order: rs2 < rs1, delete rs2
+			oldRSs: []*apps.ReplicaSet{
+				newRSWithRevisionAndCreationTimestamp("foo-1", 0, selector, now.Add(-1*duration), "2"),
+				newRSWithRevisionAndCreationTimestamp("foo-2", 0, selector, now.Time, "1"),
+			},
+			revisionHistoryLimit: 1,
+			expectedDeletedRSs:   sets.NewString("foo-2"),
+		},
+		{
+			// rs1 has revision but rs2 doesn't have revision, delete rs2
+			oldRSs: []*apps.ReplicaSet{
+				newRSWithRevisionAndCreationTimestamp("foo-1", 0, selector, now.Add(-1*duration), "1"),
+				newRSWithRevisionAndCreationTimestamp("foo-2", 0, selector, now.Time, ""),
+			},
+			revisionHistoryLimit: 1,
+			expectedDeletedRSs:   sets.NewString("foo-2"),
+		},
+		{
+			// rs1 doesn't have revision while rs2 has revision, delete rs1
+			oldRSs: []*apps.ReplicaSet{
+				newRSWithRevisionAndCreationTimestamp("foo-1", 0, selector, now.Add(-1*duration), ""),
+				newRSWithRevisionAndCreationTimestamp("foo-2", 0, selector, now.Time, "2"),
+			},
+			revisionHistoryLimit: 1,
+			expectedDeletedRSs:   sets.NewString("foo-1"),
+		},
+		{
+			// revision order: rs1 < rs2 < r3, but rs1 has replicas, delete rs2
+			oldRSs: []*apps.ReplicaSet{
+				newRSWithRevisionAndCreationTimestamp("foo-1", 1, selector, now.Add(-1*duration), "1"),
+				newRSWithRevisionAndCreationTimestamp("foo-2", 0, selector, now.Time, "2"),
+				newRSWithRevisionAndCreationTimestamp("foo-3", 0, selector, now.Add(duration), "3"),
+			},
+			revisionHistoryLimit: 1,
+			expectedDeletedRSs:   sets.NewString("foo-2"),
+		},
+		{
+			// revision order: rs1 < rs2 < r3, both rs1 && rs2 have replicas, don't delete
+			oldRSs: []*apps.ReplicaSet{
+				newRSWithRevisionAndCreationTimestamp("foo-1", 1, selector, now.Add(-1*duration), "1"),
+				newRSWithRevisionAndCreationTimestamp("foo-2", 1, selector, now.Time, "2"),
+				newRSWithRevisionAndCreationTimestamp("foo-3", 0, selector, now.Add(duration), "3"),
+			},
+			revisionHistoryLimit: 1,
+			expectedDeletedRSs:   sets.NewString(),
+		},
+		{
+			// revision order: rs2 < rs4 < rs1 < rs3, delete rs2 && rs4
+			oldRSs: []*apps.ReplicaSet{
+				newRSWithRevisionAndCreationTimestamp("foo-1", 0, selector, now.Add(-1*duration), "3"),
+				newRSWithRevisionAndCreationTimestamp("foo-2", 0, selector, now.Time, "1"),
+				newRSWithRevisionAndCreationTimestamp("foo-3", 0, selector, now.Add(duration), "4"),
+				newRSWithRevisionAndCreationTimestamp("foo-4", 0, selector, now.Add(2*duration), "2"),
+			},
+			revisionHistoryLimit: 2,
+			expectedDeletedRSs:   sets.NewString("foo-2", "foo-4"),
+		},
+	}
+
+	for i := range tests {
+		test := tests[i]
+		t.Logf("scenario %d", i)
+
+		fake := &fake.Clientset{}
+		informers := informers.NewSharedInformerFactory(fake, controller.NoResyncPeriodFunc())
+		controller, err := NewDeploymentController(informers.Apps().V1().Deployments(), informers.Apps().V1().ReplicaSets(), informers.Core().V1().Pods(), fake)
+		if err != nil {
+			t.Fatalf("error creating Deployment controller: %v", err)
+		}
+
+		controller.eventRecorder = &record.FakeRecorder{}
+		controller.dListerSynced = alwaysReady
+		controller.rsListerSynced = alwaysReady
+		controller.podListerSynced = alwaysReady
+		for _, rs := range test.oldRSs {
+			informers.Apps().V1().ReplicaSets().Informer().GetIndexer().Add(rs)
+		}
+
+		stopCh := make(chan struct{})
+		defer close(stopCh)
+		informers.Start(stopCh)
+
+		d := newDeployment("foo", 1, &test.revisionHistoryLimit, nil, nil, map[string]string{"foo": "bar"})
+		controller.cleanupDeployment(test.oldRSs, d)
+
+		deletedRSs := sets.String{}
+		for _, action := range fake.Actions() {
+			deleteAction, ok := action.(clienttesting.DeleteActionImpl)
+			if !ok {
+				t.Logf("Found not-delete action with verb %v. Ignoring.", action.GetVerb())
+				continue
+			}
+
+			if deleteAction.GetResource().Resource != "replicasets" {
+				continue
+			}
+
+			deletedRSs.Insert(deleteAction.GetName())
+		}
+		t.Logf("&test.revisionHistoryLimit: %d, &test.deletedReplicaSets: %v", test.revisionHistoryLimit, deletedRSs)
+
+		if !test.expectedDeletedRSs.Equal(deletedRSs) {
+			t.Errorf("expect to delete old replica sets %v, but got %v", test.expectedDeletedRSs, deletedRSs)
 			continue
 		}
 	}

--- a/pkg/controller/deployment/sync_test.go
+++ b/pkg/controller/deployment/sync_test.go
@@ -27,7 +27,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
-	clienttesting "k8s.io/client-go/testing"
 	testclient "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/kubernetes/pkg/controller"
@@ -570,7 +569,7 @@ func TestDeploymentController_cleanupDeploymentOrder(t *testing.T) {
 
 		deletedRSs := sets.String{}
 		for _, action := range fake.Actions() {
-			deleteAction, ok := action.(clienttesting.DeleteActionImpl)
+			deleteAction, ok := action.(testclient.DeleteActionImpl)
 			if !ok {
 				t.Logf("Found not-delete action with verb %v. Ignoring.", action.GetVerb())
 				continue

--- a/pkg/controller/deployment/util/deployment_util.go
+++ b/pkg/controller/deployment/util/deployment_util.go
@@ -949,3 +949,18 @@ func GetDeploymentsForReplicaSet(deploymentLister appslisters.DeploymentLister, 
 
 	return deployments, nil
 }
+
+// ReplicaSetsByRevision sorts a list of ReplicaSet by revision, using their creation timestamp or name as a tie breaker.
+// By using the creation timestamp, this sorts from old to new replica sets.
+type ReplicaSetsByRevision []*apps.ReplicaSet
+
+func (o ReplicaSetsByRevision) Len() int      { return len(o) }
+func (o ReplicaSetsByRevision) Swap(i, j int) { o[i], o[j] = o[j], o[i] }
+func (o ReplicaSetsByRevision) Less(i, j int) bool {
+	revision1, err1 := Revision(o[i])
+	revision2, err2 := Revision(o[j])
+	if err1 != nil || err2 != nil || revision1 == revision2 {
+		return controller.ReplicaSetsByCreationTimestamp(o).Less(i, j)
+	}
+	return revision1 < revision2
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design


Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug   

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #82570 reported by myself, and I also add some test cases
**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
Clean ReplicaSet by revision instead of creation timestamp in deployment controller
```

