### PR TITLE
Add feature gate to disable all in-tree cloud providers

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -617,6 +617,12 @@ const (
 	// Enable kubelet exec plugins for image pull credentials.
 	KubeletCredentialProviders featuregate.Feature = "KubeletCredentialProviders"
 
+	// owner: @andrewsykim
+	// alpha: v1.22
+	//
+	// Disable any functionality in kube-apiserver, kube-controller-manager and kubelet related to the `--cloud-provider` component flag.
+	DisableCloudProviders featuregate.Feature = "DisableCloudProviders"
+
 	// owner: @zshihang
 	// alpha: v1.20
 	// beta: v1.21
@@ -837,6 +843,7 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 	NamespaceDefaultLabelName:                      {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.24
 	CSIVolumeHealth:                                {Default: false, PreRelease: featuregate.Alpha},
 	WindowsHostProcessContainers:                   {Default: false, PreRelease: featuregate.Alpha},
+	DisableCloudProviders:                          {Default: false, PreRelease: featuregate.Alpha},
 
 	// inherited features from generic apiserver, relisted here to get a conflict if it is changed
 	// unintentionally on either side:

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -387,6 +387,11 @@ func NewMainKubelet(kubeCfg *kubeletconfiginternal.KubeletConfiguration,
 		}
 	}
 
+	if utilfeature.DefaultFeatureGate.Enabled(features.DisableCloudProviders) && cloudprovider.IsDeprecatedInternal(cloudProvider) {
+		cloudprovider.DisableWarningForProvider(cloudProvider)
+		return nil, fmt.Errorf("cloud provider %q was specified, but built-in cloud providers are disabled. Please set --cloud-provider=external and migrate to an external cloud provider", cloudProvider)
+	}
+
 	var nodeHasSynced cache.InformerSynced
 	var nodeLister corelisters.NodeLister
 

--- a/staging/src/k8s.io/cloud-provider/plugins.go
+++ b/staging/src/k8s.io/cloud-provider/plugins.go
@@ -40,11 +40,11 @@ var (
 		external bool
 		detail   string
 	}{
-		{"aws", false, "The AWS provider is deprecated and will be removed in a future release"},
-		{"azure", false, "The Azure provider is deprecated and will be removed in a future release"},
-		{"gce", false, "The GCE provider is deprecated and will be removed in a future release"},
+		{"aws", false, "The AWS provider is deprecated and will be removed in a future release. Please use https://github.com/kubernetes/cloud-provider-aws"},
+		{"azure", false, "The Azure provider is deprecated and will be removed in a future release. Please use https://github.com/kubernetes-sigs/cloud-provider-azure"},
+		{"gce", false, "The GCE provider is deprecated and will be removed in a future release. Please use https://github.com/kubernetes/cloud-provider-gcp"},
 		{"openstack", true, "https://github.com/kubernetes/cloud-provider-openstack"},
-		{"vsphere", false, "The vSphere provider is deprecated and will be removed in a future release"},
+		{"vsphere", false, "The vSphere provider is deprecated and will be removed in a future release. Please use https://github.com/kubernetes/cloud-provider-vsphere"},
 	}
 )
 
@@ -91,6 +91,33 @@ func IsExternal(name string) bool {
 	return name == externalCloudProvider
 }
 
+// IsDeprecatedInternal is responsible for preventing cloud.Interface
+// from being initialized in kubelet, kube-controller-manager or kube-api-server
+func IsDeprecatedInternal(name string) bool {
+	for _, provider := range deprecatedCloudProviders {
+		if provider.name == name {
+			return true
+		}
+	}
+
+	return false
+}
+
+// DisableWarningForProvider logs information about disabled cloud provider state
+func DisableWarningForProvider(providerName string) {
+	for _, provider := range deprecatedCloudProviders {
+		if provider.name == providerName {
+			klog.Infof("INFO: Please make sure you are running external cloud controller manager binary for provider %q."+
+				"In-tree cloud providers are currently disabled. Refer to https://github.com/kubernetes/kubernetes/tree/master/staging/src/k8s.io/cloud-provider/sample"+
+				"for example implementation.", providerName)
+			detail := fmt.Sprintf("Please reach to sig-cloud-provider and use 'external' cloud provider for %q: %s", providerName, provider.detail)
+			klog.Warningf("WARNING: %q built-in cloud provider is now disabled. %s", providerName, detail)
+			break
+		}
+	}
+}
+
+// DeprecationWarningForProvider logs information about deprecated cloud provider state
 func DeprecationWarningForProvider(providerName string) {
 	for _, provider := range deprecatedCloudProviders {
 		if provider.name != providerName {


### PR DESCRIPTION
FeatureGate acts as a secondary switch to disable cloud-controller loops
in KCM, Kubelet and KAPI.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Implementing DisableCloudProviders FG according to proposal https://github.com/kubernetes/enhancements/pull/2443

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

#### Special notes for your reviewer:

https://github.com/kubernetes/test-infra/pull/22035 is required for `pull-kubernetes-e2e-gce-alpha-features` job to pass.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Introduce a feature gate DisableCloudProviders allowing to disable cloud-provider initialization in KAPI, KCM and kubelet.

DisableCloudProviders FeatureGate is currently in Alpha, which means is currently disabled by default. Once the FeatureGate moves to beta, in-tree cloud providers would be disabled by default, and a user won't be able to specify --cloud-provider=<aws|openstack|azure|gcp|vsphere> anymore to any of KCM, KAPI or kubelet. Only a --cloud-provider=external would be allowed. CCM would have to run out-of-tree with CSI.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: https://github.com/kubernetes/enhancements/pull/2443
- [Usage]: <link>
- [Other doc]: <link>
- 
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/pull/2443
```
