### PR TITLE
Solve the problem that the scheduling framework test assistant didn't keep pluginconfig

### DIFF
--- a/pkg/scheduler/testing/framework_helpers.go
+++ b/pkg/scheduler/testing/framework_helpers.go
@@ -28,14 +28,14 @@ func NewFramework(fns []RegisterPluginFunc, opts ...runtime.Option) (framework.F
 	plugins := &schedulerapi.Plugins{}
 	var pluginConfigs []schedulerapi.PluginConfig
 	for _, f := range fns {
-		f(&registry, plugins, pluginConfigs)
+		f(&registry, plugins, &pluginConfigs)
 	}
 	return runtime.NewFramework(registry, plugins, pluginConfigs, opts...)
 }
 
 // RegisterPluginFunc is a function signature used in method RegisterFilterPlugin()
 // to register a Filter Plugin to a given registry.
-type RegisterPluginFunc func(reg *runtime.Registry, plugins *schedulerapi.Plugins, pluginConfigs []schedulerapi.PluginConfig)
+type RegisterPluginFunc func(reg *runtime.Registry, plugins *schedulerapi.Plugins, pluginConfigs *[]schedulerapi.PluginConfig)
 
 // RegisterQueueSortPlugin returns a function to register a QueueSort Plugin to a given registry.
 func RegisterQueueSortPlugin(pluginName string, pluginNewFunc runtime.PluginFactory) RegisterPluginFunc {
@@ -89,7 +89,7 @@ func RegisterPluginAsExtensions(pluginName string, pluginNewFunc runtime.PluginF
 
 // RegisterPluginAsExtensionsWithWeight returns a function to register a Plugin as given extensionPoints with weight to a given registry.
 func RegisterPluginAsExtensionsWithWeight(pluginName string, weight int32, pluginNewFunc runtime.PluginFactory, extensions ...string) RegisterPluginFunc {
-	return func(reg *runtime.Registry, plugins *schedulerapi.Plugins, pluginConfigs []schedulerapi.PluginConfig) {
+	return func(reg *runtime.Registry, plugins *schedulerapi.Plugins, pluginConfigs *[]schedulerapi.PluginConfig) {
 		reg.Register(pluginName, pluginNewFunc)
 		for _, extension := range extensions {
 			ps := getPluginSetByExtension(plugins, extension)
@@ -98,9 +98,7 @@ func RegisterPluginAsExtensionsWithWeight(pluginName string, weight int32, plugi
 			}
 			ps.Enabled = append(ps.Enabled, schedulerapi.Plugin{Name: pluginName, Weight: weight})
 		}
-		//lint:ignore SA4006 this value of pluginConfigs is never used.
-		//lint:ignore SA4010 this result of append is never used.
-		pluginConfigs = append(pluginConfigs, schedulerapi.PluginConfig{Name: pluginName})
+		*pluginConfigs = append(*pluginConfigs, schedulerapi.PluginConfig{Name: pluginName})
 	}
 }
 


### PR DESCRIPTION
… keep pluginconfig

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
The method RegisterPluginAsExtensionsWithWeight in pkg/scheduler/testing/framework_helpers.go only modifies the slice of PluginConfig internally.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #99318

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```
NONE

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
