### PR TITLE
update to handle beta removals in 1.22

### DIFF
--- a/pkg/controlplane/instance.go
+++ b/pkg/controlplane/instance.go
@@ -83,7 +83,6 @@ import (
 	"k8s.io/client-go/kubernetes"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 	discoveryclient "k8s.io/client-go/kubernetes/typed/discovery/v1"
-	"k8s.io/component-base/version"
 	"k8s.io/component-helpers/apimachinery/lease"
 	"k8s.io/klog/v2"
 	api "k8s.io/kubernetes/pkg/apis/core"
@@ -571,7 +570,7 @@ func (m *Instance) InstallAPIs(apiResourceConfigSource serverstorage.APIResource
 	apiGroupsInfo := []*genericapiserver.APIGroupInfo{}
 
 	// used later in the loop to filter the served resource by those that have expired.
-	resourceExpirationEvaluator, err := genericapiserver.NewResourceExpirationEvaluator(version.Get())
+	resourceExpirationEvaluator, err := genericapiserver.NewResourceExpirationEvaluator(*m.GenericAPIServer.Version)
 	if err != nil {
 		return err
 	}

--- a/pkg/controlplane/instance_test.go
+++ b/pkg/controlplane/instance_test.go
@@ -317,31 +317,13 @@ func TestAPIVersionOfDiscoveryEndpoints(t *testing.T) {
 	assert.NoError(decodeResponse(resp, &groupList))
 	assert.Equal(groupList.APIVersion, "")
 
-	// /apis/extensions exists in release-1.1
-	resp, err = http.Get(server.URL + "/apis/extensions")
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
-	group := metav1.APIGroup{}
-	assert.NoError(decodeResponse(resp, &group))
-	assert.Equal(group.APIVersion, "")
-
-	// /apis/extensions/v1beta1 exists in release-1.1
-	resp, err = http.Get(server.URL + "/apis/extensions/v1beta1")
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
-	resourceList = metav1.APIResourceList{}
-	assert.NoError(decodeResponse(resp, &resourceList))
-	assert.Equal(resourceList.APIVersion, "")
-
 	// /apis/autoscaling doesn't exist in release-1.1, so the APIVersion field
 	// should be non-empty in the results returned by the server.
 	resp, err = http.Get(server.URL + "/apis/autoscaling")
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
-	group = metav1.APIGroup{}
+	group := metav1.APIGroup{}
 	assert.NoError(decodeResponse(resp, &group))
 	assert.Equal(group.APIVersion, "v1")
 
@@ -376,8 +358,10 @@ func TestStorageVersionHashes(t *testing.T) {
 		t.Error(err)
 	}
 	var count int
+	apiResources := sets.NewString()
 	for _, g := range all {
 		for _, r := range g.APIResources {
+			apiResources.Insert(g.GroupVersion + "/" + r.Name)
 			if strings.Contains(r.Name, "/") ||
 				storageversionhashdata.NoStorageVersionHash.Has(g.GroupVersion+"/"+r.Name) {
 				if r.StorageVersionHash != "" {
@@ -399,7 +383,8 @@ func TestStorageVersionHashes(t *testing.T) {
 		}
 	}
 	if count != len(storageversionhashdata.GVRToStorageVersionHash) {
-		t.Errorf("please remove the redundant entries from GVRToStorageVersionHash")
+		knownResources := sets.StringKeySet(storageversionhashdata.GVRToStorageVersionHash)
+		t.Errorf("please remove the redundant entries from GVRToStorageVersionHash: %v", knownResources.Difference(apiResources).List())
 	}
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/server/config.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/config.go
@@ -593,6 +593,8 @@ func (c completedConfig) New(name string, delegationTarget DelegationTarget) (*G
 
 		APIServerID:           c.APIServerID,
 		StorageVersionManager: c.StorageVersionManager,
+
+		Version: c.Version,
 	}
 
 	for {

--- a/staging/src/k8s.io/apiserver/pkg/server/deleted_kinds.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/deleted_kinds.go
@@ -83,6 +83,7 @@ func NewResourceExpirationEvaluator(currentVersion apimachineryversion.Info) (Re
 	} else {
 		ret.strictRemovedHandlingInAlpha = envBool
 	}
+
 	if envString, ok := os.LookupEnv("KUBE_APISERVER_SERVE_REMOVED_APIS_FOR_ONE_RELEASE"); !ok {
 		// do nothing
 	} else if envBool, err := strconv.ParseBool(envString); err != nil {

--- a/staging/src/k8s.io/apiserver/pkg/server/deleted_kinds.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/deleted_kinds.go
@@ -54,7 +54,10 @@ type ResourceExpirationEvaluator interface {
 }
 
 func NewResourceExpirationEvaluator(currentVersion apimachineryversion.Info) (ResourceExpirationEvaluator, error) {
-	ret := &resourceExpirationEvaluator{}
+	ret := &resourceExpirationEvaluator{
+		// TODO https://github.com/kubernetes/kubernetes/issues/101951 set this back to false after beta is tagged.
+		strictRemovedHandlingInAlpha: true,
+	}
 	if len(currentVersion.Major) > 0 {
 		currentMajor64, err := strconv.ParseInt(currentVersion.Major, 10, 32)
 		if err != nil {

--- a/staging/src/k8s.io/apiserver/pkg/server/deleted_kinds_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/deleted_kinds_test.go
@@ -82,6 +82,7 @@ func Test_newResourceExpirationEvaluator(t *testing.T) {
 				return
 			}
 
+			actual.(*resourceExpirationEvaluator).strictRemovedHandlingInAlpha = false
 			if !reflect.DeepEqual(tt.expected, *actual.(*resourceExpirationEvaluator)) {
 				t.Fatal(actual)
 			}

--- a/staging/src/k8s.io/apiserver/pkg/server/genericapiserver.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/genericapiserver.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/clock"
 	"k8s.io/apimachinery/pkg/util/sets"
 	utilwaitgroup "k8s.io/apimachinery/pkg/util/waitgroup"
+	"k8s.io/apimachinery/pkg/version"
 	"k8s.io/apiserver/pkg/admission"
 	"k8s.io/apiserver/pkg/audit"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
@@ -209,6 +210,9 @@ type GenericAPIServer struct {
 
 	// StorageVersionManager holds the storage versions of the API resources installed by this server.
 	StorageVersionManager storageversion.Manager
+
+	// Version will enable the /version endpoint if non-nil
+	Version *version.Info
 }
 
 // DelegationTarget is an interface which allows for composition of API servers with top level handling that works

--- a/staging/src/k8s.io/kubectl/pkg/cmd/auth/reconcile.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/auth/reconcile.go
@@ -138,6 +138,7 @@ func (o *ReconcileOptions) Complete(cmd *cobra.Command, f cmdutil.Factory, args 
 		NamespaceParam(namespace).DefaultNamespace().
 		FilenameParam(enforceNamespace, o.FilenameOptions).
 		Flatten().
+		Local().
 		Do()
 
 	if err := r.Err(); err != nil {

--- a/test/integration/framework/master_utils.go
+++ b/test/integration/framework/master_utils.go
@@ -309,6 +309,12 @@ func NewMasterConfigWithOptions(opts *MasterConfigOptions) *controlplane.Config 
 
 	genericConfig := genericapiserver.NewConfig(legacyscheme.Codecs)
 	kubeVersion := version.Get()
+	if len(kubeVersion.Major) == 0 {
+		kubeVersion.Major = "1"
+	}
+	if len(kubeVersion.Minor) == 0 {
+		kubeVersion.Minor = "22"
+	}
 	genericConfig.Version = &kubeVersion
 	genericConfig.Authorization.Authorizer = authorizerfactory.NewAlwaysAllowAuthorizer()
 


### PR DESCRIPTION
Some APIs are removed in 1.22.  This PR handles that removal in advance of a beta being tagged at which point these APIs are automatically no longer served.

/kind cleanup
/priority important-soon
/assign @liggitt 

```release-note
NONE
```