### PR TITLE
e2e: TM: wait for SRIOV devices in pod scope tests

### DIFF
--- a/test/e2e_node/topology_manager_test.go
+++ b/test/e2e_node/topology_manager_test.go
@@ -593,6 +593,8 @@ func runTMScopeResourceAlignmentTestSuite(f *framework.Framework, configMap *v1.
 	sd := setupSRIOVConfigOrFail(f, configMap)
 	var ctnAttrs, initCtnAttrs []tmCtnAttribute
 
+	waitForSRIOVResources(f, sd)
+
 	envInfo := &testEnvInfo{
 		numaNodes:         numaNodes,
 		sriovResourceName: sd.resourceName,


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
Make sure the pod-scope topology manager e2e tests wait for the availability of the devices to avoid hard-to-debug false negatives/flakes.

#### Which issue(s) this PR fixes:
N/A

#### Special notes for your reviewer:
CI lanes did NOT fail (and will not fail) because the CI machines aren't multi NUMA nor expose SRIOV devices, so the relevant portion of the test will just skip, avoiding the issue at all. We will see this misbehaviour on multi-NUMA + SRIOV boxes, like baremetal, which some organizations (e.g. RH) run.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
N/A
