### PR TITLE
Switch add-on manager to use lease for leader election

### DIFF
--- a/cluster/addons/addon-manager/CHANGELOG.md
+++ b/cluster/addons/addon-manager/CHANGELOG.md
@@ -1,3 +1,7 @@
+### Version 9.1.4 (Wed February 10 2021 Jordan Liggitt <liggitt@google.com>)
+ - Update kubectl to v1.20.2.
+ - Fix a bug in leader election (https://github.com/kubernetes/kubernetes/issues/98966)
+
 ### Version 9.1.3 (Mon November 30 2020 Spencer Peterson <spencerjp@google.com>)
  - Update kubectl to v1.19.3.
 

--- a/cluster/addons/addon-manager/Makefile
+++ b/cluster/addons/addon-manager/Makefile
@@ -15,8 +15,8 @@
 IMAGE=gcr.io/k8s-staging-addon-manager/kube-addon-manager
 ARCH?=amd64
 TEMP_DIR:=$(shell mktemp -d)
-VERSION=v9.1.3
-KUBECTL_VERSION?=v1.19.3
+VERSION=v9.1.4
+KUBECTL_VERSION?=v1.20.2
 
 BASEIMAGE=k8s.gcr.io/debian-base-$(ARCH):v1.0.0
 

--- a/cluster/addons/addon-manager/kube-addons.sh
+++ b/cluster/addons/addon-manager/kube-addons.sh
@@ -273,15 +273,22 @@ function is_leader() {
   fi
   # shellcheck disable=SC2086
   # Disabling because "${KUBECTL_OPTS}" needs to allow for expansion here
-  KUBE_CONTROLLER_MANAGER_LEADER=$(${KUBECTL} ${KUBECTL_OPTS} -n kube-system get ep kube-controller-manager \
-    -o go-template=$'{{index .metadata.annotations "control-plane.alpha.kubernetes.io/leader"}}' \
-    | sed 's/^.*"holderIdentity":"\([^"]*\)".*/\1/')
-  # If there was any problem with getting the leader election results, var will
-  # be empty. Since it's better to have multiple addon managers than no addon
-  # managers at all, we're going to assume that we're the leader in such case.
-  log INFO "Leader is $KUBE_CONTROLLER_MANAGER_LEADER"
-  # KUBE_CONTROLLER_MANAGER_LEADER value is in the form "${HOSTNAME}_*"
-  # Here we verify that the value is either empty or is in the expected form for the leader
-  KUBE_CONTROLLER_MANAGER_LEADER="${KUBE_CONTROLLER_MANAGER_LEADER##${HOSTNAME}_*}"
-  [[ "$KUBE_CONTROLLER_MANAGER_LEADER" == "" ]]
+  KUBE_CONTROLLER_MANAGER_LEADER=$(${KUBECTL} ${KUBECTL_OPTS} -n kube-system get leases.v1.coordination.k8s.io kube-controller-manager -o "jsonpath={.spec.holderIdentity}")
+
+  case "${KUBE_CONTROLLER_MANAGER_LEADER}" in
+  "")
+    log ERR "No leader election info found."
+    return 1
+    ;;
+
+  "${HOSTNAME}"_*)
+    log INFO "Leader is $KUBE_CONTROLLER_MANAGER_LEADER"
+    return 0
+    ;;
+
+  *)
+    log INFO "Leader is $KUBE_CONTROLLER_MANAGER_LEADER, not ${HOSTNAME}_*"
+    return 1
+    ;;
+  esac
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

xref #98966

* Fixes the add-on manager to use leases instead of endpoints to match what kube-controller-manager does in 1.20.
* Defaults to be safe (do nothing) rather than dangerous (go ahead) if leader info cannot be determined

Note that this does *not* complete #98966, and the add-on manager should still implement its own leader election if that is an important feature for it to have.

#### Does this PR introduce a user-facing change?
```release-note
Fixes add-on manager leader election
```

/cc @zmerlynn 