### PR TITLE
Wrong  command (kubectl top) description 

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/top/top.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/top/top.go
@@ -37,7 +37,7 @@ var (
 		"v1beta1",
 	}
 	topLong = templates.LongDesc(i18n.T(`
-		Display Resource (CPU/Memory/Storage) usage.
+		Display Resource (CPU/Memory) usage.
 
 		The top command allows you to see the resource consumption for nodes or pods.
 
@@ -47,7 +47,7 @@ var (
 func NewCmdTop(f cmdutil.Factory, streams genericclioptions.IOStreams) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "top",
-		Short: i18n.T("Display Resource (CPU/Memory/Storage) usage."),
+		Short: i18n.T("Display Resource (CPU/Memory) usage."),
 		Long:  topLong,
 		Run:   cmdutil.DefaultSubCommandRun(streams.ErrOut),
 	}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/top/top_node.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/top/top_node.go
@@ -52,7 +52,7 @@ type TopNodeOptions struct {
 
 var (
 	topNodeLong = templates.LongDesc(i18n.T(`
-		Display Resource (CPU/Memory/Storage) usage of nodes.
+		Display Resource (CPU/Memory) usage of nodes.
 
 		The top-node command allows you to see the resource consumption of nodes.`))
 
@@ -74,7 +74,7 @@ func NewCmdTopNode(f cmdutil.Factory, o *TopNodeOptions, streams genericclioptio
 	cmd := &cobra.Command{
 		Use:                   "node [NAME | -l label]",
 		DisableFlagsInUseLine: true,
-		Short:                 i18n.T("Display Resource (CPU/Memory/Storage) usage of nodes"),
+		Short:                 i18n.T("Display Resource (CPU/Memory) usage of nodes"),
 		Long:                  topNodeLong,
 		Example:               topNodeExample,
 		Run: func(cmd *cobra.Command, args []string) {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/top/top_pod.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/top/top_pod.go
@@ -60,7 +60,7 @@ const metricsCreationDelay = 2 * time.Minute
 
 var (
 	topPodLong = templates.LongDesc(i18n.T(`
-		Display Resource (CPU/Memory/Storage) usage of pods.
+		Display Resource (CPU/Memory) usage of pods.
 
 		The 'top pod' command allows you to see the resource consumption of pods.
 
@@ -91,7 +91,7 @@ func NewCmdTopPod(f cmdutil.Factory, o *TopPodOptions, streams genericclioptions
 	cmd := &cobra.Command{
 		Use:                   "pod [NAME | -l label]",
 		DisableFlagsInUseLine: true,
-		Short:                 i18n.T("Display Resource (CPU/Memory/Storage) usage of pods"),
+		Short:                 i18n.T("Display Resource (CPU/Memory) usage of pods"),
 		Long:                  topPodLong,
 		Example:               topPodExample,
 		Run: func(cmd *cobra.Command, args []string) {


### PR DESCRIPTION
#### What this PR does / why we need it:

When you invoke 'kubctl top',  the prompt shows that it can display CPU/Memory/Storage usage

```
Available Commands:
  node        Display Resource (CPU/Memory/Storage) usage of nodes
  pod         Display Resource (CPU/Memory/Storage) usage of pods
```

But，actually, it can only show  display CPU and Memory usage

```
[root@hqcloud-39 ~]# kubectl top node
NAME             CPU(cores)   CPU%   MEMORY(bytes)   MEMORY%   
172.17.174.4     461m         23%    5307Mi          74%       
172.17.222.230   150m         7%     4177Mi          58%       
172.17.76.238    195m         9%     3751Mi          78%

[root@hqcloud-39 ~]# kubectl top pod -n kube-system
NAME                                          CPU(cores)   MEMORY(bytes)   
calico-kube-controllers-7fdc86d8ff-vj9p9      2m           28Mi            
calico-node-bccvl                             15m          67Mi            
calico-node-j4hpr                             15m          53Mi            
coredns-65dbdb44db-m6cxk                      3m           31Mi            
dashboard-metrics-scraper-545bbb8767-vb8md    1m           13Mi            
hqcloud-scheduler-5c5858b589-ktjrm            1m           80Mi            
hqcloud-trigger-6c4958ddf5-sf7s6              1m           176Mi           
kubernetes-dashboard-65665f84db-t62cc         1m           18Mi            
kuboard-ff5b49d68-jtdt9                       0m           3Mi             
metrics-server-7f96bbcc66-tb5ph               1m           15Mi            
traefik-ingress-controller-74767b894f-ht6p8   3m           33Mi
```

https://github.com/kubernetes/kubernetes/pull/99060
--

What type of PR is this?

/kind documentation