### PR TITLE
fix apf controller unit test

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/apf_controller.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/apf_controller.go
@@ -234,13 +234,6 @@ func (cfgCtlr *configController) updateObservations() {
 	}
 }
 
-// used from the unit tests only.
-func (cfgCtlr *configController) getPriorityLevelState(plName string) *priorityLevelState {
-	cfgCtlr.lock.Lock()
-	defer cfgCtlr.lock.Unlock()
-	return cfgCtlr.priorityLevelStates[plName]
-}
-
 func (cfgCtlr *configController) Run(stopCh <-chan struct{}) error {
 	defer utilruntime.HandleCrash()
 


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:
- don't expose the internal states of the apf controller to the caller
- return a boolean, instead of the priority level states

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs

```
