### PR TITLE
PodNodeSelector admission - remove "alpha" string

### DIFF
--- a/plugin/pkg/admission/podnodeselector/admission.go
+++ b/plugin/pkg/admission/podnodeselector/admission.go
@@ -39,8 +39,13 @@ import (
 
 // NamespaceNodeSelectors is for assigning node selectors labels to
 // namespaces. Default value is the annotation key
-// scheduler.alpha.kubernetes.io/node-selector
-var NamespaceNodeSelectors = []string{"scheduler.alpha.kubernetes.io/node-selector"}
+// scheduler.kubernetes.io/node-selector
+// ("scheduler.alpha.kubernetes.io/node-selector" is deprecated and will be
+// removed in a future release)
+var NamespaceNodeSelectors = []string{
+	"scheduler.alpha.kubernetes.io/node-selector",
+	"scheduler.kubernetes.io/node-selector",
+}
 
 // PluginName is a string with the name of the plugin
 const PluginName = "PodNodeSelector"

--- a/plugin/pkg/admission/podnodeselector/admission_test.go
+++ b/plugin/pkg/admission/podnodeselector/admission_test.go
@@ -154,7 +154,7 @@ func TestPodAdmission(t *testing.T) {
 	}
 	for _, test := range tests {
 		if !test.ignoreTestNamespaceNodeSelector {
-			namespace.ObjectMeta.Annotations = map[string]string{"scheduler.alpha.kubernetes.io/node-selector": test.namespaceNodeSelector}
+			namespace.ObjectMeta.Annotations = map[string]string{"scheduler.kubernetes.io/node-selector": test.namespaceNodeSelector}
 			informerFactory.Core().V1().Namespaces().Informer().GetStore().Update(namespace)
 		}
 		handler.clusterNodeSelectors = make(map[string]string)

--- a/test/e2e/apps/daemon_set.go
+++ b/test/e2e/apps/daemon_set.go
@@ -60,9 +60,9 @@ const (
 	daemonsetColorLabel  = daemonsetLabelPrefix + "color"
 )
 
-// NamespaceNodeSelectors the annotation key scheduler.alpha.kubernetes.io/node-selector is for assigning
+// NamespaceNodeSelectors the annotation key scheduler.kubernetes.io/node-selector is for assigning
 // node selectors labels to namespaces
-var NamespaceNodeSelectors = []string{"scheduler.alpha.kubernetes.io/node-selector"}
+var NamespaceNodeSelectors = []string{"scheduler.kubernetes.io/node-selector"}
 
 type updateDSFunc func(*appsv1.DaemonSet)
 


### PR DESCRIPTION
#### What type of PR is this?


/kind feature

/kind api-change


#### What this PR does / why we need it:

Remove "alpha" string from the annotation key as to have GKE reconsider
https://issuetracker.google.com/issues/181042681 including this plugin
in their distribution.


#### Special notes for your reviewer:

I am unsure of the criteria to move such an annotation from alpha to
beta or GA but this plugin seems to be 5 years old and I presume its
status change was never brought up

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
The PodNodeSelector admission plugin's annotation key "scheduler.alpha.kubernetes.io/node-selector" is deprecated in favour of "scheduler.kubernetes.io/node-selector", 
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
-->
```docs

- [Usage]: https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#configuration-annotation-format

```
