### PR TITLE
Scheduler: export all fields of struct framework.Status

### DIFF
--- a/pkg/scheduler/core/generic_scheduler.go
+++ b/pkg/scheduler/core/generic_scheduler.go
@@ -262,7 +262,7 @@ func (g *genericScheduler) findNodesThatPassFilters(ctx context.Context, fwk fra
 		// this is to make sure all nodes have the same chance of being examined across pods.
 		nodeInfo := allNodes[(g.nextStartNodeIndex+i)%len(allNodes)]
 		status := fwk.RunFilterPluginsWithNominatedPods(ctx, state, pod, nodeInfo)
-		if status.Code() == framework.Error {
+		if status.GetCode() == framework.Error {
 			errCh.SendErrorWithCancel(status.AsError(), cancel)
 			return
 		}

--- a/pkg/scheduler/core/generic_scheduler_test.go
+++ b/pkg/scheduler/core/generic_scheduler_test.go
@@ -830,7 +830,7 @@ func TestFindFitAllError(t *testing.T) {
 			if !found {
 				t.Errorf("failed to find node %v in %v", node.Name, nodeToStatusMap)
 			}
-			reasons := status.Reasons()
+			reasons := status.Reasons
 			if len(reasons) != 1 || reasons[0] != st.ErrReasonFake {
 				t.Errorf("unexpected failure reasons: %v", reasons)
 			}
@@ -874,7 +874,7 @@ func TestFindFitSomeError(t *testing.T) {
 			if !found {
 				t.Errorf("failed to find node %v in %v", node.Name, nodeToStatusMap)
 			}
-			reasons := status.Reasons()
+			reasons := status.Reasons
 			if len(reasons) != 1 || reasons[0] != st.ErrReasonFake {
 				t.Errorf("unexpected failures: %v", reasons)
 			}

--- a/pkg/scheduler/framework/interface.go
+++ b/pkg/scheduler/framework/interface.go
@@ -106,17 +106,17 @@ const (
 // the reasons should explain why.
 // NOTE: A nil Status is also considered as Success.
 type Status struct {
-	code    Code
-	reasons []string
-	err     error
+	Code    Code
+	Reasons []string
+	Err     error
 }
 
-// Code returns code of the Status.
-func (s *Status) Code() Code {
+// GetCode returns code of the Status.
+func (s *Status) GetCode() Code {
 	if s == nil {
 		return Success
 	}
-	return s.code
+	return s.Code
 }
 
 // Message returns a concatenated message on reasons of the Status.
@@ -124,27 +124,22 @@ func (s *Status) Message() string {
 	if s == nil {
 		return ""
 	}
-	return strings.Join(s.reasons, ", ")
-}
-
-// Reasons returns reasons of the Status.
-func (s *Status) Reasons() []string {
-	return s.reasons
+	return strings.Join(s.Reasons, ", ")
 }
 
 // AppendReason appends given reason to the Status.
 func (s *Status) AppendReason(reason string) {
-	s.reasons = append(s.reasons, reason)
+	s.Reasons = append(s.Reasons, reason)
 }
 
 // IsSuccess returns true if and only if "Status" is nil or Code is "Success".
 func (s *Status) IsSuccess() bool {
-	return s.Code() == Success
+	return s.GetCode() == Success
 }
 
 // IsUnschedulable returns true if "Status" is Unschedulable (Unschedulable or UnschedulableAndUnresolvable).
 func (s *Status) IsUnschedulable() bool {
-	code := s.Code()
+	code := s.GetCode()
 	return code == Unschedulable || code == UnschedulableAndUnresolvable
 }
 
@@ -154,8 +149,8 @@ func (s *Status) AsError() error {
 	if s.IsSuccess() {
 		return nil
 	}
-	if s.err != nil {
-		return s.err
+	if s.Err != nil {
+		return s.Err
 	}
 	return errors.New(s.Message())
 }
@@ -163,11 +158,11 @@ func (s *Status) AsError() error {
 // NewStatus makes a Status out of the given arguments and returns its pointer.
 func NewStatus(code Code, reasons ...string) *Status {
 	s := &Status{
-		code:    code,
-		reasons: reasons,
+		Code:    code,
+		Reasons: reasons,
 	}
 	if code == Error {
-		s.err = errors.New(s.Message())
+		s.Err = errors.New(s.Message())
 	}
 	return s
 }
@@ -175,9 +170,9 @@ func NewStatus(code Code, reasons ...string) *Status {
 // AsStatus wraps an error in a Status.
 func AsStatus(err error) *Status {
 	return &Status{
-		code:    Error,
-		reasons: []string{err.Error()},
-		err:     err,
+		Code:    Error,
+		Reasons: []string{err.Error()},
+		Err:     err,
 	}
 }
 
@@ -194,14 +189,14 @@ func (p PluginToStatus) Merge() *Status {
 
 	finalStatus := NewStatus(Success)
 	for _, s := range p {
-		if s.Code() == Error {
-			finalStatus.err = s.AsError()
+		if s.GetCode() == Error {
+			finalStatus.Err = s.AsError()
 		}
-		if statusPrecedence[s.Code()] > statusPrecedence[finalStatus.code] {
-			finalStatus.code = s.Code()
+		if statusPrecedence[s.GetCode()] > statusPrecedence[finalStatus.Code] {
+			finalStatus.Code = s.GetCode()
 		}
 
-		for _, r := range s.reasons {
+		for _, r := range s.Reasons {
 			finalStatus.AppendReason(r)
 		}
 	}

--- a/pkg/scheduler/framework/interface_test.go
+++ b/pkg/scheduler/framework/interface_test.go
@@ -53,8 +53,8 @@ func TestStatus(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		if test.status.Code() != test.expectedCode {
-			t.Errorf("test #%v, expect status.Code() returns %v, but %v", i, test.expectedCode, test.status.Code())
+		if test.status.GetCode() != test.expectedCode {
+			t.Errorf("test #%v, expect status.Code() returns %v, but %v", i, test.expectedCode, test.status.GetCode())
 		}
 
 		if test.status.Message() != test.expectedMessage {
@@ -115,8 +115,8 @@ func TestPluginToStatusMerge(t *testing.T) {
 
 	for i, test := range tests {
 		gotStatus := test.statusMap.Merge()
-		if test.wantCode != gotStatus.Code() {
-			t.Errorf("test #%v, wantCode %v, gotCode %v", i, test.wantCode, gotStatus.Code())
+		if test.wantCode != gotStatus.GetCode() {
+			t.Errorf("test #%v, wantCode %v, gotCode %v", i, test.wantCode, gotStatus.GetCode())
 		}
 	}
 }

--- a/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption.go
+++ b/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption.go
@@ -246,7 +246,7 @@ func PodEligibleToPreemptOthers(pod *v1.Pod, nodeInfos framework.NodeInfoLister,
 	if len(nomNodeName) > 0 {
 		// If the pod's nominated node is considered as UnschedulableAndUnresolvable by the filters,
 		// then the pod should be considered for preempting again.
-		if nominatedNodeStatus.Code() == framework.UnschedulableAndUnresolvable {
+		if nominatedNodeStatus.GetCode() == framework.UnschedulableAndUnresolvable {
 			return true
 		}
 
@@ -271,7 +271,7 @@ func nodesWherePreemptionMightHelp(nodes []*framework.NodeInfo, m framework.Node
 		name := node.Node().Name
 		// We reply on the status by each plugin - 'Unschedulable' or 'UnschedulableAndUnresolvable'
 		// to determine whether preemption may help or not on the node.
-		if m[name].Code() == framework.UnschedulableAndUnresolvable {
+		if m[name].GetCode() == framework.UnschedulableAndUnresolvable {
 			continue
 		}
 		potentialNodes = append(potentialNodes, node)

--- a/pkg/scheduler/framework/plugins/nodelabel/node_label_test.go
+++ b/pkg/scheduler/framework/plugins/nodelabel/node_label_test.go
@@ -124,8 +124,8 @@ func TestNodeLabelFilter(t *testing.T) {
 			}
 
 			status := p.(framework.FilterPlugin).Filter(context.TODO(), nil, pod, nodeInfo)
-			if status.Code() != test.res {
-				t.Errorf("Status mismatch. got: %v, want: %v", status.Code(), test.res)
+			if status.GetCode() != test.res {
+				t.Errorf("Status mismatch. got: %v, want: %v", status.GetCode(), test.res)
 			}
 		})
 	}
@@ -263,8 +263,8 @@ func TestNodeLabelFilterWithoutNode(t *testing.T) {
 			t.Fatalf("Failed to create plugin: %v", err)
 		}
 		status := p.(framework.FilterPlugin).Filter(context.TODO(), nil, pod, nodeInfo)
-		if status.Code() != framework.Error {
-			t.Errorf("Status mismatch. got: %v, want: %v", status.Code(), framework.Error)
+		if status.GetCode() != framework.Error {
+			t.Errorf("Status mismatch. got: %v, want: %v", status.GetCode(), framework.Error)
 		}
 	})
 }
@@ -277,8 +277,8 @@ func TestNodeLabelScoreWithoutNode(t *testing.T) {
 			t.Fatalf("Failed to create plugin: %+v", err)
 		}
 		_, status := p.(framework.ScorePlugin).Score(context.Background(), nil, nil, "")
-		if status.Code() != framework.Error {
-			t.Errorf("Status mismatch. got: %v, want: %v", status.Code(), framework.Error)
+		if status.GetCode() != framework.Error {
+			t.Errorf("Status mismatch. got: %v, want: %v", status.GetCode(), framework.Error)
 		}
 	})
 }

--- a/pkg/scheduler/framework/plugins/podtopologyspread/filtering_test.go
+++ b/pkg/scheduler/framework/plugins/podtopologyspread/filtering_test.go
@@ -1421,8 +1421,8 @@ func TestSingleConstraint(t *testing.T) {
 			for _, node := range tt.nodes {
 				nodeInfo, _ := snapshot.NodeInfos().Get(node.Name)
 				status := p.Filter(context.Background(), state, tt.pod, nodeInfo)
-				if len(tt.wantStatusCode) != 0 && status.Code() != tt.wantStatusCode[node.Name] {
-					t.Errorf("[%s]: expected status code %v got %v", node.Name, tt.wantStatusCode[node.Name], status.Code())
+				if len(tt.wantStatusCode) != 0 && status.GetCode() != tt.wantStatusCode[node.Name] {
+					t.Errorf("[%s]: expected status code %v got %v", node.Name, tt.wantStatusCode[node.Name], status.GetCode())
 				}
 			}
 		})
@@ -1647,8 +1647,8 @@ func TestMultipleConstraints(t *testing.T) {
 			for _, node := range tt.nodes {
 				nodeInfo, _ := snapshot.NodeInfos().Get(node.Name)
 				status := p.Filter(context.Background(), state, tt.pod, nodeInfo)
-				if len(tt.wantStatusCode) != 0 && status.Code() != tt.wantStatusCode[node.Name] {
-					t.Errorf("[%s]: expected error code %v got %v", node.Name, tt.wantStatusCode[node.Name], status.Code())
+				if len(tt.wantStatusCode) != 0 && status.GetCode() != tt.wantStatusCode[node.Name] {
+					t.Errorf("[%s]: expected error code %v got %v", node.Name, tt.wantStatusCode[node.Name], status.GetCode())
 				}
 			}
 		})

--- a/pkg/scheduler/framework/plugins/serviceaffinity/service_affinity_test.go
+++ b/pkg/scheduler/framework/plugins/serviceaffinity/service_affinity_test.go
@@ -177,8 +177,8 @@ func TestServiceAffinity(t *testing.T) {
 			}
 			nodeInfo := mustGetNodeInfo(t, snapshot, test.node.Name)
 			status := p.Filter(context.Background(), state, test.pod, nodeInfo)
-			if status.Code() != test.res {
-				t.Errorf("Status mismatch. got: %v, want: %v", status.Code(), test.res)
+			if status.GetCode() != test.res {
+				t.Errorf("Status mismatch. got: %v, want: %v", status.GetCode(), test.res)
 			}
 		})
 	}

--- a/pkg/scheduler/framework/runtime/framework.go
+++ b/pkg/scheduler/framework/runtime/framework.go
@@ -424,7 +424,7 @@ func (f *frameworkImpl) QueueSortFunc() framework.LessFunc {
 func (f *frameworkImpl) RunPreFilterPlugins(ctx context.Context, state *framework.CycleState, pod *v1.Pod) (status *framework.Status) {
 	startTime := time.Now()
 	defer func() {
-		metrics.FrameworkExtensionPointDuration.WithLabelValues(preFilter, status.Code().String(), f.profileName).Observe(metrics.SinceInSeconds(startTime))
+		metrics.FrameworkExtensionPointDuration.WithLabelValues(preFilter, status.GetCode().String(), f.profileName).Observe(metrics.SinceInSeconds(startTime))
 	}()
 	for _, pl := range f.preFilterPlugins {
 		status = f.runPreFilterPlugin(ctx, pl, state, pod)
@@ -567,7 +567,7 @@ func (f *frameworkImpl) runFilterPlugin(ctx context.Context, pl framework.Filter
 func (f *frameworkImpl) RunPostFilterPlugins(ctx context.Context, state *framework.CycleState, pod *v1.Pod, filteredNodeStatusMap framework.NodeToStatusMap) (_ *framework.PostFilterResult, status *framework.Status) {
 	startTime := time.Now()
 	defer func() {
-		metrics.FrameworkExtensionPointDuration.WithLabelValues(postFilter, status.Code().String(), f.profileName).Observe(metrics.SinceInSeconds(startTime))
+		metrics.FrameworkExtensionPointDuration.WithLabelValues(postFilter, status.GetCode().String(), f.profileName).Observe(metrics.SinceInSeconds(startTime))
 	}()
 
 	statuses := make(framework.PluginToStatus)
@@ -689,7 +689,7 @@ func (f *frameworkImpl) RunPreScorePlugins(
 ) (status *framework.Status) {
 	startTime := time.Now()
 	defer func() {
-		metrics.FrameworkExtensionPointDuration.WithLabelValues(preScore, status.Code().String(), f.profileName).Observe(metrics.SinceInSeconds(startTime))
+		metrics.FrameworkExtensionPointDuration.WithLabelValues(preScore, status.GetCode().String(), f.profileName).Observe(metrics.SinceInSeconds(startTime))
 	}()
 	for _, pl := range f.preScorePlugins {
 		status = f.runPreScorePlugin(ctx, pl, state, pod, nodes)
@@ -720,7 +720,7 @@ func (f *frameworkImpl) runPreScorePlugin(ctx context.Context, pl framework.PreS
 func (f *frameworkImpl) RunScorePlugins(ctx context.Context, state *framework.CycleState, pod *v1.Pod, nodes []*v1.Node) (ps framework.PluginToNodeScores, status *framework.Status) {
 	startTime := time.Now()
 	defer func() {
-		metrics.FrameworkExtensionPointDuration.WithLabelValues(score, status.Code().String(), f.profileName).Observe(metrics.SinceInSeconds(startTime))
+		metrics.FrameworkExtensionPointDuration.WithLabelValues(score, status.GetCode().String(), f.profileName).Observe(metrics.SinceInSeconds(startTime))
 	}()
 	pluginToNodeScores := make(framework.PluginToNodeScores, len(f.scorePlugins))
 	for _, pl := range f.scorePlugins {
@@ -820,7 +820,7 @@ func (f *frameworkImpl) runScoreExtension(ctx context.Context, pl framework.Scor
 func (f *frameworkImpl) RunPreBindPlugins(ctx context.Context, state *framework.CycleState, pod *v1.Pod, nodeName string) (status *framework.Status) {
 	startTime := time.Now()
 	defer func() {
-		metrics.FrameworkExtensionPointDuration.WithLabelValues(preBind, status.Code().String(), f.profileName).Observe(metrics.SinceInSeconds(startTime))
+		metrics.FrameworkExtensionPointDuration.WithLabelValues(preBind, status.GetCode().String(), f.profileName).Observe(metrics.SinceInSeconds(startTime))
 	}()
 	for _, pl := range f.preBindPlugins {
 		status = f.runPreBindPlugin(ctx, pl, state, pod, nodeName)
@@ -847,14 +847,14 @@ func (f *frameworkImpl) runPreBindPlugin(ctx context.Context, pl framework.PreBi
 func (f *frameworkImpl) RunBindPlugins(ctx context.Context, state *framework.CycleState, pod *v1.Pod, nodeName string) (status *framework.Status) {
 	startTime := time.Now()
 	defer func() {
-		metrics.FrameworkExtensionPointDuration.WithLabelValues(bind, status.Code().String(), f.profileName).Observe(metrics.SinceInSeconds(startTime))
+		metrics.FrameworkExtensionPointDuration.WithLabelValues(bind, status.GetCode().String(), f.profileName).Observe(metrics.SinceInSeconds(startTime))
 	}()
 	if len(f.bindPlugins) == 0 {
 		return framework.NewStatus(framework.Skip, "")
 	}
 	for _, bp := range f.bindPlugins {
 		status = f.runBindPlugin(ctx, bp, state, pod, nodeName)
-		if status != nil && status.Code() == framework.Skip {
+		if status != nil && status.GetCode() == framework.Skip {
 			continue
 		}
 		if !status.IsSuccess() {
@@ -906,7 +906,7 @@ func (f *frameworkImpl) runPostBindPlugin(ctx context.Context, pl framework.Post
 func (f *frameworkImpl) RunReservePluginsReserve(ctx context.Context, state *framework.CycleState, pod *v1.Pod, nodeName string) (status *framework.Status) {
 	startTime := time.Now()
 	defer func() {
-		metrics.FrameworkExtensionPointDuration.WithLabelValues(reserve, status.Code().String(), f.profileName).Observe(metrics.SinceInSeconds(startTime))
+		metrics.FrameworkExtensionPointDuration.WithLabelValues(reserve, status.GetCode().String(), f.profileName).Observe(metrics.SinceInSeconds(startTime))
 	}()
 	for _, pl := range f.reservePlugins {
 		status = f.runReservePluginReserve(ctx, pl, state, pod, nodeName)
@@ -962,7 +962,7 @@ func (f *frameworkImpl) runReservePluginUnreserve(ctx context.Context, pl framew
 func (f *frameworkImpl) RunPermitPlugins(ctx context.Context, state *framework.CycleState, pod *v1.Pod, nodeName string) (status *framework.Status) {
 	startTime := time.Now()
 	defer func() {
-		metrics.FrameworkExtensionPointDuration.WithLabelValues(permit, status.Code().String(), f.profileName).Observe(metrics.SinceInSeconds(startTime))
+		metrics.FrameworkExtensionPointDuration.WithLabelValues(permit, status.GetCode().String(), f.profileName).Observe(metrics.SinceInSeconds(startTime))
 	}()
 	pluginsWaitTime := make(map[string]time.Duration)
 	statusCode := framework.Success
@@ -972,9 +972,9 @@ func (f *frameworkImpl) RunPermitPlugins(ctx context.Context, state *framework.C
 			if status.IsUnschedulable() {
 				msg := fmt.Sprintf("rejected pod %q by permit plugin %q: %v", pod.Name, pl.Name(), status.Message())
 				klog.V(4).Infof(msg)
-				return framework.NewStatus(status.Code(), msg)
+				return framework.NewStatus(status.GetCode(), msg)
 			}
-			if status.Code() == framework.Wait {
+			if status.GetCode() == framework.Wait {
 				// Not allowed to be greater than maxTimeout.
 				if timeout > maxTimeout {
 					timeout = maxTimeout
@@ -1019,13 +1019,13 @@ func (f *frameworkImpl) WaitOnPermit(ctx context.Context, pod *v1.Pod) (status *
 
 	startTime := time.Now()
 	s := <-waitingPod.s
-	metrics.PermitWaitDuration.WithLabelValues(s.Code().String()).Observe(metrics.SinceInSeconds(startTime))
+	metrics.PermitWaitDuration.WithLabelValues(s.GetCode().String()).Observe(metrics.SinceInSeconds(startTime))
 
 	if !s.IsSuccess() {
 		if s.IsUnschedulable() {
 			msg := fmt.Sprintf("pod %q rejected while waiting on permit: %v", pod.Name, s.Message())
 			klog.V(4).Infof(msg)
-			return framework.NewStatus(s.Code(), msg)
+			return framework.NewStatus(s.GetCode(), msg)
 		}
 		err := s.AsError()
 		klog.ErrorS(err, "Failed waiting on permit for pod", "pod", klog.KObj(pod))

--- a/pkg/scheduler/framework/runtime/framework_test.go
+++ b/pkg/scheduler/framework/runtime/framework_test.go
@@ -812,7 +812,7 @@ func TestRunScorePlugins(t *testing.T) {
 
 			if tt.err {
 				if status.IsSuccess() {
-					t.Errorf("Expected status to be non-success. got: %v", status.Code().String())
+					t.Errorf("Expected status to be non-success. got: %v", status.GetCode().String())
 				}
 				return
 			}
@@ -2003,8 +2003,8 @@ func TestRunBindPlugins(t *testing.T) {
 			}
 
 			st := fwk.RunBindPlugins(context.Background(), state, pod, "")
-			if st.Code() != tt.wantStatus {
-				t.Errorf("got status code %s, want %s", st.Code(), tt.wantStatus)
+			if st.GetCode() != tt.wantStatus {
+				t.Errorf("got status code %s, want %s", st.GetCode(), tt.wantStatus)
 			}
 
 			// Stop the goroutine which records metrics and ensure it's stopped.
@@ -2113,17 +2113,17 @@ func TestWaitOnPermit(t *testing.T) {
 			}
 
 			runPermitPluginsStatus := f.RunPermitPlugins(context.Background(), nil, pod, "")
-			if runPermitPluginsStatus.Code() != framework.Wait {
+			if runPermitPluginsStatus.GetCode() != framework.Wait {
 				t.Fatalf("Expected RunPermitPlugins to return status %v, but got %v",
-					framework.Wait, runPermitPluginsStatus.Code())
+					framework.Wait, runPermitPluginsStatus.GetCode())
 			}
 
 			go tt.action(f)
 
 			waitOnPermitStatus := f.WaitOnPermit(context.Background(), pod)
-			if waitOnPermitStatus.Code() != tt.wantStatus {
+			if waitOnPermitStatus.GetCode() != tt.wantStatus {
 				t.Fatalf("Expected WaitOnPermit to return status %v, but got %v",
-					tt.wantStatus, waitOnPermitStatus.Code())
+					tt.wantStatus, waitOnPermitStatus.GetCode())
 			}
 			if waitOnPermitStatus.Message() != tt.wantMessage {
 				t.Fatalf("Expected WaitOnPermit to return status with message %q, but got %q",

--- a/pkg/scheduler/framework/runtime/metrics_recorder.go
+++ b/pkg/scheduler/framework/runtime/metrics_recorder.go
@@ -66,7 +66,7 @@ func newMetricsRecorder(bufferSize int, interval time.Duration) *metricsRecorder
 func (r *metricsRecorder) observePluginDurationAsync(extensionPoint, pluginName string, status *framework.Status, value float64) {
 	newMetric := &frameworkMetric{
 		metric:      metrics.PluginExecutionDuration,
-		labelValues: []string{pluginName, extensionPoint, status.Code().String()},
+		labelValues: []string{pluginName, extensionPoint, status.GetCode().String()},
 		value:       value,
 	}
 	select {

--- a/pkg/scheduler/framework/types.go
+++ b/pkg/scheduler/framework/types.go
@@ -107,7 +107,7 @@ const (
 func (f *FitError) Error() string {
 	reasons := make(map[string]int)
 	for _, status := range f.FilteredNodesStatuses {
-		for _, reason := range status.Reasons() {
+		for _, reason := range status.Reasons {
 			reasons[reason]++
 		}
 	}

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -391,10 +391,10 @@ func (sched *Scheduler) bind(ctx context.Context, fwk framework.Framework, assum
 	if bindStatus.IsSuccess() {
 		return nil
 	}
-	if bindStatus.Code() == framework.Error {
+	if bindStatus.GetCode() == framework.Error {
 		return bindStatus.AsError()
 	}
-	return fmt.Errorf("bind status: %s, %v", bindStatus.Code().String(), bindStatus.Message())
+	return fmt.Errorf("bind status: %s, %v", bindStatus.GetCode().String(), bindStatus.Message())
 }
 
 // TODO(#87159): Move this to a Plugin.
@@ -463,7 +463,7 @@ func (sched *Scheduler) scheduleOne(ctx context.Context) {
 			} else {
 				// Run PostFilter plugins to try to make the pod schedulable in a future scheduling cycle.
 				result, status := fwk.RunPostFilterPlugins(ctx, state, pod, fitError.FilteredNodesStatuses)
-				if status.Code() == framework.Error {
+				if status.GetCode() == framework.Error {
 					klog.ErrorS(nil, "Status after running PostFilter plugins for pod", klog.KObj(pod), "status", status)
 				} else {
 					klog.V(5).InfoS("Status after running PostFilter plugins for pod", "pod", klog.KObj(pod), "status", status)
@@ -518,7 +518,7 @@ func (sched *Scheduler) scheduleOne(ctx context.Context) {
 
 	// Run "permit" plugins.
 	runPermitStatus := fwk.RunPermitPlugins(schedulingCycleCtx, state, assumedPod, scheduleResult.SuggestedHost)
-	if runPermitStatus.Code() != framework.Wait && !runPermitStatus.IsSuccess() {
+	if runPermitStatus.GetCode() != framework.Wait && !runPermitStatus.IsSuccess() {
 		var reason string
 		if runPermitStatus.IsUnschedulable() {
 			metrics.PodUnschedulable(fwk.ProfileName(), metrics.SinceInSeconds(start))


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:

We are trying to remove `reflect.DeepEqual` in scheduling tests to make it easier to swap implementations. As one option, we can export all fields of the compared objects. I use this separated PR to evaluate whether it is worth to export all fields of  `framework.Status` struct since it is a widely used one.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of #94696

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
none
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
