### PR TITLE
kubectl diff: update regex to allow equal sign

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/diff/diff.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/diff/diff.go
@@ -177,8 +177,8 @@ func (d *DiffProgram) getCommand(args ...string) (string, exec.Cmd) {
 		diff = diffCommand[0]
 
 		if len(diffCommand) > 1 {
-			// Regex accepts: Alphanumeric (case-insensitive) and dash
-			isValidChar := regexp.MustCompile(`^[a-zA-Z0-9-]+$`).MatchString
+			// Regex accepts: Alphanumeric (case-insensitive), dash and equal
+			isValidChar := regexp.MustCompile(`^[a-zA-Z0-9-=]+$`).MatchString
 			for i := 1; i < len(diffCommand); i++ {
 				if isValidChar(diffCommand[i]) {
 					args = append(args, diffCommand[i])


### PR DESCRIPTION
When using GNU diffutils, some commands (e.g. --color[=WHEN])
requires an equal sign.

Signed-off-by: Douglas Schilling Landgraf <dougsland@redhat.com>
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:
Allow users to use external diff commands using = sign, example:
```
$ export KUBECTL_EXTERNAL_DIFF="diff --color=auto"; kubectl diff -f deploy.yaml 
```

**Which issue(s) this PR fixes**:
Fixes #https://github.com/kubernetes/kubectl/issues/1007

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
KUBECTL_EXTERNAL_DIFF now accepts equal sign for additional parameters.
```

/sig cli