### PR TITLE
Add kubectl describe for policy/v1 PDB

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/describe/describe_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/describe/describe_test.go
@@ -35,6 +35,7 @@ import (
 	discoveryv1beta1 "k8s.io/api/discovery/v1beta1"
 	networkingv1 "k8s.io/api/networking/v1"
 	networkingv1beta1 "k8s.io/api/networking/v1beta1"
+	policyv1 "k8s.io/api/policy/v1"
 	policyv1beta1 "k8s.io/api/policy/v1beta1"
 	storagev1 "k8s.io/api/storage/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
@@ -2577,7 +2578,7 @@ func TestDescribeCSINode(t *testing.T) {
 	}
 }
 
-func TestDescribePodDisruptionBudget(t *testing.T) {
+func TestDescribePodDisruptionBudgetV1beta1(t *testing.T) {
 	minAvailable := intstr.FromInt(22)
 	f := fake.NewSimpleClientset(&policyv1beta1.PodDisruptionBudget{
 		ObjectMeta: metav1.ObjectMeta{
@@ -2589,6 +2590,34 @@ func TestDescribePodDisruptionBudget(t *testing.T) {
 			MinAvailable: &minAvailable,
 		},
 		Status: policyv1beta1.PodDisruptionBudgetStatus{
+			DisruptionsAllowed: 5,
+		},
+	})
+	s := PodDisruptionBudgetDescriber{f}
+	out, err := s.Describe("ns1", "pdb1", DescriberSettings{ShowEvents: true})
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if !strings.Contains(out, "pdb1") ||
+		!strings.Contains(out, "ns1") ||
+		!strings.Contains(out, "22") ||
+		!strings.Contains(out, "5") {
+		t.Errorf("unexpected out: %s", out)
+	}
+}
+
+func TestDescribePodDisruptionBudgetV1(t *testing.T) {
+	minAvailable := intstr.FromInt(22)
+	f := fake.NewSimpleClientset(&policyv1.PodDisruptionBudget{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:         "ns1",
+			Name:              "pdb1",
+			CreationTimestamp: metav1.Time{Time: time.Now().Add(1.9e9)},
+		},
+		Spec: policyv1.PodDisruptionBudgetSpec{
+			MinAvailable: &minAvailable,
+		},
+		Status: policyv1.PodDisruptionBudgetStatus{
 			DisruptionsAllowed: 5,
 		},
 	})


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Builds on top of https://github.com/kubernetes/kubernetes/pull/99290, only the last commit is new.

Adds kubectl describe support for policy/v1 PDB

/assign @mortent 

```release-note
NONE
```