### PR TITLE
Log detailed service information during GCE Windows node startup

### DIFF
--- a/cluster/gce/windows/common.psm1
+++ b/cluster/gce/windows/common.psm1
@@ -48,6 +48,25 @@ function Log-Output {
   }
 }
 
+# Dumps detailed information about the specified service to the console output.
+# $Delay can be set to a positive value to introduce some seconds of delay
+# before querying the service information, which may produce more consistent
+# results if this function is called immediately after changing a service's
+# configuration.
+function Write-VerboseServiceInfoToConsole {
+  param (
+    [parameter(Mandatory=$true)] [string]$Service,
+    [parameter(Mandatory=$false)] [int]$Delay = 0
+  )
+  if ($Delay -gt 0) {
+    Start-Sleep $Delay
+  }
+  Get-Service -ErrorAction Continue $Service | Select-Object * | Out-String
+  & sc.exe queryex $Service
+  & sc.exe qc $Service
+  & sc.exe qfailure $Service
+}
+
 # Checks if a file should be written or overwritten by testing if it already
 # exists and checking the value of the global $REDO_STEPS variable. Emits an
 # informative message if the file already exists.

--- a/cluster/gce/windows/k8s-node-setup.psm1
+++ b/cluster/gce/windows/k8s-node-setup.psm1
@@ -317,6 +317,7 @@ function Set-PrerequisiteOptions {
   Log-Output "Disabling Windows Update service"
   & sc.exe config wuauserv start=disabled
   & sc.exe stop wuauserv
+  Write-VerboseServiceInfoToConsole -Service 'wuauserv' -Delay 1
 
   # Use TLS 1.2: needed for Invoke-WebRequest downloads from github.com.
   [Net.ServicePointManager]::SecurityProtocol = `
@@ -443,6 +444,7 @@ function Start-CSIProxy {
     & sc.exe failure csiproxy reset= 0 actions= restart/10000
     Log-Output "Starting CSI Proxy Service"
     & sc.exe start csiproxy
+    Write-VerboseServiceInfoToConsole -Service 'csiproxy' -Delay 1
   }
 }
 
@@ -1232,6 +1234,7 @@ function Start-WorkerServices {
 
   Log-Output "Waiting 10 seconds for kubelet to stabilize"
   Start-Sleep 10
+  Write-VerboseServiceInfoToConsole -Service 'kubelet'
 
   if (Get-Process | Where-Object Name -eq "kube-proxy") {
     Log-Output -Fatal `
@@ -1242,6 +1245,7 @@ function Start-WorkerServices {
   & sc.exe failure kube-proxy reset= 0 actions= restart/10000
   Log-Output "Starting kube-proxy service"
   & sc.exe start kube-proxy
+  Write-VerboseServiceInfoToConsole -Service 'kube-proxy' -Delay 1
 
   # F1020 23:08:52.000083    9136 server.go:361] unable to load in-cluster
   # configuration, KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT must be
@@ -1757,12 +1761,12 @@ function Create-LoggingAgentServices {
   Log-Output 'Creating service: ${LOGGINGAGENT_SERVICE}'
   sc.exe create $LOGGINGAGENT_SERVICE binpath= "${LOGGINGAGENT_ROOT}\bin\fluent-bit.exe -c \fluent-bit\conf\fluent-bit.conf"
   sc.exe failure $LOGGINGAGENT_SERVICE reset= 30 actions= restart/5000
-  sc.exe query $LOGGINGAGENT_SERVICE
+  Write-VerboseServiceInfoToConsole -Service $LOGGINGAGENT_SERVICE
 
   Log-Output 'Creating service: ${LOGGINGEXPORTER_SERVICE}'
   sc.exe create  $LOGGINGEXPORTER_SERVICE  binpath= "${LOGGINGEXPORTER_ROOT}\flb-exporter.exe --kubernetes-separator=_ --stackdriver-resource-model=k8s --enable-pod-label-discovery --logtostderr --winsvc  --pod-label-dot-replacement=_"
   sc.exe failure $LOGGINGEXPORTER_SERVICE reset= 30 actions= restart/5000
-  sc.exe query $LOGGINGEXPORTER_SERVICE
+  Write-VerboseServiceInfoToConsole -Service $LOGGINGEXPORTER_SERVICE
 }
 
 # Writes the logging configuration file for Logging agent. Restart-LoggingAgent
@@ -2134,6 +2138,7 @@ function Configure-StackdriverAgent {
   # seconds. The logging agent may die die to various disruptions but can be
   # resumed.
   sc.exe failure StackdriverLogging reset= 0 actions= restart/1000/restart/10000
+  Write-VerboseServiceInfoToConsole -Service 'StackdriverLogging'
 }
 
 # The NODE_NAME placeholder must be replaced with the node's name (hostname).


### PR DESCRIPTION
Writes verbose service information to the Windows console log. This is needed to see e.g. the failure + restart configurations for the various services we configure. The output can be seen in the VM's serial port output along with the rest of the startup script output.

/kind cleanup

```release-note
NONE
```