### PR TITLE
show output param "name" in kubectl get --help usage

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/get/get.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/get/get.go
@@ -156,7 +156,7 @@ func NewCmdGet(parent string, f cmdutil.Factory, streams genericclioptions.IOStr
 	o := NewGetOptions(parent, streams)
 
 	cmd := &cobra.Command{
-		Use:                   "get [(-o|--output=)json|yaml|wide|custom-columns=...|custom-columns-file=...|go-template=...|go-template-file=...|jsonpath=...|jsonpath-file=...] (TYPE[.VERSION][.GROUP] [NAME | -l label] | TYPE[.VERSION][.GROUP]/NAME ...) [flags]",
+		Use:                   fmt.Sprintf("get [(-o|--output=)%s] (TYPE[.VERSION][.GROUP] [NAME | -l label] | TYPE[.VERSION][.GROUP]/NAME ...) [flags]", strings.Join(o.PrintFlags.AllowedFormats(), "|")),
 		DisableFlagsInUseLine: true,
 		Short:                 i18n.T("Display one or many resources"),
 		Long:                  getLong + "\n\n" + cmdutil.SuggestAPIResources(parent),

--- a/staging/src/k8s.io/kubectl/pkg/cmd/get/get_flags.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/get/get_flags.go
@@ -17,6 +17,7 @@ limitations under the License.
 package get
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -160,7 +161,7 @@ func (f *PrintFlags) AddFlags(cmd *cobra.Command) {
 	f.CustomColumnsFlags.AddFlags(cmd)
 
 	if f.OutputFormat != nil {
-		cmd.Flags().StringVarP(f.OutputFormat, "output", "o", *f.OutputFormat, "Output format. One of: json|yaml|wide|name|custom-columns=...|custom-columns-file=...|go-template=...|go-template-file=...|jsonpath=...|jsonpath-file=... See custom columns [http://kubernetes.io/docs/user-guide/kubectl-overview/#custom-columns], golang template [http://golang.org/pkg/text/template/#pkg-overview] and jsonpath template [http://kubernetes.io/docs/user-guide/jsonpath].")
+		cmd.Flags().StringVarP(f.OutputFormat, "output", "o", *f.OutputFormat, fmt.Sprintf("Output format. One of: %s See custom columns [http://kubernetes.io/docs/user-guide/kubectl-overview/#custom-columns], golang template [http://golang.org/pkg/text/template/#pkg-overview] and jsonpath template [http://kubernetes.io/docs/user-guide/jsonpath].", strings.Join(f.AllowedFormats(), "|")))
 	}
 	if f.NoHeaders != nil {
 		cmd.Flags().BoolVar(f.NoHeaders, "no-headers", *f.NoHeaders, "When using the default or custom-column output format, don't print headers (default print headers).")


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation


#### What this PR does / why we need it:

Show missing "name" in "--output" section of Usage in kubectl get --help

#### Which issue(s) this PR fixes:
Fixes https://github.com/kubernetes/kubectl/issues/1029

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

