### PR TITLE
kubectl: print info for default container annotation usage

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/util/helpers.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/util/helpers.go
@@ -756,6 +756,7 @@ func GetDefaultContainerName(pod *corev1.Pod, enableSuggestedCmdUsage bool, w io
 		if annotations := pod.Annotations; annotations != nil && len(annotations[podutils.DefaultContainerAnnotationName]) > 0 {
 			containerName := annotations[podutils.DefaultContainerAnnotationName]
 			if exists, _ := podutils.FindContainerByName(pod, containerName); exists != nil {
+				fmt.Fprintf(w, "Defaulting container name to container %s.\n", containerName)
 				return containerName
 			} else {
 				fmt.Fprintf(w, "Default container name %q in annotation not found in a pod\n", containerName)


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/kind cleanup

#### What this PR does / why we need it:
Defaulting container name should be print if `-c` is not specified.

When there is no annotation for default container, the log print is like below
```
kubectl exec -it [pod-name] -- sh
kubectl exec [POD] [COMMAND] is DEPRECATED and will be removed in a future version. Use kubectl exec [POD] -- [COMMAND] instead.
Defaulting container name to container-1.
Use 'kubectl describe pod/valid-pod -n default' to see all of the containers in this pod.
# ps aux
```
If no annotation is specified:
```
kubectl exec -it [pod-name]sh
Defaulting container name to container-1.
# ps aux
```

When I add `kubectl.kubernetes.io/default-container: container-2` to pod, there is no log for which container is selected.
```
kubectl exec -it [pod-name]sh
# ps aux
```

Expected:
```
kubectl exec -it [pod-name]sh
Defaulting container name to container-2.
# ps aux
```


#### Which issue(s) this PR fixes:
default container related

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```