### PR TITLE
fix warnings in hack/verify-external-dependencies-version.sh

### DIFF
--- a/build/dependencies.yaml
+++ b/build/dependencies.yaml
@@ -85,6 +85,7 @@ dependencies:
     - path: cluster/gce/upgrade-aliases.sh
       match: ETCD_IMAGE|ETCD_VERSION
     - path: cmd/kubeadm/app/constants/constants.go
+      match: DefaultEtcdVersion =
     - path: hack/lib/etcd.sh
       match: ETCD_VERSION=
     - path: staging/src/k8s.io/sample-apiserver/artifacts/example/deployment.yaml
@@ -98,6 +99,7 @@ dependencies:
     - path: cluster/images/etcd/Makefile
       match: BUNDLED_ETCD_VERSIONS\?|LATEST_ETCD_VERSION\?
     - path: cluster/images/etcd/migrate/options.go
+      match: supportedEtcdVersions
 
   # Golang
   - name: "golang: upstream version"


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
A lot of warning when I browse pull-kubernetes-dependencies logs.
https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/99574//1366699229757575168

#### Which issue(s) this PR fixes:

Fixes None

#### Special notes for your reviewer:
Warnings like below
```
INFO Validating zeitgeist options...
WARN Line 1 matches expected regexp '', but not version '3.4.13': /*
WARN Line 2 matches expected regexp '', but not version '3.4.13': Copyright 2019 The Kubernetes Authors.
WARN Line 3 matches expected regexp '', but not version '3.4.13':
WARN Line 4 matches expected regexp '', but not version '3.4.13': Licensed under the Apache License, Version 2.0 (the "License");
WARN Line 5 matches expected regexp '', but not version '3.4.13': you may not use this file except in compliance with the License.
WARN Line 6 matches expected regexp '', but not version '3.4.13': You may obtain a copy of the License at
WARN Line 7 matches expected regexp '', but not version '3.4.13':
WARN Line 8 matches expected regexp '', but not version '3.4.13':     http://www.apache.org/licenses/LICENSE-2.0
WARN Line 9 matches expected regexp '', but not version '3.4.13':
WARN Line 10 matches expected regexp '', but not version '3.4.13': Unless required by applicable law or agreed to in writing, software
WARN Line 11 matches expected regexp '', but not version '3.4.13': distributed under the License is distributed on an "AS IS" BASIS,
WARN Line 12 matches expected regexp '', but not version '3.4.13': WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
WARN
```
#### Does this PR introduce a user-facing change?
```release-note
None
```
