### PR TITLE
Avoid sending events for every non-conformant pod in disruption controller

### DIFF
--- a/pkg/controller/disruption/disruption.go
+++ b/pkg/controller/disruption/disruption.go
@@ -49,10 +49,9 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
+	"k8s.io/klog/v2"
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 	"k8s.io/kubernetes/pkg/controller"
-
-	"k8s.io/klog/v2"
 )
 
 // DeletionTimeout sets maximum time from the moment a pod is added to DisruptedPods in PDB.Status
@@ -679,7 +678,6 @@ func (dc *DisruptionController) getExpectedScale(pdb *policy.PodDisruptionBudget
 		controllerRef := metav1.GetControllerOf(pod)
 		if controllerRef == nil {
 			err = fmt.Errorf("found no controller ref for pod %q", pod.Name)
-			dc.recorder.Event(pdb, v1.EventTypeWarning, "NoControllerRef", err.Error())
 			return
 		}
 
@@ -704,7 +702,6 @@ func (dc *DisruptionController) getExpectedScale(pdb *policy.PodDisruptionBudget
 		}
 		if !foundController {
 			err = fmt.Errorf("found no controllers for pod %q", pod.Name)
-			dc.recorder.Event(pdb, v1.EventTypeWarning, "NoControllers", err.Error())
 			return
 		}
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
The disruption controller currently sends an event for every pod covered by a PDB selector that doesn't conform (either doesn't have a controller or the controller doesn't implement scale) when scale is needed (every PDB configuration except when `minAvailable` is a number). This can have scalability implications. 
With this PR, we will instead only send a single event (`CalculateExpectedPodCountFailed`) per a PDB when this happens.

We can also consider eventually using information from the PDB condition introduced in https://github.com/kubernetes/kubernetes/pull/98127 to avoid sending an event on every reconcile. But this change should address the scalability concerns.

This change doesn't fully follow the plan as described in the PDB to GA KEP: https://github.com/kubernetes/enhancements/pull/2114. The KEP will be updated to reflect this change in plans.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
- [KEP](https://github.com/kubernetes/enhancements/pull/2114): https://github.com/kubernetes/enhancements/pull/2114

@kubernetes/sig-apps-pr-reviews