### PR TITLE
Make kube-proxy check if IPv6 is really supported before assuming dual-stack

### DIFF
--- a/cmd/kube-proxy/app/server_others.go
+++ b/cmd/kube-proxy/app/server_others.go
@@ -134,15 +134,7 @@ func newProxyServer(
 	}
 
 	nodeIP := detectNodeIP(client, hostname, config.BindAddress)
-	protocol := utiliptables.ProtocolIPv4
-	if utilsnet.IsIPv6(nodeIP) {
-		klog.V(0).Infof("kube-proxy node IP is an IPv6 address (%s), assume IPv6 operation", nodeIP.String())
-		protocol = utiliptables.ProtocolIPv6
-	} else {
-		klog.V(0).Infof("kube-proxy node IP is an IPv4 address (%s), assume IPv4 operation", nodeIP.String())
-	}
-
-	iptInterface = utiliptables.New(execer, protocol)
+	klog.Infof("Detected node IP %s", nodeIP.String())
 
 	// Create event recorder
 	eventBroadcaster := record.NewBroadcaster()
@@ -181,6 +173,38 @@ func newProxyServer(
 
 	klog.V(2).Info("DetectLocalMode: '", string(detectLocalMode), "'")
 
+	primaryProtocol := utiliptables.ProtocolIPv4
+	if utilsnet.IsIPv6(nodeIP) {
+		primaryProtocol = utiliptables.ProtocolIPv6
+	}
+	iptInterface = utiliptables.New(execer, primaryProtocol)
+
+	var ipt [2]utiliptables.Interface
+	dualStack := utilfeature.DefaultFeatureGate.Enabled(features.IPv6DualStack) && proxyMode != proxyModeUserspace
+	if dualStack {
+		// Create iptables handlers for both families, one is already created
+		// Always ordered as IPv4, IPv6
+		if primaryProtocol == utiliptables.ProtocolIPv4 {
+			ipt[0] = iptInterface
+			ipt[1] = utiliptables.New(execer, utiliptables.ProtocolIPv6)
+
+			// Just because the feature gate is enabled doesn't mean the node
+			// actually supports dual-stack
+			if _, err := ipt[1].ChainExists(utiliptables.TableNAT, utiliptables.ChainPostrouting); err != nil {
+				klog.Warningf("No iptables support for IPv6: %v", err)
+				dualStack = false
+			}
+		} else {
+			ipt[0] = utiliptables.New(execer, utiliptables.ProtocolIPv4)
+			ipt[1] = iptInterface
+		}
+	}
+	if dualStack {
+		klog.V(0).Infof("kube-proxy running in dual-stack mode, %s-primary", iptInterface.Protocol())
+	} else {
+		klog.V(0).Infof("kube-proxy running in single-stack %s mode", iptInterface.Protocol())
+	}
+
 	if proxyMode == proxyModeIPTables {
 		klog.V(0).Info("Using iptables Proxier.")
 		if config.IPTables.MasqueradeBit == nil {
@@ -188,19 +212,8 @@ func newProxyServer(
 			return nil, fmt.Errorf("unable to read IPTables MasqueradeBit from config")
 		}
 
-		if utilfeature.DefaultFeatureGate.Enabled(features.IPv6DualStack) {
+		if dualStack {
 			klog.V(0).Info("creating dualStackProxier for iptables.")
-
-			// Create iptables handlers for both families, one is already created
-			// Always ordered as IPv4, IPv6
-			var ipt [2]utiliptables.Interface
-			if iptInterface.IsIPv6() {
-				ipt[1] = iptInterface
-				ipt[0] = utiliptables.New(execer, utiliptables.ProtocolIPv4)
-			} else {
-				ipt[0] = iptInterface
-				ipt[1] = utiliptables.New(execer, utiliptables.ProtocolIPv6)
-			}
 
 			// Always ordered to match []ipt
 			var localDetectors [2]proxyutiliptables.LocalTrafficDetector
@@ -256,19 +269,8 @@ func newProxyServer(
 		proxymetrics.RegisterMetrics()
 	} else if proxyMode == proxyModeIPVS {
 		klog.V(0).Info("Using ipvs Proxier.")
-		if utilfeature.DefaultFeatureGate.Enabled(features.IPv6DualStack) {
+		if dualStack {
 			klog.V(0).Info("creating dualStackProxier for ipvs.")
-
-			// Create iptables handlers for both families, one is already created
-			// Always ordered as IPv4, IPv6
-			var ipt [2]utiliptables.Interface
-			if iptInterface.IsIPv6() {
-				ipt[1] = iptInterface
-				ipt[0] = utiliptables.New(execer, utiliptables.ProtocolIPv4)
-			} else {
-				ipt[0] = iptInterface
-				ipt[1] = utiliptables.New(execer, utiliptables.ProtocolIPv6)
-			}
 
 			nodeIPs := nodeIPTuple(config.BindAddress)
 

--- a/pkg/kubelet/dockershim/network/hostport/fake_iptables.go
+++ b/pkg/kubelet/dockershim/network/hostport/fake_iptables.go
@@ -123,6 +123,14 @@ func (f *fakeIPTables) DeleteChain(tableName utiliptables.Table, chainName utili
 	return nil
 }
 
+func (f *fakeIPTables) ChainExists(tableName utiliptables.Table, chainName utiliptables.Chain) (bool, error) {
+	_, _, err := f.getChain(tableName, chainName)
+	if err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
 // Returns index of rule in array; < 0 if rule is not found
 func findRule(chain *fakeChain, rule string) int {
 	for i, candidate := range chain.rules {

--- a/pkg/util/iptables/testing/fake.go
+++ b/pkg/util/iptables/testing/fake.go
@@ -93,6 +93,11 @@ func (*FakeIPTables) DeleteChain(table iptables.Table, chain iptables.Chain) err
 	return nil
 }
 
+// ChainExists is part of iptables.Interface
+func (*FakeIPTables) ChainExists(table iptables.Table, chain iptables.Chain) (bool, error) {
+	return true, nil
+}
+
 // EnsureRule is part of iptables.Interface
 func (*FakeIPTables) EnsureRule(position iptables.RulePosition, table iptables.Table, chain iptables.Chain, args ...string) (bool, error) {
 	return true, nil


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
Now that the dual stack feature gate is enabled by default, kube-proxy defaults to trying to run dual stack (regardless of the cluster configuration), but some nodes have no IPv6 support, resulting in lots of spurious errors.

#### Which issue(s) this PR fixes:
Fixes #99031

#### Special notes for your reviewer:
@aojea I wrote this before noticing #99066... but this version is much smaller and more back-port-able. Maybe we want to merge pieces of both PRs together

#### Does this PR introduce a user-facing change?
-->
```release-note
Fixes spurious errors about IPv6 in kube-proxy logs on nodes with IPv6 disabled.
```

/priority important-soon
/sig network