### PR TITLE
Adding tests that clarifies precision requirements for datetime serialization

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/time_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/time_test.go
@@ -53,17 +53,43 @@ func TestTimeMarshalYAML(t *testing.T) {
 
 func TestTimeUnmarshalYAML(t *testing.T) {
 	cases := []struct {
-		input  string
-		result Time
+		name       string
+		input      string
+		result     Time
+		shouldFail bool
 	}{
-		{"t: null\n", Time{}},
-		{"t: 1998-05-05T05:05:05Z\n", Time{Date(1998, time.May, 5, 5, 5, 5, 0, time.UTC).Local()}},
+		{
+			"null timestamp should work",
+			"t: null\n",
+			Time{},
+			false,
+		},
+		{
+			"RFC3339 timestamp should work",
+			"t: 1998-05-05T05:05:05Z\n",
+			Time{Date(1998, time.May, 5, 5, 5, 5, 0, time.UTC).Local()},
+			false,
+		},
+		{
+			"RFC3339(Millis) timestamp should work",
+			"t: 1998-05-05T05:05:05.000Z\n",
+			Time{Date(1998, time.May, 5, 5, 5, 5, 0, time.UTC).Local()},
+			false,
+		},
+		{
+			"RFC3339(Micro) timestamp should work",
+			"t: 1998-05-05T05:05:05.000000Z\n",
+			Time{Date(1998, time.May, 5, 5, 5, 5, 0, time.UTC).Local()},
+			false,
+		},
 	}
 
 	for _, c := range cases {
 		var result TimeHolder
 		if err := yaml.Unmarshal([]byte(c.input), &result); err != nil {
-			t.Errorf("Failed to unmarshal input '%v': %v", c.input, err)
+			if !c.shouldFail {
+				t.Errorf("Failed to unmarshal input '%v': %v", c.input, err)
+			}
 		}
 		if result.T != c.result {
 			t.Errorf("Failed to unmarshal input '%v': expected %+v, got %+v", c.input, c.result, result)
@@ -95,17 +121,43 @@ func TestTimeMarshalJSON(t *testing.T) {
 
 func TestTimeUnmarshalJSON(t *testing.T) {
 	cases := []struct {
-		input  string
-		result Time
+		name       string
+		input      string
+		result     Time
+		shouldFail bool
 	}{
-		{"{\"t\":null}", Time{}},
-		{"{\"t\":\"1998-05-05T05:05:05Z\"}", Time{Date(1998, time.May, 5, 5, 5, 5, 0, time.UTC).Local()}},
+		{
+			"null timestamp should work",
+			"{\"t\":null}",
+			Time{},
+			false,
+		},
+		{
+			"RFC3339 timestamp should work",
+			"{\"t\":\"1998-05-05T05:05:05Z\"}",
+			Time{Date(1998, time.May, 5, 5, 5, 5, 0, time.UTC).Local()},
+			false,
+		},
+		{
+			"RFC3339(Millis) timestamp should work",
+			"{\"t\":\"1998-05-05T05:05:05.000Z\"}",
+			Time{Date(1998, time.May, 5, 5, 5, 5, 0, time.UTC).Local()},
+			false,
+		},
+		{
+			"RFC3339(Micro) timestamp should work",
+			"{\"t\":\"1998-05-05T05:05:05.000000Z\"}",
+			Time{Date(1998, time.May, 5, 5, 5, 5, 0, time.UTC).Local()},
+			false,
+		},
 	}
 
 	for _, c := range cases {
 		var result TimeHolder
 		if err := json.Unmarshal([]byte(c.input), &result); err != nil {
-			t.Errorf("Failed to unmarshal input '%v': %v", c.input, err)
+			if !c.shouldFail {
+				t.Errorf("Failed to unmarshal input '%v': %v", c.input, err)
+			}
 		}
 		if result.T != c.result {
 			t.Errorf("Failed to unmarshal input '%v': expected %+v, got %+v", c.input, c.result, result)


### PR DESCRIPTION
for now there're 2 different formats of timestamp supported in the codebase: (1) conventional RFC3339 timestamp defined in go sdk which doesnt contain fractional seconds (2) extended timestamp defined in this codebase [RFC3339Micro](https://github.com/kubernetes/kubernetes/blob/bb376f161640529f600203faee4cd0de8ec16778/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/micro_time.go#L24) which requires explicit 6 digits of fractional second (w/ zeros right-padded). 
 (1) is a well-known standard while (2) is a non-standard.

this pull clarifies/ensures more expected server-side behavior for [de]serializing date-time types in either YAML or JSON, so that we can keep the compatibility:

- for (1) we will be dropping fractional seconds if extra precision provided in the YAML/JSON string.
- for (2) it will always fail upon insufficient precision.

/assign @sttts @roycaihw 

```release-note
NONE
```
