### PR TITLE
Log invalid scheduler-policy input instead of panic

### DIFF
--- a/pkg/scheduler/factory.go
+++ b/pkg/scheduler/factory.go
@@ -221,7 +221,11 @@ func (c *Configurator) createFromConfig(policy schedulerapi.Policy) (*Scheduler,
 	} else {
 		for _, predicate := range policy.Predicates {
 			klog.V(2).InfoS("Registering predicate", "predicate", predicate.Name)
-			predicateKeys.Insert(lr.ProcessPredicatePolicy(predicate, args))
+			predicateName, err := lr.ProcessPredicatePolicy(predicate, args)
+			if err != nil {
+				return nil, err
+			}
+			predicateKeys.Insert(predicateName)
 		}
 	}
 
@@ -236,7 +240,11 @@ func (c *Configurator) createFromConfig(policy schedulerapi.Policy) (*Scheduler,
 				continue
 			}
 			klog.V(2).InfoS("Registering priority", "priority", priority.Name)
-			priorityKeys[lr.ProcessPriorityPolicy(priority, args)] = priority.Weight
+			priorityName, err := lr.ProcessPriorityPolicy(priority, args)
+			if err != nil {
+				return nil, err
+			}
+			priorityKeys[priorityName] = priority.Weight
 		}
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug
#### What this PR does / why we need it:
Logged warnings that don't crash the kube-scheduler pod.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #99306

```
=== RUN   TestCreateFromConfig
=== RUN   TestCreateFromConfig/policy_with_unspecified_predicates_or_priorities_uses_default
=== RUN   TestCreateFromConfig/policy_with_arguments
=== RUN   TestCreateFromConfig/policy_with_HardPodAffinitySymmetricWeight_argument
=== RUN   TestCreateFromConfig/policy_with_illegal_arguments
E0303 11:28:37.788222   10956 legacy_registry.go:636] "Invalid configuration" err="priority type not found" policy={Name:RequestedToCapacityRatioPriority Weight:2 Argument:<nil>}
E0303 11:28:37.803846   10956 factory.go:249] "Get priority policy failed" err="priority type not found" priority={Name:RequestedToCapacityRatioPriority Weight:2 Argument:<nil>} args=&{Weight:0 NodeLabelArgs:<nil> RequestedToCapacityRatioArgs:<nil> ServiceAffinityArgs:&TypeMeta{Kind:,APIVersion:,} NodeResourcesFitArgs:<nil> InterPodAffinityArgs:<nil>}
--- PASS: TestCreateFromConfig (0.02s)
    --- PASS: TestCreateFromConfig/policy_with_unspecified_predicates_or_priorities_uses_default (0.00s)
    --- PASS: TestCreateFromConfig/policy_with_arguments (0.00s)
    --- PASS: TestCreateFromConfig/policy_with_HardPodAffinitySymmetricWeight_argument (0.00s)
    --- PASS: TestCreateFromConfig/policy_with_illegal_arguments (0.02s)
PASS
ok  	k8s.io/kubernetes/pkg/scheduler	0.119s
```
#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```
NONE

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
