### PR TITLE
e2e: split test into kubeup & generic tests

### DIFF
--- a/test/e2e/network/firewall.go
+++ b/test/e2e/network/firewall.go
@@ -201,9 +201,6 @@ var _ = SIGDescribe("Firewall rule", func() {
 	})
 
 	ginkgo.It("should have correct firewall rules for e2e cluster", func() {
-		nodes, err := e2enode.GetReadySchedulableNodes(cs)
-		framework.ExpectNoError(err)
-
 		ginkgo.By("Checking if e2e firewall rules are correct")
 		for _, expFw := range gce.GetE2eFirewalls(cloudConfig.MasterName, cloudConfig.MasterTag, cloudConfig.NodeTag, cloudConfig.Network, cloudConfig.ClusterIPRange) {
 			fw, err := gceCloud.GetFirewall(expFw.Name)
@@ -211,6 +208,11 @@ var _ = SIGDescribe("Firewall rule", func() {
 			err = gce.VerifyFirewallRule(fw, expFw, cloudConfig.Network, false)
 			framework.ExpectNoError(err)
 		}
+	})
+
+	ginkgo.It("control plane should not expose well-known ports", func() {
+		nodes, err := e2enode.GetReadySchedulableNodes(cs)
+		framework.ExpectNoError(err)
 
 		ginkgo.By("Checking well known ports on master and nodes are not exposed externally")
 		nodeAddr := e2enode.FirstAddress(nodes, v1.NodeExternalIP)


### PR DESCRIPTION
The "should have correct firewall rules for e2e cluster" test is GCE
specific, and likely specific to the kube-up configuration.

However, the second half of the test is a generic behaviour based test
that verifies that ports are not reachable.

We can split this into two tests, with an eye to running the generic
test in more places.


/kind cleanup
/kind failing-test

```release-note
NONE
```
