### PR TITLE
enable concurrent-job-syncs setting in kube-controller-manager

### DIFF
--- a/cmd/kube-controller-manager/app/options/jobcontroller.go
+++ b/cmd/kube-controller-manager/app/options/jobcontroller.go
@@ -32,6 +32,7 @@ func (o *JobControllerOptions) AddFlags(fs *pflag.FlagSet) {
 	if o == nil {
 		return
 	}
+	fs.Int32Var(&o.ConcurrentJobSyncs, "concurrent-job-syncs", o.ConcurrentJobSyncs, "The number of job objects that are allowed to sync concurrently. Larger number = more responsive jobs, but more CPU (and network) load")
 }
 
 // ApplyTo fills up JobController config with options.


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
It allows to set the concurrent-job-syncs in the job controller instead of using the default value, which is needed in some scenario e.g.  high-throughput small jobs

**Special notes for your reviewer**:
None

**Does this PR introduce a user-facing change?**:
```release-note
Add flag --concurrent-job-syncs in kube-controller-manager
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
None
