### PR TITLE
Event recording no longer panics on stopped broadcaster.

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/watch/mux_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/watch/mux_test.go
@@ -223,4 +223,16 @@ func TestBroadcasterWatchAfterShutdown(t *testing.T) {
 		m.Action(event1.Type, event1.Object)
 	}
 	action()
+
+	actionOrDrop := func() {
+		defer func() {
+			if err := recover(); err != nil {
+				t.Error("should not cause panic")
+			}
+		}()
+		if m.ActionOrDrop(event1.Type, event1.Object) {
+			t.Error("should return false on closed channel")
+		}
+	}
+	actionOrDrop()
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
/sig api-machinery

**What this PR does / why we need it**:

If `ActionOrDrop` is called on a stopped Event broadcaster a panic would occur as data would be send to a closed channel.

In some controllers, developers [might not control of the lifecycle][1] of the `Broadcaster`, resulting in runtime panics.

[1]: https://github.com/kubernetes-sigs/controller-runtime/issues/1367#issuecomment-772626132

**Which issue(s) this PR fixes**:

Related PR #95664
Related issue https://github.com/kubernetes-sigs/controller-runtime/issues/1367

**Special notes for your reviewer**:

In general, I think that the entire `Broadcaster` should be reworked and accept `context.Context` as a first argument to `Action`, `ActionOrDrop`, `WatchWithPrefix`, `Watch`. This would allow for context cancellation to be passed when creating the event:

```go
recorder.Event(ctx, someObject, "Warning", "some reason", "some message")
```

 This would cause lots of changes in the entire K8S code-base, but I can also go for that approach.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
client-go's EventBroadcaster event recording no longer panics if `Shutdown()` has already been called.
```

/cc @DirectXMan12 

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```