### PR TITLE
Fix staticcheck failures for vendor/k8s.io/apiserver/pkg/storage

### DIFF
--- a/hack/.staticcheck_failures
+++ b/hack/.staticcheck_failures
@@ -16,10 +16,6 @@ vendor/k8s.io/apiserver/pkg/server/dynamiccertificates
 vendor/k8s.io/apiserver/pkg/server/filters
 vendor/k8s.io/apiserver/pkg/server/httplog
 vendor/k8s.io/apiserver/pkg/server/routes
-vendor/k8s.io/apiserver/pkg/storage
-vendor/k8s.io/apiserver/pkg/storage/cacher
-vendor/k8s.io/apiserver/pkg/storage/tests
-vendor/k8s.io/apiserver/pkg/storage/value/encrypt/envelope
 vendor/k8s.io/apiserver/pkg/util/webhook
 vendor/k8s.io/apiserver/pkg/util/wsstream
 vendor/k8s.io/client-go/discovery

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_whitebox_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_whitebox_test.go
@@ -663,7 +663,8 @@ func TestCacherNoLeakWithMultipleWatchers(t *testing.T) {
 				ctx, _ := context.WithTimeout(context.Background(), 3*time.Second)
 				w, err := cacher.Watch(ctx, "pods/ns", storage.ListOptions{ResourceVersion: "0", Predicate: pred})
 				if err != nil {
-					t.Fatalf("Failed to create watch: %v", err)
+					t.Errorf("Failed to create watch: %v", err)
+					return
 				}
 				w.Stop()
 			}
@@ -731,7 +732,8 @@ func testCacherSendBookmarkEvents(t *testing.T, allowWatchBookmarks, expectedBoo
 					ResourceVersion: fmt.Sprintf("%v", resourceVersion+uint64(i)),
 				}})
 			if err != nil {
-				t.Fatalf("failed to add a pod: %v", err)
+				t.Errorf("failed to add a pod: %v", err)
+				return
 			}
 			time.Sleep(100 * time.Millisecond)
 		}
@@ -924,9 +926,9 @@ func TestDispatchingBookmarkEventsWithConcurrentStop(t *testing.T) {
 
 		select {
 		case <-done:
-			break
 		case <-time.After(time.Second):
-			t.Fatal("receive result timeout")
+			t.Errorf("receive result timeout")
+			return
 		}
 		w.Stop()
 		wg.Wait()
@@ -980,7 +982,8 @@ func TestBookmarksOnResourceVersionUpdates(t *testing.T) {
 		for {
 			event, ok := <-w.ResultChan()
 			if !ok {
-				t.Fatalf("Unexpected closed channel")
+				t.Errorf("Unexpected closed channel")
+				return
 			}
 			rv, err := cacher.versioner.ObjectResourceVersion(event.Object)
 			if err != nil {

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/caching_object_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/caching_object_test.go
@@ -149,7 +149,8 @@ func TestCachingObjectRaces(t *testing.T) {
 			}
 			accessor, err := meta.Accessor(object.GetObject())
 			if err != nil {
-				t.Fatalf("failed to get accessor: %v", err)
+				t.Errorf("failed to get accessor: %v", err)
+				return
 			}
 			if selfLink := accessor.GetSelfLink(); selfLink != "selfLink" {
 				t.Errorf("unexpected selfLink: %s", selfLink)

--- a/staging/src/k8s.io/apiserver/pkg/storage/selection_predicate_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/selection_predicate_test.go
@@ -30,17 +30,9 @@ type Ignored struct {
 	ID string
 }
 
-type IgnoredList struct {
-	Items []Ignored
-}
-
 func (obj *Ignored) GetObjectKind() schema.ObjectKind     { return schema.EmptyObjectKind }
-func (obj *IgnoredList) GetObjectKind() schema.ObjectKind { return schema.EmptyObjectKind }
 func (obj *Ignored) DeepCopyObject() runtime.Object {
 	panic("Ignored does not support DeepCopy")
-}
-func (obj *IgnoredList) DeepCopyObject() runtime.Object {
-	panic("IgnoredList does not support DeepCopy")
 }
 
 func TestSelectionPredicate(t *testing.T) {

--- a/staging/src/k8s.io/apiserver/pkg/storage/tests/cacher_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/tests/cacher_test.go
@@ -901,7 +901,8 @@ func TestWatchBookmarksWithCorrectResourceVersion(t *testing.T) {
 				pod := fmt.Sprintf("foo-%d", i)
 				err := createPod(etcdStorage, makeTestPod(pod))
 				if err != nil {
-					t.Fatalf("failed to create pod %v: %v", pod, err)
+					t.Errorf("failed to create pod %v: %v", pod, err)
+					return
 				}
 				time.Sleep(time.Second / 100)
 			}

--- a/staging/src/k8s.io/apiserver/pkg/storage/value/encrypt/envelope/grpc_service_unix_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/value/encrypt/envelope/grpc_service_unix_test.go
@@ -138,7 +138,7 @@ func TestTimeouts(t *testing.T) {
 
 				service, err = NewGRPCService(socketName.endpoint, tt.callTimeout)
 				if err != nil {
-					t.Fatalf("failed to create envelope service, error: %v", err)
+					t.Errorf("failed to create envelope service, error: %v", err)
 				}
 				defer destroyService(service)
 				kubeAPIServerWG.Done()
@@ -153,10 +153,10 @@ func TestTimeouts(t *testing.T) {
 
 				f, err := mock.NewBase64Plugin(socketName.path)
 				if err != nil {
-					t.Fatalf("failed to construct test KMS provider server, error: %v", err)
+					t.Errorf("failed to construct test KMS provider server, error: %v", err)
 				}
 				if err := f.Start(); err != nil {
-					t.Fatalf("Failed to start test KMS provider server, error: %v", err)
+					t.Errorf("Failed to start test KMS provider server, error: %v", err)
 				}
 				defer f.CleanUp()
 				kmsPluginWG.Done()
@@ -228,7 +228,7 @@ func TestIntermittentConnectionLoss(t *testing.T) {
 		wg1.Done()
 		_, err := service.Encrypt(data)
 		if err != nil {
-			t.Fatalf("failed when executing encrypt, error: %v", err)
+			t.Errorf("failed when executing encrypt, error: %v", err)
 		}
 	}()
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Part of #92402
`vendor/k8s.io/apiserver/pkg/storage/selection_predicate_test.go:33:6: type IgnoredList is unused (U1000)`

`vendor/k8s.io/apiserver/pkg/storage/cacher/cacher_whitebox_test.go:656:2: the goroutine calls T.Fatalf, which must be called in the same goroutine as the test (SA2002) `
`vendor/k8s.io/apiserver/pkg/storage/cacher/cacher_whitebox_test.go:666:6: call to T.Fatalf 
vendor/k8s.io/apiserver/pkg/storage/cacher/cacher_whitebox_test.go:724:2: the goroutine calls T.Fatalf, which must be called in the same goroutine as the test (SA2002)`
`vendor/k8s.io/apiserver/pkg/storage/cacher/cacher_whitebox_test.go:734:5: call to T.Fatalf
vendor/k8s.io/apiserver/pkg/storage/cacher/cacher_whitebox_test.go:927:4: ineffective break statement. Did you mean to break out of the outer loop? (SA4011)`
`vendor/k8s.io/apiserver/pkg/storage/cacher/cacher_whitebox_test.go:978:2: the goroutine calls T.Fatalf, which must be called in the same goroutine as the test (SA2002)`
`vendor/k8s.io/apiserver/pkg/storage/cacher/cacher_whitebox_test.go:983:5: call to T.Fatalf`

`vendor/k8s.io/apiserver/pkg/storage/cacher/caching_object_test.go:137:3: the goroutine calls T.Fatalf, which must be called in the same goroutine as the test (SA2002)`
`vendor/k8s.io/apiserver/pkg/storage/cacher/caching_object_test.go:152:5: call to T.Fatalf
vendor/k8s.io/apiserver/pkg/storage/tests/cacher_test.go:894:2: the goroutine calls T.Fatalf, which must be called in the same goroutine as the test (SA2002)`
`vendor/k8s.io/apiserver/pkg/storage/tests/cacher_test.go:904:6: call to T.Fatalf`

`vendor/k8s.io/apiserver/pkg/storage/value/encrypt/envelope/grpc_service_unix_test.go:135:4: the goroutine calls T.Fatalf, which must be called in the same goroutine as the test (SA2002)
vendor/k8s.io/apiserver/pkg/storage/value/encrypt/envelope/grpc_service_unix_test.go:141:6: call to T.Fatalf
vendor/k8s.io/apiserver/pkg/storage/value/encrypt/envelope/grpc_service_unix_test.go:150:4: the goroutine calls T.Fatalf, which must be called in the same goroutine as the test (SA2002)
vendor/k8s.io/apiserver/pkg/storage/value/encrypt/envelope/grpc_service_unix_test.go:159:6: call to T.Fatalf
vendor/k8s.io/apiserver/pkg/storage/value/encrypt/envelope/grpc_service_unix_test.go:224:2: the goroutine calls T.Fatalf, which must be called in the same goroutine as the test (SA2002)
vendor/k8s.io/apiserver/pkg/storage/value/encrypt/envelope/grpc_service_unix_test.go:231:4: call to T.Fatalf`
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
