### PR TITLE
kubeadm: flatten admin.conf for cluster-info generation

### DIFF
--- a/cmd/kubeadm/app/phases/bootstraptoken/clusterinfo/clusterinfo.go
+++ b/cmd/kubeadm/app/phases/bootstraptoken/clusterinfo/clusterinfo.go
@@ -47,6 +47,9 @@ func CreateBootstrapConfigMapIfNotExists(client clientset.Interface, file string
 	if err != nil {
 		return errors.Wrap(err, "failed to load admin kubeconfig")
 	}
+	if err = clientcmdapi.FlattenConfig(adminConfig); err != nil {
+		return err
+	}
 
 	adminCluster := adminConfig.Contexts[adminConfig.CurrentContext].Cluster
 	// Copy the cluster from admin.conf to the bootstrap kubeconfig, contains the CA cert and the server URL


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

This PR invokes flatten for kubeconfig before generating cluster-info configmap

**Which issue(s) this PR fixes**:

Fixes #98881

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
kubeadm: fix a bug where external credentials in an existing admin.conf prevented the CA certificate to be written in the cluster-info ConfigMap.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
