### PR TITLE
Fix Spelling error about [formatted] for statefulset.go

### DIFF
--- a/test/e2e/apps/statefulset.go
+++ b/test/e2e/apps/statefulset.go
@@ -1317,7 +1317,7 @@ func deleteStatefulPodAtIndex(c clientset.Interface, index int, ss *appsv1.State
 	}
 }
 
-// getStatefulSetPodNameAtIndex gets formated pod name given index.
+// getStatefulSetPodNameAtIndex gets formatted pod name given index.
 func getStatefulSetPodNameAtIndex(index int, ss *appsv1.StatefulSet) string {
 	// TODO: we won't use "-index" as the name strategy forever,
 	// pull the name out from an identity mapper.


### PR DESCRIPTION
What type of PR is this?
/kind cleanup

What this PR does / why we need it:
Fix Spelling error about [formatted] for statefulset.go

Which issue(s) this PR fixes:

Fixes #

Special notes for your reviewer:

Does this PR introduce a user-facing change?:

```release-note
NONE
```
Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.: