### PR TITLE
correct typo in kubectl plugin command

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/plugin/plugin.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/plugin/plugin.go
@@ -123,7 +123,7 @@ func (o *PluginListOptions) Run() error {
 		files, err := ioutil.ReadDir(dir)
 		if err != nil {
 			if _, ok := err.(*os.PathError); ok {
-				fmt.Fprintf(o.ErrOut, "Unable read directory %q from your PATH: %v. Skipping...\n", dir, err)
+				fmt.Fprintf(o.ErrOut, "Unable to read directory %q from your PATH: %v. Skipping...\n", dir, err)
 				continue
 			}
 


### PR DESCRIPTION
#### What type of PR is this?

It should be 'unable to read' when invoking 'kubectl plugin list' 

```
Unable read directory "/root/bin" from your PATH: open /root/bin: no such file or directory. Skipping...
error: unable to find any kubectl plugins in your PATH
```

What type of PR is this?
/kind documentation


