### PR TITLE
bump agnhost to 2.26

### DIFF
--- a/build/dependencies.yaml
+++ b/build/dependencies.yaml
@@ -10,7 +10,7 @@ dependencies:
 
   # then after merge and successful postsubmit image push / promotion, bump this
   - name: "agnhost: dependents"
-    version: "2.21"
+    version: "2.26"
     refPaths:
     - path: test/utils/image/manifest.go
       match: configs\[Agnhost\] = Config{promoterE2eRegistry, "agnhost", "\d+\.\d+"}

--- a/test/utils/image/manifest.go
+++ b/test/utils/image/manifest.go
@@ -212,7 +212,7 @@ const (
 
 func initImageConfigs() (map[int]Config, map[int]Config) {
 	configs := map[int]Config{}
-	configs[Agnhost] = Config{promoterE2eRegistry, "agnhost", "2.21"}
+	configs[Agnhost] = Config{promoterE2eRegistry, "agnhost", "2.26"}
 	configs[AgnhostPrivate] = Config{PrivateRegistry, "agnhost", "2.6"}
 	configs[AuthenticatedAlpine] = Config{gcAuthenticatedRegistry, "alpine", "3.7"}
 	configs[AuthenticatedWindowsNanoServer] = Config{gcAuthenticatedRegistry, "windows-nanoserver", "v1"}


### PR DESCRIPTION

/kind bug

**What this PR does / why we need it**:

It contains several bugfixes and improvements

```release-note
NONE
```

Depends-on: https://github.com/kubernetes/k8s.io/pull/1540