### PR TITLE
networking nodeipam UT: set node poll interval to 1s in UT

### DIFF
--- a/pkg/controller/nodeipam/ipam/cidr_allocator.go
+++ b/pkg/controller/nodeipam/ipam/cidr_allocator.go
@@ -76,6 +76,10 @@ const (
 	updateMaxRetries = 10
 )
 
+// nodePollInterval is used in listing node
+// This is a variable instead of a const to enable testing.
+var nodePollInterval = 10 * time.Second
+
 // CIDRAllocator is an interface implemented by things that know how
 // to allocate/occupy/recycle CIDR for nodes.
 type CIDRAllocator interface {
@@ -123,7 +127,7 @@ func listNodes(kubeClient clientset.Interface) (*v1.NodeList, error) {
 	var nodeList *v1.NodeList
 	// We must poll because apiserver might not be up. This error causes
 	// controller manager to restart.
-	if pollErr := wait.Poll(10*time.Second, apiserverStartupGracePeriod, func() (bool, error) {
+	if pollErr := wait.Poll(nodePollInterval, apiserverStartupGracePeriod, func() (bool, error) {
 		var err error
 		nodeList, err = kubeClient.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{
 			FieldSelector: fields.Everything().String(),

--- a/pkg/controller/nodeipam/ipam/range_allocator_test.go
+++ b/pkg/controller/nodeipam/ipam/range_allocator_test.go
@@ -32,9 +32,7 @@ import (
 	"k8s.io/kubernetes/pkg/controller/testutil"
 )
 
-const (
-	nodePollInterval = 100 * time.Millisecond
-)
+const testNodePollInterval = 10 * time.Millisecond
 
 var alwaysReady = func() bool { return true }
 
@@ -320,6 +318,13 @@ func TestOccupyPreExistingCIDR(t *testing.T) {
 }
 
 func TestAllocateOrOccupyCIDRSuccess(t *testing.T) {
+	// Non-parallel test (overrides global var)
+	oldNodePollInterval := nodePollInterval
+	nodePollInterval = testNodePollInterval
+	defer func() {
+		nodePollInterval = oldNodePollInterval
+	}()
+
 	// all tests operate on a single node
 	testCases := []testCase{
 		{
@@ -700,6 +705,13 @@ type releaseTestCase struct {
 }
 
 func TestReleaseCIDRSuccess(t *testing.T) {
+	// Non-parallel test (overrides global var)
+	oldNodePollInterval := nodePollInterval
+	nodePollInterval = testNodePollInterval
+	defer func() {
+		nodePollInterval = oldNodePollInterval
+	}()
+
 	testCases := []releaseTestCase{
 		{
 			description: "Correctly release preallocated CIDR",


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
/kind flake

**What this PR does / why we need it**:
111.43s -> 3~5s
- k8s.io/kubernetes/pkg/controller/nodeipam 112.441s
IPAM node list function uses 10s interval to get node list during intialization.

**Which issue(s) this PR fixes**:
Part of  #98486

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
None
```