### PR TITLE
Automated cherry pick of #99755: fix RemoveStatusCondition() cap out of range

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/api/meta/conditions.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/meta/conditions.go
@@ -57,7 +57,7 @@ func SetStatusCondition(conditions *[]metav1.Condition, newCondition metav1.Cond
 // RemoveStatusCondition removes the corresponding conditionType from conditions.
 // conditions must be non-nil.
 func RemoveStatusCondition(conditions *[]metav1.Condition, conditionType string) {
-	if conditions == nil {
+	if conditions == nil || len(*conditions) == 0 {
 		return
 	}
 	newConditions := make([]metav1.Condition, 0, len(*conditions)-1)

--- a/staging/src/k8s.io/apimachinery/pkg/api/meta/conditions_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/meta/conditions_test.go
@@ -121,6 +121,12 @@ func TestRemoveStatusCondition(t *testing.T) {
 				{Type: "third"},
 			},
 		},
+		{
+			name:          "empty_conditions",
+			conditions:    []metav1.Condition{},
+			conditionType: "Foo",
+			expected:      []metav1.Condition{},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Cherry pick of #99755 on release-1.20.

#99755: fix RemoveStatusCondition() cap out of range

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.