### PR TITLE
Automated cherry pick of #94238: Set snapshotType for tests with NTFS. #94242: Remove file_mode args for Windows test #95780: Enable Volume Expansion tests for Windows

### DIFF
--- a/test/e2e/storage/testpatterns/testpattern.go
+++ b/test/e2e/storage/testpatterns/testpattern.go
@@ -255,6 +255,7 @@ var (
 		FsType:                 "ntfs",
 		FeatureTag:             "[sig-windows]",
 		SnapshotDeletionPolicy: DeleteSnapshot,
+		SnapshotType:           DynamicCreatedSnapshot,
 	}
 
 	// Definitions for Filesystem volume mode

--- a/test/e2e/storage/testpatterns/testpattern.go
+++ b/test/e2e/storage/testpatterns/testpattern.go
@@ -329,6 +329,16 @@ var (
 		VolType:        DynamicPV,
 		AllowExpansion: true,
 	}
+
+	// NtfsDynamicPVAllowExpansion is TestPattern for "Dynamic PV (default fs)(allowExpansion)"
+	NtfsDynamicPVAllowExpansion = TestPattern{
+		Name:           "Dynamic PV (ntfs)(allowExpansion)",
+		VolType:        DynamicPV,
+		AllowExpansion: true,
+		FsType:         "ntfs",
+		FeatureTag:     "[sig-windows]",
+	}
+
 	// BlockVolModeDynamicPVAllowExpansion is TestPattern for "Dynamic PV (block volmode)(allowExpansion)"
 	BlockVolModeDynamicPVAllowExpansion = TestPattern{
 		Name:           "Dynamic PV (block volmode)(allowExpansion)",

--- a/test/e2e/storage/testsuites/snapshottable.go
+++ b/test/e2e/storage/testsuites/snapshottable.go
@@ -407,6 +407,9 @@ func CreateSnapshotResource(sDriver SnapshottableTestDriver, config *PerTestConf
 		ginkgo.By("deleting the snapshot and snapshot content") // TODO: test what happens when I have two snapshot content that refer to the same content
 		ginkgo.By("creating a snapshot content with the snapshot handle")
 		ginkgo.By("creating a snapshot with that snapshot content")
+	default:
+		err = fmt.Errorf("SnapshotType must be set to either DynamicCreatedSnapshot or PreprovisionedCreatedSnapshot")
+		framework.ExpectNoError(err)
 	}
 	return &r
 }

--- a/test/e2e/storage/testsuites/subpath.go
+++ b/test/e2e/storage/testsuites/subpath.go
@@ -686,8 +686,14 @@ func setWriteCommand(file string, container *v1.Container) {
 	container.Args = []string{
 		"mounttest",
 		fmt.Sprintf("--new_file_0644=%v", file),
-		fmt.Sprintf("--file_mode=%v", file),
 	}
+	// See issue https://github.com/kubernetes/kubernetes/issues/94237 about file_mode
+	// not working well on Windows
+	// TODO: remove this check after issue is resolved
+	if !framework.NodeOSDistroIs("windows") {
+		container.Args = append(container.Args, fmt.Sprintf("--file_mode=%v", file))
+	}
+
 }
 
 func addSubpathVolumeContainer(container *v1.Container, volumeMount v1.VolumeMount) {

--- a/test/e2e/storage/testsuites/volume_expand.go
+++ b/test/e2e/storage/testsuites/volume_expand.go
@@ -36,6 +36,7 @@ import (
 	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
 	e2evolume "k8s.io/kubernetes/test/e2e/framework/volume"
 	"k8s.io/kubernetes/test/e2e/storage/testpatterns"
+	imageutils "k8s.io/kubernetes/test/utils/image"
 )
 
 const (
@@ -62,6 +63,8 @@ func InitVolumeExpandTestSuite() TestSuite {
 				testpatterns.BlockVolModeDynamicPV,
 				testpatterns.DefaultFsDynamicPVAllowExpansion,
 				testpatterns.BlockVolModeDynamicPVAllowExpansion,
+				testpatterns.NtfsDynamicPV,
+				testpatterns.NtfsDynamicPVAllowExpansion,
 			},
 			SupportedSizeRange: e2evolume.SizeRange{
 				Min: "1Mi",
@@ -170,6 +173,7 @@ func (v *volumeExpandTestSuite) DefineTests(driver TestDriver, pattern testpatte
 				PVCs:          []*v1.PersistentVolumeClaim{l.resource.Pvc},
 				SeLinuxLabel:  e2epv.SELinuxLabel,
 				NodeSelection: l.config.ClientNodeSelection,
+				ImageID:       getTestImage(),
 			}
 			l.pod, err = e2epod.CreateSecPodWithNodeSelection(f.ClientSet, &podConfig, framework.PodStartTimeout)
 			defer func() {
@@ -213,6 +217,7 @@ func (v *volumeExpandTestSuite) DefineTests(driver TestDriver, pattern testpatte
 				PVCs:          []*v1.PersistentVolumeClaim{l.resource.Pvc},
 				SeLinuxLabel:  e2epv.SELinuxLabel,
 				NodeSelection: l.config.ClientNodeSelection,
+				ImageID:       getTestImage(),
 			}
 			l.pod2, err = e2epod.CreateSecPodWithNodeSelection(f.ClientSet, &podConfig, framework.PodStartTimeout)
 			defer func() {
@@ -240,6 +245,7 @@ func (v *volumeExpandTestSuite) DefineTests(driver TestDriver, pattern testpatte
 				PVCs:          []*v1.PersistentVolumeClaim{l.resource.Pvc},
 				SeLinuxLabel:  e2epv.SELinuxLabel,
 				NodeSelection: l.config.ClientNodeSelection,
+				ImageID:       getTestImage(),
 			}
 			l.pod, err = e2epod.CreateSecPodWithNodeSelection(f.ClientSet, &podConfig, framework.PodStartTimeout)
 			defer func() {
@@ -413,4 +419,13 @@ func WaitForFSResize(pvc *v1.PersistentVolumeClaim, c clientset.Interface) (*v1.
 		return nil, fmt.Errorf("error waiting for pvc %q filesystem resize to finish: %v", pvc.Name, waitErr)
 	}
 	return updatedPVC, nil
+}
+
+// TODO: after issue https://github.com/kubernetes/kubernetes/issues/81245 is resolved
+// this utility can be moved to e2epod
+func getTestImage() int {
+	if framework.NodeOSDistroIs("windows") {
+		return imageutils.Agnhost
+	}
+	return imageutils.BusyBox
 }


### PR DESCRIPTION
Cherry pick of #94238 #94242 #95780 on release-1.19.

#94238: Set snapshotType for tests with NTFS.
#94242: Remove file_mode args for Windows test
#95780: Enable Volume Expansion tests for Windows

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.