### PR TITLE
Support apiserver.config.k8s.io group for v1alpha1 and v1beta1

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/apis/apiserver/v1alpha1/register.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/apiserver/v1alpha1/register.go
@@ -23,9 +23,13 @@ import (
 )
 
 const GroupName = "apiserver.k8s.io"
+const ConfigGroupName = "apiserver.config.k8s.io"
 
 // SchemeGroupVersion is group version used to register these objects
 var SchemeGroupVersion = schema.GroupVersion{Group: GroupName, Version: "v1alpha1"}
+
+// ConfigSchemeGroupVersion is group version used to register these objects
+var ConfigSchemeGroupVersion = schema.GroupVersion{Group: ConfigGroupName, Version: "v1alpha1"}
 
 var (
 	// TODO: move SchemeBuilder with zz_generated.deepcopy.go to k8s.io/api.
@@ -45,6 +49,10 @@ func init() {
 // Adds the list of known types to the given scheme.
 func addKnownTypes(scheme *runtime.Scheme) error {
 	scheme.AddKnownTypes(SchemeGroupVersion,
+		&AdmissionConfiguration{},
+		&EgressSelectorConfiguration{},
+	)
+	scheme.AddKnownTypes(ConfigSchemeGroupVersion,
 		&AdmissionConfiguration{},
 		&EgressSelectorConfiguration{},
 	)

--- a/staging/src/k8s.io/apiserver/pkg/apis/apiserver/v1beta1/register.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/apiserver/v1beta1/register.go
@@ -23,9 +23,13 @@ import (
 )
 
 const GroupName = "apiserver.k8s.io"
+const ConfigGroupName = "apiserver.config.k8s.io"
 
 // SchemeGroupVersion is group version used to register these objects
 var SchemeGroupVersion = schema.GroupVersion{Group: GroupName, Version: "v1beta1"}
+
+// ConfigSchemeGroupVersion is group version used to register these objects
+var ConfigSchemeGroupVersion = schema.GroupVersion{Group: ConfigGroupName, Version: "v1beta1"}
 
 var (
 	// TODO: move SchemeBuilder with zz_generated.deepcopy.go to k8s.io/api.
@@ -45,6 +49,9 @@ func init() {
 // Adds the list of known types to the given scheme.
 func addKnownTypes(scheme *runtime.Scheme) error {
 	scheme.AddKnownTypes(SchemeGroupVersion,
+		&EgressSelectorConfiguration{},
+	)
+	scheme.AddKnownTypes(ConfigSchemeGroupVersion,
 		&EgressSelectorConfiguration{},
 	)
 	metav1.AddToGroupVersion(scheme, SchemeGroupVersion)


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
In #85098, we moved apiserver types from `apiserver.k8s.io` to `apiserver.config.k8s.io` for `v1`, but didn't allow v1alpha1 or v1beta1 to be used in that group.  I'm in the process of adding a new type to v1alpha1, and it needs to be under `config.k8s.io`, as requested here: https://github.com/kubernetes/kubernetes/pull/94942#discussion_r522589349.

Split from https://github.com/kubernetes/kubernetes/pull/94942 (and now blocks that PR).
/priority important-soon

/release-note-none

/assign @liggitt 