### PR TITLE
remove generator dependency of expose

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/expose/expose.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/expose/expose.go
@@ -438,31 +438,34 @@ func (o *ExposeServiceOptions) createService() (*corev1.Service, error) {
 			if err != nil {
 				return nil, err
 			}
-			name := ""
+			name := "default"
 			// If we are going to assign multiple ports to a service, we need to
 			// generate a different name for each one.
 			if len(portStringSlice) > 1 {
 				name = fmt.Sprintf("port-%d", i+1)
 			}
 
+			protocol := o.Protocol
+
 			switch {
-			case len(o.Protocol) == 0 && len(portProtocolMap) == 0:
+			case len(protocol) == 0 && len(portProtocolMap) == 0:
 				// Default to TCP, what the flag was doing previously.
-				o.Protocol = "TCP"
-			case len(o.Protocol) > 0 && len(portProtocolMap) > 0:
+				protocol = "TCP"
+			case len(protocol) > 0 && len(portProtocolMap) > 0:
 				// User has specified the --protocol while exposing a multiprotocol resource
 				// We should stomp multiple protocols with the one specified ie. do nothing
-			case len(o.Protocol) == 0 && len(portProtocolMap) > 0:
+			case len(protocol) == 0 && len(portProtocolMap) > 0:
 				// no --protocol and we expose a multiprotocol resource
-				o.Protocol = "TCP" // have the default so we can stay sane
-				if len(stillPortString) > 0 {
-					o.Protocol = stillPortString
+				protocol = "TCP" // have the default so we can stay sane
+				if exposeProtocol, found := portProtocolMap[stillPortString]; found {
+					protocol = exposeProtocol
 				}
 			}
+
 			ports = append(ports, corev1.ServicePort{
 				Name:     name,
 				Port:     int32(port),
-				Protocol: corev1.Protocol(o.Protocol),
+				Protocol: corev1.Protocol(protocol),
 			})
 		}
 	}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/expose/expose.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/expose/expose.go
@@ -22,7 +22,7 @@ import (
 	"strconv"
 	"strings"
 
-	cobra "github.com/spf13/cobra"
+	"github.com/spf13/cobra"
 	"k8s.io/klog/v2"
 
 	corev1 "k8s.io/api/core/v1"
@@ -345,6 +345,10 @@ func (o *ExposeServiceOptions) RunExpose(cmd *cobra.Command, args []string) erro
 			if err != nil {
 				return err
 			}
+		}
+		err = o.checkService(service, cmd)
+		if err != nil {
+			return err
 		}
 		return nil
 	})

--- a/staging/src/k8s.io/kubectl/pkg/cmd/expose/expose.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/expose/expose.go
@@ -17,23 +17,27 @@ limitations under the License.
 package expose
 
 import (
+	"fmt"
 	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/spf13/cobra"
 	"k8s.io/klog/v2"
 
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/unstructuredscheme"
 	"k8s.io/apimachinery/pkg/runtime"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/cli-runtime/pkg/printers"
 	"k8s.io/cli-runtime/pkg/resource"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
-	"k8s.io/kubectl/pkg/generate"
-	generateversioned "k8s.io/kubectl/pkg/generate/versioned"
 	"k8s.io/kubectl/pkg/polymorphichelpers"
 	"k8s.io/kubectl/pkg/scheme"
 	"k8s.io/kubectl/pkg/util"
@@ -93,7 +97,6 @@ type ExposeServiceOptions struct {
 
 	fieldManager string
 
-	Generators                func(string) map[string]generate.Generator
 	CanBeExposed              polymorphichelpers.CanBeExposedFunc
 	MapBasedSelectorForObject func(runtime.Object) (string, error)
 	PortsForObject            polymorphichelpers.PortsForObjectFunc
@@ -107,6 +110,11 @@ type ExposeServiceOptions struct {
 
 	Recorder genericclioptions.Recorder
 	genericclioptions.IOStreams
+}
+
+type Param struct {
+	Name     string
+	Required bool
 }
 
 func NewExposeServiceOptions(ioStreams genericclioptions.IOStreams) *ExposeServiceOptions {
@@ -145,6 +153,7 @@ func NewCmdExposeService(f cmdutil.Factory, streams genericclioptions.IOStreams)
 	o.PrintFlags.AddFlags(cmd)
 
 	cmd.Flags().String("generator", "service/v2", i18n.T("The name of the API generator to use. There are 2 generators: 'service/v1' and 'service/v2'. The only difference between them is that service port in v1 is named 'default', while it is left unnamed in v2. Default is 'service/v2'."))
+	cmd.Flags().MarkDeprecated("generator", "has no effect and will be removed in the future")
 	cmd.Flags().String("protocol", "", i18n.T("The network protocol for the service to be created. Default is 'TCP'."))
 	cmd.Flags().String("port", "", i18n.T("The port that the service should serve on. Copied from the resource being exposed, if unspecified"))
 	cmd.Flags().String("type", "", i18n.T("Type for this service: ClusterIP, NodePort, LoadBalancer, or ExternalName. Default is 'ClusterIP'."))
@@ -193,7 +202,6 @@ func (o *ExposeServiceOptions) Complete(f cmdutil.Factory, cmd *cobra.Command) e
 		return err
 	}
 
-	o.Generators = generateversioned.GeneratorFn
 	o.Builder = f.NewBuilder()
 	o.ClientForMapping = f.ClientForMapping
 	o.CanBeExposed = polymorphichelpers.CanBeExposedFn
@@ -228,14 +236,30 @@ func (o *ExposeServiceOptions) RunExpose(cmd *cobra.Command, args []string) erro
 		return cmdutil.UsageErrorf(cmd, err.Error())
 	}
 
-	// Get the generator, setup and validate all required parameters
-	generatorName := cmdutil.GetFlagString(cmd, "generator")
-	generators := o.Generators("expose")
-	generator, found := generators[generatorName]
-	if !found {
-		return cmdutil.UsageErrorf(cmd, "generator %q not found.", generatorName)
+	names := []Param{
+		{Name: "default-name", Required: true},
+		{Name: "name", Required: false},
+		{Name: "selector", Required: true},
+		// port will be used if a user specifies --port OR the exposed object
+		// has one port
+		{Name: "port", Required: false},
+		// ports will be used iff a user doesn't specify --port AND the
+		// exposed object has multiple ports
+		{Name: "ports", Required: false},
+		{Name: "labels", Required: false},
+		{Name: "external-ip", Required: false},
+		{Name: "load-balancer-ip", Required: false},
+		{Name: "type", Required: false},
+		{Name: "protocol", Required: false},
+		// protocols will be used to keep port-protocol mapping derived from
+		// exposed object
+		{Name: "protocols", Required: false},
+		{Name: "container-port", Required: false}, // alias of target-port
+		{Name: "target-port", Required: false},
+		{Name: "port-name", Required: false},
+		{Name: "session-affinity", Required: false},
+		{Name: "cluster-ip", Required: false},
 	}
-	names := generator.ParamNames()
 
 	err = r.Visit(func(info *resource.Info, err error) error {
 		if err != nil {
@@ -256,7 +280,7 @@ func (o *ExposeServiceOptions) RunExpose(cmd *cobra.Command, args []string) erro
 
 		// For objects that need a pod selector, derive it from the exposed object in case a user
 		// didn't explicitly specify one via --selector
-		if s, found := params["selector"]; found && generate.IsZero(s) {
+		if s, found := params["selector"]; found && s == nil {
 			s, err := o.MapBasedSelectorForObject(info.Object)
 			if err != nil {
 				return cmdutil.UsageErrorf(cmd, "couldn't retrieve selectors via --selector flag or introspection: %v", err)
@@ -268,7 +292,7 @@ func (o *ExposeServiceOptions) RunExpose(cmd *cobra.Command, args []string) erro
 
 		// For objects that need a port, derive it from the exposed object in case a user
 		// didn't explicitly specify one via --port
-		if port, found := params["port"]; found && generate.IsZero(port) {
+		if port, found := params["port"]; found && port == nil {
 			ports, err := o.PortsForObject(info.Object)
 			if err != nil {
 				return cmdutil.UsageErrorf(cmd, "couldn't find port via --port flag or introspection: %v", err)
@@ -292,28 +316,24 @@ func (o *ExposeServiceOptions) RunExpose(cmd *cobra.Command, args []string) erro
 			if err != nil {
 				return cmdutil.UsageErrorf(cmd, "couldn't find protocol via introspection: %v", err)
 			}
-			if protocols := generate.MakeProtocols(protocolsMap); !generate.IsZero(protocols) {
+			if protocols := MakeProtocols(protocolsMap); protocols != nil {
 				params["protocols"] = protocols
 			}
 		}
 
-		if generate.IsZero(params["labels"]) {
+		if params["labels"] == nil {
 			labels, err := meta.NewAccessor().Labels(info.Object)
 			if err != nil {
 				return err
 			}
 			params["labels"] = polymorphichelpers.MakeLabels(labels)
 		}
-		if err = generate.ValidateParams(names, params); err != nil {
-			return err
-		}
-		// Check for invalid flags used against the present generator.
-		if err := generate.EnsureFlagsValid(cmd, generators, generatorName); err != nil {
+		if err = ValidateParams(names, params); err != nil {
 			return err
 		}
 
 		// Generate new object
-		object, err := generator.Generate(params)
+		object, err := generateService(params)
 		if err != nil {
 			return err
 		}
@@ -377,4 +397,251 @@ func (o *ExposeServiceOptions) RunExpose(cmd *cobra.Command, args []string) erro
 		return err
 	}
 	return nil
+}
+
+func generateService(genericParams map[string]interface{}) (runtime.Object, error) {
+	params := map[string]string{}
+	for key, value := range genericParams {
+		strVal, isString := value.(string)
+		if !isString {
+			return nil, fmt.Errorf("expected string, saw %v for '%s'", value, key)
+		}
+		params[key] = strVal
+	}
+	selectorString, found := params["selector"]
+	if !found || len(selectorString) == 0 {
+		return nil, fmt.Errorf("'selector' is a required parameter")
+	}
+	selector, err := ParseLabels(selectorString)
+	if err != nil {
+		return nil, err
+	}
+
+	labelsString, found := params["labels"]
+	var labels map[string]string
+	if found && len(labelsString) > 0 {
+		labels, err = ParseLabels(labelsString)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	name, found := params["name"]
+	if !found || len(name) == 0 {
+		name, found = params["default-name"]
+		if !found || len(name) == 0 {
+			return nil, fmt.Errorf("'name' is a required parameter")
+		}
+	}
+
+	isHeadlessService := params["cluster-ip"] == "None"
+
+	ports := []v1.ServicePort{}
+	servicePortName, found := params["port-name"]
+	if !found {
+		// Leave the port unnamed.
+		servicePortName = ""
+	}
+
+	protocolsString, found := params["protocols"]
+	var portProtocolMap map[string]string
+	if found && len(protocolsString) > 0 {
+		portProtocolMap, err = ParseProtocols(protocolsString)
+		if err != nil {
+			return nil, err
+		}
+	}
+	// ports takes precedence over port since it will be
+	// specified only when the user hasn't specified a port
+	// via --port and the exposed object has multiple ports.
+	var portString string
+	if portString, found = params["ports"]; !found {
+		portString, found = params["port"]
+		if !found && !isHeadlessService {
+			return nil, fmt.Errorf("'ports' or 'port' is a required parameter")
+		}
+	}
+
+	if portString != "" {
+		portStringSlice := strings.Split(portString, ",")
+		for i, stillPortString := range portStringSlice {
+			port, err := strconv.Atoi(stillPortString)
+			if err != nil {
+				return nil, err
+			}
+			name := servicePortName
+			// If we are going to assign multiple ports to a service, we need to
+			// generate a different name for each one.
+			if len(portStringSlice) > 1 {
+				name = fmt.Sprintf("port-%d", i+1)
+			}
+			protocol := params["protocol"]
+
+			switch {
+			case len(protocol) == 0 && len(portProtocolMap) == 0:
+				// Default to TCP, what the flag was doing previously.
+				protocol = "TCP"
+			case len(protocol) > 0 && len(portProtocolMap) > 0:
+				// User has specified the --protocol while exposing a multiprotocol resource
+				// We should stomp multiple protocols with the one specified ie. do nothing
+			case len(protocol) == 0 && len(portProtocolMap) > 0:
+				// no --protocol and we expose a multiprotocol resource
+				protocol = "TCP" // have the default so we can stay sane
+				if exposeProtocol, found := portProtocolMap[stillPortString]; found {
+					protocol = exposeProtocol
+				}
+			}
+			ports = append(ports, v1.ServicePort{
+				Name:     name,
+				Port:     int32(port),
+				Protocol: v1.Protocol(protocol),
+			})
+		}
+	}
+
+	service := v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   name,
+			Labels: labels,
+		},
+		Spec: v1.ServiceSpec{
+			Selector: selector,
+			Ports:    ports,
+		},
+	}
+	targetPortString := params["target-port"]
+	if len(targetPortString) == 0 {
+		targetPortString = params["container-port"]
+	}
+	if len(targetPortString) > 0 {
+		var targetPort intstr.IntOrString
+		if portNum, err := strconv.Atoi(targetPortString); err != nil {
+			targetPort = intstr.FromString(targetPortString)
+		} else {
+			targetPort = intstr.FromInt(portNum)
+		}
+		// Use the same target-port for every port
+		for i := range service.Spec.Ports {
+			service.Spec.Ports[i].TargetPort = targetPort
+		}
+	} else {
+		// If --target-port or --container-port haven't been specified, this
+		// should be the same as Port
+		for i := range service.Spec.Ports {
+			port := service.Spec.Ports[i].Port
+			service.Spec.Ports[i].TargetPort = intstr.FromInt(int(port))
+		}
+	}
+	if len(params["external-ip"]) > 0 {
+		service.Spec.ExternalIPs = []string{params["external-ip"]}
+	}
+	if len(params["type"]) != 0 {
+		service.Spec.Type = v1.ServiceType(params["type"])
+	}
+	if service.Spec.Type == v1.ServiceTypeLoadBalancer {
+		service.Spec.LoadBalancerIP = params["load-balancer-ip"]
+	}
+	if len(params["session-affinity"]) != 0 {
+		switch v1.ServiceAffinity(params["session-affinity"]) {
+		case v1.ServiceAffinityNone:
+			service.Spec.SessionAffinity = v1.ServiceAffinityNone
+		case v1.ServiceAffinityClientIP:
+			service.Spec.SessionAffinity = v1.ServiceAffinityClientIP
+		default:
+			return nil, fmt.Errorf("unknown session affinity: %s", params["session-affinity"])
+		}
+	}
+	if len(params["cluster-ip"]) != 0 {
+		if params["cluster-ip"] == "None" {
+			service.Spec.ClusterIP = v1.ClusterIPNone
+		} else {
+			service.Spec.ClusterIP = params["cluster-ip"]
+		}
+	}
+	return &service, nil
+}
+
+// ParseLabels turns a string representation of a label set into a map[string]string
+func ParseLabels(labelSpec interface{}) (map[string]string, error) {
+	labelString, isString := labelSpec.(string)
+	if !isString {
+		return nil, fmt.Errorf("expected string, found %v", labelSpec)
+	}
+	if len(labelString) == 0 {
+		return nil, fmt.Errorf("no label spec passed")
+	}
+	labels := map[string]string{}
+	labelSpecs := strings.Split(labelString, ",")
+	for ix := range labelSpecs {
+		labelSpec := strings.Split(labelSpecs[ix], "=")
+		if len(labelSpec) != 2 {
+			return nil, fmt.Errorf("unexpected label spec: %s", labelSpecs[ix])
+		}
+		if len(labelSpec[0]) == 0 {
+			return nil, fmt.Errorf("unexpected empty label key")
+		}
+		labels[labelSpec[0]] = labelSpec[1]
+	}
+	return labels, nil
+}
+
+// ParseProtocols turns a string representation of a protocol set into a map[string]string
+func ParseProtocols(protocols interface{}) (map[string]string, error) {
+	protocolsString, isString := protocols.(string)
+	if !isString {
+		return nil, fmt.Errorf("expected string, found %v", protocols)
+	}
+	if len(protocolsString) == 0 {
+		return nil, fmt.Errorf("no protocols passed")
+	}
+	portProtocolMap := map[string]string{}
+	protocolsSlice := strings.Split(protocolsString, ",")
+	for ix := range protocolsSlice {
+		portProtocol := strings.Split(protocolsSlice[ix], "/")
+		if len(portProtocol) != 2 {
+			return nil, fmt.Errorf("unexpected port protocol mapping: %s", protocolsSlice[ix])
+		}
+		if len(portProtocol[0]) == 0 {
+			return nil, fmt.Errorf("unexpected empty port")
+		}
+		if len(portProtocol[1]) == 0 {
+			return nil, fmt.Errorf("unexpected empty protocol")
+		}
+		portProtocolMap[portProtocol[0]] = portProtocol[1]
+	}
+	return portProtocolMap, nil
+}
+
+// MakeParams is a utility that creates generator parameters from a command line
+func MakeParams(cmd *cobra.Command, params []GeneratorParam) map[string]interface{} {
+	result := map[string]interface{}{}
+	for ix := range params {
+		f := cmd.Flags().Lookup(params[ix].Name)
+		if f != nil {
+			result[params[ix].Name] = f.Value.String()
+		}
+	}
+	return result
+}
+
+// ValidateParams ensures that all required params are present in the params map
+func ValidateParams(paramSpec []GeneratorParam, params map[string]interface{}) error {
+	allErrs := []error{}
+	for ix := range paramSpec {
+		if paramSpec[ix].Required {
+			value, found := params[paramSpec[ix].Name]
+			if !found || IsZero(value) {
+				allErrs = append(allErrs, fmt.Errorf("Parameter: %s is required", paramSpec[ix].Name))
+			}
+		}
+	}
+	return utilerrors.NewAggregate(allErrs)
+}
+
+func MakeProtocols(protocols map[string]string) string {
+	out := []string{}
+	for key, value := range protocols {
+		out = append(out, fmt.Sprintf("%s/%s", key, value))
+	}
+	return strings.Join(out, ",")
 }

--- a/staging/src/k8s.io/kubectl/pkg/cmd/expose/expose_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/expose/expose_test.go
@@ -443,6 +443,7 @@ func TestGenerateService(t *testing.T) {
 		name 	 		string
 		port     		string
 		protocol    	string
+		protocols		string
 		targetPort  	string
 		clusterIP   	string
 		labels			string
@@ -471,6 +472,7 @@ func TestGenerateService(t *testing.T) {
 					},
 					Ports: []corev1.ServicePort{
 						{
+							Name:		"default",
 							Port:       80,
 							Protocol:   "TCP",
 							TargetPort: intstr.FromInt(1234),
@@ -496,6 +498,7 @@ func TestGenerateService(t *testing.T) {
 					},
 					Ports: []corev1.ServicePort{
 						{
+							Name:		"default",
 							Port:       80,
 							Protocol:   "UDP",
 							TargetPort: intstr.FromString("foobar"),
@@ -526,6 +529,7 @@ func TestGenerateService(t *testing.T) {
 					},
 					Ports: []corev1.ServicePort{
 						{
+							Name:		"default",
 							Port:       80,
 							Protocol:   "TCP",
 							TargetPort: intstr.FromInt(1234),
@@ -552,6 +556,7 @@ func TestGenerateService(t *testing.T) {
 					},
 					Ports: []corev1.ServicePort{
 						{
+							Name:		"default",
 							Port:       80,
 							Protocol:   "UDP",
 							TargetPort: intstr.FromString("foobar"),
@@ -580,6 +585,7 @@ func TestGenerateService(t *testing.T) {
 					},
 					Ports: []corev1.ServicePort{
 						{
+							Name:		"default",
 							Port:       80,
 							Protocol:   "UDP",
 							TargetPort: intstr.FromString("foobar"),
@@ -595,6 +601,7 @@ func TestGenerateService(t *testing.T) {
 			name:           "test",
 			port:           "80",
 			protocol:       "UDP",
+			targetPort:		"foobar",
 			serviceType:     string(corev1.ServiceTypeNodePort),
 			expected: &corev1.Service{
 				ObjectMeta: metav1.ObjectMeta{
@@ -607,6 +614,7 @@ func TestGenerateService(t *testing.T) {
 					},
 					Ports: []corev1.ServicePort{
 						{
+							Name:		"default",
 							Port:       80,
 							Protocol:   "UDP",
 							TargetPort: intstr.FromString("foobar"),
@@ -634,6 +642,7 @@ func TestGenerateService(t *testing.T) {
 					},
 					Ports: []corev1.ServicePort{
 						{
+							Name:		"default",
 							Port:       80,
 							Protocol:   "UDP",
 							TargetPort: intstr.FromString("foobar"),
@@ -715,6 +724,7 @@ func TestGenerateService(t *testing.T) {
 					},
 					Ports: []corev1.ServicePort{
 						{
+							Name:		"default",
 							Port:       80,
 							Protocol:   "TCP",
 							TargetPort: intstr.FromInt(1234),
@@ -742,6 +752,7 @@ func TestGenerateService(t *testing.T) {
 					},
 					Ports: []corev1.ServicePort{
 						{
+							Name:		"default",
 							Port:       80,
 							Protocol:   "TCP",
 							TargetPort: intstr.FromInt(1234),
@@ -962,6 +973,7 @@ func TestGenerateService(t *testing.T) {
 					},
 					Ports: []corev1.ServicePort{
 						{
+							Name:		"default",
 							Port:       80,
 							Protocol:   "SCTP",
 							TargetPort: intstr.FromInt(1234),
@@ -992,6 +1004,7 @@ func TestGenerateService(t *testing.T) {
 					},
 					Ports: []corev1.ServicePort{
 						{
+							Name:		"default",
 							Port:       80,
 							Protocol:   "SCTP",
 							TargetPort: intstr.FromInt(1234),
@@ -1072,6 +1085,7 @@ func TestGenerateService(t *testing.T) {
 					},
 					Ports: []corev1.ServicePort{
 						{
+							Name:		"default",
 							Port:       80,
 							Protocol:   "SCTP",
 							TargetPort: intstr.FromInt(1234),
@@ -1099,6 +1113,7 @@ func TestGenerateService(t *testing.T) {
 					},
 					Ports: []corev1.ServicePort{
 						{
+							Name:		"default",
 							Port:       80,
 							Protocol:   "SCTP",
 							TargetPort: intstr.FromInt(1234),
@@ -1174,7 +1189,6 @@ func TestGenerateService(t *testing.T) {
 			name:      "test",
 			port:      "80,8080",
 			protocol:  "8080/SCTP",
-			targetPort:"foobar",
 			expected: &corev1.Service{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test",
@@ -1287,10 +1301,17 @@ func TestGenerateService(t *testing.T) {
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			var service *corev1.Service = nil
+
+			if strings.Contains(test.protocol,"/") {
+				test.protocols = test.protocol
+				test.protocol = ""
+			}
+
 			exposeServiceOptions := ExposeServiceOptions{
 				Selector:		 test.selector,
 				Name:			 test.name,
 				Protocol:		 test.protocol,
+				Protocols:		 test.protocols,
 				Port:			 test.port,
 				ClusterIP:		 test.clusterIP,
 				TargetPort: 	 test.targetPort,
@@ -1298,12 +1319,6 @@ func TestGenerateService(t *testing.T) {
 				ExternalIP: 	 test.externalIP,
 				Type:			 test.serviceType,
 				SessionAffinity: test.sessionAffinity,
-			}
-	
-			if test.setup != nil {
-				if teardown := test.setup(t, &exposeServiceOptions); teardown != nil {
-					defer teardown()
-				}
 			}
 
 			err := exposeServiceOptions.Validate()

--- a/staging/src/k8s.io/kubectl/pkg/cmd/expose/expose_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/expose/expose_test.go
@@ -72,7 +72,7 @@ func TestRunExposeService(t *testing.T) {
 					Selector: map[string]string{"app": "go"},
 				},
 			},
-			expected: "service/foo exposed",
+			expected: "error: selector must be specified",
 			status:   200,
 		},
 		{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup
<!--
Add one of the following kinds:
/kind bug

/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Remove the dependency between `kubectl expose` command and generators

#### Which issue(s) this PR fixes:
Part of #93100 
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

#### Special notes for your reviewer:
/assign @rikatz 
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
generator flag of 'kubectl expose' has no effect and will be removed in future
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
