### PR TITLE
[wip]Fix kubectl taint node, taint time will not be recorded

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/taint/utils.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/taint/utils.go
@@ -19,6 +19,7 @@ package taint
 
 import (
 	"fmt"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
@@ -65,7 +66,8 @@ func parseTaints(spec []string) ([]corev1.Taint, []corev1.Taint, error) {
 				uniqueTaints[newTaint.Effect] = sets.String{}
 			}
 			uniqueTaints[newTaint.Effect].Insert(newTaint.Key)
-
+			now := metav1.Now()
+			newTaint.TimeAdded = &now
 			taints = append(taints, newTaint)
 		}
 	}

--- a/test/integration/endpointslice/endpointslicemirroring_test.go
+++ b/test/integration/endpointslice/endpointslicemirroring_test.go
@@ -377,13 +377,13 @@ func TestEndpointSliceMirroringUpdates(t *testing.T) {
 
 					if !apiequality.Semantic.DeepEqual(epAddresses, sliceAddresses) {
 						t.Logf("Expected EndpointSlice to have the same IP addresses, expected %v got %v", epAddresses, sliceAddresses)
-						continue
+						return false, nil
 					}
 
 					// check labels were mirrored
 					if !isSubset(customEndpoints.Labels, endpointSlice.Labels) {
 						t.Logf("Expected EndpointSlice to mirror labels, expected %v to be in received %v", customEndpoints.Labels, endpointSlice.Labels)
-						continue
+						return false, nil
 					}
 
 					// check annotations but endpoints.kubernetes.io/last-change-trigger-time were mirrored
@@ -396,13 +396,10 @@ func TestEndpointSliceMirroringUpdates(t *testing.T) {
 					}
 					if !apiequality.Semantic.DeepEqual(annotations, endpointSlice.Annotations) {
 						t.Logf("Expected EndpointSlice to mirror annotations, expected %v received %v", customEndpoints.Annotations, endpointSlice.Annotations)
-						continue
+						return false, nil
 					}
-					// This is a temporary workaround for https://github.com/kubernetes/kubernetes/issues/100033.
-					// TODO(robscott): When that issue is fixed, update this test to expect all EndpointSlices to meet this criteria.
-					return true, nil
 				}
-				return false, nil
+				return true, nil
 			})
 			if err != nil {
 				t.Fatalf("Timed out waiting for conditions: %v", err)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

When executing kubectl taint node, the taint time should not be added to the taints data structure, it is not actually recorded

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #98482

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fix kubectl taint node, time is not recorded 
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
/sig cli