### PR TITLE
remove more CRD v1beta1 client dependencies from test integration

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/fixtures/etcd.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/fixtures/etcd.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fixtures
+
+import (
+	"context"
+	"encoding/json"
+	"path"
+
+	"go.etcd.io/etcd/clientv3"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	"k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
+	"k8s.io/client-go/dynamic"
+)
+
+// CreateCRDUsingRemovedAPI creates a CRD directly using etcd.  This is must *ONLY* be used for checks of compatibility
+// with removed data.  Do not use this just because you don't want to update your test to use v1.  Only use this
+// when it actually matters.
+func CreateCRDUsingRemovedAPI(etcdClient *clientv3.Client, etcdStoragePrefix string, betaCRD *apiextensionsv1beta1.CustomResourceDefinition, apiExtensionsClient clientset.Interface, dynamicClientSet dynamic.Interface) (*apiextensionsv1.CustomResourceDefinition, error) {
+	// attempt defaulting, best effort
+	apiextensionsv1beta1.SetDefaults_CustomResourceDefinition(betaCRD)
+	betaCRD.Kind = "CustomResourceDefinition"
+	betaCRD.APIVersion = apiextensionsv1beta1.SchemeGroupVersion.Group + "/" + apiextensionsv1beta1.SchemeGroupVersion.Version
+
+	ctx := genericapirequest.WithNamespace(genericapirequest.NewContext(), metav1.NamespaceNone)
+	key := path.Join("/", etcdStoragePrefix, "apiextensions.k8s.io", "customresourcedefinitions", betaCRD.Name)
+	val, _ := json.Marshal(betaCRD)
+	if _, err := etcdClient.Put(ctx, key, string(val)); err != nil {
+		return nil, err
+	}
+
+	crd, err := apiExtensionsClient.ApiextensionsV1().CustomResourceDefinitions().Get(context.TODO(), betaCRD.Name, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	return waitForCRDReady(crd, apiExtensionsClient, dynamicClientSet)
+}

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/fixtures/resources.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/fixtures/resources.go
@@ -24,7 +24,6 @@ import (
 	"k8s.io/utils/pointer"
 
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -246,19 +245,6 @@ func NewCurletInstance(namespace, name string) *unstructured.Unstructured {
 	}
 }
 
-func servedVersions(crd *apiextensionsv1beta1.CustomResourceDefinition) []string {
-	if len(crd.Spec.Versions) == 0 {
-		return []string{crd.Spec.Version}
-	}
-	var versions []string
-	for _, v := range crd.Spec.Versions {
-		if v.Served {
-			versions = append(versions, v.Name)
-		}
-	}
-	return versions
-}
-
 func servedV1Versions(crd *apiextensionsv1.CustomResourceDefinition) []string {
 	if len(crd.Spec.Versions) == 0 {
 		return []string{}
@@ -270,22 +256,6 @@ func servedV1Versions(crd *apiextensionsv1.CustomResourceDefinition) []string {
 		}
 	}
 	return versions
-}
-
-func existsInDiscovery(crd *apiextensionsv1beta1.CustomResourceDefinition, apiExtensionsClient clientset.Interface, version string) (bool, error) {
-	groupResource, err := apiExtensionsClient.Discovery().ServerResourcesForGroupVersion(crd.Spec.Group + "/" + version)
-	if err != nil {
-		if errors.IsNotFound(err) {
-			return false, nil
-		}
-		return false, err
-	}
-	for _, g := range groupResource.APIResources {
-		if g.Name == crd.Spec.Names.Plural {
-			return true, nil
-		}
-	}
-	return false, nil
 }
 
 func existsInDiscoveryV1(crd *apiextensionsv1.CustomResourceDefinition, apiExtensionsClient clientset.Interface, version string) (bool, error) {
@@ -304,37 +274,27 @@ func existsInDiscoveryV1(crd *apiextensionsv1.CustomResourceDefinition, apiExten
 	return false, nil
 }
 
-// CreateNewCustomResourceDefinitionWatchUnsafe creates the CRD and makes sure
+// waitForCRDReadyWatchUnsafe creates the CRD and makes sure
 // the apiextension apiserver has installed the CRD. But it's not safe to watch
-// the created CR. Please call CreateNewCustomResourceDefinition if you need to
+// the created CR. Please call CreateCRDUsingRemovedAPI if you need to
 // watch the CR.
-func CreateNewCustomResourceDefinitionWatchUnsafe(crd *apiextensionsv1beta1.CustomResourceDefinition, apiExtensionsClient clientset.Interface) (*apiextensionsv1beta1.CustomResourceDefinition, error) {
-	crd, err := apiExtensionsClient.ApiextensionsV1beta1().CustomResourceDefinitions().Create(context.TODO(), crd, metav1.CreateOptions{})
-	if err != nil {
-		return nil, err
-	}
-
+func waitForCRDReadyWatchUnsafe(crd *apiextensionsv1.CustomResourceDefinition, apiExtensionsClient clientset.Interface) (*apiextensionsv1.CustomResourceDefinition, error) {
 	// wait until all resources appears in discovery
-	for _, version := range servedVersions(crd) {
+	for _, version := range servedV1Versions(crd) {
 		err := wait.PollImmediate(500*time.Millisecond, 30*time.Second, func() (bool, error) {
-			return existsInDiscovery(crd, apiExtensionsClient, version)
+			return existsInDiscoveryV1(crd, apiExtensionsClient, version)
 		})
 		if err != nil {
 			return nil, err
 		}
 	}
 
-	return crd, err
+	return crd, nil
 }
 
-// CreateNewCustomResourceDefinition creates the given CRD and makes sure its watch cache is primed on the server.
-func CreateNewCustomResourceDefinition(crd *apiextensionsv1beta1.CustomResourceDefinition, apiExtensionsClient clientset.Interface, dynamicClientSet dynamic.Interface) (*apiextensionsv1beta1.CustomResourceDefinition, error) {
-	crd, err := CreateNewCustomResourceDefinitionWatchUnsafe(crd, apiExtensionsClient)
-	if err != nil {
-		return nil, err
-	}
-
-	v1CRD, err := apiExtensionsClient.ApiextensionsV1().CustomResourceDefinitions().Get(context.TODO(), crd.Name, metav1.GetOptions{})
+// waitForCRDReady creates the given CRD and makes sure its watch cache is primed on the server.
+func waitForCRDReady(crd *apiextensionsv1.CustomResourceDefinition, apiExtensionsClient clientset.Interface, dynamicClientSet dynamic.Interface) (*apiextensionsv1.CustomResourceDefinition, error) {
+	v1CRD, err := waitForCRDReadyWatchUnsafe(crd, apiExtensionsClient)
 	if err != nil {
 		return nil, err
 	}
@@ -355,7 +315,7 @@ func CreateNewCustomResourceDefinition(crd *apiextensionsv1beta1.CustomResourceD
 	if err != nil {
 		return nil, err
 	}
-	return crd, nil
+	return v1CRD, err
 }
 
 // CreateNewV1CustomResourceDefinitionWatchUnsafe creates the CRD and makes sure
@@ -419,7 +379,7 @@ func resourceClientForVersion(crd *apiextensionsv1.CustomResourceDefinition, dyn
 func isWatchCachePrimed(crd *apiextensionsv1.CustomResourceDefinition, dynamicClientSet dynamic.Interface) (bool, error) {
 	ns := ""
 	if crd.Spec.Scope != apiextensionsv1.ClusterScoped {
-		ns = "aval"
+		ns = "default"
 	}
 
 	versions := servedV1Versions(crd)

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/validation_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/validation_test.go
@@ -19,7 +19,6 @@ package integration
 import (
 	"context"
 	"fmt"
-	"path"
 	"strings"
 	"testing"
 	"time"
@@ -28,10 +27,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/util/json"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/util/yaml"
-	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
 
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
@@ -701,7 +698,7 @@ func TestForbiddenFieldsInSchema(t *testing.T) {
 }
 
 func TestNonStructuralSchemaConditionUpdate(t *testing.T) {
-	tearDown, apiExtensionClient, _, etcdclient, etcdStoragePrefix, err := fixtures.StartDefaultServerWithClientsAndEtcd(t)
+	tearDown, apiExtensionClient, dynamicClient, etcdclient, etcdStoragePrefix, err := fixtures.StartDefaultServerWithClientsAndEtcd(t)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -752,11 +749,8 @@ spec:
 
 	// create CRDs.  We cannot create these in v1, but they can exist in upgraded clusters
 	t.Logf("Creating CRD %s", betaCRD.Name)
-	ctx := genericapirequest.WithNamespace(genericapirequest.NewContext(), metav1.NamespaceNone)
-	key := path.Join("/", etcdStoragePrefix, "apiextensions.k8s.io", "customresourcedefinitions/foos.tests.example.com")
-	val, _ := json.Marshal(betaCRD)
-	if _, err := etcdclient.Put(ctx, key, string(val)); err != nil {
-		t.Fatalf("unexpected error: %v", err)
+	if _, err := fixtures.CreateCRDUsingRemovedAPI(etcdclient, etcdStoragePrefix, betaCRD, apiExtensionClient, dynamicClient); err != nil {
+		t.Fatal(err)
 	}
 
 	// wait for condition with violations

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/versioning_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/versioning_test.go
@@ -62,7 +62,7 @@ func TestInternalVersionIsHandlerVersion(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// update validation via update because the cache priming in CreateNewCustomResourceDefinition will fail otherwise
+	// update validation via update because the cache priming in CreateCRDUsingRemovedAPI will fail otherwise
 	t.Logf("Updating CRD to validate apiVersion")
 	noxuDefinition, err = UpdateCustomResourceDefinitionWithRetry(apiExtensionClient, noxuDefinition.Name, func(crd *apiextensionsv1.CustomResourceDefinition) {
 		for i := range crd.Spec.Versions {

--- a/test/integration/garbagecollector/garbage_collector_test.go
+++ b/test/integration/garbagecollector/garbage_collector_test.go
@@ -226,7 +226,7 @@ func setupWithServer(t *testing.T, result *kubeapiservertesting.TestServer, work
 	if err != nil {
 		t.Fatalf("error creating extension clientset: %v", err)
 	}
-	// CreateNewCustomResourceDefinition wants to use this namespace for verifying
+	// CreateCRDUsingRemovedAPI wants to use this namespace for verifying
 	// namespace-scoped CRD creation.
 	createNamespaceOrDie("aval", clientSet, t)
 

--- a/test/integration/master/kube_apiserver_test.go
+++ b/test/integration/master/kube_apiserver_test.go
@@ -28,6 +28,10 @@ import (
 	"testing"
 	"time"
 
+	"k8s.io/apiextensions-apiserver/test/integration/fixtures"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+
 	"github.com/go-openapi/spec"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -204,26 +208,32 @@ func TestOpenAPIApiextensionsOverlapProtection(t *testing.T) {
 	}
 
 	// Create a CRD that overlaps OpenAPI path with the CRD API
-	crd := &apiextensionsv1beta1.CustomResourceDefinition{
+	crd := &apiextensionsv1.CustomResourceDefinition{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        "customresourcedefinitions.apiextensions.k8s.io",
 			Annotations: map[string]string{"api-approved.kubernetes.io": "unapproved, test-only"},
 		},
-		Spec: apiextensionsv1beta1.CustomResourceDefinitionSpec{
-			Group:   "apiextensions.k8s.io",
-			Version: "v1beta1",
-			Scope:   apiextensionsv1beta1.ClusterScoped,
-			Names: apiextensionsv1beta1.CustomResourceDefinitionNames{
+		Spec: apiextensionsv1.CustomResourceDefinitionSpec{
+			Group: "apiextensions.k8s.io",
+			Scope: apiextensionsv1.ClusterScoped,
+			Names: apiextensionsv1.CustomResourceDefinitionNames{
 				Plural:   "customresourcedefinitions",
 				Singular: "customresourcedefinition",
 				Kind:     "CustomResourceDefinition",
 				ListKind: "CustomResourceDefinitionList",
 			},
-			Validation: &apiextensionsv1beta1.CustomResourceValidation{
-				OpenAPIV3Schema: &apiextensionsv1beta1.JSONSchemaProps{
-					Type: "object",
-					Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
-						testApiextensionsOverlapProbeString: {Type: "boolean"},
+			Versions: []apiextensionsv1.CustomResourceDefinitionVersion{
+				{
+					Name:    "v1beta1",
+					Served:  true,
+					Storage: true,
+					Schema: &apiextensionsv1.CustomResourceValidation{
+						OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
+							Type: "object",
+							Properties: map[string]apiextensionsv1.JSONSchemaProps{
+								testApiextensionsOverlapProbeString: {Type: "boolean"},
+							},
+						},
 					},
 				},
 			},
@@ -263,26 +273,32 @@ func TestOpenAPIApiextensionsOverlapProtection(t *testing.T) {
 	}
 
 	// Create a CRD that overlaps OpenAPI definition with the CRD API
-	crd = &apiextensionsv1beta1.CustomResourceDefinition{
+	crd = &apiextensionsv1.CustomResourceDefinition{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        "customresourcedefinitions.apiextensions.apis.pkg.apiextensions-apiserver.k8s.io",
 			Annotations: map[string]string{"api-approved.kubernetes.io": "unapproved, test-only"},
 		},
-		Spec: apiextensionsv1beta1.CustomResourceDefinitionSpec{
-			Group:   "apiextensions.apis.pkg.apiextensions-apiserver.k8s.io",
-			Version: "v1beta1",
-			Scope:   apiextensionsv1beta1.ClusterScoped,
-			Names: apiextensionsv1beta1.CustomResourceDefinitionNames{
+		Spec: apiextensionsv1.CustomResourceDefinitionSpec{
+			Group: "apiextensions.apis.pkg.apiextensions-apiserver.k8s.io",
+			Scope: apiextensionsv1.ClusterScoped,
+			Names: apiextensionsv1.CustomResourceDefinitionNames{
 				Plural:   "customresourcedefinitions",
 				Singular: "customresourcedefinition",
 				Kind:     "CustomResourceDefinition",
 				ListKind: "CustomResourceDefinitionList",
 			},
-			Validation: &apiextensionsv1beta1.CustomResourceValidation{
-				OpenAPIV3Schema: &apiextensionsv1beta1.JSONSchemaProps{
-					Type: "object",
-					Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
-						testApiextensionsOverlapProbeString: {Type: "boolean"},
+			Versions: []apiextensionsv1.CustomResourceDefinitionVersion{
+				{
+					Name:    "v1beta1",
+					Served:  true,
+					Storage: true,
+					Schema: &apiextensionsv1.CustomResourceValidation{
+						OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
+							Type: "object",
+							Properties: map[string]apiextensionsv1.JSONSchemaProps{
+								testApiextensionsOverlapProbeString: {Type: "boolean"},
+							},
+						},
 					},
 				},
 			},
@@ -319,17 +335,24 @@ func triggerSpecUpdateWithProbeCRD(t *testing.T, apiextensionsclient *apiextensi
 	name := fmt.Sprintf("integration-test-%s-crd", suffix)
 	kind := fmt.Sprintf("Integration-test-%s-crd", suffix)
 	group := "probe.test.com"
-	crd := &apiextensionsv1beta1.CustomResourceDefinition{
+	crd := &apiextensionsv1.CustomResourceDefinition{
 		ObjectMeta: metav1.ObjectMeta{Name: name + "s." + group},
-		Spec: apiextensionsv1beta1.CustomResourceDefinitionSpec{
-			Group:   group,
-			Version: "v1",
-			Scope:   apiextensionsv1beta1.ClusterScoped,
-			Names: apiextensionsv1beta1.CustomResourceDefinitionNames{
+		Spec: apiextensionsv1.CustomResourceDefinitionSpec{
+			Group: group,
+			Scope: apiextensionsv1.ClusterScoped,
+			Names: apiextensionsv1.CustomResourceDefinitionNames{
 				Plural:   name + "s",
 				Singular: name,
 				Kind:     kind,
 				ListKind: kind + "List",
+			},
+			Versions: []apiextensionsv1.CustomResourceDefinitionVersion{
+				{
+					Name:    "v1",
+					Served:  true,
+					Storage: true,
+					Schema:  fixtures.AllowAllSchema(),
+				},
 			},
 		},
 	}

--- a/test/integration/metrics/metrics_test.go
+++ b/test/integration/metrics/metrics_test.go
@@ -99,7 +99,7 @@ func TestApiserverMetrics(t *testing.T) {
 	}
 
 	// Make a request to a deprecated API to ensure there's at least one data point
-	if _, err := client.RbacV1beta1().Roles(metav1.NamespaceDefault).List(context.TODO(), metav1.ListOptions{}); err != nil {
+	if _, err := client.PolicyV1beta1().PodSecurityPolicies().List(context.TODO(), metav1.ListOptions{}); err != nil {
 		t.Fatalf("unexpected error getting rbac roles: %v", err)
 	}
 

--- a/test/integration/storageversion/storage_version_filter_test.go
+++ b/test/integration/storageversion/storage_version_filter_test.go
@@ -88,7 +88,7 @@ func testBuiltinResourceWrite(t *testing.T, cfg *rest.Config, shouldBlock bool) 
 
 func testCRDWrite(t *testing.T, cfg *rest.Config, shouldBlock bool) {
 	crdClient := apiextensionsclientset.NewForConfigOrDie(cfg)
-	_, err := crdClient.ApiextensionsV1beta1().CustomResourceDefinitions().Create(context.TODO(), etcd.GetCustomResourceDefinitionData()[1], metav1.CreateOptions{})
+	_, err := crdClient.ApiextensionsV1().CustomResourceDefinitions().Create(context.TODO(), etcd.GetCustomResourceDefinitionData()[1], metav1.CreateOptions{})
 	assertBlocking("writes to CRD", t, err, shouldBlock)
 }
 


### PR DESCRIPTION
Another set of tests we need to update for CRD v1 before we reach 1.22 betas


/kind bug
/priority important-soon
@kubernetes/sig-api-machinery-pr-reviews 
/assign @sttts 

```release-note
NONE
```