### PR TITLE
Refactor on windows e2e storage related tests

### DIFF
--- a/test/e2e/framework/deployment/fixtures.go
+++ b/test/e2e/framework/deployment/fixtures.go
@@ -28,8 +28,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/uuid"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/framework"
+	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 	testutils "k8s.io/kubernetes/test/utils"
-	imageutils "k8s.io/kubernetes/test/utils/image"
 )
 
 // UpdateDeploymentWithRetries updates the specified deployment with retries.
@@ -199,13 +199,10 @@ func testDeployment(replicas int32, podLabels map[string]string, nodeSelector ma
 					TerminationGracePeriodSeconds: &zero,
 					Containers: []v1.Container{
 						{
-							Name:    "write-pod",
-							Image:   imageutils.GetE2EImage(imageutils.BusyBox),
-							Command: []string{"/bin/sh"},
-							Args:    []string{"-c", command},
-							SecurityContext: &v1.SecurityContext{
-								Privileged: &isPrivileged,
-							},
+							Name:            "write-pod",
+							Image:           e2epod.GetDefaultTestImage(),
+							Command:         e2epod.GenerateScriptCmd(command),
+							SecurityContext: e2epod.GenerateContainerSecurityContext(isPrivileged),
 						},
 					},
 					RestartPolicy: v1.RestartPolicyAlways,

--- a/test/e2e/framework/pod/create.go
+++ b/test/e2e/framework/pod/create.go
@@ -145,13 +145,10 @@ func MakePod(ns string, nodeSelector map[string]string, pvclaims []*v1.Persisten
 		Spec: v1.PodSpec{
 			Containers: []v1.Container{
 				{
-					Name:    "write-pod",
-					Image:   BusyBoxImage,
-					Command: []string{"/bin/sh"},
-					Args:    []string{"-c", command},
-					SecurityContext: &v1.SecurityContext{
-						Privileged: &isPrivileged,
-					},
+					Name:            "write-pod",
+					Image:           GetDefaultTestImage(),
+					Command:         GenerateScriptCmd(command),
+					SecurityContext: GenerateContainerSecurityContext(isPrivileged),
 				},
 			},
 			RestartPolicy: v1.RestartPolicyOnFailure,
@@ -187,10 +184,6 @@ func MakeSecPod(podConfig *Config) (*v1.Pod, error) {
 			return &i
 		}(1000)
 	}
-	image := imageutils.BusyBox
-	if podConfig.ImageID != imageutils.None {
-		image = podConfig.ImageID
-	}
 	podSpec := &v1.Pod{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Pod",
@@ -200,28 +193,34 @@ func MakeSecPod(podConfig *Config) (*v1.Pod, error) {
 			Name:      podName,
 			Namespace: podConfig.NS,
 		},
-		Spec: v1.PodSpec{
-			HostIPC: podConfig.HostIPC,
-			HostPID: podConfig.HostPID,
-			SecurityContext: &v1.PodSecurityContext{
-				FSGroup: podConfig.FsGroup,
-			},
-			Containers: []v1.Container{
-				{
-					Name:    "write-pod",
-					Image:   imageutils.GetE2EImage(image),
-					Command: []string{"/bin/sh"},
-					Args:    []string{"-c", podConfig.Command},
-					SecurityContext: &v1.SecurityContext{
-						Privileged: &podConfig.IsPrivileged,
-					},
-				},
-			},
-			RestartPolicy: v1.RestartPolicyOnFailure,
-		},
+		Spec: *MakePodSpec(podConfig),
 	}
+	return podSpec, nil
+}
+
+// MakePodSpec returns a PodSpec definition
+func MakePodSpec(podConfig *Config) *v1.PodSpec {
+	image := imageutils.BusyBox
+	if podConfig.ImageID != imageutils.None {
+		image = podConfig.ImageID
+	}
+	podSpec := &v1.PodSpec{
+		HostIPC:         podConfig.HostIPC,
+		HostPID:         podConfig.HostPID,
+		SecurityContext: GeneratePodSecurityContext(podConfig.FsGroup, podConfig.SeLinuxLabel),
+		Containers: []v1.Container{
+			{
+				Name:            "write-pod",
+				Image:           GetTestImage(image),
+				Command:         GenerateScriptCmd(podConfig.Command),
+				SecurityContext: GenerateContainerSecurityContext(podConfig.IsPrivileged),
+			},
+		},
+		RestartPolicy: v1.RestartPolicyOnFailure,
+	}
+
 	if podConfig.PodFSGroupChangePolicy != nil {
-		podSpec.Spec.SecurityContext.FSGroupChangePolicy = podConfig.PodFSGroupChangePolicy
+		podSpec.SecurityContext.FSGroupChangePolicy = podConfig.PodFSGroupChangePolicy
 	}
 
 	var volumeMounts = make([]v1.VolumeMount, 0)
@@ -247,13 +246,13 @@ func MakeSecPod(podConfig *Config) (*v1.Pod, error) {
 		volumeIndex++
 	}
 
-	podSpec.Spec.Containers[0].VolumeMounts = volumeMounts
-	podSpec.Spec.Containers[0].VolumeDevices = volumeDevices
-	podSpec.Spec.Volumes = volumes
+	podSpec.Containers[0].VolumeMounts = volumeMounts
+	podSpec.Containers[0].VolumeDevices = volumeDevices
+	podSpec.Volumes = volumes
 	if runtime.GOOS != "windows" {
-		podSpec.Spec.SecurityContext.SELinuxOptions = podConfig.SeLinuxLabel
+		podSpec.SecurityContext.SELinuxOptions = podConfig.SeLinuxLabel
 	}
 
-	SetNodeSelection(&podSpec.Spec, podConfig.NodeSelection)
-	return podSpec, nil
+	SetNodeSelection(podSpec, podConfig.NodeSelection)
+	return podSpec
 }

--- a/test/e2e/framework/pod/utils.go
+++ b/test/e2e/framework/pod/utils.go
@@ -1,0 +1,120 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pod
+
+import (
+	"flag"
+
+	v1 "k8s.io/api/core/v1"
+	imageutils "k8s.io/kubernetes/test/utils/image"
+)
+
+// NodeOSDistroIs returns true if the distro is the same as `--node-os-distro`
+// the package framework/pod can't import the framework package (see #81245)
+// we need to check if the --node-os-distro=windows is set and the framework package
+// is the one that's parsing the flags, as a workaround this method is looking for the same flag again
+// TODO: replace with `framework.NodeOSDistroIs` when #81245 is complete
+func NodeOSDistroIs(distro string) bool {
+	var nodeOsDistro *flag.Flag = flag.Lookup("node-os-distro")
+	if nodeOsDistro != nil && nodeOsDistro.Value.String() == distro {
+		return true
+	}
+	return false
+}
+
+// GenerateScriptCmd generates the corresponding command lines to execute a command.
+// Depending on the Node OS is Windows or linux, the command will use powershell or /bin/sh
+func GenerateScriptCmd(command string) []string {
+	var commands []string
+	if !NodeOSDistroIs("windows") {
+		commands = []string{"/bin/sh", "-c", command}
+	} else {
+		commands = []string{"powershell", "/c", command}
+	}
+	return commands
+}
+
+// GetDefaultTestImage returns the default test image based on OS.
+// If the node OS is windows, currently we return Agnhost image for Windows node
+// due to the issue of #https://github.com/kubernetes-sigs/windows-testing/pull/35.
+// If the node OS is linux, return busybox image
+func GetDefaultTestImage() string {
+	return imageutils.GetE2EImage(GetDefaultTestImageID())
+}
+
+// GetDefaultTestImageID returns the default test image id based on OS.
+// If the node OS is windows, currently we return Agnhost image for Windows node
+// due to the issue of #https://github.com/kubernetes-sigs/windows-testing/pull/35.
+// If the node OS is linux, return busybox image
+func GetDefaultTestImageID() int {
+	return GetTestImageID(imageutils.BusyBox)
+}
+
+// GetTestImage returns the image name with the given input
+// If the Node OS is windows, currently we return Agnhost image for Windows node
+// due to the issue of #https://github.com/kubernetes-sigs/windows-testing/pull/35.
+func GetTestImage(id int) string {
+	if NodeOSDistroIs("windows") {
+		return imageutils.GetE2EImage(imageutils.Agnhost)
+	}
+	return imageutils.GetE2EImage(id)
+}
+
+// GetTestImageID returns the image id with the given input
+// If the Node OS is windows, currently we return Agnhost image for Windows node
+// due to the issue of #https://github.com/kubernetes-sigs/windows-testing/pull/35.
+func GetTestImageID(id int) int {
+	if NodeOSDistroIs("windows") {
+		return imageutils.Agnhost
+	}
+	return id
+}
+
+// GeneratePodSecurityContext generates the corresponding pod security context with the given inputs
+// If the Node OS is windows, currently we will ignore the inputs and return nil.
+// TODO: Will modify it after windows has its own security context
+func GeneratePodSecurityContext(fsGroup *int64, seLinuxOptions *v1.SELinuxOptions) *v1.PodSecurityContext {
+	if NodeOSDistroIs("windows") {
+		return nil
+	}
+	return &v1.PodSecurityContext{
+		FSGroup:        fsGroup,
+		SELinuxOptions: seLinuxOptions,
+	}
+}
+
+// GenerateContainerSecurityContext generates the corresponding container security context with the given inputs
+// If the Node OS is windows, currently we will ignore the inputs and return nil.
+// TODO: Will modify it after windows has its own security context
+func GenerateContainerSecurityContext(privileged bool) *v1.SecurityContext {
+	if NodeOSDistroIs("windows") {
+		return nil
+	}
+	return &v1.SecurityContext{
+		Privileged: &privileged,
+	}
+}
+
+// GetLinuxLabel returns the default SELinuxLabel based on OS.
+// If the node OS is windows, it will return nil
+func GetLinuxLabel() *v1.SELinuxOptions {
+	if NodeOSDistroIs("windows") {
+		return nil
+	}
+	return &v1.SELinuxOptions{
+		Level: "s0:c0,c1"}
+}

--- a/test/e2e/framework/pv/pv.go
+++ b/test/e2e/framework/pv/pv.go
@@ -735,7 +735,7 @@ func WaitForPersistentVolumeClaimsPhase(phase v1.PersistentVolumeClaimPhase, c c
 	if len(pvcNames) == 0 {
 		return fmt.Errorf("Incorrect parameter: Need at least one PVC to track. Found 0")
 	}
-	framework.Logf("Waiting up to %v for PersistentVolumeClaims %v to have phase %s", timeout, pvcNames, phase)
+	framework.Logf("Waiting up to timeout=%v for PersistentVolumeClaims %v to have phase %s", timeout, pvcNames, phase)
 	for start := time.Now(); time.Since(start) < timeout; time.Sleep(poll) {
 		phaseFoundInAllClaims := true
 		for _, pvcName := range pvcNames {
@@ -864,4 +864,12 @@ func WaitForPVCFinalizer(ctx context.Context, cs clientset.Interface, name, name
 		err = fmt.Errorf("finalizer %s not added to pvc %s/%s", finalizer, namespace, name)
 	}
 	return err
+}
+
+// GetDefaultFSType returns the default fsType
+func GetDefaultFSType() string {
+	if framework.NodeOSDistroIs("windows") {
+		return "ntfs"
+	}
+	return "ext4"
 }

--- a/test/e2e/storage/csi_mock_volume.go
+++ b/test/e2e/storage/csi_mock_volume.go
@@ -1876,7 +1876,7 @@ func startBusyBoxPodWithVolumeSource(cs clientset.Interface, volumeSource v1.Vol
 							MountPath: "/mnt/test",
 						},
 					},
-					Command: e2evolume.GenerateScriptCmd("while true ; do sleep 2; done"),
+					Command: e2epod.GenerateScriptCmd("while true ; do sleep 2; done"),
 				},
 			},
 			SecurityContext: &v1.PodSecurityContext{

--- a/test/e2e/storage/persistent_volumes-gce.go
+++ b/test/e2e/storage/persistent_volumes-gce.go
@@ -86,13 +86,14 @@ var _ = utils.SIGDescribe("PersistentVolumes GCEPD", func() {
 		ginkgo.By("Initializing Test Spec")
 		diskName, err = e2epv.CreatePDWithRetry()
 		framework.ExpectNoError(err)
+
 		pvConfig = e2epv.PersistentVolumeConfig{
 			NamePrefix: "gce-",
 			Labels:     volLabel,
 			PVSource: v1.PersistentVolumeSource{
 				GCEPersistentDisk: &v1.GCEPersistentDiskVolumeSource{
 					PDName:   diskName,
-					FSType:   "ext3",
+					FSType:   e2epv.GetDefaultFSType(),
 					ReadOnly: false,
 				},
 			},

--- a/test/e2e/storage/persistent_volumes.go
+++ b/test/e2e/storage/persistent_volumes.go
@@ -420,9 +420,8 @@ func makeStatefulSetWithPVCs(ns, cmd string, mounts []v1.VolumeMount, claims []v
 					Containers: []v1.Container{
 						{
 							Name:           "nginx",
-							Image:          imageutils.GetE2EImage(imageutils.Nginx),
-							Command:        []string{"/bin/sh"},
-							Args:           []string{"-c", cmd},
+							Image:          e2epod.GetTestImage(imageutils.Nginx),
+							Command:        e2epod.GenerateScriptCmd(cmd),
 							VolumeMounts:   mounts,
 							ReadinessProbe: readyProbe,
 						},

--- a/test/e2e/storage/testsuites/disruptive.go
+++ b/test/e2e/storage/testsuites/disruptive.go
@@ -26,7 +26,6 @@ import (
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 	e2epv "k8s.io/kubernetes/test/e2e/framework/pv"
 	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
-	e2evolume "k8s.io/kubernetes/test/e2e/framework/volume"
 	storageframework "k8s.io/kubernetes/test/e2e/storage/framework"
 	"k8s.io/kubernetes/test/e2e/storage/utils"
 	storageutils "k8s.io/kubernetes/test/e2e/storage/utils"
@@ -170,7 +169,7 @@ func (s *disruptiveTestSuite) DefineTests(driver storageframework.TestDriver, pa
 						InlineVolumeSources: inlineSources,
 						SeLinuxLabel:        e2epv.SELinuxLabel,
 						NodeSelection:       l.config.ClientNodeSelection,
-						ImageID:             e2evolume.GetDefaultTestImageID(),
+						ImageID:             e2epod.GetDefaultTestImageID(),
 					}
 					l.pod, err = e2epod.CreateSecPodWithNodeSelection(l.cs, &podConfig, f.Timeouts.PodStart)
 					framework.ExpectNoError(err, "While creating pods for kubelet restart test")

--- a/test/e2e/storage/testsuites/ephemeral.go
+++ b/test/e2e/storage/testsuites/ephemeral.go
@@ -347,8 +347,8 @@ func StartInPodWithInlineVolume(c clientset.Interface, ns, podName, command stri
 			Containers: []v1.Container{
 				{
 					Name:    "csi-volume-tester",
-					Image:   e2evolume.GetDefaultTestImage(),
-					Command: e2evolume.GenerateScriptCmd(command),
+					Image:   e2epod.GetDefaultTestImage(),
+					Command: e2epod.GenerateScriptCmd(command),
 				},
 			},
 			RestartPolicy: v1.RestartPolicyNever,

--- a/test/e2e/storage/testsuites/multivolume.go
+++ b/test/e2e/storage/testsuites/multivolume.go
@@ -408,9 +408,9 @@ func testAccessMultipleVolumes(f *framework.Framework, cs clientset.Interface, n
 	podConfig := e2epod.Config{
 		NS:            ns,
 		PVCs:          pvcs,
-		SeLinuxLabel:  e2evolume.GetLinuxLabel(),
+		SeLinuxLabel:  e2epod.GetLinuxLabel(),
 		NodeSelection: node,
-		ImageID:       e2evolume.GetDefaultTestImageID(),
+		ImageID:       e2epod.GetDefaultTestImageID(),
 	}
 	pod, err := e2epod.CreateSecPodWithNodeSelection(cs, &podConfig, f.Timeouts.PodStart)
 	defer func() {
@@ -487,10 +487,10 @@ func TestConcurrentAccessToSingleVolume(f *framework.Framework, cs clientset.Int
 		podConfig := e2epod.Config{
 			NS:            ns,
 			PVCs:          []*v1.PersistentVolumeClaim{pvc},
-			SeLinuxLabel:  e2evolume.GetLinuxLabel(),
+			SeLinuxLabel:  e2epod.GetLinuxLabel(),
 			NodeSelection: node,
 			PVCsReadOnly:  readOnly,
-			ImageID:       e2evolume.GetTestImageID(imageutils.DebianIptables),
+			ImageID:       e2epod.GetTestImageID(imageutils.DebianIptables),
 		}
 		pod, err := e2epod.CreateSecPodWithNodeSelection(cs, &podConfig, f.Timeouts.PodStart)
 		defer func() {
@@ -653,9 +653,9 @@ func initializeVolume(cs clientset.Interface, t *framework.TimeoutContext, ns st
 	podConfig := e2epod.Config{
 		NS:            ns,
 		PVCs:          []*v1.PersistentVolumeClaim{pvc},
-		SeLinuxLabel:  e2evolume.GetLinuxLabel(),
+		SeLinuxLabel:  e2epod.GetLinuxLabel(),
 		NodeSelection: node,
-		ImageID:       e2evolume.GetDefaultTestImageID(),
+		ImageID:       e2epod.GetDefaultTestImageID(),
 	}
 	pod, err := e2epod.CreateSecPod(cs, &podConfig, t.PodStart)
 	defer func() {

--- a/test/e2e/storage/testsuites/provisioning.go
+++ b/test/e2e/storage/testsuites/provisioning.go
@@ -330,8 +330,8 @@ func SetupStorageClass(
 			// skip storageclass creation if it already exists
 			ginkgo.By("Storage class " + computedStorageClass.Name + " is already created, skipping creation.")
 		} else {
-			ginkgo.By("Creating a StorageClass " + class.Name)
-			_, err = client.StorageV1().StorageClasses().Create(context.TODO(), class, metav1.CreateOptions{})
+			ginkgo.By("Creating a StorageClass")
+			class, err = client.StorageV1().StorageClasses().Create(context.TODO(), class, metav1.CreateOptions{})
 			framework.ExpectNoError(err)
 			computedStorageClass, err = client.StorageV1().StorageClasses().Get(context.TODO(), class.Name, metav1.GetOptions{})
 			framework.ExpectNoError(err)
@@ -698,8 +698,8 @@ func StartInPodWithVolume(c clientset.Interface, ns, claimName, podName, command
 			Containers: []v1.Container{
 				{
 					Name:    "volume-tester",
-					Image:   e2evolume.GetDefaultTestImage(),
-					Command: e2evolume.GenerateScriptCmd(command),
+					Image:   e2epod.GetDefaultTestImage(),
+					Command: e2epod.GenerateScriptCmd(command),
 					VolumeMounts: []v1.VolumeMount{
 						{
 							Name:      "my-volume",

--- a/test/e2e/storage/testsuites/snapshottable.go
+++ b/test/e2e/storage/testsuites/snapshottable.go
@@ -139,7 +139,7 @@ func (s *snapshottableTestSuite) DefineTests(driver storageframework.TestDriver,
 			sc = volumeResource.Sc
 			claimSize = pvc.Spec.Resources.Requests.Storage().String()
 
-			ginkgo.By("starting a pod to use the claim")
+			ginkgo.By("[init] starting a pod to use the claim")
 			originalMntTestData = fmt.Sprintf("hello from %s namespace", pvc.GetNamespace())
 			command := fmt.Sprintf("echo '%s' > %s", originalMntTestData, datapath)
 
@@ -147,13 +147,14 @@ func (s *snapshottableTestSuite) DefineTests(driver storageframework.TestDriver,
 
 			err = e2epv.WaitForPersistentVolumeClaimPhase(v1.ClaimBound, cs, pvc.Namespace, pvc.Name, framework.Poll, f.Timeouts.ClaimProvision)
 			framework.ExpectNoError(err)
-			ginkgo.By("checking the claim")
+
 			// Get new copy of the claim
+			ginkgo.By("[init] checking the claim")
 			pvc, err = cs.CoreV1().PersistentVolumeClaims(pvc.Namespace).Get(context.TODO(), pvc.Name, metav1.GetOptions{})
 			framework.ExpectNoError(err)
 
 			// Get the bound PV
-			ginkgo.By("checking the PV")
+			ginkgo.By("[init] checking the PV")
 			_, err = cs.CoreV1().PersistentVolumes().Get(context.TODO(), pvc.Spec.VolumeName, metav1.GetOptions{})
 			framework.ExpectNoError(err)
 		}

--- a/test/e2e/storage/testsuites/subpath.go
+++ b/test/e2e/storage/testsuites/subpath.go
@@ -446,8 +446,8 @@ func (s *subPathTestSuite) DefineTests(driver storageframework.TestDriver, patte
 		defer cleanup()
 
 		// Change volume container to busybox so we can exec later
-		l.pod.Spec.Containers[1].Image = e2evolume.GetDefaultTestImage()
-		l.pod.Spec.Containers[1].Command = e2evolume.GenerateScriptCmd("sleep 100000")
+		l.pod.Spec.Containers[1].Image = e2epod.GetDefaultTestImage()
+		l.pod.Spec.Containers[1].Command = e2epod.GenerateScriptCmd("sleep 100000")
 		l.pod.Spec.Containers[1].Args = nil
 
 		ginkgo.By(fmt.Sprintf("Creating pod %s", l.pod.Name))
@@ -521,19 +521,19 @@ func SubpathTestPod(f *framework.Framework, subpath, volumeType string, source *
 	initSubpathContainer := e2epod.NewAgnhostContainer(
 		fmt.Sprintf("test-init-subpath-%s", suffix),
 		[]v1.VolumeMount{volumeSubpathMount, probeMount}, nil, "mounttest")
-	initSubpathContainer.SecurityContext = e2evolume.GenerateSecurityContext(privilegedSecurityContext)
+	initSubpathContainer.SecurityContext = e2epod.GenerateContainerSecurityContext(privilegedSecurityContext)
 	initVolumeContainer := e2epod.NewAgnhostContainer(
 		fmt.Sprintf("test-init-volume-%s", suffix),
 		[]v1.VolumeMount{volumeMount, probeMount}, nil, "mounttest")
-	initVolumeContainer.SecurityContext = e2evolume.GenerateSecurityContext(privilegedSecurityContext)
+	initVolumeContainer.SecurityContext = e2epod.GenerateContainerSecurityContext(privilegedSecurityContext)
 	subpathContainer := e2epod.NewAgnhostContainer(
 		fmt.Sprintf("test-container-subpath-%s", suffix),
 		[]v1.VolumeMount{volumeSubpathMount, probeMount}, nil, "mounttest")
-	subpathContainer.SecurityContext = e2evolume.GenerateSecurityContext(privilegedSecurityContext)
+	subpathContainer.SecurityContext = e2epod.GenerateContainerSecurityContext(privilegedSecurityContext)
 	volumeContainer := e2epod.NewAgnhostContainer(
 		fmt.Sprintf("test-container-volume-%s", suffix),
 		[]v1.VolumeMount{volumeMount, probeMount}, nil, "mounttest")
-	volumeContainer.SecurityContext = e2evolume.GenerateSecurityContext(privilegedSecurityContext)
+	volumeContainer.SecurityContext = e2epod.GenerateContainerSecurityContext(privilegedSecurityContext)
 
 	return &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -544,9 +544,9 @@ func SubpathTestPod(f *framework.Framework, subpath, volumeType string, source *
 			InitContainers: []v1.Container{
 				{
 					Name:            fmt.Sprintf("init-volume-%s", suffix),
-					Image:           e2evolume.GetDefaultTestImage(),
+					Image:           e2epod.GetDefaultTestImage(),
 					VolumeMounts:    []v1.VolumeMount{volumeMount, probeMount},
-					SecurityContext: e2evolume.GenerateSecurityContext(privilegedSecurityContext),
+					SecurityContext: e2epod.GenerateContainerSecurityContext(privilegedSecurityContext),
 				},
 				initSubpathContainer,
 				initVolumeContainer,
@@ -569,7 +569,7 @@ func SubpathTestPod(f *framework.Framework, subpath, volumeType string, source *
 					},
 				},
 			},
-			SecurityContext: e2evolume.GeneratePodSecurityContext(nil, seLinuxOptions),
+			SecurityContext: e2epod.GeneratePodSecurityContext(nil, seLinuxOptions),
 		},
 	}
 }
@@ -613,8 +613,8 @@ func volumeFormatPod(f *framework.Framework, volumeSource *v1.VolumeSource) *v1.
 			Containers: []v1.Container{
 				{
 					Name:    fmt.Sprintf("init-volume-%s", f.Namespace.Name),
-					Image:   e2evolume.GetDefaultTestImage(),
-					Command: e2evolume.GenerateScriptCmd("echo nothing"),
+					Image:   e2epod.GetDefaultTestImage(),
+					Command: e2epod.GenerateScriptCmd("echo nothing"),
 					VolumeMounts: []v1.VolumeMount{
 						{
 							Name:      volumeName,
@@ -635,7 +635,7 @@ func volumeFormatPod(f *framework.Framework, volumeSource *v1.VolumeSource) *v1.
 }
 
 func setInitCommand(pod *v1.Pod, command string) {
-	pod.Spec.InitContainers[0].Command = e2evolume.GenerateScriptCmd(command)
+	pod.Spec.InitContainers[0].Command = e2epod.GenerateScriptCmd(command)
 }
 
 func setWriteCommand(file string, container *v1.Container) {
@@ -792,11 +792,11 @@ func (h *podContainerRestartHooks) FixLivenessProbe(pod *v1.Pod, probeFilePath s
 func testPodContainerRestartWithHooks(f *framework.Framework, pod *v1.Pod, hooks *podContainerRestartHooks) {
 	pod.Spec.RestartPolicy = v1.RestartPolicyOnFailure
 
-	pod.Spec.Containers[0].Image = e2evolume.GetDefaultTestImage()
-	pod.Spec.Containers[0].Command = e2evolume.GenerateScriptCmd("sleep 100000")
+	pod.Spec.Containers[0].Image = e2epod.GetDefaultTestImage()
+	pod.Spec.Containers[0].Command = e2epod.GenerateScriptCmd("sleep 100000")
 	pod.Spec.Containers[0].Args = nil
-	pod.Spec.Containers[1].Image = e2evolume.GetDefaultTestImage()
-	pod.Spec.Containers[1].Command = e2evolume.GenerateScriptCmd("sleep 100000")
+	pod.Spec.Containers[1].Image = e2epod.GetDefaultTestImage()
+	pod.Spec.Containers[1].Command = e2epod.GenerateScriptCmd("sleep 100000")
 	pod.Spec.Containers[1].Args = nil
 	hooks.AddLivenessProbe(pod, probeFilePath)
 
@@ -923,7 +923,7 @@ func TestPodContainerRestartWithConfigmapModified(f *framework.Framework, origin
 		break
 	}
 	pod := SubpathTestPod(f, subpath, "configmap", &v1.VolumeSource{ConfigMap: &v1.ConfigMapVolumeSource{LocalObjectReference: v1.LocalObjectReference{Name: original.Name}}}, false)
-	pod.Spec.InitContainers[0].Command = e2evolume.GenerateScriptCmd(fmt.Sprintf("touch %v", probeFilePath))
+	pod.Spec.InitContainers[0].Command = e2epod.GenerateScriptCmd(fmt.Sprintf("touch %v", probeFilePath))
 
 	modifiedValue := modified.Data[subpath]
 	testPodContainerRestartWithHooks(f, pod, &podContainerRestartHooks{
@@ -966,11 +966,11 @@ func testSubpathReconstruction(f *framework.Framework, hostExec utils.HostExec, 
 	}
 
 	// Change to busybox
-	pod.Spec.Containers[0].Image = e2evolume.GetDefaultTestImage()
-	pod.Spec.Containers[0].Command = e2evolume.GenerateScriptCmd("sleep 100000")
+	pod.Spec.Containers[0].Image = e2epod.GetDefaultTestImage()
+	pod.Spec.Containers[0].Command = e2epod.GenerateScriptCmd("sleep 100000")
 	pod.Spec.Containers[0].Args = nil
-	pod.Spec.Containers[1].Image = e2evolume.GetDefaultTestImage()
-	pod.Spec.Containers[1].Command = e2evolume.GenerateScriptCmd("sleep 100000")
+	pod.Spec.Containers[1].Image = e2epod.GetDefaultTestImage()
+	pod.Spec.Containers[1].Command = e2epod.GenerateScriptCmd("sleep 100000")
 	pod.Spec.Containers[1].Args = nil
 	// If grace period is too short, then there is not enough time for the volume
 	// manager to cleanup the volumes

--- a/test/e2e/storage/testsuites/topology.go
+++ b/test/e2e/storage/testsuites/topology.go
@@ -34,7 +34,6 @@ import (
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 	e2epv "k8s.io/kubernetes/test/e2e/framework/pv"
 	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
-	e2evolume "k8s.io/kubernetes/test/e2e/framework/volume"
 	storageframework "k8s.io/kubernetes/test/e2e/storage/framework"
 	storageutils "k8s.io/kubernetes/test/e2e/storage/utils"
 )
@@ -338,8 +337,8 @@ func (t *topologyTestSuite) createResources(cs clientset.Interface, l *topologyT
 		NS:            l.config.Framework.Namespace.Name,
 		PVCs:          []*v1.PersistentVolumeClaim{l.resource.Pvc},
 		NodeSelection: e2epod.NodeSelection{Affinity: affinity},
-		SeLinuxLabel:  e2evolume.GetLinuxLabel(),
-		ImageID:       e2evolume.GetDefaultTestImageID(),
+		SeLinuxLabel:  e2epod.GetLinuxLabel(),
+		ImageID:       e2epod.GetDefaultTestImageID(),
 	}
 	l.pod, err = e2epod.MakeSecPod(&podConfig)
 	framework.ExpectNoError(err)

--- a/test/e2e/storage/testsuites/volume_expand.go
+++ b/test/e2e/storage/testsuites/volume_expand.go
@@ -180,9 +180,9 @@ func (v *volumeExpandTestSuite) DefineTests(driver storageframework.TestDriver, 
 			podConfig := e2epod.Config{
 				NS:            f.Namespace.Name,
 				PVCs:          []*v1.PersistentVolumeClaim{l.resource.Pvc},
-				SeLinuxLabel:  e2evolume.GetLinuxLabel(),
+				SeLinuxLabel:  e2epod.GetLinuxLabel(),
 				NodeSelection: l.config.ClientNodeSelection,
-				ImageID:       e2evolume.GetDefaultTestImageID(),
+				ImageID:       e2epod.GetDefaultTestImageID(),
 			}
 			l.pod, err = e2epod.CreateSecPodWithNodeSelection(f.ClientSet, &podConfig, f.Timeouts.PodStart)
 			defer func() {
@@ -224,9 +224,9 @@ func (v *volumeExpandTestSuite) DefineTests(driver storageframework.TestDriver, 
 			podConfig = e2epod.Config{
 				NS:            f.Namespace.Name,
 				PVCs:          []*v1.PersistentVolumeClaim{l.resource.Pvc},
-				SeLinuxLabel:  e2evolume.GetLinuxLabel(),
+				SeLinuxLabel:  e2epod.GetLinuxLabel(),
 				NodeSelection: l.config.ClientNodeSelection,
-				ImageID:       e2evolume.GetDefaultTestImageID(),
+				ImageID:       e2epod.GetDefaultTestImageID(),
 			}
 			l.pod2, err = e2epod.CreateSecPodWithNodeSelection(f.ClientSet, &podConfig, resizedPodStartupTimeout)
 			defer func() {
@@ -252,9 +252,9 @@ func (v *volumeExpandTestSuite) DefineTests(driver storageframework.TestDriver, 
 			podConfig := e2epod.Config{
 				NS:            f.Namespace.Name,
 				PVCs:          []*v1.PersistentVolumeClaim{l.resource.Pvc},
-				SeLinuxLabel:  e2evolume.GetLinuxLabel(),
+				SeLinuxLabel:  e2epod.GetLinuxLabel(),
 				NodeSelection: l.config.ClientNodeSelection,
-				ImageID:       e2evolume.GetDefaultTestImageID(),
+				ImageID:       e2epod.GetDefaultTestImageID(),
 			}
 			l.pod, err = e2epod.CreateSecPodWithNodeSelection(f.ClientSet, &podConfig, f.Timeouts.PodStart)
 			defer func() {
@@ -352,9 +352,9 @@ func WaitForResizingCondition(pvc *v1.PersistentVolumeClaim, c clientset.Interfa
 }
 
 // WaitForControllerVolumeResize waits for the controller resize to be finished
-func WaitForControllerVolumeResize(pvc *v1.PersistentVolumeClaim, c clientset.Interface, duration time.Duration) error {
+func WaitForControllerVolumeResize(pvc *v1.PersistentVolumeClaim, c clientset.Interface, timeout time.Duration) error {
 	pvName := pvc.Spec.VolumeName
-	waitErr := wait.PollImmediate(resizePollInterval, duration, func() (bool, error) {
+	waitErr := wait.PollImmediate(resizePollInterval, timeout, func() (bool, error) {
 		pvcSize := pvc.Spec.Resources.Requests[v1.ResourceStorage]
 
 		pv, err := c.CoreV1().PersistentVolumes().Get(context.TODO(), pvName, metav1.GetOptions{})

--- a/test/e2e/storage/testsuites/volume_io.go
+++ b/test/e2e/storage/testsuites/volume_io.go
@@ -199,7 +199,7 @@ func makePodSpec(config e2evolume.TestConfig, initCmd string, volsrc v1.VolumeSo
 			InitContainers: []v1.Container{
 				{
 					Name:  config.Prefix + "-io-init",
-					Image: e2evolume.GetDefaultTestImage(),
+					Image: e2epod.GetDefaultTestImage(),
 					Command: []string{
 						"/bin/sh",
 						"-c",
@@ -216,7 +216,7 @@ func makePodSpec(config e2evolume.TestConfig, initCmd string, volsrc v1.VolumeSo
 			Containers: []v1.Container{
 				{
 					Name:  config.Prefix + "-io-client",
-					Image: e2evolume.GetDefaultTestImage(),
+					Image: e2epod.GetDefaultTestImage(),
 					Command: []string{
 						"/bin/sh",
 						"-c",

--- a/test/e2e/storage/testsuites/volumemode.go
+++ b/test/e2e/storage/testsuites/volumemode.go
@@ -219,9 +219,9 @@ func (t *volumeModeTestSuite) DefineTests(driver storageframework.TestDriver, pa
 				podConfig := e2epod.Config{
 					NS:            l.ns.Name,
 					PVCs:          []*v1.PersistentVolumeClaim{l.Pvc},
-					SeLinuxLabel:  e2evolume.GetLinuxLabel(),
+					SeLinuxLabel:  e2epod.GetLinuxLabel(),
 					NodeSelection: l.config.ClientNodeSelection,
-					ImageID:       e2evolume.GetDefaultTestImageID(),
+					ImageID:       e2epod.GetDefaultTestImageID(),
 				}
 				pod, err := e2epod.MakeSecPod(&podConfig)
 				framework.ExpectNoError(err, "Failed to create pod")
@@ -305,8 +305,8 @@ func (t *volumeModeTestSuite) DefineTests(driver storageframework.TestDriver, pa
 		podConfig := e2epod.Config{
 			NS:           l.ns.Name,
 			PVCs:         []*v1.PersistentVolumeClaim{l.Pvc},
-			SeLinuxLabel: e2evolume.GetLinuxLabel(),
-			ImageID:      e2evolume.GetDefaultTestImageID(),
+			SeLinuxLabel: e2epod.GetLinuxLabel(),
+			ImageID:      e2epod.GetDefaultTestImageID(),
 		}
 		pod, err := e2epod.MakeSecPod(&podConfig)
 		framework.ExpectNoError(err)
@@ -362,8 +362,8 @@ func (t *volumeModeTestSuite) DefineTests(driver storageframework.TestDriver, pa
 		podConfig := e2epod.Config{
 			NS:           l.ns.Name,
 			PVCs:         []*v1.PersistentVolumeClaim{l.Pvc},
-			SeLinuxLabel: e2evolume.GetLinuxLabel(),
-			ImageID:      e2evolume.GetDefaultTestImageID(),
+			SeLinuxLabel: e2epod.GetLinuxLabel(),
+			ImageID:      e2epod.GetDefaultTestImageID(),
 		}
 		pod, err := e2epod.MakeSecPod(&podConfig)
 		framework.ExpectNoError(err)

--- a/test/e2e/storage/testsuites/volumes.go
+++ b/test/e2e/storage/testsuites/volumes.go
@@ -231,7 +231,7 @@ func testScriptInPod(
 			Containers: []v1.Container{
 				{
 					Name:    fmt.Sprintf("exec-container-%s", suffix),
-					Image:   e2evolume.GetTestImage(imageutils.Nginx),
+					Image:   e2epod.GetTestImage(imageutils.Nginx),
 					Command: command,
 					VolumeMounts: []v1.VolumeMount{
 						{


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind failing-test

#### What this PR does / why we need it:

Fixes this test when it runs in windows nodes: `Kubernetes e2e suite.[sig-storage] PersistentVolumes GCEPD should test that deleting a PVC before the pod does not cause pod deletion to fail on PD detach`, it's always failing as seen here: https://testgrid.kubernetes.io/provider-gcp-compute-persistent-disk-csi-driver#ci-win1909-provider-gcp-compute-persistent-disk-csi-driver-migration

There are a lot of functions that provide compatibility with windows in the pod spec, these methods are in `test/e2e/framework/volume`, however, these methods are also needed in `test/e2e/framework/deployment` and `test/e2e/framework/pod`, because these compat methods are related with the pod spec I *moved them* to `test/e2e/framework/pod`

`test/e2e/framework/pod` needs to use the flag `--node-os-distro` however flag parsing and querying is inside the `test/e2e/framework/` package which can't be imported because of a cyclic dependency issue, after #81245 is done we can hopefully import it and avoid having 2 places fetching the flags

Additional cleanup:
- in `framework/pod/create.go` I moved the v1.PodSpec embedded object to its own function, hopefully it can be reused in other places in the future

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

/cc @jingxu97 @msau42 