### PR TITLE
Add ProxyURL attribute to Config for Kubernetes client initialization

### DIFF
--- a/staging/src/k8s.io/client-go/rest/config.go
+++ b/staging/src/k8s.io/client-go/rest/config.go
@@ -67,6 +67,9 @@ type Config struct {
 	Username string
 	Password string `datapolicy:"password"`
 
+	// Proxy URL to be used for specific cluster
+	ProxyURL string
+
 	// Server requires Bearer authentication. This client will not attempt to use
 	// refresh tokens for an OAuth2 flow.
 	// TODO: demonstrate an OAuth2 compatible client.

--- a/staging/src/k8s.io/client-go/tools/clientcmd/client_config.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/client_config.go
@@ -225,6 +225,7 @@ func getServerIdentificationPartialConfig(configAuthInfo clientcmdapi.AuthInfo, 
 	configClientConfig.CAData = configClusterInfo.CertificateAuthorityData
 	configClientConfig.Insecure = configClusterInfo.InsecureSkipTLSVerify
 	configClientConfig.ServerName = configClusterInfo.TLSServerName
+	configClientConfig.ProxyURL = configClusterInfo.ProxyURL
 	mergo.Merge(mergedConfig, configClientConfig, mergo.WithOverride)
 
 	return mergedConfig, nil


### PR DESCRIPTION
proxy-url was introduced in Kubernetes 1.19+ and this PR https://github.com/kubernetes/kubernetes/pull/81443 have added an option to use the proxy-url in kubeconfig.

~~~
apiVersion: v1
clusters:
- cluster:
    insecure-skip-tls-verify: true
    proxy-url: http://127.0.0.1:8080
    server: https://example.com:6443
~~~

We are missing ProxyURL as common attribute that can be passed to a Kubernetes client on initiliazation. For example during `oc login`.

