### PR TITLE
Use autogenerated Job conversion functions

### DIFF
--- a/pkg/apis/batch/v1/conversion.go
+++ b/pkg/apis/batch/v1/conversion.go
@@ -19,12 +19,10 @@ package v1
 import (
 	"fmt"
 
-	batchv1 "k8s.io/api/batch/v1"
-
+	v1 "k8s.io/api/batch/v1"
 	"k8s.io/apimachinery/pkg/conversion"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/kubernetes/pkg/apis/batch"
-	k8s_api_v1 "k8s.io/kubernetes/pkg/apis/core/v1"
 )
 
 func addConversionFuncs(scheme *runtime.Scheme) error {
@@ -40,42 +38,13 @@ func addConversionFuncs(scheme *runtime.Scheme) error {
 	)
 }
 
-func Convert_batch_JobSpec_To_v1_JobSpec(in *batch.JobSpec, out *batchv1.JobSpec, s conversion.Scope) error {
-	out.Parallelism = in.Parallelism
-	out.Completions = in.Completions
-	out.ActiveDeadlineSeconds = in.ActiveDeadlineSeconds
-	out.BackoffLimit = in.BackoffLimit
-	out.TTLSecondsAfterFinished = in.TTLSecondsAfterFinished
-	out.Selector = in.Selector
-	if in.ManualSelector != nil {
-		out.ManualSelector = new(bool)
-		*out.ManualSelector = *in.ManualSelector
-	} else {
-		out.ManualSelector = nil
-	}
+// The following functions don't do anything special, but they need to be added
+// here due to the dependency of v1beta1 and v2alpha1 on v1.
 
-	if err := k8s_api_v1.Convert_core_PodTemplateSpec_To_v1_PodTemplateSpec(&in.Template, &out.Template, s); err != nil {
-		return err
-	}
-	return nil
+func Convert_batch_JobSpec_To_v1_JobSpec(in *batch.JobSpec, out *v1.JobSpec, s conversion.Scope) error {
+	return autoConvert_batch_JobSpec_To_v1_JobSpec(in, out, s)
 }
 
-func Convert_v1_JobSpec_To_batch_JobSpec(in *batchv1.JobSpec, out *batch.JobSpec, s conversion.Scope) error {
-	out.Parallelism = in.Parallelism
-	out.Completions = in.Completions
-	out.ActiveDeadlineSeconds = in.ActiveDeadlineSeconds
-	out.BackoffLimit = in.BackoffLimit
-	out.TTLSecondsAfterFinished = in.TTLSecondsAfterFinished
-	out.Selector = in.Selector
-	if in.ManualSelector != nil {
-		out.ManualSelector = new(bool)
-		*out.ManualSelector = *in.ManualSelector
-	} else {
-		out.ManualSelector = nil
-	}
-
-	if err := k8s_api_v1.Convert_v1_PodTemplateSpec_To_core_PodTemplateSpec(&in.Template, &out.Template, s); err != nil {
-		return err
-	}
-	return nil
+func Convert_v1_JobSpec_To_batch_JobSpec(in *v1.JobSpec, out *batch.JobSpec, s conversion.Scope) error {
+	return autoConvert_v1_JobSpec_To_batch_JobSpec(in, out, s)
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

The specialized functions don't have any logic that is not contained in the autogenerated ones.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

Due to the dependencies of v1beta1 and v2alpha1 on v1, the conversion function needs to be manually listed for the code-generation tools to work.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

/sig apps