### PR TITLE
Fix staticcheck failures for vendor/k8s.io/client-go/transport

### DIFF
--- a/hack/.staticcheck_failures
+++ b/hack/.staticcheck_failures
@@ -25,4 +25,3 @@ vendor/k8s.io/apiserver/pkg/util/wsstream
 vendor/k8s.io/client-go/discovery
 vendor/k8s.io/client-go/rest
 vendor/k8s.io/client-go/rest/watch
-vendor/k8s.io/client-go/transport

--- a/staging/src/k8s.io/client-go/transport/token_source_test.go
+++ b/staging/src/k8s.io/client-go/transport/token_source_test.go
@@ -140,16 +140,23 @@ func TestCachingTokenSourceRace(t *testing.T) {
 
 		var wg sync.WaitGroup
 		wg.Add(100)
+		errc := make(chan error)
 
 		for i := 0; i < 100; i++ {
 			go func() {
 				defer wg.Done()
 				if _, err := ts.Token(); err != nil {
-					t.Fatalf("err: %v", err)
+					errc <- err
 				}
 			}()
 		}
-		wg.Wait()
+		go func() {
+			wg.Wait()
+			close(errc)
+		}()
+		if err, ok := <-errc; ok {
+			t.Fatalf("err: %v", err)
+		}
 		if tts.calls != 1 {
 			t.Errorf("expected one call to Token() but saw: %d", tts.calls)
 		}

--- a/staging/src/k8s.io/client-go/transport/token_source_test.go
+++ b/staging/src/k8s.io/client-go/transport/token_source_test.go
@@ -140,7 +140,7 @@ func TestCachingTokenSourceRace(t *testing.T) {
 
 		var wg sync.WaitGroup
 		wg.Add(100)
-		errc := make(chan error)
+		errc := make(chan error, 100)
 
 		for i := 0; i < 100; i++ {
 			go func() {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Part of #92402

```
vendor/k8s.io/client-go/transport/token_source_test.go:145:4: the goroutine calls T.Fatalf, which must be called in the same goroutine as the test (SA2002)
vendor/k8s.io/client-go/transport/token_source_test.go:148:6: call to T.Fatalf
```

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:


```docs

```
