### PR TITLE
support additional WHAT= when building release-images / quick-release…

### DIFF
--- a/build/release-images.sh
+++ b/build/release-images.sh
@@ -29,6 +29,11 @@ CMD_TARGETS="${KUBE_SERVER_IMAGE_TARGETS[*]}"
 if [[ "${KUBE_BUILD_CONFORMANCE}" =~ [yY] ]]; then
     CMD_TARGETS="${CMD_TARGETS} ${KUBE_CONFORMANCE_IMAGE_TARGETS[*]}"
 fi
+# include extra WHAT if specified so you can build docker images + binaries
+# in one call with a single pass of syncing to the container + generating code
+if [[ -n "${KUBE_EXTRA_WHAT:-}" ]]; then
+    CMD_TARGETS="${CMD_TARGETS} ${KUBE_EXTRA_WHAT}"
+fi
 
 kube::build::verify_prereqs
 kube::build::build_image


### PR DESCRIPTION
…-images

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup
(I guess? or a feature of the build ..?)

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Enables building containerized binaries + images faster (see https://github.com/kubernetes/kubernetes/issues/99517) by allowing extra desired binaries to be supplied when we build binaries in a container for building images.

With this change:

`time make quick-release-images KUBE_EXTRA_WHAT="cmd/kubectl cmd/kubelet cmd/kubeadm test/e2e/e2e.test vendor/github.com/onsi/ginkgo/ginkgo"`
```
real	5m3.889s
user	0m10.871s
sys	0m4.532s
```

Closest equivalent I can come up with without this change:
`time (make quick-release-images && KUBE_VERBOSE=0 build/run.sh make all WHAT="cmd/kubectl cmd/kubelet cmd/kubeadm test/e2e/e2e.test vendor/github.com/onsi/ginkgo/ginkgo")`
```
real	6m0.402s
user	0m15.654s
sys	0m6.377s
```

AKA building e2e dependencies without this PR takes 6 minutes whereas with this PR it takes 5 minutes.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/sig testing
/triage accepted