### PR TITLE
kubeadm should ignore cgroup driver check on Windows node.

### DIFF
--- a/pkg/kubelet/dockershim/docker_service.go
+++ b/pkg/kubelet/dockershim/docker_service.go
@@ -24,6 +24,7 @@ import (
 	"net/http"
 	"path"
 	"path/filepath"
+	"runtime"
 	"sync"
 	"time"
 
@@ -267,11 +268,12 @@ func NewDockerService(config *ClientConfig, podSandboxImage string, streamingCon
 	} else {
 		cgroupDriver = dockerInfo.CgroupDriver
 	}
-	if len(kubeCgroupDriver) != 0 && kubeCgroupDriver != cgroupDriver {
+	if runtime.GOOS == "linux" && len(kubeCgroupDriver) != 0 && kubeCgroupDriver != cgroupDriver {
 		return nil, fmt.Errorf("misconfiguration: kubelet cgroup driver: %q is different from docker cgroup driver: %q", kubeCgroupDriver, cgroupDriver)
 	}
 	klog.Infof("Setting cgroupDriver to %s", cgroupDriver)
 	ds.cgroupDriver = cgroupDriver
+
 	ds.versionCache = cache.NewObjectCache(
 		func() (interface{}, error) {
 			return ds.getDockerVersion()


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
/sig windows
/sig cluster-lifecycle
/area kubeadm

**What this PR does / why we need it**:

> kubeadm doesn't do anything about cgroup drivers on Windows because cgroups don't exist on Windows.
>  ideally the kubelet checks about this should be skipped entirely in dockershim for non-Linux.

**Which issue(s) this PR fixes**:

Fixes #97759

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
kubeadm should ignore cgroup driver check on Windows node.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
