### PR TITLE
sched: avoid using shareable singleton instance

### DIFF
--- a/pkg/scheduler/framework/runtime/framework.go
+++ b/pkg/scheduler/framework/runtime/framework.go
@@ -212,8 +212,10 @@ func WithCaptureProfile(c CaptureProfile) Option {
 	}
 }
 
-var defaultFrameworkOptions = frameworkOptions{
-	metricsRecorder: newMetricsRecorder(1000, time.Second),
+func defaultFrameworkOptions() frameworkOptions {
+	return frameworkOptions{
+		metricsRecorder: newMetricsRecorder(1000, time.Second),
+	}
 }
 
 // TODO(#91029): move this to frameworkImpl runtime package.
@@ -234,7 +236,7 @@ var _ framework.Framework = &frameworkImpl{}
 
 // NewFramework initializes plugins given the configuration and the registry.
 func NewFramework(r Registry, plugins *config.Plugins, args []config.PluginConfig, opts ...Option) (framework.Framework, error) {
-	options := defaultFrameworkOptions
+	options := defaultFrameworkOptions()
 	for _, opt := range opts {
 		opt(&options)
 	}


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup
/sig scheduling

**What this PR does / why we need it**:

Using a shareable singleton instance may result in unexpected behavior - changes made by one caller is actually persisted, that changes may be unexpected by another caller.

In terms of framework.go#defaultFrameworkOptions, it's harmless in the regular flow. But in unit tests, one test's change to framework options is better isolated to other tests to avoid potential flakiness.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```