### PR TITLE
run cronjob every 1minute in UT

### DIFF
--- a/pkg/controller/cronjob/cronjob_controllerv2_test.go
+++ b/pkg/controller/cronjob/cronjob_controllerv2_test.go
@@ -367,9 +367,9 @@ func TestController2_updateCronJob(t *testing.T) {
 			},
 			args: args{
 				oldJobSchedule: "30 * * * *",
-				newJobSchedule: "1 * * * *",
+				newJobSchedule: "*/1 * * * *",
 			},
-			deltaTimeForQueue:    61*time.Second + nextScheduleDelta,
+			deltaTimeForQueue:    1*time.Second + nextScheduleDelta,
 			roundOffTimeDuration: 750 * time.Millisecond,
 		},
 		// TODO: Add more test cases for updating scheduling.


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
 `1 * * * *` means first minute. It will wait until the next minute.

In UT of cronjob , `*/1 * * * *` means every minutes.
Change it to `0 * * * *` should be also ok.

**Which issue(s) this PR fixes**:
Part fo #98486 for  k8s.io/kubernetes/pkg/controller/cronjob 61.696s

**Special notes for your reviewer**:
To make it more stable, check 1 minute later to prevent minute 0 from missing. 🤔
```
- 			if d.Round(tt.roundOffTimeDuration).Seconds() != tt.deltaTimeForQueue.Round(tt.roundOffTimeDuration).Seconds() {
+			if d.Round(tt.roundOffTimeDuration).Seconds() != tt.deltaTimeForQueue.Round(tt.roundOffTimeDuration).Seconds() && d.Round(tt.roundOffTimeDuration).Seconds() != (tt.deltaTimeForQueue+ 60*time.Second).Round(tt.roundOffTimeDuration).Seconds()  {
				t.Errorf("Expected %#v got %#v", (tt.deltaTimeForQueue).Round(tt.roundOffTimeDuration).String(), d.Round(tt.roundOffTimeDuration).String())
			}
```

**Does this PR introduce a user-facing change?**:
```release-note
None
```
