### PR TITLE
Fixes nil panic for nil delegated auth options

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/options/authentication.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/authentication.go
@@ -226,6 +226,10 @@ func (s *DelegatingAuthenticationOptions) WithClientTimeout(timeout time.Duratio
 }
 
 func (s *DelegatingAuthenticationOptions) Validate() []error {
+	if s == nil {
+		return nil
+	}
+
 	allErrors := []error{}
 	allErrors = append(allErrors, s.RequestHeader.Validate()...)
 

--- a/staging/src/k8s.io/apiserver/pkg/server/options/authorization.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/authorization.go
@@ -104,8 +104,11 @@ func (s *DelegatingAuthorizationOptions) WithCustomRetryBackoff(backoff wait.Bac
 }
 
 func (s *DelegatingAuthorizationOptions) Validate() []error {
-	allErrors := []error{}
+	if s == nil {
+		return nil
+	}
 
+	allErrors := []error{}
 	if s.WebhookRetryBackoff != nil && s.WebhookRetryBackoff.Steps <= 0 {
 		allErrors = append(allErrors, fmt.Errorf("number of webhook retry attempts must be greater than 1, but is: %d", s.WebhookRetryBackoff.Steps))
 	}


### PR DESCRIPTION
/kind bug
/sig api-machinery

/assign @lavalamp @deads2k 

```release-note
NONE
```

[RecommendedOptions](https://github.com/kubernetes/kubernetes/blob/65395137b5c4354893408dcc8d078954210ffeff/staging/src/k8s.io/apiserver/pkg/server/options/recommended.go#L39-L40) used to work on nil authn/z options for building a custom aggregated apiserver. while in 1.20.x release, we updated optionality of the fields (unintentionally i believe b/c these field explicitly defined expected behavior in their Apply/AddFlags methods) which leads to nil panic after i bumped kubernetes related dependencies to 1.20+. and these fields are declared as a pointer which implies they're optional so this pull adds a defensive short-circuiting to get rid of panics (just as we did in [the most of other fields](https://github.com/kubernetes/kubernetes/blob/65395137b5c4354893408dcc8d078954210ffeff/staging/src/k8s.io/apiserver/pkg/server/options/admission.go#L162-L164) under RecommendedOptions)


```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x60 pc=0x255a5e6]

goroutine 1 [running]:
k8s.io/apiserver/pkg/server/options.(*DelegatingAuthorizationOptions).Validate(0x0, 0x3891370, 0x0, 0x3891370)
        /gopath/pkg/mod/k8s.io/apiserver@v0.20.1/pkg/server/options/authorization.go:109 +0x26
k8s.io/apiserver/pkg/server/options.(*RecommendedOptions).Validate(0xc000595680, 0xc000596510, 0x9, 0x3892740)
        /gopath/pkg/mod/k8s.io/apiserver@v0.20.1/pkg/server/options/recommended.go:142 +0x1d1

```