### PR TITLE
Preparation for Topology migration to GA for CSI migration

### DIFF
--- a/plugin/pkg/admission/storage/persistentvolume/label/admission_test.go
+++ b/plugin/pkg/admission/storage/persistentvolume/label/admission_test.go
@@ -66,9 +66,9 @@ func Test_PVLAdmission(t *testing.T) {
 			name:    "non-cloud PV ignored",
 			handler: newPersistentVolumeLabel(),
 			pvlabeler: mockVolumeLabels(map[string]string{
-				"a":                           "1",
-				"b":                           "2",
-				v1.LabelFailureDomainBetaZone: "1__2__3",
+				"a":                  "1",
+				"b":                  "2",
+				v1.LabelTopologyZone: "1__2__3",
 			}),
 			preAdmissionPV: &api.PersistentVolume{
 				ObjectMeta: metav1.ObjectMeta{Name: "noncloud", Namespace: "myns"},
@@ -234,7 +234,7 @@ func Test_PVLAdmission(t *testing.T) {
 			err: nil,
 		},
 		{
-			name:    "existing labels from dynamic provisioning are not changed",
+			name:    "existing Beta labels from dynamic provisioning are not changed",
 			handler: newPersistentVolumeLabel(),
 			pvlabeler: mockVolumeLabels(map[string]string{
 				v1.LabelFailureDomainBetaZone:   "domain1",
@@ -289,6 +289,74 @@ func Test_PVLAdmission(t *testing.T) {
 										},
 										{
 											Key:      v1.LabelFailureDomainBetaZone,
+											Operator: api.NodeSelectorOpIn,
+											Values:   []string{"existingDomain"},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			err: nil,
+		},
+		{
+			name:    "existing GA labels from dynamic provisioning are not changed",
+			handler: newPersistentVolumeLabel(),
+			pvlabeler: mockVolumeLabels(map[string]string{
+				v1.LabelTopologyZone:   "domain1",
+				v1.LabelTopologyRegion: "region1",
+			}),
+			preAdmissionPV: &api.PersistentVolume{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "awsebs", Namespace: "myns",
+					Labels: map[string]string{
+						v1.LabelTopologyZone:   "existingDomain",
+						v1.LabelTopologyRegion: "existingRegion",
+					},
+					Annotations: map[string]string{
+						persistentvolume.AnnDynamicallyProvisioned: "kubernetes.io/aws-ebs",
+					},
+				},
+				Spec: api.PersistentVolumeSpec{
+					PersistentVolumeSource: api.PersistentVolumeSource{
+						AWSElasticBlockStore: &api.AWSElasticBlockStoreVolumeSource{
+							VolumeID: "123",
+						},
+					},
+				},
+			},
+			postAdmissionPV: &api.PersistentVolume{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "awsebs",
+					Namespace: "myns",
+					Labels: map[string]string{
+						v1.LabelTopologyZone:   "existingDomain",
+						v1.LabelTopologyRegion: "existingRegion",
+					},
+					Annotations: map[string]string{
+						persistentvolume.AnnDynamicallyProvisioned: "kubernetes.io/aws-ebs",
+					},
+				},
+				Spec: api.PersistentVolumeSpec{
+					PersistentVolumeSource: api.PersistentVolumeSource{
+						AWSElasticBlockStore: &api.AWSElasticBlockStoreVolumeSource{
+							VolumeID: "123",
+						},
+					},
+					NodeAffinity: &api.VolumeNodeAffinity{
+						Required: &api.NodeSelector{
+							NodeSelectorTerms: []api.NodeSelectorTerm{
+								{
+									MatchExpressions: []api.NodeSelectorRequirement{
+										{
+											Key:      v1.LabelTopologyRegion,
+											Operator: api.NodeSelectorOpIn,
+											Values:   []string{"existingRegion"},
+										},
+										{
+											Key:      v1.LabelTopologyZone,
 											Operator: api.NodeSelectorOpIn,
 											Values:   []string{"existingDomain"},
 										},
@@ -367,9 +435,9 @@ func Test_PVLAdmission(t *testing.T) {
 			name:    "GCE PD PV labeled correctly",
 			handler: newPersistentVolumeLabel(),
 			pvlabeler: mockVolumeLabels(map[string]string{
-				"a":                           "1",
-				"b":                           "2",
-				v1.LabelFailureDomainBetaZone: "1__2__3",
+				"a":                  "1",
+				"b":                  "2",
+				v1.LabelTopologyZone: "1__2__3",
 			}),
 			preAdmissionPV: &api.PersistentVolume{
 				ObjectMeta: metav1.ObjectMeta{Name: "gcepd", Namespace: "myns"},
@@ -386,9 +454,9 @@ func Test_PVLAdmission(t *testing.T) {
 					Name:      "gcepd",
 					Namespace: "myns",
 					Labels: map[string]string{
-						"a":                           "1",
-						"b":                           "2",
-						v1.LabelFailureDomainBetaZone: "1__2__3",
+						"a":                  "1",
+						"b":                  "2",
+						v1.LabelTopologyZone: "1__2__3",
 					},
 				},
 				Spec: api.PersistentVolumeSpec{
@@ -413,7 +481,7 @@ func Test_PVLAdmission(t *testing.T) {
 											Values:   []string{"2"},
 										},
 										{
-											Key:      v1.LabelFailureDomainBetaZone,
+											Key:      v1.LabelTopologyZone,
 											Operator: api.NodeSelectorOpIn,
 											Values:   []string{"1", "2", "3"},
 										},

--- a/staging/src/k8s.io/cloud-provider/volume/helpers/zones.go
+++ b/staging/src/k8s.io/cloud-provider/volume/helpers/zones.go
@@ -23,7 +23,7 @@ import (
 	"strconv"
 	"strings"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	cloudvolume "k8s.io/cloud-provider/volume"
 	"k8s.io/klog/v2"
@@ -118,9 +118,12 @@ func SelectZonesForVolume(zoneParameterPresent, zonesParameterPresent bool, zone
 
 		// pick node's zone for one of the replicas
 		var ok bool
-		zoneFromNode, ok = node.ObjectMeta.Labels[v1.LabelFailureDomainBetaZone]
+		zoneFromNode, ok = node.ObjectMeta.Labels[v1.LabelTopologyZone]
 		if !ok {
-			return nil, fmt.Errorf("%s Label for node missing", v1.LabelFailureDomainBetaZone)
+			zoneFromNode, ok = node.ObjectMeta.Labels[v1.LabelFailureDomainBetaZone]
+			if !ok {
+				return nil, fmt.Errorf("Either %s or %s Label for node missing", v1.LabelTopologyZone, v1.LabelFailureDomainBetaZone)
+			}
 		}
 		// if single replica volume and node with zone found, return immediately
 		if numReplicas == 1 {
@@ -135,7 +138,7 @@ func SelectZonesForVolume(zoneParameterPresent, zonesParameterPresent bool, zone
 	}
 
 	if (len(allowedTopologies) > 0) && (allowedZones.Len() == 0) {
-		return nil, fmt.Errorf("no matchLabelExpressions with %s key found in allowedTopologies. Please specify matchLabelExpressions with %s key", v1.LabelFailureDomainBetaZone, v1.LabelFailureDomainBetaZone)
+		return nil, fmt.Errorf("no matchLabelExpressions with %s key found in allowedTopologies. Please specify matchLabelExpressions with %s key", v1.LabelTopologyZone, v1.LabelTopologyZone)
 	}
 
 	if allowedZones.Len() > 0 {
@@ -185,7 +188,7 @@ func ZonesFromAllowedTopologies(allowedTopologies []v1.TopologySelectorTerm) (se
 	zones := make(sets.String)
 	for _, term := range allowedTopologies {
 		for _, exp := range term.MatchLabelExpressions {
-			if exp.Key == v1.LabelFailureDomainBetaZone {
+			if exp.Key == v1.LabelTopologyZone || exp.Key == v1.LabelFailureDomainBetaZone {
 				for _, value := range exp.Values {
 					zones.Insert(value)
 				}

--- a/staging/src/k8s.io/cloud-provider/volume/helpers/zones_test.go
+++ b/staging/src/k8s.io/cloud-provider/volume/helpers/zones_test.go
@@ -20,7 +20,7 @@ import (
 	"hash/fnv"
 	"testing"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 )
 
@@ -416,8 +416,11 @@ func TestChooseZonesForVolume(t *testing.T) {
 
 func TestSelectZoneForVolume(t *testing.T) {
 
-	nodeWithZoneLabels := &v1.Node{}
-	nodeWithZoneLabels.Labels = map[string]string{v1.LabelFailureDomainBetaZone: "zoneX"}
+	nodeWithGATopologyLabels := &v1.Node{}
+	nodeWithGATopologyLabels.Labels = map[string]string{v1.LabelTopologyZone: "zoneX"}
+
+	nodeWithBetaTopologyLabels := &v1.Node{}
+	nodeWithBetaTopologyLabels.Labels = map[string]string{v1.LabelFailureDomainBetaZone: "zoneY"}
 
 	nodeWithNoLabels := &v1.Node{}
 
@@ -468,7 +471,7 @@ func TestSelectZoneForVolume(t *testing.T) {
 		// [3] AllowedTopologies irrelevant
 		{
 			Name:        "Node_with_Zone_labels_and_Zone_parameter_present",
-			Node:        nodeWithZoneLabels,
+			Node:        nodeWithGATopologyLabels,
 			ZonePresent: true,
 			Zone:        "zoneX",
 			Reject:      true,
@@ -480,7 +483,7 @@ func TestSelectZoneForVolume(t *testing.T) {
 		// [3] AllowedTopologies irrelevant
 		{
 			Name:         "Node_with_Zone_labels_and_Zones_parameter_present",
-			Node:         nodeWithZoneLabels,
+			Node:         nodeWithGATopologyLabels,
 			ZonesPresent: true,
 			Zones:        "zoneX,zoneY",
 			Reject:       true,
@@ -499,7 +502,7 @@ func TestSelectZoneForVolume(t *testing.T) {
 				{
 					MatchLabelExpressions: []v1.TopologySelectorLabelRequirement{
 						{
-							Key:    v1.LabelFailureDomainBetaZone,
+							Key:    v1.LabelTopologyZone,
 							Values: []string{"zoneX"},
 						},
 					},
@@ -521,7 +524,7 @@ func TestSelectZoneForVolume(t *testing.T) {
 				{
 					MatchLabelExpressions: []v1.TopologySelectorLabelRequirement{
 						{
-							Key:    v1.LabelFailureDomainBetaZone,
+							Key:    v1.LabelTopologyZone,
 							Values: []string{"zoneX"},
 						},
 					},
@@ -530,7 +533,7 @@ func TestSelectZoneForVolume(t *testing.T) {
 			Reject: true,
 		},
 
-		// Key specified in AllowedTopologies is not LabelFailureDomainBetaZone [Fail]
+		// Key specified in AllowedTopologies is not LabelTopologyZone [Fail]
 		// [1] nil Node
 		// [2] no Zone/Zones parameter
 		// [3] AllowedTopologies with invalid key specified
@@ -545,7 +548,7 @@ func TestSelectZoneForVolume(t *testing.T) {
 							Values: []string{"zoneX"},
 						},
 						{
-							Key:    v1.LabelFailureDomainBetaZone,
+							Key:    v1.LabelTopologyZone,
 							Values: []string{"zoneY"},
 						},
 					},
@@ -554,7 +557,7 @@ func TestSelectZoneForVolume(t *testing.T) {
 			Reject: true,
 		},
 
-		// AllowedTopologies without keys specifying LabelFailureDomainBetaZone [Fail]
+		// AllowedTopologies without keys specifying LabelTopologyZone [Fail]
 		// [1] nil Node
 		// [2] no Zone/Zones parameter
 		// [3] Invalid AllowedTopologies
@@ -610,16 +613,28 @@ func TestSelectZoneForVolume(t *testing.T) {
 			ExpectedZones: "zoneX,zoneY",
 		},
 
-		// Select zone from node label [Pass]
+		// Select zone from node ga label [Pass]
 		// [1] Node with zone labels
 		// [2] no zone/zones parameters
 		// [3] no AllowedTopology
 		{
-			Name:               "Node_with_Zone_labels_and_VolumeScheduling_enabled",
-			Node:               nodeWithZoneLabels,
+			Name:               "Node_with_GA_Zone_labels_and_VolumeScheduling_enabled",
+			Node:               nodeWithGATopologyLabels,
 			Reject:             false,
 			ExpectSpecificZone: true,
 			ExpectedZone:       "zoneX",
+		},
+
+		// Select zone from node beta label [Pass]
+		// [1] Node with zone labels
+		// [2] no zone/zones parameters
+		// [3] no AllowedTopology
+		{
+			Name:               "Node_with_Beta_Zone_labels_and_VolumeScheduling_enabled",
+			Node:               nodeWithBetaTopologyLabels,
+			Reject:             false,
+			ExpectSpecificZone: true,
+			ExpectedZone:       "zoneY",
 		},
 
 		// Select zone from node label [Pass]
@@ -628,12 +643,12 @@ func TestSelectZoneForVolume(t *testing.T) {
 		// [3] AllowedTopology with single term with multiple values specified (ignored)
 		{
 			Name: "Node_with_Zone_labels_and_Multiple_Allowed_Topology_values_and_VolumeScheduling_enabled",
-			Node: nodeWithZoneLabels,
+			Node: nodeWithGATopologyLabels,
 			AllowedTopologies: []v1.TopologySelectorTerm{
 				{
 					MatchLabelExpressions: []v1.TopologySelectorLabelRequirement{
 						{
-							Key:    v1.LabelFailureDomainBetaZone,
+							Key:    v1.LabelTopologyZone,
 							Values: []string{"zoneZ", "zoneY"},
 						},
 					},
@@ -650,6 +665,27 @@ func TestSelectZoneForVolume(t *testing.T) {
 		// [3] AllowedTopologies with single term with multiple values specified
 		{
 			Name: "Nil_Node_with_Multiple_Allowed_Topology_values_and_VolumeScheduling_enabled",
+			Node: nil,
+			AllowedTopologies: []v1.TopologySelectorTerm{
+				{
+					MatchLabelExpressions: []v1.TopologySelectorLabelRequirement{
+						{
+							Key:    v1.LabelTopologyZone,
+							Values: []string{"zoneX", "zoneY"},
+						},
+					},
+				},
+			},
+			Reject:        false,
+			ExpectedZones: "zoneX,zoneY",
+		},
+
+		// Select Zone from AllowedTopologies using Beta labels [Pass]
+		// [1] nil Node
+		// [2] no Zone/Zones parametes specified
+		// [3] AllowedTopologies with single term with multiple values specified
+		{
+			Name: "Nil_Node_with_Multiple_Allowed_Topology_values_Beta_label_and_VolumeScheduling_enabled",
 			Node: nil,
 			AllowedTopologies: []v1.TopologySelectorTerm{
 				{
@@ -676,7 +712,7 @@ func TestSelectZoneForVolume(t *testing.T) {
 				{
 					MatchLabelExpressions: []v1.TopologySelectorLabelRequirement{
 						{
-							Key:    v1.LabelFailureDomainBetaZone,
+							Key:    v1.LabelTopologyZone,
 							Values: []string{"zoneX"},
 						},
 					},
@@ -684,7 +720,7 @@ func TestSelectZoneForVolume(t *testing.T) {
 				{
 					MatchLabelExpressions: []v1.TopologySelectorLabelRequirement{
 						{
-							Key:    v1.LabelFailureDomainBetaZone,
+							Key:    v1.LabelTopologyZone,
 							Values: []string{"zoneY"},
 						},
 					},
@@ -706,7 +742,7 @@ func TestSelectZoneForVolume(t *testing.T) {
 				{
 					MatchLabelExpressions: []v1.TopologySelectorLabelRequirement{
 						{
-							Key:    v1.LabelFailureDomainBetaZone,
+							Key:    v1.LabelTopologyZone,
 							Values: []string{"zoneX"},
 						},
 					},
@@ -771,7 +807,7 @@ func TestSelectZoneForVolume(t *testing.T) {
 func TestSelectZonesForVolume(t *testing.T) {
 
 	nodeWithZoneLabels := &v1.Node{}
-	nodeWithZoneLabels.Labels = map[string]string{v1.LabelFailureDomainBetaZone: "zoneX"}
+	nodeWithZoneLabels.Labels = map[string]string{v1.LabelTopologyZone: "zoneX"}
 
 	nodeWithNoLabels := &v1.Node{}
 
@@ -865,7 +901,7 @@ func TestSelectZonesForVolume(t *testing.T) {
 				{
 					MatchLabelExpressions: []v1.TopologySelectorLabelRequirement{
 						{
-							Key:    v1.LabelFailureDomainBetaZone,
+							Key:    v1.LabelTopologyZone,
 							Values: []string{"zoneX"},
 						},
 					},
@@ -889,7 +925,7 @@ func TestSelectZonesForVolume(t *testing.T) {
 				{
 					MatchLabelExpressions: []v1.TopologySelectorLabelRequirement{
 						{
-							Key:    v1.LabelFailureDomainBetaZone,
+							Key:    v1.LabelTopologyZone,
 							Values: []string{"zoneX"},
 						},
 					},
@@ -898,7 +934,7 @@ func TestSelectZonesForVolume(t *testing.T) {
 			Reject: true,
 		},
 
-		// Key specified in AllowedTopologies is not LabelFailureDomainBetaZone [Fail]
+		// Key specified in AllowedTopologies is not LabelTopologyZone [Fail]
 		// [1] nil Node
 		// [2] no Zone/Zones parameter
 		// [3] AllowedTopologies with invalid key specified
@@ -915,7 +951,7 @@ func TestSelectZonesForVolume(t *testing.T) {
 							Values: []string{"zoneX"},
 						},
 						{
-							Key:    v1.LabelFailureDomainBetaZone,
+							Key:    v1.LabelTopologyZone,
 							Values: []string{"zoneY"},
 						},
 					},
@@ -924,7 +960,7 @@ func TestSelectZonesForVolume(t *testing.T) {
 			Reject: true,
 		},
 
-		// AllowedTopologies without keys specifying LabelFailureDomainBetaZone [Fail]
+		// AllowedTopologies without keys specifying LabelTopologyZone [Fail]
 		// [1] nil Node
 		// [2] no Zone/Zones parameter
 		// [3] Invalid AllowedTopologies
@@ -999,7 +1035,7 @@ func TestSelectZonesForVolume(t *testing.T) {
 				{
 					MatchLabelExpressions: []v1.TopologySelectorLabelRequirement{
 						{
-							Key:    v1.LabelFailureDomainBetaZone,
+							Key:    v1.LabelTopologyZone,
 							Values: []string{"zoneX"},
 						},
 					},
@@ -1123,7 +1159,7 @@ func TestSelectZonesForVolume(t *testing.T) {
 				{
 					MatchLabelExpressions: []v1.TopologySelectorLabelRequirement{
 						{
-							Key:    v1.LabelFailureDomainBetaZone,
+							Key:    v1.LabelTopologyZone,
 							Values: []string{"zoneV", "zoneW", "zoneX", "zoneY", "zoneZ"},
 						},
 					},
@@ -1149,7 +1185,7 @@ func TestSelectZonesForVolume(t *testing.T) {
 				{
 					MatchLabelExpressions: []v1.TopologySelectorLabelRequirement{
 						{
-							Key:    v1.LabelFailureDomainBetaZone,
+							Key:    v1.LabelTopologyZone,
 							Values: []string{"zoneX", "zoneY"},
 						},
 					},
@@ -1176,7 +1212,7 @@ func TestSelectZonesForVolume(t *testing.T) {
 				{
 					MatchLabelExpressions: []v1.TopologySelectorLabelRequirement{
 						{
-							Key:    v1.LabelFailureDomainBetaZone,
+							Key:    v1.LabelTopologyZone,
 							Values: []string{"zoneX", "zoneY", "zoneZ"},
 						},
 					},
@@ -1200,7 +1236,7 @@ func TestSelectZonesForVolume(t *testing.T) {
 				{
 					MatchLabelExpressions: []v1.TopologySelectorLabelRequirement{
 						{
-							Key:    v1.LabelFailureDomainBetaZone,
+							Key:    v1.LabelTopologyZone,
 							Values: []string{"zoneX", "zoneY"},
 						},
 					},
@@ -1228,7 +1264,7 @@ func TestSelectZonesForVolume(t *testing.T) {
 				{
 					MatchLabelExpressions: []v1.TopologySelectorLabelRequirement{
 						{
-							Key:    v1.LabelFailureDomainBetaZone,
+							Key:    v1.LabelTopologyZone,
 							Values: []string{"zoneV"},
 						},
 					},
@@ -1236,7 +1272,7 @@ func TestSelectZonesForVolume(t *testing.T) {
 				{
 					MatchLabelExpressions: []v1.TopologySelectorLabelRequirement{
 						{
-							Key:    v1.LabelFailureDomainBetaZone,
+							Key:    v1.LabelTopologyZone,
 							Values: []string{"zoneW"},
 						},
 					},
@@ -1244,7 +1280,7 @@ func TestSelectZonesForVolume(t *testing.T) {
 				{
 					MatchLabelExpressions: []v1.TopologySelectorLabelRequirement{
 						{
-							Key:    v1.LabelFailureDomainBetaZone,
+							Key:    v1.LabelTopologyZone,
 							Values: []string{"zoneX"},
 						},
 					},
@@ -1252,7 +1288,7 @@ func TestSelectZonesForVolume(t *testing.T) {
 				{
 					MatchLabelExpressions: []v1.TopologySelectorLabelRequirement{
 						{
-							Key:    v1.LabelFailureDomainBetaZone,
+							Key:    v1.LabelTopologyZone,
 							Values: []string{"zoneY"},
 						},
 					},
@@ -1260,7 +1296,7 @@ func TestSelectZonesForVolume(t *testing.T) {
 				{
 					MatchLabelExpressions: []v1.TopologySelectorLabelRequirement{
 						{
-							Key:    v1.LabelFailureDomainBetaZone,
+							Key:    v1.LabelTopologyZone,
 							Values: []string{"zoneZ"},
 						},
 					},
@@ -1286,7 +1322,7 @@ func TestSelectZonesForVolume(t *testing.T) {
 				{
 					MatchLabelExpressions: []v1.TopologySelectorLabelRequirement{
 						{
-							Key:    v1.LabelFailureDomainBetaZone,
+							Key:    v1.LabelTopologyZone,
 							Values: []string{"zoneX"},
 						},
 					},
@@ -1294,7 +1330,7 @@ func TestSelectZonesForVolume(t *testing.T) {
 				{
 					MatchLabelExpressions: []v1.TopologySelectorLabelRequirement{
 						{
-							Key:    v1.LabelFailureDomainBetaZone,
+							Key:    v1.LabelTopologyZone,
 							Values: []string{"zoneY"},
 						},
 					},
@@ -1321,7 +1357,7 @@ func TestSelectZonesForVolume(t *testing.T) {
 				{
 					MatchLabelExpressions: []v1.TopologySelectorLabelRequirement{
 						{
-							Key:    v1.LabelFailureDomainBetaZone,
+							Key:    v1.LabelTopologyZone,
 							Values: []string{"zoneX"},
 						},
 					},
@@ -1329,7 +1365,7 @@ func TestSelectZonesForVolume(t *testing.T) {
 				{
 					MatchLabelExpressions: []v1.TopologySelectorLabelRequirement{
 						{
-							Key:    v1.LabelFailureDomainBetaZone,
+							Key:    v1.LabelTopologyZone,
 							Values: []string{"zoneY"},
 						},
 					},
@@ -1337,7 +1373,7 @@ func TestSelectZonesForVolume(t *testing.T) {
 				{
 					MatchLabelExpressions: []v1.TopologySelectorLabelRequirement{
 						{
-							Key:    v1.LabelFailureDomainBetaZone,
+							Key:    v1.LabelTopologyZone,
 							Values: []string{"zoneZ"},
 						},
 					},
@@ -1361,7 +1397,7 @@ func TestSelectZonesForVolume(t *testing.T) {
 				{
 					MatchLabelExpressions: []v1.TopologySelectorLabelRequirement{
 						{
-							Key:    v1.LabelFailureDomainBetaZone,
+							Key:    v1.LabelTopologyZone,
 							Values: []string{"zoneX"},
 						},
 					},
@@ -1369,7 +1405,7 @@ func TestSelectZonesForVolume(t *testing.T) {
 				{
 					MatchLabelExpressions: []v1.TopologySelectorLabelRequirement{
 						{
-							Key:    v1.LabelFailureDomainBetaZone,
+							Key:    v1.LabelTopologyZone,
 							Values: []string{"zoneY"},
 						},
 					},

--- a/staging/src/k8s.io/csi-translation-lib/plugins/aws_ebs.go
+++ b/staging/src/k8s.io/csi-translation-lib/plugins/aws_ebs.go
@@ -142,7 +142,7 @@ func (t *awsElasticBlockStoreCSITranslator) TranslateInTreePVToCSI(pv *v1.Persis
 		},
 	}
 
-	if err := translateTopology(pv, AWSEBSTopologyKey); err != nil {
+	if err := translateTopologyFromInTreeToCSI(pv, AWSEBSTopologyKey); err != nil {
 		return nil, fmt.Errorf("failed to translate topology: %v", err)
 	}
 

--- a/staging/src/k8s.io/csi-translation-lib/plugins/in_tree_volume.go
+++ b/staging/src/k8s.io/csi-translation-lib/plugins/in_tree_volume.go
@@ -19,6 +19,7 @@ package plugins
 import (
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 
 	v1 "k8s.io/api/core/v1"
@@ -88,23 +89,30 @@ func replaceTopology(pv *v1.PersistentVolume, oldKey, newKey string) error {
 	return nil
 }
 
-// getTopologyZones returns all topology zones with the given key found in the PV.
-func getTopologyZones(pv *v1.PersistentVolume, key string) []string {
+// getTopologyValues returns all unique topology values with the given key found in the PV.
+func getTopologyValues(pv *v1.PersistentVolume, key string) []string {
 	if pv.Spec.NodeAffinity == nil ||
 		pv.Spec.NodeAffinity.Required == nil ||
 		len(pv.Spec.NodeAffinity.Required.NodeSelectorTerms) < 1 {
 		return nil
 	}
 
-	var values []string
+	values := make(map[string]bool)
 	for i := range pv.Spec.NodeAffinity.Required.NodeSelectorTerms {
 		for _, r := range pv.Spec.NodeAffinity.Required.NodeSelectorTerms[i].MatchExpressions {
 			if r.Key == key {
-				values = append(values, r.Values...)
+				for _, v := range r.Values {
+					values[v] = true
+				}
 			}
 		}
 	}
-	return values
+	var re []string
+	for k := range values {
+		re = append(re, k)
+	}
+	sort.Strings(re)
+	return re
 }
 
 // addTopology appends the topology to the given PV.
@@ -124,9 +132,17 @@ func addTopology(pv *v1.PersistentVolume, topologyKey string, zones []string) er
 	}
 
 	// Make sure the necessary fields exist
-	pv.Spec.NodeAffinity = new(v1.VolumeNodeAffinity)
-	pv.Spec.NodeAffinity.Required = new(v1.NodeSelector)
-	pv.Spec.NodeAffinity.Required.NodeSelectorTerms = make([]v1.NodeSelectorTerm, 1)
+	if pv.Spec.NodeAffinity == nil {
+		pv.Spec.NodeAffinity = new(v1.VolumeNodeAffinity)
+	}
+
+	if pv.Spec.NodeAffinity.Required == nil {
+		pv.Spec.NodeAffinity.Required = new(v1.NodeSelector)
+	}
+
+	if len(pv.Spec.NodeAffinity.Required.NodeSelectorTerms) == 0 {
+		pv.Spec.NodeAffinity.Required.NodeSelectorTerms = make([]v1.NodeSelectorTerm, 1)
+	}
 
 	topology := v1.NodeSelectorRequirement{
 		Key:      topologyKey,
@@ -134,31 +150,240 @@ func addTopology(pv *v1.PersistentVolume, topologyKey string, zones []string) er
 		Values:   zones,
 	}
 
-	pv.Spec.NodeAffinity.Required.NodeSelectorTerms[0].MatchExpressions = append(
-		pv.Spec.NodeAffinity.Required.NodeSelectorTerms[0].MatchExpressions,
-		topology,
-	)
+	// add the CSI topology to each term
+	for i := range pv.Spec.NodeAffinity.Required.NodeSelectorTerms {
+		pv.Spec.NodeAffinity.Required.NodeSelectorTerms[i].MatchExpressions = append(
+			pv.Spec.NodeAffinity.Required.NodeSelectorTerms[i].MatchExpressions,
+			topology,
+		)
+	}
 
 	return nil
 }
 
-// translateTopology converts existing zone labels or in-tree topology to CSI topology.
+// removeTopology removes the topology from the given PV. Return false
+// if the topology key is not found
+func removeTopology(pv *v1.PersistentVolume, topologyKey string) bool {
+	// Make sure the necessary fields exist
+	if pv == nil || pv.Spec.NodeAffinity == nil || pv.Spec.NodeAffinity.Required == nil ||
+		pv.Spec.NodeAffinity.Required.NodeSelectorTerms == nil || len(pv.Spec.NodeAffinity.Required.NodeSelectorTerms) == 0 {
+		return false
+	}
+
+	found := true
+	succeed := false
+	for found == true {
+		found = false
+		var termIndexRemoved []int
+		for termIndex, nodeSelectorTerms := range pv.Spec.NodeAffinity.Required.NodeSelectorTerms {
+			nsrequirements := nodeSelectorTerms.MatchExpressions
+
+			index := -1
+			for i, nodeSelectorRequirement := range nsrequirements {
+				if nodeSelectorRequirement.Key == topologyKey {
+					index = i
+					break
+				}
+			}
+			// We found the key that need to be removed
+			if index != -1 {
+				nsrequirements[len(nsrequirements)-1], nsrequirements[index] = nsrequirements[index], nsrequirements[len(nsrequirements)-1]
+				pv.Spec.NodeAffinity.Required.NodeSelectorTerms[termIndex].MatchExpressions = nsrequirements[:len(nsrequirements)-1]
+				if len(nsrequirements)-1 == 0 {
+					// No other expression left, the whole term should be removed
+					termIndexRemoved = append(termIndexRemoved, termIndex)
+				}
+				succeed = true
+				found = true
+			}
+		}
+
+		if len(termIndexRemoved) > 0 {
+			for i, index := range termIndexRemoved {
+				index = index - i
+				nodeSelectorTerms := pv.Spec.NodeAffinity.Required.NodeSelectorTerms
+				nodeSelectorTerms[len(nodeSelectorTerms)-1], nodeSelectorTerms[index] = nodeSelectorTerms[index], nodeSelectorTerms[len(nodeSelectorTerms)-1]
+				pv.Spec.NodeAffinity.Required.NodeSelectorTerms = nodeSelectorTerms[:len(nodeSelectorTerms)-1]
+			}
+		}
+	}
+
+	return succeed
+}
+
+// translateTopologyFromInTreeToCSI converts existing zone labels or in-tree topology to CSI topology.
 // In-tree topology has precedence over zone labels.
-func translateTopology(pv *v1.PersistentVolume, topologyKey string) error {
+func translateTopologyFromInTreeToCSI(pv *v1.PersistentVolume, topologyKey string) error {
 	// If topology is already set, assume the content is accurate
-	if len(getTopologyZones(pv, topologyKey)) > 0 {
+	if len(getTopologyValues(pv, topologyKey)) > 0 {
 		return nil
 	}
 
-	zones := getTopologyZones(pv, v1.LabelFailureDomainBetaZone)
+	_, zoneLabel, _ := getTopologyLabel(pv)
+
+	// migrate topology node affinity
+	zones := getTopologyValues(pv, zoneLabel)
 	if len(zones) > 0 {
-		return replaceTopology(pv, v1.LabelFailureDomainBetaZone, topologyKey)
+		return replaceTopology(pv, zoneLabel, topologyKey)
 	}
 
-	if label, ok := pv.Labels[v1.LabelFailureDomainBetaZone]; ok {
+	// if nothing is in the NodeAffinity, try to fetch the topology from PV labels
+	label, ok := pv.Labels[zoneLabel]
+	if ok {
 		zones = strings.Split(label, labelMultiZoneDelimiter)
 		if len(zones) > 0 {
 			return addTopology(pv, topologyKey, zones)
+		}
+	}
+
+	return nil
+}
+
+// getTopologyLabel checks if the kubernetes topology used in this PV is GA
+// and return the zone/region label used.
+// It first check the NodeAffinity to find topology. If nothing is found,
+// It checks the PV labels. If it is empty in both places, it will return
+// GA label by default
+func getTopologyLabel(pv *v1.PersistentVolume) (bool, string, string) {
+
+	// Check the NodeAffinity first for the topology version
+	zoneGA := TopologyKeyExist(v1.LabelTopologyZone, pv.Spec.NodeAffinity)
+	regionGA := TopologyKeyExist(v1.LabelTopologyRegion, pv.Spec.NodeAffinity)
+	if zoneGA || regionGA {
+		// GA NodeAffinity exists
+		return true, v1.LabelTopologyZone, v1.LabelTopologyRegion
+	}
+
+	// If no GA topology in NodeAffinity, check the beta one
+	zoneBeta := TopologyKeyExist(v1.LabelFailureDomainBetaZone, pv.Spec.NodeAffinity)
+	regionBeta := TopologyKeyExist(v1.LabelFailureDomainBetaRegion, pv.Spec.NodeAffinity)
+	if zoneBeta || regionBeta {
+		// Beta NodeAffinity exists, GA NodeAffinity not exist
+		return false, v1.LabelFailureDomainBetaZone, v1.LabelFailureDomainBetaRegion
+	}
+
+	// If nothing is in the NodeAfinity, we should check pv labels
+	_, zoneGA = pv.Labels[v1.LabelTopologyZone]
+	_, regionGA = pv.Labels[v1.LabelTopologyRegion]
+	if zoneGA || regionGA {
+		// NodeAffinity not exist, GA label exists
+		return true, v1.LabelTopologyZone, v1.LabelTopologyRegion
+	}
+
+	// If GA label not exists, check beta version
+	_, zoneBeta = pv.Labels[v1.LabelFailureDomainBetaZone]
+	_, regionBeta = pv.Labels[v1.LabelFailureDomainBetaRegion]
+	if zoneBeta || regionBeta {
+		// Beta label exists, NodeAffinity not exist, GA label not exists
+		return false, v1.LabelFailureDomainBetaZone, v1.LabelFailureDomainBetaRegion
+	}
+
+	// No labels or NodeAffinity exist, default to GA version
+	return true, v1.LabelTopologyZone, v1.LabelTopologyRegion
+}
+
+// TopologyKeyExist checks if a certain key exists in a VolumeNodeAffinity
+func TopologyKeyExist(key string, vna *v1.VolumeNodeAffinity) bool {
+	if vna == nil || vna.Required == nil || vna.Required.NodeSelectorTerms == nil || len(vna.Required.NodeSelectorTerms) == 0 {
+		return false
+	}
+
+	for _, nodeSelectorTerms := range vna.Required.NodeSelectorTerms {
+		nsrequirements := nodeSelectorTerms.MatchExpressions
+		for _, nodeSelectorRequirement := range nsrequirements {
+			if nodeSelectorRequirement.Key == key {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+type regionParser func(pv *v1.PersistentVolume) (string, error)
+
+// translateTopologyFromCSIToInTree translate a CSI PV topology to
+// Kubernetes topology and add labels to it. Note that this function
+// will only work for plugin with single topologyKey. If a plugin has
+// more than one topologyKey, it will need to be processed separately
+// by the plugin.
+// regionParser is a function to generate region val based on PV
+// if the function is not set, we will not set region topology.
+// 1. Remove any existing CSI topologyKey from NodeAffinity
+// 2. Add Kubernetes Topology in the NodeAffinity if it does not exist
+//    2.1 Try to use CSI topology values to recover the Kubernetes topology first
+//    2.2 If CSI topology values does not exist, try to use PV label
+// 3. Add Kubernetes Topology labels(zone and region)
+func translateTopologyFromCSIToInTree(pv *v1.PersistentVolume, topologyKey string, regionParser regionParser) error {
+
+	csiTopologyZoneValues := getTopologyValues(pv, topologyKey)
+
+	// 1. Frist remove the CSI topology Key
+	removeTopology(pv, topologyKey)
+
+	_, zoneLabel, regionLabel := getTopologyLabel(pv)
+	zoneLabelVal, zoneOK := pv.Labels[zoneLabel]
+	regionLabelVal, regionOK := pv.Labels[regionLabel]
+
+	// 2. Add Kubernetes Topology in the NodeAffinity if it does not exist
+	// Check if Kubernetes Zone Topology already exist
+	topologyZoneValue := getTopologyValues(pv, zoneLabel)
+	if len(topologyZoneValue) == 0 {
+		// No Kubernetes Topology exist in the current PV, we need to add it
+		// 2.1 Let's try to use CSI topology to recover the zone topology first
+		if len(csiTopologyZoneValues) > 0 {
+			err := addTopology(pv, zoneLabel, csiTopologyZoneValues)
+			if err != nil {
+				return fmt.Errorf("Failed to add Kubernetes topology zone to PV NodeAffinity. %v", err)
+			}
+		} else if zoneOK {
+			// 2.2 If no CSI topology values exist, try to search PV labels for zone labels
+			zones := strings.Split(zoneLabelVal, labelMultiZoneDelimiter)
+			if len(zones) > 0 {
+				err := addTopology(pv, zoneLabel, zones)
+				if err != nil {
+					return fmt.Errorf("Failed to add Kubernetes topology zone to PV NodeAffinity. %v", err)
+				}
+			}
+		}
+	}
+
+	// Check if Kubernetes Region Topology already exist
+	topologyRegionValue := getTopologyValues(pv, regionLabel)
+	if len(topologyRegionValue) == 0 {
+		// 2.1 Let's try to use CSI topology to recover the region topology first
+		if len(csiTopologyZoneValues) > 0 && regionParser != nil {
+			regionVal, err := regionParser(pv)
+			if err != nil {
+				return fmt.Errorf("Failed to parse zones value(%v) to region label %v", csiTopologyZoneValues, err)
+			}
+			err = addTopology(pv, regionLabel, []string{regionVal})
+			if err != nil {
+				return fmt.Errorf("Failed to add Kubernetes topology region to PV NodeAffinity. %v", err)
+			}
+		} else if regionOK {
+			// 2.2 If no CSI topology values exist, try to search PV labels for region labels
+			err := addTopology(pv, regionLabel, []string{regionLabelVal})
+			if err != nil {
+				return fmt.Errorf("Failed to add Kubernetes topology region to PV NodeAffinity. %v", err)
+			}
+		}
+	}
+
+	// 3. Add Kubernetes Topology labels, if it already exists, we trust it
+	if len(csiTopologyZoneValues) > 0 {
+		if pv.Labels == nil {
+			pv.Labels = make(map[string]string)
+		}
+		if !zoneOK {
+			csiTopologyZoneValStr := strings.Join(csiTopologyZoneValues, labelMultiZoneDelimiter)
+			pv.Labels[zoneLabel] = csiTopologyZoneValStr
+		}
+		if !regionOK && regionParser != nil {
+			regionVal, err := regionParser(pv)
+			if err != nil {
+				return fmt.Errorf("Failed to parse zones value(%v) to region label %v", csiTopologyZoneValues, err)
+			}
+			pv.Labels[regionLabel] = regionVal
 		}
 	}
 
@@ -177,7 +402,7 @@ func translateAllowedTopologies(terms []v1.TopologySelectorTerm, key string) ([]
 		newTerm := v1.TopologySelectorTerm{}
 		for _, exp := range term.MatchLabelExpressions {
 			var newExp v1.TopologySelectorLabelRequirement
-			if exp.Key == v1.LabelFailureDomainBetaZone {
+			if exp.Key == v1.LabelFailureDomainBetaZone || exp.Key == v1.LabelTopologyZone {
 				newExp = v1.TopologySelectorLabelRequirement{
 					Key:    key,
 					Values: exp.Values,

--- a/staging/src/k8s.io/csi-translation-lib/plugins/in_tree_volume_test.go
+++ b/staging/src/k8s.io/csi-translation-lib/plugins/in_tree_volume_test.go
@@ -21,7 +21,402 @@ import (
 	"testing"
 
 	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+var (
+	useast1aGALabels = map[string]string{
+		v1.LabelTopologyZone:   "us-east1-a",
+		v1.LabelTopologyRegion: "us-east1",
+	}
+	useast1aGANodeSelectorTerm = []v1.NodeSelectorTerm{
+		{
+			MatchExpressions: []v1.NodeSelectorRequirement{
+				{
+					Key:      v1.LabelTopologyZone,
+					Operator: v1.NodeSelectorOpIn,
+					Values:   []string{"us-east1-a"},
+				},
+				{
+					Key:      v1.LabelTopologyRegion,
+					Operator: v1.NodeSelectorOpIn,
+					Values:   []string{"us-east1"},
+				},
+			},
+		},
+	}
+
+	uswest2bBetaLabels = map[string]string{
+		v1.LabelFailureDomainBetaZone:   "us-west2-b",
+		v1.LabelFailureDomainBetaRegion: "us-west2",
+	}
+
+	uswest2bBetaNodeSelectorTerm = []v1.NodeSelectorTerm{
+		{
+			MatchExpressions: []v1.NodeSelectorRequirement{
+				{
+					Key:      v1.LabelFailureDomainBetaZone,
+					Operator: v1.NodeSelectorOpIn,
+					Values:   []string{"us-west2-b"},
+				},
+				{
+					Key:      v1.LabelFailureDomainBetaRegion,
+					Operator: v1.NodeSelectorOpIn,
+					Values:   []string{"us-west2"},
+				},
+			},
+		},
+	}
+)
+
+func TestTranslateTopologyFromCSIToInTree(t *testing.T) {
+	testCases := []struct {
+		name                      string
+		key                       string
+		expErr                    bool
+		regionParser              regionParser
+		pv                        *v1.PersistentVolume
+		expectedNodeSelectorTerms []v1.NodeSelectorTerm
+		expectedLabels            map[string]string
+	}{
+		{
+			name:         "Remove CSI Topology Key and do not change existing GA Kubernetes topology",
+			key:          GCEPDTopologyKey,
+			expErr:       false,
+			regionParser: gceRegionParser,
+			pv: &v1.PersistentVolume{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "gcepd", Namespace: "myns",
+					Labels: useast1aGALabels,
+				},
+				Spec: v1.PersistentVolumeSpec{
+					NodeAffinity: &v1.VolumeNodeAffinity{
+						Required: &v1.NodeSelector{
+							NodeSelectorTerms: []v1.NodeSelectorTerm{
+								{
+									MatchExpressions: []v1.NodeSelectorRequirement{
+										{
+											Key:      v1.LabelTopologyZone,
+											Operator: v1.NodeSelectorOpIn,
+											Values:   []string{"us-east1-a"},
+										},
+										{
+											Key:      v1.LabelTopologyRegion,
+											Operator: v1.NodeSelectorOpIn,
+											Values:   []string{"us-east1"},
+										},
+										{
+											Key:      GCEPDTopologyKey,
+											Operator: v1.NodeSelectorOpIn,
+											Values:   []string{"whatever"},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedNodeSelectorTerms: useast1aGANodeSelectorTerm,
+			expectedLabels:            useast1aGALabels,
+		},
+		{
+			name:         "Remove CSI Topology Key and do not change existing Beta Kubernetes topology",
+			key:          GCEPDTopologyKey,
+			expErr:       false,
+			regionParser: gceRegionParser,
+			pv: &v1.PersistentVolume{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "gcepd", Namespace: "myns",
+					Labels: uswest2bBetaLabels,
+				},
+				Spec: v1.PersistentVolumeSpec{
+					NodeAffinity: &v1.VolumeNodeAffinity{
+						Required: &v1.NodeSelector{
+							NodeSelectorTerms: []v1.NodeSelectorTerm{
+								{
+									MatchExpressions: []v1.NodeSelectorRequirement{
+										{
+											Key:      v1.LabelFailureDomainBetaZone,
+											Operator: v1.NodeSelectorOpIn,
+											Values:   []string{"us-west2-b"},
+										},
+										{
+											Key:      v1.LabelFailureDomainBetaRegion,
+											Operator: v1.NodeSelectorOpIn,
+											Values:   []string{"us-west2"},
+										},
+										{
+											Key:      GCEPDTopologyKey,
+											Operator: v1.NodeSelectorOpIn,
+											Values:   []string{"whatever"},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedNodeSelectorTerms: uswest2bBetaNodeSelectorTerm,
+			expectedLabels:            uswest2bBetaLabels,
+		},
+		{
+			name:         "Remove CSI Topology Key and add Kubernetes topology from NodeAffinity, ignore labels",
+			key:          GCEPDTopologyKey,
+			expErr:       false,
+			regionParser: gceRegionParser,
+			pv: &v1.PersistentVolume{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "gcepd", Namespace: "myns",
+					Labels: map[string]string{
+						v1.LabelTopologyZone:   "existingZone",
+						v1.LabelTopologyRegion: "existingRegion",
+					},
+				},
+				Spec: v1.PersistentVolumeSpec{
+					NodeAffinity: &v1.VolumeNodeAffinity{
+						Required: &v1.NodeSelector{
+							NodeSelectorTerms: []v1.NodeSelectorTerm{
+								{
+									MatchExpressions: []v1.NodeSelectorRequirement{
+										{
+											Key:      GCEPDTopologyKey,
+											Operator: v1.NodeSelectorOpIn,
+											Values:   []string{"us-east1-a"},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedNodeSelectorTerms: useast1aGANodeSelectorTerm,
+			expectedLabels: map[string]string{
+				v1.LabelTopologyRegion: "existingRegion",
+				v1.LabelTopologyZone:   "existingZone",
+			},
+		},
+		{
+			name:         "Add GA Kubernetes topology from labels",
+			key:          GCEPDTopologyKey,
+			expErr:       false,
+			regionParser: gceRegionParser,
+			pv: &v1.PersistentVolume{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "gcepd", Namespace: "myns",
+					Labels: map[string]string{
+						v1.LabelTopologyZone:   "existingZone",
+						v1.LabelTopologyRegion: "existingRegion",
+					},
+				},
+			},
+			expectedNodeSelectorTerms: []v1.NodeSelectorTerm{
+				{
+					MatchExpressions: []v1.NodeSelectorRequirement{
+						{
+							Key:      v1.LabelTopologyZone,
+							Operator: v1.NodeSelectorOpIn,
+							Values:   []string{"existingZone"},
+						},
+						{
+							Key:      v1.LabelTopologyRegion,
+							Operator: v1.NodeSelectorOpIn,
+							Values:   []string{"existingRegion"},
+						},
+					},
+				},
+			},
+			expectedLabels: map[string]string{
+				v1.LabelTopologyZone:   "existingZone",
+				v1.LabelTopologyRegion: "existingRegion",
+			},
+		},
+		{
+			name:         "Generate GA labels and kubernetes topology only from CSI topology",
+			key:          GCEPDTopologyKey,
+			expErr:       false,
+			regionParser: gceRegionParser,
+			pv: &v1.PersistentVolume{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "gcepd", Namespace: "myns",
+				},
+				Spec: v1.PersistentVolumeSpec{
+					NodeAffinity: &v1.VolumeNodeAffinity{
+						Required: &v1.NodeSelector{
+							NodeSelectorTerms: []v1.NodeSelectorTerm{
+								{
+									MatchExpressions: []v1.NodeSelectorRequirement{
+										{
+											Key:      GCEPDTopologyKey,
+											Operator: v1.NodeSelectorOpIn,
+											Values:   []string{"us-east1-a"},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedNodeSelectorTerms: useast1aGANodeSelectorTerm,
+			expectedLabels:            useast1aGALabels,
+		},
+		{
+			name:         "Generate Beta labels and kubernetes topology from CSI topology with partial Beta NodeAffinity",
+			key:          GCEPDTopologyKey,
+			expErr:       false,
+			regionParser: gceRegionParser,
+			pv: &v1.PersistentVolume{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "gcepd", Namespace: "myns",
+				},
+				Spec: v1.PersistentVolumeSpec{
+					NodeAffinity: &v1.VolumeNodeAffinity{
+						Required: &v1.NodeSelector{
+							NodeSelectorTerms: []v1.NodeSelectorTerm{
+								{
+									MatchExpressions: []v1.NodeSelectorRequirement{
+										{
+											Key:      GCEPDTopologyKey,
+											Operator: v1.NodeSelectorOpIn,
+											Values:   []string{"us-west2-b"},
+										},
+										{
+											Key:      v1.LabelFailureDomainBetaZone,
+											Operator: v1.NodeSelectorOpIn,
+											Values:   []string{"us-west2-b"},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedNodeSelectorTerms: uswest2bBetaNodeSelectorTerm,
+			expectedLabels:            uswest2bBetaLabels,
+		},
+		{
+			name:         "regionParser is missing and only zone labels get generated",
+			key:          GCEPDTopologyKey,
+			expErr:       false,
+			regionParser: nil,
+			pv: &v1.PersistentVolume{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "gcepd", Namespace: "myns",
+				},
+				Spec: v1.PersistentVolumeSpec{
+					NodeAffinity: &v1.VolumeNodeAffinity{
+						Required: &v1.NodeSelector{
+							NodeSelectorTerms: []v1.NodeSelectorTerm{
+								{
+									MatchExpressions: []v1.NodeSelectorRequirement{
+										{
+											Key:      GCEPDTopologyKey,
+											Operator: v1.NodeSelectorOpIn,
+											Values:   []string{"us-east1-a"},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedNodeSelectorTerms: []v1.NodeSelectorTerm{
+				{
+					MatchExpressions: []v1.NodeSelectorRequirement{
+						{
+							Key:      v1.LabelTopologyZone,
+							Operator: v1.NodeSelectorOpIn,
+							Values:   []string{"us-east1-a"},
+						},
+					},
+				},
+			},
+			expectedLabels: map[string]string{
+				v1.LabelTopologyZone: "us-east1-a",
+			},
+		},
+		{
+			name:         "Remove multi-term CSI Topology Key and add GA Kubernetes topology",
+			key:          GCEPDTopologyKey,
+			expErr:       false,
+			regionParser: gceRegionParser,
+			pv: &v1.PersistentVolume{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "gcepd", Namespace: "myns",
+				},
+				Spec: v1.PersistentVolumeSpec{
+					NodeAffinity: &v1.VolumeNodeAffinity{
+						Required: &v1.NodeSelector{
+							NodeSelectorTerms: []v1.NodeSelectorTerm{
+								{
+									MatchExpressions: []v1.NodeSelectorRequirement{
+										{
+											Key:      GCEPDTopologyKey,
+											Operator: v1.NodeSelectorOpIn,
+											Values:   []string{"us-east1-a"},
+										},
+									},
+								},
+								{
+									MatchExpressions: []v1.NodeSelectorRequirement{
+										{
+											Key:      GCEPDTopologyKey,
+											Operator: v1.NodeSelectorOpIn,
+											Values:   []string{"us-east1-c"},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedNodeSelectorTerms: []v1.NodeSelectorTerm{
+				{
+					MatchExpressions: []v1.NodeSelectorRequirement{
+						{
+							Key:      v1.LabelTopologyZone,
+							Operator: v1.NodeSelectorOpIn,
+							Values:   []string{"us-east1-a", "us-east1-c"},
+						},
+						{
+							Key:      v1.LabelTopologyRegion,
+							Operator: v1.NodeSelectorOpIn,
+							Values:   []string{"us-east1"},
+						},
+					},
+				},
+			},
+			expectedLabels: map[string]string{
+				v1.LabelTopologyZone:   "us-east1-a__us-east1-c",
+				v1.LabelTopologyRegion: "us-east1",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Logf("Running test: %v", tc.name)
+		err := translateTopologyFromCSIToInTree(tc.pv, tc.key, tc.regionParser)
+		if err != nil && !tc.expErr {
+			t.Errorf("Did not expect an error, got: %v", err)
+		}
+		if err == nil && tc.expErr {
+			t.Errorf("Expected an error but did not get one")
+		}
+
+		if !reflect.DeepEqual(tc.pv.Spec.NodeAffinity.Required.NodeSelectorTerms, tc.expectedNodeSelectorTerms) {
+			t.Errorf("Expected topology: %v, but got: %v", tc.expectedNodeSelectorTerms, tc.pv.Spec.NodeAffinity.Required.NodeSelectorTerms)
+		}
+		if !reflect.DeepEqual(tc.pv.Labels, tc.expectedLabels) {
+			t.Errorf("Expected labels: %v, but got: %v", tc.expectedLabels, tc.pv.Labels)
+		}
+	}
+}
 
 func TestTranslateAllowedTopologies(t *testing.T) {
 	testCases := []struct {
@@ -211,4 +606,147 @@ func TestAddTopology(t *testing.T) {
 			t.Errorf("Expected affinity: %v, but got: %v", tc.expectedAffinity, pv.Spec.NodeAffinity)
 		}
 	}
+}
+
+func TestRemoveTopology(t *testing.T) {
+	testCases := []struct {
+		name             string
+		topologyKey      string
+		pv               *v1.PersistentVolume
+		expOk            bool
+		expectedAffinity *v1.VolumeNodeAffinity
+	}{
+		{
+			name:        "Remove single csi topology from PV",
+			topologyKey: GCEPDTopologyKey,
+			pv: makePVWithNodeSelectorTerms([]v1.NodeSelectorTerm{
+				{
+					MatchExpressions: []v1.NodeSelectorRequirement{
+						{
+							Key:      GCEPDTopologyKey,
+							Operator: v1.NodeSelectorOpIn,
+							Values:   []string{"us-east1-a"},
+						},
+					},
+				},
+			}),
+			expOk: true,
+			expectedAffinity: &v1.VolumeNodeAffinity{
+				Required: &v1.NodeSelector{
+					NodeSelectorTerms: []v1.NodeSelectorTerm{},
+				},
+			},
+		},
+		{
+			name:        "Not found the topology key so do nothing",
+			topologyKey: GCEPDTopologyKey,
+			pv: makePVWithNodeSelectorTerms([]v1.NodeSelectorTerm{
+				{
+					MatchExpressions: []v1.NodeSelectorRequirement{
+						{
+							Key:      v1.LabelTopologyZone,
+							Operator: v1.NodeSelectorOpIn,
+							Values:   []string{"us-east1-a"},
+						},
+					},
+				},
+			}),
+			expOk: false,
+			expectedAffinity: &v1.VolumeNodeAffinity{
+				Required: &v1.NodeSelector{
+					NodeSelectorTerms: []v1.NodeSelectorTerm{
+						{
+							MatchExpressions: []v1.NodeSelectorRequirement{
+								{
+									Key:      v1.LabelTopologyZone,
+									Operator: v1.NodeSelectorOpIn,
+									Values:   []string{"us-east1-a"},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:        "Remove the topology key from multiple terms",
+			topologyKey: GCEPDTopologyKey,
+			pv: makePVWithNodeSelectorTerms([]v1.NodeSelectorTerm{
+				{
+					MatchExpressions: []v1.NodeSelectorRequirement{
+						{
+							Key:      GCEPDTopologyKey,
+							Operator: v1.NodeSelectorOpIn,
+							Values:   []string{"us-east1-a"},
+						},
+					},
+				},
+				{
+					MatchExpressions: []v1.NodeSelectorRequirement{
+						{
+							Key:      GCEPDTopologyKey,
+							Operator: v1.NodeSelectorOpIn,
+							Values:   []string{"us-east1-c"},
+						},
+					},
+				},
+			}),
+			expOk: true,
+			expectedAffinity: &v1.VolumeNodeAffinity{
+				Required: &v1.NodeSelector{
+					NodeSelectorTerms: []v1.NodeSelectorTerm{},
+				},
+			},
+		},
+		{
+			name:        "Remove the topology key from single term duplicate expression",
+			topologyKey: GCEPDTopologyKey,
+			pv: makePVWithNodeSelectorTerms([]v1.NodeSelectorTerm{
+				{
+					MatchExpressions: []v1.NodeSelectorRequirement{
+						{
+							Key:      GCEPDTopologyKey,
+							Operator: v1.NodeSelectorOpIn,
+							Values:   []string{"us-east1-a"},
+						},
+						{
+							Key:      GCEPDTopologyKey,
+							Operator: v1.NodeSelectorOpIn,
+							Values:   []string{"us-east1-a"},
+						},
+					},
+				},
+			}),
+			expOk: true,
+			expectedAffinity: &v1.VolumeNodeAffinity{
+				Required: &v1.NodeSelector{
+					NodeSelectorTerms: []v1.NodeSelectorTerm{},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Logf("Running test: %v", tc.name)
+		ok := removeTopology(tc.pv, tc.topologyKey)
+		if tc.expOk != ok {
+			t.Errorf("Expected ok: %v, but got: %v", tc.expOk, ok)
+		}
+		if !reflect.DeepEqual(tc.pv.Spec.NodeAffinity, tc.expectedAffinity) {
+			t.Errorf("Expected affinity: %v, but got: %v", tc.expectedAffinity, tc.pv.Spec.NodeAffinity)
+		}
+	}
+}
+
+func makePVWithNodeSelectorTerms(nodeSelectorTerms []v1.NodeSelectorTerm) *v1.PersistentVolume {
+	return &v1.PersistentVolume{
+		Spec: v1.PersistentVolumeSpec{
+			NodeAffinity: &v1.VolumeNodeAffinity{
+				Required: &v1.NodeSelector{
+					NodeSelectorTerms: nodeSelectorTerms,
+				},
+			},
+		},
+	}
+
 }

--- a/staging/src/k8s.io/csi-translation-lib/plugins/openstack_cinder.go
+++ b/staging/src/k8s.io/csi-translation-lib/plugins/openstack_cinder.go
@@ -95,7 +95,7 @@ func (t *osCinderCSITranslator) TranslateInTreePVToCSI(pv *v1.PersistentVolume) 
 		VolumeAttributes: map[string]string{},
 	}
 
-	if err := translateTopology(pv, CinderTopologyKey); err != nil {
+	if err := translateTopologyFromInTreeToCSI(pv, CinderTopologyKey); err != nil {
 		return nil, fmt.Errorf("failed to translate topology: %v", err)
 	}
 


### PR DESCRIPTION
This also includes a change on CSI migration TranslateCSIToInTree
where we remove the CSI topology and add Kubernetes Topology to
the NodeAffinity


**What type of PR is this?**
/kind bug
/kind cleanup


**What this PR does / why we need it**:
This PR is a subset work from https://github.com/kubernetes/kubernetes/pull/97746 with some comments addressed and test.
Specifically, this PR prepares for the migration from `failure-domain.beta.kubernetes.io/zone` topology to GA version which is `topology.kubernetes.io/zone`.

Besides, this PR also contains a behavior change in the csi-translation library TranslateCSIToInTree for gce-pd where we remove the CSI topology and inserts the kubernetes topology. This surfaces two purpose: 1. Fix a potential rollback issue. 2. Prepare for the fully deprecation of PV label admission-controller.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

Partially fix https://github.com/kubernetes/kubernetes/issues/92237

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Remove CSI topology from migrated in-tree gcepd volume.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/sig storage
/assign @msau42
/cc @wongma7 @mattcary @verult  

The follow-up for this PR includes:
1. Upgrade csi-translation-lib to the newer version on csi-provisioner
2. Upgrade in-tree volume plugins to use the GA label

