### PR TITLE
Add UT for volume metrics OperationCompleteHook func

### DIFF
--- a/pkg/volume/util/BUILD
+++ b/pkg/volume/util/BUILD
@@ -75,6 +75,8 @@ go_test(
         "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",
         "//staging/src/k8s.io/component-base/featuregate/testing:go_default_library",
+        "//staging/src/k8s.io/component-base/metrics/legacyregistry:go_default_library",
+        "//staging/src/k8s.io/component-base/metrics/testutil:go_default_library",
         "//vendor/k8s.io/utils/pointer:go_default_library",
     ] + select({
         "@io_bazel_rules_go//go/platform:android": [

--- a/pkg/volume/util/metrics.go
+++ b/pkg/volume/util/metrics.go
@@ -61,7 +61,7 @@ var storageOperationErrorMetric = metrics.NewCounterVec(
 
 var storageOperationStatusMetric = metrics.NewCounterVec(
 	&metrics.CounterOpts{
-		Name:           "storage_operation_status_count",
+		Name:           "storage_operation_status_total",
 		Help:           "Storage operation return statuses count",
 		StabilityLevel: metrics.ALPHA,
 	},

--- a/pkg/volume/util/operationexecutor/operation_generator_test.go
+++ b/pkg/volume/util/operationexecutor/operation_generator_test.go
@@ -82,7 +82,7 @@ func TestOperationGenerator_GenerateUnmapVolumeFunc_PluginName(t *testing.T) {
 			t.Fatalf("Error occurred while generating unmapVolumeFunc: %v", e)
 		}
 
-		metricFamilyName := "storage_operation_status_count"
+		metricFamilyName := "storage_operation_status_total"
 		labelFilter := map[string]string{
 			"status":         "success",
 			"operation_name": "unmap_volume",

--- a/test/e2e/storage/volume_metrics.go
+++ b/test/e2e/storage/volume_metrics.go
@@ -641,7 +641,7 @@ func getControllerStorageMetrics(ms e2emetrics.ControllerManagerMetrics, pluginN
 				}
 				result.latencyMetrics[operation] = count
 			}
-		case "storage_operation_status_count":
+		case "storage_operation_status_total":
 			for _, sample := range samples {
 				count := int64(sample.Value)
 				operation := string(sample.Metric["operation_name"])


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup 

**What this PR does / why we need it**:

Add UT for metrics OperationCompleteHook func
At the same time, metrics rename `storage_operation_status_count` to `storage_operation_status_total`  to suit the rules

result as fellow:
```
 > go test -run TestOperationCompleteHook ./pkg/volume/util -v     
=== RUN   TestOperationCompleteHook
=== RUN   TestOperationCompleteHook/operation_complete_without_error
=== RUN   TestOperationCompleteHook/operation_complete_with_error
--- PASS: TestOperationCompleteHook (0.00s)
    --- PASS: TestOperationCompleteHook/operation_complete_without_error (0.00s)
    --- PASS: TestOperationCompleteHook/operation_complete_with_error (0.00s)
PASS
ok  	k8s.io/kubernetes/pkg/volume/util	0.021s
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes  https://github.com/kubernetes/kubernetes/pull/95892#issuecomment-721345338

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
metrics rename `storage_operation_status_count` to `storage_operation_status_total`  to make it standard.
```

