### PR TITLE
Update: StatefulSet Replica scaling to include Patch Scale +1 endpoint

### DIFF
--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -1315,7 +1315,7 @@
   description: Create a StatefulSet resource. Newly created StatefulSet resource MUST
     have a scale of one. Bring the scale of the StatefulSet resource up to two. StatefulSet
     scale MUST be at two replicas.
-  release: v1.16
+  release: v1.16, v1.21
   file: test/e2e/apps/statefulset.go
 - testname: StatefulSet, Rolling Update with Partition
   codename: '[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it:**
This PR adds a test to test the following untested endpoints:
- patchAppsV1NamespacedStatefulSetScale

**Which issue(s) this PR fixes:**
Fixes #98125

**Testgrid Link:**

**Special notes for your reviewer:**
Adds +1 endpoint test coverage (good for conformance)

**Does this PR introduce a user-facing change?:**
```
NONE

```

**Release note:**
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:**
```
NONE

```

/sig testing
/sig architecture
/area conformance