### PR TITLE
Updates the Azure File minimum size for premium accounts

### DIFF
--- a/pkg/volume/azure_file/azure_file.go
+++ b/pkg/volume/azure_file/azure_file.go
@@ -55,8 +55,9 @@ var _ volume.PersistentVolumePlugin = &azureFilePlugin{}
 var _ volume.ExpandableVolumePlugin = &azureFilePlugin{}
 
 const (
-	azureFilePluginName    = "kubernetes.io/azure-file"
-	defaultSecretNamespace = "default"
+	azureFilePluginName     = "kubernetes.io/azure-file"
+	defaultSecretNamespace  = "default"
+	minimumPremiumShareSize = 100 // GB
 )
 
 func getPath(uid types.UID, volName string, host volume.VolumeHost) string {

--- a/pkg/volume/azure_file/azure_provision.go
+++ b/pkg/volume/azure_file/azure_provision.go
@@ -207,10 +207,15 @@ func (a *azureFileProvisioner) Provision(selectedNode *v1.Node, allowedTopologie
 		resourceGroup = a.options.PVC.ObjectMeta.Annotations[resourceGroupAnnotation]
 	}
 
+	fileShareSize := int(requestGiB)
 	// when use azure file premium, account kind should be specified as FileStorage
 	accountKind := string(storage.StorageV2)
 	if strings.HasPrefix(strings.ToLower(sku), "premium") {
 		accountKind = string(storage.FileStorage)
+		// when using azure file premium, the shares have a minimum size
+		if fileShareSize < minimumPremiumShareSize {
+			fileShareSize = minimumPremiumShareSize
+		}
 	}
 
 	accountOptions := &azure.AccountOptions{
@@ -225,7 +230,7 @@ func (a *azureFileProvisioner) Provision(selectedNode *v1.Node, allowedTopologie
 	shareOptions := &fileclient.ShareOptions{
 		Name:       shareName,
 		Protocol:   storage.SMB,
-		RequestGiB: requestGiB,
+		RequestGiB: fileShareSize,
 	}
 
 	account, key, err := a.azureProvider.CreateFileShare(accountOptions, shareOptions)
@@ -252,7 +257,7 @@ func (a *azureFileProvisioner) Provision(selectedNode *v1.Node, allowedTopologie
 			PersistentVolumeReclaimPolicy: a.options.PersistentVolumeReclaimPolicy,
 			AccessModes:                   a.options.PVC.Spec.AccessModes,
 			Capacity: v1.ResourceList{
-				v1.ResourceName(v1.ResourceStorage): resource.MustParse(fmt.Sprintf("%dGi", requestGiB)),
+				v1.ResourceName(v1.ResourceStorage): resource.MustParse(fmt.Sprintf("%dGi", fileShareSize)),
 			},
 			PersistentVolumeSource: v1.PersistentVolumeSource{
 				AzureFile: &v1.AzureFilePersistentVolumeSource{


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
Updates the minimum storage request for premium Azure File accounts. Premium Azure File requires a minimum of 100 GB, and any dynamically provisioned volumes with a request less than this amount currently fail with a vague error:

> storage: service returned error: StatusCode=400, ErrorCode=InvalidHeaderValue, ErrorMessage=The value for one of the HTTP headers is not in the correct format

Note: The Azure File CSI Driver already does this. This PR allows the in-tree driver to mirror the behaviour when handling these volumes.

#### Which issue(s) this PR fixes:
Fixes https://github.com/Azure/AKS/issues/1516

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
When dynamically provisioning Azure File volumes for a premium account, the requested size will be set to 100GB if the request is initially lower than this value to accommodate Azure File requirements.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
