### PR TITLE
fix json log format panic, change the flag name in flagIsSet

### DIFF
--- a/cmd/kube-apiserver/app/options/globalflags_test.go
+++ b/cmd/kube-apiserver/app/options/globalflags_test.go
@@ -36,6 +36,7 @@ func TestAddCustomGlobalFlags(t *testing.T) {
 	// flag set. This allows us to test against all global flags from
 	// flags.CommandLine.
 	nfs := namedFlagSets.FlagSet("test")
+	nfs.SetNormalizeFunc(cliflag.WordSepNormalizeFunc)
 	globalflag.AddGlobalFlags(nfs, "test-cmd")
 	AddCustomGlobalFlags(nfs)
 
@@ -46,11 +47,11 @@ func TestAddCustomGlobalFlags(t *testing.T) {
 
 	// Get all flags from flags.CommandLine, except flag `test.*`.
 	wantedFlag := []string{"help"}
-	pflag.CommandLine.SetNormalizeFunc(cliflag.WordSepNormalizeFunc)
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
+	normalizeFunc := nfs.GetNormalizeFunc()
 	pflag.VisitAll(func(flag *pflag.Flag) {
 		if !strings.Contains(flag.Name, "test.") {
-			wantedFlag = append(wantedFlag, flag.Name)
+			wantedFlag = append(wantedFlag, string(normalizeFunc(nfs, flag.Name)))
 		}
 	})
 	sort.Strings(wantedFlag)

--- a/pkg/kubelet/apis/config/validation/validation_test.go
+++ b/pkg/kubelet/apis/config/validation/validation_test.go
@@ -22,6 +22,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	componentbaseconfig "k8s.io/component-base/config"
 	kubeletconfig "k8s.io/kubernetes/pkg/kubelet/apis/config"
 )
 
@@ -103,6 +104,50 @@ func TestValidateKubeletConfiguration(t *testing.T) {
 		},
 	}
 	if allErrors := ValidateKubeletConfiguration(successCase2); allErrors != nil {
+		t.Errorf("expect no errors, got %v", allErrors)
+	}
+
+	successCase3 := &kubeletconfig.KubeletConfiguration{
+		CgroupsPerQOS:                   true,
+		EnforceNodeAllocatable:          []string{"pods"},
+		SystemReservedCgroup:            "",
+		KubeReservedCgroup:              "",
+		SystemCgroups:                   "",
+		CgroupRoot:                      "",
+		EventBurst:                      10,
+		EventRecordQPS:                  5,
+		HealthzPort:                     10248,
+		ImageGCHighThresholdPercent:     85,
+		ImageGCLowThresholdPercent:      80,
+		IPTablesDropBit:                 15,
+		IPTablesMasqueradeBit:           14,
+		KubeAPIBurst:                    10,
+		KubeAPIQPS:                      5,
+		MaxOpenFiles:                    1000000,
+		MaxPods:                         110,
+		OOMScoreAdj:                     -999,
+		PodsPerCore:                     100,
+		Port:                            65535,
+		ReadOnlyPort:                    0,
+		RegistryBurst:                   10,
+		RegistryPullQPS:                 5,
+		HairpinMode:                     kubeletconfig.PromiscuousBridge,
+		NodeLeaseDurationSeconds:        1,
+		CPUCFSQuotaPeriod:               metav1.Duration{Duration: 50 * time.Millisecond},
+		ReservedSystemCPUs:              "0-3",
+		TopologyManagerScope:            kubeletconfig.ContainerTopologyManagerScope,
+		TopologyManagerPolicy:           kubeletconfig.NoneTopologyManagerPolicy,
+		ShutdownGracePeriod:             metav1.Duration{Duration: 10 * time.Minute},
+		ShutdownGracePeriodCriticalPods: metav1.Duration{Duration: 0},
+		FeatureGates: map[string]bool{
+			"CustomCPUCFSQuotaPeriod": true,
+			"GracefulNodeShutdown":    true,
+		},
+		Logging: componentbaseconfig.LoggingConfiguration{
+			Format: "json",
+		},
+	}
+	if allErrors := ValidateKubeletConfiguration(successCase3); allErrors != nil {
 		t.Errorf("expect no errors, got %v", allErrors)
 	}
 

--- a/staging/src/k8s.io/component-base/cli/globalflag/globalflags_test.go
+++ b/staging/src/k8s.io/component-base/cli/globalflag/globalflags_test.go
@@ -24,12 +24,14 @@ import (
 	"testing"
 
 	"github.com/spf13/pflag"
+
 	cliflag "k8s.io/component-base/cli/flag"
 )
 
 func TestAddGlobalFlags(t *testing.T) {
 	namedFlagSets := &cliflag.NamedFlagSets{}
 	nfs := namedFlagSets.FlagSet("global")
+	nfs.SetNormalizeFunc(cliflag.WordSepNormalizeFunc)
 	AddGlobalFlags(nfs, "test-cmd")
 
 	actualFlag := []string{}
@@ -40,9 +42,10 @@ func TestAddGlobalFlags(t *testing.T) {
 	// Get all flags from flags.CommandLine, except flag `test.*`.
 	wantedFlag := []string{"help"}
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
+	normalizeFunc := nfs.GetNormalizeFunc()
 	pflag.VisitAll(func(flag *pflag.Flag) {
 		if !strings.Contains(flag.Name, "test.") {
-			wantedFlag = append(wantedFlag, normalize(flag.Name))
+			wantedFlag = append(wantedFlag, string(normalizeFunc(nfs, flag.Name)))
 		}
 	})
 	sort.Strings(wantedFlag)

--- a/staging/src/k8s.io/component-base/logs/options.go
+++ b/staging/src/k8s.io/component-base/logs/options.go
@@ -57,9 +57,9 @@ func NewOptions() *Options {
 func (o *Options) Validate() []error {
 	errs := []error{}
 	if o.LogFormat != defaultLogFormat {
-		allFlags := unsupportedLoggingFlags()
+		allFlags := unsupportedLoggingFlags(hyphensToUnderscores)
 		for _, fname := range allFlags {
-			if flagIsSet(fname) {
+			if flagIsSet(fname, hyphensToUnderscores) {
 				errs = append(errs, fmt.Errorf("non-default logging format doesn't honor flag: %s", fname))
 			}
 		}
@@ -70,10 +70,22 @@ func (o *Options) Validate() []error {
 	return errs
 }
 
-func flagIsSet(name string) bool {
+// hyphensToUnderscores replaces hyphens with underscores
+// we should always use underscores instead of hyphens when validate flags
+func hyphensToUnderscores(s string) string {
+	return strings.Replace(s, "-", "_", -1)
+}
+
+func flagIsSet(name string, normalizeFunc func(name string) string) bool {
 	f := flag.Lookup(name)
 	if f != nil {
 		return f.DefValue != f.Value.String()
+	}
+	if normalizeFunc != nil {
+		f = flag.Lookup(normalizeFunc(name))
+		if f != nil {
+			return f.DefValue != f.Value.String()
+		}
 	}
 	pf := pflag.Lookup(name)
 	if pf != nil {
@@ -84,7 +96,12 @@ func flagIsSet(name string) bool {
 
 // AddFlags add logging-format flag
 func (o *Options) AddFlags(fs *pflag.FlagSet) {
-	unsupportedFlags := fmt.Sprintf("--%s", strings.Join(unsupportedLoggingFlags(), ", --"))
+	normalizeFunc := func(name string) string {
+		f := fs.GetNormalizeFunc()
+		return string(f(fs, name))
+	}
+
+	unsupportedFlags := fmt.Sprintf("--%s", strings.Join(unsupportedLoggingFlags(normalizeFunc), ", --"))
 	formats := fmt.Sprintf(`"%s"`, strings.Join(logRegistry.List(), `", "`))
 	fs.StringVar(&o.LogFormat, logFormatFlagName, defaultLogFormat, fmt.Sprintf("Sets the log format. Permitted formats: %s.\nNon-default formats don't honor these flags: %s.\nNon-default choices are currently alpha and subject to change without warning.", formats, unsupportedFlags))
 
@@ -109,7 +126,7 @@ func (o *Options) Get() (logr.Logger, error) {
 	return logRegistry.Get(o.LogFormat)
 }
 
-func unsupportedLoggingFlags() []string {
+func unsupportedLoggingFlags(normalizeFunc func(name string) string) []string {
 	allFlags := []string{}
 
 	// k8s.io/klog flags
@@ -117,7 +134,11 @@ func unsupportedLoggingFlags() []string {
 	klog.InitFlags(fs)
 	fs.VisitAll(func(flag *flag.Flag) {
 		if _, found := supportedLogsFlags[flag.Name]; !found {
-			allFlags = append(allFlags, strings.Replace(flag.Name, "_", "-", -1))
+			name := flag.Name
+			if normalizeFunc != nil {
+				name = normalizeFunc(name)
+			}
+			allFlags = append(allFlags, name)
 		}
 	})
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
kubelet will panic with --logging-format=json

#### Which issue(s) this PR fixes:

Fixes #99239

#### Special notes for your reviewer:

@serathius
@ehashman
@knight42 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
