### PR TITLE
Indexed job implementation

### DIFF
--- a/pkg/controller/job/indexed_job_utils.go
+++ b/pkg/controller/job/indexed_job_utils.go
@@ -1,0 +1,214 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package job
+
+import (
+	"fmt"
+	"math"
+	"sort"
+	"strconv"
+	"strings"
+
+	batch "k8s.io/api/batch/v1"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/kubernetes/pkg/controller"
+)
+
+const (
+	completionIndexEnvName = "JOB_COMPLETION_INDEX"
+	unknownCompletionIndex = -1
+)
+
+// calculateCompletedIndexesStr returns a string representation of the list
+// of completed indexes in compressed format.
+func calculateCompletedIndexesStr(pods []*v1.Pod) string {
+	sort.Sort(byCompletionIndex(pods))
+	var result strings.Builder
+	var lastSucceeded int
+	firstSucceeded := math.MinInt32
+	for _, p := range pods {
+		ix := getCompletionIndex(p.Annotations)
+		if ix == unknownCompletionIndex {
+			continue
+		}
+		if p.Status.Phase == v1.PodSucceeded {
+			if firstSucceeded == math.MinInt32 {
+				firstSucceeded = ix
+			} else if ix > lastSucceeded+1 {
+				addSingleOrRangeStr(&result, firstSucceeded, lastSucceeded)
+				firstSucceeded = ix
+			}
+			lastSucceeded = ix
+		}
+	}
+	if firstSucceeded != math.MinInt32 {
+		addSingleOrRangeStr(&result, firstSucceeded, lastSucceeded)
+	}
+	return result.String()
+}
+
+func addSingleOrRangeStr(builder *strings.Builder, first, last int) {
+	if builder.Len() > 0 {
+		builder.WriteRune(',')
+	}
+	builder.WriteString(strconv.Itoa(first))
+	if last > first {
+		if last == first+1 {
+			builder.WriteRune(',')
+		} else {
+			builder.WriteRune('-')
+		}
+		builder.WriteString(strconv.Itoa(last))
+	}
+}
+
+// firstPendingIndexes returns `count` indexes less than `completions` that are
+// not covered by running or succeeded pods.
+func firstPendingIndexes(pods []*v1.Pod, count, completions int) []int {
+	if count == 0 {
+		return nil
+	}
+	nonPending := sets.NewInt()
+	for _, p := range pods {
+		if p.Status.Phase == v1.PodSucceeded || controller.IsPodActive(p) {
+			ix := getCompletionIndex(p.Annotations)
+			if ix != unknownCompletionIndex {
+				nonPending.Insert(ix)
+			}
+		}
+	}
+	result := make([]int, 0, count)
+	// The following algorithm is bounded by the number of non pending pods and
+	// parallelism.
+	// TODO(#99368): Convert the list of non-pending pods into a set of
+	// non-pending intervals from the job's .status.completedIndexes and active
+	// pods.
+	candidate := 0
+	for _, np := range nonPending.List() {
+		for ; candidate < np && candidate < completions; candidate++ {
+			result = append(result, candidate)
+			if len(result) == count {
+				return result
+			}
+		}
+		candidate = np + 1
+	}
+	for ; candidate < completions && len(result) < count; candidate++ {
+		result = append(result, candidate)
+	}
+	return result
+}
+
+// appendDuplicatedIndexPodsForRemoval scans active `pods` for duplicated
+// completion indexes. For each index, it selects n-1 pods for removal, where n
+// is the number of repetitions. The pods to be removed are appended to `rm`,
+// while the remaining pods are appended to `left`.
+// All pods that don't have a completion index are appended to `rm`.
+func appendDuplicatedIndexPodsForRemoval(rm, left, pods []*v1.Pod) ([]*v1.Pod, []*v1.Pod) {
+	sort.Sort(byCompletionIndex(pods))
+	lastIndex := unknownCompletionIndex
+	firstRepeatPos := 0
+	for i, p := range pods {
+		ix := getCompletionIndex(p.Annotations)
+		if ix != lastIndex {
+			rm, left = appendPodsWithSameIndexForRemovalAndRemaining(rm, left, pods[firstRepeatPos:i], lastIndex)
+			firstRepeatPos = i
+			lastIndex = ix
+		}
+	}
+	return appendPodsWithSameIndexForRemovalAndRemaining(rm, left, pods[firstRepeatPos:], lastIndex)
+}
+
+func appendPodsWithSameIndexForRemovalAndRemaining(rm, left, pods []*v1.Pod, ix int) ([]*v1.Pod, []*v1.Pod) {
+	if ix == unknownCompletionIndex {
+		rm = append(rm, pods...)
+		return rm, left
+	}
+	if len(pods) == 1 {
+		left = append(left, pods[0])
+		return rm, left
+	}
+	sort.Sort(controller.ActivePods(pods))
+	rm = append(rm, pods[:len(pods)-1]...)
+	left = append(left, pods[len(pods)-1])
+	return rm, left
+}
+
+func getCompletionIndex(annotations map[string]string) int {
+	if annotations == nil {
+		return unknownCompletionIndex
+	}
+	v, ok := annotations[batch.JobCompletionIndexAnnotationAlpha]
+	if !ok {
+		return unknownCompletionIndex
+	}
+	i, err := strconv.Atoi(v)
+	if err != nil {
+		return unknownCompletionIndex
+	}
+	if i < 0 {
+		return unknownCompletionIndex
+	}
+	return i
+}
+
+func addCompletionIndexEnvVariables(template *v1.PodTemplateSpec) {
+	for i := range template.Spec.InitContainers {
+		addCompletionIndexEnvVariable(&template.Spec.InitContainers[i])
+	}
+	for i := range template.Spec.Containers {
+		addCompletionIndexEnvVariable(&template.Spec.Containers[i])
+	}
+}
+
+func addCompletionIndexEnvVariable(container *v1.Container) {
+	for _, v := range container.Env {
+		if v.Name == completionIndexEnvName {
+			return
+		}
+	}
+	container.Env = append(container.Env, v1.EnvVar{
+		Name: completionIndexEnvName,
+		ValueFrom: &v1.EnvVarSource{
+			FieldRef: &v1.ObjectFieldSelector{
+				FieldPath: fmt.Sprintf("metadata.annotations['%s']", batch.JobCompletionIndexAnnotationAlpha),
+			},
+		},
+	})
+}
+
+func addCompletionIndexAnnotation(template *v1.PodTemplateSpec, index int) {
+	if template.Annotations == nil {
+		template.Annotations = make(map[string]string, 1)
+	}
+	template.Annotations[batch.JobCompletionIndexAnnotationAlpha] = strconv.Itoa(index)
+}
+
+type byCompletionIndex []*v1.Pod
+
+func (bci byCompletionIndex) Less(i, j int) bool {
+	return getCompletionIndex(bci[i].Annotations) < getCompletionIndex(bci[j].Annotations)
+}
+
+func (bci byCompletionIndex) Swap(i, j int) {
+	bci[i], bci[j] = bci[j], bci[i]
+}
+
+func (bci byCompletionIndex) Len() int {
+	return len(bci)
+}

--- a/pkg/controller/job/indexed_job_utils_test.go
+++ b/pkg/controller/job/indexed_job_utils_test.go
@@ -1,0 +1,256 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package job
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	batch "k8s.io/api/batch/v1"
+	v1 "k8s.io/api/core/v1"
+)
+
+const noIndex = "-"
+
+func TestCalculateCompletedIndexesStr(t *testing.T) {
+	cases := map[string][]indexPhase{
+		"1": {
+			{"1", v1.PodSucceeded},
+		},
+		"5,10": {
+			{"2", v1.PodFailed},
+			{"5", v1.PodSucceeded},
+			{"5", v1.PodSucceeded},
+			{"10", v1.PodFailed},
+			{"10", v1.PodSucceeded},
+		},
+		"2,3,5-7": {
+			{"0", v1.PodRunning},
+			{"1", v1.PodPending},
+			{"2", v1.PodSucceeded},
+			{"3", v1.PodSucceeded},
+			{"5", v1.PodSucceeded},
+			{"6", v1.PodSucceeded},
+			{"7", v1.PodSucceeded},
+		},
+		"0-2": {
+			{"0", v1.PodSucceeded},
+			{"1", v1.PodFailed},
+			{"1", v1.PodSucceeded},
+			{"2", v1.PodSucceeded},
+			{"2", v1.PodSucceeded},
+			{"3", v1.PodFailed},
+		},
+		"0,2-5": {
+			{"0", v1.PodSucceeded},
+			{"1", v1.PodFailed},
+			{"2", v1.PodSucceeded},
+			{"3", v1.PodSucceeded},
+			{"4", v1.PodSucceeded},
+			{"5", v1.PodSucceeded},
+			{noIndex, v1.PodSucceeded},
+			{"-2", v1.PodSucceeded},
+		},
+	}
+	for want, tc := range cases {
+		t.Run(want, func(t *testing.T) {
+			pods := hollowPodsWithIndexPhase(tc)
+			gotStr := calculateCompletedIndexesStr(pods)
+			if diff := cmp.Diff(want, gotStr); diff != "" {
+				t.Errorf("Unexpected completed indexes (-want,+got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestFirstPendingIndexes(t *testing.T) {
+	cases := map[string]struct {
+		cnt         int
+		completions int
+		pods        []indexPhase
+		want        []int
+	}{
+		"cnt greater than completions": {
+			cnt:         5,
+			completions: 3,
+			want:        []int{0, 1, 2},
+		},
+		"cnt less than completions": {
+			cnt:         2,
+			completions: 5,
+			want:        []int{0, 1},
+		},
+		"first pods running or succeeded": {
+			pods: []indexPhase{
+				{"0", v1.PodRunning},
+				{"1", v1.PodPending},
+				{"2", v1.PodFailed},
+			},
+			cnt:         3,
+			completions: 10,
+			want:        []int{2, 3, 4},
+		},
+		"last pods running or succeeded": {
+			pods: []indexPhase{
+				{"4", v1.PodFailed},
+				{"5", v1.PodSucceeded},
+				{"6", v1.PodPending},
+			},
+			cnt:         6,
+			completions: 6,
+			want:        []int{0, 1, 2, 3, 4},
+		},
+		"mixed": {
+			pods: []indexPhase{
+				{"1", v1.PodFailed},
+				{"2", v1.PodSucceeded},
+				{"3", v1.PodPending},
+				{"5", v1.PodFailed},
+				{"5", v1.PodRunning},
+				{"8", v1.PodPending},
+				{noIndex, v1.PodRunning},
+				{"-3", v1.PodRunning},
+			},
+			cnt:         5,
+			completions: 10,
+			want:        []int{0, 1, 4, 6, 7},
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			pods := hollowPodsWithIndexPhase(tc.pods)
+			got := firstPendingIndexes(pods, tc.cnt, tc.completions)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("Wrong first pending indexes (-want,+got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestAppendDuplicatedIndexPodsForRemoval(t *testing.T) {
+	cases := map[string]struct {
+		pods     []indexPhase
+		wantRm   []indexPhase
+		wantLeft []indexPhase
+	}{
+		"all unique": {
+			pods: []indexPhase{
+				{noIndex, v1.PodPending},
+				{"2", v1.PodPending},
+				{"5", v1.PodRunning},
+			},
+			wantRm: []indexPhase{
+				{noIndex, v1.PodPending},
+			},
+			wantLeft: []indexPhase{
+				{"2", v1.PodPending},
+				{"5", v1.PodRunning},
+			},
+		},
+		"all with index": {
+			pods: []indexPhase{
+				{"5", v1.PodPending},
+				{"0", v1.PodRunning},
+				{"3", v1.PodPending},
+				{"0", v1.PodRunning},
+				{"3", v1.PodRunning},
+				{"0", v1.PodPending},
+			},
+			wantRm: []indexPhase{
+				{"0", v1.PodPending},
+				{"0", v1.PodRunning},
+				{"3", v1.PodPending},
+			},
+			wantLeft: []indexPhase{
+				{"0", v1.PodRunning},
+				{"3", v1.PodRunning},
+				{"5", v1.PodPending},
+			},
+		},
+		"mixed": {
+			pods: []indexPhase{
+				{noIndex, v1.PodPending},
+				{"invalid", v1.PodRunning},
+				{"-2", v1.PodRunning},
+				{"0", v1.PodPending},
+				{"1", v1.PodPending},
+				{"1", v1.PodPending},
+				{"1", v1.PodRunning},
+			},
+			wantRm: []indexPhase{
+				{noIndex, v1.PodPending},
+				{"invalid", v1.PodRunning},
+				{"-2", v1.PodRunning},
+				{"1", v1.PodPending},
+				{"1", v1.PodPending},
+			},
+			wantLeft: []indexPhase{
+				{"0", v1.PodPending},
+				{"1", v1.PodRunning},
+			},
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			pods := hollowPodsWithIndexPhase(tc.pods)
+			rm, left := appendDuplicatedIndexPodsForRemoval(nil, nil, pods)
+			rmInt := toIndexPhases(rm)
+			leftInt := toIndexPhases(left)
+			if diff := cmp.Diff(tc.wantRm, rmInt); diff != "" {
+				t.Errorf("Unexpected pods for removal (-want,+got):\n%s", diff)
+			}
+			if diff := cmp.Diff(tc.wantLeft, leftInt); diff != "" {
+				t.Errorf("Unexpected pods to keep (-want,+got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func hollowPodsWithIndexPhase(descs []indexPhase) []*v1.Pod {
+	pods := make([]*v1.Pod, 0, len(descs))
+	for _, desc := range descs {
+		p := &v1.Pod{
+			Status: v1.PodStatus{
+				Phase: desc.Phase,
+			},
+		}
+		if desc.Index != noIndex {
+			p.Annotations = map[string]string{
+				batch.JobCompletionIndexAnnotationAlpha: desc.Index,
+			}
+		}
+		pods = append(pods, p)
+	}
+	return pods
+}
+
+type indexPhase struct {
+	Index string
+	Phase v1.PodPhase
+}
+
+func toIndexPhases(pods []*v1.Pod) []indexPhase {
+	result := make([]indexPhase, len(pods))
+	for i, p := range pods {
+		index := noIndex
+		if p.Annotations != nil {
+			index = p.Annotations[batch.JobCompletionIndexAnnotationAlpha]
+		}
+		result[i] = indexPhase{index, p.Status.Phase}
+	}
+	return result
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

/sig apps
/area batch
/area workload-api/job

Implements support for Indexed Job.

For an indexed Job, the job controller creates a Pod with an associated index from 0 to (.spec.completions-1). The index is added as an annotation.

Other implementation details:
- When feature gate is disabled, the job controller doesn't process indexed jobs.
- The job controller creates Pods for the lowest indexes that don't have active or succeeded pods.
- If there are more than one pod for an index, the controller removes all but one, using the same strategy where the number of active pods exceeds parallelism.
- Active pods that don't have an index are removed.
- Finished pods that don't have an index don't count towards failures or successes, but they are not removed.

**Which issue(s) this PR fixes**:

Fixes #97169 #14188

Ref kubernetes/enhancements#2214

**Special notes for your reviewer**:

Builds on top of #98441
Integration test to follow

**Does this PR introduce a user-facing change?**:

```release-note
Support for Indexed Job: a Job that is considered completed when Pods associated to indexes from 0 to (.spec.completions-1) have succeeded.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs
- [KEP]: git.k8s.io/enhancements/keps/sig-apps/2214-indexed-job
- [Usage]: https://kubernetes.io/docs/concepts/workloads/controllers/job/#indexed-job
```
