### PR TITLE
kubeadm: get k8s CI version markers from k8s infra bucket

### DIFF
--- a/cmd/kubeadm/app/util/version.go
+++ b/cmd/kubeadm/app/util/version.go
@@ -39,6 +39,7 @@ const (
 
 var (
 	kubeReleaseBucketURL  = "https://dl.k8s.io"
+	kubeCIBucketURL       = "https://storage.googleapis.com/k8s-release-dev"
 	kubeReleaseRegex      = regexp.MustCompile(`^v?(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)([-0-9a-zA-Z_\.+]*)?$`)
 	kubeReleaseLabelRegex = regexp.MustCompile(`^((latest|stable)+(-[1-9](\.[1-9]([0-9])?)?)?)\z`)
 	kubeBucketPrefixes    = regexp.MustCompile(`^((release|ci|ci-cross)/)?([-\w_\.+]+)$`)
@@ -160,7 +161,7 @@ func normalizedBuildVersion(version string) string {
 // Internal helper: split version parts,
 // Return base URL and cleaned-up version
 func splitVersion(version string) (string, string, error) {
-	var urlSuffix string
+	var bucketURL, urlSuffix string
 	subs := kubeBucketPrefixes.FindAllStringSubmatch(version, 1)
 	if len(subs) != 1 || len(subs[0]) != 4 {
 		return "", "", errors.Errorf("invalid version %q", version)
@@ -170,10 +171,12 @@ func splitVersion(version string) (string, string, error) {
 	case strings.HasPrefix(subs[0][2], "ci"):
 		// Just use whichever the user specified
 		urlSuffix = subs[0][2]
+		bucketURL = kubeCIBucketURL
 	default:
 		urlSuffix = "release"
+		bucketURL = kubeReleaseBucketURL
 	}
-	url := fmt.Sprintf("%s/%s", kubeReleaseBucketURL, urlSuffix)
+	url := fmt.Sprintf("%s/%s", bucketURL, urlSuffix)
 	return url, subs[0][3], nil
 }
 

--- a/cmd/kubeadm/app/util/version_test.go
+++ b/cmd/kubeadm/app/util/version_test.go
@@ -19,11 +19,12 @@ package util
 import (
 	"errors"
 	"fmt"
-	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	"path"
 	"strings"
 	"testing"
 	"time"
+
+	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
 )
 
 func TestEmptyVersion(t *testing.T) {
@@ -195,8 +196,8 @@ func TestSplitVersion(t *testing.T) {
 		{"release/v1.7.0", "https://dl.k8s.io/release", "v1.7.0", true},
 		{"release/latest-1.7", "https://dl.k8s.io/release", "latest-1.7", true},
 		// CI builds area
-		{"ci/latest", "https://dl.k8s.io/ci", "latest", true},
-		{"ci/latest-1.7", "https://dl.k8s.io/ci", "latest-1.7", true},
+		{"ci/latest", "https://storage.googleapis.com/k8s-release-dev/ci", "latest", true},
+		{"ci/latest-1.7", "https://storage.googleapis.com/k8s-release-dev/ci", "latest-1.7", true},
 		// unknown label in default (release) area: splitVersion validate only areas.
 		{"unknown-1", "https://dl.k8s.io/release", "unknown-1", true},
 		// unknown area, not valid input.

--- a/cmd/kubeadm/app/util/version_test.go
+++ b/cmd/kubeadm/app/util/version_test.go
@@ -203,9 +203,6 @@ func TestSplitVersion(t *testing.T) {
 		// unknown area, not valid input.
 		{"unknown/latest-1", "", "", false},
 	}
-	// kubeReleaseBucketURL can be overridden during network tests, thus ensure
-	// it will contain value corresponding to expected outcome for this unit test
-	kubeReleaseBucketURL = "https://dl.k8s.io"
 
 	for _, tc := range cases {
 		t.Run(fmt.Sprintf("input:%s/label:%s", tc.input, tc.label), func(t *testing.T) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**


/kind bug


**What this PR does / why we need it**:


Updates kubeadm version resolution to use kubernetes community infra
bucket to fetch appropriate k8s ci versions. The images are already
being pulled from the kubernetes community infra bucket meaning that a
mismatch can occur when the ci version is fetched from the google infra
bucket and the image is not yet present on k8s infra.

Follow-up to #97087

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
xref https://github.com/kubernetes/kubernetes/issues/98646

**Special notes for your reviewer**:

This should likely be CP'ed back to 1.20 branch as well.

Context: https://kubernetes.slack.com/archives/C09QZ4DQB/p1612269558032700

/priority critical-urgent
/sig release

/assign @neolit123 
/cc @justaugustus @saschagrunert 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kubeadm: get k8s CI version markers from k8s infra bucket
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
