### PR TITLE
delegated authn: allow client CA override based on non-empty opts

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/options/authentication.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/authentication.go
@@ -290,16 +290,16 @@ func (s *DelegatingAuthenticationOptions) ApplyTo(authenticationInfo *server.Aut
 	}
 
 	// get the clientCA information
-	clientCAFileSpecified := len(s.ClientCert.ClientCA) > 0
+	clientCASpecified := s.ClientCert != ClientCertAuthenticationOptions{}
 	var clientCAProvider dynamiccertificates.CAContentProvider
-	if clientCAFileSpecified {
+	if clientCASpecified {
 		clientCAProvider, err = s.ClientCert.GetClientCAContentProvider()
 		if err != nil {
-			return fmt.Errorf("unable to load client CA file %q: %v", s.ClientCert.ClientCA, err)
+			return fmt.Errorf("unable to load client CA provider: %v", err)
 		}
 		cfg.ClientCertificateCAContentProvider = clientCAProvider
 		if err = authenticationInfo.ApplyClientCert(cfg.ClientCertificateCAContentProvider, servingInfo); err != nil {
-			return fmt.Errorf("unable to assign  client CA file: %v", err)
+			return fmt.Errorf("unable to assign client CA provider: %v", err)
 		}
 
 	} else if !s.SkipInClusterLookup {


### PR DESCRIPTION
Signed-off-by: Monis Khan <mok@vmware.com>

/kind bug
/sig auth
/priority important-longterm
/triage accepted
/milestone v1.21
@kubernetes/sig-auth-pr-reviews

```release-note
NONE
```