### PR TITLE
Automated cherry pick of #98830 upstream release 1.18

### DIFF
--- a/pkg/volume/util/subpath/subpath_windows.go
+++ b/pkg/volume/util/subpath/subpath_windows.go
@@ -75,7 +75,7 @@ func getUpperPath(path string) string {
 // Check whether a directory/file is a link type or not
 // LinkType could be SymbolicLink, Junction, or HardLink
 func isLinkPath(path string) (bool, error) {
-	cmd := fmt.Sprintf("(Get-Item -Path %s).LinkType", path)
+	cmd := fmt.Sprintf("(Get-Item -Path %s).LinkType", escapeWindowsPath(path))
 	output, err := exec.Command("powershell", "/c", cmd).CombinedOutput()
 	if err != nil {
 		return false, err
@@ -84,6 +84,17 @@ func isLinkPath(path string) (bool, error) {
 		return true, nil
 	}
 	return false, nil
+}
+
+// Escape the special character in vsphere windows path
+func escapeWindowsPath(path string) (string) {
+	if strings.Contains(path, "``[") || strings.Contains(path, "``]") || strings.Contains(path, "` ") {
+		return path
+	}
+	escapeLeft := strings.Replace(path, "[", "``[", -1)
+	escapeRight := strings.Replace(escapeLeft, "]", "``]", -1)
+	escapeSpace := strings.Replace(escapeRight, " ", "` ", -1)
+	return escapeSpace
 }
 
 // evalSymlink returns the path name after the evaluation of any symbolic links.
@@ -113,7 +124,7 @@ func evalSymlink(path string) (string, error) {
 		}
 	}
 	// This command will give the target path of a given symlink
-	cmd := fmt.Sprintf("(Get-Item -Path %s).Target", upperpath)
+	cmd := fmt.Sprintf("(Get-Item -Path %s).Target", escapeWindowsPath(upperpath))
 	output, err := exec.Command("powershell", "/c", cmd).CombinedOutput()
 	if err != nil {
 		return "", err

--- a/pkg/volume/util/subpath/subpath_windows.go
+++ b/pkg/volume/util/subpath/subpath_windows.go
@@ -75,7 +75,7 @@ func getUpperPath(path string) string {
 // Check whether a directory/file is a link type or not
 // LinkType could be SymbolicLink, Junction, or HardLink
 func isLinkPath(path string) (bool, error) {
-	cmd := fmt.Sprintf("(Get-Item -Path %s).LinkType", escapeWindowsPath(path))
+	cmd := fmt.Sprintf("(Get-Item -LiteralPath %q).LinkType", path)
 	output, err := exec.Command("powershell", "/c", cmd).CombinedOutput()
 	if err != nil {
 		return false, err
@@ -84,17 +84,6 @@ func isLinkPath(path string) (bool, error) {
 		return true, nil
 	}
 	return false, nil
-}
-
-// Escape the special character in vsphere windows path
-func escapeWindowsPath(path string) (string) {
-	if strings.Contains(path, "``[") || strings.Contains(path, "``]") || strings.Contains(path, "` ") {
-		return path
-	}
-	escapeLeft := strings.Replace(path, "[", "``[", -1)
-	escapeRight := strings.Replace(escapeLeft, "]", "``]", -1)
-	escapeSpace := strings.Replace(escapeRight, " ", "` ", -1)
-	return escapeSpace
 }
 
 // evalSymlink returns the path name after the evaluation of any symbolic links.
@@ -124,7 +113,7 @@ func evalSymlink(path string) (string, error) {
 		}
 	}
 	// This command will give the target path of a given symlink
-	cmd := fmt.Sprintf("(Get-Item -Path %s).Target", escapeWindowsPath(upperpath))
+	cmd := fmt.Sprintf("(Get-Item -LiteralPath %q).Target", upperpath)
 	output, err := exec.Command("powershell", "/c", cmd).CombinedOutput()
 	if err != nil {
 		return "", err


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug
/kind failing-test

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fix handing special characters in the volume path on Windows
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
