### PR TITLE
add knabben to test/e2e/network/netpol/OWNERS

### DIFF
--- a/test/e2e/network/netpol/OWNERS
+++ b/test/e2e/network/netpol/OWNERS
@@ -2,7 +2,9 @@ approvers:
  - jayunit100
  - mattfenwick
  - abhiraut
+ - knabben
 reviewers:
  - jayunit100
  - mattfenwick
  - abhiraut
+ - knabben


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

@knabben has contributed a ton to the e2e netpol tests and knows them really well!

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
