### PR TITLE
Optimize and parallelize LoadBalancer Host update

### DIFF
--- a/staging/src/k8s.io/cloud-provider/fake/fake.go
+++ b/staging/src/k8s.io/cloud-provider/fake/fake.go
@@ -224,6 +224,8 @@ func (f *Cloud) EnsureLoadBalancer(ctx context.Context, clusterName string, serv
 // It adds an entry "update" into the internal method call record.
 func (f *Cloud) UpdateLoadBalancer(ctx context.Context, clusterName string, service *v1.Service, nodes []*v1.Node) error {
 	f.addCall("update")
+	f.Lock.Lock()
+	defer f.Lock.Unlock()
 	f.UpdateCalls = append(f.UpdateCalls, UpdateBalancerCall{service, nodes})
 	return f.Err
 }


### PR DESCRIPTION
This PR optimized load balancer hosts handling in service controller. It fixes the potential memory leak due to the slow serialized processing of services on node updates. This PR also allow the `--concurrent-service-syncs` to control the number of worker threads to update load balancer hosts. This is to improve performance of the service controller when clusters has many load balancer type services and cluster nodes undergo significant churn. When the `--concurrent-service-syncs==1`, which is the default, the behavior stayed the same as the existing logic. 

**Which issue(s) this PR fixes**:
Fixes #

/kind bug

```release-note
NONE
```

