### PR TITLE
Add --chunk-size flag to kubectl drain

### DIFF
--- a/staging/src/k8s.io/cli-runtime/pkg/resource/helper.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/resource/helper.go
@@ -18,9 +18,12 @@ package resource
 
 import (
 	"context"
+	"fmt"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -88,6 +91,54 @@ func (m *Helper) List(namespace, apiVersion string, options *metav1.ListOptions)
 		Resource(m.Resource).
 		VersionedParams(options, metav1.ParameterCodec)
 	return req.Do(context.TODO()).Get()
+}
+
+// FollowContinue handles the continue parameter returned by the API server when using list
+// chunking. To take advantage of this, the initial ListOptions provided by the consumer
+// should include a non-zero Limit parameter.
+func FollowContinue(initialOpts *metav1.ListOptions,
+	listFunc func(metav1.ListOptions) (runtime.Object, error)) error {
+	opts := initialOpts
+	for {
+		list, err := listFunc(*opts)
+		if err != nil {
+			return err
+		}
+		nextContinueToken, _ := metadataAccessor.Continue(list)
+		if len(nextContinueToken) == 0 {
+			return nil
+		}
+		opts.Continue = nextContinueToken
+	}
+}
+
+// EnhanceListError augments errors typically returned by List operations with additional context,
+// making sure to retain the StatusError type when applicable.
+func EnhanceListError(err error, opts metav1.ListOptions, subj string) error {
+	if apierrors.IsResourceExpired(err) {
+		return err
+	}
+	if apierrors.IsBadRequest(err) || apierrors.IsNotFound(err) {
+		if se, ok := err.(*apierrors.StatusError); ok {
+			// modify the message without hiding this is an API error
+			if len(opts.LabelSelector) == 0 && len(opts.FieldSelector) == 0 {
+				se.ErrStatus.Message = fmt.Sprintf("Unable to list %q: %v", subj,
+					se.ErrStatus.Message)
+			} else {
+				se.ErrStatus.Message = fmt.Sprintf(
+					"Unable to find %q that match label selector %q, field selector %q: %v", subj,
+					opts.LabelSelector,
+					opts.FieldSelector, se.ErrStatus.Message)
+			}
+			return se
+		}
+		if len(opts.LabelSelector) == 0 && len(opts.FieldSelector) == 0 {
+			return fmt.Errorf("Unable to list %q: %v", subj, err)
+		}
+		return fmt.Errorf("Unable to find %q that match label selector %q, field selector %q: %v",
+			subj, opts.LabelSelector, opts.FieldSelector, err)
+	}
+	return err
 }
 
 func (m *Helper) Watch(namespace, apiVersion string, options *metav1.ListOptions) (watch.Interface, error) {

--- a/staging/src/k8s.io/cli-runtime/pkg/resource/helper_test.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/resource/helper_test.go
@@ -19,6 +19,7 @@ package resource
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -26,6 +27,7 @@ import (
 	"strings"
 	"testing"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -624,6 +626,177 @@ func TestHelperReplace(t *testing.T) {
 			}
 			if !reflect.DeepEqual(expect, body) {
 				t.Fatalf("unexpected body: %s", string(body))
+			}
+		})
+	}
+}
+
+func TestEnhanceListError(t *testing.T) {
+	podGVR := corev1.SchemeGroupVersion.WithResource(corev1.ResourcePods.String())
+	podSubject := podGVR.String()
+	tests := []struct {
+		name string
+		err  error
+		opts metav1.ListOptions
+		subj string
+
+		expectedErr     string
+		expectStatusErr bool
+	}{
+		{
+			name:            "leaves resource expired error as is",
+			err:             apierrors.NewResourceExpired("resourceversion too old"),
+			opts:            metav1.ListOptions{},
+			subj:            podSubject,
+			expectedErr:     "resourceversion too old",
+			expectStatusErr: true,
+		}, {
+			name:            "leaves unrecognized error as is",
+			err:             errors.New("something went wrong"),
+			opts:            metav1.ListOptions{},
+			subj:            podSubject,
+			expectedErr:     "something went wrong",
+			expectStatusErr: false,
+		}, {
+			name:            "bad request StatusError without selectors",
+			err:             apierrors.NewBadRequest("request is invalid"),
+			opts:            metav1.ListOptions{},
+			subj:            podSubject,
+			expectedErr:     "Unable to list \"/v1, Resource=pods\": request is invalid",
+			expectStatusErr: true,
+		}, {
+			name: "bad request StatusError with selectors",
+			err:  apierrors.NewBadRequest("request is invalid"),
+			opts: metav1.ListOptions{
+				LabelSelector: "a=b",
+				FieldSelector: ".spec.nodeName=foo",
+			},
+			subj:            podSubject,
+			expectedErr:     "Unable to find \"/v1, Resource=pods\" that match label selector \"a=b\", field selector \".spec.nodeName=foo\": request is invalid",
+			expectStatusErr: true,
+		}, {
+			name:            "not found without selectors",
+			err:             apierrors.NewNotFound(podGVR.GroupResource(), "foo"),
+			opts:            metav1.ListOptions{},
+			subj:            podSubject,
+			expectedErr:     "Unable to list \"/v1, Resource=pods\": pods \"foo\" not found",
+			expectStatusErr: true,
+		}, {
+			name: "not found StatusError with selectors",
+			err:  apierrors.NewNotFound(podGVR.GroupResource(), "foo"),
+			opts: metav1.ListOptions{
+				LabelSelector: "a=b",
+				FieldSelector: ".spec.nodeName=foo",
+			},
+			subj:            podSubject,
+			expectedErr:     "Unable to find \"/v1, Resource=pods\" that match label selector \"a=b\", field selector \".spec.nodeName=foo\": pods \"foo\" not found",
+			expectStatusErr: true,
+		}, {
+			name: "non StatusError without selectors",
+			err: fmt.Errorf("extra info: %w", apierrors.NewNotFound(podGVR.GroupResource(),
+				"foo")),
+			opts:            metav1.ListOptions{},
+			subj:            podSubject,
+			expectedErr:     "Unable to list \"/v1, Resource=pods\": extra info: pods \"foo\" not found",
+			expectStatusErr: false,
+		}, {
+			name: "non StatusError with selectors",
+			err:  fmt.Errorf("extra info: %w", apierrors.NewNotFound(podGVR.GroupResource(), "foo")),
+			opts: metav1.ListOptions{
+				LabelSelector: "a=b",
+				FieldSelector: ".spec.nodeName=foo",
+			},
+			subj: podSubject,
+			expectedErr: "Unable to find \"/v1, " +
+				"Resource=pods\" that match label selector \"a=b\", " +
+				"field selector \".spec.nodeName=foo\": extra info: pods \"foo\" not found",
+			expectStatusErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := EnhanceListError(tt.err, tt.opts, tt.subj)
+			if err == nil {
+				t.Errorf("EnhanceListError did not return an error")
+			}
+			if err.Error() != tt.expectedErr {
+				t.Errorf("EnhanceListError() error = %q, expectedErr %q", err, tt.expectedErr)
+			}
+			if tt.expectStatusErr {
+				if _, ok := err.(*apierrors.StatusError); !ok {
+					t.Errorf("EnhanceListError incorrectly returned a non-StatusError: %v", err)
+				}
+			}
+		})
+	}
+}
+
+func TestFollowContinue(t *testing.T) {
+	var continueTokens []string
+	tests := []struct {
+		name        string
+		initialOpts *metav1.ListOptions
+		tokensSeen  []string
+		listFunc    func(metav1.ListOptions) (runtime.Object, error)
+
+		expectedTokens []string
+		wantErr        string
+	}{
+		{
+			name:        "updates list options with continue token until list finished",
+			initialOpts: &metav1.ListOptions{},
+			listFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+				continueTokens = append(continueTokens, options.Continue)
+				obj := corev1.PodList{}
+				switch options.Continue {
+				case "":
+					metadataAccessor.SetContinue(&obj, "abc")
+				case "abc":
+					metadataAccessor.SetContinue(&obj, "def")
+				case "def":
+					metadataAccessor.SetKind(&obj, "ListComplete")
+				}
+				return &obj, nil
+			},
+			expectedTokens: []string{"", "abc", "def"},
+		},
+		{
+			name:        "stops looping if listFunc returns an error",
+			initialOpts: &metav1.ListOptions{},
+			listFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+				continueTokens = append(continueTokens, options.Continue)
+				obj := corev1.PodList{}
+				switch options.Continue {
+				case "":
+					metadataAccessor.SetContinue(&obj, "abc")
+				case "abc":
+					return nil, fmt.Errorf("err from list func")
+				case "def":
+					metadataAccessor.SetKind(&obj, "ListComplete")
+				}
+				return &obj, nil
+			},
+			expectedTokens: []string{"", "abc"},
+			wantErr:        "err from list func",
+		},
+	}
+	for _, tt := range tests {
+		continueTokens = []string{}
+		t.Run(tt.name, func(t *testing.T) {
+			err := FollowContinue(tt.initialOpts, tt.listFunc)
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("FollowContinue was expected to return an error and did not")
+				} else if err.Error() != tt.wantErr {
+					t.Fatalf("wanted error %q, got %q", tt.wantErr, err.Error())
+				}
+			} else {
+				if err != nil {
+					t.Errorf("FollowContinue failed: %v", tt.wantErr)
+				}
+				if !reflect.DeepEqual(continueTokens, tt.expectedTokens) {
+					t.Errorf("got token list %q, wanted %q", continueTokens, tt.expectedTokens)
+				}
 			}
 		})
 	}

--- a/staging/src/k8s.io/cli-runtime/pkg/resource/selector.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/resource/selector.go
@@ -17,11 +17,9 @@ limitations under the License.
 package resource
 
 import (
-	"fmt"
-
-	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
 )
 
@@ -49,41 +47,23 @@ func NewSelector(client RESTClient, mapping *meta.RESTMapping, namespace, labelS
 
 // Visit implements Visitor and uses request chunking by default.
 func (r *Selector) Visit(fn VisitorFunc) error {
-	var continueToken string
-	for {
-		list, err := NewHelper(r.Client, r.Mapping).List(
+	helper := NewHelper(r.Client, r.Mapping)
+	initialOpts := metav1.ListOptions{
+		LabelSelector: r.LabelSelector,
+		FieldSelector: r.FieldSelector,
+		Limit:         r.LimitChunks,
+	}
+	return FollowContinue(&initialOpts, func(options metav1.ListOptions) (runtime.Object, error) {
+		list, err := helper.List(
 			r.Namespace,
 			r.ResourceMapping().GroupVersionKind.GroupVersion().String(),
-			&metav1.ListOptions{
-				LabelSelector: r.LabelSelector,
-				FieldSelector: r.FieldSelector,
-				Limit:         r.LimitChunks,
-				Continue:      continueToken,
-			},
+			&options,
 		)
 		if err != nil {
-			if errors.IsResourceExpired(err) {
-				return err
-			}
-			if errors.IsBadRequest(err) || errors.IsNotFound(err) {
-				if se, ok := err.(*errors.StatusError); ok {
-					// modify the message without hiding this is an API error
-					if len(r.LabelSelector) == 0 && len(r.FieldSelector) == 0 {
-						se.ErrStatus.Message = fmt.Sprintf("Unable to list %q: %v", r.Mapping.Resource, se.ErrStatus.Message)
-					} else {
-						se.ErrStatus.Message = fmt.Sprintf("Unable to find %q that match label selector %q, field selector %q: %v", r.Mapping.Resource, r.LabelSelector, r.FieldSelector, se.ErrStatus.Message)
-					}
-					return se
-				}
-				if len(r.LabelSelector) == 0 && len(r.FieldSelector) == 0 {
-					return fmt.Errorf("Unable to list %q: %v", r.Mapping.Resource, err)
-				}
-				return fmt.Errorf("Unable to find %q that match label selector %q, field selector %q: %v", r.Mapping.Resource, r.LabelSelector, r.FieldSelector, err)
-			}
-			return err
+			return nil, EnhanceListError(err, options, r.Mapping.Resource.String())
 		}
 		resourceVersion, _ := metadataAccessor.ResourceVersion(list)
-		nextContinueToken, _ := metadataAccessor.Continue(list)
+
 		info := &Info{
 			Client:  r.Client,
 			Mapping: r.Mapping,
@@ -95,13 +75,10 @@ func (r *Selector) Visit(fn VisitorFunc) error {
 		}
 
 		if err := fn(info, nil); err != nil {
-			return err
+			return nil, err
 		}
-		if len(nextContinueToken) == 0 {
-			return nil
-		}
-		continueToken = nextContinueToken
-	}
+		return list, nil
+	})
 }
 
 func (r *Selector) Watch(resourceVersion string) (watch.Interface, error) {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/drain/drain.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/drain/drain.go
@@ -148,6 +148,7 @@ func NewDrainCmdOptions(f cmdutil.Factory, ioStreams genericclioptions.IOStreams
 			GracePeriodSeconds: -1,
 			Out:                ioStreams.Out,
 			ErrOut:             ioStreams.ErrOut,
+			ChunkSize:          cmdutil.DefaultChunkSize,
 		},
 	}
 	o.drainer.OnPodDeletedOrEvicted = o.onPodDeletedOrEvicted
@@ -198,6 +199,7 @@ func NewCmdDrain(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *cobr
 	cmd.Flags().BoolVar(&o.drainer.DisableEviction, "disable-eviction", o.drainer.DisableEviction, "Force drain to use delete, even if eviction is supported. This will bypass checking PodDisruptionBudgets, use with caution.")
 	cmd.Flags().IntVar(&o.drainer.SkipWaitForDeleteTimeoutSeconds, "skip-wait-for-delete-timeout", o.drainer.SkipWaitForDeleteTimeoutSeconds, "If pod DeletionTimestamp older than N seconds, skip waiting for the pod.  Seconds must be greater than 0 to skip.")
 
+	cmdutil.AddChunkSizeFlag(cmd, &o.drainer.ChunkSize)
 	cmdutil.AddDryRunFlag(cmd)
 	return cmd
 }
@@ -256,6 +258,7 @@ func (o *DrainCmdOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args [
 	builder := f.NewBuilder().
 		WithScheme(scheme.Scheme, scheme.Scheme.PrioritizedVersionsAllGroups()...).
 		NamespaceParam(o.Namespace).DefaultNamespace().
+		RequestChunksOf(o.drainer.ChunkSize).
 		ResourceNames("nodes", args...).
 		SingleResourceType().
 		Flatten()

--- a/staging/src/k8s.io/kubectl/pkg/cmd/drain/drain_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/drain/drain_test.go
@@ -810,6 +810,7 @@ func TestDrain(t *testing.T) {
 							}
 							getParams := make(url.Values)
 							getParams["fieldSelector"] = []string{"spec.nodeName=node"}
+							getParams["limit"] = []string{"500"}
 							if !reflect.DeepEqual(getParams, values) {
 								t.Fatalf("%s: expected:\n%v\nsaw:\n%v\n", test.description, getParams, values)
 							}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/get/get.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/get/get.go
@@ -145,7 +145,7 @@ func NewGetOptions(parent string, streams genericclioptions.IOStreams) *GetOptio
 		CmdParent:  parent,
 
 		IOStreams:   streams,
-		ChunkSize:   500,
+		ChunkSize:   cmdutil.DefaultChunkSize,
 		ServerPrint: true,
 	}
 }

--- a/staging/src/k8s.io/kubectl/pkg/cmd/get/get.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/get/get.go
@@ -175,7 +175,6 @@ func NewCmdGet(parent string, f cmdutil.Factory, streams genericclioptions.IOStr
 	cmd.Flags().BoolVarP(&o.Watch, "watch", "w", o.Watch, "After listing/getting the requested object, watch for changes. Uninitialized objects are excluded if no object name is provided.")
 	cmd.Flags().BoolVar(&o.WatchOnly, "watch-only", o.WatchOnly, "Watch for changes to the requested object(s), without listing/getting first.")
 	cmd.Flags().BoolVar(&o.OutputWatchEvents, "output-watch-events", o.OutputWatchEvents, "Output watch event objects when --watch or --watch-only is used. Existing objects are output as initial ADDED events.")
-	cmd.Flags().Int64Var(&o.ChunkSize, "chunk-size", o.ChunkSize, "Return large lists in chunks rather than all at once. Pass 0 to disable. This flag is beta and may change in the future.")
 	cmd.Flags().BoolVar(&o.IgnoreNotFound, "ignore-not-found", o.IgnoreNotFound, "If the requested object does not exist the command will return exit code 0.")
 	cmd.Flags().StringVarP(&o.LabelSelector, "selector", "l", o.LabelSelector, "Selector (label query) to filter on, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)")
 	cmd.Flags().StringVar(&o.FieldSelector, "field-selector", o.FieldSelector, "Selector (field query) to filter on, supports '=', '==', and '!='.(e.g. --field-selector key1=value1,key2=value2). The server only supports a limited number of field queries per type.")
@@ -183,6 +182,7 @@ func NewCmdGet(parent string, f cmdutil.Factory, streams genericclioptions.IOStr
 	addOpenAPIPrintColumnFlags(cmd, o)
 	addServerPrintColumnFlags(cmd, o)
 	cmdutil.AddFilenameOptionFlags(cmd, &o.FilenameOptions, "identifying the resource to get from a server.")
+	cmdutil.AddChunkSizeFlag(cmd, &o.ChunkSize)
 	return cmd
 }
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/util/helpers.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/util/helpers.go
@@ -464,6 +464,11 @@ func AddGeneratorFlags(cmd *cobra.Command, defaultGenerator string) {
 	AddDryRunFlag(cmd)
 }
 
+func AddChunkSizeFlag(cmd *cobra.Command, value *int64) {
+	cmd.Flags().Int64Var(value, "chunk-size", *value,
+		"Return large lists in chunks rather than all at once. Pass 0 to disable. This flag is beta and may change in the future.")
+}
+
 type ValidateOptions struct {
 	EnableValidation bool
 }

--- a/staging/src/k8s.io/kubectl/pkg/cmd/util/helpers.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/util/helpers.go
@@ -50,6 +50,7 @@ import (
 const (
 	ApplyAnnotationsFlag = "save-config"
 	DefaultErrorExitCode = 1
+	DefaultChunkSize     = 500
 )
 
 type debugError interface {


### PR DESCRIPTION
#### What type of PR is this?

/kind feature


#### What this PR does / why we need it:

Adds the `--chunk-size` flag to kubectl drain . This flag causes the `limit` parameter to be set on list requests the command makes, which in practice is a node list and a pod list. The flag's value defaults to 500, the same as `kubectl get`.

Having this flag available with a sane default value improves the scalability of the command because list requests made without a limit parameter (as `drain` is sending today) can cause a full load of the underlying resource data from etcd to be attempted, and this may fail on clusters of sufficient scale. For example, this change may help you if you are seeing grpc message size errors when attempting to drain in a large cluster, even when you're targeting a single node running a small number of pods. For more detail on the problem and solutions considered, please refer to this issue: https://github.com/kubernetes/kubectl/issues/1028.

#### Which issue(s) this PR fixes:

Part 1 of fixing https://github.com/kubernetes/kubectl/issues/1028

#### Special notes for your reviewer:

I initially used the Selector Visitor in an attempt to follow established patterns; this is where `continue` support was added when chunking was added to `get`, and it does work for this case too. However, in a later commit I did some refactoring to extract the `continue` handling, making it easier to add chunking support to places like `drain` that are using a specific client right now.


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
`kubectl drain` will by default fetch large lists of resources in chunks of up to 500 items rather than requesting all resources up front from the server. A new flag `--chunk-size=SIZE` may be used to alter the number of items or disable this feature when `0` is passed.  This is a beta feature.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

The flag is included in kubectl's own flag documentation, i.e.:

```
Options:
      --chunk-size=500: Return large lists in chunks rather than all at once. Pass 0 to disable. This flag is beta and may change in the future.
```

If other documentation updates need to be made, please let me know.