### PR TITLE
Scheduler: remove reflect.DeepEqual for defaultpreemption, helper, imagelocality package

### DIFF
--- a/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption_test.go
+++ b/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption_test.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
-	"reflect"
 	"sort"
 	"strings"
 	"testing"
@@ -302,11 +301,11 @@ func TestPostFilter(t *testing.T) {
 			}
 
 			gotResult, gotStatus := p.PostFilter(context.TODO(), state, tt.pod, tt.filteredNodesStatuses)
-			if !reflect.DeepEqual(gotStatus, tt.wantStatus) {
-				t.Errorf("Status does not match: %v, want: %v", gotStatus, tt.wantStatus)
+			if diff := cmp.Diff(tt.wantStatus, gotStatus); diff != "" {
+				t.Errorf("Unexpected status (-want, +got):\n%s", diff)
 			}
-			if diff := cmp.Diff(gotResult, tt.wantResult); diff != "" {
-				t.Errorf("Unexpected postFilterResult (-want, +got): %s", diff)
+			if diff := cmp.Diff(tt.wantResult, gotResult); diff != "" {
+				t.Errorf("Unexpected postFilterResult (-want, +got):\n%s", diff)
 			}
 		})
 	}

--- a/pkg/scheduler/framework/plugins/helper/BUILD
+++ b/pkg/scheduler/framework/plugins/helper/BUILD
@@ -35,6 +35,7 @@ go_test(
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/client-go/informers:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/fake:go_default_library",
+        "//vendor/github.com/google/go-cmp/cmp:go_default_library",
     ],
 )
 

--- a/pkg/scheduler/framework/plugins/helper/normalize_score_test.go
+++ b/pkg/scheduler/framework/plugins/helper/normalize_score_test.go
@@ -18,9 +18,9 @@ package helper
 
 import (
 	"fmt"
-	"reflect"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
 )
 
@@ -76,8 +76,8 @@ func TestDefaultNormalizeScore(t *testing.T) {
 			}
 
 			DefaultNormalizeScore(framework.MaxNodeScore, test.reverse, scores)
-			if !reflect.DeepEqual(scores, expectedScores) {
-				t.Errorf("expected %v, got %v", expectedScores, scores)
+			if diff := cmp.Diff(expectedScores, scores); diff != "" {
+				t.Errorf("Unexpected scores (-want, +got):\n%s", diff)
 			}
 		})
 	}

--- a/pkg/scheduler/framework/plugins/helper/spread_test.go
+++ b/pkg/scheduler/framework/plugins/helper/spread_test.go
@@ -18,10 +18,10 @@ package helper
 
 import (
 	"fmt"
-	"reflect"
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/informers"
@@ -97,8 +97,8 @@ func TestGetPodServices(t *testing.T) {
 			get, err := GetPodServices(fakeInformerFactory.Core().V1().Services().Lister(), test.pod)
 			if err != nil {
 				t.Errorf("Error from GetPodServices: %v", err)
-			} else if !reflect.DeepEqual(get, test.expect) {
-				t.Errorf("Expect services %v, but got %v", test.expect, get)
+			} else if diff := cmp.Diff(test.expect, get); diff != "" {
+				t.Errorf("Unexpected services (-want, +got):\n%s", diff)
 			}
 		})
 	}

--- a/pkg/scheduler/framework/plugins/imagelocality/BUILD
+++ b/pkg/scheduler/framework/plugins/imagelocality/BUILD
@@ -22,6 +22,7 @@ go_test(
         "//pkg/scheduler/internal/cache:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/github.com/google/go-cmp/cmp:go_default_library",
     ],
 )
 

--- a/pkg/scheduler/framework/plugins/imagelocality/image_locality_test.go
+++ b/pkg/scheduler/framework/plugins/imagelocality/image_locality_test.go
@@ -20,9 +20,9 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
-	"reflect"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
@@ -348,8 +348,8 @@ func TestImageLocalityPriority(t *testing.T) {
 				gotList = append(gotList, framework.NodeScore{Name: nodeName, Score: score})
 			}
 
-			if !reflect.DeepEqual(test.expectedList, gotList) {
-				t.Errorf("expected:\n\t%+v,\ngot:\n\t%+v", test.expectedList, gotList)
+			if diff := cmp.Diff(test.expectedList, gotList); diff != "" {
+				t.Errorf("Unexpected node score list (-want, +got):\n%s", diff)
 			}
 		})
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:


Use cmp instead of reflect.DeepEqual in scheduler test for defaultpreemption, helper and imagelocality package.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Xref #94696

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
none
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
