### PR TITLE
Migrate cmd/kubelet/app/server_linux.go logs to structured logging

### DIFF
--- a/cmd/kubelet/app/server_linux.go
+++ b/cmd/kubelet/app/server_linux.go
@@ -24,19 +24,19 @@ import (
 func watchForLockfileContention(path string, done chan struct{}) error {
 	watcher, err := inotify.NewWatcher()
 	if err != nil {
-		klog.Errorf("unable to create watcher for lockfile: %v", err)
+		klog.ErrorS("unable to create watcher for lockfile: %v", err)
 		return err
 	}
 	if err = watcher.AddWatch(path, inotify.InOpen|inotify.InDeleteSelf); err != nil {
-		klog.Errorf("unable to watch lockfile: %v", err)
+		klog.ErrorS("unable to watch lockfile: %v", err)
 		return err
 	}
 	go func() {
 		select {
 		case ev := <-watcher.Event:
-			klog.Infof("inotify event: %v", ev)
+			klog.InfoS("inotify event: %v", ev)
 		case err = <-watcher.Error:
-			klog.Errorf("inotify watcher error: %v", err)
+			klog.ErrorS("inotify watcher error: %v", err)
 		}
 		close(done)
 	}()


### PR DESCRIPTION
/kind documentation

Migrate cmd/kubelet/app/server_linux.go logs to structured logging，https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/migration-to-structured-logging.md