### PR TITLE
migrate winkernel network type string "overlay" as const

### DIFF
--- a/pkg/proxy/winkernel/hns_test.go
+++ b/pkg/proxy/winkernel/hns_test.go
@@ -27,17 +27,19 @@ import (
 	"testing"
 )
 
-const sourceVip = "192.168.1.2"
-const serviceVip = "11.0.0.1"
-const addressPrefix = "192.168.1.0/24"
-const gatewayAddress = "192.168.1.1"
-const epMacAddress = "00-11-22-33-44-55"
-const epIpAddress = "192.168.1.3"
-const epIpAddressRemote = "192.168.2.3"
-const epPaAddress = "10.0.0.3"
-const protocol = 6
-const internalPort = 80
-const externalPort = 32440
+const (
+	sourceVip         = "192.168.1.2"
+	serviceVip        = "11.0.0.1"
+	addressPrefix     = "192.168.1.0/24"
+	gatewayAddress    = "192.168.1.1"
+	epMacAddress      = "00-11-22-33-44-55"
+	epIpAddress       = "192.168.1.3"
+	epIpAddressRemote = "192.168.2.3"
+	epPaAddress       = "10.0.0.3"
+	protocol          = 6
+	internalPort      = 80
+	externalPort      = 32440
+)
 
 func TestGetNetworkByName(t *testing.T) {
 	hnsV1 := hnsV1{}
@@ -484,7 +486,7 @@ func mustTestNetwork(t *testing.T) *hcn.HostComputeNetwork {
 }
 func createTestNetwork() (*hcn.HostComputeNetwork, error) {
 	network := &hcn.HostComputeNetwork{
-		Type: "Overlay",
+		Type: NETWORK_TYPE_OVERLAY,
 		Name: "TestOverlay",
 		MacPool: hcn.MacPool{
 			Ranges: []hcn.MacRange{

--- a/pkg/proxy/winkernel/proxier_test.go
+++ b/pkg/proxy/winkernel/proxier_test.go
@@ -35,12 +35,14 @@ import (
 	"time"
 )
 
-const testHostName = "test-hostname"
-const macAddress = "00-11-22-33-44-55"
-const clusterCIDR = "192.168.1.0/24"
-const destinationPrefix = "192.168.2.0/24"
-const providerAddress = "10.0.0.3"
-const guid = "123ABC"
+const (
+	testHostName      = "test-hostname"
+	macAddress        = "00-11-22-33-44-55"
+	clusterCIDR       = "192.168.1.0/24"
+	destinationPrefix = "192.168.2.0/24"
+	providerAddress   = "10.0.0.3"
+	guid              = "123ABC"
+)
 
 type fakeHNS struct{}
 
@@ -60,7 +62,7 @@ func (hns fakeHNS) getNetworkByName(name string) (*hnsNetworkInfo, error) {
 	return &hnsNetworkInfo{
 		id:            strings.ToUpper(guid),
 		name:          name,
-		networkType:   "Overlay",
+		networkType:   NETWORK_TYPE_OVERLAY,
 		remoteSubnets: remoteSubnets,
 	}, nil
 }
@@ -142,7 +144,7 @@ func NewFakeProxier(syncPeriod time.Duration, minSyncPeriod time.Duration, clust
 
 func TestCreateServiceVip(t *testing.T) {
 	syncPeriod := 30 * time.Second
-	proxier := NewFakeProxier(syncPeriod, syncPeriod, clusterCIDR, "testhost", net.ParseIP("10.0.0.1"), "Overlay", false)
+	proxier := NewFakeProxier(syncPeriod, syncPeriod, clusterCIDR, "testhost", net.ParseIP("10.0.0.1"), NETWORK_TYPE_OVERLAY, false)
 	if proxier == nil {
 		t.Error()
 	}
@@ -198,7 +200,7 @@ func TestCreateServiceVip(t *testing.T) {
 
 func TestCreateRemoteEndpointOverlay(t *testing.T) {
 	syncPeriod := 30 * time.Second
-	proxier := NewFakeProxier(syncPeriod, syncPeriod, clusterCIDR, "testhost", net.ParseIP("10.0.0.1"), "Overlay", false)
+	proxier := NewFakeProxier(syncPeriod, syncPeriod, clusterCIDR, "testhost", net.ParseIP("10.0.0.1"), NETWORK_TYPE_OVERLAY, false)
 	if proxier == nil {
 		t.Error()
 	}
@@ -649,7 +651,7 @@ func TestSharedRemoteEndpointUpdate(t *testing.T) {
 }
 func TestCreateLoadBalancer(t *testing.T) {
 	syncPeriod := 30 * time.Second
-	proxier := NewFakeProxier(syncPeriod, syncPeriod, clusterCIDR, "testhost", net.ParseIP("10.0.0.1"), "Overlay", false)
+	proxier := NewFakeProxier(syncPeriod, syncPeriod, clusterCIDR, "testhost", net.ParseIP("10.0.0.1"), NETWORK_TYPE_OVERLAY, false)
 	if proxier == nil {
 		t.Error()
 	}
@@ -708,7 +710,7 @@ func TestCreateLoadBalancer(t *testing.T) {
 
 func TestCreateDsrLoadBalancer(t *testing.T) {
 	syncPeriod := 30 * time.Second
-	proxier := NewFakeProxier(syncPeriod, syncPeriod, clusterCIDR, "testhost", net.ParseIP("10.0.0.1"), "Overlay", false)
+	proxier := NewFakeProxier(syncPeriod, syncPeriod, clusterCIDR, "testhost", net.ParseIP("10.0.0.1"), NETWORK_TYPE_OVERLAY, false)
 	if proxier == nil {
 		t.Error()
 	}
@@ -770,7 +772,7 @@ func TestCreateDsrLoadBalancer(t *testing.T) {
 
 func TestEndpointSlice(t *testing.T) {
 	syncPeriod := 30 * time.Second
-	proxier := NewFakeProxier(syncPeriod, syncPeriod, clusterCIDR, "testhost", net.ParseIP("10.0.0.1"), "Overlay", true)
+	proxier := NewFakeProxier(syncPeriod, syncPeriod, clusterCIDR, "testhost", net.ParseIP("10.0.0.1"), NETWORK_TYPE_OVERLAY, true)
 	if proxier == nil {
 		t.Error()
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind cleanup

**What this PR does / why we need it**:

migrate winkernel network type string "overlay" as const.
make it looks more standard.

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
