### PR TITLE
Align ownership of secret and configmap tests with sig-node

### DIFF
--- a/test/e2e/common/secrets.go
+++ b/test/e2e/common/secrets.go
@@ -33,7 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
-var _ = ginkgo.Describe("[sig-api-machinery] Secrets", func() {
+var _ = SIGNodeDescribe("Secrets", func() {
 	f := framework.NewDefaultFramework("secrets")
 
 	/*


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
Aligns ownership of common secret and configmap testing with sig-node.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:
@wojtek-t per discussion on slack in sig-node.


#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.: