### PR TITLE
deprecating in-tree vsphere volume diskformat parameters, vsphere less than 67u3, vm hardware less than 15 and multi vCenter support

### DIFF
--- a/pkg/volume/vsphere_volume/vsphere_volume_util.go
+++ b/pkg/volume/vsphere_volume/vsphere_volume_util.go
@@ -40,15 +40,22 @@ const (
 	checkSleepDuration = time.Second
 	diskByIDPath       = "/dev/disk/by-id/"
 	diskSCSIPrefix     = "wwn-0x"
-	diskformat         = "diskformat"
-	datastore          = "datastore"
-	StoragePolicyName  = "storagepolicyname"
+	// diskformat parameter is deprecated as of Kubernetes v1.21.0
+	diskformat        = "diskformat"
+	datastore         = "datastore"
+	StoragePolicyName = "storagepolicyname"
 
-	HostFailuresToTolerateCapability    = "hostfailurestotolerate"
-	ForceProvisioningCapability         = "forceprovisioning"
-	CacheReservationCapability          = "cachereservation"
-	DiskStripesCapability               = "diskstripes"
-	ObjectSpaceReservationCapability    = "objectspacereservation"
+	// hostfailurestotolerate parameter is deprecated as of Kubernetes v1.19.0
+	HostFailuresToTolerateCapability = "hostfailurestotolerate"
+	// forceprovisioning parameter is deprecated as of Kubernetes v1.19.0
+	ForceProvisioningCapability = "forceprovisioning"
+	// cachereservation parameter is deprecated as of Kubernetes v1.19.0
+	CacheReservationCapability = "cachereservation"
+	// diskstripes parameter is deprecated as of Kubernetes v1.19.0
+	DiskStripesCapability = "diskstripes"
+	// objectspacereservation parameter is deprecated as of Kubernetes v1.19.0
+	ObjectSpaceReservationCapability = "objectspacereservation"
+	// iopslimit parameter is deprecated as of Kubernetes v1.19.0
 	IopsLimitCapability                 = "iopslimit"
 	HostFailuresToTolerateCapabilityMin = 0
 	HostFailuresToTolerateCapabilityMax = 3

--- a/staging/src/k8s.io/legacy-cloud-providers/go.mod
+++ b/staging/src/k8s.io/legacy-cloud-providers/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/Azure/go-autorest/autorest/validation v0.1.0 // indirect
 	github.com/GoogleCloudPlatform/k8s-cloud-provider v0.0.0-20200415212048-7901bc822317
 	github.com/aws/aws-sdk-go v1.35.24
+	github.com/blang/semver v3.5.1+incompatible
 	github.com/dnaeon/go-vcr v1.0.1 // indirect
 	github.com/golang/mock v1.4.4
 	github.com/google/go-cmp v0.5.2

--- a/staging/src/k8s.io/legacy-cloud-providers/vsphere/nodemanager.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/vsphere/nodemanager.go
@@ -25,10 +25,12 @@ import (
 	"sync"
 
 	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/mo"
+	"k8s.io/klog/v2"
+
 	v1 "k8s.io/api/core/v1"
 	k8stypes "k8s.io/apimachinery/pkg/types"
 	cloudprovider "k8s.io/cloud-provider"
-	"k8s.io/klog/v2"
 	"k8s.io/legacy-cloud-providers/vsphere/vclib"
 )
 
@@ -201,7 +203,21 @@ func (nm *NodeManager) DiscoverNode(node *v1.Node) error {
 				if vm != nil {
 					klog.V(4).Infof("Found node %s as vm=%+v in vc=%s and datacenter=%s",
 						node.Name, vm, res.vc, res.datacenter.Name())
-
+					var vmObj mo.VirtualMachine
+					err := vm.Properties(ctx, vm.Reference(), []string{"config"}, &vmObj)
+					if err != nil || vmObj.Config == nil {
+						klog.Errorf("failed to retrieve guest vmconfig for node: %s Err: %v", node.Name, err)
+					} else {
+						klog.V(4).Infof("vm hardware version for node:%s is %s", node.Name, vmObj.Config.Version)
+						// vmconfig.Version returns vm hardware version as vmx-11, vmx-13, vmx-14, vmx-15 etc.
+						vmhardwaredeprecated, err := isGuestHardwareVersionDeprecated(vmObj.Config.Version)
+						if err != nil {
+							klog.Errorf("failed to check if vm hardware version is deprecated. VM Hardware Version: %s Err: %v", vmObj.Config.Version, err)
+						}
+						if vmhardwaredeprecated {
+							klog.Warningf("VM Hardware version: %s from node: %s is deprecated. Please consider upgrading virtual machine hardware version to vmx-15 or higher", vmObj.Config.Version, node.Name)
+						}
+					}
 					// Get the node zone information
 					nodeFd := node.ObjectMeta.Labels[v1.LabelFailureDomainBetaZone]
 					nodeRegion := node.ObjectMeta.Labels[v1.LabelFailureDomainBetaRegion]

--- a/staging/src/k8s.io/legacy-cloud-providers/vsphere/vclib/BUILD
+++ b/staging/src/k8s.io/legacy-cloud-providers/vsphere/vclib/BUILD
@@ -29,6 +29,7 @@ go_library(
         "//staging/src/k8s.io/client-go/pkg/version:go_default_library",
         "//staging/src/k8s.io/component-base/metrics:go_default_library",
         "//staging/src/k8s.io/component-base/metrics/legacyregistry:go_default_library",
+        "//vendor/github.com/blang/semver:go_default_library",
         "//vendor/github.com/vmware/govmomi/find:go_default_library",
         "//vendor/github.com/vmware/govmomi/object:go_default_library",
         "//vendor/github.com/vmware/govmomi/pbm:go_default_library",

--- a/staging/src/k8s.io/legacy-cloud-providers/vsphere/vclib/connection.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/vsphere/vclib/connection.go
@@ -29,8 +29,9 @@ import (
 	"github.com/vmware/govmomi/sts"
 	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/soap"
-	"k8s.io/client-go/pkg/version"
 	"k8s.io/klog/v2"
+
+	"k8s.io/client-go/pkg/version"
 )
 
 // VSphereConnection contains information for connecting to vCenter
@@ -84,7 +85,6 @@ func (connection *VSphereConnection) Connect(ctx context.Context) error {
 		klog.Errorf("Failed to create govmomi client. err: %+v", err)
 		return err
 	}
-	setVCenterInfoMetric(connection)
 	return nil
 }
 
@@ -217,6 +217,13 @@ func (connection *VSphereConnection) NewClient(ctx context.Context) (*vim25.Clie
 		connection.RoundTripperCount = RoundTripperDefaultCount
 	}
 	client.RoundTripper = vim25.Retry(client.RoundTripper, vim25.TemporaryNetworkError(int(connection.RoundTripperCount)))
+	vcdeprecated, err := isvCenterDeprecated(client.ServiceContent.About.Version, client.ServiceContent.About.ApiVersion)
+	if err != nil {
+		klog.Errorf("failed to check if vCenter version:%v and api version: %s is deprecated. Error: %v", client.ServiceContent.About.Version, client.ServiceContent.About.ApiVersion, err)
+	}
+	if vcdeprecated {
+		klog.Warningf("vCenter is deprecated. version: %s, api verson: %s Please consider upgrading vCenter and ESXi servers to 6.7u3 or higher", client.ServiceContent.About.Version, client.ServiceContent.About.ApiVersion)
+	}
 	return client, nil
 }
 

--- a/staging/src/k8s.io/legacy-cloud-providers/vsphere/vclib/constants.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/vsphere/vclib/constants.go
@@ -53,6 +53,7 @@ const (
 	ClusterComputeResourceType = "ClusterComputeResource"
 	HostSystemType             = "HostSystem"
 	NameProperty               = "name"
+	MinvCenterVersion          = "6.7.0"
 )
 
 // Test Constants

--- a/staging/src/k8s.io/legacy-cloud-providers/vsphere/vclib/utils.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/vsphere/vclib/utils.go
@@ -22,6 +22,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/blang/semver"
 	"github.com/vmware/govmomi/find"
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/vim25/soap"
@@ -198,4 +199,35 @@ func VerifyVolumePathsForVMDevices(vmDevices object.VirtualDeviceList, volPaths 
 		}
 	}
 
+}
+
+// isvCenterDeprecated takes vCenter version and vCenter API version as input and return true if vCenter is deprecated
+func isvCenterDeprecated(vCenterVersion string, vCenerAPIVersion string) (bool, error) {
+	minvcversion, err := semver.New(MinvCenterVersion)
+	vcdeprecated := false
+	if err != nil {
+		return false, fmt.Errorf("failed to get parse vCenter version: %s. err: %+v", MinvCenterVersion, err)
+	} else {
+		vcversion, err := semver.New(vCenterVersion)
+		if err != nil {
+			return false, fmt.Errorf("failed to parse vCenter version: %s. err: %+v", vCenterVersion, err)
+		} else {
+			result := vcversion.Compare(*minvcversion)
+			if result == -1 {
+				// vcversion is less than minvcversion
+				vcdeprecated = true
+			} else if result == 0 {
+				// vcversion is equal to minvcversion
+				// check patch version
+				vcapiversion, err := semver.ParseTolerant(vCenerAPIVersion)
+				if err != nil {
+					return false, fmt.Errorf("failed to parse vCenter api version: %s. err: %+v", vCenerAPIVersion, err)
+				}
+				if vcapiversion.Patch < 3 {
+					vcdeprecated = true
+				}
+			}
+		}
+	}
+	return vcdeprecated, nil
 }

--- a/staging/src/k8s.io/legacy-cloud-providers/vsphere/vclib/utils_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/vsphere/vclib/utils_test.go
@@ -69,3 +69,73 @@ func TestUtils(t *testing.T) {
 		t.Errorf("unexpected error: %s", err)
 	}
 }
+
+func TestIsvCenter70update1Deprecated(t *testing.T) {
+	vcdeprecated, err := isvCenterDeprecated("7.0.1", "7.0.1.1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if vcdeprecated {
+		t.Fatal("vSphere 7.0 update1 should not be deprecated")
+	}
+}
+
+func TestIsvCenter70Deprecated(t *testing.T) {
+	vcdeprecated, err := isvCenterDeprecated("7.0.0", "7.0.0.0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if vcdeprecated {
+		t.Fatal("vSphere 7.0 should not be deprecated")
+	}
+}
+
+func TestIsvCenter67u3Deprecated(t *testing.T) {
+	vcdeprecated, err := isvCenterDeprecated("6.7.0", "6.7.3")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if vcdeprecated {
+		t.Fatal("vSphere 67u3 should not be deprecated")
+	}
+}
+
+func TestIsvCenter67Deprecated(t *testing.T) {
+	vcdeprecated, err := isvCenterDeprecated("6.7.0", "6.7")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !vcdeprecated {
+		t.Fatal("vSphere 6.7 should be deprecated")
+	}
+}
+
+func TestIsvCenter67u2Deprecated(t *testing.T) {
+	vcdeprecated, err := isvCenterDeprecated("6.7.0", "6.7.2")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !vcdeprecated {
+		t.Fatal("vSphere 6.7 update 2 should be deprecated")
+	}
+}
+
+func TestIsvCenter67u1Deprecated(t *testing.T) {
+	vcdeprecated, err := isvCenterDeprecated("6.7.0", "6.7.1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !vcdeprecated {
+		t.Fatal("vSphere 6.7 update 1 should be deprecated")
+	}
+}
+
+func TestIsvCenter65Deprecated(t *testing.T) {
+	vcdeprecated, err := isvCenterDeprecated("6.5.0", "6.5")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !vcdeprecated {
+		t.Fatal("vSphere 6.5 should be deprecated")
+	}
+}

--- a/staging/src/k8s.io/legacy-cloud-providers/vsphere/vsphere.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/vsphere/vsphere.go
@@ -411,6 +411,9 @@ func populateVsphereInstanceMap(cfg *VSphereConfig) (map[string]*VSphereInstance
 			klog.Error(msg)
 			return nil, errors.New(msg)
 		}
+		if len(cfg.VirtualCenter) > 1 {
+			klog.Warning("Multi vCenter support is deprecated. vSphere CSI Driver does not support Kubernetes nodes spread across multiple vCenter servers. Please consider moving all Kubernetes nodes to single vCenter server")
+		}
 
 		for vcServer, vcConfig := range cfg.VirtualCenter {
 			klog.V(4).Infof("Initializing vc server %s", vcServer)

--- a/staging/src/k8s.io/legacy-cloud-providers/vsphere/vsphere_util.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/vsphere/vsphere_util.go
@@ -25,6 +25,7 @@ import (
 	"math/rand"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -766,6 +767,21 @@ func IsUUIDSupportedNode(node *v1.Node) (bool, error) {
 		return true, nil
 	}
 	return false, nil
+}
+
+func isGuestHardwareVersionDeprecated(vmHardwareversion string) (bool, error) {
+	vmHardwareDeprecated := false
+	// vmconfig.Version returns vm hardware version as vmx-11, vmx-13, vmx-14, vmx-15 etc.
+	version := strings.Trim(vmHardwareversion, "vmx-")
+	value, err := strconv.ParseInt(version, 0, 64)
+	if err != nil {
+		return false, fmt.Errorf("failed to parse vm hardware version: %v Err: %v", version, err)
+	} else {
+		if value < 15 {
+			vmHardwareDeprecated = true
+		}
+	}
+	return vmHardwareDeprecated, nil
 }
 
 func GetNodeUUID(node *v1.Node) (string, error) {

--- a/staging/src/k8s.io/legacy-cloud-providers/vsphere/vsphere_util_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/vsphere/vsphere_util_test.go
@@ -72,3 +72,63 @@ func TestGetPathFromFileNotFound(t *testing.T) {
 		t.Errorf("expected err when calling getPathFromFileNotFound with nil err")
 	}
 }
+
+func TestVMX15Deprecated(t *testing.T) {
+	vmhardwaredeprecated, err := isGuestHardwareVersionDeprecated("vmx-15")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if vmhardwaredeprecated {
+		t.Fatal("vmx-15 should not be deprecated")
+	}
+}
+
+func TestVMX14Deprecated(t *testing.T) {
+	vmhardwaredeprecated, err := isGuestHardwareVersionDeprecated("vmx-14")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !vmhardwaredeprecated {
+		t.Fatal("vmx-14 should be deprecated")
+	}
+}
+
+func TestVMX13Deprecated(t *testing.T) {
+	vmhardwaredeprecated, err := isGuestHardwareVersionDeprecated("vmx-13")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !vmhardwaredeprecated {
+		t.Fatal("vmx-13 should be deprecated")
+	}
+}
+
+func TestVMX11Deprecated(t *testing.T) {
+	vmhardwaredeprecated, err := isGuestHardwareVersionDeprecated("vmx-11")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !vmhardwaredeprecated {
+		t.Fatal("vmx-11 should be deprecated")
+	}
+}
+
+func TestVMX17Deprecated(t *testing.T) {
+	vmhardwaredeprecated, err := isGuestHardwareVersionDeprecated("vmx-17")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if vmhardwaredeprecated {
+		t.Fatal("vmx-17 should not be deprecated")
+	}
+}
+
+func TestVMX18Deprecated(t *testing.T) {
+	vmhardwaredeprecated, err := isGuestHardwareVersionDeprecated("vmx-18")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if vmhardwaredeprecated {
+		t.Fatal("vmx-18 should not be deprecated")
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind feature
/kind deprecation


**What this PR does / why we need it**:
This PR is deprecating followings for in-tree vSphere cloud provider and in-tree vSphere volume plugin

- diskformat parameters, 
- vsphere releases less than 67u3
- vm hardware versions less than 15 and 
- multi vCenter support


PR checks vCenter API version vSphere Cloud Provider is interacting with. If the vCenter version is less than 67u3, a deprecation warning message is printed.

> klog.Warningf("vSphere version: %s is deprecated. Please consider upgrading vSphere to 6.7u3.", client.ServiceContent.About.ApiVersion)

Note: code block for vCenter version check is validated for vSphere releases mentioned in this gist - https://gist.github.com/divyenpatel/b537c949c1078e2005d42e0e2c07f38d using https://play.golang.org/p/6IR0KMPOrjk

PR checks Node VM's guest hardware version during node discovery, and it finds hardware version is less than 15, a deprecation warning message is printed.

> klog.Warningf("node vm hardware version:%s is deprecated. please consider upgrading virtual machine hardware version to vmx-15 or higher", vmconfig.Version)

PR checks if vSphere Cloud Provider is configured to work with multiple vCenter servers when kubernetes nodes in the cluster are spread across multiple vCenter servers, and prints a deprecation warning message for multi vCenter support.

> klog.Warningf("Multi vCenter support is deprecated. vSphere CSI Driver does not support kubernertes nodes spread across multiple vCenter servers. Please consider moving all k8s nodes to single vCenter server")


**Special notes for your reviewer**:
vSphere CSI driver can not support provisioning of thick/zerored thick volume using in-tree vSphere storageclass parameter `diskformat` after the migration is turned on.

Existing thick/zeroed thick volumes created using the in-tree vSphere volume plugin, can be migrated to CSI, but new thick/zeroed thick volumes can not be created by the vSphere CSI driver.

We have already deprecated raw vsan policy parameters `hostfailurestotolerate`, `forceprovisioning`, `cachereservation`, `diskstripes`, `objectspacereservation`, `iopslimit` as of Kubernetes 1.19 - https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.19.md#deprecation

vSphere CSI driver does not support Kubernetes nodes spread across multiple vCenter servers.


**Does this PR introduce a user-facing change?**:

```release-note
ACTION REQUIRED: `diskformat` stroage class parameter for in-tree vSphere volume plugin is deprecated as of v1.21 release. Please consider updating storageclass and remove `diskformat` parameter. vSphere CSI Driver does not support diskformat storageclass parameter.

vSphere releases less than 67u3 are deprecated as of v1.21. Please consider upgrading vSphere to 67u3 or above. vSphere CSI Driver requires minimum vSphere 67u3.

VM Hardware version less than 15 is deprecated as of v1.21. Please consider upgrading the Node VM Hardware version to 15 or above. vSphere CSI Driver recommends Node VM's Hardware version set to at least vmx-15.

Multi vCenter support is deprecated as of v1.21. If you have a Kubernetes cluster spanning across multiple vCenter servers, please consider moving all k8s nodes to a single vCenter Server. vSphere CSI Driver does not support Kubernetes deployment spanning across multiple vCenter servers.

Support for these deprecations will be available till Kubernetes v1.24.
```

cc: @xing-yang @SandeepPissay @chethanv28 