### PR TITLE
promote RootCAConfigMap e2e test to Conformance

### DIFF
--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -2232,6 +2232,13 @@
     and 3c the ServiceTokenVolume MUST not be auto mounted.
   release: v1.9
   file: test/e2e/auth/service_accounts.go
+- testname: RootCA ConfigMap test
+  codename: '[sig-auth] ServiceAccounts should guarantee kube-root-ca.crt exist in
+    any namespace [Conformance]'
+  description: Ensure every namespace exist a ConfigMap for root ca cert. 1. Created
+    automatically 2. Recreated if deleted 3. Reconciled if modified
+  release: v1.21
+  file: test/e2e/auth/service_accounts.go
 - testname: Service Account Tokens Must AutoMount
   codename: '[sig-auth] ServiceAccounts should mount an API token into pods  [Conformance]'
   description: Ensure that Service Account keys are mounted into the Container. Pod

--- a/test/e2e/auth/service_accounts.go
+++ b/test/e2e/auth/service_accounts.go
@@ -875,7 +875,15 @@ var _ = SIGDescribe("ServiceAccounts", func() {
 		framework.ExpectEqual(eventFound, true, "failed to find %v event", watch.Deleted)
 	})
 
-	ginkgo.It("should guarantee kube-root-ca.crt exist in any namespace", func() {
+	/*
+		Release: v1.21
+		Testname: RootCA ConfigMap test
+		Description: Ensure every namespace exist a ConfigMap for root ca cert.
+			1. Created automatically
+			2. Recreated if deleted
+			3. Reconciled if modified
+	*/
+	framework.ConformanceIt("should guarantee kube-root-ca.crt exist in any namespace", func() {
 		const rootCAConfigMapName = "kube-root-ca.crt"
 
 		framework.ExpectNoError(wait.PollImmediate(500*time.Millisecond, wait.ForeverTestTimeout, func() (bool, error) {


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
meet criteria for graduating RootCAConfigMap GA

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
- [KEP]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-auth/1205-bound-service-account-tokens
```
