### PR TITLE
adding windows os selector to the dnsPolicy tests

### DIFF
--- a/test/e2e/windows/dns.go
+++ b/test/e2e/windows/dns.go
@@ -30,7 +30,7 @@ import (
 	"github.com/onsi/ginkgo"
 )
 
-var _ = SIGDescribe("DNS", func() {
+var _ = SIGDescribe("[Feature:Windows] DNS", func() {
 
 	ginkgo.BeforeEach(func() {
 		e2eskipper.SkipUnlessNodeOSDistroIs("windows")
@@ -49,6 +49,9 @@ var _ = SIGDescribe("DNS", func() {
 		testUtilsPod.Spec.DNSConfig = &v1.PodDNSConfig{
 			Nameservers: []string{testInjectedIP},
 			Searches:    []string{testSearchPath},
+		}
+		testUtilsPod.Spec.NodeSelector = map[string]string{
+			"kubernetes.io/os": "windows",
 		}
 		testUtilsPod, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(context.TODO(), testUtilsPod, metav1.CreateOptions{})
 		framework.ExpectNoError(err)


### PR DESCRIPTION
**What type of PR is this?**

Adding node selectors to our DNS pod tests for windows 
fixes #97805 

**What this PR does / why we need it**:

E2e behaves unpredictably to pods are submitted with out this metadata, because even if a pod lands on a windows node due to a taint, some admission controllers might require this value to be set.  Example here is EKS, where the CNI is dependent on the admission controllers ability to recognize the OS of a pod.  

**Which issue(s) this PR fixes**:

Mediates issues such as https://github.com/aws/containers-roadmap/issues/463 , havent filed an upstream issue because this is a relatively small fix.  

```release-note
none
```

