### PR TITLE
correct typo in kubeadm init phase command

### DIFF
--- a/cmd/kubeadm/app/cmd/phases/init/addons.go
+++ b/cmd/kubeadm/app/cmd/phases/init/addons.go
@@ -43,7 +43,7 @@ var (
 func NewAddonPhase() workflow.Phase {
 	return workflow.Phase{
 		Name:  "addon",
-		Short: "Install required addons for passing Conformance tests",
+		Short: "Install required addons for passing conformance tests",
 		Long:  cmdutil.MacroCommandLongDescription,
 		Phases: []workflow.Phase{
 			{


### PR DESCRIPTION


#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

It should be ''conformance tests"  instead of "Conformance tests"

```
...

Available Commands:
  addon              Install required addons for passing Conformance tests
  ...

Use "kubeadm init phase [command] --help" for more information about a comman
```

#### What type of PR is this?

/kind cleanup

#### Does this PR introduce a user-facing change?

```release-note

```

