### PR TITLE
Fix "Pod Disks schedule pods each with a PD" test in windows

### DIFF
--- a/test/e2e/framework/kubectl/kubectl_utils.go
+++ b/test/e2e/framework/kubectl/kubectl_utils.go
@@ -142,6 +142,10 @@ func (tk *TestKubeconfig) WriteFileViaContainer(podName, containerName string, p
 		}
 	}
 	command := fmt.Sprintf("echo '%s' > '%s'; sync", contents, path)
+	// TODO: replace with `framework.NodeOSDistroIs` when #81245 is complete
+	if e2epod.NodeOSDistroIs("windows") {
+		command = fmt.Sprintf("echo '%s' > '%s'; sleep 1", contents, path)
+	}
 	stdout, stderr, err := tk.kubectlExecWithRetry(tk.Namespace, podName, containerName, "--", "/bin/sh", "-c", command)
 	if err != nil {
 		e2elog.Logf("error running kubectl exec to write file: %v\nstdout=%v\nstderr=%v)", err, string(stdout), string(stderr))

--- a/test/e2e/framework/kubectl/kubectl_utils.go
+++ b/test/e2e/framework/kubectl/kubectl_utils.go
@@ -142,7 +142,7 @@ func (tk *TestKubeconfig) WriteFileViaContainer(podName, containerName string, p
 		}
 	}
 	command := fmt.Sprintf("echo '%s' > '%s'; sync", contents, path)
-	// TODO: replace with `framework.NodeOSDistroIs` when #81245 is complete
+	// TODO(mauriciopoppe): remove this statement once we add `sync` to the test image, ref #101172
 	if e2epod.NodeOSDistroIs("windows") {
 		command = fmt.Sprintf("echo '%s' > '%s';", contents, path)
 	}

--- a/test/e2e/framework/kubectl/kubectl_utils.go
+++ b/test/e2e/framework/kubectl/kubectl_utils.go
@@ -144,7 +144,7 @@ func (tk *TestKubeconfig) WriteFileViaContainer(podName, containerName string, p
 	command := fmt.Sprintf("echo '%s' > '%s'; sync", contents, path)
 	// TODO: replace with `framework.NodeOSDistroIs` when #81245 is complete
 	if e2epod.NodeOSDistroIs("windows") {
-		command = fmt.Sprintf("echo '%s' > '%s'; sleep 1", contents, path)
+		command = fmt.Sprintf("echo '%s' > '%s';", contents, path)
 	}
 	stdout, stderr, err := tk.kubectlExecWithRetry(tk.Namespace, podName, containerName, "--", "/bin/sh", "-c", command)
 	if err != nil {

--- a/test/e2e/storage/pd.go
+++ b/test/e2e/storage/pd.go
@@ -596,7 +596,7 @@ func testPDPod(diskNames []string, targetNode types.NodeName, readOnly bool, num
 		if numContainers > 1 {
 			containers[i].Name = fmt.Sprintf("mycontainer%v", i+1)
 		}
-		containers[i].Image = imageutils.GetE2EImage(imageutils.BusyBox)
+		containers[i].Image = e2epod.GetTestImage(imageutils.BusyBox)
 		containers[i].Command = []string{"sleep", "6000"}
 		containers[i].VolumeMounts = make([]v1.VolumeMount, len(diskNames))
 		for k := range diskNames {
@@ -636,7 +636,7 @@ func testPDPod(diskNames []string, targetNode types.NodeName, readOnly bool, num
 			pod.Spec.Volumes[k].VolumeSource = v1.VolumeSource{
 				GCEPersistentDisk: &v1.GCEPersistentDiskVolumeSource{
 					PDName:   diskName,
-					FSType:   "ext4",
+					FSType:   e2epv.GetDefaultFSType(),
 					ReadOnly: readOnly,
 				},
 			}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

Optionally add one or more of the following kinds if applicable:

/kind failing-test

#### What this PR does / why we need it:

Fixes the tests related with `Pod Disks schedule pods each with a PD` and `Pod Disks schedule a pod w/ RW PD(s) mounted to 1 or more containers, write to PD, verify content, delete pod, and repeat in rapid succession [Slow]` in windows nodes

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

/sig storage
/cc @jingxu97 
