### PR TITLE
Fix api installer to indicate PATCH may return a 201 for server side apply

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/installer.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/installer.go
@@ -805,6 +805,8 @@ func (a *APIInstaller) registerResourceHandlers(path string, storage rest.Storag
 				Operation("patch"+namespaced+kind+strings.Title(subresource)+operationSuffix).
 				Produces(append(storageMeta.ProducesMIMETypes(action.Verb), mediaTypes...)...).
 				Returns(http.StatusOK, "OK", producedObject).
+				// Patch can return 201 when a server side apply is requested
+				Returns(http.StatusCreated, "Created", producedObject).
 				Reads(metav1.Patch{}).
 				Writes(producedObject)
 			if err := AddObjectParams(ws, route, versionedPatchOptions); err != nil {


### PR DESCRIPTION
This leads to problem with generated code and docs.

e.g. https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#patch-pod-v1-core

is wrong.

#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
The current installer for PATCH just indicates a return of 200, but with the addition of server-side apply, PATCH sometime returns 201, this means the OpenAPI spec that we generate is wrong, and this in turn leads to problems with generated docs and code (e.g. https://github.com/kubernetes-client/csharp/issues/576).

#### Does this PR introduce a user-facing change?
```release-note
Generated OpenAPI now correctly specifies 201 as a possible response code for PATCH operations
```
