### PR TITLE
legacy-cloud-providers/azure: Minor language fixes in test cases

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_instances_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_instances_test.go
@@ -698,7 +698,7 @@ func TestInstanceExistsByProviderID(t *testing.T) {
 			expected:   true,
 		},
 		{
-			name:       "InstanceExistsByProviderID should return false if VMSS exist but VM doesn't",
+			name:       "InstanceExistsByProviderID should return false if VMSS exists but the VM doesn't",
 			providerID: "azure:///subscriptions/script/resourceGroups/rg/providers/Microsoft.Compute/virtualMachineScaleSets/vmssee6c2/virtualMachines/0",
 			scaleSet:   "vmssee6c2",
 			expected:   false,

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/retry/azure_error.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/retry/azure_error.go
@@ -89,7 +89,7 @@ func (err *Error) IsThrottled() bool {
 	return err.HTTPStatusCode == http.StatusTooManyRequests || err.RetryAfter.After(now())
 }
 
-// IsNotFound returns true the if the requested object wasn't found
+// IsNotFound returns true if the requested object wasn't found
 func (err *Error) IsNotFound() bool {
 	if err == nil {
 		return false


### PR DESCRIPTION
What type of PR is this?
/kind cleanup

What this PR does / why we need it:
fix comments spelling error in #95305

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```
Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```release-note
None
```