### PR TITLE
exec credential provider: add rest_client_exec_plugin_call_total metric

### DIFF
--- a/staging/src/k8s.io/client-go/plugin/pkg/client/auth/exec/exec.go
+++ b/staging/src/k8s.io/client-go/plugin/pkg/client/auth/exec/exec.go
@@ -400,7 +400,9 @@ func (a *Authenticator) refreshCredsLocked(r *clientauthentication.Response) err
 		cmd.Stdin = a.stdin
 	}
 
-	if err := cmd.Run(); err != nil {
+	err = cmd.Run()
+	incrementCallsMetric(err)
+	if err != nil {
 		return a.wrapCmdRunErrorLocked(err)
 	}
 

--- a/staging/src/k8s.io/client-go/plugin/pkg/client/auth/exec/metrics.go
+++ b/staging/src/k8s.io/client-go/plugin/pkg/client/auth/exec/metrics.go
@@ -17,10 +17,37 @@ limitations under the License.
 package exec
 
 import (
+	"errors"
+	"os/exec"
+	"reflect"
 	"sync"
 	"time"
 
+	"k8s.io/klog/v2"
+
 	"k8s.io/client-go/tools/metrics"
+)
+
+// The following constants shadow the special values used in the prometheus metrics implementation.
+const (
+	// noError indicates that the plugin process was successfully started and exited with an exit
+	// code of 0.
+	noError = "no_error"
+	// pluginExecutionError indicates that the plugin process was successfully started and then
+	// it returned a non-zero exit code.
+	pluginExecutionError = "plugin_execution_error"
+	// pluginNotFoundError indicates that we could not find the exec plugin.
+	pluginNotFoundError = "plugin_not_found_error"
+	// clientInternalError indicates that we attempted to start the plugin process, but failed
+	// for some reason.
+	clientInternalError = "client_internal_error"
+
+	// successExitCode represents an exec plugin invocation that was successful.
+	successExitCode = 0
+	// failureExitCode represents an exec plugin invocation that was not successful. This code is
+	// used in some failure modes (e.g., plugin not found, client internal error) so that someone
+	// can more easily monitor all unsuccessful invocations.
+	failureExitCode = 1
 )
 
 type certificateExpirationTracker struct {
@@ -56,5 +83,27 @@ func (c *certificateExpirationTracker) set(a *Authenticator, t time.Time) {
 		c.metricSet(nil)
 	} else {
 		c.metricSet(&earliest)
+	}
+}
+
+// incrementCallsMetric increments a global metrics counter for the number of calls to an exec
+// plugin, partitioned by exit code. The provided err should be the return value from
+// exec.Cmd.Run().
+func incrementCallsMetric(err error) {
+	execExitError := &exec.ExitError{}
+	execError := &exec.Error{}
+	switch {
+	case err == nil: // Binary execution succeeded.
+		metrics.ExecPluginCalls.Increment(successExitCode, noError)
+
+	case errors.As(err, &execExitError): // Binary execution failed (see "os/exec".Cmd.Run()).
+		metrics.ExecPluginCalls.Increment(execExitError.ExitCode(), pluginExecutionError)
+
+	case errors.As(err, &execError): // Binary does not exist (see exec.Error).
+		metrics.ExecPluginCalls.Increment(failureExitCode, pluginNotFoundError)
+
+	default: // We don't know about this error type.
+		klog.V(2).InfoS("unexpected exec plugin return error type", "type", reflect.TypeOf(err).String(), "err", err)
+		metrics.ExecPluginCalls.Increment(failureExitCode, clientInternalError)
 	}
 }

--- a/staging/src/k8s.io/client-go/plugin/pkg/client/auth/exec/metrics_test.go
+++ b/staging/src/k8s.io/client-go/plugin/pkg/client/auth/exec/metrics_test.go
@@ -17,8 +17,14 @@ limitations under the License.
 package exec
 
 import (
+	"fmt"
 	"testing"
 	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"k8s.io/client-go/pkg/apis/clientauthentication"
+	"k8s.io/client-go/tools/clientcmd/api"
+	"k8s.io/client-go/tools/metrics"
 )
 
 type mockExpiryGauge struct {
@@ -92,5 +98,100 @@ func TestCertificateExpirationTracker(t *testing.T) {
 				t.Errorf("got: %s; want: %s", mockMetric.v, tc.want)
 			}
 		})
+	}
+}
+
+type mockCallsMetric struct {
+	exitCode  int
+	errorType string
+}
+
+type mockCallsMetricCounter struct {
+	calls []mockCallsMetric
+}
+
+func (f *mockCallsMetricCounter) Increment(exitCode int, errorType string) {
+	f.calls = append(f.calls, mockCallsMetric{exitCode: exitCode, errorType: errorType})
+}
+
+func TestCallsMetric(t *testing.T) {
+	const (
+		goodOutput = `{
+			"kind": "ExecCredential",
+			"apiVersion": "client.authentication.k8s.io/v1beta1",
+			"status": {
+				"token": "foo-bar"
+			}
+		}`
+	)
+
+	callsMetricCounter := &mockCallsMetricCounter{}
+	originalExecPluginCalls := metrics.ExecPluginCalls
+	t.Cleanup(func() { metrics.ExecPluginCalls = originalExecPluginCalls })
+	metrics.ExecPluginCalls = callsMetricCounter
+
+	exitCodes := []int{0, 1, 2, 0}
+	var wantCallsMetrics []mockCallsMetric
+	for _, exitCode := range exitCodes {
+		c := api.ExecConfig{
+			Command:    "./testdata/test-plugin.sh",
+			APIVersion: "client.authentication.k8s.io/v1beta1",
+			Env: []api.ExecEnvVar{
+				{Name: "TEST_EXIT_CODE", Value: fmt.Sprintf("%d", exitCode)},
+				{Name: "TEST_OUTPUT", Value: goodOutput},
+			},
+		}
+
+		a, err := newAuthenticator(newCache(), &c, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Run refresh creds twice so that our test validates that the metrics are set correctly twice
+		// in a row with the same authenticator.
+		refreshCreds := func() {
+			if err := a.refreshCredsLocked(&clientauthentication.Response{}); (err == nil) != (exitCode == 0) {
+				if err != nil {
+					t.Fatalf("wanted no error, but got %q", err.Error())
+				} else {
+					t.Fatal("wanted error, but got nil")
+				}
+			}
+			mockCallsMetric := mockCallsMetric{exitCode: exitCode, errorType: "no_error"}
+			if exitCode != 0 {
+				mockCallsMetric.errorType = "plugin_execution_error"
+			}
+			wantCallsMetrics = append(wantCallsMetrics, mockCallsMetric)
+		}
+		refreshCreds()
+		refreshCreds()
+	}
+
+	// Run some iterations of the authenticator where the exec plugin fails to run to test special
+	// metric values.
+	refreshCreds := func(command string) {
+		c := api.ExecConfig{
+			Command:    "does not exist",
+			APIVersion: "client.authentication.k8s.io/v1beta1",
+		}
+		a, err := newAuthenticator(newCache(), &c, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := a.refreshCredsLocked(&clientauthentication.Response{}); err == nil {
+			t.Fatal("expected the authenticator to fail because the plugin does not exist")
+		}
+		wantCallsMetrics = append(wantCallsMetrics, mockCallsMetric{exitCode: 1, errorType: "plugin_not_found_error"})
+	}
+	refreshCreds("does not exist without path slashes")
+	refreshCreds("./does/not/exist/with/relative/path")
+	refreshCreds("/does/not/exist/with/absolute/path")
+
+	callsMetricComparer := cmp.Comparer(func(a, b mockCallsMetric) bool {
+		return a.exitCode == b.exitCode && a.errorType == b.errorType
+	})
+	actuallCallsMetrics := callsMetricCounter.calls
+	if diff := cmp.Diff(wantCallsMetrics, actuallCallsMetrics, callsMetricComparer); diff != "" {
+		t.Fatalf("got unexpected metrics calls; -want, +got:\n%s", diff)
 	}
 }

--- a/staging/src/k8s.io/client-go/tools/metrics/metrics.go
+++ b/staging/src/k8s.io/client-go/tools/metrics/metrics.go
@@ -46,6 +46,12 @@ type ResultMetric interface {
 	Increment(code string, method string, host string)
 }
 
+// CallsMetric counts calls that take place for a specific exec plugin.
+type CallsMetric interface {
+	// Increment increments a counter per exitCode and callStatus.
+	Increment(exitCode int, callStatus string)
+}
+
 var (
 	// ClientCertExpiry is the expiry time of a client certificate
 	ClientCertExpiry ExpiryMetric = noopExpiry{}
@@ -57,6 +63,9 @@ var (
 	RateLimiterLatency LatencyMetric = noopLatency{}
 	// RequestResult is the result metric that rest clients will update.
 	RequestResult ResultMetric = noopResult{}
+	// ExecPluginCalls is the number of calls made to an exec plugin, partitioned by
+	// exit code and call status.
+	ExecPluginCalls CallsMetric = noopCalls{}
 )
 
 // RegisterOpts contains all the metrics to register. Metrics may be nil.
@@ -66,6 +75,7 @@ type RegisterOpts struct {
 	RequestLatency        LatencyMetric
 	RateLimiterLatency    LatencyMetric
 	RequestResult         ResultMetric
+	ExecPluginCalls       CallsMetric
 }
 
 // Register registers metrics for the rest client to use. This can
@@ -87,6 +97,9 @@ func Register(opts RegisterOpts) {
 		if opts.RequestResult != nil {
 			RequestResult = opts.RequestResult
 		}
+		if opts.ExecPluginCalls != nil {
+			ExecPluginCalls = opts.ExecPluginCalls
+		}
 	})
 }
 
@@ -105,3 +118,7 @@ func (noopLatency) Observe(string, url.URL, time.Duration) {}
 type noopResult struct{}
 
 func (noopResult) Increment(string, string, string) {}
+
+type noopCalls struct{}
+
+func (noopCalls) Increment(int, string) {}

--- a/staging/src/k8s.io/component-base/metrics/prometheus/restclient/metrics.go
+++ b/staging/src/k8s.io/component-base/metrics/prometheus/restclient/metrics.go
@@ -17,6 +17,7 @@ limitations under the License.
 package restclient
 
 import (
+	"fmt"
 	"math"
 	"net/url"
 	"time"
@@ -103,6 +104,17 @@ var (
 			},
 		},
 	)
+
+	execPluginCalls = k8smetrics.NewCounterVec(
+		&k8smetrics.CounterOpts{
+			Name: "rest_client_exec_plugin_call_total",
+			Help: "Number of calls to an exec plugin, partitioned by the type of " +
+				"event encountered (no_error, plugin_execution_error, plugin_not_found_error, " +
+				"client_internal_error) and an optional exit code. The exit code will " +
+				"be set to 0 if and only if the plugin call was successful.",
+		},
+		[]string{"code", "call_status"},
+	)
 )
 
 func init() {
@@ -117,6 +129,7 @@ func init() {
 		RequestLatency:        &latencyAdapter{m: requestLatency},
 		RateLimiterLatency:    &latencyAdapter{m: rateLimiterLatency},
 		RequestResult:         &resultAdapter{requestResult},
+		ExecPluginCalls:       &callsAdapter{m: execPluginCalls},
 	})
 }
 
@@ -150,4 +163,12 @@ type rotationAdapter struct {
 
 func (r *rotationAdapter) Observe(d time.Duration) {
 	r.m.Observe(d.Seconds())
+}
+
+type callsAdapter struct {
+	m *k8smetrics.CounterVec
+}
+
+func (r *callsAdapter) Increment(code int, callStatus string) {
+	r.m.WithLabelValues(fmt.Sprintf("%d", code), callStatus).Inc()
 }


### PR DESCRIPTION
Signed-off-by: Andrew Keesler <akeesler@vmware.com>

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

- Add `rest_client_exec_plugin_call_total` metric to client-go which tracks the number of calls to any exec plugin and partitions the calls by exit code.

**Which issue(s) this PR fixes**:

- This is in service of getting the client-go credential plugin feature to GA: https://github.com/kubernetes/enhancements/issues/541.
- Here are the metrics described in the KEP: https://github.com/kubernetes/enhancements/tree/7e69f3be9783e33f597b02de8c952b6eca1e8273/keps/sig-auth/541-external-credential-providers#metrics.
  - Note that 2 of the metrics have already been implemented, and this PR is adding the 3rd.

**Does this PR introduce a user-facing change?**:

```release-note
A client-go metric, rest_client_exec_plugin_call_total, has been added to track total calls to client-go credential plugins.
```
