### PR TITLE
Promote ReplicaSet Replace and Patch Test +2 Endpoints

### DIFF
--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -704,6 +704,13 @@
     the Job MUST execute to completion.
   release: v1.16
   file: test/e2e/apps/job.go
+- testname: ReplicaSet, is created, Replaced and Patched
+  codename: '[sig-apps] ReplicaSet Replace and Patch tests [Conformance]'
+  description: Create a ReplicaSet (RS) with a single Pod. The Pod MUST be verified
+    that it is running. The RS MUST scale to two replicas and verify the scale count
+    The RS MUST be patched and verify that patch succeeded.
+  release: v1.21
+  file: test/e2e/apps/replica_set.go
 - testname: ReplicaSet, completes the scaling of a ReplicaSet subresource
   codename: '[sig-apps] ReplicaSet Replicaset should have a working scale subresource
     [Conformance]'

--- a/test/e2e/apps/replica_set.go
+++ b/test/e2e/apps/replica_set.go
@@ -131,7 +131,14 @@ var _ = SIGDescribe("ReplicaSet", func() {
 		testRSScaleSubresources(f)
 	})
 
-	ginkgo.It("ReplicaSet Replace and Patch tests", func() {
+	/*
+		Release: v1.21
+		Testname: ReplicaSet, is created, Replaced and Patched
+		Description: Create a ReplicaSet (RS) with a single Pod. The Pod MUST be verified
+		that it is running. The RS MUST scale to two replicas and verify the scale count
+		The RS MUST be patched and verify that patch succeeded.
+	*/
+	framework.ConformanceIt("Replace and Patch tests", func() {
 		testRSLifeCycle(f)
 	})
 })


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it:**
This PR adds a test to test the following untested endpoints:
- replaceAppsV1NamespacedReplicaSet
- patchAppsV1NamespacedReplicaSet

**Which issue(s) this PR fixes:**
Fixes #99134

**Testgrid Link:**
[Link](https://testgrid.k8s.io/sig-release-master-blocking#gce-cos-master-default&width=5&include-filter-by-regex=ReplicaSet%20Replace%20and%20Patch%20tests)

**Special notes for your reviewer:**
Adds +2 endpoint test coverage (good for conformance)

**Does this PR introduce a user-facing change?:**
```
NONE

```

**Release note:**
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:**
```
NONE

```

/sig testing
/sig architecture
/sig apps
/area conformance