### PR TITLE
Improve wording in kubeadm upgrade plan

### DIFF
--- a/cmd/kubeadm/app/cmd/upgrade/plan.go
+++ b/cmd/kubeadm/app/cmd/upgrade/plan.go
@@ -224,7 +224,7 @@ func printUpgradePlan(up *upgrade.Upgrade, plan *outputapi.UpgradePlan, unstable
 		} else if component.Name == constants.Kubelet {
 			if printManualUpgradeHeader {
 				fmt.Fprintln(w, "Components that must be upgraded manually after you have upgraded the control plane with 'kubeadm upgrade apply':")
-				fmt.Fprintln(tabw, "COMPONENT\tCURRENT\tAVAILABLE")
+				fmt.Fprintln(tabw, "COMPONENT\tCURRENT\tTARGET")
 				fmt.Fprintf(tabw, "%s\t%s\t%s\n", component.Name, component.CurrentVersion, component.NewVersion)
 				printManualUpgradeHeader = false
 			} else {
@@ -237,7 +237,7 @@ func printUpgradePlan(up *upgrade.Upgrade, plan *outputapi.UpgradePlan, unstable
 
 				fmt.Fprintf(w, "Upgrade to the latest %s:\n", up.Description)
 				fmt.Fprintln(w, "")
-				fmt.Fprintln(tabw, "COMPONENT\tCURRENT\tAVAILABLE")
+				fmt.Fprintln(tabw, "COMPONENT\tCURRENT\tTARGET")
 				printHeader = false
 			}
 			fmt.Fprintf(tabw, "%s\t%s\t%s\n", component.Name, component.CurrentVersion, component.NewVersion)

--- a/cmd/kubeadm/app/cmd/upgrade/plan_test.go
+++ b/cmd/kubeadm/app/cmd/upgrade/plan_test.go
@@ -100,12 +100,12 @@ func TestPrintAvailableUpgrades(t *testing.T) {
 				},
 			},
 			expectedBytes: []byte(`Components that must be upgraded manually after you have upgraded the control plane with 'kubeadm upgrade apply':
-COMPONENT   CURRENT      AVAILABLE
+COMPONENT   CURRENT      TARGET
 kubelet     1 x v1.8.1   v1.8.3
 
 Upgrade to the latest version in the v1.8 series:
 
-COMPONENT                 CURRENT   AVAILABLE
+COMPONENT                 CURRENT   TARGET
 kube-apiserver            v1.8.1    v1.8.3
 kube-controller-manager   v1.8.1    v1.8.3
 kube-scheduler            v1.8.1    v1.8.3
@@ -148,12 +148,12 @@ _____________________________________________________________________
 				},
 			},
 			expectedBytes: []byte(`Components that must be upgraded manually after you have upgraded the control plane with 'kubeadm upgrade apply':
-COMPONENT   CURRENT      AVAILABLE
+COMPONENT   CURRENT      TARGET
 kubelet     1 x v1.8.3   v1.9.0
 
 Upgrade to the latest stable version:
 
-COMPONENT                 CURRENT   AVAILABLE
+COMPONENT                 CURRENT   TARGET
 kube-apiserver            v1.8.3    v1.9.0
 kube-controller-manager   v1.8.3    v1.9.0
 kube-scheduler            v1.8.3    v1.9.0
@@ -214,12 +214,12 @@ _____________________________________________________________________
 				},
 			},
 			expectedBytes: []byte(`Components that must be upgraded manually after you have upgraded the control plane with 'kubeadm upgrade apply':
-COMPONENT   CURRENT      AVAILABLE
+COMPONENT   CURRENT      TARGET
 kubelet     1 x v1.8.3   v1.8.5
 
 Upgrade to the latest version in the v1.8 series:
 
-COMPONENT                 CURRENT   AVAILABLE
+COMPONENT                 CURRENT   TARGET
 kube-apiserver            v1.8.3    v1.8.5
 kube-controller-manager   v1.8.3    v1.8.5
 kube-scheduler            v1.8.3    v1.8.5
@@ -234,12 +234,12 @@ You can now apply the upgrade by executing the following command:
 _____________________________________________________________________
 
 Components that must be upgraded manually after you have upgraded the control plane with 'kubeadm upgrade apply':
-COMPONENT   CURRENT      AVAILABLE
+COMPONENT   CURRENT      TARGET
 kubelet     1 x v1.8.3   v1.9.0
 
 Upgrade to the latest stable version:
 
-COMPONENT                 CURRENT   AVAILABLE
+COMPONENT                 CURRENT   TARGET
 kube-apiserver            v1.8.3    v1.9.0
 kube-controller-manager   v1.8.3    v1.9.0
 kube-scheduler            v1.8.3    v1.9.0
@@ -282,12 +282,12 @@ _____________________________________________________________________
 				},
 			},
 			expectedBytes: []byte(`Components that must be upgraded manually after you have upgraded the control plane with 'kubeadm upgrade apply':
-COMPONENT   CURRENT      AVAILABLE
+COMPONENT   CURRENT      TARGET
 kubelet     1 x v1.8.5   v1.9.0-beta.1
 
 Upgrade to the latest experimental version:
 
-COMPONENT                 CURRENT   AVAILABLE
+COMPONENT                 CURRENT   TARGET
 kube-apiserver            v1.8.5    v1.9.0-beta.1
 kube-controller-manager   v1.8.5    v1.9.0-beta.1
 kube-scheduler            v1.8.5    v1.9.0-beta.1
@@ -330,12 +330,12 @@ _____________________________________________________________________
 				},
 			},
 			expectedBytes: []byte(`Components that must be upgraded manually after you have upgraded the control plane with 'kubeadm upgrade apply':
-COMPONENT   CURRENT      AVAILABLE
+COMPONENT   CURRENT      TARGET
 kubelet     1 x v1.8.5   v1.9.0-rc.1
 
 Upgrade to the latest release candidate version:
 
-COMPONENT                 CURRENT   AVAILABLE
+COMPONENT                 CURRENT   TARGET
 kube-apiserver            v1.8.5    v1.9.0-rc.1
 kube-controller-manager   v1.8.5    v1.9.0-rc.1
 kube-scheduler            v1.8.5    v1.9.0-rc.1
@@ -379,13 +379,13 @@ _____________________________________________________________________
 				},
 			},
 			expectedBytes: []byte(`Components that must be upgraded manually after you have upgraded the control plane with 'kubeadm upgrade apply':
-COMPONENT   CURRENT      AVAILABLE
+COMPONENT   CURRENT      TARGET
 kubelet     1 x v1.9.2   v1.9.3
             2 x v1.9.3   v1.9.3
 
 Upgrade to the latest version in the v1.9 series:
 
-COMPONENT                 CURRENT   AVAILABLE
+COMPONENT                 CURRENT   TARGET
 kube-apiserver            v1.9.2    v1.9.3
 kube-controller-manager   v1.9.2    v1.9.3
 kube-scheduler            v1.9.2    v1.9.3
@@ -430,12 +430,12 @@ _____________________________________________________________________
 			},
 			externalEtcd: true,
 			expectedBytes: []byte(`Components that must be upgraded manually after you have upgraded the control plane with 'kubeadm upgrade apply':
-COMPONENT   CURRENT      AVAILABLE
+COMPONENT   CURRENT      TARGET
 kubelet     1 x v1.9.2   v1.9.3
 
 Upgrade to the latest version in the v1.9 series:
 
-COMPONENT                 CURRENT   AVAILABLE
+COMPONENT                 CURRENT   TARGET
 kube-apiserver            v1.9.2    v1.9.3
 kube-controller-manager   v1.9.2    v1.9.3
 kube-scheduler            v1.9.2    v1.9.3
@@ -477,12 +477,12 @@ _____________________________________________________________________
 				},
 			},
 			expectedBytes: []byte(`Components that must be upgraded manually after you have upgraded the control plane with 'kubeadm upgrade apply':
-COMPONENT   CURRENT       AVAILABLE
+COMPONENT   CURRENT       TARGET
 kubelet     1 x v1.10.2   v1.11.0
 
 Upgrade to the latest kubedns to coredns:
 
-COMPONENT                 CURRENT   AVAILABLE
+COMPONENT                 CURRENT   TARGET
 kube-apiserver            v1.10.2   v1.11.0
 kube-controller-manager   v1.10.2   v1.11.0
 kube-scheduler            v1.10.2   v1.11.0
@@ -524,12 +524,12 @@ _____________________________________________________________________
 				},
 			},
 			expectedBytes: []byte(`Components that must be upgraded manually after you have upgraded the control plane with 'kubeadm upgrade apply':
-COMPONENT   CURRENT       AVAILABLE
+COMPONENT   CURRENT       TARGET
 kubelet     1 x v1.10.2   v1.11.0
 
 Upgrade to the latest coredns:
 
-COMPONENT                 CURRENT   AVAILABLE
+COMPONENT                 CURRENT   TARGET
 kube-apiserver            v1.10.2   v1.11.0
 kube-controller-manager   v1.10.2   v1.11.0
 kube-scheduler            v1.10.2   v1.11.0
@@ -570,12 +570,12 @@ _____________________________________________________________________
 				},
 			},
 			expectedBytes: []byte(`Components that must be upgraded manually after you have upgraded the control plane with 'kubeadm upgrade apply':
-COMPONENT   CURRENT       AVAILABLE
+COMPONENT   CURRENT       TARGET
 kubelet     1 x v1.10.2   v1.11.0
 
 Upgrade to the latest coredns to kubedns:
 
-COMPONENT                 CURRENT   AVAILABLE
+COMPONENT                 CURRENT   TARGET
 kube-apiserver            v1.10.2   v1.11.0
 kube-controller-manager   v1.10.2   v1.11.0
 kube-scheduler            v1.10.2   v1.11.0

--- a/cmd/kubeadm/app/phases/upgrade/compute.go
+++ b/cmd/kubeadm/app/phases/upgrade/compute.go
@@ -101,7 +101,7 @@ func GetAvailableUpgrades(versionGetterImpl VersionGetter, experimentalUpgradesA
 		fmt.Println("[upgrade/versions] WARNING: Falling back to current kubeadm version as latest stable version")
 		stableVersionStr, stableVersion = kubeadmVersionStr, kubeadmVersion
 	} else {
-		fmt.Printf("[upgrade/versions] Latest %s: %s\n", "stable version", stableVersionStr)
+		fmt.Printf("[upgrade/versions] Target version: %s\n", stableVersionStr)
 	}
 
 	// Get the kubelet versions in the cluster


### PR DESCRIPTION
Originally raised as an issue with invalid versions to plan, but it has
been determined with air gapped environments and development versions it
is not possible to fully address that issue.

But one thing that was identified was that we can do a better job in how
we output the upgrade plan information. Kubeadm outputs the requested
version as "Latest stable version", though that may not actually be the
case. For this instance, we want to change this to "Target version" to
be a little more accurate.

Then in the component upgrade table that is emitted, the last column of
AVAILABLE isn't quite right either. Also changing this to TARGET to
reflect that this is the version we are targeting to upgrade to,
regardless of its availability.

There could be some improvements in checking available versions,
particularly in air gapped environments, to make sure we actually have
access to the requested version. But this at least clarifies some of the
output a bit.

Fixes https://github.com/kubernetes/kubeadm/issues/2311

/kind bug
/kind cleanup

```release-note
kubeadm: Some text in the `kubeadm upgrade plan` output has changed. If you have scripts or other automation that parses this output, please review these changes and update your scripts to account for the new output.
```
