### PR TITLE
Fix nil ptr dereference in log line

### DIFF
--- a/pkg/kubelet/volumemanager/reconciler/reconciler.go
+++ b/pkg/kubelet/volumemanager/reconciler/reconciler.go
@@ -404,11 +404,11 @@ func (rc *reconciler) syncStates() {
 			if volumeInDSW {
 				// Some pod needs the volume, don't clean it up and hope that
 				// reconcile() calls SetUp and reconstructs the volume in ASW.
-				klog.V(4).InfoS("Volume exists in desired state, skip cleaning up mounts", "pod", klog.KObj(reconstructedVolume.pod), "volumeSpecName", volume.volumeSpecName)
+				klog.V(4).InfoS("Volume exists in desired state, skip cleaning up mounts", "podName", volume.podName, "volumeSpecName", volume.volumeSpecName)
 				continue
 			}
 			// No pod needs the volume.
-			klog.InfoS("Could not construct volume information, cleaning up mounts", "pod", klog.KObj(reconstructedVolume.pod), "volumeSpecName", volume.volumeSpecName, "error", err)
+			klog.InfoS("Could not construct volume information, cleaning up mounts", "podName", volume.podName, "volumeSpecName", volume.volumeSpecName, "error", err)
 			rc.cleanupMounts(volume)
 			continue
 		}


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/kind failing-test
/sig storage

#### What this PR does / why we need it:
Fixes a nil pointer deference in a log line that prevents volume mounts from being cleaned up.

[See this comment](https://github.com/kubernetes/kubernetes/issues/100419#issuecomment-804438631) on the attached issue for more context.

#### Which issue(s) this PR fixes:
Fixes #100419

#### Does this PR introduce a user-facing change?
```release-note
NONE
```