### PR TITLE
Fix staticcheck failures for vendor/k8s.io/apimachinery/pkg/runtime

### DIFF
--- a/hack/.staticcheck_failures
+++ b/hack/.staticcheck_failures
@@ -3,7 +3,6 @@ pkg/controller/replicaset
 pkg/kubelet/dockershim
 vendor/k8s.io/apimachinery/pkg/api/apitesting/roundtrip
 vendor/k8s.io/apimachinery/pkg/apis/meta/v1/validation
-vendor/k8s.io/apimachinery/pkg/runtime/serializer/json
 vendor/k8s.io/apimachinery/pkg/util/httpstream/spdy
 vendor/k8s.io/apimachinery/pkg/util/net
 vendor/k8s.io/apimachinery/pkg/util/sets/types

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/json/meta_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/json/meta_test.go
@@ -38,7 +38,7 @@ func TestSimpleMetaFactoryInterpret(t *testing.T) {
 	}
 
 	// unparsable
-	gvk, err = factory.Interpret([]byte(`{`))
+	_, err = factory.Interpret([]byte(`{`))
 	if err == nil {
 		t.Errorf("unexpected non-error")
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Part of #92402

```
vendor/k8s.io/apimachinery/pkg/runtime/serializer/json/meta_test.go:41:2: this value of gvk is never used (SA4006)
```

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:


```docs

```
