### PR TITLE
Promote EndpointSlice API test to Conformance

### DIFF
--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -1213,6 +1213,16 @@
     named "kubernetes" in the default namespace.
   release: v1.21
   file: test/e2e/network/endpointslice.go
+- testname: EndpointSlice API
+  codename: '[sig-network] EndpointSlice should support creating EndpointSlice API
+    operations [Conformance]'
+  description: The discovery.k8s.io API group MUST exist in the /apis discovery document.
+    The discovery.k8s.io/v1 API group/version MUST exist in the /apis/discovery.k8s.io
+    discovery document. The endpointslices resource MUST exist in the /apis/discovery.k8s.io/v1
+    discovery document. The endpointslices resource must support create, get, list,
+    watch, update, patch, delete, and deletecollection.
+  release: v1.21
+  file: test/e2e/network/endpointslice.go
 - testname: EndpointSlice Mirroring
   codename: '[sig-network] EndpointSliceMirroring should mirror a custom Endpoints
     resource through create update and delete [Conformance]'

--- a/test/e2e/network/endpointslice.go
+++ b/test/e2e/network/endpointslice.go
@@ -332,7 +332,15 @@ var _ = common.SIGDescribe("EndpointSlice", func() {
 		expectEndpointsAndSlices(cs, f.Namespace.Name, svc2, []*v1.Pod{pod1, pod2}, 2, 2, true)
 	})
 
-	ginkgo.It("should support creating EndpointSlice API operations", func() {
+	/*
+		Release: v1.21
+		Testname: EndpointSlice API
+		Description: The discovery.k8s.io API group MUST exist in the /apis discovery document.
+		The discovery.k8s.io/v1 API group/version MUST exist in the /apis/discovery.k8s.io discovery document.
+		The endpointslices resource MUST exist in the /apis/discovery.k8s.io/v1 discovery document.
+		The endpointslices resource must support create, get, list, watch, update, patch, delete, and deletecollection.
+	*/
+	framework.ConformanceIt("should support creating EndpointSlice API operations", func() {
 		// Setup
 		ns := f.Namespace.Name
 		epsVersion := "v1"


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
This PR promotes the last EndpointPoint Slice API e2e test to conformance.

#### Special notes for your reviewer:
This e2e test was introduced into testgrid on 3/10: https://testgrid.k8s.io/sig-release-master-blocking#gce-cos-master-default&include-filter-by-regex=EndpointSlice&width=5 and has been flake free. It will qualify on 3/24 and this PR can be merged then.

This will add the remaining coverage needed for the v1 EndpointSlice APIs:
https://apisnoop.cncf.io/1.21.0/stable/discovery

<img width="1048" alt="Screen Shot 2021-03-19 at 4 38 42 PM" src="https://user-images.githubusercontent.com/1980422/111851714-95efdf80-88d1-11eb-8c80-a94cc8b2ebdf.png">


#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
KEP: [EndpointSlice KEP](https://github.com/kubernetes/enhancements/blob/8413469b89851d094eb22813a06594bd4a6d36a4/keps/sig-network/0752-endpointslices/README.md)
Enhancement Issue: kubernetes/enhancements#752

/sig network
/sig testing
/cc @Riaankl @hh @robscott @aojea 
/assign @thockin 