### PR TITLE
Use a debugging tool in E2E tests

### DIFF
--- a/hack/ginkgo-e2e.sh
+++ b/hack/ginkgo-e2e.sh
@@ -161,18 +161,14 @@ PATH=$(dirname "${e2e_test}"):"${PATH}"
 export PATH
 
 # Choose the program to execute.
-program="${ginkgo}"
-program_args="${ginkgo_args[@]}"
+program=("${ginkgo}")
 if [[ "${E2E_TEST_DEBUG_TOOL}" == "delve" ]]; then
-  program="dlv"
-  program_args=("exec")
-fi
-if [[ "${E2E_TEST_DEBUG_TOOL}" == "gdb" ]]; then
-  program="gdb"
-  program_args=("")
+  program=("dlv" "exec")
+elif [[ "${E2E_TEST_DEBUG_TOOL}" == "gdb" ]]; then
+  program=("gdb")
 fi
 
-"${program}" "${program_args[@]:+${program_args[@]}}" "${e2e_test}" -- \
+"${program[@]}" "${ginkgo_args[@]:+${ginkgo_args[@]}}" "${e2e_test}" -- \
   "${auth_config[@]:+${auth_config[@]}}" \
   --ginkgo.flakeAttempts="${FLAKE_ATTEMPTS}" \
   --host="${KUBE_MASTER_URL}" \

--- a/hack/ginkgo-e2e.sh
+++ b/hack/ginkgo-e2e.sh
@@ -41,6 +41,13 @@ GINKGO_NO_COLOR=${GINKGO_NO_COLOR:-n}
 # If 'y', will rerun failed tests once to give them a second chance.
 GINKGO_TOLERATE_FLAKES=${GINKGO_TOLERATE_FLAKES:-n}
 
+# If set, the command executed will be:
+# - `dlv exec` if set to "delve"
+# - `gdb` if set to "gdb"
+# NOTE: for this to work the e2e.test binary has to be compiled with
+# make WHAT=test/e2e/e2e.test GOGCFLAGS="all=-N -l" GOLDFLAGS=""
+E2E_TEST_DEBUG_TOOL=${E2E_TEST_DEBUG_TOOL:-}
+
 : "${KUBECTL:="${KUBE_ROOT}/cluster/kubectl.sh"}"
 : "${KUBE_CONFIG_FILE:="config-test.sh"}"
 
@@ -152,7 +159,20 @@ CONTAINER_RUNTIME=${CONTAINER_RUNTIME:-${KUBE_CONTAINER_RUNTIME:-}}
 # Add path for things like running kubectl binary.
 PATH=$(dirname "${e2e_test}"):"${PATH}"
 export PATH
-"${ginkgo}" "${ginkgo_args[@]:+${ginkgo_args[@]}}" "${e2e_test}" -- \
+
+# Choose the program to execute.
+program="${ginkgo}"
+program_args="${ginkgo_args[@]}"
+if [[ "${E2E_TEST_DEBUG_TOOL}" == "delve" ]]; then
+  program="dlv"
+  program_args=("exec")
+fi
+if [[ "${E2E_TEST_DEBUG_TOOL}" == "gdb" ]]; then
+  program="gdb"
+  program_args=("")
+fi
+
+"${program}" "${program_args[@]:+${program_args[@]}}" "${e2e_test}" -- \
   "${auth_config[@]:+${auth_config[@]}}" \
   --ginkgo.flakeAttempts="${FLAKE_ATTEMPTS}" \
   --host="${KUBE_MASTER_URL}" \


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

Optionally add one or more of the following kinds if applicable:

#### What this PR does / why we need it:

As a developer working on making changes to e2e tests I sometimes want to run a test with a debugger, I modified the `ginkgo-e2e.sh` file to accept a new env var `E2E_TEST_DEBUG_TOOL`, when set to `E2E_TEST_DEBUG_TOOL=delve` it'll run `dlv exec` instead of `ginkgo`

Setup:

```
❯ make WHAT=test/e2e/e2e.test GOGCFLAGS="all=-N -l" GOLDFLAGS=""
+++ [0313 00:31:01] Building go targets for linux/amd64:
    test/e2e/e2e.test

mauriciopoppe@mauriciopoppe ~/go/src/k8s.io/kubernetes enable-delve-in-e2e-tests* 47s
❯ E2E_TEST_DEBUG_TOOL=delve ./hack/ginkgo-e2e.sh --ginkgo.focus="sig-apps.*Deployment.*should.*run.*the.*lifecycle.*of.*a.*Deployment" --allowed-not-ready-nodes=10
Setting up for KUBERNETES_PROVIDER="gce".
Project: ---
Network Project: ---
Zone: ---
Trying to find master named '---'
Looking for address '---'
Using master: --- (external IP: ---; internal IP: (not set))
Type 'help' for list of commands.
(dlv) break test/e2e/apps/deployment.go:224
Breakpoint 1 set at 0x6897b2e for k8s.io/kubernetes/test/e2e/apps.glob..func4.13() _output/local/go/src/k8s.io/kubernetes/test/e2e/apps/deployment.go:224
(dlv) continue
Mar 13 00:37:10.476: INFO: Fetching cloud provider for "gce"
I0313 00:37:10.477527 2233899 gce.go:909] Using DefaultTokenSource &oauth2.reuseTokenSource{new:(*oauth2.tokenRefresher)(0xc0036894a0), mu:sync.Mutex{state:0, sema:0x0}, t:(*oauth2.Token)(0xc0036f2660)}
W0313 00:37:10.658653 2233899 gce.go:477] No network name or URL specified.
I0313 00:37:10.658846 2233899 e2e.go:129] Starting e2e run "4080ebfc-c7ed-4299-870e-1167148382d2" on Ginkgo node 1
{"msg":"Test Suite starting","total":1,"completed":0,"skipped":0,"failed":0}
Running Suite: Kubernetes e2e suite
===================================
Random Seed: 1615595828 - Will randomize all specs
Will run 1 of 5744 specs

Mar 13 00:37:16.282: INFO: cluster-master-image: cos-85-13310-1041-9
Mar 13 00:37:16.283: INFO: cluster-node-image: cos-85-13310-1041-9
Mar 13 00:37:16.283: INFO: >>> kubeConfig: ---
Mar 13 00:37:16.287: INFO: Waiting up to 30m0s for all (but 10) nodes to be schedulable
Mar 13 00:37:16.477: INFO: Unschedulable nodes= 2, maximum value for starting tests= 10
Mar 13 00:37:16.477: INFO:      -> Node e2e-test-mauriciopoppe-windows-node-group-b5wm [[[ Ready=true, Network(available)=true, Taints=[{node.kubernetes.io/os  NoSchedule <nil>}], NonblockingTaints=node-role.kubernetes.io/master ]]]
Mar 13 00:37:16.477: INFO:      -> Node e2e-test-mauriciopoppe-windows-node-group-jpck [[[ Ready=true, Network(available)=true, Taints=[{node.kubernetes.io/os  NoSchedule <nil>}], NonblockingTaints=node-role.kubernetes.io/master ]]]
Mar 13 00:37:16.477: INFO: Waiting up to 10m0s for all pods (need at least 0) in namespace 'kube-system' to be running and ready
Mar 13 00:37:16.646: INFO: 23 / 23 pods in namespace 'kube-system' are running and ready (0 seconds elapsed)
Mar 13 00:37:16.646: INFO: expected 7 pod replicas in namespace 'kube-system', 7 are Running and Ready.
Mar 13 00:37:16.646: INFO: Waiting up to 5m0s for all daemonsets in namespace 'kube-system' to start
Mar 13 00:37:16.696: INFO: 3 / 3 pods ready in namespace 'kube-system' in daemonset 'fluentd-gcp-v3.2.0' (0 seconds elapsed)
Mar 13 00:37:16.697: INFO: 3 / 3 pods ready in namespace 'kube-system' in daemonset 'metadata-proxy-v0.1' (0 seconds elapsed)
Mar 13 00:37:16.697: INFO: e2e test version: v1.21.0-beta.1.198+99557563496395-dirty
Mar 13 00:37:16.734: INFO: kube-apiserver version: v1.21.0-alpha.3.65+9730cfa971804a-dirty
Mar 13 00:37:16.734: INFO: >>> kubeConfig: ---
Mar 13 00:37:16.777: INFO: Cluster IP family: ipv4
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
------------------------------
[sig-apps] Deployment
  should run the lifecycle of a Deployment [Conformance]
  _output/local/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:630
[BeforeEach] [sig-apps] Deployment
  _output/local/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:185
STEP: Creating a kubernetes client
Mar 13 00:37:16.803: INFO: >>> kubeConfig: ---
STEP: Building a namespace api object, basename deployment
W0313 00:37:16.965557 2233899 warnings.go:70] policy/v1beta1 PodSecurityPolicy is deprecated in v1.21+, unavailable in v1.25+
Mar 13 00:37:16.965: INFO: Found PodSecurityPolicies; testing pod creation to see if PodSecurityPolicy is enabled
Mar 13 00:37:17.010: INFO: No PSP annotation exists on dry run pod; assuming PodSecurityPolicy is disabled
STEP: Waiting for a default service account to be provisioned in namespace
[BeforeEach] [sig-apps] Deployment
  _output/local/go/src/k8s.io/kubernetes/test/e2e/apps/deployment.go:86
[It] should run the lifecycle of a Deployment [Conformance]
  _output/local/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:630
STEP: creating a Deployment
> k8s.io/kubernetes/test/e2e/apps.glob..func4.13() _output/local/go/src/k8s.io/kubernetes/test/e2e/apps/deployment.go:224 (hits goroutine(178):1 total:1) (PC: 0x6897b2e)
   219:                                                 }},
   220:                                         },
   221:                                 },
   222:                         },
   223:                 }
=> 224:                 _, err = f.ClientSet.AppsV1().Deployments(testNamespaceName).Create(context.TODO(), &testDeployment, metav1.CreateOptions{})
   225:                 framework.ExpectNoError(err, "failed to create Deployment %v in namespace %v", testDeploymentName, testNamespaceName)
   226:
   227:                 ginkgo.By("waiting for Deployment to be created")
   228:                 ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
   229:                 defer cancel()
(dlv) print testDeployment
k8s.io/kubernetes/vendor/k8s.io/api/apps/v1.Deployment {
        TypeMeta: k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/apis/meta/v1.TypeMeta {Kind: "", APIVersion: ""},
        ObjectMeta: k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta {
                Name: "test-deployment",
                GenerateName: "",
                Namespace: "",
                SelfLink: "",
                UID: "",
                ResourceVersion: "",
                Generation: 0,
                CreationTimestamp: (*"k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/apis/meta/v1.Time")(0xc000670988),
                DeletionTimestamp: *k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/apis/meta/v1.Time nil,
                DeletionGracePeriodSeconds: *int64 nil,
                Labels: map[string]string [...],
                Annotations: map[string]string nil,
                OwnerReferences: []k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/apis/meta/v1.OwnerReference len: 0, cap: 0, nil,
                Finalizers: []string len: 0, cap: 0, nil,
                ClusterName: "",
                ManagedFields: []k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/apis/meta/v1.ManagedFieldsEntry len: 0, cap: 0, nil,},
        Spec: k8s.io/kubernetes/vendor/k8s.io/api/apps/v1.DeploymentSpec {
                Replicas: *2,
                Selector: *(*"k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/apis/meta/v1.LabelSelector")(0xc0036f4b60),
                Template: (*"k8s.io/kubernetes/vendor/k8s.io/api/core/v1.PodTemplateSpec")(0xc000670a28),
                Strategy: (*"k8s.io/kubernetes/vendor/k8s.io/api/apps/v1.DeploymentStrategy")(0xc000670d00),
                MinReadySeconds: 0,
                RevisionHistoryLimit: *int32 nil,
                Paused: false,
                ProgressDeadlineSeconds: *int32 nil,},
        Status: k8s.io/kubernetes/vendor/k8s.io/api/apps/v1.DeploymentStatus {
                ObservedGeneration: 0,
                Replicas: 0,
                UpdatedReplicas: 0,
                ReadyReplicas: 0,
                AvailableReplicas: 0,
                UnavailableReplicas: 0,
                Conditions: []k8s.io/kubernetes/vendor/k8s.io/api/apps/v1.DeploymentCondition len: 0, cap: 0, nil,
                CollisionCount: *int32 nil,},}

```

Additional changes that might be needed:

- this could be a flag in kubetest too e.g. `--debug`
- update https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/e2e-tests.md and write some docs about it

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```