### PR TITLE
set numberOfWorkers for netpol suite to the ideal value (3) that is n…

### DIFF
--- a/test/e2e/network/netpol/probe.go
+++ b/test/e2e/network/netpol/probe.go
@@ -42,7 +42,7 @@ type ProbeJobResults struct {
 
 // ProbePodToPodConnectivity runs a series of probes in kube, and records the results in `testCase.Reachability`
 func ProbePodToPodConnectivity(k8s *kubeManager, model *Model, testCase *TestCase) {
-	numberOfWorkers := 30
+	numberOfWorkers := 3 // See https://github.com/kubernetes/kubernetes/pull/97690
 	allPods := model.AllPods()
 	size := len(allPods) * len(allPods)
 	jobs := make(chan *ProbeJob, size)


### PR DESCRIPTION
Fixes #97744

Implements the learnings from #97690 to be more polite to the other ginkgo sig-network tests... 

<img width="997" alt="image" src="https://user-images.githubusercontent.com/826111/103601815-794e2900-4ed8-11eb-9ab2-ad2ba28edf9d.png">

the inflection point for test speed here is clearly 3 threads, at which point concurrency gives us diminishing returns.