### PR TITLE
Automated cherry pick of #99463: Use Lstat in plugin watcher to avoid Windows problem

### DIFF
--- a/pkg/kubelet/pluginmanager/pluginwatcher/plugin_watcher.go
+++ b/pkg/kubelet/pluginmanager/pluginwatcher/plugin_watcher.go
@@ -159,7 +159,7 @@ func (w *Watcher) traversePluginDir(dir string) error {
 func (w *Watcher) handleCreateEvent(event fsnotify.Event) error {
 	klog.V(6).Infof("Handling create event: %v", event)
 
-	fi, err := os.Stat(event.Name)
+	fi, err := os.Lstat(event.Name)
 	if err != nil {
 		return fmt.Errorf("stat file %s failed: %v", event.Name, err)
 	}


### PR DESCRIPTION
Cherry pick of #99463 on release-1.19.

#99463: Use Lstat in plugin watcher to avoid Windows problem

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.