### PR TITLE
Allow adding healthz and livez checks independent to each other

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/config.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/config.go
@@ -633,7 +633,7 @@ func (c completedConfig) New(name string, delegationTarget DelegationTarget) (*G
 			}
 		}
 		// TODO: Once we get rid of /healthz consider changing this to post-start-hook.
-		err := s.addReadyzChecks(healthz.NewInformerSyncHealthz(c.SharedInformerFactory))
+		err := s.AddReadyzChecks(healthz.NewInformerSyncHealthz(c.SharedInformerFactory))
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
Without this PR checks can only be added to all "/healthz", "livez", "readyz" endpoints at once.

As readiness and liveness are separate properties of applications adding them should be separate. 
This PR allows that by making private functions public and removing requirement that livez probes are also added to readyz.

#### Which issue(s) this PR fixes:
Fixes https://github.com/kubernetes/kubernetes/issues/96896

#### Does this PR introduce a user-facing change?

No, Change in k8s.io/apiserver library, no changes in Kubernetes behavior.
```release-note
NONE
```
/assign @sttts 