### PR TITLE
fix e2e test kube-proxy tcp_wait

### DIFF
--- a/test/e2e/network/kube_proxy.go
+++ b/test/e2e/network/kube_proxy.go
@@ -213,7 +213,7 @@ var _ = common.SIGDescribe("KubeProxy", func() {
 		cmd := fmt.Sprintf("conntrack -L -f %s -d %v "+
 			"| grep -m 1 'CLOSE_WAIT.*dport=%v' ",
 			ipFamily, ip, testDaemonTCPPort)
-		if err := wait.PollImmediate(2*time.Second, epsilonSeconds, func() (bool, error) {
+		if err := wait.PollImmediate(2*time.Second, epsilonSeconds*time.Second, func() (bool, error) {
 			result, err := framework.RunHostCmd(fr.Namespace.Name, "e2e-net-exec", cmd)
 			// retry if we can't obtain the conntrack entry
 			if err != nil {


### PR DESCRIPTION
/kind flake
```release-note
NONE
```

wait.Pollimmediate expects duration and we were passing the absolute value of seconds
:upside_down_face: 