### PR TITLE
Automated cherry pick of #98005: Sync node status during kubelet node shutdown

### DIFF
--- a/pkg/kubelet/nodeshutdown/BUILD
+++ b/pkg/kubelet/nodeshutdown/BUILD
@@ -11,10 +11,12 @@ go_library(
     deps = select({
         "@io_bazel_rules_go//go/platform:aix": [
             "//pkg/kubelet/eviction:go_default_library",
+            "//pkg/kubelet/lifecycle:go_default_library",
         ],
         "@io_bazel_rules_go//go/platform:android": [
             "//pkg/features:go_default_library",
             "//pkg/kubelet/eviction:go_default_library",
+            "//pkg/kubelet/lifecycle:go_default_library",
             "//pkg/kubelet/nodeshutdown/systemd:go_default_library",
             "//pkg/kubelet/types:go_default_library",
             "//pkg/kubelet/util/format:go_default_library",
@@ -26,25 +28,32 @@ go_library(
         ],
         "@io_bazel_rules_go//go/platform:darwin": [
             "//pkg/kubelet/eviction:go_default_library",
+            "//pkg/kubelet/lifecycle:go_default_library",
         ],
         "@io_bazel_rules_go//go/platform:dragonfly": [
             "//pkg/kubelet/eviction:go_default_library",
+            "//pkg/kubelet/lifecycle:go_default_library",
         ],
         "@io_bazel_rules_go//go/platform:freebsd": [
             "//pkg/kubelet/eviction:go_default_library",
+            "//pkg/kubelet/lifecycle:go_default_library",
         ],
         "@io_bazel_rules_go//go/platform:illumos": [
             "//pkg/kubelet/eviction:go_default_library",
+            "//pkg/kubelet/lifecycle:go_default_library",
         ],
         "@io_bazel_rules_go//go/platform:ios": [
             "//pkg/kubelet/eviction:go_default_library",
+            "//pkg/kubelet/lifecycle:go_default_library",
         ],
         "@io_bazel_rules_go//go/platform:js": [
             "//pkg/kubelet/eviction:go_default_library",
+            "//pkg/kubelet/lifecycle:go_default_library",
         ],
         "@io_bazel_rules_go//go/platform:linux": [
             "//pkg/features:go_default_library",
             "//pkg/kubelet/eviction:go_default_library",
+            "//pkg/kubelet/lifecycle:go_default_library",
             "//pkg/kubelet/nodeshutdown/systemd:go_default_library",
             "//pkg/kubelet/types:go_default_library",
             "//pkg/kubelet/util/format:go_default_library",
@@ -56,21 +65,27 @@ go_library(
         ],
         "@io_bazel_rules_go//go/platform:nacl": [
             "//pkg/kubelet/eviction:go_default_library",
+            "//pkg/kubelet/lifecycle:go_default_library",
         ],
         "@io_bazel_rules_go//go/platform:netbsd": [
             "//pkg/kubelet/eviction:go_default_library",
+            "//pkg/kubelet/lifecycle:go_default_library",
         ],
         "@io_bazel_rules_go//go/platform:openbsd": [
             "//pkg/kubelet/eviction:go_default_library",
+            "//pkg/kubelet/lifecycle:go_default_library",
         ],
         "@io_bazel_rules_go//go/platform:plan9": [
             "//pkg/kubelet/eviction:go_default_library",
+            "//pkg/kubelet/lifecycle:go_default_library",
         ],
         "@io_bazel_rules_go//go/platform:solaris": [
             "//pkg/kubelet/eviction:go_default_library",
+            "//pkg/kubelet/lifecycle:go_default_library",
         ],
         "@io_bazel_rules_go//go/platform:windows": [
             "//pkg/kubelet/eviction:go_default_library",
+            "//pkg/kubelet/lifecycle:go_default_library",
         ],
         "//conditions:default": [],
     }),

--- a/pkg/kubelet/nodeshutdown/nodeshutdown_manager_others.go
+++ b/pkg/kubelet/nodeshutdown/nodeshutdown_manager_others.go
@@ -22,14 +22,21 @@ import (
 	"time"
 
 	"k8s.io/kubernetes/pkg/kubelet/eviction"
+	"k8s.io/kubernetes/pkg/kubelet/lifecycle"
 )
 
 // Manager is a fake node shutdown manager for non linux platforms.
 type Manager struct{}
 
 // NewManager returns a fake node shutdown manager for non linux platforms.
-func NewManager(getPodsFunc eviction.ActivePodsFunc, killPodFunc eviction.KillPodFunc, shutdownGracePeriodRequested, shutdownGracePeriodCriticalPods time.Duration) *Manager {
-	return &Manager{}
+func NewManager(getPodsFunc eviction.ActivePodsFunc, killPodFunc eviction.KillPodFunc, syncNodeStatus func(), shutdownGracePeriodRequested, shutdownGracePeriodCriticalPods time.Duration) (*Manager, lifecycle.PodAdmitHandler) {
+	m := &Manager{}
+	return m, m
+}
+
+// Admit returns a fake Pod admission which always returns true
+func (m *Manager) Admit(attrs *lifecycle.PodAdmitAttributes) lifecycle.PodAdmitResult {
+	return lifecycle.PodAdmitResult{Admit: true}
 }
 
 // Start is a no-op always returning nil for non linux platforms.


### PR DESCRIPTION
Cherry pick of #98005 on release-1.20.

#98005: Sync node status during kubelet node shutdown

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.