### PR TITLE
use index instead of value for range loop in scheduler framework

### DIFF
--- a/pkg/scheduler/framework/v1alpha1/framework.go
+++ b/pkg/scheduler/framework/v1alpha1/framework.go
@@ -582,8 +582,8 @@ func (f *framework) GetWaitingPod(uid types.UID) WaitingPod {
 
 func pluginNameToConfig(args []config.PluginConfig) map[string]*runtime.Unknown {
 	pc := make(map[string]*runtime.Unknown, 0)
-	for _, p := range args {
-		pc[p.Name] = &p.Args
+	for i := range args {
+		pc[args[i].Name] = &args[i].Args
 	}
 	return pc
 }


### PR DESCRIPTION
**What type of PR is this?**



/kind bug



**What this PR does / why we need it**:

```
func pluginNameToConfig(args []config.PluginConfig) map[string]*runtime.Unknown {
	pc := make(map[string]*runtime.Unknown, 0)
	for _, p := range args {
		pc[p.Name] = &p.Args 
	}
	return pc
}
```
every p inside range loop has same address in high version of golang, so just use index instead of value.