### PR TITLE
remove unused constant of kubeletPort in e2e test

### DIFF
--- a/test/e2e_node/services/kubelet.go
+++ b/test/e2e_node/services/kubelet.go
@@ -87,7 +87,6 @@ func RunKubelet() {
 
 const (
 	// Ports of different e2e services.
-	kubeletPort         = "10250"
 	kubeletReadOnlyPort = "10255"
 	// KubeletRootDirectory specifies the directory where the kubelet runtime information is stored.
 	KubeletRootDirectory = "/var/lib/kubelet"


### PR DESCRIPTION
What type of PR is this?
/kind cleanup

What this PR does / why we need it:
remove unused constant of kubeletPort in e2e test

Which issue(s) this PR fixes:

Fixes #

Special notes for your reviewer:

Does this PR introduce a user-facing change?:

```release-note
NONE
```
Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.: