### PR TITLE
Set cgroup values via libcontainer

### DIFF
--- a/pkg/kubelet/cm/cgroup_manager_linux.go
+++ b/pkg/kubelet/cm/cgroup_manager_linux.go
@@ -351,32 +351,6 @@ func getSupportedSubsystems() map[subsystem]bool {
 	return supportedSubsystems
 }
 
-// setSupportedSubsystemsV1 sets cgroup resource limits on cgroup v1 only on the supported
-// subsystems. ie. cpu and memory. We don't use libcontainer's cgroup/fs/Set()
-// method as it doesn't allow us to skip updates on the devices cgroup
-// Allowing or denying all devices by writing 'a' to devices.allow or devices.deny is
-// not possible once the device cgroups has children. Once the pod level cgroup are
-// created under the QOS level cgroup we cannot update the QOS level device cgroup.
-// We would like to skip setting any values on the device cgroup in this case
-// but this is not possible with libcontainers Set() method
-// See https://github.com/opencontainers/runc/issues/932
-func setSupportedSubsystemsV1(cgroupConfig *libcontainerconfigs.Cgroup) error {
-	for sys, required := range getSupportedSubsystems() {
-		if _, ok := cgroupConfig.Paths[sys.Name()]; !ok {
-			if required {
-				return fmt.Errorf("failed to find subsystem mount for required subsystem: %v", sys.Name())
-			}
-			// the cgroup is not mounted, but its not required so continue...
-			klog.V(6).InfoS("Unable to find subsystem mount for optional subsystem", "subsystemName", sys.Name())
-			continue
-		}
-		if err := sys.Set(cgroupConfig.Paths[sys.Name()], cgroupConfig); err != nil {
-			return fmt.Errorf("failed to set config for supported subsystems : %v", err)
-		}
-	}
-	return nil
-}
-
 // getCpuWeight converts from the range [2, 262144] to [1, 10000]
 func getCpuWeight(cpuShares *uint64) uint64 {
 	if cpuShares == nil {
@@ -464,40 +438,6 @@ func propagateControllers(path string) error {
 	return nil
 }
 
-// setResourcesV2 sets cgroup resource limits on cgroup v2
-func setResourcesV2(cgroupConfig *libcontainerconfigs.Cgroup) error {
-	if err := propagateControllers(cgroupConfig.Path); err != nil {
-		return err
-	}
-	cgroupConfig.Resources.Devices = []*libcontainerdevices.Rule{
-		{
-			Type:        'a',
-			Permissions: "rwm",
-			Allow:       true,
-			Minor:       libcontainerdevices.Wildcard,
-			Major:       libcontainerdevices.Wildcard,
-		},
-	}
-	cgroupConfig.Resources.SkipDevices = true
-
-	// if the hugetlb controller is missing
-	supportedControllers := getSupportedUnifiedControllers()
-	if !supportedControllers.Has("hugetlb") {
-		cgroupConfig.Resources.HugetlbLimit = nil
-		// the cgroup is not present, but its not required so skip it
-		klog.V(6).InfoS("Optional subsystem not supported: hugetlb")
-	}
-
-	manager, err := cgroupfs2.NewManager(cgroupConfig, filepath.Join(cmutil.CgroupRoot, cgroupConfig.Path), false)
-	if err != nil {
-		return fmt.Errorf("failed to create cgroup v2 manager: %v", err)
-	}
-	config := &libcontainerconfigs.Config{
-		Cgroups: cgroupConfig,
-	}
-	return manager.Set(config)
-}
-
 func (m *cgroupManagerImpl) toResources(resourceConfig *ResourceConfig) *libcontainerconfigs.Resources {
 	resources := &libcontainerconfigs.Resources{
 		Devices: []*libcontainerdevices.Rule{
@@ -577,10 +517,11 @@ func (m *cgroupManagerImpl) Update(cgroupConfig *CgroupConfig) error {
 	}
 
 	unified := libcontainercgroups.IsCgroup2UnifiedMode()
+	var paths map[string]string
 	if unified {
 		libcontainerCgroupConfig.Path = m.Name(cgroupConfig.Name)
 	} else {
-		libcontainerCgroupConfig.Paths = m.buildCgroupPaths(cgroupConfig.Name)
+		paths = m.buildCgroupPaths(cgroupConfig.Name)
 	}
 
 	// libcontainer consumes a different field and expects a different syntax
@@ -594,15 +535,28 @@ func (m *cgroupManagerImpl) Update(cgroupConfig *CgroupConfig) error {
 	}
 
 	if unified {
-		if err := setResourcesV2(libcontainerCgroupConfig); err != nil {
-			return fmt.Errorf("failed to set resources for cgroup %v: %v", cgroupConfig.Name, err)
+		if err := propagateControllers(libcontainerCgroupConfig.Path); err != nil {
+			return err
 		}
-	} else {
-		if err := setSupportedSubsystemsV1(libcontainerCgroupConfig); err != nil {
-			return fmt.Errorf("failed to set supported cgroup subsystems for cgroup %v: %v", cgroupConfig.Name, err)
+
+		supportedControllers := getSupportedUnifiedControllers()
+		if !supportedControllers.Has("hugetlb") {
+			libcontainerCgroupConfig.Resources.HugetlbLimit = nil
+			klog.V(6).InfoS("Optional subsystem not supported: hugetlb")
 		}
+	} else if _, ok := m.subsystems.MountPoints["hugetlb"]; !ok {
+		libcontainerCgroupConfig.Resources.HugetlbLimit = nil
+		klog.V(6).InfoS("Optional subsystem not supported: hugetlb")
 	}
-	return nil
+
+	manager, err := m.adapter.newManager(libcontainerCgroupConfig, paths)
+	if err != nil {
+		return fmt.Errorf("failed to create cgroup manager: %v", err)
+	}
+	config := &libcontainerconfigs.Config{
+		Cgroups: libcontainerCgroupConfig,
+	}
+	return manager.Set(config)
 }
 
 // Create creates the specified cgroup


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

<!--
Add one of the following kinds:

/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug
/kind cleanup

**What this PR does / why we need it**:

WIP to run all e2e tests.

Currently we set cgroup values in `pkg/kubelet/cm/cgroup_manager_linux.go` manually per subsystem, howerever, when using the systemd driver, we should set them via opencontainers/runc/libcontainer to make sure we update the systemd slices and scopes.

Will come back with more info when I have tested more.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #88197

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fix resource enforcement when using systemd cgroup driver
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
