### PR TITLE
Delete the hugePages capacity from the memory resource capacity

### DIFF
--- a/pkg/kubelet/cm/container_manager_linux.go
+++ b/pkg/kubelet/cm/container_manager_linux.go
@@ -251,6 +251,10 @@ func NewContainerManager(mountUtil mount.Interface, cadvisorInterface cadvisor.I
 	for k, v := range capacity {
 		internalCapacity[k] = v
 	}
+
+	// remove hugePage capacity from memory capacity
+	internalCapacity[v1.ResourceMemory] = GetAllocatableMemory(capacity)
+
 	pidlimits, err := pidlimit.Stats()
 	if err == nil && pidlimits != nil && pidlimits.MaxPID != nil {
 		internalCapacity[pidlimit.PIDs] = *resource.NewQuantity(

--- a/pkg/kubelet/nodestatus/setters.go
+++ b/pkg/kubelet/nodestatus/setters.go
@@ -371,8 +371,10 @@ func MachineInfo(nodeName string,
 				delete(node.Status.Allocatable, k)
 			}
 		}
+		capacity := node.Status.Capacity.DeepCopy()
+		capacity[v1.ResourceMemory] = cm.GetAllocatableMemory(capacity)
 		allocatableReservation := nodeAllocatableReservationFunc()
-		for k, v := range node.Status.Capacity {
+		for k, v := range capacity {
 			value := v.DeepCopy()
 			if res, exists := allocatableReservation[k]; exists {
 				value.Sub(res)
@@ -389,19 +391,6 @@ func MachineInfo(nodeName string,
 				klog.V(2).InfoS("Updated allocatable", "device", k, "allocatable", v.Value())
 			}
 			node.Status.Allocatable[k] = v
-		}
-		// for every huge page reservation, we need to remove it from allocatable memory
-		for k, v := range node.Status.Capacity {
-			if v1helper.IsHugePageResourceName(k) {
-				allocatableMemory := node.Status.Allocatable[v1.ResourceMemory]
-				value := v.DeepCopy()
-				allocatableMemory.Sub(value)
-				if allocatableMemory.Sign() < 0 {
-					// Negative Allocatable resources don't make sense.
-					allocatableMemory.Set(0)
-				}
-				node.Status.Allocatable[v1.ResourceMemory] = allocatableMemory
-			}
 		}
 		return nil
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
On linux, If a node contains hugePages, the memory.limit_in_bytes of kubepods cgroup contains the capacity of hugePages, which causes problems with the oomkiller.

on a node with 512's 2Mi hugePages,
![image](https://user-images.githubusercontent.com/1468240/110327152-9330f700-8054-11eb-94aa-7dbdb7d18522.png)

the memory capacity of the node is 8152412Ki, I think the memory should be less than 7G
![image](https://user-images.githubusercontent.com/1468240/110327281-bbb8f100-8054-11eb-9e76-90e3f46a9c5b.png)

the memory.limit_in_bytes of kubepods.slice cgroup is 8348069888， I think the  memory.limit_in_bytes should be less than 7G too.
![image](https://user-images.githubusercontent.com/1468240/110327531-0f2b3f00-8055-11eb-8dd9-f1a2de40f35d.png)

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Delete the hugePages capacity from the memory resource capacity on the node with hugePages.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
