### PR TITLE
fix golint in dockershim

### DIFF
--- a/hack/.golint_failures
+++ b/hack/.golint_failures
@@ -101,7 +101,6 @@ pkg/kubelet/dockershim/network
 pkg/kubelet/dockershim/network/cni/testing
 pkg/kubelet/dockershim/network/hostport
 pkg/kubelet/dockershim/network/kubenet
-pkg/kubelet/dockershim/network/testing
 pkg/kubelet/pluginmanager/pluginwatcher
 pkg/kubelet/pod/testing
 pkg/kubelet/preemption

--- a/pkg/kubelet/dockershim/docker_service.go
+++ b/pkg/kubelet/dockershim/docker_service.go
@@ -353,8 +353,8 @@ func (ds *dockerService) UpdateRuntimeConfig(_ context.Context, r *runtimeapi.Up
 	klog.Infof("docker cri received runtime config %+v", runtimeConfig)
 	if ds.network != nil && runtimeConfig.NetworkConfig.PodCidr != "" {
 		event := make(map[string]interface{})
-		event[network.NET_PLUGIN_EVENT_POD_CIDR_CHANGE_DETAIL_CIDR] = runtimeConfig.NetworkConfig.PodCidr
-		ds.network.Event(network.NET_PLUGIN_EVENT_POD_CIDR_CHANGE, event)
+		event[network.NetPluginEventPodCIDRChangeDetailCIDR] = runtimeConfig.NetworkConfig.PodCidr
+		ds.network.Event(network.NetPluginEventPodCIDRChange, event)
 	}
 
 	return &runtimeapi.UpdateRuntimeConfigResponse{}, nil

--- a/pkg/kubelet/dockershim/network/cni/cni.go
+++ b/pkg/kubelet/dockershim/network/cni/cni.go
@@ -269,16 +269,16 @@ func (plugin *cniNetworkPlugin) checkInitialized() error {
 // Event handles any change events. The only event ever sent is the PodCIDR change.
 // No network plugins support changing an already-set PodCIDR
 func (plugin *cniNetworkPlugin) Event(name string, details map[string]interface{}) {
-	if name != network.NET_PLUGIN_EVENT_POD_CIDR_CHANGE {
+	if name != network.NetPluginEventPodCIDRChange {
 		return
 	}
 
 	plugin.Lock()
 	defer plugin.Unlock()
 
-	podCIDR, ok := details[network.NET_PLUGIN_EVENT_POD_CIDR_CHANGE_DETAIL_CIDR].(string)
+	podCIDR, ok := details[network.NetPluginEventPodCIDRChangeDetailCIDR].(string)
 	if !ok {
-		klog.Warningf("%s event didn't contain pod CIDR", network.NET_PLUGIN_EVENT_POD_CIDR_CHANGE)
+		klog.Warningf("%s event didn't contain pod CIDR", network.NetPluginEventPodCIDRChange)
 		return
 	}
 

--- a/pkg/kubelet/dockershim/network/cni/cni_test.go
+++ b/pkg/kubelet/dockershim/network/cni/cni_test.go
@@ -236,8 +236,8 @@ func TestCNIPlugin(t *testing.T) {
 		t.Fatalf("cniPlugin returned non-err with no podCidr")
 	}
 
-	cniPlugin.Event(network.NET_PLUGIN_EVENT_POD_CIDR_CHANGE, map[string]interface{}{
-		network.NET_PLUGIN_EVENT_POD_CIDR_CHANGE_DETAIL_CIDR: "10.0.2.0/24",
+	cniPlugin.Event(network.NetPluginEventPodCIDRChange, map[string]interface{}{
+		network.NetPluginEventPodCIDRChangeDetailCIDR: "10.0.2.0/24",
 	})
 
 	if err := cniPlugin.Status(); err != nil {

--- a/pkg/kubelet/dockershim/network/kubenet/kubenet_linux.go
+++ b/pkg/kubelet/dockershim/network/kubenet/kubenet_linux.go
@@ -231,16 +231,16 @@ func findMinMTU() (*net.Interface, error) {
 
 func (plugin *kubenetNetworkPlugin) Event(name string, details map[string]interface{}) {
 	var err error
-	if name != network.NET_PLUGIN_EVENT_POD_CIDR_CHANGE {
+	if name != network.NetPluginEventPodCIDRChange {
 		return
 	}
 
 	plugin.mu.Lock()
 	defer plugin.mu.Unlock()
 
-	podCIDR, ok := details[network.NET_PLUGIN_EVENT_POD_CIDR_CHANGE_DETAIL_CIDR].(string)
+	podCIDR, ok := details[network.NetPluginEventPodCIDRChangeDetailCIDR].(string)
 	if !ok {
-		klog.Warningf("%s event didn't contain pod CIDR", network.NET_PLUGIN_EVENT_POD_CIDR_CHANGE)
+		klog.Warningf("%s event didn't contain pod CIDR", network.NetPluginEventPodCIDRChange)
 		return
 	}
 

--- a/pkg/kubelet/dockershim/network/kubenet/kubenet_linux_test.go
+++ b/pkg/kubelet/dockershim/network/kubenet/kubenet_linux_test.go
@@ -182,8 +182,8 @@ func TestTeardownCallsShaper(t *testing.T) {
 	mockcni.On("DelNetwork", mock.AnythingOfType("*context.timerCtx"), mock.AnythingOfType("*libcni.NetworkConfig"), mock.AnythingOfType("*libcni.RuntimeConf")).Return(nil)
 
 	details := make(map[string]interface{})
-	details[network.NET_PLUGIN_EVENT_POD_CIDR_CHANGE_DETAIL_CIDR] = "10.0.0.1/24"
-	kubenet.Event(network.NET_PLUGIN_EVENT_POD_CIDR_CHANGE, details)
+	details[network.NetPluginEventPodCIDRChangeDetailCIDR] = "10.0.0.1/24"
+	kubenet.Event(network.NetPluginEventPodCIDRChange, details)
 
 	existingContainerID := kubecontainer.BuildContainerID("docker", "123")
 	kubenet.podIPs[existingContainerID] = utilsets.NewString("10.0.0.1")
@@ -290,8 +290,8 @@ func TestTearDownWithoutRuntime(t *testing.T) {
 		kubenet.iptables = ipttest.NewFake()
 
 		details := make(map[string]interface{})
-		details[network.NET_PLUGIN_EVENT_POD_CIDR_CHANGE_DETAIL_CIDR] = strings.Join(tc.podCIDR, ",")
-		kubenet.Event(network.NET_PLUGIN_EVENT_POD_CIDR_CHANGE, details)
+		details[network.NetPluginEventPodCIDRChangeDetailCIDR] = strings.Join(tc.podCIDR, ",")
+		kubenet.Event(network.NetPluginEventPodCIDRChange, details)
 
 		if len(kubenet.podCIDRs) != len(tc.podCIDR) {
 			t.Errorf("generated podCidr: %q, expecting: %q are not of the same length", kubenet.podCIDRs, tc.podCIDR)

--- a/pkg/kubelet/dockershim/network/plugins.go
+++ b/pkg/kubelet/dockershim/network/plugins.go
@@ -46,8 +46,8 @@ const (
 
 	// Called when the node's Pod CIDR is known when using the
 	// controller manager's --allocate-node-cidrs=true option
-	NET_PLUGIN_EVENT_POD_CIDR_CHANGE             = "pod-cidr-change"
-	NET_PLUGIN_EVENT_POD_CIDR_CHANGE_DETAIL_CIDR = "pod-cidr"
+	NetPluginEventPodCIDRChange           = "pod-cidr-change"
+	NetPluginEventPodCIDRChangeDetailCIDR = "pod-cidr"
 )
 
 // NetworkPlugin is an interface to network plugins for the kubelet

--- a/pkg/kubelet/dockershim/network/testing/fake_host.go
+++ b/pkg/kubelet/dockershim/network/testing/fake_host.go
@@ -27,28 +27,33 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/dockershim/network/hostport"
 )
 
-type fakeNetworkHost struct {
+// FakeNetworkHost is the struct for testing
+type FakeNetworkHost struct {
 	fakeNamespaceGetter
 	FakePortMappingGetter
 	kubeClient clientset.Interface
 	Legacy     bool
 }
 
-func NewFakeHost(kubeClient clientset.Interface) *fakeNetworkHost {
-	host := &fakeNetworkHost{kubeClient: kubeClient, Legacy: true}
+// NewFakeHost returns a struct that implements the FakeNetworkHost interface
+func NewFakeHost(kubeClient clientset.Interface) *FakeNetworkHost {
+	host := &FakeNetworkHost{kubeClient: kubeClient, Legacy: true}
 	return host
 }
 
-func (fnh *fakeNetworkHost) GetPodByName(name, namespace string) (*v1.Pod, bool) {
+// GetPodByName returns empty pod struct
+func (fnh *FakeNetworkHost) GetPodByName(name, namespace string) (*v1.Pod, bool) {
 	return nil, false
 }
 
-func (fnh *fakeNetworkHost) GetKubeClient() clientset.Interface {
+// GetKubeClient returns nil for testing
+func (fnh *FakeNetworkHost) GetKubeClient() clientset.Interface {
 	return nil
 }
 
-func (nh *fakeNetworkHost) SupportsLegacyFeatures() bool {
-	return nh.Legacy
+// SupportsLegacyFeatures returns the Legacy value of FakeNetworkHost struct
+func (fnh *FakeNetworkHost) SupportsLegacyFeatures() bool {
+	return fnh.Legacy
 }
 
 type fakeNamespaceGetter struct {
@@ -59,10 +64,12 @@ func (nh *fakeNamespaceGetter) GetNetNS(containerID string) (string, error) {
 	return nh.ns, nil
 }
 
+// FakePortMappingGetter returns the record of port mapping for testing
 type FakePortMappingGetter struct {
 	PortMaps map[string][]*hostport.PortMapping
 }
 
+// GetPodPortMappings returns the port by containerID for testing
 func (pm *FakePortMappingGetter) GetPodPortMappings(containerID string) ([]*hostport.PortMapping, error) {
 	return pm.PortMaps[containerID], nil
 }

--- a/pkg/kubelet/dockershim/network/testing/mock_network_plugin.go
+++ b/pkg/kubelet/dockershim/network/testing/mock_network_plugin.go
@@ -30,49 +30,57 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/dockershim/network"
 )
 
-// Mock of NetworkPlugin interface
+// MockNetworkPlugin is the Mock of NetworkPlugin interface
 type MockNetworkPlugin struct {
 	ctrl     *gomock.Controller
-	recorder *_MockNetworkPluginRecorder
+	recorder *MockNetworkPluginRecorder
 }
 
-// Recorder for MockNetworkPlugin (not exported)
-type _MockNetworkPluginRecorder struct {
+// MockNetworkPluginRecorder is the recorder for MockNetworkPlugin
+type MockNetworkPluginRecorder struct {
 	mock *MockNetworkPlugin
 }
 
+// NewMockNetworkPlugin returns empty MockNetworkPlugin
 func NewMockNetworkPlugin(ctrl *gomock.Controller) *MockNetworkPlugin {
 	mock := &MockNetworkPlugin{ctrl: ctrl}
-	mock.recorder = &_MockNetworkPluginRecorder{mock}
+	mock.recorder = &MockNetworkPluginRecorder{mock}
 	return mock
 }
 
-func (_m *MockNetworkPlugin) EXPECT() *_MockNetworkPluginRecorder {
+// EXPECT returns the recorder for MockNetworkPlugin
+func (_m *MockNetworkPlugin) EXPECT() *MockNetworkPluginRecorder {
 	return _m.recorder
 }
 
+// Capabilities returns the mock of a set of NET_PLUGIN_CAPABILITY_*
 func (_m *MockNetworkPlugin) Capabilities() sets.Int {
 	ret := _m.ctrl.Call(_m, "Capabilities")
 	ret0, _ := ret[0].(sets.Int)
 	return ret0
 }
 
+// Finish checks to see if all the methods that were expected to be called were called
 func (_m *MockNetworkPlugin) Finish() {
 	_m.ctrl.Finish()
 }
 
-func (_mr *_MockNetworkPluginRecorder) Capabilities() *gomock.Call {
+// Capabilities returns the mock of a set of NET_PLUGIN_CAPABILITY_* by MockNetworkPluginRecorder
+func (_mr *MockNetworkPluginRecorder) Capabilities() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Capabilities")
 }
 
+// Event executed by gomock Call()
 func (_m *MockNetworkPlugin) Event(_param0 string, _param1 map[string]interface{}) {
 	_m.ctrl.Call(_m, "Event", _param0, _param1)
 }
 
-func (_mr *_MockNetworkPluginRecorder) Event(arg0, arg1 interface{}) *gomock.Call {
+// Event executed by gomock RecordCall()
+func (_mr *MockNetworkPluginRecorder) Event(arg0, arg1 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Event", arg0, arg1)
 }
 
+// GetPodNetworkStatus is the mock to obtain the ipv4 or ipv6 addresses of the container
 func (_m *MockNetworkPlugin) GetPodNetworkStatus(_param0 string, _param1 string, _param2 container.ContainerID) (*network.PodNetworkStatus, error) {
 	ret := _m.ctrl.Call(_m, "GetPodNetworkStatus", _param0, _param1, _param2)
 	ret0, _ := ret[0].(*network.PodNetworkStatus)
@@ -80,56 +88,69 @@ func (_m *MockNetworkPlugin) GetPodNetworkStatus(_param0 string, _param1 string,
 	return ret0, ret1
 }
 
-func (_mr *_MockNetworkPluginRecorder) GetPodNetworkStatus(arg0, arg1, arg2 interface{}) *gomock.Call {
+// GetPodNetworkStatus executed by gomock RecordCall()
+func (_mr *MockNetworkPluginRecorder) GetPodNetworkStatus(arg0, arg1, arg2 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetPodNetworkStatus", arg0, arg1, arg2)
 }
 
+// Init initializes the plugin of MockNetworkPlugin
 func (_m *MockNetworkPlugin) Init(_param0 network.Host, _param1 kubeletconfig.HairpinMode, nonMasqueradeCIDR string, mtu int) error {
 	ret := _m.ctrl.Call(_m, "Init", _param0, _param1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-func (_mr *_MockNetworkPluginRecorder) Init(arg0, arg1 interface{}) *gomock.Call {
+// Init initializes the plugin of MockNetworkPluginRecorder
+func (_mr *MockNetworkPluginRecorder) Init(arg0, arg1 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Init", arg0, arg1)
 }
 
+// Name returns the plugin's name of MockNetworkPlugin
 func (_m *MockNetworkPlugin) Name() string {
 	ret := _m.ctrl.Call(_m, "Name")
 	ret0, _ := ret[0].(string)
 	return ret0
 }
 
-func (_mr *_MockNetworkPluginRecorder) Name() *gomock.Call {
+// Name returns the plugin's name of MockNetworkPluginRecorder
+func (_mr *MockNetworkPluginRecorder) Name() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Name")
 }
 
+// SetUpPod is the mock method of MockNetworkPlugin called after the infra container of
+// the pod has been created
 func (_m *MockNetworkPlugin) SetUpPod(_param0 string, _param1 string, _param2 container.ContainerID, annotations, options map[string]string) error {
 	ret := _m.ctrl.Call(_m, "SetUpPod", _param0, _param1, _param2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-func (_mr *_MockNetworkPluginRecorder) SetUpPod(arg0, arg1, arg2 interface{}) *gomock.Call {
+// SetUpPod is the mock method of MockNetworkPluginRecorder called after the infra container of
+// the pod has been created
+func (_mr *MockNetworkPluginRecorder) SetUpPod(arg0, arg1, arg2 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetUpPod", arg0, arg1, arg2)
 }
 
+// Status is called by gomock, it will returns error if the network plugin is in error state
 func (_m *MockNetworkPlugin) Status() error {
 	ret := _m.ctrl.Call(_m, "Status")
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-func (_mr *_MockNetworkPluginRecorder) Status() *gomock.Call {
+// Status is called by gomock RecordCall() function
+func (_mr *MockNetworkPluginRecorder) Status() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Status")
 }
 
+// TearDownPod is the mock method called before a pod's infra container will be deleted
 func (_m *MockNetworkPlugin) TearDownPod(_param0 string, _param1 string, _param2 container.ContainerID) error {
 	ret := _m.ctrl.Call(_m, "TearDownPod", _param0, _param1, _param2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-func (_mr *_MockNetworkPluginRecorder) TearDownPod(arg0, arg1, arg2 interface{}) *gomock.Call {
+// TearDownPod is the mock method called by gomock RecordCall()
+func (_mr *MockNetworkPluginRecorder) TearDownPod(arg0, arg1, arg2 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "TearDownPod", arg0, arg1, arg2)
 }

--- a/pkg/kubelet/dockershim/network/testing/plugins_test.go
+++ b/pkg/kubelet/dockershim/network/testing/plugins_test.go
@@ -35,8 +35,8 @@ import (
 )
 
 func TestSelectDefaultPlugin(t *testing.T) {
-	all_plugins := []network.NetworkPlugin{}
-	plug, err := network.InitNetworkPlugin(all_plugins, "", NewFakeHost(nil), kubeletconfig.HairpinNone, "10.0.0.0/8", network.UseDefaultMTU)
+	allPlugins := []network.NetworkPlugin{}
+	plug, err := network.InitNetworkPlugin(allPlugins, "", NewFakeHost(nil), kubeletconfig.HairpinNone, "10.0.0.0/8", network.UseDefaultMTU)
 	if err != nil {
 		t.Fatalf("Unexpected error in selecting default plugin: %v", err)
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind cleanup


**What this PR does / why we need it**:
Fix golint:
pkg/kubelet/dockershim/network/plugins.go:49:2: don't use ALL_CAPS in Go names; use CamelCase
pkg/kubelet/dockershim/network/plugins.go:50:2: don't use ALL_CAPS in Go names; use CamelCase
pkg/kubelet/dockershim/network/testing/plugins_test.go:38:2: don't use underscores in Go names; var all_plugins should be allPlugins
pkg/kubelet/dockershim/network/testing/fake_host.go:50:1: receiver name nh should be consistent with previous receiver name fnh for fakeNetworkHost
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
