### PR TITLE
fix infinite wait if there is an error on watch

### DIFF
--- a/test/e2e/node/pods.go
+++ b/test/e2e/node/pods.go
@@ -282,6 +282,7 @@ var _ = SIGDescribe("Pods Extended", func() {
 								events = append(events, event)
 								if event.Type == watch.Error {
 									framework.Logf("watch error seen for %s: %#v", pod.Name, event.Object)
+									break
 								}
 								if event.Type == watch.Deleted {
 									framework.Logf("watch delete seen for %s", pod.Name)


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
The watch goroutine will loop forever if an error is reached. This fix will unblock the goroutine on watch error.

**Which issue(s) this PR fixes**:
This may be a partial fix for #98142

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs
NONE
```
