### PR TITLE
A hacky way to register service events handler dynamically

### DIFF
--- a/pkg/scheduler/framework/plugins/serviceaffinity/service_affinity.go
+++ b/pkg/scheduler/framework/plugins/serviceaffinity/service_affinity.go
@@ -82,6 +82,9 @@ func getArgs(obj runtime.Object) (config.ServiceAffinityArgs, error) {
 	if !ok {
 		return config.ServiceAffinityArgs{}, fmt.Errorf("want args to be of type ServiceAffinityArgs, got %T", obj)
 	}
+	if len(ptr.AffinityLabels) == 0 {
+		return *ptr, fmt.Errorf("args.affinityLabels cannot be empty")
+	}
 	return *ptr, nil
 }
 
@@ -127,10 +130,6 @@ func (pl *ServiceAffinity) createPreFilterState(pod *v1.Pod) (*preFilterState, e
 
 // PreFilter invoked at the prefilter extension point.
 func (pl *ServiceAffinity) PreFilter(ctx context.Context, cycleState *framework.CycleState, pod *v1.Pod) *framework.Status {
-	if len(pl.args.AffinityLabels) == 0 {
-		return nil
-	}
-
 	s, err := pl.createPreFilterState(pod)
 	if err != nil {
 		return framework.AsStatus(fmt.Errorf("could not create preFilterState: %w", err))
@@ -141,9 +140,6 @@ func (pl *ServiceAffinity) PreFilter(ctx context.Context, cycleState *framework.
 
 // PreFilterExtensions returns prefilter extensions, pod add and remove.
 func (pl *ServiceAffinity) PreFilterExtensions() framework.PreFilterExtensions {
-	if len(pl.args.AffinityLabels) == 0 {
-		return nil
-	}
 	return pl
 }
 
@@ -233,10 +229,6 @@ func getPreFilterState(cycleState *framework.CycleState) (*preFilterState, error
 // 		- L is not defined in the pod itself already.
 // 		- and SOME pod, from a service, in the same namespace, ALREADY scheduled onto a node, has a matching value.
 func (pl *ServiceAffinity) Filter(ctx context.Context, cycleState *framework.CycleState, pod *v1.Pod, nodeInfo *framework.NodeInfo) *framework.Status {
-	if len(pl.args.AffinityLabels) == 0 {
-		return nil
-	}
-
 	node := nodeInfo.Node()
 	if node == nil {
 		return framework.AsStatus(fmt.Errorf("node not found"))


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/sig scheduling

#### What this PR does / why we need it:

A hacky way with (_almost_) least code of changes to register service events handler dynamically.

- commit1: error out if ServiceAffinity is enabled but with empty args.affinityLabels.
- commit2: hacky logic. add a no-op indexer during New(), and verify if this no-op indexer's present during registering event handlers.

(alternatively, we can inject some logic to `frameworkCapturer` to be called back when a profile is composed - i.e., iterate all filter plugins, and check if ServiceAffinity exists)

#### Which issue(s) this PR fixes:

Follow-up of https://github.com/kubernetes/kubernetes/issues/94009#issuecomment-797716300

#### Special notes for your reviewer:

I've tested locally this PR works. Will add comments if this way looks good.

#### Does this PR introduce a user-facing change?

```release-note
scheduler: suppress registering service events handler if ServiceAffinity plugin is not enabled.
```
