### PR TITLE
Add csi_operations_seconds metrics on kubelet

### DIFF
--- a/pkg/volume/csi/csi_attacher.go
+++ b/pkg/volume/csi/csi_attacher.go
@@ -257,7 +257,7 @@ func (c *csiAttacher) MountDevice(spec *volume.Spec, devicePath string, deviceMo
 	}
 	csi := c.csiClient
 
-	ctx, cancel := context.WithTimeout(context.Background(), c.watchTimeout)
+	ctx, cancel := createCSIOperationContext(spec, c.watchTimeout)
 	defer cancel()
 	// Check whether "STAGE_UNSTAGE_VOLUME" is set
 	stageUnstageSet, err := csi.NodeSupportsStageUnstage(ctx)
@@ -516,7 +516,8 @@ func (c *csiAttacher) UnmountDevice(deviceMountPath string) error {
 	}
 	csi := c.csiClient
 
-	ctx, cancel := context.WithTimeout(context.Background(), c.watchTimeout)
+	// could not get whether this is migrated because there is no spec
+	ctx, cancel := createCSIOperationContext(nil, csiTimeout)
 	defer cancel()
 	// Check whether "STAGE_UNSTAGE_VOLUME" is set
 	stageUnstageSet, err := csi.NodeSupportsStageUnstage(ctx)

--- a/pkg/volume/csi/csi_block.go
+++ b/pkg/volume/csi/csi_block.go
@@ -357,7 +357,7 @@ func (m *csiBlockMapper) MapPodDevice() (string, error) {
 		accessMode = m.spec.PersistentVolume.Spec.AccessModes[0]
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), csiTimeout)
+	ctx, cancel := createCSIOperationContext(m.spec, csiTimeout)
 	defer cancel()
 
 	csiClient, err := m.csiClientGetter.Get()
@@ -426,7 +426,7 @@ func (m *csiBlockMapper) TearDownDevice(globalMapPath, devicePath string) error 
 		return errors.New("CSIBlockVolume feature not enabled")
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), csiTimeout)
+	ctx, cancel := createCSIOperationContext(m.spec, csiTimeout)
 	defer cancel()
 
 	csiClient, err := m.csiClientGetter.Get()
@@ -499,7 +499,7 @@ func (m *csiBlockMapper) UnmapPodDevice() error {
 		return errors.New(log("blockMapper.UnmapPodDevice failed to get CSI client: %v", err))
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), csiTimeout)
+	ctx, cancel := createCSIOperationContext(m.spec, csiTimeout)
 	defer cancel()
 
 	// Call NodeUnpublishVolume.

--- a/pkg/volume/csi/csi_client_test.go
+++ b/pkg/volume/csi/csi_client_test.go
@@ -371,7 +371,7 @@ func TestClientNodeGetInfo(t *testing.T) {
 		fakeCloser := fake.NewCloser(t)
 		client := &csiDriverClient{
 			driverName: "Fake Driver Name",
-			nodeV1ClientCreator: func(addr csiAddr) (csipbv1.NodeClient, io.Closer, error) {
+			nodeV1ClientCreator: func(addr csiAddr, m *MetricsManager) (csipbv1.NodeClient, io.Closer, error) {
 				nodeClient := fake.NewNodeClient(false /* stagingCapable */)
 				nodeClient.SetNextError(tc.err)
 				nodeClient.SetNodeGetInfoResp(&csipbv1.NodeGetInfoResponse{
@@ -434,7 +434,7 @@ func TestClientNodePublishVolume(t *testing.T) {
 		fakeCloser := fake.NewCloser(t)
 		client := &csiDriverClient{
 			driverName: "Fake Driver Name",
-			nodeV1ClientCreator: func(addr csiAddr) (csipbv1.NodeClient, io.Closer, error) {
+			nodeV1ClientCreator: func(addr csiAddr, m *MetricsManager) (csipbv1.NodeClient, io.Closer, error) {
 				nodeClient := fake.NewNodeClient(false /* stagingCapable */)
 				nodeClient.SetNextError(tc.err)
 				return nodeClient, fakeCloser, nil
@@ -488,7 +488,7 @@ func TestClientNodeUnpublishVolume(t *testing.T) {
 		fakeCloser := fake.NewCloser(t)
 		client := &csiDriverClient{
 			driverName: "Fake Driver Name",
-			nodeV1ClientCreator: func(addr csiAddr) (csipbv1.NodeClient, io.Closer, error) {
+			nodeV1ClientCreator: func(addr csiAddr, m *MetricsManager) (csipbv1.NodeClient, io.Closer, error) {
 				nodeClient := fake.NewNodeClient(false /* stagingCapable */)
 				nodeClient.SetNextError(tc.err)
 				return nodeClient, fakeCloser, nil
@@ -534,7 +534,7 @@ func TestClientNodeStageVolume(t *testing.T) {
 		fakeCloser := fake.NewCloser(t)
 		client := &csiDriverClient{
 			driverName: "Fake Driver Name",
-			nodeV1ClientCreator: func(addr csiAddr) (csipbv1.NodeClient, io.Closer, error) {
+			nodeV1ClientCreator: func(addr csiAddr, m *MetricsManager) (csipbv1.NodeClient, io.Closer, error) {
 				nodeClient := fake.NewNodeClient(false /* stagingCapable */)
 				nodeClient.SetNextError(tc.err)
 				return nodeClient, fakeCloser, nil
@@ -586,7 +586,7 @@ func TestClientNodeUnstageVolume(t *testing.T) {
 		fakeCloser := fake.NewCloser(t)
 		client := &csiDriverClient{
 			driverName: "Fake Driver Name",
-			nodeV1ClientCreator: func(addr csiAddr) (csipbv1.NodeClient, io.Closer, error) {
+			nodeV1ClientCreator: func(addr csiAddr, m *MetricsManager) (csipbv1.NodeClient, io.Closer, error) {
 				nodeClient := fake.NewNodeClient(false /* stagingCapable */)
 				nodeClient.SetNextError(tc.err)
 				return nodeClient, fakeCloser, nil
@@ -647,7 +647,7 @@ func TestNodeExpandVolume(t *testing.T) {
 		fakeCloser := fake.NewCloser(t)
 		client := &csiDriverClient{
 			driverName: "Fake Driver Name",
-			nodeV1ClientCreator: func(addr csiAddr) (csipbv1.NodeClient, io.Closer, error) {
+			nodeV1ClientCreator: func(addr csiAddr, m *MetricsManager) (csipbv1.NodeClient, io.Closer, error) {
 				nodeClient := fake.NewNodeClient(false /* stagingCapable */)
 				nodeClient.SetNextError(tc.err)
 				return nodeClient, fakeCloser, nil

--- a/pkg/volume/csi/csi_metrics.go
+++ b/pkg/volume/csi/csi_metrics.go
@@ -19,9 +19,12 @@ package csi
 import (
 	"context"
 	"fmt"
+	"time"
 
+	"google.golang.org/grpc"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kubernetes/pkg/volume"
+	volumeutil "k8s.io/kubernetes/pkg/volume/util"
 )
 
 var _ volume.MetricsProvider = &metricsCsi{}
@@ -78,4 +81,52 @@ func (mc *metricsCsi) GetMetrics() (*volume.Metrics, error) {
 	//set recorded time
 	metrics.Time = currentTime
 	return metrics, nil
+}
+
+// MetricsManager defines the metrics mananger for CSI operation
+type MetricsManager struct {
+	driverName string
+}
+
+// NewCSIMetricsManager creates a CSIMetricsManager object
+func NewCSIMetricsManager(driverName string) *MetricsManager {
+	cmm := MetricsManager{
+		driverName: driverName,
+	}
+	return &cmm
+}
+
+type additionalInfo struct {
+	Migrated string
+}
+type additionalInfoKeyType struct{}
+
+var additionalInfoKey additionalInfoKeyType
+
+// RecordMetricsInterceptor is a grpc interceptor that is used to
+// record CSI operation
+func (cmm *MetricsManager) RecordMetricsInterceptor(
+	ctx context.Context,
+	method string,
+	req, reply interface{},
+	cc *grpc.ClientConn,
+	invoker grpc.UnaryInvoker,
+	opts ...grpc.CallOption) error {
+	start := time.Now()
+	err := invoker(ctx, method, req, reply, cc, opts...)
+	duration := time.Since(start)
+	// Check if this is migrated operation
+	additionalInfoVal := ctx.Value(additionalInfoKey)
+	migrated := "false"
+	if additionalInfoVal != nil {
+		additionalInfoVal, ok := additionalInfoVal.(additionalInfo)
+		if !ok {
+			return err
+		}
+		migrated = additionalInfoVal.Migrated
+	}
+	// Record the metric latency
+	volumeutil.RecordCSIOperationLatencyMetrics(cmm.driverName, method, err, duration, migrated)
+
+	return err
 }

--- a/pkg/volume/csi/csi_metrics_test.go
+++ b/pkg/volume/csi/csi_metrics_test.go
@@ -45,7 +45,7 @@ func TestGetMetrics(t *testing.T) {
 		metricsGetter := &metricsCsi{volumeID: tc.volumeID, targetPath: tc.targetPath}
 		metricsGetter.csiClient = &csiDriverClient{
 			driverName: "com.google.gcepd",
-			nodeV1ClientCreator: func(addr csiAddr) (csipbv1.NodeClient, io.Closer, error) {
+			nodeV1ClientCreator: func(addr csiAddr, m *MetricsManager) (csipbv1.NodeClient, io.Closer, error) {
 				nodeClient := fake.NewNodeClientWithVolumeStats(true /* VolumeStatsCapable */)
 				fakeCloser := fake.NewCloser(t)
 				nodeClient.SetNodeVolumeStatsResp(getRawVolumeInfo())
@@ -114,7 +114,7 @@ func TestGetMetricsDriverNotSupportStats(t *testing.T) {
 		metricsGetter := &metricsCsi{volumeID: tc.volumeID, targetPath: tc.targetPath}
 		metricsGetter.csiClient = &csiDriverClient{
 			driverName: "com.simple.SimpleDriver",
-			nodeV1ClientCreator: func(addr csiAddr) (csipbv1.NodeClient, io.Closer, error) {
+			nodeV1ClientCreator: func(addr csiAddr, m *MetricsManager) (csipbv1.NodeClient, io.Closer, error) {
 				nodeClient := fake.NewNodeClientWithVolumeStats(false /* VolumeStatsCapable */)
 				fakeCloser := fake.NewCloser(t)
 				nodeClient.SetNodeVolumeStatsResp(getRawVolumeInfo())

--- a/pkg/volume/csi/csi_mounter.go
+++ b/pkg/volume/csi/csi_mounter.go
@@ -17,7 +17,6 @@ limitations under the License.
 package csi
 
 import (
-	"context"
 	"crypto/sha256"
 	"encoding/json"
 	"errors"
@@ -114,7 +113,7 @@ func (c *csiMountMgr) SetUpAt(dir string, mounterArgs volume.MounterArgs) error 
 		return volumetypes.NewTransientOperationFailure(log("mounter.SetUpAt failed to get CSI client: %v", err))
 
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), csiTimeout)
+	ctx, cancel := createCSIOperationContext(c.spec, csiTimeout)
 	defer cancel()
 
 	volSrc, pvSrc, err := getSourceFromSpec(c.spec)
@@ -396,7 +395,8 @@ func (c *csiMountMgr) TearDownAt(dir string) error {
 		return errors.New(log("mounter.SetUpAt failed to get CSI client: %v", err))
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), csiTimeout)
+	// Could not get spec info on whether this is a migrated operation because c.spec is nil
+	ctx, cancel := createCSIOperationContext(c.spec, csiTimeout)
 	defer cancel()
 
 	if err := csi.NodeUnpublishVolume(ctx, volID, dir); err != nil {

--- a/pkg/volume/csi/csi_util.go
+++ b/pkg/volume/csi/csi_util.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"time"
 
 	api "k8s.io/api/core/v1"
@@ -192,4 +193,13 @@ func GetCSIDriverName(spec *volume.Spec) (string, error) {
 	default:
 		return "", errors.New(log("volume source not found in volume.Spec"))
 	}
+}
+
+func createCSIOperationContext(volumeSpec *volume.Spec, timeout time.Duration) (context.Context, context.CancelFunc) {
+	migrated := false
+	if volumeSpec != nil {
+		migrated = volumeSpec.Migrated
+	}
+	ctx := context.WithValue(context.Background(), additionalInfoKey, additionalInfo{Migrated: strconv.FormatBool(migrated)})
+	return context.WithTimeout(ctx, timeout)
 }

--- a/pkg/volume/csi/csi_util_test.go
+++ b/pkg/volume/csi/csi_util_test.go
@@ -26,12 +26,14 @@ import (
 	"path"
 	"path/filepath"
 	"testing"
+	"time"
 
 	api "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog/v2"
+	"k8s.io/kubernetes/pkg/volume"
 )
 
 // TestMain starting point for all tests.
@@ -143,6 +145,52 @@ func TestSaveVolumeData(t *testing.T) {
 		}
 		if string(data) != jsonData.String() {
 			t.Errorf("expecting encoded data %v, got %v", string(data), jsonData)
+		}
+	}
+}
+
+func TestCreateCSIOperationContext(t *testing.T) {
+	testCases := []struct {
+		name     string
+		spec     *volume.Spec
+		migrated string
+	}{
+		{
+			name:     "test volume spec nil",
+			spec:     nil,
+			migrated: "false",
+		},
+		{
+			name: "test volume normal spec with migrated true",
+			spec: &volume.Spec{
+				Migrated: true,
+			},
+			migrated: "true",
+		},
+		{
+			name: "test volume normal spec with migrated false",
+			spec: &volume.Spec{
+				Migrated: false,
+			},
+			migrated: "false",
+		},
+	}
+	for _, tc := range testCases {
+		t.Logf("test case: %s", tc.name)
+		timeout := time.Minute
+		ctx, _ := createCSIOperationContext(tc.spec, timeout)
+
+		additionalInfoVal := ctx.Value(additionalInfoKey)
+		if additionalInfoVal == nil {
+			t.Error("Could not load additional info from context")
+		}
+		additionalInfoV, ok := additionalInfoVal.(additionalInfo)
+		if !ok {
+			t.Errorf("Additional info type assertion fail, additionalInfo object: %v", additionalInfoVal)
+		}
+		migrated := additionalInfoV.Migrated
+		if migrated != tc.migrated {
+			t.Errorf("Expect migrated value: %v, got: %v", tc.migrated, migrated)
 		}
 	}
 }

--- a/pkg/volume/csi/expander.go
+++ b/pkg/volume/csi/expander.go
@@ -17,7 +17,6 @@ limitations under the License.
 package csi
 
 import (
-	"context"
 	"errors"
 	"fmt"
 
@@ -71,7 +70,7 @@ func (c *csiPlugin) nodeExpandWithClient(
 	fsVolume bool) (bool, error) {
 	driverName := csiSource.Driver
 
-	ctx, cancel := context.WithTimeout(context.Background(), csiTimeout)
+	ctx, cancel := createCSIOperationContext(resizeOptions.VolumeSpec, csiTimeout)
 	defer cancel()
 
 	nodeExpandSet, err := csClient.NodeSupportsNodeExpand(ctx)

--- a/pkg/volume/util/BUILD
+++ b/pkg/volume/util/BUILD
@@ -44,6 +44,8 @@ go_library(
         "//staging/src/k8s.io/component-base/metrics/legacyregistry:go_default_library",
         "//staging/src/k8s.io/component-helpers/scheduling/corev1:go_default_library",
         "//staging/src/k8s.io/mount-utils:go_default_library",
+        "//vendor/google.golang.org/grpc/codes:go_default_library",
+        "//vendor/google.golang.org/grpc/status:go_default_library",
         "//vendor/k8s.io/klog/v2:go_default_library",
         "//vendor/k8s.io/utils/exec:go_default_library",
         "//vendor/k8s.io/utils/strings:go_default_library",

--- a/pkg/volume/util/types/types.go
+++ b/pkg/volume/util/types/types.go
@@ -68,7 +68,6 @@ func (o *GeneratedOperations) Run() (eventErr, detailedErr error) {
 			Err:      &context.DetailedErr,
 			Migrated: &context.Migrated,
 		}
-		c.Err = &detailedErr
 		defer o.CompleteFunc(c)
 	}
 	if o.EventRecorderFunc != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature


#### What this PR does / why we need it:
This PR adds a new metrics called `csi_operations_seconds` for kubelet. It records the kubelet CSI operation to the driver.
Example:
```
csi_operations_seconds_bucket{driver_name="pd.csi.storage.gke.io",grpc_status_code="OK",method_name="/csi.v1.Node/NodeStageVolume",migrated="true",le="0.1"} 0
csi_operations_seconds_bucket{driver_name="pd.csi.storage.gke.io",grpc_status_code="OK",method_name="/csi.v1.Node/NodeStageVolume",migrated="true",le="0.25"} 0
csi_operations_seconds_bucket{driver_name="pd.csi.storage.gke.io",grpc_status_code="OK",method_name="/csi.v1.Node/NodeStageVolume",migrated="true",le="0.5"} 0
csi_operations_seconds_bucket{driver_name="pd.csi.storage.gke.io",grpc_status_code="OK",method_name="/csi.v1.Node/NodeStageVolume",migrated="true",le="1"} 1
csi_operations_seconds_bucket{driver_name="pd.csi.storage.gke.io",grpc_status_code="OK",method_name="/csi.v1.Node/NodeStageVolume",migrated="true",le="2.5"} 1
csi_operations_seconds_bucket{driver_name="pd.csi.storage.gke.io",grpc_status_code="OK",method_name="/csi.v1.Node/NodeStageVolume",migrated="true",le="5"} 1
csi_operations_seconds_bucket{driver_name="pd.csi.storage.gke.io",grpc_status_code="OK",method_name="/csi.v1.Node/NodeStageVolume",migrated="true",le="10"} 1
csi_operations_seconds_bucket{driver_name="pd.csi.storage.gke.io",grpc_status_code="OK",method_name="/csi.v1.Node/NodeStageVolume",migrated="true",le="15"} 1
csi_operations_seconds_bucket{driver_name="pd.csi.storage.gke.io",grpc_status_code="OK",method_name="/csi.v1.Node/NodeStageVolume",migrated="true",le="25"} 1
csi_operations_seconds_bucket{driver_name="pd.csi.storage.gke.io",grpc_status_code="OK",method_name="/csi.v1.Node/NodeStageVolume",migrated="true",le="50"} 1
csi_operations_seconds_bucket{driver_name="pd.csi.storage.gke.io",grpc_status_code="OK",method_name="/csi.v1.Node/NodeStageVolume",migrated="true",le="120"} 1
csi_operations_seconds_bucket{driver_name="pd.csi.storage.gke.io",grpc_status_code="OK",method_name="/csi.v1.Node/NodeStageVolume",migrated="true",le="300"} 1
csi_operations_seconds_bucket{driver_name="pd.csi.storage.gke.io",grpc_status_code="OK",method_name="/csi.v1.Node/NodeStageVolume",migrated="true",le="600"} 1
csi_operations_seconds_bucket{driver_name="pd.csi.storage.gke.io",grpc_status_code="OK",method_name="/csi.v1.Node/NodeStageVolume",migrated="true",le="+Inf"} 1
csi_operations_seconds_sum{driver_name="pd.csi.storage.gke.io",grpc_status_code="OK",method_name="/csi.v1.Node/NodeStageVolume",migrated="true"} 0.843569755
csi_operations_seconds_bucket_count{driver_name="pd.csi.storage.gke.io",grpc_status_code="OK",method_name="/csi.v1.Node/NodeStageVolume",migrated="true"} 1
```
This is useful to get the operation metrics from Node side. Similarly, we have the `csi_sidecar_operations_seconds` which runs on the sidecar containers and that only records the controller side operation. With this new metric, we get a full picture of the metrics.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
https://github.com/kubernetes/kubernetes/issues/98279 is related

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Add `csi_operations_seconds` metric on kubelet that exposes CSI operations duration and status for node CSI operations.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/sig storage
/assign @msau42 
/cc @mattcary @saad-ali 