### PR TITLE
the last upperbound of kms latency metric is too small

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/value/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/value/metrics.go
@@ -47,8 +47,8 @@ var (
 			Name:      "transformation_duration_seconds",
 			Help:      "Latencies in seconds of value transformation operations.",
 			// In-process transformations (ex. AES CBC) complete on the order of 20 microseconds. However, when
-			// external KMS is involved latencies may climb into milliseconds.
-			Buckets:        metrics.ExponentialBuckets(5e-6, 2, 14),
+			// external KMS is involved latencies may climb into hundreds of milliseconds.
+			Buckets:        metrics.ExponentialBuckets(5e-6, 2, 25),
 			StabilityLevel: metrics.ALPHA,
 		},
 		[]string{"transformation_type"},


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
the current setting implies that the latency of kms operation should not exceed 40ms which is too small.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```