### PR TITLE
Namespace has no effect when exposing deployment with --dry-run=client

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/expose/expose.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/expose/expose.go
@@ -335,6 +335,9 @@ func (o *ExposeServiceOptions) RunExpose(cmd *cobra.Command, args []string) erro
 		}
 
 		if o.DryRunStrategy == cmdutil.DryRunClient {
+			if meta, err := meta.Accessor(object); err == nil && o.EnforceNamespace {
+				meta.SetNamespace(o.Namespace)
+			}
 			return o.PrintObj(object, o.Out)
 		}
 		if err := util.CreateOrUpdateAnnotation(cmdutil.GetFlagBool(cmd, cmdutil.ApplyAnnotationsFlag), object, scheme.DefaultJSONEncoder()); err != nil {


### PR DESCRIPTION

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This is how to reproduce.

```
$ kubectl create ns testns
$ kubectl -n testns create deployment test-deploy --image=nginx
$ kubectl -n testns expose deployment.apps/test-deploy --port=80 --dry-run=client -o yaml
apiVersion: v1
kind: Service
metadata:
  creationTimestamp: null
  labels:
    app: test-deploy
  name: test-deploy
spec:
  ports:
  - port: 80
    protocol: TCP
    targetPort: 80
  selector:
    app: test-deploy
status:
  loadBalancer: {}
```

If ```--dry-run=client``` is not specified, namespace element is contained in the yaml.

**Which issue(s) this PR fixes**:
NONE

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
Fixed no effect namespace when exposing deployment with --dry-run=client.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs
NONE
```
