### PR TITLE
Sync writes to fake reactor chain

### DIFF
--- a/staging/src/k8s.io/client-go/testing/fake.go
+++ b/staging/src/k8s.io/client-go/testing/fake.go
@@ -96,31 +96,49 @@ type ProxyReactionFunc func(action Action) (handled bool, ret restclient.Respons
 
 // AddReactor appends a reactor to the end of the chain.
 func (c *Fake) AddReactor(verb, resource string, reaction ReactionFunc) {
+	c.Lock()
+	defer c.Unlock()
+
 	c.ReactionChain = append(c.ReactionChain, &SimpleReactor{verb, resource, reaction})
 }
 
 // PrependReactor adds a reactor to the beginning of the chain.
 func (c *Fake) PrependReactor(verb, resource string, reaction ReactionFunc) {
+	c.Lock()
+	defer c.Unlock()
+
 	c.ReactionChain = append([]Reactor{&SimpleReactor{verb, resource, reaction}}, c.ReactionChain...)
 }
 
 // AddWatchReactor appends a reactor to the end of the chain.
 func (c *Fake) AddWatchReactor(resource string, reaction WatchReactionFunc) {
+	c.Lock()
+	defer c.Unlock()
+
 	c.WatchReactionChain = append(c.WatchReactionChain, &SimpleWatchReactor{resource, reaction})
 }
 
 // PrependWatchReactor adds a reactor to the beginning of the chain.
 func (c *Fake) PrependWatchReactor(resource string, reaction WatchReactionFunc) {
+	c.Lock()
+	defer c.Unlock()
+
 	c.WatchReactionChain = append([]WatchReactor{&SimpleWatchReactor{resource, reaction}}, c.WatchReactionChain...)
 }
 
 // AddProxyReactor appends a reactor to the end of the chain.
 func (c *Fake) AddProxyReactor(resource string, reaction ProxyReactionFunc) {
+	c.Lock()
+	defer c.Unlock()
+
 	c.ProxyReactionChain = append(c.ProxyReactionChain, &SimpleProxyReactor{resource, reaction})
 }
 
 // PrependProxyReactor adds a reactor to the beginning of the chain.
 func (c *Fake) PrependProxyReactor(resource string, reaction ProxyReactionFunc) {
+	c.Lock()
+	defer c.Unlock()
+
 	c.ProxyReactionChain = append([]ProxyReactor{&SimpleProxyReactor{resource, reaction}}, c.ProxyReactionChain...)
 }
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This PR syncs writes to the reaction chain used in the fake client reactor.

I encountered data races using this fake client where one goroutine is calling `PrependWatchReactor()` while another is attempting to read this chain via `InvokesWatch()`. Other writes and reads are protected.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/sig api-machinery

@msau42 @yuga711 @caesarxuchao