### PR TITLE
Remove EndpointSliceNodeName feature gate logic

### DIFF
--- a/pkg/controller/endpointslice/utils.go
+++ b/pkg/controller/endpointslice/utils.go
@@ -45,10 +45,6 @@ func podToEndpoint(pod *corev1.Pod, node *corev1.Node, service *corev1.Service, 
 	// zone, and region, but this will be expanded in the future.
 	topology := map[string]string{}
 
-	if pod.Spec.NodeName != "" {
-		topology["kubernetes.io/hostname"] = pod.Spec.NodeName
-	}
-
 	if node != nil {
 		topologyLabels := []string{
 			"topology.kubernetes.io/zone",
@@ -72,7 +68,6 @@ func podToEndpoint(pod *corev1.Pod, node *corev1.Node, service *corev1.Service, 
 		Conditions: discovery.EndpointConditions{
 			Ready: &ready,
 		},
-		Topology: topology,
 		TargetRef: &corev1.ObjectReference{
 			Kind:            "Pod",
 			Namespace:       pod.ObjectMeta.Namespace,
@@ -87,7 +82,10 @@ func podToEndpoint(pod *corev1.Pod, node *corev1.Node, service *corev1.Service, 
 		ep.Conditions.Terminating = &terminating
 	}
 
-	if pod.Spec.NodeName != "" && utilfeature.DefaultFeatureGate.Enabled(features.EndpointSliceNodeName) {
+	if pod.Spec.NodeName != "" {
+		topology["kubernetes.io/hostname"] = pod.Spec.NodeName
+		ep.Topology = topology
+
 		ep.NodeName = &pod.Spec.NodeName
 	}
 

--- a/pkg/controller/endpointslicemirroring/utils.go
+++ b/pkg/controller/endpointslicemirroring/utils.go
@@ -27,12 +27,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/leaderelection/resourcelock"
 	"k8s.io/kubernetes/pkg/apis/discovery/validation"
 	endpointutil "k8s.io/kubernetes/pkg/controller/util/endpoint"
-	"k8s.io/kubernetes/pkg/features"
 )
 
 // addrTypePortMapKey is used to uniquely identify groups of endpoint ports and
@@ -140,9 +138,7 @@ func addressToEndpoint(address corev1.EndpointAddress, ready bool) *discovery.En
 		endpoint.Topology = map[string]string{
 			"kubernetes.io/hostname": *address.NodeName,
 		}
-		if utilfeature.DefaultFeatureGate.Enabled(features.EndpointSliceNodeName) {
-			endpoint.NodeName = address.NodeName
-		}
+		endpoint.NodeName = address.NodeName
 	}
 	if address.Hostname != "" {
 		endpoint.Hostname = &address.Hostname

--- a/pkg/controlplane/reconcilers/endpointsadapter.go
+++ b/pkg/controlplane/reconcilers/endpointsadapter.go
@@ -18,15 +18,14 @@ package reconcilers
 
 import (
 	"context"
+
 	corev1 "k8s.io/api/core/v1"
 	discovery "k8s.io/api/discovery/v1beta1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 	discoveryclient "k8s.io/client-go/kubernetes/typed/discovery/v1beta1"
-	"k8s.io/kubernetes/pkg/features"
 	utilnet "k8s.io/utils/net"
 )
 
@@ -178,9 +177,7 @@ func endpointFromAddress(address corev1.EndpointAddress, ready bool) discovery.E
 		ep.Topology = map[string]string{
 			"kubernetes.io/hostname": *address.NodeName,
 		}
-		if utilfeature.DefaultFeatureGate.Enabled(features.EndpointSliceNodeName) {
-			ep.NodeName = address.NodeName
-		}
+		ep.NodeName = address.NodeName
 	}
 
 	return ep

--- a/pkg/proxy/endpointslicecache.go
+++ b/pkg/proxy/endpointslicecache.go
@@ -23,13 +23,11 @@ import (
 	"strings"
 	"sync"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	discovery "k8s.io/api/discovery/v1beta1"
 	"k8s.io/apimachinery/pkg/types"
-	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/klog/v2"
-	"k8s.io/kubernetes/pkg/features"
 	utilproxy "k8s.io/kubernetes/pkg/proxy/util"
 	utilnet "k8s.io/utils/net"
 )
@@ -136,9 +134,7 @@ func newEndpointSliceInfo(endpointSlice *discovery.EndpointSlice, remove bool) *
 				Terminating: endpoint.Conditions.Terminating != nil && *endpoint.Conditions.Terminating,
 			}
 
-			if utilfeature.DefaultFeatureGate.Enabled(features.EndpointSliceNodeName) {
-				epInfo.NodeName = endpoint.NodeName
-			}
+			epInfo.NodeName = endpoint.NodeName
 
 			esInfo.Endpoints = append(esInfo.Endpoints, epInfo)
 		}

--- a/pkg/registry/discovery/endpointslice/strategy.go
+++ b/pkg/registry/discovery/endpointslice/strategy.go
@@ -105,14 +105,10 @@ func (endpointSliceStrategy) AllowUnconditionalUpdate() bool {
 
 // dropDisabledConditionsOnCreate will drop any fields that are disabled.
 func dropDisabledFieldsOnCreate(endpointSlice *discovery.EndpointSlice) {
-	dropNodeName := !utilfeature.DefaultFeatureGate.Enabled(features.EndpointSliceNodeName)
 	dropTerminating := !utilfeature.DefaultFeatureGate.Enabled(features.EndpointSliceTerminatingCondition)
 
-	if dropNodeName || dropTerminating {
+	if dropTerminating {
 		for i := range endpointSlice.Endpoints {
-			if dropNodeName {
-				endpointSlice.Endpoints[i].NodeName = nil
-			}
 			if dropTerminating {
 				endpointSlice.Endpoints[i].Conditions.Serving = nil
 				endpointSlice.Endpoints[i].Conditions.Terminating = nil
@@ -124,16 +120,6 @@ func dropDisabledFieldsOnCreate(endpointSlice *discovery.EndpointSlice) {
 // dropDisabledFieldsOnUpdate will drop any disable fields that have not already
 // been set on the EndpointSlice.
 func dropDisabledFieldsOnUpdate(oldEPS, newEPS *discovery.EndpointSlice) {
-	dropNodeName := !utilfeature.DefaultFeatureGate.Enabled(features.EndpointSliceNodeName)
-	if dropNodeName {
-		for _, ep := range oldEPS.Endpoints {
-			if ep.NodeName != nil {
-				dropNodeName = false
-				break
-			}
-		}
-	}
-
 	dropTerminating := !utilfeature.DefaultFeatureGate.Enabled(features.EndpointSliceTerminatingCondition)
 	if dropTerminating {
 		for _, ep := range oldEPS.Endpoints {
@@ -144,11 +130,8 @@ func dropDisabledFieldsOnUpdate(oldEPS, newEPS *discovery.EndpointSlice) {
 		}
 	}
 
-	if dropNodeName || dropTerminating {
+	if dropTerminating {
 		for i := range newEPS.Endpoints {
-			if dropNodeName {
-				newEPS.Endpoints[i].NodeName = nil
-			}
 			if dropTerminating {
 				newEPS.Endpoints[i].Conditions.Serving = nil
 				newEPS.Endpoints[i].Conditions.Terminating = nil


### PR DESCRIPTION
What type of PR is this?
/kind feature
/kind cleanup

#### What this PR does / why we need it:
#99746 graduated EndpointSliceNodeName to GA so it is always enabled. This PR removes all the logic that was checking if it was enabled. 

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
This is a followup PR for the remaining [comments](https://github.com/kubernetes/kubernetes/pull/99746#pullrequestreview-603712596) on #99746.


/cc @robscott @liggitt @wojtek-t
/assign @thockin
/sig network
/priority important-soon