### PR TITLE
sped up scheduler tests by using fake clock

### DIFF
--- a/pkg/controller/nodelifecycle/scheduler/timed_workers.go
+++ b/pkg/controller/nodelifecycle/scheduler/timed_workers.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/clock"
 
 	"k8s.io/klog/v2"
 )
@@ -45,17 +46,17 @@ type TimedWorker struct {
 	WorkItem  *WorkArgs
 	CreatedAt time.Time
 	FireAt    time.Time
-	Timer     *time.Timer
+	Timer     clock.Timer
 }
 
-// CreateWorker creates a TimedWorker that will execute `f` not earlier than `fireAt`.
-func CreateWorker(args *WorkArgs, createdAt time.Time, fireAt time.Time, f func(args *WorkArgs) error) *TimedWorker {
+// createWorker creates a TimedWorker that will execute `f` not earlier than `fireAt`.
+func createWorker(args *WorkArgs, createdAt time.Time, fireAt time.Time, f func(args *WorkArgs) error, clock clock.Clock) *TimedWorker {
 	delay := fireAt.Sub(createdAt)
 	if delay <= 0 {
 		go f(args)
 		return nil
 	}
-	timer := time.AfterFunc(delay, func() { f(args) })
+	timer := clock.AfterFunc(delay, func() { f(args) })
 	return &TimedWorker{
 		WorkItem:  args,
 		CreatedAt: createdAt,
@@ -77,6 +78,7 @@ type TimedWorkerQueue struct {
 	// map of workers keyed by string returned by 'KeyFromWorkArgs' from the given worker.
 	workers  map[string]*TimedWorker
 	workFunc func(args *WorkArgs) error
+	clock    clock.Clock
 }
 
 // CreateWorkerQueue creates a new TimedWorkerQueue for workers that will execute
@@ -85,6 +87,7 @@ func CreateWorkerQueue(f func(args *WorkArgs) error) *TimedWorkerQueue {
 	return &TimedWorkerQueue{
 		workers:  make(map[string]*TimedWorker),
 		workFunc: f,
+		clock:    clock.RealClock{},
 	}
 }
 
@@ -115,7 +118,7 @@ func (q *TimedWorkerQueue) AddWork(args *WorkArgs, createdAt time.Time, fireAt t
 		klog.Warningf("Trying to add already existing work for %+v. Skipping.", args)
 		return
 	}
-	worker := CreateWorker(args, createdAt, fireAt, q.getWrappedWorkerFunc(key))
+	worker := createWorker(args, createdAt, fireAt, q.getWrappedWorkerFunc(key), q.clock)
 	q.workers[key] = worker
 }
 


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup
/kind failing-test
/sig node

**What this PR does / why we need it**:

```
$ go test k8s.io/kubernetes/pkg/controller/nodelifecycle/scheduler 
ok      k8s.io/kubernetes/pkg/controller/nodelifecycle/scheduler        22.716s
```

**Which issue(s) this PR fixes**:
Fixes #98495

**Special notes for your reviewer**:

There are still tests to improve in this package, but 22 seconds may be good enough for now.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
