### PR TITLE
go-to-protobuf: set Extras for protoField

### DIFF
--- a/staging/src/k8s.io/code-generator/cmd/go-to-protobuf/protobuf/generator.go
+++ b/staging/src/k8s.io/code-generator/cmd/go-to-protobuf/protobuf/generator.go
@@ -477,11 +477,11 @@ func memberTypeToProtobufField(locator ProtobufLocator, field *protoField, t *ty
 	case types.Builtin:
 		field.Type, err = locator.ProtoTypeFor(t)
 	case types.Map:
-		valueField := &protoField{}
+		valueField := &protoField{Extras: make(map[string]string)}
 		if err := memberTypeToProtobufField(locator, valueField, t.Elem); err != nil {
 			return err
 		}
-		keyField := &protoField{}
+		keyField := &protoField{Extras: make(map[string]string)}
 		if err := memberTypeToProtobufField(locator, keyField, t.Key); err != nil {
 			return err
 		}


### PR DESCRIPTION
A panic is observed:

```console
panic: assignment to entry in nil map

goroutine 1 [running]:
k8s.io/code-generator/cmd/go-to-protobuf/protobuf.memberTypeToProtobufField(0x84bfa0, 0xc008eadec0, 0xc00b5165a8, 0xc0052758c0, 0xffffffffffffffff, 0x100000000000000)
        /go/src/k8s.io/code-generator/cmd/go-to-protobuf/protobuf/generator.go:499 +0x9c3
k8s.io/code-generator/cmd/go-to-protobuf/protobuf.memberTypeToProtobufField(0x84bfa0, 0xc008eadec0, 0xc00b5165a8, 0xc005275810, 0x7cafe9, 0xc00b516430)
        /go/src/k8s.io/code-generator/cmd/go-to-protobuf/protobuf/generator.go:515 +0x305
k8s.io/code-generator/cmd/go-to-protobuf/protobuf.memberTypeToProtobufField(0x84bfa0, 0xc008eadec0, 0xc00b516b88, 0xc00648d4a0, 0xffffffffffffffff, 0xc00b5166c0)
        /go/src/k8s.io/code-generator/cmd/go-to-protobuf/protobuf/generator.go:481 +0x6fd
k8s.io/code-generator/cmd/go-to-protobuf/protobuf.memberTypeToProtobufField(0x84bfa0, 0xc008eadec0, 0xc00b516b88, 0xc00648d3f0, 0x0, 0x1)
        /go/src/k8s.io/code-generator/cmd/go-to-protobuf/protobuf/generator.go:515 +0x305
k8s.io/code-generator/cmd/go-to-protobuf/protobuf.membersToFields(0x84bfa0, 0xc008eadec0, 0xc00648cdc0, 0xc000016160, 0x1e, 0x0, 0x0, 0x7ffeebf94d2d, 0x1e, 0xc0000fca50, ...)
        /go/src/k8s.io/code-generator/cmd/go-to-protobuf/protobuf/generator.go:661 +0xd9c
k8s.io/code-generator/cmd/go-to-protobuf/protobuf.bodyGen.doStruct(0x84bfa0, 0xc008eadec0, 0xc000016160, 0x1e, 0x0, 0x0, 0x7ffeebf94d2d, 0x1e, 0x0, 0xc0000fca50, ...)
        /go/src/k8s.io/code-generator/cmd/go-to-protobuf/protobuf/generator.go:361 +0x17ca
k8s.io/code-generator/cmd/go-to-protobuf/protobuf.(*genProtoIDL).GenerateType(0xc008e36f20, 0xc008b62310, 0xc00648cdc0, 0x844e40, 0xc008e61980, 0x0, 0x0)
        /go/src/k8s.io/code-generator/cmd/go-to-protobuf/protobuf/generator.go:183 +0x364
k8s.io/gengo/generator.(*Context).executeBody(0xc008b62310, 0x844b80, 0xc008e0f0b0, 0x850de0, 0xc008e36f20, 0x1, 0x1)
        /go/pkg/mod/k8s.io/gengo@v0.0.0-20200114144118-36b2048a9120/generator/execute.go:306 +0x11c
k8s.io/gengo/generator.(*Context).ExecutePackage(0xc0000cd730, 0xc000094150, 0x25, 0x84ebe0, 0xc0001408f0, 0x0, 0x0)
        /go/pkg/mod/k8s.io/gengo@v0.0.0-20200114144118-36b2048a9120/generator/execute.go:267 +0xb25
k8s.io/gengo/generator.(*Context).ExecutePackages(0xc0000cd730, 0xc000094150, 0x25, 0xc00198ef00, 0xc, 0x10, 0x8, 0x10)
        /go/pkg/mod/k8s.io/gengo@v0.0.0-20200114144118-36b2048a9120/generator/execute.go:51 +0xbf
k8s.io/code-generator/cmd/go-to-protobuf/protobuf.Run(0xc0000b06c0)
        /go/src/k8s.io/code-generator/cmd/go-to-protobuf/protobuf/cmd.go:236 +0x1185
main.main()
        /go/src/k8s.io/code-generator/cmd/go-to-protobuf/main.go:38 +0x84
```

This happens when the `Extras` field is nil.

```release-note
NONE
```

Reproducible with the following type definition:

```go
type Foo struct {
	metav1.TypeMeta `json:",inline"`
	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`

	Spec FooSpec `json:"spec" protobuf:"bytes,2,opt,name=spec"`
}

type AllocationList map[string]corev1.ResourceList

type FooSpec struct {
	Allocation AllocationList `json:"allocation,omitempty" protobuf:"bytes,1,rep,name=allocation"`
}
```