### PR TITLE
remove azure  disable-tcp-reset annotations which is already removed 

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_loadbalancer.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_loadbalancer.go
@@ -99,11 +99,6 @@ const (
 	// to enable the high availability ports on the standard internal load balancer.
 	ServiceAnnotationLoadBalancerEnableHighAvailabilityPorts = "service.beta.kubernetes.io/azure-load-balancer-enable-high-availability-ports"
 
-	// ServiceAnnotationLoadBalancerDisableTCPReset is the annotation used on the service
-	// to set enableTcpReset to false in load balancer rule. This only works for Azure standard load balancer backed service.
-	// TODO(feiskyer): disable-tcp-reset annotations has been depracated since v1.18, it would removed on v1.20.
-	ServiceAnnotationLoadBalancerDisableTCPReset = "service.beta.kubernetes.io/azure-load-balancer-disable-tcp-reset"
-
 	// ServiceAnnotationLoadBalancerHealthProbeProtocol determines the network protocol that the load balancer health probe use.
 	// If not set, the local service would use the HTTP and the cluster service would use the TCP by default.
 	ServiceAnnotationLoadBalancerHealthProbeProtocol = "service.beta.kubernetes.io/azure-load-balancer-health-probe-protocol"
@@ -1612,14 +1607,6 @@ func (az *Cloud) reconcileLoadBalancerRule(
 		ports = []v1.ServicePort{}
 	}
 
-	var enableTCPReset *bool
-	if az.useStandardLoadBalancer() {
-		enableTCPReset = to.BoolPtr(true)
-		if _, ok := service.Annotations[ServiceAnnotationLoadBalancerDisableTCPReset]; ok {
-			klog.Warning("annotation service.beta.kubernetes.io/azure-load-balancer-disable-tcp-reset has been removed as of Kubernetes 1.20. TCP Resets are always enabled on Standard SKU load balancers.")
-		}
-	}
-
 	var expectedProbes []network.Probe
 	var expectedRules []network.LoadBalancingRule
 	for _, port := range ports {
@@ -1695,7 +1682,7 @@ func (az *Cloud) reconcileLoadBalancerRule(
 				FrontendPort:        to.Int32Ptr(port.Port),
 				BackendPort:         to.Int32Ptr(port.Port),
 				DisableOutboundSnat: to.BoolPtr(az.disableLoadBalancerOutboundSNAT()),
-				EnableTCPReset:      enableTCPReset,
+				EnableTCPReset:      to.BoolPtr(true),
 				EnableFloatingIP:    to.BoolPtr(true),
 			},
 		}


### PR DESCRIPTION
trivial fix 
- will the warning message be removed in 1.22？

**What type of PR is this?**
/kind cleanup
/sig cloud-provider
/area azure

**What this PR does / why we need it**:
> 	// TODO(feiskyer): disable-tcp-reset annotations have been deprecated since v1.18, it would removed on v1.20.	

**Which issue(s) this PR fixes**:
edit TODO in comments

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
None
```