### PR TITLE
staging/src/k8s.io/apiserver/pkg/registry:migrate to structured logs

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/storage_factory.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/storage_factory.go
@@ -50,7 +50,7 @@ func StorageWithCacher() generic.StorageDecorator {
 			return s, d, err
 		}
 		if klog.V(5).Enabled() {
-			klog.Infof("Storage caching is enabled for %s", objectTypeToString(newFunc()))
+			klog.InfoS("Storage caching is enabled", objectTypeToArgs(newFunc())...)
 		}
 
 		cacherConfig := cacherstorage.Config{
@@ -83,15 +83,16 @@ func StorageWithCacher() generic.StorageDecorator {
 	}
 }
 
-func objectTypeToString(obj runtime.Object) string {
+func objectTypeToArgs(obj runtime.Object) []interface{} {
 	// special-case unstructured objects that tell us their apiVersion/kind
 	if u, isUnstructured := obj.(*unstructured.Unstructured); isUnstructured {
 		if apiVersion, kind := u.GetAPIVersion(), u.GetKind(); len(apiVersion) > 0 && len(kind) > 0 {
-			return fmt.Sprintf("apiVersion=%s, kind=%s", apiVersion, kind)
+			return []interface{}{"apiVersion", apiVersion, "kind", kind}
 		}
 	}
+
 	// otherwise just return the type
-	return fmt.Sprintf("%T", obj)
+	return []interface{}{"type", fmt.Sprintf("%T", obj)}
 }
 
 // TODO : Remove all the code below when PR

--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store.go
@@ -464,7 +464,7 @@ func ShouldDeleteDuringUpdate(ctx context.Context, key string, obj, existing run
 // Used for objects that are either been finalized or have never initialized.
 func (e *Store) deleteWithoutFinalizers(ctx context.Context, name, key string, obj runtime.Object, preconditions *storage.Preconditions, options *metav1.DeleteOptions) (runtime.Object, bool, error) {
 	out := e.NewFunc()
-	klog.V(6).Infof("going to delete %s from registry, triggered by update", name)
+	klog.V(6).InfoS("Going to delete object from registry, triggered by update", "object", klog.KRef(genericapirequest.NamespaceValue(ctx), name))
 	// Using the rest.ValidateAllObjectFunc because the request is an UPDATE request and has already passed the admission for the UPDATE verb.
 	if err := e.Storage.Delete(ctx, key, out, preconditions, rest.ValidateAllObjectFunc, dryrun.IsDryRun(options.DryRun), nil); err != nil {
 		// Deletion is racy, i.e., there could be multiple update
@@ -935,7 +935,8 @@ func (e *Store) updateForGracefulDeletionAndFinalizers(ctx context.Context, name
 			if !graceful {
 				// set the DeleteGracePeriods to 0 if the object has pendingFinalizers but not supporting graceful deletion
 				if pendingFinalizers {
-					klog.V(6).Infof("update the DeletionTimestamp to \"now\" and GracePeriodSeconds to 0 for object %s, because it has pending finalizers", name)
+					klog.V(6).InfoS("Object has pending finalizers, so the registry is going to update its status to deleting",
+						"object", klog.KRef(genericapirequest.NamespaceValue(ctx), name), "gracePeriod", time.Second*0)
 					err = markAsDeleting(existing, time.Now())
 					if err != nil {
 						return nil, err
@@ -1055,7 +1056,7 @@ func (e *Store) Delete(ctx context.Context, name string, deleteValidation rest.V
 	}
 
 	// delete immediately, or no graceful deletion supported
-	klog.V(6).Infof("going to delete %s from registry: ", name)
+	klog.V(6).InfoS("Going to delete object from registry", "object", klog.KRef(genericapirequest.NamespaceValue(ctx), name))
 	out = e.NewFunc()
 	if err := e.Storage.Delete(ctx, key, out, &preconditions, storage.ValidateObjectFunc(deleteValidation), dryrun.IsDryRun(options.DryRun), nil); err != nil {
 		// Please refer to the place where we set ignoreNotFound for the reason
@@ -1148,7 +1149,7 @@ func (e *Store) DeleteCollection(ctx context.Context, deleteValidation rest.Vali
 					return
 				}
 				if _, _, err := e.Delete(ctx, accessor.GetName(), deleteValidation, options); err != nil && !apierrors.IsNotFound(err) {
-					klog.V(4).Infof("Delete %s in DeleteCollection failed: %v", accessor.GetName(), err)
+					klog.V(4).InfoS("Delete object in DeleteCollection failed", "object", klog.KObj(accessor), "err", err)
 					errs <- err
 					return
 				}
@@ -1425,12 +1426,12 @@ func (e *Store) CompleteWithOptions(options *generic.StoreOptions) error {
 func (e *Store) startObservingCount(period time.Duration) func() {
 	prefix := e.KeyRootFunc(genericapirequest.NewContext())
 	resourceName := e.DefaultQualifiedResource.String()
-	klog.V(2).Infof("Monitoring %v count at <storage-prefix>/%v", resourceName, prefix)
+	klog.V(2).InfoS("Monitoring resource count at path", "resource", resourceName, "path", "<storage-prefix>/"+prefix)
 	stopCh := make(chan struct{})
 	go wait.JitterUntil(func() {
 		count, err := e.Storage.Count(prefix)
 		if err != nil {
-			klog.V(5).Infof("Failed to update storage count metric: %v", err)
+			klog.V(5).InfoS("Failed to update storage count metric", "err", err)
 			metrics.UpdateObjectCount(resourceName, -1)
 		} else {
 			metrics.UpdateObjectCount(resourceName, count)


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
part of kubernetes/enhancements#1602
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Ref:

https://github.com/kubernetes/enhancements/tree/master/keps/sig-instrumentation/1602-structured-logging
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/migration-to-structured-logging.md

**Special notes for your reviewer**:
```
before:
I0121 16:59:03.150391    8631 storage_factory.go:53] Storage caching is enabled for apiVersion=stable.example.com/v1alpha1, kind=MultiVersion
after:
I0209 10:26:24.302235   14163 storage_factory.go:53] "Storage caching is enabled" apiVersion="stable.example.com/v1alpha1" kind="MultiVersion

before:
I0126 15:12:31.613307   26953 store.go:462] going to delete foo from registry, triggered by update
after:
I0209 10:41:57.130386   14527 store.go:463] "Going to delete object from registry, triggered by update" object="default/foo"

before:
I0126 15:15:44.601852   27145 store.go:930] update the DeletionTimestamp to "now" and GracePeriodSeconds to 0 for object foo, because it has pending finalizers
after:
I0209 10:53:36.509553   14732 store.go:930] "Object has pending finalizers, so the registry is going to update its status to deleting" object="test/foo" GracePeriodSeconds="0"
	
before:
I0126 15:17:21.465594   27250 store.go:1051] going to delete foo from registry:
after:
I0209 10:55:38.621276   14837 store.go:1051] "Going delete object from registry" object="test/foo"


before:
I0126 15:29:45.366832   27464 store.go:1146] Delete foo in DeleteCollection failed: this is for test
after:
I0126 15:29:45.366850   27464 store.go:1147] "Deleted object in DeleteCollection failed" object="test/foo" err="this is for test"

before:
I0126 15:37:35.911081   31426 store.go:1421] Monitoring noxus.mygroup.example.com count at <storage-prefix>//noxus
after:
I0209 11:08:53.890182   15337 store.go:1421] "Monitoring resource count at path" resource="noxus.mygroup.example.com" path="/noxus"

before:
I0126 15:37:35.912756   31426 store.go:1429] Failed to update storage count metric: rpc error: code = Unavailable desc = transport is closing
after:
I0126 15:37:35.912763   31426 store.go:1430] "Failed to update storage count metric" err="rpc error: code = Unavailable desc = transport is closing"
```
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
migrate staging/src/k8s.io/apiserver/pkg/registry logs to structured logging.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
