### PR TITLE
Revert : conformance: promote container exec probe timeout tests

### DIFF
--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -1950,14 +1950,6 @@
     restart count to 1.
   release: v1.9
   file: test/e2e/common/node/container_probe.go
-- testname: Pod liveness probe, container exec timeout, restart
-  codename: '[sig-node] Probing container should be restarted with an exec liveness
-    probe with timeout [NodeConformance] [Conformance]'
-  description: A Pod is created with liveness probe with a Exec action on the Pod.
-    If the liveness probe call does not return within the timeout specified, liveness
-    probe MUST restart the Pod.
-  release: v1.9
-  file: test/e2e/common/node/container_probe.go
 - testname: Pod liveness probe, using http endpoint, multiple restarts (slow)
   codename: '[sig-node] Probing container should have monotonically increasing restart
     count [NodeConformance] [Conformance]'
@@ -1969,14 +1961,6 @@
     returns an http error after 10 seconds from the start. Restart counts MUST increment
     everytime health check fails, measure upto 5 restart.
   release: v1.9
-  file: test/e2e/common/node/container_probe.go
-- testname: Pod readiness probe, container exec timeout, not ready
-  codename: '[sig-node] Probing container should not be ready with an exec readiness
-    probe timeout [NodeConformance] [Conformance]'
-  description: A Pod is created with readiness probe with a Exec action on the Pod.
-    If the readiness probe call does not return within the timeout specified, readiness
-    probe MUST not be Ready.
-  release: v1.20
   file: test/e2e/common/node/container_probe.go
 - testname: Pod readiness probe, with initial delay
   codename: '[sig-node] Probing container with readiness probe should not be ready

--- a/test/e2e/common/node/container_probe.go
+++ b/test/e2e/common/node/container_probe.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2eevents "k8s.io/kubernetes/test/e2e/framework/events"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
+	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
 	testutils "k8s.io/kubernetes/test/utils"
 
 	"github.com/onsi/ginkgo"
@@ -214,6 +215,9 @@ var _ = SIGDescribe("Probing container", func() {
 		Description: A Pod is created with liveness probe with a Exec action on the Pod. If the liveness probe call does not return within the timeout specified, liveness probe MUST restart the Pod.
 	*/
 	ginkgo.It("should be restarted with an exec liveness probe with timeout [NodeConformance]", func() {
+		// The ExecProbeTimeout feature gate exists to allow backwards-compatibility with pre-1.20 cluster behaviors, where livenessProbe timeouts were ignored
+		// If ExecProbeTimeout feature gate is disabled, timeout enforcement for exec livenessProbes is disabled, so we should skip this test
+		e2eskipper.SkipUnlessExecProbeTimeoutEnabled()
 		cmd := []string{"/bin/sh", "-c", "sleep 600"}
 		livenessProbe := &v1.Probe{
 			Handler:             execHandler([]string{"/bin/sh", "-c", "sleep 10"}),

--- a/test/e2e/common/node/container_probe.go
+++ b/test/e2e/common/node/container_probe.go
@@ -213,7 +213,7 @@ var _ = SIGDescribe("Probing container", func() {
 		Testname: Pod liveness probe, container exec timeout, restart
 		Description: A Pod is created with liveness probe with a Exec action on the Pod. If the liveness probe call does not return within the timeout specified, liveness probe MUST restart the Pod.
 	*/
-	framework.ConformanceIt("should be restarted with an exec liveness probe with timeout [NodeConformance]", func() {
+	ginkgo.It("should be restarted with an exec liveness probe with timeout [NodeConformance]", func() {
 		cmd := []string{"/bin/sh", "-c", "sleep 600"}
 		livenessProbe := &v1.Probe{
 			Handler:             execHandler([]string{"/bin/sh", "-c", "sleep 10"}),
@@ -230,7 +230,7 @@ var _ = SIGDescribe("Probing container", func() {
 		Testname: Pod readiness probe, container exec timeout, not ready
 		Description: A Pod is created with readiness probe with a Exec action on the Pod. If the readiness probe call does not return within the timeout specified, readiness probe MUST not be Ready.
 	*/
-	framework.ConformanceIt("should not be ready with an exec readiness probe timeout [NodeConformance]", func() {
+	ginkgo.It("should not be ready with an exec readiness probe timeout [NodeConformance]", func() {
 		cmd := []string{"/bin/sh", "-c", "sleep 600"}
 		readinessProbe := &v1.Probe{
 			Handler:             execHandler([]string{"/bin/sh", "-c", "sleep 10"}),

--- a/test/e2e/framework/skipper/skipper.go
+++ b/test/e2e/framework/skipper/skipper.go
@@ -46,7 +46,10 @@ import (
 // New local storage types to support local storage capacity isolation
 var localStorageCapacityIsolation featuregate.Feature = "LocalStorageCapacityIsolation"
 
-var downwardAPIHugePages featuregate.Feature = "DownwardAPIHugePages"
+var (
+	downwardAPIHugePages featuregate.Feature = "DownwardAPIHugePages"
+	execProbeTimeout     featuregate.Feature = "ExecProbeTimeout"
+)
 
 func skipInternalf(caller int, format string, args ...interface{}) {
 	msg := fmt.Sprintf(format, args...)
@@ -142,6 +145,12 @@ func SkipUnlessLocalEphemeralStorageEnabled() {
 func SkipUnlessDownwardAPIHugePagesEnabled() {
 	if !utilfeature.DefaultFeatureGate.Enabled(downwardAPIHugePages) {
 		skipInternalf(1, "Only supported when %v feature is enabled", downwardAPIHugePages)
+	}
+}
+
+func SkipUnlessExecProbeTimeoutEnabled() {
+	if !utilfeature.DefaultFeatureGate.Enabled(execProbeTimeout) {
+		skipInternalf(1, "Only supported when %v feature is enabled", execProbeTimeout)
 	}
 }
 


### PR DESCRIPTION
Reverting af3e118b1fc4c90c088da9ffa375087b1dcf947f and
2242d0ffc409594bd4543153ebdba4534c8e83cf as these tests fail when
ExecProbeTimeout feature gate is turned on.

Signed-off-by: Davanum Srinivas <davanum@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
We promoted a conformance test that is not yet ready. The behavior of the conformance test changes with feature flags applied.

fails the first test `it tests only GA, non-optional features or APIs (e.g., no alpha or beta endpoints, no feature flags required, no deprecated features)` from the guidelines:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/conformance-tests.md#conformance-test-requirements

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
Incorporated changes from https://github.com/kubernetes/kubernetes/pull/100028 by @jackfrancis 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
