### PR TITLE
Automated cherry pick of #97431: additional subnet configuration for AWS ELB

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/aws/tags.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/aws/tags.go
@@ -152,6 +152,15 @@ func (t *awsTagging) hasClusterTag(tags []*ec2.Tag) bool {
 	return false
 }
 
+func (t *awsTagging) hasNoClusterPrefixTag(tags []*ec2.Tag) bool {
+	for _, tag := range tags {
+		if strings.HasPrefix(aws.StringValue(tag.Key), TagNameKubernetesClusterPrefix) {
+			return false
+		}
+	}
+	return true
+}
+
 // Ensure that a resource has the correct tags
 // If it has no tags, we assume that this was a problem caused by an error in between creation and tagging,
 // and we add the tags.  If it has a different cluster's tags, that is an error.

--- a/staging/src/k8s.io/legacy-cloud-providers/aws/tags_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/aws/tags_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestFilterTags(t *testing.T) {
@@ -180,5 +181,54 @@ func TestHasClusterTag(t *testing.T) {
 		if result != g.Expected {
 			t.Errorf("Unexpected result for tags %v: %t", g.Tags, result)
 		}
+	}
+}
+
+func TestHasNoClusterPrefixTag(t *testing.T) {
+	awsServices := NewFakeAWSServices(TestClusterID)
+	c, err := newAWSCloud(CloudConfig{}, awsServices)
+	if err != nil {
+		t.Errorf("Error building aws cloud: %v", err)
+		return
+	}
+	tests := []struct {
+		name string
+		tags []*ec2.Tag
+		want bool
+	}{
+		{
+			name: "no tags",
+			want: true,
+		},
+		{
+			name: "no cluster tags",
+			tags: []*ec2.Tag{
+				{
+					Key:   aws.String("not a cluster tag"),
+					Value: aws.String("true"),
+				},
+			},
+			want: true,
+		},
+		{
+			name: "contains cluster tags",
+			tags: []*ec2.Tag{
+				{
+					Key:   aws.String("tag1"),
+					Value: aws.String("value1"),
+				},
+				{
+					Key:   aws.String("kubernetes.io/cluster/test.cluster"),
+					Value: aws.String("owned"),
+				},
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, c.tagging.hasNoClusterPrefixTag(tt.tags))
+		})
 	}
 }


### PR DESCRIPTION
Cherry pick of #97431 on release-1.20.

#97431: additional subnet configuration for AWS ELB

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.