### PR TITLE
enable goaway testcases

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/filters/goaway_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/filters/goaway_test.go
@@ -299,8 +299,6 @@ func requestGOAWAYServer(client *http.Client, serverBaseURL, url string) (<-chan
 // TestClientReceivedGOAWAY tests the in-flight watch requests will not be affected and new requests use a new
 // connection after client received GOAWAY.
 func TestClientReceivedGOAWAY(t *testing.T) {
-	t.Skip("disabled because of https://github.com/kubernetes/kubernetes/issues/94622")
-
 	s, err := newTestGOAWAYServer()
 	if err != nil {
 		t.Fatalf("failed to set-up test GOAWAY http server, err: %v", err)
@@ -438,10 +436,7 @@ func TestGOAWAYHTTP1Requests(t *testing.T) {
 }
 
 // TestGOAWAYConcurrency tests GOAWAY frame will not affect concurrency requests in a single http client instance.
-// Known issues in history: https://github.com/kubernetes/kubernetes/issues/91131.
 func TestGOAWAYConcurrency(t *testing.T) {
-	t.Skip("disabled because of https://github.com/kubernetes/kubernetes/issues/94532")
-
 	s, err := newTestGOAWAYServer()
 	if err != nil {
 		t.Fatalf("failed to set-up test GOAWAY http server, err: %v", err)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind flake

**What this PR does / why we need it**:

After we upgraded golang.org/x/net to latest version, goaway testcases will not flake.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #94532
Fixes #94622

**Special notes for your reviewer**:

Apiserver's clients in k/k repo use [golang.org/x/net/http2](https://github.com/kubernetes/kubernetes/blob/c9604bd302f9ff4df6c4cf6a8cc9130a497bcf36/staging/src/k8s.io/apimachinery/pkg/util/net/http.go#L174) to config http2 transports instead of use golang SDK h2_bundle. A new version of golang.org/x/net(with https://github.com/golang/net/commit/ff519b6c91021e6316e1df005bc19f266994ddda) will fix HTTP2 un-expected error when received GOAWAY frame.

For other clients which use default http2 configuration in golang SDK, golang 1.15.8 or 1.16+ required to avoid HTTP2 un-expected error when received GOAWAY frame.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
If kube-apiserver enabled goaway feature, clients required golang 1.15.8 or 1.16+ version to avoid un-expected data race issue.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
