### PR TITLE
stop using CRD v1beta1 in tests

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/apiapproval_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/apiapproval_test.go
@@ -22,8 +22,6 @@ import (
 	"time"
 
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-
-	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/apiextensions-apiserver/test/integration/fixtures"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -47,7 +45,7 @@ func TestAPIApproval(t *testing.T) {
 
 	newSigKubeAPIFn := func(resource, approvalAnnotation string) *apiextensionsv1.CustomResourceDefinition {
 		return &apiextensionsv1.CustomResourceDefinition{
-			ObjectMeta: metav1.ObjectMeta{Name: resource + ".sigs.k8s.io", Annotations: map[string]string{apiextensionsv1beta1.KubeAPIApprovedAnnotation: approvalAnnotation}},
+			ObjectMeta: metav1.ObjectMeta{Name: resource + ".sigs.k8s.io", Annotations: map[string]string{apiextensionsv1.KubeAPIApprovedAnnotation: approvalAnnotation}},
 			Spec: apiextensionsv1.CustomResourceDefinitionSpec{
 				Group: "sigs.k8s.io",
 				Versions: []apiextensionsv1.CustomResourceDefinitionVersion{

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/apiapproval_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/apiapproval_test.go
@@ -21,6 +21,8 @@ import (
 	"testing"
 	"time"
 
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/apiextensions-apiserver/test/integration/fixtures"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -34,43 +36,50 @@ func TestAPIApproval(t *testing.T) {
 	}
 	defer tearDown()
 
-	noxuDefinition := fixtures.NewNoxuCustomResourceDefinition(apiextensionsv1beta1.NamespaceScoped)
-	noxuDefinition, err = fixtures.CreateNewCustomResourceDefinition(noxuDefinition, apiExtensionClient, dynamicClient)
+	noxuDefinition := fixtures.NewNoxuV1CustomResourceDefinition(apiextensionsv1.NamespaceScoped)
+	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(noxuDefinition, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if noxuAPIApproved := findCRDCondition(noxuDefinition, apiextensionsv1beta1.KubernetesAPIApprovalPolicyConformant); noxuAPIApproved != nil {
+	if noxuAPIApproved := findCRDCondition(noxuDefinition, apiextensionsv1.KubernetesAPIApprovalPolicyConformant); noxuAPIApproved != nil {
 		t.Fatal(noxuAPIApproved)
 	}
 
-	newSigKubeAPIFn := func(resource, approvalAnnotation string) *apiextensionsv1beta1.CustomResourceDefinition {
-		return &apiextensionsv1beta1.CustomResourceDefinition{
+	newSigKubeAPIFn := func(resource, approvalAnnotation string) *apiextensionsv1.CustomResourceDefinition {
+		return &apiextensionsv1.CustomResourceDefinition{
 			ObjectMeta: metav1.ObjectMeta{Name: resource + ".sigs.k8s.io", Annotations: map[string]string{apiextensionsv1beta1.KubeAPIApprovedAnnotation: approvalAnnotation}},
-			Spec: apiextensionsv1beta1.CustomResourceDefinitionSpec{
-				Group:   "sigs.k8s.io",
-				Version: "v1beta1",
-				Names: apiextensionsv1beta1.CustomResourceDefinitionNames{
+			Spec: apiextensionsv1.CustomResourceDefinitionSpec{
+				Group: "sigs.k8s.io",
+				Versions: []apiextensionsv1.CustomResourceDefinitionVersion{
+					{
+						Name:    "v1beta1",
+						Served:  true,
+						Storage: true,
+						Schema:  fixtures.AllowAllSchema(),
+					},
+				},
+				Names: apiextensionsv1.CustomResourceDefinitionNames{
 					Plural:   resource,
 					Singular: resource + "singular",
 					Kind:     resource + "Kind",
 					ListKind: resource + "List",
 				},
-				Scope: apiextensionsv1beta1.NamespaceScoped,
+				Scope: apiextensionsv1.NamespaceScoped,
 			},
 		}
 	}
 	// the unit tests cover all variations. We just need to be sure that we see the code being called
 	approvedKubeAPI := newSigKubeAPIFn("approved", "https://github.com/kubernetes/kubernetes/pull/79724")
-	approvedKubeAPI, err = fixtures.CreateNewCustomResourceDefinition(approvedKubeAPI, apiExtensionClient, dynamicClient)
+	approvedKubeAPI, err = fixtures.CreateNewV1CustomResourceDefinition(approvedKubeAPI, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}
 	err = wait.PollImmediate(100*time.Millisecond, 30*time.Second, func() (bool, error) {
-		approvedKubeAPI, err = apiExtensionClient.ApiextensionsV1beta1().CustomResourceDefinitions().Get(context.TODO(), approvedKubeAPI.Name, metav1.GetOptions{})
+		approvedKubeAPI, err = apiExtensionClient.ApiextensionsV1().CustomResourceDefinitions().Get(context.TODO(), approvedKubeAPI.Name, metav1.GetOptions{})
 		if err != nil {
 			return false, err
 		}
-		if approvedKubeAPIApproved := findCRDCondition(approvedKubeAPI, apiextensionsv1beta1.KubernetesAPIApprovalPolicyConformant); approvedKubeAPIApproved == nil || approvedKubeAPIApproved.Status != apiextensionsv1beta1.ConditionTrue {
+		if approvedKubeAPIApproved := findCRDCondition(approvedKubeAPI, apiextensionsv1.KubernetesAPIApprovalPolicyConformant); approvedKubeAPIApproved == nil || approvedKubeAPIApproved.Status != apiextensionsv1.ConditionTrue {
 			t.Log(approvedKubeAPIApproved)
 			return false, nil
 		}

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/basic_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/basic_test.go
@@ -25,7 +25,8 @@ import (
 	"testing"
 	"time"
 
-	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+
 	"k8s.io/apiextensions-apiserver/test/integration/fixtures"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -56,8 +57,8 @@ func TestNamespaceScopedCRUD(t *testing.T) {
 	}
 	defer tearDown()
 
-	noxuDefinition := fixtures.NewNoxuCustomResourceDefinition(apiextensionsv1beta1.NamespaceScoped)
-	noxuDefinition, err = fixtures.CreateNewCustomResourceDefinition(noxuDefinition, apiExtensionClient, dynamicClient)
+	noxuDefinition := fixtures.NewNoxuV1CustomResourceDefinition(apiextensionsv1.NamespaceScoped)
+	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(noxuDefinition, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -75,8 +76,8 @@ func TestClusterScopedCRUD(t *testing.T) {
 	}
 	defer tearDown()
 
-	noxuDefinition := fixtures.NewNoxuCustomResourceDefinition(apiextensionsv1beta1.ClusterScoped)
-	noxuDefinition, err = fixtures.CreateNewCustomResourceDefinition(noxuDefinition, apiExtensionClient, dynamicClient)
+	noxuDefinition := fixtures.NewNoxuV1CustomResourceDefinition(apiextensionsv1.ClusterScoped)
+	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(noxuDefinition, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -86,7 +87,7 @@ func TestClusterScopedCRUD(t *testing.T) {
 	testFieldSelector(t, ns, noxuDefinition, dynamicClient)
 }
 
-func testSimpleCRUD(t *testing.T, ns string, noxuDefinition *apiextensionsv1beta1.CustomResourceDefinition, dynamicClient dynamic.Interface) {
+func testSimpleCRUD(t *testing.T, ns string, noxuDefinition *apiextensionsv1.CustomResourceDefinition, dynamicClient dynamic.Interface) {
 	noxuResourceClients := map[string]dynamic.ResourceInterface{}
 	noxuWatchs := map[string]watch.Interface{}
 	disabledVersions := map[string]bool{}
@@ -321,8 +322,8 @@ func TestInvalidCRUD(t *testing.T) {
 	}
 	defer tearDown()
 
-	noxuDefinition := fixtures.NewNoxuCustomResourceDefinition(apiextensionsv1beta1.ClusterScoped)
-	noxuDefinition, err = fixtures.CreateNewCustomResourceDefinition(noxuDefinition, apiExtensionClient, dynamicClient)
+	noxuDefinition := fixtures.NewNoxuV1CustomResourceDefinition(apiextensionsv1.ClusterScoped)
+	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(noxuDefinition, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -373,7 +374,7 @@ func TestInvalidCRUD(t *testing.T) {
 	}
 }
 
-func testFieldSelector(t *testing.T, ns string, noxuDefinition *apiextensionsv1beta1.CustomResourceDefinition, dynamicClient dynamic.Interface) {
+func testFieldSelector(t *testing.T, ns string, noxuDefinition *apiextensionsv1.CustomResourceDefinition, dynamicClient dynamic.Interface) {
 	noxuResourceClient := newNamespacedCustomResourceClient(ns, dynamicClient, noxuDefinition)
 	initialList, err := noxuResourceClient.List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
@@ -527,9 +528,9 @@ func TestDiscovery(t *testing.T) {
 	}
 	defer tearDown()
 
-	scope := apiextensionsv1beta1.NamespaceScoped
-	noxuDefinition := fixtures.NewNoxuCustomResourceDefinition(scope)
-	if _, err = fixtures.CreateNewCustomResourceDefinition(noxuDefinition, apiExtensionClient, dynamicClient); err != nil {
+	scope := apiextensionsv1.NamespaceScoped
+	noxuDefinition := fixtures.NewNoxuV1CustomResourceDefinition(scope)
+	if _, err = fixtures.CreateNewV1CustomResourceDefinition(noxuDefinition, apiExtensionClient, dynamicClient); err != nil {
 		t.Fatal(err)
 	}
 
@@ -574,8 +575,8 @@ func TestNoNamespaceReject(t *testing.T) {
 	}
 	defer tearDown()
 
-	noxuDefinition := fixtures.NewNoxuCustomResourceDefinition(apiextensionsv1beta1.NamespaceScoped)
-	noxuDefinition, err = fixtures.CreateNewCustomResourceDefinition(noxuDefinition, apiExtensionClient, dynamicClient)
+	noxuDefinition := fixtures.NewNoxuV1CustomResourceDefinition(apiextensionsv1.NamespaceScoped)
+	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(noxuDefinition, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -593,7 +594,7 @@ func TestNoNamespaceReject(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if e, a := noxuDefinition.Spec.Group+"/"+noxuDefinition.Spec.Version, initialListTypeMeta.GetAPIVersion(); e != a {
+	if e, a := noxuDefinition.Spec.Group+"/"+noxuDefinition.Spec.Versions[0].Name, initialListTypeMeta.GetAPIVersion(); e != a {
 		t.Errorf("expected %v, got %v", e, a)
 	}
 	if e, a := noxuDefinition.Spec.Names.ListKind, initialListTypeMeta.GetKind(); e != a {
@@ -613,8 +614,8 @@ func TestSameNameDiffNamespace(t *testing.T) {
 	}
 	defer tearDown()
 
-	noxuDefinition := fixtures.NewNoxuCustomResourceDefinition(apiextensionsv1beta1.NamespaceScoped)
-	noxuDefinition, err = fixtures.CreateNewCustomResourceDefinition(noxuDefinition, apiExtensionClient, dynamicClient)
+	noxuDefinition := fixtures.NewNoxuV1CustomResourceDefinition(apiextensionsv1.NamespaceScoped)
+	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(noxuDefinition, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -636,8 +637,8 @@ func TestSelfLink(t *testing.T) {
 	defer tearDown()
 
 	// namespace scoped
-	noxuDefinition := fixtures.NewNoxuCustomResourceDefinition(apiextensionsv1beta1.NamespaceScoped)
-	noxuDefinition, err = fixtures.CreateNewCustomResourceDefinition(noxuDefinition, apiExtensionClient, dynamicClient)
+	noxuDefinition := fixtures.NewNoxuV1CustomResourceDefinition(apiextensionsv1.NamespaceScoped)
+	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(noxuDefinition, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -656,8 +657,8 @@ func TestSelfLink(t *testing.T) {
 	}
 
 	// cluster scoped
-	curletDefinition := fixtures.NewCurletCustomResourceDefinition(apiextensionsv1beta1.ClusterScoped)
-	curletDefinition, err = fixtures.CreateNewCustomResourceDefinition(curletDefinition, apiExtensionClient, dynamicClient)
+	curletDefinition := fixtures.NewCurletV1CustomResourceDefinition(apiextensionsv1.ClusterScoped)
+	curletDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(curletDefinition, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -682,8 +683,8 @@ func TestPreserveInt(t *testing.T) {
 	}
 	defer tearDown()
 
-	noxuDefinition := fixtures.NewNoxuCustomResourceDefinition(apiextensionsv1beta1.ClusterScoped)
-	noxuDefinition, err = fixtures.CreateNewCustomResourceDefinition(noxuDefinition, apiExtensionClient, dynamicClient)
+	noxuDefinition := fixtures.NewNoxuV1CustomResourceDefinition(apiextensionsv1.ClusterScoped)
+	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(noxuDefinition, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -724,8 +725,8 @@ func TestPatch(t *testing.T) {
 	}
 	defer tearDown()
 
-	noxuDefinition := fixtures.NewNoxuCustomResourceDefinition(apiextensionsv1beta1.ClusterScoped)
-	noxuDefinition, err = fixtures.CreateNewCustomResourceDefinition(noxuDefinition, apiExtensionClient, dynamicClient)
+	noxuDefinition := fixtures.NewNoxuV1CustomResourceDefinition(apiextensionsv1.ClusterScoped)
+	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(noxuDefinition, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -802,8 +803,8 @@ func TestCrossNamespaceListWatch(t *testing.T) {
 	}
 	defer tearDown()
 
-	noxuDefinition := fixtures.NewNoxuCustomResourceDefinition(apiextensionsv1beta1.NamespaceScoped)
-	noxuDefinition, err = fixtures.CreateNewCustomResourceDefinition(noxuDefinition, apiExtensionClient, dynamicClient)
+	noxuDefinition := fixtures.NewNoxuV1CustomResourceDefinition(apiextensionsv1.NamespaceScoped)
+	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(noxuDefinition, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -881,7 +882,7 @@ func TestCrossNamespaceListWatch(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			if e, a := noxuDefinition.Spec.Group+"/"+noxuDefinition.Spec.Version, createdTypeMeta.GetAPIVersion(); e != a {
+			if e, a := noxuDefinition.Spec.Group+"/"+noxuDefinition.Spec.Versions[0].Name, createdTypeMeta.GetAPIVersion(); e != a {
 				t.Errorf("expected %v, got %v", e, a)
 			}
 			if e, a := noxuDefinition.Spec.Names.Kind, createdTypeMeta.GetKind(); e != a {
@@ -901,7 +902,7 @@ func TestCrossNamespaceListWatch(t *testing.T) {
 	checkNamespacesWatchHelper(t, ns2, noxuNamespacesWatch2)
 }
 
-func createInstanceWithNamespaceHelper(t *testing.T, ns string, name string, noxuNamespacedResourceClient dynamic.ResourceInterface, noxuDefinition *apiextensionsv1beta1.CustomResourceDefinition) *unstructured.Unstructured {
+func createInstanceWithNamespaceHelper(t *testing.T, ns string, name string, noxuNamespacedResourceClient dynamic.ResourceInterface, noxuDefinition *apiextensionsv1.CustomResourceDefinition) *unstructured.Unstructured {
 	createdInstance, err := instantiateCustomResource(t, fixtures.NewNoxuInstance(ns, name), noxuNamespacedResourceClient, noxuDefinition)
 	if err != nil {
 		t.Fatalf("unable to create noxu Instance:%v", err)
@@ -944,27 +945,27 @@ func TestNameConflict(t *testing.T) {
 	}
 	defer tearDown()
 
-	noxuDefinition := fixtures.NewNoxuCustomResourceDefinition(apiextensionsv1beta1.NamespaceScoped)
-	noxuDefinition, err = fixtures.CreateNewCustomResourceDefinition(noxuDefinition, apiExtensionClient, dynamicClient)
+	noxuDefinition := fixtures.NewNoxuV1CustomResourceDefinition(apiextensionsv1.NamespaceScoped)
+	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(noxuDefinition, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	noxu2Definition := fixtures.NewNoxu2CustomResourceDefinition(apiextensionsv1beta1.NamespaceScoped)
-	_, err = apiExtensionClient.ApiextensionsV1beta1().CustomResourceDefinitions().Create(context.TODO(), noxu2Definition, metav1.CreateOptions{})
+	noxu2Definition := fixtures.NewNoxu2CustomResourceDefinition(apiextensionsv1.NamespaceScoped)
+	_, err = apiExtensionClient.ApiextensionsV1().CustomResourceDefinitions().Create(context.TODO(), noxu2Definition, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// A NameConflict occurs
 	err = wait.Poll(500*time.Millisecond, wait.ForeverTestTimeout, func() (bool, error) {
-		crd, err := apiExtensionClient.ApiextensionsV1beta1().CustomResourceDefinitions().Get(context.TODO(), noxu2Definition.Name, metav1.GetOptions{})
+		crd, err := apiExtensionClient.ApiextensionsV1().CustomResourceDefinitions().Get(context.TODO(), noxu2Definition.Name, metav1.GetOptions{})
 		if err != nil {
 			return false, err
 		}
 
 		for _, condition := range crd.Status.Conditions {
-			if condition.Type == apiextensionsv1beta1.NamesAccepted && condition.Status == apiextensionsv1beta1.ConditionFalse {
+			if condition.Type == apiextensionsv1.NamesAccepted && condition.Status == apiextensionsv1.ConditionFalse {
 				return true, nil
 			}
 		}
@@ -974,20 +975,20 @@ func TestNameConflict(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = fixtures.DeleteCustomResourceDefinition(noxuDefinition, apiExtensionClient)
+	err = fixtures.DeleteV1CustomResourceDefinition(noxuDefinition, apiExtensionClient)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// Names are now accepted
 	err = wait.Poll(500*time.Millisecond, wait.ForeverTestTimeout, func() (bool, error) {
-		crd, err := apiExtensionClient.ApiextensionsV1beta1().CustomResourceDefinitions().Get(context.TODO(), noxu2Definition.Name, metav1.GetOptions{})
+		crd, err := apiExtensionClient.ApiextensionsV1().CustomResourceDefinitions().Get(context.TODO(), noxu2Definition.Name, metav1.GetOptions{})
 		if err != nil {
 			return false, err
 		}
 
 		for _, condition := range crd.Status.Conditions {
-			if condition.Type == apiextensionsv1beta1.NamesAccepted && condition.Status == apiextensionsv1beta1.ConditionTrue {
+			if condition.Type == apiextensionsv1.NamesAccepted && condition.Status == apiextensionsv1.ConditionTrue {
 				return true, nil
 			}
 		}
@@ -1005,15 +1006,15 @@ func TestStatusGetAndPatch(t *testing.T) {
 	}
 	defer tearDown()
 
-	noxuDefinition := fixtures.NewNoxuCustomResourceDefinition(apiextensionsv1beta1.NamespaceScoped)
-	noxuDefinition, err = fixtures.CreateNewCustomResourceDefinition(noxuDefinition, apiExtensionClient, dynamicClient)
+	noxuDefinition := fixtures.NewNoxuV1CustomResourceDefinition(apiextensionsv1.NamespaceScoped)
+	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(noxuDefinition, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// make sure we don't get 405 Method Not Allowed from Getting CRD/status subresource
-	result := &apiextensionsv1beta1.CustomResourceDefinition{}
-	err = apiExtensionClient.ApiextensionsV1beta1().RESTClient().Get().
+	result := &apiextensionsv1.CustomResourceDefinition{}
+	err = apiExtensionClient.ApiextensionsV1().RESTClient().Get().
 		Resource("customresourcedefinitions").
 		Name(noxuDefinition.Name).
 		SubResource("status").
@@ -1024,7 +1025,7 @@ func TestStatusGetAndPatch(t *testing.T) {
 	}
 
 	// make sure we don't get 405 Method Not Allowed from Patching CRD/status subresource
-	_, err = apiExtensionClient.ApiextensionsV1beta1().CustomResourceDefinitions().
+	_, err = apiExtensionClient.ApiextensionsV1().CustomResourceDefinitions().
 		Patch(context.TODO(), noxuDefinition.Name, types.StrategicMergePatchType,
 			[]byte(fmt.Sprintf(`{"labels":{"test-label":"dummy"}}`)), metav1.PatchOptions{},
 			"status")

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/basic_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/basic_test.go
@@ -26,7 +26,6 @@ import (
 	"time"
 
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-
 	"k8s.io/apiextensions-apiserver/test/integration/fixtures"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/change_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/change_test.go
@@ -23,7 +23,7 @@ import (
 	"testing"
 	"time"
 
-	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	"k8s.io/apiextensions-apiserver/test/integration/fixtures"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -50,8 +50,8 @@ func TestChangeCRD(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	noxuDefinition := fixtures.NewNoxuCustomResourceDefinition(apiextensionsv1beta1.NamespaceScoped)
-	noxuDefinition, err = fixtures.CreateNewCustomResourceDefinition(noxuDefinition, apiExtensionsClient, dynamicClient)
+	noxuDefinition := fixtures.NewNoxuV1CustomResourceDefinition(apiextensionsv1.NamespaceScoped)
+	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(noxuDefinition, apiExtensionsClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -76,7 +76,7 @@ func TestChangeCRD(t *testing.T) {
 
 			time.Sleep(10 * time.Millisecond)
 
-			noxuDefinitionToUpdate, err := apiExtensionsClient.ApiextensionsV1beta1().CustomResourceDefinitions().Get(context.TODO(), noxuDefinition.Name, metav1.GetOptions{})
+			noxuDefinitionToUpdate, err := apiExtensionsClient.ApiextensionsV1().CustomResourceDefinitions().Get(context.TODO(), noxuDefinition.Name, metav1.GetOptions{})
 			if err != nil {
 				t.Error(err)
 				continue
@@ -90,7 +90,7 @@ func TestChangeCRD(t *testing.T) {
 			} else {
 				noxuDefinitionToUpdate.Spec.Versions = noxuDefinitionToUpdate.Spec.Versions[0:1]
 			}
-			if _, err := apiExtensionsClient.ApiextensionsV1beta1().CustomResourceDefinitions().Update(context.TODO(), noxuDefinitionToUpdate, metav1.UpdateOptions{}); err != nil && !apierrors.IsConflict(err) {
+			if _, err := apiExtensionsClient.ApiextensionsV1().CustomResourceDefinitions().Update(context.TODO(), noxuDefinitionToUpdate, metav1.UpdateOptions{}); err != nil && !apierrors.IsConflict(err) {
 				t.Error(err)
 				continue
 			}

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/conversion/conversion_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/conversion/conversion_test.go
@@ -27,6 +27,8 @@ import (
 	"testing"
 	"time"
 
+	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+
 	"github.com/google/go-cmp/cmp"
 
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -42,7 +44,6 @@ import (
 	"k8s.io/client-go/dynamic"
 
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	serveroptions "k8s.io/apiextensions-apiserver/pkg/cmd/server/options"
 	"k8s.io/apiextensions-apiserver/test/integration/fixtures"
@@ -335,7 +336,7 @@ func validateNonTrivialConverted(t *testing.T, ctc *conversionTestContext) {
 			client := ctc.versionedClient(ns, createVersion.Name)
 
 			fixture := newConversionMultiVersionFixture(ns, name, createVersion.Name)
-			if !*ctc.crd.Spec.PreserveUnknownFields {
+			if createVersion.Schema.OpenAPIV3Schema.XPreserveUnknownFields == nil || !*createVersion.Schema.OpenAPIV3Schema.XPreserveUnknownFields {
 				if err := unstructured.SetNestedField(fixture.Object, "foo", "garbage"); err != nil {
 					t.Fatal(err)
 				}
@@ -393,7 +394,7 @@ func validateNonTrivialConvertedList(t *testing.T, ctc *conversionTestContext) {
 		name := "converted-" + createVersion.Name
 		client := ctc.versionedClient(ns, createVersion.Name)
 		fixture := newConversionMultiVersionFixture(ns, name, createVersion.Name)
-		if !*ctc.crd.Spec.PreserveUnknownFields {
+		if createVersion.Schema.OpenAPIV3Schema.XPreserveUnknownFields == nil || !*createVersion.Schema.OpenAPIV3Schema.XPreserveUnknownFields {
 			if err := unstructured.SetNestedField(fixture.Object, "foo", "garbage"); err != nil {
 				t.Fatal(err)
 			}
@@ -428,13 +429,12 @@ func validateNonTrivialConvertedList(t *testing.T, ctc *conversionTestContext) {
 }
 
 func validateStoragePruning(t *testing.T, ctc *conversionTestContext) {
-	if *ctc.crd.Spec.PreserveUnknownFields {
-		return
-	}
-
 	ns := ctc.namespace
 
 	for _, createVersion := range ctc.crd.Spec.Versions {
+		if createVersion.Schema.OpenAPIV3Schema.XPreserveUnknownFields == nil || !*createVersion.Schema.OpenAPIV3Schema.XPreserveUnknownFields {
+			continue
+		}
 		t.Run(fmt.Sprintf("getting objects created as %s", createVersion.Name), func(t *testing.T) {
 			name := "storagepruning-" + createVersion.Name
 			client := ctc.versionedClient(ns, createVersion.Name)
@@ -905,13 +905,13 @@ func newConversionTestContext(t *testing.T, apiExtensionsClient clientset.Interf
 	if err != nil {
 		t.Fatal(err)
 	}
-	crd, err := apiExtensionsClient.ApiextensionsV1beta1().CustomResourceDefinitions().Get(context.TODO(), v1CRD.Name, metav1.GetOptions{})
+	crd, err := apiExtensionsClient.ApiextensionsV1().CustomResourceDefinitions().Get(context.TODO(), v1CRD.Name, metav1.GetOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	tearDown := func() {
-		if err := fixtures.DeleteCustomResourceDefinition(crd, apiExtensionsClient); err != nil {
+		if err := fixtures.DeleteV1CustomResourceDefinition(crd, apiExtensionsClient); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -923,13 +923,13 @@ type conversionTestContext struct {
 	namespace           string
 	apiExtensionsClient clientset.Interface
 	dynamicClient       dynamic.Interface
-	crd                 *apiextensionsv1beta1.CustomResourceDefinition
+	crd                 *apiextensionsv1.CustomResourceDefinition
 	etcdObjectReader    *storage.EtcdObjectReader
 }
 
 func (c *conversionTestContext) versionedClient(ns string, version string) dynamic.ResourceInterface {
 	gvr := schema.GroupVersionResource{Group: c.crd.Spec.Group, Version: version, Resource: c.crd.Spec.Names.Plural}
-	if c.crd.Spec.Scope != apiextensionsv1beta1.ClusterScoped {
+	if c.crd.Spec.Scope != apiextensionsv1.ClusterScoped {
 		return c.dynamicClient.Resource(gvr).Namespace(ns)
 	}
 	return c.dynamicClient.Resource(gvr)
@@ -943,17 +943,19 @@ func (c *conversionTestContext) versionedClients(ns string) map[string]dynamic.R
 	return ret
 }
 
-func (c *conversionTestContext) setConversionWebhook(t *testing.T, webhookClientConfig *apiextensionsv1beta1.WebhookClientConfig, reviewVersions []string) {
-	crd, err := c.apiExtensionsClient.ApiextensionsV1beta1().CustomResourceDefinitions().Get(context.TODO(), c.crd.Name, metav1.GetOptions{})
+func (c *conversionTestContext) setConversionWebhook(t *testing.T, webhookClientConfig *apiextensionsv1.WebhookClientConfig, reviewVersions []string) {
+	crd, err := c.apiExtensionsClient.ApiextensionsV1().CustomResourceDefinitions().Get(context.TODO(), c.crd.Name, metav1.GetOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
-	crd.Spec.Conversion = &apiextensionsv1beta1.CustomResourceConversion{
-		Strategy:                 apiextensionsv1beta1.WebhookConverter,
-		WebhookClientConfig:      webhookClientConfig,
-		ConversionReviewVersions: reviewVersions,
+	crd.Spec.Conversion = &apiextensionsv1.CustomResourceConversion{
+		Strategy: apiextensionsv1.WebhookConverter,
+		Webhook: &apiextensionsv1.WebhookConversion{
+			ClientConfig:             webhookClientConfig,
+			ConversionReviewVersions: reviewVersions,
+		},
 	}
-	crd, err = c.apiExtensionsClient.ApiextensionsV1beta1().CustomResourceDefinitions().Update(context.TODO(), crd, metav1.UpdateOptions{})
+	crd, err = c.apiExtensionsClient.ApiextensionsV1().CustomResourceDefinitions().Update(context.TODO(), crd, metav1.UpdateOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -962,15 +964,15 @@ func (c *conversionTestContext) setConversionWebhook(t *testing.T, webhookClient
 }
 
 func (c *conversionTestContext) removeConversionWebhook(t *testing.T) {
-	crd, err := c.apiExtensionsClient.ApiextensionsV1beta1().CustomResourceDefinitions().Get(context.TODO(), c.crd.Name, metav1.GetOptions{})
+	crd, err := c.apiExtensionsClient.ApiextensionsV1().CustomResourceDefinitions().Get(context.TODO(), c.crd.Name, metav1.GetOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
-	crd.Spec.Conversion = &apiextensionsv1beta1.CustomResourceConversion{
-		Strategy: apiextensionsv1beta1.NoneConverter,
+	crd.Spec.Conversion = &apiextensionsv1.CustomResourceConversion{
+		Strategy: apiextensionsv1.NoneConverter,
 	}
 
-	crd, err = c.apiExtensionsClient.ApiextensionsV1beta1().CustomResourceDefinitions().Update(context.TODO(), crd, metav1.UpdateOptions{})
+	crd, err = c.apiExtensionsClient.ApiextensionsV1().CustomResourceDefinitions().Update(context.TODO(), crd, metav1.UpdateOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -998,14 +1000,14 @@ func (c *conversionTestContext) setAndWaitStorageVersion(t *testing.T, version s
 }
 
 func (c *conversionTestContext) setStorageVersion(t *testing.T, version string) {
-	crd, err := c.apiExtensionsClient.ApiextensionsV1beta1().CustomResourceDefinitions().Get(context.TODO(), c.crd.Name, metav1.GetOptions{})
+	crd, err := c.apiExtensionsClient.ApiextensionsV1().CustomResourceDefinitions().Get(context.TODO(), c.crd.Name, metav1.GetOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
 	for i, v := range crd.Spec.Versions {
 		crd.Spec.Versions[i].Storage = v.Name == version
 	}
-	crd, err = c.apiExtensionsClient.ApiextensionsV1beta1().CustomResourceDefinitions().Update(context.TODO(), crd, metav1.UpdateOptions{})
+	crd, err = c.apiExtensionsClient.ApiextensionsV1().CustomResourceDefinitions().Update(context.TODO(), crd, metav1.UpdateOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1027,7 +1029,7 @@ func (c *conversionTestContext) waitForStorageVersion(t *testing.T, version stri
 }
 
 func (c *conversionTestContext) setServed(t *testing.T, version string, served bool) {
-	crd, err := c.apiExtensionsClient.ApiextensionsV1beta1().CustomResourceDefinitions().Get(context.TODO(), c.crd.Name, metav1.GetOptions{})
+	crd, err := c.apiExtensionsClient.ApiextensionsV1().CustomResourceDefinitions().Get(context.TODO(), c.crd.Name, metav1.GetOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1036,7 +1038,7 @@ func (c *conversionTestContext) setServed(t *testing.T, version string, served b
 			crd.Spec.Versions[i].Served = served
 		}
 	}
-	crd, err = c.apiExtensionsClient.ApiextensionsV1beta1().CustomResourceDefinitions().Update(context.TODO(), crd, metav1.UpdateOptions{})
+	crd, err = c.apiExtensionsClient.ApiextensionsV1().CustomResourceDefinitions().Update(context.TODO(), crd, metav1.UpdateOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/conversion/conversion_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/conversion/conversion_test.go
@@ -27,8 +27,6 @@ import (
 	"testing"
 	"time"
 
-	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
-
 	"github.com/google/go-cmp/cmp"
 
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -44,6 +42,7 @@ import (
 	"k8s.io/client-go/dynamic"
 
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	serveroptions "k8s.io/apiextensions-apiserver/pkg/cmd/server/options"
 	"k8s.io/apiextensions-apiserver/test/integration/fixtures"
@@ -336,10 +335,8 @@ func validateNonTrivialConverted(t *testing.T, ctc *conversionTestContext) {
 			client := ctc.versionedClient(ns, createVersion.Name)
 
 			fixture := newConversionMultiVersionFixture(ns, name, createVersion.Name)
-			if createVersion.Schema.OpenAPIV3Schema.XPreserveUnknownFields == nil || !*createVersion.Schema.OpenAPIV3Schema.XPreserveUnknownFields {
-				if err := unstructured.SetNestedField(fixture.Object, "foo", "garbage"); err != nil {
-					t.Fatal(err)
-				}
+			if err := unstructured.SetNestedField(fixture.Object, "foo", "garbage"); err != nil {
+				t.Fatal(err)
 			}
 			if _, err := client.Create(context.TODO(), fixture, metav1.CreateOptions{}); err != nil {
 				t.Fatal(err)
@@ -394,10 +391,8 @@ func validateNonTrivialConvertedList(t *testing.T, ctc *conversionTestContext) {
 		name := "converted-" + createVersion.Name
 		client := ctc.versionedClient(ns, createVersion.Name)
 		fixture := newConversionMultiVersionFixture(ns, name, createVersion.Name)
-		if createVersion.Schema.OpenAPIV3Schema.XPreserveUnknownFields == nil || !*createVersion.Schema.OpenAPIV3Schema.XPreserveUnknownFields {
-			if err := unstructured.SetNestedField(fixture.Object, "foo", "garbage"); err != nil {
-				t.Fatal(err)
-			}
+		if err := unstructured.SetNestedField(fixture.Object, "foo", "garbage"); err != nil {
+			t.Fatal(err)
 		}
 		_, err := client.Create(context.TODO(), fixture, metav1.CreateOptions{})
 		if err != nil {
@@ -432,9 +427,6 @@ func validateStoragePruning(t *testing.T, ctc *conversionTestContext) {
 	ns := ctc.namespace
 
 	for _, createVersion := range ctc.crd.Spec.Versions {
-		if createVersion.Schema.OpenAPIV3Schema.XPreserveUnknownFields == nil || !*createVersion.Schema.OpenAPIV3Schema.XPreserveUnknownFields {
-			continue
-		}
 		t.Run(fmt.Sprintf("getting objects created as %s", createVersion.Name), func(t *testing.T) {
 			name := "storagepruning-" + createVersion.Name
 			client := ctc.versionedClient(ns, createVersion.Name)

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/conversion/webhook.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/conversion/webhook.go
@@ -38,7 +38,7 @@ import (
 
 // StartConversionWebhookServer starts an http server with the provided handler and returns the WebhookClientConfig
 // needed to configure a CRD to use this conversion webhook as its converter.
-func StartConversionWebhookServer(handler http.Handler) (func(), *apiextensionsv1beta1.WebhookClientConfig, error) {
+func StartConversionWebhookServer(handler http.Handler) (func(), *apiextensionsv1.WebhookClientConfig, error) {
 	roots := x509.NewCertPool()
 	if !roots.AppendCertsFromPEM(localhostCert) {
 		return nil, nil, fmt.Errorf("failed to append Cert from PEM")
@@ -57,7 +57,7 @@ func StartConversionWebhookServer(handler http.Handler) (func(), *apiextensionsv
 	}
 	webhookServer.StartTLS()
 	endpoint := webhookServer.URL + "/convert"
-	webhookConfig := &apiextensionsv1beta1.WebhookClientConfig{
+	webhookConfig := &apiextensionsv1.WebhookClientConfig{
 		CABundle: localhostCert,
 		URL:      &endpoint,
 	}

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/finalization_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/finalization_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apiextensions-apiserver/test/integration/fixtures"
 	"k8s.io/apimachinery/pkg/api/errors"

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/finalization_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/finalization_test.go
@@ -22,9 +22,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
-
-	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
-
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apiextensions-apiserver/test/integration/fixtures"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -36,8 +34,8 @@ func TestFinalization(t *testing.T) {
 	require.NoError(t, err)
 	defer tearDown()
 
-	noxuDefinition := fixtures.NewNoxuCustomResourceDefinition(apiextensionsv1beta1.ClusterScoped)
-	noxuDefinition, err = fixtures.CreateNewCustomResourceDefinition(noxuDefinition, apiExtensionClient, dynamicClient)
+	noxuDefinition := fixtures.NewNoxuV1CustomResourceDefinition(apiextensionsv1.ClusterScoped)
+	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(noxuDefinition, apiExtensionClient, dynamicClient)
 	require.NoError(t, err)
 
 	ns := "not-the-default"
@@ -100,8 +98,8 @@ func TestFinalizationAndDeletion(t *testing.T) {
 	defer tearDown()
 
 	// Create a CRD.
-	noxuDefinition := fixtures.NewNoxuCustomResourceDefinition(apiextensionsv1beta1.ClusterScoped)
-	noxuDefinition, err = fixtures.CreateNewCustomResourceDefinition(noxuDefinition, apiExtensionClient, dynamicClient)
+	noxuDefinition := fixtures.NewNoxuV1CustomResourceDefinition(apiextensionsv1.ClusterScoped)
+	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(noxuDefinition, apiExtensionClient, dynamicClient)
 	require.NoError(t, err)
 
 	// Create a CR with a finalizer.
@@ -129,7 +127,7 @@ func TestFinalizationAndDeletion(t *testing.T) {
 	require.NotNil(t, gottenNoxuInstance.GetDeletionTimestamp())
 
 	// Delete the CRD.
-	fixtures.DeleteCustomResourceDefinition(noxuDefinition, apiExtensionClient)
+	fixtures.DeleteV1CustomResourceDefinition(noxuDefinition, apiExtensionClient)
 
 	// Check is CR still there after the CRD deletion.
 	gottenNoxuInstance, err = noxuResourceClient.Get(context.TODO(), name, metav1.GetOptions{})
@@ -157,7 +155,7 @@ func TestFinalizationAndDeletion(t *testing.T) {
 	}
 
 	err = wait.Poll(500*time.Millisecond, wait.ForeverTestTimeout, func() (bool, error) {
-		_, err = apiExtensionClient.ApiextensionsV1beta1().CustomResourceDefinitions().Get(context.TODO(), noxuDefinition.Name, metav1.GetOptions{})
+		_, err = apiExtensionClient.ApiextensionsV1().CustomResourceDefinitions().Get(context.TODO(), noxuDefinition.Name, metav1.GetOptions{})
 		return errors.IsNotFound(err), err
 	})
 	if !errors.IsNotFound(err) {

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/fixtures/resources.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/fixtures/resources.go
@@ -44,6 +44,16 @@ const (
 	noxuInstanceNum int64 = 9223372036854775807
 )
 
+// AllowAllSchema doesn't enforce any schema restrictions
+func AllowAllSchema() *apiextensionsv1.CustomResourceValidation {
+	return &apiextensionsv1.CustomResourceValidation{
+		OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
+			XPreserveUnknownFields: pointer.BoolPtr(true),
+			Type:                   "object",
+		},
+	}
+}
+
 // NewRandomNameV1CustomResourceDefinition generates a CRD with random name to avoid name conflict in e2e tests
 func NewRandomNameV1CustomResourceDefinition(scope apiextensionsv1.ResourceScope) *apiextensionsv1.CustomResourceDefinition {
 	// ensure the singular doesn't end in an s for now
@@ -57,12 +67,7 @@ func NewRandomNameV1CustomResourceDefinition(scope apiextensionsv1.ResourceScope
 					Name:    "v1beta1",
 					Served:  true,
 					Storage: true,
-					Schema: &apiextensionsv1.CustomResourceValidation{
-						OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
-							XPreserveUnknownFields: pointer.BoolPtr(true),
-							Type:                   "object",
-						},
-					},
+					Schema:  AllowAllSchema(),
 				},
 			},
 			Names: apiextensionsv1.CustomResourceDefinitionNames{
@@ -70,46 +75,6 @@ func NewRandomNameV1CustomResourceDefinition(scope apiextensionsv1.ResourceScope
 				Singular: gName,
 				Kind:     gName,
 				ListKind: gName + "List",
-			},
-			Scope: scope,
-		},
-	}
-}
-
-// NewRandomNameCustomResourceDefinition generates a CRD with random name to avoid name conflict in e2e tests
-func NewRandomNameCustomResourceDefinition(scope apiextensionsv1beta1.ResourceScope) *apiextensionsv1beta1.CustomResourceDefinition {
-	// ensure the singular doesn't end in an s for now
-	gName := names.SimpleNameGenerator.GenerateName("foo") + "a"
-	return &apiextensionsv1beta1.CustomResourceDefinition{
-		ObjectMeta: metav1.ObjectMeta{Name: gName + "s.mygroup.example.com"},
-		Spec: apiextensionsv1beta1.CustomResourceDefinitionSpec{
-			Group:   "mygroup.example.com",
-			Version: "v1beta1",
-			Names: apiextensionsv1beta1.CustomResourceDefinitionNames{
-				Plural:   gName + "s",
-				Singular: gName,
-				Kind:     gName,
-				ListKind: gName + "List",
-			},
-			Scope: scope,
-		},
-	}
-}
-
-// NewNoxuCustomResourceDefinition returns a WishIHadChosenNoxu CRD.
-func NewNoxuCustomResourceDefinition(scope apiextensionsv1beta1.ResourceScope) *apiextensionsv1beta1.CustomResourceDefinition {
-	return &apiextensionsv1beta1.CustomResourceDefinition{
-		ObjectMeta: metav1.ObjectMeta{Name: "noxus.mygroup.example.com"},
-		Spec: apiextensionsv1beta1.CustomResourceDefinitionSpec{
-			Group:   "mygroup.example.com",
-			Version: "v1beta1",
-			Names: apiextensionsv1beta1.CustomResourceDefinitionNames{
-				Plural:     "noxus",
-				Singular:   "nonenglishnoxu",
-				Kind:       "WishIHadChosenNoxu",
-				ShortNames: []string{"foo", "bar", "abc", "def"},
-				ListKind:   "NoxuItemList",
-				Categories: []string{"all"},
 			},
 			Scope: scope,
 		},
@@ -126,12 +91,7 @@ func NewNoxuV1CustomResourceDefinition(scope apiextensionsv1.ResourceScope) *api
 				Name:    "v1beta1",
 				Served:  true,
 				Storage: true,
-				Schema: &apiextensionsv1.CustomResourceValidation{
-					OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
-						XPreserveUnknownFields: pointer.BoolPtr(true),
-						Type:                   "object",
-					},
-				},
+				Schema:  AllowAllSchema(),
 			}},
 			Names: apiextensionsv1.CustomResourceDefinitionNames{
 				Plural:     "noxus",
@@ -173,13 +133,12 @@ func NewNoxuInstance(namespace, name string) *unstructured.Unstructured {
 }
 
 // NewMultipleVersionNoxuCRD returns a WishIHadChosenNoxu with multiple versions.
-func NewMultipleVersionNoxuCRD(scope apiextensionsv1beta1.ResourceScope) *apiextensionsv1beta1.CustomResourceDefinition {
-	return &apiextensionsv1beta1.CustomResourceDefinition{
+func NewMultipleVersionNoxuCRD(scope apiextensionsv1.ResourceScope) *apiextensionsv1.CustomResourceDefinition {
+	return &apiextensionsv1.CustomResourceDefinition{
 		ObjectMeta: metav1.ObjectMeta{Name: "noxus.mygroup.example.com"},
-		Spec: apiextensionsv1beta1.CustomResourceDefinitionSpec{
-			Group:   "mygroup.example.com",
-			Version: "v1beta1",
-			Names: apiextensionsv1beta1.CustomResourceDefinitionNames{
+		Spec: apiextensionsv1.CustomResourceDefinitionSpec{
+			Group: "mygroup.example.com",
+			Names: apiextensionsv1.CustomResourceDefinitionNames{
 				Plural:     "noxus",
 				Singular:   "nonenglishnoxu",
 				Kind:       "WishIHadChosenNoxu",
@@ -188,38 +147,52 @@ func NewMultipleVersionNoxuCRD(scope apiextensionsv1beta1.ResourceScope) *apiext
 				Categories: []string{"all"},
 			},
 			Scope: scope,
-			Versions: []apiextensionsv1beta1.CustomResourceDefinitionVersion{
+			Versions: []apiextensionsv1.CustomResourceDefinitionVersion{
 				{
 					Name:    "v1beta1",
 					Served:  true,
 					Storage: false,
+					Subresources: &apiextensionsv1.CustomResourceSubresources{
+						Status: &apiextensionsv1.CustomResourceSubresourceStatus{},
+					},
+					Schema: AllowAllSchema(),
 				},
 				{
 					Name:    "v1beta2",
 					Served:  true,
 					Storage: true,
+					Subresources: &apiextensionsv1.CustomResourceSubresources{
+						Status: &apiextensionsv1.CustomResourceSubresourceStatus{},
+					},
+					Schema: AllowAllSchema(),
 				},
 				{
 					Name:    "v0",
 					Served:  false,
 					Storage: false,
+					Subresources: &apiextensionsv1.CustomResourceSubresources{
+						Status: &apiextensionsv1.CustomResourceSubresourceStatus{},
+					},
+					Schema: AllowAllSchema(),
 				},
-			},
-			Subresources: &apiextensionsv1beta1.CustomResourceSubresources{
-				Status: &apiextensionsv1beta1.CustomResourceSubresourceStatus{},
 			},
 		},
 	}
 }
 
 // NewNoxu2CustomResourceDefinition returns a WishIHadChosenNoxu2 CRD.
-func NewNoxu2CustomResourceDefinition(scope apiextensionsv1beta1.ResourceScope) *apiextensionsv1beta1.CustomResourceDefinition {
-	return &apiextensionsv1beta1.CustomResourceDefinition{
+func NewNoxu2CustomResourceDefinition(scope apiextensionsv1.ResourceScope) *apiextensionsv1.CustomResourceDefinition {
+	return &apiextensionsv1.CustomResourceDefinition{
 		ObjectMeta: metav1.ObjectMeta{Name: "noxus2.mygroup.example.com"},
-		Spec: apiextensionsv1beta1.CustomResourceDefinitionSpec{
-			Group:   "mygroup.example.com",
-			Version: "v1alpha1",
-			Names: apiextensionsv1beta1.CustomResourceDefinitionNames{
+		Spec: apiextensionsv1.CustomResourceDefinitionSpec{
+			Group: "mygroup.example.com",
+			Versions: []apiextensionsv1.CustomResourceDefinitionVersion{{
+				Name:    "v1alpha1",
+				Served:  true,
+				Storage: true,
+				Schema:  AllowAllSchema(),
+			}},
+			Names: apiextensionsv1.CustomResourceDefinitionNames{
 				Plural:     "noxus2",
 				Singular:   "nonenglishnoxu2",
 				Kind:       "WishIHadChosenNoxu2",
@@ -231,14 +204,21 @@ func NewNoxu2CustomResourceDefinition(scope apiextensionsv1beta1.ResourceScope) 
 	}
 }
 
-// NewCurletCustomResourceDefinition returns a Curlet CRD.
-func NewCurletCustomResourceDefinition(scope apiextensionsv1beta1.ResourceScope) *apiextensionsv1beta1.CustomResourceDefinition {
-	return &apiextensionsv1beta1.CustomResourceDefinition{
+// NewCurletV1CustomResourceDefinition returns a Curlet CRD.
+func NewCurletV1CustomResourceDefinition(scope apiextensionsv1.ResourceScope) *apiextensionsv1.CustomResourceDefinition {
+	return &apiextensionsv1.CustomResourceDefinition{
 		ObjectMeta: metav1.ObjectMeta{Name: "curlets.mygroup.example.com"},
-		Spec: apiextensionsv1beta1.CustomResourceDefinitionSpec{
-			Group:   "mygroup.example.com",
-			Version: "v1beta1",
-			Names: apiextensionsv1beta1.CustomResourceDefinitionNames{
+		Spec: apiextensionsv1.CustomResourceDefinitionSpec{
+			Group: "mygroup.example.com",
+			Versions: []apiextensionsv1.CustomResourceDefinitionVersion{
+				{
+					Name:    "v1beta1",
+					Served:  true,
+					Storage: true,
+					Schema:  AllowAllSchema(),
+				},
+			},
+			Names: apiextensionsv1.CustomResourceDefinitionNames{
 				Plural:   "curlets",
 				Singular: "curlet",
 				Kind:     "Curlet",
@@ -506,23 +486,6 @@ func isWatchCachePrimed(crd *apiextensionsv1.CustomResourceDefinition, dynamicCl
 	return true, nil
 }
 
-// DeleteCustomResourceDefinition deletes a CRD and waits until it disappears from discovery.
-func DeleteCustomResourceDefinition(crd *apiextensionsv1beta1.CustomResourceDefinition, apiExtensionsClient clientset.Interface) error {
-	if err := apiExtensionsClient.ApiextensionsV1beta1().CustomResourceDefinitions().Delete(context.TODO(), crd.Name, metav1.DeleteOptions{}); err != nil {
-		return err
-	}
-	for _, version := range servedVersions(crd) {
-		err := wait.PollImmediate(500*time.Millisecond, 30*time.Second, func() (bool, error) {
-			exists, err := existsInDiscovery(crd, apiExtensionsClient, version)
-			return !exists, err
-		})
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
 // DeleteV1CustomResourceDefinition deletes a CRD and waits until it disappears from discovery.
 func DeleteV1CustomResourceDefinition(crd *apiextensionsv1.CustomResourceDefinition, apiExtensionsClient clientset.Interface) error {
 	if err := apiExtensionsClient.ApiextensionsV1().CustomResourceDefinitions().Delete(context.TODO(), crd.Name, metav1.DeleteOptions{}); err != nil {
@@ -564,7 +527,7 @@ func DeleteV1CustomResourceDefinitions(deleteListOpts metav1.ListOptions, apiExt
 }
 
 // CreateNewVersionedScaleClient returns a scale client.
-func CreateNewVersionedScaleClient(crd *apiextensionsv1beta1.CustomResourceDefinition, config *rest.Config, version string) (scale.ScalesGetter, error) {
+func CreateNewVersionedScaleClient(crd *apiextensionsv1.CustomResourceDefinition, config *rest.Config, version string) (scale.ScalesGetter, error) {
 	discoveryClient, err := discovery.NewDiscoveryClientForConfig(config)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/fixtures/server.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/fixtures/server.go
@@ -20,9 +20,15 @@ import (
 	"io/ioutil"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/google/uuid"
+	"go.etcd.io/etcd/clientv3"
+	"go.etcd.io/etcd/pkg/transport"
+	"google.golang.org/grpc"
 	"k8s.io/apiextensions-apiserver/pkg/cmd/server/options"
+	serveroptions "k8s.io/apiextensions-apiserver/pkg/cmd/server/options"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	servertesting "k8s.io/apiextensions-apiserver/pkg/cmd/server/testing"
@@ -101,6 +107,55 @@ func StartDefaultServerWithClients(t servertesting.Logger, extraFlags ...string)
 	}
 
 	return tearDown, apiExtensionsClient, dynamicClient, nil
+}
+
+// StartDefaultServerWithClientsAndEtcd starts a test server and returns clients for it.
+func StartDefaultServerWithClientsAndEtcd(t servertesting.Logger, extraFlags ...string) (func(), clientset.Interface, dynamic.Interface, *clientv3.Client, string, error) {
+	tearDown, config, options, err := StartDefaultServer(t, extraFlags...)
+	if err != nil {
+		return nil, nil, nil, nil, "", err
+	}
+
+	apiExtensionsClient, err := clientset.NewForConfig(config)
+	if err != nil {
+		tearDown()
+		return nil, nil, nil, nil, "", err
+	}
+
+	dynamicClient, err := dynamic.NewForConfig(config)
+	if err != nil {
+		tearDown()
+		return nil, nil, nil, nil, "", err
+	}
+
+	RESTOptionsGetter := serveroptions.NewCRDRESTOptionsGetter(*options.RecommendedOptions.Etcd)
+	restOptions, err := RESTOptionsGetter.GetRESTOptions(schema.GroupResource{Group: "hopefully-ignored-group", Resource: "hopefully-ignored-resources"})
+	if err != nil {
+		return nil, nil, nil, nil, "", err
+	}
+	tlsInfo := transport.TLSInfo{
+		CertFile:      restOptions.StorageConfig.Transport.CertFile,
+		KeyFile:       restOptions.StorageConfig.Transport.KeyFile,
+		TrustedCAFile: restOptions.StorageConfig.Transport.TrustedCAFile,
+	}
+	tlsConfig, err := tlsInfo.ClientConfig()
+	if err != nil {
+		return nil, nil, nil, nil, "", err
+	}
+	etcdConfig := clientv3.Config{
+		Endpoints:   restOptions.StorageConfig.Transport.ServerList,
+		DialTimeout: 20 * time.Second,
+		DialOptions: []grpc.DialOption{
+			grpc.WithBlock(), // block until the underlying connection is up
+		},
+		TLS: tlsConfig,
+	}
+	etcdclient, err := clientv3.New(etcdConfig)
+	if err != nil {
+		return nil, nil, nil, nil, "", err
+	}
+
+	return tearDown, apiExtensionsClient, dynamicClient, etcdclient, restOptions.StorageConfig.Prefix, nil
 }
 
 // IntegrationEtcdServers returns etcd server URLs.

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/helpers.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/helpers.go
@@ -22,7 +22,6 @@ import (
 	"testing"
 
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -34,11 +33,11 @@ import (
 
 var swaggerMetadataDescriptions = metav1.ObjectMeta{}.SwaggerDoc()
 
-func instantiateCustomResource(t *testing.T, instanceToCreate *unstructured.Unstructured, client dynamic.ResourceInterface, definition *apiextensionsv1beta1.CustomResourceDefinition) (*unstructured.Unstructured, error) {
+func instantiateCustomResource(t *testing.T, instanceToCreate *unstructured.Unstructured, client dynamic.ResourceInterface, definition *apiextensionsv1.CustomResourceDefinition) (*unstructured.Unstructured, error) {
 	return instantiateVersionedCustomResource(t, instanceToCreate, client, definition, definition.Spec.Versions[0].Name)
 }
 
-func instantiateVersionedCustomResource(t *testing.T, instanceToCreate *unstructured.Unstructured, client dynamic.ResourceInterface, definition *apiextensionsv1beta1.CustomResourceDefinition, version string) (*unstructured.Unstructured, error) {
+func instantiateVersionedCustomResource(t *testing.T, instanceToCreate *unstructured.Unstructured, client dynamic.ResourceInterface, definition *apiextensionsv1.CustomResourceDefinition, version string) (*unstructured.Unstructured, error) {
 	createdInstance, err := client.Create(context.TODO(), instanceToCreate, metav1.CreateOptions{})
 	if err != nil {
 		t.Logf("%#v", createdInstance)
@@ -65,28 +64,28 @@ func instantiateVersionedCustomResource(t *testing.T, instanceToCreate *unstruct
 	return createdInstance, nil
 }
 
-func newNamespacedCustomResourceVersionedClient(ns string, client dynamic.Interface, crd *apiextensionsv1beta1.CustomResourceDefinition, version string) dynamic.ResourceInterface {
+func newNamespacedCustomResourceVersionedClient(ns string, client dynamic.Interface, crd *apiextensionsv1.CustomResourceDefinition, version string) dynamic.ResourceInterface {
 	gvr := schema.GroupVersionResource{Group: crd.Spec.Group, Version: version, Resource: crd.Spec.Names.Plural}
 
-	if crd.Spec.Scope != apiextensionsv1beta1.ClusterScoped {
+	if crd.Spec.Scope != apiextensionsv1.ClusterScoped {
 		return client.Resource(gvr).Namespace(ns)
 	}
 	return client.Resource(gvr)
 }
 
-func newNamespacedCustomResourceClient(ns string, client dynamic.Interface, crd *apiextensionsv1beta1.CustomResourceDefinition) dynamic.ResourceInterface {
+func newNamespacedCustomResourceClient(ns string, client dynamic.Interface, crd *apiextensionsv1.CustomResourceDefinition) dynamic.ResourceInterface {
 	return newNamespacedCustomResourceVersionedClient(ns, client, crd, crd.Spec.Versions[0].Name)
 }
 
 // UpdateCustomResourceDefinitionWithRetry updates a CRD, retrying up to 5 times on version conflict errors.
-func UpdateCustomResourceDefinitionWithRetry(client clientset.Interface, name string, update func(*apiextensionsv1beta1.CustomResourceDefinition)) (*apiextensionsv1beta1.CustomResourceDefinition, error) {
+func UpdateCustomResourceDefinitionWithRetry(client clientset.Interface, name string, update func(*apiextensionsv1.CustomResourceDefinition)) (*apiextensionsv1.CustomResourceDefinition, error) {
 	for i := 0; i < 5; i++ {
-		crd, err := client.ApiextensionsV1beta1().CustomResourceDefinitions().Get(context.TODO(), name, metav1.GetOptions{})
+		crd, err := client.ApiextensionsV1().CustomResourceDefinitions().Get(context.TODO(), name, metav1.GetOptions{})
 		if err != nil {
 			return nil, fmt.Errorf("failed to get CustomResourceDefinition %q: %v", name, err)
 		}
 		update(crd)
-		crd, err = client.ApiextensionsV1beta1().CustomResourceDefinitions().Update(context.TODO(), crd, metav1.UpdateOptions{})
+		crd, err = client.ApiextensionsV1().CustomResourceDefinitions().Update(context.TODO(), crd, metav1.UpdateOptions{})
 		if err == nil {
 			return crd, nil
 		}
@@ -117,13 +116,7 @@ func UpdateV1CustomResourceDefinitionWithRetry(client clientset.Interface, name 
 }
 
 // getSchemaForVersion returns the validation schema for given version in given CRD.
-func getSchemaForVersion(crd *apiextensionsv1beta1.CustomResourceDefinition, version string) (*apiextensionsv1beta1.CustomResourceValidation, error) {
-	if !hasPerVersionSchema(crd.Spec.Versions) {
-		return crd.Spec.Validation, nil
-	}
-	if crd.Spec.Validation != nil {
-		return nil, fmt.Errorf("malformed CustomResourceDefinition %s version %s: top-level and per-version schemas must be mutual exclusive", crd.Name, version)
-	}
+func getSchemaForVersion(crd *apiextensionsv1.CustomResourceDefinition, version string) (*apiextensionsv1.CustomResourceValidation, error) {
 	for _, v := range crd.Spec.Versions {
 		if version == v.Name {
 			return v.Schema, nil
@@ -133,13 +126,7 @@ func getSchemaForVersion(crd *apiextensionsv1beta1.CustomResourceDefinition, ver
 }
 
 // getSubresourcesForVersion returns the subresources for given version in given CRD.
-func getSubresourcesForVersion(crd *apiextensionsv1beta1.CustomResourceDefinition, version string) (*apiextensionsv1beta1.CustomResourceSubresources, error) {
-	if !hasPerVersionSubresources(crd.Spec.Versions) {
-		return crd.Spec.Subresources, nil
-	}
-	if crd.Spec.Subresources != nil {
-		return nil, fmt.Errorf("malformed CustomResourceDefinition %s version %s: top-level and per-version subresources must be mutual exclusive", crd.Name, version)
-	}
+func getSubresourcesForVersion(crd *apiextensionsv1.CustomResourceDefinition, version string) (*apiextensionsv1.CustomResourceSubresources, error) {
 	for _, v := range crd.Spec.Versions {
 		if version == v.Name {
 			return v.Subresources, nil
@@ -152,13 +139,7 @@ func getSubresourcesForVersion(crd *apiextensionsv1beta1.CustomResourceDefinitio
 // NOTE: the newly logically-defaulted columns is not pointing to the original CRD object.
 // One cannot mutate the original CRD columns using the logically-defaulted columns. Please iterate through
 // the original CRD object instead.
-func getColumnsForVersion(crd *apiextensionsv1beta1.CustomResourceDefinition, version string) ([]apiextensionsv1beta1.CustomResourceColumnDefinition, error) {
-	if !hasPerVersionColumns(crd.Spec.Versions) {
-		return serveDefaultColumnsIfEmpty(crd.Spec.AdditionalPrinterColumns), nil
-	}
-	if len(crd.Spec.AdditionalPrinterColumns) > 0 {
-		return nil, fmt.Errorf("malformed CustomResourceDefinition %s version %s: top-level and per-version additionalPrinterColumns must be mutual exclusive", crd.Name, version)
-	}
+func getColumnsForVersion(crd *apiextensionsv1.CustomResourceDefinition, version string) ([]apiextensionsv1.CustomResourceColumnDefinition, error) {
 	for _, v := range crd.Spec.Versions {
 		if version == v.Name {
 			return serveDefaultColumnsIfEmpty(v.AdditionalPrinterColumns), nil
@@ -171,41 +152,11 @@ func getColumnsForVersion(crd *apiextensionsv1beta1.CustomResourceDefinition, ve
 // NOTE: in this way, the newly logically-defaulted columns is not pointing to the original CRD object.
 // One cannot mutate the original CRD columns using the logically-defaulted columns. Please iterate through
 // the original CRD object instead.
-func serveDefaultColumnsIfEmpty(columns []apiextensionsv1beta1.CustomResourceColumnDefinition) []apiextensionsv1beta1.CustomResourceColumnDefinition {
+func serveDefaultColumnsIfEmpty(columns []apiextensionsv1.CustomResourceColumnDefinition) []apiextensionsv1.CustomResourceColumnDefinition {
 	if len(columns) > 0 {
 		return columns
 	}
-	return []apiextensionsv1beta1.CustomResourceColumnDefinition{
+	return []apiextensionsv1.CustomResourceColumnDefinition{
 		{Name: "Age", Type: "date", Description: swaggerMetadataDescriptions["creationTimestamp"], JSONPath: ".metadata.creationTimestamp"},
 	}
-}
-
-// hasPerVersionSchema returns true if a CRD uses per-version schema.
-func hasPerVersionSchema(versions []apiextensionsv1beta1.CustomResourceDefinitionVersion) bool {
-	for _, v := range versions {
-		if v.Schema != nil {
-			return true
-		}
-	}
-	return false
-}
-
-// hasPerVersionSubresources returns true if a CRD uses per-version subresources.
-func hasPerVersionSubresources(versions []apiextensionsv1beta1.CustomResourceDefinitionVersion) bool {
-	for _, v := range versions {
-		if v.Subresources != nil {
-			return true
-		}
-	}
-	return false
-}
-
-// hasPerVersionColumns returns true if a CRD uses per-version columns.
-func hasPerVersionColumns(versions []apiextensionsv1beta1.CustomResourceDefinitionVersion) bool {
-	for _, v := range versions {
-		if len(v.AdditionalPrinterColumns) > 0 {
-			return true
-		}
-	}
-	return false
 }

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/limit_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/limit_test.go
@@ -22,9 +22,10 @@ import (
 	"strings"
 	"testing"
 
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+
 	"k8s.io/client-go/dynamic"
 
-	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	"k8s.io/apiextensions-apiserver/test/integration/fixtures"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -47,14 +48,14 @@ func TestLimits(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	noxuDefinition := fixtures.NewNoxuCustomResourceDefinition(apiextensionsv1beta1.ClusterScoped)
-	noxuDefinition, err = fixtures.CreateNewCustomResourceDefinition(noxuDefinition, apiExtensionClient, dynamicClient)
+	noxuDefinition := fixtures.NewNoxuV1CustomResourceDefinition(apiextensionsv1.ClusterScoped)
+	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(noxuDefinition, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	kind := noxuDefinition.Spec.Names.Kind
-	apiVersion := noxuDefinition.Spec.Group + "/" + noxuDefinition.Spec.Version
+	apiVersion := noxuDefinition.Spec.Group + "/" + noxuDefinition.Spec.Versions[0].Name
 
 	rest := apiExtensionClient.Discovery().RESTClient()
 
@@ -70,7 +71,7 @@ values: `+strings.Repeat("[", 3*1024*1024), apiVersion, kind))
 		_, err := rest.Post().
 			SetHeader("Accept", "application/yaml").
 			SetHeader("Content-Type", "application/yaml").
-			AbsPath("/apis", noxuDefinition.Spec.Group, noxuDefinition.Spec.Version, noxuDefinition.Spec.Names.Plural).
+			AbsPath("/apis", noxuDefinition.Spec.Group, noxuDefinition.Spec.Versions[0].Name, noxuDefinition.Spec.Names.Plural).
 			Body(yamlBody).
 			DoRaw(context.TODO())
 		if !apierrors.IsRequestEntityTooLargeError(err) {
@@ -93,7 +94,7 @@ values: `+strings.Repeat("[", 3*1024*1024), apiVersion, kind))
 		_, err := rest.Post().
 			SetHeader("Accept", "application/yaml").
 			SetHeader("Content-Type", "application/yaml").
-			AbsPath("/apis", noxuDefinition.Spec.Group, noxuDefinition.Spec.Version, noxuDefinition.Spec.Names.Plural).
+			AbsPath("/apis", noxuDefinition.Spec.Group, noxuDefinition.Spec.Versions[0].Name, noxuDefinition.Spec.Names.Plural).
 			Body(yamlBody).
 			DoRaw(context.TODO())
 		if !apierrors.IsBadRequest(err) {
@@ -116,7 +117,7 @@ values: `+strings.Repeat("[", 3*1024*1024), apiVersion, kind))
 		_, err := rest.Post().
 			SetHeader("Accept", "application/yaml").
 			SetHeader("Content-Type", "application/yaml").
-			AbsPath("/apis", noxuDefinition.Spec.Group, noxuDefinition.Spec.Version, noxuDefinition.Spec.Names.Plural).
+			AbsPath("/apis", noxuDefinition.Spec.Group, noxuDefinition.Spec.Versions[0].Name, noxuDefinition.Spec.Names.Plural).
 			Body(yamlBody).
 			DoRaw(context.TODO())
 		if !apierrors.IsBadRequest(err) {
@@ -137,7 +138,7 @@ values: `+strings.Repeat("[", 3*1024*1024), apiVersion, kind))
 		_, err := rest.Post().
 			SetHeader("Accept", "application/json").
 			SetHeader("Content-Type", "application/json").
-			AbsPath("/apis", noxuDefinition.Spec.Group, noxuDefinition.Spec.Version, noxuDefinition.Spec.Names.Plural).
+			AbsPath("/apis", noxuDefinition.Spec.Group, noxuDefinition.Spec.Versions[0].Name, noxuDefinition.Spec.Names.Plural).
 			Body(jsonBody).
 			DoRaw(context.TODO())
 		if !apierrors.IsRequestEntityTooLargeError(err) {
@@ -161,7 +162,7 @@ values: `+strings.Repeat("[", 3*1024*1024), apiVersion, kind))
 		_, err := rest.Post().
 			SetHeader("Accept", "application/json").
 			SetHeader("Content-Type", "application/json").
-			AbsPath("/apis", noxuDefinition.Spec.Group, noxuDefinition.Spec.Version, noxuDefinition.Spec.Names.Plural).
+			AbsPath("/apis", noxuDefinition.Spec.Group, noxuDefinition.Spec.Versions[0].Name, noxuDefinition.Spec.Names.Plural).
 			Body(jsonBody).
 			DoRaw(context.TODO())
 		if !apierrors.IsBadRequest(err) {
@@ -185,7 +186,7 @@ values: `+strings.Repeat("[", 3*1024*1024), apiVersion, kind))
 		_, err := rest.Post().
 			SetHeader("Accept", "application/json").
 			SetHeader("Content-Type", "application/json").
-			AbsPath("/apis", noxuDefinition.Spec.Group, noxuDefinition.Spec.Version, noxuDefinition.Spec.Names.Plural).
+			AbsPath("/apis", noxuDefinition.Spec.Group, noxuDefinition.Spec.Versions[0].Name, noxuDefinition.Spec.Names.Plural).
 			Body(jsonBody).
 			DoRaw(context.TODO())
 		if !apierrors.IsBadRequest(err) {
@@ -196,7 +197,7 @@ values: `+strings.Repeat("[", 3*1024*1024), apiVersion, kind))
 	// Create instance to allow patching
 	{
 		jsonBody := []byte(fmt.Sprintf(`{"apiVersion": %q, "kind": %q, "metadata": {"name": "test"}}`, apiVersion, kind))
-		_, err := rest.Post().AbsPath("/apis", noxuDefinition.Spec.Group, noxuDefinition.Spec.Version, noxuDefinition.Spec.Names.Plural).Body(jsonBody).DoRaw(context.TODO())
+		_, err := rest.Post().AbsPath("/apis", noxuDefinition.Spec.Group, noxuDefinition.Spec.Versions[0].Name, noxuDefinition.Spec.Names.Plural).Body(jsonBody).DoRaw(context.TODO())
 		if err != nil {
 			t.Fatalf("error creating object: %v", err)
 		}
@@ -207,7 +208,7 @@ values: `+strings.Repeat("[", 3*1024*1024), apiVersion, kind))
 			t.Skip("skipping expensive test")
 		}
 		patchBody := []byte(`[{"op":"add","path":"/foo","value":` + strings.Repeat("[", 3*1024*1024/2-100) + strings.Repeat("]", 3*1024*1024/2-100) + `}]`)
-		err = rest.Patch(types.JSONPatchType).AbsPath("/apis", noxuDefinition.Spec.Group, noxuDefinition.Spec.Version, noxuDefinition.Spec.Names.Plural, "test").
+		err = rest.Patch(types.JSONPatchType).AbsPath("/apis", noxuDefinition.Spec.Group, noxuDefinition.Spec.Versions[0].Name, noxuDefinition.Spec.Names.Plural, "test").
 			Body(patchBody).Do(context.TODO()).Error()
 		if !apierrors.IsBadRequest(err) {
 			t.Errorf("expected success or bad request err, got %v", err)
@@ -218,7 +219,7 @@ values: `+strings.Repeat("[", 3*1024*1024), apiVersion, kind))
 			t.Skip("skipping expensive test")
 		}
 		patchBody := []byte(`{"value":` + strings.Repeat("[", 3*1024*1024/2-100) + strings.Repeat("]", 3*1024*1024/2-100) + `}`)
-		err = rest.Patch(types.MergePatchType).AbsPath("/apis", noxuDefinition.Spec.Group, noxuDefinition.Spec.Version, noxuDefinition.Spec.Names.Plural, "test").
+		err = rest.Patch(types.MergePatchType).AbsPath("/apis", noxuDefinition.Spec.Group, noxuDefinition.Spec.Versions[0].Name, noxuDefinition.Spec.Names.Plural, "test").
 			Body(patchBody).Do(context.TODO()).Error()
 		if !apierrors.IsBadRequest(err) {
 			t.Errorf("expected success or bad request err, got %v", err)
@@ -229,7 +230,7 @@ values: `+strings.Repeat("[", 3*1024*1024), apiVersion, kind))
 			t.Skip("skipping expensive test")
 		}
 		patchBody := []byte(`{"value":` + strings.Repeat("[", 3*1024*1024/2-100) + strings.Repeat("]", 3*1024*1024/2-100) + `}`)
-		err = rest.Patch(types.ApplyPatchType).Param("fieldManager", "test").AbsPath("/apis", noxuDefinition.Spec.Group, noxuDefinition.Spec.Version, noxuDefinition.Spec.Names.Plural, "test").
+		err = rest.Patch(types.ApplyPatchType).Param("fieldManager", "test").AbsPath("/apis", noxuDefinition.Spec.Group, noxuDefinition.Spec.Versions[0].Name, noxuDefinition.Spec.Names.Plural, "test").
 			Body(patchBody).Do(context.TODO()).Error()
 		if !apierrors.IsBadRequest(err) {
 			t.Errorf("expected bad request err, got %#v", err)

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/limit_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/limit_test.go
@@ -23,13 +23,11 @@ import (
 	"testing"
 
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-
-	"k8s.io/client-go/dynamic"
-
 	"k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	"k8s.io/apiextensions-apiserver/test/integration/fixtures"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/dynamic"
 )
 
 func TestLimits(t *testing.T) {

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/listtype_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/listtype_test.go
@@ -23,16 +23,14 @@ import (
 	"time"
 
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-
-	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/client-go/util/retry"
-	"sigs.k8s.io/yaml"
-
 	"k8s.io/apiextensions-apiserver/test/integration/fixtures"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/util/retry"
+	"sigs.k8s.io/yaml"
 )
 
 var listTypeResourceFixture = &apiextensionsv1.CustomResourceDefinition{

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/listtype_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/listtype_test.go
@@ -22,37 +22,38 @@ import (
 	"testing"
 	"time"
 
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/yaml"
 
-	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/apiextensions-apiserver/test/integration/fixtures"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
-var listTypeResourceFixture = &apiextensionsv1beta1.CustomResourceDefinition{
+var listTypeResourceFixture = &apiextensionsv1.CustomResourceDefinition{
 	ObjectMeta: metav1.ObjectMeta{Name: "foos.tests.example.com"},
-	Spec: apiextensionsv1beta1.CustomResourceDefinitionSpec{
+	Spec: apiextensionsv1.CustomResourceDefinitionSpec{
 		Group: "tests.example.com",
-		Versions: []apiextensionsv1beta1.CustomResourceDefinitionVersion{
+		Versions: []apiextensionsv1.CustomResourceDefinitionVersion{
 			{
 				Name:    "v1beta1",
 				Storage: true,
 				Served:  true,
+				Schema:  fixtures.AllowAllSchema(),
 			},
 		},
-		Names: apiextensionsv1beta1.CustomResourceDefinitionNames{
+		Names: apiextensionsv1.CustomResourceDefinitionNames{
 			Plural:   "foos",
 			Singular: "foo",
 			Kind:     "Foo",
 			ListKind: "FooList",
 		},
-		Scope:      apiextensionsv1beta1.ClusterScoped,
-		Validation: &apiextensionsv1beta1.CustomResourceValidation{},
+		Scope: apiextensionsv1.ClusterScoped,
 	},
 }
 
@@ -128,11 +129,11 @@ func TestListTypes(t *testing.T) {
 	defer tearDownFn()
 
 	crd := listTypeResourceFixture.DeepCopy()
-	if err := yaml.Unmarshal([]byte(listTypeResourceSchema), &crd.Spec.Validation.OpenAPIV3Schema); err != nil {
+	if err := yaml.Unmarshal([]byte(listTypeResourceSchema), &crd.Spec.Versions[0].Schema.OpenAPIV3Schema); err != nil {
 		t.Fatal(err)
 	}
 
-	crd, err = fixtures.CreateNewCustomResourceDefinition(crd, apiExtensionClient, dynamicClient)
+	crd, err = fixtures.CreateNewV1CustomResourceDefinition(crd, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -195,14 +196,14 @@ func TestListTypes(t *testing.T) {
 
 	t.Logf("Remove \"b\" from the keys in the schema which renders the valid instance invalid")
 	err = retry.RetryOnConflict(retry.DefaultBackoff, func() error {
-		crd, err := apiExtensionClient.ApiextensionsV1beta1().CustomResourceDefinitions().Get(context.TODO(), crd.Name, metav1.GetOptions{})
+		crd, err := apiExtensionClient.ApiextensionsV1().CustomResourceDefinitions().Get(context.TODO(), crd.Name, metav1.GetOptions{})
 		if err != nil {
 			return err
 		}
-		s := crd.Spec.Validation.OpenAPIV3Schema.Properties["correct-map"]
+		s := crd.Spec.Versions[0].Schema.OpenAPIV3Schema.Properties["correct-map"]
 		s.XListMapKeys = []string{"a"}
-		crd.Spec.Validation.OpenAPIV3Schema.Properties["correct-map"] = s
-		_, err = apiExtensionClient.ApiextensionsV1beta1().CustomResourceDefinitions().Update(context.TODO(), crd, metav1.UpdateOptions{})
+		crd.Spec.Versions[0].Schema.OpenAPIV3Schema.Properties["correct-map"] = s
+		_, err = apiExtensionClient.ApiextensionsV1().CustomResourceDefinitions().Update(context.TODO(), crd, metav1.UpdateOptions{})
 		return err
 	})
 	if err != nil {

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/objectmeta_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/objectmeta_test.go
@@ -30,7 +30,6 @@ import (
 	"sigs.k8s.io/yaml"
 
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	serveroptions "k8s.io/apiextensions-apiserver/pkg/cmd/server/options"
 	"k8s.io/apiextensions-apiserver/test/integration/fixtures"
@@ -52,8 +51,8 @@ func TestPostInvalidObjectMeta(t *testing.T) {
 	}
 	defer tearDown()
 
-	noxuDefinition := fixtures.NewNoxuCustomResourceDefinition(apiextensionsv1beta1.NamespaceScoped)
-	noxuDefinition, err = fixtures.CreateNewCustomResourceDefinition(noxuDefinition, apiExtensionClient, dynamicClient)
+	noxuDefinition := fixtures.NewNoxuV1CustomResourceDefinition(apiextensionsv1.NamespaceScoped)
+	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(noxuDefinition, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -114,11 +113,11 @@ func TestInvalidObjectMetaInStorage(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	noxuDefinition := fixtures.NewNoxuCustomResourceDefinition(apiextensionsv1beta1.NamespaceScoped)
-	noxuDefinition.Spec.Validation = &apiextensionsv1beta1.CustomResourceValidation{
-		OpenAPIV3Schema: &apiextensionsv1beta1.JSONSchemaProps{
+	noxuDefinition := fixtures.NewNoxuV1CustomResourceDefinition(apiextensionsv1.NamespaceScoped)
+	noxuDefinition.Spec.Versions[0].Schema = &apiextensionsv1.CustomResourceValidation{
+		OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
 			Type: "object",
-			Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
+			Properties: map[string]apiextensionsv1.JSONSchemaProps{
 				"embedded": {
 					Type:                   "object",
 					XEmbeddedResource:      true,
@@ -127,7 +126,7 @@ func TestInvalidObjectMetaInStorage(t *testing.T) {
 			},
 		},
 	}
-	noxuDefinition, err = fixtures.CreateNewCustomResourceDefinition(noxuDefinition, apiExtensionClient, dynamicClient)
+	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(noxuDefinition, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/pruning_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/pruning_test.go
@@ -41,7 +41,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/json"
 	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/client-go/dynamic"
-	"k8s.io/utils/pointer"
 
 	"k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	"k8s.io/apiextensions-apiserver/test/integration/fixtures"
@@ -62,8 +61,7 @@ var pruningFixture = &apiextensionsv1.CustomResourceDefinition{
 				},
 				Schema: &apiextensionsv1.CustomResourceValidation{
 					OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
-						XPreserveUnknownFields: pointer.BoolPtr(false),
-						Type:                   "object",
+						Type: "object",
 					},
 				},
 			},

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/pruning_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/pruning_test.go
@@ -24,6 +24,8 @@ import (
 	"testing"
 	"time"
 
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+
 	"go.etcd.io/etcd/clientv3"
 	"go.etcd.io/etcd/pkg/transport"
 	"google.golang.org/grpc"
@@ -41,26 +43,36 @@ import (
 	"k8s.io/client-go/dynamic"
 	"k8s.io/utils/pointer"
 
-	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	"k8s.io/apiextensions-apiserver/test/integration/fixtures"
 )
 
-var pruningFixture = &apiextensionsv1beta1.CustomResourceDefinition{
+var pruningFixture = &apiextensionsv1.CustomResourceDefinition{
 	ObjectMeta: metav1.ObjectMeta{Name: "foos.tests.example.com"},
-	Spec: apiextensionsv1beta1.CustomResourceDefinitionSpec{
-		Group:   "tests.example.com",
-		Version: "v1beta1",
-		Names: apiextensionsv1beta1.CustomResourceDefinitionNames{
+	Spec: apiextensionsv1.CustomResourceDefinitionSpec{
+		Group: "tests.example.com",
+		Scope: apiextensionsv1.ClusterScoped,
+		Versions: []apiextensionsv1.CustomResourceDefinitionVersion{
+			{
+				Name:    "v1beta1",
+				Served:  true,
+				Storage: true,
+				Subresources: &apiextensionsv1.CustomResourceSubresources{
+					Status: &apiextensionsv1.CustomResourceSubresourceStatus{},
+				},
+				Schema: &apiextensionsv1.CustomResourceValidation{
+					OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
+						XPreserveUnknownFields: pointer.BoolPtr(false),
+						Type:                   "object",
+					},
+				},
+			},
+		},
+		Names: apiextensionsv1.CustomResourceDefinitionNames{
 			Plural:   "foos",
 			Singular: "foo",
 			Kind:     "Foo",
 			ListKind: "FooList",
-		},
-		Scope:                 apiextensionsv1beta1.ClusterScoped,
-		PreserveUnknownFields: pointer.BoolPtr(false),
-		Subresources: &apiextensionsv1beta1.CustomResourceSubresources{
-			Status: &apiextensionsv1beta1.CustomResourceSubresourceStatus{},
 		},
 	},
 }
@@ -189,18 +201,18 @@ func TestPruningCreate(t *testing.T) {
 	defer tearDownFn()
 
 	crd := pruningFixture.DeepCopy()
-	crd.Spec.Validation = &apiextensionsv1beta1.CustomResourceValidation{}
-	if err := yaml.Unmarshal([]byte(fooSchema), &crd.Spec.Validation.OpenAPIV3Schema); err != nil {
+	crd.Spec.Versions[0].Schema = &apiextensionsv1.CustomResourceValidation{}
+	if err := yaml.Unmarshal([]byte(fooSchema), &crd.Spec.Versions[0].Schema.OpenAPIV3Schema); err != nil {
 		t.Fatal(err)
 	}
 
-	crd, err = fixtures.CreateNewCustomResourceDefinition(crd, apiExtensionClient, dynamicClient)
+	crd, err = fixtures.CreateNewV1CustomResourceDefinition(crd, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	t.Logf("Creating CR and expect 'unspecified' fields to be pruned")
-	fooClient := dynamicClient.Resource(schema.GroupVersionResource{crd.Spec.Group, crd.Spec.Version, crd.Spec.Names.Plural})
+	fooClient := dynamicClient.Resource(schema.GroupVersionResource{crd.Spec.Group, crd.Spec.Versions[0].Name, crd.Spec.Names.Plural})
 	foo := &unstructured.Unstructured{}
 	if err := yaml.Unmarshal([]byte(pruningFooInstance), &foo.Object); err != nil {
 		t.Fatal(err)
@@ -241,18 +253,18 @@ func TestPruningStatus(t *testing.T) {
 	defer tearDownFn()
 
 	crd := pruningFixture.DeepCopy()
-	crd.Spec.Validation = &apiextensionsv1beta1.CustomResourceValidation{}
-	if err := yaml.Unmarshal([]byte(fooStatusSchema), &crd.Spec.Validation.OpenAPIV3Schema); err != nil {
+	crd.Spec.Versions[0].Schema = &apiextensionsv1.CustomResourceValidation{}
+	if err := yaml.Unmarshal([]byte(fooStatusSchema), &crd.Spec.Versions[0].Schema.OpenAPIV3Schema); err != nil {
 		t.Fatal(err)
 	}
 
-	crd, err = fixtures.CreateNewCustomResourceDefinition(crd, apiExtensionClient, dynamicClient)
+	crd, err = fixtures.CreateNewV1CustomResourceDefinition(crd, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	t.Logf("Creating CR and expect 'unspecified' fields to be pruned")
-	fooClient := dynamicClient.Resource(schema.GroupVersionResource{crd.Spec.Group, crd.Spec.Version, crd.Spec.Names.Plural})
+	fooClient := dynamicClient.Resource(schema.GroupVersionResource{crd.Spec.Group, crd.Spec.Versions[0].Name, crd.Spec.Names.Plural})
 	foo := &unstructured.Unstructured{}
 	if err := yaml.Unmarshal([]byte(pruningFooInstance), &foo.Object); err != nil {
 		t.Fatal(err)
@@ -310,12 +322,12 @@ func TestPruningFromStorage(t *testing.T) {
 	}
 
 	crd := pruningFixture.DeepCopy()
-	crd.Spec.Validation = &apiextensionsv1beta1.CustomResourceValidation{}
-	if err := yaml.Unmarshal([]byte(fooSchema), &crd.Spec.Validation.OpenAPIV3Schema); err != nil {
+	crd.Spec.Versions[0].Schema = &apiextensionsv1.CustomResourceValidation{}
+	if err := yaml.Unmarshal([]byte(fooSchema), &crd.Spec.Versions[0].Schema.OpenAPIV3Schema); err != nil {
 		t.Fatal(err)
 	}
 
-	crd, err = fixtures.CreateNewCustomResourceDefinition(crd, apiExtensionClient, dynamicClient)
+	crd, err = fixtures.CreateNewV1CustomResourceDefinition(crd, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -368,7 +380,7 @@ func TestPruningFromStorage(t *testing.T) {
 	}
 
 	t.Logf("Checking that CustomResource is pruned from unknown fields")
-	fooClient := dynamicClient.Resource(schema.GroupVersionResource{crd.Spec.Group, crd.Spec.Version, crd.Spec.Names.Plural})
+	fooClient := dynamicClient.Resource(schema.GroupVersionResource{crd.Spec.Group, crd.Spec.Versions[0].Name, crd.Spec.Names.Plural})
 	foo, err := fooClient.Get(context.TODO(), "foo", metav1.GetOptions{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -400,16 +412,16 @@ func TestPruningPatch(t *testing.T) {
 	defer tearDownFn()
 
 	crd := pruningFixture.DeepCopy()
-	crd.Spec.Validation = &apiextensionsv1beta1.CustomResourceValidation{}
-	if err := yaml.Unmarshal([]byte(fooSchema), &crd.Spec.Validation.OpenAPIV3Schema); err != nil {
+	crd.Spec.Versions[0].Schema = &apiextensionsv1.CustomResourceValidation{}
+	if err := yaml.Unmarshal([]byte(fooSchema), &crd.Spec.Versions[0].Schema.OpenAPIV3Schema); err != nil {
 		t.Fatal(err)
 	}
-	crd, err = fixtures.CreateNewCustomResourceDefinition(crd, apiExtensionClient, dynamicClient)
+	crd, err = fixtures.CreateNewV1CustomResourceDefinition(crd, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	fooClient := dynamicClient.Resource(schema.GroupVersionResource{crd.Spec.Group, crd.Spec.Version, crd.Spec.Names.Plural})
+	fooClient := dynamicClient.Resource(schema.GroupVersionResource{crd.Spec.Group, crd.Spec.Versions[0].Name, crd.Spec.Names.Plural})
 	foo := &unstructured.Unstructured{}
 	if err := yaml.Unmarshal([]byte(pruningFooInstance), &foo.Object); err != nil {
 		t.Fatal(err)
@@ -451,18 +463,18 @@ func TestPruningCreatePreservingUnknownFields(t *testing.T) {
 	defer tearDownFn()
 
 	crd := pruningFixture.DeepCopy()
-	crd.Spec.Validation = &apiextensionsv1beta1.CustomResourceValidation{}
-	if err := yaml.Unmarshal([]byte(fooSchemaPreservingUnknownFields), &crd.Spec.Validation.OpenAPIV3Schema); err != nil {
+	crd.Spec.Versions[0].Schema = &apiextensionsv1.CustomResourceValidation{}
+	if err := yaml.Unmarshal([]byte(fooSchemaPreservingUnknownFields), &crd.Spec.Versions[0].Schema.OpenAPIV3Schema); err != nil {
 		t.Fatal(err)
 	}
 
-	crd, err = fixtures.CreateNewCustomResourceDefinition(crd, apiExtensionClient, dynamicClient)
+	crd, err = fixtures.CreateNewV1CustomResourceDefinition(crd, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	t.Logf("Creating CR and expect 'unspecified' field to be pruned")
-	fooClient := dynamicClient.Resource(schema.GroupVersionResource{crd.Spec.Group, crd.Spec.Version, crd.Spec.Names.Plural})
+	fooClient := dynamicClient.Resource(schema.GroupVersionResource{crd.Spec.Group, crd.Spec.Versions[0].Name, crd.Spec.Names.Plural})
 	foo := &unstructured.Unstructured{}
 	if err := yaml.Unmarshal([]byte(pruningFooInstance), &foo.Object); err != nil {
 		t.Fatal(err)
@@ -536,18 +548,18 @@ func TestPruningEmbeddedResources(t *testing.T) {
 	defer tearDownFn()
 
 	crd := pruningFixture.DeepCopy()
-	crd.Spec.Validation = &apiextensionsv1beta1.CustomResourceValidation{}
-	if err := yaml.Unmarshal([]byte(fooSchemaEmbeddedResource), &crd.Spec.Validation.OpenAPIV3Schema); err != nil {
+	crd.Spec.Versions[0].Schema = &apiextensionsv1.CustomResourceValidation{}
+	if err := yaml.Unmarshal([]byte(fooSchemaEmbeddedResource), &crd.Spec.Versions[0].Schema.OpenAPIV3Schema); err != nil {
 		t.Fatal(err)
 	}
 
-	crd, err = fixtures.CreateNewCustomResourceDefinition(crd, apiExtensionClient, dynamicClient)
+	crd, err = fixtures.CreateNewV1CustomResourceDefinition(crd, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	t.Logf("Creating CR and expect 'unspecified' field to be pruned")
-	fooClient := dynamicClient.Resource(schema.GroupVersionResource{crd.Spec.Group, crd.Spec.Version, crd.Spec.Names.Plural})
+	fooClient := dynamicClient.Resource(schema.GroupVersionResource{crd.Spec.Group, crd.Spec.Versions[0].Name, crd.Spec.Names.Plural})
 	foo := &unstructured.Unstructured{}
 	if err := yaml.Unmarshal([]byte(fooSchemaEmbeddedResourceInstance), &foo.Object); err != nil {
 		t.Fatal(err)

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/registration_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/registration_test.go
@@ -28,7 +28,7 @@ import (
 
 	"go.etcd.io/etcd/clientv3"
 
-	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apiextensionsclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	"k8s.io/apiextensions-apiserver/test/integration/fixtures"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -47,8 +47,8 @@ func TestMultipleResourceInstances(t *testing.T) {
 	defer tearDown()
 
 	ns := "not-the-default"
-	noxuDefinition := fixtures.NewNoxuCustomResourceDefinition(apiextensionsv1beta1.NamespaceScoped)
-	noxuDefinition, err = fixtures.CreateNewCustomResourceDefinition(noxuDefinition, apiExtensionClient, dynamicClient)
+	noxuDefinition := fixtures.NewNoxuV1CustomResourceDefinition(apiextensionsv1.NamespaceScoped)
+	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(noxuDefinition, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -172,8 +172,8 @@ func TestMultipleRegistration(t *testing.T) {
 
 	ns := "not-the-default"
 	sameInstanceName := "foo"
-	noxuDefinition := fixtures.NewNoxuCustomResourceDefinition(apiextensionsv1beta1.NamespaceScoped)
-	noxuDefinition, err = fixtures.CreateNewCustomResourceDefinition(noxuDefinition, apiExtensionClient, dynamicClient)
+	noxuDefinition := fixtures.NewNoxuV1CustomResourceDefinition(apiextensionsv1.NamespaceScoped)
+	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(noxuDefinition, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -191,8 +191,8 @@ func TestMultipleRegistration(t *testing.T) {
 		t.Errorf("expected %v, got %v", e, a)
 	}
 
-	curletDefinition := fixtures.NewCurletCustomResourceDefinition(apiextensionsv1beta1.NamespaceScoped)
-	curletDefinition, err = fixtures.CreateNewCustomResourceDefinition(curletDefinition, apiExtensionClient, dynamicClient)
+	curletDefinition := fixtures.NewCurletV1CustomResourceDefinition(apiextensionsv1.NamespaceScoped)
+	curletDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(curletDefinition, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -225,11 +225,11 @@ func TestDeRegistrationAndReRegistration(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer tearDown()
-	noxuDefinition := fixtures.NewNoxuCustomResourceDefinition(apiextensionsv1beta1.NamespaceScoped)
+	noxuDefinition := fixtures.NewNoxuV1CustomResourceDefinition(apiextensionsv1.NamespaceScoped)
 	ns := "not-the-default"
 	sameInstanceName := "foo"
 	func() {
-		noxuDefinition, err := fixtures.CreateNewCustomResourceDefinition(noxuDefinition, apiExtensionClient, dynamicClient)
+		noxuDefinition, err := fixtures.CreateNewV1CustomResourceDefinition(noxuDefinition, apiExtensionClient, dynamicClient)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -237,10 +237,10 @@ func TestDeRegistrationAndReRegistration(t *testing.T) {
 		if _, err := instantiateCustomResource(t, fixtures.NewNoxuInstance(ns, sameInstanceName), noxuNamespacedResourceClient, noxuDefinition); err != nil {
 			t.Fatal(err)
 		}
-		if err := fixtures.DeleteCustomResourceDefinition(noxuDefinition, apiExtensionClient); err != nil {
+		if err := fixtures.DeleteV1CustomResourceDefinition(noxuDefinition, apiExtensionClient); err != nil {
 			t.Fatal(err)
 		}
-		if _, err := apiExtensionClient.ApiextensionsV1beta1().CustomResourceDefinitions().Get(context.TODO(), noxuDefinition.Name, metav1.GetOptions{}); err == nil || !errors.IsNotFound(err) {
+		if _, err := apiExtensionClient.ApiextensionsV1().CustomResourceDefinitions().Get(context.TODO(), noxuDefinition.Name, metav1.GetOptions{}); err == nil || !errors.IsNotFound(err) {
 			t.Fatalf("expected a NotFound error, got:%v", err)
 		}
 		if _, err = noxuNamespacedResourceClient.List(context.TODO(), metav1.ListOptions{}); err == nil || !errors.IsNotFound(err) {
@@ -252,10 +252,10 @@ func TestDeRegistrationAndReRegistration(t *testing.T) {
 	}()
 
 	func() {
-		if _, err := apiExtensionClient.ApiextensionsV1beta1().CustomResourceDefinitions().Get(context.TODO(), noxuDefinition.Name, metav1.GetOptions{}); err == nil || !errors.IsNotFound(err) {
+		if _, err := apiExtensionClient.ApiextensionsV1().CustomResourceDefinitions().Get(context.TODO(), noxuDefinition.Name, metav1.GetOptions{}); err == nil || !errors.IsNotFound(err) {
 			t.Fatalf("expected a NotFound error, got:%v", err)
 		}
-		noxuDefinition, err := fixtures.CreateNewCustomResourceDefinition(noxuDefinition, apiExtensionClient, dynamicClient)
+		noxuDefinition, err := fixtures.CreateNewV1CustomResourceDefinition(noxuDefinition, apiExtensionClient, dynamicClient)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -327,8 +327,8 @@ func TestEtcdStorage(t *testing.T) {
 	etcdPrefix := s.RecommendedOptions.Etcd.StorageConfig.Prefix
 
 	ns1 := "another-default-is-possible"
-	curletDefinition := fixtures.NewCurletCustomResourceDefinition(apiextensionsv1beta1.ClusterScoped)
-	curletDefinition, err = fixtures.CreateNewCustomResourceDefinition(curletDefinition, apiExtensionClient, dynamicClient)
+	curletDefinition := fixtures.NewCurletV1CustomResourceDefinition(apiextensionsv1.ClusterScoped)
+	curletDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(curletDefinition, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -338,8 +338,8 @@ func TestEtcdStorage(t *testing.T) {
 	}
 
 	ns2 := "the-cruel-default"
-	noxuDefinition := fixtures.NewNoxuCustomResourceDefinition(apiextensionsv1beta1.NamespaceScoped)
-	noxuDefinition, err = fixtures.CreateNewCustomResourceDefinition(noxuDefinition, apiExtensionClient, dynamicClient)
+	noxuDefinition := fixtures.NewNoxuV1CustomResourceDefinition(apiextensionsv1.NamespaceScoped)
+	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(noxuDefinition, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/scope_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/scope_test.go
@@ -21,6 +21,8 @@ import (
 	"strings"
 	"testing"
 
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+
 	"github.com/stretchr/testify/assert"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -30,7 +32,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/dynamic"
 
-	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/apiextensions-apiserver/test/integration/fixtures"
 )
 
@@ -41,15 +42,32 @@ func TestHandlerScope(t *testing.T) {
 	}
 	defer tearDown()
 
-	for _, scope := range []apiextensionsv1beta1.ResourceScope{apiextensionsv1beta1.ClusterScoped, apiextensionsv1beta1.NamespaceScoped} {
+	for _, scope := range []apiextensionsv1.ResourceScope{apiextensionsv1.ClusterScoped, apiextensionsv1.NamespaceScoped} {
 		t.Run(string(scope), func(t *testing.T) {
 
-			crd := &apiextensionsv1beta1.CustomResourceDefinition{
-				ObjectMeta: metav1.ObjectMeta{Name: strings.ToLower(string(scope)) + "s.test.apiextensions-apiserver.k8s.io"},
-				Spec: apiextensionsv1beta1.CustomResourceDefinitionSpec{
-					Group:   "test.apiextensions-apiserver.k8s.io",
-					Version: "v1beta1",
-					Names: apiextensionsv1beta1.CustomResourceDefinitionNames{
+			crd := &apiextensionsv1.CustomResourceDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        strings.ToLower(string(scope)) + "s.test.apiextensions-apiserver.k8s.io",
+					Annotations: map[string]string{"api-approved.kubernetes.io": "unapproved, test-only"},
+				},
+				Spec: apiextensionsv1.CustomResourceDefinitionSpec{
+					Group: "test.apiextensions-apiserver.k8s.io",
+					Versions: []apiextensionsv1.CustomResourceDefinitionVersion{
+						{
+							Name:    "v1beta1",
+							Served:  true,
+							Storage: true,
+							Subresources: &apiextensionsv1.CustomResourceSubresources{
+								Status: &apiextensionsv1.CustomResourceSubresourceStatus{},
+								Scale: &apiextensionsv1.CustomResourceSubresourceScale{
+									SpecReplicasPath:   ".spec.replicas",
+									StatusReplicasPath: ".status.replicas",
+								},
+							},
+							Schema: fixtures.AllowAllSchema(),
+						},
+					},
+					Names: apiextensionsv1.CustomResourceDefinitionNames{
 						Plural:   strings.ToLower(string(scope)) + "s",
 						Singular: strings.ToLower(string(scope)),
 						Kind:     string(scope),
@@ -58,14 +76,7 @@ func TestHandlerScope(t *testing.T) {
 					Scope: scope,
 				},
 			}
-			crd.Spec.Subresources = &apiextensionsv1beta1.CustomResourceSubresources{
-				Status: &apiextensionsv1beta1.CustomResourceSubresourceStatus{},
-				Scale: &apiextensionsv1beta1.CustomResourceSubresourceScale{
-					SpecReplicasPath:   ".spec.replicas",
-					StatusReplicasPath: ".status.replicas",
-				},
-			}
-			crd, err = fixtures.CreateNewCustomResourceDefinition(crd, apiExtensionClient, dynamicClient)
+			crd, err = fixtures.CreateNewV1CustomResourceDefinition(crd, apiExtensionClient, dynamicClient)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -75,7 +86,7 @@ func TestHandlerScope(t *testing.T) {
 			ns := "test"
 			var client dynamic.ResourceInterface = dynamicClient.Resource(gvr)
 			var otherScopeClient dynamic.ResourceInterface = dynamicClient.Resource(gvr).Namespace(ns)
-			if crd.Spec.Scope == apiextensionsv1beta1.NamespaceScoped {
+			if crd.Spec.Scope == apiextensionsv1.NamespaceScoped {
 				client, otherScopeClient = otherScopeClient, client
 			}
 
@@ -141,7 +152,7 @@ func TestHandlerScope(t *testing.T) {
 			err = otherScopeClient.DeleteCollection(context.TODO(), metav1.DeleteOptions{}, metav1.ListOptions{})
 			assert.True(t, apierrors.IsNotFound(err))
 
-			if scope == apiextensionsv1beta1.ClusterScoped {
+			if scope == apiextensionsv1.ClusterScoped {
 				_, err = otherScopeClient.List(context.TODO(), metav1.ListOptions{})
 				assert.True(t, apierrors.IsNotFound(err))
 

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/scope_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/scope_test.go
@@ -21,18 +21,16 @@ import (
 	"strings"
 	"testing"
 
-	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-
 	"github.com/stretchr/testify/assert"
 
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apiextensions-apiserver/test/integration/fixtures"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/dynamic"
-
-	"k8s.io/apiextensions-apiserver/test/integration/fixtures"
 )
 
 func TestHandlerScope(t *testing.T) {

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/subresources_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/subresources_test.go
@@ -388,7 +388,6 @@ func TestValidationSchemaWithStatus(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// fields other than properties in root schema are not allowed
 	noxuDefinition := newNoxuValidationCRDs()[0]
 
 	// make sure we are not restricting fields to properties even in subschemas
@@ -457,12 +456,10 @@ func TestValidateOnlyStatus(t *testing.T) {
 	noxuDefinitions := NewNoxuSubresourcesCRDs(apiextensionsv1.NamespaceScoped)
 	for _, noxuDefinition := range noxuDefinitions {
 		noxuDefinition.Spec.Versions[0].Schema = &apiextensionsv1.CustomResourceValidation{
-			OpenAPIV3Schema: schema,
+			OpenAPIV3Schema: schema.DeepCopy(),
 		}
-		schemaWithDescription := schema.DeepCopy()
-		schemaWithDescription.Description = "test"
 		noxuDefinition.Spec.Versions[1].Schema = &apiextensionsv1.CustomResourceValidation{
-			OpenAPIV3Schema: schemaWithDescription,
+			OpenAPIV3Schema: schema.DeepCopy(),
 		}
 
 		noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(noxuDefinition, apiExtensionClient, dynamicClient)

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/table_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/table_test.go
@@ -32,42 +32,42 @@ import (
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/rest"
 
-	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	"k8s.io/apiextensions-apiserver/test/integration/fixtures"
 )
 
-func newTableCRD() *apiextensionsv1beta1.CustomResourceDefinition {
-	return &apiextensionsv1beta1.CustomResourceDefinition{
+func newTableCRD() *apiextensionsv1.CustomResourceDefinition {
+	return &apiextensionsv1.CustomResourceDefinition{
 		ObjectMeta: metav1.ObjectMeta{Name: "tables.mygroup.example.com"},
-		Spec: apiextensionsv1beta1.CustomResourceDefinitionSpec{
-			Group:   "mygroup.example.com",
-			Version: "v1beta1",
-			Names: apiextensionsv1beta1.CustomResourceDefinitionNames{
+		Spec: apiextensionsv1.CustomResourceDefinitionSpec{
+			Group: "mygroup.example.com",
+			Names: apiextensionsv1.CustomResourceDefinitionNames{
 				Plural:   "tables",
 				Singular: "table",
 				Kind:     "Table",
 				ListKind: "TablemList",
 			},
-			Scope: apiextensionsv1beta1.ClusterScoped,
-			Versions: []apiextensionsv1beta1.CustomResourceDefinitionVersion{
+			Scope: apiextensionsv1.ClusterScoped,
+			Versions: []apiextensionsv1.CustomResourceDefinitionVersion{
 				{
 					Name:    "v1beta1",
 					Served:  true,
 					Storage: false,
-					AdditionalPrinterColumns: []apiextensionsv1beta1.CustomResourceColumnDefinition{
+					AdditionalPrinterColumns: []apiextensionsv1.CustomResourceColumnDefinition{
 						{Name: "Age", Type: "date", JSONPath: ".metadata.creationTimestamp"},
 						{Name: "Alpha", Type: "string", JSONPath: ".spec.alpha"},
 						{Name: "Beta", Type: "integer", Description: "the beta field", Format: "int64", Priority: 42, JSONPath: ".spec.beta"},
 						{Name: "Gamma", Type: "integer", Description: "a column with wrongly typed values", JSONPath: ".spec.gamma"},
 						{Name: "Epsilon", Type: "string", Description: "an array of integers as string", JSONPath: ".spec.epsilon"},
 					},
+					Schema: fixtures.AllowAllSchema(),
 				},
 				{
 					Name:    "v1",
 					Served:  true,
 					Storage: true,
-					AdditionalPrinterColumns: []apiextensionsv1beta1.CustomResourceColumnDefinition{
+					AdditionalPrinterColumns: []apiextensionsv1.CustomResourceColumnDefinition{
 						{Name: "Age", Type: "date", JSONPath: ".metadata.creationTimestamp"},
 						{Name: "Alpha", Type: "string", JSONPath: ".spec.alpha"},
 						{Name: "Beta", Type: "integer", Description: "the beta field", Format: "int64", Priority: 42, JSONPath: ".spec.beta"},
@@ -75,6 +75,7 @@ func newTableCRD() *apiextensionsv1beta1.CustomResourceDefinition {
 						{Name: "Epsilon", Type: "string", Description: "an array of integers as string", JSONPath: ".spec.epsilon"},
 						{Name: "Zeta", Type: "integer", Description: "the zeta field", Format: "int64", Priority: 42, JSONPath: ".spec.zeta"},
 					},
+					Schema: fixtures.AllowAllSchema(),
 				},
 			},
 		},
@@ -119,12 +120,12 @@ func TestTableGet(t *testing.T) {
 	}
 
 	crd := newTableCRD()
-	crd, err = fixtures.CreateNewCustomResourceDefinition(crd, apiExtensionClient, dynamicClient)
+	crd, err = fixtures.CreateNewV1CustomResourceDefinition(crd, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	crd, err = apiExtensionClient.ApiextensionsV1beta1().CustomResourceDefinitions().Get(context.TODO(), crd.Name, metav1.GetOptions{})
+	crd, err = apiExtensionClient.ApiextensionsV1().CustomResourceDefinitions().Get(context.TODO(), crd.Name, metav1.GetOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -377,8 +378,8 @@ func TestColumnsPatch(t *testing.T) {
 	}
 
 	// CRD with no top-level and per-version columns should be created successfully
-	crd := NewNoxuSubresourcesCRDs(apiextensionsv1beta1.NamespaceScoped)[0]
-	crd, err = fixtures.CreateNewCustomResourceDefinition(crd, apiExtensionClient, dynamicClient)
+	crd := NewNoxuSubresourcesCRDs(apiextensionsv1.NamespaceScoped)[0]
+	crd, err = fixtures.CreateNewV1CustomResourceDefinition(crd, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -386,14 +387,50 @@ func TestColumnsPatch(t *testing.T) {
 	// One should be able to patch the CRD to use per-version columns. The top-level columns
 	// should not be defaulted during creation, and apiserver should not return validation
 	// error about top-level and per-version columns being mutual exclusive.
-	patch := []byte(`{"spec":{"versions":[{"name":"v1beta1","served":true,"storage":true,"additionalPrinterColumns":[{"name":"Age","type":"date","JSONPath":".metadata.creationTimestamp"}]},{"name":"v1","served":true,"storage":false,"additionalPrinterColumns":[{"name":"Age2","type":"date","JSONPath":".metadata.creationTimestamp"}]}]}}`)
+	patch := []byte(`{
+  "spec": {
+    "versions": [
+      {
+        "name": "v1beta1",
+        "served": true,
+        "storage": true,
+        "additionalPrinterColumns": [
+          {
+            "name": "Age",
+            "type": "date",
+            "jsonPath": ".metadata.creationTimestamp"
+          }
+        ],
+        "schema": {
+          "openAPIV3Schema": {"x-kubernetes-preserve-unknown-fields": true, "type": "object"}
+        }
+      },
+      {
+        "name": "v1",
+        "served": true,
+        "storage": false,
+        "additionalPrinterColumns": [
+          {
+            "name": "Age2",
+            "type": "date",
+            "jsonPath": ".metadata.creationTimestamp"
+          }
+        ],
+        "schema": {
+          "openAPIV3Schema": {"x-kubernetes-preserve-unknown-fields": true, "type": "object"}
+        }
+      }
+    ]
+  }
+}
+`)
 
-	_, err = apiExtensionClient.ApiextensionsV1beta1().CustomResourceDefinitions().Patch(context.TODO(), crd.Name, types.MergePatchType, patch, metav1.PatchOptions{})
+	_, err = apiExtensionClient.ApiextensionsV1().CustomResourceDefinitions().Patch(context.TODO(), crd.Name, types.MergePatchType, patch, metav1.PatchOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	crd, err = apiExtensionClient.ApiextensionsV1beta1().CustomResourceDefinitions().Get(context.TODO(), crd.Name, metav1.GetOptions{})
+	crd, err = apiExtensionClient.ApiextensionsV1().CustomResourceDefinitions().Get(context.TODO(), crd.Name, metav1.GetOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -420,11 +457,11 @@ func TestPatchCleanTopLevelColumns(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	crd := NewNoxuSubresourcesCRDs(apiextensionsv1beta1.NamespaceScoped)[0]
-	crd.Spec.AdditionalPrinterColumns = []apiextensionsv1beta1.CustomResourceColumnDefinition{
+	crd := NewNoxuSubresourcesCRDs(apiextensionsv1.NamespaceScoped)[0]
+	crd.Spec.Versions[0].AdditionalPrinterColumns = []apiextensionsv1.CustomResourceColumnDefinition{
 		{Name: "Age", Type: "date", Description: swaggerMetadataDescriptions["creationTimestamp"], JSONPath: ".metadata.creationTimestamp"},
 	}
-	crd, err = fixtures.CreateNewCustomResourceDefinition(crd, apiExtensionClient, dynamicClient)
+	crd, err = fixtures.CreateNewV1CustomResourceDefinition(crd, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -432,14 +469,51 @@ func TestPatchCleanTopLevelColumns(t *testing.T) {
 
 	// One should be able to patch the CRD to use per-version columns by cleaning
 	// the top-level columns.
-	patch := []byte(`{"spec":{"additionalPrinterColumns":null,"versions":[{"name":"v1beta1","served":true,"storage":true,"additionalPrinterColumns":[{"name":"Age","type":"date","JSONPath":".metadata.creationTimestamp"}]},{"name":"v1","served":true,"storage":false,"additionalPrinterColumns":[{"name":"Age2","type":"date","JSONPath":".metadata.creationTimestamp"}]}]}}`)
+	patch := []byte(`{
+  "spec": {
+    "additionalPrinterColumns": null,
+    "versions": [
+      {
+        "name": "v1beta1",
+        "served": true,
+        "storage": true,
+        "additionalPrinterColumns": [
+          {
+            "name": "Age",
+            "type": "date",
+            "jsonPath": ".metadata.creationTimestamp"
+          }
+        ],
+        "schema": {
+          "openAPIV3Schema": {"x-kubernetes-preserve-unknown-fields": true, "type": "object"}
+        }
+      },
+      {
+        "name": "v1",
+        "served": true,
+        "storage": false,
+        "additionalPrinterColumns": [
+          {
+            "name": "Age2",
+            "type": "date",
+            "jsonPath": ".metadata.creationTimestamp"
+          }
+        ],
+        "schema": {
+          "openAPIV3Schema": {"x-kubernetes-preserve-unknown-fields": true, "type": "object"}
+        }
+      }
+    ]
+  }
+}
+`)
 
-	_, err = apiExtensionClient.ApiextensionsV1beta1().CustomResourceDefinitions().Patch(context.TODO(), crd.Name, types.MergePatchType, patch, metav1.PatchOptions{})
+	_, err = apiExtensionClient.ApiextensionsV1().CustomResourceDefinitions().Patch(context.TODO(), crd.Name, types.MergePatchType, patch, metav1.PatchOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	crd, err = apiExtensionClient.ApiextensionsV1beta1().CustomResourceDefinitions().Get(context.TODO(), crd.Name, metav1.GetOptions{})
+	crd, err = apiExtensionClient.ApiextensionsV1().CustomResourceDefinitions().Get(context.TODO(), crd.Name, metav1.GetOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/validation_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/validation_test.go
@@ -835,7 +835,6 @@ spec:
 }
 
 func TestNonStructuralSchemaCondition(t *testing.T) {
-	t.Skip("non-structural schemas can no longer be created")
 	tearDown, apiExtensionClient, _, err := fixtures.StartDefaultServerWithClients(t)
 	if err != nil {
 		t.Fatal(err)
@@ -1603,12 +1602,12 @@ properties:
 			if err != nil {
 				t.Fatalf("failed decoding of: %v\n\n%s", err, manifest)
 			}
-			crd := obj.(*apiextensionsv1.CustomResourceDefinition)
+			crd := obj.(*apiextensionsv1beta1.CustomResourceDefinition)
 			crd.Spec.Group = fmt.Sprintf("tests-%d.apiextension.k8s.io", i)
 			crd.Name = fmt.Sprintf("foos.%s", crd.Spec.Group)
 
 			// create CRDs
-			crd, err = apiExtensionClient.ApiextensionsV1().CustomResourceDefinitions().Create(context.TODO(), crd, metav1.CreateOptions{})
+			crd, err = apiExtensionClient.ApiextensionsV1beta1().CustomResourceDefinitions().Create(context.TODO(), crd, metav1.CreateOptions{})
 			if len(tst.expectedCreateErrors) > 0 && err == nil {
 				t.Fatalf("expected create errors, got none")
 			} else if len(tst.expectedCreateErrors) == 0 && err != nil {

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/validation_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/validation_test.go
@@ -744,7 +744,7 @@ spec:
 	origSchema := &apiextensionsv1.JSONSchemaProps{
 		Type: "object",
 		Properties: map[string]apiextensionsv1.JSONSchemaProps{
-			"a": apiextensionsv1.JSONSchemaProps{
+			"a": {
 				Type: "object",
 			},
 		},
@@ -1712,10 +1712,6 @@ func toValidationJSON(yml string) string {
 }
 
 func float64Ptr(f float64) *float64 {
-	return &f
-}
-
-func int64Ptr(f int64) *int64 {
 	return &f
 }
 

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/validation_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/validation_test.go
@@ -647,21 +647,24 @@ func TestForbiddenFieldsInSchema(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			// v1 doesn't allow additional properties at all. this isn't necessary in v1.
-			//validationSchema.OpenAPIV3Schema.AdditionalProperties.Allows = false
-			//_, err = fixtures.CreateNewV1CustomResourceDefinition(noxuDefinition, apiExtensionClient, dynamicClient)
-			//if err == nil {
-			//	t.Fatalf("unexpected non-error: additionalProperties cannot be set to false")
-			//}
+			existingProperties := validationSchema.OpenAPIV3Schema.Properties
+			validationSchema.OpenAPIV3Schema.Properties = nil
+			validationSchema.OpenAPIV3Schema.AdditionalProperties = &apiextensionsv1.JSONSchemaPropsOrBool{Allows: false}
+			_, err = fixtures.CreateNewV1CustomResourceDefinition(noxuDefinition, apiExtensionClient, dynamicClient)
+			if err == nil {
+				t.Fatalf("unexpected non-error: additionalProperties cannot be set to false")
+			}
+			// reset
+			validationSchema.OpenAPIV3Schema.Properties = existingProperties
+			validationSchema.OpenAPIV3Schema.AdditionalProperties = nil
 
 			validationSchema.OpenAPIV3Schema.Properties["zeta"] = apiextensionsv1.JSONSchemaProps{
 				Type:        "array",
 				UniqueItems: true,
+				AdditionalProperties: &apiextensionsv1.JSONSchemaPropsOrBool{
+					Allows: true,
+				},
 			}
-
-			// v1 doesn't allow additional properties at all. this isn't necessary in v1.
-			//validationSchema.OpenAPIV3Schema.AdditionalProperties.Allows = true
-
 			_, err = fixtures.CreateNewV1CustomResourceDefinition(noxuDefinition, apiExtensionClient, dynamicClient)
 			if err == nil {
 				t.Fatalf("unexpected non-error: uniqueItems cannot be set to true")

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/versioning_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/versioning_test.go
@@ -25,7 +25,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apiextensions-apiserver/test/integration/fixtures"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -40,13 +40,13 @@ func TestInternalVersionIsHandlerVersion(t *testing.T) {
 	}
 	defer tearDown()
 
-	noxuDefinition := fixtures.NewMultipleVersionNoxuCRD(apiextensionsv1beta1.NamespaceScoped)
+	noxuDefinition := fixtures.NewMultipleVersionNoxuCRD(apiextensionsv1.NamespaceScoped)
 
 	assert.Equal(t, "v1beta1", noxuDefinition.Spec.Versions[0].Name)
 	assert.Equal(t, "v1beta2", noxuDefinition.Spec.Versions[1].Name)
 	assert.True(t, noxuDefinition.Spec.Versions[1].Storage)
 
-	noxuDefinition, err = fixtures.CreateNewCustomResourceDefinition(noxuDefinition, apiExtensionClient, dynamicClient)
+	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(noxuDefinition, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -64,16 +64,20 @@ func TestInternalVersionIsHandlerVersion(t *testing.T) {
 
 	// update validation via update because the cache priming in CreateNewCustomResourceDefinition will fail otherwise
 	t.Logf("Updating CRD to validate apiVersion")
-	noxuDefinition, err = UpdateCustomResourceDefinitionWithRetry(apiExtensionClient, noxuDefinition.Name, func(crd *apiextensionsv1beta1.CustomResourceDefinition) {
-		crd.Spec.Validation = &apiextensionsv1beta1.CustomResourceValidation{
-			OpenAPIV3Schema: &apiextensionsv1beta1.JSONSchemaProps{
-				Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
-					"apiVersion": {
-						Pattern: "^mygroup.example.com/v1beta1$", // this means we can only patch via the v1beta1 handler version
+	noxuDefinition, err = UpdateCustomResourceDefinitionWithRetry(apiExtensionClient, noxuDefinition.Name, func(crd *apiextensionsv1.CustomResourceDefinition) {
+		for i := range crd.Spec.Versions {
+			crd.Spec.Versions[i].Schema = &apiextensionsv1.CustomResourceValidation{
+				OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
+					Type: "object",
+					Properties: map[string]apiextensionsv1.JSONSchemaProps{
+						"apiVersion": {
+							Pattern: "^mygroup.example.com/v1beta1$", // this means we can only patch via the v1beta1 handler version
+							Type:    "string",
+						},
 					},
+					Required: []string{"apiVersion"},
 				},
-				Required: []string{"apiVersion"},
-			},
+			}
 		}
 	})
 	assert.NoError(t, err)
@@ -134,8 +138,8 @@ func TestVersionedNamespacedScopedCRD(t *testing.T) {
 	}
 	defer tearDown()
 
-	noxuDefinition := fixtures.NewMultipleVersionNoxuCRD(apiextensionsv1beta1.NamespaceScoped)
-	noxuDefinition, err = fixtures.CreateNewCustomResourceDefinition(noxuDefinition, apiExtensionClient, dynamicClient)
+	noxuDefinition := fixtures.NewMultipleVersionNoxuCRD(apiextensionsv1.NamespaceScoped)
+	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(noxuDefinition, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -151,8 +155,8 @@ func TestVersionedClusterScopedCRD(t *testing.T) {
 	}
 	defer tearDown()
 
-	noxuDefinition := fixtures.NewMultipleVersionNoxuCRD(apiextensionsv1beta1.ClusterScoped)
-	noxuDefinition, err = fixtures.CreateNewCustomResourceDefinition(noxuDefinition, apiExtensionClient, dynamicClient)
+	noxuDefinition := fixtures.NewMultipleVersionNoxuCRD(apiextensionsv1.ClusterScoped)
+	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(noxuDefinition, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -162,40 +166,44 @@ func TestVersionedClusterScopedCRD(t *testing.T) {
 }
 
 func TestStoragedVersionInNamespacedCRDStatus(t *testing.T) {
-	noxuDefinition := fixtures.NewMultipleVersionNoxuCRD(apiextensionsv1beta1.NamespaceScoped)
+	noxuDefinition := fixtures.NewMultipleVersionNoxuCRD(apiextensionsv1.NamespaceScoped)
 	ns := "not-the-default"
 	testStoragedVersionInCRDStatus(t, ns, noxuDefinition)
 }
 
 func TestStoragedVersionInClusterScopedCRDStatus(t *testing.T) {
-	noxuDefinition := fixtures.NewMultipleVersionNoxuCRD(apiextensionsv1beta1.ClusterScoped)
+	noxuDefinition := fixtures.NewMultipleVersionNoxuCRD(apiextensionsv1.ClusterScoped)
 	ns := ""
 	testStoragedVersionInCRDStatus(t, ns, noxuDefinition)
 }
 
-func testStoragedVersionInCRDStatus(t *testing.T, ns string, noxuDefinition *apiextensionsv1beta1.CustomResourceDefinition) {
-	versionsV1Beta1Storage := []apiextensionsv1beta1.CustomResourceDefinitionVersion{
+func testStoragedVersionInCRDStatus(t *testing.T, ns string, noxuDefinition *apiextensionsv1.CustomResourceDefinition) {
+	versionsV1Beta1Storage := []apiextensionsv1.CustomResourceDefinitionVersion{
 		{
 			Name:    "v1beta1",
 			Served:  true,
 			Storage: true,
+			Schema:  fixtures.AllowAllSchema(),
 		},
 		{
 			Name:    "v1beta2",
 			Served:  true,
 			Storage: false,
+			Schema:  fixtures.AllowAllSchema(),
 		},
 	}
-	versionsV1Beta2Storage := []apiextensionsv1beta1.CustomResourceDefinitionVersion{
+	versionsV1Beta2Storage := []apiextensionsv1.CustomResourceDefinitionVersion{
 		{
 			Name:    "v1beta1",
 			Served:  true,
 			Storage: false,
+			Schema:  fixtures.AllowAllSchema(),
 		},
 		{
 			Name:    "v1beta2",
 			Served:  true,
 			Storage: true,
+			Schema:  fixtures.AllowAllSchema(),
 		},
 	}
 	tearDown, apiExtensionClient, dynamicClient, err := fixtures.StartDefaultServerWithClients(t)
@@ -205,13 +213,13 @@ func testStoragedVersionInCRDStatus(t *testing.T, ns string, noxuDefinition *api
 	defer tearDown()
 
 	noxuDefinition.Spec.Versions = versionsV1Beta1Storage
-	noxuDefinition, err = fixtures.CreateNewCustomResourceDefinition(noxuDefinition, apiExtensionClient, dynamicClient)
+	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(noxuDefinition, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// The storage version list should be initilized to storage version
-	crd, err := apiExtensionClient.ApiextensionsV1beta1().CustomResourceDefinitions().Get(context.TODO(), noxuDefinition.Name, metav1.GetOptions{})
+	crd, err := apiExtensionClient.ApiextensionsV1().CustomResourceDefinitions().Get(context.TODO(), noxuDefinition.Name, metav1.GetOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -221,11 +229,11 @@ func testStoragedVersionInCRDStatus(t *testing.T, ns string, noxuDefinition *api
 
 	// Changing CRD storage version should be reflected immediately
 	crd.Spec.Versions = versionsV1Beta2Storage
-	_, err = apiExtensionClient.ApiextensionsV1beta1().CustomResourceDefinitions().Update(context.TODO(), crd, metav1.UpdateOptions{})
+	_, err = apiExtensionClient.ApiextensionsV1().CustomResourceDefinitions().Update(context.TODO(), crd, metav1.UpdateOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
-	crd, err = apiExtensionClient.ApiextensionsV1beta1().CustomResourceDefinitions().Get(context.TODO(), noxuDefinition.Name, metav1.GetOptions{})
+	crd, err = apiExtensionClient.ApiextensionsV1().CustomResourceDefinitions().Get(context.TODO(), noxuDefinition.Name, metav1.GetOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -233,7 +241,7 @@ func testStoragedVersionInCRDStatus(t *testing.T, ns string, noxuDefinition *api
 		t.Errorf("expected %v, got %v", e, a)
 	}
 
-	err = fixtures.DeleteCustomResourceDefinition(crd, apiExtensionClient)
+	err = fixtures.DeleteV1CustomResourceDefinition(crd, apiExtensionClient)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/integration/apiserver/apiserver_test.go
+++ b/test/integration/apiserver/apiserver_test.go
@@ -32,10 +32,9 @@ import (
 	"testing"
 	"time"
 
-	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-
 	apps "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	"k8s.io/apiextensions-apiserver/test/integration/fixtures"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"

--- a/test/integration/apiserver/apply/apply_crd_beta_test.go
+++ b/test/integration/apiserver/apply/apply_crd_beta_test.go
@@ -1,0 +1,234 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apiserver
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	"k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	"k8s.io/apiextensions-apiserver/test/integration/fixtures"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	genericfeatures "k8s.io/apiserver/pkg/features"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	"k8s.io/client-go/dynamic"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
+	apiservertesting "k8s.io/kubernetes/cmd/kube-apiserver/app/testing"
+	"k8s.io/kubernetes/test/integration/framework"
+)
+
+// TestApplyCRDNoSchema tests that CRDs and CRs can both be applied to with a PATCH request with the apply content type
+// when there is no validation field provided.
+func TestApplyCRDNoSchema(t *testing.T) {
+	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, genericfeatures.ServerSideApply, true)()
+
+	server, err := apiservertesting.StartTestServer(t, apiservertesting.NewDefaultTestServerOptions(), nil, framework.SharedEtcd())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer server.TearDownFn()
+	config := server.ClientConfig
+
+	apiExtensionClient, err := clientset.NewForConfig(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dynamicClient, err := dynamic.NewForConfig(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	noxuDefinition := nearlyRemovedBetaMultipleVersionNoxuCRD(apiextensionsv1beta1.ClusterScoped)
+
+	noxuDefinition, err = fixtures.CreateNewCustomResourceDefinition(noxuDefinition, apiExtensionClient, dynamicClient)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	kind := noxuDefinition.Spec.Names.Kind
+	apiVersion := noxuDefinition.Spec.Group + "/" + noxuDefinition.Spec.Version
+	name := "mytest"
+
+	rest := apiExtensionClient.Discovery().RESTClient()
+	yamlBody := []byte(fmt.Sprintf(`
+apiVersion: %s
+kind: %s
+metadata:
+  name: %s
+spec:
+  replicas: 1`, apiVersion, kind, name))
+	result, err := rest.Patch(types.ApplyPatchType).
+		AbsPath("/apis", noxuDefinition.Spec.Group, noxuDefinition.Spec.Version, noxuDefinition.Spec.Names.Plural).
+		Name(name).
+		Param("fieldManager", "apply_test").
+		Body(yamlBody).
+		DoRaw(context.TODO())
+	if err != nil {
+		t.Fatalf("failed to create custom resource with apply: %v:\n%v", err, string(result))
+	}
+	verifyReplicas(t, result, 1)
+
+	// Patch object to change the number of replicas
+	result, err = rest.Patch(types.MergePatchType).
+		AbsPath("/apis", noxuDefinition.Spec.Group, noxuDefinition.Spec.Version, noxuDefinition.Spec.Names.Plural).
+		Name(name).
+		Body([]byte(`{"spec":{"replicas": 5}}`)).
+		DoRaw(context.TODO())
+	if err != nil {
+		t.Fatalf("failed to update number of replicas with merge patch: %v:\n%v", err, string(result))
+	}
+	verifyReplicas(t, result, 5)
+
+	// Re-apply, we should get conflicts now, since the number of replicas was changed.
+	result, err = rest.Patch(types.ApplyPatchType).
+		AbsPath("/apis", noxuDefinition.Spec.Group, noxuDefinition.Spec.Version, noxuDefinition.Spec.Names.Plural).
+		Name(name).
+		Param("fieldManager", "apply_test").
+		Body(yamlBody).
+		DoRaw(context.TODO())
+	if err == nil {
+		t.Fatalf("Expecting to get conflicts when applying object after updating replicas, got no error: %s", result)
+	}
+	status, ok := err.(*apierrors.StatusError)
+	if !ok {
+		t.Fatalf("Expecting to get conflicts as API error")
+	}
+	if len(status.Status().Details.Causes) != 1 {
+		t.Fatalf("Expecting to get one conflict when applying object after updating replicas, got: %v", status.Status().Details.Causes)
+	}
+
+	// Re-apply with force, should work fine.
+	result, err = rest.Patch(types.ApplyPatchType).
+		AbsPath("/apis", noxuDefinition.Spec.Group, noxuDefinition.Spec.Version, noxuDefinition.Spec.Names.Plural).
+		Name(name).
+		Param("force", "true").
+		Param("fieldManager", "apply_test").
+		Body(yamlBody).
+		DoRaw(context.TODO())
+	if err != nil {
+		t.Fatalf("failed to apply object with force after updating replicas: %v:\n%v", err, string(result))
+	}
+	verifyReplicas(t, result, 1)
+
+	// Try to set managed fields using a subresource and verify that it has no effect
+	existingManagedFields, err := getManagedFields(result)
+	if err != nil {
+		t.Fatalf("failed to get managedFields from response: %v", err)
+	}
+	updateBytes := []byte(`{
+		"metadata": {
+			"managedFields": [{
+				"manager":"testing",
+				"operation":"Update",
+				"apiVersion":"v1",
+				"fieldsType":"FieldsV1",
+				"fieldsV1":{
+					"f:spec":{
+						"f:containers":{
+							"k:{\"name\":\"testing\"}":{
+								".":{},
+								"f:image":{},
+								"f:name":{}
+							}
+						}
+					}
+				}
+			}]
+		}
+	}`)
+	result, err = rest.Patch(types.MergePatchType).
+		AbsPath("/apis", noxuDefinition.Spec.Group, noxuDefinition.Spec.Version, noxuDefinition.Spec.Names.Plural).
+		SubResource("status").
+		Name(name).
+		Param("fieldManager", "subresource_test").
+		Body(updateBytes).
+		DoRaw(context.TODO())
+	if err != nil {
+		t.Fatalf("Error updating subresource: %v ", err)
+	}
+	newManagedFields, err := getManagedFields(result)
+	if err != nil {
+		t.Fatalf("failed to get managedFields from response: %v", err)
+	}
+	if !reflect.DeepEqual(existingManagedFields, newManagedFields) {
+		t.Fatalf("Expected managed fields to not have changed when trying manually settting them via subresoures.\n\nExpected: %#v\n\nGot: %#v", existingManagedFields, newManagedFields)
+	}
+
+	// However, it is possible to modify managed fields using the main resource
+	result, err = rest.Patch(types.MergePatchType).
+		AbsPath("/apis", noxuDefinition.Spec.Group, noxuDefinition.Spec.Version, noxuDefinition.Spec.Names.Plural).
+		Name(name).
+		Param("fieldManager", "subresource_test").
+		Body([]byte(`{"metadata":{"managedFields":[{}]}}`)).
+		DoRaw(context.TODO())
+	if err != nil {
+		t.Fatalf("Error updating managed fields of the main resource: %v ", err)
+	}
+	newManagedFields, err = getManagedFields(result)
+	if err != nil {
+		t.Fatalf("failed to get managedFields from response: %v", err)
+	}
+
+	if len(newManagedFields) != 0 {
+		t.Fatalf("Expected managed fields to have been reset, but got: %v", newManagedFields)
+	}
+}
+
+func nearlyRemovedBetaMultipleVersionNoxuCRD(scope apiextensionsv1beta1.ResourceScope) *apiextensionsv1beta1.CustomResourceDefinition {
+	return &apiextensionsv1beta1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{Name: "noxus.mygroup.example.com"},
+		Spec: apiextensionsv1beta1.CustomResourceDefinitionSpec{
+			Group:   "mygroup.example.com",
+			Version: "v1beta1",
+			Names: apiextensionsv1beta1.CustomResourceDefinitionNames{
+				Plural:     "noxus",
+				Singular:   "nonenglishnoxu",
+				Kind:       "WishIHadChosenNoxu",
+				ShortNames: []string{"foo", "bar", "abc", "def"},
+				ListKind:   "NoxuItemList",
+				Categories: []string{"all"},
+			},
+			Scope: scope,
+			Versions: []apiextensionsv1beta1.CustomResourceDefinitionVersion{
+				{
+					Name:    "v1beta1",
+					Served:  true,
+					Storage: false,
+				},
+				{
+					Name:    "v1beta2",
+					Served:  true,
+					Storage: true,
+				},
+				{
+					Name:    "v0",
+					Served:  false,
+					Storage: false,
+				},
+			},
+			Subresources: &apiextensionsv1beta1.CustomResourceSubresources{
+				Status: &apiextensionsv1beta1.CustomResourceSubresourceStatus{},
+			},
+		},
+	}
+}

--- a/test/utils/crd/crd_util.go
+++ b/test/utils/crd/crd_util.go
@@ -89,12 +89,7 @@ func CreateMultiVersionTestCRD(f *framework.Framework, group string, opts ...Opt
 			Served:  true,
 			Storage: true,
 			Name:    "v1",
-			Schema: &apiextensionsv1.CustomResourceValidation{
-				OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
-					XPreserveUnknownFields: pointer.BoolPtr(true),
-					Type:                   "object",
-				},
-			},
+			Schema:  fixtures.AllowAllSchema(),
 		}}
 	}
 


### PR DESCRIPTION
Remove unnecessary v1beta1 dependencies from tests.  This has a few we cannot yet remove, so I have to tweak those tests so they still test something valuable.  I'll remove WIP once I have done that.

/kind cleanup
/priority important-soon
@kubernetes/sig-api-machinery-pr-reviews 

```release-note
NONE
```