### PR TITLE
automated-cherry-pick-of-#97625: use default unkown sock for kubeadm cmd if cri detect is not needed

### DIFF
--- a/cmd/kubeadm/app/cmd/alpha/certs.go
+++ b/cmd/kubeadm/app/cmd/alpha/certs.go
@@ -133,7 +133,7 @@ func (o *genCSRConfig) addFlagSet(flagSet *pflag.FlagSet) {
 func (o *genCSRConfig) load() (err error) {
 	o.kubeadmConfig, err = configutil.LoadOrDefaultInitConfiguration(
 		o.kubeadmConfigPath,
-		&kubeadmapiv1beta2.InitConfiguration{},
+		cmdutil.DefaultInitConfiguration(),
 		&kubeadmapiv1beta2.ClusterConfiguration{},
 	)
 	if err != nil {
@@ -357,7 +357,7 @@ func getInternalCfg(cfgPath string, kubeconfigPath string, cfg kubeadmapiv1beta2
 	}
 
 	// Otherwise read config from --config if provided, otherwise use default configuration
-	return configutil.LoadOrDefaultInitConfiguration(cfgPath, &kubeadmapiv1beta2.InitConfiguration{}, &cfg)
+	return configutil.LoadOrDefaultInitConfiguration(cfgPath, cmdutil.DefaultInitConfiguration(), &cfg)
 }
 
 // newCmdCertsExpiration creates a new `cert check-expiration` command.

--- a/cmd/kubeadm/app/cmd/alpha/kubeconfig.go
+++ b/cmd/kubeadm/app/cmd/alpha/kubeconfig.go
@@ -59,7 +59,7 @@ func newCmdKubeConfigUtility(out io.Writer) *cobra.Command {
 // newCmdUserKubeConfig returns sub commands for kubeconfig phase
 func newCmdUserKubeConfig(out io.Writer) *cobra.Command {
 
-	initCfg := &kubeadmapiv1beta2.InitConfiguration{}
+	initCfg := cmdutil.DefaultInitConfiguration()
 	clusterCfg := &kubeadmapiv1beta2.ClusterConfiguration{}
 
 	// Default values for the cobra help text

--- a/cmd/kubeadm/app/cmd/config.go
+++ b/cmd/kubeadm/app/cmd/config.go
@@ -455,14 +455,7 @@ func NewCmdConfigImagesList(out io.Writer, mockK8sVersion *string) *cobra.Comman
 
 // NewImagesList returns the underlying struct for the "kubeadm config images list" command
 func NewImagesList(cfgPath string, cfg *kubeadmapiv1beta2.ClusterConfiguration) (*ImagesList, error) {
-	// Avoid running the CRI auto-detection code as we don't need it
-	versionedInitCfg := &kubeadmapiv1beta2.InitConfiguration{
-		NodeRegistration: kubeadmapiv1beta2.NodeRegistrationOptions{
-			CRISocket: constants.DefaultDockerCRISocket,
-		},
-	}
-
-	initcfg, err := configutil.LoadOrDefaultInitConfiguration(cfgPath, versionedInitCfg, cfg)
+	initcfg, err := configutil.LoadOrDefaultInitConfiguration(cfgPath, cmdutil.DefaultInitConfiguration(), cfg)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not convert cfg to an internal cfg")
 	}

--- a/cmd/kubeadm/app/cmd/phases/init/certs.go
+++ b/cmd/kubeadm/app/cmd/phases/init/certs.go
@@ -153,12 +153,12 @@ func getCertPhaseFlags(name string) []string {
 
 func getSANDescription(certSpec *certsphase.KubeadmCert) string {
 	//Defaulted config we will use to get SAN certs
-	defaultConfig := &kubeadmapiv1beta2.InitConfiguration{
-		LocalAPIEndpoint: kubeadmapiv1beta2.APIEndpoint{
-			// GetAPIServerAltNames errors without an AdvertiseAddress; this is as good as any.
-			AdvertiseAddress: "127.0.0.1",
-		},
+	defaultConfig := cmdutil.DefaultInitConfiguration()
+	// GetAPIServerAltNames errors without an AdvertiseAddress; this is as good as any.
+	defaultConfig.LocalAPIEndpoint = kubeadmapiv1beta2.APIEndpoint{
+		AdvertiseAddress: "127.0.0.1",
 	}
+
 	defaultInternalConfig := &kubeadmapi.InitConfiguration{}
 
 	kubeadmscheme.Scheme.Default(defaultConfig)

--- a/cmd/kubeadm/app/cmd/token.go
+++ b/cmd/kubeadm/app/cmd/token.go
@@ -92,7 +92,7 @@ func NewCmdToken(out io.Writer, errW io.Writer) *cobra.Command {
 	tokenCmd.PersistentFlags().BoolVar(&dryRun,
 		options.DryRun, dryRun, "Whether to enable dry-run mode or not")
 
-	cfg := &kubeadmapiv1beta2.InitConfiguration{}
+	cfg := cmdutil.DefaultInitConfiguration()
 
 	// Default values for the cobra help text
 	kubeadmscheme.Scheme.Default(cfg)
@@ -243,11 +243,6 @@ func RunCreateToken(out io.Writer, client clientset.Interface, cfgPath string, i
 
 	// This call returns the ready-to-use configuration based on the configuration file that might or might not exist and the default cfg populated by flags
 	klog.V(1).Infoln("[token] loading configurations")
-
-	// In fact, we don't do any CRI ops at all.
-	// This is just to force skipping the CRI detection.
-	// Ref: https://github.com/kubernetes/kubeadm/issues/1559
-	initCfg.NodeRegistration.CRISocket = kubeadmconstants.DefaultDockerCRISocket
 
 	internalcfg, err := configutil.LoadOrDefaultInitConfiguration(cfgPath, initCfg, clusterCfg)
 	if err != nil {

--- a/cmd/kubeadm/app/cmd/util/BUILD
+++ b/cmd/kubeadm/app/cmd/util/BUILD
@@ -10,6 +10,7 @@ go_library(
     importpath = "k8s.io/kubernetes/cmd/kubeadm/app/cmd/util",
     visibility = ["//visibility:public"],
     deps = [
+        "//cmd/kubeadm/app/apis/kubeadm/v1beta2:go_default_library",
         "//cmd/kubeadm/app/cmd/options:go_default_library",
         "//cmd/kubeadm/app/constants:go_default_library",
         "//cmd/kubeadm/app/util/kubeconfig:go_default_library",

--- a/cmd/kubeadm/app/cmd/util/cmdutil.go
+++ b/cmd/kubeadm/app/cmd/util/cmdutil.go
@@ -23,6 +23,7 @@ import (
 
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/klog/v2"
+	kubeadmapiv1beta2 "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta2"
 	"k8s.io/kubernetes/cmd/kubeadm/app/cmd/options"
 	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
 )
@@ -86,4 +87,15 @@ func AddCRISocketFlag(flagSet *pflag.FlagSet, criSocket *string) {
 		criSocket, options.NodeCRISocket, *criSocket,
 		"Path to the CRI socket to connect. If empty kubeadm will try to auto-detect this value; use this option only if you have more than one CRI installed or if you have non-standard CRI socket.",
 	)
+}
+
+// DefaultInitConfiguration return default InitConfiguration. Avoid running the CRI auto-detection
+// code as we don't need it.
+func DefaultInitConfiguration() *kubeadmapiv1beta2.InitConfiguration {
+	initCfg := &kubeadmapiv1beta2.InitConfiguration{
+		NodeRegistration: kubeadmapiv1beta2.NodeRegistrationOptions{
+			CRISocket: kubeadmconstants.UnknownCRISocket, // avoid CRI detection
+		},
+	}
+	return initCfg
 }

--- a/cmd/kubeadm/app/constants/constants.go
+++ b/cmd/kubeadm/app/constants/constants.go
@@ -218,6 +218,9 @@ const (
 	// init/join time for use later. kubeadm annotates the node object with this information
 	AnnotationKubeadmCRISocket = "kubeadm.alpha.kubernetes.io/cri-socket"
 
+	// UnknownCRISocket defines the undetected or unknown CRI socket
+	UnknownCRISocket = "/var/run/unknown.sock"
+
 	// KubeadmConfigConfigMap specifies in what ConfigMap in the kube-system namespace the `kubeadm init` configuration should be stored
 	KubeadmConfigConfigMap = "kubeadm-config"
 

--- a/cmd/kubeadm/app/util/config/cluster.go
+++ b/cmd/kubeadm/app/util/config/cluster.go
@@ -125,7 +125,7 @@ func getInitConfigurationFromCluster(kubeconfigDir string, client clientset.Inte
 		// However, if newControlPlane == true, initcfg.NodeRegistration is not used at all and it's overwritten later on.
 		// Thus it's necessary to supply some default value, that will avoid the call to DetectCRISocket() and as
 		// initcfg.NodeRegistration is discarded, setting whatever value here is harmless.
-		initcfg.NodeRegistration.CRISocket = constants.DefaultDockerCRISocket
+		initcfg.NodeRegistration.CRISocket = constants.UnknownCRISocket
 	}
 	return initcfg, nil
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
cherry-pick from #97625 to fix in 1.19

**What this PR does / why we need it**:
per https://github.com/kubernetes/kubeadm/issues/2364#issuecomment-756732276

**Which issue(s) this PR fixes**:
Fixes kubernetes/kubeadm#2364

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
kubeadm: avoid detection of the container runtime for commands that do not need it
```