### PR TITLE
proxy/ipvs: apply a existed endpoint using an update operation instea…

### DIFF
--- a/pkg/proxy/ipvs/graceful_termination.go
+++ b/pkg/proxy/ipvs/graceful_termination.go
@@ -187,15 +187,11 @@ func (m *GracefulTerminationManager) tryDeleteRs() {
 	}
 }
 
-// MoveRSOutofGracefulDeleteList to delete an rs and remove it from the rsList immediately
+// MoveRSOutofGracefulDeleteList remove rs from the rsList immediately
 func (m *GracefulTerminationManager) MoveRSOutofGracefulDeleteList(uniqueRS string) error {
 	rsToDelete, find := m.rsList.exist(uniqueRS)
 	if !find || rsToDelete == nil {
 		return fmt.Errorf("failed to find rs: %q", uniqueRS)
-	}
-	err := m.ipvs.DeleteRealServer(rsToDelete.VirtualServer, rsToDelete.RealServer)
-	if err != nil {
-		return err
 	}
 	m.rsList.remove(rsToDelete)
 	return nil

--- a/pkg/proxy/ipvs/proxier.go
+++ b/pkg/proxy/ipvs/proxier.go
@@ -2075,6 +2075,11 @@ func (proxier *Proxier) syncEndpoint(svcPortName proxy.ServicePortName, onlyNode
 				klog.Errorf("Failed to delete endpoint: %v in gracefulDeleteQueue, error: %v", ep, err)
 				continue
 			}
+			err = proxier.ipvs.UpdateRealServer(appliedVirtualServer, newDest)
+			if err != nil {
+				klog.Errorf("Failed to update destination: %v, error: %v", newDest, err)
+			}
+			continue
 		}
 		err = proxier.ipvs.AddRealServer(appliedVirtualServer, newDest)
 		if err != nil {


### PR DESCRIPTION
…d of a delete with a following add operations

Signed-off-by: chengzhycn <chengzhycn@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
delete the real server and add it again may introduce extra consumptions to kernel, they can be replaced by a single update operation. 
The other reason I think they should be replaced is that MoveRSOutofGracefulDeleteList may be thought that only delete the rs from the graceful delete list, but it actually do two things: one thing is mentioned above, the other is send delete command to the kernel. It may lead some misunderstandings between the function name and its doings.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```