### PR TITLE
Update go version check to 1.16+

### DIFF
--- a/build/dependencies.yaml
+++ b/build/dependencies.yaml
@@ -120,6 +120,8 @@ dependencies:
     version: 1.16
     refPaths:
     - path: build/build-image/cross/VERSION
+    - path: hack/lib/golang.sh
+      match: minimum_go_version=go([0-9]+\.[0-9]+)
 
   - name: "k8s.gcr.io/kube-cross: dependents"
     version: v1.16.0-1

--- a/hack/lib/golang.sh
+++ b/hack/lib/golang.sh
@@ -479,7 +479,7 @@ EOF
   local go_version
   IFS=" " read -ra go_version <<< "$(GOFLAGS='' go version)"
   local minimum_go_version
-  minimum_go_version=go1.15.0
+  minimum_go_version=go1.16.0
   if [[ "${minimum_go_version}" != $(echo -e "${minimum_go_version}\n${go_version[2]}" | sort -s -t. -k 1,1 -k 2,2n -k 3,3n | head -n1) && "${go_version[2]}" != "devel" ]]; then
     kube::log::usage_from_stdin <<EOF
 Detected go version: ${go_version[*]}.


### PR DESCRIPTION
Follow up from #98572 to ensure gofmt / update-vendor / etc are run with go1.16+

/cc @justaugustus @dims 

```release-note
NONE
```