### PR TITLE
Fix about heapster in hack/grab-profiles.sh

### DIFF
--- a/hack/grab-profiles.sh
+++ b/hack/grab-profiles.sh
@@ -67,15 +67,13 @@ profile_components=""
 output_dir="."
 tunnel_port="${tunnel_port:-1234}"
 
-args=$(getopt -o s:mho:k:c -l server:,master,heapster,output:,kubelet:,scheduler,controller-manager,help,inuse-space,inuse-objects,alloc-space,alloc-objects,cpu,kubelet-binary:,master-binary:,scheduler-binary:,controller-manager-binary:,scheduler-port:,controller-manager-port: -- "$@")
+args=$(getopt -o s:mho:k:c -l server:,master,output:,kubelet:,scheduler,controller-manager,help,inuse-space,inuse-objects,alloc-space,alloc-objects,cpu,kubelet-binary:,master-binary:,scheduler-binary:,controller-manager-binary:,scheduler-port:,controller-manager-port: -- "$@")
 if [[ $? ]]; then
   >&2 echo "Error in getopt"
   exit 1
 fi
 
-HEAPSTER_VERSION="v0.18.2"
 MASTER_PPROF_PATH=""
-HEAPSTER_PPROF_PATH="/api/v1/namespaces/kube-system/services/monitoring-heapster/proxy"
 KUBELET_PPROF_PATH_PREFIX="/api/v1/proxy/nodes"
 SCHEDULER_PPROF_PATH_PREFIX="/api/v1/namespaces/kube-system/pods/kube-scheduler/proxy"
 CONTROLLER_MANAGER_PPROF_PATH_PREFIX="/api/v1/namespaces/kube-system/pods/kube-controller-manager/proxy"
@@ -105,10 +103,6 @@ while true; do
       fi
       master_binary=$1
       shift
-      ;;
-    -h|--heapster)
-      shift
-      profile_components="heapster ${profile_components}"
       ;;
     -k|--kubelet)
       shift
@@ -212,7 +206,6 @@ while true; do
         -o/--output,
         -s/--server,
         -m/--master,
-        -h/--heapster,
         --inuse-space,
         --inuse-objects,
         --alloc-space,
@@ -274,14 +267,6 @@ for component in ${profile_components}; do
     scheduler)
       path="${SCHEDULER_PPROF_PATH_PREFIX}-${server_addr}:${scheduler_port}"
       binary=${scheduler_binary}
-      ;;
-    heapster)
-      rm heapster
-      wget https://github.com/kubernetes/heapster/releases/download/${HEAPSTER_VERSION}/heapster
-      kube::util::trap_add 'rm -f heapster' EXIT
-      kube::util::trap_add 'rm -f heapster' SIGTERM
-      binary=heapster
-      path=${HEAPSTER_PPROF_PATH}
       ;;
     kubelet)
       path="${KUBELET_PPROF_PATH_PREFIX}"


### PR DESCRIPTION
**What type of PR is this?**
Since k/k has abandoned the heapster, and the heapster repo [heapster](https://github.com/kubernetes-retired/heapster) is no longer maintained since 2018

/kind cleanup
/kind feature

**What this PR does / why we need it**:
Maintain master code availability

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
None
```
