### PR TITLE
Fix golint errors for plugin/pkg/auth/authorizer/{node,rbac}

### DIFF
--- a/plugin/pkg/auth/authorizer/node/graph_populator.go
+++ b/plugin/pkg/auth/authorizer/node/graph_populator.go
@@ -35,6 +35,7 @@ type graphPopulator struct {
 	graph *Graph
 }
 
+// AddGraphEventHandlers adds graph event handlers.
 func AddGraphEventHandlers(
 	graph *Graph,
 	nodes corev1informers.NodeInformer,

--- a/plugin/pkg/auth/authorizer/node/node_authorizer.go
+++ b/plugin/pkg/auth/authorizer/node/node_authorizer.go
@@ -83,6 +83,7 @@ var (
 	csiNodeResource   = storageapi.Resource("csinodes")
 )
 
+// RulesFor returns all known rules for a particular user within a specified namespace.
 func (r *NodeAuthorizer) RulesFor(user user.Info, namespace string) ([]authorizer.ResourceRuleInfo, []authorizer.NonResourceRuleInfo, bool, error) {
 	if _, isNode := r.identifier.NodeIdentity(user); isNode {
 		// indicate nodes do not have fully enumerated permissions
@@ -91,6 +92,7 @@ func (r *NodeAuthorizer) RulesFor(user user.Info, namespace string) ([]authorize
 	return nil, nil, false, nil
 }
 
+// Authorize authorizes a given user's access to resources based on specified attributes.
 func (r *NodeAuthorizer) Authorize(ctx context.Context, attrs authorizer.Attributes) (authorizer.Decision, string, error) {
 	nodeName, isNode := r.identifier.NodeIdentity(attrs.GetUser())
 	if !isNode {

--- a/plugin/pkg/auth/authorizer/rbac/rbac.go
+++ b/plugin/pkg/auth/authorizer/rbac/rbac.go
@@ -76,7 +76,7 @@ func (v *authorizingVisitor) visit(source fmt.Stringer, rule *rbacv1.PolicyRule,
 	return true
 }
 
-// Authorize authorizes the requested attributes for a given user and returns 
+// Authorize authorizes the requested attributes for a given user and returns
 // any errors that may have occured during the process.
 func (r *RBACAuthorizer) Authorize(ctx context.Context, requestAttributes authorizer.Attributes) (authorizer.Decision, string, error) {
 	ruleCheckingVisitor := &authorizingVisitor{requestAttributes: requestAttributes}
@@ -132,7 +132,7 @@ func (r *RBACAuthorizer) Authorize(ctx context.Context, requestAttributes author
 	return authorizer.DecisionNoOpinion, reason, nil
 }
 
-// RulesFor fetches the PolicyRules for a given user and any errors 
+// RulesFor fetches the PolicyRules for a given user and any errors
 // that may have occured during the process.
 func (r *RBACAuthorizer) RulesFor(user user.Info, namespace string) ([]authorizer.ResourceRuleInfo, []authorizer.NonResourceRuleInfo, bool, error) {
 	var (

--- a/plugin/pkg/auth/authorizer/rbac/subject_locator.go
+++ b/plugin/pkg/auth/authorizer/rbac/subject_locator.go
@@ -25,18 +25,21 @@ import (
 	rbacregistryvalidation "k8s.io/kubernetes/pkg/registry/rbac/validation"
 )
 
+// RoleToRuleMapper is an interface of GetRoleToReferenceRules.
 type RoleToRuleMapper interface {
 	// GetRoleReferenceRules attempts to resolve the role reference of a RoleBinding or ClusterRoleBinding.  The passed namespace should be the namespace
 	// of the role binding, the empty string if a cluster role binding.
 	GetRoleReferenceRules(roleRef rbacv1.RoleRef, namespace string) ([]rbacv1.PolicyRule, error)
 }
 
+// SubjectLocator is an interface of AllowedSubjects.
 type SubjectLocator interface {
 	AllowedSubjects(attributes authorizer.Attributes) ([]rbacv1.Subject, error)
 }
 
 var _ = SubjectLocator(&SubjectAccessEvaluator{})
 
+// SubjectAccessEvaluator holds information to evaluate subject access.
 type SubjectAccessEvaluator struct {
 	superUser string
 
@@ -45,6 +48,7 @@ type SubjectAccessEvaluator struct {
 	roleToRuleMapper         RoleToRuleMapper
 }
 
+// NewSubjectAccessEvaluator returns a new SubjectAccessEvaluator object.
 func NewSubjectAccessEvaluator(roles rbacregistryvalidation.RoleGetter, roleBindings rbacregistryvalidation.RoleBindingLister, clusterRoles rbacregistryvalidation.ClusterRoleGetter, clusterRoleBindings rbacregistryvalidation.ClusterRoleBindingLister, superUser string) *SubjectAccessEvaluator {
 	subjectLocator := &SubjectAccessEvaluator{
 		superUser:                superUser,


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:
This PR fixes golint issues for `plugin/pkg/auth/authorizer/node` and `plugin/pkg/auth/authorizer/rbac`:

```
plugin/pkg/auth/authorizer/node/graph.go:99:1: exported function NewGraph should have comment or be unexported
plugin/pkg/auth/authorizer/node/graph.go:138:17: don't use underscores in Go names; method getOrCreateVertex_locked should be getOrCreateVertexLocked
plugin/pkg/auth/authorizer/node/graph.go:146:17: don't use underscores in Go names; method getVertex_rlocked should be getVertexRlocked
plugin/pkg/auth/authorizer/node/graph.go:152:17: don't use underscores in Go names; method createVertex_locked should be createVertexLocked
plugin/pkg/auth/authorizer/node/graph.go:173:17: don't use underscores in Go names; method deleteVertex_locked should be deleteVertexLocked
plugin/pkg/auth/authorizer/node/graph.go:217:17: don't use underscores in Go names; method deleteEdges_locked should be deleteEdgesLocked
plugin/pkg/auth/authorizer/node/graph.go:254:17: don't use underscores in Go names; method removeEdgeFromDestinationIndex_locked should be removeEdgeFromDestinationIndexLocked
plugin/pkg/auth/authorizer/node/graph.go:274:17: don't use underscores in Go names; method addEdgeToDestinationIndex_locked should be addEdgeToDestinationIndexLocked
plugin/pkg/auth/authorizer/node/graph.go:291:17: don't use underscores in Go names; method removeVertex_locked should be removeVertexLocked
plugin/pkg/auth/authorizer/node/graph.go:302:17: don't use underscores in Go names; method recomputeDestinationIndex_locked should be recomputeDestinationIndexLocked
plugin/pkg/auth/authorizer/node/graph.go:399:1: exported method Graph.DeletePod should have comment or be unexported
plugin/pkg/auth/authorizer/node/graph.go:440:1: exported method Graph.DeletePV should have comment or be unexported
plugin/pkg/auth/authorizer/node/graph.go:471:1: exported method Graph.DeleteVolumeAttachment should have comment or be unexported
plugin/pkg/auth/authorizer/node/graph_populator.go:38:1: exported function AddGraphEventHandlers should have comment or be unexported
plugin/pkg/auth/authorizer/node/node_authorizer.go:53:6: type name will be used as node.NodeAuthorizer by other packages, and that stutters; consider calling this Authorizer
plugin/pkg/auth/authorizer/node/node_authorizer.go:86:1: exported method NodeAuthorizer.RulesFor should have comment or be unexported
plugin/pkg/auth/authorizer/node/node_authorizer.go:94:1: exported method NodeAuthorizer.Authorize should have comment or be unexported
plugin/pkg/auth/authorizer/rbac/rbac.go:37:6: exported type RequestToRuleMapper should have comment or be unexported
plugin/pkg/auth/authorizer/rbac/rbac.go:50:6: exported type RBACAuthorizer should have comment or be unexported
plugin/pkg/auth/authorizer/rbac/rbac.go:50:6: type name will be used as rbac.RBACAuthorizer by other packages, and that stutters; consider calling this Authorizer
plugin/pkg/auth/authorizer/rbac/rbac.go:75:1: exported method RBACAuthorizer.Authorize should have comment or be unexported
plugin/pkg/auth/authorizer/rbac/rbac.go:129:1: exported method RBACAuthorizer.RulesFor should have comment or be unexported
plugin/pkg/auth/authorizer/rbac/rbac.go:159:1: exported function New should have comment or be unexported
plugin/pkg/auth/authorizer/rbac/rbac.go:168:1: exported function RulesAllow should have comment or be unexported
plugin/pkg/auth/authorizer/rbac/rbac.go:178:1: exported function RuleAllows should have comment or be unexported
plugin/pkg/auth/authorizer/rbac/rbac.go:195:6: exported type RoleGetter should have comment or be unexported
plugin/pkg/auth/authorizer/rbac/rbac.go:199:1: exported method RoleGetter.GetRole should have comment or be unexported
plugin/pkg/auth/authorizer/rbac/rbac.go:203:6: exported type RoleBindingLister should have comment or be unexported
plugin/pkg/auth/authorizer/rbac/rbac.go:207:1: exported method RoleBindingLister.ListRoleBindings should have comment or be unexported
plugin/pkg/auth/authorizer/rbac/rbac.go:211:6: exported type ClusterRoleGetter should have comment or be unexported
plugin/pkg/auth/authorizer/rbac/rbac.go:215:1: exported method ClusterRoleGetter.GetClusterRole should have comment or be unexported
plugin/pkg/auth/authorizer/rbac/rbac.go:219:6: exported type ClusterRoleBindingLister should have comment or be unexported
plugin/pkg/auth/authorizer/rbac/rbac.go:223:1: exported method ClusterRoleBindingLister.ListClusterRoleBindings should have comment or be unexported
plugin/pkg/auth/authorizer/rbac/subject_locator.go:28:6: exported type RoleToRuleMapper should have comment or be unexported
plugin/pkg/auth/authorizer/rbac/subject_locator.go:34:6: exported type SubjectLocator should have comment or be unexported
plugin/pkg/auth/authorizer/rbac/subject_locator.go:40:6: exported type SubjectAccessEvaluator should have comment or be unexported
plugin/pkg/auth/authorizer/rbac/subject_locator.go:48:1: exported function NewSubjectAccessEvaluator should have comment or be unexported
```

**Which issue(s) this PR fixes**:
#68026

**Special notes for your reviewer**:
The reason the 2 directories haven't been removed from the `.golint_failures` file is because there's 2 errors in here for stutters, which is a bigger issue around naming and should probably be discussed before implementation.

```
plugin/pkg/auth/authorizer/node/node_authorizer.go:53:6: type name will be used as node.NodeAuthorizer by other packages, and that stutters; consider calling this Authorizer
plugin/pkg/auth/authorizer/rbac/rbac.go:54:6: type name will be used as rbac.RBACAuthorizer by other packages, and that stutters; consider calling this Authorizer
```

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```