### PR TITLE
avoid hardcoding amd64 specifics on cross compiling

### DIFF
--- a/hack/lib/golang.sh
+++ b/hack/lib/golang.sh
@@ -393,11 +393,15 @@ kube::golang::set_platform_envs() {
   export GOOS=${platform%/*}
   export GOARCH=${platform##*/}
 
-  # Do not set CC when building natively on a platform, only if cross-compiling from linux/amd64
-  if [[ $(kube::golang::host_platform) == "linux/amd64" ]]; then
-    # Dynamic CGO linking for other server architectures than linux/amd64 goes here
+  # Do not set CC when building natively on a platform, only if cross-compiling
+  if [[ $(kube::golang::host_platform) != "$platform" ]]; then
+    # Dynamic CGO linking for other server architectures than host architecture goes here
     # If you want to include support for more server platforms than these, add arch-specific gcc names here
     case "${platform}" in
+      "linux/amd64")
+        export CGO_ENABLED=1
+        export CC=${KUBE_LINUX_AMD64_CC:-x86_64-linux-gnu-gcc}
+        ;;
       "linux/arm")
         export CGO_ENABLED=1
         export CC=${KUBE_LINUX_ARM_CC:-arm-linux-gnueabihf-gcc}


### PR DESCRIPTION
**What type of PR is this?**

/kind feature
/sig release

**What this PR does / why we need it**:

Follow up to #98508 https://github.com/kubernetes/kubernetes/pull/98508#issuecomment-769244361

This makes sure that when building, for example, on arm64 host for amd64 target the default CC if defined properly. Previous logic only worked on amd64 hosts.


**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```

cc @BenTheElder @bnrjee 