### PR TITLE
Fix typo in pkg/kubelet/.../helpers_test.go

### DIFF
--- a/pkg/kubelet/apis/config/helpers_test.go
+++ b/pkg/kubelet/apis/config/helpers_test.go
@@ -119,7 +119,7 @@ func TestAllPrimitiveFieldPaths(t *testing.T) {
 		unexpected := result.Difference(expect)
 
 		if len(missing) > 0 {
-			t.Errorf("the following fields were exepcted, but missing from the result:\n%s", strings.Join(missing.List(), "\n"))
+			t.Errorf("the following fields were expected, but missing from the result:\n%s", strings.Join(missing.List(), "\n"))
 		}
 		if len(unexpected) > 0 {
 			t.Errorf("the following fields were in the result, but unexpected:\n%s", strings.Join(unexpected.List(), "\n"))


### PR DESCRIPTION
What type of PR is this?
/kind cleanup

What this PR does / why we need it:
Fix typo in kubernetes/pkg/kubelet/apis/config/helpers_test.go

Which issue(s) this PR fixes:

Fixes #

Special notes for your reviewer:

Does this PR introduce a user-facing change?:

```release-note
NONE
```
Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.: