### PR TITLE
Fix --ignore-errors does not take effect if multiple logs are printed and unfollowed

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/logs/logs.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/logs/logs.go
@@ -371,7 +371,11 @@ func (o LogsOptions) sequentialConsumeRequest(requests map[corev1.ObjectReferenc
 	for objRef, request := range requests {
 		out := o.addPrefixIfNeeded(objRef, o.Out)
 		if err := o.ConsumeRequestFn(request, out); err != nil {
-			return err
+			if !o.IgnoreLogErrors {
+				return err
+			}
+
+			fmt.Fprintf(o.Out, "error: %v\n", err)
 		}
 	}
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #97530

**Special notes for your reviewer**:


**Does this PR introduce a user-facing change?**:

Does this PR before, exit if there are any errors
```
> kubectl logs --previous deploy/random-crash --all-containers --ignore-errors
error: previous terminated container "bash" in pod "random-crash-67858b7cdc-kwc6z" not found
```

Does this PR after, be consistent with parallelConsumeRequest behavior
```
> kubectl logs --previous deploy/random-crash --all-containers --ignore-errors
error: previous terminated container "bash" in pod "random-crash-67858b7cdc-kwc6z" not found
error: previous terminated container "error-container" in pod "random-crash-67858b7cdc-kwc6z" not found
```

```release-note
kubectl logs: Fix --ignore-errors does not take effect if multiple logs are printed and unfollowed
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
