### PR TITLE
part1: master to controlplane in test/integration(1.22)

### DIFF
--- a/test/integration/ipamperf/ipam_test.go
+++ b/test/integration/ipamperf/ipam_test.go
@@ -114,8 +114,8 @@ func TestPerformance(t *testing.T) {
 		t.Skip("Skipping because we want to run short tests")
 	}
 
-	apiURL, masterShutdown := util.StartApiserver()
-	defer masterShutdown()
+	apiURL, apiserverShutdown := util.StartApiserver()
+	defer apiserverShutdown()
 
 	_, clusterCIDR, _ := net.ParseCIDR("10.96.0.0/11") // allows up to 8K nodes
 	_, serviceCIDR, _ := net.ParseCIDR("10.94.0.0/24") // does not matter for test - pick upto  250 services

--- a/test/integration/master/synthetic_master_test.go
+++ b/test/integration/master/synthetic_master_test.go
@@ -143,13 +143,13 @@ func TestEmptyList(t *testing.T) {
 	}
 }
 
-func initStatusForbiddenMasterCongfig() *controlplane.Config {
+func initStatusForbiddenControlPlaneConfig() *controlplane.Config {
 	masterConfig := framework.NewIntegrationTestMasterConfig()
 	masterConfig.GenericConfig.Authorization.Authorizer = authorizerfactory.NewAlwaysDenyAuthorizer()
 	return masterConfig
 }
 
-func initUnauthorizedMasterCongfig() *controlplane.Config {
+func initUnauthorizedControlPlaneConfig() *controlplane.Config {
 	masterConfig := framework.NewIntegrationTestMasterConfig()
 	tokenAuthenticator := tokentest.New()
 	tokenAuthenticator.Tokens[AliceToken] = &user.DefaultInfo{Name: "alice", UID: "1"}
@@ -178,7 +178,7 @@ func TestStatus(t *testing.T) {
 		},
 		{
 			name:         "403",
-			masterConfig: initStatusForbiddenMasterCongfig(),
+			masterConfig: initStatusForbiddenControlPlaneConfig(),
 			statusCode:   http.StatusForbidden,
 			reqPath:      "/apis",
 			reason:       "Forbidden",
@@ -186,7 +186,7 @@ func TestStatus(t *testing.T) {
 		},
 		{
 			name:         "401",
-			masterConfig: initUnauthorizedMasterCongfig(),
+			masterConfig: initUnauthorizedControlPlaneConfig(),
 			statusCode:   http.StatusUnauthorized,
 			reqPath:      "/apis",
 			reason:       "Unauthorized",

--- a/test/integration/openshift/openshift_test.go
+++ b/test/integration/openshift/openshift_test.go
@@ -23,9 +23,9 @@ import (
 	"k8s.io/kubernetes/pkg/controlplane"
 )
 
-// This test references methods that OpenShift uses to customize the master on startup, that
-// are not referenced directly by a master.
-func TestMasterExportsSymbols(t *testing.T) {
+// This test references methods that OpenShift uses to customize the apiserver on startup, that
+// are not referenced directly by an instance.
+func TestApiserverExportsSymbols(t *testing.T) {
 	_ = &controlplane.Config{
 		GenericConfig: &genericapiserver.Config{
 			EnableMetrics: true,

--- a/test/integration/quota/quota_test.go
+++ b/test/integration/quota/quota_test.go
@@ -77,7 +77,7 @@ func TestQuota(t *testing.T) {
 
 	masterConfig := framework.NewIntegrationTestMasterConfig()
 	masterConfig.GenericConfig.AdmissionControl = admission
-	_, _, closeFn := framework.RunAMasterUsingServer(masterConfig, s, h)
+	_, _, closeFn := framework.RunAnApiserverUsingServer(masterConfig, s, h)
 	defer closeFn()
 
 	ns := framework.CreateTestingNamespace("quotaed", s, t)
@@ -277,7 +277,7 @@ func TestQuotaLimitedResourceDenial(t *testing.T) {
 
 	masterConfig := framework.NewIntegrationTestMasterConfig()
 	masterConfig.GenericConfig.AdmissionControl = admission
-	_, _, closeFn := framework.RunAMasterUsingServer(masterConfig, s, h)
+	_, _, closeFn := framework.RunAnApiserverUsingServer(masterConfig, s, h)
 	defer closeFn()
 
 	ns := framework.CreateTestingNamespace("quota", s, t)

--- a/test/integration/serviceaccount/service_account_test.go
+++ b/test/integration/serviceaccount/service_account_test.go
@@ -446,7 +446,7 @@ func startServiceAccountTestServer(t *testing.T) (*clientset.Clientset, restclie
 	masterConfig.GenericConfig.Authentication.Authenticator = authenticator
 	masterConfig.GenericConfig.Authorization.Authorizer = authorizer
 	masterConfig.GenericConfig.AdmissionControl = serviceAccountAdmission
-	_, _, kubeAPIServerCloseFn := framework.RunAMasterUsingServer(masterConfig, apiServer, h)
+	_, _, kubeAPIServerCloseFn := framework.RunAnApiserverUsingServer(masterConfig, apiServer, h)
 
 	// Start the service account and service account token controllers
 	stopCh := make(chan struct{})

--- a/test/integration/util/util.go
+++ b/test/integration/util/util.go
@@ -62,7 +62,7 @@ func StartApiserver() (string, ShutdownFunc) {
 		h.M.GenericAPIServer.Handler.ServeHTTP(w, req)
 	}))
 
-	_, _, closeFn := framework.RunAMasterUsingServer(framework.NewIntegrationTestMasterConfig(), s, h)
+	_, _, closeFn := framework.RunAnApiserverUsingServer(framework.NewIntegrationTestMasterConfig(), s, h)
 
 	shutdownFunc := func() {
 		klog.Infof("destroying API server")
@@ -340,7 +340,7 @@ func InitTestMaster(t *testing.T, nsPrefix string, admission admission.Interface
 		masterConfig.GenericConfig.AdmissionControl = admission
 	}
 
-	_, testCtx.HTTPServer, testCtx.CloseFn = framework.RunAMasterUsingServer(masterConfig, s, h)
+	_, testCtx.HTTPServer, testCtx.CloseFn = framework.RunAnApiserverUsingServer(masterConfig, s, h)
 
 	if nsPrefix != "default" {
 		testCtx.NS = framework.CreateTestingNamespace(nsPrefix+string(uuid.NewUUID()), s, t)

--- a/test/integration/volumescheduling/util.go
+++ b/test/integration/volumescheduling/util.go
@@ -85,7 +85,7 @@ func initTestMaster(t *testing.T, nsPrefix string, admission admission.Interface
 		masterConfig.GenericConfig.AdmissionControl = admission
 	}
 
-	_, testCtx.httpServer, testCtx.closeFn = framework.RunAMasterUsingServer(masterConfig, s, h)
+	_, testCtx.httpServer, testCtx.closeFn = framework.RunAnApiserverUsingServer(masterConfig, s, h)
 
 	if nsPrefix != "default" {
 		testCtx.ns = framework.CreateTestingNamespace(nsPrefix+string(uuid.NewUUID()), s, t)


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/wg naming
/area test


#### What this PR does / why we need it:

- masterConfig -> instanceConfig (type: *controlplane.Config)
- NewMasterConfigWithOptions -> NewControlPlaneConfigWithOptions (include etcd) : maybe should change to Instance as well. #102279

Some summaries:

- [x] RunAMasterUsingServer 8 times
- [x] startMasterOrDie 5 times
- [x] initStatusForbiddenMasterCongfig and initStatusForbiddenMasterCongfig 2times
- [x] masterShutdown 2 times
- [x] TestMasterExportsSymbols 1 times

#102270
- [x] MasterHolder 8 times
- [x] MasterReceiver 6 times
- [x] masterCountServers 5 times
- [x] masterCount 4 times
- [x] masterCloseFn 2 times

#102272
- [x] NewIntegrationTestMasterConfig. 72 times

#102276
- [x] RunAMaster. 113 times
- [ ] package master 10 files


#### Which issue(s) this PR fixes:
xref #94900

#### Special notes for your reviewer:
- [x] all except etcd releated
- [ ] etcd related;
- [ ] system:masters

#### Does this PR introduce a user-facing change?

```release-note
None
```
