### PR TITLE
modify hostname of ErrReason

### DIFF
--- a/pkg/scheduler/framework/plugins/nodename/node_name.go
+++ b/pkg/scheduler/framework/plugins/nodename/node_name.go
@@ -34,7 +34,7 @@ const (
 	Name = "NodeName"
 
 	// ErrReason returned when node name doesn't match.
-	ErrReason = "node(s) didn't match the requested hostname"
+	ErrReason = "node(s) didn't match the requested node name"
 )
 
 // Name returns name of the plugin. It is used in logs, etc.


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
In NodeName plugin of scheduler, ErrReason "node(s) didn't match the requested hostname", here hostname is not correct, because hostname is the host name , especially in /etc/hostname, but node name  is assigned in a cluster, generally they are not the same name, so hostname should be modified to nodename. Additionally there is comparision "pod.Spec.NodeName == nodeInfo.Node().Name" in Fits func, so nodename is more appropriate.

**Special notes for your reviewer**:
no

**Does this PR introduce a user-facing change?**:
no

```release-note
   NONE
```
