### PR TITLE
feat(kubeadm): graduate command "kubeconfig user"

### DIFF
--- a/cmd/kubeadm/app/cmd/alpha/alpha.go
+++ b/cmd/kubeadm/app/cmd/alpha/alpha.go
@@ -29,32 +29,29 @@ func NewCmdAlpha(in io.Reader, out io.Writer) *cobra.Command {
 		Short: "Kubeadm experimental sub-commands",
 	}
 
-	cmd.AddCommand(newCmdKubeConfigUtility(out))
+	kubeconfigCmd := NewCmdKubeConfigUtility(out)
+	deprecateCommand(`please use the same command under "kubeadm kubeconfig"`, kubeconfigCmd)
+	cmd.AddCommand(kubeconfigCmd)
 
 	const shDeprecatedMessage = "self-hosting support in kubeadm is deprecated " +
 		"and will be removed in a future release"
 	shCommand := newCmdSelfhosting(in)
-	shCommand.Deprecated = shDeprecatedMessage
-	for _, cmd := range shCommand.Commands() {
-		cmd.Deprecated = shDeprecatedMessage
-	}
+	deprecateCommand(shDeprecatedMessage, shCommand)
 	cmd.AddCommand(shCommand)
 
 	certsCommand := NewCmdCertsUtility(out)
-	deprecateCertsCommand(certsCommand)
+	deprecateCommand(`please use the same command under "kubeadm certs"`, certsCommand)
 	cmd.AddCommand(certsCommand)
 
 	return cmd
 }
 
-func deprecateCertsCommand(cmds ...*cobra.Command) {
-	const deprecatedMessage = "please use the same command under \"kubeadm certs\""
-
+func deprecateCommand(msg string, cmds ...*cobra.Command) {
 	for _, cmd := range cmds {
-		cmd.Deprecated = deprecatedMessage
+		cmd.Deprecated = msg
 		childCmds := cmd.Commands()
 		if len(childCmds) > 0 {
-			deprecateCertsCommand(childCmds...)
+			deprecateCommand(msg, childCmds...)
 		}
 	}
 }

--- a/cmd/kubeadm/app/cmd/alpha/kubeconfig.go
+++ b/cmd/kubeadm/app/cmd/alpha/kubeconfig.go
@@ -43,8 +43,8 @@ var (
 	`)
 )
 
-// newCmdKubeConfigUtility returns main command for kubeconfig phase
-func newCmdKubeConfigUtility(out io.Writer) *cobra.Command {
+// NewCmdKubeConfigUtility returns main command for kubeconfig phase
+func NewCmdKubeConfigUtility(out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "kubeconfig",
 		Short: "Kubeconfig file utilities",

--- a/cmd/kubeadm/app/cmd/cmd.go
+++ b/cmd/kubeadm/app/cmd/cmd.go
@@ -95,6 +95,9 @@ func NewKubeadmCommand(in io.Reader, out, err io.Writer) *cobra.Command {
 	// TODO: remove "certs" from "alpha"
 	// https://github.com/kubernetes/kubeadm/issues/2291
 	cmds.AddCommand(alpha.NewCmdCertsUtility(out))
+	// TODO: remove "kubeconfig" from "alpha"
+	// https://github.com/kubernetes/kubeadm/issues/2292
+	cmds.AddCommand(alpha.NewCmdKubeConfigUtility(out))
 
 	return cmds
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind feature
/kind deprecation

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:

Graduate command `kubeadm alpha kubeconfig user` to `kubeadm kubeconfig user`.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
xref https://github.com/kubernetes/kubeadm/issues/2292

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kubeadm: graduate the command `kubeadm alpha kubeconfig user` to `kubeadm kubeconfig user`. The `kubeadm alpha kubeconfig user` command is deprecated now.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
