### PR TITLE
e2e testing for hugepages downward api

### DIFF
--- a/test/e2e/framework/skipper/skipper.go
+++ b/test/e2e/framework/skipper/skipper.go
@@ -46,6 +46,8 @@ import (
 // New local storage types to support local storage capacity isolation
 var localStorageCapacityIsolation featuregate.Feature = "LocalStorageCapacityIsolation"
 
+var downwardAPIHugePages featuregate.Feature = "DownwardAPIHugePages"
+
 func skipInternalf(caller int, format string, args ...interface{}) {
 	msg := fmt.Sprintf(format, args...)
 	framework.Logf(msg)
@@ -134,6 +136,12 @@ func SkipUnlessAtLeast(value int, minValue int, message string) {
 func SkipUnlessLocalEphemeralStorageEnabled() {
 	if !utilfeature.DefaultFeatureGate.Enabled(localStorageCapacityIsolation) {
 		skipInternalf(1, "Only supported when %v feature is enabled", localStorageCapacityIsolation)
+	}
+}
+
+func SkipUnlessDownwardAPIHugePagesEnabled() {
+	if !utilfeature.DefaultFeatureGate.Enabled(downwardAPIHugePages) {
+		skipInternalf(1, "Only supported when %v feature is enabled", downwardAPIHugePages)
 	}
 }
 


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
Add e2e testing for hugepages in downward API.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:
Related KEP:
https://github.com/kubernetes/enhancements/pull/2352

Usage of hugepages requires cpu or memory are specified to pass validation.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
- [KEP]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/2053-downward-api-hugepages
```
