### PR TITLE
[test-only] Promote PDB CRUD e2e tests to conformance

### DIFF
--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -698,11 +698,29 @@
     MUST succeed. It MUST succeed when deleting the Deployment.
   release: v1.20
   file: test/e2e/apps/deployment.go
+- testname: 'PodDisruptionBudget: list and delete collection'
+  codename: '[sig-apps] DisruptionController Listing PodDisruptionBudgets for all
+    namespaces should list and delete a collection of PodDisruptionBudgets [Conformance]'
+  description: PodDisruptionBudget API must support list and deletecollection operations.
+  release: v1.21
+  file: test/e2e/apps/disruption.go
+- testname: 'PodDisruptionBudget: create and delete object'
+  codename: '[sig-apps] DisruptionController should create a PodDisruptionBudget [Conformance]'
+  description: PodDisruptionBudget API must support create and delete operations.
+  release: v1.21
+  file: test/e2e/apps/disruption.go
 - testname: 'PodDisruptionBudget: Status updates'
   codename: '[sig-apps] DisruptionController should observe PodDisruptionBudget status
     updated [Conformance]'
   description: Disruption controller MUST update the PDB status with how many disruptions
     are allowed.
+  release: v1.21
+  file: test/e2e/apps/disruption.go
+- testname: 'PodDisruptionBudget: update and patch status'
+  codename: '[sig-apps] DisruptionController should update/patch PodDisruptionBudget
+    status [Conformance]'
+  description: PodDisruptionBudget API must support update and patch operations on
+    status subresource.
   release: v1.21
   file: test/e2e/apps/disruption.go
 - testname: Jobs, orphan pods, re-adoption

--- a/test/e2e/apps/disruption.go
+++ b/test/e2e/apps/disruption.go
@@ -75,7 +75,12 @@ var _ = SIGDescribe("DisruptionController", func() {
 	ginkgo.Context("Listing PodDisruptionBudgets for all namespaces", func() {
 		anotherFramework := framework.NewDefaultFramework("disruption-2")
 
-		ginkgo.It("should list and delete a collection of PodDisruptionBudgets", func() {
+		/*
+		   Release : v1.21
+		   Testname: PodDisruptionBudget: list and delete collection
+		   Description: PodDisruptionBudget API must support list and deletecollection operations.
+		*/
+		framework.ConformanceIt("should list and delete a collection of PodDisruptionBudgets", func() {
 			specialLabels := map[string]string{"foo_pdb": "bar_pdb"}
 			labelSelector := labels.SelectorFromSet(specialLabels).String()
 			createPDBMinAvailableOrDie(cs, ns, defaultName, intstr.FromInt(2), specialLabels)
@@ -91,8 +96,14 @@ var _ = SIGDescribe("DisruptionController", func() {
 		})
 	})
 
-	ginkgo.It("should create a PodDisruptionBudget", func() {
+	/*
+		Release : v1.21
+		Testname: PodDisruptionBudget: create and delete object
+		Description: PodDisruptionBudget API must support create and delete operations.
+	*/
+	framework.ConformanceIt("should create a PodDisruptionBudget", func() {
 		createPDBMinAvailableOrDie(cs, ns, defaultName, intstr.FromString("1%"), defaultLabels)
+		deletePDBOrDie(cs, ns, defaultName)
 	})
 
 	/*
@@ -119,7 +130,12 @@ var _ = SIGDescribe("DisruptionController", func() {
 		framework.ExpectNoError(err)
 	})
 
-	ginkgo.It("should update/patch PodDisruptionBudget status", func() {
+	/*
+		Release : v1.21
+		Testname: PodDisruptionBudget: update and patch status
+		Description: PodDisruptionBudget API must support update and patch operations on status subresource.
+	*/
+	framework.ConformanceIt("should update/patch PodDisruptionBudget status", func() {
 		createPDBMinAvailableOrDie(cs, ns, defaultName, intstr.FromInt(1), defaultLabels)
 
 		ginkgo.By("Updating PodDisruptionBudget status")


### PR DESCRIPTION
Promotes additional existing PDB e2e tests to conformance to cover CRUD operations

xref https://github.com/kubernetes/kubernetes/pull/84740#issuecomment-795616462

/kind test

Run history at https://testgrid.k8s.io/sig-release-master-blocking#gce-ubuntu-master-containerd&include-filter-by-regex=DisruptionController&show-stale-tests=&exclude-filter-by-regex=eviction&exclude-filter-by-regex=Conformance&exclude-filter-by-regex=status%20updated&width=5 showing flake free operation for > 2 weeks

```release-note
NONE
```

/cc @mortent 