### PR TITLE
kubeadm: perform a host name check on init / join

### DIFF
--- a/cmd/kubeadm/app/preflight/BUILD
+++ b/cmd/kubeadm/app/preflight/BUILD
@@ -25,6 +25,7 @@ go_library(
         "//cmd/kubeadm/app/util/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/net:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/validation:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/version:go_default_library",
         "//staging/src/k8s.io/component-base/version:go_default_library",
         "//vendor/github.com/PuerkitoBio/purell:go_default_library",

--- a/cmd/kubeadm/app/preflight/checks.go
+++ b/cmd/kubeadm/app/preflight/checks.go
@@ -38,6 +38,7 @@ import (
 	"github.com/pkg/errors"
 	netutil "k8s.io/apimachinery/pkg/util/net"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/validation"
 	versionutil "k8s.io/apimachinery/pkg/util/version"
 	kubeadmversion "k8s.io/component-base/version"
 	"k8s.io/klog/v2"
@@ -402,8 +403,12 @@ func (HostnameCheck) Name() string {
 }
 
 // Check validates if hostname match dns sub domain regex.
+// Check hostname length and format
 func (hc HostnameCheck) Check() (warnings, errorList []error) {
-	klog.V(1).Infoln("checking whether the given node name is reachable using net.LookupHost")
+	klog.V(1).Infoln("checking whether the given node name is valid and reachable using net.LookupHost")
+	for _, msg := range validation.IsQualifiedName(hc.nodeName) {
+		warnings = append(warnings, errors.Errorf("invalid node name format %q: %s", hc.nodeName, msg))
+	}
 
 	addr, err := net.LookupHost(hc.nodeName)
 	if addr == nil {


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
small enhancement 

#### What this PR does / why we need it:
https://github.com/kubernetes/kubernetes/issues/99156#issuecomment-780895957

#### Which issue(s) this PR fixes:
Make it clear during `kubeadm join`. User may encounter an issue like #99156.
Longer node name may lead to label adding problem and so on.

#### Special notes for your reviewer:
The host name will be used as the machine name and will be used as the [DNS suffix](https://daocloud.github.io/dce-check/#/O/O705-hostname_compatibility?id=_1-host-name-does-not-meet-rfc-1123-%e4%b8%bb%e6%9c%ba%e5%90%8d%e4%b8%8d%e7%ac%a6%e5%90%88%e8%a7%84%e8%8c%83), so the host name must meet the hostname specification defined by RFC 1123. Hostname should be less than 63 characters and satisfy regular expression `^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$`

#### Does this PR introduce a user-facing change?
```release-note
kubeadm: during "init" and "join" perform preflight validation on the host / node name and throw warnings if a name is not compliant
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```