### PR TITLE
endpoint controller: generated endpoints should not be mutated

### DIFF
--- a/test/integration/endpoints/BUILD
+++ b/test/integration/endpoints/BUILD
@@ -10,6 +10,7 @@ go_test(
     deps = [
         "//pkg/controller/endpoint:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/api/equality:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/intstr:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/wait:go_default_library",


### PR DESCRIPTION


**What type of PR is this?**


/kind bug


**What this PR does / why we need it**:

The endpoints controller generate Endpoints for Services based on
the Pods that match the Service selector. These endpoints are used
for kube-proxy and other implementations, to forward the traffic
from the Service IP to the Pods IPs.

It turn out that these endpoints objects can be mutated, creating
the possibility of diverting the Service traffic, to avoid that,
we resync the endpoint update on the endpoint controller, if the
mentioned Endpoints was generated by the endpoints controller.


**Which issue(s) this PR fixes**:

Fixes #98066 

**Special notes for your reviewer**:

This can be exploited by a bad actor, because you can modify an Endpoint object after it was generated using new IPs

**Does this PR introduce a user-facing change?**:

```release-note
Endpoints generated by the Endpoints Controller must match the Service selector Pod IPs, so updates of the Endpoints object will be dropped by the controller.
```
