### PR TITLE
Build conformance image when building via `cross` or `cross-in-a-container`

### DIFF
--- a/build/root/Makefile
+++ b/build/root/Makefile
@@ -506,6 +506,7 @@ ifeq ($(PRINT_HELP),y)
 cross cross-in-a-container:
 	@echo "$$CROSS_HELP_INFO"
 else
+cross cross-in-a-container: KUBE_BUILD_CONFORMANCE = y
 cross:
 	hack/make-rules/cross.sh
 cross-in-a-container: KUBE_OUTPUT_SUBPATH = $(OUT_DIR)/dockerized


### PR DESCRIPTION
#### What type of PR is this?

/kind regression


#### What this PR does / why we need it:
This enables building the conformance image when running `make
cross-in-a-container`, which is being used by the release engineering
tooling.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
None
#### Special notes for your reviewer:
Refers to https://github.com/kubernetes/kubernetes/pull/99386
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
