### PR TITLE
Promote Read, Replace and Patch DeploymentScale test to Conformance +3 endpoints 

### DIFF
--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -2018,6 +2018,15 @@
   description: A conformant Kubernetes distribution MUST support DaemonSet RollingUpdates.
   release: v1.10
   file: test/e2e/apps/daemon_set.go
+- testname: Deployment, completes the scaling of a Deployment subresource
+  codename: '[sig-apps] Deployment Deployment should have a working scale subresource
+    [Conformance]'
+  description: Create a Deployment with a single Pod. The Pod MUST be verified that
+    it is running. The Deployment MUST get and verify the scale subresource count.
+    The Deployment MUST update and verify the scale subresource. The Deployment MUST
+    patch and verify a scale subresource.
+  release: v1.21
+  file: test/e2e/apps/deployment.go
 - testname: Deployment Recreate
   codename: '[sig-apps] Deployment RecreateDeployment should delete old pods and create
     new ones [Conformance]'

--- a/test/e2e/apps/deployment.go
+++ b/test/e2e/apps/deployment.go
@@ -133,7 +133,16 @@ var _ = SIGDescribe("Deployment", func() {
 	ginkgo.It("test Deployment ReplicaSet orphaning and adoption regarding controllerRef", func() {
 		testDeploymentsControllerRef(f)
 	})
-	ginkgo.It("Deployment should have a working scale subresource", func() {
+
+	/*
+	   Release: v1.21
+	   Testname: Deployment, completes the scaling of a Deployment subresource
+	   Description: Create a Deployment with a single Pod. The Pod MUST be verified
+	   that it is running. The Deployment MUST get and verify the scale subresource count.
+	   The Deployment MUST update and verify the scale subresource. The Deployment MUST patch and verify
+	   a scale subresource.
+	*/
+	framework.ConformanceIt("Deployment should have a working scale subresource", func() {
 		testDeploymentSubresources(f)
 	})
 	/*


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it:**
This PR adds a test to test the following untested endpoints:
**What this PR does / why we need it:**
This PR adds a test to test the following untested endpoints:

- replaceAppsV1NamespacedDeploymentScale
- readAppsV1NamespacedDeploymentScale
- patchAppsV1NamespacedDeploymentScale

**Which issue(s) this PR fixes:**
Fixes #98936

**Testgrid Link:**
[Testgrid](https://testgrid.k8s.io/sig-release-master-blocking#gce-cos-master-default&width=5&include-filter-by-regex=Deployment%20should%20have%20a%20working%20scale%20subresource&graph-metrics=test-duration-minutes)

**Special notes for your reviewer:**
Adds +3 endpoint test coverage (good for conformance)

**Does this PR introduce a user-facing change?:**
```
NONE

```

**Release note:**
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:**
```
NONE

```

/sig testing
/sig architecture
/area conformance