### PR TITLE
Refactor scheduler nodeScores loop to be more efficient

### DIFF
--- a/pkg/scheduler/generic_scheduler.go
+++ b/pkg/scheduler/generic_scheduler.go
@@ -437,13 +437,18 @@ func prioritizeNodes(
 	}
 
 	// Summarize all scores.
-	result := make(framework.NodeScoreList, 0, len(nodes))
+	result := make(framework.NodeScoreList, len(nodes))
 
-	for i := range nodes {
-		result = append(result, framework.NodeScore{Name: nodes[i].Name, Score: 0})
-		for j := range scoresMap {
-			result[i].Score += scoresMap[j][i].Score
+	pluginIndex := 0
+	for _, nodeScores := range scoresMap {
+		for i := range nodeScores {
+			result[i].Score += nodeScores[i].Score
+			// for the first time through, we also need to populate Node names in result[]
+			if pluginIndex == 0 {
+				result[i].Name = nodes[i].Name
+			}
 		}
+		pluginIndex++
 	}
 
 	if len(extenders) != 0 && nodes != nil {


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup


#### What this PR does / why we need it:
This refactors a loop in `generic_scheduler.go` that calculates node scores from plugin results, as described in https://github.com/kubernetes/kubernetes/pull/99411/files#r582329889 to improve efficiency and clarity

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
