### PR TITLE
Return an error if schema is nil

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/mergepatch/errors.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/mergepatch/errors.go
@@ -100,3 +100,7 @@ func IsConflict(err error) bool {
 	_, ok := err.(ErrConflict)
 	return ok
 }
+
+func ErrNilSchema(key string) error {
+	return fmt.Errorf("attempting to get the subschema and the patch metadata from a nil schema with key %s", key)
+}

--- a/staging/src/k8s.io/apimachinery/pkg/util/strategicpatch/patch.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/strategicpatch/patch.go
@@ -260,6 +260,9 @@ func handleDirectiveMarker(key string, originalValue, modifiedValue interface{},
 // diffOptions contains multiple options to control how we do the diff.
 func handleMapDiff(key string, originalValue, modifiedValue, patch map[string]interface{},
 	schema LookupPatchMeta, diffOptions DiffOptions) error {
+	if schema == nil {
+		return mergepatch.ErrNilSchema(key)
+	}
 	subschema, patchMeta, err := schema.LookupPatchMetadataForStruct(key)
 
 	if err != nil {
@@ -303,6 +306,9 @@ func handleMapDiff(key string, originalValue, modifiedValue, patch map[string]in
 // diffOptions contains multiple options to control how we do the diff.
 func handleSliceDiff(key string, originalValue, modifiedValue []interface{}, patch map[string]interface{},
 	schema LookupPatchMeta, diffOptions DiffOptions) error {
+	if schema == nil {
+		return mergepatch.ErrNilSchema(key)
+	}
 	subschema, patchMeta, err := schema.LookupPatchMetadataForSlice(key)
 	if err != nil {
 		// We couldn't look up metadata for the field
@@ -1163,6 +1169,9 @@ func mergePatchIntoOriginal(original, patch map[string]interface{}, schema Looku
 				return mergepatch.ErrBadArgType(patchFieldValue, patchList)
 			}
 		}
+		if schema == nil {
+			return mergepatch.ErrNilSchema(originalKey)
+		}
 		subschema, patchMeta, err = schema.LookupPatchMetadataForSlice(originalKey)
 		if err != nil {
 			return err
@@ -1341,6 +1350,9 @@ func mergeMap(original, patch map[string]interface{}, schema LookupPatchMeta, me
 			continue
 		}
 		// If they're both maps or lists, recurse into the value.
+		if schema == nil {
+			return nil, mergepatch.ErrNilSchema(k)
+		}
 		switch originalType.Kind() {
 		case reflect.Map:
 			subschema, patchMeta, err2 := schema.LookupPatchMetadataForStruct(k)
@@ -1624,6 +1636,9 @@ func sortMergeListsByNameMap(s map[string]interface{}, schema LookupPatchMeta) (
 			}
 		} else if k != directiveMarker {
 			// recurse for map and slice.
+			if schema == nil {
+				return nil, mergepatch.ErrNilSchema(k)
+			}
 			switch typedV := v.(type) {
 			case map[string]interface{}:
 				subschema, _, err := schema.LookupPatchMetadataForStruct(k)
@@ -1889,6 +1904,9 @@ func mapsHaveConflicts(typedLeft, typedRight map[string]interface{}, schema Look
 				var patchMeta PatchMeta
 				var patchStrategy string
 				var err error
+				if schema == nil {
+					return true, mergepatch.ErrNilSchema(key)
+				}
 				switch leftValue.(type) {
 				case []interface{}:
 					subschema, patchMeta, err = schema.LookupPatchMetadataForSlice(key)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Some functions call schema.LookupPatchMetadataForSlice or schema.LookupPatchMetadataForStruct without checking if schema is nil or not.
It will cause a panic when schema is nil. This PR adds a check and returns an error for nil schema.

panic stacktrace:
```
E0301 22:27:45.946426       1 runtime.go:78] Observed a panic: "invalid memory address or nil pointer dereference" (runtime error: invalid memory address or nil pointer dereference)
goroutine 3391 [running]:
k8s.io/apimachinery/pkg/util/runtime.logPanic(0x1850960, 0x2a743f0)
	/workspace/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:74 +0x92
k8s.io/apimachinery/pkg/util/runtime.HandleCrash(0x0, 0x0, 0x0)
	/workspace/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:48 +0x82
panic(0x1850960, 0x2a743f0)
	/usr/local/go/src/runtime/panic.go:969 +0x166
k8s.io/apimachinery/pkg/util/strategicpatch.handleMapDiff(0xc009a29680, 0xc, 0xc009a3f770, 0xc009a3e240, 0xc009a3fb00, 0x0, 0x0, 0x7fc400010001, 0x0, 0x0)
	/workspace/vendor/k8s.io/apimachinery/pkg/util/strategicpatch/patch.go:263 +0x59
k8s.io/apimachinery/pkg/util/strategicpatch.diffMaps(0xc009a3f6e0, 0xc009a3e1b0, 0x0, 0x0, 0x10001, 0x0, 0x0, 0x0)
	/workspace/vendor/k8s.io/apimachinery/pkg/util/strategicpatch/patch.go:212 +0x4f5
k8s.io/apimachinery/pkg/util/strategicpatch.handleMapDiff(0xc009a295b7, 0x5, 0xc009a3f6e0, 0xc009a3e1b0, 0xc009a3fad0, 0x1d2a300, 0xc00095d030, 0xc000010001, 0x0, 0x0)
	/workspace/vendor/k8s.io/apimachinery/pkg/util/strategicpatch/patch.go:286 +0x2ad
k8s.io/apimachinery/pkg/util/strategicpatch.diffMaps(0xc009a3ee40, 0xc009a238f0, 0x1d2a300, 0xc00095d030, 0x10001, 0x0, 0x0, 0x0)
	/workspace/vendor/k8s.io/apimachinery/pkg/util/strategicpatch/patch.go:212 +0x4f5
k8s.io/apimachinery/pkg/util/strategicpatch.handleMapDiff(0xc009a28f6a, 0x6, 0xc009a3ee40, 0xc009a238f0, 0xc009a3faa0, 0x1d2a300, 0xc00095d020, 0xc000010001, 0x0, 0x0)
	/workspace/vendor/k8s.io/apimachinery/pkg/util/strategicpatch/patch.go:286 +0x2ad
k8s.io/apimachinery/pkg/util/strategicpatch.diffMaps(0xc009a3e4b0, 0xc009a22f90, 0x1d2a300, 0xc00095d020, 0x10001, 0x0, 0x0, 0x0)
	/workspace/vendor/k8s.io/apimachinery/pkg/util/strategicpatch/patch.go:212 +0x4f5
k8s.io/apimachinery/pkg/util/strategicpatch.handleMapDiff(0xc009a29758, 0x4, 0xc009a3e4b0, 0xc009a22f90, 0xc009a3f9e0, 0x1d2a300, 0xc000a1a290, 0x10001, 0x0, 0x0)
	/workspace/vendor/k8s.io/apimachinery/pkg/util/strategicpatch/patch.go:286 +0x2ad
k8s.io/apimachinery/pkg/util/strategicpatch.diffMaps(0xc009a3e3c0, 0xc009a22ea0, 0x1d2a300, 0xc000a1a290, 0xc000010001, 0x0, 0x0, 0x10)
	/workspace/vendor/k8s.io/apimachinery/pkg/util/strategicpatch/patch.go:212 +0x4f5
k8s.io/apimachinery/pkg/util/strategicpatch.CreateThreeWayMergePatch(0xc0097df980, 0x1964, 0x1980, 0xc009aba000, 0x3656, 0x3656, 0xc009aac000, 0x384d, 0x384d, 0x1d2a300, ...)
	/workspace/vendor/k8s.io/apimachinery/pkg/util/strategicpatch/patch.go:2050 +0x15a
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
