### PR TITLE
Log and expose cgroup OOM events to the associated Pod resource

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -1357,7 +1357,7 @@ func (kl *Kubelet) initializeModules() error {
 	}
 
 	// Start out of memory watcher.
-	if err := kl.oomWatcher.Start(kl.nodeRef); err != nil {
+	if err := kl.oomWatcher.Start(kl.nodeRef, kl.GetPodByUID); err != nil {
 		return fmt.Errorf("failed to start OOM watcher %v", err)
 	}
 

--- a/pkg/kubelet/kubelet_getters.go
+++ b/pkg/kubelet/kubelet_getters.go
@@ -212,6 +212,12 @@ func (kl *Kubelet) GetPodByName(namespace, name string) (*v1.Pod, bool) {
 	return kl.podManager.GetPodByName(namespace, name)
 }
 
+// GetPodByUID gets the pod that matches pod UID, as well as
+// whether the pod is found.
+func (kl *Kubelet) GetPodByUID(uid types.UID) (*v1.Pod, bool) {
+	return kl.podManager.GetPodByUID(uid)
+}
+
 // GetPodByCgroupfs provides the pod that maps to the specified cgroup, as well
 // as whether the pod was found.
 func (kl *Kubelet) GetPodByCgroupfs(cgroupfs string) (*v1.Pod, bool) {

--- a/pkg/kubelet/oom/oom_watcher_linux.go
+++ b/pkg/kubelet/oom/oom_watcher_linux.go
@@ -85,7 +85,7 @@ func (ow *realWatcher) Start(ref *v1.ObjectReference, getPodByUID GetPodByUIDFun
 
 			parsedContainer := containerRegexp.FindStringSubmatch(event.VictimContainerName)
 			if parsedContainer != nil && event.ContainerName != legacyRecordEventContainerName {
-				klog.V(1).Infof("Got sys oom event: %v", event)
+				klog.V(1).InfoS("Got sys oom event", "event", event)
 				ow.recorder.Eventf(ref, v1.EventTypeWarning, systemOOMEvent, eventMsg)
 				if pod, ok := getPodByUID(types.UID(parsedContainer[1])); ok {
 					ow.recorder.Eventf(pod, v1.EventTypeWarning, systemOOMEvent, eventMsg)
@@ -93,7 +93,7 @@ func (ow *realWatcher) Start(ref *v1.ObjectReference, getPodByUID GetPodByUIDFun
 			}
 
 			if event.ContainerName == legacyRecordEventContainerName {
-				klog.V(1).Infof("Got sys oom event: %v", event)
+				klog.V(1).InfoS("Got sys oom event", "event", event)
 				ow.recorder.Eventf(ref, v1.EventTypeWarning, systemOOMEvent, eventMsg)
 			}
 		}

--- a/pkg/kubelet/oom/oom_watcher_linux.go
+++ b/pkg/kubelet/oom/oom_watcher_linux.go
@@ -88,7 +88,7 @@ func (ow *realWatcher) Start(ref *v1.ObjectReference, getPodByUID GetPodByUIDFun
 			}
 
 			parsedContainer := containerRegexp.FindStringSubmatch(event.VictimContainerName)
-			if parsedContainer != nil && event.ContainerName != legacyRecordEventContainerName {
+			if parsedContainer != nil && len(parsedContainer) == 2 && event.ContainerName != legacyRecordEventContainerName {
 				klog.V(1).InfoS("Got cgroup oom event", "event", event)
 				if pod, ok := getPodByUID(types.UID(parsedContainer[1])); ok {
 					ow.recorder.Eventf(pod, v1.EventTypeWarning, cGroupOOMEvent, eventMsg)

--- a/pkg/kubelet/oom/oom_watcher_linux_test.go
+++ b/pkg/kubelet/oom/oom_watcher_linux_test.go
@@ -21,11 +21,11 @@ import (
 	"testing"
 	"time"
 
-	v1 "k8s.io/api/core/v1"
-	"k8s.io/client-go/tools/record"
-
 	"github.com/google/cadvisor/utils/oomparser"
 	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
 )
 
 type fakeStreamer struct {
@@ -38,16 +38,26 @@ func (fs *fakeStreamer) StreamOoms(outStream chan<- *oomparser.OomInstance) {
 	}
 }
 
-// TestWatcherRecordsEventsForOomEvents ensures that our OomInstances coming
+// Mock function that is used to find Pods by UID where the Pod is found.
+func GetPodByUIDReturnTrue(uid types.UID) (*v1.Pod, bool) {
+	return &v1.Pod{}, true
+}
+
+// Mock function that is used to find Pods by UID where the Pod is not found.
+func GetPodByUIDReturnFalse(uid types.UID) (*v1.Pod, bool) {
+	return &v1.Pod{}, false
+}
+
+// TestWatcherRecordsEventsForLegacyOomEvents ensures that our OomInstances coming
 // from `StreamOoms` are translated into events in our recorder.
-func TestWatcherRecordsEventsForOomEvents(t *testing.T) {
+func TestWatcherRecordsEventsForLegacyOomEvents(t *testing.T) {
 	oomInstancesToStream := []*oomparser.OomInstance{
 		{
 			Pid:                 1000,
 			ProcessName:         "fakeProcess",
 			TimeOfDeath:         time.Now(),
-			ContainerName:       recordEventContainerName + "some-container",
-			VictimContainerName: recordEventContainerName,
+			ContainerName:       legacyRecordEventContainerName,
+			VictimContainerName: legacyRecordEventContainerName,
 		},
 	}
 	numExpectedOomEvents := len(oomInstancesToStream)
@@ -63,33 +73,74 @@ func TestWatcherRecordsEventsForOomEvents(t *testing.T) {
 		recorder:    fakeRecorder,
 		oomStreamer: fakeStreamer,
 	}
-	assert.NoError(t, oomWatcher.Start(node))
+	assert.NoError(t, oomWatcher.Start(node, GetPodByUIDReturnFalse))
 
-	eventsRecorded := getRecordedEvents(fakeRecorder, numExpectedOomEvents)
+	eventsRecorded := getRecordedEvents(t, fakeRecorder, numExpectedOomEvents)
 	assert.Equal(t, numExpectedOomEvents, len(eventsRecorded))
 }
 
-func getRecordedEvents(fakeRecorder *record.FakeRecorder, numExpectedOomEvents int) []string {
+// TestWatcherRecordsEventsForOomEvents ensures that our OomInstances coming
+// from `StreamOoms` are translated into events in our recorder.
+func TestWatcherRecordsEventsForOomEvents(t *testing.T) {
+	oomInstancesToStream := []*oomparser.OomInstance{
+		{
+			Pid:                 1000,
+			ProcessName:         "fakeProcess",
+			TimeOfDeath:         time.Now(),
+			ContainerName:       "/kubepods/podfa08b07e-b396-4cd5-bda3-f7ebbe2e9b88",
+			VictimContainerName: "/kubepods/podfa08b07e-b396-4cd5-bda3-f7ebbe2e9b88",
+		},
+		{
+			Pid:                 1000,
+			ProcessName:         "fakeProcess",
+			TimeOfDeath:         time.Now(),
+			ContainerName:       "/kubepods/burstable/podfa08b07e-b396-4cd5-bda3-f7ebbe2e9b88",
+			VictimContainerName: "/kubepods/burstable/podfa08b07e-b396-4cd5-bda3-f7ebbe2e9b88",
+		},
+	}
+	numExpectedOomEvents := len(oomInstancesToStream) * 2
+
+	fakeStreamer := &fakeStreamer{
+		oomInstancesToStream: oomInstancesToStream,
+	}
+
+	fakeRecorder := record.NewFakeRecorder(numExpectedOomEvents)
+	node := &v1.ObjectReference{}
+
+	oomWatcher := &realWatcher{
+		recorder:    fakeRecorder,
+		oomStreamer: fakeStreamer,
+	}
+	assert.NoError(t, oomWatcher.Start(node, GetPodByUIDReturnTrue))
+
+	eventsRecorded := getRecordedEvents(t, fakeRecorder, numExpectedOomEvents)
+	assert.Equal(t, numExpectedOomEvents, len(eventsRecorded))
+}
+
+func getRecordedEvents(t *testing.T, fakeRecorder *record.FakeRecorder, numExpectedOomEvents int) []string {
+	done := false
 	eventsRecorded := []string{}
 
-	select {
-	case event := <-fakeRecorder.Events:
-		eventsRecorded = append(eventsRecorded, event)
-
-		if len(eventsRecorded) == numExpectedOomEvents {
-			break
+	for !done {
+		select {
+		case event := <-fakeRecorder.Events:
+			eventsRecorded = append(eventsRecorded, event)
+			t.Log(event)
+			if len(eventsRecorded) == numExpectedOomEvents {
+				done = true
+			}
+		case <-time.After(10 * time.Second):
+			done = true
 		}
-	case <-time.After(10 * time.Second):
-		break
 	}
 
 	return eventsRecorded
 }
 
-// TestWatcherRecordsEventsForOomEventsCorrectContainerName verifies that we
+// TestWatcherRecordsEventsForLegacyOomEventsCorrectContainerName verifies that we
 // only record OOM events when the container name is the one for which we want
 // to record events (i.e. /).
-func TestWatcherRecordsEventsForOomEventsCorrectContainerName(t *testing.T) {
+func TestWatcherRecordsEventsForLegacyOomEventsCorrectContainerName(t *testing.T) {
 	// By "incorrect" container name, we mean a container name for which we
 	// don't want to record an oom event.
 	numOomEventsWithIncorrectContainerName := 1
@@ -98,15 +149,15 @@ func TestWatcherRecordsEventsForOomEventsCorrectContainerName(t *testing.T) {
 			Pid:                 1000,
 			ProcessName:         "fakeProcess",
 			TimeOfDeath:         time.Now(),
-			ContainerName:       recordEventContainerName + "some-container",
-			VictimContainerName: recordEventContainerName,
+			ContainerName:       legacyRecordEventContainerName,
+			VictimContainerName: legacyRecordEventContainerName,
 		},
 		{
 			Pid:                 1000,
 			ProcessName:         "fakeProcess",
 			TimeOfDeath:         time.Now(),
-			ContainerName:       recordEventContainerName + "kubepods/some-container",
-			VictimContainerName: recordEventContainerName + "kubepods",
+			ContainerName:       legacyRecordEventContainerName + "kubepods/invalid-container-name",
+			VictimContainerName: legacyRecordEventContainerName + "kubepods/invalid-container-name",
 		},
 	}
 	numExpectedOomEvents := len(oomInstancesToStream) - numOomEventsWithIncorrectContainerName
@@ -122,15 +173,64 @@ func TestWatcherRecordsEventsForOomEventsCorrectContainerName(t *testing.T) {
 		recorder:    fakeRecorder,
 		oomStreamer: fakeStreamer,
 	}
-	assert.NoError(t, oomWatcher.Start(node))
+	assert.NoError(t, oomWatcher.Start(node, GetPodByUIDReturnFalse))
 
-	eventsRecorded := getRecordedEvents(fakeRecorder, numExpectedOomEvents)
+	eventsRecorded := getRecordedEvents(t, fakeRecorder, numExpectedOomEvents)
 	assert.Equal(t, numExpectedOomEvents, len(eventsRecorded))
 }
 
-// TestWatcherRecordsEventsForOomEventsWithAdditionalInfo verifies that our the
+// TestWatcherRecordsEventsForOomEventsCorrectContainerName verifies that we
+// only record OOM events when the container name is the one for which we want
+// to record events.
+func TestWatcherRecordsEventsForOomEventsCorrectContainerName(t *testing.T) {
+	// By "incorrect" container name, we mean a container name for which we
+	// don't want to record an oom event.
+	numOomEventsWithIncorrectContainerName := 1
+	oomInstancesToStream := []*oomparser.OomInstance{
+		{
+			Pid:                 1000,
+			ProcessName:         "fakeProcess",
+			TimeOfDeath:         time.Now(),
+			ContainerName:       "/kubepods/podfa08b07e-b396-4cd5-bda3-f7ebbe2e9b88",
+			VictimContainerName: "/kubepods/podfa08b07e-b396-4cd5-bda3-f7ebbe2e9b88",
+		},
+		{
+			Pid:                 1000,
+			ProcessName:         "fakeProcess",
+			TimeOfDeath:         time.Now(),
+			ContainerName:       "/kubepods/burstable/podfa08b07e-b396-4cd5-bda3-f7ebbe2e9b88",
+			VictimContainerName: "/kubepods/burstable/podfa08b07e-b396-4cd5-bda3-f7ebbe2e9b88",
+		},
+		{
+			Pid:                 1000,
+			ProcessName:         "fakeProcess",
+			TimeOfDeath:         time.Now(),
+			ContainerName:       "/kubepods/invalid-container-name",
+			VictimContainerName: "/kubepods/invalid-container-name",
+		},
+	}
+	numExpectedOomEvents := len(oomInstancesToStream) - numOomEventsWithIncorrectContainerName
+
+	fakeStreamer := &fakeStreamer{
+		oomInstancesToStream: oomInstancesToStream,
+	}
+
+	fakeRecorder := record.NewFakeRecorder(numExpectedOomEvents)
+	node := &v1.ObjectReference{}
+
+	oomWatcher := &realWatcher{
+		recorder:    fakeRecorder,
+		oomStreamer: fakeStreamer,
+	}
+	assert.NoError(t, oomWatcher.Start(node, GetPodByUIDReturnTrue))
+
+	eventsRecorded := getRecordedEvents(t, fakeRecorder, numExpectedOomEvents)
+	assert.Equal(t, numExpectedOomEvents, len(eventsRecorded))
+}
+
+// TestWatcherRecordsEventsForLegacyOomEventsWithAdditionalInfo verifies that the
 // emitted event has the proper pid/process data when appropriate.
-func TestWatcherRecordsEventsForOomEventsWithAdditionalInfo(t *testing.T) {
+func TestWatcherRecordsEventsForLegacyOomEventsWithAdditionalInfo(t *testing.T) {
 	// The process and event info should appear in the event message.
 	eventPid := 1000
 	processName := "fakeProcess"
@@ -140,8 +240,8 @@ func TestWatcherRecordsEventsForOomEventsWithAdditionalInfo(t *testing.T) {
 			Pid:                 eventPid,
 			ProcessName:         processName,
 			TimeOfDeath:         time.Now(),
-			ContainerName:       recordEventContainerName + "some-container",
-			VictimContainerName: recordEventContainerName,
+			ContainerName:       legacyRecordEventContainerName,
+			VictimContainerName: legacyRecordEventContainerName,
 		},
 	}
 	numExpectedOomEvents := len(oomInstancesToStream)
@@ -157,12 +257,122 @@ func TestWatcherRecordsEventsForOomEventsWithAdditionalInfo(t *testing.T) {
 		recorder:    fakeRecorder,
 		oomStreamer: fakeStreamer,
 	}
-	assert.NoError(t, oomWatcher.Start(node))
+	assert.NoError(t, oomWatcher.Start(node, GetPodByUIDReturnFalse))
 
-	eventsRecorded := getRecordedEvents(fakeRecorder, numExpectedOomEvents)
+	eventsRecorded := getRecordedEvents(t, fakeRecorder, numExpectedOomEvents)
 
 	assert.Equal(t, numExpectedOomEvents, len(eventsRecorded))
 	assert.Contains(t, eventsRecorded[0], systemOOMEvent)
 	assert.Contains(t, eventsRecorded[0], fmt.Sprintf("pid: %d", eventPid))
 	assert.Contains(t, eventsRecorded[0], fmt.Sprintf("victim process: %s", processName))
+}
+
+// TestWatcherRecordsEventsForOomEventsWithAdditionalInfo verifies that the
+// emitted events have the proper pid/process data for both node and pod
+// resources.
+func TestWatcherRecordsEventsForOomEventsWithAdditionalInfo(t *testing.T) {
+	// The process and event info should appear in the event message.
+	eventPid1 := 1000
+	processName1 := "fakeProcess"
+	eventPid2 := 2000
+	processName2 := "fakeProcess2"
+
+	oomInstancesToStream := []*oomparser.OomInstance{
+		{
+			Pid:                 eventPid1,
+			ProcessName:         processName1,
+			TimeOfDeath:         time.Now(),
+			ContainerName:       "/kubepods/podfa08b07e-b396-4cd5-bda3-f7ebbe2e9b88",
+			VictimContainerName: "/kubepods/podfa08b07e-b396-4cd5-bda3-f7ebbe2e9b88",
+		},
+		{
+			Pid:                 eventPid2,
+			ProcessName:         processName2,
+			TimeOfDeath:         time.Now(),
+			ContainerName:       "/kubepods/burstable/podfa08b07e-b396-4cd5-bda3-f7ebbe2e9b88",
+			VictimContainerName: "/kubepods/burstable/podfa08b07e-b396-4cd5-bda3-f7ebbe2e9b88",
+		},
+	}
+	// 4 events are emitted, one each for both the node and pod resource
+	numExpectedOomEvents := len(oomInstancesToStream) * 2
+
+	fakeStreamer := &fakeStreamer{
+		oomInstancesToStream: oomInstancesToStream,
+	}
+
+	fakeRecorder := record.NewFakeRecorder(numExpectedOomEvents)
+	node := &v1.ObjectReference{}
+
+	oomWatcher := &realWatcher{
+		recorder:    fakeRecorder,
+		oomStreamer: fakeStreamer,
+	}
+	assert.NoError(t, oomWatcher.Start(node, GetPodByUIDReturnTrue))
+
+	eventsRecorded := getRecordedEvents(t, fakeRecorder, numExpectedOomEvents)
+
+	assert.Equal(t, numExpectedOomEvents, len(eventsRecorded))
+	assert.Contains(t, eventsRecorded[0], systemOOMEvent)
+	assert.Contains(t, eventsRecorded[0], fmt.Sprintf("pid: %d", eventPid1))
+	assert.Contains(t, eventsRecorded[0], fmt.Sprintf("victim process: %s", processName1))
+	assert.Contains(t, eventsRecorded[1], systemOOMEvent)
+	assert.Contains(t, eventsRecorded[1], fmt.Sprintf("pid: %d", eventPid1))
+	assert.Contains(t, eventsRecorded[1], fmt.Sprintf("victim process: %s", processName1))
+	assert.Contains(t, eventsRecorded[2], systemOOMEvent)
+	assert.Contains(t, eventsRecorded[2], fmt.Sprintf("pid: %d", eventPid2))
+	assert.Contains(t, eventsRecorded[2], fmt.Sprintf("victim process: %s", processName2))
+	assert.Contains(t, eventsRecorded[3], systemOOMEvent)
+	assert.Contains(t, eventsRecorded[3], fmt.Sprintf("pid: %d", eventPid2))
+	assert.Contains(t, eventsRecorded[3], fmt.Sprintf("victim process: %s", processName2))
+}
+
+// TestWatcherRecordsEventsForOomEventsWithPodNotFound verifies that the
+// emitted node resource events have the proper pid/process data when
+// the pod cannot be found.
+func TestWatcherRecordsEventsForOomEventsWithPodNotFound(t *testing.T) {
+	eventPid1 := 1000
+	processName1 := "fakeProcess"
+	eventPid2 := 2000
+	processName2 := "fakeProcess2"
+
+	oomInstancesToStream := []*oomparser.OomInstance{
+		{
+			Pid:                 eventPid1,
+			ProcessName:         processName1,
+			TimeOfDeath:         time.Now(),
+			ContainerName:       "/kubepods/podfa08b07e-b396-4cd5-bda3-f7ebbe2e9b88",
+			VictimContainerName: "/kubepods/podfa08b07e-b396-4cd5-bda3-f7ebbe2e9b88",
+		},
+		{
+			Pid:                 eventPid2,
+			ProcessName:         processName2,
+			TimeOfDeath:         time.Now(),
+			ContainerName:       "/kubepods/burstable/podfa08b07e-b396-4cd5-bda3-f7ebbe2e9b88",
+			VictimContainerName: "/kubepods/burstable/podfa08b07e-b396-4cd5-bda3-f7ebbe2e9b88",
+		},
+	}
+	// 2 events are emitted, only for the node resource when the pod resource is not found
+	numExpectedOomEvents := len(oomInstancesToStream)
+
+	fakeStreamer := &fakeStreamer{
+		oomInstancesToStream: oomInstancesToStream,
+	}
+
+	fakeRecorder := record.NewFakeRecorder(numExpectedOomEvents)
+	node := &v1.ObjectReference{}
+
+	oomWatcher := &realWatcher{
+		recorder:    fakeRecorder,
+		oomStreamer: fakeStreamer,
+	}
+	assert.NoError(t, oomWatcher.Start(node, GetPodByUIDReturnFalse))
+
+	eventsRecorded := getRecordedEvents(t, fakeRecorder, numExpectedOomEvents)
+	assert.Equal(t, numExpectedOomEvents, len(eventsRecorded))
+	assert.Contains(t, eventsRecorded[0], systemOOMEvent)
+	assert.Contains(t, eventsRecorded[0], fmt.Sprintf("pid: %d", eventPid1))
+	assert.Contains(t, eventsRecorded[0], fmt.Sprintf("victim process: %s", processName1))
+	assert.Contains(t, eventsRecorded[1], systemOOMEvent)
+	assert.Contains(t, eventsRecorded[1], fmt.Sprintf("pid: %d", eventPid2))
+	assert.Contains(t, eventsRecorded[1], fmt.Sprintf("victim process: %s", processName2))
 }

--- a/pkg/kubelet/oom/oom_watcher_linux_test.go
+++ b/pkg/kubelet/oom/oom_watcher_linux_test.go
@@ -98,7 +98,7 @@ func TestWatcherRecordsEventsForOomEvents(t *testing.T) {
 			VictimContainerName: "/kubepods/burstable/podfa08b07e-b396-4cd5-bda3-f7ebbe2e9b88",
 		},
 	}
-	numExpectedOomEvents := len(oomInstancesToStream) * 2
+	numExpectedOomEvents := len(oomInstancesToStream)
 
 	fakeStreamer := &fakeStreamer{
 		oomInstancesToStream: oomInstancesToStream,
@@ -293,7 +293,7 @@ func TestWatcherRecordsEventsForOomEventsWithAdditionalInfo(t *testing.T) {
 		},
 	}
 	// 4 events are emitted, one each for both the node and pod resource
-	numExpectedOomEvents := len(oomInstancesToStream) * 2
+	numExpectedOomEvents := len(oomInstancesToStream)
 
 	fakeStreamer := &fakeStreamer{
 		oomInstancesToStream: oomInstancesToStream,
@@ -311,18 +311,12 @@ func TestWatcherRecordsEventsForOomEventsWithAdditionalInfo(t *testing.T) {
 	eventsRecorded := getRecordedEvents(fakeRecorder, numExpectedOomEvents)
 
 	assert.Equal(t, numExpectedOomEvents, len(eventsRecorded))
-	assert.Contains(t, eventsRecorded[0], systemOOMEvent)
+	assert.Contains(t, eventsRecorded[0], cGroupOOMEvent)
 	assert.Contains(t, eventsRecorded[0], fmt.Sprintf("pid: %d", eventPid1))
 	assert.Contains(t, eventsRecorded[0], fmt.Sprintf("victim process: %s", processName1))
-	assert.Contains(t, eventsRecorded[1], systemOOMEvent)
-	assert.Contains(t, eventsRecorded[1], fmt.Sprintf("pid: %d", eventPid1))
-	assert.Contains(t, eventsRecorded[1], fmt.Sprintf("victim process: %s", processName1))
-	assert.Contains(t, eventsRecorded[2], systemOOMEvent)
-	assert.Contains(t, eventsRecorded[2], fmt.Sprintf("pid: %d", eventPid2))
-	assert.Contains(t, eventsRecorded[2], fmt.Sprintf("victim process: %s", processName2))
-	assert.Contains(t, eventsRecorded[3], systemOOMEvent)
-	assert.Contains(t, eventsRecorded[3], fmt.Sprintf("pid: %d", eventPid2))
-	assert.Contains(t, eventsRecorded[3], fmt.Sprintf("victim process: %s", processName2))
+	assert.Contains(t, eventsRecorded[1], cGroupOOMEvent)
+	assert.Contains(t, eventsRecorded[1], fmt.Sprintf("pid: %d", eventPid2))
+	assert.Contains(t, eventsRecorded[1], fmt.Sprintf("victim process: %s", processName2))
 }
 
 // TestWatcherRecordsEventsForOomEventsWithPodNotFound verifies that the
@@ -351,7 +345,7 @@ func TestWatcherRecordsEventsForOomEventsWithPodNotFound(t *testing.T) {
 		},
 	}
 	// 2 events are emitted, only for the node resource when the pod resource is not found
-	numExpectedOomEvents := len(oomInstancesToStream)
+	numExpectedOomEvents := 0
 
 	fakeStreamer := &fakeStreamer{
 		oomInstancesToStream: oomInstancesToStream,
@@ -368,10 +362,4 @@ func TestWatcherRecordsEventsForOomEventsWithPodNotFound(t *testing.T) {
 
 	eventsRecorded := getRecordedEvents(fakeRecorder, numExpectedOomEvents)
 	assert.Equal(t, numExpectedOomEvents, len(eventsRecorded))
-	assert.Contains(t, eventsRecorded[0], systemOOMEvent)
-	assert.Contains(t, eventsRecorded[0], fmt.Sprintf("pid: %d", eventPid1))
-	assert.Contains(t, eventsRecorded[0], fmt.Sprintf("victim process: %s", processName1))
-	assert.Contains(t, eventsRecorded[1], systemOOMEvent)
-	assert.Contains(t, eventsRecorded[1], fmt.Sprintf("pid: %d", eventPid2))
-	assert.Contains(t, eventsRecorded[1], fmt.Sprintf("victim process: %s", processName2))
 }

--- a/pkg/kubelet/oom/oom_watcher_linux_test.go
+++ b/pkg/kubelet/oom/oom_watcher_linux_test.go
@@ -75,7 +75,7 @@ func TestWatcherRecordsEventsForLegacyOomEvents(t *testing.T) {
 	}
 	assert.NoError(t, oomWatcher.Start(node, GetPodByUIDReturnFalse))
 
-	eventsRecorded := getRecordedEvents(t, fakeRecorder, numExpectedOomEvents)
+	eventsRecorded := getRecordedEvents(fakeRecorder, numExpectedOomEvents)
 	assert.Equal(t, numExpectedOomEvents, len(eventsRecorded))
 }
 
@@ -113,11 +113,11 @@ func TestWatcherRecordsEventsForOomEvents(t *testing.T) {
 	}
 	assert.NoError(t, oomWatcher.Start(node, GetPodByUIDReturnTrue))
 
-	eventsRecorded := getRecordedEvents(t, fakeRecorder, numExpectedOomEvents)
+	eventsRecorded := getRecordedEvents(fakeRecorder, numExpectedOomEvents)
 	assert.Equal(t, numExpectedOomEvents, len(eventsRecorded))
 }
 
-func getRecordedEvents(t *testing.T, fakeRecorder *record.FakeRecorder, numExpectedOomEvents int) []string {
+func getRecordedEvents(fakeRecorder *record.FakeRecorder, numExpectedOomEvents int) []string {
 	done := false
 	eventsRecorded := []string{}
 
@@ -125,7 +125,6 @@ func getRecordedEvents(t *testing.T, fakeRecorder *record.FakeRecorder, numExpec
 		select {
 		case event := <-fakeRecorder.Events:
 			eventsRecorded = append(eventsRecorded, event)
-			t.Log(event)
 			if len(eventsRecorded) == numExpectedOomEvents {
 				done = true
 			}
@@ -175,7 +174,7 @@ func TestWatcherRecordsEventsForLegacyOomEventsCorrectContainerName(t *testing.T
 	}
 	assert.NoError(t, oomWatcher.Start(node, GetPodByUIDReturnFalse))
 
-	eventsRecorded := getRecordedEvents(t, fakeRecorder, numExpectedOomEvents)
+	eventsRecorded := getRecordedEvents(fakeRecorder, numExpectedOomEvents)
 	assert.Equal(t, numExpectedOomEvents, len(eventsRecorded))
 }
 
@@ -224,7 +223,7 @@ func TestWatcherRecordsEventsForOomEventsCorrectContainerName(t *testing.T) {
 	}
 	assert.NoError(t, oomWatcher.Start(node, GetPodByUIDReturnTrue))
 
-	eventsRecorded := getRecordedEvents(t, fakeRecorder, numExpectedOomEvents)
+	eventsRecorded := getRecordedEvents(fakeRecorder, numExpectedOomEvents)
 	assert.Equal(t, numExpectedOomEvents, len(eventsRecorded))
 }
 
@@ -259,7 +258,7 @@ func TestWatcherRecordsEventsForLegacyOomEventsWithAdditionalInfo(t *testing.T) 
 	}
 	assert.NoError(t, oomWatcher.Start(node, GetPodByUIDReturnFalse))
 
-	eventsRecorded := getRecordedEvents(t, fakeRecorder, numExpectedOomEvents)
+	eventsRecorded := getRecordedEvents(fakeRecorder, numExpectedOomEvents)
 
 	assert.Equal(t, numExpectedOomEvents, len(eventsRecorded))
 	assert.Contains(t, eventsRecorded[0], systemOOMEvent)
@@ -309,7 +308,7 @@ func TestWatcherRecordsEventsForOomEventsWithAdditionalInfo(t *testing.T) {
 	}
 	assert.NoError(t, oomWatcher.Start(node, GetPodByUIDReturnTrue))
 
-	eventsRecorded := getRecordedEvents(t, fakeRecorder, numExpectedOomEvents)
+	eventsRecorded := getRecordedEvents(fakeRecorder, numExpectedOomEvents)
 
 	assert.Equal(t, numExpectedOomEvents, len(eventsRecorded))
 	assert.Contains(t, eventsRecorded[0], systemOOMEvent)
@@ -367,7 +366,7 @@ func TestWatcherRecordsEventsForOomEventsWithPodNotFound(t *testing.T) {
 	}
 	assert.NoError(t, oomWatcher.Start(node, GetPodByUIDReturnFalse))
 
-	eventsRecorded := getRecordedEvents(t, fakeRecorder, numExpectedOomEvents)
+	eventsRecorded := getRecordedEvents(fakeRecorder, numExpectedOomEvents)
 	assert.Equal(t, numExpectedOomEvents, len(eventsRecorded))
 	assert.Contains(t, eventsRecorded[0], systemOOMEvent)
 	assert.Contains(t, eventsRecorded[0], fmt.Sprintf("pid: %d", eventPid1))

--- a/pkg/kubelet/oom/oom_watcher_unsupported.go
+++ b/pkg/kubelet/oom/oom_watcher_unsupported.go
@@ -32,6 +32,6 @@ func NewWatcher(_ record.EventRecorder) (Watcher, error) {
 	return &oomWatcherUnsupported{}, nil
 }
 
-func (ow *oomWatcherUnsupported) Start(_ *v1.ObjectReference) error {
+func (ow *oomWatcherUnsupported) Start(_ *v1.ObjectReference, _ GetPodByUIDFunc) error {
 	return nil
 }

--- a/pkg/kubelet/oom/types.go
+++ b/pkg/kubelet/oom/types.go
@@ -16,9 +16,15 @@ limitations under the License.
 
 package oom
 
-import v1 "k8s.io/api/core/v1"
+import (
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// ActivePodsFunc returns pods bound to the kubelet that are active (i.e. non-terminal state)
+type GetPodByUIDFunc func(uid types.UID) (*v1.Pod, bool)
 
 // Watcher defines the interface of OOM watchers.
 type Watcher interface {
-	Start(ref *v1.ObjectReference) error
+	Start(ref *v1.ObjectReference, getPodByUID GetPodByUIDFunc) error
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind feature

#### What this PR does / why we need it:

With cadvisor v0.39.0, the OOM parser correctly returns the container information for kernels >= 5.0. This PR has two aspects.

This allows us to expose the underlying cgroup OOM to the associated Pod resource by emitting an event. In addition, we should log the cgroup OOM in the kubelet logs.
- Adds cgroup OOM log message to Kubelet
- Adds the cgroup OOM event messages to the associated Pod resource.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #100483

#### Special notes for your reviewer:

```
$ kubectl describe pod -n default memory-demo-2
...
Events:
  Type     Reason     Age                From               Message
  ----     ------     ----               ----               -------
  Normal   Scheduled  30s                default-scheduler  Successfully assigned default/memory-demo-2 to 127.0.0.1
  Normal   Pulled     28s                kubelet            Successfully pulled image "polinux/stress" in 1.145060952s
  Warning  CgroupOOM  28s                kubelet            Cgroup OOM encountered, victim process: stress, pid: 470521
```

```
$ kubectl describe node 127.0.0.1
...
Events:
  Type     Reason     Age                 From        Message
  ----     ------     ----                ----        -------
  Normal   Starting   5m28s               kube-proxy  Starting kube-proxy.
```
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Emit pod CgroupOOM events to the associated Pod resource
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
