### PR TITLE
retry dry-run update on conflict

### DIFF
--- a/test/integration/dryrun/BUILD
+++ b/test/integration/dryrun/BUILD
@@ -31,6 +31,7 @@ go_test(
         "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",
         "//staging/src/k8s.io/client-go/dynamic:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes:go_default_library",
+        "//staging/src/k8s.io/client-go/util/retry:go_default_library",
         "//staging/src/k8s.io/component-base/featuregate/testing:go_default_library",
         "//test/integration/etcd:go_default_library",
         "//test/integration/framework:go_default_library",


### PR DESCRIPTION
**What type of PR is this?**

/kind flake

**What this PR does / why we need it**:

Improves dry-run test on controller-updated resources. Fixes https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/98668/pull-kubernetes-integration/1356290435806400512

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/cc @apelisse 