### PR TITLE
Promote Read, Replace and Patch ReplicaSetScale test to Conformance +3 endpoints

### DIFF
--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -2082,6 +2082,15 @@
     the Job MUST execute to completion.
   release: v1.16
   file: test/e2e/apps/job.go
+- testname: ReplicaSet, completes the scaling of a ReplicaSet subresource
+  codename: '[sig-apps] ReplicaSet Replicaset should have a working scale subresource
+    [Conformance]'
+  description: Create a ReplicaSet (RS) with a single Pod. The Pod MUST be verified
+    that it is running. The RS MUST get and verify the scale subresource count. The
+    RS MUST update and verify the scale subresource. The RS MUST patch and verify
+    a scale subresource.
+  release: v1.21
+  file: test/e2e/apps/replica_set.go
 - testname: Replica Set, adopt matching pods and release non matching pods
   codename: '[sig-apps] ReplicaSet should adopt matching pods on creation and release
     no longer matching pods [Conformance]'

--- a/test/e2e/apps/replica_set.go
+++ b/test/e2e/apps/replica_set.go
@@ -119,7 +119,15 @@ var _ = SIGDescribe("ReplicaSet", func() {
 		testRSAdoptMatchingAndReleaseNotMatching(f)
 	})
 
-	ginkgo.It("Replicaset should have a working scale subresource", func() {
+	/*
+		Release: v1.21
+		Testname: ReplicaSet, completes the scaling of a ReplicaSet subresource
+		Description: Create a ReplicaSet (RS) with a single Pod. The Pod MUST be verified
+		that it is running. The RS MUST get and verify the scale subresource count.
+		The RS MUST update and verify the scale subresource. The RS MUST patch and verify
+		a scale subresource.
+	*/
+	framework.ConformanceIt("Replicaset should have a working scale subresource", func() {
 		testRSScaleSubresources(f)
 	})
 })


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it:**
This PR adds a test to test the following untested endpoints:

- replaceAppsV1NamespacedReplicaSetScale
- readAppsV1NamespacedReplicaSetScale
- patchAppsV1NamespacedReplicaSetScale

**Which issue(s) this PR fixes:**
Fixes #98920

**Testgrid Link:**
[Testgrid](https://testgrid.k8s.io/sig-release-master-blocking#gce-cos-master-default&width=5&include-filter-by-regex=Replicaset%20should%20have%20a%20working%20scale%20subresource&graph-metrics=test-duration-minutes)

**Special notes for your reviewer:**
Adds +3 endpoint test coverage (good for conformance)

**Does this PR introduce a user-facing change?:**
```
NONE

```

**Release note:**
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:**
```
NONE

```

/sig testing
/sig architecture
/sig apps
/area conformance