### PR TITLE
Graduate ServiceAccountIssuerDiscovery to GA

### DIFF
--- a/cmd/kube-apiserver/app/BUILD
+++ b/cmd/kube-apiserver/app/BUILD
@@ -17,7 +17,6 @@ go_library(
         "//pkg/controlplane/controller/crdregistration:go_default_library",
         "//pkg/controlplane/reconcilers:go_default_library",
         "//pkg/controlplane/tunneler:go_default_library",
-        "//pkg/features:go_default_library",
         "//pkg/generated/openapi:go_default_library",
         "//pkg/kubeapiserver:go_default_library",
         "//pkg/kubeapiserver/admission:go_default_library",

--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -73,7 +73,6 @@ import (
 	"k8s.io/kubernetes/pkg/controlplane"
 	"k8s.io/kubernetes/pkg/controlplane/reconcilers"
 	"k8s.io/kubernetes/pkg/controlplane/tunneler"
-	"k8s.io/kubernetes/pkg/features"
 	generatedopenapi "k8s.io/kubernetes/pkg/generated/openapi"
 	"k8s.io/kubernetes/pkg/kubeapiserver"
 	kubeapiserveradmission "k8s.io/kubernetes/pkg/kubeapiserver/admission"
@@ -422,21 +421,19 @@ func CreateKubeAPIServerConfig(
 		config.ExtraConfig.ProxyTransport = c
 	}
 
-	if utilfeature.DefaultFeatureGate.Enabled(features.ServiceAccountIssuerDiscovery) {
-		// Load the public keys.
-		var pubKeys []interface{}
-		for _, f := range s.Authentication.ServiceAccounts.KeyFiles {
-			keys, err := keyutil.PublicKeysFromFile(f)
-			if err != nil {
-				return nil, nil, nil, fmt.Errorf("failed to parse key file %q: %v", f, err)
-			}
-			pubKeys = append(pubKeys, keys...)
+	// Load the public keys.
+	var pubKeys []interface{}
+	for _, f := range s.Authentication.ServiceAccounts.KeyFiles {
+		keys, err := keyutil.PublicKeysFromFile(f)
+		if err != nil {
+			return nil, nil, nil, fmt.Errorf("failed to parse key file %q: %v", f, err)
 		}
-		// Plumb the required metadata through ExtraConfig.
-		config.ExtraConfig.ServiceAccountIssuerURL = s.Authentication.ServiceAccounts.Issuer
-		config.ExtraConfig.ServiceAccountJWKSURI = s.Authentication.ServiceAccounts.JWKSURI
-		config.ExtraConfig.ServiceAccountPublicKeys = pubKeys
+		pubKeys = append(pubKeys, keys...)
 	}
+	// Plumb the required metadata through ExtraConfig.
+	config.ExtraConfig.ServiceAccountIssuerURL = s.Authentication.ServiceAccounts.Issuer
+	config.ExtraConfig.ServiceAccountJWKSURI = s.Authentication.ServiceAccounts.JWKSURI
+	config.ExtraConfig.ServiceAccountPublicKeys = pubKeys
 
 	return config, serviceResolver, pluginInitializers, nil
 }

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -194,6 +194,7 @@ const (
 	// owner: @mtaufen
 	// alpha: v1.18
 	// beta: v1.20
+	// stable: v1.21
 	//
 	// Enable OIDC discovery endpoints (issuer and JWKS URLs) for the service
 	// account issuer in the API server.
@@ -699,7 +700,7 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 	SupportPodPidsLimit:                            {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.23
 	SupportNodePidsLimit:                           {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.23
 	BoundServiceAccountTokenVolume:                 {Default: false, PreRelease: featuregate.Alpha},
-	ServiceAccountIssuerDiscovery:                  {Default: true, PreRelease: featuregate.Beta},
+	ServiceAccountIssuerDiscovery:                  {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.22
 	CRIContainerLogRotation:                        {Default: true, PreRelease: featuregate.Beta},
 	CSIMigration:                                   {Default: true, PreRelease: featuregate.Beta},
 	CSIMigrationGCE:                                {Default: false, PreRelease: featuregate.Beta}, // Off by default (requires GCE PD CSI Driver)

--- a/pkg/kubeapiserver/options/authentication.go
+++ b/pkg/kubeapiserver/options/authentication.go
@@ -213,18 +213,14 @@ func (o *BuiltInAuthenticationOptions) Validate() []error {
 			allErrors = append(allErrors, errors.New("service-account-key-file is a required flag"))
 		}
 
-		if utilfeature.DefaultFeatureGate.Enabled(features.ServiceAccountIssuerDiscovery) {
-			// Validate the JWKS URI when it is explicitly set.
-			// When unset, it is later derived from ExternalHost.
-			if o.ServiceAccounts.JWKSURI != "" {
-				if u, err := url.Parse(o.ServiceAccounts.JWKSURI); err != nil {
-					allErrors = append(allErrors, fmt.Errorf("service-account-jwks-uri must be a valid URL: %v", err))
-				} else if u.Scheme != "https" {
-					allErrors = append(allErrors, fmt.Errorf("service-account-jwks-uri requires https scheme, parsed as: %v", u.String()))
-				}
+		// Validate the JWKS URI when it is explicitly set.
+		// When unset, it is later derived from ExternalHost.
+		if o.ServiceAccounts.JWKSURI != "" {
+			if u, err := url.Parse(o.ServiceAccounts.JWKSURI); err != nil {
+				allErrors = append(allErrors, fmt.Errorf("service-account-jwks-uri must be a valid URL: %v", err))
+			} else if u.Scheme != "https" {
+				allErrors = append(allErrors, fmt.Errorf("service-account-jwks-uri requires https scheme, parsed as: %v", u.String()))
 			}
-		} else if len(o.ServiceAccounts.JWKSURI) > 0 {
-			allErrors = append(allErrors, fmt.Errorf("service-account-jwks-uri may only be set when the ServiceAccountIssuerDiscovery feature gate is enabled"))
 		}
 	}
 

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
@@ -494,18 +494,16 @@ func ClusterRoles() []rbacv1.ClusterRole {
 		},
 	}
 
-	if utilfeature.DefaultFeatureGate.Enabled(features.ServiceAccountIssuerDiscovery) {
-		// Add the cluster role for reading the ServiceAccountIssuerDiscovery endpoints
-		roles = append(roles, rbacv1.ClusterRole{
-			ObjectMeta: metav1.ObjectMeta{Name: "system:service-account-issuer-discovery"},
-			Rules: []rbacv1.PolicyRule{
-				rbacv1helpers.NewRule("get").URLs(
-					"/.well-known/openid-configuration",
-					"/openid/v1/jwks",
-				).RuleOrDie(),
-			},
-		})
-	}
+	// Add the cluster role for reading the ServiceAccountIssuerDiscovery endpoints
+	roles = append(roles, rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{Name: "system:service-account-issuer-discovery"},
+		Rules: []rbacv1.PolicyRule{
+			rbacv1helpers.NewRule("get").URLs(
+				"/.well-known/openid-configuration",
+				"/openid/v1/jwks",
+			).RuleOrDie(),
+		},
+	})
 
 	// node-proxier role is used by kube-proxy.
 	nodeProxierRules := []rbacv1.PolicyRule{
@@ -590,19 +588,17 @@ func ClusterRoleBindings() []rbacv1.ClusterRoleBinding {
 		},
 	}
 
-	if utilfeature.DefaultFeatureGate.Enabled(features.ServiceAccountIssuerDiscovery) {
-		// Allow all in-cluster workloads (via their service accounts) to read the OIDC discovery endpoints.
-		// Users with certain forms of write access (create pods, create secrets, create service accounts, etc)
-		// can gain access to a service account identity which would allow them to access this information.
-		// This includes the issuer URL, which is already present in the SA token JWT.  Similarly, SAs can
-		// already gain this same info via introspection of their own token.  Since this discovery endpoint
-		// points to what issued all service account tokens, it seems fitting for SAs to have this access.
-		// Defer to the cluster admin with regard to binding directly to all authenticated and/or
-		// unauthenticated users.
-		rolebindings = append(rolebindings,
-			rbacv1helpers.NewClusterBinding("system:service-account-issuer-discovery").Groups(serviceaccount.AllServiceAccountsGroup).BindingOrDie(),
-		)
-	}
+	// Allow all in-cluster workloads (via their service accounts) to read the OIDC discovery endpoints.
+	// Users with certain forms of write access (create pods, create secrets, create service accounts, etc)
+	// can gain access to a service account identity which would allow them to access this information.
+	// This includes the issuer URL, which is already present in the SA token JWT.  Similarly, SAs can
+	// already gain this same info via introspection of their own token.  Since this discovery endpoint
+	// points to what issued all service account tokens, it seems fitting for SAs to have this access.
+	// Defer to the cluster admin with regard to binding directly to all authenticated and/or
+	// unauthenticated users.
+	rolebindings = append(rolebindings,
+		rbacv1helpers.NewClusterBinding("system:service-account-issuer-discovery").Groups(serviceaccount.AllServiceAccountsGroup).BindingOrDie(),
+	)
 
 	addClusterRoleBindingLabel(rolebindings)
 

--- a/test/integration/auth/svcaccttoken_test.go
+++ b/test/integration/auth/svcaccttoken_test.go
@@ -43,16 +43,13 @@ import (
 	"k8s.io/apiserver/pkg/authentication/request/bearertoken"
 	apiserverserviceaccount "k8s.io/apiserver/pkg/authentication/serviceaccount"
 	"k8s.io/apiserver/pkg/authorization/authorizerfactory"
-	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	clientset "k8s.io/client-go/kubernetes"
 	v1listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/keyutil"
-	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	"k8s.io/kubernetes/pkg/apis/core"
 	serviceaccountgetter "k8s.io/kubernetes/pkg/controller/serviceaccount"
-	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/serviceaccount"
 	"k8s.io/kubernetes/test/integration/framework"
 )
@@ -64,7 +61,6 @@ AwEHoUQDQgAEH6cuzP8XuD5wal6wf9M6xDljTOPLX2i8uIp/C/ASqiIGUeeKQtX0
 -----END EC PRIVATE KEY-----`
 
 func TestServiceAccountTokenCreate(t *testing.T) {
-	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.ServiceAccountIssuerDiscovery, true)()
 
 	// Build client config, clientset, and informers
 	sk, err := keyutil.ParsePrivateKeyPEM([]byte(ecdsaPrivateKey))


### PR DESCRIPTION
Waiting on KEP updates first:
https://github.com/kubernetes/enhancements/pull/2363

**What type of PR is this?**
/kind feature
/sig auth
/milestone v1.21

**What this PR does / why we need it**:
Graduates ServiceAccountIssuerDiscovery to GA.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
The `ServiceAccountIssuerDiscovery` feature has graduated to GA, and is unconditionally enabled. The `ServiceAccountIssuerDiscovery` feature-gate will be removed in 1.22.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs
- [KEP]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-auth/1393-oidc-discovery
- [Usage]: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#service-account-issuer-discovery
```
