### PR TITLE
Move NodeResourcesFit plugin args validation to apis/config/validation

### DIFF
--- a/pkg/scheduler/apis/config/validation/validation_pluginargs_test.go
+++ b/pkg/scheduler/apis/config/validation/validation_pluginargs_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package validation
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -980,6 +982,77 @@ func TestValidateVolumeBindingArgs(t *testing.T) {
 			err := ValidateVolumeBindingArgs(&tc.args)
 			if diff := cmp.Diff(tc.wantErr, err, ignoreBadValueDetail); diff != "" {
 				t.Errorf("ValidateVolumeBindingArgs returned err (-want,+got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestValidateFitArgs(t *testing.T) {
+	argsTest := []struct {
+		name   string
+		args   config.NodeResourcesFitArgs
+		expect string
+	}{
+		{
+			name: "IgnoredResources: too long value",
+			args: config.NodeResourcesFitArgs{
+				IgnoredResources: []string{fmt.Sprintf("longvalue%s", strings.Repeat("a", 64))},
+			},
+			expect: "name part must be no more than 63 characters",
+		},
+		{
+			name: "IgnoredResources: name is empty",
+			args: config.NodeResourcesFitArgs{
+				IgnoredResources: []string{"example.com/"},
+			},
+			expect: "name part must be non-empty",
+		},
+		{
+			name: "IgnoredResources: name has too many slash",
+			args: config.NodeResourcesFitArgs{
+				IgnoredResources: []string{"example.com/aaa/bbb"},
+			},
+			expect: "a qualified name must consist of alphanumeric characters",
+		},
+		{
+			name: "IgnoredResources: valid args",
+			args: config.NodeResourcesFitArgs{
+				IgnoredResources: []string{"example.com"},
+			},
+		},
+		{
+			name: "IgnoredResourceGroups: valid args ",
+			args: config.NodeResourcesFitArgs{
+				IgnoredResourceGroups: []string{"example.com"},
+			},
+		},
+		{
+			name: "IgnoredResourceGroups: illegal args",
+			args: config.NodeResourcesFitArgs{
+				IgnoredResourceGroups: []string{"example.com/"},
+			},
+			expect: "name part must be non-empty",
+		},
+		{
+			name: "IgnoredResourceGroups: name is too long",
+			args: config.NodeResourcesFitArgs{
+				IgnoredResourceGroups: []string{strings.Repeat("a", 64)},
+			},
+			expect: "name part must be no more than 63 characters",
+		},
+		{
+			name: "IgnoredResourceGroups: name cannot be contain slash",
+			args: config.NodeResourcesFitArgs{
+				IgnoredResourceGroups: []string{"example.com/aa"},
+			},
+			expect: "resource group name can't contain '/'",
+		},
+	}
+
+	for _, test := range argsTest {
+		t.Run(test.name, func(t *testing.T) {
+			if err := ValidateNodeResourcesFitArgs(&test.args); err != nil && !strings.Contains(err.Error(), test.expect) {
+				t.Errorf("case[%v]: error details do not include %v", test.name, err)
 			}
 		})
 	}

--- a/pkg/scheduler/framework/plugins/noderesources/fit_test.go
+++ b/pkg/scheduler/framework/plugins/noderesources/fit_test.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"reflect"
-	"strings"
 	"testing"
 
 	v1 "k8s.io/api/core/v1"
@@ -570,75 +569,4 @@ func TestStorageRequests(t *testing.T) {
 		})
 	}
 
-}
-
-func TestValidateFitArgs(t *testing.T) {
-	argsTest := []struct {
-		name   string
-		args   config.NodeResourcesFitArgs
-		expect string
-	}{
-		{
-			name: "IgnoredResources: too long value",
-			args: config.NodeResourcesFitArgs{
-				IgnoredResources: []string{fmt.Sprintf("longvalue%s", strings.Repeat("a", 64))},
-			},
-			expect: "name part must be no more than 63 characters",
-		},
-		{
-			name: "IgnoredResources: name is empty",
-			args: config.NodeResourcesFitArgs{
-				IgnoredResources: []string{"example.com/"},
-			},
-			expect: "name part must be non-empty",
-		},
-		{
-			name: "IgnoredResources: name has too many slash",
-			args: config.NodeResourcesFitArgs{
-				IgnoredResources: []string{"example.com/aaa/bbb"},
-			},
-			expect: "a qualified name must consist of alphanumeric characters",
-		},
-		{
-			name: "IgnoredResources: valid args",
-			args: config.NodeResourcesFitArgs{
-				IgnoredResources: []string{"example.com"},
-			},
-		},
-		{
-			name: "IgnoredResourceGroups: valid args ",
-			args: config.NodeResourcesFitArgs{
-				IgnoredResourceGroups: []string{"example.com"},
-			},
-		},
-		{
-			name: "IgnoredResourceGroups: illegal args",
-			args: config.NodeResourcesFitArgs{
-				IgnoredResourceGroups: []string{"example.com/"},
-			},
-			expect: "name part must be non-empty",
-		},
-		{
-			name: "IgnoredResourceGroups: name is too long",
-			args: config.NodeResourcesFitArgs{
-				IgnoredResourceGroups: []string{strings.Repeat("a", 64)},
-			},
-			expect: "name part must be no more than 63 characters",
-		},
-		{
-			name: "IgnoredResourceGroups: name cannot be contain slash",
-			args: config.NodeResourcesFitArgs{
-				IgnoredResourceGroups: []string{"example.com/aa"},
-			},
-			expect: "resource group name can't contain '/'",
-		},
-	}
-
-	for _, test := range argsTest {
-		t.Run(test.name, func(t *testing.T) {
-			if err := validateFitArgs(test.args); err != nil && !strings.Contains(err.Error(), test.expect) {
-				t.Errorf("case[%v]: error details do not include %v", test.name, err)
-			}
-		})
-	}
 }


### PR DESCRIPTION
Signed-off-by: Dave Chen <dave.chen@arm.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup


#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of: https://github.com/kubernetes/kubernetes/issues/88093

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
