### PR TITLE
migrate scheduling_queue.go to structured logging

### DIFF
--- a/pkg/scheduler/internal/queue/scheduling_queue_test.go
+++ b/pkg/scheduler/internal/queue/scheduling_queue_test.go
@@ -27,6 +27,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	ktypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/clock"
 	"k8s.io/component-base/metrics/testutil"
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
@@ -1514,7 +1515,11 @@ func TestBackOffFlow(t *testing.T) {
 			UID:       "test-uid",
 		},
 	}
-	podID := nsNameForPod(pod)
+
+	podID := ktypes.NamespacedName{
+		Namespace: pod.Namespace,
+		Name:      pod.Name,
+	}
 	if err := q.Add(pod); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
Ref:
https://github.com/kubernetes/enhancements/tree/master/keps/sig-instrumentation/1602-structured-logging
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/migration-to-structured-logging.md

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
*Verify log output (scheduling_queue.go)*
```
before
scheduling_queue.go:253] Error adding pod ns2/mpp to the scheduling queue: couldn't create key for object &{Pod:&Pod{ObjectMeta:{...CST m=+0.016562001}: <nil>
scheduling_queue.go:257] Error: pod ns2/mpp is already in the unschedulable queue.
scheduling_queue.go:262] Error: pod ns2/mpp is already in the podBackoff queue.
scheduling_queue.go:347] Unable to pop pod ns2/mpp from backoff queue despite backoff completion.
scheduling_queue.go:517] Error adding pod up to the backoff queue: couldn't create key for object &{Pod:&Pod{ObjectMeta:{...CST m=+0.018590301}: <nil>
scheduling_queue.go:524] Error adding pod to the scheduling queue: couldn't create key for object &{Pod:&Pod{ObjectMeta:{...CST m=+0.018590301}: <nil>
scheduling_queue.go:547] Error getting label selectors for pod: afp.
scheduling_queue.go:751] Pod ns2/mpp already exists in the nominated map!
scheduling_queue.go:813] About to try and schedule pod ns2/mpp
scheduling_queue.go:816] Error while retrieving next pod from scheduling queue: object was removed from heap data
```
```
after
scheduling_queue.go:253] "Error adding pod to the scheduling queue" err="couldn't create key for object &{Pod:&Pod{ObjectMeta:{...CST m=+0.018528101}: <nil>" pod="ns2/mpp"
scheduling_queue.go:257] "Error: pod is already in the unschedulable queue" pod="ns2/mpp"
scheduling_queue.go:262] "Error: pod is already in the podBackoff queue" pod="ns2/mpp"
scheduling_queue.go:347] "Unable to pop pod from backoff queue despite backoff completion" pod="ns2/mpp"
scheduling_queue.go:517] "Error adding pod to the backoff queue" err="couldn't create key for object &{Pod:&Pod{ObjectMeta:{...CST m=+0.016580101}: <nil>" pod="ns1/up"
scheduling_queue.go:524] "Error adding pod to the scheduling queue" err="couldn't create key for object &{Pod:&Pod{ObjectMeta:{...CST m=+0.016580101}: <nil>" pod="ns1/up"
scheduling_queue.go:547] "Error getting label selectors for pod" err="out is not a valid pod selector operator" pod="ns1/afp"
scheduling_queue.go:751] "Pod already exists in the nominated map" pod="ns2/mpp"
scheduling_queue.go:813] "About to try and schedule pod" pod="ns2/mpp"
scheduling_queue.go:816] "Error while retrieving next pod from scheduling queue" err="object was removed from heap data"
```

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->

