### PR TITLE
[test-only] e2e fix: loosen newTestResourceQuota to 10 configmaps

### DIFF
--- a/test/e2e/apimachinery/resource_quota.go
+++ b/test/e2e/apimachinery/resource_quota.go
@@ -335,6 +335,7 @@ var _ = SIGDescribe("ResourceQuota", func() {
 		ginkgo.By("Creating a ResourceQuota")
 		quotaName := "test-quota"
 		resourceQuota := newTestResourceQuota(quotaName)
+		resourceQuota.Spec.Hard[v1.ResourceConfigMaps] = resource.MustParse(hardConfigMaps)
 		_, err = createResourceQuota(f.ClientSet, f.Namespace.Name, resourceQuota)
 		framework.ExpectNoError(err)
 
@@ -353,9 +354,6 @@ var _ = SIGDescribe("ResourceQuota", func() {
 		ginkgo.By("Ensuring resource quota status captures configMap creation")
 		usedResources = v1.ResourceList{}
 		usedResources[v1.ResourceQuotas] = resource.MustParse(strconv.Itoa(c + 1))
-		// we expect there to be two configmaps because each namespace will receive
-		// a ca.crt configmap by default.
-		// ref:https://github.com/kubernetes/kubernetes/pull/68812
 		usedResources[v1.ResourceConfigMaps] = resource.MustParse(hardConfigMaps)
 		err = waitForResourceQuota(f.ClientSet, f.Namespace.Name, quotaName, usedResources)
 		framework.ExpectNoError(err)
@@ -1567,7 +1565,7 @@ func newTestResourceQuota(name string) *v1.ResourceQuota {
 	hard[v1.ResourceQuotas] = resource.MustParse("1")
 	hard[v1.ResourceCPU] = resource.MustParse("1")
 	hard[v1.ResourceMemory] = resource.MustParse("500Mi")
-	hard[v1.ResourceConfigMaps] = resource.MustParse("2")
+	hard[v1.ResourceConfigMaps] = resource.MustParse("10")
 	hard[v1.ResourceSecrets] = resource.MustParse("10")
 	hard[v1.ResourcePersistentVolumeClaims] = resource.MustParse("10")
 	hard[v1.ResourceRequestsStorage] = resource.MustParse("10Gi")


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
Fix a problem in conformance.

The configMap should not be restricted to 2 in resource quota.
In some case, there are config maps which will be created by default.

-  Why this is needed? The CA configmap created by default in 1.20. Per https://github.com/kubernetes/kubernetes/issues/100016#issuecomment-795689545

#### Which issue(s) this PR fixes:
Fixes #100016

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```
