### PR TITLE
[WIP] kube-proxy maybe dual-stack

### DIFF
--- a/cmd/kube-proxy/app/server_others.go
+++ b/cmd/kube-proxy/app/server_others.go
@@ -133,6 +133,7 @@ func newProxyServer(
 		return nil, err
 	}
 
+	// nodeIP is ONLY used by iptables and IPVS mode to filter LoadBalancer source ranges
 	nodeIP := detectNodeIP(client, hostname, config.BindAddress)
 	protocol := utiliptables.ProtocolIPv4
 	if utilsnet.IsIPv6(nodeIP) {

--- a/cmd/kube-proxy/app/server_others_test.go
+++ b/cmd/kube-proxy/app/server_others_test.go
@@ -217,34 +217,34 @@ func Test_getDetectLocalMode(t *testing.T) {
 	}
 }
 
-func Test_detectNodeIP(t *testing.T) {
+func Test_detectNodeIPs(t *testing.T) {
 	cases := []struct {
 		name        string
 		nodeInfo    *v1.Node
 		hostname    string
 		bindAddress string
-		expectedIP  net.IP
+		expectedIPs [2]net.IP
 	}{
 		{
 			name:        "Bind address IPv4 unicast address and no Node object",
 			nodeInfo:    makeNodeWithAddresses("", "", ""),
 			hostname:    "fakeHost",
 			bindAddress: "10.0.0.1",
-			expectedIP:  net.ParseIP("10.0.0.1"),
+			expectedIPs: [2]net.IP{net.ParseIP("10.0.0.1"), net.ParseIP("::1")},
 		},
 		{
 			name:        "Bind address IPv6 unicast address and no Node object",
 			nodeInfo:    makeNodeWithAddresses("", "", ""),
 			hostname:    "fakeHost",
 			bindAddress: "fd00:4321::2",
-			expectedIP:  net.ParseIP("fd00:4321::2"),
+			expectedIPs: [2]net.IP{net.ParseIP("fd00:4321::2"), net.ParseIP("127.0.0.1")},
 		},
 		{
 			name:        "No Valid IP found",
 			nodeInfo:    makeNodeWithAddresses("", "", ""),
 			hostname:    "fakeHost",
 			bindAddress: "",
-			expectedIP:  net.ParseIP("127.0.0.1"),
+			expectedIPs: [2]net.IP{net.ParseIP("127.0.0.1"), net.ParseIP("::1")},
 		},
 		// Disabled because the GetNodeIP method has a backoff retry mechanism
 		// and the test takes more than 30 seconds
@@ -254,70 +254,84 @@ func Test_detectNodeIP(t *testing.T) {
 		//	nodeInfo:    makeNodeWithAddresses("", "", ""),
 		//	hostname:    "fakeHost",
 		//	bindAddress: "0.0.0.0",
-		//	expectedIP:  net.ParseIP("127.0.0.1"),
+		//	expectedIPs:  net.ParseIP("127.0.0.1"),
 		// },
 		{
 			name:        "Bind address 0.0.0.0 and node with IPv4 InternalIP set",
 			nodeInfo:    makeNodeWithAddresses("fakeHost", "192.168.1.1", "90.90.90.90"),
 			hostname:    "fakeHost",
 			bindAddress: "0.0.0.0",
-			expectedIP:  net.ParseIP("192.168.1.1"),
+			expectedIPs: [2]net.IP{net.ParseIP("192.168.1.1"), net.ParseIP("::1")},
 		},
 		{
 			name:        "Bind address :: and node with IPv4 InternalIP set",
 			nodeInfo:    makeNodeWithAddresses("fakeHost", "192.168.1.1", "90.90.90.90"),
 			hostname:    "fakeHost",
 			bindAddress: "::",
-			expectedIP:  net.ParseIP("192.168.1.1"),
+			expectedIPs: [2]net.IP{net.ParseIP("192.168.1.1"), net.ParseIP("::1")},
 		},
 		{
 			name:        "Bind address 0.0.0.0 and node with IPv6 InternalIP set",
 			nodeInfo:    makeNodeWithAddresses("fakeHost", "fd00:1234::1", "2001:db8::2"),
 			hostname:    "fakeHost",
 			bindAddress: "0.0.0.0",
-			expectedIP:  net.ParseIP("fd00:1234::1"),
+			expectedIPs: [2]net.IP{net.ParseIP("fd00:1234::1"), net.ParseIP("127.0.0.1")},
 		},
 		{
 			name:        "Bind address :: and node with IPv6 InternalIP set",
 			nodeInfo:    makeNodeWithAddresses("fakeHost", "fd00:1234::1", "2001:db8::2"),
 			hostname:    "fakeHost",
 			bindAddress: "::",
-			expectedIP:  net.ParseIP("fd00:1234::1"),
+			expectedIPs: [2]net.IP{net.ParseIP("fd00:1234::1"), net.ParseIP("127.0.0.1")},
 		},
 		{
 			name:        "Bind address 0.0.0.0 and node with only IPv4 ExternalIP set",
 			nodeInfo:    makeNodeWithAddresses("fakeHost", "", "90.90.90.90"),
 			hostname:    "fakeHost",
 			bindAddress: "0.0.0.0",
-			expectedIP:  net.ParseIP("90.90.90.90"),
+			expectedIPs: [2]net.IP{net.ParseIP("90.90.90.90"), net.ParseIP("::1")},
 		},
 		{
 			name:        "Bind address :: and node with only IPv4 ExternalIP set",
 			nodeInfo:    makeNodeWithAddresses("fakeHost", "", "90.90.90.90"),
 			hostname:    "fakeHost",
 			bindAddress: "::",
-			expectedIP:  net.ParseIP("90.90.90.90"),
+			expectedIPs: [2]net.IP{net.ParseIP("90.90.90.90"), net.ParseIP("::1")},
 		},
 		{
 			name:        "Bind address 0.0.0.0 and node with only IPv6 ExternalIP set",
 			nodeInfo:    makeNodeWithAddresses("fakeHost", "", "2001:db8::2"),
 			hostname:    "fakeHost",
 			bindAddress: "0.0.0.0",
-			expectedIP:  net.ParseIP("2001:db8::2"),
+			expectedIPs: [2]net.IP{net.ParseIP("2001:db8::2"), net.ParseIP("127.0.0.1")},
 		},
 		{
 			name:        "Bind address :: and node with only IPv6 ExternalIP set",
 			nodeInfo:    makeNodeWithAddresses("fakeHost", "", "2001:db8::2"),
 			hostname:    "fakeHost",
 			bindAddress: "::",
-			expectedIP:  net.ParseIP("2001:db8::2"),
+			expectedIPs: [2]net.IP{net.ParseIP("2001:db8::2"), net.ParseIP("127.0.0.1")},
+		},
+		{
+			name:        "Bind address 0.0.0.0 and node with dual-stack addresses IPv6 first",
+			nodeInfo:    makeNodeWithAddresses("fakeHost", "2001:db8::2", "192.168.1.1"),
+			hostname:    "fakeHost",
+			bindAddress: "0.0.0.0",
+			expectedIPs: [2]net.IP{net.ParseIP("2001:db8::2"), net.ParseIP("192.168.1.1")},
+		},
+		{
+			name:        "Bind address 0.0.0.0 and node with dual-stack addresses IPv4 first",
+			nodeInfo:    makeNodeWithAddresses("fakeHost", "192.168.1.1", "2001:db8::2"),
+			hostname:    "fakeHost",
+			bindAddress: "0.0.0.0",
+			expectedIPs: [2]net.IP{net.ParseIP("192.168.1.1"), net.ParseIP("2001:db8::2")},
 		},
 	}
 	for _, c := range cases {
 		client := clientsetfake.NewSimpleClientset(c.nodeInfo)
-		ip := detectNodeIP(client, c.hostname, c.bindAddress)
-		if !ip.Equal(c.expectedIP) {
-			t.Errorf("Case[%s] Expected IP %q got %q", c.name, c.expectedIP, ip)
+		ips := detectNodeIPs(client, c.hostname, c.bindAddress)
+		if !reflect.DeepEqual(ips, c.expectedIPs) {
+			t.Errorf("Case[%s] Expected IP %q got %q", c.name, c.expectedIPs, ips)
 		}
 	}
 }

--- a/pkg/util/node/node.go
+++ b/pkg/util/node/node.go
@@ -147,7 +147,13 @@ func GetNodeHostIP(node *v1.Node) (net.IP, error) {
 // GetNodeIP returns an IP (as with GetNodeHostIP) for the node with the provided name.
 // If required, it will wait for the node to be created.
 func GetNodeIP(client clientset.Interface, name string) net.IP {
-	var nodeIP net.IP
+	return GetNodeIPs(client, name)[0]
+}
+
+// GetNodeIPs returns node IP or IPs (as with GetNodeHostIPs), for the node with the provided name.
+// If required, it will wait for the node to be created.
+func GetNodeIPs(client clientset.Interface, name string) []net.IP {
+	nodeIPs := []net.IP{}
 	backoff := wait.Backoff{
 		Steps:    6,
 		Duration: 1 * time.Second,
@@ -161,7 +167,7 @@ func GetNodeIP(client clientset.Interface, name string) net.IP {
 			klog.Errorf("Failed to retrieve node info: %v", err)
 			return false, nil
 		}
-		nodeIP, err = GetNodeHostIP(node)
+		nodeIPs, err = GetNodeHostIPs(node)
 		if err != nil {
 			klog.Errorf("Failed to retrieve node IP: %v", err)
 			return false, err
@@ -169,9 +175,9 @@ func GetNodeIP(client clientset.Interface, name string) net.IP {
 		return true, nil
 	})
 	if err == nil {
-		klog.Infof("Successfully retrieved node IP: %v", nodeIP)
+		klog.Infof("Successfully retrieved node IPs: %v", nodeIPs)
 	}
-	return nodeIP
+	return nodeIPs
 }
 
 // GetZoneKey is a helper function that builds a string identifier that is unique per failure-zone;


### PR DESCRIPTION
kube-proxy, if the dual-stack feature gate is enabled, is always
running to proxy instances, one per family, independently of the
user configuration, that may want only to use one IP family.

On systems that may have one IP family disabled or missing some
kernel modules for that family, this will cause that kube-proxy
keep spamming the logs with errors.

Since kube-proxy can infer the user intention based on the
configuration of the local-traffic-detectors, it will use only
dual-stack if the user has configured the local-traffic-detectors
for both IP families.


/kind cleanup
/kind bug

Fixes #99031 
Fixes #95515 


```release-note
NONE
```
