### PR TITLE
feat(kubectl): adding --node-name option to top

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/top/top_pod.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/top/top_pod.go
@@ -22,7 +22,7 @@ import (
 	"fmt"
 	"time"
 
-	v1 "k8s.io/api/core/v1"
+	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/discovery"
@@ -83,7 +83,7 @@ var (
 		# Show metrics for the pods defined by label name=myLabel
 		kubectl top pod -l name=myLabel
 		
-		# Show pod metrics with more information (such as node name). Requires GET /pods access.
+		# Show pod metrics with more information (such as node name). Requires read access to Pods resource.
 		kubectl top pod -o wide`))
 )
 
@@ -214,10 +214,9 @@ func (o TopPodOptions) RunTopPod() error {
 	// check if user wants wide data, if so get pods to join metrics together
 	if o.Output == "wide" {
 		pods, err = getPods(o, selector)
-	}
-
-	if err != nil {
-		return err
+		if err != nil {
+			return err
+		}
 	}
 
 	return o.Printer.PrintPodMetrics(metrics.Items, o.PrintContainers, o.AllNamespaces, o.NoHeaders, o.SortBy, pods)
@@ -298,7 +297,7 @@ func getPods(o TopPodOptions, selector labels.Selector) (pods *v1.PodList, err e
 		LabelSelector: selector.String(),
 	})
 	if err != nil {
-		return pods, err
+		return nil, err
 	}
-	return pods, err
+	return pods, nil
 }

--- a/staging/src/k8s.io/kubectl/pkg/cmd/top/top_pod.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/top/top_pod.go
@@ -83,7 +83,7 @@ var (
 		# Show metrics for the pods defined by label name=myLabel
 		kubectl top pod -l name=myLabel
 		
-		# Show pod metrics with more information (such as node name)
+		# Show pod metrics with more information (such as node name). Requires GET /pods access.
 		kubectl top pod -o wide`))
 )
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/top/top_pod.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/top/top_pod.go
@@ -45,11 +45,11 @@ type TopPodOptions struct {
 	Namespace          string
 	Selector           string
 	SortBy             string
+	Output             string
 	AllNamespaces      bool
 	PrintContainers    bool
 	NoHeaders          bool
 	UseProtocolBuffers bool
-	NodeName           bool
 
 	PodClient       corev1client.PodsGetter
 	Printer         *metricsutil.TopCmdPrinter
@@ -83,8 +83,8 @@ var (
 		# Show metrics for the pods defined by label name=myLabel
 		kubectl top pod -l name=myLabel
 		
-		# Show NodeHame information alongside pod
-		kubectl top pod --node-name`))
+		# Show pod metrics with more information (such as node name)
+		kubectl top pod -o wide`))
 )
 
 func NewCmdTopPod(f cmdutil.Factory, o *TopPodOptions, streams genericclioptions.IOStreams) *cobra.Command {
@@ -109,6 +109,7 @@ func NewCmdTopPod(f cmdutil.Factory, o *TopPodOptions, streams genericclioptions
 	}
 	cmd.Flags().StringVarP(&o.Selector, "selector", "l", o.Selector, "Selector (label query) to filter on, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)")
 	cmd.Flags().StringVar(&o.SortBy, "sort-by", o.SortBy, "If non-empty, sort pods list using specified field. The field can be either 'cpu' or 'memory'.")
+	cmd.Flags().StringVarP(&o.Output, "output", "o", o.Output, "If present, print output with more information (such as node name)")
 	cmd.Flags().BoolVar(&o.PrintContainers, "containers", o.PrintContainers, "If present, print usage of containers within a pod.")
 	cmd.Flags().BoolVarP(&o.AllNamespaces, "all-namespaces", "A", o.AllNamespaces, "If present, list the requested object(s) across all namespaces. Namespace in current context is ignored even if specified with --namespace.")
 	cmd.Flags().BoolVar(&o.NoHeaders, "no-headers", o.NoHeaders, "If present, print output without headers.")
@@ -210,8 +211,8 @@ func (o TopPodOptions) RunTopPod() error {
 		}
 	}
 
-	// check if user wants host information. Get pods from core client to merge with results
-	if o.NodeName == true {
+	// check if user wants wide data, if so get pods to join metrics together
+	if o.Output == "wide" {
 		pods, err = getPods(o, selector)
 	}
 

--- a/staging/src/k8s.io/kubectl/pkg/metricsutil/metrics_printer.go
+++ b/staging/src/k8s.io/kubectl/pkg/metricsutil/metrics_printer.go
@@ -37,6 +37,7 @@ var (
 	NamespaceColumn = "NAMESPACE"
 	PodColumn       = "POD"
 	HostColumn      = "NODE"
+	IpColumn        = "IP"
 )
 
 type ResourceMetricsInfo struct {
@@ -203,6 +204,7 @@ func (printer *TopCmdPrinter) PrintPodMetrics(metrics []metricsapi.PodMetrics, p
 		}
 		if len(pods.Items) > 0 {
 			printValue(w, HostColumn)
+			printValue(w, IpColumn)
 		}
 		if printContainers {
 			printValue(w, PodColumn)
@@ -246,6 +248,7 @@ func printSinglePodMetrics(out io.Writer, m *metricsapi.PodMetrics, withNamespac
 	}
 	if podExists {
 		printValue(out, pod.Spec.NodeName)
+		printValue(out, pod.Status.HostIP)
 	}
 	printMetricsLine(out, &ResourceMetricsInfo{
 		Name:      m.Name,

--- a/staging/src/k8s.io/kubectl/pkg/metricsutil/metrics_printer.go
+++ b/staging/src/k8s.io/kubectl/pkg/metricsutil/metrics_printer.go
@@ -21,7 +21,7 @@ import (
 	"io"
 	"sort"
 
-	v1 "k8s.io/api/core/v1"
+	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/cli-runtime/pkg/printers"
 	metricsapi "k8s.io/metrics/pkg/apis/metrics"
@@ -215,12 +215,12 @@ func (printer *TopCmdPrinter) PrintPodMetrics(metrics []metricsapi.PodMetrics, p
 	sort.Sort(NewPodMetricsSorter(metrics, withNamespace, sortBy))
 	podMap := createPodMap(pods)
 	for _, m := range metrics {
-		pod, ok := podMap[m.Name]
+		pod := podMap[m.Name]
 		if printContainers {
 			sort.Sort(NewContainerMetricsSorter(m.Containers, sortBy))
-			printSinglePodContainerMetrics(w, &m, withNamespace, pod, ok)
+			printSinglePodContainerMetrics(w, &m, withNamespace, pod)
 		} else {
-			printSinglePodMetrics(w, &m, withNamespace, pod, ok)
+			printSinglePodMetrics(w, &m, withNamespace, pod)
 		}
 	}
 	return nil
@@ -241,12 +241,12 @@ func printColumnNames(out io.Writer, names []string) {
 	fmt.Fprint(out, "\n")
 }
 
-func printSinglePodMetrics(out io.Writer, m *metricsapi.PodMetrics, withNamespace bool, pod v1.Pod, podExists bool) {
+func printSinglePodMetrics(out io.Writer, m *metricsapi.PodMetrics, withNamespace bool, pod v1.Pod) {
 	podMetrics := getPodMetrics(m)
 	if withNamespace {
 		printValue(out, m.Namespace)
 	}
-	if podExists {
+	if pod != nil {
 		printValue(out, pod.Spec.NodeName)
 		printValue(out, pod.Status.HostIP)
 	}
@@ -257,12 +257,12 @@ func printSinglePodMetrics(out io.Writer, m *metricsapi.PodMetrics, withNamespac
 	})
 }
 
-func printSinglePodContainerMetrics(out io.Writer, m *metricsapi.PodMetrics, withNamespace bool, pod v1.Pod, podExists bool) {
+func printSinglePodContainerMetrics(out io.Writer, m *metricsapi.PodMetrics, withNamespace bool, pod v1.Pod) {
 	for _, c := range m.Containers {
 		if withNamespace {
 			printValue(out, m.Namespace)
 		}
-		if podExists {
+		if pod != nil {
 			printValue(out, pod.Spec.NodeName)
 			printValue(out, pod.Status.HostIP)
 		}

--- a/staging/src/k8s.io/kubectl/pkg/metricsutil/metrics_printer.go
+++ b/staging/src/k8s.io/kubectl/pkg/metricsutil/metrics_printer.go
@@ -37,7 +37,7 @@ var (
 	NamespaceColumn = "NAMESPACE"
 	PodColumn       = "POD"
 	HostColumn      = "NODE"
-	IpColumn        = "IP"
+	IpColumn        = "NODE_IP"
 )
 
 type ResourceMetricsInfo struct {

--- a/staging/src/k8s.io/kubectl/pkg/metricsutil/metrics_printer.go
+++ b/staging/src/k8s.io/kubectl/pkg/metricsutil/metrics_printer.go
@@ -21,7 +21,7 @@ import (
 	"io"
 	"sort"
 
-	v1 "k8s.io/api/core/v1"
+	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/cli-runtime/pkg/printers"
 	metricsapi "k8s.io/metrics/pkg/apis/metrics"

--- a/staging/src/k8s.io/kubectl/pkg/metricsutil/metrics_printer.go
+++ b/staging/src/k8s.io/kubectl/pkg/metricsutil/metrics_printer.go
@@ -264,6 +264,7 @@ func printSinglePodContainerMetrics(out io.Writer, m *metricsapi.PodMetrics, wit
 		}
 		if podExists {
 			printValue(out, pod.Spec.NodeName)
+			printValue(out, pod.Status.HostIP)
 		}
 		printValue(out, m.Name)
 		printMetricsLine(out, &ResourceMetricsInfo{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

Adds an option to kubectl top pod, which prints out hostIP information alongside pod information:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #97859

**Special notes for your reviewer**:
Here is an example of how this could be done. At first I wanted to get the extra pod information from the metrics api, but that was a little more involved than just making 1 extra call to get the pods if the option is set. Overall this does what I intended. It could be a little better. we could have it work with the sort option if we wanted. Could also allow for other pod status data if we wanted as well. But overall hostIP was the most important field that was needed when topping pods.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
## print host ip information alongside pod data when running top
kubectl top pods --wide

```