### PR TITLE
Migrate scheduler-plugin's logs to structured logging

### DIFF
--- a/pkg/scheduler/framework/plugins/noderesources/resource_allocation.go
+++ b/pkg/scheduler/framework/plugins/noderesources/resource_allocation.go
@@ -104,9 +104,7 @@ func calculateResourceAllocatableRequest(nodeInfo *framework.NodeInfo, pod *v1.P
 		}
 	}
 	if klog.V(10).Enabled() {
-		klog.Infof("requested resource %v not considered for node score calculation",
-			resource,
-		)
+		klog.InfoS("requested resource not considered for node score calculation", "resource", resource)
 	}
 	return 0, 0
 }

--- a/pkg/scheduler/framework/plugins/nodevolumelimits/csi.go
+++ b/pkg/scheduler/framework/plugins/nodevolumelimits/csi.go
@@ -82,7 +82,7 @@ func (pl *CSILimits) Filter(ctx context.Context, _ *framework.CycleState, pod *v
 	csiNode, err := pl.csiNodeLister.Get(node.Name)
 	if err != nil {
 		// TODO: return the error once CSINode is created by default (2 releases)
-		klog.V(5).Infof("Could not get a CSINode object for the node: %v", err)
+		klog.V(5).InfoS("Could not get a CSINode object for the node", "error", err)
 	}
 
 	newVolumes := make(map[string]string)
@@ -149,13 +149,13 @@ func (pl *CSILimits) filterAttachableVolumes(
 		pvc, err := pl.pvcLister.PersistentVolumeClaims(namespace).Get(pvcName)
 
 		if err != nil {
-			klog.V(5).Infof("Unable to look up PVC info for %s/%s", namespace, pvcName)
+			klog.V(5).InfoS("Unable to look up PVC info", "namespace", namespace, "pvcName", pvcName)
 			continue
 		}
 
 		driverName, volumeHandle := pl.getCSIDriverInfo(csiNode, pvc)
 		if driverName == "" || volumeHandle == "" {
-			klog.V(5).Infof("Could not find a CSI driver name or volume handle, not counting volume")
+			klog.V(5).InfoS("Could not find a CSI driver name or volume handle, not counting volume")
 			continue
 		}
 
@@ -175,13 +175,13 @@ func (pl *CSILimits) getCSIDriverInfo(csiNode *storagev1.CSINode, pvc *v1.Persis
 	pvcName := pvc.Name
 
 	if pvName == "" {
-		klog.V(5).Infof("Persistent volume had no name for claim %s/%s", namespace, pvcName)
+		klog.V(5).InfoS("Persistent volume had no name for claim", "namespace", namespace, "pvcName", pvcName)
 		return pl.getCSIDriverInfoFromSC(csiNode, pvc)
 	}
 
 	pv, err := pl.pvLister.Get(pvName)
 	if err != nil {
-		klog.V(5).Infof("Unable to look up PV info for PVC %s/%s and PV %s", namespace, pvcName, pvName)
+		klog.V(5).InfoS("Unable to look up PV info for PVC and PV", "namespace", namespace, "pvcName", pvcName, "pvName", pvName)
 		// If we can't fetch PV associated with PVC, may be it got deleted
 		// or PVC was prebound to a PVC that hasn't been created yet.
 		// fallback to using StorageClass for volume counting
@@ -197,23 +197,23 @@ func (pl *CSILimits) getCSIDriverInfo(csiNode *storagev1.CSINode, pvc *v1.Persis
 
 		pluginName, err := pl.translator.GetInTreePluginNameFromSpec(pv, nil)
 		if err != nil {
-			klog.V(5).Infof("Unable to look up plugin name from PV spec: %v", err)
+			klog.ErrorS(err, "Unable to look up plugin name from PV spec")
 			return "", ""
 		}
 
 		if !isCSIMigrationOn(csiNode, pluginName) {
-			klog.V(5).Infof("CSI Migration of plugin %s is not enabled", pluginName)
+			klog.V(5).InfoS("CSI Migration of plugin is not enabled", "pluginName", pluginName)
 			return "", ""
 		}
 
 		csiPV, err := pl.translator.TranslateInTreePVToCSI(pv)
 		if err != nil {
-			klog.V(5).Infof("Unable to translate in-tree volume to CSI: %v", err)
+			klog.ErrorS(err, "Unable to translate in-tree volume to CSI: %v")
 			return "", ""
 		}
 
 		if csiPV.Spec.PersistentVolumeSource.CSI == nil {
-			klog.V(5).Infof("Unable to get a valid volume source for translated PV %s", pvName)
+			klog.V(5).InfoS("Unable to get a valid volume source for translated PV", "pvName", pvName)
 			return "", ""
 		}
 
@@ -232,13 +232,13 @@ func (pl *CSILimits) getCSIDriverInfoFromSC(csiNode *storagev1.CSINode, pvc *v1.
 	// If StorageClass is not set or not found, then PVC must be using immediate binding mode
 	// and hence it must be bound before scheduling. So it is safe to not count it.
 	if scName == "" {
-		klog.V(5).Infof("PVC %s/%s has no StorageClass", namespace, pvcName)
+		klog.V(5).InfoS("PVC has no StorageClass", "namespace", namespace, "pvcName", pvcName)
 		return "", ""
 	}
 
 	storageClass, err := pl.scLister.Get(scName)
 	if err != nil {
-		klog.V(5).Infof("Could not get StorageClass for PVC %s/%s: %v", namespace, pvcName, err)
+		klog.ErrorS(err, "Could not get StorageClass for PVC", "namespace", namespace, "pvcName", pvcName)
 		return "", ""
 	}
 
@@ -250,13 +250,13 @@ func (pl *CSILimits) getCSIDriverInfoFromSC(csiNode *storagev1.CSINode, pvc *v1.
 	provisioner := storageClass.Provisioner
 	if pl.translator.IsMigratableIntreePluginByName(provisioner) {
 		if !isCSIMigrationOn(csiNode, provisioner) {
-			klog.V(5).Infof("CSI Migration of plugin %s is not enabled", provisioner)
+			klog.V(5).InfoS("CSI Migration of plugin is not enabled", "provisioner", provisioner)
 			return "", ""
 		}
 
 		driverName, err := pl.translator.GetCSINameFromInTreeName(provisioner)
 		if err != nil {
-			klog.V(5).Infof("Unable to look up driver name from plugin name: %v", err)
+			klog.ErrorS(err, "Unable to look up driver name from plugin name")
 			return "", ""
 		}
 		return driverName, volumeHandle

--- a/pkg/scheduler/framework/plugins/podtopologyspread/filtering.go
+++ b/pkg/scheduler/framework/plugins/podtopologyspread/filtering.go
@@ -294,7 +294,7 @@ func (pl *PodTopologySpread) Filter(ctx context.Context, cycleState *framework.C
 		tpKey := c.TopologyKey
 		tpVal, ok := node.Labels[c.TopologyKey]
 		if !ok {
-			klog.V(5).Infof("node '%s' doesn't have required label '%s'", node.Name, tpKey)
+			klog.V(5).InfoS("node doesn't have required label", "node", node.Name, "label", tpKey)
 			return framework.NewStatus(framework.UnschedulableAndUnresolvable, ErrReasonNodeLabelNotMatch)
 		}
 

--- a/pkg/scheduler/framework/plugins/volumebinding/volume_binding.go
+++ b/pkg/scheduler/framework/plugins/volumebinding/volume_binding.go
@@ -254,13 +254,13 @@ func (pl *VolumeBinding) PreBind(ctx context.Context, cs *framework.CycleState, 
 	if !ok {
 		return framework.AsStatus(fmt.Errorf("no pod volumes found for node %q", nodeName))
 	}
-	klog.V(5).Infof("Trying to bind volumes for pod \"%v/%v\"", pod.Namespace, pod.Name)
+	klog.V(5).InfoS("Trying to bind volumes for pod", "pod", klog.KObj(pod))
 	err = pl.Binder.BindPodVolumes(pod, podVolumes)
 	if err != nil {
-		klog.V(1).Infof("Failed to bind volumes for pod \"%v/%v\": %v", pod.Namespace, pod.Name, err)
+		klog.ErrorS(err, "Failed to bind volumes for pod", "pod", klog.KObj(pod))
 		return framework.AsStatus(err)
 	}
-	klog.V(5).Infof("Success binding volumes for pod \"%v/%v\"", pod.Namespace, pod.Name)
+	klog.V(5).InfoS("Success binding volumes for pod", "pod", klog.KObj(pod))
 	return nil
 }
 


### PR DESCRIPTION
Migrate scheduler-plugin's logs to structured logging

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Ref:

[keps/sig-instrumentation/1602-structured-logging](https://github.com/kubernetes/enhancements/tree/master/keps/sig-instrumentation/1602-structured-logging)
[Structured Logging migration instructions](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/migration-to-structured-logging.md)

**Does this PR introduce a user-facing change?:**:
```
Migrate some scheduler plugin log messages to structured logging
````
