### PR TITLE
fix e2e loadbalancer test

### DIFF
--- a/test/e2e/network/loadbalancer.go
+++ b/test/e2e/network/loadbalancer.go
@@ -422,7 +422,7 @@ var _ = SIGDescribe("LoadBalancers", func() {
 			s.Spec.Ports[0].Port++
 		})
 		framework.ExpectNoError(err)
-		if int(udpService.Spec.Ports[0].Port) != svcPort {
+		if int(udpService.Spec.Ports[0].Port) == svcPort {
 			framework.Failf("UDP Spec.Ports[0].Port (%d) did not change", udpService.Spec.Ports[0].Port)
 		}
 		if int(udpService.Spec.Ports[0].NodePort) != udpNodePort {


### PR DESCRIPTION

/kind failing-test

```release-note
NONE
```

Somehow I messed it up migrating the tests and now it failing because is doing the right thing :smile: 
https://testgrid.k8s.io/sig-network-gce#gci-gce-slow