### PR TITLE
kubeadm: a warning to user as ipv6 site-local is deprecated

### DIFF
--- a/cmd/kubeadm/app/apis/kubeadm/validation/validation.go
+++ b/cmd/kubeadm/app/apis/kubeadm/validation/validation.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	bootstrapapi "k8s.io/cluster-bootstrap/token/api"
 	bootstraputil "k8s.io/cluster-bootstrap/token/util"
+	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	kubeadmapiv1beta2 "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta2"
 	kubeadmcmdoptions "k8s.io/kubernetes/cmd/kubeadm/app/cmd/options"
@@ -398,6 +399,12 @@ func ValidateIPNetFromString(subnetStr string, minAddrs int64, isDualStack bool,
 		numAddresses := utilnet.RangeSize(s)
 		if numAddresses < minAddrs {
 			allErrs = append(allErrs, field.Invalid(fldPath, s.String(), fmt.Sprintf("subnet with %d address(es) is too small, the minimum is %d", numAddresses, minAddrs)))
+		}
+
+		// Warn when the subnet is in site-local range - i.e. contains addresses that belong to fec0::/10
+		_, siteLocalNet, _ := net.ParseCIDR("fec0::/10")
+		if siteLocalNet.Contains(s.IP) || s.Contains(siteLocalNet.IP) {
+			klog.Warningf("the subnet %v contains IPv6 site-local addresses that belong to fec0::/10 which has been deprecated by rfc3879", s)
 		}
 	}
 	return allErrs


### PR DESCRIPTION
#### What type of PR is this?
/sig network
/kind feature
/cc @aojea 

#### What this PR does / why we need it:
Site local addresses are the ones that belong to the range FEC0::/10 and are deprecated

As it is deprecated, we may disallow this subnet or give a warning when the user uses this subnet.
Or it would be a error.

#### Which issue(s) this PR fixes:
same as #91935

#### Special notes for your reviewer:
See details in https://github.com/kubernetes/kubernetes/pull/89251#issuecomment-601397169

http://linux-ip.net/html/tools-ip-address.html
Site-local addresses are supposed to be used within a site. Routers will not forward any packet with site-local source or destination address outside the site.

https://tools.ietf.org/html/rfc3879
deprecated in 2004

#### Does this PR introduce a user-facing change?
```release-note
kubeadm: a warning to user as ipv6 site-local is deprecated
```
