### PR TITLE
Automated cherry pick of #97003: make hostPort match test linuxonly

### DIFF
--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -2033,9 +2033,10 @@
 - testname: Scheduling, HostPort matching and HostIP and Protocol not-matching
   codename: '[sig-scheduling] SchedulerPredicates [Serial] validates that there is
     no conflict between pods with same hostPort but different hostIP and protocol
-    [Conformance]'
+    [LinuxOnly] [Conformance]'
   description: Pods with the same HostPort value MUST be able to be scheduled to the
-    same node if the HostIP or Protocol is different.
+    same node if the HostIP or Protocol is different. This test is marked LinuxOnly
+    since hostNetwork is not supported on Windows.
   release: v1.16
   file: test/e2e/scheduling/predicates.go
 - testname: Pod preemption verification

--- a/test/e2e/scheduling/predicates.go
+++ b/test/e2e/scheduling/predicates.go
@@ -657,9 +657,14 @@ var _ = SIGDescribe("SchedulerPredicates [Serial]", func() {
 		Release: v1.16
 		Testname: Scheduling, HostPort matching and HostIP and Protocol not-matching
 		Description: Pods with the same HostPort value MUST be able to be scheduled to the same node
-		if the HostIP or Protocol is different.
+		if the HostIP or Protocol is different. This test is marked LinuxOnly since hostNetwork is not supported on
+		Windows.
 	*/
-	framework.ConformanceIt("validates that there is no conflict between pods with same hostPort but different hostIP and protocol", func() {
+
+	// TODO: Add a new e2e test to scheduler which validates if hostPort is working and move this test to e2e/network
+	//		 so that appropriate team owns the e2e.
+	//		 xref: https://github.com/kubernetes/kubernetes/issues/98075.
+	framework.ConformanceIt("validates that there is no conflict between pods with same hostPort but different hostIP and protocol [LinuxOnly]", func() {
 
 		nodeName := GetNodeThatCanRunPod(f)
 		localhost := "127.0.0.1"


### PR DESCRIPTION
Cherry pick of #97003 on release-1.20.

#97003: make hostPort match test linuxonly

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.