### PR TITLE
Fix completed indexed job with repeated indexes

### DIFF
--- a/pkg/controller/job/job_controller.go
+++ b/pkg/controller/job/job_controller.go
@@ -524,6 +524,10 @@ func (jm *Controller) syncJob(key string) (bool, error) {
 		failureMessage = "Job was active longer than specified deadline"
 	}
 
+	var succeededIndexes string
+	if job.Spec.CompletionMode == batch.IndexedCompletion {
+		succeededIndexes, succeeded = calculateSucceededIndexes(pods)
+	}
 	jobConditionsChanged := false
 	manageJobCalled := false
 	if jobFailed {
@@ -622,7 +626,7 @@ func (jm *Controller) syncJob(key string) (bool, error) {
 		job.Status.Succeeded = succeeded
 		job.Status.Failed = failed
 		if job.Spec.CompletionMode == batch.IndexedCompletion {
-			job.Status.CompletedIndexes = calculateCompletedIndexesStr(pods)
+			job.Status.CompletedIndexes = succeededIndexes
 		}
 
 		if err := jm.updateHandler(&job); err != nil {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

An Indexed Job can only be considered completed if all the indexes are completed. Before this PR, it was only counting the number of succeeded pods, even if indexes were repeated.

#### Which issue(s) this PR fixes:

Ref kubernetes/enhancements#2214

#### Does this PR introduce a user-facing change?

This feature was not released yet.

```release-note
NONE
```