### PR TITLE
Support storage encryption for aggregation server

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/options/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/BUILD
@@ -68,6 +68,7 @@ go_library(
         "//staging/src/k8s.io/apiserver/pkg/server/storage:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/storage/storagebackend:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/storage/storagebackend/factory:go_default_library",
+        "//staging/src/k8s.io/apiserver/pkg/storage/value:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/util/flowcontrol:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/util/webhook:go_default_library",


### PR DESCRIPTION
the [sample apiserver](https://github.com/kubernetes/kubernetes/tree/master/staging/src/k8s.io/sample-apiserver) provides the following flag to encrypt certain resources in a configuration file:

```
 --encryption-provider-config string                       The file containing configuration for encryption providers to be used for storing secrets in etcd
```

but actually setting the flag doesn't make a difference for sample apiserver as far as i tested locally. this pull adds implementation for the flag which will work for all aggregated apiserver like sample apiserver.

```release-note
NONE
```

/cc @lavalamp @deads2k 