### PR TITLE
migrate "client-go retry-watcher watch" to structured logging

### DIFF
--- a/staging/src/k8s.io/client-go/tools/watch/retrywatcher.go
+++ b/staging/src/k8s.io/client-go/tools/watch/retrywatcher.go
@@ -116,24 +116,24 @@ func (rw *RetryWatcher) doReceive() (bool, time.Duration) {
 		return false, 0
 
 	case io.ErrUnexpectedEOF:
-		klog.V(1).Infof("Watch closed with unexpected EOF: %v", err)
+		klog.V(1).InfoS("Watch closed with unexpected EOF", "err", err)
 		return false, 0
 
 	default:
-		msg := "Watch failed: %v"
+		msg := "Watch failed"
 		if net.IsProbableEOF(err) || net.IsTimeout(err) {
-			klog.V(5).Infof(msg, err)
+			klog.V(5).InfoS(msg, "err", err)
 			// Retry
 			return false, 0
 		}
 
-		klog.Errorf(msg, err)
+		klog.ErrorS(err, msg)
 		// Retry
 		return false, 0
 	}
 
 	if watcher == nil {
-		klog.Error("Watch returned nil watcher")
+		klog.ErrorS(nil, "Watch returned nil watcher")
 		// Retry
 		return false, 0
 	}
@@ -144,11 +144,11 @@ func (rw *RetryWatcher) doReceive() (bool, time.Duration) {
 	for {
 		select {
 		case <-rw.stopChan:
-			klog.V(4).Info("Stopping RetryWatcher.")
+			klog.V(4).InfoS("Stopping RetryWatcher.")
 			return true, 0
 		case event, ok := <-ch:
 			if !ok {
-				klog.V(4).Infof("Failed to get event! Re-creating the watcher. Last RV: %s", rw.lastResourceVersion)
+				klog.V(4).InfoS("Failed to get event! Re-creating the watcher.", "resourceVersion", rw.lastResourceVersion)
 				return false, 0
 			}
 


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

```
Watch failed: 
 Get \"https://xxx/api/v1/services?allowWatchBookmarks=1&resourceVersion=x&watch=1\": context canceled
```
change the log here to structured log.

#### Special notes for your reviewer:
part of https://github.com/kubernetes/enhancements/issues/1602 as well
As it is related to log, change the log here to structured log.

#### Does this PR introduce a user-facing change?
```release-note
None
```
