### PR TITLE
add enqueue-extensions nodevolumelimits plugin

### DIFF
--- a/pkg/scheduler/framework/plugins/nodevolumelimits/csi.go
+++ b/pkg/scheduler/framework/plugins/nodevolumelimits/csi.go
@@ -57,6 +57,7 @@ type CSILimits struct {
 }
 
 var _ framework.FilterPlugin = &CSILimits{}
+var _ framework.EnqueueExtensions = &CSILimits{}
 
 // CSIName is the name of the plugin used in the plugin registry and configurations.
 const CSIName = "NodeVolumeLimits"
@@ -64,6 +65,15 @@ const CSIName = "NodeVolumeLimits"
 // Name returns name of the plugin. It is used in logs, etc.
 func (pl *CSILimits) Name() string {
 	return CSIName
+}
+
+// EventsToRegister returns the possible events that may make a Pod
+// failed by this plugin schedulable.
+func (pl *CSILimits) EventsToRegister() []framework.ClusterEvent {
+	return []framework.ClusterEvent{
+		{Resource: framework.CSINode, ActionType: framework.Add},
+		{Resource: framework.Pod, ActionType: framework.Delete},
+	}
 }
 
 // Filter invoked at the filter extension point.

--- a/pkg/scheduler/framework/plugins/nodevolumelimits/non_csi.go
+++ b/pkg/scheduler/framework/plugins/nodevolumelimits/non_csi.go
@@ -119,6 +119,7 @@ type nonCSILimits struct {
 }
 
 var _ framework.FilterPlugin = &nonCSILimits{}
+var _ framework.EnqueueExtensions = &nonCSILimits{}
 
 // newNonCSILimitsWithInformerFactory returns a plugin with filter name and informer factory.
 func newNonCSILimitsWithInformerFactory(
@@ -193,6 +194,15 @@ func newNonCSILimits(
 // Name returns name of the plugin. It is used in logs, etc.
 func (pl *nonCSILimits) Name() string {
 	return pl.name
+}
+
+// EventsToRegister returns the possible events that may make a Pod
+// failed by this plugin schedulable.
+func (pl *nonCSILimits) EventsToRegister() []framework.ClusterEvent {
+	return []framework.ClusterEvent{
+		{Resource: framework.Node, ActionType: framework.Add},
+		{Resource: framework.Pod, ActionType: framework.Delete},
+	}
 }
 
 // Filter invoked at the filter extension point.


### PR DESCRIPTION

#### What type of PR is this?
/kind feature
/sig scheduling

#### What this PR does / why we need it:
Implement EnqueueExtensions interface in nodevolumelimits* plugins.

#### Which issue(s) this PR fixes:

Fixes <https://github.com/kubernetes/kubernetes/issues/94009>

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
NONE

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

NONE
