### PR TITLE
deflake a resource quota check for best-effort pods

### DIFF
--- a/test/e2e/apimachinery/resource_quota.go
+++ b/test/e2e/apimachinery/resource_quota.go
@@ -43,7 +43,7 @@ import (
 
 const (
 	// how long to wait for a resource quota update to occur
-	resourceQuotaTimeout = 30 * time.Second
+	resourceQuotaTimeout = time.Minute
 	podName              = "pfpod"
 )
 
@@ -1734,7 +1734,7 @@ func waitForResourceQuota(c clientset.Interface, ns, quotaName string, used v1.R
 // updateResourceQuotaUntilUsageAppears updates the resource quota object until the usage is populated
 // for the specific resource name.
 func updateResourceQuotaUntilUsageAppears(c clientset.Interface, ns, quotaName string, resourceName v1.ResourceName) error {
-	return wait.Poll(framework.Poll, 1*time.Minute, func() (bool, error) {
+	return wait.Poll(framework.Poll, resourceQuotaTimeout, func() (bool, error) {
 		resourceQuota, err := c.CoreV1().ResourceQuotas(ns).Get(context.TODO(), quotaName, metav1.GetOptions{})
 		if err != nil {
 			return false, err


### PR DESCRIPTION
**A small flake that failed continuously, but the frequency is only once a day.** 

### What type of PR is this?
/kind flake
/sig api-machinery

###  What this PR does / why we need it:
The changed timeout is for Line 1714
It seems that resource quota status/used updating is not that quick.

### Which issue(s) this PR fixes:
Fixes #98856

**Special notes for your reviewer**:
Try to fix it like #96265 for configmap check.
**Kubernetes Aggregated Failures link**: https://storage.googleapis.com/k8s-gubernator/triage/index.html?test=ResourceQuota%20should%20verify%20ResourceQuota%20with%20best%20effort%20scope
```
1 clusters of 7 failures out of 142149 builds from 2021/2/5 AM 8:00:31 to 2021/2/19 AM 7:31:33.
1 clusters of 8 failures (1 in last day) out of 133480 builds  from 2021/4/9上午8:00:14 to 2021/4/23下午3:23:54.
```

Another way to fix this may be https://github.com/kubernetes/kubernetes/issues/98856#issuecomment-775732623.
- add more concurrent namespace syncs or resource quota syncs.

**Does this PR introduce a user-facing change?**:
```release-note
None
```