### PR TITLE
API Machinery: Add equal func for Requirement struct

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/labels/BUILD
+++ b/staging/src/k8s.io/apimachinery/pkg/labels/BUILD
@@ -37,6 +37,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/validation:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/validation/field:go_default_library",
+        "//vendor/github.com/google/go-cmp/cmp:go_default_library",
         "//vendor/k8s.io/klog/v2:go_default_library",
     ],
 )

--- a/staging/src/k8s.io/apimachinery/pkg/labels/selector.go
+++ b/staging/src/k8s.io/apimachinery/pkg/labels/selector.go
@@ -22,6 +22,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/google/go-cmp/cmp"
 	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation"
@@ -274,6 +275,17 @@ func (r *Requirement) Values() sets.String {
 		ret.Insert(r.strValues[i])
 	}
 	return ret
+}
+
+// Equal checks the equality of requirement.
+func (r Requirement) Equal(x Requirement) bool {
+	if r.key != x.key {
+		return false
+	}
+	if r.operator != x.operator {
+		return false
+	}
+	return cmp.Equal(r.strValues, x.strValues)
 }
 
 // Empty returns true if the internalSelector doesn't restrict selection space

--- a/staging/src/k8s.io/apimachinery/pkg/labels/selector_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/labels/selector_test.go
@@ -904,7 +904,7 @@ func TestValidatedSelectorFromSet(t *testing.T) {
 			t.Errorf("ValidatedSelectorFromSet %#v returned unexpected error (-want,+got):\n%s", tc.name, diff)
 		}
 		if err == nil {
-			if diff := cmp.Diff(tc.expectedSelector, selector, cmp.AllowUnexported(Requirement{})); diff != "" {
+			if diff := cmp.Diff(tc.expectedSelector, selector); diff != "" {
 				t.Errorf("ValidatedSelectorFromSet %#v returned unexpected selector (-want,+got):\n%s", tc.name, diff)
 			}
 		}
@@ -926,5 +926,77 @@ func BenchmarkRequirementString(b *testing.B) {
 		if r.String() != "environment notin (dev)" {
 			b.Errorf("Unexpected Requirement string")
 		}
+	}
+}
+
+func TestRequirementEqual(t *testing.T) {
+	tests := []struct {
+		name string
+		x, y *Requirement
+		want bool
+	}{
+		{
+			name: "same requirements should be equal",
+			x: &Requirement{
+				key:       "key",
+				operator:  selection.Equals,
+				strValues: []string{"foo", "bar"},
+			},
+			y: &Requirement{
+				key:       "key",
+				operator:  selection.Equals,
+				strValues: []string{"foo", "bar"},
+			},
+			want: true,
+		},
+		{
+			name: "requirements with different keys should not be equal",
+			x: &Requirement{
+				key:       "key1",
+				operator:  selection.Equals,
+				strValues: []string{"foo", "bar"},
+			},
+			y: &Requirement{
+				key:       "key2",
+				operator:  selection.Equals,
+				strValues: []string{"foo", "bar"},
+			},
+			want: false,
+		},
+		{
+			name: "requirements with different operators should not be equal",
+			x: &Requirement{
+				key:       "key",
+				operator:  selection.Equals,
+				strValues: []string{"foo", "bar"},
+			},
+			y: &Requirement{
+				key:       "key",
+				operator:  selection.In,
+				strValues: []string{"foo", "bar"},
+			},
+			want: false,
+		},
+		{
+			name: "requirements with different values should not be equal",
+			x: &Requirement{
+				key:       "key",
+				operator:  selection.Equals,
+				strValues: []string{"foo", "bar"},
+			},
+			y: &Requirement{
+				key:       "key",
+				operator:  selection.Equals,
+				strValues: []string{"foobar"},
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := cmp.Equal(tt.x, tt.y); got != tt.want {
+				t.Errorf("cmp.Equal() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Add Equal func for `Requirement` struct. This is useful when we need compare `Requirement` and `Selector` with cmp lib.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Xref #94696

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
none
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
