### PR TITLE
e2e createSync() method wait for pod running and ready

### DIFF
--- a/test/e2e/common/configmap_volume.go
+++ b/test/e2e/common/configmap_volume.go
@@ -213,7 +213,8 @@ var _ = ginkgo.Describe("[sig-storage] ConfigMap", func() {
 		})
 
 		ginkgo.By("Creating the pod")
-		f.PodClient().CreateSync(pod)
+		f.PodClient().Create(pod)
+		e2epod.WaitForPodNameRunningInNamespace(f.ClientSet, pod.Name, f.Namespace.Name)
 
 		pollLogs1 := func() (string, error) {
 			return e2epod.GetPodLogs(f.ClientSet, f.Namespace.Name, pod.Name, pod.Spec.Containers[0].Name)

--- a/test/e2e/common/empty_dir.go
+++ b/test/e2e/common/empty_dir.go
@@ -282,7 +282,8 @@ var _ = ginkgo.Describe("[sig-storage] EmptyDir volumes", func() {
 		}
 
 		ginkgo.By("Creating Pod")
-		pod = f.PodClient().CreateSync(pod)
+		f.PodClient().Create(pod)
+		e2epod.WaitForPodNameRunningInNamespace(f.ClientSet, pod.Name, f.Namespace.Name)
 
 		ginkgo.By("Reading file content from the nginx-container")
 		result := f.ExecShellInContainer(pod.Name, busyBoxMainContainerName, fmt.Sprintf("cat %s", busyBoxMainVolumeFilePath))

--- a/test/e2e/common/pods.go
+++ b/test/e2e/common/pods.go
@@ -19,6 +19,7 @@ package common
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"runtime/debug"
@@ -28,7 +29,6 @@ import (
 
 	"golang.org/x/net/websocket"
 
-	"encoding/json"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -813,7 +813,8 @@ var _ = framework.KubeDescribe("Pods", func() {
 		}
 
 		ginkgo.By("submitting the pod to kubernetes")
-		podClient.CreateSync(pod)
+		f.PodClient().Create(pod)
+		e2epod.WaitForPodNameRunningInNamespace(f.ClientSet, pod.Name, f.Namespace.Name)
 		framework.ExpectEqual(podClient.PodIsReady(podName), false, "Expect pod's Ready condition to be false initially.")
 
 		ginkgo.By(fmt.Sprintf("patching pod status with condition %q to true", readinessGate1))

--- a/test/e2e/framework/pod/wait.go
+++ b/test/e2e/framework/pod/wait.go
@@ -357,7 +357,7 @@ func WaitForPodNoLongerRunningInNamespace(c clientset.Interface, podName, namesp
 	return WaitTimeoutForPodNoLongerRunningInNamespace(c, podName, namespace, defaultPodDeletionTimeout)
 }
 
-// WaitTimeoutForPodReadyInNamespace waits the given timeout diration for the
+// WaitTimeoutForPodReadyInNamespace waits the given timeout duration for the
 // specified pod to be ready and running.
 func WaitTimeoutForPodReadyInNamespace(c clientset.Interface, podName, namespace string, timeout time.Duration) error {
 	return wait.PollImmediate(poll, timeout, podRunningAndReady(c, podName, namespace))

--- a/test/e2e/framework/pods.go
+++ b/test/e2e/framework/pods.go
@@ -96,12 +96,12 @@ func (c *PodClient) Create(pod *v1.Pod) *v1.Pod {
 	return p
 }
 
-// CreateSync creates a new pod according to the framework specifications, and wait for it to start.
+// CreateSync creates a new pod according to the framework specifications, and wait for it to start and be running and ready.
 func (c *PodClient) CreateSync(pod *v1.Pod) *v1.Pod {
 	namespace := c.f.Namespace.Name
 	p := c.Create(pod)
-	ExpectNoError(e2epod.WaitForPodNameRunningInNamespace(c.f.ClientSet, p.Name, namespace))
-	// Get the newest pod after it becomes running, some status may change after pod created, such as pod ip.
+	ExpectNoError(e2epod.WaitTimeoutForPodReadyInNamespace(c.f.ClientSet, p.Name, namespace, PodStartTimeout))
+	// Get the newest pod after it becomes running and ready, some status may change after pod created, such as pod ip.
 	p, err := c.Get(context.TODO(), p.Name, metav1.GetOptions{})
 	ExpectNoError(err)
 	return p


### PR DESCRIPTION
The user expectations calling this method is that the pod should
be ready for the test, however, it only checks that is running,
causing timing issues on busy environments.

It is important to mention that if a pod is not Ready and is backing a Service, 
the Service traffic will not be forwarded to it. This can cause flakiness for tests
that use Services.

/kind flake
```release-note
NONE
```


follow up on https://github.com/kubernetes/kubernetes/pull/99097