### PR TITLE
kubelet: handle graceful termination of mirror pods

### DIFF
--- a/pkg/kubelet/status/status_manager.go
+++ b/pkg/kubelet/status/status_manager.go
@@ -598,10 +598,8 @@ func (m *manager) syncPod(uid types.UID, status versionedPodStatus) {
 
 	m.apiStatusVersions[kubetypes.MirrorPodUID(pod.UID)] = status.version
 
-	// We don't handle graceful deletion of mirror pods.
 	if m.canBeDeleted(pod, status.status) {
 		deleteOptions := metav1.DeleteOptions{
-			GracePeriodSeconds: new(int64),
 			// Use the pod UID as the precondition for deletion to prevent deleting a
 			// newly created pod with the same name and namespace.
 			Preconditions: metav1.NewUIDPreconditions(string(pod.UID)),


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/sig node

#### What this PR does / why we need it:
The kubelet has received various fixes to static pod graceful shutdowns. [98103](https://github.com/kubernetes/kubernetes/pull/98103) [92442](https://github.com/kubernetes/kubernetes/pull/92442). Mirror pods get an explicit zero grace period. We can remove the zero grace period from mirror pods, since we support static pod shutdowns.

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
NONE
```
