### PR TITLE
Fix non-amd64 conformance image builds

### DIFF
--- a/cluster/images/conformance/Dockerfile
+++ b/cluster/images/conformance/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM BASEIMAGE
+FROM --platform=linux/ARCH BASEIMAGE
 
 COPY ginkgo /usr/local/bin/
 COPY e2e.test /usr/local/bin/

--- a/cluster/images/conformance/Makefile
+++ b/cluster/images/conformance/Makefile
@@ -54,7 +54,7 @@ endif
 	chmod a+rx ${TEMP_DIR}/e2e.test
 	chmod a+rx ${TEMP_DIR}/gorunner
 
-	cd ${TEMP_DIR} && sed -i.back "s|BASEIMAGE|${BASEIMAGE}|g" Dockerfile
+	cd ${TEMP_DIR} && sed -i.back "s|ARCH|${ARCH}|g; s|BASEIMAGE|${BASEIMAGE}|g" Dockerfile
 
 	docker build --pull -t ${REGISTRY}/conformance-${ARCH}:${VERSION} ${TEMP_DIR}
 	rm -rf "${TEMP_DIR}"

--- a/cluster/images/conformance/Makefile
+++ b/cluster/images/conformance/Makefile
@@ -31,7 +31,7 @@ E2E_GO_RUNNER_BIN?=$(shell test -f $(LOCAL_OUTPUT_PATH)/go-runner && echo $(LOCA
 
 CLUSTER_DIR?=$(shell pwd)/../../../cluster/
 
-BASEIMAGE=debian:stretch-slim
+BASEIMAGE=debian:stable-slim
 TEMP_DIR:=$(shell mktemp -d -t conformanceXXXXXX)
 
 all: build


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**


/kind bug

**What this PR does / why we need it**:

~Updates the conformance image to build for the correct architecture when
not amd64. This was previously implemented but caused issues in the
release pipeline due to an issue in buildkit with the baseimage not
being present in the gcr mirror registry. This change addresses that
concern by pre-pulling the baseimage.~

The approach above was abandoned in favor of specifying platform
for each build. This allows us to be more consistent with other image
builds in k/k. Note that this did require switching to `debian:stable-slim`
because `debian:stretch-slim` does not have support for s390x in its
multi-arch build.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #89554 

**Special notes for your reviewer**:

Based on work done initially in https://github.com/kubernetes/kubernetes/pull/90400 by @zhlhahaha then subsequently reverted in https://github.com/kubernetes/kubernetes/pull/92042.

See https://github.com/moby/buildkit/issues/1271 for more info on the issue and https://github.com/kubernetes-sigs/cluster-addons/pull/84 for an example of working around it.

/assign @BenTheElder @dims 
/cc @kubernetes/release-engineering 
/sig release
/milestone v1.21
/priority critical-urgent

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
