### PR TITLE
Disallow local loopback for volume hosts

### DIFF
--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -1999,6 +1999,7 @@ function start-kube-controller-manager {
   params+=("--kubeconfig=${config_path}" "--authentication-kubeconfig=${config_path}" "--authorization-kubeconfig=${config_path}")
   params+=("--root-ca-file=${CA_CERT_BUNDLE_PATH}")
   params+=("--service-account-private-key-file=${SERVICEACCOUNT_KEY_PATH}")
+  params+=("--volume-host-allow-local-loopback=false")
   if [[ -n "${ENABLE_GARBAGE_COLLECTOR:-}" ]]; then
     params+=("--enable-garbage-collector=${ENABLE_GARBAGE_COLLECTOR}")
   fi


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:
This is another part of the fix for #91542

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
Mitigate CVE-2020-8555 for kube-up using GCE by preventing local loopback folume hosts.
```

/cc @liggitt @msau42 
/sig storage