### PR TITLE
attacher: organize unit tests into subtests

### DIFF
--- a/pkg/volume/awsebs/attacher_test.go
+++ b/pkg/volume/awsebs/attacher_test.go
@@ -62,7 +62,7 @@ func TestGetVolumeName_PersistentVolume(t *testing.T) {
 
 // One testcase for TestAttachDetach table test below
 type testcase struct {
-	name aws.KubernetesVolumeID
+	name string
 	// For fake AWS:
 	attach attachCall
 	detach detachCall
@@ -128,15 +128,16 @@ func TestAttachDetach(t *testing.T) {
 	}
 
 	for _, testcase := range tests {
-		testcase.t = t
-		device, err := testcase.test(&testcase)
-		if err != testcase.expectedError {
-			t.Errorf("%s failed: expected err=%q, got %q", testcase.name, testcase.expectedError.Error(), err.Error())
-		}
-		if device != testcase.expectedDevice {
-			t.Errorf("%s failed: expected device=%q, got %q", testcase.name, testcase.expectedDevice, device)
-		}
-		t.Logf("Test %q succeeded", testcase.name)
+		t.Run(testcase.name, func(t *testing.T) {
+			testcase.t = t
+			device, err := testcase.test(&testcase)
+			if err != testcase.expectedError {
+				t.Errorf("failed: expected err=%q, got %q", testcase.expectedError.Error(), err.Error())
+			}
+			if device != testcase.expectedDevice {
+				t.Errorf("failed: expected device=%q, got %q", testcase.expectedDevice, device)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Organize unit tests in subtests.
```
#### before
=== RUN   TestAttachDetach
    attacher_test.go:139: Test "Attach_Positive" succeeded
E0219 15:45:08.058933    7036 attacher.go:86] Error attaching volume "disk" to node "instance": Fake attach error
    attacher_test.go:139: Test "Attach_Negative" succeeded
    attacher_test.go:139: Test "Detach_Positive" succeeded
E0219 15:45:08.080894    7036 attacher.go:282] Error detaching volumeID "disk": Fake detach error
    attacher_test.go:139: Test "Detach_Negative" succeeded
--- PASS: TestAttachDetach (0.02s)
PASS
```
```
#### after
=== RUN   TestAttachDetach
=== RUN   TestAttachDetach/Attach_Positive
=== RUN   TestAttachDetach/Attach_Negative
E0219 16:06:46.298434   12268 attacher.go:86] Error attaching volume "disk" to node "instance": Fake attach error
=== RUN   TestAttachDetach/Detach_Positive
=== RUN   TestAttachDetach/Detach_Negative
E0219 16:06:46.311119   12268 attacher.go:282] Error detaching volumeID "disk": Fake detach error
--- PASS: TestAttachDetach (0.01s)
    --- PASS: TestAttachDetach/Attach_Positive (0.00s)
    --- PASS: TestAttachDetach/Attach_Negative (0.01s)
    --- PASS: TestAttachDetach/Detach_Positive (0.00s)
    --- PASS: TestAttachDetach/Detach_Negative (0.00s)
PASS
ok  	k8s.io/kubernetes/pkg/volume/awsebs	0.109s
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
