### PR TITLE
Reduce time for cert tests UT

### DIFF
--- a/cmd/kubeadm/app/util/config/common.go
+++ b/cmd/kubeadm/app/util/config/common.go
@@ -82,7 +82,7 @@ func validateSupportedVersion(gv schema.GroupVersion, allowDeprecated bool) erro
 
 // NormalizeKubernetesVersion resolves version labels, sets alternative
 // image registry if requested for CI builds, and validates minimal
-// version that kubeadm SetInitDynamicDefaultssupports.
+// version that kubeadm SetInitDynamicDefaults supports.
 func NormalizeKubernetesVersion(cfg *kubeadmapi.ClusterConfiguration) error {
 	// Requested version is automatic CI build, thus use KubernetesCI Image Repository for core images
 	if kubeadmutil.KubernetesIsCIVersion(cfg.KubernetesVersion) {


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
```
W0128 15:52:50.881721   13815 kubelet.go:213] cannot determine if systemd-resolved is active: no supported init system detected, skipping checking for services
W0128 15:52:57.773203   13815 version.go:118] could not obtain client version; using remote version: v1.20.2
```
https://github.com/kubernetes/kubernetes/blob/cea1d4e20b4a7886d8ff65f34c6d4f95efcb4742/cmd/kubeadm/app/util/version.go#L97
Time costs here is about 5-7s each.
The fetch URL has a hard-code timeout of 10s.

**Which issue(s) this PR fixes**:

part pf #98486
- /cmd/kubeadm/app/phases/certs

**Special notes for your reviewer**:
time make test WHAT=./cmd/kubeadm/app/phases/certs  GOFLAGS=-v KUBE_COVER=y KUBE_RACE=-race

Before: 113.901s, 109.867s  and 106.877s
After(test twice): 81.17s and 81.00s

**Does this PR introduce a user-facing change?**:

```release-note
None
```

