### PR TITLE
fix e2e ingress test, when we enable the ingress webhook

### DIFF
--- a/test/e2e/network/ingress.go
+++ b/test/e2e/network/ingress.go
@@ -1015,10 +1015,6 @@ var _ = common.SIGDescribe("Ingress API", func() {
 
 		// Ingress resource create/read/update/watch verbs
 		ginkgo.By("creating")
-		_, err := ingClient.Create(context.TODO(), ingTemplate, metav1.CreateOptions{})
-		framework.ExpectNoError(err)
-		_, err = ingClient.Create(context.TODO(), ingTemplate, metav1.CreateOptions{})
-		framework.ExpectNoError(err)
 		createdIngress, err := ingClient.Create(context.TODO(), ingTemplate, metav1.CreateOptions{})
 		framework.ExpectNoError(err)
 


### PR DESCRIPTION
Signed-off-by: Xianglin Gao <xianglin.gxl@alibaba-inc.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:


-->

#### What this PR does / why we need it:
When we run the e2e test against a k8s cluster installed with a ingress webhook(https://github.com/kubernetes/ingress-nginx/blob/5f1a37a624ca38e8cccc87cb7a36d7dbcbe70b01/deploy/static/provider/baremetal/deploy.yaml#L586), we will get this failure. 

```
[sig-network] Ingress API
  should support creating Ingress API operations [Conformance]
  /workspace/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:629
[BeforeEach] [sig-network] Ingress API
  /workspace/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:174
STEP: Creating a kubernetes client
Mar 22 06:54:11.386: INFO: >>> kubeConfig: /tmp/kubeconfig-926267848
STEP: Building a namespace api object, basename ingress
STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in ingress-2026
STEP: Waiting for a default service account to be provisioned in namespace
[It] should support creating Ingress API operations [Conformance]
  /workspace/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:629
STEP: getting /apis
STEP: getting /apis/networking.k8s.io
STEP: getting /apis/networking.k8s.iov1
STEP: creating
Mar 22 06:54:11.558: FAIL: Unexpected error:
    <*errors.StatusError | 0xc000bf75e0>: {
        ErrStatus: {
            TypeMeta: {Kind: "", APIVersion: ""},
            ListMeta: {
                SelfLink: "",
                ResourceVersion: "",
                Continue: "",
                RemainingItemCount: nil,
            },
            Status: "Failure",
            Message: "admission webhook \"validate.nginx.ingress.kubernetes.io\" denied the request: host \"foo.bar.com\" and path \"/\" is already defined in ingress ingress-2026/e2e-example-ingfddnc",
            Reason: "BadRequest",
            Details: nil,
            Code: 400,
        },
    }
    admission webhook "validate.nginx.ingress.kubernetes.io" denied the request: host "foo.bar.com" and path "/" is already defined in ingress ingress-2026/e2e-example-ingfddnc
occurred
```
Look like we get this failure, since we create the same ingress too many times.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
