### PR TITLE
When a pod has been completed, the pod doesn't need to be evicted by kube-controller.

### DIFF
--- a/cmd/kube-controller-manager/app/core.go
+++ b/cmd/kube-controller-manager/app/core.go
@@ -434,6 +434,7 @@ func startPodGCController(ctx ControllerContext) (http.Handler, bool, error) {
 		ctx.ClientBuilder.ClientOrDie("pod-garbage-collector"),
 		ctx.InformerFactory.Core().V1().Pods(),
 		ctx.InformerFactory.Core().V1().Nodes(),
+		ctx.InformerFactory.Batch().V1().Jobs(),
 		int(ctx.ComponentConfig.PodGCController.TerminatedPodGCThreshold),
 	).Run(ctx.Stop)
 	return nil, true, nil

--- a/pkg/controller/testutil/test_utils.go
+++ b/pkg/controller/testutil/test_utils.go
@@ -441,6 +441,13 @@ func NewNode(name string) *v1.Node {
 	}
 }
 
+// NewPodWithSpecialPhase is a helper function for creating Pods with special phase for testing.
+func NewPodWithSpecialPhase(name, host string, podPhase v1.PodPhase) *v1.Pod {
+	pod := NewPod(name, host)
+	pod.Status.Phase = podPhase
+	return pod
+}
+
 // NewPod is a helper function for creating Pods for testing.
 func NewPod(name, host string) *v1.Pod {
 	pod := &v1.Pod{

--- a/pkg/controller/util/node/controller_utils.go
+++ b/pkg/controller/util/node/controller_utils.go
@@ -72,6 +72,12 @@ func DeletePods(kubeClient clientset.Interface, pods []*v1.Pod, recorder record.
 			remaining = true
 			continue
 		}
+
+		// the terminated pod should be ignored during eviction.
+		if IsPodInTerminatedState(pod) {
+			continue
+		}
+
 		// if the pod is managed by a daemonset, ignore it
 		if _, err := daemonStore.GetPodDaemonSets(pod); err == nil {
 			// No error means at least one daemonset was found
@@ -299,4 +305,9 @@ func GetNodeCondition(status *v1.NodeStatus, conditionType v1.NodeConditionType)
 		}
 	}
 	return -1, nil
+}
+
+// IsPodInTerminatedState will return true, if the pod in terminated state.
+func IsPodInTerminatedState(pod *v1.Pod) bool {
+	return pod.Status.Phase == v1.PodFailed || pod.Status.Phase == v1.PodSucceeded
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

When a pod has been finalized, the pod doesn't need to be evicted by kube-controller. Because if the job has a finalized pod, but the pod is evicted by kube-controller due to node damage, the job will have to execute this pod again.

If user really need to restart the pod, user can manually(or by API) evict the pod. This will give users more choice to avoid meaningless resource consumption.

#### Which issue(s) this PR fixes:

[Fixes #96363](https://github.com/kubernetes/kubernetes/issues/96363)

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

