### PR TITLE
Automated cherry pick of #99600: Count pod overhead as an entity's resource usage

### DIFF
--- a/pkg/quota/v1/evaluator/core/BUILD
+++ b/pkg/quota/v1/evaluator/core/BUILD
@@ -46,6 +46,7 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//pkg/apis/core:go_default_library",
+        "//pkg/features:go_default_library",
         "//pkg/quota/v1:go_default_library",
         "//pkg/quota/v1/generic:go_default_library",
         "//pkg/util/node:go_default_library",
@@ -54,6 +55,8 @@ go_test(
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/clock:go_default_library",
+        "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",
+        "//staging/src/k8s.io/component-base/featuregate/testing:go_default_library",
     ],
 )
 

--- a/pkg/quota/v1/evaluator/core/pods.go
+++ b/pkg/quota/v1/evaluator/core/pods.go
@@ -30,10 +30,12 @@ import (
 	"k8s.io/apimachinery/pkg/util/clock"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apiserver/pkg/admission"
+	"k8s.io/apiserver/pkg/util/feature"
 	api "k8s.io/kubernetes/pkg/apis/core"
 	k8s_api_v1 "k8s.io/kubernetes/pkg/apis/core/v1"
 	"k8s.io/kubernetes/pkg/apis/core/v1/helper"
 	"k8s.io/kubernetes/pkg/apis/core/v1/helper/qos"
+	"k8s.io/kubernetes/pkg/features"
 	quota "k8s.io/kubernetes/pkg/quota/v1"
 	"k8s.io/kubernetes/pkg/quota/v1/generic"
 )
@@ -351,6 +353,10 @@ func PodUsageFunc(obj runtime.Object, clock clock.Clock) (corev1.ResourceList, e
 		limits = quota.Max(limits, pod.Spec.InitContainers[i].Resources.Limits)
 	}
 
+	if feature.DefaultFeatureGate.Enabled(features.PodOverhead) {
+		requests = quota.Add(requests, pod.Spec.Overhead)
+		limits = quota.Add(limits, pod.Spec.Overhead)
+	}
 	result = quota.Add(result, podComputeUsageHelper(requests, limits))
 	return result, nil
 }

--- a/pkg/quota/v1/evaluator/core/pods_test.go
+++ b/pkg/quota/v1/evaluator/core/pods_test.go
@@ -25,7 +25,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/clock"
+	"k8s.io/apiserver/pkg/util/feature"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	api "k8s.io/kubernetes/pkg/apis/core"
+	"k8s.io/kubernetes/pkg/features"
 	quota "k8s.io/kubernetes/pkg/quota/v1"
 	"k8s.io/kubernetes/pkg/quota/v1/generic"
 	"k8s.io/kubernetes/pkg/util/node"
@@ -90,8 +93,9 @@ func TestPodEvaluatorUsage(t *testing.T) {
 	deletionTimestampNotPastGracePeriod := metav1.NewTime(fakeClock.Now())
 
 	testCases := map[string]struct {
-		pod   *api.Pod
-		usage corev1.ResourceList
+		pod                *api.Pod
+		usage              corev1.ResourceList
+		podOverheadEnabled bool
 	}{
 		"init container CPU": {
 			pod: &api.Pod{
@@ -433,9 +437,68 @@ func TestPodEvaluatorUsage(t *testing.T) {
 				generic.ObjectCountQuotaResourceNameFor(schema.GroupResource{Resource: "pods"}): resource.MustParse("1"),
 			},
 		},
+		"count pod overhead as usage": {
+			pod: &api.Pod{
+				Spec: api.PodSpec{
+					Overhead: api.ResourceList{
+						api.ResourceCPU: resource.MustParse("1"),
+					},
+					Containers: []api.Container{
+						{
+							Resources: api.ResourceRequirements{
+								Requests: api.ResourceList{
+									api.ResourceCPU: resource.MustParse("1"),
+								},
+								Limits: api.ResourceList{
+									api.ResourceCPU: resource.MustParse("2"),
+								},
+							},
+						},
+					},
+				},
+			},
+			usage: corev1.ResourceList{
+				corev1.ResourceRequestsCPU: resource.MustParse("2"),
+				corev1.ResourceLimitsCPU:   resource.MustParse("3"),
+				corev1.ResourcePods:        resource.MustParse("1"),
+				corev1.ResourceCPU:         resource.MustParse("2"),
+				generic.ObjectCountQuotaResourceNameFor(schema.GroupResource{Resource: "pods"}): resource.MustParse("1"),
+			},
+			podOverheadEnabled: true,
+		},
+		"do not count pod overhead as usage with pod overhead disabled": {
+			pod: &api.Pod{
+				Spec: api.PodSpec{
+					Overhead: api.ResourceList{
+						api.ResourceCPU: resource.MustParse("1"),
+					},
+					Containers: []api.Container{
+						{
+							Resources: api.ResourceRequirements{
+								Requests: api.ResourceList{
+									api.ResourceCPU: resource.MustParse("1"),
+								},
+								Limits: api.ResourceList{
+									api.ResourceCPU: resource.MustParse("2"),
+								},
+							},
+						},
+					},
+				},
+			},
+			usage: corev1.ResourceList{
+				corev1.ResourceRequestsCPU: resource.MustParse("1"),
+				corev1.ResourceLimitsCPU:   resource.MustParse("2"),
+				corev1.ResourcePods:        resource.MustParse("1"),
+				corev1.ResourceCPU:         resource.MustParse("1"),
+				generic.ObjectCountQuotaResourceNameFor(schema.GroupResource{Resource: "pods"}): resource.MustParse("1"),
+			},
+			podOverheadEnabled: false,
+		},
 	}
 	for testName, testCase := range testCases {
 		t.Run(testName, func(t *testing.T) {
+			defer featuregatetesting.SetFeatureGateDuringTest(t, feature.DefaultFeatureGate, features.PodOverhead, testCase.podOverheadEnabled)()
 			actual, err := evaluator.Usage(testCase.pod)
 			if err != nil {
 				t.Error(err)


### PR DESCRIPTION
Cherry pick of #99600 on release-1.18.

#99600: Count pod overhead as an entity's resource usage

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.