### PR TITLE
fix unit test "TestSPDYExecutorStream" flaking problem

### DIFF
--- a/staging/src/k8s.io/client-go/tools/remotecommand/remotecommand_test.go
+++ b/staging/src/k8s.io/client-go/tools/remotecommand/remotecommand_test.go
@@ -208,7 +208,8 @@ func createHTTPStreams(w http.ResponseWriter, req *http.Request, opts *StreamOpt
 	}
 
 	// wait for stream
-	replyChan := make(chan struct{}, 1)
+	replyChan := make(chan struct{}, 4)
+	defer close(replyChan)
 	receivedStreams := 0
 	expectedStreams := 1
 	if opts.Stdout != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug
/kind failing-test
/kind flake

**What this PR does / why we need it**:

fix Unit Test "TestSPDYExecutorStream"  occasionally failed problem.


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #  https://github.com/kubernetes/kubernetes/issues/97331

**Special notes for your reviewer**:

why we have the problem:
1. replyChan size is 1 before
2. when the server received one stream connect, replyChan is added with one item
3. if the server handled the next stream connect first, instead of consuming replyChan. (they are in a select-case loop)
4. this will block the server.  And this leads to a timeout.

core code:
1. remotecommand_test.go line 224 - 245

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
