### PR TITLE
[WIP]kubelet: make running pod metrics more accurate

### DIFF
--- a/pkg/kubelet/pleg/generic_test.go
+++ b/pkg/kubelet/pleg/generic_test.go
@@ -704,7 +704,7 @@ kubelet_running_containers{container_state="unknown"} 2
 			wants: `
 # HELP kubelet_running_pods [ALPHA] Number of pods currently running
 # TYPE kubelet_running_pods gauge
-kubelet_running_pods 2
+kubelet_running_pods 1
 `,
 		},
 	}


### PR DESCRIPTION
**Edited**
- this PR tries to make the `kubelet_running_pod` more accurate with the CLI shows.
- However, https://github.com/kubernetes/kubernetes/issues/99624#issuecomment-823412461, it just means that `how many pods have running containers in the container runtime, and mainly for debugging purpose.`

#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
Does this change will introduce a performance issue? 

#### Which issue(s) this PR fixes:
Fixes #99624

#### Special notes for your reviewer:
Another way to fix it, is to rename the metrics name.

Here kubelet_running_pods is more like kubelet_running_sandboxes (It will take all pod into account if the pause container started.)

This depends on how we define `Running Pod`
https://github.com/kubernetes/kubernetes/blob/66cbf0196bd5ed0f06d7c40fccba887aae5405d8/pkg/apis/core/types.go#L2283-L2289

> 	// PodRunning means the pod has been bound to a node and all of the containers have been started.
> 	// At least one container is still running or is in the process of being restarted.
> 	PodRunning PodPhase = "Running"

kubectl get pod -o yaml  -A | grep 'phase: Running' | wc -l

#### Does this PR introduce a user-facing change?
```release-note
kubelet calculate running pod more accurate for metrics
```
