### PR TITLE
kubelet_test: Deflake TestWatchFileChanged

### DIFF
--- a/pkg/kubelet/config/file_linux_test.go
+++ b/pkg/kubelet/config/file_linux_test.go
@@ -108,11 +108,16 @@ var (
 	testCases = []struct {
 		watchDir bool
 		symlink  bool
+		period   time.Duration
 	}{
-		{true, true},
-		{true, false},
-		{false, true},
-		{false, false},
+		// set the period to be long enough for the file to be changed
+		// and short enough to trigger the event
+		{true, true, 3 * time.Second},
+
+		// set the period to avoid periodic PodUpdate event
+		{true, false, 60 * time.Second},
+		{false, true, 60 * time.Second},
+		{false, false, 60 * time.Second},
 	}
 )
 
@@ -124,7 +129,7 @@ func TestWatchFileAdded(t *testing.T) {
 
 func TestWatchFileChanged(t *testing.T) {
 	for _, testCase := range testCases {
-		watchFileChanged(testCase.watchDir, testCase.symlink, t)
+		watchFileChanged(testCase.watchDir, testCase.symlink, testCase.period, t)
 	}
 }
 
@@ -275,7 +280,7 @@ func watchFileAdded(watchDir bool, symlink bool, t *testing.T) {
 	}
 }
 
-func watchFileChanged(watchDir bool, symlink bool, t *testing.T) {
+func watchFileChanged(watchDir bool, symlink bool, period time.Duration, t *testing.T) {
 	hostname := types.NodeName("random-test-hostname")
 	var testCases = getTestCases(hostname)
 
@@ -314,22 +319,23 @@ func watchFileChanged(watchDir bool, symlink bool, t *testing.T) {
 			}()
 
 			if watchDir {
-				NewSourceFile(dirName, hostname, 100*time.Millisecond, ch)
+				NewSourceFile(dirName, hostname, period, ch)
 			} else {
-				NewSourceFile(file, hostname, 100*time.Millisecond, ch)
+				NewSourceFile(file, hostname, period, ch)
 			}
+
+			// await fsnotify to be ready
+			time.Sleep(time.Second)
+
 			// expect an update by SourceFile.resetStoreFromPath()
 			expectUpdate(t, ch, testCase)
 
+			pod := testCase.pod.(*v1.Pod)
+			pod.Spec.Containers[0].Name = "image2"
+
+			testCase.expected.Pods[0].Spec.Containers[0].Name = "image2"
 			changeFile := func() {
 				// Edit the file content
-				testCase.lock.Lock()
-				defer testCase.lock.Unlock()
-
-				pod := testCase.pod.(*v1.Pod)
-				pod.Spec.Containers[0].Name = "image2"
-
-				testCase.expected.Pods[0].Spec.Containers[0].Name = "image2"
 				if symlink {
 					file = testCase.writeToFile(linkedDirName, fileName, t)
 					return
@@ -374,8 +380,6 @@ func expectUpdate(t *testing.T, ch chan interface{}, testCase *testCase) {
 				}
 			}
 
-			testCase.lock.Lock()
-			defer testCase.lock.Unlock()
 			if !apiequality.Semantic.DeepEqual(testCase.expected, update) {
 				t.Fatalf("%s: Expected: %#v, Got: %#v", testCase.desc, testCase.expected, update)
 			}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind failing-test
/kind flake

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Issue: https://github.com/kubernetes/kubernetes/issues/99845

This PR deflakes `TestWatchFileChanged` by
- Adjust the period of triggering PodUpdate event
- Fix lock race between 'changeFile' and 'expectUpdate'
- Await fsnotify to be ready

Regarding the data race mentioned in https://github.com/kubernetes/kubernetes/issues/99845,
the data race occurred because `t.Fatalf` was called inside of `go changeFile()`, after the test already had failed. There will be no data race if the test does not fail.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

Verify:
```bash
$ go test -c -race ./pkg/kubelet/config
$ stress -p 24 ./config.test -test.run=TestWatchFileChanged -test.v -test.cpu=1
...
14m5s: 65624 runs so far, 0 failures
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
