### PR TITLE
Avoid closing a file twice in LaunchTempFile in editor

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/cp/cp.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/cp/cp.go
@@ -486,9 +486,9 @@ func (o *CopyOptions) untarAll(src fileSpec, reader io.Reader, destDir, prefix s
 		if err != nil {
 			return err
 		}
-		defer outFile.Close()
 		if _, err := io.Copy(outFile, tarReader); err != nil {
 			return err
+			outFile.Close()
 		}
 		if err := outFile.Close(); err != nil {
 			return err

--- a/staging/src/k8s.io/kubectl/pkg/cmd/util/editor/editor.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/util/editor/editor.go
@@ -146,10 +146,10 @@ func (e Editor) LaunchTempFile(prefix, suffix string, r io.Reader) ([]byte, stri
 	if err != nil {
 		return nil, "", err
 	}
-	defer f.Close()
 	path := f.Name()
 	if _, err := io.Copy(f, r); err != nil {
 		os.Remove(path)
+		f.Close()
 		return nil, path, err
 	}
 	// This file descriptor needs to close so the next process (Launch) can claim it.


### PR DESCRIPTION
There is a `defer f.Close()` call in `LaunchTempFile`, but an explicit
`f.Close()` is called a few lines below. Move this deferred `f.Close()`
call to the `if` block to avoid closing `f` twice.

The [doc of Close()](https://golang.org/pkg/os/#File.Close) says:

> Close will return an error if it has already been called.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

See the top of the comment.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

