### PR TITLE
bugfix: nodeport quota check failure result into failing to create a clusterip service

### DIFF
--- a/pkg/quota/v1/evaluator/core/BUILD
+++ b/pkg/quota/v1/evaluator/core/BUILD
@@ -46,6 +46,7 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//pkg/apis/core:go_default_library",
+        "//pkg/features:go_default_library",
         "//pkg/util/node:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/resource:go_default_library",
@@ -54,6 +55,9 @@ go_test(
         "//staging/src/k8s.io/apimachinery/pkg/util/clock:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/quota/v1:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/quota/v1/generic:go_default_library",
+        "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",
+        "//staging/src/k8s.io/component-base/featuregate/testing:go_default_library",
+        "//vendor/k8s.io/utils/pointer:go_default_library",
     ],
 )
 

--- a/pkg/quota/v1/evaluator/core/services.go
+++ b/pkg/quota/v1/evaluator/core/services.go
@@ -26,8 +26,10 @@ import (
 	"k8s.io/apiserver/pkg/admission"
 	quota "k8s.io/apiserver/pkg/quota/v1"
 	"k8s.io/apiserver/pkg/quota/v1/generic"
+	"k8s.io/apiserver/pkg/util/feature"
 	api "k8s.io/kubernetes/pkg/apis/core"
 	k8s_api_v1 "k8s.io/kubernetes/pkg/apis/core/v1"
+	"k8s.io/kubernetes/pkg/features"
 )
 
 // the name used for object count quota
@@ -128,12 +130,31 @@ func (p *serviceEvaluator) Usage(item runtime.Object) (corev1.ResourceList, erro
 		value := resource.NewQuantity(int64(ports), resource.DecimalSI)
 		result[corev1.ResourceServicesNodePorts] = *value
 	case corev1.ServiceTypeLoadBalancer:
-		// load balancer services need to count node ports and load balancers
-		value := resource.NewQuantity(int64(ports), resource.DecimalSI)
-		result[corev1.ResourceServicesNodePorts] = *value
+		// load balancer services need to count node ports. If creation of node ports
+		// is suppressed only ports with explicit NodePort values are counted.
+		// nodeports won't be allocated yet, so we can't simply count the actual values.
+		// We need to look at the intent.
+		if feature.DefaultFeatureGate.Enabled(features.ServiceLBNodePortControl) &&
+			svc.Spec.AllocateLoadBalancerNodePorts != nil &&
+			*svc.Spec.AllocateLoadBalancerNodePorts == false {
+			result[corev1.ResourceServicesNodePorts] = *portsWithNodePorts(svc)
+		} else {
+			value := resource.NewQuantity(int64(ports), resource.DecimalSI)
+			result[corev1.ResourceServicesNodePorts] = *value
+		}
 		result[corev1.ResourceServicesLoadBalancers] = *(resource.NewQuantity(1, resource.DecimalSI))
 	}
 	return result, nil
+}
+
+func portsWithNodePorts(svc *corev1.Service) *resource.Quantity {
+	count := 0
+	for _, p := range svc.Spec.Ports {
+		if p.NodePort != 0 {
+			count++
+		}
+	}
+	return resource.NewQuantity(int64(count), resource.DecimalSI)
 }
 
 // UsageStats calculates aggregate usage for the object.

--- a/pkg/quota/v1/evaluator/core/services_test.go
+++ b/pkg/quota/v1/evaluator/core/services_test.go
@@ -24,7 +24,11 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	quota "k8s.io/apiserver/pkg/quota/v1"
 	"k8s.io/apiserver/pkg/quota/v1/generic"
+	"k8s.io/apiserver/pkg/util/feature"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	api "k8s.io/kubernetes/pkg/apis/core"
+	"k8s.io/kubernetes/pkg/features"
+	utilpointer "k8s.io/utils/pointer"
 )
 
 func TestServiceEvaluatorMatchesResources(t *testing.T) {
@@ -52,8 +56,9 @@ func TestServiceEvaluatorMatchesResources(t *testing.T) {
 func TestServiceEvaluatorUsage(t *testing.T) {
 	evaluator := NewServiceEvaluator(nil)
 	testCases := map[string]struct {
-		service *api.Service
-		usage   corev1.ResourceList
+		service                         *api.Service
+		usage                           corev1.ResourceList
+		serviceLBNodePortControlEnabled bool
 	}{
 		"loadbalancer": {
 			service: &api.Service{
@@ -81,6 +86,27 @@ func TestServiceEvaluatorUsage(t *testing.T) {
 			},
 			usage: corev1.ResourceList{
 				corev1.ResourceServicesNodePorts:     resource.MustParse("1"),
+				corev1.ResourceServicesLoadBalancers: resource.MustParse("1"),
+				corev1.ResourceServices:              resource.MustParse("1"),
+				generic.ObjectCountQuotaResourceNameFor(schema.GroupResource{Resource: "services"}): resource.MustParse("1"),
+			},
+		},
+		"loadbalancer_2_ports": {
+			service: &api.Service{
+				Spec: api.ServiceSpec{
+					Type: api.ServiceTypeLoadBalancer,
+					Ports: []api.ServicePort{
+						{
+							Port: 27443,
+						},
+						{
+							Port: 27444,
+						},
+					},
+				},
+			},
+			usage: corev1.ResourceList{
+				corev1.ResourceServicesNodePorts:     resource.MustParse("2"),
 				corev1.ResourceServicesLoadBalancers: resource.MustParse("1"),
 				corev1.ResourceServices:              resource.MustParse("1"),
 				generic.ObjectCountQuotaResourceNameFor(schema.GroupResource{Resource: "services"}): resource.MustParse("1"),
@@ -138,15 +164,113 @@ func TestServiceEvaluatorUsage(t *testing.T) {
 				generic.ObjectCountQuotaResourceNameFor(schema.GroupResource{Resource: "services"}): resource.MustParse("1"),
 			},
 		},
+		"nodeports-disabled": {
+			service: &api.Service{
+				Spec: api.ServiceSpec{
+					Type: api.ServiceTypeLoadBalancer,
+					Ports: []api.ServicePort{
+						{
+							Port: 27443,
+						},
+						{
+							Port: 27444,
+						},
+					},
+					AllocateLoadBalancerNodePorts: utilpointer.BoolPtr(false),
+				},
+			},
+			usage: corev1.ResourceList{
+				corev1.ResourceServices:              resource.MustParse("1"),
+				corev1.ResourceServicesNodePorts:     resource.MustParse("0"),
+				corev1.ResourceServicesLoadBalancers: resource.MustParse("1"),
+				generic.ObjectCountQuotaResourceNameFor(schema.GroupResource{Resource: "services"}): resource.MustParse("1"),
+			},
+			serviceLBNodePortControlEnabled: true,
+		},
+		"nodeports-default-enabled": {
+			service: &api.Service{
+				Spec: api.ServiceSpec{
+					Type: api.ServiceTypeLoadBalancer,
+					Ports: []api.ServicePort{
+						{
+							Port:     27443,
+							NodePort: 32001,
+						},
+						{
+							Port:     27444,
+							NodePort: 32002,
+						},
+					},
+					AllocateLoadBalancerNodePorts: nil,
+				},
+			},
+			usage: corev1.ResourceList{
+				corev1.ResourceServices:              resource.MustParse("1"),
+				corev1.ResourceServicesNodePorts:     resource.MustParse("2"),
+				corev1.ResourceServicesLoadBalancers: resource.MustParse("1"),
+				generic.ObjectCountQuotaResourceNameFor(schema.GroupResource{Resource: "services"}): resource.MustParse("1"),
+			},
+		},
+		"nodeports-explicitly-enabled": {
+			service: &api.Service{
+				Spec: api.ServiceSpec{
+					Type: api.ServiceTypeLoadBalancer,
+					Ports: []api.ServicePort{
+						{
+							Port: 27443,
+						},
+						{
+							Port: 27444,
+						},
+					},
+					AllocateLoadBalancerNodePorts: utilpointer.BoolPtr(true),
+				},
+			},
+			usage: corev1.ResourceList{
+				corev1.ResourceServices:              resource.MustParse("1"),
+				corev1.ResourceServicesNodePorts:     resource.MustParse("2"),
+				corev1.ResourceServicesLoadBalancers: resource.MustParse("1"),
+				generic.ObjectCountQuotaResourceNameFor(schema.GroupResource{Resource: "services"}): resource.MustParse("1"),
+			},
+			serviceLBNodePortControlEnabled: true,
+		},
+		"nodeports-disabled-but-specified": {
+			service: &api.Service{
+				Spec: api.ServiceSpec{
+					Type: api.ServiceTypeLoadBalancer,
+					Ports: []api.ServicePort{
+						{
+							Port:     27443,
+							NodePort: 32001,
+						},
+						{
+							Port:     27444,
+							NodePort: 32002,
+						},
+					},
+					AllocateLoadBalancerNodePorts: utilpointer.BoolPtr(false),
+				},
+			},
+			usage: corev1.ResourceList{
+				corev1.ResourceServices:              resource.MustParse("1"),
+				corev1.ResourceServicesNodePorts:     resource.MustParse("2"),
+				corev1.ResourceServicesLoadBalancers: resource.MustParse("1"),
+				generic.ObjectCountQuotaResourceNameFor(schema.GroupResource{Resource: "services"}): resource.MustParse("1"),
+			},
+			serviceLBNodePortControlEnabled: true,
+		},
 	}
 	for testName, testCase := range testCases {
-		actual, err := evaluator.Usage(testCase.service)
-		if err != nil {
-			t.Errorf("%s unexpected error: %v", testName, err)
-		}
-		if !quota.Equals(testCase.usage, actual) {
-			t.Errorf("%s expected: %v, actual: %v", testName, testCase.usage, actual)
-		}
+		t.Run(testName, func(t *testing.T) {
+			defer featuregatetesting.SetFeatureGateDuringTest(t, feature.DefaultFeatureGate, features.ServiceLBNodePortControl, testCase.serviceLBNodePortControlEnabled)()
+			actual, err := evaluator.Usage(testCase.service)
+			if err != nil {
+				t.Errorf("%s unexpected error: %v", testName, err)
+			}
+			if !quota.Equals(testCase.usage, actual) {
+				t.Errorf("%s expected: %v, actual: %v", testName, testCase.usage, actual)
+			}
+		})
 	}
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/resourcequota/controller.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/resourcequota/controller.go
@@ -510,7 +510,10 @@ func CheckRequest(quotas []corev1.ResourceQuota, a admission.Attributes, evaluat
 		}
 	}
 
-	if quota.IsZero(deltaUsage) {
+	// ignore items in deltaUsage with zero usage
+	deltaUsage = quota.RemoveZeros(deltaUsage)
+	// if there is no remaining non-zero usage, short-circuit and return
+	if len(deltaUsage) == 0 {
 		return quotas, nil
 	}
 

--- a/staging/src/k8s.io/apiserver/pkg/quota/v1/resources.go
+++ b/staging/src/k8s.io/apiserver/pkg/quota/v1/resources.go
@@ -226,6 +226,17 @@ func IsZero(a corev1.ResourceList) bool {
 	return true
 }
 
+// RemoveZeros returns a new resource list that only has no zero values
+func RemoveZeros(a corev1.ResourceList) corev1.ResourceList {
+	result := corev1.ResourceList{}
+	for key, value := range a {
+		if !value.IsZero() {
+			result[key] = value
+		}
+	}
+	return result
+}
+
 // IsNegative returns the set of resource names that have a negative value.
 func IsNegative(a corev1.ResourceList) []corev1.ResourceName {
 	results := []corev1.ResourceName{}

--- a/staging/src/k8s.io/apiserver/pkg/quota/v1/resources_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/quota/v1/resources_test.go
@@ -287,6 +287,50 @@ func TestIsZero(t *testing.T) {
 	}
 }
 
+func TestRemoveZeros(t *testing.T) {
+	testCases := map[string]struct {
+		a        corev1.ResourceList
+		expected corev1.ResourceList
+	}{
+		"empty": {
+			a:        corev1.ResourceList{},
+			expected: corev1.ResourceList{},
+		},
+		"all-zeros": {
+			a: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("0"),
+				corev1.ResourceMemory: resource.MustParse("0"),
+			},
+			expected: corev1.ResourceList{},
+		},
+		"some-zeros": {
+			a: corev1.ResourceList{
+				corev1.ResourceCPU:     resource.MustParse("0"),
+				corev1.ResourceMemory:  resource.MustParse("0"),
+				corev1.ResourceStorage: resource.MustParse("100Gi"),
+			},
+			expected: corev1.ResourceList{
+				corev1.ResourceStorage: resource.MustParse("100Gi"),
+			},
+		},
+		"non-zero": {
+			a: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("200m"),
+				corev1.ResourceMemory: resource.MustParse("1Gi"),
+			},
+			expected: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("200m"),
+				corev1.ResourceMemory: resource.MustParse("1Gi"),
+			},
+		},
+	}
+	for testName, testCase := range testCases {
+		if result := RemoveZeros(testCase.a); !Equals(result, testCase.expected) {
+			t.Errorf("%s expected: %v, actual: %v", testName, testCase.expected, result)
+		}
+	}
+}
+
 func TestIsNegative(t *testing.T) {
 	testCases := map[string]struct {
 		a        corev1.ResourceList


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
```
apiVersion: v1
kind: ResourceQuota
metadata:
  name: default-quota
  namespace: default
spec:
  hard:
    services.nodeports: "0"
```
When quota is like above and there are already two nodeports service created before the quota creation.

```
$ k create svc clusterip cip --tcp=1234:1234
Error from server (Forbidden): services "cip" is forbidden: exceeded quota: default-quota, requested: services.nodeports=0, used: services.nodeports=2, limited: services.nodeports=0
```
This PR tries to fix this. As the created service is clusterip, it can be created as no quota is set for services, only for nodeport.

**Which issue(s) this PR fixes**:
Fixes #97437 and #73628 

**Special notes for your reviewer**:
Cherrypicks from #97319 to fix NodePort and LB problem as well. Thanks @uablrek for that commit.

To summarize the expectations:
live = current
NP = nodeport
LB = load balancer

Service hard quota | NP hard quota | LB hard quota | live Services count | live NP count | live LB count | create Service (ClusterIP) | create NP | create LB with NP | create LB with AllocateLBNodePorts=false 
-- | -- | -- | -- | -- | -- | -- | -- | -- | --
None | 0 | None | 2 | 2 | 0 | **should success but failed** | expected fail | expected failed  |  **should success but failed**
2 | None | None | 3 | 0 | 0 | expected fail | expected fail | expected fail | expected fail 
4 | 2 | None | 4 | 2 | 0 | expected fail | expected fail | expected fail | expected fail 
4 | 2 | None | 5 | 1 | 0 | expected fail | expected fail | expected fail | expected fail 
4 | 2 | None | 3 | 2 | 0 | expected success | expected fail | expected fail |  **should success but failed**
4 | 2 | 1 | 3 | 2 | 1 | expected success | expected fail | expected fail | expected failed

Edited after https://github.com/kubernetes/kubernetes/pull/97451#issuecomment-750425082 comments. 


**Does this PR introduce a user-facing change?**:
```release-note
fix counting error in service/nodeport/loadbalancer quota check
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs
None
```
