### PR TITLE
test: remove gcr.io/gke-release since it is deprecated

### DIFF
--- a/test/utils/image/manifest.go
+++ b/test/utils/image/manifest.go
@@ -78,7 +78,6 @@ func initReg() RegistryList {
 		GcEtcdRegistry:          "k8s.gcr.io",
 		GcRegistry:              "k8s.gcr.io",
 		SigStorageRegistry:      "k8s.gcr.io/sig-storage",
-		GcrReleaseRegistry:      "gcr.io/gke-release",
 		PrivateRegistry:         "gcr.io/k8s-authenticated-test",
 		SampleRegistry:          "gcr.io/google-samples",
 		MicrosoftRegistry:       "mcr.microsoft.com",
@@ -116,7 +115,6 @@ var (
 	gcEtcdRegistry          = registry.GcEtcdRegistry
 	gcRegistry              = registry.GcRegistry
 	sigStorageRegistry      = registry.SigStorageRegistry
-	gcrReleaseRegistry      = registry.GcrReleaseRegistry
 	invalidRegistry         = registry.InvalidRegistry
 	sampleRegistry          = registry.SampleRegistry
 	microsoftRegistry       = registry.MicrosoftRegistry
@@ -397,8 +395,6 @@ func ReplaceRegistryInImageURL(imageURL string) (string, error) {
 		registryAndUser = PrivateRegistry
 	case "gcr.io/google-samples":
 		registryAndUser = sampleRegistry
-	case "gcr.io/gke-release":
-		registryAndUser = gcrReleaseRegistry
 	case "docker.io/library":
 		registryAndUser = dockerLibraryRegistry
 	default:

--- a/test/utils/image/manifest_test.go
+++ b/test/utils/image/manifest_test.go
@@ -83,13 +83,6 @@ var registryTests = []struct {
 		},
 	},
 	{
-		"gcr.io/gke-release/test:latest",
-		result{
-			result: "test.io/gke-release/test:latest",
-			err:    nil,
-		},
-	},
-	{
 		"gcr.io/google-samples/test:latest",
 		result{
 			result: "test.io/google-samples/test:latest",
@@ -119,7 +112,6 @@ func TestReplaceRegistryInImageURL(t *testing.T) {
 	e2eRegistry = "test.io/kubernetes-e2e-test-images"
 	e2eVolumeRegistry = "test.io/kubernetes-e2e-test-images/volume"
 	gcRegistry = "test.io"
-	gcrReleaseRegistry = "test.io/gke-release"
 	PrivateRegistry = "test.io/k8s-authenticated-test"
 	sampleRegistry = "test.io/google-samples"
 	sigStorageRegistry = "test.io/sig-storage"


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

As part of the efforts described in this Issue: https://github.com/kubernetes/k8s.io/issues/1525 we are trying to move away from `gcp project gke-release`

This PR update the tests to remove the gke-release reference.

If this makes no sense and we want to keep that as is, feel free to close this PR.

/assign @spiffxp 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
