### PR TITLE
csr signers: increase the number of workers

### DIFF
--- a/cmd/kube-controller-manager/app/certificates.go
+++ b/cmd/kube-controller-manager/app/certificates.go
@@ -57,7 +57,7 @@ func startCSRSigningController(ctx ControllerContext) (http.Handler, bool, error
 		if err != nil {
 			return nil, false, fmt.Errorf("failed to start kubernetes.io/kubelet-serving certificate controller: %v", err)
 		}
-		go kubeletServingSigner.Run(1, ctx.Stop)
+		go kubeletServingSigner.Run(5, ctx.Stop)
 	} else {
 		klog.V(2).Infof("skipping CSR signer controller %q because specific files were specified for other signers and not this one.", "kubernetes.io/kubelet-serving")
 	}
@@ -67,7 +67,7 @@ func startCSRSigningController(ctx ControllerContext) (http.Handler, bool, error
 		if err != nil {
 			return nil, false, fmt.Errorf("failed to start kubernetes.io/kube-apiserver-client-kubelet certificate controller: %v", err)
 		}
-		go kubeletClientSigner.Run(1, ctx.Stop)
+		go kubeletClientSigner.Run(5, ctx.Stop)
 	} else {
 		klog.V(2).Infof("skipping CSR signer controller %q because specific files were specified for other signers and not this one.", "kubernetes.io/kube-apiserver-client-kubelet")
 	}
@@ -77,7 +77,7 @@ func startCSRSigningController(ctx ControllerContext) (http.Handler, bool, error
 		if err != nil {
 			return nil, false, fmt.Errorf("failed to start kubernetes.io/kube-apiserver-client certificate controller: %v", err)
 		}
-		go kubeAPIServerClientSigner.Run(1, ctx.Stop)
+		go kubeAPIServerClientSigner.Run(5, ctx.Stop)
 	} else {
 		klog.V(2).Infof("skipping CSR signer controller %q because specific files were specified for other signers and not this one.", "kubernetes.io/kube-apiserver-client")
 	}
@@ -87,7 +87,7 @@ func startCSRSigningController(ctx ControllerContext) (http.Handler, bool, error
 		if err != nil {
 			return nil, false, fmt.Errorf("failed to start kubernetes.io/legacy-unknown certificate controller: %v", err)
 		}
-		go legacyUnknownSigner.Run(1, ctx.Stop)
+		go legacyUnknownSigner.Run(5, ctx.Stop)
 	} else {
 		klog.V(2).Infof("skipping CSR signer controller %q because specific files were specified for other signers and not this one.", "kubernetes.io/legacy-unknown")
 	}
@@ -176,7 +176,7 @@ func startCSRApprovingController(ctx ControllerContext) (http.Handler, bool, err
 		ctx.ClientBuilder.ClientOrDie("certificate-controller"),
 		ctx.InformerFactory.Certificates().V1().CertificateSigningRequests(),
 	)
-	go approver.Run(1, ctx.Stop)
+	go approver.Run(5, ctx.Stop)
 
 	return nil, true, nil
 }


### PR DESCRIPTION
This change updates the number of workers that the CSR signing
controllers use.  If a large number of certificates (especially
short lived ones) are approved at the same time, it can take the
signing controllers a long time to process them serially.  The
NewCSRSigningController logic is already go routine safe.

Signed-off-by: Monis Khan <mok@vmware.com>

/kind bug
/sig auth
/priority important-longterm
/triage accepted
/milestone v1.21
@kubernetes/sig-auth-pr-reviews 

```release-note
NONE
```