### PR TITLE
Add kubectl-convert to client-binaries

### DIFF
--- a/build/BUILD
+++ b/build/BUILD
@@ -124,6 +124,7 @@ release_filegroup(
     name = "client-targets",
     conditioned_srcs = for_platforms(for_client = [
         "//cmd/kubectl",
+        "//cmd/kubectl-convert",
     ]),
 )
 

--- a/cmd/kubectl-convert/BUILD
+++ b/cmd/kubectl-convert/BUILD
@@ -6,7 +6,7 @@ load(
 load("//staging/src/k8s.io/component-base/version:def.bzl", "version_x_defs")
 
 go_binary(
-    name = "kubectl",
+    name = "kubectl-convert",
     embed = [":go_default_library"],
     pure = "on",
     visibility = ["//visibility:public"],

--- a/hack/lib/golang.sh
+++ b/hack/lib/golang.sh
@@ -248,6 +248,7 @@ kube::golang::setup_platforms
 # If you update this list, please also update build/BUILD.
 readonly KUBE_CLIENT_TARGETS=(
   cmd/kubectl
+  cmd/kubectl-convert
 )
 readonly KUBE_CLIENT_BINARIES=("${KUBE_CLIENT_TARGETS[@]##*/}")
 readonly KUBE_CLIENT_BINARIES_WIN=("${KUBE_CLIENT_BINARIES[@]/%/.exe}")

--- a/test/cmd/convert.sh
+++ b/test/cmd/convert.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+
+# Copyright 2021 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+run_convert_tests() {
+  set -o nounset
+  set -o errexit
+
+  ### Convert deployment YAML file locally without affecting the live deployment
+  # Pre-condition: no deployments exist
+  kube::test::get_object_assert deployment "{{range.items}}{{${id_field:?}}}:{{end}}" ''
+  # Command
+  # Create a deployment (revision 1)
+  kubectl create -f hack/testdata/deployment-revision1.yaml "${kube_flags[@]:?}"
+  kube::test::get_object_assert deployment "{{range.items}}{{${id_field:?}}}:{{end}}" 'nginx:'
+  kube::test::get_object_assert deployment "{{range.items}}{{${image_field0:?}}}:{{end}}" "${IMAGE_DEPLOYMENT_R1}:"
+  # Command
+  output_message=$(kubectl convert --local -f hack/testdata/deployment-revision1.yaml --output-version=apps/v1beta1 -o yaml "${kube_flags[@]:?}")
+  # Post-condition: apiVersion is still apps/v1 in the live deployment, but command output is the new value
+  kube::test::get_object_assert 'deployment nginx' "{{ .apiVersion }}" 'apps/v1'
+  kube::test::if_has_string "${output_message}" "apps/v1beta1"
+  # Clean up
+  kubectl delete deployment nginx "${kube_flags[@]:?}"
+
+  ## Convert multiple busybox PODs recursively from directory of YAML files
+  # Command
+  output_message=$(! kubectl-convert -f hack/testdata/recursive/pod --recursive 2>&1 "${kube_flags[@]:?}")
+  # Post-condition: busybox0 & busybox1 PODs are converted, and since busybox2 is malformed, it should error
+  kube::test::if_has_string "${output_message}" "Object 'Kind' is missing"
+
+  # check that convert command supports --template output
+  output_message=$(kubectl-convert "${kube_flags[@]:?}" -f hack/testdata/deployment-revision1.yaml --output-version=apps/v1beta2 --template="{{ .metadata.name }}:")
+  kube::test::if_has_string "${output_message}" 'nginx:'
+
+  set +o nounset
+  set +o errexit
+}

--- a/test/cmd/legacy-script.sh
+++ b/test/cmd/legacy-script.sh
@@ -33,6 +33,7 @@ source "${KUBE_ROOT}/test/cmd/authentication.sh"
 source "${KUBE_ROOT}/test/cmd/authorization.sh"
 source "${KUBE_ROOT}/test/cmd/batch.sh"
 source "${KUBE_ROOT}/test/cmd/certificate.sh"
+source "${KUBE_ROOT}/test/cmd/convert.sh"
 source "${KUBE_ROOT}/test/cmd/core.sh"
 source "${KUBE_ROOT}/test/cmd/crd.sh"
 source "${KUBE_ROOT}/test/cmd/create.sh"
@@ -298,7 +299,7 @@ setup() {
   kube::util::ensure-gnu-sed
 
   kube::log::status "Building kubectl"
-  make -C "${KUBE_ROOT}" WHAT="cmd/kubectl"
+  make -C "${KUBE_ROOT}" WHAT="cmd/kubectl cmd/kubectl-convert"
 
   # Check kubectl
   kube::log::status "Running kubectl with no options"
@@ -559,6 +560,13 @@ runTests() {
   fi
   if kube::test::if_supports_resource "${deployments}"; then
     record_command run_kubectl_create_kustomization_directory_tests
+  fi
+
+  ######################
+  # Convert            #
+  ######################
+  if kube::test::if_supports_resource "${deployments}"; then
+    record_command run_convert_tests
   fi
 
   ######################


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind documentation

/sig cli
/sig release
/priority backlog

#### What this PR does / why we need it:
In https://github.com/kubernetes/kubernetes/pull/96190 I moved all the remaining bits of kubectl to staging repository. Per https://github.com/kubernetes/kubectl/issues/725 it was decided that `kubectl convert` will become a plugin but I missed it in that PR. This should fix our release such that it will include `kubectl-convert` binaries along `kubectl`. 

#### Which issue(s) this PR fixes:
Fixes #99076 

#### Special notes for your reviewer:
/assign @liggitt @neolit123 

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
