### PR TITLE
update metadata-concealment to 1.6 for removing legacy checking

### DIFF
--- a/build/dependencies.yaml
+++ b/build/dependencies.yaml
@@ -210,3 +210,17 @@ dependencies:
       match: k8s.gcr.io\/pause:\d+\.\d+
     - path: test/utils/image/manifest.go
       match: configs\[Pause\] = Config{gcRegistry, "pause", "\d+\.\d+"}
+
+  # metadata-concealment: bump this one first
+  - name: "metadata-concealment"
+    version: "1.6"
+    refPaths:
+    - path: test/images/metadata-concealment/VERSION
+      match: \d.\d
+
+  # then after merge and successful postsubmit image push / promotion, bump this
+  - name: "metadata-concealment: dependents"
+    version: "1.6"
+    refPaths:
+    - path: test/utils/image/manifest.go
+      match: configs\[CheckMetadataConcealment\] = Config{promoterE2eRegistry, "metadata-concealment", "\d+\.\d+"}

--- a/test/utils/image/manifest.go
+++ b/test/utils/image/manifest.go
@@ -219,7 +219,7 @@ func initImageConfigs() (map[int]Config, map[int]Config) {
 	configs[APIServer] = Config{e2eRegistry, "sample-apiserver", "1.17"}
 	configs[AppArmorLoader] = Config{e2eRegistry, "apparmor-loader", "1.0"}
 	configs[BusyBox] = Config{dockerLibraryRegistry, "busybox", "1.29"}
-	configs[CheckMetadataConcealment] = Config{e2eRegistry, "metadata-concealment", "1.2"}
+	configs[CheckMetadataConcealment] = Config{promoterE2eRegistry, "metadata-concealment", "1.6"}
 	configs[CudaVectorAdd] = Config{e2eRegistry, "cuda-vector-add", "1.0"}
 	configs[CudaVectorAdd2] = Config{e2eRegistry, "cuda-vector-add", "2.0"}
 	configs[DebianIptables] = Config{buildImageRegistry, "debian-iptables", "buster-v1.3.0"}


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
https://github.com/kubernetes/kubernetes/pull/97789#issuecomment-763977809

- [x]  #97789 is merged
- [x]  image build successfully in [sig-testing-images#post-kubernetes-push-e2e-metadata-concealment-test-images](https://testgrid.k8s.io/sig-testing-images#post-kubernetes-push-e2e-metadata-concealment-test-images) 
- - ✅ gcr.io/k8s-staging-e2e-test-images/metadata-concealment:1.6 
- [x]  Promote PR merged in k8s.io:  1.6 promote PR https://github.com/kubernetes/k8s.io/pull/1577
- - ✅k8s.gcr.io/e2e-test-images/metadata-concealment:1.6 (new promoted image)

To update the image using here to fix #97789.

**Which issue(s) this PR fixes**:
Fixes #94791

**Does this PR introduce a user-facing change?**:
```release-note
None
```