### PR TITLE
.github: update enhancement issue template to point to KEPs

### DIFF
--- a/.github/ISSUE_TEMPLATE/enhancement.md
+++ b/.github/ISSUE_TEMPLATE/enhancement.md
@@ -1,10 +1,16 @@
 ---
-name: Enhancement Request
-about: Suggest an enhancement to the Kubernetes project
+name: Enhancement Tracking Issue
+about: Provide supporting details for a feature in development
 labels: kind/feature
 
 ---
-<!-- Please only use this template for submitting enhancement requests -->
+<!-- Feature requests are unlikely to make progress as an issue.
+
+Instead, please suggest enhancements by engaging with SIGs on slack and mailing lists.
+
+A proposal that works through the design along with the implications of the change can be opened as a KEP:
+https://git.k8s.io/enhancements/keps#kubernetes-enhancement-proposals-keps
+-->
 
 #### What would you like to be added:
 


### PR DESCRIPTION
Enhancements in Kubernetes need to follow the KEP process.
Feature requests created as issues are unlikely to make progress.

We should point folks to the KEPs doc to avoid polluting such feature
request issues in k/k.

Ref: https://kubernetes.slack.com/archives/C1TU9EB9S/p1612578520133400


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

---

/kind cleanup
/priority backlog
/cc @liggitt @dims @BenTheElder @mrbobbytables @cblecker @alisondy 
/hold
needs to be approved by other contribex leads + communicated via k-dev

