### PR TITLE
Automated cherry pick of #97700: OWNERS: Update SIG Release aliases

### DIFF
--- a/CHANGELOG/OWNERS
+++ b/CHANGELOG/OWNERS
@@ -1,7 +1,6 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-  - sig-release-approvers
   - release-engineering-approvers
 reviewers:
   - release-engineering-reviewers

--- a/CHANGELOG/OWNERS
+++ b/CHANGELOG/OWNERS
@@ -1,9 +1,21 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-  - changelog-approvers
+  - wilsonehusin # 1.21 Release Notes Lead
+  - cpanato # Release Manager
+  - feiskyer # Release Manager
+  - hasheddan # Release Manager / SIG Technical Lead
+  - idealhack # Release Manager
+  - justaugustus # Release Manager / SIG Chair
+  - puerco # Release Manager
+  - saschagrunert # Release Manager / SIG Chair
+  - xmudrii # Release Manager
 reviewers:
-  - changelog-reviewers
+  - wilsonehusin # 1.21 Release Notes Lead
+  - ashnehete # 1.21 Release Notes shadow
+  - melodychn # 1.21 Release Notes shadow
+  - pmmalinov01 # 1.21 Release Notes shadow
+  - soniasingla # 1.21 Release Notes shadow
 
 labels:
   - sig/release

--- a/CHANGELOG/OWNERS
+++ b/CHANGELOG/OWNERS
@@ -1,9 +1,9 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-  - release-engineering-approvers
+  - changelog-approvers
 reviewers:
-  - release-engineering-reviewers
+  - changelog-reviewers
 
 labels:
   - sig/release

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -133,14 +133,21 @@ aliases:
     - BenTheElder
     - cblecker
     - dims
-    - justaugustus
+    - justaugustus # Release Manager / SIG Chair
     - listx
   build-image-reviewers:
     - BenTheElder
     - cblecker
+    - cpanato # Release Manager
     - dims
-    - justaugustus
+    - feiskyer # Release Manager
+    - hasheddan # Release Manager / SIG Technical Lead
+    - idealhack # Release Manager
+    - justaugustus # Release Manager / SIG Chair
     - listx
+    - puerco # Release Manager
+    - saschagrunert # Release Manager / SIG Chair
+    - xmudrii # Release Manager
 
   sig-storage-approvers:
     - saad-ali

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -160,6 +160,12 @@ aliases:
     - xmudrii # Release Manager
   changelog-reviewers:
     - wilsonehusin # 1.21 Release Notes Lead
+    # TODO(wilsonehusin): uncomment once ashnehete is an org member
+    #                     https://github.com/kubernetes/kubernetes/pull/97700#issuecomment-766734702
+    #- ashnehete # 1.21 Release Notes shadow
+    - melodychn # 1.21 Release Notes shadow
+    - pmmalinov01 # 1.21 Release Notes shadow
+    - soniasingla # 1.21 Release Notes shadow
 
   sig-storage-approvers:
     - saad-ali

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -149,7 +149,9 @@ aliases:
     - saschagrunert # Release Manager / SIG Chair
     - xmudrii # Release Manager
   changelog-approvers:
+    - wilsonehusin # 1.21 Release Notes Lead
   changelog-reviewers:
+    - wilsonehusin # 1.21 Release Notes Lead
 
   sig-storage-approvers:
     - saad-ali

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -148,6 +148,8 @@ aliases:
     - puerco # Release Manager
     - saschagrunert # Release Manager / SIG Chair
     - xmudrii # Release Manager
+  changelog-approvers:
+  changelog-reviewers:
 
   sig-storage-approvers:
     - saad-ali

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -150,6 +150,14 @@ aliases:
     - xmudrii # Release Manager
   changelog-approvers:
     - wilsonehusin # 1.21 Release Notes Lead
+    - cpanato # Release Manager
+    - feiskyer # Release Manager
+    - hasheddan # Release Manager / SIG Technical Lead
+    - idealhack # Release Manager
+    - justaugustus # Release Manager / SIG Chair
+    - puerco # Release Manager
+    - saschagrunert # Release Manager / SIG Chair
+    - xmudrii # Release Manager
   changelog-reviewers:
     - wilsonehusin # 1.21 Release Notes Lead
 

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -112,11 +112,6 @@ aliases:
     - WanLinghao
 
   # SIG Release
-  sig-release-approvers:
-    - alejandrox1 # SIG Technical Lead
-    - justaugustus # SIG Chair
-    - saschagrunert # SIG Technical Lead
-    - tpepper # SIG Chair
   release-engineering-approvers:
     - alejandrox1 # SIG Technical Lead
     - justaugustus # SIG Chair

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -113,10 +113,14 @@ aliases:
 
   # SIG Release
   release-engineering-approvers:
-    - alejandrox1 # SIG Technical Lead
-    - justaugustus # SIG Chair
-    - saschagrunert # SIG Technical Lead
-    - tpepper # SIG Chair
+    - cpanato # Release Manager
+    - feiskyer # Release Manager
+    - hasheddan # Release Manager / SIG Technical Lead
+    - idealhack # Release Manager
+    - justaugustus # Release Manager / SIG Chair
+    - puerco # Release Manager
+    - saschagrunert # Release Manager / SIG Chair
+    - xmudrii # Release Manager
   release-engineering-reviewers:
     - cpanato # Branch Manager
     - feiskyer # Patch Release Team

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -148,24 +148,6 @@ aliases:
     - puerco # Release Manager
     - saschagrunert # Release Manager / SIG Chair
     - xmudrii # Release Manager
-  changelog-approvers:
-    - wilsonehusin # 1.21 Release Notes Lead
-    - cpanato # Release Manager
-    - feiskyer # Release Manager
-    - hasheddan # Release Manager / SIG Technical Lead
-    - idealhack # Release Manager
-    - justaugustus # Release Manager / SIG Chair
-    - puerco # Release Manager
-    - saschagrunert # Release Manager / SIG Chair
-    - xmudrii # Release Manager
-  changelog-reviewers:
-    - wilsonehusin # 1.21 Release Notes Lead
-    # TODO(wilsonehusin): uncomment once ashnehete is an org member
-    #                     https://github.com/kubernetes/kubernetes/pull/97700#issuecomment-766734702
-    #- ashnehete # 1.21 Release Notes shadow
-    - melodychn # 1.21 Release Notes shadow
-    - pmmalinov01 # 1.21 Release Notes shadow
-    - soniasingla # 1.21 Release Notes shadow
 
   sig-storage-approvers:
     - saad-ali

--- a/build/OWNERS
+++ b/build/OWNERS
@@ -4,8 +4,10 @@ reviewers:
   - bentheelder
   - cblecker
   - fejta
-  - justaugustus
+  - hasheddan # Release Manager / SIG Technical Lead
+  - justaugustus # Release Manager / SIG Chair
   - lavalamp
+  - saschagrunert # Release Manager / SIG Chair
   - spiffxp
 approvers:
   - bentheelder


### PR DESCRIPTION
Cherry pick of #97700 on release-1.18.

#97700: OWNERS(sig-release): Remove SIG Release approvers alias

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.