### PR TITLE
Update conformance metadata for relocated test

### DIFF
--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -1627,7 +1627,7 @@
   description: Pods with the same HostPort value MUST be able to be scheduled to the
     same node if the HostIP or Protocol is different. This test is marked LinuxOnly
     since hostNetwork is not supported on Windows.
-  release: v1.16, v1.20
+  release: v1.16, v1.21
   file: test/e2e/network/hostport.go
 - testname: Ingress API
   codename: '[sig-network] Ingress API should support creating Ingress API operations

--- a/test/e2e/network/hostport.go
+++ b/test/e2e/network/hostport.go
@@ -49,7 +49,7 @@ var _ = SIGDescribe("HostPort", func() {
 	})
 
 	/*
-		Release: v1.16, v1.20
+		Release: v1.16, v1.21
 		Testname: Scheduling, HostPort matching and HostIP and Protocol not-matching
 		Description: Pods with the same HostPort value MUST be able to be scheduled to the same node
 		if the HostIP or Protocol is different. This test is marked LinuxOnly since hostNetwork is not supported on

--- a/test/e2e/scheduling/predicates.go
+++ b/test/e2e/scheduling/predicates.go
@@ -651,13 +651,6 @@ var _ = SIGDescribe("SchedulerPredicates [Serial]", func() {
 		verifyResult(cs, 1, 0, ns)
 	})
 
-	/*
-		Release: v1.16
-		Testname: Scheduling, HostPort matching and HostIP and Protocol not-matching
-		Description: Pods with the same HostPort value MUST be able to be scheduled to the same node
-		if the HostIP or Protocol is different. This test doesn´t test the HostPort functionality.
-		 xref: https://github.com/kubernetes/kubernetes/issues/98075
-	*/
 	ginkgo.It("validates that there is no conflict between pods with same hostPort but different hostIP and protocol", func() {
 
 		nodeName := GetNodeThatCanRunPod(f)


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:
#98299 moved a conformance test from Scheduling to SIG-Network. 
This PR cleans up some old conformance metadata and updates the release metadata to 1.21

**Special notes for your reviewer**:
The reference to 1.20 in the metadata is causing k8s-conformance tests to fail at the moment.

**Does this PR introduce a user-facing change?**:

```
NONE
```
**Release note:**

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```
NONE
```