### PR TITLE
Update containerd config for gce

### DIFF
--- a/cluster/gce/windows/k8s-node-setup.psm1
+++ b/cluster/gce/windows/k8s-node-setup.psm1
@@ -1587,8 +1587,16 @@ function Configure_Containerd {
   $config_dir = [System.IO.Path]::GetDirectoryName($config_path)
   New-Item $config_dir -ItemType 'directory' -Force | Out-Null
   Set-Content ${config_path} @"
+[plugins.scheduler]
+  schedule_delay = '0s'
+  startup_delay = '0s'
 [plugins.cri]
   sandbox_image = 'INFRA_CONTAINER_IMAGE'
+[plugins.cri.containerd]
+  snapshotter = 'windows'
+  default_runtime_name = 'runhcs-wcow-process'
+  disable_snapshot_annotations = true
+  discard_unpacked_layers = true
 [plugins.cri.cni]
   bin_dir = 'CNI_BIN_DIR'
   conf_dir = 'CNI_CONF_DIR'


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Updating containerd config (gce windows startup script) to:
- Set (discard_unpacked_layers=true) to avoid GC labels kept on layers, in which prevents the cleanup of uncompressed content. this leads to additional disk space used by containerd. As only one snapshotter is used, clean-up after pulls shouldn't have implications.
- Disable annotations passed to snapshotter (disable_snapshot_annotations=true), as it's not required (lazy loading is not utilized).
- Set the the GC scheduler parameters, with no delay at startup.
- Explicitly setting the default runtime and snapshotter used. 


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

No


```release-note
NONE
```
