### PR TITLE
Promote cronjob e2es to conformance

### DIFF
--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -598,6 +598,36 @@
     and minor versions MUST only be an integer.
   release: v1.19
   file: test/e2e/apimachinery/server_version.go
+- testname: CronJob Suspend
+  codename: '[sig-apps] CronJob should not schedule jobs when suspended [Slow] [Conformance]'
+  description: CronJob MUST support suspension, which suppresses creation of new jobs.
+  release: v1.21
+  file: test/e2e/apps/cronjob.go
+- testname: CronJob FrobidConcurrent
+  codename: '[sig-apps] CronJob should not schedule new jobs when ForbidConcurrent
+    [Slow] [Conformance]'
+  description: CronJob MUST support ForbidConcurrent policy, allowing to run single,
+    previous job at the time.
+  release: v1.21
+  file: test/e2e/apps/cronjob.go
+- testname: CronJob ReplaceConcurrent
+  codename: '[sig-apps] CronJob should replace jobs when ReplaceConcurrent [Conformance]'
+  description: CronJob MUST support ReplaceConcurrent policy, allowing to run single,
+    newer job at the time.
+  release: v1.21
+  file: test/e2e/apps/cronjob.go
+- testname: CronJob AllowConcurrent
+  codename: '[sig-apps] CronJob should schedule multiple jobs concurrently [Conformance]'
+  description: CronJob MUST support AllowConcurrent policy, allowing to run multiple
+    jobs at the same time.
+  release: v1.21
+  file: test/e2e/apps/cronjob.go
+- testname: CronJob API Operations
+  codename: '[sig-apps] CronJob should support CronJob API operations [Conformance]'
+  description: ' CronJob MUST support create, get, list, watch, update, patch, delete,
+    and deletecollection. CronJob/status MUST support get, update and patch.'
+  release: v1.21
+  file: test/e2e/apps/cronjob.go
 - testname: DaemonSet-FailedPodCreation
   codename: '[sig-apps] Daemon set [Serial] should retry creating failed daemon pods
     [Conformance]'

--- a/test/e2e/apps/cronjob.go
+++ b/test/e2e/apps/cronjob.go
@@ -64,8 +64,12 @@ var _ = SIGDescribe("CronJob", func() {
 		e2eskipper.SkipIfMissingResource(f.DynamicClient, CronJobGroupVersionResourceBeta, f.Namespace.Name)
 	})
 
-	// multiple jobs running at once
-	ginkgo.It("should schedule multiple jobs concurrently", func() {
+	/*
+	   Release: v1.21
+	   Testname: CronJob AllowConcurrent
+	   Description: CronJob MUST support AllowConcurrent policy, allowing to run multiple jobs at the same time.
+	*/
+	framework.ConformanceIt("should schedule multiple jobs concurrently", func() {
 		ginkgo.By("Creating a cronjob")
 		cronJob := newTestCronJob("concurrent", "*/1 * * * ?", batchv1.AllowConcurrent,
 			sleepCommand, nil, nil)
@@ -87,8 +91,12 @@ var _ = SIGDescribe("CronJob", func() {
 		framework.ExpectNoError(err, "Failed to delete CronJob %s in namespace %s", cronJob.Name, f.Namespace.Name)
 	})
 
-	// suspended should not schedule jobs
-	ginkgo.It("should not schedule jobs when suspended [Slow]", func() {
+	/*
+	   Release: v1.21
+	   Testname: CronJob Suspend
+	   Description: CronJob MUST support suspension, which suppresses creation of new jobs.
+	*/
+	framework.ConformanceIt("should not schedule jobs when suspended [Slow]", func() {
 		ginkgo.By("Creating a suspended cronjob")
 		cronJob := newTestCronJob("suspended", "*/1 * * * ?", batchv1.AllowConcurrent,
 			sleepCommand, nil, nil)
@@ -111,8 +119,12 @@ var _ = SIGDescribe("CronJob", func() {
 		framework.ExpectNoError(err, "Failed to delete CronJob %s in namespace %s", cronJob.Name, f.Namespace.Name)
 	})
 
-	// only single active job is allowed for ForbidConcurrent
-	ginkgo.It("should not schedule new jobs when ForbidConcurrent [Slow]", func() {
+	/*
+	   Release: v1.21
+	   Testname: CronJob FrobidConcurrent
+	   Description: CronJob MUST support ForbidConcurrent policy, allowing to run single, previous job at the time.
+	*/
+	framework.ConformanceIt("should not schedule new jobs when ForbidConcurrent [Slow]", func() {
 		ginkgo.By("Creating a ForbidConcurrent cronjob")
 		cronJob := newTestCronJob("forbid", "*/1 * * * ?", batchv1.ForbidConcurrent,
 			sleepCommand, nil, nil)
@@ -143,8 +155,12 @@ var _ = SIGDescribe("CronJob", func() {
 		framework.ExpectNoError(err, "Failed to delete CronJob %s in namespace %s", cronJob.Name, f.Namespace.Name)
 	})
 
-	// only single active job is allowed for ReplaceConcurrent
-	ginkgo.It("should replace jobs when ReplaceConcurrent", func() {
+	/*
+	   Release: v1.21
+	   Testname: CronJob ReplaceConcurrent
+	   Description: CronJob MUST support ReplaceConcurrent policy, allowing to run single, newer job at the time.
+	*/
+	framework.ConformanceIt("should replace jobs when ReplaceConcurrent", func() {
 		ginkgo.By("Creating a ReplaceConcurrent cronjob")
 		cronJob := newTestCronJob("replace", "*/1 * * * ?", batchv1.ReplaceConcurrent,
 			sleepCommand, nil, nil)
@@ -285,7 +301,14 @@ var _ = SIGDescribe("CronJob", func() {
 		ensureHistoryLimits(f.ClientSet, f.Namespace.Name, cronJob)
 	})
 
-	ginkgo.It("should support CronJob API operations", func() {
+	/*
+	   Release: v1.21
+	   Testname: CronJob API Operations
+	   Description:
+	   CronJob MUST support create, get, list, watch, update, patch, delete, and deletecollection.
+	   CronJob/status MUST support get, update and patch.
+	*/
+	framework.ConformanceIt("should support CronJob API operations", func() {
 		ginkgo.By("Creating a cronjob")
 		successLimit := int32(1)
 		failedLimit := int32(0)


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/kind design
/area conformance
/sig testing
/sig apps 
/priority backlog

#### What this PR does / why we need it:
This promotes CronJob e2es to conformance as complimentary to https://github.com/kubernetes/kubernetes/pull/98965.
See kubernetes/enhancements#19 and complete description from https://github.com/kubernetes/enhancements/tree/master/keps/sig-apps/19-Graduate-CronJob-to-Stable

This split the conformance promotion from https://github.com/kubernetes/kubernetes/pull/99197 and builds on top it, so only the last commit matters in here. 

#### Special notes for your reviewer:
/assign @spiffxp 

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
- [KEP]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-apps/19-Graduate-CronJob-to-Stable 
```