### PR TITLE
skip checking nodeport on external addrs in conformance tests

### DIFF
--- a/test/e2e/network/service.go
+++ b/test/e2e/network/service.go
@@ -914,6 +914,7 @@ var _ = common.SIGDescribe("Services", func() {
 
 		ginkgo.By("creating a TCP service " + serviceName + " with type=ClusterIP in namespace " + ns)
 		jig := e2eservice.NewTestJig(cs, ns, serviceName)
+		jig.ExternalIPs = true
 		servicePort := 8080
 		tcpService, err := jig.CreateTCPServiceWithPort(nil, int32(servicePort))
 		framework.ExpectNoError(err)
@@ -983,6 +984,7 @@ var _ = common.SIGDescribe("Services", func() {
 
 		ginkgo.By("creating a TCP service " + serviceName + " with type=ClusterIP in namespace " + ns)
 		jig := e2eservice.NewTestJig(cs, ns, serviceName)
+		jig.ExternalIPs = true
 		servicePort := 8080
 		svc, err := jig.CreateTCPServiceWithPort(nil, int32(servicePort))
 		framework.ExpectNoError(err)
@@ -1176,6 +1178,7 @@ var _ = common.SIGDescribe("Services", func() {
 		}
 
 		jig := e2eservice.NewTestJig(cs, ns, serviceName)
+		jig.ExternalIPs = true
 
 		ginkgo.By("creating service " + serviceName + " with type=clusterIP in namespace " + ns)
 		clusterIPService, err := jig.CreateTCPService(func(svc *v1.Service) {
@@ -1204,6 +1207,7 @@ var _ = common.SIGDescribe("Services", func() {
 		serviceName := "nodeport-update-service"
 		ns := f.Namespace.Name
 		jig := e2eservice.NewTestJig(cs, ns, serviceName)
+		jig.ExternalIPs = true
 
 		ginkgo.By("creating a TCP service " + serviceName + " with type=ClusterIP in namespace " + ns)
 		tcpService, err := jig.CreateTCPService(nil)


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
/sig testing
/sig network

**What this PR does / why we need it**:
In some user scenarios, the external IP nodeport is for access from APPs outside this cluster/zone.

- However, in most scenarios, external IP is just for SSH or special use(Ingress Gateway, etc.)

Different users have different proposals.

> most of the network tests now run from the cluster, no need to reach externalIPs.

Per https://github.com/kubernetes/kubernetes/issues/90764#issuecomment-775833055, I prefer to remove it before a clear definition for the external IPs.

> **move ExternalIP from Conformance entirely until it has a clear definition**

**Which issue(s) this PR fixes**:
Fixes #90764

**Special notes for your reviewer**:
And @BenTheElder suggestion is like adding a feature filter. I will work on it if this is needed.
> Per https://github.com/kubernetes/kubernetes/pull/98791#discussion_r572480431, I will add new test with `[Feature:ExternalNodeAccess]` and remove current case. [WIP]

**Does this PR introduce a user-facing change?**:
```release-note
None
```