### PR TITLE
Automated cherry pick of #97950: remove executable permission bits

### DIFF
--- a/pkg/kubelet/nodeshutdown/systemd/inhibit_linux.go
+++ b/pkg/kubelet/nodeshutdown/systemd/inhibit_linux.go
@@ -178,7 +178,7 @@ InhibitDelayMaxSec=%.0f
 `, inhibitDelayMax.Seconds())
 
 	logindOverridePath := filepath.Join(logindConfigDirectory, kubeletLogindConf)
-	if err := ioutil.WriteFile(logindOverridePath, []byte(inhibitOverride), 0755); err != nil {
+	if err := ioutil.WriteFile(logindOverridePath, []byte(inhibitOverride), 0644); err != nil {
 		return fmt.Errorf("failed writing logind shutdown inhibit override file %v: %v", logindOverridePath, err)
 	}
 


### PR DESCRIPTION
Cherry pick of #97950 on release-1.20.

#97950: remove executable permission bits

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.