### PR TITLE
test images: Adds --progress=plain to docker buildx build

### DIFF
--- a/test/images/image-util.sh
+++ b/test/images/image-util.sh
@@ -160,7 +160,7 @@ build() {
       fi
     fi
 
-    docker buildx build --no-cache --pull --output=type="${output_type}" --platform "${os_name}/${arch}" \
+    docker buildx build --progress=plain --no-cache --pull --output=type="${output_type}" --platform "${os_name}/${arch}" \
         --build-arg BASEIMAGE="${base_image}" --build-arg REGISTRY="${REGISTRY}" --build-arg OS_VERSION="${os_version}" \
         -t "${REGISTRY}/${image}:${TAG}-${suffix}" -f "${dockerfile_name}" .
 


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug
/sig testing
/priority important-soon

**What this PR does / why we need it**:

The default value for the progress is ``auto``, which will eat the output of RUN commands. This makes it a bit hard to debug when issues occur. Changing that option to ``plain`` will ensure that the output is properly kept.

Sample output with ``auto``:

```
++ docker buildx build --progress=tty --no-cache --pull --output=type=registry --platform linux/arm --build-arg BASEIMAGE=arm32v6/alpine:3.8 --build-arg REGISTRY=claudiubelu --build-arg OS_VERSION= -t claudiubelu/apparmor-loader:1.3-linux-arm -f Dockerfile .
[+] Building 12.4s (10/10) FINISHED
 => [internal] load build definition from Dockerfile                                                            0.0s
 => => transferring dockerfile: 1.05kB                                                                          0.0s
 => [internal] load .dockerignore                                                                               0.0s
 => => transferring context: 2B                                                                                 0.0s
 => [internal] load metadata for docker.io/arm32v6/alpine:3.8                                                   1.1s
 => [auth] arm32v6/alpine:pull token for registry-1.docker.io                                                   0.0s
 => CACHED [1/4] FROM docker.io/arm32v6/alpine:3.8@sha256:dabea2944dcc2b86482b4f0b0fb62da80e0673e900c46c0e03b4  0.0s
 => => resolve docker.io/arm32v6/alpine:3.8@sha256:dabea2944dcc2b86482b4f0b0fb62da80e0673e900c46c0e03b45919881  0.0s
 => [internal] load build context                                                                               0.2s
 => => transferring context: 6.02MB                                                                             0.2s
 => [2/4] COPY qemu-arm-static /usr/bin/                                                                        0.6s
 => [3/4] RUN apk add apparmor libapparmor --update-cache --repository http://dl-cdn.alpinelinux.org/alpine/ed  3.5s
 => [4/4] ADD loader /usr/bin/loader                                                                            0.1s
 => exporting to image                                                                                          6.6s
 => => exporting layers                                                                                         1.0s
 => => exporting manifest sha256:0b8b6896229f1b832516a319f3dfac136fb28d83118e82833c8aa97ed0663ef2               0.0s
 => => exporting config sha256:31159c40b842c3b3ee161a49dd0405ea392ee9ccfc280aaa375ec2bbfd29ae1b                 0.0s
 => => pushing layers                                                                                           3.4s
 => => pushing manifest for docker.io/claudiubelu/apparmor-loader:1.3-linux-arm                                 2.1s
++ popd
```

Sample output with ``plain``:

```
++ docker buildx build --progress=plain --no-cache --pull --output=type=registry --platform linux/ppc64le --build-arg BASEIMAGE=ppc64le/alpine:3.8 --build-arg REGISTRY=claudiubelu --build-arg OS_VERSION= -t claudiubelu/apparmor-loader:1.3-linux-ppc64le -f Dockerfile .
#1 [internal] load build definition from Dockerfile
#1 sha256:2ed9bb2991f12f5b60a25b8f6d8fe79bb729a16b3111630f1a2e5230b2306cfa
#1 transferring dockerfile: 1.06kB done
#1 DONE 0.0s

......

#8 [3/4] RUN apk add apparmor libapparmor --update-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing/ --allow-untrusted &&     apk add --no-cache musl>1.1.20 --repository http://dl-cdn.alpinelinux.org/alpine/edge/main/
#8 sha256:0d6cac74cc2570f0629380f2ccd5bb5fbfcf2bbf4013fe2d864fcc737e34a0db
#8 0.142 fetch http://dl-cdn.alpinelinux.org/alpine/edge/testing/ppc64le/APKINDEX.tar.gz
#8 0.493 fetch http://dl-cdn.alpinelinux.org/alpine/v3.8/main/ppc64le/APKINDEX.tar.gz
#8 1.016 fetch http://dl-cdn.alpinelinux.org/alpine/v3.8/community/ppc64le/APKINDEX.tar.gz
#8 1.509 (1/9) Installing ncurses-terminfo-base (6.1_p20180818-r1)
#8 1.524 (2/9) Installing ncurses-terminfo (6.1_p20180818-r1)
#8 1.937 (3/9) Installing ncurses-libs (6.1_p20180818-r1)
#8 1.957 (4/9) Installing readline (7.0.003-r0)
#8 1.971 (5/9) Installing bash (4.4.19-r1)
#8 2.015 Executing bash-4.4.19-r1.post-install
#8 2.052 (6/9) Installing libintl (0.19.8.1-r2)
#8 2.062 (7/9) Installing apparmor (2.13.4-r0)
#8 2.102 (8/9) Installing sed (4.4-r2)
#8 2.117 (9/9) Installing libapparmor (2.13.4-r0)
#8 2.127 Executing busybox-1.28.4-r3.trigger
#8 2.176 OK: 15 MiB in 22 packages
#8 2.328 fetch http://dl-cdn.alpinelinux.org/alpine/edge/main/ppc64le/APKINDEX.tar.gz
#8 2.655 fetch http://dl-cdn.alpinelinux.org/alpine/v3.8/main/ppc64le/APKINDEX.tar.gz
#8 2.816 fetch http://dl-cdn.alpinelinux.org/alpine/v3.8/community/ppc64le/APKINDEX.tar.gz
#8 3.107 (1/2) Upgrading musl (1.1.19-r11 -> 1.2.2_pre7-r0)
#8 3.139 (2/2) Upgrading musl-utils (1.1.19-r11 -> 1.2.2_pre7-r0)
#8 3.151 Executing busybox-1.28.4-r3.trigger
#8 3.198 OK: 16 MiB in 22 packages
#8 DONE 3.8s

......

#10 exporting to image
#10 sha256:e8c613e07b0b7ff33893b694f7759a10d42e180f2b4dc349fb57dc6b71dcab00
#10 exporting layers
#10 exporting layers 1.1s done
#10 exporting manifest sha256:8d157edf48c8d16a7316462314c5b335b38f5342e43041d17b293fe2ea603d07
#10 exporting manifest sha256:8d157edf48c8d16a7316462314c5b335b38f5342e43041d17b293fe2ea603d07 0.0s done
#10 exporting config sha256:c58db1eb9941a213615ffe8827d62cace7656ee01887b9b6732f75106495ecd6 0.0s done
#10 pushing layers
#10 pushing layers 3.0s done
#10 pushing manifest for docker.io/claudiubelu/apparmor-loader:1.3-linux-ppc64le
#10 pushing manifest for docker.io/claudiubelu/apparmor-loader:1.3-linux-ppc64le 2.0s done
#10 DONE 6.2s
++ popd

```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
