### PR TITLE
test: fix skipping of GenericEphemeralVolume volume type

### DIFF
--- a/test/e2e/storage/external/external.go
+++ b/test/e2e/storage/external/external.go
@@ -244,7 +244,7 @@ func (d *driverDefinition) SkipUnsupportedTest(pattern storageframework.TestPatt
 	switch pattern.VolType {
 	case "":
 		supported = true
-	case storageframework.DynamicPV:
+	case storageframework.DynamicPV, storageframework.GenericEphemeralVolume:
 		if d.StorageClass.FromName || d.StorageClass.FromFile != "" || d.StorageClass.FromExistingClassName != "" {
 			supported = true
 		}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind failing-test

#### What this PR does / why we need it:

The test should run for test drivers which support dynamic
provisioning, but was skipped because of the volume type check:

```
External Storage [Driver: hostpath.csi.k8s.io]
[90m/home/prow/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/test/e2e/storage/external/external.go:175
  [Testpattern: Generic Ephemeral-volume (default fs) [Feature:GenericEphemeralVolume] (late-binding)] ephemeral
  [90m/home/prow/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/test/e2e/storage/framework/testsuite.go:50
    [36m[1mshould support multiple inline ephemeral volumes [BeforeEach]
    [90m/home/prow/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/test/e2e/storage/testsuites/ephemeral.go:211

    [36mDriver "hostpath.csi.k8s.io" does not support volume type "GenericEphemeralVolume" - skipping

    /home/prow/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/test/e2e/storage/external/external.go:255
```

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
