### PR TITLE
fix ignored podinfo parserr

### DIFF
--- a/pkg/scheduler/framework/BUILD
+++ b/pkg/scheduler/framework/BUILD
@@ -21,6 +21,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/errors:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",
         "//staging/src/k8s.io/client-go/informers:go_default_library",


### PR DESCRIPTION
fix kube-scheduler ignored parse error when new PodInfo .

/sig scheduling