### PR TITLE
add feature gate ControllerManagerLeaderMigration

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -663,6 +663,12 @@ const (
 	//
 	// Enables the usage of different protocols in the same Service with type=LoadBalancer
 	MixedProtocolLBService featuregate.Feature = "MixedProtocolLBService"
+
+	// owner: @jiahuif
+	// alpha: v1.21
+	//
+	// Enables Leader Migration for kube-controller-manager and cloud-controller-manager
+	ControllerManagerLeaderMigration featuregate.Feature = "ControllerManagerLeaderMigration"
 )
 
 func init() {
@@ -763,6 +769,7 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 	MixedProtocolLBService:                         {Default: false, PreRelease: featuregate.Alpha},
 	PreferNominatedNode:                            {Default: false, PreRelease: featuregate.Alpha},
 	RunAsGroup:                                     {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.22
+	ControllerManagerLeaderMigration:               {Default: false, PreRelease: featuregate.Alpha},
 
 	// inherited features from generic apiserver, relisted here to get a conflict if it is changed
 	// unintentionally on either side:


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
This PR is split from 96541 that add the required feature gate of KEP-2436 (https://github.com/kubernetes/enhancements/issues/2436)
The reason of splitting is that changes to features have different owners than the original PR.
#### Special notes for your reviewer:

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

- KEP: https://github.com/kubernetes/enhancements/tree/master/keps/sig-cloud-provider/2436-controller-manager-leader-migration

```yaml
# https://github.com/kubernetes/enhancements/blob/d7f1a349bd377e1a476e5634c27933139fd0fafe/keps/sig-cloud-provider/2436-controller-manager-leader-migration/kep.yaml#L39

# List the feature gate name and the components for which it must be enabled
feature-gates:
  - name: ControllerManagerLeaderMigration
    components:
      - cloud-controller-manager
      - kube-controller-manager
disable-supported: true

```
