### PR TITLE
catching errors for 'kubeadm join'

### DIFF
--- a/cmd/kubeadm/app/util/config/joinconfiguration.go
+++ b/cmd/kubeadm/app/util/config/joinconfiguration.go
@@ -135,7 +135,9 @@ func DefaultedJoinConfiguration(defaultversionedcfg *kubeadmapiv1beta2.JoinConfi
 	// Takes passed flags into account; the defaulting is executed once again enforcing assignment of
 	// static default values to cfg only for values not provided with flags
 	kubeadmscheme.Scheme.Default(defaultversionedcfg)
-	kubeadmscheme.Scheme.Convert(defaultversionedcfg, internalcfg, nil)
+	if err := kubeadmscheme.Scheme.Convert(defaultversionedcfg, internalcfg, nil) ; err != nil {
+		return nil, err
+	}
 
 	// Applies dynamic defaults to settings not provided with flags
 	if err := SetJoinDynamicDefaults(internalcfg); err != nil {

--- a/cmd/kubeadm/app/util/config/joinconfiguration.go
+++ b/cmd/kubeadm/app/util/config/joinconfiguration.go
@@ -135,7 +135,7 @@ func DefaultedJoinConfiguration(defaultversionedcfg *kubeadmapiv1beta2.JoinConfi
 	// Takes passed flags into account; the defaulting is executed once again enforcing assignment of
 	// static default values to cfg only for values not provided with flags
 	kubeadmscheme.Scheme.Default(defaultversionedcfg)
-	if err := kubeadmscheme.Scheme.Convert(defaultversionedcfg, internalcfg, nil) ; err != nil {
+	if err := kubeadmscheme.Scheme.Convert(defaultversionedcfg, internalcfg, nil); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
#### What this PR does / why we need it:

In the function 'DefaultedJoinConfiguration', it may return nil after invoking kubeadmscheme.Scheme.Convert(defaultversionedcfg, internalcfg, nil). 

Howerver, current implementation forgets to handle it.

For example, if you want to join a worker to a Kubernetses cluster with a yaml as follow, but use a wrong apiVersion
```
apiVersion: kubeadm.k8s.io/v1beta3
kind: JoinConfiguration
discovery:
  bootstrapToken:
    apiServerEndpoint: kube-apiserver:6443
    token: abcdef.0123456789abcdef
    unsafeSkipCAVerification: true
  timeout: 5m0s
  tlsBootstrapToken: abcdef.0123456789abcdef
```

Then you would encounter a error  after executing 'kubeadm join [yaml]'
```
unable to convert the internal object type  to Unstructured without providing a preferred version to convert to
```

The code is as below when invoking kubeadmscheme.Scheme.Convert(defaultversionedcfg, internalcfg, nil).

```
func (s *Scheme) Convert(in, out interface{}, context interface{}) error {
	unstructuredIn, okIn := in.(Unstructured)
	unstructuredOut, okOut := out.(Unstructured)
	switch {
	case okIn && okOut:
		// converting unstructured input to an unstructured output is a straight copy - unstructured
		// is a "smart holder" and the contents are passed by reference between the two objects
		unstructuredOut.SetUnstructuredContent(unstructuredIn.UnstructuredContent())
		return nil

	case okOut:
		// if the output is an unstructured object, use the standard Go type to unstructured
		// conversion. The object must not be internal.
		obj, ok := in.(Object)
		if !ok {
			return fmt.Errorf("unable to convert object type %T to Unstructured, must be a runtime.Object", in)
		}
		gvks, unversioned, err := s.ObjectKinds(obj)
		if err != nil {
			return err
		}
		gvk := gvks[0]

		// if no conversion is necessary, convert immediately
		if unversioned || gvk.Version != APIVersionInternal {
			content, err := DefaultUnstructuredConverter.ToUnstructured(in)
			if err != nil {
				return err
			}
			unstructuredOut.SetUnstructuredContent(content)
			unstructuredOut.GetObjectKind().SetGroupVersionKind(gvk)
			return nil
		}

		// attempt to convert the object to an external version first.
		target, ok := context.(GroupVersioner)
		if !ok {
			return fmt.Errorf("unable to convert the internal object type %T to Unstructured without providing a preferred version to convert to", in)
		}
		// Convert is implicitly unsafe, so we don't need to perform a safe conversion
		versioned, err := s.UnsafeConvertToVersion(obj, target)
		if err != nil {
			return err
		}
		content, err := DefaultUnstructuredConverter.ToUnstructured(versioned)
		if err != nil {
			return err
		}
		unstructuredOut.SetUnstructuredContent(content)
		return nil

	case okIn:
		// converting an unstructured object to any type is modeled by first converting
		// the input to a versioned type, then running standard conversions
		typed, err := s.unstructuredToTyped(unstructuredIn)
		if err != nil {
			return err
		}
		in = typed
	}

	meta := s.generateConvertMeta(in)
	meta.Context = context
	return s.converter.Convert(in, out, meta)
}
```

#### What type of PR is this?

/kind bug


