### PR TITLE
protobuf serializer: set content type when into is runtime.Unknown

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/protobuf/protobuf.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/protobuf/protobuf.go
@@ -120,9 +120,7 @@ func (s *Serializer) Decode(originalData []byte, gvk *schema.GroupVersionKind, i
 
 	if intoUnknown, ok := into.(*runtime.Unknown); ok && intoUnknown != nil {
 		*intoUnknown = unk
-		if ok, _, _ := s.RecognizesData(unk.Raw); ok {
-			intoUnknown.ContentType = runtime.ContentTypeProtobuf
-		}
+		intoUnknown.ContentType = runtime.ContentTypeProtobuf
 		return intoUnknown, &actual, nil
 	}
 

--- a/staging/src/k8s.io/apimachinery/pkg/test/runtime_serializer_protobuf_protobuf_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/test/runtime_serializer_protobuf_protobuf_test.go
@@ -218,7 +218,7 @@ func TestProtobufDecode(t *testing.T) {
 		0x0a, 0x15,
 		0x0a, 0x0d, 0x6f, 0x74, 0x68, 0x65, 0x72, 0x2f, 0x76, 0x65, 0x72, 0x73, 0x69, 0x6f, 0x6e, // apiversion
 		0x12, 0x04, 0x74, 0x65, 0x73, 0x74, // kind
-		0x12, 0x07, 0x6b, 0x38, 0x73, 0x00, 0x01, 0x02, 0x03, // data
+		0x12, 0x03, 0x01, 0x02, 0x03, // data
 		0x1a, 0x00, // content-type
 		0x22, 0x00, // content-encoding
 	}
@@ -238,7 +238,9 @@ func TestProtobufDecode(t *testing.T) {
 		},
 		{
 			obj: &runtime.Unknown{
-				Raw: []byte{},
+				// content type is set because wire data has the right prefix
+				ContentType: runtime.ContentTypeProtobuf,
+				Raw:         []byte{},
 			},
 			data: wire1,
 		},
@@ -248,9 +250,9 @@ func TestProtobufDecode(t *testing.T) {
 					APIVersion: "other/version",
 					Kind:       "test",
 				},
-				// content type is set because the prefix matches the content
+				// content type is set because wire data has the right prefix
 				ContentType: runtime.ContentTypeProtobuf,
-				Raw:         []byte{0x6b, 0x38, 0x73, 0x00, 0x01, 0x02, 0x03},
+				Raw:         []byte{0x01, 0x02, 0x03},
 			},
 			data: wire2,
 		},


### PR DESCRIPTION
The originalData is validated to have the correct prefix at the
start of Serializer.Decode.  This combined with a successful
Unmarshal into runtime.Unknown is sufficient for us to assert that
the content type is runtime.ContentTypeProtobuf.

The previous code only set content type when Unknown.Raw was
prefixed with s.prefix but this should never be the case.

Signed-off-by: Monis Khan <mok@vmware.com>

```release-note
NONE
```