### PR TITLE
staging/src/k8s.io/apiserver/pkg/admission: migrate to structured logs

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/namespace/lifecycle/admission.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/namespace/lifecycle/admission.go
@@ -140,7 +140,7 @@ func (l *Lifecycle) Admit(ctx context.Context, a admission.Attributes, o admissi
 			exists = true
 		}
 		if exists {
-			klog.V(4).Infof("found %s in cache after waiting", a.GetNamespace())
+			klog.V(4).InfoS("Namespace existed in cache after waiting", "namespace", klog.KRef("", a.GetNamespace()))
 		}
 	}
 
@@ -161,7 +161,8 @@ func (l *Lifecycle) Admit(ctx context.Context, a admission.Attributes, o admissi
 		case err != nil:
 			return errors.NewInternalError(err)
 		}
-		klog.V(4).Infof("found %s via storage lookup", a.GetNamespace())
+
+		klog.V(4).InfoS("Found namespace via storage lookup", "namespace", klog.KRef("", a.GetNamespace()))
 	}
 
 	// ensure that we're not trying to create objects in terminating namespaces

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/resourcequota/controller.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/resourcequota/controller.go
@@ -377,7 +377,7 @@ func getMatchedLimitedScopes(evaluator quota.Evaluator, inputObject runtime.Obje
 	for _, limitedResource := range limitedResources {
 		matched, err := evaluator.MatchingScopes(inputObject, limitedResource.MatchScopes)
 		if err != nil {
-			klog.Errorf("Error while matching limited Scopes: %v", err)
+			klog.ErrorS(err, "Error while matching limited Scopes")
 			return []corev1.ScopedResourceSelectorRequirement{}, err
 		}
 		for _, scope := range matched {
@@ -449,6 +449,8 @@ func CheckRequest(quotas []corev1.ResourceQuota, a admission.Attributes, evaluat
 		match, err := evaluator.Matches(&resourceQuota, inputObject)
 		if err != nil {
 			klog.Errorf("Error occurred while matching resource quota, %v, against input object. Err: %v", resourceQuota, err)
+			klog.ErrorS(err, "Error occurred while matching resource quota against input object",
+				"resourceQuota", resourceQuota)
 			return quotas, err
 		}
 		if !match {

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/object/matcher.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/object/matcher.go
@@ -36,7 +36,7 @@ func matchObject(obj runtime.Object, selector labels.Selector) bool {
 	}
 	accessor, err := meta.Accessor(obj)
 	if err != nil {
-		klog.V(5).Infof("cannot access metadata of %v: %v", obj, err)
+		klog.V(5).InfoS("Accessing metadata failed", "object", obj, "err", err)
 		return false
 	}
 	return selector.Matches(labels.Set(accessor.GetLabels()))

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugins.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugins.go
@@ -81,7 +81,7 @@ func (ps *Plugins) Register(name string, plugin Factory) {
 		ps.registry = map[string]Factory{}
 	}
 
-	klog.V(1).Infof("Registered admission plugin %q", name)
+	klog.V(1).InfoS("Registered admission plugin", "plugin", name)
 	ps.registry[name] = plugin
 }
 


### PR DESCRIPTION
Migrate to structured logs

File modified:
staging/src/k8s.io/apiserver/pkg/admission

**What type of PR is this?**
/kind cleanup
**What this PR does / why we need it**:
Ref:

keps/sig-instrumentation/1602-structured-logging
Structured Logging migration instructions

**Which issue(s) this PR fixes**:
Ref:
https://github.com/kubernetes/enhancements/tree/master/keps/sig-instrumentation/1602-structured-logging

https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/migration-to-structured-logging.md
**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
