### PR TITLE
fix static check for vendor/k8s.io/apiserver/pkg/storage/etcd3/

### DIFF
--- a/hack/.staticcheck_failures
+++ b/hack/.staticcheck_failures
@@ -32,7 +32,6 @@ vendor/k8s.io/apiserver/pkg/server/httplog
 vendor/k8s.io/apiserver/pkg/server/routes
 vendor/k8s.io/apiserver/pkg/storage
 vendor/k8s.io/apiserver/pkg/storage/cacher
-vendor/k8s.io/apiserver/pkg/storage/etcd3
 vendor/k8s.io/apiserver/pkg/storage/tests
 vendor/k8s.io/apiserver/pkg/storage/value/encrypt/envelope
 vendor/k8s.io/apiserver/pkg/util/webhook

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store_test.go
@@ -2078,7 +2078,6 @@ func Test_decodeContinue(t *testing.T) {
 
 func Test_growSlice(t *testing.T) {
 	type args struct {
-		t               reflect.Type
 		initialCapacity int
 		v               reflect.Value
 		maxCapacity     int


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
static check on vendor/k8s.io/apiserver/pkg/storage/etcd3/ part of #92402

**Does this PR introduce a user-facing change?**:
```release-note
None
```