### PR TITLE
Promote Cinder topology labels to GA

### DIFF
--- a/pkg/volume/cinder/cinder_test.go
+++ b/pkg/volume/cinder/cinder_test.go
@@ -123,7 +123,7 @@ func (fake *fakePDManager) DetachDisk(c *cinderVolumeUnmounter) error {
 
 func (fake *fakePDManager) CreateVolume(c *cinderVolumeProvisioner, node *v1.Node, allowedTopologies []v1.TopologySelectorTerm) (volumeID string, volumeSizeGB int, labels map[string]string, fstype string, err error) {
 	labels = make(map[string]string)
-	labels[v1.LabelFailureDomainBetaZone] = "nova"
+	labels[v1.LabelTopologyZone] = "nova"
 	return "test-volume-name", 1, labels, "", nil
 }
 
@@ -241,7 +241,7 @@ func TestPlugin(t *testing.T) {
 
 	req := persistentSpec.Spec.NodeAffinity.Required.NodeSelectorTerms[0].MatchExpressions[0]
 
-	if req.Key != v1.LabelFailureDomainBetaZone {
+	if req.Key != v1.LabelTopologyZone {
 		t.Errorf("Provision() returned unexpected requirement key in NodeAffinity %v", req.Key)
 	}
 

--- a/pkg/volume/cinder/cinder_util.go
+++ b/pkg/volume/cinder/cinder_util.go
@@ -156,7 +156,7 @@ func getZonesFromNodes(kubeClient clientset.Interface) (sets.String, error) {
 		return zones, err
 	}
 	for _, node := range nodes.Items {
-		if zone, ok := node.Labels[v1.LabelFailureDomainBetaZone]; ok {
+		if zone, ok := node.Labels[v1.LabelTopologyZone]; ok {
 			zones.Insert(zone)
 		}
 	}
@@ -229,10 +229,10 @@ func (util *DiskUtil) CreateVolume(c *cinderVolumeProvisioner, node *v1.Node, al
 	volumeLabels = make(map[string]string)
 	if IgnoreVolumeAZ == false {
 		if volumeAZ != "" {
-			volumeLabels[v1.LabelFailureDomainBetaZone] = volumeAZ
+			volumeLabels[v1.LabelTopologyZone] = volumeAZ
 		}
 		if volumeRegion != "" {
-			volumeLabels[v1.LabelFailureDomainBetaRegion] = volumeRegion
+			volumeLabels[v1.LabelTopologyRegion] = volumeRegion
 		}
 	}
 	return volumeID, volSizeGiB, volumeLabels, fstype, nil

--- a/staging/src/k8s.io/legacy-cloud-providers/openstack/openstack_volumes.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/openstack/openstack_volumes.go
@@ -748,10 +748,10 @@ func (os *OpenStack) GetLabelsForVolume(ctx context.Context, pv *v1.PersistentVo
 	// Construct Volume Labels
 	labels := make(map[string]string)
 	if volume.AvailabilityZone != "" {
-		labels[v1.LabelFailureDomainBetaZone] = volume.AvailabilityZone
+		labels[v1.LabelTopologyZone] = volume.AvailabilityZone
 	}
 	if os.region != "" {
-		labels[v1.LabelFailureDomainBetaRegion] = os.region
+		labels[v1.LabelTopologyRegion] = os.region
 	}
 	klog.V(4).Infof("The Volume %s has labels %v", pv.Spec.Cinder.VolumeID, labels)
 


### PR DESCRIPTION
/kind feature

#### What this PR does / why we need it:
Use GA topology labels in in-tree Cinder volume plugin.

```release-note
[ACTION REQUIRED] Newly provisioned PVs by OpenStack Cinder plugin will no longer use the deprecated "failure-domain.beta.kubernetes.io/zone" and "failure-domain.beta.kubernetes.io/region" labels. It will use "topology.kubernetes.io/zone" and "topology.kubernetes.io/region" labels instead.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
```

cc @Jiawei0227 
