### PR TITLE
Migrate pkg/kubelet/config to structured logging

### DIFF
--- a/pkg/kubelet/config/common.go
+++ b/pkg/kubelet/config/common.go
@@ -68,16 +68,16 @@ func applyDefaults(pod *api.Pod, source string, isFile bool, nodeName types.Node
 			fmt.Fprintf(hasher, "url:%s", source)
 		}
 		pod.UID = types.UID(hex.EncodeToString(hasher.Sum(nil)[0:]))
-		klog.V(5).Infof("Generated UID %q pod %q from %s", pod.UID, pod.Name, source)
+		klog.V(5).InfoS("Generated UID", "pod", klog.KObj(pod), "podUID", pod.UID, "source", source)
 	}
 
 	pod.Name = generatePodName(pod.Name, nodeName)
-	klog.V(5).Infof("Generated Name %q for UID %q from URL %s", pod.Name, pod.UID, source)
+	klog.V(5).InfoS("Generated pod name", "pod", klog.KObj(pod), "podUID", pod.UID, "source", source)
 
 	if pod.Namespace == "" {
 		pod.Namespace = metav1.NamespaceDefault
 	}
-	klog.V(5).Infof("Using namespace %q for pod %q from %s", pod.Namespace, pod.Name, source)
+	klog.V(5).InfoS("Set namespace for pod", "pod", klog.KObj(pod), "source", source)
 
 	// Set the Host field to indicate this pod is scheduled on the current node.
 	pod.Spec.NodeName = string(nodeName)
@@ -145,7 +145,7 @@ func tryDecodeSinglePod(data []byte, defaultFn defaultFunc) (parsed bool, pod *v
 	}
 	v1Pod := &v1.Pod{}
 	if err := k8s_api_v1.Convert_core_Pod_To_v1_Pod(newPod, v1Pod, nil); err != nil {
-		klog.Errorf("Pod %q failed to convert to v1", newPod.Name)
+		klog.ErrorS(err, "Pod failed to convert to v1", "pod", klog.KObj(newPod))
 		return true, nil, err
 	}
 	return true, v1Pod, nil

--- a/pkg/kubelet/config/file.go
+++ b/pkg/kubelet/config/file.go
@@ -65,7 +65,7 @@ func NewSourceFile(path string, nodeName types.NodeName, period time.Duration, u
 	path = strings.TrimRight(path, string(os.PathSeparator))
 
 	config := newSourceFile(path, nodeName, period, updates)
-	klog.V(1).Infof("Watching path %q", path)
+	klog.V(1).InfoS("Watching path", "path", path)
 	config.run()
 }
 
@@ -95,17 +95,17 @@ func (s *sourceFile) run() {
 	go func() {
 		// Read path immediately to speed up startup.
 		if err := s.listConfig(); err != nil {
-			klog.Errorf("Unable to read config path %q: %v", s.path, err)
+			klog.ErrorS(err, "Unable to read config path", "path", s.path)
 		}
 		for {
 			select {
 			case <-listTicker.C:
 				if err := s.listConfig(); err != nil {
-					klog.Errorf("Unable to read config path %q: %v", s.path, err)
+					klog.ErrorS(err, "Unable to read config path", "path", s.path)
 				}
 			case e := <-s.watchEvents:
 				if err := s.consumeWatchEvent(e); err != nil {
-					klog.Errorf("Unable to process watch event: %v", err)
+					klog.ErrorS(err, "Unable to process watch event")
 				}
 			}
 		}
@@ -173,24 +173,24 @@ func (s *sourceFile) extractFromDir(name string) ([]*v1.Pod, error) {
 	for _, path := range dirents {
 		statInfo, err := os.Stat(path)
 		if err != nil {
-			klog.Errorf("Can't get metadata for %q: %v", path, err)
+			klog.ErrorS(err, "Could not get metadata", "path", path)
 			continue
 		}
 
 		switch {
 		case statInfo.Mode().IsDir():
-			klog.Errorf("Not recursing into manifest path %q", path)
+			klog.ErrorS(nil, "Provided manifest path is a directory, not recursing into manifest path", "path", path)
 		case statInfo.Mode().IsRegular():
 			pod, err := s.extractFromFile(path)
 			if err != nil {
 				if !os.IsNotExist(err) {
-					klog.Errorf("Can't process manifest file %q: %v", path, err)
+					klog.ErrorS(err, "Could not process manifest file", "path", path)
 				}
 			} else {
 				pods = append(pods, pod)
 			}
 		default:
-			klog.Errorf("Manifest path %q is not a directory or file: %v", path, statInfo.Mode())
+			klog.ErrorS(nil, "Manifest path is not a directory or file", "path", path, "mode", statInfo.Mode())
 		}
 	}
 	return pods, nil
@@ -198,7 +198,7 @@ func (s *sourceFile) extractFromDir(name string) ([]*v1.Pod, error) {
 
 // extractFromFile parses a file for Pod configuration information.
 func (s *sourceFile) extractFromFile(filename string) (pod *v1.Pod, err error) {
-	klog.V(3).Infof("Reading config file %q", filename)
+	klog.V(3).InfoS("Reading config file", "path", filename)
 	defer func() {
 		if err == nil && pod != nil {
 			objKey, keyErr := cache.MetaNamespaceKeyFunc(pod)

--- a/pkg/kubelet/config/file_linux.go
+++ b/pkg/kubelet/config/file_linux.go
@@ -57,7 +57,7 @@ func (s *sourceFile) startWatch() {
 		}
 
 		if err := s.doWatch(); err != nil {
-			klog.Errorf("Unable to read config path %q: %v", s.path, err)
+			klog.ErrorS(err, "Unable to read config path", "path", s.path)
 			if _, retryable := err.(*retryableError); !retryable {
 				backOff.Next(backOffID, time.Now())
 			}
@@ -102,7 +102,7 @@ func (s *sourceFile) doWatch() error {
 func (s *sourceFile) produceWatchEvent(e *fsnotify.Event) error {
 	// Ignore file start with dots
 	if strings.HasPrefix(filepath.Base(e.Name), ".") {
-		klog.V(4).Infof("Ignored pod manifest: %s, because it starts with dots", e.Name)
+		klog.V(4).InfoS("Ignored pod manifest, because it starts with dots", "eventName", e.Name)
 		return nil
 	}
 	var eventType podEventType

--- a/pkg/kubelet/config/http.go
+++ b/pkg/kubelet/config/http.go
@@ -54,7 +54,7 @@ func NewSourceURL(url string, header http.Header, nodeName types.NodeName, perio
 		// read the manifest URL passed to kubelet.
 		client: &http.Client{Timeout: 10 * time.Second},
 	}
-	klog.V(1).Infof("Watching URL %s", url)
+	klog.V(1).InfoS("Watching URL", "URL", url)
 	go wait.Until(config.run, period, wait.NeverStop)
 }
 
@@ -63,16 +63,16 @@ func (s *sourceURL) run() {
 		// Don't log this multiple times per minute. The first few entries should be
 		// enough to get the point across.
 		if s.failureLogs < 3 {
-			klog.Warningf("Failed to read pods from URL: %v", err)
+			klog.InfoS("Failed to read pods from URL", "err", err)
 		} else if s.failureLogs == 3 {
-			klog.Warningf("Failed to read pods from URL. Dropping verbosity of this message to V(4): %v", err)
+			klog.InfoS("Failed to read pods from URL. Dropping verbosity of this message to V(4)", "err", err)
 		} else {
-			klog.V(4).Infof("Failed to read pods from URL: %v", err)
+			klog.V(4).InfoS("Failed to read pods from URL", "err", err)
 		}
 		s.failureLogs++
 	} else {
 		if s.failureLogs > 0 {
-			klog.Info("Successfully read pods from URL.")
+			klog.InfoS("Successfully read pods from URL")
 			s.failureLogs = 0
 		}
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?


/kind cleanup
/sig instrumentation
/sig node
/priority important-soon

#### What this PR does / why we need it:
Migrate `pkg/kubelet/config` to structured logging
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Ref #98976
#### Special notes for your reviewer:
part of [kubernetes/enhancements#1602](https://github.com/kubernetes/enhancements/issues/1602)
As it is related to log, change the log here to structured log.
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

- [KEP]: [Structured Logging](https://github.com/kubernetes/enhancements/tree/master/keps/sig-instrumentation/1602-structured-logging)

```docs

```
