### PR TITLE
Updating EndpointSlice controllers to avoid duplicate creations

### DIFF
--- a/pkg/controller/endpointslice/endpointslice_tracker.go
+++ b/pkg/controller/endpointslice/endpointslice_tracker.go
@@ -19,7 +19,6 @@ package endpointslice
 import (
 	"sync"
 
-	v1 "k8s.io/api/core/v1"
 	discovery "k8s.io/api/discovery/v1"
 	"k8s.io/apimachinery/pkg/types"
 )
@@ -83,11 +82,11 @@ func (est *endpointSliceTracker) ShouldSync(endpointSlice *discovery.EndpointSli
 // StaleSlices returns true if one or more of the provided EndpointSlices
 // have older generations than the corresponding tracked ones or if the tracker
 // is expecting one or more of the provided EndpointSlices to be deleted.
-func (est *endpointSliceTracker) StaleSlices(service *v1.Service, endpointSlices []*discovery.EndpointSlice) bool {
+func (est *endpointSliceTracker) StaleSlices(namespace, name string, endpointSlices []*discovery.EndpointSlice) bool {
 	est.lock.Lock()
 	defer est.lock.Unlock()
 
-	nn := types.NamespacedName{Name: service.Name, Namespace: service.Namespace}
+	nn := types.NamespacedName{Name: name, Namespace: namespace}
 	gfs, ok := est.generationsByService[nn]
 	if !ok {
 		return false
@@ -99,6 +98,51 @@ func (est *endpointSliceTracker) StaleSlices(service *v1.Service, endpointSlices
 		}
 	}
 	return false
+}
+
+// MissingSlices returns true if this tracker is tracking more EndpointSlices
+// for the provided Service than have been provided to this function. If this
+// function returns true, it can be used as an indication that the controller
+// should fall back to a full API list instead of relying on the cache.
+func (est *endpointSliceTracker) MissingSlices(namespace, name string, endpointSlices []*discovery.EndpointSlice) bool {
+	est.lock.Lock()
+	defer est.lock.Unlock()
+
+	nn := types.NamespacedName{Name: name, Namespace: namespace}
+	gfs, ok := est.generationsByService[nn]
+	if !ok {
+		return false
+	}
+	providedSlices := make(map[types.UID]bool, len(endpointSlices))
+	for _, endpointSlice := range endpointSlices {
+		providedSlices[endpointSlice.UID] = true
+	}
+	for trackedUID, gen := range gfs {
+		if gen == deletionExpected {
+			continue
+		}
+		_, ok := providedSlices[trackedUID]
+		if !ok {
+			return true
+		}
+	}
+	return false
+}
+
+// Reset updates the tracker to contain only the provided slices for the
+// specified Service.
+func (est *endpointSliceTracker) Reset(namespace, name string, endpointSlices []*discovery.EndpointSlice) {
+	est.lock.Lock()
+	defer est.lock.Unlock()
+
+	gfs := generationsBySlice{}
+	nn := types.NamespacedName{Name: name, Namespace: namespace}
+
+	for _, endpointSlice := range endpointSlices {
+		gfs[endpointSlice.UID] = endpointSlice.Generation
+	}
+
+	est.generationsByService[nn] = gfs
 }
 
 // Update adds or updates the generation in this endpointSliceTracker for the

--- a/pkg/controller/endpointslice/endpointslice_tracker_test.go
+++ b/pkg/controller/endpointslice/endpointslice_tracker_test.go
@@ -17,9 +17,9 @@ limitations under the License.
 package endpointslice
 
 import (
+	"reflect"
 	"testing"
 
-	v1 "k8s.io/api/core/v1"
 	discovery "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -125,19 +125,21 @@ func TestEndpointSliceTrackerStaleSlices(t *testing.T) {
 	epSlice1NewerGen.Generation = 2
 
 	testCases := []struct {
-		name         string
-		tracker      *endpointSliceTracker
-		serviceParam *v1.Service
-		slicesParam  []*discovery.EndpointSlice
-		expectNewer  bool
+		name             string
+		tracker          *endpointSliceTracker
+		serviceName      string
+		serviceNamespace string
+		slicesParam      []*discovery.EndpointSlice
+		expectNewer      bool
 	}{{
 		name: "empty tracker",
 		tracker: &endpointSliceTracker{
 			generationsByService: map[types.NamespacedName]generationsBySlice{},
 		},
-		serviceParam: &v1.Service{ObjectMeta: metav1.ObjectMeta{Name: "svc1", Namespace: "ns1"}},
-		slicesParam:  []*discovery.EndpointSlice{},
-		expectNewer:  false,
+		serviceName:      "svc1",
+		serviceNamespace: "ns1",
+		slicesParam:      []*discovery.EndpointSlice{},
+		expectNewer:      false,
 	}, {
 		name: "empty slices",
 		tracker: &endpointSliceTracker{
@@ -145,9 +147,10 @@ func TestEndpointSliceTrackerStaleSlices(t *testing.T) {
 				{Name: "svc1", Namespace: "ns1"}: {},
 			},
 		},
-		serviceParam: &v1.Service{ObjectMeta: metav1.ObjectMeta{Name: "svc1", Namespace: "ns1"}},
-		slicesParam:  []*discovery.EndpointSlice{},
-		expectNewer:  false,
+		serviceName:      "svc1",
+		serviceNamespace: "ns1",
+		slicesParam:      []*discovery.EndpointSlice{},
+		expectNewer:      false,
 	}, {
 		name: "matching slices",
 		tracker: &endpointSliceTracker{
@@ -157,9 +160,10 @@ func TestEndpointSliceTrackerStaleSlices(t *testing.T) {
 				},
 			},
 		},
-		serviceParam: &v1.Service{ObjectMeta: metav1.ObjectMeta{Name: "svc1", Namespace: "ns1"}},
-		slicesParam:  []*discovery.EndpointSlice{epSlice1},
-		expectNewer:  false,
+		serviceName:      "svc1",
+		serviceNamespace: "ns1",
+		slicesParam:      []*discovery.EndpointSlice{epSlice1},
+		expectNewer:      false,
 	}, {
 		name: "newer slice in tracker",
 		tracker: &endpointSliceTracker{
@@ -169,9 +173,10 @@ func TestEndpointSliceTrackerStaleSlices(t *testing.T) {
 				},
 			},
 		},
-		serviceParam: &v1.Service{ObjectMeta: metav1.ObjectMeta{Name: "svc1", Namespace: "ns1"}},
-		slicesParam:  []*discovery.EndpointSlice{epSlice1},
-		expectNewer:  true,
+		serviceName:      "svc1",
+		serviceNamespace: "ns1",
+		slicesParam:      []*discovery.EndpointSlice{epSlice1},
+		expectNewer:      true,
 	}, {
 		name: "newer slice in params",
 		tracker: &endpointSliceTracker{
@@ -181,16 +186,223 @@ func TestEndpointSliceTrackerStaleSlices(t *testing.T) {
 				},
 			},
 		},
-		serviceParam: &v1.Service{ObjectMeta: metav1.ObjectMeta{Name: "svc1", Namespace: "ns1"}},
-		slicesParam:  []*discovery.EndpointSlice{epSlice1NewerGen},
-		expectNewer:  false,
+		serviceName:      "svc1",
+		serviceNamespace: "ns1",
+		slicesParam:      []*discovery.EndpointSlice{epSlice1NewerGen},
+		expectNewer:      false,
 	}}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			actualNewer := tc.tracker.StaleSlices(tc.serviceParam, tc.slicesParam)
+			actualNewer := tc.tracker.StaleSlices(tc.serviceNamespace, tc.serviceName, tc.slicesParam)
 			if actualNewer != tc.expectNewer {
 				t.Errorf("Expected %t, got %t", tc.expectNewer, actualNewer)
+			}
+		})
+	}
+}
+
+func TestEndpointSliceTrackerMissingSlices(t *testing.T) {
+	epSlice1 := &discovery.EndpointSlice{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "example-1",
+			Namespace:  "ns1",
+			UID:        "original",
+			Generation: 1,
+			Labels:     map[string]string{discovery.LabelServiceName: "svc1"},
+		},
+	}
+
+	epSlice2 := epSlice1.DeepCopy()
+	epSlice2.UID = "different"
+
+	testCases := []struct {
+		name             string
+		tracker          *endpointSliceTracker
+		serviceName      string
+		serviceNamespace string
+		slicesParam      []*discovery.EndpointSlice
+		expectMissing    bool
+	}{{
+		name: "empty tracker",
+		tracker: &endpointSliceTracker{
+			generationsByService: map[types.NamespacedName]generationsBySlice{},
+		},
+		serviceName:      "svc1",
+		serviceNamespace: "ns1",
+		slicesParam:      []*discovery.EndpointSlice{},
+		expectMissing:    false,
+	}, {
+		name: "empty slices",
+		tracker: &endpointSliceTracker{
+			generationsByService: map[types.NamespacedName]generationsBySlice{
+				{Name: "svc1", Namespace: "ns1"}: {},
+			},
+		},
+		serviceName:      "svc1",
+		serviceNamespace: "ns1",
+		slicesParam:      []*discovery.EndpointSlice{},
+		expectMissing:    false,
+	}, {
+		name: "a missing slice that is expected to be deleted",
+		tracker: &endpointSliceTracker{
+			generationsByService: map[types.NamespacedName]generationsBySlice{
+				{Name: "svc1", Namespace: "ns1"}: {
+					epSlice1.UID: deletionExpected,
+				},
+			},
+		},
+		serviceName:      "svc1",
+		serviceNamespace: "ns1",
+		slicesParam:      []*discovery.EndpointSlice{},
+		expectMissing:    false,
+	}, {
+		name: "matching slices",
+		tracker: &endpointSliceTracker{
+			generationsByService: map[types.NamespacedName]generationsBySlice{
+				{Name: "svc1", Namespace: "ns1"}: {
+					epSlice1.UID: epSlice1.Generation,
+				},
+			},
+		},
+		serviceName:      "svc1",
+		serviceNamespace: "ns1",
+		slicesParam:      []*discovery.EndpointSlice{epSlice1},
+		expectMissing:    false,
+	}, {
+		name: "different slice in tracker",
+		tracker: &endpointSliceTracker{
+			generationsByService: map[types.NamespacedName]generationsBySlice{
+				{Name: "svc1", Namespace: "ns1"}: {
+					epSlice2.UID: epSlice2.Generation,
+				},
+			},
+		},
+		serviceName:      "svc1",
+		serviceNamespace: "ns1",
+		slicesParam:      []*discovery.EndpointSlice{epSlice1},
+		expectMissing:    true,
+	}, {
+		name: "more slices in params",
+		tracker: &endpointSliceTracker{
+			generationsByService: map[types.NamespacedName]generationsBySlice{
+				{Name: "svc1", Namespace: "ns1"}: {
+					epSlice1.UID: epSlice1.Generation,
+				},
+			},
+		},
+		serviceName:      "svc1",
+		serviceNamespace: "ns1",
+		slicesParam:      []*discovery.EndpointSlice{epSlice1, epSlice2},
+		expectMissing:    false,
+	}}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actualMissing := tc.tracker.MissingSlices(tc.serviceNamespace, tc.serviceName, tc.slicesParam)
+			if actualMissing != tc.expectMissing {
+				t.Errorf("Expected %t, got %t", tc.expectMissing, actualMissing)
+			}
+		})
+	}
+}
+
+func TestEndpointSliceTrackerReset(t *testing.T) {
+	epSlice1 := &discovery.EndpointSlice{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "example-1",
+			Namespace:  "ns1",
+			UID:        "original",
+			Generation: 1,
+			Labels:     map[string]string{discovery.LabelServiceName: "svc1"},
+		},
+	}
+
+	epSlice2 := epSlice1.DeepCopy()
+	epSlice2.UID = "different"
+
+	testCases := []struct {
+		name                     string
+		tracker                  *endpointSliceTracker
+		serviceName              string
+		serviceNamespace         string
+		slicesParam              []*discovery.EndpointSlice
+		expectGenerationsBySlice generationsBySlice
+	}{{
+		name: "empty tracker",
+		tracker: &endpointSliceTracker{
+			generationsByService: map[types.NamespacedName]generationsBySlice{},
+		},
+		serviceName:              "svc1",
+		serviceNamespace:         "ns1",
+		slicesParam:              []*discovery.EndpointSlice{},
+		expectGenerationsBySlice: generationsBySlice{},
+	}, {
+		name: "empty slices",
+		tracker: &endpointSliceTracker{
+			generationsByService: map[types.NamespacedName]generationsBySlice{
+				{Name: "svc1", Namespace: "ns1"}: {},
+			},
+		},
+		serviceName:              "svc1",
+		serviceNamespace:         "ns1",
+		slicesParam:              []*discovery.EndpointSlice{},
+		expectGenerationsBySlice: generationsBySlice{},
+	}, {
+		name: "matching slices",
+		tracker: &endpointSliceTracker{
+			generationsByService: map[types.NamespacedName]generationsBySlice{
+				{Name: "svc1", Namespace: "ns1"}: {
+					epSlice1.UID: epSlice1.Generation,
+				},
+			},
+		},
+		serviceName:              "svc1",
+		serviceNamespace:         "ns1",
+		slicesParam:              []*discovery.EndpointSlice{epSlice1},
+		expectGenerationsBySlice: generationsBySlice{epSlice1.UID: epSlice1.Generation},
+	}, {
+		name: "different slice in tracker",
+		tracker: &endpointSliceTracker{
+			generationsByService: map[types.NamespacedName]generationsBySlice{
+				{Name: "svc1", Namespace: "ns1"}: {
+					epSlice2.UID: epSlice2.Generation,
+				},
+			},
+		},
+		serviceName:              "svc1",
+		serviceNamespace:         "ns1",
+		slicesParam:              []*discovery.EndpointSlice{epSlice1},
+		expectGenerationsBySlice: generationsBySlice{epSlice1.UID: epSlice1.Generation},
+	}, {
+		name: "more slices in params",
+		tracker: &endpointSliceTracker{
+			generationsByService: map[types.NamespacedName]generationsBySlice{
+				{Name: "svc1", Namespace: "ns1"}: {
+					epSlice1.UID: epSlice1.Generation,
+				},
+			},
+		},
+		serviceName:      "svc1",
+		serviceNamespace: "ns1",
+		slicesParam:      []*discovery.EndpointSlice{epSlice1, epSlice2},
+		expectGenerationsBySlice: generationsBySlice{
+			epSlice1.UID: epSlice1.Generation,
+			epSlice2.UID: epSlice2.Generation,
+		},
+	}}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.tracker.Reset(tc.serviceNamespace, tc.serviceName, tc.slicesParam)
+			serviceNN := types.NamespacedName{Name: tc.serviceName, Namespace: tc.serviceNamespace}
+			actualGenerationsBySlice, ok := tc.tracker.generationsByService[serviceNN]
+
+			if !ok {
+				t.Fatalf("Expected generations by slice to exist for %s/%s", tc.serviceNamespace, tc.serviceName)
+			}
+			if !reflect.DeepEqual(actualGenerationsBySlice, tc.expectGenerationsBySlice) {
+				t.Errorf("Expected %+v, got %+v", tc.expectGenerationsBySlice, actualGenerationsBySlice)
 			}
 		})
 	}


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
This involves adding MissingSlices and Reset functions to the EndpointSliceTracker that can be used to indicate if the controller should fallback to an API query when fetching EndpointSlices.

#### Which issue(s) this PR fixes:
Fixes #100033

#### Does this PR introduce a user-facing change?
```release-note
EndpointSlice controllers are less likely to create duplicate EndpointSlices.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
- Enhancement Issue: https://github.com/kubernetes/enhancements/issues/752

/cc @aojea @swetharepakula @wojtek-t 
/assign @thockin
/sig network
/priority important-soon 