### PR TITLE
WIP: Fix container image architecture for conformance image

### DIFF
--- a/cluster/images/conformance/Dockerfile
+++ b/cluster/images/conformance/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM BASEIMAGE
+FROM --platform=linux/ARCH BASEIMAGE
 
 COPY ginkgo /usr/local/bin/
 COPY e2e.test /usr/local/bin/

--- a/cluster/images/conformance/Makefile
+++ b/cluster/images/conformance/Makefile
@@ -34,6 +34,13 @@ CLUSTER_DIR?=$(shell pwd)/../../../cluster/
 BASEIMAGE=debian:stretch-slim
 TEMP_DIR:=$(shell mktemp -d -t conformanceXXXXXX)
 
+# The BASEIMAGE does not support s390x right now.
+ifeq ($(ARCH),s390x)
+FROM_ARCH=amd64
+else
+FROM_ARCH=$(ARCH)
+endif
+
 all: build
 
 build:
@@ -54,7 +61,9 @@ endif
 	chmod a+rx ${TEMP_DIR}/e2e.test
 	chmod a+rx ${TEMP_DIR}/gorunner
 
-	cd ${TEMP_DIR} && sed -i.back "s|BASEIMAGE|${BASEIMAGE}|g" Dockerfile
+	cd ${TEMP_DIR} && \
+		sed -i.back "s|BASEIMAGE|${BASEIMAGE}|g" Dockerfile && \
+		sed -i.back "s|ARCH|${FROM_ARCH}|g" Dockerfile
 
 	docker build --pull -t ${REGISTRY}/conformance-${ARCH}:${VERSION} ${TEMP_DIR}
 	rm -rf "${TEMP_DIR}"


### PR DESCRIPTION

**What type of PR is this?**

/kind bug


**What this PR does / why we need it**:
We have to specify the target platform when choosing the `FROM` image in
the conformance `Dockerfile`. Otherwise the image architecture would
always result in the host architecture, which is likely to fallback to
`amd64`.
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubernetes/issues/89554

**Special notes for your reviewer**:
/hold I have to do some manual tests with this PR
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixed non amd64 conformance images to contain the correct architecture in the container image manifest.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```
