### PR TITLE
oidc authenticator: attempt to immediately initialize verifier

### DIFF
--- a/staging/src/k8s.io/apiserver/plugin/pkg/authenticator/token/oidc/oidc.go
+++ b/staging/src/k8s.io/apiserver/plugin/pkg/authenticator/token/oidc/oidc.go
@@ -218,7 +218,7 @@ func New(opts Options) (*Authenticator, error) {
 	return newAuthenticator(opts, func(ctx context.Context, a *Authenticator, config *oidc.Config) {
 		// Asynchronously attempt to initialize the authenticator. This enables
 		// self-hosted providers, providers that run on top of Kubernetes itself.
-		go wait.PollUntil(time.Second*10, func() (done bool, err error) {
+		go wait.PollImmediateUntil(time.Second*10, func() (done bool, err error) {
 			provider, err := oidc.NewProvider(ctx, a.issuerURL)
 			if err != nil {
 				klog.Errorf("oidc authenticator: initializing plugin: %v", err)


### PR DESCRIPTION
This change updates the OIDC authenticator to not wait 10 seconds before attempting to fetch the `/.well-known/openid-configuration`
metadata from the OIDC issuer.  In most situations this results in the API server being able to verify ID tokens sooner.

Signed-off-by: Monis Khan <mok@vmware.com>

/kind cleanup

```release-note
kube-apiserver: The OIDC authenticator no longer waits 10 seconds before attempting to fetch the metadata required to verify tokens.
```