### PR TITLE
OWNERS: RelEng and CHANGELOG updates

### DIFF
--- a/CHANGELOG/OWNERS
+++ b/CHANGELOG/OWNERS
@@ -1,9 +1,21 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-  - changelog-approvers
+  - wilsonehusin # 1.21 Release Notes Lead
+  - cpanato # Release Manager
+  - feiskyer # Release Manager
+  - hasheddan # Release Manager / SIG Technical Lead
+  - idealhack # Release Manager
+  - justaugustus # Release Manager / SIG Chair
+  - puerco # Release Manager
+  - saschagrunert # Release Manager / SIG Chair
+  - xmudrii # Release Manager
 reviewers:
-  - changelog-reviewers
+  - wilsonehusin # 1.21 Release Notes Lead
+  - ashnehete # 1.21 Release Notes shadow
+  - melodychn # 1.21 Release Notes shadow
+  - pmmalinov01 # 1.21 Release Notes shadow
+  - soniasingla # 1.21 Release Notes shadow
 
 labels:
   - sig/release

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -153,22 +153,6 @@ aliases:
     - puerco # Release Manager
     - saschagrunert # Release Manager / SIG Chair
     - xmudrii # Release Manager
-  changelog-approvers:
-    - wilsonehusin # 1.21 Release Notes Lead
-    - cpanato # Release Manager
-    - feiskyer # Release Manager
-    - hasheddan # Release Manager / SIG Technical Lead
-    - idealhack # Release Manager
-    - justaugustus # Release Manager / SIG Chair
-    - puerco # Release Manager
-    - saschagrunert # Release Manager / SIG Chair
-    - xmudrii # Release Manager
-  changelog-reviewers:
-    - wilsonehusin # 1.21 Release Notes Lead
-    - ashnehete # 1.21 Release Notes shadow
-    - melodychn # 1.21 Release Notes shadow
-    - pmmalinov01 # 1.21 Release Notes shadow
-    - soniasingla # 1.21 Release Notes shadow
 
   sig-storage-approvers:
     - saad-ali

--- a/build/OWNERS
+++ b/build/OWNERS
@@ -5,8 +5,10 @@ reviewers:
   - cblecker
   - dims
   - fejta
-  - justaugustus
+  - hasheddan # Release Manager / SIG Technical Lead
+  - justaugustus # Release Manager / SIG Chair
   - lavalamp
+  - saschagrunert # Release Manager / SIG Chair
   - spiffxp
 approvers:
   - bentheelder


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

- OWNERS(CHANGELOG): Move reviewers/approvers to CHANGELOG/ dir

  Given we're pulling the relnotes team into review, the changes to
  reviewers will happen a little more frequently, which means we'll have
  the same issue of needing a top-level approver to do updates that we
  were trying to avoid by creating the subdirectory in the first place.

- build/OWNERS: Add Dan and Sascha as reviewers
  
  @hasheddan and @saschagrunert are senior Release Managers, SIG Release leadership, and
  have already been giving thoughtful reviews of the content in this
  directory.

  Adding them as reviewers to spread the load of SIG Release eyes on
  content.

/assign @liggitt @spiffxp @cblecker  
cc: @kubernetes/release-engineering @wilsonehusin 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
