### PR TITLE
logcheck: check Windows files

### DIFF
--- a/hack/verify-structured-logging.sh
+++ b/hack/verify-structured-logging.sh
@@ -52,7 +52,8 @@ done < <(cat "${migrated_packages_file}")
 # TODO: Improve concurrancy here
 ret=0
 for package in "${migrated_packages[@]}"; do
-  logcheck "$KUBE_ROOT/$package" || ret=$?
+    GOOS=linux    logcheck "$KUBE_ROOT/$package" || ret=$?
+    GOOS=windows  logcheck "$KUBE_ROOT/$package" || ret=$?
 done
 
 if [ $ret -eq 0 ]; then

--- a/pkg/kubelet/dockershim/network/cni/cni_windows.go
+++ b/pkg/kubelet/dockershim/network/cni/cni_windows.go
@@ -54,9 +54,9 @@ func (plugin *cniNetworkPlugin) GetPodNetworkStatus(namespace string, name strin
 	cniTimeoutCtx, cancelFunc := context.WithTimeout(context.Background(), network.CNITimeoutSec*time.Second)
 	defer cancelFunc()
 	result, err := plugin.addToNetwork(cniTimeoutCtx, plugin.getDefaultNetwork(), name, namespace, id, netnsPath, nil, nil)
-	klog.V(5).Infof("GetPodNetworkStatus result %+v", result)
+	klog.V(5).InfoS("GetPodNetworkStatus", "result", result)
 	if err != nil {
-		klog.Errorf("error while adding to cni network: %s", err)
+		klog.ErrorS(err, "Got error while adding to cni network")
 		return nil, err
 	}
 
@@ -64,7 +64,7 @@ func (plugin *cniNetworkPlugin) GetPodNetworkStatus(namespace string, name strin
 	var result020 *cniTypes020.Result
 	result020, err = cniTypes020.GetResult(result)
 	if err != nil {
-		klog.Errorf("error while cni parsing result: %s", err)
+		klog.ErrorS(err, "Got error while cni parsing result")
 		return nil, err
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup 

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

~To avoid multiple invalid outputs, we should consider making the underlying tools of the script (in the klog repo) able to process the package/resource list in a single call at the same time, rather than making multiple calls at the same time in the script, which would reduce the number of executions, reduce forking, and make execution slightly faster.~ (edited by @bentheelder: prev comment here now struck-out is from another issue and not related to this PR actually)

Ensures that we logcheck files for both GOOS=linux and GOOS=windows.
Fixes windows failure.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Xref https://github.com/kubernetes/klog/issues/215

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/issues/1602
```
