### PR TITLE
fix recreate sandbox when a job is done

### DIFF
--- a/pkg/kubelet/container/helpers.go
+++ b/pkg/kubelet/container/helpers.go
@@ -58,6 +58,16 @@ type RuntimeHelper interface {
 	GetExtraSupplementalGroupsForPod(pod *v1.Pod) []int64
 }
 
+// ShouldPodBeRestarted checks whether a pod needs to be restarted.
+func ShouldPodBeRestarted(pod *v1.Pod, podStatus *PodStatus) bool {
+	for _, container := range pod.Spec.Containers {
+		if ShouldContainerBeRestarted(&container, pod, podStatus) {
+			return true
+		}
+	}
+	return false
+}
+
 // ShouldContainerBeRestarted checks whether a container needs to be restarted.
 // TODO(yifan): Think about how to refactor this.
 func ShouldContainerBeRestarted(container *v1.Container, pod *v1.Pod, podStatus *PodStatus) bool {

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager.go
@@ -511,7 +511,7 @@ func (m *kubeGenericRuntimeManager) computePodActions(pod *v1.Pod, podStatus *ku
 	// If we need to (re-)create the pod sandbox, everything will need to be
 	// killed and recreated, and init containers should be purged.
 	if createPodSandbox {
-		if !shouldRestartOnFailure(pod) && attempt != 0 && len(podStatus.ContainerStatuses) != 0 {
+		if !kubecontainer.ShouldPodBeRestarted(pod, podStatus) && attempt != 0 && len(podStatus.ContainerStatuses) != 0 {
 			// Should not restart the pod, just return.
 			// we should not create a sandbox for a pod if it is already done.
 			// if all containers are done and should not be started, there is no need to create a new sandbox.


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
If a job is done, we shouldn't recreate sandbox.

#### Which issue(s) this PR fixes:
https://github.com/awslabs/amazon-eks-ami/issues/592
https://github.com/kubernetes/kubernetes/issues/95916

#### How to reproduce it (as minimally and precisely as possible):
```yaml
apiVersion: batch/v1beta1
kind: CronJob
metadata:
  name: hello
spec:
  schedule: "*/1 * * * *"
  jobTemplate:
    spec:
      template:
        spec:
          containers:
          - name: hello
            image: busybox
            args:
            - /bin/sh
            - -c
            - date; echo Hello from the Kubernetes cluster
          restartPolicy: OnFailure
```

kubelet log
```
I0223 13:20:03.238964  285333 kuberuntime_manager.go:659] SyncPod received new pod "hello-1614057600-9mtz9_default(5c87e898-2dee-4f06-8036-8765a93b06d8)", will create a sandbox for it
I0223 13:20:03.238973  285333 kuberuntime_manager.go:666] Stopping PodSandbox for "hello-1614057600-9mtz9_default(5c87e898-2dee-4f06-8036-8765a93b06d8)", will start new one
I0223 13:20:03.238990  285333 kuberuntime_manager.go:721] Creating sandbox for pod "hello-1614057600-9mtz9_default(5c87e898-2dee-4f06-8036-8765a93b06d8)"
...
I0223 13:20:06.882342  285333 kuberuntime_manager.go:668] Stopping PodSandbox for "hello-1614057600-9mtz9_default(5c87e898-2dee-4f06-8036-8765a93b06d8)" because all other containers are dead.
I0223 13:20:07.894401  285333 kuberuntime_manager.go:440] No ready sandbox for pod "hello-1614057600-9mtz9_default(5c87e898-2dee-4f06-8036-8765a93b06d8)" can be found. Need to start a new one
```
event
```
55m         Normal    Scheduled                pod/hello-1614057600-9mtz9   Successfully assigned default/hello-1614057600-9mtz9 to 192.168.0.96
55m         Normal    Pulling                  pod/hello-1614057600-9mtz9   Pulling image "busybox"
55m         Normal    Pulled                   pod/hello-1614057600-9mtz9   Successfully pulled image "busybox"
55m         Normal    Created                  pod/hello-1614057600-9mtz9   Created container hello
55m         Normal    Started                  pod/hello-1614057600-9mtz9   Started container hello
55m         Normal    SandboxChanged           pod/hello-1614057600-9mtz9   Pod sandbox changed, it will be killed and re-created.
55m         Warning   FailedCreatePodSandBox   pod/hello-1614057600-9mtz9   Failed to create pod sandbox: rpc error: code = Unknown desc = failed to start sandbox container for pod "hello-1614057600-9mtz9": Error response from daemon: OCI runtime create failed: container_linux.go:349: starting container process caused "process_linux.go:319: getting the final child's pid from pipe caused \"EOF\"": unknown
55m         Normal    SuccessfulCreate         job/hello-1614057600         Created pod: hello-1614057600-9mtz9
55m         Normal    Completed                job/hello-1614061020         Job completed
```