### PR TITLE
fix: show resource kind only when --show-kind is specified

### DIFF
--- a/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/name_flags.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/name_flags.go
@@ -83,6 +83,5 @@ func (f *NamePrintFlags) AddFlags(c *cobra.Command) {}
 func NewNamePrintFlags(operation string) *NamePrintFlags {
 	return &NamePrintFlags{
 		Operation: operation,
-		ShowKind:  false, // by default it doesn't show kind
 	}
 }

--- a/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/name_flags.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/name_flags.go
@@ -33,6 +33,9 @@ type NamePrintFlags struct {
 	// took place on an object, to be included in the
 	// finalized "successful" message.
 	Operation string
+	// ShowKind is a flag to decide whether the resource's
+	// kind should be printed. By default it's false.
+	ShowKind bool
 }
 
 // Complete sets NamePrintFlags operation flag from sucessTemplate
@@ -56,6 +59,7 @@ func (f *NamePrintFlags) AllowedFormats() []string {
 func (f *NamePrintFlags) ToPrinter(outputFormat string) (printers.ResourcePrinter, error) {
 	namePrinter := &printers.NamePrinter{
 		Operation: f.Operation,
+		ShowKind:  f.ShowKind,
 	}
 
 	outputFormat = strings.ToLower(outputFormat)
@@ -79,5 +83,6 @@ func (f *NamePrintFlags) AddFlags(c *cobra.Command) {}
 func NewNamePrintFlags(operation string) *NamePrintFlags {
 	return &NamePrintFlags{
 		Operation: operation,
+		ShowKind:  false, // by default it doesn't show kind
 	}
 }

--- a/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/name_flags_test.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/name_flags_test.go
@@ -35,6 +35,7 @@ func TestNamePrinterSupportsExpectedFormats(t *testing.T) {
 		name           string
 		outputFormat   string
 		operation      string
+		showKind       bool
 		dryRun         bool
 		expectedError  string
 		expectedOutput string
@@ -43,33 +44,45 @@ func TestNamePrinterSupportsExpectedFormats(t *testing.T) {
 		{
 			name:           "valid \"name\" output format with no operation prints resource name",
 			outputFormat:   "name",
+			showKind:       false,
+			expectedOutput: "foo",
+		},
+		{
+			name:           "valid \"kind/name\" output format with no operation prints resource name",
+			outputFormat:   "name",
+			showKind:       true,
 			expectedOutput: "pod/foo",
 		},
 		{
 			name:           "valid \"name\" output format and an operation results in a short-output (non success printer) message",
 			outputFormat:   "name",
 			operation:      "patched",
+			showKind:       true,
 			expectedOutput: "pod/foo",
 		},
 		{
 			name:          "operation and no valid \"name\" output does not match a printer",
 			operation:     "patched",
 			outputFormat:  "invalid",
+			showKind:      true,
 			dryRun:        true,
 			expectNoMatch: true,
 		},
 		{
 			name:           "operation and empty output still matches name printer",
+			showKind:       true,
 			expectedOutput: "pod/foo patched",
 			operation:      "patched",
 		},
 		{
 			name:          "no printer is matched on an invalid outputFormat",
+			showKind:      true,
 			outputFormat:  "invalid",
 			expectNoMatch: true,
 		},
 		{
 			name:          "printer should not match on any other format supported by another printer",
+			showKind:      true,
 			outputFormat:  "go-template",
 			expectNoMatch: true,
 		},
@@ -79,6 +92,7 @@ func TestNamePrinterSupportsExpectedFormats(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			printFlags := NamePrintFlags{
 				Operation: tc.operation,
+				ShowKind:  tc.showKind,
 			}
 
 			p, err := printFlags.ToPrinter(tc.outputFormat)

--- a/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/name_flags_test.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/name_flags_test.go
@@ -44,7 +44,6 @@ func TestNamePrinterSupportsExpectedFormats(t *testing.T) {
 		{
 			name:           "valid \"name\" output format with no operation prints resource name",
 			outputFormat:   "name",
-			showKind:       false,
 			expectedOutput: "foo",
 		},
 		{

--- a/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/print_flags.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/print_flags.go
@@ -157,6 +157,13 @@ func (f *PrintFlags) WithTypeSetter(scheme *runtime.Scheme) *PrintFlags {
 	return f
 }
 
+// WithShowKindOnName sets true on NamePrintFlags in Flags to show
+// ResourceKind on the name
+func (f *PrintFlags) WithShowKindOnName() *PrintFlags {
+	f.NamePrintFlags.ShowKind = true
+	return f
+}
+
 // NewPrintFlags returns a default *PrintFlags
 func NewPrintFlags(operation string) *PrintFlags {
 	outputFormat := ""

--- a/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/print_flags_test.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/print_flags_test.go
@@ -20,7 +20,7 @@ import (
 	"bytes"
 	"testing"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -63,7 +63,7 @@ func TestNamePrinter(t *testing.T) {
 			"pod/bar\n"},
 	}
 
-	printFlags := NewPrintFlags("").WithTypeSetter(scheme.Scheme).WithDefaultOutput("name")
+	printFlags := NewPrintFlags("").WithTypeSetter(scheme.Scheme).WithDefaultOutput("name").WithShowKindOnName()
 	printer, err := printFlags.ToPrinter()
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)

--- a/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/print_flags_test.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/print_flags_test.go
@@ -20,7 +20,7 @@ import (
 	"bytes"
 	"testing"
 
-	v1 "k8s.io/api/core/v1"
+	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"

--- a/staging/src/k8s.io/cli-runtime/pkg/printers/name.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/printers/name.go
@@ -123,19 +123,18 @@ func printObj(w io.Writer, name string, operation string, shortOutput, showKind 
 		operation = ""
 	}
 
-	if len(groupKind.Group) == 0 {
-		if showKind {
-			fmt.Fprintf(w, "%s/%s%s\n", strings.ToLower(groupKind.Kind), name, operation)
-		} else {
-			fmt.Fprintf(w, "%s%s\n", name, operation)
-		}
+	obj := fmt.Sprintf("%s%s", name, operation)
+
+	if !showKind {
+		fmt.Fprintf(w, "%s\n",  obj)
 		return nil
 	}
 
-	if showKind {
-		fmt.Fprintf(w, "%s.%s/%s%s\n", strings.ToLower(groupKind.Kind), groupKind.Group, name, operation)
-	} else {
-		fmt.Fprintf(w, "%s%s\n", name, operation)
+	kind := strings.ToLower(groupKind.Kind)
+	if len(groupKind.Group) > 0 {
+		kind = fmt.Sprintf("%s.%s", kind, groupKind.Group)
 	}
+
+	fmt.Fprintf(w, "%s/%s\n", kind, obj)
 	return nil
 }

--- a/staging/src/k8s.io/cli-runtime/pkg/printers/name.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/printers/name.go
@@ -126,7 +126,7 @@ func printObj(w io.Writer, name string, operation string, shortOutput, showKind 
 	obj := fmt.Sprintf("%s%s", name, operation)
 
 	if !showKind {
-		fmt.Fprintf(w, "%s\n",  obj)
+		fmt.Fprintf(w, "%s\n", obj)
 		return nil
 	}
 

--- a/staging/src/k8s.io/cli-runtime/pkg/printers/name_test.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/printers/name_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Kubernetes Authors.
+Copyright 2021 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/k8s.io/cli-runtime/pkg/printers/name_test.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/printers/name_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package printers
 
 import (
@@ -19,9 +35,9 @@ func TestPrintObj(t *testing.T) {
 	}{
 		// must be: [kind.group/name operation]
 		{
-			name:        "testing-pod",
-			operation:   "edited",
-			showKind:    true,
+			name:      "testing-pod",
+			operation: "edited",
+			showKind:  true,
 			groupKind: schema.GroupKind{
 				Group: "test",
 				Kind:  "pod",
@@ -42,18 +58,18 @@ func TestPrintObj(t *testing.T) {
 		},
 		// when Group is empty, it's omitted
 		{
-			name:        "testing-pod",
-			operation:   "edited",
-			showKind:    true,
+			name:      "testing-pod",
+			operation: "edited",
+			showKind:  true,
 			groupKind: schema.GroupKind{
-				Kind:  "pod",
+				Kind: "pod",
 			},
 			expected: "pod/testing-pod edited\n",
 		},
 		// when showKind is false, it's omitted
 		{
-			name:        "testing-pod",
-			operation:   "edited",
+			name:      "testing-pod",
+			operation: "edited",
 			groupKind: schema.GroupKind{
 				Group: "test",
 				Kind:  "pod",
@@ -62,8 +78,8 @@ func TestPrintObj(t *testing.T) {
 		},
 		// when Kind is empty, error should be responded
 		{
-			name:        "testing-pod",
-			operation:   "edited",
+			name:      "testing-pod",
+			operation: "edited",
 			groupKind: schema.GroupKind{
 				Group: "test",
 			},

--- a/staging/src/k8s.io/cli-runtime/pkg/printers/name_test.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/printers/name_test.go
@@ -1,0 +1,86 @@
+package printers
+
+import (
+	"bytes"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func TestPrintObj(t *testing.T) {
+	tests := []struct {
+		name          string
+		operation     string
+		shortOutput   bool
+		showKind      bool
+		groupKind     schema.GroupKind
+		expected      string
+		expectedError bool
+	}{
+		// must be: [kind.group/name operation]
+		{
+			name:        "testing-pod",
+			operation:   "edited",
+			showKind:    true,
+			groupKind: schema.GroupKind{
+				Group: "test",
+				Kind:  "pod",
+			},
+			expected: "pod.test/testing-pod edited\n",
+		},
+		// when shortOutput is true, operation is omitted
+		{
+			name:        "testing-pod",
+			operation:   "edited",
+			shortOutput: true,
+			showKind:    true,
+			groupKind: schema.GroupKind{
+				Group: "test",
+				Kind:  "pod",
+			},
+			expected: "pod.test/testing-pod\n",
+		},
+		// when Group is empty, it's omitted
+		{
+			name:        "testing-pod",
+			operation:   "edited",
+			showKind:    true,
+			groupKind: schema.GroupKind{
+				Kind:  "pod",
+			},
+			expected: "pod/testing-pod edited\n",
+		},
+		// when showKind is false, it's omitted
+		{
+			name:        "testing-pod",
+			operation:   "edited",
+			groupKind: schema.GroupKind{
+				Group: "test",
+				Kind:  "pod",
+			},
+			expected: "testing-pod edited\n",
+		},
+		// when Kind is empty, error should be responded
+		{
+			name:        "testing-pod",
+			operation:   "edited",
+			groupKind: schema.GroupKind{
+				Group: "test",
+			},
+			expectedError: true,
+		},
+	}
+
+	for _, test := range tests {
+		out := bytes.NewBuffer([]byte{})
+		err := printObj(out, test.name, test.operation, test.shortOutput, test.showKind, test.groupKind)
+
+		if test.expectedError != (err != nil) {
+			t.Errorf("Expected Error fail. Should be (%v); got (%s)", test.expectedError, err)
+		}
+
+		if out.String() != test.expected {
+			t.Errorf("Error output. Should be (%s); got (%s)", test.expected, out.String())
+		}
+	}
+}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/annotate/annotate.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/annotate/annotate.go
@@ -115,7 +115,7 @@ var (
 // NewAnnotateOptions creates the options for annotate
 func NewAnnotateOptions(ioStreams genericclioptions.IOStreams) *AnnotateOptions {
 	return &AnnotateOptions{
-		PrintFlags: genericclioptions.NewPrintFlags("annotated").WithTypeSetter(scheme.Scheme),
+		PrintFlags: genericclioptions.NewPrintFlags("annotated").WithTypeSetter(scheme.Scheme).WithShowKindOnName(),
 
 		RecordFlags: genericclioptions.NewRecordFlags(),
 		Recorder:    genericclioptions.NoopRecorder{},

--- a/staging/src/k8s.io/kubectl/pkg/cmd/apply/apply.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apply/apply.go
@@ -232,7 +232,6 @@ func (o *ApplyOptions) Complete(f cmdutil.Factory, cmd *cobra.Command) error {
 	// allow for a success message operation to be specified at print time
 	o.ToPrinter = func(operation string) (printers.ResourcePrinter, error) {
 		o.PrintFlags.NamePrintFlags.Operation = operation
-		o.PrintFlags.NamePrintFlags.ShowKind = true
 		cmdutil.PrintFlagsWithDryRunStrategy(o.PrintFlags, o.DryRunStrategy)
 		return o.PrintFlags.ToPrinter()
 	}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/apply/apply.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apply/apply.go
@@ -142,7 +142,7 @@ func NewApplyOptions(ioStreams genericclioptions.IOStreams) *ApplyOptions {
 	return &ApplyOptions{
 		RecordFlags: genericclioptions.NewRecordFlags(),
 		DeleteFlags: delete.NewDeleteFlags("that contains the configuration to apply"),
-		PrintFlags:  genericclioptions.NewPrintFlags("created").WithTypeSetter(scheme.Scheme),
+		PrintFlags:  genericclioptions.NewPrintFlags("created").WithTypeSetter(scheme.Scheme).WithShowKindOnName(),
 
 		Overwrite:    true,
 		OpenAPIPatch: true,
@@ -232,6 +232,7 @@ func (o *ApplyOptions) Complete(f cmdutil.Factory, cmd *cobra.Command) error {
 	// allow for a success message operation to be specified at print time
 	o.ToPrinter = func(operation string) (printers.ResourcePrinter, error) {
 		o.PrintFlags.NamePrintFlags.Operation = operation
+		o.PrintFlags.NamePrintFlags.ShowKind = true
 		cmdutil.PrintFlagsWithDryRunStrategy(o.PrintFlags, o.DryRunStrategy)
 		return o.PrintFlags.ToPrinter()
 	}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/apply/apply_set_last_applied.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apply/apply_set_last_applied.go
@@ -87,7 +87,7 @@ var (
 // NewSetLastAppliedOptions takes option arguments from a CLI stream and returns it at SetLastAppliedOptions type.
 func NewSetLastAppliedOptions(ioStreams genericclioptions.IOStreams) *SetLastAppliedOptions {
 	return &SetLastAppliedOptions{
-		PrintFlags: genericclioptions.NewPrintFlags("configured").WithTypeSetter(scheme.Scheme),
+		PrintFlags: genericclioptions.NewPrintFlags("configured").WithTypeSetter(scheme.Scheme).WithShowKindOnName(),
 		IOStreams:  ioStreams,
 	}
 }

--- a/staging/src/k8s.io/kubectl/pkg/cmd/auth/reconcile.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/auth/reconcile.go
@@ -79,7 +79,7 @@ var (
 func NewReconcileOptions(ioStreams genericclioptions.IOStreams) *ReconcileOptions {
 	return &ReconcileOptions{
 		FilenameOptions: &resource.FilenameOptions{},
-		PrintFlags:      genericclioptions.NewPrintFlags("reconciled").WithTypeSetter(scheme.Scheme),
+		PrintFlags:      genericclioptions.NewPrintFlags("reconciled").WithTypeSetter(scheme.Scheme).WithShowKindOnName(),
 		IOStreams:       ioStreams,
 	}
 }

--- a/staging/src/k8s.io/kubectl/pkg/cmd/autoscale/autoscale.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/autoscale/autoscale.go
@@ -86,7 +86,7 @@ type AutoscaleOptions struct {
 // NewAutoscaleOptions creates the options for autoscale
 func NewAutoscaleOptions(ioStreams genericclioptions.IOStreams) *AutoscaleOptions {
 	return &AutoscaleOptions{
-		PrintFlags:      genericclioptions.NewPrintFlags("autoscaled").WithTypeSetter(scheme.Scheme),
+		PrintFlags:      genericclioptions.NewPrintFlags("autoscaled").WithTypeSetter(scheme.Scheme).WithShowKindOnName(),
 		FilenameOptions: &resource.FilenameOptions{},
 		RecordFlags:     genericclioptions.NewRecordFlags(),
 		Recorder:        genericclioptions.NoopRecorder{},

--- a/staging/src/k8s.io/kubectl/pkg/cmd/certificates/certificates.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/certificates/certificates.go
@@ -78,7 +78,7 @@ type CertificateOptions struct {
 // NewCertificateOptions creates CertificateOptions struct for `certificate` command
 func NewCertificateOptions(ioStreams genericclioptions.IOStreams, operation string) *CertificateOptions {
 	return &CertificateOptions{
-		PrintFlags: genericclioptions.NewPrintFlags(operation).WithTypeSetter(scheme.Scheme),
+		PrintFlags: genericclioptions.NewPrintFlags(operation).WithTypeSetter(scheme.Scheme).WithShowKindOnName(),
 		IOStreams:  ioStreams,
 	}
 }

--- a/staging/src/k8s.io/kubectl/pkg/cmd/clusterinfo/clusterinfo_dump.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/clusterinfo/clusterinfo_dump.go
@@ -64,7 +64,7 @@ type ClusterInfoDumpOptions struct {
 
 func NewCmdClusterInfoDump(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *cobra.Command {
 	o := &ClusterInfoDumpOptions{
-		PrintFlags: genericclioptions.NewPrintFlags("").WithTypeSetter(scheme.Scheme).WithDefaultOutput("json"),
+		PrintFlags: genericclioptions.NewPrintFlags("").WithTypeSetter(scheme.Scheme).WithDefaultOutput("json").WithShowKindOnName(),
 
 		IOStreams: ioStreams,
 	}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/view.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/view.go
@@ -70,7 +70,7 @@ var (
 // NewCmdConfigView returns a Command instance for 'config view' sub command
 func NewCmdConfigView(f cmdutil.Factory, streams genericclioptions.IOStreams, ConfigAccess clientcmd.ConfigAccess) *cobra.Command {
 	o := &ViewOptions{
-		PrintFlags:   genericclioptions.NewPrintFlags("").WithTypeSetter(scheme.Scheme).WithDefaultOutput("yaml"),
+		PrintFlags:   genericclioptions.NewPrintFlags("").WithTypeSetter(scheme.Scheme).WithDefaultOutput("yaml").WithShowKindOnName(),
 		ConfigAccess: ConfigAccess,
 
 		IOStreams: streams,

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create.go
@@ -87,7 +87,7 @@ var (
 // NewCreateOptions returns an initialized CreateOptions instance
 func NewCreateOptions(ioStreams genericclioptions.IOStreams) *CreateOptions {
 	return &CreateOptions{
-		PrintFlags:  genericclioptions.NewPrintFlags("created").WithTypeSetter(scheme.Scheme),
+		PrintFlags:  genericclioptions.NewPrintFlags("created").WithTypeSetter(scheme.Scheme).WithShowKindOnName(),
 		RecordFlags: genericclioptions.NewRecordFlags(),
 
 		Recorder: genericclioptions.NoopRecorder{},
@@ -361,7 +361,7 @@ type CreateSubcommandOptions struct {
 // NewCreateSubcommandOptions returns initialized CreateSubcommandOptions
 func NewCreateSubcommandOptions(ioStreams genericclioptions.IOStreams) *CreateSubcommandOptions {
 	return &CreateSubcommandOptions{
-		PrintFlags: genericclioptions.NewPrintFlags("created").WithTypeSetter(scheme.Scheme),
+		PrintFlags: genericclioptions.NewPrintFlags("created").WithTypeSetter(scheme.Scheme).WithShowKindOnName(),
 		IOStreams:  ioStreams,
 	}
 }

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_clusterrolebinding.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_clusterrolebinding.go
@@ -71,7 +71,7 @@ func NewClusterRoleBindingOptions(ioStreams genericclioptions.IOStreams) *Cluste
 		Users:           []string{},
 		Groups:          []string{},
 		ServiceAccounts: []string{},
-		PrintFlags:      genericclioptions.NewPrintFlags("created").WithTypeSetter(scheme.Scheme),
+		PrintFlags:      genericclioptions.NewPrintFlags("created").WithTypeSetter(scheme.Scheme).WithShowKindOnName(),
 		IOStreams:       ioStreams,
 	}
 }

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_configmap.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_configmap.go
@@ -108,7 +108,7 @@ func NewConfigMapOptions(ioStreams genericclioptions.IOStreams) *ConfigMapOption
 	return &ConfigMapOptions{
 		FileSources:    []string{},
 		LiteralSources: []string{},
-		PrintFlags:     genericclioptions.NewPrintFlags("created").WithTypeSetter(scheme.Scheme),
+		PrintFlags:     genericclioptions.NewPrintFlags("created").WithTypeSetter(scheme.Scheme).WithShowKindOnName(),
 		IOStreams:      ioStreams,
 	}
 }

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_cronjob.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_cronjob.go
@@ -78,7 +78,7 @@ type CreateCronJobOptions struct {
 // NewCreateCronJobOptions returns an initialized CreateCronJobOptions instance
 func NewCreateCronJobOptions(ioStreams genericclioptions.IOStreams) *CreateCronJobOptions {
 	return &CreateCronJobOptions{
-		PrintFlags: genericclioptions.NewPrintFlags("created").WithTypeSetter(scheme.Scheme),
+		PrintFlags: genericclioptions.NewPrintFlags("created").WithTypeSetter(scheme.Scheme).WithShowKindOnName(),
 		IOStreams:  ioStreams,
 	}
 }

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_deployment.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_deployment.go
@@ -84,7 +84,7 @@ func NewCreateDeploymentOptions(ioStreams genericclioptions.IOStreams) *CreateDe
 	return &CreateDeploymentOptions{
 		Port:       -1,
 		Replicas:   1,
-		PrintFlags: genericclioptions.NewPrintFlags("created").WithTypeSetter(scheme.Scheme),
+		PrintFlags: genericclioptions.NewPrintFlags("created").WithTypeSetter(scheme.Scheme).WithShowKindOnName(),
 		IOStreams:  ioStreams,
 	}
 }

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_deployment_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_deployment_test.go
@@ -147,7 +147,7 @@ func TestCreateDeploymentNoImage(t *testing.T) {
 	cmd := NewCmdCreateDeployment(tf, ioStreams)
 	cmd.Flags().Set("output", "name")
 	options := &CreateDeploymentOptions{
-		PrintFlags:     genericclioptions.NewPrintFlags("created").WithTypeSetter(scheme.Scheme),
+		PrintFlags:     genericclioptions.NewPrintFlags("created").WithTypeSetter(scheme.Scheme).WithShowKindOnName(),
 		DryRunStrategy: cmdutil.DryRunClient,
 		IOStreams:      ioStreams,
 	}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_ingress.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_ingress.go
@@ -128,7 +128,7 @@ type CreateIngressOptions struct {
 // NewCreateIngressOptions creates the CreateIngressOptions to be used later
 func NewCreateIngressOptions(ioStreams genericclioptions.IOStreams) *CreateIngressOptions {
 	return &CreateIngressOptions{
-		PrintFlags: genericclioptions.NewPrintFlags("created").WithTypeSetter(scheme.Scheme),
+		PrintFlags: genericclioptions.NewPrintFlags("created").WithTypeSetter(scheme.Scheme).WithShowKindOnName(),
 		IOStreams:  ioStreams,
 	}
 }

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_job.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_job.go
@@ -78,7 +78,7 @@ type CreateJobOptions struct {
 // NewCreateJobOptions initializes and returns new CreateJobOptions instance
 func NewCreateJobOptions(ioStreams genericclioptions.IOStreams) *CreateJobOptions {
 	return &CreateJobOptions{
-		PrintFlags: genericclioptions.NewPrintFlags("created").WithTypeSetter(scheme.Scheme),
+		PrintFlags: genericclioptions.NewPrintFlags("created").WithTypeSetter(scheme.Scheme).WithShowKindOnName(),
 		IOStreams:  ioStreams,
 	}
 }

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_pdb.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_pdb.go
@@ -79,7 +79,7 @@ type PodDisruptionBudgetOpts struct {
 // NewPodDisruptionBudgetOpts creates a new *PodDisruptionBudgetOpts with sane defaults
 func NewPodDisruptionBudgetOpts(ioStreams genericclioptions.IOStreams) *PodDisruptionBudgetOpts {
 	return &PodDisruptionBudgetOpts{
-		PrintFlags: genericclioptions.NewPrintFlags("created").WithTypeSetter(scheme.Scheme),
+		PrintFlags: genericclioptions.NewPrintFlags("created").WithTypeSetter(scheme.Scheme).WithShowKindOnName(),
 		IOStreams:  ioStreams,
 	}
 }

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_priorityclass.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_priorityclass.go
@@ -76,7 +76,7 @@ func NewPriorityClassOptions(ioStreams genericclioptions.IOStreams) *PriorityCla
 	return &PriorityClassOptions{
 		Value:            0,
 		PreemptionPolicy: "PreemptLowerPriority",
-		PrintFlags:       genericclioptions.NewPrintFlags("created").WithTypeSetter(scheme.Scheme),
+		PrintFlags:       genericclioptions.NewPrintFlags("created").WithTypeSetter(scheme.Scheme).WithShowKindOnName(),
 		IOStreams:        ioStreams,
 	}
 }

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_priorityclass_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_priorityclass_test.go
@@ -60,14 +60,10 @@ func TestCreatePriorityClass(t *testing.T) {
 	cmd.Flags().Set("output", outputFormat)
 	cmd.Flags().Set("preemption-policy", "Never")
 
-	printFlags := genericclioptions.NewPrintFlags("created").WithTypeSetter(scheme.Scheme)
-	printFlags.OutputFormat = &outputFormat
+	options := NewPriorityClassOptions(ioStreams)
+	options.PrintFlags.OutputFormat = &outputFormat
+	options.Name = pcName
 
-	options := &PriorityClassOptions{
-		PrintFlags: printFlags,
-		Name:       pcName,
-		IOStreams:  ioStreams,
-	}
 	err := options.Complete(tf, cmd, []string{pcName})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_quota.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_quota.go
@@ -75,7 +75,7 @@ type QuotaOpts struct {
 // NewQuotaOpts creates a new *QuotaOpts with sane defaults
 func NewQuotaOpts(ioStreams genericclioptions.IOStreams) *QuotaOpts {
 	return &QuotaOpts{
-		PrintFlags: genericclioptions.NewPrintFlags("created").WithTypeSetter(scheme.Scheme),
+		PrintFlags: genericclioptions.NewPrintFlags("created").WithTypeSetter(scheme.Scheme).WithShowKindOnName(),
 		IOStreams:  ioStreams,
 	}
 }

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_role.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_role.go
@@ -145,7 +145,7 @@ type CreateRoleOptions struct {
 // NewCreateRoleOptions returns an initialized CreateRoleOptions instance
 func NewCreateRoleOptions(ioStreams genericclioptions.IOStreams) *CreateRoleOptions {
 	return &CreateRoleOptions{
-		PrintFlags: genericclioptions.NewPrintFlags("created").WithTypeSetter(scheme.Scheme),
+		PrintFlags: genericclioptions.NewPrintFlags("created").WithTypeSetter(scheme.Scheme).WithShowKindOnName(),
 
 		IOStreams: ioStreams,
 	}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_rolebinding.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_rolebinding.go
@@ -74,7 +74,7 @@ func NewRoleBindingOptions(ioStreams genericclioptions.IOStreams) *RoleBindingOp
 		Users:           []string{},
 		Groups:          []string{},
 		ServiceAccounts: []string{},
-		PrintFlags:      genericclioptions.NewPrintFlags("created").WithTypeSetter(scheme.Scheme),
+		PrintFlags:      genericclioptions.NewPrintFlags("created").WithTypeSetter(scheme.Scheme).WithShowKindOnName(),
 		IOStreams:       ioStreams,
 	}
 }

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_service.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_service.go
@@ -82,7 +82,7 @@ type ServiceOptions struct {
 // NewServiceOptions creates a ServiceOptions struct
 func NewServiceOptions(ioStreams genericclioptions.IOStreams, serviceType corev1.ServiceType) *ServiceOptions {
 	return &ServiceOptions{
-		PrintFlags: genericclioptions.NewPrintFlags("created").WithTypeSetter(scheme.Scheme),
+		PrintFlags: genericclioptions.NewPrintFlags("created").WithTypeSetter(scheme.Scheme).WithShowKindOnName(),
 		IOStreams:  ioStreams,
 		Type:       serviceType,
 	}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_serviceaccount.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_serviceaccount.go
@@ -69,7 +69,7 @@ type ServiceAccountOpts struct {
 // NewServiceAccountOpts creates a new *ServiceAccountOpts with sane defaults
 func NewServiceAccountOpts(ioStreams genericclioptions.IOStreams) *ServiceAccountOpts {
 	return &ServiceAccountOpts{
-		PrintFlags: genericclioptions.NewPrintFlags("created").WithTypeSetter(scheme.Scheme),
+		PrintFlags: genericclioptions.NewPrintFlags("created").WithTypeSetter(scheme.Scheme).WithShowKindOnName(),
 		IOStreams:  ioStreams,
 	}
 }

--- a/staging/src/k8s.io/kubectl/pkg/cmd/drain/drain.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/drain/drain.go
@@ -142,7 +142,7 @@ var (
 
 func NewDrainCmdOptions(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *DrainCmdOptions {
 	o := &DrainCmdOptions{
-		PrintFlags: genericclioptions.NewPrintFlags("drained").WithTypeSetter(scheme.Scheme),
+		PrintFlags: genericclioptions.NewPrintFlags("drained").WithTypeSetter(scheme.Scheme).WithShowKindOnName(),
 		IOStreams:  ioStreams,
 		drainer: &drain.Helper{
 			GracePeriodSeconds: -1,

--- a/staging/src/k8s.io/kubectl/pkg/cmd/expose/expose.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/expose/expose.go
@@ -112,7 +112,7 @@ type ExposeServiceOptions struct {
 func NewExposeServiceOptions(ioStreams genericclioptions.IOStreams) *ExposeServiceOptions {
 	return &ExposeServiceOptions{
 		RecordFlags: genericclioptions.NewRecordFlags(),
-		PrintFlags:  genericclioptions.NewPrintFlags("exposed").WithTypeSetter(scheme.Scheme),
+		PrintFlags:  genericclioptions.NewPrintFlags("exposed").WithTypeSetter(scheme.Scheme).WithShowKindOnName(),
 
 		Recorder:  genericclioptions.NoopRecorder{},
 		IOStreams: ioStreams,

--- a/staging/src/k8s.io/kubectl/pkg/cmd/get/get_flags.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/get/get_flags.go
@@ -117,6 +117,9 @@ func (f *PrintFlags) ToPrinter() (printers.ResourcePrinter, error) {
 	}
 	f.HumanReadableFlags.NoHeaders = noHeaders
 	f.CustomColumnsFlags.NoHeaders = noHeaders
+	if f.HumanReadableFlags.ShowKind != nil {
+		f.NamePrintFlags.ShowKind = *f.HumanReadableFlags.ShowKind
+	}
 
 	// for "get.go" we want to support a --template argument given, even when no --output format is provided
 	if f.TemplateFlags.TemplateArgument != nil && len(*f.TemplateFlags.TemplateArgument) > 0 && len(outputFormat) == 0 {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/label/label.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/label/label.go
@@ -116,7 +116,7 @@ func NewLabelOptions(ioStreams genericclioptions.IOStreams) *LabelOptions {
 		RecordFlags: genericclioptions.NewRecordFlags(),
 		Recorder:    genericclioptions.NoopRecorder{},
 
-		PrintFlags: genericclioptions.NewPrintFlags("labeled").WithTypeSetter(scheme.Scheme),
+		PrintFlags: genericclioptions.NewPrintFlags("labeled").WithTypeSetter(scheme.Scheme).WithShowKindOnName(),
 
 		IOStreams: ioStreams,
 	}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/patch/patch.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/patch/patch.go
@@ -100,7 +100,7 @@ func NewPatchOptions(ioStreams genericclioptions.IOStreams) *PatchOptions {
 	return &PatchOptions{
 		RecordFlags: genericclioptions.NewRecordFlags(),
 		Recorder:    genericclioptions.NoopRecorder{},
-		PrintFlags:  genericclioptions.NewPrintFlags("patched").WithTypeSetter(scheme.Scheme),
+		PrintFlags:  genericclioptions.NewPrintFlags("patched").WithTypeSetter(scheme.Scheme).WithShowKindOnName(),
 		IOStreams:   ioStreams,
 	}
 }

--- a/staging/src/k8s.io/kubectl/pkg/cmd/replace/replace.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/replace/replace.go
@@ -99,7 +99,7 @@ type ReplaceOptions struct {
 
 func NewReplaceOptions(streams genericclioptions.IOStreams) *ReplaceOptions {
 	return &ReplaceOptions{
-		PrintFlags:  genericclioptions.NewPrintFlags("replaced"),
+		PrintFlags:  genericclioptions.NewPrintFlags("replaced").WithShowKindOnName(),
 		DeleteFlags: delete.NewDeleteFlags("to use to replace the resource."),
 
 		IOStreams: streams,

--- a/staging/src/k8s.io/kubectl/pkg/cmd/rollout/rollout_history.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/rollout/rollout_history.go
@@ -65,7 +65,7 @@ type RolloutHistoryOptions struct {
 // NewRolloutHistoryOptions returns an initialized RolloutHistoryOptions instance
 func NewRolloutHistoryOptions(streams genericclioptions.IOStreams) *RolloutHistoryOptions {
 	return &RolloutHistoryOptions{
-		PrintFlags: genericclioptions.NewPrintFlags("").WithTypeSetter(scheme.Scheme),
+		PrintFlags: genericclioptions.NewPrintFlags("").WithTypeSetter(scheme.Scheme).WithShowKindOnName(),
 		IOStreams:  streams,
 	}
 }

--- a/staging/src/k8s.io/kubectl/pkg/cmd/rollout/rollout_pause.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/rollout/rollout_pause.go
@@ -70,7 +70,7 @@ var (
 // NewCmdRolloutPause returns a Command instance for 'rollout pause' sub command
 func NewCmdRolloutPause(f cmdutil.Factory, streams genericclioptions.IOStreams) *cobra.Command {
 	o := &PauseOptions{
-		PrintFlags: genericclioptions.NewPrintFlags("paused").WithTypeSetter(scheme.Scheme),
+		PrintFlags: genericclioptions.NewPrintFlags("paused").WithTypeSetter(scheme.Scheme).WithShowKindOnName(),
 		IOStreams:  streams,
 	}
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/rollout/rollout_restart.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/rollout/rollout_restart.go
@@ -69,7 +69,7 @@ var (
 // NewRolloutRestartOptions returns an initialized RestartOptions instance
 func NewRolloutRestartOptions(streams genericclioptions.IOStreams) *RestartOptions {
 	return &RestartOptions{
-		PrintFlags: genericclioptions.NewPrintFlags("restarted").WithTypeSetter(scheme.Scheme),
+		PrintFlags: genericclioptions.NewPrintFlags("restarted").WithTypeSetter(scheme.Scheme).WithShowKindOnName(),
 		IOStreams:  streams,
 	}
 }

--- a/staging/src/k8s.io/kubectl/pkg/cmd/rollout/rollout_resume.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/rollout/rollout_resume.go
@@ -69,7 +69,7 @@ var (
 // NewRolloutResumeOptions returns an initialized ResumeOptions instance
 func NewRolloutResumeOptions(streams genericclioptions.IOStreams) *ResumeOptions {
 	return &ResumeOptions{
-		PrintFlags: genericclioptions.NewPrintFlags("resumed").WithTypeSetter(scheme.Scheme),
+		PrintFlags: genericclioptions.NewPrintFlags("resumed").WithTypeSetter(scheme.Scheme).WithShowKindOnName(),
 		IOStreams:  streams,
 	}
 }

--- a/staging/src/k8s.io/kubectl/pkg/cmd/rollout/rollout_status.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/rollout/rollout_status.go
@@ -81,7 +81,7 @@ type RolloutStatusOptions struct {
 // NewRolloutStatusOptions returns an initialized RolloutStatusOptions instance
 func NewRolloutStatusOptions(streams genericclioptions.IOStreams) *RolloutStatusOptions {
 	return &RolloutStatusOptions{
-		PrintFlags:      genericclioptions.NewPrintFlags("").WithTypeSetter(scheme.Scheme),
+		PrintFlags:      genericclioptions.NewPrintFlags("").WithTypeSetter(scheme.Scheme).WithShowKindOnName(),
 		FilenameOptions: &resource.FilenameOptions{},
 		IOStreams:       streams,
 		Watch:           true,

--- a/staging/src/k8s.io/kubectl/pkg/cmd/rollout/rollout_undo.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/rollout/rollout_undo.go
@@ -68,7 +68,7 @@ var (
 // NewRolloutUndoOptions returns an initialized UndoOptions instance
 func NewRolloutUndoOptions(streams genericclioptions.IOStreams) *UndoOptions {
 	return &UndoOptions{
-		PrintFlags: genericclioptions.NewPrintFlags("rolled back").WithTypeSetter(scheme.Scheme),
+		PrintFlags: genericclioptions.NewPrintFlags("rolled back").WithTypeSetter(scheme.Scheme).WithShowKindOnName(),
 		IOStreams:  streams,
 		ToRevision: int64(0),
 	}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/run/run.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/run/run.go
@@ -133,7 +133,7 @@ type RunOptions struct {
 
 func NewRunOptions(streams genericclioptions.IOStreams) *RunOptions {
 	return &RunOptions{
-		PrintFlags:  genericclioptions.NewPrintFlags("created").WithTypeSetter(scheme.Scheme),
+		PrintFlags:  genericclioptions.NewPrintFlags("created").WithTypeSetter(scheme.Scheme).WithShowKindOnName(),
 		DeleteFlags: delete.NewDeleteFlags("to use to replace the resource."),
 		RecordFlags: genericclioptions.NewRecordFlags(),
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/scale/scale.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/scale/scale.go
@@ -93,7 +93,7 @@ type ScaleOptions struct {
 
 func NewScaleOptions(ioStreams genericclioptions.IOStreams) *ScaleOptions {
 	return &ScaleOptions{
-		PrintFlags:      genericclioptions.NewPrintFlags("scaled"),
+		PrintFlags:      genericclioptions.NewPrintFlags("scaled").WithShowKindOnName(),
 		RecordFlags:     genericclioptions.NewRecordFlags(),
 		CurrentReplicas: -1,
 		Recorder:        genericclioptions.NoopRecorder{},

--- a/staging/src/k8s.io/kubectl/pkg/cmd/set/set_env.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/set/set_env.go
@@ -136,7 +136,7 @@ type EnvOptions struct {
 // pod templates are selected by default and allowing environment to be overwritten
 func NewEnvOptions(streams genericclioptions.IOStreams) *EnvOptions {
 	return &EnvOptions{
-		PrintFlags: genericclioptions.NewPrintFlags("env updated").WithTypeSetter(scheme.Scheme),
+		PrintFlags: genericclioptions.NewPrintFlags("env updated").WithTypeSetter(scheme.Scheme).WithShowKindOnName(),
 
 		ContainerSelector: "*",
 		Overwrite:         true,

--- a/staging/src/k8s.io/kubectl/pkg/cmd/set/set_env_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/set/set_env_test.go
@@ -58,7 +58,7 @@ func TestSetEnvLocal(t *testing.T) {
 
 	streams, _, buf, bufErr := genericclioptions.NewTestIOStreams()
 	opts := NewEnvOptions(streams)
-	opts.PrintFlags = genericclioptions.NewPrintFlags("").WithDefaultOutput(outputFormat).WithTypeSetter(scheme.Scheme)
+	opts.PrintFlags = genericclioptions.NewPrintFlags("").WithDefaultOutput(outputFormat).WithTypeSetter(scheme.Scheme).WithShowKindOnName()
 	opts.FilenameOptions = resource.FilenameOptions{
 		Filenames: []string{"../../../testdata/controller.yaml"},
 	}
@@ -132,7 +132,7 @@ func TestSetMultiResourcesEnvLocal(t *testing.T) {
 	outputFormat := "name"
 	streams, _, buf, bufErr := genericclioptions.NewTestIOStreams()
 	opts := NewEnvOptions(streams)
-	opts.PrintFlags = genericclioptions.NewPrintFlags("").WithDefaultOutput(outputFormat).WithTypeSetter(scheme.Scheme)
+	opts.PrintFlags = genericclioptions.NewPrintFlags("").WithDefaultOutput(outputFormat).WithTypeSetter(scheme.Scheme).WithShowKindOnName()
 	opts.FilenameOptions = resource.FilenameOptions{
 		Filenames: []string{"../../../testdata/set/multi-resource-yaml.yaml"},
 	}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/set/set_image.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/set/set_image.go
@@ -91,7 +91,7 @@ var (
 // NewImageOptions returns an initialized SetImageOptions instance
 func NewImageOptions(streams genericclioptions.IOStreams) *SetImageOptions {
 	return &SetImageOptions{
-		PrintFlags:  genericclioptions.NewPrintFlags("image updated").WithTypeSetter(scheme.Scheme),
+		PrintFlags:  genericclioptions.NewPrintFlags("image updated").WithTypeSetter(scheme.Scheme).WithShowKindOnName(),
 		RecordFlags: genericclioptions.NewRecordFlags(),
 
 		Recorder: genericclioptions.NoopRecorder{},

--- a/staging/src/k8s.io/kubectl/pkg/cmd/set/set_image_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/set/set_image_test.go
@@ -65,7 +65,7 @@ func TestImageLocal(t *testing.T) {
 	cmd.Flags().Set("local", "true")
 
 	opts := SetImageOptions{
-		PrintFlags: genericclioptions.NewPrintFlags("").WithDefaultOutput(outputFormat).WithTypeSetter(scheme.Scheme),
+		PrintFlags: genericclioptions.NewPrintFlags("").WithDefaultOutput(outputFormat).WithTypeSetter(scheme.Scheme).WithShowKindOnName(),
 		FilenameOptions: resource.FilenameOptions{
 			Filenames: []string{"../../../testdata/controller.yaml"}},
 		Local:     true,
@@ -87,7 +87,7 @@ func TestImageLocal(t *testing.T) {
 }
 
 func TestSetImageValidation(t *testing.T) {
-	printFlags := genericclioptions.NewPrintFlags("").WithTypeSetter(scheme.Scheme)
+	printFlags := genericclioptions.NewPrintFlags("").WithTypeSetter(scheme.Scheme).WithShowKindOnName()
 
 	testCases := []struct {
 		name         string
@@ -177,7 +177,7 @@ func TestSetMultiResourcesImageLocal(t *testing.T) {
 	cmd.Flags().Set("local", "true")
 
 	opts := SetImageOptions{
-		PrintFlags: genericclioptions.NewPrintFlags("").WithDefaultOutput(outputFormat).WithTypeSetter(scheme.Scheme),
+		PrintFlags: genericclioptions.NewPrintFlags("").WithDefaultOutput(outputFormat).WithTypeSetter(scheme.Scheme).WithShowKindOnName(),
 		FilenameOptions: resource.FilenameOptions{
 			Filenames: []string{"../../../testdata/set/multi-resource-yaml.yaml"}},
 		Local:     true,

--- a/staging/src/k8s.io/kubectl/pkg/cmd/set/set_resources.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/set/set_resources.go
@@ -95,7 +95,7 @@ type SetResourcesOptions struct {
 // pod templates are selected by default.
 func NewResourcesOptions(streams genericclioptions.IOStreams) *SetResourcesOptions {
 	return &SetResourcesOptions{
-		PrintFlags:  genericclioptions.NewPrintFlags("resource requirements updated").WithTypeSetter(scheme.Scheme),
+		PrintFlags:  genericclioptions.NewPrintFlags("resource requirements updated").WithTypeSetter(scheme.Scheme).WithShowKindOnName(),
 		RecordFlags: genericclioptions.NewRecordFlags(),
 
 		Recorder: genericclioptions.NoopRecorder{},

--- a/staging/src/k8s.io/kubectl/pkg/cmd/set/set_resources_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/set/set_resources_test.go
@@ -64,7 +64,7 @@ func TestResourcesLocal(t *testing.T) {
 	cmd.Flags().Set("local", "true")
 
 	opts := SetResourcesOptions{
-		PrintFlags: genericclioptions.NewPrintFlags("").WithDefaultOutput(outputFormat).WithTypeSetter(scheme.Scheme),
+		PrintFlags: genericclioptions.NewPrintFlags("").WithDefaultOutput(outputFormat).WithTypeSetter(scheme.Scheme).WithShowKindOnName(),
 		FilenameOptions: resource.FilenameOptions{
 			Filenames: []string{"../../../testdata/controller.yaml"}},
 		Local:             true,
@@ -112,7 +112,7 @@ func TestSetMultiResourcesLimitsLocal(t *testing.T) {
 	cmd.Flags().Set("local", "true")
 
 	opts := SetResourcesOptions{
-		PrintFlags: genericclioptions.NewPrintFlags("").WithDefaultOutput(outputFormat).WithTypeSetter(scheme.Scheme),
+		PrintFlags: genericclioptions.NewPrintFlags("").WithDefaultOutput(outputFormat).WithTypeSetter(scheme.Scheme).WithShowKindOnName(),
 		FilenameOptions: resource.FilenameOptions{
 			Filenames: []string{"../../../testdata/set/multi-resource-yaml.yaml"}},
 		Local:             true,

--- a/staging/src/k8s.io/kubectl/pkg/cmd/set/set_selector.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/set/set_selector.go
@@ -85,7 +85,7 @@ func NewSelectorOptions(streams genericclioptions.IOStreams) *SetSelectorOptions
 			WithAll(false).
 			WithLocal(false).
 			WithLatest(),
-		PrintFlags:  genericclioptions.NewPrintFlags("selector updated").WithTypeSetter(scheme.Scheme),
+		PrintFlags:  genericclioptions.NewPrintFlags("selector updated").WithTypeSetter(scheme.Scheme).WithShowKindOnName(),
 		RecordFlags: genericclioptions.NewRecordFlags(),
 
 		Recorder: genericclioptions.NoopRecorder{},

--- a/staging/src/k8s.io/kubectl/pkg/cmd/set/set_selector_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/set/set_selector_test.go
@@ -329,7 +329,7 @@ func TestSelectorTest(t *testing.T) {
 		selector:       labelToSet,
 		ResourceFinder: genericclioptions.NewSimpleFakeResourceFinder(info),
 		Recorder:       genericclioptions.NoopRecorder{},
-		PrintObj:       (&printers.NamePrinter{}).PrintObj,
+		PrintObj:       (&printers.NamePrinter{ShowKind: true}).PrintObj,
 		IOStreams:      iostreams,
 	}
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/set/set_serviceaccount.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/set/set_serviceaccount.go
@@ -82,7 +82,7 @@ type SetServiceAccountOptions struct {
 // NewSetServiceAccountOptions returns an initialized SetServiceAccountOptions instance
 func NewSetServiceAccountOptions(streams genericclioptions.IOStreams) *SetServiceAccountOptions {
 	return &SetServiceAccountOptions{
-		PrintFlags:  genericclioptions.NewPrintFlags("serviceaccount updated").WithTypeSetter(scheme.Scheme),
+		PrintFlags:  genericclioptions.NewPrintFlags("serviceaccount updated").WithTypeSetter(scheme.Scheme).WithShowKindOnName(),
 		RecordFlags: genericclioptions.NewRecordFlags(),
 
 		Recorder: genericclioptions.NoopRecorder{},

--- a/staging/src/k8s.io/kubectl/pkg/cmd/set/set_serviceaccount_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/set/set_serviceaccount_test.go
@@ -120,7 +120,7 @@ func TestSetServiceAccountMultiLocal(t *testing.T) {
 	cmd.Flags().Set("output", outputFormat)
 	cmd.Flags().Set("local", "true")
 	opts := SetServiceAccountOptions{
-		PrintFlags: genericclioptions.NewPrintFlags("").WithDefaultOutput(outputFormat).WithTypeSetter(scheme.Scheme),
+		PrintFlags: genericclioptions.NewPrintFlags("").WithDefaultOutput(outputFormat).WithTypeSetter(scheme.Scheme).WithShowKindOnName(),
 		fileNameOptions: resource.FilenameOptions{
 			Filenames: []string{"../../../testdata/set/multi-resource-yaml.yaml"}},
 		local:     true,

--- a/staging/src/k8s.io/kubectl/pkg/cmd/set/set_subject.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/set/set_subject.go
@@ -84,7 +84,7 @@ type SubjectOptions struct {
 // NewSubjectOptions returns an initialized SubjectOptions instance
 func NewSubjectOptions(streams genericclioptions.IOStreams) *SubjectOptions {
 	return &SubjectOptions{
-		PrintFlags: genericclioptions.NewPrintFlags("subjects updated").WithTypeSetter(scheme.Scheme),
+		PrintFlags: genericclioptions.NewPrintFlags("subjects updated").WithTypeSetter(scheme.Scheme).WithShowKindOnName(),
 
 		IOStreams: streams,
 	}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/taint/taint.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/taint/taint.go
@@ -96,7 +96,7 @@ var (
 
 func NewCmdTaint(f cmdutil.Factory, streams genericclioptions.IOStreams) *cobra.Command {
 	options := &TaintOptions{
-		PrintFlags: genericclioptions.NewPrintFlags("tainted").WithTypeSetter(scheme.Scheme),
+		PrintFlags: genericclioptions.NewPrintFlags("tainted").WithTypeSetter(scheme.Scheme).WithShowKindOnName(),
 		IOStreams:  streams,
 	}
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/util/editor/editoptions.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/util/editor/editoptions.go
@@ -92,7 +92,7 @@ func NewEditOptions(editMode EditMode, ioStreams genericclioptions.IOStreams) *E
 
 		EditMode: editMode,
 
-		PrintFlags: genericclioptions.NewPrintFlags("edited").WithTypeSetter(scheme.Scheme),
+		PrintFlags: genericclioptions.NewPrintFlags("edited").WithTypeSetter(scheme.Scheme).WithShowKindOnName(),
 
 		editPrinterOptions: &editPrinterOptions{
 			// create new editor-specific PrintFlags, with all
@@ -204,6 +204,7 @@ func (o *EditOptions) Complete(f cmdutil.Factory, args []string, cmd *cobra.Comm
 
 	o.ToPrinter = func(operation string) (printers.ResourcePrinter, error) {
 		o.PrintFlags.NamePrintFlags.Operation = operation
+		o.PrintFlags.NamePrintFlags.ShowKind = true
 		return o.PrintFlags.ToPrinter()
 	}
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/wait/wait.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/wait/wait.go
@@ -91,7 +91,7 @@ type WaitFlags struct {
 func NewWaitFlags(restClientGetter genericclioptions.RESTClientGetter, streams genericclioptions.IOStreams) *WaitFlags {
 	return &WaitFlags{
 		RESTClientGetter: restClientGetter,
-		PrintFlags:       genericclioptions.NewPrintFlags("condition met"),
+		PrintFlags:       genericclioptions.NewPrintFlags("condition met").WithShowKindOnName(),
 		ResourceBuilderFlags: genericclioptions.NewResourceBuilderFlags().
 			WithLabelSelector("").
 			WithFieldSelector("").

--- a/test/cmd/authentication.sh
+++ b/test/cmd/authentication.sh
@@ -52,7 +52,7 @@ EOF
   # Command
   output=$(kubectl "${kube_flags_with_token[@]:?}" --kubeconfig="${TMPDIR:-/tmp}"/invalid_exec_plugin.yaml get namespace kube-system -o name || true)
 
-  if [[ "${output}" == "namespace/kube-system" ]]; then
+  if [[ "${output}" == "kube-system" ]]; then
     kube::log::status "exec credential plugin not triggered since kubectl was called with provided --token"
   else
     kube::log::status "Unexpected output when providing --token for authentication - exec credential plugin likely triggered. Output: ${output}"

--- a/test/cmd/crd.sh
+++ b/test/cmd/crd.sh
@@ -189,10 +189,10 @@ run_non_native_resource_tests() {
   kube::test::if_has_string "${output_message}" 'myobj'
 
   output_message=$(kubectl "${kube_flags[@]}" get resources/myobj -o name)
-  kube::test::if_has_string "${output_message}" 'kind.mygroup.example.com/myobj'
+  kube::test::if_has_string "${output_message}" 'myobj'
 
   output_message=$(kubectl "${kube_flags[@]}" get kind.mygroup.example.com/myobj -o name)
-  kube::test::if_has_string "${output_message}" 'kind.mygroup.example.com/myobj'
+  kube::test::if_has_string "${output_message}" 'myobj'
 
   # Delete the resource with cascading strategy background.
   kubectl "${kube_flags[@]}" delete resources myobj --cascade=background
@@ -228,7 +228,7 @@ run_non_native_resource_tests() {
   kubectl "${kube_flags[@]}" get foos      -o "go-template={{range .items}}{{.someField}}{{end}}" --allow-missing-template-keys=false
   kubectl "${kube_flags[@]}" get foos/test -o "go-template={{.someField}}"                        --allow-missing-template-keys=false
   output_message=$(kubectl "${kube_flags[@]}" get foos/test -o name)
-  kube::test::if_has_string "${output_message}" 'foo.company.com/test'
+  kube::test::if_has_string "${output_message}" 'test'
 
   # Test patching
   kube::log::status "Testing CustomResource patching"
@@ -311,7 +311,7 @@ run_non_native_resource_tests() {
   # Stop the watcher and the patch loop.
   kill -9 "${watch_pid}"
   kill -9 "${patch_pid}"
-  kube::test::if_has_string "${watch_output}" 'bar.company.com/test'
+  kube::test::if_has_string "${watch_output}" 'test'
 
   # Delete the resource with cascading strategy orphan.
   kubectl "${kube_flags[@]}" delete bars test --cascade=orphan

--- a/test/cmd/crd.sh
+++ b/test/cmd/crd.sh
@@ -184,9 +184,9 @@ run_non_native_resource_tests() {
   # Test that we can create a new resource of type Kind
   kubectl "${kube_flags[@]}" create -f hack/testdata/CRD/resource.yaml "${kube_flags[@]}"
 
-  # Test that -o name returns kind.group/resourcename
+  # Test that -o name returns only resourcename
   output_message=$(kubectl "${kube_flags[@]}" get resource/myobj -o name)
-  kube::test::if_has_string "${output_message}" 'kind.mygroup.example.com/myobj'
+  kube::test::if_has_string "${output_message}" 'myobj'
 
   output_message=$(kubectl "${kube_flags[@]}" get resources/myobj -o name)
   kube::test::if_has_string "${output_message}" 'kind.mygroup.example.com/myobj'

--- a/test/cmd/get.sh
+++ b/test/cmd/get.sh
@@ -181,7 +181,7 @@ run_kubectl_get_tests() {
   kube::test::if_has_string "${output_message}" 'valid-pod' # pod details
   output_message=$(kubectl get pods/valid-pod -o name -w --request-timeout=1 "${kube_flags[@]}")
   kube::test::if_has_not_string "${output_message}" 'STATUS' # no headers
-  kube::test::if_has_string     "${output_message}" 'pod/valid-pod' # resource name
+  kube::test::if_has_string     "${output_message}" 'valid-pod' # -o name returns only resource name
   output_message=$(kubectl get pods/valid-pod -o yaml -w --request-timeout=1 "${kube_flags[@]}")
   kube::test::if_has_not_string "${output_message}" 'STATUS'          # no headers
   kube::test::if_has_string     "${output_message}" 'name: valid-pod' # yaml


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Currently `kubectl get xx -o name` shows the name with kind. See:

![image](https://user-images.githubusercontent.com/60682957/107321400-c760d880-6ae5-11eb-9883-0ccb03e19004.png)

However, this is an invalid behavior because `kubectl get` accepts `--show-kind` param which specifies to show kind with the resource name. The expected behavior is:
* when --show-kind is specified, kind is shown
* else, kind is **not** shown

After this PR merged, the problem is fixed:

![image](https://user-images.githubusercontent.com/60682957/107321585-26bee880-6ae6-11eb-9e9c-8df1ee08020a.png)


**Which issue(s) this PR fixes**:

Fixes https://github.com/kubernetes/kubectl/issues/669

**Special notes for your reviewer**:

* About changed files

I know there are a lot of changed files which look terrible, but most of them are just tiny change for not making breaking changes.
Basically, there are only 3 parts which actually fixes this bug:

https://github.com/kubernetes/kubernetes/pull/98904/files#diff-646d07042c5cb40b3c11dc4407586c4b3421cb656b7d26c3b88085072adc9af1
https://github.com/kubernetes/kubernetes/pull/98904/files#diff-d6cf14015bc6efb5c381d44f803ba206d37fe0e2910bc6d6bbcb956744442fe3
https://github.com/kubernetes/kubernetes/pull/98904/files#diff-1e4e40e8afb1e2dd3ee9ce305674f709459ae0f6a178ff0a2accaca2d54067ba

We need `WithShowKindOnName` because most kubectl subcommand uses `NamePrintFlags` struct in `PrintFlags`, and they use `NamePrintFlags` to print name. For example, `kubectl edit` command finally shows the message `pod/foo edited` , but the `pod/foo` part is built by `NamePrintFlags`.
Without `WithShowKindOnName` , the message changes to `foo edited`. I personally think it's ok, but I was not very sure if we should make the breaking change, so I chose to explicitly specify to show kind in kubectl subcommands by `WithShowKindOnName`.
If we think the behavior is preferred, then I will remove `WithShowKindOnName` and fix current tests not to show kind.

* unit tests

I ran unit tests on my local machine for `staging/src/k8s.io/cli-runtime` and `staging/src/k8s.io/kubectl` already and made sure they passes.

* Original PR

The original PR was https://github.com/kubernetes/kubernetes/pull/79393. I submitted this PR because the PR seems old , not maintained, and requires some changes.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
