### PR TITLE
Adding myself as an approver for EndpointSlice controller

### DIFF
--- a/pkg/controller/endpoint/OWNERS
+++ b/pkg/controller/endpoint/OWNERS
@@ -10,5 +10,6 @@ reviewers:
 - bowei
 - MrHohn
 - thockin
+- robscott
 labels:
 - sig/network

--- a/pkg/controller/endpointslice/OWNERS
+++ b/pkg/controller/endpointslice/OWNERS
@@ -5,6 +5,7 @@ approvers:
 - freehan
 - MrHohn
 - thockin
+- robscott
 - sig-network-approvers
 reviewers:
 - robscott


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Adds myself as approver for EndpointSlice controller and reviewer for Endpoints controller.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
N/A

/sig network
/assign @freehan @bowei 