### PR TITLE
Make image build logs verbose if necessary

### DIFF
--- a/build/lib/release.sh
+++ b/build/lib/release.sh
@@ -383,12 +383,16 @@ EOF
           echo "COPY nsswitch.conf /etc/" >> "${docker_file_path}"
         fi
 
-        DOCKER_CLI_EXPERIMENTAL=enabled "${DOCKER[@]}" buildx build \
+        local build_log="${docker_build_path}/build.log"
+        if ! DOCKER_CLI_EXPERIMENTAL=enabled "${DOCKER[@]}" buildx build \
           --platform linux/"${arch}" \
           --load ${docker_build_opts:+"${docker_build_opts}"} \
-          -q \
           -t "${docker_image_tag}" \
-          "${docker_build_path}" >/dev/null
+          "${docker_build_path}" >"${build_log}" 2>&1; then
+            cat "${build_log}"
+            exit 1
+        fi
+        rm "${build_log}"
 
         # If we are building an official/alpha/beta release we want to keep
         # docker images and tag them appropriately.


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

The `-q` flag is not implemented by `docker buildx`, which results in an
output:

```
WARN[0000] quiet currently not implemented.
```

In the same way, the build output is not logged to `stdout` (but
`stderr`). This means we now dump the whole build process to a file and
if the `docker buildx` command fails, then we output those logs by
printing the contents of that file. This will also reduce the overall
verbosity and aligns to the original `docker build` behavior.

**Which issue(s) this PR fixes**:

None

**Special notes for your reviewer**:

Follow up of https://github.com/kubernetes/kubernetes/pull/98529#commitcomment-46488020

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```

/cc @kubernetes/release-engineering 
/sig release
/priority important-soon