### PR TITLE
Remove redundant code in kubectl top pod

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/top/top_pod.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/top/top_pod.go
@@ -183,9 +183,9 @@ func (o TopPodOptions) RunTopPod() error {
 	if len(metrics.Items) == 0 {
 		// If the API server query is successful but all the pods are newly created,
 		// the metrics are probably not ready yet, so we return the error here in the first place.
-		e := verifyEmptyMetrics(o, selector)
-		if e != nil {
-			return e
+		err := verifyEmptyMetrics(o, selector)
+		if err != nil {
+			return err
 		}
 
 		// if we had no errors, be sure we output something.

--- a/staging/src/k8s.io/kubectl/pkg/cmd/top/top_pod.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/top/top_pod.go
@@ -195,9 +195,6 @@ func (o TopPodOptions) RunTopPod() error {
 			fmt.Fprintf(o.ErrOut, "No resources found in %s namespace.\n", o.Namespace)
 		}
 	}
-	if err != nil {
-		return err
-	}
 
 	return o.Printer.PrintPodMetrics(metrics.Items, o.PrintContainers, o.AllNamespaces, o.NoHeaders, o.SortBy)
 }


### PR DESCRIPTION
#### What this PR does / why we need it:

when invoke 'kubectl top pod',  we found the last three lines are  redundant.

```
        ...
        metrics, err := getMetricsFromMetricsAPI(o.MetricsClient, o.Namespace, o.ResourceName, o.AllNamespaces, selector)
	if err != nil {
		return err
	}

	// First we check why no metrics have been received.
	if len(metrics.Items) == 0 {
		// If the API server query is successful but all the pods are newly created,
		// the metrics are probably not ready yet, so we return the error here in the first place.
		e := verifyEmptyMetrics(o, selector)
		if e != nil {
			return e
		}
                ....
	}

	if err != nil {
		return err
	}
```

/kind bug