### PR TITLE
Fix for Kubernetes API rejects pods/logs text/plain media type

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/codec_factory.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/codec_factory.go
@@ -87,6 +87,12 @@ func newSerializersForScheme(scheme *runtime.Scheme, mf json.MetaFactory, option
 			Serializer:         yamlSerializer,
 		},
 		{
+			AcceptContentTypes: []string{runtime.ContentTypeText},
+			ContentType:        runtime.ContentTypeText,
+			EncodesAsText:      true,
+			Serializer:         jsonSerializer,
+		},
+		{
 			AcceptContentTypes: []string{runtime.ContentTypeProtobuf},
 			ContentType:        runtime.ContentTypeProtobuf,
 			FileExtensions:     []string{"pb"},

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/types.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/types.go
@@ -44,6 +44,7 @@ const (
 	ContentTypeJSON     string = "application/json"
 	ContentTypeYAML     string = "application/yaml"
 	ContentTypeProtobuf string = "application/vnd.kubernetes.protobuf"
+	ContentTypeText     string = "text/plain"
 )
 
 // RawExtension is used to hold extensions in external versions.


### PR DESCRIPTION
and it's likely going to reject also others that may support text/plain in the future.

The Open API standard has a specification regarding supported media types.

```
    "/api/v1/namespaces/{namespace}/pods/{name}/log": {
      "get": {
        "consumes": [
          "*/*"
        ],
        "description": "read log of the specified Pod",
        "operationId": "readCoreV1NamespacedPodLog",
        "produces": [
          "text/plain",
          "application/json",
          "application/yaml",
          "application/vnd.kubernetes.protobuf"
        ],
```

**First I will try to describe the issue how I understand it:**

Each Kube API Group has its own serializer that is initialized at the
start of the API server. That one is defined per API group,
API server installs the API Group and at the same time it will initialize the serializer for it.

The default serializer contains Accept types, in case of default API Group as in this case:

```
          "application/json",
          "application/yaml",
          "application/vnd.kubernetes.protobuf"
```

The request is validated against the OpenAPI Spec Standard *produces* field but before returning
the results, it still goes thru the Kubernetes API Serializer for requested API Group.

The Kubernetes API Serializer doesn't know about text/plain and hence it will just reject
 the request with 406 Not Accepted

I was trying to add already existing jsonSerializer, as it has support to return Raw data if
the runtime.Object is unknown type.

Although I think we should not need any serializer for text/plain but Kuberenetes
API takes all objects thru their Serializers in https://github.com/kubernetes/kubernetes/blob/9f2f1b8c460b4b5ec8bfcd34490fb259ebad65b0/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/negotiation/negotiate.go#L45-L57 , meaning even if anything
is supported in OpenAPI Spec, it will be rejected if it is not supported
in the Group API Serializer. Also it seems that if we modify the Serializer, it will also ignore produces
in OpenAPI sSpec.

I am open for suggestions how to do this.
I think it's important to take into consideration other types, that may be supported
by OpenAPI spec *produces* but Kubernetes API will reject to server them.


**What type of PR is this?**

/kind bug
/kind api-change


Fixes #61450

**Special notes for your reviewer**:

After adding a Serializer it seems that it affects entire API group, and other resources will accept 'text/plain' as well.

```
curl -k --cert /Users/rrobin/.minikube/profiles/minikube/client.crt --key /Users/rrobin/.minikube/profiles/minikube/client.key 'https://192.168.49.3:8443/api/v1/namespaces/default/secrets?limit=500' -H 'Accept: text/plain' -s | head

{"kind":"SecretList","apiVersion":"v1","metadata":{"resourceVersion":"7501"},"items":[{"metadata":{"name":"default-token-8kfgd","namespace":"default","uid":"8a130d72-efb6-4f7e-9a81-021e5a6bb352","resourceVersion":"381","creationTimestamp":"2021-01-28T04:37:29Z","annotations":{"kubernetes.io/service-account.name":"default","kubernetes.io/service-account.uid":"4eef5c60-7782-449c-9676-cc7614681018"},"managedFields":[{"manager":"kube-controller-manager","operation":"Update","apiVersion":"v1","
```


```
curl -k --cert /Users/rrobin/.minikube/profiles/minikube/client.crt --key /Users/rrobin/.minikube/profiles/minikube/client.key https://192.168.49.3:8443/api/v1/namespaces/kube-system/pods/etcd-minikube/log -H 'Accept: text/plain' -s | head

[WARNING] Deprecated '--logger=capnslog' flag is set; use '--logger=zap' flag instead
2021-01-28 04:42:39.555791 I | etcdmain: etcd Version: 3.4.13
2021-01-28 04:42:39.555974 I | etcdmain: Git SHA: ae9734ed2
2021-01-28 04:42:39.556232 I | etcdmain: Go Version: go1.12.17
2021-01-28 04:42:39.556403 I | etcdmain: Go OS/Arch: linux/amd64
2021-01-28 04:42:39.556435 I | etcdmain: setting maximum number of CPUs to 2, total number of available CPUs is 2
2021-01-28 04:42:39.556590 N | etcdmain: the server is already initialized as member before, starting as etcd member...
[WARNING] Deprecated '--logger=capnslog' flag is set; use '--logger=zap' flag instead
2021-01-28 04:42:39.556844 I | embed: peerTLS: cert = /var/lib/minikube/certs/etcd/peer.crt, key = /var/lib/minikube/certs/etcd/peer.key, trusted-ca = /var/lib/minikube/certs/etcd/ca.crt, client-cert-auth = true, crl-file =
2021-01-28 04:42:39.570252 I | embed: name = minikube
```

So I am still working on solution, please ignore the commits in this PR for the time-being. I have converted this PR to draft.