### PR TITLE
kubectl: support --subresource flag

### DIFF
--- a/pkg/printers/internalversion/printers.go
+++ b/pkg/printers/internalversion/printers.go
@@ -588,6 +588,7 @@ func AddHandlers(h printers.PrintHandler) {
 		{Name: "Name", Type: "string", Description: metav1.ObjectMeta{}.SwaggerDoc()["name"]},
 		{Name: "Desired", Type: "integer", Description: autoscalingv1.ScaleSpec{}.SwaggerDoc()["replicas"]},
 		{Name: "Available", Type: "integer", Description: autoscalingv1.ScaleStatus{}.SwaggerDoc()["replicas"]},
+		{Name: "Age", Type: "string", Description: metav1.ObjectMeta{}.SwaggerDoc()["creationTimestamp"]},
 	}
 	h.TableHandler(scaleColumnDefinitions, printScale)
 }
@@ -2627,7 +2628,7 @@ func printScale(obj *autoscaling.Scale, options printers.GenerateOptions) ([]met
 	row := metav1.TableRow{
 		Object: runtime.RawExtension{Object: obj},
 	}
-	row.Cells = append(row.Cells, obj.Name, obj.Spec.Replicas, obj.Status.Replicas)
+	row.Cells = append(row.Cells, obj.Name, obj.Spec.Replicas, obj.Status.Replicas, translateTimestampSince(obj.CreationTimestamp))
 	return []metav1.TableRow{row}, nil
 }
 

--- a/pkg/printers/internalversion/printers_test.go
+++ b/pkg/printers/internalversion/printers_test.go
@@ -5841,7 +5841,7 @@ func TestPrintScale(t *testing.T) {
 			},
 			expected: []metav1.TableRow{
 				{
-					Cells: []interface{}{"test-autoscaling", int32(2), int32(1)},
+					Cells: []interface{}{"test-autoscaling", int32(2), int32(1), string("0s")},
 				},
 			},
 		},

--- a/staging/src/k8s.io/cli-runtime/pkg/resource/helper_test.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/resource/helper_test.go
@@ -68,6 +68,17 @@ func V1DeepEqualSafePodSpec() corev1.PodSpec {
 	}
 }
 
+func V1DeepEqualSafePodStatus() corev1.PodStatus {
+	return corev1.PodStatus{
+		Conditions: []corev1.PodCondition{
+			{
+				Status: corev1.ConditionTrue,
+				Type:   corev1.PodReady,
+			},
+		},
+	}
+}
+
 func TestHelperDelete(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -257,11 +268,12 @@ func TestHelperCreate(t *testing.T) {
 
 func TestHelperGet(t *testing.T) {
 	tests := []struct {
-		name    string
-		Err     bool
-		Req     func(*http.Request) bool
-		Resp    *http.Response
-		HttpErr error
+		name        string
+		subresource string
+		Err         bool
+		Req         func(*http.Request) bool
+		Resp        *http.Response
+		HttpErr     error
 	}{
 		{
 			name:    "test1",
@@ -301,6 +313,35 @@ func TestHelperGet(t *testing.T) {
 				return true
 			},
 		},
+		{
+			name:        "test with subresource",
+			subresource: "status",
+			Resp: &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     header(),
+				Body:       objBody(&corev1.Pod{TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "Pod"}, ObjectMeta: metav1.ObjectMeta{Name: "foo"}}),
+			},
+			Req: func(req *http.Request) bool {
+				if req.Method != "GET" {
+					t.Errorf("unexpected method: %#v", req)
+					return false
+				}
+				parts := splitPath(req.URL.Path)
+				if parts[1] != "bar" {
+					t.Errorf("url doesn't contain namespace: %#v", req)
+					return false
+				}
+				if parts[2] != "foo" {
+					t.Errorf("url doesn't contain name: %#v", req)
+					return false
+				}
+				if parts[3] != "status" {
+					t.Errorf("url doesn't contain subresource: %#v", req)
+					return false
+				}
+				return true
+			},
+		},
 	}
 	for i, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -313,6 +354,7 @@ func TestHelperGet(t *testing.T) {
 			modifier := &Helper{
 				RESTClient:      client,
 				NamespaceScoped: true,
+				Subresource:     tt.subresource,
 			}
 			obj, err := modifier.Get("bar", "foo")
 
@@ -356,6 +398,34 @@ func TestHelperList(t *testing.T) {
 		},
 		{
 			name: "test3",
+			Resp: &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     header(),
+				Body: objBody(&corev1.PodList{
+					Items: []corev1.Pod{{
+						ObjectMeta: metav1.ObjectMeta{Name: "foo"},
+					},
+					},
+				}),
+			},
+			Req: func(req *http.Request) bool {
+				if req.Method != "GET" {
+					t.Errorf("unexpected method: %#v", req)
+					return false
+				}
+				if req.URL.Path != "/namespaces/bar" {
+					t.Errorf("url doesn't contain name: %#v", req.URL)
+					return false
+				}
+				if req.URL.Query().Get(metav1.LabelSelectorQueryParam(corev1GV.String())) != labels.SelectorFromSet(labels.Set{"foo": "baz"}).String() {
+					t.Errorf("url doesn't contain query parameters: %#v", req.URL)
+					return false
+				}
+				return true
+			},
+		},
+		{
+			name: "test with",
 			Resp: &http.Response{
 				StatusCode: http.StatusOK,
 				Header:     header(),
@@ -501,6 +571,7 @@ func TestHelperReplace(t *testing.T) {
 		Object          runtime.Object
 		Namespace       string
 		NamespaceScoped bool
+		Subresource     string
 
 		ExpectPath   string
 		ExpectObject runtime.Object
@@ -592,6 +663,29 @@ func TestHelperReplace(t *testing.T) {
 			Resp:            &http.Response{StatusCode: http.StatusOK, Header: header(), Body: objBody(&metav1.Status{Status: metav1.StatusSuccess})},
 			Req:             expectPut,
 		},
+		{
+			Name:            "test7 - with status subresource",
+			Namespace:       "bar",
+			NamespaceScoped: true,
+			Subresource:     "status",
+			Object: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "foo"},
+				Status:     V1DeepEqualSafePodStatus(),
+			},
+			ExpectPath: "/namespaces/bar/foo/status",
+			ExpectObject: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "foo", ResourceVersion: "10"},
+				Status:     V1DeepEqualSafePodStatus(),
+			},
+			Overwrite: true,
+			HTTPClient: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+				if req.Method == "PUT" {
+					return &http.Response{StatusCode: http.StatusOK, Header: header(), Body: objBody(&metav1.Status{Status: metav1.StatusSuccess})}, nil
+				}
+				return &http.Response{StatusCode: http.StatusOK, Header: header(), Body: objBody(&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "foo", ResourceVersion: "10"}})}, nil
+			}),
+			Req: expectPut,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.Name, func(t *testing.T) {
@@ -605,6 +699,7 @@ func TestHelperReplace(t *testing.T) {
 			modifier := &Helper{
 				RESTClient:      client,
 				NamespaceScoped: tt.NamespaceScoped,
+				Subresource:     tt.Subresource,
 			}
 			_, err := modifier.Replace(tt.Namespace, "foo", tt.Overwrite, tt.Object)
 			if (err != nil) != tt.Err {

--- a/staging/src/k8s.io/cli-runtime/pkg/resource/visitor.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/resource/visitor.go
@@ -78,12 +78,16 @@ type Info struct {
 	// defined. If retrieved from the server, the Builder expects the mapping client to
 	// decide the final form. Use the AsVersioned, AsUnstructured, and AsInternal helpers
 	// to alter the object versions.
+	// If Subresource is specified, this will be the object for the subresource.
 	Object runtime.Object
 	// Optional, this is the most recent resource version the server knows about for
 	// this type of resource. It may not match the resource version of the object,
 	// but if set it should be equal to or newer than the resource version of the
 	// object (however the server defines resource version).
 	ResourceVersion string
+	// Optional, if specified, the object is the most recent value of the subresource
+	// returned by the server if available.
+	Subresource string
 }
 
 // Visit implements Visitor
@@ -93,7 +97,7 @@ func (i *Info) Visit(fn VisitorFunc) error {
 
 // Get retrieves the object from the Namespace and Name fields
 func (i *Info) Get() (err error) {
-	obj, err := NewHelper(i.Client, i.Mapping).Get(i.Namespace, i.Name)
+	obj, err := NewHelper(i.Client, i.Mapping).WithSubresource(i.Subresource).Get(i.Namespace, i.Name)
 	if err != nil {
 		if errors.IsNotFound(err) && len(i.Namespace) > 0 && i.Namespace != metav1.NamespaceDefault && i.Namespace != metav1.NamespaceAll {
 			err2 := i.Client.Get().AbsPath("api", "v1", "namespaces", i.Namespace).Do(context.TODO()).Error()

--- a/staging/src/k8s.io/kubectl/pkg/cmd/edit/edit.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/edit/edit.go
@@ -63,7 +63,10 @@ var (
 		kubectl edit job.v1.batch/myjob -o json
 
 		# Edit the deployment 'mydeployment' in YAML and save the modified config in its annotation
-		kubectl edit deployment/mydeployment -o yaml --save-config`))
+		kubectl edit deployment/mydeployment -o yaml --save-config
+
+		# Edit the deployment/mydeployment's status subresource
+		kubectl edit deployment mydeployment --subresource='status'`))
 )
 
 // NewCmdEdit creates the `edit` command
@@ -80,6 +83,7 @@ func NewCmdEdit(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *cobra
 		ValidArgsFunction:     util.ResourceTypeAndNameCompletionFunc(f),
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdutil.CheckErr(o.Complete(f, args, cmd))
+			cmdutil.CheckErr(o.Validate())
 			cmdutil.CheckErr(o.Run())
 		},
 	}
@@ -96,5 +100,6 @@ func NewCmdEdit(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *cobra
 		"Defaults to the line ending native to your platform.")
 	cmdutil.AddFieldManagerFlagVar(cmd, &o.FieldManager, "kubectl-edit")
 	cmdutil.AddApplyAnnotationVarFlags(cmd, &o.ApplyAnnotation)
+	cmdutil.AddSubresourceFlags(cmd, &o.Subresource, "If specified, edit will operate on the subresource of the requested object.", editor.SupportedSubresources...)
 	return cmd
 }

--- a/staging/src/k8s.io/kubectl/pkg/cmd/edit/edit_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/edit/edit_test.go
@@ -53,6 +53,7 @@ type EditTestCase struct {
 	Output           string   `yaml:"outputFormat"`
 	OutputPatch      string   `yaml:"outputPatch"`
 	SaveConfig       string   `yaml:"saveConfig"`
+	Subresource      string   `yaml:"subresource"`
 	Namespace        string   `yaml:"namespace"`
 	ExpectedStdout   []string `yaml:"expectedStdout"`
 	ExpectedStderr   []string `yaml:"expectedStderr"`
@@ -252,6 +253,9 @@ func TestEdit(t *testing.T) {
 			}
 			if len(testcase.SaveConfig) > 0 {
 				cmd.Flags().Set("save-config", testcase.SaveConfig)
+			}
+			if len(testcase.Subresource) > 0 {
+				cmd.Flags().Set("subresource", testcase.Subresource)
 			}
 
 			cmdutil.BehaviorOnFatal(func(str string, code int) {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/edit/testdata/testcase-edit-subresource-status/0.response
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/edit/testdata/testcase-edit-subresource-status/0.response
@@ -1,0 +1,85 @@
+{
+    "apiVersion": "apps/v1",
+    "kind": "Deployment",
+    "metadata": {
+        "annotations": {
+            "deployment.kubernetes.io/revision": "1"
+        },
+        "creationTimestamp": "2021-06-23T17:01:10Z",
+        "generation": 5,
+        "labels": {
+            "app": "nginx"
+        },
+        "name": "nginx",
+        "namespace": "edit-test",
+        "resourceVersion": "121107",
+        "uid": "a598ee47-9635-482b-bacb-16c9e3ade05c"
+    },
+    "spec": {
+        "progressDeadlineSeconds": 600,
+        "replicas": 3,
+        "revisionHistoryLimit": 10,
+        "selector": {
+            "matchLabels": {
+                "app": "nginx"
+            }
+        },
+        "strategy": {
+            "rollingUpdate": {
+                "maxSurge": "25%",
+                "maxUnavailable": "25%"
+            },
+            "type": "RollingUpdate"
+        },
+        "template": {
+            "metadata": {
+                "creationTimestamp": null,
+                "labels": {
+                    "app": "nginx"
+                }
+            },
+            "spec": {
+                "containers": [
+                    {
+                        "image": "gcr.io/kakaraparthy-devel/nginx:latest",
+                        "imagePullPolicy": "Always",
+                        "name": "nginx",
+                        "resources": {},
+                        "terminationMessagePath": "/dev/termination-log",
+                        "terminationMessagePolicy": "File"
+                    }
+                ],
+                "dnsPolicy": "ClusterFirst",
+                "restartPolicy": "Always",
+                "schedulerName": "default-scheduler",
+                "securityContext": {},
+                "terminationGracePeriodSeconds": 30
+            }
+        }
+    },
+    "status": {
+        "availableReplicas": 3,
+        "conditions": [
+            {
+                "lastTransitionTime": "2021-06-23T17:01:10Z",
+                "lastUpdateTime": "2021-06-23T17:01:18Z",
+                "message": "ReplicaSet \"nginx-6f5fdbd667\" has successfully progressed.",
+                "reason": "NewReplicaSetAvailable",
+                "status": "True",
+                "type": "Progressing"
+            },
+            {
+                "lastTransitionTime": "2021-06-23T17:59:01Z",
+                "lastUpdateTime": "2021-06-23T17:59:01Z",
+                "message": "Deployment has minimum availability.",
+                "reason": "MinimumReplicasAvailable",
+                "status": "True",
+                "type": "Available"
+            }
+        ],
+        "observedGeneration": 5,
+        "readyReplicas": 3,
+        "replicas": 3,
+        "updatedReplicas": 3
+    }
+}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/edit/testdata/testcase-edit-subresource-status/1.edited
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/edit/testdata/testcase-edit-subresource-status/1.edited
@@ -1,0 +1,66 @@
+# Please edit the object below. Lines beginning with a '#' will be ignored,
+# and an empty file will abort the edit. If an error occurs while saving this file will be
+# reopened with the relevant failures.
+#
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    deployment.kubernetes.io/revision: "1"
+  creationTimestamp: "2021-06-23T17:01:10Z"
+  generation: 5
+  labels:
+    app: nginx
+  name: nginx
+  namespace: edit-test
+  resourceVersion: "121107"
+  uid: a598ee47-9635-482b-bacb-16c9e3ade05c
+spec:
+  progressDeadlineSeconds: 600
+  replicas: 3
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: nginx
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - image: gcr.io/kakaraparthy-devel/nginx:latest
+        imagePullPolicy: Always
+        name: nginx
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30
+status:
+  availableReplicas: 3
+  conditions:
+  - lastTransitionTime: "2021-06-23T17:01:10Z"
+    lastUpdateTime: "2021-06-23T17:01:18Z"
+    message: ReplicaSet "nginx-6f5fdbd667" has successfully progressed.
+    reason: NewReplicaSetAvailable
+    status: "True"
+    type: Progressing
+  - lastTransitionTime: "2021-06-23T17:59:01Z"
+    lastUpdateTime: "2021-06-23T17:59:01Z"
+    message: Deployment has minimum availability.
+    reason: MinimumReplicasAvailable
+    status: "True"
+    type: Available
+  observedGeneration: 5
+  readyReplicas: 3
+  replicas: 4
+  updatedReplicas: 3

--- a/staging/src/k8s.io/kubectl/pkg/cmd/edit/testdata/testcase-edit-subresource-status/1.original
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/edit/testdata/testcase-edit-subresource-status/1.original
@@ -1,0 +1,66 @@
+# Please edit the object below. Lines beginning with a '#' will be ignored,
+# and an empty file will abort the edit. If an error occurs while saving this file will be
+# reopened with the relevant failures.
+#
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    deployment.kubernetes.io/revision: "1"
+  creationTimestamp: "2021-06-23T17:01:10Z"
+  generation: 5
+  labels:
+    app: nginx
+  name: nginx
+  namespace: edit-test
+  resourceVersion: "121107"
+  uid: a598ee47-9635-482b-bacb-16c9e3ade05c
+spec:
+  progressDeadlineSeconds: 600
+  replicas: 3
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: nginx
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - image: gcr.io/kakaraparthy-devel/nginx:latest
+        imagePullPolicy: Always
+        name: nginx
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30
+status:
+  availableReplicas: 3
+  conditions:
+  - lastTransitionTime: "2021-06-23T17:01:10Z"
+    lastUpdateTime: "2021-06-23T17:01:18Z"
+    message: ReplicaSet "nginx-6f5fdbd667" has successfully progressed.
+    reason: NewReplicaSetAvailable
+    status: "True"
+    type: Progressing
+  - lastTransitionTime: "2021-06-23T17:59:01Z"
+    lastUpdateTime: "2021-06-23T17:59:01Z"
+    message: Deployment has minimum availability.
+    reason: MinimumReplicasAvailable
+    status: "True"
+    type: Available
+  observedGeneration: 5
+  readyReplicas: 3
+  replicas: 3
+  updatedReplicas: 3

--- a/staging/src/k8s.io/kubectl/pkg/cmd/edit/testdata/testcase-edit-subresource-status/2.request
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/edit/testdata/testcase-edit-subresource-status/2.request
@@ -1,0 +1,5 @@
+{
+  "status": {
+    "replicas": 4
+  }
+}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/edit/testdata/testcase-edit-subresource-status/2.response
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/edit/testdata/testcase-edit-subresource-status/2.response
@@ -1,0 +1,85 @@
+{
+    "apiVersion": "apps/v1",
+    "kind": "Deployment",
+    "metadata": {
+        "annotations": {
+            "deployment.kubernetes.io/revision": "1"
+        },
+        "creationTimestamp": "2021-06-23T17:01:10Z",
+        "generation": 5,
+        "labels": {
+            "app": "nginx"
+        },
+        "name": "nginx",
+        "namespace": "edit-test",
+        "resourceVersion": "121107",
+        "uid": "a598ee47-9635-482b-bacb-16c9e3ade05c"
+    },
+    "spec": {
+        "progressDeadlineSeconds": 600,
+        "replicas": 3,
+        "revisionHistoryLimit": 10,
+        "selector": {
+            "matchLabels": {
+                "app": "nginx"
+            }
+        },
+        "strategy": {
+            "rollingUpdate": {
+                "maxSurge": "25%",
+                "maxUnavailable": "25%"
+            },
+            "type": "RollingUpdate"
+        },
+        "template": {
+            "metadata": {
+                "creationTimestamp": null,
+                "labels": {
+                    "app": "nginx"
+                }
+            },
+            "spec": {
+                "containers": [
+                    {
+                        "image": "gcr.io/kakaraparthy-devel/nginx:latest",
+                        "imagePullPolicy": "Always",
+                        "name": "nginx",
+                        "resources": {},
+                        "terminationMessagePath": "/dev/termination-log",
+                        "terminationMessagePolicy": "File"
+                    }
+                ],
+                "dnsPolicy": "ClusterFirst",
+                "restartPolicy": "Always",
+                "schedulerName": "default-scheduler",
+                "securityContext": {},
+                "terminationGracePeriodSeconds": 30
+            }
+        }
+    },
+    "status": {
+        "availableReplicas": 3,
+        "conditions": [
+            {
+                "lastTransitionTime": "2021-06-23T17:01:10Z",
+                "lastUpdateTime": "2021-06-23T17:01:18Z",
+                "message": "ReplicaSet \"nginx-6f5fdbd667\" has successfully progressed.",
+                "reason": "NewReplicaSetAvailable",
+                "status": "True",
+                "type": "Progressing"
+            },
+            {
+                "lastTransitionTime": "2021-06-23T17:59:01Z",
+                "lastUpdateTime": "2021-06-23T17:59:01Z",
+                "message": "Deployment has minimum availability.",
+                "reason": "MinimumReplicasAvailable",
+                "status": "True",
+                "type": "Available"
+            }
+        ],
+        "observedGeneration": 5,
+        "readyReplicas": 3,
+        "replicas": 4,
+        "updatedReplicas": 3
+    }
+}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/edit/testdata/testcase-edit-subresource-status/test.yaml
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/edit/testdata/testcase-edit-subresource-status/test.yaml
@@ -1,0 +1,27 @@
+description: edit the status subresource
+mode: edit
+args:
+  - deployment
+  - nginx
+namespace: edit-test
+subresource: status
+expectedStdOut:
+  - deployment.apps/nginx edited
+expectedExitCode: 0
+steps:
+  - type: request
+    expectedMethod: GET
+    expectedPath: /apis/extensions/v1beta1/namespaces/edit-test/deployments/nginx/status
+    expectedInput: 0.request
+    resultingStatusCode: 200
+    resultingOutput: 0.response
+  - type: edit
+    expectedInput: 1.original
+    resultingOutput: 1.edited
+  - type: request
+    expectedMethod: PATCH
+    expectedPath: /apis/apps/v1/namespaces/edit-test/deployments/nginx/status
+    expectedContentType: application/strategic-merge-patch+json
+    expectedInput: 2.request
+    resultingStatusCode: 200
+    resultingOutput: 2.response

--- a/staging/src/k8s.io/kubectl/pkg/cmd/get/get_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/get/get_test.go
@@ -242,6 +242,60 @@ foo    <unknown>
 	}
 }
 
+func TestGetObjectSubresourceStatus(t *testing.T) {
+	_, _, replicationcontrollers := cmdtesting.TestData()
+
+	tf := cmdtesting.NewTestFactory().WithNamespace("test")
+	defer tf.Cleanup()
+	codec := scheme.Codecs.LegacyCodec(scheme.Scheme.PrioritizedVersionsAllGroups()...)
+
+	tf.UnstructuredClient = &fake.RESTClient{
+		NegotiatedSerializer: resource.UnstructuredPlusDefaultContentConfig().NegotiatedSerializer,
+		Resp:                 &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, &replicationcontrollers.Items[0])},
+	}
+
+	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
+	cmd := NewCmdGet("kubectl", tf, streams)
+	cmd.SetOutput(buf)
+	cmd.Flags().Set("subresource", "status")
+	cmd.Run(cmd, []string{"replicationcontrollers", "rc1"})
+
+	expected := `NAME   AGE
+rc1    <unknown>
+`
+
+	if e, a := expected, buf.String(); e != a {
+		t.Errorf("expected\n%v\ngot\n%v", e, a)
+	}
+}
+
+func TestGetObjectSubresourceScale(t *testing.T) {
+	_, _, replicationcontrollers := cmdtesting.TestData()
+
+	tf := cmdtesting.NewTestFactory().WithNamespace("test")
+	defer tf.Cleanup()
+	codec := scheme.Codecs.LegacyCodec(scheme.Scheme.PrioritizedVersionsAllGroups()...)
+
+	tf.UnstructuredClient = &fake.RESTClient{
+		NegotiatedSerializer: resource.UnstructuredPlusDefaultContentConfig().NegotiatedSerializer,
+		Resp:                 &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: replicationControllersScaleSubresourceTableObjBody(codec, replicationcontrollers.Items[0])},
+	}
+
+	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
+	cmd := NewCmdGet("kubectl", tf, streams)
+	cmd.SetOutput(buf)
+	cmd.Flags().Set("subresource", "scale")
+	cmd.Run(cmd, []string{"replicationcontrollers", "rc1"})
+
+	expected := `NAME   DESIRED   AVAILABLE
+rc1    1         0
+`
+
+	if e, a := expected, buf.String(); e != a {
+		t.Errorf("expected\n%v\ngot\n%v", e, a)
+	}
+}
+
 func TestGetTableObjects(t *testing.T) {
 	pods, _, _ := cmdtesting.TestData()
 
@@ -2899,6 +2953,26 @@ func componentStatusTableObjBody(codec runtime.Codec, componentStatuses ...corev
 func emptyTableObjBody(codec runtime.Codec) io.ReadCloser {
 	table := &metav1.Table{
 		ColumnDefinitions: podColumns,
+	}
+	return cmdtesting.ObjBody(codec, table)
+}
+
+func replicationControllersScaleSubresourceTableObjBody(codec runtime.Codec, replicationControllers ...corev1.ReplicationController) io.ReadCloser {
+	table := &metav1.Table{
+		ColumnDefinitions: []metav1.TableColumnDefinition{
+			{Name: "Name", Type: "string", Description: metav1.ObjectMeta{}.SwaggerDoc()["name"]},
+			{Name: "Desired", Type: "integer", Description: autoscalingv1.ScaleSpec{}.SwaggerDoc()["replicas"]},
+			{Name: "Available", Type: "integer", Description: autoscalingv1.ScaleStatus{}.SwaggerDoc()["replicas"]},
+		},
+	}
+
+	for i := range replicationControllers {
+		b := bytes.NewBuffer(nil)
+		codec.Encode(&replicationControllers[i], b)
+		table.Rows = append(table.Rows, metav1.TableRow{
+			Object: runtime.RawExtension{Raw: b.Bytes()},
+			Cells:  []interface{}{replicationControllers[i].Name, replicationControllers[i].Spec.Replicas, replicationControllers[i].Status.Replicas},
+		})
 	}
 	return cmdtesting.ObjBody(codec, table)
 }

--- a/staging/src/k8s.io/kubectl/pkg/cmd/patch/patch.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/patch/patch.go
@@ -41,6 +41,7 @@ import (
 	"k8s.io/kubectl/pkg/scheme"
 	"k8s.io/kubectl/pkg/util"
 	"k8s.io/kubectl/pkg/util/i18n"
+	"k8s.io/kubectl/pkg/util/slice"
 	"k8s.io/kubectl/pkg/util/templates"
 )
 
@@ -56,10 +57,11 @@ type PatchOptions struct {
 	ToPrinter   func(string) (printers.ResourcePrinter, error)
 	Recorder    genericclioptions.Recorder
 
-	Local     bool
-	PatchType string
-	Patch     string
-	PatchFile string
+	Local       bool
+	PatchType   string
+	Patch       string
+	PatchFile   string
+	Subresource string
 
 	namespace                    string
 	enforceNamespace             bool
@@ -94,8 +96,13 @@ var (
 		kubectl patch pod valid-pod -p '{"spec":{"containers":[{"name":"kubernetes-serve-hostname","image":"new image"}]}}'
 
 		# Update a container's image using a JSON patch with positional arrays
-		kubectl patch pod valid-pod --type='json' -p='[{"op": "replace", "path": "/spec/containers/0/image", "value":"new image"}]'`))
+		kubectl patch pod valid-pod --type='json' -p='[{"op": "replace", "path": "/spec/containers/0/image", "value":"new image"}]'
+		
+		# Update a deployment's replicas through the scale subresource using a merge patch.
+		kubectl patch deployment nginx-deployment --subresource='scale' --type='merge' -p '{"spec":{"replicas":2}}'`))
 )
+
+var supportedSubresources = []string{"status", "scale"}
 
 func NewPatchOptions(ioStreams genericclioptions.IOStreams) *PatchOptions {
 	return &PatchOptions{
@@ -133,6 +140,7 @@ func NewCmdPatch(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *cobr
 	cmdutil.AddFilenameOptionFlags(cmd, &o.FilenameOptions, "identifying the resource to update")
 	cmd.Flags().BoolVar(&o.Local, "local", o.Local, "If true, patch will operate on the content of the file, not the server-side resource.")
 	cmdutil.AddFieldManagerFlagVar(cmd, &o.fieldManager, "kubectl-patch")
+	cmdutil.AddSubresourceFlags(cmd, &o.Subresource, "If specified, patch will operate on the subresource of the requested object.", supportedSubresources...)
 
 	return cmd
 }
@@ -192,7 +200,9 @@ func (o *PatchOptions) Validate() error {
 			return fmt.Errorf("--type must be one of %v, not %q", sets.StringKeySet(patchTypes).List(), o.PatchType)
 		}
 	}
-
+	if len(o.Subresource) > 0 && !slice.ContainsString(supportedSubresources, o.Subresource, nil) {
+		return fmt.Errorf("invalid subresource value: %q. Must be one of %v", o.Subresource, supportedSubresources)
+	}
 	return nil
 }
 
@@ -224,6 +234,7 @@ func (o *PatchOptions) RunPatch() error {
 		LocalParam(o.Local).
 		NamespaceParam(o.namespace).DefaultNamespace().
 		FilenameParam(o.enforceNamespace, &o.FilenameOptions).
+		Subresource(o.Subresource).
 		ResourceTypeOrNameArgs(false, o.args...).
 		Flatten().
 		Do()
@@ -255,7 +266,8 @@ func (o *PatchOptions) RunPatch() error {
 			helper := resource.
 				NewHelper(client, mapping).
 				DryRun(o.dryRunStrategy == cmdutil.DryRunServer).
-				WithFieldManager(o.fieldManager)
+				WithFieldManager(o.fieldManager).
+				WithSubresource(o.Subresource)
 			patchedObj, err := helper.Patch(namespace, name, patchType, patchBytes, nil)
 			if err != nil {
 				return err

--- a/staging/src/k8s.io/kubectl/pkg/cmd/testing/util.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/testing/util.go
@@ -150,6 +150,22 @@ func EmptyTestData() (*corev1.PodList, *corev1.ServiceList, *corev1.ReplicationC
 	return pods, svc, rc
 }
 
+func SubresourceTestData() *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "test", ResourceVersion: "10"},
+		Spec: corev1.PodSpec{
+			RestartPolicy:                 corev1.RestartPolicyAlways,
+			DNSPolicy:                     corev1.DNSClusterFirst,
+			TerminationGracePeriodSeconds: &grace,
+			SecurityContext:               &corev1.PodSecurityContext{},
+			EnableServiceLinks:            &enableServiceLinks,
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodPending,
+		},
+	}
+}
+
 func GenResponseWithJsonEncodedBody(bodyStruct interface{}) (*http.Response, error) {
 	jsonBytes, err := json.Marshal(bodyStruct)
 	if err != nil {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/util/helpers.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/util/helpers.go
@@ -468,6 +468,10 @@ func AddLabelSelectorFlagVar(cmd *cobra.Command, p *string) {
 	cmd.Flags().StringVarP(p, "selector", "l", *p, "Selector (label query) to filter on, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2). Matching objects must satisfy all of the specified label constraints.")
 }
 
+func AddSubresourceFlags(cmd *cobra.Command, subresource *string, usage string, allowedSubresources ...string) {
+	cmd.Flags().StringVar(subresource, "subresource", "", fmt.Sprintf("%s Must be one of %v. This flag is alpha and may change in the future.", usage, allowedSubresources))
+}
+
 type ValidateOptions struct {
 	EnableValidation bool
 }

--- a/test/cmd/get.sh
+++ b/test/cmd/get.sh
@@ -175,6 +175,14 @@ run_kubectl_get_tests() {
   output_message=$(! kubectl get pod valid-pod --allow-missing-template-keys=false -o go-template='{{.missing}}' "${kube_flags[@]}")
   kube::test::if_has_string "${output_message}" 'map has no entry for key "missing"'
 
+  ## check --subresource=status works
+  output_message=$(kubectl get "${kube_flags[@]}" pod valid-pod --subresource=status)
+  kube::test::if_has_string "${output_message}" 'valid-pod'
+
+   ## check --subresource=scale returns an error for pods
+  output_message=$(! kubectl get pod valid-pod --subresource=scale 2>&1 "${kube_flags[@]:?}")
+  kube::test::if_has_string "${output_message}" 'the server could not find the requested resource'
+
   ### Test kubectl get watch
   output_message=$(kubectl get pods -w --request-timeout=1 "${kube_flags[@]}")
   kube::test::if_has_string "${output_message}" 'STATUS'    # headers


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
xref https://github.com/kubernetes/kubectl/issues/564#issuecomment-621327402, https://github.com/kubernetes/kubernetes/issues/15858#issuecomment-624686815, https://github.com/kubernetes/kubernetes/issues/67455
Follow up to https://github.com/kubernetes/kubernetes/pull/60902, https://github.com/kubernetes/kubernetes/pull/67454

Implements the KEP - https://github.com/kubernetes/enhancements/tree/master/keps/sig-cli/2590-kubectl-subresource

This PR adds `--subresource` support to get, patch and replace commands.


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
An alpha flag --subresource is added to get, patch, edit replace kubectl commands to fetch and update status and scale subresources.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
- [KEP]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-cli/2590-kubectl-subresource
```
