### PR TITLE
Use os.CreateTemp in kubectl editor

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/util/editor/editor.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/util/editor/editor.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"math/rand"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -142,7 +141,7 @@ func (e Editor) Launch(path string) error {
 // the contents of the file after launch, any errors that occur, and the path of the
 // temporary file so the caller can clean it up as needed.
 func (e Editor) LaunchTempFile(prefix, suffix string, r io.Reader) ([]byte, string, error) {
-	f, err := tempFile(prefix, suffix)
+	f, err := os.CreateTemp("", prefix+"*"+suffix)
 	if err != nil {
 		return nil, "", err
 	}
@@ -159,30 +158,6 @@ func (e Editor) LaunchTempFile(prefix, suffix string, r io.Reader) ([]byte, stri
 	}
 	bytes, err := ioutil.ReadFile(path)
 	return bytes, path, err
-}
-
-func tempFile(prefix, suffix string) (f *os.File, err error) {
-	dir := os.TempDir()
-
-	for i := 0; i < 10000; i++ {
-		name := filepath.Join(dir, prefix+randSeq(5)+suffix)
-		f, err = os.OpenFile(name, os.O_RDWR|os.O_CREATE|os.O_EXCL, 0600)
-		if os.IsExist(err) {
-			continue
-		}
-		break
-	}
-	return
-}
-
-var letters = []rune("abcdefghijklmnopqrstuvwxyz0123456789")
-
-func randSeq(n int) string {
-	b := make([]rune, n)
-	for i := range b {
-		b[i] = letters[rand.Intn(len(letters))]
-	}
-	return string(b)
 }
 
 func platformize(linux, windows string) string {


### PR DESCRIPTION
`os.CreateTemp` seems to perform the exactly same task here, and its
implementation seems having considered many more edge cases than the
implementation here. This patch uses `os.CreateTemp` here to avoid
reinventing the wheel.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

See the top of this comment box.

#### Does this PR introduce a user-facing change?

```release-note
None
```
