### PR TITLE
kubectl: reuse clients in "kubectl get --output yaml|json"

### DIFF
--- a/staging/src/k8s.io/cli-runtime/go.mod
+++ b/staging/src/k8s.io/cli-runtime/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1
 	github.com/emicklei/go-restful v2.9.5+incompatible // indirect
 	github.com/evanphx/json-patch v4.9.0+incompatible
+	github.com/google/go-cmp v0.5.2
 	github.com/googleapis/gnostic v0.4.1
 	github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de
 	github.com/mailru/easyjson v0.7.0 // indirect

--- a/staging/src/k8s.io/cli-runtime/pkg/resource/BUILD
+++ b/staging/src/k8s.io/cli-runtime/pkg/resource/BUILD
@@ -58,6 +58,7 @@ go_test(
     srcs = [
         "builder_example_test.go",
         "builder_test.go",
+        "client_test.go",
         "crd_finder_test.go",
         "dry_run_verifier_test.go",
         "helper_test.go",
@@ -89,6 +90,7 @@ go_test(
         "//staging/src/k8s.io/client-go/restmapper:go_default_library",
         "//staging/src/k8s.io/client-go/util/testing:go_default_library",
         "//vendor/github.com/davecgh/go-spew/spew:go_default_library",
+        "//vendor/github.com/google/go-cmp/cmp:go_default_library",
         "//vendor/github.com/googleapis/gnostic/openapiv2:go_default_library",
         "//vendor/github.com/stretchr/testify/assert:go_default_library",
         "//vendor/k8s.io/kube-openapi/pkg/util/proto/testing:go_default_library",

--- a/staging/src/k8s.io/cli-runtime/pkg/resource/builder.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/resource/builder.go
@@ -283,7 +283,7 @@ func (b *Builder) Unstructured() *Builder {
 	b.mapper = &mapper{
 		localFn:      b.isLocal,
 		restMapperFn: b.restMapperFn,
-		clientFn:     b.getClient,
+		clientFn:     newClientPool(b.getClient).get,
 		decoder:      &metadataValidatingDecoder{unstructured.UnstructuredJSONScheme},
 	}
 
@@ -310,7 +310,7 @@ func (b *Builder) WithScheme(scheme *runtime.Scheme, decodingVersions ...schema.
 	b.mapper = &mapper{
 		localFn:      b.isLocal,
 		restMapperFn: b.restMapperFn,
-		clientFn:     b.getClient,
+		clientFn:     newClientPool(b.getClient).get,
 		decoder:      codecFactory.UniversalDecoder(decodingVersions...),
 	}
 

--- a/staging/src/k8s.io/cli-runtime/pkg/resource/client_test.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/resource/client_test.go
@@ -1,0 +1,118 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package resource
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+type fakeRESTClient struct {
+	name string
+	RESTClient
+}
+
+func TestClientPool(t *testing.T) {
+	foov1GroupVersion := schema.GroupVersion{
+		Group:   "foo",
+		Version: "v1",
+	}
+	foov1beta1GroupVersion := schema.GroupVersion{
+		Group:   "foo",
+		Version: "v1beta1",
+	}
+
+	metav1Client := &fakeRESTClient{name: "metav1"}
+	foov1Client := &fakeRESTClient{name: "foov1"}
+	foov1beta1Client := &fakeRESTClient{name: "foov1"}
+	clients := []RESTClient{
+		metav1Client,
+		foov1Client,
+		foov1beta1Client,
+		nil,
+	}
+	clientFuncCalls := make([]schema.GroupVersion, 0)
+	clientFunc := func(version schema.GroupVersion) (RESTClient, error) {
+		client := clients[len(clientFuncCalls)]
+		clientFuncCalls = append(clientFuncCalls, version)
+
+		if client == nil {
+			return nil, errors.New("not found")
+		}
+
+		return client, nil
+	}
+
+	cp := newClientPool(clientFunc)
+	assertClientPoolGet(t, cp, metav1.SchemeGroupVersion, metav1Client, nil)
+	assertClientPoolGet(t, cp, metav1.SchemeGroupVersion, metav1Client, nil)
+	assertClientPoolGet(t, cp, foov1GroupVersion, foov1Client, nil)
+	assertClientPoolGet(t, cp, foov1GroupVersion, foov1Client, nil)
+	assertClientPoolGet(t, cp, foov1beta1GroupVersion, foov1Client, nil)
+	assertClientPoolGet(t, cp, foov1beta1GroupVersion, foov1beta1Client, nil)
+
+	assertClientPoolGet(t, cp, foov1GroupVersion, foov1Client, nil)
+	assertClientPoolGet(t, cp, foov1beta1GroupVersion, foov1Client, nil)
+	assertClientPoolGet(t, cp, metav1.SchemeGroupVersion, metav1Client, nil)
+
+	assertClientPoolGet(t, cp, schema.GroupVersion{}, nil, errors.New("not found"))
+
+	wantCalls := []schema.GroupVersion{
+		metav1.SchemeGroupVersion,
+		foov1GroupVersion,
+		foov1beta1GroupVersion,
+		{},
+	}
+	if diff := cmp.Diff(clientFuncCalls, wantCalls); diff != "" {
+		t.Fatalf("unexpected calls to client func: -got, +want:\n %s", diff)
+	}
+}
+
+func assertClientPoolGet(
+	t *testing.T,
+	cp *clientPool,
+	key schema.GroupVersion,
+	wantClient *fakeRESTClient,
+	wantError error,
+) {
+	t.Helper()
+
+	client, err := cp.get(key)
+	if err != nil {
+		if wantError == nil || wantError.Error() != err.Error() {
+			t.Fatalf("want error %q, got error %q", wantError, err)
+		}
+	} else {
+		if wantError != nil {
+			t.Fatalf("want error %q, got error <nil>", wantError)
+		}
+	}
+	if client == nil {
+		if wantClient != nil {
+			t.Fatalf("want client %s, got client <nil>", wantClient.name)
+		}
+	} else {
+		gotClient := client.(*fakeRESTClient)
+		if gotClient.name != wantClient.name {
+			t.Fatalf("want client %s, got client %s", wantClient.name, gotClient.name)
+		}
+	}
+}


### PR DESCRIPTION
Signed-off-by: Andrew Keesler <akeesler@vmware.com>

/sig cli

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

- Previously, during `kubectl get --output`, we were creating a `resource.RESTClient` per object to print out, which is unnecessary.
- See https://github.com/kubernetes/kubernetes/issues/91913#issuecomment-756785173 and previous comments for related issues.

**Which issue(s) this PR fixes**:

(Partially) fixes #91913.

**Special notes for your reviewer**:

- Read https://github.com/kubernetes/kubernetes/issues/91913#issuecomment-646291219 and onward to learn the backstory for this issue.

- This bug is related to the client-go credential plugin feature set, which is tracked here: https://github.com/kubernetes/enhancements/issues/541.
- The feature set is currently in beta, and we want to get it to GA, which involves tackling the related bugs.
- See https://github.com/kubernetes/kubernetes/issues/91913#issuecomment-646291219 and onward for why this bug is related to the client-go credential plugin feature set.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
