### PR TITLE
WIP - allow reusing a restclient for multiple group versions

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/clientset/versioned/BUILD
+++ b/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/clientset/versioned/BUILD
@@ -10,6 +10,7 @@ go_library(
     importpath = "k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/clientset/versioned",
     visibility = ["//visibility:public"],
     deps = [
+        "//staging/src/k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/clientset/versioned/scheme:go_default_library",
         "//staging/src/k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/clientset/versioned/typed/cr/v1:go_default_library",
         "//staging/src/k8s.io/client-go/discovery:go_default_library",
         "//staging/src/k8s.io/client-go/rest:go_default_library",

--- a/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/clientset/versioned/typed/cr/v1/cr_client.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/clientset/versioned/typed/cr/v1/cr_client.go
@@ -19,7 +19,6 @@ limitations under the License.
 package v1
 
 import (
-	v1 "k8s.io/apiextensions-apiserver/examples/client-go/pkg/apis/cr/v1"
 	"k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/clientset/versioned/scheme"
 	rest "k8s.io/client-go/rest"
 )
@@ -67,11 +66,9 @@ func New(c rest.Interface) *CrV1Client {
 }
 
 func setConfigDefaults(config *rest.Config) error {
-	gv := v1.SchemeGroupVersion
-	config.GroupVersion = &gv
-	config.APIPath = "/apis"
-	config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
-
+	if config.NegotiatedSerializer == nil {
+		config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
+	}
 	if config.UserAgent == "" {
 		config.UserAgent = rest.DefaultKubernetesUserAgent()
 	}

--- a/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/clientset/versioned/typed/cr/v1/example.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/clientset/versioned/typed/cr/v1/example.go
@@ -85,6 +85,8 @@ func (c *examples) List(ctx context.Context, opts metav1.ListOptions) (result *v
 	result = &v1.ExampleList{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		Prefix("/apis", "cr.example.apiextensions.k8s.io", "v1").
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("examples").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/BUILD
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/BUILD
@@ -14,6 +14,7 @@ go_library(
     importmap = "k8s.io/kubernetes/vendor/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset",
     importpath = "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset",
     deps = [
+        "//staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/scheme:go_default_library",
         "//staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1:go_default_library",
         "//staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1:go_default_library",
         "//staging/src/k8s.io/client-go/discovery:go_default_library",

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/clientset.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/clientset.go
@@ -21,6 +21,7 @@ package clientset
 import (
 	"fmt"
 
+	"k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/scheme"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1"
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1"
 	discovery "k8s.io/client-go/discovery"
@@ -71,21 +72,19 @@ func NewForConfig(c *rest.Config) (*Clientset, error) {
 		}
 		configShallowCopy.RateLimiter = flowcontrol.NewTokenBucketRateLimiter(configShallowCopy.QPS, configShallowCopy.Burst)
 	}
-	var cs Clientset
-	var err error
-	cs.apiextensionsV1beta1, err = apiextensionsv1beta1.NewForConfig(&configShallowCopy)
-	if err != nil {
+	if err := setConfigDefaults(&configShallowCopy); err != nil {
 		return nil, err
 	}
-	cs.apiextensionsV1, err = apiextensionsv1.NewForConfig(&configShallowCopy)
+	client, err := rest.RESTClientFor(&configShallowCopy)
 	if err != nil {
 		return nil, err
 	}
 
-	cs.DiscoveryClient, err = discovery.NewDiscoveryClientForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
+	var cs Clientset
+	cs.apiextensionsV1beta1 = apiextensionsv1beta1.New(client)
+	cs.apiextensionsV1 = apiextensionsv1.New(client)
+
+	cs.DiscoveryClient = discovery.NewDiscoveryClient(client)
 	return &cs, nil
 }
 
@@ -108,4 +107,15 @@ func New(c rest.Interface) *Clientset {
 
 	cs.DiscoveryClient = discovery.NewDiscoveryClient(c)
 	return &cs
+}
+
+func setConfigDefaults(config *rest.Config) error {
+	if config.NegotiatedSerializer == nil {
+		config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
+	}
+	if config.UserAgent == "" {
+		config.UserAgent = rest.DefaultKubernetesUserAgent()
+	}
+
+	return nil
 }

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1/apiextensions_client.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1/apiextensions_client.go
@@ -19,7 +19,6 @@ limitations under the License.
 package v1
 
 import (
-	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/scheme"
 	rest "k8s.io/client-go/rest"
 )
@@ -67,11 +66,9 @@ func New(c rest.Interface) *ApiextensionsV1Client {
 }
 
 func setConfigDefaults(config *rest.Config) error {
-	gv := v1.SchemeGroupVersion
-	config.GroupVersion = &gv
-	config.APIPath = "/apis"
-	config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
-
+	if config.NegotiatedSerializer == nil {
+		config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
+	}
 	if config.UserAgent == "" {
 		config.UserAgent = rest.DefaultKubernetesUserAgent()
 	}

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1/customresourcedefinition.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1/customresourcedefinition.go
@@ -82,6 +82,8 @@ func (c *customResourceDefinitions) List(ctx context.Context, opts metav1.ListOp
 	}
 	result = &v1.CustomResourceDefinitionList{}
 	err = c.client.Get().
+		Prefix("/apis", "apiextensions.k8s.io", "v1").
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("customresourcedefinitions").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1/apiextensions_client.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1/apiextensions_client.go
@@ -19,7 +19,6 @@ limitations under the License.
 package v1beta1
 
 import (
-	v1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/scheme"
 	rest "k8s.io/client-go/rest"
 )
@@ -67,11 +66,9 @@ func New(c rest.Interface) *ApiextensionsV1beta1Client {
 }
 
 func setConfigDefaults(config *rest.Config) error {
-	gv := v1beta1.SchemeGroupVersion
-	config.GroupVersion = &gv
-	config.APIPath = "/apis"
-	config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
-
+	if config.NegotiatedSerializer == nil {
+		config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
+	}
 	if config.UserAgent == "" {
 		config.UserAgent = rest.DefaultKubernetesUserAgent()
 	}

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1/customresourcedefinition.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1/customresourcedefinition.go
@@ -82,6 +82,8 @@ func (c *customResourceDefinitions) List(ctx context.Context, opts v1.ListOption
 	}
 	result = &v1beta1.CustomResourceDefinitionList{}
 	err = c.client.Get().
+		Prefix("/apis", "apiextensions.k8s.io", "v1beta1").
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("customresourcedefinitions").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).

--- a/staging/src/k8s.io/client-go/examples/out-of-cluster-client-configuration/BUILD
+++ b/staging/src/k8s.io/client-go/examples/out-of-cluster-client-configuration/BUILD
@@ -17,11 +17,11 @@ go_library(
     importmap = "k8s.io/kubernetes/vendor/k8s.io/client-go/examples/out-of-cluster-client-configuration",
     importpath = "k8s.io/client-go/examples/out-of-cluster-client-configuration",
     deps = [
-        "//staging/src/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes:go_default_library",
         "//staging/src/k8s.io/client-go/tools/clientcmd:go_default_library",
         "//staging/src/k8s.io/client-go/util/homedir:go_default_library",
+        "//vendor/k8s.io/klog/v2:go_default_library",
     ],
 )
 

--- a/staging/src/k8s.io/client-go/kubernetes/BUILD
+++ b/staging/src/k8s.io/client-go/kubernetes/BUILD
@@ -12,6 +12,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//staging/src/k8s.io/client-go/discovery:go_default_library",
+        "//staging/src/k8s.io/client-go/kubernetes/scheme:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1beta1:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/typed/apiserverinternal/v1alpha1:go_default_library",

--- a/staging/src/k8s.io/client-go/kubernetes/clientset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/clientset.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 
 	discovery "k8s.io/client-go/discovery"
+	"k8s.io/client-go/kubernetes/scheme"
 	admissionregistrationv1 "k8s.io/client-go/kubernetes/typed/admissionregistration/v1"
 	admissionregistrationv1beta1 "k8s.io/client-go/kubernetes/typed/admissionregistration/v1beta1"
 	internalv1alpha1 "k8s.io/client-go/kubernetes/typed/apiserverinternal/v1alpha1"
@@ -399,185 +400,60 @@ func NewForConfig(c *rest.Config) (*Clientset, error) {
 		}
 		configShallowCopy.RateLimiter = flowcontrol.NewTokenBucketRateLimiter(configShallowCopy.QPS, configShallowCopy.Burst)
 	}
-	var cs Clientset
-	var err error
-	cs.admissionregistrationV1, err = admissionregistrationv1.NewForConfig(&configShallowCopy)
-	if err != nil {
+	if err := setConfigDefaults(&configShallowCopy); err != nil {
 		return nil, err
 	}
-	cs.admissionregistrationV1beta1, err = admissionregistrationv1beta1.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
-	cs.internalV1alpha1, err = internalv1alpha1.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
-	cs.appsV1, err = appsv1.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
-	cs.appsV1beta1, err = appsv1beta1.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
-	cs.appsV1beta2, err = appsv1beta2.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
-	cs.authenticationV1, err = authenticationv1.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
-	cs.authenticationV1beta1, err = authenticationv1beta1.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
-	cs.authorizationV1, err = authorizationv1.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
-	cs.authorizationV1beta1, err = authorizationv1beta1.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
-	cs.autoscalingV1, err = autoscalingv1.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
-	cs.autoscalingV2beta1, err = autoscalingv2beta1.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
-	cs.autoscalingV2beta2, err = autoscalingv2beta2.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
-	cs.batchV1, err = batchv1.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
-	cs.batchV1beta1, err = batchv1beta1.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
-	cs.batchV2alpha1, err = batchv2alpha1.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
-	cs.certificatesV1, err = certificatesv1.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
-	cs.certificatesV1beta1, err = certificatesv1beta1.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
-	cs.coordinationV1beta1, err = coordinationv1beta1.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
-	cs.coordinationV1, err = coordinationv1.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
-	cs.coreV1, err = corev1.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
-	cs.discoveryV1alpha1, err = discoveryv1alpha1.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
-	cs.discoveryV1beta1, err = discoveryv1beta1.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
-	cs.eventsV1, err = eventsv1.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
-	cs.eventsV1beta1, err = eventsv1beta1.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
-	cs.extensionsV1beta1, err = extensionsv1beta1.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
-	cs.flowcontrolV1alpha1, err = flowcontrolv1alpha1.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
-	cs.flowcontrolV1beta1, err = flowcontrolv1beta1.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
-	cs.networkingV1, err = networkingv1.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
-	cs.networkingV1beta1, err = networkingv1beta1.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
-	cs.nodeV1, err = nodev1.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
-	cs.nodeV1alpha1, err = nodev1alpha1.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
-	cs.nodeV1beta1, err = nodev1beta1.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
-	cs.policyV1beta1, err = policyv1beta1.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
-	cs.rbacV1, err = rbacv1.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
-	cs.rbacV1beta1, err = rbacv1beta1.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
-	cs.rbacV1alpha1, err = rbacv1alpha1.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
-	cs.schedulingV1alpha1, err = schedulingv1alpha1.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
-	cs.schedulingV1beta1, err = schedulingv1beta1.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
-	cs.schedulingV1, err = schedulingv1.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
-	cs.storageV1beta1, err = storagev1beta1.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
-	cs.storageV1, err = storagev1.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
-	cs.storageV1alpha1, err = storagev1alpha1.NewForConfig(&configShallowCopy)
+	client, err := rest.RESTClientFor(&configShallowCopy)
 	if err != nil {
 		return nil, err
 	}
 
-	cs.DiscoveryClient, err = discovery.NewDiscoveryClientForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
+	var cs Clientset
+	cs.admissionregistrationV1 = admissionregistrationv1.New(client)
+	cs.admissionregistrationV1beta1 = admissionregistrationv1beta1.New(client)
+	cs.internalV1alpha1 = internalv1alpha1.New(client)
+	cs.appsV1 = appsv1.New(client)
+	cs.appsV1beta1 = appsv1beta1.New(client)
+	cs.appsV1beta2 = appsv1beta2.New(client)
+	cs.authenticationV1 = authenticationv1.New(client)
+	cs.authenticationV1beta1 = authenticationv1beta1.New(client)
+	cs.authorizationV1 = authorizationv1.New(client)
+	cs.authorizationV1beta1 = authorizationv1beta1.New(client)
+	cs.autoscalingV1 = autoscalingv1.New(client)
+	cs.autoscalingV2beta1 = autoscalingv2beta1.New(client)
+	cs.autoscalingV2beta2 = autoscalingv2beta2.New(client)
+	cs.batchV1 = batchv1.New(client)
+	cs.batchV1beta1 = batchv1beta1.New(client)
+	cs.batchV2alpha1 = batchv2alpha1.New(client)
+	cs.certificatesV1 = certificatesv1.New(client)
+	cs.certificatesV1beta1 = certificatesv1beta1.New(client)
+	cs.coordinationV1beta1 = coordinationv1beta1.New(client)
+	cs.coordinationV1 = coordinationv1.New(client)
+	cs.coreV1 = corev1.New(client)
+	cs.discoveryV1alpha1 = discoveryv1alpha1.New(client)
+	cs.discoveryV1beta1 = discoveryv1beta1.New(client)
+	cs.eventsV1 = eventsv1.New(client)
+	cs.eventsV1beta1 = eventsv1beta1.New(client)
+	cs.extensionsV1beta1 = extensionsv1beta1.New(client)
+	cs.flowcontrolV1alpha1 = flowcontrolv1alpha1.New(client)
+	cs.flowcontrolV1beta1 = flowcontrolv1beta1.New(client)
+	cs.networkingV1 = networkingv1.New(client)
+	cs.networkingV1beta1 = networkingv1beta1.New(client)
+	cs.nodeV1 = nodev1.New(client)
+	cs.nodeV1alpha1 = nodev1alpha1.New(client)
+	cs.nodeV1beta1 = nodev1beta1.New(client)
+	cs.policyV1beta1 = policyv1beta1.New(client)
+	cs.rbacV1 = rbacv1.New(client)
+	cs.rbacV1beta1 = rbacv1beta1.New(client)
+	cs.rbacV1alpha1 = rbacv1alpha1.New(client)
+	cs.schedulingV1alpha1 = schedulingv1alpha1.New(client)
+	cs.schedulingV1beta1 = schedulingv1beta1.New(client)
+	cs.schedulingV1 = schedulingv1.New(client)
+	cs.storageV1beta1 = storagev1beta1.New(client)
+	cs.storageV1 = storagev1.New(client)
+	cs.storageV1alpha1 = storagev1alpha1.New(client)
+
+	cs.DiscoveryClient = discovery.NewDiscoveryClient(client)
 	return &cs, nil
 }
 
@@ -682,4 +558,15 @@ func New(c rest.Interface) *Clientset {
 
 	cs.DiscoveryClient = discovery.NewDiscoveryClient(c)
 	return &cs
+}
+
+func setConfigDefaults(config *rest.Config) error {
+	if config.NegotiatedSerializer == nil {
+		config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
+	}
+	if config.UserAgent == "" {
+		config.UserAgent = rest.DefaultKubernetesUserAgent()
+	}
+
+	return nil
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1/admissionregistration_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1/admissionregistration_client.go
@@ -19,7 +19,6 @@ limitations under the License.
 package v1
 
 import (
-	v1 "k8s.io/api/admissionregistration/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
 )
@@ -72,11 +71,9 @@ func New(c rest.Interface) *AdmissionregistrationV1Client {
 }
 
 func setConfigDefaults(config *rest.Config) error {
-	gv := v1.SchemeGroupVersion
-	config.GroupVersion = &gv
-	config.APIPath = "/apis"
-	config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
-
+	if config.NegotiatedSerializer == nil {
+		config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
+	}
 	if config.UserAgent == "" {
 		config.UserAgent = rest.DefaultKubernetesUserAgent()
 	}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1/mutatingwebhookconfiguration.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1/mutatingwebhookconfiguration.go
@@ -81,6 +81,8 @@ func (c *mutatingWebhookConfigurations) List(ctx context.Context, opts metav1.Li
 	}
 	result = &v1.MutatingWebhookConfigurationList{}
 	err = c.client.Get().
+		Prefix("/apis", "admissionregistration.k8s.io", "v1").
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("mutatingwebhookconfigurations").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1/validatingwebhookconfiguration.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1/validatingwebhookconfiguration.go
@@ -81,6 +81,8 @@ func (c *validatingWebhookConfigurations) List(ctx context.Context, opts metav1.
 	}
 	result = &v1.ValidatingWebhookConfigurationList{}
 	err = c.client.Get().
+		Prefix("/apis", "admissionregistration.k8s.io", "v1").
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("validatingwebhookconfigurations").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1beta1/admissionregistration_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1beta1/admissionregistration_client.go
@@ -19,7 +19,6 @@ limitations under the License.
 package v1beta1
 
 import (
-	v1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
 )
@@ -72,11 +71,9 @@ func New(c rest.Interface) *AdmissionregistrationV1beta1Client {
 }
 
 func setConfigDefaults(config *rest.Config) error {
-	gv := v1beta1.SchemeGroupVersion
-	config.GroupVersion = &gv
-	config.APIPath = "/apis"
-	config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
-
+	if config.NegotiatedSerializer == nil {
+		config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
+	}
 	if config.UserAgent == "" {
 		config.UserAgent = rest.DefaultKubernetesUserAgent()
 	}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1beta1/mutatingwebhookconfiguration.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1beta1/mutatingwebhookconfiguration.go
@@ -81,6 +81,8 @@ func (c *mutatingWebhookConfigurations) List(ctx context.Context, opts v1.ListOp
 	}
 	result = &v1beta1.MutatingWebhookConfigurationList{}
 	err = c.client.Get().
+		Prefix("/apis", "admissionregistration.k8s.io", "v1beta1").
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("mutatingwebhookconfigurations").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1beta1/validatingwebhookconfiguration.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1beta1/validatingwebhookconfiguration.go
@@ -81,6 +81,8 @@ func (c *validatingWebhookConfigurations) List(ctx context.Context, opts v1.List
 	}
 	result = &v1beta1.ValidatingWebhookConfigurationList{}
 	err = c.client.Get().
+		Prefix("/apis", "admissionregistration.k8s.io", "v1beta1").
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("validatingwebhookconfigurations").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apiserverinternal/v1alpha1/apiserverinternal_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apiserverinternal/v1alpha1/apiserverinternal_client.go
@@ -19,7 +19,6 @@ limitations under the License.
 package v1alpha1
 
 import (
-	v1alpha1 "k8s.io/api/apiserverinternal/v1alpha1"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
 )
@@ -67,11 +66,9 @@ func New(c rest.Interface) *InternalV1alpha1Client {
 }
 
 func setConfigDefaults(config *rest.Config) error {
-	gv := v1alpha1.SchemeGroupVersion
-	config.GroupVersion = &gv
-	config.APIPath = "/apis"
-	config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
-
+	if config.NegotiatedSerializer == nil {
+		config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
+	}
 	if config.UserAgent == "" {
 		config.UserAgent = rest.DefaultKubernetesUserAgent()
 	}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apiserverinternal/v1alpha1/storageversion.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apiserverinternal/v1alpha1/storageversion.go
@@ -82,6 +82,8 @@ func (c *storageVersions) List(ctx context.Context, opts v1.ListOptions) (result
 	}
 	result = &v1alpha1.StorageVersionList{}
 	err = c.client.Get().
+		Prefix("/apis", "internal.apiserver.k8s.io", "v1alpha1").
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("storageversions").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/apps_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/apps_client.go
@@ -19,7 +19,6 @@ limitations under the License.
 package v1
 
 import (
-	v1 "k8s.io/api/apps/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
 )
@@ -87,11 +86,9 @@ func New(c rest.Interface) *AppsV1Client {
 }
 
 func setConfigDefaults(config *rest.Config) error {
-	gv := v1.SchemeGroupVersion
-	config.GroupVersion = &gv
-	config.APIPath = "/apis"
-	config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
-
+	if config.NegotiatedSerializer == nil {
+		config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
+	}
 	if config.UserAgent == "" {
 		config.UserAgent = rest.DefaultKubernetesUserAgent()
 	}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/controllerrevision.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/controllerrevision.go
@@ -85,6 +85,8 @@ func (c *controllerRevisions) List(ctx context.Context, opts metav1.ListOptions)
 	result = &v1.ControllerRevisionList{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		Prefix("/apis", "apps", "v1").
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("controllerrevisions").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/daemonset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/daemonset.go
@@ -86,6 +86,8 @@ func (c *daemonSets) List(ctx context.Context, opts metav1.ListOptions) (result 
 	result = &v1.DaemonSetList{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		Prefix("/apis", "apps", "v1").
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("daemonsets").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/deployment.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/deployment.go
@@ -90,6 +90,8 @@ func (c *deployments) List(ctx context.Context, opts metav1.ListOptions) (result
 	result = &v1.DeploymentList{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		Prefix("/apis", "apps", "v1").
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("deployments").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/replicaset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/replicaset.go
@@ -90,6 +90,8 @@ func (c *replicaSets) List(ctx context.Context, opts metav1.ListOptions) (result
 	result = &v1.ReplicaSetList{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		Prefix("/apis", "apps", "v1").
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("replicasets").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/statefulset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/statefulset.go
@@ -90,6 +90,8 @@ func (c *statefulSets) List(ctx context.Context, opts metav1.ListOptions) (resul
 	result = &v1.StatefulSetList{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		Prefix("/apis", "apps", "v1").
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("statefulsets").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta1/apps_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta1/apps_client.go
@@ -19,7 +19,6 @@ limitations under the License.
 package v1beta1
 
 import (
-	v1beta1 "k8s.io/api/apps/v1beta1"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
 )
@@ -77,11 +76,9 @@ func New(c rest.Interface) *AppsV1beta1Client {
 }
 
 func setConfigDefaults(config *rest.Config) error {
-	gv := v1beta1.SchemeGroupVersion
-	config.GroupVersion = &gv
-	config.APIPath = "/apis"
-	config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
-
+	if config.NegotiatedSerializer == nil {
+		config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
+	}
 	if config.UserAgent == "" {
 		config.UserAgent = rest.DefaultKubernetesUserAgent()
 	}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta1/controllerrevision.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta1/controllerrevision.go
@@ -85,6 +85,8 @@ func (c *controllerRevisions) List(ctx context.Context, opts v1.ListOptions) (re
 	result = &v1beta1.ControllerRevisionList{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		Prefix("/apis", "apps", "v1beta1").
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("controllerrevisions").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta1/deployment.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta1/deployment.go
@@ -86,6 +86,8 @@ func (c *deployments) List(ctx context.Context, opts v1.ListOptions) (result *v1
 	result = &v1beta1.DeploymentList{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		Prefix("/apis", "apps", "v1beta1").
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("deployments").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta1/statefulset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta1/statefulset.go
@@ -86,6 +86,8 @@ func (c *statefulSets) List(ctx context.Context, opts v1.ListOptions) (result *v
 	result = &v1beta1.StatefulSetList{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		Prefix("/apis", "apps", "v1beta1").
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("statefulsets").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/apps_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/apps_client.go
@@ -19,7 +19,6 @@ limitations under the License.
 package v1beta2
 
 import (
-	v1beta2 "k8s.io/api/apps/v1beta2"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
 )
@@ -87,11 +86,9 @@ func New(c rest.Interface) *AppsV1beta2Client {
 }
 
 func setConfigDefaults(config *rest.Config) error {
-	gv := v1beta2.SchemeGroupVersion
-	config.GroupVersion = &gv
-	config.APIPath = "/apis"
-	config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
-
+	if config.NegotiatedSerializer == nil {
+		config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
+	}
 	if config.UserAgent == "" {
 		config.UserAgent = rest.DefaultKubernetesUserAgent()
 	}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/controllerrevision.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/controllerrevision.go
@@ -85,6 +85,8 @@ func (c *controllerRevisions) List(ctx context.Context, opts v1.ListOptions) (re
 	result = &v1beta2.ControllerRevisionList{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		Prefix("/apis", "apps", "v1beta2").
+		GroupVersion(v1beta2.SchemeGroupVersion).
 		Resource("controllerrevisions").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/daemonset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/daemonset.go
@@ -86,6 +86,8 @@ func (c *daemonSets) List(ctx context.Context, opts v1.ListOptions) (result *v1b
 	result = &v1beta2.DaemonSetList{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		Prefix("/apis", "apps", "v1beta2").
+		GroupVersion(v1beta2.SchemeGroupVersion).
 		Resource("daemonsets").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/deployment.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/deployment.go
@@ -86,6 +86,8 @@ func (c *deployments) List(ctx context.Context, opts v1.ListOptions) (result *v1
 	result = &v1beta2.DeploymentList{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		Prefix("/apis", "apps", "v1beta2").
+		GroupVersion(v1beta2.SchemeGroupVersion).
 		Resource("deployments").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/replicaset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/replicaset.go
@@ -86,6 +86,8 @@ func (c *replicaSets) List(ctx context.Context, opts v1.ListOptions) (result *v1
 	result = &v1beta2.ReplicaSetList{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		Prefix("/apis", "apps", "v1beta2").
+		GroupVersion(v1beta2.SchemeGroupVersion).
 		Resource("replicasets").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/statefulset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/statefulset.go
@@ -89,6 +89,8 @@ func (c *statefulSets) List(ctx context.Context, opts v1.ListOptions) (result *v
 	result = &v1beta2.StatefulSetList{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		Prefix("/apis", "apps", "v1beta2").
+		GroupVersion(v1beta2.SchemeGroupVersion).
 		Resource("statefulsets").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/authentication/v1/authentication_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/authentication/v1/authentication_client.go
@@ -19,7 +19,6 @@ limitations under the License.
 package v1
 
 import (
-	v1 "k8s.io/api/authentication/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
 )
@@ -67,11 +66,9 @@ func New(c rest.Interface) *AuthenticationV1Client {
 }
 
 func setConfigDefaults(config *rest.Config) error {
-	gv := v1.SchemeGroupVersion
-	config.GroupVersion = &gv
-	config.APIPath = "/apis"
-	config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
-
+	if config.NegotiatedSerializer == nil {
+		config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
+	}
 	if config.UserAgent == "" {
 		config.UserAgent = rest.DefaultKubernetesUserAgent()
 	}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/authentication/v1beta1/authentication_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/authentication/v1beta1/authentication_client.go
@@ -19,7 +19,6 @@ limitations under the License.
 package v1beta1
 
 import (
-	v1beta1 "k8s.io/api/authentication/v1beta1"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
 )
@@ -67,11 +66,9 @@ func New(c rest.Interface) *AuthenticationV1beta1Client {
 }
 
 func setConfigDefaults(config *rest.Config) error {
-	gv := v1beta1.SchemeGroupVersion
-	config.GroupVersion = &gv
-	config.APIPath = "/apis"
-	config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
-
+	if config.NegotiatedSerializer == nil {
+		config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
+	}
 	if config.UserAgent == "" {
 		config.UserAgent = rest.DefaultKubernetesUserAgent()
 	}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/authorization/v1/authorization_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/authorization/v1/authorization_client.go
@@ -19,7 +19,6 @@ limitations under the License.
 package v1
 
 import (
-	v1 "k8s.io/api/authorization/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
 )
@@ -82,11 +81,9 @@ func New(c rest.Interface) *AuthorizationV1Client {
 }
 
 func setConfigDefaults(config *rest.Config) error {
-	gv := v1.SchemeGroupVersion
-	config.GroupVersion = &gv
-	config.APIPath = "/apis"
-	config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
-
+	if config.NegotiatedSerializer == nil {
+		config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
+	}
 	if config.UserAgent == "" {
 		config.UserAgent = rest.DefaultKubernetesUserAgent()
 	}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/authorization/v1beta1/authorization_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/authorization/v1beta1/authorization_client.go
@@ -19,7 +19,6 @@ limitations under the License.
 package v1beta1
 
 import (
-	v1beta1 "k8s.io/api/authorization/v1beta1"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
 )
@@ -82,11 +81,9 @@ func New(c rest.Interface) *AuthorizationV1beta1Client {
 }
 
 func setConfigDefaults(config *rest.Config) error {
-	gv := v1beta1.SchemeGroupVersion
-	config.GroupVersion = &gv
-	config.APIPath = "/apis"
-	config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
-
+	if config.NegotiatedSerializer == nil {
+		config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
+	}
 	if config.UserAgent == "" {
 		config.UserAgent = rest.DefaultKubernetesUserAgent()
 	}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v1/autoscaling_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v1/autoscaling_client.go
@@ -19,7 +19,6 @@ limitations under the License.
 package v1
 
 import (
-	v1 "k8s.io/api/autoscaling/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
 )
@@ -67,11 +66,9 @@ func New(c rest.Interface) *AutoscalingV1Client {
 }
 
 func setConfigDefaults(config *rest.Config) error {
-	gv := v1.SchemeGroupVersion
-	config.GroupVersion = &gv
-	config.APIPath = "/apis"
-	config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
-
+	if config.NegotiatedSerializer == nil {
+		config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
+	}
 	if config.UserAgent == "" {
 		config.UserAgent = rest.DefaultKubernetesUserAgent()
 	}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v1/horizontalpodautoscaler.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v1/horizontalpodautoscaler.go
@@ -86,6 +86,8 @@ func (c *horizontalPodAutoscalers) List(ctx context.Context, opts metav1.ListOpt
 	result = &v1.HorizontalPodAutoscalerList{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		Prefix("/apis", "autoscaling", "v1").
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("horizontalpodautoscalers").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v2beta1/autoscaling_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v2beta1/autoscaling_client.go
@@ -19,7 +19,6 @@ limitations under the License.
 package v2beta1
 
 import (
-	v2beta1 "k8s.io/api/autoscaling/v2beta1"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
 )
@@ -67,11 +66,9 @@ func New(c rest.Interface) *AutoscalingV2beta1Client {
 }
 
 func setConfigDefaults(config *rest.Config) error {
-	gv := v2beta1.SchemeGroupVersion
-	config.GroupVersion = &gv
-	config.APIPath = "/apis"
-	config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
-
+	if config.NegotiatedSerializer == nil {
+		config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
+	}
 	if config.UserAgent == "" {
 		config.UserAgent = rest.DefaultKubernetesUserAgent()
 	}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v2beta1/horizontalpodautoscaler.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v2beta1/horizontalpodautoscaler.go
@@ -86,6 +86,8 @@ func (c *horizontalPodAutoscalers) List(ctx context.Context, opts v1.ListOptions
 	result = &v2beta1.HorizontalPodAutoscalerList{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		Prefix("/apis", "autoscaling", "v2beta1").
+		GroupVersion(v2beta1.SchemeGroupVersion).
 		Resource("horizontalpodautoscalers").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v2beta2/autoscaling_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v2beta2/autoscaling_client.go
@@ -19,7 +19,6 @@ limitations under the License.
 package v2beta2
 
 import (
-	v2beta2 "k8s.io/api/autoscaling/v2beta2"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
 )
@@ -67,11 +66,9 @@ func New(c rest.Interface) *AutoscalingV2beta2Client {
 }
 
 func setConfigDefaults(config *rest.Config) error {
-	gv := v2beta2.SchemeGroupVersion
-	config.GroupVersion = &gv
-	config.APIPath = "/apis"
-	config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
-
+	if config.NegotiatedSerializer == nil {
+		config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
+	}
 	if config.UserAgent == "" {
 		config.UserAgent = rest.DefaultKubernetesUserAgent()
 	}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v2beta2/horizontalpodautoscaler.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v2beta2/horizontalpodautoscaler.go
@@ -86,6 +86,8 @@ func (c *horizontalPodAutoscalers) List(ctx context.Context, opts v1.ListOptions
 	result = &v2beta2.HorizontalPodAutoscalerList{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		Prefix("/apis", "autoscaling", "v2beta2").
+		GroupVersion(v2beta2.SchemeGroupVersion).
 		Resource("horizontalpodautoscalers").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/batch/v1/batch_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/batch/v1/batch_client.go
@@ -19,7 +19,6 @@ limitations under the License.
 package v1
 
 import (
-	v1 "k8s.io/api/batch/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
 )
@@ -67,11 +66,9 @@ func New(c rest.Interface) *BatchV1Client {
 }
 
 func setConfigDefaults(config *rest.Config) error {
-	gv := v1.SchemeGroupVersion
-	config.GroupVersion = &gv
-	config.APIPath = "/apis"
-	config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
-
+	if config.NegotiatedSerializer == nil {
+		config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
+	}
 	if config.UserAgent == "" {
 		config.UserAgent = rest.DefaultKubernetesUserAgent()
 	}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/batch/v1/job.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/batch/v1/job.go
@@ -86,6 +86,8 @@ func (c *jobs) List(ctx context.Context, opts metav1.ListOptions) (result *v1.Jo
 	result = &v1.JobList{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		Prefix("/apis", "batch", "v1").
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("jobs").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/batch/v1beta1/batch_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/batch/v1beta1/batch_client.go
@@ -19,7 +19,6 @@ limitations under the License.
 package v1beta1
 
 import (
-	v1beta1 "k8s.io/api/batch/v1beta1"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
 )
@@ -67,11 +66,9 @@ func New(c rest.Interface) *BatchV1beta1Client {
 }
 
 func setConfigDefaults(config *rest.Config) error {
-	gv := v1beta1.SchemeGroupVersion
-	config.GroupVersion = &gv
-	config.APIPath = "/apis"
-	config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
-
+	if config.NegotiatedSerializer == nil {
+		config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
+	}
 	if config.UserAgent == "" {
 		config.UserAgent = rest.DefaultKubernetesUserAgent()
 	}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/batch/v1beta1/cronjob.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/batch/v1beta1/cronjob.go
@@ -86,6 +86,8 @@ func (c *cronJobs) List(ctx context.Context, opts v1.ListOptions) (result *v1bet
 	result = &v1beta1.CronJobList{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		Prefix("/apis", "batch", "v1beta1").
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("cronjobs").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/batch/v2alpha1/batch_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/batch/v2alpha1/batch_client.go
@@ -19,7 +19,6 @@ limitations under the License.
 package v2alpha1
 
 import (
-	v2alpha1 "k8s.io/api/batch/v2alpha1"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
 )
@@ -67,11 +66,9 @@ func New(c rest.Interface) *BatchV2alpha1Client {
 }
 
 func setConfigDefaults(config *rest.Config) error {
-	gv := v2alpha1.SchemeGroupVersion
-	config.GroupVersion = &gv
-	config.APIPath = "/apis"
-	config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
-
+	if config.NegotiatedSerializer == nil {
+		config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
+	}
 	if config.UserAgent == "" {
 		config.UserAgent = rest.DefaultKubernetesUserAgent()
 	}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/batch/v2alpha1/cronjob.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/batch/v2alpha1/cronjob.go
@@ -86,6 +86,8 @@ func (c *cronJobs) List(ctx context.Context, opts v1.ListOptions) (result *v2alp
 	result = &v2alpha1.CronJobList{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		Prefix("/apis", "batch", "v2alpha1").
+		GroupVersion(v2alpha1.SchemeGroupVersion).
 		Resource("cronjobs").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/certificates/v1/certificates_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/certificates/v1/certificates_client.go
@@ -19,7 +19,6 @@ limitations under the License.
 package v1
 
 import (
-	v1 "k8s.io/api/certificates/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
 )
@@ -67,11 +66,9 @@ func New(c rest.Interface) *CertificatesV1Client {
 }
 
 func setConfigDefaults(config *rest.Config) error {
-	gv := v1.SchemeGroupVersion
-	config.GroupVersion = &gv
-	config.APIPath = "/apis"
-	config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
-
+	if config.NegotiatedSerializer == nil {
+		config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
+	}
 	if config.UserAgent == "" {
 		config.UserAgent = rest.DefaultKubernetesUserAgent()
 	}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/certificates/v1/certificatesigningrequest.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/certificates/v1/certificatesigningrequest.go
@@ -84,6 +84,8 @@ func (c *certificateSigningRequests) List(ctx context.Context, opts metav1.ListO
 	}
 	result = &v1.CertificateSigningRequestList{}
 	err = c.client.Get().
+		Prefix("/apis", "certificates.k8s.io", "v1").
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("certificatesigningrequests").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/certificates/v1beta1/certificates_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/certificates/v1beta1/certificates_client.go
@@ -19,7 +19,6 @@ limitations under the License.
 package v1beta1
 
 import (
-	v1beta1 "k8s.io/api/certificates/v1beta1"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
 )
@@ -67,11 +66,9 @@ func New(c rest.Interface) *CertificatesV1beta1Client {
 }
 
 func setConfigDefaults(config *rest.Config) error {
-	gv := v1beta1.SchemeGroupVersion
-	config.GroupVersion = &gv
-	config.APIPath = "/apis"
-	config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
-
+	if config.NegotiatedSerializer == nil {
+		config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
+	}
 	if config.UserAgent == "" {
 		config.UserAgent = rest.DefaultKubernetesUserAgent()
 	}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/certificates/v1beta1/certificatesigningrequest.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/certificates/v1beta1/certificatesigningrequest.go
@@ -82,6 +82,8 @@ func (c *certificateSigningRequests) List(ctx context.Context, opts v1.ListOptio
 	}
 	result = &v1beta1.CertificateSigningRequestList{}
 	err = c.client.Get().
+		Prefix("/apis", "certificates.k8s.io", "v1beta1").
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("certificatesigningrequests").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/coordination/v1/coordination_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/coordination/v1/coordination_client.go
@@ -19,7 +19,6 @@ limitations under the License.
 package v1
 
 import (
-	v1 "k8s.io/api/coordination/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
 )
@@ -67,11 +66,9 @@ func New(c rest.Interface) *CoordinationV1Client {
 }
 
 func setConfigDefaults(config *rest.Config) error {
-	gv := v1.SchemeGroupVersion
-	config.GroupVersion = &gv
-	config.APIPath = "/apis"
-	config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
-
+	if config.NegotiatedSerializer == nil {
+		config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
+	}
 	if config.UserAgent == "" {
 		config.UserAgent = rest.DefaultKubernetesUserAgent()
 	}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/coordination/v1/lease.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/coordination/v1/lease.go
@@ -85,6 +85,8 @@ func (c *leases) List(ctx context.Context, opts metav1.ListOptions) (result *v1.
 	result = &v1.LeaseList{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		Prefix("/apis", "coordination.k8s.io", "v1").
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("leases").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/coordination/v1beta1/coordination_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/coordination/v1beta1/coordination_client.go
@@ -19,7 +19,6 @@ limitations under the License.
 package v1beta1
 
 import (
-	v1beta1 "k8s.io/api/coordination/v1beta1"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
 )
@@ -67,11 +66,9 @@ func New(c rest.Interface) *CoordinationV1beta1Client {
 }
 
 func setConfigDefaults(config *rest.Config) error {
-	gv := v1beta1.SchemeGroupVersion
-	config.GroupVersion = &gv
-	config.APIPath = "/apis"
-	config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
-
+	if config.NegotiatedSerializer == nil {
+		config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
+	}
 	if config.UserAgent == "" {
 		config.UserAgent = rest.DefaultKubernetesUserAgent()
 	}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/coordination/v1beta1/lease.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/coordination/v1beta1/lease.go
@@ -85,6 +85,8 @@ func (c *leases) List(ctx context.Context, opts v1.ListOptions) (result *v1beta1
 	result = &v1beta1.LeaseList{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		Prefix("/apis", "coordination.k8s.io", "v1beta1").
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("leases").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/componentstatus.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/componentstatus.go
@@ -81,6 +81,8 @@ func (c *componentStatuses) List(ctx context.Context, opts metav1.ListOptions) (
 	}
 	result = &v1.ComponentStatusList{}
 	err = c.client.Get().
+		Prefix("/apis", "core", "v1").
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("componentstatuses").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/configmap.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/configmap.go
@@ -85,6 +85,8 @@ func (c *configMaps) List(ctx context.Context, opts metav1.ListOptions) (result 
 	result = &v1.ConfigMapList{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		Prefix("/apis", "core", "v1").
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("configmaps").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/core_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/core_client.go
@@ -19,7 +19,6 @@ limitations under the License.
 package v1
 
 import (
-	v1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
 )
@@ -142,11 +141,9 @@ func New(c rest.Interface) *CoreV1Client {
 }
 
 func setConfigDefaults(config *rest.Config) error {
-	gv := v1.SchemeGroupVersion
-	config.GroupVersion = &gv
-	config.APIPath = "/api"
-	config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
-
+	if config.NegotiatedSerializer == nil {
+		config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
+	}
 	if config.UserAgent == "" {
 		config.UserAgent = rest.DefaultKubernetesUserAgent()
 	}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/endpoints.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/endpoints.go
@@ -85,6 +85,8 @@ func (c *endpoints) List(ctx context.Context, opts metav1.ListOptions) (result *
 	result = &v1.EndpointsList{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		Prefix("/apis", "core", "v1").
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("endpoints").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/event.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/event.go
@@ -85,6 +85,8 @@ func (c *events) List(ctx context.Context, opts metav1.ListOptions) (result *v1.
 	result = &v1.EventList{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		Prefix("/apis", "core", "v1").
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("events").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/limitrange.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/limitrange.go
@@ -85,6 +85,8 @@ func (c *limitRanges) List(ctx context.Context, opts metav1.ListOptions) (result
 	result = &v1.LimitRangeList{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		Prefix("/apis", "core", "v1").
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("limitranges").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/namespace.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/namespace.go
@@ -81,6 +81,8 @@ func (c *namespaces) List(ctx context.Context, opts metav1.ListOptions) (result 
 	}
 	result = &v1.NamespaceList{}
 	err = c.client.Get().
+		Prefix("/apis", "core", "v1").
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("namespaces").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/node.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/node.go
@@ -82,6 +82,8 @@ func (c *nodes) List(ctx context.Context, opts metav1.ListOptions) (result *v1.N
 	}
 	result = &v1.NodeList{}
 	err = c.client.Get().
+		Prefix("/apis", "core", "v1").
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("nodes").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/persistentvolume.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/persistentvolume.go
@@ -82,6 +82,8 @@ func (c *persistentVolumes) List(ctx context.Context, opts metav1.ListOptions) (
 	}
 	result = &v1.PersistentVolumeList{}
 	err = c.client.Get().
+		Prefix("/apis", "core", "v1").
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("persistentvolumes").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/persistentvolumeclaim.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/persistentvolumeclaim.go
@@ -86,6 +86,8 @@ func (c *persistentVolumeClaims) List(ctx context.Context, opts metav1.ListOptio
 	result = &v1.PersistentVolumeClaimList{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		Prefix("/apis", "core", "v1").
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("persistentvolumeclaims").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/pod.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/pod.go
@@ -89,6 +89,8 @@ func (c *pods) List(ctx context.Context, opts metav1.ListOptions) (result *v1.Po
 	result = &v1.PodList{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		Prefix("/apis", "core", "v1").
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("pods").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/podtemplate.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/podtemplate.go
@@ -85,6 +85,8 @@ func (c *podTemplates) List(ctx context.Context, opts metav1.ListOptions) (resul
 	result = &v1.PodTemplateList{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		Prefix("/apis", "core", "v1").
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("podtemplates").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/replicationcontroller.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/replicationcontroller.go
@@ -90,6 +90,8 @@ func (c *replicationControllers) List(ctx context.Context, opts metav1.ListOptio
 	result = &v1.ReplicationControllerList{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		Prefix("/apis", "core", "v1").
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("replicationcontrollers").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/resourcequota.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/resourcequota.go
@@ -86,6 +86,8 @@ func (c *resourceQuotas) List(ctx context.Context, opts metav1.ListOptions) (res
 	result = &v1.ResourceQuotaList{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		Prefix("/apis", "core", "v1").
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("resourcequotas").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/secret.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/secret.go
@@ -85,6 +85,8 @@ func (c *secrets) List(ctx context.Context, opts metav1.ListOptions) (result *v1
 	result = &v1.SecretList{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		Prefix("/apis", "core", "v1").
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("secrets").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/service.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/service.go
@@ -85,6 +85,8 @@ func (c *services) List(ctx context.Context, opts metav1.ListOptions) (result *v
 	result = &v1.ServiceList{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		Prefix("/apis", "core", "v1").
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("services").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/serviceaccount.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/serviceaccount.go
@@ -88,6 +88,8 @@ func (c *serviceAccounts) List(ctx context.Context, opts metav1.ListOptions) (re
 	result = &v1.ServiceAccountList{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		Prefix("/apis", "core", "v1").
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("serviceaccounts").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/discovery/v1alpha1/discovery_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/discovery/v1alpha1/discovery_client.go
@@ -19,7 +19,6 @@ limitations under the License.
 package v1alpha1
 
 import (
-	v1alpha1 "k8s.io/api/discovery/v1alpha1"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
 )
@@ -67,11 +66,9 @@ func New(c rest.Interface) *DiscoveryV1alpha1Client {
 }
 
 func setConfigDefaults(config *rest.Config) error {
-	gv := v1alpha1.SchemeGroupVersion
-	config.GroupVersion = &gv
-	config.APIPath = "/apis"
-	config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
-
+	if config.NegotiatedSerializer == nil {
+		config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
+	}
 	if config.UserAgent == "" {
 		config.UserAgent = rest.DefaultKubernetesUserAgent()
 	}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/discovery/v1alpha1/endpointslice.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/discovery/v1alpha1/endpointslice.go
@@ -85,6 +85,8 @@ func (c *endpointSlices) List(ctx context.Context, opts v1.ListOptions) (result 
 	result = &v1alpha1.EndpointSliceList{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		Prefix("/apis", "discovery.k8s.io", "v1alpha1").
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("endpointslices").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/discovery/v1beta1/discovery_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/discovery/v1beta1/discovery_client.go
@@ -19,7 +19,6 @@ limitations under the License.
 package v1beta1
 
 import (
-	v1beta1 "k8s.io/api/discovery/v1beta1"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
 )
@@ -67,11 +66,9 @@ func New(c rest.Interface) *DiscoveryV1beta1Client {
 }
 
 func setConfigDefaults(config *rest.Config) error {
-	gv := v1beta1.SchemeGroupVersion
-	config.GroupVersion = &gv
-	config.APIPath = "/apis"
-	config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
-
+	if config.NegotiatedSerializer == nil {
+		config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
+	}
 	if config.UserAgent == "" {
 		config.UserAgent = rest.DefaultKubernetesUserAgent()
 	}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/discovery/v1beta1/endpointslice.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/discovery/v1beta1/endpointslice.go
@@ -85,6 +85,8 @@ func (c *endpointSlices) List(ctx context.Context, opts v1.ListOptions) (result 
 	result = &v1beta1.EndpointSliceList{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		Prefix("/apis", "discovery.k8s.io", "v1beta1").
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("endpointslices").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/events/v1/event.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/events/v1/event.go
@@ -85,6 +85,8 @@ func (c *events) List(ctx context.Context, opts metav1.ListOptions) (result *v1.
 	result = &v1.EventList{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		Prefix("/apis", "events.k8s.io", "v1").
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("events").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/events/v1/events_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/events/v1/events_client.go
@@ -19,7 +19,6 @@ limitations under the License.
 package v1
 
 import (
-	v1 "k8s.io/api/events/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
 )
@@ -67,11 +66,9 @@ func New(c rest.Interface) *EventsV1Client {
 }
 
 func setConfigDefaults(config *rest.Config) error {
-	gv := v1.SchemeGroupVersion
-	config.GroupVersion = &gv
-	config.APIPath = "/apis"
-	config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
-
+	if config.NegotiatedSerializer == nil {
+		config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
+	}
 	if config.UserAgent == "" {
 		config.UserAgent = rest.DefaultKubernetesUserAgent()
 	}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/events/v1beta1/event.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/events/v1beta1/event.go
@@ -85,6 +85,8 @@ func (c *events) List(ctx context.Context, opts v1.ListOptions) (result *v1beta1
 	result = &v1beta1.EventList{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		Prefix("/apis", "events.k8s.io", "v1beta1").
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("events").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/events/v1beta1/events_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/events/v1beta1/events_client.go
@@ -19,7 +19,6 @@ limitations under the License.
 package v1beta1
 
 import (
-	v1beta1 "k8s.io/api/events/v1beta1"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
 )
@@ -67,11 +66,9 @@ func New(c rest.Interface) *EventsV1beta1Client {
 }
 
 func setConfigDefaults(config *rest.Config) error {
-	gv := v1beta1.SchemeGroupVersion
-	config.GroupVersion = &gv
-	config.APIPath = "/apis"
-	config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
-
+	if config.NegotiatedSerializer == nil {
+		config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
+	}
 	if config.UserAgent == "" {
 		config.UserAgent = rest.DefaultKubernetesUserAgent()
 	}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/daemonset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/daemonset.go
@@ -86,6 +86,8 @@ func (c *daemonSets) List(ctx context.Context, opts v1.ListOptions) (result *v1b
 	result = &v1beta1.DaemonSetList{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		Prefix("/apis", "extensions", "v1beta1").
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("daemonsets").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/deployment.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/deployment.go
@@ -89,6 +89,8 @@ func (c *deployments) List(ctx context.Context, opts v1.ListOptions) (result *v1
 	result = &v1beta1.DeploymentList{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		Prefix("/apis", "extensions", "v1beta1").
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("deployments").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/extensions_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/extensions_client.go
@@ -19,7 +19,6 @@ limitations under the License.
 package v1beta1
 
 import (
-	v1beta1 "k8s.io/api/extensions/v1beta1"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
 )
@@ -92,11 +91,9 @@ func New(c rest.Interface) *ExtensionsV1beta1Client {
 }
 
 func setConfigDefaults(config *rest.Config) error {
-	gv := v1beta1.SchemeGroupVersion
-	config.GroupVersion = &gv
-	config.APIPath = "/apis"
-	config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
-
+	if config.NegotiatedSerializer == nil {
+		config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
+	}
 	if config.UserAgent == "" {
 		config.UserAgent = rest.DefaultKubernetesUserAgent()
 	}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/ingress.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/ingress.go
@@ -86,6 +86,8 @@ func (c *ingresses) List(ctx context.Context, opts v1.ListOptions) (result *v1be
 	result = &v1beta1.IngressList{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		Prefix("/apis", "extensions", "v1beta1").
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("ingresses").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/networkpolicy.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/networkpolicy.go
@@ -85,6 +85,8 @@ func (c *networkPolicies) List(ctx context.Context, opts v1.ListOptions) (result
 	result = &v1beta1.NetworkPolicyList{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		Prefix("/apis", "extensions", "v1beta1").
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("networkpolicies").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/podsecuritypolicy.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/podsecuritypolicy.go
@@ -81,6 +81,8 @@ func (c *podSecurityPolicies) List(ctx context.Context, opts v1.ListOptions) (re
 	}
 	result = &v1beta1.PodSecurityPolicyList{}
 	err = c.client.Get().
+		Prefix("/apis", "extensions", "v1beta1").
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("podsecuritypolicies").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/replicaset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/replicaset.go
@@ -89,6 +89,8 @@ func (c *replicaSets) List(ctx context.Context, opts v1.ListOptions) (result *v1
 	result = &v1beta1.ReplicaSetList{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		Prefix("/apis", "extensions", "v1beta1").
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("replicasets").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/flowcontrol/v1alpha1/flowcontrol_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/flowcontrol/v1alpha1/flowcontrol_client.go
@@ -19,7 +19,6 @@ limitations under the License.
 package v1alpha1
 
 import (
-	v1alpha1 "k8s.io/api/flowcontrol/v1alpha1"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
 )
@@ -72,11 +71,9 @@ func New(c rest.Interface) *FlowcontrolV1alpha1Client {
 }
 
 func setConfigDefaults(config *rest.Config) error {
-	gv := v1alpha1.SchemeGroupVersion
-	config.GroupVersion = &gv
-	config.APIPath = "/apis"
-	config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
-
+	if config.NegotiatedSerializer == nil {
+		config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
+	}
 	if config.UserAgent == "" {
 		config.UserAgent = rest.DefaultKubernetesUserAgent()
 	}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/flowcontrol/v1alpha1/flowschema.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/flowcontrol/v1alpha1/flowschema.go
@@ -82,6 +82,8 @@ func (c *flowSchemas) List(ctx context.Context, opts v1.ListOptions) (result *v1
 	}
 	result = &v1alpha1.FlowSchemaList{}
 	err = c.client.Get().
+		Prefix("/apis", "flowcontrol.apiserver.k8s.io", "v1alpha1").
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("flowschemas").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/flowcontrol/v1alpha1/prioritylevelconfiguration.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/flowcontrol/v1alpha1/prioritylevelconfiguration.go
@@ -82,6 +82,8 @@ func (c *priorityLevelConfigurations) List(ctx context.Context, opts v1.ListOpti
 	}
 	result = &v1alpha1.PriorityLevelConfigurationList{}
 	err = c.client.Get().
+		Prefix("/apis", "flowcontrol.apiserver.k8s.io", "v1alpha1").
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("prioritylevelconfigurations").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/flowcontrol/v1beta1/flowcontrol_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/flowcontrol/v1beta1/flowcontrol_client.go
@@ -19,7 +19,6 @@ limitations under the License.
 package v1beta1
 
 import (
-	v1beta1 "k8s.io/api/flowcontrol/v1beta1"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
 )
@@ -72,11 +71,9 @@ func New(c rest.Interface) *FlowcontrolV1beta1Client {
 }
 
 func setConfigDefaults(config *rest.Config) error {
-	gv := v1beta1.SchemeGroupVersion
-	config.GroupVersion = &gv
-	config.APIPath = "/apis"
-	config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
-
+	if config.NegotiatedSerializer == nil {
+		config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
+	}
 	if config.UserAgent == "" {
 		config.UserAgent = rest.DefaultKubernetesUserAgent()
 	}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/flowcontrol/v1beta1/flowschema.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/flowcontrol/v1beta1/flowschema.go
@@ -82,6 +82,8 @@ func (c *flowSchemas) List(ctx context.Context, opts v1.ListOptions) (result *v1
 	}
 	result = &v1beta1.FlowSchemaList{}
 	err = c.client.Get().
+		Prefix("/apis", "flowcontrol.apiserver.k8s.io", "v1beta1").
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("flowschemas").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/flowcontrol/v1beta1/prioritylevelconfiguration.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/flowcontrol/v1beta1/prioritylevelconfiguration.go
@@ -82,6 +82,8 @@ func (c *priorityLevelConfigurations) List(ctx context.Context, opts v1.ListOpti
 	}
 	result = &v1beta1.PriorityLevelConfigurationList{}
 	err = c.client.Get().
+		Prefix("/apis", "flowcontrol.apiserver.k8s.io", "v1beta1").
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("prioritylevelconfigurations").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1/ingress.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1/ingress.go
@@ -86,6 +86,8 @@ func (c *ingresses) List(ctx context.Context, opts metav1.ListOptions) (result *
 	result = &v1.IngressList{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		Prefix("/apis", "networking.k8s.io", "v1").
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("ingresses").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1/ingressclass.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1/ingressclass.go
@@ -81,6 +81,8 @@ func (c *ingressClasses) List(ctx context.Context, opts metav1.ListOptions) (res
 	}
 	result = &v1.IngressClassList{}
 	err = c.client.Get().
+		Prefix("/apis", "networking.k8s.io", "v1").
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("ingressclasses").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1/networking_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1/networking_client.go
@@ -19,7 +19,6 @@ limitations under the License.
 package v1
 
 import (
-	v1 "k8s.io/api/networking/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
 )
@@ -77,11 +76,9 @@ func New(c rest.Interface) *NetworkingV1Client {
 }
 
 func setConfigDefaults(config *rest.Config) error {
-	gv := v1.SchemeGroupVersion
-	config.GroupVersion = &gv
-	config.APIPath = "/apis"
-	config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
-
+	if config.NegotiatedSerializer == nil {
+		config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
+	}
 	if config.UserAgent == "" {
 		config.UserAgent = rest.DefaultKubernetesUserAgent()
 	}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1/networkpolicy.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1/networkpolicy.go
@@ -85,6 +85,8 @@ func (c *networkPolicies) List(ctx context.Context, opts metav1.ListOptions) (re
 	result = &v1.NetworkPolicyList{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		Prefix("/apis", "networking.k8s.io", "v1").
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("networkpolicies").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1beta1/ingress.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1beta1/ingress.go
@@ -86,6 +86,8 @@ func (c *ingresses) List(ctx context.Context, opts v1.ListOptions) (result *v1be
 	result = &v1beta1.IngressList{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		Prefix("/apis", "networking.k8s.io", "v1beta1").
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("ingresses").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1beta1/ingressclass.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1beta1/ingressclass.go
@@ -81,6 +81,8 @@ func (c *ingressClasses) List(ctx context.Context, opts v1.ListOptions) (result 
 	}
 	result = &v1beta1.IngressClassList{}
 	err = c.client.Get().
+		Prefix("/apis", "networking.k8s.io", "v1beta1").
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("ingressclasses").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1beta1/networking_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1beta1/networking_client.go
@@ -19,7 +19,6 @@ limitations under the License.
 package v1beta1
 
 import (
-	v1beta1 "k8s.io/api/networking/v1beta1"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
 )
@@ -72,11 +71,9 @@ func New(c rest.Interface) *NetworkingV1beta1Client {
 }
 
 func setConfigDefaults(config *rest.Config) error {
-	gv := v1beta1.SchemeGroupVersion
-	config.GroupVersion = &gv
-	config.APIPath = "/apis"
-	config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
-
+	if config.NegotiatedSerializer == nil {
+		config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
+	}
 	if config.UserAgent == "" {
 		config.UserAgent = rest.DefaultKubernetesUserAgent()
 	}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/node/v1/node_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/node/v1/node_client.go
@@ -19,7 +19,6 @@ limitations under the License.
 package v1
 
 import (
-	v1 "k8s.io/api/node/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
 )
@@ -67,11 +66,9 @@ func New(c rest.Interface) *NodeV1Client {
 }
 
 func setConfigDefaults(config *rest.Config) error {
-	gv := v1.SchemeGroupVersion
-	config.GroupVersion = &gv
-	config.APIPath = "/apis"
-	config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
-
+	if config.NegotiatedSerializer == nil {
+		config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
+	}
 	if config.UserAgent == "" {
 		config.UserAgent = rest.DefaultKubernetesUserAgent()
 	}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/node/v1/runtimeclass.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/node/v1/runtimeclass.go
@@ -81,6 +81,8 @@ func (c *runtimeClasses) List(ctx context.Context, opts metav1.ListOptions) (res
 	}
 	result = &v1.RuntimeClassList{}
 	err = c.client.Get().
+		Prefix("/apis", "node.k8s.io", "v1").
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("runtimeclasses").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/node/v1alpha1/node_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/node/v1alpha1/node_client.go
@@ -19,7 +19,6 @@ limitations under the License.
 package v1alpha1
 
 import (
-	v1alpha1 "k8s.io/api/node/v1alpha1"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
 )
@@ -67,11 +66,9 @@ func New(c rest.Interface) *NodeV1alpha1Client {
 }
 
 func setConfigDefaults(config *rest.Config) error {
-	gv := v1alpha1.SchemeGroupVersion
-	config.GroupVersion = &gv
-	config.APIPath = "/apis"
-	config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
-
+	if config.NegotiatedSerializer == nil {
+		config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
+	}
 	if config.UserAgent == "" {
 		config.UserAgent = rest.DefaultKubernetesUserAgent()
 	}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/node/v1alpha1/runtimeclass.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/node/v1alpha1/runtimeclass.go
@@ -81,6 +81,8 @@ func (c *runtimeClasses) List(ctx context.Context, opts v1.ListOptions) (result 
 	}
 	result = &v1alpha1.RuntimeClassList{}
 	err = c.client.Get().
+		Prefix("/apis", "node.k8s.io", "v1alpha1").
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("runtimeclasses").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/node/v1beta1/node_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/node/v1beta1/node_client.go
@@ -19,7 +19,6 @@ limitations under the License.
 package v1beta1
 
 import (
-	v1beta1 "k8s.io/api/node/v1beta1"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
 )
@@ -67,11 +66,9 @@ func New(c rest.Interface) *NodeV1beta1Client {
 }
 
 func setConfigDefaults(config *rest.Config) error {
-	gv := v1beta1.SchemeGroupVersion
-	config.GroupVersion = &gv
-	config.APIPath = "/apis"
-	config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
-
+	if config.NegotiatedSerializer == nil {
+		config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
+	}
 	if config.UserAgent == "" {
 		config.UserAgent = rest.DefaultKubernetesUserAgent()
 	}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/node/v1beta1/runtimeclass.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/node/v1beta1/runtimeclass.go
@@ -81,6 +81,8 @@ func (c *runtimeClasses) List(ctx context.Context, opts v1.ListOptions) (result 
 	}
 	result = &v1beta1.RuntimeClassList{}
 	err = c.client.Get().
+		Prefix("/apis", "node.k8s.io", "v1beta1").
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("runtimeclasses").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/policy/v1beta1/poddisruptionbudget.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/policy/v1beta1/poddisruptionbudget.go
@@ -86,6 +86,8 @@ func (c *podDisruptionBudgets) List(ctx context.Context, opts v1.ListOptions) (r
 	result = &v1beta1.PodDisruptionBudgetList{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		Prefix("/apis", "policy", "v1beta1").
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("poddisruptionbudgets").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/policy/v1beta1/podsecuritypolicy.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/policy/v1beta1/podsecuritypolicy.go
@@ -81,6 +81,8 @@ func (c *podSecurityPolicies) List(ctx context.Context, opts v1.ListOptions) (re
 	}
 	result = &v1beta1.PodSecurityPolicyList{}
 	err = c.client.Get().
+		Prefix("/apis", "policy", "v1beta1").
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("podsecuritypolicies").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/policy/v1beta1/policy_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/policy/v1beta1/policy_client.go
@@ -19,7 +19,6 @@ limitations under the License.
 package v1beta1
 
 import (
-	v1beta1 "k8s.io/api/policy/v1beta1"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
 )
@@ -77,11 +76,9 @@ func New(c rest.Interface) *PolicyV1beta1Client {
 }
 
 func setConfigDefaults(config *rest.Config) error {
-	gv := v1beta1.SchemeGroupVersion
-	config.GroupVersion = &gv
-	config.APIPath = "/apis"
-	config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
-
+	if config.NegotiatedSerializer == nil {
+		config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
+	}
 	if config.UserAgent == "" {
 		config.UserAgent = rest.DefaultKubernetesUserAgent()
 	}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1/clusterrole.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1/clusterrole.go
@@ -81,6 +81,8 @@ func (c *clusterRoles) List(ctx context.Context, opts metav1.ListOptions) (resul
 	}
 	result = &v1.ClusterRoleList{}
 	err = c.client.Get().
+		Prefix("/apis", "rbac.authorization.k8s.io", "v1").
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("clusterroles").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1/clusterrolebinding.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1/clusterrolebinding.go
@@ -81,6 +81,8 @@ func (c *clusterRoleBindings) List(ctx context.Context, opts metav1.ListOptions)
 	}
 	result = &v1.ClusterRoleBindingList{}
 	err = c.client.Get().
+		Prefix("/apis", "rbac.authorization.k8s.io", "v1").
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("clusterrolebindings").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1/rbac_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1/rbac_client.go
@@ -19,7 +19,6 @@ limitations under the License.
 package v1
 
 import (
-	v1 "k8s.io/api/rbac/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
 )
@@ -82,11 +81,9 @@ func New(c rest.Interface) *RbacV1Client {
 }
 
 func setConfigDefaults(config *rest.Config) error {
-	gv := v1.SchemeGroupVersion
-	config.GroupVersion = &gv
-	config.APIPath = "/apis"
-	config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
-
+	if config.NegotiatedSerializer == nil {
+		config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
+	}
 	if config.UserAgent == "" {
 		config.UserAgent = rest.DefaultKubernetesUserAgent()
 	}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1/role.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1/role.go
@@ -85,6 +85,8 @@ func (c *roles) List(ctx context.Context, opts metav1.ListOptions) (result *v1.R
 	result = &v1.RoleList{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		Prefix("/apis", "rbac.authorization.k8s.io", "v1").
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("roles").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1/rolebinding.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1/rolebinding.go
@@ -85,6 +85,8 @@ func (c *roleBindings) List(ctx context.Context, opts metav1.ListOptions) (resul
 	result = &v1.RoleBindingList{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		Prefix("/apis", "rbac.authorization.k8s.io", "v1").
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("rolebindings").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/clusterrole.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/clusterrole.go
@@ -81,6 +81,8 @@ func (c *clusterRoles) List(ctx context.Context, opts v1.ListOptions) (result *v
 	}
 	result = &v1alpha1.ClusterRoleList{}
 	err = c.client.Get().
+		Prefix("/apis", "rbac.authorization.k8s.io", "v1alpha1").
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("clusterroles").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/clusterrolebinding.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/clusterrolebinding.go
@@ -81,6 +81,8 @@ func (c *clusterRoleBindings) List(ctx context.Context, opts v1.ListOptions) (re
 	}
 	result = &v1alpha1.ClusterRoleBindingList{}
 	err = c.client.Get().
+		Prefix("/apis", "rbac.authorization.k8s.io", "v1alpha1").
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("clusterrolebindings").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/rbac_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/rbac_client.go
@@ -19,7 +19,6 @@ limitations under the License.
 package v1alpha1
 
 import (
-	v1alpha1 "k8s.io/api/rbac/v1alpha1"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
 )
@@ -82,11 +81,9 @@ func New(c rest.Interface) *RbacV1alpha1Client {
 }
 
 func setConfigDefaults(config *rest.Config) error {
-	gv := v1alpha1.SchemeGroupVersion
-	config.GroupVersion = &gv
-	config.APIPath = "/apis"
-	config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
-
+	if config.NegotiatedSerializer == nil {
+		config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
+	}
 	if config.UserAgent == "" {
 		config.UserAgent = rest.DefaultKubernetesUserAgent()
 	}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/role.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/role.go
@@ -85,6 +85,8 @@ func (c *roles) List(ctx context.Context, opts v1.ListOptions) (result *v1alpha1
 	result = &v1alpha1.RoleList{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		Prefix("/apis", "rbac.authorization.k8s.io", "v1alpha1").
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("roles").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/rolebinding.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/rolebinding.go
@@ -85,6 +85,8 @@ func (c *roleBindings) List(ctx context.Context, opts v1.ListOptions) (result *v
 	result = &v1alpha1.RoleBindingList{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		Prefix("/apis", "rbac.authorization.k8s.io", "v1alpha1").
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("rolebindings").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/clusterrole.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/clusterrole.go
@@ -81,6 +81,8 @@ func (c *clusterRoles) List(ctx context.Context, opts v1.ListOptions) (result *v
 	}
 	result = &v1beta1.ClusterRoleList{}
 	err = c.client.Get().
+		Prefix("/apis", "rbac.authorization.k8s.io", "v1beta1").
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("clusterroles").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/clusterrolebinding.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/clusterrolebinding.go
@@ -81,6 +81,8 @@ func (c *clusterRoleBindings) List(ctx context.Context, opts v1.ListOptions) (re
 	}
 	result = &v1beta1.ClusterRoleBindingList{}
 	err = c.client.Get().
+		Prefix("/apis", "rbac.authorization.k8s.io", "v1beta1").
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("clusterrolebindings").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/rbac_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/rbac_client.go
@@ -19,7 +19,6 @@ limitations under the License.
 package v1beta1
 
 import (
-	v1beta1 "k8s.io/api/rbac/v1beta1"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
 )
@@ -82,11 +81,9 @@ func New(c rest.Interface) *RbacV1beta1Client {
 }
 
 func setConfigDefaults(config *rest.Config) error {
-	gv := v1beta1.SchemeGroupVersion
-	config.GroupVersion = &gv
-	config.APIPath = "/apis"
-	config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
-
+	if config.NegotiatedSerializer == nil {
+		config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
+	}
 	if config.UserAgent == "" {
 		config.UserAgent = rest.DefaultKubernetesUserAgent()
 	}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/role.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/role.go
@@ -85,6 +85,8 @@ func (c *roles) List(ctx context.Context, opts v1.ListOptions) (result *v1beta1.
 	result = &v1beta1.RoleList{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		Prefix("/apis", "rbac.authorization.k8s.io", "v1beta1").
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("roles").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/rolebinding.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/rolebinding.go
@@ -85,6 +85,8 @@ func (c *roleBindings) List(ctx context.Context, opts v1.ListOptions) (result *v
 	result = &v1beta1.RoleBindingList{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		Prefix("/apis", "rbac.authorization.k8s.io", "v1beta1").
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("rolebindings").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1/priorityclass.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1/priorityclass.go
@@ -81,6 +81,8 @@ func (c *priorityClasses) List(ctx context.Context, opts metav1.ListOptions) (re
 	}
 	result = &v1.PriorityClassList{}
 	err = c.client.Get().
+		Prefix("/apis", "scheduling.k8s.io", "v1").
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("priorityclasses").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1/scheduling_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1/scheduling_client.go
@@ -19,7 +19,6 @@ limitations under the License.
 package v1
 
 import (
-	v1 "k8s.io/api/scheduling/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
 )
@@ -67,11 +66,9 @@ func New(c rest.Interface) *SchedulingV1Client {
 }
 
 func setConfigDefaults(config *rest.Config) error {
-	gv := v1.SchemeGroupVersion
-	config.GroupVersion = &gv
-	config.APIPath = "/apis"
-	config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
-
+	if config.NegotiatedSerializer == nil {
+		config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
+	}
 	if config.UserAgent == "" {
 		config.UserAgent = rest.DefaultKubernetesUserAgent()
 	}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1alpha1/priorityclass.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1alpha1/priorityclass.go
@@ -81,6 +81,8 @@ func (c *priorityClasses) List(ctx context.Context, opts v1.ListOptions) (result
 	}
 	result = &v1alpha1.PriorityClassList{}
 	err = c.client.Get().
+		Prefix("/apis", "scheduling.k8s.io", "v1alpha1").
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("priorityclasses").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1alpha1/scheduling_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1alpha1/scheduling_client.go
@@ -19,7 +19,6 @@ limitations under the License.
 package v1alpha1
 
 import (
-	v1alpha1 "k8s.io/api/scheduling/v1alpha1"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
 )
@@ -67,11 +66,9 @@ func New(c rest.Interface) *SchedulingV1alpha1Client {
 }
 
 func setConfigDefaults(config *rest.Config) error {
-	gv := v1alpha1.SchemeGroupVersion
-	config.GroupVersion = &gv
-	config.APIPath = "/apis"
-	config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
-
+	if config.NegotiatedSerializer == nil {
+		config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
+	}
 	if config.UserAgent == "" {
 		config.UserAgent = rest.DefaultKubernetesUserAgent()
 	}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1beta1/priorityclass.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1beta1/priorityclass.go
@@ -81,6 +81,8 @@ func (c *priorityClasses) List(ctx context.Context, opts v1.ListOptions) (result
 	}
 	result = &v1beta1.PriorityClassList{}
 	err = c.client.Get().
+		Prefix("/apis", "scheduling.k8s.io", "v1beta1").
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("priorityclasses").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1beta1/scheduling_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1beta1/scheduling_client.go
@@ -19,7 +19,6 @@ limitations under the License.
 package v1beta1
 
 import (
-	v1beta1 "k8s.io/api/scheduling/v1beta1"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
 )
@@ -67,11 +66,9 @@ func New(c rest.Interface) *SchedulingV1beta1Client {
 }
 
 func setConfigDefaults(config *rest.Config) error {
-	gv := v1beta1.SchemeGroupVersion
-	config.GroupVersion = &gv
-	config.APIPath = "/apis"
-	config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
-
+	if config.NegotiatedSerializer == nil {
+		config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
+	}
 	if config.UserAgent == "" {
 		config.UserAgent = rest.DefaultKubernetesUserAgent()
 	}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1/csidriver.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1/csidriver.go
@@ -81,6 +81,8 @@ func (c *cSIDrivers) List(ctx context.Context, opts metav1.ListOptions) (result 
 	}
 	result = &v1.CSIDriverList{}
 	err = c.client.Get().
+		Prefix("/apis", "storage.k8s.io", "v1").
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("csidrivers").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1/csinode.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1/csinode.go
@@ -81,6 +81,8 @@ func (c *cSINodes) List(ctx context.Context, opts metav1.ListOptions) (result *v
 	}
 	result = &v1.CSINodeList{}
 	err = c.client.Get().
+		Prefix("/apis", "storage.k8s.io", "v1").
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("csinodes").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1/storage_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1/storage_client.go
@@ -19,7 +19,6 @@ limitations under the License.
 package v1
 
 import (
-	v1 "k8s.io/api/storage/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
 )
@@ -82,11 +81,9 @@ func New(c rest.Interface) *StorageV1Client {
 }
 
 func setConfigDefaults(config *rest.Config) error {
-	gv := v1.SchemeGroupVersion
-	config.GroupVersion = &gv
-	config.APIPath = "/apis"
-	config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
-
+	if config.NegotiatedSerializer == nil {
+		config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
+	}
 	if config.UserAgent == "" {
 		config.UserAgent = rest.DefaultKubernetesUserAgent()
 	}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1/storageclass.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1/storageclass.go
@@ -81,6 +81,8 @@ func (c *storageClasses) List(ctx context.Context, opts metav1.ListOptions) (res
 	}
 	result = &v1.StorageClassList{}
 	err = c.client.Get().
+		Prefix("/apis", "storage.k8s.io", "v1").
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("storageclasses").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1/volumeattachment.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1/volumeattachment.go
@@ -82,6 +82,8 @@ func (c *volumeAttachments) List(ctx context.Context, opts metav1.ListOptions) (
 	}
 	result = &v1.VolumeAttachmentList{}
 	err = c.client.Get().
+		Prefix("/apis", "storage.k8s.io", "v1").
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("volumeattachments").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1alpha1/csistoragecapacity.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1alpha1/csistoragecapacity.go
@@ -85,6 +85,8 @@ func (c *cSIStorageCapacities) List(ctx context.Context, opts v1.ListOptions) (r
 	result = &v1alpha1.CSIStorageCapacityList{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		Prefix("/apis", "storage.k8s.io", "v1alpha1").
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("csistoragecapacities").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1alpha1/storage_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1alpha1/storage_client.go
@@ -19,7 +19,6 @@ limitations under the License.
 package v1alpha1
 
 import (
-	v1alpha1 "k8s.io/api/storage/v1alpha1"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
 )
@@ -72,11 +71,9 @@ func New(c rest.Interface) *StorageV1alpha1Client {
 }
 
 func setConfigDefaults(config *rest.Config) error {
-	gv := v1alpha1.SchemeGroupVersion
-	config.GroupVersion = &gv
-	config.APIPath = "/apis"
-	config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
-
+	if config.NegotiatedSerializer == nil {
+		config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
+	}
 	if config.UserAgent == "" {
 		config.UserAgent = rest.DefaultKubernetesUserAgent()
 	}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1alpha1/volumeattachment.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1alpha1/volumeattachment.go
@@ -82,6 +82,8 @@ func (c *volumeAttachments) List(ctx context.Context, opts v1.ListOptions) (resu
 	}
 	result = &v1alpha1.VolumeAttachmentList{}
 	err = c.client.Get().
+		Prefix("/apis", "storage.k8s.io", "v1alpha1").
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("volumeattachments").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/csidriver.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/csidriver.go
@@ -81,6 +81,8 @@ func (c *cSIDrivers) List(ctx context.Context, opts v1.ListOptions) (result *v1b
 	}
 	result = &v1beta1.CSIDriverList{}
 	err = c.client.Get().
+		Prefix("/apis", "storage.k8s.io", "v1beta1").
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("csidrivers").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/csinode.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/csinode.go
@@ -81,6 +81,8 @@ func (c *cSINodes) List(ctx context.Context, opts v1.ListOptions) (result *v1bet
 	}
 	result = &v1beta1.CSINodeList{}
 	err = c.client.Get().
+		Prefix("/apis", "storage.k8s.io", "v1beta1").
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("csinodes").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/storage_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/storage_client.go
@@ -19,7 +19,6 @@ limitations under the License.
 package v1beta1
 
 import (
-	v1beta1 "k8s.io/api/storage/v1beta1"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
 )
@@ -82,11 +81,9 @@ func New(c rest.Interface) *StorageV1beta1Client {
 }
 
 func setConfigDefaults(config *rest.Config) error {
-	gv := v1beta1.SchemeGroupVersion
-	config.GroupVersion = &gv
-	config.APIPath = "/apis"
-	config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
-
+	if config.NegotiatedSerializer == nil {
+		config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
+	}
 	if config.UserAgent == "" {
 		config.UserAgent = rest.DefaultKubernetesUserAgent()
 	}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/storageclass.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/storageclass.go
@@ -81,6 +81,8 @@ func (c *storageClasses) List(ctx context.Context, opts v1.ListOptions) (result 
 	}
 	result = &v1beta1.StorageClassList{}
 	err = c.client.Get().
+		Prefix("/apis", "storage.k8s.io", "v1beta1").
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("storageclasses").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/volumeattachment.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/volumeattachment.go
@@ -82,6 +82,8 @@ func (c *volumeAttachments) List(ctx context.Context, opts v1.ListOptions) (resu
 	}
 	result = &v1beta1.VolumeAttachmentList{}
 	err = c.client.Get().
+		Prefix("/apis", "storage.k8s.io", "v1beta1").
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("volumeattachments").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).

--- a/staging/src/k8s.io/client-go/plugin/pkg/client/auth/exec/exec.go
+++ b/staging/src/k8s.io/client-go/plugin/pkg/client/auth/exec/exec.go
@@ -278,7 +278,7 @@ func (a *Authenticator) UpdateTransportConfig(c *transport.Config) error {
 	defer a.mu.Unlock()
 	a.onRotateList = append(a.onRotateList, d.CloseAll)
 	onRotateListLength := len(a.onRotateList)
-	if onRotateListLength > onRotateListWarningLength {
+	if onRotateListLength%onRotateListWarningLength == 0 {
 		klog.Warningf("constructing many client instances from the same exec auth config can cause performance problems during cert rotation and can exhaust available network connections; %d clients constructed calling %q", onRotateListLength, a.cmd)
 	}
 

--- a/staging/src/k8s.io/client-go/rest/config.go
+++ b/staging/src/k8s.io/client-go/rest/config.go
@@ -304,13 +304,9 @@ type ContentConfig struct {
 // A RESTClient created by this method is generic - it expects to operate on an API that follows
 // the Kubernetes conventions, but may not be the Kubernetes API.
 func RESTClientFor(config *Config) (*RESTClient, error) {
-	if config.GroupVersion == nil {
-		return nil, fmt.Errorf("GroupVersion is required when initializing a RESTClient")
-	}
 	if config.NegotiatedSerializer == nil {
 		return nil, fmt.Errorf("NegotiatedSerializer is required when initializing a RESTClient")
 	}
-
 	baseURL, versionedAPIPath, err := defaultServerUrlFor(config)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/rest/request.go
+++ b/staging/src/k8s.io/client-go/rest/request.go
@@ -108,6 +108,7 @@ type Request struct {
 	resource     string
 	resourceName string
 	subresource  string
+	groupVersion schema.GroupVersion
 
 	// output
 	err  error
@@ -127,8 +128,10 @@ func NewRequest(c *RESTClient) *Request {
 	var pathPrefix string
 	if c.base != nil {
 		pathPrefix = path.Join("/", c.base.Path, c.versionedAPIPath)
-	} else {
+	} else if len(c.versionedAPIPath) > 0 {
 		pathPrefix = path.Join("/", c.versionedAPIPath)
+	} else {
+		pathPrefix = "/"
 	}
 
 	var timeout time.Duration
@@ -138,6 +141,7 @@ func NewRequest(c *RESTClient) *Request {
 
 	r := &Request{
 		c:              c,
+		groupVersion:   c.content.GroupVersion,
 		rateLimiter:    c.rateLimiter,
 		backoff:        backoff,
 		timeout:        timeout,
@@ -347,13 +351,31 @@ func (r *Request) Param(paramName, s string) *Request {
 	return r.setParam(paramName, s)
 }
 
+// GroupVersion sets the API group and version associated with this request, and resets the prefix to
+// /api/<group> (for v1) or /apis/<group>/<version> (for all other group/versions)
+func (r *Request) GroupVersion(groupVersion schema.GroupVersion) *Request {
+	versionedAPIPath := "/apis"
+	if groupVersion.Group == "" && groupVersion.Version == "v1" {
+		versionedAPIPath = "/api"
+	}
+
+	if r.c.base != nil {
+		r.pathPrefix = path.Join("/", r.c.base.Path, versionedAPIPath, groupVersion.Group, groupVersion.Version)
+	} else {
+		r.pathPrefix = path.Join("/", versionedAPIPath, groupVersion.Group, groupVersion.Version)
+	}
+
+	r.groupVersion = groupVersion
+	return r
+}
+
 // VersionedParams will take the provided object, serialize it to a map[string][]string using the
 // implicit RESTClient API version and the default parameter codec, and then add those as parameters
 // to the request. Use this to provide versioned query parameters from client libraries.
 // VersionedParams will not write query parameters that have omitempty set and are empty. If a
 // parameter has already been set it is appended to (Params and VersionedParams are additive).
 func (r *Request) VersionedParams(obj runtime.Object, codec runtime.ParameterCodec) *Request {
-	return r.SpecificallyVersionedParams(obj, codec, r.c.content.GroupVersion)
+	return r.SpecificallyVersionedParams(obj, codec, r.groupVersion)
 }
 
 func (r *Request) SpecificallyVersionedParams(obj runtime.Object, codec runtime.ParameterCodec, version schema.GroupVersion) *Request {
@@ -1153,7 +1175,7 @@ func (r *Request) newUnstructuredResponseError(body []byte, isTextResponse bool,
 	}
 	var groupResource schema.GroupResource
 	if len(r.resource) > 0 {
-		groupResource.Group = r.c.content.GroupVersion.Group
+		groupResource.Group = r.groupVersion.Group
 		groupResource.Resource = r.resource
 	}
 	return errors.NewGenericServerResponse(

--- a/staging/src/k8s.io/code-generator/_examples/HyphenGroup/clientset/versioned/BUILD
+++ b/staging/src/k8s.io/code-generator/_examples/HyphenGroup/clientset/versioned/BUILD
@@ -13,6 +13,7 @@ go_library(
         "//staging/src/k8s.io/client-go/discovery:go_default_library",
         "//staging/src/k8s.io/client-go/rest:go_default_library",
         "//staging/src/k8s.io/client-go/util/flowcontrol:go_default_library",
+        "//staging/src/k8s.io/code-generator/_examples/HyphenGroup/clientset/versioned/scheme:go_default_library",
         "//staging/src/k8s.io/code-generator/_examples/HyphenGroup/clientset/versioned/typed/example/v1:go_default_library",
     ],
 )

--- a/staging/src/k8s.io/code-generator/_examples/HyphenGroup/clientset/versioned/clientset.go
+++ b/staging/src/k8s.io/code-generator/_examples/HyphenGroup/clientset/versioned/clientset.go
@@ -24,6 +24,7 @@ import (
 	discovery "k8s.io/client-go/discovery"
 	rest "k8s.io/client-go/rest"
 	flowcontrol "k8s.io/client-go/util/flowcontrol"
+	"k8s.io/code-generator/_examples/HyphenGroup/clientset/versioned/scheme"
 	examplegroupv1 "k8s.io/code-generator/_examples/HyphenGroup/clientset/versioned/typed/example/v1"
 )
 
@@ -63,17 +64,18 @@ func NewForConfig(c *rest.Config) (*Clientset, error) {
 		}
 		configShallowCopy.RateLimiter = flowcontrol.NewTokenBucketRateLimiter(configShallowCopy.QPS, configShallowCopy.Burst)
 	}
-	var cs Clientset
-	var err error
-	cs.exampleGroupV1, err = examplegroupv1.NewForConfig(&configShallowCopy)
+	if err := setConfigDefaults(&configShallowCopy); err != nil {
+		return nil, err
+	}
+	client, err := rest.RESTClientFor(&configShallowCopy)
 	if err != nil {
 		return nil, err
 	}
 
-	cs.DiscoveryClient, err = discovery.NewDiscoveryClientForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
+	var cs Clientset
+	cs.exampleGroupV1 = examplegroupv1.New(client)
+
+	cs.DiscoveryClient = discovery.NewDiscoveryClient(client)
 	return &cs, nil
 }
 
@@ -94,4 +96,15 @@ func New(c rest.Interface) *Clientset {
 
 	cs.DiscoveryClient = discovery.NewDiscoveryClient(c)
 	return &cs
+}
+
+func setConfigDefaults(config *rest.Config) error {
+	if config.NegotiatedSerializer == nil {
+		config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
+	}
+	if config.UserAgent == "" {
+		config.UserAgent = rest.DefaultKubernetesUserAgent()
+	}
+
+	return nil
 }

--- a/staging/src/k8s.io/code-generator/_examples/HyphenGroup/clientset/versioned/typed/example/v1/clustertesttype.go
+++ b/staging/src/k8s.io/code-generator/_examples/HyphenGroup/clientset/versioned/typed/example/v1/clustertesttype.go
@@ -86,6 +86,8 @@ func (c *clusterTestTypes) List(ctx context.Context, opts metav1.ListOptions) (r
 	}
 	result = &v1.ClusterTestTypeList{}
 	err = c.client.Get().
+		Prefix("/apis", "example-group.hyphens.code-generator.k8s.io", "v1").
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("clustertesttypes").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).

--- a/staging/src/k8s.io/code-generator/_examples/HyphenGroup/clientset/versioned/typed/example/v1/example_client.go
+++ b/staging/src/k8s.io/code-generator/_examples/HyphenGroup/clientset/versioned/typed/example/v1/example_client.go
@@ -20,7 +20,6 @@ package v1
 
 import (
 	rest "k8s.io/client-go/rest"
-	v1 "k8s.io/code-generator/_examples/HyphenGroup/apis/example/v1"
 	"k8s.io/code-generator/_examples/HyphenGroup/clientset/versioned/scheme"
 )
 
@@ -72,11 +71,9 @@ func New(c rest.Interface) *ExampleGroupV1Client {
 }
 
 func setConfigDefaults(config *rest.Config) error {
-	gv := v1.SchemeGroupVersion
-	config.GroupVersion = &gv
-	config.APIPath = "/apis"
-	config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
-
+	if config.NegotiatedSerializer == nil {
+		config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
+	}
 	if config.UserAgent == "" {
 		config.UserAgent = rest.DefaultKubernetesUserAgent()
 	}

--- a/staging/src/k8s.io/code-generator/_examples/HyphenGroup/clientset/versioned/typed/example/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/_examples/HyphenGroup/clientset/versioned/typed/example/v1/testtype.go
@@ -86,6 +86,8 @@ func (c *testTypes) List(ctx context.Context, opts metav1.ListOptions) (result *
 	result = &v1.TestTypeList{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		Prefix("/apis", "example-group.hyphens.code-generator.k8s.io", "v1").
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("testtypes").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).

--- a/staging/src/k8s.io/code-generator/_examples/MixedCase/clientset/versioned/BUILD
+++ b/staging/src/k8s.io/code-generator/_examples/MixedCase/clientset/versioned/BUILD
@@ -13,6 +13,7 @@ go_library(
         "//staging/src/k8s.io/client-go/discovery:go_default_library",
         "//staging/src/k8s.io/client-go/rest:go_default_library",
         "//staging/src/k8s.io/client-go/util/flowcontrol:go_default_library",
+        "//staging/src/k8s.io/code-generator/_examples/MixedCase/clientset/versioned/scheme:go_default_library",
         "//staging/src/k8s.io/code-generator/_examples/MixedCase/clientset/versioned/typed/example/v1:go_default_library",
     ],
 )

--- a/staging/src/k8s.io/code-generator/_examples/MixedCase/clientset/versioned/clientset.go
+++ b/staging/src/k8s.io/code-generator/_examples/MixedCase/clientset/versioned/clientset.go
@@ -24,6 +24,7 @@ import (
 	discovery "k8s.io/client-go/discovery"
 	rest "k8s.io/client-go/rest"
 	flowcontrol "k8s.io/client-go/util/flowcontrol"
+	"k8s.io/code-generator/_examples/MixedCase/clientset/versioned/scheme"
 	examplev1 "k8s.io/code-generator/_examples/MixedCase/clientset/versioned/typed/example/v1"
 )
 
@@ -63,17 +64,18 @@ func NewForConfig(c *rest.Config) (*Clientset, error) {
 		}
 		configShallowCopy.RateLimiter = flowcontrol.NewTokenBucketRateLimiter(configShallowCopy.QPS, configShallowCopy.Burst)
 	}
-	var cs Clientset
-	var err error
-	cs.exampleV1, err = examplev1.NewForConfig(&configShallowCopy)
+	if err := setConfigDefaults(&configShallowCopy); err != nil {
+		return nil, err
+	}
+	client, err := rest.RESTClientFor(&configShallowCopy)
 	if err != nil {
 		return nil, err
 	}
 
-	cs.DiscoveryClient, err = discovery.NewDiscoveryClientForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
+	var cs Clientset
+	cs.exampleV1 = examplev1.New(client)
+
+	cs.DiscoveryClient = discovery.NewDiscoveryClient(client)
 	return &cs, nil
 }
 
@@ -94,4 +96,15 @@ func New(c rest.Interface) *Clientset {
 
 	cs.DiscoveryClient = discovery.NewDiscoveryClient(c)
 	return &cs
+}
+
+func setConfigDefaults(config *rest.Config) error {
+	if config.NegotiatedSerializer == nil {
+		config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
+	}
+	if config.UserAgent == "" {
+		config.UserAgent = rest.DefaultKubernetesUserAgent()
+	}
+
+	return nil
 }

--- a/staging/src/k8s.io/code-generator/_examples/MixedCase/clientset/versioned/typed/example/v1/clustertesttype.go
+++ b/staging/src/k8s.io/code-generator/_examples/MixedCase/clientset/versioned/typed/example/v1/clustertesttype.go
@@ -87,6 +87,8 @@ func (c *clusterTestTypes) List(ctx context.Context, opts metav1.ListOptions) (r
 	}
 	result = &v1.ClusterTestTypeList{}
 	err = c.client.Get().
+		Prefix("/apis", "example.crd.code-generator.k8s.io", "v1").
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("clustertesttypes").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).

--- a/staging/src/k8s.io/code-generator/_examples/MixedCase/clientset/versioned/typed/example/v1/example_client.go
+++ b/staging/src/k8s.io/code-generator/_examples/MixedCase/clientset/versioned/typed/example/v1/example_client.go
@@ -20,7 +20,6 @@ package v1
 
 import (
 	rest "k8s.io/client-go/rest"
-	v1 "k8s.io/code-generator/_examples/MixedCase/apis/example/v1"
 	"k8s.io/code-generator/_examples/MixedCase/clientset/versioned/scheme"
 )
 
@@ -72,11 +71,9 @@ func New(c rest.Interface) *ExampleV1Client {
 }
 
 func setConfigDefaults(config *rest.Config) error {
-	gv := v1.SchemeGroupVersion
-	config.GroupVersion = &gv
-	config.APIPath = "/apis"
-	config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
-
+	if config.NegotiatedSerializer == nil {
+		config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
+	}
 	if config.UserAgent == "" {
 		config.UserAgent = rest.DefaultKubernetesUserAgent()
 	}

--- a/staging/src/k8s.io/code-generator/_examples/MixedCase/clientset/versioned/typed/example/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/_examples/MixedCase/clientset/versioned/typed/example/v1/testtype.go
@@ -86,6 +86,8 @@ func (c *testTypes) List(ctx context.Context, opts metav1.ListOptions) (result *
 	result = &v1.TestTypeList{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		Prefix("/apis", "example.crd.code-generator.k8s.io", "v1").
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("testtypes").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).

--- a/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/internalversion/BUILD
+++ b/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/internalversion/BUILD
@@ -13,6 +13,7 @@ go_library(
         "//staging/src/k8s.io/client-go/discovery:go_default_library",
         "//staging/src/k8s.io/client-go/rest:go_default_library",
         "//staging/src/k8s.io/client-go/util/flowcontrol:go_default_library",
+        "//staging/src/k8s.io/code-generator/_examples/apiserver/clientset/internalversion/scheme:go_default_library",
         "//staging/src/k8s.io/code-generator/_examples/apiserver/clientset/internalversion/typed/example/internalversion:go_default_library",
         "//staging/src/k8s.io/code-generator/_examples/apiserver/clientset/internalversion/typed/example2/internalversion:go_default_library",
         "//staging/src/k8s.io/code-generator/_examples/apiserver/clientset/internalversion/typed/example3.io/internalversion:go_default_library",

--- a/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/internalversion/typed/example/internalversion/example_client.go
+++ b/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/internalversion/typed/example/internalversion/example_client.go
@@ -66,16 +66,12 @@ func New(c rest.Interface) *ExampleClient {
 }
 
 func setConfigDefaults(config *rest.Config) error {
-	config.APIPath = "/apis"
 	if config.UserAgent == "" {
 		config.UserAgent = rest.DefaultKubernetesUserAgent()
 	}
-	if config.GroupVersion == nil || config.GroupVersion.Group != scheme.Scheme.PrioritizedVersionsForGroup("example.apiserver.code-generator.k8s.io")[0].Group {
-		gv := scheme.Scheme.PrioritizedVersionsForGroup("example.apiserver.code-generator.k8s.io")[0]
-		config.GroupVersion = &gv
+	if config.NegotiatedSerializer == nil {
+		config.NegotiatedSerializer = scheme.Codecs
 	}
-	config.NegotiatedSerializer = scheme.Codecs
-
 	if config.QPS == 0 {
 		config.QPS = 5
 	}

--- a/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/internalversion/typed/example/internalversion/testtype.go
+++ b/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/internalversion/typed/example/internalversion/testtype.go
@@ -86,6 +86,8 @@ func (c *testTypes) List(ctx context.Context, opts v1.ListOptions) (result *exam
 	result = &example.TestTypeList{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		Prefix("/apis", "example.apiserver.code-generator.k8s.io", "").
+		GroupVersion(example.SchemeGroupVersion).
 		Resource("testtypes").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).

--- a/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/internalversion/typed/example2/internalversion/example2_client.go
+++ b/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/internalversion/typed/example2/internalversion/example2_client.go
@@ -66,16 +66,12 @@ func New(c rest.Interface) *SecondExampleClient {
 }
 
 func setConfigDefaults(config *rest.Config) error {
-	config.APIPath = "/apis"
 	if config.UserAgent == "" {
 		config.UserAgent = rest.DefaultKubernetesUserAgent()
 	}
-	if config.GroupVersion == nil || config.GroupVersion.Group != scheme.Scheme.PrioritizedVersionsForGroup("example.test.apiserver.code-generator.k8s.io")[0].Group {
-		gv := scheme.Scheme.PrioritizedVersionsForGroup("example.test.apiserver.code-generator.k8s.io")[0]
-		config.GroupVersion = &gv
+	if config.NegotiatedSerializer == nil {
+		config.NegotiatedSerializer = scheme.Codecs
 	}
-	config.NegotiatedSerializer = scheme.Codecs
-
 	if config.QPS == 0 {
 		config.QPS = 5
 	}

--- a/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/internalversion/typed/example2/internalversion/testtype.go
+++ b/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/internalversion/typed/example2/internalversion/testtype.go
@@ -82,6 +82,8 @@ func (c *testTypes) List(ctx context.Context, opts v1.ListOptions) (result *exam
 	}
 	result = &example2.TestTypeList{}
 	err = c.client.Get().
+		Prefix("/apis", "example.test.apiserver.code-generator.k8s.io", "").
+		GroupVersion(example2.SchemeGroupVersion).
 		Resource("testtypes").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).

--- a/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/internalversion/typed/example3.io/internalversion/example3.io_client.go
+++ b/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/internalversion/typed/example3.io/internalversion/example3.io_client.go
@@ -66,16 +66,12 @@ func New(c rest.Interface) *ThirdExampleClient {
 }
 
 func setConfigDefaults(config *rest.Config) error {
-	config.APIPath = "/apis"
 	if config.UserAgent == "" {
 		config.UserAgent = rest.DefaultKubernetesUserAgent()
 	}
-	if config.GroupVersion == nil || config.GroupVersion.Group != scheme.Scheme.PrioritizedVersionsForGroup("example.dots.apiserver.code-generator.k8s.io")[0].Group {
-		gv := scheme.Scheme.PrioritizedVersionsForGroup("example.dots.apiserver.code-generator.k8s.io")[0]
-		config.GroupVersion = &gv
+	if config.NegotiatedSerializer == nil {
+		config.NegotiatedSerializer = scheme.Codecs
 	}
-	config.NegotiatedSerializer = scheme.Codecs
-
 	if config.QPS == 0 {
 		config.QPS = 5
 	}

--- a/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/internalversion/typed/example3.io/internalversion/testtype.go
+++ b/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/internalversion/typed/example3.io/internalversion/testtype.go
@@ -86,6 +86,8 @@ func (c *testTypes) List(ctx context.Context, opts v1.ListOptions) (result *exam
 	result = &example3io.TestTypeList{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		Prefix("/apis", "example.dots.apiserver.code-generator.k8s.io", "").
+		GroupVersion(example3io.SchemeGroupVersion).
 		Resource("testtypes").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).

--- a/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/versioned/BUILD
+++ b/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/versioned/BUILD
@@ -13,6 +13,7 @@ go_library(
         "//staging/src/k8s.io/client-go/discovery:go_default_library",
         "//staging/src/k8s.io/client-go/rest:go_default_library",
         "//staging/src/k8s.io/client-go/util/flowcontrol:go_default_library",
+        "//staging/src/k8s.io/code-generator/_examples/apiserver/clientset/versioned/scheme:go_default_library",
         "//staging/src/k8s.io/code-generator/_examples/apiserver/clientset/versioned/typed/example/v1:go_default_library",
         "//staging/src/k8s.io/code-generator/_examples/apiserver/clientset/versioned/typed/example2/v1:go_default_library",
         "//staging/src/k8s.io/code-generator/_examples/apiserver/clientset/versioned/typed/example3.io/v1:go_default_library",

--- a/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/versioned/typed/example/v1/example_client.go
+++ b/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/versioned/typed/example/v1/example_client.go
@@ -20,7 +20,6 @@ package v1
 
 import (
 	rest "k8s.io/client-go/rest"
-	v1 "k8s.io/code-generator/_examples/apiserver/apis/example/v1"
 	"k8s.io/code-generator/_examples/apiserver/clientset/versioned/scheme"
 )
 
@@ -67,11 +66,9 @@ func New(c rest.Interface) *ExampleV1Client {
 }
 
 func setConfigDefaults(config *rest.Config) error {
-	gv := v1.SchemeGroupVersion
-	config.GroupVersion = &gv
-	config.APIPath = "/apis"
-	config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
-
+	if config.NegotiatedSerializer == nil {
+		config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
+	}
 	if config.UserAgent == "" {
 		config.UserAgent = rest.DefaultKubernetesUserAgent()
 	}

--- a/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/versioned/typed/example/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/versioned/typed/example/v1/testtype.go
@@ -86,6 +86,8 @@ func (c *testTypes) List(ctx context.Context, opts metav1.ListOptions) (result *
 	result = &v1.TestTypeList{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		Prefix("/apis", "example.apiserver.code-generator.k8s.io", "v1").
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("testtypes").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).

--- a/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/versioned/typed/example2/v1/example2_client.go
+++ b/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/versioned/typed/example2/v1/example2_client.go
@@ -20,7 +20,6 @@ package v1
 
 import (
 	rest "k8s.io/client-go/rest"
-	v1 "k8s.io/code-generator/_examples/apiserver/apis/example2/v1"
 	"k8s.io/code-generator/_examples/apiserver/clientset/versioned/scheme"
 )
 
@@ -67,11 +66,9 @@ func New(c rest.Interface) *SecondExampleV1Client {
 }
 
 func setConfigDefaults(config *rest.Config) error {
-	gv := v1.SchemeGroupVersion
-	config.GroupVersion = &gv
-	config.APIPath = "/apis"
-	config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
-
+	if config.NegotiatedSerializer == nil {
+		config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
+	}
 	if config.UserAgent == "" {
 		config.UserAgent = rest.DefaultKubernetesUserAgent()
 	}

--- a/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/versioned/typed/example2/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/versioned/typed/example2/v1/testtype.go
@@ -86,6 +86,8 @@ func (c *testTypes) List(ctx context.Context, opts metav1.ListOptions) (result *
 	result = &v1.TestTypeList{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		Prefix("/apis", "example.test.apiserver.code-generator.k8s.io", "v1").
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("testtypes").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).

--- a/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/versioned/typed/example3.io/v1/example3.io_client.go
+++ b/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/versioned/typed/example3.io/v1/example3.io_client.go
@@ -20,7 +20,6 @@ package v1
 
 import (
 	rest "k8s.io/client-go/rest"
-	v1 "k8s.io/code-generator/_examples/apiserver/apis/example3.io/v1"
 	"k8s.io/code-generator/_examples/apiserver/clientset/versioned/scheme"
 )
 
@@ -67,11 +66,9 @@ func New(c rest.Interface) *ThirdExampleV1Client {
 }
 
 func setConfigDefaults(config *rest.Config) error {
-	gv := v1.SchemeGroupVersion
-	config.GroupVersion = &gv
-	config.APIPath = "/apis"
-	config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
-
+	if config.NegotiatedSerializer == nil {
+		config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
+	}
 	if config.UserAgent == "" {
 		config.UserAgent = rest.DefaultKubernetesUserAgent()
 	}

--- a/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/versioned/typed/example3.io/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/versioned/typed/example3.io/v1/testtype.go
@@ -86,6 +86,8 @@ func (c *testTypes) List(ctx context.Context, opts metav1.ListOptions) (result *
 	result = &v1.TestTypeList{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		Prefix("/apis", "example.dots.apiserver.code-generator.k8s.io", "v1").
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("testtypes").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).

--- a/staging/src/k8s.io/code-generator/_examples/crd/clientset/versioned/BUILD
+++ b/staging/src/k8s.io/code-generator/_examples/crd/clientset/versioned/BUILD
@@ -13,6 +13,7 @@ go_library(
         "//staging/src/k8s.io/client-go/discovery:go_default_library",
         "//staging/src/k8s.io/client-go/rest:go_default_library",
         "//staging/src/k8s.io/client-go/util/flowcontrol:go_default_library",
+        "//staging/src/k8s.io/code-generator/_examples/crd/clientset/versioned/scheme:go_default_library",
         "//staging/src/k8s.io/code-generator/_examples/crd/clientset/versioned/typed/example/v1:go_default_library",
         "//staging/src/k8s.io/code-generator/_examples/crd/clientset/versioned/typed/example2/v1:go_default_library",
     ],

--- a/staging/src/k8s.io/code-generator/_examples/crd/clientset/versioned/clientset.go
+++ b/staging/src/k8s.io/code-generator/_examples/crd/clientset/versioned/clientset.go
@@ -24,6 +24,7 @@ import (
 	discovery "k8s.io/client-go/discovery"
 	rest "k8s.io/client-go/rest"
 	flowcontrol "k8s.io/client-go/util/flowcontrol"
+	"k8s.io/code-generator/_examples/crd/clientset/versioned/scheme"
 	examplev1 "k8s.io/code-generator/_examples/crd/clientset/versioned/typed/example/v1"
 	secondexamplev1 "k8s.io/code-generator/_examples/crd/clientset/versioned/typed/example2/v1"
 )
@@ -71,21 +72,19 @@ func NewForConfig(c *rest.Config) (*Clientset, error) {
 		}
 		configShallowCopy.RateLimiter = flowcontrol.NewTokenBucketRateLimiter(configShallowCopy.QPS, configShallowCopy.Burst)
 	}
-	var cs Clientset
-	var err error
-	cs.exampleV1, err = examplev1.NewForConfig(&configShallowCopy)
-	if err != nil {
+	if err := setConfigDefaults(&configShallowCopy); err != nil {
 		return nil, err
 	}
-	cs.secondExampleV1, err = secondexamplev1.NewForConfig(&configShallowCopy)
+	client, err := rest.RESTClientFor(&configShallowCopy)
 	if err != nil {
 		return nil, err
 	}
 
-	cs.DiscoveryClient, err = discovery.NewDiscoveryClientForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
+	var cs Clientset
+	cs.exampleV1 = examplev1.New(client)
+	cs.secondExampleV1 = secondexamplev1.New(client)
+
+	cs.DiscoveryClient = discovery.NewDiscoveryClient(client)
 	return &cs, nil
 }
 
@@ -108,4 +107,15 @@ func New(c rest.Interface) *Clientset {
 
 	cs.DiscoveryClient = discovery.NewDiscoveryClient(c)
 	return &cs
+}
+
+func setConfigDefaults(config *rest.Config) error {
+	if config.NegotiatedSerializer == nil {
+		config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
+	}
+	if config.UserAgent == "" {
+		config.UserAgent = rest.DefaultKubernetesUserAgent()
+	}
+
+	return nil
 }

--- a/staging/src/k8s.io/code-generator/_examples/crd/clientset/versioned/typed/example/v1/clustertesttype.go
+++ b/staging/src/k8s.io/code-generator/_examples/crd/clientset/versioned/typed/example/v1/clustertesttype.go
@@ -86,6 +86,8 @@ func (c *clusterTestTypes) List(ctx context.Context, opts metav1.ListOptions) (r
 	}
 	result = &v1.ClusterTestTypeList{}
 	err = c.client.Get().
+		Prefix("/apis", "example.crd.code-generator.k8s.io", "v1").
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("clustertesttypes").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).

--- a/staging/src/k8s.io/code-generator/_examples/crd/clientset/versioned/typed/example/v1/example_client.go
+++ b/staging/src/k8s.io/code-generator/_examples/crd/clientset/versioned/typed/example/v1/example_client.go
@@ -20,7 +20,6 @@ package v1
 
 import (
 	rest "k8s.io/client-go/rest"
-	v1 "k8s.io/code-generator/_examples/crd/apis/example/v1"
 	"k8s.io/code-generator/_examples/crd/clientset/versioned/scheme"
 )
 
@@ -72,11 +71,9 @@ func New(c rest.Interface) *ExampleV1Client {
 }
 
 func setConfigDefaults(config *rest.Config) error {
-	gv := v1.SchemeGroupVersion
-	config.GroupVersion = &gv
-	config.APIPath = "/apis"
-	config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
-
+	if config.NegotiatedSerializer == nil {
+		config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
+	}
 	if config.UserAgent == "" {
 		config.UserAgent = rest.DefaultKubernetesUserAgent()
 	}

--- a/staging/src/k8s.io/code-generator/_examples/crd/clientset/versioned/typed/example/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/_examples/crd/clientset/versioned/typed/example/v1/testtype.go
@@ -86,6 +86,8 @@ func (c *testTypes) List(ctx context.Context, opts metav1.ListOptions) (result *
 	result = &v1.TestTypeList{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		Prefix("/apis", "example.crd.code-generator.k8s.io", "v1").
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("testtypes").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).

--- a/staging/src/k8s.io/code-generator/_examples/crd/clientset/versioned/typed/example2/v1/example2_client.go
+++ b/staging/src/k8s.io/code-generator/_examples/crd/clientset/versioned/typed/example2/v1/example2_client.go
@@ -20,7 +20,6 @@ package v1
 
 import (
 	rest "k8s.io/client-go/rest"
-	v1 "k8s.io/code-generator/_examples/crd/apis/example2/v1"
 	"k8s.io/code-generator/_examples/crd/clientset/versioned/scheme"
 )
 
@@ -67,11 +66,9 @@ func New(c rest.Interface) *SecondExampleV1Client {
 }
 
 func setConfigDefaults(config *rest.Config) error {
-	gv := v1.SchemeGroupVersion
-	config.GroupVersion = &gv
-	config.APIPath = "/apis"
-	config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
-
+	if config.NegotiatedSerializer == nil {
+		config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
+	}
 	if config.UserAgent == "" {
 		config.UserAgent = rest.DefaultKubernetesUserAgent()
 	}

--- a/staging/src/k8s.io/code-generator/_examples/crd/clientset/versioned/typed/example2/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/_examples/crd/clientset/versioned/typed/example2/v1/testtype.go
@@ -86,6 +86,8 @@ func (c *testTypes) List(ctx context.Context, opts metav1.ListOptions) (result *
 	result = &v1.TestTypeList{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		Prefix("/apis", "example.test.crd.code-generator.k8s.io", "v1").
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("testtypes").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).

--- a/staging/src/k8s.io/code-generator/cmd/client-gen/generators/client_generator.go
+++ b/staging/src/k8s.io/code-generator/cmd/client-gen/generators/client_generator.go
@@ -152,6 +152,7 @@ func packageForGroup(gv clientgentypes.GroupVersion, typeList []*types.Type, cli
 						OptionalName: strings.ToLower(c.Namers["private"].Name(t)),
 					},
 					outputPackage:    groupVersionClientPackage,
+					inputPackage:     inputPackage,
 					clientsetPackage: clientsetPackage,
 					group:            gv.Group.NonEmpty(),
 					version:          gv.Version.String(),

--- a/staging/src/k8s.io/code-generator/cmd/client-gen/generators/generator_for_group.go
+++ b/staging/src/k8s.io/code-generator/cmd/client-gen/generators/generator_for_group.go
@@ -209,16 +209,12 @@ func New(c $.restRESTClientInterface|raw$) *$.GroupGoName$$.Version$Client {
 
 var setInternalVersionClientDefaultsTemplate = `
 func setConfigDefaults(config *$.restConfig|raw$) error {
-	config.APIPath = $.apiPath$
 	if config.UserAgent == "" {
 		config.UserAgent = $.restDefaultKubernetesUserAgent|raw$()
 	}
-	if config.GroupVersion == nil || config.GroupVersion.Group != scheme.Scheme.PrioritizedVersionsForGroup("$.groupName$")[0].Group {
-		gv := scheme.Scheme.PrioritizedVersionsForGroup("$.groupName$")[0]
-		config.GroupVersion = &gv
+	if config.NegotiatedSerializer == nil {
+		config.NegotiatedSerializer = scheme.Codecs
 	}
-	config.NegotiatedSerializer = scheme.Codecs
-
 	if config.QPS == 0 {
 		config.QPS = 5
 	}
@@ -232,11 +228,9 @@ func setConfigDefaults(config *$.restConfig|raw$) error {
 
 var setClientDefaultsTemplate = `
 func setConfigDefaults(config *$.restConfig|raw$) error {
-	gv := $.SchemeGroupVersion|raw$
-	config.GroupVersion =  &gv
-	config.APIPath = $.apiPath$
-	config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
-
+	if config.NegotiatedSerializer == nil {
+		config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
+	}
 	if config.UserAgent == "" {
 		config.UserAgent = $.restDefaultKubernetesUserAgent|raw$()
 	}

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/BUILD
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/BUILD
@@ -17,6 +17,7 @@ go_library(
         "//staging/src/k8s.io/client-go/discovery:go_default_library",
         "//staging/src/k8s.io/client-go/rest:go_default_library",
         "//staging/src/k8s.io/client-go/util/flowcontrol:go_default_library",
+        "//staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme:go_default_library",
         "//staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/typed/apiregistration/v1:go_default_library",
         "//staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/typed/apiregistration/v1beta1:go_default_library",
     ],

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/clientset.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/clientset.go
@@ -24,6 +24,7 @@ import (
 	discovery "k8s.io/client-go/discovery"
 	rest "k8s.io/client-go/rest"
 	flowcontrol "k8s.io/client-go/util/flowcontrol"
+	"k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
 	apiregistrationv1 "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/typed/apiregistration/v1"
 	apiregistrationv1beta1 "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/typed/apiregistration/v1beta1"
 )
@@ -71,21 +72,19 @@ func NewForConfig(c *rest.Config) (*Clientset, error) {
 		}
 		configShallowCopy.RateLimiter = flowcontrol.NewTokenBucketRateLimiter(configShallowCopy.QPS, configShallowCopy.Burst)
 	}
-	var cs Clientset
-	var err error
-	cs.apiregistrationV1beta1, err = apiregistrationv1beta1.NewForConfig(&configShallowCopy)
-	if err != nil {
+	if err := setConfigDefaults(&configShallowCopy); err != nil {
 		return nil, err
 	}
-	cs.apiregistrationV1, err = apiregistrationv1.NewForConfig(&configShallowCopy)
+	client, err := rest.RESTClientFor(&configShallowCopy)
 	if err != nil {
 		return nil, err
 	}
 
-	cs.DiscoveryClient, err = discovery.NewDiscoveryClientForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
+	var cs Clientset
+	cs.apiregistrationV1beta1 = apiregistrationv1beta1.New(client)
+	cs.apiregistrationV1 = apiregistrationv1.New(client)
+
+	cs.DiscoveryClient = discovery.NewDiscoveryClient(client)
 	return &cs, nil
 }
 
@@ -108,4 +107,15 @@ func New(c rest.Interface) *Clientset {
 
 	cs.DiscoveryClient = discovery.NewDiscoveryClient(c)
 	return &cs
+}
+
+func setConfigDefaults(config *rest.Config) error {
+	if config.NegotiatedSerializer == nil {
+		config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
+	}
+	if config.UserAgent == "" {
+		config.UserAgent = rest.DefaultKubernetesUserAgent()
+	}
+
+	return nil
 }

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/typed/apiregistration/v1/apiregistration_client.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/typed/apiregistration/v1/apiregistration_client.go
@@ -20,7 +20,6 @@ package v1
 
 import (
 	rest "k8s.io/client-go/rest"
-	v1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
 	"k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
 )
 
@@ -67,11 +66,9 @@ func New(c rest.Interface) *ApiregistrationV1Client {
 }
 
 func setConfigDefaults(config *rest.Config) error {
-	gv := v1.SchemeGroupVersion
-	config.GroupVersion = &gv
-	config.APIPath = "/apis"
-	config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
-
+	if config.NegotiatedSerializer == nil {
+		config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
+	}
 	if config.UserAgent == "" {
 		config.UserAgent = rest.DefaultKubernetesUserAgent()
 	}

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/typed/apiregistration/v1/apiservice.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/typed/apiregistration/v1/apiservice.go
@@ -82,6 +82,8 @@ func (c *aPIServices) List(ctx context.Context, opts metav1.ListOptions) (result
 	}
 	result = &v1.APIServiceList{}
 	err = c.client.Get().
+		Prefix("/apis", "apiregistration.k8s.io", "v1").
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("apiservices").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/typed/apiregistration/v1beta1/apiregistration_client.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/typed/apiregistration/v1beta1/apiregistration_client.go
@@ -20,7 +20,6 @@ package v1beta1
 
 import (
 	rest "k8s.io/client-go/rest"
-	v1beta1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1"
 	"k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
 )
 
@@ -67,11 +66,9 @@ func New(c rest.Interface) *ApiregistrationV1beta1Client {
 }
 
 func setConfigDefaults(config *rest.Config) error {
-	gv := v1beta1.SchemeGroupVersion
-	config.GroupVersion = &gv
-	config.APIPath = "/apis"
-	config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
-
+	if config.NegotiatedSerializer == nil {
+		config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
+	}
 	if config.UserAgent == "" {
 		config.UserAgent = rest.DefaultKubernetesUserAgent()
 	}

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/typed/apiregistration/v1beta1/apiservice.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/typed/apiregistration/v1beta1/apiservice.go
@@ -82,6 +82,8 @@ func (c *aPIServices) List(ctx context.Context, opts v1.ListOptions) (result *v1
 	}
 	result = &v1beta1.APIServiceList{}
 	err = c.client.Get().
+		Prefix("/apis", "apiregistration.k8s.io", "v1beta1").
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("apiservices").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).

--- a/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/BUILD
+++ b/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/BUILD
@@ -13,6 +13,7 @@ go_library(
         "//staging/src/k8s.io/client-go/discovery:go_default_library",
         "//staging/src/k8s.io/client-go/rest:go_default_library",
         "//staging/src/k8s.io/client-go/util/flowcontrol:go_default_library",
+        "//staging/src/k8s.io/metrics/pkg/client/clientset/versioned/scheme:go_default_library",
         "//staging/src/k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1alpha1:go_default_library",
         "//staging/src/k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1beta1:go_default_library",
     ],

--- a/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/clientset.go
+++ b/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/clientset.go
@@ -24,6 +24,7 @@ import (
 	discovery "k8s.io/client-go/discovery"
 	rest "k8s.io/client-go/rest"
 	flowcontrol "k8s.io/client-go/util/flowcontrol"
+	"k8s.io/metrics/pkg/client/clientset/versioned/scheme"
 	metricsv1alpha1 "k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1alpha1"
 	metricsv1beta1 "k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1beta1"
 )
@@ -71,21 +72,19 @@ func NewForConfig(c *rest.Config) (*Clientset, error) {
 		}
 		configShallowCopy.RateLimiter = flowcontrol.NewTokenBucketRateLimiter(configShallowCopy.QPS, configShallowCopy.Burst)
 	}
-	var cs Clientset
-	var err error
-	cs.metricsV1alpha1, err = metricsv1alpha1.NewForConfig(&configShallowCopy)
-	if err != nil {
+	if err := setConfigDefaults(&configShallowCopy); err != nil {
 		return nil, err
 	}
-	cs.metricsV1beta1, err = metricsv1beta1.NewForConfig(&configShallowCopy)
+	client, err := rest.RESTClientFor(&configShallowCopy)
 	if err != nil {
 		return nil, err
 	}
 
-	cs.DiscoveryClient, err = discovery.NewDiscoveryClientForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
+	var cs Clientset
+	cs.metricsV1alpha1 = metricsv1alpha1.New(client)
+	cs.metricsV1beta1 = metricsv1beta1.New(client)
+
+	cs.DiscoveryClient = discovery.NewDiscoveryClient(client)
 	return &cs, nil
 }
 
@@ -108,4 +107,15 @@ func New(c rest.Interface) *Clientset {
 
 	cs.DiscoveryClient = discovery.NewDiscoveryClient(c)
 	return &cs
+}
+
+func setConfigDefaults(config *rest.Config) error {
+	if config.NegotiatedSerializer == nil {
+		config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
+	}
+	if config.UserAgent == "" {
+		config.UserAgent = rest.DefaultKubernetesUserAgent()
+	}
+
+	return nil
 }

--- a/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1alpha1/metrics_client.go
+++ b/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1alpha1/metrics_client.go
@@ -20,7 +20,6 @@ package v1alpha1
 
 import (
 	rest "k8s.io/client-go/rest"
-	v1alpha1 "k8s.io/metrics/pkg/apis/metrics/v1alpha1"
 	"k8s.io/metrics/pkg/client/clientset/versioned/scheme"
 )
 
@@ -72,11 +71,9 @@ func New(c rest.Interface) *MetricsV1alpha1Client {
 }
 
 func setConfigDefaults(config *rest.Config) error {
-	gv := v1alpha1.SchemeGroupVersion
-	config.GroupVersion = &gv
-	config.APIPath = "/apis"
-	config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
-
+	if config.NegotiatedSerializer == nil {
+		config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
+	}
 	if config.UserAgent == "" {
 		config.UserAgent = rest.DefaultKubernetesUserAgent()
 	}

--- a/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1alpha1/nodemetrics.go
+++ b/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1alpha1/nodemetrics.go
@@ -75,6 +75,8 @@ func (c *nodeMetricses) List(ctx context.Context, opts v1.ListOptions) (result *
 	}
 	result = &v1alpha1.NodeMetricsList{}
 	err = c.client.Get().
+		Prefix("/apis", "metrics.k8s.io", "v1alpha1").
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("nodes").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).

--- a/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1alpha1/podmetrics.go
+++ b/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1alpha1/podmetrics.go
@@ -79,6 +79,8 @@ func (c *podMetricses) List(ctx context.Context, opts v1.ListOptions) (result *v
 	result = &v1alpha1.PodMetricsList{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		Prefix("/apis", "metrics.k8s.io", "v1alpha1").
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("pods").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).

--- a/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1beta1/metrics_client.go
+++ b/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1beta1/metrics_client.go
@@ -20,7 +20,6 @@ package v1beta1
 
 import (
 	rest "k8s.io/client-go/rest"
-	v1beta1 "k8s.io/metrics/pkg/apis/metrics/v1beta1"
 	"k8s.io/metrics/pkg/client/clientset/versioned/scheme"
 )
 
@@ -72,11 +71,9 @@ func New(c rest.Interface) *MetricsV1beta1Client {
 }
 
 func setConfigDefaults(config *rest.Config) error {
-	gv := v1beta1.SchemeGroupVersion
-	config.GroupVersion = &gv
-	config.APIPath = "/apis"
-	config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
-
+	if config.NegotiatedSerializer == nil {
+		config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
+	}
 	if config.UserAgent == "" {
 		config.UserAgent = rest.DefaultKubernetesUserAgent()
 	}

--- a/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1beta1/nodemetrics.go
+++ b/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1beta1/nodemetrics.go
@@ -75,6 +75,8 @@ func (c *nodeMetricses) List(ctx context.Context, opts v1.ListOptions) (result *
 	}
 	result = &v1beta1.NodeMetricsList{}
 	err = c.client.Get().
+		Prefix("/apis", "metrics.k8s.io", "v1beta1").
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("nodes").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).

--- a/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1beta1/podmetrics.go
+++ b/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1beta1/podmetrics.go
@@ -79,6 +79,8 @@ func (c *podMetricses) List(ctx context.Context, opts v1.ListOptions) (result *v
 	result = &v1beta1.PodMetricsList{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		Prefix("/apis", "metrics.k8s.io", "v1beta1").
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("pods").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).

--- a/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/BUILD
+++ b/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/BUILD
@@ -13,6 +13,7 @@ go_library(
         "//staging/src/k8s.io/client-go/discovery:go_default_library",
         "//staging/src/k8s.io/client-go/rest:go_default_library",
         "//staging/src/k8s.io/client-go/util/flowcontrol:go_default_library",
+        "//staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/scheme:go_default_library",
         "//staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/typed/wardle/v1alpha1:go_default_library",
         "//staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/typed/wardle/v1beta1:go_default_library",
     ],

--- a/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/typed/wardle/v1alpha1/fischer.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/typed/wardle/v1alpha1/fischer.go
@@ -81,6 +81,8 @@ func (c *fischers) List(ctx context.Context, opts v1.ListOptions) (result *v1alp
 	}
 	result = &v1alpha1.FischerList{}
 	err = c.client.Get().
+		Prefix("/apis", "wardle.example.com", "v1alpha1").
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("fischers").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).

--- a/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/typed/wardle/v1alpha1/flunder.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/typed/wardle/v1alpha1/flunder.go
@@ -86,6 +86,8 @@ func (c *flunders) List(ctx context.Context, opts v1.ListOptions) (result *v1alp
 	result = &v1alpha1.FlunderList{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		Prefix("/apis", "wardle.example.com", "v1alpha1").
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("flunders").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).

--- a/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/typed/wardle/v1alpha1/wardle_client.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/typed/wardle/v1alpha1/wardle_client.go
@@ -20,7 +20,6 @@ package v1alpha1
 
 import (
 	rest "k8s.io/client-go/rest"
-	v1alpha1 "k8s.io/sample-apiserver/pkg/apis/wardle/v1alpha1"
 	"k8s.io/sample-apiserver/pkg/generated/clientset/versioned/scheme"
 )
 
@@ -72,11 +71,9 @@ func New(c rest.Interface) *WardleV1alpha1Client {
 }
 
 func setConfigDefaults(config *rest.Config) error {
-	gv := v1alpha1.SchemeGroupVersion
-	config.GroupVersion = &gv
-	config.APIPath = "/apis"
-	config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
-
+	if config.NegotiatedSerializer == nil {
+		config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
+	}
 	if config.UserAgent == "" {
 		config.UserAgent = rest.DefaultKubernetesUserAgent()
 	}

--- a/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/typed/wardle/v1beta1/flunder.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/typed/wardle/v1beta1/flunder.go
@@ -86,6 +86,8 @@ func (c *flunders) List(ctx context.Context, opts v1.ListOptions) (result *v1bet
 	result = &v1beta1.FlunderList{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		Prefix("/apis", "wardle.example.com", "v1beta1").
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("flunders").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).

--- a/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/typed/wardle/v1beta1/wardle_client.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/typed/wardle/v1beta1/wardle_client.go
@@ -20,7 +20,6 @@ package v1beta1
 
 import (
 	rest "k8s.io/client-go/rest"
-	v1beta1 "k8s.io/sample-apiserver/pkg/apis/wardle/v1beta1"
 	"k8s.io/sample-apiserver/pkg/generated/clientset/versioned/scheme"
 )
 
@@ -67,11 +66,9 @@ func New(c rest.Interface) *WardleV1beta1Client {
 }
 
 func setConfigDefaults(config *rest.Config) error {
-	gv := v1beta1.SchemeGroupVersion
-	config.GroupVersion = &gv
-	config.APIPath = "/apis"
-	config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
-
+	if config.NegotiatedSerializer == nil {
+		config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
+	}
 	if config.UserAgent == "" {
 		config.UserAgent = rest.DefaultKubernetesUserAgent()
 	}

--- a/staging/src/k8s.io/sample-controller/pkg/generated/clientset/versioned/BUILD
+++ b/staging/src/k8s.io/sample-controller/pkg/generated/clientset/versioned/BUILD
@@ -13,6 +13,7 @@ go_library(
         "//staging/src/k8s.io/client-go/discovery:go_default_library",
         "//staging/src/k8s.io/client-go/rest:go_default_library",
         "//staging/src/k8s.io/client-go/util/flowcontrol:go_default_library",
+        "//staging/src/k8s.io/sample-controller/pkg/generated/clientset/versioned/scheme:go_default_library",
         "//staging/src/k8s.io/sample-controller/pkg/generated/clientset/versioned/typed/samplecontroller/v1alpha1:go_default_library",
     ],
 )

--- a/staging/src/k8s.io/sample-controller/pkg/generated/clientset/versioned/clientset.go
+++ b/staging/src/k8s.io/sample-controller/pkg/generated/clientset/versioned/clientset.go
@@ -24,6 +24,7 @@ import (
 	discovery "k8s.io/client-go/discovery"
 	rest "k8s.io/client-go/rest"
 	flowcontrol "k8s.io/client-go/util/flowcontrol"
+	"k8s.io/sample-controller/pkg/generated/clientset/versioned/scheme"
 	samplecontrollerv1alpha1 "k8s.io/sample-controller/pkg/generated/clientset/versioned/typed/samplecontroller/v1alpha1"
 )
 
@@ -63,17 +64,18 @@ func NewForConfig(c *rest.Config) (*Clientset, error) {
 		}
 		configShallowCopy.RateLimiter = flowcontrol.NewTokenBucketRateLimiter(configShallowCopy.QPS, configShallowCopy.Burst)
 	}
-	var cs Clientset
-	var err error
-	cs.samplecontrollerV1alpha1, err = samplecontrollerv1alpha1.NewForConfig(&configShallowCopy)
+	if err := setConfigDefaults(&configShallowCopy); err != nil {
+		return nil, err
+	}
+	client, err := rest.RESTClientFor(&configShallowCopy)
 	if err != nil {
 		return nil, err
 	}
 
-	cs.DiscoveryClient, err = discovery.NewDiscoveryClientForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
+	var cs Clientset
+	cs.samplecontrollerV1alpha1 = samplecontrollerv1alpha1.New(client)
+
+	cs.DiscoveryClient = discovery.NewDiscoveryClient(client)
 	return &cs, nil
 }
 
@@ -94,4 +96,15 @@ func New(c rest.Interface) *Clientset {
 
 	cs.DiscoveryClient = discovery.NewDiscoveryClient(c)
 	return &cs
+}
+
+func setConfigDefaults(config *rest.Config) error {
+	if config.NegotiatedSerializer == nil {
+		config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
+	}
+	if config.UserAgent == "" {
+		config.UserAgent = rest.DefaultKubernetesUserAgent()
+	}
+
+	return nil
 }

--- a/staging/src/k8s.io/sample-controller/pkg/generated/clientset/versioned/typed/samplecontroller/v1alpha1/foo.go
+++ b/staging/src/k8s.io/sample-controller/pkg/generated/clientset/versioned/typed/samplecontroller/v1alpha1/foo.go
@@ -86,6 +86,8 @@ func (c *foos) List(ctx context.Context, opts v1.ListOptions) (result *v1alpha1.
 	result = &v1alpha1.FooList{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		Prefix("/apis", "samplecontroller.k8s.io", "v1alpha1").
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("foos").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).

--- a/staging/src/k8s.io/sample-controller/pkg/generated/clientset/versioned/typed/samplecontroller/v1alpha1/samplecontroller_client.go
+++ b/staging/src/k8s.io/sample-controller/pkg/generated/clientset/versioned/typed/samplecontroller/v1alpha1/samplecontroller_client.go
@@ -20,7 +20,6 @@ package v1alpha1
 
 import (
 	rest "k8s.io/client-go/rest"
-	v1alpha1 "k8s.io/sample-controller/pkg/apis/samplecontroller/v1alpha1"
 	"k8s.io/sample-controller/pkg/generated/clientset/versioned/scheme"
 )
 
@@ -67,11 +66,9 @@ func New(c rest.Interface) *SamplecontrollerV1alpha1Client {
 }
 
 func setConfigDefaults(config *rest.Config) error {
-	gv := v1alpha1.SchemeGroupVersion
-	config.GroupVersion = &gv
-	config.APIPath = "/apis"
-	config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
-
+	if config.NegotiatedSerializer == nil {
+		config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
+	}
 	if config.UserAgent == "" {
 		config.UserAgent = rest.DefaultKubernetesUserAgent()
 	}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Allows constructing a clientset from a restclient to actually work for multiple group versions

**Which issue(s) this PR fixes**:
xref #91913

```release-note
NONE
```

/cc @enj 