### PR TITLE
set GOOS=linux for the staticcheck tool

### DIFF
--- a/hack/verify-staticcheck.sh
+++ b/hack/verify-staticcheck.sh
@@ -94,7 +94,7 @@ while read -r error; do
   elif [[ "${in_failing}" -eq "0" ]]; then
     really_failing+=( "$pkg" )
   fi
-done < <(staticcheck -checks "${checks}" "${all_packages[@]}" 2>/dev/null || true)
+done < <(GOOS=linux staticcheck -checks "${checks}" "${all_packages[@]}" 2>/dev/null || true)
 
 export IFS=$'\n'  # Expand ${really_failing[*]} to separate lines
 kube::util::read-array really_failing < <(sort -u <<<"${really_failing[*]}")


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

the `staticcheck` will have different output results under different operating systems. For developers who use macOS, it will report a lot of strange errors that variables or functions are not used.

On macOS:

- without this change:

```
➜  kubernetes git:(master) make verify WHAT=staticcheck
Verifying verify-staticcheck.sh

+++ Running case: verify.staticcheck
+++ working dir: /Users/dijun/workspace/golang/src/k8s.io/kubernetes
+++ command: bash "hack/make-rules/../../hack/verify-staticcheck.sh"
Errors from staticcheck:
cmd/kubelet/app/options/globalflags.go:55:6: func register is unused (U1000)
cmd/kubelet/app/options/globalflags.go:76:6: func registerDeprecated is unused (U1000)
pkg/kubelet/cm/helpers.go:25:6: func hardEvictionReservation is unused (U1000)
pkg/kubelet/cm/helpers_unsupported.go:54:6: func getCgroupProcs is unused (U1000)
pkg/kubelet/config/file.go:37:6: type podEventType is unused (U1000)
pkg/kubelet/config/file.go:40:2: const podAdd is unused (U1000)
pkg/kubelet/config/file.go:41:2: const podModify is unused (U1000)
pkg/kubelet/config/file.go:42:2: const podDelete is unused (U1000)
pkg/kubelet/config/file.go:48:2: field fileName is unused (U1000)
pkg/kubelet/config/file.go:49:2: field eventType is unused (U1000)
pkg/kubelet/kubelet_volumes_test.go:541:6: type stubBlockVolume is unused (U1000)
pkg/kubelet/kuberuntime/helpers_unsupported.go:22:6: func milliCPUToShares is unused (U1000)
pkg/kubelet/kuberuntime/security_context.go:27:37: func (*kubeGenericRuntimeManager).determineEffectiveSecurityContext is unused (U1000)
pkg/kubelet/kuberuntime/security_context.go:81:6: func convertToRuntimeSecurityContext is unused (U1000)
pkg/kubelet/kuberuntime/security_context.go:107:6: func convertToRuntimeSELinuxOption is unused (U1000)
pkg/kubelet/kuberuntime/security_context.go:121:6: func convertToRuntimeCapabilities is unused (U1000)
pkg/util/iptables/iptables_unsupported.go:30:6: func grabIptablesFileLock is unused (U1000)
pkg/volume/awsebs/aws_util.go:203:6: func verifyDevicePath is unused (U1000)
pkg/volume/awsebs/aws_util.go:218:6: func getDiskByIDPaths is unused (U1000)
pkg/volume/awsebs/aws_util.go:262:6: func findNvmeVolume is unused (U1000)
pkg/volume/local/local_test.go:415:6: func testFSGroupMount is unused (U1000)
pkg/volume/util/fsquota/quota.go:48:6: func enabledQuotasForMonitoring is unused (U1000)
pkg/volume/util/hostutil/hostutil.go:78:6: func getFileType is unused (U1000)
test/e2e_node/image_list.go:73:6: func updateImageAllowList is unused (U1000)
test/e2e_node/image_list.go:81:6: func getNodeProblemDetectorImage is unused (U1000)
test/e2e_node/image_list.go:235:6: func getSRIOVDevicePluginImage is unused (U1000)
test/e2e_node/util.go:62:5: var startServices is unused (U1000)
test/e2e_node/util.go:63:5: var stopServices is unused (U1000)
vendor/k8s.io/mount-utils/mount.go:34:2: const defaultMountCommand is unused (U1000)
vendor/k8s.io/mount-utils/mount_unsupported.go:80:36: func (*SafeFormatAndMount).diskLooksUnformatted is unused (U1000)

Please review the above warnings. You can test via:
  hack/verify-staticcheck.sh <failing package>
If the above warnings do not make sense, you can exempt the line or file. See:
  https://staticcheck.io/docs/#ignoring-problems

+++ exit code: 1
+++ error: 1
FAILED   verify-staticcheck.sh	587s
========================
FAILED TESTS
========================
hack/make-rules/../../hack/verify-staticcheck.sh
make: *** [verify] Error 1

staticcheck.sh

+++ Running case: verify.staticcheck
+++ working dir: /Users/dijun/workspace/golang/src/k8s.io/kubernetes
+++ command: bash "hack/make-rules/../../hack/verify-staticcheck.sh"
Errors from staticcheck:
cmd/kubelet/app/options/globalflags.go:55:6: func register is unused (U1000)
cmd/kubelet/app/options/globalflags.go:76:6: func registerDeprecated is unused (U1000)
pkg/kubelet/cm/helpers.go:25:6: func hardEvictionReservation is unused (U1000)
pkg/kubelet/cm/helpers_unsupported.go:54:6: func getCgroupProcs is unused (U1000)
pkg/kubelet/config/file.go:37:6: type podEventType is unused (U1000)
pkg/kubelet/config/file.go:40:2: const podAdd is unused (U1000)
pkg/kubelet/config/file.go:41:2: const podModify is unused (U1000)
pkg/kubelet/config/file.go:42:2: const podDelete is unused (U1000)
pkg/kubelet/config/file.go:48:2: field fileName is unused (U1000)
pkg/kubelet/config/file.go:49:2: field eventType is unused (U1000)
pkg/kubelet/kubelet_volumes_test.go:541:6: type stubBlockVolume is unused (U1000)
pkg/kubelet/kuberuntime/helpers_unsupported.go:22:6: func milliCPUToShares is unused (U1000)
pkg/kubelet/kuberuntime/security_context.go:27:37: func (*kubeGenericRuntimeManager).determineEffectiveSecurityContext is unused (U1000)
pkg/kubelet/kuberuntime/security_context.go:81:6: func convertToRuntimeSecurityContext is unused (U1000)
pkg/kubelet/kuberuntime/security_context.go:107:6: func convertToRuntimeSELinuxOption is unused (U1000)
pkg/kubelet/kuberuntime/security_context.go:121:6: func convertToRuntimeCapabilities is unused (U1000)
pkg/util/iptables/iptables_unsupported.go:30:6: func grabIptablesFileLock is unused (U1000)
pkg/volume/awsebs/aws_util.go:203:6: func verifyDevicePath is unused (U1000)
pkg/volume/awsebs/aws_util.go:218:6: func getDiskByIDPaths is unused (U1000)
pkg/volume/awsebs/aws_util.go:262:6: func findNvmeVolume is unused (U1000)
pkg/volume/local/local_test.go:415:6: func testFSGroupMount is unused (U1000)
pkg/volume/util/fsquota/quota.go:48:6: func enabledQuotasForMonitoring is unused (U1000)
pkg/volume/util/hostutil/hostutil.go:78:6: func getFileType is unused (U1000)
test/e2e_node/image_list.go:73:6: func updateImageAllowList is unused (U1000)
test/e2e_node/image_list.go:81:6: func getNodeProblemDetectorImage is unused (U1000)
test/e2e_node/image_list.go:235:6: func getSRIOVDevicePluginImage is unused (U1000)
test/e2e_node/util.go:62:5: var startServices is unused (U1000)
test/e2e_node/util.go:63:5: var stopServices is unused (U1000)
vendor/k8s.io/mount-utils/mount.go:34:2: const defaultMountCommand is unused (U1000)
vendor/k8s.io/mount-utils/mount_unsupported.go:80:36: func (*SafeFormatAndMount).diskLooksUnformatted is unused (U1000)

Please review the above warnings. You can test via:
  hack/verify-staticcheck.sh <failing package>
If the above warnings do not make sense, you can exempt the line or file. See:
  https://staticcheck.io/docs/#ignoring-problems

+++ exit code: 1
+++ error: 1
FAILED   verify-staticcheck.sh	587s
========================
FAILED TESTS
========================
hack/make-rules/../../hack/verify-staticcheck.sh
make: *** [verify] Error 1
```

- with this change:

```
➜  kubernetes git:(master) ✗ make verify WHAT=staticcheck
Verifying verify-staticcheck.sh

+++ Running case: verify.staticcheck
+++ working dir: /Users/dijun/workspace/golang/src/k8s.io/kubernetes
+++ command: bash "hack/make-rules/../../hack/verify-staticcheck.sh"
Congratulations!  All Go source files have passed staticcheck.
+++ exit code: 0
SUCCESS  verify-staticcheck.sh	877s
```

Refer #92402

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
