### PR TITLE
Automated cherry pick of #95150: DNS should support configurable pod

### DIFF
--- a/test/e2e/windows/dns.go
+++ b/test/e2e/windows/dns.go
@@ -67,7 +67,7 @@ var _ = SIGDescribe("DNS", func() {
 			Command:       cmd,
 			Namespace:     f.Namespace.Name,
 			PodName:       testUtilsPod.Name,
-			ContainerName: "util",
+			ContainerName: "agnhost-container",
 			CaptureStdout: true,
 			CaptureStderr: true,
 		})


### PR DESCRIPTION
Cherry pick of #95150 on release-1.19.

#95150: DNS should support configurable pod

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

ref: #99369 