### PR TITLE
switch most e2e tests to storage/v1 over v1beta1

### DIFF
--- a/test/integration/scheduler_perf/scheduler_perf_legacy_test.go
+++ b/test/integration/scheduler_perf/scheduler_perf_legacy_test.go
@@ -23,7 +23,7 @@ import (
 	"time"
 
 	v1 "k8s.io/api/core/v1"
-	storagev1beta1 "k8s.io/api/storage/v1beta1"
+	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
@@ -162,7 +162,7 @@ func BenchmarkSchedulingMigratedInTreePVs(b *testing.B) {
 		v1.ResourceName(driverKey): fmt.Sprintf("%d", util.DefaultMaxEBSVolumes),
 	}
 	var count int32 = util.DefaultMaxEBSVolumes
-	csiAllocatable := map[string]*storagev1beta1.VolumeNodeResources{
+	csiAllocatable := map[string]*storagev1.VolumeNodeResources{
 		testCSIDriver: {
 			Count: &count,
 		},
@@ -193,7 +193,7 @@ func BenchmarkSchedulingCSIPVs(b *testing.B) {
 		v1.ResourceName(driverKey): fmt.Sprintf("%d", util.DefaultMaxEBSVolumes),
 	}
 	var count int32 = util.DefaultMaxEBSVolumes
-	csiAllocatable := map[string]*storagev1beta1.VolumeNodeResources{
+	csiAllocatable := map[string]*storagev1.VolumeNodeResources{
 		testCSIDriver: {
 			Count: &count,
 		},


### PR DESCRIPTION
v1beta1 is removed in 1.22.  This updates nearly all e2e tests to use the current API.  It is important to test the API we want people to use and this eases the opening of 1.22

/kind bug
/priority important-soon
@kubernetes/sig-storage-bugs 

```release-note
NONE
```