### PR TITLE
Expose resources overrides and maxPods conf in kubemark

### DIFF
--- a/pkg/kubelet/cm/container_manager_stub.go
+++ b/pkg/kubelet/cm/container_manager_stub.go
@@ -35,6 +35,7 @@ import (
 
 type containerManagerStub struct {
 	shouldResetExtendedResourceCapacity bool
+	extendedPluginResources             v1.ResourceList
 }
 
 var _ ContainerManager = &containerManagerStub{}
@@ -86,7 +87,7 @@ func (cm *containerManagerStub) GetPluginRegistrationHandler() cache.PluginHandl
 }
 
 func (cm *containerManagerStub) GetDevicePluginResourceCapacity() (v1.ResourceList, v1.ResourceList, []string) {
-	return nil, nil, []string{}
+	return cm.extendedPluginResources, cm.extendedPluginResources, []string{}
 }
 
 func (cm *containerManagerStub) NewPodContainerManager() PodContainerManager {
@@ -135,4 +136,11 @@ func NewStubContainerManager() ContainerManager {
 
 func NewStubContainerManagerWithExtendedResource(shouldResetExtendedResourceCapacity bool) ContainerManager {
 	return &containerManagerStub{shouldResetExtendedResourceCapacity: shouldResetExtendedResourceCapacity}
+}
+
+func NewStubContainerManagerWithDevicePluginResource(extendedPluginResources v1.ResourceList) ContainerManager {
+	return &containerManagerStub{
+		shouldResetExtendedResourceCapacity: false,
+		extendedPluginResources:             extendedPluginResources,
+	}
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

These flags help user customize hollow-node in large scale testing. 

`cpu` `memory` can be overrided using new `--extended-resources ` as well.  It's because devicePluginCapacity override existing `node.Status.Capacity`.


https://github.com/kubernetes/kubernetes/blob/58814dbe3fc13602fb8a9ac67f9e046c9eb09326/pkg/kubelet/nodestatus/setters.go#L340-L345

In real world cases, system default resources will never be part of `devicePluginCapacity`. Them comes from cadvisor.  My question is should I make some changes to cadvisor instead for `cpu` and `memory` resource customization or just use the way in PR? 



#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #100158 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
It add two flags, `--max-pods` and `--extended-resources`
```

Usage
```
./_output/bin/kubemark --morph=kubelet --kubeconfig=/Users/jiaxin/.kube/config --max-pods=150 --extended-resources=nvidia.com/gpu=8,cpu=96,memory=48000Mi
```


#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
