### PR TITLE
fix wrong NumCPU in kube-proxy under static CPU policy

### DIFF
--- a/cmd/kube-proxy/app/server.go
+++ b/cmd/kube-proxy/app/server.go
@@ -24,7 +24,6 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
-	goruntime "runtime"
 	"strings"
 	"time"
 
@@ -784,7 +783,7 @@ func getConntrackMax(config kubeproxyconfig.KubeProxyConntrackConfiguration) (in
 		if config.Min != nil {
 			floor = int(*config.Min)
 		}
-		scaled := int(*config.MaxPerCore) * goruntime.NumCPU()
+		scaled := int(*config.MaxPerCore) * detectNumCPU()
 		if scaled > floor {
 			klog.V(3).Infof("getConntrackMax: using scaled conntrack-max-per-core")
 			return scaled, nil

--- a/cmd/kube-proxy/app/server_windows.go
+++ b/cmd/kube-proxy/app/server_windows.go
@@ -24,6 +24,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	goruntime "runtime"
 
 	// Enable pprof HTTP handlers.
 	_ "net/http/pprof"
@@ -183,6 +184,10 @@ func getProxyMode(proxyMode string, kcompat winkernel.KernelCompatTester) string
 		return tryWinKernelSpaceProxy(kcompat)
 	}
 	return proxyModeUserspace
+}
+
+func detectNumCPU() int {
+	return goruntime.NumCPU()
 }
 
 func tryWinKernelSpaceProxy(kcompat winkernel.KernelCompatTester) string {


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
Fixes wrong NumCPU used in conntrack-max calculation in kube-proxy on nodes with static CPU policy turned on.

#### Which issue(s) this PR fixes:
Fixes #99225

#### Special notes for your reviewer:
kube-proxy will try look up CPU core number in Node resource info to calculate conntrack-max, only if failed, it will then lookup through golang's `runtime.NumCPU()`.

#### Does this PR introduce a user-facing change?
```release-note
Fixed a bug that causes smaller number of conntrack-max being used under CPU static policy. (#99225, @xh4n3)
```