### PR TITLE
Configure --tls-cipher-suites on kube-apiserver

### DIFF
--- a/cluster/gce/config-default.sh
+++ b/cluster/gce/config-default.sh
@@ -560,5 +560,6 @@ export ETCD_PROGRESS_NOTIFY_INTERVAL="${ETCD_PROGRESS_NOTIFY_INTERVAL:-10m}"
 # unzipping the image layers to disk.
 export WINDOWS_ENABLE_PIGZ="${WINDOWS_ENABLE_PIGZ:-true}"
 
-# TLS_CIPHER_SUITES defines cipher suites allowed to be used by kube-apiserver. If this variable is unset or empty, kube-apiserver is allowed to use any cipher it supports.
+# TLS_CIPHER_SUITES defines cipher suites allowed to be used by kube-apiserver. 
+# If this variable is unset or empty, kube-apiserver will allow its default set of cipher suites.
 export TLS_CIPHER_SUITES=""

--- a/cluster/gce/config-default.sh
+++ b/cluster/gce/config-default.sh
@@ -559,3 +559,6 @@ export ETCD_PROGRESS_NOTIFY_INTERVAL="${ETCD_PROGRESS_NOTIFY_INTERVAL:-10m}"
 # It improves container image pull performance since most time is spent
 # unzipping the image layers to disk.
 export WINDOWS_ENABLE_PIGZ="${WINDOWS_ENABLE_PIGZ:-true}"
+
+# TLS_CIPHER_SUITES defines cipher suites allowed to be used by kube-apiserver. If this variable is unset or empty, kube-apiserver is allowed to use any cipher it supports.
+export TLS_CIPHER_SUITES=""

--- a/cluster/gce/config-test.sh
+++ b/cluster/gce/config-test.sh
@@ -596,5 +596,6 @@ export ETCD_PROGRESS_NOTIFY_INTERVAL="${ETCD_PROGRESS_NOTIFY_INTERVAL:-10m}"
 # unzipping the image layers to disk.
 export WINDOWS_ENABLE_PIGZ="${WINDOWS_ENABLE_PIGZ:-true}"
 
-# TLS_CIPHER_SUITES defines cipher suites allowed to be used by kube-apiserver. If this variable is unset or empty, kube-apiserver is allowed to use any cipher it supports.
+# TLS_CIPHER_SUITES defines cipher suites allowed to be used by kube-apiserver. 
+# If this variable is unset or empty, kube-apiserver will allow its default set of cipher suites.
 export TLS_CIPHER_SUITES=""

--- a/cluster/gce/config-test.sh
+++ b/cluster/gce/config-test.sh
@@ -595,3 +595,6 @@ export ETCD_PROGRESS_NOTIFY_INTERVAL="${ETCD_PROGRESS_NOTIFY_INTERVAL:-10m}"
 # It improves container image pull performance since most time is spent
 # unzipping the image layers to disk.
 export WINDOWS_ENABLE_PIGZ="${WINDOWS_ENABLE_PIGZ:-true}"
+
+# TLS_CIPHER_SUITES defines cipher suites allowed to be used by kube-apiserver. If this variable is unset or empty, kube-apiserver is allowed to use any cipher it supports.
+export TLS_CIPHER_SUITES=""

--- a/cluster/gce/gci/configure-kubeapiserver.sh
+++ b/cluster/gce/gci/configure-kubeapiserver.sh
@@ -92,6 +92,9 @@ function start-kube-apiserver {
     fi
     params+=" --tls-sni-cert-key=${OLD_MASTER_CERT_PATH},${OLD_MASTER_KEY_PATH}:${old_ips}"
   fi
+  if [[ -n "${TLS_CIPHER_SUITES:-}" ]]; then
+    params+=" --tls-cipher-suites=${TLS_CIPHER_SUITES}"
+  fi
   params+=" --kubelet-preferred-address-types=InternalIP,ExternalIP,Hostname"
   if [[ -s "${REQUESTHEADER_CA_CERT_PATH:-}" ]]; then
     params+=" --requestheader-client-ca-file=${REQUESTHEADER_CA_CERT_PATH}"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
It is recommended by CIS kubernetes benchmark that kube-apiserver and kubelet should not use weak ciphers for TLS. This PR allows configuration to be injected into kube-apiserver during the cluster startup.

**Does this PR introduce a user-facing change?**:
No, this PR does not change kubernetes itself, but only the GCP reference startup scripts.
```release-note
NONE
```