### PR TITLE
Update flaky volume toleration regex to include projected volumes

### DIFF
--- a/test/e2e/node/pods.go
+++ b/test/e2e/node/pods.go
@@ -206,7 +206,7 @@ var _ = SIGDescribe("Pods Extended", func() {
 		ginkgo.It("should never report success for a pending container", func() {
 			ginkgo.By("creating pods that should always exit 1 and terminating the pod after a random delay")
 
-			var reBug88766 = regexp.MustCompile(`rootfs_linux.*kubernetes\.io~secret.*no such file or directory`)
+			var reBug88766 = regexp.MustCompile(`rootfs_linux.*kubernetes\.io~(secret|projected).*no such file or directory`)
 
 			var (
 				lock sync.Mutex


### PR DESCRIPTION
#### What type of PR is this?

/kind flake

#### What this PR does / why we need it:

Injected service account tokens changed from secret-based to projected-token based by default in https://github.com/kubernetes/kubernetes/pull/95667, which merged 2/18

That coincides with this flake starting: https://storage.googleapis.com/k8s-gubernator/triage/index.html?date=2021-02-27&text=volumes%2Fkubernetes.io~projected

This test already tolerated secret volume setup errors, until https://github.com/kubernetes/kubernetes/issues/88766 is resolved. The regex should be expanded to accomodate projected volume tokens until that issue is resolved.

#### Which issue(s) this PR fixes:
Fixes #99599

```release-note
NONE
```

/cc @zshihang @smarterclayton @jkaniuk @ehashman 