### PR TITLE
fix azure file migration issue

### DIFF
--- a/staging/src/k8s.io/csi-translation-lib/plugins/azure_file.go
+++ b/staging/src/k8s.io/csi-translation-lib/plugins/azure_file.go
@@ -37,11 +37,11 @@ const (
 	volumeIDTemplate = "%s#%s#%s#%s"
 	// Parameter names defined in azure file CSI driver, refer to
 	// https://github.com/kubernetes-sigs/azurefile-csi-driver/blob/master/docs/driver-parameters.md
-	azureFileShareName = "shareName"
-
-	secretNameTemplate     = "azure-storage-account-%s-secret"
-	defaultSecretNamespace = "default"
-
+	shareNameField          = "sharename"
+	secretNameField         = "secretname"
+	secretNamespaceField    = "secretnamespace"
+	secretNameTemplate      = "azure-storage-account-%s-secret"
+	defaultSecretNamespace  = "default"
 	resourceGroupAnnotation = "kubernetes.io/azure-file-resource-group"
 )
 
@@ -90,7 +90,7 @@ func (t *azureFileCSITranslator) TranslateInTreeInlineVolumeToCSI(volume *v1.Vol
 						Driver:           AzureFileDriverName,
 						VolumeHandle:     fmt.Sprintf(volumeIDTemplate, "", accountName, azureSource.ShareName, ""),
 						ReadOnly:         azureSource.ReadOnly,
-						VolumeAttributes: map[string]string{azureFileShareName: azureSource.ShareName},
+						VolumeAttributes: map[string]string{shareNameField: azureSource.ShareName},
 						NodeStageSecretRef: &v1.SecretReference{
 							Name:      azureSource.SecretName,
 							Namespace: defaultSecretNamespace,
@@ -135,7 +135,7 @@ func (t *azureFileCSITranslator) TranslateInTreePVToCSI(pv *v1.PersistentVolume)
 				Namespace: defaultSecretNamespace,
 			},
 			ReadOnly:         azureSource.ReadOnly,
-			VolumeAttributes: map[string]string{azureFileShareName: azureSource.ShareName},
+			VolumeAttributes: map[string]string{shareNameField: azureSource.ShareName},
 			VolumeHandle:     volumeID,
 		}
 	)
@@ -163,31 +163,48 @@ func (t *azureFileCSITranslator) TranslateCSIPVToInTree(pv *v1.PersistentVolume)
 		ReadOnly: csiSource.ReadOnly,
 	}
 
+	for k, v := range csiSource.VolumeAttributes {
+		switch strings.ToLower(k) {
+		case shareNameField:
+			azureSource.ShareName = v
+		case secretNameField:
+			azureSource.SecretName = v
+		case secretNamespaceField:
+			ns := v
+			azureSource.SecretNamespace = &ns
+		}
+	}
+
 	resourceGroup := ""
 	if csiSource.NodeStageSecretRef != nil && csiSource.NodeStageSecretRef.Name != "" {
 		azureSource.SecretName = csiSource.NodeStageSecretRef.Name
 		azureSource.SecretNamespace = &csiSource.NodeStageSecretRef.Namespace
-		if csiSource.VolumeAttributes != nil {
-			if shareName, ok := csiSource.VolumeAttributes[azureFileShareName]; ok {
-				azureSource.ShareName = shareName
-			}
-		}
-	} else {
+	}
+	if azureSource.ShareName == "" || azureSource.SecretName == "" {
 		rg, storageAccount, fileShareName, _, err := getFileShareInfo(csiSource.VolumeHandle)
 		if err != nil {
 			return nil, err
 		}
-		azureSource.ShareName = fileShareName
-		azureSource.SecretName = fmt.Sprintf(secretNameTemplate, storageAccount)
+		if azureSource.ShareName == "" {
+			azureSource.ShareName = fileShareName
+		}
+		if azureSource.SecretName == "" {
+			azureSource.SecretName = fmt.Sprintf(secretNameTemplate, storageAccount)
+		}
 		resourceGroup = rg
+	}
+
+	if azureSource.SecretNamespace == nil {
+		ns := defaultSecretNamespace
+		azureSource.SecretNamespace = &ns
 	}
 
 	pv.Spec.CSI = nil
 	pv.Spec.AzureFile = azureSource
+	if pv.ObjectMeta.Annotations == nil {
+		pv.ObjectMeta.Annotations = map[string]string{}
+	}
 	if resourceGroup != "" {
-		if pv.ObjectMeta.Annotations == nil {
-			pv.ObjectMeta.Annotations = map[string]string{}
-		}
 		pv.ObjectMeta.Annotations[resourceGroupAnnotation] = resourceGroup
 	}
 

--- a/staging/src/k8s.io/csi-translation-lib/plugins/azure_file_test.go
+++ b/staging/src/k8s.io/csi-translation-lib/plugins/azure_file_test.go
@@ -140,7 +140,7 @@ func TestTranslateAzureFileInTreeStorageClassToCSI(t *testing.T) {
 								Namespace: "default",
 							},
 							ReadOnly:         true,
-							VolumeAttributes: map[string]string{azureFileShareName: "sharename"},
+							VolumeAttributes: map[string]string{shareNameField: "sharename"},
 							VolumeHandle:     "#secretname#sharename#",
 						},
 					},
@@ -217,7 +217,7 @@ func TestTranslateAzureFileInTreePVToCSI(t *testing.T) {
 								Name:      "secretname",
 								Namespace: secretNamespace,
 							},
-							VolumeAttributes: map[string]string{azureFileShareName: "sharename"},
+							VolumeAttributes: map[string]string{shareNameField: "sharename"},
 							VolumeHandle:     "#secretname#sharename#",
 						},
 					},
@@ -256,7 +256,7 @@ func TestTranslateAzureFileInTreePVToCSI(t *testing.T) {
 								Name:      "secretname",
 								Namespace: secretNamespace,
 							},
-							VolumeAttributes: map[string]string{azureFileShareName: "sharename"},
+							VolumeAttributes: map[string]string{shareNameField: "sharename"},
 							VolumeHandle:     "rg#secretname#sharename#",
 						},
 					},
@@ -285,9 +285,18 @@ func TestTranslateAzureFileInTreePVToCSI(t *testing.T) {
 func TestTranslateCSIPVToInTree(t *testing.T) {
 	translator := NewAzureFileCSITranslator()
 
+	secretName := "secretname"
 	secretNamespace := "secretnamespace"
+	shareName := "sharename"
+	defaultNS := "default"
 	mp := make(map[string]string)
-	mp["shareName"] = "unit-test"
+	mp["shareName"] = shareName
+
+	secretMap := make(map[string]string)
+	secretMap["shareName"] = shareName
+	secretMap["secretName"] = secretName
+	secretMap["secretNamespace"] = secretNamespace
+
 	cases := []struct {
 		name   string
 		volume *corev1.PersistentVolume
@@ -315,13 +324,16 @@ func TestTranslateCSIPVToInTree(t *testing.T) {
 				},
 			},
 			expVol: &corev1.PersistentVolume{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{},
+				},
 				Spec: corev1.PersistentVolumeSpec{
 					PersistentVolumeSource: corev1.PersistentVolumeSource{
 						AzureFile: &corev1.AzureFilePersistentVolumeSource{
 							SecretName:      "ut",
 							SecretNamespace: &secretNamespace,
 							ReadOnly:        true,
-							ShareName:       "unit-test",
+							ShareName:       shareName,
 						},
 					},
 				},
@@ -334,7 +346,7 @@ func TestTranslateCSIPVToInTree(t *testing.T) {
 				Spec: corev1.PersistentVolumeSpec{
 					PersistentVolumeSource: corev1.PersistentVolumeSource{
 						CSI: &corev1.CSIPersistentVolumeSource{
-							VolumeHandle:     "unit-test",
+							VolumeHandle:     shareName,
 							ReadOnly:         true,
 							VolumeAttributes: mp,
 						},
@@ -344,7 +356,7 @@ func TestTranslateCSIPVToInTree(t *testing.T) {
 			expErr: true,
 		},
 		{
-			name: "translate from volume handle",
+			name: "translate from VolumeAttributes",
 			volume: &corev1.PersistentVolume{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "file.csi.azure.com-sharename",
@@ -367,9 +379,116 @@ func TestTranslateCSIPVToInTree(t *testing.T) {
 				Spec: corev1.PersistentVolumeSpec{
 					PersistentVolumeSource: corev1.PersistentVolumeSource{
 						AzureFile: &corev1.AzureFilePersistentVolumeSource{
-							SecretName: "azure-storage-account-st-secret",
-							ShareName:  "pvc-file-dynamic",
-							ReadOnly:   true,
+							SecretName:      "azure-storage-account-st-secret",
+							ShareName:       shareName,
+							SecretNamespace: &defaultNS,
+							ReadOnly:        true,
+						},
+					},
+				},
+			},
+			expErr: false,
+		},
+		{
+			name: "translate from SecretMap VolumeAttributes",
+			volume: &corev1.PersistentVolume{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "file.csi.azure.com-sharename",
+					Annotations: map[string]string{},
+				},
+				Spec: corev1.PersistentVolumeSpec{
+					PersistentVolumeSource: corev1.PersistentVolumeSource{
+						CSI: &corev1.CSIPersistentVolumeSource{
+							VolumeHandle:     "rg#st#pvc-file-dynamic#diskname.vhd",
+							ReadOnly:         true,
+							VolumeAttributes: secretMap,
+						},
+					},
+				},
+			},
+			expVol: &corev1.PersistentVolume{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "file.csi.azure.com-sharename",
+					Annotations: map[string]string{},
+				},
+				Spec: corev1.PersistentVolumeSpec{
+					PersistentVolumeSource: corev1.PersistentVolumeSource{
+						AzureFile: &corev1.AzureFilePersistentVolumeSource{
+							SecretName:      secretName,
+							SecretNamespace: &secretNamespace,
+							ShareName:       shareName,
+							ReadOnly:        true,
+						},
+					},
+				},
+			},
+			expErr: false,
+		},
+		{
+			name: "translate from NodeStageSecretRef",
+			volume: &corev1.PersistentVolume{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "file.csi.azure.com-sharename",
+				},
+				Spec: corev1.PersistentVolumeSpec{
+					PersistentVolumeSource: corev1.PersistentVolumeSource{
+						CSI: &corev1.CSIPersistentVolumeSource{
+							VolumeHandle:     "rg#st#pvc-file-dynamic#diskname.vhd",
+							ReadOnly:         true,
+							VolumeAttributes: mp,
+							NodeStageSecretRef: &corev1.SecretReference{
+								Name:      secretName,
+								Namespace: secretNamespace,
+							},
+						},
+					},
+				},
+			},
+			expVol: &corev1.PersistentVolume{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "file.csi.azure.com-sharename",
+					Annotations: map[string]string{},
+				},
+				Spec: corev1.PersistentVolumeSpec{
+					PersistentVolumeSource: corev1.PersistentVolumeSource{
+						AzureFile: &corev1.AzureFilePersistentVolumeSource{
+							SecretName:      secretName,
+							ShareName:       shareName,
+							SecretNamespace: &secretNamespace,
+							ReadOnly:        true,
+						},
+					},
+				},
+			},
+			expErr: false,
+		},
+		{
+			name: "translate from VolumeHandle",
+			volume: &corev1.PersistentVolume{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "file.csi.azure.com-sharename",
+				},
+				Spec: corev1.PersistentVolumeSpec{
+					PersistentVolumeSource: corev1.PersistentVolumeSource{
+						CSI: &corev1.CSIPersistentVolumeSource{
+							VolumeHandle: "rg#st#pvc-file-dynamic#diskname.vhd",
+							ReadOnly:     true,
+						},
+					},
+				},
+			},
+			expVol: &corev1.PersistentVolume{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "file.csi.azure.com-sharename",
+					Annotations: map[string]string{resourceGroupAnnotation: "rg"},
+				},
+				Spec: corev1.PersistentVolumeSpec{
+					PersistentVolumeSource: corev1.PersistentVolumeSource{
+						AzureFile: &corev1.AzureFilePersistentVolumeSource{
+							SecretName:      "azure-storage-account-st-secret",
+							ShareName:       "pvc-file-dynamic",
+							SecretNamespace: &defaultNS,
+							ReadOnly:        true,
 						},
 					},
 				},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
fix azure file migration issue

Azure file CSI migration failed due to following error, that's because in Azure file CSI migration scenario, the namespace is set as nil, this PR set the PV namespace as `default` (by default), I have verified it works well in CSI migration test.

```
event for azurefile-volume-tester-x2clj: {kubelet k8s-agentpool1-42361127-1} FailedMount: MountVolume.MountDevice failed for volume "pvc-bb75bfa5-72ee-46ec-a770-6bb87580b151" : fetching NodeStageSecretRef default/azure-storage-account-fbf92849c9d7f4cb6ad5691-secret failed: kubernetes.io/csi: failed to find the secret azure-storage-account-fbf92849c9d7f4cb6ad5691-secret in the namespace default with error: secrets "azure-storage-account-fbf92849c9d7f4cb6ad5691-secret" is forbidden: User "system:node:k8s-agentpool1-42361127-1" cannot get resource "secrets" in API group "" in the namespace "default": no relationship found between node 'k8s-agentpool1-42361127-1' and this object
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #96508

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
fix azure file migration issue
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
fix azure file migration issue
```

/priority important-soon
/sig cloud-provider
/area provider/azure
/triage accepted