### PR TITLE
Migrate pkg/probe/tcp logs to structured logging

### DIFF
--- a/pkg/probe/tcp/tcp.go
+++ b/pkg/probe/tcp/tcp.go
@@ -17,6 +17,7 @@ limitations under the License.
 package tcp
 
 import (
+	"fmt"
 	"net"
 	"strconv"
 	"time"
@@ -55,7 +56,7 @@ func DoTCPProbe(addr string, timeout time.Duration) (probe.Result, string, error
 	}
 	err = conn.Close()
 	if err != nil {
-		klog.Errorf("Unexpected error closing TCP probe socket: %v (%#v)", err, err)
+		klog.ErrorS(fmt.Errorf("%v (%#v)", err, err), "Unexpected error closing TCP probe socket")
 	}
 	return probe.Success, "", nil
 }


### PR DESCRIPTION
in pkg/probe/tcp/tcp.go

- log event of closing TCP probe socket.


**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it:**

Ref:

- [keps/sig-instrumentation/1602-structured-logging](https://github.com/kubernetes/enhancements/tree/master/keps/sig-instrumentation/1602-structured-logging)

- [Structured Logging migration instructions](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/migration-to-structured-logging.md)


**Does this PR introduce a user-facing change?:**

`Migrate some probe/tcp log messages to structured logging `