### PR TITLE
sched: add a benchmark test for MoveAllToActiveOrBackoffQueue

### DIFF
--- a/pkg/scheduler/internal/queue/BUILD
+++ b/pkg/scheduler/internal/queue/BUILD
@@ -36,6 +36,7 @@ go_test(
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/clock:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//staging/src/k8s.io/component-base/metrics/testutil:go_default_library",
     ],
 )


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/sig scheduling

#### What this PR does / why we need it:

To showcase the performance gain of #98241, per [discussion], it's desired to design a benchmark (unit) test to move Pods between different internal scheduling queues. This PR provides a baseline of benchmark result of exercising `MoveAllToActiveOrBackoffQueue`.

[discussion]: https://github.com/kubernetes/kubernetes/pull/98241#discussion_r573011453

#### Which issue(s) this PR fixes:

Related with #98241.

#### Special notes for your reviewer:

Note that I will rebase and amend this PR a bit in #98241 to show the perf diff.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
