### PR TITLE
Promote RunAsGroup e2e test to Conformance

### DIFF
--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -645,6 +645,24 @@
     patch, delete, and deletecollection.'
   release: v1.20
   file: test/e2e/common/runtimeclass.go
+- testname: Security Context, test RunAsGroup at container level
+  codename: '[k8s.io] [sig-node] Security Context should support container.SecurityContext.RunAsUser
+    And container.SecurityContext.RunAsGroup [LinuxOnly] [Conformance]'
+  description: 'Container is created with runAsUser and runAsGroup option by passing
+    uid 1001 and gid 2002 at containr level. Pod MUST be in Succeeded phase. [LinuxOnly]:
+    This test is marked as LinuxOnly since Windows does not support running as UID
+    / GID.'
+  release: v1.21
+  file: test/e2e/node/security_context.go
+- testname: Security Context, test RunAsGroup at pod level
+  codename: '[k8s.io] [sig-node] Security Context should support pod.Spec.SecurityContext.RunAsUser
+    And pod.Spec.SecurityContext.RunAsGroup [LinuxOnly] [Conformance]'
+  description: 'Container is created with runAsUser and runAsGroup option by passing
+    uid 1001 and gid 2002 at pod level. Pod MUST be in Succeeded phase. [LinuxOnly]:
+    This test is marked as LinuxOnly since Windows does not support running as UID
+    / GID.'
+  release: v1.21
+  file: test/e2e/node/security_context.go
 - testname: ConfigMap Volume, text data, binary data
   codename: '[k8s.io] [sig-storage] ConfigMap binary data should be reflected in volume
     [NodeConformance] [Conformance]'

--- a/test/e2e/node/security_context.go
+++ b/test/e2e/node/security_context.go
@@ -86,7 +86,13 @@ var _ = SIGDescribe("Security Context", func() {
 		})
 	})
 
-	ginkgo.It("should support pod.Spec.SecurityContext.RunAsUser And pod.Spec.SecurityContext.RunAsGroup [LinuxOnly]", func() {
+	/*
+		Release: v1.21
+		Testname: Security Context, test RunAsGroup at pod level
+		Description: Container is created with runAsUser and runAsGroup option by passing uid 1001 and gid 2002 at pod level. Pod MUST be in Succeeded phase.
+		[LinuxOnly]: This test is marked as LinuxOnly since Windows does not support running as UID / GID.
+	*/
+	framework.ConformanceIt("should support pod.Spec.SecurityContext.RunAsUser And pod.Spec.SecurityContext.RunAsGroup [LinuxOnly]", func() {
 		pod := scTestPod(false, false)
 		userID := int64(1001)
 		groupID := int64(2002)
@@ -115,7 +121,13 @@ var _ = SIGDescribe("Security Context", func() {
 		})
 	})
 
-	ginkgo.It("should support container.SecurityContext.RunAsUser And container.SecurityContext.RunAsGroup [LinuxOnly]", func() {
+	/*
+		Release: v1.21
+		Testname: Security Context, test RunAsGroup at container level
+		Description: Container is created with runAsUser and runAsGroup option by passing uid 1001 and gid 2002 at containr level. Pod MUST be in Succeeded phase.
+		[LinuxOnly]: This test is marked as LinuxOnly since Windows does not support running as UID / GID.
+	*/
+	framework.ConformanceIt("should support container.SecurityContext.RunAsUser And container.SecurityContext.RunAsGroup [LinuxOnly]", func() {
 		pod := scTestPod(false, false)
 		userID := int64(1001)
 		groupID := int64(2001)


### PR DESCRIPTION
/area conformance

@kubernetes/sig-architecture-pr-reviews @kubernetes/sig-foo-pr-reviews @kubernetes/cncf-conformance-wg

