### PR TITLE
Graduate EndpointSliceNodeName feature gate to GA

### DIFF
--- a/pkg/controller/endpointslice/endpointslice_controller_test.go
+++ b/pkg/controller/endpointslice/endpointslice_controller_test.go
@@ -452,6 +452,7 @@ func TestSyncService(t *testing.T) {
 					Addresses: []string{"10.0.0.1"},
 					TargetRef: &v1.ObjectReference{Kind: "Pod", Namespace: "default", Name: "pod0"},
 					Topology:  map[string]string{"kubernetes.io/hostname": "node-1"},
+					NodeName:  utilpointer.StringPtr("node-1"),
 				},
 				{
 					Conditions: discovery.EndpointConditions{
@@ -460,6 +461,7 @@ func TestSyncService(t *testing.T) {
 					Addresses: []string{"10.0.0.2"},
 					TargetRef: &v1.ObjectReference{Kind: "Pod", Namespace: "default", Name: "pod1"},
 					Topology:  map[string]string{"kubernetes.io/hostname": "node-1"},
+					NodeName:  utilpointer.StringPtr("node-1"),
 				},
 			},
 		},
@@ -565,6 +567,7 @@ func TestSyncService(t *testing.T) {
 					Addresses: []string{"fd08::5678:0000:0000:9abc:def0"},
 					TargetRef: &v1.ObjectReference{Kind: "Pod", Namespace: "default", Name: "pod1"},
 					Topology:  map[string]string{"kubernetes.io/hostname": "node-1"},
+					NodeName:  utilpointer.StringPtr("node-1"),
 				},
 			},
 		},
@@ -670,6 +673,7 @@ func TestSyncService(t *testing.T) {
 					Addresses: []string{"10.0.0.1"},
 					TargetRef: &v1.ObjectReference{Kind: "Pod", Namespace: "default", Name: "pod0"},
 					Topology:  map[string]string{"kubernetes.io/hostname": "node-1"},
+					NodeName:  utilpointer.StringPtr("node-1"),
 				},
 				{
 					Conditions: discovery.EndpointConditions{
@@ -680,6 +684,7 @@ func TestSyncService(t *testing.T) {
 					Addresses: []string{"10.0.0.2"},
 					TargetRef: &v1.ObjectReference{Kind: "Pod", Namespace: "default", Name: "pod1"},
 					Topology:  map[string]string{"kubernetes.io/hostname": "node-1"},
+					NodeName:  utilpointer.StringPtr("node-1"),
 				},
 			},
 			terminatingGateEnabled: true,
@@ -784,6 +789,7 @@ func TestSyncService(t *testing.T) {
 					Addresses: []string{"10.0.0.1"},
 					TargetRef: &v1.ObjectReference{Kind: "Pod", Namespace: "default", Name: "pod0"},
 					Topology:  map[string]string{"kubernetes.io/hostname": "node-1"},
+					NodeName:  utilpointer.StringPtr("node-1"),
 				},
 			},
 			terminatingGateEnabled: false,
@@ -890,6 +896,7 @@ func TestSyncService(t *testing.T) {
 					Addresses: []string{"10.0.0.1"},
 					TargetRef: &v1.ObjectReference{Kind: "Pod", Namespace: "default", Name: "pod0"},
 					Topology:  map[string]string{"kubernetes.io/hostname": "node-1"},
+					NodeName:  utilpointer.StringPtr("node-1"),
 				},
 				{
 					Conditions: discovery.EndpointConditions{
@@ -900,6 +907,7 @@ func TestSyncService(t *testing.T) {
 					Addresses: []string{"10.0.0.2"},
 					TargetRef: &v1.ObjectReference{Kind: "Pod", Namespace: "default", Name: "pod1"},
 					Topology:  map[string]string{"kubernetes.io/hostname": "node-1"},
+					NodeName:  utilpointer.StringPtr("node-1"),
 				},
 			},
 			terminatingGateEnabled: true,
@@ -1004,6 +1012,7 @@ func TestSyncService(t *testing.T) {
 					Addresses: []string{"10.0.0.1"},
 					TargetRef: &v1.ObjectReference{Kind: "Pod", Namespace: "default", Name: "pod0"},
 					Topology:  map[string]string{"kubernetes.io/hostname": "node-1"},
+					NodeName:  utilpointer.StringPtr("node-1"),
 				},
 			},
 			terminatingGateEnabled: false,

--- a/pkg/controller/endpointslice/reconciler_test.go
+++ b/pkg/controller/endpointslice/reconciler_test.go
@@ -131,6 +131,7 @@ func TestReconcile1Pod(t *testing.T) {
 							"topology.kubernetes.io/zone":   "us-central1-a",
 							"topology.kubernetes.io/region": "us-central1",
 						},
+						NodeName: utilpointer.StringPtr("node-1"),
 						TargetRef: &corev1.ObjectReference{
 							Kind:      "Pod",
 							Namespace: namespace,
@@ -156,6 +157,7 @@ func TestReconcile1Pod(t *testing.T) {
 							"topology.kubernetes.io/zone":   "us-central1-a",
 							"topology.kubernetes.io/region": "us-central1",
 						},
+						NodeName: utilpointer.StringPtr("node-1"),
 						TargetRef: &corev1.ObjectReference{
 							Kind:      "Pod",
 							Namespace: namespace,
@@ -186,6 +188,7 @@ func TestReconcile1Pod(t *testing.T) {
 							"topology.kubernetes.io/zone":   "us-central1-a",
 							"topology.kubernetes.io/region": "us-central1",
 						},
+						NodeName: utilpointer.StringPtr("node-1"),
 						TargetRef: &corev1.ObjectReference{
 							Kind:      "Pod",
 							Namespace: namespace,
@@ -213,6 +216,7 @@ func TestReconcile1Pod(t *testing.T) {
 							"topology.kubernetes.io/zone":   "us-central1-a",
 							"topology.kubernetes.io/region": "us-central1",
 						},
+						NodeName: utilpointer.StringPtr("node-1"),
 						TargetRef: &corev1.ObjectReference{
 							Kind:      "Pod",
 							Namespace: namespace,
@@ -230,6 +234,7 @@ func TestReconcile1Pod(t *testing.T) {
 					"topology.kubernetes.io/zone":   "us-central1-a",
 					"topology.kubernetes.io/region": "us-central1",
 				},
+				NodeName: utilpointer.StringPtr("node-1"),
 				TargetRef: &corev1.ObjectReference{
 					Kind:      "Pod",
 					Namespace: namespace,
@@ -253,6 +258,7 @@ func TestReconcile1Pod(t *testing.T) {
 							"topology.kubernetes.io/zone":   "us-central1-a",
 							"topology.kubernetes.io/region": "us-central1",
 						},
+						NodeName: utilpointer.StringPtr("node-1"),
 						TargetRef: &corev1.ObjectReference{
 							Kind:      "Pod",
 							Namespace: namespace,
@@ -270,6 +276,7 @@ func TestReconcile1Pod(t *testing.T) {
 					"topology.kubernetes.io/zone":   "us-central1-a",
 					"topology.kubernetes.io/region": "us-central1",
 				},
+				NodeName: utilpointer.StringPtr("node-1"),
 				TargetRef: &corev1.ObjectReference{
 					Kind:      "Pod",
 					Namespace: namespace,
@@ -295,6 +302,7 @@ func TestReconcile1Pod(t *testing.T) {
 							"topology.kubernetes.io/zone":   "us-central1-a",
 							"topology.kubernetes.io/region": "us-central1",
 						},
+						NodeName: utilpointer.StringPtr("node-1"),
 						TargetRef: &corev1.ObjectReference{
 							Kind:      "Pod",
 							Namespace: namespace,
@@ -312,6 +320,7 @@ func TestReconcile1Pod(t *testing.T) {
 					"topology.kubernetes.io/zone":   "us-central1-a",
 					"topology.kubernetes.io/region": "us-central1",
 				},
+				NodeName: utilpointer.StringPtr("node-1"),
 				TargetRef: &corev1.ObjectReference{
 					Kind:      "Pod",
 					Namespace: namespace,
@@ -337,6 +346,7 @@ func TestReconcile1Pod(t *testing.T) {
 							"topology.kubernetes.io/zone":   "us-central1-a",
 							"topology.kubernetes.io/region": "us-central1",
 						},
+						NodeName: utilpointer.StringPtr("node-1"),
 						TargetRef: &corev1.ObjectReference{
 							Kind:      "Pod",
 							Namespace: namespace,
@@ -364,6 +374,7 @@ func TestReconcile1Pod(t *testing.T) {
 							"topology.kubernetes.io/zone":   "us-central1-a",
 							"topology.kubernetes.io/region": "us-central1",
 						},
+						NodeName: utilpointer.StringPtr("node-1"),
 						TargetRef: &corev1.ObjectReference{
 							Kind:      "Pod",
 							Namespace: namespace,
@@ -390,6 +401,7 @@ func TestReconcile1Pod(t *testing.T) {
 							"topology.kubernetes.io/zone":   "us-central1-a",
 							"topology.kubernetes.io/region": "us-central1",
 						},
+						NodeName: utilpointer.StringPtr("node-1"),
 						TargetRef: &corev1.ObjectReference{
 							Kind:      "Pod",
 							Namespace: namespace,
@@ -406,6 +418,7 @@ func TestReconcile1Pod(t *testing.T) {
 							"topology.kubernetes.io/zone":   "us-central1-a",
 							"topology.kubernetes.io/region": "us-central1",
 						},
+						NodeName: utilpointer.StringPtr("node-1"),
 						TargetRef: &corev1.ObjectReference{
 							Kind:      "Pod",
 							Namespace: namespace,

--- a/pkg/controller/endpointslice/utils_test.go
+++ b/pkg/controller/endpointslice/utils_test.go
@@ -252,7 +252,6 @@ func TestPodToEndpoint(t *testing.T) {
 		expectedEndpoint         discovery.Endpoint
 		publishNotReadyAddresses bool
 		terminatingGateEnabled   bool
-		nodeNameGateEnabled      bool
 	}{
 		{
 			name: "Ready pod",
@@ -262,6 +261,7 @@ func TestPodToEndpoint(t *testing.T) {
 				Addresses:  []string{"1.2.3.5"},
 				Conditions: discovery.EndpointConditions{Ready: utilpointer.BoolPtr(true)},
 				Topology:   map[string]string{"kubernetes.io/hostname": "node-1"},
+				NodeName:   utilpointer.StringPtr("node-1"),
 				TargetRef: &v1.ObjectReference{
 					Kind:            "Pod",
 					Namespace:       ns,
@@ -279,6 +279,7 @@ func TestPodToEndpoint(t *testing.T) {
 				Addresses:  []string{"1.2.3.5"},
 				Conditions: discovery.EndpointConditions{Ready: utilpointer.BoolPtr(true)},
 				Topology:   map[string]string{"kubernetes.io/hostname": "node-1"},
+				NodeName:   utilpointer.StringPtr("node-1"),
 				TargetRef: &v1.ObjectReference{
 					Kind:            "Pod",
 					Namespace:       ns,
@@ -296,6 +297,7 @@ func TestPodToEndpoint(t *testing.T) {
 				Addresses:  []string{"1.2.3.5"},
 				Conditions: discovery.EndpointConditions{Ready: utilpointer.BoolPtr(false)},
 				Topology:   map[string]string{"kubernetes.io/hostname": "node-1"},
+				NodeName:   utilpointer.StringPtr("node-1"),
 				TargetRef: &v1.ObjectReference{
 					Kind:            "Pod",
 					Namespace:       ns,
@@ -309,24 +311,6 @@ func TestPodToEndpoint(t *testing.T) {
 			name: "Unready pod + publishNotReadyAddresses",
 			pod:  unreadyPod,
 			svc:  &svcPublishNotReady,
-			expectedEndpoint: discovery.Endpoint{
-				Addresses:  []string{"1.2.3.5"},
-				Conditions: discovery.EndpointConditions{Ready: utilpointer.BoolPtr(true)},
-				Topology:   map[string]string{"kubernetes.io/hostname": "node-1"},
-				TargetRef: &v1.ObjectReference{
-					Kind:            "Pod",
-					Namespace:       ns,
-					Name:            readyPod.Name,
-					UID:             readyPod.UID,
-					ResourceVersion: readyPod.ResourceVersion,
-				},
-			},
-		},
-		{
-			name:                "Ready pod + node name gate enabled",
-			pod:                 readyPod,
-			svc:                 &svc,
-			nodeNameGateEnabled: true,
 			expectedEndpoint: discovery.Endpoint{
 				Addresses:  []string{"1.2.3.5"},
 				Conditions: discovery.EndpointConditions{Ready: utilpointer.BoolPtr(true)},
@@ -354,6 +338,7 @@ func TestPodToEndpoint(t *testing.T) {
 					"topology.kubernetes.io/zone":   "us-central1-a",
 					"topology.kubernetes.io/region": "us-central1",
 				},
+				NodeName: utilpointer.StringPtr("node-1"),
 				TargetRef: &v1.ObjectReference{
 					Kind:            "Pod",
 					Namespace:       ns,
@@ -376,6 +361,7 @@ func TestPodToEndpoint(t *testing.T) {
 					"topology.kubernetes.io/zone":   "us-central1-a",
 					"topology.kubernetes.io/region": "us-central1",
 				},
+				NodeName: utilpointer.StringPtr("node-1"),
 				TargetRef: &v1.ObjectReference{
 					Kind:            "Pod",
 					Namespace:       ns,
@@ -399,6 +385,7 @@ func TestPodToEndpoint(t *testing.T) {
 					"topology.kubernetes.io/zone":   "us-central1-a",
 					"topology.kubernetes.io/region": "us-central1",
 				},
+				NodeName: utilpointer.StringPtr("node-1"),
 				TargetRef: &v1.ObjectReference{
 					Kind:            "Pod",
 					Namespace:       ns,
@@ -420,6 +407,7 @@ func TestPodToEndpoint(t *testing.T) {
 					Terminating: utilpointer.BoolPtr(false),
 				},
 				Topology: map[string]string{"kubernetes.io/hostname": "node-1"},
+				NodeName: utilpointer.StringPtr("node-1"),
 				TargetRef: &v1.ObjectReference{
 					Kind:            "Pod",
 					Namespace:       ns,
@@ -440,6 +428,7 @@ func TestPodToEndpoint(t *testing.T) {
 					Ready: utilpointer.BoolPtr(false),
 				},
 				Topology: map[string]string{"kubernetes.io/hostname": "node-1"},
+				NodeName: utilpointer.StringPtr("node-1"),
 				TargetRef: &v1.ObjectReference{
 					Kind:            "Pod",
 					Namespace:       ns,
@@ -462,6 +451,7 @@ func TestPodToEndpoint(t *testing.T) {
 					Terminating: utilpointer.BoolPtr(true),
 				},
 				Topology: map[string]string{"kubernetes.io/hostname": "node-1"},
+				NodeName: utilpointer.StringPtr("node-1"),
 				TargetRef: &v1.ObjectReference{
 					Kind:            "Pod",
 					Namespace:       ns,
@@ -482,6 +472,7 @@ func TestPodToEndpoint(t *testing.T) {
 					Ready: utilpointer.BoolPtr(false),
 				},
 				Topology: map[string]string{"kubernetes.io/hostname": "node-1"},
+				NodeName: utilpointer.StringPtr("node-1"),
 				TargetRef: &v1.ObjectReference{
 					Kind:            "Pod",
 					Namespace:       ns,
@@ -504,6 +495,7 @@ func TestPodToEndpoint(t *testing.T) {
 					Terminating: utilpointer.BoolPtr(true),
 				},
 				Topology: map[string]string{"kubernetes.io/hostname": "node-1"},
+				NodeName: utilpointer.StringPtr("node-1"),
 				TargetRef: &v1.ObjectReference{
 					Kind:            "Pod",
 					Namespace:       ns,
@@ -519,7 +511,6 @@ func TestPodToEndpoint(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.EndpointSliceTerminatingCondition, testCase.terminatingGateEnabled)()
-			defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.EndpointSliceNodeName, testCase.nodeNameGateEnabled)()
 
 			endpoint := podToEndpoint(testCase.pod, testCase.node, testCase.svc, discovery.AddressTypeIPv4)
 			if !reflect.DeepEqual(testCase.expectedEndpoint, endpoint) {

--- a/pkg/controller/endpointslicemirroring/utils_test.go
+++ b/pkg/controller/endpointslicemirroring/utils_test.go
@@ -27,11 +27,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/rand"
-	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/kubernetes/fake"
 	k8stesting "k8s.io/client-go/testing"
-	featuregatetesting "k8s.io/component-base/featuregate/testing"
-	"k8s.io/kubernetes/pkg/features"
 	utilpointer "k8s.io/utils/pointer"
 )
 
@@ -81,83 +78,39 @@ func TestNewEndpointSlice(t *testing.T) {
 }
 
 func TestAddressToEndpoint(t *testing.T) {
-	testCases := []struct {
-		name                string
-		epAddress           v1.EndpointAddress
-		expectedEndpoint    discovery.Endpoint
-		ready               bool
-		nodeNameGateEnabled bool
-	}{{
-		name: "simple + gate enabled",
-		epAddress: v1.EndpointAddress{
-			IP:       "10.1.2.3",
-			Hostname: "foo",
-			NodeName: utilpointer.StringPtr("node-abc"),
-			TargetRef: &v1.ObjectReference{
-				APIVersion: "v1",
-				Kind:       "Pod",
-				Namespace:  "default",
-				Name:       "foo",
-			},
+	//name: "simple + gate enabled",
+	epAddress := v1.EndpointAddress{
+		IP:       "10.1.2.3",
+		Hostname: "foo",
+		NodeName: utilpointer.StringPtr("node-abc"),
+		TargetRef: &v1.ObjectReference{
+			APIVersion: "v1",
+			Kind:       "Pod",
+			Namespace:  "default",
+			Name:       "foo",
 		},
-		ready:               true,
-		nodeNameGateEnabled: true,
-		expectedEndpoint: discovery.Endpoint{
-			Addresses: []string{"10.1.2.3"},
-			Hostname:  utilpointer.StringPtr("foo"),
-			Conditions: discovery.EndpointConditions{
-				Ready: utilpointer.BoolPtr(true),
-			},
-			Topology: map[string]string{
-				"kubernetes.io/hostname": "node-abc",
-			},
-			TargetRef: &v1.ObjectReference{
-				APIVersion: "v1",
-				Kind:       "Pod",
-				Namespace:  "default",
-				Name:       "foo",
-			},
-			NodeName: utilpointer.StringPtr("node-abc"),
-		},
-	}, {
-		name: "simple + gate disabled",
-		epAddress: v1.EndpointAddress{
-			IP:       "10.1.2.3",
-			Hostname: "foo",
-			NodeName: utilpointer.StringPtr("node-abc"),
-			TargetRef: &v1.ObjectReference{
-				APIVersion: "v1",
-				Kind:       "Pod",
-				Namespace:  "default",
-				Name:       "foo",
-			},
-		},
-		ready:               true,
-		nodeNameGateEnabled: false,
-		expectedEndpoint: discovery.Endpoint{
-			Addresses: []string{"10.1.2.3"},
-			Hostname:  utilpointer.StringPtr("foo"),
-			Conditions: discovery.EndpointConditions{
-				Ready: utilpointer.BoolPtr(true),
-			},
-			Topology: map[string]string{
-				"kubernetes.io/hostname": "node-abc",
-			},
-			TargetRef: &v1.ObjectReference{
-				APIVersion: "v1",
-				Kind:       "Pod",
-				Namespace:  "default",
-				Name:       "foo",
-			},
-		},
-	}}
-
-	for _, tc := range testCases {
-		defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.EndpointSliceNodeName, tc.nodeNameGateEnabled)()
-
-		ep := addressToEndpoint(tc.epAddress, tc.ready)
-		assert.EqualValues(t, tc.expectedEndpoint, *ep)
 	}
+	ready := true
+	expectedEndpoint := discovery.Endpoint{
+		Addresses: []string{"10.1.2.3"},
+		Hostname:  utilpointer.StringPtr("foo"),
+		Conditions: discovery.EndpointConditions{
+			Ready: utilpointer.BoolPtr(true),
+		},
+		Topology: map[string]string{
+			"kubernetes.io/hostname": "node-abc",
+		},
+		TargetRef: &v1.ObjectReference{
+			APIVersion: "v1",
+			Kind:       "Pod",
+			Namespace:  "default",
+			Name:       "foo",
+		},
+		NodeName: utilpointer.StringPtr("node-abc"),
+	}
+
+	ep := addressToEndpoint(epAddress, ready)
+	assert.EqualValues(t, expectedEndpoint, *ep)
 }
 
 // Test helpers

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -748,7 +748,7 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 	EndpointSlice:                                  {Default: true, PreRelease: featuregate.Beta},
 	EndpointSliceProxying:                          {Default: true, PreRelease: featuregate.Beta},
 	EndpointSliceTerminatingCondition:              {Default: false, PreRelease: featuregate.Alpha},
-	EndpointSliceNodeName:                          {Default: false, PreRelease: featuregate.Alpha},
+	EndpointSliceNodeName:                          {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, //remove in 1.25
 	WindowsEndpointSliceProxying:                   {Default: false, PreRelease: featuregate.Alpha},
 	StartupProbe:                                   {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.23
 	AllowInsecureBackendProxy:                      {Default: true, PreRelease: featuregate.Beta},

--- a/pkg/registry/discovery/endpointslice/strategy_test.go
+++ b/pkg/registry/discovery/endpointslice/strategy_test.go
@@ -31,7 +31,6 @@ func Test_dropDisabledFieldsOnCreate(t *testing.T) {
 	testcases := []struct {
 		name                   string
 		terminatingGateEnabled bool
-		nodeNameGateEnabled    bool
 		eps                    *discovery.EndpointSlice
 		expectedEPS            *discovery.EndpointSlice
 	}{
@@ -132,8 +131,7 @@ func Test_dropDisabledFieldsOnCreate(t *testing.T) {
 			},
 		},
 		{
-			name:                "node name gate enabled, field should be allowed",
-			nodeNameGateEnabled: true,
+			name: "node name gate enabled, field should be allowed",
 			eps: &discovery.EndpointSlice{
 				Endpoints: []discovery.Endpoint{
 					{
@@ -151,30 +149,6 @@ func Test_dropDisabledFieldsOnCreate(t *testing.T) {
 					},
 					{
 						NodeName: utilpointer.StringPtr("node-2"),
-					},
-				},
-			},
-		},
-		{
-			name:                "node name gate disabled, field should be allowed",
-			nodeNameGateEnabled: false,
-			eps: &discovery.EndpointSlice{
-				Endpoints: []discovery.Endpoint{
-					{
-						NodeName: utilpointer.StringPtr("node-1"),
-					},
-					{
-						NodeName: utilpointer.StringPtr("node-2"),
-					},
-				},
-			},
-			expectedEPS: &discovery.EndpointSlice{
-				Endpoints: []discovery.Endpoint{
-					{
-						NodeName: nil,
-					},
-					{
-						NodeName: nil,
 					},
 				},
 			},
@@ -184,7 +158,6 @@ func Test_dropDisabledFieldsOnCreate(t *testing.T) {
 	for _, testcase := range testcases {
 		t.Run(testcase.name, func(t *testing.T) {
 			defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.EndpointSliceTerminatingCondition, testcase.terminatingGateEnabled)()
-			defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.EndpointSliceNodeName, testcase.nodeNameGateEnabled)()
 
 			dropDisabledFieldsOnCreate(testcase.eps)
 			if !apiequality.Semantic.DeepEqual(testcase.eps, testcase.expectedEPS) {
@@ -200,7 +173,6 @@ func Test_dropDisabledFieldsOnUpdate(t *testing.T) {
 	testcases := []struct {
 		name                   string
 		terminatingGateEnabled bool
-		nodeNameGateEnabled    bool
 		oldEPS                 *discovery.EndpointSlice
 		newEPS                 *discovery.EndpointSlice
 		expectedEPS            *discovery.EndpointSlice
@@ -483,8 +455,7 @@ func Test_dropDisabledFieldsOnUpdate(t *testing.T) {
 			},
 		},
 		{
-			name:                "node name gate enabled, set on new EPS",
-			nodeNameGateEnabled: true,
+			name: "node name gate enabled, set on new EPS",
 			oldEPS: &discovery.EndpointSlice{
 				Endpoints: []discovery.Endpoint{
 					{
@@ -517,42 +488,7 @@ func Test_dropDisabledFieldsOnUpdate(t *testing.T) {
 			},
 		},
 		{
-			name:                "node name gate disabled, set on new EPS",
-			nodeNameGateEnabled: false,
-			oldEPS: &discovery.EndpointSlice{
-				Endpoints: []discovery.Endpoint{
-					{
-						NodeName: nil,
-					},
-					{
-						NodeName: nil,
-					},
-				},
-			},
-			newEPS: &discovery.EndpointSlice{
-				Endpoints: []discovery.Endpoint{
-					{
-						NodeName: utilpointer.StringPtr("node-1"),
-					},
-					{
-						NodeName: utilpointer.StringPtr("node-2"),
-					},
-				},
-			},
-			expectedEPS: &discovery.EndpointSlice{
-				Endpoints: []discovery.Endpoint{
-					{
-						NodeName: nil,
-					},
-					{
-						NodeName: nil,
-					},
-				},
-			},
-		},
-		{
-			name:                "node name gate disabled, set on old and updated EPS",
-			nodeNameGateEnabled: false,
+			name: "node name gate disabled, set on old and updated EPS",
 			oldEPS: &discovery.EndpointSlice{
 				Endpoints: []discovery.Endpoint{
 					{
@@ -589,7 +525,6 @@ func Test_dropDisabledFieldsOnUpdate(t *testing.T) {
 	for _, testcase := range testcases {
 		t.Run(testcase.name, func(t *testing.T) {
 			defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.EndpointSliceTerminatingCondition, testcase.terminatingGateEnabled)()
-			defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.EndpointSliceNodeName, testcase.nodeNameGateEnabled)()
 
 			dropDisabledFieldsOnUpdate(testcase.oldEPS, testcase.newEPS)
 			if !apiequality.Semantic.DeepEqual(testcase.newEPS, testcase.expectedEPS) {


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
Graduates the nodeName field in the EndpointSliceAPI to GA

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
EndpointSliceNodeName will always be enabled, so NodeName will always be available in the v1beta1 API.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
- [KEP]: [EndpointSlice Enhancement](https://github.com/kubernetes/enhancements/blob/8413469b89851d094eb22813a06594bd4a6d36a4/keps/sig-network/0752-endpointslices/README.md)


/cc @robscott @liggitt @wojtek-t 
/assign @thockin
/sig network
/priority important-soon