### PR TITLE
Add request value verification for hugepage

### DIFF
--- a/pkg/apis/core/helper/helpers.go
+++ b/pkg/apis/core/helper/helpers.go
@@ -39,6 +39,21 @@ func IsHugePageResourceName(name core.ResourceName) bool {
 	return strings.HasPrefix(string(name), core.ResourceHugePagesPrefix)
 }
 
+// IsHugePageResourceValueDivisible returns true if the resource value of storage is
+// integer multiple of page size.
+func IsHugePageResourceValueDivisible(name core.ResourceName, quantity resource.Quantity) bool {
+	pageSize, err := HugePageSizeFromResourceName(name)
+	if err != nil {
+		return false
+	}
+
+	if pageSize.Sign() <= 0 || pageSize.MilliValue()%int64(1000) != int64(0) {
+		return false
+	}
+
+	return quantity.Value()%pageSize.Value() == 0
+}
+
 // IsQuotaHugePageResourceName returns true if the resource name has the quota
 // related huge page resource prefix.
 func IsQuotaHugePageResourceName(name core.ResourceName) bool {

--- a/pkg/apis/core/helper/helpers_test.go
+++ b/pkg/apis/core/helper/helpers_test.go
@@ -211,6 +211,60 @@ func TestIsHugePageResourceName(t *testing.T) {
 	}
 }
 
+func TestIsHugePageResourceValueDivisible(t *testing.T) {
+	testCases := []struct {
+		name     core.ResourceName
+		quantity resource.Quantity
+		result   bool
+	}{
+		{
+			name:     core.ResourceName("hugepages-2Mi"),
+			quantity: resource.MustParse("4Mi"),
+			result:   true,
+		},
+		{
+			name:     core.ResourceName("hugepages-2Mi"),
+			quantity: resource.MustParse("5Mi"),
+			result:   false,
+		},
+		{
+			name:     core.ResourceName("hugepages-1Gi"),
+			quantity: resource.MustParse("2Gi"),
+			result:   true,
+		},
+		{
+			name:     core.ResourceName("hugepages-1Gi"),
+			quantity: resource.MustParse("2.1Gi"),
+			result:   false,
+		},
+		{
+			name:     core.ResourceName("hugepages-1Mi"),
+			quantity: resource.MustParse("2.1Mi"),
+			result:   false,
+		},
+		{
+			name:     core.ResourceName("hugepages-64Ki"),
+			quantity: resource.MustParse("128Ki"),
+			result:   true,
+		},
+		{
+			name:     core.ResourceName("hugepages-"),
+			quantity: resource.MustParse("128Ki"),
+			result:   false,
+		},
+		{
+			name:     core.ResourceName("hugepages"),
+			quantity: resource.MustParse("128Ki"),
+			result:   false,
+		},
+	}
+	for _, testCase := range testCases {
+		if testCase.result != IsHugePageResourceValueDivisible(testCase.name, testCase.quantity) {
+			t.Errorf("resource: %v storage:%v expected result: %v", testCase.name, testCase.quantity, testCase.result)
+		}
+	}
+}
+
 func TestHugePageResourceName(t *testing.T) {
 	testCases := []struct {
 		pageSize resource.Quantity

--- a/pkg/apis/node/validation/validation.go
+++ b/pkg/apis/node/validation/validation.go
@@ -54,7 +54,8 @@ func ValidateRuntimeClassUpdate(new, old *node.RuntimeClass) field.ErrorList {
 
 func validateOverhead(overhead *node.Overhead, fldPath *field.Path) field.ErrorList {
 	// reuse the ResourceRequirements validation logic
-	return corevalidation.ValidateResourceRequirements(&core.ResourceRequirements{Limits: overhead.PodFixed}, fldPath)
+	return corevalidation.ValidateResourceRequirements(&core.ResourceRequirements{Limits: overhead.PodFixed}, fldPath,
+		corevalidation.PodValidationOptions{})
 }
 
 func validateScheduling(s *node.Scheduling, fldPath *field.Path) field.ErrorList {

--- a/pkg/registry/apps/deployment/strategy_test.go
+++ b/pkg/registry/apps/deployment/strategy_test.go
@@ -20,6 +20,7 @@ import (
 	"reflect"
 	"testing"
 
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -245,5 +246,116 @@ func TestDeploymentDefaultGarbageCollectionPolicy(t *testing.T) {
 			t.Errorf("%s/%s: DefaultGarbageCollectionPolicy() = %#v, want %#v", test.requestInfo.APIGroup,
 				test.requestInfo.APIVersion, got, want)
 		}
+	}
+}
+
+func newDeploymentWithHugePageValue(reousreceName api.ResourceName, value resource.Quantity) *apps.Deployment {
+	return &apps.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            deploymentName,
+			Namespace:       namespace,
+			ResourceVersion: "1",
+		},
+		Spec: apps.DeploymentSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels:      map[string]string{"foo": "bar"},
+				MatchExpressions: []metav1.LabelSelectorRequirement{},
+			},
+			Strategy: apps.DeploymentStrategy{
+				Type: apps.RollingUpdateDeploymentStrategyType,
+				RollingUpdate: &apps.RollingUpdateDeployment{
+					MaxSurge:       intstr.FromInt(1),
+					MaxUnavailable: intstr.FromInt(1),
+				},
+			},
+			Template: api.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "foo",
+					Labels:    map[string]string{"foo": "bar"},
+				},
+				Spec: api.PodSpec{
+					RestartPolicy: api.RestartPolicyAlways,
+					DNSPolicy:     api.DNSDefault,
+					Containers: []api.Container{{
+						Name:                     fakeImageName,
+						Image:                    fakeImage,
+						ImagePullPolicy:          api.PullNever,
+						TerminationMessagePolicy: api.TerminationMessageReadFile,
+						Resources: api.ResourceRequirements{
+							Requests: api.ResourceList{
+								api.ResourceName(api.ResourceCPU): resource.MustParse("10"),
+								api.ResourceName(reousreceName):   value,
+							},
+							Limits: api.ResourceList{
+								api.ResourceName(api.ResourceCPU): resource.MustParse("10"),
+								api.ResourceName(reousreceName):   value,
+							},
+						}},
+					}},
+			},
+		},
+	}
+}
+
+func TestDeploymentStrategyValidate(t *testing.T) {
+	tests := []struct {
+		name       string
+		deployment *apps.Deployment
+	}{
+		{
+			name:       "validation on a new deployment with indivisible hugepages values",
+			deployment: newDeploymentWithHugePageValue(api.ResourceHugePagesPrefix+"2Mi", resource.MustParse("2.1Mi")),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if errs := Strategy.Validate(genericapirequest.NewContext(), tc.deployment); len(errs) == 0 {
+				t.Error("expected failure")
+			}
+		})
+	}
+}
+
+func TestDeploymentStrategyValidateUpdate(t *testing.T) {
+	tests := []struct {
+		name          string
+		newDeployment *apps.Deployment
+		oldDeployment *apps.Deployment
+	}{
+		{
+			name:          "validation on an existing deployment with indivisible hugepages values to a new deployment with indivisible hugepages values",
+			newDeployment: newDeploymentWithHugePageValue(api.ResourceHugePagesPrefix+"2Mi", resource.MustParse("2.1Mi")),
+			oldDeployment: newDeploymentWithHugePageValue(api.ResourceHugePagesPrefix+"1Gi", resource.MustParse("1.1Gi")),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if errs := Strategy.ValidateUpdate(genericapirequest.NewContext(), tc.newDeployment, tc.oldDeployment); len(errs) != 0 {
+				t.Errorf("unexpected error:%v", errs)
+			}
+		})
+	}
+
+	errTests := []struct {
+		name          string
+		newDeployment *apps.Deployment
+		oldDeployment *apps.Deployment
+	}{
+		{
+			name:          "validation on an existing deployment with divisible hugepages values to a new deployment with indivisible hugepages values",
+			newDeployment: newDeploymentWithHugePageValue(api.ResourceHugePagesPrefix+"2Mi", resource.MustParse("2.1Mi")),
+			oldDeployment: newDeploymentWithHugePageValue(api.ResourceHugePagesPrefix+"1Gi", resource.MustParse("2Gi")),
+		},
+	}
+
+	for _, tc := range errTests {
+		t.Run(tc.name, func(t *testing.T) {
+			if errs := Strategy.ValidateUpdate(genericapirequest.NewContext(), tc.newDeployment, tc.oldDeployment); len(errs) == 0 {
+				t.Error("expected failure")
+			}
+		})
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
Limit the request value of hugepage to integer multiple of page size to ensure the memory allocated is equal to the request.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #98513

**Special notes for your reviewer**:
the limitation can refer to https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/1539-hugepages

The quantity of huge pages must be a positive amount of memory in bytes. The specified amount must align with the <hugepagesize>; otherwise, the pod will fail validation. For example, it would be valid to request hugepages-2Mi: 4Mi, but invalid to request hugepages-2Mi: 3Mi.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
hugepages request values are limited to integer multiples of the page size.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->

