### PR TITLE
Fix translation of Cinder storage classess to CSI

### DIFF
--- a/staging/src/k8s.io/csi-translation-lib/plugins/BUILD
+++ b/staging/src/k8s.io/csi-translation-lib/plugins/BUILD
@@ -46,6 +46,7 @@ go_test(
         "azure_file_test.go",
         "gce_pd_test.go",
         "in_tree_volume_test.go",
+        "openstack_cinder_test.go",
         "vsphere_volume_test.go",
     ],
     embed = [":go_default_library"],

--- a/staging/src/k8s.io/csi-translation-lib/plugins/openstack_cinder_test.go
+++ b/staging/src/k8s.io/csi-translation-lib/plugins/openstack_cinder_test.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package plugins
+
+import (
+	"reflect"
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	storage "k8s.io/api/storage/v1"
+)
+
+func TestTranslateCinderInTreeStorageClassToCSI(t *testing.T) {
+	translator := NewOpenStackCinderCSITranslator()
+
+	cases := []struct {
+		name   string
+		sc     *storage.StorageClass
+		expSc  *storage.StorageClass
+		expErr bool
+	}{
+		{
+			name:  "translate normal",
+			sc:    NewStorageClass(map[string]string{"foo": "bar"}, nil),
+			expSc: NewStorageClass(map[string]string{"foo": "bar"}, nil),
+		},
+		{
+			name:  "translate empty map",
+			sc:    NewStorageClass(map[string]string{}, nil),
+			expSc: NewStorageClass(map[string]string{}, nil),
+		},
+
+		{
+			name:  "translate with fstype",
+			sc:    NewStorageClass(map[string]string{"fstype": "ext3"}, nil),
+			expSc: NewStorageClass(map[string]string{"csi.storage.k8s.io/fstype": "ext3"}, nil),
+		},
+		{
+			name:  "translate with topology in parameters (no translation expected)",
+			sc:    NewStorageClass(map[string]string{"availability": "nova"}, nil),
+			expSc: NewStorageClass(map[string]string{"availability": "nova"}, nil),
+		},
+		{
+			name:  "translate with topology",
+			sc:    NewStorageClass(map[string]string{}, generateToplogySelectors(v1.LabelFailureDomainBetaZone, []string{"nova"})),
+			expSc: NewStorageClass(map[string]string{}, generateToplogySelectors(CinderTopologyKey, []string{"nova"})),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Logf("Testing %v", tc.name)
+		got, err := translator.TranslateInTreeStorageClassToCSI(tc.sc)
+		if err != nil && !tc.expErr {
+			t.Errorf("Did not expect error but got: %v", err)
+		}
+
+		if err == nil && tc.expErr {
+			t.Errorf("Expected error, but did not get one.")
+		}
+
+		if !reflect.DeepEqual(got, tc.expSc) {
+			t.Errorf("Got parameters: %v, expected: %v", got, tc.expSc)
+		}
+
+	}
+}


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:
In-tree Cinder storage class must be translated to CSI:

* `sc.parameters["fsType"]` -> `sc.parameters["csi.storage.k8s.io/fstype"]`
* ~`sc.parameters["availability"]` -> `sc.allowedTopology` (with CSI topology keys)~
* `sc.allowedTopology` (with in-tree topology keys) -> `sc.allowedTopology`  (with CSI topology keys)

Found by running e2e tests with CSI migration enabled. One topology test failed:

```
[sig-storage] In-tree Volumes [Driver: cinder] [Testpattern: Dynamic PV (delayed binding)] topology should provision a volume and schedule a pod with AllowedTopologies [Suite:openshift/conformance/parallel] [Suite:k8s]

...

ProvisioningFailed: failed to provision volume with StorageClass "e2e-topology-1939-cinder-scf2rsm": error generating accessibility requirements: topology map[topology.cinder.csi.openstack.org/zone:nova] from selected node "jsafrane-5x4gw-worker-0-vc2z9" is not in requisite: [map[failure-domain.beta.kubernetes.io/zone:nova]]
```

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixed provisioning of Cinder volumes migrated to CSI when StorageClass with AllowedTopologies was used.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
