### PR TITLE
DynamicControllerClientBuilder: allows for plugging HTTP wrappers for custom behaviour

### DIFF
--- a/staging/src/k8s.io/controller-manager/pkg/clientbuilder/client_builder_dynamic.go
+++ b/staging/src/k8s.io/controller-manager/pkg/clientbuilder/client_builder_dynamic.go
@@ -116,7 +116,7 @@ func (t *DynamicControllerClientBuilder) Config(saName string) (*restclient.Conf
 
 	rt, ok := t.roundTripperFuncMap[saName]
 	if ok {
-		configCopy.WrapTransport = rt
+		configCopy.Wrap(rt)
 	} else {
 		cachedTokenSource := transport.NewCachedTokenSource(&tokenSourceImpl{
 			namespace:          t.Namespace,
@@ -125,7 +125,7 @@ func (t *DynamicControllerClientBuilder) Config(saName string) (*restclient.Conf
 			expirationSeconds:  t.expirationSeconds,
 			leewayPercent:      t.leewayPercent,
 		})
-		configCopy.WrapTransport = transport.ResettableTokenSourceWrapTransport(cachedTokenSource)
+		configCopy.Wrap(transport.ResettableTokenSourceWrapTransport(cachedTokenSource))
 		t.roundTripperFuncMap[saName] = configCopy.WrapTransport
 	}
 

--- a/staging/src/k8s.io/controller-manager/pkg/clientbuilder/client_builder_dynamic.go
+++ b/staging/src/k8s.io/controller-manager/pkg/clientbuilder/client_builder_dynamic.go
@@ -235,7 +235,11 @@ func (ts *tokenSourceImpl) Token() (*oauth2.Token, error) {
 
 func constructClient(saNamespace, saName string, config *restclient.Config) restclient.Config {
 	username := apiserverserviceaccount.MakeUsername(saNamespace, saName)
-	ret := *restclient.AnonymousClientConfig(config)
+	// make a shallow copy
+	// the caller already castrated the config during creation
+	// this allows for potential extensions in the future
+	// for example it preserve HTTP wrappers for custom behavior per request
+	ret := *config
 	restclient.AddUserAgent(&ret, username)
 	return ret
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug

/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
There might be cases in which callers want to preserve HTTP wrappers for custom behavior per request. For example, there might be distributions that would like to add custom HTTP Headers for each HTTP request. This PR allows for that. 

It uses the `Wrap` method that adds a transport middleware function that will give the caller an opportunity to wrap the underlying `http.RoundTripper` prior to the first API call being made.

We cannot use `WrapTransport` because it simply overwrites RoundTrippers for the current config instead of appending to already existing ones.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
