### PR TITLE
Increase the timeout of waiting for node ready in local-up-cluster.sh

### DIFF
--- a/hack/local-up-cluster.sh
+++ b/hack/local-up-cluster.sh
@@ -692,11 +692,11 @@ function wait_node_ready(){
   # check the nodes information after kubelet daemon start
   local nodes_stats="${KUBECTL} --kubeconfig '${CERT_DIR}/admin.kubeconfig' get nodes"
   local node_name=$HOSTNAME_OVERRIDE
-  local system_node_wait_time=60
+  local system_node_wait_time=150
   local interval_time=2
   kube::util::wait_for_success "$system_node_wait_time" "$interval_time" "$nodes_stats | grep $node_name"
   if [ $? == "1" ]; then
-    echo "time out on waiting $node_name info"
+    echo "time out on waiting for getting node info: $node_name"
     exit 1
   fi
 }

--- a/hack/local-up-cluster.sh
+++ b/hack/local-up-cluster.sh
@@ -129,6 +129,10 @@ KUBE_CONTROLLERS="${KUBE_CONTROLLERS:-"*"}"
 # Audit policy
 AUDIT_POLICY_FILE=${AUDIT_POLICY_FILE:-""}
 
+# The timeout setting When waiting node ready with 'kubectl get nodes'
+NODE_READY_TIMEOUT_SECOND=${NODE_READY_TIMEOUT_SECOND:-150}
+NODE_READY_INTERVAL_SECOND=${NODE_READY_INTERVAL_SECOND:-2}
+
 # sanity check for OpenStack provider
 if [ "${CLOUD_PROVIDER}" == "openstack" ]; then
     if [ "${CLOUD_CONFIG}" == "" ]; then
@@ -692,9 +696,7 @@ function wait_node_ready(){
   # check the nodes information after kubelet daemon start
   local nodes_stats="${KUBECTL} --kubeconfig '${CERT_DIR}/admin.kubeconfig' get nodes"
   local node_name=$HOSTNAME_OVERRIDE
-  local system_node_wait_time=150
-  local interval_time=2
-  kube::util::wait_for_success "$system_node_wait_time" "$interval_time" "$nodes_stats | grep $node_name"
+  kube::util::wait_for_success "$NODE_READY_TIMEOUT_SECOND" "$NODE_READY_INTERVAL_SECOND" "$nodes_stats | grep $node_name"
   if [ $? == "1" ]; then
     echo "time out on waiting for getting node info: $node_name"
     exit 1


### PR DESCRIPTION
Signed-off-by: Qiutong Song <songqt01@gmail.com>

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:
As debugging k8s locally, I test it with containerd runtime. This PR is to increase the timeout of waiting for "kubelet get node". 60 seconds are not enough for containerd due to some reason unknown. On my local machine, it took around 120s and therefore I set it to 150s.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes # None

#### Special notes for your reviewer:

This was my original PR: https://github.com/kubernetes/kubernetes/pull/99109

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```
