### PR TITLE
respect ExecProbeTimeout=false for dockershim

### DIFF
--- a/pkg/kubelet/dockershim/exec.go
+++ b/pkg/kubelet/dockershim/exec.go
@@ -26,8 +26,10 @@ import (
 
 	dockertypes "github.com/docker/docker/api/types"
 
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/tools/remotecommand"
 	"k8s.io/klog/v2"
+	"k8s.io/kubernetes/pkg/features"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	"k8s.io/kubernetes/pkg/kubelet/dockershim/libdocker"
 )
@@ -106,7 +108,7 @@ func (*NativeExecHandler) ExecInContainer(ctx context.Context, client libdocker.
 		ExecStarted:  execStarted,
 	}
 
-	if timeout > 0 {
+	if timeout > 0 && utilfeature.DefaultFeatureGate.Enabled(features.ExecProbeTimeout) {
 		var cancel context.CancelFunc
 		ctx, cancel = context.WithTimeout(ctx, timeout)
 		defer cancel()

--- a/pkg/kubelet/dockershim/exec_test.go
+++ b/pkg/kubelet/dockershim/exec_test.go
@@ -29,7 +29,11 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/tools/remotecommand"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
+	"k8s.io/kubernetes/pkg/features"
+	"k8s.io/kubernetes/pkg/kubelet/dockershim/libdocker"
 	mockclient "k8s.io/kubernetes/pkg/kubelet/dockershim/libdocker/testing"
 )
 
@@ -43,6 +47,8 @@ func TestExecInContainer(t *testing.T) {
 		returnStartExec    error
 		returnInspectExec1 *dockertypes.ContainerExecInspect
 		returnInspectExec2 error
+		execProbeTimeout   bool
+		startExecDelay     time.Duration
 		expectError        error
 	}{{
 		description:       "ExecInContainer succeeds",
@@ -57,6 +63,7 @@ func TestExecInContainer(t *testing.T) {
 			ExitCode:    0,
 			Pid:         100},
 		returnInspectExec2: nil,
+		execProbeTimeout:   true,
 		expectError:        nil,
 	}, {
 		description:        "CreateExec returns an error",
@@ -66,6 +73,7 @@ func TestExecInContainer(t *testing.T) {
 		returnStartExec:    nil,
 		returnInspectExec1: nil,
 		returnInspectExec2: nil,
+		execProbeTimeout:   true,
 		expectError:        fmt.Errorf("failed to exec in container - Exec setup failed - error in CreateExec()"),
 	}, {
 		description:        "StartExec returns an error",
@@ -75,6 +83,7 @@ func TestExecInContainer(t *testing.T) {
 		returnStartExec:    fmt.Errorf("error in StartExec()"),
 		returnInspectExec1: nil,
 		returnInspectExec2: nil,
+		execProbeTimeout:   true,
 		expectError:        fmt.Errorf("error in StartExec()"),
 	}, {
 		description:        "InspectExec returns an error",
@@ -84,6 +93,7 @@ func TestExecInContainer(t *testing.T) {
 		returnStartExec:    nil,
 		returnInspectExec1: nil,
 		returnInspectExec2: fmt.Errorf("error in InspectExec()"),
+		execProbeTimeout:   true,
 		expectError:        fmt.Errorf("error in InspectExec()"),
 	}, {
 		description:       "ExecInContainer returns context DeadlineExceeded",
@@ -98,7 +108,30 @@ func TestExecInContainer(t *testing.T) {
 			ExitCode:    0,
 			Pid:         100},
 		returnInspectExec2: nil,
+		execProbeTimeout:   true,
 		expectError:        context.DeadlineExceeded,
+	}, {
+		description:        "[ExecProbeTimeout=true] StartExec that takes longer than the probe timeout returns context.DeadlineExceeded",
+		timeout:            1 * time.Second,
+		returnCreateExec1:  &dockertypes.IDResponse{ID: "12345678"},
+		returnCreateExec2:  nil,
+		startExecDelay:     5 * time.Second,
+		returnStartExec:    fmt.Errorf("error in StartExec()"),
+		returnInspectExec1: nil,
+		returnInspectExec2: nil,
+		execProbeTimeout:   true,
+		expectError:        context.DeadlineExceeded,
+	}, {
+		description:        "[ExecProbeTimeout=false] StartExec that takes longer than the probe timeout returns a error",
+		timeout:            1 * time.Second,
+		returnCreateExec1:  &dockertypes.IDResponse{ID: "12345678"},
+		returnCreateExec2:  nil,
+		startExecDelay:     5 * time.Second,
+		returnStartExec:    fmt.Errorf("error in StartExec()"),
+		returnInspectExec1: nil,
+		returnInspectExec2: nil,
+		execProbeTimeout:   false,
+		expectError:        fmt.Errorf("error in StartExec()"),
 	}}
 
 	eh := &NativeExecHandler{}
@@ -110,23 +143,27 @@ func TestExecInContainer(t *testing.T) {
 	var resize <-chan remotecommand.TerminalSize
 
 	for _, tc := range testcases {
-		t.Logf("TestCase: %q", tc.description)
+		tc := tc
+		t.Run(tc.description, func(t *testing.T) {
+			t.Parallel()
+			defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.ExecProbeTimeout, tc.execProbeTimeout)()
 
-		mockClient := mockclient.NewMockInterface(ctrl)
-		mockClient.EXPECT().CreateExec(gomock.Any(), gomock.Any()).Return(
-			tc.returnCreateExec1,
-			tc.returnCreateExec2)
-		mockClient.EXPECT().StartExec(gomock.Any(), gomock.Any(), gomock.Any()).Return(tc.returnStartExec)
-		mockClient.EXPECT().InspectExec(gomock.Any()).Return(
-			tc.returnInspectExec1,
-			tc.returnInspectExec2)
+			mockClient := mockclient.NewMockInterface(ctrl)
+			mockClient.EXPECT().CreateExec(gomock.Any(), gomock.Any()).Return(
+				tc.returnCreateExec1,
+				tc.returnCreateExec2)
+			mockClient.EXPECT().StartExec(gomock.Any(), gomock.Any(), gomock.Any()).Do(func(_ string, _ dockertypes.ExecStartCheck, _ libdocker.StreamOptions) { time.Sleep(tc.startExecDelay) }).Return(tc.returnStartExec)
+			mockClient.EXPECT().InspectExec(gomock.Any()).Return(
+				tc.returnInspectExec1,
+				tc.returnInspectExec2)
 
-		// use parent context of 2 minutes since that's the default remote
-		// runtime connection timeout used by dockershim
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
-		defer cancel()
-		err := eh.ExecInContainer(ctx, mockClient, container, cmd, stdin, stdout, stderr, false, resize, tc.timeout)
-		assert.Equal(t, tc.expectError, err)
+			// use parent context of 2 minutes since that's the default remote
+			// runtime connection timeout used by dockershim
+			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+			defer cancel()
+			err := eh.ExecInContainer(ctx, mockClient, container, cmd, stdin, stdout, stderr, false, resize, tc.timeout)
+			assert.Equal(t, tc.expectError, err)
+		})
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This PR ensures that the kubelet ExecProbeTimeout feature gate is respected when evaluating whether to timeout an exec probe's context when its configured `timeoutSeconds` period has expired.

The current implementation has the effect of ignoring the probe outcome after the `timeoutSeconds` period has expired.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #100198

#### Special notes for your reviewer:

I've tested that a build with this PR restored the expected behavior, where timeouts are simply ignored.

The original PR that fixed the buggy timeout behavior *does not* reproduce this new "probes always succeed pathology" according to my tests:

https://github.com/kubernetes/kubernetes/pull/94115

Further testing confirmed that this commit is the first that reproduces this new bug:

https://github.com/kubernetes/kubernetes/pull/96495

It appears that this surface area change ommitted the ExecProbeTimeout feature gate:

https://github.com/kubernetes/kubernetes/pull/96495/files#diff-de4678da3e9d01e8ee0aadd641deb2ffec3a53c8603476509e59fa8dc5449deaL117

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
respect ExecProbeTimeout=false for dockershim
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
