### PR TITLE
prevent mutation of deletion options during delete collection

### DIFF
--- a/test/integration/scheduler/util.go
+++ b/test/integration/scheduler/util.go
@@ -474,9 +474,12 @@ func noPodsInNamespace(c clientset.Interface, podNamespace string) wait.Conditio
 }
 
 // cleanupPodsInNamespace deletes the pods in the given namespace and waits for them to
-// be actually deleted.
+// be actually deleted.  They are removed with no grace.
 func cleanupPodsInNamespace(cs clientset.Interface, t *testing.T, ns string) {
-	if err := cs.CoreV1().Pods(ns).DeleteCollection(context.TODO(), metav1.DeleteOptions{}, metav1.ListOptions{}); err != nil {
+	t.Helper()
+
+	zero := int64(0)
+	if err := cs.CoreV1().Pods(ns).DeleteCollection(context.TODO(), metav1.DeleteOptions{GracePeriodSeconds: &zero}, metav1.ListOptions{}); err != nil {
 		t.Errorf("error while listing pod in namespace %v: %v", ns, err)
 		return
 	}


### PR DESCRIPTION
DeepCopy the deletion options because individual graceful deleters communicate changes via a mutating function in the delete strategy called in the delete method.  While that is always ugly, it works when making a single call.  When making multiple calls via delete collection, the mutation applied to pod/A can change the option ultimately used for pod/B.  This can result in pods be non-gracefully terminated

The mutation happens here https://github.com/kubernetes/kubernetes/blob/master/pkg/registry/core/pod/strategy.go#L159 and is documented as the proper way for gracefuldeleters to indicate new values.

/kind bug
/priority important-soon
@kubernetes/sig-node-bugs 

```release-note
graceful termination will now be honored when deleting a collection of pods.
```