### PR TITLE
Change yaml.load() to safe_load()

### DIFF
--- a/hack/verify-publishing-bot.py
+++ b/hack/verify-publishing-bot.py
@@ -45,7 +45,7 @@ def get_gomod_dependencies(rootdir, components):
 def get_rules_dependencies(rules_file):
     import yaml
     with open(rules_file) as f:
-        data = yaml.load(f)
+        data = yaml.safe_load(f)
     return data
 
 


### PR DESCRIPTION
Hardening measure to prevent [issues] with parsing crafted yaml:

https://pyyaml.org/wiki/PyYAMLDocumentation#loading-yaml

`safe_load()` will become the default in [version 6.0]:

[issues]: https://nvd.nist.gov/vuln/search/results?form_type=Basic&results_type=overview&query=pyyaml&search_type=all
[version 6.0]: https://github.com/yaml/pyyaml/issues/420#issuecomment-696752389