### PR TITLE
Error in kubectl drain --dry-run=server

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/drain/drain.go
+++ b/staging/src/k8s.io/kubectl/pkg/drain/drain.go
@@ -220,6 +220,8 @@ func filterPods(podList *corev1.PodList, filters []PodFilter) *PodDeleteList {
 		// Add the pod to PodDeleteList no matter what PodDeleteStatus is,
 		// those pods whose PodDeleteStatus is false like DaemonSet will
 		// be catched by list.errors()
+		pod.Kind = "Pod"
+		pod.APIVersion = "v1"
 		pods = append(pods, PodDelete{
 			Pod:    pod,
 			Status: status,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug
/kind failing-test


#### What this PR does / why we need it:

_**Problem 1**_: `kubectl drain --dry-run=server` seems to be broken, and have been for a while (confirmed in v1.18.10 and v1.20.1)

**Error message: `error: error when evicting pods/"test-pod-2" -n "test-ns": /, Kind= doesn't support dry-run`**

The following reproduces the issue, where `test-pod-2` is an unmanaged Pod labelled with `c=d`.

```
> kubectl drain docker-desktop --force  --pod-selector c=d --dry-run=server
node/docker-desktop cordoned (server dry run)
WARNING: deleting Pods not managed by ReplicationController, ReplicaSet, Job, DaemonSet or StatefulSet: test-ns/test-pod-2
evicting pod test-ns/test-pod-2 (server dry run)
Warning: apiextensions.k8s.io/v1beta1 CustomResourceDefinition is deprecated in v1.16+, unavailable in v1.22+; use apiextensions.k8s.io/v1 CustomResourceDefinition
There are pending pods in node "docker-desktop" when an error occurred: error when evicting pods/"test-pod-2" -n "test-ns": /, Kind= doesn't support dry-run
pod/test-pod-2
error: unable to drain node "docker-desktop", aborting command...

There are pending nodes to be drained:
 docker-desktop
error: error when evicting pods/"test-pod-2" -n "test-ns": /, Kind= doesn't support dry-run
```

The problem seems to be that the PodList returned by the server does not include type meta on the individual items, leading the server-side support checks that do `pod.GroupVersionKind()` to receive empty GVKs. I have a tentative fix for this in the first commit.

**_Problem 2_**: The integration tests haven't caught this because they're invalid: the test pods aren't scheduled on the test node, so the tests are "successfully" draining nothing. The second commit fixes this by adding the pods manually with `spec.nodeName`.

**_Problem 3_**: When I manually place the test pods on the test node with `spec.nodeName`, the drain tests hang forever. That turns out to be because the test node is not ready / can't run pods, so the eviction sets the deletionTimestamp, but the pod never goes away. I dumped the pod and node state [in this test run--see the end of the logs]( https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/100206/pull-kubernetes-integration/1371896188843855872#1:build-log.txt%3A9389). It looks plausible that this node object is not backed by a real node. I worked around this in the second commit by adding `--skip-wait-for-delete-timeout=1` to the drain commands. This means the tests confirm the drain command marks the pod for deletion, but do not confirm that deletion eventually happens (which involves other things that are not, I believe, the core purpose of this test suite).

#### Special notes for your reviewer:

I discovered this while implementing https://github.com/kubernetes/kubernetes/pull/100148. 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixes kubectl drain --dry-run=server
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
