### PR TITLE
Migrate scheduler-runtime's logs to structured logging

### DIFF
--- a/pkg/scheduler/framework/runtime/framework.go
+++ b/pkg/scheduler/framework/runtime/framework.go
@@ -930,7 +930,7 @@ func (f *frameworkImpl) WaitOnPermit(ctx context.Context, pod *v1.Pod) (status *
 		return nil
 	}
 	defer f.waitingPods.remove(pod.UID)
-	klog.V(4).Infof("pod %q waiting on permit", pod.Name)
+	klog.V(4).InfoS("pod waiting on permit", "pod", klog.KObj(pod))
 
 	startTime := time.Now()
 	s := <-waitingPod.s


### PR DESCRIPTION
Migrate scheduler-runtime's logs to structured logging

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Ref:

[keps/sig-instrumentation/1602-structured-logging](https://github.com/kubernetes/enhancements/tree/master/keps/sig-instrumentation/1602-structured-logging)
[Structured Logging migration instructions](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/migration-to-structured-logging.md)

**Does this PR introduce a user-facing change?:**:
```
Migrate some scheduler runtime log messages to structured logging
````
