### PR TITLE
Add support for NodePort when exposing deployment

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_service.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_service.go
@@ -294,7 +294,7 @@ func NewCmdCreateServiceNodePort(f cmdutil.Factory, ioStreams genericclioptions.
 
 	cmdutil.AddApplyAnnotationFlags(cmd)
 	cmdutil.AddValidateFlags(cmd)
-	cmd.Flags().IntVar(&o.NodePort, "node-port", o.NodePort, "Port used to expose the service on each node in a cluster.")
+	cmd.Flags().IntVar(&o.NodePort, "node-port", o.NodePort, i18n.T("Port used to expose the service on each node in a cluster."))
 	cmdutil.AddFieldManagerFlagVar(cmd, &o.FieldManager, "kubectl-create")
 	cmd.Flags().StringSliceVar(&o.TCP, "tcp", o.TCP, "Port pairs can be specified as '<port>:<targetPort>'.")
 	cmdutil.AddDryRunFlag(cmd)

--- a/staging/src/k8s.io/kubectl/pkg/cmd/expose/expose.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/expose/expose.go
@@ -129,7 +129,7 @@ func NewCmdExposeService(f cmdutil.Factory, streams genericclioptions.IOStreams)
 	}
 
 	cmd := &cobra.Command{
-		Use:                   "expose (-f FILENAME | TYPE NAME) [--port=port] [--protocol=TCP|UDP|SCTP] [--target-port=number-or-name] [--name=name] [--external-ip=external-ip-of-service] [--type=type]",
+		Use:                   "expose (-f FILENAME | TYPE NAME) [--port=port] [--protocol=TCP|UDP|SCTP] [--target-port=number-or-name] [--node-port=number] [--name=name] [--external-ip=external-ip-of-service] [--type=type]",
 		DisableFlagsInUseLine: true,
 		Short:                 i18n.T("Take a replication controller, service, deployment or pod and expose it as a new Kubernetes Service"),
 		Long:                  exposeLong,
@@ -154,6 +154,7 @@ func NewCmdExposeService(f cmdutil.Factory, streams genericclioptions.IOStreams)
 	cmd.Flags().String("container-port", "", i18n.T("Synonym for --target-port"))
 	cmd.Flags().MarkDeprecated("container-port", "--container-port will be removed in the future, please use --target-port instead")
 	cmd.Flags().String("target-port", "", i18n.T("Name or number for the port on the container that the service should direct traffic to. Optional."))
+	cmd.Flags().String("node-port", "", i18n.T("Port used to expose the service on each node in a cluster."))
 	cmd.Flags().String("external-ip", "", i18n.T("Additional external IP address (not managed by Kubernetes) to accept for the service. If this IP is routed to a node, the service can be accessed by this IP in addition to its generated service IP."))
 	cmd.Flags().String("overrides", "", i18n.T("An inline JSON override for the generated object. If this is non-empty, it is used to override the generated object. Requires that the object supply a valid apiVersion field."))
 	cmd.Flags().String("name", "", i18n.T("The name for the newly created object."))

--- a/staging/src/k8s.io/kubectl/pkg/generate/versioned/service.go
+++ b/staging/src/k8s.io/kubectl/pkg/generate/versioned/service.go
@@ -71,6 +71,7 @@ func paramNames() []generate.GeneratorParam {
 		{Name: "protocols", Required: false},
 		{Name: "container-port", Required: false}, // alias of target-port
 		{Name: "target-port", Required: false},
+		{Name: "node-port", Required: false},
 		{Name: "port-name", Required: false},
 		{Name: "session-affinity", Required: false},
 		{Name: "cluster-ip", Required: false},
@@ -208,6 +209,19 @@ func generateService(genericParams map[string]interface{}) (runtime.Object, erro
 		for i := range service.Spec.Ports {
 			port := service.Spec.Ports[i].Port
 			service.Spec.Ports[i].TargetPort = intstr.FromInt(int(port))
+		}
+	}
+	if len(params["node-port"]) > 0 {
+		nodePortStringSlice := strings.Split(params["node-port"], ",")
+		if len(service.Spec.Ports) != len(nodePortStringSlice) {
+			return nil, fmt.Errorf("the quantity of ports(%d) should be equal to nodePorts(%d)", len(service.Spec.Ports), len(nodePortStringSlice))
+		}
+		for i, stillNodePortString := range nodePortStringSlice {
+			port, err := strconv.Atoi(stillNodePortString)
+			if err != nil {
+				return nil, err
+			}
+			service.Spec.Ports[i].NodePort = int32(port)
 		}
 	}
 	if len(params["external-ip"]) > 0 {


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Previously, ```expose``` command does not allow to specify ```--node-port``` even when the type of service is NodePort.

```
$ kubectl create deployment test-deploy --image=nginx
$ kubectl expose deployment.apps/test-deploy --port=80 --type=NodePort --node-port=30082
Error: unknown flag: --node-port
See 'kubectl expose --help' for usage.
```

**Which issue(s) this PR fixes**:
NONE

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Add support for NodePort when exposing deployment
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
