### PR TITLE
Fix staging/src/k8s.io/apiserver/pkg/server/filters flake test timeout

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/filters/priority-and-fairness_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/filters/priority-and-fairness_test.go
@@ -380,13 +380,16 @@ func TestPriorityAndFairnessWithPanicRecoveryAndTimeoutFilter(t *testing.T) {
 		})
 		handler := newHandlerChain(t, requestHandler, controller, userName, requestTimeout)
 
-		server, requestGetter := newHTTP2ServerWithClient(handler)
+		server, requestGetter := newHTTP2ServerWithClient(handler, requestTimeout*2)
 		defer server.Close()
 
 		var err error
 		_, err = requestGetter(firstRequestPathPanic)
 		if !executed {
 			t.Errorf("Expected inner handler to be executed for request: %q", firstRequestPathPanic)
+		}
+		if isClientTimeout(err) {
+			t.Fatalf("the client has unexpectedly timed out - request: %q error: %s", firstRequestPathPanic, err.Error())
 		}
 		expectResetStreamError(t, err)
 
@@ -414,8 +417,9 @@ func TestPriorityAndFairnessWithPanicRecoveryAndTimeoutFilter(t *testing.T) {
 	})
 
 	t.Run("priority level concurrency is set to 1, request times out and inner handler hasn't written to the response yet", func(t *testing.T) {
+		t.Parallel()
 		const (
-			requestTimeout                                        = 3 * time.Second
+			requestTimeout                                        = 5 * time.Second
 			userName                                              = "alice"
 			fsName                                                = "test-fs"
 			plName                                                = "test-pl"
@@ -442,8 +446,13 @@ func TestPriorityAndFairnessWithPanicRecoveryAndTimeoutFilter(t *testing.T) {
 		})
 		handler := newHandlerChain(t, requestHandler, controller, userName, requestTimeout)
 
-		server, requestGetter := newHTTP2ServerWithClient(handler)
+		server, requestGetter := newHTTP2ServerWithClient(handler, requestTimeout*2)
 		defer server.Close()
+
+		go hardStop(t, stopCh, requestTimeout*3, func() {
+			// the client timed out unexpectedly, let's clean up and abort.
+			close(reqHandlerCompletedCh)
+		})
 
 		var (
 			response *http.Response
@@ -454,6 +463,9 @@ func TestPriorityAndFairnessWithPanicRecoveryAndTimeoutFilter(t *testing.T) {
 
 			t.Logf("Waiting for the request: %q to time out", rquestTimesOutPath)
 			response, err = requestGetter(rquestTimesOutPath)
+			if isClientTimeout(err) {
+				t.Fatalf("the client has unexpectedly timed out - request: %q error: %s", rquestTimesOutPath, err.Error())
+			}
 		}()
 
 		if !executed {
@@ -479,8 +491,9 @@ func TestPriorityAndFairnessWithPanicRecoveryAndTimeoutFilter(t *testing.T) {
 	})
 
 	t.Run("priority level concurrency is set to 1, inner handler panics after the request times out", func(t *testing.T) {
+		t.Parallel()
 		const (
-			requestTimeout                                        = 3 * time.Second
+			requestTimeout                                        = 5 * time.Second
 			userName                                              = "alice"
 			fsName                                                = "test-fs"
 			plName                                                = "test-pl"
@@ -511,8 +524,13 @@ func TestPriorityAndFairnessWithPanicRecoveryAndTimeoutFilter(t *testing.T) {
 		})
 		handler := newHandlerChain(t, requestHandler, controller, userName, requestTimeout)
 
-		server, requestGetter := newHTTP2ServerWithClient(handler)
+		server, requestGetter := newHTTP2ServerWithClient(handler, requestTimeout*2)
 		defer server.Close()
+
+		go hardStop(t, stopCh, requestTimeout*3, func() {
+			// the client timed out unexpectedly, let's clean up and abort.
+			close(reqHandlerCompletedCh)
+		})
 
 		var (
 			response *http.Response
@@ -522,6 +540,9 @@ func TestPriorityAndFairnessWithPanicRecoveryAndTimeoutFilter(t *testing.T) {
 			defer close(callerRoundTripDoneCh)
 			t.Logf("Waiting for the request: %q to time out", rquestTimesOutPath)
 			response, err = requestGetter(rquestTimesOutPath)
+			if isClientTimeout(err) {
+				t.Fatalf("the client has unexpectedly timed out - request: %q error: %s", rquestTimesOutPath, err.Error())
+			}
 		}()
 
 		t.Logf("Waiting for the inner handler of the request: %q to complete", rquestTimesOutPath)
@@ -544,8 +565,9 @@ func TestPriorityAndFairnessWithPanicRecoveryAndTimeoutFilter(t *testing.T) {
 	})
 
 	t.Run("priority level concurrency is set to 1, inner handler writes to the response before request times out", func(t *testing.T) {
+		t.Parallel()
 		const (
-			requestTimeout                                        = 3 * time.Second
+			requestTimeout                                        = 5 * time.Second
 			userName                                              = "alice"
 			fsName                                                = "test-fs"
 			plName                                                = "test-pl"
@@ -577,14 +599,22 @@ func TestPriorityAndFairnessWithPanicRecoveryAndTimeoutFilter(t *testing.T) {
 		})
 		handler := newHandlerChain(t, requestHandler, controller, userName, requestTimeout)
 
-		server, requestGetter := newHTTP2ServerWithClient(handler)
+		server, requestGetter := newHTTP2ServerWithClient(handler, requestTimeout*2)
 		defer server.Close()
+
+		go hardStop(t, stopCh, requestTimeout*3, func() {
+			// the client timed out unexpectedly, let's clean up and abort.
+			close(reqHandlerCompletedCh)
+		})
 
 		var err error
 		func() {
 			defer close(callerRoundTripDoneCh)
 			t.Logf("Waiting for the request: %q to time out", rquestTimesOutPath)
 			_, err = requestGetter(rquestTimesOutPath)
+			if isClientTimeout(err) {
+				t.Fatalf("the client has unexpectedly timed out - request: %q error: %s", rquestTimesOutPath, err.Error())
+			}
 		}()
 
 		t.Logf("Waiting for the inner handler of the request: %q to complete", rquestTimesOutPath)
@@ -602,8 +632,9 @@ func TestPriorityAndFairnessWithPanicRecoveryAndTimeoutFilter(t *testing.T) {
 	})
 
 	t.Run("priority level concurrency is set to 1, queue length is 1, first request should time out and second (enqueued) request should time out as well", func(t *testing.T) {
+		t.Parallel()
 		const (
-			requestTimeout                                                     = 3 * time.Second
+			requestTimeout                                                     = 5 * time.Second
 			userName                                                           = "alice"
 			fsName                                                             = "test-fs"
 			plName                                                             = "test-pl"
@@ -646,8 +677,14 @@ func TestPriorityAndFairnessWithPanicRecoveryAndTimeoutFilter(t *testing.T) {
 		})
 		handler := newHandlerChain(t, requestHandler, controller, userName, requestTimeout)
 
-		server, requestGetter := newHTTP2ServerWithClient(handler)
+		server, requestGetter := newHTTP2ServerWithClient(handler, requestTimeout*2)
 		defer server.Close()
+
+		go hardStop(t, stopCh, requestTimeout*3, func() {
+			// the client timed out unexpectedly, let's clean up and abort.
+			close(firstReqInProgressCh)
+			close(firstReqHandlerCompletedCh)
+		})
 
 		var firstReqErr, secondReqErr error
 		var resp1, resp2 *http.Response
@@ -655,6 +692,9 @@ func TestPriorityAndFairnessWithPanicRecoveryAndTimeoutFilter(t *testing.T) {
 			defer close(firstReqRoundTripDoneCh)
 			t.Logf("Waiting for the request: %q to time out", firstRequestTimesOutPath)
 			resp1, firstReqErr = requestGetter(firstRequestTimesOutPath)
+			if isClientTimeout(firstReqErr) {
+				t.Fatalf("the client has unexpectedly timed out - request: %q error: %s", firstRequestTimesOutPath, firstReqErr.Error())
+			}
 		}()
 		func() {
 			defer close(secondReqRoundTripDoneCh)
@@ -662,6 +702,9 @@ func TestPriorityAndFairnessWithPanicRecoveryAndTimeoutFilter(t *testing.T) {
 			// we must wait for the "first" request to start executing first
 			<-firstReqInProgressCh
 			resp2, secondReqErr = requestGetter(secondRequestEnqueuedPath)
+			if isClientTimeout(secondReqErr) {
+				t.Fatalf("the client has unexpectedly timed out - request: %q error: %s", secondRequestEnqueuedPath, secondReqErr.Error())
+			}
 		}()
 
 		<-firstReqRoundTripDoneCh
@@ -736,13 +779,14 @@ func startAPFController(t *testing.T, stopCh <-chan struct{}, apfConfiguration [
 }
 
 // returns a started http2 server, with a client function to send request to the server.
-func newHTTP2ServerWithClient(handler http.Handler) (*httptest.Server, func(path string) (*http.Response, error)) {
+func newHTTP2ServerWithClient(handler http.Handler, clientTimeout time.Duration) (*httptest.Server, func(path string) (*http.Response, error)) {
 	server := httptest.NewUnstartedServer(handler)
 	server.EnableHTTP2 = true
 	server.StartTLS()
-
+	cli := server.Client()
+	cli.Timeout = clientTimeout
 	return server, func(path string) (*http.Response, error) {
-		return server.Client().Get(server.URL + path)
+		return cli.Get(server.URL + path)
 	}
 }
 
@@ -948,4 +992,21 @@ func gaugeValueMatch(name string, labelFilter map[string]string, wantValue int) 
 	}
 
 	return nil
+}
+
+func isClientTimeout(err error) bool {
+	if urlErr, ok := err.(*url.Error); ok {
+		return urlErr.Timeout()
+	}
+	return false
+}
+
+func hardStop(t *testing.T, stopCh <-chan struct{}, testTimeout time.Duration, cleanup func()) {
+	select {
+	case <-stopCh:
+		// The test has completed normally.
+	case <-time.After(testTimeout):
+		cleanup()
+		t.Fatalf("the test did not finish within %s", testTimeout)
+	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind flake

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
xref https://github.com/kubernetes/kubernetes/issues/98486#issuecomment-783232922

https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/99236/pull-kubernetes-bazel-test/1364043067924942848

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
