### PR TITLE
Automated cherry pick of #92839: AWS cloudprovider allow nlb-ip and external type lbs to be managed externally

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/aws/aws.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/aws/aws.go
@@ -3641,6 +3641,9 @@ func (c *Cloud) getSubnetCidrs(subnetIDs []string) ([]string, error) {
 // EnsureLoadBalancer implements LoadBalancer.EnsureLoadBalancer
 func (c *Cloud) EnsureLoadBalancer(ctx context.Context, clusterName string, apiService *v1.Service, nodes []*v1.Node) (*v1.LoadBalancerStatus, error) {
 	annotations := apiService.Annotations
+	if isLBExternal(annotations) {
+		return nil, cloudprovider.ImplementedElsewhere
+	}
 	klog.V(2).Infof("EnsureLoadBalancer(%v, %v, %v, %v, %v, %v, %v)",
 		clusterName, apiService.Namespace, apiService.Name, c.region, apiService.Spec.LoadBalancerIP, apiService.Spec.Ports, annotations)
 
@@ -3652,7 +3655,6 @@ func (c *Cloud) EnsureLoadBalancer(ctx context.Context, clusterName string, apiS
 	if len(apiService.Spec.Ports) == 0 {
 		return nil, fmt.Errorf("requested load balancer with no ports")
 	}
-
 	// Figure out what mappings we want on the load balancer
 	listeners := []*elb.Listener{}
 	v2Mappings := []nlbPortMapping{}
@@ -4042,6 +4044,9 @@ func (c *Cloud) EnsureLoadBalancer(ctx context.Context, clusterName string, apiS
 
 // GetLoadBalancer is an implementation of LoadBalancer.GetLoadBalancer
 func (c *Cloud) GetLoadBalancer(ctx context.Context, clusterName string, service *v1.Service) (*v1.LoadBalancerStatus, bool, error) {
+	if isLBExternal(service.Annotations) {
+		return nil, false, nil
+	}
 	loadBalancerName := c.GetLoadBalancerName(ctx, clusterName, service)
 
 	if isNLB(service.Annotations) {
@@ -4310,6 +4315,9 @@ func (c *Cloud) updateInstanceSecurityGroupsForLoadBalancer(lb *elb.LoadBalancer
 
 // EnsureLoadBalancerDeleted implements LoadBalancer.EnsureLoadBalancerDeleted.
 func (c *Cloud) EnsureLoadBalancerDeleted(ctx context.Context, clusterName string, service *v1.Service) error {
+	if isLBExternal(service.Annotations) {
+		return nil
+	}
 	loadBalancerName := c.GetLoadBalancerName(ctx, clusterName, service)
 
 	if isNLB(service.Annotations) {
@@ -4494,11 +4502,13 @@ func (c *Cloud) EnsureLoadBalancerDeleted(ctx context.Context, clusterName strin
 
 // UpdateLoadBalancer implements LoadBalancer.UpdateLoadBalancer
 func (c *Cloud) UpdateLoadBalancer(ctx context.Context, clusterName string, service *v1.Service, nodes []*v1.Node) error {
+	if isLBExternal(service.Annotations) {
+		return cloudprovider.ImplementedElsewhere
+	}
 	instances, err := c.findInstancesForELB(nodes)
 	if err != nil {
 		return err
 	}
-
 	loadBalancerName := c.GetLoadBalancerName(ctx, clusterName, service)
 	if isNLB(service.Annotations) {
 		lb, err := c.describeLoadBalancerv2(loadBalancerName)

--- a/staging/src/k8s.io/legacy-cloud-providers/aws/aws_loadbalancer.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/aws/aws_loadbalancer.go
@@ -69,6 +69,13 @@ func isNLB(annotations map[string]string) bool {
 	return false
 }
 
+func isLBExternal(annotations map[string]string) bool {
+	if val := annotations[ServiceAnnotationLoadBalancerType]; val == "nlb-ip" || val == "external" {
+		return true
+	}
+	return false
+}
+
 type nlbPortMapping struct {
 	FrontendPort     int64
 	FrontendProtocol string

--- a/staging/src/k8s.io/legacy-cloud-providers/aws/aws_loadbalancer_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/aws/aws_loadbalancer_test.go
@@ -165,6 +165,43 @@ func TestIsNLB(t *testing.T) {
 	}
 }
 
+func TestIsLBExternal(t *testing.T) {
+	tests := []struct {
+		name        string
+		annotations map[string]string
+		want        bool
+	}{
+		{
+			name:        "No annotation",
+			annotations: map[string]string{},
+			want:        false,
+		},
+		{
+			name:        "Type NLB",
+			annotations: map[string]string{"service.beta.kubernetes.io/aws-load-balancer-type": "nlb"},
+			want:        false,
+		},
+		{
+			name:        "Type NLB-IP",
+			annotations: map[string]string{"service.beta.kubernetes.io/aws-load-balancer-type": "nlb-ip"},
+			want:        true,
+		},
+		{
+			name:        "Type External",
+			annotations: map[string]string{"service.beta.kubernetes.io/aws-load-balancer-type": "external"},
+			want:        true,
+		},
+	}
+	for _, test := range tests {
+		t.Logf("Running test case %s", test.name)
+		got := isLBExternal(test.annotations)
+
+		if got != test.want {
+			t.Errorf("Incorrect value for isLBExternal() case %s. Got %t, expected %t.", test.name, got, test.want)
+		}
+	}
+}
+
 func TestSyncElbListeners(t *testing.T) {
 	tests := []struct {
 		name                 string


### PR DESCRIPTION
Cherry pick of #92839 on release-1.18.

#92839: AWS cloudprovider allow nlb-ip and external type lbs to be managed externally

```release-note
AWS cloudprovider will ignore provisioning load balancers if the annotation service.beta.kubernetes.io/aws-load-balancer-type is external or nlb-ip
```

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.