### PR TITLE
Imporve kubeadm prompts

### DIFF
--- a/cmd/kubeadm/app/cmd/config.go
+++ b/cmd/kubeadm/app/cmd/config.go
@@ -71,7 +71,7 @@ func newCmdConfig(out io.Writer) *cobra.Command {
 		// cobra will print usage information, but still exit cleanly.
 		// We want to return an error code in these cases so that the
 		// user knows that their command was invalid.
-		RunE: cmdutil.SubCmdRunE("config"),
+		PreRunE: cmdutil.SubCmdRunE("config"),
 	}
 
 	options.AddKubeConfigFlag(cmd.PersistentFlags(), &kubeConfigFile)
@@ -92,7 +92,7 @@ func newCmdConfigPrint(out io.Writer) *cobra.Command {
 		Long: dedent.Dedent(`
 			This command prints configurations for subcommands provided.
 			For details, see: https://godoc.org/k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta2`),
-		RunE: cmdutil.SubCmdRunE("print"),
+		PreRunE: cmdutil.SubCmdRunE("print"),
 	}
 	cmd.AddCommand(newCmdConfigPrintInitDefaults(out))
 	cmd.AddCommand(newCmdConfigPrintJoinDefaults(out))
@@ -245,7 +245,7 @@ func newCmdConfigMigrate(out io.Writer) *cobra.Command {
 			In other words, the output of this command is what kubeadm actually would read internally if you
 			submitted this file to "kubeadm init"
 		`), kubeadmapiv1beta2.SchemeGroupVersion, kubeadmapiv1beta2.SchemeGroupVersion),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, args []string) error {
 			if len(oldCfgPath) == 0 {
 				return errors.New("the --old-config flag is mandatory")
 			}
@@ -318,7 +318,7 @@ func newCmdConfigImages(out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "images",
 		Short: "Interact with container images used by kubeadm",
-		RunE:  cmdutil.SubCmdRunE("images"),
+		PreRunE:  cmdutil.SubCmdRunE("images"),
 	}
 	cmd.AddCommand(newCmdConfigImagesList(out, nil))
 	cmd.AddCommand(newCmdConfigImagesPull())

--- a/cmd/kubeadm/app/cmd/token.go
+++ b/cmd/kubeadm/app/cmd/token.go
@@ -85,7 +85,7 @@ func newCmdToken(out io.Writer, errW io.Writer) *cobra.Command {
 		// cobra will print usage information, but still exit cleanly.
 		// We want to return an error code in these cases so that the
 		// user knows that their command was invalid.
-		RunE: cmdutil.SubCmdRunE("token"),
+		PreRunE: cmdutil.SubCmdRunE("token"),
 	}
 
 	options.AddKubeConfigFlag(tokenCmd.PersistentFlags(), &kubeConfigFile)


### PR DESCRIPTION
#### What this PR does / why we need it:

When you invoke 'kubeadm config',  the output may be confusing

```
missing subcommand; "config" is not meant to be run on its own
To see the stack trace of this error execute with --v=5 or higher
```

But if you invoke other kubeadm commands, such as 'kubeadm', 'kubeadm alpha', 'kubeadm certs',
The output prompts are more comprehensible, e.g.,
```
Usage:
  kubeadm alpha [command]

Available Commands:
  kubeconfig  Kubeconfig file utilities

Flags:
  -h, --help   help for alpha

......

Use "kubeadm alpha [command] --help" for more information about a command.
```

Hence,  we hope to improve kubeadm prompts
