### PR TITLE
update verify-shellcheck to v0.7.1, fix nits, multi-arch digest pinning, fix new lint errors

### DIFF
--- a/hack/lib/golang.sh
+++ b/hack/lib/golang.sh
@@ -874,7 +874,7 @@ kube::golang::build_binaries() {
         cat "/tmp//${platform//\//_}.build"
       done
 
-      exit ${fails}
+      exit "${fails}"
     else
       for platform in "${platforms[@]}"; do
         kube::log::status "Building go targets for ${platform}:" "${targets[@]}"

--- a/hack/verify-shellcheck.sh
+++ b/hack/verify-shellcheck.sh
@@ -27,9 +27,9 @@ source "${KUBE_ROOT}/hack/lib/util.sh"
 
 # required version for this script, if not installed on the host we will
 # use the official docker image instead. keep this in sync with SHELLCHECK_IMAGE
-SHELLCHECK_VERSION="0.7.0"
+SHELLCHECK_VERSION="0.7.1"
 # upstream shellcheck latest stable image as of October 23rd, 2019
-SHELLCHECK_IMAGE="koalaman/shellcheck-alpine:v0.7.0@sha256:24bbf52aae6eaa27accc9f61de32d30a1498555e6ef452966d0702ff06f38ecb"
+SHELLCHECK_IMAGE="docker.io/koalaman/shellcheck-alpine:v0.7.1@sha256:d6147f30864ddb7c9cf983fc277d345bc315e798e309ddf70062b194843ee252"
 
 # disabled lints
 disabled=(

--- a/hack/verify-shellcheck.sh
+++ b/hack/verify-shellcheck.sh
@@ -25,6 +25,9 @@ KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 source "${KUBE_ROOT}/hack/lib/init.sh"
 source "${KUBE_ROOT}/hack/lib/util.sh"
 
+# allow overriding docker cli, which should work fine for this script
+DOCKER="${DOCKER:-docker}"
+
 # required version for this script, if not installed on the host we will
 # use the official docker image instead. keep this in sync with SHELLCHECK_IMAGE
 SHELLCHECK_VERSION="0.7.1"
@@ -105,7 +108,7 @@ if ${HAVE_SHELLCHECK}; then
   shellcheck "${SHELLCHECK_OPTIONS[@]}" "${all_shell_scripts[@]}" || res=$?
 else
   echo "Using shellcheck ${SHELLCHECK_VERSION} docker image."
-  docker run \
+  "${DOCKER}" run \
     --rm -v "${KUBE_ROOT}:${KUBE_ROOT}" -w "${KUBE_ROOT}" \
     "${SHELLCHECK_IMAGE}" \
   shellcheck "${SHELLCHECK_OPTIONS[@]}" "${all_shell_scripts[@]}" || res=$?

--- a/hack/verify-shellcheck.sh
+++ b/hack/verify-shellcheck.sh
@@ -113,7 +113,7 @@ fi
 
 # print a message based on the result
 if [ $res -eq 0 ]; then
-  echo 'Congratulations! All shell files are passing lint (excluding those in hack/.shellcheck_failures).'
+  echo 'Congratulations! All shell files are passing lint :-)'
 else
   {
     echo
@@ -121,7 +121,7 @@ else
     echo 'If the above warnings do not make sense, you can exempt this warning with a comment'
     echo ' (if your reviewer is okay with it).'
     echo 'In general please prefer to fix the error, we have already disabled specific lints'
-    echo ' that the project chooses to ignire.'
+    echo ' that the project chooses to ignore.'
     echo 'See: https://github.com/koalaman/shellcheck/wiki/Ignore#ignoring-one-specific-instance-in-a-file'
     echo
   } >&2

--- a/test/cmd/core.sh
+++ b/test/cmd/core.sh
@@ -560,7 +560,7 @@ run_pod_tests() {
   resourceVersion=$(kubectl get "${kube_flags[@]}" pod valid-pod -o go-template='{{ .metadata.resourceVersion }}')
   ((resourceVersion+=100))
   # Command
-  kubectl patch "${kube_flags[@]}" pod valid-pod -p='{"spec":{"containers":[{"name": "kubernetes-serve-hostname", "image": "nginx"}]},"metadata":{"resourceVersion":"'$resourceVersion'"}}' 2> "${ERROR_FILE}" || true
+  kubectl patch "${kube_flags[@]}" pod valid-pod -p='{"spec":{"containers":[{"name": "kubernetes-serve-hostname", "image": "nginx"}]},"metadata":{"resourceVersion":"'"$resourceVersion"'"}}' 2> "${ERROR_FILE}" || true
   # Post-condition: should get an error reporting the conflict
   if grep -q "please apply your changes to the latest version and try again" "${ERROR_FILE}"; then
     kube::log::status "\"kubectl patch with resourceVersion $resourceVersion\" returns error as expected: $(cat "${ERROR_FILE}")"

--- a/test/images/pets/zookeeper-installer/on-start.sh
+++ b/test/images/pets/zookeeper-installer/on-start.sh
@@ -60,7 +60,7 @@ for peer in "${PEERS[@]}"; do
     if [[ "${peer}" == *"${HOSTNAME}"* ]]; then
       MY_ID=$i
       MY_NAME=${peer}
-      echo $i > "${MY_ID_FILE}"
+      echo "$i" > "${MY_ID_FILE}"
       echo "server.${i}=${peer}:2888:3888:observer;2181" >> "${CFG_BAK}"
     else
       if [[ $(echo srvr | /opt/nc "${peer}" 2181 | grep Mode) = "Mode: leader" ]]; then
@@ -95,10 +95,10 @@ ADD_SERVER="server.$MY_ID=$MY_NAME:2888:3888:participant;0.0.0.0:2181"
 # Prove that we've actually joined the running cluster
 ITERATION=0
 until echo config | /opt/nc localhost 2181 | grep "${ADD_SERVER}" > /dev/null; do
-  echo $ITERATION] waiting for updated config to sync back to localhost
+  echo "$ITERATION"] waiting for updated config to sync back to localhost
   sleep 1
   (( ITERATION=ITERATION+1 ))
-  if [ $ITERATION -eq 20 ]; then
+  if [ "$ITERATION" -eq 20 ]; then
     exit 1
   fi
 done


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

- fixes the pass / fail messages in `hack/verify-shellcheck.sh`
- updates to current shellcheck stable (v0.7.0 -> v0.7.1)
- switches to a multi-arch digest instead of an amd64 digest (thanks @jonjohnsonjr)
-  fixes new lint errors (trivial unquoted variable expansion issues)
- enable `DOCKER` env override for docker CLI, like other kubernetes scripts

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
/sig testing