### PR TITLE
Enable or disable GCP Firewall Rules Logging per service

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/gce/gce_annotations.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/gce/gce_annotations.go
@@ -73,6 +73,9 @@ const (
 
 	// NetworkTierAnnotationPremium is an annotation to indicate the Service is on the Premium network tier
 	NetworkTierAnnotationPremium = cloud.NetworkTierPremium
+
+	// LogFirewallRules is annotated with "true" when the users want to enable Firewall Logs
+	LogFirewallRules = "cloud.google.com/log-firewall-rules"
 )
 
 // GetLoadBalancerAnnotationType returns the type of GCP load balancer which should be assembled.

--- a/staging/src/k8s.io/legacy-cloud-providers/gce/gce_loadbalancer_internal.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/gce/gce_loadbalancer_internal.go
@@ -445,12 +445,17 @@ func (g *Cloud) ensureInternalFirewall(svc *v1.Service, fwName, fwDesc string, s
 		}
 	}
 
+	b, _ := strconv.ParseBool(svc.Annotations[LogFirewallRules])
+
 	expectedFirewall := &compute.Firewall{
 		Name:         fwName,
 		Description:  fwDesc,
 		Network:      g.networkURL,
 		SourceRanges: sourceRanges,
 		TargetTags:   targetTags,
+		LogConfig: &compute.FirewallLogConfig{
+			Enable: b,
+		},
 		Allowed: []*compute.FirewallAllowed{
 			{
 				IPProtocol: strings.ToLower(string(protocol)),


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Kubernetes creates VPC Firewall Rules automatically on GCP. Some GCP users must have logging enabled for compliance reasons. However there is no way to specify that Kubernetes should enable logging for the Firewall Rules that are created automatically. This PR introduces a new annotation to eventually enable Logging for GCP Firewall Rules.


#### Does this PR introduce a user-facing change?
```release-note
GCP cloud provider introduces the optional service annotation cloud.google.com/log-firewall-rules to enable Firewall Rules Logging for VPC firewall rules created automatically by Kubernetes.
```

