### PR TITLE
Fix staticcheck failures for vendor/k8s.io/apiserver/pkg/server/{dynamiccertificates,filters}

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/dynamiccertificates/tlsconfig.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/dynamiccertificates/tlsconfig.go
@@ -108,11 +108,13 @@ func (c *DynamicServingCertificateController) GetConfigForClient(clientHello *tl
 		return tlsConfigCopy, nil
 	}
 
+	//lint:ignore SA1019 backwards compatibility
 	ipCert, ok := tlsConfigCopy.NameToCertificate[host]
 	if !ok {
 		return tlsConfigCopy, nil
 	}
 	tlsConfigCopy.Certificates = []tls.Certificate{*ipCert}
+	//lint:ignore SA1019 backwards compatibility
 	tlsConfigCopy.NameToCertificate = nil
 
 	return tlsConfigCopy, nil
@@ -206,6 +208,7 @@ func (c *DynamicServingCertificateController) syncCerts() error {
 	}
 
 	if len(newContent.sniCerts) > 0 {
+		//lint:ignore SA1019 backwards compatibility
 		newTLSConfigCopy.NameToCertificate, err = c.BuildNamedCertificates(newContent.sniCerts)
 		if err != nil {
 			return fmt.Errorf("unable to build named certificate map: %v", err)
@@ -215,6 +218,7 @@ func (c *DynamicServingCertificateController) syncCerts() error {
 		// is necessary because there is only one cert anyway.
 		// Moreover, if servingCert is not set, the first SNI
 		// cert will become the default cert. That's what we expect anyway.
+		//lint:ignore SA1019 backwards compatibility
 		for _, sniCert := range newTLSConfigCopy.NameToCertificate {
 			newTLSConfigCopy.Certificates = append(newTLSConfigCopy.Certificates, *sniCert)
 		}

--- a/staging/src/k8s.io/apiserver/pkg/server/filters/timeout.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/filters/timeout.go
@@ -269,6 +269,7 @@ func (tw *baseTimeoutWriter) CloseNotify() <-chan bool {
 
 	// the outer ResponseWriter object returned by WrapForHTTP1Or2 implements
 	// http.CloseNotifier if the inner object (tw.w) implements http.CloseNotifier.
+	//lint:ignore SA1019 There are places in the code base requiring the CloseNotifier interface to be implemented.
 	return tw.w.(http.CloseNotifier).CloseNotify()
 }
 


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Part of #92402
```
vendor/k8s.io/apiserver/pkg/server/dynamiccertificates/tlsconfig.go:111:16: tlsConfigCopy.NameToCertificate is deprecated: NameToCertificate only allows associating a single certificate with a given name. Leave this field nil to let the library select the first compatible chain from Certificates.  (SA1019)
vendor/k8s.io/apiserver/pkg/server/dynamiccertificates/tlsconfig.go:116:2: tlsConfigCopy.NameToCertificate is deprecated: NameToCertificate only allows associating a single certificate with a given name. Leave this field nil to let the library select the first compatible chain from Certificates.  (SA1019)
vendor/k8s.io/apiserver/pkg/server/dynamiccertificates/tlsconfig.go:209:3: newTLSConfigCopy.NameToCertificate is deprecated: NameToCertificate only allows associating a single certificate with a given name. Leave this field nil to let the library select the first compatible chain from Certificates.  (SA1019)
vendor/k8s.io/apiserver/pkg/server/dynamiccertificates/tlsconfig.go:218:27: newTLSConfigCopy.NameToCertificate is deprecated: NameToCertificate only allows associating a single certificate with a given name. Leave this field nil to let the library select the first compatible chain from Certificates.  (SA1019)
vendor/k8s.io/apiserver/pkg/server/filters/goaway_test.go:110:2: var responseBodySize is unused (U1000)
vendor/k8s.io/apiserver/pkg/server/filters/goaway_test.go:118:6: func newTestGOAWAYServer is unused (U1000)
vendor/k8s.io/apiserver/pkg/server/filters/priority-and-fairness_test.go:452:3: the goroutine calls T.Fatalf, which must be called in the same goroutine as the test (SA2002)
vendor/k8s.io/apiserver/pkg/server/filters/priority-and-fairness_test.go:1010:3: call to T.Fatalf
vendor/k8s.io/apiserver/pkg/server/filters/priority-and-fairness_test.go:530:3: the goroutine calls T.Fatalf, which must be called in the same goroutine as the test (SA2002)
vendor/k8s.io/apiserver/pkg/server/filters/priority-and-fairness_test.go:1010:3: call to T.Fatalf
vendor/k8s.io/apiserver/pkg/server/filters/priority-and-fairness_test.go:605:3: the goroutine calls T.Fatalf, which must be called in the same goroutine as the test (SA2002)
vendor/k8s.io/apiserver/pkg/server/filters/priority-and-fairness_test.go:1010:3: call to T.Fatalf
vendor/k8s.io/apiserver/pkg/server/filters/priority-and-fairness_test.go:683:3: the goroutine calls T.Fatalf, which must be called in the same goroutine as the test (SA2002)
vendor/k8s.io/apiserver/pkg/server/filters/priority-and-fairness_test.go:1010:3: call to T.Fatalf
vendor/k8s.io/apiserver/pkg/server/filters/priority-and-fairness_test.go:691:3: the goroutine calls T.Fatalf, which must be called in the same goroutine as the test (SA2002)
vendor/k8s.io/apiserver/pkg/server/filters/priority-and-fairness_test.go:696:5: call to T.Fatalf
vendor/k8s.io/apiserver/pkg/server/filters/timeout.go:147:22: http.CloseNotifier is deprecated: the CloseNotifier interface predates Go's context package. New code should use Request.Context instead.  (SA1019)
vendor/k8s.io/apiserver/pkg/server/filters/timeout.go:267:15: http.CloseNotifier is deprecated: the CloseNotifier interface predates Go's context package. New code should use Request.Context instead.  (SA1019)

```
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
