### PR TITLE
Add kubelet metrics for ephemeral containers

### DIFF
--- a/pkg/kubelet/metrics/metrics.go
+++ b/pkg/kubelet/metrics/metrics.go
@@ -84,13 +84,14 @@ const (
 	RunPodSandboxDurationKey = "run_podsandbox_duration_seconds"
 	RunPodSandboxErrorsKey   = "run_podsandbox_errors_total"
 
-	// Metrics to keep track of objects under management
-	ManagedPodsKey                  = "managed_pods"
-	ManagedContainersKey            = "managed_containers"
+	// Metrics to keep track of total number of Pods and Containers started
 	StartedPodsTotalKey             = "started_pods_total"
 	StartedPodsErrorsTotalKey       = "started_pods_errors_total"
 	StartedContainersTotalKey       = "started_containers_total"
 	StartedContainersErrorsTotalKey = "started_containers_errors_total"
+
+	// Metrics to track ephemeral container usage by this kubelet
+	ManagedEphemeralContainersKey = "managed_ephemeral_containers"
 
 	// Values used in metric labels
 	Container          = "container"
@@ -483,24 +484,14 @@ var (
 		},
 		[]string{"container_type", "code"},
 	)
-	// ManagedPods is a gauge that tracks how many pods are managed by this kubelet
-	ManagedPods = metrics.NewGauge(
+	// ManagedEphemeralContainers is a gauge that indicates how many ephemeral containers are managed by this kubelet.
+	ManagedEphemeralContainers = metrics.NewGauge(
 		&metrics.GaugeOpts{
 			Subsystem:      KubeletSubsystem,
-			Name:           ManagedPodsKey,
-			Help:           "Number of pods managed by this kubelet",
+			Name:           ManagedEphemeralContainersKey,
+			Help:           "Current number of ephemeral containers in pods managed by this kubelet. Ephemeral containers will be ignored if disabled by the EphemeralContainers feature gate, and this number will be 0.",
 			StabilityLevel: metrics.ALPHA,
 		},
-	)
-	// ManagedContainers is a gauge that tracks how many containers are managed by this kubelet
-	ManagedContainers = metrics.NewGaugeVec(
-		&metrics.GaugeOpts{
-			Subsystem:      KubeletSubsystem,
-			Name:           ManagedContainersKey,
-			Help:           "Number of containers managed by this kubelet",
-			StabilityLevel: metrics.ALPHA,
-		},
-		[]string{"container_type"},
 	)
 )
 
@@ -530,8 +521,7 @@ func Register(collectors ...metrics.StableCollector) {
 		legacyregistry.MustRegister(DevicePluginAllocationDuration)
 		legacyregistry.MustRegister(RunningContainerCount)
 		legacyregistry.MustRegister(RunningPodCount)
-		legacyregistry.MustRegister(ManagedPods)
-		legacyregistry.MustRegister(ManagedContainers)
+		legacyregistry.MustRegister(ManagedEphemeralContainers)
 		legacyregistry.MustRegister(StartedPodsTotal)
 		legacyregistry.MustRegister(StartedPodsErrorsTotal)
 		legacyregistry.MustRegister(StartedContainersTotal)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature
/sig node
/priority important-soon

#### What this PR does / why we need it:

This adds alpha metrics to the kubelet that track pods and containers under management and counters for container creation. This is part of the Ephemeral Containers (kubernetes/enhancements#277) PRR.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #97974

#### Special notes for your reviewer:

As part of code cleanup this slightly changes the format of log messages of particular container types. This isn't necessary and can be reverted, but using the same label in log messages in metrics seems cleaner and more supportable.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://git.k8s.io/enhancements/keps/sig-node/277-ephemeral-containers
```
