### PR TITLE
Repair pigz URL for Windows GCE nodes

### DIFF
--- a/cluster/gce/windows/k8s-node-setup.psm1
+++ b/cluster/gce/windows/k8s-node-setup.psm1
@@ -1535,7 +1535,7 @@ function Start_Containerd {
 # Pigz Resources
 $PIGZ_ROOT = 'C:\pigz'
 $PIGZ_VERSION = '2.3.1'
-$PIGZ_TAR_URL = 'https://storage.googleapis.com/gke-release/winnode/pigz/prod/gke_windows/pigz/release/5/20201104-134221/pigz-$PIGZ_VERSION.zip'
+$PIGZ_TAR_URL = "https://storage.googleapis.com/gke-release/winnode/pigz/prod/gke_windows/pigz/release/5/20201104-134221/pigz-$PIGZ_VERSION.zip"
 $PIGZ_TAR_HASH = '5a6f8f5530acc85ea51797f58c1409e5af6b69e55da243ffc608784cf14fec0cd16f74cc61c564d69e1a267750aecfc1e4c53b5219ff5f893b42a7576306f34c'
 
 # Install Pigz (https://github.com/madler/pigz) into Windows for improved image


### PR DESCRIPTION
New Windows nodes are failing to start with:

windows-startup-script-ps1: Failed to download file from https://storage.googleapis.com/gke-release/winnode/pigz/prod/gke_windows/pigz/release/5/20201104-134221/pigz-$PIGZ_VERSION.zip.

With this fix, the nodes start successfully.

/kind bug

Follow-up to https://github.com/kubernetes/kubernetes/pull/96470.

```release-note
NONE
```