### PR TITLE
Annotate objects with '=' in the name

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/annotate/annotate.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/annotate/annotate.go
@@ -206,7 +206,7 @@ func (o *AnnotateOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args [
 
 	// retrieves resource and annotation args from args
 	// also checks args to verify that all resources are specified before annotations
-	resources, annotationArgs, err := cmdutil.GetResourcesAndPairs(args, "annotation")
+	resources, annotationArgs, err := cmdutil.GetResourcesAndPairs(args, "annotation", o.all, o.Filenames)
 	if err != nil {
 		return err
 	}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/annotate/annotate_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/annotate/annotate_test.go
@@ -682,6 +682,8 @@ func TestAnnotateMultipleObjects(t *testing.T) {
 					return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, &pods.Items[0])}, nil
 				case "/namespaces/test/pods/bar":
 					return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, &pods.Items[1])}, nil
+				case "/namespaces/test/pods/foo=bar":
+					return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, &pods.Items[1])}, nil
 				default:
 					t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
 					return nil, nil

--- a/staging/src/k8s.io/kubectl/pkg/cmd/delete/delete_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/delete/delete_test.go
@@ -776,7 +776,7 @@ func TestDeleteMultipleSelector(t *testing.T) {
 	cmd.Flags().Set("output", "name")
 	cmd.Run(cmd, []string{"pods,services"})
 
-	if buf.String() != "pod/foo\npod/bar\nservice/baz\n" {
+	if buf.String() != "pod/foo\npod/bar\npod/foo=bar\nservice/baz\n" {
 		t.Errorf("unexpected output: %s", buf.String())
 	}
 }

--- a/staging/src/k8s.io/kubectl/pkg/cmd/describe/describe_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/describe/describe_test.go
@@ -159,7 +159,7 @@ func TestDescribeListObjects(t *testing.T) {
 
 	cmd := NewCmdDescribe("kubectl", tf, streams)
 	cmd.Run(cmd, []string{"pods"})
-	if buf.String() != fmt.Sprintf("%s\n\n%s", d.Output, d.Output) {
+	if buf.String() != fmt.Sprintf("%s\n\n%s\n\n%s", d.Output, d.Output, d.Output) {
 		t.Errorf("unexpected output: %s", buf.String())
 	}
 }

--- a/staging/src/k8s.io/kubectl/pkg/cmd/get/get_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/get/get_test.go
@@ -389,9 +389,10 @@ func TestGetMultipleResourceTypesShowKinds(t *testing.T) {
 	cmd.SetOutput(buf)
 	cmd.Run(cmd, []string{"all"})
 
-	expected := `NAME      AGE
-pod/foo   <unknown>
-pod/bar   <unknown>
+	expected := `NAME          AGE
+pod/foo       <unknown>
+pod/bar       <unknown>
+pod/foo=bar   <unknown>
 
 NAME          AGE
 service/baz   <unknown>
@@ -450,9 +451,10 @@ func TestGetMultipleTableResourceTypesShowKinds(t *testing.T) {
 	cmd.SetOutput(buf)
 	cmd.Run(cmd, []string{"all"})
 
-	expected := `NAME      READY   STATUS   RESTARTS   AGE
-pod/foo   0/0              0          <unknown>
-pod/bar   0/0              0          <unknown>
+	expected := `NAME          READY   STATUS   RESTARTS   AGE
+pod/foo       0/0              0          <unknown>
+pod/bar       0/0              0          <unknown>
+pod/foo=bar   0/0              0          <unknown>
 
 NAME          TYPE        CLUSTER-IP   EXTERNAL-IP   PORT(S)   AGE
 service/baz   ClusterIP   <none>       <none>        <none>    <unknown>
@@ -510,9 +512,10 @@ func TestNoBlankLinesForGetMultipleTableResource(t *testing.T) {
 	cmd := NewCmdGet("kubectl", tf, streams)
 	cmd.SetOutput(buf)
 
-	expected := `NAME      READY   STATUS   RESTARTS   AGE
-pod/foo   0/0              0          <unknown>
-pod/bar   0/0              0          <unknown>
+	expected := `NAME          READY   STATUS   RESTARTS   AGE
+pod/foo       0/0              0          <unknown>
+pod/bar       0/0              0          <unknown>
+pod/foo=bar   0/0              0          <unknown>
 
 NAME          TYPE        CLUSTER-IP   EXTERNAL-IP   PORT(S)   AGE
 service/baz   ClusterIP   <none>       <none>        <none>    <unknown>
@@ -1184,9 +1187,10 @@ func TestGetListObjects(t *testing.T) {
 	cmd.SetOutput(buf)
 	cmd.Run(cmd, []string{"pods"})
 
-	expected := `NAME   AGE
-foo    <unknown>
-bar    <unknown>
+	expected := `NAME      AGE
+foo       <unknown>
+bar       <unknown>
+foo=bar   <unknown>
 `
 	if e, a := expected, buf.String(); e != a {
 		t.Errorf("expected\n%v\ngot\n%v", e, a)
@@ -1210,9 +1214,10 @@ func TestGetListTableObjects(t *testing.T) {
 	cmd.SetOutput(buf)
 	cmd.Run(cmd, []string{"pods"})
 
-	expected := `NAME   READY   STATUS   RESTARTS   AGE
-foo    0/0              0          <unknown>
-bar    0/0              0          <unknown>
+	expected := `NAME      READY   STATUS   RESTARTS   AGE
+foo       0/0              0          <unknown>
+bar       0/0              0          <unknown>
+foo=bar   0/0              0          <unknown>
 `
 	if e, a := expected, buf.String(); e != a {
 		t.Errorf("expected\n%v\ngot\n%v", e, a)
@@ -1335,9 +1340,10 @@ func TestGetMultipleTypeObjects(t *testing.T) {
 	cmd.SetOutput(buf)
 	cmd.Run(cmd, []string{"pods,services"})
 
-	expected := `NAME      AGE
-pod/foo   <unknown>
-pod/bar   <unknown>
+	expected := `NAME          AGE
+pod/foo       <unknown>
+pod/bar       <unknown>
+pod/foo=bar   <unknown>
 
 NAME          AGE
 service/baz   <unknown>
@@ -1374,9 +1380,10 @@ func TestGetMultipleTypeTableObjects(t *testing.T) {
 	cmd.SetOutput(buf)
 	cmd.Run(cmd, []string{"pods,services"})
 
-	expected := `NAME      READY   STATUS   RESTARTS   AGE
-pod/foo   0/0              0          <unknown>
-pod/bar   0/0              0          <unknown>
+	expected := `NAME          READY   STATUS   RESTARTS   AGE
+pod/foo       0/0              0          <unknown>
+pod/bar       0/0              0          <unknown>
+pod/foo=bar   0/0              0          <unknown>
 
 NAME          TYPE        CLUSTER-IP   EXTERNAL-IP   PORT(S)   AGE
 service/baz   ClusterIP   <none>       <none>        <none>    <unknown>
@@ -1459,6 +1466,25 @@ func TestGetMultipleTypeObjectsAsList(t *testing.T) {
         },
         {
             "apiVersion": "v1",
+            "kind": "Pod",
+            "metadata": {
+                "creationTimestamp": null,
+                "name": "foo=bar",
+                "namespace": "test",
+                "resourceVersion": "10"
+            },
+            "spec": {
+                "containers": null,
+                "dnsPolicy": "ClusterFirst",
+                "enableServiceLinks": true,
+                "restartPolicy": "Always",
+                "securityContext": {},
+                "terminationGracePeriodSeconds": 30
+            },
+            "status": {}
+        },
+        {
+            "apiVersion": "v1",
             "kind": "Service",
             "metadata": {
                 "creationTimestamp": null,
@@ -1519,9 +1545,10 @@ func TestGetMultipleTypeObjectsWithLabelSelector(t *testing.T) {
 	cmd.Flags().Set("selector", "a=b")
 	cmd.Run(cmd, []string{"pods,services"})
 
-	expected := `NAME      AGE
-pod/foo   <unknown>
-pod/bar   <unknown>
+	expected := `NAME          AGE
+pod/foo       <unknown>
+pod/bar       <unknown>
+pod/foo=bar   <unknown>
 
 NAME          AGE
 service/baz   <unknown>
@@ -1563,9 +1590,10 @@ func TestGetMultipleTypeTableObjectsWithLabelSelector(t *testing.T) {
 	cmd.Flags().Set("selector", "a=b")
 	cmd.Run(cmd, []string{"pods,services"})
 
-	expected := `NAME      READY   STATUS   RESTARTS   AGE
-pod/foo   0/0              0          <unknown>
-pod/bar   0/0              0          <unknown>
+	expected := `NAME          READY   STATUS   RESTARTS   AGE
+pod/foo       0/0              0          <unknown>
+pod/bar       0/0              0          <unknown>
+pod/foo=bar   0/0              0          <unknown>
 
 NAME          TYPE        CLUSTER-IP   EXTERNAL-IP   PORT(S)   AGE
 service/baz   ClusterIP   <none>       <none>        <none>    <unknown>
@@ -1607,9 +1635,10 @@ func TestGetMultipleTypeObjectsWithFieldSelector(t *testing.T) {
 	cmd.Flags().Set("field-selector", "a=b")
 	cmd.Run(cmd, []string{"pods,services"})
 
-	expected := `NAME      AGE
-pod/foo   <unknown>
-pod/bar   <unknown>
+	expected := `NAME          AGE
+pod/foo       <unknown>
+pod/bar       <unknown>
+pod/foo=bar   <unknown>
 
 NAME          AGE
 service/baz   <unknown>
@@ -1651,9 +1680,10 @@ func TestGetMultipleTypeTableObjectsWithFieldSelector(t *testing.T) {
 	cmd.Flags().Set("field-selector", "a=b")
 	cmd.Run(cmd, []string{"pods,services"})
 
-	expected := `NAME      READY   STATUS   RESTARTS   AGE
-pod/foo   0/0              0          <unknown>
-pod/bar   0/0              0          <unknown>
+	expected := `NAME          READY   STATUS   RESTARTS   AGE
+pod/foo       0/0              0          <unknown>
+pod/bar       0/0              0          <unknown>
+pod/foo=bar   0/0              0          <unknown>
 
 NAME          TYPE        CLUSTER-IP   EXTERNAL-IP   PORT(S)   AGE
 service/baz   ClusterIP   <none>       <none>        <none>    <unknown>

--- a/staging/src/k8s.io/kubectl/pkg/cmd/label/label.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/label/label.go
@@ -187,7 +187,7 @@ func (o *LabelOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []st
 		return o.PrintFlags.ToPrinter()
 	}
 
-	resources, labelArgs, err := cmdutil.GetResourcesAndPairs(args, "label")
+	resources, labelArgs, err := cmdutil.GetResourcesAndPairs(args, "label", o.all, o.Filenames)
 	if err != nil {
 		return err
 	}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/label/label_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/label/label_test.go
@@ -308,16 +308,16 @@ func TestLabelErrors(t *testing.T) {
 			args:  []string{"pods=bar"},
 			errFn: func(err error) bool { return strings.Contains(err.Error(), "one or more resources must be specified") },
 		},
-		"resources but no selectors": {
+		"resource selected but not enough labels": {
 			args: []string{"pods", "app=bar"},
 			errFn: func(err error) bool {
-				return strings.Contains(err.Error(), "resource(s) were provided, but no name, label selector, or --all flag specified")
+				return strings.Contains(err.Error(), "at least one label update is required")
 			},
 		},
-		"multiple resources but no selectors": {
+		"multiple resources selected but no labels": {
 			args: []string{"pods,deployments", "app=bar"},
 			errFn: func(err error) bool {
-				return strings.Contains(err.Error(), "resource(s) were provided, but no name, label selector, or --all flag specified")
+				return strings.Contains(err.Error(), "at least one label update is required")
 			},
 		},
 	}
@@ -467,6 +467,8 @@ func TestLabelMultipleObjects(t *testing.T) {
 				case "/namespaces/test/pods/foo":
 					return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, &pods.Items[0])}, nil
 				case "/namespaces/test/pods/bar":
+					return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, &pods.Items[1])}, nil
+				case "/namespaces/test/pods/foo=bar":
 					return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, &pods.Items[1])}, nil
 				default:
 					t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)

--- a/staging/src/k8s.io/kubectl/pkg/cmd/set/set_image.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/set/set_image.go
@@ -170,7 +170,7 @@ func (o *SetImageOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args [
 		return err
 	}
 
-	o.Resources, o.ContainerImages, err = getResourcesAndImages(args)
+	o.Resources, o.ContainerImages, err = getResourcesAndImages(args, o.All, o.Filenames)
 	if err != nil {
 		return err
 	}
@@ -315,9 +315,9 @@ func setImage(containers []v1.Container, containerName string, image string) boo
 }
 
 // getResourcesAndImages retrieves resources and container name:images pair from given args
-func getResourcesAndImages(args []string) (resources []string, containerImages map[string]string, err error) {
+func getResourcesAndImages(args []string, allResources bool, fileNames []string) (resources []string, containerImages map[string]string, err error) {
 	pairType := "image"
-	resources, imageArgs, err := cmdutil.GetResourcesAndPairs(args, pairType)
+	resources, imageArgs, err := cmdutil.GetResourcesAndPairs(args, pairType, allResources, fileNames)
 	if err != nil {
 		return
 	}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/testing/util.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/testing/util.go
@@ -92,6 +92,16 @@ func TestData() (*corev1.PodList, *corev1.ServiceList, *corev1.ReplicationContro
 					EnableServiceLinks:            &enableServiceLinks,
 				},
 			},
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "foo=bar", Namespace: "test", ResourceVersion: "10"},
+				Spec: corev1.PodSpec{
+					RestartPolicy:                 corev1.RestartPolicyAlways,
+					DNSPolicy:                     corev1.DNSClusterFirst,
+					TerminationGracePeriodSeconds: &grace,
+					SecurityContext:               &corev1.PodSecurityContext{},
+					EnableServiceLinks:            &enableServiceLinks,
+				},
+			},
 		},
 	}
 	svc := &corev1.ServiceList{

--- a/staging/src/k8s.io/kubectl/pkg/cmd/util/helpers.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/util/helpers.go
@@ -588,11 +588,20 @@ func PrintFlagsWithDryRunStrategy(printFlags *genericclioptions.PrintFlags, dryR
 }
 
 // GetResourcesAndPairs retrieves resources and "KEY=VALUE or KEY-" pair args from given args
-func GetResourcesAndPairs(args []string, pairType string) (resources []string, pairArgs []string, err error) {
+func GetResourcesAndPairs(args []string, pairType string, allResources bool, fileNames []string) (resources []string, pairArgs []string, err error) {
 	foundPair := false
-	for _, s := range args {
+	for i, s := range args {
+		// if first arg contains '/' we consider as a '<resource>/<name>'
+		foundFirstResource := strings.Contains(s, "/") && i == 0 &&
+			!allResources && len(fileNames) == 0
+		// if first arg does not contain '/' and this is second argument
+		// we consider as a '<resource> <name>'
+		firstResource := i == 1 && !strings.Contains(args[0], "/") &&
+			!allResources && len(fileNames) == 0
 		nonResource := (strings.Contains(s, "=") && s[0] != '=') || (strings.HasSuffix(s, "-") && s != "-")
 		switch {
+		case foundFirstResource || firstResource:
+			resources = append(resources, s)
 		case !foundPair && nonResource:
 			foundPair = true
 			fallthrough


### PR DESCRIPTION
/kind bug

Fixes BZ#1917280

For example when we have a group name that contains '=' character:

`$ kubectl annotate group/foo=bar bar=foo`

This is tricky, because both arguments contains `=` they are considered to be annotations pairs:

```
foo=bar
bar=foo
```

And the resource we want to annotate is missing.

Hence the error message:
`one or more resources must be specified as <resource> <name> or <resource>/<name>`

With this patch I run some iteration using `resource/name` and `resource name` and it seems to have worked in all occasions on both.