### PR TITLE
Return error when persister fails to modify config

### DIFF
--- a/staging/src/k8s.io/client-go/tools/clientcmd/config.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/config.go
@@ -374,7 +374,7 @@ func (p *persister) Persist(config map[string]string) error {
 	authInfo, ok := newConfig.AuthInfos[p.user]
 	if ok && authInfo.AuthProvider != nil {
 		authInfo.AuthProvider.Config = config
-		ModifyConfig(p.configAccess, *newConfig, false)
+		return ModifyConfig(p.configAccess, *newConfig, false)
 	}
 	return nil
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
Currently the config persister silently discards errors that happen when trying to persist config changes.
In my case a stale lock file caused all changes to the config to fail. As refreshed oidc tokens could not per persisted I ended up with a broken oidc authconfig every time the idToken expired.

The swallowed error in my case was:

```
could not persist new tokens: open /Users/[SNIPPED]/.kube/config.lock: file exists
```

#### Special notes for your reviewer:

```release-note
NONE
```
