### PR TITLE
Fix loadbalancer e2e udp: Part 2 

### DIFF
--- a/test/e2e/network/loadbalancer.go
+++ b/test/e2e/network/loadbalancer.go
@@ -422,8 +422,10 @@ var _ = SIGDescribe("LoadBalancers", func() {
 			s.Spec.Ports[0].Port++
 		})
 		framework.ExpectNoError(err)
-		if int(udpService.Spec.Ports[0].Port) == svcPort {
-			framework.Failf("UDP Spec.Ports[0].Port (%d) did not change", udpService.Spec.Ports[0].Port)
+		svcPortOld := svcPort
+		svcPort = int(udpService.Spec.Ports[0].Port)
+		if svcPort == svcPortOld {
+			framework.Failf("UDP Spec.Ports[0].Port (%d) did not change", svcPort)
 		}
 		if int(udpService.Spec.Ports[0].NodePort) != udpNodePort {
 			framework.Failf("UDP Spec.Ports[0].NodePort (%d) changed", udpService.Spec.Ports[0].NodePort)


### PR DESCRIPTION
/kind bug
/kind failing-test

**What this PR does / why we need it**:

The test mutates the port and uses it later to poll the service, so we need to store the new port or the test will fail trying to poll the old port

https://testgrid.k8s.io/sig-network-gce#gci-gce-ipvs


**Which issue(s) this PR fixes**:

Fixes #98427

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
