### PR TITLE
fix error test

### DIFF
--- a/cmd/kube-controller-manager/app/options/options_test.go
+++ b/cmd/kube-controller-manager/app/options/options_test.go
@@ -461,8 +461,8 @@ func TestApplyTo(t *testing.T) {
 	expected := &kubecontrollerconfig.Config{
 		ComponentConfig: kubectrlmgrconfig.KubeControllerManagerConfiguration{
 			Generic: cmconfig.GenericControllerManagerConfiguration{
-				Port:            10252,     // Note: InsecureServingOptions.ApplyTo will write the flag value back into the component config
-				Address:         "0.0.0.0", // Note: InsecureServingOptions.ApplyTo will write the flag value back into the component config
+				Port:            10000,     // Note: InsecureServingOptions.ApplyTo will write the flag value back into the component config
+				Address:         "192.168.4.10", // Note: InsecureServingOptions.ApplyTo will write the flag value back into the component config
 				MinResyncPeriod: metav1.Duration{Duration: 8 * time.Hour},
 				ClientConnection: componentbaseconfig.ClientConnectionConfiguration{
 					ContentType: "application/json",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:


Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
test failed in cmd/kube-controller-manager/app/options/options_test.go
```
=== RUN   TestAddFlags
Flag --address has been deprecated, see --bind-address instead.
Flag --horizontal-pod-autoscaler-downscale-delay has been deprecated, This flag is currently no-op and will be deleted.
Flag --horizontal-pod-autoscaler-upscale-delay has been deprecated, This flag is currently no-op and will be deleted.
Flag --port has been deprecated, see --secure-port instead.
--- PASS: TestAddFlags (0.00s)
=== RUN   TestApplyTo
Flag --address has been deprecated, see --bind-address instead.
Flag --horizontal-pod-autoscaler-downscale-delay has been deprecated, This flag is currently no-op and will be deleted.
Flag --horizontal-pod-autoscaler-upscale-delay has been deprecated, This flag is currently no-op and will be deleted.
Flag --port has been deprecated, see --secure-port instead.
W1223 09:23:21.490484   14853 authentication.go:303] No authentication-kubeconfig provided in order to lookup client-ca-file in configmap/extension-apiserver-authentication in kube-system, so client certificate authentication won't work.
W1223 09:23:21.490543   14853 authentication.go:327] No authentication-kubeconfig provided in order to lookup requestheader-client-ca-file in configmap/extension-apiserver-authentication in kube-system, so request-header client certificate authentication won't work.
W1223 09:23:21.490557   14853 authorization.go:173] No authorization-kubeconfig provided, so SubjectAccessReview of authorization tokens won't work.
    options_test.go:645: Got different configuration than expected.
        Difference detected on:
          config.KubeControllerManagerConfiguration{
          	TypeMeta: {},
          	Generic: config.GenericControllerManagerConfiguration{
        - 		Port:             10252,
        + 		Port:             10000,
        - 		Address:          "0.0.0.0",
        + 		Address:          "192.168.4.10",
          		MinResyncPeriod:  {Duration: s"8h0m0s"},
          		ClientConnection: {ContentType: "application/json", QPS: 50, Burst: 100},
          		... // 4 identical fields
          	},
          	KubeCloudShared:        {CloudProvider: {Name: "gce", CloudConfigFile: "/cloud-config"}, UseServiceAccountCredentials: true, RouteReconciliationPeriod: {Duration: s"30s"}, NodeMonitorPeriod: {Duration: s"10s"}, ...},
          	AttachDetachController: {DisableAttachDetachReconcilerSync: true, ReconcilerSyncLoopPeriod: {Duration: s"30s"}},
          	... // 23 identical fields
          }
--- FAIL: TestApplyTo (0.35s)
FAIL
```
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
