### PR TITLE
check containerd as well as docker-containerd

### DIFF
--- a/pkg/kubelet/cm/container_manager_linux.go
+++ b/pkg/kubelet/cm/container_manager_linux.go
@@ -69,10 +69,10 @@ import (
 )
 
 const (
-	dockerProcessName     = "dockerd"
+	dockerProcessName = "dockerd"
+	// dockerd option --pidfile can specify path to use for daemon PID file, pid file path is default "/var/run/docker.pid"
 	dockerPidFile         = "/var/run/docker.pid"
-	containerdProcessName = "docker-containerd"
-	containerdPidFile     = "/run/docker/libcontainerd/docker-containerd.pid"
+	containerdProcessName = "containerd"
 	maxPidFileLength      = 1 << 10 // 1KB
 )
 
@@ -841,6 +841,8 @@ func EnsureDockerInContainer(dockerAPIVersion *utilversion.Version, oomScoreAdj 
 	type process struct{ name, file string }
 	dockerProcs := []process{{dockerProcessName, dockerPidFile}}
 	if dockerAPIVersion.AtLeast(containerdAPIVersion) {
+		// By default containerd is started separately, so there is no pid file.
+		containerdPidFile := ""
 		dockerProcs = append(dockerProcs, process{containerdProcessName, containerdPidFile})
 	}
 	var errs []error


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
/sig node

**What this PR does / why we need it**:
- dockerd pidfile: dockerd option --pidfile can specify path to use for daemon PID file, pid file path is default "/var/run/docker.pid" . Refer to [docker options](https://docs.docker.com/engine/reference/commandline/dockerd/#daemon:~:text=%2Dp%2C%20%2D%2Dpidfile%20string,for%20daemon%20PID%20file%20(default%20%22%2Fvar%2Frun%2Fdocker.pid%22)).
- docker-containerd is renamed to containerd in the new release of docker.
- containerd.pid is removed(https://github.com/moby/moby/issues/23069#issuecomment-222270659):  moby/moby#23069  when contained started separately with dockerd, dockerd can start with `--containerd` option to bind the socket. Then no PID for containerd. 


According to [EndOfLife Docker Versions](https://success.mirantis.com/article/maintenance-lifecycle#endoflifeeoldockerengineversions)
As the old version docker is not supported. So use the current default behavior.
- no containerd pid
- user containerd as process name

**Which issue(s) this PR fixes**:
Fixes #97565

**Special notes for your reviewer**:
However, this may be removed later as docker-shim is deprecated.

**Does this PR introduce a user-facing change?**:
```release-note
In the method that ensures that the docker and containerd are in the correct containers with the proper OOM score set up, fixed the bug of identifying containerd process.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs

```
