### PR TITLE
add myself to owners for etcd metrics

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/metrics/OWNERS
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/metrics/OWNERS
@@ -1,0 +1,4 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+  - logicalhan

--- a/test/integration/metrics/OWNERS
+++ b/test/integration/metrics/OWNERS
@@ -1,0 +1,8 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+- sig-instrumentation-approvers
+reviewers:
+- sig-instrumentation-reviewers
+labels:
+- sig/instrumentation


### PR DESCRIPTION

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

integration/metrics belongs to sig-instrumentation.
etcd/metrics.go is something I am personally more familiar with and have been a reviewer for through a top-level Owners file.

```release-note
NONE
```
/sig api-machinery 
/priority important-soon
