### PR TITLE
fix nil pointer dereference when NodeInfo.RemovePod

### DIFF
--- a/pkg/scheduler/framework/types.go
+++ b/pkg/scheduler/framework/types.go
@@ -581,7 +581,7 @@ func (n *NodeInfo) RemovePod(pod *v1.Pod) error {
 			return nil
 		}
 	}
-	return fmt.Errorf("no corresponding pod %s in pods of node %s", pod.Name, n.node.Name)
+	return fmt.Errorf("no corresponding pod %s in pods of node %s", pod.Name, pod.Spec.NodeName)
 }
 
 // resets the slices to nil so that we can do DeepEqual in unit tests.

--- a/pkg/scheduler/framework/types_test.go
+++ b/pkg/scheduler/framework/types_test.go
@@ -1060,6 +1060,8 @@ func TestNodeInfoRemovePod(t *testing.T) {
 		if !reflect.DeepEqual(test.expectedNodeInfo, ni) {
 			t.Errorf("expected: %#v, got: %#v", test.expectedNodeInfo, ni)
 		}
+		ni.RemoveNode()
+		ni.RemovePod(test.pod)
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

>  E1230 15:36:15.979242  331116 runtime.go:78] Observed a panic: "invalid memory address or nil pointer dereference" (runtime error: invalid memory address or nil pointer dereference)
 goroutine 1845 [running]:
 dispatcher/vendor/k8s.io/apimachinery/pkg/util/runtime.logPanic(0x17da4a0, 0x278fa20)
   /home/jenkins/go/src/dispatcher/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:74 +0xa6
 dispatcher/vendor/k8s.io/apimachinery/pkg/util/runtime.HandleCrash(0x0, 0x0, 0x0)
   /home/jenkins/go/src/dispatcher/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:48 +0x89
 panic(0x17da4a0, 0x278fa20)
   /usr/local/go/src/runtime/panic.go:969 +0x1b9
 dispatcher/vendor/k8s.io/kubernetes/pkg/scheduler/framework/v1alpha1.(*NodeInfo).RemovePod(0xc943bafea0, 0xc5e8261800, 0xc3a153d380, 0x2b)
   /home/jenkins/go/src/dispatcher/vendor/k8s.io/kubernetes/pkg/scheduler/framework/v1alpha1/types.go:553 +0x65d
 dispatcher/pkg/cache.(*schedulerCache).removePod(0xc00106b4a0, 0xc5e8261800, 0xc3544d1260, 0x2b)
   /home/jenkins/go/src/dispatcher/pkg/cache/cache.go:142 +0x85
 dispatcher/pkg/cache.(*schedulerCache).updatePod(0xc00106b4a0, 0xc5e8261800, 0xc42ea66400, 0x1, 0x27e83e0)
   /home/jenkins/go/src/dispatcher/pkg/cache/cache.go:127 +0x7b
 dispatcher/pkg/cache.(*schedulerCache).UpdatePod(0xc00106b4a0, 0xc5e8261800, 0xc42ea66400, 0x0, 0x0)
   /home/jenkins/go/src/dispatcher/pkg/cache/cache.go:203 +0x1d3
 dispatcher/pkg/clusters/scheduler.(*Scheduler).updatePodInCache(0xc002a2a000, 0x19e1b80, 0xc5e8261800, 0x19e1b80, 0xc42ea66400)
   /home/jenkins/go/src/dispatcher/pkg/clusters/scheduler/scheduler.go:385 +0x9b
 dispatcher/vendor/k8s.io/client-go/tools/cache.ResourceEventHandlerFuncs.OnUpdate(...)
   /home/jenkins/go/src/dispatcher/vendor/k8s.io/client-go/tools/cache/controller.go:234
 dispatcher/vendor/k8s.io/client-go/tools/cache.FilteringResourceEventHandler.OnUpdate(0x1ac5c78, 0x1c33780, 0xc0005cd160, 0x19e1b80, 0xc5e8261800, 0x19e1b80, 0xc42ea66400)
   /home/jenkins/go/src/dispatcher/vendor/k8s.io/client-go/tools/cache/controller.go:269 +0x122
 dispatcher/vendor/k8s.io/client-go/tools/cache.(*processorListener).run.func1()
   /home/jenkins/go/src/dispatcher/vendor/k8s.io/client-go/tools/cache/shared_informer.go:775 +0x1c5
 dispatcher/vendor/k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1(0xc0007abf60)
   /home/jenkins/go/src/dispatcher/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:155 +0x5f
 dispatcher/vendor/k8s.io/apimachinery/pkg/util/wait.BackoffUntil(0xc000827f60, 0x1bf1500, 0xc001c94060, 0x17a0e01, 0xc0014e24e0)
   /home/jenkins/go/src/dispatcher/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:156 +0xad
 dispatcher/vendor/k8s.io/apimachinery/pkg/util/wait.JitterUntil(0xc0007abf60, 0x3b9aca00, 0x0, 0x1ac9401, 0xc0014e24e0)
   /home/jenkins/go/src/dispatcher/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:133 +0x98
 dispatcher/vendor/k8s.io/apimachinery/pkg/util/wait.Until(...)
   /home/jenkins/go/src/dispatcher/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:90
 dispatcher/vendor/k8s.io/client-go/tools/cache.(*processorListener).run(0xc000a56500)
   /home/jenkins/go/src/dispatcher/vendor/k8s.io/client-go/tools/cache/shared_informer.go:771 +0x95
 dispatcher/vendor/k8s.io/apimachinery/pkg/util/wait.(*Group).Start.func1(0xc0010de290, 0xc001298160)
   /home/jenkins/go/src/dispatcher/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:73 +0x51
 created by dispatcher/vendor/k8s.io/apimachinery/pkg/util/wait.(*Group).Start
   /home/jenkins/go/src/dispatcher/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:71 +0x65
 panic: runtime error: invalid memory address or nil pointer dereference [recovered]
   panic: runtime error: invalid memory address or nil pointer dereference
 [signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0x13b735d]



> goroutine 1845 [running]:
 dispatcher/vendor/k8s.io/apimachinery/pkg/util/runtime.HandleCrash(0x0, 0x0, 0x0)
   /home/jenkins/go/src/dispatcher/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:55 +0x10c
 panic(0x17da4a0, 0x278fa20)
   /usr/local/go/src/runtime/panic.go:969 +0x1b9
 dispatcher/vendor/k8s.io/kubernetes/pkg/scheduler/framework/v1alpha1.(*NodeInfo).RemovePod(0xc943bafea0, 0xc5e8261800, 0xc3a153d380, 0x2b)
   /home/jenkins/go/src/dispatcher/vendor/k8s.io/kubernetes/pkg/scheduler/framework/v1alpha1/types.go:553 +0x65d
 dispatcher/pkg/cache.(*schedulerCache).removePod(0xc00106b4a0, 0xc5e8261800, 0xc3544d1260, 0x2b)
   /home/jenkins/go/src/dispatcher/pkg/cache/cache.go:142 +0x85
 dispatcher/pkg/cache.(*schedulerCache).updatePod(0xc00106b4a0, 0xc5e8261800, 0xc42ea66400, 0x1, 0x27e83e0)
   /home/jenkins/go/src/dispatcher/pkg/cache/cache.go:127 +0x7b
 dispatcher/pkg/cache.(*schedulerCache).UpdatePod(0xc00106b4a0, 0xc5e8261800, 0xc42ea66400, 0x0, 0x0)
   /home/jenkins/go/src/dispatcher/pkg/cache/cache.go:203 +0x1d3
 dispatcher/pkg/clusters/scheduler.(*Scheduler).updatePodInCache(0xc002a2a000, 0x19e1b80, 0xc5e8261800, 0x19e1b80, 0xc42ea66400)
   /home/jenkins/go/src/dispatcher/pkg/clusters/scheduler/scheduler.go:385 +0x9b
 dispatcher/vendor/k8s.io/client-go/tools/cache.ResourceEventHandlerFuncs.OnUpdate(...)
   /home/jenkins/go/src/dispatcher/vendor/k8s.io/client-go/tools/cache/controller.go:234
 dispatcher/vendor/k8s.io/client-go/tools/cache.FilteringResourceEventHandler.OnUpdate(0x1ac5c78, 0x1c33780, 0xc0005cd160, 0x19e1b80, 0xc5e8261800, 0x19e1b80, 0xc42ea66400)
   /home/jenkins/go/src/dispatcher/vendor/k8s.io/client-go/tools/cache/controller.go:269 +0x122
 dispatcher/vendor/k8s.io/client-go/tools/cache.(*processorListener).run.func1()
   /home/jenkins/go/src/dispatcher/vendor/k8s.io/client-go/tools/cache/shared_informer.go:775 +0x1c5
 dispatcher/vendor/k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1(0xc0007abf60)
   /home/jenkins/go/src/dispatcher/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:155 +0x5f
 dispatcher/vendor/k8s.io/apimachinery/pkg/util/wait.BackoffUntil(0xc000827f60, 0x1bf1500, 0xc001c94060, 0x17a0e01, 0xc0014e24e0)
   /home/jenkins/go/src/dispatcher/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:156 +0xad
 dispatcher/vendor/k8s.io/apimachinery/pkg/util/wait.JitterUntil(0xc0007abf60, 0x3b9aca00, 0x0, 0x1ac9401, 0xc0014e24e0)
   /home/jenkins/go/src/dispatcher/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:133 +0x98
 dispatcher/vendor/k8s.io/apimachinery/pkg/util/wait.Until(...)
   /home/jenkins/go/src/dispatcher/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:90
 dispatcher/vendor/k8s.io/client-go/tools/cache.(*processorListener).run(0xc000a56500)
   /home/jenkins/go/src/dispatcher/vendor/k8s.io/client-go/tools/cache/shared_informer.go:771 +0x95
 dispatcher/vendor/k8s.io/apimachinery/pkg/util/wait.(*Group).Start.func1(0xc0010de290, 0xc001298160)
   /home/jenkins/go/src/dispatcher/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:73 +0x51
 created by dispatcher/vendor/k8s.io/apimachinery/pkg/util/wait.(*Group).Start
   /home/jenkins/go/src/dispatcher/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:71 +0x65


Add one of the following kinds:

/kind bug

**What this PR does / why we need it**:
When `RemoveNode` is called before `RemovePod`, k8s will panic: "invalid memory address or nil pointer dereference"  

This PR fix nil pointer dereference when NodeInfo.RemovePod

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
/sig-scheduler