### PR TITLE
Update delegated authorization options default to eliminate unnecessary SARs

### DIFF
--- a/cmd/kube-controller-manager/app/options/options.go
+++ b/cmd/kube-controller-manager/app/options/options.go
@@ -193,7 +193,6 @@ func NewKubeControllerManagerOptions() (*KubeControllerManagerOptions, error) {
 
 	s.Authentication.RemoteKubeConfigFileOptional = true
 	s.Authorization.RemoteKubeConfigFileOptional = true
-	s.Authorization.AlwaysAllowPaths = []string{"/healthz"}
 
 	// Set the PairName but leave certificate directory blank to generate in-memory by default
 	s.SecureServing.ServerCert.CertDirectory = ""

--- a/cmd/kube-controller-manager/app/options/options_test.go
+++ b/cmd/kube-controller-manager/app/options/options_test.go
@@ -428,7 +428,8 @@ func TestAddFlags(t *testing.T) {
 			ClientTimeout:                10 * time.Second,
 			WebhookRetryBackoff:          apiserveroptions.DefaultAuthWebhookRetryBackoff(),
 			RemoteKubeConfigFileOptional: true,
-			AlwaysAllowPaths:             []string{"/healthz"}, // note: this does not match /healthz/ or /healthz/*
+			AlwaysAllowPaths:             []string{"/healthz", "/readyz", "/livez"}, // note: this does not match /healthz/ or /healthz/*
+			AlwaysAllowGroups:            []string{"system:masters"},
 		},
 		Kubeconfig: "/kubeconfig",
 		Master:     "192.168.4.20",

--- a/cmd/kube-scheduler/app/options/options.go
+++ b/cmd/kube-scheduler/app/options/options.go
@@ -113,7 +113,6 @@ func NewOptions() (*Options, error) {
 	o.Authentication.TolerateInClusterLookupFailure = true
 	o.Authentication.RemoteKubeConfigFileOptional = true
 	o.Authorization.RemoteKubeConfigFileOptional = true
-	o.Authorization.AlwaysAllowPaths = []string{"/healthz"}
 
 	// Set the PairName but leave certificate directory blank to generate in-memory by default
 	o.SecureServing.ServerCert.CertDirectory = ""

--- a/cmd/kube-scheduler/app/options/options_test.go
+++ b/cmd/kube-scheduler/app/options/options_test.go
@@ -292,7 +292,8 @@ profiles:
 					AllowCacheTTL:                10 * time.Second,
 					DenyCacheTTL:                 10 * time.Second,
 					RemoteKubeConfigFileOptional: true,
-					AlwaysAllowPaths:             []string{"/healthz"}, // note: this does not match /healthz/ or /healthz/*
+					AlwaysAllowPaths:             []string{"/healthz", "/readyz", "/livez"}, // note: this does not match /healthz/ or /healthz/*
+					AlwaysAllowGroups:            []string{"system:masters"},
 				},
 				Logs: logs.NewOptions(),
 			},
@@ -390,7 +391,8 @@ profiles:
 					AllowCacheTTL:                10 * time.Second,
 					DenyCacheTTL:                 10 * time.Second,
 					RemoteKubeConfigFileOptional: true,
-					AlwaysAllowPaths:             []string{"/healthz"}, // note: this does not match /healthz/ or /healthz/*
+					AlwaysAllowPaths:             []string{"/healthz", "/readyz", "/livez"}, // note: this does not match /healthz/ or /healthz/*
+					AlwaysAllowGroups:            []string{"system:masters"},
 				},
 				Logs: logs.NewOptions(),
 			},
@@ -456,7 +458,8 @@ profiles:
 					AllowCacheTTL:                10 * time.Second,
 					DenyCacheTTL:                 10 * time.Second,
 					RemoteKubeConfigFileOptional: true,
-					AlwaysAllowPaths:             []string{"/healthz"}, // note: this does not match /healthz/ or /healthz/*
+					AlwaysAllowPaths:             []string{"/healthz", "/readyz", "/livez"}, // note: this does not match /healthz/ or /healthz/*
+					AlwaysAllowGroups:            []string{"system:masters"},
 				},
 				Logs: logs.NewOptions(),
 			},

--- a/staging/src/k8s.io/apiserver/pkg/server/options/authorization.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/authorization.go
@@ -78,6 +78,14 @@ func NewDelegatingAuthorizationOptions() *DelegatingAuthorizationOptions {
 		DenyCacheTTL:        10 * time.Second,
 		ClientTimeout:       10 * time.Second,
 		WebhookRetryBackoff: DefaultAuthWebhookRetryBackoff(),
+		// This allows the kubelet to always get health and readiness without causing an authorization check.
+		// This field can be cleared by callers if they don't want this behavior.
+		AlwaysAllowPaths: []string{"/healthz", "/readyz", "/livez"},
+		// In an authorization call delegated to a kube-apiserver (the expected common-case), system:masters has full
+		// authority in a hard-coded authorizer.  This means that our default can reasonably be to skip an authorization
+		// check for system:masters.
+		// This field can be cleared by callers if they don't want this behavior.
+		AlwaysAllowGroups: []string{"system:masters"},
 	}
 }
 

--- a/staging/src/k8s.io/cloud-provider/options/options.go
+++ b/staging/src/k8s.io/cloud-provider/options/options.go
@@ -42,6 +42,7 @@ import (
 	cliflag "k8s.io/component-base/cli/flag"
 	cmoptions "k8s.io/controller-manager/options"
 	"k8s.io/controller-manager/pkg/clientbuilder"
+
 	// add the related feature gates
 	_ "k8s.io/controller-manager/pkg/features/register"
 )
@@ -98,7 +99,6 @@ func NewCloudControllerManagerOptions() (*CloudControllerManagerOptions, error) 
 
 	s.Authentication.RemoteKubeConfigFileOptional = true
 	s.Authorization.RemoteKubeConfigFileOptional = true
-	s.Authorization.AlwaysAllowPaths = []string{"/healthz"}
 
 	// Set the PairName but leave certificate directory blank to generate in-memory by default
 	s.SecureServing.ServerCert.CertDirectory = ""

--- a/staging/src/k8s.io/cloud-provider/options/options_test.go
+++ b/staging/src/k8s.io/cloud-provider/options/options_test.go
@@ -120,7 +120,8 @@ func TestDefaultFlags(t *testing.T) {
 			ClientTimeout:                10 * time.Second,
 			WebhookRetryBackoff:          apiserveroptions.DefaultAuthWebhookRetryBackoff(),
 			RemoteKubeConfigFileOptional: true,
-			AlwaysAllowPaths:             []string{"/healthz"}, // note: this does not match /healthz/ or
+			AlwaysAllowPaths:             []string{"/healthz", "/readyz", "/livez"}, // note: this does not match /healthz/ or /healthz/*
+			AlwaysAllowGroups:            []string{"system:masters"},
 		},
 		Kubeconfig:                "",
 		Master:                    "",
@@ -256,7 +257,8 @@ func TestAddFlags(t *testing.T) {
 			ClientTimeout:                10 * time.Second,
 			WebhookRetryBackoff:          apiserveroptions.DefaultAuthWebhookRetryBackoff(),
 			RemoteKubeConfigFileOptional: true,
-			AlwaysAllowPaths:             []string{"/healthz"}, // note: this does not match /healthz/ or
+			AlwaysAllowPaths:             []string{"/healthz", "/readyz", "/livez"}, // note: this does not match /healthz/ or /healthz/*
+			AlwaysAllowGroups:            []string{"system:masters"},
 		},
 		Kubeconfig:                "/kubeconfig",
 		Master:                    "192.168.4.20",


### PR DESCRIPTION
healthz, readyz, and livez are canonical names for checks that the kubelet does.  By default, allow access to them in the options. Callers can adjust the defaults if they have a reason to require checks.

system:masters has full power, so the authorization check is unnecessary and just uses an extra call for in-cluster access.  Callers can adjust the defaults if they have a reason to require checks.

This directly impacts kube-controller-manager, kube-scheduler, and cloud-controller-manager in tree.  I think these values are reasonable, but am happy to hear from @kubernetes/sig-auth-pr-reviews on the subject.  And I'm willing to wire a configuration option if we think cluster-admins should be able to twiddle these knobs.

/kind cleanup
/priority important-soon
@kubernetes/sig-auth-pr-reviews @kubernetes/sig-api-machinery-pr-reviews 

```release-note
The default delegating authorization options now allow unauthenticated access to healthz, readyz, and livez.  A system:masters user connecting to an authz delegator will not perform an authz check.
```