### PR TITLE
Promote NetworkPolicy test to Conformance +8 Endpoints

### DIFF
--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -1251,6 +1251,16 @@
     watch, update, patch, delete, and deletecollection.'
   release: v1.19
   file: test/e2e/network/ingressclass.go
+- testname: NetworkPolicies API Create, List, Replace, Patch and Delete operations
+  codename: '[sig-network] Netpol API should support creating NetworkPolicy API operations
+    [Conformance]'
+  description: ' - The networking.k8s.io API group MUST exist in the /apis discovery
+    document. - The networking.k8s.io/v1 API group/version MUST exist in the /apis/networking.k8s.io
+    discovery document. - The NetworkPolicies resources MUST exist in the /apis/networking.k8s.io/v1
+    discovery document. - The NetworkPolicies resource must support create, get, list,
+    watch, update, patch, delete, and deletecollection.'
+  release: v1.21
+  file: test/e2e/network/netpol/network_policy_api.go
 - testname: Networking, intra pod http
   codename: '[sig-network] Networking Granular Checks: Pods should function for intra-pod
     communication: http [NodeConformance] [Conformance]'

--- a/test/e2e/network/netpol/network_policy_api.go
+++ b/test/e2e/network/netpol/network_policy_api.go
@@ -36,16 +36,15 @@ import (
 var _ = common.SIGDescribe("Netpol API", func() {
 	f := framework.NewDefaultFramework("netpol")
 	/*
-		Release: v1.20
-		Testname: NetworkPolicies API
+		Release: v1.21
+		Testname: NetworkPolicies API Create, List, Replace, Patch and Delete operations
 		Description:
 		- The networking.k8s.io API group MUST exist in the /apis discovery document.
 		- The networking.k8s.io/v1 API group/version MUST exist in the /apis/networking.k8s.io discovery document.
 		- The NetworkPolicies resources MUST exist in the /apis/networking.k8s.io/v1 discovery document.
 		- The NetworkPolicies resource must support create, get, list, watch, update, patch, delete, and deletecollection.
 	*/
-
-	ginkgo.It("should support creating NetworkPolicy API operations", func() {
+	framework.ConformanceIt("should support creating NetworkPolicy API operations", func() {
 		// Setup
 		ns := f.Namespace.Name
 		npVersion := "v1"


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it:**
This PR adds a test to test the following untested endpoints:
- createNetworkingV1NamespacedNetworkPolicy
- readNetworkingV1NamespacedNetworkPolicy
- listNetworkingV1NamespacedNetworkPolicy
- listNetworkingV1NetworkPolicyForAllNamespaces
- patchNetworkingV1NamespacedNetworkPolicy
- replaceNetworkingV1NamespacedNetworkPolicy
- deleteNetworkingV1CollectionNamespacedNetworkPolicy
- deleteNetworkingV1NamespacedNetworkPolicy

**Testgrid Link:**
[Link](https://k8s-testgrid.appspot.com/sig-release-master-blocking#gce-cos-master-default&include-filter-by-regex=Netpol%20API%20should%20support%20creating%20NetworkPolicy%20API%20operations&graph-metrics=test-duration-minutes&width=5)
The test has run more than 14 days flake-free.

**Special notes for your reviewer:**
Adds +8 endpoint test coverage (good for conformance)
The will move the [Network API Group ](https://apisnoop.cncf.io/1.21.0/stable/networking)to 100% Conformance tested.

**Does this PR introduce a user-facing change?:**
```
NONE

```

**Release note:**
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:**
```
NONE

```

/sig testing
/sig architecture
/sig apps
/area conformance