### PR TITLE
proxy/config tests: avoid multiple calls to done

### DIFF
--- a/pkg/proxy/config/api_test.go
+++ b/pkg/proxy/config/api_test.go
@@ -152,8 +152,9 @@ func newSvcHandler(t *testing.T, svcs []*v1.Service, done func()) ServiceHandler
 	shm := &ServiceHandlerMock{
 		state: make(map[types.NamespacedName]*v1.Service),
 	}
+	var callDoneOnce sync.Once
 	shm.process = func(services []*v1.Service) {
-		defer done()
+		defer callDoneOnce.Do(done)
 		if !reflect.DeepEqual(services, svcs) {
 			t.Errorf("Unexpected services: %#v, expected: %#v", services, svcs)
 		}
@@ -165,8 +166,9 @@ func newEpsHandler(t *testing.T, eps []*v1.Endpoints, done func()) EndpointsHand
 	ehm := &EndpointsHandlerMock{
 		state: make(map[types.NamespacedName]*v1.Endpoints),
 	}
+	var callDoneOnce sync.Once
 	ehm.process = func(endpoints []*v1.Endpoints) {
-		defer done()
+		defer callDoneOnce.Do(done)
 		if !reflect.DeepEqual(eps, endpoints) {
 			t.Errorf("Unexpected endpoints: %#v, expected: %#v", endpoints, eps)
 		}


### PR DESCRIPTION
If the callback is called multiple times the wait group will be
over-decremented.

/kind failing-test
/kind flake

```release-note
NONE
```