### PR TITLE
Fix some error logs that do not need concatenation but begin with low…

### DIFF
--- a/pkg/kubelet/time_cache_test.go
+++ b/pkg/kubelet/time_cache_test.go
@@ -26,7 +26,7 @@ import (
 func TestTimeCache(t *testing.T) {
 	cache := &timeCache{cache: lru.New(2)}
 	if a, ok := cache.Get("123"); ok {
-		t.Errorf("expected cache miss, got %v, %v", a, ok)
+		t.Errorf("Expected cache miss, got %v, %v", a, ok)
 	}
 
 	now := time.Now()
@@ -35,21 +35,21 @@ func TestTimeCache(t *testing.T) {
 	cache.Add("soon", soon)
 
 	if a, ok := cache.Get("now"); !ok || !a.Equal(now) {
-		t.Errorf("expected cache hit matching %v, got %v, %v", now, a, ok)
+		t.Errorf("Expected cache hit matching %v, got %v, %v", now, a, ok)
 	}
 	if a, ok := cache.Get("soon"); !ok || !a.Equal(soon) {
-		t.Errorf("expected cache hit matching %v, got %v, %v", soon, a, ok)
+		t.Errorf("Expected cache hit matching %v, got %v, %v", soon, a, ok)
 	}
 
 	then := now.Add(-time.Minute)
 	cache.Add("then", then)
 	if a, ok := cache.Get("now"); ok {
-		t.Errorf("expected cache miss from oldest evicted value, got %v, %v", a, ok)
+		t.Errorf("Expected cache miss from oldest evicted value, got %v, %v", a, ok)
 	}
 	if a, ok := cache.Get("soon"); !ok || !a.Equal(soon) {
-		t.Errorf("expected cache hit matching %v, got %v, %v", soon, a, ok)
+		t.Errorf("Expected cache hit matching %v, got %v, %v", soon, a, ok)
 	}
 	if a, ok := cache.Get("then"); !ok || !a.Equal(then) {
-		t.Errorf("expected cache hit matching %v, got %v, %v", then, a, ok)
+		t.Errorf("Expected cache hit matching %v, got %v, %v", then, a, ok)
 	}
 }


### PR DESCRIPTION
What type of PR is this?
/kind cleanup

What this PR does / why we need it:
Fix some error logs that do not need concatenation but begin with lowercase in package[pkg/kubelet/time_cache_test.go]

Which issue(s) this PR fixes:

Fixes #

Special notes for your reviewer:

Does this PR introduce a user-facing change?:

```release-note
NONE
```
Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
