### PR TITLE
Remove active pods past completions

### DIFF
--- a/pkg/controller/job/job_controller_test.go
+++ b/pkg/controller/job/job_controller_test.go
@@ -364,7 +364,7 @@ func TestControllerSyncJob(t *testing.T) {
 			expectedCondition:       &jobConditionComplete,
 			expectedConditionStatus: v1.ConditionTrue,
 		},
-		"more active pods than completions": {
+		"more active pods than parallelism": {
 			parallelism:       2,
 			completions:       5,
 			backoffLimit:      6,
@@ -372,6 +372,17 @@ func TestControllerSyncJob(t *testing.T) {
 			activePods:        10,
 			expectedDeletions: 8,
 			expectedActive:    2,
+		},
+		"more active pods than remaining completions": {
+			parallelism:       3,
+			completions:       4,
+			backoffLimit:      6,
+			jobKeyForget:      true,
+			activePods:        3,
+			succeededPods:     2,
+			expectedDeletions: 1,
+			expectedActive:    2,
+			expectedSucceeded: 2,
 		},
 		"status change": {
 			parallelism:       2,


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

The job controller might have extra pods when it gets restarted and the informers cache didn't see all pod updates, or if the user changes the parallelism.
However, the removal is only applied based on parallelism, ignoring completed pods.
In this PR, we consider the minimum of parallelism and remaining completions to remove pods. We also wait for active pods to be removed before declaring the job completed.

#### Which issue(s) this PR fixes:

This is option 2 of https://github.com/kubernetes/kubernetes/issues/28486#issuecomment-791624490

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
The job controller removes running pods when the number of completions was achieved.
```