### PR TITLE
Additional subnet configuration options for AWS ELB

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/aws/tags.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/aws/tags.go
@@ -152,6 +152,15 @@ func (t *awsTagging) hasClusterTag(tags []*ec2.Tag) bool {
 	return false
 }
 
+func (t *awsTagging) hasNoClusterPrefixTag(tags []*ec2.Tag) bool {
+	for _, tag := range tags {
+		if strings.HasPrefix(aws.StringValue(tag.Key), TagNameKubernetesClusterPrefix) {
+			return false
+		}
+	}
+	return true
+}
+
 // Ensure that a resource has the correct tags
 // If it has no tags, we assume that this was a problem caused by an error in between creation and tagging,
 // and we add the tags.  If it has a different cluster's tags, that is an error.

--- a/staging/src/k8s.io/legacy-cloud-providers/aws/tags_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/aws/tags_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestFilterTags(t *testing.T) {
@@ -180,5 +181,54 @@ func TestHasClusterTag(t *testing.T) {
 		if result != g.Expected {
 			t.Errorf("Unexpected result for tags %v: %t", g.Tags, result)
 		}
+	}
+}
+
+func TestHasNoClusterPrefixTag(t *testing.T) {
+	awsServices := NewFakeAWSServices(TestClusterID)
+	c, err := newAWSCloud(CloudConfig{}, awsServices)
+	if err != nil {
+		t.Errorf("Error building aws cloud: %v", err)
+		return
+	}
+	tests := []struct {
+		name string
+		tags []*ec2.Tag
+		want bool
+	}{
+		{
+			name: "no tags",
+			want: true,
+		},
+		{
+			name: "no cluster tags",
+			tags: []*ec2.Tag{
+				{
+					Key:   aws.String("not a cluster tag"),
+					Value: aws.String("true"),
+				},
+			},
+			want: true,
+		},
+		{
+			name: "contains cluster tags",
+			tags: []*ec2.Tag{
+				{
+					Key:   aws.String("tag1"),
+					Value: aws.String("value1"),
+				},
+				{
+					Key:   aws.String("kubernetes.io/cluster/test.cluster"),
+					Value: aws.String("owned"),
+				},
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, c.tagging.hasNoClusterPrefixTag(tt.tags))
+		})
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:
This fix fulfills the security requirements of choosing specific set of subnets per load balancer on the same cluster.

We need this PR to support the following use-cases-
- Ability to choose different or specific set of subnets per LB to fulfil security requirements. This will be supported via annotation.
- Simplify VPC setup requirements since cluster name is no longer required on the tag key for subnet resources. This also helps easily provision k8s on an existing VPC setup.

Prior to this change, the AWS cloudprovider would auto discover subnets only with the cluster tags when provisioning NLB/CLB for service resources. We want to modify this behavior to include the subnets without any cluster tags, in addition to the ones previously matched by auto-discovery. After the changes, the auto-discovery will consider all subnets except the ones tagged explicitly for other cluster. If there are multiple subnets per AZ, the ties are broken in the following order 
- prefer the subnet with the correct role tag. `kubernetes.io/role/elb` for public and `kubernetes.io/role/internal-elb` for private access
- prefer the subnet with the cluster tag `kubernetes.io/cluster/<Cluster Name>`
- prefer the subnet that is first in lexicographic order

This PR also introduces an additional annotation to manually configure the subnets.
```
service.beta.kubernetes.io/aws-load-balancer-subnets: <CSV List of subnet IDs or names>
```
The default behavior is to auto-discover the subnets. The annotation is a comma separated list of subnet IDs or the Name tag of the subnets. The subnets specified on this annotation must exist on the same VPC and must be from different AZs.

For NLB, due to current limitations, subnet configuration is applied during load balancer creation only. 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
Verified the following on a kops cluster -
- subnets with the appropriate cluster tag continue to get auto-discovered
- subnets without any cluster tag also gets auto-discovered
- subnets with cluster tag not matching the current cluster is not used
- in case there are multiple subnets on an AZ, role tag takes precedence over cluster tag, cluster tag over lexicographic order of subnets
- subnets annotation support both subnet IDs and names
- subnets annotation override auto-discovery. For NLB, the specified subnets are used during LB creation
- for CLB, subnets annotation can be edited and the changes get reflected on the load balancer during the next reconcile
- when nonexistent subnets were specified in the annotation, service-controller threw an error. Once the annotation got edited, lb got reconciled successfully
- when multiple subnets from the same AZ were specified in the annotation, got InvalidConfigurationRequest from ELB api

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
AWS cloudprovider supports auto-discovering subnets without any kubernetes.io/cluster/<clusterName> tags. It also supports additional service annotation service.beta.kubernetes.io/aws-load-balancer-subnets to manually configure the subnets. 
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
