### PR TITLE
Fix staticcheck: staging/src/k8s.io/client-go/{rest/watch,transport}

### DIFF
--- a/hack/.staticcheck_failures
+++ b/hack/.staticcheck_failures
@@ -41,6 +41,4 @@ vendor/k8s.io/apiserver/pkg/util/wsstream
 vendor/k8s.io/cli-runtime/pkg/printers
 vendor/k8s.io/client-go/discovery
 vendor/k8s.io/client-go/rest
-vendor/k8s.io/client-go/rest/watch
-vendor/k8s.io/client-go/transport
 vendor/k8s.io/cloud-provider/sample

--- a/staging/src/k8s.io/client-go/rest/watch/decoder_test.go
+++ b/staging/src/k8s.io/client-go/rest/watch/decoder_test.go
@@ -54,7 +54,9 @@ func TestDecoder(t *testing.T) {
 		go func() {
 			data, err := runtime.Encode(scheme.Codecs.LegacyCodec(v1.SchemeGroupVersion), expect)
 			if err != nil {
-				t.Fatalf("Unexpected error %v", err)
+				t.Errorf("Unexpected error %v", err)
+				in.Close()
+				return
 			}
 			event := metav1.WatchEvent{
 				Type:   string(eType),
@@ -70,7 +72,9 @@ func TestDecoder(t *testing.T) {
 		go func() {
 			action, got, err := decoder.Decode()
 			if err != nil {
-				t.Fatalf("Unexpected error %v", err)
+				t.Errorf("Unexpected error %v", err)
+				close(done)
+				return
 			}
 			if e, a := eType, action; e != a {
 				t.Errorf("Expected %v, got %v", e, a)

--- a/staging/src/k8s.io/client-go/transport/token_source_test.go
+++ b/staging/src/k8s.io/client-go/transport/token_source_test.go
@@ -145,7 +145,7 @@ func TestCachingTokenSourceRace(t *testing.T) {
 			go func() {
 				defer wg.Done()
 				if _, err := ts.Token(); err != nil {
-					t.Fatalf("err: %v", err)
+					t.Errorf("err: %v", err)
 				}
 			}()
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
Fix staticcheck failures for staging/src/k8s.io/client-go/{rest/watch,transport}
```release-note
vendor/k8s.io/client-go/rest/watch/decoder_test.go:54:3: the goroutine calls T.Fatalf, which must be called in the same goroutine as the test (SA2002)
vendor/k8s.io/client-go/rest/watch/decoder_test.go:57:5: call to T.Fatalf
vendor/k8s.io/client-go/rest/watch/decoder_test.go:70:3: the goroutine calls T.Fatalf, which must be called in the same goroutine as the test (SA2002)
vendor/k8s.io/client-go/rest/watch/decoder_test.go:73:5: call to T.Fatalf
vendor/k8s.io/client-go/transport/token_source_test.go:145:4: the goroutine calls T.Fatalf, which must be called in the same goroutine as the test (SA2002)
vendor/k8s.io/client-go/transport/token_source_test.go:148:6: call to T.Fatalf
```
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

Part of #92402

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
