### PR TITLE
reduce configmap and secret watch of kubelet

### DIFF
--- a/pkg/kubelet/configmap/configmap_manager.go
+++ b/pkg/kubelet/configmap/configmap_manager.go
@@ -135,7 +135,7 @@ func NewCachingConfigMapManager(kubeClient clientset.Interface, getTTL manager.G
 // - whenever a pod is created or updated, we start individual watches for all
 //   referenced objects that aren't referenced from other registered pods
 // - every GetObject() returns a value from local cache propagated via watches
-func NewWatchingConfigMapManager(kubeClient clientset.Interface) Manager {
+func NewWatchingConfigMapManager(kubeClient clientset.Interface, resyncInterval time.Duration) Manager {
 	listConfigMap := func(namespace string, opts metav1.ListOptions) (runtime.Object, error) {
 		return kubeClient.CoreV1().ConfigMaps(namespace).List(context.TODO(), opts)
 	}
@@ -153,6 +153,6 @@ func NewWatchingConfigMapManager(kubeClient clientset.Interface) Manager {
 	}
 	gr := corev1.Resource("configmap")
 	return &configMapManager{
-		manager: manager.NewWatchBasedManager(listConfigMap, watchConfigMap, newConfigMap, isImmutable, gr, getConfigMapNames),
+		manager: manager.NewWatchBasedManager(listConfigMap, watchConfigMap, newConfigMap, isImmutable, gr, resyncInterval, getConfigMapNames),
 	}
 }

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -558,8 +558,8 @@ func NewMainKubelet(kubeCfg *kubeletconfiginternal.KubeletConfiguration,
 	var configMapManager configmap.Manager
 	switch kubeCfg.ConfigMapAndSecretChangeDetectionStrategy {
 	case kubeletconfiginternal.WatchChangeDetectionStrategy:
-		secretManager = secret.NewWatchingSecretManager(kubeDeps.KubeClient)
-		configMapManager = configmap.NewWatchingConfigMapManager(kubeDeps.KubeClient)
+		secretManager = secret.NewWatchingSecretManager(kubeDeps.KubeClient, klet.resyncInterval)
+		configMapManager = configmap.NewWatchingConfigMapManager(kubeDeps.KubeClient, klet.resyncInterval)
 	case kubeletconfiginternal.TTLCacheChangeDetectionStrategy:
 		secretManager = secret.NewCachingSecretManager(
 			kubeDeps.KubeClient, manager.GetObjectTTLFromNodeFunc(klet.GetNode))

--- a/pkg/kubelet/secret/secret_manager.go
+++ b/pkg/kubelet/secret/secret_manager.go
@@ -136,7 +136,7 @@ func NewCachingSecretManager(kubeClient clientset.Interface, getTTL manager.GetO
 // - whenever a pod is created or updated, we start individual watches for all
 //   referenced objects that aren't referenced from other registered pods
 // - every GetObject() returns a value from local cache propagated via watches
-func NewWatchingSecretManager(kubeClient clientset.Interface) Manager {
+func NewWatchingSecretManager(kubeClient clientset.Interface, resyncInterval time.Duration) Manager {
 	listSecret := func(namespace string, opts metav1.ListOptions) (runtime.Object, error) {
 		return kubeClient.CoreV1().Secrets(namespace).List(context.TODO(), opts)
 	}
@@ -154,6 +154,6 @@ func NewWatchingSecretManager(kubeClient clientset.Interface) Manager {
 	}
 	gr := corev1.Resource("secret")
 	return &secretManager{
-		manager: manager.NewWatchBasedManager(listSecret, watchSecret, newSecret, isImmutable, gr, getSecretNames),
+		manager: manager.NewWatchBasedManager(listSecret, watchSecret, newSecret, isImmutable, gr, resyncInterval, getSecretNames),
 	}
 }

--- a/pkg/kubelet/util/manager/watch_based_manager.go
+++ b/pkg/kubelet/util/manager/watch_based_manager.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/clock"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
@@ -44,25 +45,108 @@ type isImmutableFunc func(runtime.Object) bool
 // objectCacheItem is a single item stored in objectCache.
 type objectCacheItem struct {
 	refCount  int
-	store     cache.Store
+	store     *cacheStore
+	reflector *cache.Reflector
+
 	hasSynced func() (bool, error)
 
-	// lock is protecting from closing stopCh multiple times.
-	lock   sync.Mutex
-	stopCh chan struct{}
+	// waitGroup is used to ensure that there won't be two concurrent calls to reflector.Run
+	waitGroup sync.WaitGroup
+
+	// lock is to ensure the access and modify of lastAccessTime, stopped, and immutable are thread safety,
+	// and protecting from closing stopCh multiple times.
+	lock           sync.Mutex
+	lastAccessTime time.Time
+	stopped        bool
+	immutable      bool
+	stopCh         chan struct{}
 }
 
 func (i *objectCacheItem) stop() bool {
 	i.lock.Lock()
 	defer i.lock.Unlock()
-	select {
-	case <-i.stopCh:
-		// This means that channel is already closed.
+	return i.stopThreadUnsafe()
+}
+
+func (i *objectCacheItem) stopThreadUnsafe() bool {
+	if i.stopped {
 		return false
-	default:
-		close(i.stopCh)
-		return true
 	}
+	i.stopped = true
+	close(i.stopCh)
+	if !i.immutable {
+		i.store.unsetInitialized()
+	}
+	return true
+}
+
+func (i *objectCacheItem) setLastAccessTime(time time.Time) {
+	i.lock.Lock()
+	defer i.lock.Unlock()
+	i.lastAccessTime = time
+}
+
+func (i *objectCacheItem) setImmutable() {
+	i.lock.Lock()
+	defer i.lock.Unlock()
+	i.immutable = true
+}
+
+func (i *objectCacheItem) stopIfIdle(now time.Time, maxIdleTime time.Duration) bool {
+	i.lock.Lock()
+	defer i.lock.Unlock()
+	if !i.stopped && now.After(i.lastAccessTime.Add(maxIdleTime)) {
+		return i.stopThreadUnsafe()
+	}
+	return false
+}
+
+func (i *objectCacheItem) restartReflectorIfNeeded() {
+	i.lock.Lock()
+	defer i.lock.Unlock()
+	if i.immutable || !i.stopped {
+		return
+	}
+	i.stopCh = make(chan struct{})
+	i.stopped = false
+	go i.startReflector()
+}
+
+func (i *objectCacheItem) startReflector() {
+	i.waitGroup.Wait()
+	i.waitGroup.Add(1)
+	defer i.waitGroup.Done()
+	i.reflector.Run(i.stopCh)
+}
+
+// cacheStore is in order to rewrite Replace function to mark initialized flag
+type cacheStore struct {
+	cache.Store
+	lock        sync.Mutex
+	initialized bool
+}
+
+func (c *cacheStore) Replace(list []interface{}, resourceVersion string) error {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	err := c.Store.Replace(list, resourceVersion)
+	if err != nil {
+		return err
+	}
+	c.initialized = true
+	return nil
+}
+
+func (c *cacheStore) hasSynced() bool {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	return c.initialized
+}
+
+func (c *cacheStore) unsetInitialized() {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	c.initialized = false
 }
 
 // objectCache is a local cache of objects propagated via
@@ -73,10 +157,14 @@ type objectCache struct {
 	newObject     newObjectFunc
 	isImmutable   isImmutableFunc
 	groupResource schema.GroupResource
+	clock         clock.Clock
+	maxIdleTime   time.Duration
 
 	lock  sync.RWMutex
 	items map[objectKey]*objectCacheItem
 }
+
+const minIdleTime = 1 * time.Minute
 
 // NewObjectCache returns a new watch-based instance of Store interface.
 func NewObjectCache(
@@ -84,24 +172,38 @@ func NewObjectCache(
 	watchObject watchObjectFunc,
 	newObject newObjectFunc,
 	isImmutable isImmutableFunc,
-	groupResource schema.GroupResource) Store {
-	return &objectCache{
+	groupResource schema.GroupResource,
+	clock clock.Clock,
+	maxIdleTime time.Duration) Store {
+
+	if maxIdleTime < minIdleTime {
+		maxIdleTime = minIdleTime
+	}
+
+	store := &objectCache{
 		listObject:    listObject,
 		watchObject:   watchObject,
 		newObject:     newObject,
 		isImmutable:   isImmutable,
 		groupResource: groupResource,
+		clock:         clock,
+		maxIdleTime:   maxIdleTime,
 		items:         make(map[objectKey]*objectCacheItem),
 	}
+
+	// TODO propagate stopCh from the higher level.
+	go wait.Until(store.startRecycleIdleWatch, time.Minute, wait.NeverStop)
+	return store
 }
 
-func (c *objectCache) newStore() cache.Store {
+func (c *objectCache) newStore() *cacheStore {
 	// TODO: We may consider created a dedicated store keeping just a single
 	// item, instead of using a generic store implementation for this purpose.
 	// However, simple benchmarks show that memory overhead in that case is
 	// decrease from ~600B to ~300B per object. So we are not optimizing it
 	// until we will see a good reason for that.
-	return cache.NewStore(cache.MetaNamespaceKeyFunc)
+	store := cache.NewStore(cache.MetaNamespaceKeyFunc)
+	return &cacheStore{store, sync.Mutex{}, false}
 }
 
 func (c *objectCache) newReflector(namespace, name string) *objectCacheItem {
@@ -122,14 +224,15 @@ func (c *objectCache) newReflector(namespace, name string) *objectCacheItem {
 		store,
 		0,
 	)
-	stopCh := make(chan struct{})
-	go reflector.Run(stopCh)
-	return &objectCacheItem{
+	item := &objectCacheItem{
 		refCount:  0,
 		store:     store,
-		hasSynced: func() (bool, error) { return reflector.LastSyncResourceVersion() != "", nil },
-		stopCh:    stopCh,
+		reflector: reflector,
+		hasSynced: func() (bool, error) { return store.hasSynced(), nil },
+		stopCh:    make(chan struct{}),
 	}
+	go item.startReflector()
+	return item
 }
 
 func (c *objectCache) AddReference(namespace, name string) {
@@ -184,10 +287,11 @@ func (c *objectCache) Get(namespace, name string) (runtime.Object, error) {
 	if !exists {
 		return nil, fmt.Errorf("object %q/%q not registered", namespace, name)
 	}
+	item.restartReflectorIfNeeded()
 	if err := wait.PollImmediate(10*time.Millisecond, time.Second, item.hasSynced); err != nil {
 		return nil, fmt.Errorf("failed to sync %s cache: %v", c.groupResource.String(), err)
 	}
-
+	item.setLastAccessTime(c.clock.Now())
 	obj, exists, err := item.store.GetByKey(c.key(namespace, name))
 	if err != nil {
 		return nil, err
@@ -207,6 +311,7 @@ func (c *objectCache) Get(namespace, name string) (runtime.Object, error) {
 		// - doing that would require significant refactoring to reflector
 		// we limit ourselves to just quickly stop the reflector here.
 		if c.isImmutable(object) {
+			item.setImmutable()
 			if item.stop() {
 				klog.V(4).Infof("Stopped watching for changes of %q/%q - object is immutable", namespace, name)
 			}
@@ -214,6 +319,17 @@ func (c *objectCache) Get(namespace, name string) (runtime.Object, error) {
 		return object, nil
 	}
 	return nil, fmt.Errorf("unexpected object type: %v", obj)
+}
+
+func (c *objectCache) startRecycleIdleWatch() {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	for key, item := range c.items {
+		if item.stopIfIdle(c.clock.Now(), c.maxIdleTime) {
+			klog.V(4).InfoS("Not acquired for long time, Stopped watching for changes", "objectKey", key, "maxIdleTime", c.maxIdleTime)
+		}
+	}
 }
 
 // NewWatchBasedManager creates a manager that keeps a cache of all objects
@@ -228,7 +344,15 @@ func NewWatchBasedManager(
 	newObject newObjectFunc,
 	isImmutable isImmutableFunc,
 	groupResource schema.GroupResource,
+	resyncInterval time.Duration,
 	getReferencedObjects func(*v1.Pod) sets.String) Manager {
-	objectStore := NewObjectCache(listObject, watchObject, newObject, isImmutable, groupResource)
+
+	// If a configmap/secret is used as a volume, the volumeManager will visit the objectCacheItem every resyncInterval cycle,
+	// We just want to stop the objectCacheItem referenced by environment variables,
+	// So, maxIdleTime is set to an integer multiple of resyncInterval,
+	// We currently set it to 5 times.
+	maxIdleTime := resyncInterval * 5
+
+	objectStore := NewObjectCache(listObject, watchObject, newObject, isImmutable, groupResource, clock.RealClock{}, maxIdleTime)
 	return NewCacheBasedManager(objectStore, getReferencedObjects)
 }

--- a/test/integration/kubelet/watch_manager_test.go
+++ b/test/integration/kubelet/watch_manager_test.go
@@ -27,6 +27,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/clock"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes"
@@ -61,7 +62,8 @@ func TestWatchBasedManager(t *testing.T) {
 	// We want all watches to be up and running to stress test it.
 	// So don't treat any secret as immutable here.
 	isImmutable := func(_ runtime.Object) bool { return false }
-	store := manager.NewObjectCache(listObj, watchObj, newObj, isImmutable, schema.GroupResource{Group: "v1", Resource: "secrets"})
+	fakeClock := clock.NewFakeClock(time.Now())
+	store := manager.NewObjectCache(listObj, watchObj, newObj, isImmutable, schema.GroupResource{Group: "v1", Resource: "secrets"}, fakeClock, time.Minute)
 
 	// create 1000 secrets in parallel
 	t.Log(time.Now(), "creating 1000 secrets")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
In a large cluster, if a large number of pods reference configmap/secret as environment variables, kubelet will generate a lot of watches for configmap and secret, and kube-apiserver will use too much memory due to too many watches.
Although we have added Immutable features, in real usage scenarios, many configmaps are not marked as Immutable.

#### Which issue(s) this PR fixes:
Fixes #98660 

#### Special notes for your reviewer:
@wojtek-t 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
When the kubelet is watching a ConfigMap or Secret purely in the context of setting environment variables
for containers, only hold that watch for a defined duration before cancelling it. This change reduces the CPU
and memory usage of the kube-apiserver in large clusters.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
