### PR TITLE
kubeadm: promote DualStack feature gate to Beta

### DIFF
--- a/cmd/kubeadm/app/apis/kubeadm/validation/validation.go
+++ b/cmd/kubeadm/app/apis/kubeadm/validation/validation.go
@@ -454,7 +454,7 @@ func ValidatePodSubnetNodeMask(subnetStr string, c *kubeadm.ClusterConfiguration
 func getClusterNodeMask(c *kubeadm.ClusterConfiguration, isIPv6 bool) (int, error) {
 	// defaultNodeMaskCIDRIPv4 is default mask size for IPv4 node cidr for use by the controller manager
 	const defaultNodeMaskCIDRIPv4 = 24
-	// DefaultNodeMaskCIDRIPv6 is default mask size for IPv6 node cidr for use by the controller manager
+	// defaultNodeMaskCIDRIPv6 is default mask size for IPv6 node cidr for use by the controller manager
 	const defaultNodeMaskCIDRIPv6 = 64
 	var maskSize int
 	var maskArg string

--- a/cmd/kubeadm/app/apis/kubeadm/validation/validation_test.go
+++ b/cmd/kubeadm/app/apis/kubeadm/validation/validation_test.go
@@ -1137,14 +1137,17 @@ func TestGetClusterNodeMask(t *testing.T) {
 		expectedError bool
 	}{
 		{
-			name:         "ipv4 default mask",
-			cfg:          &kubeadmapi.ClusterConfiguration{},
+			name: "ipv4 default mask",
+			cfg: &kubeadmapi.ClusterConfiguration{
+				FeatureGates: map[string]bool{features.IPv6DualStack: false},
+			},
 			isIPv6:       false,
 			expectedMask: 24,
 		},
 		{
 			name: "ipv4 custom mask",
 			cfg: &kubeadmapi.ClusterConfiguration{
+				FeatureGates: map[string]bool{features.IPv6DualStack: false},
 				ControllerManager: kubeadmapi.ControlPlaneComponent{
 					ExtraArgs: map[string]string{"node-cidr-mask-size": "23"},
 				},
@@ -1155,6 +1158,7 @@ func TestGetClusterNodeMask(t *testing.T) {
 		{
 			name: "ipv4 wrong mask",
 			cfg: &kubeadmapi.ClusterConfiguration{
+				FeatureGates: map[string]bool{features.IPv6DualStack: false},
 				ControllerManager: kubeadmapi.ControlPlaneComponent{
 					ExtraArgs: map[string]string{"node-cidr-mask-size": "aa23"},
 				},
@@ -1163,14 +1167,17 @@ func TestGetClusterNodeMask(t *testing.T) {
 			expectedError: true,
 		},
 		{
-			name:         "ipv6 default mask",
-			cfg:          &kubeadmapi.ClusterConfiguration{},
+			name: "ipv6 default mask",
+			cfg: &kubeadmapi.ClusterConfiguration{
+				FeatureGates: map[string]bool{features.IPv6DualStack: false},
+			},
 			isIPv6:       true,
 			expectedMask: 64,
 		},
 		{
 			name: "ipv6 custom mask",
 			cfg: &kubeadmapi.ClusterConfiguration{
+				FeatureGates: map[string]bool{features.IPv6DualStack: false},
 				ControllerManager: kubeadmapi.ControlPlaneComponent{
 					ExtraArgs: map[string]string{"node-cidr-mask-size": "83"},
 				},

--- a/cmd/kubeadm/app/features/features.go
+++ b/cmd/kubeadm/app/features/features.go
@@ -28,7 +28,7 @@ import (
 )
 
 const (
-	// IPv6DualStack is expected to be alpha in v1.16
+	// IPv6DualStack is expected to be beta in v1.21
 	IPv6DualStack = "IPv6DualStack"
 	// PublicKeysECDSA is expected to be alpha in v1.19
 	PublicKeysECDSA = "PublicKeysECDSA"
@@ -36,7 +36,7 @@ const (
 
 // InitFeatureGates are the default feature gates for the init command
 var InitFeatureGates = FeatureList{
-	IPv6DualStack:   {FeatureSpec: featuregate.FeatureSpec{Default: false, PreRelease: featuregate.Alpha}},
+	IPv6DualStack:   {FeatureSpec: featuregate.FeatureSpec{Default: true, PreRelease: featuregate.Beta}},
 	PublicKeysECDSA: {FeatureSpec: featuregate.FeatureSpec{Default: false, PreRelease: featuregate.Alpha}},
 }
 

--- a/cmd/kubeadm/test/cmd/init_test.go
+++ b/cmd/kubeadm/test/cmd/init_test.go
@@ -329,8 +329,8 @@ func TestCmdInitFeatureGates(t *testing.T) {
 			args: "",
 		},
 		{
-			name: "feature gate IPv6DualStack=true",
-			args: "--feature-gates=IPv6DualStack=true",
+			name: "feature gate IPv6DualStack=false",
+			args: "--feature-gates=IPv6DualStack=false",
 		},
 		{
 			name: "feature gate PublicKeysECDSA=true",


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
upgrade IPv6DualStack feature to beta and turn on by default for kubeadm

#### Which issue(s) this PR fixes:

Part of https://github.com/kubernetes/kubeadm/issues/1612

#### Special notes for your reviewer:
Since #98969 is merged.

#### Does this PR introduce a user-facing change?
```release-note
kubeadm: promote IPv6DualStack feature gate to Beta
```
#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
- [KEP]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-network/563-dual-stack
```
