### PR TITLE
[WIP] deflake: try to add node affinity for pod in e2e storage cases

### DIFF
--- a/test/e2e/storage/persistent_volumes-local.go
+++ b/test/e2e/storage/persistent_volumes-local.go
@@ -890,6 +890,10 @@ func makeLocalPVConfig(config *localTestConfig, volume *localTestVolume) e2epv.P
 	if !found {
 		framework.Failf("Node does not have required label %q", nodeKey)
 	}
+	framework.Logf("nodeValue for local PV is %q", nodeValue)
+	if len(nodeValue) == 0 {
+		nodeValue = config.node0.Name
+	}
 
 	pvConfig := e2epv.PersistentVolumeConfig{
 		PVSource: v1.PersistentVolumeSource{


### PR DESCRIPTION
#### What type of PR is this?
/kind flake
/sig storage scheduling

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
Try to make #99252 happen less

#### Special notes for your reviewer:
https://github.com/kubernetes/kubernetes/issues/99252#issuecomment-782589782
There may be a different reason for failures. This PR try to prevent the error below:
- 3594: 2021-02-20T06:49:45.705230352Z stderr F I0220 06:49:45.705094 1 scheduler_binder.go:795] PersistentVolume "local-pvxpz44", Node "kind-worker2" mismatch for Pod "persistent-local-volumes-test-1190/pod-655bc831-6e5c-41be-a935-77728c6697e3": no matching NodeSelectorTerms



#### Does this PR introduce a user-facing change?
```release-note
None
```
