### PR TITLE
Snapshot e2e test: wait for the node to stop using a volume before taking a snapshot

### DIFF
--- a/test/e2e/storage/testsuites/provisioning.go
+++ b/test/e2e/storage/testsuites/provisioning.go
@@ -674,10 +674,14 @@ func (t StorageClassTest) TestBindingWaitForFirstConsumerMultiPVC(claims []*v1.P
 
 // RunInPodWithVolume runs a command in a pod with given claim mounted to /mnt directory.
 // It starts, checks, collects output and stops it.
-func RunInPodWithVolume(c clientset.Interface, t *framework.TimeoutContext, ns, claimName, podName, command string, node e2epod.NodeSelection) {
+func RunInPodWithVolume(c clientset.Interface, t *framework.TimeoutContext, ns, claimName, podName, command string, node e2epod.NodeSelection) *v1.Pod {
 	pod := StartInPodWithVolume(c, ns, claimName, podName, command, node)
 	defer StopPod(c, pod)
 	framework.ExpectNoError(e2epod.WaitForPodSuccessInNamespaceTimeout(c, pod.Name, pod.Namespace, t.PodStartSlow))
+	// get the latest status of the pod
+	pod, err := c.CoreV1().Pods(pod.Namespace).Get(context.TODO(), pod.Name, metav1.GetOptions{})
+	framework.ExpectNoError(err)
+	return pod
 }
 
 // StartInPodWithVolume starts a command in a pod with given claim mounted to /mnt directory

--- a/test/e2e/storage/testsuites/snapshottable.go
+++ b/test/e2e/storage/testsuites/snapshottable.go
@@ -19,9 +19,11 @@ package testsuites
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
 
 	v1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
@@ -143,7 +145,7 @@ func (s *snapshottableTestSuite) DefineTests(driver storageframework.TestDriver,
 			originalMntTestData = fmt.Sprintf("hello from %s namespace", pvc.GetNamespace())
 			command := fmt.Sprintf("echo '%s' > %s", originalMntTestData, datapath)
 
-			RunInPodWithVolume(cs, f.Timeouts, pvc.Namespace, pvc.Name, "pvc-snapshottable-tester", command, config.ClientNodeSelection)
+			pod := RunInPodWithVolume(cs, f.Timeouts, pvc.Namespace, pvc.Name, "pvc-snapshottable-tester", command, config.ClientNodeSelection)
 
 			err = e2epv.WaitForPersistentVolumeClaimPhase(v1.ClaimBound, cs, pvc.Namespace, pvc.Name, framework.Poll, f.Timeouts.ClaimProvision)
 			framework.ExpectNoError(err)
@@ -155,8 +157,47 @@ func (s *snapshottableTestSuite) DefineTests(driver storageframework.TestDriver,
 
 			// Get the bound PV
 			ginkgo.By("[init] checking the PV")
-			_, err = cs.CoreV1().PersistentVolumes().Get(context.TODO(), pvc.Spec.VolumeName, metav1.GetOptions{})
+			pv, err := cs.CoreV1().PersistentVolumes().Get(context.TODO(), pvc.Spec.VolumeName, metav1.GetOptions{})
 			framework.ExpectNoError(err)
+
+			// At this point we know that:
+			// - a pod was created with a PV that's supposed to have data
+			//
+			// However there's a caching issue that @jinxu97 explained and it's related with the pod & volume
+			// lifecycle in windows, to understand it we first analyze what the volumemanager does:
+			// - when a pod is delete the volumemanager will try to cleanup the volume mounts
+			//   - NodeUnpublishVolume: unbinds the bind mount from the container
+			//     - Linux: the data is flushed to disk
+			//     - Windows: we delete a symlink, data's not flushed yet to disk
+			//   - NodeUnstageVolume: unmount the global mount
+			//     - Linux: disk is detached
+			//     - Windows: data is flushed to disk and the disk is detached
+			//
+			// Pod deletion might not guarantee a data flush to disk, however NodeUnstageVolume adds the logic
+			// to flush the data to disk (see #81690 for details).
+			//
+			// In the following code by checking if the PV is not in the node.Status.VolumesInUse field we
+			// ensure that the volume is not used by the node anymore (an indicator that NodeUnstageVolume has
+			// already finished)
+			if framework.NodeOSDistroIs("windows") {
+				nodeName := pod.Spec.NodeName
+				gomega.Expect(nodeName).NotTo(gomega.BeEmpty(), "pod.Spec.NodeName must not be empty")
+
+				ginkgo.By(fmt.Sprintf("[init] waiting until the node=%s is not using the volume=%s", nodeName, pv.Name))
+				success := storageutils.WaitUntil(framework.Poll, f.Timeouts.PVDelete, func() bool {
+					node, err := cs.CoreV1().Nodes().Get(context.TODO(), nodeName, metav1.GetOptions{})
+					framework.ExpectNoError(err)
+					volumesInUse := node.Status.VolumesInUse
+					framework.Logf("current volumes in use: %+v", volumesInUse)
+					for i := 0; i < len(volumesInUse); i++ {
+						if strings.HasSuffix(string(volumesInUse[i]), pv.Name) {
+							return false
+						}
+					}
+					return true
+				})
+				framework.ExpectEqual(success, true)
+			}
 		}
 
 		cleanup := func() {
@@ -200,8 +241,8 @@ func (s *snapshottableTestSuite) DefineTests(driver storageframework.TestDriver,
 				vsc = sr.Vsclass
 			})
 			ginkgo.It("should check snapshot fields, check restore correctly works after modifying source data, check deletion", func() {
-				ginkgo.By("checking the snapshot")
 				// Get new copy of the snapshot
+				ginkgo.By("checking the snapshot")
 				vs, err = dc.Resource(storageutils.SnapshotGVR).Namespace(vs.GetNamespace()).Get(context.TODO(), vs.GetName(), metav1.GetOptions{})
 				framework.ExpectNoError(err)
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

Optionally add one or more of the following kinds if applicable:
/kind failing-test
/kind flake

#### What this PR does / why we need it:

During the volume snapshot test there's a caching problem that happens in windows, in the test after a pod is created with its volume, we write data to it and immediately delete it, at this point:

- a pod was created with a PV that's supposed to have data                                            
- when a container is no longer running the volumemanager will try to cleanup the volume mounts      
  - Unpublish: unbinds the global mount from the container                                            
    - Linux: the data is flushed to disk                                                              
    - Windows: we delete a symlink, data's not flushed yet to disk                                    
  - Unstage: unmount the global mount                                                                 
    - Linux: disk is detached                                                                         
    - Windows: data is flushed to disk and the disk is detached                                       
                                                                                                      
Therefore the conclusion is that in Linux the data is already flushed to disk when the pod           
is deleted, however in Windows the data might not be flushed to disk yet when the pod is deleted     
                                                                                                      
In the fix we make sure that the node isn't using the PV before taking the snapshot   

New logs:

```
STEP: [init] waiting until the node=e2e-test-mauriciopoppe-windows-node-group-jpck is not using the volume=pvc-2a8336a9-5def-4f57-aa9a-d5aaa4df9837
Mar 10 04:41:09.496: INFO: current volumes in use: [kubernetes.io/csi/pd.csi.storage.gke.io^projects/mauriciopoppe-gke-dev/zones/us-central1-b/disks/pvc-2a8336a9-5def-4f57-aa9a-d5aaa4df9837]
Mar 10 04:41:11.533: INFO: current volumes in use: [kubernetes.io/csi/pd.csi.storage.gke.io^projects/mauriciopoppe-gke-dev/zones/us-central1-b/disks/pvc-2a8336a9-5def-4f57-aa9a-d5aaa4df9837]
Mar 10 04:41:13.570: INFO: current volumes in use: [kubernetes.io/csi/pd.csi.storage.gke.io^projects/mauriciopoppe-gke-dev/zones/us-central1-b/disks/pvc-2a8336a9-5def-4f57-aa9a-d5aaa4df9837]
Mar 10 04:41:15.608: INFO: current volumes in use: [kubernetes.io/csi/pd.csi.storage.gke.io^projects/mauriciopoppe-gke-dev/zones/us-central1-b/disks/pvc-2a8336a9-5def-4f57-aa9a-d5aaa4df9837]
Mar 10 04:41:17.643: INFO: current volumes in use: [kubernetes.io/csi/pd.csi.storage.gke.io^projects/mauriciopoppe-gke-dev/zones/us-central1-b/disks/pvc-2a8336a9-5def-4f57-aa9a-d5aaa4df9837]
Mar 10 04:41:19.680: INFO: current volumes in use: [kubernetes.io/csi/pd.csi.storage.gke.io^projects/mauriciopoppe-gke-dev/zones/us-central1-b/disks/pvc-2a8336a9-5def-4f57-aa9a-d5aaa4df9837]
Mar 10 04:41:21.718: INFO: current volumes in use: [kubernetes.io/csi/pd.csi.storage.gke.io^projects/mauriciopoppe-gke-dev/zones/us-central1-b/disks/pvc-2a8336a9-5def-4f57-aa9a-d5aaa4df9837]
Mar 10 04:41:23.755: INFO: current volumes in use: [kubernetes.io/csi/pd.csi.storage.gke.io^projects/mauriciopoppe-gke-dev/zones/us-central1-b/disks/pvc-2a8336a9-5def-4f57-aa9a-d5aaa4df9837]
Mar 10 04:41:25.793: INFO: current volumes in use: [kubernetes.io/csi/pd.csi.storage.gke.io^projects/mauriciopoppe-gke-dev/zones/us-central1-b/disks/pvc-2a8336a9-5def-4f57-aa9a-d5aaa4df9837]
Mar 10 04:41:27.830: INFO: current volumes in use: [kubernetes.io/csi/pd.csi.storage.gke.io^projects/mauriciopoppe-gke-dev/zones/us-central1-b/disks/pvc-2a8336a9-5def-4f57-aa9a-d5aaa4df9837]
Mar 10 04:41:29.867: INFO: current volumes in use: []
Mar 10 04:41:29.867: INFO: WaitUntil finished successfully after 20.406886973s
```    

Results (`stress -p 3`):

```
11h44m15s: 332 runs so far, 4 failures (1.20%)
```                                  

All of the failures have an error like this (this error is unrelated with the snapshot error that we're supposed to fix):

```
Mar 10 08:11:49.074: INFO: At 2021-03-10 07:56:33 +0000 UTC - event for pvc-snapshottable-data-tester-qkdq6: {kubelet e2e-test-mauriciopoppe-windows-node-group-jpck} FailedMount: MountVolume.MountDevice failed for volume "pvc-34b7a924-f1f7-47f9-940e-9bdfe89179c4" : rpc error: code = Internal desc = Error when getting device path: could not find disk number for device pvc-34b7a924-f1f7-47f9-940e-9bdfe89179c4
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

/cc @jingxu97 