### PR TITLE
fix bug : The status change of kubelet will cause unnecessary pod mig…

### DIFF
--- a/pkg/kubelet/kubelet_node_status.go
+++ b/pkg/kubelet/kubelet_node_status.go
@@ -73,6 +73,8 @@ func (kl *Kubelet) registerWithAPIServer() {
 		if registered {
 			klog.Infof("Successfully registered node %s", node.Name)
 			kl.registrationCompleted = true
+			//The node status remains ready when restarting the kubelet when container runtime is running normally.
+			kl.updateRuntimeUp()
 			return
 		}
 	}


### PR DESCRIPTION
…ration

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
If kubelet is stopped, pod will migrate between different nodes, which is normal. However, if you just restart the kubelet or modify the kubelet parameters through configz, the status change of the kubelet will cause unnecessary pod migration.
When we restart kubelet, the following code will be executed:

https://github.com/kubernetes/kubernetes/blob/2195718940282cc4e1b553760c1e9e020b9fb992/pkg/kubelet/kubelet.go#L1434-L1442

The kl.syncNodeStatus method is executed every 10 seconds by default,and the kl.updateRuntimeUp method is executed every 5 seconds by default.They are all executed in goroutine.

kl.syncNodeStatus will do the following thing:

1. kl.registerWithAPIServer()  tip : After the registration is successful, the flag bit will be set and will not be executed in the loop
2. kl.updateNodeStatus()
https://github.com/kubernetes/kubernetes/blob/2195718940282cc4e1b553760c1e9e020b9fb992/pkg/kubelet/kubelet_node_status.go#L445-L459


kl.updateRuntimeUp will read the status information in kl.containerRuntime and update it to kl.runtimeState, and provide it to kl.syncNodeStatus(kl.updateNodeStatus() inside) to use when judging the NodeReady status in node.

Therefore, if the kubelet is restarted, the status of the node is likely to change like this: ready->not ready->ready.

we should execute kl.updateRuntimeUp before execute kl.updateNodeStatus() in syncNodeStatus() when first time we register this node.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
