### PR TITLE
Update gce-pd volume topology label to GA

### DIFF
--- a/pkg/volume/gcepd/attacher_test.go
+++ b/pkg/volume/gcepd/attacher_test.go
@@ -458,7 +458,7 @@ func createPVSpec(name string, readOnly bool, zones []string) *volume.Spec {
 	if zones != nil {
 		zonesLabel := strings.Join(zones, cloudvolume.LabelMultiZoneDelimiter)
 		spec.PersistentVolume.ObjectMeta.Labels = map[string]string{
-			v1.LabelFailureDomainBetaZone: zonesLabel,
+			v1.LabelTopologyZone: zonesLabel,
 		}
 	}
 

--- a/pkg/volume/gcepd/gce_pd.go
+++ b/pkg/volume/gcepd/gce_pd.go
@@ -545,7 +545,7 @@ func (c *gcePersistentDiskProvisioner) Provision(selectedNode *v1.Node, allowedT
 		for k, v := range labels {
 			pv.Labels[k] = v
 			var values []string
-			if k == v1.LabelFailureDomainBetaZone {
+			if k == v1.LabelTopologyZone {
 				values, err = volumehelpers.LabelZonesToList(v)
 				if err != nil {
 					return nil, fmt.Errorf("failed to convert label string for Zone: %s to a List: %v", v, err)

--- a/pkg/volume/gcepd/gce_pd_test.go
+++ b/pkg/volume/gcepd/gce_pd_test.go
@@ -86,7 +86,7 @@ type fakePDManager struct {
 func (fake *fakePDManager) CreateVolume(c *gcePersistentDiskProvisioner, node *v1.Node, allowedTopologies []v1.TopologySelectorTerm) (volumeID string, volumeSizeGB int, labels map[string]string, fstype string, err error) {
 	labels = make(map[string]string)
 	labels["fakepdmanager"] = "yes"
-	labels[v1.LabelFailureDomainBetaZone] = "zone1__zone2"
+	labels[v1.LabelTopologyZone] = "zone1__zone2"
 	return "test-gce-volume-name", 100, labels, "", nil
 }
 
@@ -200,8 +200,8 @@ func TestPlugin(t *testing.T) {
 		t.Errorf("Provision() returned unexpected value for fakepdmanager: %v", persistentSpec.Labels["fakepdmanager"])
 	}
 
-	if persistentSpec.Labels[v1.LabelFailureDomainBetaZone] != "zone1__zone2" {
-		t.Errorf("Provision() returned unexpected value for %s: %v", v1.LabelFailureDomainBetaZone, persistentSpec.Labels[v1.LabelFailureDomainBetaZone])
+	if persistentSpec.Labels[v1.LabelTopologyZone] != "zone1__zone2" {
+		t.Errorf("Provision() returned unexpected value for %s: %v", v1.LabelTopologyZone, persistentSpec.Labels[v1.LabelTopologyZone])
 	}
 
 	if persistentSpec.Spec.NodeAffinity == nil {
@@ -219,9 +219,9 @@ func TestPlugin(t *testing.T) {
 		t.Errorf("NodeSelectorRequirement fakepdmanager-in-yes not found in volume NodeAffinity")
 	}
 	zones, _ := volumehelpers.ZonesToSet("zone1,zone2")
-	r, _ = getNodeSelectorRequirementWithKey(v1.LabelFailureDomainBetaZone, term)
+	r, _ = getNodeSelectorRequirementWithKey(v1.LabelTopologyZone, term)
 	if r == nil {
-		t.Errorf("NodeSelectorRequirement %s-in-%v not found in volume NodeAffinity", v1.LabelFailureDomainBetaZone, zones)
+		t.Errorf("NodeSelectorRequirement %s-in-%v not found in volume NodeAffinity", v1.LabelTopologyZone, zones)
 	} else {
 		sort.Strings(r.Values)
 		if !reflect.DeepEqual(r.Values, zones.List()) {

--- a/pkg/volume/gcepd/gce_util.go
+++ b/pkg/volume/gcepd/gce_util.go
@@ -356,7 +356,10 @@ func udevadmChangeToDrive(drivePath string) error {
 // Checks whether the given GCE PD volume spec is associated with a regional PD.
 func isRegionalPD(spec *volume.Spec) bool {
 	if spec.PersistentVolume != nil {
-		zonesLabel := spec.PersistentVolume.Labels[v1.LabelFailureDomainBetaZone]
+		zonesLabel := spec.PersistentVolume.Labels[v1.LabelTopologyZone]
+		if zonesLabel == "" {
+			zonesLabel = spec.PersistentVolume.Labels[v1.LabelFailureDomainBetaZone]
+		}
 		zones := strings.Split(zonesLabel, cloudvolume.LabelMultiZoneDelimiter)
 		return len(zones) > 1
 	}

--- a/staging/src/k8s.io/legacy-cloud-providers/gce/gce_disks_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/gce/gce_disks_test.go
@@ -443,7 +443,7 @@ func pv(name, zone string) *v1.PersistentVolume {
 	return &v1.PersistentVolume{
 		ObjectMeta: metav1.ObjectMeta{
 			Labels: map[string]string{
-				v1.LabelFailureDomainBetaZone: zone,
+				v1.LabelTopologyZone: zone,
 			},
 		},
 		Spec: v1.PersistentVolumeSpec{
@@ -484,12 +484,12 @@ func TestGetLabelsForVolume_Basic(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	if labels[v1.LabelFailureDomainBetaZone] != zone {
-		t.Errorf("Failure domain is '%v', but zone is '%v'",
-			labels[v1.LabelFailureDomainBetaZone], zone)
+	if labels[v1.LabelTopologyZone] != zone {
+		t.Errorf("Topology Zone is '%v', but zone is '%v'",
+			labels[v1.LabelTopologyZone], zone)
 	}
-	if labels[v1.LabelFailureDomainBetaRegion] != gceRegion {
-		t.Errorf("Region is '%v', but region is 'us-central1'", labels[v1.LabelFailureDomainBetaRegion])
+	if labels[v1.LabelTopologyRegion] != gceRegion {
+		t.Errorf("Region is '%v', but region is 'us-central1'", labels[v1.LabelTopologyRegion])
 	}
 }
 
@@ -515,7 +515,7 @@ func TestGetLabelsForVolume_NoZone(t *testing.T) {
 	gce.CreateDisk(diskName, diskType, zone, sizeGb, nil)
 
 	pv := pv(diskName, zone)
-	delete(pv.Labels, v1.LabelFailureDomainBetaZone)
+	delete(pv.Labels, v1.LabelTopologyZone)
 
 	/* Act */
 	labels, err := gce.GetLabelsForVolume(ctx, pv)
@@ -524,12 +524,12 @@ func TestGetLabelsForVolume_NoZone(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	if labels[v1.LabelFailureDomainBetaZone] != zone {
-		t.Errorf("Failure domain is '%v', but zone is '%v'",
-			labels[v1.LabelFailureDomainBetaZone], zone)
+	if labels[v1.LabelTopologyZone] != zone {
+		t.Errorf("Topology Zone is '%v', but zone is '%v'",
+			labels[v1.LabelTopologyZone], zone)
 	}
-	if labels[v1.LabelFailureDomainBetaRegion] != gceRegion {
-		t.Errorf("Region is '%v', but region is 'europe-west1'", labels[v1.LabelFailureDomainBetaRegion])
+	if labels[v1.LabelTopologyRegion] != gceRegion {
+		t.Errorf("Region is '%v', but region is 'europe-west1'", labels[v1.LabelTopologyRegion])
 	}
 }
 
@@ -575,7 +575,7 @@ func TestGetLabelsForVolume_DiskNotFoundAndNoZone(t *testing.T) {
 	}
 
 	pv := pv(diskName, zone)
-	delete(pv.Labels, v1.LabelFailureDomainBetaZone)
+	delete(pv.Labels, v1.LabelTopologyZone)
 
 	/* Act */
 	_, err := gce.GetLabelsForVolume(ctx, pv)
@@ -617,12 +617,12 @@ func TestGetLabelsForVolume_DupDisk(t *testing.T) {
 	if err != nil {
 		t.Error("Disk name and zone uniquely identifies a disk, yet an error is returned.")
 	}
-	if labels[v1.LabelFailureDomainBetaZone] != zone {
-		t.Errorf("Failure domain is '%v', but zone is '%v'",
-			labels[v1.LabelFailureDomainBetaZone], zone)
+	if labels[v1.LabelTopologyZone] != zone {
+		t.Errorf("Topology Zone is '%v', but zone is '%v'",
+			labels[v1.LabelTopologyZone], zone)
 	}
-	if labels[v1.LabelFailureDomainBetaRegion] != gceRegion {
-		t.Errorf("Region is '%v', but region is 'us-west1'", labels[v1.LabelFailureDomainBetaRegion])
+	if labels[v1.LabelTopologyRegion] != gceRegion {
+		t.Errorf("Region is '%v', but region is 'us-west1'", labels[v1.LabelTopologyRegion])
 	}
 }
 
@@ -651,7 +651,7 @@ func TestGetLabelsForVolume_DupDiskNoZone(t *testing.T) {
 	}
 
 	pv := pv(diskName, zone)
-	delete(pv.Labels, v1.LabelFailureDomainBetaZone)
+	delete(pv.Labels, v1.LabelTopologyZone)
 
 	/* Act */
 	_, err := gce.GetLabelsForVolume(ctx, pv)
@@ -746,13 +746,13 @@ func TestGetAutoLabelsForPD(t *testing.T) {
 				return
 			}
 
-			if got := labels[v1.LabelFailureDomainBetaZone]; !tc.wantZoneLabel.Has(got) {
-				t.Errorf("labels[v1.LabelFailureDomainBetaZone] = %v; want one of: %v", got, tc.wantZoneLabel.List())
+			if got := labels[v1.LabelTopologyZone]; !tc.wantZoneLabel.Has(got) {
+				t.Errorf("labels[v1.LabelTopologyZone] = %v; want one of: %v", got, tc.wantZoneLabel.List())
 			}
 
 			// Validate labels
-			if got := labels[v1.LabelFailureDomainBetaRegion]; got != gceRegion {
-				t.Errorf("labels[v1.LabelFailureDomainBetaRegion] = %v; want: %v", got, gceRegion)
+			if got := labels[v1.LabelTopologyRegion]; got != gceRegion {
+				t.Errorf("labels[v1.LabelTopologyRegion] = %v; want: %v", got, gceRegion)
 			}
 		})
 	}

--- a/test/e2e/storage/drivers/in_tree.go
+++ b/test/e2e/storage/drivers/in_tree.go
@@ -1243,7 +1243,7 @@ func InitGcePdDriver() storageframework.TestDriver {
 			},
 			SupportedFsType:      supportedTypes,
 			SupportedMountOption: sets.NewString("debug", "nouid32"),
-			TopologyKeys:         []string{v1.LabelFailureDomainBetaZone},
+			TopologyKeys:         []string{v1.LabelTopologyZone},
 			Capabilities: map[storageframework.Capability]bool{
 				storageframework.CapPersistence:         true,
 				storageframework.CapFsGroup:             true,

--- a/test/e2e/storage/regional_pd.go
+++ b/test/e2e/storage/regional_pd.go
@@ -235,10 +235,10 @@ func testZonalFailover(c clientset.Interface, ns string) {
 	nodeName := pod.Spec.NodeName
 	node, err := c.CoreV1().Nodes().Get(context.TODO(), nodeName, metav1.GetOptions{})
 	framework.ExpectNoError(err)
-	podZone := node.Labels[v1.LabelFailureDomainBetaZone]
+	podZone := node.Labels[v1.LabelTopologyZone]
 
 	ginkgo.By("tainting nodes in the zone the pod is scheduled in")
-	selector := labels.SelectorFromSet(labels.Set(map[string]string{v1.LabelFailureDomainBetaZone: podZone}))
+	selector := labels.SelectorFromSet(labels.Set(map[string]string{v1.LabelTopologyZone: podZone}))
 	nodesInZone, err := c.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{LabelSelector: selector.String()})
 	framework.ExpectNoError(err)
 	removeTaintFunc := addTaint(c, ns, nodesInZone.Items, podZone)
@@ -266,7 +266,7 @@ func testZonalFailover(c clientset.Interface, ns string) {
 		if err != nil {
 			return false, nil
 		}
-		newPodZone := node.Labels[v1.LabelFailureDomainBetaZone]
+		newPodZone := node.Labels[v1.LabelTopologyZone]
 		return newPodZone == otherZone, nil
 	})
 	framework.ExpectNoError(waitErr, "Error waiting for pod to be scheduled in a different zone (%q): %v", otherZone, err)
@@ -354,9 +354,9 @@ func testRegionalDelayedBinding(c clientset.Interface, ns string, pvcCount int) 
 	if node == nil {
 		framework.Failf("unexpected nil node found")
 	}
-	zone, ok := node.Labels[v1.LabelFailureDomainBetaZone]
+	zone, ok := node.Labels[v1.LabelTopologyZone]
 	if !ok {
-		framework.Failf("label %s not found on Node", v1.LabelFailureDomainBetaZone)
+		framework.Failf("label %s not found on Node", v1.LabelTopologyZone)
 	}
 	for _, pv := range pvs {
 		checkZoneFromLabelAndAffinity(pv, zone, false)
@@ -423,9 +423,9 @@ func testRegionalAllowedTopologiesWithDelayedBinding(c clientset.Interface, ns s
 	if node == nil {
 		framework.Failf("unexpected nil node found")
 	}
-	nodeZone, ok := node.Labels[v1.LabelFailureDomainBetaZone]
+	nodeZone, ok := node.Labels[v1.LabelTopologyZone]
 	if !ok {
-		framework.Failf("label %s not found on Node", v1.LabelFailureDomainBetaZone)
+		framework.Failf("label %s not found on Node", v1.LabelTopologyZone)
 	}
 	zoneFound := false
 	for _, zone := range topoZones {
@@ -466,7 +466,7 @@ func addAllowedTopologiesToStorageClass(c clientset.Interface, sc *storagev1.Sto
 	term := v1.TopologySelectorTerm{
 		MatchLabelExpressions: []v1.TopologySelectorLabelRequirement{
 			{
-				Key:    v1.LabelFailureDomainBetaZone,
+				Key:    v1.LabelTopologyZone,
 				Values: zones,
 			},
 		},
@@ -568,7 +568,7 @@ func getTwoRandomZones(c clientset.Interface) []string {
 // If match is true, check if zones in PV exactly match zones given.
 // Otherwise, check whether zones in PV is superset of zones given.
 func verifyZonesInPV(volume *v1.PersistentVolume, zones sets.String, match bool) error {
-	pvZones, err := volumehelpers.LabelZonesToSet(volume.Labels[v1.LabelFailureDomainBetaZone])
+	pvZones, err := volumehelpers.LabelZonesToSet(volume.Labels[v1.LabelTopologyZone])
 	if err != nil {
 		return err
 	}
@@ -585,17 +585,17 @@ func checkZoneFromLabelAndAffinity(pv *v1.PersistentVolume, zone string, matchZo
 	checkZonesFromLabelAndAffinity(pv, sets.NewString(zone), matchZone)
 }
 
-// checkZoneLabelAndAffinity checks the LabelFailureDomainBetaZone label of PV and terms
-// with key LabelFailureDomainBetaZone in PV's node affinity contains zone
+// checkZoneLabelAndAffinity checks the LabelTopologyZone label of PV and terms
+// with key LabelTopologyZone in PV's node affinity contains zone
 // matchZones is used to indicate if zones should match perfectly
 func checkZonesFromLabelAndAffinity(pv *v1.PersistentVolume, zones sets.String, matchZones bool) {
 	ginkgo.By("checking PV's zone label and node affinity terms match expected zone")
 	if pv == nil {
 		framework.Failf("nil pv passed")
 	}
-	pvLabel, ok := pv.Labels[v1.LabelFailureDomainBetaZone]
+	pvLabel, ok := pv.Labels[v1.LabelTopologyZone]
 	if !ok {
-		framework.Failf("label %s not found on PV", v1.LabelFailureDomainBetaZone)
+		framework.Failf("label %s not found on PV", v1.LabelTopologyZone)
 	}
 
 	zonesFromLabel, err := volumehelpers.LabelZonesToSet(pvLabel)
@@ -603,10 +603,10 @@ func checkZonesFromLabelAndAffinity(pv *v1.PersistentVolume, zones sets.String, 
 		framework.Failf("unable to parse zone labels %s: %v", pvLabel, err)
 	}
 	if matchZones && !zonesFromLabel.Equal(zones) {
-		framework.Failf("value[s] of %s label for PV: %v does not match expected zone[s]: %v", v1.LabelFailureDomainBetaZone, zonesFromLabel, zones)
+		framework.Failf("value[s] of %s label for PV: %v does not match expected zone[s]: %v", v1.LabelTopologyZone, zonesFromLabel, zones)
 	}
 	if !matchZones && !zonesFromLabel.IsSuperset(zones) {
-		framework.Failf("value[s] of %s label for PV: %v does not contain expected zone[s]: %v", v1.LabelFailureDomainBetaZone, zonesFromLabel, zones)
+		framework.Failf("value[s] of %s label for PV: %v does not contain expected zone[s]: %v", v1.LabelTopologyZone, zonesFromLabel, zones)
 	}
 	if pv.Spec.NodeAffinity == nil {
 		framework.Failf("node affinity not found in PV spec %v", pv.Spec)
@@ -618,7 +618,7 @@ func checkZonesFromLabelAndAffinity(pv *v1.PersistentVolume, zones sets.String, 
 	for _, term := range pv.Spec.NodeAffinity.Required.NodeSelectorTerms {
 		keyFound := false
 		for _, r := range term.MatchExpressions {
-			if r.Key != v1.LabelFailureDomainBetaZone {
+			if r.Key != v1.LabelTopologyZone {
 				continue
 			}
 			keyFound = true
@@ -632,7 +632,7 @@ func checkZonesFromLabelAndAffinity(pv *v1.PersistentVolume, zones sets.String, 
 			break
 		}
 		if !keyFound {
-			framework.Failf("label %s not found in term %v", v1.LabelFailureDomainBetaZone, term)
+			framework.Failf("label %s not found in term %v", v1.LabelTopologyZone, term)
 		}
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
This is a follow-up PR for https://github.com/kubernetes/kubernetes/pull/97823

This PR updates the gce-pd volume topology label to use GA version. Previously we were using beta label(FailureDomain) for the in-tree volumes. But as the Beta label has been deprecated for a while and is scheduled to be removed soon. We should update this to use GA label instead.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fix #92237 by upgrading the label to GA version.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
[ACTION REQUIRED] Newly provisioned PVs by gce-pd will no longer have the beta FailureDomain label. gce-pd volume plugin will start to have GA topology label instead.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/sig storage
/cc @msau42 
