### PR TITLE
Increasing maximum number of ports allowed in EndpointSlice

### DIFF
--- a/pkg/apis/discovery/validation/validation.go
+++ b/pkg/apis/discovery/validation/validation.go
@@ -40,7 +40,7 @@ var (
 	)
 	maxTopologyLabels = 16
 	maxAddresses      = 100
-	maxPorts          = 100
+	maxPorts          = 20000
 	maxEndpoints      = 1000
 )
 


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/kind cleanup

#### What this PR does / why we need it:
Increases maximum number of ports allowed in EndpointSlices from 100 to 20,000.

#### Which issue(s) this PR fixes:
Helps with #99382

#### Does this PR introduce a user-facing change?
```release-note
Fixes a regression in 1.18+ where endpoint slice controller would attempt to create endpoint slices with too many ports; the maximum number of ports allowed in EndpointSlices has been increased from 100 to 20,000
```

/sig network
/priority important-soon
/triage accepted
/cc @freehan
/assign @thockin