### PR TITLE
fix staticcheck: test/e2e_node

### DIFF
--- a/test/e2e/common/util.go
+++ b/test/e2e/common/util.go
@@ -60,7 +60,7 @@ var CurrentSuite Suite
 // PrePulledImages are a list of images used in e2e/common tests. These images should be prepulled
 // before tests starts, so that the tests won't fail due image pulling flakes.
 // Currently, this is only used by node e2e test.
-// See also updateImageAllowList() in ../../e2e_node/image_list.go
+// See also UpdateImageAllowList() in ../../e2e_node/image_list.go
 // TODO(random-liu): Change the image puller pod to use similar mechanism.
 var PrePulledImages = sets.NewString(
 	imageutils.GetE2EImage(imageutils.Agnhost),

--- a/test/e2e_node/e2e_node_suite_test.go
+++ b/test/e2e_node/e2e_node_suite_test.go
@@ -182,7 +182,7 @@ var _ = ginkgo.SynchronizedBeforeSuite(func() []byte {
 	// This helps with debugging test flakes since it is hard to tell when a test failure is due to image pulling.
 	if framework.TestContext.PrepullImages {
 		klog.Infof("Pre-pulling images so that they are cached for the tests.")
-		updateImageAllowList()
+		UpdateImageAllowList()
 		err := PrePullAllImages()
 		gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 	}
@@ -192,10 +192,10 @@ var _ = ginkgo.SynchronizedBeforeSuite(func() []byte {
 	// We should mask locksmithd when provisioning the machine.
 	maskLocksmithdOnCoreos()
 
-	if *startServices {
+	if *StartServices {
 		// If the services are expected to stop after test, they should monitor the test process.
 		// If the services are expected to keep running after test, they should not monitor the test process.
-		e2es = services.NewE2EServices(*stopServices)
+		e2es = services.NewE2EServices(*StopServices)
 		gomega.Expect(e2es.Start()).To(gomega.Succeed(), "should be able to start node services.")
 	} else {
 		klog.Infof("Running tests without starting services.")
@@ -220,7 +220,7 @@ var _ = ginkgo.SynchronizedBeforeSuite(func() []byte {
 // Tear down the kubelet on the node
 var _ = ginkgo.SynchronizedAfterSuite(func() {}, func() {
 	if e2es != nil {
-		if *startServices && *stopServices {
+		if *StartServices && *StopServices {
 			klog.Infof("Stopping node services...")
 			e2es.Stop()
 		}
@@ -285,7 +285,7 @@ func waitForNodeReady() {
 // update test context with node configuration.
 func updateTestContext() error {
 	setExtraEnvs()
-	updateImageAllowList()
+	UpdateImageAllowList()
 
 	client, err := getAPIServerClient()
 	if err != nil {

--- a/test/e2e_node/image_list.go
+++ b/test/e2e_node/image_list.go
@@ -66,11 +66,11 @@ var NodePrePullImageList = sets.NewString(
 	"gcr.io/kubernetes-e2e-test-images/node-perf/tf-wide-deep-amd64:1.0",
 )
 
-// updateImageAllowList updates the framework.ImagePrePullList with
+// UpdateImageAllowList updates the framework.ImagePrePullList with
 // 1. the hard coded lists
 // 2. the ones passed in from framework.TestContext.ExtraEnvs
 // So this function needs to be called after the extra envs are applied.
-func updateImageAllowList() {
+func UpdateImageAllowList() {
 	// Union NodePrePullImageList and PrePulledImages into the framework image pre-pull list.
 	framework.ImagePrePullList = NodePrePullImageList.Union(commontest.PrePulledImages)
 	// Images from extra envs

--- a/test/e2e_node/util.go
+++ b/test/e2e_node/util.go
@@ -59,8 +59,11 @@ import (
 	"github.com/onsi/gomega"
 )
 
-var startServices = flag.Bool("start-services", true, "If true, start local node services")
-var stopServices = flag.Bool("stop-services", true, "If true, stop local node services after running tests")
+// StartServices is a flag to control if start local node services.
+var StartServices = flag.Bool("start-services", true, "If true, start local node services")
+
+// StopServices is a flag to control if stop local node services after running tests.
+var StopServices = flag.Bool("stop-services", true, "If true, stop local node services after running tests")
 var busyboxImage = imageutils.GetE2EImage(imageutils.BusyBox)
 
 const (


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

PR cleans up the issues identified by staticcheck in `test/e2e_node`

```
test/e2e_node/image_list.go:73:6: func updateImageAllowList is unused (U1000)
test/e2e_node/image_list.go:81:6: func getNodeProblemDetectorImage is unused (U1000)
test/e2e_node/image_list.go:235:6: func getSRIOVDevicePluginImage is unused (U1000)
test/e2e_node/util.go:62:5: var startServices is unused (U1000)
test/e2e_node/util.go:63:5: var stopServices is unused (U1000)
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of #92402

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
