### PR TITLE
Add staticcheck failures packages in .staticcheck_failures

### DIFF
--- a/hack/.staticcheck_failures
+++ b/hack/.staticcheck_failures
@@ -1,6 +1,8 @@
 cluster/images/etcd/migrate
 pkg/controller/replicaset
 pkg/kubelet/dockershim
+test/e2e
+test/e2e_node
 test/integration/garbagecollector
 test/integration/scheduler_perf
 vendor/k8s.io/apimachinery/pkg/api/apitesting/roundtrip


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
In packages `test/e2e` and `test/e2e_node`, the following staticcheck failures:
```
test/e2e/viperconfig.go:39:6: func viperizeFlags is unused (U1000)
test/e2e/viperconfig.go:110:6: func viperUnmarshal is unused (U1000)
test/e2e_node/benchmark_util.go:48:6: func dumpDataToFile is unused (U1000)
test/e2e_node/benchmark_util.go:62:6: func logPerfData is unused (U1000)
test/e2e_node/benchmark_util.go:74:6: func logDensityTimeSeries is unused (U1000)
test/e2e_node/benchmark_util.go:94:6: type int64arr is unused (U1000)
test/e2e_node/benchmark_util.go:101:6: func getCumulatedPodTimeSeries is unused (U1000)
test/e2e_node/benchmark_util.go:112:6: func getLatencyPerfData is unused (U1000)
test/e2e_node/benchmark_util.go:135:6: func getThroughputPerfData is unused (U1000)
test/e2e_node/benchmark_util.go:158:6: func getTestNodeInfo is unused (U1000)
test/e2e_node/benchmark_util.go:198:6: func printPerfData is unused (U1000)
test/e2e_node/docker_util.go:28:6: func getDockerAPIVersion is unused (U1000)
test/e2e_node/docker_util.go:38:6: func isSharedPIDNamespaceSupported is unused (U1000)
test/e2e_node/docker_util.go:48:6: func isDockerLiveRestoreSupported is unused (U1000)
test/e2e_node/docker_util.go:57:6: func getDockerInfo is unused (U1000)
test/e2e_node/docker_util.go:67:6: func isDockerLiveRestoreEnabled is unused (U1000)
test/e2e_node/docker_util.go:76:6: func getDockerLoggingDriver is unused (U1000)
test/e2e_node/docker_util.go:86:6: func isDockerSELinuxSupportEnabled is unused (U1000)
test/e2e_node/docker_util.go:95:6: func startDockerDaemon is unused (U1000)
test/e2e_node/docker_util.go:107:6: func stopDockerDaemon is unused (U1000)
test/e2e_node/image_list.go:73:6: func updateImageAllowList is unused (U1000)
test/e2e_node/image_list.go:235:6: func getSRIOVDevicePluginImage is unused (U1000)
test/e2e_node/numa_alignment.go:34:6: type numaPodResources is unused (U1000)
test/e2e_node/numa_alignment.go:80:6: func getCPUsPerNUMANode is unused (U1000)
test/e2e_node/numa_alignment.go:92:6: func getCPUToNUMANodeMapFromEnv is unused (U1000)
test/e2e_node/numa_alignment.go:141:6: func getPCIDeviceToNumaNodeMapFromEnv is unused (U1000)
test/e2e_node/numa_alignment.go:164:6: func makeEnvMap is unused (U1000)
test/e2e_node/numa_alignment.go:180:6: type testEnvInfo is unused (U1000)
test/e2e_node/numa_alignment.go:187:6: func containerWantsDevices is unused (U1000)
test/e2e_node/numa_alignment.go:192:6: func checkNUMAAlignment is unused (U1000)
test/e2e_node/numa_alignment.go:223:6: type pciDeviceInfo is unused (U1000)
test/e2e_node/numa_alignment.go:230:6: func getPCIDeviceInfo is unused (U1000)
test/e2e_node/numa_alignment.go:270:6: func numaNodeFromSysFsEntry is unused (U1000)
test/e2e_node/resource_collector.go:258:6: func formatCPUSummary is unused (U1000)
test/e2e_node/resource_collector.go:297:6: func getCadvisorPod is unused (U1000)
test/e2e_node/resource_collector.go:371:6: func deletePodsSync is unused (U1000)
test/e2e_node/resource_collector.go:391:6: func newTestPods is unused (U1000)
test/e2e_node/util.go:62:5: var startServices is unused (U1000)
test/e2e_node/util.go:63:5: var stopServices is unused (U1000)
test/e2e_node/util.go:75:6: func getNodeSummary is unused (U1000)
test/e2e_node/util.go:107:6: func getV1alpha1NodeDevices is unused (U1000)
test/e2e_node/util.go:126:6: func getV1NodeDevices is unused (U1000)
test/e2e_node/util.go:146:6: func getCurrentKubeletConfig is unused (U1000)
test/e2e_node/util.go:154:6: func tempSetCurrentKubeletConfig is unused (U1000)
test/e2e_node/util.go:181:6: func isKubeletConfigEnabled is unused (U1000)
test/e2e_node/util.go:197:6: func setKubeletConfiguration is unused (U1000)
test/e2e_node/util.go:252:6: func setNodeConfigSource is unused (U1000)
test/e2e_node/util.go:276:6: func createConfigMap is unused (U1000)
test/e2e_node/util.go:286:6: func newKubeletConfigMap is unused (U1000)
test/e2e_node/util.go:300:6: func listNamespaceEvents is unused (U1000)
test/e2e_node/util.go:311:6: func logPodEvents is unused (U1000)
test/e2e_node/util.go:317:6: func logNodeEvents is unused (U1000)
test/e2e_node/util.go:323:6: func getLocalNode is unused (U1000)
test/e2e_node/util.go:333:6: func logKubeletLatencyMetrics is unused (U1000)
test/e2e_node/util.go:347:6: func getKubeletMetrics is unused (U1000)
test/e2e_node/util.go:366:6: func runCommand is unused (U1000)
test/e2e_node/util.go:397:6: func findRunningKubletServiceName is unused (U1000)
test/e2e_node/util.go:408:6: func restartKubelet is unused (U1000)
test/e2e_node/util.go:419:6: func stopKubelet is unused (U1000)
test/e2e_node/util.go:429:6: func toCgroupFsName is unused (U1000)
test/e2e_node/util.go:439:6: func reduceAllocatableMemoryUsage is unused (U1000)
test/e2e_node/util.go:449:6: func withFeatureGate is unused (U1000)
test/e2e_node/util_xfs_linux.go:28:6: func detectMountpoint is unused (U1000)
test/e2e_node/util_xfs_linux.go:63:6: func isXfs is unused (U1000)
```
These functions are used in `*_test.go` files.

xref: #92402

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
