### PR TITLE
Change masquerade method to SNAT method

### DIFF
--- a/pkg/proxy/iptables/proxier.go
+++ b/pkg/proxy/iptables/proxier.go
@@ -964,7 +964,7 @@ func (proxier *Proxier) syncProxyRules() {
 	masqRule := []string{
 		"-A", string(kubePostroutingChain),
 		"-m", "comment", "--comment", `"kubernetes service traffic requiring SNAT"`,
-		"-j", "MASQUERADE",
+		"-j", "SNAT", "--to-source", proxier.nodeIP.String(),
 	}
 	if proxier.iptables.HasRandomFully() {
 		masqRule = append(masqRule, "--random-fully")


### PR DESCRIPTION

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
 I found that masquerade is unreliable when there are multiple network interfaces. I think SNAT is better for this.
**Which issue(s) this PR fixes**:
Fixes #78949 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
NONE

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

