### PR TITLE
Remove docker remote / docker-machine from build scripts

### DIFF
--- a/build/common.sh
+++ b/build/common.sh
@@ -30,8 +30,6 @@ GROUP_ID=$(id -g)
 DOCKER_OPTS=${DOCKER_OPTS:-""}
 IFS=" " read -r -a DOCKER <<< "docker ${DOCKER_OPTS}"
 DOCKER_HOST=${DOCKER_HOST:-""}
-DOCKER_MACHINE_NAME=${DOCKER_MACHINE_NAME:-"kube-dev"}
-readonly DOCKER_MACHINE_DRIVER=${DOCKER_MACHINE_DRIVER:-"virtualbox --virtualbox-cpu-count -1"}
 
 # This will canonicalize the path
 KUBE_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")"/.. && pwd -P)
@@ -177,59 +175,11 @@ function kube::build::docker_available_on_osx() {
       return 0
     fi
 
-    kube::log::status "No docker host is set. Checking options for setting one..."
-    if [[ -z "$(which docker-machine)" ]]; then
-      kube::log::status "It looks like you're running Mac OS X, yet neither Docker for Mac nor docker-machine can be found."
-      kube::log::status "See: https://docs.docker.com/engine/installation/mac/ for installation instructions."
-      return 1
-    elif [[ -n "$(which docker-machine)" ]]; then
-      kube::build::prepare_docker_machine
-    fi
+    kube::log::status "No docker host is set."
+    kube::log::status "It looks like you're running Mac OS X, but Docker for Mac cannot be found."
+    kube::log::status "See: https://docs.docker.com/engine/installation/mac/ for installation instructions."
+    return 1
   fi
-}
-
-function kube::build::prepare_docker_machine() {
-  kube::log::status "docker-machine was found."
-
-  local available_memory_bytes
-  available_memory_bytes=$(sysctl -n hw.memsize 2>/dev/null)
-
-  local bytes_in_mb=1048576
-
-  # Give virtualbox 1/2 the system memory. Its necessary to divide by 2, instead
-  # of multiple by .5, because bash can only multiply by ints.
-  local memory_divisor=2
-
-  local virtualbox_memory_mb=$(( available_memory_bytes / (bytes_in_mb * memory_divisor) ))
-
-  docker-machine inspect "${DOCKER_MACHINE_NAME}" &> /dev/null || {
-    kube::log::status "Creating a machine to build Kubernetes"
-    docker-machine create --driver "${DOCKER_MACHINE_DRIVER}" \
-      --virtualbox-memory "${virtualbox_memory_mb}" \
-      --engine-env HTTP_PROXY="${KUBERNETES_HTTP_PROXY:-}" \
-      --engine-env HTTPS_PROXY="${KUBERNETES_HTTPS_PROXY:-}" \
-      --engine-env NO_PROXY="${KUBERNETES_NO_PROXY:-127.0.0.1}" \
-      "${DOCKER_MACHINE_NAME}" > /dev/null || {
-      kube::log::error "Something went wrong creating a machine."
-      kube::log::error "Try the following: "
-      kube::log::error "docker-machine create -d ${DOCKER_MACHINE_DRIVER} --virtualbox-memory ${virtualbox_memory_mb} ${DOCKER_MACHINE_NAME}"
-      return 1
-    }
-  }
-  docker-machine start "${DOCKER_MACHINE_NAME}" &> /dev/null
-  # it takes `docker-machine env` a few seconds to work if the machine was just started
-  local docker_machine_out
-  while ! docker_machine_out=$(docker-machine env "${DOCKER_MACHINE_NAME}" 2>&1); do
-    if [[ ${docker_machine_out} =~ "Error checking TLS connection" ]]; then
-      echo "${docker_machine_out}"
-      docker-machine regenerate-certs "${DOCKER_MACHINE_NAME}"
-    else
-      sleep 1
-    fi
-  done
-  eval "$(docker-machine env "${DOCKER_MACHINE_NAME}")"
-  kube::log::status "A Docker host using docker-machine named '${DOCKER_MACHINE_NAME}' is ready to go!"
-  return 0
 }
 
 function kube::build::is_osx() {
@@ -254,18 +204,6 @@ function kube::build::update_dockerfile() {
     sed_opts=(-i '')
   fi
   sed "${sed_opts[@]}" "s/KUBE_BUILD_IMAGE_CROSS_TAG/${KUBE_BUILD_IMAGE_CROSS_TAG}/" "${LOCAL_OUTPUT_BUILD_CONTEXT}/Dockerfile"
-}
-
-function kube::build::set_proxy() {
-  if [[ -n "${KUBERNETES_HTTPS_PROXY:-}" ]]; then
-    echo "ENV https_proxy $KUBERNETES_HTTPS_PROXY" >> "${LOCAL_OUTPUT_BUILD_CONTEXT}/Dockerfile"
-  fi
-  if [[ -n "${KUBERNETES_HTTP_PROXY:-}" ]]; then
-    echo "ENV http_proxy $KUBERNETES_HTTP_PROXY" >> "${LOCAL_OUTPUT_BUILD_CONTEXT}/Dockerfile"
-  fi
-  if [[ -n "${KUBERNETES_NO_PROXY:-}" ]]; then
-    echo "ENV no_proxy $KUBERNETES_NO_PROXY" >> "${LOCAL_OUTPUT_BUILD_CONTEXT}/Dockerfile"
-  fi
 }
 
 function kube::build::ensure_docker_in_path() {
@@ -430,7 +368,6 @@ function kube::build::build_image() {
   chmod go= "${LOCAL_OUTPUT_BUILD_CONTEXT}/rsyncd.password"
 
   kube::build::update_dockerfile
-  kube::build::set_proxy
   kube::build::docker_build "${KUBE_BUILD_IMAGE}" "${LOCAL_OUTPUT_BUILD_CONTEXT}" 'false'
 
   # Clean up old versions of everything
@@ -660,7 +597,7 @@ function kube::build::start_rsyncd_container() {
     return 0
   fi
 
-  kube::log::error "Could not connect to rsync container. See build/README.md for setting up remote Docker engine."
+  kube::log::error "Could not connect to rsync container."
   return 1
 }
 

--- a/hack/lib/util.sh
+++ b/hack/lib/util.sh
@@ -617,11 +617,9 @@ Can't connect to 'docker' daemon.  please fix and retry.
 Possible causes:
   - Docker Daemon not started
     - Linux: confirm via your init system
-    - macOS w/ docker-machine: run `docker-machine ls` and `docker-machine start <name>`
     - macOS w/ Docker for Mac: Check the menu bar and start the Docker application
   - DOCKER_HOST hasn't been set or is set incorrectly
     - Linux: domain socket is used, DOCKER_* should be unset. In Bash run `unset ${!DOCKER_*}`
-    - macOS w/ docker-machine: run `eval "$(docker-machine env <name>)"`
     - macOS w/ Docker for Mac: domain socket is used, DOCKER_* should be unset. In Bash run `unset ${!DOCKER_*}`
   - Other things to check:
     - Linux: User isn't in 'docker' group.  Add and relogin.

--- a/hack/verify-vendor-licenses.sh
+++ b/hack/verify-vendor-licenses.sh
@@ -27,8 +27,6 @@ KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 source "${KUBE_ROOT}/hack/lib/init.sh"
 
 # create a nice clean place to put our new licenses
-# must be in the user dir (e.g. KUBE_ROOT) in order for the docker volume mount
-# to work with docker-machine on macs
 mkdir -p "${KUBE_ROOT}/_tmp"
 _tmpdir="$(mktemp -d "${KUBE_ROOT}/_tmp/kube-licenses.XXXXXX")"
 #echo "Created workspace: ${_tmpdir}"

--- a/hack/verify-vendor.sh
+++ b/hack/verify-vendor.sh
@@ -26,8 +26,6 @@ KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 source "${KUBE_ROOT}/hack/lib/init.sh"
 
 # create a nice clean place to put our new vendor tree
-# must be in the user dir (e.g. KUBE_ROOT) in order for the docker volume mount
-# to work with docker-machine on macs
 mkdir -p "${KUBE_ROOT}/_tmp"
 _tmpdir="$(mktemp -d "${KUBE_ROOT}/_tmp/kube-vendor.XXXXXX")"
 


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Remove docker-machine / remote docker support from build scripts.

Docker-machine is no longer accepting new features and in maintenance mode only. Team agreed to remove docker-machine / docker remote support in slack chat to simplify build scripts: https://kubernetes.slack.com/archives/C2C40FMNF/p1598059799085900

**Which issue(s) this PR fixes**:
Part of #94091.

A new contributor expressed interest in updating the doc only, so I skipped that part. Only build/README.md needs to be udpated.

**Special notes for your reviewer**:
I ran a regex search on the code base: "docker.machine|docker.remote|remote.docker", and inspected the build scripts to determine what needed to be removed.

I ran the following tests to make sure build scripts were not broken:
- Run `build/run.sh make` on Ubuntu 20.04. Completes successfully.
- Run `build/run.sh make` on MacOS Catalina. Completes successfully.
- Run `build/run.sh make` on MacOS Catalina without docker daemon, only docker client installed. Fails as expected and displays the following messages: 

```
+++ [1230 13:18:03] Verifying Prerequisites....
+++ [1230 13:18:03] No docker host is set.
+++ [1230 13:18:03] It looks like you're running Mac OS X, but Docker for Mac cannot be found.
+++ [1230 13:18:03] See: https://docs.docker.com/engine/installation/mac/ for installation instructions.
```

**Does this PR introduce a user-facing change?**:

-->
```release-note
Official support to build kubernetes with docker-machine / remote docker is removed. This change does not affect building kubernetes with docker locally.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
