### PR TITLE
Automated cherry pick of #99613: fix wrong NumCPU in kube-proxy under static CPU policy

### DIFF
--- a/cmd/kube-proxy/app/BUILD
+++ b/cmd/kube-proxy/app/BUILD
@@ -87,6 +87,8 @@ go_library(
             "//staging/src/k8s.io/client-go/tools/cache:go_default_library",
             "//staging/src/k8s.io/client-go/tools/watch:go_default_library",
             "//staging/src/k8s.io/component-base/metrics:go_default_library",
+            "//vendor/github.com/google/cadvisor/machine:go_default_library",
+            "//vendor/github.com/google/cadvisor/utils/sysfs:go_default_library",
             "//vendor/k8s.io/utils/net:go_default_library",
         ],
         "@io_bazel_rules_go//go/platform:android": [
@@ -99,6 +101,8 @@ go_library(
             "//staging/src/k8s.io/client-go/tools/cache:go_default_library",
             "//staging/src/k8s.io/client-go/tools/watch:go_default_library",
             "//staging/src/k8s.io/component-base/metrics:go_default_library",
+            "//vendor/github.com/google/cadvisor/machine:go_default_library",
+            "//vendor/github.com/google/cadvisor/utils/sysfs:go_default_library",
             "//vendor/k8s.io/utils/net:go_default_library",
         ],
         "@io_bazel_rules_go//go/platform:darwin": [
@@ -111,6 +115,8 @@ go_library(
             "//staging/src/k8s.io/client-go/tools/cache:go_default_library",
             "//staging/src/k8s.io/client-go/tools/watch:go_default_library",
             "//staging/src/k8s.io/component-base/metrics:go_default_library",
+            "//vendor/github.com/google/cadvisor/machine:go_default_library",
+            "//vendor/github.com/google/cadvisor/utils/sysfs:go_default_library",
             "//vendor/k8s.io/utils/net:go_default_library",
         ],
         "@io_bazel_rules_go//go/platform:dragonfly": [
@@ -123,6 +129,8 @@ go_library(
             "//staging/src/k8s.io/client-go/tools/cache:go_default_library",
             "//staging/src/k8s.io/client-go/tools/watch:go_default_library",
             "//staging/src/k8s.io/component-base/metrics:go_default_library",
+            "//vendor/github.com/google/cadvisor/machine:go_default_library",
+            "//vendor/github.com/google/cadvisor/utils/sysfs:go_default_library",
             "//vendor/k8s.io/utils/net:go_default_library",
         ],
         "@io_bazel_rules_go//go/platform:freebsd": [
@@ -135,6 +143,8 @@ go_library(
             "//staging/src/k8s.io/client-go/tools/cache:go_default_library",
             "//staging/src/k8s.io/client-go/tools/watch:go_default_library",
             "//staging/src/k8s.io/component-base/metrics:go_default_library",
+            "//vendor/github.com/google/cadvisor/machine:go_default_library",
+            "//vendor/github.com/google/cadvisor/utils/sysfs:go_default_library",
             "//vendor/k8s.io/utils/net:go_default_library",
         ],
         "@io_bazel_rules_go//go/platform:illumos": [
@@ -147,6 +157,8 @@ go_library(
             "//staging/src/k8s.io/client-go/tools/cache:go_default_library",
             "//staging/src/k8s.io/client-go/tools/watch:go_default_library",
             "//staging/src/k8s.io/component-base/metrics:go_default_library",
+            "//vendor/github.com/google/cadvisor/machine:go_default_library",
+            "//vendor/github.com/google/cadvisor/utils/sysfs:go_default_library",
             "//vendor/k8s.io/utils/net:go_default_library",
         ],
         "@io_bazel_rules_go//go/platform:ios": [
@@ -159,6 +171,8 @@ go_library(
             "//staging/src/k8s.io/client-go/tools/cache:go_default_library",
             "//staging/src/k8s.io/client-go/tools/watch:go_default_library",
             "//staging/src/k8s.io/component-base/metrics:go_default_library",
+            "//vendor/github.com/google/cadvisor/machine:go_default_library",
+            "//vendor/github.com/google/cadvisor/utils/sysfs:go_default_library",
             "//vendor/k8s.io/utils/net:go_default_library",
         ],
         "@io_bazel_rules_go//go/platform:js": [
@@ -171,6 +185,8 @@ go_library(
             "//staging/src/k8s.io/client-go/tools/cache:go_default_library",
             "//staging/src/k8s.io/client-go/tools/watch:go_default_library",
             "//staging/src/k8s.io/component-base/metrics:go_default_library",
+            "//vendor/github.com/google/cadvisor/machine:go_default_library",
+            "//vendor/github.com/google/cadvisor/utils/sysfs:go_default_library",
             "//vendor/k8s.io/utils/net:go_default_library",
         ],
         "@io_bazel_rules_go//go/platform:linux": [
@@ -183,6 +199,8 @@ go_library(
             "//staging/src/k8s.io/client-go/tools/cache:go_default_library",
             "//staging/src/k8s.io/client-go/tools/watch:go_default_library",
             "//staging/src/k8s.io/component-base/metrics:go_default_library",
+            "//vendor/github.com/google/cadvisor/machine:go_default_library",
+            "//vendor/github.com/google/cadvisor/utils/sysfs:go_default_library",
             "//vendor/k8s.io/utils/net:go_default_library",
         ],
         "@io_bazel_rules_go//go/platform:nacl": [
@@ -195,6 +213,8 @@ go_library(
             "//staging/src/k8s.io/client-go/tools/cache:go_default_library",
             "//staging/src/k8s.io/client-go/tools/watch:go_default_library",
             "//staging/src/k8s.io/component-base/metrics:go_default_library",
+            "//vendor/github.com/google/cadvisor/machine:go_default_library",
+            "//vendor/github.com/google/cadvisor/utils/sysfs:go_default_library",
             "//vendor/k8s.io/utils/net:go_default_library",
         ],
         "@io_bazel_rules_go//go/platform:netbsd": [
@@ -207,6 +227,8 @@ go_library(
             "//staging/src/k8s.io/client-go/tools/cache:go_default_library",
             "//staging/src/k8s.io/client-go/tools/watch:go_default_library",
             "//staging/src/k8s.io/component-base/metrics:go_default_library",
+            "//vendor/github.com/google/cadvisor/machine:go_default_library",
+            "//vendor/github.com/google/cadvisor/utils/sysfs:go_default_library",
             "//vendor/k8s.io/utils/net:go_default_library",
         ],
         "@io_bazel_rules_go//go/platform:openbsd": [
@@ -219,6 +241,8 @@ go_library(
             "//staging/src/k8s.io/client-go/tools/cache:go_default_library",
             "//staging/src/k8s.io/client-go/tools/watch:go_default_library",
             "//staging/src/k8s.io/component-base/metrics:go_default_library",
+            "//vendor/github.com/google/cadvisor/machine:go_default_library",
+            "//vendor/github.com/google/cadvisor/utils/sysfs:go_default_library",
             "//vendor/k8s.io/utils/net:go_default_library",
         ],
         "@io_bazel_rules_go//go/platform:plan9": [
@@ -231,6 +255,8 @@ go_library(
             "//staging/src/k8s.io/client-go/tools/cache:go_default_library",
             "//staging/src/k8s.io/client-go/tools/watch:go_default_library",
             "//staging/src/k8s.io/component-base/metrics:go_default_library",
+            "//vendor/github.com/google/cadvisor/machine:go_default_library",
+            "//vendor/github.com/google/cadvisor/utils/sysfs:go_default_library",
             "//vendor/k8s.io/utils/net:go_default_library",
         ],
         "@io_bazel_rules_go//go/platform:solaris": [
@@ -243,6 +269,8 @@ go_library(
             "//staging/src/k8s.io/client-go/tools/cache:go_default_library",
             "//staging/src/k8s.io/client-go/tools/watch:go_default_library",
             "//staging/src/k8s.io/component-base/metrics:go_default_library",
+            "//vendor/github.com/google/cadvisor/machine:go_default_library",
+            "//vendor/github.com/google/cadvisor/utils/sysfs:go_default_library",
             "//vendor/k8s.io/utils/net:go_default_library",
         ],
         "@io_bazel_rules_go//go/platform:windows": [

--- a/cmd/kube-proxy/app/server.go
+++ b/cmd/kube-proxy/app/server.go
@@ -24,7 +24,6 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
-	goruntime "runtime"
 	"strings"
 	"time"
 
@@ -790,7 +789,7 @@ func getConntrackMax(config kubeproxyconfig.KubeProxyConntrackConfiguration) (in
 		if config.Min != nil {
 			floor = int(*config.Min)
 		}
-		scaled := int(*config.MaxPerCore) * goruntime.NumCPU()
+		scaled := int(*config.MaxPerCore) * detectNumCPU()
 		if scaled > floor {
 			klog.V(3).Infof("getConntrackMax: using scaled conntrack-max-per-core")
 			return scaled, nil

--- a/cmd/kube-proxy/app/server_others.go
+++ b/cmd/kube-proxy/app/server_others.go
@@ -25,9 +25,12 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	goruntime "runtime"
 	"strings"
 	"time"
 
+	"github.com/google/cadvisor/machine"
+	"github.com/google/cadvisor/utils/sysfs"
 	"k8s.io/apimachinery/pkg/watch"
 
 	"k8s.io/apimachinery/pkg/runtime"
@@ -432,6 +435,15 @@ func detectNodeIP(client clientset.Interface, hostname, bindAddress string) net.
 		nodeIP = net.ParseIP("127.0.0.1")
 	}
 	return nodeIP
+}
+
+func detectNumCPU() int {
+	// try get numCPU from /sys firstly due to a known issue (https://github.com/kubernetes/kubernetes/issues/99225)
+	_, numCPU, err := machine.GetTopology(sysfs.NewRealSysFs())
+	if err != nil || numCPU < 1 {
+		return goruntime.NumCPU()
+	}
+	return numCPU
 }
 
 func getDetectLocalMode(config *proxyconfigapi.KubeProxyConfiguration) (proxyconfigapi.LocalMode, error) {

--- a/cmd/kube-proxy/app/server_windows.go
+++ b/cmd/kube-proxy/app/server_windows.go
@@ -24,6 +24,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	goruntime "runtime"
 
 	// Enable pprof HTTP handlers.
 	_ "net/http/pprof"
@@ -185,6 +186,10 @@ func getProxyMode(proxyMode string, kcompat winkernel.KernelCompatTester) string
 		return tryWinKernelSpaceProxy(kcompat)
 	}
 	return proxyModeUserspace
+}
+
+func detectNumCPU() int {
+	return goruntime.NumCPU()
 }
 
 func tryWinKernelSpaceProxy(kcompat winkernel.KernelCompatTester) string {


### PR DESCRIPTION
Cherry pick of #99613 on release-1.20.

#99613: fix wrong NumCPU in kube-proxy under static CPU policy

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.