### PR TITLE
Automated cherry pick of #94238: Set snapshotType for tests with NTFS.

### DIFF
--- a/test/e2e/storage/testpatterns/testpattern.go
+++ b/test/e2e/storage/testpatterns/testpattern.go
@@ -255,6 +255,7 @@ var (
 		FsType:                 "ntfs",
 		FeatureTag:             "[sig-windows]",
 		SnapshotDeletionPolicy: DeleteSnapshot,
+		SnapshotType:           DynamicCreatedSnapshot,
 	}
 
 	// Definitions for Filesystem volume mode

--- a/test/e2e/storage/testsuites/snapshottable.go
+++ b/test/e2e/storage/testsuites/snapshottable.go
@@ -407,6 +407,9 @@ func CreateSnapshotResource(sDriver SnapshottableTestDriver, config *PerTestConf
 		ginkgo.By("deleting the snapshot and snapshot content") // TODO: test what happens when I have two snapshot content that refer to the same content
 		ginkgo.By("creating a snapshot content with the snapshot handle")
 		ginkgo.By("creating a snapshot with that snapshot content")
+	default:
+		err = fmt.Errorf("SnapshotType must be set to either DynamicCreatedSnapshot or PreprovisionedCreatedSnapshot")
+		framework.ExpectNoError(err)
 	}
 	return &r
 }


### PR DESCRIPTION
Cherry pick of #94238 on release-1.19.

#94238: Set snapshotType for tests with NTFS.

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.