### PR TITLE
add operator for allocateMemory.available signal

### DIFF
--- a/pkg/kubelet/eviction/api/types.go
+++ b/pkg/kubelet/eviction/api/types.go
@@ -58,12 +58,13 @@ const (
 // from either above or below, never both). There is thus no reason to expose the
 // operator in the Kubelet's public API. Instead, we internally map signal types to operators.
 var OpForSignal = map[Signal]ThresholdOperator{
-	SignalMemoryAvailable:   OpLessThan,
-	SignalNodeFsAvailable:   OpLessThan,
-	SignalNodeFsInodesFree:  OpLessThan,
-	SignalImageFsAvailable:  OpLessThan,
-	SignalImageFsInodesFree: OpLessThan,
-	SignalPIDAvailable:      OpLessThan,
+	SignalMemoryAvailable:            OpLessThan,
+	SignalNodeFsAvailable:            OpLessThan,
+	SignalNodeFsInodesFree:           OpLessThan,
+	SignalImageFsAvailable:           OpLessThan,
+	SignalImageFsInodesFree:          OpLessThan,
+	SignalAllocatableMemoryAvailable: OpLessThan,
+	SignalPIDAvailable:               OpLessThan,
 }
 
 // ThresholdValue is a value holder that abstracts literal versus percentage based quantity


### PR DESCRIPTION

**What type of PR is this?**
/kind bug
/sig node

**What this PR does / why we need it**:
miss operator for allocateMemory.available signal 


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
