### PR TITLE
migrate volume/csi/expander.go logs to structured logging

### DIFF
--- a/pkg/volume/csi/expander.go
+++ b/pkg/volume/csi/expander.go
@@ -38,14 +38,14 @@ func (c *csiPlugin) RequiresFSResize() bool {
 	// NodeExpand to do the right thing and return early if plugin does not have
 	// node expansion capability.
 	if !utilfeature.DefaultFeatureGate.Enabled(features.ExpandCSIVolumes) {
-		klog.V(4).Infof("Resizing is not enabled for CSI volume")
+		klog.V(4).InfoS("Resizing is not enabled for CSI volume")
 		return false
 	}
 	return true
 }
 
 func (c *csiPlugin) NodeExpand(resizeOptions volume.NodeResizeOptions) (bool, error) {
-	klog.V(4).Infof(log("Expander.NodeExpand(%s)", resizeOptions.DeviceMountPath))
+	klog.V(4).InfoS("Expander.NodeExpand with path", "plugin", CSIPluginName, "path", resizeOptions.DeviceMountPath)
 	csiSource, err := getCSISourceFromSpec(resizeOptions.VolumeSpec)
 	if err != nil {
 		return false, errors.New(log("Expander.NodeExpand failed to get CSI persistent source: %v", err))

--- a/pkg/volume/csi/nodeinfomanager/nodeinfomanager.go
+++ b/pkg/volume/csi/nodeinfomanager/nodeinfomanager.go
@@ -398,7 +398,7 @@ func (nim *nodeInfoManager) InitializeCSINodeWithAnnotation() error {
 	var lastErr error
 	err := wait.ExponentialBackoff(updateBackoff, func() (bool, error) {
 		if lastErr = nim.tryInitializeCSINodeWithAnnotation(csiKubeClient); lastErr != nil {
-			klog.V(2).Infof("Failed to publish CSINode: %v", lastErr)
+			klog.V(2).InfoS("Failed to publish CSINode", "err", lastErr)
 			return false, nil
 		}
 		return true, nil
@@ -557,13 +557,13 @@ func (nim *nodeInfoManager) installDriverToCSINode(
 
 	if maxAttachLimit > 0 {
 		if maxAttachLimit > math.MaxInt32 {
-			klog.Warningf("Exceeded max supported attach limit value, truncating it to %d", math.MaxInt32)
+			klog.InfoS("Exceeded max supported attach limit value, and truncate it to the value", "limit", math.MaxInt32)
 			maxAttachLimit = math.MaxInt32
 		}
 		m := int32(maxAttachLimit)
 		driverSpec.Allocatable = &storagev1.VolumeNodeResources{Count: &m}
 	} else {
-		klog.Errorf("Invalid attach limit value %d cannot be added to CSINode object for %q", maxAttachLimit, driverName)
+		klog.ErrorS(nil, "Invalid attach limit cannot be added to CSINode object", "limit", maxAttachLimit, "driver", driverName)
 	}
 
 	newDriverSpecs = append(newDriverSpecs, driverSpec)


### PR DESCRIPTION
What type of PR is this?
/kind cleanup

What this PR does / why we need it:
part of kubernetes/enhancements#1602

Which issue(s) this PR fixes:
keps/sig-instrumentation/1602-structured-logging

Structured Logging migration instructions

Special notes for your reviewer:

Does this PR introduce a user-facing change?
```release-note
migrate volume/csi/expander.go and volume/csi/nodeinfomanager/nodeinfomanager.go logs to structured logging
```