### PR TITLE
kubectl logs: don't check default container annotation if --all-containers is specified

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/polymorphichelpers/logsforobject.go
+++ b/staging/src/k8s.io/kubectl/pkg/polymorphichelpers/logsforobject.go
@@ -73,30 +73,31 @@ func logsForObjectWithClient(clientset corev1client.CoreV1Interface, object, opt
 		return ret, nil
 
 	case *corev1.Pod:
-		// in case the "kubectl.kubernetes.io/default-container" annotation is present, we preset the opts.Containers to default to selected
-		// container. This gives users ability to preselect the most interesting container in pod.
-		if annotations := t.GetAnnotations(); annotations != nil && len(opts.Container) == 0 {
-			var containerName string
-			if len(annotations[defaultLogsContainerAnnotationName]) > 0 {
-				containerName = annotations[defaultLogsContainerAnnotationName]
-				fmt.Fprintf(os.Stderr, "Using deprecated annotation `kubectl.kubernetes.io/default-logs-container` in pod/%v. Please use `kubectl.kubernetes.io/default-container` instead\n", t.Name)
-			} else if len(annotations[podutils.DefaultContainerAnnotationName]) > 0 {
-				containerName = annotations[podutils.DefaultContainerAnnotationName]
-			}
-			if len(containerName) > 0 {
-				if exists, _ := podutils.FindContainerByName(t, containerName); exists != nil {
-					opts.Container = containerName
-				} else {
-					fmt.Fprintf(os.Stderr, "Default container name %q not found in a pod\n", containerName)
-				}
-			}
-		}
 		// if allContainers is true, then we're going to locate all containers and then iterate through them. At that point, "allContainers" is false
 		if !allContainers {
+			// in case the "kubectl.kubernetes.io/default-container" annotation is present, we preset the opts.Containers to default to selected
+			// container. This gives users ability to preselect the most interesting container in pod.
+			if annotations := t.GetAnnotations(); annotations != nil && len(opts.Container) == 0 {
+				var containerName string
+				if len(annotations[defaultLogsContainerAnnotationName]) > 0 {
+					containerName = annotations[defaultLogsContainerAnnotationName]
+					fmt.Fprintf(os.Stderr, "Using deprecated annotation `kubectl.kubernetes.io/default-logs-container` in pod/%v. Please use `kubectl.kubernetes.io/default-container` instead\n", t.Name)
+				} else if len(annotations[podutils.DefaultContainerAnnotationName]) > 0 {
+					containerName = annotations[podutils.DefaultContainerAnnotationName]
+				}
+				if len(containerName) > 0 {
+					if exists, _ := podutils.FindContainerByName(t, containerName); exists != nil {
+						opts.Container = containerName
+					} else {
+						fmt.Fprintf(os.Stderr, "Default container name %q not found in a pod\n", containerName)
+					}
+				}
+			}
+
 			var containerName string
 			if opts == nil || len(opts.Container) == 0 {
 				// We don't know container name. In this case we expect only one container to be present in the pod (ignoring InitContainers).
-				// If there is more than one container we should return an error showing all container names.
+				// If there is more than one container, we should return an error showing all container names.
 				if len(t.Spec.Containers) != 1 {
 					containerNames := getContainerNames(t.Spec.Containers)
 					initContainerNames := getContainerNames(t.Spec.InitContainers)


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/kind cleanup

#### What this PR does / why we need it:
issue from #97099

`kubectl logs valid-pod  --all-containers` should not check `kubectl.kubernetes.io/default-logs-container` annotation or `kubectl.kubernetes.io/default-container`.

#### Which issue(s) this PR fixes:
Issue found in testing.

#### Special notes for your reviewer:
Testing data here
```
[root@daocloud logs]# /root/kubectl-1.21.0-alpha.1 logs valid-pod --all-containers
Hello, World!
2 Hello, World!
[root@daocloud logs]#
[root@daocloud logs]# /root/kubectl-master logs valid-pod  --all-containers
Using deprecated annotation `kubectl.kubernetes.io/default-logs-container` in pod/valid-pod. Please use `kubectl.kubernetes.io/default-container` instead
Hello, World!
2 Hello, World!
[root@daocloud logs]#
[root@daocloud logs]# /root/kubectl-with-fix logs valid-pod  --all-containers
Hello, World!
2 Hello, World!
```
A sample for testing is like below:
```
apiVersion: v1
kind: Pod
metadata:
  annotations:
    kubectl.kubernetes.io/default-logs-container: hello-2
    kubectl.kubernetes.io/default-container: hello-1
  labels:
    app: log-testing
  name: hello-logs
spec:
  containers:
  - image: daocloud.io/daocloud/hello-logs:1
    imagePullPolicy: IfNotPresent
    name: hello-1
  - image: daocloud.io/daocloud/hello-logs:2
    imagePullPolicy: IfNotPresent
    name: hello-2
```

#### Does this PR introduce a user-facing change?
```release-note
None
```
