### PR TITLE
disable colors in zeitgeist so as not to break shell2junit

### DIFF
--- a/hack/verify-external-dependencies-version.sh
+++ b/hack/verify-external-dependencies-version.sh
@@ -38,7 +38,9 @@ cd -
 # Prefer full path for running zeitgeist
 ZEITGEIST_BIN="$(which zeitgeist)"
 
+# TODO: revert sed hack when zetigeist respects CLICOLOR/ttys
 CLICOLOR=0 "${ZEITGEIST_BIN}" validate \
   --local \
   --base-path "${KUBE_ROOT}" \
-  --config "${KUBE_ROOT}"/build/dependencies.yaml
+  --config "${KUBE_ROOT}"/build/dependencies.yaml \
+  2> >(sed -e $'s/\x1b\[[0-9;]*m//g' >&2)

--- a/hack/verify-external-dependencies-version.sh
+++ b/hack/verify-external-dependencies-version.sh
@@ -38,7 +38,7 @@ cd -
 # Prefer full path for running zeitgeist
 ZEITGEIST_BIN="$(which zeitgeist)"
 
-"${ZEITGEIST_BIN}" validate \
+CLICOLOR=0 "${ZEITGEIST_BIN}" validate \
   --local \
   --base-path "${KUBE_ROOT}" \
   --config "${KUBE_ROOT}"/build/dependencies.yaml


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Disables colored output in zetigeist so we stop getting bad junit:
> error on line 7 at column 26: Input is not proper UTF-8, indicate encoding !
> Bytes: 0x1B 0x5B 0x33 0x36
https://storage.googleapis.com/kubernetes-jenkins/pr-logs/pull/99782/pull-kubernetes-dependencies/1367537951436705792/artifacts/junit_verify.xml

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

see:  https://github.com/kubernetes/release/issues/1935

we should still also log something like "failed" or "error" when there is one so it's easier to grep the output and CI will surface those lines

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
