### PR TITLE
fix vendor/k8s.io/apiserver/pkg/util/wsstream staticcheck

### DIFF
--- a/hack/.staticcheck_failures
+++ b/hack/.staticcheck_failures
@@ -34,7 +34,6 @@ vendor/k8s.io/apiserver/pkg/storage/cacher
 vendor/k8s.io/apiserver/pkg/storage/tests
 vendor/k8s.io/apiserver/pkg/storage/value/encrypt/envelope
 vendor/k8s.io/apiserver/pkg/util/webhook
-vendor/k8s.io/apiserver/pkg/util/wsstream
 vendor/k8s.io/client-go/discovery
 vendor/k8s.io/client-go/rest
 vendor/k8s.io/client-go/rest/watch

--- a/staging/src/k8s.io/apiserver/pkg/util/wsstream/conn_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/wsstream/conn_test.go
@@ -59,7 +59,8 @@ func TestRawConn(t *testing.T) {
 		defer wg.Done()
 		data, err := ioutil.ReadAll(conn.channels[0])
 		if err != nil {
-			t.Fatal(err)
+			t.Errorf("%v", err)
+			return
 		}
 		if !reflect.DeepEqual(data, []byte("client")) {
 			t.Errorf("unexpected server read: %v", data)
@@ -75,7 +76,8 @@ func TestRawConn(t *testing.T) {
 	go func() {
 		defer wg.Done()
 		if n, err := conn.channels[1].Write([]byte("server")); err != nil && n != 6 {
-			t.Fatalf("%d: %v", n, err)
+			t.Errorf("%d: %v", n, err)
+			return
 		}
 	}()
 
@@ -141,7 +143,8 @@ func TestBase64Conn(t *testing.T) {
 		defer wg.Done()
 		data, err := ioutil.ReadAll(conn.channels[0])
 		if err != nil {
-			t.Fatal(err)
+			t.Errorf("%v", err)
+			return
 		}
 		if !reflect.DeepEqual(data, []byte("client")) {
 			t.Errorf("unexpected server read: %s", string(data))
@@ -157,7 +160,8 @@ func TestBase64Conn(t *testing.T) {
 	go func() {
 		defer wg.Done()
 		if n, err := conn.channels[1].Write([]byte("server")); err != nil && n != 6 {
-			t.Fatalf("%d: %v", n, err)
+			t.Errorf("%d: %v", n, err)
+			return
 		}
 	}()
 


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Fixes vendor/k8s.io/apiserver/pkg/util/wsstream staticcheck errors.

**Which issue(s) this PR fixes**:

Part of #92402


**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

NONE

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```release-note
```