### PR TITLE
sched: fix a bug that metrics of init or collected pods are re-collected

### DIFF
--- a/staging/src/k8s.io/component-base/metrics/testutil/metrics.go
+++ b/staging/src/k8s.io/component-base/metrics/testutil/metrics.go
@@ -281,21 +281,6 @@ func (hist *Histogram) Average() float64 {
 	return hist.GetSampleSum() / float64(hist.GetSampleCount())
 }
 
-// Clear clears all fields of the wrapped histogram
-func (hist *Histogram) Clear() {
-	if hist.SampleCount != nil {
-		*hist.SampleCount = 0
-	}
-	if hist.SampleSum != nil {
-		*hist.SampleSum = 0
-	}
-	for _, b := range hist.Bucket {
-		if b.CumulativeCount != nil {
-			*b.CumulativeCount = 0
-		}
-	}
-}
-
 // Validate makes sure the wrapped histogram has all necessary fields set and with valid values.
 func (hist *Histogram) Validate() error {
 	if hist.SampleCount == nil || hist.GetSampleCount() == 0 {

--- a/staging/src/k8s.io/component-base/metrics/testutil/metrics_test.go
+++ b/staging/src/k8s.io/component-base/metrics/testutil/metrics_test.go
@@ -121,48 +121,6 @@ func TestHistogramQuantile(t *testing.T) {
 	}
 }
 
-func TestHistogramClear(t *testing.T) {
-	samples := []float64{0.5, 0.5, 0.5, 0.5, 1.5, 1.5, 1.5, 1.5, 3, 3, 3, 3, 6, 6, 6, 6}
-	bounds := []float64{1, 2, 4, 8}
-	h := samples2Histogram(samples, bounds)
-
-	if *h.SampleCount == 0 {
-		t.Errorf("Expected histogram .SampleCount to be non-zero")
-	}
-	if *h.SampleSum == 0 {
-		t.Errorf("Expected histogram .SampleSum to be non-zero")
-	}
-
-	for _, b := range h.Bucket {
-		if b.CumulativeCount != nil {
-			if *b.CumulativeCount == 0 {
-				t.Errorf("Expected histogram bucket to have non-zero comulative count")
-			}
-		}
-	}
-
-	h.Clear()
-
-	if *h.SampleCount != 0 {
-		t.Errorf("Expected histogram .SampleCount to be zero, have %v instead", *h.SampleCount)
-	}
-
-	if *h.SampleSum != 0 {
-		t.Errorf("Expected histogram .SampleSum to be zero, have %v instead", *h.SampleSum)
-	}
-
-	for _, b := range h.Bucket {
-		if b.CumulativeCount != nil {
-			if *b.CumulativeCount != 0 {
-				t.Errorf("Expected histogram bucket to have zero comulative count, have %v instead", *b.CumulativeCount)
-			}
-		}
-		if b.UpperBound != nil {
-			*b.UpperBound = 0
-		}
-	}
-}
-
 func TestHistogramValidate(t *testing.T) {
 	tests := []struct {
 		name string

--- a/test/integration/scheduler_perf/util.go
+++ b/test/integration/scheduler_perf/util.go
@@ -205,10 +205,6 @@ func collectHistogram(metric string, labels map[string]string) *DataItem {
 	q99 := hist.Quantile(0.95)
 	avg := hist.Average()
 
-	// clear the metrics so that next test always starts with empty prometheus
-	// metrics (since the metrics are shared among all tests run inside the same binary)
-	hist.Clear()
-
 	msFactor := float64(time.Second) / float64(time.Millisecond)
 
 	// Copy labels and add "Metric" label for this metric.


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/sig scheduling

#### What this PR does / why we need it:

Fix a bug in scheduler integration perf test that metrics of init or collected pods get re-collected. See https://github.com/kubernetes/kubernetes/issues/99218#issuecomment-786226360 for more details.

After applying this fix, running:

```
make test-integration WHAT=./test/integration/scheduler_perf KUBE_TEST_VMODULE="''" KUBE_TEST_ARGS="-alsologtostderr=false -logtostderr=false -run=^$$ -benchtime=1ns -bench=BenchmarkPerfScheduling/SchedulingBasic"
```

will observe 1000 measure Pods getting collected:

<details><summary>Output:</summary>
<p>

```
[DEBUG] 35 le 0.01
[DEBUG] 102 le 0.02
[DEBUG] 228 le 0.04
[DEBUG] 297 le 0.08
[DEBUG] 350 le 0.16
[DEBUG] 409 le 0.32
[DEBUG] 790 le 0.64
[DEBUG] 921 le 1.28
[DEBUG] 985 le 2.56
[DEBUG] 1000 le 5.12
[DEBUG] 1000 le 10.24
[DEBUG] 1000 le 20.48
[DEBUG] 1000 le 40.96
[DEBUG] 1000 le 81.92
[DEBUG] 1000 le 163.84
[DEBUG] 1000 le 327.68
[DEBUG] 1000 le 655.36
[DEBUG] 1000 le 1310.72
[DEBUG] 1000 le 2621.44
[DEBUG] 1000 le 5242.88
[DEBUG] 1000 le +Inf
pkg: k8s.io/kubernetes/test/integration/scheduler_perf
BenchmarkPerfScheduling/SchedulingBasic/500Nodes-4         	       1	14656122851 ns/op

[DEBUG] 0 le 0.01
[DEBUG] 0 le 0.02
[DEBUG] 6 le 0.04
[DEBUG] 14 le 0.08
[DEBUG] 30 le 0.16
[DEBUG] 70 le 0.32
[DEBUG] 175 le 0.64
[DEBUG] 365 le 1.28
[DEBUG] 968 le 2.56
[DEBUG] 1000 le 5.12
[DEBUG] 1000 le 10.24
[DEBUG] 1000 le 20.48
[DEBUG] 1000 le 40.96
[DEBUG] 1000 le 81.92
[DEBUG] 1000 le 163.84
[DEBUG] 1000 le 327.68
[DEBUG] 1000 le 655.36
[DEBUG] 1000 le 1310.72
[DEBUG] 1000 le 2621.44
[DEBUG] 1000 le 5242.88
[DEBUG] 1000 le +Inf
BenchmarkPerfScheduling/SchedulingBasic/5000Nodes-4        	       1	37273363857 ns/op
```

</p>
</details> 

#### Which issue(s) this PR fixes:

Fixes #99218

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
