### PR TITLE
Automated cherry pick of #99464: Number of sockets is assumed to be same as NUMA nodes

### DIFF
--- a/pkg/kubelet/cm/cpumanager/topology/topology.go
+++ b/pkg/kubelet/cm/cpumanager/topology/topology.go
@@ -253,7 +253,7 @@ func Discover(machineInfo *cadvisorapi.MachineInfo, numaNodeInfo NUMANodeInfo) (
 
 	return &CPUTopology{
 		NumCPUs:    machineInfo.NumCores,
-		NumSockets: len(machineInfo.Topology),
+		NumSockets: machineInfo.NumSockets,
 		NumCores:   numPhysicalCores,
 		CPUDetails: CPUDetails,
 	}, nil

--- a/pkg/kubelet/cm/cpumanager/topology/topology_test.go
+++ b/pkg/kubelet/cm/cpumanager/topology/topology_test.go
@@ -45,7 +45,8 @@ func Test_Discover(t *testing.T) {
 		{
 			name: "OneSocketHT",
 			machineInfo: cadvisorapi.MachineInfo{
-				NumCores: 8,
+				NumCores:   8,
+				NumSockets: 1,
 				Topology: []cadvisorapi.Node{
 					{Id: 0,
 						Cores: []cadvisorapi.Core{
@@ -80,7 +81,8 @@ func Test_Discover(t *testing.T) {
 		{
 			name: "DualSocketNoHT",
 			machineInfo: cadvisorapi.MachineInfo{
-				NumCores: 4,
+				NumCores:   4,
+				NumSockets: 2,
 				Topology: []cadvisorapi.Node{
 					{Id: 0,
 						Cores: []cadvisorapi.Core{
@@ -116,7 +118,8 @@ func Test_Discover(t *testing.T) {
 		{
 			name: "DualSocketHT - non unique Core'ID's",
 			machineInfo: cadvisorapi.MachineInfo{
-				NumCores: 12,
+				NumCores:   12,
+				NumSockets: 2,
 				Topology: []cadvisorapi.Node{
 					{Id: 0,
 						Cores: []cadvisorapi.Core{
@@ -162,7 +165,8 @@ func Test_Discover(t *testing.T) {
 		{
 			name: "OneSocketHT fail",
 			machineInfo: cadvisorapi.MachineInfo{
-				NumCores: 8,
+				NumCores:   8,
+				NumSockets: 1,
 				Topology: []cadvisorapi.Node{
 					{Id: 0,
 						Cores: []cadvisorapi.Core{
@@ -181,7 +185,8 @@ func Test_Discover(t *testing.T) {
 		{
 			name: "OneSocketHT fail",
 			machineInfo: cadvisorapi.MachineInfo{
-				NumCores: 8,
+				NumCores:   8,
+				NumSockets: 1,
 				Topology: []cadvisorapi.Node{
 					{Id: 0,
 						Cores: []cadvisorapi.Core{


### PR DESCRIPTION
Cherry pick of #99464 on release-1.19.

#99464: Number of sockets is assumed to be same as NUMA nodes

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Fixes a regression in 1.19+ to make kubelet retrieve number of sockets from cAdvisor MachineInfo, instead of assuming it to be equal to number of NUMA nodes.
```