### PR TITLE
Add WaitForPodReady to wait for single pod

### DIFF
--- a/test/e2e/framework/metrics/metrics_grabber.go
+++ b/test/e2e/framework/metrics/metrics_grabber.go
@@ -189,7 +189,7 @@ func (g *Grabber) GrabFromControllerManager() (ControllerManagerMetrics, error) 
 	var err error
 	podName := g.kubeControllerManager
 	g.waitForControllerManagerReadyOnce.Do(func() {
-		if readyErr := e2epod.WaitForPodsReady(g.client, metav1.NamespaceSystem, podName, 0); readyErr != nil {
+		if readyErr := e2epod.WaitForPodReady(g.client, metav1.NamespaceSystem, podName, 0); readyErr != nil {
 			err = fmt.Errorf("error waiting for controller manager pod to be ready: %w", readyErr)
 			return
 		}

--- a/test/e2e/framework/pod/wait.go
+++ b/test/e2e/framework/pod/wait.go
@@ -492,6 +492,20 @@ func WaitForPodsWithLabelRunningReady(c clientset.Interface, ns string, label la
 	return pods, err
 }
 
+// WaitForPodReady waits for a pod to become ready.
+func WaitForPodReady(c clientset.Interface, ns, name string, minReadySeconds int) error {
+	return wait.Poll(poll, 5*time.Minute, func() (bool, error) {
+		pod, err := c.CoreV1().Pods(ns).Get(context.TODO(), name, metav1.GetOptions{})
+		if err != nil {
+			return false, nil
+		}
+		if !podutils.IsPodAvailable(pod, int32(minReadySeconds), metav1.Now()) {
+			return false, nil
+		}
+		return true, nil
+	})
+}
+
 // WaitForPodsReady waits for the pods to become ready.
 func WaitForPodsReady(c clientset.Interface, ns, name string, minReadySeconds int) error {
 	label := labels.SelectorFromSet(labels.Set(map[string]string{"name": name}))


### PR DESCRIPTION

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
WaitForPodsReady doesn't work if the pod name is greater than 63 characters like "kube-controller-manager-ip-172-20-39-70.us-west-2.compute.internal". List will return `unable to parse requirement: invalid label value: "kube-controller-manager-ip-172-20-39-70.us-west-2.compute.internal": at key: "name": must be no more than 63 characters`

Since waitForControllerManagerReadyOnce is waiting for a single Pod, add WaitForPodReady and use it.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
