### PR TITLE
Fix Spelling error about [Connect to a internal Service using]

### DIFF
--- a/staging/src/k8s.io/kubectl/docs/book/pages/container_debugging/proxying_traffic_to_services.md
+++ b/staging/src/k8s.io/kubectl/docs/book/pages/container_debugging/proxying_traffic_to_services.md
@@ -24,7 +24,7 @@ accessed without the need for a Proxy.
 {% method %}
 ## Connecting to an internal Service
 
-Connect to a internal Service using the Proxy command, and the Service Proxy url.
+Connect to an internal Service using the Proxy command, and the Service Proxy url.
 
 To visit the nginx service go to the Proxy URL at
 `http://127.0.0.1:8001/api/v1/namespaces/default/services/nginx/proxy/`


### PR DESCRIPTION

What type of PR is this?
/kind cleanup

What this PR does / why we need it:
Fix Spelling error about [Connect to a internal Service using]

Which issue(s) this PR fixes:

Fixes #

Special notes for your reviewer:

Does this PR introduce a user-facing change?:

```release-note
NONE
```
Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
