### PR TITLE
Print queue lengths on watch termination

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher.go
@@ -1258,7 +1258,7 @@ func (c *cacheWatcher) add(event *watchCacheEvent, timer *time.Timer) bool {
 		// This means that we couldn't send event to that watcher.
 		// Since we don't want to block on it infinitely,
 		// we simply terminate it.
-		klog.V(1).Infof("Forcing %v watcher close due to unresponsiveness: %v", c.objectType.String(), c.identifier)
+		klog.V(1).Infof("Forcing %v watcher close due to unresponsiveness: %v. len(c.input) = %v, len(c.result) = %v", c.objectType.String(), c.identifier, len(c.input), len(c.result))
 		terminatedWatchersCounter.WithLabelValues(c.objectType.String()).Inc()
 		c.forget()
 	}


### PR DESCRIPTION
Print c.input and c.result queue lengths to:
a) understand what length are being used (they varies by type)
b) understand which queue is being blocked

Part of: https://github.com/kubernetes/kubernetes/pull/98141
Ref #97798

```release-note
NONE
```

/kind feature
/sig scalability
/assign @wojtek-t