### PR TITLE
Adjusts FSGroupPolicy retrieval to allow for nil results

### DIFF
--- a/pkg/volume/csi/csi_plugin.go
+++ b/pkg/volume/csi/csi_plugin.go
@@ -912,12 +912,10 @@ func (p *csiPlugin) getFSGroupPolicy(driver string) (storage.FSGroupPolicy, erro
 	}
 
 	// If the csiDriver isn't defined, return the default behavior
-	if csiDriver == nil {
+	// This also allows drivers that were created before the feature existed
+	// to use the default policy instead of throwing an error.
+	if csiDriver == nil || csiDriver.Spec.FSGroupPolicy == nil || *csiDriver.Spec.FSGroupPolicy == "" {
 		return storage.ReadWriteOnceWithFSTypeFSGroupPolicy, nil
-	}
-	// If the csiDriver exists but the fsGroupPolicy isn't defined, return an error
-	if csiDriver.Spec.FSGroupPolicy == nil || *csiDriver.Spec.FSGroupPolicy == "" {
-		return storage.ReadWriteOnceWithFSTypeFSGroupPolicy, errors.New(log("expected valid fsGroupPolicy, received nil value or empty string"))
 	}
 	return *csiDriver.Spec.FSGroupPolicy, nil
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
While we set the default value for the `CSIDriver.Spec.FSGroupPolicy` when new objects are created, it's possible that a CSIDriver created before the feature flag was enabled will not have this value set.

This adjusts the behaviour to return the default FSGroupPolicy instead of throwing an error in such scenarios.

#### Which issue(s) this PR fixes:
Fixes #99790 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```