### PR TITLE
print <none> when custome column array is out of bound

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/get/customcolumn.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/get/customcolumn.go
@@ -241,7 +241,10 @@ func (s *CustomColumnsPrinter) printOneObject(obj runtime.Object, parsers []*jso
 			values, err = parser.FindResults(reflect.ValueOf(obj).Elem().Interface())
 		}
 
-		if err != nil {
+		if err != nil && strings.Contains(fmt.Sprint(err), "array index out of bounds") {
+			// print <none> and the parsing error when out of bound error like .status.conditions[99].status and continue
+			fmt.Fprintln(out, err)
+		} else if err != nil {
 			return err
 		}
 		valueStrings := []string{}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/get/customcolumn_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/get/customcolumn_test.go
@@ -421,10 +421,13 @@ fake3
 			expectErr: false,
 		},
 		{
-			name:           "containers[5], illegal expression because it is out of bounds",
-			spec:           "CONTAINER:.spec.containers[5].name",
-			expectedOutput: "",
-			expectErr:      true,
+			name: "containers[5], print <none> because it is out of bounds",
+			spec: "CONTAINER:.spec.containers[5].name",
+			expectedOutput: `CONTAINER
+array index out of bounds: index 5, length 4
+<none>
+`,
+			expectErr: false,
 		},
 		{
 			name: "containers[-1], it equals containers[3]",
@@ -451,10 +454,13 @@ fake0
 			expectErr: false,
 		},
 		{
-			name:           "containers[-5], illegal expression because it is out of bounds",
-			spec:           "CONTAINER:.spec.containers[-5].name",
-			expectedOutput: "",
-			expectErr:      true,
+			name: "containers[-5], print <none> for illegal expression because it is out of bounds",
+			spec: "CONTAINER:.spec.containers[-5].name",
+			expectedOutput: `CONTAINER
+array index out of bounds: index -1, length 4
+<none>
+`,
+			expectErr: false,
 		},
 		{
 			name: "containers[0:0], it equals empty set",
@@ -538,6 +544,15 @@ fake1,fake2
 			name: "containers[-5:-5], it equals empty set",
 			spec: "CONTAINER:.spec.containers[-5:-5].name",
 			expectedOutput: `CONTAINER
+<none>
+`,
+			expectErr: false,
+		},
+		{
+			name: "conditions[99], print <none> because it is out of bounds",
+			spec: "STATUS:.status.conditions[99].status",
+			expectedOutput: `STATUS
+array index out of bounds: index 99, length 0
 <none>
 `,
 			expectErr: false,


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

Fixes https://github.com/kubernetes/kubectl/issues/996

#### Special notes for your reviewer:
custom-columns stops abruptly when hitting a non-existent array index

Before
```
[root@daocloud logs]# /root/kubectl-dev get pods -o=custom-columns=STATUS:.status.conditions[9].status
STATUS
TRUE
error: array index out of bounds: index 9, length 4
TRUE
```


After 

```
[root@daocloud logs]# /root/kubectl-dev get pods -o=custom-columns=STATUS:.status.conditions[9].status
STATUS
TRUE
<none>
TRUE
```

#### Does this PR introduce a user-facing change?
```release-note
kubectl: return none when the custom-column array is out of bound 
```