### PR TITLE
enable profiling by default in kube-proxy

### DIFF
--- a/cmd/kube-proxy/app/server.go
+++ b/cmd/kube-proxy/app/server.go
@@ -199,7 +199,7 @@ func (o *Options) AddFlags(fs *pflag.FlagSet) {
 
 	fs.BoolVar(&o.config.IPVS.StrictARP, "ipvs-strict-arp", o.config.IPVS.StrictARP, "Enable strict ARP by setting arp_ignore to 1 and arp_announce to 2")
 	fs.BoolVar(&o.config.IPTables.MasqueradeAll, "masquerade-all", o.config.IPTables.MasqueradeAll, "If using the pure iptables proxy, SNAT all traffic sent via Service cluster IPs (this not commonly needed)")
-	fs.BoolVar(&o.config.EnableProfiling, "profiling", o.config.EnableProfiling, "If true enables profiling via web interface on /debug/pprof handler.")
+	fs.BoolVar(o.config.EnableProfiling, "profiling", *o.config.EnableProfiling, "If true enables profiling via web interface on /debug/pprof handler.")
 
 	fs.Float32Var(&o.config.ClientConnection.QPS, "kube-api-qps", o.config.ClientConnection.QPS, "QPS to use while talking with kubernetes apiserver")
 	fs.Var(&o.config.DetectLocalMode, "detect-local-mode", "Mode to use to detect local traffic")

--- a/cmd/kube-proxy/app/server_others.go
+++ b/cmd/kube-proxy/app/server_others.go
@@ -375,7 +375,7 @@ func newProxyServer(
 		NodeRef:                nodeRef,
 		MetricsBindAddress:     config.MetricsBindAddress,
 		BindAddressHardFail:    config.BindAddressHardFail,
-		EnableProfiling:        config.EnableProfiling,
+		EnableProfiling:        *config.EnableProfiling,
 		OOMScoreAdj:            config.OOMScoreAdj,
 		ConfigSyncPeriod:       config.ConfigSyncPeriod.Duration,
 		HealthzServer:          healthzServer,

--- a/cmd/kube-proxy/app/server_test.go
+++ b/cmd/kube-proxy/app/server_test.go
@@ -264,6 +264,7 @@ nodePortAddresses:
 			UDPIdleTimeout:     metav1.Duration{Duration: 123 * time.Millisecond},
 			NodePortAddresses:  []string{"10.20.30.40/16", "fd00:1::0/64"},
 			DetectLocalMode:    kubeproxyconfig.LocalModeClusterCIDR,
+			EnableProfiling:    utilpointer.BoolPtr(true),
 		}
 
 		options := NewOptions()

--- a/cmd/kube-proxy/app/server_windows.go
+++ b/cmd/kube-proxy/app/server_windows.go
@@ -170,7 +170,7 @@ func newProxyServer(config *proxyconfigapi.KubeProxyConfiguration, cleanupAndExi
 		NodeRef:             nodeRef,
 		MetricsBindAddress:  config.MetricsBindAddress,
 		BindAddressHardFail: config.BindAddressHardFail,
-		EnableProfiling:     config.EnableProfiling,
+		EnableProfiling:     *config.EnableProfiling,
 		OOMScoreAdj:         config.OOMScoreAdj,
 		ConfigSyncPeriod:    config.ConfigSyncPeriod.Duration,
 		HealthzServer:       healthzServer,

--- a/pkg/proxy/apis/config/fuzzer/fuzzer.go
+++ b/pkg/proxy/apis/config/fuzzer/fuzzer.go
@@ -46,6 +46,7 @@ func Funcs(codecs runtimeserializer.CodecFactory) []interface{} {
 			obj.OOMScoreAdj = utilpointer.Int32Ptr(c.Int31())
 			obj.ClientConnection.ContentType = "bar"
 			obj.NodePortAddresses = []string{"1.2.3.0/24"}
+			obj.EnableProfiling = utilpointer.BoolPtr(true)
 		},
 	}
 }

--- a/pkg/proxy/apis/config/scheme/testdata/KubeProxyConfiguration/after/v1alpha1.yaml
+++ b/pkg/proxy/apis/config/scheme/testdata/KubeProxyConfiguration/after/v1alpha1.yaml
@@ -15,7 +15,7 @@ conntrack:
   tcpCloseWaitTimeout: 1h0m0s
   tcpEstablishedTimeout: 24h0m0s
 detectLocalMode: ""
-enableProfiling: false
+enableProfiling: true
 healthzBindAddress: 0.0.0.0:10256
 hostnameOverride: ""
 iptables:

--- a/pkg/proxy/apis/config/types.go
+++ b/pkg/proxy/apis/config/types.go
@@ -124,7 +124,7 @@ type KubeProxyConfiguration struct {
 	BindAddressHardFail bool
 	// enableProfiling enables profiling via web interface on /debug/pprof handler.
 	// Profiling handlers will be handled by metrics server.
-	EnableProfiling bool
+	EnableProfiling *bool
 	// clusterCIDR is the CIDR range of the pods in the cluster. It is used to
 	// bridge traffic coming from outside of the cluster. If not provided,
 	// no off-cluster bridging will be performed.

--- a/pkg/proxy/apis/config/v1alpha1/BUILD
+++ b/pkg/proxy/apis/config/v1alpha1/BUILD
@@ -54,5 +54,6 @@ go_test(
         "//staging/src/k8s.io/component-base/config/v1alpha1:go_default_library",
         "//staging/src/k8s.io/kube-proxy/config/v1alpha1:go_default_library",
         "//vendor/github.com/google/go-cmp/cmp:go_default_library",
+        "//vendor/k8s.io/utils/pointer:go_default_library",
     ],
 )

--- a/pkg/proxy/apis/config/v1alpha1/defaults.go
+++ b/pkg/proxy/apis/config/v1alpha1/defaults.go
@@ -125,6 +125,11 @@ func SetDefaults_KubeProxyConfiguration(obj *kubeproxyconfigv1alpha1.KubeProxyCo
 	if obj.FeatureGates == nil {
 		obj.FeatureGates = make(map[string]bool)
 	}
+
+	// Enable profiling by default in the kube-proxy
+	if obj.EnableProfiling == nil {
+		obj.EnableProfiling = pointer.BoolPtr(true)
+	}
 }
 
 // getDefaultAddresses returns default address of healthz and metrics server

--- a/pkg/proxy/apis/config/v1alpha1/defaults_test.go
+++ b/pkg/proxy/apis/config/v1alpha1/defaults_test.go
@@ -24,6 +24,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	componentbaseconfig "k8s.io/component-base/config/v1alpha1"
 	kubeproxyconfigv1alpha1 "k8s.io/kube-proxy/config/v1alpha1"
+	"k8s.io/utils/pointer"
 )
 
 func TestDefaultsKubeProxyConfiguration(t *testing.T) {
@@ -67,6 +68,7 @@ func TestDefaultsKubeProxyConfiguration(t *testing.T) {
 					TCPCloseWaitTimeout:   &metav1.Duration{Duration: 1 * time.Hour},
 				},
 				ConfigSyncPeriod: metav1.Duration{Duration: 15 * time.Minute},
+				EnableProfiling:  pointer.BoolPtr(true),
 			},
 		},
 		{
@@ -103,6 +105,7 @@ func TestDefaultsKubeProxyConfiguration(t *testing.T) {
 					TCPCloseWaitTimeout:   &metav1.Duration{Duration: 1 * time.Hour},
 				},
 				ConfigSyncPeriod: metav1.Duration{Duration: 15 * time.Minute},
+				EnableProfiling:  pointer.BoolPtr(true),
 			},
 		},
 	}

--- a/pkg/proxy/apis/config/v1alpha1/zz_generated.conversion.go
+++ b/pkg/proxy/apis/config/v1alpha1/zz_generated.conversion.go
@@ -97,7 +97,7 @@ func autoConvert_v1alpha1_KubeProxyConfiguration_To_config_KubeProxyConfiguratio
 	out.HealthzBindAddress = in.HealthzBindAddress
 	out.MetricsBindAddress = in.MetricsBindAddress
 	out.BindAddressHardFail = in.BindAddressHardFail
-	out.EnableProfiling = in.EnableProfiling
+	out.EnableProfiling = (*bool)(unsafe.Pointer(in.EnableProfiling))
 	out.ClusterCIDR = in.ClusterCIDR
 	out.HostnameOverride = in.HostnameOverride
 	if err := configv1alpha1.Convert_v1alpha1_ClientConnectionConfiguration_To_config_ClientConnectionConfiguration(&in.ClientConnection, &out.ClientConnection, s); err != nil {
@@ -137,7 +137,7 @@ func autoConvert_config_KubeProxyConfiguration_To_v1alpha1_KubeProxyConfiguratio
 	out.HealthzBindAddress = in.HealthzBindAddress
 	out.MetricsBindAddress = in.MetricsBindAddress
 	out.BindAddressHardFail = in.BindAddressHardFail
-	out.EnableProfiling = in.EnableProfiling
+	out.EnableProfiling = (*bool)(unsafe.Pointer(in.EnableProfiling))
 	out.ClusterCIDR = in.ClusterCIDR
 	out.HostnameOverride = in.HostnameOverride
 	if err := configv1alpha1.Convert_config_ClientConnectionConfiguration_To_v1alpha1_ClientConnectionConfiguration(&in.ClientConnection, &out.ClientConnection, s); err != nil {

--- a/pkg/proxy/apis/config/zz_generated.deepcopy.go
+++ b/pkg/proxy/apis/config/zz_generated.deepcopy.go
@@ -58,6 +58,11 @@ func (in *KubeProxyConfiguration) DeepCopyInto(out *KubeProxyConfiguration) {
 			(*out)[key] = val
 		}
 	}
+	if in.EnableProfiling != nil {
+		in, out := &in.EnableProfiling, &out.EnableProfiling
+		*out = new(bool)
+		**out = **in
+	}
 	out.ClientConnection = in.ClientConnection
 	in.IPTables.DeepCopyInto(&out.IPTables)
 	in.IPVS.DeepCopyInto(&out.IPVS)

--- a/staging/src/k8s.io/kube-proxy/config/v1alpha1/types.go
+++ b/staging/src/k8s.io/kube-proxy/config/v1alpha1/types.go
@@ -120,7 +120,7 @@ type KubeProxyConfiguration struct {
 	BindAddressHardFail bool `json:"bindAddressHardFail"`
 	// enableProfiling enables profiling via web interface on /debug/pprof handler.
 	// Profiling handlers will be handled by metrics server.
-	EnableProfiling bool `json:"enableProfiling"`
+	EnableProfiling *bool `json:"enableProfiling"`
 	// clusterCIDR is the CIDR range of the pods in the cluster. It is used to
 	// bridge traffic coming from outside of the cluster. If not provided,
 	// no off-cluster bridging will be performed.

--- a/staging/src/k8s.io/kube-proxy/config/v1alpha1/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/kube-proxy/config/v1alpha1/zz_generated.deepcopy.go
@@ -36,6 +36,11 @@ func (in *KubeProxyConfiguration) DeepCopyInto(out *KubeProxyConfiguration) {
 			(*out)[key] = val
 		}
 	}
+	if in.EnableProfiling != nil {
+		in, out := &in.EnableProfiling, &out.EnableProfiling
+		*out = new(bool)
+		**out = **in
+	}
 	out.ClientConnection = in.ClientConnection
 	in.IPTables.DeepCopyInto(&out.IPTables)
 	in.IPVS.DeepCopyInto(&out.IPVS)


### PR DESCRIPTION
**What type of PR is this?**
/kind feature
/sig network


**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes #98410


**Does this PR introduce a user-facing change?**:
```release-note
Profiling is enabled by default in the kube-proxy. 
```