### PR TITLE
Disable in-tree plugin without enabling CSI migration

### DIFF
--- a/cmd/kube-controller-manager/app/plugins_providers.go
+++ b/cmd/kube-controller-manager/app/plugins_providers.go
@@ -35,40 +35,48 @@ import (
 
 type probeFn func() []volume.VolumePlugin
 
-func appendPluginBasedOnMigrationFeatureFlags(plugins []volume.VolumePlugin, inTreePluginName string, featureGate featuregate.FeatureGate, pluginMigration, pluginMigrationComplete featuregate.Feature, fn probeFn) ([]volume.VolumePlugin, error) {
+func appendPluginBasedOnFeatureFlags(plugins []volume.VolumePlugin, inTreePluginName string, featureGate featuregate.FeatureGate, pluginInfo pluginInfo) ([]volume.VolumePlugin, error) {
 	// Skip appending the in-tree plugin to the list of plugins to be probed/initialized
 	// if the CSIMigration feature flag and plugin specific feature flag indicating
 	// CSI migration is complete
-	err := csimigration.CheckMigrationFeatureFlags(featureGate, pluginMigration, pluginMigrationComplete)
+	migrationComplete, err := csimigration.CheckMigrationFeatureFlags(featureGate, pluginInfo.pluginMigrationFeature,
+		pluginInfo.pluginMigrationCompleteFeature, pluginInfo.pluginUnregisterFeature)
 	if err != nil {
 		klog.Warningf("Unexpected CSI Migration Feature Flags combination detected: %v. CSI Migration may not take effect", err)
 		// TODO: fail and return here once alpha only tests can set the feature flags for a plugin correctly
 	}
-	if featureGate.Enabled(features.CSIMigration) && featureGate.Enabled(pluginMigration) && featureGate.Enabled(pluginMigrationComplete) {
-		klog.Infof("Skip registration of plugin %s since feature flag %v is enabled", inTreePluginName, pluginMigrationComplete)
+	// TODO: This can be removed after feature flag CSIMigrationvSphereComplete is removed.
+	if migrationComplete {
+		klog.Infof("Skip registration of plugin %s since migration is complete", inTreePluginName)
 		return plugins, nil
 	}
-	plugins = append(plugins, fn()...)
+	if featureGate.Enabled(pluginInfo.pluginUnregisterFeature) {
+		klog.Infof("Skip registration of plugin %s since feature flag %v is enabled", inTreePluginName, pluginInfo.pluginUnregisterFeature)
+		return plugins, nil
+	}
+	plugins = append(plugins, pluginInfo.pluginProbeFunction()...)
 	return plugins, nil
 }
 
 type pluginInfo struct {
-	pluginMigrationFeature         featuregate.Feature
+	pluginMigrationFeature featuregate.Feature
+	// deprecated, only to keep here for vSphere
 	pluginMigrationCompleteFeature featuregate.Feature
+	pluginUnregisterFeature        featuregate.Feature
 	pluginProbeFunction            probeFn
 }
 
 func appendAttachableLegacyProviderVolumes(allPlugins []volume.VolumePlugin, featureGate featuregate.FeatureGate) ([]volume.VolumePlugin, error) {
 	pluginMigrationStatus := make(map[string]pluginInfo)
-	pluginMigrationStatus[plugins.AWSEBSInTreePluginName] = pluginInfo{pluginMigrationFeature: features.CSIMigrationAWS, pluginMigrationCompleteFeature: features.CSIMigrationAWSComplete, pluginProbeFunction: awsebs.ProbeVolumePlugins}
-	pluginMigrationStatus[plugins.GCEPDInTreePluginName] = pluginInfo{pluginMigrationFeature: features.CSIMigrationGCE, pluginMigrationCompleteFeature: features.CSIMigrationGCEComplete, pluginProbeFunction: gcepd.ProbeVolumePlugins}
-	pluginMigrationStatus[plugins.CinderInTreePluginName] = pluginInfo{pluginMigrationFeature: features.CSIMigrationOpenStack, pluginMigrationCompleteFeature: features.CSIMigrationOpenStackComplete, pluginProbeFunction: cinder.ProbeVolumePlugins}
-	pluginMigrationStatus[plugins.AzureDiskInTreePluginName] = pluginInfo{pluginMigrationFeature: features.CSIMigrationAzureDisk, pluginMigrationCompleteFeature: features.CSIMigrationAzureDiskComplete, pluginProbeFunction: azuredd.ProbeVolumePlugins}
-	pluginMigrationStatus[plugins.VSphereInTreePluginName] = pluginInfo{pluginMigrationFeature: features.CSIMigrationvSphere, pluginMigrationCompleteFeature: features.CSIMigrationvSphereComplete, pluginProbeFunction: vsphere_volume.ProbeVolumePlugins}
+	pluginMigrationStatus[plugins.AWSEBSInTreePluginName] = pluginInfo{pluginMigrationFeature: features.CSIMigrationAWS, pluginUnregisterFeature: features.InTreePluginAWSUnregister, pluginProbeFunction: awsebs.ProbeVolumePlugins}
+	pluginMigrationStatus[plugins.GCEPDInTreePluginName] = pluginInfo{pluginMigrationFeature: features.CSIMigrationGCE, pluginUnregisterFeature: features.InTreePluginGCEUnregister, pluginProbeFunction: gcepd.ProbeVolumePlugins}
+	pluginMigrationStatus[plugins.CinderInTreePluginName] = pluginInfo{pluginMigrationFeature: features.CSIMigrationOpenStack, pluginUnregisterFeature: features.InTreePluginOpenStackUnregister, pluginProbeFunction: cinder.ProbeVolumePlugins}
+	pluginMigrationStatus[plugins.AzureDiskInTreePluginName] = pluginInfo{pluginMigrationFeature: features.CSIMigrationAzureDisk, pluginUnregisterFeature: features.InTreePluginAzureDiskUnregister, pluginProbeFunction: azuredd.ProbeVolumePlugins}
+	pluginMigrationStatus[plugins.VSphereInTreePluginName] = pluginInfo{pluginMigrationFeature: features.CSIMigrationvSphere, pluginMigrationCompleteFeature: features.CSIMigrationvSphereComplete, pluginUnregisterFeature: features.InTreePluginvSphereUnregister, pluginProbeFunction: vsphere_volume.ProbeVolumePlugins}
 
 	var err error
 	for pluginName, pluginInfo := range pluginMigrationStatus {
-		allPlugins, err = appendPluginBasedOnMigrationFeatureFlags(allPlugins, pluginName, featureGate, pluginInfo.pluginMigrationFeature, pluginInfo.pluginMigrationCompleteFeature, pluginInfo.pluginProbeFunction)
+		allPlugins, err = appendPluginBasedOnFeatureFlags(allPlugins, pluginName, featureGate, pluginInfo)
 		if err != nil {
 			return allPlugins, err
 		}
@@ -81,20 +89,24 @@ func appendExpandableLegacyProviderVolumes(allPlugins []volume.VolumePlugin, fea
 }
 
 func appendLegacyProviderVolumes(allPlugins []volume.VolumePlugin, featureGate featuregate.FeatureGate) ([]volume.VolumePlugin, error) {
-	pluginMigrationStatus := make(map[string]pluginInfo)
-	pluginMigrationStatus[plugins.AWSEBSInTreePluginName] = pluginInfo{pluginMigrationFeature: features.CSIMigrationAWS, pluginMigrationCompleteFeature: features.CSIMigrationAWSComplete, pluginProbeFunction: awsebs.ProbeVolumePlugins}
-	pluginMigrationStatus[plugins.GCEPDInTreePluginName] = pluginInfo{pluginMigrationFeature: features.CSIMigrationGCE, pluginMigrationCompleteFeature: features.CSIMigrationGCEComplete, pluginProbeFunction: gcepd.ProbeVolumePlugins}
-	pluginMigrationStatus[plugins.CinderInTreePluginName] = pluginInfo{pluginMigrationFeature: features.CSIMigrationOpenStack, pluginMigrationCompleteFeature: features.CSIMigrationOpenStackComplete, pluginProbeFunction: cinder.ProbeVolumePlugins}
-	pluginMigrationStatus[plugins.AzureDiskInTreePluginName] = pluginInfo{pluginMigrationFeature: features.CSIMigrationAzureDisk, pluginMigrationCompleteFeature: features.CSIMigrationAzureDiskComplete, pluginProbeFunction: azuredd.ProbeVolumePlugins}
-	pluginMigrationStatus[plugins.AzureFileInTreePluginName] = pluginInfo{pluginMigrationFeature: features.CSIMigrationAzureFile, pluginMigrationCompleteFeature: features.CSIMigrationAzureFileComplete, pluginProbeFunction: azure_file.ProbeVolumePlugins}
-	pluginMigrationStatus[plugins.VSphereInTreePluginName] = pluginInfo{pluginMigrationFeature: features.CSIMigrationvSphere, pluginMigrationCompleteFeature: features.CSIMigrationvSphereComplete, pluginProbeFunction: vsphere_volume.ProbeVolumePlugins}
-
 	var err error
-	for pluginName, pluginInfo := range pluginMigrationStatus {
-		allPlugins, err = appendPluginBasedOnMigrationFeatureFlags(allPlugins, pluginName, featureGate, pluginInfo.pluginMigrationFeature, pluginInfo.pluginMigrationCompleteFeature, pluginInfo.pluginProbeFunction)
-		if err != nil {
-			return allPlugins, err
-		}
+	// First append attachable volumes
+	allPlugins, err = appendAttachableLegacyProviderVolumes(allPlugins, featureGate)
+	if err != nil {
+		return allPlugins, err
 	}
+
+	// Then append non-attachable volumes
+	pluginName := plugins.AzureFileInTreePluginName
+	pluginInfo := pluginInfo{
+		pluginMigrationFeature:  features.CSIMigrationAzureFile,
+		pluginUnregisterFeature: features.InTreePluginAzureFileUnregister,
+		pluginProbeFunction:     azure_file.ProbeVolumePlugins,
+	}
+	allPlugins, err = appendPluginBasedOnFeatureFlags(allPlugins, pluginName, featureGate, pluginInfo)
+	if err != nil {
+		return allPlugins, err
+	}
+
 	return allPlugins, nil
 }

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -328,12 +328,11 @@ const (
 	// Enables the GCE PD in-tree driver to GCE CSI Driver migration feature.
 	CSIMigrationGCE featuregate.Feature = "CSIMigrationGCE"
 
-	// owner: @davidz627
-	// alpha: v1.17
+	// owner: @Jiawei0227
+	// alpha: v1.21
 	//
 	// Disables the GCE PD in-tree driver.
-	// Expects GCE PD CSI Driver to be installed and configured on all nodes.
-	CSIMigrationGCEComplete featuregate.Feature = "CSIMigrationGCEComplete"
+	InTreePluginGCEUnregister featuregate.Feature = "InTreePluginGCEUnregister"
 
 	// owner: @leakingtapan
 	// alpha: v1.14
@@ -343,11 +342,10 @@ const (
 	CSIMigrationAWS featuregate.Feature = "CSIMigrationAWS"
 
 	// owner: @leakingtapan
-	// alpha: v1.17
+	// alpha: v1.21
 	//
 	// Disables the AWS EBS in-tree driver.
-	// Expects AWS EBS CSI Driver to be installed and configured on all nodes.
-	CSIMigrationAWSComplete featuregate.Feature = "CSIMigrationAWSComplete"
+	InTreePluginAWSUnregister featuregate.Feature = "InTreePluginAWSUnregister"
 
 	// owner: @andyzhangx
 	// alpha: v1.15
@@ -357,11 +355,10 @@ const (
 	CSIMigrationAzureDisk featuregate.Feature = "CSIMigrationAzureDisk"
 
 	// owner: @andyzhangx
-	// alpha: v1.17
+	// alpha: v1.21
 	//
 	// Disables the Azure Disk in-tree driver.
-	// Expects Azure Disk CSI Driver to be installed and configured on all nodes.
-	CSIMigrationAzureDiskComplete featuregate.Feature = "CSIMigrationAzureDiskComplete"
+	InTreePluginAzureDiskUnregister featuregate.Feature = "InTreePluginAzureDiskUnregister"
 
 	// owner: @andyzhangx
 	// alpha: v1.15
@@ -370,11 +367,10 @@ const (
 	CSIMigrationAzureFile featuregate.Feature = "CSIMigrationAzureFile"
 
 	// owner: @andyzhangx
-	// alpha: v1.17
+	// alpha: v1.21
 	//
 	// Disables the Azure File in-tree driver.
-	// Expects Azure File CSI Driver to be installed and configured on all nodes.
-	CSIMigrationAzureFileComplete featuregate.Feature = "CSIMigrationAzureFileComplete"
+	InTreePluginAzureFileUnregister featuregate.Feature = "InTreePluginAzureFileUnregister"
 
 	// owner: @divyenpatel
 	// beta: v1.19 (requires: vSphere vCenter/ESXi Version: 7.0u1, HW Version: VM version 15)
@@ -388,6 +384,25 @@ const (
 	// Disables the vSphere in-tree driver.
 	// Expects vSphere CSI Driver to be installed and configured on all nodes.
 	CSIMigrationvSphereComplete featuregate.Feature = "CSIMigrationvSphereComplete"
+
+	// owner: @divyenpatel
+	// alpha: v1.21
+	//
+	// Disables the vSphere in-tree driver.
+	InTreePluginvSphereUnregister featuregate.Feature = "InTreePluginvSphereUnregister"
+
+	// owner: @adisky
+	// alpha: v1.14
+	// beta: v1.18
+	//
+	// Enables the OpenStack Cinder in-tree driver to OpenStack Cinder CSI Driver migration feature.
+	CSIMigrationOpenStack featuregate.Feature = "CSIMigrationOpenStack"
+
+	// owner: @adisky
+	// alpha: v1.21
+	//
+	// Disables the OpenStack Cinder in-tree driver.
+	InTreePluginOpenStackUnregister featuregate.Feature = "InTreePluginOpenStackUnregister"
 
 	// owner: @huffmanca
 	// alpha: v1.19
@@ -424,20 +439,6 @@ const (
 	//
 	// Enables support for running container entrypoints as different usernames than their default ones.
 	WindowsRunAsUserName featuregate.Feature = "WindowsRunAsUserName"
-
-	// owner: @adisky
-	// alpha: v1.14
-	// beta: v1.18
-	//
-	// Enables the OpenStack Cinder in-tree driver to OpenStack Cinder CSI Driver migration feature.
-	CSIMigrationOpenStack featuregate.Feature = "CSIMigrationOpenStack"
-
-	// owner: @adisky
-	// alpha: v1.17
-	//
-	// Disables the OpenStack Cinder in-tree driver.
-	// Expects the OpenStack Cinder CSI Driver to be installed and configured on all nodes.
-	CSIMigrationOpenStackComplete featuregate.Feature = "CSIMigrationOpenStackComplete"
 
 	// owner: @RobertKrawitz
 	// alpha: v1.15
@@ -683,60 +684,61 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 	AppArmor:             {Default: true, PreRelease: featuregate.Beta},
 	DynamicKubeletConfig: {Default: true, PreRelease: featuregate.Beta},
 	ExperimentalHostUserNamespaceDefaultingGate: {Default: false, PreRelease: featuregate.Beta},
-	DevicePlugins:                  {Default: true, PreRelease: featuregate.Beta},
-	RotateKubeletServerCertificate: {Default: true, PreRelease: featuregate.Beta},
-	LocalStorageCapacityIsolation:  {Default: true, PreRelease: featuregate.Beta},
-	Sysctls:                        {Default: true, PreRelease: featuregate.Beta},
-	EphemeralContainers:            {Default: false, PreRelease: featuregate.Alpha},
-	QOSReserved:                    {Default: false, PreRelease: featuregate.Alpha},
-	ExpandPersistentVolumes:        {Default: true, PreRelease: featuregate.Beta},
-	ExpandInUsePersistentVolumes:   {Default: true, PreRelease: featuregate.Beta},
-	ExpandCSIVolumes:               {Default: true, PreRelease: featuregate.Beta},
-	CPUManager:                     {Default: true, PreRelease: featuregate.Beta},
-	CPUCFSQuotaPeriod:              {Default: false, PreRelease: featuregate.Alpha},
-	TopologyManager:                {Default: true, PreRelease: featuregate.Beta},
-	ServiceNodeExclusion:           {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.22
-	NodeDisruptionExclusion:        {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.22
-	CSIDriverRegistry:              {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.20
-	BlockVolume:                    {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.20
-	StorageObjectInUseProtection:   {Default: true, PreRelease: featuregate.GA},
-	SupportPodPidsLimit:            {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.23
-	SupportNodePidsLimit:           {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.23
-	BoundServiceAccountTokenVolume: {Default: false, PreRelease: featuregate.Alpha},
-	ServiceAccountIssuerDiscovery:  {Default: true, PreRelease: featuregate.Beta},
-	CRIContainerLogRotation:        {Default: true, PreRelease: featuregate.Beta},
-	CSIMigration:                   {Default: true, PreRelease: featuregate.Beta},
-	CSIMigrationGCE:                {Default: false, PreRelease: featuregate.Beta}, // Off by default (requires GCE PD CSI Driver)
-	CSIMigrationGCEComplete:        {Default: false, PreRelease: featuregate.Alpha},
-	CSIMigrationAWS:                {Default: false, PreRelease: featuregate.Beta}, // Off by default (requires AWS EBS CSI driver)
-	CSIMigrationAWSComplete:        {Default: false, PreRelease: featuregate.Alpha},
-	CSIMigrationAzureDisk:          {Default: false, PreRelease: featuregate.Beta}, // Off by default (requires Azure Disk CSI driver)
-	CSIMigrationAzureDiskComplete:  {Default: false, PreRelease: featuregate.Alpha},
-	CSIMigrationAzureFile:          {Default: false, PreRelease: featuregate.Alpha},
-	CSIMigrationAzureFileComplete:  {Default: false, PreRelease: featuregate.Alpha},
-	CSIMigrationvSphere:            {Default: false, PreRelease: featuregate.Beta},
-	CSIMigrationvSphereComplete:    {Default: false, PreRelease: featuregate.Beta},
-	RunAsGroup:                     {Default: true, PreRelease: featuregate.Beta},
-	CSIMigrationOpenStack:          {Default: false, PreRelease: featuregate.Beta}, // Off by default (requires OpenStack Cinder CSI driver)
-	CSIMigrationOpenStackComplete:  {Default: false, PreRelease: featuregate.Alpha},
-	VolumeSubpath:                  {Default: true, PreRelease: featuregate.GA},
-	ConfigurableFSGroupPolicy:      {Default: true, PreRelease: featuregate.Beta},
-	BalanceAttachedNodeVolumes:     {Default: false, PreRelease: featuregate.Alpha},
-	CSIBlockVolume:                 {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.20
-	CSIInlineVolume:                {Default: true, PreRelease: featuregate.Beta},
-	CSIStorageCapacity:             {Default: false, PreRelease: featuregate.Alpha},
-	CSIServiceAccountToken:         {Default: false, PreRelease: featuregate.Alpha},
-	GenericEphemeralVolume:         {Default: false, PreRelease: featuregate.Alpha},
-	CSIVolumeFSGroupPolicy:         {Default: true, PreRelease: featuregate.Beta},
-	RuntimeClass:                   {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.23
-	NodeLease:                      {Default: true, PreRelease: featuregate.GA, LockToDefault: true},
-	SCTPSupport:                    {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.22
-	VolumeSnapshotDataSource:       {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.21
-	ProcMountType:                  {Default: false, PreRelease: featuregate.Alpha},
-	TTLAfterFinished:               {Default: false, PreRelease: featuregate.Alpha},
-	KubeletPodResources:            {Default: true, PreRelease: featuregate.Beta},
-	WindowsGMSA:                    {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.20
-	WindowsRunAsUserName:           {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.20
+	DevicePlugins:                                  {Default: true, PreRelease: featuregate.Beta},
+	RotateKubeletServerCertificate:                 {Default: true, PreRelease: featuregate.Beta},
+	LocalStorageCapacityIsolation:                  {Default: true, PreRelease: featuregate.Beta},
+	Sysctls:                                        {Default: true, PreRelease: featuregate.Beta},
+	EphemeralContainers:                            {Default: false, PreRelease: featuregate.Alpha},
+	QOSReserved:                                    {Default: false, PreRelease: featuregate.Alpha},
+	ExpandPersistentVolumes:                        {Default: true, PreRelease: featuregate.Beta},
+	ExpandInUsePersistentVolumes:                   {Default: true, PreRelease: featuregate.Beta},
+	ExpandCSIVolumes:                               {Default: true, PreRelease: featuregate.Beta},
+	CPUManager:                                     {Default: true, PreRelease: featuregate.Beta},
+	CPUCFSQuotaPeriod:                              {Default: false, PreRelease: featuregate.Alpha},
+	TopologyManager:                                {Default: true, PreRelease: featuregate.Beta},
+	ServiceNodeExclusion:                           {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.22
+	NodeDisruptionExclusion:                        {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.22
+	CSIDriverRegistry:                              {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.20
+	BlockVolume:                                    {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.20
+	StorageObjectInUseProtection:                   {Default: true, PreRelease: featuregate.GA},
+	SupportPodPidsLimit:                            {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.23
+	SupportNodePidsLimit:                           {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.23
+	BoundServiceAccountTokenVolume:                 {Default: false, PreRelease: featuregate.Alpha},
+	ServiceAccountIssuerDiscovery:                  {Default: true, PreRelease: featuregate.Beta},
+	CRIContainerLogRotation:                        {Default: true, PreRelease: featuregate.Beta},
+	CSIMigration:                                   {Default: true, PreRelease: featuregate.Beta},
+	CSIMigrationGCE:                                {Default: false, PreRelease: featuregate.Beta}, // Off by default (requires GCE PD CSI Driver)
+	InTreePluginGCEUnregister:                      {Default: false, PreRelease: featuregate.Alpha},
+	CSIMigrationAWS:                                {Default: false, PreRelease: featuregate.Beta}, // Off by default (requires AWS EBS CSI driver)
+	InTreePluginAWSUnregister:                      {Default: false, PreRelease: featuregate.Alpha},
+	CSIMigrationAzureDisk:                          {Default: false, PreRelease: featuregate.Beta}, // Off by default (requires Azure Disk CSI driver)
+	InTreePluginAzureDiskUnregister:                {Default: false, PreRelease: featuregate.Alpha},
+	CSIMigrationAzureFile:                          {Default: false, PreRelease: featuregate.Alpha}, // Off by default (requires Azure File CSI driver)
+	InTreePluginAzureFileUnregister:                {Default: false, PreRelease: featuregate.Alpha},
+	CSIMigrationvSphere:                            {Default: false, PreRelease: featuregate.Beta}, // Off by default (requires vSphere CSI driver)
+	CSIMigrationvSphereComplete:                    {Default: false, PreRelease: featuregate.Beta}, // remove in 1.22
+	InTreePluginvSphereUnregister:                  {Default: false, PreRelease: featuregate.Alpha},
+	RunAsGroup:                                     {Default: true, PreRelease: featuregate.Beta},
+	CSIMigrationOpenStack:                          {Default: false, PreRelease: featuregate.Beta}, // Off by default (requires OpenStack Cinder CSI driver)
+	InTreePluginOpenStackUnregister:                {Default: false, PreRelease: featuregate.Alpha},
+	VolumeSubpath:                                  {Default: true, PreRelease: featuregate.GA},
+	ConfigurableFSGroupPolicy:                      {Default: true, PreRelease: featuregate.Beta},
+	BalanceAttachedNodeVolumes:                     {Default: false, PreRelease: featuregate.Alpha},
+	CSIBlockVolume:                                 {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.20
+	CSIInlineVolume:                                {Default: true, PreRelease: featuregate.Beta},
+	CSIStorageCapacity:                             {Default: false, PreRelease: featuregate.Alpha},
+	CSIServiceAccountToken:                         {Default: false, PreRelease: featuregate.Alpha},
+	GenericEphemeralVolume:                         {Default: false, PreRelease: featuregate.Alpha},
+	CSIVolumeFSGroupPolicy:                         {Default: true, PreRelease: featuregate.Beta},
+	RuntimeClass:                                   {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.23
+	NodeLease:                                      {Default: true, PreRelease: featuregate.GA, LockToDefault: true},
+	SCTPSupport:                                    {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.22
+	VolumeSnapshotDataSource:                       {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.21
+	ProcMountType:                                  {Default: false, PreRelease: featuregate.Alpha},
+	TTLAfterFinished:                               {Default: false, PreRelease: featuregate.Alpha},
+	KubeletPodResources:                            {Default: true, PreRelease: featuregate.Beta},
+	WindowsGMSA:                                    {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.20
+	WindowsRunAsUserName:                           {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.20
 	LocalStorageCapacityIsolationFSQuotaMonitoring: {Default: false, PreRelease: featuregate.Alpha},
 	NonPreemptingPriority:                          {Default: true, PreRelease: featuregate.Beta},
 	PodOverhead:                                    {Default: true, PreRelease: featuregate.Beta},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature


**What this PR does / why we need it**:
This commit replaces all the alpha CSIMigrationXXXComplete
flag with InTreePluginXXUnregister flag. This new flag will
be a superset of the CSIMigrationXXXComplete. But this
decouple the plugin unregister from CSI migration. So
if a K8s distribution want to go directly with CSI and
do not support in-tree, they can use this flag directly.

For the only beta feature CSIMigrationvSphereComplete, we
deprecate it and it will be removed in 1.22.

Testing:
1. Enable the InTreePluginXXUnregister and not CSIMigrationXXX,
verify that the PVC using old plugin name will have error
saying cannot find the plugin
2. Enable both the InTreePluginXXUnregister and CSIMigrationXXX
verify that the PVC using old plugin name will start to use
the migrated CSI plugin

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #96730

**Special notes for your reviewer**:
We will deprecate the CSIMigrationvSphereComplete feature flag.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
ACTION REQUIRED: Remove alpha CSIMigrationXXComplete flag and add alpha InTreePluginXXUnregister flag. Deprecate CSIMigrationvSphereComplete flag and it will be removed in 1.22.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

TODO:
Remove CSIMigrationvSphereComplete flag after deprecation over.

/sig storage
/assign @msau42 @mattcary 