### PR TITLE
Fix unified flag in --logging-format description

### DIFF
--- a/staging/src/k8s.io/component-base/logs/options.go
+++ b/staging/src/k8s.io/component-base/logs/options.go
@@ -117,7 +117,7 @@ func unsupportedLoggingFlags() []string {
 	klog.InitFlags(fs)
 	fs.VisitAll(func(flag *flag.Flag) {
 		if _, found := supportedLogsFlags[flag.Name]; !found {
-			allFlags = append(allFlags, flag.Name)
+			allFlags = append(allFlags, strings.Replace(flag.Name, "_", "-", -1))
 		}
 	})
 


### PR DESCRIPTION
Signed-off-by: chymy <chang.min1@zte.com.cn>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
In k8s components, the command line parameters are all combined with `-`, not `_`.
So in --logging-format description, 
```
--logging-format string
                Sets the log format. Permitted formats: "json", "text".
                Non-default formats don't honor these flags: --add_dir_header, --alsologtostderr, --log_backtrace_at, --log_dir,
                --log_file, --log_file_max_size, --logtostderr, --one_output, --skip_headers, --skip_log_headers, --stderrthreshold,
                --vmodule, --log-flush-frequency.
```
should be: 
```
--logging-format string
                Sets the log format. Permitted formats: "json", "text".
                Non-default formats don't honor these flags: --add-dir-header, --alsologtostderr, --log-backtrace-at, --log-dir,
                --log-file, --log-file-max-size, --logtostderr, --one-output, --skip-headers, --skip-log-headers, --stderrthreshold,
                --vmodule, --log-flush-frequency.
```

To be consistent with global flags：
```
Global flags:

      --add-dir-header
                If true, adds the file directory to the header of the log messages
      --alsologtostderr
                log to standard error as well as files
  -h, --help
                help for kube-scheduler
      --log-backtrace-at traceLocation
                when logging hits line file:N, emit a stack trace (default :0)
      --log-dir string
                If non-empty, write log files in this directory
      --log-file string
                If non-empty, use this log file
      --log-file-max-size uint
                Defines the maximum size a log file can grow to. Unit is megabytes. If the value is 0, the maximum file size is
                unlimited. (default 1800)
      --log-flush-frequency duration
                Maximum number of seconds between log flushes (default 5s)
      --logtostderr
                log to standard error instead of files (default true)
      --one-output
                If true, only write logs to their native severity level (vs also writing to each lower severity level
      --skip-headers
                If true, avoid header prefixes in the log messages
      --skip-log-headers
                If true, avoid headers when opening log files
```

 in order to prevent the reader from making mistakes by using underlined flags, it is better to replace _ with - in --logging-format description

e.g.:
```sh
# kube-controller-manager --add_dir_header
Error: unknown flag: --add_dir_header
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
