### PR TITLE
Run pause image as non-root user and group

### DIFF
--- a/build/dependencies.yaml
+++ b/build/dependencies.yaml
@@ -160,7 +160,7 @@ dependencies:
       match: __default_go_runner_version=
 
   - name: "k8s.gcr.io/pause"
-    version: 3.4
+    version: 3.5
     refPaths:
     - path: build/pause/Makefile
       match: TAG =

--- a/build/pause/Dockerfile
+++ b/build/pause/Dockerfile
@@ -16,4 +16,5 @@ ARG BASE
 FROM ${BASE}
 ARG ARCH
 ADD bin/pause-linux-${ARCH} /pause
+USER 65535:65535
 ENTRYPOINT ["/pause"]

--- a/build/pause/Makefile
+++ b/build/pause/Makefile
@@ -17,7 +17,7 @@
 REGISTRY ?= staging-k8s.gcr.io
 IMAGE = $(REGISTRY)/pause
 
-TAG = 3.4.1
+TAG = 3.5
 REV = $(shell git describe --contains --always --match='v*')
 
 # Architectures supported: amd64, arm, arm64, ppc64le and s390x


### PR DESCRIPTION

**What type of PR is this?**


/kind feature


**What this PR does / why we need it**:
We now build the pause image to use a pseudo user and group 65535:65535.
This increases the security aspect of the container image, if a
vulnerability would directly affect the pause container.

**Which issue(s) this PR fixes**:

Fixes #95038

**Special notes for your reviewer**:
/hold

I'm not sure what the CI thinks about this change, nor if it has other implications.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Update pause container to run as pseudo user and group `65535:65535`. This implies the release of version 3.5 of the container images.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```
