### PR TITLE
remove alpha scheduler annotations for taints and tolerations

### DIFF
--- a/pkg/apis/core/annotation_key_constants.go
+++ b/pkg/apis/core/annotation_key_constants.go
@@ -29,14 +29,6 @@ const (
 	// MirrorPodAnnotationKey represents the annotation key set by kubelets when creating mirror pods
 	MirrorPodAnnotationKey string = "kubernetes.io/config.mirror"
 
-	// TolerationsAnnotationKey represents the key of tolerations data (json serialized)
-	// in the Annotations of a Pod.
-	TolerationsAnnotationKey string = "scheduler.alpha.kubernetes.io/tolerations"
-
-	// TaintsAnnotationKey represents the key of taints data (json serialized)
-	// in the Annotations of a Node.
-	TaintsAnnotationKey string = "scheduler.alpha.kubernetes.io/taints"
-
 	// SeccompPodAnnotationKey represents the key of a seccomp profile applied
 	// to all containers of a pod.
 	// Deprecated: set a pod security context `seccompProfile` field.

--- a/pkg/apis/core/helper/helpers.go
+++ b/pkg/apis/core/helper/helpers.go
@@ -17,7 +17,6 @@ limitations under the License.
 package helper
 
 import (
-	"encoding/json"
 	"fmt"
 	"strings"
 

--- a/pkg/apis/core/helper/helpers.go
+++ b/pkg/apis/core/helper/helpers.go
@@ -405,19 +405,6 @@ func NodeSelectorRequirementsAsFieldSelector(nsm []core.NodeSelectorRequirement)
 	return fields.AndSelectors(selectors...), nil
 }
 
-// GetTolerationsFromPodAnnotations gets the json serialized tolerations data from Pod.Annotations
-// and converts it to the []Toleration type in core.
-func GetTolerationsFromPodAnnotations(annotations map[string]string) ([]core.Toleration, error) {
-	var tolerations []core.Toleration
-	if len(annotations) > 0 && annotations[core.TolerationsAnnotationKey] != "" {
-		err := json.Unmarshal([]byte(annotations[core.TolerationsAnnotationKey]), &tolerations)
-		if err != nil {
-			return tolerations, err
-		}
-	}
-	return tolerations, nil
-}
-
 // AddOrUpdateTolerationInPod tries to add a toleration to the pod's toleration list.
 // Returns true if something was updated, false otherwise.
 func AddOrUpdateTolerationInPod(pod *core.Pod, toleration *core.Toleration) bool {
@@ -444,19 +431,6 @@ func AddOrUpdateTolerationInPod(pod *core.Pod, toleration *core.Toleration) bool
 
 	pod.Spec.Tolerations = newTolerations
 	return true
-}
-
-// GetTaintsFromNodeAnnotations gets the json serialized taints data from Pod.Annotations
-// and converts it to the []Taint type in core.
-func GetTaintsFromNodeAnnotations(annotations map[string]string) ([]core.Taint, error) {
-	var taints []core.Taint
-	if len(annotations) > 0 && annotations[core.TaintsAnnotationKey] != "" {
-		err := json.Unmarshal([]byte(annotations[core.TaintsAnnotationKey]), &taints)
-		if err != nil {
-			return []core.Taint{}, err
-		}
-	}
-	return taints, nil
 }
 
 // GetPersistentVolumeClass returns StorageClassName.

--- a/pkg/apis/core/validation/validation.go
+++ b/pkg/apis/core/validation/validation.go
@@ -139,29 +139,8 @@ func ValidatePodSpecificAnnotations(annotations map[string]string, spec *core.Po
 		}
 	}
 
-	if annotations[core.TolerationsAnnotationKey] != "" {
-		allErrs = append(allErrs, ValidateTolerationsInPodAnnotations(annotations, fldPath)...)
-	}
-
 	allErrs = append(allErrs, ValidateSeccompPodAnnotations(annotations, fldPath)...)
 	allErrs = append(allErrs, ValidateAppArmorPodAnnotations(annotations, spec, fldPath)...)
-
-	return allErrs
-}
-
-// ValidateTolerationsInPodAnnotations tests that the serialized tolerations in Pod.Annotations has valid data
-func ValidateTolerationsInPodAnnotations(annotations map[string]string, fldPath *field.Path) field.ErrorList {
-	allErrs := field.ErrorList{}
-
-	tolerations, err := helper.GetTolerationsFromPodAnnotations(annotations)
-	if err != nil {
-		allErrs = append(allErrs, field.Invalid(fldPath, core.TolerationsAnnotationKey, err.Error()))
-		return allErrs
-	}
-
-	if len(tolerations) > 0 {
-		allErrs = append(allErrs, ValidateTolerations(tolerations, fldPath.Child(core.TolerationsAnnotationKey))...)
-	}
 
 	return allErrs
 }
@@ -4598,23 +4577,6 @@ func ValidateReadOnlyPersistentDisks(volumes []core.Volume, fldPath *field.Path)
 	return allErrs
 }
 
-// ValidateTaintsInNodeAnnotations tests that the serialized taints in Node.Annotations has valid data
-func ValidateTaintsInNodeAnnotations(annotations map[string]string, fldPath *field.Path) field.ErrorList {
-	allErrs := field.ErrorList{}
-
-	taints, err := helper.GetTaintsFromNodeAnnotations(annotations)
-	if err != nil {
-		allErrs = append(allErrs, field.Invalid(fldPath, core.TaintsAnnotationKey, err.Error()))
-		return allErrs
-	}
-
-	if len(taints) > 0 {
-		allErrs = append(allErrs, validateNodeTaints(taints, fldPath.Child(core.TaintsAnnotationKey))...)
-	}
-
-	return allErrs
-}
-
 // validateNodeTaints tests if given taints have valid data.
 func validateNodeTaints(taints []core.Taint, fldPath *field.Path) field.ErrorList {
 	allErrors := field.ErrorList{}
@@ -4651,10 +4613,6 @@ func validateNodeTaints(taints []core.Taint, fldPath *field.Path) field.ErrorLis
 
 func ValidateNodeSpecificAnnotations(annotations map[string]string, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
-
-	if annotations[core.TaintsAnnotationKey] != "" {
-		allErrs = append(allErrs, ValidateTaintsInNodeAnnotations(annotations, fldPath)...)
-	}
 
 	if annotations[core.PreferAvoidPodsAnnotationKey] != "" {
 		allErrs = append(allErrs, ValidateAvoidPodsInNodeAnnotations(annotations, fldPath)...)

--- a/staging/src/k8s.io/api/core/v1/annotation_key_constants.go
+++ b/staging/src/k8s.io/api/core/v1/annotation_key_constants.go
@@ -29,14 +29,6 @@ const (
 	// MirrorAnnotationKey represents the annotation key set by kubelets when creating mirror pods
 	MirrorPodAnnotationKey string = "kubernetes.io/config.mirror"
 
-	// TolerationsAnnotationKey represents the key of tolerations data (json serialized)
-	// in the Annotations of a Pod.
-	TolerationsAnnotationKey string = "scheduler.alpha.kubernetes.io/tolerations"
-
-	// TaintsAnnotationKey represents the key of taints data (json serialized)
-	// in the Annotations of a Node.
-	TaintsAnnotationKey string = "scheduler.alpha.kubernetes.io/taints"
-
 	// SeccompPodAnnotationKey represents the key of a seccomp profile applied
 	// to all containers of a pod.
 	// Deprecated: set a pod security context `seccompProfile` field.


### PR DESCRIPTION
Currently, we use taints  as node filed and tolerations as pod fileds. https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/

After reading #25320, it seems the annotations for taints and tolerations are old ways in 1.6. The removed annotations here are not documented in kubernetes docs.  Should we remove them or mark them as deprecated?  
`scheduler.alpha.kubernetes.io/tolerations` and `scheduler.alpha.kubernetes.io/taints` now are used in validation only. 

Other alpha annotations about scheduler are used in scheduler plugin and admission controller.  

To summarize annotations for scheduler,
**NodePreferAvoidPods**
- Used in scheduler plugin. NodePreferAvoidPods: Scores nodes according to the node annotation scheduler.alpha.kubernetes.io/preferAvoidPods. Extension points: Score.
-  NodePreferAvoidPodsPriority: Prioritizes nodes according to the node annotation scheduler.alpha.kubernetes.io/preferAvoidPods. You can use this to hint that two different Pods shouldn't run on the same Node.

**PodNodeSelector Admission Controller**
https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#podnodeselector
```
	NSDefaultTolerations string = "scheduler.alpha.kubernetes.io/defaultTolerations"
	NSWLTolerations      string = "scheduler.alpha.kubernetes.io/tolerationsWhitelist"
```


**What type of PR is this?**
/kind deprecation

**What this PR does / why we need it**:
Make cluster use field-based taints and remove annotation-based taints

**Which issue(s) this PR fixes**:
https://github.com/kubernetes/kubernetes/issues/25320#issuecomment-529031483


**Special notes for your reviewer**:



**Does this PR introduce a user-facing change?**:

```release-note
Remove annotation-based taints and tolerations.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
