### PR TITLE
Revert "tests: Set a 5 minute timeout for kubectl cluster-info dump"

### DIFF
--- a/test/e2e/kubectl/kubectl.go
+++ b/test/e2e/kubectl/kubectl.go
@@ -1083,12 +1083,7 @@ metadata:
 	ginkgo.Describe("Kubectl cluster-info dump", func() {
 		ginkgo.It("should check if cluster-info dump succeeds", func() {
 			ginkgo.By("running cluster-info dump")
-
-			// Should return in a timely fashion (or we should mark the test slow)
-			timer := time.NewTimer(300 * time.Second)
-			defer timer.Stop()
-
-			framework.NewKubectlCommand(ns, "cluster-info", "dump").WithTimeout(timer.C).ExecOrDie(ns)
+			framework.RunKubectlOrDie(ns, "cluster-info", "dump")
 		})
 	})
 


### PR DESCRIPTION
This reverts #99107 due to #99449

#### What type of PR is this?
/kind bug
/kind failing-test

#### What this PR does / why we need it:
Should fix #99449

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
-->
```release-note
NONE
```

/cc @wojtek-t 