### PR TITLE
Automated cherry pick of #96421: kube-aggregator: fix apiservice availability gauge

### DIFF
--- a/staging/src/k8s.io/kube-aggregator/pkg/controllers/status/BUILD
+++ b/staging/src/k8s.io/kube-aggregator/pkg/controllers/status/BUILD
@@ -41,7 +41,10 @@ go_library(
 
 go_test(
     name = "go_default_test",
-    srcs = ["available_controller_test.go"],
+    srcs = [
+        "available_controller_test.go",
+        "metrics_test.go",
+    ],
     embed = [":go_default_library"],
     deps = [
         "//staging/src/k8s.io/api/core/v1:go_default_library",
@@ -50,6 +53,7 @@ go_test(
         "//staging/src/k8s.io/client-go/testing:go_default_library",
         "//staging/src/k8s.io/client-go/tools/cache:go_default_library",
         "//staging/src/k8s.io/client-go/util/workqueue:go_default_library",
+        "//staging/src/k8s.io/component-base/metrics/testutil:go_default_library",
         "//staging/src/k8s.io/kube-aggregator/pkg/apis/apiregistration/v1:go_default_library",
         "//staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/fake:go_default_library",
         "//staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/typed/apiregistration/v1:go_default_library",

--- a/staging/src/k8s.io/kube-aggregator/pkg/controllers/status/metrics.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/controllers/status/metrics.go
@@ -17,8 +17,9 @@ limitations under the License.
 package apiserver
 
 import (
+	"sync"
+
 	"k8s.io/component-base/metrics"
-	"k8s.io/component-base/metrics/legacyregistry"
 )
 
 /*
@@ -30,25 +31,120 @@ import (
  * the metric stability policy.
  */
 var (
-	unavailableCounter = metrics.NewCounterVec(
-		&metrics.CounterOpts{
-			Name:           "aggregator_unavailable_apiservice_total",
-			Help:           "Counter of APIServices which are marked as unavailable broken down by APIService name and reason.",
-			StabilityLevel: metrics.ALPHA,
-		},
-		[]string{"name", "reason"},
-	)
-	unavailableGauge = metrics.NewGaugeVec(
-		&metrics.GaugeOpts{
-			Name:           "aggregator_unavailable_apiservice",
-			Help:           "Gauge of APIServices which are marked as unavailable broken down by APIService name.",
-			StabilityLevel: metrics.ALPHA,
-		},
+	unavailableGaugeDesc = metrics.NewDesc(
+		"aggregator_unavailable_apiservice",
+		"Gauge of APIServices which are marked as unavailable broken down by APIService name.",
 		[]string{"name"},
+		nil,
+		metrics.ALPHA,
+		"",
 	)
 )
 
-func init() {
-	legacyregistry.MustRegister(unavailableCounter)
-	legacyregistry.MustRegister(unavailableGauge)
+type availabilityMetrics struct {
+	unavailableCounter *metrics.CounterVec
+
+	*availabilityCollector
+}
+
+func newAvailabilityMetrics() *availabilityMetrics {
+	return &availabilityMetrics{
+		unavailableCounter: metrics.NewCounterVec(
+			&metrics.CounterOpts{
+				Name:           "aggregator_unavailable_apiservice_total",
+				Help:           "Counter of APIServices which are marked as unavailable broken down by APIService name and reason.",
+				StabilityLevel: metrics.ALPHA,
+			},
+			[]string{"name", "reason"},
+		),
+		availabilityCollector: newAvailabilityCollector(),
+	}
+}
+
+// Register registers apiservice availability metrics.
+func (m *availabilityMetrics) Register(
+	registrationFunc func(metrics.Registerable) error,
+	customRegistrationFunc func(metrics.StableCollector) error,
+) error {
+	err := registrationFunc(m.unavailableCounter)
+	if err != nil {
+		return err
+	}
+
+	err = customRegistrationFunc(m.availabilityCollector)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// UnavailableCounter returns a counter to track apiservices marked as unavailable.
+func (m *availabilityMetrics) UnavailableCounter(apiServiceName, reason string) metrics.CounterMetric {
+	return m.unavailableCounter.WithLabelValues(apiServiceName, reason)
+}
+
+type availabilityCollector struct {
+	metrics.BaseStableCollector
+
+	mtx            sync.RWMutex
+	availabilities map[string]bool
+}
+
+// Check if apiServiceStatusCollector implements necessary interface.
+var _ metrics.StableCollector = &availabilityCollector{}
+
+func newAvailabilityCollector() *availabilityCollector {
+	return &availabilityCollector{
+		availabilities: make(map[string]bool),
+	}
+}
+
+// DescribeWithStability implements the metrics.StableCollector interface.
+func (c *availabilityCollector) DescribeWithStability(ch chan<- *metrics.Desc) {
+	ch <- unavailableGaugeDesc
+}
+
+// CollectWithStability implements the metrics.StableCollector interface.
+func (c *availabilityCollector) CollectWithStability(ch chan<- metrics.Metric) {
+	c.mtx.RLock()
+	defer c.mtx.RUnlock()
+
+	for apiServiceName, isAvailable := range c.availabilities {
+		gaugeValue := 1.0
+		if isAvailable {
+			gaugeValue = 0.0
+		}
+		ch <- metrics.NewLazyConstMetric(
+			unavailableGaugeDesc,
+			metrics.GaugeValue,
+			gaugeValue,
+			apiServiceName,
+		)
+	}
+}
+
+// SetAPIServiceAvailable sets the given apiservice availability gauge to available.
+func (c *availabilityCollector) SetAPIServiceAvailable(apiServiceKey string) {
+	c.setAPIServiceAvailability(apiServiceKey, true)
+}
+
+// SetAPIServiceUnavailable sets the given apiservice availability gauge to unavailable.
+func (c *availabilityCollector) SetAPIServiceUnavailable(apiServiceKey string) {
+	c.setAPIServiceAvailability(apiServiceKey, false)
+}
+
+func (c *availabilityCollector) setAPIServiceAvailability(apiServiceKey string, availability bool) {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
+
+	c.availabilities[apiServiceKey] = availability
+}
+
+// ForgetAPIService removes the availability gauge of the given apiservice.
+func (c *availabilityCollector) ForgetAPIService(apiServiceKey string) {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
+
+	delete(c.availabilities, apiServiceKey)
 }

--- a/staging/src/k8s.io/kube-aggregator/pkg/controllers/status/metrics_test.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/controllers/status/metrics_test.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apiserver
+
+import (
+	"strings"
+	"testing"
+
+	"k8s.io/component-base/metrics/testutil"
+)
+
+func TestAPIServiceAvailabilityCollection(t *testing.T) {
+	collector := newAvailabilityCollector()
+
+	availableAPIService := "available"
+	unavailableAPIService := "unavailable"
+
+	collector.SetAPIServiceAvailable(availableAPIService)
+	collector.SetAPIServiceUnavailable(unavailableAPIService)
+
+	err := testutil.CustomCollectAndCompare(collector, strings.NewReader(`
+	# HELP aggregator_unavailable_apiservice [ALPHA] Gauge of APIServices which are marked as unavailable broken down by APIService name.
+	# TYPE aggregator_unavailable_apiservice gauge
+	aggregator_unavailable_apiservice{name="available"} 0
+	aggregator_unavailable_apiservice{name="unavailable"} 1
+	`))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	collector.ClearState()
+
+	collector.ForgetAPIService(availableAPIService)
+	collector.ForgetAPIService(unavailableAPIService)
+
+	err = testutil.CustomCollectAndCompare(collector, strings.NewReader(`
+	# HELP aggregator_unavailable_apiservice [ALPHA] Gauge of APIServices which are marked as unavailable broken down by APIService name.
+	# TYPE aggregator_unavailable_apiservice gauge
+	`))
+	if err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
Cherry pick of #96421 on release-1.19.

#96421: kube-aggregator: fix apiservice availability gauge

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.