### PR TITLE
fix typo in retry doc

### DIFF
--- a/staging/src/k8s.io/client-go/util/retry/util.go
+++ b/staging/src/k8s.io/client-go/util/retry/util.go
@@ -79,7 +79,7 @@ func OnError(backoff wait.Backoff, retriable func(error) bool, fn func() error) 
 //         // if you got a conflict on the last update attempt then you need to get
 //         // the current version before making your own changes.
 //         pod, err := c.Pods("mynamespace").Get(name, metav1.GetOptions{})
-//         if err ! nil {
+//         if err != nil {
 //             return err
 //         }
 //


### PR DESCRIPTION
#### What type of PR is this?

Fixing typo in retry docstring

/kind documentation

#### Does this PR introduce a user-facing change?

```release-note
NONE
```