### PR TITLE
fix nil error e2e/network/kube_proxy.go

### DIFF
--- a/test/e2e/network/kube_proxy.go
+++ b/test/e2e/network/kube_proxy.go
@@ -235,9 +235,9 @@ var _ = SIGDescribe("KubeProxy", func() {
 			return false, fmt.Errorf("wrong TCP CLOSE_WAIT timeout: %v expected: %v", timeoutSeconds, expectedTimeoutSeconds)
 		}); err != nil {
 			// Dump all conntrack entries for debugging
-			result, err := framework.RunHostCmd(fr.Namespace.Name, "e2e-net-exec", "conntrack -L")
-			if err != nil {
-				framework.Logf("failed to obtain conntrack entry: %v %v", result, err)
+			result, err2 := framework.RunHostCmd(fr.Namespace.Name, "e2e-net-exec", "conntrack -L")
+			if err2 != nil {
+				framework.Logf("failed to obtain conntrack entry: %v %v", result, err2)
 			}
 			framework.Logf("conntrack entries for node %v:  %v", serverNodeInfo.nodeIP, result)
 			framework.Failf("no valid conntrack entry for port %d on node %s: %v", testDaemonTCPPort, serverNodeInfo.nodeIP, err)


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/99390/pull-kubernetes-e2e-kind-ipv6/1364774798772670464

>  Failure [284.407 seconds]
> [sig-network] KubeProxy
> /home/prow/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:23
>   should set TCP CLOSE_WAIT timeout [Privileged] [It]
>   /home/prow/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/test/e2e/network/kube_proxy.go:52
>   Feb 25 03:39:45.911: no valid conntrack entry for port 11302 on node fc00:f853:ccd:e793::2: <nil> ​

The original error message is missing here.
It makes me no way to dig into the flake here.

#### Which issue(s) this PR fixes:

#### Does this PR introduce a user-facing change?

```release-note
None
```