### PR TITLE
test/utils/image: remove listx from OWNERS

### DIFF
--- a/test/utils/image/OWNERS
+++ b/test/utils/image/OWNERS
@@ -4,12 +4,10 @@ reviewers:
   - justaugustus
   - luxas
   - mkumatag
-  - listx
   - dims
 approvers:
   - luxas
   - mkumatag
-  - listx
   - dims
 emeritus_approvers:
   - ixdy


### PR DESCRIPTION
Removing myself from OWNERS as I haven't had the bandwidth to go over
these reviews for a long time.

This should have been part of #99718, which has already been merged.

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:


```docs

```
