### PR TITLE
update retry_handler log

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/aws/retry_handler.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/aws/retry_handler.go
@@ -54,8 +54,8 @@ func (c *CrossRequestRetryDelay) BeforeSign(r *request.Request) {
 	now := time.Now()
 	delay := c.backoff.ComputeDelayForRequest(now)
 	if delay > 0 {
-		klog.Warningf("Inserting delay before AWS request (%s) to avoid RequestLimitExceeded: %s",
-			describeRequest(r), delay.String())
+		klog.InfoS("Inserting delay before AWS request to avoid RequestLimitExceeded",
+			"request",describeRequest(r), "delay", delay.String())
 
 		if sleepFn := r.Config.SleepDelay; sleepFn != nil {
 			// Support SleepDelay for backwards compatibility
@@ -98,8 +98,8 @@ func (c *CrossRequestRetryDelay) AfterRetry(r *request.Request) {
 	if awsError.Code() == "RequestLimitExceeded" {
 		c.backoff.ReportError()
 		recordAWSThrottlesMetric(operationName(r))
-		klog.Warningf("Got RequestLimitExceeded error on AWS request (%s)",
-			describeRequest(r))
+		klog.InfoS("Got RequestLimitExceeded error on AWS request",
+			"request", describeRequest(r))
 	}
 }
 


### PR DESCRIPTION
/kind Structured Logging migration

Fixes #
update aws retry_handler log

**Does this PR introduce a user-facing change?**:
NONE

```release-note
 Structured Logging migration
```

```docs
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/migration-to-structured-logging.md
```
