### PR TITLE
Remove inactive members from OWNERS - Jan 2021

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -41,7 +41,6 @@ aliases:
     - mikedanese
     - mml
     - ncdc
-    - nikhiljindal
     - smarterclayton
     - sttts
     - thockin
@@ -421,7 +420,6 @@ aliases:
     - caesarxuchao
     - vishh
     - mikedanese
-    - nikhiljindal
     - davidopp
     - pmorie
     - sttts

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -36,7 +36,6 @@ aliases:
     - dims
     - enj
     - erictune
-    - jianhuiz
     - lavalamp
     - liggitt
     - mikedanese
@@ -59,7 +58,6 @@ aliases:
     - dims
     - enj
     - errordeveloper
-    - jianhuiz
     - lavalamp
     - liggitt
     - mikedanese
@@ -97,7 +95,6 @@ aliases:
     - tallclair
   sig-auth-policy-reviewers:
     - deads2k
-    - jianhuiz
     - liggitt
     - mbohlool
     - tallclair

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -426,7 +426,6 @@ aliases:
     - vishh
     - mikedanese
     - nikhiljindal
-    - gmarek
     - davidopp
     - pmorie
     - sttts

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -535,7 +535,6 @@ aliases:
     - calebamiles     # Release
     - caseydavenport  # Network
     - countspongebob  # Scalability
-    - csbell          # Multicluster
     - dcbw            # Network
     - dchen1107       # Node
     - deads2k         # API Machinery

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -96,7 +96,6 @@ aliases:
   sig-auth-policy-reviewers:
     - deads2k
     - liggitt
-    - mbohlool
     - tallclair
     - krmayankk
 

--- a/cmd/kube-apiserver/OWNERS
+++ b/cmd/kube-apiserver/OWNERS
@@ -6,7 +6,6 @@ approvers:
 - lavalamp
 - liggitt
 - mml
-- nikhiljindal
 - smarterclayton
 - sttts
 reviewers:
@@ -19,7 +18,6 @@ reviewers:
 - caesarxuchao
 - mikedanese
 - liggitt
-- nikhiljindal
 - ncdc
 - sttts
 - hzxuzhonghu
@@ -28,3 +26,6 @@ reviewers:
 labels:
 - sig/api-machinery
 - area/apiserver
+
+emeritus_approvers:
+- nikhiljindal

--- a/cmd/kube-controller-manager/OWNERS
+++ b/cmd/kube-controller-manager/OWNERS
@@ -29,7 +29,6 @@ reviewers:
 - lavalamp
 - liggitt
 - luxas
-- madhusudancs
 - mikedanese
 - mml
 - mwielgus

--- a/cmd/kube-controller-manager/OWNERS
+++ b/cmd/kube-controller-manager/OWNERS
@@ -18,7 +18,6 @@ reviewers:
 - erictune
 - errordeveloper
 - feiskyer
-- gmarek
 - humblec
 - ingvagabund
 - janetkuo

--- a/cmd/kube-controller-manager/OWNERS
+++ b/cmd/kube-controller-manager/OWNERS
@@ -32,7 +32,6 @@ reviewers:
 - mikedanese
 - mml
 - mwielgus
-- nikhiljindal
 - ping035627
 - piosz
 - pmorie

--- a/pkg/api/testing/OWNERS
+++ b/pkg/api/testing/OWNERS
@@ -12,7 +12,6 @@ reviewers:
 - caesarxuchao
 - vishh
 - mikedanese
-- nikhiljindal
 - erictune
 - pmorie
 - dchen1107

--- a/pkg/api/testing/OWNERS
+++ b/pkg/api/testing/OWNERS
@@ -22,7 +22,6 @@ reviewers:
 - yifan-gu
 - soltysh
 - jsafrane
-- madhusudancs
 - hongchaodeng
 - rootfs
 - aveshagarwal

--- a/pkg/api/v1/OWNERS
+++ b/pkg/api/v1/OWNERS
@@ -14,7 +14,6 @@ reviewers:
 - mikedanese
 - liggitt
 - nikhiljindal
-- gmarek
 - erictune
 - davidopp
 - pmorie

--- a/pkg/api/v1/OWNERS
+++ b/pkg/api/v1/OWNERS
@@ -13,7 +13,6 @@ reviewers:
 - vishh
 - mikedanese
 - liggitt
-- nikhiljindal
 - erictune
 - davidopp
 - pmorie

--- a/pkg/api/v1/OWNERS
+++ b/pkg/api/v1/OWNERS
@@ -29,7 +29,6 @@ reviewers:
 - jsafrane
 - dims
 - errordeveloper
-- madhusudancs
 - krousey
 - jayunit100
 - rootfs

--- a/pkg/apis/OWNERS
+++ b/pkg/apis/OWNERS
@@ -39,7 +39,6 @@ filters:
     - piosz
     - dims
     - errordeveloper
-    - madhusudancs
     - krousey
     - rootfs
 

--- a/pkg/apis/OWNERS
+++ b/pkg/apis/OWNERS
@@ -20,7 +20,6 @@ filters:
     - vishh
     - mikedanese
     - liggitt
-    - nikhiljindal
     - erictune
     - pmorie
     - sttts

--- a/pkg/apis/OWNERS
+++ b/pkg/apis/OWNERS
@@ -21,7 +21,6 @@ filters:
     - mikedanese
     - liggitt
     - nikhiljindal
-    - gmarek
     - erictune
     - pmorie
     - sttts

--- a/pkg/apis/abac/OWNERS
+++ b/pkg/apis/abac/OWNERS
@@ -5,4 +5,3 @@ reviewers:
 - smarterclayton
 - deads2k
 - liggitt
-- mbohlool

--- a/pkg/apis/apps/OWNERS
+++ b/pkg/apis/apps/OWNERS
@@ -14,7 +14,6 @@ reviewers:
 - errordeveloper
 - mml
 - m1093782566
-- mbohlool
 - kevin-wangzefeng
 labels:
 - sig/apps

--- a/pkg/apis/apps/OWNERS
+++ b/pkg/apis/apps/OWNERS
@@ -16,6 +16,5 @@ reviewers:
 - m1093782566
 - mbohlool
 - kevin-wangzefeng
-- jianhuiz
 labels:
 - sig/apps

--- a/pkg/apis/autoscaling/OWNERS
+++ b/pkg/apis/autoscaling/OWNERS
@@ -13,6 +13,5 @@ reviewers:
 - piosz
 - dims
 - errordeveloper
-- madhusudancs
 - mml
 - mbohlool

--- a/pkg/apis/autoscaling/OWNERS
+++ b/pkg/apis/autoscaling/OWNERS
@@ -14,4 +14,3 @@ reviewers:
 - dims
 - errordeveloper
 - mml
-- mbohlool

--- a/pkg/apis/autoscaling/OWNERS
+++ b/pkg/apis/autoscaling/OWNERS
@@ -16,4 +16,3 @@ reviewers:
 - madhusudancs
 - mml
 - mbohlool
-- jianhuiz

--- a/pkg/apis/batch/OWNERS
+++ b/pkg/apis/batch/OWNERS
@@ -15,6 +15,5 @@ reviewers:
 - dims
 - errordeveloper
 - mml
-- mbohlool
 labels:
 - sig/apps

--- a/pkg/apis/batch/OWNERS
+++ b/pkg/apis/batch/OWNERS
@@ -16,6 +16,5 @@ reviewers:
 - errordeveloper
 - mml
 - mbohlool
-- jianhuiz
 labels:
 - sig/apps

--- a/pkg/apis/core/OWNERS
+++ b/pkg/apis/core/OWNERS
@@ -20,7 +20,6 @@ reviewers:
 - mikedanese
 - liggitt
 - nikhiljindal
-- gmarek
 - erictune
 - davidopp
 - pmorie

--- a/pkg/apis/core/OWNERS
+++ b/pkg/apis/core/OWNERS
@@ -19,7 +19,6 @@ reviewers:
 - vishh
 - mikedanese
 - liggitt
-- nikhiljindal
 - erictune
 - davidopp
 - pmorie

--- a/pkg/apis/core/install/OWNERS
+++ b/pkg/apis/core/install/OWNERS
@@ -6,5 +6,4 @@ reviewers:
 - deads2k
 - caesarxuchao
 - liggitt
-- nikhiljindal
 - dims

--- a/pkg/apis/core/v1/OWNERS
+++ b/pkg/apis/core/v1/OWNERS
@@ -14,7 +14,6 @@ reviewers:
 - mikedanese
 - liggitt
 - nikhiljindal
-- gmarek
 - erictune
 - davidopp
 - pmorie

--- a/pkg/apis/core/v1/OWNERS
+++ b/pkg/apis/core/v1/OWNERS
@@ -13,7 +13,6 @@ reviewers:
 - vishh
 - mikedanese
 - liggitt
-- nikhiljindal
 - erictune
 - davidopp
 - pmorie

--- a/pkg/apis/core/v1/OWNERS
+++ b/pkg/apis/core/v1/OWNERS
@@ -29,7 +29,6 @@ reviewers:
 - jsafrane
 - dims
 - errordeveloper
-- madhusudancs
 - krousey
 - jayunit100
 - rootfs

--- a/pkg/apis/core/validation/OWNERS
+++ b/pkg/apis/core/validation/OWNERS
@@ -14,7 +14,6 @@ reviewers:
 - mikedanese
 - liggitt
 - nikhiljindal
-- gmarek
 - erictune
 - davidopp
 - pmorie

--- a/pkg/apis/core/validation/OWNERS
+++ b/pkg/apis/core/validation/OWNERS
@@ -13,7 +13,6 @@ reviewers:
 - vishh
 - mikedanese
 - liggitt
-- nikhiljindal
 - erictune
 - davidopp
 - pmorie

--- a/pkg/apis/extensions/OWNERS
+++ b/pkg/apis/extensions/OWNERS
@@ -28,7 +28,6 @@ reviewers:
 - rootfs
 - mml
 - resouer
-- mbohlool
 - therc
 - pweil-
 - lukaszo

--- a/pkg/apis/extensions/OWNERS
+++ b/pkg/apis/extensions/OWNERS
@@ -25,7 +25,6 @@ reviewers:
 - piosz
 - dims
 - errordeveloper
-- madhusudancs
 - rootfs
 - mml
 - resouer

--- a/pkg/apis/extensions/OWNERS
+++ b/pkg/apis/extensions/OWNERS
@@ -11,7 +11,6 @@ reviewers:
 - caesarxuchao
 - mikedanese
 - liggitt
-- nikhiljindal
 - erictune
 - pmorie
 - sttts

--- a/pkg/apis/extensions/OWNERS
+++ b/pkg/apis/extensions/OWNERS
@@ -33,6 +33,5 @@ reviewers:
 - therc
 - pweil-
 - lukaszo
-- jianhuiz
 labels:
 - sig/apps

--- a/pkg/client/OWNERS
+++ b/pkg/client/OWNERS
@@ -20,7 +20,6 @@ reviewers:
 - mikedanese
 - liggitt
 - nikhiljindal
-- gmarek
 - erictune
 - davidopp
 - pmorie

--- a/pkg/client/OWNERS
+++ b/pkg/client/OWNERS
@@ -19,7 +19,6 @@ reviewers:
 - vishh
 - mikedanese
 - liggitt
-- nikhiljindal
 - erictune
 - davidopp
 - pmorie

--- a/pkg/cloudprovider/OWNERS
+++ b/pkg/cloudprovider/OWNERS
@@ -18,7 +18,6 @@ reviewers:
 - vishh
 - mikedanese
 - liggitt
-- gmarek
 - erictune
 - davidopp
 - pmorie

--- a/pkg/controller/nodeipam/OWNERS
+++ b/pkg/controller/nodeipam/OWNERS
@@ -1,13 +1,14 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-- gmarek
 - bowei
 reviewers:
-- gmarek
 - smarterclayton
 - ingvagabund
 - aveshagarwal
 - k82cn
 labels:
 - sig/network
+
+emeritus_approvers:
+- gmarek

--- a/pkg/controller/nodelifecycle/OWNERS
+++ b/pkg/controller/nodelifecycle/OWNERS
@@ -1,12 +1,13 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-- gmarek
 - bowei
 - k82cn
 reviewers:
-- gmarek
 - smarterclayton
 - ingvagabund
 - aveshagarwal
 - k82cn
+
+emeritus_approvers:
+- gmarek

--- a/pkg/controller/podgc/OWNERS
+++ b/pkg/controller/podgc/OWNERS
@@ -2,7 +2,8 @@
 
 approvers:
 - foxish
-- gmarek
 reviewers:
 - foxish
+
+emeritus_approvers:
 - gmarek

--- a/pkg/controlplane/OWNERS
+++ b/pkg/controlplane/OWNERS
@@ -5,7 +5,6 @@ approvers:
 - derekwaynecarr
 - lavalamp
 - mikedanese
-- nikhiljindal
 - sttts
 - wojtek-t
 reviewers:
@@ -19,7 +18,6 @@ reviewers:
 - caesarxuchao
 - mikedanese
 - liggitt
-- nikhiljindal
 - erictune
 - davidopp
 - pmorie
@@ -38,3 +36,6 @@ reviewers:
 - enj
 labels:
 - sig/api-machinery
+
+emeritus_approvers:
+- nikhiljindal

--- a/pkg/controlplane/OWNERS
+++ b/pkg/controlplane/OWNERS
@@ -20,7 +20,6 @@ reviewers:
 - mikedanese
 - liggitt
 - nikhiljindal
-- gmarek
 - erictune
 - davidopp
 - pmorie

--- a/pkg/controlplane/OWNERS
+++ b/pkg/controlplane/OWNERS
@@ -34,7 +34,6 @@ reviewers:
 - timothysc
 - soltysh
 - piosz
-- madhusudancs
 - hongchaodeng
 - enj
 labels:

--- a/pkg/credentialprovider/OWNERS
+++ b/pkg/credentialprovider/OWNERS
@@ -18,7 +18,6 @@ reviewers:
 - justinsb
 - dims
 - resouer
-- mbohlool
 - mfojtik
 - therc
 - andrewsykim

--- a/pkg/kubelet/cm/cpumanager/OWNERS
+++ b/pkg/kubelet/cm/cpumanager/OWNERS
@@ -4,6 +4,8 @@ approvers:
 - derekwaynecarr
 - vishh
 - ConnorDoyle
-- balajismaniam
 reviewers:
 - klueska
+
+emeritus_approvers:
+- balajismaniam

--- a/pkg/kubemark/OWNERS
+++ b/pkg/kubemark/OWNERS
@@ -1,12 +1,13 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 reviewers:
-  - gmarek
   - shyamjvs
   - sig-scalability-reviewers
   - wojtek-t
 approvers:
-  - gmarek
   - shyamjvs
   - sig-scalability-approvers
   - wojtek-t
+
+emeritus_approvers:
+- gmarek

--- a/pkg/registry/OWNERS
+++ b/pkg/registry/OWNERS
@@ -17,7 +17,6 @@ reviewers:
 - caesarxuchao
 - mikedanese
 - liggitt
-- nikhiljindal
 - gmarek
 - erictune
 - davidopp

--- a/pkg/registry/OWNERS
+++ b/pkg/registry/OWNERS
@@ -34,6 +34,5 @@ reviewers:
 - soltysh
 - piosz
 - dims
-- madhusudancs
 - hongchaodeng
 - enj

--- a/pkg/registry/events/OWNERS
+++ b/pkg/registry/events/OWNERS
@@ -1,10 +1,11 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 reviewers:
-- gmarek
 - deads2k
 - sttts
 approvers:
-- gmarek
 - deads2k
 - sttts
+
+emeritus_approvers:
+- gmarek

--- a/pkg/registry/extensions/OWNERS
+++ b/pkg/registry/extensions/OWNERS
@@ -3,4 +3,3 @@
 reviewers:
 - deads2k
 - hongchaodeng
-- mbohlool

--- a/pkg/registry/registrytest/OWNERS
+++ b/pkg/registry/registrytest/OWNERS
@@ -12,7 +12,6 @@ reviewers:
 - mikedanese
 - liggitt
 - nikhiljindal
-- gmarek
 - erictune
 - pmorie
 - timothysc

--- a/pkg/registry/registrytest/OWNERS
+++ b/pkg/registry/registrytest/OWNERS
@@ -11,7 +11,6 @@ reviewers:
 - caesarxuchao
 - mikedanese
 - liggitt
-- nikhiljindal
 - erictune
 - pmorie
 - timothysc

--- a/staging/OWNERS
+++ b/staging/OWNERS
@@ -12,6 +12,5 @@ reviewers:
 - caesarxuchao
 - mikedanese
 - liggitt
-- nikhiljindal
 - sttts
 - krousey

--- a/staging/src/k8s.io/api/apps/OWNERS
+++ b/staging/src/k8s.io/api/apps/OWNERS
@@ -14,5 +14,4 @@ reviewers:
 - errordeveloper
 - mml
 - m1093782566
-- mbohlool
 - kevin-wangzefeng

--- a/staging/src/k8s.io/api/apps/OWNERS
+++ b/staging/src/k8s.io/api/apps/OWNERS
@@ -16,4 +16,3 @@ reviewers:
 - m1093782566
 - mbohlool
 - kevin-wangzefeng
-- jianhuiz

--- a/staging/src/k8s.io/api/autoscaling/OWNERS
+++ b/staging/src/k8s.io/api/autoscaling/OWNERS
@@ -13,6 +13,5 @@ reviewers:
 - piosz
 - dims
 - errordeveloper
-- madhusudancs
 - mml
 - mbohlool

--- a/staging/src/k8s.io/api/autoscaling/OWNERS
+++ b/staging/src/k8s.io/api/autoscaling/OWNERS
@@ -14,4 +14,3 @@ reviewers:
 - dims
 - errordeveloper
 - mml
-- mbohlool

--- a/staging/src/k8s.io/api/autoscaling/OWNERS
+++ b/staging/src/k8s.io/api/autoscaling/OWNERS
@@ -16,4 +16,3 @@ reviewers:
 - madhusudancs
 - mml
 - mbohlool
-- jianhuiz

--- a/staging/src/k8s.io/api/batch/OWNERS
+++ b/staging/src/k8s.io/api/batch/OWNERS
@@ -15,4 +15,3 @@ reviewers:
 - dims
 - errordeveloper
 - mml
-- mbohlool

--- a/staging/src/k8s.io/api/batch/OWNERS
+++ b/staging/src/k8s.io/api/batch/OWNERS
@@ -16,4 +16,3 @@ reviewers:
 - errordeveloper
 - mml
 - mbohlool
-- jianhuiz

--- a/staging/src/k8s.io/api/certificates/OWNERS
+++ b/staging/src/k8s.io/api/certificates/OWNERS
@@ -10,5 +10,4 @@ reviewers:
 - sttts
 - dims
 - errordeveloper
-- mbohlool
 - enj

--- a/staging/src/k8s.io/api/certificates/OWNERS
+++ b/staging/src/k8s.io/api/certificates/OWNERS
@@ -11,5 +11,4 @@ reviewers:
 - dims
 - errordeveloper
 - mbohlool
-- jianhuiz
 - enj

--- a/staging/src/k8s.io/api/extensions/OWNERS
+++ b/staging/src/k8s.io/api/extensions/OWNERS
@@ -28,7 +28,6 @@ reviewers:
 - rootfs
 - mml
 - resouer
-- mbohlool
 - therc
 - pweil-
 - lukaszo

--- a/staging/src/k8s.io/api/extensions/OWNERS
+++ b/staging/src/k8s.io/api/extensions/OWNERS
@@ -33,4 +33,3 @@ reviewers:
 - therc
 - pweil-
 - lukaszo
-- jianhuiz

--- a/staging/src/k8s.io/api/extensions/OWNERS
+++ b/staging/src/k8s.io/api/extensions/OWNERS
@@ -25,7 +25,6 @@ reviewers:
 - piosz
 - dims
 - errordeveloper
-- madhusudancs
 - rootfs
 - mml
 - resouer

--- a/staging/src/k8s.io/api/extensions/OWNERS
+++ b/staging/src/k8s.io/api/extensions/OWNERS
@@ -11,7 +11,6 @@ reviewers:
 - caesarxuchao
 - mikedanese
 - liggitt
-- nikhiljindal
 - erictune
 - pmorie
 - sttts

--- a/staging/src/k8s.io/apiextensions-apiserver/OWNERS
+++ b/staging/src/k8s.io/apiextensions-apiserver/OWNERS
@@ -8,7 +8,6 @@ reviewers:
 - deads2k
 - sttts
 - enisoc
-- mbohlool
 - yue9944882
 - logicalhan
 - jpbetz

--- a/staging/src/k8s.io/apimachinery/OWNERS
+++ b/staging/src/k8s.io/apimachinery/OWNERS
@@ -18,7 +18,6 @@ reviewers:
 - cheftako
 - mikedanese
 - liggitt
-- gmarek
 - sttts
 - ncdc
 - logicalhan

--- a/staging/src/k8s.io/apimachinery/pkg/api/errors/OWNERS
+++ b/staging/src/k8s.io/apimachinery/pkg/api/errors/OWNERS
@@ -12,7 +12,6 @@ reviewers:
 - mikedanese
 - liggitt
 - nikhiljindal
-- gmarek
 - erictune
 - saad-ali
 - janetkuo

--- a/staging/src/k8s.io/apimachinery/pkg/api/errors/OWNERS
+++ b/staging/src/k8s.io/apimachinery/pkg/api/errors/OWNERS
@@ -11,7 +11,6 @@ reviewers:
 - caesarxuchao
 - mikedanese
 - liggitt
-- nikhiljindal
 - erictune
 - saad-ali
 - janetkuo

--- a/staging/src/k8s.io/apimachinery/pkg/api/meta/OWNERS
+++ b/staging/src/k8s.io/apimachinery/pkg/api/meta/OWNERS
@@ -11,7 +11,6 @@ reviewers:
 - mikedanese
 - liggitt
 - nikhiljindal
-- gmarek
 - janetkuo
 - ncdc
 - dims

--- a/staging/src/k8s.io/apimachinery/pkg/api/meta/OWNERS
+++ b/staging/src/k8s.io/apimachinery/pkg/api/meta/OWNERS
@@ -17,4 +17,3 @@ reviewers:
 - krousey
 - resouer
 - mfojtik
-- jianhuiz

--- a/staging/src/k8s.io/apimachinery/pkg/api/meta/OWNERS
+++ b/staging/src/k8s.io/apimachinery/pkg/api/meta/OWNERS
@@ -10,7 +10,6 @@ reviewers:
 - caesarxuchao
 - mikedanese
 - liggitt
-- nikhiljindal
 - janetkuo
 - ncdc
 - dims

--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/OWNERS
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/OWNERS
@@ -10,4 +10,3 @@ reviewers:
 - saad-ali
 - janetkuo
 - xiang90
-- mbohlool

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/OWNERS
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/OWNERS
@@ -19,7 +19,6 @@ reviewers:
 - ncdc
 - soltysh
 - dims
-- madhusudancs
 - hongchaodeng
 - krousey
 - mml

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/OWNERS
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/OWNERS
@@ -26,4 +26,3 @@ reviewers:
 - mbohlool
 - therc
 - kevin-wangzefeng
-- jianhuiz

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/OWNERS
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/OWNERS
@@ -8,7 +8,6 @@ reviewers:
 - brendandburns
 - caesarxuchao
 - liggitt
-- nikhiljindal
 - erictune
 - davidopp
 - sttts

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/OWNERS
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/OWNERS
@@ -22,6 +22,5 @@ reviewers:
 - hongchaodeng
 - krousey
 - mml
-- mbohlool
 - therc
 - kevin-wangzefeng

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/OWNERS
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/OWNERS
@@ -9,7 +9,6 @@ reviewers:
 - caesarxuchao
 - liggitt
 - nikhiljindal
-- gmarek
 - erictune
 - davidopp
 - sttts

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/openapi/OWNERS
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/openapi/OWNERS
@@ -1,4 +1,0 @@
-# See the OWNERS docs at https://go.k8s.io/owners
-
-reviewers:
-- mbohlool

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/testing/OWNERS
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/testing/OWNERS
@@ -9,4 +9,3 @@ reviewers:
 - soltysh
 - mml
 - mbohlool
-- jianhuiz

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/testing/OWNERS
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/testing/OWNERS
@@ -8,4 +8,3 @@ reviewers:
 - erictune
 - soltysh
 - mml
-- mbohlool

--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/OWNERS
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/OWNERS
@@ -11,7 +11,6 @@ reviewers:
 - caesarxuchao
 - mikedanese
 - liggitt
-- nikhiljindal
 - davidopp
 - saad-ali
 - janetkuo

--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/OWNERS
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/OWNERS
@@ -12,7 +12,6 @@ reviewers:
 - mikedanese
 - liggitt
 - nikhiljindal
-- gmarek
 - davidopp
 - saad-ali
 - janetkuo

--- a/staging/src/k8s.io/apiserver/pkg/registry/rest/OWNERS
+++ b/staging/src/k8s.io/apiserver/pkg/registry/rest/OWNERS
@@ -11,7 +11,6 @@ reviewers:
 - mikedanese
 - liggitt
 - nikhiljindal
-- gmarek
 - justinsb
 - ncdc
 - dims

--- a/staging/src/k8s.io/apiserver/pkg/registry/rest/OWNERS
+++ b/staging/src/k8s.io/apiserver/pkg/registry/rest/OWNERS
@@ -17,6 +17,5 @@ reviewers:
 - hongchaodeng
 - krousey
 - ingvagabund
-- jianhuiz
 - sdminonne
 - enj

--- a/staging/src/k8s.io/apiserver/pkg/registry/rest/OWNERS
+++ b/staging/src/k8s.io/apiserver/pkg/registry/rest/OWNERS
@@ -10,7 +10,6 @@ reviewers:
 - caesarxuchao
 - mikedanese
 - liggitt
-- nikhiljindal
 - justinsb
 - ncdc
 - dims

--- a/staging/src/k8s.io/apiserver/pkg/server/options/OWNERS
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/OWNERS
@@ -5,7 +5,6 @@ reviewers:
 - wojtek-t
 - deads2k
 - liggitt
-- nikhiljindal
 - sttts
 - jlowdermilk
 - soltysh

--- a/staging/src/k8s.io/apiserver/pkg/storage/OWNERS
+++ b/staging/src/k8s.io/apiserver/pkg/storage/OWNERS
@@ -22,5 +22,4 @@ reviewers:
 - mml
 - ingvagabund
 - resouer
-- mbohlool
 - enj

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/OWNERS
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/OWNERS
@@ -3,5 +3,4 @@
 reviewers:
 - wojtek-t
 - timothysc
-- madhusudancs
 - hongchaodeng

--- a/staging/src/k8s.io/client-go/rest/OWNERS
+++ b/staging/src/k8s.io/client-go/rest/OWNERS
@@ -8,7 +8,6 @@ reviewers:
 - deads2k
 - brendandburns
 - liggitt
-- nikhiljindal
 - erictune
 - sttts
 - luxas

--- a/staging/src/k8s.io/client-go/rest/OWNERS
+++ b/staging/src/k8s.io/client-go/rest/OWNERS
@@ -9,7 +9,6 @@ reviewers:
 - brendandburns
 - liggitt
 - nikhiljindal
-- gmarek
 - erictune
 - sttts
 - luxas

--- a/staging/src/k8s.io/client-go/tools/cache/OWNERS
+++ b/staging/src/k8s.io/client-go/tools/cache/OWNERS
@@ -29,7 +29,6 @@ reviewers:
 - soltysh
 - jsafrane
 - dims
-- madhusudancs
 - hongchaodeng
 - krousey
 - xiang90

--- a/staging/src/k8s.io/client-go/tools/cache/OWNERS
+++ b/staging/src/k8s.io/client-go/tools/cache/OWNERS
@@ -20,7 +20,6 @@ reviewers:
 - caesarxuchao
 - mikedanese
 - liggitt
-- nikhiljindal
 - erictune
 - davidopp
 - pmorie

--- a/staging/src/k8s.io/client-go/tools/leaderelection/OWNERS
+++ b/staging/src/k8s.io/client-go/tools/leaderelection/OWNERS
@@ -7,7 +7,6 @@ reviewers:
 - wojtek-t
 - deads2k
 - mikedanese
-- gmarek
 - timothysc
 - ingvagabund
 - resouer

--- a/staging/src/k8s.io/client-go/tools/record/OWNERS
+++ b/staging/src/k8s.io/client-go/tools/record/OWNERS
@@ -10,7 +10,6 @@ reviewers:
 - vishh
 - mikedanese
 - liggitt
-- nikhiljindal
 - erictune
 - pmorie
 - dchen1107

--- a/staging/src/k8s.io/cloud-provider/OWNERS
+++ b/staging/src/k8s.io/cloud-provider/OWNERS
@@ -13,7 +13,6 @@ reviewers:
 - vishh
 - mikedanese
 - liggitt
-- gmarek
 - davidopp
 - pmorie
 - sttts

--- a/staging/src/k8s.io/cloud-provider/controllers/route/OWNERS
+++ b/staging/src/k8s.io/cloud-provider/controllers/route/OWNERS
@@ -1,13 +1,14 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-- gmarek
 - wojtek-t
 - bowei
 - andrewsykim
 - cheftako
 reviewers:
-- gmarek
 - wojtek-t
 - andrewsykim
 - cheftako
+
+emeritus_approvers:
+- gmarek

--- a/test/e2e_node/perf/workloads/OWNERS
+++ b/test/e2e_node/perf/workloads/OWNERS
@@ -3,7 +3,9 @@
 approvers:
 - vishh
 - derekwaynecarr
-- balajismaniam
 - ConnorDoyle
 reviewers:
 - sig-node-reviewers
+
+emeritus_approvers:
+- balajismaniam


### PR DESCRIPTION
Ref: https://github.com/kubernetes/org/issues/2456

As a part of cleaning up inactive members (those with no activity within
the past 18 months), this commit removes the following people from
various OWNERS files:
- @balajismaniam
- @gmarek
- @jianhuiz
- @madhusudancs
- @mbohlool
- @nikhiljindal
- @csbell 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

This PR replaces https://github.com/kubernetes/kubernetes/pull/99073, https://github.com/kubernetes/kubernetes/pull/99075 and https://github.com/kubernetes/kubernetes/pull/99077

/cc @mrbobbytables @liggitt 
/assign @liggitt 
