### PR TITLE
[WIP] debug netpol job flakiness

### DIFF
--- a/pkg/controller/endpointslice/utils.go
+++ b/pkg/controller/endpointslice/utils.go
@@ -410,7 +410,7 @@ func getAddressTypesForService(service *corev1.Service) map[discovery.AddressTyp
 			addrType = discovery.AddressTypeIPv6
 		}
 		serviceSupportedAddresses[addrType] = struct{}{}
-		klog.V(2).Infof("couldn't find ipfamilies for headless service: %v/%v. This could happen if controller manager is connected to an old apiserver that does not support ip families yet. EndpointSlices for this Service will use %s as the IP Family based on familyOf(ClusterIP:%v).", service.Namespace, service.Name, addrType, service.Spec.ClusterIP)
+		klog.V(2).Infof("couldn't find ipfamilies for service without endpoints: %v/%v. This could happen if controller manager is connected to an old apiserver that does not support ip families yet. EndpointSlices for this Service will use %s as the IP Family based on familyOf(ClusterIP:%v).", service.Namespace, service.Name, addrType, service.Spec.ClusterIP)
 		return serviceSupportedAddresses
 	}
 

--- a/test/e2e/network/netpol/network_policy.go
+++ b/test/e2e/network/netpol/network_policy.go
@@ -113,7 +113,7 @@ func SIGDescribeCopy(text string, body func()) bool {
 	return ginkgo.Describe("[sig-network] "+text, body)
 }
 
-var _ = SIGDescribeCopy("Netpol [LinuxOnly]", func() {
+var _ = SIGDescribeCopy("Netpol [Disruptive][LinuxOnly]", func() {
 	f := framework.NewDefaultFramework("netpol")
 
 	ginkgo.Context("NetworkPolicy between server and client", func() {

--- a/test/e2e/network/netpol/probe.go
+++ b/test/e2e/network/netpol/probe.go
@@ -43,7 +43,7 @@ type ProbeJobResults struct {
 // ProbePodToPodConnectivity runs a series of probes in kube, and records the results in `testCase.Reachability`
 func ProbePodToPodConnectivity(k8s *Scenario, model *Model, testCase *TestCase) {
 	k8s.ClearCache()
-	numberOfWorkers := 30
+	numberOfWorkers := 10
 	allPods := model.AllPods()
 	size := len(allPods) * len(allPods)
 	jobs := make(chan *ProbeJob, size)

--- a/test/e2e/network/network_policy.go
+++ b/test/e2e/network/network_policy.go
@@ -60,7 +60,7 @@ type protocolPort struct {
 
 var protocolSCTP = v1.ProtocolSCTP
 
-var _ = SIGDescribe("NetworkPolicy [LinuxOnly]", func() {
+var _ = SIGDescribe("NetworkPolicy [Disruptive][LinuxOnly]", func() {
 	var service *v1.Service
 	var podServer *v1.Pod
 	var podServerLabelSelector string


### PR DESCRIPTION
/kind flake

**What this PR does / why we need it**:

The job is flaky, random test fail, usually showing symptons that can be related to endpoints or pods not coming up on time ... that is a theory though :/



xref: 
https://github.com/kubernetes/test-infra/pull/20367

```release-note
NONE
```
