### PR TITLE
kubeadm unit test initalize global variables

### DIFF
--- a/cmd/kubeadm/app/cmd/phases/init/certs_test.go
+++ b/cmd/kubeadm/app/cmd/phases/init/certs_test.go
@@ -41,6 +41,12 @@ func (t *testCertsData) CertificateDir() string             { return t.cfg.Certi
 func (t *testCertsData) CertificateWriteDir() string        { return t.cfg.CertificatesDir }
 
 func TestCertsWithCSRs(t *testing.T) {
+	// restore global variables
+	defer func() {
+		csrOnly = false
+		csrDir = ""
+	}()
+
 	csrDir := testutil.SetupTempDir(t)
 	defer os.RemoveAll(csrDir)
 	certDir := testutil.SetupTempDir(t)
@@ -52,12 +58,9 @@ func TestCertsWithCSRs(t *testing.T) {
 	}
 	certsData.cfg.CertificatesDir = certDir
 
-	// global vars
+	// set global vars for the test
 	csrOnly = true
 	csrDir = certDir
-	defer func() {
-		csrOnly = false
-	}()
 
 	phase := NewCertsPhase()
 	// find the api cert phase


### PR DESCRIPTION

/kind failing-test
/kind flake

```release-note
NONE
```

xref https://testgrid.k8s.io/sig-testing-canaries#ci-kubernetes-generate-make-test-count10


Before it fail to run more than one time, the global variables weren't restored and the next iteration was using the previous value in the code under test, however, the test itself was using the new value.

```
go test -timeout 60s -count 2 -run TestCertsWithCSRs ./cmd/kubeadm/app/cmd/phases/init/
[certs] Generating CSR for apiserver instead of certificate
[certs] Generating "apiserver" key and CSR
[certs] Generating CSR for apiserver instead of certificate
[certs] Generating "apiserver" key and CSR
--- FAIL: TestCertsWithCSRs (0.06s)
    certs_test.go:82: couldn't load certificate "apiserver": could not load CSR file: could not load the CSR /tmp/009840433/apiserver.csr: failed to read file: open /tmp/009840433/apiserver.csr: no such file or directory
FAIL
FAIL    k8s.io/kubernetes/cmd/kubeadm/app/cmd/phases/init       0.143s
FAIL
```

Initialising the variables at the beginning of the test make the test idempotent.

```
go test -timeout 60s -count 20 -run TestCertsWithCSRs ./cmd/kubeadm/app/cmd/phases/init/
ok      k8s.io/kubernetes/cmd/kubeadm/app/cmd/phases/init       1.455s
```
