### PR TITLE
Change KUBE_PARALLEL_BUILD_MEMORY to 20 GiB

### DIFF
--- a/hack/lib/golang.sh
+++ b/hack/lib/golang.sh
@@ -306,10 +306,11 @@ readonly KUBE_TEST_SERVER_BINARIES=("${KUBE_TEST_SERVER_TARGETS[@]##*/}")
 readonly KUBE_TEST_SERVER_PLATFORMS=("${KUBE_SERVER_PLATFORMS[@]:+"${KUBE_SERVER_PLATFORMS[@]}"}")
 
 # Gigabytes necessary for parallel platform builds.
-# As of January 2018, RAM usage is exceeding 30G.
+# As of March 2021 (go 1.16/amd64), the RSS usage is 2GiB by using cached
+# memory of 15GiB.
 # This variable can be overwritten at your own risk.
-# It's defaulting to 40G to provide some headroom
-readonly KUBE_PARALLEL_BUILD_MEMORY=${KUBE_PARALLEL_BUILD_MEMORY:-40}
+# It's defaulting to 20G to provide some headroom.
+readonly KUBE_PARALLEL_BUILD_MEMORY=${KUBE_PARALLEL_BUILD_MEMORY:-20}
 
 readonly KUBE_ALL_TARGETS=(
   "${KUBE_SERVER_TARGETS[@]}"


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

A benchmark with go1.16 on amd64 resulted in an overall maximum memory usage of 15GiB. This means we now lower the `KUBE_PARALLEL_BUILD_MEMORY` to `20` to still have some room left.

The benchmark has been done with the following `Dockerfile`:

```dockerfile
FROM k8s.gcr.io/build-image/kube-cross:v1.16.0-1
RUN apt-get update && apt-get install -y time

WORKDIR /go/src/k8s.io/kubernetes
RUN git clone https://github.com/kubernetes/kubernetes
ENV KUBE_PARALLEL_BUILD_MEMORY=0
RUN /usr/bin/time -v make -C kubernetes cross-in-a-container
```

The value of interest from the output:

```
Maximum resident set size (kbytes): 1847108
```

The RSS is not the only value we have to consider. During the runtime I measured the usage of the cached memory, which gets peaks up to 15GiB.

Test machine specs:
- CPU: 2 x Intel 28-Core Processor @ 2.2GHz
- RAM: 384GB
- OS: Debian 10 (buster)

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

/sig testing release