### PR TITLE
migrate generic_scheduler.go and types.go to structured logs

### DIFF
--- a/pkg/scheduler/core/BUILD
+++ b/pkg/scheduler/core/BUILD
@@ -15,7 +15,6 @@ go_library(
         "//pkg/scheduler/internal/cache:go_default_library",
         "//pkg/scheduler/internal/parallelize:go_default_library",
         "//pkg/scheduler/metrics:go_default_library",
-        "//pkg/scheduler/util:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/net:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",

--- a/pkg/scheduler/framework/types.go
+++ b/pkg/scheduler/framework/types.go
@@ -562,7 +562,7 @@ func removeFromSlice(s []*PodInfo, k string) []*PodInfo {
 	for i := range s {
 		k2, err := GetPodKey(s[i].Pod)
 		if err != nil {
-			klog.Errorf("Cannot get pod key, err: %v", err)
+			klog.ErrorS(err, "Cannot get pod key")
 			continue
 		}
 		if k == k2 {
@@ -591,7 +591,7 @@ func (n *NodeInfo) RemovePod(pod *v1.Pod) error {
 	for i := range n.Pods {
 		k2, err := GetPodKey(n.Pods[i].Pod)
 		if err != nil {
-			klog.Errorf("Cannot get pod key, err: %v", err)
+			klog.ErrorS(err, "Cannot get pod key")
 			continue
 		}
 		if k == k2 {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup
**What this PR does / why we need it**:
Ref:
https://github.com/kubernetes/enhancements/tree/master/keps/sig-instrumentation/1602-structured-logging
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/migration-to-structured-logging.md

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

**Verify log output (generic_scheduler.go):**
```
before:
generic_scheduler.go:318] Skipping extender &{false pod0 false false} as it returned error not a binder and has ignorable flag set
generic_scheduler.go:376] Plugin NodeAffinity scores on default/test-pod => [{node0 5} {node1 3}]
generic_scheduler.go:414] test-pod_default -> tmp: fakeExtender, Score: (7)
generic_scheduler.go:432] Host tmp => Score 7
```
```
after
generic_scheduler.go:318] "Skipping extender as it returned error and has ignorable flag set"  err="not a binder" extender=&{isBinder:false interestedPodName:pod0 ignorable:false gotBind:false}
generic_scheduler.go:375] "Plugin scored node for pod" pod="default/test-pod" plugin="NodeAffinity" node="node0" score=5
generic_scheduler.go:375] "Plugin scored node for pod" pod="default/test-pod" plugin="NodeAffinity" node="node1" score=3
generic_scheduler.go:413] "Extender scored node for pod" pod="default/test-pod" host="tmp" extenders name="fakeExtender" score=7
generic_scheduler.go:431] "Calculated node's final score for pod" pod="default/test-pod" node="tmp" score=7
```
**Verify log output (types.go):**
```
before:
types.go:565] Cannot get pod key, err: Cannot get cache key for pod with empty UID
types.go:594] Cannot get pod key, err: Cannot get cache key for pod with empty UID
```
```
after
types.go:565] "Cannot get pod key" err="Cannot get cache key for pod with empty UID"
types.go:594] Cannot get pod key, err: Cannot get cache key for pod with empty UID
```

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->

