### PR TITLE
Fix golint errors for pkg/cmd/annotate

### DIFF
--- a/hack/.golint_failures
+++ b/hack/.golint_failures
@@ -414,7 +414,6 @@ staging/src/k8s.io/kube-aggregator/pkg/apis/apiregistration/v1
 staging/src/k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1
 staging/src/k8s.io/kube-aggregator/pkg/apiserver
 staging/src/k8s.io/kube-aggregator/pkg/controllers/autoregister
-staging/src/k8s.io/kubectl/pkg/cmd/annotate
 staging/src/k8s.io/kubectl/pkg/cmd/apply
 staging/src/k8s.io/kubectl/pkg/cmd/attach
 staging/src/k8s.io/kubectl/pkg/cmd/autoscale

--- a/staging/src/k8s.io/kubectl/pkg/cmd/annotate/annotate.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/annotate/annotate.go
@@ -42,8 +42,8 @@ import (
 	"k8s.io/kubectl/pkg/util/templates"
 )
 
-// AnnotateOptions have the data required to perform the annotate operation
-type AnnotateOptions struct {
+// Options have the data required to perform the annotate operation
+type Options struct {
 	PrintFlags *genericclioptions.PrintFlags
 	PrintObj   printers.ResourcePrinterFunc
 
@@ -113,8 +113,8 @@ var (
 )
 
 // NewAnnotateOptions creates the options for annotate
-func NewAnnotateOptions(ioStreams genericclioptions.IOStreams) *AnnotateOptions {
-	return &AnnotateOptions{
+func NewAnnotateOptions(ioStreams genericclioptions.IOStreams) *Options {
+	return &Options{
 		PrintFlags: genericclioptions.NewPrintFlags("annotated").WithTypeSetter(scheme.Scheme),
 
 		RecordFlags: genericclioptions.NewRecordFlags(),
@@ -160,7 +160,7 @@ func NewCmdAnnotate(parent string, f cmdutil.Factory, ioStreams genericclioption
 }
 
 // Complete adapts from the command line args and factory to the data required.
-func (o *AnnotateOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []string) error {
+func (o *Options) Complete(f cmdutil.Factory, cmd *cobra.Command, args []string) error {
 	var err error
 
 	o.RecordFlags.Complete(cmd)
@@ -219,8 +219,8 @@ func (o *AnnotateOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args [
 	return nil
 }
 
-// Validate checks to the AnnotateOptions to see if there is sufficient information run the command.
-func (o AnnotateOptions) Validate() error {
+// Validate checks to the Options to see if there is sufficient information run the command.
+func (o Options) Validate() error {
 	if o.all && len(o.selector) > 0 {
 		return fmt.Errorf("cannot set --all and --selector at the same time")
 	}
@@ -249,7 +249,7 @@ func (o AnnotateOptions) Validate() error {
 }
 
 // RunAnnotate does the work
-func (o AnnotateOptions) RunAnnotate() error {
+func (o Options) RunAnnotate() error {
 	b := o.builder.
 		Unstructured().
 		LocalParam(o.local).
@@ -422,7 +422,7 @@ func validateNoAnnotationOverwrites(accessor metav1.Object, annotations map[stri
 }
 
 // updateAnnotations updates annotations of obj
-func (o AnnotateOptions) updateAnnotations(obj runtime.Object) error {
+func (o Options) updateAnnotations(obj runtime.Object) error {
 	accessor, err := meta.Accessor(obj)
 	if err != nil {
 		return err

--- a/staging/src/k8s.io/kubectl/pkg/cmd/annotate/annotate_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/annotate/annotate_test.go
@@ -358,7 +358,7 @@ func TestUpdateAnnotations(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		options := &AnnotateOptions{
+		options := &Options{
 			overwrite:         test.overwrite,
 			newAnnotations:    test.annotations,
 			removeAnnotations: test.remove,


### PR DESCRIPTION


**What type of PR is this?**
/kind cleanup


**What this PR does / why we need it**:
This PR fixed golint issues in `pkg/cmd/annotate`

**Which issue(s) this PR fixes**:
Part of #68026



**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
