### PR TITLE
Fix staticcheck in k8s.io/apimachinery/pkg/util

### DIFF
--- a/hack/.staticcheck_failures
+++ b/hack/.staticcheck_failures
@@ -1,11 +1,6 @@
 cluster/images/etcd/migrate
 vendor/k8s.io/apimachinery/pkg/api/apitesting/roundtrip
 vendor/k8s.io/apimachinery/pkg/apis/meta/v1/validation
-vendor/k8s.io/apimachinery/pkg/util/httpstream/spdy
-vendor/k8s.io/apimachinery/pkg/util/net
-vendor/k8s.io/apimachinery/pkg/util/sets/types
-vendor/k8s.io/apimachinery/pkg/util/strategicpatch
-vendor/k8s.io/apimachinery/pkg/util/wait
 vendor/k8s.io/apiserver/pkg/endpoints/filters
 vendor/k8s.io/apiserver/pkg/endpoints/metrics
 vendor/k8s.io/apiserver/pkg/registry/rest/resttest

--- a/staging/src/k8s.io/apimachinery/pkg/util/httpstream/spdy/roundtripper.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/httpstream/spdy/roundtripper.go
@@ -183,8 +183,11 @@ func (s *SpdyRoundTripper) dial(req *http.Request) (net.Conn, error) {
 		return nil, err
 	}
 
+	//lint:ignore SA1019 ignore deprecated httputil.NewProxyClientConn
 	proxyClientConn := httputil.NewProxyClientConn(proxyDialConn, nil)
 	_, err = proxyClientConn.Do(&proxyReq)
+	//lint:ignore SA1019 ignore deprecated httputil.ErrPersistEOF: it might be
+	// returned from the invocation of proxyClientConn.Do
 	if err != nil && err != httputil.ErrPersistEOF {
 		return nil, err
 	}

--- a/staging/src/k8s.io/apimachinery/pkg/util/net/http.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/net/http.go
@@ -113,6 +113,7 @@ func SetOldTransportDefaults(t *http.Transport) *http.Transport {
 		t.Proxy = NewProxierWithNoProxyCIDR(http.ProxyFromEnvironment)
 	}
 	// If no custom dialer is set, use the default context dialer
+	//lint:file-ignore SA1019 Keep supporting deprecated Dial method of custom transports
 	if t.DialContext == nil && t.Dial == nil {
 		t.DialContext = defaultTransport.DialContext
 	}

--- a/staging/src/k8s.io/apimachinery/pkg/util/sets/types/types.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/sets/types/types.go
@@ -20,6 +20,7 @@ limitations under the License.
 package types
 
 //go:generate set-gen -i k8s.io/kubernetes/pkg/util/sets/types
+//lint:file-ignore U1000 Ignore unused fields
 
 type ReferenceSetTypes struct {
 	// These types all cause files to be generated.

--- a/staging/src/k8s.io/apimachinery/pkg/util/strategicpatch/patch.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/strategicpatch/patch.go
@@ -987,10 +987,10 @@ func validatePatchWithSetOrderList(patchList, setOrderList interface{}, mergeKey
 		return nil
 	}
 
-	var nonDeleteList, toDeleteList []interface{}
+	var nonDeleteList []interface{}
 	var err error
 	if len(mergeKey) > 0 {
-		nonDeleteList, toDeleteList, err = extractToDeleteItems(typedPatchList)
+		nonDeleteList, _, err = extractToDeleteItems(typedPatchList)
 		if err != nil {
 			return err
 		}
@@ -1018,7 +1018,6 @@ func validatePatchWithSetOrderList(patchList, setOrderList interface{}, mergeKey
 	if patchIndex < len(nonDeleteList) && setOrderIndex >= len(typedSetOrderList) {
 		return fmt.Errorf("The order in patch list:\n%v\n doesn't match %s list:\n%v\n", typedPatchList, setElementOrderDirectivePrefix, setOrderList)
 	}
-	typedPatchList = append(nonDeleteList, toDeleteList...)
 	return nil
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
PR fixes issues found by staticcheck in `k8s.io/apimachinery/pkg/util`:
```
vendor/k8s.io/apimachinery/pkg/util/httpstream/spdy/roundtripper.go:186:21: httputil.NewProxyClientConn is deprecated: Use the Client or Transport in package net/http instead.  (SA1019)
vendor/k8s.io/apimachinery/pkg/util/httpstream/spdy/roundtripper.go:188:26: httputil.ErrPersistEOF is deprecated: No longer used.  (SA1019)
vendor/k8s.io/apimachinery/pkg/util/net/http.go:116:29: t.Dial is deprecated: Use DialContext instead, which allows the transport to cancel dials as soon as they are no longer needed. If both are set, DialContext takes priority.  (SA1019)
vendor/k8s.io/apimachinery/pkg/util/net/http.go:225:6: transport.Dial is deprecated: Use DialContext instead, which allows the transport to cancel dials as soon as they are no longer needed. If both are set, DialContext takes priority.  (SA1019)
vendor/k8s.io/apimachinery/pkg/util/net/http.go:227:12: transport.Dial is deprecated: Use DialContext instead, which allows the transport to cancel dials as soon as they are no longer needed. If both are set, DialContext takes priority.  (SA1019)
vendor/k8s.io/apimachinery/pkg/util/sets/types/types.go:28:2: field a is unused (U1000)
vendor/k8s.io/apimachinery/pkg/util/sets/types/types.go:29:2: field b is unused (U1000)
vendor/k8s.io/apimachinery/pkg/util/sets/types/types.go:30:2: field c is unused (U1000)
vendor/k8s.io/apimachinery/pkg/util/sets/types/types.go:31:2: field d is unused (U1000)
vendor/k8s.io/apimachinery/pkg/util/sets/types/types.go:32:2: field e is unused (U1000)
vendor/k8s.io/apimachinery/pkg/util/strategicpatch/patch.go:1021:2: this value of typedPatchList is never used (SA4006)
vendor/k8s.io/apimachinery/pkg/util/strategicpatch/patch.go:1021:19: this result of append is never used, except maybe in other appends (SA4010)
vendor/k8s.io/apimachinery/pkg/util/wait/wait_test.go:415:2: the goroutine calls T.Fatalf, which must be called in the same goroutine as the test (SA2002)
vendor/k8s.io/apimachinery/pkg/util/wait/wait_test.go:427:4: call to T.Fatalf
vendor/k8s.io/apimachinery/pkg/util/wait/wait_test.go:451:2: the goroutine calls T.Fatalf, which must be called in the same goroutine as the test (SA2002)
vendor/k8s.io/apimachinery/pkg/util/wait/wait_test.go:458:3: call to T.Fatalf
```

#### Which issue(s) this PR fixes:
Part of #92402

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
