### PR TITLE
Migrate scheduler's logs to structured logging

### DIFF
--- a/pkg/scheduler/core/generic_scheduler.go
+++ b/pkg/scheduler/core/generic_scheduler.go
@@ -353,8 +353,7 @@ func (g *genericScheduler) findNodesThatPassExtenders(pod *v1.Pod, feasibleNodes
 		feasibleList, failedMap, err := extender.Filter(pod, feasibleNodes)
 		if err != nil {
 			if extender.IsIgnorable() {
-				klog.Warningf("Skipping extender %v as it returned error %v and has ignorable flag set",
-					extender, err)
+				klog.ErrorS(err, "Skipping extender as it returned error and has ignorable flag set", "extender", extender)
 				continue
 			}
 			return nil, err

--- a/pkg/scheduler/internal/cache/node_tree.go
+++ b/pkg/scheduler/internal/cache/node_tree.go
@@ -53,7 +53,7 @@ func (nt *nodeTree) addNode(n *v1.Node) {
 	if na, ok := nt.tree[zone]; ok {
 		for _, nodeName := range na {
 			if nodeName == n.Name {
-				klog.Warningf("node %q already exist in the NodeTree", n.Name)
+				klog.InfoS("node already exist in the NodeTree", "node", n.Name)
 				return
 			}
 		}
@@ -62,7 +62,7 @@ func (nt *nodeTree) addNode(n *v1.Node) {
 		nt.zones = append(nt.zones, zone)
 		nt.tree[zone] = []string{n.Name}
 	}
-	klog.V(2).Infof("Added node %q in group %q to NodeTree", n.Name, zone)
+	klog.V(2).InfoS("Added node to NodeTree", "node", n.Name, "zone", zone)
 	nt.numNodes++
 }
 
@@ -76,7 +76,7 @@ func (nt *nodeTree) removeNode(n *v1.Node) error {
 				if len(nt.tree[zone]) == 0 {
 					nt.removeZone(zone)
 				}
-				klog.V(2).Infof("Removed node %q in group %q from NodeTree", n.Name, zone)
+				klog.V(2).InfoS("Removed node from NodeTree", "node", n.Name, "zone", zone)
 				nt.numNodes--
 				return nil
 			}


### PR DESCRIPTION
Migrate scheduler's logs to structured logging

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Ref:

[keps/sig-instrumentation/1602-structured-logging](https://github.com/kubernetes/enhancements/tree/master/keps/sig-instrumentation/1602-structured-logging)
[Structured Logging migration instructions](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/migration-to-structured-logging.md)

**Does this PR introduce a user-facing change?:**:
```
Migrate some scheduler runtime log messages to structured logging
````
