### PR TITLE
kubeadm: support semver metadata imagetags for etcd during upgrades

### DIFF
--- a/cmd/kubeadm/app/phases/upgrade/staticpods.go
+++ b/cmd/kubeadm/app/phases/upgrade/staticpods.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/pkg/errors"
@@ -286,7 +287,8 @@ func performEtcdStaticPodUpgrade(certsRenewMgr *renewal.Manager, client clientse
 	// or the kubeadm preferred one for the desired Kubernetes version
 	var desiredEtcdVersion *version.Version
 	if cfg.Etcd.Local.ImageTag != "" {
-		desiredEtcdVersion, err = version.ParseSemantic(cfg.Etcd.Local.ImageTag)
+		desiredEtcdVersion, err = version.ParseSemantic(
+			ConvertImageTagMetadataToSemver(cfg.Etcd.Local.ImageTag))
 		if err != nil {
 			return true, errors.Wrapf(err, "failed to parse tag %q as a semantic version", cfg.Etcd.Local.ImageTag)
 		}
@@ -643,5 +645,14 @@ func GetEtcdImageTagFromStaticPod(manifestDir string) (string, error) {
 		return "", err
 	}
 
-	return image.TagFromImage(pod.Spec.Containers[0].Image), nil
+	return ConvertImageTagMetadataToSemver(image.TagFromImage(pod.Spec.Containers[0].Image)), nil
+}
+
+// ConvertImageTagMetadataToSemver converts imagetag in the format of semver_metadata to semver+metadata
+func ConvertImageTagMetadataToSemver(tag string) string {
+	// Container registries do not support `+` characters in tag names. This prevents imagetags from
+	// correctly representing semantic versions which use the plus symbol to delimit build metadata.
+	// Kubernetes uses the the convention of using an underscore in image registries to preserve
+	// build metadata information in imagetags.
+	return strings.Replace(tag, "_", "+", 1)
 }

--- a/cmd/kubeadm/app/phases/upgrade/staticpods.go
+++ b/cmd/kubeadm/app/phases/upgrade/staticpods.go
@@ -288,7 +288,7 @@ func performEtcdStaticPodUpgrade(certsRenewMgr *renewal.Manager, client clientse
 	var desiredEtcdVersion *version.Version
 	if cfg.Etcd.Local.ImageTag != "" {
 		desiredEtcdVersion, err = version.ParseSemantic(
-			ConvertImageTagMetadataToSemver(cfg.Etcd.Local.ImageTag))
+			convertImageTagMetadataToSemver(cfg.Etcd.Local.ImageTag))
 		if err != nil {
 			return true, errors.Wrapf(err, "failed to parse tag %q as a semantic version", cfg.Etcd.Local.ImageTag)
 		}
@@ -645,14 +645,14 @@ func GetEtcdImageTagFromStaticPod(manifestDir string) (string, error) {
 		return "", err
 	}
 
-	return ConvertImageTagMetadataToSemver(image.TagFromImage(pod.Spec.Containers[0].Image)), nil
+	return convertImageTagMetadataToSemver(image.TagFromImage(pod.Spec.Containers[0].Image)), nil
 }
 
-// ConvertImageTagMetadataToSemver converts imagetag in the format of semver_metadata to semver+metadata
-func ConvertImageTagMetadataToSemver(tag string) string {
+// convertImageTagMetadataToSemver converts imagetag in the format of semver_metadata to semver+metadata
+func convertImageTagMetadataToSemver(tag string) string {
 	// Container registries do not support `+` characters in tag names. This prevents imagetags from
 	// correctly representing semantic versions which use the plus symbol to delimit build metadata.
-	// Kubernetes uses the the convention of using an underscore in image registries to preserve
+	// Kubernetes uses the convention of using an underscore in image registries to preserve
 	// build metadata information in imagetags.
 	return strings.Replace(tag, "_", "+", 1)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:

During upgrades, kubeadm uses the ImageTag field to determine the current version of etcd running and the desired version of etcd the user maybe upgrading to. To do so, the imagetag is parsed directly as a semver. Unfortunately, container repositories do not support the `+` character within image tags. In the semantic versioning spec, `+` characters are used to delimit the version and build metadata. To work around this limitation for kubernetes images, the `+` delimiter is converted to a `_`. To support local etcd upgrade logic, I have continued this pattern for etcd imagetags containing build metadata. 


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #100349

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
[kubeadm] Support for custom imagetags for etcd images which contain build metadata, when imagetags are in the form of version_metadata. For instance, if the etcd version is v3.4.13+patch.0, the supported imagetag would be v3.4.13_patch.0
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
