### PR TITLE
prevent panic on webhook authenticator and authorizer timeout before response

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/util/webhook/webhook_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/webhook/webhook_test.go
@@ -711,6 +711,33 @@ func TestWithExponentialBackoffWebhookErrorIsMostImportant(t *testing.T) {
 	}
 }
 
+func TestWithExponentialBackoffWithRetryExhaustedWhileContextIsNotCanceled(t *testing.T) {
+	alwaysRetry := func(e error) bool {
+		return true
+	}
+
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
+
+	attemptsGot := 0
+	errExpected := errors.New("webhook not available")
+	webhookFunc := func() error {
+		attemptsGot++
+		return errExpected
+	}
+
+	// webhook err has higher priority than ctx error. we expect the webhook error to be returned.
+	retryBackoff := wait.Backoff{Steps: 5}
+	err := WithExponentialBackoff(ctx, retryBackoff, webhookFunc, alwaysRetry)
+
+	if attemptsGot != 5 {
+		t.Errorf("expected %d webhook attempts, but got: %d", 1, attemptsGot)
+	}
+	if errExpected != err {
+		t.Errorf("expected error: %v, but got: %v", errExpected, err)
+	}
+}
+
 func TestWithExponentialBackoffParametersNotSet(t *testing.T) {
 	alwaysRetry := func(e error) bool {
 		return true


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:
`webhook.WithExponentialBackoff` returns an error, and the priority is:
- A: if the last invocation of the webhook function returned an error, that error should be returned, otherwise
- B: the error associated with the context if it has been canceled or it has expired; or the `ErrWaitTimeout` returned by the apimachinery `wait` package once all retries have been exhausted.

caller should check the error returned by `webhook.WithExponentialBackoff` to handle both `A` and `B`. Currently, we only handle `A`.

Since we don't handle `A`, a panic results in the `authorizer` and the `authenticator`:
- authenticator: https://github.com/kubernetes/kubernetes/blob/cc09a6df5805574394e2eff285756d2886b34805/staging/src/k8s.io/apiserver/plugin/pkg/authenticator/token/webhook/webhook.go#L122
- authorizer: https://github.com/kubernetes/kubernetes/blob/v1.20.0/staging/src/k8s.io/apiserver/plugin/pkg/authorizer/webhook/webhook.go#L208

`result` will be `nil` since the retriable webhook function has never executed due to `B`.  

This PR ensures that we handle both `A` and `B` 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs

```
