### PR TITLE
Fix typo of BoostrapToken in kubeadmin-type.go]

### DIFF
--- a/cmd/kubeadm/app/apis/output/types.go
+++ b/cmd/kubeadm/app/apis/output/types.go
@@ -24,7 +24,7 @@ import (
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // BootstrapToken represents information for the output produced by 'kubeadm token list'
-// This is a copy of BoostrapToken struct from ../kubeadm/types.go with 2 additions:
+// This is a copy of BootstrapToken struct from ../kubeadm/types.go with 2 additions:
 // metav1.TypeMeta and metav1.ObjectMeta
 type BootstrapToken struct {
 	metav1.TypeMeta

--- a/cmd/kubeadm/app/apis/output/v1alpha1/types.go
+++ b/cmd/kubeadm/app/apis/output/v1alpha1/types.go
@@ -24,7 +24,7 @@ import (
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // BootstrapToken represents information for the bootstrap token output produced by kubeadm
-// This is a copy of BoostrapToken struct from ../kubeadm/types.go with 2 additions:
+// This is a copy of BootstrapToken struct from ../kubeadm/types.go with 2 additions:
 // metav1.TypeMeta and metav1.ObjectMeta
 type BootstrapToken struct {
 	metav1.TypeMeta `json:",inline"`


### PR DESCRIPTION
What type of PR is this?
/kind cleanup

What this PR does / why we need it:
Fix typo of BoostrapToken in kubeadmin-type.go

Which issue(s) this PR fixes:

Fixes #

Special notes for your reviewer:

Does this PR introduce a user-facing change?:

```release-note
NONE
```
Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.: