### PR TITLE
Pod Terminating error result in Unknown Pod Condition

### DIFF
--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -31,6 +31,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"time"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -1706,68 +1707,88 @@ func (kl *Kubelet) convertToAPIContainerStatuses(pod *v1.Pod, podStatus *kubecon
 		statuses[container.Name] = status
 	}
 
-	for _, container := range containers {
-		found := false
-		for _, cStatus := range podStatus.ContainerStatuses {
-			if container.Name == cStatus.Name {
-				found = true
-				break
+	// if the pod is terminating and the condition last transition time is less than grace period,
+	// the pod should not be marked as unknown state
+	active := false
+	for _, condition := range pod.Status.Conditions {
+		// Default: "30s"
+		grace := 30 * time.Second
+		if pod.Spec.TerminationGracePeriodSeconds != nil {
+			grace = time.Duration(*pod.Spec.TerminationGracePeriodSeconds) * time.Second
+		}
+		graceBefore := metav1.NewTime(time.Now().Add(-grace))
+
+		if (&graceBefore).Before(&condition.LastTransitionTime) {
+			active = true
+			break
+		}
+	}
+	if !active {
+		for _, container := range containers {
+
+			found := false
+			for _, cStatus := range podStatus.ContainerStatuses {
+				if container.Name == cStatus.Name {
+					found = true
+					break
+				}
 			}
-		}
-		if found {
-			continue
-		}
-		// if no container is found, then assuming it should be waiting seems plausible, but the status code requires
-		// that a previous termination be present.  If we're offline long enough (or something removed the container?), then
-		// the previous termination may not be present.  This next code block ensures that if the container was previously running
-		// then when that container status disappears, we can infer that it terminated even if we don't know the status code.
-		// By setting the lasttermination state we are able to leave the container status waiting and present more accurate
-		// data via the API.
+			if found {
+				continue
+			}
+			// if no container is found, then assuming it should be waiting seems plausible, but the status code requires
+			// that a previous termination be present.  If we're offline long enough (or something removed the container?), then
+			// the previous termination may not be present.  This next code block ensures that if the container was previously running
+			// then when that container status disappears, we can infer that it terminated even if we don't know the status code.
+			// By setting the lasttermination state we are able to leave the container status waiting and present more accurate
+			// data via the API.
 
-		oldStatus, ok := oldStatuses[container.Name]
-		if !ok {
-			continue
-		}
-		if oldStatus.State.Terminated != nil {
-			// if the old container status was terminated, the lasttermination status is correct
-			continue
-		}
-		if oldStatus.State.Running == nil {
-			// if the old container status isn't running, then waiting is an appropriate status and we have nothing to do
-			continue
-		}
+			oldStatus, ok := oldStatuses[container.Name]
+			if !ok {
+				continue
+			}
+			if oldStatus.State.Terminated != nil {
+				// if the old container status was terminated, the lasttermination status is correct
+				continue
+			}
+			if oldStatus.State.Running == nil {
+				// if the old container status isn't running, then waiting is an appropriate status and we have nothing to do
+				continue
+			}
 
-		if pod.DeletionTimestamp == nil {
-			continue
-		}
+			if pod.DeletionTimestamp == nil {
+				continue
+			}
 
-		// and if the pod itself is being deleted, then the CRI may have removed the container already and for whatever reason the kubelet missed the exit code
-		// (this seems not awesome).  We know at this point that we will not be restarting the container.
-		status := statuses[container.Name]
-		// if the status we're about to write indicates the default, the Waiting status will force this pod back into Pending.
-		// That isn't true, we know the pod is going away.
-		isDefaultWaitingStatus := status.State.Waiting != nil && status.State.Waiting.Reason == "ContainerCreating"
-		if hasInitContainers {
-			isDefaultWaitingStatus = status.State.Waiting != nil && status.State.Waiting.Reason == "PodInitializing"
-		}
-		if !isDefaultWaitingStatus {
-			// we the status was written, don't override
-			continue
-		}
-		if status.LastTerminationState.Terminated != nil {
-			// if we already have a termination state, nothing to do
-			continue
-		}
+			// and if the pod itself is being deleted, then the CRI may have removed the container already and for whatever reason the kubelet missed the exit code
+			// (this seems not awesome).  We know at this point that we will not be restarting the container.
+			status := statuses[container.Name]
 
-		// setting this value ensures that we show as stopped here, not as waiting:
-		// https://github.com/kubernetes/kubernetes/blob/90c9f7b3e198e82a756a68ffeac978a00d606e55/pkg/kubelet/kubelet_pods.go#L1440-L1445
-		// This prevents the pod from becoming pending
-		status.LastTerminationState.Terminated = &v1.ContainerStateTerminated{
-			Reason:   "ContainerStatusUnknown",
-			Message:  "The container could not be located when the pod was deleted.  The container used to be Running",
-			ExitCode: 137,
+			// if the status we're about to write indicates the default, the Waiting status will force this pod back into Pending.
+			// That isn't true, we know the pod is going away.
+			isDefaultWaitingStatus := status.State.Waiting != nil && status.State.Waiting.Reason == "ContainerCreating"
+			if hasInitContainers {
+				isDefaultWaitingStatus = status.State.Waiting != nil && status.State.Waiting.Reason == "PodInitializing"
+			}
+			if !isDefaultWaitingStatus {
+				// if the status was written, don't override
+				continue
+			}
+			if status.LastTerminationState.Terminated != nil {
+				// if we already have a termination state, nothing to do
+				continue
+			}
+
+			// setting this value ensures that we show as stopped here, not as waiting:
+			// https://github.com/kubernetes/kubernetes/blob/90c9f7b3e198e82a756a68ffeac978a00d606e55/pkg/kubelet/kubelet_pods.go#L1440-L1445
+			// This prevents the pod from becoming pending
+			status.LastTerminationState.Terminated = &v1.ContainerStateTerminated{
+				Reason:   "ContainerStatusUnknown",
+				Message:  "The container could not be located when the pod was deleted.  The container used to be Running",
+				ExitCode: 137,
+			}
+			statuses[container.Name] = status
 		}
-		statuses[container.Name] = status
 	}
 
 	// Make the latest container status comes first.


### PR DESCRIPTION
**What type of PR is this?**
/kind regression
/kind bug


**What this PR does / why we need it**:
After graceful terminating period, kubelet kill container with --force.
At the time, sandbox container and app container will be exited.
- one of the container status would be none
- the other may be in process to delete

After the app container is deleted, the ContainerStatuses would be cleaned. 
And the status will become terminated later.

**// if the pod is terminating and the condition last transition time is less than grace period,
// the pod should not be marked as unknown state**

**Which issue(s) this PR fixes**:

Fixes #97288

**Special notes for your reviewer**:
```
[root@daocloud ~]# date && time kubectl delete pod --all && date
Fri Jan  8 18:23:15 CST 2021
pod "nginx-deployment-58568c997f-5vz7m" deleted
pod "nginx-deployment-58568c997f-6z7xs" deleted
pod "nginx-deployment-58568c997f-dg2sk" deleted
pod "nginx-deployment-58568c997f-f7lbz" deleted
pod "nginx-deployment-58568c997f-g6nwv" deleted
pod "nginx-deployment-58568c997f-kblt2" deleted
pod "nginx-deployment-58568c997f-n54bh" deleted
pod "nginx-deployment-58568c997f-r2hdn" deleted
pod "nginx-deployment-58568c997f-v27gc" deleted
pod "nginx-deployment-58568c997f-xbhgh" deleted


real	0m14.323s
user	0m0.130s
sys	0m0.032s
Fri Jan  8 18:23:29 CST 2021
```
Testing result is like above.
**Does this PR introduce a user-facing change?**:
```release-note
fix regression: pod terminating always costs more than graceful period
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:


```docs

```
