### PR TITLE
Graduate EndpointSlice Controllers to GA

### DIFF
--- a/cmd/kube-apiserver/app/options/validation.go
+++ b/cmd/kube-apiserver/app/options/validation.go
@@ -55,12 +55,10 @@ func validateClusterIPFlags(options *ServerRunOptions) []error {
 	}
 
 	// Secondary IP validation
-	// while api-server dualstack bits does not have dependency on EndPointSlice, its
-	// a good idea to have validation consistent across all components (ControllerManager
-	// needs EndPointSlice + DualStack feature flags).
+	// ControllerManager needs DualStack feature flags
 	secondaryServiceClusterIPRangeUsed := (options.SecondaryServiceClusterIPRange.IP != nil)
-	if secondaryServiceClusterIPRangeUsed && (!utilfeature.DefaultFeatureGate.Enabled(features.IPv6DualStack) || !utilfeature.DefaultFeatureGate.Enabled(features.EndpointSlice)) {
-		errs = append(errs, fmt.Errorf("secondary service cluster-ip range(--service-cluster-ip-range[1]) can only be used if %v and %v feature is enabled", string(features.IPv6DualStack), string(features.EndpointSlice)))
+	if secondaryServiceClusterIPRangeUsed && !utilfeature.DefaultFeatureGate.Enabled(features.IPv6DualStack) {
+		errs = append(errs, fmt.Errorf("secondary service cluster-ip range(--service-cluster-ip-range[1]) can only be used if %v feature is enabled", string(features.IPv6DualStack)))
 	}
 
 	// note: While the cluster might be dualstack (i.e. pods with multiple IPs), the user may choose

--- a/cmd/kube-apiserver/app/options/validation_test.go
+++ b/cmd/kube-apiserver/app/options/validation_test.go
@@ -52,13 +52,12 @@ func makeOptionsWithCIDRs(serviceCIDR string, secondaryServiceCIDR string) *Serv
 	}
 }
 
-func TestClusterSerivceIPRange(t *testing.T) {
+func TestClusterServiceIPRange(t *testing.T) {
 	testCases := []struct {
-		name                string
-		options             *ServerRunOptions
-		enableDualStack     bool
-		enableEndpointSlice bool
-		expectErrors        bool
+		name            string
+		options         *ServerRunOptions
+		enableDualStack bool
+		expectErrors    bool
 	}{
 		{
 			name:            "no service cidr",
@@ -67,11 +66,10 @@ func TestClusterSerivceIPRange(t *testing.T) {
 			enableDualStack: false,
 		},
 		{
-			name:                "only secondary service cidr, dual stack gate on",
-			expectErrors:        true,
-			options:             makeOptionsWithCIDRs("", "10.0.0.0/16"),
-			enableDualStack:     true,
-			enableEndpointSlice: true,
+			name:            "only secondary service cidr, dual stack gate on",
+			expectErrors:    true,
+			options:         makeOptionsWithCIDRs("", "10.0.0.0/16"),
+			enableDualStack: true,
 		},
 		{
 			name:            "only secondary service cidr, dual stack gate off",
@@ -80,18 +78,16 @@ func TestClusterSerivceIPRange(t *testing.T) {
 			enableDualStack: false,
 		},
 		{
-			name:                "primary and secondary are provided but not dual stack v4-v4",
-			expectErrors:        true,
-			options:             makeOptionsWithCIDRs("10.0.0.0/16", "11.0.0.0/16"),
-			enableDualStack:     true,
-			enableEndpointSlice: true,
+			name:            "primary and secondary are provided but not dual stack v4-v4",
+			expectErrors:    true,
+			options:         makeOptionsWithCIDRs("10.0.0.0/16", "11.0.0.0/16"),
+			enableDualStack: true,
 		},
 		{
-			name:                "primary and secondary are provided but not dual stack v6-v6",
-			expectErrors:        true,
-			options:             makeOptionsWithCIDRs("2000::/108", "3000::/108"),
-			enableDualStack:     true,
-			enableEndpointSlice: true,
+			name:            "primary and secondary are provided but not dual stack v6-v6",
+			expectErrors:    true,
+			options:         makeOptionsWithCIDRs("2000::/108", "3000::/108"),
+			enableDualStack: true,
 		},
 		{
 			name:            "valid dual stack with gate disabled",
@@ -100,34 +96,24 @@ func TestClusterSerivceIPRange(t *testing.T) {
 			enableDualStack: false,
 		},
 		{
-			name:                "service cidr is too big",
-			expectErrors:        true,
-			options:             makeOptionsWithCIDRs("10.0.0.0/8", ""),
-			enableDualStack:     true,
-			enableEndpointSlice: true,
+			name:            "service cidr is too big",
+			expectErrors:    true,
+			options:         makeOptionsWithCIDRs("10.0.0.0/8", ""),
+			enableDualStack: true,
 		},
 		{
-			name:                "dual-stack secondary cidr too big",
-			expectErrors:        true,
-			options:             makeOptionsWithCIDRs("10.0.0.0/16", "3000::/64"),
-			enableDualStack:     true,
-			enableEndpointSlice: true,
+			name:            "dual-stack secondary cidr too big",
+			expectErrors:    true,
+			options:         makeOptionsWithCIDRs("10.0.0.0/16", "3000::/64"),
+			enableDualStack: true,
 		},
 		{
-			name:                "valid v6-v4 dual stack + gate on + endpointSlice gate is on",
-			expectErrors:        false,
-			options:             makeOptionsWithCIDRs("3000::/108", "10.0.0.0/16"),
-			enableDualStack:     true,
-			enableEndpointSlice: true,
+			name:            "valid v6-v4 dual stack + gate on + endpointSlice gate is on",
+			expectErrors:    false,
+			options:         makeOptionsWithCIDRs("3000::/108", "10.0.0.0/16"),
+			enableDualStack: true,
 		},
 
-		{
-			name:                "valid v4-v6 dual stack + gate on + endpointSlice is off",
-			expectErrors:        true,
-			options:             makeOptionsWithCIDRs("10.0.0.0/16", "3000::/108"),
-			enableDualStack:     true,
-			enableEndpointSlice: false,
-		},
 		/* success cases */
 		{
 			name:            "valid primary",
@@ -136,25 +122,22 @@ func TestClusterSerivceIPRange(t *testing.T) {
 			enableDualStack: false,
 		},
 		{
-			name:                "valid v4-v6 dual stack + gate on",
-			expectErrors:        false,
-			options:             makeOptionsWithCIDRs("10.0.0.0/16", "3000::/108"),
-			enableDualStack:     true,
-			enableEndpointSlice: true,
+			name:            "valid v4-v6 dual stack + gate on",
+			expectErrors:    false,
+			options:         makeOptionsWithCIDRs("10.0.0.0/16", "3000::/108"),
+			enableDualStack: true,
 		},
 		{
-			name:                "valid v6-v4 dual stack + gate on",
-			expectErrors:        false,
-			options:             makeOptionsWithCIDRs("3000::/108", "10.0.0.0/16"),
-			enableDualStack:     true,
-			enableEndpointSlice: true,
+			name:            "valid v6-v4 dual stack + gate on",
+			expectErrors:    false,
+			options:         makeOptionsWithCIDRs("3000::/108", "10.0.0.0/16"),
+			enableDualStack: true,
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.IPv6DualStack, tc.enableDualStack)()
-			defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.EndpointSlice, tc.enableEndpointSlice)()
 			errs := validateClusterIPFlags(tc.options)
 			if len(errs) > 0 && !tc.expectErrors {
 				t.Errorf("expected no errors, errors found %+v", errs)

--- a/cmd/kube-controller-manager/app/core.go
+++ b/cmd/kube-controller-manager/app/core.go
@@ -110,8 +110,8 @@ func startNodeIpamController(ctx ControllerContext) (http.Handler, bool, error) 
 		return nil, false, err
 	}
 
-	// failure: more than one cidr and dual stack is not enabled and/or endpoint slice is not enabled
-	if len(clusterCIDRs) > 1 && (!utilfeature.DefaultFeatureGate.Enabled(features.IPv6DualStack) || !utilfeature.DefaultFeatureGate.Enabled(features.EndpointSlice)) {
+	// failure: more than one cidr and dual stack is not enabled
+	if len(clusterCIDRs) > 1 && !utilfeature.DefaultFeatureGate.Enabled(features.IPv6DualStack) {
 		return nil, false, fmt.Errorf("len of ClusterCIDRs==%v and dualstack or EndpointSlice feature is not enabled", len(clusterCIDRs))
 	}
 

--- a/cmd/kube-controller-manager/app/discovery.go
+++ b/cmd/kube-controller-manager/app/discovery.go
@@ -23,7 +23,7 @@ package app
 import (
 	"net/http"
 
-	discoveryv1beta1 "k8s.io/api/discovery/v1beta1"
+	discoveryv1 "k8s.io/api/discovery/v1"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/klog/v2"
 	endpointslicecontroller "k8s.io/kubernetes/pkg/controller/endpointslice"
@@ -37,8 +37,8 @@ func startEndpointSliceController(ctx ControllerContext) (http.Handler, bool, er
 		return nil, false, nil
 	}
 
-	if !ctx.AvailableResources[discoveryv1beta1.SchemeGroupVersion.WithResource("endpointslices")] {
-		klog.Warningf("Not starting endpointslice-controller since discovery.k8s.io/v1beta1 resources are not available")
+	if !ctx.AvailableResources[discoveryv1.SchemeGroupVersion.WithResource("endpointslices")] {
+		klog.Warningf("Not starting endpointslice-controller since discovery.k8s.io/v1 resources are not available")
 		return nil, false, nil
 	}
 
@@ -46,7 +46,7 @@ func startEndpointSliceController(ctx ControllerContext) (http.Handler, bool, er
 		ctx.InformerFactory.Core().V1().Pods(),
 		ctx.InformerFactory.Core().V1().Services(),
 		ctx.InformerFactory.Core().V1().Nodes(),
-		ctx.InformerFactory.Discovery().V1beta1().EndpointSlices(),
+		ctx.InformerFactory.Discovery().V1().EndpointSlices(),
 		ctx.ComponentConfig.EndpointSliceController.MaxEndpointsPerSlice,
 		ctx.ClientBuilder.ClientOrDie("endpointslice-controller"),
 		ctx.ComponentConfig.EndpointSliceController.EndpointUpdatesBatchPeriod.Duration,
@@ -60,14 +60,14 @@ func startEndpointSliceMirroringController(ctx ControllerContext) (http.Handler,
 		return nil, false, nil
 	}
 
-	if !ctx.AvailableResources[discoveryv1beta1.SchemeGroupVersion.WithResource("endpointslices")] {
-		klog.Warningf("Not starting endpointslicemirroring-controller since discovery.k8s.io/v1beta1 resources are not available")
+	if !ctx.AvailableResources[discoveryv1.SchemeGroupVersion.WithResource("endpointslices")] {
+		klog.Warningf("Not starting endpointslicemirroring-controller since discovery.k8s.io/v1 resources are not available")
 		return nil, false, nil
 	}
 
 	go endpointslicemirroringcontroller.NewController(
 		ctx.InformerFactory.Core().V1().Endpoints(),
-		ctx.InformerFactory.Discovery().V1beta1().EndpointSlices(),
+		ctx.InformerFactory.Discovery().V1().EndpointSlices(),
 		ctx.InformerFactory.Core().V1().Services(),
 		ctx.ComponentConfig.EndpointSliceMirroringController.MirroringMaxEndpointsPerSubset,
 		ctx.ClientBuilder.ClientOrDie("endpointslicemirroring-controller"),

--- a/cmd/kube-controller-manager/app/discovery.go
+++ b/cmd/kube-controller-manager/app/discovery.go
@@ -23,25 +23,11 @@ package app
 import (
 	"net/http"
 
-	discoveryv1 "k8s.io/api/discovery/v1"
-	utilfeature "k8s.io/apiserver/pkg/util/feature"
-	"k8s.io/klog/v2"
 	endpointslicecontroller "k8s.io/kubernetes/pkg/controller/endpointslice"
 	endpointslicemirroringcontroller "k8s.io/kubernetes/pkg/controller/endpointslicemirroring"
-	"k8s.io/kubernetes/pkg/features"
 )
 
 func startEndpointSliceController(ctx ControllerContext) (http.Handler, bool, error) {
-	if !utilfeature.DefaultFeatureGate.Enabled(features.EndpointSlice) {
-		klog.V(2).Infof("Not starting endpointslice-controller since EndpointSlice feature gate is disabled")
-		return nil, false, nil
-	}
-
-	if !ctx.AvailableResources[discoveryv1.SchemeGroupVersion.WithResource("endpointslices")] {
-		klog.Warningf("Not starting endpointslice-controller since discovery.k8s.io/v1 resources are not available")
-		return nil, false, nil
-	}
-
 	go endpointslicecontroller.NewController(
 		ctx.InformerFactory.Core().V1().Pods(),
 		ctx.InformerFactory.Core().V1().Services(),
@@ -55,16 +41,6 @@ func startEndpointSliceController(ctx ControllerContext) (http.Handler, bool, er
 }
 
 func startEndpointSliceMirroringController(ctx ControllerContext) (http.Handler, bool, error) {
-	if !utilfeature.DefaultFeatureGate.Enabled(features.EndpointSlice) {
-		klog.V(2).Infof("Not starting endpointslicemirroring-controller since EndpointSlice feature gate is disabled")
-		return nil, false, nil
-	}
-
-	if !ctx.AvailableResources[discoveryv1.SchemeGroupVersion.WithResource("endpointslices")] {
-		klog.Warningf("Not starting endpointslicemirroring-controller since discovery.k8s.io/v1 resources are not available")
-		return nil, false, nil
-	}
-
 	go endpointslicemirroringcontroller.NewController(
 		ctx.InformerFactory.Core().V1().Endpoints(),
 		ctx.InformerFactory.Discovery().V1().EndpointSlices(),

--- a/pkg/controller/endpointslice/endpointset.go
+++ b/pkg/controller/endpointslice/endpointset.go
@@ -19,7 +19,7 @@ package endpointslice
 import (
 	"sort"
 
-	discovery "k8s.io/api/discovery/v1beta1"
+	discovery "k8s.io/api/discovery/v1"
 	endpointutil "k8s.io/kubernetes/pkg/controller/util/endpoint"
 )
 

--- a/pkg/controller/endpointslice/endpointslice_controller.go
+++ b/pkg/controller/endpointslice/endpointslice_controller.go
@@ -23,18 +23,18 @@ import (
 	"golang.org/x/time/rate"
 
 	v1 "k8s.io/api/core/v1"
-	discovery "k8s.io/api/discovery/v1beta1"
+	discovery "k8s.io/api/discovery/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	coreinformers "k8s.io/client-go/informers/core/v1"
-	discoveryinformers "k8s.io/client-go/informers/discovery/v1beta1"
+	discoveryinformers "k8s.io/client-go/informers/discovery/v1"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	v1core "k8s.io/client-go/kubernetes/typed/core/v1"
 	corelisters "k8s.io/client-go/listers/core/v1"
-	discoverylisters "k8s.io/client-go/listers/discovery/v1beta1"
+	discoverylisters "k8s.io/client-go/listers/discovery/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
@@ -87,7 +87,7 @@ func NewController(podInformer coreinformers.PodInformer,
 	recorder := broadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: "endpoint-slice-controller"})
 
 	if client != nil && client.CoreV1().RESTClient().GetRateLimiter() != nil {
-		ratelimiter.RegisterMetricAndTrackRateLimiterUsage("endpoint_slice_controller", client.DiscoveryV1beta1().RESTClient().GetRateLimiter())
+		ratelimiter.RegisterMetricAndTrackRateLimiterUsage("endpoint_slice_controller", client.DiscoveryV1().RESTClient().GetRateLimiter())
 	}
 
 	endpointslicemetrics.RegisterMetrics()

--- a/pkg/controller/endpointslice/endpointslice_tracker.go
+++ b/pkg/controller/endpointslice/endpointslice_tracker.go
@@ -19,8 +19,8 @@ package endpointslice
 import (
 	"sync"
 
-	"k8s.io/api/core/v1"
-	discovery "k8s.io/api/discovery/v1beta1"
+	v1 "k8s.io/api/core/v1"
+	discovery "k8s.io/api/discovery/v1"
 	"k8s.io/apimachinery/pkg/types"
 )
 

--- a/pkg/controller/endpointslice/endpointslice_tracker_test.go
+++ b/pkg/controller/endpointslice/endpointslice_tracker_test.go
@@ -19,8 +19,8 @@ package endpointslice
 import (
 	"testing"
 
-	"k8s.io/api/core/v1"
-	discovery "k8s.io/api/discovery/v1beta1"
+	v1 "k8s.io/api/core/v1"
+	discovery "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 )

--- a/pkg/controller/endpointslice/metrics/cache_test.go
+++ b/pkg/controller/endpointslice/metrics/cache_test.go
@@ -19,7 +19,7 @@ package metrics
 import (
 	"testing"
 
-	discovery "k8s.io/api/discovery/v1beta1"
+	discovery "k8s.io/api/discovery/v1"
 	"k8s.io/apimachinery/pkg/types"
 	endpointutil "k8s.io/kubernetes/pkg/controller/util/endpoint"
 )

--- a/pkg/controller/endpointslice/reconciler_test.go
+++ b/pkg/controller/endpointslice/reconciler_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	corev1 "k8s.io/api/core/v1"
-	discovery "k8s.io/api/discovery/v1beta1"
+	discovery "k8s.io/api/discovery/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -126,12 +126,8 @@ func TestReconcile1Pod(t *testing.T) {
 					{
 						Addresses:  []string{"1.2.3.4"},
 						Conditions: discovery.EndpointConditions{Ready: utilpointer.BoolPtr(true)},
-						Topology: map[string]string{
-							"kubernetes.io/hostname":        "node-1",
-							"topology.kubernetes.io/zone":   "us-central1-a",
-							"topology.kubernetes.io/region": "us-central1",
-						},
-						NodeName: utilpointer.StringPtr("node-1"),
+						Zone:       utilpointer.StringPtr("us-central1-a"),
+						NodeName:   utilpointer.StringPtr("node-1"),
 						TargetRef: &corev1.ObjectReference{
 							Kind:      "Pod",
 							Namespace: namespace,
@@ -152,12 +148,8 @@ func TestReconcile1Pod(t *testing.T) {
 					{
 						Addresses:  []string{"1.2.3.4"},
 						Conditions: discovery.EndpointConditions{Ready: utilpointer.BoolPtr(true)},
-						Topology: map[string]string{
-							"kubernetes.io/hostname":        "node-1",
-							"topology.kubernetes.io/zone":   "us-central1-a",
-							"topology.kubernetes.io/region": "us-central1",
-						},
-						NodeName: utilpointer.StringPtr("node-1"),
+						Zone:       utilpointer.StringPtr("us-central1-a"),
+						NodeName:   utilpointer.StringPtr("node-1"),
 						TargetRef: &corev1.ObjectReference{
 							Kind:      "Pod",
 							Namespace: namespace,
@@ -183,11 +175,7 @@ func TestReconcile1Pod(t *testing.T) {
 							Serving:     utilpointer.BoolPtr(true),
 							Terminating: utilpointer.BoolPtr(false),
 						},
-						Topology: map[string]string{
-							"kubernetes.io/hostname":        "node-1",
-							"topology.kubernetes.io/zone":   "us-central1-a",
-							"topology.kubernetes.io/region": "us-central1",
-						},
+						Zone:     utilpointer.StringPtr("us-central1-a"),
 						NodeName: utilpointer.StringPtr("node-1"),
 						TargetRef: &corev1.ObjectReference{
 							Kind:      "Pod",
@@ -211,12 +199,8 @@ func TestReconcile1Pod(t *testing.T) {
 					{
 						Addresses:  []string{"1.2.3.4"},
 						Conditions: discovery.EndpointConditions{Ready: utilpointer.BoolPtr(true)},
-						Topology: map[string]string{
-							"kubernetes.io/hostname":        "node-1",
-							"topology.kubernetes.io/zone":   "us-central1-a",
-							"topology.kubernetes.io/region": "us-central1",
-						},
-						NodeName: utilpointer.StringPtr("node-1"),
+						Zone:       utilpointer.StringPtr("us-central1-a"),
+						NodeName:   utilpointer.StringPtr("node-1"),
 						TargetRef: &corev1.ObjectReference{
 							Kind:      "Pod",
 							Namespace: namespace,
@@ -229,12 +213,8 @@ func TestReconcile1Pod(t *testing.T) {
 			expectedEndpoint: discovery.Endpoint{
 				Addresses:  []string{"1.2.3.4"},
 				Conditions: discovery.EndpointConditions{Ready: utilpointer.BoolPtr(true)},
-				Topology: map[string]string{
-					"kubernetes.io/hostname":        "node-1",
-					"topology.kubernetes.io/zone":   "us-central1-a",
-					"topology.kubernetes.io/region": "us-central1",
-				},
-				NodeName: utilpointer.StringPtr("node-1"),
+				Zone:       utilpointer.StringPtr("us-central1-a"),
+				NodeName:   utilpointer.StringPtr("node-1"),
 				TargetRef: &corev1.ObjectReference{
 					Kind:      "Pod",
 					Namespace: namespace,
@@ -253,12 +233,8 @@ func TestReconcile1Pod(t *testing.T) {
 					{
 						Addresses:  []string{"1.2.3.4"},
 						Conditions: discovery.EndpointConditions{Ready: utilpointer.BoolPtr(true)},
-						Topology: map[string]string{
-							"kubernetes.io/hostname":        "node-1",
-							"topology.kubernetes.io/zone":   "us-central1-a",
-							"topology.kubernetes.io/region": "us-central1",
-						},
-						NodeName: utilpointer.StringPtr("node-1"),
+						Zone:       utilpointer.StringPtr("us-central1-a"),
+						NodeName:   utilpointer.StringPtr("node-1"),
 						TargetRef: &corev1.ObjectReference{
 							Kind:      "Pod",
 							Namespace: namespace,
@@ -271,12 +247,8 @@ func TestReconcile1Pod(t *testing.T) {
 			expectedEndpoint: discovery.Endpoint{
 				Addresses:  []string{"1.2.3.4"},
 				Conditions: discovery.EndpointConditions{Ready: utilpointer.BoolPtr(true)},
-				Topology: map[string]string{
-					"kubernetes.io/hostname":        "node-1",
-					"topology.kubernetes.io/zone":   "us-central1-a",
-					"topology.kubernetes.io/region": "us-central1",
-				},
-				NodeName: utilpointer.StringPtr("node-1"),
+				Zone:       utilpointer.StringPtr("us-central1-a"),
+				NodeName:   utilpointer.StringPtr("node-1"),
 				TargetRef: &corev1.ObjectReference{
 					Kind:      "Pod",
 					Namespace: namespace,
@@ -297,12 +269,8 @@ func TestReconcile1Pod(t *testing.T) {
 					{
 						Addresses:  []string{"1.2.3.4"},
 						Conditions: discovery.EndpointConditions{Ready: utilpointer.BoolPtr(true)},
-						Topology: map[string]string{
-							"kubernetes.io/hostname":        "node-1",
-							"topology.kubernetes.io/zone":   "us-central1-a",
-							"topology.kubernetes.io/region": "us-central1",
-						},
-						NodeName: utilpointer.StringPtr("node-1"),
+						Zone:       utilpointer.StringPtr("us-central1-a"),
+						NodeName:   utilpointer.StringPtr("node-1"),
 						TargetRef: &corev1.ObjectReference{
 							Kind:      "Pod",
 							Namespace: namespace,
@@ -315,12 +283,8 @@ func TestReconcile1Pod(t *testing.T) {
 			expectedEndpoint: discovery.Endpoint{
 				Addresses:  []string{"1.2.3.4"},
 				Conditions: discovery.EndpointConditions{Ready: utilpointer.BoolPtr(true)},
-				Topology: map[string]string{
-					"kubernetes.io/hostname":        "node-1",
-					"topology.kubernetes.io/zone":   "us-central1-a",
-					"topology.kubernetes.io/region": "us-central1",
-				},
-				NodeName: utilpointer.StringPtr("node-1"),
+				Zone:       utilpointer.StringPtr("us-central1-a"),
+				NodeName:   utilpointer.StringPtr("node-1"),
 				TargetRef: &corev1.ObjectReference{
 					Kind:      "Pod",
 					Namespace: namespace,
@@ -341,12 +305,8 @@ func TestReconcile1Pod(t *testing.T) {
 					{
 						Addresses:  []string{"1234::5678:0000:0000:9abc:def0"},
 						Conditions: discovery.EndpointConditions{Ready: utilpointer.BoolPtr(true)},
-						Topology: map[string]string{
-							"kubernetes.io/hostname":        "node-1",
-							"topology.kubernetes.io/zone":   "us-central1-a",
-							"topology.kubernetes.io/region": "us-central1",
-						},
-						NodeName: utilpointer.StringPtr("node-1"),
+						Zone:       utilpointer.StringPtr("us-central1-a"),
+						NodeName:   utilpointer.StringPtr("node-1"),
 						TargetRef: &corev1.ObjectReference{
 							Kind:      "Pod",
 							Namespace: namespace,
@@ -369,12 +329,8 @@ func TestReconcile1Pod(t *testing.T) {
 					{
 						Addresses:  []string{"1234::5678:0000:0000:9abc:def0"},
 						Conditions: discovery.EndpointConditions{Ready: utilpointer.BoolPtr(true)},
-						Topology: map[string]string{
-							"kubernetes.io/hostname":        "node-1",
-							"topology.kubernetes.io/zone":   "us-central1-a",
-							"topology.kubernetes.io/region": "us-central1",
-						},
-						NodeName: utilpointer.StringPtr("node-1"),
+						Zone:       utilpointer.StringPtr("us-central1-a"),
+						NodeName:   utilpointer.StringPtr("node-1"),
 						TargetRef: &corev1.ObjectReference{
 							Kind:      "Pod",
 							Namespace: namespace,
@@ -396,12 +352,8 @@ func TestReconcile1Pod(t *testing.T) {
 					{
 						Addresses:  []string{"1234::5678:0000:0000:9abc:def0"},
 						Conditions: discovery.EndpointConditions{Ready: utilpointer.BoolPtr(true)},
-						Topology: map[string]string{
-							"kubernetes.io/hostname":        "node-1",
-							"topology.kubernetes.io/zone":   "us-central1-a",
-							"topology.kubernetes.io/region": "us-central1",
-						},
-						NodeName: utilpointer.StringPtr("node-1"),
+						Zone:       utilpointer.StringPtr("us-central1-a"),
+						NodeName:   utilpointer.StringPtr("node-1"),
 						TargetRef: &corev1.ObjectReference{
 							Kind:      "Pod",
 							Namespace: namespace,
@@ -413,12 +365,8 @@ func TestReconcile1Pod(t *testing.T) {
 					{
 						Addresses:  []string{"1.2.3.4"},
 						Conditions: discovery.EndpointConditions{Ready: utilpointer.BoolPtr(true)},
-						Topology: map[string]string{
-							"kubernetes.io/hostname":        "node-1",
-							"topology.kubernetes.io/zone":   "us-central1-a",
-							"topology.kubernetes.io/region": "us-central1",
-						},
-						NodeName: utilpointer.StringPtr("node-1"),
+						Zone:       utilpointer.StringPtr("us-central1-a"),
+						NodeName:   utilpointer.StringPtr("node-1"),
 						TargetRef: &corev1.ObjectReference{
 							Kind:      "Pod",
 							Namespace: namespace,
@@ -512,7 +460,7 @@ func TestReconcile1EndpointSlice(t *testing.T) {
 	svc, endpointMeta := newServiceAndEndpointMeta("foo", namespace)
 	endpointSlice1 := newEmptyEndpointSlice(1, namespace, endpointMeta, svc)
 
-	_, createErr := client.DiscoveryV1beta1().EndpointSlices(namespace).Create(context.TODO(), endpointSlice1, metav1.CreateOptions{})
+	_, createErr := client.DiscoveryV1().EndpointSlices(namespace).Create(context.TODO(), endpointSlice1, metav1.CreateOptions{})
 	assert.Nil(t, createErr, "Expected no error creating endpoint slice")
 
 	numActionsBefore := len(client.Actions())
@@ -1281,7 +1229,7 @@ func TestReconcilerFinalizeSvcDeletionTimestamp(t *testing.T) {
 			}
 
 			// Add EndpointSlice that can be updated.
-			esToUpdate, err := client.DiscoveryV1beta1().EndpointSlices(namespace).Create(context.TODO(), &discovery.EndpointSlice{
+			esToUpdate, err := client.DiscoveryV1().EndpointSlices(namespace).Create(context.TODO(), &discovery.EndpointSlice{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:            "to-update",
 					OwnerReferences: []metav1.OwnerReference{*ownerRef},
@@ -1297,7 +1245,7 @@ func TestReconcilerFinalizeSvcDeletionTimestamp(t *testing.T) {
 			esToUpdate.Endpoints = []discovery.Endpoint{{Addresses: []string{"10.2.3.4"}}}
 
 			// Add EndpointSlice that can be deleted.
-			esToDelete, err := client.DiscoveryV1beta1().EndpointSlices(namespace).Create(context.TODO(), &discovery.EndpointSlice{
+			esToDelete, err := client.DiscoveryV1().EndpointSlices(namespace).Create(context.TODO(), &discovery.EndpointSlice{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:            "to-delete",
 					OwnerReferences: []metav1.OwnerReference{*ownerRef},
@@ -1470,7 +1418,7 @@ func portsAndAddressTypeEqual(slice1, slice2 discovery.EndpointSlice) bool {
 func createEndpointSlices(t *testing.T, client *fake.Clientset, namespace string, endpointSlices []*discovery.EndpointSlice) {
 	t.Helper()
 	for _, endpointSlice := range endpointSlices {
-		_, err := client.DiscoveryV1beta1().EndpointSlices(namespace).Create(context.TODO(), endpointSlice, metav1.CreateOptions{})
+		_, err := client.DiscoveryV1().EndpointSlices(namespace).Create(context.TODO(), endpointSlice, metav1.CreateOptions{})
 		if err != nil {
 			t.Fatalf("Expected no error creating Endpoint Slice, got: %v", err)
 		}
@@ -1479,7 +1427,7 @@ func createEndpointSlices(t *testing.T, client *fake.Clientset, namespace string
 
 func fetchEndpointSlices(t *testing.T, client *fake.Clientset, namespace string) []discovery.EndpointSlice {
 	t.Helper()
-	fetchedSlices, err := client.DiscoveryV1beta1().EndpointSlices(namespace).List(context.TODO(), metav1.ListOptions{})
+	fetchedSlices, err := client.DiscoveryV1().EndpointSlices(namespace).List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
 		t.Fatalf("Expected no error fetching Endpoint Slices, got: %v", err)
 		return []discovery.EndpointSlice{}

--- a/pkg/controller/endpointslice/utils_test.go
+++ b/pkg/controller/endpointslice/utils_test.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
-	discovery "k8s.io/api/discovery/v1beta1"
+	discovery "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -260,7 +260,6 @@ func TestPodToEndpoint(t *testing.T) {
 			expectedEndpoint: discovery.Endpoint{
 				Addresses:  []string{"1.2.3.5"},
 				Conditions: discovery.EndpointConditions{Ready: utilpointer.BoolPtr(true)},
-				Topology:   map[string]string{"kubernetes.io/hostname": "node-1"},
 				NodeName:   utilpointer.StringPtr("node-1"),
 				TargetRef: &v1.ObjectReference{
 					Kind:            "Pod",
@@ -278,7 +277,6 @@ func TestPodToEndpoint(t *testing.T) {
 			expectedEndpoint: discovery.Endpoint{
 				Addresses:  []string{"1.2.3.5"},
 				Conditions: discovery.EndpointConditions{Ready: utilpointer.BoolPtr(true)},
-				Topology:   map[string]string{"kubernetes.io/hostname": "node-1"},
 				NodeName:   utilpointer.StringPtr("node-1"),
 				TargetRef: &v1.ObjectReference{
 					Kind:            "Pod",
@@ -296,7 +294,6 @@ func TestPodToEndpoint(t *testing.T) {
 			expectedEndpoint: discovery.Endpoint{
 				Addresses:  []string{"1.2.3.5"},
 				Conditions: discovery.EndpointConditions{Ready: utilpointer.BoolPtr(false)},
-				Topology:   map[string]string{"kubernetes.io/hostname": "node-1"},
 				NodeName:   utilpointer.StringPtr("node-1"),
 				TargetRef: &v1.ObjectReference{
 					Kind:            "Pod",
@@ -314,7 +311,6 @@ func TestPodToEndpoint(t *testing.T) {
 			expectedEndpoint: discovery.Endpoint{
 				Addresses:  []string{"1.2.3.5"},
 				Conditions: discovery.EndpointConditions{Ready: utilpointer.BoolPtr(true)},
-				Topology:   map[string]string{"kubernetes.io/hostname": "node-1"},
 				NodeName:   utilpointer.StringPtr("node-1"),
 				TargetRef: &v1.ObjectReference{
 					Kind:            "Pod",
@@ -333,12 +329,8 @@ func TestPodToEndpoint(t *testing.T) {
 			expectedEndpoint: discovery.Endpoint{
 				Addresses:  []string{"1.2.3.5"},
 				Conditions: discovery.EndpointConditions{Ready: utilpointer.BoolPtr(true)},
-				Topology: map[string]string{
-					"kubernetes.io/hostname":        "node-1",
-					"topology.kubernetes.io/zone":   "us-central1-a",
-					"topology.kubernetes.io/region": "us-central1",
-				},
-				NodeName: utilpointer.StringPtr("node-1"),
+				Zone:       utilpointer.StringPtr("us-central1-a"),
+				NodeName:   utilpointer.StringPtr("node-1"),
 				TargetRef: &v1.ObjectReference{
 					Kind:            "Pod",
 					Namespace:       ns,
@@ -356,12 +348,8 @@ func TestPodToEndpoint(t *testing.T) {
 			expectedEndpoint: discovery.Endpoint{
 				Addresses:  []string{"1.2.3.4"},
 				Conditions: discovery.EndpointConditions{Ready: utilpointer.BoolPtr(true)},
-				Topology: map[string]string{
-					"kubernetes.io/hostname":        "node-1",
-					"topology.kubernetes.io/zone":   "us-central1-a",
-					"topology.kubernetes.io/region": "us-central1",
-				},
-				NodeName: utilpointer.StringPtr("node-1"),
+				Zone:       utilpointer.StringPtr("us-central1-a"),
+				NodeName:   utilpointer.StringPtr("node-1"),
 				TargetRef: &v1.ObjectReference{
 					Kind:            "Pod",
 					Namespace:       ns,
@@ -380,12 +368,8 @@ func TestPodToEndpoint(t *testing.T) {
 				Addresses:  []string{"1.2.3.5"},
 				Conditions: discovery.EndpointConditions{Ready: utilpointer.BoolPtr(true)},
 				Hostname:   &readyPodHostname.Spec.Hostname,
-				Topology: map[string]string{
-					"kubernetes.io/hostname":        "node-1",
-					"topology.kubernetes.io/zone":   "us-central1-a",
-					"topology.kubernetes.io/region": "us-central1",
-				},
-				NodeName: utilpointer.StringPtr("node-1"),
+				Zone:       utilpointer.StringPtr("us-central1-a"),
+				NodeName:   utilpointer.StringPtr("node-1"),
 				TargetRef: &v1.ObjectReference{
 					Kind:            "Pod",
 					Namespace:       ns,
@@ -406,7 +390,6 @@ func TestPodToEndpoint(t *testing.T) {
 					Serving:     utilpointer.BoolPtr(true),
 					Terminating: utilpointer.BoolPtr(false),
 				},
-				Topology: map[string]string{"kubernetes.io/hostname": "node-1"},
 				NodeName: utilpointer.StringPtr("node-1"),
 				TargetRef: &v1.ObjectReference{
 					Kind:            "Pod",
@@ -427,7 +410,6 @@ func TestPodToEndpoint(t *testing.T) {
 				Conditions: discovery.EndpointConditions{
 					Ready: utilpointer.BoolPtr(false),
 				},
-				Topology: map[string]string{"kubernetes.io/hostname": "node-1"},
 				NodeName: utilpointer.StringPtr("node-1"),
 				TargetRef: &v1.ObjectReference{
 					Kind:            "Pod",
@@ -450,7 +432,6 @@ func TestPodToEndpoint(t *testing.T) {
 					Serving:     utilpointer.BoolPtr(true),
 					Terminating: utilpointer.BoolPtr(true),
 				},
-				Topology: map[string]string{"kubernetes.io/hostname": "node-1"},
 				NodeName: utilpointer.StringPtr("node-1"),
 				TargetRef: &v1.ObjectReference{
 					Kind:            "Pod",
@@ -471,7 +452,6 @@ func TestPodToEndpoint(t *testing.T) {
 				Conditions: discovery.EndpointConditions{
 					Ready: utilpointer.BoolPtr(false),
 				},
-				Topology: map[string]string{"kubernetes.io/hostname": "node-1"},
 				NodeName: utilpointer.StringPtr("node-1"),
 				TargetRef: &v1.ObjectReference{
 					Kind:            "Pod",
@@ -494,7 +474,6 @@ func TestPodToEndpoint(t *testing.T) {
 					Serving:     utilpointer.BoolPtr(false),
 					Terminating: utilpointer.BoolPtr(true),
 				},
-				Topology: map[string]string{"kubernetes.io/hostname": "node-1"},
 				NodeName: utilpointer.StringPtr("node-1"),
 				TargetRef: &v1.ObjectReference{
 					Kind:            "Pod",

--- a/pkg/controller/endpointslicemirroring/endpointset.go
+++ b/pkg/controller/endpointslicemirroring/endpointset.go
@@ -19,7 +19,7 @@ package endpointslicemirroring
 import (
 	"sort"
 
-	discovery "k8s.io/api/discovery/v1beta1"
+	discovery "k8s.io/api/discovery/v1"
 	endpointutil "k8s.io/kubernetes/pkg/controller/util/endpoint"
 )
 

--- a/pkg/controller/endpointslicemirroring/endpointslice_tracker.go
+++ b/pkg/controller/endpointslicemirroring/endpointslice_tracker.go
@@ -19,8 +19,8 @@ package endpointslicemirroring
 import (
 	"sync"
 
-	"k8s.io/api/core/v1"
-	discovery "k8s.io/api/discovery/v1beta1"
+	v1 "k8s.io/api/core/v1"
+	discovery "k8s.io/api/discovery/v1"
 	"k8s.io/apimachinery/pkg/types"
 )
 

--- a/pkg/controller/endpointslicemirroring/endpointslice_tracker_test.go
+++ b/pkg/controller/endpointslicemirroring/endpointslice_tracker_test.go
@@ -19,8 +19,8 @@ package endpointslicemirroring
 import (
 	"testing"
 
-	"k8s.io/api/core/v1"
-	discovery "k8s.io/api/discovery/v1beta1"
+	v1 "k8s.io/api/core/v1"
+	discovery "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 )

--- a/pkg/controller/endpointslicemirroring/endpointslicemirroring_controller.go
+++ b/pkg/controller/endpointslicemirroring/endpointslicemirroring_controller.go
@@ -23,18 +23,18 @@ import (
 	"golang.org/x/time/rate"
 
 	v1 "k8s.io/api/core/v1"
-	discovery "k8s.io/api/discovery/v1beta1"
+	discovery "k8s.io/api/discovery/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	coreinformers "k8s.io/client-go/informers/core/v1"
-	discoveryinformers "k8s.io/client-go/informers/discovery/v1beta1"
+	discoveryinformers "k8s.io/client-go/informers/discovery/v1"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	v1core "k8s.io/client-go/kubernetes/typed/core/v1"
 	corelisters "k8s.io/client-go/listers/core/v1"
-	discoverylisters "k8s.io/client-go/listers/discovery/v1beta1"
+	discoverylisters "k8s.io/client-go/listers/discovery/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
@@ -79,7 +79,7 @@ func NewController(endpointsInformer coreinformers.EndpointsInformer,
 	recorder := broadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: "endpoint-slice-mirroring-controller"})
 
 	if client != nil && client.CoreV1().RESTClient().GetRateLimiter() != nil {
-		ratelimiter.RegisterMetricAndTrackRateLimiterUsage("endpoint_slice_mirroring_controller", client.DiscoveryV1beta1().RESTClient().GetRateLimiter())
+		ratelimiter.RegisterMetricAndTrackRateLimiterUsage("endpoint_slice_mirroring_controller", client.DiscoveryV1().RESTClient().GetRateLimiter())
 	}
 
 	metrics.RegisterMetrics()

--- a/pkg/controller/endpointslicemirroring/endpointslicemirroring_controller_test.go
+++ b/pkg/controller/endpointslicemirroring/endpointslicemirroring_controller_test.go
@@ -23,7 +23,7 @@ import (
 	"time"
 
 	v1 "k8s.io/api/core/v1"
-	discovery "k8s.io/api/discovery/v1beta1"
+	discovery "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/informers"
@@ -52,7 +52,7 @@ func newController(batchPeriod time.Duration) (*fake.Clientset, *endpointSliceMi
 
 	esController := NewController(
 		informerFactory.Core().V1().Endpoints(),
-		informerFactory.Discovery().V1beta1().EndpointSlices(),
+		informerFactory.Discovery().V1().EndpointSlices(),
 		informerFactory.Core().V1().Services(),
 		int32(1000),
 		client,
@@ -65,7 +65,7 @@ func newController(batchPeriod time.Duration) (*fake.Clientset, *endpointSliceMi
 	return client, &endpointSliceMirroringController{
 		esController,
 		informerFactory.Core().V1().Endpoints().Informer().GetStore(),
-		informerFactory.Discovery().V1beta1().EndpointSlices().Informer().GetStore(),
+		informerFactory.Discovery().V1().EndpointSlices().Informer().GetStore(),
 		informerFactory.Core().V1().Services().Informer().GetStore(),
 	}
 }
@@ -229,7 +229,7 @@ func TestSyncEndpoints(t *testing.T) {
 			for _, epSlice := range tc.endpointSlices {
 				epSlice.Namespace = namespace
 				esController.endpointSliceStore.Add(epSlice)
-				_, err := client.DiscoveryV1beta1().EndpointSlices(namespace).Create(context.TODO(), epSlice, metav1.CreateOptions{})
+				_, err := client.DiscoveryV1().EndpointSlices(namespace).Create(context.TODO(), epSlice, metav1.CreateOptions{})
 				if err != nil {
 					t.Fatalf("Expected no error creating EndpointSlice, got %v", err)
 				}

--- a/pkg/controller/endpointslicemirroring/metrics/cache_test.go
+++ b/pkg/controller/endpointslicemirroring/metrics/cache_test.go
@@ -19,7 +19,7 @@ package metrics
 import (
 	"testing"
 
-	discovery "k8s.io/api/discovery/v1beta1"
+	discovery "k8s.io/api/discovery/v1"
 	"k8s.io/apimachinery/pkg/types"
 	endpointutil "k8s.io/kubernetes/pkg/controller/util/endpoint"
 )

--- a/pkg/controller/endpointslicemirroring/reconciler.go
+++ b/pkg/controller/endpointslicemirroring/reconciler.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
-	discovery "k8s.io/api/discovery/v1beta1"
+	discovery "k8s.io/api/discovery/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -230,7 +230,7 @@ func (r *reconciler) finalize(endpoints *corev1.Endpoints, slices slicesByAction
 	// be deleted.
 	recycleSlices(&slices)
 
-	epsClient := r.client.DiscoveryV1beta1().EndpointSlices(endpoints.Namespace)
+	epsClient := r.client.DiscoveryV1().EndpointSlices(endpoints.Namespace)
 
 	// Don't create more EndpointSlices if corresponding Endpoints resource is
 	// being deleted.
@@ -276,7 +276,7 @@ func (r *reconciler) deleteEndpoints(namespace, name string, endpointSlices []*d
 	r.metricsCache.DeleteEndpoints(types.NamespacedName{Namespace: namespace, Name: name})
 	var errs []error
 	for _, endpointSlice := range endpointSlices {
-		err := r.client.DiscoveryV1beta1().EndpointSlices(namespace).Delete(context.TODO(), endpointSlice.Name, metav1.DeleteOptions{})
+		err := r.client.DiscoveryV1().EndpointSlices(namespace).Delete(context.TODO(), endpointSlice.Name, metav1.DeleteOptions{})
 		if err != nil {
 			errs = append(errs, err)
 		}
@@ -314,7 +314,7 @@ func totalChanges(existingSlice *discovery.EndpointSlice, desiredSet endpointSet
 
 			// If existing version of endpoint doesn't match desired version
 			// increment number of endpoints to be updated.
-			if !endpointsEqualBeyondHash(got, &endpoint) {
+			if !endpointutil.EndpointsEqualBeyondHash(got, &endpoint) {
 				totals.updated++
 			}
 		}

--- a/pkg/controller/endpointslicemirroring/reconciler_helpers.go
+++ b/pkg/controller/endpointslicemirroring/reconciler_helpers.go
@@ -17,8 +17,8 @@ limitations under the License.
 package endpointslicemirroring
 
 import (
-	"k8s.io/api/core/v1"
-	discovery "k8s.io/api/discovery/v1beta1"
+	v1 "k8s.io/api/core/v1"
+	discovery "k8s.io/api/discovery/v1"
 )
 
 // slicesByAction includes lists of slices to create, update, or delete.

--- a/pkg/controller/endpointslicemirroring/reconciler_helpers_test.go
+++ b/pkg/controller/endpointslicemirroring/reconciler_helpers_test.go
@@ -20,7 +20,7 @@ import (
 	"sort"
 	"testing"
 
-	discovery "k8s.io/api/discovery/v1beta1"
+	discovery "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 

--- a/pkg/controller/endpointslicemirroring/utils.go
+++ b/pkg/controller/endpointslicemirroring/utils.go
@@ -22,8 +22,7 @@ import (
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
-	discovery "k8s.io/api/discovery/v1beta1"
-	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	discovery "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -60,25 +59,6 @@ func getAddressType(address string) *discovery.AddressType {
 		addressType = discovery.AddressTypeIPv6
 	}
 	return &addressType
-}
-
-// endpointsEqualBeyondHash returns true if endpoints have equal attributes
-// but excludes equality checks that would have already been covered with
-// endpoint hashing (see hashEndpoint func for more info).
-func endpointsEqualBeyondHash(ep1, ep2 *discovery.Endpoint) bool {
-	if !apiequality.Semantic.DeepEqual(ep1.Topology, ep2.Topology) {
-		return false
-	}
-
-	if !boolPtrEqual(ep1.Conditions.Ready, ep2.Conditions.Ready) {
-		return false
-	}
-
-	if !objectRefPtrEqual(ep1.TargetRef, ep2.TargetRef) {
-		return false
-	}
-
-	return true
 }
 
 // newEndpointSlice returns an EndpointSlice generated from an Endpoints
@@ -135,9 +115,6 @@ func addressToEndpoint(address corev1.EndpointAddress, ready bool) *discovery.En
 	}
 
 	if address.NodeName != nil {
-		endpoint.Topology = map[string]string{
-			"kubernetes.io/hostname": *address.NodeName,
-		}
 		endpoint.NodeName = address.NodeName
 	}
 	if address.Hostname != "" {
@@ -161,29 +138,6 @@ func epPortsToEpsPorts(epPorts []corev1.EndpointPort) []discovery.EndpointPort {
 		})
 	}
 	return epsPorts
-}
-
-// boolPtrEqual returns true if a set of bool pointers have equivalent values.
-func boolPtrEqual(ptr1, ptr2 *bool) bool {
-	if (ptr1 == nil) != (ptr2 == nil) {
-		return false
-	}
-	if ptr1 != nil && ptr2 != nil && *ptr1 != *ptr2 {
-		return false
-	}
-	return true
-}
-
-// objectRefPtrEqual returns true if a set of object ref pointers have
-// equivalent values.
-func objectRefPtrEqual(ref1, ref2 *corev1.ObjectReference) bool {
-	if (ref1 == nil) != (ref2 == nil) {
-		return false
-	}
-	if ref1 != nil && ref2 != nil && !apiequality.Semantic.DeepEqual(*ref1, *ref2) {
-		return false
-	}
-	return true
 }
 
 // getServiceFromDeleteAction parses a Service resource from a delete

--- a/pkg/controller/endpointslicemirroring/utils_test.go
+++ b/pkg/controller/endpointslicemirroring/utils_test.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
-	discovery "k8s.io/api/discovery/v1beta1"
+	discovery "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -96,9 +96,6 @@ func TestAddressToEndpoint(t *testing.T) {
 		Hostname:  utilpointer.StringPtr("foo"),
 		Conditions: discovery.EndpointConditions{
 			Ready: utilpointer.BoolPtr(true),
-		},
-		Topology: map[string]string{
-			"kubernetes.io/hostname": "node-abc",
 		},
 		TargetRef: &v1.ObjectReference{
 			APIVersion: "v1",

--- a/pkg/controlplane/instance.go
+++ b/pkg/controlplane/instance.go
@@ -91,7 +91,6 @@ import (
 	"k8s.io/kubernetes/pkg/controlplane/controller/clusterauthenticationtrust"
 	"k8s.io/kubernetes/pkg/controlplane/reconcilers"
 	"k8s.io/kubernetes/pkg/controlplane/tunneler"
-	"k8s.io/kubernetes/pkg/features"
 	kubeoptions "k8s.io/kubernetes/pkg/kubeapiserver/options"
 	kubeletclient "k8s.io/kubernetes/pkg/kubelet/client"
 	"k8s.io/kubernetes/pkg/routes"
@@ -250,10 +249,7 @@ type Instance struct {
 
 func (c *Config) createMasterCountReconciler() reconcilers.EndpointReconciler {
 	endpointClient := corev1client.NewForConfigOrDie(c.GenericConfig.LoopbackClientConfig)
-	var endpointSliceClient discoveryclient.EndpointSlicesGetter
-	if utilfeature.DefaultFeatureGate.Enabled(features.EndpointSlice) {
-		endpointSliceClient = discoveryclient.NewForConfigOrDie(c.GenericConfig.LoopbackClientConfig)
-	}
+	endpointSliceClient := discoveryclient.NewForConfigOrDie(c.GenericConfig.LoopbackClientConfig)
 	endpointsAdapter := reconcilers.NewEndpointsAdapter(endpointClient, endpointSliceClient)
 
 	return reconcilers.NewMasterCountEndpointReconciler(c.ExtraConfig.MasterCount, endpointsAdapter)
@@ -265,10 +261,7 @@ func (c *Config) createNoneReconciler() reconcilers.EndpointReconciler {
 
 func (c *Config) createLeaseReconciler() reconcilers.EndpointReconciler {
 	endpointClient := corev1client.NewForConfigOrDie(c.GenericConfig.LoopbackClientConfig)
-	var endpointSliceClient discoveryclient.EndpointSlicesGetter
-	if utilfeature.DefaultFeatureGate.Enabled(features.EndpointSlice) {
-		endpointSliceClient = discoveryclient.NewForConfigOrDie(c.GenericConfig.LoopbackClientConfig)
-	}
+	endpointSliceClient := discoveryclient.NewForConfigOrDie(c.GenericConfig.LoopbackClientConfig)
 	endpointsAdapter := reconcilers.NewEndpointsAdapter(endpointClient, endpointSliceClient)
 
 	ttl := c.ExtraConfig.MasterEndpointReconcileTTL

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -466,6 +466,8 @@ const (
 
 	// owner: @robscott @freehan
 	// alpha: v1.16
+	// beta: v1.18
+	// ga: v1.21
 	//
 	// Enable Endpoint Slices for more scalable Service endpoints.
 	EndpointSlice featuregate.Feature = "EndpointSlice"

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -777,7 +777,7 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 	NonPreemptingPriority:                          {Default: true, PreRelease: featuregate.Beta},
 	PodOverhead:                                    {Default: true, PreRelease: featuregate.Beta},
 	IPv6DualStack:                                  {Default: true, PreRelease: featuregate.Beta},
-	EndpointSlice:                                  {Default: true, PreRelease: featuregate.Beta},
+	EndpointSlice:                                  {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.25
 	EndpointSliceProxying:                          {Default: true, PreRelease: featuregate.Beta},
 	EndpointSliceTerminatingCondition:              {Default: false, PreRelease: featuregate.Alpha},
 	EndpointSliceNodeName:                          {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, //remove in 1.25

--- a/pkg/proxy/apis/config/validation/validation.go
+++ b/pkg/proxy/apis/config/validation/validation.go
@@ -76,14 +76,6 @@ func Validate(config *kubeproxyconfig.KubeProxyConfiguration) field.ErrorList {
 	allErrs = append(allErrs, validateHostPort(config.MetricsBindAddress, newPath.Child("MetricsBindAddress"))...)
 
 	dualStackEnabled := effectiveFeatures.Enabled(kubefeatures.IPv6DualStack)
-	endpointSliceEnabled := effectiveFeatures.Enabled(kubefeatures.EndpointSlice)
-
-	// dual stack has strong dependency on endpoint slice since
-	// endpoint slice controller is the only capabable of producing
-	// slices for *all* clusterIPs
-	if dualStackEnabled && !endpointSliceEnabled {
-		allErrs = append(allErrs, field.Invalid(newPath.Child("FeatureGates"), config.FeatureGates, "EndpointSlice feature flag must be turned on when turning on DualStack"))
-	}
 
 	if config.ClusterCIDR != "" {
 		cidrs := strings.Split(config.ClusterCIDR, ",")

--- a/pkg/proxy/apis/config/validation/validation_test.go
+++ b/pkg/proxy/apis/config/validation/validation_test.go
@@ -122,7 +122,7 @@ func TestValidateKubeProxyConfiguration(t *testing.T) {
 			BindAddress:        "10.10.12.11",
 			HealthzBindAddress: "0.0.0.0:12345",
 			MetricsBindAddress: "127.0.0.1:10249",
-			FeatureGates:       map[string]bool{"IPv6DualStack": true, "EndpointSlice": true},
+			FeatureGates:       map[string]bool{"IPv6DualStack": true},
 			ClusterCIDR:        "192.168.59.0/24",
 			UDPIdleTimeout:     metav1.Duration{Duration: 1 * time.Second},
 			ConfigSyncPeriod:   metav1.Duration{Duration: 1 * time.Second},
@@ -285,7 +285,7 @@ func TestValidateKubeProxyConfiguration(t *testing.T) {
 				HealthzBindAddress: "0.0.0.0:12345",
 				MetricsBindAddress: "127.0.0.1:10249",
 				// DualStack ClusterCIDR without feature flag enabled
-				FeatureGates:     map[string]bool{"IPv6DualStack": false, "EndpointSlice": false},
+				FeatureGates:     map[string]bool{"IPv6DualStack": false},
 				ClusterCIDR:      "192.168.59.0/24,fd00:192:168::/64",
 				UDPIdleTimeout:   metav1.Duration{Duration: 1 * time.Second},
 				ConfigSyncPeriod: metav1.Duration{Duration: 1 * time.Second},
@@ -303,36 +303,12 @@ func TestValidateKubeProxyConfiguration(t *testing.T) {
 			},
 			expectedErrs: field.ErrorList{field.Invalid(newPath.Child("ClusterCIDR"), "192.168.59.0/24,fd00:192:168::/64", "only one CIDR allowed (e.g. 10.100.0.0/16 or fde4:8dba:82e1::/48)")},
 		},
-		"DualStack feature-enabled but EndpointSlice feature disabled": {
-			config: kubeproxyconfig.KubeProxyConfiguration{
-				BindAddress:        "10.10.12.11",
-				HealthzBindAddress: "0.0.0.0:12345",
-				MetricsBindAddress: "127.0.0.1:10249",
-				// DualStack ClusterCIDR with feature flag enabled but EndpointSlice is not enabled
-				FeatureGates:     map[string]bool{"IPv6DualStack": true, "EndpointSlice": false},
-				ClusterCIDR:      "192.168.59.0/24,fd00:192:168::/64",
-				UDPIdleTimeout:   metav1.Duration{Duration: 1 * time.Second},
-				ConfigSyncPeriod: metav1.Duration{Duration: 1 * time.Second},
-				IPTables: kubeproxyconfig.KubeProxyIPTablesConfiguration{
-					MasqueradeAll: true,
-					SyncPeriod:    metav1.Duration{Duration: 5 * time.Second},
-					MinSyncPeriod: metav1.Duration{Duration: 2 * time.Second},
-				},
-				Conntrack: kubeproxyconfig.KubeProxyConntrackConfiguration{
-					MaxPerCore:            pointer.Int32Ptr(1),
-					Min:                   pointer.Int32Ptr(1),
-					TCPEstablishedTimeout: &metav1.Duration{Duration: 5 * time.Second},
-					TCPCloseWaitTimeout:   &metav1.Duration{Duration: 5 * time.Second},
-				},
-			},
-			expectedErrs: field.ErrorList{field.Invalid(newPath.Child("FeatureGates"), map[string]bool{"EndpointSlice": false, "IPv6DualStack": true}, "EndpointSlice feature flag must be turned on when turning on DualStack")},
-		},
 		"Invalid number of ClusterCIDRs": {
 			config: kubeproxyconfig.KubeProxyConfiguration{
 				BindAddress:        "10.10.12.11",
 				HealthzBindAddress: "0.0.0.0:12345",
 				MetricsBindAddress: "127.0.0.1:10249",
-				FeatureGates:       map[string]bool{"IPv6DualStack": true, "EndpointSlice": true},
+				FeatureGates:       map[string]bool{"IPv6DualStack": true},
 				ClusterCIDR:        "192.168.59.0/24,fd00:192:168::/64,10.0.0.0/16",
 				UDPIdleTimeout:     metav1.Duration{Duration: 1 * time.Second},
 				ConfigSyncPeriod:   metav1.Duration{Duration: 1 * time.Second},

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/controller_policy.go
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/controller_policy.go
@@ -149,35 +149,33 @@ func buildControllerRoles() ([]rbacv1.ClusterRole, []rbacv1.ClusterRoleBinding) 
 		},
 	})
 
-	if utilfeature.DefaultFeatureGate.Enabled(features.EndpointSlice) {
-		addControllerRole(&controllerRoles, &controllerRoleBindings, rbacv1.ClusterRole{
-			ObjectMeta: metav1.ObjectMeta{Name: saRolePrefix + "endpointslice-controller"},
-			Rules: []rbacv1.PolicyRule{
-				rbacv1helpers.NewRule("get", "list", "watch").Groups(legacyGroup).Resources("services", "pods", "nodes").RuleOrDie(),
-				// The controller needs to be able to set a service's finalizers to be able to create an EndpointSlice
-				// resource that is owned by the service and sets blockOwnerDeletion=true in its ownerRef.
-				rbacv1helpers.NewRule("update").Groups(legacyGroup).Resources("services/finalizers").RuleOrDie(),
-				rbacv1helpers.NewRule("get", "list", "create", "update", "delete").Groups(discoveryGroup).Resources("endpointslices").RuleOrDie(),
-				eventsRule(),
-			},
-		})
+	addControllerRole(&controllerRoles, &controllerRoleBindings, rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{Name: saRolePrefix + "endpointslice-controller"},
+		Rules: []rbacv1.PolicyRule{
+			rbacv1helpers.NewRule("get", "list", "watch").Groups(legacyGroup).Resources("services", "pods", "nodes").RuleOrDie(),
+			// The controller needs to be able to set a service's finalizers to be able to create an EndpointSlice
+			// resource that is owned by the service and sets blockOwnerDeletion=true in its ownerRef.
+			rbacv1helpers.NewRule("update").Groups(legacyGroup).Resources("services/finalizers").RuleOrDie(),
+			rbacv1helpers.NewRule("get", "list", "create", "update", "delete").Groups(discoveryGroup).Resources("endpointslices").RuleOrDie(),
+			eventsRule(),
+		},
+	})
 
-		addControllerRole(&controllerRoles, &controllerRoleBindings, rbacv1.ClusterRole{
-			ObjectMeta: metav1.ObjectMeta{Name: saRolePrefix + "endpointslicemirroring-controller"},
-			Rules: []rbacv1.PolicyRule{
-				rbacv1helpers.NewRule("get", "list", "watch").Groups(legacyGroup).Resources("services", "endpoints").RuleOrDie(),
-				// The controller needs to be able to set a service's finalizers to be able to create an EndpointSlice
-				// resource that is owned by the service and sets blockOwnerDeletion=true in its ownerRef.
-				rbacv1helpers.NewRule("update").Groups(legacyGroup).Resources("services/finalizers").RuleOrDie(),
-				// The controller needs to be able to set a service's finalizers to be able to create an EndpointSlice
-				// resource that is owned by the endpoint and sets blockOwnerDeletion=true in its ownerRef.
-				// see https://github.com/openshift/kubernetes/blob/8691466059314c3f7d6dcffcbb76d14596ca716c/pkg/controller/endpointslicemirroring/utils.go#L87-L88
-				rbacv1helpers.NewRule("update").Groups(legacyGroup).Resources("endpoints/finalizers").RuleOrDie(),
-				rbacv1helpers.NewRule("get", "list", "create", "update", "delete").Groups(discoveryGroup).Resources("endpointslices").RuleOrDie(),
-				eventsRule(),
-			},
-		})
-	}
+	addControllerRole(&controllerRoles, &controllerRoleBindings, rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{Name: saRolePrefix + "endpointslicemirroring-controller"},
+		Rules: []rbacv1.PolicyRule{
+			rbacv1helpers.NewRule("get", "list", "watch").Groups(legacyGroup).Resources("services", "endpoints").RuleOrDie(),
+			// The controller needs to be able to set a service's finalizers to be able to create an EndpointSlice
+			// resource that is owned by the service and sets blockOwnerDeletion=true in its ownerRef.
+			rbacv1helpers.NewRule("update").Groups(legacyGroup).Resources("services/finalizers").RuleOrDie(),
+			// The controller needs to be able to set a service's finalizers to be able to create an EndpointSlice
+			// resource that is owned by the endpoint and sets blockOwnerDeletion=true in its ownerRef.
+			// see https://github.com/openshift/kubernetes/blob/8691466059314c3f7d6dcffcbb76d14596ca716c/pkg/controller/endpointslicemirroring/utils.go#L87-L88
+			rbacv1helpers.NewRule("update").Groups(legacyGroup).Resources("endpoints/finalizers").RuleOrDie(),
+			rbacv1helpers.NewRule("get", "list", "create", "update", "delete").Groups(discoveryGroup).Resources("endpointslices").RuleOrDie(),
+			eventsRule(),
+		},
+	})
 
 	if utilfeature.DefaultFeatureGate.Enabled(features.ExpandPersistentVolumes) {
 		addControllerRole(&controllerRoles, &controllerRoleBindings, rbacv1.ClusterRole{

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
@@ -512,9 +512,7 @@ func ClusterRoles() []rbacv1.ClusterRole {
 
 		eventsRule(),
 	}
-	if utilfeature.DefaultFeatureGate.Enabled(features.EndpointSlice) {
-		nodeProxierRules = append(nodeProxierRules, rbacv1helpers.NewRule("list", "watch").Groups(discoveryGroup).Resources("endpointslices").RuleOrDie())
-	}
+	nodeProxierRules = append(nodeProxierRules, rbacv1helpers.NewRule("list", "watch").Groups(discoveryGroup).Resources("endpointslices").RuleOrDie())
 	roles = append(roles, rbacv1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{Name: "system:node-proxier"},
 		Rules:      nodeProxierRules,

--- a/test/integration/dualstack/dualstack_endpoints_test.go
+++ b/test/integration/dualstack/dualstack_endpoints_test.go
@@ -115,7 +115,7 @@ func TestDualStackEndpoints(t *testing.T) {
 		informers.Core().V1().Pods(),
 		informers.Core().V1().Services(),
 		informers.Core().V1().Nodes(),
-		informers.Discovery().V1beta1().EndpointSlices(),
+		informers.Discovery().V1().EndpointSlices(),
 		int32(100),
 		client,
 		1*time.Second)

--- a/test/integration/endpointslice/endpointslicemirroring_test.go
+++ b/test/integration/endpointslice/endpointslicemirroring_test.go
@@ -23,7 +23,7 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
-	discovery "k8s.io/api/discovery/v1beta1"
+	discovery "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/informers"
@@ -60,14 +60,14 @@ func TestEndpointSliceMirroring(t *testing.T) {
 		informers.Core().V1().Pods(),
 		informers.Core().V1().Services(),
 		informers.Core().V1().Nodes(),
-		informers.Discovery().V1beta1().EndpointSlices(),
+		informers.Discovery().V1().EndpointSlices(),
 		int32(100),
 		client,
 		1*time.Second)
 
 	epsmController := endpointslicemirroring.NewController(
 		informers.Core().V1().Endpoints(),
-		informers.Discovery().V1beta1().EndpointSlices(),
+		informers.Discovery().V1().EndpointSlices(),
 		informers.Core().V1().Services(),
 		int32(100),
 		client,


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
Graduates EPS controllers to use V1 Endpoint Slice Resources and API

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
EndpointSlice Controllers are now GA. The EndpointSlice Controller will not populate the `deprecatedTopology` field and will only provide topology information through the `zone` and `nodeName` fields.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

Please use the following format for linking documentation:
KEP: [EndpointSlice KEP](https://github.com/kubernetes/enhancements/blob/8413469b89851d094eb22813a06594bd4a6d36a4/keps/sig-network/0752-endpointslices/README.md)
Enhancement Issue: kubernetes/enhancements#752

/cc @aojea @andrewsykim @liggitt @robscott @wojtek-t
/assign @thockin
/sig network
/priority important-soon