### PR TITLE
Cherry pick #96876 in controller to 1.19: fix nodelifecyle controller not add NoExecute taint bug

### DIFF
--- a/pkg/controller/nodelifecycle/node_lifecycle_controller.go
+++ b/pkg/controller/nodelifecycle/node_lifecycle_controller.go
@@ -1477,13 +1477,13 @@ func (nc *Controller) markNodeForTainting(node *v1.Node, status v1.ConditionStat
 	defer nc.evictorLock.Unlock()
 	if status == v1.ConditionFalse {
 		if !taintutils.TaintExists(node.Spec.Taints, NotReadyTaintTemplate) {
-			nc.zoneNoExecuteTainter[utilnode.GetZoneKey(node)].SetRemove(node.Name)
+			nc.zoneNoExecuteTainter[utilnode.GetZoneKey(node)].Remove(node.Name)
 		}
 	}
 
 	if status == v1.ConditionUnknown {
 		if !taintutils.TaintExists(node.Spec.Taints, UnreachableTaintTemplate) {
-			nc.zoneNoExecuteTainter[utilnode.GetZoneKey(node)].SetRemove(node.Name)
+			nc.zoneNoExecuteTainter[utilnode.GetZoneKey(node)].Remove(node.Name)
 		}
 	}
 

--- a/pkg/controller/nodelifecycle/scheduler/rate_limited_queue.go
+++ b/pkg/controller/nodelifecycle/scheduler/rate_limited_queue.go
@@ -194,15 +194,6 @@ func (q *UniqueQueue) Clear() {
 	}
 }
 
-// SetRemove remove value from the set if value existed
-func (q *UniqueQueue) SetRemove(value string) {
-	q.lock.Lock()
-	defer q.lock.Unlock()
-	if q.set.Has(value) {
-		q.set.Delete(value)
-	}
-}
-
 // RateLimitedTimedQueue is a unique item priority queue ordered by
 // the expected next time of execution. It is also rate limited.
 type RateLimitedTimedQueue struct {
@@ -287,11 +278,6 @@ func (q *RateLimitedTimedQueue) Remove(value string) bool {
 // Clear removes all items from the queue
 func (q *RateLimitedTimedQueue) Clear() {
 	q.queue.Clear()
-}
-
-// SetRemove remove value from the set of the queue
-func (q *RateLimitedTimedQueue) SetRemove(value string) {
-	q.queue.SetRemove(value)
 }
 
 // SwapLimiter safely swaps current limiter for this queue with the

--- a/pkg/controller/nodelifecycle/scheduler/rate_limited_queue_test.go
+++ b/pkg/controller/nodelifecycle/scheduler/rate_limited_queue_test.go
@@ -282,17 +282,6 @@ func TestClear(t *testing.T) {
 	}
 }
 
-func TestSetRemove(t *testing.T) {
-	evictor := NewRateLimitedTimedQueue(flowcontrol.NewFakeAlwaysRateLimiter())
-	evictor.Add("first", "11111")
-
-	evictor.SetRemove("first")
-
-	if evictor.queue.set.Len() != 0 {
-		t.Fatalf("SetRemove should remove element from the set.")
-	}
-}
-
 func TestSwapLimiter(t *testing.T) {
 	evictor := NewRateLimitedTimedQueue(flowcontrol.NewFakeAlwaysRateLimiter())
 	fakeAlways := flowcontrol.NewFakeAlwaysRateLimiter()


### PR DESCRIPTION
What type of PR is this?
/kind bug

What this PR does / why we need it:
this PR #89059 try to fix reconcile problem, so every 5s monitorNodeHealth() run processTaintBaseEviction(), add nodes to zoneNoExecuteTainter cause these nodes' status is Unknown or False.
Ref: kubernetes/kubernetes#96876

Which issue(s) this PR fixes:
Fix: #94183 #96183

Special notes for your reviewer:
I write a helper func to print values inside RateLimitedTimedQueue, and unit test running log as below, and log display the dirty data inside queue field.

Does this PR introduce a user-facing change?
```release-note
fixing a regression in 1.19+ where a failed node may not have the NoExecute taint set correctly
```