### PR TITLE
Drop runs-per-test for unit tests

### DIFF
--- a/build/root/.bazelrc
+++ b/build/root/.bazelrc
@@ -32,7 +32,6 @@ test:unit --@io_bazel_rules_go//go/config:race
 
 test:unit --build_tests_only
 test:unit --test_tag_filters=-e2e,-integration
-test:unit --runs_per_test=2
 
 test:integration --local_test_jobs 4
 test:integration --test_tag_filters=integration


### PR DESCRIPTION
This was added on the assumption that we could use bazel test result caching.

Since we can't this actually doubles the runtime (or resources) of every unit test run.

Without this, flakes can still be seen in the triage board or periodic runs.

Whittling down bazelisms in our test configs ahead of https://github.com/kubernetes/kubernetes/issues/97921

```release-note
NONE
```

/cc @BenTheElder 