### PR TITLE
Remove invalid env test of kubectl debug

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/debug/debug_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/debug/debug_test.go
@@ -1200,11 +1200,6 @@ func TestCompleteAndValidate(t *testing.T) {
 			wantError: true,
 		},
 		{
-			name:      "Invalid environment variables",
-			args:      "--image=busybox --env=FOO mypod",
-			wantError: true,
-		},
-		{
 			name:      "Invalid image name",
 			args:      "--image=image:label@deadbeef mypod",
 			wantError: true,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
Unit test for debug.go print:
```
Error: invalid argument "FOO" for "--env" flag: FOO must be formatted as key=value
Usage:
   [flags]

Flags:
      --arguments-only             If specified, everything after -- will be passed to the new container as Args instead of Command.
      --attach                     If true, wait for the container to start running, and then attach as if 'kubectl attach ...' were called.  Default false, unless '-i/--stdin' is set, in which case the default is true.
  -c, --container string           Container name to use for debug container.
      --copy-to string             Create a copy of the target Pod with this name.
      --env stringToString         Environment variables to set in the container. (default [])
  -h, --help                       help for this command
      --image string               Container image to use for debug container.
      --image-pull-policy string   The image pull policy for the container. If left empty, this value will not be specified by the client and defaulted by the server.
      --quiet                      If true, suppress informational messages.
      --replace                    When used with '--copy-to', delete the original Pod.
      --same-node                  When used with '--copy-to', schedule the copy of target Pod on the same node.
      --set-image stringToString   When used with '--copy-to', a list of name=image pairs for changing container images, similar to how 'kubectl set image' works. (default [])
      --share-processes            When used with '--copy-to', enable process namespace sharing in the copy. (default true)
  -i, --stdin                      Keep stdin open on the container(s) in the pod, even if nothing is attached.
      --target string              When using an ephemeral container, target processes in this container name.
  -t, --tty                        Allocate a TTY for the debugging container.

PASS
ok      k8s.io/kubectl/pkg/cmd/debug    0.062s
```

Since the flag format validate is done by spf13 package, maybe we should remove the env flag test.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
