### PR TITLE
Reset the metric registry before measuring something

### DIFF
--- a/test/integration/scheduler_perf/util.go
+++ b/test/integration/scheduler_perf/util.go
@@ -160,7 +160,10 @@ func newMetricsCollector(config *metricsCollectorConfig, labels map[string]strin
 }
 
 func (*metricsCollector) run(ctx context.Context) {
-	// metricCollector doesn't need to start before the tests, so nothing to do here.
+	// metricCollector doesn't need to start before the tests, but all the items in the registry
+	// should be reset to get rid of the data that is generated during the phase of environment preparation,
+	// create init pod for example.
+	legacyregistry.Reset()
 }
 
 func (pc *metricsCollector) collect() []DataItem {


### PR DESCRIPTION
There is no need to collect the metric data which is generated during
the phase of environment preparation, as this is not what we want to
measure.

`Preemption/500Nodes/2000InitPods/500PodsToSchedule`

indicator  |         scheduler_pod_scheduling_duration_seconds (before) |  scheduler_pod_scheduling_duration_seconds (after)                   
-----------|---------------------------| -------------------------- 
Average (ms)   | 321.7938825079999 | 5977.825632601997  
Perc50 (ms)     | 332.258064516129    | 7664.5472837022135  
Perc90 (ms)     |590.3225806451613    | 9724.909456740443   
Perc99  (ms)    | 622.5806451612902   | 9982.454728370221   


Obviously, the third colume `scheduler_pod_scheduling_duration_seconds (after)`  is more reasonable, as it shows us the performance where the `preemption` is really happen, instead of all the metric data stored in the registry.

Signed-off-by: Dave Chen <dave.chen@arm.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

Add one of the following kinds:
/kind bug


**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```


/sig scheduling
/sig testing