### PR TITLE
exec credential provider: use stdin to detect user interaction

### DIFF
--- a/staging/src/k8s.io/client-go/plugin/pkg/client/auth/exec/exec.go
+++ b/staging/src/k8s.io/client-go/plugin/pkg/client/auth/exec/exec.go
@@ -198,7 +198,7 @@ func newAuthenticator(c *cache, config *api.ExecConfig, cluster *clientauthentic
 
 		stdin:       os.Stdin,
 		stderr:      os.Stderr,
-		interactive: term.IsTerminal(int(os.Stdout.Fd())),
+		interactive: term.IsTerminal(int(os.Stdin.Fd())),
 		now:         time.Now,
 		environ:     os.Environ,
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

We are not sure why this was stdout, since stdin is what the user uses to pass
information to the exec plugin.

There is a question of backwards compatibility here. Our take is that this is a
bug, and so we are ameliorating behavior instead of breaking behavior. There are
2 main cases to consider with respect to backwards compatibility:

1. an existing exec plugin depended on stdin being hooked up to them if stdout
   was a terminal (e.g., echo foo | client-go-command-line-tool); we believe
   this is an anti-pattern, since the client-go-command-line-tool could be using
   stdin elsewhere (e.g., echo foo | kubectl apply -f -)

2. an existing exec plugin depended on stdin not being hooked up to them if
   stdout was not a terminal (e.g., client-go-command-line-tool >/dev/null);
   hopefully there are very few plugins that have tried to base logic off of
   whether stdin returned EOF immediately, since this could also happen when
   something else is wrong with stdin

We hope to apply a stronger fix to this exec plugin user interaction stuff in a
future release.

#### Which issue(s) this PR fixes:

Fixes https://github.com/kubernetes/kubernetes/issues/98451

#### Special notes for your reviewer:

- Related convo: https://kubernetes.slack.com/archives/C0EN96KUY/p1614713017053400?thread_ts=1614636195.030500&cid=C0EN96KUY

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
stdin is now only passed to client-go exec credential plugins when it is detected to be an interactive terminal. Previously, it was passed to client-go exec plugins when **stdout** was detected to be an interactive terminal.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

- KEP: https://github.com/kubernetes/enhancements/tree/master/keps/sig-auth/541-external-credential-providers