### PR TITLE
add if check for number of scheduled pods to be greater than 0

### DIFF
--- a/test/integration/scheduler_perf/util.go
+++ b/test/integration/scheduler_perf/util.go
@@ -256,12 +256,15 @@ func (tc *throughputCollector) run(ctx context.Context) {
 			}
 
 			scheduled := len(podsScheduled)
-			samplingRatioSeconds := float64(throughputSampleFrequency) / float64(time.Second)
-			throughput := float64(scheduled-lastScheduledCount) / samplingRatioSeconds
-			tc.schedulingThroughputs = append(tc.schedulingThroughputs, throughput)
-			lastScheduledCount = scheduled
+			// Only do sampling if number of scheduled pods is greater than zero
+			if scheduled > 0 {
+				samplingRatioSeconds := float64(throughputSampleFrequency) / float64(time.Second)
+				throughput := float64(scheduled-lastScheduledCount) / samplingRatioSeconds
+				tc.schedulingThroughputs = append(tc.schedulingThroughputs, throughput)
+				lastScheduledCount = scheduled
+				klog.Infof("%d pods scheduled", lastScheduledCount)
+			}
 
-			klog.Infof("%d pods scheduled", lastScheduledCount)
 		}
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
/sig scheduling

#### What this PR does / why we need it:
Starts sampling in throughputCollector if number of scheduled pods is greater than zero

#### Which issue(s) this PR fixes:
Fixes 1st part of <https://github.com/kubernetes/kubernetes/issues/98898>

#### Does this PR introduce a user-facing change?
NONE