### PR TITLE
remove unused constant of FrameworkName

### DIFF
--- a/test/images/resource-consumer/common/common.go
+++ b/test/images/resource-consumer/common/common.go
@@ -37,6 +37,4 @@ const (
 	UnknownFunction           = "unknown function"
 	IncorrectFunctionArgument = "incorrect function argument"
 	NotGivenFunctionArgument  = "not given function argument"
-
-	FrameworkName = "horizontal-pod-autoscaling"
 )


### PR DESCRIPTION

What type of PR is this?
/kind cleanup

What this PR does / why we need it:
remove unused constant of FrameworkName

Which issue(s) this PR fixes:

Fixes #

Special notes for your reviewer:

Does this PR introduce a user-facing change?:

```release-note
NONE
```
Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
