### PR TITLE
Automated cherry pick of #99756: Updating EndpointSliceMirroring controller to wait for cache

### DIFF
--- a/pkg/controller/endpointslicemirroring/BUILD
+++ b/pkg/controller/endpointslicemirroring/BUILD
@@ -6,6 +6,7 @@ go_library(
         "endpointset.go",
         "endpointslice_tracker.go",
         "endpointslicemirroring_controller.go",
+        "errors.go",
         "events.go",
         "reconciler.go",
         "reconciler_helpers.go",

--- a/pkg/controller/endpointslicemirroring/endpointslice_tracker.go
+++ b/pkg/controller/endpointslicemirroring/endpointslice_tracker.go
@@ -19,102 +19,154 @@ package endpointslicemirroring
 import (
 	"sync"
 
+	"k8s.io/api/core/v1"
 	discovery "k8s.io/api/discovery/v1beta1"
 	"k8s.io/apimachinery/pkg/types"
 )
 
-// endpointSliceResourceVersions tracks expected EndpointSlice resource versions
-// by EndpointSlice name.
-type endpointSliceResourceVersions map[string]string
+const (
+	deletionExpected = -1
+)
 
-// endpointSliceTracker tracks EndpointSlices and their associated resource
-// versions to help determine if a change to an EndpointSlice has been processed
-// by the EndpointSlice controller.
+// generationsBySlice tracks expected EndpointSlice generations by EndpointSlice
+// uid. A value of deletionExpected (-1) may be used here to indicate that we
+// expect this EndpointSlice to be deleted.
+type generationsBySlice map[types.UID]int64
+
+// endpointSliceTracker tracks EndpointSlices and their associated generation to
+// help determine if a change to an EndpointSlice has been processed by the
+// EndpointSlice controller.
 type endpointSliceTracker struct {
-	// lock protects resourceVersionsByService.
+	// lock protects generationsByService.
 	lock sync.Mutex
-	// resourceVersionsByService tracks the list of EndpointSlices and
-	// associated resource versions expected for a given Service.
-	resourceVersionsByService map[types.NamespacedName]endpointSliceResourceVersions
+	// generationsByService tracks the generations of EndpointSlices for each
+	// Service.
+	generationsByService map[types.NamespacedName]generationsBySlice
 }
 
 // newEndpointSliceTracker creates and initializes a new endpointSliceTracker.
 func newEndpointSliceTracker() *endpointSliceTracker {
 	return &endpointSliceTracker{
-		resourceVersionsByService: map[types.NamespacedName]endpointSliceResourceVersions{},
+		generationsByService: map[types.NamespacedName]generationsBySlice{},
 	}
 }
 
-// Has returns true if the endpointSliceTracker has a resource version for the
+// Has returns true if the endpointSliceTracker has a generation for the
 // provided EndpointSlice.
 func (est *endpointSliceTracker) Has(endpointSlice *discovery.EndpointSlice) bool {
 	est.lock.Lock()
 	defer est.lock.Unlock()
 
-	rrv, ok := est.relatedResourceVersions(endpointSlice)
+	gfs, ok := est.generationsForSliceUnsafe(endpointSlice)
 	if !ok {
 		return false
 	}
-	_, ok = rrv[endpointSlice.Name]
+	_, ok = gfs[endpointSlice.UID]
 	return ok
 }
 
-// Stale returns true if this endpointSliceTracker does not have a resource
-// version for the provided EndpointSlice or it does not match the resource
-// version of the provided EndpointSlice.
-func (est *endpointSliceTracker) Stale(endpointSlice *discovery.EndpointSlice) bool {
+// ShouldSync returns true if this endpointSliceTracker does not have a
+// generation for the provided EndpointSlice or it is greater than the
+// generation of the tracked EndpointSlice.
+func (est *endpointSliceTracker) ShouldSync(endpointSlice *discovery.EndpointSlice) bool {
 	est.lock.Lock()
 	defer est.lock.Unlock()
 
-	rrv, ok := est.relatedResourceVersions(endpointSlice)
+	gfs, ok := est.generationsForSliceUnsafe(endpointSlice)
 	if !ok {
 		return true
 	}
-	return rrv[endpointSlice.Name] != endpointSlice.ResourceVersion
+	g, ok := gfs[endpointSlice.UID]
+	return !ok || endpointSlice.Generation > g
 }
 
-// Update adds or updates the resource version in this endpointSliceTracker for
-// the provided EndpointSlice.
+// StaleSlices returns true if one or more of the provided EndpointSlices
+// have older generations than the corresponding tracked ones or if the tracker
+// is expecting one or more of the provided EndpointSlices to be deleted.
+func (est *endpointSliceTracker) StaleSlices(service *v1.Service, endpointSlices []*discovery.EndpointSlice) bool {
+	est.lock.Lock()
+	defer est.lock.Unlock()
+
+	nn := types.NamespacedName{Name: service.Name, Namespace: service.Namespace}
+	gfs, ok := est.generationsByService[nn]
+	if !ok {
+		return false
+	}
+	for _, endpointSlice := range endpointSlices {
+		g, ok := gfs[endpointSlice.UID]
+		if ok && (g == deletionExpected || g > endpointSlice.Generation) {
+			return true
+		}
+	}
+	return false
+}
+
+// Update adds or updates the generation in this endpointSliceTracker for the
+// provided EndpointSlice.
 func (est *endpointSliceTracker) Update(endpointSlice *discovery.EndpointSlice) {
 	est.lock.Lock()
 	defer est.lock.Unlock()
 
-	rrv, ok := est.relatedResourceVersions(endpointSlice)
+	gfs, ok := est.generationsForSliceUnsafe(endpointSlice)
+
 	if !ok {
-		rrv = endpointSliceResourceVersions{}
-		est.resourceVersionsByService[getServiceNN(endpointSlice)] = rrv
+		gfs = generationsBySlice{}
+		est.generationsByService[getServiceNN(endpointSlice)] = gfs
 	}
-	rrv[endpointSlice.Name] = endpointSlice.ResourceVersion
+	gfs[endpointSlice.UID] = endpointSlice.Generation
 }
 
-// DeleteService removes the set of resource versions tracked for the Service.
+// DeleteService removes the set of generations tracked for the Service.
 func (est *endpointSliceTracker) DeleteService(namespace, name string) {
 	est.lock.Lock()
 	defer est.lock.Unlock()
 
 	serviceNN := types.NamespacedName{Name: name, Namespace: namespace}
-	delete(est.resourceVersionsByService, serviceNN)
+	delete(est.generationsByService, serviceNN)
 }
 
-// Delete removes the resource version in this endpointSliceTracker for the
-// provided EndpointSlice.
-func (est *endpointSliceTracker) Delete(endpointSlice *discovery.EndpointSlice) {
+// ExpectDeletion sets the generation to deletionExpected in this
+// endpointSliceTracker for the provided EndpointSlice.
+func (est *endpointSliceTracker) ExpectDeletion(endpointSlice *discovery.EndpointSlice) {
 	est.lock.Lock()
 	defer est.lock.Unlock()
 
-	rrv, ok := est.relatedResourceVersions(endpointSlice)
-	if ok {
-		delete(rrv, endpointSlice.Name)
+	gfs, ok := est.generationsForSliceUnsafe(endpointSlice)
+
+	if !ok {
+		gfs = generationsBySlice{}
+		est.generationsByService[getServiceNN(endpointSlice)] = gfs
 	}
+	gfs[endpointSlice.UID] = deletionExpected
 }
 
-// relatedResourceVersions returns the set of resource versions tracked for the
-// Service corresponding to the provided EndpointSlice, and a bool to indicate
-// if it exists.
-func (est *endpointSliceTracker) relatedResourceVersions(endpointSlice *discovery.EndpointSlice) (endpointSliceResourceVersions, bool) {
+// HandleDeletion removes the generation in this endpointSliceTracker for the
+// provided EndpointSlice. This returns true if the tracker expected this
+// EndpointSlice to be deleted and false if not.
+func (est *endpointSliceTracker) HandleDeletion(endpointSlice *discovery.EndpointSlice) bool {
+	est.lock.Lock()
+	defer est.lock.Unlock()
+
+	gfs, ok := est.generationsForSliceUnsafe(endpointSlice)
+
+	if ok {
+		g, ok := gfs[endpointSlice.UID]
+		delete(gfs, endpointSlice.UID)
+		if ok && g != deletionExpected {
+			return false
+		}
+	}
+
+	return true
+}
+
+// generationsForSliceUnsafe returns the generations for the Service
+// corresponding to the provided EndpointSlice, and a bool to indicate if it
+// exists. A lock must be applied before calling this function.
+func (est *endpointSliceTracker) generationsForSliceUnsafe(endpointSlice *discovery.EndpointSlice) (generationsBySlice, bool) {
 	serviceNN := getServiceNN(endpointSlice)
-	vers, ok := est.resourceVersionsByService[serviceNN]
-	return vers, ok
+	generations, ok := est.generationsByService[serviceNN]
+	return generations, ok
 }
 
 // getServiceNN returns a namespaced name for the Service corresponding to the

--- a/pkg/controller/endpointslicemirroring/endpointslicemirroring_controller.go
+++ b/pkg/controller/endpointslicemirroring/endpointslicemirroring_controller.go
@@ -316,6 +316,10 @@ func (c *Controller) syncEndpoints(key string) error {
 		return err
 	}
 
+	if c.endpointSliceTracker.StaleSlices(svc, endpointSlices) {
+		return &StaleInformerCache{"EndpointSlice informer cache is out of date"}
+	}
+
 	err = c.reconciler.reconcile(endpoints, endpointSlices)
 	if err != nil {
 		return err
@@ -439,7 +443,7 @@ func (c *Controller) onEndpointSliceAdd(obj interface{}) {
 		utilruntime.HandleError(fmt.Errorf("onEndpointSliceAdd() expected type discovery.EndpointSlice, got %T", obj))
 		return
 	}
-	if managedByController(endpointSlice) && c.endpointSliceTracker.Stale(endpointSlice) {
+	if managedByController(endpointSlice) && c.endpointSliceTracker.ShouldSync(endpointSlice) {
 		c.queueEndpointsForEndpointSlice(endpointSlice)
 	}
 }
@@ -455,7 +459,18 @@ func (c *Controller) onEndpointSliceUpdate(prevObj, obj interface{}) {
 		utilruntime.HandleError(fmt.Errorf("onEndpointSliceUpdated() expected type discovery.EndpointSlice, got %T, %T", prevObj, obj))
 		return
 	}
-	if managedByChanged(prevEndpointSlice, endpointSlice) || (managedByController(endpointSlice) && c.endpointSliceTracker.Stale(endpointSlice)) {
+	// EndpointSlice generation does not change when labels change. Although the
+	// controller will never change LabelServiceName, users might. This check
+	// ensures that we handle changes to this label.
+	svcName := endpointSlice.Labels[discovery.LabelServiceName]
+	prevSvcName := prevEndpointSlice.Labels[discovery.LabelServiceName]
+	if svcName != prevSvcName {
+		klog.Warningf("%s label changed from %s  to %s for %s", discovery.LabelServiceName, prevSvcName, svcName, endpointSlice.Name)
+		c.queueEndpointsForEndpointSlice(endpointSlice)
+		c.queueEndpointsForEndpointSlice(prevEndpointSlice)
+		return
+	}
+	if managedByChanged(prevEndpointSlice, endpointSlice) || (managedByController(endpointSlice) && c.endpointSliceTracker.ShouldSync(endpointSlice)) {
 		c.queueEndpointsForEndpointSlice(endpointSlice)
 	}
 }
@@ -470,7 +485,11 @@ func (c *Controller) onEndpointSliceDelete(obj interface{}) {
 		return
 	}
 	if managedByController(endpointSlice) && c.endpointSliceTracker.Has(endpointSlice) {
-		c.queueEndpointsForEndpointSlice(endpointSlice)
+		// This returns false if we didn't expect the EndpointSlice to be
+		// deleted. If that is the case, we queue the Service for another sync.
+		if !c.endpointSliceTracker.HandleDeletion(endpointSlice) {
+			c.queueEndpointsForEndpointSlice(endpointSlice)
+		}
 	}
 }
 

--- a/pkg/controller/endpointslicemirroring/errors.go
+++ b/pkg/controller/endpointslicemirroring/errors.go
@@ -1,0 +1,25 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package endpointslicemirroring
+
+// StaleInformerCache errors indicate that the informer cache includes out of
+// date resources.
+type StaleInformerCache struct {
+	msg string
+}
+
+func (e *StaleInformerCache) Error() string { return e.msg }

--- a/pkg/controller/endpointslicemirroring/reconciler.go
+++ b/pkg/controller/endpointslicemirroring/reconciler.go
@@ -263,7 +263,7 @@ func (r *reconciler) finalize(endpoints *corev1.Endpoints, slices slicesByAction
 		if err != nil {
 			return fmt.Errorf("failed to delete %s EndpointSlice for Endpoints %s/%s: %v", endpointSlice.Name, endpoints.Namespace, endpoints.Name, err)
 		}
-		r.endpointSliceTracker.Delete(endpointSlice)
+		r.endpointSliceTracker.ExpectDeletion(endpointSlice)
 		metrics.EndpointSliceChanges.WithLabelValues("delete").Inc()
 	}
 

--- a/pkg/controller/endpointslicemirroring/utils_test.go
+++ b/pkg/controller/endpointslicemirroring/utils_test.go
@@ -172,13 +172,13 @@ func newClientset() *fake.Clientset {
 			endpointSlice.ObjectMeta.Name = fmt.Sprintf("%s-%s", endpointSlice.ObjectMeta.GenerateName, rand.String(8))
 			endpointSlice.ObjectMeta.GenerateName = ""
 		}
-		endpointSlice.ObjectMeta.ResourceVersion = "100"
+		endpointSlice.ObjectMeta.Generation = 1
 
 		return false, endpointSlice, nil
 	}))
 	client.PrependReactor("update", "endpointslices", k8stesting.ReactionFunc(func(action k8stesting.Action) (bool, runtime.Object, error) {
 		endpointSlice := action.(k8stesting.CreateAction).GetObject().(*discovery.EndpointSlice)
-		endpointSlice.ObjectMeta.ResourceVersion = "200"
+		endpointSlice.ObjectMeta.Generation++
 		return false, endpointSlice, nil
 	}))
 


### PR DESCRIPTION
Cherry pick of #99756 on release-1.20.

#99756: Updating EndpointSliceMirroring controller to wait for cache

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### Does this PR introduce a user-facing change?
```release-note
EndpointSliceMirroring controller is now less likely to emit FailedToUpdateEndpointSlices events.
```