### PR TITLE
test images: powershell-helper linux cache

### DIFF
--- a/test/images/busybox/Dockerfile_windows
+++ b/test/images/busybox/Dockerfile_windows
@@ -57,7 +57,7 @@ RUN mkdir /curl-full /curl-dir && \
 
 # Windows Stage
 FROM --platform=linux/amd64 $REGISTRY/windows-servercore-cache:1.0-linux-amd64-$OS_VERSION as servercore-helper
-FROM e2eteam/powershell-helper:6.2.7 as ps-helper
+FROM e2eteam/powershell-helper:6.2.7-linux-cache as ps-helper
 FROM $BASEIMAGE
 
 COPY --from=prep /tmp-dir /tmp

--- a/test/images/windows/Makefile
+++ b/test/images/windows/Makefile
@@ -23,7 +23,8 @@ sub-build-%:
 	img_version=$(shell cat $*/VERSION); \
 	docker --tlsverify --tlscacert "$(DOCKER_CERT_PATH)/ca.pem" \
 		--tlscert "$(DOCKER_CERT_PATH)/cert.pem" --tlskey "$(DOCKER_CERT_PATH)/key.pem" \
-		-H "$(REMOTE_DOCKER_URL)" build --no-cache --pull -t "$(REGISTRY)/$*:$${img_version}" $*/
+		-H "$(REMOTE_DOCKER_URL)" build --no-cache --pull -t "$(REGISTRY)/$*:$${img_version}" \
+		-f $*/Dockerfile_windows $*/
 
 sub-push-%:
 	img_version=`cat $*/VERSION`; \
@@ -31,8 +32,15 @@ sub-push-%:
 		--tlscert "$(DOCKER_CERT_PATH)/cert.pem" --tlskey "$(DOCKER_CERT_PATH)/key.pem" \
 		-H "$(REMOTE_DOCKER_URL)" push "$(REGISTRY)/$*:$${img_version}"
 
+sub-repush-as-linux-%:
+	img_version=$(shell cat $*/VERSION); \
+	docker buildx build --progress=plain --no-cache --pull --output=type=registry --platform "linux/amd64" \
+		--build-arg SOURCE="$(REGISTRY)/$*:$${img_version}" -t "$(REGISTRY)/$*:$${img_version}"-linux-cache $*/
+
 all-build: $(foreach image, ${ALL_IMAGES}, sub-build-${image})
 
 all-push: all-build $(foreach image, ${ALL_IMAGES}, sub-push-${image})
 
-.PHONY: all-build all-push
+all-push-as-linux: all-push $(foreach image, ${ALL_IMAGES}, sub-repush-as-linux-${image})
+
+.PHONY: all-build all-push all-push-as-linux

--- a/test/images/windows/README.md
+++ b/test/images/windows/README.md
@@ -71,10 +71,22 @@ Finally, the node must be able to push the images to the desired container regis
 authenticated with the registry you're pushing to.
 
 
+### Additional configuration
+
+The `powershell-helper` image uses `mcr.microsoft.com/windows/nanoserver:1809` as a base image.
+Note that `docker buildx` has an issue pulling cross-registry images when building images, and in
+order to circumvent this issue, the make target `all-push-as-linux` will push a Linux cache image
+which will contain only the necessary bits, and this cache image can then be used in the regular
+image building process. As an additional benefit, using a Linux cache image will be faster.
+
+In order to build the Linux cache image, `docker buildx` is needed. For more information about it
+can be read [here](../README.md).
+
+
 ## Building images
 
 The images are built through `make`:
 
 ```bash
-make REGISTRY=foo_registry REMOTE_DOCKER_URL=$REMOTE_DOCKER_URL all-push
+make REGISTRY=foo_registry REMOTE_DOCKER_URL=$REMOTE_DOCKER_URL all-push-as-linux
 ```

--- a/test/images/windows/powershell-helper/Dockerfile
+++ b/test/images/windows/powershell-helper/Dockerfile
@@ -12,40 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM mcr.microsoft.com/windows/servercore:ltsc2019 as prep
+ARG SOURCE
 
-ENV PS_VERSION=6.2.7
-ADD https://github.com/PowerShell/PowerShell/releases/download/v$PS_VERSION/PowerShell-$PS_VERSION-win-x64.zip /PowerShell/powershell.zip
+# NOTE(claudiub): The src image is already based on nanoserver, but it seems that docker buildx
+# has an issue pulling cross-registry images, and we avoid that by pulling it ourselves.
+FROM --platform="windows/amd64" mcr.microsoft.com/windows/nanoserver:1809 as nanoserver
+FROM --platform="windows/amd64" $SOURCE as src
+FROM scratch
 
-RUN cd C:\PowerShell &\
-    tar.exe -xf powershell.zip &\
-    del powershell.zip &\
-    mklink powershell.exe pwsh.exe
+# NOTE(claudiub): We're basically forcing docker buildx to finish pulling the nanoserver image
+# before continuing with the rest of this Dockerfile.
+COPY --from=nanoserver /License.txt /License.txt
 
-FROM mcr.microsoft.com/windows/nanoserver:1809
-
-COPY --from=prep /PowerShell /PowerShell
-
-# set a fixed location for the Module analysis cache
-ENV LOCALAPPDATA="C:\Users\ContainerAdministrator\AppData\Local" \
-    PSModuleAnalysisCachePath="C:\Users\ContainerAdministrator\AppData\Local\Microsoft\Windows\PowerShell\docker\ModuleAnalysisCache" \
-    # Persist %PSCORE% ENV variable for user convenience
-    PSCORE="C:\PowerShell\pwsh.exe"
-
-# use downloaded powershell
-USER ContainerAdministrator
-RUN setx /M PATH "C:\Powershell\;%PATH%"
-
-# intialize powershell module cache
-RUN powershell \
-        -NoLogo \
-        -NoProfile \
-        -Command " \
-          $stopTime = (get-date).AddMinutes(15); \
-          $ErrorActionPreference = 'Stop' ; \
-          $ProgressPreference = 'SilentlyContinue' ; \
-          while(!(Test-Path -Path $env:PSModuleAnalysisCachePath)) {  \
-            Write-Host "'Waiting for $env:PSModuleAnalysisCachePath'" ; \
-            if((get-date) -gt $stopTime) { throw 'timout expired'} \
-            Start-Sleep -Seconds 6 ; \
-          }"
+COPY --from=src /PowerShell /PowerShell
+COPY --from=src /Users/ContainerAdministrator/AppData/Local/Microsoft/Windows/PowerShell/docker/ModuleAnalysisCache /Users/ContainerAdministrator/AppData/Local/Microsoft/Windows/PowerShell/docker/ModuleAnalysisCache

--- a/test/images/windows/powershell-helper/Dockerfile_windows
+++ b/test/images/windows/powershell-helper/Dockerfile_windows
@@ -1,0 +1,51 @@
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM mcr.microsoft.com/windows/servercore:ltsc2019 as prep
+
+ENV PS_VERSION=6.2.7
+ADD https://github.com/PowerShell/PowerShell/releases/download/v$PS_VERSION/PowerShell-$PS_VERSION-win-x64.zip /PowerShell/powershell.zip
+
+RUN cd C:\PowerShell &\
+    tar.exe -xf powershell.zip &\
+    del powershell.zip &\
+    mklink powershell.exe pwsh.exe
+
+FROM mcr.microsoft.com/windows/nanoserver:1809
+
+COPY --from=prep /PowerShell /PowerShell
+
+# set a fixed location for the Module analysis cache
+ENV LOCALAPPDATA="C:\Users\ContainerAdministrator\AppData\Local" \
+    PSModuleAnalysisCachePath="C:\Users\ContainerAdministrator\AppData\Local\Microsoft\Windows\PowerShell\docker\ModuleAnalysisCache" \
+    # Persist %PSCORE% ENV variable for user convenience
+    PSCORE="C:\PowerShell\pwsh.exe"
+
+# use downloaded powershell
+USER ContainerAdministrator
+RUN setx /M PATH "C:\Powershell\;%PATH%"
+
+# intialize powershell module cache
+RUN powershell \
+        -NoLogo \
+        -NoProfile \
+        -Command " \
+          $stopTime = (get-date).AddMinutes(15); \
+          $ErrorActionPreference = 'Stop' ; \
+          $ProgressPreference = 'SilentlyContinue' ; \
+          while(!(Test-Path -Path $env:PSModuleAnalysisCachePath)) {  \
+            Write-Host "'Waiting for $env:PSModuleAnalysisCachePath'" ; \
+            if((get-date) -gt $stopTime) { throw 'timout expired'} \
+            Start-Sleep -Seconds 6 ; \
+          }"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind cleanup
/sig windows
/sig testing

#### What this PR does / why we need it:

We can cache the ``powershell-helper`` image's results into a scratch Linux image using ``docker buildx``. This will allow us to spend less time pulling the data we need from the ``powershell-helper`` image when we need it.

Additionally, ``docker buildx`` might have some issues with cross-registry images, so this will allow us to circumvent it. Currently, the busybox Image Builder job is failing [1] because of it. It errors out because it's not being able to find ``sha256:62239e9aa1a352a20b0d4969c2b508b8a18d10e799d4db72e6f24ccbb2c724d9``, which is the nanoserver image layer the ``e2eteam/powershell-helper:6.2.7`` was built with. That image is on mcr, while the ``powershell-helper`` image is on dockerhub. Looking at the job logs, it can be seen that pulling the nanoserver layer took 0.0 seconds for 100 mb.

Alternatively, the nanoserver layers / image could be pulled beforehand (and adding some instruction that would force ``docker buildx`` to wait for the image to finish pulling), and that would ensure that they will exist, so this error won't occur anymore. 

[1] https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/post-kubernetes-push-e2e-busybox-test-images/1366557273911988224

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
