### PR TITLE
test images: Fixes echoserver image for Windows

### DIFF
--- a/test/images/echoserver/Dockerfile_windows
+++ b/test/images/echoserver/Dockerfile_windows
@@ -19,21 +19,24 @@ ARG REGISTRY
 FROM --platform=linux/amd64 alpine:3.6 as prep
 
 ADD https://openresty.org/download/openresty-1.13.6.2-win64.zip /openresty-win64.zip
+ADD http://wiki.overbyte.eu/arch/openssl-1.1.1i-win64.zip /openssl.zip
 RUN mkdir /openresty &&\
-    unzip /openresty-win64.zip -d /openresty
+    unzip /openresty-win64.zip -d /openresty &&\
+    mkdir /openssl &&\
+    unzip /openssl.zip -d /openssl
 
-FROM $REGISTRY/windows-image-builder-helper:1.1-windows-amd64-1809 as helper
 FROM $BASEIMAGE
 
 COPY --from=prep /openresty/openresty-1.13.6.2-win64 /openresty
-COPY --from=helper /Windows/System32/vcruntime140.dll /Windows/System32/
-COPY --from=helper ["/Program Files/OpenSSL", "/Program Files/OpenSSL"]
+COPY --from=prep /openssl /openssl
 
-ENV PATH="C:\openresty\;C:\bin\;C:\curl\;C:\Windows\system32;C:\Windows;C:\Program Files\PowerShell;"
+ADD ["https://raw.githubusercontent.com/openssl/openssl/OpenSSL_1_1_1i/apps/openssl.cnf", "/Program Files/Common Files/SSL/openssl.cnf"]
+
+ENV PATH="C:\openssl\;C:\openresty\;C:\bin\;C:\curl\;C:\Windows\system32;C:\Windows;C:\Program Files\PowerShell;"
 
 ADD run.sh /openresty/run.sh
 ADD nginx.conf /openresty/conf/nginx.conf
 ADD template.lua /openresty/lua/template.lua
 
 EXPOSE 80 443 8080 8443
-ENTRYPOINT ["/bin/sh", "/openresty/run.sh"]
+ENTRYPOINT ["/bin/sh", "-c", " cd /openresty && ./run.sh"]

--- a/test/images/echoserver/run.sh
+++ b/test/images/echoserver/run.sh
@@ -21,5 +21,15 @@ openssl req -x509 -sha256 -nodes -days 365 -newkey rsa:2048 \
 -out /certs/certificate.crt \
 -subj "/C=UK/ST=Warwickshire/L=Leamington/O=OrgName/OU=IT Department/CN=example.com"
 
+# If we're running on Windows, skip loading the Linux .so modules.
+if [ "$(uname)" = "Windows_NT" ]; then
+	sed -i -E "s/^(load_module modules\/ndk_http_module.so;)$/#\1/" conf/nginx.conf
+	sed -i -E "s/^(load_module modules\/ngx_http_lua_module.so;)$/#\1/" conf/nginx.conf
+	sed -i -E "s/^(load_module modules\/ngx_http_lua_upstream_module.so;)$/#\1/" conf/nginx.conf
+
+	# NOTE(claudiub): on Windows, nginx will take the paths in the nginx.conf file as relative paths.
+	cmd /S /C "mklink /D C:\\openresty\\certs C:\\certs"
+fi
+
 echo "Starting nginx"
 nginx -g "daemon off;"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

/sig windows
/sig testing
/priority important-soon

**What this PR does / why we need it**:

The Windows echoserver image no longer relies on a helper image.

This addresses the current echoserver image builder postsubmit job which is currently failing [1].

[1] https://testgrid.k8s.io/sig-testing-images#post-kubernetes-push-e2e-echoserver-test-images

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
