### PR TITLE
Avoid kubelet warnings for imagePullSecret entries with empty names

### DIFF
--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -881,6 +881,11 @@ func (kl *Kubelet) getPullSecretsForPod(pod *v1.Pod) []v1.Secret {
 	pullSecrets := []v1.Secret{}
 
 	for _, secretRef := range pod.Spec.ImagePullSecrets {
+		if len(secretRef.Name) == 0 {
+			// API validation permitted entries with empty names (http://issue.k8s.io/99454#issuecomment-787838112).
+			// Ignore to avoid unnecessary warnings.
+			continue
+		}
 		secret, err := kl.secretManager.GetSecret(pod.Namespace, secretRef.Name)
 		if err != nil {
 			klog.Warningf("Unable to retrieve pull secret %s/%s for %s/%s due to %v.  The image pull may not succeed.", pod.Namespace, secretRef.Name, pod.Namespace, pod.Name, err)


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Unfortunately, API validation permits imagePullSecret entries with empty Name fields (xref https://github.com/kubernetes/kubernetes/issues/99454#issuecomment-787838112). The kubelet should skip those when computing pull secrets, rather than warning when the unnamed secret predictably cannot be fetched.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/cc @wojtek-t 
/sig node