### PR TITLE
Fix golint errors for pkg/cmd/apply

### DIFF
--- a/hack/.golint_failures
+++ b/hack/.golint_failures
@@ -410,7 +410,6 @@ staging/src/k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1
 staging/src/k8s.io/kube-aggregator/pkg/apiserver
 staging/src/k8s.io/kube-aggregator/pkg/controllers/autoregister
 staging/src/k8s.io/kubectl/pkg/cmd/annotate
-staging/src/k8s.io/kubectl/pkg/cmd/apply
 staging/src/k8s.io/kubectl/pkg/cmd/attach
 staging/src/k8s.io/kubectl/pkg/cmd/autoscale
 staging/src/k8s.io/kubectl/pkg/cmd/certificates

--- a/staging/src/k8s.io/kubectl/pkg/cmd/apply/patcher.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apply/patcher.go
@@ -72,7 +72,7 @@ type Patcher struct {
 	OpenapiSchema openapi.Resources
 }
 
-func newPatcher(o *ApplyOptions, info *resource.Info, helper *resource.Helper) (*Patcher, error) {
+func newPatcher(o *Options, info *resource.Info, helper *resource.Helper) (*Patcher, error) {
 	var openapiSchema openapi.Resources
 	if o.OpenAPIPatch {
 		openapiSchema = o.OpenAPISchema

--- a/staging/src/k8s.io/kubectl/pkg/cmd/apply/prune.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apply/prune.go
@@ -50,7 +50,7 @@ type pruner struct {
 	out io.Writer
 }
 
-func newPruner(o *ApplyOptions) pruner {
+func newPruner(o *Options) pruner {
 	return pruner{
 		mapper:        o.Mapper,
 		dynamicClient: o.DynamicClient,
@@ -69,7 +69,7 @@ func newPruner(o *ApplyOptions) pruner {
 	}
 }
 
-func (p *pruner) pruneAll(o *ApplyOptions) error {
+func (p *pruner) pruneAll(o *Options) error {
 
 	namespacedRESTMappings, nonNamespacedRESTMappings, err := getRESTMappings(o.Mapper, &(o.PruneResources))
 	if err != nil {


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
This PR fixed golint issues in `pkg/cmd/apply`

Errors from golint:
```
staging/src/k8s.io/kubectl/pkg/cmd/apply/apply.go:50:6: type name will be used as apply.ApplyOptions by other packages, and that stutters; consider calling this Options
staging/src/k8s.io/kubectl/pkg/cmd/apply/apply.go:655:1: comment on exported method ApplyOptions.MarkObjectVisited should be of the form "MarkObjectVisited ..."
staging/src/k8s.io/kubectl/pkg/cmd/apply/apply.go:666:1: comment on exported method ApplyOptions.PrintAndPrunePostProcessor should be of the form "PrintAndPrunePostProcessor ..."

```

**Which issue(s) this PR fixes**:
Part of #68026

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs

```
