### PR TITLE
Use distroless to build Conformance image

### DIFF
--- a/cluster/images/conformance/Dockerfile
+++ b/cluster/images/conformance/Dockerfile
@@ -15,8 +15,12 @@
 ARG BASEIMAGE
 
 FROM gcr.io/k8s-staging-build-image/debian-base:v2.1.3 as base
+RUN mkdir /tmp/results \
+ && chown 65532 /tmp/results # Distroless nonroot UID
 
 FROM ${BASEIMAGE}
+
+COPY --from=base /tmp/results /tmp
 
 # This is a dependency for `kubectl diff` tests
 COPY --from=base /usr/bin/diff /usr/local/bin/

--- a/cluster/images/conformance/Dockerfile
+++ b/cluster/images/conformance/Dockerfile
@@ -14,12 +14,17 @@
 
 ARG BASEIMAGE
 
+FROM gcr.io/k8s-staging-build-image/debian-base:v2.1.3 as base
+
 FROM ${BASEIMAGE}
+
+# This is a dependency for `kubectl diff` tests
+COPY --from=base /usr/bin/diff /usr/local/bin/
 
 COPY ginkgo /usr/local/bin/
 COPY e2e.test /usr/local/bin/
 COPY kubectl /usr/local/bin/
-COPY run_e2e.sh /run_e2e.sh
+COPY gorunner /run_e2e.sh
 COPY gorunner /gorunner
 COPY cluster /kubernetes/cluster
 WORKDIR /usr/local/bin
@@ -32,4 +37,4 @@ ENV E2E_VERBOSITY="4"
 ENV RESULTS_DIR="/tmp/results"
 ENV KUBECONFIG=""
 
-CMD [ "/bin/bash", "-c", "/run_e2e.sh" ]
+CMD [ "/gorunner" ]

--- a/cluster/images/conformance/Dockerfile
+++ b/cluster/images/conformance/Dockerfile
@@ -21,12 +21,15 @@ FROM ${BASEIMAGE}
 # This is a dependency for `kubectl diff` tests
 COPY --from=base /usr/bin/diff /usr/local/bin/
 
+COPY cluster /kubernetes/cluster
 COPY ginkgo /usr/local/bin/
 COPY e2e.test /usr/local/bin/
 COPY kubectl /usr/local/bin/
-COPY gorunner /usr/local/bin/
+COPY gorunner /usr/local/bin/kubeconformance
+
+# Legacy executables -- deprecated
+COPY gorunner /run_e2e.sh
 COPY gorunner /gorunner
-COPY cluster /kubernetes/cluster
 
 ENV E2E_FOCUS="\[Conformance\]"
 ENV E2E_SKIP=""
@@ -36,4 +39,4 @@ ENV E2E_VERBOSITY="4"
 ENV RESULTS_DIR="/tmp/results"
 ENV KUBECONFIG=""
 
-ENTRYPOINT [ "/gorunner" ]
+ENTRYPOINT [ "kubeconformance" ]

--- a/cluster/images/conformance/Dockerfile
+++ b/cluster/images/conformance/Dockerfile
@@ -15,12 +15,8 @@
 ARG BASEIMAGE
 
 FROM gcr.io/k8s-staging-build-image/debian-base:v2.1.3 as base
-RUN mkdir /tmp/results \
- && chown 65532 /tmp/results # Distroless nonroot UID
 
 FROM ${BASEIMAGE}
-
-COPY --from=base /tmp/results /tmp
 
 # This is a dependency for `kubectl diff` tests
 COPY --from=base /usr/bin/diff /usr/local/bin/

--- a/cluster/images/conformance/Dockerfile
+++ b/cluster/images/conformance/Dockerfile
@@ -13,13 +13,14 @@
 # limitations under the License.
 
 ARG BASEIMAGE
+ARG RUNNERIMAGE
 
-FROM gcr.io/k8s-staging-build-image/debian-base:v2.1.3 as base
+FROM ${BASEIMAGE} as debbase
 
-FROM ${BASEIMAGE}
+FROM ${RUNNERIMAGE}
 
 # This is a dependency for `kubectl diff` tests
-COPY --from=base /usr/bin/diff /usr/local/bin/
+COPY --from=debbase /usr/bin/diff /usr/local/bin/
 
 COPY cluster /kubernetes/cluster
 COPY ginkgo /usr/local/bin/

--- a/cluster/images/conformance/Dockerfile
+++ b/cluster/images/conformance/Dockerfile
@@ -28,10 +28,9 @@ COPY --from=base /usr/bin/diff /usr/local/bin/
 COPY ginkgo /usr/local/bin/
 COPY e2e.test /usr/local/bin/
 COPY kubectl /usr/local/bin/
-COPY gorunner /run_e2e.sh
+COPY gorunner /usr/local/bin/
 COPY gorunner /gorunner
 COPY cluster /kubernetes/cluster
-WORKDIR /usr/local/bin
 
 ENV E2E_FOCUS="\[Conformance\]"
 ENV E2E_SKIP=""
@@ -41,4 +40,4 @@ ENV E2E_VERBOSITY="4"
 ENV RESULTS_DIR="/tmp/results"
 ENV KUBECONFIG=""
 
-CMD [ "/gorunner" ]
+ENTRYPOINT [ "/gorunner" ]

--- a/cluster/images/conformance/Makefile
+++ b/cluster/images/conformance/Makefile
@@ -31,7 +31,7 @@ E2E_GO_RUNNER_BIN?=$(shell test -f $(LOCAL_OUTPUT_PATH)/go-runner && echo $(LOCA
 
 CLUSTER_DIR?=$(shell pwd)/../../../cluster/
 
-BASEIMAGE=debian:stable-slim
+BASEIMAGE=gcr.io/distroless/base:nonroot
 TEMP_DIR:=$(shell mktemp -d -t conformanceXXXXXX)
 
 all: build

--- a/cluster/images/conformance/Makefile
+++ b/cluster/images/conformance/Makefile
@@ -31,7 +31,7 @@ E2E_GO_RUNNER_BIN?=$(shell test -f $(LOCAL_OUTPUT_PATH)/go-runner && echo $(LOCA
 
 CLUSTER_DIR?=$(shell pwd)/../../../cluster/
 
-BASEIMAGE=gcr.io/distroless/base:nonroot
+BASEIMAGE=gcr.io/distroless/base:latest
 TEMP_DIR:=$(shell mktemp -d -t conformanceXXXXXX)
 
 all: build

--- a/cluster/images/conformance/Makefile
+++ b/cluster/images/conformance/Makefile
@@ -31,8 +31,15 @@ E2E_GO_RUNNER_BIN?=$(shell test -f $(LOCAL_OUTPUT_PATH)/go-runner && echo $(LOCA
 
 CLUSTER_DIR?=$(shell pwd)/../../../cluster/
 
-BASEIMAGE=gcr.io/distroless/base:latest
-TEMP_DIR:=$(shell mktemp -d -t conformanceXXXXXX)
+ifeq ($(ARCH),amd64)
+    BASEIMAGE?=${KUBE_BASE_IMAGE_REGISTRY}/build-image/debian-base:v2.1.3
+else
+    BASEIMAGE?=${KUBE_BASE_IMAGE_REGISTRY}/build-image/debian-base-${ARCH}:v2.1.3
+endif
+
+RUNNERIMAGE?=gcr.io/distroless/static:latest
+
+TEMP_DIR:=$(shell mktemp -d -t conformance-XXXXXX)
 
 all: build
 
@@ -60,6 +67,7 @@ endif
 		--pull \
 		-t ${REGISTRY}/conformance-${ARCH}:${VERSION} \
 		--build-arg BASEIMAGE=$(BASEIMAGE) \
+		--build-arg RUNNERIMAGE=$(RUNNERIMAGE) \
 		${TEMP_DIR}
 	rm -rf "${TEMP_DIR}"
 

--- a/cluster/images/conformance/Makefile
+++ b/cluster/images/conformance/Makefile
@@ -31,6 +31,9 @@ E2E_GO_RUNNER_BIN?=$(shell test -f $(LOCAL_OUTPUT_PATH)/go-runner && echo $(LOCA
 
 CLUSTER_DIR?=$(shell pwd)/../../../cluster/
 
+# This is defined in root Makefile, but some build contexts do not refer to them
+KUBE_BASE_IMAGE_REGISTRY?=k8s.gcr.io
+
 ifeq ($(ARCH),amd64)
     BASEIMAGE?=${KUBE_BASE_IMAGE_REGISTRY}/build-image/debian-base:v2.1.3
 else

--- a/cluster/images/conformance/Makefile
+++ b/cluster/images/conformance/Makefile
@@ -40,7 +40,7 @@ else
     BASEIMAGE?=${KUBE_BASE_IMAGE_REGISTRY}/build-image/debian-base-${ARCH}:v2.1.3
 endif
 
-RUNNERIMAGE?=gcr.io/distroless/static:latest
+RUNNERIMAGE?=gcr.io/distroless/base:latest
 
 TEMP_DIR:=$(shell mktemp -d -t conformance-XXXXXX)
 

--- a/cluster/images/conformance/go-runner/main.go
+++ b/cluster/images/conformance/go-runner/main.go
@@ -30,7 +30,7 @@ import (
 
 func main() {
 	if strings.Contains(os.Args[0], "run_e2e.sh") || strings.Contains(os.Args[0], "gorunner") {
-		log.Print("warn: calling test with e2e.test is deprecated, please rely on container manifest to invoke executable")
+		log.Print("warn: calling test with e2e.test is deprecated and will be removed in 1.25, please rely on container manifest to invoke executable")
 	}
 	env := envWithDefaults(map[string]string{
 		resultsDirEnvKey: defaultResultsDir,

--- a/cluster/images/conformance/go-runner/main.go
+++ b/cluster/images/conformance/go-runner/main.go
@@ -23,11 +23,15 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"strings"
 
 	"github.com/pkg/errors"
 )
 
 func main() {
+	if strings.Contains(os.Args[0], "run_e2e.sh") || strings.Contains(os.Args[0], "gorunner") {
+		log.Print("warn: calling test with e2e.test is deprecated, please rely on container manifest to invoke executable")
+	}
 	env := envWithDefaults(map[string]string{
 		resultsDirEnvKey: defaultResultsDir,
 		skipEnvKey:       defaultSkip,


### PR DESCRIPTION
Signed-off-by: Wilson Husin <whusin@vmware.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind cleanup

#### What this PR does / why we need it:

In order to avoid noisy / false positive CVE image scanning, Conformance image is now be built based on Distroless.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #96692

#### Special notes for your reviewer:

```
❯ sonobuoy status --show-all
         PLUGIN                 NODE     STATUS   RESULT
            e2e               global   complete   passed
```

This deprecates `/run_e2e.sh` -- while the existing parameters will still be honored, users running the test should not call `/run_e2e.sh` and should instead call `/kubeconformance` (previously named `/gorunner`).

I think I have made potentially controversial decisions and I'd like to point them out for discussion:

1. `/run_e2e.sh` still exists, just that now it force invokes `/kubeconformance`. If you have been using Sonobuoy to run conformance testing per [cncf/k8s-conformance instructions](https://github.com/cncf/k8s-conformance/blob/master/instructions.md), this change should not affect you since [gorunner has been the default executor since Sonobuoy 0.16](https://github.com/vmware-tanzu/sonobuoy/commit/0e16b5ea9e5a048f14398024634033fddaf8b423).
1. the name `gorunner` somewhat collides with [k/release `go-runner`](https://github.com/kubernetes/release/tree/master/images/build/go-runner) which are two different things -- ~do folks have opinions on what the new name of conformance `gorunner`? I'm leaning towards reusing `run_e2e` without `.sh` suffix.~ UPDATE: I have chosen to use `kubeconformance` as the binary name for now.
1. in Dockerfile, I'm pointing to a specific version of `gcr.io/k8s-staging-build-image/debian-base:v2.1.3` because I'm out of clues on how other images are finding the `debian-base`, if at all -- ideally I don't want to add more work for whoever doing bumps on `debian-base` images that they need to bump yet-another-file in this repository.
    - referring to `debian:latest` from DockerHub wouldn't be the best solution either because (I think) this is the last image in k/k which still pulls images from DockerHub.
1. in Dockerfile, I _think_ we should be using `ENTRYPOINT` instead of `CMD`, but the fact that it hasn't been done made me question my own thoughts, would love to hear what others think.

Having said all the above, I think these are current blockers for this PR:

- [x] print deprecation warning for invoking `run_e2e.sh`, ask to use the compiled Go-based runner instead.
- [x] rename `/gorunner` into something else.
- [x] use alias instead of hardcoded `debian-base` reference.


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
[ACTION REQUIRED] Conformance image is now built with Distroless. Users running Conformance testing should rely on container entrypoint instead of manual invocation to `/run_e2e.sh` or `/gorunner`, as they are now deprecated and will be removed in 1.25 release. Invoking `ginkgo` and `e2e.test` are still supported through overriding entrypoint (docker) or defining container `spec.command` (kubernetes)
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

I'm not sure which "roles" and "hats" should be notified but since y'all were involved in the initial discussion 3 months ago, I figured to start with you all 😄  
/cc @justaugustus @BenTheElder 