### PR TITLE
Fix bug in CPUManager with race on container map access

### DIFF
--- a/pkg/kubelet/cm/cpumanager/cpu_manager.go
+++ b/pkg/kubelet/cm/cpumanager/cpu_manager.go
@@ -402,6 +402,7 @@ func (m *manager) reconcileState() (success []reconciledContainer, failure []rec
 				continue
 			}
 
+			m.Lock()
 			if cstatus.State.Terminated != nil {
 				// The container is terminated but we can't call m.RemoveContainer()
 				// here because it could remove the allocated cpuset for the container
@@ -412,6 +413,7 @@ func (m *manager) reconcileState() (success []reconciledContainer, failure []rec
 				if err == nil {
 					klog.Warningf("[cpumanager] reconcileState: ignoring terminated container (pod: %s, container id: %s)", pod.Name, containerID)
 				}
+				m.Unlock()
 				continue
 			}
 
@@ -419,6 +421,7 @@ func (m *manager) reconcileState() (success []reconciledContainer, failure []rec
 			// Idempotently add it to the containerMap incase it is missing.
 			// This can happen after a kubelet restart, for example.
 			m.containerMap.Add(string(pod.UID), container.Name, containerID)
+			m.Unlock()
 
 			cset := m.state.GetCPUSetOrDefault(string(pod.UID), container.Name)
 			if cset.IsEmpty() {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Fixes a sporadic bug that causes the `kubelet` to crash:
```
Dec 19 12:01:13 ngcdgx2k8s0094d kubelet[69329]: fatal error: concurrent map iteration and map write
Dec 19 12:01:13 ngcdgx2k8s0094d kubelet[69329]: goroutine 141 [running]:
Dec 19 12:01:13 ngcdgx2k8s0094d kubelet[69329]: runtime.throw(0x43a5919, 0x26)
Dec 19 12:01:13 ngcdgx2k8s0094d kubelet[69329]:         /usr/local/go/src/runtime/panic.go:774 +0x72 fp=0xc0036eaca8 sp=0xc0036eac78 pc=0x432eb2
Dec 19 12:01:13 ngcdgx2k8s0094d kubelet[69329]: runtime.mapiternext(0xc0036eadb0)
Dec 19 12:01:13 ngcdgx2k8s0094d kubelet[69329]:         /usr/local/go/src/runtime/map.go:858 +0x579 fp=0xc0036ead30 sp=0xc0036eaca8 pc=0x412db9
Dec 19 12:01:13 ngcdgx2k8s0094d kubelet[69329]: k8s.io/kubernetes/pkg/kubelet/cm/cpumanager/containermap.ContainerMap.GetContainerID(0xc000cae360, 0xc002671350, 0x24, 0xc0038c15a0, 0xb, 0xc0038c15a0, 0xb, 0x0, 0x0)
Dec 19 12:01:13 ngcdgx2k8s0094d kubelet[69329]:         /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/pkg/kubelet/cm/cpumanager/containermap/container_map.go:57 +0x9e fp=0xc0036eae20 sp=0xc0036ead30 pc=0x1b2806e
Dec 19 12:01:13 ngcdgx2k8s0094d kubelet[69329]: k8s.io/kubernetes/pkg/kubelet/cm/cpumanager/containermap.ContainerMap.RemoveByContainerRef(...)
Dec 19 12:01:13 ngcdgx2k8s0094d kubelet[69329]:         /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/pkg/kubelet/cm/cpumanager/containermap/container_map.go:49
Dec 19 12:01:13 ngcdgx2k8s0094d kubelet[69329]: k8s.io/kubernetes/pkg/kubelet/cm/cpumanager.(*manager).policyRemoveContainerByRef(0xc00065c990, 0xc002671350, 0x24, 0xc0038c15a0, 0xb, 0x2, 0x2)
```

```release-note
Fixed bug in CPUManager with race on container map access
```