### PR TITLE
Remove modprobe configs from configure-helper

### DIFF
--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -3151,7 +3151,6 @@ function main() {
   fi
   reset-motd
   prepare-mounter-rootfs
-  modprobe configs
   echo "Done for the configuration for kubernetes"
 }
 


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
`modprobe configs` was added in https://github.com/kubernetes/kubernetes/pull/45136/ because the COS GPU installer used to (in 2018) require IKCONFIG since it read /proc/config.gz (https://github.com/GoogleCloudPlatform/cos-gpu-installer/blob/396b70cf721c8e7ed92663f6810ce406ac52e8c2/entrypoint.sh#L212). 

However, in https://github.com/GoogleCloudPlatform/cos-gpu-installer/pull/60, the logic of reading /proc/config.gz was removed. So `modprobe configs` is not needed anymore. 

Moreover, `modprobe configs`  is causing failures on Ubuntu nodes, so removing it from configure-helper.sh 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
