### PR TITLE
SchedulerPolicySource fields need not be specified

### DIFF
--- a/pkg/scheduler/apis/config/types.go
+++ b/pkg/scheduler/apis/config/types.go
@@ -143,8 +143,8 @@ type SchedulerAlgorithmSource struct {
 	Provider *string
 }
 
-// SchedulerPolicySource configures a means to obtain a scheduler Policy. One
-// source field must be specified, and source fields are mutually exclusive.
+// SchedulerPolicySource configures a means to obtain a scheduler Policy.
+// Source fields are mutually exclusive.
 type SchedulerPolicySource struct {
 	// File is a file policy source.
 	File *SchedulerPolicyFileSource


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/sig scheduling

#### What this PR does / why we need it:
The comment about SchedulerPolicySource fields is wrong

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:


#### Does this PR introduce a user-facing change?
"NONE"

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
"NONE"
