### PR TITLE
use Lstat instead of Stat for unix socket on windows

### DIFF
--- a/pkg/kubelet/cm/devicemanager/manager.go
+++ b/pkg/kubelet/cm/devicemanager/manager.go
@@ -211,7 +211,10 @@ func (m *ManagerImpl) removeContents(dir string) error {
 		if filePath == m.checkpointFile() {
 			continue
 		}
-		stat, err := os.Stat(filePath)
+		// TODO: Until the bug - https://github.com/golang/go/issues/33357 is fixed, os.stat wouldn't return the
+		// right mode(socket) on windows. Hence deleting the file, without checking whether
+		// its a socket, on windows.
+		stat, err := os.Lstat(filePath)
 		if err != nil {
 			klog.Errorf("Failed to stat file %s: %v", filePath, err)
 			continue


### PR DESCRIPTION
**What type of PR is this?**
fix https://github.com/kubernetes/kubernetes/issues/97554

/kind bug
/kind regression

**Which issue(s) this PR fixes**:

Fixes #97554

**What this PR does / why we need it**:

Fix the os.Stat on unix socket on Windows by using os.Lstat unit there is a change a fix in Golang.
