### PR TITLE
 Fix issue in checking domain socket for plugin watcher

### DIFF
--- a/pkg/kubelet/pluginmanager/pluginwatcher/plugin_watcher.go
+++ b/pkg/kubelet/pluginmanager/pluginwatcher/plugin_watcher.go
@@ -159,7 +159,13 @@ func (w *Watcher) traversePluginDir(dir string) error {
 func (w *Watcher) handleCreateEvent(event fsnotify.Event) error {
 	klog.V(6).Infof("Handling create event: %v", event)
 
-	fi, err := os.Lstat(event.Name)
+	fi, err := os.Stat(event.Name)
+	// TODO: This is a workaround for Windows 20H2 issue for os.Stat(). Please see
+	// microsoft/Windows-Containers#97 for details.
+	// Once the issue is resvolved, the following os.Lstat() is not needed.
+	if err != nil && runtime.GOOS == "windows" {
+		fi, err = os.Lstat(event.Name)
+	}
 	if err != nil {
 		return fmt.Errorf("stat file %s failed: %v", event.Name, err)
 	}


### PR DESCRIPTION
Due to recent os.Stat() issue for Windows 20H2, added the logic to use
os.Lstat() if os.Stat() fails for Windows.

Notes about behavior change

- Linux: Behavior will not change because we try to use os.Stat() first which works fine for Linux OS.
- Windows: Behavior will not change too due to the following reason (But we did discover that symlink to dir use case does not work for Windows always) 
     - If path is a symlink points to a file. If Stat() fails, Lstat() will pass the check and it will further move to call the function IsUnixDomainSocket to check whether it is a domain socket.
     - if path is a symlink points to a dir:
         - Before this change, Stat() will fail and return directly. (will not traverse down the dir)   
         - After this change: Stat() will fail, Lstat() can pass, so it will call  IsUnixDomainSocket which will fail and return. (will not traverse down the dir) 


This is a follow up PR for https://github.com/kubernetes/kubernetes/pull/99463/files#r586706301

Change-Id: Ic9fc07ecc6e9c2984e854ac77121ff61c8e0d041

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
