### PR TITLE
Remove duplicate code,maybe

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/cmd.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/cmd.go
@@ -509,11 +509,6 @@ func NewKubectlCommand(in io.Reader, out, err io.Writer) *cobra.Command {
 	}
 
 	flags := cmds.PersistentFlags()
-	flags.SetNormalizeFunc(cliflag.WarnWordSepNormalizeFunc) // Warn for "_" flags
-
-	// Normalize all flags that are coming from other packages or pre-configurations
-	// a.k.a. change all "_" to "-". e.g. glog package
-	flags.SetNormalizeFunc(cliflag.WordSepNormalizeFunc)
 
 	addProfilingFlags(flags)
 
@@ -538,7 +533,7 @@ func NewKubectlCommand(in io.Reader, out, err io.Writer) *cobra.Command {
 	i18n.LoadTranslations("kubectl", nil)
 
 	// From this point and forward we get warnings on flags that contain "_" separators
-	cmds.SetGlobalNormalizationFunc(cliflag.WarnWordSepNormalizeFunc)
+	cmds.SetGlobalNormalizationFunc(cliflag.WordSepNormalizeFunc)
 
 	ioStreams := genericclioptions.IOStreams{In: in, Out: out, ErrOut: err}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
https://github.com/kubernetes/kubernetes/blob/80ff14a47d583985acc21e7d450a62fee6da6b73/staging/src/k8s.io/kubectl/pkg/cmd/cmd.go#L511-L541
In the above code, `flags.SetNormalizeFunc` was called twice Continuously (line 512&516).And did the same thing again in the `SetGlobalNormalizationFunc`(line 541).
Why do the same thing three times? Are these steps necessary? 

And I noticed that `WarnWordSepNormalizeFunc` and `WordSepNormalizeFunc` both replace _ with "-". But in function `InitFlags` still use "_" initializing the flags. If use `WarnWordSepNormalizeFunc` as param to `SetGlobalNormalizationFunc`, I received the following warning Every time:

```

W0317 10:23:02.825284    2306 flags.go:39] skip_log_headers is DEPRECATED and will be removed in a future version. Use skip-log-headers instead.
W0317 10:23:02.826973    2306 flags.go:39] log_backtrace_at is DEPRECATED and will be removed in a future version. Use log-backtrace-at instead.
W0317 10:23:02.826989    2306 flags.go:39] log_file_max_size is DEPRECATED and will be removed in a future version. Use log-file-max-size instead.
W0317 10:23:02.827000    2306 flags.go:39] skip_headers is DEPRECATED and will be removed in a future version. Use skip-headers instead.
W0317 10:23:02.827013    2306 flags.go:39] log_dir is DEPRECATED and will be removed in a future version. Use log-dir instead.
W0317 10:23:02.827032    2306 flags.go:39] add_dir_header is DEPRECATED and will be removed in a future version. Use add-dir-header instead.
W0317 10:23:02.827043    2306 flags.go:39] one_output is DEPRECATED and will be removed in a future version. Use one-output instead.
W0317 10:23:02.827080    2306 flags.go:39] log_file is DEPRECATED and will be removed in a future version. Use log-file instead.
```

I tried to delete the lines 512&516 and modify param of `SetGlobalNormalizationFunc` to make sure don't output warning. Kubectl still seems to work properly. Is this right?
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
