### PR TITLE
Relax csiNodeIDMaxLength to longer limit

### DIFF
--- a/pkg/controller/volume/persistentvolume/pv_controller_base.go
+++ b/pkg/controller/volume/persistentvolume/pv_controller_base.go
@@ -365,7 +365,7 @@ func (ctrl *PersistentVolumeController) updateVolumeMigrationAnnotations(volume 
 
 // updateMigrationAnnotations takes an Annotations map and checks for a
 // provisioner name using the provisionerKey. It will then add a
-// "volume.beta.kubernetes.io/migrated-to" annotation if migration with the CSI
+// "pv.kubernetes.io/migrated-to" annotation if migration with the CSI
 // driver name for that provisioner is "on" based on feature flags, it will also
 // remove the annotation is migration is "off" for that provisioner in rollback
 // scenarios. Returns true if the annotations map was modified and false otherwise.

--- a/pkg/registry/storage/csinode/strategy.go
+++ b/pkg/registry/storage/csinode/strategy.go
@@ -48,8 +48,13 @@ func (csiNodeStrategy) PrepareForCreate(ctx context.Context, obj runtime.Object)
 func (csiNodeStrategy) Validate(ctx context.Context, obj runtime.Object) field.ErrorList {
 	csiNode := obj.(*storage.CSINode)
 
-	errs := validation.ValidateCSINode(csiNode)
-	errs = append(errs, validation.ValidateCSINode(csiNode)...)
+	// in 1.21, on create, set AllowLongNodeID=false
+	// in 1.22, on create, set AllowLongNodeID=true
+	validateOptions := validation.CSINodeValidationOptions{
+		AllowLongNodeID: false,
+	}
+
+	errs := validation.ValidateCSINode(csiNode, validateOptions)
 
 	return errs
 }
@@ -69,8 +74,20 @@ func (csiNodeStrategy) PrepareForUpdate(ctx context.Context, obj, old runtime.Ob
 func (csiNodeStrategy) ValidateUpdate(ctx context.Context, obj, old runtime.Object) field.ErrorList {
 	newCSINodeObj := obj.(*storage.CSINode)
 	oldCSINodeObj := old.(*storage.CSINode)
-	errorList := validation.ValidateCSINode(newCSINodeObj)
-	return append(errorList, validation.ValidateCSINodeUpdate(newCSINodeObj, oldCSINodeObj)...)
+	// in 1.21 on update, set AllowLongNodeID to true only if the old object already has a long node ID
+	// in 1.22 on update, set AllowLongNodeID=true
+	allowLongNodeID := false
+	for _, nodeDriver := range oldCSINodeObj.Spec.Drivers {
+		if validation.CSINodeLongerID(nodeDriver.NodeID) {
+			allowLongNodeID = true
+		}
+	}
+	validateOptions := validation.CSINodeValidationOptions{
+		AllowLongNodeID: allowLongNodeID,
+	}
+
+	errorList := validation.ValidateCSINode(newCSINodeObj, validateOptions)
+	return append(errorList, validation.ValidateCSINodeUpdate(newCSINodeObj, oldCSINodeObj, validateOptions)...)
 }
 
 func (csiNodeStrategy) AllowUnconditionalUpdate() bool {


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup


**What this PR does / why we need it**:
With CSI spec change in https://github.com/container-storage-interface/spec/pull/464, the length for CSI node id can be extended to 192 bytes. This can unblock users that have a longer csi node id in their CSI driver.

For backwards compatibility, we will break this down to two release. This release we will prepare for the next release change on the actual limits.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Prepare to increased CSINodeIDMaxLength from 128  bytes to 192 bytes in 1.22.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/sig storage
/assign @saad-ali 

