### PR TITLE
Apply context to restclient and serviceaccount metrics

### DIFF
--- a/pkg/serviceaccount/claims.go
+++ b/pkg/serviceaccount/claims.go
@@ -192,9 +192,9 @@ func (v *validator) Validate(ctx context.Context, _ string, public *jwt.Claims, 
 			secondsAfterWarn := nowTime.Unix() - warnafter.Time().Unix()
 			auditInfo := fmt.Sprintf("subject: %s, seconds after warning threshold: %d", public.Subject, secondsAfterWarn)
 			audit.AddAuditAnnotation(ctx, "authentication.k8s.io/stale-token", auditInfo)
-			staleTokensTotal.Inc()
+			staleTokensTotal.WithContext(ctx).Inc()
 		} else {
-			validTokensTotal.Inc()
+			validTokensTotal.WithContext(ctx).Inc()
 		}
 	}
 

--- a/pkg/serviceaccount/jwt.go
+++ b/pkg/serviceaccount/jwt.go
@@ -290,7 +290,7 @@ func (j *jwtTokenAuthenticator) AuthenticateToken(ctx context.Context, tokenData
 	if len(tokenAudiences) == 0 {
 		// only apiserver audiences are allowed for legacy tokens
 		audit.AddAuditAnnotation(ctx, "authentication.k8s.io/legacy-token", public.Subject)
-		legacyTokensTotal.Inc()
+		legacyTokensTotal.WithContext(ctx).Inc()
 		tokenAudiences = j.implicitAuds
 	}
 

--- a/staging/src/k8s.io/client-go/tools/metrics/metrics.go
+++ b/staging/src/k8s.io/client-go/tools/metrics/metrics.go
@@ -19,6 +19,7 @@ limitations under the License.
 package metrics
 
 import (
+	"context"
 	"net/url"
 	"sync"
 	"time"
@@ -38,12 +39,12 @@ type ExpiryMetric interface {
 
 // LatencyMetric observes client latency partitioned by verb and url.
 type LatencyMetric interface {
-	Observe(verb string, u url.URL, latency time.Duration)
+	Observe(ctx context.Context, verb string, u url.URL, latency time.Duration)
 }
 
 // ResultMetric counts response codes partitioned by method and host.
 type ResultMetric interface {
-	Increment(code string, method string, host string)
+	Increment(ctx context.Context, code string, method string, host string)
 }
 
 // CallsMetric counts calls that take place for a specific exec plugin.
@@ -113,11 +114,11 @@ func (noopExpiry) Set(*time.Time) {}
 
 type noopLatency struct{}
 
-func (noopLatency) Observe(string, url.URL, time.Duration) {}
+func (noopLatency) Observe(context.Context, string, url.URL, time.Duration) {}
 
 type noopResult struct{}
 
-func (noopResult) Increment(string, string, string) {}
+func (noopResult) Increment(context.Context, string, string, string) {}
 
 type noopCalls struct{}
 

--- a/staging/src/k8s.io/component-base/metrics/prometheus/restclient/metrics.go
+++ b/staging/src/k8s.io/component-base/metrics/prometheus/restclient/metrics.go
@@ -17,6 +17,7 @@ limitations under the License.
 package restclient
 
 import (
+	"context"
 	"fmt"
 	"math"
 	"net/url"
@@ -137,16 +138,16 @@ type latencyAdapter struct {
 	m *k8smetrics.HistogramVec
 }
 
-func (l *latencyAdapter) Observe(verb string, u url.URL, latency time.Duration) {
-	l.m.WithLabelValues(verb, u.String()).Observe(latency.Seconds())
+func (l *latencyAdapter) Observe(ctx context.Context, verb string, u url.URL, latency time.Duration) {
+	l.m.WithContext(ctx).WithLabelValues(verb, u.String()).Observe(latency.Seconds())
 }
 
 type resultAdapter struct {
 	m *k8smetrics.CounterVec
 }
 
-func (r *resultAdapter) Increment(code, method, host string) {
-	r.m.WithLabelValues(code, method, host).Inc()
+func (r *resultAdapter) Increment(ctx context.Context, code, method, host string) {
+	r.m.WithContext(ctx).WithLabelValues(code, method, host).Inc()
 }
 
 type expiryToTTLAdapter struct {


### PR DESCRIPTION

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:


Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Similar to #98196 and #98246, this PR plumbs context to other request-based metrics in restclient and serviceaccount pkg.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
