### PR TITLE
Optimized function getProxyMode

### DIFF
--- a/cmd/kube-proxy/app/server_windows.go
+++ b/cmd/kube-proxy/app/server_windows.go
@@ -179,9 +179,7 @@ func newProxyServer(config *proxyconfigapi.KubeProxyConfiguration, cleanupAndExi
 }
 
 func getProxyMode(proxyMode string, kcompat winkernel.KernelCompatTester) string {
-	if proxyMode == proxyModeUserspace {
-		return proxyModeUserspace
-	} else if proxyMode == proxyModeKernelspace {
+	if proxyMode == proxyModeKernelspace {
 		return tryWinKernelSpaceProxy(kcompat)
 	}
 	return proxyModeUserspace


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

The logic of function getProxyMode is redundant. It returns "kernelspace" if and only if Windows Kernel Version is supported, otherwise it returns "userspace". I simplified its logic.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

NONE

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.: