### PR TITLE
Revert "Automated cherry pick of #97417: fix azure file secret not found issue"

### DIFF
--- a/pkg/volume/azure_file/azure_file.go
+++ b/pkg/volume/azure_file/azure_file.go
@@ -55,8 +55,7 @@ var _ volume.PersistentVolumePlugin = &azureFilePlugin{}
 var _ volume.ExpandableVolumePlugin = &azureFilePlugin{}
 
 const (
-	azureFilePluginName    = "kubernetes.io/azure-file"
-	defaultSecretNamespace = "default"
+	azureFilePluginName = "kubernetes.io/azure-file"
 )
 
 func getPath(uid types.UID, volName string, host volume.VolumeHost) string {
@@ -116,7 +115,7 @@ func (plugin *azureFilePlugin) newMounterInternal(spec *volume.Spec, pod *v1.Pod
 	if err != nil {
 		return nil, err
 	}
-	secretName, secretNamespace, err := getSecretNameAndNamespace(spec, defaultSecretNamespace)
+	secretName, secretNamespace, err := getSecretNameAndNamespace(spec, pod.Namespace)
 	if err != nil {
 		// Log-and-continue instead of returning an error for now
 		// due to unspecified backwards compatibility concerns (a subject to revise)
@@ -171,7 +170,7 @@ func (plugin *azureFilePlugin) ExpandVolumeDevice(
 		return oldSize, err
 	}
 
-	secretName, secretNamespace, err := getSecretNameAndNamespace(spec, defaultSecretNamespace)
+	secretName, secretNamespace, err := getSecretNameAndNamespace(spec, spec.PersistentVolume.Spec.ClaimRef.Namespace)
 	if err != nil {
 		return oldSize, err
 	}

--- a/pkg/volume/azure_file/azure_provision.go
+++ b/pkg/volume/azure_file/azure_provision.go
@@ -71,7 +71,7 @@ func (plugin *azureFilePlugin) newDeleterInternal(spec *volume.Spec, util azureU
 		return nil, fmt.Errorf("invalid PV spec")
 	}
 
-	secretName, secretNamespace, err := getSecretNameAndNamespace(spec, defaultSecretNamespace)
+	secretName, secretNamespace, err := getSecretNameAndNamespace(spec, spec.PersistentVolume.Spec.ClaimRef.Namespace)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Reverts kubernetes/kubernetes#97453

```release-note
Reverts breaking change to inline AzureFile volumes in v1.18.15-v1.18.17; referenced secrets are now correctly searched for in the same namespace as the pod as in previous releases.
```
