### PR TITLE
Automated cherry pick of #98836: kubeadm: get k8s CI version markers from k8s infra bucket

### DIFF
--- a/cmd/kubeadm/app/util/version.go
+++ b/cmd/kubeadm/app/util/version.go
@@ -39,6 +39,7 @@ const (
 
 var (
 	kubeReleaseBucketURL  = "https://dl.k8s.io"
+	kubeCIBucketURL       = "https://storage.googleapis.com/k8s-release-dev"
 	kubeReleaseRegex      = regexp.MustCompile(`^v?(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)([-0-9a-zA-Z_\.+]*)?$`)
 	kubeReleaseLabelRegex = regexp.MustCompile(`^((latest|stable)+(-[1-9](\.[1-9]([0-9])?)?)?)\z`)
 	kubeBucketPrefixes    = regexp.MustCompile(`^((release|ci|ci-cross)/)?([-\w_\.+]+)$`)
@@ -160,7 +161,7 @@ func normalizedBuildVersion(version string) string {
 // Internal helper: split version parts,
 // Return base URL and cleaned-up version
 func splitVersion(version string) (string, string, error) {
-	var urlSuffix string
+	var bucketURL, urlSuffix string
 	subs := kubeBucketPrefixes.FindAllStringSubmatch(version, 1)
 	if len(subs) != 1 || len(subs[0]) != 4 {
 		return "", "", errors.Errorf("invalid version %q", version)
@@ -170,10 +171,12 @@ func splitVersion(version string) (string, string, error) {
 	case strings.HasPrefix(subs[0][2], "ci"):
 		// Just use whichever the user specified
 		urlSuffix = subs[0][2]
+		bucketURL = kubeCIBucketURL
 	default:
 		urlSuffix = "release"
+		bucketURL = kubeReleaseBucketURL
 	}
-	url := fmt.Sprintf("%s/%s", kubeReleaseBucketURL, urlSuffix)
+	url := fmt.Sprintf("%s/%s", bucketURL, urlSuffix)
 	return url, subs[0][3], nil
 }
 

--- a/cmd/kubeadm/app/util/version_test.go
+++ b/cmd/kubeadm/app/util/version_test.go
@@ -19,11 +19,12 @@ package util
 import (
 	"errors"
 	"fmt"
-	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	"path"
 	"strings"
 	"testing"
 	"time"
+
+	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
 )
 
 func TestEmptyVersion(t *testing.T) {
@@ -195,8 +196,8 @@ func TestSplitVersion(t *testing.T) {
 		{"release/v1.7.0", "https://dl.k8s.io/release", "v1.7.0", true},
 		{"release/latest-1.7", "https://dl.k8s.io/release", "latest-1.7", true},
 		// CI builds area
-		{"ci/latest", "https://dl.k8s.io/ci", "latest", true},
-		{"ci/latest-1.7", "https://dl.k8s.io/ci", "latest-1.7", true},
+		{"ci/latest", "https://storage.googleapis.com/k8s-release-dev/ci", "latest", true},
+		{"ci/latest-1.7", "https://storage.googleapis.com/k8s-release-dev/ci", "latest-1.7", true},
 		// unknown label in default (release) area: splitVersion validate only areas.
 		{"unknown-1", "https://dl.k8s.io/release", "unknown-1", true},
 		// unknown area, not valid input.

--- a/cmd/kubeadm/app/util/version_test.go
+++ b/cmd/kubeadm/app/util/version_test.go
@@ -203,9 +203,6 @@ func TestSplitVersion(t *testing.T) {
 		// unknown area, not valid input.
 		{"unknown/latest-1", "", "", false},
 	}
-	// kubeReleaseBucketURL can be overridden during network tests, thus ensure
-	// it will contain value corresponding to expected outcome for this unit test
-	kubeReleaseBucketURL = "https://dl.k8s.io"
 
 	for _, tc := range cases {
 		t.Run(fmt.Sprintf("input:%s/label:%s", tc.input, tc.label), func(t *testing.T) {


### PR DESCRIPTION
Cherry pick of #98836 on release-1.20.

#98836: kubeadm: get k8s CI version markers from k8s infra bucket

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.