### PR TITLE
[hpa] add flag  concurrent-horizontal-pod-autoscaler-syncs to kube-controller-manager

### DIFF
--- a/api/api-rules/violation_exceptions.list
+++ b/api/api-rules/violation_exceptions.list
@@ -535,6 +535,7 @@ API rule violation: names_match,k8s.io/kube-controller-manager/config/v1alpha1,G
 API rule violation: names_match,k8s.io/kube-controller-manager/config/v1alpha1,GarbageCollectorControllerConfiguration,GCIgnoredResources
 API rule violation: names_match,k8s.io/kube-controller-manager/config/v1alpha1,GroupResource,Group
 API rule violation: names_match,k8s.io/kube-controller-manager/config/v1alpha1,GroupResource,Resource
+API rule violation: names_match,k8s.io/kube-controller-manager/config/v1alpha1,HPAControllerConfiguration,ConcurrentHorizontalPodAutoscalerSyncs
 API rule violation: names_match,k8s.io/kube-controller-manager/config/v1alpha1,HPAControllerConfiguration,HorizontalPodAutoscalerCPUInitializationPeriod
 API rule violation: names_match,k8s.io/kube-controller-manager/config/v1alpha1,HPAControllerConfiguration,HorizontalPodAutoscalerDownscaleForbiddenWindow
 API rule violation: names_match,k8s.io/kube-controller-manager/config/v1alpha1,HPAControllerConfiguration,HorizontalPodAutoscalerDownscaleStabilizationWindow

--- a/cmd/kube-controller-manager/app/autoscaling.go
+++ b/cmd/kube-controller-manager/app/autoscaling.go
@@ -104,6 +104,6 @@ func startHPAControllerWithMetricsClient(ctx ControllerContext, metricsClient me
 		ctx.ComponentConfig.HPAController.HorizontalPodAutoscalerTolerance,
 		ctx.ComponentConfig.HPAController.HorizontalPodAutoscalerCPUInitializationPeriod.Duration,
 		ctx.ComponentConfig.HPAController.HorizontalPodAutoscalerInitialReadinessDelay.Duration,
-	).Run(ctx.Stop)
+	).Run(int(ctx.ComponentConfig.HPAController.ConcurrentHorizontalPodAutoscalerSyncs), ctx.Stop)
 	return nil, true, nil
 }

--- a/cmd/kube-controller-manager/app/options/hpacontroller.go
+++ b/cmd/kube-controller-manager/app/options/hpacontroller.go
@@ -44,6 +44,7 @@ func (o *HPAControllerOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.DurationVar(&o.HorizontalPodAutoscalerCPUInitializationPeriod.Duration, "horizontal-pod-autoscaler-cpu-initialization-period", o.HorizontalPodAutoscalerCPUInitializationPeriod.Duration, "The period after pod start when CPU samples might be skipped.")
 	fs.MarkDeprecated("horizontal-pod-autoscaler-use-rest-clients", "Heapster is no longer supported as a source for Horizontal Pod Autoscaler metrics.")
 	fs.DurationVar(&o.HorizontalPodAutoscalerInitialReadinessDelay.Duration, "horizontal-pod-autoscaler-initial-readiness-delay", o.HorizontalPodAutoscalerInitialReadinessDelay.Duration, "The period after pod start during which readiness changes will be treated as initial readiness.")
+	fs.Int32Var(&o.ConcurrentHorizontalPodAutoscalerSyncs, "concurrent-horizontal-pod-autoscaler-syncs", o.ConcurrentHorizontalPodAutoscalerSyncs, "The number of horizontalPodAutoscalers that are allowed to sync concurrently. Larger number = more responsive horizontalPodAutoscalers, but more CPU (and network) load")
 }
 
 // ApplyTo fills up HPAController config with options.
@@ -60,6 +61,7 @@ func (o *HPAControllerOptions) ApplyTo(cfg *poautosclerconfig.HPAControllerConfi
 	cfg.HorizontalPodAutoscalerInitialReadinessDelay = o.HorizontalPodAutoscalerInitialReadinessDelay
 	cfg.HorizontalPodAutoscalerUpscaleForbiddenWindow = o.HorizontalPodAutoscalerUpscaleForbiddenWindow
 	cfg.HorizontalPodAutoscalerDownscaleForbiddenWindow = o.HorizontalPodAutoscalerDownscaleForbiddenWindow
+	cfg.ConcurrentHorizontalPodAutoscalerSyncs = o.ConcurrentHorizontalPodAutoscalerSyncs
 
 	return nil
 }

--- a/cmd/kube-controller-manager/app/options/options_test.go
+++ b/cmd/kube-controller-manager/app/options/options_test.go
@@ -91,6 +91,7 @@ var args = []string{
 	"--concurrent-service-syncs=2",
 	"--concurrent-serviceaccount-token-syncs=10",
 	"--concurrent_rc_syncs=10",
+	"--concurrent-horizontal-pod-autoscaler-syncs=2",
 	"--configure-cloud-routes=false",
 	"--contention-profiling=true",
 	"--controller-start-interval=2m",
@@ -308,6 +309,7 @@ func TestAddFlags(t *testing.T) {
 				HorizontalPodAutoscalerInitialReadinessDelay:        metav1.Duration{Duration: 50 * time.Second},
 				HorizontalPodAutoscalerTolerance:                    0.1,
 				HorizontalPodAutoscalerUseRESTClients:               true,
+				ConcurrentHorizontalPodAutoscalerSyncs:              2,
 			},
 		},
 		JobController: &JobControllerOptions{
@@ -569,6 +571,7 @@ func TestApplyTo(t *testing.T) {
 				HorizontalPodAutoscalerInitialReadinessDelay:        metav1.Duration{Duration: 50 * time.Second},
 				HorizontalPodAutoscalerTolerance:                    0.1,
 				HorizontalPodAutoscalerUseRESTClients:               true,
+				ConcurrentHorizontalPodAutoscalerSyncs:              2,
 			},
 			JobController: jobconfig.JobControllerConfiguration{
 				ConcurrentJobSyncs: 5,

--- a/pkg/controller/podautoscaler/config/types.go
+++ b/pkg/controller/podautoscaler/config/types.go
@@ -47,4 +47,8 @@ type HPAControllerConfiguration struct {
 	// HPA will disregard CPU samples from unready pods that had last readiness change during that
 	// period.
 	HorizontalPodAutoscalerInitialReadinessDelay metav1.Duration
+	// concurrentHorizontalPodAutoscalerSyncs is the number of horizontalPodAutoscalers that are allowed to sync
+	// concurrently. Larger number = more responsive horizontalPodAutoscalers, but more
+	// CPU (and network) load.
+	ConcurrentHorizontalPodAutoscalerSyncs int32
 }

--- a/pkg/controller/podautoscaler/config/v1alpha1/defaults.go
+++ b/pkg/controller/podautoscaler/config/v1alpha1/defaults.go
@@ -59,4 +59,7 @@ func RecommendedDefaultHPAControllerConfiguration(obj *kubectrlmgrconfigv1alpha1
 	if obj.HorizontalPodAutoscalerTolerance == 0 {
 		obj.HorizontalPodAutoscalerTolerance = 0.1
 	}
+	if obj.ConcurrentHorizontalPodAutoscalerSyncs == 0 {
+		obj.ConcurrentHorizontalPodAutoscalerSyncs = 5
+	}
 }

--- a/pkg/controller/podautoscaler/config/v1alpha1/zz_generated.conversion.go
+++ b/pkg/controller/podautoscaler/config/v1alpha1/zz_generated.conversion.go
@@ -91,6 +91,7 @@ func autoConvert_v1alpha1_HPAControllerConfiguration_To_config_HPAControllerConf
 	}
 	out.HorizontalPodAutoscalerCPUInitializationPeriod = in.HorizontalPodAutoscalerCPUInitializationPeriod
 	out.HorizontalPodAutoscalerInitialReadinessDelay = in.HorizontalPodAutoscalerInitialReadinessDelay
+	out.ConcurrentHorizontalPodAutoscalerSyncs = in.ConcurrentHorizontalPodAutoscalerSyncs
 	return nil
 }
 
@@ -105,5 +106,6 @@ func autoConvert_config_HPAControllerConfiguration_To_v1alpha1_HPAControllerConf
 	}
 	out.HorizontalPodAutoscalerCPUInitializationPeriod = in.HorizontalPodAutoscalerCPUInitializationPeriod
 	out.HorizontalPodAutoscalerInitialReadinessDelay = in.HorizontalPodAutoscalerInitialReadinessDelay
+	out.ConcurrentHorizontalPodAutoscalerSyncs = in.ConcurrentHorizontalPodAutoscalerSyncs
 	return nil
 }

--- a/pkg/controller/podautoscaler/horizontal.go
+++ b/pkg/controller/podautoscaler/horizontal.go
@@ -162,7 +162,7 @@ func NewHorizontalController(
 }
 
 // Run begins watching and syncing.
-func (a *HorizontalController) Run(stopCh <-chan struct{}) {
+func (a *HorizontalController) Run(workers int, stopCh <-chan struct{}) {
 	defer utilruntime.HandleCrash()
 	defer a.queue.ShutDown()
 
@@ -173,8 +173,9 @@ func (a *HorizontalController) Run(stopCh <-chan struct{}) {
 		return
 	}
 
-	// start a single worker (we may wish to start more in the future)
-	go wait.Until(a.worker, time.Second, stopCh)
+	for i := 0; i < workers; i++ {
+		go wait.Until(a.worker, time.Second, stopCh)
+	}
 
 	<-stopCh
 }

--- a/pkg/controller/podautoscaler/horizontal_test.go
+++ b/pkg/controller/podautoscaler/horizontal_test.go
@@ -747,7 +747,7 @@ func (tc *testCase) runTestWithController(t *testing.T, hpaController *Horizonta
 	stop := make(chan struct{})
 	defer close(stop)
 	informerFactory.Start(stop)
-	go hpaController.Run(stop)
+	go hpaController.Run(1, stop)
 
 	tc.Lock()
 	shouldWait := tc.verifyEvents

--- a/pkg/controller/podautoscaler/legacy_horizontal_test.go
+++ b/pkg/controller/podautoscaler/legacy_horizontal_test.go
@@ -523,7 +523,7 @@ func (tc *legacyTestCase) runTest(t *testing.T) {
 	stop := make(chan struct{})
 	defer close(stop)
 	informerFactory.Start(stop)
-	go hpaController.Run(stop)
+	go hpaController.Run(1, stop)
 
 	// Wait for HPA to be processed.
 	<-tc.processed

--- a/pkg/controller/podautoscaler/replica_calculator.go
+++ b/pkg/controller/podautoscaler/replica_calculator.go
@@ -209,12 +209,12 @@ func (c *ReplicaCalculator) calcPlainMetricReplicas(metrics metricsclient.PodMet
 
 	if len(missingPods) > 0 {
 		if usageRatio < 1.0 {
-			// on a scale-down, treat missing pods as using 100% of the resource request
+			// on a scale-down, treat missing pods as using target utilization
 			for podName := range missingPods {
 				metrics[podName] = metricsclient.PodMetric{Value: targetUtilization}
 			}
 		} else {
-			// on a scale-up, treat missing pods as using 0% of the resource request
+			// on a scale-up, treat missing pods as 0
 			for podName := range missingPods {
 				metrics[podName] = metricsclient.PodMetric{Value: 0}
 			}
@@ -222,7 +222,7 @@ func (c *ReplicaCalculator) calcPlainMetricReplicas(metrics metricsclient.PodMet
 	}
 
 	if rebalanceIgnored {
-		// on a scale-up, treat unready pods as using 0% of the resource request
+		// on a scale-up, treat unready pods as 0
 		for podName := range unreadyPods {
 			metrics[podName] = metricsclient.PodMetric{Value: 0}
 		}

--- a/staging/src/k8s.io/kube-controller-manager/config/v1alpha1/types.go
+++ b/staging/src/k8s.io/kube-controller-manager/config/v1alpha1/types.go
@@ -340,6 +340,10 @@ type HPAControllerConfiguration struct {
 	// HPA will disregard CPU samples from unready pods that had last readiness change during that
 	// period.
 	HorizontalPodAutoscalerInitialReadinessDelay metav1.Duration
+	// concurrentHorizontalPodAutoscalerSyncs is the number of horizontalPodAutoscalers that are allowed to sync
+	// concurrently. Larger number = more responsive horizontalPodAutoscalers, but more
+	// CPU (and network) load.
+	ConcurrentHorizontalPodAutoscalerSyncs int32
 }
 
 // JobControllerConfiguration contains elements describing JobController.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
While many other controllers has flag concurrent-xxx-syncs to set number of workers, the horizontal podautoscaler controller doesn't and just hard coded with 1 worker. It is very slow to deal with large number of hpas in cluster. This PR just export a flag `--concurrent-horizontal-pod-autoscaler-syncs` with default value 5.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
@gaorong 

#### Does this PR introduce a user-facing change?
```
`kube-controller-manager` now defaults to processing up to 5 horizontal podautoscaler objects concurrently to improve responsiveness, and exposes a `--concurrent-horizontal-pod-autoscaler-syncs` flag to allow tuning the number of horizontal podautoscaler workers.
```
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
