### PR TITLE
e2e framework TestJig used for Service testing wasn't verifying UDP works

### DIFF
--- a/test/e2e/framework/service/BUILD
+++ b/test/e2e/framework/service/BUILD
@@ -38,6 +38,7 @@ go_library(
         "//test/utils:go_default_library",
         "//test/utils/image:go_default_library",
         "//vendor/github.com/onsi/ginkgo:go_default_library",
+        "//vendor/k8s.io/utils/net:go_default_library",
     ],
 )
 

--- a/test/e2e/framework/service/jig.go
+++ b/test/e2e/framework/service/jig.go
@@ -1026,24 +1026,8 @@ func (j *TestJig) CheckServiceReachability(svc *v1.Service, pod *v1.Pod) error {
 	}
 }
 
-// CreateServicePods creates a replication controller with the label same as service. Service listens to HTTP.
+// CreateServicePods creates a replication controller with the label same as service. Service listens to TCP and UDP.
 func (j *TestJig) CreateServicePods(replica int) error {
-	config := testutils.RCConfig{
-		Client:       j.Client,
-		Name:         j.Name,
-		Image:        framework.ServeHostnameImage,
-		Command:      []string{"/agnhost", "serve-hostname"},
-		Namespace:    j.Namespace,
-		Labels:       j.Labels,
-		PollInterval: 3 * time.Second,
-		Timeout:      framework.PodReadyBeforeTimeout,
-		Replicas:     replica,
-	}
-	return e2erc.RunRC(config)
-}
-
-// CreateTCPUDPServicePods creates a replication controller with the label same as service. Service listens to TCP and UDP.
-func (j *TestJig) CreateTCPUDPServicePods(replica int) error {
 	config := testutils.RCConfig{
 		Client:       j.Client,
 		Name:         j.Name,

--- a/test/e2e/framework/service/jig.go
+++ b/test/e2e/framework/service/jig.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"fmt"
 	"net"
-	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -44,7 +43,6 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/kubernetes/test/e2e/framework"
-	e2enetwork "k8s.io/kubernetes/test/e2e/framework/network"
 	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 	e2erc "k8s.io/kubernetes/test/e2e/framework/rc"
@@ -819,14 +817,10 @@ func testReachabilityOverServiceName(serviceName string, sp v1.ServicePort, exec
 
 func testReachabilityOverClusterIP(clusterIP string, sp v1.ServicePort, execPod *v1.Pod) error {
 	// If .spec.clusterIP is set to "" or "None" for service, ClusterIP is not created, so reachability can not be tested over clusterIP:servicePort
-	isClusterIPV46, err := regexp.MatchString(e2enetwork.RegexIPv4+"||"+e2enetwork.RegexIPv6, clusterIP)
-	if err != nil {
+	if net.ParseIP(clusterIP) == nil {
 		return fmt.Errorf("unable to parse ClusterIP: %s", clusterIP)
 	}
-	if isClusterIPV46 {
-		return testEndpointReachability(clusterIP, sp.Port, sp.Protocol, execPod)
-	}
-	return nil
+	return testEndpointReachability(clusterIP, sp.Port, sp.Protocol, execPod)
 }
 
 func testReachabilityOverExternalIP(externalIP string, sp v1.ServicePort, execPod *v1.Pod) error {

--- a/test/e2e/framework/service/jig.go
+++ b/test/e2e/framework/service/jig.go
@@ -48,6 +48,7 @@ import (
 	e2erc "k8s.io/kubernetes/test/e2e/framework/rc"
 	testutils "k8s.io/kubernetes/test/utils"
 	imageutils "k8s.io/kubernetes/test/utils/image"
+	utilsnet "k8s.io/utils/net"
 )
 
 // NodePortRange should match whatever the default/configured range is
@@ -830,7 +831,7 @@ func testReachabilityOverExternalIP(externalIP string, sp v1.ServicePort, execPo
 func testReachabilityOverNodePorts(nodes *v1.NodeList, sp v1.ServicePort, pod *v1.Pod, clusterIP string) error {
 	internalAddrs := e2enode.CollectAddresses(nodes, v1.NodeInternalIP)
 	externalAddrs := e2enode.CollectAddresses(nodes, v1.NodeExternalIP)
-	isClusterIPV4 := net.ParseIP(clusterIP).To4() != nil
+	isClusterIPV4 := utilsnet.IsIPv4String(clusterIP)
 
 	for _, internalAddr := range internalAddrs {
 		// If the node's internal address points to localhost, then we are not
@@ -839,10 +840,8 @@ func testReachabilityOverNodePorts(nodes *v1.NodeList, sp v1.ServicePort, pod *v
 			framework.Logf("skipping testEndpointReachability() for internal adddress %s", internalAddr)
 			continue
 		}
-		isNodeInternalIPV4 := net.ParseIP(internalAddr).To4() != nil
-		// Check service reachability on the node internalIP which is same family
-		// as clusterIP
-		if isClusterIPV4 != isNodeInternalIPV4 {
+		// Check service reachability on the node internalIP which is same family as clusterIP
+		if isClusterIPV4 != utilsnet.IsIPv4String(internalAddr) {
 			framework.Logf("skipping testEndpointReachability() for internal adddress %s as it does not match clusterIP (%s) family", internalAddr, clusterIP)
 			continue
 		}
@@ -853,8 +852,7 @@ func testReachabilityOverNodePorts(nodes *v1.NodeList, sp v1.ServicePort, pod *v
 		}
 	}
 	for _, externalAddr := range externalAddrs {
-		isNodeExternalIPV4 := net.ParseIP(externalAddr).To4() != nil
-		if isClusterIPV4 != isNodeExternalIPV4 {
+		if isClusterIPV4 != utilsnet.IsIPv4String(externalAddr) {
 			framework.Logf("skipping testEndpointReachability() for external adddress %s as it does not match clusterIP (%s) family", externalAddr, clusterIP)
 			continue
 		}

--- a/test/e2e/network/service.go
+++ b/test/e2e/network/service.go
@@ -1228,7 +1228,7 @@ var _ = SIGDescribe("Services", func() {
 		})
 		framework.ExpectNoError(err)
 
-		err = jig.CreateTCPUDPServicePods(2)
+		err = jig.CreateServicePods(2)
 		framework.ExpectNoError(err)
 		execPod := e2epod.CreateExecPodOrFail(cs, ns, "execpod", nil)
 		err = jig.CheckServiceReachability(nodePortService, execPod)


### PR DESCRIPTION
/kind bug
/kind cleanup

The TestJig helper for Service tests was using `nc -vz -u` to test the UDP service connectivity, however, that command only checks that the packet is sent and doesn't guarantee that the port is open because it never checks the reply.

```
 nc -v -z -u 8.8.8.8 12323 && echo OK
Ncat: Version 7.80 ( https://nmap.org/ncat )
Ncat: Connected to 8.8.8.8:12323.
Ncat: UDP packet sent successfully
Ncat: 1 bytes sent, 0 bytes received in 2.01 seconds.
OK
```

```release-note
NONE
```
