### PR TITLE
Fix nil pointer dereference in disruption controller

### DIFF
--- a/pkg/controller/disruption/disruption.go
+++ b/pkg/controller/disruption/disruption.go
@@ -470,11 +470,11 @@ func (dc *DisruptionController) getPdbForPod(pod *v1.Pod) *policy.PodDisruptionB
 // IMPORTANT NOTE : the returned pods should NOT be modified.
 func (dc *DisruptionController) getPodsForPdb(pdb *policy.PodDisruptionBudget) ([]*v1.Pod, error) {
 	sel, err := metav1.LabelSelectorAsSelector(pdb.Spec.Selector)
-	if sel.Empty() {
-		return []*v1.Pod{}, nil
-	}
 	if err != nil {
 		return []*v1.Pod{}, err
+	}
+	if sel.Empty() {
+		return []*v1.Pod{}, nil
 	}
 	pods, err := dc.podLister.Pods(pdb.Namespace).List(sel)
 	if err != nil {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Fixes problem where invalid selector on PDBs leads to a nil pointer dereference that causes the controller-manager to crash-loop.

**Which issue(s) this PR fixes**:
Fixes #98702

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
Fixes a panic in the disruption budget controller for PDB objects with invalid selectors
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs

```

/sig apps
@kubernetes/sig-apps-pr-reviews 