### PR TITLE
kubectl: migrate $HOME/.kube to $HOME/.config/kube

### DIFF
--- a/staging/src/k8s.io/client-go/tools/clientcmd/loader_test.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/loader_test.go
@@ -873,7 +873,7 @@ func TestLoadingGetLoadingPrecedence(t *testing.T) {
 		precedence []string
 	}{
 		"default": {
-			precedence: []string{filepath.Join(os.Getenv("HOME"), ".kube/config")},
+			precedence: []string{filepath.Join(os.Getenv("HOME"), ".config/kube/config")},
 		},
 		"explicit": {
 			rules: &ClientConfigLoadingRules{


### PR DESCRIPTION
kubectl: migrate $HOME/.kube to $HOME/.config/kube
    
This patch implements the migration config from $HOME/.kube to
use XDG Base Directory Specification. The recommended
path now will be $HOME/.config/kube.
    
 KEP: https://github.com/kubernetes/enhancements/pull/2111
    
 Signed-off-by: Douglas Schilling Landgraf <dougsland@redhat.com>
