### PR TITLE
Automated cherry pick of #97754: kubectl-convert import known versions

### DIFF
--- a/pkg/kubectl/.import-restrictions
+++ b/pkg/kubectl/.import-restrictions
@@ -2,6 +2,18 @@ rules:
   - selectorRegexp: k8s[.]io/kubernetes/pkg
     allowedPrefixes:
       - k8s.io/kubernetes/pkg/api/legacyscheme
+      - k8s.io/kubernetes/pkg/apis/admission
+      - k8s.io/kubernetes/pkg/apis/admission/install
+      - k8s.io/kubernetes/pkg/apis/admission/v1
+      - k8s.io/kubernetes/pkg/apis/admission/v1beta1
+      - k8s.io/kubernetes/pkg/apis/admissionregistration
+      - k8s.io/kubernetes/pkg/apis/admissionregistration/install
+      - k8s.io/kubernetes/pkg/apis/admissionregistration/v1
+      - k8s.io/kubernetes/pkg/apis/admissionregistration/v1beta1
+      - k8s.io/kubernetes/pkg/apis/apiserverinternal
+      - k8s.io/kubernetes/pkg/apis/apiserverinternal/fuzzer
+      - k8s.io/kubernetes/pkg/apis/apiserverinternal/install
+      - k8s.io/kubernetes/pkg/apis/apiserverinternal/v1alpha1
       - k8s.io/kubernetes/pkg/apis/apps
       - k8s.io/kubernetes/pkg/apis/apps/install
       - k8s.io/kubernetes/pkg/apis/apps/v1
@@ -35,13 +47,29 @@ rules:
       - k8s.io/kubernetes/pkg/apis/core/helper
       - k8s.io/kubernetes/pkg/apis/core/install
       - k8s.io/kubernetes/pkg/apis/core/v1
+      - k8s.io/kubernetes/pkg/apis/discovery
+      - k8s.io/kubernetes/pkg/apis/discovery/install
+      - k8s.io/kubernetes/pkg/apis/discovery/v1alpha1
+      - k8s.io/kubernetes/pkg/apis/discovery/v1beta1
       - k8s.io/kubernetes/pkg/apis/events
       - k8s.io/kubernetes/pkg/apis/events/install
       - k8s.io/kubernetes/pkg/apis/events/v1beta1
       - k8s.io/kubernetes/pkg/apis/extensions
       - k8s.io/kubernetes/pkg/apis/extensions/install
       - k8s.io/kubernetes/pkg/apis/extensions/v1beta1
+      - k8s.io/kubernetes/pkg/apis/flowcontrol
+      - k8s.io/kubernetes/pkg/apis/flowcontrol/install
+      - k8s.io/kubernetes/pkg/apis/flowcontrol/v1alpha1
+      - k8s.io/kubernetes/pkg/apis/flowcontrol/v1beta1
+      - k8s.io/kubernetes/pkg/apis/imagepolicy
+      - k8s.io/kubernetes/pkg/apis/imagepolicy/install
+      - k8s.io/kubernetes/pkg/apis/imagepolicy/v1alpha1
       - k8s.io/kubernetes/pkg/apis/networking
+      - k8s.io/kubernetes/pkg/apis/node
+      - k8s.io/kubernetes/pkg/apis/node/install
+      - k8s.io/kubernetes/pkg/apis/node/v1
+      - k8s.io/kubernetes/pkg/apis/node/v1alpha1
+      - k8s.io/kubernetes/pkg/apis/node/v1beta1
       - k8s.io/kubernetes/pkg/apis/policy
       - k8s.io/kubernetes/pkg/apis/policy/install
       - k8s.io/kubernetes/pkg/apis/policy/v1beta1

--- a/pkg/kubectl/cmd/convert/BUILD
+++ b/pkg/kubectl/cmd/convert/BUILD
@@ -10,6 +10,9 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/api/legacyscheme:go_default_library",
+        "//pkg/apis/admission/install:go_default_library",
+        "//pkg/apis/admissionregistration/install:go_default_library",
+        "//pkg/apis/apiserverinternal/install:go_default_library",
         "//pkg/apis/apps/install:go_default_library",
         "//pkg/apis/authentication/install:go_default_library",
         "//pkg/apis/authorization/install:go_default_library",
@@ -19,8 +22,13 @@ go_library(
         "//pkg/apis/coordination/install:go_default_library",
         "//pkg/apis/core:go_default_library",
         "//pkg/apis/core/install:go_default_library",
+        "//pkg/apis/discovery/install:go_default_library",
         "//pkg/apis/events/install:go_default_library",
         "//pkg/apis/extensions/install:go_default_library",
+        "//pkg/apis/flowcontrol/install:go_default_library",
+        "//pkg/apis/imagepolicy/install:go_default_library",
+        "//pkg/apis/networking/install:go_default_library",
+        "//pkg/apis/node/install:go_default_library",
         "//pkg/apis/policy/install:go_default_library",
         "//pkg/apis/rbac/install:go_default_library",
         "//pkg/apis/scheduling/install:go_default_library",
@@ -42,13 +50,20 @@ go_library(
 
 go_test(
     name = "go_default_test",
-    srcs = ["convert_test.go"],
+    srcs = [
+        "convert_test.go",
+        "import_known_versions_test.go",
+    ],
     data = [
         "//test/fixtures",
     ],
     embed = [":go_default_library"],
     deps = [
+        "//pkg/api/legacyscheme:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//staging/src/k8s.io/cli-runtime/pkg/genericclioptions:go_default_library",
+        "//staging/src/k8s.io/client-go/kubernetes/scheme:go_default_library",
         "//staging/src/k8s.io/client-go/rest/fake:go_default_library",
         "//staging/src/k8s.io/kubectl/pkg/cmd/testing:go_default_library",
     ],

--- a/pkg/kubectl/cmd/convert/convert_test.go
+++ b/pkg/kubectl/cmd/convert/convert_test.go
@@ -90,6 +90,16 @@ func TestConvertObject(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:          "v1beta1 Ingress to extensions Ingress",
+			file:          "../../../../test/fixtures/pkg/kubectl/cmd/convert/v1beta1ingress.yaml",
+			outputVersion: "extensions/v1beta1",
+			fields: []checkField{
+				{
+					expected: "apiVersion: extensions/v1beta1",
+				},
+			},
+		},
 	}
 
 	for _, tc := range testcases {

--- a/pkg/kubectl/cmd/convert/import_known_versions.go
+++ b/pkg/kubectl/cmd/convert/import_known_versions.go
@@ -19,6 +19,9 @@ package convert
 // These imports are the API groups the client will support.
 // TODO: Remove these manual install once we don't need legacy scheme in convert
 import (
+	_ "k8s.io/kubernetes/pkg/apis/admission/install"
+	_ "k8s.io/kubernetes/pkg/apis/admissionregistration/install"
+	_ "k8s.io/kubernetes/pkg/apis/apiserverinternal/install"
 	_ "k8s.io/kubernetes/pkg/apis/apps/install"
 	_ "k8s.io/kubernetes/pkg/apis/authentication/install"
 	_ "k8s.io/kubernetes/pkg/apis/authorization/install"
@@ -27,8 +30,13 @@ import (
 	_ "k8s.io/kubernetes/pkg/apis/certificates/install"
 	_ "k8s.io/kubernetes/pkg/apis/coordination/install"
 	_ "k8s.io/kubernetes/pkg/apis/core/install"
+	_ "k8s.io/kubernetes/pkg/apis/discovery/install"
 	_ "k8s.io/kubernetes/pkg/apis/events/install"
 	_ "k8s.io/kubernetes/pkg/apis/extensions/install"
+	_ "k8s.io/kubernetes/pkg/apis/flowcontrol/install"
+	_ "k8s.io/kubernetes/pkg/apis/imagepolicy/install"
+	_ "k8s.io/kubernetes/pkg/apis/networking/install"
+	_ "k8s.io/kubernetes/pkg/apis/node/install"
 	_ "k8s.io/kubernetes/pkg/apis/policy/install"
 	_ "k8s.io/kubernetes/pkg/apis/rbac/install"
 	_ "k8s.io/kubernetes/pkg/apis/scheduling/install"

--- a/pkg/kubectl/cmd/convert/import_known_versions_test.go
+++ b/pkg/kubectl/cmd/convert/import_known_versions_test.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package convert
+
+import (
+	"sort"
+	"strings"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/kubernetes/pkg/api/legacyscheme"
+)
+
+func TestKnownVersions(t *testing.T) {
+	legacytypes := legacyscheme.Scheme.AllKnownTypes()
+	alreadyErroredGroups := map[string]bool{}
+	var gvks []schema.GroupVersionKind
+	for gvk := range scheme.Scheme.AllKnownTypes() {
+		gvks = append(gvks, gvk)
+	}
+	sort.Slice(gvks, func(i, j int) bool {
+		if isWatchEvent1, isWatchEvent2 := gvks[i].Kind == "WatchEvent", gvks[j].Kind == "WatchEvent"; isWatchEvent1 != isWatchEvent2 {
+			return isWatchEvent2
+		}
+		if isList1, isList2 := strings.HasSuffix(gvks[i].Kind, "List"), strings.HasSuffix(gvks[j].Kind, "List"); isList1 != isList2 {
+			return isList2
+		}
+		if isOptions1, isOptions2 := strings.HasSuffix(gvks[i].Kind, "Options"), strings.HasSuffix(gvks[j].Kind, "Options"); isOptions1 != isOptions2 {
+			return isOptions2
+		}
+		if isInternal1, isInternal2 := gvks[i].Group == runtime.APIVersionInternal, gvks[j].Group == runtime.APIVersionInternal; isInternal1 != isInternal2 {
+			return isInternal2
+		}
+		return gvks[i].String() < gvks[j].String()
+	})
+	for _, gvk := range gvks {
+		if alreadyErroredGroups[gvk.Group] {
+			continue
+		}
+		if _, legacyregistered := legacytypes[gvk]; !legacyregistered {
+			t.Errorf("%v is not registered in legacyscheme. Add group %q (all internal and external versions) to convert/import_known_versions.go", gvk, gvk.Group)
+			alreadyErroredGroups[gvk.Group] = true
+		}
+	}
+}

--- a/test/fixtures/pkg/kubectl/cmd/convert/v1beta1ingress.yaml
+++ b/test/fixtures/pkg/kubectl/cmd/convert/v1beta1ingress.yaml
@@ -1,0 +1,15 @@
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: example
+spec:
+  backend:
+    serviceName: default-backend
+    servicePort: 80
+  rules:
+  - http:
+      paths:
+      - path: /testpath
+        backend:
+          serviceName: test
+          servicePort: 80


### PR DESCRIPTION
Cherry pick of #97754 on release-1.20.

#97754: kubectl-convert import known versions

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
kubectl-convert: Fix a regression in 1.20 with `no kind "Ingress" is registered for version` error
```
