### PR TITLE
fix typo of [expect] in pkg/kubelet/../policy_static_test.go

### DIFF
--- a/pkg/kubelet/cm/cpumanager/policy_static_test.go
+++ b/pkg/kubelet/cm/cpumanager/policy_static_test.go
@@ -419,7 +419,7 @@ func TestStaticPolicyAdd(t *testing.T) {
 		{
 			// Only 7 CPUs are available.
 			// Pod requests 76 cores.
-			// Error is expect since available CPUs are less than the request.
+			// Error is expected since available CPUs are less than the request.
 			description: "GuPodMultipleCores, topoQuadSocketFourWayHT, NoAlloc",
 			topo:        topoQuadSocketFourWayHT,
 			stAssignments: state.ContainerCPUAssignments{


### PR DESCRIPTION
What type of PR is this?
/kind cleanup

What this PR does / why we need it:
fix typo of [expect] in pkg/kubelet/cm/cpumanager/policy_static_test.go

Which issue(s) this PR fixes:

Fixes #

Special notes for your reviewer:

Does this PR introduce a user-facing change?:

```release-note
NONE
```
Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.: