### PR TITLE
remove e2e volume registry as it is not used

### DIFF
--- a/test/utils/image/manifest.go
+++ b/test/utils/image/manifest.go
@@ -32,7 +32,6 @@ import (
 type RegistryList struct {
 	GcAuthenticatedRegistry string `yaml:"gcAuthenticatedRegistry"`
 	E2eRegistry             string `yaml:"e2eRegistry"`
-	E2eVolumeRegistry       string `yaml:"e2eVolumeRegistry"`
 	PromoterE2eRegistry     string `yaml:"promoterE2eRegistry"`
 	BuildImageRegistry      string `yaml:"buildImageRegistry"`
 	InvalidRegistry         string `yaml:"invalidRegistry"`
@@ -71,7 +70,6 @@ func initReg() RegistryList {
 	registry := RegistryList{
 		GcAuthenticatedRegistry: "gcr.io/authenticated-image-pulling",
 		E2eRegistry:             "gcr.io/kubernetes-e2e-test-images",
-		E2eVolumeRegistry:       "gcr.io/kubernetes-e2e-test-images/volume",
 		PromoterE2eRegistry:     "k8s.gcr.io/e2e-test-images",
 		BuildImageRegistry:      "k8s.gcr.io/build-image",
 		InvalidRegistry:         "invalid.com/invalid",
@@ -109,7 +107,6 @@ var (
 	// Preconfigured image configs
 	dockerLibraryRegistry   = "docker.io/library"
 	e2eRegistry             = registry.E2eRegistry
-	e2eVolumeRegistry       = registry.E2eVolumeRegistry
 	promoterE2eRegistry     = registry.PromoterE2eRegistry
 	buildImageRegistry      = registry.BuildImageRegistry
 	gcAuthenticatedRegistry = registry.GcAuthenticatedRegistry
@@ -387,8 +384,6 @@ func ReplaceRegistryInImageURL(imageURL string) (string, error) {
 	switch registryAndUser {
 	case "gcr.io/kubernetes-e2e-test-images":
 		registryAndUser = e2eRegistry
-	case "gcr.io/kubernetes-e2e-test-images/volume":
-		registryAndUser = e2eVolumeRegistry
 	case "k8s.gcr.io":
 		registryAndUser = gcRegistry
 	case "k8s.gcr.io/sig-storage":

--- a/test/utils/image/manifest_test.go
+++ b/test/utils/image/manifest_test.go
@@ -62,13 +62,6 @@ var registryTests = []struct {
 		},
 	},
 	{
-		"gcr.io/kubernetes-e2e-test-images/volume/test:123",
-		result{
-			result: "test.io/kubernetes-e2e-test-images/volume/test:123",
-			err:    nil,
-		},
-	},
-	{
 		"k8s.gcr.io/test:123",
 		result{
 			result: "test.io/test:123",
@@ -117,7 +110,6 @@ func TestReplaceRegistryInImageURL(t *testing.T) {
 	// Set custom registries
 	dockerLibraryRegistry = "test.io/library"
 	e2eRegistry = "test.io/kubernetes-e2e-test-images"
-	e2eVolumeRegistry = "test.io/kubernetes-e2e-test-images/volume"
 	gcRegistry = "test.io"
 	gcrReleaseRegistry = "test.io/gke-release"
 	PrivateRegistry = "test.io/k8s-authenticated-test"


### PR DESCRIPTION

#### What type of PR is this?

/sig testing
/sig release
/wg k8s-infra
/area test-infra
/area test
/area images-registry
/kind cleanup

#### What this PR does / why we need it:

E2eVolumeRegistry are all promted now.

#### Which issue(s) this PR fixes:

xref #96770

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```

/cc spiffxp