### PR TITLE
added sig-node attribute for tests in test/e2e/common/

### DIFF
--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -1,198 +1,3 @@
-- testname: Pod Lifecycle, post start exec hook
-  codename: '[k8s.io] Container Lifecycle Hook when create a pod with lifecycle hook
-    should execute poststart exec hook properly [NodeConformance] [Conformance]'
-  description: When a post start handler is specified in the container lifecycle using
-    a 'Exec' action, then the handler MUST be invoked after the start of the container.
-    A server pod is created that will serve http requests, create a second pod with
-    a container lifecycle specifying a post start that invokes the server pod using
-    ExecAction to validate that the post start is executed.
-  release: v1.9
-  file: test/e2e/common/lifecycle_hook.go
-- testname: Pod Lifecycle, post start http hook
-  codename: '[k8s.io] Container Lifecycle Hook when create a pod with lifecycle hook
-    should execute poststart http hook properly [NodeConformance] [Conformance]'
-  description: When a post start handler is specified in the container lifecycle using
-    a HttpGet action, then the handler MUST be invoked after the start of the container.
-    A server pod is created that will serve http requests, create a second pod with
-    a container lifecycle specifying a post start that invokes the server pod to validate
-    that the post start is executed.
-  release: v1.9
-  file: test/e2e/common/lifecycle_hook.go
-- testname: Pod Lifecycle, prestop exec hook
-  codename: '[k8s.io] Container Lifecycle Hook when create a pod with lifecycle hook
-    should execute prestop exec hook properly [NodeConformance] [Conformance]'
-  description: When a pre-stop handler is specified in the container lifecycle using
-    a 'Exec' action, then the handler MUST be invoked before the container is terminated.
-    A server pod is created that will serve http requests, create a second pod with
-    a container lifecycle specifying a pre-stop that invokes the server pod using
-    ExecAction to validate that the pre-stop is executed.
-  release: v1.9
-  file: test/e2e/common/lifecycle_hook.go
-- testname: Pod Lifecycle, prestop http hook
-  codename: '[k8s.io] Container Lifecycle Hook when create a pod with lifecycle hook
-    should execute prestop http hook properly [NodeConformance] [Conformance]'
-  description: When a pre-stop handler is specified in the container lifecycle using
-    a 'HttpGet' action, then the handler MUST be invoked before the container is terminated.
-    A server pod is created that will serve http requests, create a second pod with
-    a container lifecycle specifying a pre-stop that invokes the server pod to validate
-    that the pre-stop is executed.
-  release: v1.9
-  file: test/e2e/common/lifecycle_hook.go
-- testname: Container Runtime, TerminationMessage, from log output of succeeding container
-  codename: '[k8s.io] Container Runtime blackbox test on terminated container should
-    report termination message [LinuxOnly] as empty when pod succeeds and TerminationMessagePolicy
-    FallbackToLogsOnError is set [NodeConformance] [Conformance]'
-  description: 'Create a pod with an container. Container''s output is recorded in
-    log and container exits successfully without an error. When container is terminated,
-    terminationMessage MUST have no content as container succeed. [LinuxOnly]: Cannot
-    mount files in Windows Containers.'
-  release: v1.15
-  file: test/e2e/common/runtime.go
-- testname: Container Runtime, TerminationMessage, from file of succeeding container
-  codename: '[k8s.io] Container Runtime blackbox test on terminated container should
-    report termination message [LinuxOnly] from file when pod succeeds and TerminationMessagePolicy
-    FallbackToLogsOnError is set [NodeConformance] [Conformance]'
-  description: 'Create a pod with an container. Container''s output is recorded in
-    a file and the container exits successfully without an error. When container is
-    terminated, terminationMessage MUST match with the content from file. [LinuxOnly]:
-    Cannot mount files in Windows Containers.'
-  release: v1.15
-  file: test/e2e/common/runtime.go
-- testname: Container Runtime, TerminationMessage, from container's log output of
-    failing container
-  codename: '[k8s.io] Container Runtime blackbox test on terminated container should
-    report termination message [LinuxOnly] from log output if TerminationMessagePolicy
-    FallbackToLogsOnError is set [NodeConformance] [Conformance]'
-  description: 'Create a pod with an container. Container''s output is recorded in
-    log and container exits with an error. When container is terminated, termination
-    message MUST match the expected output recorded from container''s log. [LinuxOnly]:
-    Cannot mount files in Windows Containers.'
-  release: v1.15
-  file: test/e2e/common/runtime.go
-- testname: Container Runtime, TerminationMessagePath, non-root user and non-default
-    path
-  codename: '[k8s.io] Container Runtime blackbox test on terminated container should
-    report termination message [LinuxOnly] if TerminationMessagePath is set as non-root
-    user and at a non-default path [NodeConformance] [Conformance]'
-  description: 'Create a pod with a container to run it as a non-root user with a
-    custom TerminationMessagePath set. Pod redirects the output to the provided path
-    successfully. When the container is terminated, the termination message MUST match
-    the expected output logged in the provided custom path. [LinuxOnly]: Tagged LinuxOnly
-    due to use of ''uid'' and unable to mount files in Windows Containers.'
-  release: v1.15
-  file: test/e2e/common/runtime.go
-- testname: Container Runtime, Restart Policy, Pod Phases
-  codename: '[k8s.io] Container Runtime blackbox test when starting a container that
-    exits should run with the expected status [NodeConformance] [Conformance]'
-  description: If the restart policy is set to 'Always', Pod MUST be restarted when
-    terminated, If restart policy is 'OnFailure', Pod MUST be started only if it is
-    terminated with non-zero exit code. If the restart policy is 'Never', Pod MUST
-    never be restarted. All these three test cases MUST verify the restart counts
-    accordingly.
-  release: v1.13
-  file: test/e2e/common/runtime.go
-- testname: Docker containers, with arguments
-  codename: '[k8s.io] Docker Containers should be able to override the image''s default
-    arguments (docker cmd) [NodeConformance] [Conformance]'
-  description: Default command and  from the docker image entrypoint MUST be used
-    when Pod does not specify the container command but the arguments from Pod spec
-    MUST override when specified.
-  release: v1.9
-  file: test/e2e/common/docker_containers.go
-- testname: Docker containers, with command
-  codename: '[k8s.io] Docker Containers should be able to override the image''s default
-    command (docker entrypoint) [NodeConformance] [Conformance]'
-  description: Default command from the docker image entrypoint MUST NOT be used when
-    Pod specifies the container command.  Command from Pod spec MUST override the
-    command in the image.
-  release: v1.9
-  file: test/e2e/common/docker_containers.go
-- testname: Docker containers, with command and arguments
-  codename: '[k8s.io] Docker Containers should be able to override the image''s default
-    command and arguments [NodeConformance] [Conformance]'
-  description: Default command and arguments from the docker image entrypoint MUST
-    NOT be used when Pod specifies the container command and arguments.  Command and
-    arguments from Pod spec MUST override the command and arguments in the image.
-  release: v1.9
-  file: test/e2e/common/docker_containers.go
-- testname: Docker containers, without command and arguments
-  codename: '[k8s.io] Docker Containers should use the image defaults if command and
-    args are blank [NodeConformance] [Conformance]'
-  description: Default command and arguments from the docker image entrypoint MUST
-    be used when Pod does not specify the container command
-  release: v1.9
-  file: test/e2e/common/docker_containers.go
-- testname: init-container-starts-app-restartalways-pod
-  codename: '[k8s.io] InitContainer [NodeConformance] should invoke init containers
-    on a RestartAlways pod [Conformance]'
-  description: Ensure that all InitContainers are started and all containers in pod
-    started and at least one container is still running or is in the process of being
-    restarted when Pod has restart policy as RestartAlways.
-  release: v1.12
-  file: test/e2e/common/init_container.go
-- testname: init-container-starts-app-restartnever-pod
-  codename: '[k8s.io] InitContainer [NodeConformance] should invoke init containers
-    on a RestartNever pod [Conformance]'
-  description: Ensure that all InitContainers are started and all containers in pod
-    are voluntarily terminated with exit status 0, and the system is not going to
-    restart any of these containers when Pod has restart policy as RestartNever.
-  release: v1.12
-  file: test/e2e/common/init_container.go
-- testname: init-container-fails-stops-app-restartnever-pod
-  codename: '[k8s.io] InitContainer [NodeConformance] should not start app containers
-    and fail the pod if init containers fail on a RestartNever pod [Conformance]'
-  description: Ensure that app container is not started when at least one InitContainer
-    fails to start and Pod has restart policy as RestartNever.
-  release: v1.12
-  file: test/e2e/common/init_container.go
-- testname: init-container-fails-stops-app-restartalways-pod
-  codename: '[k8s.io] InitContainer [NodeConformance] should not start app containers
-    if init containers fail on a RestartAlways pod [Conformance]'
-  description: Ensure that app container is not started when all InitContainers failed
-    to start and Pod has restarted for few occurrences and pod has restart policy
-    as RestartAlways.
-  release: v1.12
-  file: test/e2e/common/init_container.go
-- testname: Kubelet, hostAliases
-  codename: '[k8s.io] Kubelet when scheduling a busybox Pod with hostAliases should
-    write entries to /etc/hosts [LinuxOnly] [NodeConformance] [Conformance]'
-  description: Create a Pod with hostAliases and a container with command to output
-    /etc/hosts entries. Pod's logs MUST have matching entries of specified hostAliases
-    to the output of /etc/hosts entries. Kubernetes mounts the /etc/hosts file into
-    its containers, however, mounting individual files is not supported on Windows
-    Containers. For this reason, this test is marked LinuxOnly.
-  release: v1.13
-  file: test/e2e/common/kubelet.go
-- testname: Kubelet, log output, default
-  codename: '[k8s.io] Kubelet when scheduling a busybox command in a pod should print
-    the output to logs [NodeConformance] [Conformance]'
-  description: By default the stdout and stderr from the process being executed in
-    a pod MUST be sent to the pod's logs.
-  release: v1.13
-  file: test/e2e/common/kubelet.go
-- testname: Kubelet, failed pod, delete
-  codename: '[k8s.io] Kubelet when scheduling a busybox command that always fails
-    in a pod should be possible to delete [NodeConformance] [Conformance]'
-  description: Create a Pod with terminated state. This terminated pod MUST be able
-    to be deleted.
-  release: v1.13
-  file: test/e2e/common/kubelet.go
-- testname: Kubelet, failed pod, terminated reason
-  codename: '[k8s.io] Kubelet when scheduling a busybox command that always fails
-    in a pod should have an terminated reason [NodeConformance] [Conformance]'
-  description: Create a Pod with terminated state. Pod MUST have only one container.
-    Container MUST be in terminated state and MUST have an terminated reason.
-  release: v1.13
-  file: test/e2e/common/kubelet.go
-- testname: Kubelet, pod with read only root file system
-  codename: '[k8s.io] Kubelet when scheduling a read only busybox container should
-    not write to root filesystem [LinuxOnly] [NodeConformance] [Conformance]'
-  description: Create a Pod with security context set with ReadOnlyRootFileSystem
-    set to true. The Pod then tries to write to the /file on the root, write operation
-    to the root filesystem MUST fail as expected. This test is marked LinuxOnly since
-    Windows does not support creating containers with read-only access.
-  release: v1.13
-  file: test/e2e/common/kubelet.go
 - testname: Kubelet, managed etc hosts
   codename: '[k8s.io] KubeletManagedEtcHosts should test kubelet managed /etc/hosts
     file [LinuxOnly] [NodeConformance] [Conformance]'
@@ -206,8 +11,214 @@
     mount individual files in Containers.
   release: v1.9
   file: test/e2e/common/kubelet_etc_hosts.go
+- testname: Pod Lifecycle, post start exec hook
+  codename: '[k8s.io] [sig-node] Container Lifecycle Hook when create a pod with lifecycle
+    hook should execute poststart exec hook properly [NodeConformance] [Conformance]'
+  description: When a post start handler is specified in the container lifecycle using
+    a 'Exec' action, then the handler MUST be invoked after the start of the container.
+    A server pod is created that will serve http requests, create a second pod with
+    a container lifecycle specifying a post start that invokes the server pod using
+    ExecAction to validate that the post start is executed.
+  release: v1.9
+  file: test/e2e/common/lifecycle_hook.go
+- testname: Pod Lifecycle, post start http hook
+  codename: '[k8s.io] [sig-node] Container Lifecycle Hook when create a pod with lifecycle
+    hook should execute poststart http hook properly [NodeConformance] [Conformance]'
+  description: When a post start handler is specified in the container lifecycle using
+    a HttpGet action, then the handler MUST be invoked after the start of the container.
+    A server pod is created that will serve http requests, create a second pod with
+    a container lifecycle specifying a post start that invokes the server pod to validate
+    that the post start is executed.
+  release: v1.9
+  file: test/e2e/common/lifecycle_hook.go
+- testname: Pod Lifecycle, prestop exec hook
+  codename: '[k8s.io] [sig-node] Container Lifecycle Hook when create a pod with lifecycle
+    hook should execute prestop exec hook properly [NodeConformance] [Conformance]'
+  description: When a pre-stop handler is specified in the container lifecycle using
+    a 'Exec' action, then the handler MUST be invoked before the container is terminated.
+    A server pod is created that will serve http requests, create a second pod with
+    a container lifecycle specifying a pre-stop that invokes the server pod using
+    ExecAction to validate that the pre-stop is executed.
+  release: v1.9
+  file: test/e2e/common/lifecycle_hook.go
+- testname: Pod Lifecycle, prestop http hook
+  codename: '[k8s.io] [sig-node] Container Lifecycle Hook when create a pod with lifecycle
+    hook should execute prestop http hook properly [NodeConformance] [Conformance]'
+  description: When a pre-stop handler is specified in the container lifecycle using
+    a 'HttpGet' action, then the handler MUST be invoked before the container is terminated.
+    A server pod is created that will serve http requests, create a second pod with
+    a container lifecycle specifying a pre-stop that invokes the server pod to validate
+    that the pre-stop is executed.
+  release: v1.9
+  file: test/e2e/common/lifecycle_hook.go
+- testname: Container Runtime, TerminationMessage, from log output of succeeding container
+  codename: '[k8s.io] [sig-node] Container Runtime blackbox test on terminated container
+    should report termination message [LinuxOnly] as empty when pod succeeds and TerminationMessagePolicy
+    FallbackToLogsOnError is set [NodeConformance] [Conformance]'
+  description: 'Create a pod with an container. Container''s output is recorded in
+    log and container exits successfully without an error. When container is terminated,
+    terminationMessage MUST have no content as container succeed. [LinuxOnly]: Cannot
+    mount files in Windows Containers.'
+  release: v1.15
+  file: test/e2e/common/runtime.go
+- testname: Container Runtime, TerminationMessage, from file of succeeding container
+  codename: '[k8s.io] [sig-node] Container Runtime blackbox test on terminated container
+    should report termination message [LinuxOnly] from file when pod succeeds and
+    TerminationMessagePolicy FallbackToLogsOnError is set [NodeConformance] [Conformance]'
+  description: 'Create a pod with an container. Container''s output is recorded in
+    a file and the container exits successfully without an error. When container is
+    terminated, terminationMessage MUST match with the content from file. [LinuxOnly]:
+    Cannot mount files in Windows Containers.'
+  release: v1.15
+  file: test/e2e/common/runtime.go
+- testname: Container Runtime, TerminationMessage, from container's log output of
+    failing container
+  codename: '[k8s.io] [sig-node] Container Runtime blackbox test on terminated container
+    should report termination message [LinuxOnly] from log output if TerminationMessagePolicy
+    FallbackToLogsOnError is set [NodeConformance] [Conformance]'
+  description: 'Create a pod with an container. Container''s output is recorded in
+    log and container exits with an error. When container is terminated, termination
+    message MUST match the expected output recorded from container''s log. [LinuxOnly]:
+    Cannot mount files in Windows Containers.'
+  release: v1.15
+  file: test/e2e/common/runtime.go
+- testname: Container Runtime, TerminationMessagePath, non-root user and non-default
+    path
+  codename: '[k8s.io] [sig-node] Container Runtime blackbox test on terminated container
+    should report termination message [LinuxOnly] if TerminationMessagePath is set
+    as non-root user and at a non-default path [NodeConformance] [Conformance]'
+  description: 'Create a pod with a container to run it as a non-root user with a
+    custom TerminationMessagePath set. Pod redirects the output to the provided path
+    successfully. When the container is terminated, the termination message MUST match
+    the expected output logged in the provided custom path. [LinuxOnly]: Tagged LinuxOnly
+    due to use of ''uid'' and unable to mount files in Windows Containers.'
+  release: v1.15
+  file: test/e2e/common/runtime.go
+- testname: Container Runtime, Restart Policy, Pod Phases
+  codename: '[k8s.io] [sig-node] Container Runtime blackbox test when starting a container
+    that exits should run with the expected status [NodeConformance] [Conformance]'
+  description: If the restart policy is set to 'Always', Pod MUST be restarted when
+    terminated, If restart policy is 'OnFailure', Pod MUST be started only if it is
+    terminated with non-zero exit code. If the restart policy is 'Never', Pod MUST
+    never be restarted. All these three test cases MUST verify the restart counts
+    accordingly.
+  release: v1.13
+  file: test/e2e/common/runtime.go
+- testname: Docker containers, with arguments
+  codename: '[k8s.io] [sig-node] Docker Containers should be able to override the
+    image''s default arguments (docker cmd) [NodeConformance] [Conformance]'
+  description: Default command and  from the docker image entrypoint MUST be used
+    when Pod does not specify the container command but the arguments from Pod spec
+    MUST override when specified.
+  release: v1.9
+  file: test/e2e/common/docker_containers.go
+- testname: Docker containers, with command
+  codename: '[k8s.io] [sig-node] Docker Containers should be able to override the
+    image''s default command (docker entrypoint) [NodeConformance] [Conformance]'
+  description: Default command from the docker image entrypoint MUST NOT be used when
+    Pod specifies the container command.  Command from Pod spec MUST override the
+    command in the image.
+  release: v1.9
+  file: test/e2e/common/docker_containers.go
+- testname: Docker containers, with command and arguments
+  codename: '[k8s.io] [sig-node] Docker Containers should be able to override the
+    image''s default command and arguments [NodeConformance] [Conformance]'
+  description: Default command and arguments from the docker image entrypoint MUST
+    NOT be used when Pod specifies the container command and arguments.  Command and
+    arguments from Pod spec MUST override the command and arguments in the image.
+  release: v1.9
+  file: test/e2e/common/docker_containers.go
+- testname: Docker containers, without command and arguments
+  codename: '[k8s.io] [sig-node] Docker Containers should use the image defaults if
+    command and args are blank [NodeConformance] [Conformance]'
+  description: Default command and arguments from the docker image entrypoint MUST
+    be used when Pod does not specify the container command
+  release: v1.9
+  file: test/e2e/common/docker_containers.go
+- testname: Pod events, verify event from Scheduler and Kubelet
+  codename: '[k8s.io] [sig-node] Events should be sent by kubelets and the scheduler
+    about pods scheduling and running  [Conformance]'
+  description: Create a Pod, make sure that the Pod can be queried. Create a event
+    selector for the kind=Pod and the source is the Scheduler. List of the events
+    MUST be at least one. Create a event selector for kind=Pod and the source is the
+    Kubelet. List of the events MUST be at least one. Both Scheduler and Kubelet MUST
+    send events when scheduling and running a Pod.
+  release: v1.9
+  file: test/e2e/node/events.go
+- testname: init-container-starts-app-restartalways-pod
+  codename: '[k8s.io] [sig-node] InitContainer [NodeConformance] should invoke init
+    containers on a RestartAlways pod [Conformance]'
+  description: Ensure that all InitContainers are started and all containers in pod
+    started and at least one container is still running or is in the process of being
+    restarted when Pod has restart policy as RestartAlways.
+  release: v1.12
+  file: test/e2e/common/init_container.go
+- testname: init-container-starts-app-restartnever-pod
+  codename: '[k8s.io] [sig-node] InitContainer [NodeConformance] should invoke init
+    containers on a RestartNever pod [Conformance]'
+  description: Ensure that all InitContainers are started and all containers in pod
+    are voluntarily terminated with exit status 0, and the system is not going to
+    restart any of these containers when Pod has restart policy as RestartNever.
+  release: v1.12
+  file: test/e2e/common/init_container.go
+- testname: init-container-fails-stops-app-restartnever-pod
+  codename: '[k8s.io] [sig-node] InitContainer [NodeConformance] should not start
+    app containers and fail the pod if init containers fail on a RestartNever pod
+    [Conformance]'
+  description: Ensure that app container is not started when at least one InitContainer
+    fails to start and Pod has restart policy as RestartNever.
+  release: v1.12
+  file: test/e2e/common/init_container.go
+- testname: init-container-fails-stops-app-restartalways-pod
+  codename: '[k8s.io] [sig-node] InitContainer [NodeConformance] should not start
+    app containers if init containers fail on a RestartAlways pod [Conformance]'
+  description: Ensure that app container is not started when all InitContainers failed
+    to start and Pod has restarted for few occurrences and pod has restart policy
+    as RestartAlways.
+  release: v1.12
+  file: test/e2e/common/init_container.go
+- testname: Kubelet, hostAliases
+  codename: '[k8s.io] [sig-node] Kubelet when scheduling a busybox Pod with hostAliases
+    should write entries to /etc/hosts [LinuxOnly] [NodeConformance] [Conformance]'
+  description: Create a Pod with hostAliases and a container with command to output
+    /etc/hosts entries. Pod's logs MUST have matching entries of specified hostAliases
+    to the output of /etc/hosts entries. Kubernetes mounts the /etc/hosts file into
+    its containers, however, mounting individual files is not supported on Windows
+    Containers. For this reason, this test is marked LinuxOnly.
+  release: v1.13
+  file: test/e2e/common/kubelet.go
+- testname: Kubelet, log output, default
+  codename: '[k8s.io] [sig-node] Kubelet when scheduling a busybox command in a pod
+    should print the output to logs [NodeConformance] [Conformance]'
+  description: By default the stdout and stderr from the process being executed in
+    a pod MUST be sent to the pod's logs.
+  release: v1.13
+  file: test/e2e/common/kubelet.go
+- testname: Kubelet, failed pod, delete
+  codename: '[k8s.io] [sig-node] Kubelet when scheduling a busybox command that always
+    fails in a pod should be possible to delete [NodeConformance] [Conformance]'
+  description: Create a Pod with terminated state. This terminated pod MUST be able
+    to be deleted.
+  release: v1.13
+  file: test/e2e/common/kubelet.go
+- testname: Kubelet, failed pod, terminated reason
+  codename: '[k8s.io] [sig-node] Kubelet when scheduling a busybox command that always
+    fails in a pod should have an terminated reason [NodeConformance] [Conformance]'
+  description: Create a Pod with terminated state. Pod MUST have only one container.
+    Container MUST be in terminated state and MUST have an terminated reason.
+  release: v1.13
+  file: test/e2e/common/kubelet.go
+- testname: Kubelet, pod with read only root file system
+  codename: '[k8s.io] [sig-node] Kubelet when scheduling a read only busybox container
+    should not write to root filesystem [LinuxOnly] [NodeConformance] [Conformance]'
+  description: Create a Pod with security context set with ReadOnlyRootFileSystem
+    set to true. The Pod then tries to write to the /file on the root, write operation
+    to the root filesystem MUST fail as expected. This test is marked LinuxOnly since
+    Windows does not support creating containers with read-only access.
+  release: v1.13
+  file: test/e2e/common/kubelet.go
 - testname: lease API should be available
-  codename: '[k8s.io] Lease lease API should be available [Conformance]'
+  codename: '[k8s.io] [sig-node] Lease lease API should be available [Conformance]'
   description: "Create Lease object, and get it; create and get MUST be successful
     and Spec of the read Lease MUST match Spec of original Lease. Update the Lease
     and get it; update and get MUST be successful\tand Spec of the read Lease MUST
@@ -220,254 +231,6 @@
     delete MUST be successful. Get the lease; get MUST return not found error."
   release: v1.17
   file: test/e2e/common/lease.go
-- testname: Pods, ActiveDeadlineSeconds
-  codename: '[k8s.io] Pods should allow activeDeadlineSeconds to be updated [NodeConformance]
-    [Conformance]'
-  description: Create a Pod with a unique label. Query for the Pod with the label
-    as selector MUST be successful. The Pod is updated with ActiveDeadlineSeconds
-    set on the Pod spec. Pod MUST terminate of the specified time elapses.
-  release: v1.9
-  file: test/e2e/common/pods.go
-- testname: Pods, lifecycle
-  codename: '[k8s.io] Pods should be submitted and removed [NodeConformance] [Conformance]'
-  description: A Pod is created with a unique label. Pod MUST be accessible when queried
-    using the label selector upon creation. Add a watch, check if the Pod is running.
-    Pod then deleted, The pod deletion timestamp is observed. The watch MUST return
-    the pod deleted event. Query with the original selector for the Pod MUST return
-    empty list.
-  release: v1.9
-  file: test/e2e/common/pods.go
-- testname: Pods, update
-  codename: '[k8s.io] Pods should be updated [NodeConformance] [Conformance]'
-  description: Create a Pod with a unique label. Query for the Pod with the label
-    as selector MUST be successful. Update the pod to change the value of the Label.
-    Query for the Pod with the new value for the label MUST be successful.
-  release: v1.9
-  file: test/e2e/common/pods.go
-- testname: Pods, service environment variables
-  codename: '[k8s.io] Pods should contain environment variables for services [NodeConformance]
-    [Conformance]'
-  description: Create a server Pod listening on port 9376. A Service called fooservice
-    is created for the server Pod listening on port 8765 targeting port 8080. If a
-    new Pod is created in the cluster then the Pod MUST have the fooservice environment
-    variables available from this new Pod. The new create Pod MUST have environment
-    variables such as FOOSERVICE_SERVICE_HOST, FOOSERVICE_SERVICE_PORT, FOOSERVICE_PORT,
-    FOOSERVICE_PORT_8765_TCP_PORT, FOOSERVICE_PORT_8765_TCP_PROTO, FOOSERVICE_PORT_8765_TCP
-    and FOOSERVICE_PORT_8765_TCP_ADDR that are populated with proper values.
-  release: v1.9
-  file: test/e2e/common/pods.go
-- testname: Pods, delete a collection
-  codename: '[k8s.io] Pods should delete a collection of pods [Conformance]'
-  description: A set of pods is created with a label selector which MUST be found
-    when listed. The set of pods is deleted and MUST NOT show up when listed by its
-    label selector.
-  release: v1.19
-  file: test/e2e/common/pods.go
-- testname: Pods, assigned hostip
-  codename: '[k8s.io] Pods should get a host IP [NodeConformance] [Conformance]'
-  description: Create a Pod. Pod status MUST return successfully and contains a valid
-    IP address.
-  release: v1.9
-  file: test/e2e/common/pods.go
-- testname: Pods, completes the lifecycle of a Pod and the PodStatus
-  codename: '[k8s.io] Pods should run through the lifecycle of Pods and PodStatus
-    [Conformance]'
-  description: A Pod is created with a static label which MUST succeed. It MUST succeed
-    when patching the label and the pod data. When checking and replacing the PodStatus
-    it MUST succeed. It MUST succeed when deleting the Pod.
-  release: v1.20
-  file: test/e2e/common/pods.go
-- testname: Pods, remote command execution over websocket
-  codename: '[k8s.io] Pods should support remote command execution over websockets
-    [NodeConformance] [Conformance]'
-  description: A Pod is created. Websocket is created to retrieve exec command output
-    from this pod. Message retrieved form Websocket MUST match with expected exec
-    command output.
-  release: v1.13
-  file: test/e2e/common/pods.go
-- testname: Pods, logs from websockets
-  codename: '[k8s.io] Pods should support retrieving logs from the container over
-    websockets [NodeConformance] [Conformance]'
-  description: A Pod is created. Websocket is created to retrieve log of a container
-    from this pod. Message retrieved form Websocket MUST match with container's output.
-  release: v1.13
-  file: test/e2e/common/pods.go
-- testname: Pod liveness probe, using http endpoint, failure
-  codename: '[k8s.io] Probing container should *not* be restarted with a /healthz
-    http liveness probe [NodeConformance] [Conformance]'
-  description: A Pod is created with liveness probe on http endpoint '/'. Liveness
-    probe on this endpoint will not fail. When liveness probe does not fail then the
-    restart count MUST remain zero.
-  release: v1.9
-  file: test/e2e/common/container_probe.go
-- testname: Pod liveness probe, using local file, no restart
-  codename: '[k8s.io] Probing container should *not* be restarted with a exec "cat
-    /tmp/health" liveness probe [NodeConformance] [Conformance]'
-  description: Pod is created with liveness probe that uses 'exec' command to cat
-    /temp/health file. Liveness probe MUST not fail to check health and the restart
-    count should remain 0.
-  release: v1.9
-  file: test/e2e/common/container_probe.go
-- testname: Pod liveness probe, using tcp socket, no restart
-  codename: '[k8s.io] Probing container should *not* be restarted with a tcp:8080
-    liveness probe [NodeConformance] [Conformance]'
-  description: A Pod is created with liveness probe on tcp socket 8080. The http handler
-    on port 8080 will return http errors after 10 seconds, but the socket will remain
-    open. Liveness probe MUST not fail to check health and the restart count should
-    remain 0.
-  release: v1.18
-  file: test/e2e/common/container_probe.go
-- testname: Pod liveness probe, using http endpoint, restart
-  codename: '[k8s.io] Probing container should be restarted with a /healthz http liveness
-    probe [NodeConformance] [Conformance]'
-  description: A Pod is created with liveness probe on http endpoint /healthz. The
-    http handler on the /healthz will return a http error after 10 seconds since the
-    Pod is started. This MUST result in liveness check failure. The Pod MUST now be
-    killed and restarted incrementing restart count to 1.
-  release: v1.9
-  file: test/e2e/common/container_probe.go
-- testname: Pod liveness probe, using local file, restart
-  codename: '[k8s.io] Probing container should be restarted with a exec "cat /tmp/health"
-    liveness probe [NodeConformance] [Conformance]'
-  description: Create a Pod with liveness probe that uses ExecAction handler to cat
-    /temp/health file. The Container deletes the file /temp/health after 10 second,
-    triggering liveness probe to fail. The Pod MUST now be killed and restarted incrementing
-    restart count to 1.
-  release: v1.9
-  file: test/e2e/common/container_probe.go
-- testname: Pod liveness probe, using http endpoint, multiple restarts (slow)
-  codename: '[k8s.io] Probing container should have monotonically increasing restart
-    count [NodeConformance] [Conformance]'
-  description: A Pod is created with liveness probe on http endpoint /healthz. The
-    http handler on the /healthz will return a http error after 10 seconds since the
-    Pod is started. This MUST result in liveness check failure. The Pod MUST now be
-    killed and restarted incrementing restart count to 1. The liveness probe must
-    fail again after restart once the http handler for /healthz enpoind on the Pod
-    returns an http error after 10 seconds from the start. Restart counts MUST increment
-    everytime health check fails, measure upto 5 restart.
-  release: v1.9
-  file: test/e2e/common/container_probe.go
-- testname: Pod readiness probe, with initial delay
-  codename: '[k8s.io] Probing container with readiness probe should not be ready before
-    initial delay and never restart [NodeConformance] [Conformance]'
-  description: Create a Pod that is configured with a initial delay set on the readiness
-    probe. Check the Pod Start time to compare to the initial delay. The Pod MUST
-    be ready only after the specified initial delay.
-  release: v1.9
-  file: test/e2e/common/container_probe.go
-- testname: Pod readiness probe, failure
-  codename: '[k8s.io] Probing container with readiness probe that fails should never
-    be ready and never restart [NodeConformance] [Conformance]'
-  description: Create a Pod with a readiness probe that fails consistently. When this
-    Pod is created, then the Pod MUST never be ready, never be running and restart
-    count MUST be zero.
-  release: v1.9
-  file: test/e2e/common/container_probe.go
-- testname: Security Context, runAsUser=65534
-  codename: '[k8s.io] Security Context When creating a container with runAsUser should
-    run the container with uid 65534 [LinuxOnly] [NodeConformance] [Conformance]'
-  description: 'Container is created with runAsUser option by passing uid 65534 to
-    run as unpriviledged user. Pod MUST be in Succeeded phase. [LinuxOnly]: This test
-    is marked as LinuxOnly since Windows does not support running as UID / GID.'
-  release: v1.15
-  file: test/e2e/common/security_context.go
-- testname: Security Context, privileged=false.
-  codename: '[k8s.io] Security Context When creating a pod with privileged should
-    run the container as unprivileged when false [LinuxOnly] [NodeConformance] [Conformance]'
-  description: 'Create a container to run in unprivileged mode by setting pod''s SecurityContext
-    Privileged option as false. Pod MUST be in Succeeded phase. [LinuxOnly]: This
-    test is marked as LinuxOnly since it runs a Linux-specific command.'
-  release: v1.15
-  file: test/e2e/common/security_context.go
-- testname: Security Context, readOnlyRootFilesystem=false.
-  codename: '[k8s.io] Security Context When creating a pod with readOnlyRootFilesystem
-    should run the container with writable rootfs when readOnlyRootFilesystem=false
-    [NodeConformance] [Conformance]'
-  description: Container is configured to run with readOnlyRootFilesystem to false.
-    Write operation MUST be allowed and Pod MUST be in Succeeded state.
-  release: v1.15
-  file: test/e2e/common/security_context.go
-- testname: Security Context, allowPrivilegeEscalation=false.
-  codename: '[k8s.io] Security Context when creating containers with AllowPrivilegeEscalation
-    should not allow privilege escalation when false [LinuxOnly] [NodeConformance]
-    [Conformance]'
-  description: 'Configuring the allowPrivilegeEscalation to false, does not allow
-    the privilege escalation operation. A container is configured with allowPrivilegeEscalation=false
-    and a given uid (1000) which is not 0. When the container is run, container''s
-    output MUST match with expected output verifying container ran with given uid
-    i.e. uid=1000. [LinuxOnly]: This test is marked LinuxOnly since Windows does not
-    support running as UID / GID, or privilege escalation.'
-  release: v1.15
-  file: test/e2e/common/security_context.go
-- testname: Environment variables, expansion
-  codename: '[k8s.io] Variable Expansion should allow composing env vars into new
-    env vars [NodeConformance] [Conformance]'
-  description: Create a Pod with environment variables. Environment variables defined
-    using previously defined environment variables MUST expand to proper values.
-  release: v1.9
-  file: test/e2e/common/expansion.go
-- testname: Environment variables, command argument expansion
-  codename: '[k8s.io] Variable Expansion should allow substituting values in a container''s
-    args [NodeConformance] [Conformance]'
-  description: Create a Pod with environment variables and container command arguments
-    using them. Container command arguments using the  defined environment variables
-    MUST expand to proper values.
-  release: v1.9
-  file: test/e2e/common/expansion.go
-- testname: Environment variables, command expansion
-  codename: '[k8s.io] Variable Expansion should allow substituting values in a container''s
-    command [NodeConformance] [Conformance]'
-  description: Create a Pod with environment variables and container command using
-    them. Container command using the  defined environment variables MUST expand to
-    proper values.
-  release: v1.9
-  file: test/e2e/common/expansion.go
-- testname: VolumeSubpathEnvExpansion, subpath expansion
-  codename: '[k8s.io] Variable Expansion should allow substituting values in a volume
-    subpath [sig-storage] [Conformance]'
-  description: Make sure a container's subpath can be set using an expansion of environment
-    variables.
-  release: v1.19
-  file: test/e2e/common/expansion.go
-- testname: VolumeSubpathEnvExpansion, subpath with absolute path
-  codename: '[k8s.io] Variable Expansion should fail substituting values in a volume
-    subpath with absolute path [sig-storage][Slow] [Conformance]'
-  description: Make sure a container's subpath can not be set using an expansion of
-    environment variables when absolute path is supplied.
-  release: v1.19
-  file: test/e2e/common/expansion.go
-- testname: VolumeSubpathEnvExpansion, subpath with backticks
-  codename: '[k8s.io] Variable Expansion should fail substituting values in a volume
-    subpath with backticks [sig-storage][Slow] [Conformance]'
-  description: Make sure a container's subpath can not be set using an expansion of
-    environment variables when backticks are supplied.
-  release: v1.19
-  file: test/e2e/common/expansion.go
-- testname: VolumeSubpathEnvExpansion, subpath test writes
-  codename: '[k8s.io] Variable Expansion should succeed in writing subpaths in container
-    [sig-storage][Slow] [Conformance]'
-  description: "Verify that a subpath expansion can be used to write files into subpaths.
-    1.\tvalid subpathexpr starts a container running 2.\ttest for valid subpath writes
-    3.\tsuccessful expansion of the subpathexpr isn't required for volume cleanup"
-  release: v1.19
-  file: test/e2e/common/expansion.go
-- testname: VolumeSubpathEnvExpansion, subpath ready from failed state
-  codename: '[k8s.io] Variable Expansion should verify that a failing subpath expansion
-    can be modified during the lifecycle of a container [sig-storage][Slow] [Conformance]'
-  description: Verify that a failing subpath expansion can be modified during the
-    lifecycle of a container.
-  release: v1.19
-  file: test/e2e/common/expansion.go
-- testname: Pod events, verify event from Scheduler and Kubelet
-  codename: '[k8s.io] [sig-node] Events should be sent by kubelets and the scheduler
-    about pods scheduling and running  [Conformance]'
-  description: Create a Pod, make sure that the Pod can be queried. Create a event
-    selector for the kind=Pod and the source is the Scheduler. List of the events
-    MUST be at least one. Create a event selector for kind=Pod and the source is the
-    Kubelet. List of the events MUST be at least one. Both Scheduler and Kubelet MUST
-    send events when scheduling and running a Pod.
-  release: v1.9
-  file: test/e2e/node/events.go
 - testname: Pod Eviction, Toleration limits
   codename: '[k8s.io] [sig-node] NoExecuteTaintManager Multiple Pods [Serial] evicts
     pods with minTolerationSeconds [Disruptive] [Conformance]'
@@ -489,6 +252,79 @@
     have QOSClass set to PodQOSGuaranteed.
   release: v1.9
   file: test/e2e/node/pods.go
+- testname: Pods, ActiveDeadlineSeconds
+  codename: '[k8s.io] [sig-node] Pods should allow activeDeadlineSeconds to be updated
+    [NodeConformance] [Conformance]'
+  description: Create a Pod with a unique label. Query for the Pod with the label
+    as selector MUST be successful. The Pod is updated with ActiveDeadlineSeconds
+    set on the Pod spec. Pod MUST terminate of the specified time elapses.
+  release: v1.9
+  file: test/e2e/common/pods.go
+- testname: Pods, lifecycle
+  codename: '[k8s.io] [sig-node] Pods should be submitted and removed [NodeConformance]
+    [Conformance]'
+  description: A Pod is created with a unique label. Pod MUST be accessible when queried
+    using the label selector upon creation. Add a watch, check if the Pod is running.
+    Pod then deleted, The pod deletion timestamp is observed. The watch MUST return
+    the pod deleted event. Query with the original selector for the Pod MUST return
+    empty list.
+  release: v1.9
+  file: test/e2e/common/pods.go
+- testname: Pods, update
+  codename: '[k8s.io] [sig-node] Pods should be updated [NodeConformance] [Conformance]'
+  description: Create a Pod with a unique label. Query for the Pod with the label
+    as selector MUST be successful. Update the pod to change the value of the Label.
+    Query for the Pod with the new value for the label MUST be successful.
+  release: v1.9
+  file: test/e2e/common/pods.go
+- testname: Pods, service environment variables
+  codename: '[k8s.io] [sig-node] Pods should contain environment variables for services
+    [NodeConformance] [Conformance]'
+  description: Create a server Pod listening on port 9376. A Service called fooservice
+    is created for the server Pod listening on port 8765 targeting port 8080. If a
+    new Pod is created in the cluster then the Pod MUST have the fooservice environment
+    variables available from this new Pod. The new create Pod MUST have environment
+    variables such as FOOSERVICE_SERVICE_HOST, FOOSERVICE_SERVICE_PORT, FOOSERVICE_PORT,
+    FOOSERVICE_PORT_8765_TCP_PORT, FOOSERVICE_PORT_8765_TCP_PROTO, FOOSERVICE_PORT_8765_TCP
+    and FOOSERVICE_PORT_8765_TCP_ADDR that are populated with proper values.
+  release: v1.9
+  file: test/e2e/common/pods.go
+- testname: Pods, delete a collection
+  codename: '[k8s.io] [sig-node] Pods should delete a collection of pods [Conformance]'
+  description: A set of pods is created with a label selector which MUST be found
+    when listed. The set of pods is deleted and MUST NOT show up when listed by its
+    label selector.
+  release: v1.19
+  file: test/e2e/common/pods.go
+- testname: Pods, assigned hostip
+  codename: '[k8s.io] [sig-node] Pods should get a host IP [NodeConformance] [Conformance]'
+  description: Create a Pod. Pod status MUST return successfully and contains a valid
+    IP address.
+  release: v1.9
+  file: test/e2e/common/pods.go
+- testname: Pods, completes the lifecycle of a Pod and the PodStatus
+  codename: '[k8s.io] [sig-node] Pods should run through the lifecycle of Pods and
+    PodStatus [Conformance]'
+  description: A Pod is created with a static label which MUST succeed. It MUST succeed
+    when patching the label and the pod data. When checking and replacing the PodStatus
+    it MUST succeed. It MUST succeed when deleting the Pod.
+  release: v1.20
+  file: test/e2e/common/pods.go
+- testname: Pods, remote command execution over websocket
+  codename: '[k8s.io] [sig-node] Pods should support remote command execution over
+    websockets [NodeConformance] [Conformance]'
+  description: A Pod is created. Websocket is created to retrieve exec command output
+    from this pod. Message retrieved form Websocket MUST match with expected exec
+    command output.
+  release: v1.13
+  file: test/e2e/common/pods.go
+- testname: Pods, logs from websockets
+  codename: '[k8s.io] [sig-node] Pods should support retrieving logs from the container
+    over websockets [NodeConformance] [Conformance]'
+  description: A Pod is created. Websocket is created to retrieve log of a container
+    from this pod. Message retrieved form Websocket MUST match with container's output.
+  release: v1.13
+  file: test/e2e/common/pods.go
 - testname: Pods, prestop hook
   codename: '[k8s.io] [sig-node] PreStop should call prestop when killing a pod  [Conformance]'
   description: Create a server pod with a rest endpoint '/write' that changes state.Received
@@ -499,6 +335,173 @@
     is verified by checking the status received on the server Pod.
   release: v1.9
   file: test/e2e/node/pre_stop.go
+- testname: Pod liveness probe, using http endpoint, failure
+  codename: '[k8s.io] [sig-node] Probing container should *not* be restarted with
+    a /healthz http liveness probe [NodeConformance] [Conformance]'
+  description: A Pod is created with liveness probe on http endpoint '/'. Liveness
+    probe on this endpoint will not fail. When liveness probe does not fail then the
+    restart count MUST remain zero.
+  release: v1.9
+  file: test/e2e/common/container_probe.go
+- testname: Pod liveness probe, using local file, no restart
+  codename: '[k8s.io] [sig-node] Probing container should *not* be restarted with
+    a exec "cat /tmp/health" liveness probe [NodeConformance] [Conformance]'
+  description: Pod is created with liveness probe that uses 'exec' command to cat
+    /temp/health file. Liveness probe MUST not fail to check health and the restart
+    count should remain 0.
+  release: v1.9
+  file: test/e2e/common/container_probe.go
+- testname: Pod liveness probe, using tcp socket, no restart
+  codename: '[k8s.io] [sig-node] Probing container should *not* be restarted with
+    a tcp:8080 liveness probe [NodeConformance] [Conformance]'
+  description: A Pod is created with liveness probe on tcp socket 8080. The http handler
+    on port 8080 will return http errors after 10 seconds, but the socket will remain
+    open. Liveness probe MUST not fail to check health and the restart count should
+    remain 0.
+  release: v1.18
+  file: test/e2e/common/container_probe.go
+- testname: Pod liveness probe, using http endpoint, restart
+  codename: '[k8s.io] [sig-node] Probing container should be restarted with a /healthz
+    http liveness probe [NodeConformance] [Conformance]'
+  description: A Pod is created with liveness probe on http endpoint /healthz. The
+    http handler on the /healthz will return a http error after 10 seconds since the
+    Pod is started. This MUST result in liveness check failure. The Pod MUST now be
+    killed and restarted incrementing restart count to 1.
+  release: v1.9
+  file: test/e2e/common/container_probe.go
+- testname: Pod liveness probe, using local file, restart
+  codename: '[k8s.io] [sig-node] Probing container should be restarted with a exec
+    "cat /tmp/health" liveness probe [NodeConformance] [Conformance]'
+  description: Create a Pod with liveness probe that uses ExecAction handler to cat
+    /temp/health file. The Container deletes the file /temp/health after 10 second,
+    triggering liveness probe to fail. The Pod MUST now be killed and restarted incrementing
+    restart count to 1.
+  release: v1.9
+  file: test/e2e/common/container_probe.go
+- testname: Pod liveness probe, using http endpoint, multiple restarts (slow)
+  codename: '[k8s.io] [sig-node] Probing container should have monotonically increasing
+    restart count [NodeConformance] [Conformance]'
+  description: A Pod is created with liveness probe on http endpoint /healthz. The
+    http handler on the /healthz will return a http error after 10 seconds since the
+    Pod is started. This MUST result in liveness check failure. The Pod MUST now be
+    killed and restarted incrementing restart count to 1. The liveness probe must
+    fail again after restart once the http handler for /healthz enpoind on the Pod
+    returns an http error after 10 seconds from the start. Restart counts MUST increment
+    everytime health check fails, measure upto 5 restart.
+  release: v1.9
+  file: test/e2e/common/container_probe.go
+- testname: Pod readiness probe, with initial delay
+  codename: '[k8s.io] [sig-node] Probing container with readiness probe should not
+    be ready before initial delay and never restart [NodeConformance] [Conformance]'
+  description: Create a Pod that is configured with a initial delay set on the readiness
+    probe. Check the Pod Start time to compare to the initial delay. The Pod MUST
+    be ready only after the specified initial delay.
+  release: v1.9
+  file: test/e2e/common/container_probe.go
+- testname: Pod readiness probe, failure
+  codename: '[k8s.io] [sig-node] Probing container with readiness probe that fails
+    should never be ready and never restart [NodeConformance] [Conformance]'
+  description: Create a Pod with a readiness probe that fails consistently. When this
+    Pod is created, then the Pod MUST never be ready, never be running and restart
+    count MUST be zero.
+  release: v1.9
+  file: test/e2e/common/container_probe.go
+- testname: Security Context, runAsUser=65534
+  codename: '[k8s.io] [sig-node] Security Context When creating a container with runAsUser
+    should run the container with uid 65534 [LinuxOnly] [NodeConformance] [Conformance]'
+  description: 'Container is created with runAsUser option by passing uid 65534 to
+    run as unpriviledged user. Pod MUST be in Succeeded phase. [LinuxOnly]: This test
+    is marked as LinuxOnly since Windows does not support running as UID / GID.'
+  release: v1.15
+  file: test/e2e/common/security_context.go
+- testname: Security Context, privileged=false.
+  codename: '[k8s.io] [sig-node] Security Context When creating a pod with privileged
+    should run the container as unprivileged when false [LinuxOnly] [NodeConformance]
+    [Conformance]'
+  description: 'Create a container to run in unprivileged mode by setting pod''s SecurityContext
+    Privileged option as false. Pod MUST be in Succeeded phase. [LinuxOnly]: This
+    test is marked as LinuxOnly since it runs a Linux-specific command.'
+  release: v1.15
+  file: test/e2e/common/security_context.go
+- testname: Security Context, readOnlyRootFilesystem=false.
+  codename: '[k8s.io] [sig-node] Security Context When creating a pod with readOnlyRootFilesystem
+    should run the container with writable rootfs when readOnlyRootFilesystem=false
+    [NodeConformance] [Conformance]'
+  description: Container is configured to run with readOnlyRootFilesystem to false.
+    Write operation MUST be allowed and Pod MUST be in Succeeded state.
+  release: v1.15
+  file: test/e2e/common/security_context.go
+- testname: Security Context, allowPrivilegeEscalation=false.
+  codename: '[k8s.io] [sig-node] Security Context when creating containers with AllowPrivilegeEscalation
+    should not allow privilege escalation when false [LinuxOnly] [NodeConformance]
+    [Conformance]'
+  description: 'Configuring the allowPrivilegeEscalation to false, does not allow
+    the privilege escalation operation. A container is configured with allowPrivilegeEscalation=false
+    and a given uid (1000) which is not 0. When the container is run, container''s
+    output MUST match with expected output verifying container ran with given uid
+    i.e. uid=1000. [LinuxOnly]: This test is marked LinuxOnly since Windows does not
+    support running as UID / GID, or privilege escalation.'
+  release: v1.15
+  file: test/e2e/common/security_context.go
+- testname: Environment variables, expansion
+  codename: '[k8s.io] [sig-storage] Variable Expansion should allow composing env
+    vars into new env vars [NodeConformance] [Conformance]'
+  description: Create a Pod with environment variables. Environment variables defined
+    using previously defined environment variables MUST expand to proper values.
+  release: v1.9
+  file: test/e2e/common/expansion.go
+- testname: Environment variables, command argument expansion
+  codename: '[k8s.io] [sig-storage] Variable Expansion should allow substituting values
+    in a container''s args [NodeConformance] [Conformance]'
+  description: Create a Pod with environment variables and container command arguments
+    using them. Container command arguments using the  defined environment variables
+    MUST expand to proper values.
+  release: v1.9
+  file: test/e2e/common/expansion.go
+- testname: Environment variables, command expansion
+  codename: '[k8s.io] [sig-storage] Variable Expansion should allow substituting values
+    in a container''s command [NodeConformance] [Conformance]'
+  description: Create a Pod with environment variables and container command using
+    them. Container command using the  defined environment variables MUST expand to
+    proper values.
+  release: v1.9
+  file: test/e2e/common/expansion.go
+- testname: VolumeSubpathEnvExpansion, subpath expansion
+  codename: '[k8s.io] [sig-storage] Variable Expansion should allow substituting values
+    in a volume subpath [Conformance]'
+  description: Make sure a container's subpath can be set using an expansion of environment
+    variables.
+  release: v1.19
+  file: test/e2e/common/expansion.go
+- testname: VolumeSubpathEnvExpansion, subpath with absolute path
+  codename: '[k8s.io] [sig-storage] Variable Expansion should fail substituting values
+    in a volume subpath with absolute path [Slow] [Conformance]'
+  description: Make sure a container's subpath can not be set using an expansion of
+    environment variables when absolute path is supplied.
+  release: v1.19
+  file: test/e2e/common/expansion.go
+- testname: VolumeSubpathEnvExpansion, subpath with backticks
+  codename: '[k8s.io] [sig-storage] Variable Expansion should fail substituting values
+    in a volume subpath with backticks [Slow] [Conformance]'
+  description: Make sure a container's subpath can not be set using an expansion of
+    environment variables when backticks are supplied.
+  release: v1.19
+  file: test/e2e/common/expansion.go
+- testname: VolumeSubpathEnvExpansion, subpath test writes
+  codename: '[k8s.io] [sig-storage] Variable Expansion should succeed in writing subpaths
+    in container [Slow] [Conformance]'
+  description: "Verify that a subpath expansion can be used to write files into subpaths.
+    1.\tvalid subpathexpr starts a container running 2.\ttest for valid subpath writes
+    3.\tsuccessful expansion of the subpathexpr isn't required for volume cleanup"
+  release: v1.19
+  file: test/e2e/common/expansion.go
+- testname: VolumeSubpathEnvExpansion, subpath ready from failed state
+  codename: '[k8s.io] [sig-storage] Variable Expansion should verify that a failing
+    subpath expansion can be modified during the lifecycle of a container [Slow] [Conformance]'
+  description: Verify that a failing subpath expansion can be modified during the
+    lifecycle of a container.
+  release: v1.19
+  file: test/e2e/common/expansion.go
 - testname: Admission webhook, list mutating webhooks
   codename: '[sig-api-machinery] AdmissionWebhook [Privileged:ClusterAdmin] listing
     mutating webhooks should work [Conformance]'

--- a/test/e2e/common/container_probe.go
+++ b/test/e2e/common/container_probe.go
@@ -45,7 +45,7 @@ const (
 	defaultObservationTimeout = time.Minute * 4
 )
 
-var _ = framework.KubeDescribe("Probing container", func() {
+var _ = framework.KubeDescribe("[sig-node] Probing container", func() {
 	f := framework.NewDefaultFramework("container-probe")
 	var podClient *framework.PodClient
 	probe := webserverProbeBuilder{}

--- a/test/e2e/common/docker_containers.go
+++ b/test/e2e/common/docker_containers.go
@@ -25,7 +25,7 @@ import (
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 )
 
-var _ = framework.KubeDescribe("Docker Containers", func() {
+var _ = framework.KubeDescribe("[sig-node] Docker Containers", func() {
 	f := framework.NewDefaultFramework("containers")
 
 	/*

--- a/test/e2e/common/downward_api.go
+++ b/test/e2e/common/downward_api.go
@@ -284,7 +284,7 @@ var _ = ginkgo.Describe("[sig-node] Downward API", func() {
 	})
 })
 
-var _ = framework.KubeDescribe("Downward API [Serial] [Disruptive] [NodeFeature:EphemeralStorage]", func() {
+var _ = framework.KubeDescribe("[sig-storage] Downward API [Serial] [Disruptive] [NodeFeature:EphemeralStorage]", func() {
 	f := framework.NewDefaultFramework("downward-api")
 
 	ginkgo.Context("Downward API tests for local ephemeral storage", func() {

--- a/test/e2e/common/expansion.go
+++ b/test/e2e/common/expansion.go
@@ -30,7 +30,7 @@ import (
 // These tests exercise the Kubernetes expansion syntax $(VAR).
 // For more information, see:
 // https://github.com/kubernetes/community/blob/master/contributors/design-proposals/node/expansion.md
-var _ = framework.KubeDescribe("Variable Expansion", func() {
+var _ = framework.KubeDescribe("[sig-storage] Variable Expansion", func() {
 	f := framework.NewDefaultFramework("var-expansion")
 
 	/*
@@ -106,7 +106,7 @@ var _ = framework.KubeDescribe("Variable Expansion", func() {
 		Testname: VolumeSubpathEnvExpansion, subpath expansion
 		Description: Make sure a container's subpath can be set using an expansion of environment variables.
 	*/
-	framework.ConformanceIt("should allow substituting values in a volume subpath [sig-storage]", func() {
+	framework.ConformanceIt("should allow substituting values in a volume subpath", func() {
 		envVars := []v1.EnvVar{
 			{
 				Name:  "POD_NAME",
@@ -146,7 +146,7 @@ var _ = framework.KubeDescribe("Variable Expansion", func() {
 		Testname: VolumeSubpathEnvExpansion, subpath with backticks
 		Description: Make sure a container's subpath can not be set using an expansion of environment variables when backticks are supplied.
 	*/
-	framework.ConformanceIt("should fail substituting values in a volume subpath with backticks [sig-storage][Slow]", func() {
+	framework.ConformanceIt("should fail substituting values in a volume subpath with backticks [Slow]", func() {
 
 		envVars := []v1.EnvVar{
 			{
@@ -180,7 +180,7 @@ var _ = framework.KubeDescribe("Variable Expansion", func() {
 		Testname: VolumeSubpathEnvExpansion, subpath with absolute path
 		Description: Make sure a container's subpath can not be set using an expansion of environment variables when absolute path is supplied.
 	*/
-	framework.ConformanceIt("should fail substituting values in a volume subpath with absolute path [sig-storage][Slow]", func() {
+	framework.ConformanceIt("should fail substituting values in a volume subpath with absolute path [Slow]", func() {
 		absolutePath := "/tmp"
 		if framework.NodeOSDistroIs("windows") {
 			// Windows does not typically have a C:\tmp folder.
@@ -219,7 +219,7 @@ var _ = framework.KubeDescribe("Variable Expansion", func() {
 		Testname: VolumeSubpathEnvExpansion, subpath ready from failed state
 		Description: Verify that a failing subpath expansion can be modified during the lifecycle of a container.
 	*/
-	framework.ConformanceIt("should verify that a failing subpath expansion can be modified during the lifecycle of a container [sig-storage][Slow]", func() {
+	framework.ConformanceIt("should verify that a failing subpath expansion can be modified during the lifecycle of a container [Slow]", func() {
 
 		envVars := []v1.EnvVar{
 			{
@@ -288,7 +288,7 @@ var _ = framework.KubeDescribe("Variable Expansion", func() {
 		3.	successful expansion of the subpathexpr isn't required for volume cleanup
 
 	*/
-	framework.ConformanceIt("should succeed in writing subpaths in container [sig-storage][Slow]", func() {
+	framework.ConformanceIt("should succeed in writing subpaths in container [Slow]", func() {
 
 		envVars := []v1.EnvVar{
 			{

--- a/test/e2e/common/init_container.go
+++ b/test/e2e/common/init_container.go
@@ -156,7 +156,7 @@ func initContainersInvariants(pod *v1.Pod) error {
 	return nil
 }
 
-var _ = framework.KubeDescribe("InitContainer [NodeConformance]", func() {
+var _ = framework.KubeDescribe("[sig-node] InitContainer [NodeConformance]", func() {
 	f := framework.NewDefaultFramework("init-container")
 	var podClient *framework.PodClient
 	ginkgo.BeforeEach(func() {

--- a/test/e2e/common/kubelet.go
+++ b/test/e2e/common/kubelet.go
@@ -32,7 +32,7 @@ import (
 	"github.com/onsi/gomega"
 )
 
-var _ = framework.KubeDescribe("Kubelet", func() {
+var _ = framework.KubeDescribe("[sig-node] Kubelet", func() {
 	f := framework.NewDefaultFramework("kubelet-test")
 	var podClient *framework.PodClient
 	ginkgo.BeforeEach(func() {

--- a/test/e2e/common/lease.go
+++ b/test/e2e/common/lease.go
@@ -49,7 +49,7 @@ func getPatchBytes(oldLease, newLease *coordinationv1.Lease) ([]byte, error) {
 	return patchBytes, nil
 }
 
-var _ = framework.KubeDescribe("Lease", func() {
+var _ = framework.KubeDescribe("[sig-node] Lease", func() {
 	f := framework.NewDefaultFramework("lease-test")
 
 	/*

--- a/test/e2e/common/lifecycle_hook.go
+++ b/test/e2e/common/lifecycle_hook.go
@@ -32,7 +32,7 @@ import (
 	"github.com/onsi/gomega"
 )
 
-var _ = framework.KubeDescribe("Container Lifecycle Hook", func() {
+var _ = framework.KubeDescribe("[sig-node] Container Lifecycle Hook", func() {
 	f := framework.NewDefaultFramework("container-lifecycle-hook")
 	var podClient *framework.PodClient
 	const (

--- a/test/e2e/common/node_lease.go
+++ b/test/e2e/common/node_lease.go
@@ -36,7 +36,7 @@ import (
 	"github.com/onsi/gomega"
 )
 
-var _ = framework.KubeDescribe("NodeLease", func() {
+var _ = framework.KubeDescribe("[sig-node] NodeLease", func() {
 	var nodeName string
 	f := framework.NewDefaultFramework("node-lease-test")
 

--- a/test/e2e/common/pods.go
+++ b/test/e2e/common/pods.go
@@ -29,6 +29,7 @@ import (
 	"golang.org/x/net/websocket"
 
 	"encoding/json"
+
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -179,7 +180,7 @@ func expectNoErrorWithRetries(fn func() error, maxRetries int, explain ...interf
 	gomega.ExpectWithOffset(1, err).NotTo(gomega.HaveOccurred(), explain...)
 }
 
-var _ = framework.KubeDescribe("Pods", func() {
+var _ = framework.KubeDescribe("[sig-node] Pods", func() {
 	f := framework.NewDefaultFramework("pods")
 	var podClient *framework.PodClient
 	var dc dynamic.Interface

--- a/test/e2e/common/privileged.go
+++ b/test/e2e/common/privileged.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 
 	"github.com/onsi/ginkgo"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kubernetes/test/e2e/framework"
 	imageutils "k8s.io/kubernetes/test/utils/image"
@@ -38,7 +38,7 @@ type PrivilegedPodTestConfig struct {
 	pod *v1.Pod
 }
 
-var _ = framework.KubeDescribe("PrivilegedPod [NodeConformance]", func() {
+var _ = framework.KubeDescribe("[sig-node] PrivilegedPod [NodeConformance]", func() {
 	config := &PrivilegedPodTestConfig{
 		f:                      framework.NewDefaultFramework("e2e-privileged-pod"),
 		privilegedPod:          "privileged-pod",

--- a/test/e2e/common/runtime.go
+++ b/test/e2e/common/runtime.go
@@ -35,7 +35,7 @@ import (
 	gomegatypes "github.com/onsi/gomega/types"
 )
 
-var _ = framework.KubeDescribe("Container Runtime", func() {
+var _ = framework.KubeDescribe("[sig-node] Container Runtime", func() {
 	f := framework.NewDefaultFramework("container-runtime")
 
 	ginkgo.Describe("blackbox test", func() {

--- a/test/e2e/common/security_context.go
+++ b/test/e2e/common/security_context.go
@@ -35,7 +35,7 @@ import (
 	"github.com/onsi/gomega"
 )
 
-var _ = framework.KubeDescribe("Security Context", func() {
+var _ = framework.KubeDescribe("[sig-node] Security Context", func() {
 	f := framework.NewDefaultFramework("security-context-test")
 	var podClient *framework.PodClient
 	ginkgo.BeforeEach(func() {

--- a/test/e2e/common/sysctl.go
+++ b/test/e2e/common/sysctl.go
@@ -18,7 +18,8 @@ package common
 
 import (
 	"context"
-	"k8s.io/api/core/v1"
+
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/kubernetes/test/e2e/framework"
@@ -30,7 +31,7 @@ import (
 	"github.com/onsi/gomega"
 )
 
-var _ = framework.KubeDescribe("Sysctls [LinuxOnly] [NodeFeature:Sysctls]", func() {
+var _ = framework.KubeDescribe("[sig-node] Sysctls [LinuxOnly] [NodeFeature:Sysctls]", func() {
 
 	ginkgo.BeforeEach(func() {
 		// sysctl is not supported on Windows.


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup
/priority important-longterm
/sig node
/sig storage

**What this PR does / why we need it**:
As part of a reliability working group effort the workstream of marking tests with SIG-identifier attribute was started. https://groups.google.com/g/kubernetes-sig-node/c/dVaNhlgT9CU/m/HXwY6slvAQAJ

**Which issue(s) this PR fixes**:
Related to #98326

**Special notes for your reviewer**:
First batch of files processed.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
