### PR TITLE
cleanup: disable dual stack for some manifest UT

### DIFF
--- a/cmd/kubeadm/app/phases/controlplane/manifests_test.go
+++ b/cmd/kubeadm/app/phases/controlplane/manifests_test.go
@@ -598,6 +598,7 @@ func TestGetControllerManagerCommand(t *testing.T) {
 				KubernetesVersion: cpVersion,
 				CertificatesDir:   testCertsDir,
 				ClusterName:       "some-other-cluster-name",
+				FeatureGates:      map[string]bool{features.IPv6DualStack: false},
 			},
 			expected: []string{
 				"kube-controller-manager",
@@ -615,6 +616,7 @@ func TestGetControllerManagerCommand(t *testing.T) {
 				"--authorization-kubeconfig=" + kubeadmconstants.KubernetesDir + "/controller-manager.conf",
 				"--client-ca-file=" + testCertsDir + "/ca.crt",
 				"--requestheader-client-ca-file=" + testCertsDir + "/front-proxy-ca.crt",
+				"--feature-gates=IPv6DualStack=false",
 				"--cluster-name=some-other-cluster-name",
 			},
 		},
@@ -679,6 +681,7 @@ func TestGetControllerManagerCommand(t *testing.T) {
 				},
 				CertificatesDir:   testCertsDir,
 				KubernetesVersion: cpVersion,
+				FeatureGates:      map[string]bool{features.IPv6DualStack: false},
 			},
 			expected: []string{
 				"kube-controller-manager",
@@ -696,6 +699,7 @@ func TestGetControllerManagerCommand(t *testing.T) {
 				"--authorization-kubeconfig=" + kubeadmconstants.KubernetesDir + "/controller-manager.conf",
 				"--client-ca-file=" + testCertsDir + "/ca.crt",
 				"--requestheader-client-ca-file=" + testCertsDir + "/front-proxy-ca.crt",
+				"--feature-gates=IPv6DualStack=false",
 				"--allocate-node-cidrs=true",
 				"--cluster-cidr=10.0.1.15/16",
 				"--service-cluster-ip-range=172.20.0.0/24",
@@ -811,7 +815,6 @@ func TestGetControllerManagerCommand(t *testing.T) {
 				},
 				CertificatesDir:   testCertsDir,
 				KubernetesVersion: cpVersion,
-				FeatureGates:      map[string]bool{features.IPv6DualStack: true},
 			},
 			expected: []string{
 				"kube-controller-manager",
@@ -829,7 +832,6 @@ func TestGetControllerManagerCommand(t *testing.T) {
 				"--authorization-kubeconfig=" + kubeadmconstants.KubernetesDir + "/controller-manager.conf",
 				"--client-ca-file=" + testCertsDir + "/ca.crt",
 				"--requestheader-client-ca-file=" + testCertsDir + "/front-proxy-ca.crt",
-				"--feature-gates=IPv6DualStack=true",
 				"--allocate-node-cidrs=true",
 				"--cluster-cidr=10.0.1.15/16,2001:db8::/64",
 				"--node-cidr-mask-size-ipv4=20",


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
During code reading about dual-stack, I find the manifest here is not updated for feature gate to beta.
So updated some cases in the manifest test.

#### Which issue(s) this PR fixes:
Follow up of #99294 (Something that I missed)

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
None
```