### PR TITLE
kubectl: exec and attach break scripting and should honor `--quiet`

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/util/helpers.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/util/helpers.go
@@ -30,7 +30,6 @@ import (
 	jsonpatch "github.com/evanphx/json-patch"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
-	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -45,7 +44,6 @@ import (
 	"k8s.io/client-go/scale"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/klog/v2"
-	"k8s.io/kubectl/pkg/util/podutils"
 	utilexec "k8s.io/utils/exec"
 )
 
@@ -745,29 +743,4 @@ func Warning(cmdErr io.Writer, newGeneratorName, oldGeneratorName string) {
 		newGeneratorName,
 		oldGeneratorName,
 	)
-}
-
-// GetDefaultContainerName returns the default container name for a pod.
-// it checks the annotation kubectl.kubernetes.io/default-container at first and then the first container name.
-func GetDefaultContainerName(pod *corev1.Pod, enableSuggestedCmdUsage bool, w io.Writer) string {
-	if len(pod.Spec.Containers) > 1 {
-		// in case the "kubectl.kubernetes.io/default-container" annotation is present, we preset the opts.Containers to default to selected
-		// container. This gives users ability to preselect the most interesting container in pod.
-		if annotations := pod.Annotations; annotations != nil && len(annotations[podutils.DefaultContainerAnnotationName]) > 0 {
-			containerName := annotations[podutils.DefaultContainerAnnotationName]
-			if exists, _ := podutils.FindContainerByName(pod, containerName); exists != nil {
-				fmt.Fprintf(w, "Defaulting container name to container %s.\n", containerName)
-				return containerName
-			} else {
-				fmt.Fprintf(w, "Default container name %q in annotation not found in a pod\n", containerName)
-			}
-		}
-		fmt.Fprintf(w, "Defaulting container name to first container %s.\n", pod.Spec.Containers[0].Name)
-
-		if enableSuggestedCmdUsage {
-			fmt.Fprintf(w, "Use 'kubectl describe pod/%s -n %s' to see all of the containers in this pod.\n", pod.Name, pod.Namespace)
-		}
-	}
-
-	return pod.Spec.Containers[0].Name
 }

--- a/staging/src/k8s.io/kubectl/pkg/cmd/util/podcmd/podcmd.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/util/podcmd/podcmd.go
@@ -1,0 +1,104 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package podcmd
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
+)
+
+// DefaultContainerAnnotationName is an annotation name that can be used to preselect the interesting container
+// from a pod when running kubectl.
+const DefaultContainerAnnotationName = "kubectl.kubernetes.io/default-container"
+
+// FindContainerByName selects the named container from the spec of
+// the provided pod or return nil if no such container exists.
+func FindContainerByName(pod *v1.Pod, name string) (*v1.Container, string) {
+	for i := range pod.Spec.Containers {
+		if pod.Spec.Containers[i].Name == name {
+			return &pod.Spec.Containers[i], fmt.Sprintf("spec.containers{%s}", name)
+		}
+	}
+	for i := range pod.Spec.InitContainers {
+		if pod.Spec.InitContainers[i].Name == name {
+			return &pod.Spec.InitContainers[i], fmt.Sprintf("spec.initContainers{%s}", name)
+		}
+	}
+	for i := range pod.Spec.EphemeralContainers {
+		if pod.Spec.EphemeralContainers[i].Name == name {
+			return (*v1.Container)(&pod.Spec.EphemeralContainers[i].EphemeralContainerCommon), fmt.Sprintf("spec.ephemeralContainers{%s}", name)
+		}
+	}
+	return nil, ""
+}
+
+// FindOrDefaultContainerByName defaults a container for a pod to the first container if any
+// exists, or returns an error. It will print a message to the user indicating a default was
+// selected if there was more than one container.
+func FindOrDefaultContainerByName(pod *v1.Pod, name string, quiet bool, warn io.Writer) (*v1.Container, error) {
+	var container *v1.Container
+
+	if len(name) > 0 {
+		container, _ = FindContainerByName(pod, name)
+		if container == nil {
+			return nil, fmt.Errorf("container %s not found in pod %s", name, pod.Name)
+		}
+		return container, nil
+	}
+
+	// this should never happen, but just in case
+	if len(pod.Spec.Containers) == 0 {
+		return nil, fmt.Errorf("pod %s/%s does not have any containers", pod.Namespace, pod.Name)
+	}
+
+	// read the default container the annotation as per
+	// https://github.com/kubernetes/enhancements/tree/master/keps/sig-cli/2227-kubectl-default-container
+	if name := pod.Annotations[DefaultContainerAnnotationName]; len(name) > 0 {
+		if container, _ = FindContainerByName(pod, name); container != nil {
+			klog.V(4).Infof("Defaulting container name from annotation %s", container.Name)
+			return container, nil
+		}
+		klog.V(4).Infof("Default container name from annotation %s was not found in the pod", name)
+	}
+
+	// pick the first container as per existing behavior
+	container = &pod.Spec.Containers[0]
+	if !quiet && (len(pod.Spec.Containers) > 1 || len(pod.Spec.InitContainers) > 0 || len(pod.Spec.EphemeralContainers) > 0) {
+		fmt.Fprintf(warn, "Defaulted container %q out of: %s\n", container.Name, allContainerNames(pod))
+	}
+
+	klog.V(4).Infof("Defaulting container name to %s", container.Name)
+	return &pod.Spec.Containers[0], nil
+}
+
+func allContainerNames(pod *v1.Pod) string {
+	var containers []string
+	for _, container := range pod.Spec.Containers {
+		containers = append(containers, container.Name)
+	}
+	for _, container := range pod.Spec.EphemeralContainers {
+		containers = append(containers, fmt.Sprintf("%s (ephem)", container.Name))
+	}
+	for _, container := range pod.Spec.InitContainers {
+		containers = append(containers, fmt.Sprintf("%s (init)", container.Name))
+	}
+	return strings.Join(containers, ", ")
+}

--- a/staging/src/k8s.io/kubectl/pkg/polymorphichelpers/logsforobject.go
+++ b/staging/src/k8s.io/kubectl/pkg/polymorphichelpers/logsforobject.go
@@ -30,6 +30,7 @@ import (
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/reference"
+	"k8s.io/kubectl/pkg/cmd/util/podcmd"
 	"k8s.io/kubectl/pkg/scheme"
 	"k8s.io/kubectl/pkg/util/podutils"
 )
@@ -79,8 +80,8 @@ func logsForObjectWithClient(clientset corev1client.CoreV1Interface, object, opt
 			// container. This gives users ability to preselect the most interesting container in pod.
 			if annotations := t.GetAnnotations(); annotations != nil && len(opts.Container) == 0 {
 				var containerName string
-				if len(annotations[podutils.DefaultContainerAnnotationName]) > 0 {
-					containerName = annotations[podutils.DefaultContainerAnnotationName]
+				if len(annotations[podcmd.DefaultContainerAnnotationName]) > 0 {
+					containerName = annotations[podcmd.DefaultContainerAnnotationName]
 				} else if len(annotations[defaultLogsContainerAnnotationName]) > 0 {
 					// Only log deprecation if we have only the old annotation. This allows users to
 					// set both to support multiple versions of kubectl; if they are setting both
@@ -90,7 +91,7 @@ func logsForObjectWithClient(clientset corev1client.CoreV1Interface, object, opt
 					fmt.Fprintf(os.Stderr, "Using deprecated annotation `kubectl.kubernetes.io/default-logs-container` in pod/%v. Please use `kubectl.kubernetes.io/default-container` instead\n", t.Name)
 				}
 				if len(containerName) > 0 {
-					if exists, _ := podutils.FindContainerByName(t, containerName); exists != nil {
+					if exists, _ := podcmd.FindContainerByName(t, containerName); exists != nil {
 						opts.Container = containerName
 					} else {
 						fmt.Fprintf(os.Stderr, "Default container name %q not found in a pod\n", containerName)
@@ -121,7 +122,7 @@ func logsForObjectWithClient(clientset corev1client.CoreV1Interface, object, opt
 				containerName = opts.Container
 			}
 
-			container, fieldPath := podutils.FindContainerByName(t, containerName)
+			container, fieldPath := podcmd.FindContainerByName(t, containerName)
 			if container == nil {
 				return nil, fmt.Errorf("container %s is not valid for pod %s", opts.Container, t.Name)
 			}

--- a/staging/src/k8s.io/kubectl/pkg/polymorphichelpers/logsforobject_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/polymorphichelpers/logsforobject_test.go
@@ -32,7 +32,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/diff"
 	fakeexternal "k8s.io/client-go/kubernetes/fake"
 	testclient "k8s.io/client-go/testing"
-	"k8s.io/kubectl/pkg/util/podutils"
+	"k8s.io/kubectl/pkg/cmd/util/podcmd"
 )
 
 var (
@@ -430,7 +430,7 @@ func TestLogsForObjectWithClient(t *testing.T) {
 			name: "two container pod with default container selected",
 			podFn: func() *corev1.Pod {
 				pod := testPodWithTwoContainers()
-				pod.Annotations = map[string]string{podutils.DefaultContainerAnnotationName: "foo-2-c1"}
+				pod.Annotations = map[string]string{podcmd.DefaultContainerAnnotationName: "foo-2-c1"}
 				return pod
 			},
 			podLogOptions:     &corev1.PodLogOptions{},
@@ -440,7 +440,7 @@ func TestLogsForObjectWithClient(t *testing.T) {
 			name: "two container pod with default container selected but also container set explicitly",
 			podFn: func() *corev1.Pod {
 				pod := testPodWithTwoContainers()
-				pod.Annotations = map[string]string{podutils.DefaultContainerAnnotationName: "foo-2-c1"}
+				pod.Annotations = map[string]string{podcmd.DefaultContainerAnnotationName: "foo-2-c1"}
 				return pod
 			},
 			podLogOptions: &corev1.PodLogOptions{
@@ -452,7 +452,7 @@ func TestLogsForObjectWithClient(t *testing.T) {
 			name: "two container pod with non-existing default container selected",
 			podFn: func() *corev1.Pod {
 				pod := testPodWithTwoContainers()
-				pod.Annotations = map[string]string{podutils.DefaultContainerAnnotationName: "non-existing"}
+				pod.Annotations = map[string]string{podcmd.DefaultContainerAnnotationName: "non-existing"}
 				return pod
 			},
 			podLogOptions: &corev1.PodLogOptions{},
@@ -462,7 +462,7 @@ func TestLogsForObjectWithClient(t *testing.T) {
 			name: "two container pod with default container set, but allContainers also set",
 			podFn: func() *corev1.Pod {
 				pod := testPodWithTwoContainers()
-				pod.Annotations = map[string]string{podutils.DefaultContainerAnnotationName: "foo-2-c1"}
+				pod.Annotations = map[string]string{podcmd.DefaultContainerAnnotationName: "foo-2-c1"}
 				return pod
 			},
 			allContainers:     true,

--- a/staging/src/k8s.io/kubectl/pkg/util/podutils/podutils.go
+++ b/staging/src/k8s.io/kubectl/pkg/util/podutils/podutils.go
@@ -17,17 +17,12 @@ limitations under the License.
 package podutils
 
 import (
-	"fmt"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/integer"
 )
-
-// DefaultContainerAnnotationName is an annotation name that can be used to preselect the interesting container
-// from a pod when running kubectl.
-const DefaultContainerAnnotationName = "kubectl.kubernetes.io/default-container"
 
 // IsPodAvailable returns true if a pod is available; false otherwise.
 // Precondition for an available pod is that it must be ready. On top
@@ -190,26 +185,4 @@ func maxContainerRestarts(pod *corev1.Pod) int {
 		maxRestarts = integer.IntMax(maxRestarts, int(c.RestartCount))
 	}
 	return maxRestarts
-}
-
-// FindContainerByName searches for a container by name amongst all containers in a pod.
-// Returns a pointer to a container and a field path.
-func FindContainerByName(pod *corev1.Pod, name string) (container *corev1.Container, fieldPath string) {
-	for _, c := range pod.Spec.InitContainers {
-		if c.Name == name {
-			return &c, fmt.Sprintf("spec.initContainers{%s}", c.Name)
-		}
-	}
-	for _, c := range pod.Spec.Containers {
-		if c.Name == name {
-			return &c, fmt.Sprintf("spec.containers{%s}", c.Name)
-		}
-	}
-	for _, c := range pod.Spec.EphemeralContainers {
-		if c.Name == name {
-			containerCommon := corev1.Container(c.EphemeralContainerCommon)
-			return &containerCommon, fmt.Sprintf("spec.ephemeralContainers{%s}", containerCommon.Name)
-		}
-	}
-	return nil, ""
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -2403,6 +2403,7 @@ k8s.io/kubectl/pkg/cmd/top
 k8s.io/kubectl/pkg/cmd/util
 k8s.io/kubectl/pkg/cmd/util/editor
 k8s.io/kubectl/pkg/cmd/util/editor/crlf
+k8s.io/kubectl/pkg/cmd/util/podcmd
 k8s.io/kubectl/pkg/cmd/util/sanity
 k8s.io/kubectl/pkg/cmd/version
 k8s.io/kubectl/pkg/cmd/wait


### PR DESCRIPTION
--quiet means no informational output for the human that could be confused with the output of the underlying system. We have been very lax in allowing new debugging messages to be added to exec and attach which breaks scripting (exec and attach are designed to work properly for remote scripting and only error when that error cannot be confused with the remote system). Make exec and attach properly honor --quiet to suppress informational / non-failure output from the local command.  We added quiet as an internal option several years back and have been steadily growing less tolerant of flakes (originally exec was a good citizen in almost all cases, now it is less so).

Secondly, attach and exec are inconsistent with how they show the containers the user can exec/attach to. Printing the describe command is a lot of text output (80 characters) and describe itself is pretty bad at telling you container names. The behavior of logs up to this point is more accurate, and since the vast majority of pods have a small number of containers, it would be better for humans to print a single line with all ephemeral and init containers. Update the commands to share similar debugging code (and suppress the defaulting message when --quiet is provided). After this change we no longer need EnableCmdSuggestion:

Example output:

```
# show init containers inline when defaulting to a container
$ kubectl exec -i --tty -n my-namespace some-etcd-pod -- /bin/sh
Defaulted container "etcdctl" out of: etcdctl, etcd, etcd-metrics, etcd-ensure-env-vars (init), etcd-resources-copy (init)
sh-4.4# 

# suppress output with --quiet
$ kubectl exec -q -i --tty -n my-namespace some-etcd-pod -- /bin/sh
sh-4.4# 
```

/kind bug
/kind cleanup

```release-note
`kubectl exec` and `kubectl attach` now honor the `--quiet` flag which suppresses output from the local binary that could be confused by a script with the remote command output (all non-failure output is hidden). In addition, print inline with exec and attach the list of alternate containers when we default to the first spec.container.
```

```docs

```