### PR TITLE
initialise capabilities unit test

### DIFF
--- a/pkg/capabilities/capabilities_test.go
+++ b/pkg/capabilities/capabilities_test.go
@@ -18,10 +18,17 @@ package capabilities
 
 import (
 	"reflect"
+	"sync"
 	"testing"
 )
 
 func TestGet(t *testing.T) {
+	defer func() {
+		capInstance.lock.Lock()
+		defer capInstance.lock.Unlock()
+		capInstance.capabilities = nil
+		capInstance.once = sync.Once{}
+	}()
 	defaultCap := Capabilities{
 		AllowPrivileged: false,
 		PrivilegedSources: PrivilegedSources{


### PR DESCRIPTION

/kind failing-test
/kind flake
```release-note
NONE
```

The test needs to initialise the variable, or subsequent testrun carry over the previous state.
Before:
```
=== FAIL: pkg/capabilities TestGet (0.00s)
    capabilities_test.go:36: expected Capabilities: capabilities.Capabilities{AllowPrivileged:false, PrivilegedSources:capabilities.PrivilegedSources{HostNetworkSources:[]string{}, HostPIDSources:[]string{}, HostIPCSources:[]string{}}, PerConnectionBandwidthLimitBytesPerSec:0}, got a non-default: capabilities.Capabilities{AllowPrivileged:false, PrivilegedSources:capabilities.PrivilegedSources{HostNetworkSources:[]string{"A", "B"}, HostPIDSources:[]string(nil), HostIPCSources:[]string(nil)}, PerConnectionBandwidthLimitBytesPerSec:0}
    capabilities_test.go:36: expected Capabilities: capabilities.Capabilities{AllowPrivileged:false, PrivilegedSources:capabilities.PrivilegedSources{HostNetworkSources:[]string{}, HostPIDSources:[]string{}, HostIPCSources:[]string{}}, PerConnectionBandwidthLimitBytesPerSec:0}, got a non-default: capabilities.Capabilities{AllowPrivileged:false, PrivilegedSources:capabilities.PrivilegedSources{HostNetworkSources:[]string{"A", "B"}, HostPIDSources:[]string(nil), HostIPCSources:[]string(nil)}, PerConnectionBandwidthLimitBytesPerSec:0}
```

With current change:
```
[aojea@aojea-laptop kubernetes]$ go test -timeout 300s -count 300  ./pkg/capabilities/ -run .
ok      k8s.io/kubernetes/pkg/capabilities      0.004s
```

xref: https://testgrid.k8s.io/sig-testing-canaries#ci-kubernetes-generate-make-test-count10