### PR TITLE
remove windows proxy DNS mangling

### DIFF
--- a/pkg/proxy/winuserspace/BUILD
+++ b/pkg/proxy/winuserspace/BUILD
@@ -21,16 +21,13 @@ go_library(
         "//pkg/proxy:go_default_library",
         "//pkg/proxy/config:go_default_library",
         "//pkg/proxy/util:go_default_library",
-        "//pkg/util/ipconfig:go_default_library",
         "//pkg/util/netsh:go_default_library",
         "//pkg/util/slice:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/net:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/runtime:go_default_library",
-        "//vendor/github.com/miekg/dns:go_default_library",
         "//vendor/k8s.io/klog/v2:go_default_library",
-        "//vendor/k8s.io/utils/exec:go_default_library",
     ],
 )
 

--- a/pkg/proxy/winuserspace/proxier.go
+++ b/pkg/proxy/winuserspace/proxier.go
@@ -52,7 +52,6 @@ type serviceInfo struct {
 	socket              proxySocket
 	timeout             time.Duration
 	activeClients       *clientCache
-	dnsClients          *dnsClientCache
 	sessionAffinityType v1.ServiceAffinity
 }
 
@@ -237,7 +236,6 @@ func (proxier *Proxier) addServicePortPortal(servicePortPortalName ServicePortPo
 		socket:              sock,
 		timeout:             timeout,
 		activeClients:       newClientCache(),
-		dnsClients:          newDNSClientCache(),
 		sessionAffinityType: v1.ServiceAffinityNone, // default
 	}
 	proxier.setServiceInfo(servicePortPortalName, si)


### PR DESCRIPTION

**What type of PR is this?**

/kind cleanup
/sig windows
/sig network

**What this PR does / why we need it**:

Windows user-space kube-proxy has implemented an "unclear" DNS client/manipulation in https://github.com/kubernetes/kubernetes/pull/45642#issuecomment-302310656

However, the discussion in the PR doesn't reach a conclusion neither explain clearly why this is needed.

The code makes use of some hardcoded functions that are not part of kubernetes, it seems to have some "special DNS  services"   when the portName = dns.
```go
// Kubernetes DNS service port name
	dnsPortName = "dns"
...

func isDNSService(portName string) bool {
	return portName == dnsPortName
}
```

It also have a hardcoded dns domain, that suggest this only work for testing environment
```go
	// Kubernetes cluster domain
	clusterDomain = "cluster.local"
```

If this code is just for testing some special feature and is not used in production, it should not be in the official repo, it also allow us to drop one dependency.

xref: https://github.com/kubernetes/kubernetes/pull/97405

```release-note
NONE
```

