### PR TITLE
Fix flake #99821: reduce fuzz runs 50 to 3 per apply config type

### DIFF
--- a/pkg/api/testing/applyconfiguration_test.go
+++ b/pkg/api/testing/applyconfiguration_test.go
@@ -52,7 +52,7 @@ func TestUnstructuredRoundTripApplyConfigurations(t *testing.T) {
 		}
 
 		t.Run(gvk.String(), func(t *testing.T) {
-			for i := 0; i < 50; i++ {
+			for i := 0; i < 3; i++ {
 				item := fuzzObject(t, gvk)
 				builder := applyconfigurations.ForKind(gvk)
 				unstructuredRoundTripApplyConfiguration(t, item, builder)
@@ -80,7 +80,7 @@ func TestJsonRoundTripApplyConfigurations(t *testing.T) {
 		}
 
 		t.Run(gvk.String(), func(t *testing.T) {
-			for i := 0; i < 50; i++ {
+			for i := 0; i < 3; i++ {
 				item := fuzzObject(t, gvk)
 				builder := applyconfigurations.ForKind(gvk)
 				jsonRoundTripApplyConfiguration(t, item, builder)


### PR DESCRIPTION
reducing from 50 to 3 runs per type should get the times under 10s 🤞 

#### What type of PR is this?

/kind cleanup
/kind flake


#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

Fixes #99821

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

/wg-reliability