### PR TITLE
Make proxy Transport return metav1.Status error

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/proxy/transport.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/proxy/transport.go
@@ -32,6 +32,7 @@ import (
 	"golang.org/x/net/html/atom"
 	"k8s.io/klog/v2"
 
+	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/util/net"
 	"k8s.io/apimachinery/pkg/util/sets"
 )
@@ -101,7 +102,7 @@ func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 	resp, err := rt.RoundTrip(req)
 
 	if err != nil {
-		return nil, fmt.Errorf("error trying to reach service: %w", err)
+		return nil, errors.NewServiceUnavailable(fmt.Sprintf("error trying to reach service: %v", err))
 	}
 
 	if redirect := resp.Header.Get("Location"); redirect != "" {


### PR DESCRIPTION
Fixed #98479

/sig api-machinery
/assign @p0lyn0mial @sttts

The problem described in #98479 is that when the kube-apiserver proxy is used to access a Service that's not listening, the kube-apiserver apart from correctly returning the error to the client, it also logs an error complaining that "apiserver received an error that is not an metav1.Status".

The flow of the error log is like the following:
The [err](https://github.com/kubernetes/kubernetes/blob/5fa704c6a883d369d1a4cf273f8dd13516e4a58c/staging/src/k8s.io/apimachinery/pkg/util/proxy/transport.go#L104) returned by the proxy.Transport is then returned to the client via the [responder](https://github.com/kubernetes/kubernetes/blob/5fa704c6a883d369d1a4cf273f8dd13516e4a58c/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/rest.go#L203), but when the `responder.scope.err()` calls [ErrorToAPIStatus](https://github.com/kubernetes/kubernetes/blob/5fa704c6a883d369d1a4cf273f8dd13516e4a58c/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/writers.go#L284) to interpret the error, it [leaves an error message](https://github.com/kubernetes/kubernetes/blob/5fa704c6a883d369d1a4cf273f8dd13516e4a58c/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/status.go#L71) in the apiserver log because the `err` does not implement the [statusError](https://github.com/kubernetes/kubernetes/blob/5fa704c6a883d369d1a4cf273f8dd13516e4a58c/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/status.go#L30) interface.

This PR makes the proxy.Transport return a NewServiceUnavailable error instead.

I manually verified that with this PR, there is no more error message in the apiserver log, though I can't find a simple way to unit test the behavior.

```release-note
NONE
```