### PR TITLE
staging\src\k8s.io\apiserver\pkg\endpoints: migrate to structured logs

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/filters/authentication.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/filters/authentication.go
@@ -50,7 +50,7 @@ func WithAuthentication(handler http.Handler, auth authenticator.Request, failed
 		defer recordAuthMetrics(resp, ok, err, apiAuds, authenticationStart)
 		if err != nil || !ok {
 			if err != nil {
-				klog.Errorf("Unable to authenticate the request due to an error: %v", err)
+				klog.ErrorS(err, "Unable to authenticate the request")
 			}
 			failed.ServeHTTP(w, req)
 			return

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/filters/authorization.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/filters/authorization.go
@@ -70,7 +70,7 @@ func WithAuthorization(handler http.Handler, a authorizer.Authorizer, s runtime.
 			return
 		}
 
-		klog.V(4).Infof("Forbidden: %#v, Reason: %q", req.RequestURI, reason)
+		klog.V(4).InfoS("Forbidden", "URI", req.RequestURI, "Reason", reason)
 		audit.LogAnnotation(ae, decisionAnnotationKey, decisionForbid)
 		audit.LogAnnotation(ae, reasonAnnotationKey, reason)
 		responsewriters.Forbidden(ctx, attributes, w, req, reason, s)

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/filters/impersonation.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/filters/impersonation.go
@@ -104,14 +104,14 @@ func WithImpersonation(handler http.Handler, a authorizer.Authorizer, s runtime.
 				userExtra[extraKey] = append(userExtra[extraKey], extraValue)
 
 			default:
-				klog.V(4).Infof("unknown impersonation request type: %v", impersonationRequest)
+				klog.V(4).InfoS("unknown impersonation request type", "Request", impersonationRequest)
 				responsewriters.Forbidden(ctx, actingAsAttributes, w, req, fmt.Sprintf("unknown impersonation request type: %v", impersonationRequest), s)
 				return
 			}
 
 			decision, reason, err := a.Authorize(ctx, actingAsAttributes)
 			if err != nil || decision != authorizer.DecisionAllow {
-				klog.V(4).Infof("Forbidden: %#v, Reason: %s, Error: %v", req.RequestURI, reason, err)
+				klog.V(4).InfoS("Forbidden", "URI", req.RequestURI, "Reason", reason, "Error", err)
 				responsewriters.Forbidden(ctx, actingAsAttributes, w, req, reason, s)
 				return
 			}

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/fieldmanager.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/fieldmanager.go
@@ -183,9 +183,8 @@ func (f *FieldManager) UpdateNoErrors(liveObj, newObj runtime.Object, manager st
 	obj, err := f.Update(liveObj, newObj, manager)
 	if err != nil {
 		atMostEverySecond.Do(func() {
-			klog.Errorf("[SHOULD NOT HAPPEN] failed to update managedFields for %v: %v",
-				newObj.GetObjectKind().GroupVersionKind(),
-				err)
+			klog.ErrorS(err, "[SHOULD NOT HAPPEN] failed to update managedFields", "VersionKind",
+				newObj.GetObjectKind().GroupVersionKind())
 		})
 		// Explicitly remove managedFields on failure, so that
 		// we can't have garbage in it.

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/rest.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/rest.go
@@ -429,7 +429,7 @@ func setObjectSelfLink(ctx context.Context, obj runtime.Object, req *http.Reques
 		return err
 	}
 	if err := namer.SetSelfLink(obj, uri); err != nil {
-		klog.V(4).Infof("Unable to set self link on object: %v", err)
+		klog.V(4).InfoS("Unable to set self link on object", "error", err)
 	}
 	requestInfo, ok := request.RequestInfoFrom(ctx)
 	if !ok {
@@ -493,7 +493,8 @@ func parseTimeout(str string) time.Duration {
 		if err == nil {
 			return timeout
 		}
-		klog.Errorf("Failed to parse %q: %v", str, err)
+
+		klog.ErrorS(err, "Failed to parse", "time", str)
 	}
 	// 34 chose as a number close to 30 that is likely to be unique enough to jump out at me the next time I see a timeout.  Everyone chooses 30.
 	return 34 * time.Second

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/request/requestinfo.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/request/requestinfo.go
@@ -211,7 +211,7 @@ func (r *RequestInfoFactory) NewRequestInfo(req *http.Request) (*RequestInfo, er
 		opts := metainternalversion.ListOptions{}
 		if err := metainternalversionscheme.ParameterCodec.DecodeParameters(req.URL.Query(), metav1.SchemeGroupVersion, &opts); err != nil {
 			// An error in parsing request will result in default to "list" and not setting "name" field.
-			klog.Errorf("Couldn't parse request %#v: %v", req.URL.Query(), err)
+			klog.ErrorS(err, "Couldn't parse request", "Request", req.URL.Query())
 			// Reset opts to not rely on partial results from parsing.
 			// However, if watch is set, let's report it.
 			opts = metainternalversion.ListOptions{}


### PR DESCRIPTION
Migrate to structured logs

File modified:
staging/src/k8s.io/apiserver/pkg/endpoints

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Ref:

keps/sig-instrumentation/1602-structured-logging
Structured Logging migration instructions

**Which issue(s) this PR fixes**:
Ref:

keps/sig-instrumentation/1602-structured-logging
Structured Logging migration instructions

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
