### PR TITLE
increase nodeAffinity scorePlugin weight to make this plugin work well

### DIFF
--- a/pkg/scheduler/algorithmprovider/registry.go
+++ b/pkg/scheduler/algorithmprovider/registry.go
@@ -123,7 +123,7 @@ func getDefaultConfig() *schedulerapi.Plugins {
 				{Name: imagelocality.Name, Weight: 1},
 				{Name: interpodaffinity.Name, Weight: 1},
 				{Name: noderesources.LeastAllocatedName, Weight: 1},
-				{Name: nodeaffinity.Name, Weight: 1},
+				{Name: nodeaffinity.Name, Weight: 2}, // This is a score coming from user preference.
 				{Name: nodepreferavoidpods.Name, Weight: 10000},
 				// Weight is doubled because:
 				// - This is a score coming from user preference.


### PR DESCRIPTION

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
It will make nodeAffinity scorePlugin work well

#### Which issue(s) this PR fixes:

Fixes #99630

#### Special notes for your reviewer:
Is it necessary to increase the weight of the scorePlugin coming from user preference to 10 inorder to ensure that user preference takes precedence over system internal scheduling?

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
