### PR TITLE
upgrade bazel rules_docker to 1.5.0

### DIFF
--- a/build/root/WORKSPACE
+++ b/build/root/WORKSPACE
@@ -29,12 +29,21 @@ repo_infra_configure(
 
 repo_infra_go_repositories()
 
+# **********************************
+# Python
+# **********************************
+http_archive(
+    name = "rules_python",
+    url = "https://github.com/bazelbuild/rules_python/releases/download/0.1.0/rules_python-0.1.0.tar.gz",
+    sha256 = "b6d46438523a3ec0f3cead544190ee13223a52f6a6765a29eae7b7cc24cc83a0",
+)
+
 # begin setup rules_docker
 http_archive(
     name = "io_bazel_rules_docker",
-    sha256 = "4521794f0fba2e20f3bf15846ab5e01d5332e587e9ce81629c7f96c793bb7036",
-    strip_prefix = "rules_docker-0.14.4",
-    urls = mirror("https://github.com/bazelbuild/rules_docker/releases/download/v0.14.4/rules_docker-v0.14.4.tar.gz"),
+    sha256 = "1698624e878b0607052ae6131aa216d45ebb63871ec497f26c67455b34119c80",
+    strip_prefix = "rules_docker-0.15.0",
+    urls = mirror("https://github.com/bazelbuild/rules_docker/releases/download/v0.15.0/rules_docker-v0.15.0.tar.gz"),
 )
 
 load(
@@ -47,10 +56,6 @@ container_repositories()
 load("@io_bazel_rules_docker//repositories:deps.bzl", container_deps = "deps")
 
 container_deps()
-
-load("@io_bazel_rules_docker//repositories:pip_repositories.bzl", "pip_deps")
-
-pip_deps()
 
 load(
     "@io_bazel_rules_docker//container:container.bzl",


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
During investigating #98707 log shows that 

> W0202 11:47:48.766] WARNING: Download from https://storage.googleapis.com/k8s-bazel-cache/https://github.com/bazelbuild/rules_docker/releases/download/v0.14.4/rules_docker-v0.14.4.tar.gz failed: class com.google.devtools.build.lib.bazel.repository.downloader.UnrecoverableHttpException GET returned 404 Not Found

https://github.com/bazelbuild/rules_docker/releases/download/v0.14.4/rules_docker-v0.14.4.tar.gz is available.
Run `bash hack/update-workspace-mirror.sh  "https://github.com/bazelbuild/rules_docker/releases/download/v0.14.4/rules_docker-v0.14.4.tar.gz"` would fix it(which need permission)

However, this is not related to the flake. 😓

**Which issue(s) this PR fixes**:

Upgrade rules_docker to 0.15.0.
https://github.com/bazelbuild/rules_docker/releases/tag/v0.15.0

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
None
```
