### PR TITLE
Automated cherry pick of #98555: Storage e2e: Remove pd csi driver installation in GKE

### DIFF
--- a/test/e2e/storage/drivers/csi.go
+++ b/test/e2e/storage/drivers/csi.go
@@ -432,6 +432,17 @@ func (g *gcePDCSIDriver) GetSnapshotClass(config *testsuites.PerTestConfig) *uns
 }
 
 func (g *gcePDCSIDriver) PrepareTest(f *framework.Framework) (*testsuites.PerTestConfig, func()) {
+	cfg := &testsuites.PerTestConfig{
+		Driver:    g,
+		Prefix:    "gcepd",
+		Framework: f,
+	}
+
+	if framework.ProviderIs("gke") {
+		framework.Logf("The csi gce-pd driver is automatically installed in GKE. Skipping driver installation.")
+		return cfg, func() {}
+	}
+
 	ginkgo.By("deploying csi gce-pd driver")
 	cancelLogging := testsuites.StartPodLogs(f)
 	// It would be safer to rename the gcePD driver, but that


### PR DESCRIPTION
Cherry pick of #98555 on release-1.18.

#98555: Storage e2e: Remove pd csi driver installation in GKE

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

**Notes**: This fixes conflicting PD CSI driver installations in GKE storage e2e tests.

```release-note
NONE
```

/kind bug
/priority critical-urgent
/triage accepted
/assign @msau42 @mattcary 