### PR TITLE
Fix MetricsGrabber test by skipping if the master node isn't registered

### DIFF
--- a/test/e2e/instrumentation/monitoring/metrics_grabber.go
+++ b/test/e2e/instrumentation/monitoring/metrics_grabber.go
@@ -37,17 +37,25 @@ var _ = instrumentation.SIGDescribe("MetricsGrabber", func() {
 	f := framework.NewDefaultFramework("metrics-grabber")
 	var c, ec clientset.Interface
 	var grabber *e2emetrics.Grabber
+	var masterRegistered bool
 	ginkgo.BeforeEach(func() {
 		var err error
 		c = f.ClientSet
 		ec = f.KubemarkExternalClusterClientSet
+		// Check if master Node is registered
+		nodes, err := c.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
 		framework.ExpectNoError(err)
+		for _, node := range nodes.Items {
+			if strings.HasSuffix(node.Name, "master") {
+				masterRegistered = true
+			}
+		}
 		gomega.Eventually(func() error {
 			grabber, err = e2emetrics.NewMetricsGrabber(c, ec, true, true, true, true, true)
 			if err != nil {
 				return fmt.Errorf("failed to create metrics grabber: %v", err)
 			}
-			if !grabber.HasControlPlanePods() {
+			if masterRegistered && !grabber.HasControlPlanePods() {
 				return fmt.Errorf("unable to get find control plane pods")
 			}
 			return nil
@@ -72,16 +80,6 @@ var _ = instrumentation.SIGDescribe("MetricsGrabber", func() {
 
 	ginkgo.It("should grab all metrics from a Scheduler.", func() {
 		ginkgo.By("Proxying to Pod through the API server")
-		// Check if master Node is registered
-		nodes, err := c.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
-		framework.ExpectNoError(err)
-
-		var masterRegistered = false
-		for _, node := range nodes.Items {
-			if strings.HasSuffix(node.Name, "master") {
-				masterRegistered = true
-			}
-		}
 		if !masterRegistered {
 			framework.Logf("Master is node api.Registry. Skipping testing Scheduler metrics.")
 			return
@@ -93,16 +91,6 @@ var _ = instrumentation.SIGDescribe("MetricsGrabber", func() {
 
 	ginkgo.It("should grab all metrics from a ControllerManager.", func() {
 		ginkgo.By("Proxying to Pod through the API server")
-		// Check if master Node is registered
-		nodes, err := c.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
-		framework.ExpectNoError(err)
-
-		var masterRegistered = false
-		for _, node := range nodes.Items {
-			if strings.HasSuffix(node.Name, "master") {
-				masterRegistered = true
-			}
-		}
 		if !masterRegistered {
 			framework.Logf("Master is node api.Registry. Skipping testing ControllerManager metrics.")
 			return


### PR DESCRIPTION
Fixes #98894

This only checks for the presence of master pods if the master node is registered.

This will reintroduce the flake that the check previously fixed, but only for clusters that don't register the master node.