### PR TITLE
Replicate update/patch operations from eviction test in conformance CRUD test

### DIFF
--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -704,9 +704,10 @@
   description: PodDisruptionBudget API must support list and deletecollection operations.
   release: v1.21
   file: test/e2e/apps/disruption.go
-- testname: 'PodDisruptionBudget: create and delete object'
+- testname: 'PodDisruptionBudget: create, update, patch, and delete object'
   codename: '[sig-apps] DisruptionController should create a PodDisruptionBudget [Conformance]'
-  description: PodDisruptionBudget API must support create and delete operations.
+  description: PodDisruptionBudget API must support create, update, patch, and delete
+    operations.
   release: v1.21
   file: test/e2e/apps/disruption.go
 - testname: 'PodDisruptionBudget: Status updates'


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

xref https://github.com/kubernetes/kubernetes/pull/84740#issuecomment-799011628 
Adds conformance coverage for the last two v1 PDB endpoints+operations. These operations were already tested in the eviction test, which was not promoted to conformance yet, pending Eviction v1 graduation.

These two API calls were already made from the evictions e2e test (https://testgrid.k8s.io/sig-release-master-blocking#gce-ubuntu-master-containerd&include-filter-by-regex=evictions&width=5 shows flake-free operation > 2 weeks), but that test was not promoted to conformance because it also calls `pods/eviction`, which is not yet GA.



```release-note
NONE
```

/cc @mortent