### PR TITLE
got rid of ClusterEventReg generate ClusterEvent objects on the fly

### DIFF
--- a/pkg/scheduler/eventhandlers.go
+++ b/pkg/scheduler/eventhandlers.go
@@ -119,8 +119,8 @@ func (sched *Scheduler) updateNodeInCache(oldObj, newObj interface{}) {
 
 	nodeInfo := sched.SchedulerCache.UpdateNode(oldNode, newNode)
 	// Only requeue unschedulable pods if the node became more schedulable.
-	if event := nodeSchedulingPropertiesChange(newNode, oldNode); event != "" {
-		sched.SchedulingQueue.MoveAllToActiveOrBackoffQueue(event, preCheckForNode(nodeInfo))
+	if event := nodeSchedulingPropertiesChange(newNode, oldNode); event != nil {
+		sched.SchedulingQueue.MoveAllToActiveOrBackoffQueue(*event, preCheckForNode(nodeInfo))
 	}
 }
 
@@ -412,24 +412,24 @@ func addAllEventHandlers(
 	)
 }
 
-func nodeSchedulingPropertiesChange(newNode *v1.Node, oldNode *v1.Node) string {
+func nodeSchedulingPropertiesChange(newNode *v1.Node, oldNode *v1.Node) *framework.ClusterEvent {
 	if nodeSpecUnschedulableChanged(newNode, oldNode) {
-		return queue.NodeSpecUnschedulableChange
+		return &queue.NodeSpecUnschedulableChange
 	}
 	if nodeAllocatableChanged(newNode, oldNode) {
-		return queue.NodeAllocatableChange
+		return &queue.NodeAllocatableChange
 	}
 	if nodeLabelsChanged(newNode, oldNode) {
-		return queue.NodeLabelChange
+		return &queue.NodeLabelChange
 	}
 	if nodeTaintsChanged(newNode, oldNode) {
-		return queue.NodeTaintChange
+		return &queue.NodeTaintChange
 	}
 	if nodeConditionsChanged(newNode, oldNode) {
-		return queue.NodeConditionChange
+		return &queue.NodeConditionChange
 	}
 
-	return ""
+	return nil
 }
 
 func nodeAllocatableChanged(newNode *v1.Node, oldNode *v1.Node) bool {

--- a/pkg/scheduler/framework/types.go
+++ b/pkg/scheduler/framework/types.go
@@ -75,15 +75,21 @@ const (
 	WildCard              GVK = "*"
 )
 
-// WildCardEvent semantically matches all resources on all actions.
-var WildCardEvent = ClusterEvent{Resource: WildCard, ActionType: All}
-
 // ClusterEvent abstracts how a system resource's state gets changed.
 // Resource represents the standard API resources such as Pod, Node, etc.
 // ActionType denotes the specific change such as Add, Update or Delete.
 type ClusterEvent struct {
 	Resource   GVK
 	ActionType ActionType
+	Label      string
+}
+
+// IsWildCard returns true if ClusterEvent follows WildCard semantics
+func (ce ClusterEvent) IsWildCard() bool {
+	if ce.Resource == WildCard && ce.ActionType == All {
+		return true
+	}
+	return false
 }
 
 // QueuedPodInfo is a Pod wrapper with additional information related to

--- a/pkg/scheduler/internal/queue/events.go
+++ b/pkg/scheduler/internal/queue/events.go
@@ -20,80 +20,59 @@ import (
 	"k8s.io/kubernetes/pkg/scheduler/framework"
 )
 
-// Events that trigger scheduler queue to change.
 const (
 	// PodAdd is the event when a new pod is added to API server.
 	PodAdd = "PodAdd"
-	// NodeAdd is the event when a new node is added to the cluster.
-	NodeAdd = "NodeAdd"
 	// ScheduleAttemptFailure is the event when a schedule attempt fails.
 	ScheduleAttemptFailure = "ScheduleAttemptFailure"
 	// BackoffComplete is the event when a pod finishes backoff.
 	BackoffComplete = "BackoffComplete"
-	// UnschedulableTimeout is the event when a pod stays in unschedulable for longer than timeout.
-	UnschedulableTimeout = "UnschedulableTimeout"
-	// AssignedPodAdd is the event when a pod is added that causes pods with matching affinity terms
-	// to be more schedulable.
-	AssignedPodAdd = "AssignedPodAdd"
-	// AssignedPodUpdate is the event when a pod is updated that causes pods with matching affinity
-	// terms to be more schedulable.
-	AssignedPodUpdate = "AssignedPodUpdate"
-	// AssignedPodDelete is the event when a pod is deleted that causes pods with matching affinity
-	// terms to be more schedulable.
-	AssignedPodDelete = "AssignedPodDelete"
-	// PvAdd is the event when a persistent volume is added in the cluster.
-	PvAdd = "PvAdd"
-	// PvUpdate is the event when a persistent volume is updated in the cluster.
-	PvUpdate = "PvUpdate"
-	// PvcAdd is the event when a persistent volume claim is added in the cluster.
-	PvcAdd = "PvcAdd"
-	// PvcUpdate is the event when a persistent volume claim is updated in the cluster.
-	PvcUpdate = "PvcUpdate"
-	// StorageClassAdd is the event when a StorageClass is added in the cluster.
-	StorageClassAdd = "StorageClassAdd"
-	// ServiceAdd is the event when a service is added in the cluster.
-	ServiceAdd = "ServiceAdd"
-	// ServiceUpdate is the event when a service is updated in the cluster.
-	ServiceUpdate = "ServiceUpdate"
-	// ServiceDelete is the event when a service is deleted in the cluster.
-	ServiceDelete = "ServiceDelete"
-	// CSINodeAdd is the event when a CSI node is added in the cluster.
-	CSINodeAdd = "CSINodeAdd"
-	// CSINodeUpdate is the event when a CSI node is updated in the cluster.
-	CSINodeUpdate = "CSINodeUpdate"
-	// NodeSpecUnschedulableChange is the event when unschedulable node spec is changed.
-	NodeSpecUnschedulableChange = "NodeSpecUnschedulableChange"
-	// NodeAllocatableChange is the event when node allocatable is changed.
-	NodeAllocatableChange = "NodeAllocatableChange"
-	// NodeLabelChange is the event when node label is changed.
-	NodeLabelChange = "NodeLabelChange"
-	// NodeTaintChange is the event when node taint is changed.
-	NodeTaintChange = "NodeTaintChange"
-	// NodeConditionChange is the event when node condition is changed.
-	NodeConditionChange = "NodeConditionChange"
 )
 
-// TODO: benchmark the perf gain if making the keys as enums (int), and then
-// making clusterEventReg a []framework.ClusterEvent.
-var clusterEventReg = map[string]framework.ClusterEvent{
-	AssignedPodAdd:              {Resource: framework.Pod, ActionType: framework.Add},
-	AssignedPodUpdate:           {Resource: framework.Pod, ActionType: framework.Update},
-	AssignedPodDelete:           {Resource: framework.Pod, ActionType: framework.Delete},
-	NodeAdd:                     {Resource: framework.Node, ActionType: framework.Add},
-	NodeSpecUnschedulableChange: {Resource: framework.Node, ActionType: framework.UpdateNodeTaint},
-	NodeAllocatableChange:       {Resource: framework.Node, ActionType: framework.UpdateNodeAllocatable},
-	NodeLabelChange:             {Resource: framework.Node, ActionType: framework.UpdateNodeLabel},
-	NodeTaintChange:             {Resource: framework.Node, ActionType: framework.UpdateNodeTaint},
-	NodeConditionChange:         {Resource: framework.Node, ActionType: framework.UpdateNodeCondition},
-	PvAdd:                       {Resource: framework.PersistentVolume, ActionType: framework.Add},
-	PvUpdate:                    {Resource: framework.PersistentVolume, ActionType: framework.Update},
-	PvcAdd:                      {Resource: framework.PersistentVolumeClaim, ActionType: framework.Add},
-	PvcUpdate:                   {Resource: framework.PersistentVolumeClaim, ActionType: framework.Update},
-	StorageClassAdd:             {Resource: framework.StorageClass, ActionType: framework.Add},
-	CSINodeAdd:                  {Resource: framework.CSINode, ActionType: framework.Add},
-	CSINodeUpdate:               {Resource: framework.CSINode, ActionType: framework.Update},
-	ServiceAdd:                  {Resource: framework.Service, ActionType: framework.Add},
-	ServiceUpdate:               {Resource: framework.Service, ActionType: framework.Update},
-	ServiceDelete:               {Resource: framework.Service, ActionType: framework.Delete},
-	UnschedulableTimeout:        framework.WildCardEvent,
-}
+var (
+	// AssignedPodAdd is the event when a pod is added that causes pods with matching affinity terms
+	// to be more schedulable.
+	AssignedPodAdd = framework.ClusterEvent{Resource: framework.Pod, ActionType: framework.Add, Label: "AssignedPodAdd"}
+	// NodeAdd is the event when a new node is added to the cluster.
+	NodeAdd = framework.ClusterEvent{Resource: framework.Node, ActionType: framework.Add, Label: "NodeAdd"}
+	// AssignedPodUpdate is the event when a pod is updated that causes pods with matching affinity
+	// terms to be more schedulable.
+	AssignedPodUpdate = framework.ClusterEvent{Resource: framework.Pod, ActionType: framework.Update, Label: "AssignedPodUpdate"}
+	// AssignedPodDelete is the event when a pod is deleted that causes pods with matching affinity
+	// terms to be more schedulable.
+	AssignedPodDelete = framework.ClusterEvent{Resource: framework.Pod, ActionType: framework.Delete, Label: "AssignedPodDelete"}
+	// NodeSpecUnschedulableChange is the event when unschedulable node spec is changed.
+	NodeSpecUnschedulableChange = framework.ClusterEvent{Resource: framework.Node, ActionType: framework.UpdateNodeTaint, Label: "NodeSpecUnschedulableChange"}
+	// NodeAllocatableChange is the event when node allocatable is changed.
+	NodeAllocatableChange = framework.ClusterEvent{Resource: framework.Node, ActionType: framework.UpdateNodeAllocatable, Label: "NodeAllocatableChange"}
+	// NodeLabelChange is the event when node label is changed.
+	NodeLabelChange = framework.ClusterEvent{Resource: framework.Node, ActionType: framework.UpdateNodeLabel, Label: "NodeLabelChange"}
+	// NodeTaintChange is the event when node taint is changed.
+	NodeTaintChange = framework.ClusterEvent{Resource: framework.Node, ActionType: framework.UpdateNodeTaint, Label: "NodeTaintChange"}
+	// NodeConditionChange is the event when node condition is changed.
+	NodeConditionChange = framework.ClusterEvent{Resource: framework.Node, ActionType: framework.UpdateNodeCondition, Label: "NodeConditionChange"}
+	// PvAdd is the event when a persistent volume is added in the cluster.
+	PvAdd = framework.ClusterEvent{Resource: framework.PersistentVolume, ActionType: framework.Add, Label: "PvAdd"}
+	// PvUpdate is the event when a persistent volume is updated in the cluster.
+	PvUpdate = framework.ClusterEvent{Resource: framework.PersistentVolume, ActionType: framework.Update, Label: "PvUpdate"}
+	// PvcAdd is the event when a persistent volume claim is added in the cluster.
+	PvcAdd = framework.ClusterEvent{Resource: framework.PersistentVolumeClaim, ActionType: framework.Add, Label: "PvcAdd"}
+	// PvcUpdate is the event when a persistent volume claim is updated in the cluster.
+	PvcUpdate = framework.ClusterEvent{Resource: framework.PersistentVolumeClaim, ActionType: framework.Update, Label: "PvcUpdate"}
+	// StorageClassAdd is the event when a StorageClass is added in the cluster.
+	StorageClassAdd = framework.ClusterEvent{Resource: framework.StorageClass, ActionType: framework.Add, Label: "StorageClassAdd"}
+	// CSINodeAdd is the event when a CSI node is added in the cluster.
+	CSINodeAdd = framework.ClusterEvent{Resource: framework.CSINode, ActionType: framework.Add, Label: "CSINodeAdd"}
+	// CSINodeUpdate is the event when a CSI node is updated in the cluster.
+	CSINodeUpdate = framework.ClusterEvent{Resource: framework.CSINode, ActionType: framework.Update, Label: "CSINodeUpdate"}
+	// ServiceAdd is the event when a service is added in the cluster.
+	ServiceAdd = framework.ClusterEvent{Resource: framework.Service, ActionType: framework.Add, Label: "ServiceAdd"}
+	// ServiceUpdate is the event when a service is updated in the cluster.
+	ServiceUpdate = framework.ClusterEvent{Resource: framework.Service, ActionType: framework.Update, Label: "ServiceUpdate"}
+	// ServiceDelete is the event when a service is deleted in the cluster.
+	ServiceDelete = framework.ClusterEvent{Resource: framework.Service, ActionType: framework.Delete, Label: "ServiceDelete"}
+	// WildCardEvent semantically matches all resources on all actions.
+	WildCardEvent = framework.ClusterEvent{Resource: framework.WildCard, ActionType: framework.All, Label: "WildCardEvent"}
+	// UnschedulableTimeout is the event when a pod stays in unschedulable for longer than timeout.
+	UnschedulableTimeout = framework.ClusterEvent{Resource: framework.WildCard, ActionType: framework.All, Label: "UnschedulableTimeout"}
+)

--- a/pkg/scheduler/internal/queue/scheduling_queue_test.go
+++ b/pkg/scheduler/internal/queue/scheduling_queue_test.go
@@ -46,6 +46,12 @@ const queueMetricMetadata = `
 		# TYPE scheduler_queue_incoming_pods_total counter
 	`
 
+var (
+	TestEvent    = framework.ClusterEvent{Resource: "test"}
+	NodeAllEvent = framework.ClusterEvent{Resource: framework.Node, ActionType: framework.All}
+	EmptyEvent   = framework.ClusterEvent{}
+)
+
 var lowPriority, midPriority, highPriority = int32(0), int32(100), int32(1000)
 var mediumPriority = (lowPriority + highPriority) / 2
 var highPriorityPodInfo, highPriNominatedPodInfo, medPriorityPodInfo, unschedulablePodInfo = framework.NewPodInfo(&v1.Pod{
@@ -239,7 +245,7 @@ func TestPriorityQueue_AddUnschedulableIfNotPresent_Backoff(t *testing.T) {
 	}
 
 	// move all pods to active queue when we were trying to schedule them
-	q.MoveAllToActiveOrBackoffQueue("test", nil)
+	q.MoveAllToActiveOrBackoffQueue(TestEvent, nil)
 	oldCycle := q.SchedulingCycle()
 
 	firstPod, _ := q.Pop()
@@ -397,9 +403,10 @@ func TestPriorityQueue_Delete(t *testing.T) {
 }
 
 func BenchmarkMoveAllToActiveOrBackoffQueue(b *testing.B) {
+
 	tests := []struct {
 		name      string
-		moveEvent string
+		moveEvent framework.ClusterEvent
 	}{
 		{
 			name:      "baseline",
@@ -419,8 +426,22 @@ func BenchmarkMoveAllToActiveOrBackoffQueue(b *testing.B) {
 		highPriorityPodInfo.Pod, highPriNominatedPodInfo.Pod,
 		medPriorityPodInfo.Pod, unschedulablePodInfo.Pod,
 	}
-	events := []string{NodeAdd, NodeTaintChange, NodeAllocatableChange, NodeConditionChange, NodeLabelChange, PodAdd,
-		PvcAdd, PvcUpdate, PvAdd, PvUpdate, StorageClassAdd, CSINodeAdd, CSINodeUpdate}
+
+	events := []framework.ClusterEvent{
+		NodeAdd,
+		NodeTaintChange,
+		NodeAllocatableChange,
+		NodeConditionChange,
+		NodeLabelChange,
+		PvcAdd,
+		PvcUpdate,
+		PvAdd,
+		PvUpdate,
+		StorageClassAdd,
+		CSINodeAdd,
+		CSINodeUpdate,
+	}
+
 	pluginNum := 20
 	var plugins []string
 	// Mimic that we have 20 plugins loaded in runtime.
@@ -441,10 +462,10 @@ func BenchmarkMoveAllToActiveOrBackoffQueue(b *testing.B) {
 					// - 1/3 of plugins registered for events[2]
 					// - ...
 					for j := 0; j < len(events); j++ {
-						m[clusterEventReg[events[j]]] = sets.NewString()
+						m[events[j]] = sets.NewString()
 						for k := 0; k < len(plugins); k++ {
 							if (k+1)%(j+1) == 0 {
-								m[clusterEventReg[events[j]]].Insert(plugins[k])
+								m[events[j]].Insert(plugins[k])
 							}
 						}
 					}
@@ -478,7 +499,7 @@ func BenchmarkMoveAllToActiveOrBackoffQueue(b *testing.B) {
 					}
 
 					b.StartTimer()
-					if tt.moveEvent != "" {
+					if tt.moveEvent.Resource != "" {
 						q.MoveAllToActiveOrBackoffQueue(tt.moveEvent, nil)
 					} else {
 						// Random case.
@@ -581,9 +602,7 @@ func TestPriorityQueue_AssignedPodAdded(t *testing.T) {
 	}
 
 	c := clock.NewFakeClock(time.Now())
-	m := map[framework.ClusterEvent]sets.String{
-		{Resource: framework.Pod, ActionType: framework.Add}: sets.NewString("fakePlugin"),
-	}
+	m := map[framework.ClusterEvent]sets.String{AssignedPodAdd: sets.NewString("fakePlugin")}
 	q := NewTestQueue(context.Background(), newDefaultQueueSort(), WithClock(c), WithClusterEventMap(m))
 	q.Add(medPriorityPodInfo.Pod)
 	// Add a couple of pods to the unschedulableQ.
@@ -643,7 +662,7 @@ func TestPriorityQueue_PendingPods(t *testing.T) {
 		t.Error("Unexpected list of pending Pods.")
 	}
 	// Move all to active queue. We should still see the same set of pods.
-	q.MoveAllToActiveOrBackoffQueue("test", nil)
+	q.MoveAllToActiveOrBackoffQueue(TestEvent, nil)
 	if !reflect.DeepEqual(expectedSet, makeSet(q.PendingPods())) {
 		t.Error("Unexpected list of pending Pods...")
 	}
@@ -1106,7 +1125,7 @@ func TestHighPriorityBackoff(t *testing.T) {
 	// Put in the unschedulable queue.
 	q.AddUnschedulableIfNotPresent(p, q.SchedulingCycle())
 	// Move all unschedulable pods to the active queue.
-	q.MoveAllToActiveOrBackoffQueue("test", nil)
+	q.MoveAllToActiveOrBackoffQueue(TestEvent, nil)
 
 	p, err = q.Pop()
 	if err != nil {
@@ -1122,7 +1141,7 @@ func TestHighPriorityBackoff(t *testing.T) {
 func TestHighPriorityFlushUnschedulableQLeftover(t *testing.T) {
 	c := clock.NewFakeClock(time.Now())
 	m := map[framework.ClusterEvent]sets.String{
-		{Resource: framework.Node, ActionType: framework.Add}: sets.NewString("fakePlugin"),
+		NodeAdd: sets.NewString("fakePlugin"),
 	}
 	q := NewTestQueue(context.Background(), newDefaultQueueSort(), WithClock(c), WithClusterEventMap(m))
 	midPod := v1.Pod{
@@ -1727,34 +1746,34 @@ func TestPodMatchesEvent(t *testing.T) {
 	tests := []struct {
 		name            string
 		podInfo         *framework.QueuedPodInfo
-		event           string
+		event           framework.ClusterEvent
 		clusterEventMap map[framework.ClusterEvent]sets.String
 		want            bool
 	}{
 		{
 			name:    "event not registered",
 			podInfo: newQueuedPodInfoForLookup(&v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "p"}}),
-			event:   "ClusterTearDown",
+			event:   EmptyEvent,
 			clusterEventMap: map[framework.ClusterEvent]sets.String{
-				{Resource: framework.Node, ActionType: framework.All}: sets.NewString("foo"),
+				NodeAllEvent: sets.NewString("foo"),
 			},
 			want: false,
 		},
 		{
 			name:    "pod's failed plugin matches but event does not match",
 			podInfo: newQueuedPodInfoForLookup(&v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "p"}}, "bar"),
-			event:   PodAdd,
+			event:   AssignedPodAdd,
 			clusterEventMap: map[framework.ClusterEvent]sets.String{
-				{Resource: framework.Node, ActionType: framework.All}: sets.NewString("foo", "bar"),
+				NodeAllEvent: sets.NewString("foo", "bar"),
 			},
 			want: false,
 		},
 		{
 			name:    "wildcard event wins regardless of event matching",
 			podInfo: newQueuedPodInfoForLookup(&v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "p"}}, "bar"),
-			event:   UnschedulableTimeout,
+			event:   WildCardEvent,
 			clusterEventMap: map[framework.ClusterEvent]sets.String{
-				{Resource: framework.Node, ActionType: framework.All}: sets.NewString("foo"),
+				NodeAllEvent: sets.NewString("foo"),
 			},
 			want: true,
 		},
@@ -1763,7 +1782,7 @@ func TestPodMatchesEvent(t *testing.T) {
 			podInfo: newQueuedPodInfoForLookup(&v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "p"}}, "bar"),
 			event:   NodeTaintChange,
 			clusterEventMap: map[framework.ClusterEvent]sets.String{
-				{Resource: framework.Node, ActionType: framework.All}: sets.NewString("foo", "bar"),
+				NodeAllEvent: sets.NewString("foo", "bar"),
 			},
 			want: true,
 		},
@@ -1772,8 +1791,8 @@ func TestPodMatchesEvent(t *testing.T) {
 			podInfo: newQueuedPodInfoForLookup(&v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "p"}}, "bar"),
 			event:   NodeTaintChange,
 			clusterEventMap: map[framework.ClusterEvent]sets.String{
-				{Resource: framework.Node, ActionType: framework.All}:             sets.NewString("foo"),
-				{Resource: framework.Node, ActionType: framework.UpdateNodeTaint}: sets.NewString("bar"),
+				NodeAllEvent:    sets.NewString("foo"),
+				NodeTaintChange: sets.NewString("bar"),
 			},
 			want: true,
 		},
@@ -1782,7 +1801,7 @@ func TestPodMatchesEvent(t *testing.T) {
 			podInfo: newQueuedPodInfoForLookup(&v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "p"}}, "foo", "bar"),
 			event:   NodeAdd,
 			clusterEventMap: map[framework.ClusterEvent]sets.String{
-				{Resource: framework.Node, ActionType: framework.All}: sets.NewString("bar"),
+				NodeAllEvent: sets.NewString("bar"),
 			},
 			want: true,
 		},
@@ -1791,7 +1810,7 @@ func TestPodMatchesEvent(t *testing.T) {
 			podInfo: newQueuedPodInfoForLookup(&v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "p"}}, "foo"),
 			event:   PvAdd,
 			clusterEventMap: map[framework.ClusterEvent]sets.String{
-				framework.WildCardEvent: sets.NewString("foo"),
+				WildCardEvent: sets.NewString("foo"),
 			},
 			want: true,
 		},
@@ -1800,7 +1819,7 @@ func TestPodMatchesEvent(t *testing.T) {
 			podInfo: newQueuedPodInfoForLookup(&v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "p"}}, "foo"),
 			event:   PvAdd,
 			clusterEventMap: map[framework.ClusterEvent]sets.String{
-				framework.WildCardEvent: sets.NewString("bar"),
+				WildCardEvent: sets.NewString("bar"),
 			},
 			want: false,
 		},
@@ -1867,7 +1886,7 @@ func TestMoveAllToActiveOrBackoffQueue_PreEnqueueChecks(t *testing.T) {
 			for _, podInfo := range tt.podInfos {
 				q.AddUnschedulableIfNotPresent(podInfo, q.schedulingCycle)
 			}
-			q.MoveAllToActiveOrBackoffQueue("test", tt.preEnqueueCheck)
+			q.MoveAllToActiveOrBackoffQueue(TestEvent, tt.preEnqueueCheck)
 			var got []string
 			for q.podBackoffQ.Len() != 0 {
 				obj, err := q.podBackoffQ.Pop()


### PR DESCRIPTION
#### What type of PR is this?


/kind cleanup


#### What this PR does / why we need it:
With this pr we don't need to lookup ClusterEvents in the ClusterEvent Regestry but rather generate these objects dynamically

#### Which issue(s) this PR fixes:
Fixes # <https://github.com/kubernetes/kubernetes/issues/99966>

#### Does this PR introduce a user-facing change?
```
NONE
```
#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```
NONE
```
