### PR TITLE
add duration encoder to structured logger

### DIFF
--- a/staging/src/k8s.io/component-base/logs/json/json.go
+++ b/staging/src/k8s.io/component-base/logs/json/json.go
@@ -148,8 +148,9 @@ func (l *zapLogger) WithName(name string) logr.Logger {
 var encoderConfig = zapcore.EncoderConfig{
 	MessageKey: "msg",
 
-	TimeKey:    "ts",
-	EncodeTime: zapcore.EpochMillisTimeEncoder,
+	TimeKey:        "ts",
+	EncodeTime:     zapcore.EpochMillisTimeEncoder,
+	EncodeDuration: zapcore.StringDurationEncoder,
 }
 
 // NewJSONLogger creates a new json logr.Logger using the given Zap Logger to log.

--- a/staging/src/k8s.io/component-base/logs/json/json_test.go
+++ b/staging/src/k8s.io/component-base/logs/json/json_test.go
@@ -57,6 +57,11 @@ func TestZapLoggerInfo(t *testing.T) {
 			format:     "{\"ts\":%f,\"msg\":\"non-string key argument passed to logging, ignoring all later arguments\",\"v\":0}\n{\"ts\":0.000123,\"msg\":\"test for non-string key argument\",\"v\":0,\"ns\":\"default\",\"podnum\":2}\n",
 			keysValues: []interface{}{"ns", "default", "podnum", 2, 200, "replica", "Running", 10},
 		},
+		{
+			msg:        "test for duration value argument",
+			format:     "{\"ts\":%f,\"msg\":\"test for duration value argument\",\"v\":0,\"duration\":\"5s\"}\n",
+			keysValues: []interface{}{"duration", time.Duration(5 * time.Second)},
+		},
 	}
 
 	for _, data := range testDataInfo {


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
The kubelet crashes with structured logging enabled due to the duration encoder not being enabled on the zap json logger. This  patch enables the StringDurationEncoder for durations.

```
goroutine 1 [running]:
k8s.io/kubernetes/vendor/go.uber.org/zap/zapcore.(*jsonEncoder).AppendDuration(0xc00101e9f0, 0x1bf08eb000)
        /home/rphillips/work/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/go.uber.org/zap/zapcore/json_encoder.go:225 +0x30
k8s.io/kubernetes/vendor/go.uber.org/zap/zapcore.(*jsonEncoder).AddDuration(0xc00101e9f0, 0x4aa3118, 0x7, 0x1bf08eb000)
```

The kubelet successfully starts up with this patch.

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:
@serathius
@ehashman
@knight42

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
NONE
```

/triage accepted
/priority critical-urgent