### PR TITLE
Add DaemonSet support in PDB

### DIFF
--- a/api/openapi-spec/v3/apis__apps__v1_openapi.json
+++ b/api/openapi-spec/v3/apis__apps__v1_openapi.json
@@ -8289,6 +8289,77 @@
         }
       }
     },
+    "/apis/apps/v1/namespaces/{namespace}/daemonsets/{name}/scale": {
+      "get": {
+        "description": "read scale of the specified DaemonSet",
+        "operationId": "readAppsV1NamespacedDaemonSetScale",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.autoscaling.v1.Scale"
+                }
+              },
+              "application/vnd.kubernetes.protobuf": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.autoscaling.v1.Scale"
+                }
+              },
+              "application/yaml": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.autoscaling.v1.Scale"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "tags": [
+          "apps_v1"
+        ],
+        "x-kubernetes-action": "get",
+        "x-kubernetes-group-version-kind": {
+          "group": "autoscaling",
+          "kind": "Scale",
+          "version": "v1"
+        }
+      },
+      "parameters": [
+        {
+          "description": "name of the Scale",
+          "in": "path",
+          "name": "name",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "object name and auth scope, such as for teams and projects",
+          "in": "path",
+          "name": "namespace",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "If 'true', then the output is pretty printed.",
+          "in": "query",
+          "name": "pretty",
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        }
+      ]
+    },
     "/apis/apps/v1/namespaces/{namespace}/daemonsets/{name}/status": {
       "get": {
         "description": "read status of the specified DaemonSet",

--- a/pkg/controller/disruption/disruption.go
+++ b/pkg/controller/disruption/disruption.go
@@ -234,8 +234,13 @@ func NewDisruptionControllerInternal(
 // way to take advantage of listers with scale subresources, we use the workload
 // resources directly and only fall back to the scale subresource when needed.
 func (dc *DisruptionController) finders() []podControllerFinder {
-	return []podControllerFinder{dc.getPodReplicationController, dc.getPodDeployment, dc.getPodReplicaSet,
-		dc.getPodStatefulSet, dc.getScaleController}
+	return []podControllerFinder{
+		dc.getPodReplicationController,
+		dc.getPodDeployment,
+		dc.getPodReplicaSet,
+		dc.getPodStatefulSet,
+		dc.getScaleController,
+	}
 }
 
 var (

--- a/pkg/registry/apps/daemonset/storage/storage.go
+++ b/pkg/registry/apps/daemonset/storage/storage.go
@@ -18,19 +18,45 @@ package storage
 
 import (
 	"context"
+	"fmt"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apiserver/pkg/registry/generic"
 	genericregistry "k8s.io/apiserver/pkg/registry/generic/registry"
 	"k8s.io/apiserver/pkg/registry/rest"
+	"k8s.io/client-go/scale/scheme/autoscalingv1"
 	"k8s.io/kubernetes/pkg/apis/apps"
+	"k8s.io/kubernetes/pkg/apis/autoscaling"
 	"k8s.io/kubernetes/pkg/printers"
 	printersinternal "k8s.io/kubernetes/pkg/printers/internalversion"
 	printerstorage "k8s.io/kubernetes/pkg/printers/storage"
 	"k8s.io/kubernetes/pkg/registry/apps/daemonset"
 	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
 )
+
+// DaemonSetStorage includes dummy storage for DaemonSets, and their Status and Scale subresource.
+type DaemonSetStorage struct {
+	DaemonSet *REST
+	Status    *StatusREST
+	Scale     *ScaleREST
+}
+
+// NewStorage returns new instance of DaemonSetStorage.
+func NewStorage(optsGetter generic.RESTOptionsGetter) (DaemonSetStorage, error) {
+	daemonSetRest, daemonSetStatusRest, err := NewREST(optsGetter)
+	if err != nil {
+		return DaemonSetStorage{}, err
+	}
+
+	return DaemonSetStorage{
+		DaemonSet: daemonSetRest,
+		Status:    daemonSetStatusRest,
+		Scale:     &ScaleREST{store: daemonSetRest.Store},
+	}, nil
+}
 
 // REST implements a RESTStorage for DaemonSets
 type REST struct {
@@ -114,4 +140,67 @@ func (r *StatusREST) GetResetFields() map[fieldpath.APIVersion]*fieldpath.Set {
 
 func (r *StatusREST) ConvertToTable(ctx context.Context, object runtime.Object, tableOptions runtime.Object) (*metav1.Table, error) {
 	return r.store.ConvertToTable(ctx, object, tableOptions)
+}
+
+// ScaleREST implements a Scale for DaemonSet.
+type ScaleREST struct {
+	store *genericregistry.Store
+}
+
+// ScaleREST implements only Getter, /scale is read-only by design
+var _ = rest.Getter(&ScaleREST{})
+var _ = rest.GroupVersionKindProvider(&ScaleREST{})
+
+// GroupVersionKind returns GroupVersionKind for DaemonSet Scale object
+func (r *ScaleREST) GroupVersionKind(containingGV schema.GroupVersion) schema.GroupVersionKind {
+	return autoscalingv1.SchemeGroupVersion.WithKind("Scale")
+}
+
+// New creates a new Scale object
+func (r *ScaleREST) New() runtime.Object {
+	return &autoscaling.Scale{}
+}
+
+// Get retrieves object from Scale storage.
+func (r *ScaleREST) Get(ctx context.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {
+	obj, err := r.store.Get(ctx, name, options)
+	if err != nil {
+		return nil, apierrors.NewNotFound(apps.Resource("daemonsets/scale"), name)
+	}
+	ds := obj.(*apps.DaemonSet)
+	scale, err := scaleFromDaemonSet(ds)
+	if err != nil {
+		return nil, apierrors.NewBadRequest(fmt.Sprintf("%v", err))
+	}
+	return scale, err
+}
+
+// Destroy cleans up resources on shutdown.
+func (r *ScaleREST) Destroy() {
+	// Given that underlying store is shared with REST,
+	// we don't destroy it here explicitly.
+}
+
+// scaleFromDaemonSet returns a scale subresource for a DaemonSet.
+func scaleFromDaemonSet(ds *apps.DaemonSet) (*autoscaling.Scale, error) {
+	selector, err := metav1.LabelSelectorAsSelector(ds.Spec.Selector)
+	if err != nil {
+		return nil, err
+	}
+	return &autoscaling.Scale{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              ds.Name,
+			Namespace:         ds.Namespace,
+			UID:               ds.UID,
+			ResourceVersion:   ds.ResourceVersion,
+			CreationTimestamp: ds.CreationTimestamp,
+		},
+		Spec: autoscaling.ScaleSpec{
+			Replicas: ds.Status.DesiredNumberScheduled,
+		},
+		Status: autoscaling.ScaleStatus{
+			Replicas: ds.Status.CurrentNumberScheduled,
+			Selector: selector.String(),
+		},
+	}, nil
 }

--- a/pkg/registry/apps/rest/storage_apps.go
+++ b/pkg/registry/apps/rest/storage_apps.go
@@ -76,12 +76,13 @@ func (p StorageProvider) v1Storage(apiResourceConfigSource serverstorage.APIReso
 
 	// daemonsets
 	if resource := "daemonsets"; apiResourceConfigSource.ResourceEnabled(appsapiv1.SchemeGroupVersion.WithResource(resource)) {
-		daemonSetStorage, daemonSetStatusStorage, err := daemonsetstore.NewREST(restOptionsGetter)
+		daemonSetStorage, err := daemonsetstore.NewStorage(restOptionsGetter)
 		if err != nil {
 			return storage, err
 		}
-		storage[resource] = daemonSetStorage
-		storage[resource+"/status"] = daemonSetStatusStorage
+		storage[resource] = daemonSetStorage.DaemonSet
+		storage[resource+"/status"] = daemonSetStorage.Status
+		storage[resource+"/scale"] = daemonSetStorage.Scale
 	}
 
 	// replicasets

--- a/pkg/registry/apps/statefulset/storage/storage.go
+++ b/pkg/registry/apps/statefulset/storage/storage.go
@@ -160,7 +160,7 @@ func (r *REST) ShortNames() []string {
 	return []string{"sts"}
 }
 
-// ScaleREST implements a Scale for Deployment.
+// ScaleREST implements a Scale for StatefulSet.
 type ScaleREST struct {
 	store *genericregistry.Store
 }

--- a/test/e2e/apps/daemon_set.go
+++ b/test/e2e/apps/daemon_set.go
@@ -1006,9 +1006,9 @@ var _ = SIGDescribe("Daemon set [Serial]", func() {
 			framework.ExpectNoError(err)
 
 			ginkgo.By("Check that daemon pods launch on every node of the cluster.")
-			err = e2edaemonset.CheckDaemonStatus(f, defaultName)
+			err = e2edaemonset.CheckDaemonStatus(context.TODO(), f, defaultName)
 			framework.ExpectNoError(err)
-			err = wait.PollImmediate(dsRetryPeriod, dsRetryTimeout, checkRunningOnAllNodes(f, ds))
+			err = wait.PollImmediateWithContext(context.TODO(), dsRetryPeriod, dsRetryTimeout, checkRunningOnAllNodes(f, ds))
 			framework.ExpectNoError(err)
 
 			ginkgo.By("Get the DaemonSet to find the number of replicas.")

--- a/test/e2e/apps/disruption.go
+++ b/test/e2e/apps/disruption.go
@@ -426,9 +426,9 @@ var _ = SIGDescribe("DisruptionController", func() {
 			framework.ExpectNoError(err)
 
 			ginkgo.By("Check that daemon pods launch on every node of the cluster.")
-			err = e2edaemonset.CheckDaemonStatus(f, defaultName)
+			err = e2edaemonset.CheckDaemonStatus(context.TODO(), f, defaultName)
 			framework.ExpectNoError(err)
-			err = wait.PollImmediate(dsRetryPeriod, dsRetryTimeout, checkRunningOnAllNodes(f, ds))
+			err = wait.PollImmediateWithContext(context.TODO(), dsRetryPeriod, dsRetryTimeout, checkRunningOnAllNodes(f, ds))
 			framework.ExpectNoError(err)
 		})
 
@@ -446,14 +446,14 @@ var _ = SIGDescribe("DisruptionController", func() {
 			{
 				name: "minAvailable",
 				createPDB: func(Npods int) {
-					createPDBMinAvailableOrDie(cs, ns, defaultName, intstr.FromInt(Npods-1), defaultLabels)
+					createPDBMinAvailableOrDie(context.TODO(), cs, ns, defaultName, intstr.FromInt(Npods-1), defaultLabels)
 				},
 			},
 
 			{
 				name: "maxUnavailable",
 				createPDB: func(_ int) {
-					createPDBMaxUnavailableOrDie(cs, ns, defaultName, intstr.FromString("10%"))
+					createPDBMaxUnavailableOrDie(context.TODO(), cs, ns, defaultName, intstr.FromString("10%"))
 				},
 			},
 		}
@@ -461,7 +461,7 @@ var _ = SIGDescribe("DisruptionController", func() {
 		for _, pdbCase := range pdbCases {
 			ginkgo.It("should account pods of a DaemonSet in case of "+pdbCase.name,
 				func() {
-					podList := listDaemonPods(cs, ns, defaultLabels)
+					podList := listDaemonPods(context.TODO(), cs, ns, defaultLabels)
 					Npods := len(podList.Items)
 
 					ginkgo.By("Creating PDB for " + strconv.Itoa(Npods) + " pods.")
@@ -485,7 +485,7 @@ var _ = SIGDescribe("DisruptionController", func() {
 					}, timeout, timeout/100).Should(gomega.BeTrue(), "PDB shouldn't allow disruptions")
 
 					ginkgo.By("Deleting PDB.")
-					deletePDBOrDie(cs, ns, defaultName)
+					deletePDBOrDie(context.TODO(), cs, ns, defaultName)
 				})
 
 		}

--- a/test/integration/dryrun/dryrun_test.go
+++ b/test/integration/dryrun/dryrun_test.go
@@ -36,11 +36,11 @@ import (
 	"k8s.io/client-go/util/retry"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	kubeapiservertesting "k8s.io/kubernetes/cmd/kube-apiserver/app/testing"
-	daemonStorage "k8s.io/kubernetes/pkg/registry/apps/daemonset/storage"
-	deployStorage "k8s.io/kubernetes/pkg/registry/apps/deployment/storage"
-	repSetStorage "k8s.io/kubernetes/pkg/registry/apps/replicaset/storage"
-	statSetStorage "k8s.io/kubernetes/pkg/registry/apps/statefulset/storage"
-	repContStorage "k8s.io/kubernetes/pkg/registry/core/replicationcontroller/storage"
+	daemonstorage "k8s.io/kubernetes/pkg/registry/apps/daemonset/storage"
+	deploystorage "k8s.io/kubernetes/pkg/registry/apps/deployment/storage"
+	repsetstorage "k8s.io/kubernetes/pkg/registry/apps/replicaset/storage"
+	statsetstorage "k8s.io/kubernetes/pkg/registry/apps/statefulset/storage"
+	repcontstorage "k8s.io/kubernetes/pkg/registry/core/replicationcontroller/storage"
 	"k8s.io/kubernetes/test/integration/etcd"
 	"k8s.io/kubernetes/test/integration/framework"
 )
@@ -248,11 +248,11 @@ func TestDryRun(t *testing.T) {
 	dryrunData := etcd.GetEtcdStorageData()
 
 	scaleRestMapping := map[string]interface{}{
-		"ReplicationController": &repContStorage.ScaleREST{},
-		"ReplicaSet":            &repSetStorage.ScaleREST{},
-		"Deployment":            &deployStorage.ScaleREST{},
-		"StatefulSet":           &statSetStorage.ScaleREST{},
-		"DaemonSet":             &daemonStorage.ScaleREST{},
+		"ReplicationController": &repcontstorage.ScaleREST{},
+		"ReplicaSet":            &repsetstorage.ScaleREST{},
+		"Deployment":            &deploystorage.ScaleREST{},
+		"StatefulSet":           &statsetstorage.ScaleREST{},
+		"DaemonSet":             &daemonstorage.ScaleREST{},
 	}
 
 	// dry run specific stub overrides

--- a/test/integration/scale/scale_test.go
+++ b/test/integration/scale/scale_test.go
@@ -34,11 +34,11 @@ import (
 	"k8s.io/apiserver/pkg/registry/rest"
 	"k8s.io/client-go/kubernetes"
 	apitesting "k8s.io/kubernetes/cmd/kube-apiserver/app/testing"
-	daemonStorage "k8s.io/kubernetes/pkg/registry/apps/daemonset/storage"
-	deployStorage "k8s.io/kubernetes/pkg/registry/apps/deployment/storage"
-	repSetStorage "k8s.io/kubernetes/pkg/registry/apps/replicaset/storage"
-	statSetStorage "k8s.io/kubernetes/pkg/registry/apps/statefulset/storage"
-	repContStorage "k8s.io/kubernetes/pkg/registry/core/replicationcontroller/storage"
+	daemonstorage "k8s.io/kubernetes/pkg/registry/apps/daemonset/storage"
+	deploystorage "k8s.io/kubernetes/pkg/registry/apps/deployment/storage"
+	repsetstorage "k8s.io/kubernetes/pkg/registry/apps/replicaset/storage"
+	statsetstorage "k8s.io/kubernetes/pkg/registry/apps/statefulset/storage"
+	repcontstorage "k8s.io/kubernetes/pkg/registry/core/replicationcontroller/storage"
 	"k8s.io/kubernetes/test/integration/framework"
 )
 
@@ -145,11 +145,11 @@ func TestScaleSubresources(t *testing.T) {
 	}
 
 	kindRestMapping := map[string]interface{}{
-		"replicationcontrollers": &repContStorage.ScaleREST{},
-		"replicasets":            &repSetStorage.ScaleREST{},
-		"deployments":            &deployStorage.ScaleREST{},
-		"statefulsets":           &statSetStorage.ScaleREST{},
-		"daemonsets":             &daemonStorage.ScaleREST{},
+		"replicationcontrollers": &repcontstorage.ScaleREST{},
+		"replicasets":            &repsetstorage.ScaleREST{},
+		"deployments":            &deploystorage.ScaleREST{},
+		"statefulsets":           &statsetstorage.ScaleREST{},
+		"daemonsets":             &daemonstorage.ScaleREST{},
 	}
 
 	// Ensure scale subresources return and accept expected kinds


### PR DESCRIPTION
**What type of PR is this?**

/kind fix
/sig apps 

**What this PR does / why we need it**:

Supports DaemonSets in disruption controller by adding /scale subresource to daemonsets API. It allows to control the eviction rate of DaemonSet pods. 

**Which issue(s) this PR fixes**:

#108124 

**Does this PR introduce a user-facing change?**:

```release-note
Added /scale  subresource to DaemonSet API to support of PodDisruptionBudget for DaemonSet pods.
```

