### PR TITLE
OWNERS_ALIASES: remove inactive members

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -36,13 +36,11 @@ aliases:
     - dims
     - enj
     - erictune
-    - jianhuiz
     - lavalamp
     - liggitt
     - mikedanese
     - mml
     - ncdc
-    - nikhiljindal
     - smarterclayton
     - sttts
     - thockin
@@ -59,7 +57,6 @@ aliases:
     - dims
     - enj
     - errordeveloper
-    - jianhuiz
     - lavalamp
     - liggitt
     - mikedanese
@@ -97,9 +94,7 @@ aliases:
     - tallclair
   sig-auth-policy-reviewers:
     - deads2k
-    - jianhuiz
     - liggitt
-    - mbohlool
     - tallclair
     - krmayankk
 
@@ -425,8 +420,6 @@ aliases:
     - caesarxuchao
     - vishh
     - mikedanese
-    - nikhiljindal
-    - gmarek
     - davidopp
     - pmorie
     - sttts
@@ -542,7 +535,6 @@ aliases:
     - calebamiles     # Release
     - caseydavenport  # Network
     - countspongebob  # Scalability
-    - csbell          # Multicluster
     - dcbw            # Network
     - dchen1107       # Node
     - deads2k         # API Machinery


### PR DESCRIPTION
ref: https://github.com/kubernetes/org/issues/2456

As a part of cleaning up inactive members (those with no activity within
the past 18 months), this commit removes csbell, gmarek, jianhuiz,
mbohlool, and nikhiljindal from various owner aliases.

/kind cleanup

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

/sig auth
/sig api-machinery
/sig multicluster