### PR TITLE
apf: set response headers for rejected requests

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/filters/priority-and-fairness.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/filters/priority-and-fairness.go
@@ -122,12 +122,7 @@ func WithPriorityAndFairness(
 			served = true
 			innerCtx := context.WithValue(ctx, priorityAndFairnessKey, classification)
 			innerReq := r.Clone(innerCtx)
-
-			// We intentionally set the UID of the flow-schema and priority-level instead of name. This is so that
-			// the names that cluster-admins choose for categorization and priority levels are not exposed, also
-			// the names might make it obvious to the users that they are rejected due to classification with low priority.
-			w.Header().Set(flowcontrol.ResponseHeaderMatchedPriorityLevelConfigurationUID, string(classification.PriorityLevelUID))
-			w.Header().Set(flowcontrol.ResponseHeaderMatchedFlowSchemaUID, string(classification.FlowSchemaUID))
+			setResponseHeaders(classification, w)
 
 			handler.ServeHTTP(w, innerReq)
 		}
@@ -140,6 +135,8 @@ func WithPriorityAndFairness(
 			}
 		}, execute)
 		if !served {
+			setResponseHeaders(classification, w)
+
 			if isMutatingRequest {
 				epmetrics.DroppedRequests.WithContext(ctx).WithLabelValues(epmetrics.MutatingKind).Inc()
 			} else {
@@ -157,4 +154,16 @@ func WithPriorityAndFairness(
 func StartPriorityAndFairnessWatermarkMaintenance(stopCh <-chan struct{}) {
 	startWatermarkMaintenance(watermark, stopCh)
 	startWatermarkMaintenance(waitingMark, stopCh)
+}
+
+func setResponseHeaders(classification *PriorityAndFairnessClassification, w http.ResponseWriter) {
+	if classification == nil {
+		return
+	}
+
+	// We intentionally set the UID of the flow-schema and priority-level instead of name. This is so that
+	// the names that cluster-admins choose for categorization and priority levels are not exposed, also
+	// the names might make it obvious to the users that they are rejected due to classification with low priority.
+	w.Header().Set(flowcontrol.ResponseHeaderMatchedPriorityLevelConfigurationUID, string(classification.PriorityLevelUID))
+	w.Header().Set(flowcontrol.ResponseHeaderMatchedFlowSchemaUID, string(classification.FlowSchemaUID))
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
For a rejected request, we don't set the response headers with the `FlowSchema` and `PriorityLevel` UID. This PR addresses the issue.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```
