### PR TITLE
WIP: kubelet: fix the pod UID to link its mirror pod

### DIFF
--- a/pkg/kubelet/config/file_linux_test.go
+++ b/pkg/kubelet/config/file_linux_test.go
@@ -163,11 +163,14 @@ func getTestCases(hostname types.NodeName) []*testCase {
 			},
 			expected: CreatePodUpdate(kubetypes.SET, kubetypes.FileSource, &v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:        "test-" + string(hostname),
-					UID:         "12345",
-					Namespace:   "mynamespace",
-					Annotations: map[string]string{kubetypes.ConfigHashAnnotationKey: "12345"},
-					SelfLink:    getSelfLink("test-"+string(hostname), "mynamespace"),
+					Name:      "test-" + string(hostname),
+					UID:       "12345",
+					Namespace: "mynamespace",
+					Annotations: map[string]string{
+						kubetypes.ConfigHashAnnotationKey:         "12345",
+						kubetypes.ConfigHashInternalAnnotationKey: "5c62b4264c31a432f77ed8081845e387",
+					},
+					SelfLink: getSelfLink("test-"+string(hostname), "mynamespace"),
 				},
 				Spec: v1.PodSpec{
 					NodeName:                      string(hostname),
@@ -330,6 +333,8 @@ func watchFileChanged(watchDir bool, symlink bool, t *testing.T) {
 				pod.Spec.Containers[0].Name = "image2"
 
 				testCase.expected.Pods[0].Spec.Containers[0].Name = "image2"
+				testCase.expected.Pods[0].Annotations[kubetypes.ConfigHashInternalAnnotationKey] =
+					"56e6670f5382b85bfcb869e7f4ed2cf5"
 				if symlink {
 					file = testCase.writeToFile(linkedDirName, fileName, t)
 					return

--- a/pkg/kubelet/config/http_test.go
+++ b/pkg/kubelet/config/http_test.go
@@ -160,11 +160,14 @@ func TestExtractPodsFromHTTP(t *testing.T) {
 				kubetypes.HTTPSource,
 				&v1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
-						UID:         "111",
-						Name:        "foo" + "-" + nodeName,
-						Namespace:   "mynamespace",
-						Annotations: map[string]string{kubetypes.ConfigHashAnnotationKey: "111"},
-						SelfLink:    getSelfLink("foo-"+nodeName, "mynamespace"),
+						UID:       "111",
+						Name:      "foo" + "-" + nodeName,
+						Namespace: "mynamespace",
+						Annotations: map[string]string{
+							kubetypes.ConfigHashAnnotationKey:         "111",
+							kubetypes.ConfigHashInternalAnnotationKey: "63152656d2a3012a6798130d5b6dcae2",
+						},
+						SelfLink: getSelfLink("foo-"+nodeName, "mynamespace"),
 					},
 					Spec: v1.PodSpec{
 						NodeName:                      nodeName,
@@ -232,11 +235,14 @@ func TestExtractPodsFromHTTP(t *testing.T) {
 				kubetypes.HTTPSource,
 				&v1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
-						UID:         "111",
-						Name:        "foo" + "-" + nodeName,
-						Namespace:   "default",
-						Annotations: map[string]string{kubetypes.ConfigHashAnnotationKey: "111"},
-						SelfLink:    getSelfLink("foo-"+nodeName, metav1.NamespaceDefault),
+						UID:       "111",
+						Name:      "foo" + "-" + nodeName,
+						Namespace: "default",
+						Annotations: map[string]string{
+							kubetypes.ConfigHashAnnotationKey:         "111",
+							kubetypes.ConfigHashInternalAnnotationKey: "a7dd5dc3ee4fe954826e7af351eade03",
+						},
+						SelfLink: getSelfLink("foo-"+nodeName, metav1.NamespaceDefault),
 					},
 					Spec: v1.PodSpec{
 						NodeName:                      nodeName,
@@ -261,11 +267,14 @@ func TestExtractPodsFromHTTP(t *testing.T) {
 				},
 				&v1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
-						UID:         "222",
-						Name:        "bar" + "-" + nodeName,
-						Namespace:   "default",
-						Annotations: map[string]string{kubetypes.ConfigHashAnnotationKey: "222"},
-						SelfLink:    getSelfLink("bar-"+nodeName, metav1.NamespaceDefault),
+						UID:       "222",
+						Name:      "bar" + "-" + nodeName,
+						Namespace: "default",
+						Annotations: map[string]string{
+							kubetypes.ConfigHashAnnotationKey:         "222",
+							kubetypes.ConfigHashInternalAnnotationKey: "948fd58f0260cedfc4d96f3acf0e9e5b",
+						},
+						SelfLink: getSelfLink("bar-"+nodeName, metav1.NamespaceDefault),
 					},
 					Spec: v1.PodSpec{
 						NodeName:                      nodeName,

--- a/pkg/kubelet/types/pod_update.go
+++ b/pkg/kubelet/types/pod_update.go
@@ -26,10 +26,11 @@ import (
 
 // Annotation keys for annotations used in this package.
 const (
-	ConfigSourceAnnotationKey    = "kubernetes.io/config.source"
-	ConfigMirrorAnnotationKey    = v1.MirrorPodAnnotationKey
-	ConfigFirstSeenAnnotationKey = "kubernetes.io/config.seen"
-	ConfigHashAnnotationKey      = "kubernetes.io/config.hash"
+	ConfigSourceAnnotationKey       = "kubernetes.io/config.source"
+	ConfigMirrorAnnotationKey       = v1.MirrorPodAnnotationKey
+	ConfigFirstSeenAnnotationKey    = "kubernetes.io/config.seen"
+	ConfigHashAnnotationKey         = "kubernetes.io/config.hash"
+	ConfigHashInternalAnnotationKey = "kubernetes.io/config.hash.internal"
 )
 
 // PodOperation defines what changes will be made on a pod configuration.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it:**

kubelet: fix the pod UID to link its mirror pod
Separate the hash(UID) for identifying the static pod and the hash for representing the internal pod spec.

Why we need it:
Until now if we updated the static pod, the hash linking the static pods and its mirror pod(the pod object inside of apiserver) has been changed. This caused the unlinked mirror pod to be deleted ungracefully and the apiserver to create the new mirror pod eventually.

@ehashman 

**Which issue(s) this PR fixes**:

Fixes https://github.com/kubernetes/kubernetes/issues/97722

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

**Special notes for your reviewer**:

https://github.com/kubernetes/kubernetes/issues/97722#issuecomment-757412665

**Does this PR introduce a user-facing change?**:

If the static pods are updated, the pod will respect terminationGracePeriodSeconds as expected.

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
