### PR TITLE
Scheduler: Use PodInfo instead of Pod for nominatedPods and QueuedPodInfo

### DIFF
--- a/pkg/scheduler/core/generic_scheduler_test.go
+++ b/pkg/scheduler/core/generic_scheduler_test.go
@@ -1173,7 +1173,7 @@ func TestFindFitPredicateCallCounts(t *testing.T) {
 			if err := scheduler.cache.UpdateSnapshot(scheduler.nodeInfoSnapshot); err != nil {
 				t.Fatal(err)
 			}
-			fwk.PreemptHandle().AddNominatedPod(&v1.Pod{ObjectMeta: metav1.ObjectMeta{UID: "nominated"}, Spec: v1.PodSpec{Priority: &midPriority}}, "1")
+			fwk.PreemptHandle().AddNominatedPod(framework.NewPodInfo(&v1.Pod{ObjectMeta: metav1.ObjectMeta{UID: "nominated"}, Spec: v1.PodSpec{Priority: &midPriority}}), "1")
 
 			_, _, err = scheduler.findNodesThatFitPod(context.Background(), fwk, framework.NewCycleState(), test.pod)
 

--- a/pkg/scheduler/factory.go
+++ b/pkg/scheduler/factory.go
@@ -352,7 +352,7 @@ func MakeDefaultErrorFunc(client clientset.Interface, podLister corelisters.PodL
 		}
 
 		// As <cachedPod> is from SharedInformer, we need to do a DeepCopy() here.
-		podInfo.Pod = cachedPod.DeepCopy()
+		podInfo.PodInfo = framework.NewPodInfo(cachedPod.DeepCopy())
 		if err := podQueue.AddUnschedulableIfNotPresent(podInfo, podQueue.SchedulingCycle()); err != nil {
 			klog.ErrorS(err, "Error occurred")
 		}

--- a/pkg/scheduler/factory_test.go
+++ b/pkg/scheduler/factory_test.go
@@ -467,7 +467,7 @@ func TestDefaultErrorFunc(t *testing.T) {
 				queue.Delete(testPod)
 			}
 
-			testPodInfo := &framework.QueuedPodInfo{Pod: testPod}
+			testPodInfo := &framework.QueuedPodInfo{PodInfo: framework.NewPodInfo(testPod)}
 			errFunc := MakeDefaultErrorFunc(client, podInformer.Lister(), queue, schedulerCache)
 			errFunc(testPodInfo, tt.injectErr)
 
@@ -538,7 +538,7 @@ func TestDefaultErrorFunc_NodeNotFound(t *testing.T) {
 				}
 			}
 
-			testPodInfo := &framework.QueuedPodInfo{Pod: testPod}
+			testPodInfo := &framework.QueuedPodInfo{PodInfo: framework.NewPodInfo(testPod)}
 			errFunc := MakeDefaultErrorFunc(client, podInformer.Lister(), queue, schedulerCache)
 			errFunc(testPodInfo, tt.injectErr)
 
@@ -573,7 +573,7 @@ func TestDefaultErrorFunc_PodAlreadyBound(t *testing.T) {
 	// Add node to schedulerCache no matter it's deleted in API server or not.
 	schedulerCache.AddNode(&nodeFoo)
 
-	testPodInfo := &framework.QueuedPodInfo{Pod: testPod}
+	testPodInfo := &framework.QueuedPodInfo{PodInfo: framework.NewPodInfo(testPod)}
 	errFunc := MakeDefaultErrorFunc(client, podInformer.Lister(), queue, schedulerCache)
 	errFunc(testPodInfo, fmt.Errorf("binding rejected: timeout"))
 

--- a/pkg/scheduler/framework/interface.go
+++ b/pkg/scheduler/framework/interface.go
@@ -604,13 +604,13 @@ type PreemptHandle interface {
 type PodNominator interface {
 	// AddNominatedPod adds the given pod to the nominated pod map or
 	// updates it if it already exists.
-	AddNominatedPod(pod *v1.Pod, nodeName string)
+	AddNominatedPod(pod *PodInfo, nodeName string)
 	// DeleteNominatedPodIfExists deletes nominatedPod from internal cache. It's a no-op if it doesn't exist.
 	DeleteNominatedPodIfExists(pod *v1.Pod)
 	// UpdateNominatedPod updates the <oldPod> with <newPod>.
-	UpdateNominatedPod(oldPod, newPod *v1.Pod)
+	UpdateNominatedPod(oldPod *v1.Pod, newPodInfo *PodInfo)
 	// NominatedPodsForNode returns nominatedPods on the given node.
-	NominatedPodsForNode(nodeName string) []*v1.Pod
+	NominatedPodsForNode(nodeName string) []*PodInfo
 }
 
 // PluginsRunner abstracts operations to run some plugins.

--- a/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption.go
+++ b/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption.go
@@ -733,17 +733,17 @@ func PrepareCandidate(c Candidate, fh framework.Handle, cs kubernetes.Interface,
 // worth the complexity, especially because we generally expect to have a very
 // small number of nominated pods per node.
 func getLowerPriorityNominatedPods(pn framework.PodNominator, pod *v1.Pod, nodeName string) []*v1.Pod {
-	pods := pn.NominatedPodsForNode(nodeName)
+	podInfos := pn.NominatedPodsForNode(nodeName)
 
-	if len(pods) == 0 {
+	if len(podInfos) == 0 {
 		return nil
 	}
 
 	var lowerPriorityPods []*v1.Pod
 	podPriority := corev1helpers.PodPriority(pod)
-	for _, p := range pods {
-		if corev1helpers.PodPriority(p) < podPriority {
-			lowerPriorityPods = append(lowerPriorityPods, p)
+	for _, pi := range podInfos {
+		if corev1helpers.PodPriority(pi.Pod) < podPriority {
+			lowerPriorityPods = append(lowerPriorityPods, pi.Pod)
 		}
 	}
 	return lowerPriorityPods

--- a/pkg/scheduler/framework/plugins/queuesort/priority_sort_test.go
+++ b/pkg/scheduler/framework/plugins/queuesort/priority_sort_test.go
@@ -37,55 +37,55 @@ func TestLess(t *testing.T) {
 		{
 			name: "p1.priority less than p2.priority",
 			p1: &framework.QueuedPodInfo{
-				Pod: &v1.Pod{
+				PodInfo: framework.NewPodInfo(&v1.Pod{
 					Spec: v1.PodSpec{
 						Priority: &lowPriority,
 					},
-				},
+				}),
 			},
 			p2: &framework.QueuedPodInfo{
-				Pod: &v1.Pod{
+				PodInfo: framework.NewPodInfo(&v1.Pod{
 					Spec: v1.PodSpec{
 						Priority: &highPriority,
 					},
-				},
+				}),
 			},
 			expected: false, // p2 should be ahead of p1 in the queue
 		},
 		{
 			name: "p1.priority greater than p2.priority",
 			p1: &framework.QueuedPodInfo{
-				Pod: &v1.Pod{
+				PodInfo: framework.NewPodInfo(&v1.Pod{
 					Spec: v1.PodSpec{
 						Priority: &highPriority,
 					},
-				},
+				}),
 			},
 			p2: &framework.QueuedPodInfo{
-				Pod: &v1.Pod{
+				PodInfo: framework.NewPodInfo(&v1.Pod{
 					Spec: v1.PodSpec{
 						Priority: &lowPriority,
 					},
-				},
+				}),
 			},
 			expected: true, // p1 should be ahead of p2 in the queue
 		},
 		{
 			name: "equal priority. p1 is added to schedulingQ earlier than p2",
 			p1: &framework.QueuedPodInfo{
-				Pod: &v1.Pod{
+				PodInfo: framework.NewPodInfo(&v1.Pod{
 					Spec: v1.PodSpec{
 						Priority: &highPriority,
 					},
-				},
+				}),
 				Timestamp: t1,
 			},
 			p2: &framework.QueuedPodInfo{
-				Pod: &v1.Pod{
+				PodInfo: framework.NewPodInfo(&v1.Pod{
 					Spec: v1.PodSpec{
 						Priority: &highPriority,
 					},
-				},
+				}),
 				Timestamp: t2,
 			},
 			expected: true, // p1 should be ahead of p2 in the queue
@@ -93,19 +93,19 @@ func TestLess(t *testing.T) {
 		{
 			name: "equal priority. p2 is added to schedulingQ earlier than p1",
 			p1: &framework.QueuedPodInfo{
-				Pod: &v1.Pod{
+				PodInfo: framework.NewPodInfo(&v1.Pod{
 					Spec: v1.PodSpec{
 						Priority: &highPriority,
 					},
-				},
+				}),
 				Timestamp: t2,
 			},
 			p2: &framework.QueuedPodInfo{
-				Pod: &v1.Pod{
+				PodInfo: framework.NewPodInfo(&v1.Pod{
 					Spec: v1.PodSpec{
 						Priority: &highPriority,
 					},
-				},
+				}),
 				Timestamp: t1,
 			},
 			expected: false, // p2 should be ahead of p1 in the queue

--- a/pkg/scheduler/framework/runtime/framework.go
+++ b/pkg/scheduler/framework/runtime/framework.go
@@ -657,18 +657,17 @@ func addNominatedPods(ctx context.Context, ph framework.PreemptHandle, pod *v1.P
 		// This may happen only in tests.
 		return false, state, nodeInfo, nil
 	}
-	nominatedPods := ph.NominatedPodsForNode(nodeInfo.Node().Name)
-	if len(nominatedPods) == 0 {
+	nominatedPodInfos := ph.NominatedPodsForNode(nodeInfo.Node().Name)
+	if len(nominatedPodInfos) == 0 {
 		return false, state, nodeInfo, nil
 	}
 	nodeInfoOut := nodeInfo.Clone()
 	stateOut := state.Clone()
 	podsAdded := false
-	for _, p := range nominatedPods {
-		if corev1.PodPriority(p) >= corev1.PodPriority(pod) && p.UID != pod.UID {
-			podInfoToAdd := framework.NewPodInfo(p)
-			nodeInfoOut.AddPodInfo(podInfoToAdd)
-			status := ph.RunPreFilterExtensionAddPod(ctx, stateOut, pod, podInfoToAdd, nodeInfoOut)
+	for _, pi := range nominatedPodInfos {
+		if corev1.PodPriority(pi.Pod) >= corev1.PodPriority(pod) && pi.Pod.UID != pod.UID {
+			nodeInfoOut.AddPodInfo(pi)
+			status := ph.RunPreFilterExtensionAddPod(ctx, stateOut, pod, pi, nodeInfoOut)
 			if !status.IsSuccess() {
 				return false, state, nodeInfo, status.AsError()
 			}

--- a/pkg/scheduler/framework/runtime/framework_test.go
+++ b/pkg/scheduler/framework/runtime/framework_test.go
@@ -1305,7 +1305,7 @@ func TestFilterPluginsWithNominatedPods(t *testing.T) {
 
 			podNominator := internalqueue.NewPodNominator()
 			if tt.nominatedPod != nil {
-				podNominator.AddNominatedPod(tt.nominatedPod, nodeName)
+				podNominator.AddNominatedPod(framework.NewPodInfo(tt.nominatedPod), nodeName)
 			}
 			f, err := newFrameworkWithQueueSortAndBind(registry, cfgPls, emptyArgs, WithPodNominator(podNominator))
 			if err != nil {

--- a/pkg/scheduler/framework/types.go
+++ b/pkg/scheduler/framework/types.go
@@ -44,7 +44,7 @@ var generation int64
 // the pod's status in the scheduling queue, such as the timestamp when
 // it's added to the queue.
 type QueuedPodInfo struct {
-	Pod *v1.Pod
+	*PodInfo
 	// The time pod added to the scheduling queue.
 	Timestamp time.Time
 	// Number of schedule attempts before successfully scheduled.
@@ -60,7 +60,7 @@ type QueuedPodInfo struct {
 // DeepCopy returns a deep copy of the QueuedPodInfo object.
 func (pqi *QueuedPodInfo) DeepCopy() *QueuedPodInfo {
 	return &QueuedPodInfo{
-		Pod:                     pqi.Pod.DeepCopy(),
+		PodInfo:                 pqi.PodInfo.DeepCopy(),
 		Timestamp:               pqi.Timestamp,
 		Attempts:                pqi.Attempts,
 		InitialAttemptTimestamp: pqi.InitialAttemptTimestamp,
@@ -77,6 +77,66 @@ type PodInfo struct {
 	PreferredAffinityTerms     []WeightedAffinityTerm
 	PreferredAntiAffinityTerms []WeightedAffinityTerm
 	ParseError                 error
+}
+
+// DeepCopy returns a deep copy of the PodInfo object.
+func (pi *PodInfo) DeepCopy() *PodInfo {
+	return &PodInfo{
+		Pod:                        pi.Pod.DeepCopy(),
+		RequiredAffinityTerms:      pi.RequiredAffinityTerms,
+		RequiredAntiAffinityTerms:  pi.RequiredAntiAffinityTerms,
+		PreferredAffinityTerms:     pi.PreferredAffinityTerms,
+		PreferredAntiAffinityTerms: pi.PreferredAntiAffinityTerms,
+		ParseError:                 pi.ParseError,
+	}
+}
+
+// Update creates a full new PodInfo by default. And only updates the pod when the PodInfo
+// has been instantiated and the passed pod is the exact same one as the original pod.
+func (pi *PodInfo) Update(pod *v1.Pod) {
+	if pod != nil && pi.Pod != nil && pi.Pod.UID == pod.UID {
+		// PodInfo includes immutable information, and so it is safe to update the pod in place if it is
+		// the exact same pod
+		pi.Pod = pod
+		return
+	}
+	var preferredAffinityTerms []v1.WeightedPodAffinityTerm
+	var preferredAntiAffinityTerms []v1.WeightedPodAffinityTerm
+	if affinity := pod.Spec.Affinity; affinity != nil {
+		if a := affinity.PodAffinity; a != nil {
+			preferredAffinityTerms = a.PreferredDuringSchedulingIgnoredDuringExecution
+		}
+		if a := affinity.PodAntiAffinity; a != nil {
+			preferredAntiAffinityTerms = a.PreferredDuringSchedulingIgnoredDuringExecution
+		}
+	}
+
+	// Attempt to parse the affinity terms
+	var parseErrs []error
+	requiredAffinityTerms, err := getAffinityTerms(pod, schedutil.GetPodAffinityTerms(pod.Spec.Affinity))
+	if err != nil {
+		parseErrs = append(parseErrs, fmt.Errorf("requiredAffinityTerms: %w", err))
+	}
+	requiredAntiAffinityTerms, err := getAffinityTerms(pod,
+		schedutil.GetPodAntiAffinityTerms(pod.Spec.Affinity))
+	if err != nil {
+		parseErrs = append(parseErrs, fmt.Errorf("requiredAntiAffinityTerms: %w", err))
+	}
+	weightedAffinityTerms, err := getWeightedAffinityTerms(pod, preferredAffinityTerms)
+	if err != nil {
+		parseErrs = append(parseErrs, fmt.Errorf("preferredAffinityTerms: %w", err))
+	}
+	weightedAntiAffinityTerms, err := getWeightedAffinityTerms(pod, preferredAntiAffinityTerms)
+	if err != nil {
+		parseErrs = append(parseErrs, fmt.Errorf("preferredAntiAffinityTerms: %w", err))
+	}
+
+	pi.Pod = pod
+	pi.RequiredAffinityTerms = requiredAffinityTerms
+	pi.RequiredAntiAffinityTerms = requiredAntiAffinityTerms
+	pi.PreferredAffinityTerms = weightedAffinityTerms
+	pi.PreferredAntiAffinityTerms = weightedAntiAffinityTerms
+	pi.ParseError = utilerrors.NewAggregate(parseErrs)
 }
 
 // AffinityTerm is a processed version of v1.PodAffinityTerm.
@@ -177,46 +237,11 @@ func getWeightedAffinityTerms(pod *v1.Pod, v1Terms []v1.WeightedPodAffinityTerm)
 	return terms, nil
 }
 
-// NewPodInfo return a new PodInfo
+// NewPodInfo returns a new PodInfo.
 func NewPodInfo(pod *v1.Pod) *PodInfo {
-	var preferredAffinityTerms []v1.WeightedPodAffinityTerm
-	var preferredAntiAffinityTerms []v1.WeightedPodAffinityTerm
-	if affinity := pod.Spec.Affinity; affinity != nil {
-		if a := affinity.PodAffinity; a != nil {
-			preferredAffinityTerms = a.PreferredDuringSchedulingIgnoredDuringExecution
-		}
-		if a := affinity.PodAntiAffinity; a != nil {
-			preferredAntiAffinityTerms = a.PreferredDuringSchedulingIgnoredDuringExecution
-		}
-	}
-
-	// Attempt to parse the affinity terms
-	var parseErrs []error
-	requiredAffinityTerms, err := getAffinityTerms(pod, schedutil.GetPodAffinityTerms(pod.Spec.Affinity))
-	if err != nil {
-		parseErrs = append(parseErrs, fmt.Errorf("requiredAffinityTerms: %w", err))
-	}
-	requiredAntiAffinityTerms, err := getAffinityTerms(pod, schedutil.GetPodAntiAffinityTerms(pod.Spec.Affinity))
-	if err != nil {
-		parseErrs = append(parseErrs, fmt.Errorf("requiredAntiAffinityTerms: %w", err))
-	}
-	weightedAffinityTerms, err := getWeightedAffinityTerms(pod, preferredAffinityTerms)
-	if err != nil {
-		parseErrs = append(parseErrs, fmt.Errorf("preferredAffinityTerms: %w", err))
-	}
-	weightedAntiAffinityTerms, err := getWeightedAffinityTerms(pod, preferredAntiAffinityTerms)
-	if err != nil {
-		parseErrs = append(parseErrs, fmt.Errorf("preferredAntiAffinityTerms: %w", err))
-	}
-
-	return &PodInfo{
-		Pod:                        pod,
-		RequiredAffinityTerms:      requiredAffinityTerms,
-		RequiredAntiAffinityTerms:  requiredAntiAffinityTerms,
-		PreferredAffinityTerms:     weightedAffinityTerms,
-		PreferredAntiAffinityTerms: weightedAntiAffinityTerms,
-		ParseError:                 utilerrors.NewAggregate(parseErrs),
-	}
+	pInfo := &PodInfo{}
+	pInfo.Update(pod)
+	return pInfo
 }
 
 // ImageStateSummary provides summarized information about the state of an image.

--- a/pkg/scheduler/internal/cache/debugger/dumper.go
+++ b/pkg/scheduler/internal/cache/debugger/dumper.go
@@ -70,11 +70,11 @@ func (d *CacheDumper) printNodeInfo(name string, n *framework.NodeInfo) string {
 		nodeData.WriteString(printPod(p.Pod))
 	}
 	// Dumping nominated pods info on the node
-	nominatedPods := d.podQueue.NominatedPodsForNode(name)
-	if len(nominatedPods) != 0 {
-		nodeData.WriteString(fmt.Sprintf("Nominated Pods(number: %v):\n", len(nominatedPods)))
-		for _, p := range nominatedPods {
-			nodeData.WriteString(printPod(p))
+	nominatedPodInfos := d.podQueue.NominatedPodsForNode(name)
+	if len(nominatedPodInfos) != 0 {
+		nodeData.WriteString(fmt.Sprintf("Nominated Pods(number: %v):\n", len(nominatedPodInfos)))
+		for _, pi := range nominatedPodInfos {
+			nodeData.WriteString(printPod(pi.Pod))
 		}
 	}
 	return nodeData.String()

--- a/pkg/scheduler/internal/queue/scheduling_queue.go
+++ b/pkg/scheduler/internal/queue/scheduling_queue.go
@@ -194,10 +194,12 @@ var defaultPriorityQueueOptions = priorityQueueOptions{
 // Making sure that PriorityQueue implements SchedulingQueue.
 var _ SchedulingQueue = &PriorityQueue{}
 
-// newQueuedPodInfoNoTimestamp builds a QueuedPodInfo object without timestamp.
-func newQueuedPodInfoNoTimestamp(pod *v1.Pod) *framework.QueuedPodInfo {
+// newQueuedPodInfoForLookup builds a QueuedPodInfo object for a lookup in the queue.
+func newQueuedPodInfoForLookup(pod *v1.Pod) *framework.QueuedPodInfo {
+	// Since this is only used for a lookup in the queue, we only need to set the Pod,
+	// and so we avoid creating a full PodInfo, which is expensive to instantiate frequently.
 	return &framework.QueuedPodInfo{
-		Pod: pod,
+		PodInfo: &framework.PodInfo{Pod: pod},
 	}
 }
 
@@ -262,7 +264,7 @@ func (p *PriorityQueue) Add(pod *v1.Pod) error {
 		klog.ErrorS(nil, "Error: pod is already in the podBackoff queue", "pod", klog.KObj(pod))
 	}
 	metrics.SchedulerQueueIncomingPods.WithLabelValues("active", PodAdd).Inc()
-	p.PodNominator.AddNominatedPod(pod, "")
+	p.PodNominator.AddNominatedPod(pInfo.PodInfo, "")
 	p.cond.Broadcast()
 
 	return nil
@@ -316,7 +318,7 @@ func (p *PriorityQueue) AddUnschedulableIfNotPresent(pInfo *framework.QueuedPodI
 		metrics.SchedulerQueueIncomingPods.WithLabelValues("unschedulable", ScheduleAttemptFailure).Inc()
 	}
 
-	p.PodNominator.AddNominatedPod(pod, "")
+	p.PodNominator.AddNominatedPod(pInfo.PodInfo, "")
 	return nil
 }
 
@@ -412,48 +414,53 @@ func (p *PriorityQueue) Update(oldPod, newPod *v1.Pod) error {
 	defer p.lock.Unlock()
 
 	if oldPod != nil {
-		oldPodInfo := newQueuedPodInfoNoTimestamp(oldPod)
+		oldPodInfo := newQueuedPodInfoForLookup(oldPod)
 		// If the pod is already in the active queue, just update it there.
 		if oldPodInfo, exists, _ := p.activeQ.Get(oldPodInfo); exists {
-			p.PodNominator.UpdateNominatedPod(oldPod, newPod)
-			err := p.activeQ.Update(updatePod(oldPodInfo, newPod))
-			return err
+			pInfo := updatePod(oldPodInfo, newPod)
+			p.PodNominator.UpdateNominatedPod(oldPod, pInfo.PodInfo)
+			return p.activeQ.Update(pInfo)
 		}
 
 		// If the pod is in the backoff queue, update it there.
 		if oldPodInfo, exists, _ := p.podBackoffQ.Get(oldPodInfo); exists {
-			p.PodNominator.UpdateNominatedPod(oldPod, newPod)
+			pInfo := updatePod(oldPodInfo, newPod)
+			p.PodNominator.UpdateNominatedPod(oldPod, pInfo.PodInfo)
 			p.podBackoffQ.Delete(oldPodInfo)
-			err := p.activeQ.Add(updatePod(oldPodInfo, newPod))
-			if err == nil {
-				p.cond.Broadcast()
+			if err := p.activeQ.Add(pInfo); err != nil {
+				return err
 			}
-			return err
+			p.cond.Broadcast()
+			return nil
 		}
 	}
 
 	// If the pod is in the unschedulable queue, updating it may make it schedulable.
 	if usPodInfo := p.unschedulableQ.get(newPod); usPodInfo != nil {
-		p.PodNominator.UpdateNominatedPod(oldPod, newPod)
 		if isPodUpdated(oldPod, newPod) {
 			p.unschedulableQ.delete(usPodInfo.Pod)
-			err := p.activeQ.Add(updatePod(usPodInfo, newPod))
-			if err == nil {
-				p.cond.Broadcast()
+			pInfo := updatePod(usPodInfo, newPod)
+			p.PodNominator.UpdateNominatedPod(oldPod, pInfo.PodInfo)
+			if err := p.activeQ.Add(pInfo); err != nil {
+				return err
 			}
-			return err
+			p.cond.Broadcast()
+			return nil
 		}
-		// Pod is already in unschedulable queue and hasnt updated, no need to backoff again
-		p.unschedulableQ.addOrUpdate(updatePod(usPodInfo, newPod))
+		pInfo := updatePod(usPodInfo, newPod)
+		p.PodNominator.UpdateNominatedPod(oldPod, pInfo.PodInfo)
+		// Pod is already in unschedulable queue and hasn't updated, no need to backoff again
+		p.unschedulableQ.addOrUpdate(pInfo)
 		return nil
 	}
 	// If pod is not in any of the queues, we put it in the active queue.
-	err := p.activeQ.Add(p.newQueuedPodInfo(newPod))
-	if err == nil {
-		p.PodNominator.AddNominatedPod(newPod, "")
-		p.cond.Broadcast()
+	pInfo := p.newQueuedPodInfo(newPod)
+	if err := p.activeQ.Add(pInfo); err != nil {
+		return err
 	}
-	return err
+	p.PodNominator.AddNominatedPod(pInfo.PodInfo, "")
+	p.cond.Broadcast()
+	return nil
 }
 
 // Delete deletes the item from either of the two queues. It assumes the pod is
@@ -462,9 +469,9 @@ func (p *PriorityQueue) Delete(pod *v1.Pod) error {
 	p.lock.Lock()
 	defer p.lock.Unlock()
 	p.PodNominator.DeleteNominatedPodIfExists(pod)
-	err := p.activeQ.Delete(newQueuedPodInfoNoTimestamp(pod))
-	if err != nil { // The item was probably not found in the activeQ.
-		p.podBackoffQ.Delete(newQueuedPodInfoNoTimestamp(pod))
+	if err := p.activeQ.Delete(newQueuedPodInfoForLookup(pod)); err != nil {
+		// The item was probably not found in the activeQ.
+		p.podBackoffQ.Delete(newQueuedPodInfoForLookup(pod))
 		p.unschedulableQ.delete(pod)
 	}
 	return nil
@@ -586,15 +593,15 @@ func (npm *nominatedPodMap) DeleteNominatedPodIfExists(pod *v1.Pod) {
 // This is called during the preemption process after a node is nominated to run
 // the pod. We update the structure before sending a request to update the pod
 // object to avoid races with the following scheduling cycles.
-func (npm *nominatedPodMap) AddNominatedPod(pod *v1.Pod, nodeName string) {
+func (npm *nominatedPodMap) AddNominatedPod(pi *framework.PodInfo, nodeName string) {
 	npm.Lock()
-	npm.add(pod, nodeName)
+	npm.add(pi, nodeName)
 	npm.Unlock()
 }
 
 // NominatedPodsForNode returns pods that are nominated to run on the given node,
 // but they are waiting for other pods to be removed from the node.
-func (npm *nominatedPodMap) NominatedPodsForNode(nodeName string) []*v1.Pod {
+func (npm *nominatedPodMap) NominatedPodsForNode(nodeName string) []*framework.PodInfo {
 	npm.RLock()
 	defer npm.RUnlock()
 	// TODO: we may need to return a copy of []*Pods to avoid modification
@@ -621,7 +628,7 @@ func (p *PriorityQueue) NumUnschedulablePods() int {
 func (p *PriorityQueue) newQueuedPodInfo(pod *v1.Pod) *framework.QueuedPodInfo {
 	now := p.clock.Now()
 	return &framework.QueuedPodInfo{
-		Pod:                     pod,
+		PodInfo:                 framework.NewPodInfo(pod),
 		Timestamp:               now,
 		InitialAttemptTimestamp: now,
 	}
@@ -649,7 +656,7 @@ func (p *PriorityQueue) calculateBackoffDuration(podInfo *framework.QueuedPodInf
 
 func updatePod(oldPodInfo interface{}, newPod *v1.Pod) *framework.QueuedPodInfo {
 	pInfo := oldPodInfo.(*framework.QueuedPodInfo)
-	pInfo.Pod = newPod
+	pInfo.Update(newPod)
 	return pInfo
 }
 
@@ -717,7 +724,7 @@ type nominatedPodMap struct {
 	// nominatedPods is a map keyed by a node name and the value is a list of
 	// pods which are nominated to run on the node. These are pods which can be in
 	// the activeQ or unschedulableQ.
-	nominatedPods map[string][]*v1.Pod
+	nominatedPods map[string][]*framework.PodInfo
 	// nominatedPodToNode is map keyed by a Pod UID to the node name where it is
 	// nominated.
 	nominatedPodToNode map[ktypes.UID]string
@@ -725,26 +732,26 @@ type nominatedPodMap struct {
 	sync.RWMutex
 }
 
-func (npm *nominatedPodMap) add(p *v1.Pod, nodeName string) {
+func (npm *nominatedPodMap) add(pi *framework.PodInfo, nodeName string) {
 	// always delete the pod if it already exist, to ensure we never store more than
 	// one instance of the pod.
-	npm.delete(p)
+	npm.delete(pi.Pod)
 
 	nnn := nodeName
 	if len(nnn) == 0 {
-		nnn = NominatedNodeName(p)
+		nnn = NominatedNodeName(pi.Pod)
 		if len(nnn) == 0 {
 			return
 		}
 	}
-	npm.nominatedPodToNode[p.UID] = nnn
-	for _, np := range npm.nominatedPods[nnn] {
-		if np.UID == p.UID {
-			klog.V(4).InfoS("Pod already exists in the nominated map", "pod", klog.KObj(p))
+	npm.nominatedPodToNode[pi.Pod.UID] = nnn
+	for _, npi := range npm.nominatedPods[nnn] {
+		if npi.Pod.UID == pi.Pod.UID {
+			klog.V(4).InfoS("Pod already exists in the nominated map", "pod", klog.KObj(npi.Pod))
 			return
 		}
 	}
-	npm.nominatedPods[nnn] = append(npm.nominatedPods[nnn], p)
+	npm.nominatedPods[nnn] = append(npm.nominatedPods[nnn], pi)
 }
 
 func (npm *nominatedPodMap) delete(p *v1.Pod) {
@@ -753,7 +760,7 @@ func (npm *nominatedPodMap) delete(p *v1.Pod) {
 		return
 	}
 	for i, np := range npm.nominatedPods[nnn] {
-		if np.UID == p.UID {
+		if np.Pod.UID == p.UID {
 			npm.nominatedPods[nnn] = append(npm.nominatedPods[nnn][:i], npm.nominatedPods[nnn][i+1:]...)
 			if len(npm.nominatedPods[nnn]) == 0 {
 				delete(npm.nominatedPods, nnn)
@@ -765,7 +772,7 @@ func (npm *nominatedPodMap) delete(p *v1.Pod) {
 }
 
 // UpdateNominatedPod updates the <oldPod> with <newPod>.
-func (npm *nominatedPodMap) UpdateNominatedPod(oldPod, newPod *v1.Pod) {
+func (npm *nominatedPodMap) UpdateNominatedPod(oldPod *v1.Pod, newPodInfo *framework.PodInfo) {
 	npm.Lock()
 	defer npm.Unlock()
 	// In some cases, an Update event with no "NominatedNode" present is received right
@@ -776,7 +783,7 @@ func (npm *nominatedPodMap) UpdateNominatedPod(oldPod, newPod *v1.Pod) {
 	// (1) NominatedNode info is added
 	// (2) NominatedNode info is updated
 	// (3) NominatedNode info is removed
-	if NominatedNodeName(oldPod) == "" && NominatedNodeName(newPod) == "" {
+	if NominatedNodeName(oldPod) == "" && NominatedNodeName(newPodInfo.Pod) == "" {
 		if nnn, ok := npm.nominatedPodToNode[oldPod.UID]; ok {
 			// This is the only case we should continue reserving the NominatedNode
 			nodeName = nnn
@@ -785,13 +792,13 @@ func (npm *nominatedPodMap) UpdateNominatedPod(oldPod, newPod *v1.Pod) {
 	// We update irrespective of the nominatedNodeName changed or not, to ensure
 	// that pod pointer is updated.
 	npm.delete(oldPod)
-	npm.add(newPod, nodeName)
+	npm.add(newPodInfo, nodeName)
 }
 
 // NewPodNominator creates a nominatedPodMap as a backing of framework.PodNominator.
 func NewPodNominator() framework.PodNominator {
 	return &nominatedPodMap{
-		nominatedPods:      make(map[string][]*v1.Pod),
+		nominatedPods:      make(map[string][]*framework.PodInfo),
 		nominatedPodToNode: make(map[ktypes.UID]string),
 	}
 }

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -325,7 +325,7 @@ func (sched *Scheduler) recordSchedulingFailure(fwk framework.Framework, podInfo
 	// and the time the scheduler receives a Pod Update for the nominated pod.
 	// Here we check for nil only for tests.
 	if sched.SchedulingQueue != nil {
-		sched.SchedulingQueue.AddNominatedPod(podInfo.Pod, nominatedNode)
+		sched.SchedulingQueue.AddNominatedPod(podInfo.PodInfo, nominatedNode)
 	}
 
 	pod := podInfo.Pod

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -357,7 +357,7 @@ func TestSchedulerScheduleOne(t *testing.T) {
 					gotError = err
 				},
 				NextPod: func() *framework.QueuedPodInfo {
-					return &framework.QueuedPodInfo{Pod: item.sendPod}
+					return &framework.QueuedPodInfo{PodInfo: framework.NewPodInfo(item.sendPod)}
 				},
 				Profiles: profile.Map{
 					testSchedulerName: fwk,
@@ -838,7 +838,7 @@ func setupTestScheduler(queuedPodStore *clientcache.FIFO, scache internalcache.C
 		SchedulerCache: scache,
 		Algorithm:      algo,
 		NextPod: func() *framework.QueuedPodInfo {
-			return &framework.QueuedPodInfo{Pod: clientcache.Pop(queuedPodStore).(*v1.Pod)}
+			return &framework.QueuedPodInfo{PodInfo: framework.NewPodInfo(clientcache.Pop(queuedPodStore).(*v1.Pod))}
 		},
 		Error: func(p *framework.QueuedPodInfo, err error) {
 			errChan <- err


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Instead of constructing podInfo when retrieving nominated pods, we can just store podInfo for `nominatedPodMap`.


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #97813

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
none
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
