### PR TITLE
WIP: Update e2e test images url

### DIFF
--- a/hack/testdata/pod-with-large-name.yaml
+++ b/hack/testdata/pod-with-large-name.yaml
@@ -8,4 +8,4 @@ metadata:
 spec:
   containers:
   - name: kubernetes-serve-hostname
-    image: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.1
+    image: k8s.gcr.io/e2e-test-images/serve-hostname-amd64:1.1

--- a/staging/src/k8s.io/sample-apiserver/artifacts/example/deployment.yaml
+++ b/staging/src/k8s.io/sample-apiserver/artifacts/example/deployment.yaml
@@ -20,8 +20,8 @@ spec:
       - name: wardle-server
         # build from staging/src/k8s.io/sample-apiserver/artifacts/simple-image/Dockerfile
         # or
-        # docker pull gcr.io/kubernetes-e2e-test-images/sample-apiserver:1.17
-        # docker tag gcr.io/kubernetes-e2e-test-images/sample-apiserver:1.17 kube-sample-apiserver:latest
+        # docker pull k8s.gcr.io/e2e-test-images/sample-apiserver:1.17
+        # docker tag k8s.gcr.io/e2e-test-images/sample-apiserver:1.17 kube-sample-apiserver:latest
         image: kube-sample-apiserver:latest
         imagePullPolicy: Never
         args: [ "--etcd-servers=http://localhost:2379" ]

--- a/test/e2e/testing-manifests/ingress/gce/static-ip-2/rc.yaml
+++ b/test/e2e/testing-manifests/ingress/gce/static-ip-2/rc.yaml
@@ -11,6 +11,6 @@ spec:
     spec:
       containers:
       - name: echoheaders-https
-        image: gcr.io/kubernetes-e2e-test-images/echoserver:2.2
+        image: k8s.gcr.io/e2e-test-images/echoserver:2.3
         ports:
         - containerPort: 8080

--- a/test/e2e/testing-manifests/ingress/http/rc.yaml
+++ b/test/e2e/testing-manifests/ingress/http/rc.yaml
@@ -11,7 +11,7 @@ spec:
     spec:
       containers:
       - name: echoheaders
-        image: gcr.io/kubernetes-e2e-test-images/echoserver:2.2
+        image: k8s.gcr.io/e2e-test-images/echoserver:2.3
         ports:
         - containerPort: 8080
         readinessProbe:

--- a/test/e2e/testing-manifests/ingress/http2/rc.yaml
+++ b/test/e2e/testing-manifests/ingress/http2/rc.yaml
@@ -14,6 +14,6 @@ spec:
     spec:
       containers:
       - name: echoheaders
-        image: gcr.io/kubernetes-e2e-test-images/echoserver:2.2
+        image: k8s.gcr.io/e2e-test-images/echoserver:2.3
         ports:
         - containerPort: 8443

--- a/test/e2e/testing-manifests/ingress/multiple-certs/rc.yaml
+++ b/test/e2e/testing-manifests/ingress/multiple-certs/rc.yaml
@@ -11,6 +11,6 @@ spec:
     spec:
       containers:
       - name: echoheaders-https
-        image: gcr.io/kubernetes-e2e-test-images/echoserver:2.2
+        image: k8s.gcr.io/e2e-test-images/echoserver:2.3
         ports:
         - containerPort: 8080

--- a/test/e2e/testing-manifests/ingress/neg-clusterip/rc.yaml
+++ b/test/e2e/testing-manifests/ingress/neg-clusterip/rc.yaml
@@ -15,7 +15,7 @@ spec:
         run: hostname
     spec:
       containers:
-      - image: gcr.io/kubernetes-e2e-test-images/serve-hostname:1.1
+      - image: k8s.gcr.io/e2e-test-images/serve-hostname:1.1
         imagePullPolicy: IfNotPresent
         name: hostname
       terminationGracePeriodSeconds: 120

--- a/test/e2e/testing-manifests/ingress/neg-exposed/rc.yaml
+++ b/test/e2e/testing-manifests/ingress/neg-exposed/rc.yaml
@@ -14,7 +14,7 @@ spec:
         run: hostname
     spec:
       containers:
-      - image: gcr.io/kubernetes-e2e-test-images/serve-hostname:1.1
+      - image: k8s.gcr.io/e2e-test-images/serve-hostname:1.1
         name: host1
         command:
         - /bin/sh
@@ -23,7 +23,7 @@ spec:
         ports:
         - protocol: TCP
           containerPort: 8000
-      - image: gcr.io/kubernetes-e2e-test-images/serve-hostname:1.1
+      - image: k8s.gcr.io/e2e-test-images/serve-hostname:1.1
         name: host2
         command:
         - /bin/sh

--- a/test/e2e/testing-manifests/ingress/neg/rc.yaml
+++ b/test/e2e/testing-manifests/ingress/neg/rc.yaml
@@ -15,7 +15,7 @@ spec:
         run: hostname
     spec:
       containers:
-      - image: gcr.io/kubernetes-e2e-test-images/serve-hostname:1.1
+      - image: k8s.gcr.io/e2e-test-images/serve-hostname:1.1
         imagePullPolicy: IfNotPresent
         name: hostname
       terminationGracePeriodSeconds: 120

--- a/test/e2e/testing-manifests/ingress/pre-shared-cert/rc.yaml
+++ b/test/e2e/testing-manifests/ingress/pre-shared-cert/rc.yaml
@@ -11,6 +11,6 @@ spec:
     spec:
       containers:
       - name: echoheaders-https
-        image: gcr.io/kubernetes-e2e-test-images/echoserver:2.2
+        image: k8s.gcr.io/e2e-test-images/echoserver:2.3
         ports:
         - containerPort: 8080

--- a/test/e2e/testing-manifests/ingress/static-ip/rc.yaml
+++ b/test/e2e/testing-manifests/ingress/static-ip/rc.yaml
@@ -11,6 +11,6 @@ spec:
     spec:
       containers:
       - name: echoheaders-https
-        image: gcr.io/kubernetes-e2e-test-images/echoserver:2.2
+        image: k8s.gcr.io/e2e-test-images/echoserver:2.3
         ports:
         - containerPort: 8080

--- a/test/e2e/testing-manifests/kubectl/agnhost-primary-pod.yaml
+++ b/test/e2e/testing-manifests/kubectl/agnhost-primary-pod.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   containers:
     - name: primary
-      image: gcr.io/kubernetes-e2e-test-images/agnhost:1.0
+      image: k8s.gcr.io/e2e-test-images/agnhost:2.30
       env:
         - name: PRIMARY
           value: "true"
@@ -21,7 +21,7 @@ spec:
         - mountPath: /agnhost-primary-data
           name: data
     - name: sentinel
-      image: gcr.io/kubernetes-e2e-test-images/agnhost:1.0
+      image: k8s.gcr.io/e2e-test-images/agnhost:2.30
       env:
         - name: SENTINEL
           value: "true"

--- a/test/e2e/testing-manifests/serviceloadbalancer/netexecrc.yaml
+++ b/test/e2e/testing-manifests/serviceloadbalancer/netexecrc.yaml
@@ -12,7 +12,7 @@ spec:
     spec:
       containers:
       - name: netexec
-        image: gcr.io/kubernetes-e2e-test-images/netexec:1.0
+        image: k8s.gcr.io/e2e-test-images/netexec:1.0
         ports:
         - containerPort: 8080
           # This is to force these pods to land on different hosts.

--- a/test/fixtures/doc-yaml/user-guide/multi-pod.yaml
+++ b/test/fixtures/doc-yaml/user-guide/multi-pod.yaml
@@ -10,7 +10,7 @@ metadata:
 spec:
   containers:
     - name: master
-      image: gcr.io/kubernetes-e2e-test-images/redis:1.0
+      image: k8s.gcr.io/e2e-test-images/redis:1.0
       env:
         - name: MASTER
           value: "true"
@@ -23,7 +23,7 @@ spec:
         - mountPath: /redis-master-data
           name: data
     - name: sentinel
-      image: gcr.io/kubernetes-e2e-test-images/redis:1.0
+      image: k8s.gcr.io/e2e-test-images/redis:1.0
       env:
         - name: SENTINEL
           value: "true"
@@ -42,7 +42,7 @@ metadata:
 spec:
   containers:
   - name: kubernetes-serve-hostname
-    image: gcr.io/kubernetes-e2e-test-images/serve-hostname:1.0
+    image: k8s.gcr.io/e2e-test-images/serve-hostname:1.0
     resources:
       limits:
         cpu: "1"

--- a/test/fixtures/pkg/kubectl/cmd/auth/rbac-resource-plus.yaml
+++ b/test/fixtures/pkg/kubectl/cmd/auth/rbac-resource-plus.yaml
@@ -30,7 +30,7 @@ items:
   spec:
     containers:
     - name: kubernetes-serve-hostname
-      image: gcr.io/kubernetes-e2e-test-images/serve-hostname:1.1
+      image: k8s.gcr.io/e2e-test-images/serve-hostname:1.1
       resources:
         limits:
           cpu: "1"

--- a/test/images/Makefile
+++ b/test/images/Makefile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-REGISTRY ?= gcr.io/kubernetes-e2e-test-images
+REGISTRY ?= k8s.gcr.io/e2e-test-images
 GOARM ?= 7
 DOCKER_CERT_BASE_PATH ?=
 QEMUVERSION=v5.1.0-2

--- a/test/images/README.md
+++ b/test/images/README.md
@@ -141,7 +141,7 @@ To build AND push an image, the following command can be used:
 make all-push WHAT=agnhost
 ```
 
-By default, the images will be tagged and pushed under the `gcr.io/kubernetes-e2e-test-images`
+By default, the images will be tagged and pushed under the `k8s.gcr.io/e2e-test-images`
 registry. That can changed by running this command instead:
 
 ```bash
@@ -152,7 +152,7 @@ REGISTRY=foo_registry make all-push WHAT=agnhost
 require the `agnhost` image to be published in an authenticated repo as well:
 
 ```bash
-REGISTRY=gcr.io/kubernetes-e2e-test-images make all-push WHAT=agnhost
+REGISTRY=k8s.gcr.io/e2e-test-images make all-push WHAT=agnhost
 REGISTRY=gcr.io/k8s-authenticated-test make all-push WHAT=agnhost
 ```
 

--- a/test/images/windows/Makefile
+++ b/test/images/windows/Makefile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-REGISTRY ?= gcr.io/kubernetes-e2e-test-images
+REGISTRY ?= k8s.gcr.io/e2e-test-images
 REMOTE_DOCKER_URL ?=
 DOCKER_CERT_PATH ?= "$(HOME)/.docker"
 export

--- a/test/utils/image/manifest.go
+++ b/test/utils/image/manifest.go
@@ -69,7 +69,7 @@ func (i *Config) SetVersion(version string) {
 func initReg() RegistryList {
 	registry := RegistryList{
 		GcAuthenticatedRegistry: "gcr.io/authenticated-image-pulling",
-		E2eRegistry:             "gcr.io/kubernetes-e2e-test-images",
+		E2eRegistry:             "k8s.gcr.io/e2e-test-images",
 		PromoterE2eRegistry:     "k8s.gcr.io/e2e-test-images",
 		BuildImageRegistry:      "k8s.gcr.io/build-image",
 		InvalidRegistry:         "invalid.com/invalid",
@@ -382,7 +382,7 @@ func ReplaceRegistryInImageURL(imageURL string) (string, error) {
 	}
 
 	switch registryAndUser {
-	case "gcr.io/kubernetes-e2e-test-images":
+	case "k8s.gcr.io/e2e-test-images":
 		registryAndUser = e2eRegistry
 	case "k8s.gcr.io":
 		registryAndUser = gcRegistry

--- a/test/utils/image/manifest_test.go
+++ b/test/utils/image/manifest_test.go
@@ -55,7 +55,7 @@ var registryTests = []struct {
 		},
 	},
 	{
-		"gcr.io/kubernetes-e2e-test-images/test:123",
+		"k8s.gcr.io/e2e-test-images/test:123",
 		result{
 			result: "test.io/kubernetes-e2e-test-images/test:123",
 			err:    nil,


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Promote the use of _k8s.gcr.io/e2e-test-images_ instead of _gcr.io/kubernetes-e2e-test-images_

#### Which issue(s) this PR fixes:

Fixes #96770

#### Special notes for your reviewer:

Some images may not be available in _k8s.gcr.io/e2e-test-images_ yet but likely will be soon.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```
