### PR TITLE
Deep copy statefulset pvctemplate annotations

### DIFF
--- a/pkg/controller/statefulset/stateful_set_utils.go
+++ b/pkg/controller/statefulset/stateful_set_utils.go
@@ -141,6 +141,12 @@ func getPersistentVolumeClaims(set *apps.StatefulSet, pod *v1.Pod) map[string]v1
 	claims := make(map[string]v1.PersistentVolumeClaim, len(templates))
 	for i := range templates {
 		claim := templates[i]
+		if templates[i].Annotations != nil {
+			claim.Annotations = map[string]string{}
+			for key, value := range templates[i].Annotations {
+				claim.Annotations[key] = value
+			}
+		}
 		claim.Name = getPersistentVolumeClaimName(set, &claim, ordinal)
 		claim.Namespace = set.Namespace
 		if claim.Labels != nil {

--- a/pkg/controller/statefulset/stateful_set_utils_test.go
+++ b/pkg/controller/statefulset/stateful_set_utils_test.go
@@ -365,6 +365,17 @@ func TestGetPersistentVolumeClaims(t *testing.T) {
 	if !reflect.DeepEqual(claims, resultClaims) {
 		t.Fatalf("Unexpected pvc:\n %+v\n, desired pvc:\n %+v", claims, resultClaims)
 	}
+
+	// template annotations propagate to claims, deeply
+	statefulSet.Spec.Selector.MatchLabels = nil
+	statefulSet.Spec.VolumeClaimTemplates[0].ObjectMeta.Annotations = map[string]string{"foo": "bar"}
+	claims = getPersistentVolumeClaims(statefulSet, pod)
+	delete(statefulSet.Spec.VolumeClaimTemplates[0].ObjectMeta.Annotations, "foo")
+	pvc.SetAnnotations(map[string]string{"foo": "bar"})
+	resultClaims = map[string]v1.PersistentVolumeClaim{"datadir": pvc}
+	if !reflect.DeepEqual(claims, resultClaims) {
+		t.Fatalf("Unexpected pvc:\n %+v\n, desired pvc:\n %+v", claims, resultClaims)
+	}
 }
 
 func newPod() *v1.Pod {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it:**

Statefulset pvc template annotations were not propagating properly to the created pvc. This adds a deep-copy for annotations and the related test.

**Which issue(s) this PR fixes:**

Fixes #98475

```release-note
NONE
```

Signed-off-by: Ukri Niemimuukko <ukri.niemimuukko@intel.com>