### PR TITLE
edit: Add tests for cases where the edited file name has a space

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/util/editor/editor.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/util/editor/editor.go
@@ -98,7 +98,7 @@ func defaultEnvEditor(envs []string) ([]string, bool) {
 }
 
 func (e Editor) args(path string) []string {
-	args := make([]string, len(e.Args))
+	args := make([]string, len(e.Args), len(e.Args)+1)
 	copy(args, e.Args)
 	if e.Shell {
 		last := args[len(args)-1]

--- a/staging/src/k8s.io/kubectl/pkg/cmd/util/editor/editor_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/util/editor/editor_test.go
@@ -35,6 +35,12 @@ func TestArgs(t *testing.T) {
 	if e, a := []string{"/bin/bash", "-i -c \"test\""}, (Editor{Args: []string{"/bin/bash", "-i -c"}, Shell: true}).args("test"); !reflect.DeepEqual(e, a) {
 		t.Errorf("unexpected args: %v", a)
 	}
+	if e, a := []string{"/bin/bash", "-c \"test space\""}, (Editor{Args: []string{"/bin/bash", "-c"}, Shell: true}).args("test space"); !reflect.DeepEqual(e, a) {
+		t.Errorf("unexpected args: %v", a)
+	}
+	if e, a := []string{"/bin/bash", "-c", "test space"}, (Editor{Args: []string{"/bin/bash", "-c"}, Shell: false}).args("test space"); !reflect.DeepEqual(e, a) {
+		t.Errorf("unexpected args: %v", a)
+	}
 	if e, a := []string{"/test", "test"}, (Editor{Args: []string{"/test"}}).args("test"); !reflect.DeepEqual(e, a) {
 		t.Errorf("unexpected args: %v", a)
 	}


### PR DESCRIPTION
This is a common scenario on Windows when the username contains a space
-- the default temporary directory path `%TMP%` depends on the username.
Add two tests to ensure the editing feature works properly in these
scenarios.

Also increasing `args`'s capacity by one to make it a bit more efficient
in expecting the `append` call a few lines below.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup


#### What this PR does / why we need it:

See the commit message above.

#### Special notes for your reviewer:

I can drop the single-line change if you are strict about commit message vs. actual changes.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

