### PR TITLE
Automated cherry pick of #99111: Return error when persister fails to modify config

### DIFF
--- a/staging/src/k8s.io/client-go/tools/clientcmd/config.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/config.go
@@ -374,7 +374,7 @@ func (p *persister) Persist(config map[string]string) error {
 	authInfo, ok := newConfig.AuthInfos[p.user]
 	if ok && authInfo.AuthProvider != nil {
 		authInfo.AuthProvider.Config = config
-		ModifyConfig(p.configAccess, *newConfig, false)
+		return ModifyConfig(p.configAccess, *newConfig, false)
 	}
 	return nil
 }


### PR DESCRIPTION
Cherry pick of #99111 on release-1.20.

#99111: Return error when persister fails to modify config

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.