### PR TITLE
Add dougsland and rikatz as sig-cli reviewers

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -230,6 +230,8 @@ aliases:
     - pwittrock
     - zhouya0
     - eddiezane
+    - dougsland
+    - rikatz
 
   sig-testing-reviewers:
     - bentheelder


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

This PR adds @dougsland and @rikatz as sig-cli reviewers.

Doug and Ricardo have been stepping up and helping out a ton with reviews. We're thankful to have them in the community.

#### Special notes for your reviewer:

/cc @soltysh @seans3 @pwittrock 

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
