### PR TITLE
Remove duplicate nodeSelector for kube-dns in kube-dns.yaml.base

### DIFF
--- a/cluster/addons/dns/kube-dns/kube-dns.yaml.base
+++ b/cluster/addons/dns/kube-dns/kube-dns.yaml.base
@@ -105,8 +105,6 @@ spec:
       tolerations:
       - key: "CriticalAddonsOnly"
         operator: "Exists"
-      nodeSelector:
-        kubernetes.io/os: linux
       volumes:
       - name: kube-dns-config
         configMap:


### PR DESCRIPTION
What type of PR is this?
/kind cleanup

What this PR does / why we need it:
Remove duplicate nodeSelector for kube-dns in kube-dns.yaml.base

Which issue(s) this PR fixes:

Fixes #

Special notes for your reviewer:

Does this PR introduce a user-facing change?:

```release-note
NONE
```
Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
