### PR TITLE
Scheduler: move GetAvoidPodsFromNodeAnnotations to component-helpers

### DIFF
--- a/pkg/apis/core/v1/helper/BUILD
+++ b/pkg/apis/core/v1/helper/BUILD
@@ -13,7 +13,6 @@ go_test(
     deps = [
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/resource:go_default_library",
-        "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/labels:go_default_library",
     ],
 )

--- a/pkg/apis/core/v1/helper/helpers.go
+++ b/pkg/apis/core/v1/helper/helpers.go
@@ -17,7 +17,6 @@ limitations under the License.
 package helper
 
 import (
-	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -387,19 +386,6 @@ func GetMatchingTolerations(taints []v1.Taint, tolerations []v1.Toleration) (boo
 		}
 	}
 	return true, result
-}
-
-// GetAvoidPodsFromNodeAnnotations scans the list of annotations and
-// returns the pods that needs to be avoided for this node from scheduling
-func GetAvoidPodsFromNodeAnnotations(annotations map[string]string) (v1.AvoidPods, error) {
-	var avoidPods v1.AvoidPods
-	if len(annotations) > 0 && annotations[v1.PreferAvoidPodsAnnotationKey] != "" {
-		err := json.Unmarshal([]byte(annotations[v1.PreferAvoidPodsAnnotationKey]), &avoidPods)
-		if err != nil {
-			return avoidPods, err
-		}
-	}
-	return avoidPods, nil
 }
 
 // GetPersistentVolumeClass returns StorageClassName.

--- a/pkg/apis/core/v1/helper/helpers_test.go
+++ b/pkg/apis/core/v1/helper/helpers_test.go
@@ -23,7 +23,6 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 )
 
@@ -426,102 +425,6 @@ func TestTolerationsTolerateTaintsWithFilter(t *testing.T) {
 				filteredTaints = append(filteredTaints, taint)
 			}
 			t.Errorf("[%s] expect tolerations %+v tolerate filtered taints %+v in taints %+v", tc.description, tc.tolerations, filteredTaints, tc.taints)
-		}
-	}
-}
-
-func TestGetAvoidPodsFromNode(t *testing.T) {
-	controllerFlag := true
-	testCases := []struct {
-		node        *v1.Node
-		expectValue v1.AvoidPods
-		expectErr   bool
-	}{
-		{
-			node:        &v1.Node{},
-			expectValue: v1.AvoidPods{},
-			expectErr:   false,
-		},
-		{
-			node: &v1.Node{
-				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{
-						v1.PreferAvoidPodsAnnotationKey: `
-							{
-							    "preferAvoidPods": [
-							        {
-							            "podSignature": {
-							                "podController": {
-						                            "apiVersion": "v1",
-						                            "kind": "ReplicationController",
-						                            "name": "foo",
-						                            "uid": "abcdef123456",
-						                            "controller": true
-							                }
-							            },
-							            "reason": "some reason",
-							            "message": "some message"
-							        }
-							    ]
-							}`,
-					},
-				},
-			},
-			expectValue: v1.AvoidPods{
-				PreferAvoidPods: []v1.PreferAvoidPodsEntry{
-					{
-						PodSignature: v1.PodSignature{
-							PodController: &metav1.OwnerReference{
-								APIVersion: "v1",
-								Kind:       "ReplicationController",
-								Name:       "foo",
-								UID:        "abcdef123456",
-								Controller: &controllerFlag,
-							},
-						},
-						Reason:  "some reason",
-						Message: "some message",
-					},
-				},
-			},
-			expectErr: false,
-		},
-		{
-			node: &v1.Node{
-				// Missing end symbol of "podController" and "podSignature"
-				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{
-						v1.PreferAvoidPodsAnnotationKey: `
-							{
-							    "preferAvoidPods": [
-							        {
-							            "podSignature": {
-							                "podController": {
-							                    "kind": "ReplicationController",
-							                    "apiVersion": "v1"
-							            "reason": "some reason",
-							            "message": "some message"
-							        }
-							    ]
-							}`,
-					},
-				},
-			},
-			expectValue: v1.AvoidPods{},
-			expectErr:   true,
-		},
-	}
-
-	for i, tc := range testCases {
-		v, err := GetAvoidPodsFromNodeAnnotations(tc.node.Annotations)
-		if err == nil && tc.expectErr {
-			t.Errorf("[%v]expected error but got none.", i)
-		}
-		if err != nil && !tc.expectErr {
-			t.Errorf("[%v]did not expect error but got: %v", i, err)
-		}
-		if !reflect.DeepEqual(tc.expectValue, v) {
-			t.Errorf("[%v]expect value %v but got %v with %v", i, tc.expectValue, v, v.PreferAvoidPods[0].PodSignature.PodController.Controller)
 		}
 	}
 }

--- a/pkg/apis/core/validation/BUILD
+++ b/pkg/apis/core/validation/BUILD
@@ -41,6 +41,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/util/validation:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/validation/field:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",
+        "//staging/src/k8s.io/component-helpers/scheduling/corev1:go_default_library",
         "//vendor/k8s.io/klog/v2:go_default_library",
         "//vendor/k8s.io/utils/net:go_default_library",
     ],

--- a/pkg/apis/core/validation/validation.go
+++ b/pkg/apis/core/validation/validation.go
@@ -45,6 +45,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	schedulinghelper "k8s.io/component-helpers/scheduling/corev1"
 	apiservice "k8s.io/kubernetes/pkg/api/service"
 	"k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/apis/core/helper"
@@ -3501,7 +3502,7 @@ func ValidateTopologySelectorTerm(term core.TopologySelectorTerm, fldPath *field
 func ValidateAvoidPodsInNodeAnnotations(annotations map[string]string, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
-	v1Avoids, err := v1helper.GetAvoidPodsFromNodeAnnotations(annotations)
+	v1Avoids, err := schedulinghelper.GetAvoidPodsFromNodeAnnotations(annotations)
 	if err != nil {
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("AvoidPods"), core.PreferAvoidPodsAnnotationKey, err.Error()))
 		return allErrs

--- a/pkg/scheduler/framework/plugins/nodepreferavoidpods/BUILD
+++ b/pkg/scheduler/framework/plugins/nodepreferavoidpods/BUILD
@@ -6,11 +6,11 @@ go_library(
     importpath = "k8s.io/kubernetes/pkg/scheduler/framework/plugins/nodepreferavoidpods",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/apis/core/v1/helper:go_default_library",
         "//pkg/scheduler/framework:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
+        "//staging/src/k8s.io/component-helpers/scheduling/corev1:go_default_library",
     ],
 )
 

--- a/pkg/scheduler/framework/plugins/nodepreferavoidpods/node_prefer_avoid_pods.go
+++ b/pkg/scheduler/framework/plugins/nodepreferavoidpods/node_prefer_avoid_pods.go
@@ -23,7 +23,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	v1helper "k8s.io/kubernetes/pkg/apis/core/v1/helper"
+	v1helper "k8s.io/component-helpers/scheduling/corev1"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
 )
 

--- a/staging/src/k8s.io/component-helpers/scheduling/corev1/helpers.go
+++ b/staging/src/k8s.io/component-helpers/scheduling/corev1/helpers.go
@@ -17,6 +17,8 @@ limitations under the License.
 package corev1
 
 import (
+	"encoding/json"
+
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/component-helpers/scheduling/corev1/nodeaffinity"
 )
@@ -42,4 +44,17 @@ func MatchNodeSelectorTerms(
 		return false, nil
 	}
 	return nodeaffinity.NewLazyErrorNodeSelector(nodeSelector).Match(node)
+}
+
+// GetAvoidPodsFromNodeAnnotations scans the list of annotations and
+// returns the pods that needs to be avoided for this node from scheduling
+func GetAvoidPodsFromNodeAnnotations(annotations map[string]string) (v1.AvoidPods, error) {
+	var avoidPods v1.AvoidPods
+	if len(annotations) > 0 && annotations[v1.PreferAvoidPodsAnnotationKey] != "" {
+		err := json.Unmarshal([]byte(annotations[v1.PreferAvoidPodsAnnotationKey]), &avoidPods)
+		if err != nil {
+			return avoidPods, err
+		}
+	}
+	return avoidPods, nil
 }

--- a/staging/src/k8s.io/component-helpers/scheduling/corev1/helpers_test.go
+++ b/staging/src/k8s.io/component-helpers/scheduling/corev1/helpers_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package corev1
 
 import (
+	"reflect"
 	"testing"
 
 	v1 "k8s.io/api/core/v1"
@@ -543,5 +544,101 @@ func TestMatchNodeSelectorTermsStateless(t *testing.T) {
 				t.Errorf("MatchNodeSelectorTerms() got = %v, want %v", tt.args.nodeSelector, tt.want)
 			}
 		})
+	}
+}
+
+func TestGetAvoidPodsFromNode(t *testing.T) {
+	controllerFlag := true
+	testCases := []struct {
+		node        *v1.Node
+		expectValue v1.AvoidPods
+		expectErr   bool
+	}{
+		{
+			node:        &v1.Node{},
+			expectValue: v1.AvoidPods{},
+			expectErr:   false,
+		},
+		{
+			node: &v1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						v1.PreferAvoidPodsAnnotationKey: `
+							{
+							    "preferAvoidPods": [
+							        {
+							            "podSignature": {
+							                "podController": {
+						                            "apiVersion": "v1",
+						                            "kind": "ReplicationController",
+						                            "name": "foo",
+						                            "uid": "abcdef123456",
+						                            "controller": true
+							                }
+							            },
+							            "reason": "some reason",
+							            "message": "some message"
+							        }
+							    ]
+							}`,
+					},
+				},
+			},
+			expectValue: v1.AvoidPods{
+				PreferAvoidPods: []v1.PreferAvoidPodsEntry{
+					{
+						PodSignature: v1.PodSignature{
+							PodController: &metav1.OwnerReference{
+								APIVersion: "v1",
+								Kind:       "ReplicationController",
+								Name:       "foo",
+								UID:        "abcdef123456",
+								Controller: &controllerFlag,
+							},
+						},
+						Reason:  "some reason",
+						Message: "some message",
+					},
+				},
+			},
+			expectErr: false,
+		},
+		{
+			node: &v1.Node{
+				// Missing end symbol of "podController" and "podSignature"
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						v1.PreferAvoidPodsAnnotationKey: `
+							{
+							    "preferAvoidPods": [
+							        {
+							            "podSignature": {
+							                "podController": {
+							                    "kind": "ReplicationController",
+							                    "apiVersion": "v1"
+							            "reason": "some reason",
+							            "message": "some message"
+							        }
+							    ]
+							}`,
+					},
+				},
+			},
+			expectValue: v1.AvoidPods{},
+			expectErr:   true,
+		},
+	}
+
+	for i, tc := range testCases {
+		v, err := GetAvoidPodsFromNodeAnnotations(tc.node.Annotations)
+		if err == nil && tc.expectErr {
+			t.Errorf("[%v]expected error but got none.", i)
+		}
+		if err != nil && !tc.expectErr {
+			t.Errorf("[%v]did not expect error but got: %v", i, err)
+		}
+		if !reflect.DeepEqual(tc.expectValue, v) {
+			t.Errorf("[%v]expect value %v but got %v with %v", i, tc.expectValue, v, v.PreferAvoidPods[0].PodSignature.PodController.Controller)
+		}
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup


**What this PR does / why we need it**:
As part of https://github.com/kubernetes/kubernetes/issues/89930 to decouple internal scheduler imports, this moves a function `GetAvoidPodsFromNodeAnnotations` to component-helpers from `pkg/apis/core/v1/helper`.

The only other place this is used is in validation, however its use is so generic (simply encoding an annotation's value to an external type) that moving it out of the API should be safe. In other words, its function provides no relevant API value.

**Which issue(s) this PR fixes**:
Ref https://github.com/kubernetes/kubernetes/issues/89930

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
/sig scheduling