### PR TITLE
Add trace to SerializeObject

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/BUILD
@@ -57,6 +57,7 @@ go_library(
         "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/util/flushwriter:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/util/wsstream:go_default_library",
+        "//vendor/k8s.io/utils/trace:go_default_library",
     ],
 )
 

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/errors_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/errors_test.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 
 	"k8s.io/apimachinery/pkg/runtime"
@@ -77,7 +78,7 @@ func TestForbidden(t *testing.T) {
 		observer := httptest.NewRecorder()
 		scheme := runtime.NewScheme()
 		negotiatedSerializer := serializer.NewCodecFactory(scheme).WithoutConversion()
-		Forbidden(request.NewDefaultContext(), test.attributes, observer, &http.Request{}, test.reason, negotiatedSerializer)
+		Forbidden(request.NewDefaultContext(), test.attributes, observer, &http.Request{URL: &url.URL{Path: "/path"}}, test.reason, negotiatedSerializer)
 		result := string(observer.Body.Bytes())
 		if result != test.expected {
 			t.Errorf("Forbidden response body(%#v...)\n expected: %v\ngot:       %v", test.attributes, test.expected, result)

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/writers.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/writers.go
@@ -26,6 +26,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"k8s.io/apiserver/pkg/features"
 
@@ -40,6 +41,7 @@ import (
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/apiserver/pkg/util/flushwriter"
 	"k8s.io/apiserver/pkg/util/wsstream"
+	utiltrace "k8s.io/utils/trace"
 )
 
 // StreamObject performs input stream negotiation from a ResourceStreamer and writes that to the response.
@@ -86,11 +88,20 @@ func StreamObject(statusCode int, gv schema.GroupVersion, s runtime.NegotiatedSe
 // The context is optional and can be nil. This method will perform optional content compression if requested by
 // a client and the feature gate for APIResponseCompression is enabled.
 func SerializeObject(mediaType string, encoder runtime.Encoder, hw http.ResponseWriter, req *http.Request, statusCode int, object runtime.Object) {
+	trace := utiltrace.New("SerializeObject",
+		utiltrace.Field{"method", req.Method},
+		utiltrace.Field{"url", req.URL.Path},
+		utiltrace.Field{"protocol", req.Proto},
+		utiltrace.Field{"mediaType", mediaType},
+		utiltrace.Field{"encoder", encoder.Identifier()})
+	defer trace.LogIfLong(5 * time.Second)
+
 	w := &deferredResponseWriter{
 		mediaType:       mediaType,
 		statusCode:      statusCode,
 		contentEncoding: negotiateContentEncoding(req),
 		hw:              hw,
+		trace:           trace,
 	}
 
 	err := encoder.Encode(object, w)
@@ -177,9 +188,23 @@ type deferredResponseWriter struct {
 	hasWritten bool
 	hw         http.ResponseWriter
 	w          io.Writer
+
+	trace *utiltrace.Trace
 }
 
 func (w *deferredResponseWriter) Write(p []byte) (n int, err error) {
+	if w.trace != nil {
+		// This Step usually wraps in-memory object serialization.
+		w.trace.Step("About to start writing response", utiltrace.Field{"size", len(p)})
+
+		firstWrite := !w.hasWritten
+		defer func() {
+			w.trace.Step("Write call finished",
+				utiltrace.Field{"writer", fmt.Sprintf("%T", w.w)},
+				utiltrace.Field{"size", len(p)},
+				utiltrace.Field{"firstWrite", firstWrite})
+		}()
+	}
 	if w.hasWritten {
 		return w.w.Write(p)
 	}

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/writers_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/writers_test.go
@@ -26,6 +26,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"reflect"
 	"testing"
 
@@ -62,9 +63,12 @@ func TestSerializeObjectParallel(t *testing.T) {
 			compressionEnabled: true,
 			out:                largePayload,
 			mediaType:          "application/json",
-			req: &http.Request{Header: http.Header{
-				"Accept-Encoding": []string{"gzip"},
-			}},
+			req: &http.Request{
+				Header: http.Header{
+					"Accept-Encoding": []string{"gzip"},
+				},
+				URL: &url.URL{Path: "/path"},
+			},
 			wantCode: http.StatusOK,
 			wantHeaders: http.Header{
 				"Content-Type":     []string{"application/json"},
@@ -130,7 +134,7 @@ func TestSerializeObject(t *testing.T) {
 		{
 			name:        "serialize object",
 			out:         smallPayload,
-			req:         &http.Request{Header: http.Header{}},
+			req:         &http.Request{Header: http.Header{}, URL: &url.URL{Path: "/path"}},
 			wantCode:    http.StatusOK,
 			wantHeaders: http.Header{"Content-Type": []string{""}},
 			wantBody:    smallPayload,
@@ -140,7 +144,7 @@ func TestSerializeObject(t *testing.T) {
 			name:        "return content type",
 			out:         smallPayload,
 			mediaType:   "application/json",
-			req:         &http.Request{Header: http.Header{}},
+			req:         &http.Request{Header: http.Header{}, URL: &url.URL{Path: "/path"}},
 			wantCode:    http.StatusOK,
 			wantHeaders: http.Header{"Content-Type": []string{"application/json"}},
 			wantBody:    smallPayload,
@@ -151,7 +155,7 @@ func TestSerializeObject(t *testing.T) {
 			statusCode:  http.StatusBadRequest,
 			out:         smallPayload,
 			mediaType:   "application/json",
-			req:         &http.Request{Header: http.Header{}},
+			req:         &http.Request{Header: http.Header{}, URL: &url.URL{Path: "/path"}},
 			wantCode:    http.StatusBadRequest,
 			wantHeaders: http.Header{"Content-Type": []string{"application/json"}},
 			wantBody:    smallPayload,
@@ -162,7 +166,7 @@ func TestSerializeObject(t *testing.T) {
 			out:         smallPayload,
 			outErrs:     []error{fmt.Errorf("bad")},
 			mediaType:   "application/json",
-			req:         &http.Request{Header: http.Header{}},
+			req:         &http.Request{Header: http.Header{}, URL: &url.URL{Path: "/path"}},
 			wantCode:    http.StatusInternalServerError,
 			wantHeaders: http.Header{"Content-Type": []string{"application/json"}},
 			wantBody:    smallPayload,
@@ -173,7 +177,7 @@ func TestSerializeObject(t *testing.T) {
 			out:         smallPayload,
 			outErrs:     []error{fmt.Errorf("bad"), fmt.Errorf("bad2")},
 			mediaType:   "application/json",
-			req:         &http.Request{Header: http.Header{}},
+			req:         &http.Request{Header: http.Header{}, URL: &url.URL{Path: "/path"}},
 			wantCode:    http.StatusInternalServerError,
 			wantHeaders: http.Header{"Content-Type": []string{"text/plain"}},
 			wantBody:    []byte(": bad"),
@@ -184,7 +188,7 @@ func TestSerializeObject(t *testing.T) {
 			out:         smallPayload,
 			outErrs:     []error{kerrors.NewNotFound(schema.GroupResource{}, "test"), fmt.Errorf("bad2")},
 			mediaType:   "application/json",
-			req:         &http.Request{Header: http.Header{}},
+			req:         &http.Request{Header: http.Header{}, URL: &url.URL{Path: "/path"}},
 			statusCode:  http.StatusOK,
 			wantCode:    http.StatusNotFound,
 			wantHeaders: http.Header{"Content-Type": []string{"text/plain"}},
@@ -196,7 +200,7 @@ func TestSerializeObject(t *testing.T) {
 			out:         smallPayload,
 			outErrs:     []error{kerrors.NewNotFound(schema.GroupResource{}, "test"), fmt.Errorf("bad2")},
 			mediaType:   "application/json",
-			req:         &http.Request{Header: http.Header{}},
+			req:         &http.Request{Header: http.Header{}, URL: &url.URL{Path: "/path"}},
 			statusCode:  http.StatusNotAcceptable,
 			wantCode:    http.StatusNotAcceptable,
 			wantHeaders: http.Header{"Content-Type": []string{"text/plain"}},
@@ -207,9 +211,12 @@ func TestSerializeObject(t *testing.T) {
 			name:      "compression requires feature gate",
 			out:       largePayload,
 			mediaType: "application/json",
-			req: &http.Request{Header: http.Header{
-				"Accept-Encoding": []string{"gzip"},
-			}},
+			req: &http.Request{
+				Header: http.Header{
+					"Accept-Encoding": []string{"gzip"},
+				},
+				URL: &url.URL{Path: "/path"},
+			},
 			wantCode:    http.StatusOK,
 			wantHeaders: http.Header{"Content-Type": []string{"application/json"}},
 			wantBody:    largePayload,
@@ -220,9 +227,12 @@ func TestSerializeObject(t *testing.T) {
 			compressionEnabled: true,
 			out:                largePayload,
 			mediaType:          "application/json",
-			req: &http.Request{Header: http.Header{
-				"Accept-Encoding": []string{"gzip"},
-			}},
+			req: &http.Request{
+				Header: http.Header{
+					"Accept-Encoding": []string{"gzip"},
+				},
+				URL: &url.URL{Path: "/path"},
+			},
 			wantCode: http.StatusOK,
 			wantHeaders: http.Header{
 				"Content-Type":     []string{"application/json"},
@@ -237,9 +247,12 @@ func TestSerializeObject(t *testing.T) {
 			compressionEnabled: true,
 			out:                smallPayload,
 			mediaType:          "application/json",
-			req: &http.Request{Header: http.Header{
-				"Accept-Encoding": []string{"gzip"},
-			}},
+			req: &http.Request{
+				Header: http.Header{
+					"Accept-Encoding": []string{"gzip"},
+				},
+				URL: &url.URL{Path: "/path"},
+			},
 			wantCode: http.StatusOK,
 			wantHeaders: http.Header{
 				"Content-Type": []string{"application/json"},
@@ -252,9 +265,12 @@ func TestSerializeObject(t *testing.T) {
 			compressionEnabled: true,
 			out:                largePayload,
 			mediaType:          "application/json",
-			req: &http.Request{Header: http.Header{
-				"Accept-Encoding": []string{"deflate, , gzip,"},
-			}},
+			req: &http.Request{
+				Header: http.Header{
+					"Accept-Encoding": []string{"deflate, , gzip,"},
+				},
+				URL: &url.URL{Path: "/path"},
+			},
 			wantCode: http.StatusOK,
 			wantHeaders: http.Header{
 				"Content-Type":     []string{"application/json"},
@@ -269,9 +285,12 @@ func TestSerializeObject(t *testing.T) {
 			compressionEnabled: true,
 			out:                largePayload,
 			mediaType:          "application/json",
-			req: &http.Request{Header: http.Header{
-				"Accept-Encoding": []string{"deflate"},
-			}},
+			req: &http.Request{
+				Header: http.Header{
+					"Accept-Encoding": []string{"deflate"},
+				},
+				URL: &url.URL{Path: "/path"},
+			},
 			wantCode: http.StatusOK,
 			wantHeaders: http.Header{
 				"Content-Type": []string{"application/json"},
@@ -284,9 +303,12 @@ func TestSerializeObject(t *testing.T) {
 			compressionEnabled: true,
 			out:                largePayload,
 			mediaType:          "application/json",
-			req: &http.Request{Header: http.Header{
-				"Accept-Encoding": []string{", ,  other, nothing, what, "},
-			}},
+			req: &http.Request{
+				Header: http.Header{
+					"Accept-Encoding": []string{", ,  other, nothing, what, "},
+				},
+				URL: &url.URL{Path: "/path"},
+			},
 			wantCode: http.StatusOK,
 			wantHeaders: http.Header{
 				"Content-Type": []string{"application/json"},
@@ -301,9 +323,12 @@ func TestSerializeObject(t *testing.T) {
 			out:                smallPayload,
 			outErrs:            []error{fmt.Errorf(string(largePayload)), fmt.Errorf("bad2")},
 			mediaType:          "application/json",
-			req: &http.Request{Header: http.Header{
-				"Accept-Encoding": []string{"gzip"},
-			}},
+			req: &http.Request{
+				Header: http.Header{
+					"Accept-Encoding": []string{"gzip"},
+				},
+				URL: &url.URL{Path: "/path"},
+			},
 			wantCode: http.StatusInternalServerError,
 			wantHeaders: http.Header{
 				"Content-Type":     []string{"text/plain"},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature
**What this PR does / why we need it**:
It starts logging SerializeObject calls that takes more than 5s (i.e. most likely large lists or requests where the client is not receiving response fast enough).

The standard flow of SerializeObject call is:
* object serialization
* single deferredResponseWriter.Write call with entire object

by adding a trace steps to Write call, we should be able to distinguish time spent on in-memory serialization (kube-apiserver overload) and time used to write bytes to a client (caused by e.g. slow client).

Hopefully, this will help with https://github.com/kubernetes/kubernetes/issues/97798

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->


**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/assign @wojtek-t 
