### PR TITLE
Fix variable 'state' collides with imported package name

### DIFF
--- a/pkg/kubelet/cm/cpumanager/cpu_manager.go
+++ b/pkg/kubelet/cm/cpumanager/cpu_manager.go
@@ -458,9 +458,9 @@ func findContainerIDByName(status *v1.PodStatus, name string) (string, error) {
 }
 
 func findContainerStatusByName(status *v1.PodStatus, name string) (*v1.ContainerStatus, error) {
-	for _, status := range append(status.InitContainerStatuses, status.ContainerStatuses...) {
-		if status.Name == name {
-			return &status, nil
+	for _, containerStatus := range append(status.InitContainerStatuses, status.ContainerStatuses...) {
+		if containerStatus.Name == name {
+			return &containerStatus, nil
 		}
 	}
 	return nil, fmt.Errorf("unable to find status for container with name %v in pod status (it may not be running)", name)

--- a/pkg/kubelet/cm/cpumanager/cpu_manager_test.go
+++ b/pkg/kubelet/cm/cpumanager/cpu_manager_test.go
@@ -483,14 +483,14 @@ func TestCPUManagerAddWithInitContainers(t *testing.T) {
 	for _, testCase := range testCases {
 		policy, _ := NewStaticPolicy(testCase.topo, testCase.numReservedCPUs, cpuset.NewCPUSet(), topologymanager.NewFakeManager())
 
-		state := &mockState{
+		mockState := &mockState{
 			assignments:   testCase.stAssignments,
 			defaultCPUSet: testCase.stDefaultCPUSet,
 		}
 
 		mgr := &manager{
 			policy:            policy,
-			state:             state,
+			state:             mockState,
 			containerRuntime:  mockRuntimeService{},
 			containerMap:      containermap.NewContainerMap(),
 			podStatusProvider: mockPodStatusProvider{},
@@ -526,10 +526,10 @@ func TestCPUManagerAddWithInitContainers(t *testing.T) {
 					testCase.description, containerIDs[i], err)
 			}
 
-			cset, found := state.assignments[string(testCase.pod.UID)][containers[i].Name]
+			cset, found := mockState.assignments[string(testCase.pod.UID)][containers[i].Name]
 			if !expCSets[i].IsEmpty() && !found {
 				t.Errorf("StaticPolicy AddContainer() error (%v). expected container %v to be present in assignments %v",
-					testCase.description, containers[i].Name, state.assignments)
+					testCase.description, containers[i].Name, mockState.assignments)
 			}
 
 			if found && !cset.Equals(expCSets[i]) {
@@ -540,9 +540,9 @@ func TestCPUManagerAddWithInitContainers(t *testing.T) {
 			cumCSet = cumCSet.Union(cset)
 		}
 
-		if !testCase.stDefaultCPUSet.Difference(cumCSet).Equals(state.defaultCPUSet) {
+		if !testCase.stDefaultCPUSet.Difference(cumCSet).Equals(mockState.defaultCPUSet) {
 			t.Errorf("StaticPolicy error (%v). expected final state for defaultCPUSet %v but got %v",
-				testCase.description, testCase.stDefaultCPUSet.Difference(cumCSet), state.defaultCPUSet)
+				testCase.description, testCase.stDefaultCPUSet.Difference(cumCSet), mockState.defaultCPUSet)
 		}
 	}
 }


### PR DESCRIPTION
What type of PR is this?
/kind cleanup

What this PR does / why we need it:
Fix variable 'state' collides with imported package name

Which issue(s) this PR fixes:

Fixes #

Special notes for your reviewer:

Does this PR introduce a user-facing change?:

```release-note
NONE
```
Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.: