### PR TITLE
unit test using metrics must reset the global registry

### DIFF
--- a/pkg/kubelet/dockershim/network/plugins_test.go
+++ b/pkg/kubelet/dockershim/network/plugins_test.go
@@ -30,6 +30,7 @@ import (
 
 func TestNetworkPluginManagerMetrics(t *testing.T) {
 	metrics.Register()
+	defer legacyregistry.Reset()
 
 	operation := "test_operation"
 	recordOperation(operation, time.Now())

--- a/staging/src/k8s.io/apiserver/pkg/admission/metrics/metrics_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/metrics/metrics_test.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apiserver/pkg/admission"
+	"k8s.io/component-base/metrics/legacyregistry"
 )
 
 var (
@@ -35,7 +36,8 @@ var (
 )
 
 func TestObserveAdmissionStep(t *testing.T) {
-	Metrics.reset()
+	defer Metrics.reset()
+	defer legacyregistry.Reset()
 	handler := WithStepMetrics(&mutatingAndValidatingFakeHandler{admission.NewHandler(admission.Create), true, true})
 	if err := handler.(admission.MutationInterface).Admit(context.TODO(), attr, nil); err != nil {
 		t.Errorf("Unexpected error in admit: %v", err)
@@ -57,7 +59,8 @@ func TestObserveAdmissionStep(t *testing.T) {
 }
 
 func TestObserveAdmissionController(t *testing.T) {
-	Metrics.reset()
+	defer Metrics.reset()
+	defer legacyregistry.Reset()
 	handler := WithControllerMetrics(&mutatingAndValidatingFakeHandler{admission.NewHandler(admission.Create), true, true}, "a")
 	if err := handler.(admission.MutationInterface).Admit(context.TODO(), attr, nil); err != nil {
 		t.Errorf("Unexpected error in admit: %v", err)
@@ -78,7 +81,8 @@ func TestObserveAdmissionController(t *testing.T) {
 }
 
 func TestObserveWebhook(t *testing.T) {
-	Metrics.reset()
+	defer Metrics.reset()
+	defer legacyregistry.Reset()
 	Metrics.ObserveWebhook(context.TODO(), 2*time.Second, false, attr, stepAdmit, "x")
 	wantLabels := map[string]string{
 		"name":      "x",
@@ -121,8 +125,8 @@ func TestObserveWebhookRejection(t *testing.T) {
 }
 
 func TestWithMetrics(t *testing.T) {
-	Metrics.reset()
-
+	defer Metrics.reset()
+	defer legacyregistry.Reset()
 	type Test struct {
 		name            string
 		ns              string


### PR DESCRIPTION

/kind flake
```release-note
NONE
```

There are several tests with this issues, once you register the metrics in the global register, those should be reset, otherwise they are accumulated and consequent runs of the test fail