### PR TITLE
Rolling back PR 100027

### DIFF
--- a/test/integration/endpointslice/endpointslicemirroring_test.go
+++ b/test/integration/endpointslice/endpointslicemirroring_test.go
@@ -377,13 +377,13 @@ func TestEndpointSliceMirroringUpdates(t *testing.T) {
 
 					if !apiequality.Semantic.DeepEqual(epAddresses, sliceAddresses) {
 						t.Logf("Expected EndpointSlice to have the same IP addresses, expected %v got %v", epAddresses, sliceAddresses)
-						continue
+						return false, nil
 					}
 
 					// check labels were mirrored
 					if !isSubset(customEndpoints.Labels, endpointSlice.Labels) {
 						t.Logf("Expected EndpointSlice to mirror labels, expected %v to be in received %v", customEndpoints.Labels, endpointSlice.Labels)
-						continue
+						return false, nil
 					}
 
 					// check annotations but endpoints.kubernetes.io/last-change-trigger-time were mirrored
@@ -396,13 +396,10 @@ func TestEndpointSliceMirroringUpdates(t *testing.T) {
 					}
 					if !apiequality.Semantic.DeepEqual(annotations, endpointSlice.Annotations) {
 						t.Logf("Expected EndpointSlice to mirror annotations, expected %v received %v", customEndpoints.Annotations, endpointSlice.Annotations)
-						continue
+						return false, nil
 					}
-					// This is a temporary workaround for https://github.com/kubernetes/kubernetes/issues/100033.
-					// TODO(robscott): When that issue is fixed, update this test to expect all EndpointSlices to meet this criteria.
-					return true, nil
 				}
-				return false, nil
+				return true, nil
 			})
 			if err != nil {
 				t.Fatalf("Timed out waiting for conditions: %v", err)


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/kind flake

#### What this PR does / why we need it:
PR #100027 was filed as a temporary workaround to reduce flakiness. Now that the root cause has been fixed by #100103 we can restore the full test.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/sig network
/priority important-soon
/cc @aojea @swetharepakula 
/assign @MrHohn 