### PR TITLE
Promote PodProxyWithPath & ServiceProxyWithPath test - + 12 endpoint coverage

### DIFF
--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -1702,6 +1702,14 @@
     other platforms like Windows.
   release: v1.9
   file: test/e2e/common/networking.go
+- testname: Proxy, validate ProxyWithPath responses
+  codename: '[sig-network] Proxy version v1 A set of valid responses are returned
+    for both pod and service ProxyWithPath [Conformance]'
+  description: Attempt to create a pod and a service. A set of pod and service endpoints
+    MUST be accessed via ProxyWithPath using a list of http methods. A valid response
+    MUST be returned for each endpoint.
+  release: v1.21
+  file: test/e2e/network/proxy.go
 - testname: Proxy, logs service endpoint
   codename: '[sig-network] Proxy version v1 should proxy through a service and a pod  [Conformance]'
   description: Select any node in the cluster to invoke  /logs endpoint  using the

--- a/test/e2e/network/proxy.go
+++ b/test/e2e/network/proxy.go
@@ -273,7 +273,15 @@ var _ = SIGDescribe("Proxy", func() {
 			}
 		})
 
-		ginkgo.It("A set of valid responses are returned for both pod and service ProxyWithPath", func() {
+		/*
+		Release: v1.21
+		Testname: Proxy, validate ProxyWithPath responses
+		Description: Attempt to create a pod and a service. A
+		set of pod and service endpoints MUST be accessed via
+		ProxyWithPath using a list of http methods. A valid
+		response MUST be returned for each endpoint.
+		*/
+		framework.ConformanceIt("A set of valid responses are returned for both pod and service ProxyWithPath", func() {
 
 			ns := f.Namespace.Name
 			msg := "foo"

--- a/test/e2e/network/proxy.go
+++ b/test/e2e/network/proxy.go
@@ -274,12 +274,12 @@ var _ = SIGDescribe("Proxy", func() {
 		})
 
 		/*
-		Release: v1.21
-		Testname: Proxy, validate ProxyWithPath responses
-		Description: Attempt to create a pod and a service. A
-		set of pod and service endpoints MUST be accessed via
-		ProxyWithPath using a list of http methods. A valid
-		response MUST be returned for each endpoint.
+			Release: v1.21
+			Testname: Proxy, validate ProxyWithPath responses
+			Description: Attempt to create a pod and a service. A
+			set of pod and service endpoints MUST be accessed via
+			ProxyWithPath using a list of http methods. A valid
+			response MUST be returned for each endpoint.
 		*/
 		framework.ConformanceIt("A set of valid responses are returned for both pod and service ProxyWithPath", func() {
 


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it:**
This PR adds a test to test the following untested endpoints:
Pod:
connectCoreV1PutNamespacedPodProxyWithPath
connectCoreV1PostNamespacedPodProxyWithPath 
connectCoreV1PatchNamespacedPodProxyWithPath
connectCoreV1OptionsNamespacedPodProxyWithPath 
connectCoreV1HeadNamespacedPodProxyWithPath 
connectCoreV1DeleteNamespacedPodProxyWithPath
Service:
connectCoreV1PutNamespacedServiceProxyWithPath
connectCoreV1PostNamespacedServiceProxyWithPath
connectCoreV1PatchNamespacedServiceProxyWithPath 
connectCoreV1OptionsNamespacedServiceProxyWithPath 
connectCoreV1HeadNamespacedServiceProxyWithPath
connectCoreV1DeleteNamespacedServiceProxyWithPath


**Which issue(s) this PR fixes:**
Fixes #95500

**Testgrid Link:**
[Testgrid](https://testgrid.k8s.io/sig-release-master-blocking#gce-cos-master-default&width=5&include-filter-by-regex=both%20pod%20and%20service%20ProxyWithPath&graph-metrics=test-duration-minutes)


**Special notes for your reviewer:**
Adds +12 endpoint test coverage (good for conformance)

**Does this PR introduce a user-facing change?:**
```
NONE

```

**Release note:**
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:**
```
NONE

```

/sig testing
/sig architecture
/area conformance
