### PR TITLE
Fix Spelling error about [avaliable] in index_test.go

### DIFF
--- a/pkg/controller/volume/persistentvolume/index_test.go
+++ b/pkg/controller/volume/persistentvolume/index_test.go
@@ -1504,7 +1504,7 @@ func TestFindMatchVolumeWithNode(t *testing.T) {
 			}),
 			node: node3,
 		},
-		"fail-nonavaiable": {
+		"fail-nonavaliable": {
 			expectedMatch: "",
 			claim: makePVC("100G", func(pvc *v1.PersistentVolumeClaim) {
 				pvc.Spec.AccessModes = []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce}

--- a/pkg/controller/volume/persistentvolume/index_test.go
+++ b/pkg/controller/volume/persistentvolume/index_test.go
@@ -1504,7 +1504,7 @@ func TestFindMatchVolumeWithNode(t *testing.T) {
 			}),
 			node: node3,
 		},
-		"fail-nonavaliable": {
+		"fail-nonavailable": {
 			expectedMatch: "",
 			claim: makePVC("100G", func(pvc *v1.PersistentVolumeClaim) {
 				pvc.Spec.AccessModes = []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce}


### PR DESCRIPTION
What type of PR is this?
/kind cleanup

What this PR does / why we need it:
Fix Spelling error about [avaliable] for index_test.go

Which issue(s) this PR fixes:

Fixes #

Special notes for your reviewer:

Does this PR introduce a user-facing change?:

```release-note
NONE
```
Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.: