### PR TITLE
add metrics for insecure backend proxy

### DIFF
--- a/pkg/registry/core/pod/rest/BUILD
+++ b/pkg/registry/core/pod/rest/BUILD
@@ -10,6 +10,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "log.go",
+        "metrics.go",
         "subresources.go",
     ],
     importpath = "k8s.io/kubernetes/pkg/registry/core/pod/rest",
@@ -25,11 +26,14 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/net:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/proxy:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/runtime:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/features:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/registry/generic/registry:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/registry/generic/rest:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/registry/rest:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",
+        "//staging/src/k8s.io/component-base/metrics:go_default_library",
+        "//staging/src/k8s.io/component-base/metrics/legacyregistry:go_default_library",
     ],
 )
 

--- a/pkg/registry/core/pod/rest/metrics.go
+++ b/pkg/registry/core/pod/rest/metrics.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rest
+
+import (
+	"sync"
+
+	"k8s.io/component-base/metrics"
+	"k8s.io/component-base/metrics/legacyregistry"
+)
+
+const (
+	namespace = "kube_apiserver"
+	subsystem = "pod_logs"
+
+	usageEnforce     = "enforce_tls"
+	usageSkipAllowed = "skip_tls_allowed"
+	usageSkipDenied  = "skip_tls_denied"
+)
+
+var (
+	// podLogsUsage counts and categorizes how the insecure backend skip TLS option is used and allowed.
+	podLogsUsage = metrics.NewCounterVec(
+		&metrics.CounterOpts{
+			Namespace:      namespace,
+			Subsystem:      subsystem,
+			Name:           "pods_logs_insecure_backend_total",
+			Help:           "Total number of requests for pods/logs sliced by usage type: enforce_tls, skip_tls_allowed, skip_tls_denied",
+			StabilityLevel: metrics.ALPHA,
+		},
+		[]string{"usage"},
+	)
+
+	// podLogsTLSFailure counts how many attempts to get pod logs fail on tls verification
+	podLogsTLSFailure = metrics.NewCounter(
+		&metrics.CounterOpts{
+			Namespace:      namespace,
+			Subsystem:      subsystem,
+			Name:           "pods_logs_backend_tls_failure_total",
+			Help:           "Total number of requests for pods/logs that failed due to kubelet server TLS verification",
+			StabilityLevel: metrics.ALPHA,
+		},
+	)
+)
+
+var registerMetricsOnce sync.Once
+
+func registerMetrics() {
+	registerMetricsOnce.Do(func() {
+		legacyregistry.MustRegister(podLogsUsage)
+		legacyregistry.MustRegister(podLogsTLSFailure)
+	})
+}


### PR DESCRIPTION
add metrics to measure usage and frequency of backend tls failures on pod/logs calls.

/priority important-soon
/kind cleanup
@kubernetes/sig-auth-pr-reviews 

```release-note
NONE
```