### PR TITLE
fix staticcheck for k8s.io/apiserver/pkg/endpoints

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/filters/audit_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/filters/audit_test.go
@@ -697,7 +697,7 @@ func TestAudit(t *testing.T) {
 			expectedID := types.UID("")
 			for i, expect := range test.expected {
 				event := events[i]
-				if "admin" != event.User.Username {
+				if event.User.Username != "admin" {
 					t.Errorf("Unexpected username: %s", event.User.Username)
 				}
 				if event.Stage != expect.Stage {

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/filters/request_deadline.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/filters/request_deadline.go
@@ -69,7 +69,7 @@ func withRequestDeadline(handler http.Handler, sink audit.Sink, policy policy.Ch
 
 		userSpecifiedTimeout, ok, err := parseTimeout(req)
 		if err != nil {
-			statusErr := apierrors.NewBadRequest(fmt.Sprintf("%s", err.Error()))
+			statusErr := apierrors.NewBadRequest(err.Error())
 
 			klog.Errorf("Error - %s: %#v", err.Error(), req.RequestURI)
 

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics.go
@@ -22,7 +22,6 @@ import (
 	"net"
 	"net/http"
 	"net/url"
-	"regexp"
 	"strconv"
 	"strings"
 	"sync"
@@ -216,8 +215,6 @@ var (
 		},
 		[]string{"verb", "group", "version", "resource", "subresource", "scope"},
 	)
-
-	kubectlExeRegexp = regexp.MustCompile(`^.*((?i:kubectl\.exe))`)
 
 	metrics = []resettableCollector{
 		deprecatedRequestGauge,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Part of [#92402](https://github.com/kubernetes/kubernetes/issues/92402)
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes
```
vendor/k8s.io/apiserver/pkg/endpoints/metrics/metrics.go:220:2: var kubectlExeRegexp is unused (U1000)
vendor/k8s.io/apiserver/pkg/endpoints/metrics/metrics.go:439:37: http.CloseNotifier is deprecated: the CloseNotifier interface predates Go's context package. New code should use Request.Context instead.  (SA1019)
vendor/k8s.io/apiserver/pkg/endpoints/metrics/metrics.go:466:15: http.CloseNotifier is deprecated: the CloseNotifier interface predates Go's context package. New code should use Request.Context instead.  (SA1019)
vendor/k8s.io/apiserver/pkg/endpoints/metrics/metrics.go:597:27: http.CloseNotifier is deprecated: the CloseNotifier interface predates Go's context package. New code should use Request.Context instead.  (SA1019)

vendor/k8s.io/apiserver/pkg/endpoints/filters/audit.go:176:27: http.CloseNotifier is deprecated: the CloseNotifier interface predates Go's context package. New code should use Request.Context instead.  (SA1019)
vendor/k8s.io/apiserver/pkg/endpoints/filters/audit.go:237:27: http.CloseNotifier is deprecated: the CloseNotifier interface predates Go's context package. New code should use Request.Context instead.  (SA1019)
vendor/k8s.io/apiserver/pkg/endpoints/filters/audit.go:257:7: http.CloseNotifier is deprecated: the CloseNotifier interface predates Go's context package. New code should use Request.Context instead.  (SA1019)
vendor/k8s.io/apiserver/pkg/endpoints/filters/audit_test.go:700:8: don't use Yoda conditions (ST1017)
vendor/k8s.io/apiserver/pkg/endpoints/filters/request_deadline.go:72:41: the argument is already a string, there's no need to use fmt.Sprintf (S1025)
```

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
