### PR TITLE
fix ut flake: use time.Since instead of Now()-start as it will call runtimeNano if hasMonotonic

### DIFF
--- a/staging/src/k8s.io/client-go/util/flowcontrol/throttle_test.go
+++ b/staging/src/k8s.io/client-go/util/flowcontrol/throttle_test.go
@@ -62,11 +62,11 @@ func TestMultithreadedThrottling(t *testing.T) {
 	close(startCh)
 	// wait for the first signal that we collected 100 tokens
 	<-endCh
-	// record wall time
-	endTime := time.Now()
+	// record duration since wall time
+	duration := time.Since(startTime)
 
 	// tolerate a 1% clock change because these things happen
-	if duration := endTime.Sub(startTime); duration < (time.Second * 99 / 100) {
+	if duration < (time.Second * 99 / 100) {
 		// We shouldn't be able to get 100 tokens out of the bucket in less than 1 second of wall clock time, no matter what
 		t.Errorf("Expected it to take at least 1 second to get 100 tokens, took %v", duration)
 	} else {


### PR DESCRIPTION
#### What type of PR is this?
/kind flake

#### What this PR does / why we need it:
```

// Since returns the time elapsed since t.
// It is shorthand for time.Now().Sub(t).
func Since(t Time) Duration {
	var now Time
	if t.wall&hasMonotonic != 0 {
		// Common case optimization: if t has monotonic time, then Sub will use only it.
		now = Time{hasMonotonic, runtimeNano() - startNano, nil}
	} else {
		now = Now()
	}
	return now.Sub(t)
}
```

`Since` is using `runtimeNano()` if hasMonotonic.

#### Which issue(s) this PR fixes:

Fixes #99151

#### Special notes for your reviewer:
https://golang.org/src/time/time.go?s=27943:27970#L858

#### Does this PR introduce a user-facing change?
```release-note
None
```
