### PR TITLE
Fix static failures for vendor/k8s.io/apiserver/pkg/endpoints/handlers

### DIFF
--- a/hack/.staticcheck_failures
+++ b/hack/.staticcheck_failures
@@ -12,9 +12,6 @@ vendor/k8s.io/apimachinery/pkg/util/sets/types
 vendor/k8s.io/apimachinery/pkg/util/strategicpatch
 vendor/k8s.io/apimachinery/pkg/util/wait
 vendor/k8s.io/apiserver/pkg/endpoints/filters
-vendor/k8s.io/apiserver/pkg/endpoints/handlers
-vendor/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager
-vendor/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters
 vendor/k8s.io/apiserver/pkg/endpoints/metrics
 vendor/k8s.io/apiserver/pkg/registry/generic/registry
 vendor/k8s.io/apiserver/pkg/registry/generic/rest

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/delete.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/delete.go
@@ -142,6 +142,7 @@ func DeleteResource(r rest.GracefulDeleter, allowsOptions bool, scope *RequestSc
 		// that will break existing clients.
 		// Other cases where resource is not instantly deleted are: namespace deletion
 		// and pod graceful deletion.
+		//lint:ignore SA1019 backwards compatibility
 		if !wasDeleted && options.OrphanDependents != nil && !*options.OrphanDependents {
 			status = http.StatusAccepted
 		}

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/fieldmanager_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/fieldmanager_test.go
@@ -55,6 +55,7 @@ type fakeObjectConvertor struct {
 	apiVersion fieldpath.APIVersion
 }
 
+//lint:ignore SA4009 backwards compatibility
 func (c *fakeObjectConvertor) Convert(in, out, context interface{}) error {
 	if typedValue, ok := in.(*typed.TypedValue); ok {
 		var err error

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/errors_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/errors_test.go
@@ -83,6 +83,7 @@ func TestForbidden(t *testing.T) {
 		if result != test.expected {
 			t.Errorf("Forbidden response body(%#v...)\n expected: %v\ngot:       %v", test.attributes, test.expected, result)
 		}
+		//lint:ignore SA1019 backwards compatibility
 		resultType := observer.HeaderMap.Get("Content-Type")
 		if resultType != test.contentType {
 			t.Errorf("Forbidden content type(%#v...) != %#v, got %#v", test.attributes, test.expected, result)

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/writers.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/writers.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strconv"
 	"strings"
@@ -243,8 +242,6 @@ func (w *deferredResponseWriter) Close() error {
 	}
 	return err
 }
-
-var nopCloser = ioutil.NopCloser(nil)
 
 // WriteObjectNegotiated renders an object in the content type negotiated by the client.
 func WriteObjectNegotiated(s runtime.NegotiatedSerializer, restrictions negotiation.EndpointRestrictions, gv schema.GroupVersion, w http.ResponseWriter, req *http.Request, statusCode int, object runtime.Object) {

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/writers_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/writers_test.go
@@ -64,7 +64,6 @@ func TestSerializeObjectParallel(t *testing.T) {
 
 		wantCode    int
 		wantHeaders http.Header
-		wantBody    []byte
 	}
 	newTest := func() test {
 		return test{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Part of #92402
```
vendor/k8s.io/apiserver/pkg/endpoints/handlers/delete.go:145:21: options.OrphanDependents is deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the "orphan" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both. +optional  (SA1019)
vendor/k8s.io/apiserver/pkg/endpoints/handlers/delete.go:145:58: options.OrphanDependents is deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the "orphan" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both. +optional  (SA1019)
vendor/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/fieldmanager_test.go:58:43: argument out is overwritten before first use (SA4009)
vendor/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/fieldmanager_test.go:61:3: assignment to out
vendor/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/errors_test.go:86:17: observer.HeaderMap is deprecated: HeaderMap exists for historical compatibility and should not be used. To access the headers returned by a handler, use the Response.Header map as returned by the Result method.  (SA1019)
vendor/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/writers.go:247:5: var nopCloser is unused (U1000)
vendor/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/writers_test.go:67:3: field wantBody is unused (U1000)
```
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
