### PR TITLE
kubelet logs print 'kubelet nodes sync' frequently

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -444,7 +444,6 @@ func NewMainKubelet(kubeCfg *kubeletconfiginternal.KubeletConfiguration,
 		nodeLister = kubeInformers.Core().V1().Nodes().Lister()
 		nodeHasSynced = func() bool {
 			if kubeInformers.Core().V1().Nodes().Informer().HasSynced() {
-				klog.Infof("kubelet nodes sync")
 				return true
 			}
 			klog.Infof("kubelet nodes not sync")


### PR DESCRIPTION
Signed-off-by: chymy <chang.min1@zte.com.cn>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
`kubeInformers.Core().V1().Nodes().Informer().HasSynced()` returns true, kubelet logs print `kubelet nodes sync` frequently.
```
...
I0119 00:07:50.745078   13507 kubelet.go:447] kubelet nodes sync
I0119 00:07:50.845316   13507 kubelet.go:447] kubelet nodes sync
I0119 00:07:50.945620   13507 kubelet.go:447] kubelet nodes sync
I0119 00:07:51.045768   13507 kubelet.go:447] kubelet nodes sync
I0119 00:07:51.145950   13507 kubelet.go:447] kubelet nodes sync
I0119 00:07:51.246268   13507 kubelet.go:447] kubelet nodes sync
I0119 00:07:51.346477   13507 kubelet.go:447] kubelet nodes sync
I0119 00:07:51.446598   13507 kubelet.go:447] kubelet nodes sync
I0119 00:07:51.546733   13507 kubelet.go:447] kubelet nodes sync
I0119 00:07:51.646869   13507 kubelet.go:447] kubelet nodes sync
I0119 00:07:51.747062   13507 kubelet.go:447] kubelet nodes sync
I0119 00:07:51.847257   13507 kubelet.go:447] kubelet nodes sync
I0119 00:07:51.947565   13507 kubelet.go:447] kubelet nodes sync
I0119 00:07:52.047724   13507 kubelet.go:447] kubelet nodes sync
I0119 00:07:52.147870   13507 kubelet.go:447] kubelet nodes sync
I0119 00:07:52.247981   13507 kubelet.go:447] kubelet nodes sync
I0119 00:07:52.348379   13507 kubelet.go:447] kubelet nodes sync
I0119 00:07:52.448427   13507 kubelet.go:447] kubelet nodes sync
I0119 00:07:52.548691   13507 kubelet.go:447] kubelet nodes sync
I0119 00:07:52.649026   13507 kubelet.go:447] kubelet nodes sync
I0119 00:07:52.749439   13507 kubelet.go:447] kubelet nodes sync
...
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
