### PR TITLE
Fix batch/v1 CronJob support in create, describe and polymorphichelpers

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_cronjob_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_cronjob_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 
 	batchv1 "k8s.io/api/batch/v1"
-	batchv1beta1 "k8s.io/api/batch/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -33,20 +32,20 @@ func TestCreateCronJob(t *testing.T) {
 		command  []string
 		schedule string
 		restart  string
-		expected *batchv1beta1.CronJob
+		expected *batchv1.CronJob
 	}{
 		"just image and OnFailure restart policy": {
 			image:    "busybox",
 			schedule: "0/5 * * * ?",
 			restart:  "OnFailure",
-			expected: &batchv1beta1.CronJob{
-				TypeMeta: metav1.TypeMeta{APIVersion: batchv1beta1.SchemeGroupVersion.String(), Kind: "CronJob"},
+			expected: &batchv1.CronJob{
+				TypeMeta: metav1.TypeMeta{APIVersion: batchv1.SchemeGroupVersion.String(), Kind: "CronJob"},
 				ObjectMeta: metav1.ObjectMeta{
 					Name: cronjobName,
 				},
-				Spec: batchv1beta1.CronJobSpec{
+				Spec: batchv1.CronJobSpec{
 					Schedule: "0/5 * * * ?",
-					JobTemplate: batchv1beta1.JobTemplateSpec{
+					JobTemplate: batchv1.JobTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
 							Name: cronjobName,
 						},
@@ -72,14 +71,14 @@ func TestCreateCronJob(t *testing.T) {
 			command:  []string{"date"},
 			schedule: "0/5 * * * ?",
 			restart:  "Never",
-			expected: &batchv1beta1.CronJob{
-				TypeMeta: metav1.TypeMeta{APIVersion: batchv1beta1.SchemeGroupVersion.String(), Kind: "CronJob"},
+			expected: &batchv1.CronJob{
+				TypeMeta: metav1.TypeMeta{APIVersion: batchv1.SchemeGroupVersion.String(), Kind: "CronJob"},
 				ObjectMeta: metav1.ObjectMeta{
 					Name: cronjobName,
 				},
-				Spec: batchv1beta1.CronJobSpec{
+				Spec: batchv1.CronJobSpec{
 					Schedule: "0/5 * * * ?",
-					JobTemplate: batchv1beta1.JobTemplateSpec{
+					JobTemplate: batchv1.JobTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
 							Name: cronjobName,
 						},

--- a/staging/src/k8s.io/kubectl/pkg/polymorphichelpers/updatepodspec.go
+++ b/staging/src/k8s.io/kubectl/pkg/polymorphichelpers/updatepodspec.go
@@ -81,6 +81,8 @@ func updatePodSpecForObject(obj runtime.Object, fn func(*v1.PodSpec) error) (boo
 		// CronJob
 	case *batchv1beta1.CronJob:
 		return true, fn(&t.Spec.JobTemplate.Spec.Template.Spec)
+	case *batchv1.CronJob:
+		return true, fn(&t.Spec.JobTemplate.Spec.Template.Spec)
 
 	default:
 		return false, fmt.Errorf("the object is not a pod or does not have a pod template: %T", t)

--- a/staging/src/k8s.io/kubectl/pkg/polymorphichelpers/updatepodspec_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/polymorphichelpers/updatepodspec_test.go
@@ -103,6 +103,10 @@ func TestUpdatePodSpecForObject(t *testing.T) {
 			expect: true,
 		},
 		{
+			object: &batchv1.CronJob{},
+			expect: true,
+		},
+		{
 			object:    &v1.Node{},
 			expect:    false,
 			expectErr: true,


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
/sig cli
/priority backlog
/milestone v1.21

#### What this PR does / why we need it:
This fixes the remaining bits in kubectl to fully support batch/v1 CronJob as described in https://github.com/kubernetes/enhancements/issues/19 and complete description from https://github.com/kubernetes/enhancements/tree/master/keps/sig-apps/19-Graduate-CronJob-to-Stable 

#### Special notes for your reviewer:
/assign @ingvagabund 

#### Does this PR introduce a user-facing change?
```release-note
NONE
```