### PR TITLE
client-go: warn if no timeout was specified

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/clientset/versioned/BUILD
+++ b/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/clientset/versioned/BUILD
@@ -14,6 +14,7 @@ go_library(
         "//staging/src/k8s.io/client-go/discovery:go_default_library",
         "//staging/src/k8s.io/client-go/rest:go_default_library",
         "//staging/src/k8s.io/client-go/util/flowcontrol:go_default_library",
+        "//vendor/k8s.io/klog/v2:go_default_library",
     ],
 )
 

--- a/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/clientset/versioned/clientset.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/clientset/versioned/clientset.go
@@ -25,6 +25,7 @@ import (
 	discovery "k8s.io/client-go/discovery"
 	rest "k8s.io/client-go/rest"
 	flowcontrol "k8s.io/client-go/util/flowcontrol"
+	"k8s.io/klog/v2"
 )
 
 type Interface interface {
@@ -62,6 +63,9 @@ func NewForConfig(c *rest.Config) (*Clientset, error) {
 			return nil, fmt.Errorf("burst is required to be greater than 0 when RateLimiter is not set and QPS is set to greater than 0")
 		}
 		configShallowCopy.RateLimiter = flowcontrol.NewTokenBucketRateLimiter(configShallowCopy.QPS, configShallowCopy.Burst)
+	}
+	if c.Timeout == 0 {
+		klog.Warning("The provided config doesn't specify a timeout. The Timeout specifies a time limit for requests made by this client. Request without timeout can hang forever. Usually, it is a bad idea.")
 	}
 	var cs Clientset
 	var err error

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/BUILD
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/BUILD
@@ -19,6 +19,7 @@ go_library(
         "//staging/src/k8s.io/client-go/discovery:go_default_library",
         "//staging/src/k8s.io/client-go/rest:go_default_library",
         "//staging/src/k8s.io/client-go/util/flowcontrol:go_default_library",
+        "//vendor/k8s.io/klog/v2:go_default_library",
     ],
 )
 

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/clientset.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/clientset.go
@@ -26,6 +26,7 @@ import (
 	discovery "k8s.io/client-go/discovery"
 	rest "k8s.io/client-go/rest"
 	flowcontrol "k8s.io/client-go/util/flowcontrol"
+	"k8s.io/klog/v2"
 )
 
 type Interface interface {
@@ -70,6 +71,9 @@ func NewForConfig(c *rest.Config) (*Clientset, error) {
 			return nil, fmt.Errorf("burst is required to be greater than 0 when RateLimiter is not set and QPS is set to greater than 0")
 		}
 		configShallowCopy.RateLimiter = flowcontrol.NewTokenBucketRateLimiter(configShallowCopy.QPS, configShallowCopy.Burst)
+	}
+	if c.Timeout == 0 {
+		klog.Warning("The provided config doesn't specify a timeout. The Timeout specifies a time limit for requests made by this client. Request without timeout can hang forever. Usually, it is a bad idea.")
 	}
 	var cs Clientset
 	var err error

--- a/staging/src/k8s.io/client-go/kubernetes/BUILD
+++ b/staging/src/k8s.io/client-go/kubernetes/BUILD
@@ -56,6 +56,7 @@ go_library(
         "//staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1:go_default_library",
         "//staging/src/k8s.io/client-go/rest:go_default_library",
         "//staging/src/k8s.io/client-go/util/flowcontrol:go_default_library",
+        "//vendor/k8s.io/klog/v2:go_default_library",
     ],
 )
 

--- a/staging/src/k8s.io/client-go/kubernetes/clientset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/clientset.go
@@ -66,6 +66,7 @@ import (
 	storagev1beta1 "k8s.io/client-go/kubernetes/typed/storage/v1beta1"
 	rest "k8s.io/client-go/rest"
 	flowcontrol "k8s.io/client-go/util/flowcontrol"
+	"k8s.io/klog/v2"
 )
 
 type Interface interface {
@@ -390,6 +391,9 @@ func NewForConfig(c *rest.Config) (*Clientset, error) {
 			return nil, fmt.Errorf("burst is required to be greater than 0 when RateLimiter is not set and QPS is set to greater than 0")
 		}
 		configShallowCopy.RateLimiter = flowcontrol.NewTokenBucketRateLimiter(configShallowCopy.QPS, configShallowCopy.Burst)
+	}
+	if c.Timeout == 0 {
+		klog.Warning("The provided config doesn't specify a timeout. The Timeout specifies a time limit for requests made by this client. Request without timeout can hang forever. Usually, it is a bad idea.")
 	}
 	var cs Clientset
 	var err error

--- a/staging/src/k8s.io/code-generator/cmd/client-gen/generators/generator_for_clientset.go
+++ b/staging/src/k8s.io/code-generator/cmd/client-gen/generators/generator_for_clientset.go
@@ -63,6 +63,7 @@ func (g *genClientset) Imports(c *generator.Context) (imports []string) {
 			imports = append(imports, fmt.Sprintf("%s%s \"%s\"", groupAlias, strings.ToLower(version.NonEmpty()), typedClientPath))
 		}
 	}
+	imports = append(imports, "k8s.io/klog/v2")
 	return
 }
 
@@ -143,6 +144,9 @@ func NewForConfig(c *$.Config|raw$) (*Clientset, error) {
 			return nil, fmt.Errorf("burst is required to be greater than 0 when RateLimiter is not set and QPS is set to greater than 0")
 		}
 		configShallowCopy.RateLimiter = $.flowcontrolNewTokenBucketRateLimiter|raw$(configShallowCopy.QPS, configShallowCopy.Burst)
+	}
+    if c.Timeout == 0 {
+		klog.Warning("The provided config doesn't specify a timeout. The Timeout specifies a time limit for requests made by this client. Request without timeout can hang forever. Usually, it is a bad idea.")
 	}
 	var cs Clientset
 	var err error

--- a/staging/src/k8s.io/code-generator/examples/HyphenGroup/clientset/versioned/BUILD
+++ b/staging/src/k8s.io/code-generator/examples/HyphenGroup/clientset/versioned/BUILD
@@ -14,6 +14,7 @@ go_library(
         "//staging/src/k8s.io/client-go/rest:go_default_library",
         "//staging/src/k8s.io/client-go/util/flowcontrol:go_default_library",
         "//staging/src/k8s.io/code-generator/examples/HyphenGroup/clientset/versioned/typed/example/v1:go_default_library",
+        "//vendor/k8s.io/klog/v2:go_default_library",
     ],
 )
 

--- a/staging/src/k8s.io/code-generator/examples/HyphenGroup/clientset/versioned/clientset.go
+++ b/staging/src/k8s.io/code-generator/examples/HyphenGroup/clientset/versioned/clientset.go
@@ -25,6 +25,7 @@ import (
 	rest "k8s.io/client-go/rest"
 	flowcontrol "k8s.io/client-go/util/flowcontrol"
 	examplegroupv1 "k8s.io/code-generator/examples/HyphenGroup/clientset/versioned/typed/example/v1"
+	"k8s.io/klog/v2"
 )
 
 type Interface interface {
@@ -62,6 +63,9 @@ func NewForConfig(c *rest.Config) (*Clientset, error) {
 			return nil, fmt.Errorf("burst is required to be greater than 0 when RateLimiter is not set and QPS is set to greater than 0")
 		}
 		configShallowCopy.RateLimiter = flowcontrol.NewTokenBucketRateLimiter(configShallowCopy.QPS, configShallowCopy.Burst)
+	}
+	if c.Timeout == 0 {
+		klog.Warning("The provided config doesn't specify a timeout. The Timeout specifies a time limit for requests made by this client. Request without timeout can hang forever. Usually, it is a bad idea.")
 	}
 	var cs Clientset
 	var err error

--- a/staging/src/k8s.io/code-generator/examples/MixedCase/clientset/versioned/BUILD
+++ b/staging/src/k8s.io/code-generator/examples/MixedCase/clientset/versioned/BUILD
@@ -14,6 +14,7 @@ go_library(
         "//staging/src/k8s.io/client-go/rest:go_default_library",
         "//staging/src/k8s.io/client-go/util/flowcontrol:go_default_library",
         "//staging/src/k8s.io/code-generator/examples/MixedCase/clientset/versioned/typed/example/v1:go_default_library",
+        "//vendor/k8s.io/klog/v2:go_default_library",
     ],
 )
 

--- a/staging/src/k8s.io/code-generator/examples/MixedCase/clientset/versioned/clientset.go
+++ b/staging/src/k8s.io/code-generator/examples/MixedCase/clientset/versioned/clientset.go
@@ -25,6 +25,7 @@ import (
 	rest "k8s.io/client-go/rest"
 	flowcontrol "k8s.io/client-go/util/flowcontrol"
 	examplev1 "k8s.io/code-generator/examples/MixedCase/clientset/versioned/typed/example/v1"
+	"k8s.io/klog/v2"
 )
 
 type Interface interface {
@@ -62,6 +63,9 @@ func NewForConfig(c *rest.Config) (*Clientset, error) {
 			return nil, fmt.Errorf("burst is required to be greater than 0 when RateLimiter is not set and QPS is set to greater than 0")
 		}
 		configShallowCopy.RateLimiter = flowcontrol.NewTokenBucketRateLimiter(configShallowCopy.QPS, configShallowCopy.Burst)
+	}
+	if c.Timeout == 0 {
+		klog.Warning("The provided config doesn't specify a timeout. The Timeout specifies a time limit for requests made by this client. Request without timeout can hang forever. Usually, it is a bad idea.")
 	}
 	var cs Clientset
 	var err error

--- a/staging/src/k8s.io/code-generator/examples/apiserver/clientset/internalversion/BUILD
+++ b/staging/src/k8s.io/code-generator/examples/apiserver/clientset/internalversion/BUILD
@@ -16,6 +16,7 @@ go_library(
         "//staging/src/k8s.io/code-generator/examples/apiserver/clientset/internalversion/typed/example/internalversion:go_default_library",
         "//staging/src/k8s.io/code-generator/examples/apiserver/clientset/internalversion/typed/example2/internalversion:go_default_library",
         "//staging/src/k8s.io/code-generator/examples/apiserver/clientset/internalversion/typed/example3.io/internalversion:go_default_library",
+        "//vendor/k8s.io/klog/v2:go_default_library",
     ],
 )
 

--- a/staging/src/k8s.io/code-generator/examples/apiserver/clientset/internalversion/clientset.go
+++ b/staging/src/k8s.io/code-generator/examples/apiserver/clientset/internalversion/clientset.go
@@ -27,6 +27,7 @@ import (
 	exampleinternalversion "k8s.io/code-generator/examples/apiserver/clientset/internalversion/typed/example/internalversion"
 	secondexampleinternalversion "k8s.io/code-generator/examples/apiserver/clientset/internalversion/typed/example2/internalversion"
 	thirdexampleinternalversion "k8s.io/code-generator/examples/apiserver/clientset/internalversion/typed/example3.io/internalversion"
+	"k8s.io/klog/v2"
 )
 
 type Interface interface {
@@ -78,6 +79,9 @@ func NewForConfig(c *rest.Config) (*Clientset, error) {
 			return nil, fmt.Errorf("burst is required to be greater than 0 when RateLimiter is not set and QPS is set to greater than 0")
 		}
 		configShallowCopy.RateLimiter = flowcontrol.NewTokenBucketRateLimiter(configShallowCopy.QPS, configShallowCopy.Burst)
+	}
+	if c.Timeout == 0 {
+		klog.Warning("The provided config doesn't specify a timeout. The Timeout specifies a time limit for requests made by this client. Request without timeout can hang forever. Usually, it is a bad idea.")
 	}
 	var cs Clientset
 	var err error

--- a/staging/src/k8s.io/code-generator/examples/apiserver/clientset/versioned/BUILD
+++ b/staging/src/k8s.io/code-generator/examples/apiserver/clientset/versioned/BUILD
@@ -16,6 +16,7 @@ go_library(
         "//staging/src/k8s.io/code-generator/examples/apiserver/clientset/versioned/typed/example/v1:go_default_library",
         "//staging/src/k8s.io/code-generator/examples/apiserver/clientset/versioned/typed/example2/v1:go_default_library",
         "//staging/src/k8s.io/code-generator/examples/apiserver/clientset/versioned/typed/example3.io/v1:go_default_library",
+        "//vendor/k8s.io/klog/v2:go_default_library",
     ],
 )
 

--- a/staging/src/k8s.io/code-generator/examples/apiserver/clientset/versioned/clientset.go
+++ b/staging/src/k8s.io/code-generator/examples/apiserver/clientset/versioned/clientset.go
@@ -27,6 +27,7 @@ import (
 	examplev1 "k8s.io/code-generator/examples/apiserver/clientset/versioned/typed/example/v1"
 	secondexamplev1 "k8s.io/code-generator/examples/apiserver/clientset/versioned/typed/example2/v1"
 	thirdexamplev1 "k8s.io/code-generator/examples/apiserver/clientset/versioned/typed/example3.io/v1"
+	"k8s.io/klog/v2"
 )
 
 type Interface interface {
@@ -78,6 +79,9 @@ func NewForConfig(c *rest.Config) (*Clientset, error) {
 			return nil, fmt.Errorf("burst is required to be greater than 0 when RateLimiter is not set and QPS is set to greater than 0")
 		}
 		configShallowCopy.RateLimiter = flowcontrol.NewTokenBucketRateLimiter(configShallowCopy.QPS, configShallowCopy.Burst)
+	}
+	if c.Timeout == 0 {
+		klog.Warning("The provided config doesn't specify a timeout. The Timeout specifies a time limit for requests made by this client. Request without timeout can hang forever. Usually, it is a bad idea.")
 	}
 	var cs Clientset
 	var err error

--- a/staging/src/k8s.io/code-generator/examples/crd/clientset/versioned/BUILD
+++ b/staging/src/k8s.io/code-generator/examples/crd/clientset/versioned/BUILD
@@ -15,6 +15,7 @@ go_library(
         "//staging/src/k8s.io/client-go/util/flowcontrol:go_default_library",
         "//staging/src/k8s.io/code-generator/examples/crd/clientset/versioned/typed/example/v1:go_default_library",
         "//staging/src/k8s.io/code-generator/examples/crd/clientset/versioned/typed/example2/v1:go_default_library",
+        "//vendor/k8s.io/klog/v2:go_default_library",
     ],
 )
 

--- a/staging/src/k8s.io/code-generator/examples/crd/clientset/versioned/clientset.go
+++ b/staging/src/k8s.io/code-generator/examples/crd/clientset/versioned/clientset.go
@@ -26,6 +26,7 @@ import (
 	flowcontrol "k8s.io/client-go/util/flowcontrol"
 	examplev1 "k8s.io/code-generator/examples/crd/clientset/versioned/typed/example/v1"
 	secondexamplev1 "k8s.io/code-generator/examples/crd/clientset/versioned/typed/example2/v1"
+	"k8s.io/klog/v2"
 )
 
 type Interface interface {
@@ -70,6 +71,9 @@ func NewForConfig(c *rest.Config) (*Clientset, error) {
 			return nil, fmt.Errorf("burst is required to be greater than 0 when RateLimiter is not set and QPS is set to greater than 0")
 		}
 		configShallowCopy.RateLimiter = flowcontrol.NewTokenBucketRateLimiter(configShallowCopy.QPS, configShallowCopy.Burst)
+	}
+	if c.Timeout == 0 {
+		klog.Warning("The provided config doesn't specify a timeout. The Timeout specifies a time limit for requests made by this client. Request without timeout can hang forever. Usually, it is a bad idea.")
 	}
 	var cs Clientset
 	var err error

--- a/staging/src/k8s.io/code-generator/examples/go.mod
+++ b/staging/src/k8s.io/code-generator/examples/go.mod
@@ -9,6 +9,7 @@ require (
 	k8s.io/api v0.0.0
 	k8s.io/apimachinery v0.0.0
 	k8s.io/client-go v0.0.0
+	k8s.io/klog/v2 v2.5.0
 	k8s.io/kube-openapi v0.0.0-20201113171705-d219536bb9fd
 )
 

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/BUILD
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/BUILD
@@ -19,6 +19,7 @@ go_library(
         "//staging/src/k8s.io/client-go/util/flowcontrol:go_default_library",
         "//staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/typed/apiregistration/v1:go_default_library",
         "//staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/typed/apiregistration/v1beta1:go_default_library",
+        "//vendor/k8s.io/klog/v2:go_default_library",
     ],
 )
 

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/clientset.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/clientset.go
@@ -24,6 +24,7 @@ import (
 	discovery "k8s.io/client-go/discovery"
 	rest "k8s.io/client-go/rest"
 	flowcontrol "k8s.io/client-go/util/flowcontrol"
+	"k8s.io/klog/v2"
 	apiregistrationv1 "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/typed/apiregistration/v1"
 	apiregistrationv1beta1 "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/typed/apiregistration/v1beta1"
 )
@@ -70,6 +71,9 @@ func NewForConfig(c *rest.Config) (*Clientset, error) {
 			return nil, fmt.Errorf("burst is required to be greater than 0 when RateLimiter is not set and QPS is set to greater than 0")
 		}
 		configShallowCopy.RateLimiter = flowcontrol.NewTokenBucketRateLimiter(configShallowCopy.QPS, configShallowCopy.Burst)
+	}
+	if c.Timeout == 0 {
+		klog.Warning("The provided config doesn't specify a timeout. The Timeout specifies a time limit for requests made by this client. Request without timeout can hang forever. Usually, it is a bad idea.")
 	}
 	var cs Clientset
 	var err error

--- a/staging/src/k8s.io/metrics/go.mod
+++ b/staging/src/k8s.io/metrics/go.mod
@@ -11,6 +11,7 @@ require (
 	k8s.io/apimachinery v0.0.0
 	k8s.io/client-go v0.0.0
 	k8s.io/code-generator v0.0.0
+	k8s.io/klog/v2 v2.5.0
 )
 
 replace (

--- a/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/BUILD
+++ b/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/BUILD
@@ -15,6 +15,7 @@ go_library(
         "//staging/src/k8s.io/client-go/util/flowcontrol:go_default_library",
         "//staging/src/k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1alpha1:go_default_library",
         "//staging/src/k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1beta1:go_default_library",
+        "//vendor/k8s.io/klog/v2:go_default_library",
     ],
 )
 

--- a/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/clientset.go
+++ b/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/clientset.go
@@ -24,6 +24,7 @@ import (
 	discovery "k8s.io/client-go/discovery"
 	rest "k8s.io/client-go/rest"
 	flowcontrol "k8s.io/client-go/util/flowcontrol"
+	"k8s.io/klog/v2"
 	metricsv1alpha1 "k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1alpha1"
 	metricsv1beta1 "k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1beta1"
 )
@@ -70,6 +71,9 @@ func NewForConfig(c *rest.Config) (*Clientset, error) {
 			return nil, fmt.Errorf("burst is required to be greater than 0 when RateLimiter is not set and QPS is set to greater than 0")
 		}
 		configShallowCopy.RateLimiter = flowcontrol.NewTokenBucketRateLimiter(configShallowCopy.QPS, configShallowCopy.Burst)
+	}
+	if c.Timeout == 0 {
+		klog.Warning("The provided config doesn't specify a timeout. The Timeout specifies a time limit for requests made by this client. Request without timeout can hang forever. Usually, it is a bad idea.")
 	}
 	var cs Clientset
 	var err error

--- a/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/BUILD
+++ b/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/BUILD
@@ -15,6 +15,7 @@ go_library(
         "//staging/src/k8s.io/client-go/util/flowcontrol:go_default_library",
         "//staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/typed/wardle/v1alpha1:go_default_library",
         "//staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/typed/wardle/v1beta1:go_default_library",
+        "//vendor/k8s.io/klog/v2:go_default_library",
     ],
 )
 

--- a/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/clientset.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/clientset.go
@@ -24,6 +24,7 @@ import (
 	discovery "k8s.io/client-go/discovery"
 	rest "k8s.io/client-go/rest"
 	flowcontrol "k8s.io/client-go/util/flowcontrol"
+	"k8s.io/klog/v2"
 	wardlev1alpha1 "k8s.io/sample-apiserver/pkg/generated/clientset/versioned/typed/wardle/v1alpha1"
 	wardlev1beta1 "k8s.io/sample-apiserver/pkg/generated/clientset/versioned/typed/wardle/v1beta1"
 )
@@ -70,6 +71,9 @@ func NewForConfig(c *rest.Config) (*Clientset, error) {
 			return nil, fmt.Errorf("burst is required to be greater than 0 when RateLimiter is not set and QPS is set to greater than 0")
 		}
 		configShallowCopy.RateLimiter = flowcontrol.NewTokenBucketRateLimiter(configShallowCopy.QPS, configShallowCopy.Burst)
+	}
+	if c.Timeout == 0 {
+		klog.Warning("The provided config doesn't specify a timeout. The Timeout specifies a time limit for requests made by this client. Request without timeout can hang forever. Usually, it is a bad idea.")
 	}
 	var cs Clientset
 	var err error

--- a/staging/src/k8s.io/sample-controller/pkg/generated/clientset/versioned/BUILD
+++ b/staging/src/k8s.io/sample-controller/pkg/generated/clientset/versioned/BUILD
@@ -14,6 +14,7 @@ go_library(
         "//staging/src/k8s.io/client-go/rest:go_default_library",
         "//staging/src/k8s.io/client-go/util/flowcontrol:go_default_library",
         "//staging/src/k8s.io/sample-controller/pkg/generated/clientset/versioned/typed/samplecontroller/v1alpha1:go_default_library",
+        "//vendor/k8s.io/klog/v2:go_default_library",
     ],
 )
 

--- a/staging/src/k8s.io/sample-controller/pkg/generated/clientset/versioned/clientset.go
+++ b/staging/src/k8s.io/sample-controller/pkg/generated/clientset/versioned/clientset.go
@@ -24,6 +24,7 @@ import (
 	discovery "k8s.io/client-go/discovery"
 	rest "k8s.io/client-go/rest"
 	flowcontrol "k8s.io/client-go/util/flowcontrol"
+	"k8s.io/klog/v2"
 	samplecontrollerv1alpha1 "k8s.io/sample-controller/pkg/generated/clientset/versioned/typed/samplecontroller/v1alpha1"
 )
 
@@ -62,6 +63,9 @@ func NewForConfig(c *rest.Config) (*Clientset, error) {
 			return nil, fmt.Errorf("burst is required to be greater than 0 when RateLimiter is not set and QPS is set to greater than 0")
 		}
 		configShallowCopy.RateLimiter = flowcontrol.NewTokenBucketRateLimiter(configShallowCopy.QPS, configShallowCopy.Burst)
+	}
+	if c.Timeout == 0 {
+		klog.Warning("The provided config doesn't specify a timeout. The Timeout specifies a time limit for requests made by this client. Request without timeout can hang forever. Usually, it is a bad idea.")
 	}
 	var cs Clientset
 	var err error


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it: 
There were numerous cases in which core components didn't specify a timeout for outgoing requests. Usually, it is a bad idea. The Timeout specifies a time limit for requests made by client-go client. Request without timeout can hang forever. In extreme cases can even lead to starvation of an application. 

This PR changes client-go to warn users if there was no timeout specified.

ref:
https://github.com/kubernetes/kubernetes/pull/99358
https://github.com/kubernetes/kubernetes/pull/96217
https://github.com/kubernetes/kubernetes/pull/95725

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
