### PR TITLE
Promote ServiceStatus lifecycle e2e test to Conformance  +4 endpoint coverage

### DIFF
--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -1788,6 +1788,14 @@
     [LinuxOnly]: Windows does not support session affinity.'
   release: v1.19
   file: test/e2e/network/service.go
+- testname: Service, complete ServiceStatus lifecycle
+  codename: '[sig-network] Services should complete a service status lifecycle [Conformance]'
+  description: Create a service, the service MUST exist. When retrieving /status the
+    action MUST be validated. When patching /status the action MUST be validated.
+    When updating /status the action MUST be validated. When patching a service the
+    action MUST be validated.
+  release: v1.21
+  file: test/e2e/network/service.go
 - testname: Find Kubernetes Service in default Namespace
   codename: '[sig-network] Services should find a service from listing all namespaces
     [Conformance]'

--- a/test/e2e/network/service.go
+++ b/test/e2e/network/service.go
@@ -2205,7 +2205,16 @@ var _ = common.SIGDescribe("Services", func() {
 		framework.ExpectError(err, "should not be able to fetch Endpoint")
 	})
 
-	ginkgo.It("should complete a service status lifecycle", func() {
+	/*
+		Release: v1.21
+		Testname: Service, complete ServiceStatus lifecycle
+		Description: Create a service, the service MUST exist.
+		When retrieving /status the action MUST be validated.
+		When patching /status the action MUST be validated.
+		When updating /status the action MUST be validated.
+		When patching a service the action MUST be validated.
+	*/
+	framework.ConformanceIt("should complete a service status lifecycle", func() {
 
 		ns := f.Namespace.Name
 		svcResource := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "services"}


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it:**
This PR adds a test to test the following untested endpoints:
- patchCoreV1NamespacedServiceStatus
- readCoreV1NamespacedServiceStatus
- replaceCoreV1NamespacedServiceStatus
- patchCoreV1NamespacedService

**Which issue(s) this PR fixes:**
Fixes #94867
**Testgrid Link:**
[Link](https://testgrid.k8s.io/sig-release-master-blocking#gce-cos-master-default&include-filter-by-regex=should.complete.a.service.status.lifecycle&width=5&graph-metrics=test-duration-minutes)

**Special notes for your reviewer:**
Adds +4 endpoint test coverage (good for conformance)

**Does this PR introduce a user-facing change?:**
```
NONE

```

**Release note:**
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:**
```
NONE

```

/sig testing
/sig architecture
/area conformance