### PR TITLE
Automated cherry pick of #99464: Number of sockets is assumed to be same as NUMA nodes

### DIFF
--- a/pkg/kubelet/cm/cpumanager/topology/topology.go
+++ b/pkg/kubelet/cm/cpumanager/topology/topology.go
@@ -245,7 +245,7 @@ func Discover(machineInfo *cadvisorapi.MachineInfo) (*CPUTopology, error) {
 
 	return &CPUTopology{
 		NumCPUs:    machineInfo.NumCores,
-		NumSockets: len(machineInfo.Topology),
+		NumSockets: machineInfo.NumSockets,
 		NumCores:   numPhysicalCores,
 		CPUDetails: CPUDetails,
 	}, nil

--- a/pkg/kubelet/cm/cpumanager/topology/topology_test.go
+++ b/pkg/kubelet/cm/cpumanager/topology/topology_test.go
@@ -42,7 +42,8 @@ func Test_Discover(t *testing.T) {
 		{
 			name: "OneSocketHT",
 			machineInfo: cadvisorapi.MachineInfo{
-				NumCores: 8,
+				NumCores:   8,
+				NumSockets: 1,
 				Topology: []cadvisorapi.Node{
 					{Id: 0,
 						Cores: []cadvisorapi.Core{
@@ -74,7 +75,8 @@ func Test_Discover(t *testing.T) {
 		{
 			name: "DualSocketNoHT",
 			machineInfo: cadvisorapi.MachineInfo{
-				NumCores: 4,
+				NumCores:   4,
+				NumSockets: 2,
 				Topology: []cadvisorapi.Node{
 					{Id: 0,
 						Cores: []cadvisorapi.Core{
@@ -106,7 +108,8 @@ func Test_Discover(t *testing.T) {
 		{
 			name: "DualSocketHT - non unique Core'ID's",
 			machineInfo: cadvisorapi.MachineInfo{
-				NumCores: 12,
+				NumCores:   12,
+				NumSockets: 2,
 				Topology: []cadvisorapi.Node{
 					{Id: 0,
 						Cores: []cadvisorapi.Core{
@@ -148,7 +151,8 @@ func Test_Discover(t *testing.T) {
 		{
 			name: "OneSocketHT fail",
 			machineInfo: cadvisorapi.MachineInfo{
-				NumCores: 8,
+				NumCores:   8,
+				NumSockets: 1,
 				Topology: []cadvisorapi.Node{
 					{Id: 0,
 						Cores: []cadvisorapi.Core{
@@ -166,7 +170,8 @@ func Test_Discover(t *testing.T) {
 		{
 			name: "OneSocketHT fail",
 			machineInfo: cadvisorapi.MachineInfo{
-				NumCores: 8,
+				NumCores:   8,
+				NumSockets: 1,
 				Topology: []cadvisorapi.Node{
 					{Id: 0,
 						Cores: []cadvisorapi.Core{


### PR DESCRIPTION
What type of PR is this?
/kind bug

What this PR does / why we need it:
  cadvisor v0.37+ onwards sends NUMA nodes in machineInfo.Topology .
  It does not represent sockets.
  So socket numbers need to be taken from machineInfo.NumSockets.

Which issue(s) this PR fixes:
Fixes # #99457

Does this PR introduce a user-facing change?
> Fixes kubelet to take socket numbers from cadvisor machine Info , instead of assuming it to be equal to NUMA nodes

Master PR which is being backported to release-1:20 : https://github.com/kubernetes/kubernetes/pull/99464

```release-note
Fixes a regression in 1.19+ to make kubelet to take socket numbers from cadvisor machine Info , instead of assuming it to be equal to NUMA nodes
```
