### PR TITLE
Fix the build/README.md documentation file on docker-machine remote

### DIFF
--- a/build/README.md
+++ b/build/README.md
@@ -5,11 +5,10 @@ Building Kubernetes is easy if you take advantage of the containerized build env
 ## Requirements
 
 1. Docker, using one of the following configurations:
-  * **macOS** You can either use Docker for Mac or docker-machine. See installation instructions [here](https://docs.docker.com/docker-for-mac/).
+  * **macOS** Install Docker for Mac. See installation instructions [here](https://docs.docker.com/docker-for-mac/).
      **Note**: You will want to set the Docker VM to have at least 8GB of initial memory or building will likely fail. (See: [#11852]( http://issue.k8s.io/11852)).
   * **Linux with local Docker**  Install Docker according to the [instructions](https://docs.docker.com/installation/#installation) for your OS.
   * **Windows with Docker Desktop WSL2 backend**  Install Docker according to the [instructions](https://docs.docker.com/docker-for-windows/wsl-tech-preview/). Be sure to store your sources in the local Linux file system, not the Windows remote mount at `/mnt/c`.
-  * **Remote Docker engine** Use a big machine in the cloud to build faster. This is a little trickier so look at the section later on.
 2. **Optional** [Google Cloud SDK](https://developers.google.com/cloud/sdk/)
 
 You must install and configure Google Cloud SDK if you want to upload your release to Google Cloud Storage and may safely omit this otherwise.
@@ -44,53 +43,6 @@ There are 3 different containers instances that are run from this image.  The fi
 `rsync` is used transparently behind the scenes to efficiently move data in and out of the container.  This will use an ephemeral port picked by Docker.  You can modify this by setting the `KUBE_RSYNC_PORT` env variable.
 
 All Docker names are suffixed with a hash derived from the file path (to allow concurrent usage on things like CI machines) and a version number.  When the version number changes all state is cleared and clean build is started.  This allows the build infrastructure to be changed and signal to CI systems that old artifacts need to be deleted.
-
-## Proxy Settings
-
-If you are behind a proxy and you are letting these scripts use `docker-machine` to set up your local VM for you on macOS, you need to export proxy settings for Kubernetes build, the following environment variables should be defined.
-
-```
-export KUBERNETES_HTTP_PROXY=http://username:password@proxyaddr:proxyport
-export KUBERNETES_HTTPS_PROXY=https://username:password@proxyaddr:proxyport
-```
-
-Optionally, you can specify addresses of no proxy for Kubernetes build, for example
-
-```
-export KUBERNETES_NO_PROXY=127.0.0.1
-```
-
-If you are using sudo to make Kubernetes build for example make quick-release, you need run `sudo -E make quick-release` to pass the environment variables.
-
-## Really Remote Docker Engine
-
-It is possible to use a Docker Engine that is running remotely (under your desk or in the cloud).  Docker must be configured to connect to that machine and the local rsync port must be forwarded (via SSH or nc) from localhost to the remote machine.
-
-To do this easily with GCE and `docker-machine`, do something like this:
-```
-# Create the remote docker machine on GCE.  This is a pretty beefy machine with SSD disk.
-KUBE_BUILD_VM=k8s-build
-KUBE_BUILD_GCE_PROJECT=<project>
-docker-machine create \
-  --driver=google \
-  --google-project=${KUBE_BUILD_GCE_PROJECT} \
-  --google-zone=us-west1-a \
-  --google-machine-type=n1-standard-8 \
-  --google-disk-size=50 \
-  --google-disk-type=pd-ssd \
-  ${KUBE_BUILD_VM}
-
-# Set up local docker to talk to that machine
-eval $(docker-machine env ${KUBE_BUILD_VM})
-
-# Pin down the port that rsync will be exposed on the remote machine
-export KUBE_RSYNC_PORT=8730
-
-# forward local 8730 to that machine so that rsync works
-docker-machine ssh ${KUBE_BUILD_VM} -L ${KUBE_RSYNC_PORT}:localhost:${KUBE_RSYNC_PORT} -N &
-```
-
-Look at `docker-machine stop`, `docker-machine start` and `docker-machine rm` to manage this VM.
 
 ## Releasing
 


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
Remove docker-machine / remote docker support from build documentation.

Docker-machine is no longer accepting new features and in maintenance mode only. So documentation was updated.
**Which issue(s) this PR fixes**:
Part of #94091.

@jherrera123 worked on the build script so here is the updated documentation for the build.

**Does this PR introduce a user-facing change?**:

```release-note
Official support to build kubernetes with docker-machine / remote docker is removed. This change does not affect building kubernetes with docker locally.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
