### PR TITLE
Remove kubectl alpha debug command in 1.21

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/alpha.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/alpha.go
@@ -20,7 +20,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"k8s.io/cli-runtime/pkg/genericclioptions"
-	"k8s.io/kubectl/pkg/cmd/debug"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/util/i18n"
 	"k8s.io/kubectl/pkg/util/templates"
@@ -36,7 +35,6 @@ func NewCmdAlpha(f cmdutil.Factory, streams genericclioptions.IOStreams) *cobra.
 
 	// Alpha commands should be added here. As features graduate from alpha they should move
 	// from here to the CommandGroups defined by NewKubeletCommand() in cmd.go.
-	cmd.AddCommand(debug.NewCmdDebug(f, streams, true))
 
 	// NewKubeletCommand() will hide the alpha command if it has no subcommands. Overriding
 	// the help function ensures a reasonable message if someone types the hidden command anyway.

--- a/staging/src/k8s.io/kubectl/pkg/cmd/cmd.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/cmd.go
@@ -554,7 +554,7 @@ func NewKubectlCommand(in io.Reader, out, err io.Writer) *cobra.Command {
 				proxy.NewCmdProxy(f, ioStreams),
 				cp.NewCmdCp(f, ioStreams),
 				auth.NewCmdAuth(f, ioStreams),
-				debug.NewCmdDebug(f, ioStreams, false),
+				debug.NewCmdDebug(f, ioStreams),
 			},
 		},
 		{

--- a/staging/src/k8s.io/kubectl/pkg/cmd/debug/debug.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/debug/debug.go
@@ -93,9 +93,6 @@ var (
 		# The container will run in the host namespaces and the host's filesystem will be mounted at /host
 		kubectl debug node/mynode -it --image=busybox
 `))
-
-	// TODO(verb): Remove deprecated alpha invocation in 1.21
-	deprecationNotice = i18n.T(`NOTE: "kubectl alpha debug" is deprecated and will be removed in release 1.21. Please use "kubectl debug" instead.`)
 )
 
 var nameSuffixFunc = utilrand.String
@@ -122,7 +119,6 @@ type DebugOptions struct {
 	TTY             bool
 
 	attachChanged         bool
-	deprecatedInvocation  bool
 	shareProcessedChanged bool
 
 	podClient corev1client.PodsGetter
@@ -141,7 +137,7 @@ func NewDebugOptions(streams genericclioptions.IOStreams) *DebugOptions {
 }
 
 // NewCmdDebug returns a cobra command that runs kubectl debug.
-func NewCmdDebug(f cmdutil.Factory, streams genericclioptions.IOStreams, deprecatedInvocation bool) *cobra.Command {
+func NewCmdDebug(f cmdutil.Factory, streams genericclioptions.IOStreams) *cobra.Command {
 	o := NewDebugOptions(streams)
 
 	cmd := &cobra.Command{
@@ -155,12 +151,6 @@ func NewCmdDebug(f cmdutil.Factory, streams genericclioptions.IOStreams, depreca
 			cmdutil.CheckErr(o.Validate(cmd))
 			cmdutil.CheckErr(o.Run(f, cmd))
 		},
-		Hidden: deprecatedInvocation,
-	}
-
-	o.deprecatedInvocation = deprecatedInvocation
-	if deprecatedInvocation {
-		cmd.Long = fmt.Sprintf("%s\n\n%s", deprecationNotice, debugLong)
 	}
 
 	addDebugFlags(cmd, o)
@@ -188,10 +178,6 @@ func addDebugFlags(cmd *cobra.Command, opt *DebugOptions) {
 // Complete finishes run-time initialization of debug.DebugOptions.
 func (o *DebugOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []string) error {
 	var err error
-
-	if o.deprecatedInvocation {
-		cmd.Printf("%s\n\n", deprecationNotice)
-	}
 
 	o.PullPolicy = corev1.PullPolicy(cmdutil.GetFlagString(cmd, "image-pull-policy"))
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kubectl: The deprecated `kubectl alpha debug` command is removed. Use `kubectl debug` instead.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
