### PR TITLE
add node selector info in ErrReasonPod

### DIFF
--- a/pkg/scheduler/framework/plugins/nodeaffinity/node_affinity.go
+++ b/pkg/scheduler/framework/plugins/nodeaffinity/node_affinity.go
@@ -47,7 +47,7 @@ const (
 	preScoreStateKey = "PreScore" + Name
 
 	// ErrReasonPod is the reason for Pod's node affinity/selector not matching.
-	ErrReasonPod = "node(s) didn't match Pod's node affinity"
+	ErrReasonPod = "node(s) didn't match Pod's node affinity/selector"
 
 	// errReasonEnforced is the reason for added node affinity not matching.
 	errReasonEnforced = "node(s) didn't match scheduler-enforced node affinity"


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
In scheduler plugin nodeaffinity, node selector is included in algrithm, so add node selector info in ErrReasonPod.

**Which issue(s) this PR fixes**:
no

**Special notes for your reviewer**:
no

```release-note
   NONE
```

