### PR TITLE
SCTPSupport beta since 1.19; VolumeSubpath GA since 1.10

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -221,7 +221,7 @@ const (
 	RunAsGroup featuregate.Feature = "RunAsGroup"
 
 	// owner: @saad-ali
-	// ga
+	// ga: 	  v1.10
 	//
 	// Allow mounting a subpath of a volume in a container
 	// Do not remove this feature gate even though it's GA
@@ -298,7 +298,7 @@ const (
 
 	// owner: @janosi
 	// alpha: v1.12
-	// beta:  v1.18
+	// beta:  v1.19
 	// GA:    v1.20
 	//
 	// Enables SCTP as new protocol for Service ports, NetworkPolicy, and ContainerPort in Pod/Containers definition


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
I see that VolumeSubpath ga without a version(#60813), and found it is added in v1.10.0 but cherry-picked to 1.7-1.9.
BTW, I checked other feature gate versions.
- refer to #88932 for SCTPSupport promoted to beta since 1.19.

#### Which issue(s) this PR fixes:
None

#### Does this PR introduce a user-facing change?
```release-note
None
```