### PR TITLE
cinder: Translate CSI topology affinity into in-tree labels

### DIFF
--- a/staging/src/k8s.io/csi-translation-lib/plugins/in_tree_volume_test.go
+++ b/staging/src/k8s.io/csi-translation-lib/plugins/in_tree_volume_test.go
@@ -421,6 +421,48 @@ func TestTranslateTopologyFromCSIToInTree(t *testing.T) {
 				v1.LabelTopologyRegion: "us-east1",
 			},
 		},
+		{
+			name:         "cinder translation",
+			key:          CinderTopologyKey,
+			expErr:       false,
+			regionParser: nil,
+			pv: &v1.PersistentVolume{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "cinder", Namespace: "myns",
+				},
+				Spec: v1.PersistentVolumeSpec{
+					NodeAffinity: &v1.VolumeNodeAffinity{
+						Required: &v1.NodeSelector{
+							NodeSelectorTerms: []v1.NodeSelectorTerm{
+								{
+									MatchExpressions: []v1.NodeSelectorRequirement{
+										{
+											Key:      CinderTopologyKey,
+											Operator: v1.NodeSelectorOpIn,
+											Values:   []string{"nova"},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedNodeSelectorTerms: []v1.NodeSelectorTerm{
+				{
+					MatchExpressions: []v1.NodeSelectorRequirement{
+						{
+							Key:      v1.LabelTopologyZone,
+							Operator: v1.NodeSelectorOpIn,
+							Values:   []string{"nova"},
+						},
+					},
+				},
+			},
+			expectedLabels: map[string]string{
+				v1.LabelTopologyZone: "nova",
+			},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/staging/src/k8s.io/csi-translation-lib/plugins/openstack_cinder.go
+++ b/staging/src/k8s.io/csi-translation-lib/plugins/openstack_cinder.go
@@ -144,6 +144,12 @@ func (t *osCinderCSITranslator) TranslateCSIPVToInTree(pv *v1.PersistentVolume) 
 		ReadOnly: csiSource.ReadOnly,
 	}
 
+	// translate CSI topology to In-tree topology for rollback compatibility.
+	// It is not possible to guess Cinder Region from the Zone, therefore leave it empty.
+	if err := translateTopologyFromCSIToInTree(pv, CinderTopologyKey, nil); err != nil {
+		return nil, fmt.Errorf("failed to translate topology. PV:%+v. Error:%v", *pv, err)
+	}
+
 	pv.Spec.CSI = nil
 	pv.Spec.Cinder = cinderSource
 	return pv, nil


### PR DESCRIPTION
/kind feature

#### What this PR does / why we need it:
When translating a PV from CSI to in-tree, translate node affinity into PV labels to ensure backward compatibility.

This is Cinder equivalent of #97823.

Unlike the other clouds, where region name (eg `us-east-1`) is a substring of zone (`us-east-1d`), OpenStack has no relation between zones and regions. I omitted the region label completely. The translation layer does not have access to the region configured in cloud.conf and the region is not in PV affinity either:

This CSI PV is in region `regionOne` and zone `nova`:
```
    nodeAffinity:
      required:
        nodeSelectorTerms:
        - matchExpressions:
          - key: topology.cinder.csi.openstack.org/zone
            operator: In
            values:
            - nova
```

As result, in-tree volumes provisioned by the CSI driver when migration is enabled will be processed by the admission plugin and region will be filed there. When the admission plugin is disabled / removed, I *think* that scheduler will consider only the zone label, which should be enough to find the right nodes. My OpenStack cluster does not have multiple regions.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
