### PR TITLE
Attempt to deflake networking tests in large clusters

### DIFF
--- a/test/e2e/framework/service/const.go
+++ b/test/e2e/framework/service/const.go
@@ -51,10 +51,10 @@ const (
 	// LoadBalancerCreateTimeoutDefault is the default time to wait for a load balancer to be created/modified.
 	// TODO: once support ticket 21807001 is resolved, reduce this timeout back to something reasonable
 	// Hideen - use GetServiceLoadBalancerCreateTimeout function instead.
-	loadBalancerCreateTimeoutDefault = 20 * time.Minute
+	loadBalancerCreateTimeoutDefault = 10 * time.Minute
 	// LoadBalancerCreateTimeoutLarge is the maximum time to wait for a load balancer to be created/modified.
 	// Hideen - use GetServiceLoadBalancerCreateTimeout function instead.
-	loadBalancerCreateTimeoutLarge = 2 * time.Hour
+	loadBalancerCreateTimeoutLarge = 45 * time.Minute
 
 	// LoadBalancerPropagationTimeoutDefault is the default time to wait for pods to
 	// be targeted by load balancers.


### PR DESCRIPTION
This PR:
- increases some timeouts in two networking tests, which seemed to be too aggressive for large (5k-node) clusters
- it also decreases the "load-balancer programming" timeout for both smaller clusters (from 20m to 10m) and for larger clusters (from 2h to 45m)

```release-note
NONE
```

/kind flake
/sig network
/priority important-soon

/assign @bowei @thockin @aojea 