### PR TITLE
cherry-pick part of #97451: fix counting error in service/nodeport/loadbalancer quota check

### DIFF
--- a/pkg/quota/v1/resources.go
+++ b/pkg/quota/v1/resources.go
@@ -226,6 +226,17 @@ func IsZero(a corev1.ResourceList) bool {
 	return true
 }
 
+// RemoveZeros returns a new resource list that only has no zero values
+func RemoveZeros(a corev1.ResourceList) corev1.ResourceList {
+	result := corev1.ResourceList{}
+	for key, value := range a {
+		if !value.IsZero() {
+			result[key] = value
+		}
+	}
+	return result
+}
+
 // IsNegative returns the set of resource names that have a negative value.
 func IsNegative(a corev1.ResourceList) []corev1.ResourceName {
 	results := []corev1.ResourceName{}

--- a/pkg/quota/v1/resources_test.go
+++ b/pkg/quota/v1/resources_test.go
@@ -287,6 +287,50 @@ func TestIsZero(t *testing.T) {
 	}
 }
 
+func TestRemoveZeros(t *testing.T) {
+	testCases := map[string]struct {
+		a        corev1.ResourceList
+		expected corev1.ResourceList
+	}{
+		"empty": {
+			a:        corev1.ResourceList{},
+			expected: corev1.ResourceList{},
+		},
+		"all-zeros": {
+			a: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("0"),
+				corev1.ResourceMemory: resource.MustParse("0"),
+			},
+			expected: corev1.ResourceList{},
+		},
+		"some-zeros": {
+			a: corev1.ResourceList{
+				corev1.ResourceCPU:     resource.MustParse("0"),
+				corev1.ResourceMemory:  resource.MustParse("0"),
+				corev1.ResourceStorage: resource.MustParse("100Gi"),
+			},
+			expected: corev1.ResourceList{
+				corev1.ResourceStorage: resource.MustParse("100Gi"),
+			},
+		},
+		"non-zero": {
+			a: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("200m"),
+				corev1.ResourceMemory: resource.MustParse("1Gi"),
+			},
+			expected: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("200m"),
+				corev1.ResourceMemory: resource.MustParse("1Gi"),
+			},
+		},
+	}
+	for testName, testCase := range testCases {
+		if result := RemoveZeros(testCase.a); !Equals(result, testCase.expected) {
+			t.Errorf("%s expected: %v, actual: %v", testName, testCase.expected, result)
+		}
+	}
+}
+
 func TestIsNegative(t *testing.T) {
 	testCases := map[string]struct {
 		a        corev1.ResourceList

--- a/plugin/pkg/admission/resourcequota/controller.go
+++ b/plugin/pkg/admission/resourcequota/controller.go
@@ -510,7 +510,10 @@ func CheckRequest(quotas []corev1.ResourceQuota, a admission.Attributes, evaluat
 		}
 	}
 
-	if quota.IsZero(deltaUsage) {
+	// ignore items in deltaUsage with zero usage
+	deltaUsage = quota.RemoveZeros(deltaUsage)
+	// if there is no remaining non-zero usage, short-circuit and return
+	if len(deltaUsage) == 0 {
 		return quotas, nil
 	}
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
/sig network
/triage accepted

**What this PR does / why we need it**:
Cherry pick of #97826 (which is part of #97451) on release-1.18.

**Which issue(s) this PR fixes**:
Fixes #97437 

**Special notes for your reviewer**:
> I would recommend picking the zero portion of it to 1.17-1.20
per https://github.com/kubernetes/kubernetes/pull/97451#issuecomment-756442434

**Does this PR introduce a user-facing change?**:

```release-note
fix counting error in service/nodeport/loadbalancer quota check
```
