### PR TITLE
add test to ensure that user can clear alwaysallowpaths

### DIFF
--- a/staging/src/k8s.io/cloud-provider/options/options_test.go
+++ b/staging/src/k8s.io/cloud-provider/options/options_test.go
@@ -142,6 +142,7 @@ func TestAddFlags(t *testing.T) {
 	args := []string{
 		"--address=192.168.4.10",
 		"--allocate-node-cidrs=true",
+		"--authorization-always-allow-paths=", // this proves that we can clear the default
 		"--bind-address=192.168.4.21",
 		"--cert-dir=/a/b/c",
 		"--cloud-config=/cloud-config",
@@ -257,7 +258,7 @@ func TestAddFlags(t *testing.T) {
 			ClientTimeout:                10 * time.Second,
 			WebhookRetryBackoff:          apiserveroptions.DefaultAuthWebhookRetryBackoff(),
 			RemoteKubeConfigFileOptional: true,
-			AlwaysAllowPaths:             []string{"/healthz", "/readyz", "/livez"}, // note: this does not match /healthz/ or /healthz/*
+			AlwaysAllowPaths:             []string{},
 			AlwaysAllowGroups:            []string{"system:masters"},
 		},
 		Kubeconfig:                "/kubeconfig",


### PR DESCRIPTION
Adds a test ensuring that overriding defaults on the CLI works.  I didn't realize this test already existed or I would have simply updated it before.

@kubernetes/sig-api-machinery-misc 
/kind cleanup
/priority important-soon

```release-note
NONE
```