### PR TITLE
Incrementing EndpointSlice generation when labels change

### DIFF
--- a/pkg/registry/discovery/endpointslice/strategy.go
+++ b/pkg/registry/discovery/endpointslice/strategy.go
@@ -65,7 +65,7 @@ func (endpointSliceStrategy) PrepareForUpdate(ctx context.Context, obj, old runt
 	newEPS.ObjectMeta = v1.ObjectMeta{}
 	oldEPS.ObjectMeta = v1.ObjectMeta{}
 
-	if !apiequality.Semantic.DeepEqual(newEPS, oldEPS) {
+	if !apiequality.Semantic.DeepEqual(newEPS, oldEPS) || !apiequality.Semantic.DeepEqual(ogNewMeta.Labels, ogOldMeta.Labels) {
 		ogNewMeta.Generation = ogOldMeta.Generation + 1
 	}
 

--- a/pkg/registry/discovery/endpointslice/strategy_test.go
+++ b/pkg/registry/discovery/endpointslice/strategy_test.go
@@ -17,9 +17,11 @@ limitations under the License.
 package endpointslice
 
 import (
+	"context"
 	"testing"
 
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	"k8s.io/kubernetes/pkg/apis/discovery"
@@ -596,6 +598,97 @@ func Test_dropDisabledFieldsOnUpdate(t *testing.T) {
 				t.Logf("actual endpointslice: %v", testcase.newEPS)
 				t.Logf("expected endpointslice: %v", testcase.expectedEPS)
 				t.Errorf("unexpected EndpointSlice from update API strategy")
+			}
+		})
+	}
+}
+
+func TestPrepareForUpdate(t *testing.T) {
+	testCases := []struct {
+		name        string
+		oldEPS      *discovery.EndpointSlice
+		newEPS      *discovery.EndpointSlice
+		expectedEPS *discovery.EndpointSlice
+	}{
+		{
+			name: "unchanged EPS should not increment generation",
+			oldEPS: &discovery.EndpointSlice{
+				ObjectMeta: metav1.ObjectMeta{Generation: 1},
+				Endpoints: []discovery.Endpoint{{
+					Addresses: []string{"1.2.3.4"},
+				}},
+			},
+			newEPS: &discovery.EndpointSlice{
+				ObjectMeta: metav1.ObjectMeta{Generation: 1},
+				Endpoints: []discovery.Endpoint{{
+					Addresses: []string{"1.2.3.4"},
+				}},
+			},
+			expectedEPS: &discovery.EndpointSlice{
+				ObjectMeta: metav1.ObjectMeta{Generation: 1},
+				Endpoints: []discovery.Endpoint{{
+					Addresses: []string{"1.2.3.4"},
+				}},
+			},
+		},
+		{
+			name: "changed endpoints should increment generation",
+			oldEPS: &discovery.EndpointSlice{
+				ObjectMeta: metav1.ObjectMeta{Generation: 1},
+				Endpoints: []discovery.Endpoint{{
+					Addresses: []string{"1.2.3.4"},
+				}},
+			},
+			newEPS: &discovery.EndpointSlice{
+				ObjectMeta: metav1.ObjectMeta{Generation: 1},
+				Endpoints: []discovery.Endpoint{{
+					Addresses: []string{"1.2.3.5"},
+				}},
+			},
+			expectedEPS: &discovery.EndpointSlice{
+				ObjectMeta: metav1.ObjectMeta{Generation: 2},
+				Endpoints: []discovery.Endpoint{{
+					Addresses: []string{"1.2.3.5"},
+				}},
+			},
+		},
+		{
+			name: "changed labels should increment generation",
+			oldEPS: &discovery.EndpointSlice{
+				ObjectMeta: metav1.ObjectMeta{
+					Generation: 1,
+					Labels:     map[string]string{"example": "one"},
+				},
+				Endpoints: []discovery.Endpoint{{
+					Addresses: []string{"1.2.3.4"},
+				}},
+			},
+			newEPS: &discovery.EndpointSlice{
+				ObjectMeta: metav1.ObjectMeta{
+					Generation: 1,
+					Labels:     map[string]string{"example": "two"},
+				},
+				Endpoints: []discovery.Endpoint{{
+					Addresses: []string{"1.2.3.4"},
+				}},
+			},
+			expectedEPS: &discovery.EndpointSlice{
+				ObjectMeta: metav1.ObjectMeta{
+					Generation: 2,
+					Labels:     map[string]string{"example": "two"},
+				},
+				Endpoints: []discovery.Endpoint{{
+					Addresses: []string{"1.2.3.4"},
+				}},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			Strategy.PrepareForUpdate(context.TODO(), tc.newEPS, tc.oldEPS)
+			if !apiequality.Semantic.DeepEqual(tc.newEPS, tc.expectedEPS) {
+				t.Errorf("Expected %+v\nGot: %+v", tc.expectedEPS, tc.newEPS)
 			}
 		})
 	}


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
EndpointSlice labels can be quite meaningful. They are used to indicate the controller they are managed by and the Service they are associated with. Changing these labels can have significant effects on how the EndpointSlice is consumed so incrementing generation seems appropriate.

#### Special notes for your reviewer:
This is especially relevant to https://github.com/kubernetes/kubernetes/pull/99345 where we updated the EndpointSlice controller to track EndpointSlice generations. This change to strategy was suggested by @wojtek-t in https://github.com/kubernetes/kubernetes/pull/99345#discussion_r582911438. 

#### Does this PR introduce a user-facing change?
```release-note
EndpointSlice generation is now incremented when labels change.
```

/sig network
/triage accepted
/priority important-soon
/cc @wojtek-t @aojea 
/assign @liggitt 