### PR TITLE
Promote ServiceAccountIssuerDiscovery test to conformance

### DIFF
--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -1351,6 +1351,13 @@
     resource must support get, update, patch.'
   release: v1.19
   file: test/e2e/auth/certificates.go
+- testname: OIDC Discovery (ServiceAccountIssuerDiscovery)
+  codename: '[sig-auth] ServiceAccounts ServiceAccountIssuerDiscovery should support
+    OIDC discovery of service account issuer [Conformance]'
+  description: Ensure kube-apiserver serves correct OIDC discovery endpoints by deploying
+    a Pod that verifies its own token against these endpoints.
+  release: v1.21
+  file: test/e2e/auth/service_accounts.go
 - testname: Service account tokens auto mount optionally
   codename: '[sig-auth] ServiceAccounts should allow opting out of API token automount  [Conformance]'
   description: Ensure that Service Account keys are mounted into the Pod only when

--- a/test/e2e/auth/service_accounts.go
+++ b/test/e2e/auth/service_accounts.go
@@ -673,7 +673,15 @@ var _ = SIGDescribe("ServiceAccounts", func() {
 		}
 	})
 
-	ginkgo.It("ServiceAccountIssuerDiscovery should support OIDC discovery of service account issuer", func() {
+	/*
+	   Release: v1.21
+	   Testname: OIDC Discovery (ServiceAccountIssuerDiscovery)
+	   Description: Ensure kube-apiserver serves correct OIDC discovery
+	   endpoints by deploying a Pod that verifies its own
+	   token against these endpoints.
+	*/
+	framework.ConformanceIt("ServiceAccountIssuerDiscovery should support OIDC discovery of service account issuer", func() {
+
 		// Allow the test pod access to the OIDC discovery non-resource URLs.
 		// The role should have already been automatically created as part of the
 		// RBAC bootstrap policy, but not the role binding. If RBAC is disabled,


### PR DESCRIPTION
**What type of PR is this?**
/kind feature
/sig auth

**What this PR does / why we need it**:
This satisfies the graduation criteria for promoting
ServiceAccountIssuerDiscovery to GA, per the KEP:
https://github.com/kubernetes/enhancements/tree/master/keps/sig-auth/1393-oidc-discovery

The test only uses GA APIs and has been passing for well
over two weeks:

* https://testgrid.k8s.io/sig-release-master-blocking#gce-cos-master-alpha-features&include-filter-by-regex=ServiceAccountIssuerDiscovery&width=5&show-stale-tests=
* https://testgrid.k8s.io/sig-release-master-blocking#gce-ubuntu-master-containerd&include-filter-by-regex=ServiceAccountIssuerDiscovery&width=5

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
