### PR TITLE
cmd/kube-apiserver: Remove inactive members from OWNERS

### DIFF
--- a/cmd/kube-apiserver/OWNERS
+++ b/cmd/kube-apiserver/OWNERS
@@ -6,7 +6,6 @@ approvers:
 - lavalamp
 - liggitt
 - mml
-- nikhiljindal
 - smarterclayton
 - sttts
 reviewers:
@@ -19,12 +18,13 @@ reviewers:
 - caesarxuchao
 - mikedanese
 - liggitt
-- nikhiljindal
 - ncdc
 - sttts
 - hzxuzhonghu
 - logicalhan
 - yue9944882
+emeritus_approvers:
+- nikhiljindal
 labels:
 - sig/api-machinery
 - area/apiserver


### PR DESCRIPTION
ref: https://github.com/kubernetes/org/issues/2456

As a part of cleaning up inactive members (those with no activity within
the past 18 months) from OWNERS files, this commit moves nikhiljindal
from an approver to an emeritus_approver.

/kind cleanup


#### Does this PR introduce a user-facing change?

```release-note
NONE
```
