### PR TITLE
rename apiserver_storage_object_counts to apiserver_storage_objects

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/metrics/metrics.go
@@ -54,7 +54,7 @@ var (
 	)
 	objectCounts = compbasemetrics.NewGaugeVec(
 		&compbasemetrics.GaugeOpts{
-			Name:           "apiserver_storage_object_counts",
+			Name:           "apiserver_storage_objects",
 			Help:           "Number of stored objects at the time of last check split by kind.",
 			StabilityLevel: compbasemetrics.STABLE,
 		},

--- a/test/instrumentation/testdata/stable-metrics-list.yaml
+++ b/test/instrumentation/testdata/stable-metrics-list.yaml
@@ -65,7 +65,7 @@
   - subresource
   - verb
   - version
-- name: apiserver_storage_object_counts
+- name: apiserver_storage_objects
   help: Number of stored objects at the time of last check split by kind.
   type: Gauge
   stabilityLevel: STABLE


### PR DESCRIPTION
To conform to instrumentation best practices. 

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Pluralized `_counts` is actually an anti-pattern for metrics, instead we pluralize the name of the thing being counted for gauges. 


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
`apiserver_storage_objects` (a newer version of `etcd_object_counts) is promoted and marked as stable. 
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-instrumentation/1209-metrics-stability

```
