### PR TITLE
add label.NewValidatedRequirement  method

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/labels/selector_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/labels/selector_test.go
@@ -1000,3 +1000,15 @@ func TestRequirementEqual(t *testing.T) {
 		})
 	}
 }
+
+func BenchmarkLabelMatch(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		NewRequirement("environment", selection.NotIn, []string{"dev", "pro"})
+	}
+}
+
+func BenchmarkValidatedLabelMatch(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		NewValidatedRequirement("environment", selection.NotIn, []string{"dev", "pro"})
+	}
+}


### PR DESCRIPTION
Signed-off-by: Junjun Li <junjunli666@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design



Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

The existing labels.Requirement only provides a new method, in which the rules of key and value are verified. However, in some cases, the program has finished validating key and value validation. Therefore, this issue gives a scheme that supports validated request construction method.


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

here is the banchmark test :
```
zhoushua@B-H3KJLVDL-0114 labels % go test ./ -bench=. -count=10
goos: darwin
goarch: amd64
pkg: k8s.io/apimachinery/pkg/labels
BenchmarkLabelMatch-8                     488554              2257 ns/op
BenchmarkLabelMatch-8                     530461              2544 ns/op
BenchmarkLabelMatch-8                     512385              2306 ns/op
BenchmarkLabelMatch-8                     569864              2585 ns/op
BenchmarkLabelMatch-8                     520761              2285 ns/op
BenchmarkLabelMatch-8                     490678              2308 ns/op
BenchmarkLabelMatch-8                     584233              2481 ns/op
BenchmarkLabelMatch-8                     508418              2370 ns/op
BenchmarkLabelMatch-8                     452300              2396 ns/op
BenchmarkLabelMatch-8                     501835              3299 ns/op
BenchmarkValidatedLabelMatch-8           7980492               149 ns/op
BenchmarkValidatedLabelMatch-8           8477766               137 ns/op
BenchmarkValidatedLabelMatch-8           8587405               135 ns/op
BenchmarkValidatedLabelMatch-8           8510408               138 ns/op
BenchmarkValidatedLabelMatch-8           8625061               143 ns/op
BenchmarkValidatedLabelMatch-8           8249774               141 ns/op
BenchmarkValidatedLabelMatch-8           7728351               146 ns/op
BenchmarkValidatedLabelMatch-8           8354503               145 ns/op
BenchmarkValidatedLabelMatch-8           8684895               141 ns/op
BenchmarkValidatedLabelMatch-8           8887164               131 ns/op
PASS
ok      k8s.io/apimachinery/pkg/labels  57.875s
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
