### PR TITLE
Switch gitVersion format to non-abbreviated hash

### DIFF
--- a/staging/src/k8s.io/client-go/pkg/version/base.go
+++ b/staging/src/k8s.io/client-go/pkg/version/base.go
@@ -55,7 +55,7 @@ var (
 	// NOTE: The $Format strings are replaced during 'git archive' thanks to the
 	// companion .gitattributes file containing 'export-subst' in this same
 	// directory.  See also https://git-scm.com/docs/gitattributes
-	gitVersion   string = "v0.0.0-master+$Format:%h$"
+	gitVersion   string = "v0.0.0-master+$Format:%H$"
 	gitCommit    string = "$Format:%H$" // sha1 from git, output of $(git rev-parse HEAD)
 	gitTreeState string = ""            // state of git tree, either "clean" or "dirty"
 

--- a/staging/src/k8s.io/component-base/version/base.go
+++ b/staging/src/k8s.io/component-base/version/base.go
@@ -55,7 +55,7 @@ var (
 	// NOTE: The $Format strings are replaced during 'git archive' thanks to the
 	// companion .gitattributes file containing 'export-subst' in this same
 	// directory.  See also https://git-scm.com/docs/gitattributes
-	gitVersion   = "v0.0.0-master+$Format:%h$"
+	gitVersion   = "v0.0.0-master+$Format:%H$"
 	gitCommit    = "$Format:%H$" // sha1 from git, output of $(git rev-parse HEAD)
 	gitTreeState = ""            // state of git tree, either "clean" or "dirty"
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### Which issue(s) this PR fixes:
Fixes #99376

Ensures that source archives for a given sha/tag remain consistent over time, even if sha collisions require the abbreviated hash to grow in the future.


#### Does this PR introduce a user-facing change?
```release-note
NONE
```

Not really sure who to target this at, but maybe @kubernetes/sig-release for review? The artifacts we build don't even make use of the git archive mechanism, and our binaries override the variable using build flags.