### PR TITLE
image util unbound variable

### DIFF
--- a/test/images/image-util.sh
+++ b/test/images/image-util.sh
@@ -161,9 +161,9 @@ build() {
             "${SED}" -i "s|QEMUARCH|${QEMUARCHS[$arch]}|g" Dockerfile
             # Register qemu-*-static for all supported processors except the current one
             echo 'Registering qemu-*-static binaries in the kernel'
-            local sudo
+            local sudo=""
             if [[ $(id -u) -ne 0 ]]; then
-	            sudo=sudo
+	            sudo="sudo"
             fi
             ${sudo} "${KUBE_ROOT}/third_party/multiarch/qemu-user-static/register/register.sh" --reset -p yes
             curl -sSL https://github.com/multiarch/qemu-user-static/releases/download/"${QEMUVERSION}"/x86_64_qemu-"${QEMUARCHS[$arch]}"-static.tar.gz | tar -xz -C "${temp_dir}"


### PR DESCRIPTION
Post submit jobs to update images fail with an error

> ./image-util.sh: line 168: sudo: unbound variable

/kind bug
```release-note
NONE
```

Seen in https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/post-kubernetes-push-e2e-agnhost-test-images/1368101986561429504

make[1]: Leaving directory '/workspace/test/images/agnhost'
/workspace/_tmp/test-images-build.BEFmoj /workspace/test/images
Registering qemu-*-static binaries in the kernel
./image-util.sh: line 168: sudo: unbound variable
make: *** [Makefile:43: all-build-and-push] Error 1
ERROR
ERROR: build step 0 "gcr.io/k8s-testimages/gcb-docker-gcloud:v20201130-750d12f" failed: step exited with non-zero status: 2
ERROR: (gcloud.builds.submit) build ee9ce321-9f2c-45db-9196-8e4a60276719 completed with status "FAILURE"
