### PR TITLE
JobDeletionDurationSeconds metric in TTLAfterFinished controller

### DIFF
--- a/pkg/controller/ttlafterfinished/BUILD
+++ b/pkg/controller/ttlafterfinished/BUILD
@@ -8,6 +8,7 @@ go_library(
     deps = [
         "//pkg/controller:go_default_library",
         "//pkg/controller/job:go_default_library",
+        "//pkg/controller/ttlafterfinished/metrics:go_default_library",
         "//staging/src/k8s.io/api/batch/v1:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/errors:go_default_library",
@@ -52,6 +53,7 @@ filegroup(
     srcs = [
         ":package-srcs",
         "//pkg/controller/ttlafterfinished/config:all-srcs",
+        "//pkg/controller/ttlafterfinished/metrics:all-srcs",
     ],
     tags = ["automanaged"],
     visibility = ["//visibility:public"],

--- a/pkg/controller/ttlafterfinished/metrics/BUILD
+++ b/pkg/controller/ttlafterfinished/metrics/BUILD
@@ -1,0 +1,26 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["metrics.go"],
+    importpath = "k8s.io/kubernetes/pkg/controller/ttlafterfinished/metrics",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//staging/src/k8s.io/component-base/metrics:go_default_library",
+        "//staging/src/k8s.io/component-base/metrics/legacyregistry:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/pkg/controller/ttlafterfinished/metrics/metrics.go
+++ b/pkg/controller/ttlafterfinished/metrics/metrics.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"sync"
+
+	"k8s.io/component-base/metrics"
+	"k8s.io/component-base/metrics/legacyregistry"
+)
+
+// TTLAfterFinishedSubsystem - subsystem name used for this controller.
+const TTLAfterFinishedSubsystem = "ttl_after_finished_controller"
+
+var (
+	// JobDeletionDurationSeconds tracks the time it took to delete the job since it
+	// became eligible for deletion.
+	JobDeletionDurationSeconds = metrics.NewHistogram(
+		&metrics.HistogramOpts{
+			Subsystem:      TTLAfterFinishedSubsystem,
+			Name:           "job_deletion_duration_seconds",
+			Help:           "The time it took to delete the job since it became eligible for deletion",
+			StabilityLevel: metrics.ALPHA,
+			// Start with 100ms with the last bucket being [~27m, Inf).
+			Buckets: metrics.ExponentialBuckets(0.1, 2, 14),
+		},
+	)
+)
+
+var registerMetrics sync.Once
+
+// Register registers TTL after finished controller metrics.
+func Register() {
+	registerMetrics.Do(func() {
+		legacyregistry.MustRegister(JobDeletionDurationSeconds)
+	})
+}

--- a/pkg/controller/ttlafterfinished/ttlafterfinished_controller_test.go
+++ b/pkg/controller/ttlafterfinished/ttlafterfinished_controller_test.go
@@ -87,6 +87,7 @@ func TestTimeLeft(t *testing.T) {
 		expectErr        bool
 		expectErrStr     string
 		expectedTimeLeft *time.Duration
+		expectedExpireAt time.Time
 	}{
 		{
 			name:         "Error case: Job unfinished",
@@ -108,6 +109,7 @@ func TestTimeLeft(t *testing.T) {
 			ttl:              utilpointer.Int32Ptr(0),
 			since:            &now.Time,
 			expectedTimeLeft: durationPointer(0),
+			expectedExpireAt: now.Time,
 		},
 		{
 			name:             "Job completed now, 10s TTL",
@@ -115,6 +117,7 @@ func TestTimeLeft(t *testing.T) {
 			ttl:              utilpointer.Int32Ptr(10),
 			since:            &now.Time,
 			expectedTimeLeft: durationPointer(10),
+			expectedExpireAt: now.Add(10 * time.Second),
 		},
 		{
 			name:             "Job completed 10s ago, 15s TTL",
@@ -122,6 +125,7 @@ func TestTimeLeft(t *testing.T) {
 			ttl:              utilpointer.Int32Ptr(15),
 			since:            &now.Time,
 			expectedTimeLeft: durationPointer(5),
+			expectedExpireAt: now.Add(5 * time.Second),
 		},
 		{
 			name:         "Error case: Job failed now, no TTL",
@@ -136,6 +140,7 @@ func TestTimeLeft(t *testing.T) {
 			ttl:              utilpointer.Int32Ptr(0),
 			since:            &now.Time,
 			expectedTimeLeft: durationPointer(0),
+			expectedExpireAt: now.Time,
 		},
 		{
 			name:             "Job failed now, 10s TTL",
@@ -143,6 +148,7 @@ func TestTimeLeft(t *testing.T) {
 			ttl:              utilpointer.Int32Ptr(10),
 			since:            &now.Time,
 			expectedTimeLeft: durationPointer(10),
+			expectedExpireAt: now.Add(10 * time.Second),
 		},
 		{
 			name:             "Job failed 10s ago, 15s TTL",
@@ -150,12 +156,13 @@ func TestTimeLeft(t *testing.T) {
 			ttl:              utilpointer.Int32Ptr(15),
 			since:            &now.Time,
 			expectedTimeLeft: durationPointer(5),
+			expectedExpireAt: now.Add(5 * time.Second),
 		},
 	}
 
 	for _, tc := range testCases {
 		job := newJob(tc.completionTime, tc.failedTime, tc.ttl)
-		gotTimeLeft, gotErr := timeLeft(job, tc.since)
+		gotTimeLeft, gotExpireAt, gotErr := timeLeft(job, tc.since)
 		if tc.expectErr != (gotErr != nil) {
 			t.Errorf("%s: expected error is %t, got %t, error: %v", tc.name, tc.expectErr, gotErr != nil, gotErr)
 		}
@@ -168,6 +175,9 @@ func TestTimeLeft(t *testing.T) {
 		if !tc.expectErr {
 			if *gotTimeLeft != *tc.expectedTimeLeft {
 				t.Errorf("%s: expected time left %v, got %v", tc.name, tc.expectedTimeLeft, gotTimeLeft)
+			}
+			if *gotExpireAt != tc.expectedExpireAt {
+				t.Errorf("%s: expected expire at %v, got %v", tc.name, tc.expectedExpireAt, *gotExpireAt)
 			}
 		}
 	}


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Adds a metric to track the time it took to delete a job by the ttl-after-finished controller.

**Which issue(s) this PR fixes**:
Part of https://github.com/kubernetes/enhancements/issues/592

**Special notes for your reviewer**:
This is a requirement to graduate TTLAfterFinished to Beta: https://github.com/kubernetes/enhancements/tree/master/keps/sig-apps/592-ttl-after-finish#monitoring-requirements

**Does this PR introduce a user-facing change?**:
```release-note
A new histogram metric to track the time it took to delete a job by the ttl-after-finished controller
```

