### PR TITLE
Update controlplane to use EndpointSlice V1 API

### DIFF
--- a/pkg/controlplane/controller_test.go
+++ b/pkg/controlplane/controller_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
-	discoveryv1beta1 "k8s.io/api/discovery/v1beta1"
+	discoveryv1 "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes/fake"
@@ -36,7 +36,7 @@ func TestReconcileEndpoints(t *testing.T) {
 		o := metav1.ObjectMeta{Namespace: ns, Name: name}
 		if skipMirrorLabel {
 			o.Labels = map[string]string{
-				discoveryv1beta1.LabelSkipMirror: "true",
+				discoveryv1.LabelSkipMirror: "true",
 			}
 		}
 		return o

--- a/pkg/controlplane/instance.go
+++ b/pkg/controlplane/instance.go
@@ -81,7 +81,7 @@ import (
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
-	discoveryclient "k8s.io/client-go/kubernetes/typed/discovery/v1beta1"
+	discoveryclient "k8s.io/client-go/kubernetes/typed/discovery/v1"
 	"k8s.io/component-base/version"
 	"k8s.io/component-helpers/apimachinery/lease"
 	"k8s.io/klog/v2"

--- a/pkg/controlplane/reconcilers/endpointsadapter.go
+++ b/pkg/controlplane/reconcilers/endpointsadapter.go
@@ -20,12 +20,12 @@ import (
 	"context"
 
 	corev1 "k8s.io/api/core/v1"
-	discovery "k8s.io/api/discovery/v1beta1"
+	discovery "k8s.io/api/discovery/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
-	discoveryclient "k8s.io/client-go/kubernetes/typed/discovery/v1beta1"
+	discoveryclient "k8s.io/client-go/kubernetes/typed/discovery/v1"
 	utilnet "k8s.io/utils/net"
 )
 
@@ -174,9 +174,6 @@ func endpointFromAddress(address corev1.EndpointAddress, ready bool) discovery.E
 	}
 
 	if address.NodeName != nil {
-		ep.Topology = map[string]string{
-			"kubernetes.io/hostname": *address.NodeName,
-		}
 		ep.NodeName = address.NodeName
 	}
 

--- a/pkg/controlplane/reconcilers/endpointsadapter_test.go
+++ b/pkg/controlplane/reconcilers/endpointsadapter_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
-	discovery "k8s.io/api/discovery/v1beta1"
+	discovery "k8s.io/api/discovery/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -80,7 +80,7 @@ func TestEndpointsAdapterGet(t *testing.T) {
 			client := fake.NewSimpleClientset()
 			epAdapter := EndpointsAdapter{endpointClient: client.CoreV1()}
 			if testCase.endpointSlicesEnabled {
-				epAdapter.endpointSliceClient = client.DiscoveryV1beta1()
+				epAdapter.endpointSliceClient = client.DiscoveryV1()
 			}
 
 			for _, endpoints := range testCase.endpoints {
@@ -178,7 +178,7 @@ func TestEndpointsAdapterCreate(t *testing.T) {
 			client := fake.NewSimpleClientset()
 			epAdapter := EndpointsAdapter{endpointClient: client.CoreV1()}
 			if testCase.endpointSlicesEnabled {
-				epAdapter.endpointSliceClient = client.DiscoveryV1beta1()
+				epAdapter.endpointSliceClient = client.DiscoveryV1()
 			}
 
 			for _, endpoints := range testCase.endpoints {
@@ -198,7 +198,7 @@ func TestEndpointsAdapterCreate(t *testing.T) {
 				t.Errorf("Expected endpoints: %v, got: %v", testCase.expectedEndpoints, endpoints)
 			}
 
-			epSliceList, err := client.DiscoveryV1beta1().EndpointSlices(testCase.namespaceParam).List(context.TODO(), metav1.ListOptions{})
+			epSliceList, err := client.DiscoveryV1().EndpointSlices(testCase.namespaceParam).List(context.TODO(), metav1.ListOptions{})
 			if err != nil {
 				t.Fatalf("Error listing Endpoint Slices: %v", err)
 			}
@@ -290,7 +290,7 @@ func TestEndpointsAdapterUpdate(t *testing.T) {
 			client := fake.NewSimpleClientset()
 			epAdapter := EndpointsAdapter{endpointClient: client.CoreV1()}
 			if testCase.endpointSlicesEnabled {
-				epAdapter.endpointSliceClient = client.DiscoveryV1beta1()
+				epAdapter.endpointSliceClient = client.DiscoveryV1()
 			}
 
 			for _, endpoints := range testCase.endpoints {
@@ -310,7 +310,7 @@ func TestEndpointsAdapterUpdate(t *testing.T) {
 				t.Errorf("Expected endpoints: %v, got: %v", testCase.expectedEndpoints, endpoints)
 			}
 
-			epSliceList, err := client.DiscoveryV1beta1().EndpointSlices(testCase.namespaceParam).List(context.TODO(), metav1.ListOptions{})
+			epSliceList, err := client.DiscoveryV1().EndpointSlices(testCase.namespaceParam).List(context.TODO(), metav1.ListOptions{})
 			if err != nil {
 				t.Fatalf("Error listing Endpoint Slices: %v", err)
 			}
@@ -432,11 +432,11 @@ func TestEndpointsAdapterEnsureEndpointSliceFromEndpoints(t *testing.T) {
 			client := fake.NewSimpleClientset()
 			epAdapter := EndpointsAdapter{endpointClient: client.CoreV1()}
 			if testCase.endpointSlicesEnabled {
-				epAdapter.endpointSliceClient = client.DiscoveryV1beta1()
+				epAdapter.endpointSliceClient = client.DiscoveryV1()
 			}
 
 			for _, endpointSlice := range testCase.endpointSlices {
-				_, err := client.DiscoveryV1beta1().EndpointSlices(endpointSlice.Namespace).Create(context.TODO(), endpointSlice, metav1.CreateOptions{})
+				_, err := client.DiscoveryV1().EndpointSlices(endpointSlice.Namespace).Create(context.TODO(), endpointSlice, metav1.CreateOptions{})
 				if err != nil {
 					t.Fatalf("Error creating EndpointSlice: %v", err)
 				}
@@ -447,7 +447,7 @@ func TestEndpointsAdapterEnsureEndpointSliceFromEndpoints(t *testing.T) {
 				t.Errorf("Expected error: %v, got: %v", testCase.expectedError, err)
 			}
 
-			endpointSlice, err := client.DiscoveryV1beta1().EndpointSlices(testCase.namespaceParam).Get(context.TODO(), testCase.endpointsParam.Name, metav1.GetOptions{})
+			endpointSlice, err := client.DiscoveryV1().EndpointSlices(testCase.namespaceParam).Get(context.TODO(), testCase.endpointsParam.Name, metav1.GetOptions{})
 			if err != nil && !errors.IsNotFound(err) {
 				t.Fatalf("Error getting Endpoint Slice: %v", err)
 			}

--- a/pkg/controlplane/reconcilers/lease_test.go
+++ b/pkg/controlplane/reconcilers/lease_test.go
@@ -28,7 +28,7 @@ import (
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
-	discoveryv1beta1 "k8s.io/api/discovery/v1beta1"
+	discoveryv1 "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 )
@@ -83,7 +83,7 @@ func TestLeaseEndpointReconciler(t *testing.T) {
 		o := metav1.ObjectMeta{Namespace: ns, Name: name}
 		if skipMirrorLabel {
 			o.Labels = map[string]string{
-				discoveryv1beta1.LabelSkipMirror: "true",
+				discoveryv1.LabelSkipMirror: "true",
 			}
 		}
 		return o
@@ -586,7 +586,7 @@ func TestLeaseRemoveEndpoints(t *testing.T) {
 		o := metav1.ObjectMeta{Namespace: ns, Name: name}
 		if skipMirrorLabel {
 			o.Labels = map[string]string{
-				discoveryv1beta1.LabelSkipMirror: "true",
+				discoveryv1.LabelSkipMirror: "true",
 			}
 		}
 		return o


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
This PR updates the controlplane to use the new V1 EndpointSlice API

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
KEP: [EndpointSlice KEP](https://github.com/kubernetes/enhancements/blob/8413469b89851d094eb22813a06594bd4a6d36a4/keps/sig-network/0752-endpointslices/README.md)
Enhancement Issue: kubernetes/enhancements#752

This PR is dependent on #99662 (EndpointSlice GA API) & #99870 (EPS Controllers GA & EndpointSlice Feature Gate GA)

/cc @aojea @andrewsykim @liggitt @robscott @wojtek-t
/assign @thockin
/sig network
/priority important-soon