### PR TITLE
Bump agnhost to latest version

### DIFF
--- a/build/dependencies.yaml
+++ b/build/dependencies.yaml
@@ -10,7 +10,7 @@ dependencies:
 
   # then after merge and successful postsubmit image push / promotion, bump this
   - name: "agnhost: dependents"
-    version: "2.21"
+    version: "2.26"
     refPaths:
     - path: test/utils/image/manifest.go
       match: configs\[Agnhost\] = Config{promoterE2eRegistry, "agnhost", "\d+\.\d+"}

--- a/test/utils/image/manifest.go
+++ b/test/utils/image/manifest.go
@@ -208,7 +208,7 @@ const (
 
 func initImageConfigs() map[int]Config {
 	configs := map[int]Config{}
-	configs[Agnhost] = Config{promoterE2eRegistry, "agnhost", "2.21"}
+	configs[Agnhost] = Config{promoterE2eRegistry, "agnhost", "2.26"}
 	configs[AgnhostPrivate] = Config{PrivateRegistry, "agnhost", "2.6"}
 	configs[AuthenticatedAlpine] = Config{gcAuthenticatedRegistry, "alpine", "3.7"}
 	configs[AuthenticatedWindowsNanoServer] = Config{gcAuthenticatedRegistry, "windows-nanoserver", "v1"}


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
To publish the current test image for agnhost which will unblock #95503 

**Which issue(s) this PR fixes**:
```
NONE
```

**Special notes for your reviewer**:
Checking `gcr/images/k8s-staging-e2e-test-images`, it looks to have the latest 2.26 images published for all platforms.

**Does this PR introduce a user-facing change?**:
```
NONE
```

**Release note:**
```
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```
NONE
````

/sig testing
