### PR TITLE
tests: Set a 5 minute timeout for kubectl cluster-info dump

### DIFF
--- a/test/e2e/kubectl/kubectl.go
+++ b/test/e2e/kubectl/kubectl.go
@@ -1083,7 +1083,12 @@ metadata:
 	ginkgo.Describe("Kubectl cluster-info dump", func() {
 		ginkgo.It("should check if cluster-info dump succeeds", func() {
 			ginkgo.By("running cluster-info dump")
-			framework.RunKubectlOrDie(ns, "cluster-info", "dump")
+
+			// Should return in a timely fashion (or we should mark the test slow)
+			timer := time.NewTimer(300 * time.Second)
+			defer timer.Stop()
+
+			framework.NewKubectlCommand(ns, "cluster-info", "dump").WithTimeout(timer.C).ExecOrDie(ns)
 		})
 	})
 


### PR DESCRIPTION
We've observed this test causing e2e runs to time-out; the ginkgo
behaviour here is unhelpful, in that we don't see any output on a
timeout.

Set a (generous) time limit to start to get output and enforce some
limit to the response time.

/kind failing-test
/kind flake

```release-note
NONE
```