### PR TITLE
fix nil pointer dereference in klog.KObj pod in kubelet

### DIFF
--- a/pkg/kubelet/kuberuntime/kuberuntime_container.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container.go
@@ -674,8 +674,12 @@ func (m *kubeGenericRuntimeManager) killContainersWithSyncResult(pod *v1.Pod, ru
 			killContainerResult := kubecontainer.NewSyncResult(kubecontainer.KillContainer, container.Name)
 			if err := m.killContainer(pod, container.ID, container.Name, "", gracePeriodOverride); err != nil {
 				killContainerResult.Fail(kubecontainer.ErrKillContainer, err.Error())
-				klog.ErrorS(err, "Kill container failed", "pod", klog.KObj(pod), "podUID", pod.UID,
-					"containerName", container.Name, "containerID", container.ID)
+				if pod == nil {
+					klog.ErrorS(err, "Kill container failed", "containerName", container.Name, "containerID", container.ID)
+				} else {
+					klog.ErrorS(err, "Kill container failed", "pod", klog.KObj(pod), "podUID", pod.UID,
+						"containerName", container.Name, "containerID", container.ID)
+				}
 			}
 			containerResults <- killContainerResult
 		}(container)


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:

Catch this nil pointer error log in flake test logs of https://storage.googleapis.com/kubernetes-jenkins/pr-logs/pull/100050/pull-kubernetes-e2e-kind/1369786002343727104/artifacts/logs/kind-worker/kubelet.log

Not sure if we should fix it in klog https://github.com/pacoxu/klog/blob/master/klog.go#L1578-L1584

> 
> Mar 10 23:23:57 kind-worker kubelet[241]: E0310 23:23:57.580249     241 runtime.go:78] Observed a panic: "invalid memory address or nil pointer dereference" (runtime error: invalid memory address or nil pointer dereference)
> Mar 10 23:23:57 kind-worker kubelet[241]: goroutine 4504 [running]:
> Mar 10 23:23:57 kind-worker kubelet[241]: k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/runtime.logPanic(0x41cc2c0, 0x7377320)
> Mar 10 23:23:57 kind-worker kubelet[241]:         /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:74 +0x95
> Mar 10 23:23:57 kind-worker kubelet[241]: k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/runtime.HandleCrash(0x0, 0x0, 0x0)
> Mar 10 23:23:57 kind-worker kubelet[241]:         /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:48 +0x86
> Mar 10 23:23:57 kind-worker kubelet[241]: panic(0x41cc2c0, 0x7377320)
> Mar 10 23:23:57 kind-worker kubelet[241]:         /usr/local/go/src/runtime/panic.go:965 +0x1b9
> Mar 10 23:23:57 kind-worker kubelet[241]: k8s.io/kubernetes/vendor/k8s.io/api/core/v1.(*Pod).GetName(0x0, 0x40a4c60, 0x73f4568)
> Mar 10 23:23:57 kind-worker kubelet[241]:         <autogenerated>:1 +0x5
> Mar 10 23:23:57 kind-worker kubelet[241]: k8s.io/kubernetes/vendor/k8s.io/klog/v2.KObj(0x5191890, 0x0, 0x9c, 0xa, 0xc000f09b00, 0x40)
> Mar 10 23:23:57 kind-worker kubelet[241]:         /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/vendor/k8s.io/klog/v2/klog.go:1587 +0x31
> Mar 10 23:23:57 kind-worker kubelet[241]: k8s.io/kubernetes/pkg/kubelet/kuberuntime.(*kubeGenericRuntimeManager).killContainersWithSyncResult.func1(0xc0016ba1d0, 0xc0007f02c0, 0x0, 0x0, 0xc000a3f320, 0xc00090c380)
> Mar 10 23:23:57 kind-worker kubelet[241]:         /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/pkg/kubelet/kuberuntime/kuberuntime_container.go:677 +0x2ae
> Mar 10 23:23:57 kind-worker kubelet[241]: created by k8s.io/kubernetes/pkg/kubelet/kuberuntime.(*kubeGenericRuntimeManager).killContainersWithSyncResult
> Mar 10 23:23:57 kind-worker kubelet[241]:         /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/pkg/kubelet/kuberuntime/kuberuntime_container.go:670 +0x105
> 


#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```
