### PR TITLE
Fixed set env did not support keys with dot in it

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/set/env/env_parse_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/set/env/env_parse_test.go
@@ -34,18 +34,6 @@ func ExampleIsEnvironmentArgument_false() {
 	// Output: false
 }
 
-func ExampleIsValidEnvironmentArgument_true() {
-	test := "wordcharacters=true"
-	fmt.Println(IsValidEnvironmentArgument(test))
-	// Output: true
-}
-
-func ExampleIsValidEnvironmentArgument_false() {
-	test := "not$word^characters=test"
-	fmt.Println(IsValidEnvironmentArgument(test))
-	// Output: false
-}
-
 func ExampleSplitEnvironmentFromResources() {
 	args := []string{`resource`, "ENV\\=ARG", `ONE\=MORE`, `DASH-`}
 	fmt.Println(SplitEnvironmentFromResources(args))
@@ -54,16 +42,40 @@ func ExampleSplitEnvironmentFromResources() {
 
 func ExampleParseEnv_good() {
 	r := strings.NewReader("FROM=READER")
-	ss := []string{"ENV=VARIABLE", "AND=ANOTHER", "REMOVE-", "-"}
+	ss := []string{"ENV=VARIABLE", "ENV.TEST=VARIABLE", "AND=ANOTHER", "REMOVE-", "-"}
 	fmt.Println(ParseEnv(ss, r))
 	// Output:
-	// [{ENV VARIABLE nil} {AND ANOTHER nil} {FROM READER nil}] [REMOVE] <nil>
+	// [{ENV VARIABLE nil} {ENV.TEST VARIABLE nil} {AND ANOTHER nil} {FROM READER nil}] [REMOVE] <nil>
 }
 
-func ExampleParseEnv_bad() {
+func ExampleParseEnv_bad_first() {
 	var r io.Reader
 	bad := []string{"This not in the key=value format."}
 	fmt.Println(ParseEnv(bad, r))
 	// Output:
-	// [] [] environment variables must be of the form key=value and can only contain letters, numbers, and underscores
+	// [] [] "This not in the key" is not a valid key name: a valid environment variable name must consist of alphabetic characters, digits, '_', '-', or '.', and must not start with a digit (e.g. 'my.env-name',  or 'MY_ENV.NAME',  or 'MyEnvName1', regex used for validation is '[-._a-zA-Z][-._a-zA-Z0-9]*')
+}
+
+func ExampleParseEnv_bad_second() {
+	var r io.Reader
+	bad := []string{".=VARIABLE"}
+	fmt.Println(ParseEnv(bad, r))
+	// Output:
+	// [] [] "." is not a valid key name: must not be '.'
+}
+
+func ExampleParseEnv_bad_third() {
+	var r io.Reader
+	bad := []string{"..=VARIABLE"}
+	fmt.Println(ParseEnv(bad, r))
+	// Output:
+	// [] [] ".." is not a valid key name: must not be '..'
+}
+
+func ExampleParseEnv_bad_fourth() {
+	var r io.Reader
+	bad := []string{"..ENV=VARIABLE"}
+	fmt.Println(ParseEnv(bad, r))
+	// Output:
+	// [] [] "..ENV" is not a valid key name: must not start with '..'
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug


**What this PR does / why we need it**:
Fixed the bug that cannot set an environment variable name with a dot.  
To reproduce:
`kubectl set env deployment/app test.on=true`. 
An error will be thrown `error: environment variables must be of the form key=value and can only contain letters, numbers, and underscores`

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubectl/issues/1014

**Special notes for your reviewer**:
/cc @rikatz
/cc @soltysh  
Very similar PR https://github.com/kubernetes/kubernetes/pull/48986 <- was referring to this

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
