### PR TITLE
client-go: NewSelfSignedCACert makes Go 1.15+ compatible cert

### DIFF
--- a/staging/src/k8s.io/client-go/util/cert/cert.go
+++ b/staging/src/k8s.io/client-go/util/cert/cert.go
@@ -62,6 +62,7 @@ func NewSelfSignedCACert(cfg Config, key crypto.Signer) (*x509.Certificate, erro
 			CommonName:   cfg.CommonName,
 			Organization: cfg.Organization,
 		},
+		DNSNames:              []string{cfg.CommonName},
 		NotBefore:             now.UTC(),
 		NotAfter:              now.Add(duration365d * 10).UTC(),
 		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,

--- a/staging/src/k8s.io/client-go/util/cert/cert_test.go
+++ b/staging/src/k8s.io/client-go/util/cert/cert_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package cert_test
 
 import (

--- a/staging/src/k8s.io/client-go/util/cert/cert_test.go
+++ b/staging/src/k8s.io/client-go/util/cert/cert_test.go
@@ -1,0 +1,30 @@
+package cert_test
+
+import (
+	cryptorand "crypto/rand"
+	"crypto/rsa"
+	"testing"
+
+	"k8s.io/client-go/util/cert"
+)
+
+const COMMON_NAME = "foo.example.com"
+
+// TestSelfSignedCertHasSAN verifies the existing of
+// a SAN on the generated self-signed certificate.
+// a SAN ensures that the certificate is considered
+// valid by default in go 1.15 and above, which
+// turns off fallback to Common Name by default.
+func TestSelfSignedCertHasSAN(t *testing.T) {
+	key, err := rsa.GenerateKey(cryptorand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("rsa key failed to generate: %v", err)
+	}
+	selfSignedCert, err := cert.NewSelfSignedCACert(cert.Config{CommonName: COMMON_NAME}, key)
+	if err != nil {
+		t.Fatalf("self signed certificate failed to generate: %v", err)
+	}
+	if len(selfSignedCert.DNSNames) == 0 {
+		t.Fatalf("self signed certificate has zero DNS names.")
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug


#### What this PR does / why we need it:

As of Go 1.15, X.509 certificates without a SAN no longer
fall back to the CommonName of the certificate.

https://golang.org/doc/go1.15#commonname

Updating NewSelfSignedCACert to produce certificates that
work with this change.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [GoLang CommonName cert default removal](https://golang.org/doc/go1.15#commonname)
```
