### PR TITLE
cleanup: fix some error log capitalization

### DIFF
--- a/cmd/kubeadm/app/cmd/completion_test.go
+++ b/cmd/kubeadm/app/cmd/completion_test.go
@@ -39,7 +39,7 @@ func TestNewCmdCompletion(t *testing.T) {
 	cmd := newCmdCompletion(&out, "")
 	parentCmd.AddCommand(cmd)
 	if err := parentCmd.Execute(); err != nil {
-		t.Errorf("Cannot exectute newCmdCompletion: %v", err)
+		t.Errorf("cannot exectute newCmdCompletion: %v", err)
 	}
 }
 
@@ -90,7 +90,7 @@ func TestRunCompletion(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			if err := RunCompletion(&out, "", cmd, tc.args); (err != nil) != tc.expectedError {
-				t.Errorf("Test case %q: TestRunCompletion expected error: %v, saw: %v", tc.name, tc.expectedError, (err != nil))
+				t.Errorf("test case %q: TestRunCompletion expected error: %v, saw: %v", tc.name, tc.expectedError, (err != nil))
 			}
 		})
 	}

--- a/cmd/kubeadm/app/cmd/version_test.go
+++ b/cmd/kubeadm/app/cmd/version_test.go
@@ -28,7 +28,7 @@ func TestNewCmdVersion(t *testing.T) {
 	var buf bytes.Buffer
 	cmd := newCmdVersion(&buf)
 	if err := cmd.Execute(); err != nil {
-		t.Errorf("Cannot execute version command: %v", err)
+		t.Errorf("cannot execute version command: %v", err)
 	}
 }
 
@@ -91,7 +91,7 @@ func TestRunVersion(t *testing.T) {
 			}
 		error:
 			if (err != nil) != tc.expectedError {
-				t.Errorf("Test case %q: RunVersion expected error: %v, saw: %v; %v", tc.name, tc.expectedError, err != nil, err)
+				t.Errorf("test case %q: RunVersion expected error: %v, saw: %v; %v", tc.name, tc.expectedError, err != nil, err)
 			}
 		})
 	}


### PR DESCRIPTION
What type of PR is this?
/kind cleanup

What this PR does / why we need it:
Fix some errors start with capital letters in scheduler.

Which issue(s) this PR fixes:
Fixes #15863

Special notes for your reviewer: None
Does this PR introduce a user-facing change?:  None
Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:  None