### PR TITLE
Use GA topology labels for EBS

### DIFF
--- a/pkg/volume/awsebs/aws_ebs_test.go
+++ b/pkg/volume/awsebs/aws_ebs_test.go
@@ -396,7 +396,7 @@ func TestGetCandidateZone(t *testing.T) {
 			node: &v1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
-						v1.LabelFailureDomainBetaZone: testZone,
+						v1.LabelTopologyZone: testZone,
 					},
 				},
 			},

--- a/plugin/pkg/admission/storage/persistentvolume/label/admission_test.go
+++ b/plugin/pkg/admission/storage/persistentvolume/label/admission_test.go
@@ -174,9 +174,9 @@ func Test_PVLAdmission(t *testing.T) {
 			name:    "AWS EBS PV labeled correctly",
 			handler: newPersistentVolumeLabel(),
 			pvlabeler: mockVolumeLabels(map[string]string{
-				"a":                           "1",
-				"b":                           "2",
-				v1.LabelFailureDomainBetaZone: "1__2__3",
+				"a":                  "1",
+				"b":                  "2",
+				v1.LabelTopologyZone: "1__2__3",
 			}),
 			preAdmissionPV: &api.PersistentVolume{
 				ObjectMeta: metav1.ObjectMeta{Name: "awsebs", Namespace: "myns"},
@@ -193,9 +193,9 @@ func Test_PVLAdmission(t *testing.T) {
 					Name:      "awsebs",
 					Namespace: "myns",
 					Labels: map[string]string{
-						"a":                           "1",
-						"b":                           "2",
-						v1.LabelFailureDomainBetaZone: "1__2__3",
+						"a":                  "1",
+						"b":                  "2",
+						v1.LabelTopologyZone: "1__2__3",
 					},
 				},
 				Spec: api.PersistentVolumeSpec{
@@ -220,7 +220,7 @@ func Test_PVLAdmission(t *testing.T) {
 											Values:   []string{"2"},
 										},
 										{
-											Key:      v1.LabelFailureDomainBetaZone,
+											Key:      v1.LabelTopologyZone,
 											Operator: api.NodeSelectorOpIn,
 											Values:   []string{"1", "2", "3"},
 										},
@@ -373,15 +373,15 @@ func Test_PVLAdmission(t *testing.T) {
 			name:    "existing labels from user are changed",
 			handler: newPersistentVolumeLabel(),
 			pvlabeler: mockVolumeLabels(map[string]string{
-				v1.LabelFailureDomainBetaZone:   "domain1",
-				v1.LabelFailureDomainBetaRegion: "region1",
+				v1.LabelTopologyZone:   "domain1",
+				v1.LabelTopologyRegion: "region1",
 			}),
 			preAdmissionPV: &api.PersistentVolume{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "awsebs", Namespace: "myns",
 					Labels: map[string]string{
-						v1.LabelFailureDomainBetaZone:   "existingDomain",
-						v1.LabelFailureDomainBetaRegion: "existingRegion",
+						v1.LabelTopologyZone:   "existingDomain",
+						v1.LabelTopologyRegion: "existingRegion",
 					},
 				},
 				Spec: api.PersistentVolumeSpec{
@@ -397,8 +397,8 @@ func Test_PVLAdmission(t *testing.T) {
 					Name:      "awsebs",
 					Namespace: "myns",
 					Labels: map[string]string{
-						v1.LabelFailureDomainBetaZone:   "domain1",
-						v1.LabelFailureDomainBetaRegion: "region1",
+						v1.LabelTopologyZone:   "domain1",
+						v1.LabelTopologyRegion: "region1",
 					},
 				},
 				Spec: api.PersistentVolumeSpec{
@@ -413,12 +413,12 @@ func Test_PVLAdmission(t *testing.T) {
 								{
 									MatchExpressions: []api.NodeSelectorRequirement{
 										{
-											Key:      v1.LabelFailureDomainBetaRegion,
+											Key:      v1.LabelTopologyRegion,
 											Operator: api.NodeSelectorOpIn,
 											Values:   []string{"region1"},
 										},
 										{
-											Key:      v1.LabelFailureDomainBetaZone,
+											Key:      v1.LabelTopologyZone,
 											Operator: api.NodeSelectorOpIn,
 											Values:   []string{"domain1"},
 										},
@@ -630,9 +630,9 @@ func Test_PVLAdmission(t *testing.T) {
 			name:    "AWS EBS PV overrides user applied labels",
 			handler: newPersistentVolumeLabel(),
 			pvlabeler: mockVolumeLabels(map[string]string{
-				"a":                           "1",
-				"b":                           "2",
-				v1.LabelFailureDomainBetaZone: "1__2__3",
+				"a":                  "1",
+				"b":                  "2",
+				v1.LabelTopologyZone: "1__2__3",
 			}),
 			preAdmissionPV: &api.PersistentVolume{
 				ObjectMeta: metav1.ObjectMeta{
@@ -655,9 +655,9 @@ func Test_PVLAdmission(t *testing.T) {
 					Name:      "awsebs",
 					Namespace: "myns",
 					Labels: map[string]string{
-						"a":                           "1",
-						"b":                           "2",
-						v1.LabelFailureDomainBetaZone: "1__2__3",
+						"a":                  "1",
+						"b":                  "2",
+						v1.LabelTopologyZone: "1__2__3",
 					},
 				},
 				Spec: api.PersistentVolumeSpec{
@@ -682,7 +682,7 @@ func Test_PVLAdmission(t *testing.T) {
 											Values:   []string{"2"},
 										},
 										{
-											Key:      v1.LabelFailureDomainBetaZone,
+											Key:      v1.LabelTopologyZone,
 											Operator: api.NodeSelectorOpIn,
 											Values:   []string{"1", "2", "3"},
 										},

--- a/staging/src/k8s.io/csi-translation-lib/plugins/aws_ebs_test.go
+++ b/staging/src/k8s.io/csi-translation-lib/plugins/aws_ebs_test.go
@@ -17,9 +17,10 @@ limitations under the License.
 package plugins
 
 import (
-	v1 "k8s.io/api/core/v1"
 	"reflect"
 	"testing"
+
+	v1 "k8s.io/api/core/v1"
 
 	storage "k8s.io/api/storage/v1"
 )
@@ -195,6 +196,80 @@ func TestTranslateInTreeInlineVolumeToCSI(t *testing.T) {
 				}
 			}
 
+		})
+	}
+}
+
+func TestGetAwsRegionFromZones(t *testing.T) {
+
+	cases := []struct {
+		name      string
+		zones     []string
+		expRegion string
+		expErr    bool
+	}{
+		{
+			name:      "Commercial zone",
+			zones:     []string{"us-west-2a", "us-west-2b"},
+			expRegion: "us-west-2",
+		},
+		{
+			name:      "Govcloud zone",
+			zones:     []string{"us-gov-east-1a"},
+			expRegion: "us-gov-east-1",
+		},
+		{
+			name:      "Wavelength zone",
+			zones:     []string{"us-east-1-wl1-bos-wlz-1"},
+			expRegion: "us-east-1",
+		},
+		{
+			name:      "Local zone",
+			zones:     []string{"us-west-2-lax-1a"},
+			expRegion: "us-west-2",
+		},
+		{
+			name:   "Invalid: empty zones",
+			zones:  []string{},
+			expErr: true,
+		},
+		{
+			name:   "Invalid: multiple regions",
+			zones:  []string{"us-west-2a", "us-east-1a"},
+			expErr: true,
+		},
+		{
+			name:   "Invalid: region name only",
+			zones:  []string{"us-west-2"},
+			expErr: true,
+		},
+		{
+			name:   "Invalid: invalid suffix",
+			zones:  []string{"us-west-2ab"},
+			expErr: true,
+		},
+		{
+			name:   "Invalid: not enough fields",
+			zones:  []string{"us-west"},
+			expErr: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Logf("Testing %v", tc.name)
+			got, err := getAwsRegionFromZones(tc.zones)
+			if err != nil && !tc.expErr {
+				t.Fatalf("Did not expect error but got: %v", err)
+			}
+
+			if err == nil && tc.expErr {
+				t.Fatalf("Expected error, but did not get one.")
+			}
+
+			if err == nil && !reflect.DeepEqual(got, tc.expRegion) {
+				t.Errorf("Got PV name: %v, expected :%v", got, tc.expRegion)
+			}
 		})
 	}
 }

--- a/staging/src/k8s.io/csi-translation-lib/translate_test.go
+++ b/staging/src/k8s.io/csi-translation-lib/translate_test.go
@@ -170,13 +170,23 @@ func TestTopologyTranslation(t *testing.T) {
 		},
 		// EBS test cases: test mostly topology key, i.e., don't repeat testing done with GCE
 		{
-			name:                 "AWS EBS with zone labels",
+			name:                 "AWS EBS with beta zone labels",
 			pv:                   makeAWSEBSPV(kubernetesBetaTopologyLabels, nil /*topology*/),
 			expectedNodeAffinity: makeNodeAffinity(false /*multiTerms*/, plugins.AWSEBSTopologyKey, "us-east-1a"),
 		},
 		{
-			name:                 "AWS EBS with zone labels and topology",
+			name:                 "AWS EBS with beta zone labels and topology",
 			pv:                   makeAWSEBSPV(kubernetesBetaTopologyLabels, makeTopology(v1.LabelFailureDomainBetaZone, "us-east-2a")),
+			expectedNodeAffinity: makeNodeAffinity(false /*multiTerms*/, plugins.AWSEBSTopologyKey, "us-east-2a"),
+		},
+		{
+			name:                 "AWS EBS with GA zone labels",
+			pv:                   makeAWSEBSPV(kubernetesGATopologyLabels, nil /*topology*/),
+			expectedNodeAffinity: makeNodeAffinity(false /*multiTerms*/, plugins.AWSEBSTopologyKey, "us-east-1a"),
+		},
+		{
+			name:                 "AWS EBS with GA zone labels and topology",
+			pv:                   makeAWSEBSPV(kubernetesGATopologyLabels, makeTopology(v1.LabelTopologyZone, "us-east-2a")),
 			expectedNodeAffinity: makeNodeAffinity(false /*multiTerms*/, plugins.AWSEBSTopologyKey, "us-east-2a"),
 		},
 		// Cinder test cases: test mosty topology key, i.e., don't repeat testing done with GCE

--- a/staging/src/k8s.io/legacy-cloud-providers/aws/aws.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/aws/aws.go
@@ -2749,12 +2749,12 @@ func (c *Cloud) GetVolumeLabels(volumeName KubernetesVolumeID) (map[string]strin
 		return nil, fmt.Errorf("volume did not have AZ information: %q", aws.StringValue(info.VolumeId))
 	}
 
-	labels[v1.LabelFailureDomainBetaZone] = az
+	labels[v1.LabelTopologyZone] = az
 	region, err := azToRegion(az)
 	if err != nil {
 		return nil, err
 	}
-	labels[v1.LabelFailureDomainBetaRegion] = region
+	labels[v1.LabelTopologyRegion] = region
 
 	return labels, nil
 }

--- a/staging/src/k8s.io/legacy-cloud-providers/aws/aws_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/aws/aws_test.go
@@ -1576,8 +1576,8 @@ func TestGetVolumeLabels(t *testing.T) {
 
 	assert.Nil(t, err, "Error creating Volume %v", err)
 	assert.Equal(t, map[string]string{
-		v1.LabelFailureDomainBetaZone:   "us-east-1a",
-		v1.LabelFailureDomainBetaRegion: "us-east-1"}, labels)
+		v1.LabelTopologyZone:   "us-east-1a",
+		v1.LabelTopologyRegion: "us-east-1"}, labels)
 	awsServices.ec2.(*MockedFakeEC2).AssertExpectations(t)
 }
 
@@ -1650,8 +1650,8 @@ func TestGetLabelsForVolume(t *testing.T) {
 				AvailabilityZone: aws.String("us-east-1a"),
 			}},
 			map[string]string{
-				v1.LabelFailureDomainBetaZone:   "us-east-1a",
-				v1.LabelFailureDomainBetaRegion: "us-east-1",
+				v1.LabelTopologyZone:   "us-east-1a",
+				v1.LabelTopologyRegion: "us-east-1",
 			},
 			nil,
 		},

--- a/test/e2e/storage/drivers/in_tree.go
+++ b/test/e2e/storage/drivers/in_tree.go
@@ -1683,7 +1683,7 @@ func InitAwsDriver() storageframework.TestDriver {
 				"ntfs",
 			),
 			SupportedMountOption: sets.NewString("debug", "nouid32"),
-			TopologyKeys:         []string{v1.LabelFailureDomainBetaZone},
+			TopologyKeys:         []string{v1.LabelTopologyZone},
 			Capabilities: map[storageframework.Capability]bool{
 				storageframework.CapPersistence:         true,
 				storageframework.CapFsGroup:             true,
@@ -1775,7 +1775,7 @@ func (a *awsDriver) CreateVolume(config *storageframework.PerTestConfig, volType
 		// so pods should be also scheduled there.
 		config.ClientNodeSelection = e2epod.NodeSelection{
 			Selector: map[string]string{
-				v1.LabelFailureDomainBetaZone: zone,
+				v1.LabelTopologyZone: zone,
 			},
 		}
 	}


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
Similar to #98700, this PR replaces the deprecated topology labels in favor of the new GA ones for EBS plugin.

#### Which issue(s) this PR fixes:
Fixes #97785

#### Does this PR introduce a user-facing change?
```release-note
[ACTION REQUIRED] Newly provisioned PVs by EBS plugin will no longer use the deprecated "failure-domain.beta.kubernetes.io/zone" and "failure-domain.beta.kubernetes.io/region" labels. It will use "topology.kubernetes.io/zone" and "topology.kubernetes.io/region" labels instead.
```

/sig storage
 /cc @msau42 @wongma7 