### PR TITLE
enable cross-compile CC config for non-amd64

### DIFF
--- a/hack/lib/golang.sh
+++ b/hack/lib/golang.sh
@@ -416,6 +416,13 @@ kube::golang::set_platform_envs() {
         ;;
     esac
   fi
+
+  # if CC is defined for platform then always enable it
+  ccenv=$(echo "$platform" | awk -F/ '{print "KUBE_" toupper($1) "_" toupper($2) "_CC"}')
+  if [ -n "${!ccenv-}" ]; then 
+    export CGO_ENABLED=1
+    export CC="${!ccenv}"
+  fi
 }
 
 kube::golang::unset_platform_envs() {


### PR DESCRIPTION

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

With https://github.com/kubernetes/kubernetes/pull/94403/commits/462326afba0395aa28e094e29339b025354af8f7 target CC can only be set if the host platform is `linux/amd64` . Eg. it is not possible to build on arm64 for amd64 using cgo. If target is already set in the environment it is always safe to use it and enable cgo. This PR checks if env matching the `KUBE_OS_ARCH_CC` is present.

I'd also recommend removing the exception for amd64 and solving setting defaults some other way. I can follow-up with that if there is a consensus for a solution.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
