### PR TITLE
auto-detect and match the docker service cgroup driver in dockershim

### DIFF
--- a/pkg/kubelet/dockershim/docker_service.go
+++ b/pkg/kubelet/dockershim/docker_service.go
@@ -271,7 +271,8 @@ func NewDockerService(config *ClientConfig, podSandboxImage string, streamingCon
 			cgroupDriver = dockerInfo.CgroupDriver
 		}
 		if len(kubeCgroupDriver) != 0 && kubeCgroupDriver != cgroupDriver {
-			return nil, fmt.Errorf("misconfiguration: kubelet cgroup driver: %q is different from docker cgroup driver: %q", kubeCgroupDriver, cgroupDriver)
+			// auto-detect and match the docker service cgroup driver in dockershim.
+			klog.Infof("The kubelet cgroup driver %q is different from the Docker cgroup driver %q. Will use the Docker cgroup driver", kubeCgroupDriver, cgroupDriver)
 		}
 		klog.Infof("Setting cgroupDriver to %s", cgroupDriver)
 		ds.cgroupDriver = cgroupDriver


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

- cgroup driver is by default cgroupfs.
- check docker info for dockershim cgroup driver
- - if mismatch, use detected.
- - by default, use cgroupfs.


**Which issue(s) this PR fixes**:
Fixes #98222

The next step would be https://github.com/kubernetes/kubeadm/issues/874 if this is the right way.

**Special notes for your reviewer**:

> **Why is this needed:**
> 
> over the years, too many users have reported failures because of this low-level detail leaking in their userspace. we do document that cgroup drivers must be matching between the CR and the kubelet, but it feels we can improve the UX one step further by simply matching the drivers.

For more details, refer to https://github.com/kubernetes/kubernetes/issues/98222#issue-789973305

**Does this PR introduce a user-facing change?**:
```release-note
auto-detect and match the docker service cgroup driver in dockershim
```
