### PR TITLE
OWNERS: Update SIG Release aliases

### DIFF
--- a/CHANGELOG/OWNERS
+++ b/CHANGELOG/OWNERS
@@ -1,7 +1,6 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-  - sig-release-approvers
   - release-engineering-approvers
 reviewers:
   - release-engineering-reviewers

--- a/CHANGELOG/OWNERS
+++ b/CHANGELOG/OWNERS
@@ -1,9 +1,9 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-  - release-engineering-approvers
+  - changelog-approvers
 reviewers:
-  - release-engineering-reviewers
+  - changelog-reviewers
 
 labels:
   - sig/release

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -165,6 +165,12 @@ aliases:
     - xmudrii # Release Manager
   changelog-reviewers:
     - wilsonehusin # 1.21 Release Notes Lead
+    # TODO(wilsonehusin): uncomment once ashnehete is an org member
+    #                     https://github.com/kubernetes/kubernetes/pull/97700#issuecomment-766734702
+    #- ashnehete # 1.21 Release Notes shadow
+    - melodychn # 1.21 Release Notes shadow
+    - pmmalinov01 # 1.21 Release Notes shadow
+    - soniasingla # 1.21 Release Notes shadow
 
   sig-storage-approvers:
     - saad-ali

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -155,6 +155,14 @@ aliases:
     - xmudrii # Release Manager
   changelog-approvers:
     - wilsonehusin # 1.21 Release Notes Lead
+    - cpanato # Release Manager
+    - feiskyer # Release Manager
+    - hasheddan # Release Manager / SIG Technical Lead
+    - idealhack # Release Manager
+    - justaugustus # Release Manager / SIG Chair
+    - puerco # Release Manager
+    - saschagrunert # Release Manager / SIG Chair
+    - xmudrii # Release Manager
   changelog-reviewers:
     - wilsonehusin # 1.21 Release Notes Lead
 

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -117,18 +117,22 @@ aliases:
 
   # SIG Release
   release-engineering-approvers:
-    - alejandrox1 # SIG Technical Lead
-    - justaugustus # SIG Chair
-    - saschagrunert # SIG Technical Lead
-    - tpepper # SIG Chair
+    - cpanato # Release Manager
+    - feiskyer # Release Manager
+    - hasheddan # Release Manager / SIG Technical Lead
+    - idealhack # Release Manager
+    - justaugustus # Release Manager / SIG Chair
+    - puerco # Release Manager
+    - saschagrunert # Release Manager / SIG Chair
+    - xmudrii # Release Manager
   release-engineering-reviewers:
     - cpanato # Release Manager
     - feiskyer # Release Manager
-    - hasheddan # Release Manager
-    - hoegaarden # Release Manager
-    - justaugustus # SIG Chair / Release Manager
-    - saschagrunert # SIG Technical Lead / Release Manager
-    - tpepper # SIG Chair / Release Manager
+    - hasheddan # Release Manager / SIG Technical Lead
+    - idealhack # Release Manager
+    - justaugustus # Release Manager / SIG Chair
+    - puerco # Release Manager
+    - saschagrunert # Release Manager / SIG Chair
     - xmudrii # Release Manager
   build-image-approvers:
     - BenTheElder

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -138,14 +138,21 @@ aliases:
     - BenTheElder
     - cblecker
     - dims
-    - justaugustus
+    - justaugustus # Release Manager / SIG Chair
     - listx
   build-image-reviewers:
     - BenTheElder
     - cblecker
+    - cpanato # Release Manager
     - dims
-    - justaugustus
+    - feiskyer # Release Manager
+    - hasheddan # Release Manager / SIG Technical Lead
+    - idealhack # Release Manager
+    - justaugustus # Release Manager / SIG Chair
     - listx
+    - puerco # Release Manager
+    - saschagrunert # Release Manager / SIG Chair
+    - xmudrii # Release Manager
 
   sig-storage-approvers:
     - saad-ali

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -116,11 +116,6 @@ aliases:
     - WanLinghao
 
   # SIG Release
-  sig-release-approvers:
-    - alejandrox1 # SIG Technical Lead
-    - justaugustus # SIG Chair
-    - saschagrunert # SIG Technical Lead
-    - tpepper # SIG Chair
   release-engineering-approvers:
     - alejandrox1 # SIG Technical Lead
     - justaugustus # SIG Chair

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -154,7 +154,9 @@ aliases:
     - saschagrunert # Release Manager / SIG Chair
     - xmudrii # Release Manager
   changelog-approvers:
+    - wilsonehusin # 1.21 Release Notes Lead
   changelog-reviewers:
+    - wilsonehusin # 1.21 Release Notes Lead
 
   sig-storage-approvers:
     - saad-ali

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -153,6 +153,8 @@ aliases:
     - puerco # Release Manager
     - saschagrunert # Release Manager / SIG Chair
     - xmudrii # Release Manager
+  changelog-approvers:
+  changelog-reviewers:
 
   sig-storage-approvers:
     - saad-ali


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

(Edits from @justaugustus...)

Updates SIG Release OWNERS aliases to:

- Remove SIG Release approvers alias
  We're currently only using this for changelog approvals and those should
  really be handled by relnotes + RelEng.
- Syncs release-engineering-* with full Release Managers (https://github.com/kubernetes/sig-release/blob/master/release-managers.md#release-managers)
- Add Release Managers as build image reviewers
- Add CHANGELOG aliases
- Adds @wilsonehusin as CHANGELOG reviewer / approver for 1.21 cycle
- Add Release Managers as changelog approvers
- Add 1.21 Release Notes shadows as changelog reviewers

Includes:
- @tpepper offboarding
- @saschagrunert to SIG Chair
- @hasheddan to SIG Technical Lead

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
xref https://github.com/kubernetes/sig-release/issues/1322

**Special notes for your reviewer**:

/assign @justaugustus @saschagrunert 
/hold
/sig release
/area release-engineering
cc: @kubernetes/release-engineering 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
