### PR TITLE
[wip] Switch to runtime classes in Windows e2e tests

### DIFF
--- a/test/e2e/framework/node/BUILD
+++ b/test/e2e/framework/node/BUILD
@@ -11,6 +11,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//staging/src/k8s.io/api/core/v1:go_default_library",
+        "//staging/src/k8s.io/api/node/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/resource:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/conversion:go_default_library",

--- a/test/e2e/framework/node/runtimeclass.go
+++ b/test/e2e/framework/node/runtimeclass.go
@@ -18,6 +18,7 @@ package node
 
 import (
 	"fmt"
+	nodev1 "k8s.io/api/node/v1"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -52,5 +53,26 @@ func NewRuntimeClassPod(runtimeClassName string) *v1.Pod {
 			RestartPolicy:                v1.RestartPolicyNever,
 			AutomountServiceAccountToken: utilpointer.BoolPtr(false),
 		},
+	}
+}
+
+
+// NewWindowsRuntimeClass is a helper to generate a Windows RuntimeClass resource with
+// the given name & handler.
+func NewWindowsRuntimeClass(name, handler string) *nodev1.RuntimeClass {
+	scheduling := &nodev1.Scheduling{
+		NodeSelector: map[string]string{
+			"kubernetes.io/os": "windows",
+		},
+		Tolerations: []v1.Toleration {
+			{Effect: v1.TaintEffectNoSchedule, Key: "os", Operator: v1.TolerationOpEqual, Value: "windows"},
+		},
+	}
+	return &nodev1.RuntimeClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Handler: handler,
+		Scheduling: scheduling,
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Switch to using runtimeclasses instead of relying on node selector.  This helps in consolidating the nodeSelector, tolerations needed into a single runtime class.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
