### PR TITLE
(e2e/scheduler) Ensure minimum memory limit in createBalancedPodForNodes

### DIFF
--- a/test/e2e/scheduling/priorities.go
+++ b/test/e2e/scheduling/priorities.go
@@ -54,6 +54,11 @@ type Resource struct {
 
 var balancePodLabel = map[string]string{"name": "priority-balanced-memory"}
 
+// track min memory limit based on crio minimum. pods cannot set a limit lower than this
+// see: https://github.com/cri-o/cri-o/blob/29805b13e9a43d9d22628553db337ce1c1bec0a8/internal/config/cgmgr/cgmgr.go#L23
+// see: https://bugzilla.redhat.com/show_bug.cgi?id=1595256
+var crioMinMemLimit = 12 * 1024 * 1024
+
 var podRequestedResource = &v1.ResourceRequirements{
 	Limits: v1.ResourceList{
 		v1.ResourceMemory: resource.MustParse("100Mi"),
@@ -120,6 +125,19 @@ func removeAvoidPodsOffNode(c clientset.Interface, nodeName string) {
 	framework.ExpectNoError(err)
 }
 
+// nodesAreTooUtilized ensures that each node can support 2*crioMinMemLimit
+// We check for double because it needs to support at least the cri-o minimum
+// plus whatever delta between node usages (which could be up to or at least crioMinMemLimit)
+func nodesAreTooUtilized(cs clientset.Interface, nodeList *v1.NodeList) bool {
+	for _, node := range nodeList.Items {
+		_, memFraction, _, memAllocatable := computeCPUMemFraction(cs, node, podRequestedResource)
+		if float64(memAllocatable)-(memFraction*float64(memAllocatable)) < float64(2*crioMinMemLimit) {
+			return true
+		}
+	}
+	return false
+}
+
 // This test suite is used to verifies scheduler priority functions based on the default provider
 var _ = SIGDescribe("SchedulerPriorities [Serial]", func() {
 	var cs clientset.Interface
@@ -148,6 +166,12 @@ var _ = SIGDescribe("SchedulerPriorities [Serial]", func() {
 		framework.ExpectNoError(err)
 		err = e2epod.WaitForPodsRunningReady(cs, metav1.NamespaceSystem, int32(systemPodsNo), 0, framework.PodReadyBeforeTimeout, map[string]string{})
 		framework.ExpectNoError(err)
+
+		// skip if the most utilized node has less than the cri-o minMemLimit available
+		// otherwise we will not be able to run the test pod once all nodes are balanced
+		if nodesAreTooUtilized(cs, nodeList) {
+			ginkgo.Skip("nodes are too utilized to schedule test pods")
+		}
 	})
 
 	ginkgo.It("Pod should be scheduled to node that don't match the PodAntiAffinity terms", func() {
@@ -430,8 +454,9 @@ func createBalancedPodForNodes(f *framework.Framework, cs clientset.Interface, n
 	var maxCPUFraction, maxMemFraction float64 = ratio, ratio
 	var cpuFractionMap = make(map[string]float64)
 	var memFractionMap = make(map[string]float64)
+
 	for _, node := range nodes {
-		cpuFraction, memFraction := computeCPUMemFraction(cs, node, requestedResource)
+		cpuFraction, memFraction, _, _ := computeCPUMemFraction(cs, node, requestedResource)
 		cpuFractionMap[node.Name] = cpuFraction
 		memFractionMap[node.Name] = memFraction
 		if cpuFraction > maxCPUFraction {
@@ -441,6 +466,7 @@ func createBalancedPodForNodes(f *framework.Framework, cs clientset.Interface, n
 			maxMemFraction = memFraction
 		}
 	}
+
 	// we need the max one to keep the same cpu/mem use rate
 	ratio = math.Max(maxCPUFraction, maxMemFraction)
 	for _, node := range nodes {
@@ -457,7 +483,8 @@ func createBalancedPodForNodes(f *framework.Framework, cs clientset.Interface, n
 		memFraction := memFractionMap[node.Name]
 		needCreateResource[v1.ResourceCPU] = *resource.NewMilliQuantity(int64((ratio-cpuFraction)*float64(cpuAllocatableMil)), resource.DecimalSI)
 
-		needCreateResource[v1.ResourceMemory] = *resource.NewQuantity(int64((ratio-memFraction)*float64(memAllocatableVal)), resource.BinarySI)
+		// add crioMinMemLimit to ensure that all pods are setting at least that much for a limit, while keeping the same ratios
+		needCreateResource[v1.ResourceMemory] = *resource.NewQuantity(int64((ratio-memFraction)*float64(memAllocatableVal)+float64(crioMinMemLimit)), resource.BinarySI)
 
 		podConfig := &pausePodConfig{
 			Name:   "",
@@ -497,7 +524,7 @@ func createBalancedPodForNodes(f *framework.Framework, cs clientset.Interface, n
 	return nil
 }
 
-func computeCPUMemFraction(cs clientset.Interface, node v1.Node, resource *v1.ResourceRequirements) (float64, float64) {
+func computeCPUMemFraction(cs clientset.Interface, node v1.Node, resource *v1.ResourceRequirements) (float64, float64, int64, int64) {
 	framework.Logf("ComputeCPUMemFraction for node: %v", node.Name)
 	totalRequestedCPUResource := resource.Requests.Cpu().MilliValue()
 	totalRequestedMemResource := resource.Requests.Memory().Value()
@@ -536,7 +563,7 @@ func computeCPUMemFraction(cs clientset.Interface, node v1.Node, resource *v1.Re
 	framework.Logf("Node: %v, totalRequestedCPUResource: %v, cpuAllocatableMil: %v, cpuFraction: %v", node.Name, totalRequestedCPUResource, cpuAllocatableMil, cpuFraction)
 	framework.Logf("Node: %v, totalRequestedMemResource: %v, memAllocatableVal: %v, memFraction: %v", node.Name, totalRequestedMemResource, memAllocatableVal, memFraction)
 
-	return cpuFraction, memFraction
+	return cpuFraction, memFraction, cpuAllocatableMil, memAllocatableVal
 }
 
 func getNonZeroRequests(pod *v1.Pod) Resource {


### PR DESCRIPTION
**What type of PR is this?**
/kind flake

**What this PR does / why we need it**:
In order to properly test scheduler priorities (score plugins) it is necessary to create a completely balanced environment, otherwise differences in resource consumption could skew scheduler scoring decisions.

These e2es accomplish this with `createBalancedPodForNodes`, which only looks at the most-utilized node and attempts to create pods with resource requests/limits that bring all nodes to equal consumption.

However, if some nodes are very close in utilization to the highest-utlilzed node, the limits may be less than the [CRI-O minimum memory limit of 12MB](https://github.com/cri-o/cri-o/blob/29805b13e9a43d9d22628553db337ce1c1bec0a8/internal/config/cgmgr/cgmgr.go#L23). This causes the pods to fail to run with errors like:
```
Jan 14 11:25:05.737: INFO: At 2021-01-14 11:15:05 +0000 UTC - event for 50e260ab-f274-4c97-abce-e28f5ef188ef-0: {kubelet ip-10-0-199-24.us-east-2.compute.internal} FailedCreatePodSandBox: Failed to create pod sandbox: rpc error: code = Unknown desc = pod set memory limit 10485760 too low; should be at least 12582912
```
(from an OpenShift CI cluster: https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_kubernetes/494/pull-ci-openshift-kubernetes-master-e2e-aws-serial/1349654189046763520)

This PR fixes this with the following changes:
1. Ensure all nodes have available memory to support `2 * cri-o minMemLimit` (checking for double because it needs to support both a balancing pod AND the test pod itself). If not, skip the tests
2. Create a pod that will use the minMemLimit on the highest-utilized node. This ensures that the balancing pods created for all smaller nodes will set at least this much for their memory limit

```release-note
NONE
```

/sig scheduling