### PR TITLE
Add Etcd compatibility test

### DIFF
--- a/test/integration/etcd/data.go
+++ b/test/integration/etcd/data.go
@@ -767,3 +767,7 @@ func gvr(g, v, r string) schema.GroupVersionResource {
 func gvkP(g, v, k string) *schema.GroupVersionKind {
 	return &schema.GroupVersionKind{Group: g, Version: v, Kind: k}
 }
+
+func gvk(g, v, k string) schema.GroupVersionKind {
+	return schema.GroupVersionKind{Group: g, Version: v, Kind: k}
+}

--- a/test/integration/etcd/server.go
+++ b/test/integration/etcd/server.go
@@ -122,6 +122,9 @@ func StartRealMasterOrDie(t *testing.T, configFuncs ...func(*options.ServerRunOp
 	kubeClientConfig.QPS = 99999
 	kubeClientConfig.Burst = 9999
 
+	// we make requests to all resources, don't log warnings about deprecated ones
+	restclient.SetDefaultWarningHandler(restclient.NoWarnings{})
+
 	kubeClient := clientset.NewForConfigOrDie(kubeClientConfig)
 
 	go func() {


### PR DESCRIPTION
/kind cleanup

#### What this PR does / why we need it:

Builds on https://github.com/kubernetes/kubernetes/pull/99871, only the last commit is new

Fixes https://github.com/kubernetes/kubernetes/issues/99863

#### Special notes for your reviewer:

For every version we iterate over and check storage versions for, inspect the API compatibility data from previous releases.

If a previous release knew about a non-alpha version of the group-kind, then expect the current storage version to be understood by a previous release.

Would have caught https://github.com/kubernetes/kubernetes/pull/99662#discussion_r588075892 with this error:

>`    --- FAIL: TestEtcdStoragePath/discovery.k8s.io/v1,_Resource=endpointslices (0.10s)`
>`        etcd_storage_path_test.go:161: Previous releases understand non-alpha versions ["v1beta1"], but do not understand the expected current storage version "v1". This means a current server will store data in etcd that is not understood by a previous version.`
>`    --- FAIL: TestEtcdStoragePath/discovery.k8s.io/v1beta1,_Resource=endpointslices (0.03s)`
>`        etcd_storage_path_test.go:161: Previous releases understand non-alpha versions ["v1beta1"], but do not understand the expected current storage version "v1". This means a current server will store data in etcd that is not understood by a previous version.`


```release-note
NONE
```

