### PR TITLE
Automated cherry pick of #98088: Fix repeatedly aquire the inhibit lock

### DIFF
--- a/pkg/kubelet/nodeshutdown/nodeshutdown_manager_linux.go
+++ b/pkg/kubelet/nodeshutdown/nodeshutdown_manager_linux.go
@@ -173,6 +173,9 @@ func (m *Manager) aquireInhibitLock() error {
 	if err != nil {
 		return err
 	}
+	if m.inhibitLock != 0 {
+		m.dbusCon.ReleaseInhibitLock(m.inhibitLock)
+	}
 	m.inhibitLock = lock
 	return nil
 }


### PR DESCRIPTION
Cherry pick of #98088 on release-1.20.

#98088: Fix repeatedly aquire the inhibit lock

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.