### PR TITLE
test/* Remove inactive members from OWNERS

### DIFF
--- a/test/e2e/apimachinery/OWNERS
+++ b/test/e2e/apimachinery/OWNERS
@@ -18,7 +18,6 @@ reviewers:
 - cheftako
 - mikedanese
 - liggitt
-- gmarek
 - sttts
 - ncdc
 - logicalhan

--- a/test/e2e/instrumentation/OWNERS
+++ b/test/e2e/instrumentation/OWNERS
@@ -1,11 +1,11 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-- fabxc
 - sig-instrumentation-approvers
 - x13n
 - kawych
 emeritus_approvers:
+- fabxc
 - piosz
 - fgrzadkowski
 reviewers:


### PR DESCRIPTION
ref: https://github.com/kubernetes/org/issues/2456

As a part of cleaning up inactive members (those with no activity within the past 18 months) from OWNERS files, this PR removes gmarek as a reviewer and moves fabxc to an emeritus_approver within the `test/` directory.

/kind cleanup
/assign @cblecker @neolit123
As  root level `test/` approvers 👍 

#### Does this PR introduce a user-facing change?

```release-note
NONE
```