### PR TITLE
Fix conformance metadata release 1.20

### DIFF
--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -2033,10 +2033,9 @@
 - testname: Scheduling, HostPort matching and HostIP and Protocol not-matching
   codename: '[sig-scheduling] SchedulerPredicates [Serial] validates that there is
     no conflict between pods with same hostPort but different hostIP and protocol
-    [LinuxOnly] [Conformance]'
+    [Conformance]'
   description: Pods with the same HostPort value MUST be able to be scheduled to the
-    same node if the HostIP or Protocol is different. This test is marked LinuxOnly
-    since hostNetwork is not supported on Windows.
+    same node if the HostIP or Protocol is different.
   release: v1.16
   file: test/e2e/scheduling/predicates.go
 - testname: Pod preemption verification

--- a/test/e2e/scheduling/predicates.go
+++ b/test/e2e/scheduling/predicates.go
@@ -657,14 +657,9 @@ var _ = SIGDescribe("SchedulerPredicates [Serial]", func() {
 		Release: v1.16
 		Testname: Scheduling, HostPort matching and HostIP and Protocol not-matching
 		Description: Pods with the same HostPort value MUST be able to be scheduled to the same node
-		if the HostIP or Protocol is different. This test is marked LinuxOnly since hostNetwork is not supported on
-		Windows.
+		if the HostIP or Protocol is different.
 	*/
-
-	// TODO: Add a new e2e test to scheduler which validates if hostPort is working and move this test to e2e/network
-	//		 so that appropriate team owns the e2e.
-	//		 xref: https://github.com/kubernetes/kubernetes/issues/98075.
-	framework.ConformanceIt("validates that there is no conflict between pods with same hostPort but different hostIP and protocol [LinuxOnly]", func() {
+	framework.ConformanceIt("validates that there is no conflict between pods with same hostPort but different hostIP and protocol", func() {
 
 		nodeName := GetNodeThatCanRunPod(f)
 		localhost := "127.0.0.1"


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
#98940 addressed a SIG-Scheduling conformance test that was relocated to SIG-Network by tagging those changes to be part of the 1.21 release. This PR reverts changes made to the 1.20 release conformance metadata which is causing k8s-conformance tests to fail at the moment.


#### Which issue(s) this PR fixes:
- https://github.com/cncf/k8s-conformance/pull/1310
- https://github.com/cncf/k8s-conformance/pull/1316

#### Special notes for your reviewer:

```
NONE
```

#### Does this PR introduce a user-facing change?

```
Reverting a metadata change that causes failures in tools that test for Kubernetes conformance.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```
NONE
```
