### PR TITLE
kubeadm: update OWNERS for 1.21

### DIFF
--- a/cmd/kubeadm/OWNERS
+++ b/cmd/kubeadm/OWNERS
@@ -1,26 +1,17 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-- luxas
-- timothysc
 - fabriziopandini
 - neolit123
-- rosti
-- ereslibre
-reviewers:
-- luxas
-- timothysc
-- fabriziopandini
-- neolit123
-- kad
-- detiber
-- dixudx
-- rosti
-- yagonobre
-- ereslibre
 - SataQiu
-- yastij
-# Might want to add @xiangpengzhao, @stealthybox, @liztio and @chuckha back in the future
+reviewers:
+- yagonobre
+- pacoxu
+emeritus_approvers:
+- luxas
+- timothysc
+- rosti
+- ereslibre
 labels:
 - area/kubeadm
 - sig/cluster-lifecycle

--- a/test/e2e_kubeadm/OWNERS
+++ b/test/e2e_kubeadm/OWNERS
@@ -1,26 +1,17 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-- luxas
-- timothysc
 - fabriziopandini
 - neolit123
-- rosti
-- ereslibre
-reviewers:
-- luxas
-- timothysc
-- fabriziopandini
-- neolit123
-- kad
-- detiber
-- dixudx
-- rosti
-- yagonobre
-- ereslibre
 - SataQiu
-- yastij
-
+reviewers:
+- yagonobre
+- pacoxu
+emeritus_approvers:
+- luxas
+- timothysc
+- rosti
+- ereslibre
 labels:
 - area/kubeadm
 - sig/cluster-lifecycle


### PR DESCRIPTION
**What this PR does / why we need it**:

as part of the annual SIG reports we should keep OWNERS files up-to-date:
https://groups.google.com/g/kubernetes-sig-cluster-lifecycle/c/KH8g4WRjOAE

notes:
- if you object to the bellow amends to these OWNERs files just state so, or give your +1 / -1.
- applying a lazy consensus deadline mid next week / ~4th of Feb.
- the file under /test/ is just a copy of the one from /cmd/kubeadm
- duplicating approvers under reviewers is not needed.

removals:
- @luxas: Lucas is an emeritus SIG chair and is currently in university. we can re-add him once / if he comes back to kubeadm.
- @timothysc: Tim is a SIG chair, but has been busy with downstream work and is mostly active in the main SIG process.
- @rosti: has stated that he will no longer work on kubeadm, due to downstream commitments in other areas.
- @ereslibre: has stopped contributing, likely to downstream commitments or other reasons.
- @detiber, @dixudx, @yastij, @kad are mostly inactive in reviews, so we'd like to give the bot pings to the active team.

thank you all for your contributions and hope to see you again!

additions / promotions:
- @SataQiu: has been with kubeadm for a number of releases, being active in both review and fixing critical problems. suggesting a promotion to approver.
- @pacoxu: has been quite active in a lot of kubeadm PRs / issues recently. suggesting a promotion to reviewer.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
xref https://groups.google.com/g/kubernetes-sig-cluster-lifecycle/c/KH8g4WRjOAE

**Special notes for your reviewer**:
NONE

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
