### PR TITLE
kubectl wait ensures observedGeneration >= generation

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/wait/wait.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/wait/wait.go
@@ -442,6 +442,13 @@ func (w ConditionalWait) checkCondition(obj *unstructured.Unstructured) (bool, e
 		if !found || err != nil {
 			continue
 		}
+		generation, found, _ := unstructured.NestedInt64(obj.Object, "metadata", "generation")
+		if found {
+			observedGeneration, found := getObservedGeneration(obj, condition)
+			if found && observedGeneration < generation {
+				return false, nil
+			}
+		}
 		return strings.EqualFold(status, w.conditionStatus), nil
 	}
 
@@ -466,4 +473,13 @@ func (w ConditionalWait) isConditionMet(event watch.Event) (bool, error) {
 
 func extendErrWaitTimeout(err error, info *resource.Info) error {
 	return fmt.Errorf("%s on %s/%s", err.Error(), info.Mapping.Resource.Resource, info.Name)
+}
+
+func getObservedGeneration(obj *unstructured.Unstructured, condition map[string]interface{}) (int64, bool) {
+	conditionObservedGeneration, found, _ := unstructured.NestedInt64(condition, "observedGeneration")
+	if found {
+		return conditionObservedGeneration, true
+	}
+	statusObservedGeneration, found, _ := unstructured.NestedInt64(obj.Object, "status", "observedGeneration")
+	return statusObservedGeneration, found
 }

--- a/staging/src/k8s.io/kubectl/pkg/cmd/wait/wait_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/wait/wait_test.go
@@ -60,6 +60,21 @@ func newUnstructured(apiVersion, kind, namespace, name string) *unstructured.Uns
 	}
 }
 
+func newUnstructuredWithGeneration(apiVersion, kind, namespace, name string, generation int64) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": apiVersion,
+			"kind":       kind,
+			"metadata": map[string]interface{}{
+				"namespace":  namespace,
+				"name":       name,
+				"uid":        "some-UID-value",
+				"generation": generation,
+			},
+		},
+	}
+}
+
 func newUnstructuredStatus(status *metav1.Status) runtime.Unstructured {
 	obj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(status)
 	if err != nil {
@@ -75,6 +90,17 @@ func addCondition(in *unstructured.Unstructured, name, status string) *unstructu
 	conditions = append(conditions, map[string]interface{}{
 		"type":   name,
 		"status": status,
+	})
+	unstructured.SetNestedSlice(in.Object, conditions, "status", "conditions")
+	return in
+}
+
+func addConditionWithObservedGeneration(in *unstructured.Unstructured, name, status string, observedGeneration int64) *unstructured.Unstructured {
+	conditions, _, _ := unstructured.NestedSlice(in.Object, "status", "conditions")
+	conditions = append(conditions, map[string]interface{}{
+		"type":               name,
+		"status":             status,
+		"observedGeneration": observedGeneration,
 	})
 	unstructured.SetNestedSlice(in.Object, conditions, "status", "conditions")
 	return in
@@ -760,6 +786,82 @@ func TestWaitForCondition(t *testing.T) {
 					t.Error(spew.Sdump(actions))
 				}
 				if !actions[3].Matches("watch", "theresource") {
+					t.Error(spew.Sdump(actions))
+				}
+			},
+		},
+		{
+			name: "times out due to observedGeneration",
+			infos: []*resource.Info{
+				{
+					Mapping: &meta.RESTMapping{
+						Resource: schema.GroupVersionResource{Group: "group", Version: "version", Resource: "theresource"},
+					},
+					Name:      "name-foo",
+					Namespace: "ns-foo",
+				},
+			},
+			fakeClient: func() *dynamicfakeclient.FakeDynamicClient {
+				fakeClient := dynamicfakeclient.NewSimpleDynamicClientWithCustomListKinds(scheme, listMapping)
+				fakeClient.PrependReactor("list", "theresource", func(action clienttesting.Action) (handled bool, ret runtime.Object, err error) {
+					return true, addConditionWithObservedGeneration(
+						newUnstructuredWithGeneration("group/version", "TheKind", "ns-foo", "name-foo", 2),
+						"the-condition", "status-value", 1,
+					), nil
+				})
+				return fakeClient
+			},
+			timeout: 1 * time.Second,
+
+			expectedErr: "timed out waiting for the condition on theresource/name-foo",
+			validateActions: func(t *testing.T, actions []clienttesting.Action) {
+				if len(actions) != 2 {
+					t.Fatal(spew.Sdump(actions))
+				}
+				if !actions[0].Matches("list", "theresource") || actions[0].(clienttesting.ListAction).GetListRestrictions().Fields.String() != "metadata.name=name-foo" {
+					t.Error(spew.Sdump(actions))
+				}
+				if !actions[1].Matches("watch", "theresource") {
+					t.Error(spew.Sdump(actions))
+				}
+			},
+		},
+		{
+			name: "handles watch observedGeneration change",
+			infos: []*resource.Info{
+				{
+					Mapping: &meta.RESTMapping{
+						Resource: schema.GroupVersionResource{Group: "group", Version: "version", Resource: "theresource"},
+					},
+					Name:      "name-foo",
+					Namespace: "ns-foo",
+				},
+			},
+			fakeClient: func() *dynamicfakeclient.FakeDynamicClient {
+				fakeClient := dynamicfakeclient.NewSimpleDynamicClientWithCustomListKinds(scheme, listMapping)
+				fakeClient.PrependReactor("list", "theresource", func(action clienttesting.Action) (handled bool, ret runtime.Object, err error) {
+					return true, newUnstructuredList(addConditionWithObservedGeneration(newUnstructuredWithGeneration("group/version", "TheKind", "ns-foo", "name-foo", 2), "the-condition", "status-value", 1)), nil
+				})
+				fakeClient.PrependWatchReactor("theresource", func(action clienttesting.Action) (handled bool, ret watch.Interface, err error) {
+					fakeWatch := watch.NewRaceFreeFake()
+					fakeWatch.Action(watch.Modified, addConditionWithObservedGeneration(
+						newUnstructuredWithGeneration("group/version", "TheKind", "ns-foo", "name-foo", 2),
+						"the-condition", "status-value", 2,
+					))
+					return true, fakeWatch, nil
+				})
+				return fakeClient
+			},
+			timeout: 10 * time.Second,
+
+			validateActions: func(t *testing.T, actions []clienttesting.Action) {
+				if len(actions) != 2 {
+					t.Fatal(spew.Sdump(actions))
+				}
+				if !actions[0].Matches("list", "theresource") || actions[0].(clienttesting.ListAction).GetListRestrictions().Fields.String() != "metadata.name=name-foo" {
+					t.Error(spew.Sdump(actions))
+				}
+				if !actions[1].Matches("watch", "theresource") {
 					t.Error(spew.Sdump(actions))
 				}
 			},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:
Ensures that kubectl wait checks observedGeneration >= generation of the object before completing if observedGeneration exists (on either .status.conditions or .status).

**Why is this needed**:
script does the following
1. kubectl to update a CRD
    1. This causes a condition to go from `True` -> `False` when the controller will update the status
1. kubectl to wait for CRD to return condition `True`

However if the controller that updates the status has yet to realize the change and reset it to false by the time step 2 runs, kubectl will return immediately as the condition reflects stale state.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubectl/issues/962

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kubectl wait ensures that observedGeneration >= generation if applicable
```
