### PR TITLE
get system uuid via powershell

### DIFF
--- a/pkg/kubelet/winstats/perfcounter_nodestats.go
+++ b/pkg/kubelet/winstats/perfcounter_nodestats.go
@@ -217,15 +217,24 @@ func (p *perfCounterNodeStatsClient) getCPUUsageNanoCores() uint64 {
 }
 
 func getSystemUUID() (string, error) {
-	result, err := exec.Command("wmic", "csproduct", "get", "UUID").Output()
+	// Use PowerShell cmdlet "Get-CimInstance" instead of "wmic csproduct get
+	// uuid" for the following reasons:
+	// 1. The WMI command-line tool (Wmic) is deprecated. Use PowerShell cmdlets
+	// instead.
+	// https://docs.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2012-r2-and-2012/hh831568(v=ws.11)#wmi-providers
+	// 2. The PowerShell cmdlet "Get-CimObject" was removed from PowerShell 6
+	// and are no longer supported.
+	// https://github.com/MicrosoftDocs/PowerShell-Docs/issues/5156#issuecomment-558253083
+	command := "(Get-CimInstance -Class Win32_ComputerSystemProduct).UUID"
+	args := []string{"-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Restricted", "-Command", command}
+	result, err := exec.Command("powershell.exe", args...).CombinedOutput()
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("unable to get system uuid, reason: %q, detail: %q", err, result)
 	}
-	fields := strings.Fields(string(result))
-	if len(fields) != 2 {
-		return "", fmt.Errorf("received unexpected value retrieving vm uuid: %q", string(result))
-	}
-	return fields[1], nil
+
+	systemUUID := strings.TrimRight(string(result), "\r\n")
+
+	return systemUUID, nil
 }
 
 func getPhysicallyInstalledSystemMemoryBytes() (uint64, error) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:

The WMI command-line tool (WMIC) for getting system uuid is deprecated from Microsoft documentation:

[Features Removed or Deprecated in Windows Server 2012](https://docs.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2012-r2-and-2012/hh831568(v=ws.11)#wmi-providers)

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

Could refer this discussion for more detail: <https://stackoverflow.com/questions/57121875/what-can-i-do-about-wmic-is-deprecated>

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Update Kubelet to get system UUID via PowerShell for Windows Container Node since WMIC is deprecated.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
```
