### PR TITLE
kubectl/pkg/cmd/describe: cache describers to reuse clients

### DIFF
--- a/staging/src/k8s.io/kubectl/go.mod
+++ b/staging/src/k8s.io/kubectl/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/fvbommel/sortorder v1.0.1
 	github.com/golangplus/testing v0.0.0-20180327235837-af21d9c3145e // indirect
 	github.com/google/go-cmp v0.5.5
+	github.com/google/gofuzz v1.1.0
 	github.com/googleapis/gnostic v0.5.5
 	github.com/jonboulle/clockwork v0.2.2
 	github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de

--- a/staging/src/k8s.io/kubectl/pkg/cmd/describe/describer_cache.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/describe/describer_cache.go
@@ -1,0 +1,58 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package describe
+
+import (
+	"github.com/davecgh/go-spew/spew"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/kubectl/pkg/describe"
+)
+
+// describerCache can map from a meta.RESTMapping to a describe.ResourceDescriber.
+//
+// As of right now, this does not need to be synced since it is function-local, but
+// it certainly could be updated to be thread-safe in the future.
+type describerCache struct {
+	cache map[string]describe.ResourceDescriber
+}
+
+func newDescriberCache() *describerCache {
+	return &describerCache{cache: make(map[string]describe.ResourceDescriber)}
+}
+
+func (d *describerCache) key(mapping *meta.RESTMapping) string {
+	key := struct {
+		gvr   schema.GroupVersionResource
+		gvk   schema.GroupVersionKind
+		scope string
+	}{
+		gvr:   mapping.Resource,
+		gvk:   mapping.GroupVersionKind,
+		scope: string(mapping.Scope.Name()),
+	}
+	return (&spew.ConfigState{DisableMethods: true, Indent: " "}).Sprint(key)
+}
+
+func (d *describerCache) get(mapping *meta.RESTMapping) describe.ResourceDescriber {
+	return d.cache[d.key(mapping)]
+}
+
+func (d *describerCache) put(mapping *meta.RESTMapping, describer describe.ResourceDescriber) {
+	d.cache[d.key(mapping)] = describer
+}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/describe/describer_cache_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/describe/describer_cache_test.go
@@ -1,0 +1,166 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package describe
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	fuzz "github.com/google/gofuzz"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/kubectl/pkg/describe"
+)
+
+type fakeDescriber struct {
+	name string
+	describe.ResourceDescriber
+}
+
+func (d fakeDescriber) String() string { return fmt.Sprintf("fakeDescriber{%s}", d.name) }
+
+type fakeScope string
+
+func (s fakeScope) Name() meta.RESTScopeName { return meta.RESTScopeName(s) }
+
+var (
+	podDescriber = fakeDescriber{name: "pods"}
+	podMapping   = &meta.RESTMapping{
+		Resource: schema.GroupVersionResource{
+			Group:    "",
+			Version:  "v1",
+			Resource: "pods",
+		},
+		GroupVersionKind: schema.GroupVersionKind{
+			Group:   "",
+			Version: "v1",
+			Kind:    "Pod",
+		},
+		Scope: meta.RESTScopeNamespace,
+	}
+
+	ingressv1beta1Describer = fakeDescriber{name: "ingressv1beta1"}
+	ingressv1beta1Mapping   = &meta.RESTMapping{
+		Resource: schema.GroupVersionResource{
+			Group:    "networking.k8s.io",
+			Version:  "v1beta1",
+			Resource: "ingresses",
+		},
+		GroupVersionKind: schema.GroupVersionKind{
+			Group:   "networking.k8s.io",
+			Version: "v1beta1",
+			Kind:    "Ingress",
+		},
+		Scope: meta.RESTScopeNamespace,
+	}
+
+	ingressv1Describer = fakeDescriber{name: "ingressv1"}
+	ingressv1Mapping   = &meta.RESTMapping{
+		Resource: schema.GroupVersionResource{
+			Group:    "networking.k8s.io",
+			Version:  "v1",
+			Resource: "ingresses",
+		},
+		GroupVersionKind: schema.GroupVersionKind{
+			Group:   "networking.k8s.io",
+			Version: "v1",
+			Kind:    "Ingress",
+		},
+		Scope: meta.RESTScopeNamespace,
+	}
+
+	namespaceDescriber = fakeDescriber{name: "namespace"}
+	namespaceMapping   = &meta.RESTMapping{
+		Resource: schema.GroupVersionResource{
+			Group:    "",
+			Version:  "v1",
+			Resource: "namespaces",
+		},
+		GroupVersionKind: schema.GroupVersionKind{
+			Group:   "",
+			Version: "v1",
+			Kind:    "Namespace",
+		},
+		Scope: meta.RESTScopeRoot,
+	}
+)
+
+func TestDescriberCache(t *testing.T) {
+	t.Parallel()
+
+	dc := newDescriberCache()
+	dc.put(podMapping, podDescriber)
+	dc.put(ingressv1beta1Mapping, ingressv1beta1Describer)
+	assertCacheGet(t, dc, podMapping, podDescriber)
+	assertCacheGet(t, dc, ingressv1beta1Mapping, ingressv1beta1Describer)
+	assertCacheGet(t, dc, ingressv1Mapping, nil)
+	assertCacheGet(t, dc, namespaceMapping, nil)
+
+	dc.put(ingressv1Mapping, ingressv1Describer)
+	dc.put(namespaceMapping, namespaceDescriber)
+	assertCacheGet(t, dc, podMapping, podDescriber)
+	assertCacheGet(t, dc, ingressv1beta1Mapping, ingressv1beta1Describer)
+	assertCacheGet(t, dc, ingressv1Mapping, ingressv1Describer)
+	assertCacheGet(t, dc, namespaceMapping, namespaceDescriber)
+}
+
+// TestDescriberCacheKey attempts to serve as a reminder to update the describer cache key
+// contents if a new field is added to meta.RESTMapping.
+func TestDescriberCacheKey(t *testing.T) {
+	t.Parallel()
+
+	f := fuzz.New().NilChance(0).Funcs(
+		func(s *meta.RESTScope, f fuzz.Continue) {
+			var scope string
+			f.Fuzz(&scope)
+			*s = fakeScope(scope)
+		},
+	)
+	for i := 0; i < 100; i++ {
+		actual := meta.RESTMapping{}
+		f.Fuzz(&actual)
+
+		// Set fields that we are using in the cache key. If new fields are added to meta.RESTMapping,
+		// then we should most likely add them to the cache key and here as well.
+		actual.Resource = podMapping.Resource
+		actual.GroupVersionKind = podMapping.GroupVersionKind
+		actual.Scope = podMapping.Scope
+
+		expected := *podMapping
+		cmpScope := func(a, b meta.RESTScope) bool {
+			return a.Name() == b.Name()
+		}
+		if diff := cmp.Diff(actual, expected, cmp.Comparer(cmpScope)); diff != "" {
+			t.Fatalf("we are missing some RESTMapping fields from our cache key, -got, +want:\n %s", diff)
+		}
+	}
+}
+
+func assertCacheGet(
+	t *testing.T,
+	dc *describerCache,
+	mapping *meta.RESTMapping,
+	want describe.ResourceDescriber,
+) {
+	t.Helper()
+	got := dc.get(mapping)
+	if want != got {
+		t.Errorf("mapping %#v returned %s, wanted %s", mapping, got, want)
+	}
+}


### PR DESCRIPTION
Signed-off-by: Andrew Keesler <akeesler@vmware.com>

/sig cli

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

- Previously, during `kubectl describe`, we were creating a `kubernetes.Clientset` per object to describe, which is unnecessary.
- See https://github.com/kubernetes/kubernetes/issues/91913#issuecomment-646291219 for numerical evidence.

**Which issue(s) this PR fixes**:

(Partially) fixes #91913.

**Special notes for your reviewer**:

- Read https://github.com/kubernetes/kubernetes/issues/91913#issuecomment-646291219 and onward to learn the backstory for this issue.

- This bug is related to the client-go credential plugin feature set, which is tracked here: https://github.com/kubernetes/enhancements/issues/541.
- The feature set is currently in beta, and we want to get it to GA, which involves tackling the related bugs.
- See https://github.com/kubernetes/kubernetes/issues/91913#issuecomment-646291219 and onward for why this bug is related to the client-go credential plugin feature set.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
