### PR TITLE
custom plugin config should take precedence over default plugin config

### DIFF
--- a/pkg/scheduler/apis/config/v1beta2/default_plugins.go
+++ b/pkg/scheduler/apis/config/v1beta2/default_plugins.go
@@ -147,19 +147,34 @@ func mergePlugins(defaultPlugins, customPlugins *v1beta2.Plugins) *v1beta2.Plugi
 	return defaultPlugins
 }
 
+type pluginIndex struct {
+	index  int
+	plugin v1beta2.Plugin
+}
+
 func mergePluginSet(defaultPluginSet, customPluginSet v1beta2.PluginSet) v1beta2.PluginSet {
 	disabledPlugins := sets.NewString()
+	enabledCustomPlugins := make(map[string]pluginIndex)
 	for _, disabledPlugin := range customPluginSet.Disabled {
 		disabledPlugins.Insert(disabledPlugin.Name)
 	}
-
+	for index, enabledPlugin := range customPluginSet.Enabled {
+		enabledCustomPlugins[enabledPlugin.Name] = pluginIndex{index, enabledPlugin}
+	}
 	var enabledPlugins []v1beta2.Plugin
 	if !disabledPlugins.Has("*") {
 		for _, defaultEnabledPlugin := range defaultPluginSet.Enabled {
 			if disabledPlugins.Has(defaultEnabledPlugin.Name) {
 				continue
 			}
-
+			// The default plugin is explicitly re-configured, update the default plugin accordingly.
+			if customPlugin, ok := enabledCustomPlugins[defaultEnabledPlugin.Name]; ok {
+				klog.InfoS("Defaut plugin is explicitly re-configured and is overriding.", "plugin", defaultEnabledPlugin.Name)
+				// update the default plugin in place to preserve order
+				defaultEnabledPlugin = customPlugin.plugin
+				// kick the plugin from the enabled list of custom plugins
+				customPluginSet.Enabled = append(customPluginSet.Enabled[:customPlugin.index], customPluginSet.Enabled[customPlugin.index+1:]...)
+			}
 			enabledPlugins = append(enabledPlugins, defaultEnabledPlugin)
 		}
 	}

--- a/pkg/scheduler/apis/config/v1beta2/default_plugins_test.go
+++ b/pkg/scheduler/apis/config/v1beta2/default_plugins_test.go
@@ -359,6 +359,58 @@ func TestMergePlugins(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "CustomPluginOverrideDefaultPlugin",
+			customPlugins: &v1beta2.Plugins{
+				Filter: v1beta2.PluginSet{
+					Enabled: []v1beta2.Plugin{
+						{Name: "Plugin1", Weight: pointer.Int32Ptr(2)},
+					},
+				},
+			},
+			defaultPlugins: &v1beta2.Plugins{
+				Filter: v1beta2.PluginSet{
+					Enabled: []v1beta2.Plugin{
+						{Name: "Plugin1"},
+					},
+				},
+			},
+			expectedPlugins: &v1beta2.Plugins{
+				Filter: v1beta2.PluginSet{
+					Enabled: []v1beta2.Plugin{
+						{Name: "Plugin1", Weight: pointer.Int32Ptr(2)},
+					},
+				},
+			},
+		},
+		{
+			name: "OrderPreserveAfterOverride",
+			customPlugins: &v1beta2.Plugins{
+				Filter: v1beta2.PluginSet{
+					Enabled: []v1beta2.Plugin{
+						{Name: "Plugin2", Weight: pointer.Int32Ptr(2)},
+					},
+				},
+			},
+			defaultPlugins: &v1beta2.Plugins{
+				Filter: v1beta2.PluginSet{
+					Enabled: []v1beta2.Plugin{
+						{Name: "Plugin1"},
+						{Name: "Plugin2"},
+						{Name: "Plugin3"},
+					},
+				},
+			},
+			expectedPlugins: &v1beta2.Plugins{
+				Filter: v1beta2.PluginSet{
+					Enabled: []v1beta2.Plugin{
+						{Name: "Plugin1"},
+						{Name: "Plugin2", Weight: pointer.Int32Ptr(2)},
+						{Name: "Plugin3"},
+					},
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/staging/src/k8s.io/kube-scheduler/config/v1beta2/types.go
+++ b/staging/src/k8s.io/kube-scheduler/config/v1beta2/types.go
@@ -197,6 +197,8 @@ type Plugins struct {
 // If an array is empty, missing, or nil, default plugins at that extension point will be used.
 type PluginSet struct {
 	// Enabled specifies plugins that should be enabled in addition to default plugins.
+	// If the default plugin is also configured in the scheduler config file, the weight of plugin will
+	// be overridden accordingly.
 	// These are called after default plugins and in the same order specified here.
 	// +listType=atomic
 	Enabled []Plugin `json:"enabled,omitempty"`


### PR DESCRIPTION
Signed-off-by: Dave Chen <dave.chen@arm.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

Add one of the following kinds:
/kind bug



#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubernetes/issues/99580

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kube-scheduler: a plugin enabled in a v1beta2 configuration file takes precedence over the default configuration for that plugin; this simplifies enabling default plugins with custom configuration without needing to explicitly disable those default plugins.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
