### PR TITLE
Use ARG and --build-arg instead of sed for etcd image.

### DIFF
--- a/cluster/images/etcd/Dockerfile
+++ b/cluster/images/etcd/Dockerfile
@@ -12,7 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM BASEIMAGE as builder
+ARG BASEIMAGE
+ARG RUNNERIMAGE
+
+FROM ${BASEIMAGE} as builder
 
 # This image needs bash for running "migrate-if-needed.sh". Instead of a full debian image
 # we use just the bash-static and we wrap bash-static into a distroless image instead of
@@ -23,7 +26,7 @@ RUN apt-get update -y \
 
 RUN cp /bin/bash-static /sh
 
-FROM RUNNERIMAGE
+FROM ${RUNNERIMAGE}
 WORKDIR /
 
 COPY --from=builder /sh /bin/

--- a/cluster/images/etcd/Makefile
+++ b/cluster/images/etcd/Makefile
@@ -143,12 +143,13 @@ else
 	cd $(TEMP_DIR) && echo "ENV ETCD_UNSUPPORTED_ARCH=$(ARCH)" >> Dockerfile
 endif
 
-	# Replace BASEIMAGE with the real base image
-	cd $(TEMP_DIR) && sed -i.bak 's|BASEIMAGE|$(BASEIMAGE)|g' Dockerfile
-	cd $(TEMP_DIR) && sed -i.bak 's|RUNNERIMAGE|$(RUNNERIMAGE)|g' Dockerfile
-
 	# And build the image
-	docker build --pull -t $(REGISTRY)/etcd-$(ARCH):$(IMAGE_TAG) $(TEMP_DIR)
+	docker build \
+		--pull \
+		-t $(REGISTRY)/etcd-$(ARCH):$(IMAGE_TAG) \
+		--build-arg BASEIMAGE=$(BASEIMAGE) \
+		--build-arg RUNNERIMAGE=$(RUNNERIMAGE) \
+		$(TEMP_DIR)
 
 push: build
 	docker tag $(REGISTRY)/etcd-$(ARCH):$(IMAGE_TAG) $(MANIFEST_IMAGE)-$(ARCH):$(IMAGE_TAG)
@@ -181,8 +182,12 @@ unit-test:
 build-integration-test-image: build
 	cp -r $(TEMP_DIR) $(TEMP_DIR)_integration_test
 	cp Dockerfile $(TEMP_DIR)_integration_test/Dockerfile
-	cd $(TEMP_DIR)_integration_test && sed -i.bak 's|BASEIMAGE|golang:$(GOLANG_VERSION)|g' Dockerfile
-	docker build --pull -t etcd-integration-test $(TEMP_DIR)_integration_test
+	docker build \
+		--pull \
+		-t etcd-integration-test \
+		--build-arg BASEIMAGE=golang:$(GOLANG_VERSION) \
+		--build-arg RUNNERIMAGE=$(RUNNERIMAGE) \
+		$(TEMP_DIR)_integration_test
 
 integration-test:
 	docker run --interactive -v $(shell pwd)/../../../:/go/src/k8s.io/kubernetes$(DOCKER_VOL_OPTS) -e GOARCH=$(ARCH) etcd-integration-test \


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup


#### What this PR does / why we need it:
Switch from sed to using ARG and --build-arg to specify the BUILDIMAGE and the RUNNERIMAGE, as its a cleaner way to do this. While testing this out I also found https://github.com/kubernetes/kubernetes/issues/99058. Looks like build for integration-test-image is broken, this change makes it so that the build won't be broken anymore.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #99058

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
