### PR TITLE
fix duplicate validation error for quota editing

### DIFF
--- a/pkg/registry/core/resourcequota/strategy.go
+++ b/pkg/registry/core/resourcequota/strategy.go
@@ -72,8 +72,7 @@ func (resourcequotaStrategy) AllowCreateOnUpdate() bool {
 
 // ValidateUpdate is the default update validation for an end user.
 func (resourcequotaStrategy) ValidateUpdate(ctx context.Context, obj, old runtime.Object) field.ErrorList {
-	errorList := validation.ValidateResourceQuota(obj.(*api.ResourceQuota))
-	return append(errorList, validation.ValidateResourceQuotaUpdate(obj.(*api.ResourceQuota), old.(*api.ResourceQuota))...)
+	return validation.ValidateResourceQuotaUpdate(obj.(*api.ResourceQuota), old.(*api.ResourceQuota))
 }
 
 func (resourcequotaStrategy) AllowUnconditionalUpdate() bool {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
/kind cleanup

Detailed reason in https://github.com/kubernetes/kubernetes/pull/98201#issuecomment-765116930

**What this PR does / why we need it**:
When adding a wrong quota like `"test": "12"` in spec.hard, there are four errors return. Two of them are duplicates.

**Which issue(s) this PR fixes**:

How to reproduce it?
Create a quota and edit it with kubectl, and add `"test": "12"` in spec.hard.
```
apiVersion: v1
kind: ResourceQuota
metadata:
  name: example
spec:
  hard:
    pods: "18"
    limits.cpu: "26"
    limits.memory: "62Gi"
    "test": "12"

```
the error message is like 
```
# resourcequotas "example" was not valid:
# * spec.hard[test]: Invalid value: "test": must be a standard resource type or fully qualified
# * spec.hard[test]: Invalid value: "test": must be a standard resource for quota
# * spec.hard[test]: Invalid value: "test": must be a standard resource type or fully qualified
# * spec.hard[test]: Invalid value: "test": must be a standard resource for quota
#
```
Errors are duplicated. 

**Special notes for your reviewer**:
I read the code of LimitRange and ResourceQuota during investigating #98071 
A typo and small loop continue problem were found during the code reading. So I fixed collectively with this issue.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
