### PR TITLE
fix resource scale overflow

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity_test.go
@@ -632,6 +632,25 @@ func TestQuantityNeg(t *testing.T) {
 	}
 }
 
+func TestQuantityNegValue(t *testing.T) {
+	table := []struct {
+		input string
+		value int64
+	}{
+		{"-1Gi", -1 * 1024 * 1024 * 1024},
+		{"-50Gi", -50 * 1024 * 1024 * 1024},
+		{"-1.0Gi", -1 * 1024 * 1024 * 1024},
+		{"-50.0Gi", -50 * 1024 * 1024 * 1024},
+	}
+
+	for _, item := range table {
+		q := MustParse(item.input)
+		if q.Value() != item.value {
+			t.Errorf("value of %q: expected %v, got %v", item.input, item.value, q.Value())
+		}
+	}
+}
+
 func TestQuantityString(t *testing.T) {
 	table := []struct {
 		in        Quantity

--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/scale_int.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/scale_int.go
@@ -58,7 +58,7 @@ func scaledValue(unscaled *big.Int, scale, newScale int) int64 {
 
 	// fast path when unscaled < max.Int64 and exp(10,dif) < max.Int64
 	const log10MaxInt64 = 19
-	if unscaled.Cmp(maxInt64) < 0 && dif < log10MaxInt64 {
+	if unscaled.CmpAbs(maxInt64) < 0 && dif < log10MaxInt64 {
 		divide := int64(math.Pow10(dif))
 		result := unscaled.Int64() / divide
 		mod := unscaled.Int64() % divide


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug
/sig api-machinery

#### What this PR does / why we need it:

This PR fixes the overflow bug when the resource is negative. Sometimes negative resources can be used, e.g. computing the diff value of LVM disks.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #99231 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```