### PR TITLE
increase discovery burst for kube-controller-manager

### DIFF
--- a/cmd/kube-controller-manager/app/controllermanager.go
+++ b/cmd/kube-controller-manager/app/controllermanager.go
@@ -466,8 +466,8 @@ func CreateControllerContext(s *config.CompletedConfig, rootClientBuilder, clien
 	}
 
 	// Use a discovery client capable of being refreshed.
-	discoveryClient := rootClientBuilder.ClientOrDie("controller-discovery")
-	cachedClient := cacheddiscovery.NewMemCacheClient(discoveryClient.Discovery())
+	discoveryClient := rootClientBuilder.DiscoveryClientOrDie("controller-discovery")
+	cachedClient := cacheddiscovery.NewMemCacheClient(discoveryClient)
 	restMapper := restmapper.NewDeferredDiscoveryRESTMapper(cachedClient)
 	go wait.Until(func() {
 		restMapper.Reset()

--- a/cmd/kube-controller-manager/app/core.go
+++ b/cmd/kube-controller-manager/app/core.go
@@ -441,7 +441,8 @@ func startPodGCController(ctx ControllerContext) (http.Handler, bool, error) {
 
 func startResourceQuotaController(ctx ControllerContext) (http.Handler, bool, error) {
 	resourceQuotaControllerClient := ctx.ClientBuilder.ClientOrDie("resourcequota-controller")
-	discoveryFunc := resourceQuotaControllerClient.Discovery().ServerPreferredNamespacedResources
+	resourceQuotaControllerDiscoveryClient := ctx.ClientBuilder.DiscoveryClientOrDie("resourcequota-controller")
+	discoveryFunc := resourceQuotaControllerDiscoveryClient.ServerPreferredNamespacedResources
 	listerFuncForResource := generic.ListerFuncForResourceFunc(ctx.InformerFactory.ForResource)
 	quotaConfiguration := quotainstall.NewQuotaConfigurationForControllers(listerFuncForResource)
 
@@ -535,6 +536,7 @@ func startGarbageCollectorController(ctx ControllerContext) (http.Handler, bool,
 	}
 
 	gcClientset := ctx.ClientBuilder.ClientOrDie("generic-garbage-collector")
+	discoveryClient := ctx.ClientBuilder.DiscoveryClientOrDie("generic-garbage-collector")
 
 	config := ctx.ClientBuilder.ConfigOrDie("generic-garbage-collector")
 	metadataClient, err := metadata.NewForConfig(config)
@@ -564,7 +566,7 @@ func startGarbageCollectorController(ctx ControllerContext) (http.Handler, bool,
 
 	// Periodically refresh the RESTMapper with new discovery information and sync
 	// the garbage collector.
-	go garbageCollector.Sync(gcClientset.Discovery(), 30*time.Second, ctx.Stop)
+	go garbageCollector.Sync(discoveryClient, 30*time.Second, ctx.Stop)
 
 	return garbagecollector.NewDebugHandler(garbageCollector), true, nil
 }

--- a/cmd/kube-controller-manager/app/core_test.go
+++ b/cmd/kube-controller-manager/app/core_test.go
@@ -45,6 +45,17 @@ func (m TestClientBuilder) ClientOrDie(name string) clientset.Interface {
 	return m.clientset
 }
 
+func (m TestClientBuilder) DiscoveryClient(name string) (discovery.DiscoveryInterface, error) {
+	return m.clientset.Discovery(), nil
+}
+func (m TestClientBuilder) DiscoveryClientOrDie(name string) discovery.DiscoveryInterface {
+	ret, err := m.DiscoveryClient(name)
+	if err != nil {
+		panic(err)
+	}
+	return ret
+}
+
 // FakeDiscoveryWithError inherits DiscoveryInterface(via FakeDiscovery) with some methods accepting testing data.
 type FakeDiscoveryWithError struct {
 	fakediscovery.FakeDiscovery

--- a/staging/src/k8s.io/controller-manager/pkg/clientbuilder/client_builder.go
+++ b/staging/src/k8s.io/controller-manager/pkg/clientbuilder/client_builder.go
@@ -17,6 +17,7 @@ limitations under the License.
 package clientbuilder
 
 import (
+	"k8s.io/client-go/discovery"
 	clientset "k8s.io/client-go/kubernetes"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/klog/v2"
@@ -30,6 +31,8 @@ type ControllerClientBuilder interface {
 	ConfigOrDie(name string) *restclient.Config
 	Client(name string) (clientset.Interface, error)
 	ClientOrDie(name string) clientset.Interface
+	DiscoveryClient(name string) (discovery.DiscoveryInterface, error)
+	DiscoveryClientOrDie(name string) discovery.DiscoveryInterface
 }
 
 // SimpleControllerClientBuilder returns a fixed client with different user agents
@@ -67,6 +70,31 @@ func (b SimpleControllerClientBuilder) Client(name string) (clientset.Interface,
 // If it gets an error getting the client, it will log the error and kill the process it's running in.
 func (b SimpleControllerClientBuilder) ClientOrDie(name string) clientset.Interface {
 	client, err := b.Client(name)
+	if err != nil {
+		klog.Fatal(err)
+	}
+	return client
+}
+
+// DiscoveryClientOrDie returns a discovery.DiscoveryInterface built from the ClientBuilder
+// Discovery is special because it will artificially pump the burst quite high to handle the many discovery requests.
+func (b SimpleControllerClientBuilder) DiscoveryClient(name string) (discovery.DiscoveryInterface, error) {
+	clientConfig, err := b.Config(name)
+	if err != nil {
+		return nil, err
+	}
+	// Discovery makes a lot of requests infrequently.  This allows the burst to succeed and refill to happen
+	// in just a few seconds.
+	clientConfig.Burst = 200
+	clientConfig.QPS = 20
+	return clientset.NewForConfig(clientConfig)
+}
+
+// DiscoveryClientOrDie returns a discovery.DiscoveryInterface built from the ClientBuilder with no error.
+// Discovery is special because it will artificially pump the burst quite high to handle the many discovery requests.
+// If it gets an error getting the client, it will log the error and kill the process it's running in.
+func (b SimpleControllerClientBuilder) DiscoveryClientOrDie(name string) discovery.DiscoveryInterface {
+	client, err := b.DiscoveryClient(name)
 	if err != nil {
 		klog.Fatal(err)
 	}


### PR DESCRIPTION
fixes https://github.com/kubernetes/kubernetes/issues/99503

Discovery is known to be bursty, we even have defaults set to bump the burst if no particular burst has already been set. However, the kube-controller-manager common runs with a burst.  Since discovery usage is limited, we simply increase the burst quite large to accommodate it regardless of the suggested per-client qps.  As a side-effect, this ensures that discovery can never starve the controllers themselves.

/kind bug
/priority important-soon
@kubernetes/sig-api-machinery-bugs 

```release-note
NONE
```