### PR TITLE
don't delete pod from desiredStateOfWorld when pod's sandbox is running

### DIFF
--- a/pkg/kubelet/volumemanager/populator/desired_state_of_world_populator.go
+++ b/pkg/kubelet/volumemanager/populator/desired_state_of_world_populator.go
@@ -269,7 +269,11 @@ func (dswp *desiredStateOfWorldPopulator) findAndRemoveDeletedPods() {
 		runningContainers := false
 		for _, runningPod := range runningPods {
 			if runningPod.ID == volumeToMount.Pod.UID {
-				if len(runningPod.Containers) > 0 {
+				// runningPod.Containers only include containers in the running state,
+				// excluding containers in the creating process.
+				// By adding a non-empty judgment for runningPod.Sandboxes,
+				// ensure that all containers of the pod have been terminated.
+				if len(runningPod.Sandboxes) > 0 || len(runningPod.Containers) > 0 {
 					runningContainers = true
 				}
 


### PR DESCRIPTION
What type of PR is this?
/kind bug

What this PR does / why we need it:
don't delete pod from desiredStateOfWorld when pod's sandbox is running, 
Volume is a pod-level resource. When a HostPath volume is shared by multiple containers, the deletion of the Pod may be failed because the subpath is not empty.

Which issue(s) this PR fixes:
https://github.com/kubernetes/kubernetes/issues/97634

Special notes for your reviewer:

Does this PR introduce a user-facing change?:
NONE

Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.: