### PR TITLE
update agnhost readme

### DIFF
--- a/test/images/agnhost/README.md
+++ b/test/images/agnhost/README.md
@@ -292,14 +292,14 @@ Examples:
 
 ```console
 docker run -i \
-  k8s.gcr.io/e2e-test-images/agnhost:2.14 \
+  k8s.gcr.io/e2e-test-images/agnhost:2.29 \
   logs-generator --log-lines-total 10 --run-duration 1s
 ```
 
 ```console
 kubectl run logs-generator \
   --generator=run-pod/v1 \
-  --image=k8s.gcr.io/e2e-test-images/agnhost:2.14 \
+  --image=k8s.gcr.io/e2e-test-images/agnhost:2.29 \
   --restart=Never \
   -- logs-generator -t 10 -d 1s
 ```


### PR DESCRIPTION

/kind documentation
```release-note
NONE
```

Update the version in the agnhost README just to trigger the postubmit job, that is failing due to https://github.com/kubernetes/kubernetes/pull/99889