### PR TITLE
Kubectl: use genericclioptions.IOStreams for config subcommand

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/config.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/config.go
@@ -54,22 +54,21 @@ func NewCmdConfig(f cmdutil.Factory, pathOptions *clientcmd.PathOptions, streams
 	// file paths are common to all sub commands
 	cmd.PersistentFlags().StringVar(&pathOptions.LoadingRules.ExplicitPath, pathOptions.ExplicitFileFlag, pathOptions.LoadingRules.ExplicitPath, "use a particular kubeconfig file")
 
-	// TODO(juanvallejo): update all subcommands to work with genericclioptions.IOStreams
 	cmd.AddCommand(NewCmdConfigView(f, streams, pathOptions))
-	cmd.AddCommand(NewCmdConfigSetCluster(streams.Out, pathOptions))
-	cmd.AddCommand(NewCmdConfigSetAuthInfo(streams.Out, pathOptions))
-	cmd.AddCommand(NewCmdConfigSetContext(streams.Out, pathOptions))
-	cmd.AddCommand(NewCmdConfigSet(streams.Out, pathOptions))
-	cmd.AddCommand(NewCmdConfigUnset(streams.Out, pathOptions))
-	cmd.AddCommand(NewCmdConfigCurrentContext(streams.Out, pathOptions))
-	cmd.AddCommand(NewCmdConfigUseContext(streams.Out, pathOptions))
+	cmd.AddCommand(NewCmdConfigSetCluster(streams, pathOptions))
+	cmd.AddCommand(NewCmdConfigSetAuthInfo(streams, pathOptions))
+	cmd.AddCommand(NewCmdConfigSetContext(streams, pathOptions))
+	cmd.AddCommand(NewCmdConfigSet(streams, pathOptions))
+	cmd.AddCommand(NewCmdConfigUnset(streams, pathOptions))
+	cmd.AddCommand(NewCmdConfigCurrentContext(streams, pathOptions))
+	cmd.AddCommand(NewCmdConfigUseContext(streams, pathOptions))
 	cmd.AddCommand(NewCmdConfigGetContexts(streams, pathOptions))
-	cmd.AddCommand(NewCmdConfigGetClusters(streams.Out, pathOptions))
+	cmd.AddCommand(NewCmdConfigGetClusters(streams, pathOptions))
 	cmd.AddCommand(NewCmdConfigGetUsers(streams, pathOptions))
-	cmd.AddCommand(NewCmdConfigDeleteCluster(streams.Out, pathOptions))
-	cmd.AddCommand(NewCmdConfigDeleteContext(streams.Out, streams.ErrOut, pathOptions))
+	cmd.AddCommand(NewCmdConfigDeleteCluster(streams, pathOptions))
+	cmd.AddCommand(NewCmdConfigDeleteContext(streams, pathOptions))
 	cmd.AddCommand(NewCmdConfigDeleteUser(streams, pathOptions))
-	cmd.AddCommand(NewCmdConfigRenameContext(streams.Out, pathOptions))
+	cmd.AddCommand(NewCmdConfigRenameContext(streams, pathOptions))
 
 	return cmd
 }

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/create_authinfo.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/create_authinfo.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	cliflag "k8s.io/component-base/cli/flag"
@@ -54,6 +55,8 @@ type createAuthInfoOptions struct {
 	execArgs        []string
 	execEnv         map[string]string
 	execEnvToRemove []string
+
+	genericclioptions.IOStreams
 }
 
 const (
@@ -117,12 +120,15 @@ var (
 )
 
 // NewCmdConfigSetAuthInfo returns an Command option instance for 'config set-credentials' sub command
-func NewCmdConfigSetAuthInfo(out io.Writer, configAccess clientcmd.ConfigAccess) *cobra.Command {
-	options := &createAuthInfoOptions{configAccess: configAccess}
-	return newCmdConfigSetAuthInfo(out, options)
+func NewCmdConfigSetAuthInfo(streams genericclioptions.IOStreams, configAccess clientcmd.ConfigAccess) *cobra.Command {
+	options := &createAuthInfoOptions{
+		configAccess: configAccess,
+		IOStreams:    streams,
+	}
+	return newCmdConfigSetAuthInfo(options)
 }
 
-func newCmdConfigSetAuthInfo(out io.Writer, options *createAuthInfoOptions) *cobra.Command {
+func newCmdConfigSetAuthInfo(options *createAuthInfoOptions) *cobra.Command {
 	cmd := &cobra.Command{
 		Use: fmt.Sprintf(
 			"set-credentials NAME [--%v=path/to/certfile] "+
@@ -153,13 +159,13 @@ func newCmdConfigSetAuthInfo(out io.Writer, options *createAuthInfoOptions) *cob
 		Long:                  createAuthInfoLong,
 		Example:               createAuthInfoExample,
 		Run: func(cmd *cobra.Command, args []string) {
-			err := options.complete(cmd, out)
+			err := options.complete(cmd, options.Out)
 			if err != nil {
 				cmd.Help()
 				cmdutil.CheckErr(err)
 			}
 			cmdutil.CheckErr(options.run())
-			fmt.Fprintf(out, "User %q set.\n", options.name)
+			fmt.Fprintf(options.Out, "User %q set.\n", options.name)
 		},
 	}
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/create_cluster.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/create_cluster.go
@@ -19,12 +19,12 @@ package config
 import (
 	"errors"
 	"fmt"
-	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 
 	"github.com/spf13/cobra"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	cliflag "k8s.io/component-base/cli/flag"
@@ -41,6 +41,8 @@ type createClusterOptions struct {
 	insecureSkipTLSVerify cliflag.Tristate
 	certificateAuthority  cliflag.StringFlag
 	embedCAData           cliflag.Tristate
+
+	genericclioptions.IOStreams
 }
 
 var (
@@ -64,8 +66,11 @@ var (
 )
 
 // NewCmdConfigSetCluster returns a Command instance for 'config set-cluster' sub command
-func NewCmdConfigSetCluster(out io.Writer, configAccess clientcmd.ConfigAccess) *cobra.Command {
-	options := &createClusterOptions{configAccess: configAccess}
+func NewCmdConfigSetCluster(streams genericclioptions.IOStreams, configAccess clientcmd.ConfigAccess) *cobra.Command {
+	options := &createClusterOptions{
+		configAccess: configAccess,
+		IOStreams:    streams,
+	}
 
 	cmd := &cobra.Command{
 		Use:                   fmt.Sprintf("set-cluster NAME [--%v=server] [--%v=path/to/certificate/authority] [--%v=true] [--%v=example.com]", clientcmd.FlagAPIServer, clientcmd.FlagCAFile, clientcmd.FlagInsecure, clientcmd.FlagTLSServerName),
@@ -76,7 +81,7 @@ func NewCmdConfigSetCluster(out io.Writer, configAccess clientcmd.ConfigAccess) 
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdutil.CheckErr(options.complete(cmd))
 			cmdutil.CheckErr(options.run())
-			fmt.Fprintf(out, "Cluster %q set.\n", options.name)
+			fmt.Fprintf(options.Out, "Cluster %q set.\n", options.name)
 		},
 	}
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/create_cluster_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/create_cluster_test.go
@@ -17,11 +17,11 @@ limitations under the License.
 package config
 
 import (
-	"bytes"
 	"io/ioutil"
 	"os"
 	"testing"
 
+	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
@@ -115,8 +115,9 @@ func (test createClusterTest) run(t *testing.T) {
 	pathOptions := clientcmd.NewDefaultPathOptions()
 	pathOptions.GlobalFile = fakeKubeFile.Name()
 	pathOptions.EnvVar = ""
-	buf := bytes.NewBuffer([]byte{})
-	cmd := NewCmdConfigSetCluster(buf, pathOptions)
+	ioStreams, _, out, _ := genericclioptions.NewTestIOStreams()
+	cmd := NewCmdConfigSetCluster(ioStreams, pathOptions)
+	cmd.SetOut(out)
 	cmd.SetArgs(test.args)
 	cmd.Flags().Parse(test.flags)
 	if err := cmd.Execute(); err != nil {
@@ -127,8 +128,8 @@ func (test createClusterTest) run(t *testing.T) {
 		t.Fatalf("unexpected error loading kubeconfig file: %v", err)
 	}
 	if len(test.expected) != 0 {
-		if buf.String() != test.expected {
-			t.Errorf("Failed in %q\n expected %v\n but got %v", test.description, test.expected, buf.String())
+		if out.String() != test.expected {
+			t.Errorf("Failed in %q\n expected %v\n but got %v", test.description, test.expected, out.String())
 		}
 	}
 	if len(test.args) > 0 {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/create_context.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/create_context.go
@@ -19,10 +19,10 @@ package config
 import (
 	"errors"
 	"fmt"
-	"io"
 
 	"github.com/spf13/cobra"
 
+	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	cliflag "k8s.io/component-base/cli/flag"
@@ -38,6 +38,8 @@ type createContextOptions struct {
 	cluster      cliflag.StringFlag
 	authInfo     cliflag.StringFlag
 	namespace    cliflag.StringFlag
+
+	genericclioptions.IOStreams
 }
 
 var (
@@ -52,8 +54,11 @@ var (
 )
 
 // NewCmdConfigSetContext returns a Command instance for 'config set-context' sub command
-func NewCmdConfigSetContext(out io.Writer, configAccess clientcmd.ConfigAccess) *cobra.Command {
-	options := &createContextOptions{configAccess: configAccess}
+func NewCmdConfigSetContext(streams genericclioptions.IOStreams, configAccess clientcmd.ConfigAccess) *cobra.Command {
+	options := &createContextOptions{
+		configAccess: configAccess,
+		IOStreams:    streams,
+	}
 
 	cmd := &cobra.Command{
 		Use:                   fmt.Sprintf("set-context [NAME | --current] [--%v=cluster_nickname] [--%v=user_nickname] [--%v=namespace]", clientcmd.FlagClusterName, clientcmd.FlagAuthInfoName, clientcmd.FlagNamespace),
@@ -66,9 +71,9 @@ func NewCmdConfigSetContext(out io.Writer, configAccess clientcmd.ConfigAccess) 
 			name, exists, err := options.run()
 			cmdutil.CheckErr(err)
 			if exists {
-				fmt.Fprintf(out, "Context %q modified.\n", name)
+				fmt.Fprintf(options.Out, "Context %q modified.\n", name)
 			} else {
-				fmt.Fprintf(out, "Context %q created.\n", name)
+				fmt.Fprintf(options.Out, "Context %q created.\n", name)
 			}
 		},
 	}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/create_context_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/create_context_test.go
@@ -17,11 +17,11 @@ limitations under the License.
 package config
 
 import (
-	"bytes"
 	"io/ioutil"
 	"os"
 	"testing"
 
+	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
@@ -120,8 +120,9 @@ func (test createContextTest) run(t *testing.T) {
 	pathOptions := clientcmd.NewDefaultPathOptions()
 	pathOptions.GlobalFile = fakeKubeFile.Name()
 	pathOptions.EnvVar = ""
-	buf := bytes.NewBuffer([]byte{})
-	cmd := NewCmdConfigSetContext(buf, pathOptions)
+	ioStreams, _, out, _ := genericclioptions.NewTestIOStreams()
+	cmd := NewCmdConfigSetContext(ioStreams, pathOptions)
+	cmd.SetOut(out)
 	cmd.SetArgs(test.args)
 	cmd.Flags().Parse(test.flags)
 	if err := cmd.Execute(); err != nil {
@@ -132,8 +133,8 @@ func (test createContextTest) run(t *testing.T) {
 		t.Fatalf("unexpected error loading kubeconfig file: %v", err)
 	}
 	if len(test.expected) != 0 {
-		if buf.String() != test.expected {
-			t.Errorf("Fail in %q:\n expected %v\n but got %v\n", test.description, test.expected, buf.String())
+		if out.String() != test.expected {
+			t.Errorf("Fail in %q:\n expected %v\n but got %v\n", test.description, test.expected, out.String())
 		}
 	}
 	if test.expectedConfig.Contexts != nil {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/current_context.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/current_context.go
@@ -18,10 +18,10 @@ package config
 
 import (
 	"fmt"
-	"io"
 
 	"github.com/spf13/cobra"
 
+	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/tools/clientcmd"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/util/i18n"
@@ -31,6 +31,8 @@ import (
 // CurrentContextOptions holds the command-line options for 'config current-context' sub command
 type CurrentContextOptions struct {
 	ConfigAccess clientcmd.ConfigAccess
+
+	genericclioptions.IOStreams
 }
 
 var (
@@ -43,8 +45,11 @@ var (
 )
 
 // NewCmdConfigCurrentContext returns a Command instance for 'config current-context' sub command
-func NewCmdConfigCurrentContext(out io.Writer, configAccess clientcmd.ConfigAccess) *cobra.Command {
-	options := &CurrentContextOptions{ConfigAccess: configAccess}
+func NewCmdConfigCurrentContext(streams genericclioptions.IOStreams, configAccess clientcmd.ConfigAccess) *cobra.Command {
+	options := &CurrentContextOptions{
+		ConfigAccess: configAccess,
+		IOStreams:    streams,
+	}
 
 	cmd := &cobra.Command{
 		Use:     "current-context",
@@ -52,7 +57,7 @@ func NewCmdConfigCurrentContext(out io.Writer, configAccess clientcmd.ConfigAcce
 		Long:    currentContextLong,
 		Example: currentContextExample,
 		Run: func(cmd *cobra.Command, args []string) {
-			cmdutil.CheckErr(RunCurrentContext(out, options))
+			cmdutil.CheckErr(options.RunCurrentContext())
 		},
 	}
 
@@ -60,8 +65,8 @@ func NewCmdConfigCurrentContext(out io.Writer, configAccess clientcmd.ConfigAcce
 }
 
 // RunCurrentContext performs the execution of 'config current-context' sub command
-func RunCurrentContext(out io.Writer, options *CurrentContextOptions) error {
-	config, err := options.ConfigAccess.GetStartingConfig()
+func (o *CurrentContextOptions) RunCurrentContext() error {
+	config, err := o.ConfigAccess.GetStartingConfig()
 	if err != nil {
 		return err
 	}
@@ -71,6 +76,6 @@ func RunCurrentContext(out io.Writer, options *CurrentContextOptions) error {
 		return err
 	}
 
-	fmt.Fprintf(out, "%s\n", config.CurrentContext)
+	fmt.Fprintf(o.Out, "%s\n", config.CurrentContext)
 	return nil
 }

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/current_context_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/current_context_test.go
@@ -17,12 +17,12 @@ limitations under the License.
 package config
 
 import (
-	"bytes"
 	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
 
+	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
@@ -70,12 +70,13 @@ func (test currentContextTest) run(t *testing.T) {
 	pathOptions := clientcmd.NewDefaultPathOptions()
 	pathOptions.GlobalFile = fakeKubeFile.Name()
 	pathOptions.EnvVar = ""
+	ioStreams, _, _, _ := genericclioptions.NewTestIOStreams()
 	options := CurrentContextOptions{
 		ConfigAccess: pathOptions,
+		IOStreams:    ioStreams,
 	}
 
-	buf := bytes.NewBuffer([]byte{})
-	err = RunCurrentContext(buf, &options)
+	err = options.RunCurrentContext()
 	if len(test.expectedError) != 0 {
 		if err == nil {
 			t.Errorf("Did not get %v", test.expectedError)

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/delete_cluster.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/delete_cluster.go
@@ -18,14 +18,19 @@ package config
 
 import (
 	"fmt"
-	"io"
 
 	"github.com/spf13/cobra"
+
+	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/tools/clientcmd"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/util/i18n"
 	"k8s.io/kubectl/pkg/util/templates"
 )
+
+type deleteClusterOptions struct {
+	genericclioptions.IOStreams
+}
 
 var (
 	deleteClusterExample = templates.Examples(`
@@ -34,7 +39,8 @@ var (
 )
 
 // NewCmdConfigDeleteCluster returns a Command instance for 'config delete-cluster' sub command
-func NewCmdConfigDeleteCluster(out io.Writer, configAccess clientcmd.ConfigAccess) *cobra.Command {
+func NewCmdConfigDeleteCluster(streams genericclioptions.IOStreams, configAccess clientcmd.ConfigAccess) *cobra.Command {
+	options := &deleteClusterOptions{IOStreams: streams}
 	cmd := &cobra.Command{
 		Use:                   "delete-cluster NAME",
 		DisableFlagsInUseLine: true,
@@ -42,14 +48,14 @@ func NewCmdConfigDeleteCluster(out io.Writer, configAccess clientcmd.ConfigAcces
 		Long:                  i18n.T("Delete the specified cluster from the kubeconfig"),
 		Example:               deleteClusterExample,
 		Run: func(cmd *cobra.Command, args []string) {
-			cmdutil.CheckErr(runDeleteCluster(out, configAccess, cmd))
+			cmdutil.CheckErr(options.runDeleteCluster(configAccess, cmd))
 		},
 	}
 
 	return cmd
 }
 
-func runDeleteCluster(out io.Writer, configAccess clientcmd.ConfigAccess, cmd *cobra.Command) error {
+func (o *deleteClusterOptions) runDeleteCluster(configAccess clientcmd.ConfigAccess, cmd *cobra.Command) error {
 	config, err := configAccess.GetStartingConfig()
 	if err != nil {
 		return err
@@ -78,7 +84,7 @@ func runDeleteCluster(out io.Writer, configAccess clientcmd.ConfigAccess, cmd *c
 		return err
 	}
 
-	fmt.Fprintf(out, "deleted cluster %s from %s\n", name, configFile)
+	fmt.Fprintf(o.Out, "deleted cluster %s from %s\n", name, configFile)
 
 	return nil
 }

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/delete_cluster_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/delete_cluster_test.go
@@ -17,13 +17,13 @@ limitations under the License.
 package config
 
 import (
-	"bytes"
 	"fmt"
 	"io/ioutil"
 	"os"
 	"reflect"
 	"testing"
 
+	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
@@ -67,16 +67,17 @@ func (test deleteClusterTest) run(t *testing.T) {
 	pathOptions.GlobalFile = fakeKubeFile.Name()
 	pathOptions.EnvVar = ""
 
-	buf := bytes.NewBuffer([]byte{})
-	cmd := NewCmdConfigDeleteCluster(buf, pathOptions)
+	ioStreams, _, out, _ := genericclioptions.NewTestIOStreams()
+	cmd := NewCmdConfigDeleteCluster(ioStreams, pathOptions)
+	cmd.SetOut(out)
 	cmd.SetArgs([]string{test.clusterToDelete})
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("unexpected error executing command: %v", err)
 	}
 
 	expectedOutWithFile := fmt.Sprintf(test.expectedOut, fakeKubeFile.Name())
-	if expectedOutWithFile != buf.String() {
-		t.Errorf("expected output %s, but got %s", expectedOutWithFile, buf.String())
+	if expectedOutWithFile != out.String() {
+		t.Errorf("expected output %s, but got %s", expectedOutWithFile, out.String())
 		return
 	}
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/delete_context_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/delete_context_test.go
@@ -17,13 +17,13 @@ limitations under the License.
 package config
 
 import (
-	"bytes"
 	"fmt"
 	"io/ioutil"
 	"os"
 	"reflect"
 	"testing"
 
+	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
@@ -67,17 +67,18 @@ func (test deleteContextTest) run(t *testing.T) {
 	pathOptions.GlobalFile = fakeKubeFile.Name()
 	pathOptions.EnvVar = ""
 
-	buf := bytes.NewBuffer([]byte{})
-	errBuf := bytes.NewBuffer([]byte{})
-	cmd := NewCmdConfigDeleteContext(buf, errBuf, pathOptions)
+	ioStreams, _, out, errOut := genericclioptions.NewTestIOStreams()
+	cmd := NewCmdConfigDeleteContext(ioStreams, pathOptions)
+	cmd.SetOut(out)
+	cmd.SetErr(errOut)
 	cmd.SetArgs([]string{test.contextToDelete})
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("unexpected error executing command: %v", err)
 	}
 
 	expectedOutWithFile := fmt.Sprintf(test.expectedOut, fakeKubeFile.Name())
-	if expectedOutWithFile != buf.String() {
-		t.Errorf("expected output %s, but got %s", expectedOutWithFile, buf.String())
+	if expectedOutWithFile != out.String() {
+		t.Errorf("expected output %s, but got %s", expectedOutWithFile, out.String())
 		return
 	}
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/get_clusters.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/get_clusters.go
@@ -18,14 +18,18 @@ package config
 
 import (
 	"fmt"
-	"io"
 
 	"github.com/spf13/cobra"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/tools/clientcmd"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/util/i18n"
 	"k8s.io/kubectl/pkg/util/templates"
 )
+
+type getClustersOptions struct {
+	genericclioptions.IOStreams
+}
 
 var (
 	getClustersExample = templates.Examples(`
@@ -35,29 +39,30 @@ var (
 
 // NewCmdConfigGetClusters creates a command object for the "get-clusters" action, which
 // lists all clusters defined in the kubeconfig.
-func NewCmdConfigGetClusters(out io.Writer, configAccess clientcmd.ConfigAccess) *cobra.Command {
+func NewCmdConfigGetClusters(streams genericclioptions.IOStreams, configAccess clientcmd.ConfigAccess) *cobra.Command {
+	options := &getClustersOptions{IOStreams: streams}
 	cmd := &cobra.Command{
 		Use:     "get-clusters",
 		Short:   i18n.T("Display clusters defined in the kubeconfig"),
 		Long:    i18n.T("Display clusters defined in the kubeconfig."),
 		Example: getClustersExample,
 		Run: func(cmd *cobra.Command, args []string) {
-			cmdutil.CheckErr(runGetClusters(out, configAccess))
+			cmdutil.CheckErr(options.runGetClusters(configAccess))
 		},
 	}
 
 	return cmd
 }
 
-func runGetClusters(out io.Writer, configAccess clientcmd.ConfigAccess) error {
+func (o *getClustersOptions) runGetClusters(configAccess clientcmd.ConfigAccess) error {
 	config, err := configAccess.GetStartingConfig()
 	if err != nil {
 		return err
 	}
 
-	fmt.Fprintf(out, "NAME\n")
+	fmt.Fprintf(o.Out, "NAME\n")
 	for name := range config.Clusters {
-		fmt.Fprintf(out, "%s\n", name)
+		fmt.Fprintf(o.Out, "%s\n", name)
 	}
 
 	return nil

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/get_clusters_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/get_clusters_test.go
@@ -17,11 +17,11 @@ limitations under the License.
 package config
 
 import (
-	"bytes"
 	"io/ioutil"
 	"os"
 	"testing"
 
+	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
@@ -70,14 +70,15 @@ func (test getClustersTest) run(t *testing.T) {
 	pathOptions := clientcmd.NewDefaultPathOptions()
 	pathOptions.GlobalFile = fakeKubeFile.Name()
 	pathOptions.EnvVar = ""
-	buf := bytes.NewBuffer([]byte{})
-	cmd := NewCmdConfigGetClusters(buf, pathOptions)
+	ioStreams, _, out, _ := genericclioptions.NewTestIOStreams()
+	cmd := NewCmdConfigGetClusters(ioStreams, pathOptions)
+	cmd.SetOut(out)
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("unexpected error executing command: %v", err)
 	}
 	if len(test.expected) != 0 {
-		if buf.String() != test.expected {
-			t.Errorf("expected %v, but got %v", test.expected, buf.String())
+		if out.String() != test.expected {
+			t.Errorf("expected %v, but got %v", test.expected, out.String())
 		}
 		return
 	}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/set.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/set.go
@@ -20,12 +20,12 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
-	"io"
 	"reflect"
 	"strings"
 
 	"github.com/spf13/cobra"
 
+	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/tools/clientcmd"
 	cliflag "k8s.io/component-base/cli/flag"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
@@ -38,6 +38,8 @@ type setOptions struct {
 	propertyName  string
 	propertyValue string
 	setRawBytes   cliflag.Tristate
+
+	genericclioptions.IOStreams
 }
 
 var (
@@ -65,8 +67,11 @@ var (
 )
 
 // NewCmdConfigSet returns a Command instance for 'config set' sub command
-func NewCmdConfigSet(out io.Writer, configAccess clientcmd.ConfigAccess) *cobra.Command {
-	options := &setOptions{configAccess: configAccess}
+func NewCmdConfigSet(streams genericclioptions.IOStreams, configAccess clientcmd.ConfigAccess) *cobra.Command {
+	options := &setOptions{
+		configAccess: configAccess,
+		IOStreams:    streams,
+	}
 
 	cmd := &cobra.Command{
 		Use:                   "set PROPERTY_NAME PROPERTY_VALUE",
@@ -77,7 +82,7 @@ func NewCmdConfigSet(out io.Writer, configAccess clientcmd.ConfigAccess) *cobra.
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdutil.CheckErr(options.complete(cmd))
 			cmdutil.CheckErr(options.run())
-			fmt.Fprintf(out, "Property %q set.\n", options.propertyName)
+			fmt.Fprintf(options.Out, "Property %q set.\n", options.propertyName)
 		},
 	}
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/use_context.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/use_context.go
@@ -19,10 +19,10 @@ package config
 import (
 	"errors"
 	"fmt"
-	"io"
 
 	"github.com/spf13/cobra"
 
+	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
@@ -39,11 +39,16 @@ var (
 type useContextOptions struct {
 	configAccess clientcmd.ConfigAccess
 	contextName  string
+
+	genericclioptions.IOStreams
 }
 
 // NewCmdConfigUseContext returns a Command instance for 'config use-context' sub command
-func NewCmdConfigUseContext(out io.Writer, configAccess clientcmd.ConfigAccess) *cobra.Command {
-	options := &useContextOptions{configAccess: configAccess}
+func NewCmdConfigUseContext(streams genericclioptions.IOStreams, configAccess clientcmd.ConfigAccess) *cobra.Command {
+	options := &useContextOptions{
+		configAccess: configAccess,
+		IOStreams:    streams,
+	}
 
 	cmd := &cobra.Command{
 		Use:                   "use-context CONTEXT_NAME",
@@ -55,7 +60,7 @@ func NewCmdConfigUseContext(out io.Writer, configAccess clientcmd.ConfigAccess) 
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdutil.CheckErr(options.complete(cmd))
 			cmdutil.CheckErr(options.run())
-			fmt.Fprintf(out, "Switched to context %q.\n", options.contextName)
+			fmt.Fprintf(options.Out, "Switched to context %q.\n", options.contextName)
 		},
 	}
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/use_context_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/use_context_test.go
@@ -17,11 +17,11 @@ limitations under the License.
 package config
 
 import (
-	"bytes"
 	"io/ioutil"
 	"os"
 	"testing"
 
+	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
@@ -83,8 +83,9 @@ func (test useContextTest) run(t *testing.T) {
 	pathOptions := clientcmd.NewDefaultPathOptions()
 	pathOptions.GlobalFile = fakeKubeFile.Name()
 	pathOptions.EnvVar = ""
-	buf := bytes.NewBuffer([]byte{})
-	cmd := NewCmdConfigUseContext(buf, pathOptions)
+	ioStreams, _, out, _ := genericclioptions.NewTestIOStreams()
+	cmd := NewCmdConfigUseContext(ioStreams, pathOptions)
+	cmd.SetOut(out)
 	cmd.SetArgs(test.args)
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("unexpected error executing command: %v,kubectl config use-context args: %v", err, test.args)
@@ -94,8 +95,8 @@ func (test useContextTest) run(t *testing.T) {
 		t.Fatalf("unexpected error loading kubeconfig file: %v", err)
 	}
 	if len(test.expected) != 0 {
-		if buf.String() != test.expected {
-			t.Errorf("Failed in :%q\n expected %v\n, but got %v\n", test.description, test.expected, buf.String())
+		if out.String() != test.expected {
+			t.Errorf("Failed in :%q\n expected %v\n, but got %v\n", test.description, test.expected, out.String())
 		}
 	}
 	if test.expectedConfig.CurrentContext != config.CurrentContext {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->


/kind cleanup

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Resolve TODO `update all subcommands to work with genericclioptions.IOStreams`. This can keep all the config subcommands in the same pattern we arrange options in kubectl.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
none
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
