### PR TITLE
change minimum bash version to 4.2

### DIFF
--- a/hack/lib/util.sh
+++ b/hack/lib/util.sh
@@ -734,8 +734,8 @@ function kube::util::ensure_dockerized {
 #
 function kube::util::ensure-bash-version {
   # shellcheck disable=SC2004
-  if ((${BASH_VERSINFO[0]}<5)); then
-    echo "ERROR: This script requires a minimum bash version of 5.0"
+  if ((${BASH_VERSINFO[0]}<4)) || ( ((${BASH_VERSINFO[0]}==4)) && ((${BASH_VERSINFO[1]}<2)) ); then
+    echo "ERROR: This script requires a minimum bash version of 4.2, but got version of ${BASH_VERSINFO[0]}.${BASH_VERSINFO[1]}"
     exit 1
   fi
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind bug


**What this PR does / why we need it**:

Change the minimum bash version requirement from 5.x to 4.2, since some people still run Ubuntu 18.04 machines.

**Which issue(s) this PR fixes**:
Fixes #98419 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```