### PR TITLE
implement EnqueueExtensions interface in taint toleration scheduling

### DIFF
--- a/pkg/scheduler/framework/plugins/tainttoleration/taint_toleration.go
+++ b/pkg/scheduler/framework/plugins/tainttoleration/taint_toleration.go
@@ -35,6 +35,7 @@ type TaintToleration struct {
 var _ framework.FilterPlugin = &TaintToleration{}
 var _ framework.PreScorePlugin = &TaintToleration{}
 var _ framework.ScorePlugin = &TaintToleration{}
+var _ framework.EnqueueExtensions = &TaintToleration{}
 
 const (
 	// Name is the name of the plugin used in the plugin registry and configurations.
@@ -48,6 +49,14 @@ const (
 // Name returns name of the plugin. It is used in logs, etc.
 func (pl *TaintToleration) Name() string {
 	return Name
+}
+
+// EventsToRegister returns the possible events that may make a Pod
+// failed by this plugin schedulable.
+func (f *TaintToleration) EventsToRegister() []framework.ClusterEvent {
+	return []framework.ClusterEvent{
+		{Resource: framework.Node, ActionType: framework.Add | framework.UpdateNodeTaint},
+	}
 }
 
 // Filter invoked at the filter extension point.


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
/sig scheduling

#### What this PR does / why we need it:
Implement EnqueueExtensions interface in  taint toleration plugin.

#### Which issue(s) this PR fixes:

Part of #94009

#### Special notes for your reviewer:
**Q: Why this plugin should be interested in the specified events only?**
**A:** If a Pod failed by taint/toleration plugin, add/deleted or update event of an assigned Pod wouldn't help as that would only move Pods failed by podAffinity related plugins. But the node taint update would make node availble for the Pod. Also, adding a new Node, or capacity change of an existing Node may help to make the pod schedulable.

**Q: Any performance test proving this?**
**A:** Locally by leveraging #98900, I designed a testcase like this:
```
- name: SchedulingWithTolerationTaint
  workloadTemplate:
  - opcode: createNodes
    countParam: $initNodes
    templatePaths:
    - config/churn/node-with-taint.yaml
  - opcode: createPods
    countParam: $initPods
    podTemplatePath: config/pod-high-priority.yaml // without node affinity
    skipWaitToCompletion: true
  - opcode: churn
    mode: recreate
    number: 1
    templatePaths:
    - config/churn/service-default.yaml
    intervalMilliseconds: 1000
  - opcode: createPods
    countParam: $measurePods
    podTemplatePath: config/pod-with-tolerations.yaml
    collectMetrics: true
  workloads:
  - name: 1000Nodes
    params:
      initNodes: 1000
      initPods: 200
      measurePods: 1000
  - name: 5000Nodes
    params:
      initNodes: 5000
      initPods: 1000
      measurePods: 2000
Merge state
```

```
➜  k8s-sched-perf-stat git:(main) ✗ go run *.go /tmp/old.txt /tmp/new.txt
+--------------------------+-----------------------------------------+----------+--------+---------+---------+---------+
|          METRIC          |                  GROUP                  | QUANTILE |  UNIT  |   OLD   |   NEW   |  DIFF   |
+--------------------------+-----------------------------------------+----------+--------+---------+---------+---------+
| SchedulingThroughput     | SchedulingWithTolerationTaint/1000Nodes | Average  | pods/s |  153.58 |  170.40 | +10.95% |
| SchedulingThroughput     | SchedulingWithTolerationTaint/1000Nodes | Perc50   | pods/s |  165.56 |  168.11 | +1.54%  |
| SchedulingThroughput     | SchedulingWithTolerationTaint/1000Nodes | Perc90   | pods/s |  265.89 |  307.11 | +15.50% |
| SchedulingThroughput     | SchedulingWithTolerationTaint/1000Nodes | Perc99   | pods/s |  265.89 |  307.11 | +15.50% |
| scheduler_e2e_scheduling | SchedulingWithTolerationTaint/1000Nodes | Average  | ms     |  322.83 |  369.86 | +14.57% |
| scheduler_e2e_scheduling | SchedulingWithTolerationTaint/1000Nodes | Perc50   | ms     |   23.04 |   22.47 | -2.47%  |
| scheduler_e2e_scheduling | SchedulingWithTolerationTaint/1000Nodes | Perc90   | ms     | 1271.11 | 1362.43 | +7.18%  |
| scheduler_e2e_scheduling | SchedulingWithTolerationTaint/1000Nodes | Perc99   | ms     | 1746.20 | 1809.32 | +3.61%  |
| scheduler_pod_scheduling | SchedulingWithTolerationTaint/1000Nodes | Average  | ms     |  997.76 |  894.71 | -10.33% |
| scheduler_pod_scheduling | SchedulingWithTolerationTaint/1000Nodes | Perc50   | ms     |  834.44 |  735.28 | -11.88% |
| scheduler_pod_scheduling | SchedulingWithTolerationTaint/1000Nodes | Perc90   | ms     | 2276.28 | 2105.07 | -7.52%  |
| scheduler_pod_scheduling | SchedulingWithTolerationTaint/1000Nodes | Perc99   | ms     | 2843.59 | 2788.97 | -1.92%  |
| SchedulingThroughput     | SchedulingWithTolerationTaint/5000Nodes | Average  | pods/s |  168.87 |  183.73 | +8.80%  |
| SchedulingThroughput     | SchedulingWithTolerationTaint/5000Nodes | Perc50   | pods/s |  183.56 |  193.20 | +5.25%  |
| SchedulingThroughput     | SchedulingWithTolerationTaint/5000Nodes | Perc90   | pods/s |  243.11 |  259.70 | +6.82%  |
| SchedulingThroughput     | SchedulingWithTolerationTaint/5000Nodes | Perc99   | pods/s |  251.62 |  272.00 | +8.10%  |
| scheduler_e2e_scheduling | SchedulingWithTolerationTaint/5000Nodes | Average  | ms     |  352.06 |  323.69 | -8.06%  |
| scheduler_e2e_scheduling | SchedulingWithTolerationTaint/5000Nodes | Perc50   | ms     |   24.48 |   23.81 | -2.74%  |
| scheduler_e2e_scheduling | SchedulingWithTolerationTaint/5000Nodes | Perc90   | ms     | 1510.32 | 1471.32 | -2.58%  |
| scheduler_e2e_scheduling | SchedulingWithTolerationTaint/5000Nodes | Perc99   | ms     | 2205.06 | 1909.45 | -13.41% |
| scheduler_pod_scheduling | SchedulingWithTolerationTaint/5000Nodes | Average  | ms     | 2032.59 | 2037.57 | +0.24%  |
| scheduler_pod_scheduling | SchedulingWithTolerationTaint/5000Nodes | Perc50   | ms     | 2054.50 | 1946.82 | -5.24%  |
| scheduler_pod_scheduling | SchedulingWithTolerationTaint/5000Nodes | Perc90   | ms     | 4361.02 | 4515.75 | +3.55%  |
| scheduler_pod_scheduling | SchedulingWithTolerationTaint/5000Nodes | Perc99   | ms     | 4934.51 | 5338.13 | +8.18%  |
+--------------------------+-----------------------------------------+----------+--------+---------+---------+---------+
➜  k8s-sched-perf-stat git:(main) ✗ go run *.go /tmp/old.txt
+--------------------------+-----------------------------------------+----------+--------+---------+
|          METRIC          |                  GROUP                  | QUANTILE |  UNIT  | MEDIAN  |
+--------------------------+-----------------------------------------+----------+--------+---------+
| SchedulingThroughput     | SchedulingWithTolerationTaint/1000Nodes | Average  | pods/s |  153.58 |
| SchedulingThroughput     | SchedulingWithTolerationTaint/1000Nodes | Perc50   | pods/s |  165.56 |
| SchedulingThroughput     | SchedulingWithTolerationTaint/1000Nodes | Perc90   | pods/s |  265.89 |
| SchedulingThroughput     | SchedulingWithTolerationTaint/1000Nodes | Perc99   | pods/s |  265.89 |
| scheduler_e2e_scheduling | SchedulingWithTolerationTaint/1000Nodes | Average  | ms     |  322.83 |
| scheduler_e2e_scheduling | SchedulingWithTolerationTaint/1000Nodes | Perc50   | ms     |   23.04 |
| scheduler_e2e_scheduling | SchedulingWithTolerationTaint/1000Nodes | Perc90   | ms     | 1271.11 |
| scheduler_e2e_scheduling | SchedulingWithTolerationTaint/1000Nodes | Perc99   | ms     | 1746.20 |
| scheduler_pod_scheduling | SchedulingWithTolerationTaint/1000Nodes | Average  | ms     |  997.76 |
| scheduler_pod_scheduling | SchedulingWithTolerationTaint/1000Nodes | Perc50   | ms     |  834.44 |
| scheduler_pod_scheduling | SchedulingWithTolerationTaint/1000Nodes | Perc90   | ms     | 2276.28 |
| scheduler_pod_scheduling | SchedulingWithTolerationTaint/1000Nodes | Perc99   | ms     | 2843.59 |
| SchedulingThroughput     | SchedulingWithTolerationTaint/5000Nodes | Average  | pods/s |  168.87 |
| SchedulingThroughput     | SchedulingWithTolerationTaint/5000Nodes | Perc50   | pods/s |  183.56 |
| SchedulingThroughput     | SchedulingWithTolerationTaint/5000Nodes | Perc90   | pods/s |  243.11 |
| SchedulingThroughput     | SchedulingWithTolerationTaint/5000Nodes | Perc99   | pods/s |  251.62 |
| scheduler_e2e_scheduling | SchedulingWithTolerationTaint/5000Nodes | Average  | ms     |  352.06 |
| scheduler_e2e_scheduling | SchedulingWithTolerationTaint/5000Nodes | Perc50   | ms     |   24.48 |
| scheduler_e2e_scheduling | SchedulingWithTolerationTaint/5000Nodes | Perc90   | ms     | 1510.32 |
| scheduler_e2e_scheduling | SchedulingWithTolerationTaint/5000Nodes | Perc99   | ms     | 2205.06 |
| scheduler_pod_scheduling | SchedulingWithTolerationTaint/5000Nodes | Average  | ms     | 2032.59 |
| scheduler_pod_scheduling | SchedulingWithTolerationTaint/5000Nodes | Perc50   | ms     | 2054.50 |
| scheduler_pod_scheduling | SchedulingWithTolerationTaint/5000Nodes | Perc90   | ms     | 4361.02 |
| scheduler_pod_scheduling | SchedulingWithTolerationTaint/5000Nodes | Perc99   | ms     | 4934.51 |
+--------------------------+-----------------------------------------+----------+--------+---------+
```


Further yaml samples.
```
cat test/integration/scheduler_perf/config/pod-with-tolerations.yaml
apiVersion: v1
kind: Pod
metadata:
  generateName: node-toleration-
spec:
  containers:
  - image: k8s.gcr.io/pause:3.4.1
    name: pause
    ports:
    - containerPort: 80
    resources:
      limits:
        cpu: 100m
        memory: 500Mi
      requests:
        cpu: 100m
        memory: 500Mi
  tolerations:
  - key: "key1"
    operator: "Equal"
    value: "value1"
    effect: "NoExecute"
    tolerationSeconds: 3600

cat test/integration/scheduler_perf/config/node-with-taint.yaml
apiVersion: v1
kind: Node
metadata:
  generateName: scheduler-perf-
spec:
  taints:
  - key: "foo1"
    value: "value1"
    effect: "NoExecute"
status:
  capacity:
    pods: "110"
    cpu: "4"
    memory: 32Gi
  conditions:
    - status: "True"
      type: Ready
  phase: Running
```

WIP
- test case 
- perf diff
- scheduler_e2e_scheduling
- bench mark

#### Does this PR introduce a user-facing change?

```release-note
NONE
```