### PR TITLE
errors from `ResponseWriter.Write` method are not reported in in the audit log

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/filters/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/filters/BUILD
@@ -41,6 +41,7 @@ go_test(
         "//staging/src/k8s.io/component-base/metrics/testutil:go_default_library",
         "//vendor/github.com/google/uuid:go_default_library",
         "//vendor/github.com/stretchr/testify/assert:go_default_library",
+        "//vendor/golang.org/x/net/http2:go_default_library",
     ],
 )
 

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/filters/audit_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/filters/audit_test.go
@@ -18,6 +18,12 @@ package filters
 
 import (
 	"bufio"
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"golang.org/x/net/http2"
+	"math/rand"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -842,4 +848,164 @@ func withTestContext(req *http.Request, user user.Info, audit *auditinternal.Eve
 		ctx = request.WithRequestInfo(ctx, info)
 	}
 	return req.WithContext(ctx)
+}
+
+var backendCrt1 = []byte(`-----BEGIN CERTIFICATE-----
+MIIDTjCCAjagAwIBAgIJANYWBFaLyBC/MA0GCSqGSIb3DQEBCwUAMFAxCzAJBgNV
+BAYTAlBMMQ8wDQYDVQQIDAZQb2xhbmQxDzANBgNVBAcMBkdkYW5zazELMAkGA1UE
+CgwCU0sxEjAQBgNVBAMMCTEyNy4wLjAuMTAeFw0yMDEyMTExMDI0MzBaFw0zMDEy
+MDkxMDI0MzBaMFAxCzAJBgNVBAYTAlBMMQ8wDQYDVQQIDAZQb2xhbmQxDzANBgNV
+BAcMBkdkYW5zazELMAkGA1UECgwCU0sxEjAQBgNVBAMMCTEyNy4wLjAuMTCCASIw
+DQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMYax2q/m/N237UFMFKZsox4EyKq
+De+mbaRGeKqnI7Gi9Ai3b7BPCIa7RFJ2ntpGUd5GyL+HCQHG8/f6DjsbUuhZnmn7
+F7ZJeih2DP2acKkODdGbXA52kABCMdDs2DMYhR2UwECY2t+DLpxqJqE2ab8pI9Xd
+BZ3pCNodS03yHXzfeJV44lCjxoDOi9ynXLjd3w3+FowomHMEBunTepiqnbgoYtnn
+RW9tQyQQK5g6+/j/O1M8o71s/0loBT3vKSqNSrdlMOEGrj4yyL/Cw1NmQf1V1sGf
+w1QAW5xk7Br5oh8h1D+oflGWV3Y3zluuZQnA9D+vFpjL0969oFedsgr4UU8CAwEA
+AaMrMCkwCQYDVR0TBAIwADALBgNVHQ8EBAMCBaAwDwYDVR0RBAgwBocEfwAAATAN
+BgkqhkiG9w0BAQsFAAOCAQEAWbOF7TOfGiC59S50okfcS7M4gwz2kcbqOftWzcA1
+lT1qX6TWj7A4bVIOMAFK2tWNd4Omk6bnIAxTJdHB7b1hrBjkpt2krEGH1S8xeRRz
+Gs62KQwehM3fMhLvYSEqOQMETZn9AjEigYm6ohCO5obG9Gkfz7uvuv9rbIetbAmm
+YE9HdDv6qhCqtynpP2yad3v53idlrDnCIe9e4eKUD5uR/MIp9mEFgnMXR1m43/ya
+DnmddSsjtzamVvI/+2Cqjb8qT8dMHZrCBK64UwSaJsUKzSeF6yNvZKQ1yfA/NrfV
+P6gNULDOqtPgXFP4j+Z402gjYox1bGHjeDHh1OVSnr9jVw==
+-----END CERTIFICATE-----`)
+
+var backendKey1 = []byte(`-----BEGIN PRIVATE KEY-----
+MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQDGGsdqv5vzdt+1
+BTBSmbKMeBMiqg3vpm2kRniqpyOxovQIt2+wTwiGu0RSdp7aRlHeRsi/hwkBxvP3
++g47G1LoWZ5p+xe2SXoodgz9mnCpDg3Rm1wOdpAAQjHQ7NgzGIUdlMBAmNrfgy6c
+aiahNmm/KSPV3QWd6QjaHUtN8h1833iVeOJQo8aAzovcp1y43d8N/haMKJhzBAbp
+03qYqp24KGLZ50VvbUMkECuYOvv4/ztTPKO9bP9JaAU97ykqjUq3ZTDhBq4+Msi/
+wsNTZkH9VdbBn8NUAFucZOwa+aIfIdQ/qH5Rlld2N85brmUJwPQ/rxaYy9PevaBX
+nbIK+FFPAgMBAAECggEAKmdZABR7gSWUxN6TdVrIySB6mBTmXsG0/lDHS1/zV/aV
+XbhGA+sm3BABk9UoM3iR1Y45MiXpW6QGXLH9kdFLccidC/pfHPmlWDvMlAwWyVjk
+xFUI41+leyiwGRRZQrag57ALZshRMT6XH4vpMODAydY4gXKJ3T8gUe+rSsfkX/Hl
+Ce59c8pDsV3NDy4WKy00lYZfTqBqHu10qy9W8/eVYf+RUt53nrygCesnFfmJx/P8
+GnHnN06QbZdpgVgbU49u+BujkjFgKH/60Ct9A19o34upXvkPOaKbABZ4dL1lUrbo
+e3L3vnSdgXh1oOsy/JyICmDG5M2b68h33YNa+qUEgQKBgQDs1rf1+hw75o7iDlnx
+E46CPC+9DkDuisWLgbUyW5KHPgropPl80uqnRxmaWpYGU/Fgyml08orpduHIWxtU
+0tMRKm2HoFRM010fAp3xWc/B4pt2pdRMMSjMle//4FmoNlcJ8+owmD+2eook9Qjm
+qN1UsQllkSoH4zx4iI+HhDJnHwKBgQDWIdGmlZqaYGhsndkco9yK+gve6W80ik4J
+qnjnv9ux28SBrlORn2zzfGcu5LkJw8Dp9yjZzVUiFT8VFsWVNNuJyFba227Qxrwz
+Hb/qvd5l2DfXHk4poyMZThzg7cxkxlVaWUIBMoGynDxQZIOypc6WmTeEG5+9W4+w
+NCuTKt6/0QKBgQCOgALftUUXpXmC+i+TpbixE5WFovXekRCbB8gGLKLVTLczk0+p
+kx4s19LH1Ik/9XHeUutwuh5qqmTfMDIZr1/fjC+q0wTl1KbK6cAuX2NpvPbdRJmf
+3lQ2BGELC+nmFAv6qQ/XfUOYf9JuuiBI6IGDW6HTwqwPYuIXg9MYLqpE8QKBgA/2
+2YCH6szTnzVp10PxW4Ho/nWSBb5vCT5jPTxZ63EpJ09bxdM3hZHplm/CkaEOvRU0
+XhFO46f02Y0i83waQrvU+dS7Q1nBV0qgTyybFzeUlSUulzk3dmhukGycjf59YuOn
+f+pC77R3PW/o7oClJ+/GYIMy5AfkCaRjX1RLf+vhAoGBANJBi0ARkhwOWbnD2urA
+0tPMURSYIZ+JW7ghMspbm1XV1NTreCB/llLNqUGQ7zLAmH+KyqJK8O37/oh3VHrV
+6jp9pqrqmibtGEIpQi4D9IM8Zo9mc8GexCf0x+11mamC+ZXjT+bvLQzbcJGnG5CL
+W+S7SneWTL09leh5ATNhog6s
+-----END PRIVATE KEY-----`)
+
+// The default `ResponseWriter.Write` (https://golang.org/pkg/net/http/#ResponseWriter) method's buffer is 4096 K.
+// That means that most of the time `Write` method won't return any error because it will write to memory instead of sending data over the network to a client.
+// Unfortunately, that means that the audit subsystem can contain misleading entries suggesting that data was successfully sent to a client whereas due to a network error sending might have failed.
+//
+// TestClientDisconnected tests exactly that scenario.
+func TestClientDisconnected(t *testing.T) {
+	clientFinished := make(chan struct{})
+	defer close(clientFinished)
+	backendFinished := make(chan struct{})
+	defer close(backendFinished)
+	var backendWriteError error
+
+	// set up the backend server's handler
+	auditSink := &fakeAuditSink{}
+	withFakeUser := func(nextHandler http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			ctx := r.Context()
+			ctx = request.WithUser(ctx, &user.DefaultInfo{Name: "admin"})
+			if info, err := newTestRequestInfoResolver().NewRequestInfo(r); err == nil {
+				ctx = request.WithRequestInfo(ctx, info)
+			}
+
+			nextHandler.ServeHTTP(w, r.WithContext(ctx))
+		})
+	}
+	var backendHandler http.Handler
+	backendHandler = http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		<-clientFinished
+		buff := make([]byte, 4096+1) // default http net library buffer is 4096
+		rand.Read(buff)
+		_, backendWriteError = w.Write(buff)
+		backendFinished <- struct{}{}
+	})
+	policyChecker := policy.FakeChecker(auditinternal.LevelRequestResponse, nil)
+	backendHandler = WithAudit(backendHandler, auditSink, policyChecker, nil)
+	backendHandler = withFakeUser(backendHandler)
+	// set up the backend server
+	backendServer := httptest.NewUnstartedServer(backendHandler)
+	backendCert, err := tls.X509KeyPair(backendCrt1, backendKey1)
+	if err != nil {
+		t.Fatalf("backend: invalid x509/key pair: %v", err)
+	}
+	backendServer.TLS = &tls.Config{
+		Certificates: []tls.Certificate{backendCert},
+		NextProtos:   []string{http2.NextProtoTLS},
+	}
+	backendServer.StartTLS()
+	defer backendServer.Close()
+
+	// set up the client
+	clientCACertPool := x509.NewCertPool()
+	clientCACertPool.AppendCertsFromPEM(backendCrt1)
+	clientTLSConfig := &tls.Config{
+		RootCAs:    clientCACertPool,
+		NextProtos: []string{http2.NextProtoTLS},
+	}
+	client := &http.Client{}
+	client.Transport = &http2.Transport{
+		TLSClientConfig: clientTLSConfig,
+	}
+
+	// client request
+	sendRequest := func() error {
+		ctx, _ := context.WithTimeout(context.TODO(), 1*time.Millisecond)
+		req, err := http.NewRequestWithContext(ctx, "GET", fmt.Sprintf("https://127.0.0.1:%d", backendServer.Listener.Addr().(*net.TCPAddr).Port), nil)
+		if err != nil {
+			return err
+		}
+		_, err = client.Do(req)
+		if err == nil {
+			return fmt.Errorf("expected to get error - ctx cancelled")
+		}
+		clientFinished <- struct{}{}
+		return nil
+	}
+
+	// act
+	if err := sendRequest(); err != nil {
+		t.Fatal(err)
+	}
+
+	// validate
+	<-backendFinished
+	if backendWriteError == nil {
+		t.Error("expected to get an error - client disconnected before write started")
+
+	} else if backendWriteError.Error() != "http2: stream closed" {
+		t.Errorf("unexpected error received: %v", backendWriteError)
+	}
+
+	if len(auditSink.Events()) != 2 {
+		t.Fatalf("unexpected events recorded in the audit log, expected exaclty 2 got %d", len(auditSink.events))
+	}
+	auditEntryValidated := false
+	for _, ev := range auditSink.Events() {
+		if ev.Stage == auditinternal.StageResponseComplete {
+			if ev.ResponseStatus.Message != "error while sending data to the client, err = http2: stream closed" {
+				t.Fatalf("unexpected Message received = %q", ev.ResponseStatus.Message)
+			}
+			if ev.ResponseStatus.Status != "Failure" {
+				t.Fatalf("unexpected Status received = %q", ev.ResponseStatus.Status)
+			}
+			auditEntryValidated = true
+		}
+	}
+	if !auditEntryValidated {
+		t.Fatal("auditlog wasn't validated")
+	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**: This PR examines errors returned from the  `Write` method that writes the data to the connection as part of an HTTP reply and properly reports any issue in the audit log.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->


**Special notes for your reviewer**: Unfortunately the `Write` method stores data in memory. The default buffer size is 4096 K so most of the time it won't return any errors. One way of improving it would be changing the default buffer size - not supported by the std lib at the moment.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
