### PR TITLE
Automated cherry pick of #98555: Storage e2e: Remove pd csi driver installation in GKE

### DIFF
--- a/test/e2e/storage/drivers/csi.go
+++ b/test/e2e/storage/drivers/csi.go
@@ -549,11 +549,22 @@ func (g *gcePDCSIDriver) GetSnapshotClass(config *testsuites.PerTestConfig) *uns
 }
 
 func (g *gcePDCSIDriver) PrepareTest(f *framework.Framework) (*testsuites.PerTestConfig, func()) {
+	testns := f.Namespace.Name
+	cfg := &testsuites.PerTestConfig{
+		Driver:    g,
+		Prefix:    "gcepd",
+		Framework: f,
+	}
+
+	if framework.ProviderIs("gke") {
+		framework.Logf("The csi gce-pd driver is automatically installed in GKE. Skipping driver installation.")
+		return cfg, func() {}
+	}
+
 	ginkgo.By("deploying csi gce-pd driver")
 	// Create secondary namespace which will be used for creating driver
 	driverNamespace := utils.CreateDriverNamespace(f)
-	ns2 := driverNamespace.Name
-	ns1 := f.Namespace.Name
+	driverns := driverNamespace.Name
 
 	cancelLogging := testsuites.StartPodLogs(f, driverNamespace)
 	// It would be safer to rename the gcePD driver, but that
@@ -568,7 +579,7 @@ func (g *gcePDCSIDriver) PrepareTest(f *framework.Framework) (*testsuites.PerTes
 	// 	DriverContainerName:      "gce-driver",
 	// 	ProvisionerContainerName: "csi-external-provisioner",
 	// }
-	createGCESecrets(f.ClientSet, ns2)
+	createGCESecrets(f.ClientSet, driverns)
 
 	manifests := []string{
 		"test/e2e/testing-manifests/storage-csi/external-attacher/rbac.yaml",
@@ -590,17 +601,17 @@ func (g *gcePDCSIDriver) PrepareTest(f *framework.Framework) (*testsuites.PerTes
 	// Cleanup CSI driver and namespaces. This function needs to be idempotent and can be
 	// concurrently called from defer (or AfterEach) and AfterSuite action hooks.
 	cleanupFunc := func() {
-		ginkgo.By(fmt.Sprintf("deleting the test namespace: %s", ns1))
-		// Delete the primary namespace but its okay to fail here because this namespace will
+		ginkgo.By(fmt.Sprintf("deleting the test namespace: %s", testns))
+		// Delete the primary namespace but it's okay to fail here because this namespace will
 		// also be deleted by framework.Aftereach hook
-		tryFunc(deleteNamespaceFunc(f.ClientSet, ns1, framework.DefaultNamespaceDeletionTimeout))
+		tryFunc(deleteNamespaceFunc(f.ClientSet, testns, framework.DefaultNamespaceDeletionTimeout))
 
-		ginkgo.By("uninstalling csi mock driver")
+		ginkgo.By("uninstalling csi gce-pd driver")
 		tryFunc(cleanup)
 		tryFunc(cancelLogging)
 
-		ginkgo.By(fmt.Sprintf("deleting the driver namespace: %s", ns2))
-		tryFunc(deleteNamespaceFunc(f.ClientSet, ns2, framework.DefaultNamespaceDeletionTimeout))
+		ginkgo.By(fmt.Sprintf("deleting the driver namespace: %s", driverns))
+		tryFunc(deleteNamespaceFunc(f.ClientSet, driverns, framework.DefaultNamespaceDeletionTimeout))
 		// cleanup function has already ran and hence we don't need to run it again.
 		// We do this as very last action because in-case defer(or AfterEach) races
 		// with AfterSuite and test routine gets killed then this block still


### PR DESCRIPTION
Cherry pick of #98555 on release-1.19.

#98555: Storage e2e: Remove pd csi driver installation in GKE

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

**Notes**: This fixes conflicting PD CSI driver installations in GKE storage e2e tests.

```release-note
NONE
```
