### PR TITLE
promote apiserver_request_duration_seconds to STABLE

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics.go
@@ -97,7 +97,7 @@ var (
 			// Thus we customize buckets significantly, to empower both usecases.
 			Buckets: []float64{0.05, 0.1, 0.15, 0.2, 0.25, 0.3, 0.35, 0.4, 0.45, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0,
 				1.25, 1.5, 1.75, 2.0, 2.5, 3.0, 3.5, 4.0, 4.5, 5, 6, 7, 8, 9, 10, 15, 20, 25, 30, 40, 50, 60},
-			StabilityLevel: compbasemetrics.ALPHA,
+			StabilityLevel: compbasemetrics.STABLE,
 		},
 		[]string{"verb", "dry_run", "group", "version", "resource", "subresource", "scope", "component"},
 	)

--- a/test/instrumentation/testdata/stable-metrics-list.yaml
+++ b/test/instrumentation/testdata/stable-metrics-list.yaml
@@ -1,3 +1,55 @@
+- name: apiserver_request_duration_seconds
+  help: Response latency distribution in seconds for each verb, dry run value, group,
+    version, resource, subresource, scope and component.
+  type: Histogram
+  stabilityLevel: STABLE
+  labels:
+  - component
+  - dry_run
+  - group
+  - resource
+  - scope
+  - subresource
+  - verb
+  - version
+  buckets:
+  - 0.05
+  - 0.1
+  - 0.15
+  - 0.2
+  - 0.25
+  - 0.3
+  - 0.35
+  - 0.4
+  - 0.45
+  - 0.5
+  - 0.6
+  - 0.7
+  - 0.8
+  - 0.9
+  - 1
+  - 1.25
+  - 1.5
+  - 1.75
+  - 2
+  - 2.5
+  - 3
+  - 3.5
+  - 4
+  - 4.5
+  - 5
+  - 6
+  - 7
+  - 8
+  - 9
+  - 10
+  - 15
+  - 20
+  - 25
+  - 30
+  - 40
+  - 50
+  - 60
 - name: apiserver_request_total
   help: Counter of apiserver requests broken out for each verb, dry run value, group,
     version, resource, scope, component, and HTTP response code.


### PR DESCRIPTION
This change promotes apiserver_request_duration_seconds to stable metric status. 

Change-Id: I1b050b812738719aedd7ac6f4794ec742812e12d

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This is a common metric used for SLOs/SLIs. We are promoting this to stable status to preserve that intent while shedding less useful dimensions.

#### Which issue(s) this PR fixes:

Fixes #91536

#### Special notes for your reviewer:

We went over this in the SIG Api-Machinery meeting and agreed this was appropriate.

Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```release-note
apiserver_request_duration_seconds is promoted to stable status.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
- [KEP]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-instrumentation/1209-metrics-stability
```
