### PR TITLE
Automated cherry pick of #98200: Fix dbus shutdown events not continuing if they are not valid

### DIFF
--- a/pkg/kubelet/nodeshutdown/systemd/inhibit_linux.go
+++ b/pkg/kubelet/nodeshutdown/systemd/inhibit_linux.go
@@ -142,11 +142,12 @@ func (bus *DBusCon) MonitorShutdown() (<-chan bool, error) {
 			case event := <-busChan:
 				if event == nil || len(event.Body) == 0 {
 					klog.Errorf("Failed obtaining shutdown event, PrepareForShutdown event was empty")
+					continue
 				}
 				shutdownActive, ok := event.Body[0].(bool)
 				if !ok {
 					klog.Errorf("Failed obtaining shutdown event, PrepareForShutdown event was not bool type as expected")
-					return
+					continue
 				}
 				shutdownChan <- shutdownActive
 			}


### PR DESCRIPTION
Cherry pick of #98200 on release-1.20.

#98200: Fix dbus shutdown events not continuing if they are not valid

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.