### PR TITLE
staging/publishing: add -mod=mod for smoke tests for go1.16

### DIFF
--- a/staging/publishing/rules.yaml
+++ b/staging/publishing/rules.yaml
@@ -154,8 +154,8 @@ rules:
         branch: release-1.20
   smoke-test: |
     # assumes GO111MODULE=on
-    go build ./...
-    go test ./...
+    go build -mod=mod ./...
+    go test -mod=mod ./...
 
 - destination: component-base
   library: true
@@ -510,7 +510,7 @@ rules:
     - k8s.io/code-generator
   smoke-test: |
     # assumes GO111MODULE=on
-    go build .
+    go build -mod=mod .
 
 - destination: sample-controller
   branches:
@@ -594,7 +594,7 @@ rules:
     - k8s.io/code-generator
   smoke-test: |
     # assumes GO111MODULE=on
-    go build .
+    go build -mod=mod .
 
 - destination: apiextensions-apiserver
   branches:


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

xref https://github.com/golang/go/issues/44129, https://github.com/golang/go/issues/44747, https://github.com/kubernetes/release/issues/1834#issuecomment-789096385

With the move to go1.16, we are hitting a go bug for how
`go build`/`go test` work with modules - https://github.com/golang/go/issues/44129.

This commit adds the `-mod=mod` flag for `go build` and `go test`
commands in the smoke test rules ([workaround](https://github.com/golang/go/issues/44129#issuecomment-789250634) mentioned in the issue).

#### Which issue(s) this PR fixes:

Fixes the publishing-bot failure in https://github.com/kubernetes/kubernetes/issues/56876#issuecomment-789076331

#### Special notes for your reviewer:

Tested this locally for client-go master. Can reproduce the error locally and verified that this commit fixes the issue.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
