### PR TITLE
Fix the data race in the leaderelection package

### DIFF
--- a/staging/src/k8s.io/client-go/tools/leaderelection/leaderelection.go
+++ b/staging/src/k8s.io/client-go/tools/leaderelection/leaderelection.go
@@ -56,6 +56,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"sync"
 	"time"
 
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -187,6 +188,9 @@ type LeaderElector struct {
 	// clock is wrapper around time to allow for less flaky testing
 	clock clock.Clock
 
+	// used to lock the observedRecord
+	observedRecordLock sync.Mutex
+
 	metrics leaderMetricsAdapter
 }
 
@@ -224,13 +228,14 @@ func RunOrDie(ctx context.Context, lec LeaderElectionConfig) {
 
 // GetLeader returns the identity of the last observed leader or returns the empty string if
 // no leader has yet been observed.
+// This function is for informational purposes. (e.g. monitoring, logs, etc.)
 func (le *LeaderElector) GetLeader() string {
-	return le.observedRecord.HolderIdentity
+	return le.getObservedRecord().HolderIdentity
 }
 
 // IsLeader returns true if the last observed leader was this client else returns false.
 func (le *LeaderElector) IsLeader() bool {
-	return le.observedRecord.HolderIdentity == le.config.Lock.Identity()
+	return le.getObservedRecord().HolderIdentity == le.config.Lock.Identity()
 }
 
 // acquire loops calling tryAcquireOrRenew and returns true immediately when tryAcquireOrRenew succeeds.
@@ -301,8 +306,8 @@ func (le *LeaderElector) release() bool {
 		klog.Errorf("Failed to release lock: %v", err)
 		return false
 	}
-	le.observedRecord = leaderElectionRecord
-	le.observedTime = le.clock.Now()
+
+	le.setObservedRecord(&leaderElectionRecord)
 	return true
 }
 
@@ -329,16 +334,17 @@ func (le *LeaderElector) tryAcquireOrRenew(ctx context.Context) bool {
 			klog.Errorf("error initially creating leader election record: %v", err)
 			return false
 		}
-		le.observedRecord = leaderElectionRecord
-		le.observedTime = le.clock.Now()
+
+		le.setObservedRecord(&leaderElectionRecord)
+
 		return true
 	}
 
 	// 2. Record obtained, check the Identity & Time
 	if !bytes.Equal(le.observedRawRecord, oldLeaderElectionRawRecord) {
-		le.observedRecord = *oldLeaderElectionRecord
+		le.setObservedRecord(oldLeaderElectionRecord)
+
 		le.observedRawRecord = oldLeaderElectionRawRecord
-		le.observedTime = le.clock.Now()
 	}
 	if len(oldLeaderElectionRecord.HolderIdentity) > 0 &&
 		le.observedTime.Add(le.config.LeaseDuration).After(now.Time) &&
@@ -362,8 +368,7 @@ func (le *LeaderElector) tryAcquireOrRenew(ctx context.Context) bool {
 		return false
 	}
 
-	le.observedRecord = leaderElectionRecord
-	le.observedTime = le.clock.Now()
+	le.setObservedRecord(&leaderElectionRecord)
 	return true
 }
 
@@ -391,4 +396,23 @@ func (le *LeaderElector) Check(maxTolerableExpiredLease time.Duration) error {
 	}
 
 	return nil
+}
+
+// setObservedRecord will set a new observedRecord and update observedTime to the current time.
+// Protect critical sections with lock.
+func (le *LeaderElector) setObservedRecord(observedRecord *rl.LeaderElectionRecord) {
+	le.observedRecordLock.Lock()
+	defer le.observedRecordLock.Unlock()
+
+	le.observedRecord = *observedRecord
+	le.observedTime = le.clock.Now()
+}
+
+// getObservedRecord returns observersRecord.
+// Protect critical sections with lock.
+func (le *LeaderElector) getObservedRecord() rl.LeaderElectionRecord {
+	le.observedRecordLock.Lock()
+	defer le.observedRecordLock.Unlock()
+
+	return le.observedRecord
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:

Fix the data race in the leaderelection package.

```
WARNING: DATA RACE
Read at 0x00c0007dc3c0 by goroutine 116:
  k8s.io/client-go/tools/leaderelection.(*LeaderElector).IsLeader()
      /home/circleci/go/pkg/mod/k8s.io/client-go@v0.19.6/tools/leaderelection/leaderelection.go:233 +0x12d
...

Previous write at 0x00c0007dc3c0 by goroutine 111:
  k8s.io/client-go/tools/leaderelection.(*LeaderElector).tryAcquireOrRenew()
      /home/circleci/go/pkg/mod/k8s.io/client-go@v0.19.6/tools/leaderelection/leaderelection.go:365 +0xc84
  k8s.io/client-go/tools/leaderelection.(*LeaderElector).renew.func1.1()
      /home/circleci/go/pkg/mod/k8s.io/client-go@v0.19.6/tools/leaderelection/leaderelection.go:267 +0x53
  k8s.io/apimachinery/pkg/util/wait.PollImmediateUntil()
      /home/circleci/go/pkg/mod/k8s.io/apimachinery@v0.19.6/pkg/util/wait/wait.go:500 +0x38
  k8s.io/client-go/tools/leaderelection.(*LeaderElector).renew.func1()
      /home/circleci/go/pkg/mod/k8s.io/client-go@v0.19.6/tools/leaderelection/leaderelection.go:266 +0x1ab
  k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1()
      /home/circleci/go/pkg/mod/k8s.io/apimachinery@v0.19.6/pkg/util/wait/wait.go:155 +0x75
  k8s.io/apimachinery/pkg/util/wait.BackoffUntil()
      /home/circleci/go/pkg/mod/k8s.io/apimachinery@v0.19.6/pkg/util/wait/wait.go:156 +0xba
  k8s.io/apimachinery/pkg/util/wait.JitterUntil()
      /home/circleci/go/pkg/mod/k8s.io/apimachinery@v0.19.6/pkg/util/wait/wait.go:133 +0x114
  k8s.io/apimachinery/pkg/util/wait.Until()
      /home/circleci/go/pkg/mod/k8s.io/apimachinery@v0.19.6/pkg/util/wait/wait.go:90 +0x189
  k8s.io/client-go/tools/leaderelection.(*LeaderElector).renew()
      /home/circleci/go/pkg/mod/k8s.io/client-go@v0.19.6/tools/leaderelection/leaderelection.go:263 +0xd3
  k8s.io/client-go/tools/leaderelection.(*LeaderElector).Run()
      /home/circleci/go/pkg/mod/k8s.io/client-go@v0.19.6/tools/leaderelection/leaderelection.go:209 +0x1e4
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/client-go/issues/857

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
