### PR TITLE
Automated cherry pick of #99795: Increasing maximum number of ports allowed in EndpointSlice

### DIFF
--- a/pkg/apis/discovery/validation/validation.go
+++ b/pkg/apis/discovery/validation/validation.go
@@ -43,7 +43,7 @@ var (
 	)
 	maxTopologyLabels = 16
 	maxAddresses      = 100
-	maxPorts          = 100
+	maxPorts          = 20000
 	maxEndpoints      = 1000
 )
 


### PR DESCRIPTION
Cherry pick of #99795 on release-1.19.

#99795: Increasing maximum number of ports allowed in EndpointSlice

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Fixes a regression in 1.18+ where endpoint slice controller would attempt to create endpoint slices with too many ports; the maximum number of ports allowed in EndpointSlices has been increased from 100 to 20,000
```
