### PR TITLE
remove unused function of NewSingleContentTypeSerializer

### DIFF
--- a/test/integration/framework/serializer.go
+++ b/test/integration/framework/serializer.go
@@ -21,14 +21,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/serializer/versioning"
 )
 
-// NewSingleContentTypeSerializer wraps a serializer in a NegotiatedSerializer that handles one content type
-func NewSingleContentTypeSerializer(scheme *runtime.Scheme, info runtime.SerializerInfo) runtime.StorageSerializer {
-	return &wrappedSerializer{
-		scheme: scheme,
-		info:   info,
-	}
-}
-
 type wrappedSerializer struct {
 	scheme *runtime.Scheme
 	info   runtime.SerializerInfo


### PR DESCRIPTION
What type of PR is this?
/kind cleanup

What this PR does / why we need it:
remove unused function of NewSingleContentTypeSerializer

Which issue(s) this PR fixes:

Fixes #

Special notes for your reviewer:

Does this PR introduce a user-facing change?:

```release-note
NONE
```
Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
