### PR TITLE
Promote intree gce-pd topology label to GA version

### DIFF
--- a/pkg/volume/gcepd/attacher_test.go
+++ b/pkg/volume/gcepd/attacher_test.go
@@ -458,7 +458,7 @@ func createPVSpec(name string, readOnly bool, zones []string) *volume.Spec {
 	if zones != nil {
 		zonesLabel := strings.Join(zones, cloudvolume.LabelMultiZoneDelimiter)
 		spec.PersistentVolume.ObjectMeta.Labels = map[string]string{
-			v1.LabelFailureDomainBetaZone: zonesLabel,
+			v1.LabelTopologyZone: zonesLabel,
 		}
 	}
 

--- a/pkg/volume/gcepd/gce_pd.go
+++ b/pkg/volume/gcepd/gce_pd.go
@@ -542,7 +542,7 @@ func (c *gcePersistentDiskProvisioner) Provision(selectedNode *v1.Node, allowedT
 		for k, v := range labels {
 			pv.Labels[k] = v
 			var values []string
-			if k == v1.LabelFailureDomainBetaZone {
+			if k == v1.LabelTopologyZone {
 				values, err = volumehelpers.LabelZonesToList(v)
 				if err != nil {
 					return nil, fmt.Errorf("failed to convert label string for Zone: %s to a List: %v", v, err)

--- a/pkg/volume/gcepd/gce_pd_test.go
+++ b/pkg/volume/gcepd/gce_pd_test.go
@@ -86,7 +86,7 @@ type fakePDManager struct {
 func (fake *fakePDManager) CreateVolume(c *gcePersistentDiskProvisioner, node *v1.Node, allowedTopologies []v1.TopologySelectorTerm) (volumeID string, volumeSizeGB int, labels map[string]string, fstype string, err error) {
 	labels = make(map[string]string)
 	labels["fakepdmanager"] = "yes"
-	labels[v1.LabelFailureDomainBetaZone] = "zone1__zone2"
+	labels[v1.LabelTopologyZone] = "zone1__zone2"
 	return "test-gce-volume-name", 100, labels, "", nil
 }
 
@@ -200,8 +200,8 @@ func TestPlugin(t *testing.T) {
 		t.Errorf("Provision() returned unexpected value for fakepdmanager: %v", persistentSpec.Labels["fakepdmanager"])
 	}
 
-	if persistentSpec.Labels[v1.LabelFailureDomainBetaZone] != "zone1__zone2" {
-		t.Errorf("Provision() returned unexpected value for %s: %v", v1.LabelFailureDomainBetaZone, persistentSpec.Labels[v1.LabelFailureDomainBetaZone])
+	if persistentSpec.Labels[v1.LabelTopologyZone] != "zone1__zone2" {
+		t.Errorf("Provision() returned unexpected value for %s: %v", v1.LabelTopologyZone, persistentSpec.Labels[v1.LabelTopologyZone])
 	}
 
 	if persistentSpec.Spec.NodeAffinity == nil {
@@ -219,9 +219,9 @@ func TestPlugin(t *testing.T) {
 		t.Errorf("NodeSelectorRequirement fakepdmanager-in-yes not found in volume NodeAffinity")
 	}
 	zones, _ := volumehelpers.ZonesToSet("zone1,zone2")
-	r, _ = getNodeSelectorRequirementWithKey(v1.LabelFailureDomainBetaZone, term)
+	r, _ = getNodeSelectorRequirementWithKey(v1.LabelTopologyZone, term)
 	if r == nil {
-		t.Errorf("NodeSelectorRequirement %s-in-%v not found in volume NodeAffinity", v1.LabelFailureDomainBetaZone, zones)
+		t.Errorf("NodeSelectorRequirement %s-in-%v not found in volume NodeAffinity", v1.LabelTopologyZone, zones)
 	} else {
 		sort.Strings(r.Values)
 		if !reflect.DeepEqual(r.Values, zones.List()) {

--- a/pkg/volume/gcepd/gce_util.go
+++ b/pkg/volume/gcepd/gce_util.go
@@ -356,7 +356,7 @@ func udevadmChangeToDrive(drivePath string) error {
 // Checks whether the given GCE PD volume spec is associated with a regional PD.
 func isRegionalPD(spec *volume.Spec) bool {
 	if spec.PersistentVolume != nil {
-		zonesLabel := spec.PersistentVolume.Labels[v1.LabelFailureDomainBetaZone]
+		zonesLabel := spec.PersistentVolume.Labels[v1.LabelTopologyZone]
 		zones := strings.Split(zonesLabel, cloudvolume.LabelMultiZoneDelimiter)
 		return len(zones) > 1
 	}

--- a/plugin/pkg/admission/storage/persistentvolume/label/admission.go
+++ b/plugin/pkg/admission/storage/persistentvolume/label/admission.go
@@ -130,7 +130,7 @@ func (l *persistentVolumeLabel) Admit(ctx context.Context, a admission.Attribute
 
 			// Set NodeSelectorRequirements based on the labels
 			var values []string
-			if k == v1.LabelFailureDomainBetaZone {
+			if k == v1.LabelTopologyZone {
 				zones, err := volumehelpers.LabelZonesToSet(v)
 				if err != nil {
 					return admission.NewForbidden(a, fmt.Errorf("failed to convert label string for Zone: %s to a Set", v))
@@ -172,14 +172,14 @@ func (l *persistentVolumeLabel) findVolumeLabels(volume *api.PersistentVolume) (
 	existingLabels := volume.Labels
 
 	// All cloud providers set only these two labels.
-	domain, domainOK := existingLabels[v1.LabelFailureDomainBetaZone]
-	region, regionOK := existingLabels[v1.LabelFailureDomainBetaRegion]
+	domain, domainOK := existingLabels[v1.LabelTopologyZone]
+	region, regionOK := existingLabels[v1.LabelTopologyRegion]
 	isDynamicallyProvisioned := metav1.HasAnnotation(volume.ObjectMeta, persistentvolume.AnnDynamicallyProvisioned)
 	if isDynamicallyProvisioned && domainOK && regionOK {
 		// PV already has all the labels and we can trust the dynamic provisioning that it provided correct values.
 		return map[string]string{
-			v1.LabelFailureDomainBetaZone:   domain,
-			v1.LabelFailureDomainBetaRegion: region,
+			v1.LabelTopologyZone:   domain,
+			v1.LabelTopologyRegion: region,
 		}, nil
 	}
 

--- a/plugin/pkg/admission/storage/persistentvolume/label/admission.go
+++ b/plugin/pkg/admission/storage/persistentvolume/label/admission.go
@@ -130,7 +130,7 @@ func (l *persistentVolumeLabel) Admit(ctx context.Context, a admission.Attribute
 
 			// Set NodeSelectorRequirements based on the labels
 			var values []string
-			if k == v1.LabelTopologyZone {
+			if k == v1.LabelTopologyZone || k == v1.LabelFailureDomainBetaZone {
 				zones, err := volumehelpers.LabelZonesToSet(v)
 				if err != nil {
 					return admission.NewForbidden(a, fmt.Errorf("failed to convert label string for Zone: %s to a Set", v))
@@ -172,15 +172,31 @@ func (l *persistentVolumeLabel) findVolumeLabels(volume *api.PersistentVolume) (
 	existingLabels := volume.Labels
 
 	// All cloud providers set only these two labels.
+	topologyLabelGA := true
 	domain, domainOK := existingLabels[v1.LabelTopologyZone]
 	region, regionOK := existingLabels[v1.LabelTopologyRegion]
+	// If they dont have GA labels we should check for failuredomain beta labels
+	// TODO: remove this once all the cloud provider change to topology labels
+	if !domainOK || !regionOK {
+		topologyLabelGA = false
+		domain, domainOK = existingLabels[v1.LabelFailureDomainBetaZone]
+		region, regionOK = existingLabels[v1.LabelFailureDomainBetaRegion]
+	}
+
 	isDynamicallyProvisioned := metav1.HasAnnotation(volume.ObjectMeta, persistentvolume.AnnDynamicallyProvisioned)
 	if isDynamicallyProvisioned && domainOK && regionOK {
 		// PV already has all the labels and we can trust the dynamic provisioning that it provided correct values.
+		if topologyLabelGA {
+			return map[string]string{
+				v1.LabelTopologyZone:   domain,
+				v1.LabelTopologyRegion: region,
+			}, nil
+		}
 		return map[string]string{
-			v1.LabelTopologyZone:   domain,
-			v1.LabelTopologyRegion: region,
+			v1.LabelFailureDomainBetaZone:   domain,
+			v1.LabelFailureDomainBetaRegion: region,
 		}, nil
+
 	}
 
 	// Either missing labels or we don't trust the user provided correct values.

--- a/plugin/pkg/admission/storage/persistentvolume/label/admission_test.go
+++ b/plugin/pkg/admission/storage/persistentvolume/label/admission_test.go
@@ -174,9 +174,9 @@ func Test_PVLAdmission(t *testing.T) {
 			name:    "AWS EBS PV labeled correctly",
 			handler: newPersistentVolumeLabel(),
 			pvlabeler: mockVolumeLabels(map[string]string{
-				"a":                  "1",
-				"b":                  "2",
-				v1.LabelTopologyZone: "1__2__3",
+				"a":                           "1",
+				"b":                           "2",
+				v1.LabelFailureDomainBetaZone: "1__2__3",
 			}),
 			preAdmissionPV: &api.PersistentVolume{
 				ObjectMeta: metav1.ObjectMeta{Name: "awsebs", Namespace: "myns"},
@@ -193,9 +193,9 @@ func Test_PVLAdmission(t *testing.T) {
 					Name:      "awsebs",
 					Namespace: "myns",
 					Labels: map[string]string{
-						"a":                  "1",
-						"b":                  "2",
-						v1.LabelTopologyZone: "1__2__3",
+						"a":                           "1",
+						"b":                           "2",
+						v1.LabelFailureDomainBetaZone: "1__2__3",
 					},
 				},
 				Spec: api.PersistentVolumeSpec{
@@ -220,7 +220,7 @@ func Test_PVLAdmission(t *testing.T) {
 											Values:   []string{"2"},
 										},
 										{
-											Key:      v1.LabelTopologyZone,
+											Key:      v1.LabelFailureDomainBetaZone,
 											Operator: api.NodeSelectorOpIn,
 											Values:   []string{"1", "2", "3"},
 										},
@@ -237,15 +237,15 @@ func Test_PVLAdmission(t *testing.T) {
 			name:    "existing labels from dynamic provisioning are not changed",
 			handler: newPersistentVolumeLabel(),
 			pvlabeler: mockVolumeLabels(map[string]string{
-				v1.LabelTopologyZone:   "domain1",
-				v1.LabelTopologyRegion: "region1",
+				v1.LabelFailureDomainBetaZone:   "domain1",
+				v1.LabelFailureDomainBetaRegion: "region1",
 			}),
 			preAdmissionPV: &api.PersistentVolume{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "awsebs", Namespace: "myns",
 					Labels: map[string]string{
-						v1.LabelTopologyZone:   "existingDomain",
-						v1.LabelTopologyRegion: "existingRegion",
+						v1.LabelFailureDomainBetaZone:   "existingDomain",
+						v1.LabelFailureDomainBetaRegion: "existingRegion",
 					},
 					Annotations: map[string]string{
 						persistentvolume.AnnDynamicallyProvisioned: "kubernetes.io/aws-ebs",
@@ -264,8 +264,8 @@ func Test_PVLAdmission(t *testing.T) {
 					Name:      "awsebs",
 					Namespace: "myns",
 					Labels: map[string]string{
-						v1.LabelTopologyZone:   "existingDomain",
-						v1.LabelTopologyRegion: "existingRegion",
+						v1.LabelFailureDomainBetaZone:   "existingDomain",
+						v1.LabelFailureDomainBetaRegion: "existingRegion",
 					},
 					Annotations: map[string]string{
 						persistentvolume.AnnDynamicallyProvisioned: "kubernetes.io/aws-ebs",
@@ -283,12 +283,12 @@ func Test_PVLAdmission(t *testing.T) {
 								{
 									MatchExpressions: []api.NodeSelectorRequirement{
 										{
-											Key:      v1.LabelTopologyRegion,
+											Key:      v1.LabelFailureDomainBetaRegion,
 											Operator: api.NodeSelectorOpIn,
 											Values:   []string{"existingRegion"},
 										},
 										{
-											Key:      v1.LabelTopologyZone,
+											Key:      v1.LabelFailureDomainBetaZone,
 											Operator: api.NodeSelectorOpIn,
 											Values:   []string{"existingDomain"},
 										},
@@ -305,15 +305,15 @@ func Test_PVLAdmission(t *testing.T) {
 			name:    "existing labels from user are changed",
 			handler: newPersistentVolumeLabel(),
 			pvlabeler: mockVolumeLabels(map[string]string{
-				v1.LabelTopologyZone:   "domain1",
-				v1.LabelTopologyRegion: "region1",
+				v1.LabelFailureDomainBetaZone:   "domain1",
+				v1.LabelFailureDomainBetaRegion: "region1",
 			}),
 			preAdmissionPV: &api.PersistentVolume{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "awsebs", Namespace: "myns",
 					Labels: map[string]string{
-						v1.LabelTopologyZone:   "existingDomain",
-						v1.LabelTopologyRegion: "existingRegion",
+						v1.LabelFailureDomainBetaZone:   "existingDomain",
+						v1.LabelFailureDomainBetaRegion: "existingRegion",
 					},
 				},
 				Spec: api.PersistentVolumeSpec{
@@ -329,8 +329,8 @@ func Test_PVLAdmission(t *testing.T) {
 					Name:      "awsebs",
 					Namespace: "myns",
 					Labels: map[string]string{
-						v1.LabelTopologyZone:   "domain1",
-						v1.LabelTopologyRegion: "region1",
+						v1.LabelFailureDomainBetaZone:   "domain1",
+						v1.LabelFailureDomainBetaRegion: "region1",
 					},
 				},
 				Spec: api.PersistentVolumeSpec{
@@ -345,12 +345,12 @@ func Test_PVLAdmission(t *testing.T) {
 								{
 									MatchExpressions: []api.NodeSelectorRequirement{
 										{
-											Key:      v1.LabelTopologyRegion,
+											Key:      v1.LabelFailureDomainBetaRegion,
 											Operator: api.NodeSelectorOpIn,
 											Values:   []string{"region1"},
 										},
 										{
-											Key:      v1.LabelTopologyZone,
+											Key:      v1.LabelFailureDomainBetaZone,
 											Operator: api.NodeSelectorOpIn,
 											Values:   []string{"domain1"},
 										},
@@ -430,9 +430,9 @@ func Test_PVLAdmission(t *testing.T) {
 			name:    "Azure Disk PV labeled correctly",
 			handler: newPersistentVolumeLabel(),
 			pvlabeler: mockVolumeLabels(map[string]string{
-				"a":                  "1",
-				"b":                  "2",
-				v1.LabelTopologyZone: "1__2__3",
+				"a":                           "1",
+				"b":                           "2",
+				v1.LabelFailureDomainBetaZone: "1__2__3",
 			}),
 			preAdmissionPV: &api.PersistentVolume{
 				ObjectMeta: metav1.ObjectMeta{
@@ -452,9 +452,9 @@ func Test_PVLAdmission(t *testing.T) {
 					Name:      "azurepd",
 					Namespace: "myns",
 					Labels: map[string]string{
-						"a":                  "1",
-						"b":                  "2",
-						v1.LabelTopologyZone: "1__2__3",
+						"a":                           "1",
+						"b":                           "2",
+						v1.LabelFailureDomainBetaZone: "1__2__3",
 					},
 				},
 				Spec: api.PersistentVolumeSpec{
@@ -479,7 +479,7 @@ func Test_PVLAdmission(t *testing.T) {
 											Values:   []string{"2"},
 										},
 										{
-											Key:      v1.LabelTopologyZone,
+											Key:      v1.LabelFailureDomainBetaZone,
 											Operator: api.NodeSelectorOpIn,
 											Values:   []string{"1", "2", "3"},
 										},
@@ -496,9 +496,9 @@ func Test_PVLAdmission(t *testing.T) {
 			name:    "Cinder Disk PV labeled correctly",
 			handler: newPersistentVolumeLabel(),
 			pvlabeler: mockVolumeLabels(map[string]string{
-				"a":                  "1",
-				"b":                  "2",
-				v1.LabelTopologyZone: "1__2__3",
+				"a":                           "1",
+				"b":                           "2",
+				v1.LabelFailureDomainBetaZone: "1__2__3",
 			}),
 			preAdmissionPV: &api.PersistentVolume{
 				ObjectMeta: metav1.ObjectMeta{
@@ -518,9 +518,9 @@ func Test_PVLAdmission(t *testing.T) {
 					Name:      "azurepd",
 					Namespace: "myns",
 					Labels: map[string]string{
-						"a":                  "1",
-						"b":                  "2",
-						v1.LabelTopologyZone: "1__2__3",
+						"a":                           "1",
+						"b":                           "2",
+						v1.LabelFailureDomainBetaZone: "1__2__3",
 					},
 				},
 				Spec: api.PersistentVolumeSpec{
@@ -545,7 +545,7 @@ func Test_PVLAdmission(t *testing.T) {
 											Values:   []string{"2"},
 										},
 										{
-											Key:      v1.LabelTopologyZone,
+											Key:      v1.LabelFailureDomainBetaZone,
 											Operator: api.NodeSelectorOpIn,
 											Values:   []string{"1", "2", "3"},
 										},
@@ -562,9 +562,9 @@ func Test_PVLAdmission(t *testing.T) {
 			name:    "AWS EBS PV overrides user applied labels",
 			handler: newPersistentVolumeLabel(),
 			pvlabeler: mockVolumeLabels(map[string]string{
-				"a":                  "1",
-				"b":                  "2",
-				v1.LabelTopologyZone: "1__2__3",
+				"a":                           "1",
+				"b":                           "2",
+				v1.LabelFailureDomainBetaZone: "1__2__3",
 			}),
 			preAdmissionPV: &api.PersistentVolume{
 				ObjectMeta: metav1.ObjectMeta{
@@ -587,9 +587,9 @@ func Test_PVLAdmission(t *testing.T) {
 					Name:      "awsebs",
 					Namespace: "myns",
 					Labels: map[string]string{
-						"a":                  "1",
-						"b":                  "2",
-						v1.LabelTopologyZone: "1__2__3",
+						"a":                           "1",
+						"b":                           "2",
+						v1.LabelFailureDomainBetaZone: "1__2__3",
 					},
 				},
 				Spec: api.PersistentVolumeSpec{
@@ -614,7 +614,7 @@ func Test_PVLAdmission(t *testing.T) {
 											Values:   []string{"2"},
 										},
 										{
-											Key:      v1.LabelTopologyZone,
+											Key:      v1.LabelFailureDomainBetaZone,
 											Operator: api.NodeSelectorOpIn,
 											Values:   []string{"1", "2", "3"},
 										},
@@ -819,9 +819,9 @@ func Test_PVLAdmission(t *testing.T) {
 			name:    "vSphere PV labeled correctly",
 			handler: newPersistentVolumeLabel(),
 			pvlabeler: mockVolumeLabels(map[string]string{
-				"a":                  "1",
-				"b":                  "2",
-				v1.LabelTopologyZone: "1__2__3",
+				"a":                           "1",
+				"b":                           "2",
+				v1.LabelFailureDomainBetaZone: "1__2__3",
 			}),
 			preAdmissionPV: &api.PersistentVolume{
 				ObjectMeta: metav1.ObjectMeta{
@@ -841,9 +841,9 @@ func Test_PVLAdmission(t *testing.T) {
 					Name:      "vSpherePV",
 					Namespace: "myns",
 					Labels: map[string]string{
-						"a":                  "1",
-						"b":                  "2",
-						v1.LabelTopologyZone: "1__2__3",
+						"a":                           "1",
+						"b":                           "2",
+						v1.LabelFailureDomainBetaZone: "1__2__3",
 					},
 				},
 				Spec: api.PersistentVolumeSpec{
@@ -868,7 +868,7 @@ func Test_PVLAdmission(t *testing.T) {
 											Values:   []string{"2"},
 										},
 										{
-											Key:      v1.LabelTopologyZone,
+											Key:      v1.LabelFailureDomainBetaZone,
 											Operator: api.NodeSelectorOpIn,
 											Values:   []string{"1", "2", "3"},
 										},

--- a/plugin/pkg/admission/storage/persistentvolume/label/admission_test.go
+++ b/plugin/pkg/admission/storage/persistentvolume/label/admission_test.go
@@ -66,9 +66,9 @@ func Test_PVLAdmission(t *testing.T) {
 			name:    "non-cloud PV ignored",
 			handler: newPersistentVolumeLabel(),
 			pvlabeler: mockVolumeLabels(map[string]string{
-				"a":                           "1",
-				"b":                           "2",
-				v1.LabelFailureDomainBetaZone: "1__2__3",
+				"a":                  "1",
+				"b":                  "2",
+				v1.LabelTopologyZone: "1__2__3",
 			}),
 			preAdmissionPV: &api.PersistentVolume{
 				ObjectMeta: metav1.ObjectMeta{Name: "noncloud", Namespace: "myns"},
@@ -174,9 +174,9 @@ func Test_PVLAdmission(t *testing.T) {
 			name:    "AWS EBS PV labeled correctly",
 			handler: newPersistentVolumeLabel(),
 			pvlabeler: mockVolumeLabels(map[string]string{
-				"a":                           "1",
-				"b":                           "2",
-				v1.LabelFailureDomainBetaZone: "1__2__3",
+				"a":                  "1",
+				"b":                  "2",
+				v1.LabelTopologyZone: "1__2__3",
 			}),
 			preAdmissionPV: &api.PersistentVolume{
 				ObjectMeta: metav1.ObjectMeta{Name: "awsebs", Namespace: "myns"},
@@ -193,9 +193,9 @@ func Test_PVLAdmission(t *testing.T) {
 					Name:      "awsebs",
 					Namespace: "myns",
 					Labels: map[string]string{
-						"a":                           "1",
-						"b":                           "2",
-						v1.LabelFailureDomainBetaZone: "1__2__3",
+						"a":                  "1",
+						"b":                  "2",
+						v1.LabelTopologyZone: "1__2__3",
 					},
 				},
 				Spec: api.PersistentVolumeSpec{
@@ -220,7 +220,7 @@ func Test_PVLAdmission(t *testing.T) {
 											Values:   []string{"2"},
 										},
 										{
-											Key:      v1.LabelFailureDomainBetaZone,
+											Key:      v1.LabelTopologyZone,
 											Operator: api.NodeSelectorOpIn,
 											Values:   []string{"1", "2", "3"},
 										},
@@ -237,15 +237,15 @@ func Test_PVLAdmission(t *testing.T) {
 			name:    "existing labels from dynamic provisioning are not changed",
 			handler: newPersistentVolumeLabel(),
 			pvlabeler: mockVolumeLabels(map[string]string{
-				v1.LabelFailureDomainBetaZone:   "domain1",
-				v1.LabelFailureDomainBetaRegion: "region1",
+				v1.LabelTopologyZone:   "domain1",
+				v1.LabelTopologyRegion: "region1",
 			}),
 			preAdmissionPV: &api.PersistentVolume{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "awsebs", Namespace: "myns",
 					Labels: map[string]string{
-						v1.LabelFailureDomainBetaZone:   "existingDomain",
-						v1.LabelFailureDomainBetaRegion: "existingRegion",
+						v1.LabelTopologyZone:   "existingDomain",
+						v1.LabelTopologyRegion: "existingRegion",
 					},
 					Annotations: map[string]string{
 						persistentvolume.AnnDynamicallyProvisioned: "kubernetes.io/aws-ebs",
@@ -264,8 +264,8 @@ func Test_PVLAdmission(t *testing.T) {
 					Name:      "awsebs",
 					Namespace: "myns",
 					Labels: map[string]string{
-						v1.LabelFailureDomainBetaZone:   "existingDomain",
-						v1.LabelFailureDomainBetaRegion: "existingRegion",
+						v1.LabelTopologyZone:   "existingDomain",
+						v1.LabelTopologyRegion: "existingRegion",
 					},
 					Annotations: map[string]string{
 						persistentvolume.AnnDynamicallyProvisioned: "kubernetes.io/aws-ebs",
@@ -283,12 +283,12 @@ func Test_PVLAdmission(t *testing.T) {
 								{
 									MatchExpressions: []api.NodeSelectorRequirement{
 										{
-											Key:      v1.LabelFailureDomainBetaRegion,
+											Key:      v1.LabelTopologyRegion,
 											Operator: api.NodeSelectorOpIn,
 											Values:   []string{"existingRegion"},
 										},
 										{
-											Key:      v1.LabelFailureDomainBetaZone,
+											Key:      v1.LabelTopologyZone,
 											Operator: api.NodeSelectorOpIn,
 											Values:   []string{"existingDomain"},
 										},
@@ -305,15 +305,15 @@ func Test_PVLAdmission(t *testing.T) {
 			name:    "existing labels from user are changed",
 			handler: newPersistentVolumeLabel(),
 			pvlabeler: mockVolumeLabels(map[string]string{
-				v1.LabelFailureDomainBetaZone:   "domain1",
-				v1.LabelFailureDomainBetaRegion: "region1",
+				v1.LabelTopologyZone:   "domain1",
+				v1.LabelTopologyRegion: "region1",
 			}),
 			preAdmissionPV: &api.PersistentVolume{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "awsebs", Namespace: "myns",
 					Labels: map[string]string{
-						v1.LabelFailureDomainBetaZone:   "existingDomain",
-						v1.LabelFailureDomainBetaRegion: "existingRegion",
+						v1.LabelTopologyZone:   "existingDomain",
+						v1.LabelTopologyRegion: "existingRegion",
 					},
 				},
 				Spec: api.PersistentVolumeSpec{
@@ -329,8 +329,8 @@ func Test_PVLAdmission(t *testing.T) {
 					Name:      "awsebs",
 					Namespace: "myns",
 					Labels: map[string]string{
-						v1.LabelFailureDomainBetaZone:   "domain1",
-						v1.LabelFailureDomainBetaRegion: "region1",
+						v1.LabelTopologyZone:   "domain1",
+						v1.LabelTopologyRegion: "region1",
 					},
 				},
 				Spec: api.PersistentVolumeSpec{
@@ -345,12 +345,12 @@ func Test_PVLAdmission(t *testing.T) {
 								{
 									MatchExpressions: []api.NodeSelectorRequirement{
 										{
-											Key:      v1.LabelFailureDomainBetaRegion,
+											Key:      v1.LabelTopologyRegion,
 											Operator: api.NodeSelectorOpIn,
 											Values:   []string{"region1"},
 										},
 										{
-											Key:      v1.LabelFailureDomainBetaZone,
+											Key:      v1.LabelTopologyZone,
 											Operator: api.NodeSelectorOpIn,
 											Values:   []string{"domain1"},
 										},
@@ -367,9 +367,9 @@ func Test_PVLAdmission(t *testing.T) {
 			name:    "GCE PD PV labeled correctly",
 			handler: newPersistentVolumeLabel(),
 			pvlabeler: mockVolumeLabels(map[string]string{
-				"a":                           "1",
-				"b":                           "2",
-				v1.LabelFailureDomainBetaZone: "1__2__3",
+				"a":                  "1",
+				"b":                  "2",
+				v1.LabelTopologyZone: "1__2__3",
 			}),
 			preAdmissionPV: &api.PersistentVolume{
 				ObjectMeta: metav1.ObjectMeta{Name: "gcepd", Namespace: "myns"},
@@ -386,9 +386,9 @@ func Test_PVLAdmission(t *testing.T) {
 					Name:      "gcepd",
 					Namespace: "myns",
 					Labels: map[string]string{
-						"a":                           "1",
-						"b":                           "2",
-						v1.LabelFailureDomainBetaZone: "1__2__3",
+						"a":                  "1",
+						"b":                  "2",
+						v1.LabelTopologyZone: "1__2__3",
 					},
 				},
 				Spec: api.PersistentVolumeSpec{
@@ -413,7 +413,7 @@ func Test_PVLAdmission(t *testing.T) {
 											Values:   []string{"2"},
 										},
 										{
-											Key:      v1.LabelFailureDomainBetaZone,
+											Key:      v1.LabelTopologyZone,
 											Operator: api.NodeSelectorOpIn,
 											Values:   []string{"1", "2", "3"},
 										},
@@ -430,9 +430,9 @@ func Test_PVLAdmission(t *testing.T) {
 			name:    "Azure Disk PV labeled correctly",
 			handler: newPersistentVolumeLabel(),
 			pvlabeler: mockVolumeLabels(map[string]string{
-				"a":                           "1",
-				"b":                           "2",
-				v1.LabelFailureDomainBetaZone: "1__2__3",
+				"a":                  "1",
+				"b":                  "2",
+				v1.LabelTopologyZone: "1__2__3",
 			}),
 			preAdmissionPV: &api.PersistentVolume{
 				ObjectMeta: metav1.ObjectMeta{
@@ -452,9 +452,9 @@ func Test_PVLAdmission(t *testing.T) {
 					Name:      "azurepd",
 					Namespace: "myns",
 					Labels: map[string]string{
-						"a":                           "1",
-						"b":                           "2",
-						v1.LabelFailureDomainBetaZone: "1__2__3",
+						"a":                  "1",
+						"b":                  "2",
+						v1.LabelTopologyZone: "1__2__3",
 					},
 				},
 				Spec: api.PersistentVolumeSpec{
@@ -479,7 +479,7 @@ func Test_PVLAdmission(t *testing.T) {
 											Values:   []string{"2"},
 										},
 										{
-											Key:      v1.LabelFailureDomainBetaZone,
+											Key:      v1.LabelTopologyZone,
 											Operator: api.NodeSelectorOpIn,
 											Values:   []string{"1", "2", "3"},
 										},
@@ -496,9 +496,9 @@ func Test_PVLAdmission(t *testing.T) {
 			name:    "Cinder Disk PV labeled correctly",
 			handler: newPersistentVolumeLabel(),
 			pvlabeler: mockVolumeLabels(map[string]string{
-				"a":                           "1",
-				"b":                           "2",
-				v1.LabelFailureDomainBetaZone: "1__2__3",
+				"a":                  "1",
+				"b":                  "2",
+				v1.LabelTopologyZone: "1__2__3",
 			}),
 			preAdmissionPV: &api.PersistentVolume{
 				ObjectMeta: metav1.ObjectMeta{
@@ -518,9 +518,9 @@ func Test_PVLAdmission(t *testing.T) {
 					Name:      "azurepd",
 					Namespace: "myns",
 					Labels: map[string]string{
-						"a":                           "1",
-						"b":                           "2",
-						v1.LabelFailureDomainBetaZone: "1__2__3",
+						"a":                  "1",
+						"b":                  "2",
+						v1.LabelTopologyZone: "1__2__3",
 					},
 				},
 				Spec: api.PersistentVolumeSpec{
@@ -545,7 +545,7 @@ func Test_PVLAdmission(t *testing.T) {
 											Values:   []string{"2"},
 										},
 										{
-											Key:      v1.LabelFailureDomainBetaZone,
+											Key:      v1.LabelTopologyZone,
 											Operator: api.NodeSelectorOpIn,
 											Values:   []string{"1", "2", "3"},
 										},
@@ -562,9 +562,9 @@ func Test_PVLAdmission(t *testing.T) {
 			name:    "AWS EBS PV overrides user applied labels",
 			handler: newPersistentVolumeLabel(),
 			pvlabeler: mockVolumeLabels(map[string]string{
-				"a":                           "1",
-				"b":                           "2",
-				v1.LabelFailureDomainBetaZone: "1__2__3",
+				"a":                  "1",
+				"b":                  "2",
+				v1.LabelTopologyZone: "1__2__3",
 			}),
 			preAdmissionPV: &api.PersistentVolume{
 				ObjectMeta: metav1.ObjectMeta{
@@ -587,9 +587,9 @@ func Test_PVLAdmission(t *testing.T) {
 					Name:      "awsebs",
 					Namespace: "myns",
 					Labels: map[string]string{
-						"a":                           "1",
-						"b":                           "2",
-						v1.LabelFailureDomainBetaZone: "1__2__3",
+						"a":                  "1",
+						"b":                  "2",
+						v1.LabelTopologyZone: "1__2__3",
 					},
 				},
 				Spec: api.PersistentVolumeSpec{
@@ -614,7 +614,7 @@ func Test_PVLAdmission(t *testing.T) {
 											Values:   []string{"2"},
 										},
 										{
-											Key:      v1.LabelFailureDomainBetaZone,
+											Key:      v1.LabelTopologyZone,
 											Operator: api.NodeSelectorOpIn,
 											Values:   []string{"1", "2", "3"},
 										},
@@ -819,9 +819,9 @@ func Test_PVLAdmission(t *testing.T) {
 			name:    "vSphere PV labeled correctly",
 			handler: newPersistentVolumeLabel(),
 			pvlabeler: mockVolumeLabels(map[string]string{
-				"a":                           "1",
-				"b":                           "2",
-				v1.LabelFailureDomainBetaZone: "1__2__3",
+				"a":                  "1",
+				"b":                  "2",
+				v1.LabelTopologyZone: "1__2__3",
 			}),
 			preAdmissionPV: &api.PersistentVolume{
 				ObjectMeta: metav1.ObjectMeta{
@@ -841,9 +841,9 @@ func Test_PVLAdmission(t *testing.T) {
 					Name:      "vSpherePV",
 					Namespace: "myns",
 					Labels: map[string]string{
-						"a":                           "1",
-						"b":                           "2",
-						v1.LabelFailureDomainBetaZone: "1__2__3",
+						"a":                  "1",
+						"b":                  "2",
+						v1.LabelTopologyZone: "1__2__3",
 					},
 				},
 				Spec: api.PersistentVolumeSpec{
@@ -868,7 +868,7 @@ func Test_PVLAdmission(t *testing.T) {
 											Values:   []string{"2"},
 										},
 										{
-											Key:      v1.LabelFailureDomainBetaZone,
+											Key:      v1.LabelTopologyZone,
 											Operator: api.NodeSelectorOpIn,
 											Values:   []string{"1", "2", "3"},
 										},

--- a/staging/src/k8s.io/cloud-provider/volume/helpers/zones.go
+++ b/staging/src/k8s.io/cloud-provider/volume/helpers/zones.go
@@ -23,7 +23,7 @@ import (
 	"strconv"
 	"strings"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	cloudvolume "k8s.io/cloud-provider/volume"
 	"k8s.io/klog/v2"
@@ -118,9 +118,9 @@ func SelectZonesForVolume(zoneParameterPresent, zonesParameterPresent bool, zone
 
 		// pick node's zone for one of the replicas
 		var ok bool
-		zoneFromNode, ok = node.ObjectMeta.Labels[v1.LabelFailureDomainBetaZone]
+		zoneFromNode, ok = node.ObjectMeta.Labels[v1.LabelTopologyZone]
 		if !ok {
-			return nil, fmt.Errorf("%s Label for node missing", v1.LabelFailureDomainBetaZone)
+			return nil, fmt.Errorf("%s Label for node missing", v1.LabelTopologyZone)
 		}
 		// if single replica volume and node with zone found, return immediately
 		if numReplicas == 1 {
@@ -135,7 +135,7 @@ func SelectZonesForVolume(zoneParameterPresent, zonesParameterPresent bool, zone
 	}
 
 	if (len(allowedTopologies) > 0) && (allowedZones.Len() == 0) {
-		return nil, fmt.Errorf("no matchLabelExpressions with %s key found in allowedTopologies. Please specify matchLabelExpressions with %s key", v1.LabelFailureDomainBetaZone, v1.LabelFailureDomainBetaZone)
+		return nil, fmt.Errorf("no matchLabelExpressions with %s key found in allowedTopologies. Please specify matchLabelExpressions with %s key", v1.LabelTopologyZone, v1.LabelTopologyZone)
 	}
 
 	if allowedZones.Len() > 0 {
@@ -185,7 +185,7 @@ func ZonesFromAllowedTopologies(allowedTopologies []v1.TopologySelectorTerm) (se
 	zones := make(sets.String)
 	for _, term := range allowedTopologies {
 		for _, exp := range term.MatchLabelExpressions {
-			if exp.Key == v1.LabelFailureDomainBetaZone {
+			if exp.Key == v1.LabelTopologyZone {
 				for _, value := range exp.Values {
 					zones.Insert(value)
 				}

--- a/staging/src/k8s.io/cloud-provider/volume/helpers/zones.go
+++ b/staging/src/k8s.io/cloud-provider/volume/helpers/zones.go
@@ -120,7 +120,10 @@ func SelectZonesForVolume(zoneParameterPresent, zonesParameterPresent bool, zone
 		var ok bool
 		zoneFromNode, ok = node.ObjectMeta.Labels[v1.LabelTopologyZone]
 		if !ok {
-			return nil, fmt.Errorf("%s Label for node missing", v1.LabelTopologyZone)
+			zoneFromNode, ok = node.ObjectMeta.Labels[v1.LabelFailureDomainBetaZone]
+			if !ok {
+				return nil, fmt.Errorf("Either %s or %s Label for node missing", v1.LabelTopologyZone, v1.LabelFailureDomainBetaZone)
+			}
 		}
 		// if single replica volume and node with zone found, return immediately
 		if numReplicas == 1 {
@@ -185,7 +188,7 @@ func ZonesFromAllowedTopologies(allowedTopologies []v1.TopologySelectorTerm) (se
 	zones := make(sets.String)
 	for _, term := range allowedTopologies {
 		for _, exp := range term.MatchLabelExpressions {
-			if exp.Key == v1.LabelTopologyZone {
+			if exp.Key == v1.LabelTopologyZone || exp.Key == v1.LabelFailureDomainBetaZone {
 				for _, value := range exp.Values {
 					zones.Insert(value)
 				}

--- a/staging/src/k8s.io/cloud-provider/volume/helpers/zones_test.go
+++ b/staging/src/k8s.io/cloud-provider/volume/helpers/zones_test.go
@@ -20,7 +20,7 @@ import (
 	"hash/fnv"
 	"testing"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 )
 
@@ -417,7 +417,7 @@ func TestChooseZonesForVolume(t *testing.T) {
 func TestSelectZoneForVolume(t *testing.T) {
 
 	nodeWithZoneLabels := &v1.Node{}
-	nodeWithZoneLabels.Labels = map[string]string{v1.LabelFailureDomainBetaZone: "zoneX"}
+	nodeWithZoneLabels.Labels = map[string]string{v1.LabelTopologyZone: "zoneX"}
 
 	nodeWithNoLabels := &v1.Node{}
 
@@ -499,7 +499,7 @@ func TestSelectZoneForVolume(t *testing.T) {
 				{
 					MatchLabelExpressions: []v1.TopologySelectorLabelRequirement{
 						{
-							Key:    v1.LabelFailureDomainBetaZone,
+							Key:    v1.LabelTopologyZone,
 							Values: []string{"zoneX"},
 						},
 					},
@@ -521,7 +521,7 @@ func TestSelectZoneForVolume(t *testing.T) {
 				{
 					MatchLabelExpressions: []v1.TopologySelectorLabelRequirement{
 						{
-							Key:    v1.LabelFailureDomainBetaZone,
+							Key:    v1.LabelTopologyZone,
 							Values: []string{"zoneX"},
 						},
 					},
@@ -530,7 +530,7 @@ func TestSelectZoneForVolume(t *testing.T) {
 			Reject: true,
 		},
 
-		// Key specified in AllowedTopologies is not LabelFailureDomainBetaZone [Fail]
+		// Key specified in AllowedTopologies is not LabelTopologyZone [Fail]
 		// [1] nil Node
 		// [2] no Zone/Zones parameter
 		// [3] AllowedTopologies with invalid key specified
@@ -545,7 +545,7 @@ func TestSelectZoneForVolume(t *testing.T) {
 							Values: []string{"zoneX"},
 						},
 						{
-							Key:    v1.LabelFailureDomainBetaZone,
+							Key:    v1.LabelTopologyZone,
 							Values: []string{"zoneY"},
 						},
 					},
@@ -554,7 +554,7 @@ func TestSelectZoneForVolume(t *testing.T) {
 			Reject: true,
 		},
 
-		// AllowedTopologies without keys specifying LabelFailureDomainBetaZone [Fail]
+		// AllowedTopologies without keys specifying LabelTopologyZone [Fail]
 		// [1] nil Node
 		// [2] no Zone/Zones parameter
 		// [3] Invalid AllowedTopologies
@@ -633,7 +633,7 @@ func TestSelectZoneForVolume(t *testing.T) {
 				{
 					MatchLabelExpressions: []v1.TopologySelectorLabelRequirement{
 						{
-							Key:    v1.LabelFailureDomainBetaZone,
+							Key:    v1.LabelTopologyZone,
 							Values: []string{"zoneZ", "zoneY"},
 						},
 					},
@@ -655,7 +655,7 @@ func TestSelectZoneForVolume(t *testing.T) {
 				{
 					MatchLabelExpressions: []v1.TopologySelectorLabelRequirement{
 						{
-							Key:    v1.LabelFailureDomainBetaZone,
+							Key:    v1.LabelTopologyZone,
 							Values: []string{"zoneX", "zoneY"},
 						},
 					},
@@ -676,7 +676,7 @@ func TestSelectZoneForVolume(t *testing.T) {
 				{
 					MatchLabelExpressions: []v1.TopologySelectorLabelRequirement{
 						{
-							Key:    v1.LabelFailureDomainBetaZone,
+							Key:    v1.LabelTopologyZone,
 							Values: []string{"zoneX"},
 						},
 					},
@@ -684,7 +684,7 @@ func TestSelectZoneForVolume(t *testing.T) {
 				{
 					MatchLabelExpressions: []v1.TopologySelectorLabelRequirement{
 						{
-							Key:    v1.LabelFailureDomainBetaZone,
+							Key:    v1.LabelTopologyZone,
 							Values: []string{"zoneY"},
 						},
 					},
@@ -706,7 +706,7 @@ func TestSelectZoneForVolume(t *testing.T) {
 				{
 					MatchLabelExpressions: []v1.TopologySelectorLabelRequirement{
 						{
-							Key:    v1.LabelFailureDomainBetaZone,
+							Key:    v1.LabelTopologyZone,
 							Values: []string{"zoneX"},
 						},
 					},
@@ -771,7 +771,7 @@ func TestSelectZoneForVolume(t *testing.T) {
 func TestSelectZonesForVolume(t *testing.T) {
 
 	nodeWithZoneLabels := &v1.Node{}
-	nodeWithZoneLabels.Labels = map[string]string{v1.LabelFailureDomainBetaZone: "zoneX"}
+	nodeWithZoneLabels.Labels = map[string]string{v1.LabelTopologyZone: "zoneX"}
 
 	nodeWithNoLabels := &v1.Node{}
 
@@ -865,7 +865,7 @@ func TestSelectZonesForVolume(t *testing.T) {
 				{
 					MatchLabelExpressions: []v1.TopologySelectorLabelRequirement{
 						{
-							Key:    v1.LabelFailureDomainBetaZone,
+							Key:    v1.LabelTopologyZone,
 							Values: []string{"zoneX"},
 						},
 					},
@@ -889,7 +889,7 @@ func TestSelectZonesForVolume(t *testing.T) {
 				{
 					MatchLabelExpressions: []v1.TopologySelectorLabelRequirement{
 						{
-							Key:    v1.LabelFailureDomainBetaZone,
+							Key:    v1.LabelTopologyZone,
 							Values: []string{"zoneX"},
 						},
 					},
@@ -898,7 +898,7 @@ func TestSelectZonesForVolume(t *testing.T) {
 			Reject: true,
 		},
 
-		// Key specified in AllowedTopologies is not LabelFailureDomainBetaZone [Fail]
+		// Key specified in AllowedTopologies is not LabelTopologyZone [Fail]
 		// [1] nil Node
 		// [2] no Zone/Zones parameter
 		// [3] AllowedTopologies with invalid key specified
@@ -915,7 +915,7 @@ func TestSelectZonesForVolume(t *testing.T) {
 							Values: []string{"zoneX"},
 						},
 						{
-							Key:    v1.LabelFailureDomainBetaZone,
+							Key:    v1.LabelTopologyZone,
 							Values: []string{"zoneY"},
 						},
 					},
@@ -924,7 +924,7 @@ func TestSelectZonesForVolume(t *testing.T) {
 			Reject: true,
 		},
 
-		// AllowedTopologies without keys specifying LabelFailureDomainBetaZone [Fail]
+		// AllowedTopologies without keys specifying LabelTopologyZone [Fail]
 		// [1] nil Node
 		// [2] no Zone/Zones parameter
 		// [3] Invalid AllowedTopologies
@@ -999,7 +999,7 @@ func TestSelectZonesForVolume(t *testing.T) {
 				{
 					MatchLabelExpressions: []v1.TopologySelectorLabelRequirement{
 						{
-							Key:    v1.LabelFailureDomainBetaZone,
+							Key:    v1.LabelTopologyZone,
 							Values: []string{"zoneX"},
 						},
 					},
@@ -1123,7 +1123,7 @@ func TestSelectZonesForVolume(t *testing.T) {
 				{
 					MatchLabelExpressions: []v1.TopologySelectorLabelRequirement{
 						{
-							Key:    v1.LabelFailureDomainBetaZone,
+							Key:    v1.LabelTopologyZone,
 							Values: []string{"zoneV", "zoneW", "zoneX", "zoneY", "zoneZ"},
 						},
 					},
@@ -1149,7 +1149,7 @@ func TestSelectZonesForVolume(t *testing.T) {
 				{
 					MatchLabelExpressions: []v1.TopologySelectorLabelRequirement{
 						{
-							Key:    v1.LabelFailureDomainBetaZone,
+							Key:    v1.LabelTopologyZone,
 							Values: []string{"zoneX", "zoneY"},
 						},
 					},
@@ -1176,7 +1176,7 @@ func TestSelectZonesForVolume(t *testing.T) {
 				{
 					MatchLabelExpressions: []v1.TopologySelectorLabelRequirement{
 						{
-							Key:    v1.LabelFailureDomainBetaZone,
+							Key:    v1.LabelTopologyZone,
 							Values: []string{"zoneX", "zoneY", "zoneZ"},
 						},
 					},
@@ -1200,7 +1200,7 @@ func TestSelectZonesForVolume(t *testing.T) {
 				{
 					MatchLabelExpressions: []v1.TopologySelectorLabelRequirement{
 						{
-							Key:    v1.LabelFailureDomainBetaZone,
+							Key:    v1.LabelTopologyZone,
 							Values: []string{"zoneX", "zoneY"},
 						},
 					},
@@ -1228,7 +1228,7 @@ func TestSelectZonesForVolume(t *testing.T) {
 				{
 					MatchLabelExpressions: []v1.TopologySelectorLabelRequirement{
 						{
-							Key:    v1.LabelFailureDomainBetaZone,
+							Key:    v1.LabelTopologyZone,
 							Values: []string{"zoneV"},
 						},
 					},
@@ -1236,7 +1236,7 @@ func TestSelectZonesForVolume(t *testing.T) {
 				{
 					MatchLabelExpressions: []v1.TopologySelectorLabelRequirement{
 						{
-							Key:    v1.LabelFailureDomainBetaZone,
+							Key:    v1.LabelTopologyZone,
 							Values: []string{"zoneW"},
 						},
 					},
@@ -1244,7 +1244,7 @@ func TestSelectZonesForVolume(t *testing.T) {
 				{
 					MatchLabelExpressions: []v1.TopologySelectorLabelRequirement{
 						{
-							Key:    v1.LabelFailureDomainBetaZone,
+							Key:    v1.LabelTopologyZone,
 							Values: []string{"zoneX"},
 						},
 					},
@@ -1252,7 +1252,7 @@ func TestSelectZonesForVolume(t *testing.T) {
 				{
 					MatchLabelExpressions: []v1.TopologySelectorLabelRequirement{
 						{
-							Key:    v1.LabelFailureDomainBetaZone,
+							Key:    v1.LabelTopologyZone,
 							Values: []string{"zoneY"},
 						},
 					},
@@ -1260,7 +1260,7 @@ func TestSelectZonesForVolume(t *testing.T) {
 				{
 					MatchLabelExpressions: []v1.TopologySelectorLabelRequirement{
 						{
-							Key:    v1.LabelFailureDomainBetaZone,
+							Key:    v1.LabelTopologyZone,
 							Values: []string{"zoneZ"},
 						},
 					},
@@ -1286,7 +1286,7 @@ func TestSelectZonesForVolume(t *testing.T) {
 				{
 					MatchLabelExpressions: []v1.TopologySelectorLabelRequirement{
 						{
-							Key:    v1.LabelFailureDomainBetaZone,
+							Key:    v1.LabelTopologyZone,
 							Values: []string{"zoneX"},
 						},
 					},
@@ -1294,7 +1294,7 @@ func TestSelectZonesForVolume(t *testing.T) {
 				{
 					MatchLabelExpressions: []v1.TopologySelectorLabelRequirement{
 						{
-							Key:    v1.LabelFailureDomainBetaZone,
+							Key:    v1.LabelTopologyZone,
 							Values: []string{"zoneY"},
 						},
 					},
@@ -1321,7 +1321,7 @@ func TestSelectZonesForVolume(t *testing.T) {
 				{
 					MatchLabelExpressions: []v1.TopologySelectorLabelRequirement{
 						{
-							Key:    v1.LabelFailureDomainBetaZone,
+							Key:    v1.LabelTopologyZone,
 							Values: []string{"zoneX"},
 						},
 					},
@@ -1329,7 +1329,7 @@ func TestSelectZonesForVolume(t *testing.T) {
 				{
 					MatchLabelExpressions: []v1.TopologySelectorLabelRequirement{
 						{
-							Key:    v1.LabelFailureDomainBetaZone,
+							Key:    v1.LabelTopologyZone,
 							Values: []string{"zoneY"},
 						},
 					},
@@ -1337,7 +1337,7 @@ func TestSelectZonesForVolume(t *testing.T) {
 				{
 					MatchLabelExpressions: []v1.TopologySelectorLabelRequirement{
 						{
-							Key:    v1.LabelFailureDomainBetaZone,
+							Key:    v1.LabelTopologyZone,
 							Values: []string{"zoneZ"},
 						},
 					},
@@ -1361,7 +1361,7 @@ func TestSelectZonesForVolume(t *testing.T) {
 				{
 					MatchLabelExpressions: []v1.TopologySelectorLabelRequirement{
 						{
-							Key:    v1.LabelFailureDomainBetaZone,
+							Key:    v1.LabelTopologyZone,
 							Values: []string{"zoneX"},
 						},
 					},
@@ -1369,7 +1369,7 @@ func TestSelectZonesForVolume(t *testing.T) {
 				{
 					MatchLabelExpressions: []v1.TopologySelectorLabelRequirement{
 						{
-							Key:    v1.LabelFailureDomainBetaZone,
+							Key:    v1.LabelTopologyZone,
 							Values: []string{"zoneY"},
 						},
 					},

--- a/staging/src/k8s.io/csi-translation-lib/plugins/aws_ebs.go
+++ b/staging/src/k8s.io/csi-translation-lib/plugins/aws_ebs.go
@@ -174,6 +174,8 @@ func (t *awsElasticBlockStoreCSITranslator) TranslateCSIPVToInTree(pv *v1.Persis
 		ebsSource.Partition = int32(partValue)
 	}
 
+	removeTopology(pv, AWSEBSTopologyKey)
+
 	pv.Spec.CSI = nil
 	pv.Spec.AWSElasticBlockStore = ebsSource
 	return pv, nil

--- a/staging/src/k8s.io/csi-translation-lib/plugins/azure_disk.go
+++ b/staging/src/k8s.io/csi-translation-lib/plugins/azure_disk.go
@@ -215,6 +215,8 @@ func (t *azureDiskCSITranslator) TranslateCSIPVToInTree(pv *v1.PersistentVolume)
 		}
 	}
 
+	removeTopology(pv, AzureDiskTopologyKey)
+
 	pv.Spec.CSI = nil
 	pv.Spec.AzureDisk = azureSource
 

--- a/staging/src/k8s.io/csi-translation-lib/plugins/gce_pd.go
+++ b/staging/src/k8s.io/csi-translation-lib/plugins/gce_pd.go
@@ -215,7 +215,12 @@ func (g *gcePersistentDiskCSITranslator) TranslateInTreePVToCSI(pv *v1.Persisten
 		return nil, fmt.Errorf("pv is nil or GCE Persistent Disk source not defined on pv")
 	}
 
+	// depend on which version it migrates from, the label could be failuredomain beta or topology GA version
 	zonesLabel := pv.Labels[v1.LabelFailureDomainBetaZone]
+	if zonesLabel == "" {
+		zonesLabel = pv.Labels[v1.LabelTopologyZone]
+	}
+
 	zones := strings.Split(zonesLabel, labelMultiZoneDelimiter)
 	if len(zones) == 1 && len(zones[0]) != 0 {
 		// Zonal
@@ -287,6 +292,8 @@ func (g *gcePersistentDiskCSITranslator) TranslateCSIPVToInTree(pv *v1.Persisten
 	}
 
 	// TODO: Take the zone/regional information and stick it into the label.
+
+	removeTopology(pv, GCEPDTopologyKey)
 
 	pv.Spec.CSI = nil
 	pv.Spec.GCEPersistentDisk = gceSource

--- a/staging/src/k8s.io/csi-translation-lib/plugins/openstack_cinder.go
+++ b/staging/src/k8s.io/csi-translation-lib/plugins/openstack_cinder.go
@@ -119,6 +119,8 @@ func (t *osCinderCSITranslator) TranslateCSIPVToInTree(pv *v1.PersistentVolume) 
 		ReadOnly: csiSource.ReadOnly,
 	}
 
+	removeTopology(pv, CinderTopologyKey)
+
 	pv.Spec.CSI = nil
 	pv.Spec.Cinder = cinderSource
 	return pv, nil

--- a/staging/src/k8s.io/csi-translation-lib/translate_test.go
+++ b/staging/src/k8s.io/csi-translation-lib/translate_test.go
@@ -29,11 +29,11 @@ import (
 
 var (
 	defaultZoneLabels = map[string]string{
-		v1.LabelFailureDomainBetaZone:   "us-east-1a",
+		v1.LabelTopologyZone:            "us-east-1a",
 		v1.LabelFailureDomainBetaRegion: "us-east-1",
 	}
 	regionalPDLabels = map[string]string{
-		v1.LabelFailureDomainBetaZone: "europe-west1-b__europe-west1-c",
+		v1.LabelTopologyZone: "europe-west1-b__europe-west1-c",
 	}
 )
 
@@ -94,50 +94,59 @@ func TestTranslationStability(t *testing.T) {
 func TestTopologyTranslation(t *testing.T) {
 	testCases := []struct {
 		name                 string
+		key                  string
 		pv                   *v1.PersistentVolume
 		expectedNodeAffinity *v1.VolumeNodeAffinity
 	}{
 		{
 			name:                 "GCE PD with zone labels",
+			key:                  plugins.GCEPDTopologyKey,
 			pv:                   makeGCEPDPV(defaultZoneLabels, nil /*topology*/),
 			expectedNodeAffinity: makeNodeAffinity(false /*multiTerms*/, plugins.GCEPDTopologyKey, "us-east-1a"),
 		},
 		{
 			name:                 "GCE PD with existing topology (beta keys)",
-			pv:                   makeGCEPDPV(nil /*labels*/, makeTopology(v1.LabelFailureDomainBetaZone, "us-east-2a")),
+			key:                  plugins.GCEPDTopologyKey,
+			pv:                   makeGCEPDPV(nil /*labels*/, makeTopology(v1.LabelTopologyZone, "us-east-2a")),
 			expectedNodeAffinity: makeNodeAffinity(false /*multiTerms*/, plugins.GCEPDTopologyKey, "us-east-2a"),
 		},
 		{
 			name:                 "GCE PD with existing topology (CSI keys)",
+			key:                  plugins.GCEPDTopologyKey,
 			pv:                   makeGCEPDPV(nil /*labels*/, makeTopology(plugins.GCEPDTopologyKey, "us-east-2a")),
 			expectedNodeAffinity: makeNodeAffinity(false /*multiTerms*/, plugins.GCEPDTopologyKey, "us-east-2a"),
 		},
 		{
 			name:                 "GCE PD with zone labels and topology",
-			pv:                   makeGCEPDPV(defaultZoneLabels, makeTopology(v1.LabelFailureDomainBetaZone, "us-east-2a")),
+			key:                  plugins.GCEPDTopologyKey,
+			pv:                   makeGCEPDPV(defaultZoneLabels, makeTopology(v1.LabelTopologyZone, "us-east-2a")),
 			expectedNodeAffinity: makeNodeAffinity(false /*multiTerms*/, plugins.GCEPDTopologyKey, "us-east-2a"),
 		},
 		{
 			name:                 "GCE PD with regional zones",
+			key:                  plugins.GCEPDTopologyKey,
 			pv:                   makeGCEPDPV(regionalPDLabels, nil /*topology*/),
 			expectedNodeAffinity: makeNodeAffinity(false /*multiTerms*/, plugins.GCEPDTopologyKey, "europe-west1-b", "europe-west1-c"),
 		},
 		{
 			name:                 "GCE PD with regional topology",
-			pv:                   makeGCEPDPV(nil /*labels*/, makeTopology(v1.LabelFailureDomainBetaZone, "europe-west1-b", "europe-west1-c")),
+			key:                  plugins.GCEPDTopologyKey,
+			pv:                   makeGCEPDPV(nil /*labels*/, makeTopology(v1.LabelTopologyZone, "europe-west1-b", "europe-west1-c")),
 			expectedNodeAffinity: makeNodeAffinity(false /*multiTerms*/, plugins.GCEPDTopologyKey, "europe-west1-b", "europe-west1-c"),
 		},
 		{
 			name:                 "GCE PD with regional zone and topology",
-			pv:                   makeGCEPDPV(regionalPDLabels, makeTopology(v1.LabelFailureDomainBetaZone, "europe-west1-f", "europe-west1-g")),
+			key:                  plugins.GCEPDTopologyKey,
+			pv:                   makeGCEPDPV(regionalPDLabels, makeTopology(v1.LabelTopologyZone, "europe-west1-f", "europe-west1-g")),
 			expectedNodeAffinity: makeNodeAffinity(false /*multiTerms*/, plugins.GCEPDTopologyKey, "europe-west1-f", "europe-west1-g"),
 		},
 		{
 			name: "GCE PD with multiple node selector terms",
+			key:  plugins.GCEPDTopologyKey,
 			pv: makeGCEPDPVMultTerms(
 				nil, /*labels*/
-				makeTopology(v1.LabelFailureDomainBetaZone, "europe-west1-f"),
-				makeTopology(v1.LabelFailureDomainBetaZone, "europe-west1-g")),
+				makeTopology(v1.LabelTopologyZone, "europe-west1-f"),
+				makeTopology(v1.LabelTopologyZone, "europe-west1-g")),
 			expectedNodeAffinity: makeNodeAffinity(
 				true, /*multiTerms*/
 				plugins.GCEPDTopologyKey, "europe-west1-f", "europe-west1-g"),
@@ -150,7 +159,7 @@ func TestTopologyTranslation(t *testing.T) {
 		},
 		{
 			name:                 "AWS EBS with zone labels and topology",
-			pv:                   makeAWSEBSPV(defaultZoneLabels, makeTopology(v1.LabelFailureDomainBetaZone, "us-east-2a")),
+			pv:                   makeAWSEBSPV(defaultZoneLabels, makeTopology(v1.LabelTopologyZone, "us-east-2a")),
 			expectedNodeAffinity: makeNodeAffinity(false /*multiTerms*/, plugins.AWSEBSTopologyKey, "us-east-2a"),
 		},
 		// Cinder test cases: test mosty topology key, i.e., don't repeat testing done with GCE
@@ -161,7 +170,7 @@ func TestTopologyTranslation(t *testing.T) {
 		},
 		{
 			name:                 "OpenStack Cinder with zone labels and topology",
-			pv:                   makeCinderPV(defaultZoneLabels, makeTopology(v1.LabelFailureDomainBetaZone, "us-east-2a")),
+			pv:                   makeCinderPV(defaultZoneLabels, makeTopology(v1.LabelTopologyZone, "us-east-2a")),
 			expectedNodeAffinity: makeNodeAffinity(false /*multiTerms*/, plugins.CinderTopologyKey, "us-east-2a"),
 		},
 	}
@@ -181,15 +190,15 @@ func TestTopologyTranslation(t *testing.T) {
 			t.Errorf("Expected node affinity %v, got %v", *test.expectedNodeAffinity, *nodeAffinity)
 		}
 
-		// Translate back to in-tree and make sure node affinity is still set
+		// Translate back to in-tree and make sure node affinity has been removed
 		newInTreePV, err := ctl.TranslateCSIPVToInTree(newCSIPV)
 		if err != nil {
 			t.Errorf("Error when translating to in-tree: %v", err)
 		}
 
 		nodeAffinity = newInTreePV.Spec.NodeAffinity
-		if !reflect.DeepEqual(nodeAffinity, test.expectedNodeAffinity) {
-			t.Errorf("Expected node affinity %v, got %v", *test.expectedNodeAffinity, *nodeAffinity)
+		if topologyKeyExist(test.key, nodeAffinity) {
+			t.Errorf("Expected node affinity key %v being removed, got %v", test.key, *nodeAffinity)
 		}
 	}
 }
@@ -312,6 +321,22 @@ func makeTopology(key string, values ...string) *v1.NodeSelectorRequirement {
 		Operator: v1.NodeSelectorOpIn,
 		Values:   values,
 	}
+}
+
+func topologyKeyExist(key string, vna *v1.VolumeNodeAffinity) bool {
+	if vna == nil || vna.Required == nil || vna.Required.NodeSelectorTerms == nil || len(vna.Required.NodeSelectorTerms) == 0 {
+		return false
+	}
+
+	for _, nodeSelectorTerms := range vna.Required.NodeSelectorTerms {
+		nsrequirements := nodeSelectorTerms.MatchExpressions
+		for _, nodeSelectorRequirement := range nsrequirements {
+			if nodeSelectorRequirement.Key == key {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func TestTranslateInTreeInlineVolumeToCSINameUniqueness(t *testing.T) {

--- a/staging/src/k8s.io/legacy-cloud-providers/gce/gce_disks.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/gce/gce_disks.go
@@ -515,7 +515,7 @@ func (g *Cloud) GetLabelsForVolume(ctx context.Context, pv *v1.PersistentVolume)
 
 	// If the zone is already labeled, honor the hint
 	name := pv.Spec.GCEPersistentDisk.PDName
-	zone := pv.Labels[v1.LabelFailureDomainBetaZone]
+	zone := pv.Labels[v1.LabelTopologyZone]
 
 	disk, err := g.getDiskByNameAndOptionalLabelZones(name, zone)
 	if err != nil {
@@ -848,7 +848,7 @@ func (g *Cloud) ResizeDisk(diskToResize string, oldSize resource.Quantity, newSi
 }
 
 // GetAutoLabelsForPD builds the labels that should be automatically added to a PersistentVolume backed by a GCE PD
-// Specifically, this builds FailureDomain (zone) and Region labels.
+// Specifically, this builds Topology (zone) and Region labels.
 // The PersistentVolumeLabel admission controller calls this and adds the labels when a PV is created.
 func (g *Cloud) GetAutoLabelsForPD(disk *Disk) (map[string]string, error) {
 	labels := make(map[string]string)
@@ -858,16 +858,16 @@ func (g *Cloud) GetAutoLabelsForPD(disk *Disk) (map[string]string, error) {
 			// Unexpected, but sanity-check
 			return nil, fmt.Errorf("PD did not have zone/region information: %v", disk)
 		}
-		labels[v1.LabelFailureDomainBetaZone] = zoneInfo.zone
-		labels[v1.LabelFailureDomainBetaRegion] = disk.Region
+		labels[v1.LabelTopologyZone] = zoneInfo.zone
+		labels[v1.LabelTopologyRegion] = disk.Region
 	case multiZone:
 		if zoneInfo.replicaZones == nil || zoneInfo.replicaZones.Len() <= 0 {
 			// Unexpected, but sanity-check
 			return nil, fmt.Errorf("PD is regional but does not have any replicaZones specified: %v", disk)
 		}
-		labels[v1.LabelFailureDomainBetaZone] =
+		labels[v1.LabelTopologyZone] =
 			volumehelpers.ZonesSetToLabelValue(zoneInfo.replicaZones)
-		labels[v1.LabelFailureDomainBetaRegion] = disk.Region
+		labels[v1.LabelTopologyRegion] = disk.Region
 	case nil:
 		// Unexpected, but sanity-check
 		return nil, fmt.Errorf("PD did not have ZoneInfo: %v", disk)

--- a/staging/src/k8s.io/legacy-cloud-providers/gce/gce_disks_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/gce/gce_disks_test.go
@@ -28,7 +28,7 @@ import (
 	computebeta "google.golang.org/api/compute/v0.beta"
 	compute "google.golang.org/api/compute/v1"
 	"google.golang.org/api/googleapi"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	cloudprovider "k8s.io/cloud-provider"
@@ -443,7 +443,7 @@ func pv(name, zone string) *v1.PersistentVolume {
 	return &v1.PersistentVolume{
 		ObjectMeta: metav1.ObjectMeta{
 			Labels: map[string]string{
-				v1.LabelFailureDomainBetaZone: zone,
+				v1.LabelTopologyZone: zone,
 			},
 		},
 		Spec: v1.PersistentVolumeSpec{
@@ -484,12 +484,12 @@ func TestGetLabelsForVolume_Basic(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	if labels[v1.LabelFailureDomainBetaZone] != zone {
+	if labels[v1.LabelTopologyZone] != zone {
 		t.Errorf("Failure domain is '%v', but zone is '%v'",
-			labels[v1.LabelFailureDomainBetaZone], zone)
+			labels[v1.LabelTopologyZone], zone)
 	}
-	if labels[v1.LabelFailureDomainBetaRegion] != gceRegion {
-		t.Errorf("Region is '%v', but region is 'us-central1'", labels[v1.LabelFailureDomainBetaRegion])
+	if labels[v1.LabelTopologyRegion] != gceRegion {
+		t.Errorf("Region is '%v', but region is 'us-central1'", labels[v1.LabelTopologyRegion])
 	}
 }
 
@@ -515,7 +515,7 @@ func TestGetLabelsForVolume_NoZone(t *testing.T) {
 	gce.CreateDisk(diskName, diskType, zone, sizeGb, nil)
 
 	pv := pv(diskName, zone)
-	delete(pv.Labels, v1.LabelFailureDomainBetaZone)
+	delete(pv.Labels, v1.LabelTopologyZone)
 
 	/* Act */
 	labels, err := gce.GetLabelsForVolume(ctx, pv)
@@ -524,12 +524,12 @@ func TestGetLabelsForVolume_NoZone(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	if labels[v1.LabelFailureDomainBetaZone] != zone {
-		t.Errorf("Failure domain is '%v', but zone is '%v'",
-			labels[v1.LabelFailureDomainBetaZone], zone)
+	if labels[v1.LabelTopologyZone] != zone {
+		t.Errorf("Topology zone is '%v', but zone is '%v'",
+			labels[v1.LabelTopologyZone], zone)
 	}
-	if labels[v1.LabelFailureDomainBetaRegion] != gceRegion {
-		t.Errorf("Region is '%v', but region is 'europe-west1'", labels[v1.LabelFailureDomainBetaRegion])
+	if labels[v1.LabelTopologyRegion] != gceRegion {
+		t.Errorf("Topology Region is '%v', but region is 'europe-west1'", labels[v1.LabelTopologyRegion])
 	}
 }
 
@@ -575,7 +575,7 @@ func TestGetLabelsForVolume_DiskNotFoundAndNoZone(t *testing.T) {
 	}
 
 	pv := pv(diskName, zone)
-	delete(pv.Labels, v1.LabelFailureDomainBetaZone)
+	delete(pv.Labels, v1.LabelTopologyZone)
 
 	/* Act */
 	_, err := gce.GetLabelsForVolume(ctx, pv)
@@ -617,12 +617,12 @@ func TestGetLabelsForVolume_DupDisk(t *testing.T) {
 	if err != nil {
 		t.Error("Disk name and zone uniquely identifies a disk, yet an error is returned.")
 	}
-	if labels[v1.LabelFailureDomainBetaZone] != zone {
-		t.Errorf("Failure domain is '%v', but zone is '%v'",
-			labels[v1.LabelFailureDomainBetaZone], zone)
+	if labels[v1.LabelTopologyZone] != zone {
+		t.Errorf("Topology Zone is '%v', but zone is '%v'",
+			labels[v1.LabelTopologyZone], zone)
 	}
-	if labels[v1.LabelFailureDomainBetaRegion] != gceRegion {
-		t.Errorf("Region is '%v', but region is 'us-west1'", labels[v1.LabelFailureDomainBetaRegion])
+	if labels[v1.LabelTopologyRegion] != gceRegion {
+		t.Errorf("Topology Region is '%v', but region is 'us-west1'", labels[v1.LabelTopologyRegion])
 	}
 }
 
@@ -651,7 +651,7 @@ func TestGetLabelsForVolume_DupDiskNoZone(t *testing.T) {
 	}
 
 	pv := pv(diskName, zone)
-	delete(pv.Labels, v1.LabelFailureDomainBetaZone)
+	delete(pv.Labels, v1.LabelTopologyZone)
 
 	/* Act */
 	_, err := gce.GetLabelsForVolume(ctx, pv)
@@ -746,13 +746,13 @@ func TestGetAutoLabelsForPD(t *testing.T) {
 				return
 			}
 
-			if got := labels[v1.LabelFailureDomainBetaZone]; !tc.wantZoneLabel.Has(got) {
-				t.Errorf("labels[v1.LabelFailureDomainBetaZone] = %v; want one of: %v", got, tc.wantZoneLabel.List())
+			if got := labels[v1.LabelTopologyZone]; !tc.wantZoneLabel.Has(got) {
+				t.Errorf("labels[v1.LabelTopologyZone] = %v; want one of: %v", got, tc.wantZoneLabel.List())
 			}
 
 			// Validate labels
-			if got := labels[v1.LabelFailureDomainBetaRegion]; got != gceRegion {
-				t.Errorf("labels[v1.LabelFailureDomainBetaRegion] = %v; want: %v", got, gceRegion)
+			if got := labels[v1.LabelTopologyRegion]; got != gceRegion {
+				t.Errorf("labels[v1.LabelTopologyRegion] = %v; want: %v", got, gceRegion)
 			}
 		})
 	}

--- a/test/e2e/storage/drivers/in_tree.go
+++ b/test/e2e/storage/drivers/in_tree.go
@@ -1243,7 +1243,7 @@ func InitGcePdDriver() storageframework.TestDriver {
 			},
 			SupportedFsType:      supportedTypes,
 			SupportedMountOption: sets.NewString("debug", "nouid32"),
-			TopologyKeys:         []string{v1.LabelFailureDomainBetaZone},
+			TopologyKeys:         []string{v1.LabelTopologyZone},
 			Capabilities: map[storageframework.Capability]bool{
 				storageframework.CapPersistence:         true,
 				storageframework.CapFsGroup:             true,
@@ -1278,7 +1278,7 @@ func InitWindowsGcePdDriver() storageframework.TestDriver {
 				Min: "1Gi",
 			},
 			SupportedFsType: supportedTypes,
-			TopologyKeys:    []string{v1.LabelZoneFailureDomain},
+			TopologyKeys:    []string{v1.LabelTopologyZone},
 			Capabilities: map[storageframework.Capability]bool{
 				storageframework.CapControllerExpansion: false,
 				storageframework.CapPersistence:         true,

--- a/test/e2e/storage/regional_pd.go
+++ b/test/e2e/storage/regional_pd.go
@@ -235,10 +235,10 @@ func testZonalFailover(c clientset.Interface, ns string) {
 	nodeName := pod.Spec.NodeName
 	node, err := c.CoreV1().Nodes().Get(context.TODO(), nodeName, metav1.GetOptions{})
 	framework.ExpectNoError(err)
-	podZone := node.Labels[v1.LabelFailureDomainBetaZone]
+	podZone := node.Labels[v1.LabelTopologyZone]
 
 	ginkgo.By("tainting nodes in the zone the pod is scheduled in")
-	selector := labels.SelectorFromSet(labels.Set(map[string]string{v1.LabelFailureDomainBetaZone: podZone}))
+	selector := labels.SelectorFromSet(labels.Set(map[string]string{v1.LabelTopologyZone: podZone}))
 	nodesInZone, err := c.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{LabelSelector: selector.String()})
 	framework.ExpectNoError(err)
 	removeTaintFunc := addTaint(c, ns, nodesInZone.Items, podZone)
@@ -266,7 +266,7 @@ func testZonalFailover(c clientset.Interface, ns string) {
 		if err != nil {
 			return false, nil
 		}
-		newPodZone := node.Labels[v1.LabelFailureDomainBetaZone]
+		newPodZone := node.Labels[v1.LabelTopologyZone]
 		return newPodZone == otherZone, nil
 	})
 	framework.ExpectNoError(waitErr, "Error waiting for pod to be scheduled in a different zone (%q): %v", otherZone, err)
@@ -354,9 +354,9 @@ func testRegionalDelayedBinding(c clientset.Interface, ns string, pvcCount int) 
 	if node == nil {
 		framework.Failf("unexpected nil node found")
 	}
-	zone, ok := node.Labels[v1.LabelFailureDomainBetaZone]
+	zone, ok := node.Labels[v1.LabelTopologyZone]
 	if !ok {
-		framework.Failf("label %s not found on Node", v1.LabelFailureDomainBetaZone)
+		framework.Failf("label %s not found on Node", v1.LabelTopologyZone)
 	}
 	for _, pv := range pvs {
 		checkZoneFromLabelAndAffinity(pv, zone, false)
@@ -423,9 +423,9 @@ func testRegionalAllowedTopologiesWithDelayedBinding(c clientset.Interface, ns s
 	if node == nil {
 		framework.Failf("unexpected nil node found")
 	}
-	nodeZone, ok := node.Labels[v1.LabelFailureDomainBetaZone]
+	nodeZone, ok := node.Labels[v1.LabelTopologyZone]
 	if !ok {
-		framework.Failf("label %s not found on Node", v1.LabelFailureDomainBetaZone)
+		framework.Failf("label %s not found on Node", v1.LabelTopologyZone)
 	}
 	zoneFound := false
 	for _, zone := range topoZones {
@@ -466,7 +466,7 @@ func addAllowedTopologiesToStorageClass(c clientset.Interface, sc *storagev1.Sto
 	term := v1.TopologySelectorTerm{
 		MatchLabelExpressions: []v1.TopologySelectorLabelRequirement{
 			{
-				Key:    v1.LabelFailureDomainBetaZone,
+				Key:    v1.LabelTopologyZone,
 				Values: zones,
 			},
 		},
@@ -568,7 +568,7 @@ func getTwoRandomZones(c clientset.Interface) []string {
 // If match is true, check if zones in PV exactly match zones given.
 // Otherwise, check whether zones in PV is superset of zones given.
 func verifyZonesInPV(volume *v1.PersistentVolume, zones sets.String, match bool) error {
-	pvZones, err := volumehelpers.LabelZonesToSet(volume.Labels[v1.LabelFailureDomainBetaZone])
+	pvZones, err := volumehelpers.LabelZonesToSet(volume.Labels[v1.LabelTopologyZone])
 	if err != nil {
 		return err
 	}
@@ -585,17 +585,17 @@ func checkZoneFromLabelAndAffinity(pv *v1.PersistentVolume, zone string, matchZo
 	checkZonesFromLabelAndAffinity(pv, sets.NewString(zone), matchZone)
 }
 
-// checkZoneLabelAndAffinity checks the LabelFailureDomainBetaZone label of PV and terms
-// with key LabelFailureDomainBetaZone in PV's node affinity contains zone
+// checkZoneLabelAndAffinity checks the LabelTopologyZone label of PV and terms
+// with key LabelTopologyZone in PV's node affinity contains zone
 // matchZones is used to indicate if zones should match perfectly
 func checkZonesFromLabelAndAffinity(pv *v1.PersistentVolume, zones sets.String, matchZones bool) {
 	ginkgo.By("checking PV's zone label and node affinity terms match expected zone")
 	if pv == nil {
 		framework.Failf("nil pv passed")
 	}
-	pvLabel, ok := pv.Labels[v1.LabelFailureDomainBetaZone]
+	pvLabel, ok := pv.Labels[v1.LabelTopologyZone]
 	if !ok {
-		framework.Failf("label %s not found on PV", v1.LabelFailureDomainBetaZone)
+		framework.Failf("label %s not found on PV", v1.LabelTopologyZone)
 	}
 
 	zonesFromLabel, err := volumehelpers.LabelZonesToSet(pvLabel)
@@ -603,10 +603,10 @@ func checkZonesFromLabelAndAffinity(pv *v1.PersistentVolume, zones sets.String, 
 		framework.Failf("unable to parse zone labels %s: %v", pvLabel, err)
 	}
 	if matchZones && !zonesFromLabel.Equal(zones) {
-		framework.Failf("value[s] of %s label for PV: %v does not match expected zone[s]: %v", v1.LabelFailureDomainBetaZone, zonesFromLabel, zones)
+		framework.Failf("value[s] of %s label for PV: %v does not match expected zone[s]: %v", v1.LabelTopologyZone, zonesFromLabel, zones)
 	}
 	if !matchZones && !zonesFromLabel.IsSuperset(zones) {
-		framework.Failf("value[s] of %s label for PV: %v does not contain expected zone[s]: %v", v1.LabelFailureDomainBetaZone, zonesFromLabel, zones)
+		framework.Failf("value[s] of %s label for PV: %v does not contain expected zone[s]: %v", v1.LabelTopologyZone, zonesFromLabel, zones)
 	}
 	if pv.Spec.NodeAffinity == nil {
 		framework.Failf("node affinity not found in PV spec %v", pv.Spec)
@@ -618,7 +618,7 @@ func checkZonesFromLabelAndAffinity(pv *v1.PersistentVolume, zones sets.String, 
 	for _, term := range pv.Spec.NodeAffinity.Required.NodeSelectorTerms {
 		keyFound := false
 		for _, r := range term.MatchExpressions {
-			if r.Key != v1.LabelFailureDomainBetaZone {
+			if r.Key != v1.LabelTopologyZone {
 				continue
 			}
 			keyFound = true
@@ -632,7 +632,7 @@ func checkZonesFromLabelAndAffinity(pv *v1.PersistentVolume, zones sets.String, 
 			break
 		}
 		if !keyFound {
-			framework.Failf("label %s not found in term %v", v1.LabelFailureDomainBetaZone, term)
+			framework.Failf("label %s not found in term %v", v1.LabelTopologyZone, term)
 		}
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup


**What this PR does / why we need it**:
1. The labels `failure-domain.beta.kubernetes.io/zone` and `failure-domain.beta.kubernetes.io/region` have been deprecated for almost a year now and are scheduled to be removed from kubernetes/kubernetes after 1.20 (Q1'21).

The GA version label(topology.kubernetes.io) was not initially added to volume because of https://github.com/kubernetes/kubernetes/pull/81431#discussion_r341216734

Now since we can expect all nodes to have v1 topology on them, we can modify the csi-translation logic to overcome this issue and also upgrade the label to GA version directly.

2. There is a bug in the CSI translation library that when we translate CSI to intree PV, we did not take off the CSI topology. This can be problematic for rollback scenario. This PR also fixes this by removing the CSI topology in NodeAffinity when translate from CSI to in-tree.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

1. Unblock https://github.com/kubernetes/perf-tests/issues/1554 from changing topology label to GA.
2. Fix https://github.com/kubernetes/kubernetes/issues/92237 by upgrading the loabel to GA version.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Update in-tree gce-pd volume to use GA topology labels.
```

Follow-up for this PR:
1. Upgrade csi-provisioner to use the latest csi-translation library so that the migration change works.
2. Work on non-gce-pd volumes to also change the topology label to GA version

/sig storage