### PR TITLE
test/e2e: Move gke local ssd tests to e2e/storage and assign sig ownership

### DIFF
--- a/test/e2e/BUILD
+++ b/test/e2e/BUILD
@@ -51,7 +51,6 @@ go_library(
     srcs = [
         "e2e.go",
         "examples.go",
-        "gke_local_ssd.go",
         "gke_node_pools.go",
         "suites.go",
         "viperconfig.go",
@@ -64,7 +63,6 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/runtime:go_default_library",
-        "//staging/src/k8s.io/apimachinery/pkg/util/uuid:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/authentication/serviceaccount:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes:go_default_library",

--- a/test/e2e/storage/BUILD
+++ b/test/e2e/storage/BUILD
@@ -12,6 +12,7 @@ go_library(
         "flexvolume_mounted_volume_resize.go",
         "flexvolume_online_resize.go",
         "generic_persistent_volume-disruptive.go",
+        "gke_local_ssd.go",
         "host_path_type.go",
         "in_tree_volumes.go",
         "mounted_volume_resize.go",

--- a/test/e2e/storage/gke_local_ssd.go
+++ b/test/e2e/storage/gke_local_ssd.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package e2e
+package storage
 
 import (
 	"fmt"
@@ -25,11 +25,12 @@ import (
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
+	"k8s.io/kubernetes/test/e2e/storage/utils"
 
 	"github.com/onsi/ginkgo"
 )
 
-var _ = framework.KubeDescribe("GKE local SSD [Feature:GKELocalSSD]", func() {
+var _ = utils.SIGDescribe("GKE local SSD [Feature:GKELocalSSD]", func() {
 
 	f := framework.NewDefaultFramework("localssd")
 


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/priority important-soon

#### What this PR does / why we need it:
As part of a reliability working group effort the workstream of marking tests with SIG-identifier attribute has started. https://groups.google.com/g/kubernetes-sig-node/c/dVaNhlgT9CU/m/HXwY6slvAQAJ
This PR does two things:

 - Move `test/e2e/gke_local_ssd.go` to `test/e2e/storage/gke_local_ssd.go`
 - Assign sig-storage ownership to that test

#### Which issue(s) this PR fixes:
ref #98326 

#### Special notes for your reviewer:
Please take a look at #98326 discussion to re-arrange the e2e tests.
 
#### Does this PR introduce a user-facing change?
```release-note
NONE
```