### PR TITLE
Fix fs windows tests to pass on windows machine

### DIFF
--- a/pkg/volume/util/fs/fs_windows_test.go
+++ b/pkg/volume/util/fs/fs_windows_test.go
@@ -21,8 +21,9 @@ import (
 	"io/ioutil"
 	"os"
 
-	"k8s.io/apimachinery/pkg/api/resource"
 	"testing"
+
+	"k8s.io/apimachinery/pkg/api/resource"
 )
 
 func TestDiskUsage(t *testing.T) {
@@ -54,8 +55,8 @@ func TestDiskUsage(t *testing.T) {
 	if err != nil {
 		t.Fatalf("TestDiskUsage failed: %s", err.Error())
 	}
-	file1 := dir1 + "/" + "test"
-	file2 := dir2 + "/" + "test"
+	file1 := tmpfile1.Name()
+	file2 := tmpfile2.Name()
 	fileInfo1, err := os.Lstat(file1)
 	if err != nil {
 		t.Fatalf("TestDiskUsage failed: %s", err.Error())
@@ -74,8 +75,7 @@ func TestDiskUsage(t *testing.T) {
 	if err != nil {
 		t.Fatalf("TestDiskUsage failed: %s", err.Error())
 	}
-	if size.Cmp(used) != 1 {
-		t.Fatalf("TestDiskUsage failed: %s", err.Error())
+	if size.Cmp(used) != 0 {
+		t.Fatalf("TestDiskUsage failed: expected 0, got %d", size.Cmp(used))
 	}
-
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
/kind failing-test

<!--
Add one of the following kinds:
/kind bug

/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation

/kind flake
/kind regression
-->

#### What this PR does / why we need it:
FS windows tests did not pass on windows.  

Before:
```
PS C:\projects> .\fs.test.exe
— FAIL: TestDiskUsage (0.00s)
fs_windows_test.go:61: TestDiskUsage failed: CreateFile C:\Users\jstur\AppData\Local\Temp\dir_1076373467/test: The system cannot find the file specified.
FAIL
```

Now:
```
PS C:\projects> .\fs.test.exe
PASS
```


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #99409

#### Special notes for your reviewer:

There are no build machines for windows unit tests: https://github.com/kubernetes/kubernetes/issues/51540 as of now.  

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/sig windows