### PR TITLE
Automated cherry pick of #94823: Delete namespace parameter in create adapter

### DIFF
--- a/test/e2e/autoscaling/custom_metrics_stackdriver_autoscaling.go
+++ b/test/e2e/autoscaling/custom_metrics_stackdriver_autoscaling.go
@@ -259,11 +259,11 @@ func (tc *CustomMetricTestCase) Run() {
 	}
 	defer monitoring.CleanupDescriptors(gcmService, projectID)
 
-	err = monitoring.CreateAdapter(tc.framework.Namespace.ObjectMeta.Name, monitoring.AdapterDefault)
+	err = monitoring.CreateAdapter(monitoring.AdapterDefault)
 	if err != nil {
 		framework.Failf("Failed to set up: %v", err)
 	}
-	defer monitoring.CleanupAdapter(tc.framework.Namespace.ObjectMeta.Name, monitoring.AdapterDefault)
+	defer monitoring.CleanupAdapter(monitoring.AdapterDefault)
 
 	// Run application that exports the metric
 	err = createDeploymentToScale(tc.framework, tc.kubeClient, tc.deployment, tc.pod)

--- a/test/e2e/instrumentation/monitoring/custom_metrics_deployments.go
+++ b/test/e2e/instrumentation/monitoring/custom_metrics_deployments.go
@@ -265,7 +265,7 @@ func CreateAdapter(adapterDeploymentFile string) error {
 	if err != nil {
 		return err
 	}
-	stat, err := framework.RunKubectl("create", "-f", adapterURL)
+	stat, err := framework.RunKubectl("", "create", "-f", adapterURL)
 	framework.Logf(stat)
 	return err
 }
@@ -278,7 +278,7 @@ func createClusterAdminBinding() error {
 	}
 	serviceAccount := strings.TrimSpace(stdout)
 	framework.Logf("current service account: %q", serviceAccount)
-	stat, err := framework.RunKubectl("create", "clusterrolebinding", ClusterAdminBinding, "--clusterrole=cluster-admin", "--user="+serviceAccount)
+	stat, err := framework.RunKubectl("", "create", "clusterrolebinding", ClusterAdminBinding, "--clusterrole=cluster-admin", "--user="+serviceAccount)
 	framework.Logf(stat)
 	return err
 }
@@ -317,8 +317,8 @@ func CleanupDescriptors(service *gcm.Service, projectID string) {
 }
 
 // CleanupAdapter deletes Custom Metrics - Stackdriver adapter deployments.
-func CleanupAdapter(namespace, adapterDeploymentFile string) {
-	stat, err := framework.RunKubectl(namespace, "delete", "-f", adapterDeploymentFile)
+func CleanupAdapter(adapterDeploymentFile string) {
+	stat, err := framework.RunKubectl("", "delete", "-f", adapterDeploymentFile)
 	framework.Logf(stat)
 	if err != nil {
 		framework.Logf("Failed to delete adapter deployments: %s", err)
@@ -327,11 +327,11 @@ func CleanupAdapter(namespace, adapterDeploymentFile string) {
 	if err != nil {
 		framework.Logf("Failed to delete adapter deployment file: %s", err)
 	}
-	cleanupClusterAdminBinding(namespace)
+	cleanupClusterAdminBinding()
 }
 
-func cleanupClusterAdminBinding(namespace string) {
-	stat, err := framework.RunKubectl(namespace, "delete", "clusterrolebinding", ClusterAdminBinding)
+func cleanupClusterAdminBinding() {
+	stat, err := framework.RunKubectl("", "delete", "clusterrolebinding", ClusterAdminBinding)
 	framework.Logf(stat)
 	if err != nil {
 		framework.Logf("Failed to delete cluster admin binding: %s", err)

--- a/test/e2e/instrumentation/monitoring/custom_metrics_deployments.go
+++ b/test/e2e/instrumentation/monitoring/custom_metrics_deployments.go
@@ -252,11 +252,11 @@ func prometheusExporterPodSpec(metricName string, metricValue int64, port int32)
 
 // CreateAdapter creates Custom Metrics - Stackdriver adapter
 // adapterDeploymentFile should be a filename for adapter deployment located in StagingDeploymentLocation
-func CreateAdapter(namespace, adapterDeploymentFile string) error {
+func CreateAdapter(adapterDeploymentFile string) error {
 	// A workaround to make the work on GKE. GKE doesn't normally allow to create cluster roles,
 	// which the adapter deployment does. The solution is to create cluster role binding for
 	// cluster-admin role and currently used service account.
-	err := createClusterAdminBinding(namespace)
+	err := createClusterAdminBinding()
 	if err != nil {
 		return err
 	}
@@ -265,12 +265,12 @@ func CreateAdapter(namespace, adapterDeploymentFile string) error {
 	if err != nil {
 		return err
 	}
-	stat, err := framework.RunKubectl(namespace, "create", "-f", adapterURL)
+	stat, err := framework.RunKubectl("create", "-f", adapterURL)
 	framework.Logf(stat)
 	return err
 }
 
-func createClusterAdminBinding(namespace string) error {
+func createClusterAdminBinding() error {
 	stdout, stderr, err := framework.RunCmd("gcloud", "config", "get-value", "core/account")
 	if err != nil {
 		framework.Logf(stderr)
@@ -278,7 +278,7 @@ func createClusterAdminBinding(namespace string) error {
 	}
 	serviceAccount := strings.TrimSpace(stdout)
 	framework.Logf("current service account: %q", serviceAccount)
-	stat, err := framework.RunKubectl(namespace, "create", "clusterrolebinding", ClusterAdminBinding, "--clusterrole=cluster-admin", "--user="+serviceAccount)
+	stat, err := framework.RunKubectl("create", "clusterrolebinding", ClusterAdminBinding, "--clusterrole=cluster-admin", "--user="+serviceAccount)
 	framework.Logf(stat)
 	return err
 }

--- a/test/e2e/instrumentation/monitoring/custom_metrics_stackdriver.go
+++ b/test/e2e/instrumentation/monitoring/custom_metrics_stackdriver.go
@@ -114,11 +114,11 @@ func testCustomMetrics(f *framework.Framework, kubeClient clientset.Interface, c
 	}
 	defer CleanupDescriptors(gcmService, projectID)
 
-	err = CreateAdapter(f.Namespace.Name, adapterDeployment)
+	err = CreateAdapter(adapterDeployment)
 	if err != nil {
 		framework.Failf("Failed to set up: %s", err)
 	}
-	defer CleanupAdapter(f.Namespace.Name, adapterDeployment)
+	defer CleanupAdapter(adapterDeployment)
 
 	_, err = kubeClient.RbacV1().ClusterRoleBindings().Create(context.TODO(), HPAPermissions, metav1.CreateOptions{})
 	if err != nil {
@@ -162,11 +162,11 @@ func testExternalMetrics(f *framework.Framework, kubeClient clientset.Interface,
 	defer CleanupDescriptors(gcmService, projectID)
 
 	// Both deployments - for old and new resource model - expose External Metrics API.
-	err = CreateAdapter(f.Namespace.Name, AdapterForOldResourceModel)
+	err = CreateAdapter(AdapterForOldResourceModel)
 	if err != nil {
 		framework.Failf("Failed to set up: %s", err)
 	}
-	defer CleanupAdapter(f.Namespace.Name, AdapterForOldResourceModel)
+	defer CleanupAdapter(AdapterForOldResourceModel)
 
 	_, err = kubeClient.RbacV1().ClusterRoleBindings().Create(context.TODO(), HPAPermissions, metav1.CreateOptions{})
 	if err != nil {


### PR DESCRIPTION
This cherrypick fixes the autoscaling e2e test failing in the 1.19 release branch.

Fixes https://github.com/kubernetes/kubernetes/issues/98219.

---

Cherry pick of #94823 on release-1.19.

#94823: Delete namespace parameter in create adapter

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.


```release-note
NONE
```