### PR TITLE
cmd/kubemark: Remove inactive members from OWNERS

### DIFF
--- a/cmd/kubemark/OWNERS
+++ b/cmd/kubemark/OWNERS
@@ -1,12 +1,12 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 reviewers:
-  - gmarek
   - shyamjvs
   - sig-scalability-reviewers
   - wojtek-t
 approvers:
-  - gmarek
   - shyamjvs
   - sig-scalability-approvers
   - wojtek-t
+emeritus_approvers:
+  - gmarek


### PR DESCRIPTION
ref: https://github.com/kubernetes/org/issues/2456

As a part of cleaning up inactive members (those with no activity within
the past 18 months) from OWNERS files, this commit moves gmarek from an
approver to an emeritus_approver.

/kind cleanup


#### Does this PR introduce a user-facing change?

```release-note
NONE
```
