### PR TITLE
kubectl lint: generate errors if kubernetes best practises are not followed

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/cmd.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/cmd.go
@@ -54,6 +54,7 @@ import (
 	"k8s.io/kubectl/pkg/cmd/expose"
 	"k8s.io/kubectl/pkg/cmd/get"
 	"k8s.io/kubectl/pkg/cmd/label"
+	"k8s.io/kubectl/pkg/cmd/lint"
 	"k8s.io/kubectl/pkg/cmd/logs"
 	"k8s.io/kubectl/pkg/cmd/options"
 	"k8s.io/kubectl/pkg/cmd/patch"
@@ -521,6 +522,7 @@ func NewKubectlCommand(in io.Reader, out, err io.Writer) *cobra.Command {
 				get.NewCmdGet("kubectl", f, ioStreams),
 				edit.NewCmdEdit(f, ioStreams),
 				delete.NewCmdDelete(f, ioStreams),
+				lint.NewCmdLint(f, ioStreams),
 			},
 		},
 		{

--- a/staging/src/k8s.io/kubectl/pkg/cmd/lint/example_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/lint/example_test.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package lint
+
+import (
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	cmdtesting "k8s.io/kubectl/pkg/cmd/testing"
+)
+
+func ExampleNewCmdLint() {
+	tf := cmdtesting.NewTestFactory()
+	defer tf.Cleanup()
+	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
+	cmd := NewCmdLint(tf, streams)
+	err := cmd.Flags().Set("filename", "./testdata/container_running_as_root")
+	checkErr(err)
+	cmd.SetOutput(buf)
+	err = cmd.RunE(cmd, nil)
+	checkErr(err)
+	// testdata/container_running_as_root/pod1.yaml: Pod/myapp2/container nginx is running as root
+	// Error: resources had linting errors
+	// exit status 1
+}
+
+func checkErr(e error) {
+	if e != nil {
+		panic(e)
+	}
+}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/lint/lint.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/lint/lint.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package lint
+
+import (
+	"github.com/spf13/cobra"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/resource"
+	"k8s.io/client-go/dynamic"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+	"k8s.io/kubectl/pkg/lint"
+	"k8s.io/kubectl/pkg/util/i18n"
+)
+
+//LintOptions options for lint subcommand
+type LintOptions struct {
+	FileNameOpts resource.FilenameOptions
+
+	RecordFlags *genericclioptions.RecordFlags
+	Recorder    genericclioptions.Recorder
+
+	DynamicClient dynamic.Interface
+	Mapper        meta.RESTMapper
+	Result        *resource.Result
+
+	genericclioptions.IOStreams
+}
+
+//NewLintOptions constructor to type LintOptions
+func NewLintOptions(streams genericclioptions.IOStreams) *LintOptions {
+	return &LintOptions{
+		FileNameOpts: resource.FilenameOptions{},
+		RecordFlags:  genericclioptions.NewRecordFlags(),
+		Recorder:     genericclioptions.NoopRecorder{},
+		IOStreams:    streams,
+	}
+}
+
+//NewCmdLint builds cobra command
+func NewCmdLint(f cmdutil.Factory, streams genericclioptions.IOStreams) *cobra.Command {
+	o := NewLintOptions(streams)
+	c := &lint.Cmd{Factory: f, FileNameOptions: &o.FileNameOpts, IOStreams: streams}
+	cmd := &cobra.Command{
+		Use:                   "lint [-f FILENAME] [-k DIRECTORY]",
+		DisableFlagsInUseLine: true,
+		Short:                 i18n.T("Lint resource configuration files."),
+		Long: i18n.T(`
+Look for common issues with resource configuration.  Emit an error message if kubernetes best practices not followed and exit non-0.
+`),
+		Example: i18n.T(`# lint example.yaml and exit non-0 if issues found.
+kubectl lint -f example.yaml
+`),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return c.Run()
+		},
+	}
+	o.RecordFlags.AddFlags(cmd)
+	cmdutil.AddFilenameOptionFlags(cmd, &o.FileNameOpts, "full path to Kubernetes manifests (.yaml) to lint")
+	return cmd
+}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/lint/lint_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/lint/lint_test.go
@@ -1,0 +1,87 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package lint
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	cmdtesting "k8s.io/kubectl/pkg/cmd/testing"
+)
+
+func TestNewCmdLint(t *testing.T) {
+	var resources []string
+	var testnames []string
+	err := filepath.Walk("./testdata", func(path string, info os.FileInfo, err error) error {
+		if info.Name() == "test.results" {
+			path = filepath.Dir(path)
+			resources = append(resources, path)
+			testnames = append(testnames, filepath.Base(path))
+		}
+		return nil
+	})
+	require.NoError(t, err)
+	for i := 0; i < len(resources); i++ {
+		t.Run(testnames[i], func(t *testing.T) {
+			evalTestResults(resources[i], t)
+		})
+	}
+}
+
+func run(filename, want string, t *testing.T) string {
+	tf := cmdtesting.NewTestFactory()
+	defer tf.Cleanup()
+	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
+	cmd := NewCmdLint(tf, streams)
+
+	err := cmd.Flags().Set("filename", filename)
+	require.NoError(t, err)
+	cmd.SetOutput(buf)
+
+	if len(want) > 0 {
+		require.Error(t, cmd.RunE(cmd, nil))
+	} else {
+		require.NoError(t, cmd.RunE(cmd, nil))
+	}
+	fmt.Println(strings.TrimSpace(buf.String()))
+	return strings.TrimSpace(buf.String())
+}
+
+func evalTestResults(path string, t *testing.T) {
+	var want string
+	var testFilePath, testResultPath string
+	err := filepath.Walk(path, func(path string, info os.FileInfo, err error) error {
+		switch filepath.Ext(path) {
+		case ".yaml":
+			testFilePath = path
+		case ".results":
+			testResultPath = path
+		}
+		return nil
+	})
+	require.NoError(t, err)
+	b, err := ioutil.ReadFile(testResultPath)
+	require.NoError(t, err)
+	want = strings.TrimSpace(string(b))
+	require.Equal(t, run(testFilePath, want, t), want)
+}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/lint/testdata/container_running_as_root/pod1.yaml
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/lint/testdata/container_running_as_root/pod1.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: myapp2
+spec:
+  containers:
+  - name: nginx
+    image: <Image>
+    resources:
+      limits:
+        memory: "128Mi"
+        cpu: "500m"
+    ports:
+    - containerPort: 80
+    securityContext:
+      runAsUser: 0

--- a/staging/src/k8s.io/kubectl/pkg/cmd/lint/testdata/container_running_as_root/test.results
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/lint/testdata/container_running_as_root/test.results
@@ -1,0 +1,1 @@
+testdata/container_running_as_root/pod1.yaml: Pod/myapp2/container nginx is running as root

--- a/staging/src/k8s.io/kubectl/pkg/cmd/lint/testdata/deployment_running_as_root/deployment2.yaml
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/lint/testdata/deployment_running_as_root/deployment2.yaml
@@ -1,0 +1,22 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: mydeployment
+  name: mydeployment
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: mydeployment
+  strategy: {}
+  template:
+    metadata:
+      labels:
+        app: mydeployment
+    spec:
+      securityContext:
+        runAsUser: 0
+      containers:
+      - image: myimage
+        name: myimage

--- a/staging/src/k8s.io/kubectl/pkg/cmd/lint/testdata/deployment_running_as_root/test.results
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/lint/testdata/deployment_running_as_root/test.results
@@ -1,0 +1,1 @@
+testdata/deployment_running_as_root/deployment2.yaml: Deployment mydeployment is running as root

--- a/staging/src/k8s.io/kubectl/pkg/cmd/lint/testdata/no_resources_running_as_root/containerrunas1000.yaml
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/lint/testdata/no_resources_running_as_root/containerrunas1000.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: myapp2
+spec:
+  containers:
+  - name: nginx
+    image: <Image>
+    resources:
+      limits:
+        memory: "128Mi"
+        cpu: "500m"
+    ports:
+    - containerPort: 80
+    securityContext:
+      runAsUser: 1000

--- a/staging/src/k8s.io/kubectl/pkg/cmd/lint/testdata/no_resources_running_as_root/deploymentrunas1000.yaml
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/lint/testdata/no_resources_running_as_root/deploymentrunas1000.yaml
@@ -1,0 +1,22 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: mydeployment
+  name: mydeployment
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: mydeployment
+  strategy: {}
+  template:
+    metadata:
+      labels:
+        app: mydeployment
+    spec:
+      securityContext:
+        runAsUser: 1000
+      containers:
+      - image: myimage
+        name: myimage

--- a/staging/src/k8s.io/kubectl/pkg/cmd/lint/testdata/no_resources_running_as_root/nosecuritycontextdefined.yaml
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/lint/testdata/no_resources_running_as_root/nosecuritycontextdefined.yaml
@@ -1,0 +1,20 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: mydeployment
+  name: mydeployment
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: mydeployment
+  strategy: {}
+  template:
+    metadata:
+      labels:
+        app: mydeployment
+    spec:
+      containers:
+      - image: myimage
+        name: myimage

--- a/staging/src/k8s.io/kubectl/pkg/cmd/lint/testdata/pod_running_as_root/pod2.yaml
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/lint/testdata/pod_running_as_root/pod2.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: myapp2
+spec:
+  securityContext:
+    runAsUser: 0
+  containers:
+  - name: nginx
+    image: <Image>
+    resources:
+      limits:
+        memory: "128Mi"
+        cpu: "500m"
+    ports:
+    - containerPort: 80

--- a/staging/src/k8s.io/kubectl/pkg/cmd/lint/testdata/pod_running_as_root/test.results
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/lint/testdata/pod_running_as_root/test.results
@@ -1,0 +1,1 @@
+testdata/pod_running_as_root/pod2.yaml: Pod myapp2 is running as root

--- a/staging/src/k8s.io/kubectl/pkg/lint/lint.go
+++ b/staging/src/k8s.io/kubectl/pkg/lint/lint.go
@@ -1,0 +1,185 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package lint checks Kubernetes resource configuration for common errors.
+package lint
+
+import (
+	"fmt"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/resource"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+)
+
+// Cmd command layout
+type Cmd struct {
+	Factory         cmdutil.Factory
+	FileNameOptions *resource.FilenameOptions
+	genericclioptions.IOStreams
+}
+
+// Linter interface for all Lint Operations
+type Linter interface {
+	Lint([]*resource.Info) (bool, error)
+}
+
+// SecurityContextLinter config for securitycontext linter
+type SecurityContextLinter struct {
+	Cmd
+}
+
+var _ Linter = SecurityContextLinter{}
+
+func (c *Cmd) getLinters() []Linter {
+	return []Linter{
+		SecurityContextLinter{Cmd: *c},
+	}
+}
+
+// Run read and process Lint command args
+func (c *Cmd) Run() error {
+	var err error
+	r := c.Factory.NewBuilder().
+		Unstructured().
+		FilenameParam(false, c.FileNameOptions).
+		ContinueOnError().
+		Flatten().
+		Do()
+	err = r.Err()
+	if err != nil {
+		return err
+	}
+	items, err := r.Infos()
+	if err != nil {
+		return err
+	}
+
+	passed := true
+	for _, l := range c.getLinters() {
+		result, err := l.Lint(items)
+		if err != nil {
+			return err
+		}
+		passed = passed && result
+	}
+	if !passed {
+		return fmt.Errorf("resources had linting errors")
+	}
+	return nil
+}
+
+//Lint Linter based upon SecurityContext
+func (c SecurityContextLinter) Lint(items []*resource.Info) (bool, error) {
+	passed := true
+	for i := range items {
+		u := items[i].Object.(*unstructured.Unstructured)
+		unit := u.GetKind()
+		if unit == "Pod" {
+			pods, _, err := unstructured.NestedFieldCopy(u.Object, "spec") //Pod security context
+			if err != nil {
+				return false, err
+			}
+			result := checkPodSecurityContext(pods, unit, u.GetName())
+			if result != "" {
+				fmt.Fprintf(c.Out, "%v: %v\n", items[i].Source, result)
+				passed = false
+			}
+
+			containers, _, err := unstructured.NestedSlice(u.Object, "spec", "containers") //containers security context
+			if err != nil {
+				return false, err
+			}
+			result = checkContainerSecurityContext(containers, unit, u.GetName())
+			if result != "" {
+				fmt.Fprintf(c.Out, "%v: %v\n", items[i].Source, result)
+				passed = false
+			}
+		} else {
+			pods, _, err := unstructured.NestedFieldCopy(u.Object, "spec", "template", "spec") //Pod security context for Deployment, DaemonSet etc.
+			if err != nil {
+				return false, err
+			}
+			result := checkPodSecurityContext(pods, unit, u.GetName())
+			if result != "" {
+				fmt.Fprintf(c.Out, "%v: %v\n", items[i].Source, result)
+				passed = false
+			}
+			containers, _, err := unstructured.NestedSlice(u.Object, "spec", "template", "spec", "containers") //containers security context ina pod for Deployment, DaemonSet etc.
+			if err != nil {
+				return false, err
+			}
+			result = checkContainerSecurityContext(containers, unit, u.GetName())
+			if result != "" {
+				fmt.Fprintf(c.Out, "%v: %v\n", items[i].Source, result)
+				passed = false
+			}
+		}
+	}
+	return passed, nil
+}
+
+func isRunningAsRoot(runAsUser interface{}, unit, name string) string {
+	var linterWarning string
+	switch runAsUser := runAsUser.(type) {
+	case int64:
+		isRoot := runAsUser
+		if isRoot == 0 {
+			linterWarning = unit + " " + name + " is running as root"
+		}
+	case int32:
+		isRoot := runAsUser
+		if isRoot == 0 {
+			linterWarning = unit + " " + name + " is running as root"
+		}
+	case int:
+		isRoot := runAsUser
+		if isRoot == 0 {
+			linterWarning = unit + " " + name + " is running as root"
+		}
+	}
+	return strings.TrimSpace(linterWarning)
+}
+
+func checkPodSecurityContext(pods interface{}, unit, name string) string {
+	if pods.(map[string]interface{})["securityContext"] != nil {
+		securityContext, ok := pods.(map[string]interface{})["securityContext"]
+		if ok {
+			runAsUser, ok := securityContext.(map[string]interface{})["runAsUser"]
+			if ok {
+				return isRunningAsRoot(runAsUser, unit, name)
+			}
+		}
+	}
+	return ""
+}
+
+func checkContainerSecurityContext(containers []interface{}, unit, name string) string {
+	for _, elem := range containers {
+		securityContext, ok := elem.(map[string]interface{})["securityContext"]
+		if ok {
+			runAsUser, ok := securityContext.(map[string]interface{})["runAsUser"]
+			if ok {
+				containerName := elem.(map[string]interface{})["name"]
+				item := unit + "/" + name + "/container"
+				return isRunningAsRoot(runAsUser, item, containerName.(string))
+			}
+		}
+	}
+	return ""
+}

--- a/staging/src/k8s.io/kubectl/pkg/lint/lint_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/lint/lint_test.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package lint
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsRunningAsRoot(t *testing.T) {
+	tests := []struct {
+		runAsUser   interface{}
+		unit        string
+		name        string
+		want        string
+		description string
+	}{
+		{0, "Pod", "fakepod", "Pod fakepod is running as root", "pod_runnning_as_root"},
+		{0, "Pod/fakepod/container", "fakecontainer", "Pod/fakepod/container fakecontainer is running as root", "container_running_as_root"},
+		{1000, "", "", "", "no_resources_running_as_root"},
+	}
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			got := isRunningAsRoot(test.runAsUser, test.unit, test.name)
+			require.Equal(t, test.want, got)
+		})
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
This PR adds a subcommand `lint` to `kubectl`.  Currently `kubectl lint` only generates the errors if any pods or containers are running as `root`. Although going forward this would become a goto linter to run against Kubernetes manifests. 

- Discussed in [#sig-cli meeting 16 Dec 2020 ](https://docs.google.com/document/d/1r0YElcXt6G5mOWxwZiXgGu_X6he3F--wKwg-9UBc29I/edit#)

**Which issue(s) this PR fixes**:
[This Issue](https://github.com/kubernetes/enhancements/pull/2168)
![kubectl-lint-upstream](https://user-images.githubusercontent.com/36038036/106905931-956e0180-66f4-11eb-9d4a-188c812bb496.png)

```release-note
Add a subcommand lint to kubectl.  As of now, kubectl lint only generates the errors if any pods or containers are running as root. 
Example:
➜ kubectl lint -f /Users/sulabh/.test
/Users/sulabh/.test/.test-2.yaml: Deployment mydeployment is running as root
/Users/sulabh/.test/.test.yaml: Deployment/mydeployment/container myimage is running as root
Error: resources had linting errors
exit status 1 
```
