### PR TITLE
undo promoting exec timeout tests to conformance

### DIFF
--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -1950,14 +1950,6 @@
     restart count to 1.
   release: v1.9
   file: test/e2e/common/node/container_probe.go
-- testname: Pod liveness probe, container exec timeout, restart
-  codename: '[sig-node] Probing container should be restarted with an exec liveness
-    probe with timeout [NodeConformance] [Conformance]'
-  description: A Pod is created with liveness probe with a Exec action on the Pod.
-    If the liveness probe call does not return within the timeout specified, liveness
-    probe MUST restart the Pod.
-  release: v1.9
-  file: test/e2e/common/node/container_probe.go
 - testname: Pod liveness probe, using http endpoint, multiple restarts (slow)
   codename: '[sig-node] Probing container should have monotonically increasing restart
     count [NodeConformance] [Conformance]'
@@ -1969,14 +1961,6 @@
     returns an http error after 10 seconds from the start. Restart counts MUST increment
     everytime health check fails, measure upto 5 restart.
   release: v1.9
-  file: test/e2e/common/node/container_probe.go
-- testname: Pod readiness probe, container exec timeout, not ready
-  codename: '[sig-node] Probing container should not be ready with an exec readiness
-    probe timeout [NodeConformance] [Conformance]'
-  description: A Pod is created with readiness probe with a Exec action on the Pod.
-    If the readiness probe call does not return within the timeout specified, readiness
-    probe MUST not be Ready.
-  release: v1.20
   file: test/e2e/common/node/container_probe.go
 - testname: Pod readiness probe, with initial delay
   codename: '[sig-node] Probing container with readiness probe should not be ready

--- a/test/e2e/common/node/container_probe.go
+++ b/test/e2e/common/node/container_probe.go
@@ -209,11 +209,12 @@ var _ = SIGDescribe("Probing container", func() {
 	})
 
 	/*
-		Release: v1.9
+		Release: v1.9, v1.20
 		Testname: Pod liveness probe, container exec timeout, restart
 		Description: A Pod is created with liveness probe with a Exec action on the Pod. If the liveness probe call does not return within the timeout specified, liveness probe MUST restart the Pod.
+		Note: This test will be promoted to Conformance ONLY after the feature gate will be removed
 	*/
-	framework.ConformanceIt("should be restarted with an exec liveness probe with timeout [NodeConformance]", func() {
+	ginkgo.It("should be restarted with an exec liveness probe with timeout [NodeConformance]", func() {
 		cmd := []string{"/bin/sh", "-c", "sleep 600"}
 		livenessProbe := &v1.Probe{
 			Handler:             execHandler([]string{"/bin/sh", "-c", "sleep 10"}),
@@ -229,8 +230,9 @@ var _ = SIGDescribe("Probing container", func() {
 		Release: v1.20
 		Testname: Pod readiness probe, container exec timeout, not ready
 		Description: A Pod is created with readiness probe with a Exec action on the Pod. If the readiness probe call does not return within the timeout specified, readiness probe MUST not be Ready.
+		Note: This test will be promoted to Conformance ONLY after the feature gate will be removed
 	*/
-	framework.ConformanceIt("should not be ready with an exec readiness probe timeout [NodeConformance]", func() {
+	ginkgo.It("should not be ready with an exec readiness probe timeout [NodeConformance]", func() {
 		cmd := []string{"/bin/sh", "-c", "sleep 600"}
 		readinessProbe := &v1.Probe{
 			Handler:             execHandler([]string{"/bin/sh", "-c", "sleep 10"}),


### PR DESCRIPTION
Undo if https://github.com/kubernetes/kubernetes/pull/97619#issuecomment-794518811

#### What type of PR is this?

/kind bug
/sig node
/kind conformance

#### What this PR does / why we need it:
As discussed at SIG Node meeting we need to wait with promoting these tests to conformance so clusters that decided to wait with flag adoption would still be considered conformant.


```release-note
NONE
```
