### PR TITLE
cluster/* Remove inactive members from OWNERS

### DIFF
--- a/cluster/addons/kube-proxy/OWNERS
+++ b/cluster/addons/kube-proxy/OWNERS
@@ -4,9 +4,9 @@ approvers:
 - bowei
 - freehan
 - mrhohn
-- jingax10
 reviewers:
 - bowei
 - freehan
 - mrhohn
+emeritus_approvers:
 - jingax10

--- a/cluster/gce/OWNERS
+++ b/cluster/gce/OWNERS
@@ -3,11 +3,9 @@
 reviewers:
   - bowei
   - cjcullen
-  - gmarek
   - vishh
   - mwielgus
   - MaciekPytel
-  - jingax10
   - yujuhong
   - mtaufen
   - jeremyje
@@ -15,16 +13,16 @@ reviewers:
 approvers:
   - bowei
   - cjcullen
-  - gmarek
   - vishh
   - mwielgus
   - MaciekPytel
-  - jingax10
   - yujuhong
   - mtaufen
   - jeremyje
   - sig-scalability-approvers
 emeritus_approvers:
+  - gmarek
+  - jingax10
   - jszczepkowski
 labels:
 - sig/cloud-provider

--- a/cluster/images/kubemark/OWNERS
+++ b/cluster/images/kubemark/OWNERS
@@ -1,12 +1,12 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 reviewers:
-  - gmarek
   - shyamjvs
   - wojtek-t
 approvers:
-  - gmarek
   - shyamjvs
   - wojtek-t
+emeritus_approvers:
+  - gmarek
 labels:
 - sig/scalability

--- a/cluster/kubemark/OWNERS
+++ b/cluster/kubemark/OWNERS
@@ -1,14 +1,14 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 reviewers:
-  - gmarek
   - shyamjvs
   - sig-scalability-reviewers
   - wojtek-t
 approvers:
-  - gmarek
   - shyamjvs
   - sig-scalability-approvers
   - wojtek-t
+emeritus_approvers:
+  - gmarek
 labels:
 - sig/scalability


### PR DESCRIPTION
ref: https://github.com/kubernetes/org/issues/2456

As a part of cleaning up inactive members (those with no activity within the past 18 months) from OWNERS files, this PR moves gmarek and jingax10 to emeritus_approver in any OWNERS file within the `cluster/` directory.

/kind cleanup
/assign @dims @BenTheElder 
For root cluster/* approval

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
