### PR TITLE
Fix Spelling error about [invalidResouceID]

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_standard_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_standard_test.go
@@ -857,7 +857,7 @@ func TestGetStandardInstanceIDByNodeName(t *testing.T) {
 		Name: to.StringPtr("vm1"),
 		ID:   to.StringPtr("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/vm1"),
 	}
-	invalidResouceID := "/subscriptions/subscription/resourceGroups/rg/Microsoft.Compute/virtualMachines/vm4"
+	invalidResourceID := "/subscriptions/subscription/resourceGroups/rg/Microsoft.Compute/virtualMachines/vm4"
 	testcases := []struct {
 		name           string
 		nodeName       string
@@ -882,7 +882,7 @@ func TestGetStandardInstanceIDByNodeName(t *testing.T) {
 		{
 			name:           "GetInstanceIDByNodeName should report error if ResourceID is invalid",
 			nodeName:       "vm4",
-			expectedErrMsg: fmt.Errorf("%q isn't in Azure resource ID format %q", invalidResouceID, azureResourceGroupNameRE.String()),
+			expectedErrMsg: fmt.Errorf("%q isn't in Azure resource ID format %q", invalidResourceID, azureResourceGroupNameRE.String()),
 		},
 	}
 	for _, test := range testcases {
@@ -895,7 +895,7 @@ func TestGetStandardInstanceIDByNodeName(t *testing.T) {
 		}).AnyTimes()
 		mockVMClient.EXPECT().Get(gomock.Any(), cloud.ResourceGroup, "vm4", gomock.Any()).Return(compute.VirtualMachine{
 			Name: to.StringPtr("vm4"),
-			ID:   to.StringPtr(invalidResouceID),
+			ID:   to.StringPtr(invalidResourceID),
 		}, nil).AnyTimes()
 
 		instanceID, err := cloud.VMSet.GetInstanceIDByNodeName(test.nodeName)


### PR DESCRIPTION
What type of PR is this?
/kind cleanup

What this PR does / why we need it:
Fix Spelling error about [invalidResouceID]

Which issue(s) this PR fixes:

Fixes #

Special notes for your reviewer:

Does this PR introduce a user-facing change?:

```release-note
NONE
```
Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
