### PR TITLE
Warn if KUBECTL_EXTERNAL_DIFF contains illegal characters

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/diff/diff.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/diff/diff.go
@@ -185,10 +185,15 @@ func (d *DiffProgram) getCommand(args ...string) (string, exec.Cmd) {
 
 		if len(diffCommand) > 1 {
 			// Regex accepts: Alphanumeric (case-insensitive), dash and equal
-			isValidChar := regexp.MustCompile(`^[a-zA-Z0-9-=]+$`).MatchString
+			pattern := `^[a-zA-Z0-9-=]+$`
+			isValidChar := regexp.MustCompile(pattern).MatchString
 			for i := 1; i < len(diffCommand); i++ {
 				if isValidChar(diffCommand[i]) {
 					args = append(args, diffCommand[i])
+				} else {
+					klog.Warningf(
+						"KUBECTL_EXTERNAL_DIFF command argument \"%v\" is ignored due to illegal characters. "+
+							"Acceptable characters must match %v.", diffCommand[i], pattern)
 				}
 			}
 		}


### PR DESCRIPTION
Currently if an illegal chracter is in KUBECTL_EXTERNAL_DIFF, it's
silently ignored. This PR attempts to give a warning and add some
relevant tests.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

See the commit message above.

I guess the reason we have this special character rule is to avoid complicated situations (e.g., a pile of quotations), but there are some legitimate uses, such as the one in the newly added tests (i.e., showing the top-level yaml keys as diff chunk titles). While this limitation can be circumvented by wrapping the diff command in a script, it is quite confusing if a user tries to specify it in KUBECTL_EXTERNAL_DIFF and it's not working. This PR tries to address this concern.



#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```


