### PR TITLE
Move CSIDrivers cache sync to goroutine

### DIFF
--- a/pkg/volume/csi/csi_mounter.go
+++ b/pkg/volume/csi/csi_mounter.go
@@ -285,7 +285,13 @@ func (c *csiMountMgr) SetUpAt(dir string, mounterArgs volume.MounterArgs) error 
 func (c *csiMountMgr) podAttributes() (map[string]string, error) {
 	kletHost, ok := c.plugin.host.(volume.KubeletVolumeHost)
 	if ok {
-		kletHost.WaitForCacheSync()
+		synced, err := kletHost.CSIDriversSynced()
+		if err != nil {
+			return nil, err
+		}
+		if !synced {
+			return nil, errors.New("CSIDrivers has not been synced yet")
+		}
 	}
 
 	if c.plugin.csiDriverLister == nil {

--- a/pkg/volume/plugins.go
+++ b/pkg/volume/plugins.go
@@ -37,7 +37,6 @@ import (
 	"k8s.io/client-go/informers"
 	clientset "k8s.io/client-go/kubernetes"
 	storagelistersv1 "k8s.io/client-go/listers/storage/v1"
-	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	cloudprovider "k8s.io/cloud-provider"
 	proxyutil "k8s.io/kubernetes/pkg/proxy/util"
@@ -340,9 +339,9 @@ type KubeletVolumeHost interface {
 	// CSIDriverLister returns the informer lister for the CSIDriver API Object
 	CSIDriverLister() storagelistersv1.CSIDriverLister
 	// CSIDriverSynced returns the informer synced for the CSIDriver API Object
-	CSIDriversSynced() cache.InformerSynced
+	CSIDriversSynced() (bool, error)
 	// WaitForCacheSync is a helper function that waits for cache sync for CSIDriverLister
-	WaitForCacheSync() error
+	WaitForCacheSync()
 	// Returns hostutil.HostUtils
 	GetHostUtil() hostutil.HostUtils
 }

--- a/pkg/volume/testing/volume_host.go
+++ b/pkg/volume/testing/volume_host.go
@@ -33,7 +33,6 @@ import (
 	"k8s.io/client-go/informers"
 	clientset "k8s.io/client-go/kubernetes"
 	storagelistersv1 "k8s.io/client-go/listers/storage/v1"
-	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	cloudprovider "k8s.io/cloud-provider"
 	proxyutil "k8s.io/kubernetes/pkg/proxy/util"
@@ -366,13 +365,13 @@ func (f *fakeKubeletVolumeHost) CSIDriverLister() storagelistersv1.CSIDriverList
 	return f.csiDriverLister
 }
 
-func (f *fakeKubeletVolumeHost) CSIDriversSynced() cache.InformerSynced {
+func (f *fakeKubeletVolumeHost) CSIDriversSynced() (bool, error) {
 	// not needed for testing
-	return nil
+	return true, nil
 }
 
-func (f *fakeKubeletVolumeHost) WaitForCacheSync() error {
-	return nil
+func (f *fakeKubeletVolumeHost) WaitForCacheSync() {
+	return
 }
 
 func (f *fakeKubeletVolumeHost) GetHostUtil() hostutil.HostUtils {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
If there are some pods that uses csi volume on the master node, when kube-apiserver restarts during the kubelet starting, the kubelet volumeManager may deadlock, and the kube-apiserver cannot start normally

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #99188

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
move CSIDrivers cache sync to goroutine
```
#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```