### PR TITLE
Fix  `podSpec/ReadinessGates` broken links

### DIFF
--- a/pkg/apis/core/types.go
+++ b/pkg/apis/core/types.go
@@ -2832,7 +2832,7 @@ type PodSpec struct {
 	// If specified, all readiness gates will be evaluated for pod readiness.
 	// A pod is ready when all its containers are ready AND
 	// all conditions specified in the readiness gates have status equal to "True"
-	// More info: https://git.k8s.io/enhancements/keps/sig-network/0007-pod-ready%2B%2B.md
+	// More info: https://git.k8s.io/enhancements/keps/sig-network/580-pod-readiness-gates/README.md
 	// +optional
 	ReadinessGates []PodReadinessGate
 	// RuntimeClassName refers to a RuntimeClass object in the node.k8s.io group, which should be used


### PR DESCRIPTION

/kind documentation


#### What this PR does / why we need it:

Update `podSpec/ReadinessGates` comment more info links

https://git.k8s.io/enhancements/keps/sig-network/0007-pod-ready%2B%2B.md may be deprecated

#### Which issue(s) this PR fixes:

Fixes #100238 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
NONE

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
