### PR TITLE
fix Azure file share not deleted issue when the namespace is deleted

### DIFF
--- a/pkg/volume/azure_file/azure_file.go
+++ b/pkg/volume/azure_file/azure_file.go
@@ -55,7 +55,8 @@ var _ volume.PersistentVolumePlugin = &azureFilePlugin{}
 var _ volume.ExpandableVolumePlugin = &azureFilePlugin{}
 
 const (
-	azureFilePluginName = "kubernetes.io/azure-file"
+	azureFilePluginName    = "kubernetes.io/azure-file"
+	defaultSecretNamespace = "default"
 )
 
 func getPath(uid types.UID, volName string, host volume.VolumeHost) string {
@@ -115,7 +116,7 @@ func (plugin *azureFilePlugin) newMounterInternal(spec *volume.Spec, pod *v1.Pod
 	if err != nil {
 		return nil, err
 	}
-	secretName, secretNamespace, err := getSecretNameAndNamespace(spec, pod.Namespace)
+	secretName, secretNamespace, err := getSecretNameAndNamespace(spec, defaultSecretNamespace)
 	if err != nil {
 		// Log-and-continue instead of returning an error for now
 		// due to unspecified backwards compatibility concerns (a subject to revise)
@@ -173,7 +174,7 @@ func (plugin *azureFilePlugin) ExpandVolumeDevice(
 		resourceGroup = spec.PersistentVolume.ObjectMeta.Annotations[resourceGroupAnnotation]
 	}
 
-	secretName, secretNamespace, err := getSecretNameAndNamespace(spec, spec.PersistentVolume.Spec.ClaimRef.Namespace)
+	secretName, secretNamespace, err := getSecretNameAndNamespace(spec, defaultSecretNamespace)
 	if err != nil {
 		return oldSize, err
 	}

--- a/pkg/volume/azure_file/azure_provision.go
+++ b/pkg/volume/azure_file/azure_provision.go
@@ -79,7 +79,7 @@ func (plugin *azureFilePlugin) newDeleterInternal(spec *volume.Spec, util azureU
 		return nil, fmt.Errorf("invalid PV spec")
 	}
 
-	secretName, secretNamespace, err := getSecretNameAndNamespace(spec, spec.PersistentVolume.Spec.ClaimRef.Namespace)
+	secretName, secretNamespace, err := getSecretNameAndNamespace(spec, defaultSecretNamespace)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
fix Azure file share not deleted issue when the namespace is deleted
default namespace should always be `default`

PV deletion error when PVC is created in a namespace, e.g. `test`
```
status:
  message: 'Failed to create deleter for volume "pvc-353f3a5c-640f-48c8-add7-a7f7fb13025a":
    Couldn''t get secret test/azure-storage-account-andyblobtest-secret'
  phase: Failed
# k get pv pvc-353f3a5c-640f-48c8-add7-a7f7fb13025a
NAME                                       CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM                STORAGECLASS   REASON   AGE
pvc-353f3a5c-640f-48c8-add7-a7f7fb13025a   5Gi        RWX            Delete           Failed   test/pvc-azurefile   azurefile               3m13s
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes-sigs/azurefile-csi-driver/issues/500

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
fix Azure file share not deleted issue when the namespace is deleted
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
fix Azure file share not deleted issue when the namespace is deleted
```

/kind bug
/priority important-soon
/sig cloud-provider
/area provider/azure
/triage accepted