### PR TITLE
clean usage of admissionregistration/v1beta1 from integration tests

### DIFF
--- a/test/integration/apiserver/admissionwebhook/broken_webhook_test.go
+++ b/test/integration/apiserver/admissionwebhook/broken_webhook_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 	"time"
 
-	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -60,7 +60,7 @@ func TestBrokenWebhook(t *testing.T) {
 	}
 
 	t.Logf("Creating Broken Webhook that will block all operations on all objects")
-	_, err = client.AdmissionregistrationV1beta1().ValidatingWebhookConfigurations().Create(context.TODO(), brokenWebhookConfig(brokenWebhookName), metav1.CreateOptions{})
+	_, err = client.AdmissionregistrationV1().ValidatingWebhookConfigurations().Create(context.TODO(), brokenWebhookConfig(brokenWebhookName), metav1.CreateOptions{})
 	if err != nil {
 		t.Fatalf("Failed to register broken webhook: %v", err)
 	}
@@ -96,7 +96,7 @@ func TestBrokenWebhook(t *testing.T) {
 	}
 
 	t.Logf("Deleting the broken webhook to fix the cluster")
-	err = client.AdmissionregistrationV1beta1().ValidatingWebhookConfigurations().Delete(context.TODO(), brokenWebhookName, metav1.DeleteOptions{})
+	err = client.AdmissionregistrationV1().ValidatingWebhookConfigurations().Delete(context.TODO(), brokenWebhookName, metav1.DeleteOptions{})
 	if err != nil {
 		t.Fatalf("Failed to delete broken webhook: %v", err)
 	}
@@ -149,19 +149,19 @@ func exampleDeployment(name string) *appsv1.Deployment {
 	}
 }
 
-func brokenWebhookConfig(name string) *admissionregistrationv1beta1.ValidatingWebhookConfiguration {
+func brokenWebhookConfig(name string) *admissionregistrationv1.ValidatingWebhookConfiguration {
 	var path string
-	failurePolicy := admissionregistrationv1beta1.Fail
-	return &admissionregistrationv1beta1.ValidatingWebhookConfiguration{
+	failurePolicy := admissionregistrationv1.Fail
+	return &admissionregistrationv1.ValidatingWebhookConfiguration{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
 		},
-		Webhooks: []admissionregistrationv1beta1.ValidatingWebhook{
+		Webhooks: []admissionregistrationv1.ValidatingWebhook{
 			{
 				Name: "broken-webhook.k8s.io",
-				Rules: []admissionregistrationv1beta1.RuleWithOperations{{
-					Operations: []admissionregistrationv1beta1.OperationType{admissionregistrationv1beta1.OperationAll},
-					Rule: admissionregistrationv1beta1.Rule{
+				Rules: []admissionregistrationv1.RuleWithOperations{{
+					Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.OperationAll},
+					Rule: admissionregistrationv1.Rule{
 						APIGroups:   []string{"*"},
 						APIVersions: []string{"*"},
 						Resources:   []string{"*/*"},
@@ -169,15 +169,17 @@ func brokenWebhookConfig(name string) *admissionregistrationv1beta1.ValidatingWe
 				}},
 				// This client config references a non existent service
 				// so it should always fail.
-				ClientConfig: admissionregistrationv1beta1.WebhookClientConfig{
-					Service: &admissionregistrationv1beta1.ServiceReference{
+				ClientConfig: admissionregistrationv1.WebhookClientConfig{
+					Service: &admissionregistrationv1.ServiceReference{
 						Namespace: "default",
 						Name:      "invalid-webhook-service",
 						Path:      &path,
 					},
 					CABundle: nil,
 				},
-				FailurePolicy: &failurePolicy,
+				FailurePolicy:           &failurePolicy,
+				SideEffects:             &noSideEffects,
+				AdmissionReviewVersions: []string{"v1"},
 			},
 		},
 	}

--- a/test/integration/apiserver/admissionwebhook/client_auth_test.go
+++ b/test/integration/apiserver/admissionwebhook/client_auth_test.go
@@ -32,7 +32,7 @@ import (
 	"time"
 
 	"k8s.io/api/admission/v1beta1"
-	admissionv1beta1 "k8s.io/api/admissionregistration/v1beta1"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -165,28 +165,29 @@ plugins:
 		t.Fatal(err)
 	}
 
-	fail := admissionv1beta1.Fail
-	mutatingCfg, err := client.AdmissionregistrationV1beta1().MutatingWebhookConfigurations().Create(context.TODO(), &admissionv1beta1.MutatingWebhookConfiguration{
+	fail := admissionregistrationv1.Fail
+	mutatingCfg, err := client.AdmissionregistrationV1().MutatingWebhookConfigurations().Create(context.TODO(), &admissionregistrationv1.MutatingWebhookConfiguration{
 		ObjectMeta: metav1.ObjectMeta{Name: "admission.integration.test"},
-		Webhooks: []admissionv1beta1.MutatingWebhook{{
+		Webhooks: []admissionregistrationv1.MutatingWebhook{{
 			Name: "admission.integration.test",
-			ClientConfig: admissionv1beta1.WebhookClientConfig{
+			ClientConfig: admissionregistrationv1.WebhookClientConfig{
 				URL:      &webhookServer.URL,
 				CABundle: localhostCert,
 			},
-			Rules: []admissionv1beta1.RuleWithOperations{{
-				Operations: []admissionv1beta1.OperationType{admissionv1beta1.OperationAll},
-				Rule:       admissionv1beta1.Rule{APIGroups: []string{""}, APIVersions: []string{"v1"}, Resources: []string{"pods"}},
+			Rules: []admissionregistrationv1.RuleWithOperations{{
+				Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.OperationAll},
+				Rule:       admissionregistrationv1.Rule{APIGroups: []string{""}, APIVersions: []string{"v1"}, Resources: []string{"pods"}},
 			}},
 			FailurePolicy:           &fail,
 			AdmissionReviewVersions: []string{"v1beta1"},
+			SideEffects:             &noSideEffects,
 		}},
 	}, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer func() {
-		err := client.AdmissionregistrationV1beta1().MutatingWebhookConfigurations().Delete(context.TODO(), mutatingCfg.GetName(), metav1.DeleteOptions{})
+		err := client.AdmissionregistrationV1().MutatingWebhookConfigurations().Delete(context.TODO(), mutatingCfg.GetName(), metav1.DeleteOptions{})
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/test/integration/apiserver/admissionwebhook/load_balance_test.go
+++ b/test/integration/apiserver/admissionwebhook/load_balance_test.go
@@ -31,7 +31,7 @@ import (
 	"time"
 
 	"k8s.io/api/admission/v1beta1"
-	admissionv1beta1 "k8s.io/api/admissionregistration/v1beta1"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -114,28 +114,29 @@ func TestWebhookLoadBalance(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	fail := admissionv1beta1.Fail
-	mutatingCfg, err := client.AdmissionregistrationV1beta1().MutatingWebhookConfigurations().Create(context.TODO(), &admissionv1beta1.MutatingWebhookConfiguration{
+	fail := admissionregistrationv1.Fail
+	mutatingCfg, err := client.AdmissionregistrationV1().MutatingWebhookConfigurations().Create(context.TODO(), &admissionregistrationv1.MutatingWebhookConfiguration{
 		ObjectMeta: metav1.ObjectMeta{Name: "admission.integration.test"},
-		Webhooks: []admissionv1beta1.MutatingWebhook{{
+		Webhooks: []admissionregistrationv1.MutatingWebhook{{
 			Name: "admission.integration.test",
-			ClientConfig: admissionv1beta1.WebhookClientConfig{
+			ClientConfig: admissionregistrationv1.WebhookClientConfig{
 				URL:      &webhookURL,
 				CABundle: localhostCert,
 			},
-			Rules: []admissionv1beta1.RuleWithOperations{{
-				Operations: []admissionv1beta1.OperationType{admissionv1beta1.OperationAll},
-				Rule:       admissionv1beta1.Rule{APIGroups: []string{""}, APIVersions: []string{"v1"}, Resources: []string{"pods"}},
+			Rules: []admissionregistrationv1.RuleWithOperations{{
+				Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.OperationAll},
+				Rule:       admissionregistrationv1.Rule{APIGroups: []string{""}, APIVersions: []string{"v1"}, Resources: []string{"pods"}},
 			}},
 			FailurePolicy:           &fail,
 			AdmissionReviewVersions: []string{"v1beta1"},
+			SideEffects:             &noSideEffects,
 		}},
 	}, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer func() {
-		err := client.AdmissionregistrationV1beta1().MutatingWebhookConfigurations().Delete(context.TODO(), mutatingCfg.GetName(), metav1.DeleteOptions{})
+		err := client.AdmissionregistrationV1().MutatingWebhookConfigurations().Delete(context.TODO(), mutatingCfg.GetName(), metav1.DeleteOptions{})
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/test/integration/apiserver/admissionwebhook/reinvocation_test.go
+++ b/test/integration/apiserver/admissionwebhook/reinvocation_test.go
@@ -34,8 +34,7 @@ import (
 	"time"
 
 	"k8s.io/api/admission/v1beta1"
-	admissionv1beta1 "k8s.io/api/admissionregistration/v1beta1"
-	registrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
 	schedulingv1 "k8s.io/api/scheduling/v1"
@@ -84,12 +83,12 @@ func patchAnnotationValue(configuration, webhook string, patch string) string {
 
 // testWebhookReinvocationPolicy ensures that the admission webhook reinvocation policy is applied correctly.
 func testWebhookReinvocationPolicy(t *testing.T, watchCache bool) {
-	reinvokeNever := registrationv1beta1.NeverReinvocationPolicy
-	reinvokeIfNeeded := registrationv1beta1.IfNeededReinvocationPolicy
+	reinvokeNever := admissionregistrationv1.NeverReinvocationPolicy
+	reinvokeIfNeeded := admissionregistrationv1.IfNeededReinvocationPolicy
 
 	type testWebhook struct {
 		path           string
-		policy         *registrationv1beta1.ReinvocationPolicyType
+		policy         *admissionregistrationv1.ReinvocationPolicyType
 		objectSelector *metav1.LabelSelector
 	}
 
@@ -339,46 +338,48 @@ func testWebhookReinvocationPolicy(t *testing.T, watchCache bool) {
 				t.Fatal(err)
 			}
 
-			fail := admissionv1beta1.Fail
-			webhooks := []admissionv1beta1.MutatingWebhook{}
+			fail := admissionregistrationv1.Fail
+			webhooks := []admissionregistrationv1.MutatingWebhook{}
 			for j, webhook := range tt.webhooks {
 				endpoint := webhookServer.URL + webhook.path
 				name := fmt.Sprintf("admission.integration.test.%d.%s", j, strings.TrimPrefix(webhook.path, "/"))
-				webhooks = append(webhooks, admissionv1beta1.MutatingWebhook{
+				webhooks = append(webhooks, admissionregistrationv1.MutatingWebhook{
 					Name: name,
-					ClientConfig: admissionv1beta1.WebhookClientConfig{
+					ClientConfig: admissionregistrationv1.WebhookClientConfig{
 						URL:      &endpoint,
 						CABundle: localhostCert,
 					},
-					Rules: []admissionv1beta1.RuleWithOperations{{
-						Operations: []admissionv1beta1.OperationType{admissionv1beta1.OperationAll},
-						Rule:       admissionv1beta1.Rule{APIGroups: []string{""}, APIVersions: []string{"v1"}, Resources: []string{"pods"}},
+					Rules: []admissionregistrationv1.RuleWithOperations{{
+						Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.OperationAll},
+						Rule:       admissionregistrationv1.Rule{APIGroups: []string{""}, APIVersions: []string{"v1"}, Resources: []string{"pods"}},
 					}},
 					ObjectSelector:          webhook.objectSelector,
 					NamespaceSelector:       &metav1.LabelSelector{MatchLabels: nsLabels},
 					FailurePolicy:           &fail,
 					ReinvocationPolicy:      webhook.policy,
 					AdmissionReviewVersions: []string{"v1beta1"},
+					SideEffects:             &noSideEffects,
 				})
 			}
 			// Register a marker checking webhook with each set of webhook configurations
 			markerEndpoint := webhookServer.URL + "/marker"
-			webhooks = append(webhooks, admissionv1beta1.MutatingWebhook{
+			webhooks = append(webhooks, admissionregistrationv1.MutatingWebhook{
 				Name: "admission.integration.test.marker",
-				ClientConfig: admissionv1beta1.WebhookClientConfig{
+				ClientConfig: admissionregistrationv1.WebhookClientConfig{
 					URL:      &markerEndpoint,
 					CABundle: localhostCert,
 				},
-				Rules: []admissionv1beta1.RuleWithOperations{{
-					Operations: []admissionv1beta1.OperationType{admissionv1beta1.OperationAll},
-					Rule:       admissionv1beta1.Rule{APIGroups: []string{""}, APIVersions: []string{"v1"}, Resources: []string{"pods"}},
+				Rules: []admissionregistrationv1.RuleWithOperations{{
+					Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.OperationAll},
+					Rule:       admissionregistrationv1.Rule{APIGroups: []string{""}, APIVersions: []string{"v1"}, Resources: []string{"pods"}},
 				}},
 				NamespaceSelector:       &metav1.LabelSelector{MatchLabels: markerNsLabels},
 				ObjectSelector:          &metav1.LabelSelector{MatchLabels: map[string]string{"marker": "true"}},
 				AdmissionReviewVersions: []string{"v1beta1"},
+				SideEffects:             &noSideEffects,
 			})
 
-			cfg, err := client.AdmissionregistrationV1beta1().MutatingWebhookConfigurations().Create(context.TODO(), &admissionv1beta1.MutatingWebhookConfiguration{
+			cfg, err := client.AdmissionregistrationV1().MutatingWebhookConfigurations().Create(context.TODO(), &admissionregistrationv1.MutatingWebhookConfiguration{
 				ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("admission.integration.test-%d", i)},
 				Webhooks:   webhooks,
 			}, metav1.CreateOptions{})
@@ -386,7 +387,7 @@ func testWebhookReinvocationPolicy(t *testing.T, watchCache bool) {
 				t.Fatal(err)
 			}
 			defer func() {
-				err := client.AdmissionregistrationV1beta1().MutatingWebhookConfigurations().Delete(context.TODO(), cfg.GetName(), metav1.DeleteOptions{})
+				err := client.AdmissionregistrationV1().MutatingWebhookConfigurations().Delete(context.TODO(), cfg.GetName(), metav1.DeleteOptions{})
 				if err != nil {
 					t.Fatal(err)
 				}

--- a/test/integration/apiserver/admissionwebhook/timeout_test.go
+++ b/test/integration/apiserver/admissionwebhook/timeout_test.go
@@ -32,7 +32,7 @@ import (
 	"time"
 
 	"k8s.io/api/admission/v1beta1"
-	admissionv1beta1 "k8s.io/api/admissionregistration/v1beta1"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -69,7 +69,7 @@ func testWebhookTimeout(t *testing.T, watchCache bool) {
 	type testWebhook struct {
 		path           string
 		timeoutSeconds int32
-		policy         admissionv1beta1.FailurePolicyType
+		policy         admissionregistrationv1.FailurePolicyType
 		objectSelector *metav1.LabelSelector
 	}
 
@@ -86,12 +86,12 @@ func testWebhookTimeout(t *testing.T, watchCache bool) {
 			name:           "minimum of request timeout or webhook timeout propagated",
 			timeoutSeconds: 10,
 			mutatingWebhooks: []testWebhook{
-				{path: "/mutating/1/0s", policy: admissionv1beta1.Fail, timeoutSeconds: 20},
-				{path: "/mutating/2/0s", policy: admissionv1beta1.Fail, timeoutSeconds: 5},
+				{path: "/mutating/1/0s", policy: admissionregistrationv1.Fail, timeoutSeconds: 20},
+				{path: "/mutating/2/0s", policy: admissionregistrationv1.Fail, timeoutSeconds: 5},
 			},
 			validatingWebhooks: []testWebhook{
-				{path: "/validating/3/0s", policy: admissionv1beta1.Fail, timeoutSeconds: 20},
-				{path: "/validating/4/0s", policy: admissionv1beta1.Fail, timeoutSeconds: 5},
+				{path: "/validating/3/0s", policy: admissionregistrationv1.Fail, timeoutSeconds: 20},
+				{path: "/validating/4/0s", policy: admissionregistrationv1.Fail, timeoutSeconds: 5},
 			},
 			expectInvocations: []invocation{
 				{path: "/mutating/1/0s", timeoutSeconds: 10},   // from request
@@ -104,14 +104,14 @@ func testWebhookTimeout(t *testing.T, watchCache bool) {
 			name:           "webhooks consume client timeout available, not webhook timeout",
 			timeoutSeconds: 10,
 			mutatingWebhooks: []testWebhook{
-				{path: "/mutating/1/1s", policy: admissionv1beta1.Fail, timeoutSeconds: 20},
-				{path: "/mutating/2/1s", policy: admissionv1beta1.Fail, timeoutSeconds: 5},
-				{path: "/mutating/3/1s", policy: admissionv1beta1.Fail, timeoutSeconds: 20},
+				{path: "/mutating/1/1s", policy: admissionregistrationv1.Fail, timeoutSeconds: 20},
+				{path: "/mutating/2/1s", policy: admissionregistrationv1.Fail, timeoutSeconds: 5},
+				{path: "/mutating/3/1s", policy: admissionregistrationv1.Fail, timeoutSeconds: 20},
 			},
 			validatingWebhooks: []testWebhook{
-				{path: "/validating/4/1s", policy: admissionv1beta1.Fail, timeoutSeconds: 5},
-				{path: "/validating/5/1s", policy: admissionv1beta1.Fail, timeoutSeconds: 10},
-				{path: "/validating/6/1s", policy: admissionv1beta1.Fail, timeoutSeconds: 20},
+				{path: "/validating/4/1s", policy: admissionregistrationv1.Fail, timeoutSeconds: 5},
+				{path: "/validating/5/1s", policy: admissionregistrationv1.Fail, timeoutSeconds: 10},
+				{path: "/validating/6/1s", policy: admissionregistrationv1.Fail, timeoutSeconds: 20},
 			},
 			expectInvocations: []invocation{
 				{path: "/mutating/1/1s", timeoutSeconds: 10},  // from request
@@ -126,9 +126,9 @@ func testWebhookTimeout(t *testing.T, watchCache bool) {
 			name:           "timed out client requests skip later mutating webhooks (regardless of failure policy) and fail",
 			timeoutSeconds: 3,
 			mutatingWebhooks: []testWebhook{
-				{path: "/mutating/1/5s", policy: admissionv1beta1.Ignore, timeoutSeconds: 4},
-				{path: "/mutating/2/1s", policy: admissionv1beta1.Ignore, timeoutSeconds: 5},
-				{path: "/mutating/3/1s", policy: admissionv1beta1.Ignore, timeoutSeconds: 5},
+				{path: "/mutating/1/5s", policy: admissionregistrationv1.Ignore, timeoutSeconds: 4},
+				{path: "/mutating/2/1s", policy: admissionregistrationv1.Ignore, timeoutSeconds: 5},
+				{path: "/mutating/3/1s", policy: admissionregistrationv1.Ignore, timeoutSeconds: 5},
 			},
 			expectInvocations: []invocation{
 				{path: "/mutating/1/5s", timeoutSeconds: 3}, // from request
@@ -190,27 +190,28 @@ func testWebhookTimeout(t *testing.T, watchCache bool) {
 				t.Fatal(err)
 			}
 
-			mutatingWebhooks := []admissionv1beta1.MutatingWebhook{}
+			mutatingWebhooks := []admissionregistrationv1.MutatingWebhook{}
 			for j, webhook := range tt.mutatingWebhooks {
 				name := fmt.Sprintf("admission.integration.test.%d.%s", j, strings.Replace(strings.TrimPrefix(webhook.path, "/"), "/", "-", -1))
 				endpoint := webhookServer.URL + webhook.path
-				mutatingWebhooks = append(mutatingWebhooks, admissionv1beta1.MutatingWebhook{
+				mutatingWebhooks = append(mutatingWebhooks, admissionregistrationv1.MutatingWebhook{
 					Name: name,
-					ClientConfig: admissionv1beta1.WebhookClientConfig{
+					ClientConfig: admissionregistrationv1.WebhookClientConfig{
 						URL:      &endpoint,
 						CABundle: localhostCert,
 					},
-					Rules: []admissionv1beta1.RuleWithOperations{{
-						Operations: []admissionv1beta1.OperationType{admissionv1beta1.OperationAll},
-						Rule:       admissionv1beta1.Rule{APIGroups: []string{""}, APIVersions: []string{"v1"}, Resources: []string{"pods"}},
+					Rules: []admissionregistrationv1.RuleWithOperations{{
+						Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.OperationAll},
+						Rule:       admissionregistrationv1.Rule{APIGroups: []string{""}, APIVersions: []string{"v1"}, Resources: []string{"pods"}},
 					}},
 					ObjectSelector:          webhook.objectSelector,
 					FailurePolicy:           &tt.mutatingWebhooks[j].policy,
 					TimeoutSeconds:          &tt.mutatingWebhooks[j].timeoutSeconds,
 					AdmissionReviewVersions: []string{"v1beta1"},
+					SideEffects:             &noSideEffects,
 				})
 			}
-			mutatingCfg, err := client.AdmissionregistrationV1beta1().MutatingWebhookConfigurations().Create(context.TODO(), &admissionv1beta1.MutatingWebhookConfiguration{
+			mutatingCfg, err := client.AdmissionregistrationV1().MutatingWebhookConfigurations().Create(context.TODO(), &admissionregistrationv1.MutatingWebhookConfiguration{
 				ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("admission.integration.test-%d", i)},
 				Webhooks:   mutatingWebhooks,
 			}, metav1.CreateOptions{})
@@ -218,33 +219,34 @@ func testWebhookTimeout(t *testing.T, watchCache bool) {
 				t.Fatal(err)
 			}
 			defer func() {
-				err := client.AdmissionregistrationV1beta1().MutatingWebhookConfigurations().Delete(context.TODO(), mutatingCfg.GetName(), metav1.DeleteOptions{})
+				err := client.AdmissionregistrationV1().MutatingWebhookConfigurations().Delete(context.TODO(), mutatingCfg.GetName(), metav1.DeleteOptions{})
 				if err != nil {
 					t.Fatal(err)
 				}
 			}()
 
-			validatingWebhooks := []admissionv1beta1.ValidatingWebhook{}
+			validatingWebhooks := []admissionregistrationv1.ValidatingWebhook{}
 			for j, webhook := range tt.validatingWebhooks {
 				name := fmt.Sprintf("admission.integration.test.%d.%s", j, strings.Replace(strings.TrimPrefix(webhook.path, "/"), "/", "-", -1))
 				endpoint := webhookServer.URL + webhook.path
-				validatingWebhooks = append(validatingWebhooks, admissionv1beta1.ValidatingWebhook{
+				validatingWebhooks = append(validatingWebhooks, admissionregistrationv1.ValidatingWebhook{
 					Name: name,
-					ClientConfig: admissionv1beta1.WebhookClientConfig{
+					ClientConfig: admissionregistrationv1.WebhookClientConfig{
 						URL:      &endpoint,
 						CABundle: localhostCert,
 					},
-					Rules: []admissionv1beta1.RuleWithOperations{{
-						Operations: []admissionv1beta1.OperationType{admissionv1beta1.OperationAll},
-						Rule:       admissionv1beta1.Rule{APIGroups: []string{""}, APIVersions: []string{"v1"}, Resources: []string{"pods"}},
+					Rules: []admissionregistrationv1.RuleWithOperations{{
+						Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.OperationAll},
+						Rule:       admissionregistrationv1.Rule{APIGroups: []string{""}, APIVersions: []string{"v1"}, Resources: []string{"pods"}},
 					}},
 					ObjectSelector:          webhook.objectSelector,
 					FailurePolicy:           &tt.validatingWebhooks[j].policy,
 					TimeoutSeconds:          &tt.validatingWebhooks[j].timeoutSeconds,
 					AdmissionReviewVersions: []string{"v1beta1"},
+					SideEffects:             &noSideEffects,
 				})
 			}
-			validatingCfg, err := client.AdmissionregistrationV1beta1().ValidatingWebhookConfigurations().Create(context.TODO(), &admissionv1beta1.ValidatingWebhookConfiguration{
+			validatingCfg, err := client.AdmissionregistrationV1().ValidatingWebhookConfigurations().Create(context.TODO(), &admissionregistrationv1.ValidatingWebhookConfiguration{
 				ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("admission.integration.test-%d", i)},
 				Webhooks:   validatingWebhooks,
 			}, metav1.CreateOptions{})
@@ -252,7 +254,7 @@ func testWebhookTimeout(t *testing.T, watchCache bool) {
 				t.Fatal(err)
 			}
 			defer func() {
-				err := client.AdmissionregistrationV1beta1().ValidatingWebhookConfigurations().Delete(context.TODO(), validatingCfg.GetName(), metav1.DeleteOptions{})
+				err := client.AdmissionregistrationV1().ValidatingWebhookConfigurations().Delete(context.TODO(), validatingCfg.GetName(), metav1.DeleteOptions{})
 				if err != nil {
 					t.Fatal(err)
 				}

--- a/test/integration/apiserver/print_test.go
+++ b/test/integration/apiserver/print_test.go
@@ -27,18 +27,6 @@ import (
 	"testing"
 	"time"
 
-	apiserverinternalv1alpha1 "k8s.io/api/apiserverinternal/v1alpha1"
-	discoveryv1alpha1 "k8s.io/api/discovery/v1alpha1"
-	discoveryv1beta1 "k8s.io/api/discovery/v1beta1"
-	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
-	flowcontrolv1alpha1 "k8s.io/api/flowcontrol/v1alpha1"
-	flowcontrolv1beta1 "k8s.io/api/flowcontrol/v1beta1"
-	nodev1 "k8s.io/api/node/v1"
-	nodev1alpha1 "k8s.io/api/node/v1alpha1"
-	nodev1beta1 "k8s.io/api/node/v1beta1"
-	rbacv1alpha1 "k8s.io/api/rbac/v1alpha1"
-	schedulerapi "k8s.io/api/scheduling/v1"
-	storagev1alpha1 "k8s.io/api/storage/v1alpha1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1beta1 "k8s.io/apimachinery/pkg/apis/meta/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -164,18 +152,18 @@ func TestServerSidePrint(t *testing.T) {
 	s, _, closeFn := setupWithResources(t,
 		// additional groupversions needed for the test to run
 		[]schema.GroupVersion{
-			discoveryv1alpha1.SchemeGroupVersion,
-			discoveryv1beta1.SchemeGroupVersion,
-			rbacv1alpha1.SchemeGroupVersion,
-			schedulerapi.SchemeGroupVersion,
-			storagev1alpha1.SchemeGroupVersion,
-			extensionsv1beta1.SchemeGroupVersion,
-			nodev1.SchemeGroupVersion,
-			nodev1alpha1.SchemeGroupVersion,
-			nodev1beta1.SchemeGroupVersion,
-			flowcontrolv1alpha1.SchemeGroupVersion,
-			flowcontrolv1beta1.SchemeGroupVersion,
-			apiserverinternalv1alpha1.SchemeGroupVersion,
+			{Group: "discovery.k8s.io", Version: "v1alpha1"},
+			{Group: "discovery.k8s.io", Version: "v1beta1"},
+			{Group: "rbac.authorization.k8s.io", Version: "v1alpha1"},
+			{Group: "scheduling.k8s.io", Version: "v1"},
+			{Group: "storage.k8s.io", Version: "v1alpha1"},
+			{Group: "extensions", Version: "v1beta1"},
+			{Group: "node.k8s.io", Version: "v1"},
+			{Group: "node.k8s.io", Version: "v1alpha1"},
+			{Group: "node.k8s.io", Version: "v1beta1"},
+			{Group: "flowcontrol.apiserver.k8s.io", Version: "v1alpha1"},
+			{Group: "flowcontrol.apiserver.k8s.io", Version: "v1beta1"},
+			{Group: "internal.apiserver.k8s.io", Version: "v1alpha1"},
 		},
 		[]schema.GroupVersionResource{},
 	)

--- a/test/integration/examples/apiserver_test.go
+++ b/test/integration/examples/apiserver_test.go
@@ -43,7 +43,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	"k8s.io/client-go/util/cert"
-	apiregistrationv1beta1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1"
+	apiregistrationv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
 	aggregatorclient "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset"
 	kastesting "k8s.io/kubernetes/cmd/kube-apiserver/app/testing"
 	"k8s.io/kubernetes/test/integration/framework"
@@ -111,10 +111,10 @@ func TestAggregatedAPIServer(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = aggregatorClient.ApiregistrationV1beta1().APIServices().Create(context.TODO(), &apiregistrationv1beta1.APIService{
+	_, err = aggregatorClient.ApiregistrationV1().APIServices().Create(context.TODO(), &apiregistrationv1.APIService{
 		ObjectMeta: metav1.ObjectMeta{Name: "v1alpha1.wardle.example.com"},
-		Spec: apiregistrationv1beta1.APIServiceSpec{
-			Service: &apiregistrationv1beta1.ServiceReference{
+		Spec: apiregistrationv1.APIServiceSpec{
+			Service: &apiregistrationv1.ServiceReference{
 				Namespace: "kube-wardle",
 				Name:      "api",
 			},

--- a/test/integration/examples/webhook_test.go
+++ b/test/integration/examples/webhook_test.go
@@ -22,7 +22,8 @@ import (
 	"testing"
 	"time"
 
-	admissionv1beta1 "k8s.io/api/admissionregistration/v1beta1"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -63,19 +64,22 @@ func TestWebhookLoopback(t *testing.T) {
 		},
 	})
 
-	fail := admissionv1beta1.Fail
-	_, err := client.AdmissionregistrationV1beta1().MutatingWebhookConfigurations().Create(context.TODO(), &admissionv1beta1.MutatingWebhookConfiguration{
+	fail := admissionregistrationv1.Fail
+	noSideEffects := admissionregistrationv1.SideEffectClassNone
+	_, err := client.AdmissionregistrationV1().MutatingWebhookConfigurations().Create(context.TODO(), &admissionregistrationv1.MutatingWebhookConfiguration{
 		ObjectMeta: metav1.ObjectMeta{Name: "webhooktest.example.com"},
-		Webhooks: []admissionv1beta1.MutatingWebhook{{
+		Webhooks: []admissionregistrationv1.MutatingWebhook{{
 			Name: "webhooktest.example.com",
-			ClientConfig: admissionv1beta1.WebhookClientConfig{
-				Service: &admissionv1beta1.ServiceReference{Namespace: "default", Name: "kubernetes", Path: &webhookPath},
+			ClientConfig: admissionregistrationv1.WebhookClientConfig{
+				Service: &admissionregistrationv1.ServiceReference{Namespace: "default", Name: "kubernetes", Path: &webhookPath},
 			},
-			Rules: []admissionv1beta1.RuleWithOperations{{
-				Operations: []admissionv1beta1.OperationType{admissionv1beta1.OperationAll},
-				Rule:       admissionv1beta1.Rule{APIGroups: []string{""}, APIVersions: []string{"v1"}, Resources: []string{"configmaps"}},
+			Rules: []admissionregistrationv1.RuleWithOperations{{
+				Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.OperationAll},
+				Rule:       admissionregistrationv1.Rule{APIGroups: []string{""}, APIVersions: []string{"v1"}, Resources: []string{"configmaps"}},
 			}},
-			FailurePolicy: &fail,
+			FailurePolicy:           &fail,
+			SideEffects:             &noSideEffects,
+			AdmissionReviewVersions: []string{"v1"},
 		}},
 	}, metav1.CreateOptions{})
 	if err != nil {

--- a/test/integration/storageversion/storage_version_filter_test.go
+++ b/test/integration/storageversion/storage_version_filter_test.go
@@ -37,7 +37,7 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
-	apiregistrationv1beta1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1"
+	apiregistrationv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
 	aggregatorclient "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset"
 	kubeapiservertesting "k8s.io/kubernetes/cmd/kube-apiserver/app/testing"
 	"k8s.io/kubernetes/test/integration/etcd"
@@ -94,10 +94,10 @@ func testCRDWrite(t *testing.T, cfg *rest.Config, shouldBlock bool) {
 
 func testAPIServiceWrite(t *testing.T, cfg *rest.Config, shouldBlock bool) {
 	aggregatorClient := aggregatorclient.NewForConfigOrDie(cfg)
-	_, err := aggregatorClient.ApiregistrationV1beta1().APIServices().Create(context.TODO(), &apiregistrationv1beta1.APIService{
+	_, err := aggregatorClient.ApiregistrationV1().APIServices().Create(context.TODO(), &apiregistrationv1.APIService{
 		ObjectMeta: metav1.ObjectMeta{Name: "v1alpha1.wardle.example.com"},
-		Spec: apiregistrationv1beta1.APIServiceSpec{
-			Service: &apiregistrationv1beta1.ServiceReference{
+		Spec: apiregistrationv1.APIServiceSpec{
+			Service: &apiregistrationv1.ServiceReference{
 				Namespace: "kube-wardle",
 				Name:      "api",
 			},


### PR DESCRIPTION
This removes v1beta1 admission registration from integration tests.  The tests that are present to ensure migrated data works have been switched to use direct etcd access.

/kind bug
/priority important-soon
@kubernetes/sig-apps-misc 

```release-note
NONE
```