### PR TITLE
Disable intree storage multivolume e2e test in windows nodes

### DIFF
--- a/test/e2e/storage/persistent_volumes.go
+++ b/test/e2e/storage/persistent_volumes.go
@@ -316,7 +316,12 @@ var _ = utils.SIGDescribe("PersistentVolumes", func() {
 		})
 	})
 
-	ginkgo.Describe("Default StorageClass", func() {
+	// testsuites/multivolume tests can now run with windows nodes
+	// This test is not compatible with windows because the default StorageClass
+	// doesn't have the ntfs parameter, we can't change the status of the cluster
+	// to add a StorageClass that's compatible with windows which is also the
+	// default StorageClass
+	ginkgo.Describe("Default StorageClass [LinuxOnly]", func() {
 		ginkgo.Context("pods that use multiple volumes", func() {
 
 			ginkgo.AfterEach(func() {
@@ -326,12 +331,6 @@ var _ = utils.SIGDescribe("PersistentVolumes", func() {
 			ginkgo.It("should be reschedulable [Slow]", func() {
 				// Only run on providers with default storageclass
 				e2eskipper.SkipUnlessProviderIs("openstack", "gce", "gke", "vsphere", "azure")
-				// testsuites/multivolume tests can now run with windows nodes
-				// This test is not compatible with windows because the default StorageClass
-				// doesn't have the ntfs parameter, we can't change the status of the cluster
-				// to add a StorageClass that's compatible with windows which is also the
-				// default StorageClass
-				e2eskipper.SkipIfNodeOSDistroIs("windows")
 
 				numVols := 4
 

--- a/test/e2e/storage/persistent_volumes.go
+++ b/test/e2e/storage/persistent_volumes.go
@@ -326,6 +326,12 @@ var _ = utils.SIGDescribe("PersistentVolumes", func() {
 			ginkgo.It("should be reschedulable [Slow]", func() {
 				// Only run on providers with default storageclass
 				e2eskipper.SkipUnlessProviderIs("openstack", "gce", "gke", "vsphere", "azure")
+				// testsuites/multivolume tests can now run with windows nodes
+				// This test is not compatible with windows because the default StorageClass
+				// doesn't have the ntfs parameter, we can't change the status of the cluster
+				// to add a StorageClass that's compatible with windows which is also the
+				// default StorageClass
+				e2eskipper.SkipIfNodeOSDistroIs("windows")
 
 				numVols := 4
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/sig storage

Optionally add one or more of the following kinds if applicable:

/kind failing-test

#### What this PR does / why we need it:

It makes the `Kubernetes e2e suite.[sig-storage] PersistentVolumes Default StorageClass pods that use multiple volumes should be reschedulable [Slow]` skip in windows nodes (seen in the dashboard https://testgrid.kubernetes.io/provider-gcp-compute-persistent-disk-csi-driver#ci-win2019-provider-gcp-compute-persistent-disk-csi-driver-migration&width=20)

~~The test is about testing the default storage class, for windows we need a StorageClass with `fsType=ntfs`, before the test is run a new windows compatible StorageClass is created and set to be the default storage class~~

Instead of changing the state of the cluster I focused on making the `testsuites/multivolume.go` tests work with windows nodes, see https://github.com/kubernetes/kubernetes/pull/100641

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

/cc @jingxu97 
