### PR TITLE
support removal of event handlers from SharedIndexInformers

### DIFF
--- a/pkg/controller/replication/conversion.go
+++ b/pkg/controller/replication/conversion.go
@@ -45,6 +45,7 @@ import (
 	appslisters "k8s.io/client-go/listers/apps/v1"
 	v1listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
+
 	appsinternal "k8s.io/kubernetes/pkg/apis/apps"
 	appsconversion "k8s.io/kubernetes/pkg/apis/apps/v1"
 	apiv1 "k8s.io/kubernetes/pkg/apis/core/v1"
@@ -69,12 +70,12 @@ type conversionInformer struct {
 	cache.SharedIndexInformer
 }
 
-func (i conversionInformer) AddEventHandler(handler cache.ResourceEventHandler) {
-	i.SharedIndexInformer.AddEventHandler(conversionEventHandler{handler})
+func (i conversionInformer) AddEventHandler(handler cache.ResourceEventHandler) (*cache.ResourceEventHandlerHandle, error) {
+	return i.SharedIndexInformer.AddEventHandler(conversionEventHandler{handler})
 }
 
-func (i conversionInformer) AddEventHandlerWithResyncPeriod(handler cache.ResourceEventHandler, resyncPeriod time.Duration) {
-	i.SharedIndexInformer.AddEventHandlerWithResyncPeriod(conversionEventHandler{handler}, resyncPeriod)
+func (i conversionInformer) AddEventHandlerWithResyncPeriod(handler cache.ResourceEventHandler, resyncPeriod time.Duration) (*cache.ResourceEventHandlerHandle, error) {
+	return i.SharedIndexInformer.AddEventHandlerWithResyncPeriod(conversionEventHandler{handler}, resyncPeriod)
 }
 
 type conversionLister struct {

--- a/pkg/controller/replication/conversion.go
+++ b/pkg/controller/replication/conversion.go
@@ -70,11 +70,11 @@ type conversionInformer struct {
 	cache.SharedIndexInformer
 }
 
-func (i conversionInformer) AddEventHandler(handler cache.ResourceEventHandler) (*cache.ResourceEventHandlerHandle, error) {
+func (i conversionInformer) AddEventHandler(handler cache.ResourceEventHandler) (*cache.ResourceEventHandlerRegistration, error) {
 	return i.SharedIndexInformer.AddEventHandler(conversionEventHandler{handler})
 }
 
-func (i conversionInformer) AddEventHandlerWithResyncPeriod(handler cache.ResourceEventHandler, resyncPeriod time.Duration) (*cache.ResourceEventHandlerHandle, error) {
+func (i conversionInformer) AddEventHandlerWithResyncPeriod(handler cache.ResourceEventHandler, resyncPeriod time.Duration) (*cache.ResourceEventHandlerRegistration, error) {
 	return i.SharedIndexInformer.AddEventHandlerWithResyncPeriod(conversionEventHandler{handler}, resyncPeriod)
 }
 

--- a/pkg/controller/replication/conversion.go
+++ b/pkg/controller/replication/conversion.go
@@ -70,11 +70,11 @@ type conversionInformer struct {
 	cache.SharedIndexInformer
 }
 
-func (i conversionInformer) AddEventHandler(handler cache.ResourceEventHandler) (*cache.ResourceEventHandlerRegistration, error) {
+func (i conversionInformer) AddEventHandler(handler cache.ResourceEventHandler) (cache.ResourceEventHandlerRegistration, error) {
 	return i.SharedIndexInformer.AddEventHandler(conversionEventHandler{handler})
 }
 
-func (i conversionInformer) AddEventHandlerWithResyncPeriod(handler cache.ResourceEventHandler, resyncPeriod time.Duration) (*cache.ResourceEventHandlerRegistration, error) {
+func (i conversionInformer) AddEventHandlerWithResyncPeriod(handler cache.ResourceEventHandler, resyncPeriod time.Duration) (cache.ResourceEventHandlerRegistration, error) {
 	return i.SharedIndexInformer.AddEventHandlerWithResyncPeriod(conversionEventHandler{handler}, resyncPeriod)
 }
 

--- a/staging/src/k8s.io/client-go/tools/cache/shared_informer_test.go
+++ b/staging/src/k8s.io/client-go/tools/cache/shared_informer_test.go
@@ -395,14 +395,14 @@ func TestSharedInformerRemoveHandler(t *testing.T) {
 		t.Errorf("informer has %d registered handler, instead of 2", eventHandlerCount(informer))
 	}
 
-	if err := informer.RemoveEventHandlerByHandle(handle2); err != nil {
+	if err := informer.RemoveEventHandlerByRegistration(handle2); err != nil {
 		t.Errorf("removing of first pointer handler failed: %s", err)
 	}
 	if eventHandlerCount(informer) != 1 {
 		t.Errorf("after removing handler informer has %d registered handler(s), instead of 1", eventHandlerCount(informer))
 	}
 
-	if err := informer.RemoveEventHandlerByHandle(handle1); err != nil {
+	if err := informer.RemoveEventHandlerByRegistration(handle1); err != nil {
 		t.Errorf("removing of second pointer handler failed: %s", err)
 	}
 	if eventHandlerCount(informer) != 0 {
@@ -433,14 +433,14 @@ func TestSharedInformerRemoveNonComparableHandler(t *testing.T) {
 		t.Errorf("informer has %d registered handler(s), instead of 2", eventHandlerCount(informer))
 	}
 
-	if err := informer.RemoveEventHandlerByHandle(handle2); err != nil {
+	if err := informer.RemoveEventHandlerByRegistration(handle2); err != nil {
 		t.Errorf("removing of pointer handler failed: %s", err)
 	}
 	if eventHandlerCount(informer) != 1 {
 		t.Errorf("after removal informer has %d registered handler(s), instead of 1", eventHandlerCount(informer))
 	}
 
-	if err := informer.RemoveEventHandlerByHandle(handle1); err != nil {
+	if err := informer.RemoveEventHandlerByRegistration(handle1); err != nil {
 		t.Errorf("removing of non-pointer handler failed: %s", err)
 	}
 	if eventHandlerCount(informer) != 0 {
@@ -461,7 +461,7 @@ func TestSharedInformerMultipleRegistration(t *testing.T) {
 		return
 	}
 
-	if !reg1.IsActive() {
+	if !reg1.isActive() {
 		t.Errorf("handle1 is not active after successful registration")
 		return
 	}
@@ -472,7 +472,7 @@ func TestSharedInformerMultipleRegistration(t *testing.T) {
 		return
 	}
 
-	if !reg2.IsActive() {
+	if !reg2.isActive() {
 		t.Errorf("handle2 is not active after successful registration")
 		return
 	}
@@ -481,15 +481,15 @@ func TestSharedInformerMultipleRegistration(t *testing.T) {
 		t.Errorf("informer has %d registered handler(s), instead of 1", eventHandlerCount(informer))
 	}
 
-	if err := informer.RemoveEventHandlerByHandle(reg1); err != nil {
+	if err := informer.RemoveEventHandlerByRegistration(reg1); err != nil {
 		t.Errorf("removing of duplicate handler registration failed: %s", err)
 	}
 
-	if reg1.IsActive() {
+	if reg1.isActive() {
 		t.Errorf("handle1 is still active after successful remove")
 		return
 	}
-	if !reg2.IsActive() {
+	if !reg2.isActive() {
 		t.Errorf("handle2 is not active after removing handle1")
 		return
 	}
@@ -502,11 +502,11 @@ func TestSharedInformerMultipleRegistration(t *testing.T) {
 		}
 	}
 
-	if err := informer.RemoveEventHandlerByHandle(reg2); err != nil {
+	if err := informer.RemoveEventHandlerByRegistration(reg2); err != nil {
 		t.Errorf("removing of second handler registration failed: %s", err)
 	}
 
-	if reg2.IsActive() {
+	if reg2.isActive() {
 		t.Errorf("handle2 is still active after successful remove")
 		return
 	}
@@ -528,18 +528,18 @@ func TestRemovingRemovedSharedInformer(t *testing.T) {
 		t.Errorf("informer did not add handler for the first time: %s", err)
 		return
 	}
-	if err := informer.RemoveEventHandlerByHandle(reg); err != nil {
+	if err := informer.RemoveEventHandlerByRegistration(reg); err != nil {
 		t.Errorf("removing of handler registration failed: %s", err)
 		return
 	}
-	if reg.IsActive() {
+	if reg.isActive() {
 		t.Errorf("handle is still active after successful remove")
 		return
 	}
-	if err := informer.RemoveEventHandlerByHandle(reg); err != nil {
+	if err := informer.RemoveEventHandlerByRegistration(reg); err != nil {
 		t.Errorf("removing of already removed registration yields unexpected error: %s", err)
 	}
-	if reg.IsActive() {
+	if reg.isActive() {
 		t.Errorf("handle is still active after second remove")
 		return
 	}
@@ -646,7 +646,7 @@ func TestRemoveOnStoppedSharedInformer(t *testing.T) {
 		t.Errorf("informer reports not to be stopped although stop channel closed")
 		return
 	}
-	err = informer.RemoveEventHandlerByHandle(handle)
+	err = informer.RemoveEventHandlerByRegistration(handle)
 	if err == nil {
 		t.Errorf("informer removes handler on stopped informer")
 		return

--- a/staging/src/k8s.io/client-go/tools/cache/shared_informer_test.go
+++ b/staging/src/k8s.io/client-go/tools/cache/shared_informer_test.go
@@ -110,6 +110,11 @@ func isStarted(i SharedInformer) bool {
 	return s.started
 }
 
+func isRegistered(i SharedInformer, h ResourceEventHandlerRegistration) bool {
+	s := i.(*sharedIndexInformer)
+	return s.isRegistered(h)
+}
+
 func TestListenerResyncPeriods(t *testing.T) {
 	// source simulates an apiserver object endpoint.
 	source := fcache.NewFakeControllerSource()
@@ -461,7 +466,7 @@ func TestSharedInformerMultipleRegistration(t *testing.T) {
 		return
 	}
 
-	if !reg1.isActive() {
+	if !isRegistered(informer,reg1) {
 		t.Errorf("handle1 is not active after successful registration")
 		return
 	}
@@ -472,7 +477,7 @@ func TestSharedInformerMultipleRegistration(t *testing.T) {
 		return
 	}
 
-	if !reg2.isActive() {
+	if !isRegistered(informer,reg2) {
 		t.Errorf("handle2 is not active after successful registration")
 		return
 	}
@@ -485,11 +490,11 @@ func TestSharedInformerMultipleRegistration(t *testing.T) {
 		t.Errorf("removing of duplicate handler registration failed: %s", err)
 	}
 
-	if reg1.isActive() {
+	if isRegistered(informer,reg1) {
 		t.Errorf("handle1 is still active after successful remove")
 		return
 	}
-	if !reg2.isActive() {
+	if !isRegistered(informer, reg2) {
 		t.Errorf("handle2 is not active after removing handle1")
 		return
 	}
@@ -506,7 +511,7 @@ func TestSharedInformerMultipleRegistration(t *testing.T) {
 		t.Errorf("removing of second handler registration failed: %s", err)
 	}
 
-	if reg2.isActive() {
+	if isRegistered(informer,reg2) {
 		t.Errorf("handle2 is still active after successful remove")
 		return
 	}
@@ -532,14 +537,14 @@ func TestRemovingRemovedSharedInformer(t *testing.T) {
 		t.Errorf("removing of handler registration failed: %s", err)
 		return
 	}
-	if reg.isActive() {
+	if isRegistered(informer,reg) {
 		t.Errorf("handle is still active after successful remove")
 		return
 	}
 	if err := informer.RemoveEventHandlerByRegistration(reg); err != nil {
 		t.Errorf("removing of already removed registration yields unexpected error: %s", err)
 	}
-	if reg.isActive() {
+	if isRegistered(informer,reg) {
 		t.Errorf("handle is still active after second remove")
 		return
 	}
@@ -610,17 +615,13 @@ func TestAddOnStoppedSharedInformer(t *testing.T) {
 		return
 	}
 
-	handle, err := informer.AddEventHandlerWithResyncPeriod(listener, listener.resyncPeriod)
+	_, err := informer.AddEventHandlerWithResyncPeriod(listener, listener.resyncPeriod)
 	if err == nil {
 		t.Errorf("stopped informer did not reject add handler")
 		return
 	}
 	if !strings.HasSuffix(err.Error(), "is not added to shared informer because it has stopped already") {
 		t.Errorf("adding handler to a stopped informer yields unexpected error: %s", err)
-		return
-	}
-	if handle != nil {
-		t.Errorf("got handle for added handler on stopped informer")
 		return
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
To be able to implement controllers that are dynamically deciding
on which resources to watch, it is required to get rid of
dedicated watches and event handlers again. This requires the
possibility to remove event handlers from `SharedIndexInformer`s again.
Stopping an informer is not sufficient, because there might
be multiple controllers in a controller manager that independently
decide which resources to watch.

Unfortunately the ResourceEventHandler interface encourages to use
value objects for handlers (like the ResourceEventHandlerFuncs
struct, that uses value receivers to implement the interface).
Go does not support comparison of function pointers and therefore
the comparison of such structs is not possible, also. To be able
to remove all kinds of handlers and to solve the problem of
multi-registrations of handlers a registration handle is introduced.
It is returned when adding a handler and can later be used to remove
the registration again. This handle directly stores the created
listener to simplify the deletion.


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
Remark: If as the result of a handler removal a complete informer
should be disabled it is higly recommended to incorporate
pull request #98653, which fixes a race condition when stopping
watches for an informer using the stop channel.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
