### PR TITLE
GCE Windows: add 20H2; install docker when nodes are started

### DIFF
--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -88,11 +88,13 @@ function set-linux-node-image() {
 function set-windows-node-image() {
   WINDOWS_NODE_IMAGE_PROJECT="windows-cloud"
   if [[ "${WINDOWS_NODE_OS_DISTRIBUTION}" == "win2019" ]]; then
-    WINDOWS_NODE_IMAGE="windows-server-2019-dc-core-for-containers-v20200908"
+    WINDOWS_NODE_IMAGE="windows-server-2019-dc-core-v20210112"
   elif [[ "${WINDOWS_NODE_OS_DISTRIBUTION}" == "win1909" ]]; then
-    WINDOWS_NODE_IMAGE="windows-server-1909-dc-core-for-containers-v20200908"
-  elif [[ "${WINDOWS_NODE_OS_DISTRIBUTION}" == "win1809" ]]; then
-    WINDOWS_NODE_IMAGE="windows-server-1809-dc-core-for-containers-v20200908"
+    WINDOWS_NODE_IMAGE="windows-server-1909-dc-core-v20210112"
+  elif [[ "${WINDOWS_NODE_OS_DISTRIBUTION}" == "win2004" ]]; then
+    WINDOWS_NODE_IMAGE="windows-server-2004-dc-core-v20210112"
+  elif [[ "${WINDOWS_NODE_OS_DISTRIBUTION,,}" == "win20h2" ]]; then
+    WINDOWS_NODE_IMAGE="windows-server-20h2-dc-core-v20210112"
   else
     echo "Unknown WINDOWS_NODE_OS_DISTRIBUTION ${WINDOWS_NODE_OS_DISTRIBUTION}" >&2
     exit 1

--- a/cluster/gce/windows/configure.ps1
+++ b/cluster/gce/windows/configure.ps1
@@ -117,6 +117,26 @@ try {
   FetchAndImport-ModuleFromMetadata 'k8s-node-setup-psm1' 'k8s-node-setup.psm1'
 
   Dump-DebugInfoToConsole
+
+  if (-not (Test-ContainersFeatureInstalled)) {
+    Install-ContainersFeature
+    Log-Output 'Restarting computer after enabling Windows Containers feature'
+    Restart-Computer -Force
+    # Restart-Computer does not stop the rest of the script from executing.
+    exit 0
+  }
+
+  if (-not (Test-DockerIsInstalled)) {
+    Install-Docker
+  }
+  # For some reason the docker service may not be started automatically on the
+  # first reboot, although it seems to work fine on subsequent reboots.
+  Restart-Service docker
+  Start-Sleep 5
+  if (-not (Test-DockerIsRunning)) {
+      throw "docker service failed to start or stay running"
+  }
+
   Set-PrerequisiteOptions
   $kube_env = Fetch-KubeEnv
 


### PR DESCRIPTION
Adds support on GCE for the latest Windows SAC version, 20H2. Removes 1809 which is now obsolete. Uses the latest version of all Windows VM images (January 2021 Windows Updates).

Updates the GCE Windows startup scripts to check for and install the Windows Containers feature and docker, since these dependencies are no longer installed on Windows SAC images.

Tested by running `kube-up.sh` with `WINDOWS_NODE_OS_DISTRIBUTION=win1909` and `WINDOWS_NODE_OS_DISTRIBUTION=win20h2`.

/kind cleanup

```release-note
Windows nodes on GCE will take longer to start due to dependencies installed at node creation time.
```