### PR TITLE
Update runc to a5847db

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -76,7 +76,7 @@ require (
 	github.com/onsi/ginkgo v1.11.0
 	github.com/onsi/gomega v1.7.0
 	github.com/opencontainers/go-digest v1.0.0
-	github.com/opencontainers/runc v1.0.0-rc92
+	github.com/opencontainers/runc v1.0.0-rc92.0.20200818041331-a5847db387ae
 	github.com/opencontainers/selinux v1.6.0
 	github.com/pkg/errors v0.9.1
 	github.com/pmezard/go-difflib v1.0.0
@@ -388,7 +388,7 @@ replace (
 	github.com/onsi/gomega => github.com/onsi/gomega v1.7.0
 	github.com/opencontainers/go-digest => github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec => github.com/opencontainers/image-spec v1.0.1
-	github.com/opencontainers/runc => github.com/opencontainers/runc v1.0.0-rc92
+	github.com/opencontainers/runc => github.com/opencontainers/runc v1.0.0-rc92.0.20200818041331-a5847db387ae
 	github.com/opencontainers/runtime-spec => github.com/opencontainers/runtime-spec v1.0.3-0.20200728170252-4d89ac9fbff6
 	github.com/opencontainers/selinux => github.com/opencontainers/selinux v1.6.0
 	github.com/pascaldekloe/goe => github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c
@@ -430,7 +430,7 @@ replace (
 	github.com/stretchr/objx => github.com/stretchr/objx v0.2.0
 	github.com/stretchr/testify => github.com/stretchr/testify v1.6.1
 	github.com/subosito/gotenv => github.com/subosito/gotenv v1.2.0
-	github.com/syndtr/gocapability => github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2
+	github.com/syndtr/gocapability => github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635
 	github.com/thecodeteam/goscaleio => github.com/thecodeteam/goscaleio v0.1.0
 	github.com/tidwall/pretty => github.com/tidwall/pretty v1.0.0
 	github.com/tmc/grpc-websocket-proxy => github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5

--- a/go.sum
+++ b/go.sum
@@ -402,8 +402,8 @@ github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.0.1 h1:JMemWkRwHx4Zj+fVxWoMCFm/8sYGGrUVojFA6h/TRcI=
 github.com/opencontainers/image-spec v1.0.1/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
-github.com/opencontainers/runc v1.0.0-rc92 h1:+IczUKCRzDzFDnw99O/PAqrcBBCoRp9xN3cB1SYSNS4=
-github.com/opencontainers/runc v1.0.0-rc92/go.mod h1:X1zlU4p7wOlX4+WRCz+hvlRv8phdL7UqbYD+vQwNMmE=
+github.com/opencontainers/runc v1.0.0-rc92.0.20200818041331-a5847db387ae h1:8DPtiK5oOmvl3GhYxFjbVNXGRYkzkObPN+35AnFdcSg=
+github.com/opencontainers/runc v1.0.0-rc92.0.20200818041331-a5847db387ae/go.mod h1:CKKZIDxUf3PWz86JeXHNZ9esuCkGWUQqx5KL1e7tKu4=
 github.com/opencontainers/runtime-spec v1.0.3-0.20200728170252-4d89ac9fbff6 h1:NhsM2gc769rVWDqJvapK37r+7+CBXI8xHhnfnt8uQsg=
 github.com/opencontainers/runtime-spec v1.0.3-0.20200728170252-4d89ac9fbff6/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/selinux v1.6.0 h1:+bIAS/Za3q5FTwWym4fTB0vObnfCf3G/NC7K6Jx62mY=
@@ -478,8 +478,8 @@ github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
-github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2 h1:b6uOv7YOFK0TYG7HtkIgExQo+2RdLuwRft63jn2HWj8=
-github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
+github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635 h1:kdXcSzyDtseVEc4yCz2qF8ZrQvIDBJLl4S1c3GCXmoI=
+github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/thecodeteam/goscaleio v0.1.0 h1:SB5tO98lawC+UK8ds/U2jyfOCH7GTcFztcF5x9gbut4=
 github.com/thecodeteam/goscaleio v0.1.0/go.mod h1:68sdkZAsK8bvEwBlbQnlLS+xU+hvLYM/iQ8KXej1AwM=
 github.com/tidwall/pretty v1.0.0 h1:HsD+QiTn7sK6flMKIvNmpqz1qrpP3Ps6jOKIKMooyg4=

--- a/vendor/github.com/opencontainers/runc/libcontainer/cgroups/BUILD
+++ b/vendor/github.com/opencontainers/runc/libcontainer/cgroups/BUILD
@@ -19,10 +19,12 @@ go_library(
         "@io_bazel_rules_go//go/platform:android": [
             "//vendor/github.com/docker/go-units:go_default_library",
             "//vendor/github.com/opencontainers/runc/libcontainer/configs:go_default_library",
+            "//vendor/github.com/sirupsen/logrus:go_default_library",
         ],
         "@io_bazel_rules_go//go/platform:linux": [
             "//vendor/github.com/docker/go-units:go_default_library",
             "//vendor/github.com/opencontainers/runc/libcontainer/configs:go_default_library",
+            "//vendor/github.com/sirupsen/logrus:go_default_library",
         ],
         "//conditions:default": [],
     }),

--- a/vendor/github.com/opencontainers/runc/libcontainer/cgroups/fs/fs.go
+++ b/vendor/github.com/opencontainers/runc/libcontainer/cgroups/fs/fs.go
@@ -274,11 +274,7 @@ func (m *manager) Destroy() error {
 	}
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	if err := cgroups.RemovePaths(m.paths); err != nil {
-		return err
-	}
-	m.paths = make(map[string]string)
-	return nil
+	return cgroups.RemovePaths(m.paths)
 }
 
 func (m *manager) Path(subsys string) string {

--- a/vendor/github.com/opencontainers/runc/libcontainer/cgroups/systemd/v1.go
+++ b/vendor/github.com/opencontainers/runc/libcontainer/cgroups/systemd/v1.go
@@ -212,17 +212,14 @@ func (m *legacyManager) Destroy() error {
 	}
 	unitName := getUnitName(m.cgroups)
 
-	err = stopUnit(dbusConnection, unitName)
+	stopErr := stopUnit(dbusConnection, unitName)
 	// Both on success and on error, cleanup all the cgroups we are aware of.
 	// Some of them were created directly by Apply() and are not managed by systemd.
 	if err := cgroups.RemovePaths(m.paths); err != nil {
 		return err
 	}
-	if err != nil {
-		return err
-	}
-	m.paths = make(map[string]string)
-	return nil
+
+	return stopErr
 }
 
 func (m *legacyManager) Path(subsys string) string {

--- a/vendor/github.com/opencontainers/runc/libcontainer/criu_opts_linux.go
+++ b/vendor/github.com/opencontainers/runc/libcontainer/criu_opts_linux.go
@@ -1,14 +1,6 @@
 package libcontainer
 
-// cgroup restoring strategy provided by criu
-type cgMode uint32
-
-const (
-	CRIU_CG_MODE_SOFT    cgMode = 3 + iota // restore cgroup properties if only dir created by criu
-	CRIU_CG_MODE_FULL                      // always restore all cgroups and their properties
-	CRIU_CG_MODE_STRICT                    // restore all, requiring them to not present in the system
-	CRIU_CG_MODE_DEFAULT                   // the same as CRIU_CG_MODE_SOFT
-)
+import criu "github.com/checkpoint-restore/go-criu/v4/rpc"
 
 type CriuPageServerInfo struct {
 	Address string // IP address of CRIU page server
@@ -32,7 +24,7 @@ type CriuOpts struct {
 	PreDump                 bool               // call criu predump to perform iterative checkpoint
 	PageServer              CriuPageServerInfo // allow to dump to criu page server
 	VethPairs               []VethPairName     // pass the veth to criu when restore
-	ManageCgroupsMode       cgMode             // dump or restore cgroup mode
+	ManageCgroupsMode       criu.CriuCgMode    // dump or restore cgroup mode
 	EmptyNs                 uint32             // don't c/r properties for namespace from this mask
 	AutoDedup               bool               // auto deduplication for incremental dumps
 	LazyPages               bool               // restore memory pages lazily using userfaultfd

--- a/vendor/github.com/syndtr/gocapability/capability/enum.go
+++ b/vendor/github.com/syndtr/gocapability/capability/enum.go
@@ -41,7 +41,9 @@ const (
 //go:generate go run enumgen/gen.go
 type Cap int
 
-// POSIX-draft defined capabilities.
+// POSIX-draft defined capabilities and Linux extensions.
+//
+// Defined in https://github.com/torvalds/linux/blob/master/include/uapi/linux/capability.h
 const (
 	// In a system with the [_POSIX_CHOWN_RESTRICTED] option defined, this
 	// overrides the restriction of changing file ownership and group
@@ -187,6 +189,7 @@ const (
 	// arbitrary SCSI commands
 	// Allow setting encryption key on loopback filesystem
 	// Allow setting zone reclaim policy
+	// Allow everything under CAP_BPF and CAP_PERFMON for backward compatibility
 	CAP_SYS_ADMIN = Cap(21)
 
 	// Allow use of reboot()
@@ -211,6 +214,7 @@ const (
 	// Allow more than 64hz interrupts from the real-time clock
 	// Override max number of consoles on console allocation
 	// Override max number of keymaps
+	// Control memory reclaim behavior
 	CAP_SYS_RESOURCE = Cap(24)
 
 	// Allow manipulation of system clock
@@ -256,8 +260,45 @@ const (
 	// Allow preventing system suspends
 	CAP_BLOCK_SUSPEND = Cap(36)
 
-	// Allow reading audit messages from the kernel
+	// Allow reading the audit log via multicast netlink socket
 	CAP_AUDIT_READ = Cap(37)
+
+	// Allow system performance and observability privileged operations
+	// using perf_events, i915_perf and other kernel subsystems
+	CAP_PERFMON = Cap(38)
+
+	// CAP_BPF allows the following BPF operations:
+	// - Creating all types of BPF maps
+	// - Advanced verifier features
+	//   - Indirect variable access
+	//   - Bounded loops
+	//   - BPF to BPF function calls
+	//   - Scalar precision tracking
+	//   - Larger complexity limits
+	//   - Dead code elimination
+	//   - And potentially other features
+	// - Loading BPF Type Format (BTF) data
+	// - Retrieve xlated and JITed code of BPF programs
+	// - Use bpf_spin_lock() helper
+	//
+	// CAP_PERFMON relaxes the verifier checks further:
+	// - BPF progs can use of pointer-to-integer conversions
+	// - speculation attack hardening measures are bypassed
+	// - bpf_probe_read to read arbitrary kernel memory is allowed
+	// - bpf_trace_printk to print kernel memory is allowed
+	//
+	// CAP_SYS_ADMIN is required to use bpf_probe_write_user.
+	//
+	// CAP_SYS_ADMIN is required to iterate system wide loaded
+	// programs, maps, links, BTFs and convert their IDs to file descriptors.
+	//
+	// CAP_PERFMON and CAP_BPF are required to load tracing programs.
+	// CAP_NET_ADMIN and CAP_BPF are required to load networking programs.
+	CAP_BPF = Cap(39)
+
+	// Allow checkpoint/restore related operations.
+	// Introduced in kernel 5.9
+	CAP_CHECKPOINT_RESTORE = Cap(40)
 )
 
 var (

--- a/vendor/github.com/syndtr/gocapability/capability/enum_gen.go
+++ b/vendor/github.com/syndtr/gocapability/capability/enum_gen.go
@@ -80,6 +80,12 @@ func (c Cap) String() string {
 		return "block_suspend"
 	case CAP_AUDIT_READ:
 		return "audit_read"
+	case CAP_PERFMON:
+		return "perfmon"
+	case CAP_BPF:
+		return "bpf"
+	case CAP_CHECKPOINT_RESTORE:
+		return "checkpoint_restore"
 	}
 	return "unknown"
 }
@@ -125,5 +131,8 @@ func List() []Cap {
 		CAP_WAKE_ALARM,
 		CAP_BLOCK_SUSPEND,
 		CAP_AUDIT_READ,
+		CAP_PERFMON,
+		CAP_BPF,
+		CAP_CHECKPOINT_RESTORE,
 	}
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -900,9 +900,9 @@ github.com/opencontainers/go-digest
 # github.com/opencontainers/image-spec => github.com/opencontainers/image-spec v1.0.1
 github.com/opencontainers/image-spec/specs-go
 github.com/opencontainers/image-spec/specs-go/v1
-# github.com/opencontainers/runc v1.0.0-rc92 => github.com/opencontainers/runc v1.0.0-rc92
+# github.com/opencontainers/runc v1.0.0-rc92.0.20200818041331-a5847db387ae => github.com/opencontainers/runc v1.0.0-rc92.0.20200818041331-a5847db387ae
 ## explicit
-# github.com/opencontainers/runc => github.com/opencontainers/runc v1.0.0-rc92
+# github.com/opencontainers/runc => github.com/opencontainers/runc v1.0.0-rc92.0.20200818041331-a5847db387ae
 github.com/opencontainers/runc/libcontainer
 github.com/opencontainers/runc/libcontainer/apparmor
 github.com/opencontainers/runc/libcontainer/cgroups
@@ -1060,8 +1060,8 @@ github.com/stretchr/testify/require
 # github.com/subosito/gotenv v1.2.0 => github.com/subosito/gotenv v1.2.0
 github.com/subosito/gotenv
 # github.com/subosito/gotenv => github.com/subosito/gotenv v1.2.0
-# github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2 => github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2
-# github.com/syndtr/gocapability => github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2
+# github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635 => github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635
+# github.com/syndtr/gocapability => github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635
 github.com/syndtr/gocapability/capability
 # github.com/thecodeteam/goscaleio v0.1.0 => github.com/thecodeteam/goscaleio v0.1.0
 ## explicit


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

We are seeing a bug where pods cannot be deleted due to an issue where cgroup paths fail to remove (see #97497). Right now the errors are not being bubbled up in the logs, making it very difficult to debug why the paths are not removed.

This PR bumps runc to a5847db (+ transitive dependencies) which is the most minimal diff to introduce a [logging fix](https://github.com/kubernetes/kubernetes/issues/97497#issuecomment-751148975) that will help address the problem. I don't know when the next [release of runc](https://github.com/opencontainers/runc/issues/2659) will be available; it was expected in December 2020 but there is no ETA.

I initially tried to bump runc to HEAD, but there are some incompatibilities between the current vendored version of cadvisor and changes made in runc. When we want to update runc next, we will need to also bump cadvisor.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Update runc to latest (v1.0.0-rc92.0.20210111190311-9712205ecc3a)
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/cc @pacoxu @mrunalp @rphillips 