### PR TITLE
add ListByIndex func to use index while list objects

### DIFF
--- a/staging/src/k8s.io/client-go/tools/cache/listers.go
+++ b/staging/src/k8s.io/client-go/tools/cache/listers.go
@@ -110,12 +110,11 @@ func ListAllByNamespace(indexer Indexer, namespace string, selector labels.Selec
 
 // ListByIndex used to list items using specific index
 func ListByIndex(indexer Indexer, name, key string, selector labels.Selector, appendFn AppendFunc) error {
-
 	items, err := indexer.ByIndex(name, key)
 	if err != nil {
 		// if err found, we should not list all , return err instead.
 		// if caller needs list all, do not need use specific index, use ListAll
-		klog.Warningf("can not retrieve list of objects using index : %v", err)
+		klog.InfoS("can not retrieve list of objects using index : %v", err)
 		return err
 	}
 

--- a/staging/src/k8s.io/client-go/tools/cache/listers_test.go
+++ b/staging/src/k8s.io/client-go/tools/cache/listers_test.go
@@ -1,16 +1,32 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package cache
 
 import (
-	"k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/meta"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
-	fcache "k8s.io/client-go/tools/cache/testing"
-
 	"errors"
 	"fmt"
 	"testing"
 	"time"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	fcache "k8s.io/client-go/tools/cache/testing"
 )
 
 const (
@@ -37,6 +53,7 @@ func fakeInformer() *sharedIndexInformer {
 	source.Add(&v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "h-dev", Labels: map[string]string{"app": "hello", "env": "dev"}}})
 	source.Add(&v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "h-prod", Labels: map[string]string{"app": "hello", "env": "prod"}}})
 	source.Add(&v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "h2-dev", Labels: map[string]string{"app": "hello2", "env": "dev"}}})
+	source.Add(&v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "h2-dev2", Labels: map[string]string{"app": "hello2", "env": "dev"}}})
 	source.Add(&v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "h2-prod", Labels: map[string]string{"app": "hello2", "env": "prod"}}})
 
 	// create the shared informer and resync every 1s
@@ -58,7 +75,6 @@ func (l *args) appendFunc(m interface{}) {
 }
 
 func (l *args) matchResult(resources map[string]bool) error {
-
 	for _, r := range l.ret {
 		if _, ok := resources[r.Name]; !ok {
 			return errors.New(fmt.Sprintf("test error,should not find item: %s", r.Name))
@@ -79,7 +95,6 @@ func (l *args) matchResult(resources map[string]bool) error {
 }
 
 func TestListByIndex(t *testing.T) {
-
 	// prepare base env
 	informer := fakeInformer()
 	stop := make(chan struct{})
@@ -88,13 +103,14 @@ func TestListByIndex(t *testing.T) {
 	WaitForCacheSync(stop, informer.HasSynced)
 
 	devEnvSelector, _ := labels.Parse("env=dev")
+	emptySelector := labels.NewSelector()
 	tests := []struct {
 		name      string
 		args      args
 		resources map[string]bool
 	}{
 		{
-			name: "hello-dev",
+			name: "locate-one-item",
 			args: args{
 				name:     IndexApp,
 				key:      "hello",
@@ -104,17 +120,27 @@ func TestListByIndex(t *testing.T) {
 			resources: map[string]bool{"h-dev": false},
 		},
 		{
-			name: "hello2-dev",
+			name: "locate-multiple-items",
 			args: args{
 				name:     IndexApp,
 				key:      "hello2",
 				selector: devEnvSelector,
 				indexer:  informer.GetIndexer(),
 			},
-			resources: map[string]bool{"h2-dev": false},
+			resources: map[string]bool{"h2-dev": false, "h2-dev2": false},
 		},
 		{
-			name: "hello3-dev",
+			name: "locate-all-items",
+			args: args{
+				name:     IndexApp,
+				key:      "hello2",
+				selector: emptySelector,
+				indexer:  informer.GetIndexer(),
+			},
+			resources: map[string]bool{"h2-dev": false, "h2-dev2": false, "h2-prod": false},
+		},
+		{
+			name: "find-empty",
 			args: args{
 				name:     IndexApp,
 				key:      "hello3",

--- a/staging/src/k8s.io/client-go/tools/cache/listers_test.go
+++ b/staging/src/k8s.io/client-go/tools/cache/listers_test.go
@@ -1,0 +1,139 @@
+package cache
+
+import (
+	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	fcache "k8s.io/client-go/tools/cache/testing"
+
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+)
+
+const (
+	IndexApp = "appLabel"
+)
+
+var appIndex = Indexers{IndexApp: func(obj interface{}) ([]string, error) {
+	metaData, err := meta.Accessor(obj)
+	if err != nil {
+		return []string{""}, fmt.Errorf("object has no meta: %v", err)
+	}
+
+	labels := metaData.GetLabels()
+	if _, ok := labels["app"]; !ok {
+		return []string{"unknown"}, nil
+	}
+
+	return []string{labels["app"]}, nil
+}}
+
+func fakeInformer() *sharedIndexInformer {
+	// fake controller source
+	source := fcache.NewFakeControllerSource()
+	source.Add(&v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "h-dev", Labels: map[string]string{"app": "hello", "env": "dev"}}})
+	source.Add(&v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "h-prod", Labels: map[string]string{"app": "hello", "env": "prod"}}})
+	source.Add(&v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "h2-dev", Labels: map[string]string{"app": "hello2", "env": "dev"}}})
+	source.Add(&v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "h2-prod", Labels: map[string]string{"app": "hello2", "env": "prod"}}})
+
+	// create the shared informer and resync every 1s
+	informer := NewSharedInformer(source, &v1.Pod{}, 1*time.Second).(*sharedIndexInformer)
+	_ = informer.AddIndexers(appIndex)
+	return informer
+}
+
+type args struct {
+	indexer  Indexer
+	name     string
+	key      string
+	selector labels.Selector
+	ret      []*v1.Pod
+}
+
+func (l *args) appendFunc(m interface{}) {
+	l.ret = append(l.ret, m.(*v1.Pod))
+}
+
+func (l *args) matchResult(resources map[string]bool) error {
+
+	for _, r := range l.ret {
+		if _, ok := resources[r.Name]; !ok {
+			return errors.New(fmt.Sprintf("test error,should not find item: %s", r.Name))
+		}
+		resources[r.Name] = true
+	}
+
+	if len(resources) != len(l.ret) {
+		return errors.New(fmt.Sprintf("test found not match %d, %d", len(resources), len(l.ret)))
+	}
+
+	for k, v := range resources {
+		if !v {
+			return errors.New(fmt.Sprintf(" test not found %s", k))
+		}
+	}
+	return nil
+}
+
+func TestListByIndex(t *testing.T) {
+
+	// prepare base env
+	informer := fakeInformer()
+	stop := make(chan struct{})
+	defer close(stop)
+	go informer.Run(stop)
+	WaitForCacheSync(stop, informer.HasSynced)
+
+	devEnvSelector, _ := labels.Parse("env=dev")
+	tests := []struct {
+		name      string
+		args      args
+		resources map[string]bool
+	}{
+		{
+			name: "hello-dev",
+			args: args{
+				name:     IndexApp,
+				key:      "hello",
+				selector: devEnvSelector,
+				indexer:  informer.GetIndexer(),
+			},
+			resources: map[string]bool{"h-dev": false},
+		},
+		{
+			name: "hello2-dev",
+			args: args{
+				name:     IndexApp,
+				key:      "hello2",
+				selector: devEnvSelector,
+				indexer:  informer.GetIndexer(),
+			},
+			resources: map[string]bool{"h2-dev": false},
+		},
+		{
+			name: "hello3-dev",
+			args: args{
+				name:     IndexApp,
+				key:      "hello3",
+				selector: devEnvSelector,
+				indexer:  informer.GetIndexer(),
+			},
+			resources: map[string]bool{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := ListByIndex(tt.args.indexer, tt.args.name, tt.args.key, tt.args.selector, tt.args.appendFunc); err != nil {
+				t.Fatalf("ListByIndex() error = %v", err)
+			}
+
+			if err := tt.args.matchResult(tt.resources); err != nil {
+				t.Fatalf("ListByIndex() error = %v", err)
+			}
+
+		})
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

k8s have a very powerful design of indexer and generate a lot of  object listers, like `podLister`
And,  those `Lister` should be the most encouraging way to list the objects.
However,  those `Lister` can only make use of the namespace index to find objects.

so, we need a way to use an index to get a quick find.

#### The situation very useful  

In my situation:
- we have serval namespaces, each of them has hundreds of pods.
- our app always deployed multiple versions at the same time. 
- we should show people, all of the pod they have deployed with `labelSelector: "app=xxx"`

so, if we use default lister using namespace index, we have to find hundreds of pods one by one.
but, if we can self custom a new index, group by app name, and use it, it can be much quicker.


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->


#### Special notes for your reviewer:

1. this pr is the first step, to achieve the easy part. add underlay function.
2. get great ideas from the community, see if change the list-generator template is the best way.
3. using informer.GetIndex can work too, but using lister is more encouraged I think. 

`Lister` code is generated and can't be modified by the user (PaaS/saas platform developer, who use `lister`) 
 https://github.com/kubernetes/code-generator/issues/84

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
     using lister-generator will change the interface signature
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
