### PR TITLE
fix staticcheck client-go/rest

### DIFF
--- a/hack/.staticcheck_failures
+++ b/hack/.staticcheck_failures
@@ -27,7 +27,6 @@ vendor/k8s.io/apiserver/pkg/storage/value/encrypt/envelope
 vendor/k8s.io/apiserver/pkg/util/webhook
 vendor/k8s.io/apiserver/pkg/util/wsstream
 vendor/k8s.io/client-go/discovery
-vendor/k8s.io/client-go/rest
 vendor/k8s.io/client-go/rest/watch
 vendor/k8s.io/client-go/transport
 vendor/k8s.io/cloud-provider/sample

--- a/staging/src/k8s.io/client-go/rest/BUILD
+++ b/staging/src/k8s.io/client-go/rest/BUILD
@@ -33,7 +33,6 @@ go_test(
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/clock:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/diff:go_default_library",
-        "//staging/src/k8s.io/apimachinery/pkg/util/httpstream:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/intstr:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/net:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/watch:go_default_library",

--- a/staging/src/k8s.io/client-go/rest/connection_test.go
+++ b/staging/src/k8s.io/client-go/rest/connection_test.go
@@ -52,14 +52,14 @@ func (lb *tcpLB) handleConnection(in net.Conn, stopCh chan struct{}) {
 	go io.Copy(in, out)
 	<-stopCh
 	if err := out.Close(); err != nil {
-		lb.t.Fatalf("failed to close connection: %v", err)
+		lb.t.Errorf("failed to close connection: %v", err)
 	}
 }
 
 func (lb *tcpLB) serve(stopCh chan struct{}) {
 	conn, err := lb.ln.Accept()
 	if err != nil {
-		lb.t.Fatalf("failed to accept: %v", err)
+		lb.t.Errorf("failed to accept: %v", err)
 	}
 	atomic.AddInt32(&lb.dials, 1)
 	go lb.handleConnection(conn, stopCh)

--- a/staging/src/k8s.io/client-go/rest/request.go
+++ b/staging/src/k8s.io/client-go/rest/request.go
@@ -512,6 +512,9 @@ func (r Request) finalURLTemplate() url.URL {
 	r.params = newParams
 	url := r.URL()
 
+	if url == nil {
+		return *url
+	}
 	segments := strings.Split(url.Path, "/")
 	groupIndex := 0
 	index := 0

--- a/staging/src/k8s.io/client-go/rest/request.go
+++ b/staging/src/k8s.io/client-go/rest/request.go
@@ -516,7 +516,7 @@ func (r Request) finalURLTemplate() url.URL {
 	groupIndex := 0
 	index := 0
 	trimmedBasePath := ""
-	if url != nil && r.c.base != nil && strings.Contains(url.Path, r.c.base.Path) {
+	if r.c.base != nil && strings.Contains(url.Path, r.c.base.Path) {
 		p := strings.TrimPrefix(url.Path, r.c.base.Path)
 		if !strings.HasPrefix(p, "/") {
 			p = "/" + p


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
cleanup `client-go/rest` issues identified by staticcheck

#### Which issue(s) this PR fixes:

```
vendor/k8s.io/client-go/rest/connection_test.go:65:2: the goroutine calls T.Fatalf, which must be called in the same goroutine as the test (SA2002)
vendor/k8s.io/client-go/rest/connection_test.go:55:3: call to T.Fatalf
vendor/k8s.io/client-go/rest/connection_test.go:112:2: the goroutine calls T.Fatalf, which must be called in the same goroutine as the test (SA2002)
vendor/k8s.io/client-go/rest/connection_test.go:62:3: call to T.Fatalf
vendor/k8s.io/client-go/rest/connection_test.go:145:2: the goroutine calls T.Fatalf, which must be called in the same goroutine as the test (SA2002)
vendor/k8s.io/client-go/rest/connection_test.go:62:3: call to T.Fatalf
vendor/k8s.io/client-go/rest/request.go:515:32: possible nil pointer dereference (SA5011)
vendor/k8s.io/client-go/rest/request.go:519:5: this check suggests that the pointer can be nil
vendor/k8s.io/client-go/rest/request_test.go:927:6: type errorReader is unused (U1000)
vendor/k8s.io/client-go/rest/request_test.go:1216:6: type fakeUpgradeConnection is unused (U1000)
vendor/k8s.io/client-go/rest/request_test.go:1230:6: type fakeUpgradeRoundTripper is unused (U1000)
```
Part of #92402 

