### PR TITLE
Move ownership of core events test to sig-instrumentation

### DIFF
--- a/staging/src/k8s.io/client-go/tools/events/OWNERS
+++ b/staging/src/k8s.io/client-go/tools/events/OWNERS
@@ -1,8 +1,10 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
+- sig-instrumentation-approvers
 - yastij
 - wojtek-t
 reviewers:
+- sig-instrumentation-reviewers
 - yastij
 - wojtek-t

--- a/staging/src/k8s.io/client-go/tools/record/OWNERS
+++ b/staging/src/k8s.io/client-go/tools/record/OWNERS
@@ -1,27 +1,6 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 reviewers:
-- lavalamp
-- smarterclayton
-- wojtek-t
-- deads2k
-- derekwaynecarr
-- caesarxuchao
-- vishh
-- mikedanese
-- liggitt
-- erictune
-- pmorie
-- dchen1107
-- saad-ali
-- luxas
-- yifan-gu
-- mwielgus
-- timothysc
-- jsafrane
-- dims
-- krousey
-- a-robinson
-- aveshagarwal
-- resouer
-- cjcullen
+- sig-instrumentation-reviewers
+approvers:
+- sig-instrumentation-approvers

--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -317,21 +317,6 @@
     return a valid PreferredVersion unless the group suffix is example.com.
   release: v1.19
   file: test/e2e/apimachinery/discovery.go
-- testname: Event, delete a collection
-  codename: '[sig-api-machinery] Events should delete a collection of events [Conformance]'
-  description: A set of events is created with a label selector which MUST be found
-    when listed. The set of events is deleted and MUST NOT show up when listed by
-    its label selector.
-  release: v1.20
-  file: test/e2e/apimachinery/events.go
-- testname: Event resource lifecycle
-  codename: '[sig-api-machinery] Events should ensure that an event can be fetched,
-    patched, deleted, and listed [Conformance]'
-  description: Create an event, the event MUST exist. The event is patched with a
-    new message, the check MUST have the update message. The event is deleted and
-    MUST NOT show up when listing all events.
-  release: v1.20
-  file: test/e2e/apimachinery/events.go
 - testname: Garbage Collector, delete deployment,  propagation policy background
   codename: '[sig-api-machinery] Garbage collector should delete RS created by deployment
     when not orphaning [Conformance]'
@@ -1058,6 +1043,21 @@
     show up when listing all events.
   release: v1.19
   file: test/e2e/instrumentation/events.go
+- testname: Event, delete a collection
+  codename: '[sig-instrumentation] Events should delete a collection of events [Conformance]'
+  description: A set of events is created with a label selector which MUST be found
+    when listed. The set of events is deleted and MUST NOT show up when listed by
+    its label selector.
+  release: v1.20
+  file: test/e2e/instrumentation/core_events.go
+- testname: Event resource lifecycle
+  codename: '[sig-instrumentation] Events should ensure that an event can be fetched,
+    patched, deleted, and listed [Conformance]'
+  description: Create an event, the event MUST exist. The event is patched with a
+    new message, the check MUST have the update message. The event is deleted and
+    MUST NOT show up when listing all events.
+  release: v1.20
+  file: test/e2e/instrumentation/core_events.go
 - testname: DNS, cluster
   codename: '[sig-network] DNS should provide /etc/hosts entries for the cluster [LinuxOnly]
     [Conformance]'

--- a/test/e2e/instrumentation/core_events.go
+++ b/test/e2e/instrumentation/core_events.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package apimachinery
+package instrumentation
 
 import (
 	"context"
@@ -25,6 +25,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/kubernetes/test/e2e/framework"
+	"k8s.io/kubernetes/test/e2e/instrumentation/common"
 
 	"github.com/onsi/ginkgo"
 	"k8s.io/apimachinery/pkg/types"
@@ -35,7 +36,7 @@ const (
 	eventRetryTimeout = 1 * time.Minute
 )
 
-var _ = SIGDescribe("Events", func() {
+var _ = common.SIGDescribe("Events", func() {
 	f := framework.NewDefaultFramework("events")
 
 	/*


### PR DESCRIPTION
I propose that we migrate the ownership of core.Event test to sig-instrumentation.
There isn't a perfect home for it, but sig-instrumentation is definitely better than sig-apimachinery.
And sig-instrumentaiton already owns the new events API.

Ref https://github.com/kubernetes/kubernetes/issues/98326

```release-note
NONE
```

/kind cleanup
/priority important-soon

/assign @ehashman @logicalhan @brancz @dashpole 