### PR TITLE
tolerations: add preserve option to Merge function

### DIFF
--- a/pkg/util/tolerations/tolerations.go
+++ b/pkg/util/tolerations/tolerations.go
@@ -44,12 +44,19 @@ next:
 
 // MergeTolerations merges two sets of tolerations into one. If one toleration is a superset of
 // another, only the superset is kept.
-func MergeTolerations(first, second []api.Toleration) []api.Toleration {
+func MergeTolerations(first, second []api.Toleration, preserveFirst bool) []api.Toleration {
 	all := append(first, second...)
 	var merged []api.Toleration
 
+	var offset = 0
+	if preserveFirst {
+		for _, t := range first {
+			merged = append(merged, t)
+		}
+		offset = len(first)
+	}
 next:
-	for i, t := range all {
+	for i, t := range all[offset:] {
 		for _, t2 := range merged {
 			if isSuperset(t2, t) {
 				continue next // t is redundant; ignore it

--- a/plugin/pkg/admission/podtolerationrestriction/admission.go
+++ b/plugin/pkg/admission/podtolerationrestriction/admission.go
@@ -108,7 +108,7 @@ func (p *Plugin) Admit(ctx context.Context, a admission.Attributes, o admission.
 	}
 	// Final merge of tolerations irrespective of pod type.
 	if len(extraTolerations) > 0 {
-		pod.Spec.Tolerations = tolerations.MergeTolerations(pod.Spec.Tolerations, extraTolerations)
+		pod.Spec.Tolerations = tolerations.MergeTolerations(pod.Spec.Tolerations, extraTolerations, a.GetOperation() != admission.Create)
 	}
 	return p.Validate(ctx, a, o)
 }

--- a/plugin/pkg/admission/runtimeclass/admission.go
+++ b/plugin/pkg/admission/runtimeclass/admission.go
@@ -226,7 +226,7 @@ func setScheduling(a admission.Attributes, pod *api.Pod, runtimeClass *nodev1.Ru
 		}
 	}
 
-	newTolerations := tolerations.MergeTolerations(pod.Spec.Tolerations, nodeScheduling.Tolerations)
+	newTolerations := tolerations.MergeTolerations(pod.Spec.Tolerations, nodeScheduling.Tolerations, false)
 
 	pod.Spec.NodeSelector = newNodeSelector
 	pod.Spec.Tolerations = newTolerations


### PR DESCRIPTION
In admission process, when the incoming request is Update, we should not
remove any of the Existing tolerations, otherwise, the validation will
complain. To fix this, we should keep the original Tolerations intact.

/kind bug
/sig scheduling

```release-note
NONE
```