### PR TITLE
cluster/addons/dashboard: remove inactive members from OWNERS

### DIFF
--- a/cluster/addons/dashboard/MAINTAINERS.md
+++ b/cluster/addons/dashboard/MAINTAINERS.md
@@ -1,4 +1,0 @@
-# Maintainers
-
-Piotr Bryk <bryk@google.com> and committers to the https://github.com/kubernetes/dashboard repository.
-

--- a/cluster/addons/dashboard/OWNERS
+++ b/cluster/addons/dashboard/OWNERS
@@ -1,7 +1,6 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-- bryk
 - floreks
 - jeefy
 - maciaszczykm
@@ -9,3 +8,5 @@ reviewers:
 - danielromlein
 - ianlewis
 - rf232
+emeritus_approvers:
+- bryk


### PR DESCRIPTION
ref: https://github.com/kubernetes/org/issues/2456

As a part of cleaning up inactive members (those with no activity within
the past 18 months) from OWNERS files, this commit moves byrk from
approver to emeritus_approver.

/kind cleanup
/assign @jeefy 

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

