### PR TITLE
add Yuchen to reviewers

### DIFF
--- a/staging/src/k8s.io/component-base/metrics/OWNERS
+++ b/staging/src/k8s.io/component-base/metrics/OWNERS
@@ -6,5 +6,6 @@ approvers:
 - RainbowMango
 reviewers:
 - sig-instrumentation-reviewers
+- YoyinZyc
 labels:
 - sig/instrumentation


### PR DESCRIPTION

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Adds Yuchen to reviewers for `component-base/metrics`.
