### PR TITLE
validate object count quotas

### DIFF
--- a/pkg/apis/core/helper/helpers.go
+++ b/pkg/apis/core/helper/helpers.go
@@ -209,6 +209,8 @@ var standardQuotaResources = sets.NewString(
 	string(core.ResourceSecrets),
 	string(core.ResourcePersistentVolumeClaims),
 	string(core.ResourceConfigMaps),
+	string(core.ResourceServiceAccounts),
+	string(core.ResourceLimitRanges),
 	string(core.ResourceServicesNodePorts),
 	string(core.ResourceServicesLoadBalancers),
 )
@@ -236,6 +238,8 @@ var standardResources = sets.NewString(
 	string(core.ResourceSecrets),
 	string(core.ResourceConfigMaps),
 	string(core.ResourcePersistentVolumeClaims),
+	string(core.ResourceServiceAccounts),
+	string(core.ResourceLimitRanges),
 	string(core.ResourceStorage),
 	string(core.ResourceRequestsStorage),
 	string(core.ResourceServicesNodePorts),
@@ -255,6 +259,8 @@ var integerResources = sets.NewString(
 	string(core.ResourceSecrets),
 	string(core.ResourceConfigMaps),
 	string(core.ResourcePersistentVolumeClaims),
+	string(core.ResourceServiceAccounts),
+	string(core.ResourceLimitRanges),
 	string(core.ResourceServicesNodePorts),
 	string(core.ResourceServicesLoadBalancers),
 )

--- a/pkg/apis/core/types.go
+++ b/pkg/apis/core/types.go
@@ -4796,6 +4796,10 @@ const (
 	ResourceSecrets ResourceName = "secrets"
 	// ResourceConfigMaps, number
 	ResourceConfigMaps ResourceName = "configmaps"
+	// ResourceServiceAccounts, number
+	ResourceServiceAccounts ResourceName = "serviceaccounts"
+	// ResourceLimitRanges, number
+	ResourceLimitRanges ResourceName = "limitranges"
 	// ResourcePersistentVolumeClaims, number
 	ResourcePersistentVolumeClaims ResourceName = "persistentvolumeclaims"
 	// ResourceServicesNodePorts, number

--- a/pkg/apis/core/validation/validation.go
+++ b/pkg/apis/core/validation/validation.go
@@ -61,6 +61,7 @@ import (
 
 const isNegativeErrorMsg string = apimachineryvalidation.IsNegativeErrorMsg
 const isInvalidQuotaResource string = `must be a standard resource for quota`
+const isInvalidQuotaResourceName string = "resource from non-core groups must use count/<resource>.<group>"
 const fieldImmutableErrorMsg string = apimachineryvalidation.FieldImmutableErrorMsg
 const isNotIntegerErrorMsg string = `must be an integer`
 const isNotPositiveErrorMsg string = `must be greater than zero`
@@ -4965,6 +4966,12 @@ func ValidateResourceQuotaResourceName(value string, fldPath *field.Path) field.
 	if len(strings.Split(value, "/")) == 1 {
 		if !helper.IsStandardQuotaResourceName(value) {
 			return append(allErrs, field.Invalid(fldPath, value, isInvalidQuotaResource))
+		}
+	}
+
+	if r := strings.TrimPrefix(value, "count/"); r != value {
+		if len(strings.Split(r, ".")) == 1 && !helper.IsStandardQuotaResourceName(r) {
+			return append(allErrs, field.Invalid(fldPath, value, isInvalidQuotaResourceName))
 		}
 	}
 	return allErrs


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

This recently bit us when quotas for a resource in a non-core group exceeded what we thought to be our configured limit. We were not applying count limits properly (leaving off the group for non-core resources) and did not have any feedback that our quotas were misformatted.

**Which issue(s) this PR fixes**:

Fixes #97765

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
Add a very specific validation rule to fail the resource quotas creation and update request: count/<resource>.<group> for resources from non-core groups or count/<resource> for resources from the core group
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
