### PR TITLE
kubelet: Fix race when KillPod followed by IsPodPendingTermination

### DIFF
--- a/pkg/kubelet/cm/fake_pod_container_manager.go
+++ b/pkg/kubelet/cm/fake_pod_container_manager.go
@@ -28,6 +28,7 @@ import (
 type FakePodContainerManager struct {
 	sync.Mutex
 	CalledFunctions []string
+	Events          []string
 	Cgroups         map[types.UID]CgroupName
 }
 
@@ -73,6 +74,7 @@ func (m *FakePodContainerManager) Destroy(name CgroupName) error {
 	for key, cgname := range m.Cgroups {
 		if reflect.DeepEqual(cgname, name) {
 			delete(m.Cgroups, key)
+			m.Events = append(m.Events, "PodDestroyed")
 			return nil
 		}
 	}

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -460,8 +460,9 @@ func TestSyncPodsDeletesWhenSourcesAreReadyPerQOS(t *testing.T) {
 	defer fakeContainerManager.PodContainerManager.Unlock()
 	calledFunctionCount := len(fakeContainerManager.PodContainerManager.CalledFunctions)
 	destroyCount := 0
-	for _, functionName := range fakeContainerManager.PodContainerManager.CalledFunctions {
-		if functionName == "Destroy" {
+	for _, eventName := range fakeContainerManager.PodContainerManager.Events {
+		// We should only see one `PodDestroyed` event.
+		if eventName == "PodDestroyed" {
 			destroyCount = destroyCount + 1
 		}
 	}

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -500,6 +500,39 @@ func TestSyncPodsDeletesWhenSourcesAreReady(t *testing.T) {
 	fakeRuntime.AssertKilledPods([]string{"12345678"})
 }
 
+func TestKillPodFollwedByIsPodPendingTermination(t *testing.T) {
+	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
+	defer testKubelet.Cleanup()
+	defer testKubelet.kubelet.podKiller.Close()
+	go testKubelet.kubelet.podKiller.PerformPodKillingWork()
+
+	pod := &kubecontainer.Pod{
+		ID:        "12345678",
+		Name:      "foo",
+		Namespace: "new",
+		Containers: []*kubecontainer.Container{
+			{Name: "bar"},
+		},
+	}
+
+	fakeRuntime := testKubelet.fakeRuntime
+	fakeContainerManager := testKubelet.fakeContainerManager
+	fakeContainerManager.PodContainerManager.AddPodFromCgroups(pod) // add pod to mock cgroup
+	fakeRuntime.PodList = []*containertest.FakePod{
+		{Pod: pod},
+	}
+
+	kl := testKubelet.kubelet
+	kl.podKiller.KillPod(&kubecontainer.PodPair{
+		APIPod:     nil,
+		RunningPod: pod,
+	})
+
+	if !kl.podKiller.IsPodPendingTerminationByUID(pod.ID) && len(fakeRuntime.KilledPods) == 0 {
+		t.Fatal("Race condition: When KillPod is complete, the pod should be pending termination or be killed")
+	}
+}
+
 type testNodeLister struct {
 	nodes []*v1.Node
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug
/kind failing-test

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:

This PR fixes the race when `KillPod` followed by `IsPodPendingTerminationBy(UID|PodName)`.

When we called `KillPod`, the buffered channel received the request. Then `PerformPodKillingWork` fetched the request and added the given pod to the `terminationMap`. In the meantime, the caller could call `IsPodPendingTerminationByUID` which could return false because `terminationMap` had not yet been set.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubernetes/issues/98893

**Special notes for your reviewer**:

Regarding `TestSyncPodsDeletesWhenSourcesAreReadyPerQOS` of https://github.com/kubernetes/kubernetes/issues/98893,
`HandlePodCleanup` calls `KillPod` followed by `cleanupOrphanedPodCgroups` which calls `IsPodPendingTerminationByUID` and the race occurs.


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
