### PR TITLE
Run GCE unit tests as non-root

### DIFF
--- a/cluster/gce/gci/apiserver_etcd_test.go
+++ b/cluster/gce/gci/apiserver_etcd_test.go
@@ -17,26 +17,29 @@ limitations under the License.
 package gci
 
 import (
+	"os"
+	"strconv"
 	"strings"
 	"testing"
 )
 
 type kubeAPIServeETCDEnv struct {
-	KubeHome            string
-	ETCDServers         string
-	ETCDServersOverride string
-	CAKey               string
-	CACert              string
-	CACertPath          string
-	APIServerKey        string
-	APIServerCert       string
-	APIServerCertPath   string
-	APIServerKeyPath    string
-	ETCDKey             string
-	ETCDCert            string
-	StorageBackend      string
-	StorageMediaType    string
-	CompactionInterval  string
+	KubeHome               string
+	KubeAPIServerRunAsUser string
+	ETCDServers            string
+	ETCDServersOverride    string
+	CAKey                  string
+	CACert                 string
+	CACertPath             string
+	APIServerKey           string
+	APIServerCert          string
+	APIServerCertPath      string
+	APIServerKeyPath       string
+	ETCDKey                string
+	ETCDCert               string
+	StorageBackend         string
+	StorageMediaType       string
+	CompactionInterval     string
 }
 
 func TestServerOverride(t *testing.T) {
@@ -68,6 +71,7 @@ func TestServerOverride(t *testing.T) {
 			c := newManifestTestCase(t, kubeAPIServerManifestFileName, kubeAPIServerStartFuncName, nil)
 			defer c.tearDown()
 			tc.env.KubeHome = c.kubeHome
+			tc.env.KubeAPIServerRunAsUser = strconv.Itoa(os.Getuid())
 
 			c.mustInvokeFunc(
 				tc.env,
@@ -124,6 +128,7 @@ func TestStorageOptions(t *testing.T) {
 			c := newManifestTestCase(t, kubeAPIServerManifestFileName, kubeAPIServerStartFuncName, nil)
 			defer c.tearDown()
 			tc.env.KubeHome = c.kubeHome
+			tc.env.KubeAPIServerRunAsUser = strconv.Itoa(os.Getuid())
 
 			c.mustInvokeFunc(
 				tc.env,
@@ -188,6 +193,7 @@ func TestTLSFlags(t *testing.T) {
 			c := newManifestTestCase(t, kubeAPIServerManifestFileName, kubeAPIServerStartFuncName, nil)
 			defer c.tearDown()
 			tc.env.KubeHome = c.kubeHome
+			tc.env.KubeAPIServerRunAsUser = strconv.Itoa(os.Getuid())
 
 			c.mustInvokeFunc(
 				tc.env,

--- a/cluster/gce/gci/apiserver_kms_test.go
+++ b/cluster/gce/gci/apiserver_kms_test.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -38,6 +39,7 @@ const (
 
 type kubeAPIServerEnv struct {
 	KubeHome                     string
+	KubeAPIServerRunAsUser       string
 	EncryptionProviderConfigPath string
 	EncryptionProviderConfig     string
 	CloudKMSIntegration          bool
@@ -72,6 +74,7 @@ func TestEncryptionProviderFlag(t *testing.T) {
 
 			e := kubeAPIServerEnv{
 				KubeHome:                     c.kubeHome,
+				KubeAPIServerRunAsUser:       strconv.Itoa(os.Getuid()),
 				EncryptionProviderConfigPath: filepath.Join(c.kubeHome, "encryption-provider-config.yaml"),
 				EncryptionProviderConfig:     tc.encryptionProviderConfig,
 			}
@@ -107,6 +110,7 @@ func TestEncryptionProviderConfig(t *testing.T) {
 	p := filepath.Join(c.kubeHome, "encryption-provider-config.yaml")
 	e := kubeAPIServerEnv{
 		KubeHome:                     c.kubeHome,
+		KubeAPIServerRunAsUser:       strconv.Itoa(os.Getuid()),
 		EncryptionProviderConfigPath: p,
 		EncryptionProviderConfig:     base64.StdEncoding.EncodeToString([]byte("foo")),
 	}
@@ -177,6 +181,7 @@ func TestKMSIntegration(t *testing.T) {
 
 			var e = kubeAPIServerEnv{
 				KubeHome:                     c.kubeHome,
+				KubeAPIServerRunAsUser:       strconv.Itoa(os.Getuid()),
 				EncryptionProviderConfigPath: filepath.Join(c.kubeHome, "encryption-provider-config.yaml"),
 				EncryptionProviderConfig:     base64.StdEncoding.EncodeToString([]byte("foo")),
 				CloudKMSIntegration:          tc.cloudKMSIntegration,

--- a/cluster/gce/gci/testdata/kube-apiserver/etcd.template
+++ b/cluster/gce/gci/testdata/kube-apiserver/etcd.template
@@ -13,3 +13,4 @@ readonly ETCD_SERVERS_OVERRIDES={{.ETCDServersOverride}}
 readonly STORAGE_BACKEND={{.StorageBackend}}
 readonly STORAGE_MEDIA_TYPE={{.StorageMediaType}}
 readonly ETCD_COMPACTION_INTERVAL_SEC={{.CompactionInterval}}
+readonly KUBE_API_SERVER_RUNASUSER={{.KubeAPIServerRunAsUser}}

--- a/cluster/gce/gci/testdata/kube-apiserver/kms.template
+++ b/cluster/gce/gci/testdata/kube-apiserver/kms.template
@@ -6,3 +6,4 @@ ENCRYPTION_PROVIDER_CONFIG_PATH={{.EncryptionProviderConfigPath}}
 {{if .CloudKMSIntegration}}
   readonly CLOUD_KMS_INTEGRATION=true
 {{end}}
+readonly KUBE_API_SERVER_RUNASUSER={{.KubeAPIServerRunAsUser}}


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/sig testing
/priority backlog

#### What this PR does / why we need it:
This forces the unit test in `cluster/gce/cos/` to run as non-root user, which was introduced in https://github.com/kubernetes/kubernetes/pull/96134

#### Special notes for your reviewer:
/assign @BenTheElder 
since you looked at the other PR too

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
