### PR TITLE
update dual-stack test description to remove alpha

### DIFF
--- a/test/e2e/network/dual_stack.go
+++ b/test/e2e/network/dual_stack.go
@@ -41,8 +41,8 @@ import (
 	netutils "k8s.io/utils/net"
 )
 
-// Tests for ipv6 dual stack feature
-var _ = common.SIGDescribe("[Feature:IPv6DualStackAlphaFeature] [LinuxOnly]", func() {
+// Tests for ipv4-ipv6 dual-stack feature
+var _ = common.SIGDescribe("[Feature:IPv6DualStack] [LinuxOnly]", func() {
 	f := framework.NewDefaultFramework("dualstack")
 
 	var cs clientset.Interface
@@ -119,9 +119,8 @@ var _ = common.SIGDescribe("[Feature:IPv6DualStackAlphaFeature] [LinuxOnly]", fu
 	})
 
 	// takes close to 140s to complete, so doesn't need to be marked [SLOW]
-	// this test is tagged with phase2 so we can skip this until phase 2 is completed and merged
 	// TODO (aramase) remove phase 2 tag once phase 2 of dual stack is merged
-	ginkgo.It("should be able to reach pod on ipv4 and ipv6 ip [Feature:IPv6DualStackAlphaFeature:Phase2]", func() {
+	ginkgo.It("should be able to reach pod on ipv4 and ipv6 ip [Feature:IPv6DualStack]", func() {
 		serverDeploymentName := "dualstack-server"
 		clientDeploymentName := "dualstack-client"
 
@@ -210,7 +209,7 @@ var _ = common.SIGDescribe("[Feature:IPv6DualStackAlphaFeature] [LinuxOnly]", fu
 		assertNetworkConnectivity(f, *serverPods, *clientPods, "dualstack-test-client", "80")
 	})
 
-	ginkgo.It("should create a single stack service with cluster ip from primary service range [Feature:IPv6DualStackAlphaFeature:Phase2]", func() {
+	ginkgo.It("should create a single stack service with cluster ip from primary service range [Feature:IPv6DualStack]", func() {
 		serviceName := "defaultclusterip"
 		ns := f.Namespace.Name
 		jig := e2eservice.NewTestJig(cs, ns, serviceName)
@@ -257,7 +256,7 @@ var _ = common.SIGDescribe("[Feature:IPv6DualStackAlphaFeature] [LinuxOnly]", fu
 		}
 	})
 
-	ginkgo.It("should create service with ipv4 cluster ip [Feature:IPv6DualStackAlphaFeature:Phase2]", func() {
+	ginkgo.It("should create service with ipv4 cluster ip [Feature:IPv6DualStack]", func() {
 		serviceName := "ipv4clusterip"
 		ns := f.Namespace.Name
 
@@ -302,7 +301,7 @@ var _ = common.SIGDescribe("[Feature:IPv6DualStackAlphaFeature] [LinuxOnly]", fu
 		}
 	})
 
-	ginkgo.It("should create service with ipv6 cluster ip [Feature:IPv6DualStackAlphaFeature:Phase2]", func() {
+	ginkgo.It("should create service with ipv6 cluster ip [Feature:IPv6DualStack]", func() {
 		serviceName := "ipv6clusterip"
 		ns := f.Namespace.Name
 		ipv6 := v1.IPv6Protocol
@@ -347,7 +346,7 @@ var _ = common.SIGDescribe("[Feature:IPv6DualStackAlphaFeature] [LinuxOnly]", fu
 		}
 	})
 
-	ginkgo.It("should create service with ipv4,v6 cluster ip [Feature:IPv6DualStackAlphaFeature:Phase2]", func() {
+	ginkgo.It("should create service with ipv4,v6 cluster ip [Feature:IPv6DualStack]", func() {
 		serviceName := "ipv4ipv6clusterip"
 		ns := f.Namespace.Name
 
@@ -392,7 +391,7 @@ var _ = common.SIGDescribe("[Feature:IPv6DualStackAlphaFeature] [LinuxOnly]", fu
 		}
 	})
 
-	ginkgo.It("should create service with ipv6,v4 cluster ip [Feature:IPv6DualStackAlphaFeature:Phase2]", func() {
+	ginkgo.It("should create service with ipv6,v4 cluster ip [Feature:IPv6DualStack]", func() {
 		serviceName := "ipv6ipv4clusterip"
 		ns := f.Namespace.Name
 


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
- Removes `alphafeature` from the dual-stack test descriptions as it's graduated to `beta` in v1.21

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
