### PR TITLE
Use GA topology labels for Azuredisk

### DIFF
--- a/pkg/volume/azuredd/azure_provision.go
+++ b/pkg/volume/azuredd/azure_provision.go
@@ -361,19 +361,19 @@ func (p *azureDiskProvisioner) Provision(selectedNode *v1.Node, allowedTopologie
 			})
 		}
 	} else {
-		// Set node affinity labels based on fault domains.
+		// Set node affinity labels based on topology.
 		// This is required because unzoned AzureDisk can't be attached to zoned nodes.
-		// There are at most 3 fault domains available in each region.
+		// There are at most 3 Availability Zones per supported Azure region.
 		// Refer https://docs.microsoft.com/en-us/azure/virtual-machines/windows/manage-availability.
 		for i := 0; i < 3; i++ {
 			requirements := []v1.NodeSelectorRequirement{
 				{
-					Key:      v1.LabelFailureDomainBetaRegion,
+					Key:      v1.LabelTopologyRegion,
 					Operator: v1.NodeSelectorOpIn,
 					Values:   []string{diskController.GetLocation()},
 				},
 				{
-					Key:      v1.LabelFailureDomainBetaZone,
+					Key:      v1.LabelTopologyZone,
 					Operator: v1.NodeSelectorOpIn,
 					Values:   []string{strconv.Itoa(i)},
 				},

--- a/staging/src/k8s.io/csi-translation-lib/plugins/azure_disk_test.go
+++ b/staging/src/k8s.io/csi-translation-lib/plugins/azure_disk_test.go
@@ -269,7 +269,7 @@ func TestTranslateInTreeStorageClassToCSI(t *testing.T) {
 		},
 		{
 			name:       "some translated topology",
-			options:    NewStorageClass(map[string]string{}, generateToplogySelectors(v1.LabelFailureDomainBetaZone, []string{"foo"})),
+			options:    NewStorageClass(map[string]string{}, generateToplogySelectors(v1.LabelTopologyZone, []string{"foo"})),
 			expOptions: NewStorageClass(map[string]string{}, generateToplogySelectors(AzureDiskTopologyKey, []string{"foo"})),
 		},
 		{

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure.go
@@ -92,12 +92,6 @@ const (
 
 	externalResourceGroupLabel = "kubernetes.azure.com/resource-group"
 	managedByAzureLabel        = "kubernetes.azure.com/managed"
-
-	// LabelFailureDomainBetaZone refer to https://github.com/kubernetes/api/blob/8519c5ea46199d57724725d5b969c5e8e0533692/core/v1/well_known_labels.go#L22-L23
-	LabelFailureDomainBetaZone = "failure-domain.beta.kubernetes.io/zone"
-
-	// LabelFailureDomainBetaRegion failure-domain region label
-	LabelFailureDomainBetaRegion = "failure-domain.beta.kubernetes.io/region"
 )
 
 const (
@@ -751,8 +745,12 @@ func (az *Cloud) SetInformers(informerFactory informers.SharedInformerFactory) {
 		UpdateFunc: func(prev, obj interface{}) {
 			prevNode := prev.(*v1.Node)
 			newNode := obj.(*v1.Node)
-			if newNode.Labels[LabelFailureDomainBetaZone] ==
-				prevNode.Labels[LabelFailureDomainBetaZone] {
+			if newNode.Labels[v1.LabelFailureDomainBetaZone] ==
+				prevNode.Labels[v1.LabelFailureDomainBetaZone] {
+				return
+			}
+			if newNode.Labels[v1.LabelTopologyZone] ==
+				prevNode.Labels[v1.LabelTopologyZone] {
 				return
 			}
 			az.updateNodeCaches(prevNode, newNode)
@@ -785,12 +783,23 @@ func (az *Cloud) updateNodeCaches(prevNode, newNode *v1.Node) {
 	defer az.nodeCachesLock.Unlock()
 
 	if prevNode != nil {
+
 		// Remove from nodeNames cache.
 		az.nodeNames.Delete(prevNode.ObjectMeta.Name)
 
-		// Remove from nodeZones cache.
-		prevZone, ok := prevNode.ObjectMeta.Labels[LabelFailureDomainBetaZone]
+		// Remove from nodeZones cache
+		prevZone, ok := prevNode.ObjectMeta.Labels[v1.LabelTopologyZone]
+
 		if ok && az.isAvailabilityZone(prevZone) {
+			az.nodeZones[prevZone].Delete(prevNode.ObjectMeta.Name)
+			if az.nodeZones[prevZone].Len() == 0 {
+				az.nodeZones[prevZone] = nil
+			}
+		}
+
+		//Remove from nodeZones cache if using depreciated LabelFailureDomainBetaZone
+		prevZoneFailureDomain, ok := prevNode.ObjectMeta.Labels[v1.LabelFailureDomainBetaZone]
+		if ok && az.isAvailabilityZone(prevZoneFailureDomain) {
 			az.nodeZones[prevZone].Delete(prevNode.ObjectMeta.Name)
 			if az.nodeZones[prevZone].Len() == 0 {
 				az.nodeZones[prevZone] = nil
@@ -815,7 +824,7 @@ func (az *Cloud) updateNodeCaches(prevNode, newNode *v1.Node) {
 		az.nodeNames.Insert(newNode.ObjectMeta.Name)
 
 		// Add to nodeZones cache.
-		newZone, ok := newNode.ObjectMeta.Labels[LabelFailureDomainBetaZone]
+		newZone, ok := newNode.ObjectMeta.Labels[v1.LabelTopologyZone]
 		if ok && az.isAvailabilityZone(newZone) {
 			if az.nodeZones[newZone] == nil {
 				az.nodeZones[newZone] = sets.NewString()

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_managedDiskController.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_managedDiskController.go
@@ -355,7 +355,7 @@ func (c *Cloud) GetAzureDiskLabels(diskURI string) (map[string]string, error) {
 	}
 
 	labels := map[string]string{
-		LabelFailureDomainBetaRegion: c.Location,
+		v1.LabelTopologyRegion: c.Location,
 	}
 	// no azure credential is set, return nil
 	if c.DisksClient == nil {
@@ -384,6 +384,6 @@ func (c *Cloud) GetAzureDiskLabels(diskURI string) (map[string]string, error) {
 
 	zone := c.makeZone(c.Location, zoneID)
 	klog.V(4).Infof("Got zone %q for Azure disk %q", zone, diskName)
-	labels[LabelFailureDomainBetaZone] = zone
+	labels[v1.LabelTopologyZone] = zone
 	return labels, nil
 }

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_managedDiskController_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_managedDiskController_test.go
@@ -427,8 +427,8 @@ func TestGetLabelsForVolume(t *testing.T) {
 			},
 			existedDisk: compute.Disk{Name: to.StringPtr(diskName), DiskProperties: &compute.DiskProperties{DiskSizeGB: &diskSizeGB}, Zones: &[]string{"1"}},
 			expected: map[string]string{
-				LabelFailureDomainBetaRegion: testCloud0.Location,
-				LabelFailureDomainBetaZone:   testCloud0.makeZone(testCloud0.Location, 1),
+				v1.LabelTopologyRegion: testCloud0.Location,
+				v1.LabelTopologyZone:   testCloud0.makeZone(testCloud0.Location, 1),
 			},
 			expectedErr: false,
 		},
@@ -464,7 +464,7 @@ func TestGetLabelsForVolume(t *testing.T) {
 			},
 			existedDisk: compute.Disk{Name: to.StringPtr(diskName), DiskProperties: &compute.DiskProperties{DiskSizeGB: &diskSizeGB}},
 			expected: map[string]string{
-				LabelFailureDomainBetaRegion: testCloud0.Location,
+				v1.LabelTopologyRegion: testCloud0.Location,
 			},
 			expectedErr:    false,
 			expectedErrMsg: nil,

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_test.go
@@ -3249,9 +3249,10 @@ func TestUpdateNodeCaches(t *testing.T) {
 	prevNode := v1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Labels: map[string]string{
-				LabelFailureDomainBetaZone: zone,
-				externalResourceGroupLabel: "true",
-				managedByAzureLabel:        "false",
+				v1.LabelFailureDomainBetaZone: zone,
+				v1.LabelTopologyZone:          zone,
+				externalResourceGroupLabel:    "true",
+				managedByAzureLabel:           "false",
 			},
 			Name: "prevNode",
 		},
@@ -3266,7 +3267,7 @@ func TestUpdateNodeCaches(t *testing.T) {
 	newNode := v1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Labels: map[string]string{
-				LabelFailureDomainBetaZone: zone,
+				v1.LabelTopologyZone:       zone,
 				externalResourceGroupLabel: "true",
 				managedByAzureLabel:        "false",
 			},


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
Similar to #98700, this PR replaces the deprecated topology labels in favor of the new GA ones for Azure disk

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #98281 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```
[ACTION REQUIRED] Newly provisioned PVs by Azure disk will no longer have the beta FailureDomain label. Azure disk volume plugin will start to have GA topology label instead.

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```

```
