### PR TITLE
Check for empty field name in pod.spec.imagePullSecrets[]

### DIFF
--- a/pkg/apis/core/validation/validation.go
+++ b/pkg/apis/core/validation/validation.go
@@ -3054,6 +3054,9 @@ func validateImagePullSecrets(imagePullSecrets []core.LocalObjectReference, fldP
 		if !reflect.DeepEqual(strippedRef, currPullSecret) {
 			allErrors = append(allErrors, field.Invalid(idxPath, currPullSecret, "only name may be set"))
 		}
+		if len(currPullSecret.Name) == 0 {
+			allErrors = append(allErrors, field.Required(idxPath.Child("name"), "name cannot be empty"))
+		}
 	}
 	return allErrors
 }

--- a/pkg/apis/core/validation/validation_test.go
+++ b/pkg/apis/core/validation/validation_test.go
@@ -13914,6 +13914,48 @@ func TestValidateResourceNames(t *testing.T) {
 	}
 }
 
+func TestValidateImagePullSecrets(t *testing.T) {
+	testCases := []struct {
+		name             string
+		success          bool
+		imagePullSecrets []core.LocalObjectReference
+	}{
+		{
+			name:             "empty-list",
+			success:          true,
+			imagePullSecrets: []core.LocalObjectReference{},
+		},
+		{
+			name:    "entry-with-empty-name",
+			success: false,
+			imagePullSecrets: []core.LocalObjectReference{
+				{
+					Name: "",
+				},
+			},
+		},
+		{
+			name:    "entry-containing-just-whitespaces-in-name",
+			success: true,
+			imagePullSecrets: []core.LocalObjectReference{
+				{
+					Name: " ",
+				},
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		errs := validateImagePullSecrets(testCase.imagePullSecrets, field.NewPath("field"))
+
+		if len(errs) != 0 && testCase.success {
+			t.Errorf("Case %v, unexpected error: %v", testCase.name, errs)
+		} else if len(errs) == 0 && !testCase.success {
+			t.Errorf("Case %v, should have an error", testCase.name)
+		}
+	}
+}
+
 func getResourceList(cpu, memory string) core.ResourceList {
 	res := core.ResourceList{}
 	if cpu != "" {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Adds a check to verify that pod.spec.imagePullSecrets doesn't contain any elements with empty name fields.
Right now, k8s users are able to create a pod and add an element with an empty name to imagePullSecrets but they cannot update it afterwards with the default patch strategy (strategic merge patch) as it requires the merge key "name".
This PR changes this behaviour, the user will receive an error upfront when trying to create such a pod.

Example:

You can run `kubectl apply -f` once but the second time you're presented with the error in the github issue.

```apiVersion: apps/v1
kind: Deployment
metadata:
  labels:
    app: nginx
  name: nginx
spec:
  replicas: 1
  selector:
    matchLabels:
      app: nginx
  template:
    metadata:
      labels:
        app: nginx
    spec:
      containers:
      - image: nginx
        name: nginx
      imagePullSecrets: 
      - name:
```
#### Which issue(s) this PR fixes:
Fixes #98963

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
