### PR TITLE
Add e2e test setup for windows vsphere driver

### DIFF
--- a/test/e2e/storage/drivers/in_tree.go
+++ b/test/e2e/storage/drivers/in_tree.go
@@ -1293,30 +1293,6 @@ func InitWindowsGcePdDriver() storageframework.TestDriver {
 	}
 }
 
-func InitWindowsVSphereDriver() storageframework.TestDriver {
-	return &vSphereDriver{
-		driverInfo: storageframework.DriverInfo{
-			Name:             "windows-vsphere",
-			InTreePluginName: "kubernetes.io/vsphere-volume",
-			MaxFileSize:      storageframework.FileSizeMedium,
-			SupportedSizeRange: e2evolume.SizeRange{
-				Min: "1Gi",
-			},
-			SupportedFsType: sets.NewString(
-				"ntfs",
-			),
-			TopologyKeys: []string{v1.LabelFailureDomainBetaZone},
-			Capabilities: map[storageframework.Capability]bool{
-				storageframework.CapPersistence: true,
-				storageframework.CapFsGroup:     true,
-				storageframework.CapExec:        true,
-				storageframework.CapMultiPODs:   true,
-				storageframework.CapTopology:    true,
-			},
-		},
-	}
-}
-
 func (g *gcePdDriver) GetDriverInfo() *storageframework.DriverInfo {
 	return &g.driverInfo
 }

--- a/test/e2e/storage/drivers/in_tree.go
+++ b/test/e2e/storage/drivers/in_tree.go
@@ -1293,6 +1293,30 @@ func InitWindowsGcePdDriver() storageframework.TestDriver {
 	}
 }
 
+func InitWindowsVSphereDriver() storageframework.TestDriver {
+	return &vSphereDriver{
+		driverInfo: storageframework.DriverInfo{
+			Name:             "windows-vsphere",
+			InTreePluginName: "kubernetes.io/vsphere-volume",
+			MaxFileSize:      storageframework.FileSizeMedium,
+			SupportedSizeRange: e2evolume.SizeRange{
+				Min: "1Gi",
+			},
+			SupportedFsType: sets.NewString(
+				"ntfs",
+			),
+			TopologyKeys: []string{v1.LabelFailureDomainBetaZone},
+			Capabilities: map[storageframework.Capability]bool{
+				storageframework.CapPersistence: true,
+				storageframework.CapFsGroup:     true,
+				storageframework.CapExec:        true,
+				storageframework.CapMultiPODs:   true,
+				storageframework.CapTopology:    true,
+			},
+		},
+	}
+}
+
 func (g *gcePdDriver) GetDriverInfo() *storageframework.DriverInfo {
 	return &g.driverInfo
 }
@@ -1416,6 +1440,7 @@ func InitVSphereDriver() storageframework.TestDriver {
 			SupportedFsType: sets.NewString(
 				"", // Default fsType
 				"ext4",
+				"ntfs",
 			),
 			TopologyKeys: []string{v1.LabelFailureDomainBetaZone},
 			Capabilities: map[storageframework.Capability]bool{

--- a/test/e2e/storage/in_tree_volumes.go
+++ b/test/e2e/storage/in_tree_volumes.go
@@ -38,7 +38,6 @@ var testDrivers = []func() storageframework.TestDriver{
 	drivers.InitGcePdDriver,
 	drivers.InitWindowsGcePdDriver,
 	drivers.InitVSphereDriver,
-	drivers.InitWindowsVSphereDriver,
 	drivers.InitAzureDiskDriver,
 	drivers.InitAwsDriver,
 	drivers.InitLocalDriverWithVolumeType(utils.LocalVolumeDirectory),

--- a/test/e2e/storage/in_tree_volumes.go
+++ b/test/e2e/storage/in_tree_volumes.go
@@ -38,6 +38,7 @@ var testDrivers = []func() storageframework.TestDriver{
 	drivers.InitGcePdDriver,
 	drivers.InitWindowsGcePdDriver,
 	drivers.InitVSphereDriver,
+	drivers.InitWindowsVSphereDriver,
 	drivers.InitAzureDiskDriver,
 	drivers.InitAwsDriver,
 	drivers.InitLocalDriverWithVolumeType(utils.LocalVolumeDirectory),


### PR DESCRIPTION
**What this PR does / why we need it**:

Add windows vsphere driver for running the e2e storage test. Also added ntfs to the existing vsphere driver for enabling the tests to run on windows.

```release-note
NONE
```
/kind feature /sig windows