### PR TITLE
Moving egress deny with DNS to a policy function

### DIFF
--- a/test/e2e/network/netpol/network_policy.go
+++ b/test/e2e/network/netpol/network_policy.go
@@ -18,7 +18,6 @@ package netpol
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"time"
 
@@ -159,39 +158,9 @@ var _ = SIGDescribeCopy("Netpol [LinuxOnly]", func() {
 		})
 
 		ginkgo.It("should support a 'default-deny-all' policy [Feature:NetworkPolicy]", func() {
-			np := &networkingv1.NetworkPolicy{}
-			policy := `
-			{
-				"kind": "NetworkPolicy",
-				"apiVersion": "networking.k8s.io/v1",
-				"metadata": {
-				   "name": "deny-all-tcp-allow-dns"
-				},
-				"spec": {
-				   "podSelector": {
-					  "matchLabels": {}
-				   },
-				   "ingress": [],
-				   "egress": [{
-						"ports": [
-							{
-								"protocol": "UDP",
-								"port": 53
-							}
-						]
-					}],
-				   "policyTypes": [
-					"Ingress",
-					"Egress"
-				   ]
-				}
-			 }
-			 `
-			err := json.Unmarshal([]byte(policy), np)
-			framework.ExpectNoError(err, "unmarshal network policy")
-
+			policy := GetDenyAllWithEgressDNS()
 			nsX, _, _, model, k8s := getK8SModel(f)
-			CreatePolicy(k8s, np, nsX)
+			CreatePolicy(k8s, policy, nsX)
 
 			reachability := NewReachability(model.AllPods(), true)
 			reachability.ExpectPeer(&Peer{}, &Peer{Namespace: nsX}, false)

--- a/test/e2e/network/netpol/policies.go
+++ b/test/e2e/network/netpol/policies.go
@@ -142,6 +142,31 @@ func GetDenyAll(name string) *networkingv1.NetworkPolicy {
 	return policy
 }
 
+// GetDenyAllWithEgressDNS deny all egress traffic, besides DNS/UDP port
+func GetDenyAllWithEgressDNS() *networkingv1.NetworkPolicy {
+	protocolUDP := v1.ProtocolUDP
+	return &networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "deny-all-tcp-allow-dns",
+		},
+		Spec: networkingv1.NetworkPolicySpec{
+			PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeEgress, networkingv1.PolicyTypeIngress},
+			PodSelector: metav1.LabelSelector{},
+			Ingress:     []networkingv1.NetworkPolicyIngressRule{},
+			Egress: []networkingv1.NetworkPolicyEgressRule{
+				{
+					Ports: []networkingv1.NetworkPolicyPort{
+						{
+							Protocol: &protocolUDP,
+							Port:     &intstr.IntOrString{Type: intstr.Int, IntVal: 53},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
 // GetAllowIngressByPod allows ingress by pod labels
 func GetAllowIngressByPod(name string, targetLabels map[string]string, peerPodSelector *metav1.LabelSelector) *networkingv1.NetworkPolicy {
 	policy := &networkingv1.NetworkPolicy{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind feature
/sig network
/area test

**What this PR does / why we need it**:

Chore moving the JSON netpol specification to a function keeping the other tests standards 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
