### PR TITLE
conformance: promote container exec probe timeout tests

### DIFF
--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -335,6 +335,14 @@
     restart count to 1.
   release: v1.9
   file: test/e2e/common/container_probe.go
+- testname: Pod liveness probe, container exec timeout, restart
+  codename: '[k8s.io] Probing container should be restarted with an exec liveness
+    probe with timeout [NodeConformance] [Conformance]'
+  description: A Pod is created with liveness probe with a Exec action on the Pod.
+    If the liveness probe call does not return within the timeout specified, liveness
+    probe MUST restart the Pod.
+  release: v1.9
+  file: test/e2e/common/container_probe.go
 - testname: Pod liveness probe, using http endpoint, multiple restarts (slow)
   codename: '[k8s.io] Probing container should have monotonically increasing restart
     count [NodeConformance] [Conformance]'
@@ -346,6 +354,14 @@
     returns an http error after 10 seconds from the start. Restart counts MUST increment
     everytime health check fails, measure upto 5 restart.
   release: v1.9
+  file: test/e2e/common/container_probe.go
+- testname: Pod readiness probe, container exec timeout, not ready
+  codename: '[k8s.io] Probing container should not be ready with an exec readiness
+    probe timeout [NodeConformance] [Conformance]'
+  description: A Pod is created with readiness probe with a Exec action on the Pod.
+    If the readiness probe call does not return within the timeout specified, readiness
+    probe MUST not be Ready.
+  release: v1.20
   file: test/e2e/common/container_probe.go
 - testname: Pod readiness probe, with initial delay
   codename: '[k8s.io] Probing container with readiness probe should not be ready before

--- a/test/e2e/common/container_probe.go
+++ b/test/e2e/common/container_probe.go
@@ -210,10 +210,10 @@ var _ = framework.KubeDescribe("Probing container", func() {
 
 	/*
 		Release: v1.9
-		Testname: Pod liveness probe, docker exec, restart
-		Description: A Pod is created with liveness probe with a Exec action on the Pod. If the liveness probe call  does not return within the timeout specified, liveness probe MUST restart the Pod.
+		Testname: Pod liveness probe, container exec timeout, restart
+		Description: A Pod is created with liveness probe with a Exec action on the Pod. If the liveness probe call does not return within the timeout specified, liveness probe MUST restart the Pod.
 	*/
-	ginkgo.It("should be restarted with an exec liveness probe with timeout [NodeConformance]", func() {
+	framework.ConformanceIt("should be restarted with an exec liveness probe with timeout [NodeConformance]", func() {
 		cmd := []string{"/bin/sh", "-c", "sleep 600"}
 		livenessProbe := &v1.Probe{
 			Handler:             execHandler([]string{"/bin/sh", "-c", "sleep 10"}),
@@ -227,10 +227,10 @@ var _ = framework.KubeDescribe("Probing container", func() {
 
 	/*
 		Release: v1.20
-		Testname: Pod readiness probe, docker exec, not ready
+		Testname: Pod readiness probe, container exec timeout, not ready
 		Description: A Pod is created with readiness probe with a Exec action on the Pod. If the readiness probe call does not return within the timeout specified, readiness probe MUST not be Ready.
 	*/
-	ginkgo.It("should not be ready with an exec readiness probe timeout [NodeConformance]", func() {
+	framework.ConformanceIt("should not be ready with an exec readiness probe timeout [NodeConformance]", func() {
 		cmd := []string{"/bin/sh", "-c", "sleep 600"}
 		readinessProbe := &v1.Probe{
 			Handler:             execHandler([]string{"/bin/sh", "-c", "sleep 10"}),


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
In v1.20 we fixed exec probe timeouts (https://github.com/kubernetes/kubernetes/pull/94115). Along with that PR, we also un-skipped a test exercising this behavior with liveness probes and added a new test for readiness probes. In past discussions in SIG Node, there was general agreement that exec probe timeout tests should probably be included in conformance. https://github.com/kubernetes/kubernetes/pull/96694 added those tests to `NodeConformance`, this PR adds them to actual conformance.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
