### PR TITLE
dockershim: fix started and finished timestamp of the container status 

### DIFF
--- a/pkg/kubelet/dockershim/docker_container.go
+++ b/pkg/kubelet/dockershim/docker_container.go
@@ -387,12 +387,15 @@ func (ds *dockerService) ContainerStatus(_ context.Context, req *runtimeapi.Cont
 			// Note: Can't set SeLinuxRelabel
 		})
 	}
-	// Interpret container states.
+	// Interpret container states and convert time to unix timestamps.
 	var state runtimeapi.ContainerState
 	var reason, message string
+	ct, st, ft := createdAt.UnixNano(), int64(0), int64(0)
 	if r.State.Running {
 		// Container is running.
 		state = runtimeapi.ContainerState_CONTAINER_RUNNING
+		// If container is not in the exited state, not set finished timestamp
+		st = startedAt.UnixNano()
 	} else {
 		// Container is *not* running. We need to get more details.
 		//    * Case 1: container has run and exited with non-zero finishedAt
@@ -402,6 +405,7 @@ func (ds *dockerService) ContainerStatus(_ context.Context, req *runtimeapi.Cont
 		//    * Case 3: container has been created, but not started (yet).
 		if !finishedAt.IsZero() { // Case 1
 			state = runtimeapi.ContainerState_CONTAINER_EXITED
+			st, ft = startedAt.UnixNano(), finishedAt.UnixNano()
 			switch {
 			case r.State.OOMKilled:
 				// TODO: consider exposing OOMKilled via the runtimeAPI.
@@ -415,18 +419,15 @@ func (ds *dockerService) ContainerStatus(_ context.Context, req *runtimeapi.Cont
 			}
 		} else if r.State.ExitCode != 0 { // Case 2
 			state = runtimeapi.ContainerState_CONTAINER_EXITED
-			// Adjust finshedAt and startedAt time to createdAt time to avoid
+			// Adjust finished and started timestamp to createdAt time to avoid
 			// the confusion.
-			finishedAt, startedAt = createdAt, createdAt
+			st, ft = createdAt.UnixNano(), createdAt.UnixNano()
 			reason = "ContainerCannotRun"
 		} else { // Case 3
 			state = runtimeapi.ContainerState_CONTAINER_CREATED
 		}
 		message = r.State.Error
 	}
-
-	// Convert to unix timestamps.
-	ct, st, ft := createdAt.UnixNano(), startedAt.UnixNano(), finishedAt.UnixNano()
 	exitCode := int32(r.State.ExitCode)
 
 	metadata, err := parseContainerName(r.Name)

--- a/pkg/kubelet/dockershim/docker_container_test.go
+++ b/pkg/kubelet/dockershim/docker_container_test.go
@@ -182,9 +182,6 @@ func TestContainerStatus(t *testing.T) {
 	imageName := "iamimage"
 	config := makeContainerConfig(sConfig, "pause", imageName, 0, labels, annotations)
 
-	var defaultTime time.Time
-	dt := defaultTime.UnixNano()
-	ct, st, ft := dt, dt, dt
 	state := runtimeapi.ContainerState_CONTAINER_CREATED
 	imageRef := DockerImageIDPrefix + imageName
 	// The following variables are not set in FakeDockerClient.
@@ -193,9 +190,6 @@ func TestContainerStatus(t *testing.T) {
 
 	expected := &runtimeapi.ContainerStatus{
 		State:       state,
-		CreatedAt:   ct,
-		StartedAt:   st,
-		FinishedAt:  ft,
 		Metadata:    config.Metadata,
 		Image:       config.Image,
 		ImageRef:    imageRef,


### PR DESCRIPTION
Signed-off-by: Iceber Gu <wei.cai-nat@daocloud.io>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug


#### What this PR does / why we need it:
When use `crictl`，Finished time is always `1754-08-31T06:49:24.128654848+08:05` in the run and create states, because `FinishedAt` is `-6795364578871345152`
```sh
[root@iceber-3 ~]# crictl inspect 587444fc34ec9
{
  "status": {
    "id": "587444fc34ec9846c163d0c74bbf985ac73662817a89e16b7328b955a03ef902",
    "metadata": {
      "attempt": 6,
      "name": "dx-arch-stolon-sentinel"
    },
    "state": "CONTAINER_RUNNING",
    "createdAt": "2021-03-01T16:45:23.390180141+08:00",
    "startedAt": "2021-03-01T16:45:23.544299436+08:00",
    "finishedAt": "1754-08-31T06:49:24.128654848+08:05",
    "exitCode": 0,
```
I think the default started and finished timestamp should be 0(zero value), not `-6795364578871345152`.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

#### Special notes for your reviewer:
fix `crictl`: https://github.com/kubernetes-sigs/cri-tools/pull/724

Convert `runtimeapi.ContainerStatus` to `kubecontainer.Status` in the [`toKubeContainerStatus`](https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/kuberuntime/kuberuntime_container.go#L493)
https://github.com/kubernetes/kubernetes/blob/793390e13be91d79150b57abad5710477ab96bd7/pkg/kubelet/kuberuntime/kuberuntime_container.go#L510-L522
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Return zero time (midnight on Jan. 1, 1970) instead of negative number when reporting startedAt and finishedAt of the not started or a running Pod when using dockershim as a runtime.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
