### PR TITLE
Implemented EnqueueExtensions interface for NodePorts

### DIFF
--- a/pkg/scheduler/framework/plugins/nodeports/node_ports.go
+++ b/pkg/scheduler/framework/plugins/nodeports/node_ports.go
@@ -30,6 +30,7 @@ type NodePorts struct{}
 
 var _ framework.PreFilterPlugin = &NodePorts{}
 var _ framework.FilterPlugin = &NodePorts{}
+var _ framework.EnqueueExtensions = &NodePorts{}
 
 const (
 	// Name is the name of the plugin used in the plugin registry and configurations.
@@ -95,6 +96,16 @@ func getPreFilterState(cycleState *framework.CycleState) (preFilterState, error)
 		return nil, fmt.Errorf("%+v  convert to nodeports.preFilterState error", c)
 	}
 	return s, nil
+}
+
+// EventsToRegister returns the possible events that may make a Pod
+// failed by this plugin schedulable.
+func (pl *NodePorts) EventsToRegister() []framework.ClusterEvent {
+	return []framework.ClusterEvent{
+		// Due to immutable fields `spec.containers[*].ports`, pod update events are ignored.
+		{Resource: framework.Pod, ActionType: framework.Delete},
+		{Resource: framework.Node, ActionType: framework.Add},
+	}
 }
 
 // Filter invoked at the filter extension point.


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/sig scheduling

#### What this PR does / why we need it:

Please refer to #94009 .
I implemented the EventsToRegister function to return the events that may cause the NodePorts plug-in to be unschedulable for the pod.

#### Which issue(s) this PR fixes:

Ref #94009 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

NONE

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.: