### PR TITLE
Fix a panic in "e2e.test --help" due to "--gce-zones"

### DIFF
--- a/staging/src/k8s.io/component-base/cli/flag/string_slice_flag.go
+++ b/staging/src/k8s.io/component-base/cli/flag/string_slice_flag.go
@@ -23,7 +23,7 @@ import (
 	"github.com/spf13/pflag"
 )
 
-// StringSlice implements goflag.Value and plfag.Value,
+// StringSlice implements goflag.Value and pflag.Value,
 // and allows set to be invoked repeatedly to accumulate values.
 type StringSlice struct {
 	value   *[]string
@@ -38,6 +38,9 @@ var _ goflag.Value = &StringSlice{}
 var _ pflag.Value = &StringSlice{}
 
 func (s *StringSlice) String() string {
+	if s == nil || s.value == nil {
+		return ""
+	}
 	return strings.Join(*s.value, " ")
 }
 


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
#98787 added a `--gce-zones` flag to `e2e.test` but a bug makes it so that `e2e.test --help` now panics:

```
> ./_output/bin/e2e.test --help
Usage of ./_output/bin/e2e.test:
  -add_dir_header
    	If true, adds the file directory to the header of the log messages
...
  -gce-zone string
    	GCE zone being used, if applicable
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x1802967]

goroutine 1 [running]:
k8s.io/kubernetes/vendor/k8s.io/component-base/cli/flag.(*StringSlice).String(0xc00399d720, 0x4547c40, 0xc00399d720)
	/home/danw/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/component-base/cli/flag/string_slice_flag.go:41 +0x27
...
```

with the patch:

```
...
  -gce-zone string
    	GCE zone being used, if applicable
  -gce-zones value
    	The set of zones to use in a multi-zone test instead of querying the cloud provider.
  -ginkgo.debug
    	If set, ginkgo will emit node output to files when running in parallel.
...
```

#### Special notes for your reviewer:
The change I made matches the code in other nearby files (eg, `map_string_string.go`)

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/sig testing
/assign @smarterclayton 