### PR TITLE
Apply cap_net_bind_service to kube-apiserver binary.

### DIFF
--- a/build/lib/release.sh
+++ b/build/lib/release.sh
@@ -218,6 +218,12 @@ function kube::release::package_node_tarballs() {
 function kube::release::build_server_images() {
   # Clean out any old images
   rm -rf "${RELEASE_IMAGES}"
+
+  export DOCKER_CLI_EXPERIMENTAL=enabled
+  docker run --rm --privileged multiarch/qemu-user-static:5.2.0-2 --reset -p yes
+  docker buildx rm kube-server-image-builder || true
+  docker buildx create --use --name=kube-server-image-builder
+
   local platform
   for platform in "${KUBE_SERVER_PLATFORMS[@]}"; do
     local platform_tag
@@ -239,6 +245,8 @@ function kube::release::build_server_images() {
 
     kube::release::create_docker_images_for_server "${release_stage}/server/bin" "${arch}"
   done
+
+  docker buildx rm kube-server-image-builder
 }
 
 # Package up all of the server binaries
@@ -364,8 +372,13 @@ function kube::release::create_docker_images_for_server() {
       local base_image=${wrappable##*,}
       local binary_file_path="${binary_dir}/${binary_name}"
       local docker_build_path="${binary_file_path}.dockerbuild"
-      local docker_file_path="${KUBE_ROOT}/build/server-image/Dockerfile"
       local docker_image_tag="${docker_registry}/${binary_name}-${arch}:${docker_tag}"
+
+      local docker_file_path="${KUBE_ROOT}/build/server-image/Dockerfile"
+      # If this binary has its own Dockerfile use that else use the generic Dockerfile.
+      if [[ -f "${KUBE_ROOT}/build/server-image/${binary_name}/Dockerfile" ]]; then
+          docker_file_path="${KUBE_ROOT}/build/server-image/${binary_name}/Dockerfile"
+      fi
 
       kube::log::status "Starting docker build for image: ${binary_name}-${arch}"
       (
@@ -402,7 +415,7 @@ function kube::release::create_docker_images_for_server() {
 
         kube::log::status "Deleting docker image ${docker_image_tag}"
         "${DOCKER[@]}" rmi "${docker_image_tag}" &>/dev/null || true
-      ) &
+      )
     done
 
     if [[ "${KUBE_BUILD_CONFORMANCE}" =~ [yY] ]]; then

--- a/build/lib/release.sh
+++ b/build/lib/release.sh
@@ -218,12 +218,6 @@ function kube::release::package_node_tarballs() {
 function kube::release::build_server_images() {
   # Clean out any old images
   rm -rf "${RELEASE_IMAGES}"
-
-  export DOCKER_CLI_EXPERIMENTAL=enabled
-  docker run --rm --privileged multiarch/qemu-user-static:5.2.0-2 --reset -p yes
-  docker buildx rm kube-server-image-builder || true
-  docker buildx create --use --name=kube-server-image-builder
-
   local platform
   for platform in "${KUBE_SERVER_PLATFORMS[@]}"; do
     local platform_tag
@@ -245,8 +239,6 @@ function kube::release::build_server_images() {
 
     kube::release::create_docker_images_for_server "${release_stage}/server/bin" "${arch}"
   done
-
-  docker buildx rm kube-server-image-builder
 }
 
 # Package up all of the server binaries
@@ -415,7 +407,7 @@ function kube::release::create_docker_images_for_server() {
 
         kube::log::status "Deleting docker image ${docker_image_tag}"
         "${DOCKER[@]}" rmi "${docker_image_tag}" &>/dev/null || true
-      )
+      ) &
     done
 
     if [[ "${KUBE_BUILD_CONFORMANCE}" =~ [yY] ]]; then

--- a/build/server-image/kube-apiserver/Dockerfile
+++ b/build/server-image/kube-apiserver/Dockerfile
@@ -1,0 +1,27 @@
+# Copyright 2021 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This file create the kube-apiserver image.
+ARG BASEIMAGE
+
+FROM k8s.gcr.io/build-image/setcap:buster-v1.4.0
+ARG BINARY
+COPY ${BINARY} /${BINARY}
+# We apply cap_net_bind_service so that kube-apiserver can be run as
+# non-root and still listen on port less than 1024
+RUN setcap cap_net_bind_service=+ep /${BINARY}
+
+FROM ${BASEIMAGE}
+ARG BINARY
+COPY --from=0 /${BINARY} /usr/local/bin/${BINARY}

--- a/build/server-image/kube-apiserver/Dockerfile
+++ b/build/server-image/kube-apiserver/Dockerfile
@@ -14,14 +14,15 @@
 
 # This file create the kube-apiserver image.
 ARG BASEIMAGE
-
-FROM k8s.gcr.io/build-image/setcap:buster-v1.4.0
+# we use the hosts platform to apply the capabilities to avoid the need
+# to setup qemu for the builder.
+FROM --platform=linux/$BUILDARCH k8s.gcr.io/build-image/setcap:buster-v1.4.0
 ARG BINARY
 COPY ${BINARY} /${BINARY}
 # We apply cap_net_bind_service so that kube-apiserver can be run as
 # non-root and still listen on port less than 1024
 RUN setcap cap_net_bind_service=+ep /${BINARY}
 
-FROM ${BASEIMAGE}
+FROM --platform=linux/$TARGETARCH ${BASEIMAGE}
 ARG BINARY
 COPY --from=0 /${BINARY} /usr/local/bin/${BINARY}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
Adds a Dockerfile for kube-apiserver image. The Dockerfile performs a multistage build where we apply cap_net_bind_service to the kube-apiserver binary. Since the Dockerfile contains the RUN command we need to register qemu and create a builder to use buildx for coss building.
To apply the binary we built and pushed an image with setcap installed. 
https://github.com/kubernetes/release/pull/1684
https://github.com/kubernetes/test-infra/pull/20857
https://github.com/kubernetes/k8s.io/pull/1644

This PR should be merged before https://github.com/kubernetes/kubernetes/pull/96134,

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
