### PR TITLE
add normalize function to global FlagSet

### DIFF
--- a/cmd/cloud-controller-manager/main.go
+++ b/cmd/cloud-controller-manager/main.go
@@ -48,6 +48,8 @@ import (
 func main() {
 	rand.Seed(time.Now().UnixNano())
 
+	pflag.CommandLine.SetNormalizeFunc(cliflag.WordSepNormalizeFunc)
+
 	ccmOptions, err := options.NewCloudControllerManagerOptions()
 	if err != nil {
 		klog.Fatalf("unable to initialize command options: %v", err)
@@ -70,12 +72,6 @@ func main() {
 
 	command := app.NewCloudControllerManagerCommand(ccmOptions, cloudInitializer, controllerInitializers, fss, wait.NeverStop)
 
-	// TODO: once we switch everything over to Cobra commands, we can go back to calling
-	// utilflag.InitFlags() (by removing its pflag.Parse() call). For now, we have to set the
-	// normalize func and add the go flag set by hand.
-	// Here is an sample
-	pflag.CommandLine.SetNormalizeFunc(cliflag.WordSepNormalizeFunc)
-	// utilflag.InitFlags()
 	logs.InitLogs()
 	defer logs.FlushLogs()
 

--- a/cmd/kube-apiserver/apiserver.go
+++ b/cmd/kube-apiserver/apiserver.go
@@ -23,6 +23,9 @@ import (
 	"os"
 	"time"
 
+	"github.com/spf13/pflag"
+
+	cliflag "k8s.io/component-base/cli/flag"
 	"k8s.io/component-base/logs"
 	_ "k8s.io/component-base/metrics/prometheus/clientgo" // load all the prometheus client-go plugins
 	_ "k8s.io/component-base/metrics/prometheus/version"  // for version metric registration
@@ -32,12 +35,10 @@ import (
 func main() {
 	rand.Seed(time.Now().UnixNano())
 
+	pflag.CommandLine.SetNormalizeFunc(cliflag.WordSepNormalizeFunc)
+
 	command := app.NewAPIServerCommand()
 
-	// TODO: once we switch everything over to Cobra commands, we can go back to calling
-	// utilflag.InitFlags() (by removing its pflag.Parse() call). For now, we have to set the
-	// normalize func and add the go flag set by hand.
-	// utilflag.InitFlags()
 	logs.InitLogs()
 	defer logs.FlushLogs()
 

--- a/cmd/kube-controller-manager/controller-manager.go
+++ b/cmd/kube-controller-manager/controller-manager.go
@@ -25,6 +25,9 @@ import (
 	"os"
 	"time"
 
+	"github.com/spf13/pflag"
+
+	cliflag "k8s.io/component-base/cli/flag"
 	"k8s.io/component-base/logs"
 	_ "k8s.io/component-base/metrics/prometheus/clientgo" // load all the prometheus client-go plugin
 	_ "k8s.io/component-base/metrics/prometheus/version"  // for version metric registration
@@ -34,12 +37,10 @@ import (
 func main() {
 	rand.Seed(time.Now().UnixNano())
 
+	pflag.CommandLine.SetNormalizeFunc(cliflag.WordSepNormalizeFunc)
+
 	command := app.NewControllerManagerCommand()
 
-	// TODO: once we switch everything over to Cobra commands, we can go back to calling
-	// utilflag.InitFlags() (by removing its pflag.Parse() call). For now, we have to set the
-	// normalize func and add the go flag set by hand.
-	// utilflag.InitFlags()
 	logs.InitLogs()
 	defer logs.FlushLogs()
 

--- a/cmd/kube-scheduler/scheduler.go
+++ b/cmd/kube-scheduler/scheduler.go
@@ -33,13 +33,10 @@ import (
 func main() {
 	rand.Seed(time.Now().UnixNano())
 
+	pflag.CommandLine.SetNormalizeFunc(cliflag.WordSepNormalizeFunc)
+
 	command := app.NewSchedulerCommand()
 
-	// TODO: once we switch everything over to Cobra commands, we can go back to calling
-	// utilflag.InitFlags() (by removing its pflag.Parse() call). For now, we have to set the
-	// normalize func and add the go flag set by hand.
-	pflag.CommandLine.SetNormalizeFunc(cliflag.WordSepNormalizeFunc)
-	// utilflag.InitFlags()
 	logs.InitLogs()
 	defer logs.FlushLogs()
 

--- a/staging/src/k8s.io/component-base/cli/flag/sectioned.go
+++ b/staging/src/k8s.io/component-base/cli/flag/sectioned.go
@@ -31,6 +31,8 @@ type NamedFlagSets struct {
 	Order []string
 	// FlagSets stores the flag sets by name.
 	FlagSets map[string]*pflag.FlagSet
+	// NormalizeNameFunc is the normalize function which used to initialize FlagSets created by NamedFlagSets.
+	NormalizeNameFunc func(f *pflag.FlagSet, name string) pflag.NormalizedName
 }
 
 // FlagSet returns the flag set with the given name and adds it to the
@@ -40,7 +42,12 @@ func (nfs *NamedFlagSets) FlagSet(name string) *pflag.FlagSet {
 		nfs.FlagSets = map[string]*pflag.FlagSet{}
 	}
 	if _, ok := nfs.FlagSets[name]; !ok {
-		nfs.FlagSets[name] = pflag.NewFlagSet(name, pflag.ExitOnError)
+		flagSet := pflag.NewFlagSet(name, pflag.ExitOnError)
+		flagSet.SetNormalizeFunc(pflag.CommandLine.GetNormalizeFunc())
+		if nfs.NormalizeNameFunc != nil {
+			flagSet.SetNormalizeFunc(nfs.NormalizeNameFunc)
+		}
+		nfs.FlagSets[name] = flagSet
 		nfs.Order = append(nfs.Order, name)
 	}
 	return nfs.FlagSets[name]


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
In #99257, we use NormalizeFunc to normalize the flag name, but kube-apiserver,kube-controller-manager,kube-scheduler and cloud-provider donot register the normalize function to globalFlagSet, which cause the command line parameters change:
![image](https://user-images.githubusercontent.com/1468240/110903881-15fece00-8343-11eb-83a6-88da0717b96b.png)

https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/
![image](https://user-images.githubusercontent.com/1468240/110903985-4181b880-8343-11eb-8d6a-b48b048e07ce.png)

so, we should register the cliflag.WordSepNormalizeFunc to global FlagSets before add GlobalFlags

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
@serathius

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
