### PR TITLE
Update logs in staging/src/k8s.io/csi-translation-lib

### DIFF
--- a/staging/src/k8s.io/csi-translation-lib/plugins/vsphere_volume.go
+++ b/staging/src/k8s.io/csi-translation-lib/plugins/vsphere_volume.go
@@ -96,7 +96,7 @@ func (t *vSphereCSITranslator) TranslateInTreeStorageClassToCSI(sc *storage.Stor
 		case "iopslimit":
 			params[paramIopslimit] = v
 		default:
-			klog.V(2).Infof("StorageClass parameter [name:%q, value:%q] is not supported", k, v)
+			klog.V(2).InfoS("StorageClass parameter is not supported", "name", k, "value", v)
 		}
 	}
 


### PR DESCRIPTION
Migrate to structured logs

File modified:
	staging/src/k8s.io/csi-translation-lib/plugins/vsphere_volume.go

**What type of PR is this?**
/kind cleanup


**What this PR does / why we need it**:
Migrate to structured logs according to keps/sig-instrumentation/1602-structured-logging

**Which issue(s) this PR fixes**:

Fixes #
	staging/src/k8s.io/csi-translation-lib/plugins/vsphere_volume.go

Ref:

    keps/sig-instrumentation/1602-structured-logging
    Structured Logging migration instructions