### PR TITLE
e2e: Refactor node querying to use a fluent interface

### DIFF
--- a/test/e2e/autoscaling/dns_autoscaling.go
+++ b/test/e2e/autoscaling/dns_autoscaling.go
@@ -237,13 +237,13 @@ func getExpectReplicasFuncLinear(c clientset.Interface, params *DNSParamsLinear)
 	return func(c clientset.Interface) int {
 		var replicasFromNodes float64
 		var replicasFromCores float64
-		nodes, err := e2enode.GetReadySchedulableNodes(c)
+		nodes, err := e2enode.Nodes().WhereSchedulable().Items(c)
 		framework.ExpectNoError(err)
 		if params.nodesPerReplica > 0 {
-			replicasFromNodes = math.Ceil(float64(len(nodes.Items)) / params.nodesPerReplica)
+			replicasFromNodes = math.Ceil(float64(len(nodes)) / params.nodesPerReplica)
 		}
 		if params.coresPerReplica > 0 {
-			replicasFromCores = math.Ceil(float64(getSchedulableCores(nodes.Items)) / params.coresPerReplica)
+			replicasFromCores = math.Ceil(float64(getSchedulableCores(nodes)) / params.coresPerReplica)
 		}
 		return int(math.Max(1.0, math.Max(replicasFromNodes, replicasFromCores)))
 	}


### PR DESCRIPTION
This should make the code more explicit and readable; avoiding having
to create special-case functions for each set of node attributes we
care about.

Splitting out the refactor from the fix in #97815, per https://github.com/kubernetes/kubernetes/pull/97815#discussion_r555377733

/kind cleanup

```release-note
NONE
```