### PR TITLE
Migrate to structured logs pkg/util/bandwidth/ and /conntrack

### DIFF
--- a/pkg/util/bandwidth/linux.go
+++ b/pkg/util/bandwidth/linux.go
@@ -60,10 +60,10 @@ func NewTCShaper(iface string) Shaper {
 }
 
 func (t *tcShaper) execAndLog(cmdStr string, args ...string) error {
-	klog.V(6).Infof("Running: %s %s", cmdStr, strings.Join(args, " "))
+	klog.V(6).InfoS("Running", "cmdStr", cmdStr, "args", strings.Join(args, " "))
 	cmd := t.e.Command(cmdStr, args...)
 	out, err := cmd.CombinedOutput()
-	klog.V(6).Infof("Output from tc: %s", string(out))
+	klog.V(6).InfoS("print Output from tc", "out", string(out))
 	return err
 }
 

--- a/pkg/util/conntrack/conntrack.go
+++ b/pkg/util/conntrack/conntrack.go
@@ -63,12 +63,12 @@ func Exec(execer exec.Interface, parameters ...string) error {
 	if err != nil {
 		return fmt.Errorf("error looking for path of conntrack: %v", err)
 	}
-	klog.V(4).Infof("Clearing conntrack entries %v", parameters)
+	klog.V(4).InfoS("Clearing conntrack entries", "parameters", parameters)
 	output, err := execer.Command(conntrackPath, parameters...).CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("conntrack command returned: %q, error message: %s", string(output), err)
 	}
-	klog.V(4).Infof("Conntrack entries deleted %s", string(output))
+	klog.V(4).InfoS("Conntrack entries deleted", "output", string(output))
 	return nil
 }
 

--- a/pkg/util/coverage/coverage.go
+++ b/pkg/util/coverage/coverage.go
@@ -87,6 +87,6 @@ func FlushCoverage() {
 	// This gets us atomic updates from the perspective of another process trying to access
 	// the file.
 	if err := os.Rename(tempCoveragePath(), coverageFile); err != nil {
-		klog.Errorf("Couldn't move coverage file from %s to %s", coverageFile, tempCoveragePath())
+		klog.ErrorS(err, "Couldn't move coverage file", "from", coverageFile, "to", tempCoveragePath())
 	}
 }


### PR DESCRIPTION
in pkg/util/bandwidth/linux.go
in pkg/util/conntrack/conntrack.go
in pkg/util/coverage/coverage.go


**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it:**

Ref:

- [keps/sig-instrumentation/1602-structured-logging](https://github.com/kubernetes/enhancements/tree/master/keps/sig-instrumentation/1602-structured-logging)

- [Structured Logging migration instructions](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/migration-to-structured-logging.md)


**Does this PR introduce a user-facing change?:**

`Migrate some log messages to structured logging `