### PR TITLE
Fix golint errors for kubectl/pkg/cmd/certificates/certificates.go

### DIFF
--- a/hack/.golint_failures
+++ b/hack/.golint_failures
@@ -413,7 +413,6 @@ staging/src/k8s.io/kubectl/pkg/cmd/annotate
 staging/src/k8s.io/kubectl/pkg/cmd/apply
 staging/src/k8s.io/kubectl/pkg/cmd/attach
 staging/src/k8s.io/kubectl/pkg/cmd/autoscale
-staging/src/k8s.io/kubectl/pkg/cmd/certificates
 staging/src/k8s.io/kubectl/pkg/cmd/clusterinfo
 staging/src/k8s.io/kubectl/pkg/cmd/create
 staging/src/k8s.io/kubectl/pkg/cmd/debug

--- a/staging/src/k8s.io/kubectl/pkg/cmd/certificates/certificates.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/certificates/certificates.go
@@ -41,6 +41,7 @@ import (
 	"k8s.io/kubectl/pkg/util/templates"
 )
 
+// NewCmdCertificate returns `certificate` Cobra command
 func NewCmdCertificate(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:                   "certificate SUBCOMMAND",
@@ -58,6 +59,7 @@ func NewCmdCertificate(f cmdutil.Factory, ioStreams genericclioptions.IOStreams)
 	return cmd
 }
 
+// CertificateOptions declares the arguments accepted by the certificate command
 type CertificateOptions struct {
 	resource.FilenameOptions
 
@@ -73,7 +75,7 @@ type CertificateOptions struct {
 	genericclioptions.IOStreams
 }
 
-// NewCertificateOptions creates the options for certificate
+// NewCertificateOptions creates CertificateOptions struct for `certificate` command
 func NewCertificateOptions(ioStreams genericclioptions.IOStreams, operation string) *CertificateOptions {
 	return &CertificateOptions{
 		PrintFlags: genericclioptions.NewPrintFlags(operation).WithTypeSetter(scheme.Scheme),
@@ -81,6 +83,7 @@ func NewCertificateOptions(ioStreams genericclioptions.IOStreams, operation stri
 	}
 }
 
+// Complete loads data from the command environment
 func (o *CertificateOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []string) error {
 	o.csrNames = args
 	o.outputStyle = cmdutil.GetFlagString(cmd, "output")
@@ -104,6 +107,7 @@ func (o *CertificateOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, arg
 	return nil
 }
 
+// Validate checks if the provided `certificate` arguments are valid
 func (o *CertificateOptions) Validate() error {
 	if len(o.csrNames) < 1 && cmdutil.IsFilenameSliceEmpty(o.Filenames, o.Kustomize) {
 		return fmt.Errorf("one or more CSRs must be specified as <name> or -f <filename>")
@@ -111,6 +115,7 @@ func (o *CertificateOptions) Validate() error {
 	return nil
 }
 
+// NewCmdCertificateApprove returns the `certificate approve` Cobra command
 func NewCmdCertificateApprove(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *cobra.Command {
 	o := NewCertificateOptions(ioStreams, "approved")
 
@@ -145,6 +150,7 @@ func NewCmdCertificateApprove(f cmdutil.Factory, ioStreams genericclioptions.IOS
 	return cmd
 }
 
+// RunCertificateApprove approves a certificate signing request
 func (o *CertificateOptions) RunCertificateApprove(force bool) error {
 	return o.modifyCertificateCondition(
 		o.builder,
@@ -154,6 +160,7 @@ func (o *CertificateOptions) RunCertificateApprove(force bool) error {
 	)
 }
 
+// NewCmdCertificateDeny returns the `certificate deny` Cobra command
 func NewCmdCertificateDeny(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *cobra.Command {
 	o := NewCertificateOptions(ioStreams, "denied")
 
@@ -183,6 +190,7 @@ func NewCmdCertificateDeny(f cmdutil.Factory, ioStreams genericclioptions.IOStre
 	return cmd
 }
 
+// RunCertificateDeny denies a certificate signing request
 func (o *CertificateOptions) RunCertificateDeny(force bool) error {
 	return o.modifyCertificateCondition(
 		o.builder,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup


**What this PR does / why we need it**:
Fix golint errors for `kubectl/pkg/cmd/certificates/certificates.go`

```
ng/src/k8s.io/kubectl/pkg/cmd/certificates/certificates.go:44:1: exported function NewCmdCertificate should have comment or be unexported
staging/src/k8s.io/kubectl/pkg/cmd/certificates/certificates.go:61:6: exported type CertificateOptions should have comment or be unexported
staging/src/k8s.io/kubectl/pkg/cmd/certificates/certificates.go:84:1: exported method CertificateOptions.Complete should have comment or be unexported
staging/src/k8s.io/kubectl/pkg/cmd/certificates/certificates.go:107:1: exported method CertificateOptions.Validate should have comment or be unexported
staging/src/k8s.io/kubectl/pkg/cmd/certificates/certificates.go:114:1: exported function NewCmdCertificateApprove should have comment or be unexported
staging/src/k8s.io/kubectl/pkg/cmd/certificates/certificates.go:148:1: exported method CertificateOptions.RunCertificateApprove should have comment or be unexported
staging/src/k8s.io/kubectl/pkg/cmd/certificates/certificates.go:157:1: exported function NewCmdCertificateDeny should have comment or be unexported
staging/src/k8s.io/kubectl/pkg/cmd/certificates/certificates.go:186:1: exported method CertificateOptions.RunCertificateDeny should have comment or be unexported

```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of #68026
**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
