### PR TITLE
Fix golint errors for k8s.io/cli-runtime/pkg/genericclioptions/

### DIFF
--- a/hack/.golint_failures
+++ b/hack/.golint_failures
@@ -344,7 +344,6 @@ staging/src/k8s.io/apiserver/plugin/pkg/authenticator/token/oidc
 staging/src/k8s.io/apiserver/plugin/pkg/authenticator/token/tokentest
 staging/src/k8s.io/apiserver/plugin/pkg/authenticator/token/webhook
 staging/src/k8s.io/apiserver/plugin/pkg/authorizer/webhook
-staging/src/k8s.io/cli-runtime/pkg/genericclioptions
 staging/src/k8s.io/cli-runtime/pkg/printers
 staging/src/k8s.io/cli-runtime/pkg/resource
 staging/src/k8s.io/client-go/discovery

--- a/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/builder_flags.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/builder_flags.go
@@ -52,6 +52,9 @@ func NewResourceBuilderFlags() *ResourceBuilderFlags {
 	}
 }
 
+// WithFile sets the FileNameFlags.
+// If recurse is set, it will process directory recursively. Useful when you want to manage related manifests
+// organized within the same directory.
 func (o *ResourceBuilderFlags) WithFile(recurse bool, files ...string) *ResourceBuilderFlags {
 	o.FileNameFlags = &FileNameFlags{
 		Usage:     "identifying the resource.",
@@ -62,41 +65,49 @@ func (o *ResourceBuilderFlags) WithFile(recurse bool, files ...string) *Resource
 	return o
 }
 
+// WithLabelSelector sets the LabelSelector flag
 func (o *ResourceBuilderFlags) WithLabelSelector(selector string) *ResourceBuilderFlags {
 	o.LabelSelector = &selector
 	return o
 }
 
+// WithFieldSelector sets the FieldSelector flag
 func (o *ResourceBuilderFlags) WithFieldSelector(selector string) *ResourceBuilderFlags {
 	o.FieldSelector = &selector
 	return o
 }
 
+// WithAllNamespaces sets the AllNamespaces flag
 func (o *ResourceBuilderFlags) WithAllNamespaces(defaultVal bool) *ResourceBuilderFlags {
 	o.AllNamespaces = &defaultVal
 	return o
 }
 
+// WithAll sets the All flag
 func (o *ResourceBuilderFlags) WithAll(defaultVal bool) *ResourceBuilderFlags {
 	o.All = &defaultVal
 	return o
 }
 
+// WithLocal sets the Local flag
 func (o *ResourceBuilderFlags) WithLocal(defaultVal bool) *ResourceBuilderFlags {
 	o.Local = &defaultVal
 	return o
 }
 
+// WithScheme sets the Scheme flag
 func (o *ResourceBuilderFlags) WithScheme(scheme *runtime.Scheme) *ResourceBuilderFlags {
 	o.Scheme = scheme
 	return o
 }
 
+// WithLatest sets the Latest flag
 func (o *ResourceBuilderFlags) WithLatest() *ResourceBuilderFlags {
 	o.Latest = true
 	return o
 }
 
+// StopOnError sets the StopOnFirstError flag
 func (o *ResourceBuilderFlags) StopOnError() *ResourceBuilderFlags {
 	o.StopOnFirstError = true
 	return o

--- a/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/builder_flags_fake.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/builder_flags_fake.go
@@ -20,7 +20,7 @@ import (
 	"k8s.io/cli-runtime/pkg/resource"
 )
 
-// NewSimpleResourceFinder builds a super simple ResourceFinder that just iterates over the objects you provided
+// NewSimpleFakeResourceFinder builds a super simple ResourceFinder that just iterates over the objects you provided
 func NewSimpleFakeResourceFinder(infos ...*resource.Info) ResourceFinder {
 	return &fakeResourceFinder{
 		Infos: infos,

--- a/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/client_config.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/client_config.go
@@ -23,6 +23,7 @@ import (
 )
 
 var (
+	// ErrEmptyConfig is the error message to be displayed if the configuration info is missing or incomplete
 	ErrEmptyConfig = clientcmd.NewEmptyConfigError(`Missing or incomplete configuration info.  Please point to an existing, complete config file:
 
 

--- a/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/config_flags_fake.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/config_flags_fake.go
@@ -27,12 +27,16 @@ import (
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
 
+// TestConfigFlags contains clientConfig struct
+// and interfaces that implements RESTClientGetter
 type TestConfigFlags struct {
 	clientConfig    clientcmd.ClientConfig
 	discoveryClient discovery.CachedDiscoveryInterface
 	restMapper      meta.RESTMapper
 }
 
+// ToRawKubeConfigLoader implements RESTClientGetter
+// Returns a clientconfig if it's set
 func (f *TestConfigFlags) ToRawKubeConfigLoader() clientcmd.ClientConfig {
 	if f.clientConfig == nil {
 		panic("attempt to obtain a test RawKubeConfigLoader with no clientConfig specified")
@@ -40,14 +44,22 @@ func (f *TestConfigFlags) ToRawKubeConfigLoader() clientcmd.ClientConfig {
 	return f.clientConfig
 }
 
+// ToRESTConfig implements RESTClientGetter.
+// Returns a REST client configuration based on a provided path
+// to a .kubeconfig file, loading rules, and config flag overrides.
+// Expects the AddFlags method to have been called.
 func (f *TestConfigFlags) ToRESTConfig() (*rest.Config, error) {
 	return f.ToRawKubeConfigLoader().ClientConfig()
 }
 
+// ToDiscoveryClient implements RESTClientGetter.
+// Returns a CachedDiscoveryInterface
 func (f *TestConfigFlags) ToDiscoveryClient() (discovery.CachedDiscoveryInterface, error) {
 	return f.discoveryClient, nil
 }
 
+// ToRESTMapper implements RESTClientGetter.
+// Returns a mapper.
 func (f *TestConfigFlags) ToRESTMapper() (meta.RESTMapper, error) {
 	if f.restMapper != nil {
 		return f.restMapper, nil
@@ -60,21 +72,25 @@ func (f *TestConfigFlags) ToRESTMapper() (meta.RESTMapper, error) {
 	return nil, fmt.Errorf("no restmapper")
 }
 
+// WithClientConfig sets the clientConfig flag
 func (f *TestConfigFlags) WithClientConfig(clientConfig clientcmd.ClientConfig) *TestConfigFlags {
 	f.clientConfig = clientConfig
 	return f
 }
 
+// WithRESTMapper sets the restMapper flag
 func (f *TestConfigFlags) WithRESTMapper(mapper meta.RESTMapper) *TestConfigFlags {
 	f.restMapper = mapper
 	return f
 }
 
+// WithDiscoveryClient sets the discoveryClient flag
 func (f *TestConfigFlags) WithDiscoveryClient(c discovery.CachedDiscoveryInterface) *TestConfigFlags {
 	f.discoveryClient = c
 	return f
 }
 
+// WithNamespace sets the clientConfig flag by modifying delagate and namespace
 func (f *TestConfigFlags) WithNamespace(ns string) *TestConfigFlags {
 	if f.clientConfig == nil {
 		panic("attempt to obtain a test RawKubeConfigLoader with no clientConfig specified")
@@ -86,6 +102,7 @@ func (f *TestConfigFlags) WithNamespace(ns string) *TestConfigFlags {
 	return f
 }
 
+// NewTestConfigFlags builds a TestConfigFlags struct to test ConfigFlags
 func NewTestConfigFlags() *TestConfigFlags {
 	return &TestConfigFlags{}
 }

--- a/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/doc.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/doc.go
@@ -14,6 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package genericclioptions contains flags which can be added to you command, bound, completed, and produce
+// Package genericclioptions contains flags which can be added to your command, bound, completed, and produce
 // useful helper functions.  Nothing in this package can depend on kube/kube
 package genericclioptions // import "k8s.io/cli-runtime/pkg/genericclioptions"

--- a/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/filename_flags.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/filename_flags.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/cli-runtime/pkg/resource"
 )
 
+// FileNameFlags are flags for processing files.
 // Usage of this struct by itself is discouraged.
 // These flags are composed by ResourceBuilderFlags
 // which should be used instead.
@@ -36,6 +37,7 @@ type FileNameFlags struct {
 	Recursive *bool
 }
 
+// ToOptions creates a new FileNameOptions struct and sets FilenameOptions based on FileNameflags
 func (o *FileNameFlags) ToOptions() resource.FilenameOptions {
 	options := resource.FilenameOptions{}
 
@@ -56,6 +58,7 @@ func (o *FileNameFlags) ToOptions() resource.FilenameOptions {
 	return options
 }
 
+// AddFlags binds file name flags to a given flagset
 func (o *FileNameFlags) AddFlags(flags *pflag.FlagSet) {
 	if o == nil {
 		return

--- a/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/json_yaml_flags.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/json_yaml_flags.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/cli-runtime/pkg/printers"
 )
 
+// AllowedFormats returns slice of string of allowed JSONYaml printing format
 func (f *JSONYamlPrintFlags) AllowedFormats() []string {
 	if f == nil {
 		return []string{}

--- a/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/jsonpath_flags.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/jsonpath_flags.go
@@ -46,6 +46,7 @@ type JSONPathPrintFlags struct {
 	TemplateArgument *string
 }
 
+// AllowedFormats returns slice of string of allowed JSONPath printing format
 func (f *JSONPathPrintFlags) AllowedFormats() []string {
 	formats := make([]string, 0, len(jsonFormats))
 	for format := range jsonFormats {
@@ -89,7 +90,7 @@ func (f *JSONPathPrintFlags) ToPrinter(templateFormat string) (printers.Resource
 	if templateFormat == "jsonpath-file" {
 		data, err := ioutil.ReadFile(templateValue)
 		if err != nil {
-			return nil, fmt.Errorf("error reading --template %s, %v\n", templateValue, err)
+			return nil, fmt.Errorf("error reading --template %s, %v", templateValue, err)
 		}
 
 		templateValue = string(data)
@@ -97,7 +98,7 @@ func (f *JSONPathPrintFlags) ToPrinter(templateFormat string) (printers.Resource
 
 	p, err := printers.NewJSONPathPrinter(templateValue)
 	if err != nil {
-		return nil, fmt.Errorf("error parsing jsonpath %s, %v\n", templateValue, err)
+		return nil, fmt.Errorf("error parsing jsonpath %s, %v", templateValue, err)
 	}
 
 	allowMissingKeys := true

--- a/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/kube_template_flags.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/kube_template_flags.go
@@ -33,6 +33,7 @@ type KubeTemplatePrintFlags struct {
 	TemplateArgument *string
 }
 
+// AllowedFormats returns slice of string of allowed GoTemplete and JSONPathPrint printing formats
 func (f *KubeTemplatePrintFlags) AllowedFormats() []string {
 	if f == nil {
 		return []string{}
@@ -40,6 +41,10 @@ func (f *KubeTemplatePrintFlags) AllowedFormats() []string {
 	return append(f.GoTemplatePrintFlags.AllowedFormats(), f.JSONPathPrintFlags.AllowedFormats()...)
 }
 
+// ToPrinter receives an outputFormat and returns a printer capable of
+// handling --template printing.
+// Returns false if the specified outputFormat does not match a supported format.
+// Supported Format types can be found in pkg/printers/printers.go
 func (f *KubeTemplatePrintFlags) ToPrinter(outputFormat string) (printers.ResourcePrinter, error) {
 	if f == nil {
 		return nil, NoCompatiblePrinterError{}

--- a/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/name_flags.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/name_flags.go
@@ -35,11 +35,13 @@ type NamePrintFlags struct {
 	Operation string
 }
 
+// Complete sets NamePrintFlags operation flag from sucessTemplate
 func (f *NamePrintFlags) Complete(successTemplate string) error {
 	f.Operation = fmt.Sprintf(successTemplate, f.Operation)
 	return nil
 }
 
+// AllowedFormats returns slice of string of allowed Name printing format
 func (f *NamePrintFlags) AllowedFormats() []string {
 	if f == nil {
 		return []string{}

--- a/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/print_flags.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/print_flags.go
@@ -27,6 +27,8 @@ import (
 	"k8s.io/cli-runtime/pkg/printers"
 )
 
+// NoCompatiblePrinterError is a struct that contains error information.
+// It will be constructed when a invalid printing format is provided
 type NoCompatiblePrinterError struct {
 	OutputFormat   *string
 	AllowedFormats []string
@@ -43,6 +45,8 @@ func (e NoCompatiblePrinterError) Error() string {
 	return fmt.Sprintf("unable to match a printer suitable for the output format %q, allowed formats are: %s", output, strings.Join(e.AllowedFormats, ","))
 }
 
+// IsNoCompatiblePrinterError returns true if it is a not a compatible printer
+// otherwise it will return false
 func IsNoCompatiblePrinterError(err error) bool {
 	if err == nil {
 		return false
@@ -69,10 +73,12 @@ type PrintFlags struct {
 	OutputFlagSpecified func() bool
 }
 
+// Complete sets NamePrintFlags operation flag from sucessTemplate
 func (f *PrintFlags) Complete(successTemplate string) error {
 	return f.NamePrintFlags.Complete(successTemplate)
 }
 
+// AllowedFormats returns slice of string of allowed JSONYaml/Name/Template printing format
 func (f *PrintFlags) AllowedFormats() []string {
 	ret := []string{}
 	ret = append(ret, f.JSONYamlPrintFlags.AllowedFormats()...)
@@ -81,6 +87,10 @@ func (f *PrintFlags) AllowedFormats() []string {
 	return ret
 }
 
+// ToPrinter returns a printer capable of
+// handling --output or --template printing.
+// Returns false if the specified outputFormat does not match a supported format.
+// Supported format types can be found in pkg/printers/printers.go
 func (f *PrintFlags) ToPrinter() (printers.ResourcePrinter, error) {
 	outputFormat := ""
 	if f.OutputFormat != nil {
@@ -118,6 +128,8 @@ func (f *PrintFlags) ToPrinter() (printers.ResourcePrinter, error) {
 	return nil, NoCompatiblePrinterError{OutputFormat: f.OutputFormat, AllowedFormats: f.AllowedFormats()}
 }
 
+// AddFlags receives a *cobra.Command reference and binds
+// flags related to JSON/Yaml/Name/Template printing to it
 func (f *PrintFlags) AddFlags(cmd *cobra.Command) {
 	f.JSONYamlPrintFlags.AddFlags(cmd)
 	f.NamePrintFlags.AddFlags(cmd)
@@ -145,6 +157,7 @@ func (f *PrintFlags) WithTypeSetter(scheme *runtime.Scheme) *PrintFlags {
 	return f
 }
 
+// NewPrintFlags returns a default *PrintFlags
 func NewPrintFlags(operation string) *PrintFlags {
 	outputFormat := ""
 

--- a/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/record_flags.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/record_flags.go
@@ -21,7 +21,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/evanphx/json-patch"
+	jsonpatch "github.com/evanphx/json-patch"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
@@ -74,6 +74,7 @@ func (f *RecordFlags) Complete(cmd *cobra.Command) error {
 	return nil
 }
 
+// CompleteWithChangeCause alters changeCause value with a new cause
 func (f *RecordFlags) CompleteWithChangeCause(cause string) error {
 	if f == nil {
 		return nil

--- a/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/template_flags.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/template_flags.go
@@ -47,6 +47,7 @@ type GoTemplatePrintFlags struct {
 	TemplateArgument *string
 }
 
+// AllowedFormats returns slice of string of allowed GoTemplatePrint printing format
 func (f *GoTemplatePrintFlags) AllowedFormats() []string {
 	formats := make([]string, 0, len(templateFormats))
 	for format := range templateFormats {
@@ -90,7 +91,7 @@ func (f *GoTemplatePrintFlags) ToPrinter(templateFormat string) (printers.Resour
 	if templateFormat == "templatefile" || templateFormat == "go-template-file" {
 		data, err := ioutil.ReadFile(templateValue)
 		if err != nil {
-			return nil, fmt.Errorf("error reading --template %s, %v\n", templateValue, err)
+			return nil, fmt.Errorf("error reading --template %s, %v", templateValue, err)
 		}
 
 		templateValue = string(data)
@@ -98,7 +99,7 @@ func (f *GoTemplatePrintFlags) ToPrinter(templateFormat string) (printers.Resour
 
 	p, err := printers.NewGoTemplatePrinter([]byte(templateValue))
 	if err != nil {
-		return nil, fmt.Errorf("error parsing template %s, %v\n", templateValue, err)
+		return nil, fmt.Errorf("error parsing template %s, %v", templateValue, err)
 	}
 
 	allowMissingKeys := true


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**


/kind cleanup


**What this PR does / why we need it**:
Fix golint errors for `k8s.io/cli-runtime/pkg/genericclioptions/`

```
Errors from golint:
staging/src/k8s.io/cli-runtime/pkg/genericclioptions/builder_flags_fake.go:23:1: comment on exported function NewSimpleFakeResourceFinder should be of the form "NewSimpleFakeResourceFinder ..."
staging/src/k8s.io/cli-runtime/pkg/genericclioptions/builder_flags.go:55:1: exported method ResourceBuilderFlags.WithFile should have comment or be unexported
staging/src/k8s.io/cli-runtime/pkg/genericclioptions/builder_flags.go:65:1: exported method ResourceBuilderFlags.WithLabelSelector should have comment or be unexported
staging/src/k8s.io/cli-runtime/pkg/genericclioptions/builder_flags.go:70:1: exported method ResourceBuilderFlags.WithFieldSelector should have comment or be unexported
staging/src/k8s.io/cli-runtime/pkg/genericclioptions/builder_flags.go:75:1: exported method ResourceBuilderFlags.WithAllNamespaces should have comment or be unexported
staging/src/k8s.io/cli-runtime/pkg/genericclioptions/builder_flags.go:80:1: exported method ResourceBuilderFlags.WithAll should have comment or be unexported
staging/src/k8s.io/cli-runtime/pkg/genericclioptions/builder_flags.go:85:1: exported method ResourceBuilderFlags.WithLocal should have comment or be unexported
staging/src/k8s.io/cli-runtime/pkg/genericclioptions/builder_flags.go:90:1: exported method ResourceBuilderFlags.WithScheme should have comment or be unexported
staging/src/k8s.io/cli-runtime/pkg/genericclioptions/builder_flags.go:95:1: exported method ResourceBuilderFlags.WithLatest should have comment or be unexported
staging/src/k8s.io/cli-runtime/pkg/genericclioptions/builder_flags.go:100:1: exported method ResourceBuilderFlags.StopOnError should have comment or be unexported
staging/src/k8s.io/cli-runtime/pkg/genericclioptions/client_config.go:26:2: exported var ErrEmptyConfig should have comment or be unexported
staging/src/k8s.io/cli-runtime/pkg/genericclioptions/config_flags_fake.go:30:6: exported type TestConfigFlags should have comment or be unexported
staging/src/k8s.io/cli-runtime/pkg/genericclioptions/config_flags_fake.go:36:1: exported method TestConfigFlags.ToRawKubeConfigLoader should have comment or be unexported
staging/src/k8s.io/cli-runtime/pkg/genericclioptions/config_flags_fake.go:43:1: exported method TestConfigFlags.ToRESTConfig should have comment or be unexported
staging/src/k8s.io/cli-runtime/pkg/genericclioptions/config_flags_fake.go:47:1: exported method TestConfigFlags.ToDiscoveryClient should have comment or be unexported
staging/src/k8s.io/cli-runtime/pkg/genericclioptions/config_flags_fake.go:51:1: exported method TestConfigFlags.ToRESTMapper should have comment or be unexported
staging/src/k8s.io/cli-runtime/pkg/genericclioptions/config_flags_fake.go:63:1: exported method TestConfigFlags.WithClientConfig should have comment or be unexported
staging/src/k8s.io/cli-runtime/pkg/genericclioptions/config_flags_fake.go:68:1: exported method TestConfigFlags.WithRESTMapper should have comment or be unexported
staging/src/k8s.io/cli-runtime/pkg/genericclioptions/config_flags_fake.go:73:1: exported method TestConfigFlags.WithDiscoveryClient should have comment or be unexported
staging/src/k8s.io/cli-runtime/pkg/genericclioptions/config_flags_fake.go:78:1: exported method TestConfigFlags.WithNamespace should have comment or be unexported
staging/src/k8s.io/cli-runtime/pkg/genericclioptions/config_flags_fake.go:89:1: exported function NewTestConfigFlags should have comment or be unexported
staging/src/k8s.io/cli-runtime/pkg/genericclioptions/filename_flags.go:28:1: comment on exported type FileNameFlags should be of the form "FileNameFlags ..." (with optional leading article)
staging/src/k8s.io/cli-runtime/pkg/genericclioptions/filename_flags.go:39:1: exported method FileNameFlags.ToOptions should have comment or be unexported
staging/src/k8s.io/cli-runtime/pkg/genericclioptions/filename_flags.go:59:1: exported method FileNameFlags.AddFlags should have comment or be unexported
staging/src/k8s.io/cli-runtime/pkg/genericclioptions/jsonpath_flags.go:49:1: exported method JSONPathPrintFlags.AllowedFormats should have comment or be unexported
staging/src/k8s.io/cli-runtime/pkg/genericclioptions/jsonpath_flags.go:92:27: error strings should not be capitalized or end with punctuation or a newline
staging/src/k8s.io/cli-runtime/pkg/genericclioptions/jsonpath_flags.go:100:26: error strings should not be capitalized or end with punctuation or a newline
staging/src/k8s.io/cli-runtime/pkg/genericclioptions/json_yaml_flags.go:27:1: exported method JSONYamlPrintFlags.AllowedFormats should have comment or be unexported
staging/src/k8s.io/cli-runtime/pkg/genericclioptions/kube_template_flags.go:36:1: exported method KubeTemplatePrintFlags.AllowedFormats should have comment or be unexported
staging/src/k8s.io/cli-runtime/pkg/genericclioptions/kube_template_flags.go:43:1: exported method KubeTemplatePrintFlags.ToPrinter should have comment or be unexported
staging/src/k8s.io/cli-runtime/pkg/genericclioptions/name_flags.go:38:1: exported method NamePrintFlags.Complete should have comment or be unexported
staging/src/k8s.io/cli-runtime/pkg/genericclioptions/name_flags.go:43:1: exported method NamePrintFlags.AllowedFormats should have comment or be unexported
staging/src/k8s.io/cli-runtime/pkg/genericclioptions/print_flags.go:30:6: exported type NoCompatiblePrinterError should have comment or be unexported
staging/src/k8s.io/cli-runtime/pkg/genericclioptions/print_flags.go:46:1: exported function IsNoCompatiblePrinterError should have comment or be unexported
staging/src/k8s.io/cli-runtime/pkg/genericclioptions/print_flags.go:72:1: exported method PrintFlags.Complete should have comment or be unexported
staging/src/k8s.io/cli-runtime/pkg/genericclioptions/print_flags.go:76:1: exported method PrintFlags.AllowedFormats should have comment or be unexported
staging/src/k8s.io/cli-runtime/pkg/genericclioptions/print_flags.go:84:1: exported method PrintFlags.ToPrinter should have comment or be unexported
staging/src/k8s.io/cli-runtime/pkg/genericclioptions/print_flags.go:121:1: exported method PrintFlags.AddFlags should have comment or be unexported
staging/src/k8s.io/cli-runtime/pkg/genericclioptions/print_flags.go:148:1: exported function NewPrintFlags should have comment or be unexported
staging/src/k8s.io/cli-runtime/pkg/genericclioptions/record_flags.go:77:1: exported method RecordFlags.CompleteWithChangeCause should have comment or be unexported
staging/src/k8s.io/cli-runtime/pkg/genericclioptions/template_flags.go:50:1: exported method GoTemplatePrintFlags.AllowedFormats should have comment or be unexported
staging/src/k8s.io/cli-runtime/pkg/genericclioptions/template_flags.go:93:27: error strings should not be capitalized or end with punctuation or a newline
staging/src/k8s.io/cli-runtime/pkg/genericclioptions/template_flags.go:101:26: error strings should not be capitalized or end with punctuation or a newline
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of #68026

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
