### PR TITLE
runtime/default Seccomp Profile in kubeadm control-plane components.

### DIFF
--- a/cmd/kubeadm/app/util/staticpod/utils.go
+++ b/cmd/kubeadm/app/util/staticpod/utils.go
@@ -67,6 +67,11 @@ func ComponentPod(container v1.Container, volumes map[string]v1.Volume, annotati
 			PriorityClassName: "system-node-critical",
 			HostNetwork:       true,
 			Volumes:           VolumeMapToSlice(volumes),
+			SecurityContext: &v1.PodSecurityContext{
+				SeccompProfile: &v1.SeccompProfile{
+					Type: v1.SeccompProfileTypeRuntimeDefault,
+				},
+			},
 		},
 	}
 }

--- a/cmd/kubeadm/app/util/staticpod/utils_test.go
+++ b/cmd/kubeadm/app/util/staticpod/utils_test.go
@@ -408,6 +408,11 @@ func TestComponentPod(t *testing.T) {
 					Labels:    map[string]string{"component": "foo", "tier": "control-plane"},
 				},
 				Spec: v1.PodSpec{
+					SecurityContext: &v1.PodSecurityContext{
+						SeccompProfile: &v1.SeccompProfile{
+							Type: v1.SeccompProfileTypeRuntimeDefault,
+						},
+					},
 					Containers: []v1.Container{
 						{
 							Name: "foo",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
This PR sets the seccomp profile for the control-plane components in kubeadm to runtime/default. Seccomp (secure computing mode) is used to restrict the set of system calls applications can make. Most container runtimes provide a sane set of default syscalls that are allowed or not. The defaults can easily be applied in Kubernetes by using the runtime/default annotation or setting the seccomp type in the security context of a pod or container to RuntimeDefault.

##### How tested:
Please note I had to build kind from source, which is requirement for 1.21+ See [this](https://kubernetes.slack.com/archives/CEKK1KTN2/p1620355707463300) slack thread.
1. Created node image using kind
```
kind build node-image 
```
2. Created a cluster using kind
```
kind create cluster --image kindest/node:latest -v 9
```
3. exec into the kind control-plane container
```
docker exec -it kind-control-plane /bin/bash
```
4. Made sure all pods are running
```
root@kind-control-plane:/# crictl ps -a
CONTAINER           IMAGE               CREATED             STATE               NAME                      ATTEMPT             POD ID
0078ac2264106       d1f2268f5826f       7 seconds ago       Running             etcd                      0                   1b82c448c20a7
12007debf3274       0431819786ed2       7 seconds ago       Running             kube-apiserver            0                   4cfb27d550ee0
c054be4fc20f5       b1855751337b1       7 seconds ago       Running             kube-controller-manager   0                   ff9d4277980ab
991398db24089       51a671880981a       8 seconds ago       Running             kube-scheduler            0                   a05064d6d9dbc
```
5. Made sure all Pods have the seccompProfile
```
root@kind-control-plane:/# grep seccomp -C 2 /etc/kubernetes/manifests/*.yaml
/etc/kubernetes/manifests/etcd.yaml-  priorityClassName: system-node-critical
/etc/kubernetes/manifests/etcd.yaml-  securityContext:
/etc/kubernetes/manifests/etcd.yaml:    seccompProfile:
/etc/kubernetes/manifests/etcd.yaml-      type: RuntimeDefault
/etc/kubernetes/manifests/etcd.yaml-  volumes:
--
/etc/kubernetes/manifests/kube-apiserver.yaml-  priorityClassName: system-node-critical
/etc/kubernetes/manifests/kube-apiserver.yaml-  securityContext:
/etc/kubernetes/manifests/kube-apiserver.yaml:    seccompProfile:
/etc/kubernetes/manifests/kube-apiserver.yaml-      type: RuntimeDefault
/etc/kubernetes/manifests/kube-apiserver.yaml-  volumes:
--
/etc/kubernetes/manifests/kube-controller-manager.yaml-  priorityClassName: system-node-critical
/etc/kubernetes/manifests/kube-controller-manager.yaml-  securityContext:
/etc/kubernetes/manifests/kube-controller-manager.yaml:    seccompProfile:
/etc/kubernetes/manifests/kube-controller-manager.yaml-      type: RuntimeDefault
/etc/kubernetes/manifests/kube-controller-manager.yaml-  volumes:
--
/etc/kubernetes/manifests/kube-scheduler.yaml-  priorityClassName: system-node-critical
/etc/kubernetes/manifests/kube-scheduler.yaml-  securityContext:
/etc/kubernetes/manifests/kube-scheduler.yaml:    seccompProfile:
/etc/kubernetes/manifests/kube-scheduler.yaml-      type: RuntimeDefault
/etc/kubernetes/manifests/kube-scheduler.yaml-  volumes:
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
Setting the seccompProfile for these components to runtime/default is safe and we have been doing this in kube-up for a while. 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kubeadm: set the seccompProfile to runtime/default in the PodSecurityContext of the  control-plane components that run as static Pods.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
[KEP 2568]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-cluster-lifecycle/kubeadm/2568-kubeadm-non-root-control-plane
[KEP Issue]: https://github.com/kubernetes/enhancements/issues/2568
```
