### PR TITLE
fix rounding of volume storage requests

### DIFF
--- a/pkg/volume/portworx/portworx_util.go
+++ b/pkg/volume/portworx/portworx_util.go
@@ -214,9 +214,9 @@ func (util *portworxVolumeUtil) ResizeVolume(spec *volume.Spec, newSize resource
 	}
 
 	vol := vols[0]
-	tBytes, ok := newSize.AsInt64()
-	if !ok {
-		return fmt.Errorf("quantity %v is too great, overflows int64", newSize)
+	tBytes, err := volumehelpers.RoundUpToB(newSize)
+	if err != nil {
+		return err
 	}
 	newSizeInBytes := uint64(tBytes)
 	if vol.Spec.Size >= newSizeInBytes {

--- a/staging/src/k8s.io/cloud-provider/volume/helpers/rounding_test.go
+++ b/staging/src/k8s.io/cloud-provider/volume/helpers/rounding_test.go
@@ -60,8 +60,18 @@ func Test_RoundUpToGiB(t *testing.T) {
 			roundedVal: int64(1000),
 		},
 		{
-			name:        "round overflowed quantity to int64",
-			resource:    resource.MustParse("73786976299133170k"),
+			name:       "round decimal to GiB",
+			resource:   resource.MustParse("1.2Gi"),
+			roundedVal: int64(2),
+		},
+		{
+			name:       "round big value to GiB",
+			resource:   resource.MustParse("8191Pi"),
+			roundedVal: int64(8588886016),
+		},
+		{
+			name:        "round quantity to GiB that would lead to an int64 overflow",
+			resource:    resource.MustParse("8192Pi"),
 			roundedVal:  int64(0),
 			expectError: true,
 		},
@@ -125,8 +135,18 @@ func Test_RoundUpToMB(t *testing.T) {
 			roundedVal: int64(1073742),
 		},
 		{
-			name:        "round overflowed quantity to int64",
-			resource:    resource.MustParse("73786976299133170k"),
+			name:       "round decimal to MB",
+			resource:   resource.MustParse("1.2Gi"),
+			roundedVal: int64(1289),
+		},
+		{
+			name:       "round big value to MB",
+			resource:   resource.MustParse("8191Pi"),
+			roundedVal: int64(9222246136948),
+		},
+		{
+			name:        "round quantity to MB that would lead to an int64 overflow",
+			resource:    resource.MustParse("8192Pi"),
 			roundedVal:  int64(0),
 			expectError: true,
 		},
@@ -190,8 +210,18 @@ func Test_RoundUpToMiB(t *testing.T) {
 			roundedVal: int64(1024000),
 		},
 		{
-			name:        "round overflowed quantity to int64",
-			resource:    resource.MustParse("73786976299133170k"),
+			name:       "round decimal to MiB",
+			resource:   resource.MustParse("1.2Gi"),
+			roundedVal: int64(1229),
+		},
+		{
+			name:       "round big value to MiB",
+			resource:   resource.MustParse("8191Pi"),
+			roundedVal: int64(8795019280384),
+		},
+		{
+			name:        "round quantity to MiB that would lead to an int64 overflow",
+			resource:    resource.MustParse("8192Pi"),
 			roundedVal:  int64(0),
 			expectError: true,
 		},
@@ -255,8 +285,18 @@ func Test_RoundUpToKB(t *testing.T) {
 			roundedVal: int64(1073741824),
 		},
 		{
-			name:        "round overflowed quantity to int64",
-			resource:    resource.MustParse("73786976299133170k"),
+			name:       "round decimal to KB",
+			resource:   resource.MustParse("1.2Gi"),
+			roundedVal: int64(1288491),
+		},
+		{
+			name:       "round big value to KB",
+			resource:   resource.MustParse("8191Pi"),
+			roundedVal: int64(9222246136947934),
+		},
+		{
+			name:        "round quantity to KB that would lead to an int64 overflow",
+			resource:    resource.MustParse("8192Pi"),
 			roundedVal:  int64(0),
 			expectError: true,
 		},
@@ -320,8 +360,18 @@ func Test_RoundUpToKiB(t *testing.T) {
 			roundedVal: int64(1048576000),
 		},
 		{
-			name:        "round overflowed quantity to int64",
-			resource:    resource.MustParse("73786976299133170k"),
+			name:       "round decimal to KiB",
+			resource:   resource.MustParse("1.2Gi"),
+			roundedVal: int64(1258292),
+		},
+		{
+			name:       "round big value to KiB",
+			resource:   resource.MustParse("8191Pi"),
+			roundedVal: int64(9006099743113216),
+		},
+		{
+			name:        "round quantity to KiB that would lead to an int64 overflow",
+			resource:    resource.MustParse("8192Pi"),
 			roundedVal:  int64(0),
 			expectError: true,
 		},
@@ -385,8 +435,18 @@ func Test_RoundUpToGiBInt32(t *testing.T) {
 			roundedVal: int32(1000),
 		},
 		{
-			name:        "round overflowed quantity to int32",
-			resource:    resource.MustParse("73786976299133170k"),
+			name:       "round decimal to GiB",
+			resource:   resource.MustParse("1.2Gi"),
+			roundedVal: int32(2),
+		},
+		{
+			name:       "round big value to GiB",
+			resource:   resource.MustParse("2047Pi"),
+			roundedVal: int32(2146435072),
+		},
+		{
+			name:        "round quantity to GiB that would lead to an int32 overflow",
+			resource:    resource.MustParse("2048Pi"),
 			roundedVal:  int32(0),
 			expectError: true,
 		},
@@ -395,6 +455,56 @@ func Test_RoundUpToGiBInt32(t *testing.T) {
 	for _, test := range testcases {
 		t.Run(test.name, func(t *testing.T) {
 			val, err := RoundUpToGiBInt32(test.resource)
+			if !test.expectError && err != nil {
+				t.Errorf("expected no error got: %v", err)
+			}
+
+			if test.expectError && err == nil {
+				t.Errorf("expected error but got nothing")
+			}
+
+			if val != test.roundedVal {
+				t.Logf("actual rounded value: %d", val)
+				t.Logf("expected rounded value: %d", test.roundedVal)
+				t.Error("unexpected rounded value")
+			}
+		})
+	}
+}
+
+func Test_RoundUpToB(t *testing.T) {
+	testcases := []struct {
+		name        string
+		resource    resource.Quantity
+		roundedVal  int64
+		expectError bool
+	}{
+		{
+			name:       "round m to B",
+			resource:   resource.MustParse("987m"),
+			roundedVal: int64(1),
+		},
+		{
+			name:       "round decimal to B",
+			resource:   resource.MustParse("1.2Gi"),
+			roundedVal: int64(1288490189),
+		},
+		{
+			name:       "round big value to B",
+			resource:   resource.MustParse("8191Pi"),
+			roundedVal: int64(9222246136947933184),
+		},
+		{
+			name:        "round quantity to B that would lead to an int64 overflow",
+			resource:    resource.MustParse("8192Pi"),
+			roundedVal:  int64(0),
+			expectError: true,
+		},
+	}
+
+	for _, test := range testcases {
+		t.Run(test.name, func(t *testing.T) {
+			val, err := RoundUpToB(test.resource)
 			if !test.expectError && err != nil {
 				t.Errorf("expected no error got: %v", err)
 			}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
This fixes https://github.com/kubernetes/kubernetes/issues/100091 which prevents the provisioning of volumes of storage requests that contains a decimal part (e.g. 3.2Gi).

A few things were new to me when I read the code. I might have missed the intent of [the PR that brought the change](https://github.com/kubernetes/kubernetes/pull/66464) or the idea that were behind the file I edited. I'll try to present my understanding to be sure I got it right.

The cloud provider's volume drivers are responsible to transform PVC requests into an actual disk. There are very different allocation units from one provider to the other. AWS allows you to specify the size in GiB, but Portworx accepts bytes for example. on AWS, if you want a volume of 1500MiB, the actual call to the AWS API should therefore be for a 2GiB disk.

Those manipulations of storage sizes are mostly done in the [rounding helper](https://github.com/kubernetes/kubernetes/blob/cea1d4e20b4a7886d8ff65f34c6d4f95efcb4742/staging/src/k8s.io/cloud-provider/volume/helpers/rounding.go) which provides a set of functions that round up volume sizes given an allocation unit.

There are different ways in which calculations around storage resource request might overflow there:
1. The storage request `Quantity` from the PVC might not fit in a 64bits integer. In this case, retrieving its value by calling `(q *Quantity) Value() int64` would give a wrong result and might lead in a volume of an unexpected size. This is what is mentioned in the [ScaledValue()'s](https://github.com/kubernetes/kubernetes/blob/da75c266487c52425d3eb07df30229aea04bb28e/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity.go#L728-L743) description.
2. The rounding helper provides functions for different type of results: int64, int32 and int. If each of their variant, there might be an overflow that would mess with the storage request value and result in wrong calculation.

I believe those are the two points the PR https://github.com/kubernetes/kubernetes/pull/66464 was trying to solve.
To do so, two changes were introduced:
* `RoundUpToGiBInt*` were created in order to replace unprotected integer casts
* calls to `(q *Quantity) Value()` were replaced with `(q *Quantity) AsInt64() (int64, bool)`. If the boolean is false, then an error is thrown

As stated in the issue where I tried to [summarize the symptoms](https://github.com/kubernetes/kubernetes/issues/100091), I believe the description of `AsInt64()` was misinterpreted. This function is used as if its second return value would indicate if the underlying quantity is too big to fit in a int64. If I understood [the description of AsInt64()](https://github.com/kubernetes/kubernetes/blob/da75c266487c52425d3eb07df30229aea04bb28e/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity.go#L476-L483) and [ParseQuantity()](https://github.com/kubernetes/kubernetes/blob/da75c266487c52425d3eb07df30229aea04bb28e/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity.go#L264-L378) enough, the return value false indicates something else. It tells the caller that the value is not an integer amount. This means the caller need to actually call `Value()` which relies on `ScaledValue()` and will return an approximation (which is good enough I suppose for what we do with it).


#### Which issue(s) this PR fixes:
Fixes https://github.com/kubernetes/kubernetes/issues/100091

#### Special notes for your reviewer:

In `roundUpSizeInt()` and `roundUpSizeInt32()` we check if the result is bigger than the type we're using to return the value, and eventually return an error. This allows us to return values up to the maximum possible. In `roundUpSizeInt64()` it's a bit different as we're checking if the quantity we're working with would fit in a 64 bits integer. The actual result might be much smaller since we will divide it by the allocation unit. The maximum result is that same as before the PR but potentially, we could transform our quantity into a decimal amount and work with the `big.Int` underneath. That would allow us to increase the maximum value roundUpSizeInt64()` can return. I chose not to go into that direction since calling this function to round up bytes, already allows us to manipulate thousand of petabyte. 

I don't know if all the code referring to the line I changed is in this repository, but if that's the case it looks like `RoundUpToKiBInt`, `RoundUpToKBInt`, `RoundUpToMBInt`, `RoundUpToKiB`, `RoundUpToKB`, `RoundUpToMB` are never called. If they're not meant just to be there in case somebody use them, maybe we could remove them ?

#### Does this PR introduce a user-facing change?
```release-note
Fix rounding of volume storage requests
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
