### PR TITLE
[WIP] [POC] Implement fetching custom metric in kubectl top

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/top/top.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/top/top.go
@@ -24,7 +24,6 @@ import (
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/util/i18n"
 	"k8s.io/kubectl/pkg/util/templates"
-	metricsapi "k8s.io/metrics/pkg/apis/metrics"
 )
 
 const (
@@ -55,13 +54,14 @@ func NewCmdTop(f cmdutil.Factory, streams genericclioptions.IOStreams) *cobra.Co
 	// create subcommands
 	cmd.AddCommand(NewCmdTopNode(f, nil, streams))
 	cmd.AddCommand(NewCmdTopPod(f, nil, streams))
+	cmd.AddCommand(NewCmdTopMetrics(f, nil, streams))
 
 	return cmd
 }
 
-func SupportedMetricsAPIVersionAvailable(discoveredAPIGroups *metav1.APIGroupList) bool {
+func SupportedAPIVersionAvailable(discoveredAPIGroups *metav1.APIGroupList, apiGroup string) bool {
 	for _, discoveredAPIGroup := range discoveredAPIGroups.Groups {
-		if discoveredAPIGroup.Name != metricsapi.GroupName {
+		if discoveredAPIGroup.Name != apiGroup {
 			continue
 		}
 		for _, version := range discoveredAPIGroup.Versions {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/top/top_metrics.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/top/top_metrics.go
@@ -1,0 +1,126 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package top
+
+import (
+	"errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/discovery"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+	"k8s.io/kubectl/pkg/metricsutil"
+	"k8s.io/kubectl/pkg/util/i18n"
+	"k8s.io/kubectl/pkg/util/templates"
+	custommetrics "k8s.io/metrics/pkg/apis/custom_metrics"
+
+	"github.com/spf13/cobra"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+)
+
+type TopMetricsOptions struct {
+	Printer             *metricsutil.TopCmdPrinter
+	DiscoveryClient    discovery.DiscoveryInterface
+
+	NoHeaders bool
+	Kind      string
+
+	genericclioptions.IOStreams
+}
+
+
+var (
+	topMetricsLong = templates.LongDesc(i18n.T(`
+		Display list of available metrics.
+
+		The 'top metrics' command allows you to see the list of available metrics that can be used .
+.`))
+
+	topMetricsExample = templates.Examples(i18n.T(`
+		# show all metrics available to kubectl top
+		kubectl top metrics
+
+		# show metrics available to kubectl top pods
+		kubectl top metrics pods
+        `))
+)
+
+func NewCmdTopMetrics(f cmdutil.Factory, o *TopMetricsOptions, streams genericclioptions.IOStreams) *cobra.Command {
+	if o == nil {
+		o = &TopMetricsOptions{
+			IOStreams: streams,
+		}
+	}
+
+	cmd := &cobra.Command{
+		Use:                   "metrics [NAME]",
+		DisableFlagsInUseLine: true,
+		Short:                 i18n.T("Display list of available metrics"),
+		Long:                  topMetricsLong,
+		Example:               topMetricsExample,
+		Run: func(cmd *cobra.Command, args []string) {
+			cmdutil.CheckErr(o.Complete(f, cmd, args))
+			cmdutil.CheckErr(o.Validate())
+			cmdutil.CheckErr(o.RunTopMetrics())
+		},
+		Aliases: []string{"metrics", "m"},
+	}
+	cmd.Flags().BoolVar(&o.NoHeaders, "no-headers", o.NoHeaders, "If present, print output without headers")
+	return cmd
+}
+
+func (o *TopMetricsOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []string) error {
+	if len(args) == 1 {
+		o.Kind = args[0]
+	} else if len(args) > 1 {
+		return cmdutil.UsageErrorf(cmd, "%s", cmd.Use)
+	}
+
+	clientset, err := f.KubernetesClientSet()
+	if err != nil {
+		return err
+	}
+	o.DiscoveryClient = clientset.DiscoveryClient
+	o.Printer = metricsutil.NewTopCmdPrinter(o.Out)
+	return nil
+}
+
+func (o *TopMetricsOptions) Validate() error {
+	return nil
+}
+
+func (o TopMetricsOptions) RunTopMetrics() error {
+	var err error
+	apiGroups, err := o.DiscoveryClient.ServerGroups()
+	if err != nil {
+		return err
+	}
+
+	apiAvailable := SupportedAPIVersionAvailable(apiGroups, custommetrics.GroupName)
+	if !apiAvailable {
+		return errors.New("Custom Metrics API not available")
+	}
+
+	metrics, err := o.DiscoveryClient.ServerResourcesForGroupVersion(schema.GroupVersion{
+		Group:   "custom.metrics.k8s.io",
+		Version: "v1beta2",
+	}.String())
+
+	if err != nil {
+		return err
+	}
+
+	return o.Printer.PrintMetrics(metrics.APIResources, o.NoHeaders, o.Kind)
+}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/top/top_node.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/top/top_node.go
@@ -160,7 +160,7 @@ func (o TopNodeOptions) RunTopNode() error {
 		return err
 	}
 
-	metricsAPIAvailable := SupportedMetricsAPIVersionAvailable(apiGroups)
+	metricsAPIAvailable := SupportedAPIVersionAvailable(apiGroups, metricsapi.GroupName)
 
 	if !metricsAPIAvailable {
 		return errors.New("Metrics API not available")


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

This is a simple prof of concept that `kubectl top` can support custom metrics. For feature we would need to cleanup code and figure out how to configure custom metrics columns in kubectl. First though about configuration was something similar to adding custom columns like with `kubectl get`

Command to discover metrics available:
```
$ kubectl top metrics pods
GROUP   KIND   METRIC                                
        pods   cpu                                   
        pods   cpu_cfs_periods                       
        pods   cpu_cfs_throttled                     
        pods   cpu_cfs_throttled_periods             
        pods   cpu_system                            
        pods   cpu_usage                             
        pods   cpu_user                              
        pods   file_descriptors                      
        pods   fs_reads                              
        pods   fs_reads_bytes                        
        pods   fs_writes                             
        pods   fs_writes_bytes                       
        pods   last_seen                             
        pods   memory                                
        pods   memory_cache                          
        pods   memory_failcnt                        
        pods   memory_failures                       
        pods   memory_mapped_file                    
        pods   memory_max_usage_bytes                
        pods   memory_rss                            
        pods   memory_swap                           
        pods   memory_usage_bytes                    
        pods   memory_working_set_bytes              
        pods   network_receive_bytes                 
        pods   network_receive_errors                
        pods   network_receive_packets               
        pods   network_receive_packets_dropped       
        pods   network_transmit_bytes                
        pods   network_transmit_errors               
        pods   network_transmit_packets              
        pods   network_transmit_packets_dropped      
        pods   processes                             
        pods   sockets                               
        pods   spec_cpu_period                       
        pods   spec_cpu_quota                        
        pods   spec_cpu_shares                       
        pods   spec_memory_limit_bytes               
        pods   spec_memory_reservation_limit_bytes   
        pods   spec_memory_swap_limit_bytes          
        pods   start_time_seconds                    
        pods   threads                               
        pods   threads_max                           
        pods   ulimits_soft    
```

Adding additional custom metrics to kubectl top
```
$ kubectl top pods -n monitoring --custom-metrics=network_transmit_bytes,threads,fs_reads_bytes,fs_writes_bytes
NAME                                   CPU(cores)   MEMORY(bytes)   network_transmit_bytes   threads   fs_reads_bytes   fs_writes_bytes   
alertmanager-main-0                    16m          74Mi            1.48Ki                   81        0                0                 
alertmanager-main-1                    21m          73Mi            1.74Ki                   90        0                0                 
alertmanager-main-2                    19m          74Mi            1.83Ki                   78        0                0                 
blackbox-exporter-8485dc4b9d-rwstl     4m           82Mi            376                      114       0                0                 
grafana-7cdf79544f-6559t               40m          133Mi           1.64Ki                   48        0                0                 
kube-state-metrics-986b854-nklcq       4m           108Mi           51.75Ki                  168       0                0                 
node-exporter-v5vz9                    77m          78Mi            41.04Ki                  120       0                0                 
prometheus-adapter-7ff7fd9c48-682sm    103m         80Mi            66.87Ki                  39        0                0                 
prometheus-k8s-0                       203m         738Mi           4.83Ki                   81        0                6.40Ki            
prometheus-k8s-1                       173m         716Mi           2.32Ki                   81        0                6.40Ki            
prometheus-operator-59976dc7d5-zhcng   7m           122Mi           741                      93        0                0      
```

/sig instrumentation
/sig cli

**Special notes for your reviewer**:

No need to review the code, this is poc and we should focus on:
* Is this feature useful for users?
* Does the design make sense?
* Can we improve/extend this feature?

```release-note
Implement support for custom metrics in kubectl top
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
