### PR TITLE
sched: remove Unknown queuing literal

### DIFF
--- a/pkg/scheduler/eventhandlers.go
+++ b/pkg/scheduler/eventhandlers.go
@@ -118,14 +118,8 @@ func (sched *Scheduler) updateNodeInCache(oldObj, newObj interface{}) {
 		klog.Errorf("scheduler cache UpdateNode failed: %v", err)
 	}
 
-	// Only activate unschedulable pods if the node became more schedulable.
-	// We skip the node property comparison when there is no unschedulable pods in the queue
-	// to save processing cycles. We still trigger a move to active queue to cover the case
-	// that a pod being processed by the scheduler is determined unschedulable. We want this
-	// pod to be reevaluated when a change in the cluster happens.
-	if sched.SchedulingQueue.NumUnschedulablePods() == 0 {
-		sched.SchedulingQueue.MoveAllToActiveOrBackoffQueue(queue.Unknown)
-	} else if event := nodeSchedulingPropertiesChange(newNode, oldNode); event != "" {
+	// Only requeue unschedulable pods if the node became more schedulable.
+	if event := nodeSchedulingPropertiesChange(newNode, oldNode); event != "" {
 		sched.SchedulingQueue.MoveAllToActiveOrBackoffQueue(event)
 	}
 }

--- a/pkg/scheduler/internal/queue/events.go
+++ b/pkg/scheduler/internal/queue/events.go
@@ -18,8 +18,6 @@ package queue
 
 // Events that trigger scheduler queue to change.
 const (
-	// Unknown event
-	Unknown = "Unknown"
 	// PodAdd is the event when a new pod is added to API server.
 	PodAdd = "PodAdd"
 	// NodeAdd is the event when a new node is added to the cluster.
@@ -63,9 +61,9 @@ const (
 	NodeSpecUnschedulableChange = "NodeSpecUnschedulableChange"
 	// NodeAllocatableChange is the event when node allocatable is changed.
 	NodeAllocatableChange = "NodeAllocatableChange"
-	// NodeLabelsChange is the event when node label is changed.
+	// NodeLabelChange is the event when node label is changed.
 	NodeLabelChange = "NodeLabelChange"
-	// NodeTaintsChange is the event when node taint is changed.
+	// NodeTaintChange is the event when node taint is changed.
 	NodeTaintChange = "NodeTaintChange"
 	// NodeConditionChange is the event when node condition is changed.
 	NodeConditionChange = "NodeConditionChange"


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup
/sig scheduling

**What this PR does / why we need it**:

The `Unknown` queuing event is deduced when no unschedulable pods are present. However, we don't need this as MoveAllToActiveOrBackoffQueue() and the subsequent logic are able to handle that case.

**Which issue(s) this PR fixes**:

Ref https://github.com/kubernetes/kubernetes/pull/98241#discussion_r572273294

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```