### PR TITLE
 cleanup surround LocalStorageCapacityIsolation and ephemeral-storage

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -69,6 +69,7 @@ const (
 	RotateKubeletServerCertificate featuregate.Feature = "RotateKubeletServerCertificate"
 
 	// owner: @jinxu
+	// alpha: v1.7
 	// beta: v1.10
 	//
 	// New local storage types to support local storage capacity isolation

--- a/pkg/volume/util/fsquota/quota.go
+++ b/pkg/volume/util/fsquota/quota.go
@@ -46,5 +46,5 @@ type Interface interface {
 }
 
 func enabledQuotasForMonitoring() bool {
-	return utilfeature.DefaultFeatureGate.Enabled(features.LocalStorageCapacityIsolationFSQuotaMonitoring)
+	return utilfeature.DefaultFeatureGate.Enabled(features.LocalStorageCapacityIsolation) && utilfeature.DefaultFeatureGate.Enabled(features.LocalStorageCapacityIsolationFSQuotaMonitoring)
 }


### PR DESCRIPTION
#### What type of PR is this?
> /kind bug
> see #101882

/kind cleanup

> #### What this PR does / why we need it:
> If the ephemeral storage capacity of the node is 0, it means it was during startup(Cadvisor is not ready yet.).
> At this time we should not check ephemeral storage anymore.
> 
> BTW, if kubelet just starts, only static pods with ephemeral storage requests may meet this problem.

#### Which issue(s) this PR fixes:
xref #99305

> The logic will get ephemeral-storage as the beginning. However, if cadvisor is not available, the join still may fail for this reason.


#### Special notes for your reviewer:
I did some cleanup surround LocalStorageCapacityIsolation and ephemeral-storage.
It is alpha in 1.8 and LocalStorageCapacityIsolationFSQuotaMonitoring should be turned on only if LocalStorageCapacityIsolation is enabled as well.

> As #99305 shown, the initial value of ephemeral-storage is not `Format:BinarySI`.
> ```
> Feb 22 14:04:33 NEWHOST kubelet[7331]: E0222 14:04:33.666413    7331 setters.go:527] TRACE capacity memory: {i:{value:42191773696 scale:0} d:{Dec:<nil>} s: Format:BinarySI}
> Feb 22 14:04:33 NEWHOST kubelet[7331]: E0222 14:04:33.666425    7331 setters.go:527] TRACE capacity pods: {i:{value:210 scale:0} d:{Dec:<nil>} s: Format:DecimalSI}
> Feb 22 14:04:33 NEWHOST kubelet[7331]: E0222 14:04:33.666435    7331 setters.go:527] TRACE capacity ephemeral-storage: {i:{value:0 scale:0} d:{Dec:<nil>} s: Format:}not 
> ```
> 

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
