### PR TITLE
limitrange: skip default limit setting if container's request is larger

### DIFF
--- a/plugin/pkg/admission/limitranger/admission.go
+++ b/plugin/pkg/admission/limitranger/admission.go
@@ -61,7 +61,7 @@ type LimitRanger struct {
 	actions LimitRangerActions
 	lister  corev1listers.LimitRangeLister
 
-	// liveLookups holds the last few live lookups we've done to help ammortize cost on repeated lookup failures.
+	// liveLookups holds the last few live lookups we've done to help amortize cost on repeated lookup failures.
 	// This let's us handle the case of latent caches, by looking up actual results for a namespace on cache miss/no results.
 	// We track the lookup result here so that for repeated requests, we don't look it up very often.
 	liveLookupCache *lru.Cache
@@ -243,6 +243,11 @@ func mergeContainerResources(container *api.Container, defaultRequirements *api.
 	for k, v := range defaultRequirements.Limits {
 		_, found := container.Resources.Limits[k]
 		if !found {
+			request, found := container.Resources.Requests[k]
+			if found && v.Cmp(request) < 0 {
+				// skip default limit setting if container's request is larger
+				continue
+			}
 			container.Resources.Limits[k] = v.DeepCopy()
 			setLimits = append(setLimits, string(k))
 		}
@@ -557,10 +562,7 @@ func PodValidateLimitFunc(limitRange *corev1.LimitRange, pod *api.Pod) error {
 					}
 				}
 			}
-		}
-
-		// enforce pod limits on init containers
-		if limitType == corev1.LimitTypePod {
+		} else if limitType == corev1.LimitTypePod { // enforce pod limits on init containers
 			containerRequests, containerLimits := []api.ResourceList{}, []api.ResourceList{}
 			for j := range pod.Spec.Containers {
 				container := &pod.Spec.Containers[j]

--- a/plugin/pkg/admission/limitranger/admission_test.go
+++ b/plugin/pkg/admission/limitranger/admission_test.go
@@ -227,7 +227,9 @@ func TestMergePodResourceRequirements(t *testing.T) {
 			api.ResourceCPU:    defaultRequirements.Requests[api.ResourceCPU],
 			api.ResourceMemory: resource.MustParse("512Mi"),
 		},
-		Limits: defaultRequirements.Limits,
+		Limits: api.ResourceList{
+			api.ResourceCPU: defaultRequirements.Limits[api.ResourceCPU],
+		},
 	}
 	mergePodResourceRequirements(&pod, &defaultRequirements)
 	for i := range pod.Spec.Containers {
@@ -242,7 +244,7 @@ func TestMergePodResourceRequirements(t *testing.T) {
 			t.Errorf("pod %v, expected != actual; %v != %v", pod.Name, expected, actual)
 		}
 	}
-	verifyAnnotation(t, &pod, "LimitRanger plugin set: cpu request for container foo-0; cpu, memory limit for container foo-0")
+	verifyAnnotation(t, &pod, "LimitRanger plugin set: cpu request for container foo-0; cpu limit for container foo-0")
 
 	// pod with all resources enumerated should not merge anything
 	input = getResourceRequirements(getComputeResourceList("100m", "512Mi"), getComputeResourceList("200m", "1G"))

--- a/plugin/pkg/admission/limitranger/admission_test.go
+++ b/plugin/pkg/admission/limitranger/admission_test.go
@@ -219,9 +219,9 @@ func TestMergePodResourceRequirements(t *testing.T) {
 	}
 	verifyAnnotation(t, &pod, "LimitRanger plugin set: cpu, memory request for container foo-0; cpu, memory limit for container foo-0")
 
-	// pod with some resources enumerated should only merge empty
+	// pod with some resources enumerated should only merge empty, only default cpu
 	input := getResourceRequirements(getComputeResourceList("", "512Mi"), getComputeResourceList("", ""))
-	pod = validPodInit(validPod("limit-memory", 1, input), input)
+	pod = validPodInit(validPod("limit-cpu", 1, input), input)
 	expected = api.ResourceRequirements{
 		Requests: api.ResourceList{
 			api.ResourceCPU:    defaultRequirements.Requests[api.ResourceCPU],
@@ -245,6 +245,33 @@ func TestMergePodResourceRequirements(t *testing.T) {
 		}
 	}
 	verifyAnnotation(t, &pod, "LimitRanger plugin set: cpu request for container foo-0; cpu limit for container foo-0")
+
+	// pod with some resources enumerated should only merge empty, only default memory
+	input = getResourceRequirements(getComputeResourceList("80m", ""), getComputeResourceList("", ""))
+	pod = validPodInit(validPod("limit-memory", 1, input), input)
+	expected = api.ResourceRequirements{
+		Requests: api.ResourceList{
+			api.ResourceCPU:    resource.MustParse("80m"),
+			api.ResourceMemory: defaultRequirements.Requests[api.ResourceMemory],
+		},
+		Limits: api.ResourceList{
+			api.ResourceMemory: defaultRequirements.Limits[api.ResourceMemory],
+		},
+	}
+	mergePodResourceRequirements(&pod, &defaultRequirements)
+	for i := range pod.Spec.Containers {
+		actual := pod.Spec.Containers[i].Resources
+		if !apiequality.Semantic.DeepEqual(expected, actual) {
+			t.Errorf("pod %v, expected != actual; %v != %v", pod.Name, expected, actual)
+		}
+	}
+	for i := range pod.Spec.InitContainers {
+		actual := pod.Spec.InitContainers[i].Resources
+		if !apiequality.Semantic.DeepEqual(expected, actual) {
+			t.Errorf("pod %v, expected != actual; %v != %v", pod.Name, expected, actual)
+		}
+	}
+	verifyAnnotation(t, &pod, "LimitRanger plugin set: memory request for container foo-0; memory limit for container foo-0")
 
 	// pod with all resources enumerated should not merge anything
 	input = getResourceRequirements(getComputeResourceList("100m", "512Mi"), getComputeResourceList("200m", "1G"))


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
default limit sometimes acts as max limit #51430

**Which issue(s) this PR fixes**:
Fixes #51430 

**Special notes for your reviewer**:
Default settings is not enforced as max or min.

The quota in the namespace is by default 500MB limit.
So if a user wants to create a pod with a memory request of 1GB, it should not fail.

- Current Behavior: pod failed with the default 500MB limit, as it is not larger than the requested 1GB.
- Expected: no limit for this pod.
- 

**Does this PR introduce a user-facing change?**:
```release-note
ignore default limit if container's request is larger
```