### PR TITLE
Remove extensions v1beta1 from addon manager and kubectl prune

### DIFF
--- a/cluster/addons/addon-manager/kube-addons.sh
+++ b/cluster/addons/addon-manager/kube-addons.sh
@@ -51,7 +51,7 @@ if [ -z "${KUBECTL_PRUNE_WHITELIST_OVERRIDE:-}" ]; then
     apps/v1/Deployment
     apps/v1/ReplicaSet
     apps/v1/StatefulSet
-    extensions/v1beta1/Ingress
+    networking.k8s.io/v1/Ingress
   )
 else
   read -ra KUBECTL_PRUNE_WHITELIST <<< "${KUBECTL_PRUNE_WHITELIST_OVERRIDE}"

--- a/staging/src/k8s.io/kubectl/pkg/cmd/apply/prune.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apply/prune.go
@@ -172,8 +172,7 @@ func (pr pruneResource) String() string {
 
 func getRESTMappings(mapper meta.RESTMapper, pruneResources *[]pruneResource) (namespaced, nonNamespaced []*meta.RESTMapping, err error) {
 	if len(*pruneResources) == 0 {
-		// default whitelist
-		// TODO: need to handle the older api versions - e.g. v1beta1 jobs. Github issue: #35991
+		// default allowlist
 		*pruneResources = []pruneResource{
 			{"", "v1", "ConfigMap", true},
 			{"", "v1", "Endpoints", true},
@@ -186,7 +185,7 @@ func getRESTMappings(mapper meta.RESTMapper, pruneResources *[]pruneResource) (n
 			{"", "v1", "Service", true},
 			{"batch", "v1", "Job", true},
 			{"batch", "v1beta1", "CronJob", true},
-			{"extensions", "v1beta1", "Ingress", true},
+			{"networking.k8s.io", "v1", "Ingress", true},
 			{"apps", "v1", "DaemonSet", true},
 			{"apps", "v1", "Deployment", true},
 			{"apps", "v1", "ReplicaSet", true},


### PR DESCRIPTION
**What type of PR is this?**

Cleanup before v1.22 shipping, removing extensions/v1beta1 Ingress from addon manager

/kind cleanup

**What this PR does / why we need it**: Before shipping v1.22 we need to get rid of any extensions/v1beta1 reference in the code and auxiliary tools, and this is needed to cleanup Addon manager

**Which issue(s) this PR fixes**:
Fixes #98723

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
xref: #43214  #72203 

**Still need to make tests about addon manager "what the addon manager does if given a prune list of networking.k8s.io/v1 Ingress objects while still using a manifest containing extensions/v1 Ingress objects" per Jordan comment**