### PR TITLE
Automated cherry pick of #96754: reduce buckets for etcd_request_duration_seconds

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/metrics/metrics.go
@@ -37,10 +37,8 @@ var (
 		&compbasemetrics.HistogramOpts{
 			Name: "etcd_request_duration_seconds",
 			Help: "Etcd request latency in seconds for each operation and object type.",
-			// Keeping it similar to the buckets used by the apiserver_request_duration_seconds metric so that
-			// api latency and etcd latency can be more comparable side by side.
-			Buckets: []float64{.005, .01, .025, 0.05, 0.1, 0.15, 0.2, 0.25, 0.3, 0.35, 0.4, 0.45, 0.5, 0.6, 0.7,
-				0.8, 0.9, 1.0, 1.25, 1.5, 1.75, 2.0, 2.5, 3.0, 3.5, 4.0, 4.5, 5, 6, 7, 8, 9, 10, 15, 20, 25, 30, 40, 50, 60},
+			// Etcd request latency in seconds for each operation and object type.
+			Buckets:        []float64{0.005, 0.025, 0.1, 0.25, 0.5, 1.0, 2.0, 4.0, 15.0, 30.0, 60.0},
 			StabilityLevel: compbasemetrics.ALPHA,
 		},
 		[]string{"operation", "type"},


### PR DESCRIPTION
Cherry pick of #96754 on release-1.20.

#96754: reduce buckets for etcd_request_duration_seconds

Reason for cherry pick: this reduces the cardinality of the `etcd_request_duration_seconds` metric in a stock medium weight CRD (80 crd) cluster from 25k time series to ~8k time series; excessive cardinality can be a performance bottleneck.