### PR TITLE
Automated cherry pick of #98715: fix kube-scheduler cannot send event because the Note field

### DIFF
--- a/pkg/scheduler/BUILD
+++ b/pkg/scheduler/BUILD
@@ -11,6 +11,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/api/v1/pod:go_default_library",
+        "//pkg/apis/core/validation:go_default_library",
         "//pkg/features:go_default_library",
         "//pkg/scheduler/algorithmprovider:go_default_library",
         "//pkg/scheduler/apis/config:go_default_library",


### PR DESCRIPTION
Cherry pick of #98715 on release-1.20.

#98715: fix kube-scheduler cannot send event because the Note field

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.