### PR TITLE
test: Use bytes.Buffer.String

### DIFF
--- a/pkg/util/iptables/iptables_test.go
+++ b/pkg/util/iptables/iptables_test.go
@@ -797,8 +797,8 @@ COMMIT
 		t.Fatalf("%s: Expected success, got %v", protocol, err)
 	}
 
-	if string(buffer.Bytes()) != output {
-		t.Errorf("%s: Expected output '%s', got '%v'", protocol, output, string(buffer.Bytes()))
+	if buffer.String() != output {
+		t.Errorf("%s: Expected output '%s', got '%v'", protocol, output, buffer.String())
 	}
 
 	if fcmd.CombinedOutputCalls != 1 {
@@ -817,8 +817,8 @@ COMMIT
 	if err == nil {
 		t.Errorf("%s: Expected failure", protocol)
 	}
-	if string(buffer.Bytes()) != stderrOutput {
-		t.Errorf("%s: Expected output '%s', got '%v'", protocol, stderrOutput, string(buffer.Bytes()))
+	if buffer.String() != stderrOutput {
+		t.Errorf("%s: Expected output '%s', got '%v'", protocol, stderrOutput, buffer.String())
 	}
 }
 


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
Fix some warnings from go-staticcheck.

"should use buffer.String() instead of string(buffer.Bytes()) (S1030)"

This warning is explained at this link.
https://staticcheck.io/docs/checks#S1030

#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
```
