### PR TITLE
Remove check for apparmor_parser in AppArmor host validation

### DIFF
--- a/pkg/security/apparmor/validate.go
+++ b/pkg/security/apparmor/validate.go
@@ -20,11 +20,11 @@ import (
 	"bufio"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"strings"
 
+	"github.com/opencontainers/runc/libcontainer/apparmor"
 	v1 "k8s.io/api/core/v1"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
@@ -107,7 +107,7 @@ func validateHost(runtime string) error {
 	}
 
 	// Check kernel support.
-	if !IsAppArmorEnabled() {
+	if !apparmor.IsEnabled() {
 		return errors.New("AppArmor is not enabled on the host")
 	}
 
@@ -211,18 +211,4 @@ func getAppArmorFS() (string, error) {
 	}
 
 	return "", errors.New("securityfs not found")
-}
-
-// IsAppArmorEnabled returns true if apparmor is enabled for the host.
-// This function is forked from
-// https://github.com/opencontainers/runc/blob/1a81e9ab1f138c091fe5c86d0883f87716088527/libcontainer/apparmor/apparmor.go
-// to avoid the libapparmor dependency.
-func IsAppArmorEnabled() bool {
-	if _, err := os.Stat("/sys/kernel/security/apparmor"); err == nil && os.Getenv("container") == "" {
-		if _, err = os.Stat("/sbin/apparmor_parser"); err == nil {
-			buf, err := ioutil.ReadFile("/sys/module/apparmor/parameters/enabled")
-			return err == nil && len(buf) > 1 && buf[0] == 'Y'
-		}
-	}
-	return false
 }

--- a/test/e2e_node/apparmor_test.go
+++ b/test/e2e_node/apparmor_test.go
@@ -27,7 +27,8 @@ import (
 	"strconv"
 	"strings"
 
-	"k8s.io/api/core/v1"
+	"github.com/opencontainers/runc/libcontainer/apparmor"
+	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
@@ -37,7 +38,6 @@ import (
 	"k8s.io/client-go/tools/cache"
 	watchtools "k8s.io/client-go/tools/watch"
 	"k8s.io/klog/v2"
-	"k8s.io/kubernetes/pkg/security/apparmor"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 
@@ -246,5 +246,5 @@ func isAppArmorEnabled() bool {
 	if strings.Contains(framework.TestContext.NodeName, "-ubuntu-") {
 		return true
 	}
-	return apparmor.IsAppArmorEnabled()
+	return apparmor.IsEnabled()
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

The `apparmor_parser` binary is not really required for a system to run
AppArmor from a Kubernetes perspective. How to apply the profile is more
in the responsibility of lower level runtimes like CRI-O and containerd,
which may do the binary check on their own.

This synchronizes the current libcontainer implementation with the
vendored Kubernetes source code and allows distributions to use
AppArmor, even when they do not have the parser available in
`/sbin/apparmor_parser`.

**Which issue(s) this PR fixes**:

Refers to https://github.com/opencontainers/runc/pull/2554

**Special notes for your reviewer**:

/cc @timothysc @pjbgf 
/sig node

**Does this PR introduce a user-facing change?**:

```release-note
Removed `/sbin/apparmor_parser` requirement for the AppArmor host validation.
This allows using AppArmor on distributions which ship the binary in a different path.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```
