### PR TITLE
don´t panic on e2e ESIPP tests

### DIFF
--- a/test/e2e/network/service.go
+++ b/test/e2e/network/service.go
@@ -3015,8 +3015,8 @@ var _ = SIGDescribe("ESIPP [Slow]", func() {
 		ingressIP := e2eservice.GetIngressPoint(&svc.Status.LoadBalancer.Ingress[0])
 
 		ginkgo.By("reading clientIP using the TCP service's service port via its external VIP")
-		content := GetHTTPContent(ingressIP, svcTCPPort, e2eservice.KubeProxyLagTimeout, "/clientip")
-		clientIP := content.String()
+		clientIP, err := GetHTTPContent(ingressIP, svcTCPPort, e2eservice.KubeProxyLagTimeout, "/clientip")
+		framework.ExpectNoError(err)
 		framework.Logf("ClientIP detected by target pod using VIP:SvcPort is %s", clientIP)
 
 		ginkgo.By("checking if Source IP is preserved")
@@ -3298,8 +3298,10 @@ var _ = SIGDescribe("ESIPP [Slow]", func() {
 		ginkgo.By(fmt.Sprintf("checking source ip is NOT preserved through loadbalancer %v", ingressIP))
 		var clientIP string
 		pollErr := wait.PollImmediate(framework.Poll, e2eservice.KubeProxyLagTimeout, func() (bool, error) {
-			content := GetHTTPContent(ingressIP, svcTCPPort, e2eservice.KubeProxyLagTimeout, "/clientip")
-			clientIP = content.String()
+			clientIP, err := GetHTTPContent(ingressIP, svcTCPPort, e2eservice.KubeProxyLagTimeout, "/clientip")
+			if err != nil {
+				return false, nil
+			}
 			if strings.HasPrefix(clientIP, "10.") {
 				return true, nil
 			}
@@ -3323,8 +3325,10 @@ var _ = SIGDescribe("ESIPP [Slow]", func() {
 		})
 		framework.ExpectNoError(err)
 		pollErr = wait.PollImmediate(framework.Poll, e2eservice.KubeProxyLagTimeout, func() (bool, error) {
-			content := GetHTTPContent(ingressIP, svcTCPPort, e2eservice.KubeProxyLagTimeout, path)
-			clientIP = content.String()
+			clientIP, err := GetHTTPContent(ingressIP, svcTCPPort, e2eservice.KubeProxyLagTimeout, path)
+			if err != nil {
+				return false, nil
+			}
 			ginkgo.By(fmt.Sprintf("Endpoint %v:%v%v returned client ip %v", ingressIP, svcTCPPort, path, clientIP))
 			if !strings.HasPrefix(clientIP, "10.") {
 				return true, nil

--- a/test/e2e/network/util.go
+++ b/test/e2e/network/util.go
@@ -37,19 +37,20 @@ import (
 const secondNodePortSvcName = "second-node-port-service"
 
 // GetHTTPContent returns the content of the given url by HTTP.
-func GetHTTPContent(host string, port int, timeout time.Duration, url string) bytes.Buffer {
+func GetHTTPContent(host string, port int, timeout time.Duration, url string) (string, error) {
 	var body bytes.Buffer
-	if pollErr := wait.PollImmediate(framework.Poll, timeout, func() (bool, error) {
+	pollErr := wait.PollImmediate(framework.Poll, timeout, func() (bool, error) {
 		result := e2enetwork.PokeHTTP(host, port, url, nil)
 		if result.Status == e2enetwork.HTTPSuccess {
 			body.Write(result.Body)
 			return true, nil
 		}
 		return false, nil
-	}); pollErr != nil {
-		framework.Failf("Could not reach HTTP service through %v:%v%v after %v: %v", host, port, url, timeout, pollErr)
+	})
+	if pollErr != nil {
+		framework.Logf("Could not reach HTTP service through %v:%v%v after %v: %v", host, port, url, timeout, pollErr)
 	}
-	return body
+	return body.String(), pollErr
 }
 
 // GetHTTPContentFromTestContainer returns the content of the given url by HTTP via a test container.


### PR DESCRIPTION
The ESIPP tests are using a function to poll an HTTP endpoint.
This function failed the framework if the request to the http endpoint
timed out, causing a panic that ginkgo couldn´t recover.

Also, this function was used inside a pollImmediate loop, so it should
return the error instead of fail.


/kind flake
```release-note
NONE
```

xref: https://github.com/kubernetes/kubernetes/issues/93932