### PR TITLE
bugfix: conflict between `podtolerationrestriction` admission plugin and `validateOnlyAddedTolerations`

### DIFF
--- a/cmd/cloud-controller-manager/.import-restrictions
+++ b/cmd/cloud-controller-manager/.import-restrictions
@@ -37,6 +37,7 @@ rules:
       - k8s.io/kubernetes/pkg/util/node
       - k8s.io/kubernetes/pkg/util/parsers
       - k8s.io/kubernetes/pkg/util/taints
+      - k8s.io/kubernetes/pkg/util/tolerations/merge
       - k8s.io/kubernetes/pkg/proxy/util
       - k8s.io/kubernetes/pkg/proxy/util/testing
       - k8s.io/kubernetes/pkg/util/sysctl

--- a/pkg/util/tolerations/merge/merge.go
+++ b/pkg/util/tolerations/merge/merge.go
@@ -1,0 +1,87 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package merge
+
+import (
+	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/klog/v2"
+	"k8s.io/kubernetes/pkg/apis/core"
+)
+
+// DoTolerationsMerge merges two sets of tolerations into one. If one toleration is a superset of
+// another, only the superset is kept.
+func DoTolerationsMerge(first, second []core.Toleration) []core.Toleration {
+	all := append(first, second...)
+	var merged []core.Toleration
+
+next:
+	for i, t := range all {
+		for _, t2 := range merged {
+			if IsSuperset(t2, t) {
+				continue next // t is redundant; ignore it
+			}
+		}
+		if i+1 < len(all) {
+			for _, t2 := range all[i+1:] {
+				// If the tolerations are equal, prefer the first.
+				if !equality.Semantic.DeepEqual(&t, &t2) && IsSuperset(t2, t) {
+					continue next // t is redundant; ignore it
+				}
+			}
+		}
+		merged = append(merged, t)
+	}
+
+	return merged
+}
+
+// IsSuperset checks whether ss tolerates a superset of t.
+func IsSuperset(ss, t core.Toleration) bool {
+	if equality.Semantic.DeepEqual(&t, &ss) {
+		return true
+	}
+
+	if t.Key != ss.Key &&
+		// An empty key with Exists operator means match all keys & values.
+		(ss.Key != "" || ss.Operator != core.TolerationOpExists) {
+		return false
+	}
+
+	// An empty effect means match all effects.
+	if t.Effect != ss.Effect && ss.Effect != "" {
+		return false
+	}
+
+	if ss.Effect == core.TaintEffectNoExecute {
+		if ss.TolerationSeconds != nil {
+			if t.TolerationSeconds == nil ||
+				*t.TolerationSeconds > *ss.TolerationSeconds {
+				return false
+			}
+		}
+	}
+
+	switch ss.Operator {
+	case core.TolerationOpEqual, "": // empty operator means Equal
+		return t.Operator == core.TolerationOpEqual && t.Value == ss.Value
+	case core.TolerationOpExists:
+		return true
+	default:
+		klog.Errorf("Unknown toleration operator: %s", ss.Operator)
+		return false
+	}
+}

--- a/pkg/util/tolerations/tolerations.go
+++ b/pkg/util/tolerations/tolerations.go
@@ -17,9 +17,8 @@ limitations under the License.
 package tolerations
 
 import (
-	apiequality "k8s.io/apimachinery/pkg/api/equality"
-	"k8s.io/klog/v2"
 	api "k8s.io/kubernetes/pkg/apis/core"
+	"k8s.io/kubernetes/pkg/util/tolerations/merge"
 )
 
 // VerifyAgainstWhitelist checks if the provided tolerations
@@ -32,7 +31,7 @@ func VerifyAgainstWhitelist(tolerations, whitelist []api.Toleration) bool {
 next:
 	for _, t := range tolerations {
 		for _, w := range whitelist {
-			if isSuperset(w, t) {
+			if merge.IsSuperset(w, t) {
 				continue next
 			}
 		}
@@ -40,68 +39,4 @@ next:
 	}
 
 	return true
-}
-
-// MergeTolerations merges two sets of tolerations into one. If one toleration is a superset of
-// another, only the superset is kept.
-func MergeTolerations(first, second []api.Toleration) []api.Toleration {
-	all := append(first, second...)
-	var merged []api.Toleration
-
-next:
-	for i, t := range all {
-		for _, t2 := range merged {
-			if isSuperset(t2, t) {
-				continue next // t is redundant; ignore it
-			}
-		}
-		if i+1 < len(all) {
-			for _, t2 := range all[i+1:] {
-				// If the tolerations are equal, prefer the first.
-				if !apiequality.Semantic.DeepEqual(&t, &t2) && isSuperset(t2, t) {
-					continue next // t is redundant; ignore it
-				}
-			}
-		}
-		merged = append(merged, t)
-	}
-
-	return merged
-}
-
-// isSuperset checks whether ss tolerates a superset of t.
-func isSuperset(ss, t api.Toleration) bool {
-	if apiequality.Semantic.DeepEqual(&t, &ss) {
-		return true
-	}
-
-	if t.Key != ss.Key &&
-		// An empty key with Exists operator means match all keys & values.
-		(ss.Key != "" || ss.Operator != api.TolerationOpExists) {
-		return false
-	}
-
-	// An empty effect means match all effects.
-	if t.Effect != ss.Effect && ss.Effect != "" {
-		return false
-	}
-
-	if ss.Effect == api.TaintEffectNoExecute {
-		if ss.TolerationSeconds != nil {
-			if t.TolerationSeconds == nil ||
-				*t.TolerationSeconds > *ss.TolerationSeconds {
-				return false
-			}
-		}
-	}
-
-	switch ss.Operator {
-	case api.TolerationOpEqual, "": // empty operator means Equal
-		return t.Operator == api.TolerationOpEqual && t.Value == ss.Value
-	case api.TolerationOpExists:
-		return true
-	default:
-		klog.Errorf("Unknown toleration operator: %s", ss.Operator)
-		return false
-	}
 }

--- a/plugin/pkg/admission/podtolerationrestriction/admission.go
+++ b/plugin/pkg/admission/podtolerationrestriction/admission.go
@@ -36,6 +36,7 @@ import (
 	qoshelper "k8s.io/kubernetes/pkg/apis/core/helper/qos"
 	k8s_api_v1 "k8s.io/kubernetes/pkg/apis/core/v1"
 	"k8s.io/kubernetes/pkg/util/tolerations"
+	"k8s.io/kubernetes/pkg/util/tolerations/merge"
 	pluginapi "k8s.io/kubernetes/plugin/pkg/admission/podtolerationrestriction/apis/podtolerationrestriction"
 )
 
@@ -108,7 +109,7 @@ func (p *Plugin) Admit(ctx context.Context, a admission.Attributes, o admission.
 	}
 	// Final merge of tolerations irrespective of pod type.
 	if len(extraTolerations) > 0 {
-		pod.Spec.Tolerations = tolerations.MergeTolerations(pod.Spec.Tolerations, extraTolerations)
+		pod.Spec.Tolerations = merge.DoTolerationsMerge(pod.Spec.Tolerations, extraTolerations)
 	}
 	return p.Validate(ctx, a, o)
 }

--- a/plugin/pkg/admission/runtimeclass/admission.go
+++ b/plugin/pkg/admission/runtimeclass/admission.go
@@ -39,7 +39,7 @@ import (
 	api "k8s.io/kubernetes/pkg/apis/core"
 	node "k8s.io/kubernetes/pkg/apis/node"
 	apinodev1 "k8s.io/kubernetes/pkg/apis/node/v1"
-	"k8s.io/kubernetes/pkg/util/tolerations"
+	"k8s.io/kubernetes/pkg/util/tolerations/merge"
 )
 
 // PluginName indicates name of admission plugin.
@@ -208,7 +208,7 @@ func setScheduling(a admission.Attributes, pod *api.Pod, runtimeClass *nodev1.Ru
 		}
 	}
 
-	newTolerations := tolerations.MergeTolerations(pod.Spec.Tolerations, nodeScheduling.Tolerations)
+	newTolerations := merge.DoTolerationsMerge(pod.Spec.Tolerations, nodeScheduling.Tolerations)
 
 	pod.Spec.NodeSelector = newNodeSelector
 	pod.Spec.Tolerations = newTolerations

--- a/test/e2e/framework/.import-restrictions
+++ b/test/e2e/framework/.import-restrictions
@@ -228,6 +228,7 @@ rules:
       - k8s.io/kubernetes/pkg/util/system
       - k8s.io/kubernetes/pkg/util/tail
       - k8s.io/kubernetes/pkg/util/taints
+      - k8s.io/kubernetes/pkg/util/tolerations/merge
       - k8s.io/kubernetes/pkg/volume
       - k8s.io/kubernetes/pkg/volume/util
       - k8s.io/kubernetes/pkg/volume/util/fs


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
I believe there is a conflict between [`podtolerationrestriction` admission plugin](https://github.com/kubernetes/kubernetes/blob/cc09a6df5805574394e2eff285756d2886b34805/plugin/pkg/admission/podtolerationrestriction/admission.go#L111) and [validateOnlyAddedTolerations](https://github.com/kubernetes/kubernetes/blob/cc09a6df5805574394e2eff285756d2886b34805/pkg/apis/core/validation/validation.go#L3101) validation. Resulting in all mutating requests to a pod object being rejected, with error message: `"existing toleration can not be modified except its tolerationSeconds"`

A pod spec that can reproduce this issue is:
```yaml
spec:
  tolerations:
  - operator: Exists
  - key: node.kubernetes.io/not-ready
    operator: Exists
    effect: NoExecute
```

The `podtolerationrestriction` admission plugin will call `tolerations.MergeTolerations` on the Pod tolerations, after which the pod tolerations will become:

```yaml
spec:
  tolerations:
  - operator: Exists
```

Then, `validateOnlyAddedTolerations` will fail, because `node.kubernetes.io/not-ready` is in `oldTolerations` but not in `newTolerations`.

My proposed fix is to call `tolerations.MergeTolerations` on both `oldTolerations` and `newTolerations` in `validateOnlyAddedTolerations` before comparing them. 

I actually encountered this problem in our production kubernetes cluster and this PR managed to fix the problem.

**Special notes for your reviewer**:
I have to move `MergeTolerations` to `pkg/util/tolerations/merge` in order to avoid import cycle between `pkg/apis/core/validation` and `pkg/util/tolerations`.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```