### PR TITLE
add a mechanism for delegated authorization to have a few hardcoded rules

### DIFF
--- a/staging/src/k8s.io/apiserver/BUILD
+++ b/staging/src/k8s.io/apiserver/BUILD
@@ -34,6 +34,8 @@ filegroup(
         "//staging/src/k8s.io/apiserver/pkg/authorization/authorizer:all-srcs",
         "//staging/src/k8s.io/apiserver/pkg/authorization/authorizerfactory:all-srcs",
         "//staging/src/k8s.io/apiserver/pkg/authorization/path:all-srcs",
+        "//staging/src/k8s.io/apiserver/pkg/authorization/pathforuser:all-srcs",
+        "//staging/src/k8s.io/apiserver/pkg/authorization/privilegedgroup:all-srcs",
         "//staging/src/k8s.io/apiserver/pkg/authorization/union:all-srcs",
         "//staging/src/k8s.io/apiserver/pkg/endpoints:all-srcs",
         "//staging/src/k8s.io/apiserver/pkg/features:all-srcs",

--- a/staging/src/k8s.io/apiserver/pkg/authorization/authorizerfactory/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/authorization/authorizerfactory/BUILD
@@ -10,10 +10,7 @@ go_test(
     name = "go_default_test",
     srcs = ["builtin_test.go"],
     embed = [":go_default_library"],
-    deps = [
-        "//staging/src/k8s.io/apiserver/pkg/authentication/user:go_default_library",
-        "//staging/src/k8s.io/apiserver/pkg/authorization/authorizer:go_default_library",
-    ],
+    deps = ["//staging/src/k8s.io/apiserver/pkg/authorization/authorizer:go_default_library"],
 )
 
 go_library(

--- a/staging/src/k8s.io/apiserver/pkg/authorization/authorizerfactory/builtin.go
+++ b/staging/src/k8s.io/apiserver/pkg/authorization/authorizerfactory/builtin.go
@@ -18,7 +18,6 @@ package authorizerfactory
 
 import (
 	"context"
-	"errors"
 
 	"k8s.io/apiserver/pkg/authentication/user"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
@@ -67,29 +66,4 @@ func (alwaysDenyAuthorizer) RulesFor(user user.Info, namespace string) ([]author
 
 func NewAlwaysDenyAuthorizer() *alwaysDenyAuthorizer {
 	return new(alwaysDenyAuthorizer)
-}
-
-type privilegedGroupAuthorizer struct {
-	groups []string
-}
-
-func (r *privilegedGroupAuthorizer) Authorize(ctx context.Context, attr authorizer.Attributes) (authorizer.Decision, string, error) {
-	if attr.GetUser() == nil {
-		return authorizer.DecisionNoOpinion, "Error", errors.New("no user on request.")
-	}
-	for _, attr_group := range attr.GetUser().GetGroups() {
-		for _, priv_group := range r.groups {
-			if priv_group == attr_group {
-				return authorizer.DecisionAllow, "", nil
-			}
-		}
-	}
-	return authorizer.DecisionNoOpinion, "", nil
-}
-
-// NewPrivilegedGroups is for use in loopback scenarios
-func NewPrivilegedGroups(groups ...string) *privilegedGroupAuthorizer {
-	return &privilegedGroupAuthorizer{
-		groups: groups,
-	}
 }

--- a/staging/src/k8s.io/apiserver/pkg/authorization/path/path.go
+++ b/staging/src/k8s.io/apiserver/pkg/authorization/path/path.go
@@ -82,7 +82,6 @@ func (p *PrefixMatcher) Matches(path string) bool {
 	if p.paths.Has(pth) {
 		return true
 	}
-	b/test/integration/framework/master_utils.go
 	for _, prefix := range p.prefixes {
 		if strings.HasPrefix(pth, prefix) {
 			return true

--- a/staging/src/k8s.io/apiserver/pkg/authorization/pathforuser/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/authorization/pathforuser/BUILD
@@ -1,0 +1,28 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["path_for_user.go"],
+    importmap = "k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/authorization/pathforuser",
+    importpath = "k8s.io/apiserver/pkg/authorization/pathforuser",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
+        "//staging/src/k8s.io/apiserver/pkg/authorization/authorizer:go_default_library",
+        "//staging/src/k8s.io/apiserver/pkg/authorization/path:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/staging/src/k8s.io/apiserver/pkg/authorization/pathforuser/path_for_user.go
+++ b/staging/src/k8s.io/apiserver/pkg/authorization/pathforuser/path_for_user.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pathforuser
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apiserver/pkg/authorization/authorizer"
+	"k8s.io/apiserver/pkg/authorization/path"
+)
+
+// NewAuthorizer returns an authorizer which accepts a given set of paths.
+// Each path is either a fully matching path or it ends in * in case a prefix match is done. A leading / is optional.
+func NewAuthorizer(userStrings []string, alwaysAllowPaths []string) (authorizer.Authorizer, error) {
+	users := sets.NewString(userStrings...)
+	pathMatcher, err := path.NewPrefixMatcher(alwaysAllowPaths)
+	if err != nil {
+		return nil, err
+	}
+
+	var prefixes []string
+	paths := sets.NewString()
+	for _, p := range alwaysAllowPaths {
+		p = strings.TrimPrefix(p, "/")
+		if len(p) == 0 {
+			// matches "/"
+			paths.Insert(p)
+			continue
+		}
+		if strings.ContainsRune(p[:len(p)-1], '*') {
+			return nil, fmt.Errorf("only trailing * allowed in %q", p)
+		}
+		if strings.HasSuffix(p, "*") {
+			prefixes = append(prefixes, p[:len(p)-1])
+		} else {
+			paths.Insert(p)
+		}
+	}
+
+	return authorizer.AuthorizerFunc(func(attr authorizer.Attributes) (authorizer.Decision, string, error) {
+		if attr.IsResourceRequest() {
+			return authorizer.DecisionNoOpinion, "", nil
+		}
+		if attr.GetUser() == nil {
+			return authorizer.DecisionNoOpinion, "Error", errors.New("no user on request.")
+		}
+
+		// if the request matches our set of users and the paths, then allow the action
+		if users.Has(attr.GetUser().GetName()) && pathMatcher.Matches(attr.GetPath()) {
+			return authorizer.DecisionAllow, "", nil
+		}
+
+		// otherwise this authorizer has no opinion
+		return authorizer.DecisionNoOpinion, "", nil
+	}), nil
+}

--- a/staging/src/k8s.io/apiserver/pkg/authorization/privilegedgroup/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/authorization/privilegedgroup/BUILD
@@ -1,0 +1,34 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["privileged_group.go"],
+    importmap = "k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/authorization/privilegedgroup",
+    importpath = "k8s.io/apiserver/pkg/authorization/privilegedgroup",
+    visibility = ["//visibility:public"],
+    deps = ["//staging/src/k8s.io/apiserver/pkg/authorization/authorizer:go_default_library"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["privileged_group_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//staging/src/k8s.io/apiserver/pkg/authentication/user:go_default_library",
+        "//staging/src/k8s.io/apiserver/pkg/authorization/authorizer:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/staging/src/k8s.io/apiserver/pkg/authorization/privilegedgroup/privileged_group.go
+++ b/staging/src/k8s.io/apiserver/pkg/authorization/privilegedgroup/privileged_group.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package privilegedgroup
+
+import (
+	"context"
+	"errors"
+
+	"k8s.io/apiserver/pkg/authorization/authorizer"
+)
+
+type privilegedGroupAuthorizer struct {
+	groups []string
+}
+
+func (r *privilegedGroupAuthorizer) Authorize(ctx context.Context, attr authorizer.Attributes) (authorizer.Decision, string, error) {
+	if attr.GetUser() == nil {
+		return authorizer.DecisionNoOpinion, "Error", errors.New("no user on request.")
+	}
+	for _, attr_group := range attr.GetUser().GetGroups() {
+		for _, priv_group := range r.groups {
+			if priv_group == attr_group {
+				return authorizer.DecisionAllow, "", nil
+			}
+		}
+	}
+	return authorizer.DecisionNoOpinion, "", nil
+}
+
+// NewPrivilegedGroups is for use in loopback scenarios
+func NewPrivilegedGroups(groups ...string) *privilegedGroupAuthorizer {
+	return &privilegedGroupAuthorizer{
+		groups: groups,
+	}
+}

--- a/staging/src/k8s.io/apiserver/pkg/authorization/privilegedgroup/privileged_group_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/authorization/privilegedgroup/privileged_group_test.go
@@ -14,25 +14,26 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package authorizerfactory
+package privilegedgroup
 
 import (
 	"context"
 	"testing"
 
+	"k8s.io/apiserver/pkg/authentication/user"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
 )
 
-func TestNewAlwaysAllowAuthorizer(t *testing.T) {
-	aaa := NewAlwaysAllowAuthorizer()
-	if decision, _, _ := aaa.Authorize(context.Background(), nil); decision != authorizer.DecisionAllow {
-		t.Errorf("AlwaysAllowAuthorizer.Authorize did not authorize successfully.")
-	}
-}
+func TestPrivilegedGroupAuthorizer(t *testing.T) {
+	auth := NewPrivilegedGroups("allow-01", "allow-01")
 
-func TestNewAlwaysDenyAuthorizer(t *testing.T) {
-	ada := NewAlwaysDenyAuthorizer()
-	if decision, _, _ := ada.Authorize(context.Background(), nil); decision == authorizer.DecisionAllow {
-		t.Errorf("AlwaysDenyAuthorizer.Authorize returned nil instead of error.")
+	yes := authorizer.AttributesRecord{User: &user.DefaultInfo{Groups: []string{"no", "allow-01"}}}
+	no := authorizer.AttributesRecord{User: &user.DefaultInfo{Groups: []string{"no", "deny-01"}}}
+
+	if authorized, _, _ := auth.Authorize(context.Background(), yes); authorized != authorizer.DecisionAllow {
+		t.Errorf("failed")
+	}
+	if authorized, _, _ := auth.Authorize(context.Background(), no); authorized == authorizer.DecisionAllow {
+		t.Errorf("failed")
 	}
 }

--- a/staging/src/k8s.io/apiserver/pkg/server/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/server/BUILD
@@ -96,7 +96,7 @@ go_library(
         "//staging/src/k8s.io/apiserver/pkg/authentication/request/union:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/authentication/user:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/authorization/authorizer:go_default_library",
-        "//staging/src/k8s.io/apiserver/pkg/authorization/authorizerfactory:go_default_library",
+        "//staging/src/k8s.io/apiserver/pkg/authorization/privilegedgroup:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/authorization/union:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/endpoints:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/endpoints/discovery:go_default_library",

--- a/staging/src/k8s.io/apiserver/pkg/server/config.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/config.go
@@ -28,6 +28,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	"k8s.io/apiserver/pkg/authorization/privilegedgroup"
+
 	jsonpatch "github.com/evanphx/json-patch"
 	"github.com/go-openapi/spec"
 	"github.com/google/uuid"
@@ -47,7 +49,6 @@ import (
 	authenticatorunion "k8s.io/apiserver/pkg/authentication/request/union"
 	"k8s.io/apiserver/pkg/authentication/user"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
-	"k8s.io/apiserver/pkg/authorization/authorizerfactory"
 	authorizerunion "k8s.io/apiserver/pkg/authorization/union"
 	"k8s.io/apiserver/pkg/endpoints/discovery"
 	"k8s.io/apiserver/pkg/endpoints/filterlatency"
@@ -850,6 +851,6 @@ func AuthorizeClientBearerToken(loopback *restclient.Config, authn *Authenticati
 	tokenAuthenticator := authenticatorfactory.NewFromTokens(tokens)
 	authn.Authenticator = authenticatorunion.New(tokenAuthenticator, authn.Authenticator)
 
-	tokenAuthorizer := authorizerfactory.NewPrivilegedGroups(user.SystemPrivilegedGroup)
+	tokenAuthorizer := privilegedgroup.NewPrivilegedGroups(user.SystemPrivilegedGroup)
 	authz.Authorizer = authorizerunion.New(tokenAuthorizer, authz.Authorizer)
 }

--- a/staging/src/k8s.io/apiserver/pkg/server/options/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/BUILD
@@ -55,6 +55,7 @@ go_library(
         "//staging/src/k8s.io/apiserver/pkg/authorization/authorizer:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/authorization/authorizerfactory:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/authorization/path:go_default_library",
+        "//staging/src/k8s.io/apiserver/pkg/authorization/privilegedgroup:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/authorization/union:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/features:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/registry/generic:go_default_library",

--- a/staging/src/k8s.io/apiserver/pkg/server/options/authorization.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/authorization.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"time"
 
+	"k8s.io/apiserver/pkg/authorization/privilegedgroup"
+
 	"github.com/spf13/pflag"
 	"k8s.io/klog/v2"
 
@@ -161,7 +163,7 @@ func (s *DelegatingAuthorizationOptions) toAuthorizer(client kubernetes.Interfac
 	var authorizers []authorizer.Authorizer
 
 	if len(s.AlwaysAllowGroups) > 0 {
-		authorizers = append(authorizers, authorizerfactory.NewPrivilegedGroups(s.AlwaysAllowGroups...))
+		authorizers = append(authorizers, privilegedgroup.NewPrivilegedGroups(s.AlwaysAllowGroups...))
 	}
 
 	if len(s.AlwaysAllowPaths) > 0 {

--- a/test/integration/framework/BUILD
+++ b/test/integration/framework/BUILD
@@ -59,6 +59,7 @@ go_library(
         "//staging/src/k8s.io/apiserver/pkg/authentication/user:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/authorization/authorizer:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/authorization/authorizerfactory:go_default_library",
+        "//staging/src/k8s.io/apiserver/pkg/authorization/privilegedgroup:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/authorization/union:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/endpoints/openapi:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/features:go_default_library",

--- a/test/integration/framework/master_utils.go
+++ b/test/integration/framework/master_utils.go
@@ -37,6 +37,7 @@ import (
 	"k8s.io/apiserver/pkg/authentication/user"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
 	"k8s.io/apiserver/pkg/authorization/authorizerfactory"
+	"k8s.io/apiserver/pkg/authorization/privilegedgroup"
 	authorizerunion "k8s.io/apiserver/pkg/authorization/union"
 	openapinamer "k8s.io/apiserver/pkg/endpoints/openapi"
 	genericfeatures "k8s.io/apiserver/pkg/features"
@@ -180,7 +181,7 @@ func startMasterOrDie(masterConfig *controlplane.Config, incomingServer *httptes
 	}
 
 	if masterConfig.GenericConfig.Authorization.Authorizer != nil {
-		tokenAuthorizer := authorizerfactory.NewPrivilegedGroups(user.SystemPrivilegedGroup)
+		tokenAuthorizer := privilegedgroup.NewPrivilegedGroups(user.SystemPrivilegedGroup)
 		masterConfig.GenericConfig.Authorization.Authorizer = authorizerunion.New(tokenAuthorizer, masterConfig.GenericConfig.Authorization.Authorizer)
 	} else {
 		masterConfig.GenericConfig.Authorization.Authorizer = alwaysAllow{}


### PR DESCRIPTION
In many clusters there is a metrics scraping program of some kind. This program often has a fixed identity and accesses only /metrics across many pods.  While we cannot make a default rule for this identity (it varies across different cluster deployments), the ability to specify a user who is authorized to access a particular endpoint while delegating authz checks for other accesses reduces SAR checks that aren't necessary on repeatedly accessed endpoints.

This would allow a deployment to specify something like `kube-controller-manager --authorization-direct-access=system:serviceaccount:monitoring:scraper=/metrics`.  By default there would be no change.

Even with authorization caching, a lot of traffic is related to SARs that are essentially hardcoded (we know the identity of the scraper).  These are the options we've come up with.
1, use ABAC.  Potentially taking it to v1.  We kept ABAC around for exactly this purpose.  The format isn't great, but it exists and it would work perfectly for this use-case.  Having gone through the other options, I think this is the best.
2. add an arg for this rule.  It's constrained  (non-resource request) and covers a scraping use-case.  It's ugly and not very expressive.
3. create a way to read RBAC policy from disk and run an RBAC authorizer.  This seems very heavy for a small use-case.
4. Do nothing.  Given the amount of traffic and how it interacts with priority and fairness, I think this is a bad idea for scaping behavior like this where the actors and URLs are known.

/kind feature
/priority important-soon
@kubernetes/sig-auth-feature-requests @kubernetes/sig-api-machinery-feature-requests 
/hold 

holding for discussion, unit tests, probably integration tests.

```release-note
NONE
```