### PR TITLE
Fix tests using kubectl convert

### DIFF
--- a/test/cmd/create.sh
+++ b/test/cmd/create.sh
@@ -85,7 +85,7 @@ run_kubectl_create_error_tests() {
   rm "${ERROR_FILE}"
 
   # Posting a pod to namespaces should fail.  Also tests --raw forcing the post location
-  grep -q "cannot be handled as a Namespace: converting (v1.Pod)" <<< "$( kubectl convert -f test/fixtures/doc-yaml/admin/limitrange/valid-pod.yaml -o json | kubectl create "${kube_flags[@]}" --raw /api/v1/namespaces -f - --v=8 2>&1 )"
+  grep -q 'the object provided is unrecognized (must be of type Namespace)' <<< "$( kubectl create "${kube_flags[@]}" --raw /api/v1/namespaces -f test/fixtures/doc-yaml/admin/limitrange/valid-pod.yaml --v=8 2>&1 )"
 
   grep -q "raw and --edit are mutually exclusive" <<< "$( kubectl create "${kube_flags[@]}" --raw /api/v1/namespaces -f test/fixtures/doc-yaml/admin/limitrange/valid-pod.yaml --edit 2>&1 )"
 

--- a/test/cmd/generic-resources.sh
+++ b/test/cmd/generic-resources.sh
@@ -259,32 +259,6 @@ run_recursive_resources_tests() {
   kube::test::get_object_assert pods "{{range.items}}{{${labels_field}.status}}:{{end}}" 'replaced:replaced:'
   kube::test::if_has_string "${output_message}" 'error validating data: kind not set'
 
-
-  ### Convert deployment YAML file locally without affecting the live deployment.
-  # Pre-condition: no deployments exist
-  kube::test::get_object_assert deployment "{{range.items}}{{$id_field}}:{{end}}" ''
-  # Command
-  # Create a deployment (revision 1)
-  kubectl create -f hack/testdata/deployment-revision1.yaml "${kube_flags[@]}"
-  kube::test::get_object_assert deployment "{{range.items}}{{$id_field}}:{{end}}" 'nginx:'
-  kube::test::get_object_assert deployment "{{range.items}}{{${image_field0:?}}}:{{end}}" "${IMAGE_DEPLOYMENT_R1}:"
-  # Command
-  output_message=$(kubectl convert --local -f hack/testdata/deployment-revision1.yaml --output-version=extensions/v1beta1 -o yaml "${kube_flags[@]}")
-  # Post-condition: apiVersion is still apps/v1 in the live deployment, but command output is the new value
-  kube::test::get_object_assert 'deployment nginx' "{{ .apiVersion }}" 'apps/v1'
-  kube::test::if_has_string "${output_message}" "extensions/v1beta1"
-  # Clean up
-  kubectl delete deployment nginx "${kube_flags[@]}"
-
-  ## Convert multiple busybox PODs recursively from directory of YAML files
-  # Pre-condition: only busybox0 & busybox1 PODs exist
-  kube::test::wait_object_assert pods "{{range.items}}{{$id_field}}:{{end}}" 'busybox0:busybox1:'
-  # Command
-  output_message=$(! kubectl convert -f hack/testdata/recursive/pod --recursive 2>&1 "${kube_flags[@]}")
-  # Post-condition: busybox0 & busybox1 PODs are converted, and since busybox2 is malformed, it should error
-  kube::test::get_object_assert pods "{{range.items}}{{$id_field}}:{{end}}" 'busybox0:busybox1:'
-  kube::test::if_has_string "${output_message}" "Object 'Kind' is missing"
-
   ## Get multiple busybox PODs recursively from directory of YAML files
   # Pre-condition: busybox0 & busybox1 PODs exist
   kube::test::get_object_assert pods "{{range.items}}{{$id_field}}:{{end}}" 'busybox0:busybox1:'
@@ -389,11 +363,11 @@ run_recursive_resources_tests() {
   # Create deployments (revision 1) recursively from directory of YAML files
   ! kubectl create -f hack/testdata/recursive/deployment --recursive "${kube_flags[@]}" || exit 1
   kube::test::get_object_assert deployment "{{range.items}}{{$id_field}}:{{end}}" 'nginx0-deployment:nginx1-deployment:'
-  kube::test::get_object_assert deployment "{{range.items}}{{$image_field0}}:{{end}}" "${IMAGE_NGINX}:${IMAGE_NGINX}:"
+  kube::test::get_object_assert deployment "{{range.items}}{{${image_field0:?}}}:{{end}}" "${IMAGE_NGINX}:${IMAGE_NGINX}:"
   ## Rollback the deployments to revision 1 recursively
   output_message=$(! kubectl rollout undo -f hack/testdata/recursive/deployment --recursive --to-revision=1 2>&1 "${kube_flags[@]}")
   # Post-condition: nginx0 & nginx1 should be a no-op, and since nginx2 is malformed, it should error
-  kube::test::get_object_assert deployment "{{range.items}}{{$image_field0}}:{{end}}" "${IMAGE_NGINX}:${IMAGE_NGINX}:"
+  kube::test::get_object_assert deployment "{{range.items}}{{${image_field0:?}}}:{{end}}" "${IMAGE_NGINX}:${IMAGE_NGINX}:"
   kube::test::if_has_string "${output_message}" "Object 'Kind' is missing"
   ## Pause the deployments recursively
   # shellcheck disable=SC2034  # PRESERVE_ERR_FILE is used in kubectl-with-retry

--- a/test/cmd/template-output.sh
+++ b/test/cmd/template-output.sh
@@ -62,10 +62,6 @@ run_template_output_tests() {
   output_message=$(kubectl "${kube_flags[@]:?}" expose -f hack/testdata/redis-slave-replicaset.yaml --save-config --port=80 --target-port=8000 --dry-run=client --template="{{ .metadata.name }}:")
   kube::test::if_has_string "${output_message}" 'redis-slave:'
 
-  # check that convert command supports --template output
-  output_message=$(kubectl convert "${kube_flags[@]:?}" -f hack/testdata/deployment-revision1.yaml --output-version=apps/v1beta1 --template="{{ .metadata.name }}:")
-  kube::test::if_has_string "${output_message}" 'nginx:'
-
   # check that run command supports --template output
   output_message=$(kubectl "${kube_flags[@]:?}" run --dry-run=client --template="{{ .metadata.name }}:" pi --image=perl --restart=OnFailure -- perl -Mbignum=bpi -wle 'print bpi(2000)')
   kube::test::if_has_string "${output_message}" 'pi:'


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
```hack/make-rules/test-cmd.sh``` script fails with tariling errors.

```
Error: unknown command "convert" for "kubectl"
```

1. This PR fixes the errors by replacing or removing the use of ```kubectl convert``` option because it was already removed.

2. Fix trailing shell check failure as well.

```
In ./test/cmd/generic-resources.sh line 366:
  kube::test::get_object_assert deployment "{{range.items}}{{$image_field0}}:{{end}}" "${IMAGE_NGINX}:${IMAGE_NGINX}:"
                                                             ^-----------^ SC2154: image_field0 is referenced but not assigned.
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs

```
