### PR TITLE
migrate log in pkg/volume/volume_linux.go

### DIFF
--- a/pkg/volume/volume_linux.go
+++ b/pkg/volume/volume_linux.go
@@ -66,7 +66,7 @@ func SetVolumeOwnership(mounter Mounter, fsGroup *int64, fsGroupChangePolicy *v1
 	}
 
 	if skipPermissionChange(mounter, fsGroup, fsGroupChangePolicy) {
-		klog.V(3).Infof("skipping permission and ownership change for volume %s", mounter.GetPath())
+		klog.V(3).InfoS("Skipping permission and ownership change for volume", "path", mounter.GetPath())
 		return nil
 	}
 
@@ -96,7 +96,7 @@ func legacyOwnershipChange(mounter Mounter, fsGroup *int64) error {
 func changeFilePermission(filename string, fsGroup *int64, readonly bool, info os.FileInfo) error {
 	err := os.Lchown(filename, -1, int(*fsGroup))
 	if err != nil {
-		klog.Errorf("Lchown failed on %v: %v", filename, err)
+		klog.ErrorS(err, "Lchown failed", "path", filename)
 	}
 
 	// chmod passes through to the underlying file for symlinks.
@@ -122,7 +122,7 @@ func changeFilePermission(filename string, fsGroup *int64, readonly bool, info o
 
 	err = os.Chmod(filename, info.Mode()|mask)
 	if err != nil {
-		klog.Errorf("Chmod failed on %v: %v", filename, err)
+		klog.ErrorS(err, "Chown failed", "path", filename)
 	}
 
 	return nil
@@ -132,7 +132,7 @@ func skipPermissionChange(mounter Mounter, fsGroup *int64, fsGroupChangePolicy *
 	dir := mounter.GetPath()
 
 	if fsGroupChangePolicy == nil || *fsGroupChangePolicy != v1.FSGroupChangeOnRootMismatch {
-		klog.V(4).Infof("perform recursive ownership change for %s", dir)
+		klog.V(4).InfoS("Perform recursive ownership change for directory", "path", dir)
 		return false
 	}
 	return !requiresPermissionChange(mounter.GetPath(), fsGroup, mounter.GetAttributes().ReadOnly)
@@ -141,17 +141,17 @@ func skipPermissionChange(mounter Mounter, fsGroup *int64, fsGroupChangePolicy *
 func requiresPermissionChange(rootDir string, fsGroup *int64, readonly bool) bool {
 	fsInfo, err := os.Stat(rootDir)
 	if err != nil {
-		klog.Errorf("performing recursive ownership change on %s because reading permissions of root volume failed: %v", rootDir, err)
+		klog.ErrorS(err, "Performing recursive ownership change on rootDir because reading permissions of root volume failed", "path", rootDir)
 		return true
 	}
 	stat, ok := fsInfo.Sys().(*syscall.Stat_t)
 	if !ok || stat == nil {
-		klog.Errorf("performing recursive ownership change on %s because reading permissions of root volume failed", rootDir)
+		klog.ErrorS(nil, "Performing recursive ownership change on rootDir because reading permissions of root volume failed", "path", rootDir)
 		return true
 	}
 
 	if int(stat.Gid) != int(*fsGroup) {
-		klog.V(4).Infof("expected group ownership of volume %s did not match with: %d", rootDir, stat.Gid)
+		klog.V(4).InfoS("Expected group ownership of volume did not match with Gid", "path", rootDir, "GID", stat.Gid)
 		return true
 	}
 	unixPerms := rwMask
@@ -175,7 +175,7 @@ func requiresPermissionChange(rootDir string, fsGroup *int64, readonly bool) boo
 	//     unixPerms: 770, filePerms: 750 : 770&750 = 750 (perms on directory is NOT a superset)
 	// We also need to check if setgid bits are set in permissions of the directory.
 	if (unixPerms&filePerm != unixPerms) || (fsInfo.Mode()&os.ModeSetgid == 0) {
-		klog.V(4).Infof("performing recursive ownership change on %s because of mismatching mode", rootDir)
+		klog.V(4).InfoS("Performing recursive ownership change on rootDir because of mismatching mode", "path", rootDir)
 		return true
 	}
 	return false


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Ref:

* [keps/sig-instrumentation/1602-structured-logging](https://github.com/kubernetes/enhancements/tree/master/keps/sig-instrumentation/1602-structured-logging)
* [Structured Logging migration instructions](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/migration-to-structured-logging.md)

**Does this PR introduce a user-facing change?**:

```release-note
Migrate some log messages to structured logging in pkg/volume/volume_linux.go.
```
