### PR TITLE
Add test timeout to mutation detector test

### DIFF
--- a/staging/src/k8s.io/client-go/tools/cache/mutation_detector_test.go
+++ b/staging/src/k8s.io/client-go/tools/cache/mutation_detector_test.go
@@ -49,8 +49,9 @@ func TestMutationDetector(t *testing.T) {
 
 	informer := NewSharedInformer(lw, &v1.Pod{}, 1*time.Second).(*sharedIndexInformer)
 	detector := &defaultCacheMutationDetector{
-		name:   "name",
-		period: 1 * time.Second,
+		name:           "name",
+		period:         1 * time.Second,
+		retainDuration: 2 * time.Minute,
 		failureFunc: func(message string) {
 			mutationFound <- true
 		},
@@ -72,6 +73,8 @@ func TestMutationDetector(t *testing.T) {
 
 	select {
 	case <-mutationFound:
+	case <-time.After(wait.ForeverTestTimeout):
+		t.Fatalf("failed waiting for mutating detector")
 	}
 
 }


### PR DESCRIPTION
TestMutationDetector, recently re-enabled in https://github.com/kubernetes/kubernetes/pull/99782, is timing out.

https://storage.googleapis.com/k8s-gubernator/triage/index.html?date=2021-03-06&pr=1&job=pull-kubernetes-unit&test=TestMain

Looking at one of those runs, the following tests are completing in that package:

```
TestHammerController
TestUpdate
TestPanicPropagated
TestDeltaFIFO_basic
TestDeltaFIFO_replaceWithDeleteDeltaIn
TestDeltaFIFO_requeueOnPop
TestDeltaFIFO_addUpdate
TestDeltaFIFO_enqueueingNoLister
TestDeltaFIFO_enqueueingWithLister
TestDeltaFIFO_addReplace
TestDeltaFIFO_ResyncNonExisting
TestDeltaFIFO_Resync
TestDeltaFIFO_DeleteExistingNonPropagated
TestDeltaFIFO_ReplaceMakesDeletions
TestDeltaFIFO_ReplaceMakesDeletionsReplaced
TestDeltaFIFO_ReplaceDeltaType
TestDeltaFIFO_UpdateResyncRace
TestDeltaFIFO_HasSyncedCorrectOnDeletion
TestDeltaFIFO_detectLineJumpers
TestDeltaFIFO_addIfNotPresent
TestDeltaFIFO_KeyOf
TestDeltaFIFO_HasSynced
TestDeltaFIFO_PopShouldUnblockWhenClosed
TestTTLExpirationBasic
TestReAddExpiredItem
TestTTLList
TestTTLPolicy
TestFIFO_basic
TestFIFO_requeueOnPop
TestFIFO_addUpdate
TestFIFO_addReplace
TestFIFO_detectLineJumpers
TestFIFO_addIfNotPresent
TestFIFO_HasSynced
TestFIFO_PopShouldUnblockWhenClosed
TestHeapBasic
TestHeap_Add
TestHeap_BulkAdd
TestHeapEmptyPop
TestHeap_AddIfNotPresent
TestHeap_Delete
TestHeap_Update
TestHeap_Get
TestHeap_GetByKey
TestHeap_Close
TestHeap_List
TestHeap_ListKeys
TestHeapAddAfterClose
TestGetIndexFuncValues
TestMultiIndexKeys
```

The next test is `TestMutationDetector`

Running locally with -race and stress does not show any flakes:

```
$ go test k8s.io/client-go/tools/cache -run TestMutationDetector -race -count=1 -c
$ stress ./cache.test -test.run TestMutationDetector
48 runs so far, 0 failures
96 runs so far, 0 failures
156 runs so far, 0 failures
206 runs so far, 0 failures
264 runs so far, 0 failures
324 runs so far, 0 failures
375 runs so far, 0 failures
432 runs so far, 0 failures
492 runs so far, 0 failures
544 runs so far, 0 failures
600 runs so far, 0 failures
660 runs so far, 0 failures
712 runs so far, 0 failures
768 runs so far, 0 failures
820 runs so far, 0 failures
877 runs so far, 0 failures
936 runs so far, 0 failures
988 runs so far, 0 failures
1044 runs so far, 0 failures
1104 runs so far, 0 failures
1156 runs so far, 0 failures
1212 runs so far, 0 failures
1272 runs so far, 0 failures
1324 runs so far, 0 failures
1380 runs so far, 0 failures
1440 runs so far, 0 failures
1492 runs so far, 0 failures
1548 runs so far, 0 failures
1608 runs so far, 0 failures
1660 runs so far, 0 failures
1716 runs so far, 0 failures
1776 runs so far, 0 failures
1828 runs so far, 0 failures
1884 runs so far, 0 failures
1944 runs so far, 0 failures
1996 runs so far, 0 failures
2052 runs so far, 0 failures
2112 runs so far, 0 failures
2164 runs so far, 0 failures
```

Adding a 30 second timeout to avoid package timeouts and attribute failures directly to this test.

```release-note
NONE
```