### PR TITLE
Automated cherry pick of #98305: kube-proxy: clear conntrack entries after rules are in place

### DIFF
--- a/pkg/proxy/iptables/BUILD
+++ b/pkg/proxy/iptables/BUILD
@@ -25,6 +25,7 @@ go_library(
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/api/discovery/v1beta1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",
         "//staging/src/k8s.io/client-go/tools/record:go_default_library",


### PR DESCRIPTION
Cherry pick of #98305 on release-1.20.

#98305: kube-proxy: clear conntrack entries after rules are in place

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

/kind bug