### PR TITLE
Update logs in mount_helper_common.go

### DIFF
--- a/staging/src/k8s.io/mount-utils/mount_helper_common.go
+++ b/staging/src/k8s.io/mount-utils/mount_helper_common.go
@@ -63,7 +63,7 @@ func CleanupMountWithForce(mountPath string, mounter MounterForceUnmounter, exte
 	}
 
 	// Unmount the mount path
-	klog.V(4).Infof("%q is a mountpoint, unmounting", mountPath)
+	klog.V(4).InfoS("Unmounting mountpoint of mountpath", "mountpath", mountPath)
 	if err := mounter.UnmountWithForce(mountPath, umountTimeout); err != nil {
 		return err
 	}
@@ -96,7 +96,7 @@ func doCleanupMountPoint(mountPath string, mounter Interface, extensiveMountPoin
 	}
 
 	// Unmount the mount path
-	klog.V(4).Infof("%q is a mountpoint, unmounting", mountPath)
+	klog.V(4).InfoS("Unmounting mountpoint of mountpath", "mountpath", mountPath)
 	if err := mounter.Unmount(mountPath); err != nil {
 		return err
 	}


### PR DESCRIPTION
Migrate to structured logs

File modified:
	staging/src/k8s.io/mount-utils/mount_helper_common.go

**What type of PR is this?**
/kind cleanup


**What this PR does / why we need it**:
Migrate to structured logs according to keps/sig-instrumentation/1602-structured-logging

**Which issue(s) this PR fixes**:

Fixes #
	staging/src/k8s.io/mount-utils/mount_helper_common.go

Ref:

    keps/sig-instrumentation/1602-structured-logging
    Structured Logging migration instructions