### PR TITLE
Migrate cluster role aggregator to apply

### DIFF
--- a/pkg/controller/clusterroleaggregation/clusterroleaggregation_controller_test.go
+++ b/pkg/controller/clusterroleaggregation/clusterroleaggregation_controller_test.go
@@ -21,13 +21,17 @@ import (
 
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/diff"
+	"k8s.io/apimachinery/pkg/util/yaml"
+	rbacv1ac "k8s.io/client-go/applyconfigurations/rbac/v1"
 	fakeclient "k8s.io/client-go/kubernetes/fake"
 	rbaclisters "k8s.io/client-go/listers/rbac/v1"
 	clienttesting "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/cache"
+
 	"k8s.io/kubernetes/pkg/controller"
 )
 
@@ -69,11 +73,23 @@ func TestSyncClusterRole(t *testing.T) {
 		return ret
 	}
 
+	combinedApplyRole := func(selectors []map[string]string, rules ...[]rbacv1.PolicyRule) *rbacv1ac.ClusterRoleApplyConfiguration {
+		ret := rbacv1ac.ClusterRole("combined")
+
+		var r []*rbacv1ac.PolicyRuleApplyConfiguration
+		for _, currRules := range rules {
+			r = append(r, toApplyPolicyRules(currRules)...)
+		}
+		ret.WithRules(r...)
+		return ret
+	}
+
 	tests := []struct {
-		name                 string
-		startingClusterRoles []*rbacv1.ClusterRole
-		clusterRoleToSync    string
-		expectedClusterRole  *rbacv1.ClusterRole
+		name                     string
+		startingClusterRoles     []*rbacv1.ClusterRole
+		clusterRoleToSync        string
+		expectedClusterRole      *rbacv1.ClusterRole
+		expectedClusterRoleApply *rbacv1ac.ClusterRoleApplyConfiguration
 	}{
 		{
 			name: "remove dead rules",
@@ -81,8 +97,9 @@ func TestSyncClusterRole(t *testing.T) {
 				role("hammer", map[string]string{"foo": "bar"}, hammerRules()),
 				combinedRole([]map[string]string{{"foo": "bar"}}, sawRules()),
 			},
-			clusterRoleToSync:   "combined",
-			expectedClusterRole: combinedRole([]map[string]string{{"foo": "bar"}}, hammerRules()),
+			clusterRoleToSync:        "combined",
+			expectedClusterRole:      combinedRole([]map[string]string{{"foo": "bar"}}, hammerRules()),
+			expectedClusterRoleApply: combinedApplyRole([]map[string]string{{"foo": "bar"}}, hammerRules()),
 		},
 		{
 			name: "strip rules",
@@ -90,8 +107,9 @@ func TestSyncClusterRole(t *testing.T) {
 				role("hammer", map[string]string{"foo": "not-bar"}, hammerRules()),
 				combinedRole([]map[string]string{{"foo": "bar"}}, hammerRules()),
 			},
-			clusterRoleToSync:   "combined",
-			expectedClusterRole: combinedRole([]map[string]string{{"foo": "bar"}}),
+			clusterRoleToSync:        "combined",
+			expectedClusterRole:      combinedRole([]map[string]string{{"foo": "bar"}}),
+			expectedClusterRoleApply: combinedApplyRole([]map[string]string{{"foo": "bar"}}),
 		},
 		{
 			name: "select properly and put in order",
@@ -101,8 +119,9 @@ func TestSyncClusterRole(t *testing.T) {
 				role("saw", map[string]string{"foo": "not-bar"}, sawRules()),
 				combinedRole([]map[string]string{{"foo": "bar"}}),
 			},
-			clusterRoleToSync:   "combined",
-			expectedClusterRole: combinedRole([]map[string]string{{"foo": "bar"}}, chiselRules(), hammerRules()),
+			clusterRoleToSync:        "combined",
+			expectedClusterRole:      combinedRole([]map[string]string{{"foo": "bar"}}, chiselRules(), hammerRules()),
+			expectedClusterRoleApply: combinedApplyRole([]map[string]string{{"foo": "bar"}}, chiselRules(), hammerRules()),
 		},
 		{
 			name: "select properly with multiple selectors",
@@ -112,8 +131,9 @@ func TestSyncClusterRole(t *testing.T) {
 				role("saw", map[string]string{"foo": "not-bar"}, sawRules()),
 				combinedRole([]map[string]string{{"foo": "bar"}, {"foo": "not-bar"}}),
 			},
-			clusterRoleToSync:   "combined",
-			expectedClusterRole: combinedRole([]map[string]string{{"foo": "bar"}, {"foo": "not-bar"}}, chiselRules(), hammerRules(), sawRules()),
+			clusterRoleToSync:        "combined",
+			expectedClusterRole:      combinedRole([]map[string]string{{"foo": "bar"}, {"foo": "not-bar"}}, chiselRules(), hammerRules(), sawRules()),
+			expectedClusterRoleApply: combinedApplyRole([]map[string]string{{"foo": "bar"}, {"foo": "not-bar"}}, chiselRules(), hammerRules(), sawRules()),
 		},
 		{
 			name: "select properly remove duplicates",
@@ -124,8 +144,9 @@ func TestSyncClusterRole(t *testing.T) {
 				role("other-saw", map[string]string{"foo": "not-bar"}, sawRules()),
 				combinedRole([]map[string]string{{"foo": "bar"}, {"foo": "not-bar"}}),
 			},
-			clusterRoleToSync:   "combined",
-			expectedClusterRole: combinedRole([]map[string]string{{"foo": "bar"}, {"foo": "not-bar"}}, chiselRules(), hammerRules(), sawRules()),
+			clusterRoleToSync:        "combined",
+			expectedClusterRole:      combinedRole([]map[string]string{{"foo": "bar"}, {"foo": "not-bar"}}, chiselRules(), hammerRules(), sawRules()),
+			expectedClusterRoleApply: combinedApplyRole([]map[string]string{{"foo": "bar"}, {"foo": "not-bar"}}, chiselRules(), hammerRules(), sawRules()),
 		},
 		{
 			name: "no diff skip",
@@ -133,50 +154,82 @@ func TestSyncClusterRole(t *testing.T) {
 				role("hammer", map[string]string{"foo": "bar"}, hammerRules()),
 				combinedRole([]map[string]string{{"foo": "bar"}}, hammerRules()),
 			},
-			clusterRoleToSync:   "combined",
-			expectedClusterRole: nil,
+			clusterRoleToSync:        "combined",
+			expectedClusterRoleApply: nil,
 		}}
 
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			indexer := cache.NewIndexer(controller.KeyFunc, cache.Indexers{})
-			objs := []runtime.Object{}
-			for _, obj := range test.startingClusterRoles {
-				objs = append(objs, obj)
-				indexer.Add(obj)
-			}
-			fakeClient := fakeclient.NewSimpleClientset(objs...)
-			c := ClusterRoleAggregationController{
-				clusterRoleClient: fakeClient.RbacV1(),
-				clusterRoleLister: rbaclisters.NewClusterRoleLister(indexer),
-			}
-			err := c.syncClusterRole(test.clusterRoleToSync)
-			if err != nil {
-				t.Fatal(err)
-			}
+	for _, serverSideApplyEnabled := range []bool{true, false} {
+		for _, test := range tests {
+			t.Run(test.name, func(t *testing.T) {
+				indexer := cache.NewIndexer(controller.KeyFunc, cache.Indexers{})
+				objs := []runtime.Object{}
+				for _, obj := range test.startingClusterRoles {
+					objs = append(objs, obj)
+					indexer.Add(obj)
+				}
+				fakeClient := fakeclient.NewSimpleClientset(objs...)
 
-			if test.expectedClusterRole == nil {
-				if len(fakeClient.Actions()) != 0 {
+				// The default reactor doesn't support apply, so we need our own (trivial) reactor
+				fakeClient.PrependReactor("patch", "clusterroles", func(action clienttesting.Action) (handled bool, ret runtime.Object, err error) {
+					if serverSideApplyEnabled == false {
+						// UnsupportedMediaType
+						return true, nil, errors.NewGenericServerResponse(415, "get", action.GetResource().GroupResource(), "test", "Apply not supported", 0, true)
+					}
+					return true, nil, nil // clusterroleaggregator drops returned objects so no point in constructing them
+				})
+				c := ClusterRoleAggregationController{
+					clusterRoleClient: fakeClient.RbacV1(),
+					clusterRoleLister: rbaclisters.NewClusterRoleLister(indexer),
+				}
+				err := c.syncClusterRole(test.clusterRoleToSync)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				if test.expectedClusterRoleApply == nil {
+					if len(fakeClient.Actions()) != 0 {
+						t.Fatalf("unexpected actions %#v", fakeClient.Actions())
+					}
+					return
+				}
+
+				expectedActions := 1
+				if !serverSideApplyEnabled {
+					expectedActions = 2
+				}
+				if len(fakeClient.Actions()) != expectedActions {
 					t.Fatalf("unexpected actions %#v", fakeClient.Actions())
 				}
-				return
-			}
-			if len(fakeClient.Actions()) != 1 {
-				t.Fatalf("unexpected actions %#v", fakeClient.Actions())
-			}
 
-			action := fakeClient.Actions()[0]
-			if !action.Matches("update", "clusterroles") {
-				t.Fatalf("unexpected action %#v", action)
-			}
-			updateAction, ok := action.(clienttesting.UpdateAction)
-			if !ok {
-				t.Fatalf("unexpected action %#v", action)
-			}
-			if !equality.Semantic.DeepEqual(updateAction.GetObject().(*rbacv1.ClusterRole), test.expectedClusterRole) {
-				t.Fatalf("%v", diff.ObjectDiff(test.expectedClusterRole, updateAction.GetObject().(*rbacv1.ClusterRole)))
-
-			}
-		})
+				action := fakeClient.Actions()[0]
+				if !action.Matches("patch", "clusterroles") {
+					t.Fatalf("unexpected action %#v", action)
+				}
+				applyAction, ok := action.(clienttesting.PatchAction)
+				if !ok {
+					t.Fatalf("unexpected action %#v", action)
+				}
+				ac := &rbacv1ac.ClusterRoleApplyConfiguration{}
+				if err := yaml.Unmarshal(applyAction.GetPatch(), ac); err != nil {
+					t.Fatalf("error unmarshalling apply request: %v", err)
+				}
+				if !equality.Semantic.DeepEqual(ac, test.expectedClusterRoleApply) {
+					t.Fatalf("%v", diff.ObjectDiff(test.expectedClusterRoleApply, ac))
+				}
+				if expectedActions == 2 {
+					action := fakeClient.Actions()[1]
+					if !action.Matches("update", "clusterroles") {
+						t.Fatalf("unexpected action %#v", action)
+					}
+					updateAction, ok := action.(clienttesting.UpdateAction)
+					if !ok {
+						t.Fatalf("unexpected action %#v", action)
+					}
+					if !equality.Semantic.DeepEqual(updateAction.GetObject().(*rbacv1.ClusterRole), test.expectedClusterRole) {
+						t.Fatalf("%v", diff.ObjectDiff(test.expectedClusterRole, updateAction.GetObject().(*rbacv1.ClusterRole)))
+					}
+				}
+			})
+		}
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup


#### What this PR does / why we need it:

Migrates one controller over to use the client-go support for server apply. This is something we had agreed to do as part of the KEP for [Apply for client-go's typed client](https://github.com/kubernetes/enhancements/tree/master/keps/sig-api-machinery/2155-clientgo-apply)

umbrella issue: kubernetes/enhancements#2155

#### Special notes for your reviewer:

**Does this PR introduce a user-facing change?**:

Release note will be added when all the last change in the umbrella issue is merged

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

- [KEP]: [KEP 2155](https://github.com/kubernetes/enhancements/tree/master/keps/sig-api-machinery/2155-clientgo-apply)

```docs
TODO
```

/sig api-machinery
/wg api-expression
