### PR TITLE
[sig-scheduling] SchedulerPreemption|SchedulerPredicates|SchedulerPriorities: adjust some e2e tests to run in a single node cluster scenario

### DIFF
--- a/test/e2e/scheduling/predicates.go
+++ b/test/e2e/scheduling/predicates.go
@@ -718,6 +718,9 @@ var _ = SIGDescribe("SchedulerPredicates [Serial]", func() {
 		topologyKey := "kubernetes.io/e2e-pts-filter"
 
 		ginkgo.BeforeEach(func() {
+			if len(nodeList.Items) < 2 {
+				ginkgo.Skip("At least 2 nodes are required to run the test")
+			}
 			ginkgo.By("Trying to get 2 available nodes which can run pod")
 			nodeNames = Get2NodesThatCanRunPod(f)
 			ginkgo.By(fmt.Sprintf("Apply dedicated topologyKey %v for this test on the 2 nodes.", topologyKey))

--- a/test/e2e/scheduling/preemption.go
+++ b/test/e2e/scheduling/preemption.go
@@ -121,48 +121,52 @@ var _ = SIGDescribe("SchedulerPreemption [Serial]", func() {
 	framework.ConformanceIt("validates basic preemption works", func() {
 		var podRes v1.ResourceList
 
-		// Create one pod per node that uses a lot of the node's resources.
-		ginkgo.By("Create pods that use 2/3 of node resources.")
-		pods := make([]*v1.Pod, 0, len(nodeList.Items))
-		// Now create victim pods on each of the node with lower priority
+		// Create two pods per node that uses a lot of the node's resources.
+		ginkgo.By("Create pods that use 4/5 of node resources.")
+		pods := make([]*v1.Pod, 0, 2*len(nodeList.Items))
+		// Create pods in the cluster.
+		// One of them has low priority, making it the victim for preemption.
 		for i, node := range nodeList.Items {
 			// Update each node to advertise 3 available extended resources
 			nodeCopy := node.DeepCopy()
-			nodeCopy.Status.Capacity[testExtendedResource] = resource.MustParse("3")
+			nodeCopy.Status.Capacity[testExtendedResource] = resource.MustParse("5")
 			err := patchNode(cs, &node, nodeCopy)
 			framework.ExpectNoError(err)
 
-			// Request 2 of the available resources for the victim pods
-			podRes = v1.ResourceList{}
-			podRes[testExtendedResource] = resource.MustParse("2")
+			for j := 0; j < 2; j++ {
+				// Request 2 of the available resources for the victim pods
+				podRes = v1.ResourceList{}
+				podRes[testExtendedResource] = resource.MustParse("2")
 
-			// make the first pod low priority and the rest medium priority.
-			priorityName := mediumPriorityClassName
-			if len(pods) == 0 {
-				priorityName = lowPriorityClassName
-			}
-			pods = append(pods, createPausePod(f, pausePodConfig{
-				Name:              fmt.Sprintf("pod%d-%v", i, priorityName),
-				PriorityClassName: priorityName,
-				Resources: &v1.ResourceRequirements{
-					Requests: podRes,
-					Limits:   podRes,
-				},
-				Affinity: &v1.Affinity{
-					NodeAffinity: &v1.NodeAffinity{
-						RequiredDuringSchedulingIgnoredDuringExecution: &v1.NodeSelector{
-							NodeSelectorTerms: []v1.NodeSelectorTerm{
-								{
-									MatchFields: []v1.NodeSelectorRequirement{
-										{Key: "metadata.name", Operator: v1.NodeSelectorOpIn, Values: []string{node.Name}},
+				// make the first pod low priority and the rest medium priority.
+				priorityName := mediumPriorityClassName
+				if len(pods) == 0 {
+					priorityName = lowPriorityClassName
+				}
+				pausePod := createPausePod(f, pausePodConfig{
+					Name:              fmt.Sprintf("pod%d-%d-%v", i, j, priorityName),
+					PriorityClassName: priorityName,
+					Resources: &v1.ResourceRequirements{
+						Requests: podRes,
+						Limits:   podRes,
+					},
+					Affinity: &v1.Affinity{
+						NodeAffinity: &v1.NodeAffinity{
+							RequiredDuringSchedulingIgnoredDuringExecution: &v1.NodeSelector{
+								NodeSelectorTerms: []v1.NodeSelectorTerm{
+									{
+										MatchFields: []v1.NodeSelectorRequirement{
+											{Key: "metadata.name", Operator: v1.NodeSelectorOpIn, Values: []string{node.Name}},
+										},
 									},
 								},
 							},
 						},
 					},
-				},
-			}))
-			framework.Logf("Created pod: %v", pods[i].Name)
+				})
+				pods = append(pods, pausePod)
+				framework.Logf("Created pod: %v", pausePod.Name)
+			}
 		}
 		if len(pods) < 2 {
 			framework.Failf("We need at least two pods to be created but " +
@@ -209,46 +213,49 @@ var _ = SIGDescribe("SchedulerPreemption [Serial]", func() {
 	framework.ConformanceIt("validates lower priority pod preemption by critical pod", func() {
 		var podRes v1.ResourceList
 
-		ginkgo.By("Create pods that use 2/3 of node resources.")
+		ginkgo.By("Create pods that use 4/5 of node resources.")
 		pods := make([]*v1.Pod, 0, len(nodeList.Items))
 		for i, node := range nodeList.Items {
 			// Update each node to advertise 3 available extended resources
 			nodeCopy := node.DeepCopy()
-			nodeCopy.Status.Capacity[testExtendedResource] = resource.MustParse("3")
+			nodeCopy.Status.Capacity[testExtendedResource] = resource.MustParse("5")
 			err := patchNode(cs, &node, nodeCopy)
 			framework.ExpectNoError(err)
 
-			// Request 2 of the available resources for the victim pods
-			podRes = v1.ResourceList{}
-			podRes[testExtendedResource] = resource.MustParse("2")
+			for j := 0; j < 2; j++ {
+				// Request 2 of the available resources for the victim pods
+				podRes = v1.ResourceList{}
+				podRes[testExtendedResource] = resource.MustParse("2")
 
-			// make the first pod low priority and the rest medium priority.
-			priorityName := mediumPriorityClassName
-			if len(pods) == 0 {
-				priorityName = lowPriorityClassName
-			}
-			pods = append(pods, createPausePod(f, pausePodConfig{
-				Name:              fmt.Sprintf("pod%d-%v", i, priorityName),
-				PriorityClassName: priorityName,
-				Resources: &v1.ResourceRequirements{
-					Requests: podRes,
-					Limits:   podRes,
-				},
-				Affinity: &v1.Affinity{
-					NodeAffinity: &v1.NodeAffinity{
-						RequiredDuringSchedulingIgnoredDuringExecution: &v1.NodeSelector{
-							NodeSelectorTerms: []v1.NodeSelectorTerm{
-								{
-									MatchFields: []v1.NodeSelectorRequirement{
-										{Key: "metadata.name", Operator: v1.NodeSelectorOpIn, Values: []string{node.Name}},
+				// make the first pod low priority and the rest medium priority.
+				priorityName := mediumPriorityClassName
+				if len(pods) == 0 {
+					priorityName = lowPriorityClassName
+				}
+				pausePod := createPausePod(f, pausePodConfig{
+					Name:              fmt.Sprintf("pod%d-%d-%v", i, j, priorityName),
+					PriorityClassName: priorityName,
+					Resources: &v1.ResourceRequirements{
+						Requests: podRes,
+						Limits:   podRes,
+					},
+					Affinity: &v1.Affinity{
+						NodeAffinity: &v1.NodeAffinity{
+							RequiredDuringSchedulingIgnoredDuringExecution: &v1.NodeSelector{
+								NodeSelectorTerms: []v1.NodeSelectorTerm{
+									{
+										MatchFields: []v1.NodeSelectorRequirement{
+											{Key: "metadata.name", Operator: v1.NodeSelectorOpIn, Values: []string{node.Name}},
+										},
 									},
 								},
 							},
 						},
 					},
-				},
-			}))
-			framework.Logf("Created pod: %v", pods[i].Name)
+				})
+				pods = append(pods, pausePod)
+				framework.Logf("Created pod: %v", pausePod.Name)
+			}
 		}
 		if len(pods) < 2 {
 			framework.Failf("We need at least two pods to be created but " +

--- a/test/e2e/scheduling/preemption.go
+++ b/test/e2e/scheduling/preemption.go
@@ -306,6 +306,9 @@ var _ = SIGDescribe("SchedulerPreemption [Serial]", func() {
 		var fakeRes v1.ResourceName = "example.com/fakePTSRes"
 
 		ginkgo.BeforeEach(func() {
+			if len(nodeList.Items) < 2 {
+				ginkgo.Skip("At least 2 nodes are required to run the test")
+			}
 			ginkgo.By("Trying to get 2 available nodes which can run pod")
 			nodeNames = Get2NodesThatCanRunPod(f)
 			ginkgo.By(fmt.Sprintf("Apply dedicated topologyKey %v for this test on the 2 nodes.", topologyKey))

--- a/test/e2e/scheduling/priorities.go
+++ b/test/e2e/scheduling/priorities.go
@@ -387,6 +387,9 @@ var _ = SIGDescribe("SchedulerPriorities [Serial]", func() {
 		topologyKey := "kubernetes.io/e2e-pts-score"
 
 		ginkgo.BeforeEach(func() {
+			if len(nodeList.Items) < 2 {
+				ginkgo.Skip("At least 2 nodes are required to run the test")
+			}
 			ginkgo.By("Trying to get 2 available nodes which can run pod")
 			nodeNames = Get2NodesThatCanRunPod(f)
 			ginkgo.By(fmt.Sprintf("Apply dedicated topologyKey %v for this test on the 2 nodes.", topologyKey))


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

To run the tests in a single node cluster, create two pods consuming 2/5 of the extended resource instead of one consuming 2/3.
The low priority pod will be consuming 2/5 of the extended resource instead so in case there's only a single node,
a high priority pod consuming 2/5 of the extended resource can be still scheduled. Thus, making sure only the low priority pod
gets preempted once the preemptor pod consuming 2/5 of the extended resource gets scheduled while keeping the high priority pod untouched.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
