### PR TITLE
Remove storage_operation_status_count

### DIFF
--- a/pkg/volume/util/metrics.go
+++ b/pkg/volume/util/metrics.go
@@ -50,15 +50,6 @@ var storageOperationMetric = metrics.NewHistogramVec(
 	[]string{"volume_plugin", "operation_name", "status"},
 )
 
-var storageOperationStatusMetric = metrics.NewCounterVec(
-	&metrics.CounterOpts{
-		Name:           "storage_operation_status_count",
-		Help:           "Storage operation return statuses count",
-		StabilityLevel: metrics.ALPHA,
-	},
-	[]string{"volume_plugin", "operation_name", "status"},
-)
-
 var storageOperationEndToEndLatencyMetric = metrics.NewHistogramVec(
 	&metrics.HistogramOpts{
 		Name:           "volume_operation_total_seconds",
@@ -77,7 +68,6 @@ func registerMetrics() {
 	// legacyregistry is the internal k8s wrapper around the prometheus
 	// global registry, used specifically for metric stability enforcement
 	legacyregistry.MustRegister(storageOperationMetric)
-	legacyregistry.MustRegister(storageOperationStatusMetric)
 	legacyregistry.MustRegister(storageOperationEndToEndLatencyMetric)
 }
 
@@ -94,7 +84,6 @@ func OperationCompleteHook(plugin, operationName string) func(*error) {
 			status = statusFailUnknown
 		}
 		storageOperationMetric.WithLabelValues(plugin, operationName, status).Observe(timeTaken)
-		storageOperationStatusMetric.WithLabelValues(plugin, operationName, status).Inc()
 	}
 	return opComplete
 }

--- a/pkg/volume/util/operationexecutor/operation_generator_test.go
+++ b/pkg/volume/util/operationexecutor/operation_generator_test.go
@@ -82,28 +82,28 @@ func TestOperationGenerator_GenerateUnmapVolumeFunc_PluginName(t *testing.T) {
 			t.Fatalf("Error occurred while generating unmapVolumeFunc: %v", e)
 		}
 
-		metricFamilyName := "storage_operation_status_count"
+		metricFamilyName := "storage_operation_duration_seconds"
 		labelFilter := map[string]string{
 			"status":         "success",
 			"operation_name": "unmap_volume",
 			"volume_plugin":  expectedPluginName,
 		}
 		// compare the relative change of the metric because of the global state of the prometheus.DefaultGatherer.Gather()
-		storageOperationStatusCountMetricBefore := findMetricWithNameAndLabels(metricFamilyName, labelFilter)
+		storageOperationDurationMetricBefore := findMetricWithNameAndLabels(metricFamilyName, labelFilter)
 
 		var ee error
 		unmapVolumeFunc.CompleteFunc(&ee)
 
-		storageOperationStatusCountMetricAfter := findMetricWithNameAndLabels(metricFamilyName, labelFilter)
-		if storageOperationStatusCountMetricAfter == nil {
+		storageOperationDurationMetricAfter := findMetricWithNameAndLabels(metricFamilyName, labelFilter)
+		if storageOperationDurationMetricAfter == nil {
 			t.Fatalf("Couldn't find the metric with name(%s) and labels(%v)", metricFamilyName, labelFilter)
 		}
 
-		if storageOperationStatusCountMetricBefore == nil {
-			assert.Equal(t, float64(1), *storageOperationStatusCountMetricAfter.Counter.Value, tc.name)
+		if storageOperationDurationMetricBefore == nil {
+			assert.Equal(t, uint64(1), *storageOperationDurationMetricAfter.Histogram.SampleCount, tc.name)
 		} else {
-			metricValueDiff := *storageOperationStatusCountMetricAfter.Counter.Value - *storageOperationStatusCountMetricBefore.Counter.Value
-			assert.Equal(t, float64(1), metricValueDiff, tc.name)
+			metricValueDiff := *storageOperationDurationMetricAfter.Histogram.SampleCount - *storageOperationDurationMetricBefore.Histogram.SampleCount
+			assert.Equal(t, uint64(1), metricValueDiff, tc.name)
 		}
 	}
 }

--- a/test/e2e/storage/volume_metrics.go
+++ b/test/e2e/storage/volume_metrics.go
@@ -639,21 +639,12 @@ func getControllerStorageMetrics(ms e2emetrics.ControllerManagerMetrics, pluginN
 				if len(pluginName) > 0 && pluginName != metricPluginName {
 					continue
 				}
-				result.latencyMetrics[operation] = count
-			}
-		case "storage_operation_status_count":
-			for _, sample := range samples {
-				count := int64(sample.Value)
-				operation := string(sample.Metric["operation_name"])
 				status := string(sample.Metric["status"])
 				statusCounts := result.statusMetrics[operation]
-				metricPluginName := string(sample.Metric["volume_plugin"])
-				if len(pluginName) > 0 && pluginName != metricPluginName {
-					continue
-				}
 				switch status {
 				case "success":
 					statusCounts.successCount = count
+					result.latencyMetrics[operation] = count
 				case "fail-unknown":
 					statusCounts.failCount = count
 				default:


### PR DESCRIPTION

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Remove unnecessary operation status count. This can be recovered from the storage_operation_duration_seconds histogram.

**Which issue(s) this PR fixes**:
ref: #98332
```release-note
ACTION REQUIRED: Remove storage_operation_status_count. This count is available from the storage_operation_duration_seconds histogram metric.
```
