### PR TITLE
ContainerGC cleanup duplicated running containers

### DIFF
--- a/pkg/kubelet/kuberuntime/kuberuntime_gc_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_gc_test.go
@@ -381,6 +381,17 @@ func TestContainerGC(t *testing.T) {
 			evictTerminatedPods: true,
 			allSourcesReady:     false,
 		},
+		{
+			description: "repeat running containers should be removed",
+			containers: []containerTemplate{
+				makeGCContainer(podStateProvider, "foo", "bar", 0, 0, runtimeapi.ContainerState_CONTAINER_RUNNING),
+				makeGCContainer(podStateProvider, "foo", "bar", 1, 1, runtimeapi.ContainerState_CONTAINER_RUNNING),
+				makeGCContainer(podStateProvider, "foo", "bar", 2, 2, runtimeapi.ContainerState_CONTAINER_RUNNING),
+			},
+			remain:              []int{2},
+			evictTerminatedPods: false,
+			allSourcesReady:     false,
+		},
 	} {
 		t.Logf("TestCase #%d: %+v", c, test)
 		fakeContainers := makeFakeContainers(t, m, test.containers)


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
kubelet’s ContainerGC should be able to cleanup duplicated running containers

**Which issue(s) this PR fixes**:
Fixes #98520

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
For any container defined in a single Pod, ContainerGC should keep the latest created and running instance when there are multiple found running
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
