### PR TITLE
cmd/kube-controller-manager: Remove inactive members from OWNERS

### DIFF
--- a/cmd/kube-controller-manager/OWNERS
+++ b/cmd/kube-controller-manager/OWNERS
@@ -18,7 +18,6 @@ reviewers:
 - erictune
 - errordeveloper
 - feiskyer
-- gmarek
 - humblec
 - ingvagabund
 - janetkuo
@@ -30,11 +29,9 @@ reviewers:
 - lavalamp
 - liggitt
 - luxas
-- madhusudancs
 - mikedanese
 - mml
 - mwielgus
-- nikhiljindal
 - ping035627
 - piosz
 - pmorie


### PR DESCRIPTION
ref: https://github.com/kubernetes/org/issues/2456

As a part of cleaning up inactive members (those with no activity within
the past 18 months) from OWNERS files, this commit removes gmarek,
madhusudancs, and nikhiljindal from reviewers.

/kind cleanup


#### Does this PR introduce a user-facing change?

```release-note
NONE
```
