### PR TITLE
Remove heapster flag in 'kubectl top'

### DIFF
--- a/staging/src/k8s.io/kubectl/docs/book/pages/container_debugging/proxying_traffic_to_services.md
+++ b/staging/src/k8s.io/kubectl/docs/book/pages/container_debugging/proxying_traffic_to_services.md
@@ -64,7 +64,6 @@ kubectl cluster-info
 
 Kubernetes master is running at https://104.197.5.247
 GLBCDefaultBackend is running at https://104.197.5.247/api/v1/namespaces/kube-system/services/default-http-backend:http/proxy
-Heapster is running at https://104.197.5.247/api/v1/namespaces/kube-system/services/heapster/proxy
 KubeDNS is running at https://104.197.5.247/api/v1/namespaces/kube-system/services/kube-dns:dns/proxy
 Metrics-server is running at https://104.197.5.247/api/v1/namespaces/kube-system/services/https:metrics-server:/proxy
 ```

--- a/staging/src/k8s.io/kubectl/docs/book/pages/kubectl_book/getting_started.md
+++ b/staging/src/k8s.io/kubectl/docs/book/pages/kubectl_book/getting_started.md
@@ -34,7 +34,6 @@ kubectl get deployments --namespace kube-system
 NAME                     DESIRED   CURRENT   UP-TO-DATE   AVAILABLE   AGE
 event-exporter-v0.2.3    1         1         1            1           14d
 fluentd-gcp-scaler       1         1         1            1           14d
-heapster-v1.6.0-beta.1   1         1         1            1           14d
 kube-dns                 2         2         2            2           14d
 kube-dns-autoscaler      1         1         1            1           14d
 l7-default-backend       1         1         1            1           14d

--- a/staging/src/k8s.io/kubectl/pkg/cmd/top/BUILD
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/top/BUILD
@@ -25,7 +25,6 @@ go_library(
         "//staging/src/k8s.io/metrics/pkg/apis/metrics/v1beta1:go_default_library",
         "//staging/src/k8s.io/metrics/pkg/client/clientset/versioned:go_default_library",
         "//vendor/github.com/spf13/cobra:go_default_library",
-        "//vendor/github.com/spf13/pflag:go_default_library",
         "//vendor/k8s.io/klog/v2:go_default_library",
     ],
 )

--- a/staging/src/k8s.io/kubectl/pkg/cmd/top/top_node.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/top/top_node.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 
 	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -49,17 +48,6 @@ type TopNodeOptions struct {
 	MetricsClient   metricsclientset.Interface
 
 	genericclioptions.IOStreams
-}
-
-func heapsterTopOptions(flags *pflag.FlagSet) {
-	flags.String("heapster-namespace", "kube-system", "Namespace Heapster service is located in")
-	flags.MarkDeprecated("heapster-namespace", "This flag is currently no-op and will be deleted.")
-	flags.String("heapster-service", "heapster", "Name of Heapster service")
-	flags.MarkDeprecated("heapster-service", "This flag is currently no-op and will be deleted.")
-	flags.String("heapster-scheme", "http", "Scheme (http or https) to connect to Heapster as")
-	flags.MarkDeprecated("heapster-scheme", "This flag is currently no-op and will be deleted.")
-	flags.String("heapster-port", "", "Port name in service to use")
-	flags.MarkDeprecated("heapster-port", "This flag is currently no-op and will be deleted.")
 }
 
 var (
@@ -99,7 +87,6 @@ func NewCmdTopNode(f cmdutil.Factory, o *TopNodeOptions, streams genericclioptio
 	cmd.Flags().StringVarP(&o.Selector, "selector", "l", o.Selector, "Selector (label query) to filter on, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)")
 	cmd.Flags().StringVar(&o.SortBy, "sort-by", o.Selector, "If non-empty, sort nodes list using specified field. The field can be either 'cpu' or 'memory'.")
 	cmd.Flags().BoolVar(&o.NoHeaders, "no-headers", o.NoHeaders, "If present, print output without headers")
-	heapsterTopOptions(cmd.Flags())
 
 	return cmd
 }

--- a/staging/src/k8s.io/kubectl/pkg/cmd/top/top_pod.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/top/top_pod.go
@@ -179,7 +179,6 @@ func (o TopPodOptions) RunTopPod() error {
 		return err
 	}
 
-	// TODO: Refactor this once Heapster becomes the API server.
 	// First we check why no metrics have been received.
 	if len(metrics.Items) == 0 {
 		// If the API server query is successful but all the pods are newly created,


### PR DESCRIPTION
Signed-off-by: chymy <chang.min1@zte.com.cn>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
Heapster is no longer supported for `kubectl top`, heapster flag is redundant, should be removed.
ref: #87498, kubernetes/kubectl#806
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
