### PR TITLE
Migrate pkg/probe/exec logs to structured logging.

### DIFF
--- a/pkg/probe/exec/exec.go
+++ b/pkg/probe/exec/exec.go
@@ -59,7 +59,7 @@ func (pr execProber) Probe(e exec.Cmd) (probe.Result, string, error) {
 	}
 	data := dataBuffer.Bytes()
 
-	klog.V(4).Infof("Exec probe response: %q", string(data))
+	klog.V(4).InfoS("Exec probe and received response", "response", string(data))
 	if err != nil {
 		exit, ok := err.(exec.ExitError)
 		if ok {


### PR DESCRIPTION
in pkg/probe/exec/exec.go

- log the detail data of exec probe response.

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it:**

Ref:

- [keps/sig-instrumentation/1602-structured-logging](https://github.com/kubernetes/enhancements/tree/master/keps/sig-instrumentation/1602-structured-logging)

- [Structured Logging migration instructions](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/migration-to-structured-logging.md)


**Does this PR introduce a user-facing change?:**

`Migrate some probe/exec log messages to structured logging `