### PR TITLE
vendor: upgrading cAdvisor to 0.37.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -53,7 +53,7 @@ require (
 	github.com/gogo/protobuf v1.3.1
 	github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7
 	github.com/golang/mock v1.3.1
-	github.com/google/cadvisor v0.37.4
+	github.com/google/cadvisor v0.37.5
 	github.com/google/go-cmp v0.4.0
 	github.com/google/gofuzz v1.1.0
 	github.com/google/uuid v1.1.1
@@ -274,7 +274,7 @@ replace (
 	github.com/golangplus/fmt => github.com/golangplus/fmt v0.0.0-20150411045040-2a5d6d7d2995
 	github.com/golangplus/testing => github.com/golangplus/testing v0.0.0-20180327235837-af21d9c3145e
 	github.com/google/btree => github.com/google/btree v1.0.0
-	github.com/google/cadvisor => github.com/google/cadvisor v0.37.4
+	github.com/google/cadvisor => github.com/google/cadvisor v0.37.5
 	github.com/google/go-cmp => github.com/google/go-cmp v0.4.0
 	github.com/google/gofuzz => github.com/google/gofuzz v1.1.0
 	github.com/google/martian => github.com/google/martian v2.1.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -223,8 +223,8 @@ github.com/golangplus/testing v0.0.0-20180327235837-af21d9c3145e h1:KhcknUwkWHKZ
 github.com/golangplus/testing v0.0.0-20180327235837-af21d9c3145e/go.mod h1:0AA//k/eakGydO4jKRoRL2j92ZKSzTgj9tclaCrvXHk=
 github.com/google/btree v1.0.0 h1:0udJVsspx3VBr5FwtLhQQtuAsVc79tTq0ocGIPAU6qo=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
-github.com/google/cadvisor v0.37.4 h1:xCkylGJJvSini5nSSXrUpNFsbuqBRqAOKS4ckS4uiZw=
-github.com/google/cadvisor v0.37.4/go.mod h1:BalYQhwl2UV8lpB3oFssiaW8Uj6sqfFDxw5nEs9sBgU=
+github.com/google/cadvisor v0.37.5 h1:7JxmD4TqlGk/B+bsabeBNL3YS+ppVjx74EUnautkVfk=
+github.com/google/cadvisor v0.37.5/go.mod h1:BalYQhwl2UV8lpB3oFssiaW8Uj6sqfFDxw5nEs9sBgU=
 github.com/google/go-cmp v0.4.0 h1:xsAVV57WRhGj6kEIi8ReJzQlHHqcBYCElAvkovg3B/4=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/gofuzz v1.1.0 h1:Hsa8mG0dQ46ij8Sl2AYJDUv1oA9/d6Vk+3LG99Oe02g=

--- a/vendor/github.com/google/cadvisor/container/libcontainer/BUILD
+++ b/vendor/github.com/google/cadvisor/container/libcontainer/BUILD
@@ -17,7 +17,6 @@ go_library(
         "//vendor/github.com/opencontainers/runc/libcontainer/cgroups/fs:go_default_library",
         "//vendor/github.com/opencontainers/runc/libcontainer/cgroups/fs2:go_default_library",
         "//vendor/github.com/opencontainers/runc/libcontainer/configs:go_default_library",
-        "//vendor/golang.org/x/sys/unix:go_default_library",
         "//vendor/k8s.io/klog/v2:go_default_library",
     ],
 )

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -507,9 +507,9 @@ github.com/golang/protobuf/ptypes/wrappers
 # github.com/google/btree v1.0.0 => github.com/google/btree v1.0.0
 github.com/google/btree
 # github.com/google/btree => github.com/google/btree v1.0.0
-# github.com/google/cadvisor v0.37.4 => github.com/google/cadvisor v0.37.4
+# github.com/google/cadvisor v0.37.5 => github.com/google/cadvisor v0.37.5
 ## explicit
-# github.com/google/cadvisor => github.com/google/cadvisor v0.37.4
+# github.com/google/cadvisor => github.com/google/cadvisor v0.37.5
 github.com/google/cadvisor/accelerators
 github.com/google/cadvisor/cache/memory
 github.com/google/cadvisor/client/v2


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

This PR upgrades cAdvisor 0.37.5 that fixes two bugs:
* https://github.com/google/cadvisor/issues/2798 - broken topology detection for single-NUMA multi-socket system
* https://github.com/google/cadvisor/issues/2792 - mishandling `isolcpus`

#### Which issue(s) this PR fixes:

Fixes #98870

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Fixes a regression in 1.19+ that caused cAdvisor to incorrectly detect single-socket multi-NUMA topology.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
```