### PR TITLE
Remove AppArmor loaded profile validation

### DIFF
--- a/pkg/security/apparmor/validate_test.go
+++ b/pkg/security/apparmor/validate_test.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"testing"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/stretchr/testify/assert"
@@ -47,16 +47,7 @@ func TestValidateHost(t *testing.T) {
 	assert.Error(t, validateHost("rkt"))
 }
 
-func TestValidateProfile(t *testing.T) {
-	loadedProfiles := map[string]bool{
-		"docker-default": true,
-		"foo-bar":        true,
-		"baz":            true,
-		"/usr/sbin/ntpd": true,
-		"/usr/lib/connman/scripts/dhclient-script":      true,
-		"/usr/lib/NetworkManager/nm-dhcp-client.action": true,
-		"/usr/bin/evince-previewer//sanitized_helper":   true,
-	}
+func TestValidateProfileFormat(t *testing.T) {
 	tests := []struct {
 		profile     string
 		expectValid bool
@@ -67,12 +58,10 @@ func TestValidateProfile(t *testing.T) {
 		{"baz", false}, // Missing local prefix.
 		{v1.AppArmorBetaProfileNamePrefix + "/usr/sbin/ntpd", true},
 		{v1.AppArmorBetaProfileNamePrefix + "foo-bar", true},
-		{v1.AppArmorBetaProfileNamePrefix + "unloaded", false}, // Not loaded.
-		{v1.AppArmorBetaProfileNamePrefix + "", false},
 	}
 
 	for _, test := range tests {
-		err := validateProfile(test.profile, loadedProfiles)
+		err := ValidateProfileFormat(test.profile)
 		if test.expectValid {
 			assert.NoError(t, err, "Profile %s should be valid", test.profile)
 		} else {
@@ -121,8 +110,6 @@ func TestValidateValidHost(t *testing.T) {
 		{v1.AppArmorBetaProfileNamePrefix + "foo-container", true},
 		{v1.AppArmorBetaProfileNamePrefix + "/usr/sbin/ntpd", true},
 		{"docker-default", false},
-		{v1.AppArmorBetaProfileNamePrefix + "foo", false},
-		{v1.AppArmorBetaProfileNamePrefix + "", false},
 	}
 
 	for _, test := range tests {
@@ -155,23 +142,6 @@ func TestValidateValidHost(t *testing.T) {
 		},
 	}
 	assert.NoError(t, v.Validate(pod), "Multi-container pod should validate")
-	for k, val := range pod.Annotations {
-		pod.Annotations[k] = val + "-bad"
-		assert.Error(t, v.Validate(pod), fmt.Sprintf("Multi-container pod with invalid profile %s:%s", k, pod.Annotations[k]))
-		pod.Annotations[k] = val // Restore.
-	}
-}
-
-func TestParseProfileName(t *testing.T) {
-	tests := []struct{ line, expected string }{
-		{"foo://bar/baz (kill)", "foo://bar/baz"},
-		{"foo-bar (enforce)", "foo-bar"},
-		{"/usr/foo/bar/baz (complain)", "/usr/foo/bar/baz"},
-	}
-	for _, test := range tests {
-		name := parseProfileName(test.line)
-		assert.Equal(t, test.expected, name, "Parsing %s", test.line)
-	}
 }
 
 func getPodWithProfile(profile string) *v1.Pod {


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

In general it could be possible that unconfined init containers deploy
security profiles. The existing AppArmor pre-validation would block the
complete workload without this patch being applied. If we now schedule a
workload which contains an unconfined init container, then we will skip
the validation. The underlying container runtime will fail if the
profile is not available after the execution of the init container.

This synchronizes the overall behavior with seccomp.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubernetes/issues/97273

**Special notes for your reviewer**:

/cc @pjbgf 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Removed validation if AppArmor profiles are loaded on the local node. This should be handled by the
container runtime.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```
