### PR TITLE
Use FQDN for SERVICEACCOUNT_ISSUER in tests

### DIFF
--- a/cluster/gce/config-test.sh
+++ b/cluster/gce/config-test.sh
@@ -556,9 +556,14 @@ ROTATE_CERTIFICATES=${ROTATE_CERTIFICATES:-}
 # into kube-controller-manager via `--concurrent-service-syncs`
 CONCURRENT_SERVICE_SYNCS=${CONCURRENT_SERVICE_SYNCS:-}
 
-# The value kubernetes.default.svc is only usable in Pods and should only be
-# set for tests. DO NOT COPY THIS VALUE FOR PRODUCTION CLUSTERS.
-export SERVICEACCOUNT_ISSUER='https://kubernetes.default.svc'
+# The value kubernetes.default.svc.cluster.local is only usable for full
+# OIDC discovery flows in Pods in the same cluster. For some providers
+# with configurations that support non-traditional KSA authentication methods,
+# this value may make sense, but if the expectation is traditional OIDC, don't
+# use this value in production. If you do use it, the FQDN is preferred to
+# kubernetes.default.svc, to avoid something outside the cluster attempting
+# to resolve the partially qualified name.
+export SERVICEACCOUNT_ISSUER='https://kubernetes.default.svc.cluster.local'
 
 # Optional: Enable Node termination Handler for Preemptible and GPU VMs.
 # https://github.com/GoogleCloudPlatform/k8s-node-termination-handler
@@ -596,6 +601,6 @@ export ETCD_PROGRESS_NOTIFY_INTERVAL="${ETCD_PROGRESS_NOTIFY_INTERVAL:-10m}"
 # unzipping the image layers to disk.
 export WINDOWS_ENABLE_PIGZ="${WINDOWS_ENABLE_PIGZ:-true}"
 
-# TLS_CIPHER_SUITES defines cipher suites allowed to be used by kube-apiserver. 
+# TLS_CIPHER_SUITES defines cipher suites allowed to be used by kube-apiserver.
 # If this variable is unset or empty, kube-apiserver will allow its default set of cipher suites.
 export TLS_CIPHER_SUITES=""


### PR DESCRIPTION
**What type of PR is this?**

/kind feature


**What this PR does / why we need it**:

Changes the issuer URL to a FQDN to reduce ambiguity. Updates comment to reflect reasons you might actually set this value in production.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/assign @liggitt 
/priority important-soon
/sig auth

