### PR TITLE
Fix staticcheck failures for vendor/k8s.io/apiserver/pkg/registry/generic

### DIFF
--- a/hack/.staticcheck_failures
+++ b/hack/.staticcheck_failures
@@ -13,8 +13,6 @@ vendor/k8s.io/apimachinery/pkg/util/strategicpatch
 vendor/k8s.io/apimachinery/pkg/util/wait
 vendor/k8s.io/apiserver/pkg/endpoints/filters
 vendor/k8s.io/apiserver/pkg/endpoints/metrics
-vendor/k8s.io/apiserver/pkg/registry/generic/registry
-vendor/k8s.io/apiserver/pkg/registry/generic/rest
 vendor/k8s.io/apiserver/pkg/registry/rest/resttest
 vendor/k8s.io/apiserver/pkg/server/dynamiccertificates
 vendor/k8s.io/apiserver/pkg/server/filters

--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/decorated_watcher.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/decorated_watcher.go
@@ -18,9 +18,6 @@ package registry
 
 import (
 	"context"
-	"net/http"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
 )
@@ -83,17 +80,4 @@ func (d *decoratedWatcher) Stop() {
 
 func (d *decoratedWatcher) ResultChan() <-chan watch.Event {
 	return d.resultCh
-}
-
-func makeStatusErrorEvent(err error) watch.Event {
-	status := &metav1.Status{
-		Status:  metav1.StatusFailure,
-		Message: err.Error(),
-		Code:    http.StatusInternalServerError,
-		Reason:  metav1.StatusReasonInternalError,
-	}
-	return watch.Event{
-		Type:   watch.Error,
-		Object: status,
-	}
 }

--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store.go
@@ -744,7 +744,9 @@ func shouldOrphanDependents(ctx context.Context, e *Store, accessor metav1.Objec
 	}
 
 	// An explicit policy was set at deletion time, that overrides everything
+	//lint:ignore SA1019 backwards compatibility
 	if options != nil && options.OrphanDependents != nil {
+		//lint:ignore SA1019 backwards compatibility
 		return *options.OrphanDependents
 	}
 	if options != nil && options.PropagationPolicy != nil {
@@ -785,6 +787,7 @@ func shouldDeleteDependents(ctx context.Context, e *Store, accessor metav1.Objec
 	}
 
 	// If an explicit policy was set at deletion time, that overrides both
+	//lint:ignore SA1019 backwards compatibility
 	if options != nil && options.OrphanDependents != nil {
 		return false
 	}

--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store_test.go
@@ -62,8 +62,6 @@ import (
 var scheme = runtime.NewScheme()
 var codecs = serializer.NewCodecFactory(scheme)
 
-const validInitializerName = "test.k8s.io"
-
 func init() {
 	metav1.AddToGroupVersion(scheme, metav1.SchemeGroupVersion)
 	utilruntime.Must(example.AddToScheme(scheme))
@@ -265,7 +263,7 @@ func TestStoreListResourceVersion(t *testing.T) {
 		l, err := registry.List(ctx, option)
 		if err != nil {
 			close(waitListCh)
-			t.Fatal(err)
+			t.Error(err)
 			return
 		}
 		waitListCh <- l
@@ -2062,7 +2060,7 @@ func TestStoreDeleteCollectionNotFound(t *testing.T) {
 				defer wg.Done()
 				_, err := registry.DeleteCollection(testContext, rest.ValidateAllObjectFunc, nil, &metainternalversion.ListOptions{})
 				if err != nil {
-					t.Fatalf("Unexpected error: %v", err)
+					t.Errorf("Unexpected error: %v", err)
 				}
 			}()
 		}
@@ -2650,7 +2648,7 @@ func TestRetryDeleteValidation(t *testing.T) {
 			// This update will cause the Delete to retry due to conflict.
 			_, _, err := registry.Update(testContext, test.pod.Name, rest.DefaultUpdatedObjectInfo(test.pod, transformer), rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false, &metav1.UpdateOptions{})
 			if err != nil {
-				t.Fatal(err)
+				t.Error(err)
 			}
 			updatedOnce.Do(func() {
 				close(updated)

--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/rest/streamer_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/rest/streamer_test.go
@@ -75,7 +75,6 @@ func TestInputStreamNullLocation(t *testing.T) {
 
 type testTransport struct {
 	body string
-	err  error
 }
 
 func (tt *testTransport) RoundTrip(req *http.Request) (*http.Response, error) {


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Part of #92402
```
vendor/k8s.io/apiserver/pkg/registry/generic/registry/decorated_watcher.go:88:6: func makeStatusErrorEvent is unused (U1000)
vendor/k8s.io/apiserver/pkg/registry/generic/registry/store.go:747:23: options.OrphanDependents is deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the "orphan" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both. +optional  (SA1019)
vendor/k8s.io/apiserver/pkg/registry/generic/registry/store.go:748:11: options.OrphanDependents is deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the "orphan" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both. +optional  (SA1019)
vendor/k8s.io/apiserver/pkg/registry/generic/registry/store.go:788:23: options.OrphanDependents is deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the "orphan" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both. +optional  (SA1019)
vendor/k8s.io/apiserver/pkg/registry/generic/registry/store_test.go:65:7: const validInitializerName is unused (U1000)
vendor/k8s.io/apiserver/pkg/registry/generic/registry/store_test.go:262:2: the goroutine calls T.Fatal, which must be called in the same goroutine as the test (SA2002)
vendor/k8s.io/apiserver/pkg/registry/generic/registry/store_test.go:268:4: call to T.Fatal
vendor/k8s.io/apiserver/pkg/registry/generic/registry/store_test.go:2061:4: the goroutine calls T.Fatalf, which must be called in the same goroutine as the test (SA2002)
vendor/k8s.io/apiserver/pkg/registry/generic/registry/store_test.go:2065:6: call to T.Fatalf
vendor/k8s.io/apiserver/pkg/registry/generic/registry/store_test.go:2649:3: the goroutine calls T.Fatal, which must be called in the same goroutine as the test (SA2002)
vendor/k8s.io/apiserver/pkg/registry/generic/registry/store_test.go:2653:5: call to T.Fatal
vendor/k8s.io/apiserver/pkg/registry/generic/rest/streamer_test.go:78:2: field err is unused (U1000)
```
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
