### PR TITLE
promote huge page storage medium size to GA

### DIFF
--- a/pkg/api/pod/util.go
+++ b/pkg/api/pod/util.go
@@ -21,11 +21,9 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/sets"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	api "k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/apis/core/helper"
-	v1helper "k8s.io/kubernetes/pkg/apis/core/v1/helper"
 	apivalidation "k8s.io/kubernetes/pkg/apis/core/validation"
 	"k8s.io/kubernetes/pkg/features"
 )
@@ -331,19 +329,6 @@ func usesHugePagesInProjectedEnv(item api.Container) bool {
 	return false
 }
 
-// usesMultipleHugePageResources returns true if the pod spec uses more than
-// one size of hugepage
-func usesMultipleHugePageResources(podSpec *api.PodSpec) bool {
-	hugePageResources := sets.NewString()
-	resourceSet := helper.ToPodResourcesSet(podSpec)
-	for resourceStr := range resourceSet {
-		if v1helper.IsHugePageResourceName(v1.ResourceName(resourceStr)) {
-			hugePageResources.Insert(resourceStr)
-		}
-	}
-	return len(hugePageResources) > 1
-}
-
 func checkContainerUseIndivisibleHugePagesValues(container api.Container) bool {
 	for resourceName, quantity := range container.Resources.Limits {
 		if helper.IsHugePageResourceName(resourceName) {
@@ -394,8 +379,6 @@ func usesIndivisibleHugePagesValues(podSpec *api.PodSpec) bool {
 func GetValidationOptionsFromPodSpecAndMeta(podSpec, oldPodSpec *api.PodSpec, podMeta, oldPodMeta *metav1.ObjectMeta) apivalidation.PodValidationOptions {
 	// default pod validation options based on feature gate
 	opts := apivalidation.PodValidationOptions{
-		// Allow multiple huge pages on pod create if feature is enabled
-		AllowMultipleHugePageResources: utilfeature.DefaultFeatureGate.Enabled(features.HugePageStorageMediumSize),
 		// Allow pod spec to use hugepages in downward API if feature is enabled
 		AllowDownwardAPIHugePages:   utilfeature.DefaultFeatureGate.Enabled(features.DownwardAPIHugePages),
 		AllowInvalidPodDeletionCost: !utilfeature.DefaultFeatureGate.Enabled(features.PodDeletionCost),
@@ -404,8 +387,6 @@ func GetValidationOptionsFromPodSpecAndMeta(podSpec, oldPodSpec *api.PodSpec, po
 	}
 
 	if oldPodSpec != nil {
-		// if old spec used multiple huge page sizes, we must allow it
-		opts.AllowMultipleHugePageResources = opts.AllowMultipleHugePageResources || usesMultipleHugePageResources(oldPodSpec)
 		// if old spec used hugepages in downward api, we must allow it
 		opts.AllowDownwardAPIHugePages = opts.AllowDownwardAPIHugePages || usesHugePagesInProjectedVolume(oldPodSpec)
 		// determine if any container is using hugepages in env var

--- a/pkg/apis/core/validation/validation_test.go
+++ b/pkg/apis/core/validation/validation_test.go
@@ -4113,9 +4113,8 @@ func TestValidateVolumes(t *testing.T) {
 
 func TestHugePagesIsolation(t *testing.T) {
 	testCases := map[string]struct {
-		pod                             *core.Pod
-		enableHugePageStorageMediumSize bool
-		expectError                     bool
+		pod         *core.Pod
+		expectError bool
 	}{
 		"Valid: request hugepages-2Mi": {
 			pod: &core.Pod{
@@ -4143,7 +4142,7 @@ func TestHugePagesIsolation(t *testing.T) {
 				},
 			},
 		},
-		"Valid: HugePageStorageMediumSize enabled: request more than one hugepages size": {
+		"Valid: request more than one hugepages size": {
 			pod: &core.Pod{
 				ObjectMeta: metav1.ObjectMeta{Name: "hugepages-shared", Namespace: "ns"},
 				Spec: core.PodSpec{
@@ -4170,10 +4169,9 @@ func TestHugePagesIsolation(t *testing.T) {
 					DNSPolicy:     core.DNSClusterFirst,
 				},
 			},
-			enableHugePageStorageMediumSize: true,
-			expectError:                     false,
+			expectError: false,
 		},
-		"Invalid: HugePageStorageMediumSize disabled: request hugepages-1Gi, limit hugepages-2Mi and hugepages-1Gi": {
+		"Valid: request hugepages-1Gi, limit hugepages-2Mi and hugepages-1Gi": {
 			pod: &core.Pod{
 				ObjectMeta: metav1.ObjectMeta{Name: "hugepages-multiple", Namespace: "ns"},
 				Spec: core.PodSpec{
@@ -4184,6 +4182,7 @@ func TestHugePagesIsolation(t *testing.T) {
 								Requests: core.ResourceList{
 									core.ResourceName(core.ResourceCPU):    resource.MustParse("10"),
 									core.ResourceName(core.ResourceMemory): resource.MustParse("10G"),
+									core.ResourceName("hugepages-2Mi"):     resource.MustParse("1Gi"),
 									core.ResourceName("hugepages-1Gi"):     resource.MustParse("2Gi"),
 								},
 								Limits: core.ResourceList{
@@ -4199,7 +4198,6 @@ func TestHugePagesIsolation(t *testing.T) {
 					DNSPolicy:     core.DNSClusterFirst,
 				},
 			},
-			expectError: true,
 		},
 		"Invalid: not requesting cpu and memory": {
 			pod: &core.Pod{
@@ -4251,40 +4249,10 @@ func TestHugePagesIsolation(t *testing.T) {
 			},
 			expectError: true,
 		},
-		"Invalid: HugePageStorageMediumSize disabled: request more than one hugepages size": {
-			pod: &core.Pod{
-				ObjectMeta: metav1.ObjectMeta{Name: "hugepages-shared", Namespace: "ns"},
-				Spec: core.PodSpec{
-					Containers: []core.Container{
-						{
-							Name: "ctr", Image: "image", ImagePullPolicy: "IfNotPresent", TerminationMessagePolicy: "File",
-							Resources: core.ResourceRequirements{
-								Requests: core.ResourceList{
-									core.ResourceName(core.ResourceCPU):    resource.MustParse("10"),
-									core.ResourceName(core.ResourceMemory): resource.MustParse("10G"),
-									core.ResourceName("hugepages-2Mi"):     resource.MustParse("1Gi"),
-									core.ResourceName("hugepages-1Gi"):     resource.MustParse("1Gi"),
-								},
-								Limits: core.ResourceList{
-									core.ResourceName(core.ResourceCPU):    resource.MustParse("10"),
-									core.ResourceName(core.ResourceMemory): resource.MustParse("10G"),
-									core.ResourceName("hugepages-2Mi"):     resource.MustParse("1Gi"),
-									core.ResourceName("hugepages-1Gi"):     resource.MustParse("1Gi"),
-								},
-							},
-						},
-					},
-					RestartPolicy: core.RestartPolicyAlways,
-					DNSPolicy:     core.DNSClusterFirst,
-				},
-			},
-			expectError: true,
-		},
 	}
 	for tcName, tc := range testCases {
 		t.Run(tcName, func(t *testing.T) {
-			defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.HugePageStorageMediumSize, tc.enableHugePageStorageMediumSize)()
-			errs := ValidatePodCreate(tc.pod, PodValidationOptions{AllowMultipleHugePageResources: tc.enableHugePageStorageMediumSize})
+			errs := ValidatePodCreate(tc.pod, PodValidationOptions{})
 			if tc.expectError && len(errs) == 0 {
 				t.Errorf("Unexpected success")
 			}

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -530,6 +530,7 @@ const (
 	// owner: @bart0sh
 	// alpha: v1.18
 	// beta: v1.19
+	// GA: 1.22
 	//
 	// Enables usage of HugePages-<size> in a volume medium,
 	// e.g. emptyDir:
@@ -799,8 +800,8 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 	ServiceTopology:                                {Default: false, PreRelease: featuregate.Alpha},
 	ServiceAppProtocol:                             {Default: true, PreRelease: featuregate.GA, LockToDefault: true},
 	ImmutableEphemeralVolumes:                      {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.24
-	HugePageStorageMediumSize:                      {Default: true, PreRelease: featuregate.Beta},
-	DownwardAPIHugePages:                           {Default: false, PreRelease: featuregate.Beta}, // on by default in 1.22
+	HugePageStorageMediumSize:                      {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.23
+	DownwardAPIHugePages:                           {Default: false, PreRelease: featuregate.Beta},                   // on by default in 1.22
 	AnyVolumeDataSource:                            {Default: false, PreRelease: featuregate.Alpha},
 	DefaultPodTopologySpread:                       {Default: true, PreRelease: featuregate.Beta},
 	SetHostnameAsFQDN:                              {Default: true, PreRelease: featuregate.Beta},

--- a/pkg/kubelet/config/common.go
+++ b/pkg/kubelet/config/common.go
@@ -22,15 +22,13 @@ import (
 	"fmt"
 	"strings"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	utilyaml "k8s.io/apimachinery/pkg/util/yaml"
-	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	api "k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/apis/core/helper"
-	"k8s.io/kubernetes/pkg/features"
 
 	// TODO: remove this import if
 	// api.Registry.GroupOrDie(v1.GroupName).GroupVersion.String() is changed
@@ -137,10 +135,7 @@ func tryDecodeSinglePod(data []byte, defaultFn defaultFunc) (parsed bool, pod *v
 	if err = defaultFn(newPod); err != nil {
 		return true, pod, err
 	}
-	opts := validation.PodValidationOptions{
-		AllowMultipleHugePageResources: utilfeature.DefaultFeatureGate.Enabled(features.HugePageStorageMediumSize),
-	}
-	if errs := validation.ValidatePodCreate(newPod, opts); len(errs) > 0 {
+	if errs := validation.ValidatePodCreate(newPod, validation.PodValidationOptions{}); len(errs) > 0 {
 		return true, pod, fmt.Errorf("invalid pod: %v", errs)
 	}
 	v1Pod := &v1.Pod{}
@@ -164,17 +159,13 @@ func tryDecodePodList(data []byte, defaultFn defaultFunc) (parsed bool, pods v1.
 		return false, pods, err
 	}
 
-	opts := validation.PodValidationOptions{
-		AllowMultipleHugePageResources: utilfeature.DefaultFeatureGate.Enabled(features.HugePageStorageMediumSize),
-	}
-
 	// Apply default values and validate pods.
 	for i := range newPods.Items {
 		newPod := &newPods.Items[i]
 		if err = defaultFn(newPod); err != nil {
 			return true, pods, err
 		}
-		if errs := validation.ValidatePodCreate(newPod, opts); len(errs) > 0 {
+		if errs := validation.ValidatePodCreate(newPod, validation.PodValidationOptions{}); len(errs) > 0 {
 			err = fmt.Errorf("invalid pod: %v", errs)
 			return true, pods, err
 		}

--- a/pkg/volume/emptydir/empty_dir_test.go
+++ b/pkg/volume/emptydir/empty_dir_test.go
@@ -108,24 +108,17 @@ func TestPluginEmptyRootContext(t *testing.T) {
 
 func TestPluginHugetlbfs(t *testing.T) {
 	testCases := map[string]struct {
-		medium                          v1.StorageMedium
-		enableHugePageStorageMediumSize bool
+		medium v1.StorageMedium
 	}{
-		"HugePageStorageMediumSize enabled: medium without size": {
-			medium:                          "HugePages",
-			enableHugePageStorageMediumSize: true,
-		},
-		"HugePageStorageMediumSize disabled: medium without size": {
+		"medium without size": {
 			medium: "HugePages",
 		},
-		"HugePageStorageMediumSize enabled: medium with size": {
-			medium:                          "HugePages-2Mi",
-			enableHugePageStorageMediumSize: true,
+		"medium with size": {
+			medium: "HugePages-2Mi",
 		},
 	}
 	for tcName, tc := range testCases {
 		t.Run(tcName, func(t *testing.T) {
-			defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.HugePageStorageMediumSize, tc.enableHugePageStorageMediumSize)()
 			doTestPlugin(t, pluginTestConfig{
 				medium:                        tc.medium,
 				expectedSetupMounts:           1,
@@ -381,11 +374,10 @@ func TestMetrics(t *testing.T) {
 
 func TestGetHugePagesMountOptions(t *testing.T) {
 	testCases := map[string]struct {
-		pod                             *v1.Pod
-		medium                          v1.StorageMedium
-		shouldFail                      bool
-		expectedResult                  string
-		enableHugePageStorageMediumSize bool
+		pod            *v1.Pod
+		medium         v1.StorageMedium
+		shouldFail     bool
+		expectedResult string
 	}{
 		"ProperValues": {
 			pod: &v1.Pod{
@@ -501,10 +493,9 @@ func TestGetHugePagesMountOptions(t *testing.T) {
 					},
 				},
 			},
-			medium:                          v1.StorageMediumHugePages,
-			shouldFail:                      true,
-			expectedResult:                  "",
-			enableHugePageStorageMediumSize: true,
+			medium:         v1.StorageMediumHugePages,
+			shouldFail:     true,
+			expectedResult: "",
 		},
 		"PodWithNoHugePagesRequest": {
 			pod:            &v1.Pod{},
@@ -527,10 +518,9 @@ func TestGetHugePagesMountOptions(t *testing.T) {
 					},
 				},
 			},
-			medium:                          v1.StorageMediumHugePagesPrefix + "1Gi",
-			shouldFail:                      false,
-			expectedResult:                  "pagesize=1Gi",
-			enableHugePageStorageMediumSize: true,
+			medium:         v1.StorageMediumHugePagesPrefix + "1Gi",
+			shouldFail:     false,
+			expectedResult: "pagesize=1Gi",
 		},
 		"InitContainerAndContainerHasProperValuesMultipleSizes": {
 			pod: &v1.Pod{
@@ -555,10 +545,9 @@ func TestGetHugePagesMountOptions(t *testing.T) {
 					},
 				},
 			},
-			medium:                          v1.StorageMediumHugePagesPrefix + "2Mi",
-			shouldFail:                      false,
-			expectedResult:                  "pagesize=2Mi",
-			enableHugePageStorageMediumSize: true,
+			medium:         v1.StorageMediumHugePagesPrefix + "2Mi",
+			shouldFail:     false,
+			expectedResult: "pagesize=2Mi",
 		},
 		"MediumWithoutSizeMultipleSizes": {
 			pod: &v1.Pod{
@@ -621,7 +610,6 @@ func TestGetHugePagesMountOptions(t *testing.T) {
 
 	for testCaseName, testCase := range testCases {
 		t.Run(testCaseName, func(t *testing.T) {
-			defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.HugePageStorageMediumSize, testCase.enableHugePageStorageMediumSize)()
 			value, err := getPageSizeMountOption(testCase.medium, testCase.pod)
 			if testCase.shouldFail && err == nil {
 				t.Errorf("%s: Unexpected success", testCaseName)


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR promotes support for multiple size huge pages to GA.
This feature was enabled by default in Kubernetes since v.19 and haven't got any complains since then, so it should be ready for promotion.


#### Does this PR introduce a user-facing change?

```release-note
The `HugePageStorageMediumSize` feature has been promoted to GA, allowing unconditional usage of multiple sizes huge page resources on a container level.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:


- KEP: [https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/1539-hugepages](https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/1539-hugepages)
- KEP update PR: https://github.com/kubernetes/enhancements/pull/2534
- Documentation update PR: https://github.com/kubernetes/website/pull/26664
- CI job update PR: https://github.com/kubernetes/test-infra/pull/20877

