### PR TITLE
csr: correctly handle backdating of short lived certs

### DIFF
--- a/cmd/kubelet/app/server_bootstrap_test.go
+++ b/cmd/kubelet/app/server_bootstrap_test.go
@@ -298,14 +298,14 @@ func (s *csrSimulator) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		ca := &authority.CertificateAuthority{
 			Certificate: s.serverCA,
 			PrivateKey:  s.serverPrivateKey,
-			Backdate:    s.backdate,
 		}
 		cr, err := capihelper.ParseCSR(csr.Spec.Request)
 		if err != nil {
 			t.Fatal(err)
 		}
 		der, err := ca.Sign(cr.Raw, authority.PermissiveSigningPolicy{
-			TTL: time.Hour,
+			TTL:      time.Hour,
+			Backdate: s.backdate,
 		})
 		if err != nil {
 			t.Fatal(err)

--- a/pkg/controller/certificates/authority/authority_test.go
+++ b/pkg/controller/certificates/authority/authority_test.go
@@ -40,6 +40,7 @@ func TestCertificateAuthority(t *testing.T) {
 		t.Fatal(err)
 	}
 	now := time.Now()
+	nowFunc := func() time.Time { return now }
 	tmpl := &x509.Certificate{
 		SerialNumber: big.NewInt(42),
 		Subject: pkix.Name{
@@ -68,15 +69,15 @@ func TestCertificateAuthority(t *testing.T) {
 	tests := []struct {
 		name     string
 		cr       x509.CertificateRequest
-		backdate time.Duration
 		policy   SigningPolicy
+		mutateCA func(ca *CertificateAuthority)
 
 		want    x509.Certificate
-		wantErr bool
+		wantErr string
 	}{
 		{
 			name:   "ca info",
-			policy: PermissiveSigningPolicy{TTL: time.Hour},
+			policy: PermissiveSigningPolicy{TTL: time.Hour, Now: nowFunc},
 			want: x509.Certificate{
 				Issuer:                caCert.Subject,
 				AuthorityKeyId:        caCert.SubjectKeyId,
@@ -87,7 +88,7 @@ func TestCertificateAuthority(t *testing.T) {
 		},
 		{
 			name:   "key usage",
-			policy: PermissiveSigningPolicy{TTL: time.Hour, Usages: []capi.KeyUsage{"signing"}},
+			policy: PermissiveSigningPolicy{TTL: time.Hour, Usages: []capi.KeyUsage{"signing"}, Now: nowFunc},
 			want: x509.Certificate{
 				NotBefore:             now,
 				NotAfter:              now.Add(1 * time.Hour),
@@ -97,7 +98,7 @@ func TestCertificateAuthority(t *testing.T) {
 		},
 		{
 			name:   "ext key usage",
-			policy: PermissiveSigningPolicy{TTL: time.Hour, Usages: []capi.KeyUsage{"client auth"}},
+			policy: PermissiveSigningPolicy{TTL: time.Hour, Usages: []capi.KeyUsage{"client auth"}, Now: nowFunc},
 			want: x509.Certificate{
 				NotBefore:             now,
 				NotAfter:              now.Add(1 * time.Hour),
@@ -106,9 +107,8 @@ func TestCertificateAuthority(t *testing.T) {
 			},
 		},
 		{
-			name:     "backdate",
-			policy:   PermissiveSigningPolicy{TTL: time.Hour},
-			backdate: 5 * time.Minute,
+			name:   "backdate without short",
+			policy: PermissiveSigningPolicy{TTL: time.Hour, Backdate: 5 * time.Minute, Now: nowFunc},
 			want: x509.Certificate{
 				NotBefore:             now.Add(-5 * time.Minute),
 				NotAfter:              now.Add(55 * time.Minute),
@@ -116,8 +116,44 @@ func TestCertificateAuthority(t *testing.T) {
 			},
 		},
 		{
+			name:   "backdate without short and super small ttl",
+			policy: PermissiveSigningPolicy{TTL: time.Minute, Backdate: 5 * time.Minute, Now: nowFunc},
+			want: x509.Certificate{
+				NotBefore:             now.Add(-5 * time.Minute),
+				NotAfter:              now.Add(-4 * time.Minute),
+				BasicConstraintsValid: true,
+			},
+		},
+		{
+			name:   "backdate with short",
+			policy: PermissiveSigningPolicy{TTL: time.Hour, Backdate: 5 * time.Minute, Short: 8 * time.Hour, Now: nowFunc},
+			want: x509.Certificate{
+				NotBefore:             now.Add(-5 * time.Minute),
+				NotAfter:              now.Add(time.Hour),
+				BasicConstraintsValid: true,
+			},
+		},
+		{
+			name:   "backdate with short and super small ttl",
+			policy: PermissiveSigningPolicy{TTL: time.Minute, Backdate: 5 * time.Minute, Short: 8 * time.Hour, Now: nowFunc},
+			want: x509.Certificate{
+				NotBefore:             now.Add(-5 * time.Minute),
+				NotAfter:              now.Add(time.Minute),
+				BasicConstraintsValid: true,
+			},
+		},
+		{
+			name:   "backdate with short but longer ttl",
+			policy: PermissiveSigningPolicy{TTL: 24 * time.Hour, Backdate: 5 * time.Minute, Short: 8 * time.Hour, Now: nowFunc},
+			want: x509.Certificate{
+				NotBefore:             now.Add(-5 * time.Minute),
+				NotAfter:              now.Add(24*time.Hour - 5*time.Minute),
+				BasicConstraintsValid: true,
+			},
+		},
+		{
 			name:   "truncate expiration",
-			policy: PermissiveSigningPolicy{TTL: 48 * time.Hour},
+			policy: PermissiveSigningPolicy{TTL: 48 * time.Hour, Now: nowFunc},
 			want: x509.Certificate{
 				NotBefore:             now,
 				NotAfter:              now.Add(24 * time.Hour),
@@ -126,7 +162,7 @@ func TestCertificateAuthority(t *testing.T) {
 		},
 		{
 			name:   "uri sans",
-			policy: PermissiveSigningPolicy{TTL: time.Hour},
+			policy: PermissiveSigningPolicy{TTL: time.Hour, Now: nowFunc},
 			cr: x509.CertificateRequest{
 				URIs: []*url.URL{uri},
 			},
@@ -137,6 +173,22 @@ func TestCertificateAuthority(t *testing.T) {
 				BasicConstraintsValid: true,
 			},
 		},
+		{
+			name:   "expired ca",
+			policy: PermissiveSigningPolicy{TTL: time.Hour, Now: nowFunc},
+			mutateCA: func(ca *CertificateAuthority) {
+				ca.Certificate.NotAfter = now // pretend that the CA has expired
+			},
+			wantErr: "the signer has expired: NotAfter=" + now.String(),
+		},
+		{
+			name:   "expired ca with backdate",
+			policy: PermissiveSigningPolicy{TTL: time.Hour, Backdate: 5 * time.Minute, Now: nowFunc},
+			mutateCA: func(ca *CertificateAuthority) {
+				ca.Certificate.NotAfter = now // pretend that the CA has expired
+			},
+			wantErr: "refusing to sign a certificate that expired in the past: NotAfter=" + now.String(),
+		},
 	}
 
 	crKey, err := ecdsa.GenerateKey(elliptic.P224(), rand.Reader)
@@ -146,13 +198,15 @@ func TestCertificateAuthority(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			caCertShallowCopy := *caCert
+
 			ca := &CertificateAuthority{
-				Certificate: caCert,
+				Certificate: &caCertShallowCopy,
 				PrivateKey:  caKey,
-				Now: func() time.Time {
-					return now
-				},
-				Backdate: test.backdate,
+			}
+
+			if test.mutateCA != nil {
+				test.mutateCA(ca)
 			}
 
 			csr, err := x509.CreateCertificateRequest(rand.Reader, &test.cr, crKey)
@@ -161,14 +215,14 @@ func TestCertificateAuthority(t *testing.T) {
 			}
 
 			certDER, err := ca.Sign(csr, test.policy)
-			if err != nil {
-				t.Fatal(err)
-			}
-			if test.wantErr {
-				if err == nil {
-					t.Fatal("expected error")
+			if len(test.wantErr) > 0 {
+				if errStr := errString(err); test.wantErr != errStr {
+					t.Fatalf("expected error %s but got %s", test.wantErr, errStr)
 				}
 				return
+			}
+			if err != nil {
+				t.Fatal(err)
 			}
 
 			cert, err := x509.ParseCertificate(certDER)
@@ -196,4 +250,12 @@ func TestCertificateAuthority(t *testing.T) {
 			}
 		})
 	}
+}
+
+func errString(err error) string {
+	if err == nil {
+		return ""
+	}
+
+	return err.Error()
 }

--- a/pkg/controller/certificates/authority/policies.go
+++ b/pkg/controller/certificates/authority/policies.go
@@ -31,7 +31,7 @@ import (
 type SigningPolicy interface {
 	// not-exporting apply forces signing policy implementations to be internal
 	// to this package.
-	apply(template *x509.Certificate) error
+	apply(template *x509.Certificate, signerNotAfter time.Time) error
 }
 
 // PermissiveSigningPolicy is the signing policy historically used by the local
@@ -39,31 +39,74 @@ type SigningPolicy interface {
 //
 //  * It forwards all SANs from the original signing request.
 //  * It sets allowed usages as configured in the policy.
-//  * It sets NotAfter based on the TTL configured in the policy.
 //  * It zeros all extensions.
 //  * It sets BasicConstraints to true.
 //  * It sets IsCA to false.
+//  * It validates that the signer has not expired.
+//  * It sets NotBefore and NotAfter:
+//    All certificates set NotBefore = Now() - Backdate.
+//    Long-lived certificates set NotAfter = Now() + TTL - Backdate.
+//    Short-lived certificates set NotAfter = Now() + TTL.
+//    All certificates truncate NotAfter to the expiration date of the signer.
 type PermissiveSigningPolicy struct {
-	// TTL is the certificate TTL. It's used to calculate the NotAfter value of
-	// the certificate.
+	// TTL is used in certificate NotAfter calculation as described above.
 	TTL time.Duration
+
 	// Usages are the allowed usages of a certificate.
 	Usages []capi.KeyUsage
+
+	// Backdate is used in certificate NotBefore calculation as described above.
+	Backdate time.Duration
+
+	// Short is the duration used to determine if the lifetime of a certificate should be considered short.
+	Short time.Duration
+
+	// Now defaults to time.Now but can be stubbed for testing
+	Now func() time.Time
 }
 
-func (p PermissiveSigningPolicy) apply(tmpl *x509.Certificate) error {
+func (p PermissiveSigningPolicy) apply(tmpl *x509.Certificate, signerNotAfter time.Time) error {
+	var now time.Time
+	if p.Now != nil {
+		now = p.Now()
+	} else {
+		now = time.Now()
+	}
+
+	ttl := p.TTL
+
 	usage, extUsages, err := keyUsagesFromStrings(p.Usages)
 	if err != nil {
 		return err
 	}
 	tmpl.KeyUsage = usage
 	tmpl.ExtKeyUsage = extUsages
-	tmpl.NotAfter = tmpl.NotBefore.Add(p.TTL)
 
 	tmpl.ExtraExtensions = nil
 	tmpl.Extensions = nil
 	tmpl.BasicConstraintsValid = true
 	tmpl.IsCA = false
+
+	tmpl.NotBefore = now.Add(-p.Backdate)
+
+	if ttl < p.Short {
+		// do not backdate the end time if we consider this to be a short lived certificate
+		tmpl.NotAfter = now.Add(ttl)
+	} else {
+		tmpl.NotAfter = now.Add(ttl - p.Backdate)
+	}
+
+	if !tmpl.NotAfter.Before(signerNotAfter) {
+		tmpl.NotAfter = signerNotAfter
+	}
+
+	if !tmpl.NotBefore.Before(signerNotAfter) {
+		return fmt.Errorf("the signer has expired: NotAfter=%v", signerNotAfter)
+	}
+
+	if !now.Before(signerNotAfter) {
+		return fmt.Errorf("refusing to sign a certificate that expired in the past: NotAfter=%v", signerNotAfter)
+	}
 
 	return nil
 }
@@ -124,7 +167,7 @@ func keyUsagesFromStrings(usages []capi.KeyUsage) (x509.KeyUsage, []x509.ExtKeyU
 		return 0, nil, fmt.Errorf("unrecognized usage values: %q", unrecognized)
 	}
 
-	return keyUsage, []x509.ExtKeyUsage(sorted), nil
+	return keyUsage, sorted, nil
 }
 
 type sortedExtKeyUsage []x509.ExtKeyUsage

--- a/pkg/controller/certificates/signer/ca_provider.go
+++ b/pkg/controller/certificates/signer/ca_provider.go
@@ -21,7 +21,6 @@ import (
 	"crypto"
 	"fmt"
 	"sync/atomic"
-	"time"
 
 	"k8s.io/apiserver/pkg/server/dynamiccertificates"
 	"k8s.io/client-go/util/cert"
@@ -77,7 +76,6 @@ func (p *caProvider) setCA() error {
 
 		Certificate: certs[0],
 		PrivateKey:  priv,
-		Backdate:    5 * time.Minute,
 	}
 	p.caValue.Store(ca)
 


### PR DESCRIPTION
This change updates the backdating logic to only be applied to the
NotBefore date and not the NotAfter date when the certificate is
short lived. Thus when such a certificate is issued, it will not be
immediately expired.  Long lived certificates continue to have the
same lifetime as before.

Consolidated all certificate lifetime logic into the
PermissiveSigningPolicy.policy method.

Signed-off-by: Monis Khan <mok@vmware.com>

/kind bug
/sig auth
/priority important-longterm
/triage accepted
/milestone v1.22
@kubernetes/sig-auth-pr-reviews 

```release-note
NONE
```