### PR TITLE
replace bytes.Buffer with strings.Builder

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/labels/selector_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/labels/selector_test.go
@@ -738,3 +738,21 @@ func TestValidatedSelectorFromSet(t *testing.T) {
 		}
 	}
 }
+
+func BenchmarkRequirementString(b *testing.B) {
+	r := Requirement{
+		key:      "environment",
+		operator: selection.NotIn,
+		strValues: []string{
+			"dev",
+		},
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if r.String() != "environment notin (dev)" {
+			b.Errorf("Unexpected Requirement string")
+		}
+	}
+}

--- a/staging/src/k8s.io/apimachinery/pkg/util/net/http.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/net/http.go
@@ -693,7 +693,7 @@ func parseQuotedString(quotedString string) (string, string, error) {
 	var remainder string
 	escaping := false
 	closedQuote := false
-	result := &bytes.Buffer{}
+	result := &strings.Builder{}
 loop:
 	for i := 0; i < len(quotedString); i++ {
 		b := quotedString[i]

--- a/staging/src/k8s.io/apimachinery/pkg/util/net/http_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/net/http_test.go
@@ -1107,3 +1107,21 @@ func TestPingTimeoutSeconds(t *testing.T) {
 	}
 	reset()
 }
+
+func Benchmark_ParseQuotedString(b *testing.B) {
+	str := `"The quick brown" fox jumps over the lazy dog`
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		quoted, remainder, err := parseQuotedString(str)
+		if err != nil {
+			b.Errorf("Unexpected error %s", err)
+		}
+		if quoted != "The quick brown" {
+			b.Errorf("Unexpected quoted string %s", quoted)
+		}
+		if remainder != "fox jumps over the lazy dog" {
+			b.Errorf("Unexpected remainder string %s", quoted)
+		}
+	}
+}


### PR DESCRIPTION
strings.Builder has better performance over bytes.Buffer for building
strings:

Benchmark results:
```
name old time/opnew time/opdelta
RequirementString-892.6ns ± 1%46.9ns ± 1%  -49.34%  (p=0.000 n=4+5)

name old alloc/op   new alloc/op   delta
RequirementString-8 96.0B ± 0% 32.0B ± 0%  -66.67%  (p=0.008 n=5+5)

name old allocs/op  new allocs/op  delta
RequirementString-8  2.00 ± 0%  1.00 ± 0%  -50.00%  (p=0.008 n=5+5)
```

```
name  old time/opnew time/opdelta
_ParseQuotedString-8 146ns ±20% 105ns ± 2%  -28.14%  (p=0.008 n=5+5)

name  old alloc/op   new alloc/op   delta
_ParseQuotedString-8 80.0B ± 0% 24.0B ± 0%  -70.00%  (p=0.008 n=5+5)

name  old allocs/op  new allocs/op  delta
_ParseQuotedString-8  2.00 ± 0%  2.00 ± 0% ~ (all equal)
```

Signed-off-by: André Martins <aanm90@gmail.com>

**What type of PR is this?**

/kind cleanup

```release-note
NONE
```