### PR TITLE
allow explicit disabling of metrics as an escape hatch.

### DIFF
--- a/staging/src/k8s.io/component-base/metrics/collector.go
+++ b/staging/src/k8s.io/component-base/metrics/collector.go
@@ -49,10 +49,10 @@ type StableCollector interface {
 // is a convenient assistant for custom collectors.
 // It is recommend that inherit BaseStableCollector when implementing custom collectors.
 type BaseStableCollector struct {
-	descriptors map[string]*Desc // stores all descriptors by pair<fqName, Desc>, these are collected from DescribeWithStability().
-	registrable map[string]*Desc // stores registrable descriptors by pair<fqName, Desc>, is a subset of descriptors.
-	hidden      map[string]*Desc // stores hidden descriptors by pair<fqName, Desc>, is a subset of descriptors.
-	self        StableCollector
+	descriptors  map[string]*Desc // stores all descriptors by pair<fqName, Desc>, these are collected from DescribeWithStability().
+	registerable map[string]*Desc // stores registerable descriptors by pair<fqName, Desc>, is a subset of descriptors.
+	hidden       map[string]*Desc // stores hidden descriptors by pair<fqName, Desc>, is a subset of descriptors.
+	self         StableCollector
 }
 
 // DescribeWithStability sends all descriptors to the provided channel.
@@ -64,7 +64,7 @@ func (bsc *BaseStableCollector) DescribeWithStability(ch chan<- *Desc) {
 // Describe sends all descriptors to the provided channel.
 // It intend to be called by prometheus registry.
 func (bsc *BaseStableCollector) Describe(ch chan<- *prometheus.Desc) {
-	for _, d := range bsc.registrable {
+	for _, d := range bsc.registerable {
 		ch <- d.toPrometheusDesc()
 	}
 }
@@ -128,11 +128,11 @@ func (bsc *BaseStableCollector) init(self StableCollector) {
 }
 
 func (bsc *BaseStableCollector) trackRegistrableDescriptor(d *Desc) {
-	if bsc.registrable == nil {
-		bsc.registrable = make(map[string]*Desc)
+	if bsc.registerable == nil {
+		bsc.registerable = make(map[string]*Desc)
 	}
 
-	bsc.registrable[d.fqName] = d
+	bsc.registerable[d.fqName] = d
 }
 
 func (bsc *BaseStableCollector) trackHiddenDescriptor(d *Desc) {
@@ -158,7 +158,7 @@ func (bsc *BaseStableCollector) Create(version *semver.Version, self StableColle
 		}
 	}
 
-	if len(bsc.registrable) > 0 {
+	if len(bsc.registerable) > 0 {
 		return true
 	}
 
@@ -173,7 +173,7 @@ func (bsc *BaseStableCollector) ClearState() {
 	}
 
 	bsc.descriptors = nil
-	bsc.registrable = nil
+	bsc.registerable = nil
 	bsc.hidden = nil
 	bsc.self = nil
 }

--- a/staging/src/k8s.io/component-base/metrics/options.go
+++ b/staging/src/k8s.io/component-base/metrics/options.go
@@ -28,6 +28,7 @@ import (
 // Options has all parameters needed for exposing metrics from components
 type Options struct {
 	ShowHiddenMetricsForVersion string
+	DisabledMetrics             []string
 }
 
 // NewOptions returns default metrics options
@@ -56,12 +57,21 @@ func (o *Options) AddFlags(fs *pflag.FlagSet) {
 			"The format is <major>.<minor>, e.g.: '1.16'. "+
 			"The purpose of this format is make sure you have the opportunity to notice if the next release hides additional metrics, "+
 			"rather than being surprised when they are permanently removed in the release after that.")
+	fs.StringSliceVar(&o.DisabledMetrics,
+		"disabled-metrics",
+		o.DisabledMetrics,
+		"This flag provides an escape hatch for misbehaving metrics. "+
+			"You must provide the fully qualified metric name in order to disable it.")
 }
 
 // Apply applies parameters into global configuration of metrics.
 func (o *Options) Apply() {
 	if o != nil && len(o.ShowHiddenMetricsForVersion) > 0 {
 		SetShowHidden()
+		// set disabled metrics
+		for _, metricName := range o.DisabledMetrics {
+			SetDisabledMetric(metricName)
+		}
 	}
 }
 

--- a/staging/src/k8s.io/component-base/metrics/options.go
+++ b/staging/src/k8s.io/component-base/metrics/options.go
@@ -67,7 +67,10 @@ func (o *Options) AddFlags(fs *pflag.FlagSet) {
 
 // Apply applies parameters into global configuration of metrics.
 func (o *Options) Apply() {
-	if o != nil && len(o.ShowHiddenMetricsForVersion) > 0 {
+	if o == nil {
+		return
+	}
+	if len(o.ShowHiddenMetricsForVersion) > 0 {
 		SetShowHidden()
 	}
 	// set disabled metrics

--- a/staging/src/k8s.io/component-base/metrics/options.go
+++ b/staging/src/k8s.io/component-base/metrics/options.go
@@ -61,17 +61,18 @@ func (o *Options) AddFlags(fs *pflag.FlagSet) {
 		"disabled-metrics",
 		o.DisabledMetrics,
 		"This flag provides an escape hatch for misbehaving metrics. "+
-			"You must provide the fully qualified metric name in order to disable it.")
+			"You must provide the fully qualified metric name in order to disable it. "+
+			"Disclaimer: disabling metrics is higher in precedence than showing hidden metrics.")
 }
 
 // Apply applies parameters into global configuration of metrics.
 func (o *Options) Apply() {
 	if o != nil && len(o.ShowHiddenMetricsForVersion) > 0 {
 		SetShowHidden()
-		// set disabled metrics
-		for _, metricName := range o.DisabledMetrics {
-			SetDisabledMetric(metricName)
-		}
+	}
+	// set disabled metrics
+	for _, metricName := range o.DisabledMetrics {
+		SetDisabledMetric(metricName)
 	}
 }
 

--- a/staging/src/k8s.io/component-base/metrics/registry.go
+++ b/staging/src/k8s.io/component-base/metrics/registry.go
@@ -30,10 +30,12 @@ import (
 )
 
 var (
-	showHiddenOnce sync.Once
-	showHidden     atomic.Value
-	registries     []*kubeRegistry // stores all registries created by NewKubeRegistry()
-	registriesLock sync.RWMutex
+	showHiddenOnce      sync.Once
+	disabledMetricsLock sync.RWMutex
+	showHidden          atomic.Value
+	registries          []*kubeRegistry // stores all registries created by NewKubeRegistry()
+	registriesLock      sync.RWMutex
+	disabledMetrics     = map[string]struct{}{}
 )
 
 // shouldHide be used to check if a specific metric with deprecated version should be hidden
@@ -59,6 +61,12 @@ func ValidateShowHiddenMetricsVersion(v string) []error {
 	}
 
 	return nil
+}
+
+func SetDisabledMetric(name string) {
+	disabledMetricsLock.Lock()
+	defer disabledMetricsLock.Unlock()
+	disabledMetrics[name] = struct{}{}
 }
 
 // SetShowHidden will enable showing hidden metrics. This will no-opt

--- a/staging/src/k8s.io/component-base/metrics/registry_test.go
+++ b/staging/src/k8s.io/component-base/metrics/registry_test.go
@@ -515,3 +515,39 @@ func TestRegistryReset(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestDisabledMetrics(t *testing.T) {
+	SetDisabledMetric("should_be_disabled")
+	currentVersion := apimachineryversion.Info{
+		Major:      "1",
+		Minor:      "17",
+		GitVersion: "v1.17.1-alpha-1.12345",
+	}
+	registry := newKubeRegistry(currentVersion)
+	disabledMetric := NewCounterVec(&CounterOpts{
+		Name: "should_be_disabled",
+		Help: "this metric should be disabled",
+	}, []string{"label"})
+	// gauges cannot be reset
+	enabledMetric := NewGauge(&GaugeOpts{
+		Name: "should_be_enabled",
+		Help: "this metric should not be disabled",
+	})
+
+	registry.MustRegister(disabledMetric)
+	registry.MustRegister(enabledMetric)
+	disabledMetric.WithLabelValues("one").Inc()
+	disabledMetric.WithLabelValues("two").Inc()
+	disabledMetric.WithLabelValues("two").Inc()
+	enabledMetric.Inc()
+
+	enabledMetricOutput := `
+        # HELP should_be_enabled [ALPHA] this metric should not be disabled
+        # TYPE should_be_enabled gauge
+        should_be_enabled 1
+`
+
+	if err := testutil.GatherAndCompare(registry, strings.NewReader(enabledMetricOutput), "should_be_disabled", "should_be_enabled"); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/staging/src/k8s.io/component-base/metrics/registry_test.go
+++ b/staging/src/k8s.io/component-base/metrics/registry_test.go
@@ -517,7 +517,9 @@ func TestRegistryReset(t *testing.T) {
 }
 
 func TestDisabledMetrics(t *testing.T) {
-	SetDisabledMetric("should_be_disabled")
+	o := NewOptions()
+	o.DisabledMetrics = []string{"should_be_disabled"}
+	o.Apply()
 	currentVersion := apimachineryversion.Info{
 		Major:      "1",
 		Minor:      "17",


### PR DESCRIPTION
Change-Id: I92895987d140e0e94eea3e4dea872c298d82babb

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This feature allows components to explicitly disable metrics via CLI flags. This mechanism is specifically a reliability feature, in that it provides an escape hatch for misbehaving metrics.

#### Which issue(s) this PR fixes:

Fixes #98381

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Metrics can now be disabled explicitly via a command line flag (i.e. '--disabled-metrics=bad_metric1,bad_metric2') 
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:

-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-instrumentation/1209-metrics-stability
- [Usage]: `--disabled-metrics=bad_metric1,bad_metric2`
```
