### PR TITLE
implement EnqueueExtensions interface in noderesources

### DIFF
--- a/pkg/scheduler/framework/plugins/noderesources/fit.go
+++ b/pkg/scheduler/framework/plugins/noderesources/fit.go
@@ -35,6 +35,7 @@ import (
 
 var _ framework.PreFilterPlugin = &Fit{}
 var _ framework.FilterPlugin = &Fit{}
+var _ framework.EnqueueExtensions = &Fit{}
 
 const (
 	// FitName is the name of the plugin used in the plugin registry and configurations.
@@ -187,6 +188,18 @@ func getPreFilterState(cycleState *framework.CycleState) (*preFilterState, error
 		return nil, fmt.Errorf("%+v  convert to NodeResourcesFit.preFilterState error", c)
 	}
 	return s, nil
+}
+
+// EventsToRegister returns the possible events that may make a Pod
+// failed by this plugin schedulable.
+// NOTE: if in-place-update (KEP 1287) gets implemented, then PodUpdate event
+// should be registered for this plugin since a Pod update may free up resources
+// that make other Pods schedulable.
+func (f *Fit) EventsToRegister() []framework.ClusterEvent {
+	return []framework.ClusterEvent{
+		{Resource: framework.Pod, ActionType: framework.Delete},
+		{Resource: framework.Node, ActionType: framework.Add | framework.UpdateNodeAllocatable},
+	}
 }
 
 // Filter invoked at the filter extension point.


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/sig scheduling

#### What this PR does / why we need it:

Implement EnqueueExtensions interface in noderesources plugin.

**Q: Why this plugin should be interested in the specified events only?**
A: If a Pod failed by noderesources plugin, [add](https://github.com/kubernetes/kubernetes/blob/c7fef196b60856420ce3f0470acd1093ab1d9b5f/pkg/scheduler/internal/queue/scheduling_queue.go#L508-L512) or [update](https://github.com/kubernetes/kubernetes/blob/c7fef196b60856420ce3f0470acd1093ab1d9b5f/pkg/scheduler/internal/queue/scheduling_queue.go#L516-L520) event of an assigned Pod wouldn't help as that would only move Pods failed by podAffinity related plugins. But the deletion of an assign Pod would make room for the Pod. Also, adding a new Node, or capacity change of an existing Node may help making the pod schedulable.

**Q: Any performance test proving this?**
A: Locally by leveraging #98900, I designed a testcase like this:
```yaml
- name: SchedulingWithPodChurn
  workloadTemplate:
  - opcode: createNodes
    countParam: $initNodes
  - opcode: createPods
    countParam: $initPods
    podTemplatePath: config/pod-high-priority-large-cpu.yaml
    skipWaitToCompletion: true
  - opcode: churn
    mode: create
    templatePaths:
    - config/churn/service-default.yaml
    intervalMilliseconds: 1000
  - opcode: createPods
    countParam: $measurePods
    podTemplatePath: config/pod-default.yaml
    collectMetrics: true
  workloads:
  - name: 1000Nodes
    params:
      initNodes: 1000
      initPods: 200
      measurePods: 1000
  - name: 5000Nodes
    params:
      initNodes: 5000
      initPods: 1000
      measurePods: 2000
```
This test initialized 200 (1000) high-priority but unschedulable Pods, acting as the pod "churner". And then create a new Service every 1 second in a separate thread, lastly it tries to schedule 1000 (2000) low-priority Pods, and here is the perf diff showing before/after this PR:

```
+--------------------------+----------------------------------+----------+--------+---------+---------+---------+
|          METRIC          |              GROUP               | QUANTILE |  UNIT  |   OLD   |   NEW   |  DIFF   |
+--------------------------+----------------------------------+----------+--------+---------+---------+---------+
| SchedulingThroughput     | SchedulingWithPodChurn/1000Nodes | Average  | pods/s |  135.17 |  151.12 | +11.80% |
| SchedulingThroughput     | SchedulingWithPodChurn/1000Nodes | Perc50   | pods/s |   15.12 |   15.12 | +0.00%  |
| SchedulingThroughput     | SchedulingWithPodChurn/1000Nodes | Perc90   | pods/s |  473.78 |  547.75 | +15.61% |
| SchedulingThroughput     | SchedulingWithPodChurn/1000Nodes | Perc99   | pods/s |  473.78 |  537.56 | +13.46% |
| scheduler_pod_scheduling | SchedulingWithPodChurn/1000Nodes | Average  | ms     | 3846.67 | 3515.90 | -8.60%  |
| scheduler_pod_scheduling | SchedulingWithPodChurn/1000Nodes | Perc50   | ms     | 3932.50 | 3270.14 | -16.84% |
| scheduler_pod_scheduling | SchedulingWithPodChurn/1000Nodes | Perc90   | ms     | 6024.76 | 4872.85 | -19.12% |
| scheduler_pod_scheduling | SchedulingWithPodChurn/1000Nodes | Perc99   | ms     | 6880.32 | 6112.64 | -11.16% |
+--------------------------+----------------------------------+----------+--------+---------+---------+---------+
```

```
+--------------------------+----------------------------------+----------+--------+-----------+----------+----------+
|          METRIC          |              GROUP               | QUANTILE |  UNIT  |    OLD    |   NEW    |   DIFF   |
+--------------------------+----------------------------------+----------+--------+-----------+----------+----------+
| SchedulingThroughput     | SchedulingWithPodChurn/5000Nodes | Average  | pods/s |      7.17 |    54.67 | +662.10% |
| SchedulingThroughput     | SchedulingWithPodChurn/5000Nodes | Perc50   | pods/s |      0.00 |     0.00 | NaN%     |
| SchedulingThroughput     | SchedulingWithPodChurn/5000Nodes | Perc90   | pods/s |      0.00 |   276.00 | ++Inf%   |
| SchedulingThroughput     | SchedulingWithPodChurn/5000Nodes | Perc99   | pods/s |    455.00 |   557.80 | +22.59%  |
| scheduler_pod_scheduling | SchedulingWithPodChurn/5000Nodes | Average  | ms     | 273711.77 | 32765.13 | -88.03%  |
| scheduler_pod_scheduling | SchedulingWithPodChurn/5000Nodes | Perc50   | ms     | 245760.00 | 30720.00 | -87.50%  |
| scheduler_pod_scheduling | SchedulingWithPodChurn/5000Nodes | Perc90   | ms     | 311296.00 | 38912.00 | -87.50%  |
| scheduler_pod_scheduling | SchedulingWithPodChurn/5000Nodes | Perc99   | ms     | 319488.00 | 39936.00 | -87.50%  |
+--------------------------+----------------------------------+----------+--------+-----------+----------+----------+
```

**Q: Why not showing the metric `scheduler_e2e_scheduling`?**
A: `scheduler_e2e_scheduling` records the duration from starting of a scheduling cycle to the end - which doesn't show the overall duration when the pod was added to the queue. So `scheduler_pod_scheduling` makes more sense here.

**Q: Should the benchmark test base on #99228 and #99472?**
A: For this test, it's not needed as it's infeasible to measure the time of InitPods (they're unschedulable), also no preemption is involved, so it's fine to just use the first Histogratem (attempts=1) of `scheduler_pod_scheduling`.

#### Which issue(s) this PR fixes:

Part of #94009.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```