### PR TITLE
migrate logs to structed logging

### DIFF
--- a/pkg/kubelet/dockershim/libdocker/kube_docker_client.go
+++ b/pkg/kubelet/dockershim/libdocker/kube_docker_client.go
@@ -341,10 +341,10 @@ func (p *progressReporter) start() {
 					p.cancel()
 					return
 				}
-				klog.V(2).Infof("Pulling image %q: %q", p.image, progress)
+				klog.V(2).InfoS("Pulling image", "imageName", p.image, "progress", progress)
 			case <-p.stopCh:
 				progress, _ := p.progress.get()
-				klog.V(2).Infof("Stop pulling image %q: %q", p.image, progress)
+				klog.V(2).InfoS("Stop pulling image", "imageName", p.image, "progress", progress)
 				return
 			}
 		}


### PR DESCRIPTION
Migrate some logs to structured logging

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Ref:

[keps/sig-instrumentation/1602-structured-logging](https://github.com/kubernetes/enhancements/tree/master/keps/sig-instrumentation/1602-structured-logging)
[Structured Logging migration instructions](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/migration-to-structured-logging.md)

**Does this PR introduce a user-facing change?:**:
```
Migrate some log messages to structured logging
````
