### PR TITLE
reset RunningContainerCount before setting it

### DIFF
--- a/pkg/kubelet/pleg/generic_test.go
+++ b/pkg/kubelet/pleg/generic_test.go
@@ -840,14 +840,13 @@ kubelet_running_containers{container_state="unknown"} 2
 		},
 	}
 
-	for _, test := range newTests {
-		tc := test
+	for _, tc := range newTests {
 		runtime.AllPodList = tc.podListForEachMoment
 		pleg.relist()
 		t.Run(tc.name, func(t *testing.T) {
-			for _, metric := range test.expectedMetrics {
-				testMetric := metric
-				if err := testutil.GatherAndCompare(metrics.GetGather(), strings.NewReader(testMetric.wants), testMetric.metricsName); err != nil {
+			// Test cases in this function should always run in serial, since later test case's result relies on previous one.
+			for _, expectedMetric := range tc.expectedMetrics {
+				if err := testutil.GatherAndCompare(metrics.GetGather(), strings.NewReader(expectedMetric.wants), expectedMetric.metricsName); err != nil {
 					t.Fatal(err)
 				}
 			}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
When a container state is changed from created to running, the metric **kubelet_running_containers{container_state="unknown"}** will not be cleaned, that is to say, even through there's no containers in **created** state, the metrics still shows that there's 1 container in **created** state, which is not consistent with explanation of metric **RunningContainerCount** ( "Number of containers currently running"). 
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
/sig instrumentation
**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
