### PR TITLE
Update kube-addon-manager image to v9.1.2

### DIFF
--- a/cluster/gce/manifests/kube-addon-manager.yaml
+++ b/cluster/gce/manifests/kube-addon-manager.yaml
@@ -23,11 +23,11 @@ spec:
         - all
     # When updating version also bump it in:
     # - test/kubemark/resources/manifests/kube-addon-manager.yaml
-    image: k8s.gcr.io/kube-addon-manager:v9.1.1
+    image: k8s.gcr.io/addon-manager/kube-addon-manager:v9.1.2
     command:
     - /bin/bash
     - -c
-    - exec /opt/kube-addons.sh 1>>/var/log/kube-addon-manager.log 2>&1
+    - exec /opt/kube-addons-main.sh 1>>/var/log/kube-addon-manager.log 2>&1
     resources:
       requests:
         cpu: 5m

--- a/test/kubemark/resources/manifests/kube-addon-manager.yaml
+++ b/test/kubemark/resources/manifests/kube-addon-manager.yaml
@@ -9,11 +9,11 @@ spec:
   hostNetwork: true
   containers:
   - name: kube-addon-manager
-    image: {{kube_docker_registry}}/kube-addon-manager:v9.1.1
+    image: {{kube_docker_registry}}/addon-manager/kube-addon-manager:v9.1.2
     command:
     - /bin/bash
     - -c
-    - /opt/kube-addons.sh 1>>/var/log/kube-addon-manager.log 2>&1
+    - /opt/kube-addons-main.sh 1>>/var/log/kube-addon-manager.log 2>&1
     resources:
       requests:
         cpu: 5m


### PR DESCRIPTION
Updates the addon-manager to use the image with the fix implemented in https://github.com/kubernetes/kubernetes/pull/93762

/kind bug

```release-note
NONE
```