### PR TITLE
Fix typo in comment

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/apply/apply.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apply/apply.go
@@ -652,7 +652,7 @@ func (o *ApplyOptions) MarkNamespaceVisited(info *resource.Info) {
 	}
 }
 
-// MarkNamespaceVisited keeps track of UIDs of the applied
+// MarkObjectVisited keeps track of UIDs of the applied
 // objects. Used for pruning.
 func (o *ApplyOptions) MarkObjectVisited(info *resource.Info) error {
 	metadata, err := meta.Accessor(info.Object)
@@ -663,7 +663,7 @@ func (o *ApplyOptions) MarkObjectVisited(info *resource.Info) error {
 	return nil
 }
 
-// PrintAndPrune returns a function which meets the PostProcessorFn
+// PrintAndPrunePostProcessor returns a function which meets the PostProcessorFn
 // function signature. This returned function prints all the
 // objects as a list (if configured for that), and prunes the
 // objects not applied. The returned function is the standard


### PR DESCRIPTION
Signed-off-by: Guangwen Feng <fenggw-fnst@cn.fujitsu.com>

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Fixes minor typos in the comments of kubectl/.../apply.go

**Does this PR introduce a user-facing change?**:
NONE