### PR TITLE
Get filesystem stats for files on Windows

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -664,8 +664,8 @@ func NewMainKubelet(kubeCfg *kubeletconfiginternal.KubeletConfiguration,
 	klet.runtimeCache = runtimeCache
 
 	// common provider to get host file system usage associated with a pod managed by kubelet
-	hostStatsProvider := stats.NewHostStatsProvider(kubecontainer.RealOS{}, func(podUID types.UID) string {
-		return getEtcHostsPath(klet.getPodDir(podUID))
+	hostStatsProvider := stats.NewHostStatsProvider(kubecontainer.RealOS{}, func(podUID types.UID) (string, bool) {
+		return getEtcHostsPath(klet.getPodDir(podUID)), klet.containerRuntime.SupportsSingleFileMapping()
 	})
 	if kubeDeps.useLegacyCadvisorStats {
 		klet.StatsProvider = stats.NewCadvisorStatsProvider(

--- a/pkg/kubelet/stats/host_stats_provider_test.go
+++ b/pkg/kubelet/stats/host_stats_provider_test.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package stats
+
+import (
+	"reflect"
+	"testing"
+
+	cadvisorapiv2 "github.com/google/cadvisor/info/v2"
+
+	kubecontainertest "k8s.io/kubernetes/pkg/kubelet/container/testing"
+
+	"k8s.io/apimachinery/pkg/types"
+	statsapi "k8s.io/kubelet/pkg/apis/stats/v1alpha1"
+)
+
+func Test_hostStatsProvider_getPodEtcHostsStats(t *testing.T) {
+	tests := []struct {
+		name                string
+		podEtcHostsPathFunc PodEtcHostsPathFunc
+		podUID              types.UID
+		rootFsInfo          *cadvisorapiv2.FsInfo
+		want                *statsapi.FsStats
+		wantErr             bool
+	}{
+		{
+			name: "Should return nil for runtimes that do not support etc host file",
+			podEtcHostsPathFunc: func(podUID types.UID) (string, bool) {
+				return "", false
+			},
+			podUID:     "fake0001",
+			rootFsInfo: nil,
+			want:       nil,
+			wantErr:    false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := hostStatsProvider{
+				osInterface:         &kubecontainertest.FakeOS{},
+				podEtcHostsPathFunc: tt.podEtcHostsPathFunc,
+			}
+			got, err := h.getPodEtcHostsStats(tt.podUID, tt.rootFsInfo)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("getPodEtcHostsStats() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("getPodEtcHostsStats() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/volume/util/fs/fs_windows.go
+++ b/pkg/volume/util/fs/fs_windows.go
@@ -21,6 +21,7 @@ package fs
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"syscall"
 	"unsafe"
 
@@ -40,6 +41,11 @@ func Info(path string) (int64, int64, int64, int64, int64, int64, error) {
 	var freeBytesAvailable, totalNumberOfBytes, totalNumberOfFreeBytes int64
 	var err error
 
+	// The equivalent linux call supports calls against files but the syscall for windows
+	// fails for files with error code: The directory name is invalid. (#99173)
+	// https://docs.microsoft.com/en-us/windows/win32/debug/system-error-codes--0-499-
+	// By always ensuring the directory path we meet all uses cases of this function
+	path = filepath.Dir(path)
 	ret, _, err := syscall.Syscall6(
 		procGetDiskFreeSpaceEx.Addr(),
 		4,

--- a/pkg/volume/util/fs/fs_windows_test.go
+++ b/pkg/volume/util/fs/fs_windows_test.go
@@ -21,8 +21,9 @@ import (
 	"io/ioutil"
 	"os"
 
-	"k8s.io/apimachinery/pkg/api/resource"
 	"testing"
+
+	"k8s.io/apimachinery/pkg/api/resource"
 )
 
 func TestDiskUsage(t *testing.T) {
@@ -54,8 +55,8 @@ func TestDiskUsage(t *testing.T) {
 	if err != nil {
 		t.Fatalf("TestDiskUsage failed: %s", err.Error())
 	}
-	file1 := dir1 + "/" + "test"
-	file2 := dir2 + "/" + "test"
+	file1 := tmpfile1.Name()
+	file2 := tmpfile2.Name()
 	fileInfo1, err := os.Lstat(file1)
 	if err != nil {
 		t.Fatalf("TestDiskUsage failed: %s", err.Error())
@@ -74,8 +75,55 @@ func TestDiskUsage(t *testing.T) {
 	if err != nil {
 		t.Fatalf("TestDiskUsage failed: %s", err.Error())
 	}
-	if size.Cmp(used) != 1 {
-		t.Fatalf("TestDiskUsage failed: %s", err.Error())
+	if size.Cmp(used) != 0 {
+		t.Fatalf("TestDiskUsage failed: expected 0, got %d", size.Cmp(used))
+	}
+}
+
+func TestInfo(t *testing.T) {
+	dir1, err := ioutil.TempDir("", "dir_1")
+	if err != nil {
+		t.Fatalf("TestInfo failed: %s", err.Error())
+	}
+	defer os.RemoveAll(dir1)
+
+	// should pass for folder path
+	availablebytes, capacity, usage, inodesTotal, inodesFree, inodeUsage, err := Info(dir1)
+	if err != nil {
+		t.Errorf("Info() should not error = %v", err)
+		return
+	}
+	validateInfo(t, availablebytes, capacity, usage, inodesTotal, inodeUsage, inodesFree)
+
+	// should pass for file
+	tmpfile1, err := ioutil.TempFile(dir1, "test")
+	if _, err = tmpfile1.WriteString("just for testing"); err != nil {
+		t.Fatalf("TestInfo failed: %s", err.Error())
+	}
+	availablebytes, capacity, usage, inodesTotal, inodesFree, inodeUsage, err = Info(tmpfile1.Name())
+	validateInfo(t, availablebytes, capacity, usage, inodesTotal, inodeUsage, inodesFree)
+}
+
+func validateInfo(t *testing.T, availablebytes int64, capacity int64, usage int64, inodesTotal int64, inodeUsage int64, inodesFree int64) {
+	// All of these should be greater than zero on a real system
+	if availablebytes <= 0 {
+		t.Errorf("Info() availablebytes should be greater than 0, got %v", availablebytes)
+	}
+	if capacity <= 0 {
+		t.Errorf("Info() capacity should be greater than 0, got %v", capacity)
+	}
+	if usage <= 0 {
+		t.Errorf("Info() got usage should be greater than 0, got %v", usage)
 	}
 
+	// inodes will always be zero for Windows
+	if inodesTotal != 0 {
+		t.Errorf("Info() inodesTotal = %v, want %v", inodeUsage, 0)
+	}
+	if inodesFree != 0 {
+		t.Errorf("Info() inodesFree = %v, want %v", inodesFree, 0)
+	}
+	if inodeUsage != 0 {
+		t.Errorf("Info() inodeUsage = %v, want %v", inodeUsage, 0)
+	}
 }

--- a/test/e2e/windows/kubelet_stats.go
+++ b/test/e2e/windows/kubelet_stats.go
@@ -79,6 +79,11 @@ var _ = SIGDescribe("[Feature:Windows] Kubelet-Stats [Serial]", func() {
 
 						framework.ExpectEqual(*podStats.CPU.UsageCoreNanoSeconds > 0, true, "Pod stats should not report 0 cpu usage")
 						framework.ExpectEqual(*podStats.Memory.WorkingSetBytes > 0, true, "Pod stats should not report 0 bytes for memory working set ")
+
+						for _, containerStats := range podStats.Containers {
+							framework.ExpectEqual(containerStats.Logs != nil, true, "Pod stats should have container log stats")
+							framework.ExpectEqual(*containerStats.Logs.AvailableBytes > 0, true, "container log stats should not report 0 bytes for AvailableBytes")
+						}
 					}
 					framework.ExpectEqual(statsChecked, 10, "Should find stats for 10 pods in kubelet stats")
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:

/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Pod log stats for Windows doesn't work.  With this update the stats for log files are included in summary:

http://localhost:8001/api/v1/nodes/2733k8s01000000/proxy/stats/summary (output truncated, two containers 1 with log output, 1 without)
```
 "pods": [
  {
   "podRef": {
    "name": "iis-1809-668c5b9c87-fqqml",
    "namespace": "default",
    "uid": "84ff19a1-f0bb-4ff9-bc0b-b291d0f86818"
   },
   "startTime": "2021-02-19T00:59:15Z",
   "containers": [
    {
     "name": "iis",
     "startTime": "2021-02-19T00:59:16Z",
     "cpu": {
      "time": "2021-02-19T01:14:27Z",
      "usageNanoCores": 4680917,
      "usageCoreNanoSeconds": 16203125000
     },
     "memory": {
      "time": "2021-02-19T01:14:27Z",
      "workingSetBytes": 59080704
     },
     "rootfs": {
      "time": "2021-02-19T01:14:27Z",
      "availableBytes": 7994449920,
      "capacityBytes": 31687962624,
      "usedBytes": 71303168,
      "inodesUsed": 0
     },
     "logs": {
      "time": "2021-02-19T01:14:27Z",
      "availableBytes": 7994449920,
      "capacityBytes": 31687962624,
      "usedBytes": 0,
      "inodesUsed": 0
     }
    }
   ],
  },
  {
   "podRef": {
    "name": "logger-f76f4d988-k5n9m",
    "namespace": "default",
    "uid": "6a3c95d2-27cf-4439-927e-724f069aee89"
   },
   "startTime": "2021-02-19T01:12:34Z",
   "containers": [
    {
     "name": "testwin",
     "startTime": "2021-02-19T01:13:06Z",
     "cpu": {
      "time": "2021-02-19T01:14:27Z",
      "usageNanoCores": 190263476,
      "usageCoreNanoSeconds": 19796875000
     },
     "memory": {
      "time": "2021-02-19T01:14:27Z",
      "workingSetBytes": 66772992
     },
     "rootfs": {
      "time": "2021-02-19T01:14:27Z",
      "availableBytes": 7994449920,
      "capacityBytes": 31687962624,
      "usedBytes": 37748736,
      "inodesUsed": 0
     },
     "logs": {
      "time": "2021-02-19T01:14:27Z",
      "availableBytes": 7994449920,
      "capacityBytes": 31687962624,
      "usedBytes": 172746066,
      "inodesUsed": 0
     }
    }
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #99173

#### Special notes for your reviewer:


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Pod Log stats for windows now reports metrics
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
