### PR TITLE
WIP - Tag remaining selectors as atomic

### DIFF
--- a/staging/src/k8s.io/api/apps/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/apps/v1beta1/generated.proto
@@ -304,6 +304,7 @@ message ScaleStatus {
 
   // label query over pods that should match the replicas count. More info: http://kubernetes.io/docs/user-guide/labels#label-selectors
   // +optional
+  // +mapType=atomic
   map<string, string> selector = 2;
 
   // label selector for pods that should match the replicas count. This is a serializated

--- a/staging/src/k8s.io/api/apps/v1beta1/types.go
+++ b/staging/src/k8s.io/api/apps/v1beta1/types.go
@@ -43,6 +43,7 @@ type ScaleStatus struct {
 
 	// label query over pods that should match the replicas count. More info: http://kubernetes.io/docs/user-guide/labels#label-selectors
 	// +optional
+	// +mapType=atomic
 	Selector map[string]string `json:"selector,omitempty" protobuf:"bytes,2,rep,name=selector"`
 
 	// label selector for pods that should match the replicas count. This is a serializated

--- a/staging/src/k8s.io/api/apps/v1beta2/generated.proto
+++ b/staging/src/k8s.io/api/apps/v1beta2/generated.proto
@@ -592,6 +592,7 @@ message ScaleStatus {
 
   // label query over pods that should match the replicas count. More info: http://kubernetes.io/docs/user-guide/labels#label-selectors
   // +optional
+  // +mapType=atomic
   map<string, string> selector = 2;
 
   // label selector for pods that should match the replicas count. This is a serializated

--- a/staging/src/k8s.io/api/apps/v1beta2/types.go
+++ b/staging/src/k8s.io/api/apps/v1beta2/types.go
@@ -45,6 +45,7 @@ type ScaleStatus struct {
 
 	// label query over pods that should match the replicas count. More info: http://kubernetes.io/docs/user-guide/labels#label-selectors
 	// +optional
+	// +mapType=atomic
 	Selector map[string]string `json:"selector,omitempty" protobuf:"bytes,2,rep,name=selector"`
 
 	// label selector for pods that should match the replicas count. This is a serializated

--- a/staging/src/k8s.io/api/core/v1/generated.proto
+++ b/staging/src/k8s.io/api/core/v1/generated.proto
@@ -498,6 +498,7 @@ message ConfigMapEnvSource {
 }
 
 // Selects a key from a ConfigMap.
+// +structType=atomic
 message ConfigMapKeySelector {
   // The ConfigMap to select from.
   optional LocalObjectReference localObjectReference = 1;
@@ -2330,6 +2331,7 @@ message NodeResources {
 // A node selector represents the union of the results of one or more label queries
 // over a set of nodes; that is, it represents the OR of the selectors represented
 // by the node selector terms.
+// +structType=atomic
 message NodeSelector {
   // Required. A list of node selector terms. The terms are ORed.
   repeated NodeSelectorTerm nodeSelectorTerms = 1;
@@ -2504,6 +2506,7 @@ message NodeSystemInfo {
 }
 
 // ObjectFieldSelector selects an APIVersioned field of an object.
+// +structType=atomic
 message ObjectFieldSelector {
   // Version of the schema the FieldPath is written in terms of, defaults to "v1".
   // +optional
@@ -3449,6 +3452,7 @@ message PodSpec {
   // Selector which must match a node's labels for the pod to be scheduled on that node.
   // More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
   // +optional
+  // +mapType=atomic
   map<string, string> nodeSelector = 7;
 
   // ServiceAccountName is the name of the ServiceAccount to use to run this pod.
@@ -4125,6 +4129,7 @@ message ReplicationControllerSpec {
   // controller, if empty defaulted to labels on Pod template.
   // More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
   // +optional
+  // +mapType=atomic
   map<string, string> selector = 2;
 
   // Template is the object that describes the pod that will be created if
@@ -4165,6 +4170,7 @@ message ReplicationControllerStatus {
 }
 
 // ResourceFieldSelector represents container resources (cpu, memory) and their output format
+// +structType=atomic
 message ResourceFieldSelector {
   // Container name: required for volumes, optional for env vars
   // +optional
@@ -4367,6 +4373,7 @@ message ScaleIOVolumeSource {
 
 // A scope selector represents the AND of the selectors represented
 // by the scoped-resource selector requirements.
+// +structType=atomic
 message ScopeSelector {
   // A list of scope selector requirements by scope of the resources.
   // +optional
@@ -4462,6 +4469,7 @@ message SecretEnvSource {
 }
 
 // SecretKeySelector selects a key of a Secret.
+// +structType=atomic
 message SecretKeySelector {
   // The name of the secret in the pod's namespace to select from.
   optional LocalObjectReference localObjectReference = 1;
@@ -4828,6 +4836,7 @@ message ServiceSpec {
   // Ignored if type is ExternalName.
   // More info: https://kubernetes.io/docs/concepts/services-networking/service/
   // +optional
+  // +mapType=atomic
   map<string, string> selector = 2;
 
   // clusterIP is the IP address of the service and is usually assigned
@@ -5233,6 +5242,7 @@ message TopologySelectorLabelRequirement {
 // The requirements of them are ANDed.
 // It provides a subset of functionality as NodeSelectorTerm.
 // This is an alpha feature and may change in the future.
+// +structType=atomic
 message TopologySelectorTerm {
   // A list of topology selector requirements by labels.
   // +optional

--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -2662,8 +2662,10 @@ const (
 // The requirements of them are ANDed.
 // It provides a subset of functionality as NodeSelectorTerm.
 // This is an alpha feature and may change in the future.
-// +structType=atomic
+// +structType=atomic.
 type TopologySelectorTerm struct {
+	// Usage: Fields of type []TopologySelectorTerm must be listType=atomic.
+
 	// A list of topology selector requirements by labels.
 	// +optional
 	MatchLabelExpressions []TopologySelectorLabelRequirement `json:"matchLabelExpressions,omitempty" protobuf:"bytes,1,rep,name=matchLabelExpressions"`

--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -1948,6 +1948,7 @@ type EnvVarSource struct {
 }
 
 // ObjectFieldSelector selects an APIVersioned field of an object.
+// +structType=atomic
 type ObjectFieldSelector struct {
 	// Version of the schema the FieldPath is written in terms of, defaults to "v1".
 	// +optional
@@ -1957,6 +1958,7 @@ type ObjectFieldSelector struct {
 }
 
 // ResourceFieldSelector represents container resources (cpu, memory) and their output format
+// +structType=atomic
 type ResourceFieldSelector struct {
 	// Container name: required for volumes, optional for env vars
 	// +optional
@@ -1969,6 +1971,7 @@ type ResourceFieldSelector struct {
 }
 
 // Selects a key from a ConfigMap.
+// +structType=atomic
 type ConfigMapKeySelector struct {
 	// The ConfigMap to select from.
 	LocalObjectReference `json:",inline" protobuf:"bytes,1,opt,name=localObjectReference"`
@@ -1980,6 +1983,7 @@ type ConfigMapKeySelector struct {
 }
 
 // SecretKeySelector selects a key of a Secret.
+// +structType=atomic
 type SecretKeySelector struct {
 	// The name of the secret in the pod's namespace to select from.
 	LocalObjectReference `json:",inline" protobuf:"bytes,1,opt,name=localObjectReference"`
@@ -2605,6 +2609,7 @@ const (
 // A node selector represents the union of the results of one or more label queries
 // over a set of nodes; that is, it represents the OR of the selectors represented
 // by the node selector terms.
+// +structType=atomic
 type NodeSelector struct {
 	//Required. A list of node selector terms. The terms are ORed.
 	NodeSelectorTerms []NodeSelectorTerm `json:"nodeSelectorTerms" protobuf:"bytes,1,rep,name=nodeSelectorTerms"`
@@ -2657,6 +2662,7 @@ const (
 // The requirements of them are ANDed.
 // It provides a subset of functionality as NodeSelectorTerm.
 // This is an alpha feature and may change in the future.
+// +structType=atomic
 type TopologySelectorTerm struct {
 	// A list of topology selector requirements by labels.
 	// +optional
@@ -2993,6 +2999,7 @@ type PodSpec struct {
 	// Selector which must match a node's labels for the pod to be scheduled on that node.
 	// More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
 	// +optional
+	// +mapType=atomic
 	NodeSelector map[string]string `json:"nodeSelector,omitempty" protobuf:"bytes,7,rep,name=nodeSelector"`
 
 	// ServiceAccountName is the name of the ServiceAccount to use to run this pod.
@@ -3773,6 +3780,7 @@ type ReplicationControllerSpec struct {
 	// controller, if empty defaulted to labels on Pod template.
 	// More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
 	// +optional
+	// +mapType=atomic
 	Selector map[string]string `json:"selector,omitempty" protobuf:"bytes,2,rep,name=selector"`
 
 	// TemplateRef is a reference to an object that describes the pod that will be created if
@@ -4071,6 +4079,7 @@ type ServiceSpec struct {
 	// Ignored if type is ExternalName.
 	// More info: https://kubernetes.io/docs/concepts/services-networking/service/
 	// +optional
+	// +mapType=atomic
 	Selector map[string]string `json:"selector,omitempty" protobuf:"bytes,2,rep,name=selector"`
 
 	// clusterIP is the IP address of the service and is usually assigned
@@ -5697,6 +5706,7 @@ type ResourceQuotaSpec struct {
 
 // A scope selector represents the AND of the selectors represented
 // by the scoped-resource selector requirements.
+// +structType=atomic
 type ScopeSelector struct {
 	// A list of scope selector requirements by scope of the resources.
 	// +optional

--- a/staging/src/k8s.io/api/extensions/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/extensions/v1beta1/generated.proto
@@ -1237,6 +1237,7 @@ message ScaleStatus {
 
   // label query over pods that should match the replicas count. More info: http://kubernetes.io/docs/user-guide/labels#label-selectors
   // +optional
+  // +mapType=atomic
   map<string, string> selector = 2;
 
   // label selector for pods that should match the replicas count. This is a serializated

--- a/staging/src/k8s.io/api/extensions/v1beta1/types.go
+++ b/staging/src/k8s.io/api/extensions/v1beta1/types.go
@@ -37,6 +37,7 @@ type ScaleStatus struct {
 
 	// label query over pods that should match the replicas count. More info: http://kubernetes.io/docs/user-guide/labels#label-selectors
 	// +optional
+	// +mapType=atomic
 	Selector map[string]string `json:"selector,omitempty" protobuf:"bytes,2,rep,name=selector"`
 
 	// label selector for pods that should match the replicas count. This is a serializated

--- a/staging/src/k8s.io/api/node/v1/generated.proto
+++ b/staging/src/k8s.io/api/node/v1/generated.proto
@@ -97,6 +97,7 @@ message Scheduling {
   // with a pod's existing nodeSelector. Any conflicts will cause the pod to
   // be rejected in admission.
   // +optional
+  // +mapType=atomic
   map<string, string> nodeSelector = 1;
 
   // tolerations are appended (excluding duplicates) to pods running with this

--- a/staging/src/k8s.io/api/node/v1/types.go
+++ b/staging/src/k8s.io/api/node/v1/types.go
@@ -82,6 +82,7 @@ type Scheduling struct {
 	// with a pod's existing nodeSelector. Any conflicts will cause the pod to
 	// be rejected in admission.
 	// +optional
+	// +mapType=atomic
 	NodeSelector map[string]string `json:"nodeSelector,omitempty" protobuf:"bytes,1,opt,name=nodeSelector"`
 
 	// tolerations are appended (excluding duplicates) to pods running with this

--- a/staging/src/k8s.io/api/node/v1alpha1/generated.proto
+++ b/staging/src/k8s.io/api/node/v1alpha1/generated.proto
@@ -106,6 +106,7 @@ message Scheduling {
   // with a pod's existing nodeSelector. Any conflicts will cause the pod to
   // be rejected in admission.
   // +optional
+  // +mapType=atomic
   map<string, string> nodeSelector = 1;
 
   // tolerations are appended (excluding duplicates) to pods running with this

--- a/staging/src/k8s.io/api/node/v1alpha1/types.go
+++ b/staging/src/k8s.io/api/node/v1alpha1/types.go
@@ -91,6 +91,7 @@ type Scheduling struct {
 	// with a pod's existing nodeSelector. Any conflicts will cause the pod to
 	// be rejected in admission.
 	// +optional
+	// +mapType=atomic
 	NodeSelector map[string]string `json:"nodeSelector,omitempty" protobuf:"bytes,1,opt,name=nodeSelector"`
 
 	// tolerations are appended (excluding duplicates) to pods running with this

--- a/staging/src/k8s.io/api/node/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/node/v1beta1/generated.proto
@@ -96,6 +96,7 @@ message Scheduling {
   // with a pod's existing nodeSelector. Any conflicts will cause the pod to
   // be rejected in admission.
   // +optional
+  // +mapType=atomic
   map<string, string> nodeSelector = 1;
 
   // tolerations are appended (excluding duplicates) to pods running with this

--- a/staging/src/k8s.io/api/node/v1beta1/types.go
+++ b/staging/src/k8s.io/api/node/v1beta1/types.go
@@ -83,6 +83,7 @@ type Scheduling struct {
 	// with a pod's existing nodeSelector. Any conflicts will cause the pod to
 	// be rejected in admission.
 	// +optional
+	// +mapType=atomic
 	NodeSelector map[string]string `json:"nodeSelector,omitempty" protobuf:"bytes,1,opt,name=nodeSelector"`
 
 	// tolerations are appended (excluding duplicates) to pods running with this

--- a/staging/src/k8s.io/api/storage/v1/types.go
+++ b/staging/src/k8s.io/api/storage/v1/types.go
@@ -71,6 +71,7 @@ type StorageClass struct {
 	// An empty TopologySelectorTerm list means there is no topology restriction.
 	// This field is only honored by servers that enable the VolumeScheduling feature.
 	// +optional
+	// +listType=atomic
 	AllowedTopologies []v1.TopologySelectorTerm `json:"allowedTopologies,omitempty" protobuf:"bytes,8,rep,name=allowedTopologies"`
 }
 

--- a/staging/src/k8s.io/api/storage/v1beta1/types.go
+++ b/staging/src/k8s.io/api/storage/v1beta1/types.go
@@ -75,6 +75,7 @@ type StorageClass struct {
 	// An empty TopologySelectorTerm list means there is no topology restriction.
 	// This field is only honored by servers that enable the VolumeScheduling feature.
 	// +optional
+	// +listType=atomic
 	AllowedTopologies []v1.TopologySelectorTerm `json:"allowedTopologies,omitempty" protobuf:"bytes,8,rep,name=allowedTopologies"`
 }
 

--- a/staging/src/k8s.io/apimachinery/pkg/apis/testapigroup/v1/generated.proto
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/testapigroup/v1/generated.proto
@@ -118,6 +118,7 @@ message CarpSpec {
   // Selector which must match a node's labels for the carp to be scheduled on that node.
   // More info: http://kubernetes.io/docs/user-guide/node-selection/README
   // +optional
+  // +mapType=atomic
   map<string, string> nodeSelector = 7;
 
   // ServiceAccountName is the name of the ServiceAccount to use to run this carp.

--- a/staging/src/k8s.io/apimachinery/pkg/apis/testapigroup/v1/types.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/testapigroup/v1/types.go
@@ -133,6 +133,7 @@ type CarpSpec struct {
 	// Selector which must match a node's labels for the carp to be scheduled on that node.
 	// More info: http://kubernetes.io/docs/user-guide/node-selection/README
 	// +optional
+	// +mapType=atomic
 	NodeSelector map[string]string `json:"nodeSelector,omitempty" protobuf:"bytes,7,rep,name=nodeSelector"`
 
 	// ServiceAccountName is the name of the ServiceAccount to use to run this carp.

--- a/staging/src/k8s.io/apiserver/pkg/apis/example/v1/generated.proto
+++ b/staging/src/k8s.io/apiserver/pkg/apis/example/v1/generated.proto
@@ -118,6 +118,7 @@ message PodSpec {
   // Selector which must match a node's labels for the pod to be scheduled on that node.
   // More info: http://kubernetes.io/docs/user-guide/node-selection/README
   // +optional
+  // +mapType=atomic
   map<string, string> nodeSelector = 7;
 
   // ServiceAccountName is the name of the ServiceAccount to use to run this pod.

--- a/staging/src/k8s.io/apiserver/pkg/apis/example/v1/types.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/example/v1/types.go
@@ -133,6 +133,7 @@ type PodSpec struct {
 	// Selector which must match a node's labels for the pod to be scheduled on that node.
 	// More info: http://kubernetes.io/docs/user-guide/node-selection/README
 	// +optional
+	// +mapType=atomic
 	NodeSelector map[string]string `json:"nodeSelector,omitempty" protobuf:"bytes,7,rep,name=nodeSelector"`
 
 	// ServiceAccountName is the name of the ServiceAccount to use to run this pod.


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Without this change using server-side apply to change selectors can result in objects with unexpected selectors.

Based on a [review of all occurrences of the term "selector" in types.go files](https://docs.google.com/document/d/1jA39N3uvyDHheE-g8nLKbbnKkB3zhe4plAyl8qSdk_k/edit#).

TODO:
- [ ] Add tests


#### Which issue(s) this PR fixes:

Fixes #https://github.com/kubernetes/kubernetes/issues/97970

#### Special notes for your reviewer:

Related to https://github.com/kubernetes/kubernetes/pull/97989 but for 17 selectors found after reviewing all occurrences of the term "selector" in types.go files.

#### Does this PR introduce a user-facing change?

```release-note
Server Side Apply now treats all <*>Selector fields as atomic (meaning the entire selector is managed by a single writer and updated together), since they contain interrelated and inseparable fields that do not merge in intuitive ways.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

Please use the following format for linking documentation:
- KEP: https://github.com/kubernetes/enhancements/tree/master/keps/sig-api-machinery/555-server-side-apply
- Feature issue: https://github.com/kubernetes/enhancements/issues/555
- List of "selector" occurrences in types.go files: https://docs.google.com/document/d/1jA39N3uvyDHheE-g8nLKbbnKkB3zhe4plAyl8qSdk_k/edit

/sig api-machinery
/wg api-expression
