### PR TITLE
[kube-controller-manager] Lower timeout for leaderelection resourcelock

### DIFF
--- a/cmd/kube-controller-manager/app/config/config.go
+++ b/cmd/kube-controller-manager/app/config/config.go
@@ -40,9 +40,6 @@ type Config struct {
 	// the general kube client
 	Client *clientset.Clientset
 
-	// the client only used for leader election
-	LeaderElectionClient *clientset.Clientset
-
 	// the rest config for the master
 	Kubeconfig *restclient.Config
 

--- a/cmd/kube-controller-manager/app/controllermanager.go
+++ b/cmd/kube-controller-manager/app/controllermanager.go
@@ -270,15 +270,15 @@ func Run(c *config.CompletedConfig, stopCh <-chan struct{}) error {
 	// add a uniquifier so that two processes on the same host don't accidentally both become active
 	id = id + "_" + string(uuid.NewUUID())
 
-	rl, err := resourcelock.New(c.ComponentConfig.Generic.LeaderElection.ResourceLock,
+	rl, err := resourcelock.NewFromKubeconfig(c.ComponentConfig.Generic.LeaderElection.ResourceLock,
 		c.ComponentConfig.Generic.LeaderElection.ResourceNamespace,
 		c.ComponentConfig.Generic.LeaderElection.ResourceName,
-		c.LeaderElectionClient.CoreV1(),
-		c.LeaderElectionClient.CoordinationV1(),
 		resourcelock.ResourceLockConfig{
 			Identity:      id,
 			EventRecorder: c.EventRecorder,
-		})
+		},
+		c.Kubeconfig,
+		c.ComponentConfig.Generic.LeaderElection.RenewDeadline.Duration)
 	if err != nil {
 		klog.Fatalf("error creating lock: %v", err)
 	}

--- a/cmd/kube-controller-manager/app/options/options.go
+++ b/cmd/kube-controller-manager/app/options/options.go
@@ -441,18 +441,12 @@ func (s KubeControllerManagerOptions) Config(allControllers []string, disabledBy
 		return nil, err
 	}
 
-	// shallow copy, do not modify the kubeconfig.Timeout.
-	config := *kubeconfig
-	config.Timeout = s.Generic.LeaderElection.RenewDeadline.Duration
-	leaderElectionClient := clientset.NewForConfigOrDie(restclient.AddUserAgent(&config, "leader-election"))
-
 	eventRecorder := createRecorder(client, KubeControllerManagerUserAgent)
 
 	c := &kubecontrollerconfig.Config{
-		Client:               client,
-		Kubeconfig:           kubeconfig,
-		EventRecorder:        eventRecorder,
-		LeaderElectionClient: leaderElectionClient,
+		Client:        client,
+		Kubeconfig:    kubeconfig,
+		EventRecorder: eventRecorder,
 	}
 	if err := s.ApplyTo(c); err != nil {
 		return nil, err


### PR DESCRIPTION
Migrate how resource lock and leader election config is generated to new way, hidding kubeClient. This also halfs kubeClient timeout, making it an useful value.

If timeout is equal to RenewDeadline and we hit client timeout on request, there will be no retry, as RenewDeadline part will cancel the context and lose leader election. So setting a timeout to value at least equal to RenewDeadline is pointless.

Setting it as half of RenewDeadline is a heuristic to resolve this missing retry problem without adding additional parameter.
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

1. Migrate to new unified way to create leader election configs.
1. Reduce timeout for client used in resource lock, making it an useful value that can kick in before renew deadline

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

Adding comment to function in #98058
