### PR TITLE
Add sig-cloud-provider tag for e2e tests

### DIFF
--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -635,6 +635,11 @@ func KubeDescribe(text string, body func()) bool {
 	return ginkgo.Describe("[k8s.io] "+text, body)
 }
 
+// SIGDescribe is a wrapper function for ginkgo describe. Adds SIG namespacing.
+func SIGDescribe(sig, text string, body func()) bool {
+	return ginkgo.Describe("[sig-"+sig+"] "+text, body)
+}
+
 // ConformanceIt is wrapper function for ginkgo It.  Adds "[Conformance]" tag and makes static analysis easier.
 func ConformanceIt(text string, body interface{}, timeout ...float64) bool {
 	return ginkgo.It(text+" [Conformance]", body, timeout...)

--- a/test/e2e/gke_node_pools.go
+++ b/test/e2e/gke_node_pools.go
@@ -27,7 +27,7 @@ import (
 	"github.com/onsi/ginkgo"
 )
 
-var _ = framework.KubeDescribe("GKE node pools [Feature:GKENodePool]", func() {
+var _ = framework.SIGDescribe("cloud-provider", "GKE node pools [Feature:GKENodePool]", func() {
 
 	f := framework.NewDefaultFramework("node-pools")
 

--- a/test/e2e/node/recreate_node.go
+++ b/test/e2e/node/recreate_node.go
@@ -49,7 +49,7 @@ func nodeNames(nodes []v1.Node) []string {
 	return result
 }
 
-var _ = ginkgo.Describe("Recreate [Feature:Recreate]", func() {
+var _ = framework.SIGDescribe("cloud-provider", "Recreate [Feature:Recreate]", func() {
 	f := framework.NewDefaultFramework("recreate")
 	var originalNodes []v1.Node
 	var originalPodNames []string


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/priority important-soon

#### What this PR does / why we need it:
As part of a reliability working group effort the workstream of marking tests with SIG-identifier attribute has started. https://groups.google.com/g/kubernetes-sig-node/c/dVaNhlgT9CU/m/HXwY6slvAQAJ


#### Which issue(s) this PR fixes:
ref #98326 

#### Special notes for your reviewer:


#### Does this PR introduce a user-facing change?
```release-note
NONE
```