### PR TITLE
[jsonpath] fix wrong output when using jsonpath

### DIFF
--- a/staging/src/k8s.io/client-go/util/jsonpath/jsonpath.go
+++ b/staging/src/k8s.io/client-go/util/jsonpath/jsonpath.go
@@ -132,6 +132,9 @@ func (j *JSONPath) FindResults(data interface{}) ([][]reflect.Value, error) {
 			}
 			continue
 		}
+		if len(results) == 0 {
+			break
+		}
 		fullResult = append(fullResult, results)
 	}
 	return fullResult, nil

--- a/staging/src/k8s.io/client-go/util/jsonpath/jsonpath_test.go
+++ b/staging/src/k8s.io/client-go/util/jsonpath/jsonpath_test.go
@@ -760,6 +760,64 @@ func TestNegativeIndex(t *testing.T) {
 	)
 }
 
+func TestRunningPodsJSONPathOutput(t *testing.T) {
+	var input = []byte(`{
+		"kind": "List",
+		"items": [
+			{
+				"kind": "Pod",
+				"metadata": {
+					"name": "pod1"
+				},
+				"status": {
+						"phase": "Running"
+				}
+			},
+			{
+				"kind": "Pod",
+				"metadata": {
+					"name": "pod2"
+				},
+				"status": {
+						"phase": "Running"
+				}
+			},
+			{
+				"kind": "Pod",
+				"metadata": {
+					"name": "pod3"
+				},
+				"status": {
+						"phase": "Running"
+				}
+			},
+           		{
+				"resourceVersion": "",
+				"selfLink": ""
+			}
+		]
+	}`)
+	var data interface{}
+	err := json.Unmarshal(input, &data)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	testJSONPath(
+		[]jsonpathTest{
+			{
+				"when range is used in a certain way in script, additional line is printed",
+				`{range .items[?(.status.phase=="Running")]}{.metadata.name}{" is Running\n"}`,
+				data,
+				"pod1 is Running\npod2 is Running\npod3 is Running\n",
+				false, // expect no error
+			},
+		},
+		true, // allow missing keys
+		t,
+	)
+}
+
 func TestStep(t *testing.T) {
 	var input = []byte(
 		`{


### PR DESCRIPTION
/kind bug

**Which issue(s) this PR fixes**:
Fix range loop when using jsonpath

Without patch:

```
kubectl get -n openshift-oauth-apiserver po -o jsonpath='{range .items[?(.status.phase=="Running")]}{.metadata.name}{" is Running\n"}'
apiserver-7d9cc97649-79c2x is Running
apiserver-7d9cc97649-lgks6 is Running
apiserver-7d9cc97649-qgkxn is Running
 is Running
```

With patch:

```
kubectl get -n openshift-oauth-apiserver po -o jsonpath='{range .items[?(.status.phase=="Running")]}{.metadata.name}{" is Running\n"}'
apiserver-7d9cc97649-79c2x is Running
apiserver-7d9cc97649-lgks6 is Running
apiserver-7d9cc97649-qgkxn is Running
```

Fixes BZ#1900755
