### PR TITLE
Update godoc reference widget to pkg.go.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Kubernetes (K8s)
 
-[![GoDoc Widget]][GoDoc] [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/569/badge)](https://bestpractices.coreinfrastructure.org/projects/569)
+[![GoPkg Widget]][GoPkg] [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/569/badge)](https://bestpractices.coreinfrastructure.org/projects/569)
 
 <img src="https://github.com/kubernetes/kubernetes/raw/master/logo/logo.png" width="100">
 
@@ -79,8 +79,8 @@ That said, if you have questions, reach out to us
 [developer's documentation]: https://git.k8s.io/community/contributors/devel#readme
 [Docker environment]: https://docs.docker.com/engine
 [Go environment]: https://golang.org/doc/install
-[GoDoc]: https://godoc.org/k8s.io/kubernetes
-[GoDoc Widget]: https://godoc.org/k8s.io/kubernetes?status.svg
+[GoPkg]: https://pkg.go.dev/k8s.io/kubernetes
+[GoPkg Widget]: https://pkg.go.dev/badge/k8s.io/kubernetes.svg
 [interactive tutorial]: https://kubernetes.io/docs/tutorials/kubernetes-basics
 [kubernetes.io]: https://kubernetes.io
 [Scalable Microservices with Kubernetes]: https://www.udacity.com/course/scalable-microservices-with-kubernetes--ud615


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
godoc.org has been replaced with pgk.go.dev.
A redirect exists for now, but will eventually be turned off.
For more information see the go blog post on this migration:
https://blog.golang.org/pkg.go.dev-2020

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs
```

/sig contributor-experience