### PR TITLE
staging/src/k8s.io/apiserver/pkg/audit/policy/reader.go: migrate logs to structured logging

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/audit/policy/reader.go
+++ b/staging/src/k8s.io/apiserver/pkg/audit/policy/reader.go
@@ -85,6 +85,7 @@ func LoadPolicyFromBytes(policyDef []byte) (*auditinternal.Policy, error) {
 	if policyCnt == 0 {
 		return nil, fmt.Errorf("loaded illegal policy with 0 rules")
 	}
-	klog.V(4).Infof("Loaded %d audit policy rules", policyCnt)
+
+	klog.V(4).InfoS("Load audit policy rules success", "policyCnt", policyCnt)
 	return policy, nil
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
part of https://github.com/kubernetes/enhancements/issues/1602

**Which issue(s) this PR fixes**:
Ref:

https://github.com/kubernetes/enhancements/tree/master/keps/sig-instrumentation/1602-structured-logging
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/migration-to-structured-logging.md

**Special notes for your reviewer**:
before:
I0121 09:51:42.111166    1268 reader.go:88] Loaded 3 audit policy rules

after:
I0121 09:51:42.111166    1268 reader.go:89] "Load audit policy rules success" policyCnt=3

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
