### PR TITLE
Improve warnings for default-container

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/polymorphichelpers/logsforobject.go
+++ b/staging/src/k8s.io/kubectl/pkg/polymorphichelpers/logsforobject.go
@@ -79,11 +79,15 @@ func logsForObjectWithClient(clientset corev1client.CoreV1Interface, object, opt
 			// container. This gives users ability to preselect the most interesting container in pod.
 			if annotations := t.GetAnnotations(); annotations != nil && len(opts.Container) == 0 {
 				var containerName string
-				if len(annotations[defaultLogsContainerAnnotationName]) > 0 {
+				if len(annotations[podutils.DefaultContainerAnnotationName]) > 0 {
+					containerName = annotations[podutils.DefaultContainerAnnotationName]
+				} else if len(annotations[defaultLogsContainerAnnotationName]) > 0 {
+					// Only log deprecation if we have only the old annotation. This allows users to
+					// set both to support multiple versions of kubectl; if they are setting both
+					// they must already know it is deprecated, so we don't need to add noisy
+					// warnings.
 					containerName = annotations[defaultLogsContainerAnnotationName]
 					fmt.Fprintf(os.Stderr, "Using deprecated annotation `kubectl.kubernetes.io/default-logs-container` in pod/%v. Please use `kubectl.kubernetes.io/default-container` instead\n", t.Name)
-				} else if len(annotations[podutils.DefaultContainerAnnotationName]) > 0 {
-					containerName = annotations[podutils.DefaultContainerAnnotationName]
 				}
 				if len(containerName) > 0 {
 					if exists, _ := podutils.FindContainerByName(t, containerName); exists != nil {


### PR DESCRIPTION
Right now, there is no way to use these annotations, support multiple
`kubectl` versions, and not give users annoying warnings every time they
run `kubectl log`.

If a user is setting *both* annotations, they clearly know that the old
on is deprecated. Therefor, we should not warn them.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?


#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
