### PR TITLE
Drop deprecated run flags and deprecate unused ones

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/run/run_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/run/run_test.go
@@ -40,7 +40,6 @@ import (
 	"k8s.io/kubectl/pkg/cmd/delete"
 	cmdtesting "k8s.io/kubectl/pkg/cmd/testing"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
-	generateversioned "k8s.io/kubectl/pkg/generate/versioned"
 	"k8s.io/kubectl/pkg/scheme"
 	"k8s.io/kubectl/pkg/util/i18n"
 )
@@ -210,8 +209,7 @@ func TestRunArgsFollowDashRules(t *testing.T) {
 
 				IOStreams: genericclioptions.NewTestIOStreamsDiscard(),
 
-				Image:     "nginx",
-				Generator: generateversioned.RunPodV1GeneratorName,
+				Image: "nginx",
 
 				PrintObj: func(obj runtime.Object) error {
 					return printer.PrintObj(obj, os.Stdout)
@@ -234,20 +232,18 @@ func TestRunArgsFollowDashRules(t *testing.T) {
 
 func TestGenerateService(t *testing.T) {
 	tests := []struct {
-		name             string
-		port             string
-		args             []string
-		serviceGenerator string
-		params           map[string]interface{}
-		expectErr        bool
-		service          corev1.Service
-		expectPOST       bool
+		name       string
+		port       string
+		args       []string
+		params     map[string]interface{}
+		expectErr  bool
+		service    corev1.Service
+		expectPOST bool
 	}{
 		{
-			name:             "basic",
-			port:             "80",
-			args:             []string{"foo"},
-			serviceGenerator: "service/v2",
+			name: "basic",
+			port: "80",
+			args: []string{"foo"},
 			params: map[string]interface{}{
 				"name": "foo",
 			},
@@ -276,10 +272,9 @@ func TestGenerateService(t *testing.T) {
 			expectPOST: true,
 		},
 		{
-			name:             "custom labels",
-			port:             "80",
-			args:             []string{"foo"},
-			serviceGenerator: "service/v2",
+			name: "custom labels",
+			port: "80",
+			args: []string{"foo"},
 			params: map[string]interface{}{
 				"name":   "foo",
 				"labels": "app=bar",
@@ -315,10 +310,9 @@ func TestGenerateService(t *testing.T) {
 			expectPOST: false,
 		},
 		{
-			name:             "dry-run",
-			port:             "80",
-			args:             []string{"foo"},
-			serviceGenerator: "service/v2",
+			name: "dry-run",
+			port: "80",
+			args: []string{"foo"},
 			params: map[string]interface{}{
 				"name": "foo",
 			},
@@ -411,7 +405,7 @@ func TestGenerateService(t *testing.T) {
 				test.params["port"] = test.port
 			}
 
-			_, err = opts.generateService(tf, cmd, test.serviceGenerator, test.params)
+			_, err = opts.generateService(tf, cmd, test.params)
 			if test.expectErr {
 				if err == nil {
 					t.Error("unexpected non-error")

--- a/test/cmd/core.sh
+++ b/test/cmd/core.sh
@@ -1142,15 +1142,15 @@ __EOF__
   # Pre-condition: Only the default kubernetes services exist
   kube::test::get_object_assert services "{{range.items}}{{$id_field}}:{{end}}" 'kubernetes:'
   # Dry-run command
-  kubectl run testmetadata --image=nginx --port=80 --expose --dry-run=client --service-overrides='{ "metadata": { "annotations": { "zone-context": "home" } } } '
-  kubectl run testmetadata --image=nginx --port=80 --expose --dry-run=server --service-overrides='{ "metadata": { "annotations": { "zone-context": "home" } } } '
+  kubectl run testmetadata --image=nginx --port=80 --expose --dry-run=client
+  kubectl run testmetadata --image=nginx --port=80 --expose --dry-run=server
   # Check only the default kubernetes services exist
   kube::test::get_object_assert services "{{range.items}}{{$id_field}}:{{end}}" 'kubernetes:'
   # Command
-  kubectl run testmetadata --image=nginx --port=80 --expose --service-overrides='{ "metadata": { "annotations": { "zone-context": "home" } } } '
+  kubectl run testmetadata --image=nginx --port=80 --expose
   # Check result
   kube::test::get_object_assert pods "{{range.items}}{{$id_field}}:{{end}}" 'testmetadata:'
-  kube::test::get_object_assert 'service testmetadata' "{{.metadata.annotations}}" "map\[zone-context:home\]"
+  kube::test::get_object_assert 'service testmetadata' "{{${port_field:?}}}" '80'
   # pod has field for kubectl run field manager
   output_message=$(kubectl get pod testmetadata -o=jsonpath='{.metadata.managedFields[*].manager}' "${kube_flags[@]:?}" 2>&1)
   kube::test::if_has_string "${output_message}" 'kubectl-run'


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/kind deprecation
/sig cli

#### What this PR does / why we need it:
This PR remove entirely flags which were deprecated since cleaning `kubectl run` command.

#### Special notes for your reviewer:
/assign @rikatz 

#### Does this PR introduce a user-facing change?
```release-note
Remove deprecated --generator --replicas --service-generator --service-overrides --schedule from kubectl run
Deprecate --serviceaccount --hostport --requests --limits in kubectl run
```
