### PR TITLE
Fix staticcheck in test/integration/{garbagecollector,scheduler_perf}

### DIFF
--- a/hack/.staticcheck_failures
+++ b/hack/.staticcheck_failures
@@ -1,8 +1,6 @@
 cluster/images/etcd/migrate
 pkg/controller/replicaset
 pkg/kubelet/dockershim
-test/integration/garbagecollector
-test/integration/scheduler_perf
 vendor/k8s.io/apimachinery/pkg/api/apitesting/roundtrip
 vendor/k8s.io/apimachinery/pkg/apis/meta/v1/validation
 vendor/k8s.io/apimachinery/pkg/runtime/serializer/json

--- a/test/integration/garbagecollector/garbage_collector_test.go
+++ b/test/integration/garbagecollector/garbage_collector_test.go
@@ -598,6 +598,7 @@ func setupRCsPods(t *testing.T, gc *garbagecollector.GarbageCollector, clientSet
 	}
 	orphan := false
 	switch {
+	//lint:file-ignore SA1019 Keep testing deprecated OrphanDependents option until it's being removed
 	case options.OrphanDependents == nil && options.PropagationPolicy == nil && len(initialFinalizers) == 0:
 		// if there are no deletion options, the default policy for replication controllers is orphan
 		orphan = true
@@ -1024,12 +1025,7 @@ func TestBlockingOwnerRefDoesBlock(t *testing.T) {
 	// dependency graph before handling the foreground deletion of the rc.
 	ctx.startGC(5)
 	timeout := make(chan struct{})
-	go func() {
-		select {
-		case <-time.After(5 * time.Second):
-			close(timeout)
-		}
-	}()
+	time.AfterFunc(5*time.Second, func() { close(timeout) })
 	if !cache.WaitForCacheSync(timeout, gc.IsSynced) {
 		t.Fatalf("failed to wait for garbage collector to be synced")
 	}

--- a/test/integration/scheduler_perf/scheduler_perf_legacy_test.go
+++ b/test/integration/scheduler_perf/scheduler_perf_legacy_test.go
@@ -439,6 +439,7 @@ func benchmarkScheduling(numExistingPods, minPods int,
 	testPodStrategy testutils.TestPodCreateStrategy,
 	b *testing.B) {
 	if b.N < minPods {
+		//lint:ignore SA3001 Set a minimum for b.N to get more meaningful results
 		b.N = minPods
 	}
 	finalFunc, podInformer, clientset := mustSetupScheduler()
@@ -498,7 +499,7 @@ func benchmarkScheduling(numExistingPods, minPods int,
 	b.StopTimer()
 }
 
-// makeBasePodWithSecrets creates a Pod object to be used as a template.
+// makeBasePodWithSecret creates a Pod object to be used as a template.
 // The pod uses a single Secrets volume.
 func makeBasePodWithSecret() *v1.Pod {
 	basePod := &v1.Pod{


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup


**What this PR does / why we need it**:
PR cleans up the issues identified by staticcheck in `test/integration/garbagecollector` and `test/integration/scheduler_perf`:
```
test/integration/garbagecollector/garbage_collector_test.go:601:7: options.OrphanDependents is deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the "orphan" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both. +optional  (SA1019)
test/integration/garbagecollector/garbage_collector_test.go:604:7: options.OrphanDependents is deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the "orphan" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both. +optional  (SA1019)
test/integration/garbagecollector/garbage_collector_test.go:606:13: options.OrphanDependents is deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the "orphan" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both. +optional  (SA1019)
test/integration/scheduler_perf/scheduler_perf_legacy_test.go:442:3: should not assign to b.N (SA3001)
```

**Which issue(s) this PR fixes**:
Part of #92402

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
