### PR TITLE
Add e2e networkPolicy test to validate egress deny precedence over ingress allow

### DIFF
--- a/test/e2e/network/netpol/network_policy.go
+++ b/test/e2e/network/netpol/network_policy.go
@@ -623,6 +623,95 @@ var _ = SIGDescribeCopy("Netpol [LinuxOnly]", func() {
 			ValidateOrFail(k8s, model, &TestCase{FromPort: 81, ToPort: 81, Protocol: v1.ProtocolTCP, Reachability: reachabilityPort81})
 		})
 
+		ginkgo.It("should support denying of egress traffic on the client side (even if the server explicitly allows this traffic) [Feature:NetworkPolicy]", func() {
+			// x/a --> y/a and y/b
+			// Egress allowed to y/a only. Egress to y/b should be blocked
+			// Ingress on y/a and y/b allow traffic from x/a
+			// Expectation: traffic from x/a to y/a allowed only, traffic from x/a to y/b denied by egress policy
+
+			nsX, nsY, _, model, k8s := getK8SModel(f)
+
+			// Building egress policy for x/a to y/a only
+			allowedEgressNamespaces := &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"ns": nsY,
+				},
+			}
+			allowedEgressPods := &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"pod": "a",
+				},
+			}
+			egressPolicy := GetAllowEgressByNamespaceAndPod("allow-to-ns-y-pod-a", map[string]string{"pod": "a"}, allowedEgressNamespaces, allowedEgressPods)
+			CreatePolicy(k8s, egressPolicy, nsX)
+
+			// Creating ingress policy to allow from x/a to y/a and y/b
+			allowedIngressNamespaces := &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"ns": nsX,
+				},
+			}
+			allowedIngressPods := &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"pod": "a",
+				},
+			}
+			allowIngressPolicyPodA := GetAllowIngressByNamespaceAndPod("allow-from-xa-on-ya-match-selector", map[string]string{"pod": "a"}, allowedIngressNamespaces, allowedIngressPods)
+			allowIngressPolicyPodB := GetAllowIngressByNamespaceAndPod("allow-from-xa-on-yb-match-selector", map[string]string{"pod": "b"}, allowedIngressNamespaces, allowedIngressPods)
+
+			CreatePolicy(k8s, allowIngressPolicyPodA, nsY)
+			CreatePolicy(k8s, allowIngressPolicyPodB, nsY)
+
+			// While applying the policies, traffic needs to be allowed by both egress and ingress rules.
+			// Egress rules only
+			// 	xa	xb	xc	ya	yb	yc	za	zb	zc
+			// xa	X	X	X	.	*X*	X	X	X	X
+			// xb	.	.	.	.	.	.	.	.	.
+			// xc	.	.	.	.	.	.	.	.	.
+			// ya	.	.	.	.	.	.	.	.	.
+			// yb	.	.	.	.	.	.	.	.	.
+			// yc	.	.	.	.	.	.	.	.	.
+			// za	.	.	.	.	.	.	.	.	.
+			// zb	.	.	.	.	.	.	.	.	.
+			// zc	.	.	.	.	.	.	.	.	.
+			// Ingress rules only
+			// 	xa	xb	xc	ya	yb	yc	za	zb	zc
+			// xa	.	.	.	*.*	.	.	.	.	.
+			// xb	.	.	X	X	.	.	.	.	.
+			// xc	.	.	X	X	.	.	.	.	.
+			// ya	.	.	X	X	.	.	.	.	.
+			// yb	.	.	X	X	.	.	.	.	.
+			// yc	.	.	X	X	.	.	.	.	.
+			// za	.	.	X	X	.	.	.	.	.
+			// zb	.	.	X	X	.	.	.	.	.
+			// zc	.	.	X	X	.	.	.	.	.
+			// In the resulting truth table, connections from x/a should only be allowed to y/a. x/a to y/b should be blocked by the egress on x/a.
+			// Expected results
+			// 	xa	xb	xc	ya	yb	yc	za	zb	zc
+			// xa	X	X	X	.	*X*	X	X	X	X
+			// xb	.	.	.	X	X	.	.	.	.
+			// xc	.	.	.	X	X	.	.	.	.
+			// ya	.	.	.	X	X	.	.	.	.
+			// yb	.	.	.	X	X	.	.	.	.
+			// yc	.	.	.	X	X	.	.	.	.
+			// za	.	.	.	X	X	.	.	.	.
+			// zb	.	.	.	X	X	.	.	.	.
+			// zc	.	.	.	X	X	.	.	.	.
+
+			reachability := NewReachability(model.AllPods(), true)
+			// Default all traffic flows.
+			// Exception: x/a can only egress to y/a, others are false
+			// Exception: y/a can only allow ingress from x/a, others are false
+			// Exception: y/b has no allowed traffic (due to limit on x/a egress)
+
+			reachability.ExpectPeer(&Peer{Namespace: nsX, Pod: "a"}, &Peer{}, false)
+			reachability.ExpectPeer(&Peer{}, &Peer{Namespace: nsY, Pod: "a"}, false)
+			reachability.ExpectPeer(&Peer{Namespace: nsX, Pod: "a"}, &Peer{Namespace: nsY, Pod: "a"}, true)
+			reachability.ExpectPeer(&Peer{}, &Peer{Namespace: nsY, Pod: "b"}, false)
+
+			ValidateOrFail(k8s, model, &TestCase{FromPort: 81, ToPort: 80, Protocol: v1.ProtocolTCP, Reachability: reachability})
+		})
+
 		ginkgo.It("should enforce egress policy allowing traffic to a server in a different namespace based on PodSelector and NamespaceSelector [Feature:NetworkPolicy]", func() {
 			nsX, nsY, _, model, k8s := getK8SModel(f)
 			allowedNamespaces := &metav1.LabelSelector{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
This PR introduces a net e2e test for networkPolicy to validate a scenario where an egress networkpolicy blocks traffic and an ingress policy allows it. 

**Which issue(s) this PR fixes**:
Fixes #97489 
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

**Special notes for your reviewer**:
Discussed with @jayunit100 and @mattfenwick 
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
/sig network