### PR TITLE
Migrate pkg/kubelet/metrics logs to structured logging.

### DIFF
--- a/pkg/kubelet/metrics/collectors/log_metrics.go
+++ b/pkg/kubelet/metrics/collectors/log_metrics.go
@@ -63,7 +63,7 @@ func (c *logMetricsCollector) DescribeWithStability(ch chan<- *metrics.Desc) {
 func (c *logMetricsCollector) CollectWithStability(ch chan<- metrics.Metric) {
 	podStats, err := c.podStats()
 	if err != nil {
-		klog.Errorf("failed to get pod stats: %v", err)
+		klog.ErrorS(err, "Failed to get pod stats")
 		return
 	}
 

--- a/pkg/kubelet/metrics/collectors/resource_metrics.go
+++ b/pkg/kubelet/metrics/collectors/resource_metrics.go
@@ -115,7 +115,7 @@ func (rc *resourceMetricsCollector) CollectWithStability(ch chan<- metrics.Metri
 	statsSummary, err := rc.provider.GetCPUAndMemoryStats()
 	if err != nil {
 		errorCount = 1
-		klog.Warningf("Error getting summary for resourceMetric prometheus endpoint: %v", err)
+		klog.ErrorS(err, "Error getting summary for resourceMetric prometheus endpoint")
 		return
 	}
 

--- a/pkg/kubelet/metrics/metrics.go
+++ b/pkg/kubelet/metrics/metrics.go
@@ -467,7 +467,7 @@ func SetAssignedConfig(source *corev1.NodeConfigSource) error {
 	}
 	// clean up the old timeseries (WithLabelValues creates a new one for each distinct label set)
 	if !AssignedConfig.Delete(assignedConfigLabels) {
-		klog.Warningf("Failed to delete metric for labels %v. This may result in ambiguity from multiple metrics concurrently indicating different assigned configs.", assignedConfigLabels)
+		klog.InfoS("Failed to delete metric for labels. This may result in ambiguity from multiple metrics concurrently indicating different assigned configs.", "labels", assignedConfigLabels)
 	}
 	// record the new timeseries
 	assignedConfigLabels = labels
@@ -489,7 +489,7 @@ func SetActiveConfig(source *corev1.NodeConfigSource) error {
 	}
 	// clean up the old timeseries (WithLabelValues creates a new one for each distinct label set)
 	if !ActiveConfig.Delete(activeConfigLabels) {
-		klog.Warningf("Failed to delete metric for labels %v. This may result in ambiguity from multiple metrics concurrently indicating different active configs.", activeConfigLabels)
+		klog.InfoS("Failed to delete metric for labels. This may result in ambiguity from multiple metrics concurrently indicating different active configs.", "labels", activeConfigLabels)
 	}
 	// record the new timeseries
 	activeConfigLabels = labels
@@ -511,7 +511,7 @@ func SetLastKnownGoodConfig(source *corev1.NodeConfigSource) error {
 	}
 	// clean up the old timeseries (WithLabelValues creates a new one for each distinct label set)
 	if !LastKnownGoodConfig.Delete(lastKnownGoodConfigLabels) {
-		klog.Warningf("Failed to delete metric for labels %v. This may result in ambiguity from multiple metrics concurrently indicating different last known good configs.", lastKnownGoodConfigLabels)
+		klog.InfoS("Failed to delete metric for labels. This may result in ambiguity from multiple metrics concurrently indicating different last known good configs.", "labels", lastKnownGoodConfigLabels)
 	}
 	// record the new timeseries
 	lastKnownGoodConfigLabels = labels


### PR DESCRIPTION
in pkg/kubelet/metrics.go

- log event of 'Failed to delete metric for labels'

in pkg/kubelet/metrics/collectors.go

- log event of 'Failed to get pod stats'

in pkg/kubelet/metrics/resource_metrics.go

- log event of 'Error getting summary for resourceMetric prometheus endpoint'

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it:**

Ref:

- [keps/sig-instrumentation/1602-structured-logging](https://github.com/kubernetes/enhancements/tree/master/keps/sig-instrumentation/1602-structured-logging)

- [Structured Logging migration instructions](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/migration-to-structured-logging.md)


**Does this PR introduce a user-facing change?:**

```release-note
NONE
```