### PR TITLE
kubelet: Make the test fail if (*FakeRuntime).Assert fails

### DIFF
--- a/pkg/kubelet/container/testing/fake_runtime.go
+++ b/pkg/kubelet/container/testing/fake_runtime.go
@@ -18,11 +18,11 @@ package testing
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"net/url"
 	"reflect"
 	"sync"
+	"testing"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
@@ -58,6 +58,7 @@ type FakeRuntime struct {
 	Err               error
 	InspectErr        error
 	StatusErr         error
+	T                 *testing.T
 }
 
 const FakeHost = "localhost:12345"
@@ -135,39 +136,40 @@ func (f *FakeRuntime) UpdatePodCIDR(c string) error {
 	return nil
 }
 
-func (f *FakeRuntime) assertList(expect []string, test []string) error {
+func (f *FakeRuntime) assertList(expect []string, test []string) bool {
 	if !reflect.DeepEqual(expect, test) {
-		return fmt.Errorf("expected %#v, got %#v", expect, test)
+		f.T.Errorf("AssertList: expected %#v, got %#v", expect, test)
+		return false
 	}
-	return nil
+	return true
 }
 
 // AssertCalls test if the invoked functions are as expected.
-func (f *FakeRuntime) AssertCalls(calls []string) error {
+func (f *FakeRuntime) AssertCalls(calls []string) bool {
 	f.Lock()
 	defer f.Unlock()
 	return f.assertList(calls, f.CalledFunctions)
 }
 
-func (f *FakeRuntime) AssertStartedPods(pods []string) error {
+func (f *FakeRuntime) AssertStartedPods(pods []string) bool {
 	f.Lock()
 	defer f.Unlock()
 	return f.assertList(pods, f.StartedPods)
 }
 
-func (f *FakeRuntime) AssertKilledPods(pods []string) error {
+func (f *FakeRuntime) AssertKilledPods(pods []string) bool {
 	f.Lock()
 	defer f.Unlock()
 	return f.assertList(pods, f.KilledPods)
 }
 
-func (f *FakeRuntime) AssertStartedContainers(containers []string) error {
+func (f *FakeRuntime) AssertStartedContainers(containers []string) bool {
 	f.Lock()
 	defer f.Unlock()
 	return f.assertList(containers, f.StartedContainers)
 }
 
-func (f *FakeRuntime) AssertKilledContainers(containers []string) error {
+func (f *FakeRuntime) AssertKilledContainers(containers []string) bool {
 	f.Lock()
 	defer f.Unlock()
 	return f.assertList(containers, f.KilledContainers)

--- a/pkg/kubelet/images/image_manager_test.go
+++ b/pkg/kubelet/images/image_manager_test.go
@@ -201,7 +201,7 @@ func TestParallelPuller(t *testing.T) {
 				fakeRuntime.CalledFunctions = nil
 				fakeClock.Step(time.Second)
 				_, _, err := puller.EnsureImageExists(pod, container, nil, nil)
-				assert.NoError(t, fakeRuntime.AssertCalls(expected.calls))
+				fakeRuntime.AssertCalls(expected.calls)
 				assert.Equal(t, expected.err, err)
 			}
 		})
@@ -229,7 +229,7 @@ func TestSerializedPuller(t *testing.T) {
 				fakeRuntime.CalledFunctions = nil
 				fakeClock.Step(time.Second)
 				_, _, err := puller.EnsureImageExists(pod, container, nil, nil)
-				assert.NoError(t, fakeRuntime.AssertCalls(expected.calls))
+				fakeRuntime.AssertCalls(expected.calls)
 				assert.Equal(t, expected.err, err)
 			}
 		})
@@ -287,7 +287,7 @@ func TestPullAndListImageWithPodAnnotations(t *testing.T) {
 
 	t.Run(c.testName, func(t *testing.T) {
 		_, _, err := puller.EnsureImageExists(pod, container, nil, nil)
-		assert.NoError(t, fakeRuntime.AssertCalls(c.expected[0].calls), "tick=%d", 0)
+		fakeRuntime.AssertCalls(c.expected[0].calls)
 		assert.Equal(t, c.expected[0].err, err, "tick=%d", 0)
 
 		images, _ := fakeRuntime.ListImages()

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -144,16 +144,18 @@ func newTestKubeletWithImageList(
 	imageList []kubecontainer.Image,
 	controllerAttachDetachEnabled bool,
 	initFakeVolumePlugin bool) *TestKubelet {
-	fakeRuntime := &containertest.FakeRuntime{}
-	fakeRuntime.RuntimeType = "test"
-	fakeRuntime.VersionInfo = "1.5.0"
-	fakeRuntime.ImageList = imageList
-	// Set ready conditions by default.
-	fakeRuntime.RuntimeStatus = &kubecontainer.RuntimeStatus{
-		Conditions: []kubecontainer.RuntimeCondition{
-			{Type: "RuntimeReady", Status: true},
-			{Type: "NetworkReady", Status: true},
+	fakeRuntime := &containertest.FakeRuntime{
+		ImageList: imageList,
+		// Set ready conditions by default.
+		RuntimeStatus: &kubecontainer.RuntimeStatus{
+			Conditions: []kubecontainer.RuntimeCondition{
+				{Type: "RuntimeReady", Status: true},
+				{Type: "NetworkReady", Status: true},
+			},
 		},
+		VersionInfo: "1.5.0",
+		RuntimeType: "test",
+		T:           t,
 	}
 
 	fakeRecorder := &record.FakeRecorder{}
@@ -658,7 +660,7 @@ func TestKillPodFollwedByIsPodPendingTermination(t *testing.T) {
 		RunningPod: pod,
 	})
 
-	if !(kl.podKiller.IsPodPendingTerminationByUID(pod.ID) || fakeRuntime.AssertKilledPods([]string{"12345678"}) == nil) {
+	if !(kl.podKiller.IsPodPendingTerminationByUID(pod.ID) || fakeRuntime.AssertKilledPods([]string{"12345678"})) {
 		t.Fatal("Race condition: When KillPod is complete, the pod should be pending termination or be killed")
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

The kubelet tests are expected to fail if `(*FakeRuntime).AssertXXX` fails.

This PR is a follow-up PR for https://github.com/kubernetes/kubernetes/pull/98956.
Fixes the usage of `(*FakeRuntime).AssertXXX` and fixes related tests.

`TestSyncPodsDeletesWhenSourcesAreReady` is no longer valid so covered by
- `TestHandlePodCleanUps`
- `TestHandlePodRemovesWhenSourcesAreReady`

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubernetes/issues/98937

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
