### PR TITLE
Isolate TestModifyContext from $KUBECONFIG

### DIFF
--- a/staging/src/k8s.io/client-go/tools/clientcmd/BUILD
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/BUILD
@@ -11,6 +11,7 @@ go_test(
     srcs = [
         "client_config_test.go",
         "loader_test.go",
+        "main_test.go",
         "merged_client_builder_test.go",
         "overrides_test.go",
         "validation_test.go",

--- a/staging/src/k8s.io/client-go/tools/clientcmd/main_test.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/main_test.go
@@ -1,0 +1,34 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clientcmd
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestMain(m *testing.M) {
+	tmp, err := ioutil.TempDir("", "testkubeconfig")
+	if err != nil {
+		panic(err)
+	}
+	defer os.RemoveAll(tmp)
+	os.Setenv("KUBECONFIG", filepath.Join(tmp, "dummy-nonexistent-kubeconfig"))
+	os.Exit(m.Run())
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

This unit test tries to modify the kubeconfig file that originated the source context. This means that if $KUBECONFIG is set, it tries to modify the referenced file (which is not good). If $KUBECONFIG points to a readonly location containing a kubeconfig file, the unit test fails (which is also not good):

```
--- FAIL: TestModifyContext (0.00s)
    client_config_test.go:278: Unexpected error: mkdir /var/run/kubernetes: permission denied
    client_config_test.go:800: Expected "updated", got ""
    client_config_test.go:291: unexpected number of contexts, expecting 2, but found 0
FAIL
FAIL	k8s.io/kubernetes/vendor/k8s.io/client-go/tools/clientcmd	0.459s
```

This change clears/restores $KUBECONFIG so the unit test does not interact with that file.


```release-note
NONE
```

/cc @deads2k 