### PR TITLE
migrate scheduler/internal logs into structured logging

### DIFF
--- a/pkg/scheduler/internal/cache/cache.go
+++ b/pkg/scheduler/internal/cache/cache.go
@@ -18,6 +18,7 @@ package cache
 
 import (
 	"fmt"
+	"os"
 	"sync"
 	"time"
 
@@ -125,7 +126,7 @@ func newNodeInfoListItem(ni *framework.NodeInfo) *nodeInfoListItem {
 func (cache *schedulerCache) moveNodeInfoToHead(name string) {
 	ni, ok := cache.nodes[name]
 	if !ok {
-		klog.Errorf("No NodeInfo with name %v found in the cache", name)
+		klog.ErrorS(nil, "No NodeInfo found in the cache", "node", name)
 		return
 	}
 	// if the node info list item is already at the head, we are done.
@@ -153,7 +154,7 @@ func (cache *schedulerCache) moveNodeInfoToHead(name string) {
 func (cache *schedulerCache) removeNodeInfoFromList(name string) {
 	ni, ok := cache.nodes[name]
 	if !ok {
-		klog.Errorf("No NodeInfo with name %v found in the cache", name)
+		klog.ErrorS(nil, "No NodeInfo found in the cache", "node", name)
 		return
 	}
 
@@ -271,7 +272,7 @@ func (cache *schedulerCache) UpdateSnapshot(nodeSnapshot *Snapshot) error {
 			", trying to recover",
 			len(nodeSnapshot.nodeInfoList), cache.nodeTree.numNodes,
 			len(nodeSnapshot.nodeInfoMap), len(cache.nodes))
-		klog.Error(errMsg)
+		klog.ErrorS(nil, errMsg)
 		// We will try to recover by re-creating the lists for the next scheduling cycle, but still return an
 		// error to surface the problem, the error will likely cause a failure to the current scheduling cycle.
 		cache.updateNodeInfoSnapshotList(nodeSnapshot, true)
@@ -289,7 +290,7 @@ func (cache *schedulerCache) updateNodeInfoSnapshotList(snapshot *Snapshot, upda
 		snapshot.nodeInfoList = make([]*framework.NodeInfo, 0, cache.nodeTree.numNodes)
 		nodesList, err := cache.nodeTree.list()
 		if err != nil {
-			klog.Error(err)
+			klog.ErrorS(err, "Failed to get node list from cache")
 		}
 		for _, nodeName := range nodesList {
 			if nodeInfo := snapshot.nodeInfoMap[nodeName]; nodeInfo != nil {
@@ -301,7 +302,7 @@ func (cache *schedulerCache) updateNodeInfoSnapshotList(snapshot *Snapshot, upda
 					snapshot.havePodsWithRequiredAntiAffinityNodeInfoList = append(snapshot.havePodsWithRequiredAntiAffinityNodeInfoList, nodeInfo)
 				}
 			} else {
-				klog.Errorf("node %q exist in nodeTree but not in NodeInfoMap, this should not happen.", nodeName)
+				klog.ErrorS(nil, "Node exists in nodeTree but not in NodeInfoMap, this should not happen", "node", nodeName)
 			}
 		}
 	} else {
@@ -388,7 +389,7 @@ func (cache *schedulerCache) finishBinding(pod *v1.Pod, now time.Time) error {
 	cache.mu.RLock()
 	defer cache.mu.RUnlock()
 
-	klog.V(5).Infof("Finished binding for pod %v. Can be expired.", key)
+	klog.V(5).InfoS("Finished binding for pod. Can be expired", "pod", key)
 	currState, ok := cache.podStates[key]
 	if ok && cache.assumedPods.Has(key) {
 		dl := now.Add(cache.ttl)
@@ -454,7 +455,7 @@ func (cache *schedulerCache) updatePod(oldPod, newPod *v1.Pod) error {
 func (cache *schedulerCache) removePod(pod *v1.Pod) error {
 	n, ok := cache.nodes[pod.Spec.NodeName]
 	if !ok {
-		klog.Errorf("node %v not found when trying to remove pod %v", pod.Spec.NodeName, pod.Name)
+		klog.ErrorS(nil, "Node not found when trying to remove pod", "node", pod.Spec.NodeName, "pod", pod.Name)
 		return nil
 	}
 	if err := n.info.RemovePod(pod); err != nil {
@@ -482,10 +483,10 @@ func (cache *schedulerCache) AddPod(pod *v1.Pod) error {
 	case ok && cache.assumedPods.Has(key):
 		if currState.pod.Spec.NodeName != pod.Spec.NodeName {
 			// The pod was added to a different node than it was assumed to.
-			klog.Warningf("Pod %v was assumed to be on %v but got added to %v", key, pod.Spec.NodeName, currState.pod.Spec.NodeName)
+			klog.InfoS("Pod was assumed to be on target node but got added to current node", "pod", key, "targetNode", pod.Spec.NodeName, "actualNode", currState.pod.Spec.NodeName)
 			// Clean this up.
 			if err = cache.removePod(currState.pod); err != nil {
-				klog.Errorf("removing pod error: %v", err)
+				klog.ErrorS(err, "Failed to remove pod")
 			}
 			cache.addPod(pod)
 		}
@@ -520,8 +521,8 @@ func (cache *schedulerCache) UpdatePod(oldPod, newPod *v1.Pod) error {
 	// before Update event, in which case the state would change from Assumed to Added.
 	case ok && !cache.assumedPods.Has(key):
 		if currState.pod.Spec.NodeName != newPod.Spec.NodeName {
-			klog.Errorf("Pod %v updated on a different node than previously added to.", key)
-			klog.Fatalf("Schedulercache is corrupted and can badly affect scheduling decisions")
+			klog.ErrorS(fmt.Errorf("schedulercache is corrupted and can badly affect scheduling decisions"), "Pod updated on a different node than previously added to", "pod", key)
+			os.Exit(1)
 		}
 		if err := cache.updatePod(oldPod, newPod); err != nil {
 			return err
@@ -548,8 +549,8 @@ func (cache *schedulerCache) RemovePod(pod *v1.Pod) error {
 	// before Remove event, in which case the state would change from Assumed to Added.
 	case ok && !cache.assumedPods.Has(key):
 		if currState.pod.Spec.NodeName != pod.Spec.NodeName {
-			klog.Errorf("Pod %v was assumed to be on %v but got added to %v", key, pod.Spec.NodeName, currState.pod.Spec.NodeName)
-			klog.Fatalf("Schedulercache is corrupted and can badly affect scheduling decisions")
+			klog.ErrorS(fmt.Errorf("schedulercache is corrupted and can badly affect scheduling decisions"), "Pod was assumed to be on target node but got added to current node", "pod", key, "expectedNode", pod.Spec.NodeName, "actualNode", currState.pod.Spec.NodeName)
+			os.Exit(1)
 		}
 		err := cache.removePod(currState.pod)
 		if err != nil {
@@ -733,17 +734,17 @@ func (cache *schedulerCache) cleanupAssumedPods(now time.Time) {
 	for key := range cache.assumedPods {
 		ps, ok := cache.podStates[key]
 		if !ok {
-			klog.Fatal("Key found in assumed set but not in podStates. Potentially a logical error.")
+			klog.ErrorS(nil, "Key found in assumed set but not in podStates. Potentially a logical error")
+			os.Exit(1)
 		}
 		if !ps.bindingFinished {
-			klog.V(5).Infof("Couldn't expire cache for pod %v/%v. Binding is still in progress.",
-				ps.pod.Namespace, ps.pod.Name)
+			klog.V(5).InfoS("Couldn't expire cache for pod. Binding is still in progress", "pod", klog.KObj(ps.pod))
 			continue
 		}
 		if now.After(*ps.deadline) {
-			klog.Warningf("Pod %s/%s expired", ps.pod.Namespace, ps.pod.Name)
+			klog.InfoS("Pod in specified namespace is expired", "namespace", ps.pod.Namespace, "pod", ps.pod.Name)
 			if err := cache.expirePod(key, ps); err != nil {
-				klog.Errorf("ExpirePod failed for %s: %v", key, err)
+				klog.ErrorS(err, "ExpirePod failed for pod", "pod", key)
 			}
 		}
 	}

--- a/pkg/scheduler/internal/cache/debugger/dumper.go
+++ b/pkg/scheduler/internal/cache/debugger/dumper.go
@@ -44,9 +44,9 @@ func (d *CacheDumper) DumpAll() {
 // dumpNodes writes NodeInfo to the scheduler logs.
 func (d *CacheDumper) dumpNodes() {
 	dump := d.cache.Dump()
-	klog.Info("Dump of cached NodeInfo")
+	klog.InfoS("Dump of cached NodeInfo")
 	for name, nodeInfo := range dump.Nodes {
-		klog.Info(d.printNodeInfo(name, nodeInfo))
+		klog.InfoS(d.printNodeInfo(name, nodeInfo))
 	}
 }
 
@@ -57,7 +57,7 @@ func (d *CacheDumper) dumpSchedulingQueue() {
 	for _, p := range pendingPods {
 		podData.WriteString(printPod(p))
 	}
-	klog.Infof("Dump of scheduling queue:\n%s", podData.String())
+	klog.InfoS("Dump of scheduling queue", "podData", podData.String())
 }
 
 // printNodeInfo writes parts of NodeInfo to a string.

--- a/pkg/scheduler/internal/cache/node_tree.go
+++ b/pkg/scheduler/internal/cache/node_tree.go
@@ -53,7 +53,7 @@ func (nt *nodeTree) addNode(n *v1.Node) {
 	if na, ok := nt.tree[zone]; ok {
 		for _, nodeName := range na {
 			if nodeName == n.Name {
-				klog.Warningf("node %q already exist in the NodeTree", n.Name)
+				klog.InfoS("Node already exists in the NodeTree", "node", n.Name)
 				return
 			}
 		}
@@ -62,7 +62,7 @@ func (nt *nodeTree) addNode(n *v1.Node) {
 		nt.zones = append(nt.zones, zone)
 		nt.tree[zone] = []string{n.Name}
 	}
-	klog.V(2).Infof("Added node %q in group %q to NodeTree", n.Name, zone)
+	klog.V(2).InfoS("Added node in the specified group to NodeTree", "node", n.Name, "group", zone)
 	nt.numNodes++
 }
 
@@ -76,14 +76,14 @@ func (nt *nodeTree) removeNode(n *v1.Node) error {
 				if len(nt.tree[zone]) == 0 {
 					nt.removeZone(zone)
 				}
-				klog.V(2).Infof("Removed node %q in group %q from NodeTree", n.Name, zone)
+				klog.V(2).InfoS("Removed node in the specified group from NodeTree", "node", n.Name, "group", zone)
 				nt.numNodes--
 				return nil
 			}
 		}
 	}
-	klog.Errorf("Node %q in group %q was not found", n.Name, zone)
-	return fmt.Errorf("node %q in group %q was not found", n.Name, zone)
+	klog.ErrorS(nil, "Node in the specified group was not found", "node", n.Name, "group", zone)
+	return fmt.Errorf("node %q in the specified group %q was not found", n.Name, zone)
 }
 
 // removeZone removes a zone from tree.


### PR DESCRIPTION
What type of PR is this?
/kind cleanup

What this PR does / why we need it:
part of kubernetes/enhancements#1602

Which issue(s) this PR fixes:
keps/sig-instrumentation/1602-structured-logging
Structured Logging migration instructions

Special notes for your reviewer:

Does this PR introduce a user-facing change?:
```release-note
migrate scheduler/internal logs into structured logging
```