### PR TITLE
[kubectl] improve diff cmd performances with a pool of parallel visitors to prepare LIVE and MERGED states

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/util/helpers.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/util/helpers.go
@@ -451,6 +451,10 @@ func AddApplyAnnotationVarFlags(cmd *cobra.Command, applyAnnotation *bool) {
 	cmd.Flags().BoolVar(applyAnnotation, ApplyAnnotationsFlag, *applyAnnotation, "If true, the configuration of current object will be saved in its annotation. Otherwise, the annotation will be unchanged. This flag is useful when you want to perform kubectl apply on this object in the future.")
 }
 
+func AddParallelDiffVisitorsFlag(cmd *cobra.Command) {
+	cmd.Flags().Int("parallel-visitors", 1, "Number of concurrent visitors used by diff cmd to visit objects. Default is 1, mean that objects will be visited one by one. With N visitors we can diff faster, we should care about cpu and parallelism capacity of your machine")
+}
+
 // AddGeneratorFlags adds flags common to resource generation commands
 // TODO: need to take a pass at other generator commands to use this set of flags
 func AddGeneratorFlags(cmd *cobra.Command, defaultGenerator string) {
@@ -514,6 +518,10 @@ func GetServerSideApplyFlag(cmd *cobra.Command) bool {
 
 func GetForceConflictsFlag(cmd *cobra.Command) bool {
 	return GetFlagBool(cmd, "force-conflicts")
+}
+
+func GetParallelVisitorsFlag(cmd *cobra.Command) int {
+	return GetFlagInt(cmd, "parallel-visitors")
 }
 
 func GetFieldManagerFlag(cmd *cobra.Command) string {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:

kubectl diff have 2 steps:

1. prepare LIVE and MERGED states of desired objects
2. 'diff' every 2 versions of yaml

The second step is done by one os command ('diff' cmd is the default), this phase is very fast with only one or many objects visited, we dont need to optimize it.
But the first step can be very slow if we have a lot of objects to visit, with sequential processing mode it can take very long time to finish. We can do this step with parallel goroutine to prepare the LIVE and MERGED state.

In this PR we use a pool of 'n' parallel goroutine to visit objects and prepare live and merged states

**Which issue(s) this PR fixes**:
Fixes #98886
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
default concurrent visitors is 1, without setting --parallel-visitors var the sequential mode is used
 
**Does this PR introduce a user-facing change?**:
None
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
add "parallel-visitors" param to kubectl diff command
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
new kubectl diff flag:
      --parallel-visitors=1: Number of concurrent visitors used by diff cmd to visit objects.
Default is 1, mean that objects will be visited one by one. With N visitors we can diff faster, but
we should care about cpu and your parallelism capacity

```
